### PR TITLE
linq_fold: align average semantics with linq.das (empty-source guard, double accumulator)

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -760,23 +760,24 @@ def private emit_accumulator_lane(
             $i(accName)
         }
     } elif (opName == "average") {
+        // Matches linq.das:1545 average(iterator) — always-double accumulator, uint64 counter, empty source returns 0.0lf instead of NaN. Source-element cast lifted out at macro time to avoid PERF020 redundant-cast trip when the input is already double.
         preludeStmts <- qmacro_block_to_array() {
-            var $i(accName) : $t(accType) = default<$t(accType)>
-            var $i(cntName) = 0
+            var $i(accName) : double = 0lf
+            var $i(cntName) : uint64 = 0ul
         }
-        perMatchStmts <- qmacro_block_to_array() {
-            $i(accName) += $e(valueExpr)
-            $i(cntName) ++
-        }
-        // Skip the double(accName) when accType is already double (interp doesn't fold redundant casts — would trip PERF020 and slow the inner loop tail).
         if (accType != null && accType.baseType == Type.tDouble) {
-            returnExpr = qmacro_expr() {
-                $i(accName) / double($i(cntName))
+            perMatchStmts <- qmacro_block_to_array() {
+                $i(accName) += $e(valueExpr)
+                $i(cntName) ++
             }
         } else {
-            returnExpr = qmacro_expr() {
-                double($i(accName)) / double($i(cntName))
+            perMatchStmts <- qmacro_block_to_array() {
+                $i(accName) += double($e(valueExpr))
+                $i(cntName) ++
             }
+        }
+        returnExpr = qmacro_expr() {
+            $i(cntName) != 0ul ? $i(accName) / double($i(cntName)) : 0lf
         }
     } elif (opName == "min" || opName == "max") {
         preludeStmts <- qmacro_block_to_array() {
@@ -3278,9 +3279,17 @@ def private emit_decs_accumulator(bridge : DecsBridgeShape?;
             $i(accName) += $i(finalBind)
         }
     } elif (opName == "average") {
-        perElement = qmacro_block() {
-            $i(accName) += $i(finalBind)
-            $i(cntName) ++
+        // Matches linq.das:1545 average() — always-double accumulator, uint64 counter, empty source returns 0.0lf. Cast lifted out at macro time so already-double chains don't trip PERF020.
+        if (chainInfo.finalType != null && chainInfo.finalType.baseType == Type.tDouble) {
+            perElement = qmacro_block() {
+                $i(accName) += $i(finalBind)
+                $i(cntName) ++
+            }
+        } else {
+            perElement = qmacro_block() {
+                $i(accName) += double($i(finalBind))
+                $i(cntName) ++
+            }
         }
     } elif (opName == "min" || opName == "max") {
         let workhorse = (chainInfo.finalType != null && chainInfo.finalType.isWorkhorseType)
@@ -3343,14 +3352,13 @@ def private emit_decs_accumulator(bridge : DecsBridgeShape?;
             return $i(accName)
         }))
     } elif (opName == "average") {
-        // Empty source → 0.0 / 0.0 → IEEE NaN (numerator + denominator both cast to double before division). Matches emit_accumulator_lane.
         emission = qmacro(invoke($() : double {
-            var $i(accName) : $t(accType) = default<$t(accType)>
-            var $i(cntName) = 0
+            var $i(accName) : double = 0lf
+            var $i(cntName) : uint64 = 0ul
             for_each_archetype($e(reqExpr), $e(erqExpr), $($i(archName) : Archetype) {
                 $e(forExprNode)
             })
-            return double($i(accName)) / double($i(cntName))
+            return $i(cntName) != 0ul ? $i(accName) / double($i(cntName)) : 0lf
         }))
     } elif (opName == "min" || opName == "max") {
         // No empty-panic — matches non-decs emit_accumulator_lane (returns default-initialized acc).

--- a/tests/linq/test_linq_fold.das
+++ b/tests/linq/test_linq_fold.das
@@ -879,10 +879,10 @@ def test_max_accumulator(t : T?) {
 
 [test]
 def test_average_accumulator(t : T?) {
-    t |> run("average: empty → NaN") @(t : T?) {
+    t |> run("average: empty → 0.0lf (matches linq.das semantics)") @(t : T?) {
         let arr : array<int>
         let a = _fold(each(arr).average())
-        t |> equal(true, is_nan(a))
+        t |> equal(0.0lf, a)
     }
     t |> run("average: singleton") @(t : T?) {
         let arr <- [42]

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -249,7 +249,7 @@ def target_zip_contains_proj_miss_fold() : bool {
     return _fold([10, 20, 30, 40, 50].zip([1, 2, 3, 4, 5]) |> select($(t : tuple<int; int>) => t._0 + t._1) |> contains(999))
 }
 
-// PR #2742 Copilot review #r3270337476 — DEFERRED: emit_accumulator_lane.average semantics divergence from linq.das. Pre-existing in helper (affects plan_loop_or_count's single-source path too): accumulates in accType (often int → overflow risk) and returns NaN on empty cnt, while linq.das average accumulates in double and returns 0.0lf on empty. Follow-up PR must fix the helper uniformly AND update the existing fold test "average: empty → NaN" in test_linq_fold.das to expect 0.0lf.
+// Empty-source average target. Verifies the 2-site emit_accumulator_lane.average + emit_decs_accumulator.average alignment with linq.das (double accumulator + cnt==0 guard → 0.0lf). See test_zip_average_empty_returns_zero below.
 [export, marker(no_coverage)]
 def target_zip_average_empty_fold() : double {
     var emptyA : array<int>
@@ -830,10 +830,12 @@ def test_zip_contains_proj_miss_fold_result(t : T?) {
     }
 }
 
-// PR #2742 Copilot review #r3270337476 — DEFERRED-fix tracking test. Documents the desired post-fix behavior (zip+select+average on empty source should return 0.0lf per linq.das semantics). Currently emit_accumulator_lane returns NaN, so this test is skipped until the helper is aligned (uniform fix across plan_loop_or_count + plan_zip; also requires updating "average: empty → NaN" in test_linq_fold.das to expect 0.0lf).
+// Regression guard for the 2-site average semantics fix (emit_accumulator_lane + emit_decs_accumulator align with linq.das:1545 — double accumulator + cnt==0 guard → 0.0lf on empty).
 [test]
-def test_zip_average_empty_returns_zero_when_fixed(t : T?) {
-    t->skip("DEFERRED: zip+select+average on empty source should return 0.0lf per linq.das semantics. Blocked on follow-up PR aligning emit_accumulator_lane.average with linq.das (double accumulator + cnt==0 guard); pre-existing helper divergence — affects single-source plan_loop_or_count too. Un-skip + assert `equal(target_zip_average_empty_fold(), 0.0lf)` when fix lands.")
+def test_zip_average_empty_returns_zero(t : T?) {
+    t |> run("zip+select+average on empty source returns 0.0lf") @(t : T?) {
+        t |> equal(target_zip_average_empty_fold(), 0.0lf)
+    }
 }
 
 // AST-shape: zip+accumulator splices into a single for-loop with no surviving runtime `sum`/`zip` calls.

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -368,6 +368,13 @@ def test_unroll_average_parity(t : T?) {
 }
 
 [test]
+def test_unroll_average_empty_returns_zero(t : T?) {
+    // Regression for emit_decs_accumulator.average — empty archetype set must return 0.0lf (matches linq.das:1545 cnt==0 guard), not NaN from 0.0lf / 0.0lf.
+    fixture_unroll2(0)
+    t |> equal(target_unroll_average_fold(), 0.0lf, "average splice empty-source guard")
+}
+
+[test]
 def test_unroll_where_max_parity(t : T?) {
     fixture_unroll2(5)
     // flag==1 rows: vals 1,3 → max 3


### PR DESCRIPTION
## Summary

Fixes the 2-site `average` semantics divergence flagged by Copilot in both PR #2765 and PR #2766. Both `emit_accumulator_lane` (array-side) and `emit_decs_accumulator` (decs-side) diverged from canonical `daslib/linq.das:1545-1574` `average`:

| Aspect | Old (buggy) | New (matches linq.das) |
|---|---|---|
| Accumulator type | `accType` (often `int` → overflow risk) | `double` |
| Counter type | `int` | `uint64` |
| Empty source | `0 / 0` → NaN | `cnt != 0ul ? acc / double(cnt) : 0lf` → `0.0lf` |

Macro-time `accType.baseType == Type.tDouble` cast-skip is preserved so already-double chains avoid the PERF020 redundant-cast trip on the hot path.

## Files changed

- `daslib/linq_fold.das`
  - `emit_accumulator_lane` `average` branch (~line 762): double acc + uint64 cnt + ternary return guard
  - `emit_decs_accumulator` `average` branches (~line 3280 + ~3345): same shape; macro-time cast-skip on `chainInfo.finalType` for already-double chains
- `tests/linq/test_linq_fold.das:882` — `test_average_accumulator.average: empty → NaN` flipped to expect `0.0lf`
- `tests/linq/test_linq_fold_ast.das`:
  - Un-skipped `test_zip_average_empty_returns_zero` (was the PR #2742 DEFERRED tracking test)
  - Removed DEFERRED comments above `target_zip_average_empty_fold`
- `tests/linq/test_linq_from_decs.das` — new `test_unroll_average_empty_returns_zero` regression for the decs-side path

## Verification

- Format clean, lint clean (`mcp__daslang__format_file` / `mcp__daslang__lint`)
- Full linq interp sweep: **777/777** across all 11 test files (`test_linq{,_aggregation,_bugs,_concat,_element,_fold,_fold_ast,_from_decs,_generation,_group_by,_join,_partition,_querying,_set,_sorting,_transform}.das`)
- Full linq AOT regression sweep: **1228/1228** via `bin/test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/linq`
- Pre-push formatter + lint clean

## Context

This was deferred during the PR #2742 → #2765 resurrection and again during the #2751+#2752 → #2766 bundle because:
1. Pre-existing helper divergence (not introduced by either resurrection PR)
2. 2-site fix that needed both array-side AND decs-side aligned in one go to avoid leaving one path inconsistent
3. Keeping resurrection PRs scoped to cherry-picking made the bundles easier to verify

Copilot review threads on both #2765 and #2766 explicitly flagged this and asked for it in a follow-up. This is that follow-up.

## Test plan

- [x] Interp green on all linq test files
- [x] AOT green on all linq test files (full `tests/linq` sweep)
- [x] Format + lint clean
- [x] `test_zip_average_empty_returns_zero` un-skipped and passes
- [x] `test_average_accumulator.average: empty → 0.0lf` updated and passes
- [x] `test_unroll_average_empty_returns_zero` (decs-side) added and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)