### PR TITLE
pages.yml: downgrade emsdk pin 5.0.3 → 4.0.23

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,11 +77,16 @@ jobs:
       uses: emscripten-core/setup-emsdk@v11
       with:
         # Every emsdk pin snapshots LLVM main (not a release tag). 5.0.3
-        # resolves to clang 23.0.0git from 2026-03-13 — recent enough that
-        # the preprocessor has intermittently bus-errored on the bison-
-        # generated utils/dasFormatter/ds_parser.cpp. If that recurs we'll
-        # downgrade the family (4.0.23 ≈ pre-LLVM-22.1.0 main snapshot).
-        version: '5.0.3'
+        # resolved to clang 23.0.0git (2026-03-13 main snapshot) and
+        # repeatedly broke on the bison-generated
+        # utils/dasFormatter/ds_parser.cpp — bus-errors one run, EOF-inside-
+        # `#ifndef` parse errors the next, while native clang on the same
+        # runner compiled the same file fine. 4.0.23 is the last 4.x
+        # release (2026-01-10), pinning LLVM main from 2026-01-09 (pre-
+        # LLVM-22.1.0-release, roughly clang 22.0.0git) — far enough back
+        # to dodge the clang-23-preview preprocessor regression and the
+        # closest emsdk we have to dasLLVM's 22.1.5 pin.
+        version: '4.0.23'
 
     - name: "Build WASM (Emscripten) for /playground/ + /files/wasm/"
       run: |


### PR DESCRIPTION
## Summary

Follow-up to [#2842](https://github.com/GaijinEntertainment/daScript/pull/2842). Now that `continue-on-error: true` is gone from the WASM step, master's pages deploy is **red** — and the playground stays on the placeholder until we ship green again. This PR is the fix.

The 5.0.3 pin ships clang 23.0.0git (LLVM main snapshot from 2026-03-13), and that preview compiler has now failed on `utils/dasFormatter/ds_parser.cpp` two separate ways on the same runner SHA:

- Pages run [26345453541](https://github.com/GaijinEntertainment/daScript/actions/runs/26345453541) (2026-05-23 22:40, master `1c8ff9119`): `em++` bus-errored in `clang::Lexer::SkipBlockComment` at line 6484, `code=135` / SIGBUS.
- Pages run [26348244284](https://github.com/GaijinEntertainment/daScript/actions/runs/26348244284) (2026-05-24 01:11, master `bfb04c7de`): `em++` rejected `ds_parser.hpp` with "unterminated conditional directive" at line 38 (the `YY_DAS_YY_DS_PARSER_HPP_INCLUDED` include guard) and line 102 (`DAS_YYTOKENTYPE`) — both have matching `#endif` on disk. Native clang in step 1 of the SAME run compiled the same file fine 10 minutes earlier, so the file isn't corrupt — clang-23's preprocessor is.

## Changes

Pin `emscripten-core/setup-emsdk@v11` to `4.0.23` (the last 4.x release before the 5.0.x family cutover, 2026-01-10). It pins LLVM main from 2026-01-09 — pre-LLVM-22.1.0-release, roughly clang 22.0.0git. Months older than the preview clang 23 snapshot 5.0.3 was on, so it doesn't carry the preprocessor regression, and it's the closest emsdk we have to dasLLVM's 22.1.5 pin.

Comment block updated to record both failure modes + the rationale, so the next person bumping the pin knows why we're sitting on 4.0.23.

## Follow-up

The clang-23 preprocessor bug itself is worth a minimal repro at some point — happy to send upstream — but unblocking master comes first.

## Test plan

- [ ] PR CI green
- [ ] Trigger pages.yml manually (or wait for next merge to master) and confirm the WASM step builds end-to-end without continue-on-error
- [ ] Confirm `https://daslang.io/playground/index.html` serves the real Forge-skinned IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)