### PR TITLE
tree-sitter: fix type<T>; parse failure in type position

### DIFF
--- a/tree-sitter-daslang/grammar.js
+++ b/tree-sitter-daslang/grammar.js
@@ -103,7 +103,7 @@ module.exports = grammar({
     [$.function_return_type, $.dim_type],
     [$.func_addr_expression, $.lambda_expression],
     [$.function_argument_list, $._variable_name],
-    [$.type_expression, $._type_macro_arg],
+    [$.type_expression, $.type_witness],
   ],
 
   rules: {
@@ -1400,6 +1400,7 @@ module.exports = grammar({
       $.variant_type,
       $.bitfield_type,
       $.typedecl_type,
+      $.type_witness,      // type<T> — type-witness form (e.g. `t : type<auto(T)>`)
       $.option_type,
       $._type_modifier,
       $.quote_type,        // $t(type) in macro quotes
@@ -1429,9 +1430,14 @@ module.exports = grammar({
     ),
 
     _type_macro_arg: $ => choice(
-      seq('type', '<', $._type, '>'),
+      $.type_witness,
       $._expression,
     ),
+
+    // type<T> as a TYPE (e.g. `t : type<auto(T)>` parameter, return type, struct field).
+    // Distinct node from type_expression (same shape, expression-context use only).
+    // Matches bison: type_declaration_no_options_no_dim → DAS_TYPE '<' type_declaration '>'.
+    type_witness: $ => seq('type', '<', field('type', $._type), '>'),
 
     auto_type: $ => prec.left(seq(
       'auto',

--- a/tree-sitter-daslang/src/grammar.json
+++ b/tree-sitter-daslang/src/grammar.json
@@ -8562,6 +8562,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "type_witness"
+        },
+        {
+          "type": "SYMBOL",
           "name": "option_type"
         },
         {
@@ -8894,29 +8898,37 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "type"
-            },
-            {
-              "type": "STRING",
-              "value": "<"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_type"
-            },
-            {
-              "type": "STRING",
-              "value": ">"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "type_witness"
         },
         {
           "type": "SYMBOL",
           "name": "_expression"
+        }
+      ]
+    },
+    "type_witness": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "type"
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_type"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ">"
         }
       ]
     },
@@ -10481,7 +10493,7 @@
     ],
     [
       "type_expression",
-      "_type_macro_arg"
+      "type_witness"
     ]
   ],
   "precedences": [],

--- a/tree-sitter-daslang/src/node-types.json
+++ b/tree-sitter-daslang/src/node-types.json
@@ -490,6 +490,10 @@
         "named": true
       },
       {
+        "type": "type_witness",
+        "named": true
+      },
+      {
         "type": "typedecl_type",
         "named": true
       },
@@ -4057,10 +4061,26 @@
           "named": true
         },
         {
-          "type": "_type",
+          "type": "type_witness",
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "type_witness",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/tree-sitter-daslang/test/corpus/declarations.txt
+++ b/tree-sitter-daslang/test/corpus/declarations.txt
@@ -222,3 +222,109 @@ typedef MyInt = int;
   (typedef_declaration
     name: (identifier)
     type: (basic_type)))
+
+================================================================================
+Function with type-witness parameter (basic)
+================================================================================
+
+def parse_int(t : type<int>) {
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list
+      (function_argument
+        name: (identifier)
+        type: (type_witness
+          type: (basic_type))))
+    body: (block)))
+
+================================================================================
+Function with type-witness parameter (auto)
+================================================================================
+
+def get_type_id(t : type<auto(T)>) : int {
+  return -1;
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list
+      (function_argument
+        name: (identifier)
+        type: (type_witness
+          type: (auto_type
+            (identifier)))))
+    (function_return_type
+      type: (basic_type))
+    body: (block
+      (return_statement
+        (unary_expression
+          (integer_literal))))))
+
+================================================================================
+Function with type-witness return type
+================================================================================
+
+def make_witness() : type<int> {
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list)
+    (function_return_type
+      type: (type_witness
+        type: (basic_type)))
+    body: (block)))
+
+================================================================================
+Struct field with type-witness type
+================================================================================
+
+struct Foo {
+  t : type<float>
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (structure_declaration
+    name: (identifier)
+    (structure_member
+      (structure_field
+        name: (identifier)
+        type: (type_witness
+          type: (basic_type))))))
+
+================================================================================
+Function with nested type-witness
+================================================================================
+
+def foo(t : type<array<int>>) {
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list
+      (function_argument
+        name: (identifier)
+        type: (type_witness
+          type: (array_type
+            (basic_type)))))
+    body: (block)))


### PR DESCRIPTION
## Summary

Reported via Telegram (user **Vi**): Zed syntax highlighting breaks on `type<…>` used as a function parameter type, e.g.

```das
def private get_type_id(t : type<auto(T)>) : int {
  print("{typeinfo typename(t)}")
  return -1
}
```

Root cause: the tree-sitter grammar only recognized `type<T>` in two places — inside `_type_macro_arg` (the inner sequence of a `padded(type<T>, …)` macro call) and as `type_expression` (which appears in expression positions only). Function parameters, return types, and struct fields declared with `type<T>` therefore fragmented the parse — even though this is the canonical witness-parameter form used throughout daslib (e.g. `daslib/clargs.das` lines 239/246/263/278/289).

Bison reference: `type_declaration_no_options_no_dim → DAS_TYPE '<' type_declaration '>'` ([ds2_parser.ypp:3281](https://github.com/GaijinEntertainment/daScript/blob/master/src/parser/ds2_parser.ypp#L3281)).

## Changes

- New `type_witness` rule mirroring the bison production, added to `_type` so it's accepted wherever a type is expected (parameters, return types, struct fields, typedefs, generic args, etc.).
- `_type_macro_arg` now reuses `type_witness`.
- `type_expression` stays — it remains the expression-context form (`let x = type<int>`); the conflict declaration is updated to `[type_expression, type_witness]`.
- `"type" @keyword` in both `queries/highlights.scm` and `zed-daslang/languages/daslang/highlights.scm` already covers the keyword highlight globally; no query changes needed.

## Tests

Five new corpus cases added to `test/corpus/declarations.txt`:

1. Basic param — `def parse_int(t : type<int>)`
2. Auto generic param — `def get_type_id(t : type<auto(T)>) : int` (the bug-report case)
3. Return type — `def make_witness() : type<int>`
4. Struct field — `struct Foo { t : type<float> }`
5. Nested — `def foo(t : type<array<int>>)`

`tree-sitter test` result: **34/34 pass** (5 new + 29 prior, no regressions).

## Notes on parser.c regen

The 0.22.0 CLI pinned in `package.json` doesn't run on Node 24 (EISDIR on drive root during grammar.js module resolution), so generation used 0.26.9 (still ABI 14). The parser.c diff is large because of the CLI version bump on top of the rule addition; `grammar.json` (+52/-26) and `node-types.json` (+22/-2) reflect only the rule change.

## Test plan

- [x] `tree-sitter test` (all 34 corpus cases pass)
- [x] `tree-sitter parse` on the bug-report snippet produces `(type_witness type: (auto_type (identifier)))` correctly nested under `function_argument`
- [x] `tree-sitter parse` on `padded(type<int>, 16)` in type position still produces `(type_macro …)` (existing path intact)
- [x] `tree-sitter parse` on `let x = type<int>` still produces `(type_expression …)` (expression path intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)