### PR TITLE
pages.yml: drop continue-on-error on WASM build step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,8 +76,11 @@ jobs:
     - name: Setup Emscripten
       uses: emscripten-core/setup-emsdk@v11
       with:
-        # Pinned: 5.0.7's clang crashes on utils/dasFormatter/ds_parser.cpp
-        # in diagnostic snippet rendering. 5.0.3 known-good.
+        # Every emsdk pin snapshots LLVM main (not a release tag). 5.0.3
+        # resolves to clang 23.0.0git from 2026-03-13 — recent enough that
+        # the preprocessor has intermittently bus-errored on the bison-
+        # generated utils/dasFormatter/ds_parser.cpp. If that recurs we'll
+        # downgrade the family (4.0.23 ≈ pre-LLVM-22.1.0 main snapshot).
         version: '5.0.3'
 
     - name: "Build WASM (Emscripten) for /playground/ + /files/wasm/"
@@ -89,7 +92,6 @@ jobs:
         # daslang_static.wasm playground + stage_site_playground (vendored UI
         # + js/wasm) + stage_site_playground_wasm (cross-compiled examples).
         ninja daslang_static stage_site_playground stage_site_playground_wasm
-      continue-on-error: true
 
     - name: "Fetch dasProfile per-platform benchmark JSONs"
       # dasProfile now ships a per-platform JSON file
@@ -136,12 +138,12 @@ jobs:
             --out _site/
 
         # Playground: vendor web/ui IDE + WASM artifacts.
-        # The WASM build step has continue-on-error so docs/blog still publish
-        # when emsdk hiccups. The cost of that resilience is partial state:
-        # web/output may exist without the daslang_static.{js,wasm} artifacts.
-        # Refuse to stage a half-built playground in that case — Pages preserves
-        # the previously-deployed /playground/, so the visible Run button keeps
-        # working instead of 404'ing its runtime.
+        # The WASM build step now fails the workflow (no continue-on-error),
+        # so under normal master deploys we always take the if-branch. The
+        # else-branch survives as defense-in-depth — if the artifacts ever
+        # go missing despite a green build, we stage a placeholder rather
+        # than 404'ing the route (actions/deploy-pages publishes _site as
+        # a complete snapshot, no layering over the prior deploy).
         if [ -f web/output/daslang_static.js ] && [ -f web/output/daslang_static.wasm ]; then
             mkdir -p _site/playground _site/files/wasm
             # Copy IDE source files (CodeMirror, jQuery, main.js/css, etc.)


### PR DESCRIPTION
## Summary

The pages.yml WASM build step has `continue-on-error: true`, which silently masks emscripten / clang failures: the step paints green, the staging step's file-exists guard skips the real `/playground/` copy, and we ship `site/playground/placeholder.html` (the "Runtime rebuild in progress." page). Master shows green; the live playground is the fallback.

Most recent example: pages run [26345453541](https://github.com/GaijinEntertainment/daScript/actions/runs/26345453541) (commit `1c8ff9119`, 2026-05-23 22:40) — `em++` bus-errored in `clang::Lexer::SkipBlockComment` while compiling `utils/dasFormatter/ds_parser.cpp:6484`. Four prior runs today on the same emsdk pin (`5.0.3`, resolved to LLVM commit `e5927fec` from 2026-03-13) built that file fine, so this looks like an intermittent preprocessor flake in `clang 23.0.0git` rather than a deterministic bug.

Goal: make the next flake fail the deploy red so it surfaces immediately, rather than running quietly with the placeholder for hours.

## Changes

- Drop `continue-on-error: true` from the "Build WASM (Emscripten)" step.
- Update the version-pin comment — the previous "5.0.7 crashes, 5.0.3 known-good" claim is provably wrong now (5.0.3 just crashed). New comment notes that every emsdk pin snapshots LLVM main (not a release tag), records the LLVM commit / date 5.0.3 resolves to, and points at the next-downgrade target (`4.0.23` ≈ pre-LLVM-22.1.0 main snapshot).
- Update the staging-step preamble that explicitly cited "WASM build step has continue-on-error" as the rationale for the placeholder else-branch. The branch survives as defense-in-depth — `actions/deploy-pages` publishes `_site` as a complete snapshot (no layering), so a future workflow change that re-introduces `continue-on-error` or artifacts going missing despite a green build would still 404 the route without it.

## Follow-up

The ds_parser.cpp clang crash itself is a separate dig — bison-generated 6500-line file with a comment near `:6484` that trips the clang-main preprocessor. Tracking that as a follow-up.

## Test plan

- [ ] PR's CI green
- [ ] Trigger pages.yml manually (or wait for next merge to master) and confirm WASM step succeeds end-to-end
- [ ] Confirm `https://daslang.io/playground/index.html` serves the real Forge-skinned IDE, not the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)