### PR TITLE
load_module: direct module-folder loading without the junction trick

### DIFF
--- a/doc/source/reference/embedding/external_modules.rst
+++ b/doc/source/reference/embedding/external_modules.rst
@@ -444,7 +444,8 @@ The dynamic binary discovers modules automatically from the
        auto fAccess = das::make_smart<das::FsFileAccess>();
 
        NEED_ALL_DEFAULT_MODULES
-       das::require_dynamic_modules(fAccess, das::getDasRoot(), "./", tout);
+       das::vector<das::string> load_modules;  // optional: explicit module paths
+       das::require_dynamic_modules(fAccess, das::getDasRoot(), "./", load_modules, tout);
        das::Module::Initialize();
 
        // ... compile and run scripts as normal
@@ -454,6 +455,12 @@ The dynamic binary discovers modules automatically from the
 for a ``.das_module`` file and executes it.  The ``getDasRoot()``
 function returns the daslang installation root (set via the
 ``DAS_ROOT`` environment variable or auto-detected).
+
+Each entry in ``load_modules`` is the path to a single module folder
+(the one containing ``.das_module``), bypassing the
+``<project_root>/modules/<name>`` scan.  Path basenames shadow same-named
+entries from dasroot and project_root.  This is the C++ equivalent of
+daslang's ``-load_module <path>`` CLI flag (repeatable).
 
 
 Installing external modules
@@ -553,7 +560,8 @@ simulate, evaluate — with the addition of
        auto faccess = das::smart_ptr<das::FsFileAccess>(new das::FsFileAccess);
 
        NEED_ALL_DEFAULT_MODULES
-       das::require_dynamic_modules(faccess, das::getDasRoot(), "./", tout);
+       das::vector<das::string> load_modules;
+       das::require_dynamic_modules(faccess, das::getDasRoot(), "./", load_modules, tout);
        das::Module::Initialize();
 
        // compile, simulate, evaluate hello.das ...

--- a/doc/source/reference/utils/daslang_live.rst
+++ b/doc/source/reference/utils/daslang_live.rst
@@ -708,6 +708,12 @@ CLI reference
      - Project root --- the parent of ``modules/`` for daspkg-style
        module resolution. Equivalent to passing ``project_root`` to
        MCP tools.
+   * - ``-load_module <path>``
+     - Directly load a single dynamic-module folder (the one containing
+       ``.das_module``); repeatable. Bypasses the
+       ``<project_root>/modules/<name>`` scan and shadows same-basename
+       entries in dasroot and project_root. Use when working on an
+       external module locally without setting up the junction trick.
    * - ``-dasroot <path>``
      - Override ``DAS_ROOT``.
    * - ``-cwd``

--- a/doc/source/reference/utils/mcp.rst
+++ b/doc/source/reference/utils/mcp.rst
@@ -90,10 +90,17 @@ take them are marked below; the meaning is identical everywhere.
        ``-project_root <path>`` CLI flag. Use when working on an
        external module via a ``<DummyRoot>/modules/<your-module>``
        junction.
+   * - ``load_modules``
+     - JSON array of paths to individual module folders (each
+       containing ``.das_module``) to load directly. Equivalent to
+       daslang's ``-load_module <path>`` CLI flag (repeatable).
+       Bypasses the ``<project_root>/modules/<name>`` scan and shadows
+       same-basename entries in dasroot and project_root. Use to work
+       on an external module without setting up the junction trick.
 
-Both default to empty (no project / cwd-based resolution). Most
+All three default to empty (no project / cwd-based resolution). Most
 compilation, navigation, introspection, execution, code-generation,
-and tree-sitter tools accept both arguments.
+and tree-sitter tools accept all three arguments.
 
 Compilation and diagnostics
 ---------------------------
@@ -391,12 +398,13 @@ before composing the spawn argv.
      - Args + description
    * - ``live_launch``
      - ``file`` (required), optional ``project``, ``project_root``,
-       ``port``. Launches ``daslang-live.exe`` on a script if not
-       already running, then polls up to 10 s for the HTTP server. The
-       working directory is set to the script's folder via the
-       ``-cwd`` flag; ``project`` and ``project_root`` are forwarded as
-       ``-project`` / ``-project_root``; ``port`` is forwarded as
-       ``--live-port``.
+       ``load_modules``, ``port``. Launches ``daslang-live.exe`` on a
+       script if not already running, then polls up to 10 s for the
+       HTTP server. The working directory is set to the script's folder
+       via the ``-cwd`` flag; ``project`` / ``project_root`` /
+       ``load_modules`` are forwarded as ``-project`` /
+       ``-project_root`` / ``-load_module`` (one per entry); ``port``
+       is forwarded as ``--live-port``.
    * - ``live_status``
      - Optional ``port``. Returns JSON with ``fps``, ``uptime``,
        ``paused``, ``dt``, ``has_error``. Returns 503 JSON if the script

--- a/include/daScript/ast/dyn_modules.h
+++ b/include/daScript/ast/dyn_modules.h
@@ -7,11 +7,14 @@ class TextWriter;
 
 // Initializes dynamic modules from:
 // - das_root/modules
-// - project_root/modules
-// If project_root is empty it will be ignored.
+// - project_root/modules (if project_root is non-empty and differs from das_root)
+// - each path in load_modules — treated as a single module folder (the one
+//   containing `.das_module`), bypassing the modules/<name> scan. Path basenames
+//   shadow same-named entries in das_root and project_root.
 // During initialization process it calls `initialize` in files `.das_module`.
 DAS_API bool require_dynamic_modules(smart_ptr<FileAccess> file_access,
                                      const string &das_root,
                                      const string &project_root,
+                                     const vector<string> &load_modules,
                                      TextWriter &tout);
 }

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -172,13 +172,20 @@ DAS_CC_API void das_modulegroup_release ( das_module_group * group );
 // --- Dynamic modules ---
 
 // Scan <project_root>/modules/ for .das_module descriptor files and
-// call `initialize` on each one.
+// call `initialize` on each one. Plus, for each path in load_module_paths,
+// initialize that exact folder directly (it must contain `.das_module`),
+// shadowing same-basename entries from <project_root>/modules/.
+//
+// load_module_paths may be NULL (treated as 0 entries). Each entry is a
+// path to the module folder itself, not its parent.
 //
 // If tout is NULL, diagnostic output goes to stdout.
 //
 // Returns 0 on success.
 DAS_CC_API int das_register_dynamic_modules(das_file_access *file_access,
                                          const char *project_root,
+                                         const char * const * load_module_paths,
+                                         uint32_t num_load_module_paths,
                                          das_text_writer *tout);
 
 // --- File access ---

--- a/mouse-data/docs/how-do-i-iterate-on-an-external-daslang-module-without-the-junction-trick-or-daspkg-install.md
+++ b/mouse-data/docs/how-do-i-iterate-on-an-external-daslang-module-without-the-junction-trick-or-daspkg-install.md
@@ -1,0 +1,49 @@
+---
+slug: how-do-i-iterate-on-an-external-daslang-module-without-the-junction-trick-or-daspkg-install
+title: How do I iterate on an external daslang module without the junction trick or daspkg install?
+created: 2026-05-20
+last_verified: 2026-05-20
+links: []
+---
+
+Use **`-load_module <path>`** (repeatable). Each path is the module folder itself (the one containing `.das_module`); daslang runs that folder's `initialize(<path>)` directly, skipping the `<project_root>/modules/<name>` scan. No junction, no daspkg install.
+
+```sh
+daslang.exe -load_module D:/DASPKG/dasImgui your_script.das
+daslang.exe -load_module D:/DASPKG/dasImgui -load_module D:/DASPKG/dasHV your_script.das
+daslang-live.exe -load_module D:/DASPKG/dasImgui your_live.das
+```
+
+**MCP equivalent**: every tool that takes `project_root` also takes `load_modules` (JSON array of paths):
+
+```jsonc
+mcp__daslang__compile_check {
+  "file": "your_script.das",
+  "load_modules": ["D:/DASPKG/dasImgui"]
+}
+```
+
+**Available across**: `compile_check`, `lint`, `find_symbol`, `goto_definition`, `find_references`, `type_of`, `ast_dump`, `list_requires`, `program_log`, `list_module_api`, `describe_type`, `run_test`, `run_script`, `eval_expression`, `aot`, `live_launch`.
+
+**Path semantics**: the path's basename becomes the shadow-skip key. If the same name (basename) appears under `<project_root>/modules/` or `<das_root>/modules/`, the `-load_module` entry wins with a `local 'name' shadows global` warning. Precedence: load_module > project_root > dasroot.
+
+**The C++ join point** is `require_dynamic_modules(file_access, das_root, project_root, load_modules, tout)` in [src/ast/dyn_modules.cpp](../../src/ast/dyn_modules.cpp). The `-load_module` paths are also exposed via the C API as `das_register_dynamic_modules(file_access, project_root, load_module_paths, num_load_module_paths, tout)` in [src/misc/daScriptC.cpp](../../src/misc/daScriptC.cpp).
+
+**Works with modules that register C++ shared modules too** (dasImgui, dasHV, dasPUGIXML, etc.) — the `.das_module/initialize()` callback fires the same way `-project_root` would. Caveat: the module's `.shared_module` DLLs must be ABI-compatible with the daslang.exe you're running. If you see `missing prerequisite 'imgui'` (or similar) after the `.das_module` initialize prints fire, the shared modules are stale — rebuild the module's CMake project against your current daslang sources:
+
+```sh
+cd D:/DASPKG/dasImgui
+cmake -B build -DDASLANG_DIR=D:/Work/daScript -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+```
+
+This re-emits `dasModuleImgui.shared_module` etc. into the module folder, which `-load_module` then picks up directly. No `daspkg install` step needed for the daslang-side iteration loop.
+
+**Legacy alternative**: the junction trick (`<DummyRoot>/modules/<name>` symlink + `-project_root <DummyRoot>`) still works — see [external_module_debugging.md](../../skills/external_module_debugging.md). Useful when you specifically want to exercise the `<project_root>/modules/*` scan path.
+
+## Questions
+- How do I iterate on an external daslang module without the junction trick or daspkg install?
+- What does `-load_module <path>` do?
+- What's the difference between `-load_module` and `-project_root`?
+- How do I pass multiple modules to daslang.exe?
+- What's the MCP equivalent of `-load_module`?

--- a/skills/external_module_debugging.md
+++ b/skills/external_module_debugging.md
@@ -1,67 +1,57 @@
 # Debugging an external daslang module locally
 
-When you're iterating on a daslang module that lives OUTSIDE the main daslang repo — dasImgui, dasPUGIXML, dasSQLITE, dasCards, dasTelegram, your own daspkg package, etc. — you need a way to run/lint/test from a standalone `daslang.exe` (or via the MCP server) without a full `daspkg install`. The trick is the **dummy-project-root junction pattern**.
+When you're iterating on a daslang module that lives OUTSIDE the main daslang repo — dasImgui, dasPUGIXML, dasSQLITE, dasCards, dasTelegram, your own daspkg package, etc. — you need a way to run/lint/test from a standalone `daslang.exe` (or via the MCP server) without a full `daspkg install`.
+
+The **recommended approach** is `-load_module <path>` (repeatable). The older **junction trick** still works and is documented below as a fallback for workflows that need to exercise the `<project_root>/modules/<name>` scan path itself.
 
 ## The problem
 
-Each external module ships a `.das_module` descriptor (e.g. `D:/DASPKG/dasImgui/.das_module`) whose `initialize(project_path)` callback registers native paths like `register_native_path("imgui", "imgui_widgets_builtin", "<P>/widgets/imgui_widgets_builtin.das")`. daslang only fires those callbacks when it can locate the module under a `<project_root>/modules/<name>/` directory and you pass `-project_root <project_root>` on the CLI (or `project_root` via the MCP tool).
+Each external module ships a `.das_module` descriptor (e.g. `D:/DASPKG/dasImgui/.das_module`) whose `initialize(project_path)` callback registers native paths like `register_native_path("imgui", "imgui_widgets_builtin", "<P>/widgets/imgui_widgets_builtin.das")`. daslang only fires those callbacks when it discovers the module — either by scanning `<project_root>/modules/<name>/` or via an explicit `-load_module <path>`.
 
-So running `daslang.exe path/to/your-module/main.das` directly fails with `missing prerequisite 'imgui'` — daslang has no `modules/` tree to scan, and the `.das_module` `initialize()` never fires.
+So running `daslang.exe path/to/your-module/main.das` directly fails with `missing prerequisite 'imgui'` — daslang has no module-discovery hook firing, and the `.das_module` `initialize()` never runs.
 
 Running via `daspkg install` works but cuts off the live edit loop: every `.das` or C++ change needs a reinstall.
 
-## The fix: dummy-project-root junction
+## The recommended fix: `-load_module <path>`
 
-Create a throwaway directory whose only contents are a `modules/<your-module>` junction (Windows) or symlink (POSIX) pointing at your dev checkout. Then use it as `-project_root`.
-
-### Windows
-
-```cmd
-mkdir D:\IMGUI_DEMO\modules
-mklink /J D:\IMGUI_DEMO\modules\dasImgui D:\DASPKG\dasImgui
-```
-
-`mklink /J` creates a directory junction — same effect as a symlink for daslang's purposes and doesn't need admin.
-
-### POSIX
-
-```sh
-mkdir -p /tmp/IMGUI_DEMO/modules
-ln -s /path/to/dasImgui /tmp/IMGUI_DEMO/modules/dasImgui
-```
-
-## Using it
-
-Once the junction exists, the dummy root works with every tool that takes `-project_root` / `project_root`.
+Pass `-load_module <path>` to daslang.exe / daslang-live.exe. The path is the module folder itself (the one containing `.das_module`). Repeat the flag for multiple modules. No filesystem setup, no dummy root.
 
 ### daslang.exe CLI
 
 ```sh
-daslang.exe -project_root D:/IMGUI_DEMO modules/dasImgui/examples/imgui_demo/harness_layout.das
+daslang.exe -load_module D:/DASPKG/dasImgui your_script.das
+```
+
+For multiple modules:
+
+```sh
+daslang.exe -load_module D:/DASPKG/dasImgui -load_module D:/DASPKG/dasHV your_script.das
 ```
 
 ### daslang-live
 
 ```sh
-daslang-live.exe -project_root D:/IMGUI_DEMO modules/dasImgui/examples/imgui_demo/harness_layout.das
+daslang-live.exe -load_module D:/DASPKG/dasImgui your_script.das
 ```
 
 ### MCP tools (preferred — keeps everything inside the editor)
 
-Every MCP tool that already accepts `project` also accepts `project_root`. Pass it the dummy-root path:
+Every MCP tool that already accepts `project_root` also accepts `load_modules` (a JSON array of paths). Pass the module folder(s) directly:
 
 ```jsonc
 mcp__daslang__compile_check {
   "file": "D:/DASPKG/dasImgui/examples/imgui_demo/layout.das",
-  "project_root": "D:/IMGUI_DEMO"
+  "load_modules": ["D:/DASPKG/dasImgui"]
 }
 ```
 
 Same shape for `lint`, `find_symbol`, `goto_definition`, `find_references`, `type_of`, `ast_dump`, `list_requires`, `program_log`, `list_module_api`, `describe_type`, `run_test`, `run_script`, `eval_expression`, `aot`, `live_launch`.
 
-## Why a junction, not a copy
+## Path semantics
 
-The junction is the dev checkout. Edits to the module's source (`.das` or `.cpp`) are picked up live — no sync step. A copy would need rebuilding on every change.
+- Each `-load_module <P>` is treated as a single module folder. daslang looks for `<P>/.das_module` and runs its `initialize(<P>)` callback.
+- The path's **basename** becomes the shadow-skip key. If a module with the same basename also exists under `<project_root>/modules/<basename>/` or `<das_root>/modules/<basename>/`, the explicit `-load_module` entry wins (the others are skipped with a `local '<name>' shadows global` warning).
+- Edits to the module's source (`.das` or `.cpp`) are picked up live — daslang reads from the path directly on every invocation.
 
 ## When to use this
 
@@ -72,36 +62,73 @@ The junction is the dev checkout. Edits to the module's source (`.das` or `.cpp`
 
 ## When NOT to use this
 
-- Production daspkg installs — those use `daspkg install <pkg>` which sets up the same `<root>/modules/<pkg>/` layout natively.
-- Anything that depends on a built dasModule being copied to a specific install path — junctions are paths, not file copies, and the C++ binary still lives in the dev checkout.
+- Production daspkg installs — those use `daspkg install <pkg>` which sets up the `<root>/modules/<pkg>/` layout natively, and the consuming code resolves modules without any extra flag.
+- Anything that depends on a built dasModule being copied to a specific install path — `-load_module` is a path, not a file copy, and the C++ binary still lives in the dev checkout.
 
-## Combining with `.das_project`
+## Combining with `-project_root` / `.das_project`
 
-Both `project` (a `.das_project` file path) and `project_root` (a directory) can be set on the same MCP call or CLI invocation. daslang loads them independently — `.das_project` for custom `module_get` callbacks, `-project_root` for daspkg-style `modules/*/` discovery. Use both when the module has its own `.das_project` AND you want daspkg dispatch.
+All three can be set on the same call. They're independent:
+
+- `-project` (a `.das_project` file) — custom `module_get` callbacks.
+- `-project_root` (a directory) — scan its `modules/*` for `.das_module` files.
+- `-load_module` (one path per flag, repeatable) — initialize this exact folder.
+
+Precedence on basename collision: `-load_module` shadows `<project_root>/modules/<name>`, which shadows `<das_root>/modules/<name>`.
+
+## Fallback: the junction trick
+
+Before `-load_module`, the canonical workaround was to create a throwaway directory whose only contents are a `modules/<your-module>` junction (Windows) or symlink (POSIX) pointing at your dev checkout, then use it as `-project_root`. This still works — useful if you want to exercise the `<project_root>/modules/<name>` scan path itself (rather than the direct `init_dyn_modules` path).
+
+### Windows
+
+```cmd
+mkdir D:\IMGUI_DEMO\modules
+mklink /J D:\IMGUI_DEMO\modules\dasImgui D:\DASPKG\dasImgui
+daslang.exe -project_root D:/IMGUI_DEMO your_script.das
+```
+
+`mklink /J` creates a directory junction — same effect as a symlink for daslang's purposes and doesn't need admin.
+
+### POSIX
+
+```sh
+mkdir -p /tmp/IMGUI_DEMO/modules
+ln -s /path/to/dasImgui /tmp/IMGUI_DEMO/modules/dasImgui
+daslang -project_root /tmp/IMGUI_DEMO your_script.das
+```
+
+For most workflows `-load_module` is shorter and avoids the per-module mklink step.
 
 ## Worked example: dasImgui
 
+Recommended:
+
 ```cmd
-:: One-time setup
-mkdir D:\IMGUI_DEMO\modules
-mklink /J D:\IMGUI_DEMO\modules\dasImgui D:\DASPKG\dasImgui
+daslang.exe -load_module D:/DASPKG/dasImgui ^
+  D:/DASPKG/dasImgui/examples/imgui_demo/harness_layout.das
+```
 
-:: Direct CLI
-daslang.exe -project_root D:/IMGUI_DEMO ^
-  modules/dasImgui/examples/imgui_demo/harness_layout.das
+Via MCP (inside Claude Code / editor):
 
-:: Via MCP (inside Claude Code / editor)
+```jsonc
 mcp__daslang__compile_check {
   "file": "D:/DASPKG/dasImgui/examples/imgui_demo/layout.das",
-  "project_root": "D:/IMGUI_DEMO"
+  "load_modules": ["D:/DASPKG/dasImgui"]
 }
 ```
 
-Same pattern for any other daspkg-style module — adjust the `mklink` target and the `-project_root` path.
+Junction fallback (only when you need to exercise the modules/* scan path):
+
+```cmd
+mkdir D:\IMGUI_DEMO\modules
+mklink /J D:\IMGUI_DEMO\modules\dasImgui D:\DASPKG\dasImgui
+daslang.exe -project_root D:/IMGUI_DEMO D:/DASPKG/dasImgui/examples/imgui_demo/harness_layout.das
+```
 
 ## Gotchas
 
-- **NEVER put a junction inside `D:\Work\daScript\modules\`** (daslang's own modules/ tree). That's reserved for daslang's stdlib; user-side modules belong in the dummy root.
-- **The module's `.das_module` initializer is invoked with `project_path = <dummy_root>/modules/<module_name>`** (the junction path). Inside the initializer, `{project_path}/widgets/foo.das` resolves through the junction to the real dev-checkout path. This is by design — the `.das_module` doesn't need to know it's being used via a junction.
+- **The module's `.das_module` initializer is invoked with `project_path = <the path you passed to -load_module>`.** Inside the initializer, `{project_path}/widgets/foo.das` resolves against that path directly. (With the junction trick, the path is `<dummy_root>/modules/<module_name>` — which junctions to the real dev-checkout path.)
+- **Shadow-skip uses path basenames.** `-load_module D:/DASPKG/dasImgui` shadows entries named `dasImgui` in dasroot and project_root. If you renamed the module folder locally (e.g. `dasImgui-experimental`), the basename mismatch means it won't shadow the canonical `dasImgui`.
+- **`-load_module` is independent of `-dasroot`.** `-dasroot` points at the daslang stdlib (`daslib/`); `-load_module` points at user modules. They don't conflict.
+- **NEVER put a junction inside `D:\Work\daScript\modules\`** (daslang's own modules/ tree). That's reserved for daslang's stdlib; user-side modules belong outside via `-load_module` or a dummy root.
 - **On Windows, `mklink /J` is a junction (NTFS), not a symbolic link.** Junctions don't need admin; symlinks (`mklink /D` without `/J`) do. Junctions work for daslang's path resolution.
-- **`-project_root` is independent of `-dasroot`.** `-dasroot` points at the daslang stdlib (`daslib/`); `-project_root` points at your user modules. They don't conflict.

--- a/src/ast/dyn_modules.cpp
+++ b/src/ast/dyn_modules.cpp
@@ -5,6 +5,7 @@
 #include <daScript/simulate/aot_builtin_fio.h> // dirent, DIR, readdir
 #include <daScript/misc/sysos.h>
 #include <daScript/misc/string_writer.h>       // TextWriter
+#include <cctype>                              // tolower (case-insensitive basename normalize)
 
 das::FileAccessPtr get_file_access( char * pak );
 
@@ -83,6 +84,23 @@ static Result init_dyn_modules(smart_ptr<FileAccess> fa, string path, TextWriter
     }
 }
 
+// Normalize a module-folder basename for case-insensitive shadow comparisons
+// on filesystems that are case-insensitive at the OS layer (Windows, default
+// macOS HFS+/APFS). Without this, a user-supplied -load_module D:/mods/dasimgui
+// (lowercase) would NOT shadow modules/dasImgui because the on-disk basenames
+// are byte-compared. Linux ext4 is case-sensitive, so leave names untouched.
+static das::string normalize_module_name(const das::string &name) {
+#if defined(_WIN32) || defined(__APPLE__)
+    das::string out = name;
+    for (auto &c : out) {
+        c = (char)tolower((unsigned char)c);
+    }
+    return out;
+#else
+    return name;
+#endif
+}
+
 // Collect directory names under path/modules/ without loading anything
 static das_hash_set<das::string> collect_module_names(const das::string &path) {
     das_hash_set<das::string> result;
@@ -99,7 +117,7 @@ static das_hash_set<das::string> collect_module_names(const das::string &path) {
             if (c_file.name[0] == '.') {
                 continue;
             }
-            result.insert(das::string(c_file.name));
+            result.insert(normalize_module_name(das::string(c_file.name)));
         } while (_findnext(hFile, &c_file) == 0);
         _findclose(hFile);
     }
@@ -111,7 +129,7 @@ static das_hash_set<das::string> collect_module_names(const das::string &path) {
             if (ent->d_name[0] == '.') {
                 continue;
             }
-            result.insert(das::string(ent->d_name));
+            result.insert(normalize_module_name(das::string(ent->d_name)));
         }
         closedir(dir);
     }
@@ -138,7 +156,7 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
             if (strcmp(c_file.name, ".") == 0 || strcmp(c_file.name, "..") == 0) {
                 continue;
             }
-            if (skip_set && skip_set->count(das::string(c_file.name))) {
+            if (skip_set && skip_set->count(normalize_module_name(das::string(c_file.name)))) {
                 tout << "Warning: local '" << c_file.name << "' shadows global — using local\n";
                 continue;
             }
@@ -154,7 +172,7 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
             if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
                 continue;
             }
-            if (skip_set && skip_set->count(das::string(ent->d_name))) {
+            if (skip_set && skip_set->count(normalize_module_name(das::string(ent->d_name)))) {
                 tout << "Warning: local '" << ent->d_name << "' shadows global — using local\n";
                 continue;
             }
@@ -167,24 +185,58 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
 #endif // DAS_NO_FILEIO
 }
 
+static das::string path_basename(const das::string &path) {
+    // Trim trailing separators so "/mods/foo/" yields "foo" (otherwise
+    // `substr(slash+1)` would be empty and shadow-skip would key on "").
+    size_t end = path.size();
+    while (end > 0 && (path[end - 1] == '/' || path[end - 1] == '\\')) {
+        --end;
+    }
+    if (end == 0) {
+        return das::string();
+    }
+    auto slash = path.find_last_of("\\/", end - 1);
+    if (slash == das::string::npos) {
+        return path.substr(0, end);
+    }
+    return path.substr(slash + 1, end - slash - 1);
+}
+
 bool require_dynamic_modules(FileAccessPtr file_access,
                              const das::string &das_root,
                              const das::string &project_root,
+                             const das::vector<das::string> &load_modules,
                              das::TextWriter &tout) {
     bool has_project = !project_root.empty() &&
         normalizeFileName(das_root.c_str()) !=
         normalizeFileName(project_root.c_str());
-    // Collect local module names first so we can skip shadows in das_root
-    das_hash_set<das::string> local_names;
+    // Collect local module names so we can skip shadows in das_root:
+    // both project_root scans and explicit -load_module paths take precedence
+    // over das_root entries with matching basenames.
+    das_hash_set<das::string> dasroot_skip;
     if (has_project) {
-        local_names = collect_module_names(project_root);
+        dasroot_skip = collect_module_names(project_root);
     }
-    // Always init for dasroot, skipping names that exist locally
+    // Basenames are normalized for case-insensitive filesystems (Windows, macOS)
+    // so e.g. `-load_module D:/mods/dasimgui` shadows `modules/dasImgui`.
+    das_hash_set<das::string> load_module_names;
+    for (const auto &p : load_modules) {
+        load_module_names.insert(normalize_module_name(path_basename(p)));
+    }
+    for (const auto &name : load_module_names) {
+        dasroot_skip.insert(name);
+    }
     bool all_good = das::init_modules_for_folder(file_access, das_root, tout,
-        local_names.empty() ? nullptr : &local_names);
+        dasroot_skip.empty() ? nullptr : &dasroot_skip);
     if (has_project) {
-        // Init for project_root (no skipping)
-        all_good &= das::init_modules_for_folder(file_access, project_root, tout);
+        // Init for project_root, skipping anything an explicit -load_module
+        // already covers (load_module wins over project_root/modules/<name>).
+        all_good &= das::init_modules_for_folder(file_access, project_root, tout,
+            load_module_names.empty() ? nullptr : &load_module_names);
+    }
+    // Finally, init each explicit -load_module path directly.
+    for (const auto &p : load_modules) {
+        all_good &= (Result::OK == init_dyn_modules(file_access, p, tout));
     }
     return all_good;
 }

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -152,11 +152,22 @@ void das_modulegroup_release ( das_module_group * group ) {
 
 int das_register_dynamic_modules ( das_file_access *file_access,
                                     const char *project_root,
+                                    const char * const * load_module_paths,
+                                    uint32_t num_load_module_paths,
                                     das_text_writer *tout ) {
     TextPrinter printer;
     TextWriter *writer = tout != nullptr ? (TextWriter *)tout : &printer;
+    vector<string> load_modules;
+    if (load_module_paths) {
+        load_modules.reserve(num_load_module_paths);
+        for (uint32_t i = 0; i < num_load_module_paths; ++i) {
+            if (load_module_paths[i]) {
+                load_modules.emplace_back(load_module_paths[i]);
+            }
+        }
+    }
     bool res = require_dynamic_modules((FileAccess *)file_access, project_root,
-                    project_root, *writer);
+                    project_root, load_modules, *writer);
     return !res;
 }
 

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -152,6 +152,7 @@ int das_aot_main ( int argc, char * argv[] ) {
     bool das_mode = false;
     vector<pair<string, string>> aot_files;
     string project_root;
+    vector<string> load_modules;
     if ( argc>3  ) {
         for (int ai = 1; ai != argc; ++ai) {
             if ( strcmp(argv[ai],"-q")==0 ) {
@@ -190,6 +191,13 @@ int das_aot_main ( int argc, char * argv[] ) {
             } else if ( strcmp(argv[ai],"-project-root")==0 || strcmp(argv[ai],"-project_root")==0 ) {
                 project_root = argv[ai + 1];
                 ai++;
+            } else if ( strcmp(argv[ai],"-load-module")==0 || strcmp(argv[ai],"-load_module")==0 ) {
+                if ( ai+1 >= argc ) {
+                    tout << "-load_module requires path argument";
+                    return -1;
+                }
+                load_modules.push_back(argv[ai + 1]);
+                ai++;
             } else if ( strcmp(argv[ai],"-v2syntax")==0 ) {
                 version2syntax = true;
             } else if ( strcmp(argv[ai],"-v1syntax")==0 ) {
@@ -222,7 +230,7 @@ int das_aot_main ( int argc, char * argv[] ) {
     if ( !noDynamicModules ) {
         daScriptEnvironment::ensure();
         auto access = get_file_access((char*)(projectFile.empty() ? nullptr : projectFile.c_str()));
-        require_dynamic_modules(access, getDasRoot(), project_root, tout);
+        require_dynamic_modules(access, getDasRoot(), project_root, load_modules, tout);
     }
     #endif
     Module::Initialize();
@@ -426,6 +434,7 @@ void print_help() {
         << "    -use-aot    enable AOT linking (requires AOT stubs linked into the binary)\n"
         << "    -project <path.das_project> path to project file\n"
         << "    -project_root <path> root directory of the project (used for dyn modules)\n"
+        << "    -load_module <path> directly load a single dynamic-module folder (the one containing .das_module); repeatable. Bypasses the project_root/modules/<name> scan and shadows same-basename entries from dasroot/project_root.\n"
         << "    -run-fmt    <-i/-d> <-v2/-v1> {--semicolon} run formatter\n"
         << "    -log        output program code\n"
         << "    -pause      pause after errors and pause again before exiting program\n"
@@ -516,6 +525,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     bool compileOnly = false;
     bool dumpLeaks = true;
     string project_root;
+    vector<string> load_modules;
     optional<format::FormatOptions> formatter;
     for ( int i=1; i < argc; ++i ) {
         if ( argv[i][0]=='-' ) {
@@ -594,6 +604,14 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 logModuleCompileTime = true;
             } else if ( cmd=="project-root" || cmd=="project_root" ) {
                 project_root = argv[i + 1];
+                i++;
+            } else if ( cmd=="load-module" || cmd=="load_module" ) {
+                if ( i+1 >= argc ) {
+                    printf("-load_module requires path argument\n");
+                    print_help();
+                    return -1;
+                }
+                load_modules.push_back(argv[i + 1]);
                 i++;
             } else if ( cmd=="run-fmt" ) {
                 formatter.emplace();
@@ -737,7 +755,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
         daScriptEnvironment::ensure();
         project_root = deduce_project_root(project_root, files.front());
         auto access = get_file_access((char*)(projectFile.empty() ? nullptr : projectFile.c_str()));
-        require_dynamic_modules(access, getDasRoot(), project_root, tout);
+        require_dynamic_modules(access, getDasRoot(), project_root, load_modules, tout);
     }
     #endif
     Module::Initialize();

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -39,6 +39,7 @@ das::FileAccessPtr get_file_access( char * pak );
 static TextPrinter tout;
 static string projectFile;
 static string project_root;
+static vector<string> load_modules;
 static bool version2syntax = true;
 static bool trackAllocations = false;
 static bool heapReportAtExit = false;
@@ -618,6 +619,7 @@ static void print_help() {
     tout << "Usage: daslang-live [options] <script.das> [-- script arguments]\n";
     tout << "  -project <file>    - project file (.das_project)\n";
     tout << "  -project_root <path> - project root (parent of modules/, default: script's dir)\n";
+    tout << "  -load_module <path> - directly load a single dynamic-module folder (the one containing .das_module); repeatable. Shadows same-basename entries from dasroot/project_root.\n";
     tout << "  -dasroot <path>    - override DAS_ROOT\n";
     tout << "  -cwd               - change working directory to script's folder\n";
     tout << "  -v1syntax          - use v1 syntax (default: v2)\n";
@@ -713,6 +715,8 @@ int main(int argc, char * argv[]) {
             projectFile = argv[++i];
         } else if ((arg == "-project_root" || arg == "-project-root") && i + 1 < argc) {
             project_root = argv[++i];
+        } else if ((arg == "-load_module" || arg == "-load-module") && i + 1 < argc) {
+            load_modules.push_back(argv[++i]);
         } else if (arg == "-dasroot" && i + 1 < argc) {
             setDasRoot(argv[++i]);
         } else if (arg == "-cwd") {
@@ -797,7 +801,7 @@ int main(int argc, char * argv[]) {
             project_root = (slash != string::npos) ? scriptFile.substr(0, slash) : "./";
         }
         auto access = get_file_access((char*)(projectFile.empty() ? nullptr : projectFile.c_str()));
-        require_dynamic_modules(access, getDasRoot(), project_root, tout);
+        require_dynamic_modules(access, getDasRoot(), project_root, load_modules, tout);
     }
 #endif
     Module::Initialize();

--- a/utils/mcp/protocol.das
+++ b/utils/mcp/protocol.das
@@ -163,6 +163,7 @@ struct InputSchema {
 struct PropertySchema {
     @rename = "type" _type : string
     description : string
+    @optional items : PropertySchema?
 }
 
 struct ToolsListResult {
@@ -171,6 +172,11 @@ struct ToolsListResult {
 
 let PROJECT_PROP = PropertySchema(_type = "string", description = "Path to a .das_project file for custom module resolution")
 let PROJECT_ROOT_PROP = PropertySchema(_type = "string", description = "Project root directory (parent of modules/) for daspkg-style module resolution; equivalent to daslang's -project_root CLI flag. Use when working on an external module via a <DummyRoot>/modules/<your-module> junction.")
+let LOAD_MODULES_PROP = PropertySchema(
+    _type = "array",
+    description = "List of individual module folders (each containing .das_module) to load directly, equivalent to daslang's -load_module CLI flag (repeatable). Each path is the module's own folder — no <project_root>/modules/<name> wrapper. Path basenames shadow same-named entries in dasroot and project_root. Use to work on an external module without the junction trick.",
+    items = new PropertySchema(_type = "string", description = "Path to a module folder (the one containing .das_module). Absolute paths are recommended; live_launch absolutizes them before spawning daslang-live so its -cwd flag doesn't shift the base, but other tools forward verbatim.")
+)
 
 def make_file_tool(name, description : string) : MakeFileTool {
     return MakeFileTool(
@@ -184,7 +190,8 @@ def make_file_tool(name, description : string) : MakeFileTool {
                     description = "Path to the .das file"
                 ),
                 "project" => PROJECT_PROP,
-                "project_root" => PROJECT_ROOT_PROP
+                "project_root" => PROJECT_ROOT_PROP,
+                "load_modules" => LOAD_MODULES_PROP
             },
             required = ["file"]
         )
@@ -212,6 +219,7 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Path to .das file, comma-separated paths, or glob pattern (e.g. 'dir/*.das')"),
             "project" => PROJECT_PROP,
             "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP,
             "json" => PropertySchema(_type = "string", description = "If 'true', return structured JSON (array of CompileResult with file, success, errors, warnings)")
         },
         ["file"]
@@ -226,6 +234,7 @@ def handle_tools_list(id_json : string) : string {
             "timeout" => PropertySchema(_type = "string", description = "Timeout in seconds (default: 120). Process tree is killed if exceeded"),
             "project" => PROJECT_PROP,
             "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP,
             "json" => PropertySchema(_type = "string", description = "If 'true', return structured JSON (TestSummary with file, tests, total, passed, failed, errors, skipped, success, time)"),
             "failures_only" => PropertySchema(_type = "string", description = "If 'true', only show failed tests in output")
         },
@@ -248,7 +257,8 @@ def handle_tools_list(id_json : string) : string {
             "timeout" => PropertySchema(_type = "string", description = "Timeout in seconds (default: 30). Process tree is killed if exceeded"),
             "track_allocations" => PropertySchema(_type = "string", description = "If 'true', enable heap allocation tracking and append a heap report at exit (shows where each allocation came from)"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         []
     ))
@@ -259,7 +269,8 @@ def handle_tools_list(id_json : string) : string {
             "expression" => PropertySchema(_type = "string", description = "daslang expression to evaluate (e.g. 'to_float(42) + 1.0', 'length(\"hello\")')"),
             "require" => PropertySchema(_type = "string", description = "Comma-separated module imports (e.g. 'math', 'strings, daslib/json'). On compile failure, single-token names are retried under 'daslib/'."),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["expression"]
     ))
@@ -270,7 +281,8 @@ def handle_tools_list(id_json : string) : string {
             "name" => PropertySchema(_type = "string", description = "Type name (e.g. 'TypeDecl', 'ExprCall', 'Type', 'FunctionFlags')"),
             "module" => PropertySchema(_type = "string", description = "Module to require for the type (e.g. 'ast', 'daslib/json'). Single-token names that fail to resolve are auto-retried as 'daslib/<name>'."),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["name"]
     ))
@@ -284,7 +296,8 @@ def handle_tools_list(id_json : string) : string {
             "mode" => PropertySchema(_type = "string", description = "Output mode: 'ast' (default) for S-expression, 'source' for post-macro daslang code"),
             "lineinfo" => PropertySchema(_type = "string", description = "If 'true', include LineInfo (file, line:col spans) on each AST node. Only for mode='ast'"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         []
     ))
@@ -305,6 +318,7 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Optional .das file - if provided, searches all modules loaded by that file (including daslib)"),
             "project" => PROJECT_PROP,
             "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP,
             "with_cpp_source" => PropertySchema(_type = "string", description = "If 'true', for each result with a C++ implementation (builtin functions, handled types), append the resolved C++ source location via the cpp index. Adds ~2s on first call (lazy index build)."),
             "cpp_dirs" => PropertySchema(_type = "string", description = "Optional comma-separated repo-relative paths to scope the C++ source-redirect lookup to (e.g. 'src/builtin'). Only consulted when with_cpp_source='true'. Empty -> use the cached global C++ index over CPP_SEARCH_DIRS. Non-empty -> fresh scoped scan, no global cache touched. Useful when you know which subtree the symbol lives in and want to skip the multi-hundred-file index build.")
         },
@@ -317,6 +331,7 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Path to the .das file"),
             "project" => PROJECT_PROP,
             "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP,
             "json" => PropertySchema(_type = "string", description = "If 'true', return structured JSON (RequiresResult with direct and transitive arrays of RequireEntry)")
         },
         ["file"]
@@ -340,6 +355,7 @@ def handle_tools_list(id_json : string) : string {
             "no_opt" => PropertySchema(_type = "string", description = "If 'true', disable optimizations to preserve original AST (constant folding, inlining)"),
             "project" => PROJECT_PROP,
             "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP,
             "with_cpp_source" => PropertySchema(_type = "string", description = "If 'true' and the resolved symbol is a builtin function or a handled type, append the resolved C++ source location. Adds ~2s on first call (lazy index build)."),
             "cpp_dirs" => PropertySchema(_type = "string", description = "Optional comma-separated repo-relative paths to scope the C++ source-redirect lookup to (e.g. 'src/builtin'). Only consulted when with_cpp_source='true'. Empty -> cached global C++ index. Non-empty -> fresh scoped scan, no global cache touched.")
         },
@@ -354,7 +370,8 @@ def handle_tools_list(id_json : string) : string {
             "column" => PropertySchema(_type = "string", description = "Column number (1-based)"),
             "no_opt" => PropertySchema(_type = "string", description = "If 'true', disable optimizations to preserve original AST (constant folding, inlining)"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["file", "line", "column"]
     ))
@@ -368,7 +385,8 @@ def handle_tools_list(id_json : string) : string {
             "scope" => PropertySchema(_type = "string", description = "Search scope: 'file' (default) for current file only, 'all' for all loaded modules"),
             "no_opt" => PropertySchema(_type = "string", description = "If 'true', disable optimizations to preserve original AST (constant folding, inlining)"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["file", "line", "column"]
     ))
@@ -379,7 +397,8 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Path to the .das file to compile"),
             "function" => PropertySchema(_type = "string", description = "Limit output to a specific function name (optional)"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["file"]
     ))
@@ -392,7 +411,8 @@ def handle_tools_list(id_json : string) : string {
             "section" => PropertySchema(_type = "string", description = "Limit to section: 'functions', 'generics', 'operators', 'structs', 'handled', 'enums', 'globals', 'annotations'"),
             "compact" => PropertySchema(_type = "string", description = "Set to 'true' for compact output: function signatures show types only (no arg names), structs/enums omit fields/values. Use with large modules like 'ast', then drill down with describe_type or filter"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["module"]
     ))
@@ -467,7 +487,8 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Path to the .das file"),
             "function" => PropertySchema(_type = "string", description = "Function name to extract AOT for. Supports exact name, method name (matches ClassName`method), and generic origin."),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["file"]
     ))
@@ -477,7 +498,8 @@ def handle_tools_list(id_json : string) : string {
         {
             "file" => PropertySchema(_type = "string", description = "Path to .das file, comma-separated paths, or glob pattern"),
             "project" => PROJECT_PROP,
-            "project_root" => PROJECT_ROOT_PROP
+            "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP
         },
         ["file"]
     ))
@@ -594,6 +616,7 @@ def handle_tools_list(id_json : string) : string {
             "file" => PropertySchema(_type = "string", description = "Path to the .das script file to run"),
             "project" => PROJECT_PROP,
             "project_root" => PROJECT_ROOT_PROP,
+            "load_modules" => LOAD_MODULES_PROP,
             "port" => PropertySchema(_type = "string", description = "Live API port to check (default: 9090)")
         },
         ["file"]
@@ -622,43 +645,63 @@ def get_string_arg(args : JsonValue?; name : string) : string {
     return ""
 }
 
-def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string) : string {
+def get_string_array_arg(args : JsonValue?; name : string) : array<string> {
+    var result : array<string>
+    if (args == null || !(args.value is _object)) return <- result
+    let v = (args.value as _object)?[name] ?? null
+    if (v == null || !(v.value is _array)) return <- result
+    result |> reserve(length(v.value as _array))
+    // Filter out non-string and empty-string elements so callers don't have
+    // to re-validate. Empty path entries would otherwise resolve to das_root
+    // downstream (resolve_path("") -> get_das_root()) and load it as a module.
+    for (elem in v.value as _array) {
+        if (elem != null && elem.value is _string) {
+            let s = elem.value as _string
+            if (!empty(s)) {
+                result |> push(s)
+            }
+        }
+    }
+    return <- result
+}
+
+def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string; load_modules : array<string>) : string {
     if (tool_name == "compile_check") {
-        return do_compile_check(arg1, project, project_root, arg2 == "true")
+        return do_compile_check(arg1, project, project_root, arg2 == "true", load_modules)
     } elif (tool_name == "list_functions") {
-        return do_list_functions(arg1, project, project_root)
+        return do_list_functions(arg1, project, project_root, load_modules)
     } elif (tool_name == "list_types") {
-        return do_list_types(arg1, project, project_root)
+        return do_list_types(arg1, project, project_root, load_modules)
     } elif (tool_name == "run_test") {
-        return do_run_test(arg1, project, project_root, arg2, arg3 == "true", arg4 == "true")
+        return do_run_test(arg1, project, project_root, arg2, arg3 == "true", arg4 == "true", load_modules)
     } elif (tool_name == "format_file") {
         return do_format_file(arg1)
     } elif (tool_name == "run_script") {
-        return do_run_script(arg1, arg2, arg3, arg4 == "true", project, project_root)
+        return do_run_script(arg1, arg2, arg3, arg4 == "true", project, project_root, load_modules)
     } elif (tool_name == "eval_expression") {
-        return do_eval_expression(arg1, arg2, project, project_root)
+        return do_eval_expression(arg1, arg2, project, project_root, load_modules)
     } elif (tool_name == "describe_type") {
-        return do_describe_type(arg1, arg2, project, project_root)
+        return do_describe_type(arg1, arg2, project, project_root, load_modules)
     } elif (tool_name == "ast_dump") {
-        return do_ast_dump(arg1, arg2, arg3, arg4, arg5, project, project_root)
+        return do_ast_dump(arg1, arg2, arg3, arg4, arg5, project, project_root, load_modules)
     } elif (tool_name == "list_requires") {
-        return do_list_requires(arg1, project, project_root, arg2 == "true")
+        return do_list_requires(arg1, project, project_root, arg2 == "true", load_modules)
     } elif (tool_name == "convert_to_gen2") {
         return do_convert_to_gen2(arg1, arg2 == "true")
     } elif (tool_name == "goto_definition") {
-        return do_goto_definition(arg1, arg2, arg3, arg4, project, project_root, arg5 == "true", arg6)
+        return do_goto_definition(arg1, arg2, arg3, arg4, project, project_root, arg5 == "true", arg6, load_modules)
     } elif (tool_name == "type_of") {
-        return do_type_of(arg1, arg2, arg3, arg4, project, project_root)
+        return do_type_of(arg1, arg2, arg3, arg4, project, project_root, load_modules)
     } elif (tool_name == "find_references") {
-        return do_find_references(arg1, arg2, arg3, arg4, arg5, project, project_root)
+        return do_find_references(arg1, arg2, arg3, arg4, arg5, project, project_root, load_modules)
     } elif (tool_name == "program_log") {
-        return do_program_log(arg1, arg2, project, project_root)
+        return do_program_log(arg1, arg2, project, project_root, load_modules)
     } elif (tool_name == "list_modules") {
         return do_list_modules(arg1 == "true")
     } elif (tool_name == "find_symbol") {
-        return do_find_symbol(arg1, arg2, arg3, project, project_root, arg4 == "true", arg5)
+        return do_find_symbol(arg1, arg2, arg3, project, project_root, arg4 == "true", arg5, load_modules)
     } elif (tool_name == "list_module_api") {
-        return do_list_module_api(arg1, arg2, arg3, arg4, project, project_root)
+        return do_list_module_api(arg1, arg2, arg3, arg4, project, project_root, load_modules)
     } elif (tool_name == "grep_usage") {
         return do_grep_usage(arg1, arg2, arg3, arg4)
     } elif (tool_name == "outline") {
@@ -672,9 +715,9 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, projec
     } elif (tool_name == "cpp_goto_definition") {
         return do_cpp_goto_definition(arg1, arg2, arg3)
     } elif (tool_name == "aot") {
-        return do_aot(arg1, arg2, project, project_root)
+        return do_aot(arg1, arg2, project, project_root, load_modules)
     } elif (tool_name == "lint") {
-        return do_lint(arg1, project, project_root)
+        return do_lint(arg1, project, project_root, load_modules)
     } elif (tool_name == "detect_duplicates") {
         return do_detect_duplicates(arg1, arg2, arg3, arg4, arg5, arg6)
     } elif (tool_name == "export_corpus") {
@@ -698,7 +741,7 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, projec
     } elif (tool_name == "live_shutdown") {
         return do_live_shutdown(arg1)
     } elif (tool_name == "live_launch") {
-        return do_live_launch(arg1, arg2, project_root, arg3)
+        return do_live_launch(arg1, arg2, project_root, arg3, load_modules)
     } elif (tool_name == "shutdown") {
         unsafe { exit(0); }
         return make_tool_result("shutting down")
@@ -707,18 +750,19 @@ def dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, projec
     }
 }
 
-def run_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string) : string {
+def run_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string;
+             var load_modules : array<string>) : string {
     log_tool(tool_name, "{arg1} {arg2} {arg3} {arg4} {arg5} {arg6}")
     let t0 = get_clock()
     var result : string
     // Live tools run on the main thread — they use system() and sleep() which
     // don't work well from new_thread, and they don't need compilation context
     if (starts_with(tool_name, "live_")) {
-        result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root)
+        result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root, load_modules)
     } else {
         with_channel(1) $(ch) {
-            new_thread() <| @() {
-                let tool_result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root)
+            new_thread() <| @ capture(<- load_modules) () {
+                let tool_result = dispatch_tool(tool_name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root, load_modules)
                 ch |> push_clone(ToolMessage(text = tool_result))
                 ch |> notify_and_release()
             }
@@ -740,6 +784,7 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
     var arg1, arg2, arg3, arg4, arg5, arg6 : string
     let project = get_string_arg(args, "project")
     let project_root = get_string_arg(args, "project_root")
+    var load_modules <- get_string_array_arg(args, "load_modules")
     if (name == "compile_check") {
         arg1 = get_string_arg(args, "file")
         if (empty(arg1)) return jsonrpc::error(id_json, -32602, "missing 'file' argument")
@@ -927,7 +972,7 @@ def handle_tools_call(id_json : string; params : JsonValue?) : string {
     } else {
         return jsonrpc::error(id_json, -32602, "unknown tool: {name}")
     }
-    return jsonrpc::response(id_json, run_tool(name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root))
+    return jsonrpc::response(id_json, run_tool(name, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root, load_modules))
 }
 
 // ── JSON-RPC dispatcher ──────────────────────────────────────────────

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -2680,6 +2680,215 @@ def test_project_root_run_test(t : T?) {
     }
 }
 
+// ── load_module end-to-end coverage ──────────────────────────────────
+// Tier-1 peer suite to the project_root suite above. Same pretend_mod
+// fixture, but exercised via `-load_module <pretend_mod_path>` instead
+// of `-project_root <_pretend_root>`. The two flags shadow each other
+// by basename, so pointing load_module directly at the module folder
+// (which contains `.das_module`) is the canonical alternative to the
+// `<DummyRoot>/modules/<name>` junction trick.
+
+let PRETEND_LM = "_pretend_root/modules/pretend_mod"
+
+def make_lm_array(p : string) : array<string> {
+    var arr : array<string>
+    arr |> push(p)
+    return <- arr
+}
+
+def assert_load_module_pair(t : T?; without_lm, with_lm : string) {
+    var t1 : string; var e1 = false
+    parse_result(without_lm, t1, e1)
+    t |> success(e1, "without load_module: should be error -- text={t1}")
+    t |> success(find(t1, PROOT_MISSING) >= 0,
+                 "without load_module: should mention missing prerequisite -- text={t1}")
+    var t2 : string; var e2 = false
+    parse_result(with_lm, t2, e2)
+    t |> success(!e2, "with load_module: should NOT be error -- text={t2}")
+}
+
+[test]
+def test_load_module_compile_check(t : T?) {
+    t |> run("compile_check honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_compile_check(fixture_path(PROOT_CONSUMER)),
+            do_compile_check(fixture_path(PROOT_CONSUMER), "", "", false, make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_lint(t : T?) {
+    t |> run("lint honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_lint(fixture_path(PROOT_CONSUMER)),
+            do_lint(fixture_path(PROOT_CONSUMER), "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_aot(t : T?) {
+    t |> run("aot honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_aot(fixture_path(PROOT_CONSUMER), ""),
+            do_aot(fixture_path(PROOT_CONSUMER), "", "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_list_functions(t : T?) {
+    t |> run("list_functions honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_list_functions(fixture_path(PROOT_CONSUMER)),
+            do_list_functions(fixture_path(PROOT_CONSUMER), "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_list_types(t : T?) {
+    t |> run("list_types honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_list_types(fixture_path(PROOT_CONSUMER)),
+            do_list_types(fixture_path(PROOT_CONSUMER), "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_list_requires(t : T?) {
+    t |> run("list_requires honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_list_requires(fixture_path(PROOT_CONSUMER)),
+            do_list_requires(fixture_path(PROOT_CONSUMER), "", "", false, make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_program_log(t : T?) {
+    t |> run("program_log honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_program_log(fixture_path(PROOT_CONSUMER), "main"),
+            do_program_log(fixture_path(PROOT_CONSUMER), "main", "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_ast_dump(t : T?) {
+    t |> run("ast_dump honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_ast_dump("", fixture_path(PROOT_CONSUMER), "main", "source", ""),
+            do_ast_dump("", fixture_path(PROOT_CONSUMER), "main", "source", "", "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_find_references(t : T?) {
+    t |> run("find_references honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_find_references(fixture_path(PROOT_CONSUMER), "7", "17", "file", ""),
+            do_find_references(fixture_path(PROOT_CONSUMER), "7", "17", "file", "", "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_goto_definition(t : T?) {
+    t |> run("goto_definition honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_goto_definition(fixture_path(PROOT_CONSUMER), "7", "17"),
+            do_goto_definition(fixture_path(PROOT_CONSUMER), "7", "17", "", "", "", false, "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_type_of(t : T?) {
+    t |> run("type_of honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_type_of(fixture_path(PROOT_CONSUMER), "7", "17"),
+            do_type_of(fixture_path(PROOT_CONSUMER), "7", "17", "", "", "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_find_symbol(t : T?) {
+    t |> run("find_symbol honors load_module") <| @(t : T?) {
+        assert_load_module_pair(t,
+            do_find_symbol("hello", "", fixture_path(PROOT_CONSUMER)),
+            do_find_symbol("hello", "", fixture_path(PROOT_CONSUMER), "", "", false, "", make_lm_array(fixture_path(PRETEND_LM))))
+    }
+}
+
+[test]
+def test_load_module_list_module_api(t : T?) {
+    t |> run("list_module_api honors load_module") <| @(t : T?) {
+        var t1 : string; var e1 = false
+        parse_result(do_list_module_api("pretend_mod/greet"), t1, e1)
+        t |> success(e1, "without load_module: should be error -- text={t1}")
+        t |> success(find(t1, "missing prerequisite 'pretend_mod/greet") >= 0,
+                     "without load_module: should mention missing prereq -- text={t1}")
+        var t2 : string; var e2 = false
+        parse_result(do_list_module_api("pretend_mod/greet", "", "", "", "", "", make_lm_array(fixture_path(PRETEND_LM))), t2, e2)
+        t |> success(!e2, "with load_module: should NOT be error -- text={t2}")
+        t |> success(find(t2, "hello") >= 0,
+                     "with load_module: should list hello() -- text={t2}")
+    }
+}
+
+[test]
+def test_load_module_describe_type(t : T?) {
+    t |> run("describe_type honors load_module") <| @(t : T?) {
+        var t1 : string; var e1 = false
+        parse_result(do_describe_type("FooBar", "pretend_mod/greet"), t1, e1)
+        t |> success(e1, "without load_module: should be error -- text={t1}")
+        t |> success(find(t1, "missing prerequisite 'pretend_mod/greet") >= 0,
+                     "without load_module: should mention missing prereq -- text={t1}")
+        var t2 : string; var e2 = false
+        parse_result(do_describe_type("FooBar", "pretend_mod/greet", "", "", make_lm_array(fixture_path(PRETEND_LM))), t2, e2)
+        t |> success(!e2, "with load_module: should NOT be error -- text={t2}")
+    }
+}
+
+[test]
+def test_load_module_eval_expression(t : T?) {
+    t |> run("eval_expression honors load_module") <| @(t : T?) {
+        var t1 : string; var e1 = false
+        parse_result(do_eval_expression("hello()", "pretend_mod/greet"), t1, e1)
+        t |> success(e1, "without load_module: should be error -- text={t1}")
+        t |> success(find(t1, "missing prerequisite 'pretend_mod/greet") >= 0,
+                     "without load_module: should mention missing prereq -- text={t1}")
+        var t2 : string; var e2 = false
+        parse_result(do_eval_expression("hello()", "pretend_mod/greet", "", "", make_lm_array(fixture_path(PRETEND_LM))), t2, e2)
+        t |> success(!e2, "with load_module: should NOT be error -- text={t2}")
+    }
+}
+
+[test]
+def test_load_module_run_script(t : T?) {
+    t |> run("run_script honors load_module") <| @(t : T?) {
+        let inline_code = "options gen2\nrequire pretend_mod/greet\n[export]\ndef main() \{\n    print(\"\{hello()\}\\n\")\n\}\n"
+        var t1 : string; var e1 = false
+        parse_result(do_run_script("", inline_code), t1, e1)
+        t |> success(e1, "without load_module: should be error -- text={t1}")
+        t |> success(find(t1, PROOT_MISSING) >= 0,
+                     "without load_module: should mention missing prereq -- text={t1}")
+        var t2 : string; var e2 = false
+        parse_result(do_run_script("", inline_code, "", false, "", "", make_lm_array(fixture_path(PRETEND_LM))), t2, e2)
+        t |> success(!e2, "with load_module: should NOT be error -- text={t2}")
+    }
+}
+
+[test]
+def test_load_module_run_test(t : T?) {
+    t |> run("run_test honors load_module") <| @(t : T?) {
+        var t1 : string; var e1 = false
+        parse_result(do_run_test(fixture_path(PROOT_CONSUMER)), t1, e1)
+        t |> success(e1, "without load_module: should be error -- text={t1}")
+        t |> success(find(t1, PROOT_MISSING) >= 0,
+                     "without load_module: should mention missing prereq -- text={t1}")
+        var t2 : string; var e2 = false
+        parse_result(do_run_test(fixture_path(PROOT_CONSUMER), "", "", "", false, false, make_lm_array(fixture_path(PRETEND_LM))), t2, e2)
+        t |> success(find(t2, PROOT_MISSING) < 0,
+                     "with load_module: should NOT mention missing prereq -- text={t2}")
+    }
+}
+
 // ── build_live_script_args unit tests ────────────────────────────────
 // Pins daslang-live script_args composition. Flag-ordering matters because
 // when both `-project` and `-project_root` are set, `-project_root` must end
@@ -2722,6 +2931,53 @@ def test_live_args_both(t : T?) {
 }
 
 [test]
+def test_live_args_load_module_only(t : T?) {
+    t |> run("single load_module: -load_module before -cwd") <| @(t : T?) {
+        var lm : array<string>
+        lm |> push("/p1")
+        let s = build_live_script_args("/path/foo.das", "", "", false, lm)
+        t |> equal(s, "-load_module \"/p1\" -cwd \"/path/foo.das\"",
+                   "single load_module pair between project_root slot and -cwd")
+    }
+}
+
+[test]
+def test_live_args_load_module_multi(t : T?) {
+    t |> run("two load_modules: both pairs preserved in source order") <| @(t : T?) {
+        var lm : array<string>
+        lm |> push("/p1")
+        lm |> push("/p2")
+        let s = build_live_script_args("/path/foo.das", "", "", false, lm)
+        t |> equal(s, "-load_module \"/p1\" -load_module \"/p2\" -cwd \"/path/foo.das\"",
+                   "two load_module pairs preserved in source order")
+    }
+}
+
+[test]
+def test_live_args_all_set(t : T?) {
+    t |> run("project_root + load_modules + project + cwd: ordered project_root → load_module → project → cwd") <| @(t : T?) {
+        var lm : array<string>
+        lm |> push("/m1")
+        lm |> push("/m2")
+        let s = build_live_script_args("/path/foo.das", "/p.das_project", "/proj_root", false, lm)
+        t |> equal(s,
+                   "-project_root \"/proj_root\" -load_module \"/m1\" -load_module \"/m2\" -project \"/p.das_project\" -cwd \"/path/foo.das\"",
+                   "full order: project_root, then load_modules, then project, then cwd")
+    }
+}
+
+[test]
+def test_live_args_load_module_windows_paths(t : T?) {
+    t |> run("is_windows=true: load_module paths get slash-replaced too") <| @(t : T?) {
+        var lm : array<string>
+        lm |> push("D:/mods/dasImgui")
+        let s = build_live_script_args("D:/path/foo.das", "", "", true, lm)
+        t |> equal(s, "-load_module \"D:\\mods\\dasImgui\" -cwd \"D:\\path\\foo.das\"",
+                   "windows: load_module paths slash-replaced like project_root")
+    }
+}
+
+[test]
 def test_live_args_windows_paths(t : T?) {
     t |> run("is_windows=true: forward slashes become backslashes") <| @(t : T?) {
         let s = build_live_script_args("D:/path/foo.das", "D:/p.das_project", "D:/root", true)
@@ -2732,6 +2988,58 @@ def test_live_args_windows_paths(t : T?) {
         let s = build_live_script_args("D:/path/foo.das", "", "", false)
         t |> success(find(s, "/path/foo.das") >= 0, "non-windows: keep forward slashes -- s={s}")
         t |> success(find(s, "\\path") < 0, "non-windows: no backslash conversion -- s={s}")
+    }
+}
+
+// ── resolve_load_modules unit tests ──────────────────────────────────
+// Pins the abs-resolve invariant: every load_module path passed to
+// daslang-live MUST be absolute, because daslang-live's `-cwd` chdir's
+// before `require_dynamic_modules` runs (utils/daslang-live/main.cpp:696-707).
+// A relative -load_module would re-resolve against the new cwd and fail to
+// find the module folder — same hazard as -project_root.
+
+[test]
+def test_resolve_load_modules_empty(t : T?) {
+    t |> run("empty input yields empty output") <| @(t : T?) {
+        let src : array<string>
+        let out <- resolve_load_modules(src)
+        t |> equal(length(out), 0, "empty in, empty out")
+    }
+}
+
+[test]
+def test_resolve_load_modules_absolutizes_relative(t : T?) {
+    t |> run("relative paths become absolute") <| @(t : T?) {
+        var src : array<string>
+        src |> push("foo")
+        src |> push("./bar/baz")
+        let out <- resolve_load_modules(src)
+        t |> equal(length(out), 2, "preserves entry count")
+        // resolve_path uses get_das_root() as the base for relative paths.
+        // The exact prefix is platform-specific; the invariant is that the
+        // output contains the das root as a prefix (or starts with a drive
+        // letter / leading slash on POSIX).
+        let root = get_das_root()
+        t |> success(find(out[0], root) >= 0,
+                     "out[0] should contain das root prefix -- out[0]={out[0]} root={root}")
+        t |> success(find(out[1], root) >= 0,
+                     "out[1] should contain das root prefix -- out[1]={out[1]} root={root}")
+    }
+}
+
+[test]
+def test_resolve_load_modules_preserves_absolute(t : T?) {
+    t |> run("already-absolute paths pass through unchanged") <| @(t : T?) {
+        var src : array<string>
+        let is_windows = get_platform_name() == "windows"
+        let abs1 = is_windows ? "D:/already/abs/one" : "/already/abs/one"
+        let abs2 = is_windows ? "D:/already/abs/two" : "/already/abs/two"
+        src |> push(abs1)
+        src |> push(abs2)
+        let out <- resolve_load_modules(src)
+        t |> equal(length(out), 2, "preserves entry count")
+        t |> equal(out[0], abs1, "absolute path passes through unchanged")
+        t |> equal(out[1], abs2, "absolute path passes through unchanged")
     }
 }
 
@@ -2787,6 +3095,57 @@ def test_build_subtool_argv_empty_args(t : T?) {
         t |> equal(length(argv), 5, "argv length should be 5")
         t |> equal(argv[3], "sub.das", "script comes after flag")
         t |> equal(argv[4], "--", "trailing -- still present")
+    }
+}
+
+[test]
+def test_build_subtool_argv_with_load_module(t : T?) {
+    t |> run("single load_module pair inserted before script path") <| @(t : T?) {
+        let args <- ["alpha"]
+        var lm : array<string>
+        lm |> push("/mod1")
+        let argv <- build_subtool_argv("daslang.exe", "sub.das", args, "", lm)
+        t |> equal(length(argv), 6, "argv length should be 6")
+        t |> equal(argv[0], "daslang.exe", "argv[0]=exe")
+        t |> equal(argv[1], "-load_module", "argv[1]=-load_module flag")
+        t |> equal(argv[2], "/mod1", "argv[2]=load_module path")
+        t |> equal(argv[3], "sub.das", "argv[3]=script_path (AFTER load_module)")
+        t |> equal(argv[4], "--", "argv[4]=--")
+        t |> equal(argv[5], "alpha", "argv[5]=user arg")
+    }
+}
+
+[test]
+def test_build_subtool_argv_with_load_modules_multi(t : T?) {
+    t |> run("two load_module pairs preserved in source order") <| @(t : T?) {
+        let args : array<string>
+        var lm : array<string>
+        lm |> push("/m1")
+        lm |> push("/m2")
+        let argv <- build_subtool_argv("daslang.exe", "sub.das", args, "", lm)
+        t |> equal(length(argv), 7, "argv length should be 7")
+        t |> equal(argv[1], "-load_module", "argv[1]=first -load_module flag")
+        t |> equal(argv[2], "/m1", "argv[2]=first path")
+        t |> equal(argv[3], "-load_module", "argv[3]=second -load_module flag")
+        t |> equal(argv[4], "/m2", "argv[4]=second path")
+        t |> equal(argv[5], "sub.das", "argv[5]=script (AFTER both load_module pairs)")
+    }
+}
+
+[test]
+def test_build_subtool_argv_with_project_root_and_load_module(t : T?) {
+    t |> run("project_root + load_module: project_root first, then load_module, then script") <| @(t : T?) {
+        let args : array<string>
+        var lm : array<string>
+        lm |> push("/m1")
+        let argv <- build_subtool_argv("daslang.exe", "sub.das", args, "/proj_root", lm)
+        t |> equal(length(argv), 7, "argv length should be 7")
+        t |> equal(argv[1], "-project_root", "argv[1]=-project_root flag")
+        t |> equal(argv[2], "/proj_root", "argv[2]=project_root path")
+        t |> equal(argv[3], "-load_module", "argv[3]=-load_module flag (AFTER project_root)")
+        t |> equal(argv[4], "/m1", "argv[4]=load_module path")
+        t |> equal(argv[5], "sub.das", "argv[5]=script_path (AFTER all flags)")
+        t |> equal(argv[6], "--", "argv[6]=--")
     }
 }
 

--- a/utils/mcp/tools/aot.das
+++ b/utils/mcp/tools/aot.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/aot.das so macro
 //! state from compile_file doesn't leak across MCP calls.
 
-def do_aot(file, func_name : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("aot", [file, func_name, project], project_root)
+def do_aot(file, func_name : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("aot", [file, func_name, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/ast_dump.das
+++ b/utils/mcp/tools/ast_dump.das
@@ -8,7 +8,7 @@ require common public
 //! daslang.exe subprocess with a generated stub) and file-based (forwards to
 //! subtools/ast_dump.das). Both isolate compile state from the MCP server.
 
-def do_ast_dump_expression(expression, project_root : string) : string {
+def do_ast_dump_expression(expression, project_root : string; load_modules : array<string>) : string {
     let exe = get_daslang_exe()
     if (empty(exe)) return make_tool_result("Cannot determine daslang executable path", true)
     let script_path = make_temp_das_file()
@@ -26,6 +26,11 @@ def do_ast_dump_expression(expression, project_root : string) : string {
         argv |> push("-project_root")
         argv |> push(project_root)
     }
+    argv |> reserve(length(argv) + 2 * length(load_modules) + 1)
+    for (lm in load_modules) {
+        argv |> push("-load_module")
+        argv |> push(lm)
+    }
     argv |> push(script_path)
     let exit_code = run_and_capture(argv, output)
     remove(script_path)
@@ -33,11 +38,11 @@ def do_ast_dump_expression(expression, project_root : string) : string {
     return make_tool_result(output)
 }
 
-def do_ast_dump(expression, file, func_name, mode, lineinfo : string; project : string = ""; project_root : string = "") : string {
+def do_ast_dump(expression, file, func_name, mode, lineinfo : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
     if (!empty(expression)) {
-        return do_ast_dump_expression(expression, project_root)
+        return do_ast_dump_expression(expression, project_root, load_modules)
     } elif (!empty(file)) {
-        return run_mcp_subtool("ast_dump", [file, func_name, mode, lineinfo, project], project_root)
+        return run_mcp_subtool("ast_dump", [file, func_name, mode, lineinfo, project], project_root, load_modules)
     } else {
         return make_tool_result("Provide either 'expression' or 'file' argument", true)
     }

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -356,15 +356,20 @@ def subtool_user_args(args : array<string>) : array<string> {
 // its own options and just exposes the rest via get_command_line_arguments().
 def public build_subtool_argv(exe, subtool_path : string;
                               args : array<string>;
-                              project_root : string) : array<string> {
+                              project_root : string;
+                              load_modules : array<string> = array<string>()) : array<string> {
     var argv <- [exe]
     if (!empty(project_root)) {
         argv |> push("-project_root")
         argv |> push(project_root)
     }
+    argv |> reserve(length(argv) + 2 * length(load_modules) + 2 + length(args))
+    for (lm in load_modules) {
+        argv |> push("-load_module")
+        argv |> push(lm)
+    }
     argv |> push(subtool_path)
     argv |> push("--")
-    argv |> reserve(length(argv) + length(args))
     for (a in args) {
         argv |> push(a)
     }
@@ -373,11 +378,12 @@ def public build_subtool_argv(exe, subtool_path : string;
 
 def run_mcp_subtool(subtool_name : string; args : array<string>;
                     project_root : string = "";
+                    load_modules : array<string> = array<string>();
                     timeout_sec : float = 120.0) : string {
     let exe = get_daslang_exe()
     if (empty(exe)) return make_tool_result("Cannot determine daslang executable path", true)
     let subtool_path = path_join(get_das_root(), "utils/mcp/subtools/{subtool_name}.das")
-    let argv <- build_subtool_argv(exe, subtool_path, args, project_root)
+    let argv <- build_subtool_argv(exe, subtool_path, args, project_root, load_modules)
     var output : string
     let exit_code = run_and_capture(argv, output, timeout_sec)
     if (exit_code == popen_timed_out) return make_tool_result("MCP subtool '{subtool_name}' timed out after {timeout_sec}s:\n{output}", true)

--- a/utils/mcp/tools/compile_check.das
+++ b/utils/mcp/tools/compile_check.das
@@ -10,6 +10,6 @@ require common public
 //! [call_macro] state across calls. The subtool's stdout (already a
 //! make_tool_result(...) JSON envelope) is returned verbatim.
 
-def do_compile_check(file : string; project : string = ""; project_root : string = ""; json : bool = false) : string {
-    return run_mcp_subtool("compile_check", [file, project, json ? "true" : "false"], project_root)
+def do_compile_check(file : string; project : string = ""; project_root : string = ""; json : bool = false; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("compile_check", [file, project, json ? "true" : "false"], project_root, load_modules)
 }

--- a/utils/mcp/tools/describe_type.das
+++ b/utils/mcp/tools/describe_type.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/describe_type.das so
 //! macro state from compile_file doesn't leak across MCP calls.
 
-def do_describe_type(name, module_name : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("describe_type", [name, module_name, project], project_root)
+def do_describe_type(name, module_name : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("describe_type", [name, module_name, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/eval_expression.das
+++ b/utils/mcp/tools/eval_expression.das
@@ -50,7 +50,8 @@ def private rewrite_modules_in_set(req_modules : string; missing : array<string>
     return join(out_parts, ", ") => rewritten
 }
 
-def private try_eval_expression(exe, expression, req_modules, project, project_root : string; var output : string&) : int {
+def private try_eval_expression(exe, expression, req_modules, project, project_root : string;
+                                load_modules : array<string>; var output : string&) : int {
     let stub_path = make_temp_das_file()
     let script = build_string() $(var w) {
         write(w, "options gen2\n")
@@ -85,6 +86,11 @@ def private try_eval_expression(exe, expression, req_modules, project, project_r
         argv |> push("-project_root")
         argv |> push(project_root)
     }
+    argv |> reserve(length(argv) + 2 * length(load_modules) + 3)
+    for (lm in load_modules) {
+        argv |> push("-load_module")
+        argv |> push(lm)
+    }
     if (!empty(project)) {
         argv |> push("-project")
         argv |> push(project)
@@ -95,14 +101,14 @@ def private try_eval_expression(exe, expression, req_modules, project, project_r
     return exit_code
 }
 
-def do_eval_expression(expression, req_modules : string; project : string = ""; project_root : string = "") : string {
+def do_eval_expression(expression, req_modules : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
     if (empty(expression)) return make_tool_result("missing 'expression' argument", true)
     let project_err = validate_project_arg(project)
     if (!empty(project_err)) return make_tool_result(project_err, true)
     let exe = get_daslang_exe()
     if (empty(exe)) return make_tool_result("Cannot determine daslang executable path", true)
     var output : string
-    let exit_code = try_eval_expression(exe, expression, req_modules, project, project_root, output)
+    let exit_code = try_eval_expression(exe, expression, req_modules, project, project_root, load_modules, output)
     if (exit_code == 0) return make_tool_result(strip(output))
     // exit_code < 0 means try_eval_expression failed before invoking the daslang subprocess
     // (e.g. couldn't write the temp file). Surface the message directly — no retry would help.
@@ -118,7 +124,7 @@ def do_eval_expression(expression, req_modules : string; project : string = ""; 
         let did_rewrite = rewrite._1
         if (did_rewrite) {
             var output2 : string
-            let exit_code2 = try_eval_expression(exe, expression, new_modules, project, project_root, output2)
+            let exit_code2 = try_eval_expression(exe, expression, new_modules, project, project_root, load_modules, output2)
             if (exit_code2 == 0) return make_tool_result("[resolved unqualified modules under daslib/: {new_modules}]\n{strip(output2)}")
             if (exit_code2 < 0) return make_tool_result(output2, true)
             // Retry also failed at the daslang level — surface the retry's output, since the rewrite

--- a/utils/mcp/tools/find_references.das
+++ b/utils/mcp/tools/find_references.das
@@ -9,6 +9,6 @@ require common public
 //! any shared module the compiled program requires (dasModuleImgui, etc.)
 //! loads + unloads on the subtool's process lifecycle, not the MCP server's.
 
-def public do_find_references(file : string; line_str, col_str, scope_str, no_opt_str : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("find_references", [file, line_str, col_str, scope_str, no_opt_str, project], project_root)
+def public do_find_references(file : string; line_str, col_str, scope_str, no_opt_str : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("find_references", [file, line_str, col_str, scope_str, no_opt_str, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/find_symbol.das
+++ b/utils/mcp/tools/find_symbol.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/find_symbol.das so
 //! macro state from compile_file doesn't leak across MCP calls.
 
-def do_find_symbol(query : string; kind : string = ""; file : string = ""; project : string = ""; project_root : string = ""; with_cpp_source : bool = false; cpp_dirs : string = "") : string {
-    return run_mcp_subtool("find_symbol", [query, kind, file, project, with_cpp_source ? "true" : "false", cpp_dirs], project_root)
+def do_find_symbol(query : string; kind : string = ""; file : string = ""; project : string = ""; project_root : string = ""; with_cpp_source : bool = false; cpp_dirs : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("find_symbol", [query, kind, file, project, with_cpp_source ? "true" : "false", cpp_dirs], project_root, load_modules)
 }

--- a/utils/mcp/tools/goto_definition.das
+++ b/utils/mcp/tools/goto_definition.das
@@ -9,8 +9,8 @@ require common public
 //! shared module the compiled program requires (dasModuleImgui, etc.)
 //! loads + unloads on the subtool's process lifecycle, not the MCP server's.
 
-def public do_goto_definition(file : string; line_str, col_str : string; no_opt_str : string = ""; project : string = ""; project_root : string = ""; with_cpp_source : bool = false; cpp_dirs : string = "") : string {
+def public do_goto_definition(file : string; line_str, col_str : string; no_opt_str : string = ""; project : string = ""; project_root : string = ""; with_cpp_source : bool = false; cpp_dirs : string = ""; load_modules : array<string> = array<string>()) : string {
     return run_mcp_subtool("goto_definition",
         [file, line_str, col_str, no_opt_str, with_cpp_source ? "true" : "false", cpp_dirs, project],
-        project_root)
+        project_root, load_modules)
 }

--- a/utils/mcp/tools/lint_tool.das
+++ b/utils/mcp/tools/lint_tool.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/lint_tool.das so
 //! macro state from compile_file doesn't leak across MCP calls.
 
-def do_lint(file : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("lint_tool", [file, project], project_root)
+def do_lint(file : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("lint_tool", [file, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/list_functions.das
+++ b/utils/mcp/tools/list_functions.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/list_functions.das so
 //! macro state from compile_file doesn't leak across MCP calls.
 
-def do_list_functions(file : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("list_functions", [file, project], project_root)
+def do_list_functions(file : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("list_functions", [file, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/list_module_api.das
+++ b/utils/mcp/tools/list_module_api.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/list_module_api.das so
 //! macro state from compile_file doesn't leak across MCP calls.
 
-def do_list_module_api(module_name : string; filter : string = ""; section : string = ""; compact_str : string = ""; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("list_module_api", [module_name, filter, section, compact_str, project], project_root)
+def do_list_module_api(module_name : string; filter : string = ""; section : string = ""; compact_str : string = ""; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("list_module_api", [module_name, filter, section, compact_str, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/list_requires.das
+++ b/utils/mcp/tools/list_requires.das
@@ -9,6 +9,6 @@ require common public
 //! any shared module the compiled program requires (dasModuleImgui, etc.)
 //! loads + unloads on the subtool's process lifecycle, not the MCP server's.
 
-def do_list_requires(file : string; project : string = ""; project_root : string = ""; json : bool = false) : string {
-    return run_mcp_subtool("list_requires", [file, project, json ? "true" : "false"], project_root)
+def do_list_requires(file : string; project : string = ""; project_root : string = ""; json : bool = false; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("list_requires", [file, project, json ? "true" : "false"], project_root, load_modules)
 }

--- a/utils/mcp/tools/list_types.das
+++ b/utils/mcp/tools/list_types.das
@@ -7,6 +7,6 @@ require common public
 //! Thin popen wrapper. Real logic lives in subtools/list_types.das so
 //! macro state from compile_file doesn't leak across MCP calls.
 
-def do_list_types(file : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("list_types", [file, project], project_root)
+def do_list_types(file : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("list_types", [file, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/live.das
+++ b/utils/mcp/tools/live.das
@@ -107,14 +107,38 @@ def live_is_running(port : string) : bool {
     return running
 }
 
+// Resolve each load_module entry to an absolute path. Same rationale as
+// resolving file/project/project_root before composing daslang-live argv:
+// the `-cwd` chdir runs before `require_dynamic_modules`, so any relative
+// `-load_module <P>` would re-resolve against the new cwd. Public so the
+// test suite can unit-test the abs-resolve without spawning daslang-live.
+def public resolve_load_modules(load_modules : array<string>) : array<string> {
+    var abs : array<string>
+    abs |> reserve(length(load_modules))
+    for (lm in load_modules) {
+        abs |> push(resolve_path(lm))
+    }
+    return <- abs
+}
+
 // daslang-live script_args composition. Extracted so tests can pin the
 // flag-ordering invariants without spawning a subprocess. Slash-replace on
 // Windows happens here so the resulting string is shell-ready for Start-Process.
 def public build_live_script_args(file, project, project_root : string;
-                                  is_windows : bool) : string {
+                                  is_windows : bool;
+                                  load_modules : array<string> = array<string>()) : string {
     var launch_file = clone_string(file)
     var launch_project = clone_string(project)
     var launch_project_root = clone_string(project_root)
+    var launch_load_modules : array<string>
+    launch_load_modules |> reserve(length(load_modules))
+    for (lm in load_modules) {
+        var lm_norm = clone_string(lm)
+        if (is_windows) {
+            lm_norm = replace(lm_norm, "/", "\\")
+        }
+        launch_load_modules |> push(lm_norm)
+    }
     if (is_windows) {
         launch_file = replace(launch_file, "/", "\\")
         launch_project = replace(launch_project, "/", "\\")
@@ -123,6 +147,21 @@ def public build_live_script_args(file, project, project_root : string;
     var script_args = "-cwd \"{launch_file}\""
     if (!empty(launch_project)) {
         script_args = "-project \"{launch_project}\" {script_args}"
+    }
+    // Build the -load_module chain in source order, then prepend once. Input
+    // order is preserved left-to-right in the output.
+    let lm_args = build_string() $(var w) {
+        var first = true
+        for (lm in launch_load_modules) {
+            if (!first) {
+                w |> write(" ")
+            }
+            first = false
+            w |> write("-load_module \"{lm}\"")
+        }
+    }
+    if (!empty(lm_args)) {
+        script_args = "{lm_args} {script_args}"
     }
     if (!empty(launch_project_root)) {
         script_args = "-project_root \"{launch_project_root}\" {script_args}"
@@ -153,7 +192,7 @@ def private port_in_range(s : string) : bool {
     return n > 0 && n <= 65535
 }
 
-def do_live_launch(file, project, project_root, port : string) : string {
+def do_live_launch(file, project, project_root : string; port : string = ""; load_modules : array<string> = array<string>()) : string {
     if (!empty(port) && !port_in_range(port)) return make_tool_result("invalid port '{port}': expected 1-65535", true)
     let p = empty(port) ? "9090" : port
     // Check if already running
@@ -172,19 +211,17 @@ def do_live_launch(file, project, project_root, port : string) : string {
     }
     if (!stat(live_exe).is_valid) return make_tool_result("daslang-live not found in {root}/bin/Release/ or {root}/bin/", true)
     // Build launch command — daslang-live -cwd handles working directory.
-    // CRITICAL: resolve file / project / project_root to absolute paths BEFORE
-    // composing the args. daslang-live's `-cwd` flag chdir's to the script's
-    // folder (utils/daslang-live/main.cpp:696-707) BEFORE running
-    // require_dynamic_modules — so a relative `-project_root <P>` would
-    // re-resolve against the new cwd and fail to find <P>/modules/.
-    var launch_exe = clone_string(live_exe)
-    if (is_windows) {
-        launch_exe = replace(launch_exe, "/", "\\")
-    }
+    // CRITICAL: resolve file / project / project_root / load_modules to
+    // absolute paths BEFORE composing the args. daslang-live's `-cwd` flag
+    // chdir's to the script's folder (utils/daslang-live/main.cpp:696-707)
+    // BEFORE running require_dynamic_modules — so a relative `-project_root <P>`
+    // or `-load_module <M>` would re-resolve against the new cwd and fail to
+    // find the module folder.
     let abs_file = resolve_path(file)
     let abs_project = empty(project) ? "" : resolve_path(project)
     let abs_project_root = empty(project_root) ? "" : resolve_path(project_root)
-    var script_args = build_live_script_args(abs_file, abs_project, abs_project_root, is_windows)
+    let abs_load_modules <- resolve_load_modules(load_modules)
+    var script_args = build_live_script_args(abs_file, abs_project, abs_project_root, is_windows, abs_load_modules)
     if (!empty(port)) {
         // Make the spawned binary actually bind the requested port (matching the
         // poll URL above). Without this, the binary uses its own default and we'd
@@ -193,6 +230,7 @@ def do_live_launch(file, project, project_root, port : string) : string {
     }
     let launcher = "{root}/_mcp_live_launch"
     if (is_windows) {
+        let launch_exe = replace(live_exe, "/", "\\")
         let ps1 = replace("{launcher}.ps1", "/", "\\")
         fopen(ps1, "wt") $(f) {
             if (f != null) {

--- a/utils/mcp/tools/program_log.das
+++ b/utils/mcp/tools/program_log.das
@@ -9,6 +9,6 @@ require common public
 //! any shared module the compiled program requires (dasModuleImgui, etc.)
 //! loads + unloads on the subtool's process lifecycle, not the MCP server's.
 
-def do_program_log(file, func_name : string; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("program_log", [file, func_name, project], project_root)
+def do_program_log(file, func_name : string; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("program_log", [file, func_name, project], project_root, load_modules)
 }

--- a/utils/mcp/tools/run_script.das
+++ b/utils/mcp/tools/run_script.das
@@ -4,7 +4,7 @@ options no_unused_block_arguments = false
 
 require common public
 
-def do_run_script(file, code : string; timeout_str : string = ""; track_allocations : bool = false; project : string = ""; project_root : string = "") : string {
+def do_run_script(file, code : string; timeout_str : string = ""; track_allocations : bool = false; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
     let project_err = validate_project_arg(project)
     if (!empty(project_err)) return make_tool_result(project_err, true)
     let exe = get_daslang_exe()
@@ -30,6 +30,11 @@ def do_run_script(file, code : string; timeout_str : string = ""; track_allocati
     if (!empty(project_root)) {
         argv |> push("-project_root")
         argv |> push(project_root)
+    }
+    argv |> reserve(length(argv) + 2 * length(load_modules) + 5)
+    for (lm in load_modules) {
+        argv |> push("-load_module")
+        argv |> push(lm)
     }
     if (!empty(project)) {
         argv |> push("-project")

--- a/utils/mcp/tools/run_test.das
+++ b/utils/mcp/tools/run_test.das
@@ -5,16 +5,21 @@ options no_unused_block_arguments = false
 require common public
 require daslib/fio
 
-def do_run_test(file : string; project : string = ""; project_root : string = ""; timeout_str : string = ""; json : bool = false; failures_only : bool = false) : string {
+def do_run_test(file : string; project : string = ""; project_root : string = ""; timeout_str : string = ""; json : bool = false; failures_only : bool = false; load_modules : array<string> = array<string>()) : string {
     let exe = get_daslang_exe()
     if (empty(exe)) return make_tool_result("Cannot determine daslang executable path", true)
     let test_file = resolve_path(file)
     let dastest_main = "{get_das_root()}/dastest/dastest.das"
-    // -project_root is a daslang CLI flag and must come before the script path.
+    // -project_root and -load_module are daslang CLI flags and must come before the script path.
     var argv <- [exe]
     if (!empty(project_root)) {
         argv |> push("-project_root")
         argv |> push(project_root)
+    }
+    argv |> reserve(length(argv) + 2 * length(load_modules) + 7)
+    for (lm in load_modules) {
+        argv |> push("-load_module")
+        argv |> push(lm)
     }
     argv |> push(dastest_main)
     argv |> push("--")

--- a/utils/mcp/tools/type_of.das
+++ b/utils/mcp/tools/type_of.das
@@ -9,6 +9,6 @@ require common public
 //! module the compiled program requires (dasModuleImgui, etc.) loads +
 //! unloads on the subtool's process lifecycle, not the MCP server's.
 
-def public do_type_of(file : string; line_str, col_str : string; no_opt_str : string = ""; project : string = ""; project_root : string = "") : string {
-    return run_mcp_subtool("type_of", [file, line_str, col_str, no_opt_str, project], project_root)
+def public do_type_of(file : string; line_str, col_str : string; no_opt_str : string = ""; project : string = ""; project_root : string = ""; load_modules : array<string> = array<string>()) : string {
+    return run_mcp_subtool("type_of", [file, line_str, col_str, no_opt_str, project], project_root, load_modules)
 }


### PR DESCRIPTION
## Summary

Adds **`-load_module <path>`** (repeatable) to daslang.exe and daslang-live.exe. Each path is the module folder itself (the one containing `.das_module`); daslang runs that folder's `initialize()` directly, skipping the `<project_root>/modules/<name>` scan. Eliminates the dummy-root + junction setup needed today to iterate on external modules (dasImgui, dasHV, daspkg packages, etc.) locally.

- **Core**: `require_dynamic_modules()` in `src/ast/dyn_modules.cpp` gains a `vector<string> load_modules` parameter; loops `init_dyn_modules()` per entry. Path basenames feed the shadow-skip set — load_module wins over project_root, which wins over dasroot.
- **CLI**: 3 sites (aot subcommand + main parser in `utils/daScript/main.cpp`, `utils/daslang-live/main.cpp`) parse repeatable `-load_module` / `-load-module`, accumulate to `vector<string>`, thread through.
- **C API**: `das_register_dynamic_modules()` extended in place with `(const char* const* paths, uint32_t n)` (no in-tree embedders break).
- **MCP**: `PropertySchema` gains an `@optional items : PropertySchema?` field (first array-prop precedent); `LOAD_MODULES_PROP` wired into every tool that already accepts `project_root`. 18 `do_X(...)` tool functions thread `load_modules : array<string>` through to the argv builders. Dispatcher decodes the JSON array via a new `get_string_array_arg()` helper.
- **Tests**: 17 new `test_load_module_<tool>` peer tests adjacent to each `test_project_root_<tool>` in `utils/mcp/test_tools.das`, sharing the `_pretend_root` fixture. 3 new `build_subtool_argv` argv tests + 4 new `build_live_script_args` tests pin the flag-ordering invariants. All 17 existing `test_project_root_<tool>` tests still pass.
- **Docs**: `daslang_live.rst`, `mcp.rst`, `embedding/external_modules.rst` carry the new flag entry; `skills/external_module_debugging.md` is rewritten to recommend `-load_module` with the junction trick demoted to fallback. One new mouse card.

## Test plan

- [x] Local `cmake --build build --target daslang --target daslang-live -j 64` clean (MSVC)
- [x] `utils/lint/main.das` clean on the 21 changed `.das` files (`0 issue(s), 0 error(s)`)
- [x] `utils/das-fmt/dasfmt.das --verify` clean on full tree (1864 files)
- [x] MCP test suite: **372/394** pass on the changed files (the 22 failures are pre-existing ast-grep / das-fmt environment issues — all `test_project_root_*` and all 17 new `test_load_module_*` pass)
- [x] CLI smoke (`daslang.exe -load_module D:\DASPKG-audit\fakemod_external\fakemod fixture.das`) — single + multi-flag both fire `initialize()`, requires resolve
- [x] Shadowing regression (`-project_root <P>` + `-load_module <Q>` with matching basename) — `local '<name>' shadows global` warning + load_module version wins
- [x] End-to-end on real dasImgui (after rebuilding its shared modules via `cmake -B build_msvc -DDASLANG_DIR=D:/Work/daScript-next -G "Visual Studio 17 2022" -A x64`): `daslang.exe -load_module D:\DASPKG\dasImgui smoke.das` resolves `require imgui/imgui_boost_v2` + `require imgui/imgui_colors`, runs `rgba(0xff, 0x80, 0x00, 0xff)` → `0xffff8000`. Same path via `compile_check` and `find_symbol` MCP subtools.
- [ ] CI green (extended_checks + full test/AOT sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)