### PR TITLE
benchmarks/sql cleanup + linq_decs tutorial + linq-fold patterns reference

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -66,7 +66,7 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 |---|---|---|
 | `m1` (SQL) | `:memory:` SQLite | `_sql` macro — compile-time SQL emission, work pushed to the engine |
 | `m3f` (Array) | pre-populated `array<Car>` | `_fold` over `each(arr).chain()` — fuses the chain into a single pass |
-| `m4` (Decs) | decs entities via `[decs_template]` | `_fold` over `from_decs_template(type<Car>).chain()` — fuses into a per-archetype walk |
+| `m4` (Decs) | decs entities via `[decs_template]` | `_fold` over `from_decs_template(type<DecsCar>).chain()` — fuses into a per-archetype walk |
 
 The `m3` lane (eager linq, no `_fold` splice) was dropped on 2026-05-23; the splice ladder closed the gap between m3f and m4 across the corpus, and m3 was no longer a useful comparison point.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -60,18 +60,68 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 
 ## sql/
 
-3-mode comparison: `_sql` macro over `:memory:` SQLite vs pure in-memory `array<T>` LINQ, with the array form measured both in its naive (intermediate-materializing) and `_fold`-fused shapes. Mirrors the `tests/dasSQLITE/parity_check_*.das` pattern but oriented to throughput.
+3-lane comparison over the same `Car` schema: `_sql` macro over `:memory:` SQLite vs in-memory `array<Car>` linq splice vs decs (`[decs_template]`) linq splice. Each bench builds the same data three ways via `_common.das` fixtures and runs the same query expression through each lane. See `benchmarks/sql/results.md` for the current ns/op numbers across both INTERP and JIT.
 
-| Mode | Source | Form |
+| Lane | Source | Form |
 |---|---|---|
-| `m1` | `:memory:` SQLite | `_sql` — compile-time SQL emission, work pushed to the engine |
-| `m3` | pre-populated `array<Car>` | plain LINQ chain — materializes intermediate filter/sort arrays |
-| `m3f` | pre-populated `array<Car>` | `_fold` from `daslib/linq_boost` — fuses the chain into a single pass, in-place where possible |
+| `m1` (SQL) | `:memory:` SQLite | `_sql` macro — compile-time SQL emission, work pushed to the engine |
+| `m3f` (Array) | pre-populated `array<Car>` | `_fold` over `each(arr).chain()` — fuses the chain into a single pass |
+| `m4` (Decs) | decs entities via `[decs_template]` | `_fold` over `from_decs_template(type<Car>).chain()` — fuses into a per-archetype walk |
+
+The `m3` lane (eager linq, no `_fold` splice) was dropped on 2026-05-23; the splice ladder closed the gap between m3f and m4 across the corpus, and m3 was no longer a useful comparison point.
 
 | File | Description |
 |---|---|
-| `_common.das` | Shared `Car` `[sql_table]` + `fixture_db` / `fixture_array` (not a benchmark) |
-| `select_where.das` | Filter chain — `_where(_.price > 500)` over 10K rows. Modest asymmetry; m3 walks every row. |
-| `select_where_order_take.das` | Filter + sort + limit — `_where \|> _order_by(_.price) \|> take(10)`. SQL ORDER BY + LIMIT bounds work; m3 sorts the full filtered set. |
-| `count_aggregate.das` | Aggregate — `count()` after `_where` over 1M rows. SQL pushes `COUNT(*)` to the engine returning one row; m3 materializes the full filtered array then counts it; m3f fuses where+count into one pass. Highest-asymmetry chain in daslang's favor. |
-| `indexed_lookup.das` | Indexed point lookup — `_where(_.id == K)` against the PRIMARY KEY over 1M rows. SQLite uses the PK b-tree (O(log n)); m3/m3f have no index (O(n) linear scan). Inverse-asymmetry: SQLite wins by ~1000×, illustrating where indexed storage earns its keep. |
+| `_common.das` | Shared `Car` `[sql_table]` + `[decs_template]` + `Dealer` schema + fixture builders (not a benchmark) |
+| `aggregate_match.das` | `_where + aggregate(seed, op)` — user-supplied binary reducer over a filtered slice |
+| `all_match.das` | `all(P)` with always-true predicate — full scan, returns true |
+| `any_match.das` | `any(P)` — first-hit early exit |
+| `average_aggregate.das` | `average(_.price)` — single-row scalar reduce |
+| `bare_order_where.das` | `_where + _order_by(_.price)` — fused prefilter + sort, no take |
+| `chained_where.das` | `_where + _where + count` — two filter stages then count |
+| `contains_match.das` | `contains(needle)` — early-exit equality scan |
+| `count_aggregate.das` | `count()` — engine pushes `COUNT(*)`; array/decs fuse where+count |
+| `distinct_by_count.das` | `_distinct_by(_.brand) \|> count()` (Array/Decs only; SQL TODO) |
+| `distinct_count.das` | `_select(_.brand).distinct() \|> count()` — projection then dedup |
+| `distinct_take.das` | `_select(_.brand).distinct().take(N)` — early-exit dedup |
+| `element_at_match.das` | `_where + element_at(N)` — skip then take 1 |
+| `first_match.das` | `_where + first()` — first-hit |
+| `first_or_default_match.das` | `_where + first_or_default(d)` — first-hit with default |
+| `groupby_average.das` | `_group_by(_.brand) + _select(AvgPrice = avg)` |
+| `groupby_count.das` | `_group_by(_.brand) + _select(N = count)` |
+| `groupby_first.das` | `_group_by(_.brand) + _select(FirstCar = first per group)` (Array/Decs only; SQL TODO) |
+| `groupby_having_count.das` | `_group_by + _having(length >= 5) + _select` |
+| `groupby_having_hidden_sum.das` | `_group_by + _having(sum > 50000) + _select` |
+| `groupby_max.das` | `_group_by(_.brand) + _select(MaxPrice = max)` |
+| `groupby_min.das` | `_group_by(_.brand) + _select(MinPrice = min)` |
+| `groupby_multi_reducer.das` | `_group_by + 4-slot named tuple` — count + sum + max + … fused |
+| `groupby_select_sum.das` | `_select(_.price) + _group_by(_ % 100) + _select((K, S=sum))` (Array/Decs only; SQL TODO — expression keys) |
+| `groupby_sum.das` | `_group_by(_.brand) + _select(TotalPrice = sum)` |
+| `groupby_where_count.das` | `_where + _group_by + _select(N = length)` |
+| `groupby_where_sum.das` | `_where + _group_by + _select(TotalPrice = sum)` |
+| `indexed_lookup.das` | `_where(_.id == K)` against the PRIMARY KEY — SQLite uses PK b-tree; Array/Decs scan linearly |
+| `join_count.das` | `_join(cars, dealers, on = c.dealer_id == d.id) + count()` (Decs lane absent — TODO: decs join machinery) |
+| `last_match.das` | `_where + last()` — carry-last terminator |
+| `long_count_aggregate.das` | `long_count()` — int64 counter |
+| `max_aggregate.das` | `max(_.price)` — streaming max |
+| `min_aggregate.das` | `min(_.price)` — streaming min |
+| `order_take_desc.das` | `_order_by_descending(_.price) + take(N)` — top-N largest |
+| `reverse_take.das` | `reverse + take(N)` — tail N rows |
+| `select_count.das` | `_select + count` — projection then counter (DCE'd in some lanes) |
+| `select_where.das` | `_where + _select` — filter then project |
+| `select_where_count.das` | `_select(2*price) + _where(> T) + count` — where-after-select |
+| `select_where_order_take.das` | `_where + _select + _order_by + take(N)` — full chain |
+| `select_where_sum.das` | `_select(2*price) + _where(> T) + sum` — where-after-select fused with accumulator |
+| `single_match.das` | `single` — assert-one-element with full scan |
+| `skip_take.das` | `skip(M) + take(K) + to_array` — windowing |
+| `skip_while_match.das` | `skip_while(P) + count` — predicate-driven skip |
+| `sort_first.das` | `_order_by + first` — streaming-min (no buffer) |
+| `sort_take.das` | `_order_by + take(N)` — bounded-heap (size N) |
+| `sum_aggregate.das` | `sum(_.price)` — engine pushes `SUM(price)`; array/decs accumulator |
+| `sum_where.das` | `_where + _select + sum` — three-stage |
+| `take_count.das` | `take(N) + to_array` — bounded materialization |
+| `take_count_filtered.das` | `_where + take(N) + count` (Array/Decs only; SQL semantically distinct — LIMIT-on-aggregate) |
+| `take_sum_aggregate.das` | `take(N) + sum` (Array/Decs only; SQL semantically distinct) |
+| `take_while_match.das` | `take_while(P) + count` — predicate-driven take |
+| `to_array_filter.das` | `_where + _select + to_array` — three-stage materialize |
+| `zip_dot_product.das` | `zip(a, b) + _select(_._0 * _._1) + sum` (Array/Decs only; zip is not relational, no SQL form) |

--- a/benchmarks/sql/aggregate_match.das
+++ b/benchmarks/sql/aggregate_match.das
@@ -4,9 +4,9 @@ options persistent_heap
 require _common public
 
 // User-supplied binary reducer: sum of prices over a where-filtered slice. SQL
-// can express this as `SELECT SUM(price)`. m3 traverses the array with the
-// user-block invoked per element; m3f peels the block body and inlines alongside
-// the where predicate — single pass with no per-element block invoke.
+// can express this as `SELECT SUM(price)`. The Array lane peels the block body
+// and inlines alongside the where predicate — single pass with no per-element
+// block invoke. Decs runs the same fused shape over the archetype walk.
 
 let THRESHOLD = 200
 
@@ -24,17 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let total = (arr |> _where(_.price > THRESHOLD)
-                         |> aggregate(0, $(acc : int, c : Car) => acc + c.price))
-        b |> accept(total)
-        if (total == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -62,11 +51,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def aggregate_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def aggregate_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/all_match.das
+++ b/benchmarks/sql/all_match.das
@@ -6,8 +6,8 @@ require _common public
 // Predicate that is ALWAYS true (price < 9999), so the full scan runs.
 // SQL equivalent of `all(pred)` is `count(where NOT pred) == 0` — no direct
 // `_all` terminal in sqlite_linq, so we phrase it as a counter-example count.
-// Array variants use `_all(pred)` which short-circuits on first failing element;
-// always-true predicate forces full-array traversal (fair upper-bound timing).
+// Array and Decs lanes use `_all(pred)` which short-circuits on first failing
+// element; always-true predicate forces full traversal (fair upper-bound timing).
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -22,16 +22,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let yes = arr |> _all(_.price < 9999)
-        b |> accept(yes)
-        if (!yes) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -57,11 +47,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def all_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def all_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/any_match.das
+++ b/benchmarks/sql/any_match.das
@@ -7,7 +7,7 @@ let THRESHOLD = 500
 
 // SQL: SELECT ... LIMIT 1 — engine stops at first hit. Use _first_opt then is_some
 // since sqlite_linq doesn't expose `_any()` as a chain terminal.
-// Array variants use `_any(pred)` which short-circuits at the first match.
+// Array and Decs lanes use `_any(pred)` which short-circuits at the first match.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -22,16 +22,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let yes = arr |> _any(_.price > THRESHOLD)
-        b |> accept(yes)
-        if (!yes) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -57,11 +47,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def any_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def any_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/average_aggregate.das
+++ b/benchmarks/sql/average_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT AVG(price) FROM Cars.
-// m3/m3f sum and divide on a single pass.
+// Array and Decs lanes sum and divide on a single pass.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -19,16 +19,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let a = arr |> _select(double(_.price)) |> average()
-        b |> accept(a)
-        if (a == 0.0lf) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -54,11 +44,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def average_aggregate_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def average_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/bare_order_where.das
+++ b/benchmarks/sql/bare_order_where.das
@@ -7,9 +7,9 @@ let THRESHOLD = 500
 
 // _where(_.price > T) |> _order_by(_.price) — fused prefilter + sort, NO take.
 // SQL: WHERE price > T ORDER BY price.
-// m3 (plain LINQ) materializes a filter array, then sorts a clone (two allocations).
-// m3f (spliced via plan_order_family Phase 3c) emits a single fused loop that collects
-// matching elements into one pre-allocated buffer, then sort_inplace's the buffer.
+// Array (spliced via plan_order_family Phase 3c) emits a single fused loop that
+// collects matching elements into one pre-allocated buffer, then sort_inplace's
+// the buffer. Decs runs the same fused shape over the archetype walk.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -22,18 +22,6 @@ def run_m1(b : B?; n : int) {
             if (empty(rows)) {
                 b->failNow()
             }
-        }
-    }
-}
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> _where(_.price > THRESHOLD)
-                         |> _order_by(_.price))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
         }
     }
 }
@@ -67,11 +55,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def bare_order_where_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def bare_order_where_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/chained_where.das
+++ b/benchmarks/sql/chained_where.das
@@ -8,8 +8,8 @@ let YEAR_FLOOR = 2015
 
 // where → where → count — two filter stages then count.
 // SQL: SELECT COUNT(*) ... WHERE p1 AND p2 — engine combines predicates.
-// Array variants today: m3 materializes after each where; m3f folds two whereS into one fused loop.
-// Splice mode should fuse `where(p1) |> where(p2) |> count` into a single pass with both predicates inlined.
+// Array and Decs lanes fuse `where(p1) |> where(p2) |> count` into a single
+// pass with both predicates inlined (no per-stage materialization).
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -27,18 +27,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let c = (arr |> _where(_.price > THRESHOLD)
-                     |> _where(_.year >= YEAR_FLOOR)
-                     |> count())
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -68,11 +56,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def chained_where_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def chained_where_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/contains_match.das
+++ b/benchmarks/sql/contains_match.das
@@ -23,18 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        // Project ids out then contains. Mirrors what `_fold(...select.contains(...))` does
-        // — an array-source linq chain materializes `select` first then iterates contains.
-        let yes = arr |> _select(_.id) |> contains(TARGET_ID)
-        b |> accept(yes)
-        if (!yes) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -60,11 +48,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def contains_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def contains_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/count_aggregate.das
+++ b/benchmarks/sql/count_aggregate.das
@@ -6,10 +6,9 @@ require _common public
 let THRESHOLD = 500
 
 // SQL pushes COUNT(*) to the engine returning one row.
-// m3 must materialize the full filtered array, then walk to count it.
-// m3f folds where+count into a single fused pass (no intermediate array).
+// Array and Decs lanes fold where+count into a single fused pass
+// (no intermediate filter array).
 
-// --- m1: _sql over :memory: ---
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
@@ -23,19 +22,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-// --- m3: array LINQ (materializes intermediate filter array) ---
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let c = arr |> _where(_.price > THRESHOLD) |> count()
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
-// --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -61,11 +47,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def count_aggregate_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def count_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_by_count.das
+++ b/benchmarks/sql/distinct_by_count.das
@@ -11,21 +11,11 @@ require _common public
 // distinct_by, the path that goes through the invoke-block-on-tuple shape.
 //
 // SQL: `SELECT COUNT(DISTINCT brand) FROM Cars` — sqlite_linq doesn't lower
-// `distinct() |> count()` so the m1 lane is omitted (same as join_count).
+// `_distinct_by(...) |> count()`. [Follow-up TODO 2026-05-23: error[50503]
+// `_sql: unsupported chain root or operator. Got: __::linq\`distinct_by\`...` —
+// would need a new dispatch arm in sqlite_linq for distinct/distinct_by.]
 //
 // Expected result: BRAND_COUNT (5).
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let dedup <- arr |> _distinct_by(_.brand)
-        let c = dedup |> length
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
 
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -47,11 +37,6 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
-}
-
-[benchmark]
-def distinct_by_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_count.das
+++ b/benchmarks/sql/distinct_count.das
@@ -5,7 +5,7 @@ require _common public
 
 // _select(_.brand) |> distinct() |> to_array — distinct values then materialize.
 // SQL: SELECT DISTINCT brand FROM Cars — engine builds a hashset.
-// Array variants must materialize a set/dedup before producing results.
+// Array and Decs lanes must materialize a set/dedup before producing results.
 // (sqlite_linq's `distinct() |> count()` form raises a not-implemented error
 // for `COUNT(DISTINCT col)`; we measure the materialized distinct set instead.)
 // Expected length: BRAND_COUNT (5).
@@ -23,16 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> _select(_.brand) |> distinct())
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -58,11 +48,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def distinct_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def distinct_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_take.das
+++ b/benchmarks/sql/distinct_take.das
@@ -7,32 +7,17 @@ let TAKE_N = 3
 
 // _select(_.brand) |> distinct() |> take(N) — early-exit dedup pattern.
 // SQL: SELECT DISTINCT brand FROM Cars LIMIT N — engine bounds the dedup hashset.
-// Both m3 and m3f use each(arr) for apples-to-apples comparison.
-// m3 (plain LINQ on iterator) routes through linq.das:668 — a lazy `distinct()` generator
-// composed with lazy `take(N)`, both yielding per element. Stops at N distinct yields.
-// m3f (spliced via plan_distinct): single fused for-loop with outer-loop take-guard
-// at the top — breaks as soon as the Nth distinct value has been consumed (true O(N)
-// source elements worst-case). No generator overhead. With BRAND_COUNT=5 and TAKE_N=3
-// the splice exits at source position ~3.
+// Array (spliced via plan_distinct): single fused for-loop with outer-loop
+// take-guard at the top — breaks as soon as the Nth distinct value has been
+// consumed (true O(N) source elements worst-case). Decs lane mirrors this
+// over the archetype walk. With BRAND_COUNT=5 and TAKE_N=3 the splice exits
+// at source position ~3.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _select(_.brand) |> distinct() |> take(TAKE_N))
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        unsafe {
-            let rows <- (each(arr) |> _select(_.brand) |> distinct() |> take(TAKE_N) |> to_array())
             b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
@@ -70,11 +55,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def distinct_take_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def distinct_take_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/element_at_match.das
+++ b/benchmarks/sql/element_at_match.das
@@ -7,8 +7,8 @@ let THRESHOLD = 500
 let INDEX = 100
 
 // SQL: SELECT ... WHERE price > T LIMIT 1 OFFSET N — engine skips N then takes 1.
-// m3 materializes full filtered array then indexes [N].
-// m3f counts matches and early-exits when counter hits N.
+// Array and Decs lanes count matches and early-exit when the counter hits N
+// (no full filter materialization).
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -24,16 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let row = arr |> _where(_.price > THRESHOLD) |> element_at(INDEX)
-        b |> accept(row)
-        if (row.price == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +49,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def element_at_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def element_at_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/first_match.das
+++ b/benchmarks/sql/first_match.das
@@ -6,9 +6,7 @@ require _common public
 let THRESHOLD = 500
 
 // SQL: SELECT ... LIMIT 1 — engine stops at first hit.
-// m3 materializes the full filtered array then indexes [0].
-// m3f should ideally early-exit at the first matching row; splice mode
-// is the main target here.
+// Array and Decs lanes early-exit at the first matching row via the splice.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -23,16 +21,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let row = arr |> _where(_.price > THRESHOLD) |> first()
-        b |> accept(row)
-        if (row.price == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -58,11 +46,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def first_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def first_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/first_or_default_match.das
+++ b/benchmarks/sql/first_or_default_match.das
@@ -23,17 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
-    b |> run("m3_array/{n}", n) {
-        let row = arr |> _where(_.price > THRESHOLD) |> first_or_default(sentinel)
-        b |> accept(row)
-        if (row.id == SENTINEL_ID) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
@@ -61,11 +50,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def first_or_default_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def first_or_default_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_average.das
+++ b/benchmarks/sql/groupby_average.das
@@ -24,17 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
-                                                       AvgPrice = _._1 |> select($(c : Car) => c.price) |> average())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -68,11 +57,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_average_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_average_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_count.das
+++ b/benchmarks/sql/groupby_count.das
@@ -5,8 +5,8 @@ require _common public
 
 // _group_by(_.brand) |> _select((Brand=key, N=count)) — per-group count.
 // SQL: SELECT brand, COUNT(*) GROUP BY brand — engine hashes once, returns BRAND_COUNT rows.
-// Array variants must buffer (group_by is fundamentally buffering); splice mode
-// can still inline the projection and `length` aggregation per group.
+// Array and Decs lanes must buffer (group_by is fundamentally buffering); splice
+// mode still inlines the projection and `length` aggregation per group.
 // Expected result: BRAND_COUNT (5) groups, each ~n/5 in size.
 
 def run_m1(b : B?; n : int) {
@@ -24,16 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0, N = _._1 |> length)))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -65,11 +55,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_first.das
+++ b/benchmarks/sql/groupby_first.das
@@ -4,20 +4,12 @@ options persistent_heap
 require _common public
 
 // _group_by(_.brand) |> _select((Brand=key, FirstCar=first source elem per group)).
-// No direct SQL aggregator for "first source-order row per group" → m1 omitted; m3 vs m3f
-// is the headline comparison. Splice (PR-A2) emits miss-branch-only loop (no hit update).
+// SQL equivalent would need a window function (`ROW_NUMBER() OVER (PARTITION BY brand
+// ORDER BY id)` + outer WHERE rn=1); sqlite_linq does not currently lower window
+// functions. [Follow-up TODO 2026-05-23: window-function lowering in sqlite_linq.]
+// Array vs Decs is the headline comparison. Splice (PR-A2) emits miss-branch-only
+// loop (no hit update).
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
-                                                       FirstCar = _._1 |> first())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -46,11 +38,6 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
-}
-
-[benchmark]
-def groupby_first_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_having_count.das
+++ b/benchmarks/sql/groupby_having_count.das
@@ -26,16 +26,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._having(_._1 |> length >= 5)._select((Brand = _._0, N = _._1 |> length)))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -69,11 +59,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_having_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_having_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_having_hidden_sum.das
+++ b/benchmarks/sql/groupby_having_hidden_sum.das
@@ -28,16 +28,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)._select((Brand = _._0, N = _._1 |> length)))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -71,11 +61,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_having_hidden_sum_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_having_hidden_sum_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_max.das
+++ b/benchmarks/sql/groupby_max.das
@@ -24,17 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
-                                                       MaxPrice = _._1 |> select($(c : Car) => c.price) |> max())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -68,11 +57,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_max_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_max_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_min.das
+++ b/benchmarks/sql/groupby_min.das
@@ -24,17 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
-                                                       MinPrice = _._1 |> select($(c : Car) => c.price) |> min())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -68,11 +57,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_min_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_min_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_multi_reducer.das
+++ b/benchmarks/sql/groupby_multi_reducer.das
@@ -26,19 +26,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
-                                                       N = _._1 |> length,
-                                                       TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
-                                                       MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -76,11 +63,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_multi_reducer_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_multi_reducer_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_select_sum.das
+++ b/benchmarks/sql/groupby_select_sum.das
@@ -4,20 +4,14 @@ options persistent_heap
 require _common public
 
 // _select(c => c.price) |> _group_by(price % 100) |> _select((K=key, S=sum)).
-// _sql LINQ-to-SQL requires `_group_by(_.Field)` (no expression keys) → m1 omitted; m3 vs m3f
-// is the headline comparison. Splice (PR-B) fuses the upstream Car→price projection into an
-// intermediate var bind so the key + sum acc reference the projected int (no per-element Car re-access).
+// SQL omitted: sqlite_linq's `_group_by` requires `_.Field` or a tuple of `_.Field`s.
+// The expression key (`_ % 100`) is rejected. [Follow-up TODO 2026-05-23: error[50503]
+// `_sql: _group_by: key must be \`_.Field\` or a tuple of \`_.Field\`s; got: (_ % 100)`
+// — would need expression-key support in sqlite_linq lowering.]
+// Array vs Decs is the headline comparison. Splice (PR-B) fuses the upstream Car→price
+// projection into an intermediate var bind so the key + sum acc reference the projected
+// int (no per-element Car re-access).
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._select(_.price)._group_by(_ % 100)._select((K = _._0, S = _._1 |> sum())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -46,11 +40,6 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
-}
-
-[benchmark]
-def groupby_select_sum_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_sum.das
+++ b/benchmarks/sql/groupby_sum.das
@@ -24,17 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._group_by(_.brand)._select((Brand = _._0,
-                                                       TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -68,11 +57,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_sum_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_sum_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_where_count.das
+++ b/benchmarks/sql/groupby_where_count.das
@@ -24,16 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._where(_.price > 500)._group_by(_.brand)._select((Brand = _._0, N = _._1 |> length)))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -67,11 +57,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_where_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_where_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_where_sum.das
+++ b/benchmarks/sql/groupby_where_sum.das
@@ -25,17 +25,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let groups <- (arr._where(_.price > 500)._group_by(_.brand)._select((Brand = _._0,
-                                                                              TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum())))
-        b |> accept(groups)
-        if (empty(groups)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -71,11 +60,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def groupby_where_sum_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def groupby_where_sum_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/indexed_lookup.das
+++ b/benchmarks/sql/indexed_lookup.das
@@ -5,11 +5,11 @@ require _common public
 
 // Indexed point-lookup: _where(_.id == K) where id is the PRIMARY KEY.
 // SQLite uses the PK b-tree -> O(log n).
-// m3/m3f have no index -> O(n) linear scan over the array.
-// m4 uses the decs eid hash (query(eid, ...) wraps for_eid_archetype) -> O(1).
-// m1 wins over m3/m3f by complexity-class margin; m4 wins over m1 by skipping the b-tree descent.
+// Array has no index -> O(n) linear scan.
+// Decs uses the eid hash (query(eid, ...) wraps for_eid_archetype) -> O(1).
+// SQL wins over Array by complexity-class margin; Decs wins over SQL by skipping
+// the b-tree descent.
 
-// --- m1: _sql over :memory: ---
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
@@ -24,20 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-// --- m3: array LINQ (linear scan) ---
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    let key = n / 2
-    b |> run("m3_array/{n}") {
-        let c = arr |> _where(_.id == key) |> count()
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
-
-// --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     let key = n / 2
@@ -50,12 +36,12 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
-// --- m4: decs eid lookup (O(1) hash) ---
-// query(eid, $(...)) wraps for_eid_archetype, which hashes the eid into entityLookup
-// and dispatches the block once if the archetype matches. The block-arg `car_id` is
-// the request-shape witness AND a fixture-drift gate: fixture_decs_capture_mid sets
-// id = i+1 on the n/2-th entity, so reading car_id back gives us a non-trivial value
-// that proves the lookup actually visited the expected entity (not a coincidence).
+// Decs eid lookup (O(1) hash): query(eid, $(...)) wraps for_eid_archetype, which
+// hashes the eid into entityLookup and dispatches the block once if the archetype
+// matches. The block-arg `car_id` is the request-shape witness AND a fixture-drift
+// gate: fixture_decs_capture_mid sets id = i+1 on the n/2-th entity, so reading
+// car_id back gives us a non-trivial value that proves the lookup actually visited
+// the expected entity (not a coincidence).
 def run_m4(b : B?; n : int) {
     let target_eid = fixture_decs_capture_mid(n)
     let expected_id = n / 2 + 1
@@ -74,11 +60,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def indexed_lookup_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def indexed_lookup_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_count.das
+++ b/benchmarks/sql/join_count.das
@@ -4,25 +4,30 @@ options persistent_heap
 require _common public
 
 // _join(cars, dealers, on=c.dealer_id == d.id, into=...) |> count.
-// SQL form (`_sql(... |> _join(select_from(type<Dealer>), ...))`) requires the
-// inner select_from to bind the db handle inside the _sql analyzer; that wiring
-// is not exposed for direct authoring here, so m1 is omitted for this benchmark.
-// 2-way comparison (m3 / m3f) focuses on array-side join cost.
+// SQL lane works via `_sql(... |> _join(db |> select_from(type<Dealer>), ...))`
+// — the projection must be a named-tuple (positional tuples like `(c.name, d.name)`
+// are rejected by `_sql`'s _select shape check; use `(CarName=..., DealerName=...)`).
+// The Decs lane is absent — `_join` doesn't lower onto the archetype walk, and
+// faithfully porting cross-archetype lookup would need a Dealer decs template +
+// hash-by-id index. [Follow-up TODO 2026-05-23: decs join / cross-archetype lookup
+// machinery — see plan_join in linq_fold.das, currently only handles iterator/array.]
 
-def run_m3(b : B?; n : int) {
-    let cars <- fixture_array(n)
-    let dealers <- fixture_dealers_array()
-    b |> run("m3_array/{n}", n) {
-        let c = (cars |> _join(dealers,
-                               $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                               $(c : Car, d : Dealer) => (c.name, d.name))
-                      |> count())
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let c = _sql(db |> select_from(type<Car>) |> _join(db |> select_from(type<Dealer>),
+                                                               $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                                               $(c : Car, d : Dealer) => (CarName = c.name, DealerName = d.name))
+                                                      |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
         }
     }
 }
+
 def run_m3f(b : B?; n : int) {
     let cars <- fixture_array(n)
     let dealers <- fixture_dealers_array()
@@ -39,8 +44,8 @@ def run_m3f(b : B?; n : int) {
 }
 
 [benchmark]
-def join_count_m3(b : B?) {
-    run_m3(b, 100000)
+def join_count_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/last_match.das
+++ b/benchmarks/sql/last_match.das
@@ -6,8 +6,8 @@ require _common public
 let THRESHOLD = 500
 
 // SQL: `SELECT ... WHERE price > THRESHOLD ORDER BY id DESC LIMIT 1` — engine reverses
-// then takes one. m3 materializes the full filtered array then indexes [-1].
-// m3f walks the source once, overwriting a single bind on each match.
+// then takes one. Array and Decs lanes walk the source once, overwriting a single
+// bind on each match.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -23,16 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let row = arr |> _where(_.price > THRESHOLD) |> last()
-        b |> accept(row)
-        if (row.price == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -58,11 +48,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def last_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def last_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -22,16 +22,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let c = arr |> _where(_.price > THRESHOLD) |> long_count()
-        b |> accept(c)
-        if (c == 0l) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -57,11 +47,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def long_count_aggregate_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def long_count_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/max_aggregate.das
+++ b/benchmarks/sql/max_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT MAX(price) FROM Cars.
-// m3/m3f scan the array tracking the maximum seen.
+// Array and Decs lanes scan the source tracking the maximum seen.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -19,16 +19,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let m = arr |> _select(_.price) |> max()
-        b |> accept(m)
-        if (m == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -54,11 +44,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def max_aggregate_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def max_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/min_aggregate.das
+++ b/benchmarks/sql/min_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT MIN(price) FROM Cars.
-// m3/m3f scan the array tracking the minimum seen.
+// Array and Decs lanes scan the source tracking the minimum seen.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -19,16 +19,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let m = arr |> _select(_.price) |> min()
-        b |> accept(m)
-        if (m > 999) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -54,11 +44,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def min_aggregate_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def min_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/order_take_desc.das
+++ b/benchmarks/sql/order_take_desc.das
@@ -7,9 +7,9 @@ let TAKE_N = 10
 
 // _order_by_descending(_.price) |> take(N) — top-N largest pattern.
 // SQL: ORDER BY price DESC LIMIT N — engine emits partial-sort optimization when possible.
-// m3 (plain LINQ) does a full descending sort then slices.
-// m3f (spliced via plan_order_family Phase 3b) dispatches directly to ``top_n_by_descending``
-// which uses partial_sort with a flipped comparator (array source) — O(M log N).
+// Array (spliced via plan_order_family Phase 3b) dispatches directly to
+// ``top_n_by_descending`` which uses partial_sort with a flipped comparator — O(M log N).
+// Decs runs the same shape over the archetype walk with a bounded heap of size N.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -20,17 +20,6 @@ def run_m1(b : B?; n : int) {
             if (empty(rows)) {
                 b->failNow()
             }
-        }
-    }
-}
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> _order_by_descending(_.price) |> take(TAKE_N))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
         }
     }
 }
@@ -60,11 +49,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def order_take_desc_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def order_take_desc_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,0 +1,201 @@
+# Benchmarks — SQL / Array / Decs comparison
+
+Generated 2026-05-23 from master `1c8ff9119`. Fixture size: n = 100 000
+(cars), 100 dealers, 5 brands. Each row is one bench family in
+`benchmarks/sql/`; columns are nanoseconds per logical operation.
+`—` marks an intentionally absent lane — see "Notes on missing lanes"
+below.
+
+The benchmarked chain shapes are summarised in
+`benchmarks/README.md` and the splice arms each chain fires are
+catalogued in `doc/source/reference/linq_fold_patterns.rst`.
+
+- **SQL** — `_sql` macro over an in-memory SQLite database
+  (`with_sqlite(":memory:")`).
+- **Array** — `_fold` over `each(arr)` chain, in-memory `array<Car>`.
+- **Decs** — `_fold` over `from_decs_template(type<DecsCar>)`,
+  per-archetype walk.
+- **Decs vs Array** — ratio `decs_ns / array_ns`. Values below 1× mean
+  decs wins; values above mean array wins.
+
+Sub-nanosecond cells (`0.00`) reflect early-exit terminators that exit
+before the timer resolution can measure them — they should be read as
+"effectively free."
+
+## INTERP
+
+| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
+|---|---:|---:|---:|---:|
+| `aggregate_match` | 35.1 | 6.0 | 5.9 | 0.98× |
+| `all_match` | 27.7 | 3.6 | 3.5 | 0.97× |
+| `any_match` | 0.00 | 0.00 | 0.00 | — |
+| `average_aggregate` | 31.2 | 5.8 | 8.7 | 1.50× |
+| `bare_order_where` | 274.0 | 118.4 | 126.3 | 1.07× |
+| `chained_where` | 36.4 | 8.3 | 8.0 | 0.96× |
+| `contains_match` | 0.00 | 2.3 | 1.4 | 0.61× |
+| `count_aggregate` | 29.7 | 4.1 | 4.1 | 1.00× |
+| `distinct_by_count` | — | 15.9 | 15.8 | 0.99× |
+| `distinct_count` | 41.2 | 16.0 | 15.8 | 0.99× |
+| `distinct_take` | 0.00 | 0.00 | 0.00 | — |
+| `element_at_match` | 0.00 | 0.00 | 0.00 | — |
+| `first_match` | 0.00 | 0.00 | 0.00 | — |
+| `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
+| `groupby_average` | 174.3 | 30.2 | 30.1 | 1.00× |
+| `groupby_count` | 140.9 | 19.2 | 19.3 | 1.01× |
+| `groupby_first` | — | 18.4 | 19.1 | 1.04× |
+| `groupby_having_count` | 140.0 | 19.1 | 19.2 | 1.01× |
+| `groupby_having_hidden_sum` | 181.1 | 24.8 | 23.9 | 0.96× |
+| `groupby_max` | 173.8 | 24.9 | 25.2 | 1.01× |
+| `groupby_min` | 173.5 | 25.0 | 25.4 | 1.02× |
+| `groupby_multi_reducer` | 188.5 | 32.3 | 33.3 | 1.03× |
+| `groupby_select_sum` | — | 36.8 | 36.2 | 0.98× |
+| `groupby_sum` | 185.6 | 19.2 | 18.7 | 0.97× |
+| `groupby_where_count` | 75.9 | 14.6 | 14.9 | 1.02× |
+| `groupby_where_sum` | 86.6 | 14.5 | 14.6 | 1.01× |
+| `indexed_lookup` | 1449.1 | 203294.7 | 470.6 | 0.00× |
+| `join_count` | 38.2 | 122.1 | — | — |
+| `last_match` | 0.00 | 6.0 | 14.2 | 2.37× |
+| `long_count_aggregate` | 29.3 | 4.4 | 4.5 | 1.02× |
+| `max_aggregate` | 30.5 | 6.0 | 6.9 | 1.15× |
+| `min_aggregate` | 31.1 | 6.2 | 6.9 | 1.11× |
+| `order_take_desc` | 40.2 | 15.8 | 20.3 | 1.28× |
+| `reverse_take` | 0.10 | 0.00 | 9.2 | — |
+| `select_count` | 0.10 | 0.00 | 2.2 | — |
+| `select_where` | 197.9 | 11.1 | 20.0 | 1.80× |
+| `select_where_count` | 33.7 | 5.2 | 7.4 | 1.42× |
+| `select_where_order_take` | 36.7 | 12.2 | 15.0 | 1.23× |
+| `select_where_sum` | 36.8 | 7.4 | 7.4 | 1.00× |
+| `single_match` | 0.00 | 3.0 | 5.5 | 1.83× |
+| `skip_take` | 0.50 | 0.10 | 0.20 | 2.00× |
+| `skip_while_match` | 3.6 | 5.2 | 5.3 | 1.02× |
+| `sort_first` | 38.5 | 11.0 | 13.4 | 1.22× |
+| `sort_take` | 37.6 | 16.3 | 20.5 | 1.26× |
+| `sum_aggregate` | 29.8 | 2.2 | 2.4 | 1.09× |
+| `sum_where` | 32.8 | 4.2 | 4.3 | 1.02× |
+| `take_count` | 3.6 | 0.20 | 0.40 | 2.00× |
+| `take_count_filtered` | — | 0.20 | 0.20 | 1.00× |
+| `take_sum_aggregate` | — | 0.10 | 0.10 | 1.00× |
+| `take_while_match` | 8.0 | 2.4 | 2.5 | 1.04× |
+| `to_array_filter` | 70.5 | 11.8 | 11.7 | 0.99× |
+| `zip_dot_product` | — | 8.2 | 4.8 | 0.59× |
+
+## JIT
+
+| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
+|---|---:|---:|---:|---:|
+| `aggregate_match` | 215.7 | 4.4 | 7.4 | 1.68× |
+| `all_match` | 303.8 | 3.8 | 2.1 | 0.55× |
+| `any_match` | 0.00 | 0.00 | 0.00 | — |
+| `average_aggregate` | 51.4 | 1.6 | 5.9 | 3.69× |
+| `bare_order_where` | 383.2 | 66.3 | 66.0 | 1.00× |
+| `chained_where` | 79.6 | 1.3 | 1.9 | 1.46× |
+| `contains_match` | 0.00 | 0.40 | 0.20 | 0.50× |
+| `count_aggregate` | 57.8 | 0.80 | 1.2 | 1.50× |
+| `distinct_by_count` | — | 4.2 | 5.8 | 1.38× |
+| `distinct_count` | 76.3 | 3.9 | 4.0 | 1.03× |
+| `distinct_take` | 0.00 | 0.00 | 0.00 | — |
+| `element_at_match` | 0.00 | 0.00 | 0.00 | — |
+| `first_match` | 0.00 | 0.00 | 0.00 | — |
+| `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
+| `groupby_average` | 172.9 | 2.6 | 2.9 | 1.12× |
+| `groupby_count` | 141.6 | 2.4 | 2.5 | 1.04× |
+| `groupby_first` | — | 2.2 | 3.1 | 1.41× |
+| `groupby_having_count` | 141.8 | 2.4 | 2.5 | 1.04× |
+| `groupby_having_hidden_sum` | 176.6 | 2.6 | 2.8 | 1.08× |
+| `groupby_max` | 174.4 | 2.4 | 2.7 | 1.13× |
+| `groupby_min` | 173.4 | 2.4 | 2.7 | 1.13× |
+| `groupby_multi_reducer` | 189.8 | 2.7 | 3.0 | 1.11× |
+| `groupby_select_sum` | — | 3.2 | 3.7 | 1.16× |
+| `groupby_sum` | 171.9 | 2.4 | 2.7 | 1.13× |
+| `groupby_where_count` | 75.7 | 1.7 | 1.8 | 1.06× |
+| `groupby_where_sum` | 86.8 | 1.7 | 1.8 | 1.06× |
+| `indexed_lookup` | 1253.3 | 35303.2 | 103.9 | 0.00× |
+| `join_count` | 38.0 | 36.4 | — | — |
+| `last_match` | 0.00 | 0.50 | 1.4 | 2.80× |
+| `long_count_aggregate` | 29.0 | 0.40 | 0.60 | 1.50× |
+| `max_aggregate` | 30.3 | 0.70 | 0.50 | 0.71× |
+| `min_aggregate` | 30.5 | 0.70 | 0.50 | 0.71× |
+| `order_take_desc` | 38.0 | 0.70 | 1.4 | 2.00× |
+| `reverse_take` | 0.00 | 0.00 | 1.1 | — |
+| `select_count` | 0.10 | 0.00 | 0.00 | — |
+| `select_where` | 105.6 | 4.2 | 5.5 | 1.31× |
+| `select_where_count` | 32.3 | 0.40 | 0.60 | 1.50× |
+| `select_where_order_take` | 36.2 | 0.70 | 1.4 | 2.00× |
+| `select_where_sum` | 36.8 | 0.50 | 0.60 | 1.20× |
+| `single_match` | 0.00 | 0.40 | 1.1 | 2.75× |
+| `skip_take` | 0.30 | 0.00 | 0.00 | — |
+| `skip_while_match` | 3.5 | 0.40 | 0.40 | 1.00× |
+| `sort_first` | 37.9 | 0.40 | 1.3 | 3.25× |
+| `sort_take` | 38.5 | 0.70 | 1.4 | 2.00× |
+| `sum_aggregate` | 30.5 | 0.40 | 0.30 | 0.75× |
+| `sum_where` | 33.0 | 0.40 | 0.60 | 1.50× |
+| `take_count` | 1.8 | 0.10 | 0.10 | 1.00× |
+| `take_count_filtered` | — | 0.00 | 0.00 | — |
+| `take_sum_aggregate` | — | 0.00 | 0.00 | — |
+| `take_while_match` | 8.0 | 0.20 | 0.30 | 1.50× |
+| `to_array_filter` | 48.0 | 3.3 | 3.4 | 1.03× |
+| `zip_dot_product` | — | 0.50 | 0.50 | 1.00× |
+
+## Notes on missing lanes (the `—` cells)
+
+The reasons each cell is empty are also recorded as a comment in the
+corresponding `.das` bench file; the bullets below quote that comment.
+
+- **`distinct_by_count` SQL** — sqlite_linq does not currently lower
+  `_distinct_by(...) |> count()`. Probe error: `_sql: unsupported chain
+  root or operator. Got: __::linq\`distinct_by\`...`. Follow-up TODO
+  2026-05-23: add a dispatch arm in sqlite_linq for
+  distinct/distinct_by.
+- **`groupby_first` SQL** — no direct SQL aggregator for "first
+  source-order row per group". Window functions (`ROW_NUMBER() OVER
+  (PARTITION BY brand ORDER BY id)` + outer `WHERE rn=1`) would be the
+  SQL equivalent; sqlite_linq does not currently lower window
+  functions. Follow-up TODO 2026-05-23.
+- **`groupby_select_sum` SQL** — sqlite_linq's `_group_by` requires
+  `_.Field` or a tuple of `_.Field`s; the expression key (`_ % 100`) is
+  rejected. Probe error: `_sql: _group_by: key must be \`_.Field\` or a
+  tuple of \`_.Field\`s; got: (_ % 100)`. Follow-up TODO 2026-05-23:
+  expression-key support in sqlite_linq lowering.
+- **`take_count_filtered` SQL** — by design. In SQL, LIMIT after an
+  aggregate has no effect (the aggregate collapses to one row), so the
+  bound-then-count shape has no faithful SQL translation. No follow-up.
+- **`take_sum_aggregate` SQL** — same reason as `take_count_filtered`.
+  By design, no follow-up.
+- **`zip_dot_product` SQL** — `zip` is not a relational operation.
+  No SQL form exists; by design, no follow-up.
+- **`join_count` Decs** — `_join` does not currently lower onto the
+  decs archetype walk. Faithfully porting cross-archetype lookup would
+  need a Dealer `[decs_template]` plus a hash-by-id index. Follow-up
+  TODO 2026-05-23: decs join / cross-archetype lookup machinery in
+  `plan_join` (`daslib/linq_fold.das`).
+
+## How to re-run
+
+From the repo root, on macOS / Linux:
+
+```bash
+# INTERP
+rm -f /tmp/bench_interp.txt
+for f in benchmarks/sql/*.das; do
+  bn=$(basename "$f")
+  [[ "$bn" == _* ]] && continue
+  echo "=== $bn ===" >> /tmp/bench_interp.txt
+  build/daslang dastest/dastest.das -- --bench --test "$f" \
+    >> /tmp/bench_interp.txt 2>&1
+done
+
+# JIT (-jit goes BEFORE dastest.das)
+rm -f /tmp/bench_jit.txt
+for f in benchmarks/sql/*.das; do
+  bn=$(basename "$f")
+  [[ "$bn" == _* ]] && continue
+  echo "=== $bn ===" >> /tmp/bench_jit.txt
+  build/daslang -jit dastest/dastest.das -- --bench --test "$f" \
+    >> /tmp/bench_jit.txt 2>&1
+done
+```
+
+If JIT fails to compile (e.g. `error[30341]: no matching functions or
+generics: host_jit_triple()`), the `bin/daslang` binary is stale
+relative to `src/builtin/module_jit.cpp` — rebuild with
+`cmake --build build --config Release -j 64` and retry.

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -142,20 +142,27 @@ The reasons each cell is empty are also recorded as a comment in the
 corresponding `.das` bench file; the bullets below quote that comment.
 
 - **`distinct_by_count` SQL** — sqlite_linq does not currently lower
-  `_distinct_by(...) |> count()`. Probe error: `_sql: unsupported chain
-  root or operator. Got: __::linq\`distinct_by\`...`. Follow-up TODO
-  2026-05-23: add a dispatch arm in sqlite_linq for
-  distinct/distinct_by.
+  `_distinct_by(...) |> count()`. Follow-up TODO 2026-05-23: add a
+  dispatch arm in sqlite_linq for distinct/distinct_by. Probe error:
+
+  ```
+  error[50503]: _sql: unsupported chain root or operator.
+    Got: __::linq`distinct_by`...
+  ```
 - **`groupby_first` SQL** — no direct SQL aggregator for "first
   source-order row per group". Window functions (`ROW_NUMBER() OVER
   (PARTITION BY brand ORDER BY id)` + outer `WHERE rn=1`) would be the
   SQL equivalent; sqlite_linq does not currently lower window
   functions. Follow-up TODO 2026-05-23.
 - **`groupby_select_sum` SQL** — sqlite_linq's `_group_by` requires
-  `_.Field` or a tuple of `_.Field`s; the expression key (`_ % 100`) is
-  rejected. Probe error: `_sql: _group_by: key must be \`_.Field\` or a
-  tuple of \`_.Field\`s; got: (_ % 100)`. Follow-up TODO 2026-05-23:
-  expression-key support in sqlite_linq lowering.
+  `_.Field` or a tuple of `_.Field`s; the expression key (`_ % 100`)
+  is rejected. Follow-up TODO 2026-05-23: expression-key support in
+  sqlite_linq lowering. Probe error:
+
+  ```
+  error[50503]: _sql: _group_by: key must be `_.Field` or
+    a tuple of `_.Field`s; got: (_ % 100)
+  ```
 - **`take_count_filtered` SQL** — by design. In SQL, LIMIT after an
   aggregate has no effect (the aggregate collapses to one row), so the
   bound-then-count shape has no faithful SQL translation. No follow-up.

--- a/benchmarks/sql/reverse_take.das
+++ b/benchmarks/sql/reverse_take.das
@@ -7,31 +7,16 @@ let TAKE_N = 10
 
 // _reverse() |> take(N) — last N rows of the source, reversed.
 // SQL: SELECT * FROM Cars ORDER BY id DESC LIMIT N — engine indexes-and-limits.
-// m3 (plain LINQ iterator-reverse): generator captures the source, fills an internal buffer,
-// then yields buffer[len-i-1] lazily — take(N) only triggers N yields.
-// m3f (spliced via plan_reverse): single prefilter pass into a buffer + reverse_inplace
-// + resize(min(N, length(buf))). The full O(length) reverse is paid before resize, so for
-// TAKE_N << length this is a REGRESSION vs m3 (~34 vs ~22 ns/op at 100K). See LINQ.md
-// "Phase 3+" notes — a backward-index-loop optimization is deferred.
+// Array and Decs lanes splice through plan_reverse + skip-into-tail (PR #2834):
+// 2-pass walk that sums archetype/array size first, then for_each_archetype_find
+// with whole-arch-skip + partial-arch skip-counter + early-exit after N elements.
+// O(N) work regardless of source length.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
             let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.id) |> take(TAKE_N))
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        unsafe {
-            let rows <- (each(arr) |> reverse() |> take(TAKE_N) |> to_array())
             b |> accept(rows)
             if (empty(rows)) {
                 b->failNow()
@@ -69,11 +54,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def reverse_take_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def reverse_take_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -23,16 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let c = arr |> _select(_.price * 2) |> count()
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -58,11 +48,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def select_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def select_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where.das
+++ b/benchmarks/sql/select_where.das
@@ -5,7 +5,6 @@ require _common public
 
 let THRESHOLD = 500
 
-// --- m1: _sql over :memory: ---
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
@@ -19,19 +18,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-// --- m3: array LINQ (materializing intermediate arrays) ---
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> _where(_.price > THRESHOLD))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
-// --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -57,11 +43,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def select_where_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def select_where_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -7,10 +7,9 @@ let THRESHOLD = 1000
 
 // _select(_.price * 2) |> _where(_ > T) |> count — where-after-select pattern.
 // SQL: SELECT COUNT(*) FROM Cars WHERE price * 2 > T.
-// m3 (plain LINQ) materializes a projection iterator, then a filter array, then counts.
-// m3f (spliced via Phase 3d via replaceVariablePeeling) substitutes the projection into
-// the where predicate (peeling the typer-inserted ExprRef2Value wrapper) and emits a single
-// fused counter loop — no intermediate arrays.
+// Array and Decs lanes (spliced via Phase 3d via replaceVariablePeeling) substitute
+// the projection into the where predicate (peeling the typer-inserted ExprRef2Value
+// wrapper) and emit a single fused counter loop — no intermediate arrays.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -23,17 +22,6 @@ def run_m1(b : B?; n : int) {
             if (c == 0) {
                 b->failNow()
             }
-        }
-    }
-}
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let c = arr |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> count
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
         }
     }
 }
@@ -63,11 +51,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def select_where_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def select_where_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where_order_take.das
+++ b/benchmarks/sql/select_where_order_take.das
@@ -6,7 +6,6 @@ require _common public
 let THRESHOLD = 500
 let TAKE_N = 10
 
-// --- m1: _sql over :memory: ---
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
@@ -23,21 +22,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-// --- m3: array LINQ (materializing intermediate arrays) ---
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> _where(_.price > THRESHOLD)
-                         |> _order_by(_.price)
-                         |> take(TAKE_N))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
-// --- m3f: array LINQ folded into a single fused pass ---
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -69,11 +53,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def select_where_order_take_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def select_where_order_take_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where_sum.das
+++ b/benchmarks/sql/select_where_sum.das
@@ -8,14 +8,14 @@ let THRESHOLD = 1000
 // _select(_.price * 2) |> _where(_ > T) |> sum — where-after-select pattern with the
 // sum terminator. SQL: SELECT SUM(price * 2) FROM Cars WHERE price * 2 > T.
 //
-// m3 (plain LINQ) materializes a projection iterator, then a filter array, then sums.
-// m3f (spliced via Phase 3d single-eval) binds the projection to a local once per
-// element OUTSIDE the if-wrap, then the rewritten predicate reads the bind AND the
-// sum's valueExpr reads the bind — projection (`_.price * 2`) evaluates exactly once
-// per element across the splice. Without the dedup it evaluates twice (once in the
-// inlined predicate, once in valueExpr) for ARRAY/ACCUMULATOR/EARLY_EXIT lanes.
+// Array and Decs lanes (spliced via Phase 3d single-eval) bind the projection to a
+// local once per element OUTSIDE the if-wrap, then the rewritten predicate reads the
+// bind AND the sum's valueExpr reads the bind — projection (`_.price * 2`) evaluates
+// exactly once per element across the splice. Without the dedup it evaluates twice
+// (once in the inlined predicate, once in valueExpr) for ARRAY/ACCUMULATOR/EARLY_EXIT
+// lanes.
 //
-// m1 uses ``query_scalar`` with raw SQL because ``_sql``'s ``_select`` clause only
+// SQL uses ``query_scalar`` with raw SQL because ``_sql``'s ``_select`` clause only
 // accepts a single column or named-tuple shape — arbitrary scalar expressions like
 // ``_.price * 2`` aren't representable in the typed DSL. The engine still folds the
 // projection into both the WHERE filter and the SUM, so per-row work is identical to
@@ -30,17 +30,6 @@ def run_m1(b : B?; n : int) {
             if (s == 0) {
                 b->failNow()
             }
-        }
-    }
-}
-
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let s = arr |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> sum
-        b |> accept(s)
-        if (s == 0) {
-            b->failNow()
         }
     }
 }
@@ -70,11 +59,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def select_where_sum_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def select_where_sum_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/single_match.das
+++ b/benchmarks/sql/single_match.das
@@ -7,7 +7,7 @@ require _common public
 // (semantically — exactly-one-match), but the splice still fuses upstream where.
 //
 // SQL: SELECT * FROM Cars WHERE id = 42 — pk lookup returns the single row.
-// m3/m3f traverse the array filtering and asserting one survivor.
+// Array and Decs lanes traverse the source filtering and asserting one survivor.
 
 let TARGET_ID = 42
 
@@ -24,16 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let row = arr |> _where(_.id == TARGET_ID) |> single()
-        b |> accept(row)
-        if (row.id == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +49,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def single_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def single_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/skip_take.das
+++ b/benchmarks/sql/skip_take.das
@@ -24,16 +24,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> skip(SKIP_N) |> take(TAKE_N))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -59,11 +49,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def skip_take_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def skip_take_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/skip_while_match.das
+++ b/benchmarks/sql/skip_while_match.das
@@ -5,13 +5,12 @@ require _common public
 
 // Fixture car ids run 1..n in source order, so `id < THRESHOLD` is true for the leading
 // THRESHOLD-1 elements then false from THRESHOLD on. skip_while flips on the first false
-// and emits everything that follows; both reference and splice walk the entire source.
-// The splice gain is buffer elision — reference `skip_while_impl` materializes an
+// and emits everything that follows; the splice walks the entire source.
+// The splice gain is buffer elision — a reference `skip_while_impl` materializes an
 // `array<T>` of survivors before count; splice fuses into the counter lane (in-loop ++).
 //
 // SQL: `SELECT COUNT(*) FROM Cars WHERE id >= THRESHOLD` — index scan + aggregate.
-// m3 materializes the survivor tail as `array<Car>` then `|> count` reads its length.
-// m3f splice: single pass, no allocation, in-loop counter `++`.
+// Array and Decs lanes: single pass, no allocation, in-loop counter `++`.
 
 let THRESHOLD = 50000
 
@@ -28,16 +27,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let total = arr |> _skip_while(_.id < THRESHOLD) |> count()
-        b |> accept(total)
-        if (total == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -63,11 +52,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def skip_while_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def skip_while_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_first.das
+++ b/benchmarks/sql/sort_first.das
@@ -20,16 +20,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let row = arr |> _order_by(_.price) |> first()
-        b |> accept(row)
-        if (row.id == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -55,11 +45,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def sort_first_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def sort_first_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_take.das
+++ b/benchmarks/sql/sort_take.das
@@ -2,22 +2,13 @@ options gen2
 options persistent_heap
 
 require _common public
-require daslib/sort_boost
-require daslib/linq
 
 let TAKE_N = 10
 
 // _order_by(_.price) |> take(N) — top-N (here bottom-N since ascending) pattern.
 // SQL: ORDER BY price LIMIT N — engine emits partial-sort optimization when possible.
-// Array variants must fully sort before indexing the first N.
-//
-// The m3_topn_* columns measure the new ``linq.top_n_by`` family: array source
-// uses ``partial_sort`` under the hood (O(M log N)), iterator source uses a
-// bounded heap of size N during the scan (max N elements resident).
-//
-// m3f are intentionally identical for top-N here — Phase 0 only adds
-// the library function; PR B (BufferTopN emit mode in linq_fold) is what makes
-// the m3f column move.
+// Array and Decs lanes splice through plan_order_family + bounded-heap so they
+// keep at most N elements resident during the scan (no full sort).
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -32,16 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> _order_by(_.price) |> take(TAKE_N))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -68,51 +49,14 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m3_topn_array(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_topn_array/{n}", n) {
-        let rows <- top_n_by(arr, TAKE_N, @@(c : Car -&) => c.price)
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
-def run_m3_topn_iter(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_topn_iter/{n}", n) {
-        let rows <- top_n_by(arr.to_sequence(), TAKE_N, @@(c : Car -&) => c.price)
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
-
 [benchmark]
 def sort_take_m1(b : B?) {
     run_m1(b, 100000)
 }
 
 [benchmark]
-def sort_take_m3(b : B?) {
-    run_m3(b, 100000)
-}
-
-[benchmark]
 def sort_take_m3f(b : B?) {
     run_m3f(b, 100000)
-}
-
-[benchmark]
-def sort_take_m3_topn_array(b : B?) {
-    run_m3_topn_array(b, 100000)
-}
-
-[benchmark]
-def sort_take_m3_topn_iter(b : B?) {
-    run_m3_topn_iter(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sum_aggregate.das
+++ b/benchmarks/sql/sum_aggregate.das
@@ -4,7 +4,7 @@ options persistent_heap
 require _common public
 
 // SQL: SELECT SUM(price) FROM Cars — single-row scalar reduction pushed to the engine.
-// m3/m3f traverse the array projecting and accumulating.
+// Array and Decs lanes traverse the source projecting and accumulating.
 
 def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
@@ -19,16 +19,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let s = arr |> _select(_.price) |> sum()
-        b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -54,11 +44,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def sum_aggregate_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def sum_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sum_where.das
+++ b/benchmarks/sql/sum_where.das
@@ -23,16 +23,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let s = (arr |> _where(_.price > THRESHOLD) |> _select(_.price) |> sum())
-        b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -58,11 +48,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def sum_where_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def sum_where_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_count.das
+++ b/benchmarks/sql/take_count.das
@@ -22,16 +22,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let rows <- (arr |> take(TAKE_N))
-        b |> accept(rows)
-        if (empty(rows)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -57,11 +47,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def take_count_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def take_count_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -6,20 +6,12 @@ require _common public
 let TAKE_N = 1000
 let THRESHOLD = 500
 
-// `_sql` rejects `take(n) |> count()` (LIMIT-before-aggregate collapses to one row regardless
-// in SQLite), so the m1 variant is omitted. m3/m3f filter + bound + count over the
-// array. Exercises counter-lane take splice with an upstream `where` predicate.
+// `_sql` rejects `take(n) |> count()` — semantic mismatch: in SQL, LIMIT after an
+// aggregate has no effect (aggregate collapses to one row), so the bound-then-count
+// shape has no faithful SQL translation. [By design — no follow-up TODO.] Array and
+// Decs lanes filter + bound + count over the source; exercises counter-lane take
+// splice with an upstream `where` predicate.
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let c = arr |> _where(_.price > THRESHOLD) |> take(TAKE_N) |> count()
-        b |> accept(c)
-        if (c == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -40,11 +32,6 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
-}
-
-[benchmark]
-def take_count_filtered_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -5,21 +5,13 @@ require _common public
 
 let TAKE_N = 1000
 
-// `_sql` rejects `take(n) |> sum()` (LIMIT-before-aggregate has no effect in SQLite — aggregate
-// collapses to one row regardless), so the m1 variant is omitted. m3/m3f bound the
-// projection-sum loop to the first TAKE_N matched elements (no upstream where here, so
-// "matched" == "every source element"). Exercises accumulator-lane take splice in _fold.
+// `_sql` rejects `take(n) |> sum()` — semantic mismatch: in SQL, LIMIT after an
+// aggregate has no effect (aggregate collapses to one row), so the bound-then-sum
+// shape has no faithful SQL translation. [By design — no follow-up TODO.] Array and
+// Decs lanes bound the projection-sum loop to the first TAKE_N matched elements
+// (no upstream where here, so "matched" == "every source element"). Exercises
+// accumulator-lane take splice in _fold.
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let s = arr |> _select(_.price) |> take(TAKE_N) |> sum()
-        b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -40,11 +32,6 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
-}
-
-[benchmark]
-def take_sum_aggregate_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_while_match.das
+++ b/benchmarks/sql/take_while_match.das
@@ -8,9 +8,8 @@ require _common public
 // so splice visits only the prefix.
 //
 // SQL: `SELECT COUNT(*) FROM Cars WHERE id < THRESHOLD` — query planner uses pk index.
-// m3 materializes the prefix as `array<Car>` then `|> count` reads its length.
-// m3f splice walks the prefix, breaks on the first false, counts via in-loop accumulator
-// (no buffer allocation).
+// Array and Decs lanes walk the prefix, break on the first false, count via in-loop
+// accumulator (no buffer allocation).
 
 let THRESHOLD = 50000
 
@@ -27,16 +26,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let total = arr |> _take_while(_.id < THRESHOLD) |> count()
-        b |> accept(total)
-        if (total == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -62,11 +51,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def take_while_match_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def take_while_match_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/to_array_filter.das
+++ b/benchmarks/sql/to_array_filter.das
@@ -21,16 +21,6 @@ def run_m1(b : B?; n : int) {
     }
 }
 
-def run_m3(b : B?; n : int) {
-    let arr <- fixture_array(n)
-    b |> run("m3_array/{n}", n) {
-        let prices <- (arr |> _where(_.price > THRESHOLD) |> _select(_.price))
-        b |> accept(prices)
-        if (empty(prices)) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
     b |> run("m3f_array_fold/{n}", n) {
@@ -56,11 +46,6 @@ def run_m4(b : B?; n : int) {
 [benchmark]
 def to_array_filter_m1(b : B?) {
     run_m1(b, 100000)
-}
-
-[benchmark]
-def to_array_filter_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/zip_dot_product.das
+++ b/benchmarks/sql/zip_dot_product.das
@@ -4,11 +4,11 @@ options persistent_heap
 require _common public
 
 // zip(a, b) |> select(t => t._0 * t._1) |> sum — dot product of two int sequences.
-// No clean SQL form (zip is not a natural relational operation), so m1 is omitted.
-// Splice mode should fuse zip + select + sum into a single accumulator loop.
-// m4 is the intra-archetype analogue: two int components on the same DecsCar entity
-// (price * year), summed over all entities. Wave 4 pruning keeps only those two
-// get_ro slots, so per-element cost matches the m3f two-column read.
+// No clean SQL form (zip is not a natural relational operation), so the SQL lane is
+// omitted. Splice mode fuses zip + select + sum into a single accumulator loop.
+// The Decs lane is the intra-archetype analogue: two int components on the same
+// DecsCar entity (price * year), summed over all entities. Wave 4 pruning keeps
+// only those two get_ro slots, so per-element cost matches the Array two-column read.
 
 def make_ints(n : int) : array<int> {
     var a : array<int>
@@ -19,17 +19,6 @@ def make_ints(n : int) : array<int> {
     return <- a
 }
 
-def run_m3(b : B?; n : int) {
-    let xs <- make_ints(n)
-    let ys <- make_ints(n)
-    b |> run("m3_array/{n}", n) {
-        let s = (zip(xs, ys) |> _select(_._0 * _._1) |> sum())
-        b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
-    }
-}
 def run_m3f(b : B?; n : int) {
     let xs <- make_ints(n)
     let ys <- make_ints(n)
@@ -51,11 +40,6 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
-}
-
-[benchmark]
-def zip_dot_product_m3(b : B?) {
-    run_m3(b, 100000)
 }
 
 [benchmark]

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -27,4 +27,5 @@ THE SOFTWARE.
    embedding.rst
    utils.rst
    tutorials.rst
+   linq_fold_patterns.rst
    strudel_vs_strudel_cc.rst

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -1,0 +1,237 @@
+.. _linq_fold_patterns:
+
+==================================================================
+LINQ-fold patterns — what ``_fold(...)`` recognizes
+==================================================================
+
+This is a catalog of every chain shape that the ``_fold`` macro
+splices into a specialized loop. Each row names a chain pattern, the
+splice arm in ``daslib/linq_fold.das`` it dispatches to, and a short
+note on the emitted loop's shape.
+
+Pipelines that don't match any row here fall through to the default
+``fold_linq_default`` path, which lowers via the standard
+iterator-materializing surface (the same code path as the
+non-spliced linq calls).
+
+For the corresponding tutorial, see :ref:`tutorial_linq_decs`. For
+nanosecond-level cost comparisons across the SQL / Array / Decs lanes,
+see ``benchmarks/sql/results.md`` in the source tree.
+
+How dispatch works
+==================
+
+``_fold`` walks the chain inside-out (terminator first), flattens the
+``ExprCall`` spine via ``flatten_linq``, and hands the whole thing to
+one of the ``plan_*`` functions below. Each ``plan_*`` either returns
+a specialized expression (the splice) or ``null`` (defer to the
+default). The first non-null wins.
+
+The dispatch order — in priority — is:
+
+1. **Decs source** (the source is ``from_decs_template(type<T>)`` or
+   ``from_decs(...)``): ``plan_decs_unroll``,
+   ``plan_decs_group_by``, ``plan_decs_order_family``,
+   ``plan_decs_reverse``, ``plan_decs_distinct``. Decs splices write
+   ``for_each_archetype`` walks; the per-element body reads components
+   directly out of archetype storage.
+2. **Zip source** (``zip(a, b).<...>``): ``plan_zip``. Fuses zip +
+   select + count/sum into a single accumulator loop indexed by the
+   shorter side.
+3. **Array source** with order-family: ``plan_order_family``.
+4. **Array source** with distinct/distinct_by: ``plan_distinct``.
+5. **Array source** with reverse: ``plan_reverse``.
+6. **Array source** with group_by: ``plan_group_by`` →
+   ``plan_group_by_core``.
+7. **Generic array loop**: ``plan_loop_or_count`` — the
+   ``where/select/skip/take + count/sum/aggregate`` workhorse.
+
+Source-side entry points
+========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Source
+     - Recognized by
+     - Note
+   * - ``each(array<T>)``
+     - ``peel_each``
+     - Strips the ``each`` wrapper; subsequent chain plans see the raw ``array<T>`` source.
+   * - ``zip(a, b)`` / ``zip(a, b, c)``
+     - ``plan_zip``
+     - Two- or three-source zip. Splice fuses zip + select + aggregate.
+   * - ``from_decs_template(type<T>)``
+     - ``plan_decs_unroll`` etc.
+     - Surfaces a ``[decs_template]`` schema. Decs splices fire.
+   * - ``from_decs(...)``
+     - ``plan_decs_unroll`` etc.
+     - Runtime component-name list form. Same decs splices as the template form.
+
+Array-source patterns
+=====================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Chain shape
+     - Splice arm
+     - Notes
+   * - ``.count()`` / ``.long_count()``
+     - ``emit_length_shortcut``
+     - O(1) length read when the source has a known length.
+   * - ``._where(P).count()`` / ``.long_count()``
+     - ``plan_loop_or_count`` → ``emit_counter_lane``
+     - Per-archetype counter, no allocation.
+   * - ``._where(P)._select(F).sum()`` / ``.average()`` / ``.min()`` / ``.max()`` / ``.aggregate(seed, op)``
+     - ``plan_loop_or_count`` → ``emit_accumulator_lane``
+     - Single-pass scalar reduce; ``where`` and ``select`` fuse into the body.
+   * - ``._where(P)._select(F).min_by(K)`` / ``.max_by(K)`` / ``.min_max()`` / ``.min_max_by(K)`` / ``.min_max_average()`` / ``.min_max_average_by(K)``
+     - ``plan_loop_or_count`` → ``emit_accumulator_lane``
+     - Multi-output reduce; one scalar per output kept in the loop's state.
+   * - ``._where(P).first()`` / ``.first_or_default()`` / ``.last()`` / ``.last_or_default()`` / ``.single()`` / ``.single_or_default()`` / ``.element_at(N)`` / ``.element_at_or_default(N)`` / ``.aggregate(...)``
+     - ``plan_loop_or_count`` → ``emit_early_exit_lane``
+     - Early-exit terminator; loop breaks on first match (``first``), counts to N (``element_at``), or carries-last (``last`` / ``aggregate``).
+   * - ``._where(P).any()`` / ``.all(P)`` / ``.contains(V)``
+     - ``plan_loop_or_count`` → ``emit_any_empty_shortcut``
+     - Boolean fast-path; loop exits on first hit (``any``/``contains``) or first miss (``all``).
+   * - ``._where(P).take(N).count()`` / ``.sum()``
+     - ``plan_loop_or_count`` (counter / accumulator with ``takeExpr``)
+     - Bounded counter/accumulator; loop exits at N matches.
+   * - ``._where(P).take_while(P2).<...>`` / ``.skip_while(P2).<...>``
+     - ``plan_loop_or_count`` (predicate-driven ranges)
+     - ``take_while`` exits on first non-match; ``skip_while`` toggles state.
+   * - ``._order_by(K).first()`` / ``.first_or_default()``
+     - ``plan_order_family`` (streaming-min)
+     - Single ``var best`` + ``var seen``, no buffer; one comparison per element.
+   * - ``._order_by(K).take(N).to_array()``
+     - ``plan_order_family`` (bounded-heap)
+     - ``spliced_push_heap`` fill + replace, ``spliced_pop_heap`` on replace, ``order_inplace`` at end. Buffer of size N.
+   * - ``._order_by(K).to_array()`` / ``.order_by_descending(K).to_array()`` / ``.order(K).to_array()`` / ``.order_descending(K).to_array()``
+     - ``plan_order_family`` (full-sort fallback)
+     - Materializes + sorts. No bounded-heap shortcut.
+   * - ``._distinct()`` / ``._distinct_by(K)`` followed by ``.count()`` / ``.to_array()``
+     - ``plan_distinct``
+     - Single-hash set lane; ``count`` reads ``length(set)``.
+   * - ``._group_by(K)._select(reduce).to_array()``
+     - ``plan_group_by_core`` → ``emit_reducer_branches``
+     - Per-key bucket reducer; single hash, one entry per group.
+   * - ``._group_by(K)._having(P)._select(...).to_array()``
+     - ``plan_group_by`` → ``plan_group_by_core``
+     - HAVING filter applied after the per-key reduce.
+   * - ``.reverse().take(N).to_array()`` (with no ``where`` / ``select``)
+     - ``plan_reverse`` (two-pass)
+     - Sum archetype sizes, then walk tail-first with skip-counter and early-exit.
+
+Decs-source patterns
+====================
+
+Every array pattern above has a decs mirror that walks each archetype
+of ``T``'s template instead of iterating the array. The body shape is
+identical — only the source iteration changes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Chain shape (decs source)
+     - Splice arm
+     - Notes
+   * - ``from_decs_template(type<T>)._where(P).count()``
+     - ``plan_decs_unroll`` → ``emit_decs_count_archsize``
+     - Sums archetype sizes when ``where`` is absent; counter loop otherwise.
+   * - ``from_decs_template(...)._select(F).sum()`` / ``.average()`` / ``.min()`` / ``.max()`` / ``.aggregate(...)``
+     - ``plan_decs_unroll`` → ``emit_decs_accumulator``
+     - Per-archetype accumulator; pruner keeps only the components read by ``F``.
+   * - ``from_decs_template(...).first()`` / ``.first_or_default()`` / ``.last()`` / ``.last_or_default()`` / ``.single()`` / ``.single_or_default()`` / ``.element_at(N)`` / ``.element_at_or_default(N)`` / ``.aggregate(...)``
+     - ``plan_decs_unroll`` → ``emit_decs_walk_lane`` / ``emit_decs_element_at``
+     - Walk lane reads one component per loop iteration; element_at uses cumulative-size short-circuit.
+   * - ``from_decs_template(...).any()`` / ``.all(P)`` / ``.contains(V)``
+     - ``plan_decs_unroll`` → ``emit_decs_early_exit``
+     - Boolean fast-path; walks until first match or end.
+   * - ``from_decs_template(...).to_array()``
+     - ``plan_decs_unroll`` → ``emit_decs_to_array``
+     - Concatenates archetype slices; one allocation sized by ``sum(arch.size)``.
+   * - ``from_decs_template(...)._order_by(K).first()`` / ``.first_or_default()``
+     - ``plan_decs_order_family`` (streaming-min)
+     - Single ``var best`` + ``var seen`` across archetypes.
+   * - ``from_decs_template(...)._order_by(K).take(N).to_array()``
+     - ``plan_decs_order_family`` (bounded-heap)
+     - Same heap pattern as the array variant; buffer size N.
+   * - ``from_decs_template(...).min_by(K)`` / ``.max_by(K)``
+     - ``plan_decs_unroll`` → ``emit_decs_min_max_by``
+     - Streaming-min/max with key.
+   * - ``from_decs_template(...)._distinct()`` / ``._distinct_by(K)``
+     - ``plan_decs_distinct``
+     - Single-hash set lane mirroring ``plan_distinct``.
+   * - ``from_decs_template(...).reverse().take(N).to_array()``
+     - ``plan_decs_reverse``
+     - Whole-archetype skip + partial-archetype skip-counter + early-exit.
+   * - ``from_decs_template(...)._group_by(K)._select(reduce).to_array()``
+     - ``plan_decs_group_by`` → ``plan_group_by_core``
+     - Shared bucket-reducer with the array path; differs only in the per-element source.
+   * - ``from_decs_template(...)._take_while(P).<...>`` / ``._skip_while(P).<...>``
+     - ``plan_decs_unroll`` (predicate-driven ranges)
+     - Hoists ``skippingName`` state across archetypes.
+
+Zip patterns
+============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Chain shape
+     - Splice arm
+     - Notes
+   * - ``zip(a, b)._select(F).sum()`` / ``.count()`` / ``.average()``
+     - ``plan_zip``
+     - Fuses to a single index-loop over the shorter side.
+   * - ``zip(a, b, c)._select(F).<terminator>``
+     - ``plan_zip``
+     - Three-source zip; same loop shape with three reads per iteration.
+   * - ``zip(a, b)._where(P)._select(F).<terminator>``
+     - ``plan_zip`` (chain ops)
+     - ``where`` / ``select`` / ``take`` / ``skip`` / ``take_while`` / ``skip_while`` between zip and the terminator are all fused.
+   * - ``zip(a, b).first()`` / ``.first_or_default()`` / ``.aggregate(...)``
+     - ``plan_zip`` (early-exit / accumulator)
+     - Early-exit terminator on the zipped pair.
+
+What falls back
+===============
+
+The default path (``fold_linq_default``) fires when none of the
+``plan_*`` arms recognize the chain. This is the standard linq surface
+— iterators materialize, callbacks fire, and there is no fusion.
+
+Common cases that fall back:
+
+- **Mixed-source operators** like ``union(a, b)``, ``except(a, b)``,
+  ``intersect(a, b)``, ``concat(a, b)`` after the first source has
+  been transformed (e.g. ``each(a)._select(F).union(b)``).
+- **Join terminators**: ``_join`` / ``_left_join`` / ``_right_join`` /
+  ``_full_outer_join`` / ``_cross_join``. The join itself does not yet
+  splice; downstream ``.count()`` / ``.sum()`` chains fall back.
+- **Aggregations on lazy groupings**: ``_group_by_lazy(K)._select(F)``
+  with a non-bucket-reducing ``_select``.
+- **Materialization-only chains** that the standard linq surface
+  already lowers efficiently — e.g. ``to_table()`` on a finite array.
+
+When a chain falls back, behavior is identical to writing the same
+chain without ``_fold`` — correct, but not splice-fused.
+
+See also
+========
+
+* :ref:`tutorial_linq_decs` — using ``from_decs_template`` and
+  ``_fold`` over decs entities.
+* :ref:`tutorial_linq` — the underlying linq surface (``where``,
+  ``select``, ``order_by``, etc.) and the ``_fold`` macro.
+* :doc:`/stdlib/generated/linq_fold` — the ``linq_fold`` module
+  reference (the two public macros ``_fold`` and ``_old_fold``).
+* :doc:`/stdlib/generated/linq` — the full linq surface.
+* :doc:`/stdlib/generated/linq_boost` — the shorthand macros
+  (``_where``, ``_select``, ``_order_by``, etc.) and the surrounding
+  macro family.

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -23,28 +23,36 @@ How dispatch works
 
 ``_fold`` walks the chain inside-out (terminator first), flattens the
 ``ExprCall`` spine via ``flatten_linq``, and hands the whole thing to
-one of the ``plan_*`` functions below. Each ``plan_*`` either returns
-a specialized expression (the splice) or ``null`` (defer to the
-default). The first non-null wins.
+each ``plan_*`` function below in turn. Each ``plan_*`` either returns
+a specialized expression (the splice) or ``null`` (defer to the next).
+The first non-null wins.
 
-The dispatch order — in priority — is:
+The dispatch order in ``LinqFold.visit`` (``daslib/linq_fold.das``) is:
 
-1. **Decs source** (the source is ``from_decs_template(type<T>)`` or
-   ``from_decs(...)``): ``plan_decs_unroll``,
-   ``plan_decs_group_by``, ``plan_decs_order_family``,
-   ``plan_decs_reverse``, ``plan_decs_distinct``. Decs splices write
-   ``for_each_archetype`` walks; the per-element body reads components
-   directly out of archetype storage.
-2. **Zip source** (``zip(a, b).<...>``): ``plan_zip``. Fuses zip +
-   select + count/sum into a single accumulator loop indexed by the
-   shorter side.
-3. **Array source** with order-family: ``plan_order_family``.
-4. **Array source** with distinct/distinct_by: ``plan_distinct``.
-5. **Array source** with reverse: ``plan_reverse``.
-6. **Array source** with group_by: ``plan_group_by`` →
-   ``plan_group_by_core``.
-7. **Generic array loop**: ``plan_loop_or_count`` — the
-   ``where/select/skip/take + count/sum/aggregate`` workhorse.
+1. ``plan_decs_order_family`` — decs source with order family.
+2. ``plan_order_family`` — array source with order family.
+3. ``plan_decs_reverse`` — decs source with ``reverse``.
+4. ``plan_reverse`` — array source with ``reverse``.
+5. ``plan_decs_distinct`` — decs source with ``distinct``/``distinct_by``.
+6. ``plan_distinct`` — array source with ``distinct``/``distinct_by``.
+7. ``plan_decs_group_by`` — decs source with ``group_by`` (dispatches
+   to the shared ``plan_group_by_core``).
+8. ``plan_group_by`` — array source with ``group_by`` (same shared core).
+9. ``plan_decs_unroll`` — generic decs walk
+   (``where``/``select``/``skip``/``take`` + counter / accumulator /
+   early-exit / walk lane).
+10. ``plan_zip`` — ``zip(a, b)`` source.
+11. ``plan_loop_or_count`` — generic array walk
+    (``where``/``select``/``skip``/``take`` + counter / accumulator /
+    early-exit terminator).
+12. ``fold_linq_default`` — fallback, no splice.
+
+The decs and array variants are interleaved (each decs plan runs
+before its array counterpart) because a chain starting with
+``from_decs_template(...)`` must hit the decs splice — falling through
+to the array plan would not match and would force the default. The
+generic decs walk (``plan_decs_unroll``) runs after the specialized
+decs plans so it doesn't shadow them.
 
 Source-side entry points
 ========================
@@ -84,7 +92,7 @@ Array-source patterns
      - O(1) length read when the source has a known length.
    * - ``._where(P).count()`` / ``.long_count()``
      - ``plan_loop_or_count`` → ``emit_counter_lane``
-     - Per-archetype counter, no allocation.
+     - Single counter, no allocation; one pass over the array.
    * - ``._where(P)._select(F).sum()`` / ``.average()`` / ``.min()`` / ``.max()`` / ``.aggregate(seed, op)``
      - ``plan_loop_or_count`` → ``emit_accumulator_lane``
      - Single-pass scalar reduce; ``where`` and ``select`` fuse into the body.

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -83,6 +83,7 @@ introduced in earlier tutorials.
    tutorials/52_option_and_result.rst
    tutorials/53_clargs.rst
    tutorials/54_glob.rst
+   tutorials/55_linq_decs.rst
 
 .. _tutorials_building_from_sdk:
 

--- a/doc/source/reference/tutorials/55_linq_decs.rst
+++ b/doc/source/reference/tutorials/55_linq_decs.rst
@@ -6,7 +6,6 @@ LINQ over DECS
 
 .. index::
     single: Tutorial; LINQ over DECS
-    single: Tutorial; from_decs
     single: Tutorial; from_decs_template
     single: Tutorial; _fold over decs
     single: Tutorial; decs splice
@@ -16,6 +15,8 @@ This tutorial covers ``daslib/linq_fold``'s decs lane — how a
 ``from_decs_template(type<T>)``, and how the ``_fold`` macro splices
 ``where`` / ``select`` / ``order_by`` / ``group_by`` chains into a
 single per-archetype walk without materializing intermediate iterators.
+The runtime component-name variant (``from_decs(...)``) is out of
+scope here — see the ``decs_boost`` module reference.
 
 It assumes you have read :ref:`tutorial_linq` (the linq surface and the
 ``_fold`` macro) and :ref:`tutorial_decs` (entities, components, queries,

--- a/doc/source/reference/tutorials/55_linq_decs.rst
+++ b/doc/source/reference/tutorials/55_linq_decs.rst
@@ -1,0 +1,154 @@
+.. _tutorial_linq_decs:
+
+==========================================
+LINQ over DECS
+==========================================
+
+.. index::
+    single: Tutorial; LINQ over DECS
+    single: Tutorial; from_decs
+    single: Tutorial; from_decs_template
+    single: Tutorial; _fold over decs
+    single: Tutorial; decs splice
+
+This tutorial covers ``daslib/linq_fold``'s decs lane — how a
+``[decs_template]`` schema becomes a linq source via
+``from_decs_template(type<T>)``, and how the ``_fold`` macro splices
+``where`` / ``select`` / ``order_by`` / ``group_by`` chains into a
+single per-archetype walk without materializing intermediate iterators.
+
+It assumes you have read :ref:`tutorial_linq` (the linq surface and the
+``_fold`` macro) and :ref:`tutorial_decs` (entities, components, queries,
+``[decs_template]``).
+
+Setup
+=====
+
+.. code-block:: das
+
+    options gen2
+    options persistent_heap
+
+    require daslib/decs_boost
+    require daslib/linq
+    require daslib/linq_boost
+    require daslib/linq_fold
+
+    [decs_template(prefix = "car_")]
+    struct Car {
+        id    : int
+        price : int
+        brand : int
+    }
+
+The ``prefix`` argument controls the component-name prefix decs uses
+internally — every ``Car`` field becomes a ``car_*`` component
+(``car_id``, ``car_price``, ``car_brand``). The prefix is what lets
+``from_decs_template`` find the right components on every archetype that
+carries the template.
+
+``from_decs_template`` — entry point
+=====================================
+
+``from_decs_template(type<T>)`` opens the live decs state as a linq
+source whose element type is a tuple matching ``T``'s field shape. The
+macro walks every archetype that carries the template's components — so
+adding more components to some entities later still leaves the older
+archetypes matchable.
+
+.. code-block:: das
+
+    let total = _fold(from_decs_template(type<Car>).count())
+    print("total cars: {total}\n")
+    // output: total cars: 20
+
+``_fold`` splices the chain
+============================
+
+``_fold`` rewrites a chain like
+``from_decs_template(...)._where(...).count()`` into a single
+``for_each_archetype`` walk. There is no intermediate array, no
+iterator allocation — the splice runs the per-archetype walk and
+accumulates inline.
+
+.. code-block:: das
+
+    let pricy = _fold(from_decs_template(type<Car>)._where(_.price > 50).count())
+    print("cars with price > 50: {pricy}\n")
+    // output: cars with price > 50: 9
+
+``order_by`` + ``first`` — streaming-min
+========================================
+
+``_order_by(KEY).first()`` is recognized as a *streaming-min*: the
+splice keeps a single ``var best`` + ``var seen`` per walk, no buffer
+at all. The dual shape ``_order_by(KEY).take(N)`` keeps a bounded heap
+of size N.
+
+.. code-block:: das
+
+    let cheapest = _fold(from_decs_template(type<Car>)._order_by(_.price).first())
+    print("cheapest car: id={cheapest.id} price={cheapest.price}\n")
+    // output: cheapest car: id=1 price=0
+
+.. code-block:: das
+
+    let top3 <- _fold(from_decs_template(type<Car>)._order_by(_.price).take(3).to_array())
+    for (c in top3) {
+        print("  id={c.id} price={c.price}\n")
+    }
+    // output:
+    //   id=1 price=0
+    //   id=20 price=3
+    //   id=12 price=7
+
+``group_by`` + ``select``
+==========================
+
+``_group_by(KEY)`` produces one bucket per distinct key. A follow-up
+``_select`` reads ``_._0`` (the key) and ``_._1`` (the bucket) — typical
+SQL "GROUP BY brand, take one example row" shape.
+
+.. code-block:: das
+
+    let bybrand <- _fold(from_decs_template(type<Car>)
+                          ._group_by(_.brand)
+                          ._select((Brand = _._0, FirstCar = _._1 |> first()))
+                          .to_array())
+    for (g in bybrand) {
+        print("  brand {g.Brand}: first id={g.FirstCar.id} price={g.FirstCar.price}\n")
+    }
+    // output (order may vary across hash iterations):
+    //   brand 0: first id=1 price=0
+    //   brand 4: first id=5 price=48
+    //   brand 3: first id=4 price=11
+    //   brand 2: first id=3 price=74
+    //   brand 1: first id=2 price=37
+
+When to reach for the decs lane
+================================
+
+Use ``from_decs_template`` (the decs lane) when the data already lives
+as decs entities — you avoid the array copy. Use ``each(arr)`` (the
+array lane) when you start from an ``array<T>`` you already built. The
+fold splice is shape-aware: it picks the per-element representation
+that matches the source, so the per-element cost is similar across the
+two lanes for most chains.
+
+The cross-lane numbers (SQL / Array / Decs) over the full chain catalog
+live in ``benchmarks/sql/results.md`` in the source tree.
+
+.. seealso::
+
+   :doc:`/reference/linq_fold_patterns` — catalog of chain shapes
+   that ``_fold`` recognizes, and the splice arm each one fires.
+
+   :ref:`tutorial_linq` — the underlying linq surface and the
+   ``_fold`` macro.
+
+   :ref:`tutorial_decs` — entities, components, queries,
+   ``[decs_template]``.
+
+   Full source: :download:`tutorials/language/55_linq_decs.das <../../../../tutorials/language/55_linq_decs.das>`
+
+   Previous tutorial: :ref:`tutorial_glob`

--- a/doc/source/stdlib/handmade/module-linq_fold.rst
+++ b/doc/source/stdlib/handmade/module-linq_fold.rst
@@ -13,6 +13,12 @@ change.
 See also :doc:`linq` for the underlying query operations and
 :doc:`linq_boost` for the surrounding macro family.
 
+.. seealso::
+
+   :doc:`/reference/linq_fold_patterns`
+       Catalog of chain shapes that ``_fold`` recognizes, and the
+       splice arm each one fires.
+
 All functions and symbols are in "linq_fold" module, use require to get
 access to it.
 

--- a/tutorials/language/55_linq_decs.das
+++ b/tutorials/language/55_linq_decs.das
@@ -2,7 +2,6 @@
 //
 // This tutorial covers:
 //   - from_decs_template — exposes a [decs_template] type as a linq source
-//   - from_decs — same, but driven by a runtime list of component names
 //   - _fold over decs — single-pass per-archetype walks (no intermediate array)
 //   - Canonical fold shapes: where + count, order_by + first, group_by + select
 //   - When to reach for the decs lane vs an in-memory array lane

--- a/tutorials/language/55_linq_decs.das
+++ b/tutorials/language/55_linq_decs.das
@@ -1,0 +1,142 @@
+// Tutorial 55: LINQ over DECS
+//
+// This tutorial covers:
+//   - from_decs_template — exposes a [decs_template] type as a linq source
+//   - from_decs — same, but driven by a runtime list of component names
+//   - _fold over decs — single-pass per-archetype walks (no intermediate array)
+//   - Canonical fold shapes: where + count, order_by + first, group_by + select
+//   - When to reach for the decs lane vs an in-memory array lane
+//
+// Prerequisites: tutorials/language/28_linq.das (the linq surface);
+//                tutorials/language/34_decs.das (decs entities/components).
+//
+// Run: daslang.exe tutorials/language/55_linq_decs.das
+
+options gen2
+options persistent_heap
+
+require daslib/decs_boost
+require daslib/linq
+require daslib/linq_boost
+require daslib/linq_fold
+
+// === Schema ===
+//
+// A [decs_template] struct gives the entity rows a stable column shape.
+// The `prefix` argument controls the component-name prefix decs uses
+// internally — here every Car field becomes a `car_*` component
+// (car_id, car_price, car_brand, ...). The prefix is what lets
+// `from_decs_template` find the right components per archetype.
+
+[decs_template(prefix = "car_")]
+struct Car {
+    id    : int
+    price : int
+    brand : int
+}
+
+def seed(n : int) {
+    restart()
+    create_entities(n) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        apply_decs_template(cmp, Car(
+            id    = i + 1,
+            price = (i * 37) % 100,
+            brand = i % 5
+        ))
+    }
+}
+
+[export]
+def main {
+    print("=== Tutorial 55: LINQ over DECS ===\n\n")
+
+    seed(20)
+
+    // ─── Section 1 — from_decs_template ─────────────────────────────────
+    //
+    // from_decs_template(type<T>) opens the live decs state as a linq source
+    // whose element type is a tuple matching T's field shape. The macro
+    // walks every archetype that carries the [decs_template]'s components,
+    // so adding new components later is fine — old archetypes still match.
+
+    print("--- 1. from_decs_template ---\n")
+    let total = _fold(from_decs_template(type<Car>).count())
+    print("total cars: {total}\n")
+    // output: total cars: 20
+
+    // ─── Section 2 — _fold splices the chain ────────────────────────────
+    //
+    // _fold rewrites a chain like `from_decs_template(...)._where(...).count()`
+    // into a single per-archetype walk. There is no intermediate array,
+    // no iterator allocation — the splice runs `for_each_archetype` and
+    // accumulates inline. Whatever a chain looks like, if there is a
+    // matching splice arm in linq_fold.das, the cost stays bounded.
+
+    print("\n--- 2. _fold + _where + count ---\n")
+    let pricy = _fold(from_decs_template(type<Car>)._where(_.price > 50).count())
+    print("cars with price > 50: {pricy}\n")
+    // output: cars with price > 50: 9
+
+    // ─── Section 3 — order_by + first (streaming-min) ───────────────────
+    //
+    // `_order_by(KEY).first()` is recognized as a streaming-min: the splice
+    // keeps a single `var best` + `var seen` per walk, no buffer at all.
+    // The dual `_order_by(KEY).take(N)` recognizes a bounded heap of N.
+
+    print("\n--- 3. _fold + _order_by + first ---\n")
+    let cheapest = _fold(from_decs_template(type<Car>)._order_by(_.price).first())
+    print("cheapest car: id={cheapest.id} price={cheapest.price}\n")
+    // output: cheapest car: id=1 price=0
+
+    print("\n--- 3b. _fold + _order_by + take(N) ---\n")
+    let top3 <- _fold(from_decs_template(type<Car>)._order_by(_.price).take(3).to_array())
+    for (c in top3) {
+        print("  id={c.id} price={c.price}\n")
+    }
+    // output:
+    //   id=1 price=0
+    //   id=20 price=3
+    //   id=12 price=7
+
+    // ─── Section 4 — group_by + select ──────────────────────────────────
+    //
+    // _group_by + _select fuses into a single-hash group + reduce. With
+    // a follow-up `to_array` the splice writes each bucket out once.
+
+    print("\n--- 4. _fold + _group_by + _select(first) ---\n")
+    //
+    // `_group_by(KEY)` produces one bucket per distinct key. A follow-up
+    // `_select` reads `_._0` (the key) and `_._1` (the bucket) — typical
+    // SQL "GROUP BY brand, take one example row" shape.
+    let bybrand <- _fold(from_decs_template(type<Car>)
+                          ._group_by(_.brand)
+                          ._select((Brand = _._0, FirstCar = _._1 |> first()))
+                          .to_array())
+    for (g in bybrand) {
+        print("  brand {g.Brand}: first id={g.FirstCar.id} price={g.FirstCar.price}\n")
+    }
+    // output (order may vary across hash iterations):
+    //   brand 0: first id=1 price=0
+    //   brand 4: first id=5 price=48
+    //   brand 3: first id=4 price=11
+    //   brand 2: first id=3 price=74
+    //   brand 1: first id=2 price=37
+
+    // ─── Section 5 — when to reach for the decs lane ────────────────────
+    //
+    // Use `from_decs_template` (the decs lane) when the data already lives
+    // as decs entities — you avoid the array copy. Use `each(arr)` (the
+    // array lane) when you're starting from an `array<T>` you already
+    // built. The fold splice is shape-aware: it picks the per-element
+    // representation that matches the source, so the per-element cost
+    // is similar across the two lanes for most chains.
+    //
+    // For the actual SQL / Array / Decs numbers across ~50 chain shapes,
+    // see benchmarks/sql/results.md.
+    //
+    // For the full catalog of what `_fold` recognizes (and what falls back
+    // to the iterator-materializing default), see
+    // doc/source/reference/linq_fold_patterns.rst.
+
+    print("\n=== End of Tutorial 55 ===\n")
+}


### PR DESCRIPTION
## Summary

Three threads, each on its own commit:

**Commit 1 — bench cleanup + results.md** (`benchmarks/sql/`, 54 files):

- Drops the `m3` eager-linq lane across all 52 bench files (the splice ladder closed the gap, m3 was no longer a useful comparison point). Also drops `sort_take`'s legacy `m3_topn_array` / `m3_topn_iter` algorithm-comparison wrappers.
- Backfills `join_count` SQL lane — sqlite_linq accepts the chain when the projection is a named tuple (`(CarName=c.name, DealerName=d.name)`). The existing comment about "db handle wiring" was wrong about the actual blocker.
- Refreshes the 5 keep-out comments with dated TODO markers quoting the actual `_sql` error each probe produced:
  - `distinct_by_count` — `_sql: unsupported chain root or operator. Got: __::linq` `` `distinct_by` `` `...`
  - `groupby_select_sum` — `_sql: _group_by: key must be ` ``_.Field`` ` or a tuple of` `` _.Field `` `s; got: (_ % 100)`
  - `groupby_first` — no SQL "first per group" without window-function lowering
  - `take_count_filtered` / `take_sum_aggregate` — LIMIT-on-aggregate is semantically distinct in SQL (by design, no follow-up)
  - `zip_dot_product` — zip is not a relational operation (by design)
- Decs lane for `join_count` stays absent — would need a Dealer `[decs_template]` + nested-archetype hash index. TODO referenced in the bench file and `results.md`.
- Adds [`benchmarks/sql/results.md`](benchmarks/sql/results.md) with two tables (INTERP + JIT) from master `1c8ff9119`, columns labeled SQL / Array / Decs (user-facing — drops the m1/m3f/m4 jargon), plus per-gap footnotes that quote each `.das` source comment verbatim.
- Fills in `benchmarks/README.md` sql/ section with a per-file table (was a one-line stub).

**Commit 2 — linq_decs tutorial** ([`tutorials/language/55_linq_decs.das`](tutorials/language/55_linq_decs.das) + [RST](doc/source/reference/tutorials/55_linq_decs.rst)):

Runnable, self-contained `[export] def main()` tutorial covering `from_decs_template`, the `_fold` splice over decs entities, and three canonical chain shapes (where+count, order_by+first streaming-min, group_by+select). Paired RST with standard label / seealso / download blocks; added to the language toctree after `54_glob`.

**Commit 2 also — linq-fold patterns reference** ([`doc/source/reference/linq_fold_patterns.rst`](doc/source/reference/linq_fold_patterns.rst)):

Lookup-oriented catalog of every chain shape that `_fold` recognizes, with the splice arm (`plan_*`/`emit_*` in `daslib/linq_fold.das`) each one fires. Organized by source type (array vs decs vs zip) plus a "what falls back" tail listing chains that drop to `fold_linq_default`. Linked from the reference toctree and from the handmade `module-linq_fold.rst` "See also" block (which feeds the generated `stdlib/generated/linq_fold.rst`).

## Follow-up TODOs spawned (none block this PR)

1. **sqlite_linq distinct/distinct_by lowering** — surfaced by `distinct_by_count` probe.
2. **sqlite_linq window-function lowering** — surfaced by `groupby_first` probe (would enable `ROW_NUMBER() OVER (PARTITION BY ...)`).
3. **sqlite_linq expression-key support in `_group_by`** — surfaced by `groupby_select_sum` probe.
4. **decs join / cross-archetype lookup machinery** in `plan_join` — surfaced by `join_count` decs-lane analysis.

## Test plan

- [ ] `for f in benchmarks/sql/*.das; do mcp__daslang__lint "$f"; done` — clean.
- [ ] `bin/daslang dastest/dastest.das -- --test benchmarks/sql/` — 0 errors, 0 tests, compile gate.
- [ ] INTERP bench reproduces the headline numbers in `results.md` (sort_first m4=13.4, m3f=11.0).
- [ ] JIT bench completes with 0 new failures (requires rebuilt `bin/daslang` — `host_jit_triple` was added recently).
- [ ] `bin/daslang tutorials/language/55_linq_decs.das` exits 0 with the expected print output.
- [ ] Clean Sphinx build: `rm -rf doc/sphinx-build site/doc && sphinx-build -b html -d doc/sphinx-build doc/source site/doc` — `build succeeded.` with no new warnings vs master.
- [ ] Generated `doc/source/stdlib/generated/linq_fold.rst` after `bin/daslang doc/reflections/das2rst.das` contains the `:doc:` link to `/reference/linq_fold_patterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)