### PR TITLE
linq_fold: bounded-heap / streaming-min for plan_decs_order_family

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -601,6 +601,16 @@ def top_n_by_with_cmp(var a : iterator<auto(TT)>; n : int; cmp : block<(v1 : TT 
     return <- buf
 }
 
+def public spliced_push_heap(var buf : array<auto(TT)>; cmp : block<(x, y : TT) : bool>) {
+    //! Thin re-export of sort_boost::push_heap so plan_decs_order_family's bounded-heap splice can call it via _:: from any user module without requiring sort_boost directly.
+    sort_boost::push_heap(buf, cmp)
+}
+
+def public spliced_pop_heap(var buf : array<auto(TT)>; cmp : block<(x, y : TT) : bool>) {
+    //! Thin re-export of sort_boost::pop_heap for the bounded-heap splice (see spliced_push_heap).
+    sort_boost::pop_heap(buf, cmp)
+}
+
 def unique_key(a) {
     //! generates unique key of workhorse type for the value
     static_if (typeinfo is_workhorse(a)) {

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -4524,11 +4524,11 @@ def private plan_decs_order_family(var expr : Expression?) : Expression? {
         var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
         var bhStmts : array<Expression?>
         bhStmts |> reserve(7)
+        // No `reserve(takeN)` on the bounded buf — matches the policy in linq.das top_n_by_with_cmp iterator variant. Caller may pass takeN >> actual source size, and the decs cardinality is unknown ahead of the walk; pre-reserving N slots would risk a large upfront allocation for no win (fill phase grows geometrically to min(N, M) in O(log) reallocs anyway).
         bhStmts |> push_from <| qmacro_block_to_array() {
             let $i(takeNName) = $e(takeExpr)
             var $i(bufName) : array<$t(elemType)>
             return <- $i(bufName) if ($i(takeNName) <= 0)
-            $i(bufName) |> reserve($i(takeNName))
             for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
                 $e(forExprNode)
             })

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1200,10 +1200,33 @@ def private try_make_inline_cmp(orderKey : Expression?; orderName : string;
     } else {
         cmpExpr = qmacro(_::less($e(b1), $e(b2)))
     }
-    // Emit untyped block args (`$(v1, v2) { ... }`). The typer infers v1/v2 types from
+    // Emit untyped block args (`$(v1, v2) { ... }`); typer infers v1/v2 types from the call site (top_n_by_with_cmp / order_inplace cmp-param signatures).
     return qmacro($(v1, v2) {
         return $e(cmpExpr)
     })
+}
+
+def private make_inline_less_call(orderKey : Expression?; orderName : string;
+                                  var lhsExpr, rhsExpr : Expression?; at : LineInfo) : Expression? {
+    // Direct-call mirror of try_make_inline_cmp: builds `less(KEY_BODY[lhsExpr], KEY_BODY[rhsExpr])` (or flipped for descending) for inline use without a block dispatch — needed for the bounded-heap less-test where invoking a block on a 100K-element hot path costs ~5ns/op extra.
+    if (orderKey == null || !(orderKey is ExprMakeBlock)) return null
+    var mblk = orderKey as ExprMakeBlock
+    var blk = mblk._block as ExprBlock
+    if (blk.arguments |> length != 1 || blk.list |> length != 1
+            || !(blk.list[0] is ExprReturn)) return null
+    var ret = blk.list[0] as ExprReturn
+    if (ret.subexpr == null || has_sideeffects(ret.subexpr)) return null
+    let argName = string(blk.arguments[0].name)
+    var b1 = clone_expression(ret.subexpr)
+    var b2 = clone_expression(ret.subexpr)
+    var r1 : Template
+    r1 |> replaceVariable(argName, lhsExpr)
+    var r2 : Template
+    r2 |> replaceVariable(argName, rhsExpr)
+    apply_template(r1, b1.at, b1)
+    apply_template(r2, b2.at, b2)
+    return qmacro(_::less($e(b2), $e(b1))) if (orderName == "order_by_descending")
+    return qmacro(_::less($e(b1), $e(b2)))
 }
 
 [macro_function]
@@ -4424,6 +4447,99 @@ def private plan_decs_order_family(var expr : Expression?) : Expression? {
     if (hasKey) {
         inlineCmp = try_make_inline_cmp(orderKey, orderName, elemType, at)
     }
+    // Bounded-heap / streaming-min fast paths: when the key is inline-able, skip the materialize-all + min_by/top_n pattern in favor of a per-walk state (single best for first[_or_default], heap of size N for take). Slashes 100K push_clones to ~N — the rest of the elements only pay a cmp.
+    let useBoundedHeap = takeExpr != null && inlineCmp != null && firstName == ""
+    let useStreamingMin = firstName != "" && inlineCmp != null
+    let archName = bridge.archName
+    let needIterWrap = expr._type.isIterator
+    var emission : Expression?
+    if (useStreamingMin) {
+        let bestName = qn("decs_best", at)
+        let seenName = qn("decs_seen", at)
+        var lessTest = make_inline_less_call(orderKey, orderName,
+            qmacro($i(tupName)), qmacro($i(bestName)), at)
+        var perElement : Expression? = qmacro_expr() {
+            if (!$i(seenName)) {
+                $i(bestName) := $i(tupName)
+                $i(seenName) = true
+            } elif ($e(lessTest)) {
+                $i(bestName) := $i(tupName)
+            }
+        }
+        if (whereCond != null) {
+            perElement = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $e(perElement)
+                }
+            }
+        }
+        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
+        if (firstName == "first") {
+            emission = qmacro(invoke($() : $t(elemType) {
+                var $i(bestName) = default<$t(elemType)>
+                var $i(seenName) = false
+                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                    $e(forExprNode)
+                })
+                panic("sequence contains no elements") if (!$i(seenName))
+                return $i(bestName)
+            }))
+        } else {
+            let dBindName = qn("order_d", at)
+            emission = qmacro(invoke($() : $t(elemType) {
+                let $i(dBindName) = $e(firstDefaultExpr)
+                var $i(bestName) = default<$t(elemType)>
+                var $i(seenName) = false
+                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                    $e(forExprNode)
+                })
+                return $i(bestName) if ($i(seenName))
+                return $i(dBindName)
+            }))
+        }
+        return finalize_decs_emission(emission, at, false)
+    }
+    if (useBoundedHeap) {
+        let takeNName = qn("decs_take_n", at)
+        // Direct less-test on the hot path: `less(KEY[decs_tup], KEY[buf[0]])` inlined, no block dispatch.
+        var lessTest = make_inline_less_call(orderKey, orderName,
+            qmacro($i(tupName)), qmacro($i(bufName)[0]), at)
+        var perElement : Expression? = qmacro_expr() {
+            if (length($i(bufName)) < $i(takeNName)) {
+                $i(bufName) |> push_clone($i(tupName))
+                _::spliced_push_heap($i(bufName), $e(inlineCmp))
+            } elif ($e(lessTest)) {
+                _::spliced_pop_heap($i(bufName), $e(inlineCmp))
+                $i(bufName)[length($i(bufName)) - 1] := $i(tupName)
+                _::spliced_push_heap($i(bufName), $e(inlineCmp))
+            }
+        }
+        if (whereCond != null) {
+            perElement = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $e(perElement)
+                }
+            }
+        }
+        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
+        var bhStmts : array<Expression?>
+        bhStmts |> reserve(7)
+        bhStmts |> push_from <| qmacro_block_to_array() {
+            let $i(takeNName) = $e(takeExpr)
+            var $i(bufName) : array<$t(elemType)>
+            return <- $i(bufName) if ($i(takeNName) <= 0)
+            $i(bufName) |> reserve($i(takeNName))
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $e(forExprNode)
+            })
+            _::order_inplace($i(bufName), $e(inlineCmp))
+            return <- $i(bufName)
+        }
+        emission = qmacro(invoke($() : array<$t(elemType)> {
+            $b(bhStmts)
+        }))
+        return finalize_decs_emission(emission, at, needIterWrap)
+    }
     var perElement : Expression? = qmacro_expr() {
         $i(bufName) |> push_clone($i(tupName))
     }
@@ -4435,7 +4551,6 @@ def private plan_decs_order_family(var expr : Expression?) : Expression? {
         }
     }
     var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-    let archName = bridge.archName
     var bodyStmts : array<Expression?>
     bodyStmts |> reserve(5)
     bodyStmts |> push_from <| qmacro_block_to_array() {
@@ -4444,8 +4559,6 @@ def private plan_decs_order_family(var expr : Expression?) : Expression? {
             $e(forExprNode)
         })
     }
-    let needIterWrap = expr._type.isIterator
-    var emission : Expression?
     if (firstName == "first") {
         // order + first → min/max on buffer. Empty buf must panic to match eager `first()` semantics.
         bodyStmts |> push <| qmacro_expr() {

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -1987,8 +1987,10 @@ def test_unroll5d_order_by_take_splice_shape(t : T?) {
         t |> equal(describe_count(body_expr, "for_each_archetype_find"), 0, "order family uses for_each_archetype (no early-exit needed)")
         // Buffer hoisted ABOVE for_each_archetype so it survives the archetype walk.
         t |> success(describe_count(body_expr, "decs_buf") >= 2, "decs_buf declared + populated")
-        // top_n_by call replaces the array-side to_array / sort sequence.
-        t |> equal(describe_count(body_expr, "top_n_by"), 1, "splice dispatches to top_n_by")
+        // Bounded-heap emit: spliced_push_heap appears twice (fill + replace), spliced_pop_heap once (replace). top_n_by is no longer used.
+        t |> equal(describe_count(body_expr, "spliced_push_heap"), 2, "bounded-heap fill + replace each call spliced_push_heap")
+        t |> equal(describe_count(body_expr, "spliced_pop_heap"), 1, "bounded-heap replace calls spliced_pop_heap once")
+        t |> equal(describe_count(body_expr, "top_n_by"), 0, "bounded-heap path does NOT call top_n_by")
     }
 }
 
@@ -2005,10 +2007,12 @@ def test_unroll5d_order_by_first_splice_shape(t : T?) {
         t |> success(r.matched, "qmatch must capture body")
         t |> equal(describe_count(body_expr, "to_sequence"), 0, "order_by+first splice must NOT fall to tier-2 to_sequence")
         t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype")
-        // first → min_by on the buffer (NOT top_n_by + index).
-        t |> equal(describe_count(body_expr, "min_by"), 1, "order_by+first emits min_by call")
-        t |> equal(describe_count(body_expr, "top_n_by"), 0, "order_by+first should NOT use top_n_by")
-        // Empty-buffer panic guard present.
+        // Streaming-min emit: best + seen state vars, no buffer + min_by/top_n.
+        t |> equal(describe_count(body_expr, "min_by"), 0, "streaming-min path does NOT call min_by")
+        t |> equal(describe_count(body_expr, "top_n_by"), 0, "streaming-min path does NOT call top_n_by")
+        t |> success(describe_count(body_expr, "decs_best") >= 2, "best state var declared + updated")
+        t |> success(describe_count(body_expr, "decs_seen") >= 2, "seen flag declared + updated")
+        // Empty-source panic guard preserved.
         t |> equal(describe_count(body_expr, "sequence contains no elements"), 1, "panic-on-empty guard for first()")
     }
 }


### PR DESCRIPTION
## Summary

For `from_decs._order_by(KEY).take(N).to_array()` with an inline-able key, emit a bounded heap of size N maintained during the `for_each_archetype` walk instead of materializing the full M-element buffer and then partial-sorting.

For `from_decs._order_by(KEY).first()` / `first_or_default(d)`, emit a streaming-min: single `best` + `seen` flag instead of buf + `min_by`.

Cuts 100K `push_clone`s (full struct + string alloc) down to ~N (only when the element wins the heap test).

## Bench results (INTERP, 100K rows, ns/op)

| Bench | m3f | Before | After | Δ | Gap vs m3f |
|---|---|---|---|---|---|
| `sort_first_m4` | 41.3 | 72.0 | **23.9** | -48.1 (3.0×) | **-17.4 (BEATS m3f)** |
| `sort_take_m4` | 22.7 | 52.1 | 30.6 | -21.5 (1.7×) | +7.9 |
| `order_take_desc_m4` | 22.3 | 52.1 | 30.5 | -21.6 (1.7×) | +8.2 |
| `select_where_order_take_m4` | 21.6 | 35.1 | 25.1 | -10.0 (1.4×) | +3.5 |

Full bench sweep: 4 wins, 0 regressions across all 50 m4 lanes.

## Implementation

- Adds two thin re-exports in `daslib/linq.das` (`spliced_push_heap`, `spliced_pop_heap`) so the splice can call `sort_boost::{push,pop}_heap` from any user module without requiring `sort_boost` directly.
- New `make_inline_less_call` helper in `daslib/linq_fold.das` templates the key body twice with direct operand expressions — no block dispatch on the hot path.
- Two new branches in `plan_decs_order_family`: `useBoundedHeap` (takeExpr + inlineCmp + no first) and `useStreamingMin` (first/first_or_default + inlineCmp). Both gated on inline-able key — falls through to existing materialize-then-top_n / min_by paths when the key is non-inlineable.
- Shape tests updated for `_order_by + take` and `_order_by + first` in `tests/linq/test_linq_from_decs.das` to reflect the new emit shape (no top_n_by / min_by calls; streaming-state vars + spliced heap helpers instead).

## Residual

The +8 ns/op residual on `sort_take` / `order_take_desc` is the per-element cmp overhead inherent to bounded-heap vs partial_sort on a contiguous array (m3f). Closing further would need column-pointer key-only access on the archetype side (deferred — needs indexed component access, same architectural floor as PR #2834's reverse_take residual).

## Test plan

- [x] `mcp__daslang__lint` clean on all 3 changed files
- [x] `tests/linq` — 1390/1390 pass
- [x] `tests/decs` — 245/245 pass
- [x] `tests/dasSQLITE` — 782/782 pass
- [x] `test_aot` builds cleanly (codegen smoke)
- [x] JIT smoke clean (no verifier errors)
- [x] `detect_duplicates` clean on new helpers
- [x] Full bench sweep — 4 wins on targeted lanes, 0 regressions on the other 46
- [ ] CI verifies AOT/JIT lanes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)