### PR TITLE
daslang-live: keep ModuleGroup alive for compiled Program/Context lifetime

### DIFF
--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -169,6 +169,11 @@ static void auto_tick_agents() {
 // --- Compilation ---
 
 struct CompileResult {
+    // moduleGroup owns the non-builtin dep modules (deletes them on reset()).
+    // Program/Context hold raw Module* into it via library.modules and TypeInfo
+    // (vi->annotation_arguments → FieldDeclaration::annotation), so it must
+    // outlive program+ctx. Declared first → destroyed last.
+    unique_ptr<ModuleGroup> moduleGroup;
     ProgramPtr program;
     ContextPtr ctx;
     FileAccessPtr access;
@@ -177,6 +182,7 @@ struct CompileResult {
 
 static CompileResult compile_script(const string & fn) {
     CompileResult result;
+    result.moduleGroup = make_unique<ModuleGroup>();
     result.access = get_file_access((char*)(projectFile.empty() ? nullptr : projectFile.c_str()));
 
     CodeOfPolicies policies;
@@ -190,8 +196,7 @@ static CompileResult compile_script(const string & fn) {
     policies.rtti = true;
     policies.track_allocations = trackAllocations;
 
-    ModuleGroup moduleGroup;
-    result.program = compileDaScript(fn, result.access, tout, moduleGroup, policies);
+    result.program = compileDaScript(fn, result.access, tout, *result.moduleGroup, policies);
     if (!result.program) {
         result.errors = "failed to compile " + fn;
         tout << "ERROR: " << result.errors << "\n";


### PR DESCRIPTION
## Summary

- **Bug:** `CompileResult` in `daslang-live` held `ProgramPtr` + `ContextPtr` but the local `ModuleGroup` (which owns the non-builtin dep Modules) went out of scope on `compile_script` return. `~ModuleGroup → ModuleLibrary::reset()` deleted the modules, leaving Program's `library.modules` (raw `Module*`) and every `VarInfo::annotation_arguments` (raw ptr to `FieldDeclaration::annotation`, set in [ast_debug_info_helper.cpp:319](src/ast/ast_debug_info_helper.cpp#L319) when `rtti=true`) dangling.
- **Fix:** Move `ModuleGroup` into `CompileResult` as a `unique_ptr` declared first, so reverse-declaration-order destruction puts it after `program` and `ctx`.
- **Result:** RTTI walkers that follow `vi->annotation_arguments` (e.g. `sprint_json_at` → `JsonWriter::beforeStructureField`) no longer crash on freed memory after the lifecycle has ticked for a while.

## Why daslang.exe didn't catch this

Same ownership pattern in `utils/daScript/main.cpp` — local `dummyGroup` destroyed on return. But daslang.exe runs `main()` immediately on the heap state right after simulate, so the just-freed `AnnotationArgumentList` storage hasn't been reused yet — the dangling read happens to return correct data. daslang-live ticks many frames between simulate-init and the first RTTI-walking command (e.g. an `imgui_snapshot` POST), churning the heap, so the read crash surfaces. The bug is latent in daslang.exe too, but very hard to repro.

## Repro (pre-fix)

1. Bin checkout of any module that registers `[widget]` types with field annotations (e.g. dasImgui — `@live`, `@optional`, bitfields).
2. `daslang-live.exe <script-using-the-widgets> -load_module <module-path>`
3. POST `/command` with `{"name":"imgui_snapshot"}` after a few frames.
4. Crash in `JsonWriter::beforeStructureField + 0xc0` reading `vi->annotation_arguments`.

Post-fix: snapshot returns clean JSON with per-widget payloads (verified manually against the dasImgui PR2 repro file).

## Test plan

- [x] tests/live_host: 83/83 pass.
- [x] Manual: `imgui_snapshot` POST against the dasImgui PR2 repro returns full JSON, no crash.
- [ ] CI green.
