### PR TITLE
sqlite_linq: add long_count + _distinct_by dispatch arms

### DIFF
--- a/benchmarks/sql/distinct_by_count.das
+++ b/benchmarks/sql/distinct_by_count.das
@@ -4,18 +4,23 @@ options persistent_heap
 require _common public
 
 // _distinct_by(_.brand) |> count — count distinct brand values.
-// Exercises plan_group_by_core's peeled keyBlock + plan_distinct/_decs_distinct's
-// peeled distinctKeyBlock (the per-element `invoke(keyBlock, _)` is now a direct
-// field read). Companion to distinct_count which uses _select(_.brand).distinct()
-// on a pre-projected scalar — this one keeps the full source element and uses
-// distinct_by, the path that goes through the invoke-block-on-tuple shape.
-//
-// SQL: `SELECT COUNT(DISTINCT brand) FROM Cars` — sqlite_linq doesn't lower
-// `_distinct_by(...) |> count()`. [Follow-up TODO 2026-05-23: error[50503]
-// `_sql: unsupported chain root or operator. Got: __::linq\`distinct_by\`...` —
-// would need a new dispatch arm in sqlite_linq for distinct/distinct_by.]
+// SQL emits `COUNT(DISTINCT "brand")`; Array/Decs exercise plan_group_by_core's
+// peeled keyBlock + plan_distinct / _decs_distinct's peeled distinctKeyBlock.
 //
 // Expected result: BRAND_COUNT (5).
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let c = _sql(db |> select_from(type<Car>) |> _distinct_by(_.brand) |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
 
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -37,6 +42,11 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
+}
+
+[benchmark]
+def distinct_by_count_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -13,9 +13,9 @@ def run_m1(b : B?; n : int) {
     with_sqlite(":memory:") $(db) {
         fixture_db(db, n)
         b |> run("m1_sql/{n}", n) {
-            let c = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> count())
+            let c = _sql(db |> select_from(type<Car>) |> _where(_.price > THRESHOLD) |> long_count())
             b |> accept(c)
-            if (c == 0) {
+            if (c == 0l) {
                 b->failNow()
             }
         }

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,6 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-23 from master `1c8ff9119`. Fixture size: n = 100 000
+Generated 2026-05-23 from master `30021f183`. Fixture size: n = 100 000
 (cars), 100 dealers, 5 brands. Each row is one bench family in
 `benchmarks/sql/`; columns are nanoseconds per logical operation.
 `—` marks an intentionally absent lane — see "Notes on missing lanes"
@@ -26,114 +26,114 @@ before the timer resolution can measure them — they should be read as
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 35.1 | 6.0 | 5.9 | 0.98× |
-| `all_match` | 27.7 | 3.6 | 3.5 | 0.97× |
+| `aggregate_match` | 34.7 | 5.9 | 5.8 | 0.98× |
+| `all_match` | 27.6 | 3.5 | 3.4 | 0.97× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 31.2 | 5.8 | 8.7 | 1.50× |
-| `bare_order_where` | 274.0 | 118.4 | 126.3 | 1.07× |
-| `chained_where` | 36.4 | 8.3 | 8.0 | 0.96× |
-| `contains_match` | 0.00 | 2.3 | 1.4 | 0.61× |
-| `count_aggregate` | 29.7 | 4.1 | 4.1 | 1.00× |
-| `distinct_by_count` | — | 15.9 | 15.8 | 0.99× |
-| `distinct_count` | 41.2 | 16.0 | 15.8 | 0.99× |
+| `average_aggregate` | 29.9 | 5.8 | 8.7 | 1.50× |
+| `bare_order_where` | 274.4 | 117.6 | 125.5 | 1.07× |
+| `chained_where` | 36.2 | 6.7 | 6.6 | 0.99× |
+| `contains_match` | 0.00 | 2.2 | 1.4 | 0.64× |
+| `count_aggregate` | 29.4 | 4.1 | 4.1 | 1.00× |
+| `distinct_by_count` | 40.5 | 15.6 | 16.0 | 1.03× |
+| `distinct_count` | 41.1 | 15.9 | 15.8 | 0.99× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 174.3 | 30.2 | 30.1 | 1.00× |
-| `groupby_count` | 140.9 | 19.2 | 19.3 | 1.01× |
+| `groupby_average` | 170.0 | 30.1 | 30.1 | 1.00× |
+| `groupby_count` | 140.2 | 19.2 | 19.2 | 1.00× |
 | `groupby_first` | — | 18.4 | 19.1 | 1.04× |
-| `groupby_having_count` | 140.0 | 19.1 | 19.2 | 1.01× |
-| `groupby_having_hidden_sum` | 181.1 | 24.8 | 23.9 | 0.96× |
-| `groupby_max` | 173.8 | 24.9 | 25.2 | 1.01× |
-| `groupby_min` | 173.5 | 25.0 | 25.4 | 1.02× |
-| `groupby_multi_reducer` | 188.5 | 32.3 | 33.3 | 1.03× |
-| `groupby_select_sum` | — | 36.8 | 36.2 | 0.98× |
-| `groupby_sum` | 185.6 | 19.2 | 18.7 | 0.97× |
-| `groupby_where_count` | 75.9 | 14.6 | 14.9 | 1.02× |
-| `groupby_where_sum` | 86.6 | 14.5 | 14.6 | 1.01× |
-| `indexed_lookup` | 1449.1 | 203294.7 | 470.6 | 0.00× |
-| `join_count` | 38.2 | 122.1 | — | — |
-| `last_match` | 0.00 | 6.0 | 14.2 | 2.37× |
-| `long_count_aggregate` | 29.3 | 4.4 | 4.5 | 1.02× |
-| `max_aggregate` | 30.5 | 6.0 | 6.9 | 1.15× |
-| `min_aggregate` | 31.1 | 6.2 | 6.9 | 1.11× |
-| `order_take_desc` | 40.2 | 15.8 | 20.3 | 1.28× |
+| `groupby_having_count` | 140.4 | 19.5 | 19.2 | 0.98× |
+| `groupby_having_hidden_sum` | 173.9 | 24.3 | 24.0 | 0.99× |
+| `groupby_max` | 176.4 | 24.8 | 25.9 | 1.04× |
+| `groupby_min` | 172.1 | 24.8 | 25.2 | 1.02× |
+| `groupby_multi_reducer` | 188.7 | 32.3 | 32.3 | 1.00× |
+| `groupby_select_sum` | — | 36.5 | 36.0 | 0.99× |
+| `groupby_sum` | 173.7 | 18.6 | 18.6 | 1.00× |
+| `groupby_where_count` | 74.8 | 14.6 | 14.8 | 1.01× |
+| `groupby_where_sum` | 85.9 | 14.1 | 14.6 | 1.04× |
+| `indexed_lookup` | 1454.2 | 202887.8 | 479.4 | 0.00× |
+| `join_count` | 38.1 | 127.5 | — | — |
+| `last_match` | 0.00 | 6.2 | 14.0 | 2.26× |
+| `long_count_aggregate` | 29.4 | 4.2 | 4.0 | 0.95× |
+| `max_aggregate` | 30.8 | 6.0 | 6.9 | 1.15× |
+| `min_aggregate` | 30.8 | 6.1 | 6.9 | 1.13× |
+| `order_take_desc` | 37.9 | 15.8 | 19.9 | 1.26× |
 | `reverse_take` | 0.10 | 0.00 | 9.2 | — |
 | `select_count` | 0.10 | 0.00 | 2.2 | — |
-| `select_where` | 197.9 | 11.1 | 20.0 | 1.80× |
-| `select_where_count` | 33.7 | 5.2 | 7.4 | 1.42× |
-| `select_where_order_take` | 36.7 | 12.2 | 15.0 | 1.23× |
-| `select_where_sum` | 36.8 | 7.4 | 7.4 | 1.00× |
-| `single_match` | 0.00 | 3.0 | 5.5 | 1.83× |
+| `select_where` | 194.9 | 11.1 | 19.4 | 1.75× |
+| `select_where_count` | 32.4 | 5.2 | 7.4 | 1.42× |
+| `select_where_order_take` | 36.1 | 12.1 | 15.1 | 1.25× |
+| `select_where_sum` | 36.8 | 7.4 | 7.5 | 1.01× |
+| `single_match` | 0.00 | 2.9 | 5.4 | 1.86× |
 | `skip_take` | 0.50 | 0.10 | 0.20 | 2.00× |
-| `skip_while_match` | 3.6 | 5.2 | 5.3 | 1.02× |
-| `sort_first` | 38.5 | 11.0 | 13.4 | 1.22× |
-| `sort_take` | 37.6 | 16.3 | 20.5 | 1.26× |
-| `sum_aggregate` | 29.8 | 2.2 | 2.4 | 1.09× |
+| `skip_while_match` | 3.4 | 5.3 | 5.3 | 1.00× |
+| `sort_first` | 37.4 | 11.0 | 13.3 | 1.21× |
+| `sort_take` | 38.0 | 16.2 | 20.1 | 1.24× |
+| `sum_aggregate` | 29.7 | 2.1 | 2.1 | 1.00× |
 | `sum_where` | 32.8 | 4.2 | 4.3 | 1.02× |
 | `take_count` | 3.6 | 0.20 | 0.40 | 2.00× |
 | `take_count_filtered` | — | 0.20 | 0.20 | 1.00× |
 | `take_sum_aggregate` | — | 0.10 | 0.10 | 1.00× |
-| `take_while_match` | 8.0 | 2.4 | 2.5 | 1.04× |
-| `to_array_filter` | 70.5 | 11.8 | 11.7 | 0.99× |
-| `zip_dot_product` | — | 8.2 | 4.8 | 0.59× |
+| `take_while_match` | 7.9 | 2.4 | 2.5 | 1.04× |
+| `to_array_filter` | 69.9 | 11.7 | 11.7 | 1.00× |
+| `zip_dot_product` | — | 8.0 | 4.8 | 0.60× |
 
 ## JIT
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 215.7 | 4.4 | 7.4 | 1.68× |
-| `all_match` | 303.8 | 3.8 | 2.1 | 0.55× |
+| `aggregate_match` | 34.4 | 0.40 | 0.70 | 1.75× |
+| `all_match` | 27.4 | 0.30 | 0.20 | 0.67× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 51.4 | 1.6 | 5.9 | 3.69× |
-| `bare_order_where` | 383.2 | 66.3 | 66.0 | 1.00× |
-| `chained_where` | 79.6 | 1.3 | 1.9 | 1.46× |
-| `contains_match` | 0.00 | 0.40 | 0.20 | 0.50× |
-| `count_aggregate` | 57.8 | 0.80 | 1.2 | 1.50× |
-| `distinct_by_count` | — | 4.2 | 5.8 | 1.38× |
-| `distinct_count` | 76.3 | 3.9 | 4.0 | 1.03× |
+| `average_aggregate` | 30.0 | 1.0 | 3.5 | 3.50× |
+| `bare_order_where` | 183.7 | 33.5 | 34.7 | 1.04× |
+| `chained_where` | 35.8 | 0.60 | 0.80 | 1.33× |
+| `contains_match` | 0.00 | 0.20 | 0.10 | 0.50× |
+| `count_aggregate` | 29.5 | 0.30 | 0.60 | 2.00× |
+| `distinct_by_count` | 40.9 | 2.1 | 2.1 | 1.00× |
+| `distinct_count` | 41.1 | 2.1 | 2.1 | 1.00× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 172.9 | 2.6 | 2.9 | 1.12× |
-| `groupby_count` | 141.6 | 2.4 | 2.5 | 1.04× |
+| `groupby_average` | 170.0 | 2.6 | 2.9 | 1.12× |
+| `groupby_count` | 143.0 | 2.3 | 2.5 | 1.09× |
 | `groupby_first` | — | 2.2 | 3.1 | 1.41× |
-| `groupby_having_count` | 141.8 | 2.4 | 2.5 | 1.04× |
-| `groupby_having_hidden_sum` | 176.6 | 2.6 | 2.8 | 1.08× |
-| `groupby_max` | 174.4 | 2.4 | 2.7 | 1.13× |
-| `groupby_min` | 173.4 | 2.4 | 2.7 | 1.13× |
-| `groupby_multi_reducer` | 189.8 | 2.7 | 3.0 | 1.11× |
+| `groupby_having_count` | 139.6 | 2.3 | 2.5 | 1.09× |
+| `groupby_having_hidden_sum` | 173.4 | 2.5 | 2.8 | 1.12× |
+| `groupby_max` | 171.5 | 2.4 | 2.7 | 1.13× |
+| `groupby_min` | 172.8 | 2.4 | 2.7 | 1.13× |
+| `groupby_multi_reducer` | 187.7 | 2.7 | 2.9 | 1.07× |
 | `groupby_select_sum` | — | 3.2 | 3.7 | 1.16× |
-| `groupby_sum` | 171.9 | 2.4 | 2.7 | 1.13× |
-| `groupby_where_count` | 75.7 | 1.7 | 1.8 | 1.06× |
-| `groupby_where_sum` | 86.8 | 1.7 | 1.8 | 1.06× |
-| `indexed_lookup` | 1253.3 | 35303.2 | 103.9 | 0.00× |
-| `join_count` | 38.0 | 36.4 | — | — |
+| `groupby_sum` | 169.2 | 2.4 | 2.7 | 1.13× |
+| `groupby_where_count` | 75.0 | 1.7 | 1.8 | 1.06× |
+| `groupby_where_sum` | 85.9 | 1.7 | 1.8 | 1.06× |
+| `indexed_lookup` | 1228.9 | 34818.1 | 102.7 | 0.00× |
+| `join_count` | 38.0 | 35.8 | — | — |
 | `last_match` | 0.00 | 0.50 | 1.4 | 2.80× |
-| `long_count_aggregate` | 29.0 | 0.40 | 0.60 | 1.50× |
-| `max_aggregate` | 30.3 | 0.70 | 0.50 | 0.71× |
-| `min_aggregate` | 30.5 | 0.70 | 0.50 | 0.71× |
-| `order_take_desc` | 38.0 | 0.70 | 1.4 | 2.00× |
+| `long_count_aggregate` | 29.5 | 0.40 | 0.60 | 1.50× |
+| `max_aggregate` | 30.6 | 0.70 | 0.50 | 0.71× |
+| `min_aggregate` | 31.4 | 0.60 | 0.50 | 0.83× |
+| `order_take_desc` | 37.6 | 0.70 | 1.3 | 1.86× |
 | `reverse_take` | 0.00 | 0.00 | 1.1 | — |
 | `select_count` | 0.10 | 0.00 | 0.00 | — |
-| `select_where` | 105.6 | 4.2 | 5.5 | 1.31× |
-| `select_where_count` | 32.3 | 0.40 | 0.60 | 1.50× |
-| `select_where_order_take` | 36.2 | 0.70 | 1.4 | 2.00× |
-| `select_where_sum` | 36.8 | 0.50 | 0.60 | 1.20× |
+| `select_where` | 105.9 | 4.1 | 5.4 | 1.32× |
+| `select_where_count` | 32.4 | 0.40 | 0.60 | 1.50× |
+| `select_where_order_take` | 36.3 | 0.70 | 1.4 | 2.00× |
+| `select_where_sum` | 36.7 | 0.50 | 0.60 | 1.20× |
 | `single_match` | 0.00 | 0.40 | 1.1 | 2.75× |
 | `skip_take` | 0.30 | 0.00 | 0.00 | — |
-| `skip_while_match` | 3.5 | 0.40 | 0.40 | 1.00× |
-| `sort_first` | 37.9 | 0.40 | 1.3 | 3.25× |
-| `sort_take` | 38.5 | 0.70 | 1.4 | 2.00× |
-| `sum_aggregate` | 30.5 | 0.40 | 0.30 | 0.75× |
-| `sum_where` | 33.0 | 0.40 | 0.60 | 1.50× |
+| `skip_while_match` | 3.4 | 0.40 | 0.40 | 1.00× |
+| `sort_first` | 37.4 | 0.40 | 1.3 | 3.25× |
+| `sort_take` | 37.7 | 0.70 | 1.3 | 1.86× |
+| `sum_aggregate` | 29.7 | 0.40 | 0.30 | 0.75× |
+| `sum_where` | 32.4 | 0.40 | 0.60 | 1.50× |
 | `take_count` | 1.8 | 0.10 | 0.10 | 1.00× |
 | `take_count_filtered` | — | 0.00 | 0.00 | — |
 | `take_sum_aggregate` | — | 0.00 | 0.00 | — |
-| `take_while_match` | 8.0 | 0.20 | 0.30 | 1.50× |
-| `to_array_filter` | 48.0 | 3.3 | 3.4 | 1.03× |
+| `take_while_match` | 7.9 | 0.20 | 0.30 | 1.50× |
+| `to_array_filter` | 48.8 | 3.2 | 3.3 | 1.03× |
 | `zip_dot_product` | — | 0.50 | 0.50 | 1.00× |
 
 ## Notes on missing lanes (the `—` cells)
@@ -141,14 +141,6 @@ before the timer resolution can measure them — they should be read as
 The reasons each cell is empty are also recorded as a comment in the
 corresponding `.das` bench file; the bullets below quote that comment.
 
-- **`distinct_by_count` SQL** — sqlite_linq does not currently lower
-  `_distinct_by(...) |> count()`. Follow-up TODO 2026-05-23: add a
-  dispatch arm in sqlite_linq for distinct/distinct_by. Probe error:
-
-  ```
-  error[50503]: _sql: unsupported chain root or operator.
-    Got: __::linq`distinct_by`...
-  ```
 - **`groupby_first` SQL** — no direct SQL aggregator for "first
   source-order row per group". Window functions (`ROW_NUMBER() OVER
   (PARTITION BY brand ORDER BY id)` + outer `WHERE rn=1`) would be the

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -576,6 +576,70 @@ def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
     return true
 }
 
+// nolint:STYLE015 Receiver-pin to ExprVar rejects `u.opt.X` keys SQL can't reproduce.
+[macro_function]
+def private try_peel_distinct_by_field(var node : ExpressionPtr; var distinctSource : ExpressionPtr&;
+                                       var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
+    var dbCall = match_call_in_linq(node, "distinct_by")
+    if (dbCall == null) return ""
+    if (dbCall.arguments |> length != 2) {
+        macro_error(prog, at, "_sql: _distinct_by expects (prev, key)")
+        q.hadError = true
+        return ""
+    }
+    var body = peel_lambda_single_return(dbCall.arguments[1])
+    if (body == null) {
+        macro_error(prog, at, "_sql: _distinct_by key lambda has unexpected shape")
+        q.hadError = true
+        return ""
+    }
+    var receiver : ExpressionPtr
+    var fieldName : string
+    if (!qmatch(body, $e(receiver).$f(fieldName)).matched
+            || receiver == null || !(receiver is ExprVar)) {
+        macro_error(prog, at, "_sql: _distinct_by key must be `<arg>.<field>` (single column reference) — computed keys are not yet translatable to SQL")
+        q.hadError = true
+        return ""
+    }
+    distinctSource = dbCall.arguments[0]
+    return fieldName
+}
+
+// nolint:STYLE015 Shared `count` / `long_count` peeler — `isLong` widens binding to int64; recognizes `_distinct_by(_.col)` wrap.
+[macro_function]
+def private peel_count_terminal(var node : ExpressionPtr; var q : SqlQuery&;
+                                linqName : string; isLong : bool;
+                                prog : ProgramPtr; at : LineInfo) : bool {
+    var cCall = match_call_in_linq(node, linqName)
+    if (cCall == null) return false
+    if (q.seenTerminal || q.seenToArray) {
+        macro_error(prog, at, "_sql: only one terminal allowed per chain")
+        q.hadError = true
+        return true
+    }
+    if (cCall.arguments |> length != 1) {
+        macro_error(prog, at, "_sql: `_{linqName}(predicate)` is not yet supported — use `|> _where(predicate) |> _{linqName}()` instead")
+        q.hadError = true
+        return true
+    }
+    q.matr = Materializer.One
+    q.seenTerminal = true
+    q.proj = ProjectionShape.Aggregate
+    let countBaseType = isLong ? Type.tInt64 : Type.tInt
+    q.aggregateType = new TypeDecl(at = at, baseType = countBaseType)
+    var distinctSource : ExpressionPtr
+    let distinctField = try_peel_distinct_by_field(cCall.arguments[0], distinctSource, q, prog, at)
+    if (q.hadError) return true
+    if (!empty(distinctField)) {
+        if (!analyze_chain(distinctSource, q, prog, at)) return true
+        let sqlCol = field_to_column_name(q.rootType, distinctField)
+        q.aggregateExpr = "COUNT(DISTINCT \"{sqlCol}\")"
+        return true
+    }
+    q.aggregateExpr = "COUNT(*)"
+    return analyze_chain(cCall.arguments[0], q, prog, at)
+}
+
 [macro_function]
 def private extract_key_selector_field(var keyLambda : ExpressionPtr; expectedArgName : string;
                                        prog : ProgramPtr; at : LineInfo) : string {
@@ -1306,26 +1370,10 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(foCall.arguments[0], q, prog, at)
         }
     }
-    // Peel count(prev) — `|> _count()` → SELECT COUNT(*) ...
+    // Peel count(prev) / long_count(prev) → SELECT COUNT(*) (or COUNT(DISTINCT col) when fronted by `_distinct_by(_.col)`).
     {
-        var cCall = match_call_in_linq(node, "count")
-        if (cCall != null) {
-            if (q.seenTerminal || q.seenToArray) {
-                macro_error(prog, at, "_sql: only one terminal allowed per chain")
-                return false
-            }
-            if (cCall.arguments |> length != 1) {
-                macro_error(prog, at, "_sql: `_count(predicate)` is not yet supported — use `|> _where(predicate) |> _count()` instead")
-                return false
-            }
-            q.matr = Materializer.One
-            q.seenTerminal = true
-            q.proj = ProjectionShape.Aggregate
-            q.aggregateExpr = "COUNT(*)"
-            // Narrow SQLite int64 to daslang int — matches length()/count() return type.
-            q.aggregateType = new TypeDecl(at = at, baseType = Type.tInt)
-            return analyze_chain(cCall.arguments[0], q, prog, at)
-        }
+        if (peel_count_terminal(node, q, "count", false, prog, at)
+                || peel_count_terminal(node, q, "long_count", true, prog, at)) return !q.hadError
     }
     // ---- Column aggregates: sum / average / min / max ----
     {
@@ -2010,11 +2058,12 @@ def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery
         fname = string(call.func.fromGeneric.name)
     }
     let argc = user_arg_count(call)
-    // length(_._1) / count(_._1) → COUNT(*) (narrowed to int).
-    if ((fname == "length" || fname == "count") && argc == 1
+    // length / count / long_count of `_._1` → COUNT(*); long_count widens binding to int64.
+    if ((fname == "length" || fname == "count" || fname == "long_count") && argc == 1
             && qmatch(call.arguments[0], _._1).matched) {
         sqlOut = "COUNT(*)"
-        typeOut = new TypeDecl(at = at, baseType = Type.tInt)
+        let countBaseType = fname == "long_count" ? Type.tInt64 : Type.tInt
+        typeOut = new TypeDecl(at = at, baseType = countBaseType)
         return true
     }
     // sum/average/min/max over `_._1 |> select($(p:T)=>p.X)` → SUM("X") etc.

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -6,7 +6,7 @@ options gen2
 // some malformed chains additionally cascade real type errors before the
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field). Those cascades are expected.
-expect 30341, 30928:2, 50503:20
+expect 30341, 30928:2, 50503:21
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -139,6 +139,11 @@ def main() {
     //     accept the syntax but match on nothing useful. The fixit
     //     suggests `contains` (LIKE-based) or `[sql_fts5]`.
     let bad22 <- _sql(db |> select_from(type<Car>) |> _where(_.Name |> text_match("foo")))
+
+    // 23. `_distinct_by(<computed expr>)` before count() — only `<arg>.<field>`
+    //     keys lower to `COUNT(DISTINCT "col")`; computed keys like `_.Price %
+    //     100` would need a general expression-to-SQL emitter not yet wired.
+    let bad23 <- _sql(db |> select_from(type<Car>) |> _distinct_by(_.Price % 100) |> count())
     // (Note: the "_in subquery without _select(_.Col)" diagnostic added in
     //  this round is also belt-and-suspenders — a daslang `contains` type-
     //  check rejects mismatched element types before sqlite_linq even sees

--- a/tests/dasSQLITE/test_31_long_count_distinct_by_canary.das
+++ b/tests/dasSQLITE/test_31_long_count_distinct_by_canary.das
@@ -1,0 +1,99 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Brand : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> insert(Car(Id = 1, Brand = "BMW",   Price = 100))
+    db |> insert(Car(Id = 2, Brand = "Audi",  Price = 200))
+    db |> insert(Car(Id = 3, Brand = "BMW",   Price = 300))
+    db |> insert(Car(Id = 4, Brand = "Tesla", Price = 50))
+    db |> insert(Car(Id = 5, Brand = "BMW",   Price = 999))
+}
+
+[test]
+def test_long_count_returns_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = _sql(db |> select_from(type<Car>) |> long_count())
+        t |> equal(n, 5l, "5 rows total (int64)")
+    }
+}
+
+[test]
+def test_long_count_emits_count_star(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> long_count())
+    t |> equal(sql, "SELECT COUNT(*) FROM \"Cars\"", "long_count() emits COUNT(*)")
+}
+
+[test]
+def test_long_count_with_where(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = _sql(db |> select_from(type<Car>) |> _where(_.Price > 99) |> long_count())
+        t |> equal(n, 4l, "4 rows where Price > 99")
+    }
+}
+
+[test]
+def test_distinct_by_count_emits_count_distinct(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _distinct_by(_.Brand) |> count())
+    t |> equal(sql, "SELECT COUNT(DISTINCT \"Brand\") FROM \"Cars\"",
+        "_distinct_by(_.Brand) |> count() emits COUNT(DISTINCT \"Brand\")")
+}
+
+[test]
+def test_distinct_by_count_returns_distinct_brand_total(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = _sql(db |> select_from(type<Car>) |> _distinct_by(_.Brand) |> count())
+        t |> equal(n, 3, "3 distinct brands")
+    }
+}
+
+[test]
+def test_distinct_by_long_count_returns_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let n = _sql(db |> select_from(type<Car>) |> _distinct_by(_.Brand) |> long_count())
+        t |> equal(n, 3l, "3 distinct brands (int64)")
+    }
+}
+
+[test]
+def test_distinct_by_long_count_emits_count_distinct(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _distinct_by(_.Brand) |> long_count())
+    t |> equal(sql, "SELECT COUNT(DISTINCT \"Brand\") FROM \"Cars\"",
+        "long_count after _distinct_by emits the same COUNT(DISTINCT col) as count")
+}
+
+[test]
+def test_group_by_long_count_widens_to_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+                              |> _group_by(_.Brand)
+                              |> _select((Brand = _._0, N = _._1 |> long_count())))
+        t |> equal(length(groups), 3, "3 distinct brands grouped")
+        var total = 0l
+        for (g in groups) {
+            total += g.N
+        }
+        t |> equal(total, 5l, "group totals sum to row count (int64 accumulator)")
+    }
+}
+


### PR DESCRIPTION
## Summary

Session 1 of the post-#2843 follow-up plan. Two new chain shapes now lower in `_sql(...)`:

- `|> long_count()` → `SELECT COUNT(*)` with an int64 column binding, symmetric with the existing `|> count()` (int). Also recognised inside `_select` after `_group_by` so `(..., N = _._1 |> long_count())` widens the per-group counter to int64.
- `|> _distinct_by(_.col) |> count()` (and the `long_count` variant) → `SELECT COUNT(DISTINCT "col")`. Receiver-pinned to `ExprVar` so `u.opt.X` keys reject loudly instead of silently emitting the wrong COUNT.

A small refactor extracts `peel_count_terminal` so both terminals share the distinct-by recognition path.

## What's in the diff

- **`modules/dasSQLITE/daslib/sqlite_linq.das`** — new helpers `try_peel_distinct_by_field` + `peel_count_terminal`; the inline `count` peel block becomes two calls to the shared helper. `try_translate_group_aggregate` learns `long_count` (widens to int64).
- **`tests/dasSQLITE/test_31_long_count_distinct_by_canary.das`** (new) — 8 tests covering SQL-text emission and runtime values for both terminals, plus the int64-grouped projection.
- **`tests/dasSQLITE/failed_sql_macro.das`** — case 23 added: computed `_distinct_by` key (`_.Price % 100`) rejects with a precise diagnostic. `expect 50503` bumped 20 → 21.
- **`benchmarks/sql/distinct_by_count.das`** — m1 lane backfilled with `_sql(... |> _distinct_by(_.brand) |> count())`; the dated TODO comment is removed.
- **`benchmarks/sql/long_count_aggregate.das`** — m1 lane now actually calls `long_count()` instead of `count()` (latent bench-bug). Accept is now `c == 0l` to match the int64 return.
- **`benchmarks/sql/results.md`** — refreshed INTERP + JIT tables per the [[feedback-living-results-md]] policy; commit-hash header bumped; the "distinct_by_count SQL" bullet in "Notes on missing lanes" is removed now that the lane has a number.

Headline new cells: `distinct_by_count` SQL = 40.5 ns/op (INTERP) / 40.9 (JIT); `long_count_aggregate` SQL = 29.4 (INTERP) / 29.5 (JIT) and now genuinely measures `long_count`.

## Test plan

- [x] `bin/daslang dastest/dastest.das -- --test tests/dasSQLITE/` — 790/790 pass (interpreted)
- [x] `bin/test_aot dastest/dastest.das -- --test tests/dasSQLITE/` — 790/790 pass (AOT)
- [x] `bin/daslang dastest/dastest.das -- --test tests/linq/` — 1390/1390 pass (no shared-machinery regression)
- [x] INTERP + JIT bench rerun across `benchmarks/sql/` — 0 failures, results.md refreshed
- [x] `mcp__daslang__lint` on all touched `.das` files — clean
- [x] `mcp__daslang__format_file` — all already-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)