### PR TITLE
jit/wasm-cross: fix table_sort/f2s/tree regressions (#2805)

### DIFF
--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -740,8 +740,7 @@ def private write_release_deps(prog : Program?) {
 // all compiled functions, runs init scripts, then calls the program entry point.
 def public inject_main(program_context : Context?; ctx : LLVMContextRef;
                        prog : Program?; entry_point : string; mod : LLVMOpaqueModule?;
-                       var types : PrimitiveTypes?, var uids : UidNodes?; strict : bool;
-                       target_triple : string = "") : tuple<fn : LLVMOpaqueValue?; link_whole_lib : bool> {
+                       var types : PrimitiveTypes?, var uids : UidNodes?; strict : bool) : tuple<fn : LLVMOpaqueValue?; link_whole_lib : bool> {
 
     let builder = LLVMCreateBuilder()
     defer() {
@@ -807,7 +806,7 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     )
     // wasm32-emscripten: emcc's libstandalonewasm already defines `main`,
     // emit `__main_argc_argv` instead and let crt1 chain through.
-    let main_sym = (target_triple |> starts_with("wasm32-")) ? "__main_argc_argv" : "main"
+    let main_sym = g_target_is_wasm ? "__main_argc_argv" : "main"
     let main_fn = LLVMAddFunctionWithType(mod, main_sym, main_fn_type)
     let entry = LLVMAppendBasicBlockInContext(ctx, main_fn, "entry")
     LLVMPositionBuilderAtEnd(builder, entry)
@@ -977,8 +976,11 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
         }
     }
 
-    // When linking whole compiler lib, register fusion engine (needed by simulate)
-    if (needs_whole_lib) {
+    // When linking whole compiler lib, register fusion engine (needed by simulate).
+    // Skip on wasm: cross-link only sees libDaScript_runtime.a (no
+    // jit_register_fusion symbol), and standalone exes never read the pointers
+    // it sets anyway — ShutdownStandalone passes resetFusion=false, see #2805.
+    if (needs_whole_lib && !g_target_is_wasm) {
         let reg_fusion_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
         let reg_fusion_fn = LLVMAddFunctionWithType(g_mod, "jit_register_fusion", reg_fusion_type)
         LLVMBuildCall2(builder, reg_fusion_type, reg_fusion_fn, array<LLVMValueRef>(), "")

--- a/modules/dasLLVM/daslib/llvm_macro.das
+++ b/modules/dasLLVM/daslib/llvm_macro.das
@@ -300,7 +300,7 @@ class JIT_LLVM : AstSimulateMacro {
                     }
                 }
                 if (gen_exe) {
-                    let res = inject_main(ctx, g_ctx, prog, exe_main, g_mod, g_prim_t, uids, exe_strict, target_triple)
+                    let res = inject_main(ctx, g_ctx, prog, exe_main, g_mod, g_prim_t, uids, exe_strict)
                     LINK_WHOLE_LIB = res.link_whole_lib
                     if (res.fn == null) {
                         finalize_jit(use_dll, gen_exe, g_dynamic_lib_handle)

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -946,9 +946,15 @@ extern "C" {
         // -sSTANDALONE_WASM: emit self-contained .wasm with wasi imports only.
         // -fwasm-exceptions + -sWASM_LEGACY_EXCEPTIONS=0: match the runtime
         // archive's modern wasm EH, avoid emcc's JS invoke_* trampolines.
+        // -sINITIAL_MEMORY=128MB: standalone wasm cannot grow memory under
+        // wasmtime (-sALLOW_MEMORY_GROWTH adds an unsatisfiable
+        // emscripten_notify_memory_growth import), so reserve up front. Cost
+        // is virtual address space only — lazy paging keeps RSS proportional
+        // to actual use. 128MB covers all current playground benchmarks; see
+        // #2805.
         const string runtimeArg = withRuntime ? fmt::format("\"{}\" ", runtimeLibPath) : "";
         const string cmd = fmt::format(
-            FMT_STRING("\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 2>&1"),
+            FMT_STRING("\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 -sINITIAL_MEMORY=128MB 2>&1"),
             linker, objFilePath, runtimeArg, wasmPath);
         return run_link_cmd(cmd.c_str(), wasmPath, "Wasm", context);
     }

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -158,17 +158,7 @@ set(_wasm_run_cmds)
 # URL param), with hyphens replaced by underscores (`spectral-norm` →
 # `spectral_norm`) so they're valid CMake target stems.
 #
-# `table_sort` + `f2s` + `tree` are intentionally excluded from the
-# cross-compile foreach — they each fail wasm_cross in a way that doesn't
-# affect playground UX (the playground runs them through the embedded daslang
-# interpreter, not via cross-compile). Tracked at
-# GaijinEntertainment/daScript#2805:
-#   * table_sort.wasm — wasm-ld error: undefined symbol `jit_register_fusion`
-#   * f2s.wasm        — wasmtime runtime trap (Wasm exception)
-#   * tree.wasm       — wasmtime runtime trap (Wasm exception) — treap impl
-#                       with recursive merge/split + explicit `delete` under
-#                       wasm-exceptions ABI
-foreach(ex hello loop func
+foreach(ex hello loop func table_sort f2s tree
         dict sha256 exp f2i fib_loop fib_recursive mandelbrot
         nbodies particles primes queen spectral_norm)
     add_custom_command(OUTPUT ${_web_ex_out}/${ex}.wasm


### PR DESCRIPTION
Fixes #2805 — the three playground samples excluded from wasm_cross in #2804 now cross-compile and run cleanly under wasmtime.

## Summary

- **`table_sort`** — skip the dead `jit_register_fusion` emit when targeting wasm. `sort+cblock` flips `needs_whole_lib=true` to request the compiler lib, but wasm cross-link only sees `libDaScript_runtime.a` → wasm-ld fails with `undefined symbol: jit_register_fusion`. Standalone exes go through `Module::ShutdownStandalone` (`resetFusion=false`) and never recompile, so the registration is dead code in standalone-exe context anyway. While there, swap the local `starts_with("wasm32-")` for the canonical `g_target_is_wasm` global and drop the now-unused `target_triple` param from `inject_main`.

- **`f2s` + `tree`** — bump `link_wasm`'s default to `-sINITIAL_MEMORY=128MB`. Both samples trap with "thrown Wasm exception" on the 16MB emcc default; f2s allocates ~1M strings into the linear heap, tree's treap working set + persistent_heap chunks exceed 16MB. Standalone wasm cannot grow memory under wasmtime (`-sALLOW_MEMORY_GROWTH` adds an unsatisfiable `emscripten_notify_memory_growth` import), so reserve up front. Cost is virtual address space only — lazy paging keeps RSS proportional to actual use.

- **`web/CMakeLists.txt`** — re-enable all 3 samples in the cross-compile foreach, drop the exclusion comment.

## Test plan

- [x] Local repro of all 3 traps under `D:\wasmtime\wasmtime-v44.0.1-x86_64-windows\wasmtime.exe -W exceptions=y` confirmed the link error (`table_sort`) and runtime exceptions (`f2s`, `tree`).
- [x] After fix, local end-to-end (worktree daslang + worktree `liblibDaScript_runtime.a`):
  - `table_sort.wasm` → exit 0, 10 × 100k sorts @ ~9ms
  - `f2s.wasm` → exit 0, 10 × 10k float→str @ ~144ms
  - `tree.wasm` → exit 0, 10 × 1M treap ops @ ~198ms
  - `hello.wasm` regression check → exit 0, prints "Hello World"
- [x] `daslang` `link_wasm` subprocess invocation confirmed to include `-sINITIAL_MEMORY=128MB`.
- [x] Lint clean on changed `.das` files (`utils/lint/main.das --quiet`).
- [x] No format diff on changed `.das` files.
- [ ] CI `wasm_cross` job exercises the same `ninja run_wasm_examples` target end-to-end on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)