### PR TITLE
dasSQLITE: stop migrate_93 leaking a disk artifact + fix 7 latent PERF020s

### DIFF
--- a/doc/source/reference/language/generic_programming.rst
+++ b/doc/source/reference/language/generic_programming.rst
@@ -92,6 +92,8 @@ All ``typeinfo`` traits can operate on either an expression or a ``type<T>`` arg
 * ``typeinfo is_numeric(expr)`` — true if numeric type
 * ``typeinfo is_int(expr)`` — true if exactly ``int`` (32-bit signed, non-array)
 * ``typeinfo is_int64(expr)`` — true if exactly ``int64`` (64-bit signed, non-array)
+* ``typeinfo is_float(expr)`` — true if exactly ``float`` (32-bit, non-array)
+* ``typeinfo is_double(expr)`` — true if exactly ``double`` (64-bit, non-array)
 * ``typeinfo is_numeric_comparable(expr)`` — true if numeric-comparable
 * ``typeinfo is_vector(expr)`` — true if vector type (``float2``/``int3``/etc.)
 * ``typeinfo is_any_vector(expr)`` — true if handled vector-template type

--- a/modules/dasSQLITE/daslib/sqlite_migrate.das
+++ b/modules/dasSQLITE/daslib/sqlite_migrate.das
@@ -243,7 +243,7 @@ def private _migrate_inner(db : SqlRunner) : Result<int, string> {
             commit_err = cerr |> unwrap
         }
     } recover {
-        let underlying = string(this_context().last_exception) |> rtrim
+        let underlying = this_context().last_exception |> rtrim
         let rolled_back_str = _format_versions_csv(pending, applied_count)
         to_log(LOG_ERROR, "migration v{failed_version} '{failed_desc}' FAILED — rolled back call\n  underlying error: {underlying}\n  rolled back: {rolled_back_str}\n")
         db |> try_exec("ROLLBACK") |> _log_warn_on_some
@@ -405,7 +405,7 @@ def try_baseline(db : SqlRunner; version : int) : Result<int, string> {
             commit_err = cerr |> unwrap
         }
     } recover {
-        let underlying = string(this_context().last_exception) |> rtrim
+        let underlying = this_context().last_exception |> rtrim
         db |> try_exec("ROLLBACK") |> _log_warn_on_some
         inner_err = "baseline(version={version}) failed: {underlying}"
     }
@@ -586,19 +586,36 @@ def struct_convert_field(var dst : Option<auto(SCF_T)>&; src : Option<auto(SCF_S
     }
 }
 
-// Target-typed conversion via the type's constructor. ``int(string)``, ``int(double)``, etc. dispatch
-// through daslang's existing primitive constructors. Identity above wins for same-source-target.
+// Target-typed conversion via primitive constructors (``int(string)``, ``int(double)``, etc.).
+// Auto identity above doesn't win in [struct_convert] instances (concrete `T&` beats `auto(SCF_T)&`);
+// each numeric overload short-circuits via static_if when SCF_S already matches the target.
 def struct_convert_field(var dst : int&; src : auto(SCF_S)) : void {
-    dst = int(src)
+    static_if (typeinfo is_int(src)) {
+        dst = src
+    } else {
+        dst = int(src)
+    }
 }
 def struct_convert_field(var dst : int64&; src : auto(SCF_S)) : void {
-    dst = int64(src)
+    static_if (typeinfo is_int64(src)) {
+        dst = src
+    } else {
+        dst = int64(src)
+    }
 }
 def struct_convert_field(var dst : float&; src : auto(SCF_S)) : void {
-    dst = float(src)
+    static_if (typeinfo is_float(src)) {
+        dst = src
+    } else {
+        dst = float(src)
+    }
 }
 def struct_convert_field(var dst : double&; src : auto(SCF_S)) : void {
-    dst = double(src)
+    static_if (typeinfo is_double(src)) {
+        dst = src
+    } else {
+        dst = double(src)
+    }
 }
 def struct_convert_field(var dst : string&; src : auto(SCF_S)) : void {
     dst = "{src}"
@@ -749,7 +766,7 @@ class SqlStructConvertMacro : AstFunctionAnnotation {
             if (key_exists(overrides, tname)) continue
             // Honor @sql_renamed_from on T's field — read from old's <OldName> instead of <tname>.
             let renamed_arg = find_arg(t_field.annotation, "sql_renamed_from")
-            let renamed_from = renamed_arg is tString ? string(renamed_arg as tString) : ""
+            let renamed_from = renamed_arg is tString ? (renamed_arg as tString) : ""
             let lookup_name = empty(renamed_from) ? tname : renamed_from
             let t_type = t_field._type
             let t_is_option = is_option_field_type(t_type)

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2279,6 +2279,12 @@ namespace das {
             } else if (expr->trait == "is_int64") {
                 reportAstChanged();
                 return new ExprConstBool(expr->at, expr->typeexpr->baseType == Type::tInt64 && expr->typeexpr->dim.size() == 0);
+            } else if (expr->trait == "is_float") {
+                reportAstChanged();
+                return new ExprConstBool(expr->at, expr->typeexpr->baseType == Type::tFloat && expr->typeexpr->dim.size() == 0);
+            } else if (expr->trait == "is_double") {
+                reportAstChanged();
+                return new ExprConstBool(expr->at, expr->typeexpr->baseType == Type::tDouble && expr->typeexpr->dim.size() == 0);
             } else if (expr->trait == "is_numeric_comparable") {
                 reportAstChanged();
                 return new ExprConstBool(expr->at, expr->typeexpr->isNumericComparable());

--- a/tests/dasSQLITE/migrate_93_rebuild_attached_schema.das
+++ b/tests/dasSQLITE/migrate_93_rebuild_attached_schema.das
@@ -28,7 +28,7 @@ def convert_v1_to_v2(old : UserV1; var dst : User) {
 [test]
 def test_rebuild_runs_in_attached_schema(t : T?) {
     var inscope main = open_sqlite(":memory:")
-    main |> with_attached("file:rebuild_attached_test?mode=memory&cache=shared", "att") $(att) {
+    main |> with_attached(":memory:", "att") $(att) {
         att |> exec("DROP TABLE IF EXISTS \"users\"")
         att |> exec("DROP TABLE IF EXISTS \"users_new\"")
         att |> exec("CREATE TABLE \"users\" (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, LegacyEmail TEXT NOT NULL DEFAULT '')")

--- a/tests/long_array_table/test_int_int64_disjunction.das
+++ b/tests/long_array_table/test_int_int64_disjunction.das
@@ -42,3 +42,16 @@ def test_typeinfo_is_int_traits(t : T?) {
     static_assert(!typeinfo is_int64(type<uint>), "is_int64(uint) must be false")
     t |> equal(0, 0)
 }
+
+// Symmetric is_float / is_double — added alongside is_int / is_int64 for
+// numeric struct_convert dispatch (sqlite_migrate `struct_convert_field`).
+[test]
+def test_typeinfo_is_float_double_traits(t : T?) {
+    static_assert(typeinfo is_float(type<float>), "is_float(float) must be true")
+    static_assert(!typeinfo is_float(type<double>), "is_float(double) must be false")
+    static_assert(!typeinfo is_float(type<int>), "is_float(int) must be false")
+    static_assert(typeinfo is_double(type<double>), "is_double(double) must be true")
+    static_assert(!typeinfo is_double(type<float>), "is_double(float) must be false")
+    static_assert(!typeinfo is_double(type<int>), "is_double(int) must be false")
+    t |> equal(0, 0)
+}


### PR DESCRIPTION
## Summary

Two related commits surfaced by tracking down a recurring untracked file `file:rebuild_attached_test?mode=memory&cache=shared` that keeps reappearing in the daScript working tree after running the test suite.

### Commit 1 — test cleanup ([1475667e9](https://github.com/GaijinEntertainment/daScript/commit/1475667e9))

`tests/dasSQLITE/migrate_93_rebuild_attached_schema.das` passed `"file:rebuild_attached_test?mode=memory&cache=shared"` to `with_attached`, intending an in-memory shared SQLite database via URI form. But:

- `try_open_sqlite` opens with legacy `sqlite3_open()` — no `SQLITE_OPEN_URI` flag
- `try_attach` does `ATTACH DATABASE ? AS att` with the path bound as a parameter

Without URI mode on the parent connection, SQLite treats the URI-form string as a literal filename and silently creates a real file on disk with that name in the test CWD. Nothing ever deletes it.

Fix: use `":memory:"` as the attach path. SQLite supports `:memory:` as an attach filename — each ATTACH gets a private temporary in-memory database for that schema, with the semantics this test actually needs (the "shared cache" angle was never meaningful here — only one connection ever touches the attached DB). No URI form, no file on disk, no cleanup hook required.

### Commit 2 — fix 7 latent PERF020 in sqlite_migrate ([743306437](https://github.com/GaijinEntertainment/daScript/commit/743306437))

Pre-push lint surfaced 7 honest PERF020 diagnoses while landing commit 1. None had fired on master because the file wasn't recently touched.

**(1) `struct_convert_field` numeric dispatch (lines 591-612).** The auto identity overload at line 560 is supposed to win for same-source-target, but in `[struct_convert]`-generated instances concrete `T&` beats `auto(SCF_T)&`, so each numeric target instances the converting overload and emits `dst = int(src)` even when SCF_S is already int. Fix: short-circuit via `static_if (typeinfo is_T(src)) { dst = src }` — daslang folds the branch at compile time, identity instances emit a plain assign, converting instances emit the cast.

**(2) `string(this_context().last_exception)` at lines 246 / 408.** `Context::last_exception` is `const char *` in C++, but `DAS_BIND_MANAGED_FIELD` already exposes it as daslang `string` (PERF020 confirmed `baseType == tString`). The `string(...)` wrapper was pure noise.

**(3) `string(renamed_arg as tString)` at line 766.** Variant arm `tString:string`, so `as tString` already returns `string`. Drop the wrapper.

## Test plan

- [x] `migrate_93_rebuild_attached_schema` — passes; no stray file recreated
- [x] `migrate_22_failure_rolls_back` — exercises the `last_exception` rollback log path (3 tests green, error message renders correctly: `underlying error: exec failed: near "THIS": syntax error`)
- [x] `migrate_81_struct_convert_option_flip` — exercises `struct_convert_field` Option-flip dispatch (1 test green)
- [x] `migrate_91_full_rebuild_end_to_end` — exercises `convert_and_rename` calling `struct_convert_field` across multiple fields (3 tests green)
- [x] MCP lint clean on both touched files; format unchanged
- [x] Pre-push lint clean (2 files, 0 issues)
- [ ] CI: full dasSQLITE suite + linux/darwin/windows builds + AOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)
