### PR TITLE
ci: narrow release.yml trigger to [prereleased] only (drop double-build per RC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,10 @@ name: Release
 # racing to clobber each other's assets. `released` would fire on promotion-
 # to-stable (the unflag step) — not adding it because promotion doesn't change
 # artifacts, and the artifacts uploaded at RC-cut time are exactly what ships.
-# `workflow_dispatch` stays for manual re-runs.
+# `workflow_dispatch` is build+smoke validation only — the asset upload step
+# gates on `github.event_name == 'release'`, so dispatch runs never publish
+# anything. Use it to sanity-check workflow / build / smoke changes without
+# touching real release assets; recreate the release to re-upload.
 on:
   workflow_dispatch:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,17 @@
 name: Release
 
-# Run on pre-release, full release, or manual trigger
+# Trigger only on initial prerelease creation (the project's release pattern is
+# always cut-as-prerelease, iterate RCs, then optionally unflag to promote to
+# stable). `published` was double-firing: GitHub emits both `prereleased` and
+# `published` on a fresh prerelease, so every RC cut ran two identical builds
+# racing to clobber each other's assets. `released` would fire on promotion-
+# to-stable (the unflag step) — not adding it because promotion doesn't change
+# artifacts, and the artifacts uploaded at RC-cut time are exactly what ships.
+# `workflow_dispatch` stays for manual re-runs.
 on:
   workflow_dispatch:
   release:
-    types: [prereleased, published]
+    types: [prereleased]
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## Why

Every RC cut runs `release.yml` twice in parallel today, because GitHub fires BOTH `release.prereleased` AND `release.published` on the creation of a fresh prerelease (creating a prerelease IS publishing it). Both events match the `[prereleased, published]` filter, so two identical 5-platform builds kick off and race to `gh release upload --clobber` the same assets.

Observed directly on the v0.6.2-RC4 creation:

```
queued		0.6.2-RC4	Release	v0.6.2-RC4	release	26323689833	10s	2026-05-23T04:40:16Z
queued		0.6.2-RC4	Release	v0.6.2-RC4	release	26323689818	10s	2026-05-23T04:40:16Z
```

Same workflow, same tag, same timestamp.

## Empirical release pattern

Every RC in this repo's history ships as prerelease at creation. RC3's `prerelease=False` is an unflag-to-promote performed after the original prerelease creation, not an initial state:

```
v0.6.2-RC4  prerelease=True      (just created)
v0.6.2-RC3  prerelease=False     (was True at creation; unflagged to mark Latest)
v0.6.2-RC2  prerelease=True
v0.6.2-RC1  prerelease=True
0.6.1-RC2   prerelease=False     (same — promoted post-creation)
v0.6.0      prerelease=False     (same)
```

There has never been a release created as non-prerelease here. So `published` never catches an event that `prereleased` didn't already catch — it's pure wasted CI.

## Fix

`release: types: [prereleased]` — one build per RC cut, same artifacts.

Intentionally NOT adding `released` (the unflag-to-promote event): promotion doesn't change artifacts, and the assets uploaded at RC-cut time are exactly what the eventual stable user downloads. Adding `released` would force a full rebuild on promotion for no behavioral benefit.

`workflow_dispatch` is kept for manual re-runs.

## Background

Surfaced while watching the double-fire on the v0.6.2-RC4 release that landed via #2823.
