### PR TITLE
Support clang-mingw64 toolchain (core + 7 modules + JIT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build-asan/
 build-ubsan/
 build-linux-asan/
 build-linux/
+build-mingw/
 build_eastl/
 # EASTL local-verify checkouts (build_eastl uses these via -isystem)
 eastl/
@@ -37,6 +38,11 @@ _aot_generated/
 .cache/
 
 opencoede.json
+
+# scratch smoke scripts from clang-mingw64 enablement (not part of any feature)
+_smoke*.das
+_smoke*.cpp
+_smoke*.o
 
 modules/dasSFML/libsfml/
 # site/doc/ is the Sphinx HTML output deployed by .github/workflows/pages.yml.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,9 +306,22 @@ ENDIF()
 
 # All shared libraries should pass through this macro.
 # It sets required properties for shared libraries.
+# Mingw's ADD_LIBRARY auto-prepends "lib" to the output filename. When the
+# target name already starts with "lib" (libDaScript / libDaScriptDyn /
+# libDasModuleX), this produces ugly double-lib names like liblibDaScript.a
+# or liblibDaScriptDyn.dll on disk. Strip the auto-prefix so output names
+# match MSVC convention. Only fires on Windows-non-MSVC: Linux/macOS keep
+# their conventional `lib` prefix (which they need to be linkable as -lname).
+MACRO(STRIP_DOUBLE_LIB_PREFIX_ON_MINGW lib)
+    IF(WIN32 AND NOT MSVC AND "${lib}" MATCHES "^lib")
+        SET_TARGET_PROPERTIES(${lib} PROPERTIES PREFIX "" IMPORT_PREFIX "")
+    ENDIF()
+ENDMACRO()
+
 MACRO(SETUP_DAS_SHARED_LIBRARY lib)
     ADD_LIBRARY(${lib} SHARED ${ARGN})
     SETUP_LIB_DEFINITIONS(${lib})
+    STRIP_DOUBLE_LIB_PREFIX_ON_MINGW(${lib})
     if(MSVC)
         # We export a lot of structures, some of them has not exported internals.
         # Instead of marking everything as exported let's disable
@@ -323,6 +336,7 @@ ENDMACRO()
 MACRO(ADD_DAS_STATIC_LIBRARY lib)
     ADD_LIBRARY(${lib} STATIC ${ARGN})
     SETUP_LIB_DEFINITIONS(${lib})
+    STRIP_DOUBLE_LIB_PREFIX_ON_MINGW(${lib})
 ENDMACRO()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,10 +309,11 @@ ENDIF()
 MACRO(SETUP_DAS_SHARED_LIBRARY lib)
     ADD_LIBRARY(${lib} SHARED ${ARGN})
     SETUP_LIB_DEFINITIONS(${lib})
-    if(WIN32)
+    if(MSVC)
         # We export a lot of structures, some of them has not exported internals.
         # Instead of marking everything as exported let's disable
         # warning and refactor our public API in future.
+        # MSVC-frontend gate (not WIN32) — clang-mingw doesn't understand /wd flags.
         TARGET_COMPILE_OPTIONS(${lib} PUBLIC /wd4251 /wd4661 /wd4275)
     else()
         SET_TARGET_PROPERTIES(${lib} PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -1041,7 +1042,12 @@ MACRO(SETUP_LIBDASCRIPT library shared_lib full_setup sources exports_def)
             TARGET_LINK_LIBRARIES(${library} network uuid)
         ENDIF()
         IF(WIN32)
-            target_link_libraries(${library} dbghelp)
+            # System libs that source files reference via `#pragma comment(lib,...)`.
+            # MSVC honors those pragmas, but clang-mingw + ld.lld does not always
+            # pick up the .drectve defaultlib directives — list them explicitly so
+            # every Windows toolchain links the same set. Harmless on MSVC (each
+            # lib gets added once regardless of how it was requested).
+            target_link_libraries(${library} dbghelp ws2_32 mswsock advapi32 rpcrt4)
         ENDIF()
     ENDIF()
     SETUP_CPP11(${library})

--- a/include/daScript/daScriptModule.h
+++ b/include/daScript/daScriptModule.h
@@ -11,7 +11,11 @@ namespace das
     // Note: this is similar to NEED_ALL_DEFAULT_MODULES
     // but more safe, since it allows such modules to be
     // already registered.
-    DAS_API void register_builtin_modules();
+    // Lives in libDaScript / libDaScriptDyn (compiler lib, DAS_CC_EXPORTS),
+    // NOT the runtime lib — so the export tag must be DAS_CC_API, not DAS_API.
+    // MSVC happens to link this even with the wrong tag; clang-mingw is strict
+    // and reports an undefined symbol at exe link time.
+    DAS_CC_API void register_builtin_modules();
 
 };
 

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -251,7 +251,13 @@ __forceinline uint64_t rotr64_c(uint64_t a, uint64_t b) {
 
 #if DAS_ENABLE_DLL
 #ifndef DAS_API
-#ifdef _MSC_VER
+#ifdef _WIN32
+    // __declspec(dll*) works on every Windows toolchain: MSVC, clang-cl,
+    // clang-mingw, and gcc-mingw (gcc accepts the MSVC keyword on Windows
+    // targets). ELF visibility on Windows is a no-op, so the old _MSC_VER
+    // gate left clang-mingw with untagged symbols — lld then defaulted to
+    // exporting every global and overflowed the 16-bit PE ordinal table at
+    // ~65535 symbols.
     #define DAS_EXPORT_DLL __declspec(dllexport)
     #define DAS_IMPORT_DLL __declspec(dllimport)
 #else
@@ -435,7 +441,9 @@ namespace das {
 inline void *das_aligned_alloc16(size_t size) {
     DAS_ASSERTF(size != 0, "das_aligned_alloc16 called with size 0");
     void *p;
-#if defined(_MSC_VER)
+#if defined(_WIN32)
+    // All Windows toolchains (MSVC / clang-cl / clang-mingw64 / gcc-mingw64) use
+    // the MS C runtime aligned-allocator family declared in <malloc.h>.
     p = _aligned_malloc(size, 16);
 #else
     p = nullptr;
@@ -449,7 +457,7 @@ inline void *das_aligned_alloc16(size_t size) {
 }
 inline void das_aligned_free16(void *ptr) {
     das::track_free_hook(ptr);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     _aligned_free(ptr);
 #else
     free(ptr);
@@ -457,11 +465,12 @@ inline void das_aligned_free16(void *ptr) {
 }
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
-#elif defined (__linux__) || defined (_EMSCRIPTEN_VER) || defined __HAIKU__
+#elif defined (__linux__) || defined (_EMSCRIPTEN_VER) || defined __HAIKU__ || defined(_WIN32)
+// Windows: <malloc.h> declares _aligned_msize for MSVC and the MinGW-w64 CRT.
 #include <malloc.h>
 #endif
 inline size_t das_aligned_memsize(void * ptr){
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     return _aligned_msize(ptr, 16, 0);
 #elif defined(__APPLE__)
     return malloc_size(ptr);

--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -6,15 +6,20 @@
 
 #include <sys/stat.h>
 
-#if defined(_MSC_VER)
-
+// Three header buckets:
+//   _WIN32       — io.h / direct.h        (every Windows toolchain via MS CRT)
+//   !_MSC_VER    — dirent.h / unistd.h    (POSIX shims; mingw-w64 ships them)
+//   !_WIN32      — libgen.h / sys/mman.h  (pure POSIX, absent on Windows)
+#if defined(_WIN32)
 #include <io.h>
 #include <direct.h>
-
-#else
-#include <libgen.h>
+#endif
+#if !defined(_MSC_VER)
 #include <dirent.h>
 #include <unistd.h>
+#endif
+#if !defined(_WIN32)
+#include <libgen.h>
 #include <sys/mman.h>
 #endif
 #endif
@@ -35,7 +40,7 @@ namespace das {
         Time     atime() const  { return { stats.st_atime }; }
         Time     ctime() const  { return { stats.st_ctime }; }
         Time     mtime() const  { return { stats.st_mtime }; }
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         bool     is_reg() const { return stats.st_mode & _S_IFREG; }
         bool     is_dir() const { return stats.st_mode & _S_IFDIR; }
 #else

--- a/modules/dasGlfw/CMakeLists.txt
+++ b/modules/dasGlfw/CMakeLists.txt
@@ -21,9 +21,17 @@ IF((NOT DAS_GLFW_INCLUDED) AND ((NOT ${DAS_GLFW_DISABLED}) OR (NOT DEFINED DAS_G
 	ELSEIF(UNIX)
 		SET(DAS_GLFW_STATIC_PATH ${GLFW_STATIC_LIB_PATH}/lib/libglfw3.a)
 		SET(DAS_GLFW_DYN_PATH ${GLFW_DYNAMIC_LIB_PATH}/lib/libglfw.so.${GLFW_VERSION})
-	ELSE()
-		SET(DAS_GLFW_STATIC_PATH ${GLFW_STATIC_LIB_PATH}/lib/glfw3.lib)
-		SET(DAS_GLFW_DYN_PATH ${GLFW_DYNAMIC_LIB_PATH}/lib/glfw3dll.lib)
+	ELSE()  # WIN32
+		IF(MSVC)
+			SET(DAS_GLFW_STATIC_PATH ${GLFW_STATIC_LIB_PATH}/lib/glfw3.lib)
+			SET(DAS_GLFW_DYN_PATH ${GLFW_DYNAMIC_LIB_PATH}/lib/glfw3dll.lib)
+		ELSE()  # mingw (clang-mingw / gcc-mingw)
+			# GLFW v3.4 on mingw: static -> libglfw3.a; dynamic import lib ->
+			# libglfw3dll.a; .dll itself stays glfw3.dll (no lib prefix), so
+			# the runtime install line below is unchanged.
+			SET(DAS_GLFW_STATIC_PATH ${GLFW_STATIC_LIB_PATH}/lib/libglfw3.a)
+			SET(DAS_GLFW_DYN_PATH ${GLFW_DYNAMIC_LIB_PATH}/lib/libglfw3dll.a)
+		ENDIF()
 	ENDIF()
 
 	MACRO(BUILD_GLFW glfw_libraries glfw3_target build_shared_libs install_prefix prefix_dir)

--- a/modules/dasGlfw/CMakeLists.txt
+++ b/modules/dasGlfw/CMakeLists.txt
@@ -173,10 +173,22 @@ IF((NOT DAS_GLFW_INCLUDED) AND ((NOT ${DAS_GLFW_DISABLED}) OR (NOT DEFINED DAS_G
 	# the user is shipping from an installed daslang or directly from the build
 	# tree (CI extended_checks does the latter).
 	IF(WIN32)
+		# Land glfw3.dll NEXT TO the daslang.exe on every generator:
+		# multi-config (MSBuild) puts the .exe in bin/<CONFIG>/, so we mirror
+		# that here; single-config (Ninja) puts it in bin/ directly. The old
+		# unconditional `$<CONFIG>` suffix worked for MSVC but stranded
+		# glfw3.dll in bin/Release/ on mingw where daslang.exe sits in bin/.
+		# (Computed at configure time -- avoids a $<TARGET_FILE_DIR:daslang>
+		# dependency cycle since daslang already depends on dasModuleGlfw.)
+		IF(CMAKE_CONFIGURATION_TYPES)
+			SET(_DAS_GLFW_COPY_DIR "${EXECUTABLE_OUTPUT_PATH}/$<CONFIG>")
+		ELSE()
+			SET(_DAS_GLFW_COPY_DIR "${EXECUTABLE_OUTPUT_PATH}")
+		ENDIF()
 		ADD_CUSTOM_COMMAND(TARGET dasModuleGlfw POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 				"${GLFW_DYNAMIC_LIB_PATH}/bin/glfw3.dll"
-				"${EXECUTABLE_OUTPUT_PATH}/$<CONFIG>/glfw3.dll"
+				"${_DAS_GLFW_COPY_DIR}/glfw3.dll"
 		)
 	ELSEIF(APPLE)
 		ADD_CUSTOM_COMMAND(TARGET dasModuleGlfw POST_BUILD

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -7,7 +7,9 @@
 #include "need_dasGLFW.h"
 #include "aot_dasGLFW.h"
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
+// Win32 native handles are available on every Windows toolchain (MSVC,
+// clang-cl, clang-mingw, gcc-mingw).
 
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
@@ -62,6 +64,7 @@ namespace das {
     void * DAS_glfwGetNativeWindow(GLFWwindow* window) {
         return nullptr;
     }
+    void * DAS_glfwGetNativeDisplay() { return nullptr; }
 }
 
 #endif

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -7,7 +7,11 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 
 	include(ExternalProject)
 
-	IF(WIN32)
+	IF(WIN32 AND MSVC)
+		# MSVC: build OpenSSL from sources via `perl Configure VC-WIN64A` + nmake.
+		# Both are MSVC-only — perl invokes OpenSSL's MSVC-flavored config and
+		# nmake is the MSVC make tool. clang-mingw / gcc-mingw take the ELSE
+		# branch below and pick up the system OpenSSL from the mingw sysroot.
 		set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/openssl")
 		find_package(OpenSSL QUIET PATHS ${OPENSSL_ROOT_DIR})
 		IF(NOT OpenSSL_FOUND)
@@ -41,10 +45,30 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 
 		SET(HV_LIBRARIES ${DAS_HV_DIR}/hv/$<CONFIG>/lib/hv_static.lib)
 	ELSE()
+		# POSIX + mingw (clang-mingw / gcc-mingw): use system OpenSSL.
+		IF(WIN32 AND NOT DEFINED OPENSSL_ROOT_DIR)
+			# FindOpenSSL.cmake on Windows is MSVC-centric and doesn't look in
+			# the mingw sysroot by default. Derive the sysroot from the C
+			# compiler path: <SYSROOT>/bin/clang.exe -> <SYSROOT>. clang64
+			# ships <SYSROOT>/lib/libcrypto.dll.a + libssl.dll.a, which
+			# find_package then locates correctly with this hint.
+			get_filename_component(_MINGW_BIN ${CMAKE_C_COMPILER} DIRECTORY)
+			get_filename_component(OPENSSL_ROOT_DIR ${_MINGW_BIN} DIRECTORY)
+		ENDIF()
 		find_package(OpenSSL REQUIRED)
-		# libhv ≥ master renames hv_static's OUTPUT_NAME to "hv" on POSIX,
-		# so the installed file is libhv.a (was libhv_static.a in v1.3.4).
-		SET(HV_LIBRARIES ${DAS_HV_DIR}/hv/$<CONFIG>/lib/libhv.a)
+		# libhv ≥ master renames hv_static's OUTPUT_NAME to "hv" on POSIX
+		# (-> libhv.a) but keeps the original name on mingw (-> libhv_static.a).
+		IF(WIN32)
+			# mingw: also need winmm for timeSetEvent/timeKillEvent. MSVC
+			# auto-pulls it via libhv's #pragma comment(lib, "winmm"); mingw
+			# does not honor those reliably, so list it explicitly.
+			SET(HV_LIBRARIES
+				${DAS_HV_DIR}/hv/$<CONFIG>/lib/libhv_static.a
+				winmm
+			)
+		ELSE()
+			SET(HV_LIBRARIES ${DAS_HV_DIR}/hv/$<CONFIG>/lib/libhv.a)
+		ENDIF()
 		SET(OPENSSL_LIBRARIES_FILES OpenSSL::Crypto OpenSSL::SSL)
 	ENDIF()
 

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -25,7 +25,6 @@ require jit
 
 let public LLVM_DEBUG_RESULT = false
 let public LLVM_DEBUG_EVERYTHING = false
-let LLVM_ENABLE_DIAGNOSTIC = false
 
 let public LLVM_DEBUG_TRACES = false
 let public LLVM_DEBUG_LINE_TRACES = false
@@ -363,9 +362,6 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
     init_jit_clopts()
     g_ctx = LLVMContextCreate()
     g_prim_t = new PrimitiveTypes(g_ctx)
-    if (LLVM_ENABLE_DIAGNOSTIC) {
-        set_context_diagnostics_to_log(g_ctx)
-    }
     g_failed = false
     g_fn_types |> clear()
     g_mod = LLVMModuleCreateWithNameInContext("llvm_jit_module", g_ctx)

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -819,7 +819,21 @@ def public with_default_target_machine(opt_level : uint; use_host_cpu : bool;
     LLVMInitializeAllTargetMCs()
     LLVMInitializeAllAsmPrinters()
 
-    let triple_msg = LLVMGetDefaultTargetTriple()
+    // host_jit_triple() returns the daslang-host toolchain's triple when it
+    // differs from LLVM.dll's default. On clang-mingw64, the prebuilt LLVM.dll
+    // (MSVC clang-cl-built) defaults to x86_64-pc-windows-msvc — emitting
+    // MSVC-ABI .o files that mingw's linker can't satisfy (_fltused etc).
+    // Empty string means "use LLVM default" (existing MSVC / linux / macOS
+    // builds where LLVM.dll's triple already matches the host).
+    let host_triple = host_jit_triple()
+    var triple_msg : string
+    var triple_owned_by_llvm = false
+    if (empty(host_triple)) {
+        triple_msg = LLVMGetDefaultTargetTriple()
+        triple_owned_by_llvm = true
+    } else {
+        triple_msg = host_triple
+    }
     let cpu_msg = use_host_cpu ? LLVMGetHostCPUName() : ""
     let features_msg = use_host_cpu ? LLVMGetHostCPUFeatures() : ""
 
@@ -829,7 +843,9 @@ def public with_default_target_machine(opt_level : uint; use_host_cpu : bool;
         LLVMDisposeMessage(cpu_msg)
         LLVMDisposeMessage(features_msg)
     }
-    LLVMDisposeMessage(triple_msg)
+    if (triple_owned_by_llvm) {
+        LLVMDisposeMessage(triple_msg)
+    }
 }
 
 // @mod - module to dump to dll

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -223,7 +223,7 @@ MAKE_TYPE_FACTORY(DiskSpaceInfo, das::DiskSpaceInfo)
 
 namespace das {
     void builtin_sleep ( uint32_t msec ) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         _sleep(msec);
 #else
         usleep(1000 * msec);
@@ -424,7 +424,7 @@ namespace das {
 
     char * builtin_dirname ( const char * name, Context * context, LineInfoArg * at ) {
         if ( name ) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
             char full_path[ _MAX_PATH ];
             char dir[ _MAX_DIR ];
             char fname[ _MAX_FNAME ];
@@ -452,7 +452,7 @@ namespace das {
 
     char * builtin_basename ( const char * name, Context * context, LineInfoArg * at ) {
         if ( name ) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
             char drive[ _MAX_DRIVE ];
             char full_path[ _MAX_PATH ];
             char dir[ _MAX_DIR ];
@@ -486,7 +486,7 @@ namespace das {
     }
 
      void builtin_dir ( const char * path, const Block & fblk, Context * context, LineInfoArg * at ) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         _finddata_t c_file;
         intptr_t hFile;
         string findPath = string(path ? path : "") + "/*";
@@ -545,7 +545,7 @@ namespace das {
 
     bool builtin_mkdir ( const char * path ) {
         if ( path ) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
             return _mkdir(path) == 0;
 #elif defined(_EMSCRIPTEN_VER)
             return mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == 0;
@@ -566,7 +566,7 @@ namespace das {
             context->throw_error_at(at, "popen of null");
             return -1;
         }
-#ifdef _MSC_VER
+#ifdef _WIN32
         FILE * f = _popen(cmd, bin ? "rb" : "rt");
 #elif defined(__linux__)
         FILE * f = popen(cmd, "r");
@@ -585,7 +585,7 @@ namespace das {
         vec4f args[1];
         args[0] = cast<FILE *>::from(f);
         context->invoke(blk, args, nullptr, at);
-#ifdef _MSC_VER
+#ifdef _WIN32
         return _pclose( f );
 #elif defined(__APPLE__)
         {
@@ -615,7 +615,7 @@ namespace das {
         if ( timeout_sec <= 0.0f ) {
             return builtin_popen_impl(cmd, false, blk, context, at);
         }
-#ifdef _MSC_VER
+#ifdef _WIN32
         // Windows: CreateProcess with stdout pipe + job object for process tree kill
         SECURITY_ATTRIBUTES sa;
         sa.nLength = sizeof(SECURITY_ATTRIBUTES);
@@ -739,7 +739,7 @@ namespace das {
 #endif
     }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     // Quote a single argv element for Windows CommandLineToArgvW parsing.
     // Wraps in double quotes if needed, doubles backslashes that precede a
     // quote (or end-of-string inside a quoted token), and escapes embedded
@@ -797,7 +797,7 @@ namespace das {
             context->throw_error_at(at, "popen_argv with null exe");
             return -1;
         }
-#ifdef _MSC_VER
+#ifdef _WIN32
         SECURITY_ATTRIBUTES sa;
         sa.nLength = sizeof(SECURITY_ATTRIBUTES);
         sa.bInheritHandle = TRUE;
@@ -965,7 +965,7 @@ namespace das {
 
     bool builtin_rmdir ( const char * path ) {
         if ( !path ) return false;
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         return _rmdir(path) == 0;
 #else
         return rmdir(path) == 0;
@@ -978,7 +978,7 @@ namespace das {
         return stat(path, &st) == 0;
     }
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     static bool rmdir_rec_impl ( const string & path ) {
         _finddata_t c_file;
         intptr_t hFile;
@@ -1050,7 +1050,7 @@ namespace das {
     bool builtin_mkdir_ec ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) {
         error = nullptr;
         if ( !path ) { error = empty_path_error(ctx, at); return false; }
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         if ( _mkdir(path) != 0 ) { error = errno_to_string(ctx, at); return false; }
 #elif defined(_EMSCRIPTEN_VER)
         if ( mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0 ) { error = errno_to_string(ctx, at); return false; }
@@ -1063,7 +1063,7 @@ namespace das {
     bool builtin_rmdir_ec ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) {
         error = nullptr;
         if ( !path ) { error = empty_path_error(ctx, at); return false; }
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         if ( _rmdir(path) != 0 ) { error = errno_to_string(ctx, at); return false; }
 #else
         if ( rmdir(path) != 0 ) { error = errno_to_string(ctx, at); return false; }
@@ -1182,7 +1182,7 @@ namespace das {
         if ( !cmd ) return nullptr;
         stringstream ss;
         for ( const char * ch=cmd; *ch; ) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
             if ( *ch=='^' || *ch=='|' || *ch=='<' || *ch=='>' || *ch=='&' ||
                     *ch=='%' || *ch=='$' || *ch=='`' || *ch=='\'' || *ch=='@' ) {
                 ss.put('^');

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -783,16 +783,34 @@ extern "C" {
     // The prebuilt LLVM.dll shipped via dasLLVM's FetchContent is built with
     // MSVC clang-cl, so LLVMGetDefaultTargetTriple() always returns
     // x86_64-pc-windows-msvc regardless of what host compiler built
-    // daslang.exe. On clang-mingw64 daslang.exe, MSVC-ABI .o files reference
+    // daslang.exe. On mingw daslang.exe, MSVC-ABI .o files reference
     // _fltused (msvcrt marker symbol) and other MSVC-CRT-isms that mingw's
-    // ld.lld + libc CRT cannot satisfy. Forcing x86_64-w64-windows-gnu makes
-    // LLVM emit a mingw-flavored .o with no MSVC marker symbols, links
-    // cleanly against libDaScriptDyn_runtime.dll.a, and the resulting DLL
-    // calls into the mingw daslang.exe via the same Win64 C ABI without
-    // CRT-mismatch hazards.
+    // ld.lld + libc CRT cannot satisfy. Forcing a mingw triple makes LLVM
+    // emit a mingw-flavored .o with no MSVC marker symbols, links cleanly
+    // against libDaScriptDyn_runtime.dll.a, and the resulting DLL calls
+    // into the mingw daslang.exe via the same C ABI without CRT-mismatch
+    // hazards.
+    //
+    // The arch suffix has to match the host — clang32 (i686), clang64
+    // (x86_64), clangarm64 (aarch64), clangarm32 (armv7) all share the
+    // mingw vendor/os/env suffix but differ on the arch component.
+    // Detection uses the standard GCC/Clang arch predefined macros so
+    // this works for both compilers on every supported mingw arch.
     const char * host_jit_triple ( ) {
     #if defined(_WIN32) && !defined(_MSC_VER)
-        return "x86_64-w64-windows-gnu";
+        #if defined(__aarch64__) || defined(_M_ARM64)
+            return "aarch64-w64-windows-gnu";
+        #elif defined(__arm__) || defined(_M_ARM)
+            return "armv7-w64-windows-gnu";
+        #elif defined(__x86_64__) || defined(_M_X64)
+            return "x86_64-w64-windows-gnu";
+        #elif defined(__i386__) || defined(_M_IX86)
+            return "i686-w64-windows-gnu";
+        #else
+            // Unknown mingw arch — fall back to LLVM's default and let
+            // the user explicitly override via the customLinker path.
+            return "";
+        #endif
     #else
         return "";
     #endif
@@ -908,7 +926,10 @@ extern "C" {
     }
 
     bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, const char * extraLinkerArgs, bool isShared, bool linkWholeLib, Context *context ) {
-        char cmd[1024];
+        // cmd is built via fmt::format (heap-allocated std::string) rather
+        // than a fixed stack buffer — long paths (deep build roots, spaces,
+        // long extraLinkerArgs) can easily exceed a few hundred bytes, and
+        // a fixed buffer would silently corrupt the stack on overflow.
         const char * extra = (extraLinkerArgs && extraLinkerArgs[0]) ? extraLinkerArgs : "";
         const auto paths = get_real_lib_linker_paths(dasLib, customLinker, isShared, linkWholeLib);
         const auto & linker = paths.linker;
@@ -926,7 +947,7 @@ extern "C" {
             return false;
         }
 
-
+        string cmd;
         #if defined(_WIN32) || defined(_WIN64)
             #if defined(_MSC_VER)
                 // MSVC clang-cl: -DLL marks shared, -link separates link-only
@@ -935,9 +956,9 @@ extern "C" {
                 // because the linker path itself contains spaces on Program
                 // Files installs.
                 const auto linkerParam = isShared ? "-DLL" : "";
-                auto result = compilerLibrary.empty()
-                    ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, extra, linkerParam, libraryName)
-                    : fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, extra, linkerParam, libraryName);
+                cmd = compilerLibrary.empty()
+                    ? fmt::format(FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, extra, linkerParam, libraryName)
+                    : fmt::format(FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, extra, linkerParam, libraryName);
             #else
                 // mingw clang/gcc: Unix-flavored driver, -shared/-o syntax.
                 // No rpath on Windows (DLLs resolve via PATH / LoadLibrary
@@ -950,10 +971,10 @@ extern "C" {
                 // inner per-arg quotes intact. Without this wrap cmd.exe
                 // misparses the very first quoted token as the command name.
                 const auto linkerParam = isShared ? "-shared" : "";
-                auto result = compilerLibrary.empty()
-                    ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" {} -o \"{}\" \"{}\" \"{}\" {} 2>&1\""),
+                cmd = compilerLibrary.empty()
+                    ? fmt::format(FMT_STRING("\"\"{}\" {} -o \"{}\" \"{}\" \"{}\" {} 2>&1\""),
                                             linker, linkerParam, libraryName, objFilePath, runtimeLibrary, extra)
-                    : fmt::format_to(cmd, FMT_STRING("\"\"{}\" {} -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1\""),
+                    : fmt::format(FMT_STRING("\"\"{}\" {} -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1\""),
                                             linker, linkerParam, libraryName, objFilePath, runtimeLibrary, compilerLibrary, extra);
             #endif
         #elif defined(__APPLE__)
@@ -963,9 +984,9 @@ extern "C" {
             // The embedded `\" \"` splits the format-string's outer quotes so the linker
             // sees two distinct -Wl,-rpath flags, not one with an embedded space.
             const auto rpath = "-Wl,-rpath,@executable_path\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
-            auto result = compilerLibrary.empty()
-                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, objFilePath, extra)
-                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, compilerLibrary, objFilePath, extra);
+            cmd = compilerLibrary.empty()
+                ? fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, objFilePath, extra)
+                : fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"), linker, linkerParam, rpath, libraryName, runtimeLibrary, compilerLibrary, objFilePath, extra);
         #else
             const auto linkerParam = isShared ? "-shared" : "";
             // $ORIGIN first → relocated bundle finds .so next to the exe;
@@ -974,14 +995,13 @@ extern "C" {
             // The embedded `\" \"` splits the format-string's outer quotes so the linker
             // sees two distinct -Wl,-rpath flags, not one with an embedded space.
             const auto rpath = "-Wl,-rpath,\\$ORIGIN\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
-            auto result = compilerLibrary.empty()
-                ? fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"),
+            cmd = compilerLibrary.empty()
+                ? fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"),
                                         linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, extra)
-                : fmt::format_to(cmd, FMT_STRING("\"{}\" {} \"{}\" -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"),
+                : fmt::format(FMT_STRING("\"{}\" {} \"{}\" -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"),
                                         linker, linkerParam, rpath, libraryName, objFilePath, runtimeLibrary, compilerLibrary, extra);
         #endif
-            *result = '\0';
-        return run_link_cmd(cmd, libraryName, "Library", context);
+        return run_link_cmd(cmd.c_str(), libraryName, "Library", context);
     }
 #else
     bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, const char * extraLinkerArgs, bool isShared, bool linkWholeLib, Context *context ) { return true; }

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -777,6 +777,27 @@ extern "C" {
         return fallback;
     }
 
+    // Host-toolchain JIT triple — when non-empty, daslib uses this instead of
+    // LLVMGetDefaultTargetTriple() to drive JIT codegen.
+    //
+    // The prebuilt LLVM.dll shipped via dasLLVM's FetchContent is built with
+    // MSVC clang-cl, so LLVMGetDefaultTargetTriple() always returns
+    // x86_64-pc-windows-msvc regardless of what host compiler built
+    // daslang.exe. On clang-mingw64 daslang.exe, MSVC-ABI .o files reference
+    // _fltused (msvcrt marker symbol) and other MSVC-CRT-isms that mingw's
+    // ld.lld + libc CRT cannot satisfy. Forcing x86_64-w64-windows-gnu makes
+    // LLVM emit a mingw-flavored .o with no MSVC marker symbols, links
+    // cleanly against libDaScriptDyn_runtime.dll.a, and the resulting DLL
+    // calls into the mingw daslang.exe via the same Win64 C ABI without
+    // CRT-mismatch hazards.
+    const char * host_jit_triple ( ) {
+    #if defined(_WIN32) && !defined(_MSC_VER)
+        return "x86_64-w64-windows-gnu";
+    #else
+        return "";
+    #endif
+    }
+
     static LinkerPaths get_real_lib_linker_paths(const char * dasLib, const char * customLinker, bool isShared, bool linkWholeLib) {
         LinkerPaths result;
         result.linker = customLinker != nullptr ? customLinker : "";
@@ -784,18 +805,45 @@ extern "C" {
 
         if (result.linker.empty() || result.runtimeLibrary.empty()) {
             #if defined(_WIN32) || defined(_WIN64)
-                if (result.linker.empty()) {
-                    result.linker = find_linker(nullptr, "clang-cl.exe", "clang-cl");
-                }
-                if (result.runtimeLibrary.empty()) {
-                    const auto path = get_prefix(getExecutableFileName());
-                    const auto winCfg = path.substr(path.find_last_of("\\/") + 1);
-                    const auto windowsConfig = (winCfg == "bin" ? "" : (winCfg + "/"));
-                    result.runtimeLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn_runtime.lib";
-                    if (linkWholeLib) {
-                        result.compilerLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
+                // Two distinct Windows toolchains share the _WIN32 macro:
+                //   MSVC (incl. clang-cl) → MSVC-style import libs (libFoo.lib),
+                //     linked via clang-cl.exe with -DLL / -link / -OUT: syntax.
+                //   mingw (clang-mingw / gcc-mingw) → mingw import libs
+                //     (libFoo.dll.a), linked via clang.exe with -shared / -o
+                //     syntax (Unix-like — clang.exe driver is identical to
+                //     posix clang). The split keeps daslang.exe built with one
+                //     toolchain talking to a JIT'd DLL built with the same one.
+                #if defined(_MSC_VER)
+                    if (result.linker.empty()) {
+                        result.linker = find_linker(nullptr, "clang-cl.exe", "clang-cl");
                     }
-                }
+                    if (result.runtimeLibrary.empty()) {
+                        const auto path = get_prefix(getExecutableFileName());
+                        const auto winCfg = path.substr(path.find_last_of("\\/") + 1);
+                        const auto windowsConfig = (winCfg == "bin" ? "" : (winCfg + "/"));
+                        result.runtimeLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn_runtime.lib";
+                        if (linkWholeLib) {
+                            result.compilerLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.lib";
+                        }
+                    }
+                #else
+                    // mingw — note bundled clang-cl.exe (from dasLLVM prebuilt
+                    // LLVM) is MSVC-flavored and cannot read .dll.a, so don't
+                    // probe for it; default to "clang" on PATH (clang64/bin
+                    // when daslang.exe was built with clang-mingw64).
+                    if (result.linker.empty()) {
+                        result.linker = "clang";
+                    }
+                    if (result.runtimeLibrary.empty()) {
+                        const auto path = get_prefix(getExecutableFileName());
+                        const auto winCfg = path.substr(path.find_last_of("\\/") + 1);
+                        const auto windowsConfig = (winCfg == "bin" ? "" : (winCfg + "/"));
+                        result.runtimeLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn_runtime.dll.a";
+                        if (linkWholeLib) {
+                            result.compilerLibrary = getDasRoot() + "/lib/" + windowsConfig + "libDaScriptDyn.dll.a";
+                        }
+                    }
+                #endif
             #else
                 if (result.linker.empty()) {
                     result.linker = "c++";
@@ -818,7 +866,7 @@ extern "C" {
         return result;
     }
 
-#if (defined(_MSC_VER) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
+#if (defined(_WIN32) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
     // Run a fully-formed linker command via popen, capture combined stdout/
     // stderr into a 16KB buffer, then log success or a failure diagnostic
     // (with the captured output) through the daslang Context.
@@ -880,10 +928,34 @@ extern "C" {
 
 
         #if defined(_WIN32) || defined(_WIN64)
-            const auto linkerParam = isShared ? "-DLL" : "";
-            auto result = compilerLibrary.empty()
-                ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, extra, linkerParam, libraryName)
-                : fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, extra, linkerParam, libraryName);
+            #if defined(_MSC_VER)
+                // MSVC clang-cl: -DLL marks shared, -link separates link-only
+                // flags, -OUT: names the output, msvcrt.lib pulls the import
+                // CRT. Outer doubled quotes wrap the whole command for cmd.exe
+                // because the linker path itself contains spaces on Program
+                // Files installs.
+                const auto linkerParam = isShared ? "-DLL" : "";
+                auto result = compilerLibrary.empty()
+                    ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, extra, linkerParam, libraryName)
+                    : fmt::format_to(cmd, FMT_STRING("\"\"{}\" \"{}\" \"{}\" \"{}\" msvcrt.lib {} -link {} -OUT:\"{}\" 2>&1\""), linker, objFilePath, runtimeLibrary, compilerLibrary, extra, linkerParam, libraryName);
+            #else
+                // mingw clang/gcc: Unix-flavored driver, -shared/-o syntax.
+                // No rpath on Windows (DLLs resolve via PATH / LoadLibrary
+                // search order), so the linux branch's rpath escape is
+                // dropped. linkWholeLib gets -Wl,--no-as-needed so the
+                // compiler-library symbols are forced into the JIT'd DLL
+                // even when no JIT'd code references them directly.
+                // Outer doubled quotes `\"...2>&1\"` wrap the whole command
+                // — popen → cmd.exe strips one quote pair, leaving the
+                // inner per-arg quotes intact. Without this wrap cmd.exe
+                // misparses the very first quoted token as the command name.
+                const auto linkerParam = isShared ? "-shared" : "";
+                auto result = compilerLibrary.empty()
+                    ? fmt::format_to(cmd, FMT_STRING("\"\"{}\" {} -o \"{}\" \"{}\" \"{}\" {} 2>&1\""),
+                                            linker, linkerParam, libraryName, objFilePath, runtimeLibrary, extra)
+                    : fmt::format_to(cmd, FMT_STRING("\"\"{}\" {} -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1\""),
+                                            linker, linkerParam, libraryName, objFilePath, runtimeLibrary, compilerLibrary, extra);
+            #endif
         #elif defined(__APPLE__)
             const auto linkerParam = isShared ? "-shared " : "";
             // @executable_path first → relocated bundle finds dylibs next to the exe;
@@ -915,7 +987,7 @@ extern "C" {
     bool create_shared_library ( const char * objFilePath, const char * libraryName, [[maybe_unused]] const char * dasLib, const char * customLinker, const char * extraLinkerArgs, bool isShared, bool linkWholeLib, Context *context ) { return true; }
 #endif
 
-#if (defined(_MSC_VER) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
+#if (defined(_WIN32) || defined(__linux__) || defined(__APPLE__)) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
     // Cross-compile-link a wasm32 object into a standalone .wasm via emcc.
     //   runtimeLibPath — path to libDaScript_runtime.a (wasm32). Optional:
     //     present  → link runtime symbols (das_*, malloc, memcpy, …) in.
@@ -1108,6 +1180,8 @@ extern "C" {
             addExtern<DAS_BIND_FUN(create_shared_library)>(*this, lib,  "create_shared_library",
                 SideEffects::worstDefault, "create_shared_library")
                     ->args({"objFilePath","libraryName","dasLib","customLinker","extraLinkerArgs","isShared","linkWholeLib","context"});
+            addExtern<DAS_BIND_FUN(host_jit_triple)>(*this, lib, "host_jit_triple",
+                SideEffects::none, "host_jit_triple");
             addExtern<DAS_BIND_FUN(link_wasm)>(*this, lib,  "link_wasm",
                 SideEffects::worstDefault, "link_wasm")
                     ->args({"objFilePath","wasmPath","runtimeLibPath","customEmcc","context"});

--- a/src/hal/debug_break.cpp
+++ b/src/hal/debug_break.cpp
@@ -7,7 +7,10 @@
 
 DAS_API void os_debug_break()
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
+    // __debugbreak is a clang/MSVC intrinsic that compiles on all Windows
+    // toolchains (MSVC, clang-cl, clang-mingw, gcc-mingw — gcc-mingw provides
+    // it via its <intrin.h>).
     __debugbreak();
 #else
     raise(SIGTRAP);

--- a/src/hal/debug_break.cpp
+++ b/src/hal/debug_break.cpp
@@ -5,13 +5,26 @@
 
 #include <signal.h>
 
+#if defined(_WIN32) && !defined(_MSC_VER)
+// gcc-mingw doesn't expose __debugbreak as a builtin (you'd need <intrin.h>
+// and the right configuration), and clang-mingw's behavior varies by version.
+// kernel32!DebugBreak is the portable Windows API that always works, at the
+// cost of one extra call frame — negligible vs the win of mingw-safe builds.
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 DAS_API void os_debug_break()
 {
-#ifdef _WIN32
-    // __debugbreak is a clang/MSVC intrinsic that compiles on all Windows
-    // toolchains (MSVC, clang-cl, clang-mingw, gcc-mingw — gcc-mingw provides
-    // it via its <intrin.h>).
+#if defined(_MSC_VER)
+    // MSVC (incl. clang-cl) — single-instruction intrinsic, no extra frame.
     __debugbreak();
+#elif defined(_WIN32)
+    // mingw — WinAPI works regardless of which Windows clang/gcc flavor.
+    DebugBreak();
 #else
     raise(SIGTRAP);
 #endif

--- a/src/hal/performance_time.cpp
+++ b/src/hal/performance_time.cpp
@@ -25,7 +25,8 @@ namespace das {
 // Prefer `get_time_usec(start)` / `get_time_nsec(start)` for elapsed-time
 // comparisons — those wrap the subtraction and continue to work portably.
 
-#ifdef _MSC_VER
+#ifdef _WIN32
+// QueryPerformanceCounter is the right Windows clock on any toolchain.
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/src/hal/project_specific_crash_handler.cpp
+++ b/src/hal/project_specific_crash_handler.cpp
@@ -35,7 +35,8 @@ static bool das_crash_frame_filter(const char * symbolName) {
 
 // ---- Platform-specific safe memory reads --------------------------------
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
+// MSVC + clang-cl: SEH __try/__except (clang-cl defines _MSC_VER so it lands here).
 
 static uint32_t safe_read_u32(uint64_t addr) {
     uint32_t result = 0;
@@ -55,6 +56,37 @@ static void * safe_read_ptr(uint64_t addr) {
         result = nullptr;
     }
     return result;
+}
+
+#elif defined(_WIN32)
+// clang-mingw / gcc-mingw: SEH __try/__except is not enabled by default.
+// VirtualQuery probes the page-protection state cheaply and never faults,
+// so it gives us the same safety guarantee without needing SEH.
+
+static bool is_addr_readable(uint64_t addr, size_t size) {
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery((LPCVOID)(uintptr_t)addr, &mbi, sizeof(mbi)) == 0) return false;
+    if (mbi.State != MEM_COMMIT) return false;
+    // We only need byte-level readability; the page-spanning case is rare for
+    // 4/8-byte reads and a single VirtualQuery covers the start page.
+    (void)size;
+    const DWORD protect = mbi.Protect & 0xFF;
+    return protect == PAGE_READONLY
+        || protect == PAGE_READWRITE
+        || protect == PAGE_EXECUTE_READ
+        || protect == PAGE_EXECUTE_READWRITE
+        || protect == PAGE_WRITECOPY
+        || protect == PAGE_EXECUTE_WRITECOPY;
+}
+
+static uint32_t safe_read_u32(uint64_t addr) {
+    if (!is_addr_readable(addr, sizeof(uint32_t))) return 0;
+    return *(uint32_t *)(uintptr_t)addr;
+}
+
+static void * safe_read_ptr(uint64_t addr) {
+    if (!is_addr_readable(addr, sizeof(void *))) return nullptr;
+    return *(void **)(uintptr_t)addr;
 }
 
 #elif defined(__linux__) && !defined(__EMSCRIPTEN__)

--- a/src/hal/project_specific_crash_handler.cpp
+++ b/src/hal/project_specific_crash_handler.cpp
@@ -63,20 +63,45 @@ static void * safe_read_ptr(uint64_t addr) {
 // VirtualQuery probes the page-protection state cheaply and never faults,
 // so it gives us the same safety guarantee without needing SEH.
 
+// Check a single MEMORY_BASIC_INFORMATION region for readability. Rejects
+// PAGE_GUARD / PAGE_NOACCESS / PAGE_TARGETS_INVALID — accessing those raises
+// EXCEPTION_GUARD_PAGE / EXCEPTION_ACCESS_VIOLATION which would defeat the
+// whole point of the safe-read fallback. The protection-flag mask is
+// 0xFFFF (not 0xFF) because PAGE_GUARD / PAGE_NOCACHE / PAGE_WRITECOMBINE
+// live in the top byte of the DWORD and a too-narrow mask would silently
+// strip them.
+static bool is_region_readable(const MEMORY_BASIC_INFORMATION & mbi) {
+    if (mbi.State != MEM_COMMIT) return false;
+    if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
+    const DWORD prot = mbi.Protect & 0xFF;
+    return prot == PAGE_READONLY
+        || prot == PAGE_READWRITE
+        || prot == PAGE_EXECUTE_READ
+        || prot == PAGE_EXECUTE_READWRITE
+        || prot == PAGE_WRITECOPY
+        || prot == PAGE_EXECUTE_WRITECOPY;
+}
+
+// Validate that [addr, addr+size) is fully covered by readable committed
+// memory. A 4- or 8-byte read can straddle a page boundary (rare but real,
+// e.g. unaligned reads near end-of-region), so when the first VirtualQuery's
+// region ends inside [addr, addr+size) we requery for the second region and
+// require it to also be readable. Without the second query a read could
+// reach into the next page which may be unmapped / PAGE_GUARD / PAGE_NOACCESS
+// and fault — exactly what this function exists to prevent.
 static bool is_addr_readable(uint64_t addr, size_t size) {
+    if (size == 0) return true;
     MEMORY_BASIC_INFORMATION mbi;
     if (VirtualQuery((LPCVOID)(uintptr_t)addr, &mbi, sizeof(mbi)) == 0) return false;
-    if (mbi.State != MEM_COMMIT) return false;
-    // We only need byte-level readability; the page-spanning case is rare for
-    // 4/8-byte reads and a single VirtualQuery covers the start page.
-    (void)size;
-    const DWORD protect = mbi.Protect & 0xFF;
-    return protect == PAGE_READONLY
-        || protect == PAGE_READWRITE
-        || protect == PAGE_EXECUTE_READ
-        || protect == PAGE_EXECUTE_READWRITE
-        || protect == PAGE_WRITECOPY
-        || protect == PAGE_EXECUTE_WRITECOPY;
+    if (!is_region_readable(mbi)) return false;
+    const uintptr_t region_end = (uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+    const uintptr_t read_end = (uintptr_t)addr + size;
+    if (read_end <= region_end) return true;
+    // Read spans a region boundary — check the next region too.
+    MEMORY_BASIC_INFORMATION mbi2;
+    if (VirtualQuery((LPCVOID)region_end, &mbi2, sizeof(mbi2)) == 0) return false;
+    if (!is_region_readable(mbi2)) return false;
+    return read_end <= (uintptr_t)mbi2.BaseAddress + mbi2.RegionSize;
 }
 
 static uint32_t safe_read_u32(uint64_t addr) {

--- a/src/misc/sysos.cpp
+++ b/src/misc/sysos.cpp
@@ -2,7 +2,11 @@
 
 #include "daScript/misc/sysos.h"
 
-#if defined(_MSC_VER) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
+#if defined(_WIN32) && !defined(_GAMING_XBOX) && !defined(_DURANGO)
+// All Windows toolchains use the same <windows.h> Win32 API for executable
+// path, dynamic loader, and hardware breakpoints. The old _MSC_VER gate sent
+// clang-mingw / gcc-mingw to the platform-fallback branch, which fatally
+// throws on getExecutablePathName().
     #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     namespace das {


### PR DESCRIPTION
## Summary

End-to-end clang-mingw64 (MSYS2 CLANG64, Clang 22.1.4 + lld + libc++, x86_64-w64-windows-gnu target) support for daslang. After this branch, on a clean MSYS2 clang64 sysroot:

- `daslang.exe` builds + runs (Ninja, Release).
- 7 modules build + load: `PUGIXML`, `SQLITE`, `StbImage`, `Audio`, `GLFW`, `StdDlg`, `HV` (libhv + system OpenSSL).
- `dasLLVM` binding API works (LLVM IR → JIT → run via the prebuilt LLVM.dll fetched in dasLLVM's CMakeLists).
- `daslang -jit` (daslang → LLVM IR → native DLL → call back into the host) works.

Two compile-time toolchains share the `_WIN32` macro — MSVC (incl. clang-cl) and mingw (clang-mingw / gcc-mingw) — so most of the patch is splitting Windows code into the right branch. The MSVC and POSIX paths are structurally unchanged; previously-stubbed mingw branches are filled in.

### Commits (7, on top of `origin/master`)

| Commit | Scope |
|---|---|
| `Support clang-mingw64 toolchain on Windows` | Core: `_MSC_VER` → `_WIN32` widening for `_aligned_malloc` family, `__debugbreak`, `QueryPerformanceCounter`, popen/_pclose paths in `module_builtin_fio.cpp`, fio header tripartite split, dllexport gate fix (PE 16-bit ordinal overflow 108277 → 65535), `DAS_API` → `DAS_CC_API` for `register_builtin_modules`, mingw SEH-free safe_read fallback, `target_link_libraries(... dbghelp ws2_32 mswsock advapi32 rpcrt4)`. |
| `dasGlfw: support clang-mingw64 build` | mingw GLFW import-lib names (`libglfw3.a` + `libglfw3dll.a`), Win32 native-handle branch widened to `_WIN32`, missing `DAS_glfwGetNativeDisplay` stub. |
| `dasHV: support clang-mingw64 build` | Split MSVC (perl + nmake OpenSSL-from-sources) vs ELSE (system OpenSSL via clang64 sysroot autodetect from `${CMAKE_C_COMPILER}`), `libhv_static.a` on mingw + `winmm` for timeSetEvent. |
| `mingw: drop double-lib prefix + place glfw3.dll where daslang.exe lives` | New `STRIP_DOUBLE_LIB_PREFIX_ON_MINGW` macro; CONFIGURATION_TYPES-aware POST_BUILD dest for glfw3.dll. |
| `mingw: ignore build-mingw/ and _smoke* scratch files` | gitignore. |
| `jit: support daslang -jit on clang-mingw64` | The big one — see below. |
| `dasLLVM: drop dead LLVM_ENABLE_DIAGNOSTIC branch` | 3-year-old wip residue calling an undefined `set_context_diagnostics_to_log`. Surfaced by lint on this PR (no recent PR has touched this file). 4-line deletion, no behavior change (flag was always false). |

### JIT enablement (the commit that took the most thinking)

`src/builtin/module_jit.cpp` previously gated `create_shared_library` and `link_wasm` behind `_MSC_VER || __linux__ || __APPLE__` — clang-mingw fell into the `else` branch where both stubbed `return true;` without linking. Daslib's `write_dll` panic-asserted the missing functions and `daslang -jit` was effectively off.

Three changes unblock it:

1. Gate widened to `_WIN32 || __linux__ || __APPLE__`. Game consoles (xbox / durango) keep the stub-return-true.
2. Inside Windows, split MSVC from mingw in both `get_real_lib_linker_paths` and the cmd construction:
   - MSVC keeps the existing path — `clang-cl.exe` with `-DLL`/-link/`-OUT:`/msvcrt.lib syntax, `.lib` import libs.
   - mingw uses `clang.exe` (Unix-driver `-shared`/`-o` syntax), `.dll.a` import libs, no msvcrt.lib reference, `-Wl,--no-as-needed` only for `linkWholeLib`. Outer `\"...2>&1\"` quote wrap mirrors MSVC — popen → cmd.exe strips one pair, inner per-arg quotes survive.
3. New `host_jit_triple()` C builtin returns `x86_64-w64-windows-gnu` on clang-mingw, empty elsewhere. daslib's `with_default_target_machine` prefers it when non-empty. Reason: the prebuilt `LLVM.dll` shipped via dasLLVM's FetchContent is built with MSVC clang-cl, so `LLVMGetDefaultTargetTriple()` returns `x86_64-pc-windows-msvc` regardless of what compiled daslang.exe. On mingw, that triple emits MSVC-ABI `.o` files referencing msvcrt marker symbols (`_fltused` etc.) that mingw's ld.lld + CRT can't satisfy. Forcing `x86_64-w64-windows-gnu` produces a mingw-flavored `.o` with no MSVC-ism residue.

## CI gating

This PR doesn't add a clang-mingw64 matrix entry — it just makes mingw possible. Existing CI matrices (Windows MSVC, Linux, macOS) cover all the platforms my changes touch:

- MSVC AOT/JIT path is structurally unchanged.
- Linux / macOS paths are unchanged.
- Mingw is the new code path, currently unexercised in CI — followup work to add a clang-mingw64 build job.

## Test plan

Run on E:\daslang under MSYS2 clang64 (Clang 22.1.4 + ld.lld + libc++ + system OpenSSL):

- [x] `bin/Release/daslang.exe utils/lint/main.das -- modules/dasLLVM/daslib/llvm_jit_common.das --quiet` → 0 issues, 0 errors (the only changed `.das` file).
- [x] `mcp__daslang__format_file` on `llvm_jit_common.das` → `already_formatted`.
- [x] `daslang dastest/dastest.das -- --test tests/` (interpreter): **9276/9276 passed**, 6 skipped (FluidR3_GM.sf2 not in checkout).
- [x] JIT smoke per `skills/make_pr.md`: `daslang -jit tests/jit_tests/array.das` + `tests/decs/test_bulk_create.das` → no verifier errors, exit 0.
- [x] `daslang -jit dastest --test tests/jit` → 19/19 passed. `--test tests/algorithm` → 162/162 passed. DLL cache hit path verified (second run skips codegen).
- [x] All 3 `modules/dasLLVM/examples/*jit*.das` run with `-jit` → exit 0.
- [ ] Full `dastest -jit tests/` exposes one slow test that hits the 120s per-test timeout on mingw (clang.exe + ld.lld per-link overhead). Isolated re-runs of every directory pass clean — looks like per-test link timing on mingw, not correctness. CI's JIT pass runs on Linux (uses `c++`), my changes don't affect that path.
- [ ] AOT (`test_aot.exe`): not built locally — current `build-mingw/` has `DAS_TESTS_DISABLED=ON + DAS_AOT_EXAMPLES_DISABLED=ON`, and the AOT codegen pipeline has never run end-to-end on clang-mingw64 (would surface incidental issues unrelated to this PR). `module_jit.cpp` changes don't touch AOT codegen — MSVC AOT path is structurally unchanged.

## Known gaps / followups

1. **dasClangBind on clang-mingw64**: blocked by binding regen — checked-in `.inc` files were generated against Clang 16 (CI uses apt.llvm.org's `llvm-16-dev`), don't compile against Clang 22.x. `find_package(Clang 16.0.6)` strict version match also rejects clang64's Clang 22.1.4. Disabled on mingw via `-DDAS_CLANG_BIND_DISABLED=ON`; tracked separately.
2. **CI matrix entry for clang-mingw64**: not added in this PR. Recommend a single Windows job mirroring the existing MSVC one but with clang64 sysroot.
3. **dasLLVM v22.1.5 vs clang64 v22.1.4 micro-skew**: dasLLVM CMakeLists tries `find_package(LLVM 22.1.5)`, falls through to FetchContent prebuilt (which works fine). Could optionally widen to `find_package(LLVM 22 EXACT)` but unimportant since the FetchContent path is the canonical one anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)