### PR TITLE
ci: bundle install-rule regression test (fixes utils/mcp shipped without cpp_search_config.das in 0.6.2-RC3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,3 +412,62 @@ jobs:
             ;;
         esac
 
+  ###########################################################
+  bundle_smoke:
+  ###########################################################
+  # Catches release-bundle install-rule regressions at PR time on the
+  # platform that produces 95% of such bugs (Linux x86_64). Mirrors the
+  # release.yml linux64 build path: same module flags via ci/release_modules.txt,
+  # same install layout (cmake --install --prefix ./daslang_bundle), same
+  # ci/smoke_test_bundle.sh that release.yml runs. Full-matrix smoke is
+  # still gated at release-cut time in release.yml.
+  ###########################################################
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest-fat
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - name: "Install CMake and Ninja"
+      uses: lukka/get-cmake@latest
+
+    - name: "Install: Required Dev Packages"
+      run: |
+        set -eux
+        sudo apt-get update -y
+        sudo apt-get install --no-install-recommends -y \
+          libatomic-ops-dev \
+          libglu1-mesa-dev \
+          freeglut3-dev \
+          mesa-common-dev \
+          libglfw3-dev \
+          libfreetype6-dev \
+          libudev-dev \
+          libopenal-dev \
+          libvorbis-dev \
+          libflac-dev \
+          libx11-dev \
+          libxrandr-dev \
+          libxcursor-dev \
+          libxinerama-dev \
+          libxi-dev
+
+    - name: "Build: Daslang with release modules"
+      run: |
+        set -eux
+        mkdir build
+        ACTIVE_MODULES=$(cat ci/release_modules.txt | grep -v "^#" | cut -d':' -f2 | sed 's|^|-D|' | xargs)
+        CC=clang CXX=clang++ cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=Release \
+          -G Ninja $ACTIVE_MODULES
+        cmake --build ./build --config Release --parallel
+
+    - name: "Install bundle"
+      run: |
+        set -eux
+        mkdir daslang_bundle
+        cmake --install ./build --prefix ./daslang_bundle --config Release --strip
+
+    - name: "Smoke-test installed bundle"
+      run: bash ci/smoke_test_bundle.sh ./daslang_bundle
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,10 @@ jobs:
           mkdir artifacts
           cmake --install ./build --prefix ./daslang_bundle --config ${{ matrix.cmake_preset }} --strip
           7z a artifacts/daslang-bundle-${{ matrix.release_target }}-${{ matrix.release_arch }}.zip ./daslang_bundle
+      - name: "Smoke-test installed bundle"
+        if: matrix.cmake_preset == 'Release'
+        shell: bash
+        run: bash ci/smoke_test_bundle.sh ./daslang_bundle
       - name: "Upload release asset"
         if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased') && matrix.cmake_preset == 'Release'
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1542,6 +1542,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/utils/aot/main.das DESTINATION utils/aot)
 install(FILES
     ${PROJECT_SOURCE_DIR}/utils/mcp/main.das
     ${PROJECT_SOURCE_DIR}/utils/mcp/protocol.das
+    ${PROJECT_SOURCE_DIR}/utils/mcp/cpp_search_config.das
     ${PROJECT_SOURCE_DIR}/utils/mcp/README.md
     DESTINATION utils/mcp
 )

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -21,8 +21,11 @@ if [[ $# -lt 1 ]]; then
     exit 2
 fi
 
-BUNDLE="$1"
-[[ -d "$BUNDLE" ]] || { echo "ERROR: bundle dir not found: $BUNDLE" >&2; exit 2; }
+# Canonicalize to absolute up front. The script `cd "$BUNDLE"` later, so any
+# relative path baked into $DASLANG / exe paths would resolve from the wrong
+# cwd and every check would fail with command-not-found.
+BUNDLE="$(cd "$1" 2>/dev/null && pwd -P)" \
+    || { echo "ERROR: bundle dir not found or not enterable: $1" >&2; exit 2; }
 
 if [[ -x "$BUNDLE/bin/daslang.exe" ]]; then
     DASLANG="$BUNDLE/bin/daslang.exe"

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -27,16 +27,29 @@ fi
 BUNDLE="$(cd "$1" 2>/dev/null && pwd -P)" \
     || { echo "ERROR: bundle dir not found or not enterable: $1" >&2; exit 2; }
 
-if [[ -x "$BUNDLE/bin/daslang.exe" ]]; then
+# Two exe naming conventions coexist in the bundle:
+#   * CPP_SUFFIX — for binaries built via cmake `add_executable` (daslang,
+#     daslang-live, das-fmt): platform-natural suffix (.exe on Windows,
+#     none on Linux/macOS).
+#   * DASEXE_SUFFIX — for binaries built via `daslang -exe` (aot, benchctl,
+#     dascov, daspkg, dastest, detect-dupe, hygiene, mcp): ALWAYS `.exe`
+#     on every platform (utils/CMakeLists.txt: "daslang -exe appends `.exe`
+#     to the output path"). On Linux the bundle has `daslang` + `mcp.exe`
+#     side by side.
+# Use `-f` (file-exists) rather than `-x` (executable bit) — Windows Git-Bash
+# doesn't see the +x bit on Linux ELF binaries even when this script runs
+# locally on a Linux-bundle for cross-platform repro.
+if [[ -f "$BUNDLE/bin/daslang.exe" ]]; then
     DASLANG="$BUNDLE/bin/daslang.exe"
-    EXE_SUFFIX=".exe"
-elif [[ -x "$BUNDLE/bin/daslang" ]]; then
+    CPP_SUFFIX=".exe"
+elif [[ -f "$BUNDLE/bin/daslang" ]]; then
     DASLANG="$BUNDLE/bin/daslang"
-    EXE_SUFFIX=""
+    CPP_SUFFIX=""
 else
     echo "ERROR: daslang binary not found in $BUNDLE/bin/" >&2
     exit 2
 fi
+DASEXE_SUFFIX=".exe"
 
 cd "$BUNDLE"
 
@@ -63,21 +76,22 @@ COMPILE_TESTS=(
 #               fetched at runtime + ANTHROPIC_API_KEY.
 
 # Prebuilt exes that `cmake --install` should drop into bin/ when build flags
-# allow it (DAS_LLVM, DAS_SQLITE, DAS_HV gates). Presence-checked only — we
-# don't run them with `--help` because daslang itself intercepts `--help` and
-# prints its own usage even after the `--` separator, swallowing the script's
-# CLI surface.
+# allow it (DAS_LLVM, DAS_SQLITE, DAS_HV gates). Each row is `name|kind` where
+# kind is `dasexe` (daslang -exe output, always .exe) or `cpp` (cmake
+# add_executable, platform suffix). Presence-checked only — we don't run them
+# with `--help` because daslang itself intercepts `--help` and prints its own
+# usage even after the `--` separator, swallowing the script's CLI surface.
 EXE_PRESENCE_TESTS=(
-    "aot"
-    "benchctl"
-    "das-fmt"
-    "dascov"
-    "daslang-live"
-    "daspkg"
-    "dastest"
-    "detect-dupe"
-    "hygiene"
-    "mcp"
+    "aot|dasexe"
+    "benchctl|dasexe"
+    "das-fmt|cpp"
+    "dascov|dasexe"
+    "daslang-live|cpp"
+    "daspkg|dasexe"
+    "dastest|dasexe"
+    "detect-dupe|dasexe"
+    "hygiene|dasexe"
+    "mcp|dasexe"
 )
 
 # Stdio launch test for mcp.exe — it's a JSON-RPC server, so the only safe
@@ -120,10 +134,17 @@ done
 
 echo
 echo "Prebuilt exe presence (bin/):"
-for name in "${EXE_PRESENCE_TESTS[@]}"; do
-    exe="$BUNDLE/bin/${name}${EXE_SUFFIX}"
+for entry in "${EXE_PRESENCE_TESTS[@]}"; do
+    name="${entry%%|*}"
+    kind="${entry#*|}"
+    case "$kind" in
+        dasexe) suffix="$DASEXE_SUFFIX" ;;
+        cpp)    suffix="$CPP_SUFFIX" ;;
+        *)      echo "ERROR: unknown kind '$kind' for $name" >&2; FAIL=$((FAIL + 1)); continue ;;
+    esac
+    exe="$BUNDLE/bin/${name}${suffix}"
     printf '  %-30s ' "$name"
-    if [[ -x "$exe" ]]; then
+    if [[ -f "$exe" ]]; then
         echo "OK"
         PASS=$((PASS + 1))
     else
@@ -135,7 +156,7 @@ done
 echo
 echo "Runtime launch:"
 run_check "mcp.exe (empty stdin)" bash -c \
-    "'$BUNDLE/bin/mcp${EXE_SUFFIX}' < /dev/null"
+    "'$BUNDLE/bin/mcp${DASEXE_SUFFIX}' < /dev/null"
 run_check "mcp.das (empty stdin)" bash -c \
     "'$DASLANG' utils/mcp/main.das < /dev/null"
 

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Verify that every utility in a daslang release bundle at least launches.
+#
+# Designed to catch install-rule regressions like the v0.6.2-RC3
+# `utils/mcp/cpp_search_config.das` miss, where the README-documented
+# launch (`daslang.exe utils/mcp/main.das`) failed at parse time because
+# a top-level peer of `main.das` was omitted from CMake's install(FILES …)
+# list.
+#
+# Usage:  bash ci/smoke_test_bundle.sh <bundle-root>
+#
+# <bundle-root> is the directory produced by `cmake --install … --prefix <dir>`
+# (contains bin/, daslib/, utils/, modules/, …).
+#
+# Exit 0 if every check passes; non-zero with a per-check failure log otherwise.
+
+set -u
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <bundle-root>" >&2
+    exit 2
+fi
+
+BUNDLE="$1"
+[[ -d "$BUNDLE" ]] || { echo "ERROR: bundle dir not found: $BUNDLE" >&2; exit 2; }
+
+if [[ -x "$BUNDLE/bin/daslang.exe" ]]; then
+    DASLANG="$BUNDLE/bin/daslang.exe"
+    EXE_SUFFIX=".exe"
+elif [[ -x "$BUNDLE/bin/daslang" ]]; then
+    DASLANG="$BUNDLE/bin/daslang"
+    EXE_SUFFIX=""
+else
+    echo "ERROR: daslang binary not found in $BUNDLE/bin/" >&2
+    exit 2
+fi
+
+cd "$BUNDLE"
+
+# Source-based tests — `daslang -compile-only` parses + infers + links requires
+# without executing. This is what catches install-rule misses: a missing peer
+# `.das` file surfaces as `error[20605]: missing prerequisite …`.
+#
+# Add a row when a new util ships a .das entry point. The list is intentionally
+# explicit (no glob) so removing a util is a deliberate one-line change.
+COMPILE_TESTS=(
+    "aot|utils/aot/main.das"
+    "benchctl|utils/benchctl/main.das"
+    "das-fmt|utils/das-fmt/dasfmt.das"
+    "dascov|utils/dascov/main.das"
+    "daspkg|utils/daspkg/main.das"
+    "detect-dupe|utils/detect-dupe/main.das"
+    "hygiene|utils/hygiene/main.das"
+    "lint|utils/lint/main.das"
+    "mcp|utils/mcp/main.das"
+)
+
+# Tools intentionally NOT in COMPILE_TESTS:
+#   find-dupe — require chain needs the `anthropic/anthropic` daspkg package
+#               fetched at runtime + ANTHROPIC_API_KEY.
+
+# Prebuilt exes that `cmake --install` should drop into bin/ when build flags
+# allow it (DAS_LLVM, DAS_SQLITE, DAS_HV gates). Presence-checked only — we
+# don't run them with `--help` because daslang itself intercepts `--help` and
+# prints its own usage even after the `--` separator, swallowing the script's
+# CLI surface.
+EXE_PRESENCE_TESTS=(
+    "aot"
+    "benchctl"
+    "das-fmt"
+    "dascov"
+    "daslang-live"
+    "daspkg"
+    "dastest"
+    "detect-dupe"
+    "hygiene"
+    "mcp"
+)
+
+# Stdio launch test for mcp.exe — it's a JSON-RPC server, so the only safe
+# "did it actually start" probe is to feed empty stdin and check for a clean
+# exit. The bundled mcp.exe prints "Starting daslang MCP server" then
+# "stdin closed, shutting down" within ~1s.
+
+PASS=0
+FAIL=0
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+run_check() {
+    local label="$1"; shift
+    printf '  %-30s ' "$label"
+    if "$@" > "$LOG" 2>&1; then
+        echo "OK"
+        PASS=$((PASS + 1))
+    else
+        local rc=$?
+        echo "FAIL (exit $rc)"
+        sed 's/^/      /' "$LOG"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "==================================================================="
+echo "daslang bundle smoke test"
+echo "  bundle : $BUNDLE"
+echo "  daslang: $DASLANG"
+echo "==================================================================="
+
+echo
+echo "Source compile (-compile-only):"
+for entry in "${COMPILE_TESTS[@]}"; do
+    name="${entry%%|*}"
+    path="${entry#*|}"
+    run_check "$name" "$DASLANG" -compile-only "$path"
+done
+
+echo
+echo "Prebuilt exe presence (bin/):"
+for name in "${EXE_PRESENCE_TESTS[@]}"; do
+    exe="$BUNDLE/bin/${name}${EXE_SUFFIX}"
+    printf '  %-30s ' "$name"
+    if [[ -x "$exe" ]]; then
+        echo "OK"
+        PASS=$((PASS + 1))
+    else
+        echo "MISSING ($exe)"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo
+echo "Runtime launch:"
+run_check "mcp.exe (empty stdin)" bash -c \
+    "'$BUNDLE/bin/mcp${EXE_SUFFIX}' < /dev/null"
+run_check "mcp.das (empty stdin)" bash -c \
+    "'$DASLANG' utils/mcp/main.das < /dev/null"
+
+echo
+echo "==================================================================="
+if [[ $FAIL -eq 0 ]]; then
+    echo "ALL OK ($PASS checks passed)"
+    exit 0
+else
+    echo "FAILED: $FAIL failure(s), $PASS pass(es)"
+    exit 1
+fi

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -116,17 +116,24 @@ if(MSVC)
 else()
     set(_UTIL_INSTALL_PATTERN "${PROJECT_SOURCE_DIR}/bin")
 endif()
+# `daslang -exe` writes its output via fopen("wb") which gives 0644 on Linux/
+# macOS — no executable bit. file(INSTALL) defaults to preserving source perms,
+# so without explicit FILE_PERMISSIONS the installed copy is non-executable
+# and users must `chmod +x` before running. v0.6.2-RC3 Linux bundle shipped
+# this way (all 8 daslang -exe outputs were `-rw-r--r--`).
 foreach(util ${DAS_UTILS})
     install(CODE "
         set(_util_exe \"${_UTIL_INSTALL_PATTERN}/${util}.exe\")
         if(EXISTS \"\${_util_exe}\")
-            file(INSTALL \"\${_util_exe}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${DAS_INSTALL_BINDIR}\")
+            file(INSTALL \"\${_util_exe}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${DAS_INSTALL_BINDIR}\"
+                FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
         endif()
     ")
 endforeach()
 install(CODE "
     set(_util_exe \"${_UTIL_INSTALL_PATTERN}/dastest.exe\")
     if(EXISTS \"\${_util_exe}\")
-        file(INSTALL \"\${_util_exe}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${DAS_INSTALL_BINDIR}\")
+        file(INSTALL \"\${_util_exe}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${DAS_INSTALL_BINDIR}\"
+            FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
     endif()
 ")


### PR DESCRIPTION
## Why

`v0.6.2-RC3` ships `utils/mcp/` without `cpp_search_config.das`. Users following the README launch (`daslang utils/mcp/main.das`, or `claude mcp add daslang -- ./bin/daslang utils/mcp/main.das`) hit:

```
error[20605]: missing prerequisite '../cpp_search_config.das'; file not found
    from utils/mcp/tools/cpp_common.das
    required from utils/mcp/tools/find_symbol.das
    required from utils/mcp/protocol.das
    required from utils/mcp/main.das
```

The prebuilt `bin/mcp.exe` works fine — `daslang -exe` AOT-links all `.das` into the binary, so the missing source file isn't noticed. Only the README-documented launch path is broken.

**Root cause**: [CMakeLists.txt:1542-1547](CMakeLists.txt#L1542) hand-lists three top-level files of `utils/mcp/`. When commit a093d5e4f ("mcp: C++ source-search tools + cpp_search_config + git-signature staleness") added `cpp_search_config.das` as a new peer of `main.das`/`protocol.das`, this install rule wasn't updated. The bug is **live on master** — every release built from current master ships broken.

## What this PR does

1. **Fix MCP install rule**: adds `cpp_search_config.das` to the install list — one line.
2. **`ci/smoke_test_bundle.sh`** — new shared script. For each shipped util it runs `daslang -compile-only utils/<name>/main.das` (catches install-rule misses by exercising the require chain), checks prebuilt exe presence in `bin/`, and exercises `mcp`'s stdio path with empty stdin. Exits non-zero on any miss, with the failing diagnostic inlined.
3. **`release.yml`** — inserts a `Smoke-test installed bundle` step between `Install binaries` and `Upload release asset`. A broken bundle now fails the upload step across all 5 platform cells (linux x86_64, linux arm64, darwin15, darwin26, windows).
4. **`build.yml`** — new `bundle_smoke` job, single Linux x86_64 cell. Runs on every PR (not gated to `utils/`/`CMakeLists.txt` changes by design — install-rule regressions can land from anywhere, e.g. a daslang-core change altering `-exe` output semantics). Mirrors `release.yml`'s linux64 build flags via `ci/release_modules.txt`. ~10 min/PR.
5. **`utils/CMakeLists.txt` install perms**: explicit `FILE_PERMISSIONS … OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE` on `file(INSTALL ${util}.exe …)`. **Behavioral change for downstream packagers**: previously, the 8 `daslang -exe`-built utils (`aot.exe`, `benchctl.exe`, `dascov.exe`, `daspkg.exe`, `dastest.exe`, `detect-dupe.exe`, `hygiene.exe`, `mcp.exe`) installed without the executable bit on Linux/macOS (0644). Released RC3 Linux bundle inspection confirmed: all 8 were `-rw-r--r--`, requiring `chmod +x` before any could run. From this PR onwards they install as `0755`. No-op on Windows (`.exe` extension grants execution).

   The root cause is upstream in `daslang -exe` itself — `fopen("wb")` gives 0644 with no follow-up chmod. Fixing it at the install layer here so RC4 ships correct without touching the LLVM JIT linker code path. **Follow-up**: open an issue to chmod the daslang-side output too.

## Coverage

Source-compile (`daslang -compile-only utils/<name>/main.das`):
`aot`, `benchctl`, `das-fmt`, `dascov`, `daspkg`, `detect-dupe`, `hygiene`, `lint`, `mcp`.

Prebuilt exe presence (`bin/<name>{.exe}`):
`aot`, `benchctl`, `das-fmt`, `dascov`, `daslang-live`, `daspkg`, `dastest`, `detect-dupe`, `hygiene`, `mcp`.

The script distinguishes two naming conventions: cpp-built (platform suffix — `daslang`, `daslang-live`, `das-fmt`) vs. `daslang -exe` outputs (always `.exe` on every platform per `utils/CMakeLists.txt`).

Runtime launch:
`mcp.exe` and `mcp.das` both via `< /dev/null` (JSON-RPC server clean-shutdown probe).

Skipped: `find-dupe` — needs `daspkg install` + `ANTHROPIC_API_KEY`.

## Iteration log (CI surfaced 3 distinct latent RC3 bugs)

- **Round 1 (Copilot)**: relative `./daslang_bundle` invalidated by `cd "$BUNDLE"`. Fix: canonicalize to absolute up front via `cd "$1" && pwd -P`.
- **Round 2 (CI)**: `daslang -exe` outputs are always `.exe` on every platform, but cpp-built binaries follow platform convention. Linux bundle has `daslang` + `mcp.exe` side by side. Fix: per-tool `dasexe|cpp` tagging in the smoke script with separate suffix lookup.
- **Round 3 (CI)**: install rule preserves source perms; `daslang -exe` output has no +x on Linux. RC3 Linux bundle shipped this way (all 8 daslang -exe outputs were `-rw-r--r--`). Fix: explicit `FILE_PERMISSIONS` in `utils/CMakeLists.txt`.

## Verified locally

- Smoke script against unfixed RC3 bundle on `E:\` → exit 1, two failures on the `mcp` row showing `error[20605]: missing prerequisite '../cpp_search_config.das'`.
- Same script against the bundle with the file dropped in → 21/21 OK, exit 0.
- `cmake_install.cmake` after configure now lists all four top-level files including `cpp_search_config.das`.
- RC3 Linux bundle ZIP unix-perm inspection confirmed all 8 daslang -exe outputs ship as `-rw-r--r--`.

## Follow-up

Cut **v0.6.2-RC4** by cherry-picking this PR's merged commit onto `v0.6.2-RC3` (matches existing RC1→RC2→RC3 convention — no tag movement, no untested 645-commit master delta).
