### PR TITLE
ci: add Windows clang-mingw64 worker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,7 +518,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
-          -DDAS_CLANGBIND_DISABLED=ON
+          -DDAS_CLANG_BIND_DISABLED=ON
         cmake --build ./build-mingw --parallel
 
     - name: "Test: interpreter sweep"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,3 +471,79 @@ jobs:
     - name: "Smoke-test installed bundle"
       run: bash ci/smoke_test_bundle.sh ./daslang_bundle
 
+  ###########################################################
+  build_windows_mingw:
+  ###########################################################
+  # Catches clang-mingw64 toolchain regressions at PR time. The mingw path
+  # diverges from MSVC in src/hal/debug_break.cpp, src/hal/project_specific_crash_handler.cpp,
+  # and src/builtin/module_jit.cpp (PR #2838). Without this job, a Windows-touching
+  # change that compiles under MSVC but breaks mingw would only surface when a
+  # maintainer rebuilds locally. Same runner pool as the MSVC matrix
+  # (windows-latest-fat), separate top-level job so mingw churn doesn't risk
+  # the much-larger MSVC entries.
+  #
+  # dasClangBind stays disabled here — pinned to libclang 16.0.6 (find_package
+  # strict version), which the msys2 clang64 sysroot doesn't ship. Tracked
+  # separately as the bind_clangbind regen followup.
+  ###########################################################
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: windows-latest-fat
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - name: "Install MSYS2 + clang-mingw64 toolchain"
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANG64
+        update: true
+        cache: true
+        install: >-
+          mingw-w64-clang-x86_64-toolchain
+          mingw-w64-clang-x86_64-cmake
+          mingw-w64-clang-x86_64-ninja
+          mingw-w64-clang-x86_64-openssl
+          mingw-w64-clang-x86_64-glfw
+          bison
+
+    - name: "Build: Daslang (clang-mingw64)"
+      run: |
+        set -eux
+        mkdir -p build-mingw
+        cmake --no-warn-unused-cli -B./build-mingw -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DDAS_CLANGBIND_DISABLED=ON
+        cmake --build ./build-mingw --parallel
+
+    - name: "Test: interpreter sweep"
+      run: |
+        set -eux
+        cd bin
+        ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test ../tests \
+          || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+
+    - name: "Test: JIT sweep"
+      run: |
+        set -eux
+        cd bin
+        ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --timeout 900 --test ../tests \
+          || ./daslang _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test ../tests
+
+    - name: "Small C++ Tests"
+      run: |
+        set -eux
+        cd build-mingw
+        ctest -L small --output-on-failure
+
+    - name: "Slow Release Tests (AOT)"
+      run: |
+        set -eux
+        cd bin
+        ./test_aot -use-aot _dasroot_/dastest/dastest.das -- --use-aot --color --failures-only --timeout 900 --test ../tests
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,7 +518,8 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
-          -DDAS_CLANG_BIND_DISABLED=ON
+          -DDAS_CLANG_BIND_DISABLED=ON \
+          -DDAS_LLVM_DISABLED=OFF
         cmake --build ./build-mingw --parallel
 
     - name: "Test: interpreter sweep"

--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -129,6 +129,21 @@ MACRO(SETUP_COMPILER)
         ADD_COMPILE_OPTIONS(-Wno-strict-aliasing) # disable warnings
         ADD_COMPILE_OPTIONS(-fno-strict-aliasing) # disable strict aliasing optimizations
     ENDIF()
+    # Treat signed integer overflow as two's-complement wrap.
+    # daslang signed arithmetic is defined to wrap. AOT lowers it to plain C++
+    # `int * int` / `int + int`, which is UB at the C++ level and modern
+    # clangs (AppleClang 21+, mingw clang 22+, presumably newer linux clangs)
+    # exploit it (e.g. the LCG step in daslib/random.das becomes miscompiled,
+    # producing values that violate the trailing `& 0x7FFF` mask). -fwrapv
+    # makes the C++ output faithfully match daslang's semantics across every
+    # gcc / clang-driver build (excluding clang-cl, which uses MSVC-style
+    # flags and doesn't expose this option; MSVC defaults to wrap anyway).
+    IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
+       ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+        NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") OR
+       "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        ADD_COMPILE_OPTIONS(-fwrapv)
+    ENDIF()
     IF(EMSCRIPTEN)
         ADD_COMPILE_OPTIONS(-Wno-ignored-attributes)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
@@ -138,12 +153,9 @@ MACRO(SETUP_COMPILER)
 	ELSEIF(APPLE)
 		ADD_DEFINITIONS(-DITS_PLATFORM_APPLE=1)
 		ADD_DEFINITIONS(-Wall -Wextra -pedantic)
-		# Treat signed integer overflow as two's-complement wrap.
-		# daslang signed arithmetic is defined to wrap. AOT lowers it to plain C++
-		# `int * int` / `int + int`, which is UB at the C++ level and AppleClang 21+
-		# exploits it (e.g. the LCG step in daslib/random.das becomes miscompiled).
-		# -fwrapv makes the C++ output faithfully match daslang's semantics.
-		ADD_COMPILE_OPTIONS(-fwrapv)
+		# -fwrapv now applied unconditionally to every gcc/clang build at the
+		# top of SETUP_COMPILER (was Apple-only originally; mingw clang 22+
+		# hits the same UB-exploit, see comment above the unified gate).
 		# UNCOMMENT FOR ASAN
 		# ADD_DEFINITIONS("-fsanitize=thread")
 		# SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -145,6 +145,38 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 	SETUP_HV(libDasModuleHV)
 	SETUP_HV(dasModuleHV)
 
+	IF(WIN32 AND NOT MSVC)
+		# mingw: land libssl-*.dll + libcrypto-*.dll NEXT TO daslang.exe so
+		# dasModuleHV.shared_module can resolve its openssl deps at dlopen
+		# time. MSVC has its own openssl build path (no-shared above), so it
+		# doesn't need this. Without these copies, build-time AOT codegen
+		# fails silently because register_dynamic_module's default overload
+		# (register_dynamic_module_silent) suppresses the LoadLibrary error
+		# and `require dashv` then surfaces as 20605 missing-prerequisite.
+		# Glob picks up the version suffix (libssl-3-x64.dll today, future
+		# major bumps without CMake churn).
+		FILE(GLOB _DAS_HV_OPENSSL_DLLS
+			"${OPENSSL_ROOT_DIR}/bin/libssl-*.dll"
+			"${OPENSSL_ROOT_DIR}/bin/libcrypto-*.dll")
+		IF(_DAS_HV_OPENSSL_DLLS)
+			# Mirror dasGlfw's multi-config / single-config split — Ninja
+			# (mingw default) is single-config; left in for symmetry with
+			# the glfw rule and any future generator switch.
+			IF(CMAKE_CONFIGURATION_TYPES)
+				SET(_DAS_HV_COPY_DIR "${EXECUTABLE_OUTPUT_PATH}/$<CONFIG>")
+			ELSE()
+				SET(_DAS_HV_COPY_DIR "${EXECUTABLE_OUTPUT_PATH}")
+			ENDIF()
+			ADD_CUSTOM_COMMAND(TARGET dasModuleHV POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different
+					${_DAS_HV_OPENSSL_DLLS}
+					"${_DAS_HV_COPY_DIR}/"
+			)
+		ELSE()
+			MESSAGE(WARNING "dasHV mingw: no libssl/libcrypto DLLs found under ${OPENSSL_ROOT_DIR}/bin — dasModuleHV.shared_module may fail to load at runtime")
+		ENDIF()
+	ENDIF()
+
 	ADD_MODULE_DAS(dashv dashv dashv_boost)
 
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/modules/dasHV/dashv

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -963,9 +963,15 @@ extern "C" {
                 // mingw clang/gcc: Unix-flavored driver, -shared/-o syntax.
                 // No rpath on Windows (DLLs resolve via PATH / LoadLibrary
                 // search order), so the linux branch's rpath escape is
-                // dropped. linkWholeLib gets -Wl,--no-as-needed so the
-                // compiler-library symbols are forced into the JIT'd DLL
-                // even when no JIT'd code references them directly.
+                // dropped. The linux branch's -Wl,--no-as-needed is also
+                // dropped: on ELF, --no-as-needed forces a DT_NEEDED entry
+                // for libraries that the linker would otherwise mark as
+                // not-required (lazy bind). PE/COFF has no such concept —
+                // listed libraries are always recorded in the import table,
+                // so the flag has no effect. Worse, lld on newer mingw
+                // sysroots rejects --no-as-needed as an unknown argument
+                // (older clangs / GNU ld silently ignore it, which is why
+                // this only surfaces on fresh CI installs).
                 // Outer doubled quotes `\"...2>&1\"` wrap the whole command
                 // — popen → cmd.exe strips one quote pair, leaving the
                 // inner per-arg quotes intact. Without this wrap cmd.exe
@@ -974,7 +980,7 @@ extern "C" {
                 cmd = compilerLibrary.empty()
                     ? fmt::format(FMT_STRING("\"\"{}\" {} -o \"{}\" \"{}\" \"{}\" {} 2>&1\""),
                                             linker, linkerParam, libraryName, objFilePath, runtimeLibrary, extra)
-                    : fmt::format(FMT_STRING("\"\"{}\" {} -Wl,--no-as-needed -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1\""),
+                    : fmt::format(FMT_STRING("\"\"{}\" {} -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1\""),
                                             linker, linkerParam, libraryName, objFilePath, runtimeLibrary, compilerLibrary, extra);
             #endif
         #elif defined(__APPLE__)

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -566,7 +566,18 @@ namespace das
         else if ( isnan(val) ) return "NAN";
         else {
             char buf[256];
-            auto result = fmt::format_to(buf, FMT_STRING("{:e}f"), val);
+            // {:e} defaults to %e semantics (6 digits after decimal = 7 sig figs
+            // total), which is below FLT_DECIMAL_DIG=9 — the minimum precision
+            // C++ guarantees for an exact float→text→float roundtrip. Without
+            // 9 sig figs the AOT-emitted literal can parse back to a float that
+            // differs from the value the interpreter/JIT computes at runtime,
+            // shifting boundary cases by 1 ULP. Surfaced as a tests/language/
+            // random_numbers.das failure on the mingw AOT worker: emitting
+            // 1.0f/32767.0f as "3.051851e-05f" reparses slightly high, so
+            // 32767.0f * F rounds to exactly 1.0f and the test's f < 1.0
+            // assertion flips. {:.8e} gives 9 sig figs, matching to_cpp_double's
+            // {:.17e} (= DBL_DECIMAL_DIG=17).
+            auto result = fmt::format_to(buf, FMT_STRING("{:.8e}f"), val);
             *result = 0;
             return buf;
         }


### PR DESCRIPTION
## Summary

Follow-up to #2838 (clang-mingw64 toolchain enablement). Adds a dedicated Windows mingw CI worker on top of the existing MSVC matrix, then fixes the four real bugs the new worker surfaced. The CI scope is the same one MSVC runs: build, interp sweep, JIT sweep, ctest, AOT.

## What's in here

**CI worker (`d108d2b3e`, `0d9c31c08`):**
- New `build_windows_mingw` job in `.github/workflows/build.yml`, sharing `windows-latest-fat` runner pool with the MSVC matrix as a separate top-level job. `msys2/setup-msys2` clang64 with cached install. Mirrors MSVC's test step sequence.
- Explicit `-DDAS_LLVM_DISABLED=OFF` so the JIT sweep can find LLVM.dll (the option defaults to ON; MSVC matrix entries pass it explicitly via env, the new worker now does the same). Plus flag-name fix (`DAS_CLANGBIND_DISABLED` → `DAS_CLANG_BIND_DISABLED`).

**Real bug fixes surfaced by the new worker:**

1. **`2f4016a5b` — dasHV: POST_BUILD copy libssl/libcrypto next to daslang.exe.** `dasModuleHV.shared_module` on mingw dlopens libssl-3-x64.dll + libcrypto-3-x64.dll. Ninja → cmd.exe doesn't reliably inherit msys2/clang64/bin on `%PATH%`, so LoadLibrary fails — and `register_dynamic_module`'s 2-arg overload swallows the error, surfacing as misleading `error[20605] missing prerequisite 'dashv'`. Mirrors the glfw3.dll POST_BUILD pattern from #2838.

2. **`b0329fca3` — module_jit.cpp: drop `-Wl,--no-as-needed` from mingw branch.** The flag is ELF-only (lazy-bind hint); PE/COFF always records listed libs. ld.lld on newer mingw sysroots rejects it as unknown; older clangs / GNU ld silently ignored — which is why this only surfaced when a fresh msys2 install came online in CI.

3. **`41c770c6b` — AOT: emit float constants at FLT_DECIMAL_DIG=9 sig figs.** `to_cpp_float` was using `{:e}f` (defaults to 7 sig figs), below the IEEE 754 single roundtrip minimum. Standalone correctness fix surfaced during diagnosis (doesn't itself fix the random_numbers test, but worth landing).

4. **`38749b9b5` — Extend `-fwrapv` from Apple-only to every gcc/clang build.** **This is the LCG bug.** daslang signed int wraps; AOT emits bare C++ `int * int` (UB). Modern clangs exploit even when followed by bit-masks. The team already worked around AppleClang 21+ with an Apple-scoped `-fwrapv`; mingw clang 22.1.4 -O2 surfaces the identical pattern in `daslib/random.das`'s LCG, dropping the trailing `& 0x7FFF` reasoning and returning values up to 65535. Universal `-fwrapv` in CMakeCommon.txt's SETUP_COMPILER (excluding clang-cl which doesn't accept the flag and MSVC which defaults to wrap). Linux clang 18 doesn't trigger this yet — but will when Ubuntu's image upgrades.

## Test plan

- [x] First CI run shape — caught issues #1, #2, #3 above
- [x] Full local AOT sweep on E:/daslang with `DAS_TESTS_DISABLED=OFF` — 8620/8626 pass, 0 failures, 6 skipped (FluidR3_GM.sf2 not provisioned, expected)
- [x] Local `tests/language/random_numbers.das` reproduction with -fwrapv → 13/13 pass
- [x] Final CI run — 30/30 checks pass (all matrices, all sanitizers, wasm, extended_checks, bundle_smoke)

## Notes

- The new mingw worker is wired the same way as MSVC entries (push to master + every PR). Should be marked required in repo settings once merged.
- One followup worth doing in a separate PR: flip `.das_module` initializers from the silent `register_dynamic_module` overload to the noisy one with `RegisterOnError::Fail`. The silent default hid this exact class of bug; surfacing it loudly would have shortened debugging here from hours to minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)