### PR TITLE
CI(windows32): disable dasLLVM + AOT examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,14 @@ jobs:
                 ;;
               windows32)
                 export PATH="/c/Strawberry/perl/bin:$PATH" # prepend Strawberry perl to path, so openssl will use it.
-                cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -T host=x64 -A ${{ matrix.architecture_string }} -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+                # No 32-bit prebuilt libLLVM-22 exists upstream (aleksisch/llvm-shared-builds
+                # only ships win64; llvm.org's 22.x Windows releases are x64 + ARM64 only).
+                # Without -DDAS_LLVM_DISABLED=ON dasLLVM's FetchContent grabs win64_llvm.tar.gz
+                # and drops a wrong-arch LLVM.dll next to the 32-bit daslang.exe — wasted
+                # bandwidth, and JIT can't load it anyway. AOT examples are off too: their
+                # daslib stub gen + test_aot are already gated off for 32-bit Windows in
+                # CMakeLists.txt, so the option here just skips the pathTracer build.
+                cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -T host=x64 -A ${{ matrix.architecture_string }} -DDAS_LLVM_DISABLED=ON -DDAS_AOT_EXAMPLES_DISABLED=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
                 cmake --build ./build --config ${{ matrix.cmake_preset }} --parallel
                 ;;
               windows64)


### PR DESCRIPTION
## Summary

- Pass `-DDAS_LLVM_DISABLED=ON` and `-DDAS_AOT_EXAMPLES_DISABLED=ON` to the `windows32` cmake invocation.
- Win32 CI continues to run interpreter `dastest /tests` only — no JIT, no AOT.

## Why

No 32-bit prebuilt `libLLVM-22` exists upstream:
- `aleksisch/llvm-shared-builds` only ships `win64_llvm.tar.gz`.
- `llvm.org`'s 22.1.5 Windows releases are x64 + ARM64 only.

Without `-DDAS_LLVM_DISABLED=ON`, `dasLLVM`'s `FetchContent` pulls `win64_llvm.tar.gz` on every Win32 CI run and drops a wrong-arch `LLVM.dll` next to the 32-bit `daslang.exe`. Today's Win32 CI gets away with it only because the Win32 test step never invokes `-jit`. The DLL is dead weight: wasted bandwidth, wasted disk, and JIT can't load it anyway.

`-DDAS_AOT_EXAMPLES_DISABLED=ON` is the matching cleanup: AOT examples' daslib stub generation + `test_aot` binary are already gated off for 32-bit Windows via the `WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4` clause in `CMakeLists.txt:1179`, so the only thing this option still affects on Win32 is the `pathTracer` example build. The "Slow Release Tests" CI step at `build.yml:398` already echoes `"Skipping AOT tests on 32-bit Windows"` for `windows32`, so nothing downstream changes.

## Verification

Local build on `E:/daslang` with both flags set (VS 2022, `-A Win32`, MSVC 14.44, Strawberry perl on PATH):

| | |
|---|---|
| Configure | clean |
| Build | 0 errors |
| `daslang.exe` arch | i386 confirmed via PE header |
| `_smoke.das` | ✅ hello world |
| Dynamic module load (PUGIXML, StbImage) | ✅ |
| `dastest /tests` | **8519 passed / 0 failed / 0 errors / 6 skipped** — same numbers CI master Win32 reports today |

## Test plan

- [ ] CI `build (windows, 32, Release, none)` — green
- [ ] CI `build (windows, 32, Debug, none)` — green
- [ ] No regression on `build (windows, 64, *)` (other arches' cmake calls unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)