### PR TITLE
libhv: bump pin to upstream master 5da5fc22 (trie router fix for #2675)

### DIFF
--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -73,12 +73,10 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 			"-DCMAKE_CXX_FLAGS=${_HV_ASAN_FLAG}"
 		)
 	ENDIF()
-	# TODO: switch back to ithewei/libhv upstream tag once
-	# https://github.com/ithewei/libhv/pull/835 is merged.
 	ExternalProject_Add(
 		LIBHV
-		URL https://github.com/aleksisch/libhv/archive/343437b72fbd0f348abb168d61fe7f1c6c4f4d20.tar.gz
-		URL_HASH SHA256=1b809d55dc1a637aafecb25e717c4ab302a6733390f43b32244976d6583cd866
+		URL https://github.com/ithewei/libhv/archive/5da5fc22cdfd1b59ba2b0520abb34f95d050975c.tar.gz
+		URL_HASH SHA256=b4f774936ccd6981df74b23f9e033e0b3ab584f6682d889490377dc9450b5f54
 		DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 		PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libhv
 		CMAKE_ARGS ${HV_CMAKE_FLAGS}

--- a/tests/dasHV/test_server_routes.das
+++ b/tests/dasHV/test_server_routes.das
@@ -2,7 +2,8 @@
 //
 // Covers: GET/POST/PUT/DELETE/PATCH/HEAD/ANY routes, TEXT_PLAIN, JSON,
 //         path params (:id), query params (get_param, each_param),
-//         set_header on response, get_header on request
+//         set_header on response, get_header on request,
+//         wildcard ANY("*") priority vs literal routes (#2675 regression).
 
 options gen2
 options persistent_heap
@@ -88,7 +89,7 @@ class RouteTestServer : HvWebServer {
 
 [test]
 def test_get_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("GET route returns text") @(t : T?) {
             GET("{base_url}/hello") <| $(resp) {
                 t |> equal(string(resp.body), "Hello, world!")
@@ -100,7 +101,7 @@ def test_get_route(t : T?) {
 
 [test]
 def test_post_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("POST route echoes body") @(t : T?) {
             POST("{base_url}/echo", "hello server") <| $(resp) {
                 t |> equal(string(resp.body), "hello server")
@@ -111,7 +112,7 @@ def test_post_route(t : T?) {
 
 [test]
 def test_put_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("PUT route receives body") @(t : T?) {
             PUT("{base_url}/resource", "updated") <| $(resp) {
                 t |> equal(string(resp.body), "PUT:updated")
@@ -122,7 +123,7 @@ def test_put_route(t : T?) {
 
 [test]
 def test_patch_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("PATCH route receives body") @(t : T?) {
             PATCH("{base_url}/resource", "partial") <| $(resp) {
                 t |> equal(string(resp.body), "PATCH:partial")
@@ -133,7 +134,7 @@ def test_patch_route(t : T?) {
 
 [test]
 def test_delete_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("DELETE route works") @(t : T?) {
             with_http_request() <| $(var req) {
                 req.method = http_method.DELETE
@@ -148,7 +149,7 @@ def test_delete_route(t : T?) {
 
 [test]
 def test_head_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("HEAD route sets headers, no body") @(t : T?) {
             with_http_request() <| $(var req) {
                 req.method = http_method.HEAD
@@ -165,7 +166,7 @@ def test_head_route(t : T?) {
 
 [test]
 def test_any_route(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("ANY route handles GET") @(t : T?) {
             GET("{base_url}/any-method") <| $(resp) {
                 t |> success(find(string(resp.body), "method:") >= 0, "body contains method info")
@@ -181,7 +182,7 @@ def test_any_route(t : T?) {
 
 [test]
 def test_path_params(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("single path param") @(t : T?) {
             GET("{base_url}/users/42") <| $(resp) {
                 t |> equal(string(resp.body), "user:42")
@@ -197,7 +198,7 @@ def test_path_params(t : T?) {
 
 [test]
 def test_query_params_server(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("query params accessible via each_param") @(t : T?) {
             GET("{base_url}/search?q=daslang&page=1") <| $(resp) {
                 let body = string(resp.body)
@@ -210,7 +211,7 @@ def test_query_params_server(t : T?) {
 
 [test]
 def test_response_headers_server(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("set_header on response") @(t : T?) {
             GET("{base_url}/headers") <| $(resp) {
                 let custom = get_header(resp, "X-Custom")
@@ -224,7 +225,7 @@ def test_response_headers_server(t : T?) {
 
 [test]
 def test_json_response_server(t : T?) {
-    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) <| $(base_url) {
+    with_test_server(type<RouteTestServer>, PORT_SERVER_ROUTES) $(base_url) {
         t |> run("JSON response with correct content-type") @(t : T?) {
             GET("{base_url}/api/status") <| $(resp) {
                 let ct = get_header(resp, "Content-Type")
@@ -238,6 +239,53 @@ def test_json_response_server(t : T?) {
                         delete parsed
                     }
                 }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Wildcard priority — regression for #2675
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Before libhv PR #836 (trie router), pathHandlers was an unordered_map
+// and HttpService::GetRoute iterated in container order, taking the first
+// wildcard or path match it found. ANY("*") could enumerate before
+// specific paths like /status, so every request hit the catch-all
+// (POSIX libstdc++ reliably, Windows MSVC intermittently). Symptom in
+// daslang-live: /shutdown never reached request_exit(); driver popen
+// hung the full 120s watchdog. See GaijinEntertainment/daScript#2675.
+//
+// libhv master (≥ 5da5fc22) replaces pathHandlers with a trie that
+// enforces Literal > Param > Wildcard. This test pins the contract.
+
+class WildcardPriorityServer : HvWebServer {
+    def override onInit {
+        GET("/status") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> TEXT_PLAIN("specific")
+        }
+        ANY("*") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> TEXT_PLAIN("catchall")
+        }
+    }
+}
+
+[test]
+def test_wildcard_priority(t : T?) {
+    with_test_server(type<WildcardPriorityServer>, 19009) $(base_url) {
+        t |> run("literal GET /status outranks ANY *") @(t : T?) {
+            GET("{base_url}/status") <| $(resp) {
+                t |> equal(string(resp.body), "specific")
+            }
+        }
+        t |> run("ANY * catches unknown GET paths") @(t : T?) {
+            GET("{base_url}/unknown") <| $(resp) {
+                t |> equal(string(resp.body), "catchall")
+            }
+        }
+        t |> run("ANY * catches unknown POST paths") @(t : T?) {
+            POST("{base_url}/unknown", "") <| $(resp) {
+                t |> equal(string(resp.body), "catchall")
             }
         }
     }


### PR DESCRIPTION
## Summary

- Bump libhv pin from `aleksisch/libhv@343437b7` (fork) to `ithewei/libhv@5da5fc22` (upstream master, 2026-05-21).
- Picks up upstream [ithewei/libhv#836](https://github.com/ithewei/libhv/pull/836) — replaces `HttpService::pathHandlers` (`std::unordered_map`) with a trie that enforces **Literal > Param > Wildcard** priority. Fixes #2675.
- Also picks up upstream [ithewei/libhv#835](https://github.com/ithewei/libhv/pull/835) (localtime → localtime_r), which was the reason we were on the `aleksisch/libhv` fork to begin with.
- New regression test `test_wildcard_priority` in `tests/dasHV/test_server_routes.das` pins the contract.

## Why #2675 was broken

libhv v1.3.4 stored routes in `std::unordered_map<std::string, ...>` and `GetRoute` iterated in container order, taking the first wildcard or path match. When `ANY("*")` was registered alongside specific paths like `/status`, hash-bucket layout (POSIX libstdc++ reliably, Windows MSVC intermittently) could enumerate `*` before `/status`, so every request hit the catch-all. In daslang-live this meant `/shutdown` never reached `request_exit()` and the driver popen hung the full 120s watchdog.

The new `HttpRouter::Match`:
```cpp
return Find(path, handler) ||              // Literal (exact)
       MatchParam(path, handler, params) || // RESTful :id / {id}
       MatchWildcard(path, handler);        // *
```
is deterministic regardless of insertion order.

## Test plan

- [x] `tests/dasHV` suite: 136/136 PASS locally (was 133/133 — 3 new sub-tests under `test_wildcard_priority`).
- [x] Lint clean on `tests/dasHV/test_server_routes.das` (incidentally cleaned 11 pre-existing STYLE001 hits on `with_test_server(...) <| $(base_url)` to keep the file PR-gate-green).
- [x] Format-verify on full tree (pre-push hook): 4586 files OK.
- [ ] CI matrix (Ubuntu / macOS / Windows extended_checks).

## Not touched (deliberate)

PR #2688's workaround in `modules/dasLiveHost/live/live_api.das` (`GET("/")` instead of `ANY("*")` for the help endpoint) is no longer load-bearing now that the upstream router is fixed, but reverting it changes user-visible behavior (unknown paths return 404 vs help JSON). Leaving the decision separate.

Closes #2675