### PR TITLE
infer: hoist per-module visibility + aliasCache (~19% faster compile)

### DIFF
--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -224,6 +224,7 @@ namespace das {
         static void updateAliasMap ( const TypeDeclPtr & decl, const TypeDeclPtr & pass, AliasMap & aliases, OptionsMap & options );
         Type getRangeBaseType() const;
         TypeDecl * findAlias ( const string & name, bool allowAuto = false );
+        bool computeAliasCache();     // eager full walk, populates aliasCacheValid/aliasCacheHasAlias on every visited node; returns true if subtree contains any alias
         int findArgumentIndex(const string & name) const;
         int tupleFieldIndex( const string & name ) const;
         int variantFieldIndex( const string & name ) const;
@@ -284,6 +285,8 @@ namespace das {
                                                 //  unsigned-underlying enum (uint8/uint16/uint64). Lets `int(uint8Enum)`
                                                 //  resolve to enum8u_to_int instead of enum8_to_int so the byte
                                                 //  zero-extends instead of sign-extending.
+                bool    aliasCacheValid : 1;    // findAlias subtree cache validity flag
+                bool    aliasCacheHasAlias : 1; // findAlias subtree cache result (only meaningful when aliasCacheValid)
             };
             uint32_t flags = 0;
         };

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -77,10 +77,14 @@ namespace das {
         program->library.foreach ([&](Module *mod) -> bool {
                 auto itFnList = mod->functionsByName.find(hFuncName);
                 if ( itFnList ) {
+                    // Hoist module-level visibility — pFn->module == mod for non-generic fns (set in addFunction).
+                    const bool modVis = isVisibleFunc(inWhichModule, mod);
                     auto & goodFunctions = itFnList->second;
                     for ( auto & pFn : goodFunctions ) {
                         // if ( pFn->isTemplate ) continue;
-                        if ( isVisibleFunc(inWhichModule,getFunctionVisModule(pFn)) ) {
+                        const bool funcVis = !pFn->fromGeneric ? modVis
+                                          : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                        if ( funcVis ) {
                             if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                 result.push_back(pFn);
                             }
@@ -391,11 +395,16 @@ namespace das {
         program->library.foreach ([&](Module *mod) -> bool {
                 auto itFnList = mod->functionsByName.find(hFuncName);
                 if ( itFnList ) {
+                    // Hoist module-level visibility — pFn->module == mod for non-generic fns.
+                    const bool modVis = isVisibleFunc(inWhichModule, mod);
+                    const bool modVisFromThis = thisModule->isVisibleDirectly(mod);
                     auto & goodFunctions = itFnList->second;
                     for ( auto & pFn : goodFunctions ) {
                         if ( pFn->isTemplate ) continue;
-                        if ( isVisibleFunc(inWhichModule,getFunctionVisModule(pFn)) ) {
-                            if ( !pFn->fromGeneric || thisModule->isVisibleDirectly(mod) ) {
+                        const bool funcVis = !pFn->fromGeneric ? modVis
+                                          : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                        if ( funcVis ) {
+                            if ( !pFn->fromGeneric || modVisFromThis ) {
                                 if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                     if ( isFunctionCompatible(pFn, types, arguments, false, inferBlock) ) {
                                         result.push_back(pFn);
@@ -428,12 +437,18 @@ namespace das {
         program->library.foreach ([&](Module *mod) -> bool {
                 auto itFnList = mod->functionsByName.find(hFuncName);
                 if ( itFnList ) {
+                    // Hoist module-level visibility — pFn->module == mod for non-generic fns.
+                    const bool modVis = visCheck ? isVisibleFunc(inWhichModule, mod) : true;
+                    const bool modVisFromThis = thisModule->isVisibleDirectly(mod);
                     auto & goodFunctions = itFnList->second;
                     for ( auto & pFn : goodFunctions ) {
                         if ( pFn->jitOnly && !jitEnabled() ) continue;
                         if ( pFn->isTemplate ) continue;
-                        if ( !visCheck || isVisibleFunc(inWhichModule,getFunctionVisModule(pFn) ) ) {
-                            if ( !pFn->fromGeneric || thisModule->isVisibleDirectly(mod) ) {
+                        const bool funcVis = !visCheck ? true
+                                          : !pFn->fromGeneric ? modVis
+                                          : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                        if ( funcVis ) {
+                            if ( !pFn->fromGeneric || modVisFromThis ) {
                                 if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                     if ( !argHash ) {
                                         argHash = fragile_bit_set::key(getLookupHash(types));
@@ -468,11 +483,16 @@ namespace das {
                 {   // functions
                     auto itFnList = mod->functionsByName.find(hFuncName);
                     if ( itFnList ) {
+                        // Hoist module-level visibility — pFn->module == mod by construction.
+                        const bool modVis = isVisibleFunc(inWhichModule, mod);
+                        const bool modVisFromThis = thisModule->isVisibleDirectly(mod);
                         auto & goodFunctions = itFnList->second;
                         for ( auto & pFn : goodFunctions ) {
                             if ( pFn->isTemplate ) continue;
-                            if ( isVisibleFunc(inWhichModule,getFunctionVisModule(pFn)) ) {
-                                if ( !pFn->fromGeneric || thisModule->isVisibleDirectly(mod) ) {
+                            const bool funcVis = !pFn->fromGeneric ? modVis
+                                              : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                            if ( funcVis ) {
+                                if ( !pFn->fromGeneric || modVisFromThis ) {
                                     if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                         if ( isFunctionCompatible(pFn, types, arguments, false, inferBlock) ) {
                                             resultFunctions.push_back(pFn);
@@ -486,11 +506,14 @@ namespace das {
                 {   // generics
                     auto itFnList = mod->genericsByName.find(hFuncName);
                     if ( itFnList ) {
+                        const bool modVis = isVisibleFunc(inWhichModule, mod);
                         auto & goodFunctions = itFnList->second;
                         for ( auto & pFn : goodFunctions ) {
                             if ( pFn->jitOnly && !jitEnabled() ) continue;
                             if ( pFn->isTemplate ) continue;
-                            if ( isVisibleFunc(inWhichModule,getFunctionVisModule(pFn)) ) {
+                            const bool funcVis = !pFn->fromGeneric ? modVis
+                                              : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                            if ( funcVis ) {
                                 if ( canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                     if ( isFunctionCompatible(pFn, types, arguments, true, true) ) {   // infer block here?
                                         resultGenerics.push_back(pFn);
@@ -512,12 +535,18 @@ namespace das {
                 { // functions
                     auto itFnList = mod->functionsByName.find(hFuncName);
                     if ( itFnList ) {
+                        // Hoist module-level visibility — pFn->module == mod by construction.
+                        const bool modVis = visCheck ? isVisibleFunc(inWhichModule, mod) : true;
+                        const bool modVisFromThis = thisModule->isVisibleDirectly(mod);
                         auto & goodFunctions = itFnList->second;
                         for ( auto & pFn : goodFunctions ) {
                             if ( pFn->jitOnly && !jitEnabled() ) continue;
                             if ( pFn->isTemplate ) continue;
-                            if ( !visCheck || isVisibleFunc(inWhichModule,getFunctionVisModule(pFn) ) ) {
-                                if ( !pFn->fromGeneric || thisModule->isVisibleDirectly(mod) ) {
+                            const bool funcVis = !visCheck ? true
+                                              : !pFn->fromGeneric ? modVis
+                                              : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                            if ( funcVis ) {
+                                if ( !pFn->fromGeneric || modVisFromThis ) {
                                     if ( !visCheck || canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                         auto itLook = pFn->lookup.find_and_reserve(argHash);    // if found in lookup
                                         if ( *itLook ) {
@@ -541,10 +570,14 @@ namespace das {
                 { // generics
                     auto itFnList = mod->genericsByName.find(hFuncName);
                     if ( itFnList ) {
+                        const bool modVis = visCheck ? isVisibleFunc(inWhichModule, mod) : true;
                         auto & goodFunctions = itFnList->second;
                         for ( auto & pFn : goodFunctions ) {
                             if ( pFn->isTemplate ) continue;
-                            if ( !visCheck || isVisibleFunc(inWhichModule,getFunctionVisModule(pFn)) ) {
+                            const bool funcVis = !visCheck ? true
+                                              : !pFn->fromGeneric ? modVis
+                                              : isVisibleFunc(inWhichModule, pFn->getOrigin()->module);
+                            if ( funcVis ) {
                                 if ( !visCheck || canCallPrivate(pFn,inWhichModule,thisModule) ) {
                                     auto itLook = pFn->lookup.find_and_reserve(argHash);    // if found in lookup
                                     if ( *itLook ) {

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -874,6 +874,8 @@ namespace das
             }
         }
         flags = decl.flags;
+        aliasCacheValid = false;            // not cloned — recompute lazily
+        aliasCacheHasAlias = false;
         alias = decl.alias;
         at = decl.at;
         module = decl.module;
@@ -916,6 +918,8 @@ namespace das
             }
         }
         dest->flags = src->flags;
+        dest->aliasCacheValid = false;      // not cloned — recompute lazily
+        dest->aliasCacheHasAlias = false;
         dest->alias = src->alias;
         dest->at = src->at;
         dest->module = src->module;
@@ -944,7 +948,27 @@ namespace das
         if ( annotation ) annotation->gc_collect(target, from);
     }
 
+    bool TypeDecl::computeAliasCache() {
+        // Eager full walk independent of name/allowAuto. Sets aliasCache* on every visited node.
+        // alias-type subtrees are dead ends for findAlias, so treated as NoAlias.
+        if (baseType == Type::alias) {
+            aliasCacheValid = true;
+            aliasCacheHasAlias = false;
+            return false;
+        }
+        bool hasAny = !alias.empty();
+        if (firstType && firstType->computeAliasCache()) hasAny = true;
+        if (secondType && secondType->computeAliasCache()) hasAny = true;
+        for (auto & arg : argTypes) {
+            if (arg && arg->computeAliasCache()) hasAny = true;
+        }
+        aliasCacheValid = true;
+        aliasCacheHasAlias = hasAny;
+        return hasAny;
+    }
     TypeDecl * TypeDecl::findAlias ( const string & name, bool allowAuto ) {
+        if (!aliasCacheValid) computeAliasCache();
+        if (!aliasCacheHasAlias) return nullptr;        // proven no aliases anywhere
         if (baseType == Type::alias) {
             return nullptr; // if it is another alias, can't find it
         } else if (baseType == Type::autoinfer && !allowAuto) {

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -951,6 +951,7 @@ namespace das
     bool TypeDecl::computeAliasCache() {
         // Eager full walk independent of name/allowAuto. Sets aliasCache* on every visited node.
         // alias-type subtrees are dead ends for findAlias, so treated as NoAlias.
+        if (aliasCacheValid) return aliasCacheHasAlias;
         if (baseType == Type::alias) {
             aliasCacheValid = true;
             aliasCacheHasAlias = false;


### PR DESCRIPTION
## Summary

Two independent infer-phase perf wins, identified via PerfView CPU sampling on a slow compile case (dasImgui `imgui_demo/main.das`, 13621 functions, ~30s compile-only).

### Commit 1 — hoist per-module visibility out of overload resolution inner loops

In `findFuncAddr` / `findMatchingFunctions` / `findMatchingFunctionsAndGenerics`, the per-candidate `isVisibleFunc(inWhichModule, getFunctionVisModule(pFn))` check was called once per function in `mod->functionsByName[h]`. Since `pFn->module == mod` by construction (`Module::addFunction` sets it), for non-generic candidates the visibility module is constant across the inner loop and the check is loop-invariant.

Hoist `modVis = isVisibleFunc(inWhichModule, mod)` and `modVisFromThis = thisModule->isVisibleDirectly(mod)` to the top of each non-empty bucket; per-candidate check now only fires for `fromGeneric` candidates (whose visibility module is `pFn->getOrigin()->module`).

5 call sites patched in `ast_infer_type_function.cpp` (`findFuncAddr`, two `findMatchingFunctions` overloads, two `findMatchingFunctionsAndGenerics` overloads).

### Commit 2 — lazy 2-flag subtree cache for `TypeDecl::findAlias`

`findAlias` walks `firstType` / `secondType` / `argTypes` checking each node's `alias` field. For TypeDecl subtrees that contain no aliases anywhere (the common case for non-generic / non-auto types), the walk yields nothing but still pays the recursion cost on every call.

Added a 2-bit cache in spare slots of the existing `flags` union:
- `aliasCacheValid` — set once `computeAliasCache()` has run on this node
- `aliasCacheHasAlias` — meaningful only when valid; true iff subtree contains any alias (name-independent, allowAuto-independent)

`computeAliasCache()` does one eager full walk and populates the flags on every visited node. `findAlias()` then bails in O(1) at the root when the cache says "no aliases anywhere". For subtrees with aliases, behavior is unchanged.

Cache bits are NOT cloned — both the copy ctor and the in-place `TypeDecl::clone` reset them so clones start fresh. Stored in spare bitfield slots (uint32_t flags had room) rather than a separate byte, so `sizeof(TypeDecl)` is unchanged and the shared_module ABI is preserved.

## Measurements

dasImgui `imgui_demo/main.das` compile-only, 13621 functions, Release build:

| | Total | Infer |
|---|---:|---:|
| Baseline | 29.08s | 24.43s |
| + hoist | 24.87s | 20.19s |
| + aliasCache | ~23.5s | ~18.8s |
| **Cumulative** | **-19%** | **-22%** |

PerfView CPU sampling (post-hoist): `requireModule.find` exclusive samples dropped from **9.23% → 1.38%** (-85%); `InferTypes::isVisibleFunc` dropped out of the top 20 hotspots.

## Test plan

- [x] `dastest -- --test tests`: 9316 / 9316 passed (51s)
- [x] JIT smoke (`tests/jit_tests/array.das`, `tests/decs/test_bulk_create.das`): no verifier errors
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests`: 8660 / 8660 passed (45s)
- [x] Runtime smoke: imgui_demo `--headless-frames=1` runs clean
- [x] No `.das` changes — lint / format / detect-dupe / docs N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)