### PR TITLE
playground: ?example= overrides autosave + JIT radio auto-reverts

### DIFF
--- a/site/playground/playground-tabs.js
+++ b/site/playground/playground-tabs.js
@@ -293,12 +293,20 @@
         bindTabsHandlers();
         renderTabs();
 
-        // Priority: URL hash > autosave > default sample > empty editor.
+        // Priority: URL hash > ?example= > autosave > default sample > empty editor.
         // When restored from hash or autosave we set pgRestoredFromState so
         // main.js skips its default selectSample("examples", 0) call (whose
         // async fetch would otherwise clobber the restored state ~200ms in).
+        //
+        // `?example=<slug>` (used by the daslang.io § 01 "try <test> on the
+        // playground →" deep-link) is also a URL-borne intent signal — it must
+        // override autosave, or visitors who've used the playground before
+        // land on their autosaved buffer instead of the workload they clicked
+        // through for. main.js's pageInit handles the actual selection once
+        // data.json loads; here we just refuse to clobber it with autosave.
         const hash = window.location.hash || '';
         const hasHash = hash.startsWith('#code=') || hash.startsWith('#z=');
+        const hasExampleParam = new URLSearchParams(window.location.search).has('example');
 
         if (hasHash && window.__pendingSampleBundle) {
             const bundle = window.__pendingSampleBundle;
@@ -310,7 +318,7 @@
             return;
         }
 
-        const saved = !hasHash ? loadAutosave() : null;
+        const saved = (!hasHash && !hasExampleParam) ? loadAutosave() : null;
         if (saved && saved.files && Object.keys(saved.files).length > 0) {
             pgLoadFiles(saved.files, saved.active);
             window.pgRestoredFromState = true;

--- a/site/playground/playground-tabs.js
+++ b/site/playground/playground-tabs.js
@@ -306,7 +306,10 @@
         // data.json loads; here we just refuse to clobber it with autosave.
         const hash = window.location.hash || '';
         const hasHash = hash.startsWith('#code=') || hash.startsWith('#z=');
-        const hasExampleParam = new URLSearchParams(window.location.search).has('example');
+        // Truthy on non-empty value only — matches main.js's `params.get` use,
+        // so `?example=` / `?example` (no value) doesn't silently clobber
+        // autosave only to then fall through to the default sample.
+        const hasExampleParam = !!new URLSearchParams(window.location.search).get('example');
 
         if (hasHash && window.__pendingSampleBundle) {
             const bundle = window.__pendingSampleBundle;

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -1,0 +1,79 @@
+// The interpreter/JIT (wasm) radio in the playground toolbar. Three concerns:
+//   1. Picking a sample with a precompiled .wasm enables the JIT radio.
+//   2. Picking a sample without one disables it.
+//   3. If JIT was selected when (2) happens, the radio must also be UNCHECKED
+//      and interpreter re-checked — otherwise selectedEngine() keeps returning
+//      'jit' and runCode() 404s on the missing artifact.
+//
+// SHA-256 is in the all_wasm cross-compile list (web/CMakeLists.txt); Macros
+// is multi-file so deriveJitName returns null synchronously — clean pair for
+// "JIT becomes available → user opts in → JIT becomes unavailable".
+//
+// The actual .wasm artifacts are only built by `cmake --build … all_wasm`,
+// which the playground-e2e CI lane runs but local dev typically skips. So we
+// stub the HEAD probe with page.route — the test asserts the radio-state
+// machine, not the cross-compile pipeline.
+
+const { test, expect } = require('./fixtures.js');
+
+async function waitDropdownsPopulated(page) {
+    await page.waitForFunction(
+        () => document.getElementById('examples').options.length > 1,
+        null,
+        { timeout: 10_000 }
+    );
+}
+
+const jitSel = 'input[name=engine][value=jit]';
+const interpSel = 'input[name=engine][value=interpreter]';
+
+// Make the HEAD fetch for any /samples/examples/*.wasm resolve to 200 OK so
+// updateEngineAvailability flips the JIT radio to enabled without relying on
+// build artifacts being present in the served tree.
+async function stubWasmAvailable(page) {
+    await page.route('**/samples/examples/*.wasm', route => {
+        if (route.request().method() === 'HEAD') {
+            return route.fulfill({ status: 200, body: '' });
+        }
+        return route.continue();
+    });
+}
+
+test('JIT radio enables for samples with a precompiled .wasm', async ({ playground }) => {
+    await stubWasmAvailable(playground);
+    await waitDropdownsPopulated(playground);
+
+    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
+    await expect.poll(
+        () => playground.locator(jitSel).isDisabled(),
+        { timeout: 5_000 }
+    ).toBe(false);
+});
+
+test('JIT radio auto-reverts to interpreter when sample has no .wasm', async ({ playground }) => {
+    await stubWasmAvailable(playground);
+    await waitDropdownsPopulated(playground);
+
+    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
+    await expect.poll(
+        () => playground.locator(jitSel).isDisabled(),
+        { timeout: 5_000 }
+    ).toBe(false);
+
+    // User opts into JIT.
+    await playground.locator(jitSel).check();
+    expect(await playground.locator(jitSel).isChecked()).toBe(true);
+
+    // Macros is multi-file — currentJitName is null, JIT disables synchronously
+    // (no HEAD fetch, so the stub above isn't consulted on this path).
+    await playground.locator('#examples').selectOption({ label: 'Macros (multi-file)' });
+    await expect.poll(
+        () => playground.locator(jitSel).isDisabled(),
+        { timeout: 5_000 }
+    ).toBe(true);
+
+    // The fix: disabled radio must NOT remain checked, and interpreter must
+    // be the new active selection.
+    expect(await playground.locator(jitSel).isChecked()).toBe(false);
+    expect(await playground.locator(interpSel).isChecked()).toBe(true);
+});

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -27,22 +27,39 @@ async function waitDropdownsPopulated(page) {
 const jitSel = 'input[name=engine][value=jit]';
 const interpSel = 'input[name=engine][value=interpreter]';
 
-// Make the HEAD fetch for any /samples/examples/*.wasm resolve to 200 OK so
-// updateEngineAvailability flips the JIT radio to enabled without relying on
-// build artifacts being present in the served tree.
-async function stubWasmAvailable(page) {
+// Deterministic HEAD-probe world: 200 for sha256.wasm only, 404 for every
+// other sample's .wasm regardless of what's actually present in the served
+// tree. A narrower `route('**/samples/examples/sha256.wasm', ...)` would let
+// the startup probe for the default Hello world sample hit a real hello.wasm
+// (if a local build has staged any), and JIT would be enabled from page
+// load — the "JIT enables on sha256 select" test would then pass even if
+// the sample-switch path stopped working.
+async function stubSha256WasmAvailable(page) {
     await page.route('**/samples/examples/*.wasm', route => {
-        if (route.request().method() === 'HEAD') {
-            return route.fulfill({ status: 200, body: '' });
-        }
-        return route.continue();
+        if (route.request().method() !== 'HEAD') return route.continue();
+        const ok = route.request().url().endsWith('/sha256.wasm');
+        return route.fulfill({ status: ok ? 200 : 404, body: '' });
     });
 }
 
 test('JIT radio enables for samples with a precompiled .wasm', async ({ playground }) => {
-    await stubWasmAvailable(playground);
+    await stubSha256WasmAvailable(playground);
     await waitDropdownsPopulated(playground);
 
+    // The `playground` fixture's navigate-before-route ordering means the
+    // startup HEAD probe for the default sample's .wasm has already happened
+    // against the real http.server. Force a fresh probe by selecting a sample
+    // the stub returns 404 for — that establishes the "JIT disabled" baseline
+    // we need so the SHA-256 transition actually proves the sample-switch
+    // path works.
+    await playground.locator('#examples').selectOption({ label: 'Functions' });
+    await expect.poll(
+        () => playground.locator(jitSel).isDisabled(),
+        { timeout: 5_000 }
+    ).toBe(true);
+
+    // Switching to SHA-256 must flip the radio to enabled — that transition
+    // is what the test name asserts.
     await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
     await expect.poll(
         () => playground.locator(jitSel).isDisabled(),
@@ -51,7 +68,7 @@ test('JIT radio enables for samples with a precompiled .wasm', async ({ playgrou
 });
 
 test('JIT radio auto-reverts to interpreter when sample has no .wasm', async ({ playground }) => {
-    await stubWasmAvailable(playground);
+    await stubSha256WasmAvailable(playground);
     await waitDropdownsPopulated(playground);
 
     await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });

--- a/site/tests/playground/persistence.spec.js
+++ b/site/tests/playground/persistence.spec.js
@@ -21,8 +21,25 @@ test('three-file state survives a reload', async ({ playground }) => {
         window.pgSwitchFile('main.das');
     });
 
-    // Wait for the debounced autosave (250ms) to actually fire.
-    await playground.waitForTimeout(400);
+    // Wait until autosave has actually persisted both the file set AND the
+    // active-tab pointer. A fixed-150ms-margin `waitForTimeout(400)` over a
+    // 250ms debounce is enough on localhost but flakes on CI under load —
+    // poll the localStorage payload directly instead, so we proceed the
+    // moment the writer fires (and don't proceed before it).
+    await expect.poll(
+        () => playground.evaluate(() => {
+            const raw = localStorage.getItem('daslang.playground.state.v1');
+            if (!raw) return null;
+            try {
+                const j = JSON.parse(raw);
+                return {
+                    files: Object.keys(j.files || {}).sort().join(','),
+                    active: j.active,
+                };
+            } catch (e) { return null; }
+        }),
+        { timeout: 5_000 }
+    ).toEqual({ files: 'main.das,types.das,utils.das', active: 'main.das' });
 
     await playground.reload();
     await waitTabsReady(playground);

--- a/site/tests/playground/persistence.spec.js
+++ b/site/tests/playground/persistence.spec.js
@@ -81,7 +81,16 @@ test('autosave does not override ?example= deep-link', async ({ playground }) =>
     // sha256.das ships a `// SHA-256` header comment — content match is
     // sturdier than asserting the dropdown label since selectSample resets
     // the <select> back to "Select example" after firing.
+    //
+    // Poll instead of a bare evaluate: waitTabsReady returns as soon as
+    // pgState exists (initial empty doc), but main.js's `?example=` branch
+    // still has to async-fetch data.json + sha256.das before pgLoadFiles
+    // swaps the buffer content. Polling on the sha256 header marker is the
+    // direct signal that the deep-link load actually landed.
+    await expect.poll(
+        () => playground.evaluate(() => window.pgState.files['main.das'].getValue()),
+        { timeout: 5_000 }
+    ).toMatch(/sha[- ]?256/i);
     const mainText = await playground.evaluate(() => window.pgState.files['main.das'].getValue());
-    expect(mainText).toMatch(/sha[- ]?256/i);
     expect(mainText).not.toContain('stale autosave buffer');
 });

--- a/site/tests/playground/persistence.spec.js
+++ b/site/tests/playground/persistence.spec.js
@@ -63,3 +63,25 @@ test('autosave does not override URL #code hash on reload', async ({ playground 
     const mainText = await playground.evaluate(() => window.pgState.files['main.das'].getValue());
     expect(mainText).toContain('shared via hash');
 });
+
+test('autosave does not override ?example= deep-link', async ({ playground }) => {
+    // Same intent-signal rule as #code=: a visitor following the daslang.io
+    // § 01 "try sha256 on the playground" deep-link should land on sha256,
+    // even if they've used the playground before and have an autosaved buffer.
+    await waitTabsReady(playground);
+
+    await playground.evaluate(() => {
+        window.code.getDoc().setValue('// stale autosave buffer\n');
+    });
+    await playground.waitForTimeout(400);
+
+    await playground.goto('/playground/?example=sha256');
+    await waitTabsReady(playground);
+
+    // sha256.das ships a `// SHA-256` header comment — content match is
+    // sturdier than asserting the dropdown label since selectSample resets
+    // the <select> back to "Select example" after firing.
+    const mainText = await playground.evaluate(() => window.pgState.files['main.das'].getValue());
+    expect(mainText).toMatch(/sha[- ]?256/i);
+    expect(mainText).not.toContain('stale autosave buffer');
+});

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -105,10 +105,22 @@ function deriveJitName(files) {
 function updateEngineAvailability(name) {
     const jitRadio = document.querySelector('input[name=engine][value=jit]');
     if (!jitRadio) return;
-    if (!name) { jitRadio.disabled = true; return; }
+    // When JIT becomes unavailable for the new sample, fall back to the
+    // interpreter — leaving the radio merely `disabled` but still `checked`
+    // would keep selectedEngine() returning 'jit' and runCode() would 404
+    // on the missing .wasm.
+    const disableJit = () => {
+        jitRadio.disabled = true;
+        if (jitRadio.checked) {
+            jitRadio.checked = false;
+            const interpRadio = document.querySelector('input[name=engine][value=interpreter]');
+            if (interpRadio) interpRadio.checked = true;
+        }
+    };
+    if (!name) { disableJit(); return; }
     fetch('./samples/examples/' + name + '.wasm', { method: 'HEAD' })
-        .then(r => { jitRadio.disabled = !r.ok; })
-        .catch(() => { jitRadio.disabled = true; });
+        .then(r => { if (r.ok) jitRadio.disabled = false; else disableJit(); })
+        .catch(disableJit);
 }
 
 selectSample = function(type, id) {

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -118,9 +118,18 @@ function updateEngineAvailability(name) {
         }
     };
     if (!name) { disableJit(); return; }
+    // Rapid sample-switching can land HEAD-fetch responses out of order
+    // (HTTP/2). Gate the late .then/.catch on the sample still being current
+    // — currentJitName is the source of truth for "what sample is loaded".
     fetch('./samples/examples/' + name + '.wasm', { method: 'HEAD' })
-        .then(r => { if (r.ok) jitRadio.disabled = false; else disableJit(); })
-        .catch(disableJit);
+        .then(r => {
+            if (name !== currentJitName) return;
+            if (r.ok) jitRadio.disabled = false; else disableJit();
+        })
+        .catch(() => {
+            if (name !== currentJitName) return;
+            disableJit();
+        });
 }
 
 selectSample = function(type, id) {


### PR DESCRIPTION
## Summary

Three deep-link bugs in the playground, all surfaced by the daslang.io § 01 "try `<test>` on the playground →" jumps:

1. **`?example=<slug>` was silently overridden by localStorage autosave.** Visitors who'd used the playground before landed on their stale buffer instead of the workload they clicked through for. The fix in `site/playground/playground-tabs.js` extends the existing "URL signals deep-link intent" rule (currently `#code=` / `#z=` hashes) to include `?example=` — autosave-restore is skipped so `main.js`'s `pageInit` can apply the URL param.

2. **JIT radio stayed disabled on the deep-linked sample.** A consequence of #1: when the deep-link silently fell through to Hello world (no `.wasm`) instead of selecting SHA-256 (has `.wasm`), `updateEngineAvailability` HEAD-probed the wrong artifact. Fixed by #1.

3. **JIT radio stayed `checked` after becoming `disabled`.** When JIT was opted in for a sample with a `.wasm` and the user switched to a sample without one, `updateEngineAvailability` greyed out the JIT radio but left it `checked = true`. `selectedEngine()` kept returning `'jit'` and `runCode()` 404'd on the missing artifact. Now disabling JIT also unchecks it and re-checks interpreter (`web/examples/ui/src/main.js`).

## Coverage

- `site/tests/playground/persistence.spec.js` gains an `autosave does not override ?example=` test, mirroring the existing `#code=` test.
- New `site/tests/playground/engine-toggle.spec.js` covers both "JIT enables when `.wasm` exists" and the auto-revert. HEAD probe is stubbed via `page.route` so the test doesn't depend on `cmake --build … all_wasm` running in the test env.

## Test plan

- [x] `playwright test --grep-invert @wasm` — 32/32 pass locally
- [x] End-to-end manual verification in real Chrome via Playwright MCP: `?example=sha256` after planting stale autosave lands on the SHA-256 source; opt into JIT on SHA-256 → switch to Macros → JIT radio is now disabled+unchecked, interpreter checked
- [ ] CI playground-e2e lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)