### PR TITLE
utils/daScript: add -jit-no-cache CLI flag (opt out of JIT DLL cache)

### DIFF
--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -41,6 +41,7 @@ enum class JitMode {
     Executable,
 };
 static JitMode jitEnabled = JitMode::None; // Disabled by default.
+static bool jitNoCache = false; // -jit-no-cache: bypass DLL-cache path, run in-memory.
 static string jitOutPath = ""; // Empty, JIT module will choose default.
 
 static bool noDynamicModules = false;
@@ -271,6 +272,7 @@ int compile_and_run ( const string & fn, const string & mainFnName, bool outputP
             case JitMode::Direct: break;
             default: break;
         }
+        if ( jitNoCache ) policies.jit_dll_mode = false;
         access->addExtraModule("just_in_time", getDasRoot() + "/daslib/just_in_time.das");
         policies.jit_output_path = jitOutPath;
         policies.dll_search_paths.emplace_back(getDasRoot() + "/lib");
@@ -427,6 +429,8 @@ void print_help() {
         << "    -v1syntax   enable version 1 syntax (uses Python-style indentation for code blocks)\n"
         << "    -v2makeSyntax enable version 1 syntax with version 2 constructors syntax (for arrays/structures)\n"
         << "    -jit        enable Just-In-Time compilation\n"
+        << "    -jit-no-cache  with -jit: skip the per-script DLL cache, codegen direct in-memory.\n"
+        << "                Useful when the cached .jitted_scripts/ DLL is stale or unwanted.\n"
         << "    -exe        JIT compile to standalone executable (implies -dry-run)\n"
         << "    -output <path> set JIT output path\n"
         << "    --list-shared-modules <path> with -exe: write JSON describing the program's shared modules and daspkg-package .das module sources to <path>\n"
@@ -562,6 +566,8 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 heapReportAtExit = true;
             } else if ( cmd=="jit") {
                 jitEnabled = JitMode::Direct;
+            } else if ( cmd=="jit-no-cache") {
+                jitNoCache = true;
             } else if ( cmd=="use-aot") {
                 useAot = true;
             } else if ( cmd=="output") {


### PR DESCRIPTION
## Summary

Adds a `-jit-no-cache` CLI flag to daslang. Used together with `-jit`, it routes JIT codegen through the direct in-memory path and skips the per-script DLL cache entirely (`policies.jit_dll_mode = false`). No-op without `-jit`, no-op on non-Windows platforms where the cache works fine.

## Why

With `-jit` alone, daslang's JIT pipeline writes the emitted DLL to `.jitted_scripts/<ns>/<hash>.dll` (content-addressed by AST + codegen version + opt flags) and reuses it across runs. On Windows this cache is broken — diagnosed at #2802:

The cached `.dll` has **absolute target addresses baked into its machine code**. ASLR moves DLL bases between sessions, so a cache-hit load points the JIT'd code at unmapped memory and crashes (`EXCEPTION_ACCESS_VIOLATION`, fault PC = baked offset against a stale base). Smoking gun: two consecutive sessions produced fault addresses `0x7ffcaab54f00` and `0x7ffa5eaf4f00` — different ASLR'd upper bits, identical `...4f00` low bits.

Fresh codegen re-bakes against the current load base, so deleting `.jitted_scripts/` + re-running succeeds. The principled fix is codegen-side (emit IAT-relative references instead of absolute addresses); that work is followup tracked in #2802. This PR is the opt-out flag that lets tools (dasProfile in particular) work around the cache without waiting for the deeper fix.

## What

`utils/daScript/main.cpp`:
- `static bool jitNoCache = false;` next to `jitEnabled`
- CLI parser arm for `"jit-no-cache"` setting `jitNoCache = true`
- When applying JIT policies, after the existing JitMode switch: `if (jitNoCache) policies.jit_dll_mode = false;`
- One help-text line under the existing `-jit` line

That's it. Six lines of meaningful change.

## Consumer

dasProfile uses this in its popen-spawned children on Windows so a full `--json` sweep can populate the DAS JIT row for every benchmark: [borisbat/dasProfile#4](https://github.com/borisbat/dasProfile/pull/4).

## Test plan

- [x] Built worktree daslang with this change; `daslang.exe --help` shows the new flag.
- [x] `daslang.exe -jit -jit-no-cache hello.das` runs cleanly twice in a row with no `DLL cache miss/hit` log lines (= direct in-memory path).
- [x] `daslang.exe -jit hello.das` (without the new flag) still uses the DLL cache (`cache miss → codegen → cache hit on second run` log lines), confirming the flag is opt-in.
- [x] dasProfile main.das `--json` end-to-end sweep now produces a complete `profile_results_windows.json` with the DAS JIT row populated for all 16 tests.

Out of scope: the root JIT codegen absolute-address bake — followup at #2802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)