### PR TITLE
linq_fold: trivial-let elision + reverse_take skip-into-tail — closes the m4 ladder

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3078,14 +3078,16 @@ def private build_decs_inner_for(bridge : DecsBridgeShape?; var tupBind : Expres
     return clonedForExpr
 }
 
-// Walks a chain body to collect which fields of the decs_tup named-tuple bind are actually referenced. allFieldsUsed flips when the bind is referenced as a whole-var (not via field access) — e.g. push_clone(decs_tup) in a bare to_array, or pass-to-user-fn — so the helper falls back to unpruned emission and preserves the user-visible output shape.
+// Walks a chain body to collect which fields of the decs_tup named-tuple bind are actually referenced. allFieldsUsed flips when the bind is referenced as a whole-var (not via field access) — e.g. push_clone(decs_tup) in a bare to_array, or pass-to-user-fn — so the helper falls back to unpruned emission and preserves the user-visible output shape. Also picks up bare iter-var refs (when `iterToUser` is non-empty) so the trivial-let-elision path — which rewrites `decs_sel_N`-bound projections to the iter var directly, bypassing `decs_tup` entirely — still hits the pruned arm instead of falling through to unpruned-default.
 class private DecsTupUsageScanner : AstVisitor {
     tupName       : string
+    iterToUser    : table<string; string>
     usedFields    : table<string>
     allFieldsUsed : bool = false
     inTargetField : bool = false
-    def DecsTupUsageScanner(n : string) {
+    def DecsTupUsageScanner(n : string; var i2u : table<string; string>) {
         tupName = n
+        iterToUser <- i2u
     }
     def override preVisitExprField(expr : ExprField?) : void {
         var v = expr.value
@@ -3104,17 +3106,23 @@ class private DecsTupUsageScanner : AstVisitor {
     def override preVisitExprVar(expr : ExprVar?) : void {
         if (expr.name == tupName && !inTargetField) {
             allFieldsUsed = true
+            return
+        }
+        let nm = string(expr.name)
+        if (key_exists(iterToUser, nm)) {
+            usedFields |> insert(iterToUser[nm])
         }
     }
 }
 
 [macro_function]
-def private collect_decs_tup_usage(var e : Expression?; tupName : string) : tuple<bool; array<string>> {
-    // Returns (allFieldsUsed, usedFieldNames). usedFieldNames is unordered — caller filters bridge.userNames in original order to preserve get_ro emission order.
+def private collect_decs_tup_usage(var e : Expression?; tupName : string; bridge : DecsBridgeShape?) : tuple<bool; array<string>> {
+    // Returns (allFieldsUsed, usedFieldNames). usedFieldNames is unordered — caller filters bridge.userNames in original order to preserve get_ro emission order. The bridge feeds an iter-var → user-name reverse map so bare iter-var refs (from trivial-let elision) count as field usage too.
     var allUsed = false
     var used : array<string>
     if (e == null) return (allUsed, used)
-    var sc = new DecsTupUsageScanner(tupName)
+    var iterToUser <- {for (i in 0 .. length(bridge.iterNames)); bridge.iterNames[i] => bridge.userNames[i]}
+    var sc = new DecsTupUsageScanner(tupName, iterToUser)
     make_visitor(*sc) $(astVisitorAdapter) {
         visit_expression(e, astVisitorAdapter)
     }
@@ -3167,7 +3175,7 @@ def private build_decs_inner_for_pruned(bridge : DecsBridgeShape?;
                                         var body : Expression?;
                                         at : LineInfo) : Expression? {
     // Walks body for `tupName.<field>` references; when pruning is safe + beneficial, emits the inner multi-iter for with unused get_ro slots dropped and a matching shrunk named-tuple bind. Otherwise falls through to the unpruned path so user-visible shape stays intact (bare to_array, push_clone(decs_tup), pass-to-user-fn).
-    let (allUsed, usedNames) = collect_decs_tup_usage(body, tupName)
+    let (allUsed, usedNames) = collect_decs_tup_usage(body, tupName, bridge)
     // Fallback to the unpruned bind ONLY for whole-var refs (bare to_array, push_clone(decs_tup), pass-to-user-fn) or the edge case where the body never touches decs_tup at all. The "all fields used via field access" case still benefits from flatten + bind elision — no slots dropped, but the per-iter tuple-make and field reads disappear.
     if (allUsed || empty(usedNames)) {
         var tupBind = build_decs_tup_bind(bridge, tupName, at)
@@ -3211,6 +3219,7 @@ def private build_decs_inner_for_pruned(bridge : DecsBridgeShape?;
 
 struct private DecsChainInfo {
     bindAt      : array<string>    // bind name visible at each chain position
+    elidedAt    : array<bool>      // true when the select at position i was elided (peeled to a single decs_tup field access → reused iter var as next bind, no `let decs_sel_N = ...` emit needed)
     finalBind   : string            // bind name AFTER full chain — what terminator references
     finalType   : TypeDeclPtr       // element type AFTER full chain (constant + ref stripped)
     selectCount : int               // number of `select` ops in chain; 0 means finalBind == tupName
@@ -3229,17 +3238,47 @@ def private compute_decs_chain_info(var calls : array<tuple<ExprCall?; LinqCall?
         selectCount = 0
     )
     info.bindAt |> reserve(intermediateEnd)
+    info.elidedAt |> reserve(intermediateEnd)
     var curBind = tupName
     var curType : TypeDeclPtr = clone_type(bridge.elementType)
     for (i in 0 .. intermediateEnd) {
         info.bindAt |> push(curBind)
+        info.elidedAt |> push(false)
         var cll & = unsafe(calls[i])
         let opName = cll._1.name
         if (opName == "select") {
             info.selectCount ++
-            curBind = "`decs_sel`{at.line}`{at.column}`{info.selectCount}"
             var peeled = peel_lambda_rename_var(cll._0.arguments[1], info.bindAt[i])
             if (peeled == null || peeled._type == null) return null
+            // Trivial-let elision: `_select(_.userName)` against decs_tup → iter var directly. The pruned-for keeps the iter var (its name = bridge.iterNames[idx]) and the flattener would otherwise rewrite the synthetic `let decs_sel_N = decs_tup.userName` to `let decs_sel_N = <iterVar>` — a pure copy. Renaming finalBind to the iter var name skips the binding entirely and the action references it natively. Typer wraps both the projection root (`peeled` may be ExprRef2Value) AND the ExprVar inside the ExprField in ExprRef2Value — peel both.
+            var elided = false
+            if (curBind == tupName) {
+                var top = peeled
+                if (top is ExprRef2Value) {
+                    top = (top as ExprRef2Value).subexpr
+                }
+                if (top is ExprField) {
+                    var pf = top as ExprField
+                    var pv = pf.value
+                    if (pv is ExprRef2Value) {
+                        pv = (pv as ExprRef2Value).subexpr
+                    }
+                    if (pv is ExprVar && (pv as ExprVar).name == tupName) {
+                        let fname = string(pf.name)
+                        for (ui in 0 .. length(bridge.userNames)) {
+                            if (bridge.userNames[ui] == fname) {
+                                curBind = bridge.iterNames[ui]
+                                elided = true
+                                info.elidedAt[i] = true
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+            if (!elided) {
+                curBind = "`decs_sel`{at.line}`{at.column}`{info.selectCount}"
+            }
             curType = clone_type(peeled._type)
         } elif (opName != "where_") return null
     }
@@ -3274,6 +3313,8 @@ def private wrap_decs_chain(var action : Expression?;
                 }
             }
         } elif (opName == "select") {
+            // Skip emission entirely when this select was elided in compute_decs_chain_info — the next bind is already the iter var the flattener would have produced for `let nextBind = decs_tup.userName`. No copy needed; downstream `current` already references the iter var by the elided name.
+            continue if (chainInfo.elidedAt[i])
             var proj = peel_lambda_rename_var(cll._0.arguments[1], bindHere)
             if (proj == null) return null
             let nextBind = (i + 1 < intermediateEnd) ? chainInfo.bindAt[i + 1] : chainInfo.finalBind
@@ -4634,6 +4675,63 @@ def private plan_decs_reverse(var expr : Expression?) : Expression? {
     let bufName = qn("decs_buf", at)
     let needIterWrap = expr._type.isIterator
     var bufElemType = strip_const_ref(clone_type(projection != null ? projection._type : bridge.elementType))
+    // Skip-into-tail fast path: `reverse |> take(N) |> to_array` with no where/select. Walk archetypes once to sum `arch.size` (cheap, no entity load), compute skip = total - takeN, then for_each_archetype_find skips whole archetypes whose size still fits below the skip threshold and short-circuits once the buffer reaches takeN. `where` would invalidate the size-based skip (count after filter is unknown without iterating); `select` would only affect element shape, not count, but is skipped here to keep v1 minimal.
+    if (takeExpr != null && whereCond == null && projection == null) {
+        let takeNName = qn("take_n", at)
+        let totalName = qn("decs_total", at)
+        let actualName = qn("decs_actual", at)
+        let skipName = qn("decs_skip", at)
+        let seenName = qn("decs_seen", at)
+        let skipsLeftName = qn("decs_skips", at)
+        let tupBind = build_decs_tup_bind(bridge, tupName, at)
+        // Inner-for body: skip-counter early-out before the named-tuple wrap (so skipped iters pay no per-component load); push + break-on-quota after.
+        var innerBody : Expression? = qmacro_block() {
+            if ($i(skipsLeftName) > 0_l) {
+                $i(skipsLeftName) --
+                continue
+            }
+            $e(tupBind)
+            $i(bufName) |> push_clone($i(tupName))
+            if (int64(length($i(bufName))) >= $i(actualName)) {
+                break
+            }
+        }
+        var clonedForExpr = clone_expression(bridge.forExpr)
+        var clonedFor = clonedForExpr as ExprFor
+        var newForBody = new ExprBlock(at = at)
+        newForBody.list |> push(innerBody)
+        clonedFor.body = newForBody
+        var emission : Expression? = qmacro(invoke($() : array<$t(bufElemType)> {
+            // Pass 1: arch.size sum — no entity walk, just archetype-header iteration.
+            var $i(totalName) = 0_l
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $i(totalName) += $i(archName).size
+            })
+            let $i(takeNName) = $e(takeExpr)
+            let $i(actualName) = ($i(takeNName) <= 0) ? 0_l : ((int64($i(takeNName)) < $i(totalName)) ? int64($i(takeNName)) : $i(totalName))
+            let $i(skipName) = $i(totalName) - $i(actualName)
+            var $i(bufName) : array<$t(bufElemType)>
+            if ($i(actualName) == 0_l) {
+                return <- $i(bufName)
+            }
+            $i(bufName) |> reserve(int($i(actualName)))
+            // Pass 2: skip whole archetypes via size sum; partial archetype uses skip-counter; subsequent archetypes feed directly. Returns true once buf reaches actualTake to stop iteration across remaining archetypes.
+            var $i(seenName) = 0_l
+            for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+                if ($i(seenName) + $i(archName).size <= $i(skipName)) {
+                    $i(seenName) += $i(archName).size
+                    return false
+                }
+                var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
+                $e(clonedForExpr)
+                $i(seenName) += $i(archName).size
+                return int64(length($i(bufName))) >= $i(actualName)
+            })
+            _::reverse_inplace($i(bufName))
+            return <- $i(bufName)
+        }))
+        return finalize_decs_emission(emission, at, needIterWrap)
+    }
     var pushExpr : Expression?
     if (projection != null) {
         pushExpr = qmacro_expr() {

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -3198,13 +3198,13 @@ struct RevTakeMultiArchA {
 
 [decs_template(prefix = "rev2_b_")]
 struct RevTakeMultiArchB {
-    bid : int
+    bid  : int
     bval : int
 }
 
 [test]
 def test_reverse_take_multi_archetype_parity(t : T?) {
-    // Creates two archetypes (A with 4 rows, B with 5 rows). A 9-row sum across archetypes; reverse + take(3) must return 3 rows. The unrelated B archetype is filtered out by the from_decs_template request anyway — but its presence in the decs state ensures for_each_archetype iterates across more than one archetype-class even when the request matches just one.
+    // Creates two MATCHING archetypes — both have `rev2_id` so both satisfy `from_decs_template(type<RevTakeMultiArchA>)`. Group A1: just rev2_id. Group A2: rev2_id + extra rev2_b_* components — same query matches, but the extra components land it in a separate archetype. With A1=4 + A2=5 → totalCount=9, take(3) → skip=6: A1 (size 4) skipped entirely via the size-sum arm, A2 enters with skipsLeft=2 → drains 2 then pushes 3 then returns true. Exercises both the whole-archetype-skip and partial-archetype skip-counter + early-exit.
     restart()
     for (i in 0..4) {
         create_entity() @(eid, cmp) {
@@ -3215,22 +3215,25 @@ def test_reverse_take_multi_archetype_parity(t : T?) {
     for (i in 0..5) {
         create_entity() @(eid, cmp) {
             cmp.eid := eid
-            cmp.rev2_b_bid := i + 100
+            cmp.rev2_id := i + 100
+            cmp.rev2_b_bid := i + 1000
             cmp.rev2_b_bval := i * 10
         }
     }
     commit()
     let got <- _fold(from_decs_template(type<RevTakeMultiArchA>).reverse().take(3).to_array())
-    t |> equal(got.length(), 3, "reverse+take(3) on multi-archetype world returns 3 rows from the matching archetype only")
+    t |> equal(got.length(), 3, "reverse+take(3) on two matching archetypes returns 3 rows")
     var idSet : table<int>
     for (r in got) {
         idSet |> insert(r.id)
     }
-    // All returned ids must be from the A archetype (0..3); none from B (100..104).
-    for (r in got) {
-        t |> success(r.id >= 0 && r.id < 4, "row id {r.id} must be from RevTakeMultiArchA archetype")
-    }
     t |> equal(length(idSet), 3, "all 3 ids are distinct")
+    // All returned ids must be from one of the two matching archetypes: A1 (ids 0..3) or A2 (ids 100..104). The exact subset depends on archetype iteration order (a decs-internal detail), so we just check membership.
+    for (r in got) {
+        let inA1 = r.id >= 0 && r.id < 4
+        let inA2 = r.id >= 100 && r.id < 105
+        t |> success(inA1 || inA2, "row id {r.id} must be from one of the two matching archetypes")
+    }
 }
 
 [test]

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -2525,6 +2525,43 @@ def test_wave4_take_count_no_field_ref_parity(t : T?) {
     t |> equal(target_wave4_take_count_no_field_ref_fold(), 5, "take(5).count() splice must still return 5")
 }
 
+[export, marker(no_coverage)]
+def target_wave4_all_fields_via_access_fold() : int {
+    // All 3 fields referenced via field access (chained single-field where_s — same all-fields trigger as a compound predicate, but each peeled body has a single field-access node, matching the predicate shape the rest of the suite uses).
+    return _fold(from_decs_template(type<Wave4Row>)
+        ._where(_.brand >= 0)
+        ._where(_.price >= 0)
+        ._where(_.year > 0)
+        .count())
+}
+
+[test]
+def test_wave4_all_fields_via_access_parity(t : T?) {
+    fixture_wave4(10)
+    // brand = i%4 (always >= 0), price = i*10 (always >= 0), year = 2000+(i%25) (always > 0) → all 10 rows match.
+    t |> equal(target_wave4_all_fields_via_access_fold(), 10, "all-fields-access predicate must return all rows")
+}
+
+[test]
+def test_wave4_all_fields_via_access_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_wave4_all_fields_via_access_fold)
+        t |> success(func != null, "RTTI must resolve target")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched, "qmatch must capture body")
+        // No slots pruned (all 3 fields read), but the bind is elided and body references iter vars directly.
+        t |> equal(describe_count(body_expr, "get_ro"), 3, "all 3 get_ros present (no slot pruning)")
+        t |> equal(describe_count(body_expr, "decs_tup"), 0, "named-tuple bind elided when no whole-var ref")
+        t |> success(describe_count(body_expr, "wave4_brand") >= 2, "brand iter var read directly (slot + body ref)")
+        t |> success(describe_count(body_expr, "wave4_price") >= 2, "price iter var read directly")
+        t |> success(describe_count(body_expr, "wave4_year") >= 2, "year iter var read directly")
+    }
+}
+
 // ── C2: buffer-required planners (order/reverse/distinct) ──────────────────────
 
 [export, marker(no_coverage)]

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -3088,3 +3088,135 @@ def test_unroll_take_last_splice_shape(t : T?) {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 1: trivial-let elision for `_select(_.userName)` → iter var (skips
+//          the `let decs_sel_N = car_price` no-op binding when the projection
+//          is a single field access on decs_tup)
+// ─────────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_unroll_select_sum_trivial_let_elision_splice_shape(t : T?) {
+    // `_select(_.val).sum()` peels to a single ExprField(decs_tup.val) which the flattener would rewrite to a bare iter var anyway — slice 1 elides the synthetic `let decs_sel_N = car_price` entirely and rewrites finalBind to the iter var, leaving body as `acc += <iterVar>` with no intermediate binding.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_select_sum_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_select_sum_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "decs_sel"), 0, "trivial single-field _select elided — no synthetic decs_sel binding")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "still exactly one for_each_archetype walk")
+    }
+}
+
+[test]
+def test_unroll_where_select_sum_trivial_let_elision_splice_shape(t : T?) {
+    // Same elision applies through a where filter: where(_.flag==1).select(_.val).sum() — the select still peels to a single ExprField on decs_tup, so elision fires and the binding is dropped. Asserts the elision is not gated on whether the chain is bare or filtered.
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll_where_select_sum_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll_where_select_sum_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "decs_sel"), 0, "trivial single-field _select elided after a where_")
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 2: reverse + take(N) skip-into-tail fast path on decs
+//          Two-pass: sum arch.size, then for_each_archetype_find skips whole
+//          archetypes that fit below the threshold + early-exits once the
+//          takeN-sized buffer is full. Reverses the small N buffer at end.
+// ─────────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_unroll5d_reverse_take_skip_into_tail_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_unroll5d_reverse_take_fold)
+        t |> success(func != null, "RTTI must resolve target_unroll5d_reverse_take_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 1, "skip-into-tail uses _find for early-exit once buf reaches takeN")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 2, "two walks total: 1 size-sum + 1 _find (describe_count is substring match)")
+        // decs_skips is the slice-2 unique skip-counter local (qn(\"decs_skips\", at)). Its presence proves the fast path fired vs. the legacy buffer+reverse_inplace+resize emit.
+        t |> success(describe_count(body_expr, "decs_skips") >= 1, "decs_skips local present — slice-2 fast path fired")
+    }
+}
+
+// ── Multi-archetype reverse + take: exercises whole-archetype-skip arm + partial-archetype skip-counter arm ──
+
+[decs_template(prefix = "rev2_")]
+struct RevTakeMultiArchA {
+    id : int
+}
+
+[decs_template(prefix = "rev2_b_")]
+struct RevTakeMultiArchB {
+    bid : int
+    bval : int
+}
+
+[test]
+def test_reverse_take_multi_archetype_parity(t : T?) {
+    // Creates two archetypes (A with 4 rows, B with 5 rows). A 9-row sum across archetypes; reverse + take(3) must return 3 rows. The unrelated B archetype is filtered out by the from_decs_template request anyway — but its presence in the decs state ensures for_each_archetype iterates across more than one archetype-class even when the request matches just one.
+    restart()
+    for (i in 0..4) {
+        create_entity() @(eid, cmp) {
+            cmp.eid := eid
+            cmp.rev2_id := i
+        }
+    }
+    for (i in 0..5) {
+        create_entity() @(eid, cmp) {
+            cmp.eid := eid
+            cmp.rev2_b_bid := i + 100
+            cmp.rev2_b_bval := i * 10
+        }
+    }
+    commit()
+    let got <- _fold(from_decs_template(type<RevTakeMultiArchA>).reverse().take(3).to_array())
+    t |> equal(got.length(), 3, "reverse+take(3) on multi-archetype world returns 3 rows from the matching archetype only")
+    var idSet : table<int>
+    for (r in got) {
+        idSet |> insert(r.id)
+    }
+    // All returned ids must be from the A archetype (0..3); none from B (100..104).
+    for (r in got) {
+        t |> success(r.id >= 0 && r.id < 4, "row id {r.id} must be from RevTakeMultiArchA archetype")
+    }
+    t |> equal(length(idSet), 3, "all 3 ids are distinct")
+}
+
+[test]
+def test_reverse_take_skip_zero_when_take_exceeds_total(t : T?) {
+    // takeN > totalCount → skip = 0, returns all rows reversed. Exercises the actualTake = totalCount branch and the early-exit not firing (buf never reaches takeN before iteration completes).
+    restart()
+    for (i in 0..3) {
+        create_entity() @(eid, cmp) {
+            cmp.eid := eid
+            cmp.rev2_id := i
+        }
+    }
+    commit()
+    let got <- _fold(from_decs_template(type<RevTakeMultiArchA>).reverse().take(99).to_array())
+    t |> equal(got.length(), 3, "take(N) where N > total returns all rows")
+}
+
+[test]
+def test_reverse_take_empty_source(t : T?) {
+    // No matching archetypes → totalCount = 0 → early-return empty buf before for_each_archetype_find.
+    restart()
+    commit()
+    let got <- _fold(from_decs_template(type<RevTakeMultiArchA>).reverse().take(3).to_array())
+    t |> success(empty(got), "empty source returns empty")
+}
+


### PR DESCRIPTION
Two slices that close the last m4-vs-m3f outliers from #2824's bench snapshot. Wraps the m4 perf push before docs / tutorials.

## Slice 1 — trivial-let elision

**Closes:** `sum_aggregate_m4` 1.3ns systemic gap vs m3f.

When `_select(_.userName)` peels to a single `decs_tup.<field>` reference, rename the chain bind directly to the corresponding iter var instead of synthesizing `decs_sel_N`. `wrap_decs_chain` skips emitting `let decs_sel_N = car_price` entirely; the action's `acc += <iterVar>` references the iter var natively.

Required extending `DecsTupUsageScanner` with an iter-var → user-name reverse map so bare iter-var refs still seed the pruner (previously: empty `usedNames` fell through to unpruned-default, defeating the elision).

## Slice 2 — reverse_take skip-into-tail

**Closes:** `reverse_take_m4` 48 → 9.2 ns/op (5.2× win, allocs 42B → 1B).

For `from_decs_template(...).reverse().take(N).to_array()` with no where/select, emit a two-pass invoke:

1. **Pass 1** — sum `arch.size` across archetypes (no entity load, just archetype-header walk)
2. **Pass 2** — `for_each_archetype_find` skips whole archetypes whose cumulative size still fits below `skip = total - N`; the partial archetype uses a per-iter skip-counter; once the takeN-sized buffer fills, `return true` stops iteration across remaining archetypes
3. `reverse_inplace` runs on the small N buffer at end, not the full source

`where`/`select` fall through to the legacy buffer + `reverse_inplace` + resize emit unchanged — a where filter invalidates the size-based skip (count after filter is unknown without iterating).

## Bench results (INTERP, 100K rows, ns/op)

| Lane                  | Before | After | Delta | m3f |
|-----------------------|-------:|------:|------:|----:|
| sum_aggregate_m4      |    3.4 |   2.1 | -1.3  | 2.1 |
| reverse_take_m4       |   48.0 |   9.2 | -38.8 | 0.0 |
| select_where_sum_m4   |    7.5 |   7.5 |   0.0 | 7.5 |
| contains_match_m4     |    2.1 |   1.4 | -0.7  | 2.2 |
| chained_where_m4      |    6.6 |   6.6 |   0.0 | 6.6 |
| count_aggregate_m4    |    4.1 |   4.1 |   0.0 | 4.1 |

`sum_aggregate_m4` now matches m3f exactly. `reverse_take_m4` doesn't hit m3f's 0.0 (m3f leverages array-side R6 backward-index access, which decs can't replicate without indexed-component-array helpers) but the skip-into-tail cuts the remaining cost to just the per-element iter ticks. `contains_match_m4` beats m3f at 2.2.

## Tests

- `test_unroll_select_sum_trivial_let_elision_splice_shape` — asserts `decs_sel` does not appear in `_select(_.val).sum()` splice body
- `test_unroll_where_select_sum_trivial_let_elision_splice_shape` — same elision after a `_where` filter
- `test_unroll5d_reverse_take_skip_into_tail_splice_shape` — asserts `for_each_archetype_find` count + presence of `decs_skips` skip-counter local
- `test_reverse_take_multi_archetype_parity` — exercises whole-archetype-skip + partial-archetype skip-counter
- `test_reverse_take_skip_zero_when_take_exceeds_total` — `actualTake = totalCount` branch (early-exit doesn't fire)
- `test_reverse_take_empty_source` — `totalCount = 0` early-return before `for_each_archetype_find`

## Verification

- 1388/1388 linq + 245/245 decs + 782/782 dasSQLITE green INTERP
- MCP lint + CI-style lint both clean
- AOT lane (and JIT) deferred to CI

## Out of scope

- Closing the residual reverse_take 9.2 ns/op gap vs m3f's 0.0 would require either an indexed-component-array helper (so the inner for can start at an arbitrary offset, skipping iter ticks too) or moving the skip math into decs itself. Separate slice if it ever matters in production.
- `select` is included in the skip-into-tail bail. It only affects element shape, not count, so it could in principle stay on the fast path — but the v1 emit doesn't carry projection through the inner-for body. Easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)