### PR TITLE
phase 8 doc sweep: STYLE024-26 cascade + 5-tier indexing + pre-push hook + 4 mouse cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,11 +178,12 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 
 ### Unsafe
 
-- **`unsafe(expr)`** — narrow-scope unsafe, preferred over `unsafe { block }`. Limits unsafe to the exact expression that needs it
+- **`unsafe(expr)`** — narrow-scope unsafe, preferred over `unsafe { block }`. Limits unsafe to the exact expression that needs it. Lint backs this: STYLE024 flags `unsafe` wraps with no descendant needing unsafe; STYLE025 flags blocks where exactly one statement needs unsafe (narrow to expression form); STYLE026 flags nested `unsafe { ... }`
 - **Local reference binding is unsafe:** `let blk & = expr` requires `unsafe` whenever it creates a local reference to a non-local expression — `let blk & = unsafe(expr)`
 - **Variant `as` read access is safe:** `(v as _field).member` works without `unsafe` after an `is` check
 - **Variant field assignment is always unsafe:** `v._field = value` and `set_variant_index(v, N)` require `unsafe`
 - **`reinterpret<T>(expr)`** requires `unsafe` — used for const-stripping on regular pointers: `unsafe(reinterpret<Foo?>(const_ptr))`
+- **`typeinfo is_unsafe_when_uninitialized(type<T>)`** — the trait that gates unsafe-ness per type in generic code. Pairs with field-level `@safe_when_uninitialized` and struct-level `[safe_when_uninitialized]` annotations. Canonical use in `daslib/builtin.das`: declare `var x : TT` inside `static_if (typeinfo is_unsafe_when_uninitialized(type<TT>)) { unsafe { ... } } else { ... }` — the unsafe block needs `// nolint:STYLE025` on the `unsafe {` line because STYLE025 sees only one statement needing unsafe at any instantiation and can't reason across the static_if branches
 
 ### Error handling
 
@@ -298,6 +299,7 @@ Most layout is obvious from `ls`. Non-obvious ones worth knowing:
 - `utils/detect-dupe/` (in-repo dupe finder) and `utils/find-dupe/` (Claude-based judge that needs `daspkg install --root utils/find-dupe` + `ANTHROPIC_API_KEY`) — both also exposed as MCP tools
 - `utils/mcp/`, `utils/daslang-live/`, `utils/daspkg/` — in-tree tools (most also have skills under `skills/`)
 - `tutorials/language/` (language tour) vs `tutorials/<area>/` (per-area) — never put tutorials in `modules/<X>/tutorial/`
+- **Array/dim/vector indexing lives across 5 tiers** — bug fixes (bounds checks, neg-index detection, width-aware bounds) usually need parallel edits in all of them: AOT C++ ([include/daScript/simulate/aot.h](include/daScript/simulate/aot.h)), interpreter non-fused ([include/daScript/simulate/runtime_array.h](include/daScript/simulate/runtime_array.h) + [include/daScript/simulate/simulate_nodes.h](include/daScript/simulate/simulate_nodes.h)), interpreter fused ([src/simulate/simulate_fusion_at_array.cpp](src/simulate/simulate_fusion_at_array.cpp) + [src/simulate/simulate_fusion_at.cpp](src/simulate/simulate_fusion_at.cpp)), JIT ([modules/dasLLVM/daslib/llvm_jit.das](modules/dasLLVM/daslib/llvm_jit.das)), and AST const-fold ([src/ast/ast_simulate.cpp](src/ast/ast_simulate.cpp)). Debug builds bypass the fused permutations — a fix that lands only in the fused path passes Release CI and trips Debug-ARM. Bump `LLVM_JIT_CODEGEN_VERSION` in `modules/dasLLVM/daslib/llvm_macro.das` after JIT changes to invalidate cached `.dll`s
 
 ## MCP Server (AI Tool Integration)
 

--- a/mouse-data/docs/jit-check-range-sext-vs-zext-signed-index-widening.md
+++ b/mouse-data/docs/jit-check-range-sext-vs-zext-signed-index-widening.md
@@ -1,0 +1,78 @@
+---
+slug: jit-check-range-sext-vs-zext-signed-index-widening
+title: In daslang's LLVM JIT, when do I need LLVMBuildSExt vs LLVMBuildZExt for widening an i32 index to i64 before an unsigned bounds compare?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+The JIT codegen widens index expressions to match the size operand's width before emitting `ICmp UGE` (unsigned greater-or-equal) for the bounds check. The choice between **SExt** (sign-extend) and **ZExt** (zero-extend) is determined by the daslang **index type's signedness**, not by anything LLVM can infer from the IR.
+
+## The trap
+
+Naive code uses ZExt for both:
+
+```das
+def normalize_int_widths(lhs : LLVMOpaqueValue?; rhs : LLVMOpaqueValue?) {
+    ...
+    return (LLVMBuildZExt(g_builder, lhs, LLVMTypeOf(rhs), ""), rhs) if (wl < wr)
+    ...
+}
+```
+
+For a signed `int idx = -2` JIT'd into i32, ZExt to i64 = `0x00000000FFFFFFFE` = `4294967294`. Then `ICmp UGE 4294967294, 5_000_000_000` is `false` — bounds check passes silently → corruption identical to the C++ tier (see [[uint32-cast-negative-int-wrap-bounds-check-bug-pattern]]).
+
+## The fix
+
+For **signed** index types (`tInt`, `tInt64`), widen with `LLVMBuildSExt`. Then `int32(-2)` becomes `0xFFFFFFFFFFFFFFFE` (sign-extended), and the unsigned compare against any reasonable size correctly catches it. For **unsigned** types (`tUInt`, `tUInt64`), keep `ZExt` — sign-extending a `uint32(0x80000000)` would incorrectly reject the legitimate large positive index.
+
+```das
+def check_range(tidx, maxIdx : LLVMOpaqueValue?; at : LineInfo; message : string;
+                idxIsSigned : bool = true) {
+    if (option_no_range_check) return
+    let wl = LLVMGetIntTypeWidth(LLVMTypeOf(tidx))
+    let wr = LLVMGetIntTypeWidth(LLVMTypeOf(maxIdx))
+    var ntidx = tidx
+    var nmax = maxIdx
+    if (wl < wr) {
+        if (idxIsSigned) {
+            ntidx = LLVMBuildSExt(g_builder, tidx, LLVMTypeOf(maxIdx), "")
+        } else {
+            ntidx = LLVMBuildZExt(g_builder, tidx, LLVMTypeOf(maxIdx), "")
+        }
+    } elif (wr < wl) {
+        nmax = LLVMBuildZExt(g_builder, maxIdx, LLVMTypeOf(tidx), "")  // size is always unsigned
+    }
+    ...
+    var cond = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntUGE, ntidx, nmax, "range_check")
+    ...
+}
+```
+
+## Pulling signedness from the daslang AST
+
+LLVMOpaqueValue carries no signedness info — the IR layer is signedness-agnostic. Read it from `expr.index._type.baseType` at the callsite:
+
+```das
+def is_signed_index_type(t : TypeDeclPtr) : bool {
+    return t != null && (t.baseType == Type.tInt || t.baseType == Type.tInt64)
+}
+
+// in visitExprAt(expr : ExprAt?):
+check_range(tidx, size, expr.at, "array index out of range",
+            is_signed_index_type(expr.index._type))
+```
+
+Three callsites in `llvm_jit.das`'s `visitExprAt`: dim (line ~1829), array (~1841), vector (~1872). All three need the same signedness arg.
+
+## Bump LLVM_JIT_CODEGEN_VERSION when you change this
+
+JIT artifacts are cached as content-addressed DLLs in `.jitted_scripts/<ns>/<hash>.dll`. The codegen-version constant in `modules/dasLLVM/daslib/llvm_macro.das` is folded into the hash. Any change to `check_range` shape — including the SExt fix — must bump `LLVM_JIT_CODEGEN_VERSION` (currently 0x04 post-#2776) so previously-cached DLLs miss and get GC'd.
+
+## Related
+
+- The C++ tiers carry the same neg-index bug — see [[where-array-indexing-lives-five-tier-map]] for the full sweep.
+- Why ZExt works for unsigned: a `uint32(0x80000000)` (~2.1G) is a legitimate index into a >2.1G-element array; sign-extending it would corrupt the legitimate positive value into a negative-looking i64.
+
+## Questions
+- In daslang's LLVM JIT, when do I need LLVMBuildSExt vs LLVMBuildZExt for widening an i32 index to i64 before an unsigned bounds compare?

--- a/mouse-data/docs/temp-array-generic-dispatch-is-array-vs-fixed-array-dim.md
+++ b/mouse-data/docs/temp-array-generic-dispatch-is-array-vs-fixed-array-dim.md
@@ -1,0 +1,53 @@
+---
+slug: temp-array-generic-dispatch-is-array-vs-fixed-array-dim
+title: How do I write a generic `temp_array` / `array_helper`-style helper that accepts both `array<T>` and fixed-size `T[N]`?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+A generic daslang helper like `temp_array(arr)` may be called with either a runtime `array<T>` (e.g. `var arr : array<int>`) or a fixed-size dim (e.g. `int[5]` inside `algorithm.reverse(a : int[5])`). The two need different length and builder primitives — `_::long_length` and `_builtin_make_temp_array_i64` only accept `array<T>` / `table<K;V>`, not dims.
+
+The dispatch is `static_if (typeinfo is_array(arr))`:
+
+```das
+[unsafe_operation, template(a), unused_argument(a)]
+def private array_helper(var arr : auto implicit ==const; a : auto(TT)) : array<TT -const -#> {
+    var res : array<TT -const -#>
+    static_if (typeinfo is_array(arr)) {
+        // array<T> path: long_length + i64 builder for huge-array safety
+        let lenA = _::long_length(arr)
+        if (lenA >= 1_l) {
+            unsafe { _builtin_make_temp_array_i64(res, addr(arr[0]), lenA) }
+        }
+    } else {
+        // fixed-array path: length is compile-time-bounded, use int builder
+        let lenA = _::length(arr)
+        if (lenA >= 1) {
+            unsafe { _builtin_make_temp_array(res, addr(arr[0]), lenA) }
+        }
+    }
+    return <- res
+}
+```
+
+## Why two paths
+
+- `_::long_length(arr)` is defined for `array const` and `table const` only. Calling it on `int[5]` fails compilation with `error[30341]: no matching functions or generics`. Surfaces as a tutorial dry-run failure on darwin extended_checks when something through `algorithm.reverse(int[5])` reaches the helper.
+- `_builtin_make_temp_array_i64` expects an `int64_t` length. Passing `int` from a fixed-array would also need conversion. The simpler split keeps both builders honest with their natural arg types.
+- Fixed-array sizes are compile-time bounded (typically <100 elements) — there's no realistic concern about exceeding INT_MAX. The `int` builder is fine for them.
+
+## Other typeinfo predicates that distinguish these
+
+- `typeinfo is_array(x)` — true for `array<T>` runtime arrays only.
+- `typeinfo is_dim(x)` — true for fixed-size `T[N]` (caveat: some daslang versions return this for both `T[N]` and `array<T>` in certain phases; `is_array` is the safer discriminator).
+- `typeinfo is_table(x)` — true for `table<K;V>`.
+
+When you want to dispatch between "is this something `length()` accepts" vs "is this something `long_length()` accepts", `is_array(x) || is_table(x)` is the predicate for the `long_*` family.
+
+## Bit me in PR-G (#2773)
+
+PR-G consolidated `array_helper` to use `long_length + _i64` builder unconditionally — that broke `algorithm.reverse(int[5])` because fixed-arrays don't satisfy the `long_length` overload set. Caught only by `extended_checks (darwin15, arm64)` running the language tutorials in dry-run. Fix landed in #2773 round 2: the static_if dispatch above.
+
+## Questions
+- How do I write a generic `temp_array` / `array_helper`-style helper that accepts both `array<T>` and fixed-size `T[N]`?

--- a/mouse-data/docs/uint32-cast-negative-int-wrap-bounds-check-bug-pattern.md
+++ b/mouse-data/docs/uint32-cast-negative-int-wrap-bounds-check-bug-pattern.md
@@ -1,0 +1,82 @@
+---
+slug: uint32-cast-negative-int-wrap-bounds-check-bug-pattern
+title: What's the uint32_t(neg_int) wrap bug pattern in daslang's bounds checks, and what does the fix look like?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+Anywhere daslang does `uint32_t idx = uint32_t(index); if (idx >= size) ...` for a signed int32 index, there are **two** latent bugs:
+
+## Corruption when size > UINT32_MAX
+
+For arrays/tables whose `size` field is `uint64_t` (post-PR-A: `Array`, `Table`):
+
+```cpp
+int32_t index = -2;
+uint32_t idx = uint32_t(-2);   // = 0xFFFFFFFE = 4294967294
+if (idx >= size)               // 4294967294 >= 5'000'000'000 -> FALSE
+    throw_error(...);          // doesn't fire
+return data[index];            // data[-2] — silent OOB read/write
+```
+
+The bounds check passes silently, the code uses the *signed* `index` for pointer arithmetic, and you get an off-by-N-before-start access into adjacent heap. Reproduces only when the array actually exceeds 4 GB elements (so the bug needs `DASLANG_HUGE_HEAP_TESTS=1` + `options persistent_heap = true` to surface in tests).
+
+## Diagnostic-only for size < UINT32_MAX
+
+For all the smaller collections (`TDim`, vector, matrix, std::vector binding):
+
+```cpp
+uint32_t idx = uint32_t(-2);   // = 4294967294
+if (idx >= size)               // 4294967294 >= 10 -> TRUE
+    throw_error("index out of range, %u of %u", idx, size);
+//                                   ^^^^^^^^^^^^^^^ prints 4294967294 instead of -2
+```
+
+Bounds check fires correctly (no corruption), but the error message shows the unsigned wrap value instead of the original `-2`. Every developer who passes a negative index thinks the runtime is confused.
+
+## Fix shape (both bugs, same edit)
+
+```cpp
+if ( index < 0 || uint*_t(index) >= size )
+    throw_error("... %d of %llu", index, (unsigned long long)size);
+```
+
+- Detect `<0` explicitly **before** the unsigned cast.
+- Cast width: `uint64_t(index)` if `size` is uint64_t (TArray); `uint32_t(index)` if `size` is uint32_t (dim/vector/matrix).
+- Format: `%d` for signed int slot, `%lld` for int64, `%u` / `%llu` for unsigned size — **never** mix `%u` against an `int` template parameter (variadic UB, will trip `-Wformat` on stricter builds).
+
+## Where it lives
+
+Five tiers in daslang, all carry copies of this pattern — see [[where-array-indexing-lives-five-tier-map]]. The grep that surfaces them all is the format string itself: `"index out of range"` across `include/daScript/simulate/`, `src/simulate/`, `src/ast/`, `modules/dasLLVM/`. Don't fix one and stop — every copy is a separate code path that some test mode (Debug, ARM, sanitizer, JIT) will reach.
+
+For the JIT version, the same bug appears as `LLVMBuildZExt` widening i32→i64; signed indices need `LLVMBuildSExt` instead — see [[jit-check-range-sext-vs-zext-signed-index-widening]].
+
+## Test pattern
+
+Two SUBCASE shapes from `tests-cpp/small/test_aot_int_narrowing.cpp`:
+
+**Corruption test** — no real allocation needed:
+```cpp
+TArray<uint8_t> arr;
+uint8_t fake_buf[32] = {};
+arr.data = (char*)(fake_buf + 16);     // mid-stride so neg index doesn't underflow page
+arr.size = 5'000'000'000ULL;            // > UINT32_MAX
+auto * p = TArray<uint8_t>::safe_index(&arr, -2, nullptr);
+CHECK(p == nullptr);  // master: returns non-null (bug); fix: nullptr
+```
+
+**Diagnostic test** — small array, real `Context`:
+```cpp
+Context ctx(1024);
+TArray<int32_t> arr;
+int32_t buf[10] = {};
+arr.data = (char*)buf; arr.size = 10; arr.capacity = 10;
+bool ok = ctx.runWithCatch([&](){ (void)arr(int32_t(-2), &ctx); });
+CHECK_FALSE(ok);
+CHECK(strstr(ctx.getException(), "-2") != nullptr);
+CHECK(strstr(ctx.getException(), "4294967294") == nullptr);
+```
+
+## Questions
+- What's the uint32_t(neg_int) wrap bug pattern in daslang's bounds checks, and what does the fix look like?

--- a/mouse-data/docs/where-array-indexing-lives-five-tier-map.md
+++ b/mouse-data/docs/where-array-indexing-lives-five-tier-map.md
@@ -1,0 +1,43 @@
+---
+slug: where-array-indexing-lives-five-tier-map
+title: Where in daslang's source does array indexing actually happen — when I touch one I need to touch them all?
+created: 2026-05-21
+last_verified: 2026-05-21
+links: []
+---
+
+Daslang has **five independent copies** of array-indexing logic, one per execution / build tier. Any semantic change to bounds-checking, index-width handling, or diagnostics must sweep all five, or the bug fix will fail on whichever tier the test mode lands in.
+
+## The five tiers
+
+| Tier | File | Symbol | Notes |
+|---|---|---|---|
+| AOT C++ emission | `include/daScript/simulate/aot.h` | `TArray<TT>::operator()`, `safe_index`; `TDim::operator()`; `das_default_vector_index`, `das_ati`/`das_atci`, `das_vec_index`, `das_index<Matrix>` | What `[unused]` AOT-compiled C++ runs. `size` is `uint64_t` for `TArray` — real corruption window for >4GB arrays. Others have `uint32_t` size — diagnostic-only. |
+| Interpreter — non-fused | `include/daScript/simulate/runtime_array.h:14` (`SimNode_ArrayAt::compute`), `simulate_nodes.h:835` (`SimNode_At` for dim), 852 (`SafeAt`), 868 (`AtR2V`), 961 (vector index macro) | The fallback path. Hit by Debug builds and many ARM permutations that don't enable all the fusion templates. | 
+| Interpreter — fused | `src/simulate/simulate_fusion_at_array.cpp` (6 macro instantiations for `Op2ArrayAt`), `src/simulate/simulate_fusion_at.cpp` (6 for `Op2At` dim/vec) | What Release x64 typically picks for `var x = arr[i]`. Separate copy of the bounds check inside each macro definition. |
+| JIT | `modules/dasLLVM/daslib/llvm_jit.das` — `check_range` (the shared bounds-check IR-emitter), called from `visitExprAt` at three sites (dim/array/vector) | LLVM-emitted IR. `normalize_int_widths` controls i32→i64 widening; SExt vs ZExt choice depends on whether the daslang index type is signed. |
+| AST compile-time const-fold | `src/ast/ast_simulate.cpp:~1915` (inside `ExprAt`'s simulation case) | For `arr[<const>]` daslang folds the bounds check at compile time and reports `error[50300]: index out of range`. Read the const at its natural width (`tInt` → int32, `tInt64` → int64, `tUInt` → uint32, `tUInt64` → uint64); don't narrow. |
+
+## How a typical pattern bug surfaces
+
+The `uint32_t(neg_int)` wrap bug surfaced in PR-I (#2776) in **every one** of these tiers — same shape (`uint32_t idx = uint32_t(index); if (idx >= size) ...`), copy-pasted. The fix landed sequentially over three CI rounds:
+
+1. Round 1 fixed aot.h, passed Release x64 + Linux.
+2. Round 2 added fusion files + JIT + const-fold; passed Release ARM.
+3. Round 3 caught Debug ARM, which dropped through the fused path into the **base** `SimNode_At` in `simulate_nodes.h` — yet another copy I'd missed.
+
+Lesson: when you find one of these, grep for the format string (e.g. `"array index out of range"`, `"index out of range"`, `"vector index out of range"`) across `include/daScript/simulate/`, `src/simulate/`, `src/ast/`, `modules/dasLLVM/` to find ALL the copies. Don't trust that Release x64 passing means the fix is complete — Debug + ARM use different SimNode permutations.
+
+## Why so many copies?
+
+Each tier has different costs the inner-loop can't pay:
+- AOT: per-template specialization, inlined into user C++ — the format strings literally get inlined into every call site.
+- Interp non-fused: a generic `SimNode` virtual dispatch — runtime polymorphism, can't share code with the typed AOT path.
+- Interp fused: peephole-fused `op2 = arr[idx]` patterns where the bounds check is inlined into the assignment node directly, removing one indirection.
+- JIT: emits LLVM IR directly — has access to LLVM intrinsics (e.g. `ICmp UGE`) that the C++ versions can't use.
+- AST const-fold: runs at compile time, has no Context, no runtime — different return contract (error to `program->error`, not `throw_error_at`).
+
+Consolidation would mean a perf regression in at least one tier. The duplication is load-bearing.
+
+## Questions
+- Where in daslang's source does array indexing actually happen — when I touch one I need to touch them all?

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -21,6 +21,8 @@ If a rebase produces conflicts on files that were independently changed on origi
 
 ## 1. Lint all changed `.das` files — **zero warnings required**
 
+**Pre-push hook:** the repo ships `.githooks/pre-push` (formatter `--verify` on the whole tree + lint on changed `.das` files — same gates as CI's `extended_checks`). One-time enable per clone: `git config core.hooksPath .githooks`. After that, every `git push` runs lint+format before pushing — the manual command below is for debugging hook output or running ahead of `git push`. `git push --no-verify` skips it; reserve that for emergencies (CI catches the same issues ~25 minutes later, but the round-trip is the cost the hook exists to avoid). See [.githooks/README.md](../.githooks/README.md).
+
 CI's `extended_checks` job runs the same lint utility on every `.das` file changed vs `origin/master` and **exits non-zero on any warning** (`./bin/daslang ./utils/lint/main.das -- <files> --quiet` → exit code 2 on ≥1 warning). One STYLE/LINT/PERF warning anywhere in your diff fails CI. Local lint must be clean before push — there is no "minor warning, will ignore" tier here.
 
 Lint only the files changed relative to `origin/master` (matches what CI lints):


### PR DESCRIPTION
## Summary

Docs-only PR consolidating breadcrumbs from PR-G (#2773) / PR-I (#2776) / PR-H (#2779). No code changes — the 4 mouse cards capture the cross-cutting lessons that already showed up across the round-trip review cycles, and the CLAUDE.md / make_pr.md edits make those lessons discoverable to the next session.

## Changes

**`CLAUDE.md`** — `### Unsafe` section:
- Note that lint backs the minimize-`unsafe` rule (STYLE024 drops redundant; STYLE025 narrows block→expr; STYLE026 drops nested).
- Document `typeinfo is_unsafe_when_uninitialized(type<T>)` — the trait that gates per-type unsafe-ness in generic typed-memory helpers. Pairs with field-level `@safe_when_uninitialized` / struct-level `[safe_when_uninitialized]`. Canonical use in `daslib/builtin.das`: `static_if (typeinfo is_unsafe_when_uninitialized(type<TT>)) { unsafe { ... } } else { ... }`. The unsafe block needs `// nolint:STYLE025` because STYLE025 sees only one statement needing unsafe at any instantiation and can't reason across the static_if branches.

**`CLAUDE.md`** — `## Key Directories`:
- 5-tier indexing breadcrumb. Bug fixes for bounds checks / neg-index detection / width-aware bounds usually need parallel edits across AOT C++ (`aot.h`), interpreter non-fused (`runtime_array.h` + `simulate_nodes.h`), interpreter fused (`simulate_fusion_at*.cpp`), JIT (`llvm_jit.das`), and AST const-fold (`ast_simulate.cpp`). Debug bypasses fused; Debug-ARM CI catches fused-only fixes. JIT changes need `LLVM_JIT_CODEGEN_VERSION` bumped to invalidate cached DLLs.

**`skills/make_pr.md`** — step 1 (Lint):
- Pre-push hook callout. Repo ships `.githooks/pre-push` (formatter `--verify` + lint on changed `.das` files). One-time enable: `git config core.hooksPath .githooks`. After that, every `git push` runs the gates automatically. `--no-verify` reserved for emergencies.

**4 new mouse cards** (all dated 2026-05-21):
- `where-array-indexing-lives-five-tier-map.md` — the tier map itself, with what each tier optimizes for and why consolidation costs a perf regression.
- `uint32-cast-negative-int-wrap-bounds-check-bug-pattern.md` — the corruption-vs-diagnostic split for `uint32_t(neg_int_index)`, fix shape, both test patterns (corruption via fake metadata, diagnostic via real `Context`).
- `jit-check-range-sext-vs-zext-signed-index-widening.md` — why signed daslang indices need `LLVMBuildSExt` (not `ZExt`) before the unsigned bounds compare; how to pull signedness from `expr.index._type.baseType`.
- `temp-array-generic-dispatch-is-array-vs-fixed-array-dim.md` — `static_if (typeinfo is_array(arr))` dispatch for helpers that take either `array<T>` or fixed-size `T[N]` — `long_length` doesn't accept dims.

## Test plan

- [x] Pre-push hook: `Verified! 4589 files in (6.9s)`, lint skipped (no `.das` changes).
- [x] No code changes → CI's `extended_checks` lint/format gates have nothing to validate beyond the already-green tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)