### PR TITLE
linq_fold: accumulator + early-exit terminators on zip (Phase 2 follow-up to #2741)

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -430,7 +430,10 @@ def private finalize_invoke(var res : Expression?; at : LineInfo) : Expression? 
 def private finalize_lane_emission(var topExprs : array<Expression?>; srcNames : array<string>;
                                    var bodyStmts : array<Expression?>; at : LineInfo) : Expression? {
     // Multi-source-aware invoke wrap used by emit_accumulator_lane / emit_early_exit_lane. 1-source clones top + derives param type + emits 1-arg invoke; 2-source (zip) does both sides + emits 2-arg invoke. Caller has already pushed the for-loop into bodyStmts.
-    if (length(srcNames) == 1) {
+    let nSrcs = length(srcNames)
+    if (nSrcs != 1 && nSrcs != 2) panic("finalize_lane_emission: only 1- or 2-source supported (got {nSrcs}); higher-arity zip planners must extend this branch (or build the invoke wrap directly)")
+    if (length(topExprs) != nSrcs) panic("finalize_lane_emission: topExprs length {length(topExprs)} != srcNames length {nSrcs}")
+    if (nSrcs == 1) {
         var topExpr = clone_expression(topExprs[0])
         topExpr.genFlags.alwaysSafe = true
         var srcParamType = invoke_src_param_type(topExprs[0])

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -415,12 +415,40 @@ def private peel_each(var top : Expression?) : Expression? {
 
 [macro_function]
 def private finalize_invoke(var res : Expression?; at : LineInfo) : Expression? {
-    // Post-emit cleanup: stamp loc+generated for diagnostics; set can_shadow so gensym src coexists with user scope.
+    // Post-emit cleanup: stamp loc+generated for diagnostics; set can_shadow on every block arg so gensym sources coexist with user scope. Loop handles 1-source single planners and N-source zip emission uniformly.
     res.force_at(at)
     res.force_generated(true)
     let blk = (res as ExprInvoke).arguments[0] as ExprMakeBlock
-    (blk._block as ExprBlock).arguments[0].flags.can_shadow = true
+    var blkBlock = blk._block as ExprBlock
+    for (i in 0 .. length(blkBlock.arguments)) {
+        blkBlock.arguments[i].flags.can_shadow = true
+    }
     return res
+}
+
+[macro_function]
+def private finalize_lane_emission(var topExprs : array<Expression?>; srcNames : array<string>;
+                                   var bodyStmts : array<Expression?>; at : LineInfo) : Expression? {
+    // Multi-source-aware invoke wrap used by emit_accumulator_lane / emit_early_exit_lane. 1-source clones top + derives param type + emits 1-arg invoke; 2-source (zip) does both sides + emits 2-arg invoke. Caller has already pushed the for-loop into bodyStmts.
+    if (length(srcNames) == 1) {
+        var topExpr = clone_expression(topExprs[0])
+        topExpr.genFlags.alwaysSafe = true
+        var srcParamType = invoke_src_param_type(topExprs[0])
+        var res = qmacro(invoke($($i(srcNames[0]) : $t(srcParamType)) {
+            $b(bodyStmts)
+        }, $e(topExpr)))
+        return finalize_invoke(res, at)
+    }
+    var topAExpr = clone_expression(topExprs[0])
+    topAExpr.genFlags.alwaysSafe = true
+    var topBExpr = clone_expression(topExprs[1])
+    topBExpr.genFlags.alwaysSafe = true
+    var srcAType = invoke_src_param_type(topExprs[0])
+    var srcBType = invoke_src_param_type(topExprs[1])
+    var res = qmacro(invoke($($i(srcNames[0]) : $t(srcAType), $i(srcNames[1]) : $t(srcBType)) {
+        $b(bodyStmts)
+    }, $e(topAExpr), $e(topBExpr)))
+    return finalize_invoke(res, at)
 }
 
 [macro_function]
@@ -658,13 +686,14 @@ def private emit_array_lane(var top : Expression?; var expr : Expression?; var l
 [macro_function]
 def private emit_accumulator_lane(
                                   opName : string;
-                                  var top : Expression?;
+                                  var topExprs : array<Expression?>;
                                   var projection : Expression?;
                                   var whereCond : Expression?;
                                   var intermediateBinds : array<Expression?>;
                                   var preCondStmts : array<Expression?>;
                                   var elementType : TypeDeclPtr;
-                                  srcName, accName, itName, skipName, takeCountName, skippingName : string;
+                                  srcNames : array<string>;
+                                  accName, itName, skipName, takeCountName, skippingName : string;
                                   var skipExpr, takeExpr, skipWhileCond, takeWhileCond : Expression?;
                                   at : LineInfo
                                   ) : Expression? {
@@ -766,21 +795,24 @@ def private emit_accumulator_lane(
     for (s in preludeStmts) {
         bodyStmts |> push(s)
     }
-    bodyStmts |> push <| qmacro_expr() {
-        for ($i(itName) in $i(srcName)) {
-            $e(loopBody)
+    // For-loop emission: single-source uses one iter var (itName); 2-source (zip) uses literal `itA, itB` parallel iter vars (qmacro for-loop iter-var position doesn't accept $i(...) splice). Caller (plan_zip) threads `let it = (itA, itB)` via preCondStmts so itName resolves inside the loop body.
+    if (length(srcNames) == 1) {
+        bodyStmts |> push <| qmacro_expr() {
+            for ($i(itName) in $i(srcNames[0])) {
+                $e(loopBody)
+            }
+        }
+    } else {
+        bodyStmts |> push <| qmacro_expr() {
+            for (itA, itB in $i(srcNames[0]), $i(srcNames[1])) {
+                $e(loopBody)
+            }
         }
     }
     bodyStmts |> push <| qmacro_expr() {
         return $e(returnExpr)
     }
-    var topExpr = clone_expression(top)
-    topExpr.genFlags.alwaysSafe = true
-    var srcParamType = invoke_src_param_type(top)
-    var res = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
-        $b(bodyStmts)
-    }, $e(topExpr)))
-    return finalize_invoke(res, at)
+    return finalize_lane_emission(topExprs, srcNames, bodyStmts, at)
 }
 
 [macro_function]
@@ -797,14 +829,15 @@ def private emit_any_empty_shortcut(var top : Expression?; srcName : string; at 
 [macro_function]
 def private emit_early_exit_lane(
                                  opName : string;
-                                 var top : Expression?;
+                                 var topExprs : array<Expression?>;
                                  var projection : Expression?;
                                  var whereCond : Expression?;
                                  var intermediateBinds : array<Expression?>;
                                  var preCondStmts : array<Expression?>;
                                  var elementType : TypeDeclPtr;
                                  terminatorCall : ExprCall?;
-                                 srcName, itName, skipName, takeCountName, skippingName : string;
+                                 srcNames : array<string>;
+                                 itName, skipName, takeCountName, skippingName : string;
                                  var skipExpr, takeExpr, skipWhileCond, takeWhileCond : Expression?;
                                  at : LineInfo
                                  ) : Expression? {
@@ -1122,21 +1155,24 @@ def private emit_early_exit_lane(
     for (s in preludeStmts) {
         bodyStmts |> push(s)
     }
-    bodyStmts |> push <| qmacro_expr() {
-        for ($i(itName) in $i(srcName)) {
-            $e(loopBody)
+    // For-loop emission: 1-source uses itName; 2-source (zip) uses literal `itA, itB` (qmacro for-iter-var position doesn't accept $i splice). Caller (plan_zip) threads `let it = (itA, itB)` via preCondStmts.
+    if (length(srcNames) == 1) {
+        bodyStmts |> push <| qmacro_expr() {
+            for ($i(itName) in $i(srcNames[0])) {
+                $e(loopBody)
+            }
+        }
+    } else {
+        bodyStmts |> push <| qmacro_expr() {
+            for (itA, itB in $i(srcNames[0]), $i(srcNames[1])) {
+                $e(loopBody)
+            }
         }
     }
     for (s in tailStmts) {
         bodyStmts |> push(s)
     }
-    var topExpr = clone_expression(top)
-    topExpr.genFlags.alwaysSafe = true
-    var srcParamType = invoke_src_param_type(top)
-    var res = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
-        $b(bodyStmts)
-    }, $e(topExpr)))
-    return finalize_invoke(res, at)
+    return finalize_lane_emission(topExprs, srcNames, bodyStmts, at)
 }
 
 [macro_function]
@@ -1511,10 +1547,15 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
             && type_has_length(top._type))
         return emit_length_shortcut(lastName, top, srcName, at)
     // Ring 1: accumulator lane builds its own per-op loop body (typed accumulator, optional
-    if (lane == LinqLane.ACCUMULATOR)
-        return emit_accumulator_lane(lastName, top, projection, whereCond,
-            intermediateBinds, preCondStmts, elementType, srcName, accName, itName, skipName, takeCountName,
+    if (lane == LinqLane.ACCUMULATOR) {
+        var laneTops : array<Expression?>
+        laneTops |> push(top)
+        var laneSrcs : array<string>
+        laneSrcs |> push(srcName)
+        return emit_accumulator_lane(lastName, laneTops, projection, whereCond,
+            intermediateBinds, preCondStmts, elementType, laneSrcs, accName, itName, skipName, takeCountName,
             skippingName, skipExpr, takeExpr, skipWhileCond, takeWhileCond, at)
+    }
     // Ring 2: early-exit lane — `any` no-pred + no upstream work + no limits + length-bearing
     if (lane == LinqLane.EARLY_EXIT) {
         let terminatorCall = calls.back()._0
@@ -1522,8 +1563,12 @@ def private plan_loop_or_count(var expr : Expression?) : Expression? {
         if (isAnyNoPred && whereCond == null && allProjectionsPure && noLimits
                 && type_has_length(top._type))
             return emit_any_empty_shortcut(top, srcName, at)
-        return emit_early_exit_lane(lastName, top, projection, whereCond,
-            intermediateBinds, preCondStmts, elementType, terminatorCall, srcName, itName, skipName,
+        var laneTops : array<Expression?>
+        laneTops |> push(top)
+        var laneSrcs : array<string>
+        laneSrcs |> push(srcName)
+        return emit_early_exit_lane(lastName, laneTops, projection, whereCond,
+            intermediateBinds, preCondStmts, elementType, terminatorCall, laneSrcs, itName, skipName,
             takeCountName, skippingName, skipExpr, takeExpr, skipWhileCond, takeWhileCond, at)
     }
     // Build the per-element loop body for COUNTER / ARRAY. Both lanes follow the same shape:
@@ -2875,22 +2920,47 @@ def private plan_group_by(var expr : Expression?) : Expression? {
 
 [macro_function]
 def private plan_zip(var expr : Expression?) : Expression? {
-    // Phase 2 Z1/Z2/Z3: 2-ary lockstep zip splice. Supports bare zip (array/iterator), no-pred count/long_count, and fused where_/select/take/skip/take_while/skip_while chain ops between zip and terminator. Result-selector form (3-arg zip), accumulator terminators (sum/min/max/etc.), and chained selects bail to tier-2 cascade.
+    // Phase 2 Z1/Z2/Z3 + accumulator/early-exit: 2-ary lockstep zip splice. Supports bare zip (array/iterator), no-pred count/long_count + accumulator (sum/min/max/average) + early-exit (first/first_or_default/any/all/contains) terminators, and fused where_/select/take/skip/take_while/skip_while chain ops between zip and terminator. Result-selector form (3-arg zip) and chained selects bail to tier-2 cascade.
     var (top, calls) = flatten_linq(expr)
     if (empty(calls) || calls[0]._1.name != "zip") return null
     var zipCall = calls[0]._0
     let zipArgCount = zipCall.arguments |> length
     // Z6 bail: result-selector form (3-arg zip = 2 sources + selector) yields scalar element stream — different splice shape, defer.
     if (zipArgCount != 2) return null
-    // Identify recognized terminator (count/long_count). Anything else: if it's a recognized chain op, treat as no-terminator (bare); else bail.
+    // Identify recognized terminator. Counter: count/long_count. Accumulator: sum/min/max/average. Early-exit: first/first_or_default/any/all/contains. Anything else: treat as no-terminator (bare → ARRAY lane); unrecognized chain op bails inside the chain walk.
     var lastName = ""
     var intermediateEnd = length(calls)
     if (length(calls) > 1) {
         let candidateName = calls.back()._1.name
         let candidateCall = calls.back()._0
+        let candidateArgs = candidateCall.arguments |> length
         if (candidateName == "count" || candidateName == "long_count") {
             // No-pred form only (1 arg = the source). Predicate-form bails (would change per-element work).
-            if (candidateCall.arguments |> length != 1) return null
+            if (candidateArgs != 1) return null
+            lastName = candidateName
+            intermediateEnd = length(calls) - 1
+        } elif (candidateName == "sum" || candidateName == "min" || candidateName == "max" || candidateName == "average") {
+            // Accumulator: no-arg form only (1 arg = the source).
+            if (candidateArgs != 1) return null
+            lastName = candidateName
+            intermediateEnd = length(calls) - 1
+        } elif (candidateName == "first") {
+            if (candidateArgs != 1) return null
+            lastName = candidateName
+            intermediateEnd = length(calls) - 1
+        } elif (candidateName == "first_or_default" || candidateName == "contains") {
+            // first_or_default(d): 1 default arg. contains(v): 1 value arg.
+            if (candidateArgs != 2) return null
+            lastName = candidateName
+            intermediateEnd = length(calls) - 1
+        } elif (candidateName == "any") {
+            // any(): no pred. any(p): 1 predicate arg. Both forms recognized.
+            if (candidateArgs != 1 && candidateArgs != 2) return null
+            lastName = candidateName
+            intermediateEnd = length(calls) - 1
+        } elif (candidateName == "all") {
+            // all(p): must have predicate.
+            if (candidateArgs != 2) return null
             lastName = candidateName
             intermediateEnd = length(calls) - 1
         }
@@ -3003,6 +3073,35 @@ def private plan_zip(var expr : Expression?) : Expression? {
     let isCounter = lastName == "count" || lastName == "long_count"
     // Semantic guard: impure `select` projection AHEAD of a range op (skip/take/skip_while/take_while). The eager `select(proj)|>skip(K)` pipeline runs proj on every element; our spliced order (skip-then-push) would drop the side effects on skipped items. Bail to tier-2 which preserves eager semantics. Plan_loop_or_count has the analogous gap (see PR #2741 review thread #r3269663361); fixing both planners uniformly is a separate follow-up.
     if (seenSelect && !allProjectionsPure && !noLimits) return null
+    // Accumulator + early-exit lane dispatch: reuses the generalized emit_*_lane helpers (parallel-array form). preCondStmts threads `let it = (itA, itB)` so itName resolves inside the loop body when the where/projection/predicate/value references the tuple element.
+    let lane = classify_terminator(lastName)
+    if (lane == LinqLane.ACCUMULATOR) {
+        // sum/min/max/average without projection: elementType is tuple<...>, accumulator op would not typecheck — bail to tier-2 (typer rejects anyway, but explicit bail keeps the error inside linq's normal cascade rather than the splice).
+        if (projection == null) return null
+        var preCondStmts : array<Expression?>
+        preCondStmts |> push <| qmacro_expr() {     // nolint:STYLE012
+            let $i(itName) = (itA, itB)
+        }
+        var intermediateBinds : array<Expression?>
+        var laneTops <- [srcAExpr, srcBExpr]
+        let laneSrcs <- [srcAName, srcBName]
+        return emit_accumulator_lane(lastName, laneTops, projection, whereCond,
+            intermediateBinds, preCondStmts, elementType, laneSrcs, accName, itName, skipName, takeCountName,
+            skippingName, skipExpr, takeExpr, skipWhileCond, takeWhileCond, at)
+    }
+    if (lane == LinqLane.EARLY_EXIT) {
+        var preCondStmts : array<Expression?>
+        preCondStmts |> push <| qmacro_expr() {     // nolint:STYLE012
+            let $i(itName) = (itA, itB)
+        }
+        var intermediateBinds : array<Expression?>
+        let terminatorCall = calls.back()._0
+        var laneTops <- [srcAExpr, srcBExpr]
+        let laneSrcs <- [srcAName, srcBName]
+        return emit_early_exit_lane(lastName, laneTops, projection, whereCond,
+            intermediateBinds, preCondStmts, elementType, terminatorCall, laneSrcs, itName, skipName,
+            takeCountName, skippingName, skipExpr, takeExpr, skipWhileCond, takeWhileCond, at)
+    }
     // Length shortcut: count/long_count, no chain, both length-bearing → return min(lenA, lenB) without entering the loop.
     if (noChain && bothHaveLength && isCounter) {
         var bodyStmts : array<Expression?>

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3073,9 +3073,9 @@ def private plan_zip(var expr : Expression?) : Expression? {
     let isCounter = lastName == "count" || lastName == "long_count"
     // Semantic guard: impure `select` projection AHEAD of a range op (skip/take/skip_while/take_while). The eager `select(proj)|>skip(K)` pipeline runs proj on every element; our spliced order (skip-then-push) would drop the side effects on skipped items. Bail to tier-2 which preserves eager semantics. Plan_loop_or_count has the analogous gap (see PR #2741 review thread #r3269663361); fixing both planners uniformly is a separate follow-up.
     if (seenSelect && !allProjectionsPure && !noLimits) return null
-    // Accumulator + early-exit lane dispatch: reuses the generalized emit_*_lane helpers (parallel-array form). preCondStmts threads `let it = (itA, itB)` so itName resolves inside the loop body when the where/projection/predicate/value references the tuple element.
+    // Accumulator + early-exit lane dispatch: reuses the generalized emit_*_lane helpers (parallel-array form). preCondStmts threads `let it = (itA, itB)` so itName resolves inside the loop body when the where/projection/predicate/value references the tuple element. `long_count` is classified ACCUMULATOR but routes through the COUNTER path locally (existing length-shortcut + counter loop already cover it); `!isCounter` excludes it from this branch.
     let lane = classify_terminator(lastName)
-    if (lane == LinqLane.ACCUMULATOR) {
+    if (lane == LinqLane.ACCUMULATOR && !isCounter) {
         // sum/min/max/average without projection: elementType is tuple<...>, accumulator op would not typecheck — bail to tier-2 (typer rejects anyway, but explicit bail keeps the error inside linq's normal cascade rather than the splice).
         if (projection == null) return null
         var preCondStmts : array<Expression?>

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -161,7 +161,7 @@ def target_zip_impure_select_skip_bails() : array<int> {
 }
 
 // ── PR Phase 2B+ — accumulator (sum/min/max/average) terminators on zip ──
-// All require a `select` projection to scalarize the tuple element (accumulator ops aren't defined on tuples).
+// sum/min/max/average require a `select` projection to scalarize the tuple element (accumulator ops aren't defined on tuples). `long_count` is the exception: it routes through the COUNTER path locally (length shortcut + counter loop) since the accumulator is just `int64 acc++` regardless of element type.
 [export, marker(no_coverage)]
 def target_zip_sum_proj_fold() : int {
     return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> sum())
@@ -428,6 +428,9 @@ def test_zip_long_count_uses_length_shortcut(t : T?) {
         t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
         let n = count_inner_for_loops(body_expr)
         t |> equal(n, 0, "zip(arr,arr).long_count() must use length shortcut (no for-loop)")
+        // Distinguish length-shortcut splice from tier-2 cascade by elimination: for_loops==0 rules out the counter-loop splice path; long_count==0 rules out tier-2 (which leaves the long_count call in place). Both together ⇒ length shortcut. (Can't grep for length() directly: count_call doesn't recurse into ExprOp3 ternary where length() lives in the min(...) expression.)
+        let longCountCalls = count_call(body_expr, "long_count")
+        t |> equal(longCountCalls, 0, "long_count must be inlined into the splice (no runtime call)")
     }
 }
 
@@ -706,6 +709,26 @@ def test_zip_where_long_count_fold_result(t : T?) {
     t |> run("zip+where+long_count returns int64 survivor count") @(t : T?) {
         // 3 survivors
         t |> equal(target_zip_where_long_count_fold(), 3l)
+    }
+}
+
+// long_count + chain op (where) must emit a single multi-iter counter for-loop, not cascade to tier-2. Regression guard against routing long_count through the ACCUMULATOR projection-required branch (PR #2742 Copilot review #r3270242609).
+[test]
+def test_zip_where_long_count_emits_counter_loop(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_where_long_count_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let nfor = count_inner_for_loops(body_expr)
+        t |> equal(nfor, 1, "zip+where+long_count must emit one multi-iter counter for-loop")
+        let zipCalls = count_call(body_expr, "zip")
+        t |> equal(zipCalls, 0, "zip call must be inlined into the splice")
+        let longCountCalls = count_call(body_expr, "long_count")
+        t |> equal(longCountCalls, 0, "long_count terminator must be fused (no runtime call)")
     }
 }
 

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -249,6 +249,14 @@ def target_zip_contains_proj_miss_fold() : bool {
     return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> contains(999))
 }
 
+// PR #2742 Copilot review #r3270337476 — DEFERRED: emit_accumulator_lane.average semantics divergence from linq.das. Pre-existing in helper (affects plan_loop_or_count's single-source path too): accumulates in accType (often int → overflow risk) and returns NaN on empty cnt, while linq.das average accumulates in double and returns 0.0lf on empty. Follow-up PR must fix the helper uniformly AND update the existing fold test "average: empty → NaN" in test_linq_fold.das to expect 0.0lf.
+[export, marker(no_coverage)]
+def target_zip_average_empty_fold() : double {
+    var emptyA : array<int>
+    var emptyB : array<int>
+    return _fold(emptyA.zip(emptyB) |> select($(t : tuple<int; int>) => t._0 + t._1) |> average())
+}
+
 [export, marker(no_coverage)]
 def target_zip3_fold() : array<tuple<int; int; int>> {
     return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10))._fold()
@@ -820,6 +828,12 @@ def test_zip_contains_proj_miss_fold_result(t : T?) {
     t |> run("zip+select+contains returns false on miss") @(t : T?) {
         t |> equal(target_zip_contains_proj_miss_fold(), false)
     }
+}
+
+// PR #2742 Copilot review #r3270337476 — DEFERRED-fix tracking test. Documents the desired post-fix behavior (zip+select+average on empty source should return 0.0lf per linq.das semantics). Currently emit_accumulator_lane returns NaN, so this test is skipped until the helper is aligned (uniform fix across plan_loop_or_count + plan_zip; also requires updating "average: empty → NaN" in test_linq_fold.das to expect 0.0lf).
+[test]
+def test_zip_average_empty_returns_zero_when_fixed(t : T?) {
+    t->skip("DEFERRED: zip+select+average on empty source should return 0.0lf per linq.das semantics. Blocked on follow-up PR aligning emit_accumulator_lane.average with linq.das (double accumulator + cnt==0 guard); pre-existing helper divergence — affects single-source plan_loop_or_count too. Un-skip + assert `equal(target_zip_average_empty_fold(), 0.0lf)` when fix lands.")
 }
 
 // AST-shape: zip+accumulator splices into a single for-loop with no surviving runtime `sum`/`zip` calls.

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -160,6 +160,95 @@ def target_zip_impure_select_skip_bails() : array<int> {
     return <- [10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => side_effect_zip_proj(t._0)) |> skip(2) |> _fold()
 }
 
+// ── PR Phase 2B+ — accumulator (sum/min/max/average) terminators on zip ──
+// All require a `select` projection to scalarize the tuple element (accumulator ops aren't defined on tuples).
+[export, marker(no_coverage)]
+def target_zip_sum_proj_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> sum())
+}
+
+[export, marker(no_coverage)]
+def target_zip_min_proj_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 - t._1) |> min())
+}
+
+[export, marker(no_coverage)]
+def target_zip_max_proj_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 * t._1) |> max())
+}
+
+[export, marker(no_coverage)]
+def target_zip_average_proj_fold() : double {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> average())
+}
+
+[export, marker(no_coverage)]
+def target_zip_where_sum_proj_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> where_($(t : tuple<int; int>) => t._0 > 20) |> select($(t : tuple<int; int>) => t._0 + t._1) |> sum())
+}
+
+[export, marker(no_coverage)]
+def target_zip_where_long_count_fold() : int64 {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> where_($(t : tuple<int; int>) => t._0 > 20) |> long_count())
+}
+
+// ── PR Phase 2B+ — early-exit (first/first_or_default/any/all/contains) terminators on zip ──
+[export, marker(no_coverage)]
+def target_zip_first_no_proj_fold() : tuple<int; int> {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> first())
+}
+
+[export, marker(no_coverage)]
+def target_zip_first_proj_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> first())
+}
+
+[export, marker(no_coverage)]
+def target_zip_where_first_fold() : tuple<int; int> {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> where_($(t : tuple<int; int>) => t._0 > 20) |> first())
+}
+
+[export, marker(no_coverage)]
+def target_zip_first_or_default_proj_fold() : int {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> where_($(v : int) => v > 1000) |> first_or_default(-1))
+}
+
+[export, marker(no_coverage)]
+def target_zip_any_no_pred_fold() : bool {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> any())
+}
+
+[export, marker(no_coverage)]
+def target_zip_any_no_pred_empty_fold() : bool {
+    var emptyA : array<int>
+    return _fold(emptyA.zip([1, 2, 3]) |> any())
+}
+
+[export, marker(no_coverage)]
+def target_zip_any_pred_fold() : bool {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> any($(t : tuple<int; int>) => t._0 > 30))
+}
+
+[export, marker(no_coverage)]
+def target_zip_all_pred_true_fold() : bool {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> all($(t : tuple<int; int>) => t._0 > 0))
+}
+
+[export, marker(no_coverage)]
+def target_zip_all_pred_false_fold() : bool {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> all($(t : tuple<int; int>) => t._0 > 30))
+}
+
+[export, marker(no_coverage)]
+def target_zip_contains_proj_fold() : bool {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> contains(33))
+}
+
+[export, marker(no_coverage)]
+def target_zip_contains_proj_miss_fold() : bool {
+    return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> contains(999))
+}
+
 [export, marker(no_coverage)]
 def target_zip3_fold() : array<tuple<int; int; int>> {
     return <- [1, 2, 3]._select(_ * 2).zip([10, 20, 30]._select(_ + 1), [100, 200, 300]._select(_ / 10))._fold()
@@ -566,6 +655,187 @@ def test_zip_select_count_pure_skips_it_bind(t : T?) {
         t |> equal(nfor, 1, "pure zip+select+count uses counter for-loop")
         let nbody = count_for_body_stmts(body_expr)
         t |> equal(nbody, 1, "pure zip+select+count counter body is just `acc++` — no `let it = (itA, itB)` bind")
+    }
+}
+
+// ── PR Phase 2B+ accumulator (sum/min/max/average) terminators on zip ──
+// Source: arrA=[10,20,30,40,50], arrB=[1,2,3,4,5]; pairs are (10,1)(20,2)(30,3)(40,4)(50,5).
+
+[test]
+def test_zip_sum_proj_fold_result(t : T?) {
+    t |> run("zip+select+sum returns scalar accumulator") @(t : T?) {
+        // (10+1)+(20+2)+(30+3)+(40+4)+(50+5) = 11+22+33+44+55 = 165
+        t |> equal(target_zip_sum_proj_fold(), 165)
+    }
+}
+
+[test]
+def test_zip_min_proj_fold_result(t : T?) {
+    t |> run("zip+select+min picks smallest projected value") @(t : T?) {
+        // diffs: 9,18,27,36,45 → min 9
+        t |> equal(target_zip_min_proj_fold(), 9)
+    }
+}
+
+[test]
+def test_zip_max_proj_fold_result(t : T?) {
+    t |> run("zip+select+max picks largest projected value") @(t : T?) {
+        // products: 10,40,90,160,250 → max 250
+        t |> equal(target_zip_max_proj_fold(), 250)
+    }
+}
+
+[test]
+def test_zip_average_proj_fold_result(t : T?) {
+    t |> run("zip+select+average returns double") @(t : T?) {
+        // (11+22+33+44+55)/5 = 33.0
+        t |> equal(target_zip_average_proj_fold(), 33.0lf)
+    }
+}
+
+[test]
+def test_zip_where_sum_proj_fold_result(t : T?) {
+    t |> run("zip+where+select+sum filters then sums") @(t : T?) {
+        // survivors where t._0>20: (30,3)(40,4)(50,5) → 33+44+55 = 132
+        t |> equal(target_zip_where_sum_proj_fold(), 132)
+    }
+}
+
+[test]
+def test_zip_where_long_count_fold_result(t : T?) {
+    t |> run("zip+where+long_count returns int64 survivor count") @(t : T?) {
+        // 3 survivors
+        t |> equal(target_zip_where_long_count_fold(), 3l)
+    }
+}
+
+// ── PR Phase 2B+ early-exit (first/first_or_default/any/all/contains) on zip ──
+
+[test]
+def test_zip_first_no_proj_fold_result(t : T?) {
+    t |> run("zip+first (no projection) returns first tuple") @(t : T?) {
+        let result = target_zip_first_no_proj_fold()
+        t |> equal(result._0, 10)
+        t |> equal(result._1, 1)
+    }
+}
+
+[test]
+def test_zip_first_proj_fold_result(t : T?) {
+    t |> run("zip+select+first returns first projected scalar") @(t : T?) {
+        // first pair (10,1) projected → 11
+        t |> equal(target_zip_first_proj_fold(), 11)
+    }
+}
+
+[test]
+def test_zip_where_first_fold_result(t : T?) {
+    t |> run("zip+where+first returns first survivor tuple") @(t : T?) {
+        // first pair where t._0>20: (30,3)
+        let result = target_zip_where_first_fold()
+        t |> equal(result._0, 30)
+        t |> equal(result._1, 3)
+    }
+}
+
+[test]
+def test_zip_first_or_default_proj_fold_result(t : T?) {
+    t |> run("zip+select+where+first_or_default returns default when no survivor") @(t : T?) {
+        // no projected sum > 1000, so default -1 fires
+        t |> equal(target_zip_first_or_default_proj_fold(), -1)
+    }
+}
+
+[test]
+def test_zip_any_no_pred_fold_result(t : T?) {
+    t |> run("zip+any (no pred) on non-empty pair → true") @(t : T?) {
+        t |> equal(target_zip_any_no_pred_fold(), true)
+    }
+}
+
+[test]
+def test_zip_any_no_pred_empty_fold_result(t : T?) {
+    t |> run("zip+any (no pred) on empty source → false") @(t : T?) {
+        // emptyA.zip(...) → min(0,3) = 0 iters → any returns false
+        t |> equal(target_zip_any_no_pred_empty_fold(), false)
+    }
+}
+
+[test]
+def test_zip_any_pred_fold_result(t : T?) {
+    t |> run("zip+any(pred) returns true if any pair matches") @(t : T?) {
+        // (40,4) and (50,5) satisfy t._0>30 → true
+        t |> equal(target_zip_any_pred_fold(), true)
+    }
+}
+
+[test]
+def test_zip_all_pred_true_fold_result(t : T?) {
+    t |> run("zip+all(pred) returns true when all match") @(t : T?) {
+        t |> equal(target_zip_all_pred_true_fold(), true)
+    }
+}
+
+[test]
+def test_zip_all_pred_false_fold_result(t : T?) {
+    t |> run("zip+all(pred) returns false when any fails") @(t : T?) {
+        // 10, 20, 30 fail t._0>30
+        t |> equal(target_zip_all_pred_false_fold(), false)
+    }
+}
+
+[test]
+def test_zip_contains_proj_fold_result(t : T?) {
+    t |> run("zip+select+contains returns true on hit") @(t : T?) {
+        // 30+3 = 33 matches
+        t |> equal(target_zip_contains_proj_fold(), true)
+    }
+}
+
+[test]
+def test_zip_contains_proj_miss_fold_result(t : T?) {
+    t |> run("zip+select+contains returns false on miss") @(t : T?) {
+        t |> equal(target_zip_contains_proj_miss_fold(), false)
+    }
+}
+
+// AST-shape: zip+accumulator splices into a single for-loop with no surviving runtime `sum`/`zip` calls.
+[test]
+def test_zip_sum_proj_emits_inline_accumulator(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_sum_proj_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let nfor = count_inner_for_loops(body_expr)
+        t |> equal(nfor, 1, "zip+select+sum must emit exactly one multi-iter for-loop")
+        let zipCalls = count_call(body_expr, "zip")
+        t |> equal(zipCalls, 0, "zip call must be inlined into the splice")
+        let sumCalls = count_call(body_expr, "sum")
+        t |> equal(sumCalls, 0, "sum terminator must be fused (no runtime sum call)")
+    }
+}
+
+// AST-shape: zip+early-exit emits the same single-for shape with no surviving terminator call.
+[test]
+def test_zip_first_proj_emits_early_return(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_zip_first_proj_fold)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        let nfor = count_inner_for_loops(body_expr)
+        t |> equal(nfor, 1, "zip+select+first must emit exactly one multi-iter for-loop")
+        let zipCalls = count_call(body_expr, "zip")
+        t |> equal(zipCalls, 0, "zip call must be inlined")
+        let firstCalls = count_call(body_expr, "first")
+        t |> equal(firstCalls, 0, "first terminator must be fused (no runtime first call)")
     }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #2741 (Phase 2B: zip + chain ops `where/select/take/skip/take_while/skip_while`). Extends `plan_zip`'s terminator dispatch with the second half of the deferred Phase 2 list:

- **ACCUMULATOR lane**: `sum`, `min`, `max`, `average`
- **EARLY_EXIT lane**: `first`, `first_or_default`, `any` (no-pred + pred forms), `all`, `contains`

Plus extra `long_count` coverage in the new accumulator pathway (was previously only reachable via the COUNTER length shortcut).

## Refactor (single source of truth)

`emit_accumulator_lane` and `emit_early_exit_lane` were single-source — they baked `for ($i(itName) in $i(srcName))` and `invoke($($i(srcName) : $t(srcParamType)) { ... }, $e(top))` into the helper. Generalized both via parallel arrays:

| Was | Now |
|---|---|
| `srcName : string` | `srcNames : array&lt;string&gt;` |
| `top : Expression?` | `topExprs : array&lt;Expression?&gt;` |

The helpers branch on `length(srcNames)`:

- **For-loop emission**: 1-source uses `$i(itName)`; 2-source uses literal `itA, itB` because qmacro doesn't accept `$i(...)` splice in the multi-iter for-loop iter-var position (`for ($i(a), $i(b) in ...)` → `syntax error, unexpected $i, expecting name`). plan_zip controls the calling convention so the literal names are predictable.
- **Invoke wrap**: extracted to new `finalize_lane_emission(topExprs, srcNames, bodyStmts, at)` helper. 1-source emits 1-arg invoke; 2-source emits 2-arg invoke. No body duplication between the two emit helpers.

`finalize_invoke` now loops over all block args to set `can_shadow` (was hardcoded to `args[0]`). This makes `finalize_zip_invoke` redundant for new code; kept in place for plan_zip's existing COUNTER/ARRAY paths since no behavior change there.

plan_loop_or_count's two call sites updated trivially — wrap `top` and `srcName` into 1-element arrays at the boundary. Existing single-source behavior fully preserved (the 369 fold + 184 ast tests covering plan_loop_or_count all pass unchanged).

## plan_zip dispatch

After the chain walk (`where/select/take/skip/take_while/skip_while`), classify the terminator name. ACCUMULATOR/EARLY_EXIT lanes both:

1. Build `preCondStmts` with `let $i(itName) = (itA, itB)` so itName resolves to the tuple inside the loop body (where `whereCond`/projection/predicate evaluate).
2. Call the generalized helper with `srcNames = [srcAName, srcBName]` and `topExprs = [srcAExpr, srcBExpr]`.

**Bail**: accumulator without projection. `default&lt;tuple&lt;TA;TB&gt;&gt;` has no `+=`, so sum/min/max/average wouldn't typecheck anyway. The explicit bail keeps the error inside linq's normal cascade rather than as a splice-emission error.

## Tests

16 new in [tests/linq/test_linq_fold_ast.das](tests/linq/test_linq_fold_ast.das):

**Behavioral parity (14)**:
- Accumulator: `zip+select+sum/min/max/average`, `zip+where+select+sum`, `zip+where+long_count`
- Early-exit: `zip+first` (no-proj returns tuple), `zip+select+first` (proj returns scalar), `zip+where+first`, `zip+select+where+first_or_default` (default fires), `zip+any` (no-pred true/empty), `zip+any(pred)`, `zip+all(pred)` (true/false), `zip+select+contains` (hit/miss)

**AST shape (2)**:
- `test_zip_sum_proj_emits_inline_accumulator` — single multi-iter for-loop, zero surviving `zip`/`sum` calls
- `test_zip_first_proj_emits_early_return` — single multi-iter for-loop, zero surviving `zip`/`first` calls

## Verification (pre-push)

- `mcp__daslang__lint daslib/linq_fold.das tests/linq/test_linq_fold_ast.das` — clean
- `mcp__daslang__format_file` — both already formatted
- Interpret regression sweep on `tests/linq/`: **646/646 pass** before adding new tests; **662/662 after** (test_linq, test_linq_transform, test_linq_fold, test_linq_fold_ast)
- AOT regen + AOT-mode sweep: **1169/1169 pass** via `bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/linq`

## Deferred to follow-up PRs

- **TERMINAL_WALK terminators on zip** (`last`, `last_or_default`, `single`, `single_or_default`, `element_at`, `element_at_or_default`, `aggregate`) — helpers support these via the same dispatch path; needs targets + tests
- **Z4 (3-ary zip)** / **Z5 (4..8-ary mechanical)** — needs either more arity-specific for-loop branches or direct ExprFor AST construction
- **any-no-pred length shortcut on zip** — `!empty(srcA) && !empty(srcB)` would beat the for-loop; small perf opt
- **Chained selects on zip** (Phase 3d analog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)