### PR TITLE
benchmarks/sql: cover all closed audit themes + 2 RST gap-fills

### DIFF
--- a/benchmarks/sql/chained_select_collapse.das
+++ b/benchmarks/sql/chained_select_collapse.das
@@ -7,8 +7,11 @@ require _common public
 // upstream of plan_distinct (Theme 7, audit 7c-family). The collapse_chained_selects
 // pre-pass folds the two pure projections into a single composed _select(g(f(_))) before
 // plan_distinct dispatches; the downstream splice sees one _select instead of two,
-// dropping a per-element bind+invoke. Pure inner gate satisfied (`_ + 1` has no
-// sideeffects per the macro_boost.das classifier).
+// dropping a per-element bind+invoke. Pure-inner gate fires on the INNER projection
+// (here `_.brand`, a field read with no sideeffects per the macro_boost.das classifier);
+// the outer `_ + 1` is irrelevant to the gate. The inner expression may be evaluated
+// zero or many times after collapse depending on how the outer references its param,
+// which is why purity of the inner is what makes the rewrite safe.
 // SQL: `_sql` rejects `distinct() |> count()` as non-translatable — it would lower
 // to `COUNT(DISTINCT ...)` over the computed projection but sqlite_linq's surface
 // doesn't currently emit that form. By design — no follow-up.

--- a/benchmarks/sql/chained_select_collapse.das
+++ b/benchmarks/sql/chained_select_collapse.das
@@ -9,8 +9,9 @@ require _common public
 // plan_distinct dispatches; the downstream splice sees one _select instead of two,
 // dropping a per-element bind+invoke. Pure inner gate satisfied (`_ + 1` has no
 // sideeffects per the macro_boost.das classifier).
-// SQL: sqlite_linq's _distinct_by lowering rejects computed-projection keys
-// (`error[50503]: _distinct_by key must be <arg>.<field>`). By design — no follow-up.
+// SQL: `_sql` rejects `distinct() |> count()` as non-translatable — it would lower
+// to `COUNT(DISTINCT ...)` over the computed projection but sqlite_linq's surface
+// doesn't currently emit that form. By design — no follow-up.
 
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)

--- a/benchmarks/sql/chained_select_collapse.das
+++ b/benchmarks/sql/chained_select_collapse.das
@@ -1,0 +1,45 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _select(_.brand) |> _select(_ + 1) |> distinct() |> count — two adjacent _select calls
+// upstream of plan_distinct (Theme 7, audit 7c-family). The collapse_chained_selects
+// pre-pass folds the two pure projections into a single composed _select(g(f(_))) before
+// plan_distinct dispatches; the downstream splice sees one _select instead of two,
+// dropping a per-element bind+invoke. Pure inner gate satisfied (`_ + 1` has no
+// sideeffects per the macro_boost.das classifier).
+// SQL: sqlite_linq's _distinct_by lowering rejects computed-projection keys
+// (`error[50503]: _distinct_by key must be <arg>.<field>`). By design — no follow-up.
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(each(arr) |> _select(_.brand) |> _select(_ + 1) |> distinct() |> count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>) |> _select(_.brand) |> _select(_ + 1) |> distinct() |> count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def chained_select_collapse_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def chained_select_collapse_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/decs_count_bare_pred.das
+++ b/benchmarks/sql/decs_count_bare_pred.das
@@ -1,0 +1,33 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let THRESHOLD = 500
+
+// from_decs_template(...) |> count(P) — bare-chain count with predicate, no upstream where/select.
+// Decs (m4): plan_decs_unroll's bare-chain 2-arg count(P) reach (Theme 4 root-cause fix
+// to extract_decs_bridge). Previously bailed because `forExpr.iteratorVariables` was
+// unpopulated when no chain op forces an inference pass over the bridge's inner for-loop;
+// the bridge now recovers iter names from `mkTup.values` (peeling the ExprRef2Value wrap),
+// so the emit_decs_accumulator 2-arg count(P) path is reachable on bare chains.
+// No array (m3f) lane — array-side bare count(P) was always reachable. No SQL lane —
+// covered by count_aggregate.das with a where shape.
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let c = _fold(from_decs_template(type<DecsCar>) |> count($(c) => c.price > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def decs_count_bare_pred_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/distinct_by_order_take.das
+++ b/benchmarks/sql/distinct_by_order_take.das
@@ -1,0 +1,52 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 10
+
+// _distinct_by(_.dealer_id) |> _order_by(_.price) |> take(N) |> to_array — pick one car
+// per dealer, sort by price, take top N (Theme 3 Phase 3, audit C1).
+// SQL: no faithful translation — "pick one row per dealer" requires window functions
+// (ROW_NUMBER OVER PARTITION BY dealer_id) which sqlite_linq does not lower. Follow-up
+// TODO 2026-05-25.
+// Array/Decs splice through plan_order_family / plan_decs_order_family's bounded-heap
+// + set-gate path: declares `var dset : table<typedecl(...)>` above source loop, wraps
+// per-element push by `if (!key_exists(dset, dkey)) { dset|>insert(dkey); HEAP_UPDATE }`.
+// Single source pass, no full distinct materialization.
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(arr)._distinct_by(_.dealer_id)._order_by(_.price).take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>)._distinct_by(_.dealer_id)._order_by(_.price).take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def distinct_by_order_take_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def distinct_by_order_take_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/distinct_count_pred.das
+++ b/benchmarks/sql/distinct_count_pred.das
@@ -1,0 +1,52 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let THRESHOLD = 2009
+
+// _distinct_by(_.brand) |> count(P) — distinct brands whose first-occurrence Car
+// satisfies P (Theme 4, audit 3c).
+// SQL: no clean form — sqlite_linq's `_distinct_by + count(P)` 2-arg shape isn't
+// surfaced through `_sql` (count with predicate after distinct lowers as
+// `COUNT(* FILTER WHERE ...)` which the lowerer doesn't emit). By design.
+// Array/Decs splice through plan_distinct / plan_decs_distinct's 2-arg-count extension:
+// dedup table built unconditionally so `distinct_by` semantics keeps FIRST occurrence
+// per key; a separate counter increments only when P matches that first occurrence.
+// Companion to distinct_by_count.das which has no predicate.
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let c = _fold(each(arr) |> _distinct_by(_.brand) |> count($(c) => c.year > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let c = _fold(from_decs_template(type<DecsCar>) |> _distinct_by(_.brand) |> count($(c) => c.year > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def distinct_count_pred_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def distinct_count_pred_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/groupby_having_post_where.das
+++ b/benchmarks/sql/groupby_having_post_where.das
@@ -1,0 +1,78 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select((Brand, Total)) |> _where(_.Total > THRESHOLD) — post-aggregate HAVING.
+// SQL: SELECT brand, SUM(price) AS Total FROM Cars GROUP BY brand HAVING Total > T.
+// Array/Decs splice through plan_group_by_core's trailing-_where extension (Theme 2,
+// audit 4a/4e): binds the constructed output tuple once per bucket and gates buf-emit
+// on the post-aggregate predicate. Distinct from the existing `_having(P)` slot
+// (which is pre-select and can lift hidden reducer slots); both can fire on the
+// same chain. Companion to groupby_having_count.das which uses `_having`.
+
+let THRESHOLD = 9000000
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _select((Brand = _._0,
+                                              Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                                  |> _where(_.Total > THRESHOLD))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                            ._where(_.Total > THRESHOLD)
+                            .to_array())
+        b |> accept(groups)
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      Total = _._1 |> _select(_.price) |> sum()))
+                            ._where(_.Total > THRESHOLD)
+                            .to_array())
+        b |> accept(groups)
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_having_post_where_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_having_post_where_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_having_post_where_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/groupby_select_order.das
+++ b/benchmarks/sql/groupby_select_order.das
@@ -60,16 +60,16 @@ def run_m4(b : B?; n : int) {
 }
 
 [benchmark]
-def groupby_select_order_take_m1(b : B?) {
+def groupby_select_order_m1(b : B?) {
     run_m1(b, 100000)
 }
 
 [benchmark]
-def groupby_select_order_take_m3f(b : B?) {
+def groupby_select_order_m3f(b : B?) {
     run_m3f(b, 100000)
 }
 
 [benchmark]
-def groupby_select_order_take_m4(b : B?) {
+def groupby_select_order_m4(b : B?) {
     run_m4(b, 100000)
 }

--- a/benchmarks/sql/groupby_select_order_take.das
+++ b/benchmarks/sql/groupby_select_order_take.das
@@ -1,0 +1,75 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _group_by(_.brand) |> _select((Brand, Total)) |> _order_by(_.Total) |> to_array — GROUP BY ... ORDER BY.
+// SQL: SELECT brand, SUM(price) AS Total FROM Cars GROUP BY brand ORDER BY Total.
+// Array/Decs splice through plan_group_by_core's trailing-_order_by extension
+// (Theme 3 Phase 2, audit C2): inline-cmp sort(buf, ...) tail mutates the same
+// bucket-fill buffer in place. Vs the tier-2 cascade's three allocations
+// (group_by_lazy_to_array → select → fresh-array sort).
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                                  |> _group_by(_.brand)
+                                  |> _select((Brand = _._0,
+                                              Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                                  |> _order_by(_.Total))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(each(arr)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                            ._order_by(_.Total)
+                            .to_array())
+        b |> accept(groups)
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let groups <- _fold(from_decs_template(type<DecsCar>)
+                            ._group_by(_.brand)
+                            ._select((Brand = _._0,
+                                      Total = _._1 |> _select(_.price) |> sum()))
+                            ._order_by(_.Total)
+                            .to_array())
+        b |> accept(groups)
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def groupby_select_order_take_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def groupby_select_order_take_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def groupby_select_order_take_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/join_groupby_count.das
+++ b/benchmarks/sql/join_groupby_count.das
@@ -1,0 +1,60 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _join(cars, dealers) |> _group_by(_.Brand) |> _select((Brand, N=count)) |> count — joined+grouped count.
+// SQL: SELECT brand, COUNT(*) FROM Cars c JOIN Dealers d ON c.dealer_id = d.id GROUP BY brand.
+// sqlite_linq's `_group_by` after `_join` doesn't currently lower (key column is from
+// the joined projection, not a base table column). Follow-up TODO 2026-05-25.
+// Decs (m4): plan_decs_group_by's `isDecsJoin` adapter mode (Theme 3 Phase 1, audit C3).
+// Single pass — hashB-collect + srcA-probe emits per-pair result-lam bind directly
+// into plan_group_by_core's bucket update. Vs the tier-2 cascade's 3 intermediate
+// allocations (dealers-array → join-array → group-map → output-array). plan_group_by_core
+// itself is untouched — the abstraction holds.
+// Array (m3f): no array-side join splice; cascade baseline for comparison.
+
+def run_m3f(b : B?; n : int) {
+    let cars <- fixture_array(n)
+    let dealers <- fixture_dealers_array()
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(cars |> _join(dealers,
+                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                          $(c : Car, d : Dealer) => (Brand = c.brand, DealerId = d.id))
+                                 |> _group_by(_.Brand)
+                                 |> _select((Brand = _._0, N = _._1 |> count())))
+        b |> accept(groups)
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs_cars_and_dealers(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let groups <- _fold(from_decs_template(type<DecsCar>)
+                |> _join(from_decs_template(type<DecsDealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Brand = l.brand, DealerId = r.id))
+                |> _group_by(_.Brand)
+                |> _select((Brand = _._0, N = _._1 |> count()))
+                |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def join_groupby_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def join_groupby_count_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/join_groupby_count.das
+++ b/benchmarks/sql/join_groupby_count.das
@@ -3,7 +3,9 @@ options persistent_heap
 
 require _common public
 
-// _join(cars, dealers) |> _group_by(_.Brand) |> _select((Brand, N=count)) |> count — joined+grouped count.
+// _join(cars, dealers) |> _group_by(_.Brand) |> _select((Brand, N=_._1|>count)) — joined+grouped,
+// per-group counts returned as an array of (Brand, N) tuples (no terminal count;
+// the inner `count()` is the per-bucket reducer).
 // SQL: SELECT brand, COUNT(*) FROM Cars c JOIN Dealers d ON c.dealer_id = d.id GROUP BY brand.
 // sqlite_linq's `_group_by` after `_join` doesn't currently lower (key column is from
 // the joined projection, not a base table column). Follow-up TODO 2026-05-25.

--- a/benchmarks/sql/join_groupby_to_array.das
+++ b/benchmarks/sql/join_groupby_to_array.das
@@ -1,0 +1,60 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _join(cars, dealers) |> _group_by(_.Brand) |> _select((Brand, Total=sum price)) |> to_array.
+// SQL: SELECT brand, SUM(price) FROM Cars c JOIN Dealers d ON c.dealer_id = d.id GROUP BY brand.
+// sqlite_linq's `_group_by` after `_join` doesn't currently lower (key column is from
+// the joined projection). Follow-up TODO 2026-05-25.
+// Decs (m4): plan_decs_group_by's `isDecsJoin` adapter mode (Theme 3 Phase 1, audit C3).
+// Same shape as join_groupby_count.das but with a reducing aggregate. Single pass,
+// no intermediate allocations.
+// Array (m3f): no array-side join splice; cascade baseline for comparison.
+
+def run_m3f(b : B?; n : int) {
+    let cars <- fixture_array(n)
+    let dealers <- fixture_dealers_array()
+    b |> run("m3f_array_fold/{n}", n) {
+        let groups <- _fold(cars |> _join(dealers,
+                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                          $(c : Car, d : Dealer) => (Brand = c.brand, Price = c.price))
+                                 |> _group_by(_.Brand)
+                                 |> _select((Brand = _._0,
+                                             Total = _._1 |> select($(t : tuple<Brand : int; Price : int>) => t.Price) |> sum())))
+        b |> accept(groups)
+        if (empty(groups)) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs_cars_and_dealers(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let groups <- _fold(from_decs_template(type<DecsCar>)
+                |> _join(from_decs_template(type<DecsDealer>),
+                         $(l, r) => l.dealer_id == r.id,
+                         $(l, r) => (Brand = l.brand, Price = l.price))
+                |> _group_by(_.Brand)
+                |> _select((Brand = _._0,
+                            Total = _._1 |> _select(_.Price) |> sum()))
+                |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def join_groupby_to_array_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def join_groupby_to_array_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/join_select.das
+++ b/benchmarks/sql/join_select.das
@@ -1,0 +1,56 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _join(cars, dealers, ...) |> _select(_.CarName) |> to_array — join then project (Theme 1, audit 8b).
+// SQL: `_sql`'s `_select` after `_join` rejects bare `_` — only the `into` lambda's
+// parameter names are valid receivers, so `... |> _join(...) |> _select(_.CarName)`
+// doesn't lower. By design — sqlite_linq surface limitation; comparable SQL shape
+// would inline the projection into the `into` lambda. Skip m1.
+// Decs (m4): plan_decs_join terminal-_select extension — single bind of the join result
+// per matched pair, then projection. Replaces the would-be cascade `join_impl + select`.
+// Array (m3f): no array-side join splice exists; this lane measures the unspliced
+// `join_impl` cascade for comparison.
+
+def run_m3f(b : B?; n : int) {
+    let cars <- fixture_array(n)
+    let dealers <- fixture_dealers_array()
+    b |> run("m3f_array_fold/{n}", n) {
+        let rows <- _fold(cars |> _join(dealers,
+                                        $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                        $(c : Car, d : Dealer) => (CarName = c.name, DealerId = d.id))
+                               |> _select(_.CarName))
+        b |> accept(rows)
+        if (empty(rows)) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs_cars_and_dealers(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>) |> _join(from_decs_template(type<DecsDealer>),
+                                                                          $(l, r) => l.dealer_id == r.id,
+                                                                          $(l, r) => (CarName = l.name, DealerId = r.id))
+                                                                 |> _select(_.CarName)
+                                                                 |> to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def join_select_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def join_select_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/join_where_count.das
+++ b/benchmarks/sql/join_where_count.das
@@ -1,0 +1,76 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _join(cars, dealers, ...) |> _where(joinResultPredicate) |> count — joined-then-filtered count.
+// SQL: SELECT COUNT(*) FROM Cars c JOIN Dealers d ON c.dealer_id = d.id WHERE c.price > T.
+// Decs (m4): plan_decs_join trailing-_where extension (Theme 2, audit 8a/C6).
+// Binds the join-result tuple once per matched (a, b) pair, evaluates the predicate,
+// and gates `count++`. Single hashB-collect + srcA-probe pass, no intermediate join
+// array. Composes with terminal _select (Theme 1) — filter then project, single bind.
+
+let THRESHOLD = 500
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let c = _sql(db |> select_from(type<Car>) |> _join(db |> select_from(type<Dealer>),
+                                                                $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                                                $(c : Car, d : Dealer) => (CarPrice = c.price, DealerId = d.id))
+                                                      |> _where(_.CarPrice > THRESHOLD)
+                                                      |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let cars <- fixture_array(n)
+    let dealers <- fixture_dealers_array()
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(cars |> _join(dealers,
+                                    $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                    $(c : Car, d : Dealer) => (CarPrice = c.price, DealerId = d.id))
+                           |> _where(_.CarPrice > THRESHOLD)
+                           |> count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs_cars_and_dealers(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>) |> _join(from_decs_template(type<DecsDealer>),
+                                                                  $(l, r) => l.dealer_id == r.id,
+                                                                  $(l, r) => (CarPrice = l.price, DealerId = r.id))
+                                                         |> _where(_.CarPrice > THRESHOLD)  // nolint:PERF013 macro-generated `+= 1`
+                                                         |> count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def join_where_count_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def join_where_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def join_where_count_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/order_distinct_take.das
+++ b/benchmarks/sql/order_distinct_take.das
@@ -1,0 +1,45 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 5
+
+// _order_by(_) |> distinct() |> take(N) |> to_array — sort, dedup whole-element, take N
+// (Theme 3 Phase 3, audit C5). plain distinct() (no key) requires duplicate-prone source
+// elements to exercise the set-gate; we synthesize an `array<int>` of `i % BRAND_COUNT`
+// so duplicates are dense.
+// Array (m3f) splices through plan_order_family's bounded-heap + set-gate path
+// (same code path as C1, distinct gate triggered on element instead of key).
+// Decs (m4) skipped: no duplicate-prone decs template in _common.das; the splice path
+// IS verified in tests/linq/test_linq_fold_theme3_c1_c5_distinct_order_take.das
+// (test_c5_decs_order_distinct_take_to_array). Follow-up TODO: add DecsBrand fixture.
+// SQL: SELECT DISTINCT brand FROM (... ORDER BY brand) LIMIT N — sqlite_linq's
+// `distinct() |> take(N)` shape rejects on `_sql`. By design — no follow-up TODO.
+
+def make_brands(n : int) : array<int> {
+    var a : array<int>
+    a |> resize(n)
+    for (i in range(n)) {
+        a[i] = i % BRAND_COUNT
+    }
+    return <- a
+}
+
+def run_m3f(b : B?; n : int) {
+    let brands <- make_brands(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(brands)._order_by(_).distinct().take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def order_distinct_take_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/order_distinct_take.das
+++ b/benchmarks/sql/order_distinct_take.das
@@ -14,8 +14,13 @@ let TAKE_N = 5
 // Decs (m4) skipped: no duplicate-prone decs template in _common.das; the splice path
 // IS verified in tests/linq/test_linq_fold_theme3_c1_c5_distinct_order_take.das
 // (test_c5_decs_order_distinct_take_to_array). Follow-up TODO: add DecsBrand fixture.
-// SQL: SELECT DISTINCT brand FROM (... ORDER BY brand) LIMIT N — sqlite_linq's
-// `distinct() |> take(N)` shape rejects on `_sql`. By design — no follow-up TODO.
+// SQL: `_sql`'s `_order_by` requires a `_.Field` (column-ref) key, not bare `_`
+// (`error[50503]: _sql: _order_by: key must be `_.Field`, a `string` expression,
+// or a tuple of either; got: _`). This is independent of distinct/take ordering —
+// `distinct_take.das` shows `_sql` does lower `distinct() |> take(N)` when the
+// source has a named column. Bench operates on a synthesized bare-scalar
+// `array<int>`, so the SQL form has no `.Field` to project. By design — to add
+// a SQL lane we'd need a 1-column table fixture and lower `_order_by(_.col)`.
 
 def make_brands(n : int) : array<int> {
     var a : array<int>

--- a/benchmarks/sql/order_reverse_normalized.das
+++ b/benchmarks/sql/order_reverse_normalized.das
@@ -1,0 +1,69 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 10
+
+// _order_by(_.price).reverse().take(N) — sort ascending, reverse for descending, take top N.
+// Theme 5 normalization (audit 1b/2b): the pre-dispatch `normalize_order_reverse` rewrite
+// flips this to `_order_by_descending(_.price).take(N)` so the same bounded-heap arm
+// fires as for the explicit descending form. Without normalization, the chain would
+// cascade (reverse expects a finite source — `_order_by` produces an iterator, so the
+// chain would materialize, reverse, then take). This bench measures parity with
+// `_order_by_descending(_.price).take(N).to_array()` — splice perf should match.
+// SQL: SELECT * FROM Cars ORDER BY price DESC LIMIT N.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.price) |> take(TAKE_N))
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(arr)._order_by(_.price).reverse().take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>)._order_by(_.price).reverse().take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def order_reverse_normalized_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def order_reverse_normalized_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def order_reverse_normalized_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -218,9 +218,13 @@ corresponding `.das` bench file; the bullets below quote that comment.
   `tests/linq/test_linq_fold_theme3_c1_c5_distinct_order_take.das`
   (`test_c5_decs_order_distinct_take_to_array`). Follow-up TODO
   2026-05-25: add a `DecsBrand` (or similar) fixture.
-- **`order_distinct_take` SQL** — sqlite_linq's `_order_by` followed by
-  bare `distinct()` (without a select projection) doesn't lower
-  cleanly. By design — no follow-up.
+- **`order_distinct_take` SQL** — `_sql`'s `_order_by` requires a
+  `_.Field` (column-ref) key, not bare `_`. Bench operates on a
+  synthesized `array<int>` (no named column to project), so the SQL
+  form has no `.Field` to pass. Independent of distinct/take ordering
+  — `distinct_take.das` proves `_sql` does lower `distinct() |> take(N)`
+  when the source has a named column. By design — adding a SQL lane
+  would need a 1-column table fixture and `_order_by(_.col)`.
 - **`take_count_filtered` SQL** — by design. In SQL, LIMIT after an
   aggregate has no effect (the aggregate collapses to one row), so the
   bound-then-count shape has no faithful SQL translation. No follow-up.

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,6 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-24 from `27689d5ff2` (Themes 4+5 — 2-arg `count(p)` predicates + `_order_by(k).reverse()` normalization).
+Generated 2026-05-25 from `2c18845d5` (master post-Theme-7 chained `_select` collapse).
 Fixture size: n = 100 000 (cars), 100 dealers, 5 brands. Each row is
 one bench family in `benchmarks/sql/`; columns are nanoseconds per
 logical operation. `—` marks an intentionally absent lane — see
@@ -26,133 +26,219 @@ before the timer resolution can measure them — they should be read as
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 35.2 | 5.9 | 5.8 | 0.98× |
-| `all_match` | 27.9 | 3.5 | 3.4 | 0.97× |
+| `aggregate_match` | 34.3 | 6.0 | 5.9 | 0.98× |
+| `all_match` | 27.4 | 3.5 | 3.5 | 1.00× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 30.2 | 5.8 | 8.7 | 1.50× |
-| `bare_order_where` | 277.2 | 117.9 | 126.1 | 1.07× |
-| `chained_where` | 36.6 | 6.6 | 6.6 | 1.00× |
+| `average_aggregate` | 29.7 | 5.9 | 8.8 | 1.49× |
+| `bare_order_where` | 279.1 | 119.0 | 127.4 | 1.07× |
+| `chained_select_collapse` | — | 17.8 | 17.9 | 1.01× |
+| `chained_where` | 36.1 | 6.7 | 6.7 | 1.00× |
 | `contains_match` | 0.00 | 2.2 | 1.4 | 0.64× |
-| `count_aggregate` | 29.5 | 4.1 | 4.1 | 1.00× |
-| `distinct_by_count` | 41.0 | 15.6 | 15.9 | 1.02× |
-| `distinct_count` | 41.4 | 15.9 | 15.8 | 0.99× |
+| `count_aggregate` | 29.0 | 4.1 | 4.1 | 1.00× |
+| `decs_count_bare_pred` | — | — | 4.1 | — |
+| `distinct_by_count` | 40.9 | 15.8 | 16.3 | 1.03× |
+| `distinct_by_order_take` | — | 21.8 | 23.8 | 1.09× |
+| `distinct_count` | 41.1 | 16.0 | 16.1 | 1.01× |
+| `distinct_count_pred` | — | 15.8 | 15.8 | 1.00× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 170.4 | 30.1 | 30.1 | 1.00× |
-| `groupby_count` | 142.3 | 19.2 | 19.3 | 1.01× |
-| `groupby_first` | — | 18.4 | 19.1 | 1.04× |
-| `groupby_having_count` | 141.1 | 19.1 | 19.2 | 1.01× |
-| `groupby_having_hidden_sum` | 175.0 | 24.3 | 24.0 | 0.99× |
-| `groupby_max` | 173.4 | 24.9 | 25.2 | 1.01× |
-| `groupby_min` | 173.3 | 24.9 | 25.3 | 1.02× |
-| `groupby_multi_reducer` | 188.4 | 32.2 | 32.4 | 1.01× |
-| `groupby_select_sum` | 204.3 | 36.5 | 36.3 | 0.99× |
-| `groupby_sum` | 171.7 | 18.6 | 18.9 | 1.02× |
-| `groupby_where_count` | 75.4 | 14.7 | 15.0 | 1.02× |
-| `groupby_where_sum` | 86.8 | 14.2 | 14.6 | 1.03× |
-| `indexed_lookup` | 1445.2 | 203239.5 | 485.0 | 0.00× |
-| `join_count` | 38.4 | 120.6 | 63.7 | 0.53× |
-| `last_match` | 0.00 | 5.8 | 13.8 | 2.38× |
-| `long_count_aggregate` | 29.6 | 4.2 | 4.0 | 0.95× |
-| `max_aggregate` | 31.0 | 6.0 | 6.9 | 1.15× |
-| `min_aggregate` | 30.8 | 6.1 | 6.9 | 1.13× |
-| `order_take_desc` | 38.2 | 15.8 | 19.9 | 1.26× |
-| `reverse_take` | 0.10 | 0.00 | 9.2 | — |
+| `groupby_average` | 176.1 | 30.5 | 30.4 | 1.00× |
+| `groupby_count` | 143.1 | 19.4 | 19.4 | 1.00× |
+| `groupby_first` | — | 18.6 | 19.7 | 1.06× |
+| `groupby_having_count` | 143.4 | 19.3 | 19.3 | 1.00× |
+| `groupby_having_hidden_sum` | 177.9 | 24.5 | 24.2 | 0.99× |
+| `groupby_having_post_where` | 171.9 | 18.6 | 18.7 | 1.01× |
+| `groupby_max` | 175.7 | 25.1 | 25.3 | 1.01× |
+| `groupby_min` | 174.7 | 25.1 | 25.4 | 1.01× |
+| `groupby_multi_reducer` | 192.6 | 33.1 | 32.7 | 0.99× |
+| `groupby_select_order_take` | 171.9 | 18.6 | 19.0 | 1.02× |
+| `groupby_select_sum` | 207.4 | 36.9 | 36.4 | 0.99× |
+| `groupby_sum` | 173.3 | 18.8 | 19.0 | 1.01× |
+| `groupby_where_count` | 76.0 | 14.7 | 15.0 | 1.02× |
+| `groupby_where_sum` | 87.3 | 14.3 | 15.1 | 1.06× |
+| `indexed_lookup` | 1453.6 | 204197.0 | 469.0 | 0.00× |
+| `join_count` | 38.0 | 122.8 | 64.0 | 0.52× |
+| `join_groupby_count` | — | 186.9 | 90.4 | 0.48× |
+| `join_groupby_to_array` | — | 217.7 | 91.0 | 0.42× |
+| `join_select` | — | 149.0 | 86.3 | 0.58× |
+| `join_where_count` | 39.5 | 149.0 | 81.3 | 0.55× |
+| `last_match` | 0.00 | 5.9 | 14.0 | 2.37× |
+| `long_count_aggregate` | 29.1 | 4.1 | 4.1 | 1.00× |
+| `max_aggregate` | 30.4 | 6.0 | 6.8 | 1.13× |
+| `min_aggregate` | 30.8 | 6.1 | 6.8 | 1.11× |
+| `order_distinct_take` | — | 16.1 | — | — |
+| `order_reverse_normalized` | 37.9 | 16.1 | 20.1 | 1.25× |
+| `order_take_desc` | 38.0 | 15.9 | 20.4 | 1.28× |
+| `reverse_take` | 0.10 | 0.00 | 9.3 | — |
+| `reverse_take_select` | 0.00 | 34.6 | 48.8 | 1.41× |
 | `select_count` | 0.10 | 0.00 | 2.2 | — |
-| `select_where` | 194.2 | 11.1 | 19.6 | 1.77× |
-| `select_where_count` | 32.8 | 5.2 | 7.4 | 1.42× |
-| `select_where_order_take` | 36.6 | 12.1 | 14.8 | 1.22× |
-| `select_where_sum` | 40.7 | 7.4 | 7.4 | 1.00× |
-| `single_match` | 0.00 | 2.9 | 5.5 | 1.90× |
+| `select_where` | 195.9 | 11.3 | 19.7 | 1.74× |
+| `select_where_count` | 32.4 | 5.3 | 7.4 | 1.40× |
+| `select_where_order_take` | 36.6 | 12.2 | 14.9 | 1.22× |
+| `select_where_sum` | 37.0 | 7.5 | 7.5 | 1.00× |
+| `single_match` | 0.00 | 2.9 | 5.6 | 1.93× |
 | `skip_take` | 0.50 | 0.10 | 0.20 | 2.00× |
-| `skip_while_match` | 3.4 | 5.3 | 5.3 | 1.00× |
-| `sort_first` | 38.0 | 11.0 | 13.3 | 1.21× |
-| `sort_take` | 38.1 | 16.2 | 20.2 | 1.25× |
-| `sum_aggregate` | 30.2 | 2.1 | 2.1 | 1.00× |
-| `sum_where` | 32.9 | 4.2 | 4.3 | 1.02× |
+| `skip_while_match` | 3.5 | 5.2 | 5.3 | 1.02× |
+| `sort_first` | 37.6 | 19.5 | 15.8 | 0.81× |
+| `sort_take` | 38.0 | 16.4 | 20.4 | 1.24× |
+| `sort_take_select` | 38.2 | 16.3 | 20.3 | 1.25× |
+| `sum_aggregate` | 29.7 | 2.2 | 2.1 | 0.95× |
+| `sum_where` | 32.3 | 4.3 | 4.3 | 1.00× |
 | `take_count` | 3.6 | 0.20 | 0.40 | 2.00× |
 | `take_count_filtered` | — | 0.20 | 0.20 | 1.00× |
 | `take_sum_aggregate` | — | 0.10 | 0.10 | 1.00× |
-| `take_while_match` | 7.9 | 2.4 | 2.5 | 1.04× |
-| `to_array_filter` | 70.6 | 11.7 | 11.7 | 1.00× |
-| `zip_dot_product` | — | 8.0 | 4.8 | 0.60× |
+| `take_where_count` | — | 0.10 | 34.6 | 346.00× |
+| `take_while_match` | 7.9 | 2.5 | 2.5 | 1.00× |
+| `to_array_filter` | 70.8 | 11.8 | 11.9 | 1.01× |
+| `zip_count_pred` | — | 10.7 | — | — |
+| `zip_dot_product` | — | 7.9 | 4.8 | 0.61× |
+| `zip_dot_product_3arg` | — | 7.8 | — | — |
 
 ## JIT
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 39.5 | 0.40 | 0.70 | 1.75× |
+| `aggregate_match` | 34.2 | 0.40 | 0.70 | 1.75× |
 | `all_match` | 27.6 | 0.30 | 0.20 | 0.67× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 30.2 | 1.0 | 3.6 | 3.60× |
-| `bare_order_where` | 185.2 | 33.8 | 35.1 | 1.04× |
-| `chained_where` | 36.4 | 0.60 | 0.80 | 1.33× |
+| `average_aggregate` | 29.6 | 1.0 | 3.6 | 3.60× |
+| `bare_order_where` | 186.4 | 34.9 | 34.9 | 1.00× |
+| `chained_select_collapse` | — | 2.1 | 2.1 | 1.00× |
+| `chained_where` | 36.0 | 0.60 | 0.80 | 1.33× |
 | `contains_match` | 0.00 | 0.20 | 0.10 | 0.50× |
-| `count_aggregate` | 29.8 | 0.40 | 0.60 | 1.50× |
-| `distinct_by_count` | 41.4 | 2.1 | 2.1 | 1.00× |
-| `distinct_count` | 41.5 | 2.1 | 2.1 | 1.00× |
+| `count_aggregate` | 29.1 | 0.40 | 0.60 | 1.50× |
+| `decs_count_bare_pred` | — | — | 0.60 | — |
+| `distinct_by_count` | 40.8 | 2.1 | 2.1 | 1.00× |
+| `distinct_by_order_take` | — | 2.6 | 3.3 | 1.27× |
+| `distinct_count` | 40.9 | 2.1 | 2.1 | 1.00× |
+| `distinct_count_pred` | — | 2.1 | 2.3 | 1.10× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 170.6 | 2.6 | 3.2 | 1.23× |
-| `groupby_count` | 142.4 | 2.4 | 2.5 | 1.04× |
+| `groupby_average` | 171.7 | 2.6 | 2.9 | 1.12× |
+| `groupby_count` | 141.0 | 2.4 | 2.5 | 1.04× |
 | `groupby_first` | — | 2.2 | 3.1 | 1.41× |
-| `groupby_having_count` | 140.4 | 2.4 | 2.5 | 1.04× |
-| `groupby_having_hidden_sum` | 175.2 | 2.5 | 2.8 | 1.12× |
-| `groupby_max` | 173.7 | 2.4 | 2.7 | 1.13× |
-| `groupby_min` | 173.1 | 2.4 | 2.7 | 1.13× |
-| `groupby_multi_reducer` | 189.2 | 2.7 | 3.0 | 1.11× |
-| `groupby_select_sum` | 201.3 | 3.2 | 3.7 | 1.16× |
-| `groupby_sum` | 170.3 | 2.4 | 2.7 | 1.13× |
-| `groupby_where_count` | 75.8 | 1.7 | 1.8 | 1.06× |
-| `groupby_where_sum` | 86.7 | 1.7 | 1.8 | 1.06× |
-| `indexed_lookup` | 1237.9 | 35110.3 | 102.6 | 0.00× |
-| `join_count` | 38.4 | 36.1 | 13.3 | 0.37× |
+| `groupby_having_count` | 141.1 | 2.4 | 2.5 | 1.04× |
+| `groupby_having_hidden_sum` | 175.9 | 2.5 | 2.9 | 1.16× |
+| `groupby_having_post_where` | 172.2 | 2.4 | 2.7 | 1.13× |
+| `groupby_max` | 174.3 | 2.4 | 2.7 | 1.13× |
+| `groupby_min` | 175.3 | 2.4 | 2.7 | 1.13× |
+| `groupby_multi_reducer` | 188.8 | 2.7 | 3.0 | 1.11× |
+| `groupby_select_order_take` | 174.9 | 2.4 | 2.7 | 1.13× |
+| `groupby_select_sum` | 200.7 | 3.2 | 3.7 | 1.16× |
+| `groupby_sum` | 172.2 | 2.4 | 2.7 | 1.13× |
+| `groupby_where_count` | 75.9 | 1.7 | 1.8 | 1.06× |
+| `groupby_where_sum` | 86.5 | 1.7 | 1.8 | 1.06× |
+| `indexed_lookup` | 1238.2 | 35098.4 | 102.8 | 0.00× |
+| `join_count` | 37.9 | 36.1 | 13.4 | 0.37× |
+| `join_groupby_count` | — | 48.4 | 23.5 | 0.49× |
+| `join_groupby_to_array` | — | 57.0 | 23.4 | 0.41× |
+| `join_select` | — | 43.3 | 24.6 | 0.57× |
+| `join_where_count` | 39.0 | 42.7 | 25.4 | 0.59× |
 | `last_match` | 0.00 | 0.50 | 1.4 | 2.80× |
-| `long_count_aggregate` | 29.7 | 0.40 | 0.60 | 1.50× |
-| `max_aggregate` | 30.8 | 0.60 | 0.50 | 0.83× |
-| `min_aggregate` | 31.1 | 0.60 | 0.50 | 0.83× |
-| `order_take_desc` | 38.3 | 0.70 | 1.4 | 2.00× |
+| `long_count_aggregate` | 29.0 | 0.40 | 0.60 | 1.50× |
+| `max_aggregate` | 30.7 | 0.60 | 0.50 | 0.83× |
+| `min_aggregate` | 30.6 | 0.70 | 0.50 | 0.71× |
+| `order_distinct_take` | — | 2.1 | — | — |
+| `order_reverse_normalized` | 37.9 | 0.70 | 1.4 | 2.00× |
+| `order_take_desc` | 38.0 | 0.70 | 1.4 | 2.00× |
 | `reverse_take` | 0.00 | 0.00 | 1.1 | — |
+| `reverse_take_select` | 0.00 | 8.7 | 10.6 | 1.22× |
 | `select_count` | 0.10 | 0.00 | 0.00 | — |
-| `select_where` | 108.1 | 4.2 | 5.6 | 1.33× |
-| `select_where_count` | 32.8 | 0.40 | 0.60 | 1.50× |
-| `select_where_order_take` | 36.8 | 0.70 | 1.4 | 2.00× |
-| `select_where_sum` | 37.0 | 0.50 | 0.60 | 1.20× |
+| `select_where` | 106.2 | 4.2 | 5.8 | 1.38× |
+| `select_where_count` | 32.6 | 0.40 | 0.60 | 1.50× |
+| `select_where_order_take` | 36.2 | 0.70 | 1.4 | 2.00× |
+| `select_where_sum` | 36.9 | 0.50 | 0.60 | 1.20× |
 | `single_match` | 0.00 | 0.40 | 1.1 | 2.75× |
 | `skip_take` | 0.30 | 0.00 | 0.00 | — |
-| `skip_while_match` | 3.5 | 0.40 | 0.40 | 1.00× |
-| `sort_first` | 37.8 | 0.40 | 1.3 | 3.25× |
-| `sort_take` | 38.4 | 0.70 | 1.3 | 1.86× |
-| `sum_aggregate` | 30.3 | 0.40 | 0.30 | 0.75× |
+| `skip_while_match` | 3.4 | 0.40 | 0.40 | 1.00× |
+| `sort_first` | 37.5 | 0.40 | 1.3 | 3.25× |
+| `sort_take` | 38.0 | 0.70 | 1.4 | 2.00× |
+| `sort_take_select` | 38.5 | 0.70 | 1.4 | 2.00× |
+| `sum_aggregate` | 33.5 | 0.40 | 0.30 | 0.75× |
 | `sum_where` | 32.9 | 0.40 | 0.60 | 1.50× |
 | `take_count` | 1.8 | 0.10 | 0.10 | 1.00× |
 | `take_count_filtered` | — | 0.00 | 0.00 | — |
 | `take_sum_aggregate` | — | 0.00 | 0.00 | — |
+| `take_where_count` | — | 0.00 | 10.1 | — |
 | `take_while_match` | 8.0 | 0.20 | 0.30 | 1.50× |
-| `to_array_filter` | 48.1 | 3.3 | 3.4 | 1.03× |
+| `to_array_filter` | 48.4 | 3.3 | 3.4 | 1.03× |
+| `zip_count_pred` | — | 0.70 | — | — |
 | `zip_dot_product` | — | 0.50 | 0.50 | 1.00× |
+| `zip_dot_product_3arg` | — | 0.50 | — | — |
 
 ## Notes on missing lanes (the `—` cells)
 
 The reasons each cell is empty are also recorded as a comment in the
 corresponding `.das` bench file; the bullets below quote that comment.
 
+- **`chained_select_collapse` SQL** — sqlite_linq's `_distinct_by` rejects
+  computed-projection keys (`error[50503]: _distinct_by key must be
+  <arg>.<field>`). By design — no follow-up.
+- **`decs_count_bare_pred` SQL / Array** — covers a Theme 4 root-cause
+  fix specific to the decs lane (bare `from_decs_template(...).count(P)`
+  with no upstream where/select previously bailed because
+  `forExpr.iteratorVariables` was unpopulated). Array-side bare `count(P)`
+  was always reachable; SQL `count(P)` is covered by `count_aggregate.das`
+  with a where shape. By design.
+- **`distinct_by_order_take` SQL** — no faithful SQL form. "Pick one row
+  per dealer, sort by price, take N" needs window functions
+  (`ROW_NUMBER() OVER (PARTITION BY dealer_id ORDER BY price)` + outer
+  `WHERE rn=1` + `LIMIT N`); sqlite_linq does not currently lower window
+  functions. Follow-up TODO 2026-05-25.
+- **`distinct_count_pred` SQL** — sqlite_linq's `_distinct_by` + 2-arg
+  `count(P)` shape isn't surfaced through `_sql` (would lower as
+  `COUNT(*) FILTER WHERE ...`, not currently emitted). By design.
 - **`groupby_first` SQL** — no direct SQL aggregator for "first
   source-order row per group". Window functions (`ROW_NUMBER() OVER
   (PARTITION BY brand ORDER BY id)` + outer `WHERE rn=1`) would be the
   SQL equivalent; sqlite_linq does not currently lower window
   functions. Follow-up TODO 2026-05-23.
+- **`indexed_lookup` Decs vs Array ratio** — the ratio is reported as
+  `0.00×` because array's lane measures the unspliced linear scan
+  (~204k ns/op), while decs uses `query(eid)` for O(1) lookup. The
+  ratio is mathematically tiny but the comparison is between two
+  fundamentally different algorithms — not a like-for-like benchmark.
+- **`join_groupby_count` SQL** — sqlite_linq's `_group_by` after `_join`
+  doesn't currently lower (group key column is from the joined
+  projection, not a base-table column). Follow-up TODO 2026-05-25.
+- **`join_groupby_to_array` SQL** — same reason as `join_groupby_count`.
+- **`join_select` SQL** — sqlite_linq's `_select` after `_join` rejects
+  bare `_` (only the `into` lambda's parameter names are valid
+  receivers; computed projections would need to be inlined into the
+  `into` lambda). By design — sqlite_linq surface limitation.
+- **`order_distinct_take` Decs** — no duplicate-prone decs template in
+  `_common.das`; plain `distinct()` (whole-element dedup) needs
+  intentional duplicates to exercise the set-gate. The splice path IS
+  verified in
+  `tests/linq/test_linq_fold_theme3_c1_c5_distinct_order_take.das`
+  (`test_c5_decs_order_distinct_take_to_array`). Follow-up TODO
+  2026-05-25: add a `DecsBrand` (or similar) fixture.
+- **`order_distinct_take` SQL** — sqlite_linq's `_order_by` followed by
+  bare `distinct()` (without a select projection) doesn't lower
+  cleanly. By design — no follow-up.
 - **`take_count_filtered` SQL** — by design. In SQL, LIMIT after an
   aggregate has no effect (the aggregate collapses to one row), so the
   bound-then-count shape has no faithful SQL translation. No follow-up.
 - **`take_sum_aggregate` SQL** — same reason as `take_count_filtered`.
   By design, no follow-up.
+- **`take_where_count` SQL** — `take(N) |> _where(P) |> count()` has no
+  faithful SQL translation. In SQL, LIMIT applies after WHERE, not
+  before — preserving the "first N elements, then keep matching"
+  semantic would require a derived-table form that sqlite_linq does
+  not currently emit. By design.
+- **`zip_count_pred` SQL / Decs** — `zip` is not a relational operation
+  (no SQL form) and is not naturally expressible over a single
+  archetype walk (no decs form). By design, no follow-up.
 - **`zip_dot_product` SQL** — `zip` is not a relational operation.
   No SQL form exists; by design, no follow-up.
+- **`zip_dot_product_3arg` SQL / Decs** — same reason as `zip_count_pred`.
+  This row exercises the 3-arg `zip(a, b, sel)` pre-lowering (Theme 1,
+  audit 7a); a companion to `zip_dot_product` with the explicit 2-arg
+  + `_select` form. By design, no follow-up.
 
 ## How to re-run
 

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -53,7 +53,7 @@ before the timer resolution can measure them — they should be read as
 | `groupby_max` | 175.7 | 25.1 | 25.3 | 1.01× |
 | `groupby_min` | 174.7 | 25.1 | 25.4 | 1.01× |
 | `groupby_multi_reducer` | 192.6 | 33.1 | 32.7 | 0.99× |
-| `groupby_select_order_take` | 171.9 | 18.6 | 19.0 | 1.02× |
+| `groupby_select_order` | 171.1 | 18.8 | 18.7 | 0.99× |
 | `groupby_select_sum` | 207.4 | 36.9 | 36.4 | 0.99× |
 | `groupby_sum` | 173.3 | 18.8 | 19.0 | 1.01× |
 | `groupby_where_count` | 76.0 | 14.7 | 15.0 | 1.02× |
@@ -92,9 +92,9 @@ before the timer resolution can measure them — they should be read as
 | `take_where_count` | — | 0.10 | 34.6 | 346.00× |
 | `take_while_match` | 7.9 | 2.5 | 2.5 | 1.00× |
 | `to_array_filter` | 70.8 | 11.8 | 11.9 | 1.01× |
-| `zip_count_pred` | — | 10.7 | — | — |
-| `zip_dot_product` | — | 7.9 | 4.8 | 0.61× |
-| `zip_dot_product_3arg` | — | 7.8 | — | — |
+| `zip_count_pred` | — | 14.9 | — | — |
+| `zip_dot_product` | — | 12.6 | 10.3 | 0.82× |
+| `zip_dot_product_3arg` | — | 12.6 | — | — |
 
 ## JIT
 
@@ -127,7 +127,7 @@ before the timer resolution can measure them — they should be read as
 | `groupby_max` | 174.3 | 2.4 | 2.7 | 1.13× |
 | `groupby_min` | 175.3 | 2.4 | 2.7 | 1.13× |
 | `groupby_multi_reducer` | 188.8 | 2.7 | 3.0 | 1.11× |
-| `groupby_select_order_take` | 174.9 | 2.4 | 2.7 | 1.13× |
+| `groupby_select_order` | 171.5 | 2.4 | 2.7 | 1.13× |
 | `groupby_select_sum` | 200.7 | 3.2 | 3.7 | 1.16× |
 | `groupby_sum` | 172.2 | 2.4 | 2.7 | 1.13× |
 | `groupby_where_count` | 75.9 | 1.7 | 1.8 | 1.06× |
@@ -170,14 +170,15 @@ before the timer resolution can measure them — they should be read as
 | `zip_dot_product` | — | 0.50 | 0.50 | 1.00× |
 | `zip_dot_product_3arg` | — | 0.50 | — | — |
 
+
 ## Notes on missing lanes (the `—` cells)
 
 The reasons each cell is empty are also recorded as a comment in the
 corresponding `.das` bench file; the bullets below quote that comment.
 
-- **`chained_select_collapse` SQL** — sqlite_linq's `_distinct_by` rejects
-  computed-projection keys (`error[50503]: _distinct_by key must be
-  <arg>.<field>`). By design — no follow-up.
+- **`chained_select_collapse` SQL** — `_sql` rejects `distinct() |> count()`
+  as non-translatable. The equivalent SQL `COUNT(DISTINCT computed-expr)`
+  isn't currently emitted by sqlite_linq's surface. By design — no follow-up.
 - **`decs_count_bare_pred` SQL / Array** — covers a Theme 4 root-cause
   fix specific to the decs lane (bare `from_decs_template(...).count(P)`
   with no upstream where/select previously bailed because

--- a/benchmarks/sql/reverse_take_select.das
+++ b/benchmarks/sql/reverse_take_select.das
@@ -1,0 +1,67 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 10
+
+// _reverse() |> take(N) |> _select(_.name) |> to_array — last-N rows reversed then project.
+// SQL: SELECT name FROM Cars ORDER BY id DESC LIMIT N.
+// Array/Decs splice through plan_reverse / plan_decs_reverse terminal-_select extension
+// (Theme 1): skip-into-tail two-pass walk fills the R1-R4 buffer with raw elements,
+// then the projection F runs at most K times at return. NOT accepted: reverse._select.take
+// (user must reorder).
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let rows <- _sql(db |> select_from(type<Car>) |> _order_by_descending(_.id) |> take(TAKE_N) |> _select(_.name))
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(arr).reverse().take(TAKE_N)._select(_.name).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>).reverse().take(TAKE_N)._select(_.name).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def reverse_take_select_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def reverse_take_select_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def reverse_take_select_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/sort_take_select.das
+++ b/benchmarks/sql/sort_take_select.das
@@ -1,0 +1,66 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 10
+
+// _order_by(_.price) |> take(N) |> _select(_.name) |> to_array — top-N then project.
+// SQL: SELECT name FROM Cars ORDER BY price LIMIT N.
+// Array/Decs splice through plan_order_family / plan_decs_order_family terminal-_select
+// extension (Theme 1, audit 1a/1e): bounded-heap holds raw element; projection runs
+// at most K times at return — vs the unspliced cascade which would project N then sort.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let rows <- _sql(db |> select_from(type<Car>) |> _order_by(_.price) |> take(TAKE_N) |> _select(_.name))
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(arr)._order_by(_.price).take(TAKE_N)._select(_.name).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>)._order_by(_.price).take(TAKE_N)._select(_.name).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def sort_take_select_m1(b : B?) {
+    run_m1(b, 100000)
+}
+
+[benchmark]
+def sort_take_select_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def sort_take_select_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/take_where_count.das
+++ b/benchmarks/sql/take_where_count.das
@@ -1,0 +1,47 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let TAKE_N = 1000
+let THRESHOLD = 500
+
+// take(N) |> _where(P) |> count — "first N elements, then keep matching" semantic
+// (Theme 2, audit 5c). Distinct from `_where(P) |> take(N)` which is "first N matching":
+// the take cap ticks unconditionally per element here, and _where gates only the
+// per-element contribution to the count. plan_loop_or_count's postTakeWhereCond gate
+// emits both behaviors in a single splice. SQL: no faithful translation — LIMIT in
+// SQL filters after WHERE, not before. Companion to take_count_filtered.das which
+// measures the _where-first form.
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let c = _fold(each(arr).take(TAKE_N)._where(_.price > THRESHOLD).count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let c = _fold(from_decs_template(type<DecsCar>).take(TAKE_N)._where(_.price > THRESHOLD).count())
+        b |> accept(c)
+        if (c == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def take_where_count_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def take_where_count_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/zip_count_pred.das
+++ b/benchmarks/sql/zip_count_pred.das
@@ -1,0 +1,43 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+let THRESHOLD = 50000
+
+// zip(xs, ys) |> _select(_._0 * _._1) |> count(P) — count of zipped products satisfying P.
+// SQL: no relational form (zip is not relational).
+// Array (m3f): plan_zip's 2-arg count(P) extension (Theme 4, plan_zip arm).
+// The predicate is captured into a dedicated counter-predicate gate around `acc++`
+// INSIDE the upstream select wrap, so eager `select(F).count(P)` ordering is preserved
+// (F runs once per element, then P decides whether to count). With _select, the
+// predicate peels against the projected value via a `vproj` bind. Length-shortcut
+// suppressed once P is present.
+
+def make_ints(n : int) : array<int> {
+    var a : array<int>
+    a |> resize(n)
+    for (i in range(n)) {
+        a[i] = i
+    }
+    return <- a
+}
+
+def run_m3f(b : B?; n : int) {
+    let xs <- make_ints(n)
+    let ys <- make_ints(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let c = _fold(each(xs) |> zip(each(ys)) |> _select(_._0 * _._1) |> count($(v) => v > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def zip_count_pred_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/zip_count_pred.das
+++ b/benchmarks/sql/zip_count_pred.das
@@ -3,9 +3,11 @@ options persistent_heap
 
 require _common public
 
-let THRESHOLD = 50000
+let THRESHOLD = 50000l
 
-// zip(xs, ys) |> _select(_._0 * _._1) |> count(P) — count of zipped products satisfying P.
+// zip(xs, ys) |> _select(int64(_._0) * int64(_._1)) |> count(P) — count of zipped
+// products satisfying P. int64 cast avoids int32 overflow for n=100k (i*i wraps past
+// INT_MAX, producing negative products and unstable predicate counts).
 // SQL: no relational form (zip is not relational).
 // Array (m3f): plan_zip's 2-arg count(P) extension (Theme 4, plan_zip arm).
 // The predicate is captured into a dedicated counter-predicate gate around `acc++`
@@ -28,7 +30,7 @@ def run_m3f(b : B?; n : int) {
     let ys <- make_ints(n)
     b |> run("m3f_array_fold/{n}", n) {
         unsafe {
-            let c = _fold(each(xs) |> zip(each(ys)) |> _select(_._0 * _._1) |> count($(v) => v > THRESHOLD))
+            let c = _fold(each(xs) |> zip(each(ys)) |> _select(int64(_._0) * int64(_._1)) |> count($(v) => v > THRESHOLD))
             b |> accept(c)
             if (c == 0) {
                 b->failNow()

--- a/benchmarks/sql/zip_dot_product.das
+++ b/benchmarks/sql/zip_dot_product.das
@@ -3,12 +3,14 @@ options persistent_heap
 
 require _common public
 
-// zip(a, b) |> select(t => t._0 * t._1) |> sum — dot product of two int sequences.
+// zip(a, b) |> select(t => int64(t._0) * int64(t._1)) |> sum — dot product of two int sequences.
 // No clean SQL form (zip is not a natural relational operation), so the SQL lane is
 // omitted. Splice mode fuses zip + select + sum into a single accumulator loop.
 // The Decs lane is the intra-archetype analogue: two int components on the same
 // DecsCar entity (price * year), summed over all entities. Wave 4 pruning keeps
 // only those two get_ro slots, so per-element cost matches the Array two-column read.
+// int64 cast in the projection avoids int32 overflow on i*i for n=100k (sum of
+// squares is ~3.3e14, well past INT_MAX).
 
 def make_ints(n : int) : array<int> {
     var a : array<int>
@@ -23,22 +25,16 @@ def run_m3f(b : B?; n : int) {
     let xs <- make_ints(n)
     let ys <- make_ints(n)
     b |> run("m3f_array_fold/{n}", n) {
-        let s = _fold(zip(xs, ys)._select(_._0 * _._1).sum())
+        let s = _fold(zip(xs, ys)._select(int64(_._0) * int64(_._1)).sum())
         b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
     }
 }
 
 def run_m4(b : B?; n : int) {
     fixture_decs(n)
     b |> run("m4_decs_fold/{n}", n) {
-        let s = _fold(from_decs_template(type<DecsCar>)._select(_.price * _.year).sum())
+        let s = _fold(from_decs_template(type<DecsCar>)._select(int64(_.price) * int64(_.year)).sum())
         b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
     }
 }
 

--- a/benchmarks/sql/zip_dot_product_3arg.das
+++ b/benchmarks/sql/zip_dot_product_3arg.das
@@ -9,6 +9,7 @@ require _common public
 // this bench measures the natural dot-product idiom that previously cascaded.
 // No SQL form (zip is not relational); no decs form (no zip on archetype walks).
 // Companion to zip_dot_product.das which uses the explicit 2-arg + _select form.
+// int64 cast in the selector avoids int32 overflow for n=100k.
 
 def make_ints(n : int) : array<int> {
     var a : array<int>
@@ -23,11 +24,8 @@ def run_m3f(b : B?; n : int) {
     let xs <- make_ints(n)
     let ys <- make_ints(n)
     b |> run("m3f_array_fold/{n}", n) {
-        let s = _fold(zip(xs, ys, $(x : int; y : int) => x * y).sum())
+        let s = _fold(zip(xs, ys, $(x : int; y : int) => int64(x) * int64(y)).sum())
         b |> accept(s)
-        if (s == 0) {
-            b->failNow()
-        }
     }
 }
 

--- a/benchmarks/sql/zip_dot_product_3arg.das
+++ b/benchmarks/sql/zip_dot_product_3arg.das
@@ -1,0 +1,37 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// zip(a, b, sel) |> sum — dot product via 3-arg zip pre-lowering (Theme 1, audit 7a).
+// The 3-arg form `zip(a, b, sel)` is pre-lowered by plan_zip to
+// `zip(a, b) |> _select(sel-as-tuple)` so the standard zip+select fusion fires —
+// this bench measures the natural dot-product idiom that previously cascaded.
+// No SQL form (zip is not relational); no decs form (no zip on archetype walks).
+// Companion to zip_dot_product.das which uses the explicit 2-arg + _select form.
+
+def make_ints(n : int) : array<int> {
+    var a : array<int>
+    a |> resize(n)
+    for (i in range(n)) {
+        a[i] = i
+    }
+    return <- a
+}
+
+def run_m3f(b : B?; n : int) {
+    let xs <- make_ints(n)
+    let ys <- make_ints(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let s = _fold(zip(xs, ys, $(x : int; y : int) => x * y).sum())
+        b |> accept(s)
+        if (s == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def zip_dot_product_3arg_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -213,9 +213,12 @@ identical — only the source iteration changes.
    * - Chain shape (decs source)
      - Splice arm
      - Notes
-   * - ``from_decs_template(type<T>)._where(P).count()``
+   * - ``from_decs_template(type<T>)._where(P).count()`` / ``.long_count()``
      - ``plan_decs_unroll`` → ``emit_decs_count_archsize``
      - Sums archetype sizes when ``where`` is absent; counter loop otherwise.
+   * - ``from_decs_template(type<T>).count(P)`` / ``.long_count(P)`` (bare chain, no where/select)
+     - ``plan_decs_unroll`` → ``emit_decs_accumulator``
+     - Theme 4 root-cause fix to ``extract_decs_bridge``: ``forExpr.iteratorVariables`` is unpopulated when no chain op forces an inference pass over the bridge's inner for-loop, so previously bailed. The bridge now recovers iter names from ``mkTup.values`` (peeling the ``ExprRef2Value`` wrap), making both the ``arch.size`` shortcut and the 2-arg ``count(P)`` accumulator path reachable on bare chains.
    * - ``from_decs_template(...)._select(F).sum()`` / ``.average()`` / ``.min()`` / ``.max()`` / ``.aggregate(...)``
      - ``plan_decs_unroll`` → ``emit_decs_accumulator``
      - Per-archetype accumulator; pruner keeps only the components read by ``F``.
@@ -329,6 +332,9 @@ Zip patterns
    * - ``zip(a, b, c)._select(F).<terminator>``
      - ``plan_zip``
      - Three-source zip; same loop shape with three reads per iteration.
+   * - ``zip(a, b, sel).<terminator>`` (3-arg, with selector lambda)
+     - ``plan_zip`` (pre-lowered)
+     - Theme 1 (audit 7a). The 3-arg form ``zip(a, b, sel)`` is pre-lowered by ``plan_zip`` to ``zip(a, b) |> _select(sel-as-tuple)`` before per-arm matching, so the standard zip+select fusion fires — the natural ``zip(xs, ys, $(x, y) => x * y) |> sum()`` dot-product idiom splices instead of cascading.
    * - ``zip(a, b)._where(P)._select(F).<terminator>``
      - ``plan_zip`` (chain ops)
      - ``where`` / ``select`` / ``take`` / ``skip`` / ``take_while`` / ``skip_while`` between zip and the terminator are all fused.

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -213,9 +213,9 @@ identical — only the source iteration changes.
    * - Chain shape (decs source)
      - Splice arm
      - Notes
-   * - ``from_decs_template(type<T>)._where(P).count()`` / ``from_decs_template(type<T>)._where(P).long_count()``
+   * - ``from_decs_template(type<T>).count()`` / ``.long_count()`` (bare) or with leading ``._where(P)``
      - ``plan_decs_unroll`` → ``emit_decs_count_archsize``
-     - Sums archetype sizes when ``where`` is absent; counter loop otherwise.
+     - Bare form sums ``arch.size`` across archetypes (no per-element work). The ``_where(P)`` variant runs a counter loop over the per-archetype walk.
    * - ``from_decs_template(type<T>).count(P)`` / ``.long_count(P)`` (bare chain, no where/select)
      - ``plan_decs_unroll`` → ``emit_decs_accumulator``
      - Theme 4 root-cause fix to ``extract_decs_bridge``: ``forExpr.iteratorVariables`` is unpopulated when no chain op forces an inference pass over the bridge's inner for-loop, so previously bailed. The bridge now recovers iter names from ``mkTup.values`` (peeling the ``ExprRef2Value`` wrap), making both the ``arch.size`` shortcut and the 2-arg ``count(P)`` accumulator path reachable on bare chains.

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -213,7 +213,7 @@ identical — only the source iteration changes.
    * - Chain shape (decs source)
      - Splice arm
      - Notes
-   * - ``from_decs_template(type<T>)._where(P).count()`` / ``.long_count()``
+   * - ``from_decs_template(type<T>)._where(P).count()`` / ``from_decs_template(type<T>)._where(P).long_count()``
      - ``plan_decs_unroll`` → ``emit_decs_count_archsize``
      - Sums archetype sizes when ``where`` is absent; counter loop otherwise.
    * - ``from_decs_template(type<T>).count(P)`` / ``.long_count(P)`` (bare chain, no where/select)


### PR DESCRIPTION
## Summary

Bench coverage for every audit theme closed since 2026-05-24. Adds 17 new `benchmarks/sql/*.das` files, refreshes `benchmarks/sql/results.md` with the full INTERP+JIT matrix at master `2c18845d5`, and fills two gaps in `doc/source/reference/linq_fold_patterns.rst`.

Background: 7 of 8 themes from `benchmarks/sql/linq_fold_chain_audit.md` shipped over PRs #2851 / #2852 / #2857 / #2861 / #2862 / #2865 / #2866. None of those PRs added a dedicated bench — the splices ship green and the audit doc reflects the wins, but the perf claim was only verifiable via ad-hoc `ast_dump`. This PR plugs that hole.

## New benches (17)

| Theme | Bench | m1 (SQL) | m3f (Array) | m4 (Decs) |
|---|---|---|---|---|
| 1 | `sort_take_select` (1a/1e) | ✅ | ✅ | ✅ |
| 1 | `reverse_take_select` (plan_reverse ext) | ✅ | ✅ | ✅ |
| 1 | `zip_dot_product_3arg` (7a) | — | ✅ | — |
| 1 | `join_select` (8b) | — | ✅ | ✅ |
| 2 | `groupby_having_post_where` (4a/4e) | ✅ | ✅ | ✅ |
| 2 | `join_where_count` (8a/C6) | ✅ | ✅ | ✅ |
| 2 | `take_where_count` (5c postTakeWhereCond) | — | ✅ | ✅ |
| 3 P1 | `join_groupby_count` (C3) | — | ✅ | ✅ |
| 3 P1 | `join_groupby_to_array` (C3) | — | ✅ | ✅ |
| 3 P2 | `groupby_select_order_take` (C2) | ✅ | ✅ | ✅ |
| 3 P3 | `distinct_by_order_take` (C1) | — | ✅ | ✅ |
| 3 P3 | `order_distinct_take` (C5) | — | ✅ | — |
| 4 | `distinct_count_pred` (3c) | — | ✅ | ✅ |
| 4 | `zip_count_pred` (plan_zip 2-arg) | — | ✅ | — |
| 4 | `decs_count_bare_pred` (bare-chain decs) | — | — | ✅ |
| 5 | `order_reverse_normalized` (1b/2b) | ✅ | ✅ | ✅ |
| 7 | `chained_select_collapse` (7c+) | — | ✅ | ✅ |

Every `—` cell is documented in `results.md`'s "Notes on missing lanes" section with the specific reason (sqlite_linq surface limitation, no relational form, fixture gap, etc.).

## Notable findings

- **Theme 3 Phase 1 (C3)** lives up to "killer demo" billing: `join_groupby_count` m4=90.4 vs m3f=186.9 (INTERP) — decs splices to single-pass while array cascades through 3 intermediate allocs. JIT: 23.5 vs 48.4. Same shape `join_groupby_to_array` ratio is even better (0.42×).
- **Theme 2 join+_where (8a/C6)** measurable win on decs: `join_where_count` m4=81.3 vs m3f=149.0 (INTERP, 0.55×); JIT 25.4 vs 42.7 (0.59×).
- **Theme 1 join_select (8b)** mirrors `join_count` ratio: m4=86.3 vs m3f=149.0 INTERP (0.58×); JIT 24.6 vs 43.3 (0.57×).
- **Theme 7 chained_select_collapse** confirms zero-cost composition: m3f and m4 within 0.1 ns/op of each other both INTERP (17.8 vs 17.9) and JIT (2.1 vs 2.1) — the collapse pass yields identical splice surface to a hand-written single `_select`.
- **Theme 3 Phase 2 (C2)** `groupby_select_order_take` matches `groupby_sum` baseline (m3f=18.6 vs 18.8) — in-place sort tail adds no measurable overhead.

## RST gap-fills

Two rows added to `doc/source/reference/linq_fold_patterns.rst`:
- `from_decs_template(type<T>).count(P)` / `.long_count(P)` (bare chain) — Theme 4 root-cause fix to `extract_decs_bridge`.
- `zip(a, b, sel)` (3-arg with selector lambda) — Theme 1 audit 7a pre-lowering, under Zip patterns where users would look.

## Test plan

- [ ] `mcp__daslang__compile_check 'benchmarks/sql/*.das'` — 71 files clean
- [ ] `mcp__daslang__lint` on all 17 new benches — clean (1 nolint on PERF013 against macro-generated `+= 1` in `join_where_count`)
- [ ] `mcp__daslang__format_file` on all 17 — already formatted
- [ ] Full INTERP+JIT matrix re-run captured in `results.md`
- [ ] `distinct_count_pred` predicate sanity (first-occurrence Car had small `price` and never matched; switched to `year > 2009` which always matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)