### PR TITLE
playground: add Test button, embed dastest, gate on [test]

### DIFF
--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -116,7 +116,7 @@
                 <button id="share" class="button_header button_header--ghost" type="button">↗ share</button>
             </div>
             <div class="main_header_part">
-                <button id="run" class="button_header" onclick="runCode()">▶ run</button>
+                <button id="run" class="button_header" onclick="runCode()" disabled>▶ run</button>
             </div>
             <div class="main_header_part">
                 <button id="test" class="button_header" onclick="runTests()" disabled>▶ test</button>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -118,6 +118,9 @@
             <div class="main_header_part">
                 <button id="run" class="button_header" onclick="runCode()">▶ run</button>
             </div>
+            <div class="main_header_part">
+                <button id="test" class="button_header" onclick="runTests()" disabled>▶ test</button>
+            </div>
         </div>
         <div class="main_header_right">
             <button id="clear" class="button_header button_header--ghost" onclick="clearOutput()">clear</button>

--- a/site/playground/playground-tabs.js
+++ b/site/playground/playground-tabs.js
@@ -50,6 +50,11 @@
                 localStorage.setItem(STORAGE_KEY, JSON.stringify(getStateJson()));
             } catch (e) { /* quota / disabled — ignore */ }
         }, AUTOSAVE_DEBOUNCE_MS);
+        // Refresh the Test button's enabled state on every mutation — same
+        // hook set autosave covers (edit / switch / add / rename / delete).
+        if (typeof window.updateTestButtonState === 'function') {
+            window.updateTestButtonState();
+        }
     }
 
     function attachAutosave(doc) {

--- a/site/playground/playground-tabs.js
+++ b/site/playground/playground-tabs.js
@@ -49,12 +49,14 @@
             try {
                 localStorage.setItem(STORAGE_KEY, JSON.stringify(getStateJson()));
             } catch (e) { /* quota / disabled — ignore */ }
+            // Refresh the Test button's enabled state on the same debounced
+            // tick — covers edit / switch / add / rename / delete via one
+            // signal. Inside the setTimeout so rapid keystrokes coalesce
+            // into one regex scan instead of one per keystroke.
+            if (typeof window.updateTestButtonState === 'function') {
+                window.updateTestButtonState();
+            }
         }, AUTOSAVE_DEBOUNCE_MS);
-        // Refresh the Test button's enabled state on every mutation — same
-        // hook set autosave covers (edit / switch / add / rename / delete).
-        if (typeof window.updateTestButtonState === 'function') {
-            window.updateTestButtonState();
-        }
     }
 
     function attachAutosave(doc) {

--- a/site/tests/playground/test-button.spec.js
+++ b/site/tests/playground/test-button.spec.js
@@ -1,0 +1,63 @@
+// Test button: write a file with [test] functions, hit ▶ test, check dastest
+// output. Requires WASM (tagged @wasm so the no-WASM CI gate skips this file).
+
+const { test, expect } = require('./fixtures.js');
+
+async function waitTabsReady(page) {
+    await page.waitForFunction(() => !!window.pgState, null, { timeout: 10_000 });
+    await page.locator('#pg-tabs .pg-tab[data-file="main.das"]').waitFor();
+}
+
+async function waitWasmReady(page) {
+    await page.waitForFunction(
+        () => typeof window.FS !== 'undefined' && typeof window.Module?.callMain === 'function',
+        null,
+        { timeout: 30_000 }
+    );
+}
+
+test('runs [test] functions and reports SUCCESS @wasm', async ({ playground }) => {
+    await waitTabsReady(playground);
+    await waitWasmReady(playground);
+
+    await playground.evaluate(() => {
+        window.pgSwitchFile('main.das');
+        window.code.getDoc().setValue([
+            'options gen2',
+            'require dastest/testing_boost public',
+            '',
+            '[test]',
+            'def test_math(t : T?) {',
+            '    t |> equal(2 + 2, 4)',
+            '}',
+            '',
+        ].join('\n'));
+    });
+
+    await playground.locator('#test').click();
+    await expect(playground.locator('.output_line_text', { hasText: 'SUCCESS!' }))
+        .toBeVisible({ timeout: 30_000 });
+});
+
+test('reports FAILED when a [test] assertion fails @wasm', async ({ playground }) => {
+    await waitTabsReady(playground);
+    await waitWasmReady(playground);
+
+    await playground.evaluate(() => {
+        window.pgSwitchFile('main.das');
+        window.code.getDoc().setValue([
+            'options gen2',
+            'require dastest/testing_boost public',
+            '',
+            '[test]',
+            'def test_fails(t : T?) {',
+            '    t |> equal(1, 2)',
+            '}',
+            '',
+        ].join('\n'));
+    });
+
+    await playground.locator('#test').click();
+    await expect(playground.locator('.output_line_text', { hasText: 'FAILED!' }))
+        .toBeVisible({ timeout: 30_000 });
+});

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -40,7 +40,20 @@ add_link_options(
     -sALLOW_MEMORY_GROWTH=1
 )
 # embed daslang standard library into wasm binary.
-add_link_options(--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../daslib@daslib)
+# SHELL: keeps the --embed-file + path pair atomic — without it, CMake folds
+# repeated --embed-file flags into one token (drops the second), so the second
+# directory becomes a positional arg to em++ and the embed silently fails.
+add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../daslib@daslib")
+# Exclude modules whose native dependencies are not linked in the WASM build.
+# spoof + its only consumer linked_list both require peg/peg (dasPEG module),
+# which is not linked here. Embedding them gives users a confusing
+# "module peg/peg not found" compile error; better to fail at the require
+# itself with "module not found".
+add_link_options("SHELL:--exclude-file */daslib/spoof.das")
+add_link_options("SHELL:--exclude-file */daslib/linked_list.das")
+# embed dastest runner so the playground's Test button can invoke
+# /dastest/dastest.das against user-authored [test] functions.
+add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../dastest@dastest")
 
 IF(DEFINED DAS_CONFIG_INCLUDE_DIR)
     INCLUDE_DIRECTORIES(${DAS_CONFIG_INCLUDE_DIR})

--- a/web/ui/samples/data.json
+++ b/web/ui/samples/data.json
@@ -20,6 +20,10 @@
     {
       "name" : "Random Sequence",
       "files" : ["examples/random_sequence.das"]
+    },
+    {
+      "name" : "Tests",
+      "files" : ["examples/tests.das"]
     }
   ]
 }

--- a/web/ui/samples/examples/tests.das
+++ b/web/ui/samples/examples/tests.das
@@ -1,0 +1,24 @@
+options gen2
+
+require dastest/testing_boost public
+require strings
+
+[test]
+def test_adds(t : T?) {
+    t |> equal(2 + 2, 4)
+    t |> equal("hello, " + "world", "hello, world")
+}
+
+[test]
+def test_subtests(t : T?) {
+    t |> run("strings") <| @(t : T?) {
+        t |> equal(length("daslang"), 7)
+    }
+    t |> run("range") <| @(t : T?) {
+        var sum = 0
+        for (i in range(10)) {
+            sum += i
+        }
+        t |> equal(sum, 45)
+    }
+}

--- a/web/ui/src/main.js
+++ b/web/ui/src/main.js
@@ -122,8 +122,10 @@ function syncUrlToState() {
 }
 
 // Multi-file MEMFS sync: unlink stale, write current pgState files. Returns
-// true when pgState + FS are ready (callers can then callMain); false when
-// the tab strip hasn't mounted yet (caller falls back to single-buffer flow).
+// true when both prerequisites are ready (pgState mounted AND Emscripten's
+// FS is up); false when either is still pending. Callers that fall back to
+// the single-buffer path must check WASM readiness themselves before touching
+// FS — see isWasmReady() and the runCode/runTests guards below.
 function syncMemFsFromState() {
     if (!window.pgState || typeof FS === 'undefined') return false;
     const current = new Set(Object.keys(window.pgState.files));
@@ -139,7 +141,49 @@ function syncMemFsFromState() {
     return true;
 }
 
+// WASM readiness: callMain + FS both exposed by the Emscripten module. False
+// during the ~3-5s page-load window while daslang_static.{js,wasm} streams in,
+// or indefinitely if the load fails. Both Run and Test buttons stay disabled
+// until this flips to true (see updateButtonStates + Module.onRuntimeInitialized).
+function isWasmReady() {
+    return typeof FS !== 'undefined'
+        && typeof Module === 'object' && Module !== null
+        && typeof Module.callMain === 'function';
+}
+
+// Toggle Run + Test buttons. Run requires WASM ready; Test additionally
+// requires a [test] annotation in any open buffer. Called from autosave
+// (every buffer/state mutation) and from Module.onRuntimeInitialized (WASM
+// finishes loading) so both signals refresh the gating.
+var __TEST_ANNOT_RE = /\[\s*test\b/m;
+function hasTestAnnotation() {
+    if (window.pgState) {
+        for (const doc of Object.values(window.pgState.files)) {
+            if (__TEST_ANNOT_RE.test(doc.getValue())) return true;
+        }
+        return false;
+    }
+    if (typeof code === 'object' && code) {
+        return __TEST_ANNOT_RE.test(code.getValue());
+    }
+    return false;
+}
+function updateButtonStates() {
+    const ready = isWasmReady();
+    const runBtn = document.getElementById('run');
+    const testBtn = document.getElementById('test');
+    if (runBtn) runBtn.disabled = !ready;
+    if (testBtn) testBtn.disabled = !ready || !hasTestAnnotation();
+}
+// Kept under the old name so playground-tabs.js's existing autosave hook
+// still works without churn — it triggers a full refresh.
+window.updateTestButtonState = updateButtonStates;
+
 runCode = function() {
+    if (!isWasmReady()) {
+        printOutput('daslang is still loading, please wait…', '#ff9393');
+        return;
+    }
     if (syncMemFsFromState()) {
         syncUrlToState();
         Module.callMain(['main.das']);
@@ -149,26 +193,6 @@ runCode = function() {
     runScript(code.getValue());
 }
 
-// Toggle the Test button based on whether any open buffer declares a `[test]`
-// annotation. \b after `test` keeps `[test_something]` from triggering. Called
-// from playground-tabs.js autosave (which fires on every state mutation: edit,
-// switch, add, rename, delete) so the button stays in sync without polling.
-var __TEST_ANNOT_RE = /\[\s*test\b/m;
-function updateTestButtonState() {
-    const btn = document.getElementById('test');
-    if (!btn) return;
-    let hasTest = false;
-    if (window.pgState) {
-        for (const doc of Object.values(window.pgState.files)) {
-            if (__TEST_ANNOT_RE.test(doc.getValue())) { hasTest = true; break; }
-        }
-    } else if (typeof code === 'object' && code) {
-        hasTest = __TEST_ANNOT_RE.test(code.getValue());
-    }
-    btn.disabled = !hasTest;
-}
-window.updateTestButtonState = updateTestButtonState;
-
 // Invoke dastest against the current main.das. `[test]` functions in the file
 // are discovered + run by dastest/suite.das; the existing Module.print hook
 // routes stdout into the output panel. No --color: Emscripten has no TERM and
@@ -176,6 +200,10 @@ window.updateTestButtonState = updateTestButtonState;
 // wall-clock thread (suite.das wraps each file in new_thread when timeout>0),
 // keeping the run single-threaded in the WASM build.
 runTests = function() {
+    if (!isWasmReady()) {
+        printOutput('daslang is still loading, please wait…', '#ff9393');
+        return;
+    }
     if (!syncMemFsFromState()) {
         FS.writeFile('main.das', code.getValue());
     }
@@ -261,6 +289,12 @@ var Module = {
                 printOutput(text,'#ffffff');
             };
         })(),
+        // Re-enable the Run / Test buttons once Emscripten has finished
+        // loading daslang_static.wasm and exposing FS + callMain. Both buttons
+        // ship disabled in index.html to avoid the early-click ReferenceError.
+        onRuntimeInitialized: function() {
+            if (typeof updateButtonStates === 'function') updateButtonStates();
+        },
     }
 
 window.onerror = function(message)

--- a/web/ui/src/main.js
+++ b/web/ui/src/main.js
@@ -121,27 +121,66 @@ function syncUrlToState() {
     if (url && url !== location.href) history.pushState(null, '', url);
 }
 
+// Multi-file MEMFS sync: unlink stale, write current pgState files. Returns
+// true when pgState + FS are ready (callers can then callMain); false when
+// the tab strip hasn't mounted yet (caller falls back to single-buffer flow).
+function syncMemFsFromState() {
+    if (!window.pgState || typeof FS === 'undefined') return false;
+    const current = new Set(Object.keys(window.pgState.files));
+    for (const stale of __lastWrittenFiles) {
+        if (!current.has(stale)) {
+            try { FS.unlink(stale); } catch (e) { /* ENOENT — ignore */ }
+        }
+    }
+    for (const [name, doc] of Object.entries(window.pgState.files)) {
+        FS.writeFile(name, doc.getValue());
+    }
+    __lastWrittenFiles = current;
+    return true;
+}
+
 runCode = function() {
-    // Multi-file: sync MEMFS with the current pgState (unlink stale, write
-    // current), then run main.das. Falls back to the single-buffer path when
-    // pgState isn't up yet.
-    if (window.pgState && typeof FS !== 'undefined') {
-        const current = new Set(Object.keys(window.pgState.files));
-        for (const stale of __lastWrittenFiles) {
-            if (!current.has(stale)) {
-                try { FS.unlink(stale); } catch (e) { /* ENOENT — ignore */ }
-            }
-        }
-        for (const [name, doc] of Object.entries(window.pgState.files)) {
-            FS.writeFile(name, doc.getValue());
-        }
-        __lastWrittenFiles = current;
+    if (syncMemFsFromState()) {
         syncUrlToState();
         Module.callMain(['main.das']);
         return;
     }
     syncUrlToState();
     runScript(code.getValue());
+}
+
+// Toggle the Test button based on whether any open buffer declares a `[test]`
+// annotation. \b after `test` keeps `[test_something]` from triggering. Called
+// from playground-tabs.js autosave (which fires on every state mutation: edit,
+// switch, add, rename, delete) so the button stays in sync without polling.
+var __TEST_ANNOT_RE = /\[\s*test\b/m;
+function updateTestButtonState() {
+    const btn = document.getElementById('test');
+    if (!btn) return;
+    let hasTest = false;
+    if (window.pgState) {
+        for (const doc of Object.values(window.pgState.files)) {
+            if (__TEST_ANNOT_RE.test(doc.getValue())) { hasTest = true; break; }
+        }
+    } else if (typeof code === 'object' && code) {
+        hasTest = __TEST_ANNOT_RE.test(code.getValue());
+    }
+    btn.disabled = !hasTest;
+}
+window.updateTestButtonState = updateTestButtonState;
+
+// Invoke dastest against the current main.das. `[test]` functions in the file
+// are discovered + run by dastest/suite.das; the existing Module.print hook
+// routes stdout into the output panel. No --color: Emscripten has no TERM and
+// our printOutput doesn't render ANSI escapes. --timeout=0 disables dastest's
+// wall-clock thread (suite.das wraps each file in new_thread when timeout>0),
+// keeping the run single-threaded in the WASM build.
+runTests = function() {
+    if (!syncMemFsFromState()) {
+        FS.writeFile('main.das', code.getValue());
+    }
+    syncUrlToState();
+    Module.callMain(['/dastest/dastest.das', '--', '--test', '/main.das', '--timeout=0']);
 }
 
 clearOutput = function() {


### PR DESCRIPTION
## Summary

- Embed `dastest/` next to `daslib/` in the WASM build so `[test]` functions can be invoked from the browser playground.
- Add a `▶ test` button alongside `▶ run` that calls `/dastest/dastest.das --test /main.das`; auto-toggles based on whether any open buffer contains a `[test]` annotation.
- Exclude `daslib/spoof.das` and `daslib/linked_list.das` from the playground embed — both transitively require `peg/peg` (dasPEG, not linked in WASM); failing at the `require` is friendlier than a `peg/peg`-line compile error inside spoof.
- Add a "Tests" sample to the dropdown and two Playwright specs covering pass/fail paths.

## Why

The example URL pinned at https://daslang.io/playground/index.html#z=… is a `[test]` sample that compile-failed in the deployed playground because `dastest/` was never embedded. The fix is one CMake line; everything else here is UX polish around it. `web/test/dastest_wasm.js` already proves dastest runs in this WASM build (it's invoked in CI from Node) — it was just unreachable from the browser.

## Implementation notes

- `runTests()` factored alongside `runCode()` in `web/ui/src/main.js`; both share a new `syncMemFsFromState()` helper. No `--color` (Emscripten has no `TERM`; would render escapes as garbage). `--timeout=0` keeps dastest single-threaded.
- Test-button toggle hooks into `playground-tabs.js` `autosave()` — that already fires on every state mutation (edit / switch / add / rename / delete / load), so a single signal covers everything.
- Repeated `--embed-file` / `--exclude-file` flags use the `SHELL:` prefix in CMake. Without it, CMake folds repeated flags of the same name into one token and the trailing paths become positional args to em++, silently dropping the directive.

## Test plan

- [x] Local WASM rebuild (emsdk 5.0.7, Ninja).
- [x] Manual smoke via chrome-devtools MCP: Tests sample → `SUCCESS!`, fail case → `FAILED!` with line annotations, repeated clicks fine, original broken `#z=…` URL now resolves.
- [x] All 33 Playwright specs pass locally (`@wasm` + non-`@wasm` lanes).
- [ ] CI: pages.yml lane rebuilds the WASM bundle; deploy preview surfaces the Test button against the real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)