### PR TITLE
linq_fold: port streaming-min / bounded-heap to plan_order_family

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1223,8 +1223,9 @@ def private make_inline_less_call(orderKey : Expression?; orderName : string;
     r1 |> replaceVariable(argName, lhsExpr)
     var r2 : Template
     r2 |> replaceVariable(argName, rhsExpr)
-    apply_template(r1, b1.at, b1)
-    apply_template(r2, b2.at, b2)
+    // apply_template returns the new root expression when the visitor replaces it (e.g. body == ExprVar(argName) → root substitution for identity keys like `_order_by(_)`). For non-root replacements (ExprField, etc.) the root pointer is unchanged. Always reassign.
+    b1 = apply_template(r1, b1.at, b1)
+    b2 = apply_template(r2, b2.at, b2)
     return qmacro(_::less($e(b2), $e(b1))) if (orderName == "order_by_descending")
     return qmacro(_::less($e(b1), $e(b2)))
 }
@@ -1295,6 +1296,103 @@ def private plan_order_family(var expr : Expression?) : Expression? {
         inlineCmp = try_make_inline_cmp(orderKey, orderName, orderElemType, at)
     }
     let minMaxName = order_min_call_name(orderName, hasKey)
+    // Streaming-min / bounded-heap fast paths (mirror of plan_decs_order_family). When the key is inline-able, skip the materialize-all + min_by/top_n* dispatch in favor of a per-walk state (single best for first[_or_default], heap of size N for take). For first[_or_default]: avoids the per-element `invoke(keyLambda, x)` cost in min_by_impl (~28 ns/op win on 100K-row sort_first). For take(N): avoids materializing the full filtered set before top_n_by (~7-9 ns/op win on sort_take / select_where_order_take).
+    let useBoundedHeap = takeExpr != null && inlineCmp != null && firstName == ""
+    let useStreamingMin = firstName != "" && inlineCmp != null
+    if (useStreamingMin) {
+        let bestName = qn("order_best", at)
+        let seenName = qn("order_seen", at)
+        let srcName = qn("source", at)
+        var srcParamType = invoke_src_param_type(top)
+        var topExpr = clone_expression(top)
+        topExpr.genFlags.alwaysSafe = true
+        var elemType = clone_type(orderElemType)
+        var lessTest = make_inline_less_call(orderKey, orderName,
+            qmacro($i(itName)), qmacro($i(bestName)), at)
+        var perElement : Expression? = qmacro_expr() {
+            if (!$i(seenName)) {
+                $i(bestName) := $i(itName)
+                $i(seenName) = true
+            } elif ($e(lessTest)) {
+                $i(bestName) := $i(itName)
+            }
+        }
+        if (whereCond != null) {
+            perElement = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $e(perElement)
+                }
+            }
+        }
+        var emission : Expression?
+        if (firstName == "first") {
+            emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : $t(elemType) {
+                var $i(bestName) = default<$t(elemType)>
+                var $i(seenName) = false
+                for ($i(itName) in $i(srcName)) {
+                    $e(perElement)
+                }
+                panic("sequence contains no elements") if (!$i(seenName))
+                return $i(bestName)
+            }, $e(topExpr)))
+        } else {
+            let dBindName = qn("order_d", at)
+            emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : $t(elemType) {
+                let $i(dBindName) = $e(firstDefaultExpr)
+                var $i(bestName) = default<$t(elemType)>
+                var $i(seenName) = false
+                for ($i(itName) in $i(srcName)) {
+                    $e(perElement)
+                }
+                return $i(bestName) if ($i(seenName))
+                return $i(dBindName)
+            }, $e(topExpr)))
+        }
+        return finalize_invoke(emission, at)
+    }
+    if (useBoundedHeap) {
+        let takeNName = qn("order_take_n", at)
+        let bhBufName = qn("order_buf", at)
+        let srcName = qn("source", at)
+        var srcParamType = invoke_src_param_type(top)
+        var topExpr = clone_expression(top)
+        topExpr.genFlags.alwaysSafe = true
+        var bufElemType = clone_type(orderElemType)
+        var lessTest = make_inline_less_call(orderKey, orderName,
+            qmacro($i(itName)), qmacro($i(bhBufName)[0]), at)
+        var perElement : Expression? = qmacro_expr() {
+            if (length($i(bhBufName)) < $i(takeNName)) {
+                $i(bhBufName) |> push_clone($i(itName))
+                _::spliced_push_heap($i(bhBufName), $e(inlineCmp))
+            } elif ($e(lessTest)) {
+                _::spliced_pop_heap($i(bhBufName), $e(inlineCmp))
+                $i(bhBufName)[length($i(bhBufName)) - 1] := $i(itName)
+                _::spliced_push_heap($i(bhBufName), $e(inlineCmp))
+            }
+        }
+        if (whereCond != null) {
+            perElement = qmacro_expr() {
+                if ($e(whereCond)) {
+                    $e(perElement)
+                }
+            }
+        }
+        // No `reserve(takeN)` on the bounded buf — matches the upstream top_n_by_with_cmp iterator-variant policy (linq.das:482-484). Caller may pass takeN >> actual source size, so pre-reserving N risks a large upfront allocation for no win.
+        var emission : Expression? = qmacro(invoke($($i(srcName) : $t(srcParamType)) : array<$t(bufElemType)> {
+            let $i(takeNName) = $e(takeExpr)
+            var $i(bhBufName) : array<$t(bufElemType)>
+            return <- $i(bhBufName) if ($i(takeNName) <= 0)
+            for ($i(itName) in $i(srcName)) {
+                $e(perElement)
+            }
+            _::order_inplace($i(bhBufName), $e(inlineCmp))
+            return <- $i(bhBufName)
+        }, $e(topExpr)))
+        if (needIterWrap) {
+            emission = qmacro($e(emission).to_sequence_move())
+        }
+        return finalize_invoke(emission, at)
+    }
     if (whereCond == null) {
         // No prefilter — direct call to daslib helper.
         var topExpr = clone_expression(top)

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -2061,9 +2061,9 @@ def target_where_order_by_take_splices_fold() : array<int> {
 
 [test]
 def test_order_by_take_emits_top_n_by_with_cmp(t : T?) {
-    // `order_by(key) |> take(K)` with an inlineable key body now splices to
-    // top_n_by_with_cmp(src, K, $(v1, v2) => _::less(body[v1], body[v2])) — the comparator
-    // block embeds the key body twice, eliminating the per-comparison key() dispatch.
+    // `order_by(key) |> take(K)` with an inlineable key now splices to the bounded-heap
+    // walk: `spliced_push_heap` fill+replace pair + a `_::less(it, buf[0])` replace-test on
+    // the heap top, `order_inplace(buf, cmp)` at the end. No top_n_by/top_n_by_with_cmp.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_take_splices_fold)
         if (func == null) return
@@ -2072,7 +2072,10 @@ def test_order_by_take_emits_top_n_by_with_cmp(t : T?) {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(count_call(body_expr, "top_n_by_with_cmp") >= 1, "should emit a top_n_by_with_cmp call")
+        t |> equal(count_call(body_expr, "spliced_push_heap"), 2, "bounded-heap fill + replace each call spliced_push_heap")
+        t |> equal(count_call(body_expr, "spliced_pop_heap"), 1, "bounded-heap replace pops first")
+        t |> success(count_call(body_expr, "order_inplace") >= 1, "final order_inplace on the bounded buf")
+        t |> equal(0, count_call(body_expr, "top_n_by_with_cmp"), "bounded-heap supersedes top_n_by_with_cmp")
         t |> equal(0, count_call(body_expr, "top_n_by"), "should not emit non-cmp top_n_by")
         t |> equal(0, count_call(body_expr, "order_by"), "should not emit order_by")
         t |> equal(0, count_call(body_expr, "take"), "should not emit take")
@@ -2081,9 +2084,9 @@ def test_order_by_take_emits_top_n_by_with_cmp(t : T?) {
 
 [test]
 def test_order_by_descending_take_emits_top_n_by_with_cmp(t : T?) {
-    // `order_by_descending(key) |> take(K)` with an inlineable key dispatches to the same
-    // top_n_by_with_cmp entry as ascending — direction is encoded by flipping the
-    // comparator argument order (`_::less(body[v2], body[v1])`), no `_descending` helper.
+    // `order_by_descending(key) |> take(K)` with an inlineable key hits the same bounded-heap
+    // entry as ascending — direction is encoded by flipping the inline less-test's operand
+    // order (`_::less(buf[0], it)`).
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(),
             @@target_order_by_descending_take_splices_fold)
@@ -2093,8 +2096,9 @@ def test_order_by_descending_take_emits_top_n_by_with_cmp(t : T?) {
             return <- $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(count_call(body_expr, "top_n_by_with_cmp") >= 1,
-            "should emit a top_n_by_with_cmp call (flipped comparator embeds direction)")
+        t |> equal(count_call(body_expr, "spliced_push_heap"), 2, "bounded-heap fill + replace each call spliced_push_heap (descending shares the same path)")
+        t |> equal(count_call(body_expr, "spliced_pop_heap"), 1, "bounded-heap replace pops first")
+        t |> equal(0, count_call(body_expr, "top_n_by_with_cmp"), "bounded-heap supersedes top_n_by_with_cmp")
         t |> equal(0, count_call(body_expr, "top_n_by_descending"),
             "should not emit the key-taking top_n_by_descending")
         t |> equal(0, count_call(body_expr, "order_by_descending"),
@@ -2141,8 +2145,9 @@ def test_where_order_by_emits_fused_loop_with_inline_cmp(t : T?) {
 
 [test]
 def test_where_order_by_take_emits_fused_top_n_with_cmp(t : T?) {
-    // `where |> order_by(key) |> take(K)` splices into a fused prefilter loop +
-    // top_n_by_with_cmp(buf, K, cmp) when the key is inlineable.
+    // `where |> order_by(key) |> take(K)` with an inlineable key splices into the bounded-heap
+    // walk wrapped in `if (whereCond)`. Single fused loop — no prefilter buffer, the heap IS
+    // the buffer, and at most K elements ever live in it.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(),
             @@target_where_order_by_take_splices_fold)
@@ -2152,10 +2157,13 @@ def test_where_order_by_take_emits_fused_top_n_with_cmp(t : T?) {
             return <- $e(body_expr)
         }
         t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper for fused emission")
-        t |> equal(1, count_inner_for_loops(body_expr), "single fused prefilter loop")
-        t |> success(count_call(body_expr, "top_n_by_with_cmp") >= 1, "should call top_n_by_with_cmp on the buffer")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused walk over source")
+        t |> equal(count_call(body_expr, "spliced_push_heap"), 2, "bounded-heap fill + replace each call spliced_push_heap")
+        t |> equal(count_call(body_expr, "spliced_pop_heap"), 1, "bounded-heap replace pops first")
+        t |> success(count_call(body_expr, "order_inplace") >= 1, "final order_inplace on the bounded buf")
+        t |> equal(0, count_call(body_expr, "top_n_by_with_cmp"), "bounded-heap supersedes top_n_by_with_cmp")
         t |> equal(0, count_call(body_expr, "top_n_by"), "should not emit non-cmp top_n_by")
-        t |> success(count_call(body_expr, "push_clone") >= 1, "should push_clone into the buffer")
+        t |> success(count_call(body_expr, "push_clone") >= 1, "should push_clone into the heap during fill")
     }
 }
 
@@ -3870,7 +3878,9 @@ def target_order_with_cmp_first_bails_to_tier2() : int {
 
 [test]
 def test_order_by_first_emits_min_by(t : T?) {
-    // order_by + first → min_by(top, key) directly. No sort, no take, no order_by/order helpers.
+    // order_by + first with an inlineable key now splices to the streaming-min walk —
+    // single `var order_best` + `var order_seen` state, per-element `_::less(it, order_best)`
+    // direct call. No min_by lambda dispatch, no full materialization.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_first_splices_min_by)
         if (func == null) return
@@ -3879,15 +3889,18 @@ def test_order_by_first_emits_min_by(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(count_call(body_expr, "min_by") >= 1, "should emit a min_by call")
+        t |> equal(0, count_call(body_expr, "min_by"), "streaming-min supersedes min_by")
         t |> equal(0, count_call(body_expr, "max_by"), "should NOT emit max_by (ascending)")
         t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
         t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+        t |> success(count_call(body_expr, "less") >= 1, "streaming-min uses inline less-test")
     }
 }
 
 [test]
 def test_order_by_descending_first_emits_max_by(t : T?) {
+    // Streaming-min handles descending by flipping the inline less-test operand order
+    // (`_::less(order_best, it)`); same shape as ascending.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_descending_first_splices_max_by)
         if (func == null) return
@@ -3896,17 +3909,18 @@ def test_order_by_descending_first_emits_max_by(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(count_call(body_expr, "max_by") >= 1, "should emit a max_by call")
+        t |> equal(0, count_call(body_expr, "max_by"), "streaming-min supersedes max_by")
         t |> equal(0, count_call(body_expr, "min_by"), "should NOT emit min_by (descending)")
         t |> equal(0, count_call(body_expr, "order_by_descending"), "should NOT emit order_by_descending")
         t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+        t |> success(count_call(body_expr, "less") >= 1, "streaming-min uses inline less-test (descending flips args)")
     }
 }
 
 [test]
 def test_where_order_by_first_emits_min_by_on_prefilter(t : T?) {
-    // where + order_by + first → fused prefilter loop + min_by on buf. Same shape as
-    // where + order_by + take, but min_by instead of top_n_by.
+    // where + order_by + first with an inlineable key splices to streaming-min with the
+    // per-element body wrapped in `if (whereCond)`. Single fused loop — no prefilter buffer.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_where_order_by_first_splices_min_by_on_buf)
         if (func == null) return
@@ -3915,16 +3929,18 @@ def test_where_order_by_first_emits_min_by_on_prefilter(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(count_call(body_expr, "min_by") >= 1, "should emit min_by on prefilter buf")
+        t |> equal(0, count_call(body_expr, "min_by"), "streaming-min supersedes min_by")
         t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
         t |> equal(0, count_call(body_expr, "first"), "should NOT emit first (splice absorbs)")
+        t |> equal(1, count_inner_for_loops(body_expr), "single fused walk over source (no prefilter buf)")
+        t |> success(count_call(body_expr, "less") >= 1, "streaming-min uses inline less-test")
     }
 }
 
 [test]
 def test_order_by_first_or_default_emits_top_n_by_first_or_default(t : T?) {
-    // order_by + first_or_default → top_n_by(top, 1, key) |> first_or_default(d) — empty
-    // array handles the default fallback; no min_by_or_default helper exists.
+    // order_by + first_or_default with inlineable key splices to streaming-min + return-default
+    // when !seen. No top_n_by(_, 1, _) materialization, no min_by_or_default helper.
     ast_gc_guard() {
         var func = find_module_function_via_rtti(compiling_module(), @@target_order_by_first_or_default_splices_top_n_by)
         if (func == null) return
@@ -3933,11 +3949,11 @@ def test_order_by_first_or_default_emits_top_n_by_first_or_default(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched, "should have return expression")
-        t |> success(count_call(body_expr, "top_n_by_with_cmp") + count_call(body_expr, "top_n_by") >= 1,
-            "should emit top_n_by (or top_n_by_with_cmp for inline key)")
-        t |> success(count_call(body_expr, "first_or_default") >= 1,
-            "should emit first_or_default on the 1-elem array")
+        t |> equal(0, count_call(body_expr, "top_n_by_with_cmp"), "streaming-min supersedes top_n_by_with_cmp")
+        t |> equal(0, count_call(body_expr, "top_n_by"), "streaming-min supersedes top_n_by")
+        t |> equal(0, count_call(body_expr, "first_or_default"), "streaming-min absorbs first_or_default")
         t |> equal(0, count_call(body_expr, "order_by"), "should NOT emit order_by")
+        t |> success(count_call(body_expr, "less") >= 1, "streaming-min uses inline less-test")
     }
 }
 


### PR DESCRIPTION
## Summary

Symmetric mirror of PR #2837's `plan_decs_order_family` fix, applied to the array-side splice. When the key is inline-able, `_order_by + first` splices to a per-walk streaming-min state instead of dispatching through `min_by(arr, keyLambda)` (which calls `key(x)` once per element). `_order_by + take(N)` splices to a bounded-heap walk instead of materializing into a prefilter buffer and then `top_n_by`-ing it.

### Streaming-min (firstName != "" && inlineCmp != null)
```das
invoke($(source : srcParamType) : elemType {
    var order_best = default<elemType>
    var order_seen = false
    for (it in source) {
        if (!order_seen) { order_best := it; order_seen = true }
        elif (LESS(it, order_best)) { order_best := it }
    }
    // panic-if-not-seen (first) OR return-default (first_or_default)
    return order_best
}, top)
```

### Bounded-heap (takeExpr != null && inlineCmp != null && firstName == "")
```das
invoke($(source : srcParamType) : array<elemType> {
    let n = takeExpr
    var order_buf : array<elemType>
    return <- order_buf if (n <= 0)
    for (it in source) {
        if (length(order_buf) < n) {
            order_buf |> push_clone(it)
            spliced_push_heap(order_buf, cmp)
        } elif (LESS(it, order_buf[0])) {
            spliced_pop_heap(order_buf, cmp)
            order_buf[len-1] := it
            spliced_push_heap(order_buf, cmp)
        }
    }
    order_inplace(order_buf, cmp)
    return <- order_buf
}, top)
```

Both branches handle `where_`/no-where uniformly via optional `if (whereCond)` wrap around perElement, like the decs equivalent.

## Latent bug fix in make_inline_less_call

PR #2837's `make_inline_less_call` had a latent bug: when the key body is `ExprVar` at the root (e.g. `_order_by(_)` — identity key, body == lambda arg), `apply_template`'s visitor substitutes via `visitExprVar`'s return value, but the helper ignored the return of `apply_template` — leaving the caller's `b1`/`b2` pointing at the un-substituted clone. The bug never surfaced in #2837 because every decs test had a field-access key (`_.price`), where substitution happens on the `ExprField`'s child, not the root.

Surfaced here when the array-side fix exposed it via the broad set of `_order_by(_)` tests in `test_linq_fold.das`. Fix: capture and reassign `b1 = apply_template(r1, b1.at, b1)`.

## Bench wins (100K rows, INTERP, m3f deltas)

| Lane | Pre | Post | Δ | Status |
|---|---:|---:|---:|---|
| `sort_first_m3f` | 41.1 | 11.0 | **−30.1** | was 27.8 SLOWER than m4 |
| `select_where_order_take_m3f` | 21.4 | 12.1 | **−9.3** | now BEATS m4 by 2.8 |
| `sort_take_m3f` | 22.4 | 15.9 | **−6.5** | now within 4.5 of m4 |
| `order_take_desc_m3f` | 22.4 | 16.0 | **−6.4** | now within 4.0 of m4 |

All four m3f order-family lanes were slower than m4 by 2-28 ns/op before this PR; now m3f and m4 are within ±5 ns/op across the board (m4 still slightly faster on take by the archetype/streaming-walk advantage, m3f slightly faster on first thanks to direct array indexing).

## Test plan

- [x] 1390/1390 linq + 245/245 decs + 782/782 dasSQLITE INTERP green
- [x] Same suites AOT green via `test_aot`
- [x] 1390/1390 linq JIT green
- [x] 7 AST shape tests updated: `top_n_by_with_cmp` / `min_by` / `max_by` → streaming-min (less-call) / bounded-heap (`spliced_push_heap` + `spliced_pop_heap` + `order_inplace`)
- [x] CI-style lint clean on both touched files
- [x] Full bench sweep (50 lanes): only the 4 target lanes moved meaningfully; rest within noise band

🤖 Generated with [Claude Code](https://claude.com/claude-code)