### PR TITLE
linq_fold: plan_decs_unroll Slice 5f — terminal splice for last/single/aggregate/element_at

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3901,6 +3901,263 @@ def private emit_decs_min_max_by(bridge : DecsBridgeShape?;
 }
 
 [macro_function]
+def private emit_decs_walk_lane(bridge : DecsBridgeShape?;
+                                opName : string;
+                                chainInfo : DecsChainInfo?;
+                                rangeInfo : DecsRangeInfo?;
+                                var calls : array<tuple<ExprCall?; LinqCall?>>;
+                                intermediateEnd : int;
+                                terminatorCall : ExprCall?;
+                                at : LineInfo) : Expression? {
+    // Slice 5f walk-lane: last/single/aggregate. State (found flag + retained element / accumulator) hoisted at invoke scope so it persists across archetype boundaries. single_or_default uses for_each_archetype_find for early-exit on 2nd match; others use plain for_each_archetype unless take/take_while is present.
+    let tupName = qn("decs_tup", at)
+    let names <- make_decs_range_names(at)
+    let finalBind = chainInfo.finalBind
+    var elemType = clone_type(chainInfo.finalType)
+    var preludeStmts : array<Expression?>
+    var tailStmts : array<Expression?>
+    var perElement : Expression?
+    var retType : TypeDeclPtr
+    var earlyExitFind = false
+    if (opName == "last" || opName == "last_or_default") {
+        retType = clone_type(elemType)
+        let foundName = qn("decs_found", at)
+        let bindName = qn("decs_lst", at)
+        preludeStmts |> push_from <| qmacro_block_to_array() {
+            var $i(foundName) = false
+            var $i(bindName) : $t(retType)
+        }
+        perElement = qmacro_block() {
+            $i(foundName) = true
+            $i(bindName) := $i(finalBind)
+        }
+        if (opName == "last") {
+            tailStmts |> push_from <| qmacro_block_to_array() {
+                if (!$i(foundName)) panic("sequence contains no elements")
+                return <- $i(bindName)
+            }
+        } else {
+            let defaultName = qn("decs_dv", at)
+            preludeStmts |> push <| qmacro_expr() {
+                let $i(defaultName) = $e(terminatorCall.arguments[1])
+            }
+            tailStmts |> push_from <| qmacro_block_to_array() {
+                if (!$i(foundName)) return $i(defaultName)
+                return <- $i(bindName)
+            }
+        }
+    } elif (opName == "single") {
+        retType = clone_type(elemType)
+        let foundName = qn("decs_found", at)
+        let bindName = qn("decs_sng", at)
+        preludeStmts |> push_from <| qmacro_block_to_array() {
+            var $i(foundName) = false
+            var $i(bindName) : $t(retType)
+        }
+        // Panic on 2nd match terminates the invoke regardless of nesting — no need for early-exit dispatch.
+        perElement = qmacro_block() {
+            if ($i(foundName)) panic("sequence contains more than one element")
+            $i(foundName) = true
+            $i(bindName) := $i(finalBind)
+        }
+        tailStmts |> push_from <| qmacro_block_to_array() {
+            if (!$i(foundName)) panic("sequence contains no elements")
+            return <- $i(bindName)
+        }
+    } elif (opName == "single_or_default") {
+        retType = clone_type(elemType)
+        let foundName = qn("decs_found", at)
+        let stopName = qn("decs_stop", at)
+        let bindName = qn("decs_sng", at)
+        let defaultName = qn("decs_dv", at)
+        preludeStmts |> push_from <| qmacro_block_to_array() {
+            var $i(foundName) = false
+            var $i(stopName) = false
+            var $i(bindName) : $t(retType)
+        }
+        preludeStmts |> push <| qmacro_expr() {
+            let $i(defaultName) = $e(terminatorCall.arguments[1])
+        }
+        // 2nd match → set stop, return true (exits inner lambda); for_each_archetype_find then stops the walk.
+        perElement = qmacro_block() {
+            if ($i(foundName)) {
+                $i(stopName) = true
+                return true
+            }
+            $i(foundName) = true
+            $i(bindName) := $i(finalBind)
+        }
+        tailStmts |> push_from <| qmacro_block_to_array() {
+            if ($i(stopName) || !$i(foundName)) return $i(defaultName)
+            return <- $i(bindName)
+        }
+        earlyExitFind = true
+    } elif (opName == "aggregate") {
+        var seedExpr = clone_expression(terminatorCall.arguments[1])
+        var aggFn = clone_expression(terminatorCall.arguments[2])
+        if (seedExpr._type == null) return null
+        var accType = clone_type(seedExpr._type)
+        accType.flags.constant = false
+        accType.flags.ref = false
+        retType = clone_type(accType)
+        let aggAccName = qn("decs_agg", at)
+        let aggIsWorkhorse = seedExpr._type.isWorkhorseType
+        if (aggIsWorkhorse) {
+            preludeStmts |> push <| qmacro_expr() {
+                var $i(aggAccName) : $t(accType) = $e(seedExpr)
+            }
+        } else {
+            preludeStmts |> push <| qmacro_expr() {
+                var $i(aggAccName) : $t(accType) <- $e(seedExpr)
+            }
+        }
+        var peeled = peel_lambda_rename_2vars(aggFn, aggAccName, finalBind)
+        if (peeled != null) {
+            if (aggIsWorkhorse) {
+                perElement = qmacro_expr() {
+                    $i(aggAccName) = $e(peeled)
+                }
+            } else {
+                perElement = qmacro_expr() {
+                    $i(aggAccName) <- $e(peeled)
+                }
+            }
+        } else {
+            if (aggIsWorkhorse) {
+                perElement = qmacro_expr() {
+                    $i(aggAccName) = invoke($e(aggFn), $i(aggAccName), $i(finalBind))
+                }
+            } else {
+                perElement = qmacro_expr() {
+                    $i(aggAccName) <- invoke($e(aggFn), $i(aggAccName), $i(finalBind))
+                }
+            }
+        }
+        if (aggIsWorkhorse) {
+            tailStmts |> push <| qmacro_expr() {
+                return $i(aggAccName)
+            }
+        } else {
+            tailStmts |> push <| qmacro_expr() {
+                return <- $i(aggAccName)
+            }
+        }
+    } else {
+        return null
+    }
+    perElement = wrap_inner_for_with_decs_ranges(perElement, rangeInfo, names)
+    var body = wrap_decs_chain(perElement, chainInfo, calls, intermediateEnd, at)
+    if (body == null) return null
+    var forExprNode = build_decs_inner_for_pruned(bridge, tupName, body, at)
+    let archName = bridge.archName
+    var rangeStmts <- decs_range_prelude(rangeInfo, names)
+    var bodyStmts : array<Expression?>
+    bodyStmts |> reserve(length(preludeStmts) + length(rangeStmts) + length(tailStmts) + 1)
+    bodyStmts |> push_from(preludeStmts)
+    bodyStmts |> push_from(rangeStmts)
+    if (earlyExitFind || rangeInfo.takeExpr != null || rangeInfo.takeWhileCond != null) {
+        bodyStmts |> push <| qmacro_expr() {
+            for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+                $e(forExprNode)
+                return false
+            })
+        }
+    } else {
+        bodyStmts |> push <| qmacro_expr() {
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $e(forExprNode)
+            })
+        }
+    }
+    bodyStmts |> push_from(tailStmts)
+    var emission = qmacro(invoke($() : $t(retType) {
+        $b(bodyStmts)
+    }))
+    emission.force_at(at)
+    emission.force_generated(true)
+    return emission
+}
+
+[macro_function]
+def private emit_decs_element_at(bridge : DecsBridgeShape?;
+                                 opName : string;
+                                 chainInfo : DecsChainInfo?;
+                                 rangeInfo : DecsRangeInfo?;
+                                 var calls : array<tuple<ExprCall?; LinqCall?>>;
+                                 intermediateEnd : int;
+                                 terminatorCall : ExprCall?;
+                                 at : LineInfo) : Expression? {
+    // Slice 5f element_at: counter-driven early-exit via for_each_archetype_find. idx + counter + found + result hoisted at invoke scope; perElement writes result + returns true on cnt == idx match.
+    let tupName = qn("decs_tup", at)
+    let names <- make_decs_range_names(at)
+    let finalBind = chainInfo.finalBind
+    var retType = clone_type(chainInfo.finalType)
+    let idxName = qn("decs_idx", at)
+    let cntName = qn("decs_ec", at)
+    let foundName = qn("decs_found", at)
+    let resultName = qn("decs_res", at)
+    var preludeStmts : array<Expression?>
+    var tailStmts : array<Expression?>
+    preludeStmts |> push <| qmacro_expr() {
+        let $i(idxName) = $e(terminatorCall.arguments[1])
+    }
+    if (opName == "element_at") {
+        preludeStmts |> push <| qmacro_expr() {
+            if ($i(idxName) < 0) panic("element index out of range")
+        }
+        tailStmts |> push_from <| qmacro_block_to_array() {
+            if (!$i(foundName)) panic("element index out of range")
+            return <- $i(resultName)
+        }
+    } else {
+        // element_at_or_default has no user-supplied default arg; returns default<TT>.
+        preludeStmts |> push <| qmacro_expr() {
+            if ($i(idxName) < 0) return default<$t(retType)>
+        }
+        tailStmts |> push_from <| qmacro_block_to_array() {
+            if (!$i(foundName)) return default<$t(retType)>
+            return <- $i(resultName)
+        }
+    }
+    preludeStmts |> push_from <| qmacro_block_to_array() {
+        var $i(cntName) = 0
+        var $i(foundName) = false
+        var $i(resultName) : $t(retType)
+    }
+    var perElement : Expression? = qmacro_block() {
+        if ($i(cntName) == $i(idxName)) {
+            $i(resultName) := $i(finalBind)
+            $i(foundName) = true
+            return true
+        }
+        $i(cntName) ++
+    }
+    perElement = wrap_inner_for_with_decs_ranges(perElement, rangeInfo, names)
+    var body = wrap_decs_chain(perElement, chainInfo, calls, intermediateEnd, at)
+    if (body == null) return null
+    var forExprNode = build_decs_inner_for_pruned(bridge, tupName, body, at)
+    let archName = bridge.archName
+    var rangeStmts <- decs_range_prelude(rangeInfo, names)
+    var bodyStmts : array<Expression?>
+    bodyStmts |> reserve(length(preludeStmts) + length(rangeStmts) + length(tailStmts) + 1)
+    bodyStmts |> push_from(preludeStmts)
+    bodyStmts |> push_from(rangeStmts)
+    bodyStmts |> push <| qmacro_expr() {
+        for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+            $e(forExprNode)
+            return false
+        })
+    }
+    bodyStmts |> push_from(tailStmts)
+    var emission = qmacro(invoke($() : $t(retType) {
+        $b(bodyStmts)
+    }))
+    emission.force_at(at)
+    emission.force_generated(true)
+    return emission
+}
+
+[macro_function]
 def private plan_decs_unroll(var expr : Expression?) : Expression? {
     var (top, calls) = flatten_linq(expr)
     let bridge = extract_decs_bridge(top)
@@ -3915,7 +4172,12 @@ def private plan_decs_unroll(var expr : Expression?) : Expression? {
     let isEarlyExit = (lastName == "first" || lastName == "first_or_default"
         || lastName == "any" || lastName == "all" || lastName == "contains")
     let isMinMaxBy = (lastName == "min_by" || lastName == "max_by")
-    let isTerminator = isAccum || isEarlyExit || isMinMaxBy
+    // Slice 5f: walk-lane (last/single/aggregate) + element_at counter early-exit.
+    let isWalk = (lastName == "last" || lastName == "last_or_default"
+        || lastName == "single" || lastName == "single_or_default"
+        || lastName == "aggregate")
+    let isElementAt = (lastName == "element_at" || lastName == "element_at_or_default")
+    let isTerminator = isAccum || isEarlyExit || isMinMaxBy || isWalk || isElementAt
     let tupName = qn("decs_tup", at)
     let intermediateEnd = isTerminator ? length(calls) - 1 : length(calls)
     // Slice 5a/5b: peel trailing take/skip/take_while/skip_while into rangeInfo. chainEnd is the index past which only range ops live (or == intermediateEnd if none). tupName passed so predicate-driven ranges peel against the source tuple.
@@ -3934,6 +4196,8 @@ def private plan_decs_unroll(var expr : Expression?) : Expression? {
     }
     if (isEarlyExit) return emit_decs_early_exit(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
     if (isMinMaxBy) return emit_decs_min_max_by(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
+    if (isWalk) return emit_decs_walk_lane(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
+    if (isElementAt) return emit_decs_element_at(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
     // Iterator-typed chains cascade to tier-2; only fire to_array when expr is array-typed (user wrote `.to_array()`, peeled by skip=true).
     if (expr._type == null || !expr._type.isGoodArrayType) return null
     return emit_decs_to_array(bridge, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, at)

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -915,14 +915,13 @@ def private emit_early_exit_lane(
                 return <- $i(lastBindName)
             }
         } else {
-            // Bind `d` once at the top (eager, matches linq.das line 2621).
+            // Bind `d` once at the top (eager, matches linq.das line 2621); copy/move probe matches linq.das can_copy/clone_to_move branch.
             let defaultName = qn("dval", at)
-            preludeStmts |> push <| qmacro_expr() {
-                let $i(defaultName) = $e(terminatorCall.arguments[1])
-            }
+            let dvCanCopy = (terminatorCall.arguments[1]._type != null && terminatorCall.arguments[1]._type.canCopy)
+            preludeStmts |> push(emit_default_bind(defaultName, terminatorCall.arguments[1], dvCanCopy))
             tailStmts <- qmacro_block_to_array() {
                 if (!$i(foundName)) {
-                    return $i(defaultName)
+                    $e(emit_default_return(defaultName, dvCanCopy))
                 }
                 return <- $i(lastBindName)
             }
@@ -961,20 +960,19 @@ def private emit_early_exit_lane(
             }
         } else {
             let defaultName = qn("dval", at)
-            preludeStmts |> push <| qmacro_expr() {
-                let $i(defaultName) = $e(terminatorCall.arguments[1])
-            }
+            let dvCanCopy = (terminatorCall.arguments[1]._type != null && terminatorCall.arguments[1]._type.canCopy)
+            preludeStmts |> push(emit_default_bind(defaultName, terminatorCall.arguments[1], dvCanCopy))
             // `single_or_default` early-returns default on the SECOND match (subsequent matches don't matter).
             perMatchStmts |> push_from <| qmacro_block_to_array() {
                 if ($i(foundName)) {
-                    return $i(defaultName)
+                    $e(emit_default_return(defaultName, dvCanCopy))
                 }
                 $i(foundName) = true
                 $i(bindName) := $i(valueName)
             }
             tailStmts <- qmacro_block_to_array() {
                 if (!$i(foundName)) {
-                    return $i(defaultName)
+                    $e(emit_default_return(defaultName, dvCanCopy))
                 }
                 return <- $i(bindName)
             }
@@ -1003,9 +1001,12 @@ def private emit_early_exit_lane(
                 }
             }
         } else {
-            preludeStmts |> push <| qmacro_expr() {
+            // `var t : TT; return <- t` (move-init) works for both copyable and non-copyable element types; matches linq.das line 2547.
+            let tName = qn("emptyT", at)
+            preludeStmts |> push_from <| qmacro_block_to_array() {
                 if ($i(idxName) < 0) {
-                    return default<$t(retType)>
+                    var $i(tName) : $t(retType)
+                    return <- $i(tName)
                 }
             }
         }
@@ -1019,13 +1020,17 @@ def private emit_early_exit_lane(
             $i(cntName) ++
         }
         if (opName == "element_at") {
+            let tName = qn("emptyT", at)
             tailStmts <- qmacro_block_to_array() {
                 panic("element index out of range")
-                return default<$t(retType)>
+                var $i(tName) : $t(retType)
+                return <- $i(tName)
             }
         } else {
-            tailStmts |> push <| qmacro_expr() {
-                return default<$t(retType)>
+            let tName = qn("emptyT", at)
+            tailStmts |> push_from <| qmacro_block_to_array() {
+                var $i(tName) : $t(retType)
+                return <- $i(tName)
             }
         }
     } elif (opName == "aggregate") {
@@ -3434,6 +3439,38 @@ def private decs_range_prelude(rangeInfo : DecsRangeInfo?; names : DecsRangeStat
 }
 
 [macro_function]
+def private emit_default_bind(name : string; argExpr : Expression?; canCopy : bool) : Expression? {
+    // Bind user-supplied default once. Non-copyable uses `var dv <- clone_to_move(arg)` — fully-owned local so multiple return-default sites can each clone-out without consuming.
+    var out : Expression?
+    if (canCopy) {
+        out = qmacro_expr() {
+            let $i(name) = $e(argExpr)
+        }
+    } else {
+        out = qmacro_expr() {
+            var $i(name) <- clone_to_move($e(argExpr))
+        }
+    }
+    return out
+}
+
+[macro_function]
+def private emit_default_return(name : string; canCopy : bool) : Expression? {
+    // Non-copyable uses `return <- clone_to_move(name)` (safe repeated calls — clone_to_move does NOT consume).
+    var out : Expression?
+    if (canCopy) {
+        out = qmacro_expr() {
+            return $i(name)
+        }
+    } else {
+        out = qmacro_expr() {
+            return <- clone_to_move($i(name))
+        }
+    }
+    return out
+}
+
+[macro_function]
 def private emit_decs_count_archsize(bridge : DecsBridgeShape?; at : LineInfo) : Expression? {
     // Bare count(): no chain ops, sum arch.size per archetype — skips the per-entity walk entirely.
     let accName = qn("decs_acc", at)
@@ -3938,11 +3975,12 @@ def private emit_decs_walk_lane(bridge : DecsBridgeShape?;
             }
         } else {
             let defaultName = qn("decs_dv", at)
-            preludeStmts |> push <| qmacro_expr() {
-                let $i(defaultName) = $e(terminatorCall.arguments[1])
-            }
+            let dvCanCopy = (terminatorCall.arguments[1]._type != null && terminatorCall.arguments[1]._type.canCopy)
+            preludeStmts |> push(emit_default_bind(defaultName, terminatorCall.arguments[1], dvCanCopy))
             tailStmts |> push_from <| qmacro_block_to_array() {
-                if (!$i(foundName)) return $i(defaultName)
+                if (!$i(foundName)) {
+                    $e(emit_default_return(defaultName, dvCanCopy))
+                }
                 return <- $i(bindName)
             }
         }
@@ -3970,14 +4008,13 @@ def private emit_decs_walk_lane(bridge : DecsBridgeShape?;
         let stopName = qn("decs_stop", at)
         let bindName = qn("decs_sng", at)
         let defaultName = qn("decs_dv", at)
+        let dvCanCopy = (terminatorCall.arguments[1]._type != null && terminatorCall.arguments[1]._type.canCopy)
         preludeStmts |> push_from <| qmacro_block_to_array() {
             var $i(foundName) = false
             var $i(stopName) = false
             var $i(bindName) : $t(retType)
         }
-        preludeStmts |> push <| qmacro_expr() {
-            let $i(defaultName) = $e(terminatorCall.arguments[1])
-        }
+        preludeStmts |> push(emit_default_bind(defaultName, terminatorCall.arguments[1], dvCanCopy))
         // 2nd match → set stop, return true (exits inner lambda); for_each_archetype_find then stops the walk.
         perElement = qmacro_block() {
             if ($i(foundName)) {
@@ -3988,7 +4025,9 @@ def private emit_decs_walk_lane(bridge : DecsBridgeShape?;
             $i(bindName) := $i(finalBind)
         }
         tailStmts |> push_from <| qmacro_block_to_array() {
-            if ($i(stopName) || !$i(foundName)) return $i(defaultName)
+            if ($i(stopName) || !$i(foundName)) {
+                $e(emit_default_return(defaultName, dvCanCopy))
+            }
             return <- $i(bindName)
         }
         earlyExitFind = true
@@ -4110,12 +4149,19 @@ def private emit_decs_element_at(bridge : DecsBridgeShape?;
             return <- $i(resultName)
         }
     } else {
-        // element_at_or_default has no user-supplied default arg; returns default<TT>.
-        preludeStmts |> push <| qmacro_expr() {
-            if ($i(idxName) < 0) return default<$t(retType)>
+        // element_at_or_default has no user-supplied default; mirrors linq.das via `var t : TT; return <- t` (move-init, works for both copyable and non-copyable element types).
+        let tName = qn("decs_emptyT", at)
+        preludeStmts |> push_from <| qmacro_block_to_array() {
+            if ($i(idxName) < 0) {
+                var $i(tName) : $t(retType)
+                return <- $i(tName)
+            }
         }
         tailStmts |> push_from <| qmacro_block_to_array() {
-            if (!$i(foundName)) return default<$t(retType)>
+            if (!$i(foundName)) {
+                var $i(tName) : $t(retType)
+                return <- $i(tName)
+            }
             return <- $i(resultName)
         }
     }

--- a/tests/linq/test_linq_fold_non_copyable_default.das
+++ b/tests/linq/test_linq_fold_non_copyable_default.das
@@ -1,0 +1,63 @@
+options gen2
+require daslib/linq
+require daslib/linq_boost
+require dastest/testing_boost public
+
+// Regression for PR #2822 Copilot review (commit after `550494bfc`).
+//
+// emit_default_bind / emit_default_return in daslib/linq_fold.das emit the
+// can_copy / clone_to_move branch matching daslib/linq.das:
+//   copyable    → let dv = arg            ; return dv
+//   non-copyable → var dv <- clone_to_move(arg); return <- clone_to_move(dv)
+//
+// Prior emit (`let dv = arg` + `return dv`) compile-errored on the prelude
+// bind itself for non-copyable types (e.g. array<int>).
+//
+// Scope: default-return path for last_or_default / single_or_default.
+// element_at_or_default's success path (`return $i(valueName)`) still
+// plain-returns the element — pre-existing on both paths, separate fix.
+
+[test]
+def test_last_or_default_non_copyable(t : T?) {
+    t |> run("array<int> default — empty source returns default") @(tt : T?) {
+        var src : array<array<int>>
+        var dflt : array<int>
+        dflt |> push(100)
+        dflt |> push(200)
+        let r <- _fold(each(src).last_or_default(dflt))
+        tt |> equal(length(r), 2, "non-copyable default returned via clone_to_move")
+        tt |> equal(r[0], 100)
+        tt |> equal(r[1], 200)
+    }
+}
+
+[test]
+def test_single_or_default_non_copyable_empty(t : T?) {
+    t |> run("array<int> default — empty source returns default") @(tt : T?) {
+        var src : array<array<int>>
+        var dflt : array<int>
+        dflt |> push(7)
+        let r <- _fold(each(src).single_or_default(dflt))
+        tt |> equal(length(r), 1)
+        tt |> equal(r[0], 7)
+    }
+}
+
+[test]
+def test_single_or_default_non_copyable_multi_match(t : T?) {
+    t |> run("array<int> default — multi-match returns default") @(tt : T?) {
+        var src : array<array<int>>
+        var a : array<int>
+        a |> push(1)
+        src |> emplace(a)
+        var b : array<int>
+        b |> push(2)
+        src |> emplace(b)
+        var dflt : array<int>
+        dflt |> push(99)
+        // 2 matches → single_or_default returns default
+        let r <- _fold(each(src).single_or_default(dflt))
+        tt |> equal(length(r), 1, "default returned on 2nd-match")
+        tt |> equal(r[0], 99)
+    }
+}

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -2878,3 +2878,220 @@ def test_lambda_pruned_select_sum_splice_shape(t : T?) {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 5f: walk terminators (last / single / aggregate) + element_at
+//          — the 4 outliers from PR #2812's m4 bench snapshot
+// ─────────────────────────────────────────────────────────────────────────────
+
+[export, marker(no_coverage)]
+def target_unroll_last_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._select(_.val).last())
+}
+
+[export, marker(no_coverage)]
+def target_unroll_last_or_default_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._where(_.val > 1000)._select(_.val).last_or_default(-9))
+}
+
+[export, marker(no_coverage)]
+def target_unroll_single_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._where(_.val == 3)._select(_.val).single())
+}
+
+[export, marker(no_coverage)]
+def target_unroll_single_or_default_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._where(_.val > 1000)._select(_.val).single_or_default(-7))
+}
+
+[export, marker(no_coverage)]
+def target_unroll_aggregate_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._select(_.val).aggregate(0) <| $(a, x) => a + x * x)
+}
+
+[export, marker(no_coverage)]
+def target_unroll_element_at_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._select(_.val).element_at(3))
+}
+
+[export, marker(no_coverage)]
+def target_unroll_element_at_or_default_fold() : int {
+    // element_at_or_default returns default<int> (0) on out-of-range; no user-supplied default.
+    return _fold(from_decs_template(type<UnrollChainRow>)._select(_.val).element_at_or_default(999))
+}
+
+[test]
+def test_unroll_last_parity(t : T?) {
+    fixture_unroll2(5)
+    // vals 0..4 → last is 4
+    t |> equal(target_unroll_last_fold(), 4, "last splice parity")
+}
+
+[test]
+def test_unroll_last_or_default_empty(t : T?) {
+    fixture_unroll2(5)
+    // val>1000 → none → default -9
+    t |> equal(target_unroll_last_or_default_fold(), -9, "last_or_default empty source")
+}
+
+[test]
+def test_unroll_single_parity(t : T?) {
+    fixture_unroll2(5)
+    // val==3 matches exactly once → 3
+    t |> equal(target_unroll_single_fold(), 3, "single splice parity")
+}
+
+[test]
+def test_unroll_single_or_default_empty(t : T?) {
+    fixture_unroll2(5)
+    // val>1000 → none → default -7
+    t |> equal(target_unroll_single_or_default_fold(), -7, "single_or_default empty source")
+}
+
+[export, marker(no_coverage)]
+def target_unroll_single_or_default_multi_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._where(_.val < 100)._select(_.val).single_or_default(-7))
+}
+
+[test]
+def test_unroll_single_or_default_multi(t : T?) {
+    fixture_unroll2(5)
+    // 5 rows match → single_or_default returns default on 2nd match
+    t |> equal(target_unroll_single_or_default_multi_fold(), -7, "single_or_default returns default when >1 match")
+}
+
+[test]
+def test_unroll_aggregate_parity(t : T?) {
+    fixture_unroll2(5)
+    // 0^2 + 1^2 + 2^2 + 3^2 + 4^2 = 30
+    t |> equal(target_unroll_aggregate_fold(), 30, "aggregate sum-of-squares splice parity")
+}
+
+[test]
+def test_unroll_aggregate_empty(t : T?) {
+    fixture_unroll2(0)
+    // empty source → returns seed
+    t |> equal(target_unroll_aggregate_fold(), 0, "aggregate empty returns seed")
+}
+
+[test]
+def test_unroll_element_at_parity(t : T?) {
+    fixture_unroll2(5)
+    // vals 0..4, element_at(3) → 3
+    t |> equal(target_unroll_element_at_fold(), 3, "element_at splice parity")
+}
+
+[test]
+def test_unroll_element_at_or_default_out_of_range(t : T?) {
+    fixture_unroll2(5)
+    // idx 999 way past end → default<int> == 0
+    t |> equal(target_unroll_element_at_or_default_fold(), 0, "element_at_or_default out-of-range → default<int>")
+}
+
+// Range interaction: take + last / take + aggregate
+[export, marker(no_coverage)]
+def target_unroll_take_last_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._select(_.val).take(3).last())
+}
+
+[test]
+def test_unroll_take_last_parity(t : T?) {
+    fixture_unroll2(10)
+    // take(3) of 0..9 → 0,1,2 → last is 2
+    t |> equal(target_unroll_take_last_fold(), 2, "take+last interaction")
+}
+
+[export, marker(no_coverage)]
+def target_unroll_where_aggregate_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>)._where(_.flag == 1)._select(_.val).aggregate(0) <| $(a, x) => a + x)
+}
+
+[test]
+def test_unroll_where_aggregate_parity(t : T?) {
+    fixture_unroll2(5)
+    // flag==1 rows: vals 1,3 → 1+3 = 4
+    t |> equal(target_unroll_where_aggregate_fold(), 4, "where+aggregate interaction")
+}
+
+// Splice-shape gates: emit must not hit to_sequence; exact for_each_archetype{,_find} dispatch
+[test]
+def test_unroll_last_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_last_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_last_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "last splice must NOT call to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "last (no range) uses plain for_each_archetype")
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 0, "last (no range) does NOT need _find")
+    }
+}
+
+[test]
+def test_unroll_single_or_default_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_single_or_default_multi_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_single_or_default_multi_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "single_or_default splice must NOT call to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 1, "single_or_default uses _find for early-exit on 2nd match")
+    }
+}
+
+[test]
+def test_unroll_aggregate_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_aggregate_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_aggregate_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "aggregate splice must NOT call to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "aggregate (no range) uses plain for_each_archetype")
+    }
+}
+
+[test]
+def test_unroll_element_at_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_element_at_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_element_at_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "element_at splice must NOT call to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 1, "element_at uses _find for counter early-exit")
+    }
+}
+
+[test]
+def test_unroll_take_last_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_take_last_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_take_last_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "take+last splice must NOT call to_sequence")
+        // take present → bool-lambda dispatch (for_each_archetype_find) so the range's `return true` exits the walk
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 1, "take+last uses _find when range present")
+    }
+}
+


### PR DESCRIPTION
## Summary

Closes the 4 outliers identified in PR #2812's m4 bench snapshot. These terminators were falling through to `to_sequence` materialization because `plan_decs_unroll` only recognized `first`/`any`/`all`/`contains`/`min_by`/`max_by` plus the accumulator family. Wave 5 extends the splice path to cover walk-all single-return terminators + `element_at` counter early-exit.

**`emit_decs_walk_lane`** (`last` / `last_or_default` / `single` / `single_or_default` / `aggregate`):
- State (found flag, retained element, accumulator) hoisted at invoke scope so it persists across archetype boundaries.
- `single_or_default` uses `for_each_archetype_find` for early-exit on 2nd match (sets stop flag, returns `true` from inner lambda); others use plain `for_each_archetype` unless `take`/`take_while` forces bool-lambda dispatch.
- `aggregate` mirrors `emit_accumulator_lane`'s workhorse / non-workhorse seed branch (`=` vs `<-`) and peel-or-invoke fallback for the binary lambda.

**`emit_decs_element_at`** (`element_at` / `element_at_or_default`):
- `idx` + counter + `found` + result hoisted at invoke scope.
- `perElement` compares `cnt == idx`, writes result + returns `true` on match (uses `for_each_archetype_find` for the counter early-exit).
- Pre-loop `idx<0` panic (`element_at`) or `return default<T>` (`_or_default`).
- Tail handles "not found" = out-of-range = `idx >= effective length`.

## Bench (INTERP, 100K rows, ns/op)

| Lane | master m4 | branch m4 | speedup | vs m3f |
|---|---|---|---|---|
| `last_match` | 82 | 17 | 4.8× | 17 vs 5 |
| `single_match` | 80 | 14 | 5.7× | 14 vs 3 |
| `aggregate_match` | 82 | 7 | 11.7× | **7 vs 5 ≈ matches** |
| `element_at_match` | 34 | 0 | ∞ | **0 vs 0 matches** |

Per-op allocs drop **84 B → 1 B** across all four — eliminated the `array<tuple>` materialization.

## Test plan

- [x] 16 new tests in `tests/linq/test_linq_from_decs.das` (8 parity + 4 splice-shape gates + 2 range-interaction + 2 multi-match edge cases)
- [x] 185 tests in file (up from 169)
- [x] 1376 `tests/linq` suite — interp + AOT green
- [x] 245 `tests/decs` suite — interp + AOT green
- [x] 371 `tests/ast_match` + 10 `tests/template` + 9 `tests/macro_call` + 27 `tests/macro_boost` green
- [x] Non-outlier bench smoke (`count_aggregate_m4`) unchanged at 6 ns/op
- [x] Lint clean on `daslib/linq_fold.das`

🤖 Generated with [Claude Code](https://claude.com/claude-code)