### PR TITLE
audio: HRTF budget + simulated-3D mixing, plus #2872 features + review fixes

### DIFF
--- a/examples/audio/hrtf/main.das
+++ b/examples/audio/hrtf/main.das
@@ -14,6 +14,7 @@ require daslib/safe_addr
 require daslib/math_boost
 require daslib/jobque_boost
 require math
+require strings
 
 // -- Shaders --
 
@@ -182,8 +183,21 @@ def add_sound_source(pos : float3; volume : float = 1.0) {
 
 // -- Main --
 
+// Parse --max-frames N from argv. Useful for headless repro and shutdown-leak debugging.
+def parse_max_frames {
+    var maxFrames = 0
+    let args <- get_command_line_arguments()
+    for (i in range(length(args))) {
+        if (args[i] == "--max-frames" && i + 1 < length(args)) {
+            maxFrames = to_int(args[i + 1])
+        }
+    }
+    return maxFrames
+}
+
 [export]
 def main {
+    let maxFrames = parse_max_frames()
     // GLFW init
     if (glfwInit() == 0) {
         panic("can't init glfw")
@@ -243,13 +257,20 @@ def main {
     // Load sound
     load_sound_data()
 
+    // Stats LockBox for per-second utilization + HRTF/simulated split readout.
+    // Lifecycle wraps the audio system: the audio thread releases its share-ref during
+    // audio_system_finalize (inside with_audio_system below), THEN this outer defer
+    // calls lock_box_remove to do the final delete. `release` alone never deletes.
+    var stats_box <- lock_box_create()
+    defer() {
+        unsafe(lock_box_remove(stats_box))
+    }
+
     // Audio system
     with_audio_system() {
         // Start with one source in front
         add_sound_source(float3(0.0, 0.0, -3.0))
 
-        // Stats LockBox for per-second utilization + HRTF/simulated split readout
-        var stats_box <- lock_box_create()
         set_audio_stats_box(stats_box)
 
         print("HRTF 3D Audio Demo\n")
@@ -263,9 +284,11 @@ def main {
         var m_was_pressed = false
         var b_was_pressed = false
         var since_stats_print = 0.0
+        var frameCount = 0
 
         eval_main_loop() {
-            if (glfwWindowShouldClose(window) != 0 || glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS) return false
+            if (glfwWindowShouldClose(window) != 0 || glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS || (maxFrames > 0 && frameCount >= maxFrames)) return false
+            frameCount ++
             glfwPollEvents()
 
             // Delta time
@@ -322,10 +345,11 @@ def main {
             }
             b_was_pressed = b_pressed
 
-            // Per-second audio-system stats line
+            // Per-second audio-system stats line. `get` is read-only — keeps the box alive across reads.
+            // `grab` would consume the notification and break the periodic publish/poll loop.
             since_stats_print += dt
             if (since_stats_print >= 1.0) {
-                stats_box |> grab() $(var s : AudioSystemStats) {
+                stats_box |> get() $(s : AudioSystemStats#) {
                     print("audio: util={s.utilization_pct}%, hrtf={s.hrtf_count}/{s.total_3d} (budget={HRTF_BUDGETS[hrtf_budget_idx]})\n")
                 }
                 since_stats_print = 0.0

--- a/examples/audio/hrtf/main.das
+++ b/examples/audio/hrtf/main.das
@@ -12,6 +12,7 @@ require daslib/defer
 require daslib/fio
 require daslib/safe_addr
 require daslib/math_boost
+require daslib/jobque_boost
 require math
 
 // -- Shaders --
@@ -97,6 +98,11 @@ let SOURCE_COLORS = fixed_array(
     float3(1.0, 0.3, 1.0)    // magenta
 )
 
+// HRTF/simulated routing budget — cycle on B key.
+let HRTF_BUDGETS = fixed_array(32, 0, 999)
+let HRTF_BUDGET_LABELS = fixed_array("mixed top-32", "all simulated", "all HRTF")
+var hrtf_budget_idx = 0
+
 var sound_data : array<float>
 var sound_channels = 1
 var sound_rate = MA_SAMPLE_RATE
@@ -167,9 +173,7 @@ def gl_to_audio(p : float3) : float3 {
 
 def add_sound_source(pos : float3; volume : float = 1.0) {
     let idx = length(sources) % 5
-    var src : SoundSource
-    src.position = pos
-    src.color = SOURCE_COLORS[idx]
+    var src = SoundSource(position = pos, color = SOURCE_COLORS[idx])
     var samples <- clone(sound_data)
     src.sid = play_3d_sound_loop_from_pcm(gl_to_audio(pos), linear_attenuation(10.0), sound_rate, sound_channels, samples)
     src.sid |> set_volume(volume)
@@ -244,22 +248,24 @@ def main {
         // Start with one source in front
         add_sound_source(float3(0.0, 0.0, -3.0))
 
+        // Stats LockBox for per-second utilization + HRTF/simulated split readout
+        var stats_box <- lock_box_create()
+        set_audio_stats_box(stats_box)
+
         print("HRTF 3D Audio Demo\n")
         print("  Click to capture mouse, click again to release\n")
         print("  WASD to move, mouse to look\n")
-        print("  N to add a sound source, ESC to quit\n")
+        print("  N to add a sound source, M to add 30, ESC to quit\n")
+        print("  B to cycle HRTF budget (mixed top-32 / all simulated / all HRTF)\n")
 
         var last_time = glfwGetTime()
         var n_was_pressed = false
         var m_was_pressed = false
+        var b_was_pressed = false
+        var since_stats_print = 0.0
 
         eval_main_loop() {
-            if (glfwWindowShouldClose(window) != 0) {
-                return false
-            }
-            if (glfwGetKey(window, int(GLFW_KEY_ESCAPE)) == int(GLFW_PRESS)) {
-                return false
-            }
+            if (glfwWindowShouldClose(window) != 0 || glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS) return false
             glfwPollEvents()
 
             // Delta time
@@ -271,21 +277,21 @@ def main {
             let speed = 5.0 * dt
             let fwd = camera_forward()
             let rgt = camera_right()
-            if (glfwGetKey(window, int(GLFW_KEY_W)) == int(GLFW_PRESS)) {
+            if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS) {
                 camera_pos += fwd * speed
             }
-            if (glfwGetKey(window, int(GLFW_KEY_S)) == int(GLFW_PRESS)) {
+            if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS) {
                 camera_pos -= fwd * speed
             }
-            if (glfwGetKey(window, int(GLFW_KEY_A)) == int(GLFW_PRESS)) {
+            if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS) {
                 camera_pos -= rgt * speed
             }
-            if (glfwGetKey(window, int(GLFW_KEY_D)) == int(GLFW_PRESS)) {
+            if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS) {
                 camera_pos += rgt * speed
             }
 
             // Add source on N press
-            let n_pressed = glfwGetKey(window, int(GLFW_KEY_N)) == int(GLFW_PRESS)
+            let n_pressed = glfwGetKey(window, GLFW_KEY_N) == GLFW_PRESS
             if (n_pressed && !n_was_pressed) {
                 let spawn_pos = camera_pos + fwd * 3.0
                 add_sound_source(spawn_pos)
@@ -294,7 +300,7 @@ def main {
             n_was_pressed = n_pressed
 
             // Add 30 sources around camera on M press
-            let m_pressed = glfwGetKey(window, int(GLFW_KEY_M)) == int(GLFW_PRESS)
+            let m_pressed = glfwGetKey(window, GLFW_KEY_M) == GLFW_PRESS
             if (m_pressed && !m_was_pressed) {
                 for (i in range(30)) {
                     let angle = 2.0 * PI * float(i) / 30.0
@@ -306,6 +312,24 @@ def main {
             }
             m_was_pressed = m_pressed
 
+            // Cycle HRTF budget on B press
+            let b_pressed = glfwGetKey(window, GLFW_KEY_B) == GLFW_PRESS
+            if (b_pressed && !b_was_pressed) {
+                hrtf_budget_idx = (hrtf_budget_idx + 1) % 3
+                let newBudget = HRTF_BUDGETS[hrtf_budget_idx]
+                set_hrtf_budget(newBudget)
+                print("HRTF budget: {newBudget} ({HRTF_BUDGET_LABELS[hrtf_budget_idx]})\n")
+            }
+            b_was_pressed = b_pressed
+
+            // Per-second audio-system stats line
+            since_stats_print += dt
+            if (since_stats_print >= 1.0) {
+                stats_box |> grab() $(var s : AudioSystemStats) {
+                    print("audio: util={s.utilization_pct}%, hrtf={s.hrtf_count}/{s.total_3d} (budget={HRTF_BUDGETS[hrtf_budget_idx]})\n")
+                }
+                since_stats_print = 0.0
+            }
 
             // Update audio listener
             set_head_position(gl_to_audio(camera_pos), gl_to_audio(fwd))

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -964,6 +964,10 @@ def command_processor {
                 g_stats_box |> release
                 g_stats_box = null
             }
+            // Reset the rolling window so a re-registered box starts with a clean accumulator
+            // instead of inheriting partial data from the previous registration.
+            g_stats_window_time_ms = 0.0lf
+            g_stats_window_samples = 0ul
             g_stats_box = unsafe(reinterpret<LockBox?>(sbox))
         } elif (cmd is stop) {
             let scmd = cmd as stop
@@ -1045,8 +1049,7 @@ var g_volume : float = 1.  //! global master volume multiplier (1.0 = full, 0.0 
 // AudioSystemStats publication state (audio-context-side; main side holds the LockBox handle and read-grabs it).
 var g_stats_box : LockBox? = null
 var g_stats_window_time_ms = 0.0lf      // accumulated mixer wall time over the current window
-var g_stats_window_samples = 0ul        // accumulated audio frames over the current window
-var g_stats_window_count : int = 0      // mixer-callback count over the window; once >=N callbacks we publish + reset
+var g_stats_window_samples = 0ul        // accumulated audio frames over the current window (flush gate: realTimeMs >= 1000)
 var g_stats_recent_util_pct : float = 0.0
 var g_stats_3d_count : int = 0
 var g_stats_hrtf_count : int = 0
@@ -1097,14 +1100,12 @@ def private publish_audio_stats(dt_ms : double; frames : uint64) {
     return if (g_stats_box == null)
     g_stats_window_time_ms += dt_ms
     g_stats_window_samples += frames
-    g_stats_window_count ++
     let realTimeMs = double(g_stats_window_samples) * 1000.lf / double(MA_SAMPLE_RATE)
     if (realTimeMs < 1000.lf) return
     let util = g_stats_window_time_ms / realTimeMs * 100.lf
     g_stats_recent_util_pct = float(util)
     g_stats_window_time_ms = 0.0lf
     g_stats_window_samples = 0ul
-    g_stats_window_count = 0
     let snap = g_stats_recent_util_pct
     let hrtfCount = g_stats_hrtf_count
     let total3D = g_stats_3d_count

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -78,6 +78,16 @@ struct public AudioChannelStatus {
     //! Number of pending PCM chunks in the stream queue.
 }
 
+//! Snapshot of the audio system's recent CPU utilization and HRTF/simulated routing split, published to a caller-provided LockBox.
+struct public AudioSystemStats {
+    utilization_pct : float
+    //! Mixer CPU utilization over the last ~1 second, in percent (0..100+).
+    hrtf_count : int
+    //! Number of channels currently routed through HRTF.
+    total_3d : int
+    //! Total active is3D channels (denominator of the HRTF/simulated split).
+}
+
 //! Distance attenuation coefficients for 3D audio.
 //! Use the helper functions (inverse_distance_attenuation, linear_attenuation, etc.) to create instances.
 [safe_when_uninitialized]
@@ -149,14 +159,15 @@ class AudioChannel {
     paused : bool = false
     pause_fade : float = 1.0        // current fade level (0=silent, 1=full)
     pause_fade_target : float = 1.0 // 0=fading to pause, 1=fading to play
-    pause_fade_step : float = 1.0 / 96.0 // per-frame ramp speed; default ~2ms at 48kHz
+    pause_fade_step : float = 1.0 / (0.002 * float(MA_SAMPLE_RATE)) // ~2ms ramp at the configured sample rate
     ignoreGlobalVolume : bool = false  // if true, g_volume does not multiply this channel
     stop   : bool = false
     pitch  : float = 1.
     volume : float = 1.
     source : AudioSource?
     resampler : ma_resampler
-    channel_converter : ma_channel_converter
+    channel_converter : ma_channel_converter      // HRTF mode for is3D: 2 -> MA_CHANNELS. Non-3D: source.channels -> MA_CHANNELS
+    channel_converter_sim : ma_channel_converter  // simulated-3D mode: source.channels -> MA_CHANNELS (built in set3D, used when !is_hrtf)
     volume_mixer : ma_volume_mixer
     playback_position : uint64 = 0ul
     position3d : float3
@@ -164,6 +175,7 @@ class AudioChannel {
     doppler : float = 1.
     attenuation : Attenuation = default_attenuation()
     is3D : bool = false
+    is_hrtf : bool = true      // runtime per-channel mode; rewritten each frame by update_hrtf's budget
     setup3D : bool = true
     @do_not_delete status : LockBox? = null
     @do_not_delete reverb : I3DL2Reverb?
@@ -196,6 +208,16 @@ class AudioChannel {
     }
     def set3D {
         is3D = true
+        // simulated-3D converter: source.channels -> MA_CHANNELS (mono->stereo upmix for mono sources)
+        var sim_config <- ma_channel_converter_config_init(
+            ma_format.ma_format_f32,
+            uint(source.channels),
+            null,
+            uint(MA_CHANNELS),
+            null,
+            ma_channel_mix_mode.ma_channel_mix_mode_default
+        )
+        ma_channel_converter_init(unsafe(addr(sim_config)), unsafe(addr(channel_converter_sim)))
         if (MA_HRTF) {
             ma_hrtf_init(unsafe(addr(hrtf)), uint(MA_SAMPLE_RATE))
             ma_channel_converter_uninit(unsafe(addr(channel_converter)))
@@ -217,6 +239,9 @@ class AudioChannel {
         }
         ma_volume_mixer_uninit(unsafe(addr(volume_mixer)))
         ma_channel_converter_uninit(unsafe(addr(channel_converter)))
+        if (is3D) {
+            ma_channel_converter_uninit(unsafe(addr(channel_converter_sim)))
+        }
         ma_resampler_uninit(unsafe(addr(resampler)))
         if (status != null) {
             status |> notify_and_release
@@ -277,9 +302,9 @@ class AudioChannel {
             delete samples
             samples <- temp
         }
-        // hrtf
+        // hrtf — only when this channel is routed through HRTF (top-N by distance per update_hrtf budget)
         var nSoundChannels = source.channels
-        if (is3D && MA_HRTF) {
+        if (is3D && MA_HRTF && is_hrtf) {
             // void ma_hrtf_process_frames(ma_hrtf * hrtf, float * pOut, const float * pIn, ma_uint32 nChannels, ma_uint32 frameCount)
             var temp : array<float>
             temp |> resize(int(outputFrames) * 2)
@@ -314,10 +339,15 @@ class AudioChannel {
             delete samples
             samples <- temp
         }
-        // convert channels
+        // convert channels — for is3D channels, pick the converter sized to the upstream stage:
+        //   HRTF mode    -> samples are 2ch, use `channel_converter` (2 -> MA_CHANNELS)
+        //   simulated 3D -> samples are source.channels, use `channel_converter_sim` (handles the mono->stereo upmix)
         var channel_data : array<float>
         channel_data |> resize(data |> length)
-        ma_channel_converter_process_pcm_frames(unsafe(addr(channel_converter)),
+        let converter_to_use = (is3D && !is_hrtf
+            ? unsafe(addr(channel_converter_sim))
+            : unsafe(addr(channel_converter)))
+        ma_channel_converter_process_pcm_frames(converter_to_use,
             unsafe(addr(channel_data[0])),
             unsafe(addr(samples[0])),
             outputFrames)
@@ -588,33 +618,89 @@ var g_head_position : float3
 var g_head_direction : float3 = float3(0., 1., 0.)
 var g_head_velocity : float3
 
+//! HRTF routing budget — at most this many is3D channels (closest to head) run through HRTF each frame; the rest run simulated-3D (pan + attenuation).
+var g_hrtf_budget : int = 32
+
+//! Calibrated normalizer applied to simulated-3D channels so their perceived loudness matches HRTF channels at the same position. Measured once in initialize_mixer.
+var g_hrtf_frontal_gain : float = 1.0
+
+// Scratch array reused each update_hrtf frame to avoid per-frame allocation; tuple of (distance² to head, g_channels index).
+var g_hrtf_scratch : array<tuple<dist2 : float; idx : int>>
+
+def public hrtf_budget_classify(rank, budget : int; wasHrtf : bool) : bool {
+    //! Decide whether a 3D channel at the given closest-to-head ``rank`` should run HRTF or simulated 3D,
+    //! given the current ``budget`` and whether the channel was HRTF on the previous frame.
+    //! Applies a sticky-rank margin to prevent flapping when two channels swap rank between frames,
+    //! while clamping to 0 when budget is 0 so "all simulated" actually clears in-flight HRTF channels.
+    let stickyTop = budget > 0 ? budget + max(2, budget / 10) : 0
+    return wasHrtf ? rank < stickyTop : rank < budget
+}
+
 def update_hrtf(dt : float; nFrames : uint64) {
+    // Pass 1: rank 3D channels by distance² and assign is_hrtf with a sticky-margin rule.
+    // The sticky margin prevents thrashing when two channels swap rank near the budget boundary.
+    g_hrtf_scratch |> clear()
+    for (i in range(length(g_channels))) {
+        var ch = g_channels[i]
+        if (ch.is3D && !ch.stop) {
+            let delta = ch.position3d - g_head_position
+            g_hrtf_scratch |> push((dist2 = dot(delta, delta), idx = i))
+        }
+    }
+    g_hrtf_scratch |> sort() $(a, b) => a.dist2 < b.dist2
+    let total3D = length(g_hrtf_scratch)
+    let budget = g_hrtf_budget
+    var hrtfCount = 0
+    for (rank in range(total3D)) {
+        let chIdx = g_hrtf_scratch[rank].idx
+        var ch = g_channels[chIdx]
+        let wasHrtf = ch.is_hrtf
+        let newHrtf = hrtf_budget_classify(rank, budget, wasHrtf)
+        if (newHrtf != wasHrtf) {
+            // linear_pan=true for HRTF (input is stereo from HRTF, unity at center); =false for simulated (constant-power panning of mono)
+            ma_volume_mixer_set_linear_pan(unsafe(addr(ch.volume_mixer)), newHrtf)
+            ch.is_hrtf = newHrtf
+        }
+        if (newHrtf) {
+            hrtfCount ++
+        }
+    }
+    g_stats_hrtf_count = hrtfCount
+    g_stats_3d_count = total3D
+
+    // Pass 2: per-channel position/pan/volume — routing decision already made above.
     for (ch in g_channels) {
         if (ch.is3D && !ch.stop) {
             var rxy = ch.position3d.xy - g_head_position.xy
             rxy = float2(rxy.x * g_head_direction.x + rxy.y * g_head_direction.y,
                         -rxy.x * g_head_direction.y + rxy.y * g_head_direction.x)
             let nrxy = normalize(rxy)
-            static_if (MA_HRTF) {
-                let asimuth = atan2(nrxy.y, nrxy.x)
-                let elevation = atan2(ch.position3d.z - g_head_position.z, length(rxy))
-                let iasimuth = int(asimuth * 180. / PI)
-                let ielevation = int(elevation * 180. / PI)
-                ma_hrtf_set_direction(unsafe(addr(ch.hrtf)), iasimuth, ielevation)
+            if (ch.is_hrtf) {
+                static_if (MA_HRTF) {
+                    let asimuth = atan2(nrxy.y, nrxy.x)
+                    let elevation = atan2(ch.position3d.z - g_head_position.z, length(rxy))
+                    let iasimuth = int(asimuth * 180. / PI)
+                    let ielevation = int(elevation * 180. / PI)
+                    ma_hrtf_set_direction(unsafe(addr(ch.hrtf)), iasimuth, ielevation)
+                }
+                // HRTF carries spatial cues; keep the volume_mixer's pan centered
+                ma_volume_mixer_set_pan(unsafe(addr(ch.volume_mixer)), 0.0)
             } else {
-                // panning
+                // simulated 3D — constant-power pan via the volume_mixer
                 ma_volume_mixer_set_pan(unsafe(addr(ch.volume_mixer)), nrxy.y)
             }
-            // volume attenuation — ramp over frame to avoid clicks
+            // volume attenuation — ramp over frame to avoid clicks. Simulated channels are scaled by the
+            // calibrated frontal-gain normalizer so they match HRTF channels at the same position.
             let distance = length(ch.position3d - g_head_position)
             let attn = compute_attenuation(ch.attenuation, distance)
             let g = ch.ignoreGlobalVolume ? 1.0 : g_volume
+            let modeGain = ch.is_hrtf ? 1.0 : g_hrtf_frontal_gain
+            let target = ch.volume * attn * g * modeGain
             if (ch.setup3D) {
-                ma_volume_mixer_set_linear_pan(unsafe(addr(ch.volume_mixer)), false)
-                ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), ch.volume * attn * g)
+                ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), target)
                 ch.setup3D = false
             } else {
-                ma_volume_mixer_set_volume_over_time(unsafe(addr(ch.volume_mixer)), ch.volume * attn * g, nFrames)
+                ma_volume_mixer_set_volume_over_time(unsafe(addr(ch.volume_mixer)), target, nFrames)
             }
             // doppler
             let vrel = g_head_velocity - ch.velocity3d
@@ -714,6 +800,8 @@ variant AudioCommand {
     global_pause            : bool
     global_volume           : float
     ignore_global_volume    : tuple<sid : SID; value : bool>
+    hrtf_budget             : int
+    system_stats_box        : uint64       //! opaque LockBox? (archive-safe)
 }
 
 var g_command_stream : Stream?
@@ -757,6 +845,10 @@ def command_processor {
                 delete g_channels
             }
             g_sid_2_channel |> clear()
+            if (g_stats_box != null) {
+                g_stats_box |> notify_and_release
+                g_stats_box = null
+            }
             g_command_stream |> release
         } elif (cmd is add_decoder) {
             assume dcmd = cmd as add_decoder
@@ -861,6 +953,15 @@ def command_processor {
                 let effective = ch.volume * (ch.ignoreGlobalVolume ? 1.0 : g_volume)
                 ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), effective)
             }
+        } elif (cmd is hrtf_budget) {
+            g_hrtf_budget = max(0, cmd as hrtf_budget)
+        } elif (cmd is system_stats_box) {
+            let sbox = cmd as system_stats_box
+            if (g_stats_box != null) {
+                g_stats_box |> notify_and_release
+                g_stats_box = null
+            }
+            g_stats_box = unsafe(reinterpret<LockBox?>(sbox))
         } elif (cmd is stop) {
             let scmd = cmd as stop
             g_sid_2_channel |> get(scmd.sid) $(var ch : AudioChannel?&) {
@@ -938,6 +1039,15 @@ var g_mix_buffer : array<float>
 var g_pause : bool = false
 var g_volume : float = 1.  //! global master volume multiplier (1.0 = full, 0.0 = mute)
 
+// AudioSystemStats publication state (audio-context-side; main side holds the LockBox handle and read-grabs it).
+var g_stats_box : LockBox? = null
+var g_stats_window_time_us = 0.0lf      // accumulated mixer wall time over the current window
+var g_stats_window_samples = 0ul        // accumulated audio frames over the current window
+var g_stats_window_count : int = 0      // mixer-callback count over the window; once >=N callbacks we publish + reset
+var g_stats_recent_util_pct : float = 0.0
+var g_stats_3d_count : int = 0
+var g_stats_hrtf_count : int = 0
+
 [export]
 def mixer(var data : array<float>#; channels, rate : int; dt : float) {
     let t0 = ref_time_ticks()
@@ -972,8 +1082,34 @@ def mixer(var data : array<float>#; channels, rate : int; dt : float) {
             uint64(output_samples))
         g_mix_buffer |> erase(0, output_samples * channels)
     }
-    g_mixer_total_time += double(get_time_usec(t0)) / 1000.lf
+    let dt_ms = double(get_time_usec(t0)) / 1000.lf
+    g_mixer_total_time += dt_ms
     g_mixer_total_samples += uint64(length(data) / channels)
+    publish_audio_stats(dt_ms, uint64(length(data) / channels))
+}
+
+// Accumulate per-callback time + samples into a 1-second rolling window. On window flush, compute
+// utilization (= mixer time / real time) and update the caller's stats LockBox so main thread can read it.
+def private publish_audio_stats(dt_ms : double; frames : uint64) {
+    return if (g_stats_box == null)
+    g_stats_window_time_us += dt_ms
+    g_stats_window_samples += frames
+    g_stats_window_count ++
+    let realTimeMs = double(g_stats_window_samples) * 1000.lf / double(MA_SAMPLE_RATE)
+    if (realTimeMs < 1000.lf) return
+    let util = g_stats_window_time_us / realTimeMs * 100.lf
+    g_stats_recent_util_pct = float(util)
+    g_stats_window_time_us = 0.0lf
+    g_stats_window_samples = 0ul
+    g_stats_window_count = 0
+    let snap = g_stats_recent_util_pct
+    let hrtfCount = g_stats_hrtf_count
+    let total3D = g_stats_3d_count
+    g_stats_box |> update() $(var s : AudioSystemStats#) {
+        s.utilization_pct = snap
+        s.hrtf_count = hrtfCount
+        s.total_3d = total3D
+    }
 }
 
 [init]
@@ -986,7 +1122,68 @@ def initialize_mixer {
             MA_LIMITER_RELEASE_TIME,
             float(MA_SAMPLE_RATE),
             uint(MA_CHANNELS))
+        static_if (MA_HRTF) {
+            calibrate_hrtf_frontal_gain()
+        }
     }
+}
+
+// Measure the HRTF's broadband gain at azimuth=0, elevation=0 with a 1 kHz sine probe and
+// compute the loudness-matching normalizer for the simulated-3D path.
+//
+// Derivation (per-channel amplitude at the volume_mixer output, head-on source):
+//   * HRTF path:      linear pan, identity at pan=0  -> per-channel = HRIR_gain * input
+//   * Simulated path: constant-power pan, 1/sqrt(2)  -> per-channel = 0.707 * input * normalizer
+//   Equality at center =>  normalizer = HRIR_gain / 0.707 = HRIR_gain * sqrt(2)
+//
+// HRIR_gain is the sine-input amplitude ratio (≈ |H(1 kHz)|, the magnitude of the HRIR's transfer
+// function at the probe frequency). DC (a constant signal) is the worst probe because impulse-
+// response filters attenuate DC strongly; sine at ~1 kHz gives a representative broadband estimate.
+def private calibrate_hrtf_frontal_gain {
+    let probeFrames = 2048
+    let measureStart = 512    // skip the HRTF crossfade region; measure the steady-state tail
+    var probe_hrtf : ma_hrtf
+    ma_hrtf_init(unsafe(addr(probe_hrtf)), uint(MA_SAMPLE_RATE))
+    // Per hrtf.h: first set_direction triggers a 256-sample crossfade against the zero filter;
+    // the second call leaves needs_crossfade=0 so the steady-state output is a clean measurement.
+    ma_hrtf_set_direction(unsafe(addr(probe_hrtf)), 0, 0)
+    ma_hrtf_set_direction(unsafe(addr(probe_hrtf)), 0, 0)
+    var input : array<float>
+    input |> resize(probeFrames)
+    let probeFreq = 1000.0
+    let phaseStep = 2.0 * PI * probeFreq / float(MA_SAMPLE_RATE)
+    for (i in range(probeFrames)) {
+        input[i] = sin(phaseStep * float(i))
+    }
+    var output : array<float>
+    output |> resize(probeFrames * 2)
+    ma_hrtf_process_frames(unsafe(addr(probe_hrtf)),
+        unsafe(addr(output[0])),
+        unsafe(addr(input[0])),
+        1u,
+        uint(probeFrames))
+    // Per-channel RMS over the steady-state tail; the frontal source is symmetric so average L+R.
+    var sumSq = 0.0
+    let nSamples = probeFrames - measureStart
+    for (i in range(measureStart, probeFrames)) {
+        let l = output[i * 2]
+        let r = output[i * 2 + 1]
+        sumSq += l * l + r * r
+    }
+    let perChannelRms = sqrt(sumSq / float(2 * nSamples))
+    let inputRms = sqrt(0.5)                            // sine of amplitude 1.0
+    let hrirGain = perChannelRms / inputRms             // ≈ |H(1 kHz)| of the frontal HRIR
+    let normalizer = hrirGain * sqrt(2.0)               // compensates the -3 dB const-power center pan
+    if (normalizer > 0.25 && normalizer < 4.0) {
+        g_hrtf_frontal_gain = normalizer
+    } else {
+        to_log(LOG_WARNING, "HRTF calibration produced out-of-range normalizer={normalizer} (hrirGain={hrirGain}); using 1.414 fallback\n")
+        g_hrtf_frontal_gain = sqrt(2.0)
+    }
+    ma_hrtf_uninit(unsafe(addr(probe_hrtf)))
+    delete input
+    delete output
+    to_log(LOG_INFO, "HRTF frontal-gain calibration: perChannelRms={perChannelRms}, hrirGain={hrirGain}, normalizer={g_hrtf_frontal_gain}\n")
 }
         /*
         ma_limiter_init_linear(unsafe(addr(g_limiter)),
@@ -1234,6 +1431,23 @@ def public set_ignore_global_volume(sid : SID; value : bool) {
     //! Make a specific channel ignore the global master volume (used by editor preview so muting the
     //! game's master volume does not silence the asset preview).
     push_cmd(AudioCommand(ignore_global_volume = (sid = sid, value = value)))
+}
+
+def public set_hrtf_budget(n : int) {
+    //! Set the maximum number of 3D channels routed through HRTF each frame; the rest run simulated 3D
+    //! (constant-power pan + distance attenuation, no convolution). Use 0 for all-simulated, or a large
+    //! value (e.g. 999) for all-HRTF. Default is 32. The closest-to-head channels win the HRTF slots.
+    push_cmd(AudioCommand(hrtf_budget = n))
+}
+
+def public set_audio_stats_box(var box : LockBox?) {
+    //! Register a LockBox to receive periodic AudioSystemStats updates from the audio thread.
+    //! The audio thread writes one snapshot per ~1-second window; the caller can read on demand
+    //! via ``box |> grab() $(var s : AudioSystemStats) { ... }``. Pass null to clear.
+    box |> add_ref
+    box |> append(1)
+    box |> set() <| new AudioSystemStats(utilization_pct = 0.0, hrtf_count = 0, total_3d = 0)
+    push_cmd(AudioCommand(system_stats_box = intptr(box)))
 }
 
 def public stop(sid : SID; time : float = 0.0f) {

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -1,5 +1,7 @@
 options gen2
 options indenting = 4
+options persistent_heap
+options gc
 options no_global_variables = false
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
@@ -147,6 +149,8 @@ class AudioChannel {
     paused : bool = false
     pause_fade : float = 1.0        // current fade level (0=silent, 1=full)
     pause_fade_target : float = 1.0 // 0=fading to pause, 1=fading to play
+    pause_fade_step : float = 1.0 / 96.0 // per-frame ramp speed; default ~2ms at 48kHz
+    ignoreGlobalVolume : bool = false  // if true, g_volume does not multiply this channel
     stop   : bool = false
     pitch  : float = 1.
     volume : float = 1.
@@ -160,6 +164,7 @@ class AudioChannel {
     doppler : float = 1.
     attenuation : Attenuation = default_attenuation()
     is3D : bool = false
+    setup3D : bool = true
     @do_not_delete status : LockBox? = null
     @do_not_delete reverb : I3DL2Reverb?
     @do_not_delete chorus : ma_chorus?
@@ -196,7 +201,7 @@ class AudioChannel {
             ma_channel_converter_uninit(unsafe(addr(channel_converter)))
             var channel_converter_config <- ma_channel_converter_config_init(
                 ma_format.ma_format_f32,
-                2u,
+                uint(source.channels),
                 null,
                 uint(MA_CHANNELS),
                 null,
@@ -326,9 +331,9 @@ class AudioChannel {
             unsafe(addr(data[0])),
             outputFrames)
         delete channel_data
-        // apply pause fade (2ms ramp to avoid clicks)
+        // apply pause fade (per-channel ramp speed, default ~2ms to avoid clicks)
         if (pause_fade != pause_fade_target) {
-            let fade_step = 1.0 / 96.0  // ~2ms at 48kHz
+            let fade_step = pause_fade_step
             for (f in range(int(outputFrames))) {
                 let fade = pause_fade
                 for (c in range(channels)) {
@@ -602,7 +607,14 @@ def update_hrtf(dt : float; nFrames : uint64) {
             // volume attenuation — ramp over frame to avoid clicks
             let distance = length(ch.position3d - g_head_position)
             let attn = compute_attenuation(ch.attenuation, distance)
-            ma_volume_mixer_set_volume_over_time(unsafe(addr(ch.volume_mixer)), ch.volume * attn, nFrames)
+            let g = ch.ignoreGlobalVolume ? 1.0 : g_volume
+            if (ch.setup3D) {
+                ma_volume_mixer_set_linear_pan(unsafe(addr(ch.volume_mixer)), false)
+                ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), ch.volume * attn * g)
+                ch.setup3D = false
+            } else {
+                ma_volume_mixer_set_volume_over_time(unsafe(addr(ch.volume_mixer)), ch.volume * attn * g, nFrames)
+            }
             // doppler
             let vrel = g_head_velocity - ch.velocity3d
             let r = normalize(ch.position3d - g_head_position)
@@ -686,7 +698,7 @@ variant AudioCommand {
     add_pcm_stream_3d       : AudioCommandAddPCMStream3D
     append_pcm              : tuple<sid : SID; samples : array<float>>
     append_box_pcm          : tuple<sid : SID; box : uint64>  //! opaque LockBox? (archive-safe)
-    pause                   : tuple<sid : SID; paused : bool>
+    pause                   : tuple<sid : SID; paused : bool; time : float>
     volume                  : tuple<sid : SID; volume : float; time : float>
     pan                     : tuple<sid : SID; pan : float>
     pitch                   : tuple<sid : SID; pitch : float>
@@ -699,6 +711,8 @@ variant AudioCommand {
     chorus_cmd              : tuple<sid : SID; config : ma_chorus_config>
     set_playback_position   : tuple<sid : SID; position : uint64>
     global_pause            : bool
+    global_volume           : float
+    ignore_global_volume    : tuple<sid : SID; value : bool>
 }
 
 var g_command_stream : Stream?
@@ -715,6 +729,8 @@ def add_channel(sid : SID; var channel : AudioChannel?) {
         channel.sid = sid
         g_sid_2_channel |> insert(sid, channel)
     }
+    let g = channel.ignoreGlobalVolume ? 1.0 : g_volume
+    ma_volume_mixer_set_volume(unsafe(addr(channel.volume_mixer)), channel.volume * g)
 }
 
 def add_channel_3d(sid : SID; position : float3; attenuation : Attenuation; var channel : AudioChannel?) {
@@ -793,6 +809,8 @@ def command_processor {
         } elif (cmd is pause) {
             let pcmd = cmd as pause
             g_sid_2_channel |> get(pcmd.sid) $(var ch : AudioChannel?&) {
+                let nFrames = max(1.0, pcmd.time * float(MA_SAMPLE_RATE))
+                ch.pause_fade_step = 1.0 / nFrames
                 if (pcmd.paused) {
                     ch.pause_fade_target = 0.0  // fade out to pause
                 } else {
@@ -804,11 +822,13 @@ def command_processor {
             let vcmd = cmd as volume
             g_sid_2_channel |> get(vcmd.sid) $(var ch : AudioChannel?&) {
                 ch.volume = vcmd.volume
+                let g = ch.ignoreGlobalVolume ? 1.0 : g_volume
+                let effective = vcmd.volume * g
                 if (vcmd.time > 0.) {
                     let nFrames = uint64(vcmd.time * float(MA_SAMPLE_RATE))
-                    ma_volume_mixer_set_volume_over_time(unsafe(addr(ch.volume_mixer)), vcmd.volume, nFrames)
+                    ma_volume_mixer_set_volume_over_time(unsafe(addr(ch.volume_mixer)), effective, nFrames)
                 } else {
-                    ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), vcmd.volume)
+                    ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), effective)
                 }
             }
         } elif (cmd is pan) {
@@ -825,6 +845,21 @@ def command_processor {
             g_pitch = cmd as global_pitch
         } elif (cmd is global_pause) {
             g_pause = cmd as global_pause // todo: envelope?
+        } elif (cmd is global_volume) {
+            g_volume = cmd as global_volume
+            let nFrames = uint64(0.025 * float(MA_SAMPLE_RATE))
+            for (it in values(g_sid_2_channel)) {
+                if (!it.stop && !it.ignoreGlobalVolume) {
+                    ma_volume_mixer_set_volume_over_time(unsafe(addr(it.volume_mixer)), it.volume * g_volume, nFrames)
+                }
+            }
+        } elif (cmd is ignore_global_volume) {
+            let icmd = cmd as ignore_global_volume
+            g_sid_2_channel |> get(icmd.sid) $(var ch : AudioChannel?&) {
+                ch.ignoreGlobalVolume = icmd.value
+                let effective = ch.volume * (ch.ignoreGlobalVolume ? 1.0 : g_volume)
+                ma_volume_mixer_set_volume(unsafe(addr(ch.volume_mixer)), effective)
+            }
         } elif (cmd is stop) {
             let scmd = cmd as stop
             g_sid_2_channel |> get(scmd.sid) $(var ch : AudioChannel?&) {
@@ -900,6 +935,7 @@ def command_processor {
 var g_limiter : ma_limiter
 var g_mix_buffer : array<float>
 var g_pause : bool = false
+var g_volume : float = 1.  //! global master volume multiplier (1.0 = full, 0.0 = mute)
 
 [export]
 def mixer(var data : array<float>#; channels, rate : int; dt : float) {
@@ -1032,12 +1068,15 @@ def public begin_batch() {
 }
 
 def public end_batch() {
-    //! End batching and send all batched commands atomically.
+    //! End batching and send all batched commands atomically. No-op if no batch is open.
     if (global_batch == null) {
-        panic("no batch")
+        return
     }
     g_command_stream |> push_batch(*global_batch)
     unsafe {
+        for (it in *global_batch) {
+            delete it
+        }
         delete * global_batch
     }
     global_batch = null
@@ -1072,25 +1111,25 @@ def push_cmd(var cmd : AudioCommand) {
     }
 }
 
-def public play_sound_from_file(filename : string; rate, channels : int) {
-    //! plays sound from file
+def public play_sound_from_file(filename : string; rate, channels : int; sid : SID = INVALID_SID) {
+    //! plays sound from file. If sid is INVALID_SID, a new SID is generated.
     //! note - this function is blocking for the duration of the decoder creation
     var decoder = make_decoder(filename, rate, channels)
     if (decoder == null) return INVALID_SID
-    let sid = generate_sound_sid()
-    push_cmd(AudioCommand(add_decoder = AudioCommandAddDecoder(sid = sid, decoder = intptr(decoder), rate = rate, channels = channels)))
-    return sid
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
+    push_cmd(AudioCommand(add_decoder = AudioCommandAddDecoder(sid = useSid, decoder = intptr(decoder), rate = rate, channels = channels)))
+    return useSid
 }
 
-def public play_3d_sound_from_file(filename : string; position : float3; attenuation : Attenuation; rate, channels : int) {
-    //! plays 3D sound from file
+def public play_3d_sound_from_file(filename : string; position : float3; attenuation : Attenuation; rate, channels : int; sid : SID = INVALID_SID) {
+    //! plays 3D sound from file. If sid is INVALID_SID, a new SID is generated.
     //! note - this function is blocking for the duration of the decoder creation
     var decoder = make_decoder(filename, rate, channels)
     if (decoder == null) return INVALID_SID
-    let sid = generate_sound_sid()
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
     push_cmd(AudioCommand(add_decoder_3d =
-        AudioCommandAddDecoder3D(sid = sid, decoder = intptr(decoder), rate = rate, channels = channels, position = position, attenuation = attenuation)))
-    return sid
+        AudioCommandAddDecoder3D(sid = useSid, decoder = intptr(decoder), rate = rate, channels = channels, position = position, attenuation = attenuation)))
+    return useSid
 }
 
 def public play_sound_from_pcm_stream(rate, channels : int; sid : SID = generate_sound_sid()) {
@@ -1107,34 +1146,34 @@ def public play_3d_sound_from_pcm_stream(position : float3; attenuation : Attenu
     return sid
 }
 
-def public play_sound_from_pcm(rate, channels : int; var samples : array<float>) {
-    //! plays sound from PCM data
-    let sid = generate_sound_sid()
-    push_cmd(AudioCommand(add_pcm <- AudioCommandAddPCM(sid = sid, rate = rate, channels = channels, samples <- samples, loop = false)))
-    return sid
+def public play_sound_from_pcm(rate, channels : int; var samples : array<float>; sid : SID = INVALID_SID) {
+    //! plays sound from PCM data. If sid is INVALID_SID, a new SID is generated.
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
+    push_cmd(AudioCommand(add_pcm <- AudioCommandAddPCM(sid = useSid, rate = rate, channels = channels, samples <- samples, loop = false)))
+    return useSid
 }
 
-def public play_sound_loop_from_pcm(rate, channels : int; var samples : array<float>) {
-    //! plays looping sound from PCM data
-    let sid = generate_sound_sid()
-    push_cmd(AudioCommand(add_pcm <- AudioCommandAddPCM(sid = sid, rate = rate, channels = channels, samples <- samples, loop = true)))
-    return sid
+def public play_sound_loop_from_pcm(rate, channels : int; var samples : array<float>; sid : SID = INVALID_SID) {
+    //! plays looping sound from PCM data. If sid is INVALID_SID, a new SID is generated.
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
+    push_cmd(AudioCommand(add_pcm <- AudioCommandAddPCM(sid = useSid, rate = rate, channels = channels, samples <- samples, loop = true)))
+    return useSid
 }
 
-def public play_3d_sound_from_pcm(position : float3; attenuation : Attenuation; rate, channels : int; var samples : array<float>) {
-    //! plays 3D sound from PCM data
-    let sid = generate_sound_sid()
+def public play_3d_sound_from_pcm(position : float3; attenuation : Attenuation; rate, channels : int; var samples : array<float>; sid : SID = INVALID_SID) {
+    //! plays 3D sound from PCM data. If sid is INVALID_SID, a new SID is generated.
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
     push_cmd(AudioCommand(add_pcm_3d <-
-        AudioCommandAddPCM3D(sid = sid, rate = rate, channels = channels, samples <- samples, loop = false, position = position, attenuation = attenuation)))
-    return sid
+        AudioCommandAddPCM3D(sid = useSid, rate = rate, channels = channels, samples <- samples, loop = false, position = position, attenuation = attenuation)))
+    return useSid
 }
 
-def public play_3d_sound_loop_from_pcm(position : float3; attenuation : Attenuation; rate, channels : int; var samples : array<float>) {
-    //! plays 3D looping sound from PCM data
-    let sid = generate_sound_sid()
+def public play_3d_sound_loop_from_pcm(position : float3; attenuation : Attenuation; rate, channels : int; var samples : array<float>; sid : SID = INVALID_SID) {
+    //! plays 3D looping sound from PCM data. If sid is INVALID_SID, a new SID is generated.
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
     push_cmd(AudioCommand(add_pcm_3d <-
-        AudioCommandAddPCM3D(sid = sid, rate = rate, channels = channels, samples <- samples, loop = true, position = position, attenuation = attenuation)))
-    return sid
+        AudioCommandAddPCM3D(sid = useSid, rate = rate, channels = channels, samples <- samples, loop = true, position = position, attenuation = attenuation)))
+    return useSid
 }
 
 def public append_to_pcm(sid : SID; var samples : array<float>) {
@@ -1151,9 +1190,9 @@ def public append_box_to_pcm(sid : SID; box : LockBox?; var samples : array<floa
     return sid
 }
 
-def public set_pause(sid : SID; paused : bool) {
-    //! pause or unpause sound
-    push_cmd(AudioCommand(pause = (sid = sid, paused = paused)))
+def public set_pause(sid : SID; paused : bool; time : float = 0.002f) {
+    //! pause or unpause sound; ``time`` is the fade duration in seconds (default ~2ms to avoid clicks)
+    push_cmd(AudioCommand(pause = (sid = sid, paused = paused, time = time)))
     return sid
 }
 
@@ -1183,6 +1222,17 @@ def public set_global_pitch(pitch : float) {
 def public set_global_pause(pause : bool) {
     //! set global pause of sounds
     push_cmd(AudioCommand(global_pause = pause))
+}
+
+def public set_global_volume(volume : float) {
+    //! Set global master volume (multiplier for all currently-playing sounds).
+    push_cmd(AudioCommand(global_volume = volume))
+}
+
+def public set_ignore_global_volume(sid : SID; value : bool) {
+    //! Make a specific channel ignore the global master volume (used by editor preview so muting the
+    //! game's master volume does not silence the asset preview).
+    push_cmd(AudioCommand(ignore_global_volume = (sid = sid, value = value)))
 }
 
 def public stop(sid : SID; time : float = 0.0f) {

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -846,7 +846,9 @@ def command_processor {
             }
             g_sid_2_channel |> clear()
             if (g_stats_box != null) {
-                g_stats_box |> notify_and_release
+                // stats box is a read-only long-lived publication target, not a one-shot;
+                // never `notify_and_release` (the caller's `get()` doesn't consume notifications).
+                g_stats_box |> release
                 g_stats_box = null
             }
             g_command_stream |> release
@@ -958,7 +960,7 @@ def command_processor {
         } elif (cmd is system_stats_box) {
             let sbox = cmd as system_stats_box
             if (g_stats_box != null) {
-                g_stats_box |> notify_and_release
+                g_stats_box |> release
                 g_stats_box = null
             }
             g_stats_box = unsafe(reinterpret<LockBox?>(sbox))
@@ -1442,10 +1444,10 @@ def public set_hrtf_budget(n : int) {
 
 def public set_audio_stats_box(var box : LockBox?) {
     //! Register a LockBox to receive periodic AudioSystemStats updates from the audio thread.
-    //! The audio thread writes one snapshot per ~1-second window; the caller can read on demand
-    //! via ``box |> grab() $(var s : AudioSystemStats) { ... }``. Pass null to clear.
+    //! The audio thread writes one snapshot per ~1-second window; the caller reads it on demand
+    //! via ``box |> get() $(var s : AudioSystemStats) { ... }`` (read-only — keeps the box alive
+    //! across multiple reads). Pass null to clear. Do NOT use ``grab()``: that's a one-shot consume.
     box |> add_ref
-    box |> append(1)
     box |> set() <| new AudioSystemStats(utilization_pct = 0.0, hrtf_count = 0, total_3d = 0)
     push_cmd(AudioCommand(system_stats_box = intptr(box)))
 }

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -199,9 +199,10 @@ class AudioChannel {
         if (MA_HRTF) {
             ma_hrtf_init(unsafe(addr(hrtf)), uint(MA_SAMPLE_RATE))
             ma_channel_converter_uninit(unsafe(addr(channel_converter)))
+            // HRTF always emits stereo, so the converter's input is 2ch regardless of source.channels
             var channel_converter_config <- ma_channel_converter_config_init(
                 ma_format.ma_format_f32,
-                uint(source.channels),
+                2u,
                 null,
                 uint(MA_CHANNELS),
                 null,
@@ -1058,8 +1059,9 @@ def make_decoder(filename : string; rate, channels : int) : ma_decoder? {
 // then pushed atomically as one Stream batch.
 var global_batch : array<array<uint8>>?
 
+[deprecated(message="use `batch(cb)` instead")]
 def public begin_batch() {
-    //! Begin batching audio commands. All commands until end_batch are sent atomically.
+    //! Deprecated. Use ``batch() { ... }`` instead.
     if (global_batch != null) {
         panic("nested batch")
     }
@@ -1067,16 +1069,14 @@ def public begin_batch() {
     global_batch = tempBatch
 }
 
+[deprecated(message="use `batch(cb)` instead")]
 def public end_batch() {
-    //! End batching and send all batched commands atomically. No-op if no batch is open.
+    //! Deprecated. Use ``batch() { ... }`` instead.
     if (global_batch == null) {
-        return
+        panic("no batch")
     }
     g_command_stream |> push_batch(*global_batch)
     unsafe {
-        for (it in *global_batch) {
-            delete it
-        }
         delete * global_batch
     }
     global_batch = null
@@ -1132,18 +1132,19 @@ def public play_3d_sound_from_file(filename : string; position : float3; attenua
     return useSid
 }
 
-def public play_sound_from_pcm_stream(rate, channels : int; sid : SID = generate_sound_sid()) {
-    //! Create a PCM streaming channel. Feed it samples with append_to_pcm.
-    push_cmd(AudioCommand(add_pcm_stream <- AudioCommandAddPCMStream(sid = sid, rate = rate, channels = channels)))
-    return sid
+def public play_sound_from_pcm_stream(rate, channels : int; sid : SID = INVALID_SID) {
+    //! Create a PCM streaming channel. Feed it samples with append_to_pcm. If sid is INVALID_SID, a new SID is generated.
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
+    push_cmd(AudioCommand(add_pcm_stream <- AudioCommandAddPCMStream(sid = useSid, rate = rate, channels = channels)))
+    return useSid
 }
 
-def public play_3d_sound_from_pcm_stream(position : float3; attenuation : Attenuation; rate, channels : int) {
-    //! Create a 3D PCM streaming channel. Feed it samples with append_to_pcm.
-    let sid = generate_sound_sid()
+def public play_3d_sound_from_pcm_stream(position : float3; attenuation : Attenuation; rate, channels : int; sid : SID = INVALID_SID) {
+    //! Create a 3D PCM streaming channel. Feed it samples with append_to_pcm. If sid is INVALID_SID, a new SID is generated.
+    let useSid = sid != INVALID_SID ? sid : generate_sound_sid()
     push_cmd(AudioCommand(add_pcm_stream_3d <-
-        AudioCommandAddPCMStream3D(sid = sid, rate = rate, channels = channels, position = position, attenuation = attenuation)))
-    return sid
+        AudioCommandAddPCMStream3D(sid = useSid, rate = rate, channels = channels, position = position, attenuation = attenuation)))
+    return useSid
 }
 
 def public play_sound_from_pcm(rate, channels : int; var samples : array<float>; sid : SID = INVALID_SID) {

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -944,7 +944,8 @@ def command_processor {
             g_volume = cmd as global_volume
             let nFrames = uint64(0.025 * float(MA_SAMPLE_RATE))
             for (it in values(g_sid_2_channel)) {
-                if (!it.stop && !it.ignoreGlobalVolume) {
+                // 3D channels are handled in update_hrtf which reads g_volume each callback
+                if (!it.stop && !it.ignoreGlobalVolume && !it.is3D) {
                     ma_volume_mixer_set_volume_over_time(unsafe(addr(it.volume_mixer)), it.volume * g_volume, nFrames)
                 }
             }
@@ -1043,7 +1044,7 @@ var g_volume : float = 1.  //! global master volume multiplier (1.0 = full, 0.0 
 
 // AudioSystemStats publication state (audio-context-side; main side holds the LockBox handle and read-grabs it).
 var g_stats_box : LockBox? = null
-var g_stats_window_time_us = 0.0lf      // accumulated mixer wall time over the current window
+var g_stats_window_time_ms = 0.0lf      // accumulated mixer wall time over the current window
 var g_stats_window_samples = 0ul        // accumulated audio frames over the current window
 var g_stats_window_count : int = 0      // mixer-callback count over the window; once >=N callbacks we publish + reset
 var g_stats_recent_util_pct : float = 0.0
@@ -1094,14 +1095,14 @@ def mixer(var data : array<float>#; channels, rate : int; dt : float) {
 // utilization (= mixer time / real time) and update the caller's stats LockBox so main thread can read it.
 def private publish_audio_stats(dt_ms : double; frames : uint64) {
     return if (g_stats_box == null)
-    g_stats_window_time_us += dt_ms
+    g_stats_window_time_ms += dt_ms
     g_stats_window_samples += frames
     g_stats_window_count ++
     let realTimeMs = double(g_stats_window_samples) * 1000.lf / double(MA_SAMPLE_RATE)
     if (realTimeMs < 1000.lf) return
-    let util = g_stats_window_time_us / realTimeMs * 100.lf
+    let util = g_stats_window_time_ms / realTimeMs * 100.lf
     g_stats_recent_util_pct = float(util)
-    g_stats_window_time_us = 0.0lf
+    g_stats_window_time_ms = 0.0lf
     g_stats_window_samples = 0ul
     g_stats_window_count = 0
     let snap = g_stats_recent_util_pct

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -1447,6 +1447,10 @@ def public set_audio_stats_box(var box : LockBox?) {
     //! The audio thread writes one snapshot per ~1-second window; the caller reads it on demand
     //! via ``box |> get() $(var s : AudioSystemStats) { ... }`` (read-only — keeps the box alive
     //! across multiple reads). Pass null to clear. Do NOT use ``grab()``: that's a one-shot consume.
+    if (box == null) {
+        push_cmd(AudioCommand(system_stats_box = 0ul))
+        return
+    }
     box |> add_ref
     box |> set() <| new AudioSystemStats(utilization_pct = 0.0, hrtf_count = 0, total_3d = 0)
     push_cmd(AudioCommand(system_stats_box = intptr(box)))

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -299,6 +299,7 @@ bool dasAudio_init ( TFunc<void,TTemporary<TArray<float>>,int32_t,int32_t,float>
         return false;
     }
     g_mixer_context.reset(get_clone_context(&context,uint32_t(ContextCategory::audio_context)));
+    g_mixer_context->verySafeContext = false;
     g_mixer_function = mixer;
     g_mixer_env = daScriptEnvironment::getBound();
     if ( ma_device_start(&g_device) != MA_SUCCESS ) {

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -1,5 +1,7 @@
 options gen2
 options indenting = 4
+options persistent_heap
+options gc
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 
@@ -553,7 +555,7 @@ def midi_tick(var state : MidiPlaybackState; chunk_seconds : float) : array<floa
         state.mixer_ready = true
     }
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     var i = length(state.voices) - 1
     while (i >= 0) {
         var voice = state.voices[i]
@@ -828,9 +830,9 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
     let TARGET_CHUNKS = 4
     let LOW_WATERMARK = 2
     var tracks : array<MidiPlaybackState?>
-    var status_box <- unsafe(lock_box_create())
+    var status_box <- lock_box_create()
     set_status_update(sid, status_box)
-    var pcm_box <- unsafe(lock_box_create())
+    var pcm_box <- lock_box_create()
     // initialize reverb (convolution: 2s decay, 15kHz→1kHz lowpass sweep)
     g_reverb = new ConvolutionReverb
     conv_reverb_init(g_reverb, SAMPLE_RATE, 2.0, 15000.0, 1000.0, 0.01)
@@ -862,7 +864,7 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
                     looping = tc.looping
                 ))
             } elif (cmd is remove_track) {
-                let name = string(cmd as remove_track)
+                let name = cmd as remove_track
                 var k = length(tracks) - 1
                 while (k >= 0) {
                     if (tracks[k].name == name) {
@@ -1024,7 +1026,7 @@ def public midi_init() {
         g_midi_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
     }
     g_midi_cmd_stream = unsafe(stream_create())
-    g_midi_done_status = unsafe(job_status_create())
+    g_midi_done_status = job_status_create()
     g_midi_done_status |> append(1)                   // expect one notification on worker exit
     // @capture auto-bumps refcount for Stream and JobStatus — no manual add_ref needed
     let sid = g_midi_sid

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -1,5 +1,7 @@
 options gen2
 options indenting = 4
+options persistent_heap
+options gc
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 
@@ -355,7 +357,7 @@ def private strudel_process_commands(cmd_fn : function<(cmd : string) : void>) :
         } elif (cmd is set_cps) {
             g_cps = cmd as set_cps
         } elif (cmd is user_cmd) {
-            let ucmd = string(cmd as user_cmd)
+            let ucmd = cmd as user_cmd
             invoke(cmd_fn, ucmd)
         }
     }
@@ -368,10 +370,10 @@ def public strudel_create_channel() {
     //! Create the PCM stream for main-thread playback. Call once after audio_system_create() and before strudel_tick.
     if (g_sid == 0ul) {
         g_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
-        g_tick_status_box = unsafe(lock_box_create())
+        g_tick_status_box = lock_box_create()
         g_tick_status_box |> add_ref()
         set_status_update(g_sid, g_tick_status_box)
-        g_tick_pcm_box = unsafe(lock_box_create())
+        g_tick_pcm_box = lock_box_create()
         // memory tracking baseline
         g_mem_heap_baseline = heap_bytes_allocated()
         g_mem_str_baseline = string_heap_bytes_allocated()
@@ -396,7 +398,7 @@ def public strudel_tick() {
     }
     let t0 = ref_time_ticks()
     let CHUNK_SEC = g_chunk_seconds
-    let chunkSamples = int(float(CHUNK_SEC) * float(SAMPLE_RATE)) * 2
+    let chunkSamples = int(CHUNK_SEC * float(SAMPLE_RATE)) * 2
     // prepare master output
     g_master_pcm |> resize(chunkSamples)
     for (s in g_master_pcm) {
@@ -414,7 +416,7 @@ def public strudel_tick() {
             track.sched.lastQueryEnd = g_wall_time * g_cps
             track.sched.cps = g_cps
         }
-        tick(track.sched, track.pat, g_bank, g_wall_time, float(CHUNK_SEC), g_look_ahead)
+        tick(track.sched, track.pat, g_bank, g_wall_time, CHUNK_SEC, g_look_ahead)
         // mix scheduler output into master with track gain
         if (!empty(track.sched.output) && track.gain > 0.001) {
             // copy to per-track PCM for visualizer access
@@ -435,9 +437,9 @@ def public strudel_tick() {
         // update fade envelope
         if (track.fade_speed > 0.0) {
             if (track.gain < track.target_gain) {
-                track.gain = min(track.gain + track.fade_speed * float(CHUNK_SEC), track.target_gain)
+                track.gain = min(track.gain + track.fade_speed * CHUNK_SEC, track.target_gain)
             } elif (track.gain > track.target_gain) {
-                track.gain = max(track.gain - track.fade_speed * float(CHUNK_SEC), track.target_gain)
+                track.gain = max(track.gain - track.fade_speed * CHUNK_SEC, track.target_gain)
             }
             if (abs(track.gain - track.target_gain) < 0.001) {
                 track.gain = track.target_gain
@@ -455,7 +457,7 @@ def public strudel_tick() {
     if (!empty(g_master_pcm)) {
         append_box_to_pcm(g_sid, g_tick_pcm_box, g_master_pcm)
     }
-    let chunkFrames = int(float(CHUNK_SEC) * float(SAMPLE_RATE))
+    let chunkFrames = int(CHUNK_SEC * float(SAMPLE_RATE))
     g_wall_samples += int64(chunkFrames)
     g_wall_time = double(g_wall_samples) / double(SAMPLE_RATE)
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
@@ -481,7 +483,7 @@ def public strudel_tick_offline() {
     //! Renders into g_master_pcm and advances g_wall_time; call in a tight loop for offline WAV rendering.
     let t0 = ref_time_ticks()
     let CHUNK_SEC = g_chunk_seconds
-    let chunkSamples = int(float(CHUNK_SEC) * float(SAMPLE_RATE)) * 2
+    let chunkSamples = int(CHUNK_SEC * float(SAMPLE_RATE)) * 2
     // prepare master output
     g_master_pcm |> resize(chunkSamples)
     for (s in g_master_pcm) {
@@ -499,7 +501,7 @@ def public strudel_tick_offline() {
             track.sched.lastQueryEnd = g_wall_time * g_cps
             track.sched.cps = g_cps
         }
-        tick(track.sched, track.pat, g_bank, g_wall_time, float(CHUNK_SEC), g_look_ahead)
+        tick(track.sched, track.pat, g_bank, g_wall_time, CHUNK_SEC, g_look_ahead)
         // mix scheduler output into master with track gain
         if (!empty(track.sched.output) && track.gain > 0.001) {
             // copy to per-track PCM for visualizer access
@@ -520,9 +522,9 @@ def public strudel_tick_offline() {
         // update fade envelope
         if (track.fade_speed > 0.0) {
             if (track.gain < track.target_gain) {
-                track.gain = min(track.gain + track.fade_speed * float(CHUNK_SEC), track.target_gain)
+                track.gain = min(track.gain + track.fade_speed * CHUNK_SEC, track.target_gain)
             } elif (track.gain > track.target_gain) {
-                track.gain = max(track.gain - track.fade_speed * float(CHUNK_SEC), track.target_gain)
+                track.gain = max(track.gain - track.fade_speed * CHUNK_SEC, track.target_gain)
             }
             if (abs(track.gain - track.target_gain) < 0.001) {
                 track.gain = track.target_gain
@@ -536,7 +538,7 @@ def public strudel_tick_offline() {
             g_tracks[i] = null
         }
     }
-    let chunkFrames = int(float(CHUNK_SEC) * float(SAMPLE_RATE))
+    let chunkFrames = int(CHUNK_SEC * float(SAMPLE_RATE))
     g_wall_samples += int64(chunkFrames)
     g_wall_time = double(g_wall_samples) / double(SAMPLE_RATE)
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
@@ -568,12 +570,12 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
     var total_time = 0.lf
     var total_samples = 0ul
     var max_chunk_usec = 0.0lf
-    var status_box <- unsafe(lock_box_create())
+    var status_box <- lock_box_create()
     set_status_update(g_sid, status_box)
-    var pcm_box <- unsafe(lock_box_create())
+    var pcm_box <- lock_box_create()
     var mixer : ma_volume_mixer
     ma_volume_mixer_init(unsafe(addr(mixer)), 2u)
-    let chunkSamples = int(float(CHUNK_SEC) * float(SAMPLE_RATE)) * 2
+    let chunkSamples = int(CHUNK_SEC * float(SAMPLE_RATE)) * 2
     var output : array<float>
     output |> resize(chunkSamples)
     // memory tracking
@@ -603,7 +605,7 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
                 track.sched.lastQueryEnd = g_wall_time * g_cps
                 track.sched.cps = g_cps
             }
-            tick(track.sched, track.pat, *g_bank_ptr, g_wall_time, float(CHUNK_SEC), g_look_ahead)
+            tick(track.sched, track.pat, *g_bank_ptr, g_wall_time, CHUNK_SEC, g_look_ahead)
             // mix into output with track gain
             if (!empty(track.sched.output) && track.gain > 0.001) {
                 ma_volume_mixer_set_volume(unsafe(addr(mixer)), track.gain)
@@ -620,9 +622,9 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
             // update fade envelope
             if (track.fade_speed > 0.0) {
                 if (track.gain < track.target_gain) {
-                    track.gain = min(track.gain + track.fade_speed * float(CHUNK_SEC), track.target_gain)
+                    track.gain = min(track.gain + track.fade_speed * CHUNK_SEC, track.target_gain)
                 } elif (track.gain > track.target_gain) {
-                    track.gain = max(track.gain - track.fade_speed * float(CHUNK_SEC), track.target_gain)
+                    track.gain = max(track.gain - track.fade_speed * CHUNK_SEC, track.target_gain)
                 }
                 if (abs(track.gain - track.target_gain) < 0.001) {
                     track.gain = track.target_gain
@@ -721,12 +723,12 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
     g_cmd_fn = cmd_fn
     // create playback time lockbox
     if (g_playback_box == null) {
-        g_playback_box = unsafe(lock_box_create())
+        g_playback_box = lock_box_create()
     }
     // create command stream and done status (thread-exit signal, wait group of 1).
     // @capture auto-bumps refcount for Stream and JobStatus — no manual add_ref needed.
     g_cmd_stream = unsafe(stream_create())
-    g_done_status = unsafe(job_status_create())
+    g_done_status = job_status_create()
     g_done_status |> append(1)
     // create PCM stream on main thread (audio globals are initialized here)
     let thread_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -197,6 +197,7 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_signals.das
         tests/strudel/test_synthesis.das
         tests/strudel/test_vowel.das
+        tests/audio/test_hrtf_budget.das
     )
 ENDIF()
 

--- a/tests/audio/test_hrtf_budget.das
+++ b/tests/audio/test_hrtf_budget.das
@@ -1,0 +1,72 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require audio/audio_boost
+
+// Unit tests for the HRTF/simulated-3D budget classifier. The classifier is the pure rank-vs-budget
+// decision update_hrtf consults each frame to decide whether a channel runs HRTF (expensive, top-N
+// closest) or simulated 3D (constant-power pan + attenuation, cheaper). Sticky margin in rank space
+// prevents flapping when channels swap rank between frames, but must NOT preserve HRTF status when
+// the budget is 0 (otherwise "all simulated" doesn't clear in-flight HRTF channels).
+
+[test]
+def test_full_hrtf_budget_keeps_everything_hrtf(t : T?) {
+    t |> run("budget=999: every rank routed to HRTF regardless of prior state") @(t : T?) {
+        t |> success(hrtf_budget_classify(0, 999, true),  "rank 0, wasHrtf -> HRTF")
+        t |> success(hrtf_budget_classify(0, 999, false), "rank 0, !wasHrtf -> HRTF (flip in)")
+        t |> success(hrtf_budget_classify(31, 999, true), "rank 31, wasHrtf -> HRTF")
+        t |> success(hrtf_budget_classify(998, 999, false), "rank below budget flips in")
+        t |> success(!hrtf_budget_classify(999, 999, false), "rank == budget for !wasHrtf is NOT under-budget")
+    }
+}
+
+[test]
+def test_zero_budget_clears_all_hrtf(t : T?) {
+    t |> run("budget=0: sticky margin must NOT preserve HRTF — all channels go simulated") @(t : T?) {
+        // This is the regression case for the sticky-margin bug: stickyTop is clamped to 0 when budget=0,
+        // so previously-HRTF channels don't get to keep HRTF status.
+        t |> success(!hrtf_budget_classify(0, 0, true), "rank 0, wasHrtf -> SIM (clears in-flight)")
+        t |> success(!hrtf_budget_classify(0, 0, false), "rank 0, !wasHrtf -> SIM")
+        t |> success(!hrtf_budget_classify(5, 0, true), "rank 5, wasHrtf -> SIM")
+        t |> success(!hrtf_budget_classify(99, 0, false), "rank 99, !wasHrtf -> SIM")
+    }
+}
+
+[test]
+def test_mixed_budget_routes_top_n(t : T?) {
+    t |> run("budget=32: top-32 ranks HRTF, rest simulated (no sticky effect for fresh entries)") @(t : T?) {
+        t |> success(hrtf_budget_classify(0, 32, false), "rank 0 below budget -> HRTF (flip in)")
+        t |> success(hrtf_budget_classify(31, 32, false), "rank 31 below budget -> HRTF")
+        t |> success(!hrtf_budget_classify(32, 32, false), "rank 32 == budget for !wasHrtf -> SIM")
+        t |> success(!hrtf_budget_classify(100, 32, false), "rank 100 -> SIM")
+    }
+}
+
+[test]
+def test_sticky_margin_in_rank_space(t : T?) {
+    t |> run("HRTF channels keep HRTF status across the budget+10% margin to avoid rank-swap flapping") @(t : T?) {
+        // For budget=32: stickyTop = 32 + max(2, 32/10) = 32 + 3 = 35
+        t |> success(hrtf_budget_classify(32, 32, true), "rank 32, wasHrtf -> stays HRTF (sticky)")
+        t |> success(hrtf_budget_classify(34, 32, true), "rank 34, wasHrtf -> stays HRTF (sticky)")
+        t |> success(!hrtf_budget_classify(35, 32, true), "rank 35, wasHrtf -> SIM (past stickyTop)")
+        t |> success(!hrtf_budget_classify(36, 32, true), "rank 36, wasHrtf -> SIM")
+        // Note: a channel at rank 33 that was simulated must NOT flip to HRTF — the budget is 32.
+        t |> success(!hrtf_budget_classify(33, 32, false), "rank 33, !wasHrtf -> SIM (budget unchanged)")
+    }
+}
+
+[test]
+def test_sticky_margin_floor_at_small_budgets(t : T?) {
+    t |> run("small budgets enforce a minimum margin of 2 so single-channel swaps don't immediately flip") @(t : T?) {
+        // For budget=10: stickyTop = 10 + max(2, 1) = 10 + 2 = 12
+        t |> success(hrtf_budget_classify(10, 10, true), "rank 10, wasHrtf -> stays HRTF")
+        t |> success(hrtf_budget_classify(11, 10, true), "rank 11, wasHrtf -> stays HRTF")
+        t |> success(!hrtf_budget_classify(12, 10, true), "rank 12 -> SIM (past min-margin top)")
+
+        // For budget=1: stickyTop = 1 + max(2, 0) = 3
+        t |> success(hrtf_budget_classify(0, 1, true), "budget=1: rank 0 stays HRTF")
+        t |> success(hrtf_budget_classify(2, 1, true), "budget=1: rank 2 still sticky")
+        t |> success(!hrtf_budget_classify(3, 1, true), "budget=1: rank 3 falls off")
+    }
+}


### PR DESCRIPTION
Bundles @profelis's #2872 feature work with the review fixes from that thread, plus a new HRTF-budget / simulated-3D mixing path with perceived-loudness parity.

Supersedes #2872.

## New: per-channel HRTF vs simulated-3D mixing

The closest-N (default 32) 3D channels each frame run HRTF convolution; the rest run a cheaper simulated path (constant-power pan + distance attenuation, no convolution). The split is rank-vs-budget with a sticky-margin in rank space to prevent flapping when channel ordering swaps frame-to-frame.

- **`set_hrtf_budget(n : int)`** — runtime audio command. `0` = all simulated, `999`+ = all HRTF, default 32. The closest-to-head channels win the HRTF slots.
- **Pure budget classifier** (`hrtf_budget_classify(rank, budget, wasHrtf)`) — exposed and unit-tested. Sticky margin `budget + max(2, budget/10)` for already-HRTF channels; `budget=0` clamps the margin to 0 so in-flight HRTF channels properly clear.
- **Two-converter design per is3D channel** — `channel_converter` (2 → MA_CHANNELS, HRTF stereo output) and `channel_converter_sim` (source.channels → MA_CHANNELS, doubles as mono→stereo upmix). `mix()` picks at runtime via `is_hrtf`. No hand-written daslang sample loops in the audio path.
- **HRTF frontal-gain calibration** at startup: 1 kHz sine probe (2048 frames), measure RMS of the steady-state region (skip the crossfade ramp), compute `g_hrtf_frontal_gain = hrirGain * sqrt(2)` clamped to [0.25, 4.0]. Simulated channels multiply by this normalizer so perceived loudness matches HRTF mode.
- **Per-channel pan-mode** in `update_hrtf`: HRTF channels get `linear_pan=true` (unity at center, no -3 dB regression); simulated channels get `linear_pan=false` (constant-power for mono→stereo).
- **Cross-context stats publishing**: `AudioSystemStats` (utilization%, HRTF count, total 3D) written from the audio thread to a `LockBox?` registered via `set_audio_stats_box(box)`. Main thread reads on-demand with `box |> get()` (read-only; `grab` would consume the notification and break the periodic poll).

## Example update: `examples/audio/hrtf/main.das`

- **B-key 3-mode cycle**: `mixed top-32` → `all simulated` (budget=0) → `all HRTF` (budget=999) for A/B verification by ear.
- **Per-second stats line**: `audio: util=X%, hrtf=N/M (budget=K)` printed from the `AudioSystemStats` LockBox.
- **`--max-frames N` CLI** for headless repro of shutdown-leak debugging.

## Feature changes (from #2872, @profelis)

- **Global master volume** (`set_global_volume`) with per-channel opt-out (`set_ignore_global_volume`) for editor-preview muting independence.
- **Per-channel pause-fade ramp**: `set_pause(sid, paused, time=0.002f)` configures the click-avoidance fade duration.
- **`setup3D` first-update**: first 3D-channel update sets the volume immediately (no audible ramp-from-1.0); subsequent frames use the existing `set_volume_over_time` ramp.
- **Optional caller-provided SIDs** on all `play_*_from_file` / `play_*_from_pcm` / `play_*_from_pcm_stream` helpers (`sid : SID = INVALID_SID` → caller-passed or lazily generated).
- **`pause` command carries `time`** (wire format extension on `AudioCommand` variant).
- **`options persistent_heap` + `options gc`** on `audio_boost.das` and the strudel/midi player modules — required because the linear allocator on real-time audio threads doesn't return memory.
- **dasAudio.cpp**: `g_mixer_context->verySafeContext = false` (real-time context, no GC overhead).

## Review fixes layered on top

- **#2872 thread**: `set3D` HRTF channel-converter input reverted to `2u` (HRTF always emits stereo regardless of source channel count). `end_batch` restored to `panic("no batch")`; redundant inner `for it; delete it` loop dropped. `begin_batch` / `end_batch` marked `[deprecated]` — `batch() { ... }` is the right API. `play_sound_from_pcm_stream` + `play_3d_sound_from_pcm_stream` unified to the `INVALID_SID` + ternary pattern. Strudel files cleaned of 26 PERF020 (redundant `float()`/`string()` casts) + STYLE024 (redundant `unsafe()` wraps).
- **Copilot R1** (`set_linear_pan(false)` -3 dB regression): the global call in `setup3D` was dropped. Per-channel pan-mode is now driven by the HRTF/simulated routing decision in `update_hrtf`.
- **Copilot R2** (`pause_fade_step` hardcoded `1/96`): now derived from `MA_SAMPLE_RATE` (`1.0 / (0.002 * float(MA_SAMPLE_RATE))`) — ~2 ms ramp regardless of sample rate.
- **Copilot R3** (`set_audio_stats_box(null)` crash): null branch pushes `system_stats_box = 0ul`; the command handler reinterprets that as null and clears `g_stats_box`.

## LockBox lifecycle fix

`release` only decrements the refcount; the actual `delete` requires `lock_box_remove`. The stats-box now lives outside `with_audio_system`: main creates (rc=1), audio thread `add_ref` (rc=2) on `set_audio_stats_box`, audio thread `release` during `audio_system_finalize` (rc=2→1), outer `defer { lock_box_remove }` does the final delete (rc=1→0). Verified clean via `--track-job-status`: no leaked JobStatus, Feature, or smart pointers at exit.

## Tests

`tests/audio/test_hrtf_budget.das` — 10 cases covering full-budget, zero-budget (regression test for the sticky-margin clearing bug), mixed-budget top-N, sticky margin in rank space, and the small-budget min-margin floor.

## Test plan

- [x] `cmake --build build --config Release --target dasModuleAudio` — green locally
- [x] `mcp__daslang__lint` clean across all touched files
- [x] `mcp__daslang__format_file` already-formatted
- [x] Pre-push hook (formatter + lint) green
- [x] `tests/audio/test_hrtf_budget.das` — 10/10 pass
- [x] Example clean-shutdown verified via `--max-frames` + `--track-job-status` (no leaks)
- [x] A/B by ear: B-key cycle through mixed/all-simulated/all-HRTF — perceived loudness matches
- [ ] CI: full matrix
