### PR TITLE
mouse-data: 14 cards from linq_fold decs splice work (Slices 5a-5e + PR #2741 zip)

### DIFF
--- a/mouse-data/docs/call-macro-typeof-arg-struct-fields-annotations.md
+++ b/mouse-data/docs/call-macro-typeof-arg-struct-fields-annotations.md
@@ -1,0 +1,45 @@
+---
+slug: call-macro-typeof-arg-struct-fields-annotations
+title: in a call_macro how do I parse a type<Foo> argument and read the struct fields + annotations to synthesize code?
+created: 2026-05-20
+last_verified: 2026-05-20
+links: []
+---
+
+For a `[call_macro]` that takes `type<Foo>` as an argument (where `Foo` is a struct):
+
+```das
+let typeExpr = expr.arguments[0] as ExprTypeDecl     // cast — fails if user didn't write type<...>
+let td = typeExpr.typeexpr                            // TypeDecl
+macro_verify(td != null && td.baseType == Type.tStructure, ...)
+let st = td.structType                                // StructurePtr
+```
+
+For struct annotations + fields:
+```das
+// Annotations on the struct
+for (ann in st.annotations) {
+    if (ann.annotation.name == "my_marker") {
+        let argList = ann.arguments      // AnnotationArgumentList — pass to your prefix/arg-extraction helpers
+        ...
+    }
+}
+// Fields
+for (fld in st.fields) {
+    fld.name      // das_string
+    fld._type     // TypeDecl — clone_type before stuffing into new AST
+    fld.init      // ExpressionPtr (default value, may be null) — clone_expression(fld.init) preserves null
+    fld.at        // LineInfo
+}
+```
+
+**Key gotchas:**
+- `expr.arguments[0]` is `ExprTypeDecl` (cast directly), NOT `ExprMakeBlock`. Both `_type` and `(arg as ExprTypeDecl).typeexpr` give the TypeDecl — prefer `typeexpr` when you cast.
+- Clone before reuse: `clone_type(fld._type)` / `clone_expression(fld.init)`. AST nodes have unique ownership — putting `fld._type` directly into a new TypeDecl's `argTypes` would dual-parent it.
+- `fld._type.flags.ref = false` / `flags.constant = false` strips ref/const after cloning — needed when materializing into a heap-stored tuple.
+- Reference impl: [daslib/decs_boost.das:707](daslib/decs_boost.das#L707) `FromDecsTemplateMacro` and the older block-arg form `FromDecsMacro` at line 633. Prefix-from-annotation helper `decs_prefix` at line 142 takes the `AnnotationArgumentList` from `ann.arguments`.
+
+Also for cross-referencing: `decltype` macro at [daslib/templates.das:30](daslib/templates.das#L30) shows the simpler `expr.arguments[0]._type` form when you don't need to insist on a literal `type<...>` and accept any type-producing expression.
+
+## Questions
+- in a call_macro how do I parse a type<Foo> argument and read the struct fields + annotations to synthesize code?

--- a/mouse-data/docs/count-call-body-invoke-returns-0-even-when-there-s-an-outer-exprinvoke-wrapper-why-and-how-do-i-count-invoke-nodes-in-ast-tests.md
+++ b/mouse-data/docs/count-call-body-invoke-returns-0-even-when-there-s-an-outer-exprinvoke-wrapper-why-and-how-do-i-count-invoke-nodes-in-ast-tests.md
@@ -1,0 +1,33 @@
+---
+slug: count-call-body-invoke-returns-0-even-when-there-s-an-outer-exprinvoke-wrapper-why-and-how-do-i-count-invoke-nodes-in-ast-tests
+title: count_call(body, "invoke") returns 0 even when there's an outer ExprInvoke wrapper — why, and how do I count invoke nodes in AST tests?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+`count_call(expr, funcName)` in `tests/linq/test_linq_fold_ast.das:640` matches **`ExprCall` nodes** with a matching `c.func.name` — it does NOT count `ExprInvoke` nodes. `invoke(...)` in daslang AST is `ExprInvoke` (its own node class), not `ExprCall("invoke")`. So `count_call(body_expr, "invoke")` always returns 0 regardless of how many `ExprInvoke` wrappers exist in the subtree.
+
+When you need to count invoke wrappers — e.g. proving a peeled aggregate body emits ZERO per-element block invokes while only the outer `_fold` splice wrapper remains — write a sibling helper:
+
+```
+def count_invoke_nodes(expr : Expression?) : int {
+    if (expr == null) return 0
+    var n = 0
+    if (expr is ExprInvoke) {
+        n ++
+    }
+    // ... recurse into ExprBlock/ExprFor/ExprIfThenElse/ExprOp2/ExprCall/
+    // ExprMakeBlock/ExprInvoke/ExprReturn/ExprOp1/ExprLet (same shape as count_call)
+    return n
+}
+```
+
+Then assert `equal(1, count_invoke_nodes(body_expr))` for peeled (only the outer wrapper) vs `>= 2` for runtime-invoke fallback (outer wrapper + per-element block invoke).
+
+Canonical example: PR-F's `test_aggregate_splices_peeled` uses `count_invoke_nodes` to prove the aggregate splice peeled the block body inline. See `tests/linq/test_linq_fold_ast.das` around the `// ── Phase 3+ terminal-walk lane` section.
+
+**Don't confuse with the tier-1/tier-2 distinguisher** (see [[how-do-i-write-an-ast-shape-test-that-distinguishes-tier-1-splice-from-tier-2-cascade-in-fold-exprinvoke-matches-both]]) — that's about `body_expr is ExprInvoke` matching both. This is about the helper function's traversal: `count_call` walks INTO ExprInvoke nodes' arguments but never counts the wrapper itself.
+
+## Questions
+- count_call(body, "invoke") returns 0 even when there's an outer ExprInvoke wrapper — why, and how do I count invoke nodes in AST tests?

--- a/mouse-data/docs/in-a-decs-splice-planner-plan-decs-unroll-when-wrapping-per-element-range-guards-take-skip-and-a-where-chain-around-the-same-bod.md
+++ b/mouse-data/docs/in-a-decs-splice-planner-plan-decs-unroll-when-wrapping-per-element-range-guards-take-skip-and-a-where-chain-around-the-same-bod.md
@@ -1,0 +1,53 @@
+---
+slug: in-a-decs-splice-planner-plan-decs-unroll-when-wrapping-per-element-range-guards-take-skip-and-a-where-chain-around-the-same-bod
+title: In a decs splice planner (plan_decs_unroll), when wrapping per-element range guards (take/skip) and a where_ chain around the same body, which wrap comes first — ranges or chain?
+created: 2026-05-20
+last_verified: 2026-05-20
+links: []
+---
+
+**Ranges INSIDE chain. Chain wrap goes around the range-wrapped perElement so the `where_` predicate is the outermost gate.**
+
+Concretely: in each `emit_decs_*` function that supports both ranges and chain ops:
+
+```das
+// WRONG — ranges fire BEFORE where_ filters, so take(N) counts UNFILTERED elements
+var body = wrap_decs_chain(perElement, chainInfo, calls, intermediateEnd, at)
+body = wrap_inner_for_with_decs_ranges(body, rangeInfo, skipName, takeCountName)
+
+// RIGHT — range guards wrap perElement first, then where_ wraps the whole thing
+perElement = wrap_inner_for_with_decs_ranges(perElement, rangeInfo, skipName, takeCountName)
+var body = wrap_decs_chain(perElement, chainInfo, calls, intermediateEnd, at)
+```
+
+The final inner-loop shape becomes:
+```
+for (e in arch) {
+    var tup = (...)
+    if (where_pred) {        // ← outermost: where filter first
+        if (takeC >= N) return true
+        if (skipN > 0) { skipN--; continue }
+        takeC++
+        perElement (e.g. acc++)
+    }
+}
+```
+
+**Why this matters:** User code `_where(p).take(2)` is "take 2 AFTER filter" — standard linq/SQL semantics. If you wrap ranges OUTSIDE chain, the take counter ticks on every element regardless of where_, and the cap is hit before 2 matching elements are seen.
+
+**Symptom:** `test_unroll_where_take_count_parity` (or any where+take test) fails with a too-small count. Caught when `_where(_.flag == 1).take(2).count()` on a 7-row fixture (3 flag==1 rows: 1,3,5) returned 1 instead of 2.
+
+**Mirror:** array-side `plan_loop_or_count` uses the same order:
+```das
+wrap_with_ranges(perMatchStmts, ...)            // prefix range guards onto stmts
+var loopBody = wrap_with_condition(stmts_to_expr(perMatchStmts), whereCond)  // wrap the whole thing in if(where)
+```
+
+So `wrap_with_condition(wrap_with_ranges(...))` array-side is the analog of "ranges wrap perElement, then chain wraps the result" decs-side.
+
+**Cross-archetype behavior:** the counters MUST be hoisted ABOVE `for_each_archetype` (in the invoke prelude) so they survive across archetypes — take(5) means "5 total entities across all archetypes", not "5 per archetype". The `for_each_archetype_find` `: bool` block returns `true` from the inner `return true` to stop the archetype walk when the cap is hit. Skip-only chains don't need _find — plain `for_each_archetype` is fine since skip never short-circuits.
+
+See PR #2770 for the canonical implementation in linq_fold.das (Slice 5a).
+
+## Questions
+- In a decs splice planner (plan_decs_unroll), when wrapping per-element range guards (take/skip) and a where_ chain around the same body, which wrap comes first — ranges or chain?

--- a/mouse-data/docs/in-a-fold-splice-planner-how-do-i-extract-a-select-call-s-element-type-when-the-chain-is-wrapped-in-fold-and-cll-0-type-firsttyp.md
+++ b/mouse-data/docs/in-a-fold-splice-planner-how-do-i-extract-a-select-call-s-element-type-when-the-chain-is-wrapped-in-fold-and-cll-0-type-firsttyp.md
@@ -1,0 +1,49 @@
+---
+slug: in-a-fold-splice-planner-how-do-i-extract-a-select-call-s-element-type-when-the-chain-is-wrapped-in-fold-and-cll-0-type-firsttyp
+title: In a fold splice planner, how do I extract a SELECT call's element type when the chain is wrapped in `_fold(...)` and `cll._0._type.firstType` returns an unresolved `typedecl(result_selector(...))` formula?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Problem:** plan_loop_or_count does `elementType = clone_type(cll._0._type.firstType)` and it works. When I copied this pattern into plan_zip (Phase 2B Z3), it broke with `error[30316]: local variable type can't be inferred` on the emitted `var $i(bufName) : array<$t(elementType)>` — because `firstType` came back as `typedecl(result_selector(result_selector, type<tuple<int;int>>))`, a generic-formula expression NOT a resolved type.
+
+**Why it differs:** plan_loop_or_count's typical input chain is `each(arr)._select($(x) => x*2)` where `arr : array<int>` and the lambda body `x*2` infers cleanly to `int` — the select's return type resolves all the way down to `array<int -const-&>`. plan_zip's input is `zip(a, b) |> select($(t : tuple<int;int>) => t._0 + t._1)` — `zip(a, b)`'s output is `array<tuple<int;int>>`, but when the chain is wrapped in `_fold(...)`, the call-macro context defers full generic-typedecl evaluation on select. The select call's `_type` is reported as `array<typedecl(result_selector(...)) -const-&>` with the inner typedecl still as a formula. Calling `firstType` on that returns the unresolved formula, not `int`.
+
+**Fix (PR Phase 2B / #2739):** pull elementType from the projection block's return-expression `_type` directly:
+
+```das
+var projElemType : TypeDeclPtr
+var projBody = cll._0.arguments[1]
+if (projBody is ExprMakeBlock) {
+    var projMblk = projBody as ExprMakeBlock
+    var projBlk = projMblk._block as ExprBlock
+    if (projBlk.list |> length == 1 && projBlk.list[0] is ExprReturn) {
+        var projRet = projBlk.list[0] as ExprReturn
+        if (projRet.subexpr != null && projRet.subexpr._type != null) {
+            projElemType = clone_type(projRet.subexpr._type)
+        }
+    }
+}
+if (projElemType == null) return null
+projElemType.flags.constant = false   // strip const — `array<T const>` is unwritable
+elementType = projElemType
+```
+
+The projection block (`$(t : tuple<int;int>) => t._0 + t._1`) was typed before the macro fired — `ret.subexpr._type` is concrete (`int const` here). Cloning and stripping const gives a usable element type for the buffer decl.
+
+**Two non-obvious constraints:**
+
+1. **Always strip const** via `flags.constant = false` after clone — projection return types are typically `T const` (since `t._0 + t._1` is a const r-value), and `array<T const>` fails at `push_clone` with `can't write to a constant value`.
+
+2. **Block-shape guard required.** The lookup only works for the simple `{ return <expr> }` block shape. For complex projections (multiple stmts, non-simple-return), bail to tier-2 by returning null when projElemType is null. plan_loop_or_count's `firstType` path quietly accepts these by falling back through the generic typedecl chain — but in plan_zip's _fold-wrapped context, that chain doesn't resolve.
+
+**Why plan_loop_or_count escapes:** its element binds via single-arg lambda over a SINGLE source (not a zip tuple). The single-source case lets daslang's typer pre-resolve the typedecl chain inside the _fold's argument before the macro fires; the multi-source zip-with-tuple-projection case doesn't resolve until after splice. This is a typer subtlety, not a planner bug — the workaround above is the right shape for plan_zip.
+
+**Related:** [[how-do-i-pass-a-tuple-of-iter-vars-into-a-peeled-lambda-predicate-in-a-fold-splice]] — chain-op substitution in plan_zip uses `fold_linq_cond` (rename-based) + `let it = (itA, itB)` body-bind, NOT `fold_linq_cond_peel` with raw tuple-expr substitution.
+
+## Questions
+- In a fold splice planner, how do I extract a SELECT call's element type when the chain is wrapped in `_fold(...)` and `cll._0._type.firstType` returns an unresolved `typedecl(result_selector(...))` formula?
+
+## Questions
+- In a fold splice planner, how do I extract a SELECT call's element type when the chain is wrapped in `_fold(...)` and `cll._0._type.firstType` returns an unresolved `typedecl(result_selector(...))` formula?

--- a/mouse-data/docs/in-a-linq-fold-chain-recognizer-how-do-i-distinguish-bare-count-from-the-predicate-overload-count-pred-before-popping-it-as-the.md
+++ b/mouse-data/docs/in-a-linq-fold-chain-recognizer-how-do-i-distinguish-bare-count-from-the-predicate-overload-count-pred-before-popping-it-as-the.md
@@ -1,0 +1,39 @@
+---
+slug: in-a-linq-fold-chain-recognizer-how-do-i-distinguish-bare-count-from-the-predicate-overload-count-pred-before-popping-it-as-the
+title: In a linq_fold chain recognizer, how do I distinguish bare count() from the predicate overload count(pred) before popping it as the splice terminator?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+Both forms parse as the same `count` `ExprCall` with `name == "count"`. The dispatch is by **argument count**: `count(src)` has 1 argument (the source iterator), `count(src, pred)` has 2.
+
+When you're peeling a trailing `count` off the chain to recognize it as the splice terminator, **check `length(arguments) == 1`** before consuming. Otherwise you silently miscompile `count(pred)` chains by dropping the predicate and emitting a bare count.
+
+```das
+// inside plan_X — after recognizing the group_by / source shape:
+let lastName = calls.back()._0.name
+if (lastName == "count" && length(calls.back()._0.arguments) == 1) {
+    terminatorName = lastName
+    calls |> pop
+}
+// chain still contains count(pred) if length was 2 — cascade handles it
+```
+
+Same trap shape applies to other 2-arg-overloaded terminators that splice planners pop: `first(src, pred)`, `last(src, pred)`, `any(src, pred)`, `all(src, pred)`, `single(src, pred)`. `count` is the most common offender because the predicate form is the natural way to write filtered counts (instead of `_where(pred).count()`).
+
+Reference fix: PR #2775 commit `2a16ab408` (Slice 5e, Copilot review #2). Both `plan_group_by` (array source) and `plan_decs_group_by` (decs bridge source) had the same bug — the recognizer popped `count` unconditionally and the bench/test suite missed it because every group_by test used bare `.count()`. Copilot caught it. Fix is two lines in each planner; regression test added in `tests/linq/test_linq_fold.das::test_group_by_count_predicate_cascades` (array) and `tests/linq/test_linq_from_decs.das` parity test (decs).
+
+## Questions
+
+- In a linq_fold chain recognizer, how do I distinguish bare count() from the predicate overload count(pred) before popping it as the splice terminator?
+- Why does my splice planner silently break `count(pred)` chains — the count vanishes from the emitted code?
+- Which terminator names overload on argument count and need an `arguments.length == 1` guard in a splice recognizer?
+
+## See also
+
+- [[when-adding-a-decs-specific-splice-planner-e-g-plan-decs-group-by-to-the-linq-fold-cascade-where-does-it-go-relative-to-the-arra]] — cascade ordering trap (sibling Copilot lesson from the same PR)
+- [[macro-planner-named-marker-arms-leave-room-for-future-modes]] — broader chain-recognition discipline
+
+## Questions
+- In a linq_fold chain recognizer, how do I distinguish bare count() from the predicate overload count(pred) before popping it as the splice terminator?

--- a/mouse-data/docs/in-a-qmacro-template-can-i-use-i-name-in-the-iter-var-position-of-a-multi-iterator-for-loop-e-g-for-i-a-i-b-in.md
+++ b/mouse-data/docs/in-a-qmacro-template-can-i-use-i-name-in-the-iter-var-position-of-a-multi-iterator-for-loop-e-g-for-i-a-i-b-in.md
@@ -1,0 +1,38 @@
+---
+slug: in-a-qmacro-template-can-i-use-i-name-in-the-iter-var-position-of-a-multi-iterator-for-loop-e-g-for-i-a-i-b-in
+title: In a qmacro template, can I use `$i(name)` in the iter-var position of a multi-iterator for-loop (e.g. `for ($i(a), $i(b) in ...)`)?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**No.** The qmacro parser rejects `$i(...)` splice in iter-var position of a for-loop header — fails with `syntax error, unexpected $i, expecting name or '('`. It works fine in source-expression position (`for (x in $i(srcName))`), just not in iter-name position.
+
+**Why:** the for-loop grammar at the iter-var position takes a raw `NAME` token (per the bison grammar in `src/parser/`). The `$i(...)` splice is only accepted at expression-position productions.
+
+**Workarounds:**
+
+1. **Use literal iter names**. If your splice planner controls the calling convention, hardcode the iter var names (e.g. `itA`, `itB` for 2-iter zip emission) and emit:
+   ```das
+   bodyStmts |> push <| qmacro_expr() {
+       for (itA, itB in $i(srcAName), $i(srcBName)) {
+           $e(loopBody)
+       }
+   }
+   ```
+   This is what `plan_zip` in `daslib/linq_fold.das:3160` does. Callers that need to reference the iter values from outside the for-loop (e.g. via `let it = (itA, itB)` body bind in `preCondStmts`) just use the same literal names.
+
+2. **Hand-build the ExprFor AST node** directly via `new_expr_for(...)` if you genuinely need dynamic-arity iter vars (e.g. for an 8-ary zip planner without 8 hardcoded branches). More verbose; only worth it when literal names won't scale.
+
+**Real example:** the multi-source generalization of `emit_accumulator_lane` / `emit_early_exit_lane` in PR for Phase 2B+ branches on `length(srcNames)` (1 vs 2) and emits two different `qmacro_expr() { for (...) { ... } }` blocks — one with `$i(itName)` (single iter), one with literal `itA, itB`. Dynamic-arity beyond 2 would require option 2.
+
+**Don't try:** `for ($i(itName0) in ...)` with a hardcoded loop unroll — `$i` in iter-name position fails for any arity (even 1, when the name itself comes from a splice). Single-source helpers use `$i(itName)` in iter position because that's the canonical "single iter via splice" pattern and the parser does accept it... actually wait, let me re-check.
+
+Re-checking: `for ($i(itName) in $i(srcName))` (single iter, single source, both spliced) DOES work in plan_loop_or_count's `emit_accumulator_lane` at line 770. The parser accepts `$i(name)` in iter-var position for **single-iter** for-loops. The failure was specifically the **multi-iter** form `for ($i(a), $i(b) in ...)`. So the rule is: **`$i` in iter-var position works only when there's exactly one iter var.** Multi-iter must use literal names.
+
+Why: the multi-iter grammar production expects `NAME (',' NAME)+` — the `,` separator requires the parser to lookahead for a raw NAME token, and `$i` doesn't satisfy that lookahead.
+
+**Bottom line for planners:** if you're emitting a single-iter for-loop, use `$i(name)`. If you need multi-iter (zip, archetype walks, etc.), use literal iter names and have the planner control the calling convention so the iter names are predictable (`itA`, `itB`, `itC`, ... up to your arity ceiling).
+
+## Questions
+- In a qmacro template, can I use `$i(name)` in the iter-var position of a multi-iterator for-loop (e.g. `for ($i(a), $i(b) in ...)`)?

--- a/mouse-data/docs/in-a-shared-linq-fold-splice-helper-that-runs-over-both-array-sources-each-arr-and-iterator-sources-from-decs-template-how-do-i.md
+++ b/mouse-data/docs/in-a-shared-linq-fold-splice-helper-that-runs-over-both-array-sources-each-arr-and-iterator-sources-from-decs-template-how-do-i.md
@@ -1,0 +1,52 @@
+---
+slug: in-a-shared-linq-fold-splice-helper-that-runs-over-both-array-sources-each-arr-and-iterator-sources-from-decs-template-how-do-i
+title: In a shared linq_fold splice helper that runs over both array sources (`each(arr)`) and iterator sources (`from_decs_template(...)`), how do I dispatch the explicit return type so the typer doesn't choke on `error[30343] iterator<T> = array<T>`?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+The decs bridge (`from_decs_template(type<T>)`) types as `iterator<T>` because the surface emits `to_sequence(res)` internally. Adding `.to_array()` peels it back to `array<T>`. **A splice that supports both source families must check the chain's expression type and emit the return-type annotation + final-return shape to match.**
+
+Pattern (drop-in for any planner that buffers tuples then returns):
+
+```das
+// captured once when the planner runs
+let exprIsIterator = expr._type.isIterator
+
+// dispatched in two places:
+
+// 1) the explicit return-type annotation on the inner invoke wrapper
+let retType : TypeDeclPtr = exprIsIterator
+    ? clone_type(make_iterator_type(elemType))
+    : clone_type(make_array_type(elemType))
+
+// 2) the final-return statement
+def buffer_return(bufName : string; isIterator : bool) : ExpressionPtr {
+    return isIterator
+        ? qmacro_block(return <- $i(bufName).to_sequence_move())
+        : qmacro_block(return <- $i(bufName))
+}
+```
+
+**Why both sides need it.** If you build the buffer as `array<tuple<...>>` then return it bare, the typer infers the wrapping invoke's return type as `array<...>`. If the caller chain types as `iterator<...>` (because `from_decs_template` didn't have `.to_array()` peeled), `error[30343]: iterator<...> = array<...>` fires at the call site. Adding `.to_sequence_move()` converts; the explicit `retType` annotation on the invoke wrapper anchors the typer.
+
+**Decs-side gotcha.** The decs bridge ALWAYS wraps the emit in `qmacro(invoke($() : retType { ...stmts; return ... }))` (you can't splice the body directly into the call site because of the outer `for_each_archetype` lambda scope). The explicit `: retType` annotation is non-negotiable on the decs side — without it the typer fails to infer back to iterator vs array correctly when both shapes share the helper.
+
+Reference fix: PR #2775 commit `a7b0de4d3` (Slice 5e, Copilot review #1). When `plan_decs_group_by` was first added it hardcoded `return <- $i(bufName)` (array assumption), which broke the test `target_unroll5e_groupby_iter_typed_fold` where the chain stayed iterator-typed (no `.to_array()` peel). Fix: capture `exprIsIterator` early, branch on it for both `retType` and `buffer_return`. Same dispatch is used by `plan_group_by_core` post-refactor (commit `cb72db296`), so the array-side path automatically inherits the fix and the iterator-typed case is now exercised by both source families' tests.
+
+## Questions
+
+- In a shared linq_fold splice helper that runs over both array sources (`each(arr)`) and iterator sources (`from_decs_template(...)`), how do I dispatch the explicit return type so the typer doesn't choke on `error[30343] iterator<T> = array<T>`?
+- Why does my decs splice planner fail to compile with `error[30343] iterator<X> = array<X>` only when `.to_array()` is absent from the chain?
+- What's the `buffer_return(bufName, isIterator)` pattern and where does it dispatch?
+- When does `from_decs_template(type<T>)` type as `iterator<T>` vs `array<T>` in the caller chain?
+
+## See also
+
+- [[when-adding-a-decs-specific-splice-planner-e-g-plan-decs-group-by-to-the-linq-fold-cascade-where-does-it-go-relative-to-the-arra]] — cascade ordering trap (sibling lesson)
+- [[when-does-daslib-s-order-by-return-iterator-vs-array-and-why-is-to-sequence-move-dangerous-to-wrap-blindly-around-the-result]] — `to_sequence_move` semantics on the source side
+- [[in-a-fold-splice-planner-how-do-i-extract-a-select-call-s-element-type-when-the-chain-is-wrapped-in-fold-and-cll-0-type-firsttyp]] — getting the element type out of the chain in the first place
+
+## Questions
+- In a shared linq_fold splice helper that runs over both array sources (`each(arr)`) and iterator sources (`from_decs_template(...)`), how do I dispatch the explicit return type so the typer doesn't choke on `error[30343] iterator<T> = array<T>`?

--- a/mouse-data/docs/in-linq-fold-how-do-i-extend-emit-accumulator-lane-emit-early-exit-lane-currently-single-source-to-support-multi-source-zip-emis.md
+++ b/mouse-data/docs/in-linq-fold-how-do-i-extend-emit-accumulator-lane-emit-early-exit-lane-currently-single-source-to-support-multi-source-zip-emis.md
@@ -1,0 +1,72 @@
+---
+slug: in-linq-fold-how-do-i-extend-emit-accumulator-lane-emit-early-exit-lane-currently-single-source-to-support-multi-source-zip-emis
+title: In linq_fold, how do I extend `emit_accumulator_lane` / `emit_early_exit_lane` (currently single-source) to support multi-source zip emission without duplicating ~150 LOC of per-op state-building?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Generalize via parallel arrays.** Change `srcName : string` → `srcNames : array<string>` and `top : Expression?` → `topExprs : array<Expression?>`. Single-source callers (plan_loop_or_count) pass 1-element arrays. Multi-source callers (plan_zip) pass N-element arrays.
+
+**What stays the same** (source-count-agnostic):
+- All per-op prelude / per-match / tail stmt building (the bulk of the helper)
+- `prepend_binds` / `wrap_with_ranges` / `wrap_with_condition` / `prepend_precond`
+- The `valueName` / `itName` indirection (helpers reference `$i(itName)`; for zip, caller threads `let it = (itA, itB)` via `preCondStmts` so the bind happens inside the loop body where `itName` resolves to the tuple)
+
+**What needs to branch on `length(srcNames)`**:
+
+1. **For-loop emission** — qmacro can't dynamically fan out iter vars (see [[in-a-qmacro-template-can-i-use-i-name-in-the-iter-var-position-of-a-multi-iterator-for-loop-e-g-for-i-a-i-b-in]]). Hardcode 1-source branch with `$i(itName)`; for 2-source branch, use literal `itA, itB` matching the caller convention:
+   ```das
+   if (length(srcNames) == 1) {
+       bodyStmts |> push <| qmacro_expr() {
+           for ($i(itName) in $i(srcNames[0])) {
+               $e(loopBody)
+           }
+       }
+   } else {
+       bodyStmts |> push <| qmacro_expr() {
+           for (itA, itB in $i(srcNames[0]), $i(srcNames[1])) {
+               $e(loopBody)
+           }
+       }
+   }
+   ```
+
+2. **Invoke wrap** — clone tops + derive param types + emit 1-arg or 2-arg invoke. Factor into a helper to avoid duplication across `emit_accumulator_lane` and `emit_early_exit_lane`. Pattern:
+   ```das
+   def private finalize_lane_emission(var topExprs : array<Expression?>; srcNames : array<string>;
+                                      var bodyStmts : array<Expression?>; at : LineInfo) : Expression? {
+       if (length(srcNames) == 1) {
+           var topExpr = clone_expression(topExprs[0])
+           topExpr.genFlags.alwaysSafe = true
+           var srcParamType = invoke_src_param_type(topExprs[0])
+           var res = qmacro(invoke($($i(srcNames[0]) : $t(srcParamType)) {
+               $b(bodyStmts)
+           }, $e(topExpr)))
+           return finalize_invoke(res, at)
+       }
+       // 2-source: clone both tops, derive both types, emit 2-arg invoke
+       ...
+   }
+   ```
+
+3. **`finalize_invoke`** — was hardcoded to set `can_shadow` on `arguments[0]`. Make it loop over all block arguments:
+   ```das
+   var blkBlock = blk._block as ExprBlock  // var, not let — propagates non-const through field chain
+   for (i in 0 .. length(blkBlock.arguments)) {
+       blkBlock.arguments[i].flags.can_shadow = true
+   }
+   ```
+   Single-source path unaffected (1-element loop ≡ original behavior). The `var` (not `let`) on `blkBlock` matters — `let` propagates const through the field-chain and the `flags` field-set fails with "can't get field 'genFlags' of auto& -const" or similar.
+
+**What the caller (plan_zip) must do**:
+- Build `preCondStmts` with `let $i(itName) = (itA, itB)` so the body bind is in scope before `whereCond` evaluation (which happens inside `wrap_with_condition`'s `if (...)` guard).
+- Pre-fold the projection / predicates via `fold_linq_cond(expr, itName)` rename so they reference `itName`, not the original lambda arg name.
+- For accumulator without projection on zip: bail to tier-2 (`if (projection == null) return null`) — `default<tuple<...>>` doesn't have `+=` so sum/min/max/average wouldn't typecheck anyway, but the explicit bail keeps the error in linq's normal cascade rather than the splice.
+
+**Verified on:** `daslib/linq_fold.das` Phase 2B+ branch — 220/220 ast tests + 369/369 fold tests green after refactor + adding zip+sum/min/max/average/first/first_or_default/any/all/contains dispatch. Single-source plan_loop_or_count path unaffected (just wraps params in 1-element arrays at its call sites).
+
+**Future:** N-arity beyond 2 needs either more arity-specific qmacro branches OR direct ExprFor AST construction. For-loop emission is the bottleneck; everything else (body construction, invoke wrap) scales cleanly via the parallel-arrays approach.
+
+## Questions
+- In linq_fold, how do I extend `emit_accumulator_lane` / `emit_early_exit_lane` (currently single-source) to support multi-source zip emission without duplicating ~150 LOC of per-op state-building?

--- a/mouse-data/docs/in-plan-zip-splice-multi-iterator-for-loop-how-do-i-pass-the-tuple-element-ita-itb-into-a-peeled-lambda-predicate-without-the-ty.md
+++ b/mouse-data/docs/in-plan-zip-splice-multi-iterator-for-loop-how-do-i-pass-the-tuple-element-ita-itb-into-a-peeled-lambda-predicate-without-the-ty.md
@@ -1,0 +1,51 @@
+---
+slug: in-plan-zip-splice-multi-iterator-for-loop-how-do-i-pass-the-tuple-element-ita-itb-into-a-peeled-lambda-predicate-without-the-ty
+title: In plan_zip splice (multi-iterator for-loop), how do I pass the tuple element `(itA, itB)` into a peeled lambda predicate without the typer choking on `can't locate variable 't'`?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+**Problem:** plan_zip (Phase 2B Z3) needs to splice `zip(a, b) |> where_($(t : tuple<int;int>) => t._0 > 0)` into a `for (itA, itB in srcA, srcB) { if (<peeled-pred>) { ... } }`. Tried `fold_linq_cond_peel(pred, qmacro((itA, itB)))` — substituting the lambda's `t` with the raw tuple-literal expression `(itA, itB)` — analogous to plan_loop_or_count's after-select peel where projection is substituted into the predicate. It typer-failed with `error[30838]: can't locate variable 't'` at the zip-call's location, even though the predicate body referenced `t` (not the substituted name).
+
+**Root cause (suspected):** Inside a `_fold(...)` wrapper, the typer's resolution of `qmacro((itA, itB))` (the substitution-source expression built at macro time) doesn't carry through the post-splice apply_template re-walk cleanly. The `replaceVariablePeeling` rewrites references in the cloned predicate body, but somewhere downstream the typer re-discovers a stale `t` symbol — possibly from a wrap or projection that the peel didn't reach. The exact mechanism wasn't tracked down; the symptom is reliable across all three predicate ops (where_, take_while, skip_while).
+
+**Fix (PR Phase 2B / #2739):** bind the tuple as a body-local `it` and use rename-based `fold_linq_cond(pred, itName)` instead of peel substitution:
+
+```das
+// In the chain walker:
+var predicate : Expression? = fold_linq_cond(cll._0.arguments[1], itName)
+// ...
+
+// In the body assembly, when any chain op references `it`:
+let needsItBind = whereCond != null || projection != null || skipWhileCond != null || takeWhileCond != null
+if (needsItBind) {
+    var preStmts : array<Expression?>
+    preStmts |> reserve(2)
+    preStmts |> push <| qmacro_expr() {     // nolint:STYLE012
+        let $i(itName) = (itA, itB)
+    }
+    preStmts |> push(perBody)
+    perBody = stmts_to_expr(preStmts)
+}
+```
+
+The `let it = (itA, itB)` binds the tuple-of-iter-vars to a local at the top of the for-body (BEFORE the where-wrap and BEFORE the take/skip-while range guards, since those predicates also reference `it`). All chain ops then refer to `itName` via the standard rename-target path.
+
+**Cost:** one tuple stack-copy per iteration. For workhorse element types (int int) this is 16 bytes/iter — measurable but cheap. For larger element types it scales linearly with sizeof(elem). Acceptable for the chain-fuse perf wins (vs. tier-2's `array<tuple>` materialize + roundtrip).
+
+**Three non-obvious constraints:**
+
+1. **`needsItBind` must be computed BEFORE the for-loop emission**, because it gates whether iter vars are emitted as `itA, itB` (referenced by the bind) or `_itA, _itB` (LINT002 underscore-prefix for unreferenced vars). Got bit by this: had underscore-prefix in the for-header AND `let it = (itA, itB)` in the body → typer said `can't locate variable 'itA'`. Fix: only underscore-prefix when `!needsItBind && isCounter && noChain`.
+
+2. **The bind goes OUTSIDE the where-wrap, not inside.** `wrap_with_condition(stmts_to_expr(perStmts), whereCond)` wraps everything in `if (whereCond) { ... }`. If the bind were inside the if, the where predicate (which is the `if`'s condition, evaluated before the body) wouldn't see `it`. The bind must precede the whole if-wrap — same shape as `prepend_precond` in plan_loop_or_count for the chained-select dedup case.
+
+3. **`var preStmts : array<Expression?> <- [itBind, perBody]` triggers a const-mismatch.** Array-literal init from a mix of `let` (const) and `var` (non-const) Expression refs gets inferred as `array<Expression? const>` which can't be assigned to `array<Expression?>`. Workaround: declare empty + reserve + push pattern (with `nolint:STYLE012` since reserve-then-push-twice is being flagged).
+
+**Related:** [[in-a-fold-splice-planner-how-do-i-extract-a-select-call-s-element-type-when-the-chain-is-wrapped-in-fold-and-cll-0-type-firsttyp]] — companion issue in the same PR: select's element type needs to be pulled from the projection block's return-expr `_type`, not from `cll._0._type.firstType`.
+
+## Questions
+- In plan_zip splice (multi-iterator for-loop), how do I pass the tuple element `(itA, itB)` into a peeled lambda predicate without the typer choking on `can't locate variable 't'`?
+
+## Questions
+- In plan_zip splice (multi-iterator for-loop), how do I pass the tuple element `(itA, itB)` into a peeled lambda predicate without the typer choking on `can't locate variable 't'`?

--- a/mouse-data/docs/my-fold-each-arr-where-last-chain-fails-with-error-50503-expecting-linq-expression-and-the-chain-interprets-literally-what-s-wro.md
+++ b/mouse-data/docs/my-fold-each-arr-where-last-chain-fails-with-error-50503-expecting-linq-expression-and-the-chain-interprets-literally-what-s-wro.md
@@ -1,0 +1,25 @@
+---
+slug: my-fold-each-arr-where-last-chain-fails-with-error-50503-expecting-linq-expression-and-the-chain-interprets-literally-what-s-wro
+title: My _fold(each(arr)._where(...).last()) chain fails with error[50503] "expecting linq expression" and the chain interprets literally. What's wrong?
+created: 2026-05-19
+last_verified: 2026-05-19
+links: []
+---
+
+The `_where(...)` / `_select(...)` / `_any(...)` / `_all(...)` etc. forms with leading underscore are **`[call_macro]` shorthand macros that live in `daslib/linq_boost`**, NOT `daslib/linq`. If your file requires only `daslib/linq` (and `daslib/linq_fold`), those macros are undefined; the `_fold` planner can't recognize the chain, returns null, and the chain falls back to literal-form interpretation which then fails because:
+
+- `each(arr)._where(...)` parses to dot-method-on-iterator, but iterator types have no `_where` field/method → `error[30928]: can't get field '_where' of iterator<int&>`
+- `_fold(...)` macro reports `error[50503]: expecting linq expression`
+
+**Fix:** add `require daslib/linq_boost` to the top of the file. That makes `_where` / `_select` etc. resolvable and the splice planner can do its job.
+
+| File requires only `daslib/linq` | File requires `daslib/linq` + `daslib/linq_boost` |
+|---|---|
+| `_fold(each(arr)._where(_ > 5).last())` → 50503 + 30928 cascade | works — splice plans the chain |
+
+The mistake is easy to make when writing standalone smoke tests / scratch repros, because the production benchmarks and `tests/linq/test_linq_fold.das` always require `linq_boost` already. The lambda forms (`where_(arr, $(x) => ...)`) work without `linq_boost` since they're plain function calls, but you lose the `_` placeholder convenience and the splice planner uses the `_where`-shape recognition path.
+
+**Heuristic:** if the chain uses `_<op>(_ <expr>)` placeholder forms anywhere — even one — pull in `daslib/linq_boost`. If you write all chains as `op_(arr, $(x) => ...)` with explicit lambdas, plain `daslib/linq` suffices but you lose ergonomics.
+
+## Questions
+- My _fold(each(arr)._where(...).last()) chain fails with error[50503] "expecting linq expression" and the chain interprets literally. What's wrong?

--- a/mouse-data/docs/when-a-daslang-bench-reports-0-ns-op-for-a-splice-that-should-be-doing-real-work-is-it-dce-how-do-i-verify.md
+++ b/mouse-data/docs/when-a-daslang-bench-reports-0-ns-op-for-a-splice-that-should-be-doing-real-work-is-it-dce-how-do-i-verify.md
@@ -1,0 +1,57 @@
+---
+slug: when-a-daslang-bench-reports-0-ns-op-for-a-splice-that-should-be-doing-real-work-is-it-dce-how-do-i-verify
+title: When a daslang bench reports 0 ns/op for a splice that should be doing real work, is it DCE? How do I verify?
+created: 2026-05-20
+last_verified: 2026-05-20
+links: []
+---
+
+**Not necessarily DCE — most likely the bench framework's reporting floor.** Verify with `mcp__daslang__ast_dump --mode source` before assuming the compiler optimized it away.
+
+The bench framework (`dastest/testing.das` `run(b, name, n, body)`) reports `body_time / n_iters` as ns/op. If the body is fast enough that the per-iteration share rounds below 1 ns, you'll see "0 ns/op" — even though the body is doing real, observable work.
+
+**Diagnosis:**
+
+```bash
+# Dump post-macro source for the bench file. Look for the lane's `def run_m4` (or m3f/etc) body.
+mcp__daslang__ast_dump --file benchmarks/sql/your_bench.das --mode source
+```
+
+If you see something like:
+```
+def run_m4(...) {
+    run(b, "m4_decs_fold/{n}", n, $():void {
+        let rows <- invoke($() : array<...> {
+            var decs_buf : array<...>
+            var decs_takec : int = 0
+            for_each_archetype_find(...) {
+                ...if (decs_takec >= 1000) return true
+                else { ++decs_takec; push_clone(decs_buf, ...) }
+            }
+            return <- decs_buf
+        })
+        accept(b, rows)
+        if (empty(rows)) failNow()
+    })
+}
+```
+
+…then the splice IS firing and IS building a real array. The 0 ns/op is the measurement floor, not optimization.
+
+**True DCE looks different in the dump:** the body would be missing entirely, or the `let rows` would be a constant, or `accept(b, ...)` would be called with a literal. If `accept(b, rows)` and `empty(rows)` both reference the computed result, the optimizer cannot DCE the whole chain — it might inline aggressively, but the work happens.
+
+**Don't claim DCE based on benches alone.** Always verify with `ast_dump --mode source` first. Source-dump is the ground truth for what gets emitted.
+
+**Cross-check against another lane:** if m3f (array-side splice) and m4 (decs-side splice) both round to 0 ns/op with the same chain shape, they're both at the floor — that's a strong signal the splices are equivalent fast paths, not that both got DCE'd. m1/m3 (eager) showing ns numbers > 0 with similar work confirms the floor is somewhere below the eager baseline.
+
+**Common false alarm: `b |> accept(value)` and `b->failNow()` are anti-DCE primitives** (see `dastest/testing.das` `[sideeffects] def accept(...)`). Their presence in the bench body usually rules out compiler DCE.
+
+**When to actually suspect DCE:**
+- The bench has NO `accept(...)` and NO `if (empty(...)) failNow()` — just `let rows <- chain`
+- ast_dump shows the lambda body has a missing return value or a literal
+- The bench file's plan.md / M4_DECS_EXPANSION.md flags this lane as a known DCE issue (e.g., 11 such benches were flagged in May 2026)
+
+Hit incident: PR #2770 (Slice 5a take/skip on decs) initially claimed "0 ns/op = DCE" in the PR body. ast_dump showed the splice was firing and pushing 1000 elements per iteration. Old eager bridge: 36 ns/op. New splice: rounded to 0. Real win ≈ 36×.
+
+## Questions
+- When a daslang bench reports 0 ns/op for a splice that should be doing real work, is it DCE? How do I verify?

--- a/mouse-data/docs/when-adding-a-decs-specific-splice-planner-e-g-plan-decs-group-by-to-the-linq-fold-cascade-where-does-it-go-relative-to-the-arra.md
+++ b/mouse-data/docs/when-adding-a-decs-specific-splice-planner-e-g-plan-decs-group-by-to-the-linq-fold-cascade-where-does-it-go-relative-to-the-arra.md
@@ -1,0 +1,71 @@
+---
+slug: when-adding-a-decs-specific-splice-planner-e-g-plan-decs-group-by-to-the-linq-fold-cascade-where-does-it-go-relative-to-the-arra
+title: When adding a decs-specific splice planner (e.g. plan_decs_group_by) to the linq_fold cascade, where does it go relative to the array-side planner of the same shape (e.g. plan_group_by)?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+**Pattern:** decs-specific planner MUST run BEFORE the array-side planner of the same shape. The decs planner has the stricter requirement (`extract_decs_bridge(top)` must succeed) so it won't grab non-decs chains; running it second causes the generic planner to match on the eager-bridge invoke and emit correct-but-slow code that wraps the FULL eager bridge — losing the entire perf win silently.
+
+### The trap
+
+```das
+res = plan_group_by(call.arguments[0])    // ← matches on eager-bridge iterator
+if (res != null) return res
+res = plan_decs_group_by(call.arguments[0])  // ← NEVER REACHED for decs chains
+```
+
+`plan_group_by` accepts any iterator/array source via `peel_each(top)` then iterates with `for (it in src) { ... }`. When `top` is the from_decs_template eager-bridge invoke (which returns `iterator<tuple<...>>` via `to_sequence(res)`), plan_group_by happily matches: it binds `srcName` to the eager-bridge invoke, emits the state-table walk around it, and `finalize_emission_stmts(top, srcName, ...)` wraps the whole thing. Tests pass (functional correctness preserved), BUT the eager bridge's `array<tuple>` materialization + `to_sequence` + iterator walk all still happen — that's the WHOLE thing Slice 5+ was designed to skip.
+
+### How to spot it
+
+`ast_dump --mode source` on a target function. If you see this shape:
+
+```
+return <- invoke($(var source : iterator<tuple<...>>) : ... {
+    var inscope tab : ...
+    for (it in source) { ... }              // ← array-side group_by loop
+}, invoke($() : iterator<tuple<...>> {       // ← eager bridge passed as source
+    var res : array<tuple<...>>
+    for_each_archetype(...) { for (...) { push(...) } }
+    return <- to_sequence(res)               // ← THE smoking gun
+}))
+```
+
+…then the decs planner never fired. The presence of `to_sequence` + `var res : array<tuple<...>>` + `to_sequence(res)` is the diagnostic — your splice's AST shape gate should assert `describe_count(body, "to_sequence") == 0` to catch this regression.
+
+The correct splice shape (decs planner fired) is a SINGLE invoke wrapping `var inscope tab + var dummy + for_each_archetype(req, erq, $(arch) { for (iters in get_ro) { tup_bind; key + uk + table_update } }) + table walk + return buf` — no nested invoke, no `to_sequence`, no `to_sequence_move`, no intermediate `var res`.
+
+### Why the array-side planner doesn't bail
+
+`extract_decs_bridge` only fires when `top` matches the specific eager-bridge shape (`invoke($() { var res; for_each_archetype(...); return <- to_sequence(res) })`). The array-side planner has no such guard — it just needs an iterator source, which the bridge invoke trivially provides. So unless the decs planner runs first, the array planner WILL win.
+
+### Cascade ordering rule
+
+For any "X on decs" splice in `daslib/linq_fold.das:LinqFold.visit`:
+
+```das
+res = plan_decs_<X>(call.arguments[0])    // ← decs first (strict guard)
+if (res != null) return res
+res = plan_<X>(call.arguments[0])         // ← array-side fallback
+if (res != null) return res
+```
+
+Same logic applies to future Slice 5c/5d/5f (reverse/distinct/order_by on decs) — each new decs splice MUST be inserted BEFORE its array-side equivalent in the cascade.
+
+### Regression guard pattern
+
+Every decs splice's AST shape gate should include:
+
+```das
+t |> equal(describe_count(body_expr, "to_sequence"), 0, "<op> splice must NOT fall to tier-2 to_sequence (cascade ordering)")
+t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype (no eager-bridge wrapping)")
+```
+
+The `to_sequence == 0` assertion catches both tier-2 cascade fall-through AND the cascade-ordering trap above (they leave the same fingerprint).
+
+Discovered 2026-05-20 implementing Slice 5e (plan_decs_group_by on PR #2773-to-be). Initial cascade placement after `plan_group_by` → all parity tests passed, AST shape gate caught the missing splice. Fix: swap the order, 6 line change. See [[macro-planner-named-marker-arms-leave-room-for-future-modes]] for the broader marker-arms strategy this complements.
+
+## Questions
+- When adding a decs-specific splice planner (e.g. plan_decs_group_by) to the linq_fold cascade, where does it go relative to the array-side planner of the same shape (e.g. plan_group_by)?

--- a/mouse-data/docs/when-two-linq-fold-splice-planners-e-g-plan-group-by-for-array-sources-plan-decs-group-by-for-the-decs-bridge-share-hundreds-of.md
+++ b/mouse-data/docs/when-two-linq-fold-splice-planners-e-g-plan-group-by-for-array-sources-plan-decs-group-by-for-the-decs-bridge-share-hundreds-of.md
@@ -1,0 +1,82 @@
+---
+slug: when-two-linq-fold-splice-planners-e-g-plan-group-by-for-array-sources-plan-decs-group-by-for-the-decs-bridge-share-hundreds-of
+title: When two linq_fold splice planners (e.g. plan_group_by for array sources + plan_decs_group_by for the decs bridge) share hundreds of LOC of state-table / dummy / reducer / having emit machinery, what's the right way to factor the shared core so adding a third source surface stays cheap?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+Extract the shared logic into `plan_X_core(calls, ..., adapter)` taking a small struct that encapsulates the **per-source differences**. The two surfaces (array `each(arr)` / decs `from_decs_template(type<T>)`) differ in only two things: how the per-element body is wrapped in a source loop, and how the final statement list is wrapped into the call site. Everything else (recognizing reducers, addr-compare miss detection, dummy assignment, having predicate rewrite, hidden-slot synthesis, output buffer build) is identical and belongs in `_core`.
+
+**Adapter shape (group_by example, PR #2775 commit `cb72db296`):**
+
+```das
+struct private GroupBySourceAdapter {
+    initialBindName : string         // name of the per-element tuple inside the inner loop
+    initialElemType : TypeDeclPtr    // type of that tuple (strip_const_ref'd)
+    namePrefix      : string         // gensym prefix: "grp" (array) vs "decs_grp" (decs)
+    isDecs          : bool           // branch flag
+
+    // array-source fields (populated when !isDecs)
+    arrayTop    : Expression?
+    arraySrcName : string
+
+    // decs-source fields (populated when isDecs)
+    decsBridge  : DecsBridgeShape?
+}
+```
+
+**Two dispatch helpers consume the adapter** — they're the ONLY places where source-shape leaks into `_core`:
+
+```das
+// 1) wrap body in a source iteration loop
+def adapter_emit_source_loop(adapter : GroupBySourceAdapter; body : ExpressionPtr; at : LineInfo) : ExpressionPtr {
+    if (adapter.isDecs) {
+        // for_each_archetype(req, erq, $(arch) { build_decs_inner_for(bridge, build_decs_tup_bind(...), body, at) })
+        ...
+    } else {
+        // for ($i(adapter.arraySrcName) in $e(adapter.arrayTop)) { body }
+        ...
+    }
+}
+
+// 2) wrap final stmt list as a value at the call site
+def adapter_finalize_emission(var adapter : GroupBySourceAdapter; stmts : ExpressionPtr; retType : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
+    if (adapter.isDecs) {
+        // qmacro(invoke($() : $t(retType) { ...stmts }))
+        ...
+    } else {
+        // finalize_emission_stmts(topClone, srcName, ...) — note: clone arrayTop FIRST
+        var topClone = clone_expression(adapter.arrayTop)
+        ...
+    }
+}
+```
+
+**Two specific gotchas the refactor surfaces:**
+
+1. **`finalize_emission_stmts` takes `Expression? -const`.** The adapter field `arrayTop` is read as const-ref from the struct, so you can't pass it directly — `error[10210]: argument expects mutable Expression?`. Wrap with `var topClone = clone_expression(adapter.arrayTop)` before the call. This clone is required anyway because `finalize_emission_stmts` consumes its `top` argument into the emitted tree.
+
+2. **`extract_decs_bridge` result must be assigned to `var bridge` (not `let bridge`).** The adapter's `decsBridge` field is non-const; `let bridge = extract_decs_bridge(...)` produces an `Expression? const` that the typer rejects when initializing the struct field. Plain `var bridge = extract_decs_bridge(...)` fixes it.
+
+**Why this factoring works:** the planner entry points (`plan_group_by`, `plan_decs_group_by`) become ~30 LOC each — recognize the chain shape, validate, build the adapter, hand off to `plan_group_by_core`. The shared core is ~310 LOC of reducer machinery. Adding a third source surface (e.g. SQL or some future iterator factory) is just: add fields to the adapter, add a branch in each of the two dispatch helpers, add the planner entry. The reducer / state-table machinery stays untouched.
+
+**Net diff in PR #2775 commit `cb72db296`:** 393 deletions, 161 insertions = -232 LOC across `daslib/linq_fold.das`. Two planners collapsed from ~300 LOC each to ~30 LOC each. Test suites (1280 linq AOT + 245 decs AOT) green; group_by bench numbers unchanged (refactor preserved the emit shape exactly).
+
+**When to extract — heuristic:** if two planners diverge only in source-loop wrap and final-emission wrap (the chain recognition, reducer logic, having handling, output build are byte-identical), and the duplicated body is >100 LOC, the adapter pattern wins. Below that the duplication is cheaper than the abstraction.
+
+## Questions
+
+- When two linq_fold splice planners (e.g. plan_group_by for array sources + plan_decs_group_by for the decs bridge) share hundreds of LOC of state-table / dummy / reducer / having emit machinery, what's the right way to factor the shared core so adding a third source surface stays cheap?
+- What's the GroupBySourceAdapter pattern in daslib/linq_fold.das and why does it exist?
+- How do I share the state-table / reducer emit machinery between plan_group_by and plan_decs_group_by without duplicating ~300 LOC?
+- Why does `finalize_emission_stmts(adapter.arrayTop, ...)` fail with "argument expects mutable Expression?" inside the adapter dispatch?
+
+## See also
+
+- [[when-adding-a-decs-specific-splice-planner-e-g-plan-decs-group-by-to-the-linq-fold-cascade-where-does-it-go-relative-to-the-arra]] — cascade ordering trap (companion concern when adding the second-source planner in the first place)
+- [[in-a-shared-linq-fold-splice-helper-that-runs-over-both-array-sources-each-arr-and-iterator-sources-from-decs-template-how-do-i]] — iterator vs array return-type dispatch lives inside `_core`
+- [[group-by-first-key-wins-single-hash-tab-dummy-addr-compare]] — the reducer emit shape the core preserves
+
+## Questions
+- When two linq_fold splice planners (e.g. plan_group_by for array sources + plan_decs_group_by for the decs bridge) share hundreds of LOC of state-table / dummy / reducer / having emit machinery, what's the right way to factor the shared core so adding a third source surface stays cheap?

--- a/mouse-data/docs/why-do-my-linq-fold-splice-tests-pass-when-the-chain-is-take-while-select-terminator-sum-any-first-to-array-does-the-splice-actu.md
+++ b/mouse-data/docs/why-do-my-linq-fold-splice-tests-pass-when-the-chain-is-take-while-select-terminator-sum-any-first-to-array-does-the-splice-actu.md
@@ -1,0 +1,48 @@
+---
+slug: why-do-my-linq-fold-splice-tests-pass-when-the-chain-is-take-while-select-terminator-sum-any-first-to-array-does-the-splice-actu
+title: Why do my linq_fold splice tests pass when the chain is take_while + _select + terminator (sum / any / first / to_array) — does the splice actually fire?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+**No — those tests fall through to the tier-2 eager bridge. The splice doesn't fire.**
+
+The canonical chain order is `where → skip → skip_while → take_while → take`. `select` may appear ANYWHERE in the prefix (before the first range op), but is **forbidden after any range op** because the predicate-driven ranges (`skip_while` / `take_while`) require seeing the source element / source tuple. Array side bails on `seenSelect` at [daslib/linq_fold.das:1615](daslib/linq_fold.das#L1615) and [:1623](daslib/linq_fold.das#L1623). Decs side bails inside `extract_decs_ranges` when the suffix walk hits a non-range op (returns `null` → `plan_decs_unroll` returns `null` → eager bridge takes over).
+
+**Why this trap bites:** A chain like `_take_while(_.val < 3)._select(_.val).sum()` looks like a natural splice candidate, and the test passes because the tier-2 eager bridge (`take_while_to_array → select → sum`) computes the same answer. But the splice planner returned `null`, so the new code path you added (e.g., explicit-state routing for `take_while + any/all/contains` in `emit_decs_early_exit`) gets ZERO coverage.
+
+**Always verify splice firing via `ast_dump --mode source`** — the splice emits `for_each_archetype(_find)` directly with predicates inline; tier-2 emits the user chain as eager `take_while_to_array` + `select` + terminator wrapped in `to_sequence`. Caught on PR #2772 by Copilot.
+
+**Rewrite recipes for take_while/skip_while tests that actually splice:**
+
+```das
+// any/all/contains: predicate over the SOURCE tuple (skip _select entirely)
+_take_while(_.val < 3)._any(_.val == 2)           // splices
+_take_while(_.val < 3)._all(_.val < 5)            // splices
+// contains: source-tuple equality is undefined; use any/all
+// (contains shares the same useExplicitState branch in emit_decs_early_exit)
+
+// first / to_array: return source tuples; test field access on the returned value
+_take_while(_.val < 3).first().val                // splice + extract scalar at call site
+_take_while(_.val < 3).to_array()                 // array<tuple>; test got[i].val
+
+// min_by / max_by: key extractor over source tuple (no _select needed)
+_take_while(_.val < 3)._min_by(_.val)             // splices (emit_decs_min_max_by)
+
+// sum / min / max / average: NO valid splice shape on decs.
+// _select-after-take_while bails (suffix), _select-before-take_while bails
+// (seenSelect). For now, drop these or document they hit the eager bridge.
+```
+
+**AST shape gate to lock the splice in:**
+```das
+t |> equal(describe_count(body_expr, "to_sequence"), 0, "splice fires, NOT tier-2")
+t |> equal(describe_count(body_expr, "for_each_archetype_find"), 1, "take_while-stop routes to _find")
+t |> equal(describe_count(body_expr, "decs_found"), 3, "explicit-state var + set + return")
+```
+
+See PR #2772 commit `e2228a5f4` for the full rewrite, and [[in-a-fold-splice-planner-how-do-i-extract-a-select-call-s-element-type-when-the-chain-is-wrapped-in-fold-and-cll-0-type-firsttyp]] for related splice-planner conventions.
+
+## Questions
+- Why do my linq_fold splice tests pass when the chain is take_while + _select + terminator (sum / any / first / to_array) — does the splice actually fire?


### PR DESCRIPTION
## Summary

Batches 14 blind-mouse cards that accumulated across the linq_fold decs-splice work (Slices 5a / 5b / 5e, plus the plan_zip work in PR #2741). 11 cards were authored in-session during those PRs; 3 more landed in this commit while wrapping PR #2775's Copilot review rounds.

Cards-only PR — no source changes, no tests, no docs (`mouse-data/docs/` is git-tracked corpus for the blind-mouse Q&A cache; pre-push lint skipped because no `.das` files changed).

### New (this PR, surfaced from PR #2775 Copilot rounds)

- `in-a-linq-fold-chain-recognizer-...-count-pred` — **Copilot review #2** fix. Both `count()` and `count(pred)` parse as the same `ExprCall` with `name == "count"`. The dispatch is by argument count: a chain recognizer that pops `count` as the splice terminator must check `length(arguments) == 1` first, or it silently miscompiles `count(pred)` by dropping the predicate. Same trap shape applies to first/last/any/all/single 2-arg overloads.
- `in-a-shared-linq-fold-splice-helper-...-array-iterator` — **Copilot review #1** fix. The decs bridge types as `iterator<T>` (because `from_decs_template` emits `to_sequence(res)` internally); adding `.to_array()` peels back to `array<T>`. A shared splice helper must capture `let exprIsIterator = expr._type.isIterator` and dispatch both the explicit `retType` annotation on the inner `invoke` wrapper AND the final-return shape via `buffer_return(bufName, isIterator)`. Without it, `error[30343]: iterator<T> = array<T>` fires at the call site.
- `when-two-linq-fold-splice-planners-...-shared-core` — **Copilot review #3** refactor. Pattern for sharing ~300 LOC between `plan_group_by` (array) and `plan_decs_group_by` (decs bridge) via `GroupBySourceAdapter` struct + `adapter_emit_source_loop` / `adapter_finalize_emission` dispatch helpers. Documents two gotchas: `finalize_emission_stmts` takes `Expression? -const` so the adapter field must be `clone_expression`'d first; `extract_decs_bridge` result must go to `var bridge` not `let bridge` for the adapter init to typecheck.

### Pre-staged (Slices 5a-5e + PR #2741, this session's earlier card adds)

- `call-macro-typeof-arg-struct-fields-annotations`
- `count-call-body-invoke-returns-0` — `count_call(body, "invoke")` only walks the body; AST tests that want to count an outer `ExprInvoke` wrapper need to include it explicitly
- `in-a-decs-splice-planner-plan-decs-unroll-...-range-vs-chain-wrap-order` — Slice 5a/5b: ranges wrap chain, not the reverse
- `in-a-fold-splice-planner-...-extract-select-element-type` — `cll._0._type.firstType` returns an unresolved `typedecl(result_selector(...))` formula inside `_fold(...)`; how to get the actual type
- `in-a-qmacro-template-...-i-name-multi-iterator-for` — `$i(name)` works in iter-var position of `for ($i(a), $i(b) in ...)`
- `in-linq-fold-...-extend-emit-accumulator-lane-multi-source` — PR #2741: how the single-source helper generalizes to multi-source for plan_zip
- `in-plan-zip-splice-...-tuple-element-peeled-lambda` — PR #2741: passing `(itA, itB)` into a peeled lambda without `can't locate variable 't'`
- `my-fold-each-arr-where-last-chain-...-50503` — chain interprets literally when `last()` falls outside tier-1 splice recognition
- `when-a-daslang-bench-reports-0-ns-op-...-DCE` — how to verify a splice-bench is doing real work vs being DCE'd
- `when-adding-a-decs-specific-splice-planner-...-cascade-ordering` — **cascade ordering trap** (decs-specific planner must come BEFORE array-side equivalent; bridge match is stricter)
- `why-do-my-linq-fold-splice-tests-pass-...-take_while-select-terminator` — AST-shape gate pattern for distinguishing tier-1 splice from tier-2 cascade

## Test plan

- [ ] N/A — corpus-only PR; no compile/lint/test gates fire on `mouse-data/docs/*.md` and pre-push confirmed (`no .das files changed; skipping lint`).
- [x] Each card respects mouse-add discipline: title is the question form, body opens with the verdict, citations to PR commits, `## Questions` paraphrase block, `## See also` cross-links.
- [x] Dupe-on-add gate (Jaccard >= 0.7) passed on all 3 new adds (highest sim 0.19).
- [x] 5 false-positive `mouse__ask` results from this session marked `mouse__bad` (ids 144-148) so next session's retrieval ranks the new cards over the BM25-noise hits they're replacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
