### PR TITLE
pages: bump emsdk pin 4.0.23 -> 5.0.7

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,16 +77,17 @@ jobs:
       uses: emscripten-core/setup-emsdk@v11
       with:
         # Every emsdk pin snapshots LLVM main (not a release tag). 5.0.3
-        # resolved to clang 23.0.0git (2026-03-13 main snapshot) and
-        # repeatedly broke on the bison-generated
-        # utils/dasFormatter/ds_parser.cpp — bus-errors one run, EOF-inside-
-        # `#ifndef` parse errors the next, while native clang on the same
-        # runner compiled the same file fine. 4.0.23 is the last 4.x
-        # release (2026-01-10), pinning LLVM main from 2026-01-09 (pre-
-        # LLVM-22.1.0-release, roughly clang 22.0.0git) — far enough back
-        # to dodge the clang-23-preview preprocessor regression and the
-        # closest emsdk we have to dasLLVM's 22.1.5 pin.
-        version: '4.0.23'
+        # (clang 23.0.0git, 2026-03-13 snapshot) repeatedly broke on
+        # utils/dasFormatter/ds_parser.cpp — bus-errors one run, EOF-
+        # inside-`#ifndef` parse errors the next. We pinned to 4.0.23
+        # (clang 22.0.0git, 2026-01-09 snapshot) but the same intermittent
+        # parser failures still surfaced (~1 in 4 deploys); see run
+        # https://github.com/GaijinEntertainment/daScript/actions/runs/26377946207.
+        # 5.0.7 ships clang 23.0.0git snapshot 7b58716d96c3 — same major
+        # family as the bad 5.0.3, but a different upstream snapshot.
+        # Locally compiles ds_parser.cpp + the full daslang_static target
+        # cleanly. Bump back down if 5.0.7 reintroduces the flake.
+        version: '5.0.7'
 
     - name: "Build WASM (Emscripten) for /playground/ + /files/wasm/"
       run: |


### PR DESCRIPTION
## Summary

The 4.0.23 pin (set after 5.0.3 broke on `utils/dasFormatter/ds_parser.cpp`) still surfaced the same intermittent `unterminated conditional directive` / `expected '}'` parser failures on the bison-generated file — most recently [run 26377946207](https://github.com/GaijinEntertainment/daScript/actions/runs/26377946207), ~1 in 4 recent master deploys hitting it.

5.0.7 (clang 23.0.0git snapshot `7b58716d96c3` — same major family as bad 5.0.3, but a different upstream snapshot) compiled `ds_parser.cpp` + the full `daslang_static` target cleanly locally.

Comment refreshed with the version history and fallback instruction.

## Test plan

- [x] Local: `emcmake cmake -G Ninja .. && ninja daslang_static` under emsdk 5.0.7 → all 168 steps green, `daslang_static.{js,wasm}` produced (38.9 MB / 100 KB)
- [ ] Watch a few master deploys post-merge for the flake recurring

Caveat: the failure is *intermittent*, so a single local pass + a single CI pass don't conclusively prove flake-free. If 5.0.7 reintroduces the flake, bisect 5.0.6 / 5.0.5 / 5.0.4 (the comment instructs bump-back-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)