### PR TITLE
linq_fold: Theme 3 Phase 1 — cross-arm join+group_by splice (C3)

### DIFF
--- a/benchmarks/sql/linq_fold_chain_audit.md
+++ b/benchmarks/sql/linq_fold_chain_audit.md
@@ -34,9 +34,13 @@ Coverage extension: 1415 → 1437 linq tests (12 new tests in `tests/linq/test_l
 
 Coverage extension across both themes: 1437 → 1463 linq tests (14 new in `tests/linq/test_linq_fold_theme45_quick_wins.das`); the existing `test_unroll5c_select_distinct_count_pred_parity` + `_long_count_pred_parity` parity tests in `test_linq_from_decs.das` now exercise the splice path instead of bailing.
 
+**Theme 3 Phase 1 (cross-arm composition for C3) — landed 2026-05-24**:
+
+- **C3** (`plan_decs_group_by` with new `isDecsJoin` adapter mode): the "killer demo" composition `from_decs_template(A) |> _join(from_decs_template(B), ...) |> _group_by(K) |> _select(reducer) |> [count|to_array]` now splices end-to-end. `plan_decs_group_by` recognizes a trailing `join` upstream of `group_by_lazy` and switches to a new `GroupBySourceAdapter` mode (`isDecsJoin = true`) that emits hashB-collect + srcA-probe + per-pair result-lam bind as the per-element source loop; that bind feeds `plan_group_by_core`'s existing `tab?[uk] ?? dummy` bucket update directly. **Single pass, zero intermediate allocations** (vs the tier-2 baseline's 3: dealers-array → join-array → group-map → output-array). `plan_group_by_core` itself is untouched — the abstraction held. v1 constraints: count/to_array terminator with primitive equi-keys; no segments between `join` and `group_by_lazy`; HAVING (trailing `_where` post-aggregate) deferred to v2. Coverage extension: +7 tests / 14 sub-runs in `tests/linq/test_linq_fold_theme3_decs_join_groupby.das` (1463 → 1483).
+
 Still open (queued for the next session per the cross-cutting findings below):
 
-- Theme 3 — cross-arm composition (5 of 6 composition probes; HIGHEST impact, LARGE effort).
+- Theme 3 Phase 2-3 — C1 (`_distinct_by + _order_by + take`), C2 (`_group_by + _select + _order_by`), C5 (`_order_by + distinct + take`). Should reuse what generalizes from the C3 adapter pattern.
 - Themes 6, 7, 8 — see "Cross-cutting findings" section.
 
 
@@ -1280,9 +1284,9 @@ return <- _fold(_join(decsCars, decsDealers, on=..., into=(Region=r.region, CarN
                 |> to_array())
 ```
 
-**Classification**: FALLS-OFF — `plan_decs_join` bails at 5284 (trailing chain ops); `plan_decs_group_by` requires a decs source on top, not a `_join` invoke; default cascade builds dealer-array → join-array → group-map → select-array. Three intermediate allocations.
+**Classification (post-Theme 3 Phase 1)**: SPLICE-FIRES — `plan_decs_group_by` recognizes the trailing `join` upstream of `group_by_lazy` and switches to an `isDecsJoin` `GroupBySourceAdapter` mode (Theme 3 Phase 1 landed 2026-05-24). Emission is a single zero-arg `invoke` containing: `var inscope djoin_tab : table<...>` + `var djoin_dummy : ...` + `var djoin_jhash : table<KEY; array<TUPB>>` + `for_each_archetype(B) { ... djoin_jhash[keyb(jtb)] |> push_clone(jtb) }` (hash collect) + `for_each_archetype(A) { ... get(djoin_jhash, keya(jta), $(jarr) { for (jtb in jarr) { let djoin_jres = result_lam(jta, jtb); ... addr-compare tab update }})}` (probe + per-pair bucket update). No `__::linq\`join_impl\``, no `__::linq\`group_by_lazy_to_array\``, no intermediate `array<...>` allocations.
 
-**Conclusion**: This is the "killer demo" composition. The structural fix is to refactor `plan_decs_join` so its emission integrates with `plan_decs_group_by`'s bucket-fill — instead of `push_clone(buf, result_lam(...))` in the probe loop, emit `bucket[keyExpr] |> push_clone(...)` directly. Largest single architectural change suggested by the audit.
+**Conclusion**: The "killer demo" composition. The structural fix turned out smaller than the audit predicted: `plan_group_by_core` is **untouched** because its output emission is source-shape-agnostic (loops over `kv pairs in values(tab)` regardless of how the tab was populated). The cross-arm cooperation lives entirely in a new `adapter_emit_source_loop` branch + `GroupBySourceAdapter` field extension + `plan_decs_group_by` recognizer extension. v1 constraints: count/to_array terminator with primitive equi-keys; no segments between `join` and `group_by_lazy`; HAVING on the join+group_by chain defers to v2. The same adapter pattern is the candidate vehicle for C1 / C2 / C5 (Theme 3 Phase 2-3).
 
 ### C4 — Zip + reverse + to_array
 

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2925,18 +2925,69 @@ struct private GroupBySourceAdapter {
     initialElemType : TypeDeclPtr
     // Prefix for all hoisted names ("" for array → tab/dummy/k/uk/…; "decs_" for decs → decs_tab/decs_dummy/…). Lets the same core function generate distinct-but-recognizable names per source.
     namePrefix      : string
-    // Discriminator for the two emit functions below.
+    // Discriminator for the three emit modes below (isDecsJoin > isDecs > array fallthrough).
     isDecs          : bool
+    isDecsJoin      : bool
     // Array side: the source expression bound by finalize_emission_stmts into srcName.
     arrayTop        : Expression?
     arraySrcName    : string
     // Decs side: bridge metadata used by build_decs_tup_bind / build_decs_inner_for + the outer for_each_archetype call.
     decsBridge      : DecsBridgeShape?
+    // Decs-join side (Theme 3 — audit probe C3): hashB collect + srcA probe + per-pair result-lam bind feeds plan_group_by_core's bucket update directly. initialBindName aliases the result-lam output (one bind per (a,b) pair).
+    decsJoinBridgeA    : DecsBridgeShape?
+    decsJoinBridgeB    : DecsBridgeShape?
+    decsJoinKeyaLam    : Expression?
+    decsJoinKeybLam    : Expression?
+    decsJoinResultLam  : Expression?
+    decsJoinKeyType    : TypeDeclPtr
+    decsJoinTupBType   : TypeDeclPtr
+    decsJoinResultType : TypeDeclPtr
 }
 
 [macro_function]
 def private adapter_emit_source_loop(adapter : GroupBySourceAdapter; var body : Expression?; at : LineInfo) : Expression? {
-    // Per-element source loop. Body has been segment-wrapped (inside-out where_/select) by the caller. For array: simple `for(it in src) { body }`. For decs: inner multi-iter for via build_decs_inner_for_pruned (Wave 4 prunes unreferenced components) + outer for_each_archetype.
+    // Per-element source loop. Body has been segment-wrapped (inside-out where_/select) by the caller. Three modes: decs_join (Theme 3 C3) hashes srcB, walks srcA, binds result-lam output once per pair; decs walks via for_each_archetype + inner multi-iter for; array `for(it in src)`.
+    if (adapter.isDecsJoin) {
+        // Names — derived from namePrefix to avoid collision with the regular `decs_*` set when both fire in adjacent siblings.
+        let jhashName = qn("{adapter.namePrefix}jhash", at)
+        let arrName   = qn("{adapter.namePrefix}jarr", at)
+        let tupAName  = qn("{adapter.namePrefix}jta", at)
+        let tupBName  = qn("{adapter.namePrefix}jtb", at)
+        let resName   = adapter.initialBindName
+        // Peel join lambdas against the synthesized iter-tuple bind names. Mirrors plan_decs_join (lines 5814-5816).
+        var keyaBody   = peel_lambda_rename_var(adapter.decsJoinKeyaLam, tupAName)
+        var keybBody   = peel_lambda_rename_var(adapter.decsJoinKeybLam, tupBName)
+        var resultBody = peel_lambda_rename_2vars(adapter.decsJoinResultLam, tupAName, tupBName)
+        if (keyaBody == null || keybBody == null || resultBody == null) return null
+        var tupBindA = build_decs_tup_bind(adapter.decsJoinBridgeA, tupAName, at)
+        var tupBindB = build_decs_tup_bind(adapter.decsJoinBridgeB, tupBName, at)
+        if (tupBindA == null || tupBindB == null) return null
+        // Hash collect — same shape as plan_decs_join's collect (lines 5822-5826).
+        var collectBody <- qmacro_block_to_array() {
+            // nolint:PERF006 per-key bucket size unknown ahead of time
+            $i(jhashName)[$e(keybBody)] |> push_clone($i(tupBName))
+        }
+        var collectInner = build_decs_inner_for(adapter.decsJoinBridgeB, tupBindB, stmts_to_expr(collectBody), at)
+        // Probe — wraps the upstream body. Per-pair result-lam bind lives RIGHT BEFORE $e(body) so the segment walk + reducer table-update fire on each join pair.
+        var probeBody <- qmacro_block_to_array() {
+            get($i(jhashName), $e(keyaBody), $(var $i(arrName) : array<$t(adapter.decsJoinTupBType)>) {
+                for ($i(tupBName) in $i(arrName)) {
+                    let $i(resName) : $t(adapter.decsJoinResultType) = $e(resultBody)
+                    $e(body)
+                }
+            })
+        }
+        var probeInner = build_decs_inner_for(adapter.decsJoinBridgeA, tupBindA, stmts_to_expr(probeBody), at)
+        return qmacro_block() {
+            var $i(jhashName) : table<$t(adapter.decsJoinKeyType); array<$t(adapter.decsJoinTupBType)>>
+            for_each_archetype($e(adapter.decsJoinBridgeB.reqHashExpr), $e(adapter.decsJoinBridgeB.erqExpr), $($i(adapter.decsJoinBridgeB.archName) : Archetype) {
+                $e(collectInner)
+            })
+            for_each_archetype($e(adapter.decsJoinBridgeA.reqHashExpr), $e(adapter.decsJoinBridgeA.erqExpr), $($i(adapter.decsJoinBridgeA.archName) : Archetype) {
+                $e(probeInner)
+            })
+        }
+    }
     if (adapter.isDecs) {
         var forExprNode = build_decs_inner_for_pruned(adapter.decsBridge, adapter.initialBindName, body, at)
         let archName = adapter.decsBridge.archName
@@ -2957,8 +3008,8 @@ def private adapter_emit_source_loop(adapter : GroupBySourceAdapter; var body : 
 
 [macro_function]
 def private adapter_finalize_emission(adapter : GroupBySourceAdapter; var stmts : array<Expression?>; retType : TypeDeclPtr; at : LineInfo) : Expression? {
-    // Wrap accumulated stmts into the emission invoke. Array side: bind source as param (finalize_emission_stmts handles peel + topExpr clone). Decs side: zero-arg invoke with explicit retType (the bridge is already inline via for_each_archetype).
-    if (adapter.isDecs) {
+    // Wrap accumulated stmts into the emission invoke. Array side: bind source as param (finalize_emission_stmts handles peel + topExpr clone). Decs and decs-join: zero-arg invoke with explicit retType (bridges + hash + probe loops are already inline via for_each_archetype emitted by adapter_emit_source_loop).
+    if (adapter.isDecs || adapter.isDecsJoin) {
         var emission = qmacro(invoke($() : $t(retType) {
             $b(stmts)
         }))
@@ -4820,8 +4871,21 @@ def private plan_decs_unroll(var expr : Expression?) : Expression? {
 // ── decs group_by splice (Slice 5e — state-table over for_each_archetype) ───────
 
 [macro_function]
+def private is_primitive_join_key_type(keyType : TypeDeclPtr) : bool {
+    // Primitive equi-key shape accepted by the hashed-join splice. Non-primitive keys need `_::unique_key()` wrapping at probe/insert sites to match join_impl's hash semantics (daslib/linq.das:1678) — cascade those to tier-2 so join_impl handles them correctly.
+    return (keyType != null
+        && (keyType.baseType == Type.tInt || keyType.baseType == Type.tInt64
+            || keyType.baseType == Type.tUInt || keyType.baseType == Type.tUInt64
+            || keyType.baseType == Type.tInt8 || keyType.baseType == Type.tUInt8
+            || keyType.baseType == Type.tInt16 || keyType.baseType == Type.tUInt16
+            || keyType.baseType == Type.tString
+            || keyType.baseType == Type.tFloat || keyType.baseType == Type.tDouble
+            || keyType.baseType == Type.tBool))
+}
+
+[macro_function]
 def private plan_decs_group_by(var expr : Expression?) : Expression? {
-    // Decs-bridge entry to plan_group_by_core. Recognizer + extract_decs_bridge + adapter setup; all splice machinery lives in the shared core (decs adapter dispatches the outer for_each_archetype + inner multi-iter for + tupBind wrap).
+    // Decs-bridge entry to plan_group_by_core. Recognizer + extract_decs_bridge + adapter setup; all splice machinery lives in the shared core (decs adapter dispatches the outer for_each_archetype + inner multi-iter for + tupBind wrap). Theme 3 C3: when the upstream call is `join`, switches to the isDecsJoin adapter mode so plan_decs_join's hashB-collect + srcA-probe + per-pair result-lam bind feeds plan_group_by_core's bucket-update directly (one pass, no intermediate alloc).
     var (top, calls) = flatten_linq(expr)
     if (empty(calls)) return null
     var bridge = extract_decs_bridge(top)
@@ -4859,15 +4923,52 @@ def private plan_decs_group_by(var expr : Expression?) : Expression? {
     if ((groupByCall.arguments |> length) < 2) return null
     var keyBlock = clone_expression(groupByCall.arguments[1])
     let at = groupByCall.at
-    var adapter = GroupBySourceAdapter(
-        initialBindName := qn("decs_tup", at),
-        initialElemType = strip_const_ref(clone_type(bridge.elementType)),
-        namePrefix := "decs_",
-        isDecs = true,
-        arrayTop = null,
-        arraySrcName := "",
-        decsBridge = bridge
-    )
+    var adapter : GroupBySourceAdapter
+    // Theme 3 C3 — trailing `join` upstream of `group_by_lazy`. v1: empty calls after pop (no segments between join and group_by), HAVING blocks the path (Theme 2 trailing_where is post-aggregate; defer the join+HAVING shape to v2).
+    if (!empty(calls) && calls.back()._1.name == "join" && havingCall == null && trailingWhereCall == null) {
+        var joinCall = calls.back()._0
+        calls |> pop
+        if (!empty(calls) || (joinCall.arguments |> length) != 5) return null
+        var bridgeB = extract_decs_bridge(joinCall.arguments[1])
+        if (bridgeB == null) return null
+        var keyaLam = joinCall.arguments[2]
+        var keybLam = joinCall.arguments[3]
+        var resultLam = joinCall.arguments[4]
+        if (keyaLam == null || keybLam == null || resultLam == null
+                || keyaLam._type == null || resultLam._type == null || resultLam._type.firstType == null) return null
+        var keyType = strip_const_ref(clone_type(keyaLam._type.firstType))
+        if (!is_primitive_join_key_type(keyType)) return null
+        var resultType = strip_const_ref(clone_type(resultLam._type.firstType))
+        var tupBType = strip_const_ref(clone_type(bridgeB.elementType))
+        adapter = GroupBySourceAdapter(
+            initialBindName := qn("djoin_jres", at),
+            initialElemType = strip_const_ref(clone_type(resultLam._type.firstType)),
+            namePrefix := "djoin_",
+            isDecs = false,
+            isDecsJoin = true,
+            arrayTop = null,
+            arraySrcName := "",
+            decsBridge = null,
+            decsJoinBridgeA = bridge,
+            decsJoinBridgeB = bridgeB,
+            decsJoinKeyaLam = keyaLam,
+            decsJoinKeybLam = keybLam,
+            decsJoinResultLam = resultLam,
+            decsJoinKeyType = keyType,
+            decsJoinTupBType = tupBType,
+            decsJoinResultType = resultType
+        )
+    } else {
+        adapter = GroupBySourceAdapter(
+            initialBindName := qn("decs_tup", at),
+            initialElemType = strip_const_ref(clone_type(bridge.elementType)),
+            namePrefix := "decs_",
+            isDecs = true,
+            arrayTop = null,
+            arraySrcName := "",
+            decsBridge = bridge
+        )
+    }
     return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, trailingWhereCall, terminatorName, expr._type.isIterator, at, adapter)
 }
 

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -2954,7 +2954,7 @@ def private adapter_emit_source_loop(adapter : GroupBySourceAdapter; var body : 
         let tupAName  = qn("{adapter.namePrefix}jta", at)
         let tupBName  = qn("{adapter.namePrefix}jtb", at)
         let resName   = adapter.initialBindName
-        // Peel join lambdas against the synthesized iter-tuple bind names. Mirrors plan_decs_join (lines 5814-5816).
+        // Peel join lambdas against the synthesized iter-tuple bind names. Mirrors plan_decs_join's keya/keyb/result peel.
         var keyaBody   = peel_lambda_rename_var(adapter.decsJoinKeyaLam, tupAName)
         var keybBody   = peel_lambda_rename_var(adapter.decsJoinKeybLam, tupBName)
         var resultBody = peel_lambda_rename_2vars(adapter.decsJoinResultLam, tupAName, tupBName)
@@ -2962,7 +2962,7 @@ def private adapter_emit_source_loop(adapter : GroupBySourceAdapter; var body : 
         var tupBindA = build_decs_tup_bind(adapter.decsJoinBridgeA, tupAName, at)
         var tupBindB = build_decs_tup_bind(adapter.decsJoinBridgeB, tupBName, at)
         if (tupBindA == null || tupBindB == null) return null
-        // Hash collect — same shape as plan_decs_join's collect (lines 5822-5826).
+        // Hash collect — same shape as plan_decs_join's collect loop.
         var collectBody <- qmacro_block_to_array() {
             // nolint:PERF006 per-key bucket size unknown ahead of time
             $i(jhashName)[$e(keybBody)] |> push_clone($i(tupBName))
@@ -5895,15 +5895,7 @@ def private plan_decs_join(var expr : Expression?) : Expression? {
     var keybLam = joinCall.arguments[3]
     if (keyaLam == null || keybLam == null || keyaLam._type == null) return null
     let keyType = strip_const_ref(clone_type(keyaLam._type.firstType))
-    // Primitive-only key types — non-primitive keys would need `_::unique_key()` wrapping at probe/insert sites to match join_impl's hash semantics (daslib/linq.das:1678). Cascade everything else to tier-2 so join_impl handles them correctly.
-    if (keyType == null
-            || (keyType.baseType != Type.tInt && keyType.baseType != Type.tInt64
-                && keyType.baseType != Type.tUInt && keyType.baseType != Type.tUInt64
-                && keyType.baseType != Type.tInt8 && keyType.baseType != Type.tUInt8
-                && keyType.baseType != Type.tInt16 && keyType.baseType != Type.tUInt16
-                && keyType.baseType != Type.tString
-                && keyType.baseType != Type.tFloat && keyType.baseType != Type.tDouble
-                && keyType.baseType != Type.tBool)) return null
+    if (!is_primitive_join_key_type(keyType)) return null
     let at = joinCall.at
     let tupAName = qn("decs_tup_a", at)
     let tupBName = qn("decs_tup_b", at)

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -226,6 +226,9 @@ identical — only the source iteration changes.
    * - ``from_decs_template(...)._group_by(K)._select(reduce)._where(P).to_array()`` / ``.count()``
      - ``plan_decs_group_by`` → ``plan_group_by_core`` (trailing ``where`` as HAVING)
      - Decs mirror of the array-side post-aggregate HAVING. Same predicate-on-output-tuple semantics.
+   * - ``from_decs_template(A)._join(from_decs_template(B), ka, kb, result)._group_by(K)._select(reduce).to_array()`` / ``.count()``
+     - ``plan_decs_group_by`` (``isDecsJoin`` adapter; cross-arm — see *Decs-decs equi-join*)
+     - Theme 3 Phase 1 cross-arm composition. ``plan_decs_join``'s hashB-collect + srcA-probe feeds ``plan_group_by_core``'s bucket update directly — one pass, no intermediate join array.
    * - ``from_decs_template(...)._take_while(P).<...>`` / ``._skip_while(P).<...>``
      - ``plan_decs_unroll`` (predicate-driven ranges)
      - Hoists ``skippingName`` state across archetypes.
@@ -259,6 +262,18 @@ primitive (``int*`` / ``uint*`` / ``float`` / ``double`` / ``bool`` /
    * - ``from_decs_template(A) |> _join(...) |> _where(P) |> count() / to_array()``
      - ``plan_decs_join`` (trailing ``_where``)
      - Bind join result, evaluate predicate, gate ``count++`` / ``push_clone``. Composes with the trailing ``_select`` form (filter then project, single bind per pair).
+   * - ``from_decs_template(A) |> _join(...) |> _group_by(K) |> _select(reduce) |> count() / to_array()``
+     - ``plan_decs_group_by`` (``isDecsJoin`` adapter, Theme 3 C3)
+     - Cross-arm composition. ``plan_decs_group_by`` recognizes a trailing
+       ``join`` upstream of ``group_by_lazy`` and builds an adapter that
+       emits hashB-collect + srcA-probe + per-pair result-lam bind as the
+       per-element source loop; that bind feeds
+       ``plan_group_by_core``'s ``tab?[uk] ?? dummy`` bucket update
+       directly. Single pass, no intermediate ``join`` array. v1
+       constraints: ``count`` / ``to_array`` terminator only;
+       primitive equi-key (same guard as ``plan_decs_join``); no segments
+       between ``join`` and ``group_by_lazy``; HAVING (trailing ``_where``
+       after the reducer ``_select``) defers to v2.
 
 Zip patterns
 ============

--- a/tests/linq/test_linq_fold_theme3_decs_join_groupby.das
+++ b/tests/linq/test_linq_fold_theme3_decs_join_groupby.das
@@ -1,0 +1,233 @@
+options gen2
+
+require math
+require strings
+require daslib/linq
+require daslib/linq_boost
+require daslib/linq_fold
+require daslib/decs
+require daslib/decs_boost
+require dastest/testing_boost public
+
+// Theme 3 Phase 1 (audit `benchmarks/sql/linq_fold_chain_audit.md` probe C3): the
+// "killer demo" composition. plan_decs_group_by recognizes a trailing `join`
+// upstream of `group_by_lazy` and switches to the isDecsJoin adapter mode so
+// plan_decs_join's hashB-collect + srcA-probe + per-pair result-lam bind feeds
+// plan_group_by_core's bucket-update directly — one pass, no intermediate alloc.
+// Today (pre-PR) this composition cascades to tier-2 (3 allocs).
+
+[decs_template(prefix = "dt3c_")]
+struct C3Car {
+    id : int
+    dealer_id : int
+    name : string
+}
+
+[decs_template(prefix = "dt3d_")]
+struct C3Dealer {
+    id : int
+    region : string
+    name : string
+}
+
+def populate_c3_fixture() {
+    restart()
+    // 6 cars across 3 dealers (id 1,2,3); dealers 1 & 2 are in REGION_NORTH, 3 in REGION_SOUTH.
+    create_entities(6) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        apply_decs_template(cmp, C3Car(id = i + 1, dealer_id = i % 3 + 1, name = "Car{i}"))
+    }
+    create_entities(3) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        let region = (i == 2 ? "south" : "north")
+        apply_decs_template(cmp, C3Dealer(id = i + 1, region = region, name = "Dealer{i}"))
+    }
+}
+
+// Module-level counters for the side-effect ordering probe (C3e). Reset per test run.
+var g_c3e_result_calls = 0
+
+def c3e_make_result(carName, dealerRegion : string) : tuple<Region : string; Car : string> {
+    g_c3e_result_calls ++
+    return (Region = dealerRegion, Car = carName)
+}
+
+// ── C3a: count terminator + count reducer ──────────────────────────────────────
+
+[test]
+def test_c3a_count_count(t : T?) {
+    t |> run("C3a: _join + _group_by(_.Region) + _select(N=count()) + count() (bucket count)") @(tt : T?) {
+        populate_c3_fixture()
+        unsafe {
+            let nBuckets = _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarName = l.name))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> count())
+            // 2 distinct regions across the 6 join pairs → 2 buckets.
+            tt |> equal(nBuckets, 2)
+        }
+        restart()
+    }
+}
+
+// ── C3b: count terminator + sum reducer ────────────────────────────────────────
+
+[test]
+def test_c3b_sum_count(t : T?) {
+    t |> run("C3b: _join + _group_by(_.Region) + _select(S=sum(r.CarId)) + count()") @(tt : T?) {
+        populate_c3_fixture()
+        unsafe {
+            let nBuckets = _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarId = l.id))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, S = _._1 |> select(@(r : tuple<Region : string; CarId : int>) => r.CarId) |> sum))
+                |> count())
+            tt |> equal(nBuckets, 2)
+        }
+        restart()
+    }
+}
+
+// ── C3c: to_array terminator + named-tuple reducer (full BI shape) ─────────────
+
+[test]
+def test_c3c_to_array_named_tuple(t : T?) {
+    t |> run("C3c: _join + _group_by(_.Region) + _select((R, N=count)) + to_array (per-region bucket count)") @(tt : T?) {
+        populate_c3_fixture()
+        unsafe {
+            let rows <- _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarName = l.name))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> to_array())
+            // Cars by dealer_id: dealer1 gets cars 0,3; dealer2 gets 1,4; dealer3 gets 2,5.
+            // Regions: dealer1,2 → north (4 cars), dealer3 → south (2 cars).
+            tt |> equal(length(rows), 2)
+            var perRegion <- {for (item in rows); item.R => item.N}
+            tt |> equal(perRegion["north"], 4)
+            tt |> equal(perRegion["south"], 2)
+        }
+        restart()
+    }
+}
+
+// ── C3d: parity vs handwritten cascade ─────────────────────────────────────────
+
+def c3d_handwritten() : array<tuple<R : string; N : int>> {
+    // Manual cascade equivalent to the C3c chain. Used for byte-identical parity check below.
+    var hashB : table<int; array<tuple<region : string; name : string>>>
+    query() $ [unused_argument(eid)] (eid : EntityId; dt3d_id : int; dt3d_region : string; dt3d_name : string) {
+        hashB[dt3d_id] |> push_clone((region = dt3d_region, name = dt3d_name))
+    }
+    var perRegion : table<string; int>
+    query() $ [unused_argument(eid, dt3c_id, dt3c_name)] (eid : EntityId; dt3c_id : int; dt3c_dealer_id : int; dt3c_name : string) {
+        if (key_exists(hashB, dt3c_dealer_id)) {
+            for (d in hashB[dt3c_dealer_id]) {
+                if (key_exists(perRegion, d.region)) {
+                    perRegion[d.region] ++
+                } else {
+                    perRegion |> insert(d.region, 1)
+                }
+            }
+        }
+    }
+    var out <- [for (k, v in keys(perRegion), values(perRegion)); (R = k, N = v)]
+    return <- out
+}
+
+[test]
+def test_c3d_parity_with_handwritten(t : T?) {
+    t |> run("C3d: spliced vs handwritten cascade — per-region bucket counts must agree") @(tt : T?) {
+        populate_c3_fixture()
+        unsafe {
+            let rows <- _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarName = l.name))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> to_array())
+            let hand <- c3d_handwritten()
+            tt |> equal(length(rows), length(hand))
+            var spliced  <- {for (item in rows); item.R => item.N}
+            var hand_dict <- {for (item in hand); item.R => item.N}
+            tt |> equal(spliced["north"], hand_dict["north"])
+            tt |> equal(spliced["south"], hand_dict["south"])
+        }
+        restart()
+    }
+}
+
+// ── C3e: side-effect ordering — result lambda fires once per join pair ─────────
+
+[test]
+def test_c3e_result_lambda_called_once_per_pair(t : T?) {
+    t |> run("C3e: result lambda fires exactly len(srcA)·matchesPerKey times (no double-eval)") @(tt : T?) {
+        populate_c3_fixture()
+        g_c3e_result_calls = 0
+        unsafe {
+            let nBuckets = _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => c3e_make_result(l.name, r.region))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> count())
+            tt |> equal(nBuckets, 2)
+            // 6 cars × 1 dealer match per car = 6 result-lam invocations.
+            tt |> equal(g_c3e_result_calls, 6)
+        }
+        restart()
+    }
+}
+
+// ── C3-anti-having: cascade-still-works guard ──────────────────────────────────
+
+[test]
+def test_c3_anti_having_cascades(t : T?) {
+    t |> run("C3-anti-having: _join + _group_by + _select + _where (HAVING) — v1 cascades, must produce correct result") @(tt : T?) {
+        populate_c3_fixture()
+        unsafe {
+            let rows <- _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarName = l.name))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> _where(_.N >= 3)
+                |> to_array())
+            // Only "north" (4 cars) passes N>=3; "south" (2 cars) filtered out.
+            tt |> equal(length(rows), 1)
+            tt |> equal(rows[0].R, "north")
+            tt |> equal(rows[0].N, 4)
+        }
+        restart()
+    }
+}
+
+// ── C3-anti-segment: cascade-still-works guard ─────────────────────────────────
+
+[test]
+def test_c3_anti_segment_cascades(t : T?) {
+    t |> run("C3-anti-segment: _join + _where + _group_by — segment between join and group_by_lazy cascades, must produce correct result") @(tt : T?) {
+        populate_c3_fixture()
+        unsafe {
+            let nBuckets = _fold(from_decs_template(type<C3Car>)
+                |> _join(from_decs_template(type<C3Dealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarName = l.name))
+                |> _where(_.Region == "north")
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> count())
+            // After WHERE filter: only north (4 cars) survives → 1 bucket.
+            tt |> equal(nBuckets, 1)
+        }
+        restart()
+    }
+}

--- a/tests/linq/test_linq_fold_theme3_decs_join_groupby.das
+++ b/tests/linq/test_linq_fold_theme3_decs_join_groupby.das
@@ -119,7 +119,9 @@ def test_c3c_to_array_named_tuple(t : T?) {
 // ── C3d: parity vs handwritten cascade ─────────────────────────────────────────
 
 def c3d_handwritten() : array<tuple<R : string; N : int>> {
-    // Manual cascade equivalent to the C3c chain. Used for byte-identical parity check below.
+    // Manual cascade equivalent to the C3c chain. The C3d test below compares per-bucket counts
+    // (length + dict-comprehension lookup), so bucket order does not need to match — only the
+    // per-key totals must agree between the spliced and handwritten paths.
     var hashB : table<int; array<tuple<region : string; name : string>>>
     query() $ [unused_argument(eid)] (eid : EntityId; dt3d_id : int; dt3d_region : string; dt3d_name : string) {
         hashB[dt3d_id] |> push_clone((region = dt3d_region, name = dt3d_name))


### PR DESCRIPTION
## Summary

Closes audit probe **C3** ("killer demo" composition) from
[`benchmarks/sql/linq_fold_chain_audit.md`](benchmarks/sql/linq_fold_chain_audit.md).
First slice of **Theme 3** (cross-arm composition); follows Themes
1/2/4/5 (PRs #2851, #2852, #2857).

Chain: `from_decs_template(A) |> _join(from_decs_template(B), ka, kb, result) |> _group_by(K) |> _select(reducer) |> [count|to_array]`.
Today this cascades to tier-2 with **3 intermediate allocs** (dealers-array → join-array → group-map → output-array).
After: a single zero-arg `invoke` containing one `var jhash + for_each_archetype(B) collect + for_each_archetype(A) probe + per-pair result-lam bind → bucket update`.
**Zero intermediate allocs.**

### How

- `GroupBySourceAdapter` gained an `isDecsJoin` mode + 8 `decsJoin*` fields.
- `adapter_emit_source_loop` gained an `isDecsJoin` branch — emits the hashB-collect + srcA-probe + per-pair result-lam bind as one `qmacro_block`.
- `adapter_finalize_emission` treats `isDecsJoin` same as `isDecs` (zero-arg invoke wrap; bridges already inline).
- `plan_decs_group_by` recognizes a trailing `join` upstream of `group_by_lazy` and builds the new adapter mode (mirrors the bridge/keya/keyb/result extraction from `plan_decs_join`).
- New helper `is_primitive_join_key_type` for the v1 key-type guard.
- **`plan_group_by_core` is untouched** — its output emission (`for kv in values(tab)`) was already source-shape-agnostic. The cross-arm cooperation lives entirely in the adapter layer.

### v1 constraints (deferred to Phase 2)

- Terminator: `count` (1-arg) or implicit `to_array` only.
- Primitive equi-key (same guard as `plan_decs_join`).
- No segments between `join` and `group_by_lazy` — `join → _where → _group_by` and `join → _select → _group_by` cascade.
- HAVING (trailing `_where` after the reducer `_select`) on the join+group_by chain cascades.

### Out of scope (Phase 2-3)

- **C1** (`_distinct_by + _order_by + take`), **C2** (`_group_by + _select + _order_by`), **C5** (`_order_by + _distinct + take`) — should reuse this adapter pattern.
- **HAVING on join+group_by**.
- Inter-arm segments.
- New `groupby_join_*` bench — no existing bench exercises this composition; adding one is a Phase 2 follow-up TODO (no `results.md` refresh applies under [[feedback-living-results-md]]).

### Docs (living per [[feedback-living-linq-fold-patterns-rst]])

- [`doc/source/reference/linq_fold_patterns.rst`](doc/source/reference/linq_fold_patterns.rst): new row under *Decs-decs equi-join* + cross-ref row under *Decs patterns*.
- [`benchmarks/sql/linq_fold_chain_audit.md`](benchmarks/sql/linq_fold_chain_audit.md): Status section flags Theme 3 Phase 1 closed; C3 row flipped FALLS-OFF → SPLICE-FIRES.

## Test plan

- [ ] CI green (lint, AOT regen, JIT)
- [x] `mcp__daslang__compile_check` clean on `daslib/linq_fold.das` + new test file
- [x] `mcp__daslang__lint` clean (0 issues both files)
- [x] `mcp__daslang__ast_dump` on probe `_fold(_join + _group_by + _select(N=count()) + count())` confirms single-pass splice: `var djoin_jhash : table<int; array<TUPB>>` + `for_each_archetype(B) { ... djoin_jhash[keyb] |> push_clone(jtb) }` + `for_each_archetype(A) { ... get(djoin_jhash, keya, $(jarr) { for (jtb in jarr) { let djoin_jres = ...; addr-compare tab update }})}` + `return length(djoin_tab)`. **No** `__::linq\`join_impl\``, **no** `__::linq\`group_by_lazy_to_array\``, **no** `__::linq\`select\``.
- [x] New test file: 7 tests / 14 sub-runs all pass interp.
- [x] Full linq matrix: 1483/1483 pass interp (was 1463 on master; +20 from new test file).
- [x] Full decs matrix: 245/245 pass interp (unchanged).
- [x] `mcp__daslang__format_file`: both files already formatted.
- [x] Anti-tests (`test_c3_anti_having_cascades`, `test_c3_anti_segment_cascades`) verify shapes outside v1 scope still cascade to correct results — `join_impl` instance appears in the compile output confirming the cascade fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)