### PR TITLE
phase 8b: typeinfo is_int / is_int64 + int|int64 disjunction spike

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2273,6 +2273,12 @@ namespace das {
             } else if (expr->trait == "is_numeric") {
                 reportAstChanged();
                 return new ExprConstBool(expr->at, expr->typeexpr->isNumeric());
+            } else if (expr->trait == "is_int") {
+                reportAstChanged();
+                return new ExprConstBool(expr->at, expr->typeexpr->baseType == Type::tInt && expr->typeexpr->dim.size() == 0);
+            } else if (expr->trait == "is_int64") {
+                reportAstChanged();
+                return new ExprConstBool(expr->at, expr->typeexpr->baseType == Type::tInt64 && expr->typeexpr->dim.size() == 0);
             } else if (expr->trait == "is_numeric_comparable") {
                 reportAstChanged();
                 return new ExprConstBool(expr->at, expr->typeexpr->isNumericComparable());

--- a/tests/long_array_table/test_int_int64_disjunction.das
+++ b/tests/long_array_table/test_int_int64_disjunction.das
@@ -1,0 +1,44 @@
+options gen2
+
+require dastest/testing_boost public
+
+// Phase 8b spike: can a function accept `int | int64` as a single parameter
+// signature and fork inside the body via `static_if`? If yes, PR-D (linq
+// surface widening) can use one signature per function instead of doubling
+// overloads. If no, PR-D falls back to separate `: int` / `: int64` pairs.
+//
+// Reference for the disjunction-parameter shape: tests/language/option_type.das.
+// `typeinfo is_int` / `typeinfo is_int64` are added in the same PR — string-
+// compare `stripped_typename(x) == "int"` was the fallback while landing this.
+
+def take_or(x : int | int64) : int64 {
+    static_if (typeinfo is_int(x)) {
+        return int64(x) + 1_l
+    } else {
+        return x + 1_l
+    }
+}
+
+[test]
+def test_int_branch(t : T?) {
+    let r = take_or(40)
+    t |> equal(r, 41_l)
+}
+
+[test]
+def test_int64_branch(t : T?) {
+    let r = take_or(40_l)
+    t |> equal(r, 41_l)
+}
+
+// Type-trait contract: locks `is_int` / `is_int64` against silent reverts.
+[test]
+def test_typeinfo_is_int_traits(t : T?) {
+    static_assert(typeinfo is_int(type<int>), "is_int(int) must be true")
+    static_assert(!typeinfo is_int(type<int64>), "is_int(int64) must be false")
+    static_assert(!typeinfo is_int(type<uint>), "is_int(uint) must be false")
+    static_assert(typeinfo is_int64(type<int64>), "is_int64(int64) must be true")
+    static_assert(!typeinfo is_int64(type<int>), "is_int64(int) must be false")
+    static_assert(!typeinfo is_int64(type<uint>), "is_int64(uint) must be false")
+    t |> equal(0, 0)
+}


### PR DESCRIPTION
## Summary

Spike for the next big chunk of the 64-bit array/table widening project (PR-D, linq surface widening). The question this PR answers: **can a function accept `int | int64` as a single parameter signature and fork inside the body via `static_if`, so the ~10 linq functions targeted by PR-D widen with one signature each instead of doubled overloads?**

**Yes.** `def take_or(x : int | int64)` already parses — the disjunction-parameter shape is used in [tests/language/option_type.das](https://github.com/GaijinEntertainment/daScript/blob/master/tests/language/option_type.das) for ref/auto resolution. What was missing was a clean dispatch predicate inside the body; `stripped_typename(x) == "int"` is a string-compare hack for something this prominent.

## What changed

Two new `typeinfo` traits in [src/ast/ast_infer_type.cpp](src/ast/ast_infer_type.cpp), placed right after `is_numeric` and following the `is_string` pattern (`baseType` match + `dim.size() == 0`):

```cpp
typeinfo is_int(x)   -> baseType == tInt   && dim.size() == 0
typeinfo is_int64(x) -> baseType == tInt64 && dim.size() == 0
```

Scope is intentionally surgical — `is_int` + `is_int64` only, matching PR-D's immediate need. Sibling traits (`is_uint`, `is_int8/16/32`, etc.) can be added later when a real call site needs them.

## Test plan

- [x] [tests/long_array_table/test_int_int64_disjunction.das](tests/long_array_table/test_int_int64_disjunction.das) — three tests:
  - `test_int_branch` / `test_int64_branch` — `def take_or(x : int | int64)` with `static_if (typeinfo is_int(x))` dispatch returns the right value for both call shapes
  - `test_typeinfo_is_int_traits` — `static_assert` matrix locks `is_int` / `is_int64` against silent reverts (true for the matching type, false for the other and for `uint`)
- [x] `tests/long_array_table/` full dir: 48/48 pass
- [x] `tests/apply/`, `tests/language/`: no regressions from the trait addition
- [x] Lint clean, formatter clean
- [x] Pre-push hook formatter `--verify` + lint pass

## Unblocks

[PR-D](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/longarr-phase8b-int-int64-disjunction/.. ) (linq surface widening — take/skip/element_at/chunk/last/single/...) can now use one `int | int64` signature per function with `static_if (typeinfo is_int(x))` inside the body, instead of doubling overloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)