### PR TITLE
linq_fold: m4_decs_fold bench lane + anti-DCE accept sweep + order_by+first splice arm

### DIFF
--- a/benchmarks/sql/M4_DECS_EXPANSION.md
+++ b/benchmarks/sql/M4_DECS_EXPANSION.md
@@ -1,0 +1,246 @@
+# m4_decs_fold lane — expansion plan
+
+Adds a third benchmark target alongside `m1_sql` (SQL via `_sql`) and `m3`/`m3f` (array linq, with/without `_fold` splice). The new lane is `m4_decs_fold`:
+
+```das
+_fold(from_decs_template(type<DecsCar>)._where(...)._select(...).sum())
+```
+
+Goal: tri-platform comparison (SQL vs array vs decs) under the same chain shape, so the splice path's decs win is directly comparable to its array win.
+
+## Baseline matrix (2026-05-20, before m4 expansion)
+
+100K rows, INTERP mode. m3f = `_fold(each(arr)...)`. Lower is better.
+
+### Headlines (m3f wins both)
+
+| benchmark | m1 sql | m3 | m3f | m1/m3f | m3/m3f |
+|---|---:|---:|---:|---:|---:|
+| sum_aggregate | 29 | 30 | **2** | 14.5× | 15.0× |
+| select_where_count | 32 | 57 | **5** | 6.4× | 11.4× |
+| sum_where | 32 | 43 | **4** | 8.0× | 10.8× |
+| chained_where | 36 | 45 | **6** | 6.0× | 7.5× |
+| aggregate_match | 34 | 49 | **5** | 6.8× | 9.8× |
+| all_match | 27 | 21 | **3** | 9.0× | 7.0× |
+| take_while_match | 7 | 22 | **2** | 3.5× | 11.0× |
+| count_aggregate | 29 | 29 | **4** | 7.2× | 7.2× |
+| select_where_sum | 36 | 60 | **7** | 5.1× | 8.6× |
+| to_array_filter | 74 | 42 | **11** | 6.7× | 3.8× |
+
+### Order/sort family (m3f dominates m3)
+
+| benchmark | m1 | m3 | m3f | m3/m3f |
+|---|---:|---:|---:|---:|
+| sort_take | 38 | 763 | **27** | 28.3× |
+| order_take_desc | 38 | 746 | **27** | 27.6× |
+| select_where_order_take | 36 | 379 | **24** | 15.8× |
+| sort_first | 37 | 742 | **756** | (regresses; sort dominates) |
+
+### Group-by family (2-5× wins)
+
+| benchmark | m1 | m3 | m3f | m1/m3f | m3/m3f |
+|---|---:|---:|---:|---:|---:|
+| groupby_sum | 173 | 102 | **37** | 4.7× | 2.8× |
+| groupby_count | 143 | 68 | **36** | 4.0× | 1.9× |
+| groupby_average | 171 | 106 | **52** | 3.3× | 2.0× |
+| groupby_having_count | 144 | 74 | **36** | 4.0× | 2.1× |
+| groupby_having_hidden_sum | 175 | 103 | **40** | 4.4× | 2.6× |
+| groupby_max | 174 | 103 | **44** | 4.0× | 2.3× |
+| groupby_min | 173 | 106 | **43** | 4.0× | 2.5× |
+| groupby_multi_reducer | 190 | 139 | **53** | 3.6× | 2.6× |
+| groupby_select_sum | — | 110 | **59** | — | 1.9× |
+| groupby_where_count | 76 | 64 | **23** | 3.3× | 2.8× |
+| groupby_where_sum | 86 | 79 | **23** | 3.7× | 3.4× |
+| groupby_first | — | 68 | **35** | — | 1.9× |
+
+### Anomalies / weak spots
+
+| benchmark | m1 | m3 | m3f | note |
+|---|---:|---:|---:|---|
+| indexed_lookup | 1,431 | 2,029,891 | 200,399 | SQL B-tree wins 1417× over linear scan; splice helps 10× over m3 but algorithmically can't match SQL. Decs equivalent uses **eid lookup** (archetype hash lookup, fast path). |
+| zip_dot_product | — | 52 | 57 | plan_zip landed but bench shape doesn't hit the splice (m3f slower than m3 by 10%). Worth a follow-up. |
+| join_count | — | 116 | 122 | No splice arm for join. m3f slightly slower. |
+| sort_first | 37 | 742 | 756 | Sort dominates the whole pipeline. m3f doesn't help when terminator is `first` after a full sort. |
+| distinct_take | — | 30 | 0 | m3f=0 ns/op — bench may be constant-folded; verify it actually exercises the chain. |
+| take_count_filtered / take_sum_aggregate / select_count / first_match / element_at_match / reverse_take / skip_take | various | various | 0 | Several 0 ns/op cases — verify the chain isn't being eliminated by DCE. |
+
+## Decs benchmarks (already in `benchmarks/decs/`)
+
+| benchmark | m1_hand_query | m2_eager_bridge | m3_fold_splice / m4_template_fold |
+|---|---:|---:|---:|
+| from_decs_count | 0 (arch.size) | 60 | **0** (matches hand) |
+| from_decs_sum | 4 (query) | 202 | **8** (within 2× of hand) |
+
+## m4_decs_fold expansion — triage
+
+Inventory of every `benchmarks/sql/*.das` benchmark with **decs feasibility** classification. Surfaces that don't yet exist on the decs side are flagged so we can decide whether to expand the decs surface.
+
+### Category A — clean decs map (no new surface needed)
+
+These translate directly: array `each(arr)._chain()` becomes decs `from_decs_template(type<T>)._chain()`. Splice already covers all chain shapes used.
+
+- aggregate_match
+- all_match
+- any_match
+- average_aggregate
+- chained_where
+- contains_match
+- count_aggregate
+- distinct_count
+- first_match
+- first_or_default_match
+- last_match
+- long_count_aggregate
+- max_aggregate
+- min_aggregate
+- select_count
+- select_where
+- select_where_count
+- select_where_sum
+- single_match
+- sum_aggregate
+- sum_where
+- take_count
+- take_count_filtered
+- take_sum_aggregate
+- take_while_match
+- skip_while_match
+- to_array_filter
+
+### Category B — clean decs map but needs Slice 5+ splice arms
+
+Chain shape works on decs surface today (via eager bridge), but splice planner doesn't yet handle the shape — would fall to tier-2 cascade. Listing here so each entry doubles as a future-slice trigger.
+
+- bare_order_where (order_by / reverse on decs — Slice 5+)
+- distinct_take (distinct_by + take on decs — Slice 5+)
+- element_at_match (element_at — Slice 5+)
+- groupby_average / groupby_count / groupby_first / groupby_having_count / groupby_having_hidden_sum / groupby_max / groupby_min / groupby_multi_reducer / groupby_select_sum / groupby_sum / groupby_where_count / groupby_where_sum — all need decs group_by splice (state-table family Slice 5+)
+- order_take_desc / select_where_order_take / sort_first / sort_take — order_by family on decs (Slice 5+)
+- reverse_take — reverse on decs (Slice 5+)
+- skip_take — skip+take chain on decs (Slice 5+)
+
+### Category C — needs new decs surface
+
+Benchmarks whose shape doesn't have a corresponding decs equivalent yet. Decision: build the surface OR skip.
+
+- **indexed_lookup** — SQL uses B-tree on `id`. Decs analog: **eid-based lookup** via `lookup_entity` (decs.das has `[eid]` component lookup). Build a `m4_decs_eid_lookup` lane that exercises this. NEW SURFACE: thin wrapper if needed.
+- **zip_dot_product** — pairs two parallel arrays. Decs analog: pair two component streams from the SAME archetype (intra-archetype zip is free — it's just multi-iter for over both components). Or zip across two archetypes (cross-archetype, harder). NEW SURFACE: `from_decs_template_zip` or syntactic-sugar wrapper. Worth investigating; could be a clean Slice surface add.
+- **join_count** — two tables joined. Decs analog: cross-archetype query with eid linkage. NEW SURFACE: `join_decs` or two-template iter. Larger design exercise; defer to follow-up.
+
+## Proposed execution order
+
+1. **Wave 1 — Category A only** (28 benchmarks). All splice today, all comparable now. Establishes the m4 surface in `_common.das` + per-bench m4 lane. Validates the lane convention before scope grows.
+2. **Wave 2 — Category C surface adds**:
+   - `indexed_lookup` via decs eid lookup (small change)
+   - `zip_dot_product` via decs intra-archetype zip (design discussion)
+   - `join_count` deferred to a later wave (full decs join design)
+3. **Wave 3 — Category B**: ship m4 lanes for these now using the eager bridge (so the matrix is complete), THEN as plan_decs_unroll Slice 5+ lands, the lanes start showing the splice win. Each lane stays valid throughout.
+
+## Conventions for m4 lanes
+
+Per Boris (2026-05-20):
+- One lane per benchmark, named `<bench>_m4` reported as `m4_decs_fold/{n}` (`m4` for ordinal, `decs_fold` for clarity)
+- Per-benchmark fixture call (each file calls `fixture_decs(n)` inline, mirroring how m3 calls `fixture_array(n)` inline)
+- Shared `[decs_template] DecsCar` + `fixture_decs(n)` in `_common.das` (mirrors how m3's `Car` + `fixture_array` are shared)
+- Lambda-typed args (`$(c : Car)`) replaced with `_select(_.field)` macro form in m4 bodies (Car type doesn't match the decs tuple element)
+- Sentinel values (`first_or_default`) use named-tuple literal `(id=…, name=…, …)` matching the iterator element type
+
+## First m4 sweep — results (2026-05-20, 100K rows, INTERP)
+
+47 benchmarks gained an m4 lane (all Cat A + Cat B). Skipped: `indexed_lookup`, `join_count`, `zip_dot_product` (Cat C, need surface).
+
+### Cat A — m4 splices today (chain shape covered by plan_decs_unroll)
+
+| benchmark | m1 | m3 | m3f | m4 | m4/m1 | m4/m3f | notes |
+|---|---:|---:|---:|---:|---:|---:|---|
+| sum_aggregate | 30 | 29 | 2 | **16** | 0.5x | 8x | 6-component multi-iter overhead floor |
+| select_where_sum | 36 | 57 | 7 | **18** | 0.5x | 2.6x | chain splice; beats m1 + m3 |
+| select_where_count | 32 | 58 | 5 | **18** | 0.6x | 3.6x | chain splice; beats m1 + m3 |
+| count_aggregate | 30 | 28 | 4 | **15** | 0.5x | 3.8x | (count with filter — not bare; filter walks all entities) |
+| long_count_aggregate | 29 | 28 | 4 | **15** | 0.5x | 3.8x | parallel to count |
+| sum_where | 32 | 45 | 4 | **17** | 0.5x | 4.2x | |
+| chained_where | 36 | 46 | 6 | **18** | 0.5x | 3x | |
+| select_where | 190 | 28 | 11 | **22** | **0.1x** | 2x | m4 8.6x faster than m1 SQL |
+| max_aggregate | 30 | 36 | 5 | **19** | 0.6x | 3.8x | |
+| min_aggregate | 30 | 38 | 6 | **19** | 0.6x | 3.2x | |
+| average_aggregate | 30 | 34 | 5 | **21** | 0.7x | 4.2x | |
+| all_match | 27 | 20 | 3 | **15** | 0.6x | 5x | early-exit on bridge |
+| to_array_filter | 70 | 43 | 11 | **24** | **0.3x** | 2.2x | m4 2.9x faster than m1 SQL |
+| first_match | 0 | 28 | 0 | **0** | — | — | early-exit on first hit |
+| first_or_default_match | 0 | 31 | 0 | **0** | — | — | |
+| any_match | 0 | 0 | 0 | **0** | — | — | |
+| contains_match | 0 | 28 | 2 | **8** | — | 4x | |
+
+**Net Cat A:** m4 beats SQL on most shapes (8 of 17 with concrete m1+m4 numbers; another 4 at 0 ns/op). m4 vs m3f shows a ~3-5× decs overhead from the 6-component multi-iter for-loop (every component's get_ro participates even when chain only reads one field). This is the splice's structural cost on a multi-field decs schema.
+
+### Cat B — m4 falls back to eager bridge (splice deferred to Slice 5+)
+
+These chain shapes splice on array but not yet on decs. m4 = eager bridge (materialize array<tuple>, then run on array). Slower than m3f but the comparison is real today.
+
+| benchmark | m1 | m3 | m3f | m4 | m4/m3f | needs splice arm |
+|---|---:|---:|---:|---:|---:|---|
+| bare_order_where | 273 | 357 | 120 | 196 | 1.6x | order_by on decs |
+| distinct_count | 41 | 43 | 15 | 97 | 6.5x | distinct on decs |
+| distinct_take | 0 | 30 | 0 | 34 | — | distinct + take on decs |
+| order_take_desc | 37 | 698 | 27 | 117 | 4.3x | order_by + take |
+| reverse_take | 0 | 22 | 0 | 114 | — | reverse + take |
+| select_count | 0 | 32 | 0 | 3 | — | (m4 likely DCE — verify) |
+| select_where_order_take | 36 | 355 | 24 | 102 | 4.2x | order + take after where |
+| skip_take | 0 | 15 | 0 | 37 | — | take/skip on decs |
+| skip_while_match | 3 | 20 | 5 | 83 | 16.6x | skip_while on decs |
+| sort_first | 37 | 713 | 722 | 802 | 1.1x | sort dominates; splice barely helps |
+| sort_take | 38 | 715 | 27 | 119 | 4.4x | order + take |
+| take_count | 3 | 0 | 0 | 36 | — | take on decs |
+| take_count_filtered | — | 29 | 0 | 35 | — | take after where |
+| take_sum_aggregate | — | 28 | 0 | 34 | — | take + sum |
+| take_while_match | 7 | 22 | 2 | 55 | 27.5x | take_while on decs |
+| element_at_match | 0 | 28 | 0 | 35 | — | element_at on decs |
+| last_match | 0 | 29 | 5 | 83 | 16.6x | last on decs |
+| single_match | 0 | 19 | 2 | 80 | 40x | single on decs |
+| groupby_count | 142 | 65 | 37 | 115 | 3.1x | group_by on decs (state-table) |
+| groupby_sum | 171 | 101 | 36 | 115 | 3.2x | group_by on decs |
+| groupby_average | 172 | 99 | 52 | 128 | 2.5x | group_by on decs |
+| groupby_max | 174 | 103 | 43 | 120 | 2.8x | group_by on decs |
+| groupby_min | 175 | 105 | 42 | 122 | 2.9x | group_by on decs |
+| groupby_first | — | 68 | 35 | 112 | 3.2x | group_by on decs |
+| groupby_having_count | 142 | 71 | 37 | 114 | 3.1x | group_by on decs |
+| groupby_having_hidden_sum | 176 | 102 | 40 | 122 | 3.0x | group_by on decs |
+| groupby_multi_reducer | 191 | 138 | 52 | 130 | 2.5x | group_by on decs |
+| groupby_select_sum | — | 109 | 60 | 137 | 2.3x | group_by on decs |
+| groupby_where_count | 76 | 63 | 23 | 101 | 4.4x | group_by on decs |
+| groupby_where_sum | 101 | 81 | 23 | 105 | 4.6x | group_by on decs |
+| aggregate_match | 34 | 50 | 5 | 84 | 16.8x | `aggregate(init, $(acc, c) => …)` — not a `_select(_.x).sum()` shape, distinct planner |
+
+**Net Cat B:** Establishes today's baseline. As Slice 5+ lands group_by/order/distinct/take splice arms on the decs bridge, these rows will drop into Cat A territory and the splice win will become visible without changing the benchmark.
+
+### Suspect "0 ns/op" m4 results — verify the chain isn't getting DCE'd
+
+- `first_match` / `first_or_default_match` — early-exit on the first archetype's first entity is genuinely cheap; plausible
+- `any_match` / `select_count` — both 0 on m4 and m3f; likely constant-folded
+- `take_count` / `take_count_filtered` / `take_sum_aggregate` / `reverse_take` / `skip_take` / `distinct_take` — m4=34-37 ns (eager bridge); m3f=0 ns; m1 mostly 0 too. The m3f=0 cases are suspicious — bench may be eliminating the chain at compile time. Worth dropping a `b->failNow()` floor check or a side effect to confirm.
+
+## Wave 2 — surface expansions
+
+After this m4 sweep ships, expand the surface for Cat C benchmarks:
+
+1. **`indexed_lookup`** — add `m4_decs_eid_lookup` lane using `lookup_entity` / archetype hash lookup. Decs hash-of-eid IS the fast path; benchmark it against SQL B-tree. May require minor surface (a `find_entity_by_field` helper)
+2. **`zip_dot_product`** — design intra-archetype zip surface. Two components from the SAME archetype is just a multi-iter for-loop (free). Cross-archetype zip is harder. Pick the design that lets `_zip` on decs match the array_zip shape
+3. **`join_count`** — needs full decs join design. Multi-table query equivalent via two `[decs_template]` structs + eid linkage. Larger design exercise; defer
+
+## Wave 3 — Slice 5+ enables Cat B splice
+
+As `plan_decs_unroll` gains:
+- take/skip/take_while/skip_while arms (cross-archetype counter / for_each_archetype_find early-exit)
+- distinct/group_by state-table arms (hoisted table above outer for_each_archetype)
+- order_by / reverse buffer arms
+
+…Cat B m4 numbers will drop dramatically (from ~100-130 ns down to the 5-20 ns range), matching the Cat A pattern. The matrix becomes a regression guard for each splice arm.
+
+## Wave 4 — perf optimizations on plan_decs_unroll
+
+Known overhead in the current splice: **6-component multi-iter for-loop walks ALL components** even when the chain only reads one field. Possible optimizations:
+- Track per-chain "components actually accessed" set; emit `get_ro` + iter binding only for those
+- For bare-count chains: arch.size shortcut works (already implemented) → 0 ns
+- For single-field selects: 1-component for-loop should match the array case
+
+If implemented, m4 numbers on Cat A would close most of the 3-5× gap vs m3f, making decs effectively as fast as array for projection-heavy chains.

--- a/benchmarks/sql/M4_DECS_EXPANSION.md
+++ b/benchmarks/sql/M4_DECS_EXPANSION.md
@@ -244,3 +244,13 @@ Known overhead in the current splice: **6-component multi-iter for-loop walks AL
 - For single-field selects: 1-component for-loop should match the array case
 
 If implemented, m4 numbers on Cat A would close most of the 3-5× gap vs m3f, making decs effectively as fast as array for projection-heavy chains.
+
+## Update — sort_first fix (2026-05-20, plan_order_family + first arm)
+
+Extended `plan_order_family` to recognize `first` / `first_or_default` as terminators alongside `take(N)`. `order_by + first` now splices to a single-pass `min_by` (array source: zero-alloc empty-guard + `min_by`; iterator source: `top_n_by(_, 1, _) |> first()`). `order_by_descending` routes to `max_by`. Preserves the eager `first()` panic-on-empty contract.
+
+| benchmark | m1 | m3 | m3f (old) | m3f (new) | m4 (old) | m4 (new) | m3f win |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| sort_first | 37 | 713 | 722 | **42** | 802 | **121** | 17× |
+
+Now `sort_first` lands in line with the rest of the order-family. m4_decs_fold still rides the eager bridge (Slice 5+ will close the gap).

--- a/benchmarks/sql/_common.das
+++ b/benchmarks/sql/_common.das
@@ -7,6 +7,7 @@ require sqlite/sqlite_boost public
 require sqlite/sqlite_linq public
 require dastest/testing_boost public
 require daslib/fio public
+require daslib/decs_boost public
 
 let public BRAND_COUNT = 5
 let public DEALER_COUNT = 100
@@ -74,4 +75,29 @@ def public fixture_dealers_array() : array<Dealer> {
         arr[i] = Dealer(id = i + 1, name = "Dealer{i}")
     }
     return <- arr
+}
+
+// m4_decs_fold lane: same Car schema, decs-archetype-backed. Same row generator as fixture_array so fold splice perf is directly comparable across SQL / array / decs.
+[decs_template(prefix = "car_")]
+struct public DecsCar {
+    id        : int
+    name      : string
+    price     : int
+    brand     : int
+    year      : int
+    dealer_id : int
+}
+
+def public fixture_decs(n : int) {
+    restart()
+    create_entities(n) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        apply_decs_template(cmp, DecsCar(
+            id = i + 1,
+            name = "Car{i}",
+            price = (i * 37) % 1000,
+            brand = i % BRAND_COUNT,
+            year = 2010 + (i * 7) % 16,
+            dealer_id = (i % DEALER_COUNT) + 1
+        ))
+    }
 }

--- a/benchmarks/sql/aggregate_match.das
+++ b/benchmarks/sql/aggregate_match.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
         b |> run("m1_sql/{n}", n) {
             let total = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD)
                                 |> _select(_.price) |> sum())
+            b |> accept(total)
             if (total == 0) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let total = (arr |> _where(_.price > THRESHOLD)
                          |> aggregate(0, $(acc : int, c : Car) => acc + c.price))
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }
@@ -38,6 +40,7 @@ def run_m3f(b : B?; n : int) {
     b |> run("m3f_array_fold/{n}", n) {
         let total = _fold(each(arr)._where(_.price > THRESHOLD)
             .aggregate(0, $(acc : int, c : Car) => acc + c.price))
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }
@@ -49,6 +52,7 @@ def run_m4(b : B?; n : int) {
     b |> run("m4_decs_fold/{n}", n) {
         let total = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
             .aggregate(0, $(acc, c) => acc + c.price))
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/aggregate_match.das
+++ b/benchmarks/sql/aggregate_match.das
@@ -44,6 +44,17 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let total = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
+            .aggregate(0, $(acc, c) => acc + c.price))
+        if (total == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def aggregate_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +68,9 @@ def aggregate_match_m3(b : B?) {
 [benchmark]
 def aggregate_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def aggregate_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/all_match.das
+++ b/benchmarks/sql/all_match.das
@@ -40,6 +40,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let yes = _fold(from_decs_template(type<DecsCar>)._all(_.price < 9999))
+        if (!yes) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def all_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -53,4 +63,9 @@ def all_match_m3(b : B?) {
 [benchmark]
 def all_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def all_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/all_match.das
+++ b/benchmarks/sql/all_match.das
@@ -14,6 +14,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let bad = _sql(db |> select_from(type<Car>) |> _where(_.price >= 9999) |> count())
+            b |> accept(bad)
             if (bad != 0) {
                 b->failNow()
             }
@@ -25,6 +26,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let yes = arr |> _all(_.price < 9999)
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }
@@ -34,6 +36,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let yes = _fold(each(arr)._all(_.price < 9999))
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }
@@ -44,6 +47,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let yes = _fold(from_decs_template(type<DecsCar>)._all(_.price < 9999))
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }

--- a/benchmarks/sql/any_match.das
+++ b/benchmarks/sql/any_match.das
@@ -14,6 +14,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let opt = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> _first_opt())
+            b |> accept(opt)
             if (!is_some(opt)) {
                 b->failNow()
             }
@@ -25,6 +26,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let yes = arr |> _any(_.price > THRESHOLD)
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }
@@ -34,6 +36,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let yes = _fold(each(arr)._any(_.price > THRESHOLD))
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }
@@ -44,6 +47,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let yes = _fold(from_decs_template(type<DecsCar>)._any(_.price > THRESHOLD))
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }

--- a/benchmarks/sql/any_match.das
+++ b/benchmarks/sql/any_match.das
@@ -40,6 +40,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let yes = _fold(from_decs_template(type<DecsCar>)._any(_.price > THRESHOLD))
+        if (!yes) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def any_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -53,4 +63,9 @@ def any_match_m3(b : B?) {
 [benchmark]
 def any_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def any_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/average_aggregate.das
+++ b/benchmarks/sql/average_aggregate.das
@@ -11,6 +11,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let a = _sql(db |> select_from(type<Car>) |> _select(_.price) |> average())
+            b |> accept(a)
             if (a == 0.0lf) {
                 b->failNow()
             }
@@ -22,6 +23,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let a = arr |> _select(double(_.price)) |> average()
+        b |> accept(a)
         if (a == 0.0lf) {
             b->failNow()
         }
@@ -31,6 +33,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let a = _fold(each(arr)._select(double(_.price)).average())
+        b |> accept(a)
         if (a == 0.0lf) {
             b->failNow()
         }
@@ -41,6 +44,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let a = _fold(from_decs_template(type<DecsCar>)._select(double(_.price)).average())
+        b |> accept(a)
         if (a == 0.0lf) {
             b->failNow()
         }

--- a/benchmarks/sql/average_aggregate.das
+++ b/benchmarks/sql/average_aggregate.das
@@ -37,6 +37,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let a = _fold(from_decs_template(type<DecsCar>)._select(double(_.price)).average())
+        if (a == 0.0lf) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def average_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -50,4 +60,9 @@ def average_aggregate_m3(b : B?) {
 [benchmark]
 def average_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def average_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/bare_order_where.das
+++ b/benchmarks/sql/bare_order_where.das
@@ -18,6 +18,7 @@ def run_m1(b : B?; n : int) {
             let rows <- _sql(db |> select_from(type<Car>)
                                 |> _where(_.price > THRESHOLD)
                                 |> _order_by(_.price))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -30,6 +31,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> _where(_.price > THRESHOLD)
                          |> _order_by(_.price))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -42,6 +44,7 @@ def run_m3f(b : B?; n : int) {
         let rows <- _fold(each(arr)._where(_.price > THRESHOLD)
                                    ._order_by(_.price)
                                    .to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -54,6 +57,7 @@ def run_m4(b : B?; n : int) {
         let rows <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
                                    ._order_by(_.price)
                                    .to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/bare_order_where.das
+++ b/benchmarks/sql/bare_order_where.das
@@ -48,6 +48,18 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
+                                   ._order_by(_.price)
+                                   .to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def bare_order_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -61,4 +73,9 @@ def bare_order_where_m3(b : B?) {
 [benchmark]
 def bare_order_where_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def bare_order_where_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/chained_where.das
+++ b/benchmarks/sql/chained_where.das
@@ -49,6 +49,18 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
+                               ._where(_.year >= YEAR_FLOOR)
+                               .count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def chained_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -62,4 +74,9 @@ def chained_where_m3(b : B?) {
 [benchmark]
 def chained_where_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def chained_where_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/chained_where.das
+++ b/benchmarks/sql/chained_where.das
@@ -19,6 +19,7 @@ def run_m1(b : B?; n : int) {
                             |> _where(_.price > THRESHOLD)
                             |> _where(_.year >= YEAR_FLOOR)
                             |> count())
+            b |> accept(c)
             if (c == 0) {
                 b->failNow()
             }
@@ -32,6 +33,7 @@ def run_m3(b : B?; n : int) {
         let c = (arr |> _where(_.price > THRESHOLD)
                      |> _where(_.year >= YEAR_FLOOR)
                      |> count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -43,6 +45,7 @@ def run_m3f(b : B?; n : int) {
         let c = _fold(each(arr)._where(_.price > THRESHOLD)
                                ._where(_.year >= YEAR_FLOOR)
                                .count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -55,6 +58,7 @@ def run_m4(b : B?; n : int) {
         let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
                                ._where(_.year >= YEAR_FLOOR)
                                .count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/contains_match.das
+++ b/benchmarks/sql/contains_match.das
@@ -43,6 +43,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let yes = _fold(from_decs_template(type<DecsCar>)._select(_.id).contains(TARGET_ID))
+        if (!yes) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def contains_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -56,4 +66,9 @@ def contains_match_m3(b : B?) {
 [benchmark]
 def contains_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def contains_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/contains_match.das
+++ b/benchmarks/sql/contains_match.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         b |> run("m1_sql/{n}", n) {
             // SQL doesn't have a direct CONTAINS for arbitrary values; use _any with _where.
             let opt = _sql(db |> select_from(type<Car>) |> _where(_.id == TARGET_ID) |> _first_opt())
+            b |> accept(opt)
             if (!is_some(opt)) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
         // Project ids out then contains. Mirrors what `_fold(...select.contains(...))` does
         // — an array-source linq chain materializes `select` first then iterates contains.
         let yes = arr |> _select(_.id) |> contains(TARGET_ID)
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }
@@ -37,6 +39,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let yes = _fold(each(arr)._select(_.id).contains(TARGET_ID))
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }
@@ -47,6 +50,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let yes = _fold(from_decs_template(type<DecsCar>)._select(_.id).contains(TARGET_ID))
+        b |> accept(yes)
         if (!yes) {
             b->failNow()
         }

--- a/benchmarks/sql/count_aggregate.das
+++ b/benchmarks/sql/count_aggregate.das
@@ -44,6 +44,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def count_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +67,9 @@ def count_aggregate_m3(b : B?) {
 [benchmark]
 def count_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def count_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/count_aggregate.das
+++ b/benchmarks/sql/count_aggregate.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let c = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> count())
+            b |> accept(c)
             if (c == 0) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let c = arr |> _where(_.price > THRESHOLD) |> count()
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -38,6 +40,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let c = _fold(each(arr)._where(_.price > THRESHOLD).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -48,6 +51,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/distinct_count.das
+++ b/benchmarks/sql/distinct_count.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _select(_.brand) |> distinct())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -26,6 +27,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> _select(_.brand) |> distinct())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -35,6 +37,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let rows <- _fold(each(arr)._select(_.brand).distinct().to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -45,6 +48,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let rows <- _fold(from_decs_template(type<DecsCar>)._select(_.brand).distinct().to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/distinct_count.das
+++ b/benchmarks/sql/distinct_count.das
@@ -41,6 +41,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>)._select(_.brand).distinct().to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def distinct_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +64,9 @@ def distinct_count_m3(b : B?) {
 [benchmark]
 def distinct_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def distinct_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/distinct_take.das
+++ b/benchmarks/sql/distinct_take.das
@@ -51,6 +51,18 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>)._select(_.brand).distinct().take(TAKE_N).to_array())
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -64,4 +76,9 @@ def distinct_take_m3(b : B?) {
 [benchmark]
 def distinct_take_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def distinct_take_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/distinct_take.das
+++ b/benchmarks/sql/distinct_take.das
@@ -20,6 +20,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _select(_.brand) |> distinct() |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -32,6 +33,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         unsafe {
             let rows <- (each(arr) |> _select(_.brand) |> distinct() |> take(TAKE_N) |> to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -44,6 +46,7 @@ def run_m3f(b : B?; n : int) {
     b |> run("m3f_array_fold/{n}", n) {
         unsafe {
             let rows <- _fold(each(arr)._select(_.brand).distinct().take(TAKE_N).to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -56,6 +59,7 @@ def run_m4(b : B?; n : int) {
     b |> run("m4_decs_fold/{n}", n) {
         unsafe {
             let rows <- _fold(from_decs_template(type<DecsCar>)._select(_.brand).distinct().take(TAKE_N).to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }

--- a/benchmarks/sql/element_at_match.das
+++ b/benchmarks/sql/element_at_match.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
         b |> run("m1_sql/{n}", n) {
             let row = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD)
                               |> skip(INDEX) |> _first())
+            b |> accept(row)
             if (row.price == 0) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let row = arr |> _where(_.price > THRESHOLD) |> element_at(INDEX)
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }
@@ -36,6 +38,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let row = _fold(each(arr)._where(_.price > THRESHOLD).element_at(INDEX))
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }
@@ -46,6 +49,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).element_at(INDEX))
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/element_at_match.das
+++ b/benchmarks/sql/element_at_match.das
@@ -42,6 +42,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).element_at(INDEX))
+        if (row.price == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def element_at_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -55,4 +65,9 @@ def element_at_match_m3(b : B?) {
 [benchmark]
 def element_at_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def element_at_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/first_match.das
+++ b/benchmarks/sql/first_match.das
@@ -41,6 +41,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).first())
+        if (row.price == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def first_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +64,9 @@ def first_match_m3(b : B?) {
 [benchmark]
 def first_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def first_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/first_match.das
+++ b/benchmarks/sql/first_match.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let row = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> _first())
+            b |> accept(row)
             if (row.price == 0) {
                 b->failNow()
             }
@@ -26,6 +27,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let row = arr |> _where(_.price > THRESHOLD) |> first()
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }
@@ -35,6 +37,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let row = _fold(each(arr)._where(_.price > THRESHOLD).first())
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }
@@ -45,6 +48,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).first())
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/first_or_default_match.das
+++ b/benchmarks/sql/first_or_default_match.das
@@ -43,6 +43,17 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    let sentinel = (id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).first_or_default(sentinel))
+        if (row.id == SENTINEL_ID) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def first_or_default_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -56,4 +67,9 @@ def first_or_default_match_m3(b : B?) {
 [benchmark]
 def first_or_default_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def first_or_default_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/first_or_default_match.das
+++ b/benchmarks/sql/first_or_default_match.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let row = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> _first())
+            b |> accept(row)
             if (row.price == 0) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
     b |> run("m3_array/{n}", n) {
         let row = arr |> _where(_.price > THRESHOLD) |> first_or_default(sentinel)
+        b |> accept(row)
         if (row.id == SENTINEL_ID) {
             b->failNow()
         }
@@ -37,6 +39,7 @@ def run_m3f(b : B?; n : int) {
     let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
     b |> run("m3f_array_fold/{n}", n) {
         let row = _fold(each(arr)._where(_.price > THRESHOLD).first_or_default(sentinel))
+        b |> accept(row)
         if (row.id == SENTINEL_ID) {
             b->failNow()
         }
@@ -48,6 +51,7 @@ def run_m4(b : B?; n : int) {
     let sentinel = (id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
     b |> run("m4_decs_fold/{n}", n) {
         let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).first_or_default(sentinel))
+        b |> accept(row)
         if (row.id == SENTINEL_ID) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_average.das
+++ b/benchmarks/sql/groupby_average.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0,
                                               AvgPrice = _._1 |> select($(c : Car) => c.price) |> average())))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
                                                        AvgPrice = _._1 |> select($(c : Car) => c.price) |> average())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -41,6 +43,7 @@ def run_m3f(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       AvgPrice = _._1 |> select($(c : Car) => c.price) |> average()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -55,6 +58,7 @@ def run_m4(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       AvgPrice = _._1 |> _select(_.price) |> average()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_average.das
+++ b/benchmarks/sql/groupby_average.das
@@ -47,6 +47,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      AvgPrice = _._1 |> _select(_.price) |> average()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_average_m1(b : B?) {
     run_m1(b, 100000)
@@ -60,4 +74,9 @@ def groupby_average_m3(b : B?) {
 [benchmark]
 def groupby_average_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_average_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_count.das
+++ b/benchmarks/sql/groupby_count.das
@@ -45,6 +45,19 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0, N = _._1 |> length))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +71,9 @@ def groupby_count_m3(b : B?) {
 [benchmark]
 def groupby_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_count.das
+++ b/benchmarks/sql/groupby_count.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
             let groups <- _sql(db |> select_from(type<Car>)
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0, N = _._1 |> length)))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._select((Brand = _._0, N = _._1 |> length)))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -39,6 +41,7 @@ def run_m3f(b : B?; n : int) {
                             ._group_by(_.brand)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -52,6 +55,7 @@ def run_m4(b : B?; n : int) {
                             ._group_by(_.brand)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_first.das
+++ b/benchmarks/sql/groupby_first.das
@@ -31,6 +31,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      FirstCar = _._1 |> first()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_first_m3(b : B?) {
     run_m3(b, 100000)
@@ -39,4 +53,9 @@ def groupby_first_m3(b : B?) {
 [benchmark]
 def groupby_first_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_first_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_first.das
+++ b/benchmarks/sql/groupby_first.das
@@ -12,6 +12,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
                                                        FirstCar = _._1 |> first())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -25,6 +26,7 @@ def run_m3f(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       FirstCar = _._1 |> first()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -39,6 +41,7 @@ def run_m4(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       FirstCar = _._1 |> first()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_having_count.das
+++ b/benchmarks/sql/groupby_having_count.das
@@ -18,6 +18,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _having(_._1 |> length >= 5)
                                   |> _select((Brand = _._0, N = _._1 |> length)))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -29,6 +30,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._having(_._1 |> length >= 5)._select((Brand = _._0, N = _._1 |> length)))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -42,6 +44,7 @@ def run_m3f(b : B?; n : int) {
                             ._having(_._1 |> length >= 5)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -56,6 +59,7 @@ def run_m4(b : B?; n : int) {
                             ._having(_._1 |> length >= 5)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_having_count.das
+++ b/benchmarks/sql/groupby_having_count.das
@@ -48,6 +48,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._having(_._1 |> length >= 5)
+                            ._select((Brand = _._0, N = _._1 |> length))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_having_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -61,4 +75,9 @@ def groupby_having_count_m3(b : B?) {
 [benchmark]
 def groupby_having_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_having_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_having_hidden_sum.das
+++ b/benchmarks/sql/groupby_having_hidden_sum.das
@@ -20,6 +20,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
                                   |> _select((Brand = _._0, N = _._1 |> length)))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -31,6 +32,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)._select((Brand = _._0, N = _._1 |> length)))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -44,6 +46,7 @@ def run_m3f(b : B?; n : int) {
                             ._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -58,6 +61,7 @@ def run_m4(b : B?; n : int) {
                             ._having(_._1 |> _select(_.price) |> sum > 50000)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_having_hidden_sum.das
+++ b/benchmarks/sql/groupby_having_hidden_sum.das
@@ -50,6 +50,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._having(_._1 |> _select(_.price) |> sum > 50000)
+                            ._select((Brand = _._0, N = _._1 |> length))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_having_hidden_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -63,4 +77,9 @@ def groupby_having_hidden_sum_m3(b : B?) {
 [benchmark]
 def groupby_having_hidden_sum_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_having_hidden_sum_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_max.das
+++ b/benchmarks/sql/groupby_max.das
@@ -47,6 +47,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      MaxPrice = _._1 |> _select(_.price) |> max()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_max_m1(b : B?) {
     run_m1(b, 100000)
@@ -60,4 +74,9 @@ def groupby_max_m3(b : B?) {
 [benchmark]
 def groupby_max_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_max_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_max.das
+++ b/benchmarks/sql/groupby_max.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0,
                                               MaxPrice = _._1 |> select($(c : Car) => c.price) |> max())))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
                                                        MaxPrice = _._1 |> select($(c : Car) => c.price) |> max())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -41,6 +43,7 @@ def run_m3f(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       MaxPrice = _._1 |> select($(c : Car) => c.price) |> max()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -55,6 +58,7 @@ def run_m4(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       MaxPrice = _._1 |> _select(_.price) |> max()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_min.das
+++ b/benchmarks/sql/groupby_min.das
@@ -47,6 +47,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      MinPrice = _._1 |> _select(_.price) |> min()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_min_m1(b : B?) {
     run_m1(b, 100000)
@@ -60,4 +74,9 @@ def groupby_min_m3(b : B?) {
 [benchmark]
 def groupby_min_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_min_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_min.das
+++ b/benchmarks/sql/groupby_min.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0,
                                               MinPrice = _._1 |> select($(c : Car) => c.price) |> min())))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
                                                        MinPrice = _._1 |> select($(c : Car) => c.price) |> min())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -41,6 +43,7 @@ def run_m3f(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       MinPrice = _._1 |> select($(c : Car) => c.price) |> min()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -55,6 +58,7 @@ def run_m4(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       MinPrice = _._1 |> _select(_.price) |> min()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_multi_reducer.das
+++ b/benchmarks/sql/groupby_multi_reducer.das
@@ -18,6 +18,7 @@ def run_m1(b : B?; n : int) {
                                               N = _._1 |> length,
                                               TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
                                               MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max())))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -32,6 +33,7 @@ def run_m3(b : B?; n : int) {
                                                        N = _._1 |> length,
                                                        TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
                                                        MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -47,6 +49,7 @@ def run_m3f(b : B?; n : int) {
                                       TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
                                       MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -63,6 +66,7 @@ def run_m4(b : B?; n : int) {
                                       TotalPrice = _._1 |> _select(_.price) |> sum(),
                                       MaxPrice   = _._1 |> _select(_.price) |> max()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_multi_reducer.das
+++ b/benchmarks/sql/groupby_multi_reducer.das
@@ -53,6 +53,22 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      N = _._1 |> length,
+                                      TotalPrice = _._1 |> _select(_.price) |> sum(),
+                                      MaxPrice   = _._1 |> _select(_.price) |> max()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_multi_reducer_m1(b : B?) {
     run_m1(b, 100000)
@@ -66,4 +82,9 @@ def groupby_multi_reducer_m3(b : B?) {
 [benchmark]
 def groupby_multi_reducer_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_multi_reducer_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_select_sum.das
+++ b/benchmarks/sql/groupby_select_sum.das
@@ -31,6 +31,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._select(_.price)
+                            ._group_by(_ % 100)
+                            ._select((K = _._0, S = _._1 |> sum()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_select_sum_m3(b : B?) {
     run_m3(b, 100000)
@@ -39,4 +53,9 @@ def groupby_select_sum_m3(b : B?) {
 [benchmark]
 def groupby_select_sum_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_select_sum_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_select_sum.das
+++ b/benchmarks/sql/groupby_select_sum.das
@@ -12,6 +12,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._select(_.price)._group_by(_ % 100)._select((K = _._0, S = _._1 |> sum())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -25,6 +26,7 @@ def run_m3f(b : B?; n : int) {
                             ._group_by(_ % 100)
                             ._select((K = _._0, S = _._1 |> sum()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -39,6 +41,7 @@ def run_m4(b : B?; n : int) {
                             ._group_by(_ % 100)
                             ._select((K = _._0, S = _._1 |> sum()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_sum.das
+++ b/benchmarks/sql/groupby_sum.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0,
                                               TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum())))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
                                                        TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -41,6 +43,7 @@ def run_m3f(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -55,6 +58,7 @@ def run_m4(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       TotalPrice = _._1 |> _select(_.price) |> sum()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_sum.das
+++ b/benchmarks/sql/groupby_sum.das
@@ -47,6 +47,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      TotalPrice = _._1 |> _select(_.price) |> sum()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -60,4 +74,9 @@ def groupby_sum_m3(b : B?) {
 [benchmark]
 def groupby_sum_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_sum_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_where_count.das
+++ b/benchmarks/sql/groupby_where_count.das
@@ -46,6 +46,20 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._where(_.price > 500)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0, N = _._1 |> length))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +73,9 @@ def groupby_where_count_m3(b : B?) {
 [benchmark]
 def groupby_where_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_where_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_where_count.das
+++ b/benchmarks/sql/groupby_where_count.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
                                   |> _where(_.price > 500)
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0, N = _._1 |> length)))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._where(_.price > 500)._group_by(_.brand)._select((Brand = _._0, N = _._1 |> length)))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -40,6 +42,7 @@ def run_m3f(b : B?; n : int) {
                             ._group_by(_.brand)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -54,6 +57,7 @@ def run_m4(b : B?; n : int) {
                             ._group_by(_.brand)
                             ._select((Brand = _._0, N = _._1 |> length))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/groupby_where_sum.das
+++ b/benchmarks/sql/groupby_where_sum.das
@@ -49,6 +49,21 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._where(_.price > 500)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      TotalPrice = _._1 |> _select(_.price) |> sum()))
+                            .to_array())
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def groupby_where_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -62,4 +77,9 @@ def groupby_where_sum_m3(b : B?) {
 [benchmark]
 def groupby_where_sum_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_where_sum_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_where_sum.das
+++ b/benchmarks/sql/groupby_where_sum.das
@@ -17,6 +17,7 @@ def run_m1(b : B?; n : int) {
                                   |> _group_by(_.brand)
                                   |> _select((Brand = _._0,
                                               TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum())))
+            b |> accept(groups)
             if (empty(groups)) {
                 b->failNow()
             }
@@ -29,6 +30,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         let groups <- (arr._where(_.price > 500)._group_by(_.brand)._select((Brand = _._0,
                                                                               TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum())))
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -43,6 +45,7 @@ def run_m3f(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }
@@ -58,6 +61,7 @@ def run_m4(b : B?; n : int) {
                             ._select((Brand = _._0,
                                       TotalPrice = _._1 |> _select(_.price) |> sum()))
                             .to_array())
+        b |> accept(groups)
         if (empty(groups)) {
             b->failNow()
         }

--- a/benchmarks/sql/indexed_lookup.das
+++ b/benchmarks/sql/indexed_lookup.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         let key = n / 2
         b |> run("m1_sql/{n}") {
             let c = _sql(db |> select_from(type<Car>) |> _where(_.id == key) |> count())
+            b |> accept(c)
             if (c == 0) {
                 b->failNow()
             }
@@ -28,6 +29,7 @@ def run_m3(b : B?; n : int) {
     let key = n / 2
     b |> run("m3_array/{n}") {
         let c = arr |> _where(_.id == key) |> count()
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -40,6 +42,7 @@ def run_m3f(b : B?; n : int) {
     let key = n / 2
     b |> run("m3f_array_fold/{n}") {
         let c = _fold(each(arr)._where(_.id == key).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/join_count.das
+++ b/benchmarks/sql/join_count.das
@@ -17,6 +17,7 @@ def run_m3(b : B?; n : int) {
                                $(c : Car, d : Dealer) => c.dealer_id == d.id,
                                $(c : Car, d : Dealer) => (c.name, d.name))
                       |> count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -30,6 +31,7 @@ def run_m3f(b : B?; n : int) {
                                     $(c : Car, d : Dealer) => c.dealer_id == d.id,
                                     $(c : Car, d : Dealer) => (c.name, d.name))
                            |> count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/last_match.das
+++ b/benchmarks/sql/last_match.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         b |> run("m1_sql/{n}", n) {
             let row = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD)
                               |> _order_by_descending(_.id) |> _first())
+            b |> accept(row)
             if (row.price == 0) {
                 b->failNow()
             }
@@ -26,6 +27,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let row = arr |> _where(_.price > THRESHOLD) |> last()
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }
@@ -35,6 +37,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let row = _fold(each(arr)._where(_.price > THRESHOLD).last())
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }
@@ -45,6 +48,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).last())
+        b |> accept(row)
         if (row.price == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/last_match.das
+++ b/benchmarks/sql/last_match.das
@@ -41,6 +41,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).last())
+        if (row.price == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def last_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +64,9 @@ def last_match_m3(b : B?) {
 [benchmark]
 def last_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def last_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -40,6 +40,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).long_count())
+        if (c == 0l) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def long_count_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -53,4 +63,9 @@ def long_count_aggregate_m3(b : B?) {
 [benchmark]
 def long_count_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def long_count_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -14,6 +14,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let c = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> count())
+            b |> accept(c)
             if (c == 0) {
                 b->failNow()
             }
@@ -25,6 +26,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let c = arr |> _where(_.price > THRESHOLD) |> long_count()
+        b |> accept(c)
         if (c == 0l) {
             b->failNow()
         }
@@ -34,6 +36,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let c = _fold(each(arr)._where(_.price > THRESHOLD).long_count())
+        b |> accept(c)
         if (c == 0l) {
             b->failNow()
         }
@@ -44,6 +47,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).long_count())
+        b |> accept(c)
         if (c == 0l) {
             b->failNow()
         }

--- a/benchmarks/sql/max_aggregate.das
+++ b/benchmarks/sql/max_aggregate.das
@@ -11,6 +11,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let m = _sql(db |> select_from(type<Car>) |> _select(_.price) |> max())
+            b |> accept(m)
             if (m == 0) {
                 b->failNow()
             }
@@ -22,6 +23,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let m = arr |> _select(_.price) |> max()
+        b |> accept(m)
         if (m == 0) {
             b->failNow()
         }
@@ -31,6 +33,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let m = _fold(each(arr)._select(_.price).max())
+        b |> accept(m)
         if (m == 0) {
             b->failNow()
         }
@@ -41,6 +44,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let m = _fold(from_decs_template(type<DecsCar>)._select(_.price).max())
+        b |> accept(m)
         if (m == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/max_aggregate.das
+++ b/benchmarks/sql/max_aggregate.das
@@ -37,6 +37,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let m = _fold(from_decs_template(type<DecsCar>)._select(_.price).max())
+        if (m == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def max_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -50,4 +60,9 @@ def max_aggregate_m3(b : B?) {
 [benchmark]
 def max_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def max_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/min_aggregate.das
+++ b/benchmarks/sql/min_aggregate.das
@@ -11,6 +11,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let m = _sql(db |> select_from(type<Car>) |> _select(_.price) |> min())
+            b |> accept(m)
             if (m > 999) {
                 b->failNow()
             }
@@ -22,6 +23,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let m = arr |> _select(_.price) |> min()
+        b |> accept(m)
         if (m > 999) {
             b->failNow()
         }
@@ -31,6 +33,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let m = _fold(each(arr)._select(_.price).min())
+        b |> accept(m)
         if (m > 999) {
             b->failNow()
         }
@@ -41,6 +44,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let m = _fold(from_decs_template(type<DecsCar>)._select(_.price).min())
+        b |> accept(m)
         if (m > 999) {
             b->failNow()
         }

--- a/benchmarks/sql/min_aggregate.das
+++ b/benchmarks/sql/min_aggregate.das
@@ -37,6 +37,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let m = _fold(from_decs_template(type<DecsCar>)._select(_.price).min())
+        if (m > 999) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def min_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -50,4 +60,9 @@ def min_aggregate_m3(b : B?) {
 [benchmark]
 def min_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def min_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/order_take_desc.das
+++ b/benchmarks/sql/order_take_desc.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.price) |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> _order_by_descending(_.price) |> take(TAKE_N))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -37,6 +39,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let rows <- _fold(each(arr)._order_by_descending(_.price).take(TAKE_N).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -47,6 +50,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let rows <- _fold(from_decs_template(type<DecsCar>)._order_by_descending(_.price).take(TAKE_N).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/order_take_desc.das
+++ b/benchmarks/sql/order_take_desc.das
@@ -43,6 +43,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>)._order_by_descending(_.price).take(TAKE_N).to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def order_take_desc_m1(b : B?) {
     run_m1(b, 100000)
@@ -56,4 +66,9 @@ def order_take_desc_m3(b : B?) {
 [benchmark]
 def order_take_desc_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def order_take_desc_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/reverse_take.das
+++ b/benchmarks/sql/reverse_take.das
@@ -50,6 +50,18 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>).reverse().take(TAKE_N).to_array())
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def reverse_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -63,4 +75,9 @@ def reverse_take_m3(b : B?) {
 [benchmark]
 def reverse_take_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def reverse_take_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/reverse_take.das
+++ b/benchmarks/sql/reverse_take.das
@@ -19,6 +19,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.id) |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -31,6 +32,7 @@ def run_m3(b : B?; n : int) {
     b |> run("m3_array/{n}", n) {
         unsafe {
             let rows <- (each(arr) |> reverse() |> take(TAKE_N) |> to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -43,6 +45,7 @@ def run_m3f(b : B?; n : int) {
     b |> run("m3f_array_fold/{n}", n) {
         unsafe {
             let rows <- _fold(each(arr).reverse().take(TAKE_N).to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -55,6 +58,7 @@ def run_m4(b : B?; n : int) {
     b |> run("m4_decs_fold/{n}", n) {
         unsafe {
             let rows <- _fold(from_decs_template(type<DecsCar>).reverse().take(TAKE_N).to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -41,6 +41,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._select(_.price * 2).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def select_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +64,9 @@ def select_count_m3(b : B?) {
 [benchmark]
 def select_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def select_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let c = _sql(db |> select_from(type<Car>) |> count())
+            b |> accept(c)
             if (c == 0) {
                 b->failNow()
             }
@@ -26,6 +27,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let c = arr |> _select(_.price * 2) |> count()
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -35,6 +37,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let c = _fold(each(arr)._select(_.price * 2).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -45,6 +48,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let c = _fold(from_decs_template(type<DecsCar>)._select(_.price * 2).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/select_where.das
+++ b/benchmarks/sql/select_where.das
@@ -11,6 +11,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -23,6 +24,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> _where(_.price > THRESHOLD))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -34,6 +36,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let rows <- _fold(each(arr)._where(_.price > THRESHOLD).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -44,6 +47,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let rows <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/select_where.das
+++ b/benchmarks/sql/select_where.das
@@ -40,6 +40,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def select_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -53,4 +63,9 @@ def select_where_m3(b : B?) {
 [benchmark]
 def select_where_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def select_where_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -46,6 +46,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._select(_.price * 2)._where(_ > THRESHOLD).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def select_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +69,9 @@ def select_where_count_m3(b : B?) {
 [benchmark]
 def select_where_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def select_where_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -19,6 +19,7 @@ def run_m1(b : B?; n : int) {
             // SQL form folds projection into the WHERE filter — the engine evaluates
             // ``price * 2 > T`` per row and counts matches.
             let c = _sql(db |> select_from(type<Car>) |> _where(_.price * 2 > THRESHOLD) |> count())
+            b |> accept(c)
             if (c == 0) {
                 b->failNow()
             }
@@ -30,6 +31,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let c = arr |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> count
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -40,6 +42,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let c = _fold(each(arr)._select(_.price * 2)._where(_ > THRESHOLD).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -50,6 +53,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let c = _fold(from_decs_template(type<DecsCar>)._select(_.price * 2)._where(_ > THRESHOLD).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/select_where_order_take.das
+++ b/benchmarks/sql/select_where_order_take.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
                                 |> _where(_.price > THRESHOLD)
                                 |> _order_by(_.price)
                                 |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -29,6 +30,7 @@ def run_m3(b : B?; n : int) {
         let rows <- (arr |> _where(_.price > THRESHOLD)
                          |> _order_by(_.price)
                          |> take(TAKE_N))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -43,6 +45,7 @@ def run_m3f(b : B?; n : int) {
                                    ._order_by(_.price)
                                    .take(TAKE_N)
                                    .to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -56,6 +59,7 @@ def run_m4(b : B?; n : int) {
                                    ._order_by(_.price)
                                    .take(TAKE_N)
                                    .to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/select_where_order_take.das
+++ b/benchmarks/sql/select_where_order_take.das
@@ -49,6 +49,19 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)
+                                   ._order_by(_.price)
+                                   .take(TAKE_N)
+                                   .to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def select_where_order_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -62,4 +75,9 @@ def select_where_order_take_m3(b : B?) {
 [benchmark]
 def select_where_order_take_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def select_where_order_take_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/select_where_sum.das
+++ b/benchmarks/sql/select_where_sum.das
@@ -53,6 +53,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let s = _fold(from_decs_template(type<DecsCar>)._select(_.price * 2)._where(_ > THRESHOLD).sum())
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def select_where_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -66,4 +76,9 @@ def select_where_sum_m3(b : B?) {
 [benchmark]
 def select_where_sum_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def select_where_sum_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/select_where_sum.das
+++ b/benchmarks/sql/select_where_sum.das
@@ -26,6 +26,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let s = db |> query_scalar("SELECT SUM(price * 2) FROM Cars WHERE price * 2 > {THRESHOLD}", type<int>)
+            b |> accept(s)
             if (s == 0) {
                 b->failNow()
             }
@@ -37,6 +38,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let s = arr |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> sum
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -47,6 +49,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let s = _fold(each(arr)._select(_.price * 2)._where(_ > THRESHOLD).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -57,6 +60,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let s = _fold(from_decs_template(type<DecsCar>)._select(_.price * 2)._where(_ > THRESHOLD).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/single_match.das
+++ b/benchmarks/sql/single_match.das
@@ -42,6 +42,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>)._where(_.id == TARGET_ID).single())
+        if (row.id == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def single_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -55,4 +65,9 @@ def single_match_m3(b : B?) {
 [benchmark]
 def single_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def single_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/single_match.das
+++ b/benchmarks/sql/single_match.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let row = _sql(db |> select_from(type<Car>) |> _where(_.id == TARGET_ID) |> _first())
+            b |> accept(row)
             if (row.id == 0) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let row = arr |> _where(_.id == TARGET_ID) |> single()
+        b |> accept(row)
         if (row.id == 0) {
             b->failNow()
         }
@@ -36,6 +38,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let row = _fold(each(arr)._where(_.id == TARGET_ID).single())
+        b |> accept(row)
         if (row.id == 0) {
             b->failNow()
         }
@@ -46,6 +49,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let row = _fold(from_decs_template(type<DecsCar>)._where(_.id == TARGET_ID).single())
+        b |> accept(row)
         if (row.id == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/skip_take.das
+++ b/benchmarks/sql/skip_take.das
@@ -42,6 +42,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>).skip(SKIP_N).take(TAKE_N).to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def skip_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -55,4 +65,9 @@ def skip_take_m3(b : B?) {
 [benchmark]
 def skip_take_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def skip_take_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/skip_take.das
+++ b/benchmarks/sql/skip_take.das
@@ -16,6 +16,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> skip(SKIP_N) |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -27,6 +28,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> skip(SKIP_N) |> take(TAKE_N))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -36,6 +38,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let rows <- _fold(each(arr).skip(SKIP_N).take(TAKE_N).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -46,6 +49,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let rows <- _fold(from_decs_template(type<DecsCar>).skip(SKIP_N).take(TAKE_N).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/skip_while_match.das
+++ b/benchmarks/sql/skip_while_match.das
@@ -46,6 +46,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let total = _fold(from_decs_template(type<DecsCar>)._skip_while(_.id < THRESHOLD).count())
+        if (total == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def skip_while_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +69,9 @@ def skip_while_match_m3(b : B?) {
 [benchmark]
 def skip_while_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def skip_while_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/skip_while_match.das
+++ b/benchmarks/sql/skip_while_match.das
@@ -20,6 +20,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let total = _sql(db |> select_from(type<Car>) |> _where(_.id >= THRESHOLD) |> count())
+            b |> accept(total)
             if (total == 0) {
                 b->failNow()
             }
@@ -31,6 +32,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let total = arr |> _skip_while(_.id < THRESHOLD) |> count()
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }
@@ -40,6 +42,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let total = _fold(each(arr)._skip_while(_.id < THRESHOLD).count())
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }
@@ -50,6 +53,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let total = _fold(from_decs_template(type<DecsCar>)._skip_while(_.id < THRESHOLD).count())
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/sort_first.das
+++ b/benchmarks/sql/sort_first.das
@@ -38,6 +38,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>)._order_by(_.price).first())
+        if (row.id == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def sort_first_m1(b : B?) {
     run_m1(b, 100000)
@@ -51,4 +61,9 @@ def sort_first_m3(b : B?) {
 [benchmark]
 def sort_first_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def sort_first_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/sort_first.das
+++ b/benchmarks/sql/sort_first.das
@@ -12,6 +12,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let row = _sql(db |> select_from(type<Car>) |> _order_by(_.price) |> _first())
+            b |> accept(row)
             if (row.id == 0) {
                 b->failNow()
             }
@@ -23,6 +24,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let row = arr |> _order_by(_.price) |> first()
+        b |> accept(row)
         if (row.id == 0) {
             b->failNow()
         }
@@ -32,6 +34,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let row = _fold(each(arr)._order_by(_.price).first())
+        b |> accept(row)
         if (row.id == 0) {
             b->failNow()
         }
@@ -42,6 +45,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let row = _fold(from_decs_template(type<DecsCar>)._order_by(_.price).first())
+        b |> accept(row)
         if (row.id == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/sort_take.das
+++ b/benchmarks/sql/sort_take.das
@@ -24,6 +24,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _order_by(_.price) |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -35,6 +36,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> _order_by(_.price) |> take(TAKE_N))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -45,6 +47,7 @@ def run_m3f(b : B?; n : int) {
     b |> run("m3f_array_fold/{n}", n) {
         unsafe {
             let rows <- _fold(each(arr)._order_by(_.price).take(TAKE_N).to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -57,6 +60,7 @@ def run_m4(b : B?; n : int) {
     b |> run("m4_decs_fold/{n}", n) {
         unsafe {
             let rows <- _fold(from_decs_template(type<DecsCar>)._order_by(_.price).take(TAKE_N).to_array())
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -68,6 +72,7 @@ def run_m3_topn_array(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_topn_array/{n}", n) {
         let rows <- top_n_by(arr, TAKE_N, @@(c : Car -&) => c.price)
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -78,6 +83,7 @@ def run_m3_topn_iter(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_topn_iter/{n}", n) {
         let rows <- top_n_by(arr.to_sequence(), TAKE_N, @@(c : Car -&) => c.price)
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/sort_take.das
+++ b/benchmarks/sql/sort_take.das
@@ -52,6 +52,18 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>)._order_by(_.price).take(TAKE_N).to_array())
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 def run_m3_topn_array(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_topn_array/{n}", n) {
@@ -95,4 +107,9 @@ def sort_take_m3_topn_array(b : B?) {
 [benchmark]
 def sort_take_m3_topn_iter(b : B?) {
     run_m3_topn_iter(b, 100000)
+}
+
+[benchmark]
+def sort_take_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/sum_aggregate.das
+++ b/benchmarks/sql/sum_aggregate.das
@@ -37,6 +37,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let s = _fold(from_decs_template(type<DecsCar>)._select(_.price).sum())
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def sum_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -50,4 +60,9 @@ def sum_aggregate_m3(b : B?) {
 [benchmark]
 def sum_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def sum_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/sum_aggregate.das
+++ b/benchmarks/sql/sum_aggregate.das
@@ -11,6 +11,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let s = _sql(db |> select_from(type<Car>) |> _select(_.price) |> sum())
+            b |> accept(s)
             if (s == 0) {
                 b->failNow()
             }
@@ -22,6 +23,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let s = arr |> _select(_.price) |> sum()
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -31,6 +33,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let s = _fold(each(arr)._select(_.price).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -41,6 +44,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let s = _fold(from_decs_template(type<DecsCar>)._select(_.price).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/sum_where.das
+++ b/benchmarks/sql/sum_where.das
@@ -41,6 +41,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let s = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)._select(_.price).sum())
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def sum_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +64,9 @@ def sum_where_m3(b : B?) {
 [benchmark]
 def sum_where_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def sum_where_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/sum_where.das
+++ b/benchmarks/sql/sum_where.das
@@ -15,6 +15,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let s = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> _select(_.price) |> sum())
+            b |> accept(s)
             if (s == 0) {
                 b->failNow()
             }
@@ -26,6 +27,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let s = (arr |> _where(_.price > THRESHOLD) |> _select(_.price) |> sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -35,6 +37,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let s = _fold(each(arr)._where(_.price > THRESHOLD)._select(_.price).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -45,6 +48,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let s = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)._select(_.price).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/take_count.das
+++ b/benchmarks/sql/take_count.das
@@ -14,6 +14,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> take(TAKE_N))
+            b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
             }
@@ -25,6 +26,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let rows <- (arr |> take(TAKE_N))
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -34,6 +36,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let rows <- _fold(each(arr).take(TAKE_N).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }
@@ -44,6 +47,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let rows <- _fold(from_decs_template(type<DecsCar>).take(TAKE_N).to_array())
+        b |> accept(rows)
         if (empty(rows)) {
             b->failNow()
         }

--- a/benchmarks/sql/take_count.das
+++ b/benchmarks/sql/take_count.das
@@ -40,6 +40,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let rows <- _fold(from_decs_template(type<DecsCar>).take(TAKE_N).to_array())
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def take_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -53,4 +63,9 @@ def take_count_m3(b : B?) {
 [benchmark]
 def take_count_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def take_count_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -29,6 +29,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).take(TAKE_N).count())
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def take_count_filtered_m3(b : B?) {
     run_m3(b, 100000)
@@ -37,4 +47,9 @@ def take_count_filtered_m3(b : B?) {
 [benchmark]
 def take_count_filtered_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def take_count_filtered_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -14,6 +14,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let c = arr |> _where(_.price > THRESHOLD) |> take(TAKE_N) |> count()
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -23,6 +24,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let c = _fold(each(arr)._where(_.price > THRESHOLD).take(TAKE_N).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }
@@ -33,6 +35,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let c = _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD).take(TAKE_N).count())
+        b |> accept(c)
         if (c == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -14,6 +14,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let s = arr |> _select(_.price) |> take(TAKE_N) |> sum()
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -23,6 +24,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let s = _fold(each(arr)._select(_.price).take(TAKE_N).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -33,6 +35,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let s = _fold(from_decs_template(type<DecsCar>)._select(_.price).take(TAKE_N).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -29,6 +29,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let s = _fold(from_decs_template(type<DecsCar>)._select(_.price).take(TAKE_N).sum())
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def take_sum_aggregate_m3(b : B?) {
     run_m3(b, 100000)
@@ -37,4 +47,9 @@ def take_sum_aggregate_m3(b : B?) {
 [benchmark]
 def take_sum_aggregate_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def take_sum_aggregate_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/take_while_match.das
+++ b/benchmarks/sql/take_while_match.das
@@ -19,6 +19,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let total = _sql(db |> select_from(type<Car>) |> _where(_.id < THRESHOLD) |> count())
+            b |> accept(total)
             if (total == 0) {
                 b->failNow()
             }
@@ -30,6 +31,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let total = arr |> _take_while(_.id < THRESHOLD) |> count()
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }
@@ -39,6 +41,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let total = _fold(each(arr)._take_while(_.id < THRESHOLD).count())
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }
@@ -49,6 +52,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let total = _fold(from_decs_template(type<DecsCar>)._take_while(_.id < THRESHOLD).count())
+        b |> accept(total)
         if (total == 0) {
             b->failNow()
         }

--- a/benchmarks/sql/take_while_match.das
+++ b/benchmarks/sql/take_while_match.das
@@ -45,6 +45,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let total = _fold(from_decs_template(type<DecsCar>)._take_while(_.id < THRESHOLD).count())
+        if (total == 0) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def take_while_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +68,9 @@ def take_while_match_m3(b : B?) {
 [benchmark]
 def take_while_match_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def take_while_match_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/to_array_filter.das
+++ b/benchmarks/sql/to_array_filter.das
@@ -13,6 +13,7 @@ def run_m1(b : B?; n : int) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let prices <- _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> _select(_.price))
+            b |> accept(prices)
             if (empty(prices)) {
                 b->failNow()
             }
@@ -24,6 +25,7 @@ def run_m3(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3_array/{n}", n) {
         let prices <- (arr |> _where(_.price > THRESHOLD) |> _select(_.price))
+        b |> accept(prices)
         if (empty(prices)) {
             b->failNow()
         }
@@ -33,6 +35,7 @@ def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
         let prices <- _fold(each(arr)._where(_.price > THRESHOLD)._select(_.price).to_array())
+        b |> accept(prices)
         if (empty(prices)) {
             b->failNow()
         }
@@ -43,6 +46,7 @@ def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
         let prices <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)._select(_.price).to_array())
+        b |> accept(prices)
         if (empty(prices)) {
             b->failNow()
         }

--- a/benchmarks/sql/to_array_filter.das
+++ b/benchmarks/sql/to_array_filter.das
@@ -39,6 +39,16 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let prices <- _fold(from_decs_template(type<DecsCar>)._where(_.price > THRESHOLD)._select(_.price).to_array())
+        if (empty(prices)) {
+            b->failNow()
+        }
+    }
+}
+
 [benchmark]
 def to_array_filter_m1(b : B?) {
     run_m1(b, 100000)
@@ -52,4 +62,9 @@ def to_array_filter_m3(b : B?) {
 [benchmark]
 def to_array_filter_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def to_array_filter_m4(b : B?) {
+    run_m4(b, 100000)
 }

--- a/benchmarks/sql/zip_dot_product.das
+++ b/benchmarks/sql/zip_dot_product.das
@@ -21,6 +21,7 @@ def run_m3(b : B?; n : int) {
     let ys <- make_ints(n)
     b |> run("m3_array/{n}", n) {
         let s = (zip(xs, ys) |> _select(_._0 * _._1) |> sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }
@@ -31,6 +32,7 @@ def run_m3f(b : B?; n : int) {
     let ys <- make_ints(n)
     b |> run("m3f_array_fold/{n}", n) {
         let s = _fold(zip(xs, ys)._select(_._0 * _._1).sum())
+        b |> accept(s)
         if (s == 0) {
             b->failNow()
         }

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -1526,7 +1526,11 @@ def average(var src : iterator<auto(TT)>) : double {
     var total : double = 0lf
     var count : uint64 = 0ul
     for (x in src) {
-        total += double(x)
+        static_if (typeinfo stripped_typename(x) == typeinfo stripped_typename(default<double>)) {
+            total += x
+        } else {
+            total += double(x)
+        }
         count ++
     }
     return count != 0ul ? total / double(count) : 0lf
@@ -1538,7 +1542,11 @@ def average(src : array<auto(TT)>) : double {
     var total : double = 0lf
     var count : uint64 = 0ul
     for (x in src) {
-        total += double(x)
+        static_if (typeinfo stripped_typename(x) == typeinfo stripped_typename(default<double>)) {
+            total += x
+        } else {
+            total += double(x)
+        }
         count ++
     }
     return count != 0ul ? total / double(count) : 0lf

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1262,9 +1262,12 @@ def private plan_order_family(var expr : Expression?) : Expression? {
         } elif (name == "order" || name == "order_descending"
                 || name == "order_by" || name == "order_by_descending") {
             if (hasOrder) return null
+            // bail on `order(arr, cmp)` / `order_descending(arr, cmp)` — splice helpers (min/max/top_n) can't honor a user-supplied comparator and would silently drop it.
+            let argCount = cll._0.arguments |> length
+            if ((name == "order" || name == "order_descending") && argCount >= 2) return null
             hasOrder = true
             orderName = name
-            if ((cll._0.arguments |> length) >= 2) {
+            if (argCount >= 2) {
                 orderKey = clone_expression(cll._0.arguments[1])
             }
             orderElemType = clone_type(cll._0._type.firstType)

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -425,13 +425,19 @@ def private finalize_invoke(var res : Expression?; at : LineInfo) : Expression? 
 
 [macro_function]
 def private emit_length_shortcut(opName : string; var top : Expression?; srcName : string; at : LineInfo) : Expression? {
-    // Count-shaped shortcut: emit `length(src)` (count) or `int64(length(src))` (long_count)
+    // Count-shaped shortcut: emit `length(src)` (count, int) or `int64(length(src))` (long_count). length returns int, so the int() cast on count would be redundant — interp doesn't fold it and PERF020 fires.
     var topExpr = clone_expression(top)
     topExpr.genFlags.alwaysSafe = true
-    let castName = opName == "long_count" ? "int64" : "int"
-    var res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr))) {
-        return $c(castName)(length($i(srcName)))
-    }, $e(topExpr)))
+    var res : Expression?
+    if (opName == "long_count") {
+        res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr))) {
+            return int64(length($i(srcName)))
+        }, $e(topExpr)))
+    } else {
+        res = qmacro(invoke($($i(srcName) : typedecl($e(topExpr))) {
+            return length($i(srcName))
+        }, $e(topExpr)))
+    }
     return finalize_invoke(res, at)
 }
 
@@ -730,8 +736,15 @@ def private emit_accumulator_lane(
             $i(accName) += $e(valueExpr)
             $i(cntName) ++
         }
-        returnExpr = qmacro_expr() {
-            double($i(accName)) / double($i(cntName))
+        // Skip the double(accName) when accType is already double (interp doesn't fold redundant casts — would trip PERF020 and slow the inner loop tail).
+        if (accType != null && accType.baseType == Type.tDouble) {
+            returnExpr = qmacro_expr() {
+                $i(accName) / double($i(cntName))
+            }
+        } else {
+            returnExpr = qmacro_expr() {
+                double($i(accName)) / double($i(cntName))
+            }
         }
     } elif (opName == "min" || opName == "max") {
         preludeStmts <- qmacro_block_to_array() {
@@ -3349,8 +3362,9 @@ def private plan_zip(var expr : Expression?) : Expression? {
     if (noChain && bothHaveLength && isCounter) {
         var bodyStmts : array<Expression?>
         if (lastName == "count") {
+            // length returns int already; bare `length(...)` matches return type — no cast (PERF020).
             bodyStmts |> push <| qmacro_expr() {
-                return int(length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName)))
+                return length($i(srcAName)) < length($i(srcBName)) ? length($i(srcAName)) : length($i(srcBName))
             }
         } else {
             bodyStmts |> push <| qmacro_expr() {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1195,6 +1195,13 @@ def private order_top_n_call_name(orderName : string) : string {
     return ""
 }
 
+def private order_min_call_name(orderName : string; hasKey : bool) : string {
+    // `order + first` collapses to min/max — asc → min, desc → max. Keyed forms route to min_by/max_by.
+    let isDesc = orderName == "order_descending" || orderName == "order_by_descending"
+    if (hasKey) return isDesc ? "max_by" : "min_by"
+    return isDesc ? "max" : "min"
+}
+
 [macro_function]
 def private try_make_inline_cmp(orderKey : Expression?; orderName : string;
                                 elemType : TypeDeclPtr; at : LineInfo) : Expression? {
@@ -1236,6 +1243,8 @@ def private plan_order_family(var expr : Expression?) : Expression? {
     var orderKey : Expression?
     var orderElemType : TypeDeclPtr
     var takeExpr : Expression?
+    var firstName : string
+    var firstDefaultExpr : Expression?
     var hasOrder = false
     let at = calls[0]._0.at
     let itName = "`it`{at.line}`{at.column}"
@@ -1260,10 +1269,18 @@ def private plan_order_family(var expr : Expression?) : Expression? {
             }
             orderElemType = clone_type(cll._0._type.firstType)
         } elif (name == "take") {
-            if (!hasOrder || takeExpr != null) return null
+            if (!hasOrder || takeExpr != null || firstName != "") return null
             var arg = cll._0.arguments[1]
             if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
             takeExpr = clone_expression(arg)
+        } elif (name == "first" || name == "first_or_default") {
+            // order + first → min/max (O(N) instead of sort + index). Must be terminal.
+            if (!hasOrder || takeExpr != null || firstName != "" || i != length(calls) - 1) return null
+            firstName = name
+            if (name == "first_or_default") {
+                if ((cll._0.arguments |> length) < 2) return null
+                firstDefaultExpr = clone_expression(cll._0.arguments[1])
+            }
         } else {
             return null
         }
@@ -1278,12 +1295,31 @@ def private plan_order_family(var expr : Expression?) : Expression? {
     if (hasKey) {
         inlineCmp = try_make_inline_cmp(orderKey, orderName, orderElemType, at)
     }
+    let minMaxName = order_min_call_name(orderName, hasKey)
     if (whereCond == null) {
         // No prefilter — direct call to daslib helper.
         var topExpr = clone_expression(top)
         topExpr.genFlags.alwaysSafe = true
         var emission : Expression?
-        if (takeExpr == null) {
+        if (firstName == "first") {
+            // order + first → min/max (or min_by/max_by). O(N) single pass; matches the eager `order(...).first()` panic-on-empty semantics via min/max_impl returning default-initialized ref.
+            if (hasKey) {
+                emission = qmacro($c(minMaxName)($e(topExpr), $e(orderKey)))
+            } else {
+                emission = qmacro($c(minMaxName)($e(topExpr)))
+            }
+        } elif (firstName == "first_or_default") {
+            // No min_by_or_default exists; route through top_n*(_, 1, _) which returns an array (empty or single-element), then first_or_default supplies the default.
+            var topNCall : Expression?
+            if (inlineCmp != null) {
+                topNCall = qmacro(_::top_n_by_with_cmp($e(topExpr), 1, $e(inlineCmp)))
+            } elif (hasKey) {
+                topNCall = qmacro($c(topNName)($e(topExpr), 1, $e(orderKey)))
+            } else {
+                topNCall = qmacro($c(topNName)($e(topExpr), 1))
+            }
+            emission = qmacro(_::first_or_default($e(topNCall), $e(firstDefaultExpr)))
+        } elif (takeExpr == null) {
             // Bare order family — emit the direct call. Same shape as plain LINQ, but via
             if (inlineCmp != null) {
                 // Inlined comparator dispatches to the asc `order(src, block)` overload —
@@ -1304,7 +1340,7 @@ def private plan_order_family(var expr : Expression?) : Expression? {
             }
         }
         // Wrap with to_sequence_move only when emission is array-shaped: take dispatches to
-        let emissionIsArray = takeExpr != null || top._type.isGoodArrayType
+        let emissionIsArray = takeExpr != null || (firstName == "" && top._type.isGoodArrayType)
         if (needIterWrap && emissionIsArray) {
             emission = qmacro($e(emission).to_sequence_move())
         }
@@ -1337,7 +1373,31 @@ def private plan_order_family(var expr : Expression?) : Expression? {
             $e(loopBody)
         }
     }
-    if (takeExpr == null) {
+    if (firstName == "first") {
+        // where + order + first → min/max on prefilter buffer. O(N) single pass after the filter materializes. min/max return const-refs (TT -& -const), so plain `return` — not `return <-` — matches the eager semantics.
+        var minMaxCall : Expression?
+        if (hasKey) {
+            minMaxCall = qmacro($c(minMaxName)($i(bufName), $e(orderKey)))
+        } else {
+            minMaxCall = qmacro($c(minMaxName)($i(bufName)))
+        }
+        stmts |> push <| qmacro_expr() {
+            return $e(minMaxCall)
+        }
+    } elif (firstName == "first_or_default") {
+        // No min_by_or_default helper exists; route through top_n*(_, 1, _) + first_or_default for the empty-buf case.
+        var topNCall : Expression?
+        if (inlineCmp != null) {
+            topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), 1, $e(inlineCmp)))
+        } elif (hasKey) {
+            topNCall = qmacro($c(topNName)($i(bufName), 1, $e(orderKey)))
+        } else {
+            topNCall = qmacro($c(topNName)($i(bufName), 1))
+        }
+        stmts |> push <| qmacro_expr() {
+            return _::first_or_default($e(topNCall), $e(firstDefaultExpr))
+        }
+    } elif (takeExpr == null) {
         // Sort the prefilter buffer in place and return it. order*_inplace is void
         var sortCall : Expression?
         if (inlineCmp != null) {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1302,11 +1302,31 @@ def private plan_order_family(var expr : Expression?) : Expression? {
         topExpr.genFlags.alwaysSafe = true
         var emission : Expression?
         if (firstName == "first") {
-            // order + first → min/max (or min_by/max_by). O(N) single pass; matches the eager `order(...).first()` panic-on-empty semantics via min/max_impl returning default-initialized ref.
-            if (hasKey) {
-                emission = qmacro($c(minMaxName)($e(topExpr), $e(orderKey)))
+            // order + first → preserve eager `first()` panic-on-empty. min/max return an uninitialized ref on empty, so wrap in an empty-guard for arrays (zero alloc, O(N) min scan), or use top_n*(_, 1, _) |> first() for iterators (n=1 bounded heap; first() panics on empty).
+            if (top._type.isGoodArrayType) {
+                var srcParamType = invoke_src_param_type(top)
+                let firstSrcName = "`first_src`{at.line}`{at.column}"
+                var minMaxCall : Expression?
+                if (hasKey) {
+                    minMaxCall = qmacro($c(minMaxName)($i(firstSrcName), $e(orderKey)))
+                } else {
+                    minMaxCall = qmacro($c(minMaxName)($i(firstSrcName)))
+                }
+                emission = qmacro(invoke($($i(firstSrcName) : $t(srcParamType)) {
+                    panic("sequence contains no elements") if (empty($i(firstSrcName)))
+                    return $e(minMaxCall)
+                }, $e(topExpr)))
+                emission = finalize_invoke(emission, at)
             } else {
-                emission = qmacro($c(minMaxName)($e(topExpr)))
+                var topNCall : Expression?
+                if (inlineCmp != null) {
+                    topNCall = qmacro(_::top_n_by_with_cmp($e(topExpr), 1, $e(inlineCmp)))
+                } elif (hasKey) {
+                    topNCall = qmacro($c(topNName)($e(topExpr), 1, $e(orderKey)))
+                } else {
+                    topNCall = qmacro($c(topNName)($e(topExpr), 1))
+                }
+                emission = qmacro(_::first($e(topNCall)))
             }
         } elif (firstName == "first_or_default") {
             // No min_by_or_default exists; route through top_n*(_, 1, _) which returns an array (empty or single-element), then first_or_default supplies the default.
@@ -1374,7 +1394,10 @@ def private plan_order_family(var expr : Expression?) : Expression? {
         }
     }
     if (firstName == "first") {
-        // where + order + first → min/max on prefilter buffer. O(N) single pass after the filter materializes. min/max return const-refs (TT -& -const), so plain `return` — not `return <-` — matches the eager semantics.
+        // where + order + first → min/max on prefilter buffer. Empty buf must panic to match eager `first()` semantics; min/max return uninitialized refs on empty.
+        stmts |> push <| qmacro_expr() {
+            panic("sequence contains no elements") if (empty($i(bufName)))
+        }
         var minMaxCall : Expression?
         if (hasKey) {
             minMaxCall = qmacro($c(minMaxName)($i(bufName), $e(orderKey)))

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2825,4 +2825,21 @@ def test_fold_order_by_first(t : T?) {
         }
         tt |> success(didPanic, "first() on filtered-empty array panicked")
     }
+    // ── order(arr, cmp) + first — splice MUST honor the custom comparator (was emitting bare min/max, ignoring cmp)
+    t |> run("order(arr, cmp) + first preserves custom comparator (descending cmp → max)") @(tt : T?) {
+        let v = _fold(each([10, 5, 20, 3]) |> order($(a : int, b : int) => a > b) |> first())
+        tt |> equal(20, v, "cmp orders descending → first returns max")
+    }
+    t |> run("order_descending(arr, cmp) + first preserves custom comparator") @(tt : T?) {
+        // order_descending swaps cmp args, so cmp `a > b` becomes effectively `b > a` (ascending) → first → min
+        let v = _fold(each([10, 5, 20, 3]) |> order_descending($(a : int, b : int) => a > b) |> first())
+        tt |> equal(3, v, "order_descending negates cmp → first is min")
+    }
+    t |> run("order(arr, cmp) + take preserves custom comparator (pre-existing recognizer hole)") @(tt : T?) {
+        // cmp orders descending → take(2) returns top 2
+        let result <- _fold(each([10, 5, 20, 3, 25, 8]) |> order($(a : int, b : int) => a > b) |> take(2) |> to_array())
+        tt |> equal(2, length(result), "take 2 of descending order")
+        tt |> equal(25, result[0], "first is max (25)")
+        tt |> equal(20, result[1], "second is next-max (20)")
+    }
 }

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2776,3 +2776,32 @@ def test_take_while_skip_while_cascade_bails(t : T?) {
         tt |> equal(0, length(got))
     }
 }
+
+[test]
+def test_fold_order_by_first(t : T?) {
+    t |> run("order_by + first → min_by") @(tt : T?) {
+        let v = _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by(_).first())
+        tt |> equal(2, v, "minimum element after order_by")
+    }
+    t |> run("order_by_descending + first → max_by") @(tt : T?) {
+        let v = _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by_descending(_).first())
+        tt |> equal(30, v, "maximum element after order_by_descending")
+    }
+    t |> run("where + order_by + first → min on prefilter buf") @(tt : T?) {
+        let v = _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._where(_ > 5)._order_by(_).first())
+        tt |> equal(8, v, "min of (10,20,8,30,15,25) = 8")
+    }
+    t |> run("order_by + first_or_default — empty source returns default") @(tt : T?) {
+        let empty : array<int>
+        let v = _fold(each(empty)._order_by(_).first_or_default(-1))
+        tt |> equal(-1, v, "empty source → default")
+    }
+    t |> run("order_by + first_or_default — non-empty returns min") @(tt : T?) {
+        let v = _fold(each([10, 5, 20])._order_by(_).first_or_default(-1))
+        tt |> equal(5, v, "non-empty source → min element")
+    }
+    t |> run("where + order_by + first_or_default — empty after filter") @(tt : T?) {
+        let v = _fold(each([1, 2, 3])._where(_ > 100)._order_by(_).first_or_default(-1))
+        tt |> equal(-1, v, "filter excludes all → default")
+    }
+}

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -2804,4 +2804,25 @@ def test_fold_order_by_first(t : T?) {
         let v = _fold(each([1, 2, 3])._where(_ > 100)._order_by(_).first_or_default(-1))
         tt |> equal(-1, v, "filter excludes all → default")
     }
+    t |> run("order_by + first on empty array panics") @(tt : T?) {
+        let empty : array<int>
+        var didPanic = false
+        try {
+            let v = _fold(each(empty)._order_by(_).first())
+            tt |> success(false, "expected panic; got {v}")
+        } recover {
+            didPanic = true
+        }
+        tt |> success(didPanic, "first() on empty array panicked")
+    }
+    t |> run("where + order_by + first filtered-empty panics") @(tt : T?) {
+        var didPanic = false
+        try {
+            let v = _fold(each([1, 2, 3])._where(_ > 100)._order_by(_).first())
+            tt |> success(false, "expected panic; got {v}")
+        } recover {
+            didPanic = true
+        }
+        tt |> success(didPanic, "first() on filtered-empty array panicked")
+    }
 }

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -3553,6 +3553,12 @@ def target_order_by_first_or_default_splices_top_n_by() : int {
     return _fold(each([10, 20, 5, 8, 30])._order_by(_).first_or_default(-1))
 }
 
+[export, marker(no_coverage)]
+def target_order_with_cmp_first_bails_to_tier2() : int {
+    // order(arr, cmp) with a custom comparator — splice must bail (min/max can't honor arbitrary cmp).
+    return _fold(each([10, 5, 20, 3]) |> order($(a : int, b : int) => a > b) |> first())
+}
+
 [test]
 def test_order_by_first_emits_min_by(t : T?) {
     // order_by + first → min_by(top, key) directly. No sort, no take, no order_by/order helpers.
@@ -3623,6 +3629,32 @@ def test_order_by_first_or_default_emits_top_n_by_first_or_default(t : T?) {
         t |> success(count_call(body_expr, "first_or_default") >= 1,
             "should emit first_or_default on the 1-elem array")
         t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+    }
+}
+
+[test]
+def test_order_with_cmp_first_bails_no_min_max(t : T?) {
+    // `order(arr, cmp)` with a custom comparator block: splice helpers can't honor an arbitrary cmp,
+    // so plan_order_family must bail. fold_linq_default takes over and rewrites to `order_to_array` + `first`.
+    // The key invariant: NO min/max splice (which would silently drop the cmp).
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_with_cmp_first_bails_to_tier2)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> equal(0, count_call(body_expr, "min_by"), "must NOT emit min_by (cmp can't be honored)")
+        t |> equal(0, count_call(body_expr, "max_by"), "must NOT emit max_by")
+        t |> equal(0, count_call(body_expr, "min"), "must NOT emit min")
+        t |> equal(0, count_call(body_expr, "max"), "must NOT emit max")
+        t |> equal(0, count_call(body_expr, "top_n"), "must NOT emit top_n (bare top_n would drop cmp)")
+        t |> equal(0, count_call(body_expr, "top_n_by"), "must NOT emit top_n_by")
+        // fold_linq_default rewrites the bailed chain to order_to_array + first. Confirm a sort step survives.
+        t |> success(count_call(body_expr, "order_to_array") + count_call(body_expr, "order") >= 1,
+            "sort step must survive (order_to_array or order)")
+        t |> success(count_call(body_expr, "first") >= 1, "first call must survive")
     }
 }
 

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -3531,3 +3531,98 @@ def test_select_then_take_while_cascades_to_tier2(t : T?) {
     }
 }
 
+// ── order_by + first → min_by / max_by splice arm ───────────────────────
+
+[export, marker(no_coverage)]
+def target_order_by_first_splices_min_by() : int {
+    return _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by(_).first())
+}
+
+[export, marker(no_coverage)]
+def target_order_by_descending_first_splices_max_by() : int {
+    return _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._order_by_descending(_).first())
+}
+
+[export, marker(no_coverage)]
+def target_where_order_by_first_splices_min_by_on_buf() : int {
+    return _fold(each([10, 20, 5, 8, 30, 15, 2, 25])._where(_ > 5)._order_by(_).first())
+}
+
+[export, marker(no_coverage)]
+def target_order_by_first_or_default_splices_top_n_by() : int {
+    return _fold(each([10, 20, 5, 8, 30])._order_by(_).first_or_default(-1))
+}
+
+[test]
+def test_order_by_first_emits_min_by(t : T?) {
+    // order_by + first → min_by(top, key) directly. No sort, no take, no order_by/order helpers.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_first_splices_min_by)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "min_by") >= 1, "should emit a min_by call")
+        t |> equal(0, count_call(body_expr, "max_by"), "should NOT emit max_by (ascending)")
+        t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+        t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+    }
+}
+
+[test]
+def test_order_by_descending_first_emits_max_by(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_descending_first_splices_max_by)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "max_by") >= 1, "should emit a max_by call")
+        t |> equal(0, count_call(body_expr, "min_by"), "should NOT emit min_by (descending)")
+        t |> equal(0, count_call(body_expr, "order_by_descending"), "should NOT emit order_by_descending")
+        t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+    }
+}
+
+[test]
+def test_where_order_by_first_emits_min_by_on_prefilter(t : T?) {
+    // where + order_by + first → fused prefilter loop + min_by on buf. Same shape as
+    // where + order_by + take, but min_by instead of top_n_by.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_where_order_by_first_splices_min_by_on_buf)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "min_by") >= 1, "should emit min_by on prefilter buf")
+        t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+        t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+    }
+}
+
+[test]
+def test_order_by_first_or_default_emits_top_n_by_first_or_default(t : T?) {
+    // order_by + first_or_default → top_n_by(top, 1, key) |> first_or_default(d) — empty
+    // array handles the default fallback; no min_by_or_default helper exists.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_first_or_default_splices_top_n_by)
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return $e(body_expr)
+        }
+        t |> success(r.matched, "should have return expression")
+        t |> success(count_call(body_expr, "top_n_by_with_cmp") + count_call(body_expr, "top_n_by") >= 1,
+            "should emit top_n_by (or top_n_by_with_cmp for inline key)")
+        t |> success(count_call(body_expr, "first_or_default") >= 1,
+            "should emit first_or_default on the 1-elem array")
+        t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+    }
+}
+


### PR DESCRIPTION
Single PR replacing the closed stacked pair #2756 + #2757, rebased onto fresh master (#2750 chain landed via `68fe61d50`). Incorporates the Copilot fix from #2757 review (panic-on-empty regression).

## Summary

Three logical pieces, four commits:

1. **`benchmarks/sql/*` — m4_decs_fold lane** — adds a third comparison target (decs archetype + `from_decs_template`) alongside m1 SQL and m3/m3f array. `DecsCar` template + `fixture_decs(n)` in `_common.das`, plus per-bench `run_m4` + `[benchmark]` entrypoints across 47 files. `M4_DECS_EXPANSION.md` documents the triage (Cat A splice-today / Cat B needs Slice 5+ / Cat C needs surface) and full baseline matrix.
2. **`benchmarks/sql/*` — anti-DCE defense** — inserts `b |> accept(result)` after every `let X = ...` inside `b |> run(...)` blocks (197 inserts across all four lanes). `accept` is `[sideeffects]` so the optimizer cannot eliminate the computed result; future bench shapes with heavier per-op work / smaller `n` / more-aggressive const-folding are protected. AST-dump verified: `accept` survives compilation in both spliced and eager lanes. Current 0 ns/op cases are a measurement artifact (dastest divides by `n=100000`; sub-ns body cost rounds to 0), not DCE — the sweep is preventive.
3. **`daslib/linq_fold.das` — order_by + first splice arm** — extends `plan_order_family` to recognize `first` / `first_or_default` as terminators (alongside the existing `take(N)`). Routes:
   - `order_by + first` (array src) → `invoke($(src){ panic if empty; return min_by(src, key) }, top)` — zero alloc, O(N) min scan, preserves `first()` panic-on-empty.
   - `order_by + first` (iterator src) → `top_n_by(_, 1, _) |> first()` — bounded n=1 heap; `first()` panics on empty.
   - `order_by + first_or_default(d)` → `top_n_by(_, 1, _) |> first_or_default(d)`.
   - `order_by_descending + first` → `max_by` / `top_n_by_descending` mirror.
   - `where_ + order_by + first` (prefilter path) → `panic if empty(buf)` + `min_by(buf, key)`.

   Closing #2757's Copilot finding: my initial commit emitted `min_by` bare; min_by returns an uninitialized ref on empty source (verified in `daslib/linq.das:1266`), silently swallowing the panic that eager `first()` guarantees. Followup commit `8436781df` adds the empty-guard / `top_n + first` path per source type.

## Bench headline

`benchmarks/sql/sort_first`:

| lane | before | after | win |
|------|-------:|------:|----:|
| m1_sql | 37 | 37 | — |
| m3_array (eager) | 717 | 717 | — |
| **m3f_array_fold** | **722** | **41** | **17×** |
| m4_decs_fold (eager bridge) | 802 | 118 | 6.8× |

m3f now matches m1 within 10%; m4 rides the eager bridge until plan_decs_unroll Slice 5+ lands the order-family arms on decs.

## Test plan

- [x] `tests/linq/test_linq_fold.das` — `test_fold_order_by_first` (9 cases: parity + 2 new empty-input panic regression cases)
- [x] `tests/linq/test_linq_fold_ast.das` — 4 AST-shape gates confirming `min_by` / `max_by` / `top_n_by(_, 1, _)` emission, NOT full `_::order` + `[0]`
- [x] Full linq sweep: 1159 tests pass interp
- [x] `tests/linq/test_linq_from_decs.das` regression: 15 tests pass
- [x] `mcp__daslang__lint` + `bin/daslang ./utils/lint/main.das` clean on touched files (pre-existing PERF020 warnings in `test_linq_fold_ast.das` lines 66/82/596/601 are master-baseline, unrelated to this PR — flagged after #2753's PERF020 rule landed)
- [x] `benchmarks/sql/sort_first` re-run: m3f 41 ns / m4 118 ns (17× win preserved through the panic-on-empty fix)
- [ ] AOT gate — CI

## Notes

- Copilot's 7 nested-`_select` false positives from #2756 (groupby_sum, groupby_average, groupby_min, groupby_max, groupby_multi_reducer, groupby_having_hidden_sum, groupby_where_sum) verified at runtime — the chains compile and produce real m4 numbers (e.g., groupby_sum=115ns). Inner `_select` lambda resolves before outer macro expands; the `_` shadowing concern doesn't trigger.
- M4_DECS_EXPANSION.md tail section documents the new sort_first numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)