### PR TITLE
ast,daslib: fix spurious 30151 on concept_assert under lint flags (#2830)

### DIFF
--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -400,7 +400,7 @@ def push_clone(var Arr : array<auto(numT)>; var varr : numT[] ==const) {
 def push_clone(var Arr : array<auto(numT)[]>; varr : numT[] ==const) {
     static_if (typeinfo can_copy(type<numT>)) {
         static_if (typeinfo sizeof(Arr[0]) == typeinfo sizeof(varr)) {
-            if (typeinfo can_clone_from_const(varr)) {
+            static_if (typeinfo can_clone_from_const(varr)) {
                 for (t in varr) {
                     Arr[__builtin_array_push_back_zero(Arr, typeinfo sizeof(Arr[0]))] := t
                 }
@@ -889,7 +889,7 @@ def insert_clone(var Tab : table<auto(keyT); auto(valT)>; at : keyT | #; var val
 [unused_argument(Tab, at, val)]
 def insert_clone(var Tab : table<auto(keyT); auto(valT)>; at : keyT | #; val : valT ==const | #) {
     static_if (typeinfo can_clone(val)) {
-        if (typeinfo can_clone_from_const(val)) {
+        static_if (typeinfo can_clone_from_const(val)) {
             unsafe(Tab[at]) := val
         } else {
             concept_assert(false, "can't insert value, which can't be cloned from const")
@@ -911,7 +911,7 @@ def insert_clone(var Tab : table<auto(keyT); auto(valT)[]>; at : keyT | #; var v
 [unused_argument(Tab, at, val)]
 def insert_clone(var Tab : table<auto(keyT); auto(valT)[]>; at : keyT | #; val : valT[] ==const | #) {
     static_if (typeinfo can_clone(val)) {
-        if (typeinfo can_clone_from_const(val)) {
+        static_if (typeinfo can_clone_from_const(val)) {
             unsafe(Tab[at]) := val
         } else {
             concept_assert(false, "can't insert value, which can't be cloned from const")
@@ -1180,7 +1180,7 @@ def clone_to_move(var clone_src : auto(TT) ==const | #) : TT -const -# {
 
 def clone_dim(var a; b : auto | #) {
     static_if (typeinfo is_dim(a) && typeinfo is_dim(b) && typeinfo dim(a) == typeinfo dim(b)) {
-        if (typeinfo is_pod(a)) {
+        static_if (typeinfo is_pod(a)) {
             unsafe {
                 memcpy(addr(a[0]), addr(b[0]), typeinfo sizeof(a[0]) * length(a))
             }

--- a/daslib/decs_boost.das
+++ b/daslib/decs_boost.das
@@ -241,7 +241,7 @@ def private append_iterator(arch_name : string; var qloop : ExprFor?; a; prefix,
     qloop.iterators |> resize(qli + 1)
     qloop.iterators[qli] := "{prefix}{a.name}{suffix}"
     qloop.iteratorsAka |> resize(qli + 1)
-    if (typeinfo has_field<_aka>(a)) {
+    static_if (typeinfo has_field<_aka>(a)) {
         qloop.iteratorsAka[qli] := a._aka
     } else {
         qloop.iteratorsAka[qli] := ""
@@ -384,7 +384,7 @@ class DecsQueryMacro : AstCallMacro {
         macro_verify(totalArgs == 1 || totalArgs == 2, prog, expr.at, "expecting query($(block_with_arguments)) or query(eid,$(block_with_arguments))")
         let qt = totalArgs == 2 ? DecsQueryType.eid_query : DecsQueryType.query
         let block_arg_index = totalArgs - 1
-        return <- self->implement(expr, block_arg_index, qt)
+        return <- implement(expr, block_arg_index, qt)
     }
     def implement(var expr : ExprCallMacro?; block_arg_index : int; qt : DecsQueryType) : ExpressionPtr {
         for (arg in expr.arguments) {
@@ -539,7 +539,7 @@ class DecsFindQueryMacro : DecsQueryMacro {
     //! Note: if return is missing, or end of find_query block is reached - its assumed that find_query did not find anything, and will return false.
     def override visit(prog : ProgramPtr; mod : Module?; var expr : ExprCallMacro?) : ExpressionPtr {
         macro_verify(length(expr.arguments) == 1, prog, expr.at, "expecting find_query($(block_with_arguments))")
-        return <- self->implement(expr, 0, DecsQueryType.find_query)
+        return <- implement(expr, 0, DecsQueryType.find_query)
     }
 }
 

--- a/daslib/json_boost.das
+++ b/daslib/json_boost.das
@@ -474,7 +474,7 @@ def from_JV(v : JsonValue const explicit?; anything : auto(TT)) {
             let arr & = v.value as _array
             ret |> reserve(arr |> long_length)
             for (a in arr) {
-                if (typeinfo can_copy(anything[0])) {
+                static_if (typeinfo can_copy(anything[0])) {
                     ret |> push_clone <| _::from_JV(a, decltype_noref(anything[0]))
                 } else {
                     ret |> emplace <| _::from_JV(a, decltype_noref(anything[0]))

--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -62,6 +62,7 @@ namespace das {
         bool enableInferTimeFolding = true;
         bool savedFoldingForEnum = true;        // preVisitEnumerationValue / visitEnumerationValue save-restore
         bool savedFoldingForStaticIf = true;    // preVisit(ExprIfThenElse) / visit(ExprIfThenElse) save-restore (block hooks skipped for static_if)
+        bool savedFoldingForStaticAssert = true; // preVisit(ExprStaticAssert) / visit(ExprStaticAssert) save-restore
         bool disableAot = false;
         bool multiContext = false;
         bool standaloneContext = false;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1215,8 +1215,23 @@ namespace das {
         for (auto &arg : expr->arguments) {
             markNoDiscard(arg);
         }
+        // static_assert / concept_assert needs the cond to fold to a const
+        // before verifyAndFoldContracts runs. Mirror the static_if path
+        // above: with `no_infer_time_folding` set (lint policies) plus
+        // `no_optimizations`, `int_const op int_const` shapes (typically
+        // `typeinfo sizeof(X) <= typeinfo sizeof(Y)` after typeinfo rewrites
+        // itself to ExprConstInt) stay as unfolded ExprOp1/Op2/Op3, and the
+        // contract pass raises a spurious "static assert condition is not
+        // constexpr or const" (30151). Force-enable folding for the cond
+        // subtree; restore in visit().
+        savedFoldingForStaticAssert = enableInferTimeFolding;
+        if (!enableInferTimeFolding) {
+            enableInferTimeFolding = true;
+        }
     }
     ExpressionPtr InferTypes::visit(ExprStaticAssert *expr) {
+        // Restore folding state before any early-return path below.
+        enableInferTimeFolding = savedFoldingForStaticAssert;
         if (expr->argumentsFailedToInfer) {
             if (func)
                 func->notInferred();

--- a/tests/_issue_2830_lint_repro.das
+++ b/tests/_issue_2830_lint_repro.das
@@ -1,0 +1,37 @@
+options gen2
+
+// Regression fixture for https://github.com/GaijinEntertainment/daScript/issues/2830
+// `[decs_template]` synthesizes a per-field `decs::set(cmp, name, src.field)` call
+// chain; `decs::set` is a generic with a `concept_assert(typeinfo sizeof(value) <=
+// typeinfo sizeof(cmp[0].data), ...)`. Under lint flags
+// (`no_infer_time_folding=true` plus `no_optimizations=true`) the `int_const <=
+// int_const` cond stays as an unfolded `ExprOp2`, and `ContractFolding` raised a
+// spurious `error[30151]` (static assert condition is not constexpr or const).
+//
+// `decs_boost`'s `append_iterator` also used a plain `if (typeinfo has_field<_aka>(a))`
+// where the dead branch's `a._aka` reference fails to resolve once infer-time folding
+// is off — same root cause, separate site.
+//
+// `extended_checks` runs lint on changed .das files (linux x64 only by gate); this
+// file lives in `tests/` so the lint job picks it up.
+
+require daslib/decs_boost
+require daslib/linq_boost
+require daslib/linq_fold
+
+[decs_template(prefix = "x_")]
+struct X {
+    a : int
+    b : int
+    c : int
+}
+
+[export]
+def target() : int {
+    return _fold(from_decs_template(type<X>)._where(_.a + _.b + _.c > 0).count())
+}
+
+[export]
+def main {
+    print("count={target()}\n")
+}


### PR DESCRIPTION
Closes #2830.

## Two independent bugs the lint pipeline surfaced together

The linter runs with `cop.no_infer_time_folding = true` + `cop.no_optimizations = true`. Bisect (toggle each lint policy off in turn) localizes `no_infer_time_folding` as the sole trigger. With infer-time folding off, two distinct paths in the codebase that quietly relied on it now break:

### 1. Compiler: `concept_assert` / `static_assert` cond never folds

`typeinfo sizeof(T) <= typeinfo sizeof(U)` rewrites itself to `ExprConstInt <= ExprConstInt` at infer time, but `InferTypes::visit(ExprOp1/Op2/Op3)` ([ast_infer_type_op.cpp:106](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_infer_type_op.cpp#L106), [:365](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_infer_type_op.cpp#L365), [:405](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_infer_type_op.cpp#L405)) only folds when `enableInferTimeFolding` is on. With lint disabling it and `no_optimizations` skipping `ConstFolding`, the binop stays unfolded; `ContractFolding::visit(ExprStaticAssert*)` ([ast_const_folding.cpp:848-852](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_const_folding.cpp#L848-L852)) demands `cond->constexpression || cond->rtti_isConstant()` and raises the spurious 30151.

Fix mirrors the existing static_if save+force-enable+restore pattern ([ast_infer_type.cpp:4418-4422](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_infer_type.cpp#L4418-L4422), [:4428-4430](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_infer_type.cpp#L4428-L4430)) inside `preVisit(ExprStaticAssert*)` / `visit(ExprStaticAssert*)`, so the cond subtree always folds regardless of the surrounding policy.

### 2. Daslib: 6 sites `if (typeinfo X)` instead of `static_if`

These relied on the same infer-time fold of `ExprIfThenElse` ([ast_infer_type.cpp:4444](https://github.com/GaijinEntertainment/daScript/blob/master/src/ast/ast_infer_type.cpp#L4444)) to elide the dead branch — whose body references fields/operations only valid in the true branch's universe. Under lint flags, both branches survive and the dead one fails to resolve. The decs_boost case was what the bug exposed *after* the compiler fix landed:

```
daslib/decs_boost.das:245:36
        qloop.iteratorsAka[qli] := a._aka
                                    ^   field '_aka' not found in ast_core::FieldDeclaration const
```

Convert all 6 to `static_if`:
- `daslib/decs_boost.das:244` — `if (typeinfo has_field<_aka>(a))`
- `daslib/builtin.das:403` — `if (typeinfo can_clone_from_const(varr))`
- `daslib/builtin.das:892` — `if (typeinfo can_clone_from_const(val))`
- `daslib/builtin.das:914` — `if (typeinfo can_clone_from_const(val))`
- `daslib/builtin.das:1183` — `if (typeinfo is_pod(a))`
- `daslib/json_boost.das:477` — `if (typeinfo can_copy(anything[0]))`

## "Linux x64 only"?

CI artifact: [`extended_checks` gates the lint step to `matrix.target == 'linux'`](https://github.com/GaijinEntertainment/daScript/blob/master/.github/workflows/extended_checks.yml#L226). macOS / Windows builds never invoke `utils/lint/main.das`. Verified the bug platform-independent locally on Windows daslang.exe.

## Also rolled in: 2 STYLE028 in `decs_boost.das`

Pre-existing master lint hits (`self->implement(...)` → `implement(...)`), forced into scope by "every changed .das file lint-clean" once the PR touches that file.

## Regression coverage

`tests/_issue_2830_lint_repro.das` — minimal `[decs_template]` + `from_decs_template` + `_where` fixture. CI lint runs on changed `.das` files, so the fixture exercises the failing path on this PR. Without the compiler fix, lint fails at the `concept_assert` 30151. Without the `static_if` sweep, lint fails at the `_aka` resolution 30928. Both fixes required for the fixture to pass.

## Test plan

- [x] Bisect localizes `cop.no_infer_time_folding = true` as the single trigger
- [x] WSL Ubuntu2404-CI (clang 18.1.3, Release): lint clean on all 4 repro variants (bare `[decs_template]`, +where one field, +where multi-field, +linq_fold count chain)
- [x] WSL regression: `tests/decs` 245/245, `tests/json` 266/266, `tests/lint` 8/8, `utils/lint/tests` 38/38
- [x] Windows MSVC Release: MCP lint clean on all 4 changed `.das` files
- [x] Pre-push hook: formatter `--verify` clean on 16695 files; lint clean on 3 ruleable changed files (`builtin.das` is in the lint utility's skip list)
- [ ] CI 9-lane matrix
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)