### PR TITLE
[DO NOT MERGE] CI lint probe for issue #2830

### DIFF
--- a/tests/_issue_2830_lint_repro.das
+++ b/tests/_issue_2830_lint_repro.das
@@ -1,0 +1,27 @@
+options gen2
+
+// Minimal repro for https://github.com/GaijinEntertainment/daScript/issues/2830
+// Multi-field `_where` predicate over `from_decs_template` triggers spurious
+// `error[30151]` on the unrelated concept_assert in `decs.das`'s `set()`
+// generic — under lint flags, on linux x64 only.
+
+require daslib/decs_boost
+require daslib/linq_boost
+require daslib/linq_fold
+
+[decs_template(prefix = "x_")]
+struct X {
+    a : int
+    b : int
+    c : int
+}
+
+[export]
+def target() : int {
+    return _fold(from_decs_template(type<X>)._where(_.a + _.b + _.c > 0).count())
+}
+
+[export]
+def main {
+    print("count={target()}\n")
+}


### PR DESCRIPTION
CI probe only — see #2830.

Single-file minimal repro of the spurious `error[30151]` (concept_assert in `decs.das:1370`'s `set()` generic) surfaced under lint flags by a multi-field `_where` predicate over `from_decs_template`.

Watch `extended_checks (linux, 64)` → "Run lint on changed .das files" step. If it fails on `tests/_issue_2830_lint_repro.das`, the issue's minimal repro is end-to-end confirmed.

Will close once CI verdict lands and the result is linked back to #2830.