### PR TITLE
daslib: drop dead `var res` in json_boost.from_JV&lt;EnumT&gt;

### DIFF
--- a/daslib/json_boost.das
+++ b/daslib/json_boost.das
@@ -233,10 +233,9 @@ def from_JV(v : JsonValue const explicit?; ent : auto(EnumT); defV : EnumT = def
     if (v == null || !((v.value is _string) || (v.value is _number) || (v.value is _longint))) return defV
     if (v.value is _string) {
         let name = v.value as _string
-        var res : auto(EnumTT) = default<EnumT>
         let ti = typeinfo rtti_typeinfo(type<EnumT>)
         for (ef in *ti.enumType) {
-            return unsafe(reinterpret<EnumTT>(ef.value)) if (name == ef.name)
+            return unsafe(reinterpret<EnumT>(ef.value)) if (name == ef.name)
         }
         panic("not a valid enumeration {name} in {typeinfo typename(type<EnumT>)}")
     } else {


### PR DESCRIPTION
## Summary

PR [b42a9524e](https://github.com/GaijinEntertainment/daScript/commit/b42a9524e) (daslib: tighten unsafe usage) condensed the enum-name lookup loop in `from_JV<EnumT>` to a single `return unsafe(reinterpret<EnumTT>(ef.value)) if (name == ef.name)`, which left `var res : auto(EnumTT) = default<EnumT>` as dead code — only used to bind `EnumTT` (an alias of `EnumT` since `default<EnumT>` has type `EnumT`).

This PR drops the dead var and inlines the rename: `reinterpret<EnumTT>` → `reinterpret<EnumT>`. No behavior change.

### Context

Surfaced during the dasImgui int↔enum sweep (see PR #2825 + downstream dasImgui PR #64). Original audit flagged a LINT002 transitive hit at `json_boost.das:236` from dasImgui's `from_JV` instantiations; that lint hit is gone after #2830 (de9dd7508) fixed the spurious 30151 + lint cascade through `concept_assert`. What remains is just the genuinely-dead `var res` line — left behind by the unsafe-tightening pass three years ago.

## Test plan

- [x] `tests/json/test_json_edge.das` passes (128/128). `test_enum_json` at line 622 exercises both the string-name path (`from_JV(JV("blue"), type<Color>) == Color.blue`) and the round-trip path — i.e., the exact reinterpret line touched here.
- [x] `tests/json/test_sprint_json.das` passes (57/57).
- [x] `mcp__daslang__lint` on `daslib/json_boost.das` clean.
- [x] pre-push hook (formatter + lint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)