### PR TITLE
decs_boost: from_decs_template macro (eager bridge to from_decs)

### DIFF
--- a/daslib/decs_boost.das
+++ b/daslib/decs_boost.das
@@ -703,3 +703,89 @@ class FromDecsMacro : AstCallMacro {
         )
     }
 }
+
+[call_macro(name="from_decs_template")]
+class FromDecsTemplateMacro : AstCallMacro {
+    //! This macro converts a DECS query over a ``[decs_template]`` struct into an ``iterator<tuple<...>>``.
+    //! The field list (names and types) is derived from the struct definition; component names are
+    //! the struct's prefix (per ``[decs_template(prefix=...)]``) joined with each field name. For example::
+    //!
+    //!     [decs_template(prefix="particle_")]
+    //!     struct Particle { pos, vel : float3 }
+    //!     let it = from_decs_template(type<Particle>)
+    //!     for (item in it) {
+    //!         print("pos {item.pos}, vel {item.vel}\n")
+    //!     }
+    //!
+    //! This is the eager bridge form — equivalent to writing
+    //! ``from_decs($(particle_pos : float3; particle_vel : float3){})`` by hand and projecting back into
+    //! field names. Tuple element types are by-value (the query's archetype refs do not outlive the
+    //! invoke block).
+    def override visit(prog : ProgramPtr; mod : Module?; var expr : ExprCallMacro?) : ExpressionPtr {
+        macro_verify(length(expr.arguments) == 1, prog, expr.at, "expecting from_decs_template(type<Foo>)")
+        macro_verify(expr.arguments[0] is ExprTypeDecl, prog, expr.at, "expecting from_decs_template(type<Foo>), got {expr.arguments[0].__rtti}")
+        let typeExpr = expr.arguments[0] as ExprTypeDecl
+        let td = typeExpr.typeexpr
+        macro_verify(td != null && td.baseType == Type.tStructure, prog, expr.at, "from_decs_template expects type<Struct>, got non-struct type")
+        let st = td.structType
+        macro_verify(st != null, prog, expr.at, "from_decs_template: struct type is not resolved")
+        // Resolve [decs_template] annotation + prefix
+        var prefix = ""
+        var hasTemplate = false
+        for (ann in st.annotations) {
+            if (ann.annotation.name == "decs_template") {
+                hasTemplate = true
+                let ppref = ann.arguments |> decs_prefix
+                prefix = (ppref is yes) ? (ppref as yes) : "{st.name}_"
+                break
+            }
+        }
+        macro_verify(hasTemplate, prog, expr.at, "from_decs_template: struct {st.name} is not annotated with [decs_template]")
+        macro_verify(!empty(st.fields), prog, expr.at, "from_decs_template: struct {st.name} has no fields")
+        // Tuple type (field names as record names, by-value types stripped of ref/const)
+        var tupleType = new TypeDecl(baseType = Type.tTuple, at = expr.at)
+        tupleType.argNames.resize(length(st.fields))
+        for (fld, idx in st.fields, count()) {
+            var ft = clone_type(fld._type)
+            ft.flags.ref = false
+            ft.flags.constant = false
+            tupleType.argTypes |> emplace_new(ft)
+            tupleType.argNames[idx] := fld.name
+        }
+        // Tuple constructor: pull each prefixed component into a record-named field
+        var mkTuple = new ExprMakeTuple(at = expr.at)
+        mkTuple.recordNames.resize(length(st.fields))
+        for (fld, idx in st.fields, count()) {
+            mkTuple.values |> push(new ExprVar(at = fld.at, name := "{prefix}{fld.name}"))
+            mkTuple.recordNames[idx] := fld.name
+        }
+        // Query block: one arg per field, name = prefixed component, type = const non-ref
+        // fld.init (if set) clones in so the query macro picks get_default_ro
+        var qblock = qmacro(${
+            res |> push($e(mkTuple))
+        })
+        var qba = qblock as ExprMakeBlock
+        var qbb = qba._block as ExprBlock
+        qbb.blockFlags.isClosure = true
+        for (fld in st.fields) {
+            var argType = clone_type(fld._type)
+            argType.flags.ref = false
+            argType.flags.constant = true
+            qbb.arguments |> emplace_new <| new Variable(at = fld.at,
+                name := "{prefix}{fld.name}",
+                _type = argType,
+                init = clone_expression(fld.init)
+            )
+        }
+        // Call query macro and wrap in invoke
+        var callquery = make_call(expr.at, "query")
+        (callquery as ExprCallMacro).arguments |> push(clone_expression(qblock))
+        return qmacro(
+            invoke(${
+                var res : array<$t(tupleType)>
+                $e(callquery)
+                return res.to_sequence()
+            })
+        )
+    }
+}

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -55,6 +55,7 @@ struct FromTemplateEmpty {
 
 [test]
 def test_from_decs_template(t : T?) {
+    restart()
     for (i in range(3)) {
         create_entity() @(eid, cmp) {
             cmp.eid := eid
@@ -92,7 +93,7 @@ def test_from_decs_template(t : T?) {
             from_decs_template(type<FromTemplateImplicit>)._select(_.iv).sum()
         )
         let via_explicit = (
-            from_decs($(FromTemplateImplicit_iv : int){})._select(_.FromTemplateImplicit_iv).sum()
+            from_decs($(FromTemplateImplicit_iv : int; FromTemplateImplicit_sv : string){})._select(_.FromTemplateImplicit_iv).sum()
         )
         tt |> equal(via_template, via_explicit)
         tt |> equal(via_template, 0 + 10 + 20)

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -34,3 +34,83 @@ def test_from_decs(t : T?) {
         }
     }
 }
+
+[decs_template(prefix = "ftd_default_")]
+struct FromTemplateDefault {
+    index : int
+    text  : string
+}
+
+[decs_template]
+struct FromTemplateImplicit {
+    iv : int
+    sv : string
+}
+
+[decs_template(prefix)]
+struct FromTemplateEmpty {
+    ev_index : int
+    ev_text  : string
+}
+
+[test]
+def test_from_decs_template(t : T?) {
+    for (i in range(3)) {
+        create_entity() @(eid, cmp) {
+            cmp.eid := eid
+            cmp.ftd_default_index := i
+            cmp.ftd_default_text := "ftd{i}"
+            cmp.FromTemplateImplicit_iv := i * 10
+            cmp.FromTemplateImplicit_sv := "imp{i}"
+            cmp.ev_index := i * 100
+            cmp.ev_text := "emp{i}"
+        }
+    }
+    commit()
+    t |> run("from_decs_template custom prefix parity") @(tt : T?) {
+        var via_template = (
+            from_decs_template(type<FromTemplateDefault>)
+                ._where(_.index < 2)
+                .reverse()
+                .to_array()
+        )
+        var via_explicit = (
+            from_decs($(ftd_default_index : int; ftd_default_text : string){})
+                ._where(_.ftd_default_index < 2)
+                .reverse()
+                .to_array()
+        )
+        tt |> equal(via_template.length(), via_explicit.length())
+        tt |> equal(via_template.length(), 2)
+        for (a, b in via_template, via_explicit) {
+            tt |> equal(a.index, b.ftd_default_index)
+            tt |> equal(a.text, b.ftd_default_text)
+        }
+    }
+    t |> run("from_decs_template default-prefix parity (struct name)") @(tt : T?) {
+        let via_template = (
+            from_decs_template(type<FromTemplateImplicit>)._select(_.iv).sum()
+        )
+        let via_explicit = (
+            from_decs($(FromTemplateImplicit_iv : int){})._select(_.FromTemplateImplicit_iv).sum()
+        )
+        tt |> equal(via_template, via_explicit)
+        tt |> equal(via_template, 0 + 10 + 20)
+    }
+    t |> run("from_decs_template empty-prefix parity") @(tt : T?) {
+        let via_template = (
+            from_decs_template(type<FromTemplateEmpty>).count()
+        )
+        let via_explicit = (
+            from_decs($(ev_index : int; ev_text : string){}).count()
+        )
+        tt |> equal(via_template, via_explicit)
+        tt |> equal(via_template, 3)
+    }
+    t |> run("from_decs_template projection by field name") @(tt : T?) {
+        let sum_idx = (
+            from_decs_template(type<FromTemplateDefault>)._select(_.index).sum()
+        )
+        tt |> equal(sum_idx, 0 + 1 + 2)
+    }
+}


### PR DESCRIPTION
## Summary

New `[call_macro]` `from_decs_template(type&lt;Foo&gt;)` that converts a struct annotated with `[decs_template]` into an `iterator&lt;tuple&lt;...&gt;&gt;` over the matched archetype set. Field names + types are derived from the struct definition; component names are the `[decs_template(prefix=...)]` prefix joined with each field name.

```das
[decs_template(prefix="particle_")]
struct Particle { pos, vel : float3 }

let total = (
    from_decs_template(type&lt;Particle&gt;)
        ._where(p =&gt; length(p.vel) &gt; 0.0f)
        ._select(p =&gt; length(p.pos))
        .sum()
)
```

**Eager bridge form** — emits `invoke($() { var res : array&lt;tuple&lt;...&gt;&gt;; query(...) { res |&gt; push((...)) }; return res.to_sequence() })`. Same shape as the existing `FromDecsMacro` ([daslib/decs_boost.das:633](daslib/decs_boost.das#L633)), just with the field list sourced from `st.fields` instead of a block. Tuple elements are by-value since archetype refs don't outlive the invoke block.

This is Phase 3 of a 4-phase decs-unroll plan — surface API lands now so a future `plan_from_decs_template` splice can later replace it with a zero-buffer `for_each_archetype` lowering (Phase 4).

## Details

- **Prefix resolution** mirrors `is_decs_template` / `DecsTemplate.apply`:
  - `[decs_template]` &rarr; `"{StructName}_"`
  - `[decs_template(prefix="x_")]` &rarr; `"x_"`
  - `[decs_template(prefix)]` &rarr; `""`
- **Default field values** (`fld.init` set) clone into the query block so the query macro infers `get_default_ro` for those components.
- **Validation errors** via `macro_verify`: non-`ExprTypeDecl` arg, non-struct type, missing `[decs_template]` annotation, empty struct.
- **Skipped Phase 3 T2 negative tests** — `tests/linq/` has no compile-error test framework; the `macro_verify` guards are in place and follow-up PR adds them when infrastructure exists.
- **Phase 4 splice** will switch the macro to emit a splice-able marker, and `plan_from_decs_template` in `daslib/linq_fold.das` will recognize and lower it to `for_each_archetype` without materialization.

## Files

- [daslib/decs_boost.das](daslib/decs_boost.das) (+86) &mdash; new `FromDecsTemplateMacro` class after `FromDecsMacro`
- [tests/linq/test_linq_from_decs.das](tests/linq/test_linq_from_decs.das) (+82) &mdash; 4 parity sub-tests under new `test_from_decs_template`, plus `restart()` for ECS isolation

## Test plan

- [x] `mcp__daslang__lint` &mdash; clean on both files
- [x] `mcp__daslang__format_file` &mdash; clean
- [x] `mcp__daslang__run_test tests/linq/test_linq_from_decs.das` &mdash; 7/7 pass (1 existing `from_decs` + 4 new `from_decs_template` parity sub-tests)
- [x] Interpret sweep `tests/linq` &mdash; 1138/1138 green
- [x] AOT sweep `bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/linq` (after `--aot-regen` + `test_aot` rebuild) &mdash; 1138/1138 green
- [x] Decs regression `tests/decs/test_queries.das` + `tests/decs/test_templates_comprehensive.das` &mdash; 15/15 + 7/7 green
- [ ] CI

## Review iterations

- `d83adf953` &mdash; address Copilot review: add `restart()` to isolate ECS state across tests in the same file, and make the "default-prefix parity" sub-test symmetric (explicit query now binds both `FromTemplateImplicit_iv` AND `_sv` to match the template form's component requirements). Audited the other 3 parity sub-tests &mdash; already symmetric.

&#129302; Generated with [Claude Code](https://claude.com/claude-code)