### PR TITLE
JIT: return failure on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,6 +312,13 @@ jobs:
             asan)  JIT_LINKER_STRING="--jit-linker-string=-fsanitize=address"   ;;
             tsan)  JIT_LINKER_STRING="--jit-linker-string=-fsanitize=thread"    ;;
         esac
+        # daslang built with clang on sanitizer matrix — JIT-emitted .dll
+        # must link with the same compiler (incompatible asan/tsan runtimes
+        # otherwise). c++ default = g++ on Ubuntu, mismatches.
+        JIT_PATH_TO_LINKER=""
+        if [ "${{ matrix.sanitizers }}" != "none" ] && [ -n "${{ matrix.sanitizers }}" ]; then
+            JIT_PATH_TO_LINKER="--jit-path-to-linker=clang++"
+        fi
         case "${{ matrix.target }}${{ matrix.architecture }}" in
            linux64)
             cd bin
@@ -323,7 +330,7 @@ jobs:
             printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
             # Use more time to pass UBSAN and disable leaks in JIT mode because we exit using exit(), and do not call destructors.
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --timeout 900 --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --failures-only --timeout 900 --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
            windows32)
@@ -332,7 +339,7 @@ jobs:
             ;;
            windows*)
             cd bin/"${{ matrix.cmake_preset }}"
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --timeout 900 --color --failures-only --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --timeout 900 --color --failures-only --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
             ;;
            linux_arm64)
@@ -343,12 +350,12 @@ jobs:
             # runs JIT — keep --failures-only off there so PASS lines print and
             # name the test running just before the hang if it reoccurs (see
             # RC2 release run #25572466058).
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
            *)
             cd bin
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
         esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,6 +303,15 @@ jobs:
     - name: "Test"
       run: |
         set -eux
+        # When daslang is sanitizer-instrumented, its JIT-emitted .dll cache
+        # link cmd needs -fsanitize=<kind> to pull the sanitizer runtime
+        # (otherwise unresolved __ubsan_*/__asan_*/__tsan_* symbols in lib.so).
+        JIT_LINKER_STRING=""
+        case "${{ matrix.sanitizers }}" in
+            ubsan) JIT_LINKER_STRING="--jit-linker-string=-fsanitize=undefined" ;;
+            asan)  JIT_LINKER_STRING="--jit-linker-string=-fsanitize=address"   ;;
+            tsan)  JIT_LINKER_STRING="--jit-linker-string=-fsanitize=thread"    ;;
+        esac
         case "${{ matrix.target }}${{ matrix.architecture }}" in
            linux64)
             cd bin
@@ -314,7 +323,7 @@ jobs:
             printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
             # Use more time to pass UBSAN and disable leaks in JIT mode because we exit using exit(), and do not call destructors.
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --timeout 900 --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --timeout 900 --test ../tests || ASAN_OPTIONS=detect_leaks=0 ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
            windows32)
@@ -323,7 +332,7 @@ jobs:
             ;;
            windows*)
             cd bin/"${{ matrix.cmake_preset }}"
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- --timeout 900 --color --failures-only --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --timeout 900 --color --failures-only --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../../tests
             ;;
            linux_arm64)
@@ -334,12 +343,12 @@ jobs:
             # runs JIT — keep --failures-only off there so PASS lines print and
             # name the test running just before the hang if it reoccurs (see
             # RC2 release run #25572466058).
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
            *)
             cd bin
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
             ;;
         esac

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -345,11 +345,9 @@ class CollectExternVisitor : AstVisitor {
         } else {
             if (!empty(expr.typeexpr.dim)) {
                 if (expr.typeexpr.baseType == Type.tHandle) {
-                    var elemT = clone_type(expr.typeexpr)
-                    elemT.dim |> clear() // hack to get correct ptr to ctor
                     let name = uid.get_new(expr.typeexpr)
                     if (initialize(name)) {
-                        register_new_from_annotation(name, elemT.annotation)
+                        register_new_from_annotation(name, expr.typeexpr.annotation)
                     }
                 } else {
                     if (expr.initializer) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -6359,11 +6359,9 @@ class public ResolveExternVisitor : AstVisitor {
         } else {
             if (!empty(expr.typeexpr.dim)) {
                 if (expr.typeexpr.baseType == Type.tHandle) {
-                    var elemT = clone_type(expr.typeexpr)
-                    elemT.dim |> clear() // hack to get correct ptr to ctor
-                    var new_handle_ptr = get_jit_new(elemT.annotation)
+                    var new_handle_ptr = get_jit_new(expr.typeexpr.annotation)
                     if (new_handle_ptr == null) {
-                        failed_T(elemT, "missing new`handle function pointer for {describe(elemT)}")
+                        failed_T(expr.typeexpr, "missing new`handle function pointer for {describe(expr.typeexpr)}")
                         return
                     }
                     dll.set_glob_address(uid.get_new(expr.typeexpr), new_handle_ptr)

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -842,7 +842,10 @@ def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascrip
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, file, filetype, error)
-        create_shared_library(file, add_dll_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", true, link_whole_lib)
+        let ok = create_shared_library(file, add_dll_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", true, link_whole_lib)
+        if (!ok) {
+            panic("write_dll: link failed for {out_path}")
+        }
     }
 }
 
@@ -853,7 +856,10 @@ def public write_exe(mod : LLVMOpaqueModule?; out_path : string; path_to_dascrip
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, file, filetype, error)
-        create_shared_library(file, add_exe_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", false, link_whole_lib)
+        let ok = create_shared_library(file, add_exe_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", false, link_whole_lib)
+        if (!ok) {
+            panic("write_exe: link failed for {out_path}")
+        }
     }
 }
 
@@ -906,7 +912,10 @@ def public write_wasm(mod : LLVMOpaqueModule?; out_path : string; triple : strin
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, obj, filetype, error)
         let runtime_arg = needs_runtime ? (runtime_lib ?? "") : ""
-        link_wasm(obj, "{out_path}.wasm", runtime_arg, path_to_emcc)
+        let ok = link_wasm(obj, "{out_path}.wasm", runtime_arg, path_to_emcc)
+        if (!ok) {
+            panic("write_wasm: link failed for {out_path}.wasm")
+        }
     }
 }
 

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -835,28 +835,28 @@ def public with_default_target_machine(opt_level : uint; use_host_cpu : bool;
 // @path_to_dascript_lib - path to library, required on Windows. Has no effect on Linux.
 // @path_to_linker - path to clang-cl on Windows. By default we'll use clang-cl from LLVM package
 // on Windows, default otherwise.
-def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string; link_whole_lib : bool) {
+def public write_dll(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker, linker_string : string; link_whole_lib : bool) {
     // JIT DLL cache: emitted artifact only ever runs on this host.
     with_default_target_machine(3u, true) $(targetMachine : LLVMTargetMachineRef) {
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, file, filetype, error)
-        let ok = create_shared_library(file, add_dll_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", true, link_whole_lib)
+        let ok = create_shared_library(file, add_dll_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", "{linker_string}", true, link_whole_lib)
         if (!ok) {
             panic("write_dll: link failed for {out_path}")
         }
     }
 }
 
-def public write_exe(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker : string; link_whole_lib : bool) {
+def public write_exe(mod : LLVMOpaqueModule?; out_path : string; path_to_dascript_lib, path_to_linker, linker_string : string; link_whole_lib : bool) {
     // Standalone exe: must run on any compatible CPU, keep generic.
     with_default_target_machine(3u, false) $(targetMachine : LLVMTargetMachineRef) {
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
         LLVMTargetMachineEmitToFile(targetMachine, mod, file, filetype, error)
-        let ok = create_shared_library(file, add_exe_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", false, link_whole_lib)
+        let ok = create_shared_library(file, add_exe_extension(out_path), "{path_to_dascript_lib}", "{path_to_linker}", "{linker_string}", false, link_whole_lib)
         if (!ok) {
             panic("write_exe: link failed for {out_path}")
         }

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -149,6 +149,10 @@ struct JitCliOptions {
     @clarg_name = "jit-runtime-lib"
     @clarg_doc = "JIT: explicit path to libDaScript_runtime.a (wasm cross-compile); overrides auto-locate under web/output/lib/"
     runtime_lib : Option<string>
+
+    @clarg_name = "jit-linker-string"
+    @clarg_doc = "JIT: extra args inserted verbatim into the host linker cmd (e.g. -fsanitize=undefined)"
+    linker_string : Option<string>
 }
 
 
@@ -196,6 +200,8 @@ class JIT_LLVM : AstSimulateMacro {
         // back to `options jit_runtime_lib = "..."` then write_wasm's
         // find_runtime_lib() auto-locate under web/output/lib/.
         let runtime_lib_override = cli_opts.runtime_lib |> unwrap_or((prog._options |> find_arg("jit_runtime_lib")) ?as tString ?? "")
+        // Extra args appended verbatim to the host linker cmd. CLI > script option.
+        let linker_string = cli_opts.linker_string |> unwrap_or((prog._options |> find_arg("jit_linker_string")) ?as tString ?? "")
 
         // Set global options
         LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS = prog._options |> find_arg("jit_vec3_ldu") ?as tBool ?? LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS_DEFAULT
@@ -337,10 +343,10 @@ class JIT_LLVM : AstSimulateMacro {
                     write_wasm(g_mod, output_path, target_triple, path_to_linker, jit_has_externals, runtime_lib_override)
                 } elif (gen_exe) {
                     mkdir_rec(dir_name(output_path))
-                    write_exe(g_mod, output_path, path_to_shared_lib, path_to_linker, LINK_WHOLE_LIB)
+                    write_exe(g_mod, output_path, path_to_shared_lib, path_to_linker, linker_string, LINK_WHOLE_LIB)
                 } elif (use_dll) {
                     mkdir_rec(dir_name(output_path))
-                    write_dll(g_mod, output_path, path_to_shared_lib, path_to_linker, LINK_WHOLE_LIB)
+                    write_dll(g_mod, output_path, path_to_shared_lib, path_to_linker, linker_string, LINK_WHOLE_LIB)
 
                     // Open just stored DLL, so we can keep working.
                     g_dynamic_lib_handle.reset()

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -153,6 +153,10 @@ struct JitCliOptions {
     @clarg_name = "jit-linker-string"
     @clarg_doc = "JIT: extra args inserted verbatim into the host linker cmd (e.g. -fsanitize=undefined)"
     linker_string : Option<string>
+
+    @clarg_name = "jit-path-to-linker"
+    @clarg_doc = "JIT: explicit linker binary (overrides default c++/clang-cl). Match the compiler daslang was built with to avoid sanitizer runtime mismatch."
+    path_to_linker : Option<string>
 }
 
 
@@ -190,7 +194,8 @@ class JIT_LLVM : AstSimulateMacro {
         assume config_out_path = string(prog.policies.jit_output_path)
         var output_path = config_out_path |> empty() ? ".jitted_scripts/{prog.thisNamespace}" : config_out_path
         assume path_to_shared_lib = string(prog.policies.jit_path_to_shared_lib)
-        assume path_to_linker = string(prog.policies.jit_path_to_linker)
+        // CLI --jit-path-to-linker wins over the script-level policy.
+        let path_to_linker = cli_opts.path_to_linker |> unwrap_or(string(prog.policies.jit_path_to_linker))
         // Cross-compile triple: --jit-target=<triple> CLI wins over the
         // script-level `options jit_target = "..."`.
         let opt_target = (prog._options |> find_arg("jit_target")) ?as tString ?? ""

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -858,8 +858,9 @@ extern "C" {
         return true;
     }
 
-    bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) {
+    bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, const char * extraLinkerArgs, bool isShared, bool linkWholeLib, Context *context ) {
         char cmd[1024];
+        const char * extra = (extraLinkerArgs && extraLinkerArgs[0]) ? extraLinkerArgs : "";
         const auto paths = get_real_lib_linker_paths(dasLib, customLinker, isShared, linkWholeLib);
         const auto & linker = paths.linker;
         const auto & runtimeLibrary = paths.runtimeLibrary;
@@ -880,8 +881,8 @@ extern "C" {
         #if defined(_WIN32) || defined(_WIN64)
             const auto linkerParam = isShared ? "-DLL" : "";
             auto result = compilerLibrary.empty()
-                ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, linkerParam, libraryName)
-                : fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, linkerParam, libraryName);
+                ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, extra, linkerParam, libraryName)
+                : fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, extra, linkerParam, libraryName);
         #elif defined(__APPLE__)
             const auto linkerParam = isShared ? "-shared " : "";
             // @executable_path first → relocated bundle finds dylibs next to the exe;
@@ -890,8 +891,8 @@ extern "C" {
             // sees two distinct -Wl,-rpath flags, not one with an embedded space.
             const auto rpath = "-Wl,-rpath,@executable_path\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
             auto result = compilerLibrary.empty()
-                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, objFilePath)
-                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, compilerLibrary, objFilePath);
+                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, objFilePath, extra)
+                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, compilerLibrary, objFilePath, extra);
         #else
             const auto linkerParam = isShared ? "-shared" : "";
             // $ORIGIN first → relocated bundle finds .so next to the exe;
@@ -901,16 +902,16 @@ extern "C" {
             // sees two distinct -Wl,-rpath flags, not one with an embedded space.
             const auto rpath = "-Wl,-rpath,\\$ORIGIN\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
             auto result = compilerLibrary.empty()
-                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" 2>&1"),
-                                        linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary)
-                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" 2>&1"),
-                                        linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, compilerLibrary);
+                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"),
+                                        linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, extra)
+                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"),
+                                        linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, compilerLibrary, extra);
         #endif
             *result = '\0';
         return run_link_cmd(cmd, libraryName, "Library", context);
     }
 #else
-    bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) { return true; }
+    bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, const char * extraLinkerArgs, bool isShared, bool linkWholeLib, Context *context ) { return true; }
 #endif
 
 #if (defined(_MSC_VER) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
@@ -1099,7 +1100,7 @@ extern "C" {
                     ->args({"library"});
             addExtern<DAS_BIND_FUN(create_shared_library)>(*this, lib,  "create_shared_library",
                 SideEffects::worstDefault, "create_shared_library")
-                    ->args({"objFilePath","libraryName","dasLib","customLinker", "isShared", "linkWholeLib", "context"});
+                    ->args({"objFilePath","libraryName","dasLib","customLinker","extraLinkerArgs","isShared","linkWholeLib","context"});
             addExtern<DAS_BIND_FUN(link_wasm)>(*this, lib,  "link_wasm",
                 SideEffects::worstDefault, "link_wasm")
                     ->args({"objFilePath","wasmPath","runtimeLibPath","customEmcc","context"});

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -235,8 +235,9 @@ extern "C" {
                 globalVariables[i] = GlobalVariable{};
             }
             context.allocateGlobalsAndShared();
-            memset(context.globals, 0, context.globalsSize);
-            memset(context.shared, 0, context.sharedSize);
+            // UBSAN forbid memset(null, 0, 0)
+            if (context.globalsSize) memset(context.globals, 0, context.globalsSize);
+            if (context.sharedSize)  memset(context.shared,  0, context.sharedSize);
             if ( pinvoke ) {
                 context.contextMutex = new recursive_mutex;
             }

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -824,12 +824,12 @@ extern "C" {
     //   cmd          — complete shell command, already includes 2>&1.
     //   artifactPath — output file path (logged on success/failure).
     //   artifactKind — short label for messages ("Library", "Wasm", ...).
-    static void run_link_cmd(const char * cmd, const char * artifactPath,
+    static bool run_link_cmd(const char * cmd, const char * artifactPath,
                              const char * artifactKind, Context * context) {
         FILE * fp = popen(cmd, "r");
         if ( fp == NULL ) {
             LOG(LogLevel::error) << "Failed to run command '" << cmd << "'\n";
-            return;
+            return false;
         }
         static constexpr int MAX_OUTPUT_SIZE = 16 * 1024;
         char buffer[1024], output[MAX_OUTPUT_SIZE];
@@ -851,13 +851,14 @@ extern "C" {
             context->to_out(&li, LogLevel::error, msg.c_str());
             string err = string("Output:\n") + output;
             context->to_out(&li, LogLevel::error, err.c_str());
-        } else {
-            string msg = string(artifactKind) + " " + artifactPath + " linked - ok\n";
-            context->to_out(&li, LogLevel::info, msg.c_str());
+            return false;
         }
+        string msg = string(artifactKind) + " " + artifactPath + " linked - ok\n";
+        context->to_out(&li, LogLevel::info, msg.c_str());
+        return true;
     }
 
-    void create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) {
+    bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) {
         char cmd[1024];
         const auto paths = get_real_lib_linker_paths(dasLib, customLinker, isShared, linkWholeLib);
         const auto & linker = paths.linker;
@@ -867,12 +868,12 @@ extern "C" {
         #if defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
         if (!check_file_present(runtimeLibrary.c_str())) {
             LOG(LogLevel::error) << "File '" << runtimeLibrary << "' , containing daslang runtime library, does not exist\n";
-            return;
+            return false;
         }
         #endif
         if (!check_file_present(objFilePath)) {
             LOG(LogLevel::error) << "File '" << objFilePath << "' , containing compiled definitions, does not exist\n";
-            return;
+            return false;
         }
 
 
@@ -906,10 +907,10 @@ extern "C" {
                                         linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, compilerLibrary);
         #endif
             *result = '\0';
-        run_link_cmd(cmd, libraryName, "Library", context);
+        return run_link_cmd(cmd, libraryName, "Library", context);
     }
 #else
-    void create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) { }
+    bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib, Context *context ) { return true; }
 #endif
 
 #if (defined(_MSC_VER) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
@@ -922,7 +923,7 @@ extern "C" {
     //                bin/ then PATH).
     // emcc drives wasm-ld plus libc / wasi / wasm-exceptions glue, so output
     // is self-contained -sSTANDALONE_WASM (only wasi imports).
-    void link_wasm ( const char * objFilePath, const char * wasmPath,
+    bool link_wasm ( const char * objFilePath, const char * wasmPath,
                      const char * runtimeLibPath, const char * customEmcc,
                      Context * context ) {
         #if defined(_WIN32) || defined(_WIN64)
@@ -932,7 +933,7 @@ extern "C" {
         #endif
         if ( !check_file_present(objFilePath) ) {
             LOG(LogLevel::error) << "File '" << objFilePath << "' , containing wasm32 object, does not exist\n";
-            return;
+            return false;
         }
         const bool withRuntime = runtimeLibPath != nullptr && runtimeLibPath[0] != '\0'
                                  && check_file_present(runtimeLibPath);
@@ -947,10 +948,10 @@ extern "C" {
         const string cmd = fmt::format(
             FMT_STRING("\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 2>&1"),
             linker, objFilePath, runtimeArg, wasmPath);
-        run_link_cmd(cmd.c_str(), wasmPath, "Wasm", context);
+        return run_link_cmd(cmd.c_str(), wasmPath, "Wasm", context);
     }
 #else
-    void link_wasm ( const char *, const char *, const char *, const char *, Context * ) { }
+    bool link_wasm ( const char *, const char *, const char *, const char *, Context * ) { return true; }
 #endif
 
     void jit_set_jit_state(Context & context, void *shared_lib, void *llvm_ee, void *llvm_context) {

--- a/src/misc/alloc_tracker.cpp
+++ b/src/misc/alloc_tracker.cpp
@@ -513,8 +513,14 @@ static void dump_alloc_leaks_atexit() {
         fflush(stderr);
         return;
     }
-    dump_alloc_leaks(stderr);
+    uint64_t leaked = dump_alloc_leaks(stderr);
     dump_lexer_string_leaks(stderr);
+    if (leaked > 0) {
+        // Surface leaks as non-zero exit so CI / scripts can detect.
+        // _Exit skips remaining atexit handlers (already dumped what we need).
+        fflush(stderr);
+        std::_Exit(1);
+    }
 }
 
 struct RegisterLeakDumpAtExit {

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -8,6 +8,19 @@ if(DAS_LLVM_DISABLED)
     return()
 endif()
 
+# JIT-linked util.exe pulls in libDaScriptDyn_runtime.so. When daslang is built
+# with -fsanitize=*, the .so references sanitizer runtime helpers that the JIT
+# link cmd (c++ without -fsanitize) can't satisfy. Forward the flag via
+# --jit-linker-string so daslang's link cmd resolves the right runtime.
+set(DAS_JIT_LINKER_STRING "")
+if(DAS_USE_SANITIZER STREQUAL "address" OR DAS_USE_SANITIZER STREQUAL "asan")
+    set(DAS_JIT_LINKER_STRING "--jit-linker-string=-fsanitize=address")
+elseif(DAS_USE_SANITIZER STREQUAL "undefined" OR DAS_USE_SANITIZER STREQUAL "ubsan")
+    set(DAS_JIT_LINKER_STRING "--jit-linker-string=-fsanitize=undefined")
+elseif(DAS_USE_SANITIZER STREQUAL "thread" OR DAS_USE_SANITIZER STREQUAL "tsan")
+    set(DAS_JIT_LINKER_STRING "--jit-linker-string=-fsanitize=thread")
+endif()
+
 set(DAS_UTILS
     aot
     dascov
@@ -43,6 +56,8 @@ foreach(util ${DAS_UTILS})
     add_custom_command(
         OUTPUT  ${UTIL_BIN_DIR}/${util}.exe
         COMMAND daslang -exe -output ${UTIL_BIN_DIR}/${util} ${UTIL_MAIN}
+                $<$<BOOL:${DAS_JIT_LINKER_STRING}>:-->
+                ${DAS_JIT_LINKER_STRING}
         DEPENDS ${UTIL_MAIN} daslang ${DASLIB_SOURCES} ${DASLLVM_DASLIB_SOURCES}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Building ${util} executable (daslang -exe)"
@@ -56,6 +71,8 @@ SET(TEST_MAIN ${PROJECT_SOURCE_DIR}/dastest/dastest.das)
 add_custom_command(
     OUTPUT  ${UTIL_BIN_DIR}/dastest.exe
     COMMAND daslang -exe -output ${UTIL_BIN_DIR}/dastest ${TEST_MAIN}
+            $<$<BOOL:${DAS_JIT_LINKER_STRING}>:-->
+            ${DAS_JIT_LINKER_STRING}
     DEPENDS ${TEST_MAIN} daslang ${DASLIB_SOURCES} ${DASLLVM_DASLIB_SOURCES}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMENT "Building dastest executable (daslang -exe)"


### PR DESCRIPTION
Earlier JIT was returning 0 even if JIT link failed. Because of this CI was not noticing whether JIT finished successfully or not. Now JIT will return an error.

Fixed a few errors/bugs mostly related to sanitizers, that were missing before because of this.