### PR TITLE
ast_handle: gc_local scratch TypeDecl in ManagedVectorAnnotation::walk

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -502,7 +502,10 @@ namespace das
             {
                 lock_guard<recursive_mutex> guard(walkMutex);
                 if ( !ati ) {
-                    auto dimType = new TypeDecl(*vecType);
+                    // gc_local: scratch TypeDecl just to drive makeTypeInfo —
+                    // read once, never stored on the result. RAII unlinks from
+                    // the thread gc_root immediately and deletes at scope exit.
+                    gc_local<TypeDecl> dimType(new TypeDecl(*vecType));
                     dimType->ref = 0;
                     dimType->dim.push_back(1);
                     ati = helpA.makeTypeInfo(nullptr, dimType);


### PR DESCRIPTION
## Summary

- **Bug:** `ManagedVectorAnnotation<T>::walk` in [ast_handle.h:505](include/daScript/ast/ast_handle.h#L505) constructs a scratch `TypeDecl` via `new TypeDecl(*vecType)` to drive `helpA.makeTypeInfo(nullptr, dimType)`, then drops the pointer. Pre-gc_node-migration the smart_ptr conversion at the call site auto-released; post-migration (ec3e3079ee) `TypeDeclPtr = TypeDecl*` and `new TypeDecl(...)` is a gc_node tracked on the thread `gc_root` until explicit delete.
- **Result:** the very first walk of a managed-vector field on any context leaks one TypeDecl. Daslang/daslang-live's exit-time check (`gc_root::gc_get_thread_root().gc_count != 0`) then returns exit code 1.

## How surfaced

PR #2854's new `sprint_json_at(addr, ti, human)` builtin let dasImgui's `imgui_snapshot` walk widget state structs containing `ImVector<char>` fields (ImGui InputBuf-style). That's the first daslang-live workflow that routinely hits `ManagedVectorAnnotation<ImVector<char>>::walk` and trips the exit-1.

Reproducible end-to-end:
- `daslang-live` + any script with a managed-vector field walked via `sprint_json_at` / `sprint_json` / `sprint_data` / `debug_json_scan` / archive serialize → exit 1 with `GC LEAK: 1 gc_node(s) leaked ... type=TypeDecl magic=0x1ee70001`.
- `DAS_GC_BREAK_ON_ID=<id>` confirms the construction site is `ast_handle.h:505` via stack `ManagedVectorAnnotation<ImVector<char>>::walk → DataWalker::walk → debug_json_value → builtin_json_sprint_at`.

## Fix

Wrap the scratch TypeDecl in `gc_local<TypeDecl>` (defined in [misc/gc_node.h:104](include/daScript/misc/gc_node.h#L104)). RAII unlinks from the thread `gc_root` immediately on construction and deletes at scope exit — matches the existing pattern in [ast_debug_info_helper.cpp:161](src/ast/ast_debug_info_helper.cpp#L161).

`makeTypeInfo` only reads `type->baseType`, `dim`, `structType`, `enumType`, `annotation` — never stores the TypeDecl pointer. The cached `ati` is owned by `DebugInfoAllocator` (`shared_ptr`); nothing on the runtime side needs the scratch past the read.

## Test plan

- [x] `tests/`: 9438/9438 pass.
- [x] JIT smoke: no LLVM verifier errors.
- [x] dasImgui `test_imgui_demo_widgets`: passes (was the failing case; consistently exited 1 before).
- [x] Manual: daslang-live + `imgui_snapshot` POST against `harness_widgets.das` (which has ImVector-backed widgets) → exit 0, no `GC LEAK`.
- [ ] CI green.

## Notes

- No semantic-hash impact: the change is inside a virtual method body, not in any hashed surface (mangled name, sizeOf, baseType, structType layout). No AOT bump needed.
- No JIT codegen impact (template body change, no `LLVM_JIT_CODEGEN_VERSION` bump needed).
- Lines 468 / 471 of the same file also construct `new TypeDecl(*vecType)` but return it as `TypeDeclPtr` — the caller (compile-time path) owns it under the compile gc_guard, so those don't leak.
