### PR TITLE
linq_fold: plan_order_family — order_by + first → min_by splice arm

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1195,6 +1195,13 @@ def private order_top_n_call_name(orderName : string) : string {
     return ""
 }
 
+def private order_min_call_name(orderName : string; hasKey : bool) : string {
+    // `order + first` collapses to min/max — asc → min, desc → max. Keyed forms route to min_by/max_by.
+    let isDesc = orderName == "order_descending" || orderName == "order_by_descending"
+    if (hasKey) return isDesc ? "max_by" : "min_by"
+    return isDesc ? "max" : "min"
+}
+
 [macro_function]
 def private try_make_inline_cmp(orderKey : Expression?; orderName : string;
                                 elemType : TypeDeclPtr; at : LineInfo) : Expression? {
@@ -1236,6 +1243,8 @@ def private plan_order_family(var expr : Expression?) : Expression? {
     var orderKey : Expression?
     var orderElemType : TypeDeclPtr
     var takeExpr : Expression?
+    var firstName : string
+    var firstDefaultExpr : Expression?
     var hasOrder = false
     let at = calls[0]._0.at
     let itName = "`it`{at.line}`{at.column}"
@@ -1260,10 +1269,18 @@ def private plan_order_family(var expr : Expression?) : Expression? {
             }
             orderElemType = clone_type(cll._0._type.firstType)
         } elif (name == "take") {
-            if (!hasOrder || takeExpr != null) return null
+            if (!hasOrder || takeExpr != null || firstName != "") return null
             var arg = cll._0.arguments[1]
             if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
             takeExpr = clone_expression(arg)
+        } elif (name == "first" || name == "first_or_default") {
+            // order + first → min/max (O(N) instead of sort + index). Must be terminal.
+            if (!hasOrder || takeExpr != null || firstName != "" || i != length(calls) - 1) return null
+            firstName = name
+            if (name == "first_or_default") {
+                if ((cll._0.arguments |> length) < 2) return null
+                firstDefaultExpr = clone_expression(cll._0.arguments[1])
+            }
         } else {
             return null
         }
@@ -1278,12 +1295,31 @@ def private plan_order_family(var expr : Expression?) : Expression? {
     if (hasKey) {
         inlineCmp = try_make_inline_cmp(orderKey, orderName, orderElemType, at)
     }
+    let minMaxName = order_min_call_name(orderName, hasKey)
     if (whereCond == null) {
         // No prefilter — direct call to daslib helper.
         var topExpr = clone_expression(top)
         topExpr.genFlags.alwaysSafe = true
         var emission : Expression?
-        if (takeExpr == null) {
+        if (firstName == "first") {
+            // order + first → min/max (or min_by/max_by). O(N) single pass; matches the eager `order(...).first()` panic-on-empty semantics via min/max_impl returning default-initialized ref.
+            if (hasKey) {
+                emission = qmacro($c(minMaxName)($e(topExpr), $e(orderKey)))
+            } else {
+                emission = qmacro($c(minMaxName)($e(topExpr)))
+            }
+        } elif (firstName == "first_or_default") {
+            // No min_by_or_default exists; route through top_n*(_, 1, _) which returns an array (empty or single-element), then first_or_default supplies the default.
+            var topNCall : Expression?
+            if (inlineCmp != null) {
+                topNCall = qmacro(_::top_n_by_with_cmp($e(topExpr), 1, $e(inlineCmp)))
+            } elif (hasKey) {
+                topNCall = qmacro($c(topNName)($e(topExpr), 1, $e(orderKey)))
+            } else {
+                topNCall = qmacro($c(topNName)($e(topExpr), 1))
+            }
+            emission = qmacro(_::first_or_default($e(topNCall), $e(firstDefaultExpr)))
+        } elif (takeExpr == null) {
             // Bare order family — emit the direct call. Same shape as plain LINQ, but via
             if (inlineCmp != null) {
                 // Inlined comparator dispatches to the asc `order(src, block)` overload —
@@ -1304,7 +1340,7 @@ def private plan_order_family(var expr : Expression?) : Expression? {
             }
         }
         // Wrap with to_sequence_move only when emission is array-shaped: take dispatches to
-        let emissionIsArray = takeExpr != null || top._type.isGoodArrayType
+        let emissionIsArray = takeExpr != null || (firstName == "" && top._type.isGoodArrayType)
         if (needIterWrap && emissionIsArray) {
             emission = qmacro($e(emission).to_sequence_move())
         }
@@ -1337,7 +1373,31 @@ def private plan_order_family(var expr : Expression?) : Expression? {
             $e(loopBody)
         }
     }
-    if (takeExpr == null) {
+    if (firstName == "first") {
+        // where + order + first → min/max on prefilter buffer. O(N) single pass after the filter materializes. min/max return const-refs (TT -& -const), so plain `return` — not `return <-` — matches the eager semantics.
+        var minMaxCall : Expression?
+        if (hasKey) {
+            minMaxCall = qmacro($c(minMaxName)($i(bufName), $e(orderKey)))
+        } else {
+            minMaxCall = qmacro($c(minMaxName)($i(bufName)))
+        }
+        stmts |> push <| qmacro_expr() {
+            return $e(minMaxCall)
+        }
+    } elif (firstName == "first_or_default") {
+        // No min_by_or_default helper exists; route through top_n*(_, 1, _) + first_or_default for the empty-buf case.
+        var topNCall : Expression?
+        if (inlineCmp != null) {
+            topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), 1, $e(inlineCmp)))
+        } elif (hasKey) {
+            topNCall = qmacro($c(topNName)($i(bufName), 1, $e(orderKey)))
+        } else {
+            topNCall = qmacro($c(topNName)($i(bufName), 1))
+        }
+        stmts |> push <| qmacro_expr() {
+            return _::first_or_default($e(topNCall), $e(firstDefaultExpr))
+        }
+    } elif (takeExpr == null) {
         // Sort the prefilter buffer in place and return it. order*_inplace is void
         var sortCall : Expression?
         if (inlineCmp != null) {

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2776,3 +2776,32 @@ def test_take_while_skip_while_cascade_bails(t : T?) {
         tt |> equal(0, length(got))
     }
 }
+
+[test]
+def test_fold_order_by_first(t : T?) {
+    t |> run("order_by + first → min_by") @(tt : T?) {
+        let v = _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by(_).first())
+        tt |> equal(2, v, "minimum element after order_by")
+    }
+    t |> run("order_by_descending + first → max_by") @(tt : T?) {
+        let v = _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by_descending(_).first())
+        tt |> equal(30, v, "maximum element after order_by_descending")
+    }
+    t |> run("where + order_by + first → min on prefilter buf") @(tt : T?) {
+        let v = _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._where(_ > 5)._order_by(_).first())
+        tt |> equal(8, v, "min of (10,20,8,30,15,25) = 8")
+    }
+    t |> run("order_by + first_or_default — empty source returns default") @(tt : T?) {
+        let empty : array<int>
+        let v = _fold(each(empty)._order_by(_).first_or_default(-1))
+        tt |> equal(-1, v, "empty source → default")
+    }
+    t |> run("order_by + first_or_default — non-empty returns min") @(tt : T?) {
+        let v = _fold(each([10, 5, 20])._order_by(_).first_or_default(-1))
+        tt |> equal(5, v, "non-empty source → min element")
+    }
+    t |> run("where + order_by + first_or_default — empty after filter") @(tt : T?) {
+        let v = _fold(each([1, 2, 3])._where(_ > 100)._order_by(_).first_or_default(-1))
+        tt |> equal(-1, v, "filter excludes all → default")
+    }
+}

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -3531,3 +3531,98 @@ def test_select_then_take_while_cascades_to_tier2(t : T?) {
     }
 }
 
+// ── order_by + first → min_by / max_by splice arm ───────────────────────
+
+[export, marker(no_coverage)]
+def target_order_by_first_splices_min_by() : int {
+    return _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by(_).first())
+}
+
+[export, marker(no_coverage)]
+def target_order_by_descending_first_splices_max_by() : int {
+    return _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by_descending(_).first())
+}
+
+[export, marker(no_coverage)]
+def target_where_order_by_first_splices_min_by_on_buf() : int {
+    return _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._where(_ > 5)._order_by(_).first())
+}
+
+[export, marker(no_coverage)]
+def target_order_by_first_or_default_splices_top_n_by() : int {
+    return _fold(each([10, 20, 5, 8, 30])._order_by(_).first_or_default(-1))
+}
+
+[test]
+def test_order_by_first_emits_min_by(t : T?) {
+    // order_by + first → min_by(top, key) directly. No sort, no take, no order_by/order helpers.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_first_splices_min_by)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "min_by") >= 1, "should emit a min_by call")
+        t |> equal(0, count_call(body_expr, "max_by"), "should NOT emit max_by (ascending)")
+        t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+        t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+    }
+}
+
+[test]
+def test_order_by_descending_first_emits_max_by(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_descending_first_splices_max_by)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "max_by") >= 1, "should emit a max_by call")
+        t |> equal(0, count_call(body_expr, "min_by"), "should NOT emit min_by (descending)")
+        t |> equal(0, count_call(body_expr, "order_by_descending"), "should NOT emit order_by_descending")
+        t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+    }
+}
+
+[test]
+def test_where_order_by_first_emits_min_by_on_prefilter(t : T?) {
+    // where + order_by + first → fused prefilter loop + min_by on buf. Same shape as
+    // where + order_by + take, but min_by instead of top_n_by.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_order_by_first_splices_min_by_on_buf)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "min_by") >= 1, "should emit min_by on prefilter buf")
+        t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+        t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+    }
+}
+
+[test]
+def test_order_by_first_or_default_emits_top_n_by_first_or_default(t : T?) {
+    // order_by + first_or_default → top_n_by(top, 1, key) |> first_or_default(d) — empty
+    // array handles the default fallback; no min_by_or_default helper exists.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_first_or_default_splices_top_n_by)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "top_n_by_with_cmp") + count_call(body_expr, "top_n_by") >= 1,
+            "should emit top_n_by (or top_n_by_with_cmp for inline key)")
+        t |> success(count_call(body_expr, "first_or_default") >= 1,
+            "should emit first_or_default on the 1-elem array")
+        t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+    }
+}
+


### PR DESCRIPTION
Closing — combining with #2756 + Copilot fixes into a single PR rebased on fresh master.

Reopen will fix the panic-on-empty semantic regression flagged by Copilot (emit `top_n_by(_, 1, _) |> first()` instead of `min_by` to preserve `first()`'s panic on empty) and add the corresponding empty-input regression tests.