### PR TITLE
pages.yml: update web/ui → web/examples/ui in Stage site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -137,14 +137,14 @@ jobs:
         if [ -f web/output/daslang_static.js ] && [ -f web/output/daslang_static.wasm ]; then
             mkdir -p _site/playground _site/files/wasm
             # Copy IDE source files (CodeMirror, jQuery, main.js/css, etc.)
-            cp -r web/ui/src/* _site/playground/
+            cp -r web/examples/ui/src/* _site/playground/
             # Copy WASM artifacts — known-present after the guard above.
             cp web/output/daslang_static.js _site/playground/
             cp web/output/daslang_static.wasm _site/playground/
             cp web/output/daslang_static.js _site/files/wasm/
             cp web/output/daslang_static.wasm _site/files/wasm/
             # Copy sample data if present
-            cp -r web/ui/samples _site/playground/samples 2>/dev/null || true
+            cp -r web/examples/ui/samples _site/playground/samples 2>/dev/null || true
             # Our Forge-skinned playground/index.html + skin CSS + init shim take precedence.
             # CodeMirror bundle (codemirror.min.js/css, simple-mode.js, daslang-*.js,
             # cm-forge.css) is served from /files/cm/ — copied via `cp -r site/files`


### PR DESCRIPTION
## Summary

Follow-up to #2789. With the WASM build now succeeding, the `Stage site for deployment` step in [.github/workflows/pages.yml](.github/workflows/pages.yml) enters the "ship real /playground/" branch and immediately exits 1:

```
+ cp -r 'web/ui/src/*' _site/playground/
cp: cannot stat 'web/ui/src/*': No such file or directory
##[error]Process completed with exit code 1.
```

PR #2643 moved `web/ui/` → `web/examples/ui/` in [web/CMakeLists.txt](web/CMakeLists.txt) but didn't update pages.yml's shell stage step, which still references the old paths.

Update both `cp -r web/ui/src/*` and `cp -r web/ui/samples` to `web/examples/ui/...`.

## Failing run

[Run 26235462486](https://github.com/GaijinEntertainment/daScript/actions/runs/26235462486) — `Stage site for deployment` step.

## Test plan

- [ ] CI: `Deploy to GitHub Pages` succeeds end-to-end.
- [ ] https://daslang.io/playground/ serves the real IDE with a working Run button (not `placeholder.html`).
- [ ] `_site/playground/` contains `main.js`, `main.css`, `jquery-3.6.0.min.js`, `samples/`, plus `daslang_static.{js,wasm}` and the Forge-skinned `index.html` / `forge-skin.css` / `playground-*.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)