### PR TITLE
longarr phase 2+3+4: 64-bit arrays and tables — daslang surface + AOT helpers

### DIFF
--- a/daslib/array_boost.das
+++ b/daslib/array_boost.das
@@ -155,7 +155,9 @@ def array_view(var bytes : array<auto(TT)> ==const; offset, length : int; blk : 
 def array_view(bytes : array<auto(TT)> ==const; offset, length : int64; blk : block<(view : array<TT>#) : void>) {
     //! int64 overload — creates a view of the array
     unsafe {
-        if (offset < 0_l || uint64(offset + length) > long_length(bytes)) {
+        // Validate non-negativity before the sum to avoid signed overflow UB,
+        // and so a negative length doesn't wrap to huge after the uint64 cast.
+        if (offset < 0_l || length < 0_l || uint64(offset) + uint64(length) > long_length(bytes)) {
             panic("array_view: out of range")
         }
         __builtin_array_lock_mutable(bytes)
@@ -169,7 +171,7 @@ def array_view(bytes : array<auto(TT)> ==const; offset, length : int64; blk : bl
 def array_view(var bytes : array<auto(TT)> ==const; offset, length : int64; blk : block<(var view : array<TT>#) : void>) {
     //! int64 overload — creates a mutable view of the array
     unsafe {
-        if (offset < 0_l || uint64(offset + length) > long_length(bytes)) {
+        if (offset < 0_l || length < 0_l || uint64(offset) + uint64(length) > long_length(bytes)) {
             panic("array_view: out of range")
         }
         __builtin_array_lock(bytes)

--- a/daslib/array_boost.das
+++ b/daslib/array_boost.das
@@ -104,6 +104,26 @@ def public temp_array(data : auto? ==const; lenA : int; a : auto(TT)) : array<TT
     return <- res
 }
 
+[unsafe_operation, template(a), unused_argument(a)]
+def public temp_array(var data : auto? ==const; lenA : int64; a : auto(TT)) : array<TT -const -#> {
+    //! int64 overload — creates a temporary array from the given data pointer and length
+    var res : array<TT -const -#>
+    if (lenA >= 1_l) {
+        unsafe(_builtin_make_temp_array_i64(res, data, lenA))
+    }
+    return <- res
+}
+
+[unsafe_operation, template(a), unused_argument(a)]
+def public temp_array(data : auto? ==const; lenA : int64; a : auto(TT)) : array<TT -const -#> const {
+    //! int64 overload — creates a temporary array from the given data pointer and length
+    var res : array<TT -const -#>
+    if (lenA >= 1_l) {
+        unsafe(_builtin_make_temp_array_i64(res, data, lenA))
+    }
+    return <- res
+}
+
 def array_view(bytes : array<auto(TT)> ==const; offset, length : int; blk : block<(view : array<TT>#) : void>) {
     //! creates a view of the array, which is a temporary array that is valid only within the block
     unsafe {
@@ -127,6 +147,34 @@ def array_view(var bytes : array<auto(TT)> ==const; offset, length : int; blk : 
         __builtin_array_lock(bytes)
         var res : array<TT>#
         _builtin_make_temp_array(res, addr(bytes[offset]), length)
+        invoke(blk, res)
+        __builtin_array_unlock(bytes)
+    }
+}
+
+def array_view(bytes : array<auto(TT)> ==const; offset, length : int64; blk : block<(view : array<TT>#) : void>) {
+    //! int64 overload — creates a view of the array
+    unsafe {
+        if (offset < 0_l || uint64(offset + length) > long_length(bytes)) {
+            panic("array_view: out of range")
+        }
+        __builtin_array_lock_mutable(bytes)
+        var res : array<TT>#
+        _builtin_make_temp_array_i64(res, addr(bytes[offset]), length)
+        invoke(blk, res)
+        __builtin_array_unlock_mutable(bytes)
+    }
+}
+
+def array_view(var bytes : array<auto(TT)> ==const; offset, length : int64; blk : block<(var view : array<TT>#) : void>) {
+    //! int64 overload — creates a mutable view of the array
+    unsafe {
+        if (offset < 0_l || uint64(offset + length) > long_length(bytes)) {
+            panic("array_view: out of range")
+        }
+        __builtin_array_lock(bytes)
+        var res : array<TT>#
+        _builtin_make_temp_array_i64(res, addr(bytes[offset]), length)
         invoke(blk, res)
         __builtin_array_unlock(bytes)
     }

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -43,6 +43,13 @@ def resize(var Arr : array<auto(numT)>; newSize : int) {
     __builtin_array_resize(Arr, newSize, typeinfo sizeof(Arr[0]))
 }
 
+def resize(var Arr : array<auto(numT)>; newSize : int64) {
+    static_if (typeinfo is_unsafe_when_uninitialized(type<numT>)) {
+        make_function_unsafe()
+    }
+    __builtin_array_resize_i64(Arr, newSize, typeinfo sizeof(Arr[0]))
+}
+
 def resize_and_init(var Arr : array<auto(numT)>; newSize : int) {
     let oldSize = length(Arr)
     __builtin_array_resize(Arr, newSize, typeinfo sizeof(Arr[0]))
@@ -81,8 +88,21 @@ def resize_no_init(var Arr : array<auto(numT)>; newSize : int) {
     }
 }
 
+[unused_argument(Arr, newSize)]
+def resize_no_init(var Arr : array<auto(numT)>; newSize : int64) {
+    static_if (typeinfo is_raw(type<numT>)) {
+        __builtin_array_resize_no_init_i64(Arr, newSize, typeinfo sizeof(Arr[0]))
+    } else {
+        concept_assert(false, "can't resize_no_init non-raw array")
+    }
+}
+
 def reserve(var Arr : array<auto(numT)>; newSize : int) {
     __builtin_array_reserve(Arr, newSize, typeinfo sizeof(Arr[0]))
+}
+
+def reserve(var Arr : array<auto(numT)>; newSize : int64) {
+    __builtin_array_reserve_i64(Arr, newSize, typeinfo sizeof(Arr[0]))
 }
 
 def pop(var Arr : array<auto(numT)>) {
@@ -93,7 +113,7 @@ def pop(var Arr : array<auto(numT)>) {
 def push(var Arr : array<auto(numT)>; value : numT -# const ==const; at : int) {
     static_if (typeinfo can_copy(value)) {
         static_if (typeinfo can_clone_from_const(value)) {
-            Arr[__builtin_array_push(Arr, at, typeinfo sizeof(Arr[0]))] = value
+            Arr[__builtin_array_push(Arr, int64(at), typeinfo sizeof(Arr[0]))] = value
         } else {
             concept_assert(false, "can't push value, which can't be cloned from const")
         }
@@ -105,7 +125,7 @@ def push(var Arr : array<auto(numT)>; value : numT -# const ==const; at : int) {
 [unused_argument(Arr, value)]
 def push(var Arr : array<auto(numT)>; var value : numT -# ==const; at : int) {
     static_if (typeinfo can_copy(value)) {
-        Arr[__builtin_array_push(Arr, at, typeinfo sizeof(Arr[0]))] = value
+        Arr[__builtin_array_push(Arr, int64(at), typeinfo sizeof(Arr[0]))] = value
     } else {
         concept_assert(false, "can't push value, which can't be copied")
     }
@@ -204,7 +224,7 @@ def push(var Arr : array<auto(numT)[]>; var varr : numT[] -# ==const) {
 def emplace(var Arr : array<auto(numT)>; var value : numT -#&; at : int) {
     static_if (typeinfo can_move(value)) {
         unsafe {
-            Arr[__builtin_array_push(Arr, at, typeinfo sizeof(Arr[0]))] <- value
+            Arr[__builtin_array_push(Arr, int64(at), typeinfo sizeof(Arr[0]))] <- value
         }
     } else {
         concept_assert(false, "can't emplace value, which can't be moved")
@@ -254,7 +274,7 @@ def emplace(var Arr : array<auto(numT)[]>; var value : numT[] -#) {
 def push_clone(var Arr : array<auto(numT)>; value : numT ==const | #; at : int) {
     static_if (typeinfo can_clone(value)) {
         static_if (typeinfo can_clone_from_const(value)) {
-            Arr[__builtin_array_push_zero(Arr, at, typeinfo sizeof(Arr[0]))] := value
+            Arr[__builtin_array_push_zero(Arr, int64(at), typeinfo sizeof(Arr[0]))] := value
         } else {
             concept_assert(false, "can't push-clone value, which can't be cloned from const")
         }
@@ -266,7 +286,7 @@ def push_clone(var Arr : array<auto(numT)>; value : numT ==const | #; at : int) 
 [unused_argument(Arr, value, at)]
 def push_clone(var Arr : array<auto(numT)>; var value : numT ==const | #; at : int) {
     static_if (typeinfo can_clone(value)) {
-        Arr[__builtin_array_push_zero(Arr, at, typeinfo sizeof(Arr[0]))] := value
+        Arr[__builtin_array_push_zero(Arr, int64(at), typeinfo sizeof(Arr[0]))] := value
     } else {
         concept_assert(false, "can't push-clone value, which can't be cloned")
     }
@@ -434,8 +454,16 @@ def erase(var Arr : array<auto(numT)>; at : int) {
     __builtin_array_erase(Arr, at, typeinfo sizeof(Arr[0]))
 }
 
+def erase(var Arr : array<auto(numT)>; at : int64) {
+    __builtin_array_erase_i64(Arr, at, typeinfo sizeof(Arr[0]))
+}
+
 def erase(var Arr : array<auto(numT)>; at : int; count : int) {
     __builtin_array_erase_range(Arr, at, count, typeinfo sizeof(Arr[0]))
+}
+
+def erase(var Arr : array<auto(numT)>; at : int64; count : int64) {
+    __builtin_array_erase_range_i64(Arr, at, count, typeinfo sizeof(Arr[0]))
 }
 
 
@@ -481,7 +509,11 @@ def empty(a : table<auto; auto> | #) : bool {
 }
 
 def reserve(var Tab : table<auto(keyT); auto>; newSize : int) {
-    __builtin_table_reserve(Tab, uint(newSize))
+    __builtin_table_reserve(Tab, uint64(newSize))
+}
+
+def reserve(var Tab : table<auto(keyT); auto>; newSize : int64) {
+    __builtin_table_reserve(Tab, uint64(newSize))
 }
 
 
@@ -1314,6 +1346,11 @@ def iter_range(foo) {
     return range(_::length(foo)) // assuming length(foo) exists
 }
 
+def long_iter_range(foo) {
+    concept_assert(typeinfo is_iterable(foo), "requires iterable")
+    return range64(_::long_length(foo))
+}
+
 [generic, unsafe_outside_of_for, nodiscard]
 def each(str : string) : iterator<int> {
     var it : iterator<int>
@@ -1698,6 +1735,13 @@ def find_index(arr : array<auto(TT)> | #; key : TT) {
         if (o == key) return i
     }
     return -1
+}
+
+def long_find_index(arr : array<auto(TT)> | #; key : TT) : int64 {
+    for (o, i in arr, range64(long_length(arr))) {
+        if (o == key) return i
+    }
+    return -1_l
 }
 
 def find_index(arr : auto(TT)[] | #; key : TT) {

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -509,10 +509,12 @@ def empty(a : table<auto; auto> | #) : bool {
 }
 
 def reserve(var Tab : table<auto(keyT); auto>; newSize : int) {
+    return if (newSize < 0)
     __builtin_table_reserve(Tab, uint64(newSize))
 }
 
 def reserve(var Tab : table<auto(keyT); auto>; newSize : int64) {
+    return if (newSize < 0_l)
     __builtin_table_reserve(Tab, uint64(newSize))
 }
 

--- a/daslib/debug.das
+++ b/daslib/debug.das
@@ -265,24 +265,24 @@ class DAWalker : DapiDataWalker {
     def override canVisitArray(ps : void?; ti : TypeInfo) : bool {
         //! Returns true if the array size is within the maximum children limit.
         let arr = unsafe(reinterpret<DapiArray?> ps)
-        return maxChildrenCount < 0u || arr.size <= maxChildrenCount
+        return maxChildrenCount < 0u || arr.size <= uint64(maxChildrenCount)
     }
 
-    def override canVisitArrayData(ti : TypeInfo; count : uint) : bool {
+    def override canVisitArrayData(ti : TypeInfo; count : uint64) : bool {
         //! Returns true if the array data count is within the maximum children limit.
-        return maxChildrenCount < 0u || count <= maxChildrenCount
+        return maxChildrenCount < 0u || count <= uint64(maxChildrenCount)
     }
 
-    def override beforeArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         //! Records the array element count on the current variable before walking array data.
         let n = length(varsStack)
         if (n > 0) {
             var v & = unsafe(varsStack[n - 1])
-            v.indexedVariables = count
+            v.indexedVariables = uint(count)
         }
     }
 
-    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         //! Creates a child variable entry for each array element.
         self->startCont()
         let n = length(varsStack)
@@ -295,7 +295,7 @@ class DAWalker : DapiDataWalker {
         }
     }
 
-    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         //! Finalizes an array element variable, printing its value if it has no children.
         let n = length(varsStack)
         if (n > 0) {
@@ -312,7 +312,7 @@ class DAWalker : DapiDataWalker {
         self->popStack()
     }
 
-    def override afterArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override afterArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         //! Builds an inline preview string for the array after all elements are walked.
         let n = length(varsStack)
         if (n > 0) {
@@ -334,17 +334,17 @@ class DAWalker : DapiDataWalker {
         let n = length(varsStack)
         if (n > 0) {
             var v & = unsafe(varsStack[n - 1])
-            v.indexedVariables = pa.size
+            v.indexedVariables = uint(pa.size)
         }
     }
 
     def override canVisitTable(ps : void?; ti : TypeInfo) : bool {
         //! Returns true if the table size is within the maximum children limit.
         let pa = unsafe(reinterpret<DapiTable?> ps)
-        return maxChildrenCount < 0u || pa.size <= maxChildrenCount
+        return maxChildrenCount < 0u || pa.size <= uint64(maxChildrenCount)
     }
 
-    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         //! Creates a child variable entry for a table key.
         self->startCont()
         let n = length(varsStack)
@@ -357,7 +357,7 @@ class DAWalker : DapiDataWalker {
         }
     }
 
-    def override beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void {
+    def override beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
         //! Updates the type description for the current table value.
         let n = length(varsStack)
         if (n > 0) {
@@ -366,7 +366,7 @@ class DAWalker : DapiDataWalker {
         }
     }
 
-    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
         //! Finalizes a table value variable, printing its value if it has no children.
         let n = length(varsStack)
         if (n > 0) {

--- a/daslib/debug.das
+++ b/daslib/debug.das
@@ -265,12 +265,12 @@ class DAWalker : DapiDataWalker {
     def override canVisitArray(ps : void?; ti : TypeInfo) : bool {
         //! Returns true if the array size is within the maximum children limit.
         let arr = unsafe(reinterpret<DapiArray?> ps)
-        return maxChildrenCount < 0u || arr.size <= uint64(maxChildrenCount)
+        return arr.size <= uint64(maxChildrenCount)
     }
 
     def override canVisitArrayData(ti : TypeInfo; count : uint64) : bool {
         //! Returns true if the array data count is within the maximum children limit.
-        return maxChildrenCount < 0u || count <= uint64(maxChildrenCount)
+        return count <= uint64(maxChildrenCount)
     }
 
     def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
@@ -341,7 +341,7 @@ class DAWalker : DapiDataWalker {
     def override canVisitTable(ps : void?; ti : TypeInfo) : bool {
         //! Returns true if the table size is within the maximum children limit.
         let pa = unsafe(reinterpret<DapiTable?> ps)
-        return maxChildrenCount < 0u || pa.size <= uint64(maxChildrenCount)
+        return pa.size <= uint64(maxChildrenCount)
     }
 
     def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {

--- a/daslib/debug_eval.das
+++ b/daslib/debug_eval.das
@@ -377,10 +377,10 @@ def opArray(var st : TokenStream; index : int64; var result : Result) {
         let pArray = reinterpret<DapiArray?> getPD(st, result)
         if (pArray == null) return st |> error("null pointer")
         let dim = pArray.size
-        if (index < 0l || index >= int64(dim)) return st |> error("index out of range")
+        if (index < 0l || uint64(index) >= dim) return st |> error("index out of range")
         let pData = reinterpret<int8?> pArray.data
         let elemSize = get_type_size(result.tinfo.firstType)
-        let offset = int(index) * elemSize
+        let offset = index * int64(elemSize)
         result.data = pData + offset
         result.tinfo = *result.tinfo.firstType
         return result

--- a/daslib/debugger.das
+++ b/daslib/debugger.das
@@ -61,6 +61,12 @@ def install_new_thread_local_debug_agent(var agentPtr) {
 }
 
 // das::Array. should we bind C++ structure?
+//
+// IMPORTANT: keep this struct byte-compatible with C++ `das::Array` in
+// include/daScript/misc/arraytype.h. The `_pad_after_flags` field mirrors
+// the explicit pad added to the C++ struct to make Table::keys land at the
+// same offset on every ABI (clang/Itanium 32-bit would otherwise reuse base
+// trailing padding and put keys 4 bytes earlier than MSVC).
 struct DapiArray {
     data : void?
     size : uint64
@@ -68,6 +74,7 @@ struct DapiArray {
     lock : uint
     magic : uint
     flags : bitfield<_shared; _hopeless>
+    _pad_after_flags : uint
 }
 
 // das::Table. should we bind C++ structure?

--- a/daslib/debugger.das
+++ b/daslib/debugger.das
@@ -63,8 +63,8 @@ def install_new_thread_local_debug_agent(var agentPtr) {
 // das::Array. should we bind C++ structure?
 struct DapiArray {
     data : void?
-    size : uint
-    capacity : uint
+    size : uint64
+    capacity : uint64
     lock : uint
     magic : uint
     flags : bitfield<_shared; _hopeless>
@@ -74,6 +74,7 @@ struct DapiArray {
 struct DapiTable : DapiArray {
     keys : void?
     hashes : uint?
+    tombstones : uint64
 }
 
 // das::Block
@@ -106,7 +107,7 @@ class DapiDataWalker {
     def abstract canVisitStructure(ps : void?; si : StructInfo) : bool
     def abstract canVisitDim(ps : void?; ti : TypeInfo) : bool
     def abstract canVisitArray(pa : void?; ti : TypeInfo) : bool
-    def abstract canVisitArrayData(ti : TypeInfo; count : uint) : bool
+    def abstract canVisitArrayData(ti : TypeInfo; count : uint64) : bool
     def abstract canVisitTuple(ps : void?; ti : TypeInfo) : bool
     def abstract canVisitVariant(ps : void?; ti : TypeInfo) : bool
     def abstract canVisitTable(ps : void?; ti : TypeInfo) : bool
@@ -125,19 +126,19 @@ class DapiDataWalker {
     def abstract afterTupleEntry(ps : void?; ti : TypeInfo; pv : void?; idx : int; last : bool) : void
     def abstract beforeVariant(ps : void?; ti : TypeInfo) : void
     def abstract afterVariant(ps : void?; ti : TypeInfo) : void
-    def abstract beforeArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void
-    def abstract afterArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void
-    def abstract beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void
-    def abstract afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void
+    def abstract beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void
+    def abstract afterArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void
+    def abstract beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void
+    def abstract afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void
     def abstract beforeDim(ps : void?; ti : TypeInfo) : void
     def abstract afterDim(ps : void?; ti : TypeInfo) : void
     def abstract beforeArray(pa : DapiArray; ti : TypeInfo) : void
     def abstract afterArray(pa : DapiArray; ti : TypeInfo) : void
     def abstract beforeTable(pa : DapiTable; ti : TypeInfo) : void
-    def abstract beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void
-    def abstract afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void
-    def abstract beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void
-    def abstract afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void
+    def abstract beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void
+    def abstract afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void
+    def abstract beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void
+    def abstract afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void
     def abstract afterTable(pa : DapiTable; ti : TypeInfo) : void
     def abstract beforeRef(ps : void?; ti : TypeInfo) : void
     def abstract afterRef(ps : void?; ti : TypeInfo) : void

--- a/daslib/functional.das
+++ b/daslib/functional.das
@@ -471,6 +471,18 @@ def enumerate(var src : iterator<auto(TT)>) {
     }
 }
 
+def long_enumerate(var src : iterator<auto(TT)>) {
+    //! yields tuples of `(int64 index, element)` for each element in `src`
+    return <- generator<tuple<int64, TT -&>> capture(<- src) {
+        var idx = 0_l
+        for (x in src) {
+            yield (idx, x)
+            idx ++
+        }
+        return false
+    }
+}
+
 // ===========================
 //  for_each — apply side-effect to every element
 // ===========================

--- a/doc/source/reference/tutorials/47_data_walker.rst
+++ b/doc/source/reference/tutorials/47_data_walker.rst
@@ -149,14 +149,14 @@ with key/value pairs:
         indent : int = 0
 
         def override beforeArrayData(ps : void?; stride : uint;
-                count : uint; ti : TypeInfo) : void {
+                count : uint64; ti : TypeInfo) : void {
             self->pad()
             print("array[{int(count)}] = [\n")
             indent++
         }
 
         def override beforeArrayElement(ps : void?; ti : TypeInfo;
-                pe : void?; index : uint; last : bool) : void {
+                pe : void?; index : uint64; last : bool) : void {
             self->pad()
             print("[{int(index)}] = ")
         }
@@ -279,7 +279,7 @@ for efficiency — no intermediate string concatenation:
 
         // --- arrays ---
         def override beforeArrayData(ps : void?; stride : uint;
-                count : uint; ti : TypeInfo) : void {
+                count : uint64; ti : TypeInfo) : void {
             *writer |> write("[")
             indent++
             pushComma()

--- a/doc/source/reference/tutorials/47_data_walker.rst
+++ b/doc/source/reference/tutorials/47_data_walker.rst
@@ -151,14 +151,14 @@ with key/value pairs:
         def override beforeArrayData(ps : void?; stride : uint;
                 count : uint64; ti : TypeInfo) : void {
             self->pad()
-            print("array[{int(count)}] = [\n")
+            print("array[{int64(count)}] = [\n")
             indent++
         }
 
         def override beforeArrayElement(ps : void?; ti : TypeInfo;
                 pe : void?; index : uint64; last : bool) : void {
             self->pad()
-            print("[{int(index)}] = ")
+            print("[{int64(index)}] = ")
         }
 
         def override beforeTable(pa : DapiTable; ti : TypeInfo) : void {

--- a/doc/source/stdlib/handmade/function-builtin-long_capacity-0x3c515ea107626de1.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_capacity-0x3c515ea107626de1.rst
@@ -1,1 +1,1 @@
-Returns the current capacity of a dynamic `array` — the number of elements it can hold before triggering a reallocation — as `int64`. Unlike :ref:`capacity`, never panics on arrays with more than ``INT32_MAX`` reserved slots.
+Returns the current capacity of a dynamic `array` — the number of elements it can hold before triggering a reallocation — as `int64`. Unlike `capacity`, never panics on arrays with more than ``INT32_MAX`` reserved slots.

--- a/doc/source/stdlib/handmade/function-builtin-long_capacity-0x3c515ea107626de1.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_capacity-0x3c515ea107626de1.rst
@@ -1,0 +1,1 @@
+Returns the current capacity of a dynamic `array` — the number of elements it can hold before triggering a reallocation — as `int64`. Unlike :ref:`capacity`, never panics on arrays with more than ``INT32_MAX`` reserved slots.

--- a/doc/source/stdlib/handmade/function-builtin-long_capacity-0xfd7b1aac2bad1745.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_capacity-0xfd7b1aac2bad1745.rst
@@ -1,0 +1,1 @@
+Returns the current capacity of a `table` — the number of key-value pairs it can hold before triggering a reallocation — as `int64`. Unlike :ref:`capacity`, never panics on tables with more than ``INT32_MAX`` reserved slots.

--- a/doc/source/stdlib/handmade/function-builtin-long_capacity-0xfd7b1aac2bad1745.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_capacity-0xfd7b1aac2bad1745.rst
@@ -1,1 +1,1 @@
-Returns the current capacity of a `table` — the number of key-value pairs it can hold before triggering a reallocation — as `int64`. Unlike :ref:`capacity`, never panics on tables with more than ``INT32_MAX`` reserved slots.
+Returns the current capacity of a `table` — the number of key-value pairs it can hold before triggering a reallocation — as `int64`. Unlike `capacity`, never panics on tables with more than ``INT32_MAX`` reserved slots.

--- a/doc/source/stdlib/handmade/function-builtin-long_find_index-0x9ff42bd2f8251dcb.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_find_index-0x9ff42bd2f8251dcb.rst
@@ -1,0 +1,1 @@
+Returns the int64 index of the first element in `arr` equal to `key`, or ``-1`` if not present. Same semantics as :ref:`find_index` but returns `int64` and never panics on arrays larger than ``INT32_MAX``.

--- a/doc/source/stdlib/handmade/function-builtin-long_find_index-0x9ff42bd2f8251dcb.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_find_index-0x9ff42bd2f8251dcb.rst
@@ -1,1 +1,1 @@
-Returns the int64 index of the first element in `arr` equal to `key`, or ``-1`` if not present. Same semantics as :ref:`find_index` but returns `int64` and never panics on arrays larger than ``INT32_MAX``.
+Returns the int64 index of the first element in `arr` equal to `key`, or ``-1`` if not present. Same semantics as `find_index` but returns `int64` and never panics on arrays larger than ``INT32_MAX``.

--- a/doc/source/stdlib/handmade/function-builtin-long_iter_range-0xdad18c68311c501d.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_iter_range-0xdad18c68311c501d.rst
@@ -1,1 +1,1 @@
-Returns an `int64` range iterator over the valid indices of an iterable `foo` (typically an array or table). Same role as :ref:`iter_range` but produces `int64` indices so it stays correct when the container holds more than ``INT32_MAX`` elements.
+Returns an `int64` range iterator over the valid indices of an iterable `foo` (typically an array or table). Same role as `iter_range` but produces `int64` indices so it stays correct when the container holds more than ``INT32_MAX`` elements.

--- a/doc/source/stdlib/handmade/function-builtin-long_iter_range-0xdad18c68311c501d.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_iter_range-0xdad18c68311c501d.rst
@@ -1,0 +1,1 @@
+Returns an `int64` range iterator over the valid indices of an iterable `foo` (typically an array or table). Same role as :ref:`iter_range` but produces `int64` indices so it stays correct when the container holds more than ``INT32_MAX`` elements.

--- a/doc/source/stdlib/handmade/function-builtin-long_length-0x2b5dd5904a18045d.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_length-0x2b5dd5904a18045d.rst
@@ -1,1 +1,1 @@
-Returns the number of elements currently stored in a dynamic array `array`, as `int64`. Unlike :ref:`length`, never panics on arrays with more than ``INT32_MAX`` elements.
+Returns the number of elements currently stored in a dynamic array `array`, as `int64`. Unlike `length`, never panics on arrays with more than ``INT32_MAX`` elements.

--- a/doc/source/stdlib/handmade/function-builtin-long_length-0x2b5dd5904a18045d.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_length-0x2b5dd5904a18045d.rst
@@ -1,0 +1,1 @@
+Returns the number of elements currently stored in a dynamic array `array`, as `int64`. Unlike :ref:`length`, never panics on arrays with more than ``INT32_MAX`` elements.

--- a/doc/source/stdlib/handmade/function-builtin-long_length-0x9e497af19b319d99.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_length-0x9e497af19b319d99.rst
@@ -1,0 +1,1 @@
+Returns the number of entries currently stored in a `table`, as `int64`. Unlike :ref:`length`, never panics on tables with more than ``INT32_MAX`` entries.

--- a/doc/source/stdlib/handmade/function-builtin-long_length-0x9e497af19b319d99.rst
+++ b/doc/source/stdlib/handmade/function-builtin-long_length-0x9e497af19b319d99.rst
@@ -1,1 +1,1 @@
-Returns the number of entries currently stored in a `table`, as `int64`. Unlike :ref:`length`, never panics on tables with more than ``INT32_MAX`` entries.
+Returns the number of entries currently stored in a `table`, as `int64`. Unlike `length`, never panics on tables with more than ``INT32_MAX`` entries.

--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -582,6 +582,22 @@ namespace das
             addExtern<DAS_BIND_FUN((das_atcu<TT,OT>)),SimNode_ExtFuncCallRef,vectorIndexArgFn>(*mod, lib, ".[]",
                 SideEffects::none, atcun.c_str())
                     ->args({"vec","index","context","at"});
+            auto atin64 = "das_ati_i64<"+TTN+","+OTN+">";
+            addExtern<DAS_BIND_FUN((das_ati_i64<TT,OT>)),SimNode_ExtFuncCallRef,vectorIndexArgFn>(*mod, lib, ".[]",
+                SideEffects::modifyArgument, atin64.c_str())
+                    ->args({"vec","index","context","at"});
+            auto atun64 = "das_atu_u64<"+TTN+","+OTN+">";
+            addExtern<DAS_BIND_FUN((das_atu_u64<TT,OT>)),SimNode_ExtFuncCallRef,vectorIndexArgFn>(*mod, lib, ".[]",
+                SideEffects::modifyArgument, atun64.c_str())
+                    ->args({"vec","index","context","at"});
+            auto atcin64 = "das_atci_i64<"+TTN+","+OTN+">";
+            addExtern<DAS_BIND_FUN((das_atci_i64<TT,OT>)),SimNode_ExtFuncCallRef,vectorIndexArgFn>(*mod, lib, ".[]",
+                SideEffects::none, atcin64.c_str())
+                    ->args({"vec","index","context","at"});
+            auto atcun64 = "das_atcu_u64<"+TTN+","+OTN+">";
+            addExtern<DAS_BIND_FUN((das_atcu_u64<TT,OT>)),SimNode_ExtFuncCallRef,vectorIndexArgFn>(*mod, lib, ".[]",
+                SideEffects::none, atcun64.c_str())
+                    ->args({"vec","index","context","at"});
         }
     };
 

--- a/include/daScript/builtin/debugapi_gen.inc
+++ b/include/daScript/builtin/debugapi_gen.inc
@@ -220,9 +220,9 @@ public:
   __forceinline Func get_canVisitArrayData ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_canVisitArrayData]);
   }
-  __forceinline bool invoke_canVisitArrayData ( Context * __context__, Func __funcCall__, void * self, TypeInfo const  & ti, uint32_t count ) const {
+  __forceinline bool invoke_canVisitArrayData ( Context * __context__, Func __funcCall__, void * self, TypeInfo const  & ti, uint64_t count ) const {
     return das_invoke_function<bool>::invoke
-      <void *,TypeInfo const  &,uint32_t>
+      <void *,TypeInfo const  &,uint64_t>
         (__context__,nullptr,__funcCall__,
           self,ti,count);
   }
@@ -391,36 +391,36 @@ public:
   __forceinline Func get_beforeArrayData ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_beforeArrayData]);
   }
-  __forceinline void invoke_beforeArrayData ( Context * __context__, Func __funcCall__, void * self, void * const  ps, uint32_t stride, uint32_t count, TypeInfo const  & ti ) const {
+  __forceinline void invoke_beforeArrayData ( Context * __context__, Func __funcCall__, void * self, void * const  ps, uint32_t stride, uint64_t count, TypeInfo const  & ti ) const {
     das_invoke_function<void>::invoke
-      <void *,void * const ,uint32_t,uint32_t,TypeInfo const  &>
+      <void *,void * const ,uint32_t,uint64_t,TypeInfo const  &>
         (__context__,nullptr,__funcCall__,
           self,ps,stride,count,ti);
   }
   __forceinline Func get_afterArrayData ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_afterArrayData]);
   }
-  __forceinline void invoke_afterArrayData ( Context * __context__, Func __funcCall__, void * self, void * const  ps, uint32_t stride, uint32_t count, TypeInfo const  & ti ) const {
+  __forceinline void invoke_afterArrayData ( Context * __context__, Func __funcCall__, void * self, void * const  ps, uint32_t stride, uint64_t count, TypeInfo const  & ti ) const {
     das_invoke_function<void>::invoke
-      <void *,void * const ,uint32_t,uint32_t,TypeInfo const  &>
+      <void *,void * const ,uint32_t,uint64_t,TypeInfo const  &>
         (__context__,nullptr,__funcCall__,
           self,ps,stride,count,ti);
   }
   __forceinline Func get_beforeArrayElement ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_beforeArrayElement]);
   }
-  __forceinline void invoke_beforeArrayElement ( Context * __context__, Func __funcCall__, void * self, void * const  ps, TypeInfo const  & ti, void * const  pe, uint32_t index, bool last ) const {
+  __forceinline void invoke_beforeArrayElement ( Context * __context__, Func __funcCall__, void * self, void * const  ps, TypeInfo const  & ti, void * const  pe, uint64_t index, bool last ) const {
     das_invoke_function<void>::invoke
-      <void *,void * const ,TypeInfo const  &,void * const ,uint32_t,bool>
+      <void *,void * const ,TypeInfo const  &,void * const ,uint64_t,bool>
         (__context__,nullptr,__funcCall__,
           self,ps,ti,pe,index,last);
   }
   __forceinline Func get_afterArrayElement ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_afterArrayElement]);
   }
-  __forceinline void invoke_afterArrayElement ( Context * __context__, Func __funcCall__, void * self, void * const  ps, TypeInfo const  & ti, void * const  pe, uint32_t index, bool last ) const {
+  __forceinline void invoke_afterArrayElement ( Context * __context__, Func __funcCall__, void * self, void * const  ps, TypeInfo const  & ti, void * const  pe, uint64_t index, bool last ) const {
     das_invoke_function<void>::invoke
-      <void *,void * const ,TypeInfo const  &,void * const ,uint32_t,bool>
+      <void *,void * const ,TypeInfo const  &,void * const ,uint64_t,bool>
         (__context__,nullptr,__funcCall__,
           self,ps,ti,pe,index,last);
   }
@@ -472,36 +472,36 @@ public:
   __forceinline Func get_beforeTableKey ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_beforeTableKey]);
   }
-  __forceinline void invoke_beforeTableKey ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pk, TypeInfo const  & ki, uint32_t index, bool last ) const {
+  __forceinline void invoke_beforeTableKey ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pk, TypeInfo const  & ki, uint64_t index, bool last ) const {
     das_invoke_function<void>::invoke
-      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint32_t,bool>
+      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint64_t,bool>
         (__context__,nullptr,__funcCall__,
           self,pa,ti,pk,ki,index,last);
   }
   __forceinline Func get_afterTableKey ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_afterTableKey]);
   }
-  __forceinline void invoke_afterTableKey ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pk, TypeInfo const  & ki, uint32_t index, bool last ) const {
+  __forceinline void invoke_afterTableKey ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pk, TypeInfo const  & ki, uint64_t index, bool last ) const {
     das_invoke_function<void>::invoke
-      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint32_t,bool>
+      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint64_t,bool>
         (__context__,nullptr,__funcCall__,
           self,pa,ti,pk,ki,index,last);
   }
   __forceinline Func get_beforeTableValue ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_beforeTableValue]);
   }
-  __forceinline void invoke_beforeTableValue ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pv, TypeInfo const  & kv, uint32_t index, bool last ) const {
+  __forceinline void invoke_beforeTableValue ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pv, TypeInfo const  & kv, uint64_t index, bool last ) const {
     das_invoke_function<void>::invoke
-      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint32_t,bool>
+      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint64_t,bool>
         (__context__,nullptr,__funcCall__,
           self,pa,ti,pv,kv,index,last);
   }
   __forceinline Func get_afterTableValue ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_afterTableValue]);
   }
-  __forceinline void invoke_afterTableValue ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pv, TypeInfo const  & kv, uint32_t index, bool last ) const {
+  __forceinline void invoke_afterTableValue ( Context * __context__, Func __funcCall__, void * self, debugger::DapiTable const  & pa, TypeInfo const  & ti, void * const  pv, TypeInfo const  & kv, uint64_t index, bool last ) const {
     das_invoke_function<void>::invoke
-      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint32_t,bool>
+      <void *,debugger::DapiTable const  &,TypeInfo const  &,void * const ,TypeInfo const  &,uint64_t,bool>
         (__context__,nullptr,__funcCall__,
           self,pa,ti,pv,kv,index,last);
   }

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -104,8 +104,8 @@ typedef struct {
 
 typedef struct {
     char *      data;
-    uint32_t    size;
-    uint32_t    capacity;
+    uint64_t    size;
+    uint64_t    capacity;
     uint32_t    magic;
     uint32_t    lock;
     uint32_t    flags;
@@ -114,14 +114,14 @@ typedef struct {
 // Layout MUST mirror das::Table exactly (Table : Array, then keys/hashes/tombstones).
 typedef struct {
     char *      data;
-    uint32_t    size;
-    uint32_t    capacity;
+    uint64_t    size;
+    uint64_t    capacity;
     uint32_t    magic;
     uint32_t    lock;
     uint32_t    flags;
     char *      keys;
     uint32_t *  hashes;
-    uint32_t    tombstones;
+    uint64_t    tombstones;
 } das_table;
 
 typedef vec4f (das_interop_function) ( das_context * ctx, das_node * node, vec4f * arguments );

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -109,9 +109,17 @@ typedef struct {
     uint32_t    magic;
     uint32_t    lock;
     uint32_t    flags;
+    // 4 bytes of trailing pad. The C++ Array struct has uint64_t members so its alignment is 8,
+    // and on every supported ABI sizeof(Array) is rounded to 40. Without an explicit pad here,
+    // 32-bit C compilers might tail-pack a following member into this slot and produce a
+    // different sizeof from the C++ side — see the static_asserts in src/misc/daScriptC.cpp.
+    uint32_t    _pad_after_flags;
 } das_array;
 
 // Layout MUST mirror das::Table exactly (Table : Array, then keys/hashes/tombstones).
+// In C++, Table : Array places `keys` at sizeof(Array)==40 because the derived class cannot
+// reuse the base's trailing padding (MSVC convention, and standard layout for non-POD bases).
+// The flat C mirror needs the same _pad_after_flags so `keys` lands at offset 40 on 32-bit too.
 typedef struct {
     char *      data;
     uint64_t    size;
@@ -119,6 +127,7 @@ typedef struct {
     uint32_t    magic;
     uint32_t    lock;
     uint32_t    flags;
+    uint32_t    _pad_after_flags;
     char *      keys;
     uint32_t *  hashes;
     uint64_t    tombstones;

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -169,6 +169,13 @@ namespace das {
             };
             uint32_t flags;
         };
+        // On 32-bit ABIs Array has uint64_t members forcing 8-byte alignment, so
+        // sizeof(Array) is 40 with 4 trailing pad bytes. Itanium ABI (clang on
+        // wasm/linux/darwin 32-bit) lets the derived `Table` reuse that trailing
+        // padding, placing Table::keys at offset 36; MSVC 32-bit doesn't, placing
+        // it at offset 40. Make the padding explicit so the dsize matches sizeof
+        // on every ABI and Table::keys lives at a single, predictable offset.
+        uint32_t _pad_after_flags = 0u;
         __forceinline bool isLocked() const { return lock; }
 
         friend DAS_API int builtin_array_lock_count ( const Array & arr );

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -153,8 +153,8 @@ namespace das {
 
     struct Array {
         char *data;
-        uint32_t size;
-        uint32_t capacity;
+        uint64_t size;
+        uint64_t capacity;
     // TArray, Table can set manually during copying.
     protected:
         // use friend helpers to lock-unlock.
@@ -172,8 +172,8 @@ namespace das {
         __forceinline bool isLocked() const { return lock; }
 
         friend DAS_API int builtin_array_lock_count ( const Array & arr );
-        friend DAS_API void array_mark_locked(Array &arr, void *data, uint32_t capacity);
-        friend DAS_API void array_mark_locked(Array &arr, void *data, uint32_t size, uint32_t capacity);
+        friend DAS_API void array_mark_locked(Array &arr, void *data, uint64_t capacity);
+        friend DAS_API void array_mark_locked(Array &arr, void *data, uint64_t size, uint64_t capacity);
         friend DAS_API void array_lock(Context &context, Array &arr, LineInfo *at);
         friend DAS_API void array_unlock(Context &context, Array &arr, LineInfo *at);
         friend DAS_API void table_lock(Context &context, Table &arr, LineInfo *at);
@@ -183,13 +183,13 @@ namespace das {
 
     class Context;
 
-    DAS_API void array_mark_locked(Array &arr, void *data, uint32_t capacity);
-    DAS_API void array_mark_locked(Array &arr, void *data, uint32_t size, uint32_t capacity);
+    DAS_API void array_mark_locked(Array &arr, void *data, uint64_t capacity);
+    DAS_API void array_mark_locked(Array &arr, void *data, uint64_t size, uint64_t capacity);
     DAS_API void array_lock(Context &context, Array &arr, LineInfo *at);
     DAS_API void array_unlock(Context &context, Array &arr, LineInfo *at);
-    DAS_API void array_reserve(Context &context, Array &arr, uint32_t newCapacity, uint32_t stride, LineInfo *at);
-    DAS_API void array_resize(Context &context, Array &arr, uint32_t newSize, uint32_t stride, bool zero, LineInfo *at);
-    DAS_API void array_grow(Context &context, Array &arr, uint32_t newSize, uint32_t stride); // always grows
+    DAS_API void array_reserve(Context &context, Array &arr, uint64_t newCapacity, uint32_t stride, LineInfo *at);
+    DAS_API void array_resize(Context &context, Array &arr, uint64_t newSize, uint32_t stride, bool zero, LineInfo *at);
+    DAS_API void array_grow(Context &context, Array &arr, uint64_t newSize, uint32_t stride); // always grows
     DAS_API void array_clear(Context &context, Array &arr, LineInfo *at);
 
     typedef uint32_t TableHashKey;
@@ -199,13 +199,13 @@ namespace das {
     struct Table : Array {
         char *keys;
         TableHashKey *hashes;
-        uint32_t tombstones;
+        uint64_t tombstones;
     };
 
     DAS_API void table_clear(Context &context, Table &arr, LineInfo *at);
     DAS_API void table_lock(Context &context, Table &arr, LineInfo *at);
     DAS_API void table_unlock(Context &context, Table &arr, LineInfo *at);
-    DAS_API void table_reserve_impl(Context &context, Table &arr, int32_t baseType, uint32_t newCapacity, uint32_t valueTypeSize, LineInfo *at);
+    DAS_API void table_reserve_impl(Context &context, Table &arr, int32_t baseType, uint64_t newCapacity, uint32_t valueTypeSize, LineInfo *at);
 
     struct Sequence;
     DAS_API void builtin_table_keys(Sequence &result, const Table &tab, int32_t stride, Context *__context__, LineInfoArg *at);

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1042,12 +1042,12 @@ namespace das {
     // index
         __forceinline TT & operator () ( int32_t index, Context * __context__ ) {
             uint32_t idx = uint32_t(index);
-            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %u", idx, size);
+            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %llu", idx, (unsigned long long)size);
             return ((TT *)data)[index];
         }
         __forceinline const TT & operator () ( int32_t index, Context * __context__ ) const {
             uint32_t idx = uint32_t(index);
-            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %u", idx, size);
+            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %llu", idx, (unsigned long long)size);
             return ((const TT *)data)[index];
         }
         __forceinline TT & operator () ( uint32_t idx, Context * __context__ ) {

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1849,7 +1849,7 @@ namespace das {
         static __forceinline void clear ( Context * __context__, TArray<TT> & dim ) {
             if ( dim.data ) {
                 if ( !dim.isLocked() ) {
-                    uint32_t oldSize = dim.capacity*sizeof(TT);
+                    uint64_t oldSize = uint64_t(dim.capacity)*sizeof(TT);
                     __context__->free(dim.data, oldSize);
                 } else {
                     __context__->throw_error("can't delete locked array");
@@ -1864,7 +1864,7 @@ namespace das {
         static __forceinline void clear ( Context * __context__, TTable<TKey,TVal> & tab ) {
             if ( tab.data ) {
                 if ( !tab.isLocked() ) {
-                    uint32_t oldSize = tab.capacity*(sizeof(TKey)+sizeof(TVal)+sizeof(TableHashKey));
+                    uint64_t oldSize = uint64_t(tab.capacity)*(sizeof(TKey)+sizeof(TVal)+sizeof(TableHashKey));
                     __context__->free(tab.data, oldSize);
                 } else {
                     __context__->throw_error("can't delete locked table");
@@ -3601,6 +3601,9 @@ namespace das {
     struct pscblk_array {
         static __forceinline void psrt ( Array & arr, int32_t, int32_t, int32_t n, CompareFn && cmp, Context * context, LineInfoArg * at ) {
             if ( arr.size<=1 || n<=0 ) return;
+            // The int32_t-`n` partial_sort signature can't represent the int64 surface; refuse
+            // to silently clip when arr.size > INT_MAX (would lose high bits in the clamp below).
+            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; use long_partial_sort() instead", (unsigned long long)arr.size);
             if ( uint32_t(n) > arr.size ) n = int32_t(arr.size);
             array_lock(*context, arr, at);
             auto sdata = (TT *) arr.data;
@@ -3616,6 +3619,9 @@ namespace das {
     struct pscblk_array < const Block &, TT > {
         static __forceinline void psrtr ( Array & arr, int32_t, int32_t, int32_t n, const Block & cmp, Context * context, LineInfoArg * at ) {
             if ( arr.size<=1 || n<=0 ) return;
+            // The int32_t-`n` partial_sort signature can't represent the int64 surface; refuse
+            // to silently clip when arr.size > INT_MAX (would lose high bits in the clamp below).
+            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; use long_partial_sort() instead", (unsigned long long)arr.size);
             if ( uint32_t(n) > arr.size ) n = int32_t(arr.size);
             auto data = (TT *) arr.data;
             array_lock(*context, arr, at);
@@ -3638,6 +3644,9 @@ namespace das {
         }
         static __forceinline void psrt ( Array & arr, int32_t, int32_t, int32_t n, const Block & cmp, Context * context, LineInfoArg * at ) {
             if ( arr.size<=1 || n<=0 ) return;
+            // The int32_t-`n` partial_sort signature can't represent the int64 surface; refuse
+            // to silently clip when arr.size > INT_MAX (would lose high bits in the clamp below).
+            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; use long_partial_sort() instead", (unsigned long long)arr.size);
             if ( uint32_t(n) > arr.size ) n = int32_t(arr.size);
             auto data = (TT *) arr.data;
             array_lock(*context, arr, at);

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -682,14 +682,12 @@ namespace das {
         // 64-bit index overloads (Phase 2 — 64-bit arrays)
         static __forceinline OT & at ( TT & value, int64_t index, Context * __context__ ) {
             uint64_t size = uint64_t(SIZE_POLICY::size(value));
-            uint64_t idx = uint64_t(index);
-            if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            if ( index<0 || uint64_t(index)>=size ) __context__->throw_error_ex("vector index out of range, %lld of %llu", (long long)index, (unsigned long long)size);
             return value[index];
         }
         static __forceinline const OT & at ( const TT & value, int64_t index, Context * __context__ ) {
             uint64_t size = uint64_t(SIZE_POLICY::size(value));
-            uint64_t idx = uint64_t(index);
-            if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            if ( index<0 || uint64_t(index)>=size ) __context__->throw_error_ex("vector index out of range, %lld of %llu", (long long)index, (unsigned long long)size);
             return value[index];
         }
         static __forceinline OT & at ( TT & value, uint64_t idx, Context * __context__ ) {
@@ -725,8 +723,7 @@ namespace das {
     __forceinline OT & das_ati_i64 ( TT & value, int64_t index, Context * __context__, LineInfoArg * __info__ ) {
         using SIZE_POLICY = das_default_vector_size<TT>;
         uint64_t size = uint64_t(SIZE_POLICY::size(value));
-        uint64_t idx = uint64_t(index);
-        if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+        if ( index<0 || uint64_t(index)>=size ) __context__->throw_error_at(__info__,"vector index out of range, %lld of %llu", (long long)index, (unsigned long long)size);
         return value[index];
     }
 
@@ -759,8 +756,7 @@ namespace das {
     __forceinline const OT & das_atci_i64 ( const TT & value, int64_t index, Context * __context__, LineInfoArg * __info__ ) {
         using SIZE_POLICY = das_default_vector_size<TT>;
         uint64_t size = uint64_t(SIZE_POLICY::size(value));
-        uint64_t idx = uint64_t(index);
-        if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+        if ( index<0 || uint64_t(index)>=size ) __context__->throw_error_at(__info__,"vector index out of range, %lld of %llu", (long long)index, (unsigned long long)size);
         return value[index];
     }
 

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1139,21 +1139,21 @@ namespace das {
         __forceinline TV & operator () ( const TK & key, Context * __context__ ) {
             TableHash<TK> thh(__context__,sizeof(TV));
             auto hfn = hash_function(*__context__, key);
-            int index = thh.reserve(*this, key, hfn);
+            int64_t index = thh.reserve(*this, key, hfn);
             return ((TV *)data)[index];
         }
         static __forceinline TV * safe_index ( THIS_TYPE * that, const TK & key, Context * __context__ ) {
             if (!that) return nullptr;
             TableHash<TK> thh(__context__,sizeof(TV));
             auto hfn = hash_function(*__context__, key);
-            int index = thh.find(*that, key, hfn);
+            int64_t index = thh.find(*that, key, hfn);
             return index==-1 ? nullptr : ((TV *)that->data) + index;
         }
         static __forceinline const TV * safe_index ( const THIS_TYPE * that, const TK & key, Context * __context__ ) {
             if (!that) return nullptr;
             TableHash<TK> thh(__context__,sizeof(TV));
             auto hfn = hash_function(*__context__, key);
-            int index = thh.find(*that, key, hfn);
+            int64_t index = thh.find(*that, key, hfn);
             return index==-1 ? nullptr : ((const TV *)that->data) + index;
         }
     };
@@ -2911,7 +2911,7 @@ namespace das {
         TK key = (TK) _key;
         auto hfn = hash_function(*context, key);
         TableHash<TK> thh(context,sizeof(TV));
-        int index = thh.find(tab, key, hfn);
+        int64_t index = thh.find(tab, key, hfn);
         return (TV *) ( index!=-1 ? tab.data + index * sizeof(TV) : nullptr );
     }
 

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -679,6 +679,29 @@ namespace das {
             if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %u of %u", idx, size);
             return value[idx];
         }
+        // 64-bit index overloads (Phase 2 — 64-bit arrays)
+        static __forceinline OT & at ( TT & value, int64_t index, Context * __context__ ) {
+            uint64_t size = uint64_t(SIZE_POLICY::size(value));
+            uint64_t idx = uint64_t(index);
+            if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            return value[index];
+        }
+        static __forceinline const OT & at ( const TT & value, int64_t index, Context * __context__ ) {
+            uint64_t size = uint64_t(SIZE_POLICY::size(value));
+            uint64_t idx = uint64_t(index);
+            if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            return value[index];
+        }
+        static __forceinline OT & at ( TT & value, uint64_t idx, Context * __context__ ) {
+            uint64_t size = uint64_t(SIZE_POLICY::size(value));
+            if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            return value[idx];
+        }
+        static __forceinline const OT & at ( const TT & value, uint64_t idx, Context * __context__ ) {
+            uint64_t size = uint64_t(SIZE_POLICY::size(value));
+            if ( idx>=size ) __context__->throw_error_ex("vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            return value[idx];
+        }
     };
 
     template <typename TT, typename OT>
@@ -699,6 +722,23 @@ namespace das {
     }
 
     template <typename TT, typename OT>
+    __forceinline OT & das_ati_i64 ( TT & value, int64_t index, Context * __context__, LineInfoArg * __info__ ) {
+        using SIZE_POLICY = das_default_vector_size<TT>;
+        uint64_t size = uint64_t(SIZE_POLICY::size(value));
+        uint64_t idx = uint64_t(index);
+        if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+        return value[index];
+    }
+
+    template <typename TT, typename OT>
+    __forceinline OT & das_atu_u64 ( TT & value, uint64_t idx, Context * __context__, LineInfoArg * __info__ ) {
+        using SIZE_POLICY = das_default_vector_size<TT>;
+        uint64_t size = uint64_t(SIZE_POLICY::size(value));
+        if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+        return value[idx];
+    }
+
+    template <typename TT, typename OT>
     __forceinline const OT & das_atci ( const TT & value, int32_t index, Context * __context__, LineInfoArg * __info__ ) {
         using SIZE_POLICY = das_default_vector_size<TT>;
         uint32_t size = SIZE_POLICY::size(value);
@@ -712,6 +752,23 @@ namespace das {
         using SIZE_POLICY = das_default_vector_size<TT>;
         uint32_t size = SIZE_POLICY::size(value);
         if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %u of %u", idx, size);
+        return value[idx];
+    }
+
+    template <typename TT, typename OT>
+    __forceinline const OT & das_atci_i64 ( const TT & value, int64_t index, Context * __context__, LineInfoArg * __info__ ) {
+        using SIZE_POLICY = das_default_vector_size<TT>;
+        uint64_t size = uint64_t(SIZE_POLICY::size(value));
+        uint64_t idx = uint64_t(index);
+        if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+        return value[index];
+    }
+
+    template <typename TT, typename OT>
+    __forceinline const OT & das_atcu_u64 ( const TT & value, uint64_t idx, Context * __context__, LineInfoArg * __info__ ) {
+        using SIZE_POLICY = das_default_vector_size<TT>;
+        uint64_t size = uint64_t(SIZE_POLICY::size(value));
+        if ( idx>=size ) __context__->throw_error_at(__info__,"vector index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
         return value[idx];
     }
 
@@ -994,11 +1051,27 @@ namespace das {
             return ((const TT *)data)[index];
         }
         __forceinline TT & operator () ( uint32_t idx, Context * __context__ ) {
-            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %u", idx, size);
+            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %llu", idx, (unsigned long long)size);
             return ((TT *)data)[idx];
         }
         __forceinline const TT & operator () ( uint32_t idx, Context * __context__ ) const {
-            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %u", idx, size);
+            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %u of %llu", idx, (unsigned long long)size);
+            return ((const TT *)data)[idx];
+        }
+        __forceinline TT & operator () ( int64_t index, Context * __context__ ) {
+            if ( index<0 || uint64_t(index)>=size ) __context__->throw_error_ex("array index out of range, %lld of %llu", (long long)index, (unsigned long long)size);
+            return ((TT *)data)[index];
+        }
+        __forceinline const TT & operator () ( int64_t index, Context * __context__ ) const {
+            if ( index<0 || uint64_t(index)>=size ) __context__->throw_error_ex("array index out of range, %lld of %llu", (long long)index, (unsigned long long)size);
+            return ((const TT *)data)[index];
+        }
+        __forceinline TT & operator () ( uint64_t idx, Context * __context__ ) {
+            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
+            return ((TT *)data)[idx];
+        }
+        __forceinline const TT & operator () ( uint64_t idx, Context * __context__ ) const {
+            if ( idx>=size ) __context__->throw_error_ex("array index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)size);
             return ((const TT *)data)[idx];
         }
     // safe index
@@ -1013,6 +1086,26 @@ namespace das {
             uint32_t idx = uint32_t(index);
             if ( idx>=that->size ) return nullptr;
             return ((const TT *)that->data) + index;
+        }
+        static __forceinline TT * safe_index ( THIS_TYPE * that, int64_t index, Context * ) {
+            if (!that) return nullptr;
+            if ( index<0 || uint64_t(index)>=that->size ) return nullptr;
+            return ((TT *)that->data) + index;
+        }
+        static __forceinline const TT  * safe_index ( const THIS_TYPE * that, int64_t index, Context * ) {
+            if (!that) return nullptr;
+            if ( index<0 || uint64_t(index)>=that->size ) return nullptr;
+            return ((const TT *)that->data) + index;
+        }
+        static __forceinline TT * safe_index ( THIS_TYPE * that, uint64_t idx, Context * ) {
+            if (!that) return nullptr;
+            if ( idx>=that->size ) return nullptr;
+            return ((TT *)that->data) + idx;
+        }
+        static __forceinline const TT  * safe_index ( const THIS_TYPE * that, uint64_t idx, Context * ) {
+            if (!that) return nullptr;
+            if ( idx>=that->size ) return nullptr;
+            return ((const TT *)that->data) + idx;
         }
         static __forceinline TT * safe_index ( THIS_TYPE * that, uint32_t idx, Context * ) {
             if (!that) return nullptr;

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -3603,7 +3603,8 @@ namespace das {
             if ( arr.size<=1 || n<=0 ) return;
             // The int32_t-`n` partial_sort signature can't represent the int64 surface; refuse
             // to silently clip when arr.size > INT_MAX (would lose high bits in the clamp below).
-            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; use long_partial_sort() instead", (unsigned long long)arr.size);
+            // partial_sort on arrays this large is not supported.
+            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; partial_sort is not supported on arrays this large", (unsigned long long)arr.size);
             if ( uint32_t(n) > arr.size ) n = int32_t(arr.size);
             array_lock(*context, arr, at);
             auto sdata = (TT *) arr.data;
@@ -3621,7 +3622,8 @@ namespace das {
             if ( arr.size<=1 || n<=0 ) return;
             // The int32_t-`n` partial_sort signature can't represent the int64 surface; refuse
             // to silently clip when arr.size > INT_MAX (would lose high bits in the clamp below).
-            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; use long_partial_sort() instead", (unsigned long long)arr.size);
+            // partial_sort on arrays this large is not supported.
+            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; partial_sort is not supported on arrays this large", (unsigned long long)arr.size);
             if ( uint32_t(n) > arr.size ) n = int32_t(arr.size);
             auto data = (TT *) arr.data;
             array_lock(*context, arr, at);
@@ -3646,7 +3648,8 @@ namespace das {
             if ( arr.size<=1 || n<=0 ) return;
             // The int32_t-`n` partial_sort signature can't represent the int64 surface; refuse
             // to silently clip when arr.size > INT_MAX (would lose high bits in the clamp below).
-            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; use long_partial_sort() instead", (unsigned long long)arr.size);
+            // partial_sort on arrays this large is not supported.
+            if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "partial_sort: array size %llu exceeds INT_MAX; partial_sort is not supported on arrays this large", (unsigned long long)arr.size);
             if ( uint32_t(n) > arr.size ) n = int32_t(arr.size);
             auto data = (TT *) arr.data;
             array_lock(*context, arr, at);

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -211,10 +211,11 @@ namespace das {
     __forceinline void array_grow ( Context & context, Array & arr, uint32_t stride, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't resize locked array");
         uint64_t newSize = arr.size + 1;
+        // Keep the int64 surface contract (long_length returns int64) — refuse to grow past INT64_MAX.
+        if ( newSize > uint64_t(INT64_MAX) ) {
+            context.throw_error_at(at, "array_grow: newSize exceeds INT64_MAX [newSize=%llu]", (unsigned long long)newSize);
+        }
         if ( newSize > arr.capacity ) {
-            if ( newSize > (uint64_t(1) << 63) ) {
-                context.throw_error_at(at, "array_grow: newSize exceeds 2^63 [newSize=%llu]", (unsigned long long)newSize);
-            }
             uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
             newCapacity = das::max(newCapacity, uint64_t(16));
             array_reserve(context, arr, newCapacity, stride, at);

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -218,6 +218,9 @@ namespace das {
         if ( newSize > arr.capacity ) {
             uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
             newCapacity = das::max(newCapacity, uint64_t(16));
+            // The pow2 round-up overflows past INT64_MAX when newSize > 2^62; clamp so the
+            // resulting capacity stays representable in the int64 long_capacity() surface.
+            if ( newCapacity > uint64_t(INT64_MAX) ) newCapacity = uint64_t(INT64_MAX);
             array_reserve(context, arr, newCapacity, stride, at);
         }
         arr.size = newSize;

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -44,6 +44,8 @@ namespace das {
     DAS_API void builtin_terminate ( Context * context, LineInfoArg * lineInfo );
     DAS_API int builtin_table_size ( const Table & arr );
     DAS_API int builtin_table_capacity ( const Table & arr );
+    DAS_API int64_t builtin_table_long_size ( const Table & arr );
+    DAS_API int64_t builtin_table_long_capacity ( const Table & arr );
     DAS_API void builtin_table_clear ( Table & arr, Context * context, LineInfoArg * at );
     DAS_API vec4f builtin_table_reserve ( Context & context, SimNode_CallBase * call, vec4f * args );
     DAS_API void heap_stats ( Context & context, uint64_t * bytes );
@@ -72,12 +74,19 @@ namespace das {
     DAS_API void builtin_table_clear_lock ( const Table & arr, Context * context );
     DAS_API int builtin_array_size ( const Array & arr );
     DAS_API int builtin_array_capacity ( const Array & arr );
+    DAS_API int64_t builtin_array_long_size ( const Array & arr );
+    DAS_API int64_t builtin_array_long_capacity ( const Array & arr );
     DAS_API int builtin_array_lock_count ( const Array & arr );
     DAS_API void builtin_array_resize ( Array & pArray, int newSize, int stride, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_resize_no_init ( Array & pArray, int newSize, int stride, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_reserve ( Array & pArray, int newSize, int stride, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_erase ( Array & pArray, int index, int stride, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_erase_range ( Array & pArray, int index, int count, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_array_resize_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_array_resize_no_init_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_array_reserve_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_array_erase_i64 ( Array & pArray, int64_t index, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_array_erase_range_i64 ( Array & pArray, int64_t index, int64_t count, int stride, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_clear ( Array & pArray, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_lock_mutable ( const Array & arr, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_unlock_mutable ( const Array & arr, Context * context, LineInfoArg * at );
@@ -201,43 +210,46 @@ namespace das {
 
     __forceinline void array_grow ( Context & context, Array & arr, uint32_t stride, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't resize locked array");
-        uint32_t newSize = arr.size + 1;
+        uint64_t newSize = arr.size + 1;
         if ( newSize > arr.capacity ) {
-            uint32_t newCapacity = 1 << (32 - das_clz (das::max(newSize,2u) - 1));
-            newCapacity = das::max(newCapacity, 16u);
+            if ( newSize > (uint64_t(1) << 63) ) {
+                context.throw_error_at(at, "array_grow: newSize exceeds 2^63 [newSize=%llu]", (unsigned long long)newSize);
+            }
+            uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
+            newCapacity = das::max(newCapacity, uint64_t(16));
             array_reserve(context, arr, newCapacity, stride, at);
         }
         arr.size = newSize;
     }
 
-    __forceinline int builtin_array_push ( Array & pArray, int index, int stride, Context * context, LineInfoArg * at ) {
-        uint32_t idx = pArray.size;
+    __forceinline int64_t builtin_array_push ( Array & pArray, int64_t index, int stride, Context * context, LineInfoArg * at ) {
+        uint64_t idx = pArray.size;
         array_grow(*context, pArray, stride, at);
-        if ( uint32_t(index) >= pArray.size ) context->throw_error_at(at, "insert index out of range, %u of %u", uint32_t(index), pArray.size);
-        memmove ( pArray.data+(index+1)*stride, pArray.data+index*stride, size_t(idx-index)*size_t(stride) );
+        if ( uint64_t(index) >= pArray.size ) context->throw_error_at(at, "insert index out of range, %lld of %llu", (long long)index, (unsigned long long)pArray.size);
+        memmove ( pArray.data+(index+1)*stride, pArray.data+index*stride, size_t(idx-uint64_t(index))*size_t(stride) );
         return index;
     }
 
-    __forceinline int builtin_array_push_zero ( Array & pArray, int index, int stride, Context * context, LineInfoArg * at ) {
-        uint32_t idx = pArray.size;
+    __forceinline int64_t builtin_array_push_zero ( Array & pArray, int64_t index, int stride, Context * context, LineInfoArg * at ) {
+        uint64_t idx = pArray.size;
         array_grow(*context, pArray, stride, at);
-        if ( uint32_t(index) >= pArray.size ) context->throw_error_at(at, "insert index out of range, %u of %u", uint32_t(index), pArray.size);
-        memmove ( pArray.data+(index+1)*stride, pArray.data+index*stride, size_t(idx-index)*size_t(stride) );
+        if ( uint64_t(index) >= pArray.size ) context->throw_error_at(at, "insert index out of range, %lld of %llu", (long long)index, (unsigned long long)pArray.size);
+        memmove ( pArray.data+(index+1)*stride, pArray.data+index*stride, size_t(idx-uint64_t(index))*size_t(stride) );
         memset ( pArray.data + index*stride, 0, stride );
         return index;
     }
 
-    __forceinline int builtin_array_push_back ( Array & pArray, int stride, Context * context, LineInfoArg * at ) {
-        uint32_t idx = pArray.size;
+    __forceinline int64_t builtin_array_push_back ( Array & pArray, int stride, Context * context, LineInfoArg * at ) {
+        uint64_t idx = pArray.size;
         array_grow(*context, pArray, stride, at);
-        return idx;
+        return int64_t(idx);
     }
 
-    __forceinline int builtin_array_push_back_zero ( Array & pArray, int stride, Context * context, LineInfoArg * at ) {
-        uint32_t idx = pArray.size;
+    __forceinline int64_t builtin_array_push_back_zero ( Array & pArray, int stride, Context * context, LineInfoArg * at ) {
+        uint64_t idx = pArray.size;
         array_grow(*context, pArray, stride, at);
         memset(pArray.data + idx*stride, 0, stride);
-        return idx;
+        return int64_t(idx);
     }
 
     __forceinline void concept_assert ( bool, const char * ) {}

--- a/include/daScript/simulate/data_walker.h
+++ b/include/daScript/simulate/data_walker.h
@@ -35,7 +35,7 @@ namespace das {
     // data structures
         virtual bool canVisitDim ( char * ps, TypeInfo * ti ) { return true; }
         virtual bool canVisitArray ( Array * ar, TypeInfo * ti ) { return true; }
-        virtual bool canVisitArrayData ( TypeInfo * ti, uint32_t count ) { return true; }
+        virtual bool canVisitArrayData ( TypeInfo * ti, uint64_t count ) { return true; }
         virtual bool canVisitHandle ( char * ps, TypeInfo * ti ) { return true; }
         virtual bool canVisitStructure ( char * ps, StructInfo * si ) { return true; }
         virtual bool canVisitTuple ( char * ps, TypeInfo * ti ) { return true; }
@@ -56,19 +56,19 @@ namespace das {
         virtual void afterTupleEntry ( char * ps, TypeInfo * ti, char * pv, int idx, bool last ) {}
         virtual void beforeVariant ( char * ps, TypeInfo * ti ) {}
         virtual void afterVariant ( char * ps, TypeInfo * ti ) {}
-        virtual void beforeArrayData ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti ) {}
-        virtual void afterArrayData ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti ) {}
-        virtual void beforeArrayElement ( char * pa, TypeInfo * ti, char * pe, uint32_t index, bool last ) {}
-        virtual void afterArrayElement ( char * pa, TypeInfo * ti, char * pe, uint32_t index, bool last ) {}
+        virtual void beforeArrayData ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti ) {}
+        virtual void afterArrayData ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti ) {}
+        virtual void beforeArrayElement ( char * pa, TypeInfo * ti, char * pe, uint64_t index, bool last ) {}
+        virtual void afterArrayElement ( char * pa, TypeInfo * ti, char * pe, uint64_t index, bool last ) {}
         virtual void beforeDim ( char * pa, TypeInfo * ti ) {}
         virtual void afterDim ( char * pa, TypeInfo * ti ) {}
         virtual void beforeArray ( Array * pa, TypeInfo * ti ) {}
         virtual void afterArray ( Array * pa, TypeInfo * ti ) {}
         virtual void beforeTable ( Table * pa, TypeInfo * ti ) {}
-        virtual void beforeTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint32_t index, bool last ) {}
-        virtual void afterTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint32_t index, bool last ) {}
-        virtual void beforeTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint32_t index, bool last ) {}
-        virtual void afterTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint32_t index, bool last ) {}
+        virtual void beforeTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint64_t index, bool last ) {}
+        virtual void afterTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint64_t index, bool last ) {}
+        virtual void beforeTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint64_t index, bool last ) {}
+        virtual void afterTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint64_t index, bool last ) {}
         virtual void afterTable ( Table * pa, TypeInfo * ti ) {}
         virtual void beforeRef ( char * pa, TypeInfo * ti ) {}
         virtual void afterRef ( char * pa, TypeInfo * ti ) {}
@@ -127,7 +127,7 @@ namespace das {
         virtual void walk_struct ( char * ps, StructInfo * si );
         virtual void walk_tuple ( char * ps, TypeInfo * info );
         virtual void walk_variant ( char * ps, TypeInfo * info );
-        virtual void walk_array ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti );
+        virtual void walk_array ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti );
         virtual void walk_dim ( char * pa, TypeInfo * ti );
         virtual void walk_table ( Table * tab, TypeInfo * info );
     // invalid data

--- a/include/daScript/simulate/debug_print.h
+++ b/include/daScript/simulate/debug_print.h
@@ -132,22 +132,22 @@ namespace das {
             if ( !ti->isVariantOfSimpleTypes() ) br();
         }
 
-        virtual void beforeArrayElement ( char *, TypeInfo *, char *, uint32_t, bool ) override {
+        virtual void beforeArrayElement ( char *, TypeInfo *, char *, uint64_t, bool ) override {
             ss << " ";
         }
-        virtual void afterArrayElement ( char *, TypeInfo * ti, char *, uint32_t, bool last ) override {
+        virtual void afterArrayElement ( char *, TypeInfo * ti, char *, uint64_t, bool last ) override {
             if ( !last ) {
                 ss << ",";
             }
             if ( !ti->isSimpleType() ) br();
         }
-        virtual void beforeTableKey ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool ) override {
+        virtual void beforeTableKey ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool ) override {
             ss << " ";
         }
-        virtual void beforeTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool ) override {
+        virtual void beforeTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool ) override {
             ss << " => ";
         }
-        virtual void afterTableValue ( Table *, TypeInfo * ti, char *, TypeInfo *, uint32_t, bool last ) override {
+        virtual void afterTableValue ( Table *, TypeInfo * ti, char *, TypeInfo *, uint64_t, bool last ) override {
             if ( !last ) {
                 ss << ",";
             }

--- a/include/daScript/simulate/runtime_array.h
+++ b/include/daScript/simulate/runtime_array.h
@@ -257,14 +257,14 @@ namespace das
                 ph[t]  = pha[t]->data;
             }
             char ** __restrict pi[totalCount];
-            int szz = INT_MAX;
+            uint64_t szz = ~uint64_t(0);
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + stackTop[t]);
-                szz = das::min(szz, int(pha[t]->size));
+                szz = das::min(szz, pha[t]->size);
             }
             if ( this->totalFinal == 0 ) {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += strides[t];
@@ -278,7 +278,7 @@ namespace das
                 }
             } else {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += strides[t];
@@ -332,12 +332,12 @@ namespace das
             array_lock(context, *pha, &this->debugInfo);
             ph = pha->data;
             char ** __restrict pi;
-            int szz = int(pha->size);
+            uint64_t szz = pha->size;
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
             if ( this->totalFinal == 0 ) {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode ** __restrict body = list;
@@ -349,7 +349,7 @@ namespace das
                 }
             } else {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode ** __restrict body = list;
@@ -386,14 +386,14 @@ namespace das
                 ph[t]  = pha[t]->data;
             }
             char ** __restrict pi[totalCount];
-            int szz = INT_MAX;
+            uint64_t szz = ~uint64_t(0);
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + stackTop[t]);
-                szz = das::min(szz, int(pha[t]->size));
+                szz = das::min(szz, pha[t]->size);
             }
             if ( this->totalFinal == 0 ) {
                 SimNode * __restrict body = list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += strides[t];
@@ -403,7 +403,7 @@ namespace das
                 }
             } else {
                 SimNode * __restrict body = list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += strides[t];
@@ -451,12 +451,12 @@ namespace das
             array_lock(context, *pha, &this->debugInfo);
             ph = pha->data;
             char ** __restrict pi;
-            int szz = int(pha->size);
+            uint64_t szz = pha->size;
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
             if ( this->totalFinal == 0 ) {
                 SimNode * __restrict body = list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     *pi = ph;
                     ph += stride;
                     body->eval(context);
@@ -464,7 +464,7 @@ namespace das
                 }
             } else {
                 SimNode * __restrict body = list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     *pi = ph;
                     ph += stride;
                     body->eval(context);
@@ -498,14 +498,14 @@ namespace das
                 ph[t]  = pha[t]->data;
             }
             char ** __restrict pi[totalCount];
-            int szz = INT_MAX;
+            uint64_t szz = ~uint64_t(0);
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
-                szz = das::min(szz, int(pha[t]->size));
+                szz = das::min(szz, pha[t]->size);
             }
             if ( this->totalFinal == 0 ) {
                 SimNode ** __restrict tail = this->list + this->total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -520,7 +520,7 @@ namespace das
                 }
             } else {
                 SimNode ** __restrict tail = this->list + this->total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -562,12 +562,12 @@ namespace das
             array_lock(context, *pha, &this->debugInfo);
             ph = pha->data;
             char ** __restrict pi;
-            int szz = int(pha->size);
+            uint64_t szz = pha->size;
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
             if ( this->totalFinal == 0 ) {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode ** __restrict body = list;
@@ -580,7 +580,7 @@ namespace das
                 }
             } else {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode ** __restrict body = list;
@@ -615,14 +615,14 @@ namespace das
                 ph[t]  = pha[t]->data;
             }
             char ** __restrict pi[totalCount];
-            int szz = INT_MAX;
+            uint64_t szz = ~uint64_t(0);
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
-                szz = das::min(szz, int(pha[t]->size));
+                szz = das::min(szz, pha[t]->size);
             }
             if ( this->totalFinal == 0 ) {
                 SimNode * __restrict body = this->list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -632,7 +632,7 @@ namespace das
                 }
             } else {
                 SimNode * __restrict body = this->list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -667,12 +667,12 @@ namespace das
             array_lock(context, *pha, &this->debugInfo);
             ph = pha->data;
             char ** __restrict pi;
-            int szz = int(pha->size);
+            uint64_t szz = pha->size;
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
             if ( this->totalFinal == 0 ) {
                 SimNode * __restrict body = list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     *pi = ph;
                     ph += stride;
                     body->eval(context);
@@ -680,7 +680,7 @@ namespace das
                 }
             } else {
                 SimNode * __restrict body = list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     *pi = ph;
                     ph += stride;
                     body->eval(context);
@@ -716,14 +716,14 @@ namespace das
                 ph[t]  = pha[t]->data;
             }
             char ** __restrict pi[totalCount];
-            int szz = INT_MAX;
+            uint64_t szz = ~uint64_t(0);
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
-                szz = das::min(szz, int(pha[t]->size));
+                szz = das::min(szz, pha[t]->size);
             }
             if ( this->totalFinal == 0 ) {
                 SimNode ** __restrict tail = this->list + this->total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -738,7 +738,7 @@ namespace das
                 }
             } else {
                 SimNode ** __restrict tail = this->list + this->total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -780,12 +780,12 @@ namespace das
             array_lock(context, *pha, &this->debugInfo);
             ph = pha->data;
             char ** __restrict pi;
-            int szz = int(pha->size);
+            uint64_t szz = pha->size;
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
             if ( this->totalFinal == 0 ) {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode ** __restrict body = list;
@@ -798,7 +798,7 @@ namespace das
                 }
             } else {
                 SimNode ** __restrict tail = list + total;
-                for (int i = 0; i!=szz; ++i) {
+                for (uint64_t i = 0; i!=szz; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode ** __restrict body = list;
@@ -833,14 +833,14 @@ namespace das
                 ph[t]  = pha[t]->data;
             }
             char ** __restrict pi[totalCount];
-            int szz = INT_MAX;
+            uint64_t szz = ~uint64_t(0);
             for ( int t=0; t!=totalCount; ++t ) {
                 pi[t] = (char **)(context.stack.sp() + this->stackTop[t]);
-                szz = das::min(szz, int(pha[t]->size));
+                szz = das::min(szz, pha[t]->size);
             }
             if ( this->totalFinal == 0 ) {
                 SimNode * __restrict body = this->list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -851,7 +851,7 @@ namespace das
                 }
             } else {
                 SimNode * __restrict body = this->list[0];
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     for (int t = 0; t != totalCount; ++t) {
                         *pi[t] = ph[t];
                         ph[t] += this->strides[t];
@@ -887,11 +887,11 @@ namespace das
             array_lock(context, *pha, &this->debugInfo);
             ph = pha->data;
             char ** __restrict pi;
-            int szz = int(pha->size);
+            uint64_t szz = pha->size;
             pi = (char **)(context.stack.sp() + stackTop[0]);
             auto stride = strides[0];
             if ( this->totalFinal == 0 ) {
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode * body = list[0];    // note: instruments
@@ -900,7 +900,7 @@ namespace das
                     DAS_PROCESS_LOOP1_FLAGS(continue);
                 }
             } else {
-                for (int i = 0; i!=szz && !context.stopFlags; ++i) {
+                for (uint64_t i = 0; i!=szz && !context.stopFlags; ++i) {
                     *pi = ph;
                     ph += stride;
                     SimNode * body = list[0];    // note: instruments

--- a/include/daScript/simulate/runtime_array.h
+++ b/include/daScript/simulate/runtime_array.h
@@ -18,8 +18,8 @@ namespace das
             DAS_PROFILE_NODE
             Array * pA = (Array *) l->evalPtr(context);
             auto idx = uint32_t(r->evalInt(context));
-            if ( idx >= pA->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", idx, pA->size);
-            return pA->data + idx*stride + offset;
+            if ( uint64_t(idx) >= pA->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", idx, (unsigned long long)pA->size);
+            return pA->data + uint64_t(idx)*uint64_t(stride) + offset;
         }
         SimNode * l, * r;
         uint32_t stride, offset;
@@ -52,6 +52,94 @@ namespace das
 #undef EVAL_NODE
     };
 
+    // AT (INDEX) - int64 index
+    struct SimNode_ArrayAt_I64 : SimNode {
+        DAS_PTR_NODE;
+        SimNode_ArrayAt_I64 ( const LineInfo & at, SimNode * ll, SimNode * rr, uint32_t sz, uint32_t o)
+            : SimNode(at), l(ll), r(rr), stride(sz), offset(o) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Array * pA = (Array *) l->evalPtr(context);
+            int64_t idx = r->evalInt64(context);
+            if ( idx<0 || uint64_t(idx) >= pA->size ) context.throw_error_at(debugInfo,"array index out of range, %lld of %llu", (long long)idx, (unsigned long long)pA->size);
+            return pA->data + uint64_t(idx)*uint64_t(stride) + offset;
+        }
+        SimNode * l, * r;
+        uint32_t stride, offset;
+    };
+
+    template <typename TT>
+    struct SimNode_ArrayAtR2V_I64 : SimNode_ArrayAt_I64 {
+        SimNode_ArrayAtR2V_I64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o )
+            : SimNode_ArrayAt_I64(at,rv,idx,strd,o) {}
+        SimNode * visit ( SimVisitor & vis ) override {
+            V_BEGIN();
+            V_OP_TT(ArrayAtR2V_I64);
+            V_SUB(l);
+            V_SUB(r);
+            V_ARG(stride);
+            V_ARG(offset);
+            V_END();
+        }
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+            DAS_PROFILE_NODE
+            TT * pR = (TT *) compute(context);
+            return cast<TT>::from(*pR);
+        }
+#define EVAL_NODE(TYPE,CTYPE)                                       \
+        virtual CTYPE eval##TYPE ( Context & context ) override {   \
+            DAS_PROFILE_NODE \
+            return *(CTYPE *)compute(context);                      \
+        }
+        DAS_EVAL_NODE
+#undef EVAL_NODE
+    };
+
+    // AT (INDEX) - uint64 index
+    struct SimNode_ArrayAt_U64 : SimNode {
+        DAS_PTR_NODE;
+        SimNode_ArrayAt_U64 ( const LineInfo & at, SimNode * ll, SimNode * rr, uint32_t sz, uint32_t o)
+            : SimNode(at), l(ll), r(rr), stride(sz), offset(o) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Array * pA = (Array *) l->evalPtr(context);
+            uint64_t idx = r->evalUInt64(context);
+            if ( idx >= pA->size ) context.throw_error_at(debugInfo,"array index out of range, %llu of %llu", (unsigned long long)idx, (unsigned long long)pA->size);
+            return pA->data + idx*uint64_t(stride) + offset;
+        }
+        SimNode * l, * r;
+        uint32_t stride, offset;
+    };
+
+    template <typename TT>
+    struct SimNode_ArrayAtR2V_U64 : SimNode_ArrayAt_U64 {
+        SimNode_ArrayAtR2V_U64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o )
+            : SimNode_ArrayAt_U64(at,rv,idx,strd,o) {}
+        SimNode * visit ( SimVisitor & vis ) override {
+            V_BEGIN();
+            V_OP_TT(ArrayAtR2V_U64);
+            V_SUB(l);
+            V_SUB(r);
+            V_ARG(stride);
+            V_ARG(offset);
+            V_END();
+        }
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+            DAS_PROFILE_NODE
+            TT * pR = (TT *) compute(context);
+            return cast<TT>::from(*pR);
+        }
+#define EVAL_NODE(TYPE,CTYPE)                                       \
+        virtual CTYPE eval##TYPE ( Context & context ) override {   \
+            DAS_PROFILE_NODE \
+            return *(CTYPE *)compute(context);                      \
+        }
+        DAS_EVAL_NODE
+#undef EVAL_NODE
+    };
+
     // AT (INDEX)
     struct SimNode_SafeArrayAt : SimNode_ArrayAt {
         DAS_PTR_NODE;
@@ -63,8 +151,40 @@ namespace das
             Array * pA = (Array *) l->evalPtr(context);
             if ( !pA ) return nullptr;
             auto idx = uint32_t(r->evalInt(context));
+            if (uint64_t(idx) >= pA->size) return nullptr;
+            return pA->data + uint64_t(idx)*uint64_t(stride) + offset;
+        }
+    };
+
+    // SAFE AT (INDEX) - int64 index
+    struct SimNode_SafeArrayAt_I64 : SimNode_ArrayAt_I64 {
+        DAS_PTR_NODE;
+        SimNode_SafeArrayAt_I64 ( const LineInfo & at, SimNode * ll, SimNode * rr, uint32_t sz, uint32_t o)
+            : SimNode_ArrayAt_I64(at,ll,rr,sz,o) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Array * pA = (Array *) l->evalPtr(context);
+            if ( !pA ) return nullptr;
+            int64_t idx = r->evalInt64(context);
+            if (idx<0 || uint64_t(idx) >= pA->size) return nullptr;
+            return pA->data + uint64_t(idx)*uint64_t(stride) + offset;
+        }
+    };
+
+    // SAFE AT (INDEX) - uint64 index
+    struct SimNode_SafeArrayAt_U64 : SimNode_ArrayAt_U64 {
+        DAS_PTR_NODE;
+        SimNode_SafeArrayAt_U64 ( const LineInfo & at, SimNode * ll, SimNode * rr, uint32_t sz, uint32_t o)
+            : SimNode_ArrayAt_U64(at,ll,rr,sz,o) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Array * pA = (Array *) l->evalPtr(context);
+            if ( !pA ) return nullptr;
+            uint64_t idx = r->evalUInt64(context);
             if (idx >= pA->size) return nullptr;
-            return pA->data + idx*stride + offset;
+            return pA->data + idx*uint64_t(stride) + offset;
         }
     };
 

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -65,8 +65,8 @@ namespace das
         __forceinline int find ( const Table & tab, KeyType key, uint64_t hash ) const {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
-            uint32_t mask = tab.capacity - 1;
-            uint32_t index = uint32_t(hash) & mask;
+            uint64_t mask = tab.capacity - 1;
+            uint64_t index = hash & mask;
             auto pKeys = (const KeyType *) tab.keys;
             auto pHashes = tab.hashes;
             auto hashKey = hashToHashKey(TableHashKey(hash));
@@ -85,9 +85,9 @@ namespace das
             DAS_ASSERT(hash>1);
             if ( tab.size >= (tab.capacity/2) ) grow(tab, at);
             else if ( (tab.capacity-tab.size)/2 < tab.tombstones ) rehash(tab, at);
-            uint32_t mask = tab.capacity - 1;
-            uint32_t index = uint32_t(hash) & mask;
-            uint32_t insertI = -1u;
+            uint64_t mask = tab.capacity - 1;
+            uint64_t index = hash & mask;
+            uint64_t insertI = ~uint64_t(0);
             auto pKeys = (KeyType *) tab.keys;
             auto pHashes = tab.hashes;
             auto hashKey = hashToHashKey(TableHashKey(hash));
@@ -95,7 +95,7 @@ namespace das
                 auto kh = pHashes[index];
                 if (kh == HASH_EMPTY64 ) {
                     if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
-                    if ( insertI != -1u ) {
+                    if ( insertI != ~uint64_t(0) ) {
                         index = insertI;
                         tab.tombstones--;
                     }
@@ -104,7 +104,7 @@ namespace das
                     tab.size++;
                     return (int)index;
                 } else if (kh == HASH_KILLED64) {
-                    if ( insertI == -1u ) insertI = index;
+                    if ( insertI == ~uint64_t(0) ) insertI = index;
                 } else if (kh == hashKey && KeyCompare<KeyType>()(pKeys[index], key)) {
                     return (int)index;
                 }
@@ -115,8 +115,8 @@ namespace das
         __forceinline int erase ( Table & tab, KeyType key, uint64_t hash ) {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
-            uint32_t mask = tab.capacity - 1;
-            uint32_t index = uint32_t(hash) & mask;
+            uint64_t mask = tab.capacity - 1;
+            uint64_t index = hash & mask;
             auto pKeys = (const KeyType *) tab.keys;
             auto pHashes = tab.hashes;
             auto hashKey = hashToHashKey(TableHashKey(hash));
@@ -136,7 +136,7 @@ namespace das
         }
 
         bool grow ( Table & tab, LineInfo * at ) {
-            uint32_t newCapacity = das::max(uint32_t(minCapacity), tab.capacity*2);
+            uint64_t newCapacity = das::max(uint64_t(minCapacity), tab.capacity*2);
             return reserveInternal(tab, newCapacity, at);
         }
 
@@ -144,11 +144,11 @@ namespace das
             return reserveInternal(tab, tab.capacity, at);
         }
 
-        bool reserve(Table & tab, uint32_t size, LineInfo * at ) {
+        bool reserve(Table & tab, uint64_t size, LineInfo * at ) {
             if (size <= tab.capacity)
               return true;
 
-            uint32_t newCapacity = das::max(uint32_t(minCapacity), tab.capacity*2);
+            uint64_t newCapacity = das::max(uint64_t(minCapacity), tab.capacity*2);
             while (newCapacity < size)
             {
               newCapacity *= 2;
@@ -161,8 +161,8 @@ namespace das
         __forceinline int insertNew ( Table & tab, uint64_t hash ) const {
             // TODO: take key under account and be less aggressive?
             DAS_ASSERT(hash>1);
-            uint32_t mask = tab.capacity - 1;
-            uint32_t index = uint32_t(hash) & mask;
+            uint64_t mask = tab.capacity - 1;
+            uint64_t index = hash & mask;
             auto pHashes = tab.hashes;
             while ( true ) {
                 auto kh = pHashes[index];
@@ -173,22 +173,21 @@ namespace das
             }
         }
 
-        bool reserveInternal(Table & tab, uint32_t newCapacity, LineInfo * at) {
-            DAS_VERIFYF((newCapacity & (newCapacity) - 1) == 0, "newCapacity must be power of 2, and not %i", int(newCapacity));
+        bool reserveInternal(Table & tab, uint64_t newCapacity, LineInfo * at) {
+            DAS_VERIFYF((newCapacity & (newCapacity) - 1) == 0, "newCapacity must be power of 2, and not %llu", (unsigned long long)newCapacity);
             if ( tab.magic!=0 || tab.lock!=0 ) {
                 context->throw_error_at(at, "can't grow a locked table");
                 return false;
             }
             Table newTab;
-            uint64_t memSize64 = uint64_t(newCapacity) * (uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + uint64_t(sizeof(TableHashKey)));
-            if ( memSize64>=0xffffffff ) {
-                context->throw_error_ex("can't grow table, out of index space [capacity=%i]", newCapacity);
+            uint64_t perSlot = uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + uint64_t(sizeof(TableHashKey));
+            if ( perSlot && newCapacity > UINT64_MAX / perSlot ) {
+                context->throw_error_ex("can't grow table, capacity*perSlot overflows uint64 [capacity=%llu]", (unsigned long long)newCapacity);
                 return false;
-
             }
+            uint64_t memSize64 = newCapacity * perSlot;
             const char * prev_comment = tab.data ? context->heap->get_comment(tab.data) : nullptr;
-            uint32_t memSize = uint32_t(memSize64);
-            newTab.data = (char *) context->allocate(memSize, at);
+            newTab.data = (char *) context->allocate(memSize64, at);
             context->heap->mark_comment(newTab.data, prev_comment ? prev_comment : "table");
             newTab.keys = newTab.data + newCapacity * valueTypeSize;
             newTab.hashes = (TableHashKey *)(newTab.keys + newCapacity * sizeof(KeyType));
@@ -200,14 +199,14 @@ namespace das
             newTab.tombstones = 0;
             if ( valueTypeSize ) memset(newTab.data, 0, size_t(newCapacity)*size_t(valueTypeSize));
             auto pHashes = newTab.hashes;
-            memset(pHashes, 0, newCapacity * sizeof(TableHashKey));
+            memset(pHashes, 0, size_t(newCapacity) * sizeof(TableHashKey));
             if ( tab.size ) {
                 auto pKeys = (KeyType *) newTab.keys;
                 auto pOldValues = tab.data;
                 auto pValues = newTab.data;
                 auto pOldKeys = (const KeyType *) tab.keys;
                 auto pOldHashes = tab.hashes;
-                for ( uint32_t i=0, is=tab.capacity; i!=is; ++i ) {
+                for ( uint64_t i=0, is=tab.capacity; i!=is; ++i ) {
                     auto hash = pOldHashes[i];
                     if ( hash>HASH_KILLED64 ) {
                         int index = insertNew(newTab, hash);
@@ -218,7 +217,7 @@ namespace das
                 }
             }
             if (tab.capacity && !context->verySafeContext) {
-                uint32_t oldSize = tab.capacity*(valueTypeSize + sizeof(KeyType) + sizeof(TableHashKey));
+                uint64_t oldSize = tab.capacity * perSlot;
                 context->free(tab.data, oldSize, at);
             }
             swap ( newTab, tab );

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -148,6 +148,12 @@ namespace das
             if (size <= tab.capacity)
               return true;
 
+            // Guard against overflow before doubling — otherwise huge `size` (e.g. a negative
+            // signed input cast to uint64) would infinite-loop here as newCapacity wraps to 0.
+            if (size > (uint64_t(1) << 62)) {
+              context->throw_error_at(at, "table reserve: size %llu exceeds 2^62", (unsigned long long)size);
+              return false;
+            }
             uint64_t newCapacity = das::max(uint64_t(minCapacity), tab.capacity*2);
             while (newCapacity < size)
             {

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -62,7 +62,7 @@ namespace das
             else return hash;
         }
 
-        __forceinline int find ( const Table & tab, KeyType key, uint64_t hash ) const {
+        __forceinline int64_t find ( const Table & tab, KeyType key, uint64_t hash ) const {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
             uint64_t mask = tab.capacity - 1;
@@ -75,13 +75,13 @@ namespace das
                 if ( kh==HASH_EMPTY64 ) {
                     return -1;
                 } else if ( kh==hashKey && KeyCompare<KeyType>()(pKeys[index],key) ) {
-                    return (int) index;
+                    return (int64_t) index;
                 }
                 index = (index + 1) & mask;
             }
         }
 
-        __forceinline int reserve ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {
+        __forceinline int64_t reserve ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {
             DAS_ASSERT(hash>1);
             if ( tab.size >= (tab.capacity/2) ) grow(tab, at);
             else if ( (tab.capacity-tab.size)/2 < tab.tombstones ) rehash(tab, at);
@@ -102,17 +102,17 @@ namespace das
                     pHashes[index] = hashKey;
                     pKeys[index] = key;
                     tab.size++;
-                    return (int)index;
+                    return (int64_t)index;
                 } else if (kh == HASH_KILLED64) {
                     if ( insertI == ~uint64_t(0) ) insertI = index;
                 } else if (kh == hashKey && KeyCompare<KeyType>()(pKeys[index], key)) {
-                    return (int)index;
+                    return (int64_t)index;
                 }
                 index = (index + 1) & mask;
             }
         }
 
-        __forceinline int erase ( Table & tab, KeyType key, uint64_t hash ) {
+        __forceinline int64_t erase ( Table & tab, KeyType key, uint64_t hash ) {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
             uint64_t mask = tab.capacity - 1;
@@ -129,7 +129,7 @@ namespace das
                     tab.tombstones++;
                     pHashes[index] = HASH_KILLED64;
                     memset(tab.data + index*valueTypeSize, 0, valueTypeSize);
-                    return (int) index;
+                    return (int64_t) index;
                 }
                 index = (index + 1) & mask;
             }
@@ -164,7 +164,9 @@ namespace das
         }
 
     private:
-        __forceinline int insertNew ( Table & tab, uint64_t hash ) const {
+        // Returns the slot index. Always finds a slot (called only during rehash on a fresh
+        // pre-allocated table), so signed int64_t can hold any value the uint64 capacity allows.
+        __forceinline int64_t insertNew ( Table & tab, uint64_t hash ) const {
             // TODO: take key under account and be less aggressive?
             DAS_ASSERT(hash>1);
             uint64_t mask = tab.capacity - 1;
@@ -173,7 +175,7 @@ namespace das
             while ( true ) {
                 auto kh = pHashes[index];
                 if ( kh==HASH_EMPTY64 ) {
-                    return (int) index;
+                    return (int64_t) index;
                 }
                 index = (index + 1) & mask;
             }
@@ -215,7 +217,7 @@ namespace das
                 for ( uint64_t i=0, is=tab.capacity; i!=is; ++i ) {
                     auto hash = pOldHashes[i];
                     if ( hash>HASH_KILLED64 ) {
-                        int index = insertNew(newTab, hash);
+                        int64_t index = insertNew(newTab, hash);
                         pHashes[index] = hash;
                         pKeys[index] = pOldKeys[i];
                         memcpy ( pValues + index*valueTypeSize, pOldValues + i*valueTypeSize, valueTypeSize );

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -136,6 +136,13 @@ namespace das
         }
 
         bool grow ( Table & tab, LineInfo * at ) {
+            // Guard against capacity*2 overflow — at uint64_t the wrap-to-zero produces
+            // a non-power-of-two `newCapacity` that would trip reserveInternal's verify
+            // and, before that, make `mask = capacity - 1` underflow into all-ones.
+            if ( tab.capacity > (uint64_t(1) << 62) ) {
+                context->throw_error_at(at, "table grow: capacity %llu exceeds 2^62", (unsigned long long)tab.capacity);
+                return false;
+            }
             uint64_t newCapacity = das::max(uint64_t(minCapacity), tab.capacity*2);
             return reserveInternal(tab, newCapacity, at);
         }
@@ -182,7 +189,7 @@ namespace das
         }
 
         bool reserveInternal(Table & tab, uint64_t newCapacity, LineInfo * at) {
-            DAS_VERIFYF((newCapacity & (newCapacity) - 1) == 0, "newCapacity must be power of 2, and not %llu", (unsigned long long)newCapacity);
+            DAS_VERIFYF(newCapacity != 0 && (newCapacity & (newCapacity - 1)) == 0, "newCapacity must be a nonzero power of 2, and not %llu", (unsigned long long)newCapacity);
             if ( tab.magic!=0 || tab.lock!=0 ) {
                 context->throw_error_at(at, "can't grow a locked table");
                 return false;

--- a/include/daScript/simulate/runtime_table_nodes.h
+++ b/include/daScript/simulate/runtime_table_nodes.h
@@ -68,7 +68,7 @@ namespace das
             auto key = EvalTT<KeyType>::eval(context,keyExpr);
             TableHash<KeyType> thh(&context,valueTypeSize);
             auto hfn = hash_function(context, key);
-            int index = thh.reserve(*tab, key, hfn, &debugInfo);    // if index==-1, it was a through, so safe to do
+            int64_t index = thh.reserve(*tab, key, hfn, &debugInfo);    // if index==-1, it was a through, so safe to do
             return tab->data + index * valueTypeSize + offset;
         }
         uint32_t offset;
@@ -97,7 +97,7 @@ namespace das
             auto key = EvalTT<KeyType>::eval(context,PT::keyExpr);
             TableHash<KeyType> thh(&context,PT::valueTypeSize);
             auto hfn = hash_function(context, key);
-            int index = thh.find(*tab, key, hfn);
+            int64_t index = thh.find(*tab, key, hfn);
             return index!=-1 ? tab->data + index * PT::valueTypeSize : nullptr;
         }
     };
@@ -154,7 +154,7 @@ namespace das
             auto key = EvalTT<KeyType>::eval(context,keyExpr);
             auto hfn = hash_function(context, key);
             TableHash<KeyType> thh(&context,valueTypeSize);
-            int index = thh.find(*tab, key, hfn);
+            int64_t index = thh.find(*tab, key, hfn);
             return index!=-1 ? tab->data + index * valueTypeSize : nullptr;
         }
     };

--- a/include/daScript/simulate/runtime_table_nodes.h
+++ b/include/daScript/simulate/runtime_table_nodes.h
@@ -68,7 +68,7 @@ namespace das
             auto key = EvalTT<KeyType>::eval(context,keyExpr);
             TableHash<KeyType> thh(&context,valueTypeSize);
             auto hfn = hash_function(context, key);
-            int64_t index = thh.reserve(*tab, key, hfn, &debugInfo);    // if index==-1, it was a through, so safe to do
+            int64_t index = thh.reserve(*tab, key, hfn, &debugInfo);    // reserve always returns a valid slot or throws
             return tab->data + index * valueTypeSize + offset;
         }
         uint32_t offset;

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1715,14 +1715,25 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
 // ExprAt
+    // Bring two integer LLVM values to a common width by zero-extending the narrower one.
+    // Needed since Array.size widened to i64 but daslang's default int index is still i32.
+    def normalize_int_widths(lhs : LLVMOpaqueValue?; rhs : LLVMOpaqueValue?) : tuple<LLVMOpaqueValue?; LLVMOpaqueValue?> {
+        let wl = LLVMGetIntTypeWidth(LLVMTypeOf(lhs))
+        let wr = LLVMGetIntTypeWidth(LLVMTypeOf(rhs))
+        return (LLVMBuildZExt(g_builder, lhs, LLVMTypeOf(rhs), ""), rhs) if (wl < wr)
+        return (lhs, LLVMBuildZExt(g_builder, rhs, LLVMTypeOf(lhs), "")) if (wr < wl)
+        return (lhs, rhs)
+    }
+
     def check_range(tidx, maxIdx : LLVMOpaqueValue?; at : LineInfo; message : string) {
         if (option_no_range_check) return
+        let (ntidx, nmax) = normalize_int_widths(tidx, maxIdx)
         var check_null_ptr = append_basic_block("check_dim_range")
         var check_true = append_basic_block("check_true")
         var check_end = append_basic_block("check_end")
         LLVMBuildBr(g_builder, check_null_ptr)
         LLVMPositionBuilderAtEnd(g_builder, check_null_ptr)
-        var cond = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntUGE, tidx, maxIdx, "range_check")
+        var cond = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntUGE, ntidx, nmax, "range_check")
         LLVMBuildCondBr(g_builder, cond, check_true, check_end)
         LLVMPositionBuilderAtEnd(g_builder, check_true)
         build_exception(message, at)
@@ -1889,7 +1900,8 @@ class public LlvmJitVisitor : AstVisitor {
             var if_not_null = empty(subExprT.dim) ? LLVMBuildIsNotNull(g_builder, tsrc, "") : LLVMConstInt(types.t_int1, 1ul, 0)
             res = build_select(if_not_null, resType) {
                 var maxIdx = types.ConstI32(uint64(maxIndex))
-                var if_range = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, tidx, maxIdx, "dim_range")
+                let (nidx, nmax) = normalize_int_widths(tidx, maxIdx)
+                var if_range = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, nidx, nmax, "dim_range")
                 var subRes = build_select(if_range, resType) {
                     return build_array_index(tsrc, tidx, etype, "dim_at")
                 }
@@ -1909,7 +1921,8 @@ class public LlvmJitVisitor : AstVisitor {
                 var arr_ty = expr.subexpr._type.isPointer ? expr.subexpr._type.firstType : expr.subexpr._type
                 var arr = LLVMBuildLoadData2Aligned(g_builder, type_to_llvm_type(arr_ty), tsrc, arr_ty.alignOf, "arr")
                 var size = LLVMBuildExtractValue(g_builder, arr, uint(JIT_ARRAY.SIZE), "array.size")
-                var if_range = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, tidx, size, "array_range")
+                let (nidx, nsize) = normalize_int_widths(tidx, size)
+                var if_range = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, nidx, nsize, "array_range")
                 var subRes = build_select(if_range, resType) {
                     var data = LLVMBuildExtractValue(g_builder, arr, uint(JIT_ARRAY.DATA), "array.data")
                     return build_array_index(data, tidx, etype, "array_at")
@@ -1956,7 +1969,8 @@ class public LlvmJitVisitor : AstVisitor {
             var etype = subExprT.isPointer ? subExprT.firstType : subExprT
             var resType = LLVMPointerType(type_to_llvm_type(etype), 0u)
             res = build_select(if_not_null, resType) {
-                var if_range = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, tidx, types.ConstI32(uint64(etype.vectorDim)), "dim_range")
+                let (nidx, nmax) = normalize_int_widths(tidx, types.ConstI32(uint64(etype.vectorDim)))
+                var if_range = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, nidx, nmax, "dim_range")
                 var subRes = build_select(if_range, resType) {
                     if (expr.atFlags.r2v) {
                         var lvec = LLVMBuildLoadData2Aligned(g_builder, type_to_llvm_type(expr.subexpr._type),
@@ -2924,7 +2938,10 @@ class public LlvmJitVisitor : AstVisitor {
             } elif (ssrc._type.isGoodArrayType) {// {}->first()
                 var arr = LLVMBuildLoadData2Aligned(g_builder, type_to_llvm_type(ssrc._type), getE(ssrc), ssrc._type.alignOf, "array")
                 var size = LLVMBuildExtractValue(g_builder, arr, uint(JIT_ARRAY.SIZE), "array.size")
-                var cmp_from_to = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, size, types.ConstI32(0ul), "")
+                // Array.size is i64; produce zero/one of matching width for the compare + sub.
+                var i64_zero = LLVMConstInt(LLVMTypeOf(size), 0ul, 0)
+                var i64_one = LLVMConstInt(LLVMTypeOf(size), 1ul, 0)
+                var cmp_from_to = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, size, i64_zero, "")
                 var okay = append_basic_block("for_{svar.name}_not_empty")
                 var not_okay = append_basic_block("for_{svar.name}_empty")
                 LLVMBuildCondBr(g_builder, cmp_from_to, okay, not_okay)
@@ -2935,7 +2952,7 @@ class public LlvmJitVisitor : AstVisitor {
                 build_array_lock(getE(ssrc), expr.at)
                 var data = LLVMBuildExtractValue(g_builder, arr, uint(JIT_ARRAY.DATA), "array.data")
                 LLVMBuildStore(g_builder, data, getV(svar))
-                var tail = LLVMBuildSub(g_builder, size, types.ConstI32(1ul), "")
+                var tail = LLVMBuildSub(g_builder, size, i64_one, "")
                 var sto = build_array_index(data, tail, ssrc._type.firstType, "last_element")
                 sto = LLVMBuildPtrToInt(g_builder, sto, types.LLVMIntPtrType(), "array_end")
                 range2[ssrc] = sto

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1780,7 +1780,10 @@ class public LlvmJitVisitor : AstVisitor {
         var ptr_idx : LLVMOpaqueValue?
         if (elemType.isVectorType && elemType.vectorDim == 3) {
             var data_bytes = LLVMBuildPointerCast(g_builder, data, LLVMPointerType(types.t_int8, 0u), "")
-            var data_idx = LLVMBuildMul(g_builder, tidx, types.ConstI32(12ul), "")
+            // Stride const must match tidx width — Array.size-derived `tail` is i64,
+            // dim-derived tail is i32; an i32 ConstI32 against i64 tidx is a verifier error.
+            var stride = LLVMConstInt(LLVMTypeOf(tidx), 12ul, 0)
+            var data_idx = LLVMBuildMul(g_builder, tidx, stride, "")
             ptr_idx = LLVMBuildGEP2(g_builder, types.t_int8, data_bytes, data_idx, "")
             ptr_idx = LLVMBuildPointerCast(g_builder, ptr_idx, LLVMPointerType(type_to_llvm_type(elemType), 0u), name)
         } else {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -137,26 +137,35 @@ class public Attributes {
 
 }
 
+// Indices MUST match the field order produced by `type_to_llvm_type` for `Type.tArray`
+// below, which itself mirrors the C++ `das::Array` layout (data, size, capacity, magic,
+// lock, flags, _pad_after_flags). The enum order was originally `LOOK, MAGIC` to match
+// an older mirror that had `lock, magic` in that order — when the mirror was corrected
+// to C++ order, the enum needed the same flip.
 enum public JIT_ARRAY {
     DATA
     SIZE
     CAPACITY
-    LOOK
     MAGIC
+    LOCK
     FLAGS
     PAD_AFTER_FLAGS  // mirror Array's trailing alignment pad (see arraytype.h)
 }
 
+// Indices MUST match the field order produced by `type_to_llvm_type` for `Type.tTable`
+// below — Array base fields, then keys/hashes/tombstones. Keep in sync with the C++
+// `das::Table` layout (Table : Array).
 enum public JIT_TABLE {
     DATA
     SIZE
     CAPACITY
-    LOOK
     MAGIC
+    LOCK
     FLAGS
     PAD_AFTER_FLAGS  // matches C++ sizeof(Array)==40 on 32-bit; Table::keys lands at 40
     KEYS
     HASHES
+    TOMBSTONES
 }
 
 enum public JIT_SIMFUNCTION {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -144,6 +144,7 @@ enum public JIT_ARRAY {
     LOOK
     MAGIC
     FLAGS
+    PAD_AFTER_FLAGS  // mirror Array's trailing alignment pad (see arraytype.h)
 }
 
 enum public JIT_TABLE {
@@ -153,6 +154,7 @@ enum public JIT_TABLE {
     LOOK
     MAGIC
     FLAGS
+    PAD_AFTER_FLAGS  // matches C++ sizeof(Array)==40 on 32-bit; Table::keys lands at 40
     KEYS
     HASHES
 }
@@ -926,14 +928,17 @@ def public type_to_llvm_type(t : TypeDeclPtr) {
             g_prim_t.t_int64,                    // uint64_t capacity
             g_prim_t.t_int32,                    // uint32_t magic
             g_prim_t.t_int32,                    // uint32_t lock
-            g_prim_t.t_int32                     // uint32_t flags
+            g_prim_t.t_int32,                    // uint32_t flags
+            g_prim_t.t_int32                     // _pad_after_flags (mirror trailing alignment pad)
         )
         if (t.firstType != null) {
             array_fields[int(JIT_ARRAY.DATA)] = LLVMPointerType(type_to_llvm_type(t.firstType), 0u)
         }
         res = g_prim_t |> StructType(array_fields)
     } elif (t.baseType == Type.tTable) {
-        // table type — must mirror Table layout (Array base + keys/hashes/tombstones)
+        // table type — must mirror Table layout (Array base + keys/hashes/tombstones).
+        // The explicit _pad_after_flags slot forces keys onto an 8-aligned offset on
+        // 32-bit ABIs, matching the C++ Table (where Table::keys lives at sizeof(Array)==40).
         var table_fields <- fixed_array(
             g_prim_t.LLVMVoidPtrType(),// char * data
             g_prim_t.t_int64,                    // uint64_t size
@@ -941,6 +946,7 @@ def public type_to_llvm_type(t : TypeDeclPtr) {
             g_prim_t.t_int32,                    // uint32_t magic
             g_prim_t.t_int32,                    // uint32_t lock
             g_prim_t.t_int32,                    // uint32_t flags
+            g_prim_t.t_int32,                    // _pad_after_flags
             g_prim_t.LLVMVoidPtrType(),// char * keys
             g_prim_t.LLVMVoidPtrType(),// TableHashKey * hashes
             g_prim_t.t_int64)                    // uint64_t tombstones

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -919,13 +919,13 @@ def public type_to_llvm_type(t : TypeDeclPtr) {
     } elif (t.baseType == Type.tBlock) {
         res = g_t_block
     } elif (t.baseType == Type.tArray) {
-        // array type
+        // array type — must mirror Array layout in arraytype.h byte-for-byte
         var array_fields <- fixed_array(
             g_prim_t.LLVMVoidPtrType(),// char * data
-            g_prim_t.t_int32,                    // uint32_t size
-            g_prim_t.t_int32,                    // uint32_t capacity
-            g_prim_t.t_int32,                    // uint32_t lock
+            g_prim_t.t_int64,                    // uint64_t size
+            g_prim_t.t_int64,                    // uint64_t capacity
             g_prim_t.t_int32,                    // uint32_t magic
+            g_prim_t.t_int32,                    // uint32_t lock
             g_prim_t.t_int32                     // uint32_t flags
         )
         if (t.firstType != null) {
@@ -933,17 +933,17 @@ def public type_to_llvm_type(t : TypeDeclPtr) {
         }
         res = g_prim_t |> StructType(array_fields)
     } elif (t.baseType == Type.tTable) {
-        // table type
+        // table type — must mirror Table layout (Array base + keys/hashes/tombstones)
         var table_fields <- fixed_array(
             g_prim_t.LLVMVoidPtrType(),// char * data
-            g_prim_t.t_int32,                    // uint32_t size
-            g_prim_t.t_int32,                    // uint32_t capacity
+            g_prim_t.t_int64,                    // uint64_t size
+            g_prim_t.t_int64,                    // uint64_t capacity
+            g_prim_t.t_int32,                    // uint32_t magic
             g_prim_t.t_int32,                    // uint32_t lock
             g_prim_t.t_int32,                    // uint32_t flags
-            g_prim_t.t_int32,                    // uint32_t magic
             g_prim_t.LLVMVoidPtrType(),// char * keys
-            g_prim_t.LLVMVoidPtrType(),// char * hashes
-            g_prim_t.t_int32)
+            g_prim_t.LLVMVoidPtrType(),// TableHashKey * hashes
+            g_prim_t.t_int64)                    // uint64_t tombstones
         if (t.firstType != null) {
             table_fields[int(JIT_TABLE.KEYS)] = LLVMPointerType(type_to_llvm_type(t.firstType), 0u)
         }

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -168,7 +168,10 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
     assume argType = expr.arguments[0]._type
     if (argType.isGoodArrayType) {
         var arr = LLVMBuildLoad2(ctx.builder, type_to_llvm_type(expr.arguments[0]._type), arguments[0], "arr")
-        return LLVMBuildExtractValue(ctx.builder, arr, uint(JIT_ARRAY.SIZE), "array.size")
+        var size_i64 = LLVMBuildExtractValue(ctx.builder, arr, uint(JIT_ARRAY.SIZE), "array.size")
+        // builtin length() returns int32; Array.size is uint64. Truncate.
+        // TODO Phase 7: emit panic if size > INT32_MAX to match C++ builtin_array_size.
+        return LLVMBuildTruncOrBitCast(ctx.builder, size_i64, ctx.types.t_int32, "array.size.i32")
     } else {
         return null
     }

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -26,7 +26,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x02ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x03ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasStbImage/src/dasRaster.cpp
+++ b/modules/dasStbImage/src/dasRaster.cpp
@@ -11,7 +11,7 @@ namespace das
 {
     void rast_hspan_u8 ( TArray<uint8_t> & Span, int32_t spanOffset, const TArray<uint8_t> & Tspan, int32_t tspanOffset, float uvY, float dUVY, int32_t _count, LineInfoArg * at, Context * context ) {
         if ( uint32_t(spanOffset+_count) > Span.size ) {
-            context->throw_error_at(at,"rast_hspan: span out of range %i+%i >= %i", spanOffset, _count, Span.size);
+            context->throw_error_at(at,"rast_hspan: span out of range %i+%i >= %llu", spanOffset, _count, (unsigned long long)Span.size);
         }
         if ( tspanOffset<0 ) {
             context->throw_error_at(at,"rast_hspan: tspan offset is negative");
@@ -66,7 +66,7 @@ namespace das
 
     void rast_hspan_masked_u8 ( TArray<uint8_t> & Span, int32_t spanOffset, const TArray<uint8_t> & Tspan, int32_t tspanOffset, float uvY, float dUVY, int32_t _count, LineInfoArg * at, Context * context ) {
         if ( uint32_t(spanOffset+_count) > Span.size ) {
-            context->throw_error_at(at,"rast_hspan: span out of range %i+%i >= %i", spanOffset, _count, Span.size);
+            context->throw_error_at(at,"rast_hspan: span out of range %i+%i >= %llu", spanOffset, _count, (unsigned long long)Span.size);
         }
         if ( tspanOffset<0 ) {
             context->throw_error_at(at,"rast_hspan: tspan offset is negative");
@@ -117,7 +117,7 @@ namespace das
 
     void rast_hspan_masked_solid_u8 ( uint8_t solid, TArray<uint8_t> & Span, int32_t spanOffset, const TArray<uint8_t> & Tspan, int32_t tspanOffset, float uvY, float dUVY, int32_t _count, LineInfoArg * at, Context * context ) {
         if ( uint32_t(spanOffset+_count) > Span.size ) {
-            context->throw_error_at(at,"rast_hspan: span out of range %i+%i >= %i", spanOffset, _count, Span.size);
+            context->throw_error_at(at,"rast_hspan: span out of range %i+%i >= %llu", spanOffset, _count, (unsigned long long)Span.size);
         }
         if ( tspanOffset<0 ) {
             context->throw_error_at(at,"rast_hspan: tspan offset is negative");

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -115,6 +115,23 @@ Or use the MCP `run_test` tool with the `tests/` directory.
 
 **Module-specific testing:** CI enables ALL modules via `ci/release_modules.txt` (PUGIXML, LLVM, Audio, SQLite, GLFW, HV). If you changed files under `modules/X/daslib/`, explicitly run that module's tests even if your local build has the module disabled. Handled types (C++ interop like `xml_node`, `sqlite3_stmt`) often require `var` — lint's `var`→`let` suggestion is wrong for them because the C++ binding expects non-const.
 
+## 2.5. JIT smoke check — catch verifier failures before push
+
+The dasLLVM JIT path is a **third execution tier** alongside interpreter and AOT. Changes to runtime struct layouts (`Array`, `Table`, etc.), `SimNode_*` lowerings, or the dasLLVM module (`modules/dasLLVM/daslib/`) can break JIT codegen even when the interpreter and AOT tests are green. CI catches it on the second-line builds (decs / soa / jit_tests / language tests run under JIT), but the failure shape — `LLVMVerifyFunction: Both operands to a binary operator are not of the same type! %5 = mul i64 %3, i32 12` — is a 30-minute round-trip cost per discovery cycle.
+
+**Run a JIT smoke on a couple of tests:**
+
+```bash
+bin/Release/daslang.exe -jit tests/jit_tests/array.das 2>&1 | grep -iE "verifier|Both operands|verify"
+bin/Release/daslang.exe -jit tests/decs/test_bulk_create.das 2>&1 | grep -iE "verifier|Both operands|verify"
+```
+
+**Expected:** empty output (no verifier errors). The LLVM IR generation succeeded.
+
+**Windows local caveat:** `clang-cl` may report `unable to execute command: program not executable` when linking the JIT'd `.dll`. That's a local Windows env issue (linker discovery), **not the JIT codegen** — IR was already generated and verified before the link step. Treat the `clang-cl` link failure as a known-local artifact; the only signal you care about for this gate is *no verifier errors*. For full end-to-end JIT validation, use WSL/Linux (`feedback_wsl_tsan_repro`) where clang's link path works.
+
+**What this catches:** struct-layout drift (i32 vs i64 fields in JIT mirror), mixed-width arithmetic (i64 × i32), missing intrinsic lowering after a runtime-side widening. The two suggested tests cover array indexing + table operations; widen the smoke list to `tests/soa/test_soa_basic.das` and `tests/language/typeAlias.das` if you touched generic-instance lowering or capture frames.
+
 ## 3. Build and run AOT tests
 
 **IMPORTANT:** Kill the MCP server and any running daslang processes first — they lock build output files.
@@ -269,6 +286,7 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | Sync | `git fetch origin master && git rebase origin/master` | Always run first; verify diff vs origin/master is clean |
 | Lint | `utils/lint/main.das --quiet` on `git diff --name-only origin/master..HEAD -- '*.das'` | **Zero warnings.** Fix or `// nolint:CODE` every one — CI exits 2 on any warning |
 | Tests | `dastest -- --test tests/` | Must pass. Fix own, fix obvious pre-existing, ask about unclear |
+| JIT smoke | `daslang.exe -jit <test>.das 2>&1 \| grep -iE "verifier\|Both operands"` | Empty output = pass. Windows `clang-cl` link fail is local-only, ignore |
 | AOT build | `cmake --build build --config Release --target test_aot -j 64` | Kill daslang first. Register new test dirs |
 | AOT tests | `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` | Same as regular tests |
 | Docs | `das2rst.das` + stubs + Sphinx | Only if daslib/C++ bindings/RST changed |

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -3075,7 +3075,17 @@ namespace das {
                 reportAstChanged();
                 return subset;
             }
-            if (!ixT->isIndex()) {
+            if (seT->isGoodArrayType()) {
+                if (!ixT->isIndexExt()) {
+                    expr->type = nullptr;
+                    error("index type must be 'int', 'int64', 'uint', or 'uint64', not '" + describeType(ixT) + "'", "", "",
+                          expr->index->at, CompilationError::invalid_index_type);
+                    return Visitor::visit(expr);
+                }
+                TypeDecl::clone(expr->type, seT->firstType);
+                expr->type->ref = true;
+                expr->type->constant |= seT->constant;
+            } else if (!ixT->isIndex()) {
                 expr->type = nullptr;
                 error("index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
                       expr->index->at, CompilationError::invalid_index_type);
@@ -3084,10 +3094,6 @@ namespace das {
                 expr->type = new TypeDecl(seT->getVectorBaseType());
                 expr->type->ref = seT->ref;
                 expr->type->constant = seT->constant;
-            } else if (seT->isGoodArrayType()) {
-                TypeDecl::clone(expr->type, seT->firstType);
-                expr->type->ref = true;
-                expr->type->constant |= seT->constant;
             } else if (!seT->dim.size()) {
                 error("type can't be indexed: '" + describeType(seT) + "'", "", "",
                       expr->subexpr->at, CompilationError::cant_index);
@@ -3158,10 +3164,12 @@ namespace das {
                 // expr->type = seT->annotation->makeIndexType(expr->subexpr, expr->index);
                 // expr->type->constant |= seT->constant;
             } else if (seT->isVectorType() || seT->isGoodArrayType() || seT->dim.size()) {
-                // bounded types — int/uint only
-                if (!ixT->isIndex()) {
+                // arrays accept int/int64/uint/uint64; vector and fixed_array — int/uint only
+                if (seT->isGoodArrayType() ? !ixT->isIndexExt() : !ixT->isIndex()) {
                     expr->type = nullptr;
-                    error("index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
+                    error(seT->isGoodArrayType()
+                          ? "index type must be 'int', 'int64', 'uint', or 'uint64', not '" + describeType(ixT) + "'"
+                          : "index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
                           expr->index->at, CompilationError::invalid_index_type);
                     return Visitor::visit(expr);
                 } else if (seT->isVectorType()) {
@@ -3212,8 +3220,8 @@ namespace das {
                 error("safe-index of array<> must be inside the 'unsafe' block", "", "",
                       expr->at, CompilationError::unsafe_array_safe_index);
             }
-            if (!ixT->isIndex()) {
-                error("index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
+            if (!ixT->isIndexExt()) {
+                error("index type must be 'int', 'int64', 'uint', or 'uint64', not '" + describeType(ixT) + "'", "", "",
                       expr->index->at, CompilationError::invalid_index_type);
                 return Visitor::visit(expr);
             }

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -1872,9 +1872,17 @@ namespace das
             auto pidx = simulateExpression(expr->index);
             uint32_t stride = expr->subexpr->type->firstType->getSizeOf();
             if ( r2vType->baseType!=Type::none ) {
-                return context.code->makeValueNode<SimNode_ArrayAtR2V>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset);
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  return context.code->makeValueNode<SimNode_ArrayAtR2V_I64>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset);
+                case Type::tUInt64: return context.code->makeValueNode<SimNode_ArrayAtR2V_U64>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset);
+                default:            return context.code->makeValueNode<SimNode_ArrayAtR2V>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset);
+                }
             } else {
-                return context.code->makeNode<SimNode_ArrayAt>(at, prv, pidx, stride, extraOffset);
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  return context.code->makeNode<SimNode_ArrayAt_I64>(at, prv, pidx, stride, extraOffset);
+                case Type::tUInt64: return context.code->makeNode<SimNode_ArrayAt_U64>(at, prv, pidx, stride, extraOffset);
+                default:            return context.code->makeNode<SimNode_ArrayAt>(at, prv, pidx, stride, extraOffset);
+                }
             }
         } else if ( expr->subexpr->type->isPointer() ) {
             uint32_t stride = expr->subexpr->type->firstType->getSizeOf();
@@ -1999,7 +2007,11 @@ namespace das
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);
                 uint32_t stride = seT->firstType->getSizeOf();
-                setE(expr, context.code->makeNode<SimNode_SafeArrayAt>(at, prv, pidx, stride, 0));
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  setE(expr, context.code->makeNode<SimNode_SafeArrayAt_I64>(at, prv, pidx, stride, 0)); break;
+                case Type::tUInt64: setE(expr, context.code->makeNode<SimNode_SafeArrayAt_U64>(at, prv, pidx, stride, 0)); break;
+                default:            setE(expr, context.code->makeNode<SimNode_SafeArrayAt>(at, prv, pidx, stride, 0)); break;
+                }
             } else if ( seT->isGoodTableType() ) {
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);
@@ -2046,7 +2058,11 @@ namespace das
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);
                 uint32_t stride = seT->firstType->getSizeOf();
-                setE(expr, context.code->makeNode<SimNode_SafeArrayAt>(at, prv, pidx, stride, 0));
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  setE(expr, context.code->makeNode<SimNode_SafeArrayAt_I64>(at, prv, pidx, stride, 0)); break;
+                case Type::tUInt64: setE(expr, context.code->makeNode<SimNode_SafeArrayAt_U64>(at, prv, pidx, stride, 0)); break;
+                default:            setE(expr, context.code->makeNode<SimNode_SafeArrayAt>(at, prv, pidx, stride, 0)); break;
+                }
             } else if ( expr->subexpr->type->isGoodTableType() ) {
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);

--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -93,12 +93,13 @@ namespace das {
     }
 
     void builtin_array_erase_range_i64 ( Array & pArray, int64_t index, int64_t count, int stride, Context * context, LineInfoArg * at ) {
-        if ( index < 0 || count < 0 || uint64_t(index + count) > pArray.size ) {
+        // Compute end as uint64 sum AFTER non-negativity check to avoid signed overflow UB on index+count.
+        if ( index < 0 || count < 0 || uint64_t(index) + uint64_t(count) > pArray.size ) {
             context->throw_error_at(at, "erasing array range is invalid: index=%lld count=%lld size=%llu", (long long)index, (long long)count, (unsigned long long)pArray.size);
             return;
         }
-        memmove ( pArray.data+index*stride, pArray.data+(index+count)*stride, size_t(pArray.size-uint64_t(index)-uint64_t(count))*size_t(stride) );
-        array_resize(*context, pArray, pArray.size-count, stride, false, at);
+        memmove ( pArray.data+uint64_t(index)*stride, pArray.data+(uint64_t(index)+uint64_t(count))*stride, size_t(pArray.size-uint64_t(index)-uint64_t(count))*size_t(stride) );
+        array_resize(*context, pArray, pArray.size-uint64_t(count), stride, false, at);
     }
 
     void builtin_array_clear ( Array & pArray, Context * context, LineInfoArg * at ) {

--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -24,10 +24,15 @@ namespace das {
     }
 
     int64_t builtin_array_long_size ( const Array & arr ) {
+        // The long_length surface returns int64; refuse to wrap negative if a host/interop
+        // path somehow produced a size > INT64_MAX. array_resize / array_grow already cap
+        // growth at INT64_MAX, so this catches embedder-side corruption.
+        DAS_VERIFYF(arr.size <= uint64_t(INT64_MAX), "array size %llu exceeds INT64_MAX", (unsigned long long)arr.size);
         return int64_t(arr.size);
     }
 
     int64_t builtin_array_long_capacity ( const Array & arr ) {
+        DAS_VERIFYF(arr.capacity <= uint64_t(INT64_MAX), "array capacity %llu exceeds INT64_MAX", (unsigned long long)arr.capacity);
         return int64_t(arr.capacity);
     }
 

--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -66,8 +66,8 @@ namespace das {
     }
 
     void builtin_array_erase ( Array & pArray, int index, int stride, Context * context, LineInfoArg * at ) {
-        if ( uint64_t(index) >= pArray.size ) {
-            context->throw_error_at(at, "erase index out of range, %u of %llu", uint32_t(index), (unsigned long long)pArray.size);
+        if ( index < 0 || uint64_t(index) >= pArray.size ) {
+            context->throw_error_at(at, "erase index out of range, %d of %llu", index, (unsigned long long)pArray.size);
             return;
         }
         memmove ( pArray.data+index*stride, pArray.data+(index+1)*stride, size_t(pArray.size-uint64_t(index)-1)*size_t(stride) );
@@ -75,12 +75,13 @@ namespace das {
     }
 
     void builtin_array_erase_range ( Array & pArray, int index, int count, int stride, Context * context, LineInfoArg * at ) {
-        if ( index < 0 || count < 0 || uint64_t(index + count) > pArray.size ) {
-            context->throw_error_at(at, "erasing array range is invalid: index=%i count=%i size=%llu", index, count, (unsigned long long)pArray.size);
+        // Compute end as uint64 sum AFTER non-negativity check to avoid signed overflow UB on index+count.
+        if ( index < 0 || count < 0 || uint64_t(index) + uint64_t(count) > pArray.size ) {
+            context->throw_error_at(at, "erasing array range is invalid: index=%d count=%d size=%llu", index, count, (unsigned long long)pArray.size);
             return;
         }
-        memmove ( pArray.data+index*stride, pArray.data+(index+count)*stride, size_t(pArray.size-uint64_t(index)-uint64_t(count))*size_t(stride) );
-        array_resize(*context, pArray, pArray.size-count, stride, false, at);
+        memmove ( pArray.data+uint64_t(index)*stride, pArray.data+(uint64_t(index)+uint64_t(count))*stride, size_t(pArray.size-uint64_t(index)-uint64_t(count))*size_t(stride) );
+        array_resize(*context, pArray, pArray.size-uint64_t(count), stride, false, at);
     }
 
     void builtin_array_erase_i64 ( Array & pArray, int64_t index, int stride, Context * context, LineInfoArg * at ) {

--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -11,11 +11,24 @@
 namespace das {
 
     int builtin_array_size ( const Array & arr ) {
-        return arr.size;
+        // Always-on guard (panics in both debug + release). Use long_length()
+        // for arrays that may exceed INT_MAX elements — daslang's length() is
+        // int-returning and cannot represent the larger range without lying.
+        DAS_VERIFYF(arr.size <= uint64_t(INT32_MAX), "array size %llu exceeds INT_MAX; use long_length() instead", (unsigned long long)arr.size);
+        return int(arr.size);
     }
 
     int builtin_array_capacity ( const Array & arr ) {
-        return arr.capacity;
+        DAS_VERIFYF(arr.capacity <= uint64_t(INT32_MAX), "array capacity %llu exceeds INT_MAX; use long_capacity() instead", (unsigned long long)arr.capacity);
+        return int(arr.capacity);
+    }
+
+    int64_t builtin_array_long_size ( const Array & arr ) {
+        return int64_t(arr.size);
+    }
+
+    int64_t builtin_array_long_capacity ( const Array & arr ) {
+        return int64_t(arr.capacity);
     }
 
     int builtin_array_lock_count ( const Array & arr ) {
@@ -37,21 +50,54 @@ namespace das {
         array_reserve( *context, pArray, newSize, stride, at );
     }
 
+    void builtin_array_resize_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at ) {
+        if ( newSize<0 ) context->throw_error_at(at, "resizing array to negative size %lld", (long long)newSize);
+        array_resize ( *context, pArray, uint64_t(newSize), stride, /*zero*/ true, at );
+    }
+
+    void builtin_array_resize_no_init_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at ) {
+        if ( newSize<0 ) context->throw_error_at(at, "resizing array to negative size %lld", (long long)newSize);
+        array_resize ( *context, pArray, uint64_t(newSize), stride, /*zero*/ false, at );
+    }
+
+    void builtin_array_reserve_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at ) {
+        if ( newSize<0 ) return; // no point of displaying errors, if reserve fails
+        array_reserve( *context, pArray, uint64_t(newSize), stride, at );
+    }
+
     void builtin_array_erase ( Array & pArray, int index, int stride, Context * context, LineInfoArg * at ) {
-        if ( uint32_t(index) >= pArray.size ) {
-            context->throw_error_at(at, "erase index out of range, %u of %u", uint32_t(index), pArray.size);
+        if ( uint64_t(index) >= pArray.size ) {
+            context->throw_error_at(at, "erase index out of range, %u of %llu", uint32_t(index), (unsigned long long)pArray.size);
             return;
         }
-        memmove ( pArray.data+index*stride, pArray.data+(index+1)*stride, size_t(pArray.size-index-1)*size_t(stride) );
+        memmove ( pArray.data+index*stride, pArray.data+(index+1)*stride, size_t(pArray.size-uint64_t(index)-1)*size_t(stride) );
         array_resize(*context, pArray, pArray.size-1, stride, false, at);
     }
 
     void builtin_array_erase_range ( Array & pArray, int index, int count, int stride, Context * context, LineInfoArg * at ) {
-        if ( index < 0 || count < 0 || uint32_t(index + count) > pArray.size ) {
-            context->throw_error_at(at, "erasing array range is invalid: index=%i count=%i size=%u", index, count, pArray.size);
+        if ( index < 0 || count < 0 || uint64_t(index + count) > pArray.size ) {
+            context->throw_error_at(at, "erasing array range is invalid: index=%i count=%i size=%llu", index, count, (unsigned long long)pArray.size);
             return;
         }
-        memmove ( pArray.data+index*stride, pArray.data+(index+count)*stride, size_t(pArray.size-index-count)*size_t(stride) );
+        memmove ( pArray.data+index*stride, pArray.data+(index+count)*stride, size_t(pArray.size-uint64_t(index)-uint64_t(count))*size_t(stride) );
+        array_resize(*context, pArray, pArray.size-count, stride, false, at);
+    }
+
+    void builtin_array_erase_i64 ( Array & pArray, int64_t index, int stride, Context * context, LineInfoArg * at ) {
+        if ( index < 0 || uint64_t(index) >= pArray.size ) {
+            context->throw_error_at(at, "erase index out of range, %lld of %llu", (long long)index, (unsigned long long)pArray.size);
+            return;
+        }
+        memmove ( pArray.data+index*stride, pArray.data+(index+1)*stride, size_t(pArray.size-uint64_t(index)-1)*size_t(stride) );
+        array_resize(*context, pArray, pArray.size-1, stride, false, at);
+    }
+
+    void builtin_array_erase_range_i64 ( Array & pArray, int64_t index, int64_t count, int stride, Context * context, LineInfoArg * at ) {
+        if ( index < 0 || count < 0 || uint64_t(index + count) > pArray.size ) {
+            context->throw_error_at(at, "erasing array range is invalid: index=%lld count=%lld size=%llu", (long long)index, (long long)count, (unsigned long long)pArray.size);
+            return;
+        }
+        memmove ( pArray.data+index*stride, pArray.data+(index+count)*stride, size_t(pArray.size-uint64_t(index)-uint64_t(count))*size_t(stride) );
         array_resize(*context, pArray, pArray.size-count, stride, false, at);
     }
 
@@ -103,6 +149,12 @@ namespace das {
         addExtern<DAS_BIND_FUN(builtin_array_capacity)>(*this, lib, "capacity",
             SideEffects::none, "builtin_array_capacity")
                 ->arg("array");
+        addExtern<DAS_BIND_FUN(builtin_array_long_size)>(*this, lib, "long_length",
+            SideEffects::none, "builtin_array_long_size")
+                ->arg("array");
+        addExtern<DAS_BIND_FUN(builtin_array_long_capacity)>(*this, lib, "long_capacity",
+            SideEffects::none, "builtin_array_long_capacity")
+                ->arg("array");
         addExtern<DAS_BIND_FUN(builtin_array_lock_count)>(*this, lib, "lock_count",
             SideEffects::none, "builtin_array_lock_count")
                 ->arg("array");
@@ -115,6 +167,15 @@ namespace das {
                 ->args({"array","newSize","stride","context","at"});
         addExtern<DAS_BIND_FUN(builtin_array_reserve)>(*this, lib, "__builtin_array_reserve",
             SideEffects::modifyArgument, "builtin_array_reserve")
+                ->args({"array","newSize","stride","context","at"});
+        addExtern<DAS_BIND_FUN(builtin_array_resize_i64)>(*this, lib, "__builtin_array_resize_i64",
+            SideEffects::modifyArgument, "builtin_array_resize_i64")
+                ->args({"array","newSize","stride","context","at"});
+        addExtern<DAS_BIND_FUN(builtin_array_resize_no_init_i64)>(*this, lib, "__builtin_array_resize_no_init_i64",
+            SideEffects::modifyArgument, "builtin_array_resize_no_init_i64")
+                ->args({"array","newSize","stride","context","at"});
+        addExtern<DAS_BIND_FUN(builtin_array_reserve_i64)>(*this, lib, "__builtin_array_reserve_i64",
+            SideEffects::modifyArgument, "builtin_array_reserve_i64")
                 ->args({"array","newSize","stride","context","at"});
         addExtern<DAS_BIND_FUN(builtin_array_push)>(*this, lib, "__builtin_array_push",
             SideEffects::modifyArgument, "builtin_array_push")
@@ -133,6 +194,12 @@ namespace das {
                 ->args({"array","index","stride","context","at"});
         addExtern<DAS_BIND_FUN(builtin_array_erase_range)>(*this, lib, "__builtin_array_erase_range",
             SideEffects::modifyArgument, "builtin_array_erase_range")
+                ->args({"array","index","count","stride","context","at"});
+        addExtern<DAS_BIND_FUN(builtin_array_erase_i64)>(*this, lib, "__builtin_array_erase_i64",
+            SideEffects::modifyArgument, "builtin_array_erase_i64")
+                ->args({"array","index","stride","context","at"});
+        addExtern<DAS_BIND_FUN(builtin_array_erase_range_i64)>(*this, lib, "__builtin_array_erase_range_i64",
+            SideEffects::modifyArgument, "builtin_array_erase_range_i64")
                 ->args({"array","index","count","stride","context","at"});
         addExtern<DAS_BIND_FUN(builtin_array_lock)>(*this, lib, "__builtin_array_lock",
             SideEffects::modifyArgumentAndExternal, "builtin_array_lock")

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2908,14 +2908,9 @@ namespace das {
             AstSerializerState * state,
             const TBlock<void,TTemporary<TArray<uint8_t> const>> & block,
             Context * context, LineInfoArg * at ) {
-        auto dataSize = state->storage->buffer.size();
-        if ( dataSize > INT32_MAX ) {
-            context->throw_error_at(at, "data size exceeds 2GB limit");
-            return;
-        }
         Array arr;
         array_mark_locked(arr, state->storage->buffer.data(),
-            uint32_t(state->storage->buffer.size()), uint32_t(state->storage->buffer.size()));
+            uint64_t(state->storage->buffer.size()), uint64_t(state->storage->buffer.size()));
         vec4f args[1] = { cast<Array *>::from(&arr) };
         context->invoke(block, args, nullptr, at);
     }

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -318,29 +318,29 @@ namespace debugger {
                 return true;
             }
         }
-        virtual bool canVisitArrayData ( TypeInfo * ti, uint32_t count ) override {
+        virtual bool canVisitArrayData ( TypeInfo * ti, uint64_t count ) override {
             if ( auto fn_canVisitArrayData = get_canVisitArrayData(classPtr) ) {
                 return invoke_canVisitArrayData(context,fn_canVisitArrayData,classPtr,*ti,count);
             } else {
                 return true;
             }
         }
-        virtual void beforeArrayData ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti ) override {
+        virtual void beforeArrayData ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti ) override {
             if ( auto fn_beforeArrayData = get_beforeArrayData(classPtr) ) {
                 invoke_beforeArrayData(context,fn_beforeArrayData,classPtr,pa,stride,count,*ti);
             }
         }
-        virtual void afterArrayData ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti ) override {
+        virtual void afterArrayData ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti ) override {
             if ( auto fn_afterArrayData = get_afterArrayData(classPtr) ) {
                 invoke_afterArrayData(context,fn_afterArrayData,classPtr,pa,stride,count,*ti);
             }
         }
-        virtual void beforeArrayElement ( char * pa, TypeInfo * ti, char * pe, uint32_t index, bool last ) override {
+        virtual void beforeArrayElement ( char * pa, TypeInfo * ti, char * pe, uint64_t index, bool last ) override {
             if ( auto fn_beforeArrayElement = get_beforeArrayElement(classPtr) ) {
                 invoke_beforeArrayElement(context,fn_beforeArrayElement,classPtr,pa,*ti,pe,index,last);
             }
         }
-        virtual void afterArrayElement ( char * pa, TypeInfo * ti, char * pe, uint32_t index, bool last ) override {
+        virtual void afterArrayElement ( char * pa, TypeInfo * ti, char * pe, uint64_t index, bool last ) override {
             if ( auto fn_afterArrayElement = get_afterArrayElement(classPtr) ) {
                 invoke_afterArrayElement(context,fn_afterArrayElement,classPtr,pa,*ti,pe,index,last);
             }
@@ -384,22 +384,22 @@ namespace debugger {
                 invoke_beforeTable(context,fn_beforeTable,classPtr,*pa,*ti);
             }
         }
-        virtual void beforeTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint32_t index, bool last ) override {
+        virtual void beforeTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint64_t index, bool last ) override {
            if ( auto fn_beforeTableKey = get_beforeTableKey(classPtr) ) {
                 invoke_beforeTableKey(context,fn_beforeTableKey,classPtr,*pa,*ti,pk,*ki,index,last);
             }
         }
-        virtual void afterTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint32_t index, bool last ) override {
+        virtual void afterTableKey ( Table * pa, TypeInfo * ti, char * pk, TypeInfo * ki, uint64_t index, bool last ) override {
            if ( auto fn_afterTableKey = get_afterTableKey(classPtr) ) {
                 invoke_afterTableKey(context,fn_afterTableKey,classPtr,*pa,*ti,pk,*ki,index,last);
             }
         }
-        virtual void beforeTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint32_t index, bool last ) override {
+        virtual void beforeTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint64_t index, bool last ) override {
            if ( auto fn_beforeTableValue = get_beforeTableValue(classPtr) ) {
                 invoke_beforeTableValue(context,fn_beforeTableValue,classPtr,*pa,*ti,pv,*kv,index,last);
             }
         }
-        virtual void afterTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint32_t index, bool last ) override {
+        virtual void afterTableValue ( Table * pa, TypeInfo * ti, char * pv, TypeInfo * kv, uint64_t index, bool last ) override {
            if ( auto fn_afterTableValue = get_afterTableValue(classPtr) ) {
                 invoke_afterTableValue(context,fn_afterTableValue,classPtr,*pa,*ti,pv,*kv,index,last);
             }

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -1561,7 +1561,8 @@ namespace das {
         auto key = cast<KeyType>::to(_key);
         TableHash<KeyType> thh(context,valueTypeSize);
         auto hfn = hash_function(*context, key);
-        return thh.find(*tab, key, hfn);
+        // TODO Phase 4: surface as `long_rtti_get_value_pointer` and panic from int form on >INT_MAX.
+        return (int32_t) thh.find(*tab, key, hfn);
     }
 
     int32_t rtti_getTablePtr ( void * _table, vec4f key, Type baseType, int valueTypeSize, Context * context, LineInfoArg * at ) {

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1674,7 +1674,8 @@ namespace das
     }
 
     void builtin_make_temp_array ( Array & arr, void * data, int size ) {
-        array_mark_locked(arr, (char *)data, uint64_t(uint32_t(size)));
+        // Negative size would underflow to huge uint64 — clamp to empty array instead.
+        array_mark_locked(arr, (char *)data, size < 0 ? uint64_t(0) : uint64_t(size));
     }
 
     void builtin_make_temp_array_i64 ( Array & arr, void * data, int64_t size ) {

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -800,11 +800,21 @@ namespace das
     }
 
     int builtin_table_size ( const Table & arr ) {
-        return arr.size;
+        DAS_VERIFYF(arr.size <= uint64_t(INT32_MAX), "table size %llu exceeds INT_MAX; use long_length() instead", (unsigned long long)arr.size);
+        return int(arr.size);
     }
 
     int builtin_table_capacity ( const Table & arr ) {
-        return arr.capacity;
+        DAS_VERIFYF(arr.capacity <= uint64_t(INT32_MAX), "table capacity %llu exceeds INT_MAX; use long_capacity() instead", (unsigned long long)arr.capacity);
+        return int(arr.capacity);
+    }
+
+    int64_t builtin_table_long_size ( const Table & arr ) {
+        return int64_t(arr.size);
+    }
+
+    int64_t builtin_table_long_capacity ( const Table & arr ) {
+        return int64_t(arr.capacity);
     }
 
     void builtin_table_clear ( Table & arr, Context * context, LineInfoArg * at ) {
@@ -823,7 +833,7 @@ namespace das
         Type baseType = call->types[0]->firstType->type;
         uint32_t valueTypeSize = call->types[0]->secondType->size;
         Table & tab = cast<Table&>::to(args[0]);
-        uint32_t newCapacity = cast<uint32_t>::to(args[1]);
+        uint64_t newCapacity = cast<uint64_t>::to(args[1]);
         table_reserve_impl(context, tab, baseType, newCapacity, valueTypeSize, &call->debugInfo);
         return v_zero();
     }
@@ -1214,7 +1224,7 @@ namespace das
     void builtin_array_free ( Array & dim, int szt, Context * __context__, LineInfoArg * at ) {
         if ( dim.data ) {
             if ( !dim.isLocked() || dim.hopeless ) {
-                uint32_t oldSize = dim.capacity*szt;
+                uint64_t oldSize = dim.capacity*uint64_t(szt);
                 __context__->free(dim.data, oldSize, at);
             } else {
                 __context__->throw_error_at(at, "can't delete locked array");
@@ -1231,7 +1241,7 @@ namespace das
     void builtin_table_free ( Table & tab, int szk, int szv, Context * __context__, LineInfoArg * at ) {
         if ( tab.data ) {
             if ( !tab.isLocked() || tab.hopeless ) {
-                uint32_t oldSize = tab.capacity*(szk+szv+sizeof(TableHashKey));
+                uint64_t oldSize = tab.capacity*uint64_t(szk+szv+sizeof(TableHashKey));
                 __context__->free(tab.data, oldSize, at);
             } else {
                 __context__->throw_error_at(at, "can't delete locked table");
@@ -1664,7 +1674,11 @@ namespace das
     }
 
     void builtin_make_temp_array ( Array & arr, void * data, int size ) {
-        array_mark_locked(arr, (char *)data, uint32_t(size));
+        array_mark_locked(arr, (char *)data, uint64_t(uint32_t(size)));
+    }
+
+    void builtin_make_temp_array_i64 ( Array & arr, void * data, int64_t size ) {
+        array_mark_locked(arr, (char *)data, uint64_t(size));
     }
 
     void toLog ( int level, const char * text, Context * context, LineInfoArg * at ) {
@@ -2153,6 +2167,12 @@ namespace das
         addExtern<DAS_BIND_FUN(builtin_table_capacity)>(*this, lib, "capacity",
             SideEffects::none, "builtin_table_capacity")
                 ->arg("table");
+        addExtern<DAS_BIND_FUN(builtin_table_long_size)>(*this, lib, "long_length",
+            SideEffects::none, "builtin_table_long_size")
+                ->arg("table");
+        addExtern<DAS_BIND_FUN(builtin_table_long_capacity)>(*this, lib, "long_capacity",
+            SideEffects::none, "builtin_table_long_capacity")
+                ->arg("table");
         addExtern<DAS_BIND_FUN(builtin_table_lock)>(*this, lib, "__builtin_table_lock",
             SideEffects::modifyArgumentAndExternal, "builtin_table_lock")
                 ->args({"table","context","at"});
@@ -2180,7 +2200,7 @@ namespace das
         addExtern<DAS_BIND_FUN(builtin_table_get_key)>(*this, lib, "__builtin_table_get_key",
             SideEffects::modifyExternal, "builtin_table_get_key")
                 ->args({"result","table","value_ptr","value_stride","key_stride","context","at"});
-        addInterop<builtin_table_reserve,void,vec4f,uint32_t>(*this, lib, "__builtin_table_reserve",
+        addInterop<builtin_table_reserve,void,vec4f,uint64_t>(*this, lib, "__builtin_table_reserve",
             SideEffects::modifyArgumentAndExternal, "builtin_table_reserve")
                 ->args({"table","size"});
         // array and table free
@@ -2355,6 +2375,10 @@ namespace das
             SideEffects::modifyArgument, "builtin_make_temp_array")
                 ->args({"array","data","size"});
         bmta->unsafeOperation = true;
+        auto bmta64 = addExtern<DAS_BIND_FUN(builtin_make_temp_array_i64)>(*this, lib, "_builtin_make_temp_array_i64",
+            SideEffects::modifyArgument, "builtin_make_temp_array_i64")
+                ->args({"array","data","size"});
+        bmta64->unsafeOperation = true;
         // migrate data
         addExtern<DAS_BIND_FUN(das_is_dll_build)>(*this, lib, "das_is_dll_build",
             SideEffects::worstDefault, "das_is_dll_build");

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -810,10 +810,12 @@ namespace das
     }
 
     int64_t builtin_table_long_size ( const Table & arr ) {
+        DAS_VERIFYF(arr.size <= uint64_t(INT64_MAX), "table size %llu exceeds INT64_MAX", (unsigned long long)arr.size);
         return int64_t(arr.size);
     }
 
     int64_t builtin_table_long_capacity ( const Table & arr ) {
+        DAS_VERIFYF(arr.capacity <= uint64_t(INT64_MAX), "table capacity %llu exceeds INT64_MAX", (unsigned long long)arr.capacity);
         return int64_t(arr.capacity);
     }
 
@@ -1667,7 +1669,8 @@ namespace das
 
     void builtin_temp_array ( void * data, int size, const Block & block, Context * context, LineInfoArg * at ) {
         Array arr;
-        array_mark_locked(arr, (char *)data, uint32_t(size));
+        // Negative size would wrap into a huge uint capacity; clamp to empty array instead.
+        array_mark_locked(arr, (char *)data, size < 0 ? uint64_t(0) : uint64_t(size));
         vec4f args[1];
         args[0] = cast<Array &>::from(arr);
         context->invoke(block, args, nullptr, at);

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1678,7 +1678,8 @@ namespace das
     }
 
     void builtin_make_temp_array_i64 ( Array & arr, void * data, int64_t size ) {
-        array_mark_locked(arr, (char *)data, uint64_t(size));
+        // Negative size would underflow to huge uint64 — clamp to empty array instead.
+        array_mark_locked(arr, (char *)data, size < 0 ? uint64_t(0) : uint64_t(size));
     }
 
     void toLog ( int level, const char * text, Context * context, LineInfoArg * at ) {

--- a/src/builtin/module_builtin_runtime_sort.cpp
+++ b/src/builtin/module_builtin_runtime_sort.cpp
@@ -71,10 +71,10 @@ namespace das
 
     // The sort wrappers below pass arr.size (uint64_t) into inner sort functions taking
     // int32_t length. For arrays > INT_MAX elements this would silently truncate and
-    // sort only a prefix. Panic up-front instead; users with huge arrays will need a
-    // future long_sort surface (Phase 4 follow-up).
+    // sort only a prefix. Panic up-front instead; the int-sized sort surface simply
+    // does not support arrays past INT_MAX, and there is no `long_sort` companion yet.
     static __forceinline int32_t sort_array_size_or_panic ( const Array & arr, Context * context, LineInfoArg * at, const char * op ) {
-        if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "%s: array size %llu exceeds INT_MAX; use long_%s() instead", op, (unsigned long long)arr.size, op);
+        if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "%s: array size %llu exceeds INT_MAX; sort is not supported on arrays this large", op, (unsigned long long)arr.size);
         return int32_t(arr.size);
     }
 

--- a/src/builtin/module_builtin_runtime_sort.cpp
+++ b/src/builtin/module_builtin_runtime_sort.cpp
@@ -69,15 +69,26 @@ namespace das
         builtin_sort_any_ref_cblock(anyData, elementSize, length, cmp, context, at);
     }
 
+    // The sort wrappers below pass arr.size (uint64_t) into inner sort functions taking
+    // int32_t length. For arrays > INT_MAX elements this would silently truncate and
+    // sort only a prefix. Panic up-front instead; users with huge arrays will need a
+    // future long_sort surface (Phase 4 follow-up).
+    static __forceinline int32_t sort_array_size_or_panic ( const Array & arr, Context * context, LineInfoArg * at, const char * op ) {
+        if ( arr.size > uint64_t(INT32_MAX) ) context->throw_error_at(at, "%s: array size %llu exceeds INT_MAX; use long_%s() instead", op, (unsigned long long)arr.size, op);
+        return int32_t(arr.size);
+    }
+
     void builtin_sort_array_any_cblock ( Array & arr, int32_t elementSize, int32_t, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "sort");
         array_lock(*context,arr,at);
-        builtin_sort_any_cblock(arr.data, elementSize, arr.size, cmp, context, at);
+        builtin_sort_any_cblock(arr.data, elementSize, len, cmp, context, at);
         array_unlock(*context,arr,at);
     }
 
     void builtin_sort_array_any_ref_cblock ( Array & arr, int32_t elementSize, int32_t, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "sort");
         array_lock(*context,arr,at);
-        builtin_sort_any_ref_cblock(arr.data, elementSize, arr.size, cmp, context, at);
+        builtin_sort_any_ref_cblock(arr.data, elementSize, len, cmp, context, at);
         array_unlock(*context,arr,at);
     }
 
@@ -151,13 +162,15 @@ namespace das
         builtin_partial_sort_any_ref_cblock(cast<void *>::to(anything), elementSize, length, n, cmp, context, at);
     }
     void builtin_partial_sort_array_any_cblock ( Array & arr, int32_t elementSize, int32_t, int32_t n, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "partial_sort");
         array_lock(*context, arr, at);
-        builtin_partial_sort_any_cblock(arr.data, elementSize, arr.size, n, cmp, context, at);
+        builtin_partial_sort_any_cblock(arr.data, elementSize, len, n, cmp, context, at);
         array_unlock(*context, arr, at);
     }
     void builtin_partial_sort_array_any_ref_cblock ( Array & arr, int32_t elementSize, int32_t, int32_t n, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "partial_sort");
         array_lock(*context, arr, at);
-        builtin_partial_sort_any_ref_cblock(arr.data, elementSize, arr.size, n, cmp, context, at);
+        builtin_partial_sort_any_ref_cblock(arr.data, elementSize, len, n, cmp, context, at);
         array_unlock(*context, arr, at);
     }
 
@@ -212,13 +225,15 @@ namespace das
         builtin_nth_element_any_ref_cblock(cast<void *>::to(anything), elementSize, length, n, cmp, context, at);
     }
     void builtin_nth_element_array_any_cblock ( Array & arr, int32_t elementSize, int32_t, int32_t n, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "nth_element");
         array_lock(*context, arr, at);
-        builtin_nth_element_any_cblock(arr.data, elementSize, arr.size, n, cmp, context, at);
+        builtin_nth_element_any_cblock(arr.data, elementSize, len, n, cmp, context, at);
         array_unlock(*context, arr, at);
     }
     void builtin_nth_element_array_any_ref_cblock ( Array & arr, int32_t elementSize, int32_t, int32_t n, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "nth_element");
         array_lock(*context, arr, at);
-        builtin_nth_element_any_ref_cblock(arr.data, elementSize, arr.size, n, cmp, context, at);
+        builtin_nth_element_any_ref_cblock(arr.data, elementSize, len, n, cmp, context, at);
         array_unlock(*context, arr, at);
     }
 

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -635,7 +635,8 @@ extern "C" {
         if ( tab->isLocked() ) context->throw_error_at(at, "can't insert to a locked table");
         TableHash<KeyType> thh(context,valueTypeSize);
         auto hfn = hash_function(*context, key);
-        return thh.reserve(*tab, key, hfn, at);
+        // TODO Phase 7: widen JIT helper return to int64_t — for now this narrows for tables > INT_MAX.
+        return (int32_t) thh.reserve(*tab, key, hfn, at);
     }
 
     void * das_get_jit_table_at ( int32_t baseType, Context * context, LineInfoArg * at ) {
@@ -658,7 +659,8 @@ extern "C" {
     int32_t jit_table_find ( Table * tab, KeyType key, int32_t valueTypeSize, Context * context ) {
         TableHash<KeyType> thh(context,valueTypeSize);
         auto hfn = hash_function(*context, key);
-        return thh.find(*tab, key, hfn);
+        // TODO Phase 7: widen JIT helper return to int64_t — for now this narrows for tables > INT_MAX.
+        return (int32_t) thh.find(*tab, key, hfn);
     }
 
     void * das_get_jit_table_find ( int32_t baseType, Context * context, LineInfoArg * at ) {

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -635,8 +635,11 @@ extern "C" {
         if ( tab->isLocked() ) context->throw_error_at(at, "can't insert to a locked table");
         TableHash<KeyType> thh(context,valueTypeSize);
         auto hfn = hash_function(*context, key);
-        // TODO Phase 7: widen JIT helper return to int64_t — for now this narrows for tables > INT_MAX.
-        return (int32_t) thh.reserve(*tab, key, hfn, at);
+        int64_t idx = thh.reserve(*tab, key, hfn, at);
+        // TODO Phase 7: widen JIT helper return to int64_t. Until then, guard the narrowing
+        // so JIT-emitted code never gets a wrapped-negative slot index for huge tables.
+        if ( idx > int64_t(INT32_MAX) ) context->throw_error_at(at, "JIT table slot index %lld exceeds INT32_MAX; JIT does not yet support tables past INT_MAX slots", (long long)idx);
+        return (int32_t) idx;
     }
 
     void * das_get_jit_table_at ( int32_t baseType, Context * context, LineInfoArg * at ) {
@@ -659,8 +662,11 @@ extern "C" {
     int32_t jit_table_find ( Table * tab, KeyType key, int32_t valueTypeSize, Context * context ) {
         TableHash<KeyType> thh(context,valueTypeSize);
         auto hfn = hash_function(*context, key);
-        // TODO Phase 7: widen JIT helper return to int64_t — for now this narrows for tables > INT_MAX.
-        return (int32_t) thh.find(*tab, key, hfn);
+        int64_t idx = thh.find(*tab, key, hfn);
+        // TODO Phase 7: widen JIT helper return to int64_t. Until then, guard the narrowing
+        // so JIT-emitted code never gets a wrapped-negative slot index for huge tables.
+        if ( idx > int64_t(INT32_MAX) ) context->throw_error("JIT table slot index exceeds INT32_MAX; JIT does not yet support tables past INT_MAX slots");
+        return (int32_t) idx;
     }
 
     void * das_get_jit_table_find ( int32_t baseType, Context * context, LineInfoArg * at ) {

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -1230,7 +1230,7 @@ void das_table_clear ( das_context * context, das_table * tab, int key_base_type
         uint32_t key_size = 0;
         DAS_TABLE_DISPATCH(key_base_type, { key_size = sizeof(KEY_TYPE); })
         if ( !key_size ) return; // throw_error already raised
-        uint32_t total = t->capacity * (value_size + key_size + uint32_t(sizeof(TableHashKey)));
+        uint64_t total = t->capacity * (uint64_t(value_size) + uint64_t(key_size) + uint64_t(sizeof(TableHashKey)));
         ((Context *)context)->free(t->data, total, nullptr);
     }
     memset(t, 0, sizeof(Table));

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -1248,8 +1248,8 @@ void * das_table_find ( das_context * context, das_table * tab, int key_base_typ
         memcpy(&k, key, sizeof(KEY_TYPE));
         uint64_t h = hash_function(*(Context *)context, k);
         TableHash<KEY_TYPE> hh((Context *)context, value_size);
-        int idx = hh.find(*t, k, h);
-        if ( idx >= 0 ) result = t->data + size_t(idx) * size_t(value_size);
+        int64_t idx = hh.find(*t, k, h);
+        if ( idx >= 0 ) result = t->data + uint64_t(idx) * uint64_t(value_size);
     })
     return result;
 }
@@ -1262,8 +1262,8 @@ void * das_table_insert ( das_context * context, das_table * tab, int key_base_t
         memcpy(&k, key, sizeof(KEY_TYPE));
         uint64_t h = hash_function(*(Context *)context, k);
         TableHash<KEY_TYPE> hh((Context *)context, value_size);
-        int idx = hh.reserve(*t, k, h, nullptr);
-        if ( idx >= 0 ) result = t->data + size_t(idx) * size_t(value_size);
+        int64_t idx = hh.reserve(*t, k, h, nullptr);
+        if ( idx >= 0 ) result = t->data + uint64_t(idx) * uint64_t(value_size);
     })
     return result;
 }
@@ -1276,7 +1276,7 @@ int das_table_erase ( das_context * context, das_table * tab, int key_base_type,
         memcpy(&k, key, sizeof(KEY_TYPE));
         uint64_t h = hash_function(*(Context *)context, k);
         TableHash<KEY_TYPE> hh((Context *)context, value_size);
-        int idx = hh.erase(*t, k, h);
+        int64_t idx = hh.erase(*t, k, h);
         if ( idx >= 0 ) erased = 1;
     })
     return erased;

--- a/src/misc/memory_model.cpp
+++ b/src/misc/memory_model.cpp
@@ -109,7 +109,11 @@ namespace das {
             if ( !initialSize ) {
                 initialSize = default_initial_size;
             }
-            return initialSize / ((si+1)<<4); // fit in initial size
+            // Shoe per-chunk byte total is 32-bit bounded (max 256B per element,
+            // total chunk size capped). If initialSize > UINT32_MAX*divisor (>68GB),
+            // clamp so the shoe still gets a workable chunk size.
+            uint64_t per = initialSize / ((uint64_t(si)+1)<<4);
+            return per > uint64_t(UINT32_MAX) ? UINT32_MAX : uint32_t(per);
         }
     }
 

--- a/src/simulate/bin_serializer.cpp
+++ b/src/simulate/bin_serializer.cpp
@@ -110,7 +110,7 @@ namespace das {
         virtual void beforeArray ( Array * pa, TypeInfo * ti ) override {
             verify_hash(ti->hash);
             if ( reading ) {
-                uint32_t newSize = 0;
+                uint64_t newSize = 0;
                 load(newSize);
                 array_clear(*context, *pa, /*at*/nullptr);
                 array_resize(*context, *pa, newSize, getTypeBaseSize(ti), true, /*at*/nullptr);
@@ -305,7 +305,7 @@ namespace das {
     }
 
     // load ( obj, bytesAt )
-    void _builtin_binary_load ( Context & context, LineInfo * at, TypeInfo* info, const char *data, uint32_t len, char *to) {
+    void _builtin_binary_load ( Context & context, LineInfo * at, TypeInfo* info, const char *data, uint64_t len, char *to) {
         if ( !(info->flags&(TypeInfo::flag_refType | TypeInfo::flag_ref)) )
             return;
         BinDataSerialize reader(context, at, const_cast<char*>(data), len);

--- a/src/simulate/data_walker.cpp
+++ b/src/simulate/data_walker.cpp
@@ -100,13 +100,13 @@ namespace das {
         }
     }
 
-    void DataWalker::walk_array ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti ) {
+    void DataWalker::walk_array ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti ) {
         if ( !canVisitArrayData(ti,count) ) return;
         char * pe = pa;
         beforeArrayData(pa, stride, count, ti);
         if ( cancel() ) return;
-        for ( uint32_t i=0; i!=count; ++i ) {
-            bool last = i==count-1;
+        for ( uint64_t i=0, ic=count; i!=ic; ++i ) {
+            bool last = i==ic-1;
             beforeArrayElement(pa, ti, pe, i, last);
             if ( cancel() ) return;
             walk(pe, ti);
@@ -141,8 +141,8 @@ namespace das {
         if ( !canVisitTableData(info) ) return;
         int keySize = info->firstType->size;
         int valueSize = info->secondType->size;
-        uint32_t count = 0;
-        for ( uint32_t i=0, is=tab->capacity; i!=is; ++i ) {
+        uint64_t count = 0;
+        for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
             if ( tab->hashes[i] > HASH_KILLED64 ) {
                 bool last = (count == (tab->size-1));
                 // key

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -138,25 +138,25 @@ namespace das {
         virtual void afterVariant ( char *, TypeInfo * ) override {
             ss << "}";
         }
-        virtual void beforeArrayData ( char *, uint32_t, uint32_t, TypeInfo * ) override {
+        virtual void beforeArrayData ( char *, uint32_t, uint64_t, TypeInfo * ) override {
             ss << "[";
         }
-        virtual void afterArrayData ( char *, uint32_t, uint32_t, TypeInfo * ) override {
+        virtual void afterArrayData ( char *, uint32_t, uint64_t, TypeInfo * ) override {
             ss << "]";
         }
-        virtual void afterArrayElement ( char *, TypeInfo *, char *, uint32_t, bool last ) override {
+        virtual void afterArrayElement ( char *, TypeInfo *, char *, uint64_t, bool last ) override {
             if ( !last ) ss << ",";
         }
         virtual void beforeTable ( Table *, TypeInfo * ) override {
             ss << "{";
         }
-        virtual void beforeTableKey ( Table *, TypeInfo *, char *, TypeInfo * ki, uint32_t, bool ) override {
+        virtual void beforeTableKey ( Table *, TypeInfo *, char *, TypeInfo * ki, uint64_t, bool ) override {
             if ( ki->type!=Type::tString ) ss << "\"";
         }
-        virtual void afterTableKey ( Table *, TypeInfo *, char *, TypeInfo * ki, uint32_t, bool ) override {
+        virtual void afterTableKey ( Table *, TypeInfo *, char *, TypeInfo * ki, uint64_t, bool ) override {
             if ( ki->type!=Type::tString ) ss << "\":"; else ss << ":";
         }
-        virtual void afterTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool last ) override {
+        virtual void afterTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool last ) override {
             if ( !last ) ss << ",";
         }
         virtual void afterTable ( Table *, TypeInfo * ) override {

--- a/src/simulate/json_scan.cpp
+++ b/src/simulate/json_scan.cpp
@@ -614,7 +614,7 @@ namespace das {
 
         // Reserve a key in the table and return the index
         template <typename KeyT>
-        int tableReserve(Table * tab, const KeyT & key, uint32_t valueTypeSize) {
+        int64_t tableReserve(Table * tab, const KeyT & key, uint32_t valueTypeSize) {
             auto hfn = hash_function(ctx, key);
             TableHash<KeyT> thh(&ctx, valueTypeSize);
             return thh.reserve(*tab, key, hfn, at);
@@ -623,7 +623,7 @@ namespace das {
         // Parse key from string and reserve in table (for compound key types)
         template <typename KeyT>
         bool scanKeyAndReserve(Table * tab, const string & keyStr, TypeInfo * keyTi,
-                               uint32_t valueTypeSize, int & index) {
+                               uint32_t valueTypeSize, int64_t & index) {
             KeyT key;
             memset(&key, 0, sizeof(key));
             if (!scanFromStr(keyStr, (char*)&key, keyTi)) return false;
@@ -647,7 +647,7 @@ namespace das {
                 if (!readString(keyStr)) return false;
                 if (!expect(':')) return false;
                 // insert key into table based on key type
-                int index = -1;
+                int64_t index = -1;
                 bool keyOk = true;
                 switch (ti->firstType->type) {
                     // string key

--- a/src/simulate/json_scan.cpp
+++ b/src/simulate/json_scan.cpp
@@ -461,7 +461,7 @@ namespace das {
             if (peek() == ']') { cur++; return true; }
             while (true) {
                 // grow array by one, zero-initialized
-                uint32_t idx = builtin_array_push_back_zero(*arr, stride, &ctx, (LineInfoArg*)at);
+                uint64_t idx = uint64_t(builtin_array_push_back_zero(*arr, stride, &ctx, (LineInfoArg*)at));
                 char * elem = arr->data + idx * stride;
                 if (!scanValue(elem, elemTi)) return false;
                 skipWS();

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -98,6 +98,9 @@ namespace das
         if ( newSize > arr.capacity ) {
             uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
             newCapacity = das::max(newCapacity, uint64_t(16));
+            // The pow2 round-up overflows past INT64_MAX when newSize > 2^62; clamp so the
+            // resulting capacity stays representable in the int64 long_capacity() surface.
+            if ( newCapacity > uint64_t(INT64_MAX) ) newCapacity = uint64_t(INT64_MAX);
             array_reserve(context, arr, newCapacity, stride, at);
         }
         if ( zero && newSize>arr.size ) {

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -9,14 +9,14 @@ namespace das
         arr.size = 0;
     }
 
-    void array_mark_locked ( Array & arr, void * data, uint32_t capacity ) {
+    void array_mark_locked ( Array & arr, void * data, uint64_t capacity ) {
         arr.data = (char *)data;
         arr.size = arr.capacity = capacity;
         arr.lock = 1;
         arr.magic = DAS_ARRAY_MAGIC;
     }
 
-    void array_mark_locked ( Array & arr, void * data, uint32_t size, uint32_t capacity ) {
+    void array_mark_locked ( Array & arr, void * data, uint64_t size, uint64_t capacity ) {
         arr.data = (char *)data;
         arr.size = size;
         arr.capacity = capacity;
@@ -57,22 +57,27 @@ namespace das
         }
     }
 
-    void array_reserve(Context & context, Array & arr, uint32_t newCapacity, uint32_t stride, LineInfo * at) {
+    void array_reserve(Context & context, Array & arr, uint64_t newCapacity, uint32_t stride, LineInfo * at) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't change capacity of a locked array");
         if ( arr.capacity >= newCapacity ) return;
-        uint64_t memSize64 = uint64_t(newCapacity) * uint64_t(stride);
-        if ( memSize64>=0xffffffff ) {
-            context.throw_error_at(at, "can't grow array, out of index space [capacity=%i] [stride=%i]", newCapacity, stride);
+        // Explicit mul_overflow guard: stride is uint32, newCapacity is uint64.
+        // The product can overflow uint64 when newCapacity > UINT64_MAX / stride
+        // (with stride > 0). Panic before passing a wrap-around byte count to
+        // the heap allocator (where it would silently allocate a small block
+        // and the next memcpy would overrun random memory).
+        if ( stride && newCapacity > UINT64_MAX / uint64_t(stride) ) {
+            context.throw_error_at(at, "array_reserve: capacity*stride overflows uint64 [capacity=%llu] [stride=%u]", (unsigned long long)newCapacity, stride);
         }
+        uint64_t memSize64 = newCapacity * uint64_t(stride);
         const char * prev_comment = arr.data ? context.heap->get_comment(arr.data) : nullptr;
         char * newData = nullptr;
         if ( context.verySafeContext ) {
-            newData = (char *)context.allocate(newCapacity*stride, at);
+            newData = (char *)context.allocate(memSize64, at);
             if ( newData && arr.data ) {
                 memcpy(newData, arr.data, arr.size*stride);
             }
         } else {
-            newData = (char *)context.reallocate(arr.data, arr.capacity*stride, newCapacity*stride, at);
+            newData = (char *)context.reallocate(arr.data, arr.capacity*stride, memSize64, at);
         }
         context.heap->mark_comment(newData, prev_comment ? prev_comment : "array");
         if ( newData != arr.data ) {
@@ -82,11 +87,17 @@ namespace das
         arr.capacity = newCapacity;
     }
 
-    void array_resize ( Context & context, Array & arr, uint32_t newSize, uint32_t stride, bool zero, LineInfo * at ) {
+    void array_resize ( Context & context, Array & arr, uint64_t newSize, uint32_t stride, bool zero, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't resize locked array");
         if ( newSize > arr.capacity ) {
-            uint32_t newCapacity = 1 << (32 - das_clz (das::max(newSize,2u) - 1));
-            newCapacity = das::max(newCapacity, 16u);
+            // capacity must be a power of two and >= newSize. A request for
+            // > 2^63 would shift past the type width (UB), and the resulting
+            // byte count would also blow past the heap; panic early.
+            if ( newSize > (uint64_t(1) << 63) ) {
+                context.throw_error_at(at, "array_resize: newSize exceeds 2^63 [newSize=%llu]", (unsigned long long)newSize);
+            }
+            uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
+            newCapacity = das::max(newCapacity, uint64_t(16));
             array_reserve(context, arr, newCapacity, stride, at);
         }
         if ( zero && newSize>arr.size ) {
@@ -173,7 +184,7 @@ namespace das
         for ( uint32_t i=0, is=total; i!=is; ++i, pArray-- ) {
             if ( pArray->data ) {
                 if ( !pArray->isLocked() ) {
-                    uint32_t oldSize = pArray->capacity*stride;
+                    uint64_t oldSize = pArray->capacity * uint64_t(stride);
                     context.free(pArray->data, oldSize, &debugInfo);
                 } else {
                     context.throw_error_at(debugInfo, "deleting locked array%s", errorMessage);

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -89,13 +89,13 @@ namespace das
 
     void array_resize ( Context & context, Array & arr, uint64_t newSize, uint32_t stride, bool zero, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't resize locked array");
+        // The daslang surface contract is `long_length(arr) : int64`, so a size that doesn't
+        // fit in int64_t would wrap negative on the way out. Enforce the cap up front so the
+        // int64 API stays well-defined.
+        if ( newSize > uint64_t(INT64_MAX) ) {
+            context.throw_error_at(at, "array_resize: newSize exceeds INT64_MAX [newSize=%llu]", (unsigned long long)newSize);
+        }
         if ( newSize > arr.capacity ) {
-            // capacity must be a power of two and >= newSize. A request for
-            // > 2^63 would shift past the type width (UB), and the resulting
-            // byte count would also blow past the heap; panic early.
-            if ( newSize > (uint64_t(1) << 63) ) {
-                context.throw_error_at(at, "array_resize: newSize exceeds 2^63 [newSize=%llu]", (unsigned long long)newSize);
-            }
             uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
             newCapacity = das::max(newCapacity, uint64_t(16));
             array_reserve(context, arr, newCapacity, stride, at);

--- a/src/simulate/runtime_table.cpp
+++ b/src/simulate/runtime_table.cpp
@@ -6,12 +6,12 @@
 namespace das
 {
     template <typename KeyType>
-    void table_reserve_internal ( Context & context, Table & arr, uint32_t newCapacity, uint32_t valueTypeSize, LineInfo * at ) {
+    void table_reserve_internal ( Context & context, Table & arr, uint64_t newCapacity, uint32_t valueTypeSize, LineInfo * at ) {
         TableHash<KeyType> hash(&context, valueTypeSize);
         hash.reserve(arr, newCapacity, at);
     }
 
-    void table_reserve_impl ( Context & context, Table & arr, int32_t baseType, uint32_t newCapacity, uint32_t valueTypeSize, LineInfo * at ) {
+    void table_reserve_impl ( Context & context, Table & arr, int32_t baseType, uint64_t newCapacity, uint32_t valueTypeSize, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't reserve locked table");
         if ( !newCapacity ) return;
         switch ( Type(baseType) ) {
@@ -228,7 +228,7 @@ namespace das
         for ( uint32_t i=0, is=total; i!=is; ++i, pTable-- ) {
             if ( pTable->data ) {
                 if ( !pTable->isLocked() ) {
-                    uint32_t oldSize = pTable->capacity*(vts_add_kts + sizeof(TableHashKey));
+                    uint64_t oldSize = pTable->capacity * uint64_t(vts_add_kts + sizeof(TableHashKey));
                     context.free(pTable->data, oldSize, &debugInfo);
                 } else {
                     context.throw_error_at(debugInfo, "deleting locked table%s", errorMessage);

--- a/src/simulate/simulate_fusion_at_array.cpp
+++ b/src/simulate/simulate_fusion_at_array.cpp
@@ -44,7 +44,7 @@ namespace das {
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
-            return *((CTYPE *)(pl->data + rr*stride + offset)); \
+            return *((CTYPE *)(pl->data + uint64_t(rr)*uint64_t(stride) + offset)); \
         } \
         DAS_NODE(TYPE,CTYPE); \
     };
@@ -56,7 +56,7 @@ namespace das {
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
-            return *((CTYPE *)(pl->data + rr*stride + offset)); \
+            return *((CTYPE *)(pl->data + uint64_t(rr)*uint64_t(stride) + offset)); \
         } \
         DAS_NODE(TYPE,CTYPE); \
     };
@@ -86,7 +86,7 @@ namespace das {
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             vec4f __r; \
-            DAS_LDU_WORKHORSE(__r, pl->data + rr*stride + offset, CTYPE); \
+            DAS_LDU_WORKHORSE(__r, pl->data + uint64_t(rr)*uint64_t(stride) + offset, CTYPE); \
             return __r; \
         } \
     };
@@ -100,7 +100,7 @@ namespace das {
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             vec4f __r; \
-            DAS_LDU_WORKHORSE(__r, pl->data + rr*stride + offset, CTYPE); \
+            DAS_LDU_WORKHORSE(__r, pl->data + uint64_t(rr)*uint64_t(stride) + offset, CTYPE); \
             return __r; \
         } \
     };
@@ -120,7 +120,7 @@ namespace das {
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
-            return pl->data + rr*stride + offset; \
+            return pl->data + uint64_t(rr)*uint64_t(stride) + offset; \
         } \
         DAS_PTR_NODE; \
     };
@@ -133,7 +133,7 @@ namespace das {
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
             if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
-            return pl->data + rr*stride + offset; \
+            return pl->data + uint64_t(rr)*uint64_t(stride) + offset; \
         } \
         DAS_PTR_NODE; \
     };

--- a/src/simulate/simulate_fusion_at_array.cpp
+++ b/src/simulate/simulate_fusion_at_array.cpp
@@ -43,7 +43,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
-            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
+            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             return *((CTYPE *)(pl->data + rr*stride + offset)); \
         } \
         DAS_NODE(TYPE,CTYPE); \
@@ -55,7 +55,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
-            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
+            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             return *((CTYPE *)(pl->data + rr*stride + offset)); \
         } \
         DAS_NODE(TYPE,CTYPE); \
@@ -84,7 +84,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
-            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
+            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             vec4f __r; \
             DAS_LDU_WORKHORSE(__r, pl->data + rr*stride + offset, CTYPE); \
             return __r; \
@@ -98,7 +98,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
-            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
+            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             vec4f __r; \
             DAS_LDU_WORKHORSE(__r, pl->data + rr*stride + offset, CTYPE); \
             return __r; \
@@ -119,7 +119,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = uint32_t(r.subexpr->evalInt(context)); \
-            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
+            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             return pl->data + rr*stride + offset; \
         } \
         DAS_PTR_NODE; \
@@ -132,7 +132,7 @@ namespace das {
             DAS_PROFILE_NODE \
             auto pl = (Array *) l.compute##COMPUTEL(context); \
             auto rr = *((uint32_t *)r.compute##COMPUTER(context)); \
-            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %u", rr, pl->size); \
+            if ( rr >= pl->size ) context.throw_error_at(debugInfo,"array index out of range, %u of %llu", rr, (unsigned long long)pl->size); \
             return pl->data + rr*stride + offset; \
         } \
         DAS_PTR_NODE; \

--- a/src/simulate/simulate_fusion_tableindex.cpp
+++ b/src/simulate/simulate_fusion_tableindex.cpp
@@ -45,7 +45,7 @@ namespace das {
             auto key = EvalTT<CTYPE>::eval(context,r.subexpr); \
             TableHash<CTYPE> thh(&context,valueTypeSize); \
             auto hfn = hash_function(context, key); \
-            int index = thh.reserve(*tab, key, hfn, &debugInfo); \
+            int64_t index = thh.reserve(*tab, key, hfn, &debugInfo); \
             return tab->data + index * valueTypeSize + offset; \
         } \
         DAS_PTR_NODE; \
@@ -60,7 +60,7 @@ namespace das {
             auto key = *((CTYPE *)r.compute##COMPUTER(context)); \
             TableHash<CTYPE> thh(&context,valueTypeSize); \
             auto hfn = hash_function(context, key); \
-            int index = thh.reserve(*tab, key, hfn, &debugInfo); \
+            int64_t index = thh.reserve(*tab, key, hfn, &debugInfo); \
             return tab->data + index * valueTypeSize + offset; \
         } \
         DAS_PTR_NODE; \

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -45,7 +45,7 @@ namespace das
             return ti->flags & gcFlags;
         }
 
-        virtual bool canVisitArrayData ( TypeInfo * ti, uint32_t ) override {
+        virtual bool canVisitArrayData ( TypeInfo * ti, uint64_t ) override {
             return ti->flags & gcFlags;
         }
         virtual bool canVisitTableData ( TypeInfo * ti ) override {
@@ -97,10 +97,10 @@ namespace das
             afterVariant(ps, ti);
         }
 
-        virtual void walk_array ( char * pa, uint32_t stride, uint32_t count, TypeInfo * ti ) override {
+        virtual void walk_array ( char * pa, uint32_t stride, uint64_t count, TypeInfo * ti ) override {
             if ( !canVisitArrayData(ti,count) ) return;
             char * pe = pa;
-            for ( uint32_t i=0; i!=count; ++i ) {
+            for ( uint64_t i=0; i!=count; ++i ) {
                 walk(pe, ti);
                 pe += stride;
             }
@@ -133,7 +133,7 @@ namespace das
             int valueSize = info->secondType->size;
             if (info->firstType->flags & gcFlags) {
                 if (info->secondType->flags & gcFlags) {
-                    for ( uint32_t i=0, is=tab->capacity; i!=is; ++i ) {
+                    for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
                         if ( tab->hashes[i] > HASH_KILLED64 ) {
                             // key
                             char * key = tab->keys + i*keySize;
@@ -144,7 +144,7 @@ namespace das
                         }
                     }
                 } else {
-                    for ( uint32_t i=0, is=tab->capacity; i!=is; ++i ) {
+                    for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
                         if ( tab->hashes[i] > HASH_KILLED64 ) {
                             // key
                             char * key = tab->keys + i*keySize;
@@ -153,7 +153,7 @@ namespace das
                     }
                 }
             } else {
-                for ( uint32_t i=0, is=tab->capacity; i!=is; ++i ) {
+                for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
                     if ( tab->hashes[i] > HASH_KILLED64 ) {
                         // value
                         char * value = tab->data + i*valueSize;
@@ -367,7 +367,7 @@ namespace das
         virtual void afterDim ( char *, TypeInfo * ) override {
             popRange();
         }
-        virtual bool canVisitArrayData ( TypeInfo * ti, uint32_t ) override {
+        virtual bool canVisitArrayData ( TypeInfo * ti, uint64_t ) override {
             return (ti->flags | gcAlways) & gcFlags;
         }
         virtual bool canVisitTableData ( TypeInfo * ti ) override {
@@ -379,7 +379,7 @@ namespace das
             char * pa = PA->data;
             PtrRange rdata(pa, tsize);
             if ( reportHeap && tsize && markRange(rdata) ) {
-                if ( describe_ptr(pa, tsize) ) {
+                if ( describe_ptr(pa, int(tsize)) ) {
                     describeInfo(ti);
                     ReportHistory();
                     tp << "ARRAY " << getTypeInfoMangledName(ti) << "\n";
@@ -489,25 +489,25 @@ namespace das
         virtual void afterTupleEntry ( char *, TypeInfo *, char *, int, bool ) override {
             history.pop_back();
         }
-        virtual void beforeArrayElement ( char *, TypeInfo *, char *, uint32_t index, bool ) override {
+        virtual void beforeArrayElement ( char *, TypeInfo *, char *, uint64_t index, bool ) override {
             history.push_back("["+to_string(index)+"]");
         }
-        virtual void afterArrayElement ( char *, TypeInfo *, char *, uint32_t, bool ) override {
+        virtual void afterArrayElement ( char *, TypeInfo *, char *, uint64_t, bool ) override {
             history.pop_back();
         }
-        virtual void beforeTableKey ( Table *, TypeInfo *, char * pk, TypeInfo * ki, uint32_t, bool ) override {
+        virtual void beforeTableKey ( Table *, TypeInfo *, char * pk, TypeInfo * ki, uint64_t, bool ) override {
             string keyText = debug_value ( pk, ki, PrintFlags::none );
             keys.push_back(keyText);
             history.push_back("=>key=>");
         }
-        virtual void afterTableKey ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool ) override {
+        virtual void afterTableKey ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool ) override {
             history.pop_back();
         }
-        virtual void beforeTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool ) override {
+        virtual void beforeTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool ) override {
             string keyText = keys.back();
             history.push_back("[\""+escapeString(keyText)+"\"]");
         }
-        virtual void afterTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint32_t, bool ) override {
+        virtual void afterTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool ) override {
             keys.pop_back();
             history.pop_back();
         }
@@ -598,8 +598,8 @@ namespace das
             if ( !canVisitTableData(info) ) return;
             int keySize = info->firstType->size;
             int valueSize = info->secondType->size;
-            uint32_t count = 0;
-            for ( uint32_t i=0, is=tab->capacity; i!=is; ++i ) {
+            uint64_t count = 0;
+            for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
                 if ( tab->hashes[i] > HASH_KILLED64 ) {
                     bool last = (count == (tab->size-1));
                     // key
@@ -1080,7 +1080,7 @@ namespace das
         virtual bool canVisitPointer ( TypeInfo * ) override { return false; }
         virtual bool canVisitLambda ( TypeInfo * ) override { return false; }
         virtual bool canVisitIterator ( TypeInfo * ) override { return true; }
-        virtual bool canVisitArrayData ( TypeInfo * ti, uint32_t ) override {
+        virtual bool canVisitArrayData ( TypeInfo * ti, uint64_t ) override {
             return ti->flags & gcFlags;
         }
         virtual bool canVisitTableData ( TypeInfo * ti ) override {
@@ -1089,7 +1089,7 @@ namespace das
         virtual void afterArray ( Array * pa, TypeInfo * ti ) override {
             if ( pa->data ) {
                 if ( !pa->isLocked() || pa->hopeless ) {
-                    uint32_t oldSize = pa->capacity*ti->firstType->size;
+                    uint64_t oldSize = pa->capacity*ti->firstType->size;
                     __context__->free(pa->data, oldSize, __at__);
                 } else {
                     __context__->throw_error_at(__at__, "can't delete locked array");
@@ -1105,7 +1105,7 @@ namespace das
         virtual void afterTable ( Table * pa, TypeInfo * ti ) override {
             if ( pa->data ) {
                 if ( !pa->isLocked() || pa->hopeless ) {
-                    uint32_t oldSize = pa->capacity*(ti->firstType->size+ti->secondType->size+sizeof(TableHashKey));
+                    uint64_t oldSize = pa->capacity*(ti->firstType->size+ti->secondType->size+sizeof(TableHashKey));
                     __context__->free(pa->data, oldSize, __at__);
                 } else {
                     __context__->throw_error_at(__at__, "can't delete locked table");

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -270,8 +270,8 @@ namespace das
             currentRange = ptrRangeStack.back();
             ptrRangeStack.pop_back();
         }
-        bool describe_ptr ( char * pa, int tsize, bool isHandle = false ) {
-            auto ssize = (tsize+15) & ~15;
+        bool describe_ptr ( char * pa, uint64_t tsize, bool isHandle = false ) {
+            auto ssize = (tsize + uint64_t(15)) & ~uint64_t(15);
             bool show = !errorsOnly;
             if ( context->stack.is_stack_ptr(pa) ) {
                 if ( show ) tp << "\tSTACK";
@@ -379,7 +379,7 @@ namespace das
             char * pa = PA->data;
             PtrRange rdata(pa, tsize);
             if ( reportHeap && tsize && markRange(rdata) ) {
-                if ( describe_ptr(pa, int(tsize)) ) {
+                if ( describe_ptr(pa, tsize) ) {
                     describeInfo(ti);
                     ReportHistory();
                     tp << "ARRAY " << getTypeInfoMangledName(ti) << "\n";
@@ -396,7 +396,7 @@ namespace das
             char * pa = PT->data;
             PtrRange rdata(pa, tsize);
             if ( reportHeap && tsize && markRange(rdata) ) {
-                if ( describe_ptr(pa, int(tsize)) ) {
+                if ( describe_ptr(pa, tsize) ) {
                     describeInfo(ti);
                     ReportHistory();
                     tp << "TABLE " << getTypeInfoMangledName(ti) << "\n";

--- a/src/simulate/simulate_visit.cpp
+++ b/src/simulate/simulate_visit.cpp
@@ -1032,9 +1032,49 @@ namespace das {
         V_END();
     }
 
+    SimNode * SimNode_ArrayAt_I64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(ArrayAt_I64);
+        V_SUB(l);
+        V_SUB(r);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_END();
+    }
+
+    SimNode * SimNode_ArrayAt_U64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(ArrayAt_U64);
+        V_SUB(l);
+        V_SUB(r);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_END();
+    }
+
     SimNode * SimNode_SafeArrayAt::visit ( SimVisitor & vis ) {
         V_BEGIN();
         V_OP(SafeArrayAt);
+        V_SUB(l);
+        V_SUB(r);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_END();
+    }
+
+    SimNode * SimNode_SafeArrayAt_I64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(SafeArrayAt_I64);
+        V_SUB(l);
+        V_SUB(r);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_END();
+    }
+
+    SimNode * SimNode_SafeArrayAt_U64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(SafeArrayAt_U64);
         V_SUB(l);
         V_SUB(r);
         V_ARG(stride);

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -104,6 +104,9 @@ SET(AOT_DECS_MODULE_FILES
     tests/decs/test_stages_extra.das
 )
 
+# AOT for long_array_table test files (Phase 2+3+4 — 64-bit arrays/tables)
+FILE(GLOB AOT_LONG_ARRAY_TABLE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/long_array_table/*.das")
+
 # AOT for live_host test files — dasLiveHost transitively requires dashv,
 # so AOT them only when HV is enabled.
 SET(AOT_LIVE_HOST_FILES)
@@ -401,6 +404,10 @@ add_custom_target(test_aot_archive)
 SET(ARCHIVE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_ARCHIVE_FILES}" ARCHIVE_AOT_GENERATED_SRC test_aot_archive daslang)
 
+add_custom_target(test_aot_long_array_table)
+SET(LONG_ARRAY_TABLE_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_LONG_ARRAY_TABLE_FILES}" LONG_ARRAY_TABLE_AOT_GENERATED_SRC test_aot_long_array_table daslang)
+
 add_custom_target(test_aot_ast_match)
 SET(AST_MATCH_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_AST_MATCH_FILES}" AST_MATCH_AOT_GENERATED_SRC test_aot_ast_match daslang)
@@ -686,6 +693,7 @@ SOURCE_GROUP_FILES("aot generated" TESTING_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" ALGORITHM_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" APPLY_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" ARCHIVE_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" LONG_ARRAY_TABLE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" AST_MATCH_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" ASSERT_ONCE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" ASYNC_AOT_GENERATED_SRC)
@@ -755,6 +763,7 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${ALGORITHM_AOT_GENERATED_SRC}
     ${APPLY_AOT_GENERATED_SRC}
     ${ARCHIVE_AOT_GENERATED_SRC}
+    ${LONG_ARRAY_TABLE_AOT_GENERATED_SRC}
     ${AST_MATCH_AOT_GENERATED_SRC}
     ${ASSERT_ONCE_AOT_GENERATED_SRC}
     ${ASYNC_AOT_GENERATED_SRC}
@@ -824,7 +833,7 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
 TARGET_LINK_LIBRARIES(test_aot libDaScriptAot ${SRC_LIBRARIES} ${DAS_MODULES_LIBS})
 ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_tests test_aot_testing
-    test_aot_algorithm test_aot_apply test_aot_archive test_aot_ast_match
+    test_aot_algorithm test_aot_apply test_aot_archive test_aot_long_array_table test_aot_ast_match
     test_aot_assert_once test_aot_async test_aot_bare_block test_aot_base64
     test_aot_bitfields test_aot_bool_array
     test_aot_class_boost

--- a/tests/data_walker/dw_common.das
+++ b/tests/data_walker/dw_common.das
@@ -141,16 +141,16 @@ class LogWalker : DapiDataWalker {
     def override afterArray(pa : DapiArray; ti : TypeInfo) : void {
         log += "afterArray\n"
     }
-    def override beforeArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         log += "beforeArrayData:{int(count)}\n"
     }
-    def override afterArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override afterArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         log += "afterArrayData:{int(count)}\n"
     }
-    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         log += "beforeElem:{int(index)}:{last}\n"
     }
-    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         log += "afterElem:{int(index)}:{last}\n"
     }
 
@@ -161,16 +161,16 @@ class LogWalker : DapiDataWalker {
     def override afterTable(pa : DapiTable; ti : TypeInfo) : void {
         log += "afterTable\n"
     }
-    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         log += "beforeKey:{int(index)}:{last}\n"
     }
-    def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         log += "afterKey:{int(index)}:{last}\n"
     }
-    def override beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void {
+    def override beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
         log += "beforeVal:{int(index)}:{last}\n"
     }
-    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
         log += "afterVal:{int(index)}:{last}\n"
     }
 

--- a/tests/data_walker/dw_common.das
+++ b/tests/data_walker/dw_common.das
@@ -142,16 +142,16 @@ class LogWalker : DapiDataWalker {
         log += "afterArray\n"
     }
     def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
-        log += "beforeArrayData:{int(count)}\n"
+        log += "beforeArrayData:{int64(count)}\n"
     }
     def override afterArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
-        log += "afterArrayData:{int(count)}\n"
+        log += "afterArrayData:{int64(count)}\n"
     }
     def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
-        log += "beforeElem:{int(index)}:{last}\n"
+        log += "beforeElem:{int64(index)}:{last}\n"
     }
     def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
-        log += "afterElem:{int(index)}:{last}\n"
+        log += "afterElem:{int64(index)}:{last}\n"
     }
 
     // --- table ---
@@ -162,16 +162,16 @@ class LogWalker : DapiDataWalker {
         log += "afterTable\n"
     }
     def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
-        log += "beforeKey:{int(index)}:{last}\n"
+        log += "beforeKey:{int64(index)}:{last}\n"
     }
     def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
-        log += "afterKey:{int(index)}:{last}\n"
+        log += "afterKey:{int64(index)}:{last}\n"
     }
     def override beforeTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
-        log += "beforeVal:{int(index)}:{last}\n"
+        log += "beforeVal:{int64(index)}:{last}\n"
     }
     def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
-        log += "afterVal:{int(index)}:{last}\n"
+        log += "afterVal:{int64(index)}:{last}\n"
     }
 
     // --- tuple ---

--- a/tests/data_walker/test_walk_containers.das
+++ b/tests/data_walker/test_walk_containers.das
@@ -190,10 +190,10 @@ def test_walk_table(t : T?) {
                 adapter |> walk_data(addr(tab), typeinfo rtti_typeinfo(tab))
             }
         }
-        var key_pos = find(walker.log, "beforeKey")
-        var key_after_pos = find(walker.log, "afterKey")
-        var val_pos = find(walker.log, "beforeVal")
-        var val_after_pos = find(walker.log, "afterVal")
+        let key_pos = find(walker.log, "beforeKey")
+        let key_after_pos = find(walker.log, "afterKey")
+        let val_pos = find(walker.log, "beforeVal")
+        let val_after_pos = find(walker.log, "afterVal")
         // Key should come before value
         t |> equal(key_pos < key_after_pos, true)
         t |> equal(key_after_pos < val_pos, true)

--- a/tests/data_walker/test_walk_edge_cases.das
+++ b/tests/data_walker/test_walk_edge_cases.das
@@ -79,7 +79,7 @@ def test_walk_null_pointer(t : T?) {
 def test_walk_lambda(t : T?) {
     t |> run("lambda with capture") @(t : T?) {
         var walker = new LogWalker()
-        var captured_value = 99
+        let captured_value = 99
         var lam <- @ {
             return captured_value
         }

--- a/tests/data_walker/test_walk_filtering.das
+++ b/tests/data_walker/test_walk_filtering.das
@@ -52,7 +52,7 @@ class SkipArrayWalker : DapiDataWalker {
 // A walker that skips array data but still gets before/afterArray
 class SkipArrayDataWalker : DapiDataWalker {
     log : string
-    def override canVisitArrayData(ti : TypeInfo; count : uint) : bool {
+    def override canVisitArrayData(ti : TypeInfo; count : uint64) : bool {
         log += "canVisitArrayData:{int(count)}\n"
         return false
     }
@@ -109,10 +109,7 @@ class SelectiveStructWalker : DapiDataWalker {
     log : string
     skip_name : string
     def override canVisitStructure(ps : void?; si : StructInfo) : bool {
-        if (si.name == skip_name) {
-            return false
-        }
-        return true
+        return si.name != skip_name
     }
     def override beforeStructure(ps : void?; si : StructInfo) : void {
         log += "visit:{si.name}\n"

--- a/tests/data_walker/test_walk_filtering.das
+++ b/tests/data_walker/test_walk_filtering.das
@@ -53,7 +53,7 @@ class SkipArrayWalker : DapiDataWalker {
 class SkipArrayDataWalker : DapiDataWalker {
     log : string
     def override canVisitArrayData(ti : TypeInfo; count : uint64) : bool {
-        log += "canVisitArrayData:{int(count)}\n"
+        log += "canVisitArrayData:{int64(count)}\n"
         return false
     }
     def override beforeArray(pa : DapiArray; ti : TypeInfo) : void {

--- a/tests/long_array_table/test_arr_int64_indexing.das
+++ b/tests/long_array_table/test_arr_int64_indexing.das
@@ -1,0 +1,44 @@
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_arr_i64_index_read(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(5))
+    for (i in iter_range(arr)) {
+        arr[i] = i * 10
+    }
+    let i64_idx : int64 = 2_l
+    t |> equal(arr[i64_idx], 20)
+}
+
+[test]
+def test_arr_u64_index_read(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(5))
+    for (i in iter_range(arr)) {
+        arr[i] = i * 10
+    }
+    let u64_idx : uint64 = 3_ul
+    t |> equal(arr[u64_idx], 30)
+}
+
+[test]
+def test_arr_i64_index_write(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(3))
+    let i64_idx : int64 = 1_l
+    arr[i64_idx] = 42
+    t |> equal(arr[1], 42)
+}
+
+[test]
+def test_mixed_width_indexing(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(4))
+    arr[0] = 10
+    arr[1_l] = 20
+    arr[2_ul] = 30
+    arr[uint(3)] = 40
+    t |> equal(arr[int(0)] + arr[int64(1)] + arr[uint64(2)] + arr[uint(3)], 100)
+}

--- a/tests/long_array_table/test_dapi_layout.das
+++ b/tests/long_array_table/test_dapi_layout.das
@@ -1,0 +1,80 @@
+options gen2
+require dastest/testing_boost public
+require daslib/debugger
+
+// These tests guard against drift between the daslib DapiArray/DapiTable
+// debug mirrors (daslib/debugger.das) and the C++ das::Array/das::Table
+// structs (include/daScript/misc/arraytype.h). The C++ side has a
+// static_assert canary in daScriptC.cpp; this is the daslib-side mirror.
+//
+// The pattern: overlay a real array<T> / table<K;V> with a DapiArray? /
+// DapiTable? pointer and verify size/capacity/tombstones read back the
+// values daslang reports through its own API. Any field-offset drift —
+// missing pad, wrong width, base-trailing-pad reuse difference between
+// ABIs — would surface as a mismatched compare.
+
+[test]
+def test_dapi_array_size_capacity_match(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(7))
+    let view = unsafe(reinterpret<DapiArray?>(unsafe(addr(arr))))
+    t |> equal(view.size, uint64(7))
+    t |> equal(view.capacity, uint64(long_capacity(arr)))
+}
+
+[test]
+def test_dapi_array_data_pointer_non_null(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(3))
+    let view = unsafe(reinterpret<DapiArray?>(unsafe(addr(arr))))
+    t |> success(view.data != null)
+}
+
+[test]
+def test_dapi_table_size_tombstones_match(t : T?) {
+    var tab : table<int; int>
+    tab |> insert(1, 100)
+    tab |> insert(2, 200)
+    tab |> insert(3, 300)
+    let view = unsafe(reinterpret<DapiTable?>(unsafe(addr(tab))))
+    t |> equal(view.size, uint64(3))
+    t |> equal(view.tombstones, uint64(0))
+}
+
+[test]
+def test_dapi_table_keys_hashes_non_null(t : T?) {
+    // If the inherited DapiArray slice has the wrong size, keys/hashes
+    // would land at the wrong offsets and either read garbage or null.
+    var tab : table<int; int>
+    tab |> insert(42, 100)
+    let view = unsafe(reinterpret<DapiTable?>(unsafe(addr(tab))))
+    t |> success(view.keys != null)
+    t |> success(view.hashes != null)
+}
+
+[test]
+def test_dapi_table_tombstones_after_erase(t : T?) {
+    var tab : table<int; int>
+    tab |> insert(1, 100)
+    tab |> insert(2, 200)
+    tab |> erase(1)
+    let view = unsafe(reinterpret<DapiTable?>(unsafe(addr(tab))))
+    t |> equal(view.size, uint64(1))
+    t |> equal(view.tombstones, uint64(1))
+}
+
+[test]
+def test_dapi_table_keys_offset_matches_runtime(t : T?) {
+    // Catches base-trailing-pad drift on 32-bit Itanium ABI directly.
+    // In the C++ Table memory layout, `keys` points to `data + capacity * sizeof(value)`.
+    // If DapiArray's pad/size disagrees with das::Array's, DapiTable.keys reads from
+    // the wrong slot and the equality below fails — independent of platform.
+    var tab : table<int; int>
+    for (i in range(8)) {
+        tab |> insert(i, i * 10)
+    }
+    let view = unsafe(reinterpret<DapiTable?>(unsafe(addr(tab))))
+    let data_addr = intptr(view.data)
+    let expected_keys_addr = data_addr + view.capacity * uint64(4)   // value type = int = 4 bytes
+    t |> equal(intptr(view.keys), expected_keys_addr)
+}

--- a/tests/long_array_table/test_int64_overloads.das
+++ b/tests/long_array_table/test_int64_overloads.das
@@ -1,0 +1,49 @@
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_resize_int64(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(7))
+    t |> equal(length(arr), 7)
+    t |> equal(long_length(arr), 7_l)
+}
+
+[test]
+def test_reserve_int64(t : T?) {
+    var arr : array<int>
+    arr |> reserve(int64(16))
+    t |> success(long_capacity(arr) >= 16_l)
+}
+
+[test]
+def test_erase_int64(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(5))
+    for (i in iter_range(arr)) {
+        arr[i] = i + 1
+    }
+    arr |> erase(int64(2))
+    t |> equal(length(arr), 4)
+    t |> equal(arr[2], 4)
+}
+
+[test]
+def test_erase_range_int64(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(5))
+    for (i in iter_range(arr)) {
+        arr[i] = i + 1
+    }
+    arr |> erase(int64(1), int64(2))
+    t |> equal(length(arr), 3)
+    t |> equal(arr[0], 1)
+    t |> equal(arr[1], 4)
+}
+
+[test]
+def test_table_reserve_int64(t : T?) {
+    var tab : table<int; int>
+    tab |> reserve(int64(64))
+    t |> success(long_capacity(tab) >= 64_l)
+}

--- a/tests/long_array_table/test_long_iterators.das
+++ b/tests/long_array_table/test_long_iterators.das
@@ -1,0 +1,59 @@
+options gen2
+require daslib/functional
+require dastest/testing_boost public
+
+[test]
+def test_long_iter_range(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(5))
+    for (i in iter_range(arr)) {
+        arr[i] = i + 1
+    }
+    var sum = 0_l
+    for (i in long_iter_range(arr)) {
+        sum += int64(arr[i])
+    }
+    t |> equal(sum, 15_l)
+}
+
+[test]
+def test_long_enumerate(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(4))
+    arr[0] = 10
+    arr[1] = 20
+    arr[2] = 30
+    arr[3] = 40
+    var sum_idx = 0_l
+    var sum_val = 0
+    unsafe {
+        for ((i, v) in long_enumerate(each(arr))) {
+            sum_idx += i
+            sum_val += v
+        }
+    }
+    t |> equal(sum_idx, 0_l + 1_l + 2_l + 3_l)
+    t |> equal(sum_val, 100)
+}
+
+[test]
+def test_long_find_index_present(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(5))
+    arr[0] = 100
+    arr[1] = 200
+    arr[2] = 300
+    arr[3] = 400
+    arr[4] = 500
+    t |> equal(long_find_index(arr, 300), 2_l)
+}
+
+[test]
+def test_long_find_index_missing(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(3))
+    arr[0] = 1
+    arr[1] = 2
+    arr[2] = 3
+    t |> equal(long_find_index(arr, 99), -1_l)
+}

--- a/tests/long_array_table/test_long_length.das
+++ b/tests/long_array_table/test_long_length.das
@@ -1,0 +1,25 @@
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_long_length_empty(t : T?) {
+    let arr : array<int>
+    t |> equal(long_length(arr), 0_l)
+    t |> equal(long_capacity(arr), 0_l)
+}
+
+[test]
+def test_long_length_after_resize(t : T?) {
+    var arr : array<int>
+    arr |> resize(int64(10))
+    t |> equal(long_length(arr), 10_l)
+}
+
+[test]
+def test_long_length_table(t : T?) {
+    var tab : table<int; int>
+    tab |> insert(1, 100)
+    tab |> insert(2, 200)
+    tab |> insert(3, 300)
+    t |> equal(long_length(tab), 3_l)
+}

--- a/tutorials/language/47_data_walker.das
+++ b/tutorials/language/47_data_walker.das
@@ -191,24 +191,24 @@ class ContainerPrinter : DapiDataWalker {
     }
 
     // --- arrays ---
-    def override beforeArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         self->pad()
         print("array[{int(count)}] = [\n")
         indent++
     }
 
-    def override afterArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override afterArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         indent--
         self->pad()
         print("]\n")
     }
 
-    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         self->pad()
         print("[{int(index)}] = ")
     }
 
-    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         print("\n")
     }
 
@@ -225,15 +225,15 @@ class ContainerPrinter : DapiDataWalker {
         print("\}\n")
     }
 
-    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         self->pad()
     }
 
-    def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         print(" => ")
     }
 
-    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
         print("\n")
     }
 
@@ -530,13 +530,13 @@ class JsonWalker : DapiDataWalker {
     }
 
     // --- arrays ---
-    def override beforeArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         *writer |> write("[")
         indent++
         pushComma()
     }
 
-    def override afterArrayData(ps : void?; stride : uint; count : uint; ti : TypeInfo) : void {
+    def override afterArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         popComma()
         indent--
         nl()
@@ -544,12 +544,12 @@ class JsonWalker : DapiDataWalker {
         markComma()
     }
 
-    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         comma()
         nl()
     }
 
-    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint; last : bool) : void {
+    def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         markComma()
     }
 
@@ -568,16 +568,16 @@ class JsonWalker : DapiDataWalker {
         markComma()
     }
 
-    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override beforeTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         comma()
         nl()
     }
 
-    def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableKey(pa : DapiTable; ti : TypeInfo; pk : void?; ki : TypeInfo; index : uint64; last : bool) : void {
         *writer |> write(": ")
     }
 
-    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint; last : bool) : void {
+    def override afterTableValue(pa : DapiTable; ti : TypeInfo; pv : void?; kv : TypeInfo; index : uint64; last : bool) : void {
         markComma()
     }
 

--- a/tutorials/language/47_data_walker.das
+++ b/tutorials/language/47_data_walker.das
@@ -193,7 +193,7 @@ class ContainerPrinter : DapiDataWalker {
     // --- arrays ---
     def override beforeArrayData(ps : void?; stride : uint; count : uint64; ti : TypeInfo) : void {
         self->pad()
-        print("array[{int(count)}] = [\n")
+        print("array[{int64(count)}] = [\n")
         indent++
     }
 
@@ -205,7 +205,7 @@ class ContainerPrinter : DapiDataWalker {
 
     def override beforeArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {
         self->pad()
-        print("[{int(index)}] = ")
+        print("[{int64(index)}] = ")
     }
 
     def override afterArrayElement(ps : void?; ti : TypeInfo; pe : void?; index : uint64; last : bool) : void {


### PR DESCRIPTION
## Summary

PR #2 of the 64-bit arrays/tables sequence. Lands the atomic Phase 2 + Phase 3 + Phase 4 chunk, plus the Phase 2c AOT-side helpers that Phase 4b's `arr[i64]` dispatch immediately depends on.

### What lands

- **Array / Table structs widened** to `uint64` for `size`, `capacity`, `tombstones`. `magic`, `lock`, `flags` stay `uint32`. Mirrors in `daScriptC.h` (`das_array` / `das_table`) and `daslib/debugger.das` (`DapiArray` / `DapiTable`, with the previously-missing `tombstones` field added). `TableHash<KT>` widened internally (`mask`, `index`, capacity loops) — per-bucket hash stays `uint32`.

- **DataWalker virtuals widened** — `count` / `index` params (`canVisitArrayData`, `beforeArrayData`, `afterArrayData`, `beforeArrayElement`, `afterArrayElement`, `beforeTableKey`, `afterTableKey`, `beforeTableValue`, `afterTableValue`) all to `uint64`. C++ subclasses (`json_print`, `debug_print`, debugger adapter, GC walks, bin_serializer, ast_serialize) and daslang subclasses (`daslib/debug.das`, `daslib/debug_eval.das`) updated to match. **This is a binary break for any C++ embedder subclassing `DataWalker`** — release-notes line owed.

- **daslang surface (Phase 4)**:
  - `long_length(arr)` / `long_length(tab)` / `long_capacity(arr)` / `long_capacity(tab)` return `int64`
  - `length()` / `capacity()` keep returning `int` but panic via `DAS_VERIFYF` when the underlying `uint64` exceeds `INT_MAX` — surface stays binary-compatible, loud-fails on overflow instead of silently truncating
  - int64 overloads of `resize` / `resize_no_init` / `reserve` / `erase` / `erase(range)` on arrays, `reserve` on tables
  - int64 overloads of `array_view` / `temp_array` in `array_boost.das` (paired with new `builtin_make_temp_array_i64` binding)
  - `arr[i64]` / `arr[u64]` indexing — new `SimNode_ArrayAt_I64` / `_U64` + R2V variants + `SafeArrayAt_I64` / `_U64` in `runtime_array.h`, dispatched from `ast_simulate.cpp` on `expr->index->type->baseType`; `isIndex()` relaxed to `isIndexExt()` for `array<T>` in the type inferrer (vector and fixed_array stay int/uint only)
  - `long_iter_range` / `long_find_index` in `builtin.das`, `long_enumerate` in `functional.das`
  - `__builtin_array_push` / `_push_zero` / `_push_back` / `_push_back_zero` widened to `int64_t` index/return; daslib `push` wrappers cast `at` to `int64(at)` at the boundary

- **Phase 2c — AOT helpers**:
  - `TArray<T>::operator()` int64/uint64 overloads + `safe_index` int64/uint64
  - New free-function helpers `das_ati_i64` / `das_atu_u64` / `das_atci_i64` / `das_atcu_u64` (named distinctly to avoid `DAS_BIND_FUN` overload-resolution clash with the int32 versions)
  - `ast_handle.h` bindings for the new helpers on every handled type
  - `aot_builtin.h` `DAS_API` decls for `builtin_array_*_i64`

- **Existing 32-bit offset bug fixed** — `SimNode_ArrayAt::compute()` had `idx*stride + offset` in uint32 that overflowed when `idx*stride > 4GB` (achievable today with a 2GB `array<int>` at stride 4). Now `uint64_t(idx)*uint64_t(stride) + offset`. Same fix applied to `SafeArrayAt`.

- **bin_serializer / ast_serialize get_data** — wire format and array view widened to `uint64`; "data exceeds 2GB" and "array too large to serialize" panics removed.

- **LLVM JIT codegen version** bumped `0x02` to `0x03` (`modules/dasLLVM/daslib/llvm_macro.das`) so stale `.jitted_scripts/<ns>/<hash>.dll` auto-GC on next run.

### Tests

- 16 new under `tests/long_array_table/`:
  - `test_long_length.das` — empty / resized / table parity (3)
  - `test_arr_int64_indexing.das` — i64 / u64 / mixed-width read+write (4)
  - `test_int64_overloads.das` — `resize` / `reserve` / `erase` / `erase(range)` / table `reserve` (5)
  - `test_long_iterators.das` — `long_iter_range` / `long_enumerate` / `long_find_index` (4)
- Registered in `tests/aot/CMakeLists.txt` so AOT covers them too.
- Memory-gated tests (>UINT32_MAX elements) tracked under "Pending tests for 32-bit-check removals" in the plan tracker — to follow when CI has the RAM.

### Lint sweep

Fixed 6 pre-existing warnings in directories the PR touches: 5 LINT003 (`var` to `let`) in `tests/data_walker/test_walk_containers.das` and `test_walk_edge_cases.das`, 1 STYLE017 (`if cond return false; return true` collapsed to `return !cond`) in `test_walk_filtering.das`.

### Bench

Not included in this PR. Per-bench microbench numbers will move materially once Phase 5 (next PR, fusion 64-bit variants) lands — `arr[i64]` currently goes through the un-fused `SimNode_ArrayAt_I64` path. Bench compare runs against Phase 5+ baseline.

### Why this size

Plan called Phase 2c (AOT helpers) a separate PR, but Phase 4b's `arr[i64]` dispatch emits AOT code that references the int64 `TArray::operator()` — without Phase 2c, every AOT compile of daslib breaks the moment Phase 4b lands. So the two have to ship atomic.

## Test plan

- [x] Lint: `bin/Release/daslang.exe utils/lint/main.das -- <touched dirs>` — 19 files, 0 issues
- [x] Interpreter: `bin/Release/daslang.exe dastest/dastest.das -- --test tests` — **8926 / 8926 pass**
- [x] AOT: `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **8315 / 8315 pass**
- [x] `mcp__daslang__format_file` over all changed `.das` files — already formatted
- [ ] CI green across all platforms
- [ ] Phase 0 bench compare deferred to post-Phase-5 (un-fused i64 indexing would dominate the diff today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)