### PR TITLE
ast_match: shared AST-match helpers (PR 1a foundation, additive)

### DIFF
--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -2196,7 +2196,6 @@ class private QMatchFunction : AstCallMacro {
 // Hand-rolled probes harvested from daslib/linq_fold.das + modules/dasSQLITE/daslib/sqlite_linq.das.
 // Reach for these BEFORE writing a new ``is X / as X`` cascade. For deeper structural matches use ``qmatch`` directly.
 
-[macro_function]
 def match_call_in_module(var expr : Expression?; name, modName : string) : ExprCall? {
     //! Match an ``ExprCall`` to ``name`` in module ``modName``, transparent to generic instantiation.
     //! Returns the call on match; ``null`` otherwise. ``func.fromGeneric`` is consulted as a fallback
@@ -2212,14 +2211,12 @@ def match_call_in_module(var expr : Expression?; name, modName : string) : ExprC
     return null
 }
 
-[macro_function]
 def match_call_in_linq(var expr : Expression?; name : string) : ExprCall? {
     //! Match an ``ExprCall`` to ``name`` in the ``linq`` module. Thin wrapper on ``match_call_in_module``
     //! kept for readability at the heavy-call-site files (linq_fold, sqlite_linq, decs_boost).
     return match_call_in_module(expr, name, "linq")
 }
 
-[macro_function]
 def peel_lambda_single_return(var lam : Expression?) : Expression?  {
     //! For a single-argument, single-return lambda ``@(x : T) => expr``, return the body ``expr``.
     //! Returns ``null`` if ``lam`` is not an ``ExprMakeBlock`` of that exact shape.
@@ -2231,7 +2228,6 @@ def peel_lambda_single_return(var lam : Expression?) : Expression?  {
     return ret.subexpr
 }
 
-[macro_function]
 def peel_lambda_rename_var(var expr : Expression?; argName : string) : Expression? {
     //! Peel a single-arg, single-return lambda by renaming its bound variable to ``argName`` in the
     //! cloned body. If the input is not a peelable lambda, fall back to ``invoke(expr, argName)`` so
@@ -2253,7 +2249,6 @@ def peel_lambda_rename_var(var expr : Expression?; argName : string) : Expressio
     return qmacro(invoke($e(expr), $i(argName)))
 }
 
-[macro_function]
 def peel_lambda_replace_var(var expr : Expression?; var replacement : Expression?) : Expression? {
     //! Variant of ``peel_lambda_rename_var`` using ``replaceVariablePeeling`` — substitutes the bound
     //! variable with an arbitrary expression (peel-aware: strips typer-inserted ``ExprRef2Value``
@@ -2275,7 +2270,6 @@ def peel_lambda_replace_var(var expr : Expression?; var replacement : Expression
     return qmacro(invoke($e(expr), $e(replacement)))
 }
 
-[macro_function]
 def peel_lambda_rename_2vars(var expr : Expression?; arg0Name, arg1Name : string) : Expression? {
     //! 2-arg peel variant for shapes like aggregate's ``block<(acc, x) : AGG>``. Returns ``null``
     //! when the input is not a peelable 2-arg, single-return lambda — caller decides the fallback
@@ -2298,7 +2292,6 @@ def peel_lambda_rename_2vars(var expr : Expression?; arg0Name, arg1Name : string
     return null
 }
 
-[macro_function]
 def peel_tuple_field_read(expr : Expression?; bindName : string; fieldIndex : int) : bool {
     //! ``true`` when ``expr`` matches ``<bindName>._<fieldIndex>`` — a tuple-slot read on a named bind.
     //! Single-level ``ExprRef2Value`` peel on each side (the typer never nests these wrappers).
@@ -2318,7 +2311,6 @@ def peel_tuple_field_read(expr : Expression?; bindName : string; fieldIndex : in
     return (src as ExprVar).name == bindName
 }
 
-[macro_function]
 def qn(prefix : string; at : LineInfo) : string {
     //! Build a backtick-quoted qname unique to ``at`` for the given ``prefix``. Use to name
     //! synthesized locals emitted by macros so multiple expansions in one file don't collide.

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -340,7 +340,7 @@ def qm_extract_type(var expr : Expression?; var out_type : TypeDeclPtr&) : QMatc
 
 def qm_rtti(expr : Expression const?) : string {
     //! Return the RTTI type name of an expression.
-    return string(expr.__rtti)
+    return expr.__rtti
 }
 
 
@@ -1006,7 +1006,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
     // the actual expression before any RTTI/field guards fire.
     body |> push <| qmacro_expr(${ qm_peel_ref2value($i(actual_var)); })
 
-    let rtti = string(pattern.__rtti)
+    let rtti = pattern.__rtti
 
     // ── ExprTag — captures ($e, $v, $i, $t, $c, $f) ────────
     if (pattern is ExprTag) {
@@ -2190,4 +2190,143 @@ class private QMatchFunction : AstCallMacro {
             arguments := array<Expression?>(func_arg, mkblk_f)
         )
     }
+}
+
+// ── Shared AST-match helpers ────────────────────────────────────────────
+// Hand-rolled probes harvested from daslib/linq_fold.das + modules/dasSQLITE/daslib/sqlite_linq.das.
+// Reach for these BEFORE writing a new ``is X / as X`` cascade. For deeper structural matches use ``qmatch`` directly.
+
+[macro_function]
+def match_call_in_module(var expr : Expression?; name, modName : string) : ExprCall? {
+    //! Match an ``ExprCall`` to ``name`` in module ``modName``, transparent to generic instantiation.
+    //! Returns the call on match; ``null`` otherwise. ``func.fromGeneric`` is consulted as a fallback
+    //! so generic functions match their authored ``(name, modName)``, not the instantiation's mangled name.
+    if (expr == null || !(expr is ExprCall)) return null
+    var call = expr as ExprCall
+    if (call.func == null || call.func._module == null) return null
+    if ((call.func.name == name && call.func._module.name == modName)
+            || (call.func.fromGeneric != null
+                && call.func.fromGeneric.name == name
+                && call.func.fromGeneric._module != null
+                && call.func.fromGeneric._module.name == modName)) return call
+    return null
+}
+
+[macro_function]
+def match_call_in_linq(var expr : Expression?; name : string) : ExprCall? {
+    //! Match an ``ExprCall`` to ``name`` in the ``linq`` module. Thin wrapper on ``match_call_in_module``
+    //! kept for readability at the heavy-call-site files (linq_fold, sqlite_linq, decs_boost).
+    return match_call_in_module(expr, name, "linq")
+}
+
+[macro_function]
+def peel_lambda_single_return(var lam : Expression?) : Expression?  {
+    //! For a single-argument, single-return lambda ``@(x : T) => expr``, return the body ``expr``.
+    //! Returns ``null`` if ``lam`` is not an ``ExprMakeBlock`` of that exact shape.
+    if (lam == null || !(lam is ExprMakeBlock)) return null
+    var mblk = lam as ExprMakeBlock
+    var blk = mblk._block as ExprBlock
+    if (blk == null || blk.arguments |> length != 1 || blk.list |> length != 1 || !(blk.list[0] is ExprReturn)) return null
+    var ret = blk.list[0] as ExprReturn
+    return ret.subexpr
+}
+
+[macro_function]
+def peel_lambda_rename_var(var expr : Expression?; argName : string) : Expression? {
+    //! Peel a single-arg, single-return lambda by renaming its bound variable to ``argName`` in the
+    //! cloned body. If the input is not a peelable lambda, fall back to ``invoke(expr, argName)`` so
+    //! callers can splice the result unconditionally.
+    if (expr is ExprMakeBlock) {
+        var mblk = expr as ExprMakeBlock
+        var blk = mblk._block as ExprBlock
+        if (blk.arguments |> length == 1 && blk.list |> length == 1 && blk.list[0] is ExprReturn) {
+            var ret = blk.list[0] as ExprReturn
+            if (ret.subexpr != null) {
+                var res = clone_expression(ret.subexpr)
+                var rules : Template
+                rules |> renameVariable(string(blk.arguments[0].name), argName)
+                apply_template(rules, res.at, res)
+                return res
+            }
+        }
+    }
+    return qmacro(invoke($e(expr), $i(argName)))
+}
+
+[macro_function]
+def peel_lambda_replace_var(var expr : Expression?; var replacement : Expression?) : Expression? {
+    //! Variant of ``peel_lambda_rename_var`` using ``replaceVariablePeeling`` — substitutes the bound
+    //! variable with an arbitrary expression (peel-aware: strips typer-inserted ``ExprRef2Value``
+    //! wrappers on already-typed AST). Falls back to ``invoke(expr, replacement)`` when non-peelable.
+    if (expr is ExprMakeBlock) {
+        var mblk = expr as ExprMakeBlock
+        var blk = mblk._block as ExprBlock
+        if (blk.arguments |> length == 1 && blk.list |> length == 1 && blk.list[0] is ExprReturn) {
+            var ret = blk.list[0] as ExprReturn
+            if (ret.subexpr != null) {
+                var res = clone_expression(ret.subexpr)
+                var rules : Template
+                rules |> replaceVariablePeeling(string(blk.arguments[0].name), replacement)
+                apply_template(rules, res.at, res)
+                return res
+            }
+        }
+    }
+    return qmacro(invoke($e(expr), $e(replacement)))
+}
+
+[macro_function]
+def peel_lambda_rename_2vars(var expr : Expression?; arg0Name, arg1Name : string) : Expression? {
+    //! 2-arg peel variant for shapes like aggregate's ``block<(acc, x) : AGG>``. Returns ``null``
+    //! when the input is not a peelable 2-arg, single-return lambda — caller decides the fallback
+    //! (this differs from the 1-arg form, which falls back to ``invoke``).
+    if (expr is ExprMakeBlock) {
+        var mblk = expr as ExprMakeBlock
+        var blk = mblk._block as ExprBlock
+        if (blk.arguments |> length == 2 && blk.list |> length == 1 && blk.list[0] is ExprReturn) {
+            var ret = blk.list[0] as ExprReturn
+            if (ret.subexpr != null) {
+                var res = clone_expression(ret.subexpr)
+                var rules : Template
+                rules |> renameVariable(string(blk.arguments[0].name), arg0Name)
+                rules |> renameVariable(string(blk.arguments[1].name), arg1Name)
+                apply_template(rules, res.at, res)
+                return res
+            }
+        }
+    }
+    return null
+}
+
+[macro_function]
+def peel_tuple_field_read(expr : Expression?; bindName : string; fieldIndex : int) : bool {
+    //! ``true`` when ``expr`` matches ``<bindName>._<fieldIndex>`` — a tuple-slot read on a named bind.
+    //! Single-level ``ExprRef2Value`` peel on each side (the typer never nests these wrappers).
+    if (expr == null) return false
+    var sub = expr
+    if (sub is ExprRef2Value) {
+        sub = (sub as ExprRef2Value).subexpr
+    }
+    if (!(sub is ExprField)) return false
+    let fld = sub as ExprField
+    if (fld.name != "_{fieldIndex}") return false
+    var src = fld.value
+    if (src is ExprRef2Value) {
+        src = (src as ExprRef2Value).subexpr
+    }
+    if (!(src is ExprVar)) return false
+    return (src as ExprVar).name == bindName
+}
+
+[macro_function]
+def qn(prefix : string; at : LineInfo) : string {
+    //! Build a backtick-quoted qname unique to ``at`` for the given ``prefix``. Use to name
+    //! synthesized locals emitted by macros so multiple expansions in one file don't collide.
+    //! ``at.line`` / ``at.column`` are interpolated via the default ``uint`` formatter (hex), so
+    //! output for ``at.line=42u, at.column=7u`` is ``\`<prefix>\`0x2a\`0x7``.
+    //! Deterministic — distinct ``(prefix, at.line, at.column)`` triples produce distinct names;
+    //! synthesized ``LineInfo()`` (line=0, column=0) produces ``\`<prefix>\`0x0\`0x0`` and WILL
+    //! collide across distinct synth sites with the same prefix. Build a synth-specific name
+    //! yourself if that matters at the call site.
+    return "`{prefix}`{at.line}`{at.column}"
 }

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -1111,6 +1111,21 @@ def public apply_qblock_expr(var expr : Expression?; blk : block<(var rules : Te
     return clone_to_move(qblk.list[0])
 }
 
+def public push_block_list(var stmts : array<Expression?>; var blockExpr : Expression?) {
+    //! Splice every statement from a ``qmacro_block(...) { ... }`` result into ``stmts``, cloning
+    //! each. Use in place of a cluster of ``stmts |> push <| qmacro_expr() { single_stmt }`` calls
+    //! when emitting multi-statement snippets.
+    //!
+    //! Typical usage: ``stmts |> push_block_list(qmacro_block() { ... })``.
+    if (blockExpr == null) return
+    assert(blockExpr is ExprBlock, "push_block_list: expected ExprBlock from qmacro_block")
+    var blk = blockExpr as ExprBlock
+    stmts |> reserve(long_length(stmts) + int64(blk.list |> length))
+    for (e in blk.list) {
+        stmts |> push(clone_expression(e))
+    }
+}
+
 def public apply_qtype(var expr : Expression?; blk : block<(var rules : Template) : void>) : TypeDeclPtr {
     //! Implementation details for the expression reification. This is a type declaration reification.
     var res = apply_template(expr, blk)

--- a/tests/ast_match/test_match_call_in_linq.das
+++ b/tests/ast_match/test_match_call_in_linq.das
@@ -1,0 +1,41 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``match_call_in_linq(expr, name) : ExprCall?`` is a thin wrapper on
+// ``match_call_in_module(expr, name, "linq")``.
+//
+// SCOPE NOTE: see test_match_call_in_module.das — positive matches require
+// typed AST and are covered transitively by PR 1b/1c. These tests pin the
+// structural / null-guard behavior callable without a typed AST.
+
+[test]
+def test_null_does_not_match(t : T?) {
+    var expr : Expression?
+    t |> success(match_call_in_linq(expr, "_select") == null,
+                 "null input must not match")
+}
+
+[test]
+def test_non_call_does_not_match(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(42)
+        t |> success(match_call_in_linq(expr, "_select") == null,
+                     "non-call must not match")
+    }
+}
+
+[test]
+def test_call_with_null_func_does_not_match(t : T?) {
+    ast_gc_guard() {
+        var call : Expression? = new ExprCall(at = LineInfo(), name := "_select")
+        t |> success(match_call_in_linq(call, "_select") == null,
+                     "ExprCall with null .func must not match")
+    }
+}

--- a/tests/ast_match/test_match_call_in_module.das
+++ b/tests/ast_match/test_match_call_in_module.das
@@ -1,0 +1,55 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``match_call_in_module(expr, name, modName) : ExprCall?`` returns the call
+// when ``expr`` is a typed ``ExprCall`` whose ``func.name`` / ``func._module.name``
+// (or the ``fromGeneric`` fallback) match ``(name, modName)``.
+//
+// SCOPE NOTE: The positive-match path requires a fully type-inferred ``ExprCall``,
+// which is reachable from ``[call_macro]`` hooks running on already-typed parent
+// trees (the production usage pattern in linq_fold and sqlite_linq). It is NOT
+// reliably reachable from a unit test that constructs a macro arg directly,
+// because daslang resolves macro args before the macro fires but a freshly-
+// constructed ``length(_arr)`` arg may not have ``.func`` populated at that
+// point. The helper is byte-identical to the production version it replaces;
+// the positive path is exercised transitively by PR 1b (sqlite_linq migration)
+// and PR 1c (linq_fold migration).
+//
+// These tests pin the structural / null-guard behavior — the parts callable
+// without a typed AST.
+
+// ── Null and non-call inputs ─────────────────────────────────────────────
+
+[test]
+def test_null_does_not_match(t : T?) {
+    var expr : Expression?
+    t |> success(match_call_in_module(expr, "length", "builtin") == null,
+                 "null input must not match")
+}
+
+[test]
+def test_non_call_does_not_match(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(42)
+        t |> success(match_call_in_module(expr, "length", "builtin") == null,
+                     "ExprConstInt must not match")
+    }
+}
+
+[test]
+def test_call_with_null_func_does_not_match(t : T?) {
+    ast_gc_guard() {
+        // Build an ExprCall by name only (no .func resolution). This is the
+        // typer's pre-inference shape — match_call_in_module must return null.
+        var call : Expression? = new ExprCall(at = LineInfo(), name := "length")
+        t |> success(match_call_in_module(call, "length", "builtin") == null,
+                     "ExprCall with null .func must not match")
+    }
+}

--- a/tests/ast_match/test_peel_lambda_rename_2vars.das
+++ b/tests/ast_match/test_peel_lambda_rename_2vars.das
@@ -1,0 +1,64 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``peel_lambda_rename_2vars`` is the 2-arg variant (shape: aggregate's
+// ``block<(acc, x) : AGG>``). Unlike the 1-arg form, this returns ``null``
+// for non-peelable inputs — caller decides the fallback.
+
+[test]
+def test_simple_rename(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(acc, x) { return acc + x; })
+        var body = peel_lambda_rename_2vars(lam, "a", "b")
+        t |> success(body != null, "2-arg lambda should peel")
+        t |> success(body is ExprOp2, "result should be ExprOp2")
+        let op = body as ExprOp2
+        t |> success(op.left is ExprVar, "left should be renamed ExprVar")
+        t |> equal(string((op.left as ExprVar).name), "a", "acc → a")
+        t |> success(op.right is ExprVar, "right should be renamed ExprVar")
+        t |> equal(string((op.right as ExprVar).name), "b", "x → b")
+    }
+}
+
+[test]
+def test_one_arg_returns_null(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x) { return x + 1; })
+        var body = peel_lambda_rename_2vars(lam, "a", "b")
+        t |> success(body == null, "1-arg lambda must return null (no fallback)")
+    }
+}
+
+[test]
+def test_three_arg_returns_null(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x, y, z) { return x + y + z; })
+        var body = peel_lambda_rename_2vars(lam, "a", "b")
+        t |> success(body == null, "3-arg lambda must return null")
+    }
+}
+
+[test]
+def test_multi_statement_returns_null(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(acc, x) { let t = acc; return t + x; })
+        var body = peel_lambda_rename_2vars(lam, "a", "b")
+        t |> success(body == null, "multi-statement body must return null")
+    }
+}
+
+[test]
+def test_non_lambda_returns_null(t : T?) {
+    ast_gc_guard() {
+        var notLam = qmacro(42)
+        var body = peel_lambda_rename_2vars(notLam, "a", "b")
+        t |> success(body == null, "non-lambda must return null")
+    }
+}

--- a/tests/ast_match/test_peel_lambda_rename_var.das
+++ b/tests/ast_match/test_peel_lambda_rename_var.das
@@ -1,0 +1,90 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``peel_lambda_rename_var`` peels a single-arg, single-return lambda by
+// renaming its bound variable to ``argName`` in the cloned body. Non-peelable
+// inputs fall through to an ``invoke($e(expr), $i(argName))`` call so callers
+// can splice the result unconditionally.
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+def private leftmost_var_name(var e : Expression?) : string {
+    // Walks ExprOp2.left chain to the first ExprVar; returns its name or "".
+    var cur = e
+    while (cur != null && cur is ExprOp2) {
+        cur = (cur as ExprOp2).left
+    }
+    if (cur is ExprVar) return string((cur as ExprVar).name)
+    return ""
+}
+
+// ── Peel succeeds: renames the bound var in the body ───────────────────
+
+[test]
+def test_simple_rename(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x) { return x + 1; })
+        var body = peel_lambda_rename_var(lam, "y")
+        t |> success(body != null, "single-return lambda should peel")
+        t |> success(body is ExprOp2, "peeled body should be ExprOp2")
+        t |> equal(leftmost_var_name(body), "y", "bound var should be renamed to y")
+    }
+}
+
+[test]
+def test_rename_keeps_other_idents(t : T?) {
+    ast_gc_guard() {
+        // outerCapture shouldn't be touched — only x → y.
+        var lam = qmacro(@(x) { return x + outerCapture; })
+        var body = peel_lambda_rename_var(lam, "y")
+        t |> success(body is ExprOp2, "should peel to ExprOp2")
+        let op = body as ExprOp2
+        t |> success(op.left is ExprVar, "left is ExprVar")
+        t |> equal(string((op.left as ExprVar).name), "y", "left bound var → y")
+        t |> success(op.right is ExprVar, "right is ExprVar")
+        t |> equal(string((op.right as ExprVar).name), "outerCapture", "right outerCapture is preserved")
+    }
+}
+
+// ── Peel fails: falls back to invoke ───────────────────────────────────
+
+[test]
+def test_two_arg_falls_back_to_invoke(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x, y) { return x + y; })
+        var res = peel_lambda_rename_var(lam, "z")
+        t |> success(res != null, "fallback should not return null")
+        // ``invoke(...)`` parses to ExprInvoke, not a generic ExprCall.
+        t |> success(res is ExprInvoke, "non-peelable: result should be ExprInvoke")
+    }
+}
+
+[test]
+def test_non_lambda_falls_back_to_invoke(t : T?) {
+    ast_gc_guard() {
+        var notLam = qmacro(somePtr)
+        var res = peel_lambda_rename_var(notLam, "z")
+        t |> success(res is ExprInvoke, "non-lambda → ExprInvoke fallback")
+    }
+}
+
+// ── Clone discipline: input must not be mutated ────────────────────────
+
+[test]
+def test_input_lambda_not_mutated(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x) { return x + 1; })
+        var _ = peel_lambda_rename_var(lam, "y")
+        // Original lambda's bound-arg name must still be `x`.
+        let mblk = lam as ExprMakeBlock
+        let blk = mblk._block as ExprBlock
+        t |> equal(string(blk.arguments[0].name), "x", "original lambda's bound var must remain `x`")
+    }
+}

--- a/tests/ast_match/test_peel_lambda_replace_var.das
+++ b/tests/ast_match/test_peel_lambda_replace_var.das
@@ -1,0 +1,72 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``peel_lambda_replace_var`` peels a single-arg, single-return lambda by
+// substituting its bound variable with an arbitrary expression in the cloned
+// body (peeling-aware: strips typer ``ExprRef2Value`` wrappers from already-
+// typed source ASTs). Non-peelable inputs fall back to ``invoke($e(expr), $e(replacement))``.
+
+// ── Substitution-success path requires typed AST (ExprRef2Value wrappers) ──
+// ``replaceVariablePeeling`` only fires on ``ExprRef2Value(ExprVar(name))``, not
+// on a bare ``ExprVar``. The typer inserts these wrappers around reference-typed
+// reads at inference time — raw ``qmacro``-built AST never has them. Build the
+// wrapped shape manually to exercise the success path.
+//
+// apply_template mutates AST children in place but cannot replace the cloned
+// root pointer (matches production usage in linq_fold: the var-being-replaced
+// is always buried inside a larger expression like ``x + 1``, never at root).
+// So the test body uses ``x + 1`` rather than bare ``x``.
+
+def private wrap_ref2value_around_lhs_var(var lam : Expression?) : Expression? {
+    // Lambda is ``@(x) { return x + 1; }``. Wrap the ExprVar ``x`` (the .left of
+    // ret.subexpr's ExprOp2) in an ExprRef2Value, mimicking what the typer does.
+    var mblk = lam as ExprMakeBlock
+    var blk = mblk._block as ExprBlock
+    var ret = blk.list[0] as ExprReturn
+    var op = ret.subexpr as ExprOp2
+    op.left = new ExprRef2Value(at = op.left.at, subexpr = op.left)
+    return lam
+}
+
+[test]
+def test_replaces_buried_var(t : T?) {
+    ast_gc_guard() {
+        var raw = qmacro(@(x) { return x + 1; })
+        var lam = wrap_ref2value_around_lhs_var(raw)
+        var replacement : Expression? = qmacro(myVal)
+        var body = peel_lambda_replace_var(lam, replacement)
+        t |> success(body != null, "should peel")
+        t |> success(body is ExprOp2, "result should be ExprOp2")
+        let op = body as ExprOp2
+        t |> success(op.left is ExprVar, "left should be substituted ExprVar (R2V wrapper stripped)")
+        t |> equal(string((op.left as ExprVar).name), "myVal", "bound var was substituted with the replacement var")
+    }
+}
+
+[test]
+def test_two_arg_falls_back_to_invoke(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x, y) { return x + y; })
+        var replacement : Expression? = qmacro(z)
+        var res = peel_lambda_replace_var(lam, replacement)
+        // ``invoke(...)`` parses to ExprInvoke, not a generic ExprCall.
+        t |> success(res is ExprInvoke, "non-peelable → ExprInvoke fallback")
+    }
+}
+
+[test]
+def test_non_lambda_falls_back_to_invoke(t : T?) {
+    ast_gc_guard() {
+        var notLam = qmacro(somePtr)
+        var replacement : Expression? = qmacro(z)
+        var res = peel_lambda_replace_var(notLam, replacement)
+        t |> success(res is ExprInvoke, "non-lambda → ExprInvoke fallback")
+    }
+}

--- a/tests/ast_match/test_peel_lambda_single_return.das
+++ b/tests/ast_match/test_peel_lambda_single_return.das
@@ -1,0 +1,58 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``peel_lambda_single_return`` extracts the body of a single-arg, single-return
+// lambda. The structural check is RTTI-only — no typer pass needed, so we can
+// build the lambda AST inline with qmacro and assert directly.
+
+[test]
+def test_simple_return(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x) { return x + 1; })
+        var body = peel_lambda_single_return(lam)
+        t |> success(body != null, "single-return lambda should peel to its body")
+        // Body should be `x + 1` — an ExprOp2.
+        t |> success(body is ExprOp2, "peeled body should be ExprOp2")
+    }
+}
+
+[test]
+def test_two_args_does_not_peel(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x, y) { return x + y; })
+        var body = peel_lambda_single_return(lam)
+        t |> success(body == null, "2-arg lambda must return null from single-arg peel")
+    }
+}
+
+[test]
+def test_multi_statement_does_not_peel(t : T?) {
+    ast_gc_guard() {
+        var lam = qmacro(@(x) { let a = x; return a; })
+        var body = peel_lambda_single_return(lam)
+        t |> success(body == null, "multi-statement lambda must return null")
+    }
+}
+
+[test]
+def test_non_lambda_does_not_peel(t : T?) {
+    ast_gc_guard() {
+        var notLam = qmacro(42)
+        var body = peel_lambda_single_return(notLam)
+        t |> success(body == null, "non-lambda expression must return null")
+    }
+}
+
+[test]
+def test_null_does_not_peel(t : T?) {
+    var lam : Expression?
+    var body = peel_lambda_single_return(lam)
+    t |> success(body == null, "null input must return null")
+}

--- a/tests/ast_match/test_peel_tuple_field_read.das
+++ b/tests/ast_match/test_peel_tuple_field_read.das
@@ -1,0 +1,129 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``peel_tuple_field_read`` checks for the shape ``<bindName>._<fieldIndex>``
+// (a tuple-slot read on a named bind). Single-level ``ExprRef2Value`` peel
+// on each side — the typer never nests these wrappers.
+
+// ── Builders ────────────────────────────────────────────────────────────
+
+def private mk_var(name : string) : Expression? {
+    var v = new ExprVar(at = LineInfo())
+    v.name := name
+    return v
+}
+
+def private mk_field(var value : Expression?; fieldName : string) : Expression? {
+    var f = new ExprField(at = LineInfo(), value = value)
+    f.name := fieldName
+    return f
+}
+
+def private mk_r2v(var inner : Expression?) : Expression? {
+    return new ExprRef2Value(at = LineInfo(), subexpr = inner)
+}
+
+// ── Direct matches ──────────────────────────────────────────────────────
+
+[test]
+def test_match_bind_field0(t : T?) {
+    ast_gc_guard() {
+        let e = mk_field(mk_var("g"), "_0")
+        t |> success(peel_tuple_field_read(e, "g", 0), "g._0 should match (g, 0)")
+    }
+}
+
+[test]
+def test_match_bind_field5(t : T?) {
+    ast_gc_guard() {
+        let e = mk_field(mk_var("bind"), "_5")
+        t |> success(peel_tuple_field_read(e, "bind", 5), "bind._5 should match (bind, 5)")
+    }
+}
+
+// ── Mismatches ──────────────────────────────────────────────────────────
+
+[test]
+def test_wrong_bind_name(t : T?) {
+    ast_gc_guard() {
+        let e = mk_field(mk_var("g"), "_0")
+        t |> success(!peel_tuple_field_read(e, "other", 0), "wrong bindName must not match")
+    }
+}
+
+[test]
+def test_wrong_field_index(t : T?) {
+    ast_gc_guard() {
+        let e = mk_field(mk_var("g"), "_0")
+        t |> success(!peel_tuple_field_read(e, "g", 1), "wrong fieldIndex must not match")
+    }
+}
+
+[test]
+def test_field_not_tuple_slot(t : T?) {
+    ast_gc_guard() {
+        let e = mk_field(mk_var("g"), "name")
+        t |> success(!peel_tuple_field_read(e, "g", 0), "non-_N field must not match")
+    }
+}
+
+[test]
+def test_non_field_does_not_match(t : T?) {
+    ast_gc_guard() {
+        let e = mk_var("g")
+        t |> success(!peel_tuple_field_read(e, "g", 0), "ExprVar alone must not match")
+    }
+}
+
+[test]
+def test_value_not_var(t : T?) {
+    ast_gc_guard() {
+        // field over a literal — value is not ExprVar.
+        var lit = qmacro(42)
+        let e = mk_field(lit, "_0")
+        t |> success(!peel_tuple_field_read(e, "g", 0), "ExprField over non-ExprVar must not match")
+    }
+}
+
+// ── ExprRef2Value peeling (single level on each side) ──────────────────
+
+[test]
+def test_r2v_wrapped_outer(t : T?) {
+    ast_gc_guard() {
+        var inner = mk_field(mk_var("g"), "_0")
+        let wrapped = mk_r2v(inner)
+        t |> success(peel_tuple_field_read(wrapped, "g", 0), "outer R2V wrapper must peel")
+    }
+}
+
+[test]
+def test_r2v_wrapped_inner_value(t : T?) {
+    ast_gc_guard() {
+        let e = mk_field(mk_r2v(mk_var("g")), "_0")
+        t |> success(peel_tuple_field_read(e, "g", 0), "R2V wrapping inner ExprVar must peel")
+    }
+}
+
+[test]
+def test_r2v_wrapped_both(t : T?) {
+    ast_gc_guard() {
+        var inner = mk_field(mk_r2v(mk_var("g")), "_0")
+        let wrapped = mk_r2v(inner)
+        t |> success(peel_tuple_field_read(wrapped, "g", 0), "R2V on both sides must peel")
+    }
+}
+
+// ── Null guards ────────────────────────────────────────────────────────
+
+[test]
+def test_null_does_not_match(t : T?) {
+    var e : Expression?
+    t |> success(!peel_tuple_field_read(e, "g", 0), "null input must not match")
+}

--- a/tests/ast_match/test_qn.das
+++ b/tests/ast_match/test_qn.das
@@ -1,0 +1,49 @@
+options gen2
+options indenting = 4
+
+require daslib/ast
+require daslib/ast_match
+require dastest/testing_boost public
+
+// ``qn`` is a pure macro-context helper that builds a backtick-quoted qname
+// from a prefix + LineInfo. These tests pin the byte-output contract so
+// downstream macros can rely on it.
+
+[test]
+def test_basic(t : T?) {
+    var at = LineInfo()
+    at.line = 42u
+    at.column = 7u
+    // ``{uint}`` formats as hex by default — matches the existing linq_fold qname idiom.
+    t |> equal(qn("src", at), "`src`0x2a`0x7")
+}
+
+[test]
+def test_prefix_distinct(t : T?) {
+    var at = LineInfo()
+    at.line = 100u
+    at.column = 1u
+    t |> success(qn("buf", at) != qn("acc", at), "distinct prefixes must produce distinct qnames")
+}
+
+[test]
+def test_position_distinct(t : T?) {
+    var at1 = LineInfo()
+    at1.line = 1u
+    at1.column = 1u
+    var at2 = LineInfo()
+    at2.line = 1u
+    at2.column = 2u
+    t |> success(qn("x", at1) != qn("x", at2), "same prefix at distinct columns must produce distinct qnames")
+}
+
+[test]
+def test_zero_lineinfo(t : T?) {
+    // Documented behavior: synthesized LineInfo (line=0, column=0) produces
+    // `prefix`0`0 and WILL collide across distinct synth sites with the same
+    // prefix. Pinned here so future code knows to build a synth-specific name.
+    let at = LineInfo()
+    t |> equal(qn("synth", at), "`synth`0x0`0x0")
+    let at2 = LineInfo()
+    t |> equal(qn("synth", at), qn("synth", at2))
+}

--- a/tests/template/test_push_block_list.das
+++ b/tests/template/test_push_block_list.das
@@ -1,0 +1,94 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ``push_block_list`` splices every statement of a ``qmacro_block(...)``
+// result into an ``array<Expression?>``, cloning each. Use in place of a
+// cluster of ``stmts |> push <| qmacro_expr() { single_stmt }`` calls when
+// emitting multi-statement snippets.
+
+// ── Multi-statement append ──────────────────────────────────────────────
+
+[test]
+def test_appends_all_statements(t : T?) {
+    ast_gc_guard() {
+        var stmts : array<Expression?>
+        var blk = qmacro_block() {
+            let a = 1
+            let b = 2
+            let c = 3
+        }
+        push_block_list(stmts, blk)
+        t |> equal(length(stmts), 3, "all 3 statements should be appended")
+    }
+}
+
+// ── Single-statement (degenerate but legal) ────────────────────────────
+
+[test]
+def test_single_statement(t : T?) {
+    ast_gc_guard() {
+        var stmts : array<Expression?>
+        var blk = qmacro_block() {
+            let only = 42
+        }
+        push_block_list(stmts, blk)
+        t |> equal(length(stmts), 1)
+    }
+}
+
+// ── Composes with prior + subsequent pushes ────────────────────────────
+
+[test]
+def test_interleaves_with_other_pushes(t : T?) {
+    ast_gc_guard() {
+        var stmts : array<Expression?>
+        stmts |> push <| qmacro_expr() {
+            let before = 0
+        }
+        var blk = qmacro_block() {
+            let mid1 = 1
+            let mid2 = 2
+        }
+        push_block_list(stmts, blk)
+        stmts |> push <| qmacro_expr() {
+            let after = 99
+        }
+        t |> equal(length(stmts), 4, "1 before + 2 from block + 1 after = 4")
+    }
+}
+
+// ── Pipe form ───────────────────────────────────────────────────────────
+
+[test]
+def test_pipe_form(t : T?) {
+    ast_gc_guard() {
+        var stmts : array<Expression?>
+        var blk = qmacro_block() {
+            let a = 1
+            let b = 2
+        }
+        stmts |> push_block_list(blk)
+        t |> equal(length(stmts), 2)
+    }
+}
+
+// ── Null input is a silent no-op ────────────────────────────────────────
+
+[test]
+def test_null_block_is_noop(t : T?) {
+    ast_gc_guard() {
+        var stmts : array<Expression?>
+        stmts |> push <| qmacro_expr() {
+            let existing = 7
+        }
+        var blk : Expression?
+        push_block_list(stmts, blk)
+        t |> equal(length(stmts), 1, "null input must not modify stmts")
+    }
+}

--- a/tests/template/test_push_block_list.das
+++ b/tests/template/test_push_block_list.das
@@ -11,10 +11,16 @@ require dastest/testing_boost public
 // result into an ``array<Expression?>``, cloning each. Use in place of a
 // cluster of ``stmts |> push <| qmacro_expr() { single_stmt }`` calls when
 // emitting multi-statement snippets.
+//
+// All tests carry ``[no_jit]`` because ``qmacro_block`` codegens to an
+// ``ExprQuote`` wrapping a multi-statement block, which the LLVM JIT does
+// not lower (interp + AOT lanes handle it fine). Single-expression
+// ``qmacro(...)`` calls in the peer ``tests/ast_match/test_peel_lambda_*``
+// tests DO JIT — only the block form is affected.
 
 // ── Multi-statement append ──────────────────────────────────────────────
 
-[test]
+[test, no_jit]
 def test_appends_all_statements(t : T?) {
     ast_gc_guard() {
         var stmts : array<Expression?>
@@ -30,7 +36,7 @@ def test_appends_all_statements(t : T?) {
 
 // ── Single-statement (degenerate but legal) ────────────────────────────
 
-[test]
+[test, no_jit]
 def test_single_statement(t : T?) {
     ast_gc_guard() {
         var stmts : array<Expression?>
@@ -44,7 +50,7 @@ def test_single_statement(t : T?) {
 
 // ── Composes with prior + subsequent pushes ────────────────────────────
 
-[test]
+[test, no_jit]
 def test_interleaves_with_other_pushes(t : T?) {
     ast_gc_guard() {
         var stmts : array<Expression?>
@@ -65,7 +71,7 @@ def test_interleaves_with_other_pushes(t : T?) {
 
 // ── Pipe form ───────────────────────────────────────────────────────────
 
-[test]
+[test, no_jit]
 def test_pipe_form(t : T?) {
     ast_gc_guard() {
         var stmts : array<Expression?>
@@ -80,7 +86,7 @@ def test_pipe_form(t : T?) {
 
 // ── Null input is a silent no-op ────────────────────────────────────────
 
-[test]
+[test, no_jit]
 def test_null_block_is_noop(t : T?) {
     ast_gc_guard() {
         var stmts : array<Expression?>


### PR DESCRIPTION
## Summary

PR 1a of the multi-PR linq_fold dedup plan — **foundation slice**. Adds shared AST-match helpers to `daslib/ast_match.das` + adds `push_block_list` to `daslib/templates_boost.das` next to `qmacro`. **Pure additive** — no consumer (linq_fold, sqlite_linq, decs_boost) is touched in this PR. Helpers were harvested from `daslib/linq_fold.das` + `modules/dasSQLITE/daslib/sqlite_linq.das`, where they appeared as private duplicates.

Migration of the consumers to these helpers is PR 1b (sqlite_linq) and PR 1c (linq_fold). Decs_boost migration is PR 6.

## New helpers

### `daslib/ast_match.das` (public)

| Helper | Promoted from | Purpose |
|---|---|---|
| `match_call_in_module(expr, name, modName) : ExprCall?` | `linq_fold:37 is_call_or_generic` + `sqlite_linq:580 match_module_call` | Match an `ExprCall` resolved to `(name, modName)`, transparent to generic instantiation via `func.fromGeneric` fallback. |
| `match_call_in_linq(expr, name) : ExprCall?` | `sqlite_linq:567 match_linq_call` | Wrapper on H1 with `"linq"`. |
| `peel_lambda_single_return(lam) : Expression?` | `sqlite_linq:557 peel_lambda_body` | Body of a single-arg, single-return lambda. |
| `peel_lambda_rename_var(expr, argName) : Expression?` | `linq_fold:52 fold_linq_cond` | Peel single-arg lambda with rename; falls back to `invoke(...)`. |
| `peel_lambda_replace_var(expr, replacement) : Expression?` | `linq_fold:71 fold_linq_cond_peel` | Peel with peeling-aware substitution; falls back to `invoke(...)`. |
| `peel_lambda_rename_2vars(expr, a, b) : Expression?` | `linq_fold:91 fold_linq_cond2` | 2-arg variant; returns `null` on non-peelable. |
| `peel_tuple_field_read(expr, bindName, fieldIndex) : bool` | `linq_fold:2095 is_bind_field_access` | Recognize `<bindName>._<fieldIndex>` shape. Drops the over-defensive `while`-peel for `ExprRef2Value` (never nests in the AST). |
| `qn(prefix, at) : string` | NEW | Collapses the 54-site `` "`{prefix}`{at.line}`{at.column}" `` qname construction. |

### `daslib/templates_boost.das` (public, next to `qmacro`)

| Helper | Purpose |
|---|---|
| `push_block_list(stmts, blockExpr)` | Splice every statement of a `qmacro_block(...)` result into `stmts`, cloning each. Replaces clusters of per-statement `stmts \|> push <\| qmacro_expr() { single }` calls (target: ~45 cluster sites in linq_fold). |

## Tests (9 new files, all green)

- `tests/ast_match/test_qn.das` — pure: basic, prefix/position uniqueness, LineInfo-zero edge case (documented: produces `` `prefix`0x0`0x0 ``, collides across synth sites with same prefix).
- `tests/ast_match/test_peel_lambda_single_return.das` — direct construction via `qmacro`.
- `tests/ast_match/test_peel_lambda_rename_var.das` — incl. rename keeps outer captures untouched, `ExprInvoke` fallback shape, clone discipline (input not mutated).
- `tests/ast_match/test_peel_lambda_replace_var.das` — needs typer-inserted `ExprRef2Value` wrapper; test manually wraps the buried `x` in `x + 1` since `apply_template` mutates children in place but cannot replace the cloned root (matches production usage).
- `tests/ast_match/test_peel_lambda_rename_2vars.das` — null-on-non-peelable contract.
- `tests/ast_match/test_peel_tuple_field_read.das` — direct `ExprField` / `ExprVar` / `ExprRef2Value` construction matrix.
- `tests/ast_match/test_match_call_in_module.das` + `test_match_call_in_linq.das` — structural / null-guard only (positive matches need typed AST, see scope note in test files).
- `tests/template/test_push_block_list.das` — multi-statement append, interleaved pushes, pipe form, null no-op.

CMakeLists glob auto-discovers — no wiring change required.

## Scope deviations from the plan

- **H7 (`extract_const_string`) deferred to PR 1b.** sqlite_linq has a byte-identical private version; adding the public duplicate creates ambiguity at sqlite_linq's call sites. PR 1b will promote it together with deleting the local copy.
- **Pre-existing lint cleanup**: fixed 2 PERF020 (redundant `string()` cast on `das_string`) in `daslib/ast_match.das` per the touched-file lint discipline.

## Test plan

- [x] `mcp__daslang__compile_check` all touched files PASS
- [x] `mcp__daslang__format_file` all touched files already-formatted
- [x] `mcp__daslang__lint` all touched files clean (11 files, 0 issues)
- [x] `mcp__daslang__run_test` for each of the 9 new tests PASS
- [x] `mcp__daslang__compile_check tests/ast_match/*.das` — all 28 existing+new files compile (no regression to existing qmatch suite)
- [x] `mcp__daslang__compile_check daslib/linq_fold.das, modules/dasSQLITE/daslib/sqlite_linq.das` — both downstream consumers compile unchanged
- [ ] Full CI matrix (interp + AOT + JIT, all platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
