### PR TITLE
pages.yml: disable dasGlfw in host_daslang sub-build

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -138,6 +138,11 @@ ExternalProject_Add(host_daslang
                      -DCMAKE_BUILD_TYPE:STRING=Release
                      -DDAS_LLVM_DISABLED:BOOL=OFF
                      -DDAS_PUGIXML_DISABLED:BOOL=OFF
+                     # dasGlfw pulls find_package(OpenGL REQUIRED) at configure
+                     # time. The pages.yml runner doesn't apt-install OpenGL
+                     # dev libs, and this sub-build is tooling-only (drives
+                     # .das→wasm codegen via dasLLVM — no graphics needed).
+                     -DDAS_GLFW_DISABLED:BOOL=ON
     BUILD_COMMAND    ${CMAKE_COMMAND} --build <BINARY_DIR> --target daslang --parallel)
 
 # Cross-compile web playground example scripts to wasm32 via host daslang.


### PR DESCRIPTION
## Summary

- `web/CMakeLists.txt`'s `ExternalProject_Add(host_daslang)` (added in #2643) configures with default modules, which pulls `dasGlfw` → `find_package(OpenGL REQUIRED)`.
- `wasm_build.yml`'s `wasm_cross` job apt-installs OpenGL/GLFW dev libs for this. `pages.yml` does not.
- Result: `pages.yml`'s WASM step silently fails (`continue-on-error: true`), then the `Stage site` step sees no `web/output/daslang_static.{js,wasm}` and ships [`site/playground/placeholder.html`](https://github.com/GaijinEntertainment/daScript/blob/master/site/playground/placeholder.html) — which is what's currently live at https://daslang.io/playground/.
- The `host_daslang` sub-build is tooling-only (drives `.das`→`.wasm` codegen via dasLLVM); no graphics modules needed. Add `-DDAS_GLFW_DISABLED:BOOL=ON` to its `CMAKE_CACHE_ARGS` — same pattern as pages.yml's earlier `Build: Daslang (for das2rst)` step.

## Repro from the failed run

Pages run [26230107523](https://github.com/GaijinEntertainment/daScript/actions/runs/26230107523), `Build WASM (Emscripten)` step:

```
FAILED: host_daslang-prefix/src/host_daslang-stamp/host_daslang-configure
CMake Error at .../FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY ...)
-- Configuring incomplete, errors occurred!
ninja: build stopped: subcommand failed.
##[error]Process completed with exit code 1.
```

## Test plan

- [ ] CI: `Deploy to GitHub Pages` succeeds — the WASM step completes without OpenGL find_package failure.
- [ ] After deploy, https://daslang.io/playground/ loads the real IDE (not `placeholder.html`).
- [ ] `daslang_static.wasm` is served from /playground/ and /files/wasm/.
- [ ] `wasm_build.yml` (separately) still builds — it apt-installs OpenGL libs in `wasm_cross`, so unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)