### PR TITLE
infer: exclude aliasCache scratch bits from TypeDecl hash

### DIFF
--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -479,9 +479,25 @@ namespace das
         return hash;
     }
 
+    // Save/clear/restore the lazy findAlias cache bits (PR #2849) so they don't
+    // enter the lookup/semantic hash. The bits reflect runtime cache state, not
+    // type identity; two compiles of the same source can leave them differently
+    // set depending on findAlias lifecycle, and we don't want that to leak.
+    static __forceinline uint32_t flagsWithoutAliasCache(const TypeDecl * td) {
+        TypeDecl * mut = const_cast<TypeDecl*>(td);
+        const bool savedV = mut->aliasCacheValid;
+        const bool savedH = mut->aliasCacheHasAlias;
+        mut->aliasCacheValid = false;
+        mut->aliasCacheHasAlias = false;
+        const uint32_t result = mut->flags;
+        mut->aliasCacheValid = savedV;
+        mut->aliasCacheHasAlias = savedH;
+        return result;
+    }
+
     void TypeDecl::getLookupHash(uint64_t & hash) const {
         hash = hashmix(hash, baseType);
-        hash = hashmix(hash, flags);
+        hash = hashmix(hash, flagsWithoutAliasCache(this));
         for ( auto d : dim ) {
             hash = hashmix(hash, d);
         }
@@ -554,7 +570,7 @@ namespace das
                 wr << *(de);
             }
         }
-        hb.update(flags);
+        hb.update(flagsWithoutAliasCache(this));
         hb.updateString(wr.str());
         return hb.getHash();
     }
@@ -608,7 +624,7 @@ namespace das
                 wr << *(de);
             }
         }
-        hb.update(flags);
+        hb.update(flagsWithoutAliasCache(this));
         hb.updateString(wr.str());
         return hb.getHash();
     }


### PR DESCRIPTION
## Summary

PR #2849 added `aliasCacheValid` / `aliasCacheHasAlias` bits to the `TypeDecl::flags` union for the lazy `findAlias` subtree cache. They are runtime scratch state — set on the first `findAlias` call, retained for later calls — not part of the type's semantic identity. They were leaking into `getLookupHash`, `getSemanticHash`, and `getOwnSemanticHash` via `hashmix(hash, flags)` / `hb.update(flags)`.

Within a single compile this is deterministic (same input ⇒ same cache lifecycle ⇒ same bit state). Across two semantically equivalent TypeDecls whose `findAlias`-call lifecycles differ (one cached, one not), the hashes diverge — risky for type interning and AOT semantic hashing across module boundaries.

This adds `flagsWithoutAliasCache(td)` — save the two bits via `const_cast`, clear them, read `flags`, restore — and uses it at the 3 hash sites instead of raw `flags`.

No ABI change (bits stay in the `flags` union; the helper only touches them transiently during hash compute).

## Test plan
- [x] `daslang.exe dastest/dastest.das -- --test tests/` — **9341 passed, 0 failed**
- [x] `daslang.exe -jit tests/jit_tests/array.das` + `tests/decs/test_bulk_create.das` — no verifier errors
- [x] `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` — **8685 passed, 0 failed**
- [x] No `.das` files changed (lint/format/detect-dupe not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)