### PR TITLE
cbind_boost: normalize PARSE_FILE_PREFIX so source-path strip works for backslash inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -556,13 +556,6 @@ jobs:
     # a separate SO chain, and the mingw worker doesn't exercise JIT-uses-
     # dasClangBind paths, so they coexist cleanly.
     #
-    # No `git diff --exit-code` here: the regen emits libclang's reported
-    # source-file paths in `// from ...` comments, and those paths aren't
-    # canonical across --clang_path invocations on Windows (forward-slash
-    # form vs `cygpath -w` mixed-separator form). Verifies "binder runs
-    # end-to-end" only, not "regen output is byte-canonical". A proper
-    # fix (strip path prefix in cbind_boost.das) is a follow-up.
-    #
     # TODO: bind_llvm.das self-binder doesn't run on mingw — libclang as
     # library doesn't find <cstddef> via msys2's libcxx auto-detection.
     # Needs explicit -resource-dir / -isystem injection. Tracked as a
@@ -573,4 +566,6 @@ jobs:
         set -eux
         CLANG_INCLUDE="$(cygpath -w "${MSYSTEM_PREFIX}/include")"
         ./bin/daslang.exe modules/dasClangBind/bind/bind_clangbind.das -- --clang_path "${CLANG_INCLUDE}/"
+        git diff --exit-code -- modules/dasClangBind/src/ \
+          || (echo "ERROR: dasClangBind generated files are out of date. Run './bin/daslang modules/dasClangBind/bind/bind_clangbind.das -- --clang_path <libclang-include-path>' locally and commit the result." && exit 1)
 

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -236,7 +236,12 @@ class AnyGenBind {
     }
     def init_args(pfn, pfp : string; args : array<string>) {
         PARSE_FILE_NAME = pfn
-        PARSE_FILE_PREFIX = pfp
+        // Normalize backslashes — libclang's cursor-location paths (see
+        // clang_getCursorLocationFullPath) come back with forward slashes,
+        // so for the starts_with prefix-strip in
+        // clang_getCursorLocationDescription to match on every OS+path-form
+        // combination the stored prefix must use forward slashes too.
+        PARSE_FILE_PREFIX = pfp |> replace_multiple([(text = "\\", replacement = "/")])
         ARGV := args
     }
     def openFile(path : string) {


### PR DESCRIPTION
## Summary

Followup to #2846. The mingw `build_windows_mingw` self-binder step had to drop its `git diff --exit-code` check because the regen output wasn't byte-canonical across `--clang_path` argument forms on Windows. This PR fixes the root cause and re-enables the diff check.

## Root cause

`clang_getCursorLocationDescription` in `cbind_boost.das` strips `PARSE_FILE_PREFIX` from libclang's reported source path so the `// from clang-c/X.h:line:col` comments in generated bindings stay stable across install locations.

- The cursor-side path is **already** normalized to forward slashes (`clang_getCursorLocationFullPath`, line 159).
- `PARSE_FILE_PREFIX` itself was stored **as-is** from the caller.

On the mingw CI runner the path comes from `cygpath -w`, which produces `C:\a\_temp\msys64\clang64\include/` — backslash separators with one trailing forward slash. `starts_with` then fails against the all-forward-slash cursor path, the strip is skipped, and the absolute path leaks into the regen output.

## Fix

One line in `init_args` — normalize `PARSE_FILE_PREFIX` the same way the cursor path is normalized.

## Verified locally

Same regen against the same libclang produces byte-identical output for both path forms:

```
$ daslang bind_clangbind.das -- --clang_path 'C:\msys64\clang64\include/'   # backslash
$ git diff --exit-code modules/dasClangBind/src/   # clean

$ daslang bind_clangbind.das -- --clang_path 'C:/msys64/clang64/include/'   # forward-slash
$ git diff --exit-code modules/dasClangBind/src/   # clean
```

## Test plan

- [ ] CI `build_windows_mingw` self-binder step passes with the re-enabled `git diff --exit-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)