### PR TITLE
doc: replace placeholder Sphinx logo with real daslang glyph

### DIFF
--- a/doc/source/_static/forge-logo.svg
+++ b/doc/source/_static/forge-logo.svg
@@ -1,18 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
-    <defs>
-        <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stop-color="#e8a13a" />
-            <stop offset="100%" stop-color="#a87420" />
-        </linearGradient>
-    </defs>
-    <rect x="4" y="14" width="32" height="32" rx="6" fill="url(#g)" />
-    <text x="20" y="38" text-anchor="middle"
-          font-family="JetBrains Mono, monospace"
-          font-size="22" font-weight="800" fill="#0d0c0a">&gt;</text>
-    <text x="48" y="40"
-          font-family="JetBrains Mono, SF Mono, monospace"
-          font-size="22" font-weight="600" fill="#e8e2d2">daslang</text>
-    <text x="153" y="40"
-          font-family="JetBrains Mono, SF Mono, monospace"
-          font-size="22" font-weight="400" fill="#5b5547">.io</text>
+  <g transform="translate(4 14) scale(1.3333333)">
+    <path fill="#e8a13a" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/>
+  </g>
+  <text x="48" y="40"
+        font-family="JetBrains Mono, SF Mono, monospace"
+        font-size="22" font-weight="600" fill="#e8e2d2">daslang</text>
+  <text x="153" y="40"
+        font-family="JetBrains Mono, SF Mono, monospace"
+        font-size="22" font-weight="400" fill="#5b5547">.io</text>
 </svg>


### PR DESCRIPTION
## Summary

`doc/source/_static/forge-logo.svg` (the image shown top-left in the Sphinx
sidebar of every docs page) shipped with a homemade `>`-in-a-gradient-tile
placeholder that doesn't match the brand on daslang.io.

Swap the placeholder for the actual brand glyph — the currentColor
"curlicue" path from `site/files/daslang.svg` — tinted amber (`#e8a13a`)
to match the nav lockup. Wordmark text (`daslang` + `.io`) and its colors
are unchanged, so the visual position/weight in the sidebar is identical.

`daslang.ico` (favicon) was already in sync with the site — no change.

## Test plan
- [x] `make.bat html` builds clean (warnings unchanged from baseline = 270, all pre-existing)
- [x] Logo renders in `build/html/index.html` sidebar (verified locally)