### PR TITLE
LINT010 — dead-store detection in daslib/lint (pass 1)

### DIFF
--- a/daslib/ast_print.das
+++ b/daslib/ast_print.das
@@ -1106,7 +1106,7 @@ def add(a, b : int) {
     return a + b + add_extra;
 }
 
-[sideeffects, export]
+[sideeffects, export, no_lint]
 def allExpr(arg : int) {
     //! Exercises all expression types for AST pretty-printer coverage.
     // ExprStringBuilder

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -879,7 +879,7 @@ def private update_entity_imm(eid : EntityId; blk : lambda<(eid : EntityId; var 
     var cmp : ComponentMap
     let arch_index = unsafe(decsState.archetypeLookup[lookup.archetype]) - 1
     let eidx = decsState.entityLookup[eid.id].index
-    var old_ahash = 0ul
+    var old_ahash = 0ul    // nolint:LINT010 — written inside the inner scope below, but must outlive that scope
     {// note - this scope is for arch &
         var arch & = unsafe(decsState.allArchetypes[arch_index])
         cmp |> reserve(length(arch.components))

--- a/daslib/decs_boost.das
+++ b/daslib/decs_boost.das
@@ -509,7 +509,6 @@ class DecsQueryMacro : AstCallMacro {
         var qres = move_unquote_block(qblock)
         assert(length(qres.list) == 1 && empty(qres.finalList))
         var rqres = qres.list[0]
-        qres := null
         rqres.genFlags.alwaysSafe = true
         return rqres
     }

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -25,6 +25,14 @@ class LintEverything : AstPassMacro {
     }
 }
 
+struct private DeadStoreEntry {
+    @do_not_delete v : Variable const?
+    @do_not_delete pending_expr : Expression const?
+    skip : bool
+    has_pending : bool
+    pending_pure : bool
+}
+
 def private is_block_terminator(expr : ExpressionPtr) : bool {
     // A direct-child block statement that always exits the enclosing function.
     if (expr is ExprReturn) return true
@@ -49,6 +57,7 @@ class LintVisitor : AstVisitor {
     //!   - LINT007: left and right operands of binary operator are identical
     //!   - LINT008: both branches of ternary ``?:`` are equivalent
     //!   - LINT009: ``then`` branch equals ``else`` branch of ``if``
+    //!   - LINT010: dead store — local variable written but value never read
     astVisitorAdapter : VisitorAdapter?
     exprForTerminator : array<uint64>
     compile_time_errors : bool
@@ -61,6 +70,10 @@ class LintVisitor : AstVisitor {
     // Caller-populated via collect overload; applied alongside // nolint suppression.
     disabled_codes : table<string>
     enabled_codes : table<string>
+    // LINT010 state — dead-store detection. Per-local tracking; one entry per
+    // analyzed local in the current function. Reset on function entry.
+    branch_depth : int = 0
+    ds_entries : array<DeadStoreEntry>
     def LintVisitor() {
         pass
     }
@@ -97,8 +110,20 @@ class LintVisitor : AstVisitor {
                 break
             }
         }
+        // LINT010 — reset dead-store tracking
+        branch_depth = 0
+        ds_entries |> clear()
     }
     def override visitFunction(var fun : FunctionPtr) : FunctionPtr {
+        // LINT010 — emit final dead-store warnings for any still-pending stores
+        if (!noLint && genericDepth == 0) {
+            for (e in ds_entries) {
+                if (!e.skip && e.has_pending && e.pending_pure && e.pending_expr != null) {
+                    let vname = "{e.v.name}"
+                    self->lint_error("LINT010: dead store of '{vname}': value written but never read before scope exit", e.pending_expr.at)
+                }
+            }
+        }
         noLint = false
         if (fun.fromGeneric != null || fun.flags.generated) {
             genericDepth--
@@ -107,10 +132,22 @@ class LintVisitor : AstVisitor {
     }
     def override preVisitExprBlock(blk : ExprBlock?) : void {
         exprForTerminator |> push(0ul)
+        // LINT010: a block passed as a closure / lambda body / generator body
+        // executes deferred or conditionally — treat it as a branch so writes
+        // inside don't kill pending stores outside and reads inside don't keep
+        // an outside-init "live" (the callback may never fire).
+        let bf = blk.blockFlags
+        if (!noLint && genericDepth == 0 && (bf.isClosure || bf.isLambdaBlock || bf.isGeneratorBlock)) {
+            branch_depth++
+        }
     }
     def override visitExprBlock(var blk : ExprBlock?) : ExpressionPtr {
         if (!empty(exprForTerminator)) {
             exprForTerminator |> pop()
+        }
+        let bf = blk.blockFlags
+        if (!noLint && genericDepth == 0 && (bf.isClosure || bf.isLambdaBlock || bf.isGeneratorBlock)) {
+            branch_depth--
         }
         return <- blk
     }
@@ -264,7 +301,124 @@ class LintVisitor : AstVisitor {
         if (expr.if_false != null && expr_equal(expr.if_true, expr.if_false, false)) {
             self->lint_error("LINT009: 'then' branch is equivalent to 'else' branch", expr.at)
         }
+        branch_depth++
     }
+    def override visitExprIfThenElse(var expr : ExprIfThenElse?) : ExpressionPtr {
+        if (!noLint && genericDepth == 0) {
+            branch_depth--
+        }
+        return <- expr
+    }
+
+    // --- LINT010: dead store ---
+
+    def private ds_find(v : VariablePtr) : int {
+        // Linear scan — typical function has <10 tracked locals.
+        let vc : Variable const? = v
+        for (i in range(length(ds_entries))) {
+            if (ds_entries[i].v == vc) return i
+        }
+        return -1
+    }
+
+    def override preVisitExprLetVariable(_let : ExprLet?; v : VariablePtr; _last : bool) : void {
+        // Skip reference bindings (`var r & = x`) and inscope smart_ptr vars —
+        // these have aliasing or scope-exit semantics we don't reason about.
+        // Skip constant-folded vars (their reads were inlined to use sites,
+        // so no ExprVar reference remains for us to observe) and vars whose
+        // whole-variable unusedness is already LINT002's territory.
+        if (noLint || genericDepth > 0
+            || (v._type != null && v._type.flags.ref)
+            || v.flags.inScope
+            || v.access_flags.access_fold
+            || !v.access_flags.access_get) return
+        let has_init = v.init != null
+        let init_pure = has_init && v.init.flags.noSideEffects
+        ds_entries |> emplace(DeadStoreEntry(
+            v = v,
+            pending_expr = v.init,
+            skip = false,
+            has_pending = has_init,
+            pending_pure = init_pure
+        ))
+    }
+
+    def override preVisitExprVar(expr : ExprVar?) : void {
+        if (noLint || genericDepth > 0) return
+        let i = ds_find(expr.variable)
+        if (i < 0 || ds_entries[i].skip) return
+        let vf = expr.varFlags
+        // Any reference inside a branch/loop/lambda body, OR a write under an
+        // aliasing context (addr-of, ref-bind, mutable-ref-arg, compound op),
+        // means we can't reason about this var — bail.
+        if (branch_depth > 0 || (vf.write && !vf.under_clone)) {
+            ds_entries[i].skip = true
+            return
+        }
+        // Pure store — handled in postVisit for ExprCopy/Clone/Move so the
+        // RHS reads have been observed first. preVisit of the LHS fires
+        // BEFORE the RHS is walked, so we do nothing here.
+        if (vf.write) return
+        // Read — kills any pending dead store on this var.
+        ds_entries[i].has_pending = false
+    }
+
+    def private ds_handle_store(lhs : ExpressionPtr; rhs : ExpressionPtr; var store_expr : ExpressionPtr) : void {
+        if (lhs == null || !(lhs is ExprVar)) return
+        let ev = lhs as ExprVar
+        let i = ds_find(ev.variable)
+        if (i < 0 || ds_entries[i].skip || branch_depth > 0) return
+        if (ds_entries[i].has_pending && ds_entries[i].pending_pure && ds_entries[i].pending_expr != null) {
+            let vname = "{ev.variable.name}"
+            self->lint_error("LINT010: dead store of '{vname}': overwritten without intervening read", ds_entries[i].pending_expr.at)
+        }
+        ds_entries[i].has_pending = true
+        ds_entries[i].pending_expr = store_expr
+        ds_entries[i].pending_pure = rhs != null && rhs.flags.noSideEffects
+    }
+
+    def override visitExprCopy(var expr : ExprCopy?) : ExpressionPtr {
+        ds_handle_store(expr.left, expr.right, expr)
+        return <- expr
+    }
+    def override visitExprClone(var expr : ExprClone?) : ExpressionPtr {
+        ds_handle_store(expr.left, expr.right, expr)
+        return <- expr
+    }
+    def override visitExprMove(var expr : ExprMove?) : ExpressionPtr {
+        ds_handle_store(expr.left, expr.right, expr)
+        return <- expr
+    }
+
+    // Branch / loop / try / lambda — bumps branch_depth so any var referenced
+    // inside is bailed-on.
+    def override preVisitExprFor(expr : ExprFor?) : void {
+        if (!noLint && genericDepth == 0) branch_depth++
+    }
+    def override visitExprFor(var expr : ExprFor?) : ExpressionPtr {
+        if (!noLint && genericDepth == 0) branch_depth--
+        return <- expr
+    }
+    def override preVisitExprWhile(expr : ExprWhile?) : void {
+        if (!noLint && genericDepth == 0) branch_depth++
+    }
+    def override visitExprWhile(var expr : ExprWhile?) : ExpressionPtr {
+        if (!noLint && genericDepth == 0) branch_depth--
+        return <- expr
+    }
+    def override preVisitExprTryCatch(expr : ExprTryCatch?) : void {
+        if (!noLint && genericDepth == 0) branch_depth++
+    }
+    def override visitExprTryCatch(var expr : ExprTryCatch?) : ExpressionPtr {
+        if (!noLint && genericDepth == 0) branch_depth--
+        return <- expr
+    }
+    // NOTE on lambda capture: by-copy/clone captures (the daslang default) read
+    // the local at capture time and place a copy into the lambda's struct
+    // frame — subsequent writes to the local don't reach the lambda. So the
+    // capture site is just a read for our purposes (clears pending), and
+    // later writes that aren't read again ARE dead. By-ref captures and
+    // addr-of are caught by the `write && !under_clone` check above.
 }
 
 def public paranoid(prog : ProgramPtr; compile_time_errors : bool) {

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -272,6 +272,63 @@ has side effects — the structural pattern is suspicious regardless of purity.
         x = 2
     }
 
+LINT010 — dead store
+=====================
+
+A local variable is written but the value never reaches a read — either it is
+overwritten by a later write with no intervening read, or it goes out of scope
+(``return`` / end-of-block) with no subsequent read. Two forms fire:
+
+- ``overwritten without intervening read`` — the next write happens before any
+  reader sees this one.
+- ``value written but never read before scope exit`` — the scope ends and no
+  subsequent code reads this store.
+
+The variable being read elsewhere keeps LINT002 (unused variable) silent —
+this rule is for *partial* deadness within an otherwise-used local.
+
+.. code-block:: das
+
+    // Bad — re-init before any read
+    def f() : int {
+        var x = 1                               // LINT010
+        x = 2
+        return x
+    }
+
+    // Bad — written before return, never read
+    def g(z : int) : int {
+        var t = z
+        print("{t}\n")
+        t = compute()                           // LINT010 — scope ends, no read
+        return z
+    }
+
+    // Bad — lambda captures by-copy at creation, later write never observed
+    def h() : int {
+        var x = 1
+        let f = @() => x + 1
+        x = 2                                   // LINT010 — lambda has its own copy
+        return invoke(f)
+    }
+
+    // Good
+    def g_fixed(z : int) : int {
+        var t = z
+        print("{t}\n")
+        return z * 2
+    }
+
+The rule's scope is intentionally narrow for the first pass: it only flags
+pure stores (LHS of ``=`` / ``<-`` / ``:=``) on function-local variables, only
+when the dead store's RHS has ``noSideEffects``, and only in straight-line
+basic blocks — control flow (``if`` / ``for`` / ``while`` / ``try``) and
+block-argument callbacks (``tab |> get(k) $(v) { … }``) cause the analysis to
+bail on the variable to avoid false positives. Bail signals also include
+address-of (``addr(x)``), reference bindings (``var r & = x``), mutable-ref
+parameter passing (``foo(x)`` where ``foo`` takes ``var T&``), and capture-by-
+reference. Suppress structurally-needed dead inits with ``// nolint:LINT010``.
+
 .. _perf_lint:
 
 -----------------

--- a/examples/debugapi/hw_breakpoint.das
+++ b/examples/debugapi/hw_breakpoint.das
@@ -67,10 +67,7 @@ def demo_watch_int() {
     print("  initial target = {target}\n")
 
     // Set a hardware breakpoint on 4 bytes (sizeof int) at &target
-    var bp = 0
-    unsafe {
-        bp = set_hw_breakpoint(this_context(), addr(target), 4, true)
-    }
+    let bp = unsafe(set_hw_breakpoint(this_context(), unsafe(addr(target)), 4, true))
     print("  breakpoint installed (handle={bp})\n")
 
     // Each write to `target` triggers the breakpoint.
@@ -110,10 +107,7 @@ def demo_watch_struct_field() {
     var pos = Position(x = 0.0, y = 0.0)
 
     // Watch only the `y` field — 4 bytes at offset of `y`
-    var bp = 0
-    unsafe {
-        bp = set_hw_breakpoint(this_context(), addr(pos.y), 4, true)
-    }
+    let bp = unsafe(set_hw_breakpoint(this_context(), unsafe(addr(pos.y)), 4, true))
     print("  watching pos.y\n")
 
     // Writing to pos.x does NOT trigger the breakpoint
@@ -140,10 +134,7 @@ def demo_watch_struct_field() {
 // automatically clears it when the block exits.
 
 def watch_variable(var ctx : Context; data : void?; size : int; blk : block) {
-    var bp = 0
-    unsafe {
-        bp = set_hw_breakpoint(ctx, data, size, true)
-    }
+    let bp = unsafe(set_hw_breakpoint(ctx, data, size, true))
     invoke(blk)
     unsafe {
         clear_hw_breakpoint(bp)

--- a/modules/dasAudio/strudel/strudel_midi.das
+++ b/modules/dasAudio/strudel/strudel_midi.das
@@ -138,7 +138,7 @@ def private parse_midi_track(data : array<uint8>; var cursor : int&) : MidiTrack
             status = runningStatus
         }
         let msgType = status & int(0xF0)
-        let ch = int(status & int(0x0F))
+        let ch = status & int(0x0F)
         if (msgType == int(0x80)) {
             // Note Off
             let note = (status == firstByte) ? read_byte(data, cursor) : firstByte
@@ -264,11 +264,10 @@ def private parse_midi_track(data : array<uint8>; var cursor : int&) : MidiTrack
 def parse_midi(data : array<uint8>) : MidiFile {
     //! Parse MIDI data from a byte array into a MidiFile structure.
     var result : MidiFile
-    if (length(data) < 14) return <- result
-    var cursor = 0
-    // "MThd"
-    if (int(data[0]) != 'M' || int(data[1]) != 'T' || int(data[2]) != 'h' || int(data[3]) != 'd') return <- result
-    cursor = 4
+    if (length(data) < 14
+            || int(data[0]) != 'M' || int(data[1]) != 'T'
+            || int(data[2]) != 'h' || int(data[3]) != 'd') return <- result
+    var cursor = 4
     let headerLen = read_u32(data, cursor)
     if (headerLen < 6) return <- result
     result.format = read_u16(data, cursor)

--- a/tests/language/labels.das
+++ b/tests/language/labels.das
@@ -104,7 +104,7 @@ def finally_goto(tt : T?; yes : bool = true) {
     tt |> success(!fail)
 }
 
-[sideeffects]
+[sideeffects, no_lint]
 def gotoN(n : int) {
     var res = -1
     goto n

--- a/tests/language/utility_patterns.das
+++ b/tests/language/utility_patterns.das
@@ -49,13 +49,11 @@ def test_defer_basic(t : T?) {
 // ============================================================
 
 def call_counter() : int {
-    var count = 0
     static_let() {
         var counter = 0
     }
     counter ++
-    count = counter
-    return count
+    return counter
 }
 
 [test]

--- a/tutorials/language/02_variables.das
+++ b/tutorials/language/02_variables.das
@@ -17,7 +17,7 @@ def main {
     // === var vs let ===
 
     // var declares a mutable variable — its value can change.
-    var score = 0
+    var score = 0   // nolint:LINT010 — demonstrating mutable reassignment
     score = 100
     print("score = {score}\n")
 

--- a/tutorials/language/03_operators.das
+++ b/tutorials/language/03_operators.das
@@ -87,7 +87,7 @@ def main {
 
     // = is copy assignment — works for simple types and copyable values.
     let p = 10
-    var q = p       // q is a copy of p
+    var q = p       // q is a copy of p  // nolint:LINT010 — demonstrating reassignment after copy
     q = 99
     print("p={p}  q={q}\n")    // p is unchanged
 

--- a/tutorials/language/14_lambdas.das
+++ b/tutorials/language/14_lambdas.das
@@ -31,7 +31,7 @@ def main {
     print("mul_lambda(5) = {mul_lambda(5)}\n")   // 50
 
     // Changing the original variable does NOT affect the lambda (captured by copy).
-    multiplier = 999
+    multiplier = 999  // nolint:LINT010 — dead-by-design; lambda has its own captured copy
     print("mul_lambda(5) still = {mul_lambda(5)}\n")  // still 50
 
     // === Simplified => syntax ===

--- a/utils/daspkg/utils.das
+++ b/utils/daspkg/utils.das
@@ -67,15 +67,12 @@ def run_cmd(cmd : string; var output : string&) : int {
     if (get_platform_name() == "windows") {
         full_cmd = "\"{full_cmd}\""
     }
-    var exit_code = -1
     var pipe_output : string
-    unsafe {
-        exit_code = popen(full_cmd) $(f) {
-            if (f != null) {
-                pipe_output = fread(f)
-            }
+    let exit_code = unsafe(popen(full_cmd) $(f) {
+        if (f != null) {
+            pipe_output = fread(f)
         }
-    }
+    })
     let tmp_existed = fexist(tmp_out)
     if (tmp_existed) {
         fopen(tmp_out, "rb") $(f) {

--- a/utils/lint/tests/lint010_dead_store.das
+++ b/utils/lint/tests/lint010_dead_store.das
@@ -1,0 +1,168 @@
+options gen2
+// LINT010: value stored in local variable is never read (dead store)
+//
+// Problem:
+//   A local variable is written, but the value never reaches a read —
+//   either it's overwritten by a later write with no intervening read,
+//   or the variable goes out of scope (return / end-of-block) with no
+//   subsequent read.
+//
+// Bad pattern:
+//   var x = 1     // dead — overwritten on the next line
+//   x = 2
+//   return x
+//
+// Good pattern:
+//   var x = 2
+//   return x
+//
+// Scope of pass-1 (this file):
+//   - Local variables only — not args, globals, captures, ref-bound.
+//   - Skip vars whose address is taken, that are reference-bound, or
+//     that are captured into a lambda (`Variable.capture_as_ref`).
+//   - Only fires when the dead store's RHS is `flags.noSideEffects`.
+//   - Block-local — no cross-branch / cross-loop analysis. The
+//     `neutral_*` cases below are conservatively silent, not flagged.
+//   - Boundary with LINT002 (unused variable, whole-variable): each
+//     positive below ensures the variable IS read somewhere, so
+//     LINT002 stays silent and the diagnostic surfaces as LINT010.
+
+expect 50503:5
+
+require daslib/lint
+
+// === Helpers ===
+
+def private compute_pure() : int {
+    return 42
+}
+
+def private side_effect_int() : int {
+    print("hi")
+    return 1
+}
+
+def private take_addr(_p : int?) {
+}
+
+def private bumper(var v : int&) {
+    v++
+}
+
+def private log(s : string) {
+    print("{s}\n")
+}
+
+// === Positives — these SHOULD warn ===
+
+// P1: dead init — overwritten before any read.
+def bad_dead_init() : int {
+    var x = 1       // LINT010: overwritten on next line; never read
+    x = 2
+    return x
+}
+
+// P2: dead intermediate write — init is live (read by print), final
+// write is live (read by return), but the middle write is dead.
+def bad_dead_intermediate(z : int) : int {
+    var s = z
+    print("{s}\n")          // read — keeps init live
+    s = compute_pure()      // LINT010: overwritten on next line; never read
+    s = z * 2
+    return s
+}
+
+// P3: dead final write — function returns a different value.
+def bad_dead_final_write(z : int) : int {
+    var t = z
+    print("{t}\n")          // read — keeps init live
+    t = compute_pure()      // LINT010: scope ends with no further read
+    return z
+}
+
+// P4: dead string init.
+def bad_dead_string_init() {
+    var msg = "init"        // LINT010: overwritten on next line; never read
+    msg = "real"
+    log(msg)
+}
+
+// P5: lambda captures x BY COPY at creation site — subsequent writes to the
+// local x don't reach the lambda's struct frame, so `x = 2` is dead.
+def bad_dead_after_copy_capture() : int {
+    var x = 1
+    let f = @() => x + 1
+    x = 2                   // LINT010: never read; the lambda has its own copy
+    return invoke(f)
+}
+
+// === Counter-examples — these should NOT warn ===
+
+// C1: address taken → x escapes; analysis must bail on this var.
+def good_addr_taken() {
+    var x = 1
+    take_addr(unsafe(addr(x)))
+    x = 2
+    print("{x}\n")
+}
+
+// C2: reference-bound alias → writes through r are writes to x; bail.
+def good_ref_bound() : int {
+    var x = 1
+    var r & = x
+    r = 5
+    return x
+}
+
+// C3: passed by mutable reference → callee may read current value.
+def good_ref_arg() : int {
+    var x = 1
+    bumper(x)               // callee may read x before writing
+    return x
+}
+
+// C4: RHS has observable side effects → eliding would change behavior.
+def good_rhs_has_side_effects() : int {
+    var x = side_effect_int()
+    x = 2
+    return x
+}
+
+// C5: read between two writes makes the first one live.
+def good_read_between() : int {
+    var x = 1
+    log("{x}")              // read — keeps x = 1 live
+    x = 2
+    return x
+}
+
+// C6: block-arg callback may not fire — init is the fallback path.
+def good_block_arg_callback() : int {
+    var qi = -1             // live on the "block didn't run" path
+    let tab : table<int; int> <- { 7 => 42 }
+    tab |> get(99) $(v) {
+        qi = v
+    }
+    return qi
+}
+
+// === Out-of-scope — cross-block, pass-1 must NOT flag ===
+
+// N1: write in only one branch — the init reaches the other path.
+def neutral_write_in_branch(c : bool) : int {
+    var x = 1               // live on the !c path; pass-1 must be silent
+    if (c) {
+        x = 2
+    }
+    return x
+}
+
+// N2: write inside a loop body — only the LAST iteration's value
+// reaches the return; pass-1 cross-block-blind must not flag.
+def neutral_loop_body() : int {
+    var last = 0
+    for (i in range(10)) {
+        last = i
+    }
+    return last
+}

--- a/utils/mcp/tools/convert_to_gen2.das
+++ b/utils/mcp/tools/convert_to_gen2.das
@@ -33,9 +33,7 @@ def do_convert_to_gen2(file : string; inplace : bool) : string {
     let inplace_flag = inplace ? " -i" : ""
     let cmd = "{fmt_exe} -v2{inplace_flag} {file}"
     var output : string
-    var exit_code = 0
-    unsafe {
-        exit_code = popen(cmd) $(f) {
+    let exit_code = unsafe(popen(cmd) $(f) {
             if (f == null) {
                 output = "Failed to execute: {cmd}"
                 return
@@ -46,7 +44,7 @@ def do_convert_to_gen2(file : string; inplace : bool) : string {
                 }
             }
         }
-    }
+    )
     output = strip_das_fmt_header(output)
     if (exit_code != 0) return make_tool_result("Conversion failed (exit code {exit_code}):\n{output}", true)
     if (inplace) return make_tool_result("Converted {file} to gen2 syntax in place")


### PR DESCRIPTION
## Summary

Adds a paranoid-lint rule **LINT010** that flags writes to local variables whose values are never read — either overwritten by a later write with no intervening read, or written before scope exit with no subsequent read. Lives next to LINT002 (whole-variable unused) in `daslib/lint.das`; this rule covers *partial* deadness within an otherwise-used local.

This is a starting-point first pass — landed to see how it behaves on real PRs and on the codebase at large. Known limitations called out below.

## Algorithm (block-local, linear)

Per local variable, the visitor tracks `(pending_expr, pending_pure, skip)`.

| Event | Action |
|---|---|
| `preVisitExprLetVariable` | Register var. `pending_expr = init`, `pending_pure = init.flags.noSideEffects`. Skip refs (`var r & = x`), inscope, constant-folded (`access_fold`), never-read (`!access_get`). |
| `preVisitExprVar`, `write && !under_clone` | Escape (addr-of / ref-bind / mutable-ref-arg / compound op) → `skip = true`. |
| `preVisitExprVar`, read (`!write`) | `pending = None`. |
| `postVisitExprCopy/Clone/Move` with LHS=`ExprVar(v)` | If prior pending was pure → **WARN dead store at pending.at**. Set new pending = `(this expr, expr.right.flags.noSideEffects)`. |
| `preVisitExpr{IfThenElse,For,While,TryCatch}` / `preVisitExprBlock` with `isClosure/isLambdaBlock/isGeneratorBlock` | `branch_depth++` — any ref inside bails the var. |
| `visitFunction` post | For each pending+pure+not-skipped → **WARN dead final store**. |

The post-visit ordering on Copy/Clone/Move is load-bearing — the RHS is walked between pre and post, so reads of the LHS variable inside the RHS (e.g. `x = x + 1`) clear pending before the dead-store check fires.

## Fixture

`utils/lint/tests/lint010_dead_store.das` — `expect 50503:5`:

**Positives (5):**
1. Dead init: `var x = 1; x = 2; return x`
2. Dead intermediate: `var s = z; print({s}); s = compute_pure(); s = z*2; return s`
3. Dead final write: `var t = z; print({t}); t = compute_pure(); return z`
4. Dead string init: `var msg = "init"; msg = "real"; log(msg)`
5. Dead after by-copy lambda capture: `var x = 1; let f = @() => x + 1; x = 2; return invoke(f)` — the lambda struct frame holds its own copy of `x`, so `x = 2` is genuinely dead

**Counter-examples (6):** addr-taken, reference-bound, mutable-ref-arg, side-effect RHS, read-between-writes, block-arg callback.

**Cross-block neutrals (2):** if-branch write, loop-body write — pass-1 conservatively bails.

## Codebase findings + cleanups bundled

The rule fired on 33 sites repo-wide. Categorization:

| File | Treatment |
|---|---|
| `daslib/ast_print.das` `allExpr` (20 hits) | `[no_lint]` — deliberate all-AST-types coverage fixture |
| `daslib/decs.das:882` `old_ahash` | inline `// nolint:LINT010` — structurally needed (bare-scope writes to a var declared outside) |
| `daslib/decs_boost.das:512` `qres := null` | **real find** — delete the line (ExprBlock is gc_node raw pointer, no destructor effect from setting to null) |
| `utils/daspkg/utils.das:70`, `utils/mcp/tools/convert_to_gen2.das:36`, `examples/debugapi/hw_breakpoint.das` (×3) | inline `var x = placeholder; unsafe { x = call() }` → `let x = unsafe(call())` |
| `modules/dasAudio/strudel/strudel_midi.das:268` | move `var cursor = 4` past the early-exit guards; combined adjacent guards (STYLE016); dropped one redundant `int(...)` cast (PERF020) |
| `tutorials/language/{02_variables, 03_operators, 14_lambdas}` | per-line `// nolint:LINT010` on the pedagogically-intended dead-store patterns (the 14_lambdas case literally demonstrates by-copy capture) |
| `tests/language/{labels, utility_patterns}` | refactor (`count`) or `[no_lint]` on the goto-N test fixture |

## Known limitations (pass-1)

- **Block-arg callbacks are over-conservatively bailed.** `peek_data(s) $(arr) { outlen = ... }` always runs but `tab.get(k) $(v) { ... }` may not, and the rule can't generically tell which. Currently treats all closure-bodies as conditional → misses some real finds (e.g. `daslib/base64.das:68` `outlen`).
- **Cross-branch / cross-loop bails on the variable.** `var x = 0; if (c) x = 1; return x` keeps `x = 0` live conservatively.
- **Doesn't reach into the lambda's call-function visit** — that's a separate Function visit with `flags.generated=true`, gated by `genericDepth > 0` early-return.
- **Dead store at the same level as `goto`/`label` isn't reasoned about.** `tests/language/labels.das` `gotoN` carries `[no_lint]`.

## Documentation

`doc/source/reference/language/lint.rst` — LINT010 section added in the paranoid-rules block, with three "Bad" examples (re-init, write-before-return, by-copy lambda capture) and a "Good" rewrite, plus the scope-of-pass-1 paragraph.

## Test plan

- [x] `utils/lint/tests/lint010_dead_store.das` — `expect 50503:5` passes (5/5 positives, 0 false positives)
- [x] Full repo-wide LINT010 sweep produces zero hits after cleanups
- [x] Lint on all 14 changed `.das` files clean (0 issues)
- [x] `dastest --test tests/` — **9103/9109 passed, 0 failed, 0 errors, 6 platform skips** (same as master baseline)
- [x] JIT smoke on `tests/jit_tests/array.das` — no verifier errors
- [x] All changed `.das` files already formatted per `mcp__daslang__format_file`
- [ ] CI to confirm `extended_checks` lint + sphinx on the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)