### PR TITLE
.githooks/pre-push: portable read loop (bash 3.2 compat for macOS)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -68,7 +68,12 @@ if [ ${#RANGES[@]} -eq 0 ]; then
     exit 0
 fi
 
-mapfile -t CHANGED < <(git diff --name-only --diff-filter=AM "${RANGES[@]}" -- '*.das' | sort -u)
+# Portable read-into-array (mapfile is bash 4+; macOS default ships bash 3.2).
+CHANGED=()
+while IFS= read -r line; do
+    CHANGED+=("$line")
+done < <(git diff --name-only --diff-filter=AM "${RANGES[@]}" -- '*.das' | sort -u)
+
 if [ ${#CHANGED[@]} -eq 0 ]; then
     echo "pre-push: no .das files changed; skipping lint"
     exit 0


### PR DESCRIPTION
Follow-up to #2761.

## Problem

`mapfile` is bash 4+ only. macOS ships `/bin/bash` 3.2.57 (last GPLv2 version), so every Mac developer's first push trips:

```
.githooks/pre-push: line 71: mapfile: command not found
error: failed to push some refs to ...
```

The formatter step passes, but the lint step fails on the `mapfile` call before it can read the changed-files list.

## Fix

Replace:

```bash
mapfile -t CHANGED < <(git diff --name-only --diff-filter=AM "${RANGES[@]}" -- '*.das' | sort -u)
```

with the portable equivalent:

```bash
CHANGED=()
while IFS= read -r line; do
    CHANGED+=("$line")
done < <(git diff --name-only --diff-filter=AM "${RANGES[@]}" -- '*.das' | sort -u)
```

Same semantics. Works on bash 3.2 (macOS default) and bash 4+ (Linux / Homebrew / Git for Windows). Process substitution `<(...)` is in bash 3.2 so the body stays one block.

## Verification

- `/bin/bash -n .githooks/pre-push` — syntax OK on bash 3.2.57
- End-to-end run with simulated push refs under `/bin/bash` (macOS default): hook completes, no `mapfile` error
- `${#CHANGED[@]}`, `CHANGED+=(...)`, and array `for` iteration all work in bash 3.2 — no other changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)