### PR TITLE
json: emit vec types as {x,y,z} to match daslib JV<vec>

### DIFF
--- a/daslib/json_boost.das
+++ b/daslib/json_boost.das
@@ -366,8 +366,30 @@ def JV(v : auto(VecT)) {
 
 [expect_any_vector_type(ent), template(ent), unused_argument(ent)]
 def from_JV(v : JsonValue const explicit?; ent : auto(VecT); defV : VecT = VecT()) {
-    //! Parse a JSON value and return the corresponding vector value.
+    //! Parse a JSON value and return the corresponding vector value. Accepts both the object form ``{"x":1,"y":2}`` (what ``JV(v)`` emits) and the array form ``[1,2]`` (what ``sprint_json`` / ``debug_json_value`` emit for the same vector). Missing or short arrays fall back to ``defV`` field-by-field.
     if (v == null) return defV
+    if (v.value is _array) {
+        unsafe {
+            let arr & = v.value as _array
+            let n = length(arr)
+            static_if (typeinfo vector_dim(defV) == 2) {
+                return VecT(
+                    n > 0 ? (arr[0] ?? defV.x) : defV.x,
+                    n > 1 ? (arr[1] ?? defV.y) : defV.y)
+            } static_elif (typeinfo vector_dim(defV) == 3) {
+                return VecT(
+                    n > 0 ? (arr[0] ?? defV.x) : defV.x,
+                    n > 1 ? (arr[1] ?? defV.y) : defV.y,
+                    n > 2 ? (arr[2] ?? defV.z) : defV.z)
+            } static_elif (typeinfo vector_dim(defV) == 4) {
+                return VecT(
+                    n > 0 ? (arr[0] ?? defV.x) : defV.x,
+                    n > 1 ? (arr[1] ?? defV.y) : defV.y,
+                    n > 2 ? (arr[2] ?? defV.z) : defV.z,
+                    n > 3 ? (arr[3] ?? defV.w) : defV.w)
+            }
+        }
+    }
     assume vo = v
     static_if (typeinfo vector_dim(defV) == 2) {
         return VecT(vo?["x"] ?? defV.x, vo?["y"] ?? defV.y)
@@ -386,7 +408,9 @@ def from_JV(v : JsonValue const explicit?; anything : table< auto(KT); auto(VT) 
     unsafe {
         let tab & = v.value as _object
         for (k, vv in keys(tab), values(tab)) {
-            move_to_ref(ret[k], _::from_JV(vv, type<VT -&>))
+            // VT can be scalar or struct/table — keep from_JV uniform; ?? has
+            // no overload for non-scalar VT.
+            move_to_ref(ret[k], _::from_JV(vv, type<VT -&>))  // nolint:STYLE020
         }
     }
     return <- ret
@@ -504,6 +528,7 @@ def JV(value : auto(TT)) : JsonValue? {
     //! This is the main dispatch function that handles various types.
     static_if (typeinfo is_dim(value)) {
         var arr : array<JsonValue?>
+        arr |> reserve(length(value))
         for (t in value) {
             arr |> push(JV(t))
         }

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -16,6 +16,7 @@ namespace das {
         bool unescape = false;
         bool embed = false;
         bool optional = false; // if true, we do not write zero values, only non-zero ones
+        bool inTableKey = false; // vec/range emit as array form here to fit inside the outer "..." quote
         vector<bool> ignoreNextFields;
         vector<bool> anyStructFields;
     // data structures
@@ -151,10 +152,18 @@ namespace das {
             ss << "{";
         }
         virtual void beforeTableKey ( Table *, TypeInfo *, char *, TypeInfo * ki, uint64_t, bool ) override {
-            if ( ki->type!=Type::tString ) ss << "\"";
+            if ( ki->type!=Type::tString ) {
+                ss << "\"";
+                inTableKey = true;
+            }
         }
         virtual void afterTableKey ( Table *, TypeInfo *, char *, TypeInfo * ki, uint64_t, bool ) override {
-            if ( ki->type!=Type::tString ) ss << "\":"; else ss << ":";
+            if ( ki->type!=Type::tString ) {
+                ss << "\":";
+                inTableKey = false;
+            } else {
+                ss << ":";
+            }
         }
         virtual void afterTableValue ( Table *, TypeInfo *, char *, TypeInfo *, uint64_t, bool last ) override {
             if ( !last ) ss << ",";
@@ -234,31 +243,40 @@ namespace das {
             ss << int64_t(value);
         }
         virtual void Int2 ( int2 & value ) override {
-            ss << "[" << value.x << "," << value.y << "]";
+            if ( inTableKey ) ss << "[" << value.x << "," << value.y << "]";
+            else ss << "{\"x\":" << value.x << ",\"y\":" << value.y << "}";
         }
         virtual void Int3 ( int3 & value ) override {
-            ss << "[" << value.x << "," << value.y << "," << value.z << "]";
+            if ( inTableKey ) ss << "[" << value.x << "," << value.y << "," << value.z << "]";
+            else ss << "{\"x\":" << value.x << ",\"y\":" << value.y << ",\"z\":" << value.z << "}";
         }
         virtual void Int4 ( int4 & value ) override {
-            ss << "[" << value.x << "," << value.y << "," << value.z << "," << value.w << "]";
+            if ( inTableKey ) ss << "[" << value.x << "," << value.y << "," << value.z << "," << value.w << "]";
+            else ss << "{\"x\":" << value.x << ",\"y\":" << value.y << ",\"z\":" << value.z << ",\"w\":" << value.w << "}";
         }
         virtual void UInt2 ( uint2 & value ) override {
-            ss << "[" << int64_t(value.x) << "," << int64_t(value.y) << "]";
+            if ( inTableKey ) ss << "[" << int64_t(value.x) << "," << int64_t(value.y) << "]";
+            else ss << "{\"x\":" << int64_t(value.x) << ",\"y\":" << int64_t(value.y) << "}";
         }
         virtual void UInt3 ( uint3 & value ) override {
-            ss << "[" << int64_t(value.x) << "," << int64_t(value.y) << "," << int64_t(value.z) << "]";
+            if ( inTableKey ) ss << "[" << int64_t(value.x) << "," << int64_t(value.y) << "," << int64_t(value.z) << "]";
+            else ss << "{\"x\":" << int64_t(value.x) << ",\"y\":" << int64_t(value.y) << ",\"z\":" << int64_t(value.z) << "}";
         }
         virtual void UInt4 ( uint4 & value ) override {
-            ss << "[" << int64_t(value.x) << "," << int64_t(value.y) << "," << int64_t(value.z) << "," << int64_t(value.w) << "]";
+            if ( inTableKey ) ss << "[" << int64_t(value.x) << "," << int64_t(value.y) << "," << int64_t(value.z) << "," << int64_t(value.w) << "]";
+            else ss << "{\"x\":" << int64_t(value.x) << ",\"y\":" << int64_t(value.y) << ",\"z\":" << int64_t(value.z) << ",\"w\":" << int64_t(value.w) << "}";
         }
         virtual void Float2 ( float2 & value ) override {
-            ss << "[" << value.x << "," << value.y << "]";
+            if ( inTableKey ) ss << "[" << value.x << "," << value.y << "]";
+            else ss << "{\"x\":" << value.x << ",\"y\":" << value.y << "}";
         }
         virtual void Float3 ( float3 & value ) override {
-            ss << "[" << value.x << "," << value.y << "," << value.z << "]";
+            if ( inTableKey ) ss << "[" << value.x << "," << value.y << "," << value.z << "]";
+            else ss << "{\"x\":" << value.x << ",\"y\":" << value.y << ",\"z\":" << value.z << "}";
         }
         virtual void Float4 ( float4 & value ) override {
-            ss << "[" << value.x << "," << value.y << "," << value.z << "," << value.w << "]";
+            if ( inTableKey ) ss << "[" << value.x << "," << value.y << "," << value.z << "," << value.w << "]";
+            else ss << "{\"x\":" << value.x << ",\"y\":" << value.y << ",\"z\":" << value.z << ",\"w\":" << value.w << "}";
         }
         virtual void Range ( range & value ) override {
             ss << "[" << value.x << "," << value.y << "]";

--- a/src/simulate/json_scan.cpp
+++ b/src/simulate/json_scan.cpp
@@ -788,12 +788,50 @@ namespace das {
             }
         }
 
-        // ---- scan vector types: [x,y], [x,y,z], [x,y,z,w] ----
+        // ---- scan vector types: [x,y,z,w] (legacy) or {"x":,"y":,"z":,"w":} (canonical) ----
+        //
+        // sprint_json emits the object form ``{"x":..,"y":..}`` for vec types
+        // (matching daslib JV<vecN> in json_boost). The legacy array form
+        // ``[x,y,z]`` is still accepted on the scan side so manually-crafted
+        // payloads and older-emit JSON continue to round-trip.
+
+        // Map a single-char vec field key to its component index (-1 if not
+        // x/y/z/w or if the string isn't a 1-char key). Object-form vecs use
+        // these field names exclusively.
+        static int vecFieldIndex(const string & key) {
+            if (key.size() != 1) return -1;
+            switch (key[0]) {
+                case 'x': return 0;
+                case 'y': return 1;
+                case 'z': return 2;
+                case 'w': return 3;
+                default:  return -1;
+            }
+        }
 
         template <typename T>
         bool scanVec(char * dst, int count) {
-            if (!expect('[')) return false;
+            skipWS();
             T * vals = (T*)dst;
+            if (peek() == '{') {
+                // object form: zero-init then fill by field name
+                cur++;
+                for (int i = 0; i < count; i++) vals[i] = T(0);
+                if (expect('}')) return true;
+                while (true) {
+                    string key;
+                    if (!readString(key)) return false;
+                    if (!expect(':')) return false;
+                    int64_t v;
+                    if (!readInt64(v)) return false;
+                    int idx = vecFieldIndex(key);
+                    if (idx >= 0 && idx < count) vals[idx] = T(v);
+                    if (!expect(',')) break;
+                }
+                return expect('}');
+            }
+            // legacy array form
+            if (!expect('[')) return false;
             for (int i = 0; i < count; i++) {
                 if (i > 0 && !expect(',')) return false;
                 int64_t v;
@@ -804,8 +842,25 @@ namespace das {
         }
 
         bool scanVecF(char * dst, int count) {
-            if (!expect('[')) return false;
+            skipWS();
             float * vals = (float*)dst;
+            if (peek() == '{') {
+                cur++;
+                for (int i = 0; i < count; i++) vals[i] = 0.f;
+                if (expect('}')) return true;
+                while (true) {
+                    string key;
+                    if (!readString(key)) return false;
+                    if (!expect(':')) return false;
+                    double v;
+                    if (!readDouble(v)) return false;
+                    int idx = vecFieldIndex(key);
+                    if (idx >= 0 && idx < count) vals[idx] = float(v);
+                    if (!expect(',')) break;
+                }
+                return expect('}');
+            }
+            if (!expect('[')) return false;
             for (int i = 0; i < count; i++) {
                 if (i > 0 && !expect(',')) return false;
                 double v;

--- a/tests/json/types.das
+++ b/tests/json/types.das
@@ -5,7 +5,8 @@ require daslib/json_boost
 def test_equ(t : T?; x : auto(TT)) {
     var jv = JV(x)
     // to_log(LOG_INFO, "{x}:{typeinfo(typename x)} serialized as {write_json(jv)}\n")
-    t |> equal(x, from_JV(jv, decltype_noref(x)))
+    // Generic driver: TT can be scalar or struct/table — keep from_JV uniform.
+    t |> equal(x, from_JV(jv, decltype_noref(x)))  // nolint:STYLE020
     unsafe {
         delete jv
     }
@@ -37,6 +38,44 @@ def vector_types(t : T?) {
     test_equ(t, uint2(1, 2))
     test_equ(t, uint3(1, 2, 3))
     test_equ(t, uint4(1, 2, 3, 4))
+}
+
+def test_array_form(t : T?; jsonText : string; want : auto(VecT)) {
+    var err : string
+    var v = read_json(jsonText, err)
+    t |> equal(empty(err), true, "read_json '{jsonText}' parses: {err}")
+    t |> equal(from_JV(v, type<VecT>, default<VecT>), want, "from_JV<vec> '{jsonText}'")
+    unsafe {
+        delete v
+    }
+}
+
+[test]
+def vector_array_form(t : T?) {
+    //! from_JV<vecN> accepts the JSON array form '[x,y,z,w]' (what sprint_json /
+    //! debug_json_value emit) in addition to the object form '{x,y,z,w}' (what
+    //! JV(vec) emits). Both shapes round-trip to the same vector value.
+    test_array_form(t, "[1, 2]", float2(1, 2))
+    test_array_form(t, "[1, 2, 3]", float3(1, 2, 3))
+    test_array_form(t, "[1, 2, 3, 4]", float4(1, 2, 3, 4))
+    test_array_form(t, "[1, 2]", int2(1, 2))
+    test_array_form(t, "[1, 2, 3]", int3(1, 2, 3))
+    test_array_form(t, "[1, 2, 3, 4]", int4(1, 2, 3, 4))
+    test_array_form(t, "[1, 2]", uint2(1, 2))
+    test_array_form(t, "[1, 2, 3]", uint3(1, 2, 3))
+    test_array_form(t, "[1, 2, 3, 4]", uint4(1, 2, 3, 4))
+    // Short / empty arrays fall back to default field-by-field.
+    test_array_form(t, "[]", float3(0, 0, 0))
+    test_array_form(t, "[7]", float3(7, 0, 0))
+    test_array_form(t, "[7, 8]", float3(7, 8, 0))
+    // Object form still works after the array-form branch.
+    var err : string
+    var obj = read_json("\{\"x\":1, \"y\":2, \"z\":3\}", err)
+    t |> equal(from_JV(obj, type<float3>, default<float3>), float3(1, 2, 3),
+               "object form still accepted")
+    unsafe {
+        delete obj
+    }
 }
 
 enum FooBar {
@@ -76,18 +115,14 @@ def struct_types(t : T?) {
 
 def operator ==(a, b : int[4]) {
     for (A, B in a, b) {
-        if (A != B) {
-            return false
-        }
+        return false if (A != B)
     }
     return true
 }
 
 def operator ==(a, b : SFoo[2] | #) {
     for (A, B in a, b) {
-        if (!(A == B)) {
-            return false
-        }
+        return false if (!(A == B))
     }
     return true
 }
@@ -100,18 +135,14 @@ def dim_types(t : T?) {
 
 def operator ==(a, b : array<int>) {
     for (A, B in a, b) {
-        if (A != B) {
-            return false
-        }
+        return false if (A != B)
     }
     return true
 }
 
 def operator ==(a, b : array<SFoo>) {
     for (A, B in a, b) {
-        if (!(A == B)) {
-            return false
-        }
+        return false if (!(A == B))
     }
     return true
 }
@@ -134,13 +165,9 @@ def tuple_types(t : T?) {
 }
 
 def op_equ_tab(a, b : table<string; auto(TT)>) {
-    if (a |> length != b |> length) {
-        return false
-    }
+    return false if (a |> length != b |> length)
     for (k, v in keys(a), values(a)) {
-        if (!(b |> key_exists(k))) {
-            return false
-        }
+        return false if (!(b |> key_exists(k)))
         var same = false
         b |> get(k) $(pv) {
             same = pv == v
@@ -191,13 +218,9 @@ struct MFoo {
 }
 
 def operator ==(a, b : MFoo) {
-    if (a.c |> length != b.c |> length) {
-        return false
-    }
+    return false if (a.c |> length != b.c |> length)
     for (ac, bc in a.c, b.c) {
-        if (ac != bc) {
-            return false
-        }
+        return false if (ac != bc)
     }
     return a.a == b.a && a.b == b.b
 }


### PR DESCRIPTION
## Summary

`sprint_json` / `debug_json_value` emitted vec2/3/4 as `[x,y,z]` arrays, while daslib `JV(vec)` emits `{"x":1,"y":2,"z":3}` objects. Code that emit via one and read via the other (typical pattern: snapshot via `sprint_json_at`, parse via `from_JV<vec>`) silently fell through to defaults. The mismatch surfaced in dasImgui's snapshot rail; pivot the C++ side to the object form so both sides agree, with backward-compat readers for the legacy array form.

## Changes

- **`src/simulate/json_print.cpp`** — `JsonWriter::Int2/Float2/...` emit object form `{"x":..,"y":..}`. Table-key emission keeps the legacy array form `[1,2]` (vec keys are stringified inside outer quotes; nested unescaped `"` would break the JSON).
- **`src/simulate/json_scan.cpp`** — `scanVec` / `scanVecF` accept both forms. Object branch zero-inits, fills by field name (x/y/z/w); legacy array branch preserved.
- **`daslib/json_boost.das`** — `from_JV<vecN>` accepts both forms; array branch first (matches `sprint_json` output), object branch fallback. Short / empty arrays fall back to `defV` field-by-field.
- **`daslib/json_boost.das`** — fix PERF006 in `JV(auto)`'s dim-handling branch: `reserve` before the push loop.
- **`tests/json/types.das`** — adds `vector_array_form` test covering both shapes through `from_JV`. Cleans up STYLE005 in pre-existing `operator ==` defs.

## Test plan

- [x] Full daslang test suite: 9453/9453 pass.
- [x] AOT JSON suite (`test_aot -use-aot dastest/dastest.das -- --use-aot --test tests/json`): 288/288 pass.
- [x] Lint clean on touched files.
- [x] Format clean.
- [ ] CI green.

## Follow-up

This unblocks **dasImgui PR4** (kill per-widget serializer/dispatcher lambdas) — that PR's runtime depends on `sprint_json_at` producing the same vec wire shape that `from_JV<vec>` reads. Opening once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
