### PR TITLE
linq_fold: Slice 5d order/reverse on decs (plan_decs_order_family + plan_decs_reverse)

### DIFF
--- a/benchmarks/sql/M4_DECS_EXPANSION.md
+++ b/benchmarks/sql/M4_DECS_EXPANSION.md
@@ -316,3 +316,24 @@ New `plan_decs_group_by` planner mirrors `plan_group_by` machinery (state-table 
 All 12 groupby_* rows improve 1.9-2.9× (avg ~2.3×). m4 now consistently lands 10-20 ns above m3f — the remaining gap is the Wave 4 multi-component `get_ro` overhead (every bridge component participates in the inner for-loop iteration even when the chain only reads one). m4 beats SQL on 10/10 measurable rows by 2.1-3.4×.
 
 **Coverage:** count terminator (length(tab)), implicit to_array terminator, sum/min/max/average/first reducers, multi-reducer (N+S+MX in one pass), having_ predicate over named slot, having_ predicate over hidden synthesized slot, upstream where_+group_by, upstream select+group_by(expression key), AST shape gate (no `to_sequence`, exactly one `for_each_archetype`, no `_find` variant — group_by doesn't early-exit, `decs_tab` 6 refs + `decs_dummy` 6 refs in the splice). +13 tests (80 → 93 in file).
+
+## Update — Slice 5d order/reverse on decs (2026-05-21, plan_decs_order_family + plan_decs_reverse)
+
+Two new planners `plan_decs_order_family` (mirrors `plan_order_family`) and `plan_decs_reverse` (mirrors `plan_reverse`), inserted in the cascade BEFORE their array-side equivalents per the same cascade-ordering rule as Slice 5e. Both emit a hoisted buffer above `for_each_archetype`, then dispatch to the existing daslib helper family — `order_inplace` / `top_n*` / `min_by` / `max_by` for the order arm, `reverse_inplace` + optional `resize(takeN)` for the reverse arm.
+
+`plan_decs_reverse` has three emit paths matching the array side: `count` terminator → counter loop (reverse is identity for count); `first`/`first_or_default` → walk + overwrite `last` (reverse-of-last = first-of-reverse); else → buffer + `reverse_inplace` + optional resize. The R6 backward-index optimization from array side doesn't apply: multi-iter for has no random access into the archetype.
+
+`plan_decs_order_family` has a single uniform emit (always buffers, then dispatches the appropriate terminator) — simpler than array side which has separate "no where" direct-call vs "with where" buffered paths. The decs source can never random-access, so the direct-call optimization isn't available.
+
+| benchmark | shape | m1 sql | m3 | m3f (array splice) | m4 (old, eager bridge) | m4 (new, splice) | m4 win |
+|---|---|---:|---:|---:|---:|---:|---:|
+| sort_take                | `_order_by + take` | 38 | 713 | 28 | 119 | **57** | 2.1× |
+| sort_first               | `_order_by + first` | 37 | 711 | 41 | 121 | **71** | 1.7× |
+| order_take_desc          | `_order_by_descending + take` | 37 | 694 | 28 | 117 | **58** | 2.0× |
+| select_where_order_take  | `_where + _order_by + take` | 36 | 352 | 25 | 102 | **38** | 2.7× |
+| bare_order_where         | `_where + _order_by` | 274 | 359 | 118 | 196 | **130** | 1.5× |
+| reverse_take             | `.reverse().take(N)` | 0 | 22 | 0 | 114 | **48** | 2.4× |
+
+All 6 rows improve 1.5-2.7× (avg ~2.1×). m4 lands within 2× of m3f on most rows — the remaining gap is the Wave 4 multi-component `get_ro` overhead (sort dominates the wall-clock so the gap doesn't fully close even when the splice fires). `bare_order_where` is the tightest squeeze (1.5×) because sort over 100K rows is the bottleneck; once the m4 buffer build matches m3f (~117 ns), the rest is pure sort time.
+
+**Coverage:** bare `_order_by` + to_array, bare `_order_by_descending` + to_array, `_order_by` + take, `_order_by_descending` + take, `_order_by` + first, `_order_by_descending` + first, `_order_by` + first_or_default (nonempty + empty), `_where + _order_by + take`, `_where + _order_by + first`; `.reverse() + to_array`, `.reverse() + take(N)` (in-range, beyond-length, and zero — last uses runtime-var to defeat const-fold of PERF017 false-positive on splice-emitted `0 < length(buf)`), `.reverse() + count` (no-buffer counter loop), `_where + .reverse() + first_or_default` (empty + nonempty), `_where + .reverse() + to_array`, `_where + _select + .reverse() + to_array` (projection through reverse). AST shape gates for: order+take (top_n_by emit + no to_sequence + 1 for_each_archetype), order+first (min_by emit + panic-on-empty guard + no top_n_by), reverse+to_array (1 reverse_inplace), reverse+count (no decs_buf, no reverse_inplace). +20 tests (100 → 120 in file).

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -4449,12 +4449,13 @@ def private plan_decs_reverse(var expr : Expression?) : Expression? {
     var forExprNode = build_decs_inner_for(bridge, tupBind, perElement, at)
     var resizeStmts : array<Expression?>
     if (takeExpr != null) {
-        // take(N) of reversed-buffer = last N of source reversed. Three clones since no math::min import.
-        var takeA = clone_expression(takeExpr)
-        var takeB = clone_expression(takeExpr)
-        var takeC = clone_expression(takeExpr)
+        // take(N) of reversed-buffer = last N of source reversed. Hoist once to a let so a side-effecting take expression evaluates exactly once.
+        let takeNName = "`take_n`{at.line}`{at.column}"
         resizeStmts |> push <| qmacro_expr() {
-            $i(bufName) |> resize($e(takeA) <= 0 ? 0 : ($e(takeB) < length($i(bufName)) ? $e(takeC) : length($i(bufName))))
+            let $i(takeNName) = $e(takeExpr)
+        }
+        resizeStmts |> push <| qmacro_expr() {
+            $i(bufName) |> resize($i(takeNName) <= 0 ? 0 : ($i(takeNName) < length($i(bufName)) ? $i(takeNName) : length($i(bufName))))
         }
     }
     var emission : Expression? = qmacro(invoke($() : array<$t(bufElemType)> {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -4104,6 +4104,376 @@ def private plan_decs_group_by(var expr : Expression?) : Expression? {
     return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, terminatorName, expr._type.isIterator, at, adapter)
 }
 
+// ── decs order family splice (Slice 5d — buffer + order_inplace/top_n/min_by/max_by) ───────
+
+[macro_function]
+def private plan_decs_order_family(var expr : Expression?) : Expression? {
+    // Decs-bridge entry mirroring plan_order_family. Recognizes [where_*][order|order_descending|order_by|order_by_descending][take(N)|first|first_or_default(d)]? on a from_decs_template source. Always uses a hoisted buffer above for_each_archetype (decs has no random access for the no-where direct path that array-side enjoys), then dispatches to the same daslib helper family (order_inplace / top_n* / min_by / max_by / first_or_default(top_n*(_,1,_),d)).
+    var (top, calls) = flatten_linq(expr)
+    var bridge = extract_decs_bridge(top)
+    if (bridge == null || empty(calls) || expr._type == null) return null
+    let at = calls[0]._0.at
+    let tupName = "`decs_tup`{at.line}`{at.column}"
+    let bufName = "`decs_buf`{at.line}`{at.column}"
+    var whereCond : Expression?
+    var orderName : string = ""
+    var orderKey : Expression?
+    var hasOrder = false
+    var takeExpr : Expression?
+    var firstName : string = ""
+    var firstDefaultExpr : Expression?
+    for (i in 0 .. length(calls)) {
+        var cll & = unsafe(calls[i])
+        let name = cll._1.name
+        if (name == "where_") {
+            if (hasOrder) return null
+            var pred = fold_linq_cond(cll._0.arguments[1], tupName)
+            if (pred == null) return null
+            whereCond = merge_where_cond(whereCond, pred)
+        } elif (name == "order" || name == "order_descending"
+                || name == "order_by" || name == "order_by_descending") {
+            if (hasOrder) return null
+            let argCount = cll._0.arguments |> length
+            // Bail on `order(arr, cmp)` / `order_descending(arr, cmp)` — splice helpers (min/max/top_n) can't honor a user-supplied comparator and would silently drop it. Matches plan_order_family.
+            if ((name == "order" || name == "order_descending") && argCount >= 2) return null
+            hasOrder = true
+            orderName = name
+            if (argCount >= 2) {
+                orderKey = clone_expression(cll._0.arguments[1])
+            }
+        } elif (name == "take") {
+            if (!hasOrder || takeExpr != null || firstName != "") return null
+            var arg = cll._0.arguments[1]
+            if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
+            takeExpr = clone_expression(arg)
+        } elif (name == "first" || name == "first_or_default") {
+            // order + first → min/max (O(N) instead of sort + index). Must be terminal.
+            if (!hasOrder || takeExpr != null || firstName != "" || i != length(calls) - 1) return null
+            firstName = name
+            if (name == "first_or_default") {
+                if ((cll._0.arguments |> length) < 2) return null
+                firstDefaultExpr = clone_expression(cll._0.arguments[1])
+            }
+        } else {
+            return null
+        }
+    }
+    if (!hasOrder) return null
+    let hasKey = orderName == "order_by" || orderName == "order_by_descending"
+    let topNName = order_top_n_call_name(orderName)
+    let inplaceName = "{orderName}_inplace"
+    let minMaxName = order_min_call_name(orderName, hasKey)
+    var elemType = strip_const_ref(clone_type(bridge.elementType))
+    var inlineCmp : Expression?
+    if (hasKey) {
+        inlineCmp = try_make_inline_cmp(orderKey, orderName, elemType, at)
+    }
+    var perElement : Expression? = qmacro_expr() {
+        $i(bufName) |> push_clone($i(tupName))
+    }
+    if (whereCond != null) {
+        perElement = qmacro_expr() {
+            if ($e(whereCond)) {
+                $e(perElement)
+            }
+        }
+    }
+    var tupBind = build_decs_tup_bind(bridge, tupName, at)
+    var forExprNode = build_decs_inner_for(bridge, tupBind, perElement, at)
+    var reqExpr = clone_expression(bridge.reqHashExpr)
+    var erqExpr = clone_expression(bridge.erqExpr)
+    let archName = bridge.archName
+    var bodyStmts : array<Expression?>
+    bodyStmts |> reserve(5)
+    bodyStmts |> push <| qmacro_expr() {
+        var $i(bufName) : array<$t(elemType)>
+    }
+    bodyStmts |> push <| qmacro_expr() {
+        for_each_archetype($e(reqExpr), $e(erqExpr), $($i(archName) : Archetype) {
+            $e(forExprNode)
+        })
+    }
+    let needIterWrap = expr._type.isIterator
+    var emission : Expression?
+    if (firstName == "first") {
+        // order + first → min/max on buffer. Empty buf must panic to match eager `first()` semantics.
+        bodyStmts |> push <| qmacro_expr() {
+            panic("sequence contains no elements") if (empty($i(bufName)))
+        }
+        var minMaxCall : Expression?
+        if (hasKey) {
+            minMaxCall = qmacro($c(minMaxName)($i(bufName), $e(orderKey)))
+        } else {
+            minMaxCall = qmacro($c(minMaxName)($i(bufName)))
+        }
+        bodyStmts |> push <| qmacro_expr() {
+            return $e(minMaxCall)
+        }
+        emission = qmacro(invoke($() : $t(elemType) {
+            $b(bodyStmts)
+        }))
+    } elif (firstName == "first_or_default") {
+        // No min_by_or_default helper exists; route through top_n*(_, 1, _) + first_or_default for the empty-buf case.
+        var topNCall : Expression?
+        if (inlineCmp != null) {
+            topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), 1, $e(inlineCmp)))
+        } elif (hasKey) {
+            topNCall = qmacro($c(topNName)($i(bufName), 1, $e(orderKey)))
+        } else {
+            topNCall = qmacro($c(topNName)($i(bufName), 1))
+        }
+        bodyStmts |> push <| qmacro_expr() {
+            return _::first_or_default($e(topNCall), $e(firstDefaultExpr))
+        }
+        emission = qmacro(invoke($() : $t(elemType) {
+            $b(bodyStmts)
+        }))
+    } elif (takeExpr == null) {
+        // Bare order family — sort buffer in place and return.
+        var sortCall : Expression?
+        if (inlineCmp != null) {
+            sortCall = qmacro(_::order_inplace($i(bufName), $e(inlineCmp)))
+        } elif (hasKey) {
+            sortCall = qmacro($c(inplaceName)($i(bufName), $e(orderKey)))
+        } else {
+            sortCall = qmacro($c(inplaceName)($i(bufName)))
+        }
+        bodyStmts |> push(sortCall)
+        bodyStmts |> push <| qmacro_expr() {
+            return <- $i(bufName)
+        }
+        emission = qmacro(invoke($() : array<$t(elemType)> {
+            $b(bodyStmts)
+        }))
+    } else {
+        // order + take → top_n* dispatch on the buffer.
+        var topNCall : Expression?
+        if (inlineCmp != null) {
+            topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), $e(takeExpr), $e(inlineCmp)))
+        } elif (hasKey) {
+            topNCall = qmacro($c(topNName)($i(bufName), $e(takeExpr), $e(orderKey)))
+        } else {
+            topNCall = qmacro($c(topNName)($i(bufName), $e(takeExpr)))
+        }
+        bodyStmts |> push <| qmacro_expr() {
+            return <- $e(topNCall)
+        }
+        emission = qmacro(invoke($() : array<$t(elemType)> {
+            $b(bodyStmts)
+        }))
+    }
+    emission.force_at(at)
+    emission.force_generated(true)
+    // Bare order + take both return array; wrap to iterator when the user's outer context demands it. first/first_or_default return scalar — no wrap.
+    let returnsArray = firstName == ""
+    if (needIterWrap && returnsArray) {
+        emission = qmacro($e(emission).to_sequence_move())
+    }
+    return emission
+}
+
+// ── decs reverse splice (Slice 5d — buffer + reverse_inplace; or counter/walk-last for terminators) ───────
+
+[macro_function]
+def private plan_decs_reverse(var expr : Expression?) : Expression? {
+    // Decs-bridge entry mirroring plan_reverse. Recognizes [where_*][select?][reverse][take(N)?][count|first|first_or_default(d)]? on a from_decs_template source. Three emit paths: count → counter loop (reverse is identity for count); first/first_or_default → walk + overwrite `last` (reverse-of-last = first-of-reverse); else → buffer fill + reverse_inplace + optional resize. R6 backward-index optimization from array-side doesn't apply: multi-iter for has no random access.
+    var (top, calls) = flatten_linq(expr)
+    var bridge = extract_decs_bridge(top)
+    if (bridge == null || empty(calls) || expr._type == null) return null
+    var terminatorName : string = ""
+    var terminatorCall : ExprCall?
+    {
+        let lastName = calls.back()._1.name
+        if (lastName == "count" && length(calls.back()._0.arguments) == 1) {
+            terminatorName = lastName
+            terminatorCall = calls.back()._0
+            calls |> pop
+        } elif (lastName == "first" || lastName == "first_or_default") {
+            terminatorName = lastName
+            terminatorCall = calls.back()._0
+            calls |> pop
+        }
+    }
+    if (empty(calls)) return null
+    let at = calls[0]._0.at
+    let tupName = "`decs_tup`{at.line}`{at.column}"
+    var whereCond : Expression?
+    var projection : Expression?
+    var hasReverse = false
+    var seenSelect = false
+    var takeExpr : Expression?
+    for (i in 0 .. length(calls)) {
+        var cll & = unsafe(calls[i])
+        let name = cll._1.name
+        if (name == "where_") {
+            if (hasReverse || seenSelect) return null
+            var pred = fold_linq_cond(cll._0.arguments[1], tupName)
+            if (pred == null) return null
+            whereCond = merge_where_cond(whereCond, pred)
+        } elif (name == "select") {
+            if (hasReverse || seenSelect) return null
+            seenSelect = true
+            projection = fold_linq_cond(cll._0.arguments[1], tupName)
+            if (projection == null) return null
+        } elif (name == "reverse") {
+            if (hasReverse) return null
+            hasReverse = true
+        } elif (name == "take") {
+            if (!hasReverse || takeExpr != null) return null
+            var arg = cll._0.arguments[1]
+            if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
+            takeExpr = clone_expression(arg)
+        } else {
+            return null
+        }
+    }
+    if (!hasReverse || (takeExpr != null && terminatorName != "")) return null
+    var reqExpr = clone_expression(bridge.reqHashExpr)
+    var erqExpr = clone_expression(bridge.erqExpr)
+    let archName = bridge.archName
+    if (terminatorName == "count") {
+        // Reverse is identity for count — counter loop, no buffer. Side-effecting projection still fires per match.
+        let cntName = "`decs_cnt`{at.line}`{at.column}"
+        var perElement : Expression?
+        if (projection != null && has_sideeffects(projection)) {
+            let vfinalName = "`decs_vfinal`{at.line}`{at.column}"
+            perElement = qmacro_block() {
+                var $i(vfinalName) = $e(projection)
+                $i(cntName) ++
+            }
+        } else {
+            perElement = qmacro_expr() {
+                $i(cntName) ++
+            }
+        }
+        if (whereCond != null) {
+            perElement = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $e(perElement)
+                }
+            }
+        }
+        var tupBind = build_decs_tup_bind(bridge, tupName, at)
+        var forExprNode = build_decs_inner_for(bridge, tupBind, perElement, at)
+        var emission : Expression? = qmacro(invoke($() : int {
+            var $i(cntName) = 0
+            for_each_archetype($e(reqExpr), $e(erqExpr), $($i(archName) : Archetype) {
+                $e(forExprNode)
+            })
+            return $i(cntName)
+        }))
+        emission.force_at(at)
+        emission.force_generated(true)
+        return emission
+    }
+    if (terminatorName == "first" || terminatorName == "first_or_default") {
+        // "first of reversed" = LAST surviving element. Walk all archetypes, overwrite `last` on each match. No buffer.
+        let foundName = "`decs_found`{at.line}`{at.column}"
+        let lastName = "`decs_last`{at.line}`{at.column}"
+        let dBindName = "`decs_d`{at.line}`{at.column}"
+        var lastType = strip_const_ref(clone_type(projection != null ? projection._type : bridge.elementType))
+        var valueExpr : Expression?
+        if (projection != null) {
+            valueExpr = clone_expression(projection)
+        } else {
+            valueExpr = qmacro_expr() {
+                $i(tupName)
+            }
+        }
+        var matchBlock : Expression? = qmacro_block() {
+            $i(lastName) := $e(valueExpr)
+            $i(foundName) = true
+        }
+        var perElement : Expression? = matchBlock
+        if (whereCond != null) {
+            perElement = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $e(perElement)
+                }
+            }
+        }
+        var tupBind = build_decs_tup_bind(bridge, tupName, at)
+        var forExprNode = build_decs_inner_for(bridge, tupBind, perElement, at)
+        var emission : Expression?
+        if (terminatorName == "first") {
+            emission = qmacro(invoke($() : $t(lastType) {
+                var $i(foundName) = false
+                var $i(lastName) : $t(lastType) = default<$t(lastType)>
+                for_each_archetype($e(reqExpr), $e(erqExpr), $($i(archName) : Archetype) {
+                    $e(forExprNode)
+                })
+                if (!$i(foundName)) {
+                    panic("sequence contains no elements")
+                }
+                return $i(lastName)
+            }))
+        } else {
+            var defaultExpr = clone_expression(terminatorCall.arguments[1])
+            emission = qmacro(invoke($() : $t(lastType) {
+                let $i(dBindName) = $e(defaultExpr)
+                var $i(foundName) = false
+                var $i(lastName) : $t(lastType) = default<$t(lastType)>
+                for_each_archetype($e(reqExpr), $e(erqExpr), $($i(archName) : Archetype) {
+                    $e(forExprNode)
+                })
+                return $i(foundName) ? $i(lastName) : $i(dBindName)
+            }))
+        }
+        emission.force_at(at)
+        emission.force_generated(true)
+        return emission
+    }
+    // Buffer + reverse_inplace + optional resize. Implicit to_array (no terminator).
+    let bufName = "`decs_buf`{at.line}`{at.column}"
+    let needIterWrap = expr._type.isIterator
+    var bufElemType = strip_const_ref(clone_type(projection != null ? projection._type : bridge.elementType))
+    var pushExpr : Expression?
+    if (projection != null) {
+        pushExpr = qmacro_expr() {
+            $i(bufName) |> push_clone($e(projection))
+        }
+    } else {
+        pushExpr = qmacro_expr() {
+            $i(bufName) |> push_clone($i(tupName))
+        }
+    }
+    var perElement : Expression? = pushExpr
+    if (whereCond != null) {
+        perElement = qmacro_expr() {
+            if ($e(whereCond)) {
+                $e(perElement)
+            }
+        }
+    }
+    var tupBind = build_decs_tup_bind(bridge, tupName, at)
+    var forExprNode = build_decs_inner_for(bridge, tupBind, perElement, at)
+    var resizeStmts : array<Expression?>
+    if (takeExpr != null) {
+        // take(N) of reversed-buffer = last N of source reversed. Three clones since no math::min import.
+        var takeA = clone_expression(takeExpr)
+        var takeB = clone_expression(takeExpr)
+        var takeC = clone_expression(takeExpr)
+        resizeStmts |> push <| qmacro_expr() {
+            $i(bufName) |> resize($e(takeA) <= 0 ? 0 : ($e(takeB) < length($i(bufName)) ? $e(takeC) : length($i(bufName))))
+        }
+    }
+    var emission : Expression? = qmacro(invoke($() : array<$t(bufElemType)> {
+        var $i(bufName) : array<$t(bufElemType)>
+        for_each_archetype($e(reqExpr), $e(erqExpr), $($i(archName) : Archetype) {
+            $e(forExprNode)
+        })
+        _::reverse_inplace($i(bufName))
+        $b(resizeStmts)
+        return <- $i(bufName)
+    }))
+    emission.force_at(at)
+    emission.force_generated(true)
+    if (needIterWrap) {
+        emission = qmacro($e(emission).to_sequence_move())
+    }
+    return emission
+}
+
 [macro_function]
 def private plan_zip(var expr : Expression?) : Expression? {
     // Phase 2 Z1/Z2/Z3 + accumulator/early-exit: 2-ary lockstep zip splice. Supports bare zip (array/iterator), no-pred count/long_count + accumulator (sum/min/max/average) + early-exit (first/first_or_default/any/all/contains) terminators, and fused where_/select/take/skip/take_while/skip_while chain ops between zip and terminator. Result-selector form (3-arg zip) and chained selects bail to tier-2 cascade.
@@ -4424,7 +4794,12 @@ class private LinqFold : AstCallMacro {
         macro_verify(call.arguments |> length == 1, prog, call.at, "expecting _fold(expression)")
         macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting linq expression")
         // Tier 1 splice — try the dedicated order-family planner first (handles
-        var res : Expression? = plan_order_family(call.arguments[0])
+        // Slice 5d: decs-bridge planners run BEFORE their array-side equivalents.
+        var res : Expression? = plan_decs_order_family(call.arguments[0])
+        if (res != null) return res
+        res = plan_order_family(call.arguments[0])
+        if (res != null) return res
+        res = plan_decs_reverse(call.arguments[0])
         if (res != null) return res
         res = plan_reverse(call.arguments[0])
         if (res != null) return res

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -4213,7 +4213,15 @@ def private plan_decs_order_family(var expr : Expression?) : Expression? {
             $b(bodyStmts)
         }))
     } elif (firstName == "first_or_default") {
-        // No min_by_or_default helper exists; route through top_n*(_, 1, _) + first_or_default for the empty-buf case.
+        // No min_by_or_default helper exists; route through top_n*(_, 1, _) + first_or_default for the empty-buf case. The default expression is hoisted into a let BEFORE for_each_archetype so its side effects fire ahead of iteration (matches plan_decs_reverse's first_or_default + the eager-arg-eval semantics of the non-spliced chain).
+        let dBindName = "`order_d`{at.line}`{at.column}"
+        var foDStmts : array<Expression?>
+        foDStmts |> reserve(4)
+        foDStmts |> push <| qmacro_expr() {
+            let $i(dBindName) = $e(firstDefaultExpr)
+        }
+        foDStmts |> push(bodyStmts[0])
+        foDStmts |> push(bodyStmts[1])
         var topNCall : Expression?
         if (inlineCmp != null) {
             topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), 1, $e(inlineCmp)))
@@ -4222,11 +4230,11 @@ def private plan_decs_order_family(var expr : Expression?) : Expression? {
         } else {
             topNCall = qmacro($c(topNName)($i(bufName), 1))
         }
-        bodyStmts |> push <| qmacro_expr() {
-            return _::first_or_default($e(topNCall), $e(firstDefaultExpr))
+        foDStmts |> push <| qmacro_expr() {
+            return _::first_or_default($e(topNCall), $i(dBindName))
         }
         emission = qmacro(invoke($() : $t(elemType) {
-            $b(bodyStmts)
+            $b(foDStmts)
         }))
     } elif (takeExpr == null) {
         // Bare order family — sort buffer in place and return.
@@ -4794,8 +4802,7 @@ class private LinqFold : AstCallMacro {
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(call.arguments |> length == 1, prog, call.at, "expecting _fold(expression)")
         macro_verify(call.arguments[0]._type != null, prog, call.at, "expecting linq expression")
-        // Tier 1 splice — try the dedicated order-family planner first (handles
-        // Slice 5d: decs-bridge planners run BEFORE their array-side equivalents.
+        // Decs-bridge planners run BEFORE their array-side equivalents (Slice 5d cascade rule — decs planners have stricter guards; running them second lets the generic planner match on the eager-bridge invoke and silently emit the slow shape).
         var res : Expression? = plan_decs_order_family(call.arguments[0])
         if (res != null) return res
         res = plan_order_family(call.arguments[0])

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -1651,3 +1651,379 @@ def test_unroll5e_groupby_count_splice_shape(t : T?) {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 5d: order_by / order_by_descending / reverse on decs (buffer arms)
+// ─────────────────────────────────────────────────────────────────────────────
+
+[decs_template(prefix = "unroll5d_")]
+struct Unroll5dRow {
+    id    : int
+    price : int
+    flag  : int
+}
+
+def private fixture_unroll5d() {
+    restart()
+    // 7 rows. price (jumbled walk-order so order_by must actually sort): 30,10,50,20,40,5,35.
+    // flag pattern: even-id => 1, odd-id => 0.
+    let prices = fixed_array(30, 10, 50, 20, 40, 5, 35)
+    for (i in range(7)) {
+        create_entity() @(eid, cmp) {
+            cmp.eid := eid
+            cmp.unroll5d_id := i
+            cmp.unroll5d_price := prices[i]
+            cmp.unroll5d_flag := (i % 2 == 0) ? 1 : 0
+        }
+    }
+    commit()
+}
+
+// ── order_by + to_array (bare sort) ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_to_array_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._order_by(_.price).to_array())
+}
+
+[test]
+def test_unroll5d_order_by_to_array_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_order_by_to_array_fold()
+    t |> equal(got.length(), 7)
+    // sorted ascending by price: 5,10,20,30,35,40,50.
+    let expected = [5, 10, 20, 30, 35, 40, 50]
+    for (i in range(7)) {
+        t |> equal(got[i].price, expected[i])
+    }
+}
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_desc_to_array_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._order_by_descending(_.price).to_array())
+}
+
+[test]
+def test_unroll5d_order_by_desc_to_array_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_order_by_desc_to_array_fold()
+    t |> equal(got.length(), 7)
+    let expected = [50, 40, 35, 30, 20, 10, 5]
+    for (i in range(7)) {
+        t |> equal(got[i].price, expected[i])
+    }
+}
+
+// ── order_by + take ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_take3_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._order_by(_.price).take(3).to_array())
+}
+
+[test]
+def test_unroll5d_order_by_take_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_order_by_take3_fold()
+    t |> equal(got.length(), 3)
+    let expected = [5, 10, 20]
+    for (i in range(3)) {
+        t |> equal(got[i].price, expected[i])
+    }
+}
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_desc_take3_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._order_by_descending(_.price).take(3).to_array())
+}
+
+[test]
+def test_unroll5d_order_by_desc_take_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_order_by_desc_take3_fold()
+    t |> equal(got.length(), 3)
+    let expected = [50, 40, 35]
+    for (i in range(3)) {
+        t |> equal(got[i].price, expected[i])
+    }
+}
+
+// ── order_by + first ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_first_fold() : tuple<id : int; price : int; flag : int> {
+    return _fold(from_decs_template(type<Unroll5dRow>)._order_by(_.price).first())
+}
+
+[test]
+def test_unroll5d_order_by_first_parity(t : T?) {
+    fixture_unroll5d()
+    t |> equal(target_unroll5d_order_by_first_fold().price, 5)
+}
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_desc_first_fold() : tuple<id : int; price : int; flag : int> {
+    return _fold(from_decs_template(type<Unroll5dRow>)._order_by_descending(_.price).first())
+}
+
+[test]
+def test_unroll5d_order_by_desc_first_parity(t : T?) {
+    fixture_unroll5d()
+    t |> equal(target_unroll5d_order_by_desc_first_fold().price, 50)
+}
+
+// ── order_by + first_or_default ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_order_by_first_or_default_fold() : tuple<id : int; price : int; flag : int> {
+    return _fold(from_decs_template(type<Unroll5dRow>)._order_by(_.price).first_or_default((id = -1, price = -99, flag = -1)))
+}
+
+[test]
+def test_unroll5d_order_by_first_or_default_nonempty(t : T?) {
+    fixture_unroll5d()
+    t |> equal(target_unroll5d_order_by_first_or_default_fold().price, 5)
+}
+
+[test]
+def test_unroll5d_order_by_first_or_default_empty(t : T?) {
+    restart()
+    commit()
+    t |> equal(target_unroll5d_order_by_first_or_default_fold().price, -99, "empty decs source → default")
+}
+
+// ── where + order_by + take ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_where_order_by_take_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._where(_.flag == 1)._order_by(_.price).take(2).to_array())
+}
+
+[test]
+def test_unroll5d_where_order_by_take_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_where_order_by_take_fold()
+    // flag==1 rows: ids 0,2,4,6 → prices 30,50,40,35. Sorted asc: 30,35,40,50. take(2) → 30,35.
+    t |> equal(got.length(), 2)
+    t |> equal(got[0].price, 30)
+    t |> equal(got[1].price, 35)
+}
+
+// ── where + order_by + first ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_where_order_by_first_fold() : tuple<id : int; price : int; flag : int> {
+    return _fold(from_decs_template(type<Unroll5dRow>)._where(_.flag == 1)._order_by(_.price).first())
+}
+
+[test]
+def test_unroll5d_where_order_by_first_parity(t : T?) {
+    fixture_unroll5d()
+    // flag==1 rows: prices 30,50,40,35 → min = 30.
+    t |> equal(target_unroll5d_where_order_by_first_fold().price, 30)
+}
+
+// ── reverse + to_array ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_reverse_to_array_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>).reverse().to_array())
+}
+
+[test]
+def test_unroll5d_reverse_to_array_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_reverse_to_array_fold()
+    // Decs walk order is archetype-dependent. We don't assert exact order vs the eager bridge — we assert .reverse() produces the SAME multiset reversed wrt a non-reverse fold. Cheap check: length + presence of all ids.
+    t |> equal(got.length(), 7)
+    var idsSeen : table<int>
+    for (r in got) {
+        idsSeen |> insert(r.id)
+    }
+    for (i in range(7)) {
+        t |> success(key_exists(idsSeen, i), "id {i} present")
+    }
+}
+
+// ── reverse + take ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_reverse_take_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>).reverse().take(3).to_array())
+}
+
+[test]
+def test_unroll5d_reverse_take_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_reverse_take_fold()
+    t |> equal(got.length(), 3, "reverse + take(3) yields 3 rows")
+}
+
+[test]
+def test_unroll5d_reverse_take_beyond_length(t : T?) {
+    fixture_unroll5d()
+    let huge = _fold(from_decs_template(type<Unroll5dRow>).reverse().take(99).to_array())
+    t |> equal(huge.length(), 7, "take(N>length) returns all rows reversed")
+}
+
+[test]
+def test_unroll5d_reverse_take_zero(t : T?) {
+    fixture_unroll5d()
+    // Runtime-0 take expression: a const-folded `take(0)` literal trips PERF017 on the splice-emitted resize formula (`takeB < length(buf)` collapses to `0 < length(buf)`).
+    var zeroN = 0  // nolint:LINT003 — kept as var to defeat const-fold of the take(N) arg
+    let zero = _fold(from_decs_template(type<Unroll5dRow>).reverse().take(zeroN).to_array())
+    t |> success(empty(zero), "take(0) returns empty")
+}
+
+// ── reverse + count (identity — counter loop) ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_reverse_count_fold() : int {
+    return _fold(from_decs_template(type<Unroll5dRow>).reverse().count())
+}
+
+[test]
+def test_unroll5d_reverse_count_parity(t : T?) {
+    fixture_unroll5d()
+    t |> equal(target_unroll5d_reverse_count_fold(), 7)
+}
+
+// ── reverse + first (= last of source) ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_where_reverse_first_or_default_fold() : tuple<id : int; price : int; flag : int> {
+    return _fold(from_decs_template(type<Unroll5dRow>)._where(_.flag == 1).reverse().first_or_default((id = -1, price = -99, flag = -1)))
+}
+
+[test]
+def test_unroll5d_where_reverse_first_or_default_empty(t : T?) {
+    restart()
+    commit()
+    t |> equal(target_unroll5d_where_reverse_first_or_default_fold().id, -1, "empty decs source → default")
+}
+
+[test]
+def test_unroll5d_where_reverse_first_or_default_nonempty(t : T?) {
+    fixture_unroll5d()
+    // flag==1 ids = {0,2,4,6}; last-encountered (reverse-of-first) is the maximum encountered id in archetype walk order. We only assert it's one of the flag==1 ids.
+    let id = target_unroll5d_where_reverse_first_or_default_fold().id
+    t |> success(id == 0 || id == 2 || id == 4 || id == 6, "first-of-reverse(flag==1) is one of the matching ids")
+}
+
+// ── where + reverse + to_array ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_where_reverse_to_array_fold() : array<tuple<id : int; price : int; flag : int>> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._where(_.flag == 1).reverse().to_array())
+}
+
+[test]
+def test_unroll5d_where_reverse_to_array_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_where_reverse_to_array_fold()
+    t |> equal(got.length(), 4)
+    for (r in got) {
+        t |> equal(r.flag, 1)
+    }
+}
+
+// ── where + select + reverse + to_array (projection through reverse) ──
+
+[export, marker(no_coverage)]
+def target_unroll5d_where_select_reverse_to_array_fold() : array<int> {
+    return <- _fold(from_decs_template(type<Unroll5dRow>)._where(_.flag == 1)._select(_.id).reverse().to_array())
+}
+
+[test]
+def test_unroll5d_where_select_reverse_to_array_parity(t : T?) {
+    fixture_unroll5d()
+    let got <- target_unroll5d_where_select_reverse_to_array_fold()
+    t |> equal(got.length(), 4, "4 flag==1 rows projected to id")
+    var idsSeen : table<int>
+    for (id in got) {
+        idsSeen |> insert(id)
+    }
+    for (expectedId in [0, 2, 4, 6]) {
+        t |> success(key_exists(idsSeen, expectedId), "id {expectedId} present in projection")
+    }
+}
+
+// ── AST shape gates ──
+
+[test]
+def test_unroll5d_order_by_take_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll5d_order_by_take3_fold)
+        t |> success(func != null, "RTTI must resolve target")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "order_by+take splice must NOT fall to tier-2 to_sequence (cascade ordering trap)")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype (no eager-bridge wrapping)")
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 0, "order family uses for_each_archetype (no early-exit needed)")
+        // Buffer hoisted ABOVE for_each_archetype so it survives the archetype walk.
+        t |> success(describe_count(body_expr, "decs_buf") >= 2, "decs_buf declared + populated")
+        // top_n_by call replaces the array-side to_array / sort sequence.
+        t |> equal(describe_count(body_expr, "top_n_by"), 1, "splice dispatches to top_n_by")
+    }
+}
+
+[test]
+def test_unroll5d_order_by_first_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll5d_order_by_first_fold)
+        t |> success(func != null, "RTTI must resolve target")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "qmatch must capture body")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "order_by+first splice must NOT fall to tier-2 to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype")
+        // first → min_by on the buffer (NOT top_n_by + index).
+        t |> equal(describe_count(body_expr, "min_by"), 1, "order_by+first emits min_by call")
+        t |> equal(describe_count(body_expr, "top_n_by"), 0, "order_by+first should NOT use top_n_by")
+        // Empty-buffer panic guard present.
+        t |> equal(describe_count(body_expr, "sequence contains no elements"), 1, "panic-on-empty guard for first()")
+    }
+}
+
+[test]
+def test_unroll5d_reverse_to_array_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll5d_reverse_to_array_fold)
+        t |> success(func != null, "RTTI must resolve target")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "qmatch must capture body")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "reverse splice must NOT fall to tier-2 to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype")
+        t |> equal(describe_count(body_expr, "reverse_inplace"), 1, "buffer reversed via reverse_inplace")
+    }
+}
+
+[test]
+def test_unroll5d_reverse_count_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll5d_reverse_count_fold)
+        t |> success(func != null, "RTTI must resolve target")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "qmatch must capture body")
+        // reverse+count → counter loop, NO buffer, NO reverse_inplace.
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "reverse+count splice must NOT fall to tier-2 to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype")
+        t |> equal(describe_count(body_expr, "reverse_inplace"), 0, "reverse is identity for count — no reverse_inplace")
+        t |> equal(describe_count(body_expr, "decs_buf"), 0, "no buffer needed for count")
+    }
+}
+

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -1791,6 +1791,33 @@ def test_unroll5d_order_by_first_or_default_empty(t : T?) {
     t |> equal(target_unroll5d_order_by_first_or_default_fold().price, -99, "empty decs source → default")
 }
 
+// Eval-order invariant: the splice must evaluate the first_or_default default expression BEFORE the for_each_archetype loop, matching plan_decs_reverse's first_or_default hoist + the eager-arg-eval semantics of the equivalent non-spliced chain. Detected via a side-effecting predicate that flips a global flag during iter and a side-effecting default that snapshots the flag.
+var g_eval_order_iter_seen : bool = false
+var g_eval_order_default_saw_iter : bool = false
+def trace_pred_for_eval_order(rec : tuple<id : int; price : int; flag : int>) : bool {
+    g_eval_order_iter_seen = true
+    return rec.flag == 1
+}
+def trace_default_for_eval_order() : tuple<id : int; price : int; flag : int> {
+    g_eval_order_default_saw_iter = g_eval_order_iter_seen
+    return (id = -1, price = -99, flag = -1)
+}
+
+[test]
+def test_unroll5d_order_by_first_or_default_eval_order(t : T?) {
+    fixture_unroll5d()
+    g_eval_order_iter_seen = false
+    g_eval_order_default_saw_iter = true
+    let got = _fold(
+        from_decs_template(type<Unroll5dRow>)
+            ._where(trace_pred_for_eval_order(_))
+            ._order_by(_.price)
+            .first_or_default(trace_default_for_eval_order())
+    )
+    t |> equal(g_eval_order_default_saw_iter, false, "default arg evaluated before for_each_archetype iteration")
+    t |> equal(got.flag, 1, "non-empty: top-1 by price among flag==1 returned")
+}
+
 // ── where + order_by + take ──
 
 [export, marker(no_coverage)]

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -1874,6 +1874,22 @@ def test_unroll5d_reverse_take_zero(t : T?) {
     t |> success(empty(zero), "take(0) returns empty")
 }
 
+// Side-effecting take(N) source — the splice must evaluate the take expression EXACTLY ONCE.
+var g_take_call_count = 0
+def bump_take_count() : int {
+    g_take_call_count ++
+    return 3
+}
+
+[test]
+def test_unroll5d_reverse_take_single_eval(t : T?) {
+    fixture_unroll5d()
+    g_take_call_count = 0
+    let got <- _fold(from_decs_template(type<Unroll5dRow>).reverse().take(bump_take_count()).to_array())
+    t |> equal(got.length(), 3, "take(N) honored — 3 rows")
+    t |> equal(g_take_call_count, 1, "take(N) expression evaluated exactly once (no multi-eval from splice clones)")
+}
+
 // ── reverse + count (identity — counter loop) ──
 
 [export, marker(no_coverage)]


### PR DESCRIPTION
## Summary

Two new decs-bridge splice planners in `daslib/linq_fold.das`, inserted in `LinqFold.visit` BEFORE their array-side equivalents per the [cascade-ordering rule](https://github.com/GaijinEntertainment/daScript/pull/2775#issuecomment-2890847238) (decs planner has the stricter `extract_decs_bridge` guard, so it doesn't grab array chains; running it second causes the generic planner to match on the eager-bridge invoke and silently emit the slow shape).

- **`plan_decs_order_family`** — recognizes `[where_*][order|order_descending|order_by|order_by_descending][take(N)|first|first_or_default(d)]?`. Always uses a hoisted buffer above `for_each_archetype` (decs has no random access for the array side's no-where direct-call path), then dispatches to the same daslib helpers — `order_inplace` / `top_n*` / `min_by` / `max_by` / `first_or_default(top_n*(_,1,_), d)`. Bails on the comparator form `order(arr, cmp)` (matches array side; helpers can't honor a user-supplied cmp).
- **`plan_decs_reverse`** — recognizes `[where_*][select?][reverse][take(N)?][count|first|first_or_default(d)]?`. Three emit paths mirror the array side:
  - `count` terminator → counter loop, no buffer (reverse is identity for count; side-effecting projection still fires)
  - `first` / `first_or_default` → walk + overwrite `last` (reverse-of-last surviving = first-of-reverse)
  - else → buffer fill + `_::reverse_inplace(buf)` + optional `resize(takeN)` + return
  - R6 backward-index optimization from array side does NOT apply: multi-iter for has no random access into the archetype.

Cascade insert at `LinqFold.visit`: `plan_decs_order_family` → `plan_order_family` → `plan_decs_reverse` → `plan_reverse` → ...

## Bench delta (100K rows, INTERP)

| benchmark | shape | m1 sql | m3 | m3f (array) | m4 (old) | m4 (new) | win |
|---|---|---:|---:|---:|---:|---:|---:|
| sort_take                | `_order_by + take` | 38 | 713 | 28 | 119 | **57** | 2.1× |
| sort_first               | `_order_by + first` | 37 | 711 | 41 | 121 | **71** | 1.7× |
| order_take_desc          | `_order_by_descending + take` | 37 | 694 | 28 | 117 | **58** | 2.0× |
| select_where_order_take  | `_where + _order_by + take` | 36 | 352 | 25 | 102 | **38** | 2.7× |
| bare_order_where         | `_where + _order_by` | 274 | 359 | 118 | 196 | **130** | 1.5× |
| reverse_take             | `.reverse().take(N)` | 0 | 22 | 0 | 114 | **48** | 2.4× |

Average 2.1× across 6 benches. The remaining gap to m3f is the Wave 4 multi-component `get_ro` overhead (every bridge component participates in the inner for-loop even when the chain only reads one). `bare_order_where` is the tightest squeeze because sort dominates the wall-clock — once buffer-build matches m3f (~117 ns), the rest is pure sort time.

## Tests

`tests/linq/test_linq_from_decs.das` +20 tests (100 → 120 in file):
- bare `_order_by` / `_order_by_descending` + `to_array`
- `_order_by` / `_order_by_descending` + `take(N)`
- `_order_by` / `_order_by_descending` + `first` (parity)
- `_order_by` + `first_or_default` (nonempty + empty → default)
- `_where + _order_by + take`
- `_where + _order_by + first`
- `.reverse() + to_array` (multiset preservation check; archetype walk-order isn't load-bearing)
- `.reverse() + take(N)` (in-range, beyond-length, zero — last uses runtime var to defeat const-fold of PERF017 false-positive on splice-emitted `0 &lt; length(buf)`)
- `.reverse() + count` (counter loop, no buffer)
- `_where + .reverse() + first_or_default` (empty + nonempty)
- `_where + .reverse() + to_array`
- `_where + _select + .reverse() + to_array` (projection through reverse)
- 4 AST shape gates: order+take (top_n_by emit, no to_sequence, 1 for_each_archetype), order+first (min_by emit, panic-on-empty guard, no top_n_by), reverse+to_array (1 reverse_inplace), reverse+count (no decs_buf, no reverse_inplace)

## Verification

- `mcp__daslang__compile_check` clean on touched files
- `mcp__daslang__lint` + `bin/daslang ./utils/lint/main.das` (CI gate) both clean on touched files
- `mcp__daslang__format_file` clean
- `mcp__daslang__run_test` on full linq suite: 17 files, 1257 interp tests all green
- `tests/decs` regression check (queries / templates / comprehensive): green
- `test_aot` rebuild + full linq AOT sweep: 1309/1309 AOT tests green

## Test plan

- [ ] CI: build matrix passes (interp + AOT + JIT × Linux/Mac/Win)
- [ ] CI: lint gate passes
- [ ] No regressions in `tests/linq/test_linq.das` / `test_linq_sorting.das` / `test_linq_from_decs.das`

🤖 Generated with [Claude Code](https://claude.com/claude-code)