### PR TITLE
linq_fold: Theme 3 Phase 2 — trailing `_order_by` on group_by (audit C2)

### DIFF
--- a/benchmarks/sql/linq_fold_chain_audit.md
+++ b/benchmarks/sql/linq_fold_chain_audit.md
@@ -38,9 +38,13 @@ Coverage extension across both themes: 1437 → 1463 linq tests (14 new in `test
 
 - **C3** (`plan_decs_group_by` with new `isDecsJoin` adapter mode): the "killer demo" composition `from_decs_template(A) |> _join(from_decs_template(B), ...) |> _group_by(K) |> _select(reducer) |> [count|to_array]` now splices end-to-end. `plan_decs_group_by` recognizes a trailing `join` upstream of `group_by_lazy` and switches to a new `GroupBySourceAdapter` mode (`isDecsJoin = true`) that emits hashB-collect + srcA-probe + per-pair result-lam bind as the per-element source loop; that bind feeds `plan_group_by_core`'s existing `tab?[uk] ?? dummy` bucket update directly. **Single pass, zero intermediate allocations** (vs the tier-2 baseline's 3: dealers-array → join-array → group-map → output-array). `plan_group_by_core` itself is untouched — the abstraction held. v1 constraints: count/to_array terminator with primitive equi-keys; no segments between `join` and `group_by_lazy`; HAVING (trailing `_where` post-aggregate) deferred to v2. Coverage extension: +7 tests / 14 sub-runs in `tests/linq/test_linq_fold_theme3_decs_join_groupby.das` (1463 → 1483).
 
+**Theme 3 Phase 2 (cross-arm composition for C2) — landed 2026-05-24**:
+
+- **C2** (`plan_group_by_core` trailing `_order_by` extension): the canonical SQL `GROUP BY ... ORDER BY` shape `<source> |> _group_by(K) |> _select(reduce) |> _order_by(K2) |> to_array()` now splices end-to-end. Both `plan_group_by` and `plan_decs_group_by` pop an optional trailing `_order_by` / `_order_by_descending` after the count check; `plan_group_by_core`'s to_array lane emits an inline-cmp `sort(buf, ...)` right after the bucket-fill — mutating the same buffer in place. **One pass + in-place sort** (vs the tier-2 cascade's three allocations: `group_by_lazy_to_array` → `select` → fresh-array sort). Three lanes share the same sort tail (array source, decs source via `isDecs`, decs-decs join via `isDecsJoin` — Theme 3 Phase 1 composes cleanly). v1 constraints: inline-able key only (pure single-expression lambda, no sideeffects); bare `_order` / `_order_descending` (no key) deferred; non-inline keys cascade. Composes with HAVING (`_select(reduce) |> _where(P) |> _order_by(K2)`). Coverage extension: +7 tests / 14 sub-runs in `tests/linq/test_linq_fold_theme3_c2_group_by_order_by.das` (1483 → 1497).
+
 Still open (queued for the next session per the cross-cutting findings below):
 
-- Theme 3 Phase 2-3 — C1 (`_distinct_by + _order_by + take`), C2 (`_group_by + _select + _order_by`), C5 (`_order_by + distinct + take`). Should reuse what generalizes from the C3 adapter pattern.
+- Theme 3 Phase 3 — C1 (`_distinct_by + _order_by + take`), C5 (`_order_by + distinct + take`). Likely reusable: C1/C5 are the same arm-pair (distinct ↔ order_family) in mirror order.
 - Themes 6, 7, 8 — see "Cross-cutting findings" section.
 
 
@@ -1268,9 +1272,9 @@ __::linq`order_by_inplace(pass_1, $(_) { return _.C; });
 return <- pass_1;
 ```
 
-**Classification**: FALLS-OFF — `plan_group_by` bails because trailing op is `_order_by`.
+**Classification (post-Theme 3 Phase 2)**: SPLICE-FIRES — both `plan_group_by` and `plan_decs_group_by` now pop an optional trailing `_order_by` / `_order_by_descending` after the count check; `plan_group_by_core`'s to_array lane emits an inline-cmp `sort(buf, $(v1, v2) => _::less(v1.K, v2.K))` right after the bucket-fill (using the same `try_make_inline_cmp` helper as `plan_order_family`). Emission shape: single zero-arg `invoke` containing `var inscope tab : table<...>` + `var dummy : ...` + bucket-fill `for (it in source)` loop + `var buf : array<...>` + `buf |> reserve(length(tab))` + `for (kv in values(tab)) buf |> push_clone(...)` + `sort(buf, INLINE_CMP)` + `return <- buf` + `finally finalize(tab)`. No `__::linq\`group_by_lazy_to_array\``, `__::linq\`select\``, or `__::linq\`order_by_inplace\`` calls; sort is inlined.
 
-**Conclusion**: `plan_group_by_core` already builds the bucket map directly. Letting `_select` + `_order_by` consume the bucket inside the same emission would give 1 hashmap walk + 1 inplace sort but skip the intermediate `array<tuple<string;array<Item>>>` materialization. Cross-cuts with 7b/C1 observation.
+**Conclusion**: One pass + in-place sort over a single output buffer (Theme 3 Phase 2 landed 2026-05-24). The same `plan_group_by_core` to_array tail serves all three source shapes (array via `plan_group_by`, decs via `plan_decs_group_by`'s `isDecs` mode, decs-decs join via `isDecsJoin` mode — Theme 3 Phase 1 composes cleanly with this extension). v1 constraints: inline-able key only (pure single-expression lambda, no sideeffects); bare `_order` / `_order_descending` (no key) deferred since group_by output is typically a named tuple where `<` is ill-defined; non-inline keys cascade. Composes with HAVING.
 
 ### C3 — Decs join + select + group_by + select
 

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3027,6 +3027,8 @@ def private plan_group_by_core(var calls : array<tuple<ExprCall?; LinqCall?>>;
                                var havingCall : ExprCall?;
                                var trailingWhereCall : ExprCall?;
                                terminatorName : string;
+                               orderName : string;
+                               var orderKey : Expression?;
                                exprIsIterator : bool;
                                at : LineInfo;
                                var adapter : GroupBySourceAdapter) : Expression? {
@@ -3372,6 +3374,14 @@ def private plan_group_by_core(var calls : array<tuple<ExprCall?; LinqCall?>>;
                 }
             }
         }
+        // Theme 3 Phase 2 C2: trailing `_order_by` / `_order_by_descending` on the output buffer — inline-cmp sort against the user's key. Skips the cascade's separate `order_by_inplace` call by mutating the same buf we just filled. Only inline-able keys (pure single-expression lambda, no sideeffects) splice; non-inline cascades.
+        if (orderName != "") {
+            var inlineCmp = try_make_inline_cmp(orderKey, orderName, bufElemType, at)
+            if (inlineCmp == null) return null
+            stmts |> push <| qmacro_expr() {
+                sort($i(bufName), $e(inlineCmp))
+            }
+        }
         stmts |> push(buffer_return(bufName, exprIsIterator))
     }
     return adapter_finalize_emission(adapter, stmts, retType, at)
@@ -3390,6 +3400,18 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         let lastName = calls.back()._1.name
         if (lastName == "count" && length(calls.back()._0.arguments) == 1) {
             terminatorName = lastName
+            calls |> pop
+        }
+    }
+    // Optional: trailing `_order_by(KEY)` / `_order_by_descending(KEY)` on the output (Theme 3 Phase 2, closes audit C2). Only on the to_array lane — sort + count would be wasted work; for count we cascade so the predicate-less sort isn't silently elided either. Bare `_order` / `_order_descending` (no key) are not in scope for v1: the bucket output is typically a named tuple, and `<` on tuples is ill-defined.
+    var orderName : string = ""
+    var orderKey : Expression?
+    if (terminatorName == "" && !empty(calls)
+            && (calls.back()._1.name == "order_by" || calls.back()._1.name == "order_by_descending")) {
+        var orderCall = calls.back()._0
+        if ((orderCall.arguments |> length) >= 2) {
+            orderName = calls.back()._1.name
+            orderKey = clone_expression(orderCall.arguments[1])
             calls |> pop
         }
     }
@@ -3426,7 +3448,7 @@ def private plan_group_by(var expr : Expression?) : Expression? {
         arraySrcName := qn("source", at),
         decsBridge = null
     )
-    return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, trailingWhereCall, terminatorName, expr._type.isIterator, at, adapter)
+    return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, trailingWhereCall, terminatorName, orderName, orderKey, expr._type.isIterator, at, adapter)
 }
 
 // ── decs eager-bridge unroll (Approach Z — for_each_archetype + nested _fold) ───────
@@ -4899,6 +4921,18 @@ def private plan_decs_group_by(var expr : Expression?) : Expression? {
             calls |> pop
         }
     }
+    // Optional: trailing `_order_by(KEY)` / `_order_by_descending(KEY)` on the output (Theme 3 Phase 2 C2). Decs mirror of the array-side pop. Both the isDecs and isDecsJoin adapter modes share this — the sort fires on the same buf the to_array lane fills regardless of source shape.
+    var orderName : string = ""
+    var orderKey : Expression?
+    if (terminatorName == "" && !empty(calls)
+            && (calls.back()._1.name == "order_by" || calls.back()._1.name == "order_by_descending")) {
+        var orderCall = calls.back()._0
+        if ((orderCall.arguments |> length) >= 2) {
+            orderName = calls.back()._1.name
+            orderKey = clone_expression(orderCall.arguments[1])
+            calls |> pop
+        }
+    }
     // Optional: trailing _where AFTER _select(reducer) — SQL HAVING shape on post-aggregate tuple. Theme 2 (closes audit 4e). Decs mirror of the array-side pop.
     var trailingWhereCall : ExprCall?
     if (!empty(calls) && calls.back()._1.name == "where_") {
@@ -4969,7 +5003,7 @@ def private plan_decs_group_by(var expr : Expression?) : Expression? {
             decsBridge = bridge
         )
     }
-    return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, trailingWhereCall, terminatorName, expr._type.isIterator, at, adapter)
+    return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, trailingWhereCall, terminatorName, orderName, orderKey, expr._type.isIterator, at, adapter)
 }
 
 // ── decs order family splice (Slice 5d — buffer + order_inplace/top_n/min_by/max_by) ───────

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -160,6 +160,9 @@ Array-source patterns
    * - ``._group_by(K)._select(reduce)._where(P).to_array()`` / ``.count()``
      - ``plan_group_by`` → ``plan_group_by_core`` (trailing ``where`` as HAVING)
      - HAVING filter on the constructed post-aggregate tuple (predicate references ``_.AggField`` by name). Distinct from ``_having(P)`` and orthogonal — both can fire on the same chain.
+   * - ``._group_by(K)._select(reduce)._order_by(K2).to_array()`` / ``._order_by_descending(K2).to_array()``
+     - ``plan_group_by`` → ``plan_group_by_core`` (trailing ``order_by`` as ORDER BY)
+     - Theme 3 Phase 2 (audit C2). Inline-cmp ``sort(buf, ...)`` after the bucket-fill mutates the same output buffer in place — vs the tier-2 cascade's separate ``order_by_inplace`` over a fresh allocation. v1: ``_order_by(K2)`` / ``_order_by_descending(K2)`` with inline-able key only; non-inline keys (side-effects, multi-stmt body) cascade. Composes with HAVING / ``_having(P)``.
    * - ``.reverse().take(N).to_array()`` (with no ``where`` / ``select``)
      - ``plan_reverse`` (two-pass)
      - Sum archetype sizes, then walk tail-first with skip-counter and early-exit.
@@ -226,9 +229,12 @@ identical — only the source iteration changes.
    * - ``from_decs_template(...)._group_by(K)._select(reduce)._where(P).to_array()`` / ``.count()``
      - ``plan_decs_group_by`` → ``plan_group_by_core`` (trailing ``where`` as HAVING)
      - Decs mirror of the array-side post-aggregate HAVING. Same predicate-on-output-tuple semantics.
+   * - ``from_decs_template(...)._group_by(K)._select(reduce)._order_by(K2).to_array()`` / ``._order_by_descending(K2).to_array()``
+     - ``plan_decs_group_by`` → ``plan_group_by_core`` (trailing ``order_by`` as ORDER BY)
+     - Decs mirror of the array-side ORDER BY splice (Theme 3 Phase 2 C2). Shares the same in-place inline-cmp sort tail; only the bucket-fill source differs.
    * - ``from_decs_template(A)._join(from_decs_template(B), ka, kb, result)._group_by(K)._select(reduce).to_array()`` / ``.count()``
      - ``plan_decs_group_by`` (``isDecsJoin`` adapter; cross-arm — see *Decs-decs equi-join*)
-     - Theme 3 Phase 1 cross-arm composition. ``plan_decs_join``'s hashB-collect + srcA-probe feeds ``plan_group_by_core``'s bucket update directly — one pass, no intermediate join array.
+     - Theme 3 Phase 1 cross-arm composition. ``plan_decs_join``'s hashB-collect + srcA-probe feeds ``plan_group_by_core``'s bucket update directly — one pass, no intermediate join array. Composes with the C2 trailing ``order_by`` extension above when applied to the join+group_by output.
    * - ``from_decs_template(...)._take_while(P).<...>`` / ``._skip_while(P).<...>``
      - ``plan_decs_unroll`` (predicate-driven ranges)
      - Hoists ``skippingName`` state across archetypes.

--- a/tests/linq/test_linq_fold_theme3_c2_group_by_order_by.das
+++ b/tests/linq/test_linq_fold_theme3_c2_group_by_order_by.das
@@ -1,0 +1,257 @@
+options gen2
+
+require math
+require strings
+require daslib/linq
+require daslib/linq_boost
+require daslib/linq_fold
+require daslib/decs
+require daslib/decs_boost
+require dastest/testing_boost public
+
+// Theme 3 Phase 2 (audit `benchmarks/sql/linq_fold_chain_audit.md` probe C2): the
+// canonical SQL `GROUP BY ... ORDER BY COUNT(*)` shape ("brands sorted by
+// frequency"). plan_group_by_core gained an `orderName`/`orderKey` lane that
+// emits an inline-cmp `sort(buf, ...)` right after the to_array buf-fill,
+// mutating the same buffer in place. Today (pre-PR) this composition cascades
+// to tier-2 (3 array allocs: group_by_lazy_to_array → select → order_by_inplace).
+
+// ── C2a: array source + order_by ascending ────────────────────────────────────
+
+[test]
+def test_c2a_array_order_by_asc(t : T?) {
+    t |> run("C2a: each(items) + _group_by + _select((B,C=count)) + _order_by(_.C) + to_array — array source, ascending") @(tt : T?) {
+        var items <- [for (i in range(20)); (brand = "B{i % 4}", price = float(i))]
+        let rows <- _fold(each(items)
+            |> _group_by(_.brand)
+            |> _select((B = _._0, C = _._1 |> count()))
+            |> _order_by(_.C)
+            |> to_array())
+        // 4 brands, each with 5 rows. C is identical → order_by ties trivially.
+        tt |> equal(length(rows), 4)
+        for (r in rows) {
+            tt |> equal(r.C, 5)
+        }
+    }
+}
+
+// ── C2b: array source + order_by descending with unequal counts ───────────────
+
+[test]
+def test_c2b_array_order_by_desc(t : T?) {
+    t |> run("C2b: _order_by_descending + unequal bucket counts — must produce descending-by-C sequence") @(tt : T?) {
+        // Brand frequencies: A×6, B×3, C×2, D×1 → desc order [A, B, C, D].
+        var items <- [for (k in [
+            "A", "A", "A", "A", "A", "A",
+            "B", "B", "B",
+            "C", "C",
+            "D"
+        ]); (brand = k, price = 0.0f)]
+        let rows <- _fold(each(items)
+            |> _group_by(_.brand)
+            |> _select((B = _._0, C = _._1 |> count()))
+            |> _order_by_descending(_.C)
+            |> to_array())
+        tt |> equal(length(rows), 4)
+        tt |> equal(rows[0].B, "A")
+        tt |> equal(rows[0].C, 6)
+        tt |> equal(rows[1].B, "B")
+        tt |> equal(rows[1].C, 3)
+        tt |> equal(rows[2].B, "C")
+        tt |> equal(rows[2].C, 2)
+        tt |> equal(rows[3].B, "D")
+        tt |> equal(rows[3].C, 1)
+    }
+}
+
+// ── C2c: parity vs handwritten cascade — same input, two paths agree ──────────
+
+def c2c_handwritten(items : array<tuple<brand : string; price : float>>) : array<tuple<B : string; C : int>> {
+    var perBrand : table<string; int>
+    for (it in items) {
+        if (key_exists(perBrand, it.brand)) {
+            perBrand[it.brand] ++
+        } else {
+            perBrand |> insert(it.brand, 1)
+        }
+    }
+    var out <- [for (k, v in keys(perBrand), values(perBrand)); (B = k, C = v)]
+    sort(out, $(a, b) => _::less(a.C, b.C))
+    return <- out
+}
+
+[test]
+def test_c2c_parity_handwritten(t : T?) {
+    t |> run("C2c: spliced sort vs handwritten cascade — sequences must match element-for-element") @(tt : T?) {
+        // Distinct counts so ascending sort is deterministic.
+        var items <- [for (k in [
+            "X", "X",
+            "Y", "Y", "Y", "Y",
+            "Z",
+            "W", "W", "W"
+        ]); (brand = k, price = 0.0f)]
+        let spliced <- _fold(each(items)
+            |> _group_by(_.brand)
+            |> _select((B = _._0, C = _._1 |> count()))
+            |> _order_by(_.C)
+            |> to_array())
+        let hand <- c2c_handwritten(items)
+        tt |> equal(length(spliced), length(hand))
+        for (i in range(length(spliced))) {
+            tt |> equal(spliced[i].B, hand[i].B)
+            tt |> equal(spliced[i].C, hand[i].C)
+        }
+    }
+}
+
+// ── C2d: order_by composes with HAVING (trailing _where) ──────────────────────
+
+[test]
+def test_c2d_order_by_after_having(t : T?) {
+    t |> run("C2d: _select(reducer) + _where(HAVING) + _order_by + to_array — HAVING gates buckets, sort fires on survivors") @(tt : T?) {
+        // A×6, B×3, C×2, D×1 → HAVING C>=2 keeps A,B,C; sort asc → C,B,A.
+        var items <- [for (k in [
+            "A", "A", "A", "A", "A", "A",
+            "B", "B", "B",
+            "C", "C",
+            "D"
+        ]); (brand = k, price = 0.0f)]
+        let rows <- _fold(each(items)
+            |> _group_by(_.brand)
+            |> _select((B = _._0, C = _._1 |> count()))
+            |> _where(_.C >= 2)
+            |> _order_by(_.C)
+            |> to_array())
+        tt |> equal(length(rows), 3)
+        tt |> equal(rows[0].B, "C")
+        tt |> equal(rows[0].C, 2)
+        tt |> equal(rows[1].B, "B")
+        tt |> equal(rows[1].C, 3)
+        tt |> equal(rows[2].B, "A")
+        tt |> equal(rows[2].C, 6)
+    }
+}
+
+// ── C2-anti: non-inline key cascades ─────────────────────────────────────────
+
+// Side-effecting key body fails try_make_inline_cmp's `has_sideeffects(ret.subexpr)` guard → plan_group_by_core returns null → full cascade.
+var g_c2anti_key_calls = 0
+
+def c2anti_count_and_return_C(v : tuple<B : string; C : int>) : int {
+    g_c2anti_key_calls ++
+    return v.C
+}
+
+[test]
+def test_c2_anti_non_inline_key_cascades(t : T?) {
+    t |> run("C2-anti: _order_by(side-effecting fn call) — must cascade to tier-2 (no splice) AND produce correct sorted output") @(tt : T?) {
+        let items <- [for (k in [
+            "A", "A", "A",
+            "B", "B",
+            "C"
+        ]); (brand = k, price = 0.0f)]
+        g_c2anti_key_calls = 0
+        let rows <- _fold(each(items)
+            |> _group_by(_.brand)
+            |> _select((B = _._0, C = _._1 |> count()))
+            |> _order_by(c2anti_count_and_return_C(_))
+            |> to_array())
+        // Output sorted ascending by C: C(1), B(2), A(3).
+        tt |> equal(length(rows), 3)
+        tt |> equal(rows[0].B, "C")
+        tt |> equal(rows[1].B, "B")
+        tt |> equal(rows[2].B, "A")
+        // Cascade path (linq.das `order_by_inplace`) invokes the key per element — counter must be > 0. Splice would have inlined the body and never executed the increment.
+        tt |> equal(g_c2anti_key_calls > 0, true)
+    }
+}
+
+// ── C2-decs: decs source + order_by ──────────────────────────────────────────
+
+[decs_template(prefix = "c2dt_")]
+struct C2Sale {
+    region : string
+    amount : int
+}
+
+def populate_c2_decs() {
+    restart()
+    // R×4, S×2, T×1 sales → desc by count: R, S, T.
+    create_entities(7) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        let region = (i < 4 ? "R" : (i < 6 ? "S" : "T"))
+        apply_decs_template(cmp, C2Sale(region = region, amount = i * 10))
+    }
+}
+
+[test]
+def test_c2_decs_order_by_desc(t : T?) {
+    t |> run("C2-decs: from_decs_template + _group_by + _select(count) + _order_by_descending + to_array — decs adapter feeds inline sort") @(tt : T?) {
+        populate_c2_decs()
+        unsafe {
+            let rows <- _fold(from_decs_template(type<C2Sale>)
+                |> _group_by(_.region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> _order_by_descending(_.N)
+                |> to_array())
+            tt |> equal(length(rows), 3)
+            tt |> equal(rows[0].R, "R")
+            tt |> equal(rows[0].N, 4)
+            tt |> equal(rows[1].R, "S")
+            tt |> equal(rows[1].N, 2)
+            tt |> equal(rows[2].R, "T")
+            tt |> equal(rows[2].N, 1)
+        }
+        restart()
+    }
+}
+
+// ── C2-decs-join: cross-arm composition — decs_join + group_by + order_by ────
+
+[decs_template(prefix = "c2j_car_")]
+struct C2JoinCar {
+    id : int
+    dealer_id : int
+}
+
+[decs_template(prefix = "c2j_dlr_")]
+struct C2JoinDealer {
+    id : int
+    region : string
+}
+
+def populate_c2_decs_join() {
+    restart()
+    // 6 cars: dealer_ids cycle 1,2,3,1,2,3 → 2 cars per dealer.
+    create_entities(6) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        apply_decs_template(cmp, C2JoinCar(id = i, dealer_id = i % 3 + 1))
+    }
+    // 3 dealers; ids 1,2 → "north" (4 cars), id 3 → "south" (2 cars).
+    create_entities(3) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+        let region = (i == 2 ? "south" : "north")
+        apply_decs_template(cmp, C2JoinDealer(id = i + 1, region = region))
+    }
+}
+
+[test]
+def test_c2_decs_join_order_by(t : T?) {
+    t |> run("C2-decs-join: from_decs_template(Car) + _join(Dealer) + _group_by(Region) + _select(count) + _order_by + to_array — isDecsJoin adapter + inline sort, single pass end-to-end") @(tt : T?) {
+        populate_c2_decs_join()
+        unsafe {
+            let rows <- _fold(from_decs_template(type<C2JoinCar>)
+                |> _join(from_decs_template(type<C2JoinDealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Region = r.region, CarId = l.id))
+                |> _group_by(_.Region)
+                |> _select((R = _._0, N = _._1 |> count()))
+                |> _order_by(_.N)
+                |> to_array())
+            // south(2), north(4) ascending.
+            tt |> equal(length(rows), 2)
+            tt |> equal(rows[0].R, "south")
+            tt |> equal(rows[0].N, 2)
+            tt |> equal(rows[1].R, "north")
+            tt |> equal(rows[1].N, 4)
+        }
+        restart()
+    }
+}


### PR DESCRIPTION
## Summary

- The canonical SQL `GROUP BY ... ORDER BY` shape now splices end-to-end across all three group_by source modes (array, decs, decs-join). Closes audit "killer demo" probe **C2** (`benchmarks/sql/linq_fold_chain_audit.md`).
- Both `plan_group_by` and `plan_decs_group_by` pop an optional trailing `_order_by` / `_order_by_descending` after the count check; `plan_group_by_core`'s to_array lane emits an inline-cmp `sort(buf, $(v1, v2) => _::less(v1.K, v2.K))` right after the bucket-fill, mutating the same buffer in place.
- Today (master `822a7bb85`) this composition cascades to tier-2: three array allocations — `group_by_lazy_to_array` → `select` → fresh-array `order_by_inplace`. After this PR: single zero-arg invoke, one buf allocation, inlined sort.

### Architecture

The fix is small because the abstraction held: `plan_group_by_core` is the single bucket-reducer engine shared by `plan_group_by` (array), `plan_decs_group_by` isDecs mode (decs), and `plan_decs_group_by` isDecsJoin mode (decs-decs join, Theme 3 Phase 1). One new emission tail (post-bucket-fill `sort(buf, INLINE_CMP)`) covers all three lanes.

Splice path:
```
var inscope tab : table<...>      // bucket map
var dummy : ...                    // sentinel for first-key-wins
for (it in <source>) { ... }       // bucket fill (per source-shape)
var buf : array<...>
buf |> reserve(length(tab))
for (kv in values(tab)) { buf |> push_clone(...) }
sort(buf, $(v1, v2) { return _::less(v1.K, v2.K); })   // ← NEW (inlined)
return <- buf
finally { finalize(tab) }
```

Uses the same `try_make_inline_cmp` helper as `plan_order_family` — no new sort/heap machinery.

### v1 constraints

- **Inline-able key only** (pure single-expression lambda, no sideeffects). Non-inline keys cascade. Reuses `try_make_inline_cmp`'s existing `has_sideeffects(ret.subexpr)` + `blk.list |> length != 1` guards.
- **Bare `_order` / `_order_descending`** (no key) deferred: group_by output is typically a named tuple where `<` is ill-defined.
- **`count` + `_order_by` cascades**: sort over a final scalar would be wasted work; current behavior preserved.

### Composes with

- HAVING via trailing `_where` (`_select(reduce) |> _where(P) |> _order_by(K2)`) — Theme 2.
- `_having(P)` between `group_by_lazy` and `_select` — pre-existing.
- isDecsJoin adapter (Theme 3 Phase 1) — decs-decs join + group_by + order_by chain shares the same in-place sort tail.

## Test plan

New file: `tests/linq/test_linq_fold_theme3_c2_group_by_order_by.das` — 7 tests / 14 sub-runs.

- [x] **C2a** — array source + `_order_by` ascending (equal counts; bucket-count check)
- [x] **C2b** — array source + `_order_by_descending` with unequal counts (validates desc ordering)
- [x] **C2c** — parity vs handwritten cascade (spliced output matches manual table+sort element-for-element)
- [x] **C2d** — composes with HAVING (`_select(reducer) |> _where(_.C >= 2) |> _order_by(_.C)` — gate then sort)
- [x] **C2-anti** — non-inline key (side-effecting fn call) must cascade AND still produce correct output (counter > 0 confirms cascade path executed user fn per element)
- [x] **C2-decs** — `from_decs_template + _group_by + _select + _order_by_descending + to_array` — decs adapter feeds inline sort
- [x] **C2-decs-join** — `from_decs_template(A) + _join + _group_by + _select + _order_by + to_array` — isDecsJoin adapter (Theme 3 Phase 1) composes with the new sort tail

- [x] 1497/1497 linq tests pass (interp) — was 1483 baseline on master; +14 new sub-runs
- [x] 245/245 decs tests pass (interp)
- [x] Lint clean (`mcp__daslang__lint`); format clean (`mcp__daslang__format_file`)
- [x] ast_dump confirms splice fires (single zero-arg invoke, single `buf` allocation, inlined `__builtin_sort_array_any_cblock(buf, ..., $(v1, v2) { return _::less(v1.C, v2.C); })`, no `group_by_lazy_to_array` / `select` / `order_by_inplace`)
- [x] ast_dump confirms anti-test cascades (cascade `group_by_lazy_to_array` + `order_by_inplace` instances present, splice instances absent)

### AOT note

The new test file needs an AOT stub regenerated by CI's `test_aot_linq` cmake target (same state as other Theme 3+ tests).

## Living docs

Per [[feedback-living-linq-fold-patterns-rst]] and the chain-audit refresh policy:

- `doc/source/reference/linq_fold_patterns.rst`: new row in **Array source patterns** and **Decs-source patterns** tables for the `_order_by` extension; cross-ref note added to the Decs equi-join row.
- `benchmarks/sql/linq_fold_chain_audit.md`: C2 row flipped FALLS-OFF → SPLICE-FIRES (full emission shape documented); Status section gained a "Theme 3 Phase 2 — landed 2026-05-24" block; "Still open" reframed to Phase 3 (C1 + C5 are likely shareable since both are distinct↔order_family arm pairs).

## Phase 3 follow-ups

- **C1** — `_distinct_by + _order_by + take` ("top-K most recent distinct users")
- **C5** — `_order_by + distinct + take` (variant of C1, order-first)
- **Bench**: add `groupby_order_by_count.das` to `benchmarks/sql/` (no existing bench combines group_by + order_by today; bench addition deliberately deferred to keep this PR focused on the splice arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)