### PR TITLE
linq_fold: peel key blocks (group_by + distinct_by) — 16-28 ns/op wins

### DIFF
--- a/benchmarks/sql/distinct_by_count.das
+++ b/benchmarks/sql/distinct_by_count.das
@@ -1,0 +1,65 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _distinct_by(_.brand) |> count — count distinct brand values.
+// Exercises plan_group_by_core's peeled keyBlock + plan_distinct/_decs_distinct's
+// peeled distinctKeyBlock (the per-element `invoke(keyBlock, _)` is now a direct
+// field read). Companion to distinct_count which uses _select(_.brand).distinct()
+// on a pre-projected scalar — this one keeps the full source element and uses
+// distinct_by, the path that goes through the invoke-block-on-tuple shape.
+//
+// SQL: `SELECT COUNT(DISTINCT brand) FROM Cars` — sqlite_linq doesn't lower
+// `distinct() |> count()` so the m1 lane is omitted (same as join_count).
+//
+// Expected result: BRAND_COUNT (5).
+
+def run_m3(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3_array/{n}", n) {
+        let dedup <- arr |> _distinct_by(_.brand)
+        let c = dedup |> length
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(each(arr)._distinct_by(_.brand).count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>)._distinct_by(_.brand).count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def distinct_by_count_m3(b : B?) {
+    run_m3(b, 100000)
+}
+
+[benchmark]
+def distinct_by_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def distinct_by_count_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1929,9 +1929,7 @@ def private plan_distinct(var expr : Expression?) : Expression? {
     }
     var keyExpr : Expression?
     if (isDistinctBy) {
-        keyExpr = qmacro_expr() {
-            invoke($e(distinctKeyBlock), $e(pushExpr))
-        }
+        keyExpr = peel_lambda_replace_var(distinctKeyBlock, pushExpr)
     } else {
         keyExpr = clone_expression(pushExpr)
     }
@@ -2787,9 +2785,10 @@ def private plan_group_by_core(var calls : array<tuple<ExprCall?; LinqCall?>>;
             }
         }
     }
-    // Per-element core: key derive + unique_key derive + table-update splice.
+    // Peel keyBlock so `_.field` becomes a direct field read on itName, eliminating per-element invoke + (on decs) freeing the pruner to drop unused tuple slots that the whole-tup lambda arg otherwise pins.
+    var keyExpr = peel_lambda_rename_var(keyBlock, itName)
     var coreBody = qmacro_block() {
-        let $i(kName) = invoke($e(keyBlock), $i(itName))
+        let $i(kName) = $e(keyExpr)
         let $i(ukName) = _::unique_key($i(kName))
         $e(tableUpdate)
     }
@@ -4767,9 +4766,7 @@ def private plan_decs_distinct(var expr : Expression?) : Expression? {
     }
     var keyExpr : Expression?
     if (isDistinctBy) {
-        keyExpr = qmacro_expr() {
-            invoke($e(distinctKeyBlock), $e(pushExpr))
-        }
+        keyExpr = peel_lambda_replace_var(distinctKeyBlock, pushExpr)
     } else {
         keyExpr = clone_expression(pushExpr)
     }

--- a/dastest/dastest_clargs.das
+++ b/dastest/dastest_clargs.das
@@ -1,3 +1,5 @@
+options gen2
+
 module dastest_clargs shared
 
 require daslib/clargs public

--- a/dastest/log.das
+++ b/dastest/log.das
@@ -48,9 +48,7 @@ def error(msg : string | #) {
 
 
 def green(msg : string | #) {
-    if (failuresOnly) {
-        return
-    }
+    if (failuresOnly) return
     if (!verbose) {
         print(green_str("{msg}\n"))
     } else {
@@ -69,9 +67,7 @@ def red(msg : string | #) {
 
 
 def blue(msg : string | #) {
-    if (failuresOnly) {
-        return
-    }
+    if (failuresOnly) return
     if (!verbose) {
         print(blue_str("{msg}\n"))
     } else {

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -130,13 +130,9 @@ def private internalFileCtx(ctx : SuiteCtx) : FileCtx {
 // was specified via --test-names parameter.
 // If it's empty, the test is always accepted and therefore executed.
 def private match_func_name(name : string; allowed : array<string>&) {
-    if (length(allowed) == 0) {
-        return true
-    }
+    if (empty(allowed)) return true
     for (match in allowed) {
-        if (name |> starts_with(match)) {
-            return true
-        }
+        if (name |> starts_with(match)) return true
     }
     return false
 }
@@ -144,7 +140,7 @@ def private match_func_name(name : string; allowed : array<string>&) {
 
 def test_file(file_name : string; var ctx : SuiteCtx) : SuiteResult {
     var inscope fileCtx <- internalFileCtx(ctx)
-    var res = test_file(file_name, ctx, fileCtx)
+    let res = test_file(file_name, ctx, fileCtx)
     return res
 }
 
@@ -195,7 +191,7 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
                 }
 
                 if (!failed) {
-                    for (errC, errN in keys(expectedErrors), values(expectedErrors)) {
+                    for (_errC, errN in keys(expectedErrors), values(expectedErrors)) {
                         if (errN > 0) {
                             failed = true
                             break
@@ -228,18 +224,18 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
                         }
                     }
 
-                    res.total += 1
+                    res.total ++
                     if (failed) {
-                        res.errors += 1
+                        res.errors ++
                     } else {
-                        res.passed += 1
+                        res.passed ++
                     }
                     return
                 }
                 simulate(program) $(sok; context; serrors) {
                     if (!sok) {
-                        res.total += 1
-                        res.errors += 1
+                        res.total ++
+                        res.errors ++
                         log::error("Failed to simulate {file_name}\n{serrors}")
                         return
                     }
@@ -269,8 +265,8 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
                         }
                         res += module_result
                     } else {
-                        res.errors += 1
-                        res.total += 1
+                        res.errors ++
+                        res.total ++
                         var msg = "Failed to execute {file_name}"
                         if (mod == null) {
                             msg = "{msg}. Current module is null."
@@ -298,15 +294,13 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
 
 def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_ctx : SuiteCtx) : SuiteResult {
     var inscope fileCtx <- internalFileCtx(suite_ctx)
-    var res = test_module(mod, context, suite_ctx, fileCtx)
+    let res = test_module(mod, context, suite_ctx, fileCtx)
     return res
 }
 
 
 def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_ctx : SuiteCtx; file_ctx : FileCtx) : SuiteResult {
-    if (suite_ctx.compile_only) {
-        return default<SuiteResult>
-    }
+    if (suite_ctx.compile_only) return default<SuiteResult>
     var res : SuiteResult
     var inscope fileCtx := file_ctx
     var modPtr : Module?
@@ -315,21 +309,15 @@ def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_c
         modPtr = addr(mod)
     }
     modPtr |> module_for_each_function() $(f) {
-        if (f.hash == 0ul) {
-            return
-        }
+        if (f.hash == 0ul) return
         let func = context |> get_function_by_mnh(f.hash)
         var fn = modPtr |> find_module_function_via_rtti(func)
-        if (fn == null) {
-            return
-        }
+        if (fn == null) return
         var test_name = ""
         var test_kind = ""
         for (ann in fn.annotations) {
-            var tag = "{ann.annotation.name}"
-            if (tag != "test" && tag != "benchmark") {
-                continue
-            }
+            let tag = "{ann.annotation.name}"
+            if (tag != "test" && tag != "benchmark") continue
             test_kind = tag
             var name = "{fn.name}"
             // Both [test] and [benchmark] allow a form like [test(name=foo)]
@@ -342,14 +330,10 @@ def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_c
             test_name = name
             break
         }
-        if (test_kind == "") {
-            // Not a test nor benchmark.
-            return
-        }
+        // Not a test nor benchmark.
+        if (test_kind == "") return
         let allowed_list & = test_kind == "benchmark" ? suite_ctx.bench_names : suite_ctx.testNames
-        if (!match_func_name(test_name, allowed_list)) {
-            return
-        }
+        if (!match_func_name(test_name, allowed_list)) return
         if (test_kind == "test") {
             test_any(test_name, func, length(fn.arguments), fileCtx, res)
         } elif (test_kind == "benchmark" && suite_ctx.bench_enabled) {
@@ -424,7 +408,7 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
     }
     let beforeFailed = res.failed
     let beforeErrors = res.errors
-    res.total += 1
+    res.total ++
     var dt = 0
     var deliberateRecover = false
     var failed = false
@@ -440,7 +424,7 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
     }
     try {
         if (args_num == 0) {
-            unsafe {
+            unsafe { // nolint:STYLE025 — both deref + invoke_in_context need unsafe; expression form can't wrap a pipe
                 *context.context |> invoke_in_context(func)
             }
             dt = get_time_usec(t0)
@@ -489,7 +473,7 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
         if (!deliberateRecover) {
             dt = get_time_usec(t0)
             failed = true
-            res.errors += 1
+            res.errors ++
             errorOrBlue(context.expectFailure, "{context.indenting}--- FAIL '{name}' {time_dt_hr(dt)}")
             if (!empty(context.context.exception)) {
                 let loc = file_info_hr(context.context.exceptionAt, context.uriPaths)
@@ -516,6 +500,7 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
     // clone strings from test context into dastest context
     if (!empty(testMessages)) {
         var clonedMessages : array<string>
+        clonedMessages |> reserve(length(testMessages))
         for (m in testMessages) {
             clonedMessages |> push(clone_string(m))
         }
@@ -535,13 +520,13 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
 
     if (failed) {
         if (beforeErrors == res.errors) {
-            res.failed += 1
+            res.failed ++
         }
     } elif (skipped) {
-        res.skipped += 1
+        res.skipped ++
         log::info("{context.indenting}--- SKIPPED '{name}' {time_dt_hr(dt)}")
     } else {
-        res.passed += 1
+        res.passed ++
     }
 
     if (beforeFailed < res.failed || beforeErrors < res.errors) {
@@ -563,11 +548,9 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
 def private run_queued_benchmarks(var suite_ctx : SuiteCtx; var file_ctx : FileCtx, var res : SuiteResult&) {
     for (q in suite_ctx.queued_benchmarks) {
         let failed = res.failed
-        for (i in range(suite_ctx.bench_count)) {
+        for (_i in range(suite_ctx.bench_count)) {
             run_benchmark(suite_ctx, file_ctx, res, q.name, q.fn)
-            if (res.failed > failed) {
-                break
-            }
+            if (res.failed > failed) break
         }
     }
 }
@@ -649,7 +632,7 @@ def private bench_on_finished_impl(var suite_ctx : SuiteCtx; var benchmarking : 
     }
 
     if (suite_ctx.bench_format == BenchmarkOutputFormat.json) {
-        var s = sprint_json(stats, false)
+        let s = sprint_json(stats, false)
         info_raw("{s}\n")
         return
     }

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -618,20 +618,19 @@ def private bench_on_finished_impl(var suite_ctx : SuiteCtx; var benchmarking : 
 
     if (suite_ctx.bench_format == BenchmarkOutputFormat.native) {
         let entries = [
-            (int64(avg_time), "ns/op", 18, false),
-            (int64(avg_heap_bytes), "B/op", 14, true),
-            (int64(avg_num_allocs), "allocs/op", 16, true),
-            (int64(avg_string_heap_bytes), "SB/op", 14, true),
-            (int64(avg_string_num_allocs), "strings/op", 16, true),
+            ("{avg_time:.1f}", "ns/op", 18, false),
+            ("{int64(avg_heap_bytes)}", "B/op", 14, true),
+            ("{int64(avg_num_allocs)}", "allocs/op", 16, true),
+            ("{int64(avg_string_heap_bytes)}", "SB/op", 14, true),
+            ("{int64(avg_string_num_allocs)}", "strings/op", 16, true),
         ]
         let msg = build_string() $(var w) {
-            for (i, (val, measure, width, is_alloc) in range(length(entries)), entries) {
-                let val_s = "{val}"
+            for (i, (val_s, measure, width, is_alloc) in range(length(entries)), entries) {
                 let printed_width = length(val_s + " " + measure)
                 let sep = repeat(" ", max(width - printed_width, 1))
                 let is_last = i == length(entries) - 1
                 var colored_val = yellow_str(val_s)
-                if (is_alloc && val == 0l) {
+                if (is_alloc && val_s == "0") {
                     colored_val = green_str(val_s)
                 }
                 w |> write(colored_val + " " + measure)

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -2624,9 +2624,6 @@ def target_wave4_pruned_groupby_count_fold() : array<tuple<Brand : int; N : int>
 [test]
 def test_wave4_pruned_groupby_count_parity(t : T?) {
     fixture_wave4(10)
-    // _group_by_lazy(_.brand). plan_group_by_core's bucket-build pushes `decs_tup` as a whole
-    // value, so the walker disables pruning (safety rule) → all 3 get_ros emit. See
-    // test_wave4_pruned_groupby_count_splice_shape for the AST gate.
     // brand cycles 0..3 across 10 rows → 4 distinct buckets with sizes [3,3,2,2].
     let got <- target_wave4_pruned_groupby_count_fold()
     t |> equal(got |> length, 4, "4 distinct brand buckets")
@@ -2669,15 +2666,11 @@ def test_wave4_pruned_groupby_count_splice_shape(t : T?) {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "qmatch must capture body")
-        // Documented: plan_group_by_core builds a `bucket` (array of source tuples) per key, then
-        // computes reducers over the bucket. The bucket-build site pushes `decs_tup` as a whole
-        // value — walker sees whole-var → pruning DISABLED → all 3 get_ros present. This is the
-        // safety rule firing as designed (group_by needs the full tuple for the bucket). Pruning
-        // would only fire if the splice itself were refactored to avoid materializing tuples.
-        t |> equal(describe_count(body_expr, "get_ro"), 3, "group_by bucket-build needs full tuple; pruning disabled by design")
-        t |> success(describe_count(body_expr, "wave4_brand") >= 1, "brand present")
-        t |> success(describe_count(body_expr, "wave4_price") >= 1, "price present (bucket needs full tuple)")
-        t |> success(describe_count(body_expr, "wave4_year") >= 1, "year present (bucket needs full tuple)")
+        // plan_group_by_core peels the key block (`_.brand` → `decs_tup.brand`) inline; the count-by-group shape avoids materializing the bucket — only `brand` survives in the body, so pruning drops `price`+`year`.
+        t |> equal(describe_count(body_expr, "get_ro"), 1, "count-by-group reads only brand → pruning keeps 1 get_ro")
+        t |> success(describe_count(body_expr, "wave4_brand") >= 1, "brand slot present")
+        t |> equal(describe_count(body_expr, "wave4_price"), 0, "price pruned out")
+        t |> equal(describe_count(body_expr, "wave4_year"), 0, "year pruned out")
     }
 }
 


### PR DESCRIPTION
## Summary

Bench-driven follow-up after PR #2822 closed the Wave 5 terminator splice ladder. A sweep over `benchmarks/sql` flagged group_by lanes as consistently 1.2–1.6× slower on the decs splice (m4) than the array splice (m3f). Root cause: `plan_group_by_core` and `plan_distinct`'s `distinct_by` arm emitted `invoke($keyBlock, sourceVar)` per element. Switching to `peel_lambda_rename_var` / `peel_lambda_replace_var` inlines `_.field` as a direct field read, with the existing fallback to `invoke(...)` for non-peelable blocks.

The win is twofold:
- Per-element invoke dispatch eliminated (~3-5 ns/elem in INTERP on both lanes).
- On the decs side, the whole-`decs_tup` lambda argument no longer pins the pruner — `build_decs_inner_for_pruned` now drops the components only the keyBlock referenced through the tuple shape (e.g. `tuple<id:int;name:string;price:int;brand:int;year:int;dealer_id:int>` shrinks to `tuple<brand:int>`), removing per-iter string copies and matching `get_ro` slots.

### Bench (INTERP, 100K rows, ns/op, before → after)

| bench | m3f before | m3f after | m4 before | m4 after |
|---|---:|---:|---:|---:|
| groupby_count | 36.3 | **19.5** (-46%) | 49.9 | **22.5** (-55%) |
| groupby_sum | 36.0 | 18.6 | 50.1 | 24.4 |
| groupby_min | 42.9 | 25.5 | 57.1 | 29.3 |
| groupby_max | 42.8 | 24.9 | 56.5 | 29.6 |
| groupby_average | 52.1 | 30.4 | 62.7 | 34.7 |
| groupby_having_count | 36.4 | 19.3 | 50.0 | 22.2 |
| groupby_having_hidden_sum | 39.9 | 24.2 | 57.3 | 30.1 |
| groupby_multi_reducer | 53.3 | 32.3 | 63.6 | 36.6 |
| groupby_select_sum | 58.6 | 37.2 | 61.4 | 42.4 |
| groupby_first | 35.3 | 18.5 | 47.3 | 29.9 |
| groupby_where_count | 23.7 | 14.7 | 37.0 | 19.8 |
| groupby_where_sum | 23.3 | 14.1 | 36.4 | 19.7 |
| distinct_by_count (NEW) | 33.7 | **15.3** (-55%) | 44.3 | **19.7** (-56%) |

`distinct_by_count` is the new bench that covers the path the existing `distinct_count` doesn't touch (it preselects to a scalar first). All other non-groupby/distinct_by lanes unchanged within bench noise.

### Bundled

The branch carries two adjacent improvements that surfaced while shipping this:

1. **dastest bench format with 1-decimal ns/op** (commit 1). The `native` column truncated to `int64` ns/op; `go_export` and the JSON message line already used `:.1f`. Switched native to the same shape, keeping column alignment + zero-allocs green/yellow coloring.

2. **dastest lint enablement** (commit 3). `dastest/dastest_clargs.das` was missing `options gen2`, which made it parse fine via direct daslang invocation (defaults to v2) but fail under the lint pipeline's `compile_file` path (defaults to v1) — `@clarg_doc = ...` is v2-only syntax. That parse error rippled to every lint of `dastest/suite.das` and blocked pre-push for any dastest touch. Added `options gen2`, then addressed the ~30 pre-existing PERF/STYLE/LINT warnings it surfaced in `dastest/suite.das` + 2 STYLE005 in `dastest/log.das` (the latter via suite's require chain). No behavior change.

### Splice-shape test update

`test_wave4_pruned_groupby_count_splice_shape` previously documented "pruning DISABLED — bucket needs full tuple" as a known limitation; that limitation is now fixed for the count-by-group shape, so the gate asserts 1 `get_ro` (brand) + 0 for `price`/`year`. The parity test (`test_wave4_pruned_groupby_count_parity`) is unchanged and still green.

## Test plan

- [x] `mcp__daslang__lint` clean on `daslib/linq_fold.das`, `benchmarks/sql/distinct_by_count.das`, `tests/linq/test_linq_from_decs.das`, and all touched dastest files
- [x] `tests/linq` 1382/1382 INTERP + 1382/1382 AOT
- [x] `tests/decs` 245/245 INTERP
- [x] `tests/dasSQLITE` 782/782 INTERP
- [x] `test_aot` full lane 2409/2409
- [x] Bench sweep over `benchmarks/sql` (199 benchmarks) — diff shows gains on 12 groupby + new distinct_by; all others unchanged
- [x] `dastest --bench --bench_format native` formatter visual check (3 sample benches)
- [ ] CI 9-lane matrix
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)