### PR TITLE
sqlite_linq: expression keys in _group_by + PR #2845 review fixes

### DIFF
--- a/benchmarks/sql/groupby_select_sum.das
+++ b/benchmarks/sql/groupby_select_sum.das
@@ -3,14 +3,28 @@ options persistent_heap
 
 require _common public
 
-// _select(c => c.price) |> _group_by(price % 100) |> _select((K=key, S=sum)).
-// SQL omitted: sqlite_linq's `_group_by` requires `_.Field` or a tuple of `_.Field`s.
-// The expression key (`_ % 100`) is rejected. [Follow-up TODO 2026-05-23: error[50503]
-// `_sql: _group_by: key must be \`_.Field\` or a tuple of \`_.Field\`s; got: (_ % 100)`
-// — would need expression-key support in sqlite_linq lowering.]
-// Array vs Decs is the headline comparison. Splice (PR-B) fuses the upstream Car→price
-// projection into an intermediate var bind so the key + sum acc reference the projected
-// int (no per-element Car re-access).
+// _group_by(price % 100) |> _select((K = key, S = sum(price))).
+// SQL: `SELECT (price % 100), SUM(price) FROM Cars GROUP BY (price % 100)` — exercises
+// sqlite_linq's expression-key support in _group_by (PR S2). The m1 form uses
+// `_group_by(_.price % 100)` + explicit inner select inside SUM (the shape the
+// grouped-aggregate dispatch recognises); the m3f/m4 forms keep their splice-friendly
+// `_select(_.price) |> _group_by(_ % 100) |> _select((K, S=_._1 |> sum()))` pattern,
+// which fuses the upstream Car→price projection into an intermediate var bind.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.price % 100)
+                                  |> _select((K = _._0, S = _._1 |> select($(c : Car) => c.price) |> sum())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
 
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -40,6 +54,11 @@ def run_m4(b : B?; n : int) {
             b->failNow()
         }
     }
+}
+
+[benchmark]
+def groupby_select_sum_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,6 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-23 from master `30021f183`. Fixture size: n = 100 000
+Generated 2026-05-23 from master `31e4339a8`. Fixture size: n = 100 000
 (cars), 100 dealers, 5 brands. Each row is one bench family in
 `benchmarks/sql/`; columns are nanoseconds per logical operation.
 `—` marks an intentionally absent lane — see "Notes on missing lanes"
@@ -26,57 +26,57 @@ before the timer resolution can measure them — they should be read as
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 34.7 | 5.9 | 5.8 | 0.98× |
-| `all_match` | 27.6 | 3.5 | 3.4 | 0.97× |
+| `aggregate_match` | 34.4 | 6.0 | 5.9 | 0.98× |
+| `all_match` | 27.6 | 3.7 | 3.5 | 0.95× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 29.9 | 5.8 | 8.7 | 1.50× |
-| `bare_order_where` | 274.4 | 117.6 | 125.5 | 1.07× |
-| `chained_where` | 36.2 | 6.7 | 6.6 | 0.99× |
+| `average_aggregate` | 29.5 | 5.9 | 8.8 | 1.49× |
+| `bare_order_where` | 275.1 | 118.3 | 126.0 | 1.07× |
+| `chained_where` | 36.0 | 6.7 | 6.6 | 0.99× |
 | `contains_match` | 0.00 | 2.2 | 1.4 | 0.64× |
-| `count_aggregate` | 29.4 | 4.1 | 4.1 | 1.00× |
-| `distinct_by_count` | 40.5 | 15.6 | 16.0 | 1.03× |
-| `distinct_count` | 41.1 | 15.9 | 15.8 | 0.99× |
+| `count_aggregate` | 29.7 | 4.1 | 4.1 | 1.00× |
+| `distinct_by_count` | 41.0 | 15.6 | 15.9 | 1.02× |
+| `distinct_count` | 41.2 | 15.9 | 15.8 | 0.99× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 170.0 | 30.1 | 30.1 | 1.00× |
-| `groupby_count` | 140.2 | 19.2 | 19.2 | 1.00× |
+| `groupby_average` | 170.6 | 29.9 | 30.0 | 1.00× |
+| `groupby_count` | 140.3 | 19.2 | 19.3 | 1.01× |
 | `groupby_first` | — | 18.4 | 19.1 | 1.04× |
-| `groupby_having_count` | 140.4 | 19.5 | 19.2 | 0.98× |
-| `groupby_having_hidden_sum` | 173.9 | 24.3 | 24.0 | 0.99× |
-| `groupby_max` | 176.4 | 24.8 | 25.9 | 1.04× |
-| `groupby_min` | 172.1 | 24.8 | 25.2 | 1.02× |
-| `groupby_multi_reducer` | 188.7 | 32.3 | 32.3 | 1.00× |
-| `groupby_select_sum` | — | 36.5 | 36.0 | 0.99× |
-| `groupby_sum` | 173.7 | 18.6 | 18.6 | 1.00× |
-| `groupby_where_count` | 74.8 | 14.6 | 14.8 | 1.01× |
+| `groupby_having_count` | 139.9 | 19.1 | 19.2 | 1.01× |
+| `groupby_having_hidden_sum` | 174.7 | 24.3 | 24.0 | 0.99× |
+| `groupby_max` | 173.4 | 24.9 | 25.2 | 1.01× |
+| `groupby_min` | 172.4 | 24.9 | 25.2 | 1.01× |
+| `groupby_multi_reducer` | 188.8 | 32.2 | 32.3 | 1.00× |
+| `groupby_select_sum` | 200.4 | 36.5 | 36.3 | 0.99× |
+| `groupby_sum` | 169.3 | 18.6 | 18.6 | 1.00× |
+| `groupby_where_count` | 75.6 | 14.6 | 14.8 | 1.01× |
 | `groupby_where_sum` | 85.9 | 14.1 | 14.6 | 1.04× |
-| `indexed_lookup` | 1454.2 | 202887.8 | 479.4 | 0.00× |
-| `join_count` | 38.1 | 127.5 | — | — |
-| `last_match` | 0.00 | 6.2 | 14.0 | 2.26× |
+| `indexed_lookup` | 1441.6 | 203340.0 | 474.5 | 0.00× |
+| `join_count` | 37.9 | 121.3 | — | — |
+| `last_match` | 0.00 | 5.8 | 13.8 | 2.38× |
 | `long_count_aggregate` | 29.4 | 4.2 | 4.0 | 0.95× |
-| `max_aggregate` | 30.8 | 6.0 | 6.9 | 1.15× |
-| `min_aggregate` | 30.8 | 6.1 | 6.9 | 1.13× |
-| `order_take_desc` | 37.9 | 15.8 | 19.9 | 1.26× |
+| `max_aggregate` | 30.9 | 6.0 | 6.9 | 1.15× |
+| `min_aggregate` | 31.0 | 6.1 | 6.9 | 1.13× |
+| `order_take_desc` | 38.2 | 15.8 | 19.9 | 1.26× |
 | `reverse_take` | 0.10 | 0.00 | 9.2 | — |
 | `select_count` | 0.10 | 0.00 | 2.2 | — |
-| `select_where` | 194.9 | 11.1 | 19.4 | 1.75× |
-| `select_where_count` | 32.4 | 5.2 | 7.4 | 1.42× |
-| `select_where_order_take` | 36.1 | 12.1 | 15.1 | 1.25× |
-| `select_where_sum` | 36.8 | 7.4 | 7.5 | 1.01× |
-| `single_match` | 0.00 | 2.9 | 5.4 | 1.86× |
+| `select_where` | 196.8 | 11.1 | 19.6 | 1.77× |
+| `select_where_count` | 32.6 | 5.2 | 7.4 | 1.42× |
+| `select_where_order_take` | 36.5 | 12.2 | 14.9 | 1.22× |
+| `select_where_sum` | 36.8 | 7.5 | 7.5 | 1.00× |
+| `single_match` | 0.00 | 2.9 | 5.5 | 1.90× |
 | `skip_take` | 0.50 | 0.10 | 0.20 | 2.00× |
 | `skip_while_match` | 3.4 | 5.3 | 5.3 | 1.00× |
-| `sort_first` | 37.4 | 11.0 | 13.3 | 1.21× |
-| `sort_take` | 38.0 | 16.2 | 20.1 | 1.24× |
-| `sum_aggregate` | 29.7 | 2.1 | 2.1 | 1.00× |
-| `sum_where` | 32.8 | 4.2 | 4.3 | 1.02× |
+| `sort_first` | 37.8 | 11.0 | 13.3 | 1.21× |
+| `sort_take` | 38.1 | 16.3 | 20.2 | 1.24× |
+| `sum_aggregate` | 30.0 | 2.2 | 2.1 | 0.95× |
+| `sum_where` | 33.0 | 4.2 | 4.3 | 1.02× |
 | `take_count` | 3.6 | 0.20 | 0.40 | 2.00× |
 | `take_count_filtered` | — | 0.20 | 0.20 | 1.00× |
 | `take_sum_aggregate` | — | 0.10 | 0.10 | 1.00× |
-| `take_while_match` | 7.9 | 2.4 | 2.5 | 1.04× |
-| `to_array_filter` | 69.9 | 11.7 | 11.7 | 1.00× |
+| `take_while_match` | 8.0 | 2.7 | 2.5 | 0.93× |
+| `to_array_filter` | 70.0 | 11.6 | 11.7 | 1.01× |
 | `zip_dot_product` | — | 8.0 | 4.8 | 0.60× |
 
 ## JIT
@@ -87,53 +87,53 @@ before the timer resolution can measure them — they should be read as
 | `all_match` | 27.4 | 0.30 | 0.20 | 0.67× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
 | `average_aggregate` | 30.0 | 1.0 | 3.5 | 3.50× |
-| `bare_order_where` | 183.7 | 33.5 | 34.7 | 1.04× |
-| `chained_where` | 35.8 | 0.60 | 0.80 | 1.33× |
+| `bare_order_where` | 184.2 | 33.5 | 34.8 | 1.04× |
+| `chained_where` | 36.2 | 0.60 | 0.80 | 1.33× |
 | `contains_match` | 0.00 | 0.20 | 0.10 | 0.50× |
-| `count_aggregate` | 29.5 | 0.30 | 0.60 | 2.00× |
-| `distinct_by_count` | 40.9 | 2.1 | 2.1 | 1.00× |
+| `count_aggregate` | 29.4 | 0.30 | 0.60 | 2.00× |
+| `distinct_by_count` | 41.0 | 2.1 | 2.1 | 1.00× |
 | `distinct_count` | 41.1 | 2.1 | 2.1 | 1.00× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
 | `groupby_average` | 170.0 | 2.6 | 2.9 | 1.12× |
-| `groupby_count` | 143.0 | 2.3 | 2.5 | 1.09× |
+| `groupby_count` | 140.7 | 2.3 | 2.5 | 1.09× |
 | `groupby_first` | — | 2.2 | 3.1 | 1.41× |
-| `groupby_having_count` | 139.6 | 2.3 | 2.5 | 1.09× |
-| `groupby_having_hidden_sum` | 173.4 | 2.5 | 2.8 | 1.12× |
-| `groupby_max` | 171.5 | 2.4 | 2.7 | 1.13× |
-| `groupby_min` | 172.8 | 2.4 | 2.7 | 1.13× |
-| `groupby_multi_reducer` | 187.7 | 2.7 | 2.9 | 1.07× |
-| `groupby_select_sum` | — | 3.2 | 3.7 | 1.16× |
-| `groupby_sum` | 169.2 | 2.4 | 2.7 | 1.13× |
+| `groupby_having_count` | 140.5 | 2.3 | 2.5 | 1.09× |
+| `groupby_having_hidden_sum` | 174.0 | 2.5 | 2.8 | 1.12× |
+| `groupby_max` | 175.1 | 2.4 | 2.7 | 1.13× |
+| `groupby_min` | 172.6 | 2.4 | 2.7 | 1.13× |
+| `groupby_multi_reducer` | 187.8 | 2.7 | 2.9 | 1.07× |
+| `groupby_select_sum` | 198.1 | 3.2 | 3.7 | 1.16× |
+| `groupby_sum` | 169.5 | 2.4 | 2.7 | 1.13× |
 | `groupby_where_count` | 75.0 | 1.7 | 1.8 | 1.06× |
-| `groupby_where_sum` | 85.9 | 1.7 | 1.8 | 1.06× |
-| `indexed_lookup` | 1228.9 | 34818.1 | 102.7 | 0.00× |
-| `join_count` | 38.0 | 35.8 | — | — |
+| `groupby_where_sum` | 87.9 | 1.7 | 1.8 | 1.06× |
+| `indexed_lookup` | 1238.5 | 35025.4 | 101.7 | 0.00× |
+| `join_count` | 37.6 | 35.7 | — | — |
 | `last_match` | 0.00 | 0.50 | 1.4 | 2.80× |
-| `long_count_aggregate` | 29.5 | 0.40 | 0.60 | 1.50× |
-| `max_aggregate` | 30.6 | 0.70 | 0.50 | 0.71× |
-| `min_aggregate` | 31.4 | 0.60 | 0.50 | 0.83× |
+| `long_count_aggregate` | 28.8 | 0.30 | 0.60 | 2.00× |
+| `max_aggregate` | 30.5 | 0.60 | 0.50 | 0.83× |
+| `min_aggregate` | 30.5 | 0.60 | 0.50 | 0.83× |
 | `order_take_desc` | 37.6 | 0.70 | 1.3 | 1.86× |
 | `reverse_take` | 0.00 | 0.00 | 1.1 | — |
 | `select_count` | 0.10 | 0.00 | 0.00 | — |
-| `select_where` | 105.9 | 4.1 | 5.4 | 1.32× |
+| `select_where` | 105.3 | 4.1 | 5.5 | 1.34× |
 | `select_where_count` | 32.4 | 0.40 | 0.60 | 1.50× |
-| `select_where_order_take` | 36.3 | 0.70 | 1.4 | 2.00× |
-| `select_where_sum` | 36.7 | 0.50 | 0.60 | 1.20× |
+| `select_where_order_take` | 36.2 | 0.70 | 1.3 | 1.86× |
+| `select_where_sum` | 36.6 | 0.50 | 0.60 | 1.20× |
 | `single_match` | 0.00 | 0.40 | 1.1 | 2.75× |
 | `skip_take` | 0.30 | 0.00 | 0.00 | — |
 | `skip_while_match` | 3.4 | 0.40 | 0.40 | 1.00× |
-| `sort_first` | 37.4 | 0.40 | 1.3 | 3.25× |
-| `sort_take` | 37.7 | 0.70 | 1.3 | 1.86× |
-| `sum_aggregate` | 29.7 | 0.40 | 0.30 | 0.75× |
-| `sum_where` | 32.4 | 0.40 | 0.60 | 1.50× |
-| `take_count` | 1.8 | 0.10 | 0.10 | 1.00× |
+| `sort_first` | 37.5 | 0.40 | 1.3 | 3.25× |
+| `sort_take` | 37.6 | 0.70 | 1.3 | 1.86× |
+| `sum_aggregate` | 29.8 | 0.40 | 0.30 | 0.75× |
+| `sum_where` | 32.3 | 0.40 | 0.60 | 1.50× |
+| `take_count` | 1.8 | 0.10 | 0.20 | 2.00× |
 | `take_count_filtered` | — | 0.00 | 0.00 | — |
 | `take_sum_aggregate` | — | 0.00 | 0.00 | — |
 | `take_while_match` | 7.9 | 0.20 | 0.30 | 1.50× |
-| `to_array_filter` | 48.8 | 3.2 | 3.3 | 1.03× |
+| `to_array_filter` | 47.6 | 3.2 | 3.4 | 1.06× |
 | `zip_dot_product` | — | 0.50 | 0.50 | 1.00× |
 
 ## Notes on missing lanes (the `—` cells)
@@ -146,15 +146,6 @@ corresponding `.das` bench file; the bullets below quote that comment.
   (PARTITION BY brand ORDER BY id)` + outer `WHERE rn=1`) would be the
   SQL equivalent; sqlite_linq does not currently lower window
   functions. Follow-up TODO 2026-05-23.
-- **`groupby_select_sum` SQL** — sqlite_linq's `_group_by` requires
-  `_.Field` or a tuple of `_.Field`s; the expression key (`_ % 100`)
-  is rejected. Follow-up TODO 2026-05-23: expression-key support in
-  sqlite_linq lowering. Probe error:
-
-  ```
-  error[50503]: _sql: _group_by: key must be `_.Field` or
-    a tuple of `_.Field`s; got: (_ % 100)
-  ```
 - **`take_count_filtered` SQL** — by design. In SQL, LIMIT after an
   aggregate has no effect (the aggregate collapses to one row), so the
   bound-then-count shape has no faithful SQL translation. No follow-up.

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -160,6 +160,9 @@ struct private SqlQuery {
     orderByCols : array<string>
     orderByInlineExprs : array<ExpressionPtr>
     groupByCols : array<string>
+    // nolint:STYLE014 Parallel to groupByCols: null for `_.Field` keys (groupByCols holds the daslang field name quoted, emitter translates); body for computed-expression keys (groupByCols holds the rendered SQL fragment).
+    groupByKeyExprs : array<ExpressionPtr>
+    groupByKeyTypes : array<TypeDeclPtr>
     havingSql : string
     havingBindExprs : array<ExpressionPtr>
     groupedSelectExprs : array<string>
@@ -189,6 +192,8 @@ struct private SqlQuery {
     inView      : bool
     hadError    : bool
     lastError   : string
+    // nolint:STYLE014 When true, pred_to_sql's bind fallthrough inlines ExprConst* literals into the SQL string instead of pushing `?` binds — used by expression-key contexts (e.g. _group_by) where the rendered fragment is re-used in multiple SQL positions and can't carry binds.
+    inlineConstants : bool
     // Multi-Q lowering: phase-order conflict (e.g. `take(n) |> _where(p)`) snapshots
     // the inner subtree's SQL+binds here; outer FROM renders as `(<innerSql>) AS t0`.
     innerSql       : string                 // null/empty = base-table FROM; else nested SELECT body
@@ -576,7 +581,7 @@ def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
     return true
 }
 
-// nolint:STYLE015 Receiver-pin to ExprVar rejects `u.opt.X` keys SQL can't reproduce.
+// nolint:STYLE015 Verifies the receiver IS the lambda's bound param — outer captures (`outer.Brand`) reject loudly instead of emitting a wrong `COUNT(DISTINCT "Brand")` against the SQL source.
 [macro_function]
 def private try_peel_distinct_by_field(var node : ExpressionPtr; var distinctSource : ExpressionPtr&;
                                        var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
@@ -587,7 +592,20 @@ def private try_peel_distinct_by_field(var node : ExpressionPtr; var distinctSou
         q.hadError = true
         return ""
     }
-    var body = peel_lambda_single_return(dbCall.arguments[1])
+    var lam = dbCall.arguments[1]
+    if (lam == null || !(lam is ExprMakeBlock)) {
+        macro_error(prog, at, "_sql: _distinct_by key has unexpected shape (not a lambda)")
+        q.hadError = true
+        return ""
+    }
+    var blk = (lam as ExprMakeBlock)._block as ExprBlock
+    if (blk == null || blk.arguments |> length != 1) {
+        macro_error(prog, at, "_sql: _distinct_by key lambda must take exactly one argument")
+        q.hadError = true
+        return ""
+    }
+    let expectedArgName = string(blk.arguments[0].name)
+    var body = peel_lambda_single_return(lam)
     if (body == null) {
         macro_error(prog, at, "_sql: _distinct_by key lambda has unexpected shape")
         q.hadError = true
@@ -598,6 +616,12 @@ def private try_peel_distinct_by_field(var node : ExpressionPtr; var distinctSou
     if (!qmatch(body, $e(receiver).$f(fieldName)).matched
             || receiver == null || !(receiver is ExprVar)) {
         macro_error(prog, at, "_sql: _distinct_by key must be `<arg>.<field>` (single column reference) — computed keys are not yet translatable to SQL")
+        q.hadError = true
+        return ""
+    }
+    let argName = string((receiver as ExprVar).name)
+    if (argName != expectedArgName) {
+        macro_error(prog, at, "_sql: _distinct_by key references `{argName}` but the lambda's argument is `{expectedArgName}` — outer captures can't be translated, the key must read `{expectedArgName}.<field>`")
         q.hadError = true
         return ""
     }
@@ -618,7 +642,7 @@ def private peel_count_terminal(var node : ExpressionPtr; var q : SqlQuery&;
         return true
     }
     if (cCall.arguments |> length != 1) {
-        macro_error(prog, at, "_sql: `_{linqName}(predicate)` is not yet supported — use `|> _where(predicate) |> _{linqName}()` instead")
+        macro_error(prog, at, "_sql: `{linqName}(predicate)` is not yet supported — use `|> _where(predicate) |> {linqName}()` instead")
         q.hadError = true
         return true
     }
@@ -758,6 +782,8 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.orderByCols |> clear
     q.orderByInlineExprs |> clear
     q.groupByCols |> clear
+    q.groupByKeyExprs |> clear
+    q.groupByKeyTypes |> clear
     q.havingSql := ""
     q.havingBindExprs |> clear
     q.groupedSelectExprs |> clear
@@ -1580,9 +1606,11 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
                 macro_error(prog, at, "_sql: _group_by key lambda has unexpected shape")
                 return false
             }
-            if (!collect_group_keys(body, q, prog, at)) return false
+            // nolint:STYLE015 Source first so q.rootType is set before pred_to_sql on computed keys.
+            if (!analyze_chain(gbCall.arguments[0], q, prog, at)
+                    || !collect_group_keys(body, q, prog, at)) return false
             q.seenGroupBy = true
-            return analyze_chain(gbCall.arguments[0], q, prog, at)
+            return true
         }
     }
     // Peel _where — recurse first so q.rootType is set before pred_to_sql runs (needs it for @sql_json/@sql_blob descent).
@@ -2145,6 +2173,13 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
         var val = mkTup.values[i]
         // single-key `_._0` — direct group-key reference.
         if (nKeys == 1 && qmatch(val, _._0).matched) {
+            if (q.groupByKeyExprs[0] != null) {
+                // Computed-expression key — reuse the rendered SQL fragment from collect_group_keys.
+                q.groupedSelectExprs |> push(q.groupByCols[0])
+                q.groupedSelectTypes |> push(q.groupByKeyTypes[0])
+                q.projRecordNames |> push(string(tupT.argNames[i]))
+                continue
+            }
             let col = group_key_column_name(q, 0)
             var fieldType = lookup_struct_field_type(q.rootType, col)
             if (fieldType == null) {
@@ -2164,6 +2199,12 @@ def private analyze_grouped_projection(var body : ExpressionPtr; var q : SqlQuer
                     let suffix = slice(outerName, 1, length(outerName))
                     let keyIdx = try_to_int(suffix) ?? -1
                     if (keyIdx >= 0 && keyIdx < nKeys) {
+                        if (q.groupByKeyExprs[keyIdx] != null) {
+                            q.groupedSelectExprs |> push(q.groupByCols[keyIdx])
+                            q.groupedSelectTypes |> push(q.groupByKeyTypes[keyIdx])
+                            q.projRecordNames |> push(string(tupT.argNames[i]))
+                            continue
+                        }
                         let col = group_key_column_name(q, keyIdx)
                         var fieldType = lookup_struct_field_type(q.rootType, col)
                         if (fieldType == null) {
@@ -2230,6 +2271,10 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
         if (nKeys == 1 && recv != null && recv is ExprVar
                 && (recv as ExprVar).name == "_"
                 && outerName == "_0") {
+            if (q.groupByKeyExprs[0] != null) {
+                q.orderByCols |> push("{q.groupByCols[0]} {direction}")
+                return true
+            }
             let dasName = group_key_column_name(q, 0)
             let sqlCol = field_to_column_name(q.rootType, dasName)
             q.orderByCols |> push("\"{sqlCol}\" {direction}")
@@ -2249,6 +2294,10 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
                 let suffix = slice(outerName, 1, length(outerName))
                 let keyIdx = try_to_int(suffix) ?? -1
                 if (keyIdx >= 0 && keyIdx < nKeys) {
+                    if (q.groupByKeyExprs[keyIdx] != null) {
+                        q.orderByCols |> push("{q.groupByCols[keyIdx]} {direction}")
+                        return true
+                    }
                     let dasName = group_key_column_name(q, keyIdx)
                     let sqlCol = field_to_column_name(q.rootType, dasName)
                     q.orderByCols |> push("\"{sqlCol}\" {direction}")
@@ -2300,6 +2349,35 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
 }
 
 [macro_function]
+def private push_group_key(var entry : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    var fieldName : string
+    if (qmatch(entry, _.$f(fieldName)).matched) {
+        q.groupByCols |> push("\"{fieldName}\"")
+        q.groupByKeyExprs |> push(null)
+        q.groupByKeyTypes |> push(null)
+        return true
+    }
+    // nolint:STYLE015 Render with constants inlined so the fragment carries no binds and can be re-used in SELECT/GROUP BY/ORDER BY positions.
+    let savedInlineFlag = q.inlineConstants
+    let beforeBinds = length(q.bindExprs)
+    q.inlineConstants = true
+    let exprSql = pred_to_sql(entry, q, prog, at)
+    q.inlineConstants = savedInlineFlag
+    if (q.hadError || empty(exprSql)) return false
+    if (length(q.bindExprs) > beforeBinds) {
+        // nolint:STYLE015 Runtime bind in a key fragment would have to be re-pushed at each use site (SELECT/GROUP BY/ORDER BY); reject loud instead.
+        q.bindExprs |> resize(beforeBinds)
+        macro_error(prog, at, "_sql: _group_by expression key references a runtime value — only column refs (`_.X`) and constant literals (`100`, `0.5`) are allowed inside the key expression; got: {describe(entry)}")
+        q.hadError = true
+        return false
+    }
+    q.groupByCols |> push("({exprSql})")
+    q.groupByKeyExprs |> push <| clone_expression(entry)
+    q.groupByKeyTypes |> push(entry._type)
+    return true
+}
+
+[macro_function]
 def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
     if (body == null) {
         macro_error(prog, at, "_sql: _group_by: missing key expression")
@@ -2312,15 +2390,7 @@ def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog
             return false
         }
     }
-    // Single-column form: _.FieldName. groupByCols stores DASLANG names; SQL translation deferred to emission.
-    {
-        var fieldName : string
-        if (qmatch(body, _.$f(fieldName)).matched) {
-            q.groupByCols |> push("\"{fieldName}\"")
-            return true
-        }
-    }
-    // Multi-column form: tuple literal `(_.k1, _.k2)`.
+    // Multi-column form: tuple literal `(k1, k2, ...)` — each entry is either `_.Field` or a computed expression.
     if (body is ExprMakeTuple) {
         var mkTup = body as ExprMakeTuple
         if (empty(mkTup.values)) {
@@ -2328,19 +2398,12 @@ def private collect_group_keys(var body : ExpressionPtr; var q : SqlQuery&; prog
             return false
         }
         for (i in range(length(mkTup.values))) {
-            var val = mkTup.values[i]
-            var fieldName : string
-            if (qmatch(val, _.$f(fieldName)).matched) {
-                q.groupByCols |> push("\"{fieldName}\"")
-            } else {
-                macro_error(prog, at, "_sql: _group_by: tuple-key entries must be `_.Field`; got: {describe(val)}")
-                return false
-            }
+            if (!push_group_key(mkTup.values[i], q, prog, at)) return false
         }
         return true
     }
-    macro_error(prog, at, "_sql: _group_by: key must be `_.Field` or a tuple of `_.Field`s; got: {describe(body)}")
-    return false
+    // Single key: `_.Field`, or any expression pred_to_sql can render (`_.X % 100`, `_.X + _.Y`, etc.).
+    return push_group_key(body, q, prog, at)
 }
 
 [macro_function]
@@ -2706,6 +2769,17 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                 }
             }
         }
+    }
+    // Literal-inline mode (set by expression-key contexts) — emit ExprConst* value directly so the fragment carries no binds and can be re-used at multiple SQL positions.
+    if (q.inlineConstants) {
+        if (node is ExprConstInt) return "{(node as ExprConstInt).value}"
+        if (node is ExprConstInt64) return "{(node as ExprConstInt64).value}"
+        if (node is ExprConstUInt) return "{(node as ExprConstUInt).value}"
+        if (node is ExprConstUInt64) return "{(node as ExprConstUInt64).value}"
+        if (node is ExprConstFloat) return fmt(":.9g",  (node as ExprConstFloat).value)
+        if (node is ExprConstDouble) return fmt(":.17g", (node as ExprConstDouble).value)
+        if (node is ExprConstBool) return (node as ExprConstBool).value ? "1" : "0"
+        if (node is ExprConstString) return sql_quote_lit(string((node as ExprConstString).value))
     }
     // Bind fallthrough: unrecognized exprs become `?`; sql_bind catch-all + concept_assert error if not bindable.
     if (q.inHaving) {
@@ -3295,18 +3369,22 @@ def private build_sql_select(var q : SqlQuery&; force_aliases : bool = false) : 
             w |> write(" WHERE ")
             w |> write(q.whereSql)
         }
-        // groupByCols hold daslang field names (quoted); translate to SQL identifier here.
+        // nolint:STYLE015 groupByCols hold either daslang field names (quoted) or pre-rendered SQL expression fragments; discriminate via groupByKeyExprs.
         if (!empty(q.groupByCols)) {
             w |> write(" GROUP BY ")
             for (i in range(length(q.groupByCols))) {
                 if (i > 0) {
                     w |> write(", ")
                 }
-                let dasName = group_key_column_name(q, i)
-                let sqlCol = field_to_column_name(q.rootType, dasName)
-                w |> write("\"")
-                w |> write(sqlCol)
-                w |> write("\"")
+                if (q.groupByKeyExprs[i] != null) {
+                    w |> write(q.groupByCols[i])
+                } else {
+                    let dasName = group_key_column_name(q, i)
+                    let sqlCol = field_to_column_name(q.rootType, dasName)
+                    w |> write("\"")
+                    w |> write(sqlCol)
+                    w |> write("\"")
+                }
             }
         }
         if (!empty(q.havingSql)) {

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -6,7 +6,7 @@ options gen2
 // some malformed chains additionally cascade real type errors before the
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field). Those cascades are expected.
-expect 30341, 30928:2, 50503:21
+expect 30341, 30928:2, 50503:23
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -144,6 +144,19 @@ def main() {
     //     keys lower to `COUNT(DISTINCT "col")`; computed keys like `_.Price %
     //     100` would need a general expression-to-SQL emitter not yet wired.
     let bad23 <- _sql(db |> select_from(type<Car>) |> _distinct_by(_.Price % 100) |> count())
+
+    // 24. `_distinct_by(<outer-capture>.Field)` — the key reads a captured
+    //     variable instead of the lambda's bound parameter (`_`); without
+    //     the arg-name check this would silently emit `COUNT(DISTINCT "Field")`
+    //     against the SQL row source — wrong result.
+    var capturedRow = Car(Id = 0, Name = "captured", Price = 0)
+    let bad24 <- _sql(db |> select_from(type<Car>) |> _distinct_by(capturedRow.Name) |> count())
+
+    // 25. `_group_by(_.Col - <runtime-var>)` — expression-key support inlines
+    //     constants only; a runtime-var bind would need to be re-pushed at each
+    //     re-use of the key fragment (SELECT, GROUP BY, ORDER BY positions).
+    let runtimeOffset = 5
+    let bad25 <- _sql(db |> select_from(type<Car>) |> _group_by(_.Price - runtimeOffset) |> _select((K = _._0, N = _._1 |> length)))
     // (Note: the "_in subquery without _select(_.Col)" diagnostic added in
     //  this round is also belt-and-suspenders — a daslang `contains` type-
     //  check rejects mismatched element types before sqlite_linq even sees

--- a/tests/dasSQLITE/test_32_group_by_expression_keys.das
+++ b/tests/dasSQLITE/test_32_group_by_expression_keys.das
@@ -1,0 +1,95 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Brand : string
+    Price : int
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    for (i in range(20)) {
+        db |> insert(Car(Id = i + 1, Brand = "B{i % 3}", Price = i * 10))
+    }
+}
+
+[test]
+def test_expr_key_modulo_emits_inline_constant(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _group_by(_.Price % 100) |> _select((K = _._0, N = _._1 |> length)))
+    t |> equal(sql, "SELECT ((\"Price\") % (100)), COUNT(*) FROM \"Cars\" GROUP BY ((\"Price\") % (100))",
+        "expr-key SELECT + GROUP BY share the same inlined fragment, no `?` binds")
+}
+
+[test]
+def test_expr_key_modulo_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>) |> _group_by(_.Price % 100) |> _select((K = _._0, N = _._1 |> length)))
+        t |> equal(length(groups), 10, "20 rows with Price 0,10,...,190 split by % 100 → 10 groups of 2")
+        var seen = 0
+        for (g in groups) {
+            t |> equal(g.N, 2, "every group has 2 entries")
+            seen++
+        }
+        t |> equal(seen, 10, "10 groups iterated")
+    }
+}
+
+[test]
+def test_expr_key_with_inner_select_sum(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+                              |> _group_by(_.Price % 100)
+                              |> _select((K = _._0, S = _._1 |> select($(c : Car) => c.Price) |> sum())))
+        t |> equal(length(groups), 10, "10 groups")
+        for (g in groups) {
+            t |> equal(g.S, g.K * 2 + 100, "K=0 → S=100, K=10 → S=120, etc.")
+        }
+    }
+}
+
+[test]
+def test_expr_key_order_by_uses_same_fragment(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                           |> _group_by(_.Price % 100)
+                           |> _select((K = _._0, N = _._1 |> length))
+                           |> _order_by(_._0))
+    t |> success(sql |> find("ORDER BY ((\"Price\") % (100)) ASC") >= 0,
+        "ORDER BY on the group key re-uses the expression-key fragment verbatim")
+}
+
+[test]
+def test_multi_key_mixed_field_and_expression(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                           |> _group_by((_.Brand, _.Price % 100))
+                           |> _select((B = _._0._0, K = _._0._1, N = _._1 |> length)))
+    t |> equal(sql, "SELECT \"Brand\", ((\"Price\") % (100)), COUNT(*) FROM \"Cars\" GROUP BY \"Brand\", ((\"Price\") % (100))",
+        "multi-key tuple mixes field key and expression key; both render in SELECT + GROUP BY in order")
+}
+
+[test]
+def test_expr_key_runtime_runs_correctly(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+                              |> _group_by((_.Brand, _.Price % 100))
+                              |> _select((B = _._0._0, K = _._0._1, N = _._1 |> length)))
+        t |> success(!empty(groups), "non-empty multi-key result")
+        var total = 0
+        for (g in groups) {
+            total += g.N
+        }
+        t |> equal(total, 20, "every row visits exactly one group")
+    }
+}


### PR DESCRIPTION
## Summary

Two improvements in one PR:

### 1. Expression-key support in `_group_by` (Session 2 of post-#2843 plan)

`_group_by(_.Price % 100)` (and tuples mixing field keys with expression keys) now lower to `GROUP BY (("Price") % (100))`. The rendered fragment is re-used verbatim in `SELECT` (`K = _._0`) and `ORDER BY` (`_order_by(_._0)`) positions, so the SQL stays a single source of truth across all three clauses.

**Mechanism**: `collect_group_keys` calls `pred_to_sql` with a new `q.inlineConstants` mode so the bound `_.X` field refs render as columns and `ExprConst*` literals (ints, floats, strings, bools) inline as SQL literals instead of `?` placeholders. The fragment carries no binds, which lets it be re-used at multiple SQL positions without bind-position bookkeeping.

**Runtime values reject loudly**: `_.Col - capturedVar` would need bind re-pushing at each use site, so the analyzer rejects with a precise diagnostic (`failed_sql_macro` case 25).

**Order swap in the `_group_by` peel**: recurse into the source first so `q.rootType` is set before `pred_to_sql` runs on the key (the existing field-key path didn't need this since translation was deferred to emission; expression keys do).

**Bench**: `benchmarks/sql/groupby_select_sum.das` m1 backfilled. The bench uses the explicit-inner-select shape inside SUM (`_._1 |> select($(c : Car) => c.price) |> sum()`); m3f/m4 keep their splice-friendly bare-`sum` form; both emit equivalent SQL/compute. `results.md` refreshed per the living-doc policy (`groupby_select_sum SQL` bullet removed from the missing-lanes notes).

### 2. PR #2845 review fixes (Copilot, both real)

- **`peel_count_terminal` error wording** — said `_count(predicate)` and suggested `_count()`; the actual terminals in `_sql` chains are bare `count()` / `long_count()`. Underscores dropped in both the offending name and the suggested fix.
- **`try_peel_distinct_by_field` outer-capture silent miscompile** — receiver was pinned to `ExprVar` but the var wasn't checked against the lambda's bound parameter. `_distinct_by(capturedRow.Brand) |> count()` would silently emit `COUNT(DISTINCT "Brand")` against the SQL source — wrong result, no diagnostic. Now extracts the lambda's arg name and rejects on mismatch (`failed_sql_macro` case 24).

## What's in the diff

- **`modules/dasSQLITE/daslib/sqlite_linq.das`** — new `q.inlineConstants` flag + ExprConst* inlining in `pred_to_sql`; new `push_group_key` helper called by `collect_group_keys`; `_group_by` peel recurses-first; `analyze_grouped_projection` / `collect_order_keys` / GROUP BY emitter all branch on `groupByKeyExprs[i] != null` to use the cached expression fragment. Copilot fixes folded in.
- **`tests/dasSQLITE/test_32_group_by_expression_keys.das`** (new) — 6 tests covering SQL emission + runtime values for single expression keys, multi-key tuples mixing field + expression keys, ORDER BY on the group key, and aggregate-over-expression-key projection.
- **`tests/dasSQLITE/failed_sql_macro.das`** — cases 24 (outer-capture distinct_by) + 25 (runtime-value expression key) added; `expect 50503` bumped 21 → 23.
- **`benchmarks/sql/groupby_select_sum.das`** — m1 lane backfilled; bench comment refreshed (drops the dated TODO, notes the lane-specific shape).
- **`benchmarks/sql/results.md`** — INTERP + JIT tables refreshed; commit-hash header bumped; missing-lanes bullet for `groupby_select_sum SQL` removed.

## Test plan

- [x] `bin/daslang dastest/dastest.das -- --test tests/dasSQLITE/` — 796/796 pass (interpreted)
- [x] `bin/test_aot dastest/dastest.das -- --test tests/dasSQLITE/` — 796/796 pass (AOT)
- [x] `bin/daslang dastest/dastest.das -- --test tests/linq/` — 1390/1390 pass (no shared-machinery regression)
- [x] INTERP + JIT bench rerun across `benchmarks/sql/` — 0 failures, results.md refreshed
- [x] `mcp__daslang__lint` + `format_file` on all touched files — clean
- [x] Pre-push hook (formatter + lint) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)