### PR TITLE
llvm_jit: DLLExport storage on jit_table_at globals (#2802 cache-hit fix)

### DIFF
--- a/modules/dasLLVM/daslib/llvm_dll_utils.das
+++ b/modules/dasLLVM/daslib/llvm_dll_utils.das
@@ -234,13 +234,8 @@ class public DLLHandle {
     def set_glob_address(fn : DllName, ptr : void?) {
         assert(handle != null, "dynamic_lib_handle is null")
         var fn_addr = unsafe(reinterpret<void ??>(handle |> get_function_address(fn.glob())))
-        // Silent skip = stale baked address survives into JIT'd code on cache-hit
-        // reload after ASLR shift, which crashes (#2802). Every caller in
-        // ResolveExternVisitor is fixing up a slot that MUST be writable, so a
-        // missing export is always a codegen-side linkage bug — panic loud.
-        if (fn_addr == null) {
-            panic("set_glob_address: missing DLL export {fn.glob()} — codegen-side linkage bug, see #2802")
-        }
+        // assert(fn_addr != null)
+        if (fn_addr == null) return false
         *fn_addr = ptr;
         return true
     }

--- a/modules/dasLLVM/daslib/llvm_dll_utils.das
+++ b/modules/dasLLVM/daslib/llvm_dll_utils.das
@@ -234,8 +234,13 @@ class public DLLHandle {
     def set_glob_address(fn : DllName, ptr : void?) {
         assert(handle != null, "dynamic_lib_handle is null")
         var fn_addr = unsafe(reinterpret<void ??>(handle |> get_function_address(fn.glob())))
-        // assert(fn_addr != null)
-        if (fn_addr == null) return false
+        // Silent skip = stale baked address survives into JIT'd code on cache-hit
+        // reload after ASLR shift, which crashes (#2802). Every caller in
+        // ResolveExternVisitor is fixing up a slot that MUST be writable, so a
+        // missing export is always a codegen-side linkage bug — panic loud.
+        if (fn_addr == null) {
+            panic("set_glob_address: missing DLL export {fn.glob()} — codegen-side linkage bug, see #2802")
+        }
         *fn_addr = ptr;
         return true
     }

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -222,8 +222,10 @@ def public FN_JIT_TABLE_FIND(t : Type) {
 }
 
 def private add_table_linkage(val : LLVMOpaqueValue?) {
-    // windows crashes with weak linkage
-    LLVMSetLinkage(val, LLVMLinkage.LLVMExternalLinkage)
+    // DLLExport storage so ResolveExternVisitor's set_glob_address (GetProcAddress
+    // on Windows) can find the slot on cache-hit reload; otherwise #2802 stale-addr.
+    LLVMSetLinkage(val, LLVMLinkage.LLVMDLLExportLinkage)
+    LLVMSetDLLStorageClass(val, LLVMDLLStorageClass.LLVMDLLExportStorageClass)
 }
 
 def private get_or_create_table_fn(llvm_module : LLVMOpaqueModule?; var types : PrimitiveTypes?; fn_name : DllName; at_type : LLVMOpaqueType?; fn_ptr : void?) {

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -26,7 +26,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x09ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x0aul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/tests/jit_tests/dll_cache.das
+++ b/tests/jit_tests/dll_cache.das
@@ -13,7 +13,12 @@ require dastest/testing_boost
 let OUTPUT_DIR = "{get_das_root()}/build/tests"
 let PROBE_PATH = "{OUTPUT_DIR}/dll_cache_probe.das"
 
-def write_probe(body_expr : string) : bool {
+def write_probe(table_value : int) : bool {
+    // Probe must exercise jit_table_at so jit_table_at_tString lands in the
+    // emitted globals; pairs with the set_glob_address panic to catch
+    // #2802-style linkage regressions (DLLExport storage missing would panic
+    // loud at compile_probe() instead of silently surviving into ASLR-shift
+    // crashes on cache-hit reload).
     mkdir_rec(OUTPUT_DIR)
     var ok = false
     fopen(PROBE_PATH, "w") $(f) {
@@ -22,7 +27,9 @@ def write_probe(body_expr : string) : bool {
             fprint(f, "require daslib/just_in_time\n\n")
             fprint(f, "[jit, sideeffects, export]\n")
             fprint(f, "def probe(x : int) : int \{\n")
-            fprint(f, "    return {body_expr}\n")
+            fprint(f, "    var tab : table<string; int>\n")
+            fprint(f, "    tab[\"a\"] = {table_value}\n")
+            fprint(f, "    return x + tab[\"a\"]\n")
             fprint(f, "\}\n")
             fprint(f, "\n[export]\ndef main() \{\n    let _ = probe(0)\n\}\n")
             ok = true
@@ -62,20 +69,15 @@ def list_dlls(subdir : string) : array<string> {
 
 def clear_subdir(subdir : string) {
     dir(subdir) $(fname) {
-        if (fname == "." || fname == "..") {
-            return
-        }
+        return if (fname == "." || fname == "..")
         var err : string
         remove("{subdir}/{fname}", err)
     }
 }
 
 def test_dll_cache(t : T?) {
-    if (!jit_enabled() || !das_is_dll_build()) {
-        return
-    }
-    // first compile seeds the namespace so we can locate the per-script subdir
-    t |> equal(write_probe("x + 1"), true)
+    return if (!jit_enabled() || !das_is_dll_build())
+    t |> equal(write_probe(1), true)
     let ns = compile_probe()
     t |> equal(empty(ns), false)
     let subdir = ".jitted_scripts/{ns}"
@@ -94,7 +96,7 @@ def test_dll_cache(t : T?) {
     t |> strictEqual(dlls2[0], first_dll, "cache hit keeps same DLL filename")
 
     // compile 3 with different body: miss, new DLL, old artifacts GC'd
-    t |> equal(write_probe("x + 2"), true)
+    t |> equal(write_probe(2), true)
     compile_probe()
     let dlls3 <- list_dlls(subdir)
     t |> equal(length(dlls3), 1)

--- a/tests/jit_tests/dll_cache.das
+++ b/tests/jit_tests/dll_cache.das
@@ -14,11 +14,9 @@ let OUTPUT_DIR = "{get_das_root()}/build/tests"
 let PROBE_PATH = "{OUTPUT_DIR}/dll_cache_probe.das"
 
 def write_probe(table_value : int) : bool {
-    // Probe must exercise jit_table_at so jit_table_at_tString lands in the
-    // emitted globals; pairs with the set_glob_address panic to catch
-    // #2802-style linkage regressions (DLLExport storage missing would panic
-    // loud at compile_probe() instead of silently surviving into ASLR-shift
-    // crashes on cache-hit reload).
+    // Probe uses table[k] so jit_table_at_tString lands in the emitted globals,
+    // exercising the codegen path that #2802 fixed (DLLExport linkage on the
+    // table accessor slots so ResolveExternVisitor can fix them up on reload).
     mkdir_rec(OUTPUT_DIR)
     var ok = false
     fopen(PROBE_PATH, "w") $(f) {


### PR DESCRIPTION
Fixes the Windows JIT DLL cache crash documented at #2802. Follow-up to #2808 (now merged) — that added the `-jit-no-cache` opt-out flag, this is the actual cache-side fix so the flag stays a "skip the cache entirely" convenience rather than a workaround for broken behavior.

## What was broken

The cached `.jitted_scripts/<ns>/<hash>.dll` bakes runtime function-pointer addresses into a few global initializers at codegen, then `ResolveExternVisitor` walks the AST after every DLL load and overwrites each slot via `set_glob_address` with the current-session address — that handoff is what keeps cache-hit reloads safe across ASLR shifts.

`add_table_linkage` on the `jit_table_at/find/erase` globals only set `LLVMExternalLinkage`, no DLLExport storage class. On Windows that leaves the symbol out of the DLL export table, so `set_glob_address` (GetProcAddress + write-through-pointer) finds nothing and silently returns false. The codegen-time address — valid in the session that wrote the DLL — survives unchanged into every subsequent session, where ASLR has placed the runtime DLL somewhere else. The JIT'd code loads the stale pointer and crashes inside the first table operation.

`dumpbin /exports` on a pre-fix cached DLL confirms `` `jit`table_at`tString` glob `` is missing while `save_address_global`'s builtin function-pointer globals (which use `set_public_linkage` → DLLExport) are present.

## Fix

- `add_table_linkage` mirrors `set_public_linkage`'s DLLExport linkage + DLLExportStorageClass combo. Post-fix `dumpbin /exports` shows `jit_table_at_*` in the exports table.
- `LLVM_JIT_CODEGEN_VERSION` bumped `0x09` → `0x0a` so previously-written cached DLLs miss on first run after this lands and get GC'd.

## Test

`tests/jit_tests/dll_cache.das` probe now exercises `table[k]` (was `x + 1`) so `jit_table_at_tString` lands in the emitted globals, exercising the codegen + fixup path the fix targets. The cache-behavior assertions are unchanged.

## Verification on Windows

- Two sessions of `daslang -jit dasProfile/tests/dict.das -- --nomain` (the original #2802 crash repro), cache cleared before session 1, both exit 0 with `"dictionary", 0.013941000, 10`.
- Full `jit_tests/` suite under `-jit`: 229 passed, 8 pre-existing `missing prerequisite 'UnitTest'` failures (build infra, unrelated).
- Lint: 0 issues on the 4 changed files.
- Format: all 4 files already formatted.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>