### PR TITLE
linq_fold: route ExprRef2Value peels through qm_peel_ref2value + adopt H3 in plan_zip (PR 2a)

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2405,9 +2405,7 @@ def private extend_specs_for_missing_having_reducers(var expr : Expression?; hbN
                                                      bucketElemType : TypeDeclPtr; at : LineInfo) : bool {
     // Pre-rewrite walker that appends hidden ReducerSpecs for having-only reducers; unrecognized shapes leak to rewrite_having_pred (which bails on any surviving raw `<hb>`).
     if (expr == null) return true
-    while (expr is ExprRef2Value) {
-        expr = (expr as ExprRef2Value).subexpr
-    }
+    qm_peel_ref2value(expr)
     if (expr is ExprCall) {
         var c = expr as ExprCall
         if (!having_reducer_append_if_missing(expr, hbName, itName, specs, userVisibleSlotCount, bucketElemType, at)) return false
@@ -2442,10 +2440,7 @@ def private extend_specs_for_missing_having_reducers(var expr : Expression?; hbN
 def private rewrite_having_pred(var expr : Expression?; hbName, kvName : string; specs : array<ReducerSpec>) : Expression? {
     // Substitutes `<hb>._0` → `kv._0` and `<reducer>(<hb>._1)` / `<reducer>(select(<hb>._1, <lam>))` → `kv._{slot}` (or divide expr for average) against matching specs; any other use of `<hb>` returns null and cascades.
     if (expr == null) return expr
-    // Peel typer-inserted ExprRef2Value wrappers (same pattern as peel_tuple_field_read).
-    while (expr is ExprRef2Value) {
-        expr = (expr as ExprRef2Value).subexpr
-    }
+    qm_peel_ref2value(expr)
     if (expr is ExprCall) {
         var c = expr as ExprCall
         if (c.func != null && (c.arguments |> length) == 1) {
@@ -4685,19 +4680,9 @@ def private plan_zip(var expr : Expression?) : Expression? {
             // Skip/take/while come after select; chained selects on zip stream defer (would mirror plan_loop_or_count `intermediateBinds`).
             if (seenSkip || seenSkipWhile || seenTakeWhile || seenTake || seenSelect) return null
             // Pull elementType from the projection block's return expression — the SELECT call's `_type.firstType` is a typedecl(result_selector(...)) formula that doesn't resolve when the chain is wrapped in _fold (call-macro context defers generic typedecl evaluation).
-            var projElemType : TypeDeclPtr
-            var projBody = cll._0.arguments[1]
-            if (projBody is ExprMakeBlock) {
-                var projMblk = projBody as ExprMakeBlock
-                var projBlk = projMblk._block as ExprBlock
-                if (projBlk.list |> length == 1 && projBlk.list[0] is ExprReturn) {
-                    var projRet = projBlk.list[0] as ExprReturn
-                    if (projRet.subexpr != null && projRet.subexpr._type != null) {
-                        projElemType = clone_type(projRet.subexpr._type)
-                    }
-                }
-            }
-            if (projElemType == null) return null
+            var projRet = peel_lambda_single_return(cll._0.arguments[1])
+            if (projRet == null || projRet._type == null) return null
+            var projElemType = clone_type(projRet._type)
             // Strip both constness and ref-ness — `array<T const>` is unwritable, `array<T&>` is invalid as buffer element. Matches the canonical pattern used by plan_reverse/plan_distinct/etc.
             projElemType = strip_const_ref(projElemType)
             projection = peel_lambda_rename_var(cll._0.arguments[1], itName)


### PR DESCRIPTION
## Summary

Slice 2a of the linq_fold dedup ladder (PR 2 reshaped after grounding). Two small dedups in `daslib/linq_fold.das`, no `ast_match.das` changes:

- **`extend_specs_for_missing_having_reducers` + `rewrite_having_pred`** — hand-rolled `while (expr is ExprRef2Value) { expr = (expr as ExprRef2Value).subexpr }` loops replaced with calls to `qm_peel_ref2value` from `daslib/ast_match`, the same helper `qmatch` emits at every `generate_match` dispatch. Single source of truth for `ExprRef2Value` peel semantics across the macro layer.
- **`plan_zip` projection elementType extraction** — 11-line manual `ExprMakeBlock` → `ExprBlock` → `ExprReturn` → `subexpr` unwrap collapsed to one call to `peel_lambda_single_return` (H3, already shared via PR 1a).

Net: **-15 LOC** (5 ins / 20 del). Lint clean.

## Plan deviation: qmatch adoption scope shrank

The plan envisioned qmatch conversion of `peel_tuple_field_read` internals + HAVING-clause probes + `extract_decs_bridge` cascades + `plan_zip` projection. Reality after grounding:

- `peel_tuple_field_read` lives in `ast_match.das` which **defines** qmatch — circular reference prevents qmatch usage in the same file.
- HAVING-clause probes already route the tuple-field check through `peel_tuple_field_read` (H9 from PR 1c), which is shorter than the qmatch equivalent (`qmatch(c.args[0], $e(rec)._1).matched && rec is ExprVar && (rec as ExprVar).name == hbName`).
- The outer `extend_specs_for_missing_having_reducers` recursive descent is generic RTTI dispatch on ExprCall/ExprField/ExprOp1/ExprOp2/ExprOp3 — qmatch is for shape matching, not for "is this any ExprOp2" recursion.
- `extract_decs_bridge` is block-shape matching with semantic cross-statement constraints (3 statements with specific types, `push` target var name matches `res` declared in stmt 0, `recordNames` count matches `for.sources` count) — beyond qmatch's pattern grammar.

The genuine wins from PR 2 reduce to (a) routing the two `linq_fold` while-peels through `qm_peel_ref2value` for single source of truth, and (b) `plan_zip` projection extraction via the existing H3 helper.

**Item 5 (ExprRef2Value while→if in `qm_peel_ref2value` itself) is intentionally deferred.** `tests/ast_match/test_ref2value_skip.das:test_nested_wrappers` asserts triple-wrap peel as a future-proofing guard, and `src/ast/ast_block_folding.cpp:44` could synthesize a nested wrapper (it rewraps after moving through `ExprCast`, and the inner subexpr could itself be an `ExprRef2Value`). The "never nests" claim in the plan is unverified for the synthetic case — keep the loop, route consumers through it.

## Test plan

- [x] `daslib/linq_fold.das` lint clean (MCP).
- [x] **Interp lane:** `tests/ast_match` 371/371 · `tests/linq` 1332/1332 · `tests/decs` 245/245 · `tests/dasSQLITE` 782/782.
- [x] **AOT lane:** `tests/ast_match` 371/371 · `tests/linq` 1332/1332 · `tests/decs` 245/245 · `tests/dasSQLITE` 782/782. (`test_extract_const_string.das.cpp` was missing from baseline → regenerated, committed via cmake `test_aot_ast_match` rebuild — all other AOT stubs "Content is same", confirming no codegen drift.)
- [x] **JIT lane:** `tests/ast_match` 371/371 (modulo `test_capture_cfb.das` pre-existing JIT failure on master, verified by stash+revert) · `tests/linq` 1332/1332 · `tests/decs` 245/245.
- [x] **Bench smoke (7 representative × 1 rep, 100K rows):** count_aggregate m3f 4 ns/op · sum_aggregate m3f 2 · average_aggregate m3f 5-6 · aggregate_match m3f 6 · groupby_count m3f 36 · zip_dot_product m3f 7 · distinct_count m3f 15. All within rounding noise of PR #2795 baselines. zip_dot_product specifically exercises the `plan_zip` projection path — invariant codegen confirmed.

Next: PR 3 (mechanical wins — qname sweep, `push_block_list` adoption, `finalize_emission` collapse, inline-collapse of `$b(localVec)` sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)