### PR TITLE
linq_fold: PR C — SourceAdapter + 4 decs planner migrations

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -49,7 +49,8 @@ struct private LinqCall {
 // See daslib/linq_fold.md for masterplan.
 
 variant private SourceAdapter {
-    Array : tuple<Expression?; string>     // (top, srcName) — PR C widens with Decs/DecsFind/Zip/DecsJoin
+    Array : tuple<Expression?; string>                  // (top, srcName) — PR A
+    Decs  : tuple<DecsBridgeShape?; string>             // (bridge, tupName) — PR C
 }
 
 variant SlotMatcher {
@@ -287,8 +288,13 @@ def private match_pattern(p : SplicePattern;
 // Starts minimal; grows with use per masterplan.
 
 def private array_source(var c : Captures; var top : Expression?) : bool {
-    // top is already peel_each'd by the calling stub; verify it carries an array type (indexed iteration safe).
+    // top is already peel_each'd by the calling stub; verify it carries an array type. Naturally false for decs sources (`from_decs_template(...)` is iterator-typed).
     return top != null && top._type != null && (top._type.isGoodArrayType || top._type.isArray)
+}
+
+def private decs_source(var c : Captures; var top : Expression?) : bool {
+    // For rows that should only match decs adapter (PR C). extract_decs_bridge is cheap shape check.
+    return extract_decs_bridge(top) != null
 }
 
 def private take_arg_is_int(var c : Captures; var top : Expression?) : bool {
@@ -1592,6 +1598,92 @@ def private finalize_emission_stmts(top : Expression?; srcName : string; at : Li
     return finalize_invoke(emission, at)
 }
 
+// ===== SourceAdapter helpers (PR C) — used by emit fns to dispatch source-loop + invoke wrap per adapter. =====
+
+// The per-element bind name emit fns peel where/select/key/value lambdas against. Drives build_decs_inner_for_pruned's
+// pattern matching (it scans for `tupName.<field>` access), so the decs side MUST use `decs_tup`.
+def private adapter_bind_name(adapter : SourceAdapter; at : LineInfo) : string {
+    if (adapter is Decs) return qn("decs_tup", at)
+    return qn("it", at)
+}
+
+// Source element type for state-decl construction. Returns a fresh clone so callers can pass it to strip_const_ref / $t() without aliasing.
+// Array: top._type.firstType. Decs: bridge.elementType.
+[macro_function]
+def private adapter_element_type(adapter : SourceAdapter) : TypeDeclPtr {
+    if (adapter is Decs) {
+        let bridge = (adapter as Decs)._0
+        if (bridge == null) return null
+        return clone_type(bridge.elementType)
+    }
+    let top = (adapter as Array)._0
+    if (top == null || top._type == null) return null
+    return clone_type(top._type.firstType)
+}
+
+// Per-element source loop. Array: `for(bindName in srcName) { body }`. Decs: `for_each_archetype(...) { build_decs_inner_for_pruned(bridge, tupName, body) }`.
+[macro_function]
+def private adapter_wrap_source_loop(adapter : SourceAdapter; var body : Expression?; at : LineInfo) : Expression? {
+    if (adapter is Decs) {
+        let bridge = (adapter as Decs)._0
+        let tupName = (adapter as Decs)._1
+        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, body, at)
+        let archName = bridge.archName
+        return <- qmacro_expr() {
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $e(forExprNode)
+            })
+        }
+    }
+    let srcName = (adapter as Array)._1
+    let bindName = adapter_bind_name(adapter, at)
+    return <- qmacro_block() {
+        for ($i(bindName) in $i(srcName)) {
+            $e(body)
+        }
+    }
+}
+
+// Wrap stmts into the adapter's outer invoke. Array binds top as source-arg; Decs is zero-arg invoke (state hoisted into stmts).
+// retType non-null forces explicit annotation; null relies on compiler inference from return statements.
+// wrapIter wraps the emission with .to_sequence_move() — caller drives via ctx.expr_is_iterator on array-returning emits.
+[macro_function]
+def private adapter_wrap_invoke(adapter : SourceAdapter; var stmts : array<Expression?>; retType : TypeDeclPtr; wrapIter : bool; at : LineInfo) : Expression? {
+    var emission : Expression?
+    if (adapter is Decs) {
+        if (retType != null) {
+            emission = qmacro(invoke($() : $t(retType) {
+                $b(stmts)
+            }))
+        } else {
+            emission = qmacro(invoke($() {
+                $b(stmts)
+            }))
+        }
+        return finalize_decs_emission(emission, at, wrapIter)
+    }
+    let top = (adapter as Array)._0
+    let srcName = (adapter as Array)._1
+    var srcParamType = invoke_src_param_type(top)
+    var topExpr = clone_expression(top)
+    topExpr.genFlags.alwaysSafe = true
+    if (retType != null) {
+        emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : $t(retType) {
+            $b(stmts)
+        }, $e(topExpr)))
+    } else {
+        emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
+            $b(stmts)
+        }, $e(topExpr)))
+    }
+    emission = finalize_invoke(emission, at)
+    if (wrapIter) {
+        emission = qmacro($e(emission).to_sequence_move())
+        emission.force_generated(true)
+    }
+    return emission
+}
+
 [macro_function]
 def private finalize_decs_emission(var emission : Expression?; at : LineInfo; wrapToIter : bool) : Expression? {
     emission.force_at(at)
@@ -1853,28 +1945,23 @@ def private extract_order_captures(var c : Captures; at : LineInfo; itName : str
 // emit_streaming_min — first[_or_default] with inline-cmp key. Per-walk single-best state, no buffer.
 [macro_function]
 def private emit_streaming_min(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    let itName = qn("it", at)
-    var oc <- extract_order_captures(c, at, itName)
+    let bindName = adapter_bind_name(ctx.src, at)
+    var oc <- extract_order_captures(c, at, bindName)
     // Distinct without take but with first bails — streaming-min has no dset hook (mirrors imperative final bail).
     if (!oc.ok || oc.firstName == "" || oc.distinctName != "") return null
     var inlineCmp = oc.hasKey ? try_make_inline_cmp(oc.orderKey, oc.orderName, oc.orderElemType, at) : null
     if (inlineCmp == null) return null
     let bestName = qn("order_best", at)
     let seenName = qn("order_seen", at)
-    let srcName = (ctx.src as Array)._1
-    var top = ctx.top
-    var srcParamType = invoke_src_param_type(top)
-    var topExpr = clone_expression(top)
-    topExpr.genFlags.alwaysSafe = true
     var elemType = clone_type(oc.orderElemType)
     var lessTest = make_inline_less_call(oc.orderKey, oc.orderName,
-        qmacro($i(itName)), qmacro($i(bestName)), at)
+        qmacro($i(bindName)), qmacro($i(bestName)), at)
     var perElement : Expression? = qmacro_expr() {
         if (!$i(seenName)) {
-            $i(bestName) := $i(itName)
+            $i(bestName) := $i(bindName)
             $i(seenName) = true
         } elif ($e(lessTest)) {
-            $i(bestName) := $i(itName)
+            $i(bestName) := $i(bindName)
         }
     }
     if (oc.whereCond != null) {
@@ -1885,7 +1972,7 @@ def private emit_streaming_min(var c : Captures; var ctx : EmitCtx; at : LineInf
         }
     }
     let outElemType = (oc.selectLam != null) ? oc.selectElemType : elemType
-    var emission : Expression?
+    var stmts : array<Expression?>
     if (oc.firstName == "first") {
         var firstRetExpr : Expression?
         if (oc.selectLam != null) {
@@ -1893,15 +1980,15 @@ def private emit_streaming_min(var c : Captures; var ctx : EmitCtx; at : LineInf
         } else {
             firstRetExpr = qmacro($i(bestName))
         }
-        emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : $t(outElemType) {
+        stmts |> push_from <| qmacro_block_to_array() {
             var $i(bestName) = default<$t(elemType)>
             var $i(seenName) = false
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
+        }
+        stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
+        stmts |> push_from <| qmacro_block_to_array() {
             panic("sequence contains no elements") if (!$i(seenName))
             return $e(firstRetExpr)
-        }, $e(topExpr)))
+        }
     } else {
         let dBindName = qn("order_d", at)
         var bestRetExpr : Expression?
@@ -1913,47 +2000,42 @@ def private emit_streaming_min(var c : Captures; var ctx : EmitCtx; at : LineInf
             bestRetExpr = qmacro($i(bestName))
             dRetExpr = qmacro($i(dBindName))
         }
-        emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : $t(outElemType) {
+        stmts |> push_from <| qmacro_block_to_array() {
             let $i(dBindName) = $e(oc.firstDefaultExpr)
             var $i(bestName) = default<$t(elemType)>
             var $i(seenName) = false
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
+        }
+        stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
+        stmts |> push_from <| qmacro_block_to_array() {
             return $e(bestRetExpr) if ($i(seenName))
             return $e(dRetExpr)
-        }, $e(topExpr)))
+        }
     }
-    return finalize_invoke(emission, at)
+    return adapter_wrap_invoke(ctx.src, stmts, outElemType, false, at)
 }
 
 // emit_bounded_heap — take(N) with inline-cmp key. Heap of size N during walk; distinct gate variant + terminal _select.
 [macro_function]
 def private emit_bounded_heap(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    let itName = qn("it", at)
-    var oc <- extract_order_captures(c, at, itName)
+    let bindName = adapter_bind_name(ctx.src, at)
+    var oc <- extract_order_captures(c, at, bindName)
     if (!oc.ok || oc.takeExpr == null || oc.firstName != "") return null
     var inlineCmp = oc.hasKey ? try_make_inline_cmp(oc.orderKey, oc.orderName, oc.orderElemType, at) : null
     if (inlineCmp == null) return null
     let takeNName = qn("order_take_n", at)
     let bhBufName = qn("order_buf", at)
-    let srcName = (ctx.src as Array)._1
     let dsetName = qn("order_dset", at)
     let dkeyName = qn("order_dkey", at)
-    var top = ctx.top
-    var srcParamType = invoke_src_param_type(top)
-    var topExpr = clone_expression(top)
-    topExpr.genFlags.alwaysSafe = true
     var bufElemType = clone_type(oc.orderElemType)
     var lessTest = make_inline_less_call(oc.orderKey, oc.orderName,
-        qmacro($i(itName)), qmacro($i(bhBufName)[0]), at)
+        qmacro($i(bindName)), qmacro($i(bhBufName)[0]), at)
     var perElement : Expression? = qmacro_expr() {
         if (length($i(bhBufName)) < $i(takeNName)) {
-            $i(bhBufName) |> push_clone($i(itName))
+            $i(bhBufName) |> push_clone($i(bindName))
             _::spliced_push_heap($i(bhBufName), $e(inlineCmp))
         } elif ($e(lessTest)) {
             _::spliced_pop_heap($i(bhBufName), $e(inlineCmp))
-            $i(bhBufName)[length($i(bhBufName)) - 1] := $i(itName)
+            $i(bhBufName)[length($i(bhBufName)) - 1] := $i(bindName)
             _::spliced_push_heap($i(bhBufName), $e(inlineCmp))
         }
     }
@@ -1961,10 +2043,10 @@ def private emit_bounded_heap(var c : Captures; var ctx : EmitCtx; at : LineInfo
     if (oc.distinctName != "") {
         var dkeyExpr : Expression?
         if (oc.distinctName == "distinct_by") {
-            dkeyExpr = peel_lambda_rename_var(oc.distinctKey, itName)
+            dkeyExpr = peel_lambda_rename_var(oc.distinctKey, bindName)
             if (dkeyExpr == null) return null
         } else {
-            dkeyExpr = qmacro($i(itName))
+            dkeyExpr = qmacro($i(bindName))
         }
         perElement = qmacro_block() {
             let $i(dkeyName) = _::unique_key($e(dkeyExpr))
@@ -1981,85 +2063,53 @@ def private emit_bounded_heap(var c : Captures; var ctx : EmitCtx; at : LineInfo
             }
         }
     }
-    var dsetDecl : Expression?
+    var stmts : array<Expression?>
+    stmts |> push_from <| qmacro_block_to_array() {
+        let $i(takeNName) = $e(oc.takeExpr)
+        var $i(bhBufName) : array<$t(bufElemType)>
+    }
     if (oc.distinctName != "") {
         if (oc.distinctName == "distinct_by") {
-            dsetDecl = qmacro_expr() {
+            stmts |> push <| qmacro_expr() {
                 var inscope $i(dsetName) : table<typedecl(_::unique_key(invoke($e(oc.distinctKey), default<$t(bufElemType)>)))>
             }
         } else {
-            dsetDecl = qmacro_expr() {
+            stmts |> push <| qmacro_expr() {
                 var inscope $i(dsetName) : table<typedecl(_::unique_key(default<$t(bufElemType)>))>
             }
         }
     }
-    var emission : Expression?
+    var retType : TypeDeclPtr
     if (oc.selectLam != null) {
         let outBufName = qn("order_proj_buf", at)
         let elemName = qn("order_proj_e", at)
         var projBody = peel_lambda_replace_var(oc.selectLam, qmacro($i(elemName)))
-        if (oc.distinctName != "") {
-            emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : array<$t(oc.selectElemType)> {
-                let $i(takeNName) = $e(oc.takeExpr)
-                var $i(bhBufName) : array<$t(bufElemType)>
-                var $i(outBufName) : array<$t(oc.selectElemType)>
-                $e(dsetDecl)
-                return <- $i(outBufName) if ($i(takeNName) <= 0)
-                for ($i(itName) in $i(srcName)) {
-                    $e(perElement)
-                }
-                _::order_inplace($i(bhBufName), $e(inlineCmp))
-                $i(outBufName) |> reserve(length($i(bhBufName)))
-                for ($i(elemName) in $i(bhBufName)) {
-                    $i(outBufName) |> push_clone($e(projBody))
-                }
-                return <- $i(outBufName)
-            }, $e(topExpr)))
-        } else {
-            emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : array<$t(oc.selectElemType)> {
-                let $i(takeNName) = $e(oc.takeExpr)
-                var $i(bhBufName) : array<$t(bufElemType)>
-                var $i(outBufName) : array<$t(oc.selectElemType)>
-                return <- $i(outBufName) if ($i(takeNName) <= 0)
-                for ($i(itName) in $i(srcName)) {
-                    $e(perElement)
-                }
-                _::order_inplace($i(bhBufName), $e(inlineCmp))
-                $i(outBufName) |> reserve(length($i(bhBufName)))
-                for ($i(elemName) in $i(bhBufName)) {
-                    $i(outBufName) |> push_clone($e(projBody))
-                }
-                return <- $i(outBufName)
-            }, $e(topExpr)))
+        stmts |> push_from <| qmacro_block_to_array() {
+            var $i(outBufName) : array<$t(oc.selectElemType)>
+            return <- $i(outBufName) if ($i(takeNName) <= 0)
         }
-    } elif (oc.distinctName != "") {
-        emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : array<$t(bufElemType)> {
-            let $i(takeNName) = $e(oc.takeExpr)
-            var $i(bhBufName) : array<$t(bufElemType)>
-            $e(dsetDecl)
-            return <- $i(bhBufName) if ($i(takeNName) <= 0)
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
+        stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
+        stmts |> push_from <| qmacro_block_to_array() {
             _::order_inplace($i(bhBufName), $e(inlineCmp))
-            return <- $i(bhBufName)
-        }, $e(topExpr)))
+            $i(outBufName) |> reserve(length($i(bhBufName)))
+            for ($i(elemName) in $i(bhBufName)) {
+                $i(outBufName) |> push_clone($e(projBody))
+            }
+            return <- $i(outBufName)
+        }
+        retType = clone_type(oc.selectElemType)
     } else {
-        emission = qmacro(invoke($($i(srcName) : $t(srcParamType)) : array<$t(bufElemType)> {
-            let $i(takeNName) = $e(oc.takeExpr)
-            var $i(bhBufName) : array<$t(bufElemType)>
+        stmts |> push_from <| qmacro_block_to_array() {
             return <- $i(bhBufName) if ($i(takeNName) <= 0)
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
+        }
+        stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
+        stmts |> push_from <| qmacro_block_to_array() {
             _::order_inplace($i(bhBufName), $e(inlineCmp))
             return <- $i(bhBufName)
-        }, $e(topExpr)))
+        }
+        retType = clone_type(bufElemType)
     }
-    if (ctx.expr_is_iterator) {
-        emission = qmacro($e(emission).to_sequence_move())
-    }
-    return finalize_invoke(emission, at)
+    return adapter_wrap_invoke(ctx.src, stmts, null, ctx.expr_is_iterator, at)
 }
 
 // emit_buffer_helper_dispatch — no where, no distinct. Direct call to daslib helpers (order / top_n* / min_max).
@@ -2146,37 +2196,31 @@ def private emit_buffer_helper_dispatch(var c : Captures; var ctx : EmitCtx; at 
 // emit_fused_prefilter — where+order or distinct+order. Single fused loop: filter (and dset gate) into fresh buf, then sort/min/top_n on buf.
 [macro_function]
 def private emit_fused_prefilter(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    let itName = qn("it", at)
-    var oc <- extract_order_captures(c, at, itName)
+    let bindName = adapter_bind_name(ctx.src, at)
+    var oc <- extract_order_captures(c, at, bindName)
     // Fused-prefilter requires where OR distinct upstream (buffer_helper covers the bare case); distinct+first without take bails (no per-element min-state).
     if (!oc.ok
             || (oc.whereCond == null && oc.distinctName == "")
             || (oc.distinctName != "" && oc.takeExpr == null && oc.firstName != "")) return null
-    let srcName = (ctx.src as Array)._1
     let bufName = qn("buf", at)
     let dsetName = qn("order_dset", at)
     let dkeyName = qn("order_dkey", at)
-    var top = ctx.top
-    var srcParamType = invoke_src_param_type(top)
-    var topExpr = clone_expression(top)
-    topExpr.genFlags.alwaysSafe = true
     var bufElemType = clone_type(oc.orderElemType)
     var inlineCmp = oc.hasKey ? try_make_inline_cmp(oc.orderKey, oc.orderName, oc.orderElemType, at) : null
     let topNName = order_top_n_call_name(oc.orderName)
     let inplaceName = "{oc.orderName}_inplace"
     let minMaxName = order_min_call_name(oc.orderName, oc.hasKey)
-    let needIterWrap = ctx.expr_is_iterator
     var pushStmt : Expression? = qmacro_expr() {
-        $i(bufName) |> push_clone($i(itName))
+        $i(bufName) |> push_clone($i(bindName))
     }
     // Theme 8 (audit 3b): distinct gate per-element push by set-insert on key. Single source pass, no full distinct materialization.
     if (oc.distinctName != "") {
         var dkeyExpr : Expression?
         if (oc.distinctName == "distinct_by") {
-            dkeyExpr = peel_lambda_rename_var(oc.distinctKey, itName)
+            dkeyExpr = peel_lambda_rename_var(oc.distinctKey, bindName)
             if (dkeyExpr == null) return null
         } else {
-            dkeyExpr = qmacro($i(itName))
+            dkeyExpr = qmacro($i(bindName))
         }
         pushStmt = qmacro_block() {
             let $i(dkeyName) = _::unique_key($e(dkeyExpr))
@@ -2211,16 +2255,17 @@ def private emit_fused_prefilter(var c : Captures; var ctx : EmitCtx; at : LineI
             }
         }
     }
-    if (type_has_length(top._type) && oc.distinctName == "") {
-        stmts |> push <| qmacro_expr() {
-            $i(bufName) |> reserve(length($i(srcName)))
+    // Reserve hint: array source with no distinct gate has known length. Decs has no random-access length — skip.
+    if (ctx.src is Array && oc.distinctName == "") {
+        let top = (ctx.src as Array)._0
+        let srcName = (ctx.src as Array)._1
+        if (top != null && top._type != null && type_has_length(top._type)) {
+            stmts |> push <| qmacro_expr() {
+                $i(bufName) |> reserve(length($i(srcName)))
+            }
         }
     }
-    stmts |> push <| qmacro_expr() {
-        for ($i(itName) in $i(srcName)) {
-            $e(loopBody)
-        }
-    }
+    stmts |> push <| adapter_wrap_source_loop(ctx.src, loopBody, at)
     let elemName = qn("order_proj_e", at)
     let outBufName = qn("order_proj_buf", at)
     var projBody : Expression?
@@ -2319,17 +2364,7 @@ def private emit_fused_prefilter(var c : Captures; var ctx : EmitCtx; at : LineI
             }
         }
     }
-    var bodyBlock = new ExprBlock(at = at)
-    for (s in stmts) {
-        bodyBlock.list |> emplace(s)
-    }
-    var emission : Expression? = qmacro(invoke($($i(srcName) : $t(srcParamType)) {
-        $e(bodyBlock);
-    }, $e(topExpr)))
-    if (needIterWrap) {
-        emission = qmacro($e(emission).to_sequence_move())
-    }
-    return finalize_invoke(emission, at)
+    return adapter_wrap_invoke(ctx.src, stmts, null, ctx.expr_is_iterator, at)
 }
 
 // ===== plan_loop_or_count migration (PR B) =====
@@ -2581,17 +2616,15 @@ def private populate_plan_loop_or_count_patterns {
 // Ra — counter (reverse is identity for count). Side-effecting projection still fires per match.
 [macro_function]
 def private emit_reverse_counter(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    var top = ctx.top
-    let srcName = (ctx.src as Array)._1
-    let itName = qn("it", at)
+    let bindName = adapter_bind_name(ctx.src, at)
     let cntName = qn("cnt", at)
     var whereCond : Expression?
     if (c.single |> key_exists("where")) {
-        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], itName)
+        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], bindName)
     }
     var projection : Expression?
     if (c.single |> key_exists("proj")) {
-        projection = peel_lambda_rename_var(c.single["proj"].arguments[1], itName)
+        projection = peel_lambda_rename_var(c.single["proj"].arguments[1], bindName)
     }
     var perElement : Expression?
     if (projection != null && has_sideeffects(projection)) {
@@ -2606,56 +2639,60 @@ def private emit_reverse_counter(var c : Captures; var ctx : EmitCtx; at : LineI
         }
     }
     perElement = wrap_with_condition(perElement, whereCond)
-    var body : Expression? = qmacro_block() {
+    var stmts <- qmacro_block_to_array() {
         var $i(cntName) = 0
-        for ($i(itName) in $i(srcName)) {
-            $e(perElement)
-        }
+    }
+    stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
+    stmts |> push_from <| qmacro_block_to_array() {
         return $i(cntName)
     }
-    var bodyStmts : array<Expression?>
-    bodyStmts |> push_block_list(body)
-    return finalize_emission_stmts(top, srcName, at, bodyStmts)
+    return adapter_wrap_invoke(ctx.src, stmts, null, false, at)
 }
 
 // Rb — walk + overwrite-last scalar (terminator: first / first_or_default).
 // "first of reversed" = LAST surviving element; walk source, overwrite `last` on each match. No buffer.
 [macro_function]
 def private emit_reverse_walk_overwrite_scalar(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    var top = ctx.top
-    let srcName = (ctx.src as Array)._1
-    let itName = qn("it", at)
+    let bindName = adapter_bind_name(ctx.src, at)
     let foundName = qn("found", at)
     let lastName = qn("last", at)
     let dBindName = qn("d", at)
     var whereCond : Expression?
     if (c.single |> key_exists("where")) {
-        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], itName)
+        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], bindName)
     }
     var projection : Expression?
     if (c.single |> key_exists("proj")) {
-        projection = peel_lambda_rename_var(c.single["proj"].arguments[1], itName)
+        projection = peel_lambda_rename_var(c.single["proj"].arguments[1], bindName)
     }
     var terminalSelectLam : Expression?
+    var terminalSelectElemType : TypeDeclPtr
     if (c.single |> key_exists("termsel")) {
         terminalSelectLam = c.single["termsel"].arguments[1]
+        if (terminalSelectLam == null || c.single["termsel"]._type == null || c.single["termsel"]._type.firstType == null) return null
+        terminalSelectElemType = clone_type(c.single["termsel"]._type.firstType)
     }
     if (!(c.single |> key_exists("term"))) return null
     let terminatorCall = c.single["term"]
     let terminatorName = call_norm_name(terminatorCall)
-    // Bail to cascade if upstream typing is incomplete — `lastType` reads `projection._type` / `top._type.firstType`, either can be null on partially-typed exprs.
+    // Bail to cascade if upstream typing is incomplete — `lastType` reads `projection._type` / source element type, either can be null on partially-typed exprs.
+    var lastType : TypeDeclPtr
     if (projection != null) {
         if (projection._type == null) return null
+        lastType = strip_const_ref(clone_type(projection._type))
     } else {
-        if (top._type == null || top._type.firstType == null) return null
+        var srcElemType = adapter_element_type(ctx.src)
+        if (srcElemType == null) return null
+        lastType = strip_const_ref(srcElemType)
     }
-    var lastType = strip_const_ref(clone_type(projection != null ? projection._type : top._type.firstType))
+    // outElemType drives the invoke retType; terminal _select projects the survivor at return so the lane returns post-select shape.
+    let outElemType = (terminalSelectLam != null) ? terminalSelectElemType : lastType
     var valueExpr : Expression?
     if (projection != null) {
         valueExpr = clone_expression(projection)
     } else {
         valueExpr = qmacro_expr() {
-            $i(itName)
+            $i(bindName)
         }
     }
     var matchBlock : Expression? = qmacro_block() {
@@ -2671,33 +2708,30 @@ def private emit_reverse_walk_overwrite_scalar(var c : Captures; var ctx : EmitC
     }
     // first_or_default's user default is already at post-termsel type — re-projecting through `termsel` double-applies.
     var dRetExpr : Expression? = qmacro($i(dBindName))
-    var body : Expression?
+    var stmts : array<Expression?>
+    if (terminatorName == "first_or_default") {
+        stmts |> push_from <| qmacro_block_to_array() {
+            let $i(dBindName) = $e(terminatorCall.arguments[1])
+        }
+    }
+    stmts |> push_from <| qmacro_block_to_array() {
+        var $i(foundName) = false
+        var $i(lastName) : $t(lastType) = default<$t(lastType)>
+    }
+    stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
     if (terminatorName == "first") {
-        body = qmacro_block() {
-            var $i(foundName) = false
-            var $i(lastName) : $t(lastType) = default<$t(lastType)>
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
+        stmts |> push_from <| qmacro_block_to_array() {
             if (!$i(foundName)) {
                 panic("sequence contains no elements")
             }
             return $e(lastRetExpr)
         }
     } else {
-        body = qmacro_block() {
-            let $i(dBindName) = $e(terminatorCall.arguments[1])
-            var $i(foundName) = false
-            var $i(lastName) : $t(lastType) = default<$t(lastType)>
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
+        stmts |> push_from <| qmacro_block_to_array() {
             return $i(foundName) ? $e(lastRetExpr) : $e(dRetExpr)
         }
     }
-    var bodyStmts : array<Expression?>
-    bodyStmts |> push_block_list(body)
-    return finalize_emission_stmts(top, srcName, at, bodyStmts)
+    return adapter_wrap_invoke(ctx.src, stmts, outElemType, false, at)
 }
 
 // R6 — backward index walk (bare reverse + take(N) + implicit to_array on array source).
@@ -2793,19 +2827,17 @@ def private emit_reverse_backward_walk_dset_gate(var c : Captures; var ctx : Emi
 // R1-R4 — catch-all buffer + reverse_inplace + optional resize + optional terminal _select.
 [macro_function]
 def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    var top = ctx.top
-    let srcName = (ctx.src as Array)._1
-    let itName = qn("it", at)
+    let bindName = adapter_bind_name(ctx.src, at)
     let bufName = qn("buf", at)
     let outBufName = qn("rev_proj_buf", at)
     let elemName = qn("rev_proj_e", at)
     var whereCond : Expression?
     if (c.single |> key_exists("where")) {
-        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], itName)
+        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], bindName)
     }
     var projection : Expression?
     if (c.single |> key_exists("preproj")) {
-        projection = peel_lambda_rename_var(c.single["preproj"].arguments[1], itName)
+        projection = peel_lambda_rename_var(c.single["preproj"].arguments[1], bindName)
     }
     var takeExpr : Expression?
     if (c.single |> key_exists("take")) {
@@ -2818,13 +2850,15 @@ def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at 
         if (terminalSelectLam == null || c.single["termsel"]._type == null || c.single["termsel"]._type.firstType == null) return null
         terminalSelectElemType = clone_type(c.single["termsel"]._type.firstType)
     }
-    if (top._type == null || top._type.firstType == null) return null
     // Buffer element type: post-select if a pre-reverse projection narrowed the element shape; otherwise source type.
     var bufElemType : TypeDeclPtr
     if (projection != null) {
+        if (projection._type == null) return null
         bufElemType = strip_const_ref(clone_type(projection._type))
     } else {
-        bufElemType = strip_const_ref(clone_type(top._type.firstType))
+        var srcElemType = adapter_element_type(ctx.src)
+        if (srcElemType == null) return null
+        bufElemType = strip_const_ref(srcElemType)
     }
     var projBody : Expression?
     if (terminalSelectLam != null) {
@@ -2837,14 +2871,19 @@ def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at 
         }
     } else {
         pushExpr = qmacro_expr() {
-            $i(bufName) |> push_clone($i(itName))
+            $i(bufName) |> push_clone($i(bindName))
         }
     }
     pushExpr = wrap_with_condition(pushExpr, whereCond)
+    // Reserve hint: array source with no prefilter has known length. Decs has no random-access length — skip.
     var reserveStmts : array<Expression?>
-    if (type_has_length(top._type) && whereCond == null) {
-        reserveStmts |> push <| qmacro_expr() {
-            $i(bufName) |> reserve(length($i(srcName)))
+    if (ctx.src is Array && whereCond == null) {
+        let top = (ctx.src as Array)._0
+        let srcName = (ctx.src as Array)._1
+        if (top != null && top._type != null && type_has_length(top._type)) {
+            reserveStmts |> push <| qmacro_expr() {
+                $i(bufName) |> reserve(length($i(srcName)))
+            }
         }
     }
     var resizeStmts : array<Expression?>
@@ -2856,40 +2895,31 @@ def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at 
             $i(bufName) |> resize($i(takeLimName) <= 0 ? 0 : ($i(takeLimName) < length($i(bufName)) ? $i(takeLimName) : length($i(bufName))))
         }
     }
-    var body : Expression?
+    var stmts : array<Expression?>
+    stmts |> push_from <| qmacro_block_to_array() {
+        var $i(bufName) : array<$t(bufElemType)>
+    }
+    stmts |> push_from(reserveStmts)
+    stmts |> push <| adapter_wrap_source_loop(ctx.src, pushExpr, at)
+    stmts |> push_from <| qmacro_block_to_array() {
+        _::reverse_inplace($i(bufName))
+    }
+    stmts |> push_from(resizeStmts)
     if (terminalSelectLam != null) {
-        var returnExpr = buffer_return(outBufName, ctx.expr_is_iterator)
-        body = qmacro_block() {
-            var $i(bufName) : array<$t(bufElemType)>
-            $b(reserveStmts)
-            for ($i(itName) in $i(srcName)) {
-                $e(pushExpr)
-            }
-            _::reverse_inplace($i(bufName))
-            $b(resizeStmts)
+        stmts |> push_from <| qmacro_block_to_array() {
             var $i(outBufName) : array<$t(terminalSelectElemType)>
             $i(outBufName) |> reserve(length($i(bufName)))
             for ($i(elemName) in $i(bufName)) {
                 $i(outBufName) |> push_clone($e(projBody))
             }
-            $e(returnExpr)
+            return <- $i(outBufName)
         }
     } else {
-        var returnExpr = buffer_return(bufName, ctx.expr_is_iterator)
-        body = qmacro_block() {
-            var $i(bufName) : array<$t(bufElemType)>
-            $b(reserveStmts)
-            for ($i(itName) in $i(srcName)) {
-                $e(pushExpr)
-            }
-            _::reverse_inplace($i(bufName))
-            $b(resizeStmts)
-            $e(returnExpr)
+        stmts |> push_from <| qmacro_block_to_array() {
+            return <- $i(bufName)
         }
     }
-    var bodyStmts : array<Expression?>
-    bodyStmts |> push_block_list(body)
-    return finalize_emission_stmts(top, srcName, at, bodyStmts)
+    return adapter_wrap_invoke(ctx.src, stmts, null, ctx.expr_is_iterator, at)
 }
 
 // Stub — table-driven dispatch into plan_reverse_patterns. Populated by populate_plan_reverse_patterns [_macro].
@@ -2988,9 +3018,7 @@ def private populate_plan_reverse_patterns {
 // take(N) bounds outer loop with cross-iteration break for true O(N)-source streaming exit.
 [macro_function]
 def private emit_hashtable_dedup(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
-    var top = ctx.top
-    let srcName = (ctx.src as Array)._1
-    let itName = qn("it", at)
+    let bindName = adapter_bind_name(ctx.src, at)
     let bufName = qn("buf", at)
     let seenName = qn("seen", at)
     let keyName = qn("k", at)
@@ -3000,11 +3028,11 @@ def private emit_hashtable_dedup(var c : Captures; var ctx : EmitCtx; at : LineI
     let pvName = qn("pv", at)
     var whereCond : Expression?
     if (c.single |> key_exists("where")) {
-        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], itName)
+        whereCond = peel_lambda_rename_var(c.single["where"].arguments[1], bindName)
     }
     var projection : Expression?
     if (c.single |> key_exists("proj")) {
-        projection = peel_lambda_rename_var(c.single["proj"].arguments[1], itName)
+        projection = peel_lambda_rename_var(c.single["proj"].arguments[1], bindName)
     }
     if (!(c.single |> key_exists("dist"))) return null
     let distinctCall = c.single["dist"]
@@ -3035,8 +3063,16 @@ def private emit_hashtable_dedup(var c : Captures; var ctx : EmitCtx; at : LineI
             return null
         }
     }
-    if ((takeExpr != null && terminatorName != "") || top._type == null || top._type.firstType == null) return null
-    var elemType = strip_const_ref(clone_type(projection != null ? projection._type : top._type.firstType))
+    if (takeExpr != null && terminatorName != "") return null
+    var elemType : TypeDeclPtr
+    if (projection != null) {
+        if (projection._type == null) return null
+        elemType = strip_const_ref(clone_type(projection._type))
+    } else {
+        var srcElemType = adapter_element_type(ctx.src)
+        if (srcElemType == null) return null
+        elemType = strip_const_ref(srcElemType)
+    }
     var stmts : array<Expression?>
     if (isDistinctBy) {
         stmts |> push <| qmacro_expr() {
@@ -3085,7 +3121,7 @@ def private emit_hashtable_dedup(var c : Captures; var ctx : EmitCtx; at : LineI
         }
     } else {
         pushExpr = qmacro_expr() {
-            $i(itName)
+            $i(bindName)
         }
     }
     var keyExpr : Expression?
@@ -3142,20 +3178,35 @@ def private emit_hashtable_dedup(var c : Captures; var ctx : EmitCtx; at : LineI
     var perElement = stmts_to_expr(perMatchStmts)
     perElement = wrap_with_condition(perElement, whereCond)
     if (takeExpr != null) {
-        stmts |> push <| qmacro_expr() {
-            for ($i(itName) in $i(srcName)) {
-                if ($i(takenName) >= $i(takeLimName)) {
-                    break
-                }
+        // take(N) early-exit shape diverges by adapter — Array uses break in for-loop; Decs uses for_each_archetype_find returning bool to stop the archetype walk (mirrors plan_decs_distinct imperative).
+        if (ctx.src is Decs) {
+            let bridge = (ctx.src as Decs)._0
+            let tupName = (ctx.src as Decs)._1
+            let archName = bridge.archName
+            var innerBody : Expression? = qmacro_block() {
+                break if ($i(takenName) >= $i(takeLimName))
                 $e(perElement)
+            }
+            var prunedFor = build_decs_inner_for_pruned(bridge, tupName, innerBody, at)
+            stmts |> push <| qmacro_expr() {
+                for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+                    $e(prunedFor)
+                    return $i(takenName) >= $i(takeLimName)
+                })
+            }
+        } else {
+            let srcName = (ctx.src as Array)._1
+            stmts |> push <| qmacro_expr() {
+                for ($i(bindName) in $i(srcName)) {
+                    if ($i(takenName) >= $i(takeLimName)) {
+                        break
+                    }
+                    $e(perElement)
+                }
             }
         }
     } else {
-        stmts |> push <| qmacro_expr() {
-            for ($i(itName) in $i(srcName)) {
-                $e(perElement)
-            }
-        }
+        stmts |> push <| adapter_wrap_source_loop(ctx.src, perElement, at)
     }
     if (terminatorName == "count") {
         if (countPred != null) {
@@ -3182,9 +3233,12 @@ def private emit_hashtable_dedup(var c : Captures; var ctx : EmitCtx; at : LineI
             return $i(accName)
         }
     } else {
-        stmts |> push(buffer_return(bufName, ctx.expr_is_iterator))
+        stmts |> push_from <| qmacro_block_to_array() {
+            return <- $i(bufName)
+        }
     }
-    return finalize_emission_stmts(top, srcName, at, stmts)
+    let needIterWrap = ctx.expr_is_iterator && needBuffer
+    return adapter_wrap_invoke(ctx.src, stmts, null, needIterWrap, at)
 }
 
 // Stub — table-driven dispatch into plan_distinct_patterns.

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -1856,7 +1856,7 @@ def private populate_plan_order_family_patterns {
         requires <- [@@ < RequiresPredicate > has_where_or_distinct, @@ < RequiresPredicate > take_arg_is_int],
         emit = @@ < EmitFn > emit_fused_prefilter
     )
-    // Row 5 — buffer_helper_dispatch: bare order_family + optional take/first; direct call to daslib helpers.
+    // Row 5 — buffer_helper_dispatch: bare order_family + optional take/first → direct daslib helper call (order/top_n*/min_max). array_source gates to Array only — Decs has no `top` expr, cascades to Row 4 (fused_prefilter).
     plan_order_family_patterns |> emplace <| SplicePattern(
         name = "order_buffer_helper_dispatch",
         chain <- [
@@ -1864,7 +1864,7 @@ def private populate_plan_order_family_patterns {
             Slot(matcher = m_literal("take"),       cardinality = c_opt(), capture_name = "take"),
             Slot(matcher = m_alias("first_family"), cardinality = c_opt(), capture_name = "term")
         ],
-        requires <- [@@ < RequiresPredicate > take_arg_is_int],
+        requires <- [@@ < RequiresPredicate > take_arg_is_int, @@ < RequiresPredicate > array_source],
         emit = @@ < EmitFn > emit_buffer_helper_dispatch
     )
 }
@@ -2370,8 +2370,87 @@ def private emit_fused_prefilter(var c : Captures; var ctx : EmitCtx; at : LineI
 // ===== plan_loop_or_count migration (PR B) =====
 // Single emit + single pattern row. c_chain captures where_/select head; canonical-order slots carry the rest.
 
+// PR C Decs-arm: reconstructs a flatten_linq-shaped calls array from captures, runs extract_decs_ranges +
+// compute_decs_chain_info (the same helpers plan_decs_unroll imperative uses), then dispatches to the
+// existing emit_decs_* lane fns. State-hoist-above-for_each_archetype shape stays per-adapter (D1).
+[macro_function]
+def private emit_loop_or_count_lane_decs(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
+    let bridge = (ctx.src as Decs)._0
+    let tupName = (ctx.src as Decs)._1
+    // post_take_where (Theme 2 5c on Array) has no decs lane fn yet; cascade so the chain doesn't silently lose the predicate.
+    if (c.single |> key_exists("post_take_where")) return null
+    let hasTerm = c.single |> key_exists("term")
+    var termCall : ExprCall?
+    var termName : string
+    if (hasTerm) {
+        termCall = c.single["term"]
+        termName = c.single_name["term"]
+    }
+    // D5 fast path: bare `count()` (1-arg, no chain) → arch.size sum, no entity walk.
+    let noRangeOps = (!(c.single |> key_exists("skip")) && !(c.single |> key_exists("skip_while"))
+        && !(c.single |> key_exists("take_while")) && !(c.single |> key_exists("take")))
+    if (hasTerm && termName == "count" && length(termCall.arguments) == 1
+            && (c.many["head"] |> empty) && noRangeOps) return emit_decs_count_archsize(bridge, at)
+    // Reconstruct calls = head + range ops (canonical order) + term, so existing helpers (compute_decs_chain_info, extract_decs_ranges) work unchanged. LinqCall records come from the linqCalls registry by call_norm_name; addr() to convert ref→pointer matches flatten_linq's pattern.
+    var calls : array<tuple<ExprCall?; LinqCall?>>
+    calls |> reserve(length(c.many["head"]) + 5)        // head + up to 4 range slots + term
+    for (call in c.many["head"]) {
+        let nm = call_norm_name(call)
+        if (!(linqCalls |> key_exists(nm))) return null
+        var lc & = unsafe(linqCalls?[nm] ?? default<LinqCall>)
+        calls |> push((call, unsafe(addr(lc))))
+    }
+    let rangeSlots = ["skip", "skip_while", "take_while", "take"]
+    for (sn in rangeSlots) {
+        if (c.single |> key_exists(sn)) {
+            let scall = c.single[sn]
+            let snm = call_norm_name(scall)
+            if (!(linqCalls |> key_exists(snm))) return null
+            var lc & = unsafe(linqCalls?[snm] ?? default<LinqCall>)
+            calls |> push((scall, unsafe(addr(lc))))
+        }
+    }
+    if (hasTerm) {
+        if (!(linqCalls |> key_exists(termName))) return null
+        var lc & = unsafe(linqCalls?[termName] ?? default<LinqCall>)
+        calls |> push((termCall, unsafe(addr(lc))))
+    }
+    let intermediateEnd = hasTerm ? length(calls) - 1 : length(calls)
+    let rangeInfo = extract_decs_ranges(calls, intermediateEnd, tupName, at)
+    if (rangeInfo == null) return null
+    let chainInfo = compute_decs_chain_info(calls, rangeInfo.chainEnd, tupName, bridge, at)
+    if (chainInfo == null) return null
+    // Terminator classification mirrors plan_decs_unroll imperative (linq_fold.das:5781-5791); differs from classify_terminator's 4-lane split because decs has dedicated min_max_by / walk / element_at emit fns with hoisted state.
+    let isAccum = (termName == "count" || termName == "long_count" || termName == "sum"
+        || termName == "min" || termName == "max" || termName == "average")
+    let isEarlyExit = (termName == "first" || termName == "first_or_default"
+        || termName == "any" || termName == "all" || termName == "contains")
+    let isMinMaxBy = termName == "min_by" || termName == "max_by"
+    let isWalk = (termName == "last" || termName == "last_or_default"
+        || termName == "single" || termName == "single_or_default"
+        || termName == "aggregate")
+    let isElementAt = termName == "element_at" || termName == "element_at_or_default"
+    if (isAccum) {
+        var accType : TypeDeclPtr
+        if (termName == "sum" || termName == "min" || termName == "max" || termName == "average") {
+            if (chainInfo.selectCount == 0 || chainInfo.finalType == null) return null
+            accType = clone_type(chainInfo.finalType)
+        }
+        return emit_decs_accumulator(bridge, termName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, termCall, accType, at)
+    }
+    if (isEarlyExit) return emit_decs_early_exit(bridge, termName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, termCall, at)
+    if (isMinMaxBy) return emit_decs_min_max_by(bridge, termName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, termCall, at)
+    if (isWalk) return emit_decs_walk_lane(bridge, termName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, termCall, at)
+    if (isElementAt) return emit_decs_element_at(bridge, termName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, termCall, at)
+    // Implicit to_array: only when outer expr was array-typed (caller wrote `.to_array()`, peeled by linqCalls skip=true). Iterator-typed chains cascade to tier-2 here, matches imperative plan_decs_unroll line 5813.
+    if (ctx.expr_is_iterator) return null
+    return emit_decs_to_array(bridge, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, at)
+}
+
 [macro_function]
 def private emit_loop_or_count_lane(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
+    // PR C Decs-arm: route to existing emit_decs_* lane fns. State hoists above for_each_archetype (different invoke shape from array side); unifying lane fns is out of scope per D1.
+    if (ctx.src is Decs) return emit_loop_or_count_lane_decs(c, ctx, at)
     var top = ctx.top
     let srcName = (ctx.src as Array)._1
     let itName = qn("it", at)
@@ -2824,6 +2903,65 @@ def private emit_reverse_backward_walk_dset_gate(var c : Captures; var ctx : Emi
     return finalize_emission_stmts(top, srcName, at, bodyStmts)
 }
 
+// Decs `reverse |> take(N) |> to_array` skip-into-tail: 2-pass walk (arch.size sum, then for_each_archetype_find with whole-arch-skip + partial-arch skip-counter + early-exit). Preserves PR #2834's 5.2× gain.
+[macro_function]
+def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBridgeShape?; tupName : string; needIterWrap : bool; at : LineInfo) : Expression? {
+    let bufName = qn("buf", at)
+    let takeNName = qn("take_n", at)
+    let totalName = qn("decs_total", at)
+    let actualName = qn("decs_actual", at)
+    let skipName = qn("decs_skip", at)
+    let seenName = qn("decs_seen", at)
+    let skipsLeftName = qn("decs_skips", at)
+    let archName = bridge.archName
+    var bufElemType = strip_const_ref(clone_type(bridge.elementType))
+    let tupBind = build_decs_tup_bind(bridge, tupName, at)
+    var innerBody : Expression? = qmacro_block() {
+        if ($i(skipsLeftName) > 0_l) {
+            $i(skipsLeftName) --
+            continue
+        }
+        $e(tupBind)
+        $i(bufName) |> push_clone($i(tupName))
+        if (int64(length($i(bufName))) >= $i(actualName)) {
+            break
+        }
+    }
+    var clonedForExpr = clone_expression(bridge.forExpr)
+    var clonedFor = clonedForExpr as ExprFor
+    var newForBody = new ExprBlock(at = at)
+    newForBody.list |> push(innerBody)
+    clonedFor.body = newForBody
+    var emission : Expression? = qmacro(invoke($() : array<$t(bufElemType)> {
+        var $i(totalName) = 0_l
+        for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+            $i(totalName) += $i(archName).size
+        })
+        let $i(takeNName) = $e(takeExpr)
+        let $i(actualName) = ($i(takeNName) <= 0) ? 0_l : ((int64($i(takeNName)) < $i(totalName)) ? int64($i(takeNName)) : $i(totalName))
+        let $i(skipName) = $i(totalName) - $i(actualName)
+        var $i(bufName) : array<$t(bufElemType)>
+        if ($i(actualName) == 0_l) {
+            return <- $i(bufName)
+        }
+        $i(bufName) |> reserve(int($i(actualName)))
+        var $i(seenName) = 0_l
+        for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+            if ($i(seenName) + $i(archName).size <= $i(skipName)) {
+                $i(seenName) += $i(archName).size
+                return false
+            }
+            var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
+            $e(clonedForExpr)
+            $i(seenName) += $i(archName).size
+            return int64(length($i(bufName))) >= $i(actualName)
+        })
+        _::reverse_inplace($i(bufName))
+        return <- $i(bufName)
+    }))
+    return finalize_decs_emission(emission, at, needIterWrap)
+}
+
 // R1-R4 — catch-all buffer + reverse_inplace + optional resize + optional terminal _select.
 [macro_function]
 def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expression? {
@@ -2839,6 +2977,13 @@ def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at 
     if (c.single |> key_exists("preproj")) {
         projection = peel_lambda_rename_var(c.single["preproj"].arguments[1], bindName)
     }
+    var terminalSelectLam_check : Expression?
+    if (c.single |> key_exists("termsel")) {
+        terminalSelectLam_check = c.single["termsel"].arguments[1]
+    }
+    // Decs skip-into-tail fast path for `reverse |> take(N) |> to_array` (no where/select/termsel) — preserves PR #2834's 5.2× perf gain; otherwise the unified path walks all entities then resizes.
+    if (ctx.src is Decs && (c.single |> key_exists("take")) && whereCond == null && projection == null && terminalSelectLam_check == null)
+        return emit_decs_reverse_skip_into_tail(c.single["take"].arguments[1], (ctx.src as Decs)._0, (ctx.src as Decs)._1, ctx.expr_is_iterator, at)
     var takeExpr : Expression?
     if (c.single |> key_exists("take")) {
         takeExpr = clone_expression(c.single["take"].arguments[1])
@@ -5770,48 +5915,24 @@ def private emit_decs_element_at(bridge : DecsBridgeShape?;
 
 [macro_function]
 def private plan_decs_unroll(var expr : Expression?) : Expression? {
+    // PR C stub — routes through plan_loop_or_count_patterns with Decs adapter. emit_loop_or_count_lane's Decs-arm (emit_loop_or_count_lane_decs) reconstructs a calls array from captures and dispatches to the existing emit_decs_* lane fns.
     var (top, calls) = flatten_linq(expr)
-    let bridge = extract_decs_bridge(top)
-    if (bridge == null) return null
-    let at = expr.at
-    // Slice 1: bare count → arch.size shortcut (no chain ops, no ranges).
-    if (length(calls) == 1 && calls.back()._1.name == "count" && length(calls.back()._0.arguments) == 1) return emit_decs_count_archsize(bridge, at)
-    // to_array is `skip = true` in linqCalls so it's already peeled — "no recognized terminator" means implicit to_array.
-    let lastName = empty(calls) ? "" : calls.back()._1.name
-    let isAccum = (lastName == "count" || lastName == "long_count" || lastName == "sum"
-        || lastName == "min" || lastName == "max" || lastName == "average")
-    let isEarlyExit = (lastName == "first" || lastName == "first_or_default"
-        || lastName == "any" || lastName == "all" || lastName == "contains")
-    let isMinMaxBy = (lastName == "min_by" || lastName == "max_by")
-    // Slice 5f: walk-lane (last/single/aggregate) + element_at counter early-exit.
-    let isWalk = (lastName == "last" || lastName == "last_or_default"
-        || lastName == "single" || lastName == "single_or_default"
-        || lastName == "aggregate")
-    let isElementAt = (lastName == "element_at" || lastName == "element_at_or_default")
-    let isTerminator = isAccum || isEarlyExit || isMinMaxBy || isWalk || isElementAt
+    var bridge = extract_decs_bridge(top)
+    if (bridge == null || empty(calls) || expr._type == null) return null
+    collapse_chained_selects(calls)
+    collapse_chained_wheres(calls)
+    let at = calls[0]._0.at
     let tupName = qn("decs_tup", at)
-    let intermediateEnd = isTerminator ? length(calls) - 1 : length(calls)
-    // Slice 5a/5b: peel trailing take/skip/take_while/skip_while into rangeInfo. chainEnd is the index past which only range ops live (or == intermediateEnd if none). tupName passed so predicate-driven ranges peel against the source tuple.
-    let rangeInfo = extract_decs_ranges(calls, intermediateEnd, tupName, at)
-    if (rangeInfo == null) return null
-    let chainInfo = compute_decs_chain_info(calls, rangeInfo.chainEnd, tupName, bridge, at)
-    if (chainInfo == null) return null
-    if (isAccum) {
-        // sum/min/max/average need a scalar element — selectCount==0 keeps finalType = bridge.elementType (a tuple) which can't be summed/compared.
-        var accType : TypeDeclPtr
-        if (lastName == "sum" || lastName == "min" || lastName == "max" || lastName == "average") {
-            if (chainInfo.selectCount == 0 || chainInfo.finalType == null) return null
-            accType = clone_type(chainInfo.finalType)
+    let exprIsIter = expr._type.isIterator
+    for (p in plan_loop_or_count_patterns) {
+        var r <- match_pattern(p, calls, top)
+        if (r is matched) {
+            var ctx = EmitCtx(top = null, src = SourceAdapter(Decs = (bridge, tupName)), expr_is_iterator = exprIsIter)
+            var result = invoke(p.emit, r as matched, ctx, at)
+            if (result != null) return result
         }
-        return emit_decs_accumulator(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, accType, at)
     }
-    if (isEarlyExit) return emit_decs_early_exit(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
-    if (isMinMaxBy) return emit_decs_min_max_by(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
-    if (isWalk) return emit_decs_walk_lane(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
-    if (isElementAt) return emit_decs_element_at(bridge, lastName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, calls.back()._0, at)
-    // Iterator-typed chains cascade to tier-2; only fire to_array when expr is array-typed (user wrote `.to_array()`, peeled by skip=true).
-    if (expr._type == null || !expr._type.isGoodArrayType) return null
-    return emit_decs_to_array(bridge, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, at)
+    return null
 }
 
 // ── decs group_by splice (Slice 5e — state-table over for_each_archetype) ───────
@@ -5930,938 +6051,78 @@ def private plan_decs_group_by(var expr : Expression?) : Expression? {
     return plan_group_by_core(calls, keyBlock, groupProjCall, havingCall, trailingWhereCall, terminatorName, orderName, orderKey, expr._type.isIterator, at, adapter)
 }
 
-// ── decs order family splice (Slice 5d — buffer + order_inplace/top_n/min_by/max_by) ───────
+// ── decs order family splice (PR C — pattern-table stub through plan_order_family_patterns) ───────
 
 [macro_function]
 def private plan_decs_order_family(var expr : Expression?) : Expression? {
-    // Decs-bridge entry mirroring plan_order_family. Recognizes [where_*][order|order_descending|order_by|order_by_descending][take(N)|first|first_or_default(d)]? on a from_decs_template source. Always uses a hoisted buffer above for_each_archetype (decs has no random access for the no-where direct path that array-side enjoys), then dispatches to the same daslib helper family (order_inplace / top_n* / min_by / max_by / first_or_default(top_n*(_,1,_),d)).
+    // PR C stub — reuses plan_order_family_patterns with Decs adapter. Row 4 (buffer_helper_dispatch) gated by array_source so decs cascades to Row 3 (fused_prefilter) for the bare order / order+take / order+first cases — fused_prefilter materializes the buffer, which is what the imperative decs body did anyway.
     var (top, calls) = flatten_linq(expr)
     var bridge = extract_decs_bridge(top)
     if (bridge == null || empty(calls) || expr._type == null) return null
     normalize_order_reverse(calls)
     collapse_chained_selects(calls)
+    collapse_chained_wheres(calls)
     let at = calls[0]._0.at
     let tupName = qn("decs_tup", at)
-    let bufName = qn("decs_buf", at)
-    var whereCond : Expression?
-    var orderName : string = ""
-    var orderKey : Expression?
-    var hasOrder = false
-    var takeExpr : Expression?
-    var firstName : string = ""
-    var firstDefaultExpr : Expression?
-    var selectLam : Expression?
-    var selectElemType : TypeDeclPtr
-    // Theme 3 Phase 3 (audit C1/C5): leading or middle `distinct` / `distinct_by` on a decs order+take chain — bounded-heap path gates per-element push by set-insert.
-    var distinctName : string = ""
-    var distinctKey : Expression?
-    for (i in 0 .. length(calls)) {
-        var cll & = unsafe(calls[i])
-        let name = cll._1.name
-        if (name == "where_") {
-            if (hasOrder || distinctName != "") return null
-            var pred = peel_lambda_rename_var(cll._0.arguments[1], tupName)
-            if (pred == null) return null
-            whereCond = merge_where_cond(whereCond, pred)
-        } elif (name == "distinct" || name == "distinct_by") {
-            // Decs mirror of plan_order_family's bail logic. Same shapes the set-gated bounded-heap can't honor: already-claimed distinct/first/select; `take.distinct`; `order_by(K2).distinct_by(K1)`. Plain `distinct()` after order_by stays a splice (whole-tuple equality is position-invariant).
-            if (distinctName != "" || firstName != "" || selectLam != null
-                    || takeExpr != null
-                    || (name == "distinct_by" && hasOrder)) return null
-            distinctName = name
-            if (name == "distinct_by") {
-                let argCount = cll._0.arguments |> length
-                if (argCount < 2) return null
-                distinctKey = clone_expression(cll._0.arguments[1])
-            }
-        } elif (name == "order" || name == "order_descending"
-                || name == "order_by" || name == "order_by_descending") {
-            if (hasOrder) return null
-            let argCount = cll._0.arguments |> length
-            // Bail on `order(arr, cmp)` / `order_descending(arr, cmp)` — splice helpers (min/max/top_n) can't honor a user-supplied comparator and would silently drop it. Matches plan_order_family.
-            if ((name == "order" || name == "order_descending") && argCount >= 2) return null
-            hasOrder = true
-            orderName = name
-            if (argCount >= 2) {
-                orderKey = clone_expression(cll._0.arguments[1])
-            }
-        } elif (name == "take") {
-            if (!hasOrder || takeExpr != null || firstName != "") return null
-            var arg = cll._0.arguments[1]
-            if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
-            takeExpr = clone_expression(arg)
-        } elif (name == "first" || name == "first_or_default") {
-            // order + first → min/max (O(N) instead of sort + index). Must be terminal.
-            if (!hasOrder || takeExpr != null || firstName != "" || i != length(calls) - 1) return null
-            firstName = name
-            if (name == "first_or_default") {
-                if ((cll._0.arguments |> length) < 2) return null
-                firstDefaultExpr = clone_expression(cll._0.arguments[1])
-            }
-        } elif (name == "select") {
-            // Terminal _select after take(N): heap/sort sees raw tuple, project at return.
-            if (i != length(calls) - 1 || !hasOrder
-                    || cll._0._type == null || cll._0._type.firstType == null) return null
-            selectLam = cll._0.arguments[1]
-            if (selectLam == null) return null
-            selectElemType = clone_type(cll._0._type.firstType)
-        } else {
-            return null
+    let exprIsIter = expr._type.isIterator
+    for (p in plan_order_family_patterns) {
+        var r <- match_pattern(p, calls, top)
+        if (r is matched) {
+            var ctx = EmitCtx(top = null, src = SourceAdapter(Decs = (bridge, tupName)), expr_is_iterator = exprIsIter)
+            var result = invoke(p.emit, r as matched, ctx, at)
+            if (result != null) return result
         }
     }
-    // Distinct gate is implemented only in the bounded-heap path. Without take we'd silently drop dedup — bail to cascade.
-    if (!hasOrder || (distinctName != "" && takeExpr == null)) return null
-    let hasKey = orderName == "order_by" || orderName == "order_by_descending"
-    let topNName = order_top_n_call_name(orderName)
-    let inplaceName = "{orderName}_inplace"
-    let minMaxName = order_min_call_name(orderName, hasKey)
-    var elemType = strip_const_ref(clone_type(bridge.elementType))
-    var inlineCmp : Expression?
-    if (hasKey) {
-        inlineCmp = try_make_inline_cmp(orderKey, orderName, elemType, at)
-    }
-    // Bounded-heap / streaming-min fast paths: when the key is inline-able, skip the materialize-all + min_by/top_n pattern in favor of a per-walk state (single best for first[_or_default], heap of size N for take). Slashes 100K push_clones to ~N — the rest of the elements only pay a cmp.
-    let useBoundedHeap = takeExpr != null && inlineCmp != null && firstName == ""
-    let useStreamingMin = firstName != "" && inlineCmp != null
-    let archName = bridge.archName
-    let needIterWrap = expr._type.isIterator
-    var emission : Expression?
-    if (useStreamingMin) {
-        let bestName = qn("decs_best", at)
-        let seenName = qn("decs_seen", at)
-        var lessTest = make_inline_less_call(orderKey, orderName,
-            qmacro($i(tupName)), qmacro($i(bestName)), at)
-        var perElement : Expression? = qmacro_expr() {
-            if (!$i(seenName)) {
-                $i(bestName) := $i(tupName)
-                $i(seenName) = true
-            } elif ($e(lessTest)) {
-                $i(bestName) := $i(tupName)
-            }
-        }
-        if (whereCond != null) {
-            perElement = qmacro_expr() {
-                if ($e(whereCond)) {
-                    $e(perElement)
-                }
-            }
-        }
-        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-        if (firstName == "first") {
-            emission = qmacro(invoke($() : $t(elemType) {
-                var $i(bestName) = default<$t(elemType)>
-                var $i(seenName) = false
-                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                    $e(forExprNode)
-                })
-                panic("sequence contains no elements") if (!$i(seenName))
-                return $i(bestName)
-            }))
-        } else {
-            let dBindName = qn("order_d", at)
-            emission = qmacro(invoke($() : $t(elemType) {
-                let $i(dBindName) = $e(firstDefaultExpr)
-                var $i(bestName) = default<$t(elemType)>
-                var $i(seenName) = false
-                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                    $e(forExprNode)
-                })
-                return $i(bestName) if ($i(seenName))
-                return $i(dBindName)
-            }))
-        }
-        return finalize_decs_emission(emission, at, false)
-    }
-    if (useBoundedHeap) {
-        let takeNName = qn("decs_take_n", at)
-        let dsetName = qn("decs_dset", at)
-        let dkeyName = qn("decs_dkey", at)
-        // Direct less-test on the hot path: `less(KEY[decs_tup], KEY[buf[0]])` inlined, no block dispatch.
-        var lessTest = make_inline_less_call(orderKey, orderName,
-            qmacro($i(tupName)), qmacro($i(bufName)[0]), at)
-        var perElement : Expression? = qmacro_expr() {
-            if (length($i(bufName)) < $i(takeNName)) {
-                $i(bufName) |> push_clone($i(tupName))
-                _::spliced_push_heap($i(bufName), $e(inlineCmp))
-            } elif ($e(lessTest)) {
-                _::spliced_pop_heap($i(bufName), $e(inlineCmp))
-                $i(bufName)[length($i(bufName)) - 1] := $i(tupName)
-                _::spliced_push_heap($i(bufName), $e(inlineCmp))
-            }
-        }
-        // Theme 3 Phase 3 (C1/C5 decs mirror): leading or middle distinct[_by] gates per-element push by set-insert on the distinct key.
-        if (distinctName != "") {
-            var dkeyExpr : Expression?
-            if (distinctName == "distinct_by") {
-                dkeyExpr = peel_lambda_rename_var(distinctKey, tupName)
-                if (dkeyExpr == null) return null
-            } else {
-                dkeyExpr = qmacro($i(tupName))
-            }
-            perElement = qmacro_block() {
-                let $i(dkeyName) = _::unique_key($e(dkeyExpr))
-                if (!$i(dsetName) |> key_exists($i(dkeyName))) {
-                    $i(dsetName) |> insert($i(dkeyName))
-                    $e(perElement)
-                }
-            }
-        }
-        if (whereCond != null) {
-            perElement = qmacro_expr() {
-                if ($e(whereCond)) {
-                    $e(perElement)
-                }
-            }
-        }
-        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-        // Distinct-set declaration: keyed on the same `typedecl(_::unique_key(...))` idiom plan_distinct uses. Hoisted ABOVE for_each_archetype.
-        var dsetDecl : Expression?
-        if (distinctName != "") {
-            if (distinctName == "distinct_by") {
-                dsetDecl = qmacro_expr() {
-                    var inscope $i(dsetName) : table<typedecl(_::unique_key(invoke($e(distinctKey), default<$t(elemType)>)))>
-                }
-            } else {
-                dsetDecl = qmacro_expr() {
-                    var inscope $i(dsetName) : table<typedecl(_::unique_key(default<$t(elemType)>))>
-                }
-            }
-        }
-        var bhStmts : array<Expression?>
-        bhStmts |> reserve(12)
-        // No `reserve(takeN)` on the bounded buf — matches the policy in linq.das top_n_by_with_cmp iterator variant. Caller may pass takeN >> actual source size, and the decs cardinality is unknown ahead of the walk; pre-reserving N slots would risk a large upfront allocation for no win (fill phase grows geometrically to min(N, M) in O(log) reallocs anyway).
-        if (selectLam != null) {
-            // Terminal _select projects ≤K heap survivors at return (heap holds raw tuples).
-            let outBufName = qn("decs_proj_buf", at)
-            let elemName = qn("decs_proj_e", at)
-            var projBody = peel_lambda_replace_var(selectLam, qmacro($i(elemName)))
-            bhStmts |> push_from <| qmacro_block_to_array() {
-                let $i(takeNName) = $e(takeExpr)
-                var $i(bufName) : array<$t(elemType)>
-                var $i(outBufName) : array<$t(selectElemType)>
-                return <- $i(outBufName) if ($i(takeNName) <= 0)
-            }
-            if (dsetDecl != null) {
-                bhStmts |> push(dsetDecl)
-            }
-            bhStmts |> push_from <| qmacro_block_to_array() {
-                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                    $e(forExprNode)
-                })
-                _::order_inplace($i(bufName), $e(inlineCmp))
-                $i(outBufName) |> reserve(length($i(bufName)))
-                for ($i(elemName) in $i(bufName)) {
-                    $i(outBufName) |> push_clone($e(projBody))
-                }
-                return <- $i(outBufName)
-            }
-            emission = qmacro(invoke($() : array<$t(selectElemType)> {
-                $b(bhStmts)
-            }))
-        } else {
-            bhStmts |> push_from <| qmacro_block_to_array() {
-                let $i(takeNName) = $e(takeExpr)
-                var $i(bufName) : array<$t(elemType)>
-                return <- $i(bufName) if ($i(takeNName) <= 0)
-            }
-            if (dsetDecl != null) {
-                bhStmts |> push(dsetDecl)
-            }
-            bhStmts |> push_from <| qmacro_block_to_array() {
-                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                    $e(forExprNode)
-                })
-                _::order_inplace($i(bufName), $e(inlineCmp))
-                return <- $i(bufName)
-            }
-            emission = qmacro(invoke($() : array<$t(elemType)> {
-                $b(bhStmts)
-            }))
-        }
-        return finalize_decs_emission(emission, at, needIterWrap)
-    }
-    var perElement : Expression? = qmacro_expr() {
-        $i(bufName) |> push_clone($i(tupName))
-    }
-    if (whereCond != null) {
-        perElement = qmacro_expr() {
-            if ($e(whereCond)) {
-                $e(perElement)
-            }
-        }
-    }
-    var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-    var bodyStmts : array<Expression?>
-    bodyStmts |> reserve(5)
-    bodyStmts |> push_from <| qmacro_block_to_array() {
-        var $i(bufName) : array<$t(elemType)>
-        for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-            $e(forExprNode)
-        })
-    }
-    if (firstName == "first") {
-        // order + first → min/max on buffer. Empty buf must panic to match eager `first()` semantics.
-        bodyStmts |> push <| qmacro_expr() {
-            panic("sequence contains no elements") if (empty($i(bufName)))
-        }
-        var minMaxCall : Expression?
-        if (hasKey) {
-            minMaxCall = qmacro($c(minMaxName)($i(bufName), $e(orderKey)))
-        } else {
-            minMaxCall = qmacro($c(minMaxName)($i(bufName)))
-        }
-        bodyStmts |> push <| qmacro_expr() {
-            return $e(minMaxCall)
-        }
-        emission = qmacro(invoke($() : $t(elemType) {
-            $b(bodyStmts)
-        }))
-    } elif (firstName == "first_or_default") {
-        // No min_by_or_default helper exists; route through top_n*(_, 1, _) + first_or_default for the empty-buf case. The default expression is hoisted into a let BEFORE for_each_archetype so its side effects fire ahead of iteration (matches plan_decs_reverse's first_or_default + the eager-arg-eval semantics of the non-spliced chain).
-        let dBindName = qn("order_d", at)
-        var foDStmts : array<Expression?>
-        foDStmts |> reserve(4)
-        foDStmts |> push <| qmacro_expr() {
-            let $i(dBindName) = $e(firstDefaultExpr)
-        }
-        foDStmts |> push(bodyStmts[0])
-        foDStmts |> push(bodyStmts[1])
-        var topNCall : Expression?
-        if (inlineCmp != null) {
-            topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), 1, $e(inlineCmp)))
-        } elif (hasKey) {
-            topNCall = qmacro($c(topNName)($i(bufName), 1, $e(orderKey)))
-        } else {
-            topNCall = qmacro($c(topNName)($i(bufName), 1))
-        }
-        foDStmts |> push <| qmacro_expr() {
-            return _::first_or_default($e(topNCall), $i(dBindName))
-        }
-        emission = qmacro(invoke($() : $t(elemType) {
-            $b(foDStmts)
-        }))
-    } elif (takeExpr == null) {
-        // Bare order family — sort buffer in place and return.
-        var sortCall : Expression?
-        if (inlineCmp != null) {
-            sortCall = qmacro(_::order_inplace($i(bufName), $e(inlineCmp)))
-        } elif (hasKey) {
-            sortCall = qmacro($c(inplaceName)($i(bufName), $e(orderKey)))
-        } else {
-            sortCall = qmacro($c(inplaceName)($i(bufName)))
-        }
-        bodyStmts |> push(sortCall)
-        if (selectLam != null) {
-            let outBufName = qn("decs_proj_buf", at)
-            let elemName = qn("decs_proj_e", at)
-            var projBody = peel_lambda_replace_var(selectLam, qmacro($i(elemName)))
-            bodyStmts |> push_from <| qmacro_block_to_array() {
-                var $i(outBufName) : array<$t(selectElemType)>
-                $i(outBufName) |> reserve(length($i(bufName)))
-                for ($i(elemName) in $i(bufName)) {
-                    $i(outBufName) |> push_clone($e(projBody))
-                }
-                return <- $i(outBufName)
-            }
-            emission = qmacro(invoke($() : array<$t(selectElemType)> {
-                $b(bodyStmts)
-            }))
-        } else {
-            bodyStmts |> push <| qmacro_expr() {
-                return <- $i(bufName)
-            }
-            emission = qmacro(invoke($() : array<$t(elemType)> {
-                $b(bodyStmts)
-            }))
-        }
-    } else {
-        // order + take → top_n* dispatch on the buffer.
-        var topNCall : Expression?
-        if (inlineCmp != null) {
-            topNCall = qmacro(_::top_n_by_with_cmp($i(bufName), $e(takeExpr), $e(inlineCmp)))
-        } elif (hasKey) {
-            topNCall = qmacro($c(topNName)($i(bufName), $e(takeExpr), $e(orderKey)))
-        } else {
-            topNCall = qmacro($c(topNName)($i(bufName), $e(takeExpr)))
-        }
-        if (selectLam != null) {
-            let topResName = qn("decs_top_res", at)
-            let outBufName = qn("decs_proj_buf", at)
-            let elemName = qn("decs_proj_e", at)
-            var projBody = peel_lambda_replace_var(selectLam, qmacro($i(elemName)))
-            bodyStmts |> push_from <| qmacro_block_to_array() {
-                var $i(topResName) <- $e(topNCall)
-                var $i(outBufName) : array<$t(selectElemType)>
-                $i(outBufName) |> reserve(length($i(topResName)))
-                for ($i(elemName) in $i(topResName)) {
-                    $i(outBufName) |> push_clone($e(projBody))
-                }
-                return <- $i(outBufName)
-            }
-            emission = qmacro(invoke($() : array<$t(selectElemType)> {
-                $b(bodyStmts)
-            }))
-        } else {
-            bodyStmts |> push <| qmacro_expr() {
-                return <- $e(topNCall)
-            }
-            emission = qmacro(invoke($() : array<$t(elemType)> {
-                $b(bodyStmts)
-            }))
-        }
-    }
-    // Bare order + take both return array; wrap to iterator when the user's outer context demands it. first/first_or_default return scalar — no wrap.
-    return finalize_decs_emission(emission, at, needIterWrap && firstName == "")
+    return null
 }
 
-// ── decs reverse splice (Slice 5d — buffer + reverse_inplace; or counter/walk-last for terminators) ───────
+// ── decs reverse splice (PR C — pattern-table stub through plan_reverse_patterns) ───────
 
 [macro_function]
 def private plan_decs_reverse(var expr : Expression?) : Expression? {
-    // Decs-bridge entry mirroring plan_reverse. Recognizes [where_*][select?][reverse][take(N)?][count|first|first_or_default(d)]? on a from_decs_template source. Three emit paths: count → counter loop (reverse is identity for count); first/first_or_default → walk + overwrite `last` (reverse-of-last = first-of-reverse); else → buffer fill + reverse_inplace + optional resize. R6 backward-index optimization from array-side doesn't apply: multi-iter for has no random access.
+    // PR C stub — reuses plan_reverse_patterns with Decs adapter; backward-index rows skip via array_source. `reverse |> distinct[_by]` cascades (D6 deferred).
     var (top, calls) = flatten_linq(expr)
     var bridge = extract_decs_bridge(top)
     if (bridge == null || empty(calls) || expr._type == null) return null
     normalize_order_reverse(calls)
     collapse_chained_selects(calls)
-    var terminatorName : string = ""
-    var terminatorCall : ExprCall?
-    {
-        let lastName = calls.back()._1.name
-        if (lastName == "count" && length(calls.back()._0.arguments) == 1) {
-            terminatorName = lastName
-            terminatorCall = calls.back()._0
-            calls |> pop
-        } elif (lastName == "first" || lastName == "first_or_default") {
-            terminatorName = lastName
-            terminatorCall = calls.back()._0
-            calls |> pop
-        }
-    }
-    if (empty(calls)) return null
+    collapse_chained_wheres(calls)
     let at = calls[0]._0.at
     let tupName = qn("decs_tup", at)
-    var whereCond : Expression?
-    var projection : Expression?
-    var hasReverse = false
-    var seenSelect = false
-    var takeExpr : Expression?
-    var terminalSelectLam : Expression?
-    var terminalSelectElemType : TypeDeclPtr
-    for (i in 0 .. length(calls)) {
-        var cll & = unsafe(calls[i])
-        let name = cll._1.name
-        if (name == "where_") {
-            if (hasReverse || seenSelect) return null
-            var pred = peel_lambda_rename_var(cll._0.arguments[1], tupName)
-            if (pred == null) return null
-            whereCond = merge_where_cond(whereCond, pred)
-        } elif (name == "select") {
-            if (!hasReverse && !seenSelect) {
-                seenSelect = true
-                projection = peel_lambda_rename_var(cll._0.arguments[1], tupName)
-                if (projection == null) return null
-            } elif (hasReverse && !seenSelect && terminalSelectLam == null && i == length(calls) - 1) {
-                terminalSelectLam = cll._0.arguments[1]
-                if (terminalSelectLam == null
-                        || cll._0._type == null || cll._0._type.firstType == null) return null
-                terminalSelectElemType = clone_type(cll._0._type.firstType)
-            } else {
-                return null
-            }
-        } elif (name == "reverse") {
-            if (hasReverse) return null
-            hasReverse = true
-        } elif (name == "take") {
-            if (!hasReverse || takeExpr != null) return null
-            var arg = cll._0.arguments[1]
-            if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
-            takeExpr = clone_expression(arg)
-        } else {
-            return null
+    let exprIsIter = expr._type.isIterator
+    for (p in plan_reverse_patterns) {
+        var r <- match_pattern(p, calls, top)
+        if (r is matched) {
+            var ctx = EmitCtx(top = null, src = SourceAdapter(Decs = (bridge, tupName)), expr_is_iterator = exprIsIter)
+            var result = invoke(p.emit, r as matched, ctx, at)
+            if (result != null) return result
         }
     }
-    if (!hasReverse || (takeExpr != null && terminatorName != "")
-            || (terminalSelectLam != null && terminatorName == "count")) return null
-    let archName = bridge.archName
-    if (terminatorName == "count") {
-        // Reverse is identity for count — counter loop, no buffer. Side-effecting projection still fires per match.
-        let cntName = qn("decs_cnt", at)
-        var perElement : Expression?
-        if (projection != null && has_sideeffects(projection)) {
-            let vfinalName = qn("decs_vfinal", at)
-            perElement = qmacro_block() {
-                var $i(vfinalName) = $e(projection)
-                $i(cntName) ++
-            }
-        } else {
-            perElement = qmacro_expr() {
-                $i(cntName) ++
-            }
-        }
-        if (whereCond != null) {
-            perElement = qmacro_expr() {
-                if ($e(whereCond)) {
-                    $e(perElement)
-                }
-            }
-        }
-        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-        var emission : Expression? = qmacro(invoke($() : int {
-            var $i(cntName) = 0
-            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                $e(forExprNode)
-            })
-            return $i(cntName)
-        }))
-        emission.force_at(at)
-        emission.force_generated(true)
-        return emission
-    }
-    if (terminatorName == "first" || terminatorName == "first_or_default") {
-        // "first of reversed" = LAST surviving element. Walk all archetypes, overwrite `last` on each match. No buffer.
-        let foundName = qn("decs_found", at)
-        let lastName = qn("decs_last", at)
-        let dBindName = qn("decs_d", at)
-        var lastType = strip_const_ref(clone_type(projection != null ? projection._type : bridge.elementType))
-        var valueExpr : Expression?
-        if (projection != null) {
-            valueExpr = clone_expression(projection)
-        } else {
-            valueExpr = qmacro_expr() {
-                $i(tupName)
-            }
-        }
-        var matchBlock : Expression? = qmacro_block() {
-            $i(lastName) := $e(valueExpr)
-            $i(foundName) = true
-        }
-        var perElement : Expression? = matchBlock
-        if (whereCond != null) {
-            perElement = qmacro_expr() {
-                if ($e(whereCond)) {
-                    $e(perElement)
-                }
-            }
-        }
-        var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-        // Terminal _select: `last` stays source-typed; project at return.
-        let outElemType = (terminalSelectLam != null) ? terminalSelectElemType : lastType
-        var lastRetExpr : Expression?
-        var dRetExpr : Expression?
-        if (terminalSelectLam != null) {
-            lastRetExpr = peel_lambda_replace_var(terminalSelectLam, qmacro($i(lastName)))
-            dRetExpr = peel_lambda_replace_var(terminalSelectLam, qmacro($i(dBindName)))
-        } else {
-            lastRetExpr = qmacro($i(lastName))
-            dRetExpr = qmacro($i(dBindName))
-        }
-        var emission : Expression?
-        if (terminatorName == "first") {
-            emission = qmacro(invoke($() : $t(outElemType) {
-                var $i(foundName) = false
-                var $i(lastName) : $t(lastType) = default<$t(lastType)>
-                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                    $e(forExprNode)
-                })
-                if (!$i(foundName)) {
-                    panic("sequence contains no elements")
-                }
-                return $e(lastRetExpr)
-            }))
-        } else {
-            emission = qmacro(invoke($() : $t(outElemType) {
-                let $i(dBindName) = $e(terminatorCall.arguments[1])
-                var $i(foundName) = false
-                var $i(lastName) : $t(lastType) = default<$t(lastType)>
-                for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                    $e(forExprNode)
-                })
-                return $i(foundName) ? $e(lastRetExpr) : $e(dRetExpr)
-            }))
-        }
-        emission.force_at(at)
-        emission.force_generated(true)
-        return emission
-    }
-    // Buffer + reverse_inplace + optional resize. Implicit to_array (no terminator).
-    let bufName = qn("decs_buf", at)
-    let needIterWrap = expr._type.isIterator
-    var bufElemType = strip_const_ref(clone_type(projection != null ? projection._type : bridge.elementType))
-    // Skip-into-tail fast path: `reverse |> take(N) |> to_array` with no where/select. Walk archetypes once to sum `arch.size` (cheap, no entity load), compute skip = total - takeN, then for_each_archetype_find skips whole archetypes whose size still fits below the skip threshold and short-circuits once the buffer reaches takeN. `where` would invalidate the size-based skip (count after filter is unknown without iterating); `select` would only affect element shape, not count, but is skipped here to keep v1 minimal.
-    if (takeExpr != null && whereCond == null && projection == null && terminalSelectLam == null) {
-        let takeNName = qn("take_n", at)
-        let totalName = qn("decs_total", at)
-        let actualName = qn("decs_actual", at)
-        let skipName = qn("decs_skip", at)
-        let seenName = qn("decs_seen", at)
-        let skipsLeftName = qn("decs_skips", at)
-        let tupBind = build_decs_tup_bind(bridge, tupName, at)
-        // Inner-for body: skip-counter early-out before the named-tuple wrap (so skipped iters pay no per-component load); push + break-on-quota after.
-        var innerBody : Expression? = qmacro_block() {
-            if ($i(skipsLeftName) > 0_l) {
-                $i(skipsLeftName) --
-                continue
-            }
-            $e(tupBind)
-            $i(bufName) |> push_clone($i(tupName))
-            if (int64(length($i(bufName))) >= $i(actualName)) {
-                break
-            }
-        }
-        var clonedForExpr = clone_expression(bridge.forExpr)
-        var clonedFor = clonedForExpr as ExprFor
-        var newForBody = new ExprBlock(at = at)
-        newForBody.list |> push(innerBody)
-        clonedFor.body = newForBody
-        var emission : Expression? = qmacro(invoke($() : array<$t(bufElemType)> {
-            // Pass 1: arch.size sum — no entity walk, just archetype-header iteration.
-            var $i(totalName) = 0_l
-            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                $i(totalName) += $i(archName).size
-            })
-            let $i(takeNName) = $e(takeExpr)
-            let $i(actualName) = ($i(takeNName) <= 0) ? 0_l : ((int64($i(takeNName)) < $i(totalName)) ? int64($i(takeNName)) : $i(totalName))
-            let $i(skipName) = $i(totalName) - $i(actualName)
-            var $i(bufName) : array<$t(bufElemType)>
-            if ($i(actualName) == 0_l) {
-                return <- $i(bufName)
-            }
-            $i(bufName) |> reserve(int($i(actualName)))
-            // Pass 2: skip whole archetypes via size sum; partial archetype uses skip-counter; subsequent archetypes feed directly. Returns true once buf reaches actualTake to stop iteration across remaining archetypes.
-            var $i(seenName) = 0_l
-            for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
-                if ($i(seenName) + $i(archName).size <= $i(skipName)) {
-                    $i(seenName) += $i(archName).size
-                    return false
-                }
-                var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
-                $e(clonedForExpr)
-                $i(seenName) += $i(archName).size
-                return int64(length($i(bufName))) >= $i(actualName)
-            })
-            _::reverse_inplace($i(bufName))
-            return <- $i(bufName)
-        }))
-        return finalize_decs_emission(emission, at, needIterWrap)
-    }
-    var pushExpr : Expression?
-    if (projection != null) {
-        pushExpr = qmacro_expr() {
-            $i(bufName) |> push_clone($e(projection))
-        }
-    } else {
-        pushExpr = qmacro_expr() {
-            $i(bufName) |> push_clone($i(tupName))
-        }
-    }
-    var perElement : Expression? = pushExpr
-    if (whereCond != null) {
-        perElement = qmacro_expr() {
-            if ($e(whereCond)) {
-                $e(perElement)
-            }
-        }
-    }
-    var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-    var resizeStmts : array<Expression?>
-    if (takeExpr != null) {
-        // take(N) of reversed-buffer = last N of source reversed. Hoist once to a let so a side-effecting take expression evaluates exactly once.
-        let takeNName = qn("take_n", at)
-        resizeStmts |> push_from <| qmacro_block_to_array() {
-            let $i(takeNName) = $e(takeExpr)
-            $i(bufName) |> resize($i(takeNName) <= 0 ? 0 : ($i(takeNName) < length($i(bufName)) ? $i(takeNName) : length($i(bufName))))
-        }
-    }
-    var emission : Expression?
-    if (terminalSelectLam != null) {
-        let outBufName = qn("decs_rev_proj_buf", at)
-        let elemName = qn("decs_rev_proj_e", at)
-        var projBody = peel_lambda_replace_var(terminalSelectLam, qmacro($i(elemName)))
-        emission = qmacro(invoke($() : array<$t(terminalSelectElemType)> {
-            var $i(bufName) : array<$t(bufElemType)>
-            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                $e(forExprNode)
-            })
-            _::reverse_inplace($i(bufName))
-            $b(resizeStmts)
-            var $i(outBufName) : array<$t(terminalSelectElemType)>
-            $i(outBufName) |> reserve(length($i(bufName)))
-            for ($i(elemName) in $i(bufName)) {
-                $i(outBufName) |> push_clone($e(projBody))
-            }
-            return <- $i(outBufName)
-        }))
-    } else {
-        emission = qmacro(invoke($() : array<$t(bufElemType)> {
-            var $i(bufName) : array<$t(bufElemType)>
-            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                $e(forExprNode)
-            })
-            _::reverse_inplace($i(bufName))
-            $b(resizeStmts)
-            return <- $i(bufName)
-        }))
-    }
-    return finalize_decs_emission(emission, at, needIterWrap)
+    return null
 }
 
-// ── decs distinct splice (Slice 5c — streaming dedup table hoisted above for_each_archetype) ───────
+// ── decs distinct splice (PR C — pattern-table stub through plan_distinct_patterns) ───────
 
 [macro_function]
 def private plan_decs_distinct(var expr : Expression?) : Expression? {
-    // Decs-bridge entry mirroring plan_distinct. Recognizes [where_*][select?] |> distinct[_by(key)] [|> take(N)]? [|> {count, long_count, sum, to_array}]?. Two emit shapes: buffer-required (to_array, optionally with take(N)) and buffer-free (count/long_count return length(seen); sum folds inline at fresh-key site). Take(N) flips outer iteration to for_each_archetype_find so the take-cap can stop across archetypes; counter / seen-table hoist above for_each_archetype so state persists.
+    // PR C stub — reuses plan_distinct_patterns with Decs adapter; emit_hashtable_dedup carries the per-adapter take(N) branch (Decs uses for_each_archetype_find, Array uses for+break).
     var (top, calls) = flatten_linq(expr)
     var bridge = extract_decs_bridge(top)
     if (bridge == null || empty(calls) || expr._type == null) return null
     collapse_chained_selects(calls)
-    var terminatorName : string = ""
-    var countPred : Expression?
-    {
-        let lastName = calls.back()._1.name
-        let lastArgs = calls.back()._0.arguments |> length
-        // 1-arg `sum` only (no count/long_count overload here yet); count(p) / long_count(p) Theme 4 mirror of plan_distinct — dedup UNCONDITIONAL (distinct_by FIRST-per-key semantics); separate `acc` counter increments only when p matches that first occurrence. Wrapping dedup in `if(p)` would diverge from tier-2 when a later duplicate matches but the first didn't.
-        if ((lastName == "count" || lastName == "long_count" || lastName == "sum") && lastArgs == 1) {
-            terminatorName = lastName
-            calls |> pop
-        } elif ((lastName == "count" || lastName == "long_count") && lastArgs == 2) {
-            countPred = calls.back()._0.arguments[1]
-            if (countPred == null) return null
-            terminatorName = lastName
-            calls |> pop
-        }
-    }
-    if (empty(calls)) return null
+    collapse_chained_wheres(calls)
     let at = calls[0]._0.at
-    let tupName     = qn("decs_tup", at)
-    let bufName     = qn("decs_buf", at)
-    let seenName    = qn("decs_seen", at)
-    let keyName     = qn("decs_k", at)
-    let takenName   = qn("decs_taken", at)
-    let takeLimName = qn("decs_takeLim", at)
-    let accName     = qn("decs_acc", at)
-    let pvName      = qn("decs_pv", at)
-    var whereCond : Expression?
-    var projection : Expression?
-    var hasDistinct = false
-    var seenSelect = false
-    var isDistinctBy = false
-    var distinctKeyBlock : Expression?
-    var takeExpr : Expression?
-    for (i in 0 .. length(calls)) {
-        var cll & = unsafe(calls[i])
-        let name = cll._1.name
-        if (name == "where_") {
-            if (hasDistinct || seenSelect) return null
-            var pred = peel_lambda_rename_var(cll._0.arguments[1], tupName)
-            if (pred == null) return null
-            whereCond = merge_where_cond(whereCond, pred)
-        } elif (name == "select") {
-            if (hasDistinct || seenSelect) return null
-            seenSelect = true
-            projection = peel_lambda_rename_var(cll._0.arguments[1], tupName)
-            if (projection == null) return null
-        } elif (name == "distinct") {
-            if (hasDistinct) return null
-            hasDistinct = true
-        } elif (name == "distinct_by") {
-            if (hasDistinct) return null
-            hasDistinct = true
-            isDistinctBy = true
-            distinctKeyBlock = clone_expression(cll._0.arguments[1])
-        } elif (name == "take") {
-            if (!hasDistinct || takeExpr != null) return null
-            var arg = cll._0.arguments[1]
-            if (arg == null || arg._type == null || arg._type.baseType != Type.tInt) return null
-            takeExpr = clone_expression(arg)
-        } else {
-            return null
+    let tupName = qn("decs_tup", at)
+    let exprIsIter = expr._type.isIterator
+    for (p in plan_distinct_patterns) {
+        var r <- match_pattern(p, calls, top)
+        if (r is matched) {
+            var ctx = EmitCtx(top = null, src = SourceAdapter(Decs = (bridge, tupName)), expr_is_iterator = exprIsIter)
+            var result = invoke(p.emit, r as matched, ctx, at)
+            if (result != null) return result
         }
     }
-    // take(N) only composes with the implicit-to_array terminator. count/sum + take would defeat the streaming early-exit (matches array-side bail at plan_distinct).
-    if (!hasDistinct || (takeExpr != null && terminatorName != "")) return null
-    var elemType = strip_const_ref(clone_type(projection != null ? projection._type : bridge.elementType))
-    let isCountTerminator = terminatorName == "count" || terminatorName == "long_count"
-    let isSumTerminator = terminatorName == "sum"
-    let needBuffer = !isCountTerminator && !isSumTerminator
-    // Prelude: seen-table + (buffer | accumulator | take counter). All hoisted at invoke scope so state spans archetypes.
-    var preludeStmts : array<Expression?>
-    if (isDistinctBy) {
-        preludeStmts |> push <| qmacro_expr() {
-            var inscope $i(seenName) : table<typedecl(_::unique_key(invoke($e(distinctKeyBlock), default<$t(elemType)>)))>
-        }
-    } else {
-        preludeStmts |> push <| qmacro_expr() {
-            var inscope $i(seenName) : table<typedecl(_::unique_key(default<$t(elemType)>))>
-        }
-    }
-    if (needBuffer) {
-        preludeStmts |> push <| qmacro_expr() {
-            var $i(bufName) : array<$t(elemType)>
-        }
-    } elif (isSumTerminator) {
-        preludeStmts |> push <| qmacro_expr() {
-            var $i(accName) : $t(elemType) = default<$t(elemType)>
-        }
-    } elif (countPred != null && terminatorName == "count") {
-        preludeStmts |> push <| qmacro_expr() {
-            var $i(accName) = 0
-        }
-    } elif (countPred != null && terminatorName == "long_count") {
-        preludeStmts |> push <| qmacro_expr() {
-            var $i(accName) = 0l
-        }
-    }
-    if (takeExpr != null) {
-        // Bind take(N) limit once at outer scope so a side-effecting arg fires once (matches plan_distinct).
-        preludeStmts |> push_from <| qmacro_block_to_array() {
-            let $i(takeLimName) = $e(takeExpr)
-            var $i(takenName) = 0
-        }
-    }
-    // Bind side-effecting projection once per element; key + buffer/acc share the bind (matches array-side single-eval per source elem).
-    let bindProjection = projection != null && has_sideeffects(projection)
-    var pushExpr : Expression?
-    if (projection != null) {
-        if (bindProjection) {
-            pushExpr = qmacro_expr() {
-                $i(pvName)
-            }
-        } else {
-            pushExpr = clone_expression(projection)
-        }
-    } else {
-        pushExpr = qmacro_expr() {
-            $i(tupName)
-        }
-    }
-    var keyExpr : Expression?
-    if (isDistinctBy) {
-        keyExpr = peel_lambda_replace_var(distinctKeyBlock, pushExpr)
-    } else {
-        keyExpr = clone_expression(pushExpr)
-    }
-    // count(p) / long_count(p): peel against pushExpr so the predicate sees the post-projection element (mirror of array-side).
-    if (countPred != null) {
-        countPred = peel_lambda_replace_var(countPred, pushExpr)
-        if (countPred == null) return null
-    }
-    // Per-fresh-key consume: only inside the fresh-key branch. take++ first (matches plan_distinct).
-    var consumeStmts : array<Expression?>
-    if (takeExpr != null) {
-        consumeStmts |> push <| qmacro_expr() {
-            $i(takenName) ++
-        }
-    }
-    consumeStmts |> push <| qmacro_expr() {
-        $i(seenName) |> insert($i(keyName))
-    }
-    if (needBuffer) {
-        consumeStmts |> push <| qmacro_expr() {
-            $i(bufName) |> push_clone($e(pushExpr))
-        }
-    } elif (isSumTerminator) {
-        consumeStmts |> push <| qmacro_expr() {
-            $i(accName) += $e(pushExpr)
-        }
-    }
-    // count(p) / long_count(p) Theme 4 (mirror of plan_distinct): dedup is unconditional; the predicate gates only the matched counter — otherwise `distinct_by(k).count(p)` would diverge from tier-2 when a later duplicate matches p but the first one didn't.
-    if (countPred != null && isCountTerminator) {
-        consumeStmts |> push <| qmacro_expr() {
-            if ($e(countPred)) {
-                $i(accName) ++
-            }
-        }
-    }
-    var consumeBody = stmts_to_expr(consumeStmts)
-    var ifNew : Expression? = qmacro_expr() {
-        if (!$i(seenName) |> key_exists($i(keyName))) {
-            $e(consumeBody)
-        }
-    }
-    var perMatchStmts : array<Expression?>    // nolint:STYLE012 — array-literal-of-qmacro_expr is parse-fragile
-    if (bindProjection) {
-        perMatchStmts |> push <| qmacro_expr() {
-            let $i(pvName) = $e(projection)
-        }
-    }
-    perMatchStmts |> push <| qmacro_expr() {
-        let $i(keyName) = _::unique_key($e(keyExpr))
-    }
-    perMatchStmts |> push(ifNew)
-    var perElement = stmts_to_expr(perMatchStmts)
-    perElement = wrap_with_condition(perElement, whereCond)
-    // Top-of-inner-for take-cap guard: `return true` exits both the inner for AND the archetype-find lambda, propagating the stop across archetypes.
-    if (takeExpr != null) {
-        perElement = qmacro_expr() {
-            {
-                if ($i(takenName) >= $i(takeLimName)) return true
-                $e(perElement)
-            }
-        }
-    }
-    var forExprNode = build_decs_inner_for_pruned(bridge, tupName, perElement, at)
-    let archName = bridge.archName
-    var bodyStmts : array<Expression?>
-    bodyStmts |> reserve(length(preludeStmts) + 2)
-    bodyStmts |> push_from(preludeStmts)
-    if (takeExpr != null) {
-        bodyStmts |> push <| qmacro_expr() {
-            for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
-                $e(forExprNode)
-                return false
-            })
-        }
-    } else {
-        bodyStmts |> push <| qmacro_expr() {
-            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-                $e(forExprNode)
-            })
-        }
-    }
-    var emission : Expression?
-    if (terminatorName == "count") {
-        if (countPred != null) {
-            bodyStmts |> push <| qmacro_expr() {
-                return $i(accName)
-            }
-        } else {
-            bodyStmts |> push <| qmacro_expr() {
-                return length($i(seenName))
-            }
-        }
-        emission = qmacro(invoke($() : int {
-            $b(bodyStmts)
-        }))
-    } elif (terminatorName == "long_count") {
-        if (countPred != null) {
-            bodyStmts |> push <| qmacro_expr() {
-                return $i(accName)
-            }
-        } else {
-            bodyStmts |> push <| qmacro_expr() {
-                return int64(length($i(seenName)))
-            }
-        }
-        emission = qmacro(invoke($() : int64 {
-            $b(bodyStmts)
-        }))
-    } elif (isSumTerminator) {
-        bodyStmts |> push <| qmacro_expr() {
-            return $i(accName)
-        }
-        emission = qmacro(invoke($() : $t(elemType) {
-            $b(bodyStmts)
-        }))
-    } else {
-        bodyStmts |> push <| qmacro_expr() {
-            return <- $i(bufName)
-        }
-        emission = qmacro(invoke($() : array<$t(elemType)> {
-            $b(bodyStmts)
-        }))
-    }
-    return finalize_decs_emission(emission, at, expr._type.isIterator && needBuffer)
+    return null
 }
 
 // ── decs join splice (Session 3 — hashed O(N+M) via collect-on-srcb + probe-on-srca) ───────

--- a/daslib/linq_fold.md
+++ b/daslib/linq_fold.md
@@ -6,8 +6,8 @@ Living document. Update **Status** + **Decision log** as phases ship.
 
 - [x] **PR A** — Foundation + first migrations (plan_reverse, plan_distinct) — branch `bbatkin/linq-fold-patterns-foundation`
 - [x] **PR B1** — KR-1 closure (`collapse_chained_wheres`) + `c_chain` cardinality + `Captures` wrapper struct + `plan_loop_or_count` migration — branch `bbatkin/linq-fold-pattern-table-prb` (PR #2881 merged)
-- [x] **PR B2** — `plan_order_family` migration (4 emit archetypes + 5 rows) + `Captures.single_name` parallel-table extension — branch `bbatkin/linq-fold-pattern-table-prb2`
-- [ ] **PR C** — SourceAdapter + decs mirrors (plan_decs_reverse / _distinct / _order_family / _unroll)
+- [x] **PR B2** — `plan_order_family` migration (4 emit archetypes + 5 rows) + `Captures.single_name` parallel-table extension — branch `bbatkin/linq-fold-pattern-table-prb2` (PR #2883 merged)
+- [x] **PR C** — SourceAdapter widening + 4 decs planner migrations (plan_decs_reverse / _distinct / _order_family / _unroll) — branch `bbatkin/linq-fold-pattern-table-prc`
 - [ ] **PR D** — Group-by + special cases (plan_group_by family, plan_zip, plan_decs_join, reducer-spec data table)
 
 ## Goal
@@ -51,8 +51,8 @@ Visibility follows the rule in **Tests / exports philosophy** below: default `pr
 
 ```das
 variant SourceAdapter {
-    Array        : tuple<Expression?; string>   // (top, srcName) — PR A scope
-    // PR C widens: Decs(DecsBridgeShape), DecsFind(DecsBridgeShape)
+    Array : tuple<Expression?; string>            // (top, srcName) — PR A
+    Decs  : tuple<DecsBridgeShape?; string>       // (bridge, tupName) — PR C
     // PR D widens: Zip(...), DecsJoin(...)
 }
 
@@ -185,7 +185,7 @@ Inline closures (`@@(c, top) => …`) acceptable for one-off pattern-specific ch
 | **A** | 1 — First migrations | `plan_reverse` (5 rows: Ra/Rb/R6/R-2a/R1-R4), `plan_distinct` (2 rows + return-shape switch in emit). Archetypes: `emit_counter_array`, `emit_walk_overwrite_scalar`, `emit_backward_walk`, `emit_buffer_reverse_inplace`, `emit_hashtable_dedup`. **Hard-delete imperative bodies.** | complete |
 | **B1** | 2a — Array core (`plan_loop_or_count`) | `c_chain` cardinality + `Captures` wrapper struct (`single` / `many`) + `slot_chain_of(names, cap)` constructor. `collapse_chained_wheres` pre-pass (KR-1 fix). `plan_loop_or_count` migration (1 row + lane dispatch — preserves existing factoring; head c_chain matches `["where_", "select"]` greedy). | complete |
 | **B2** | 2b — Array core (`plan_order_family`) | `plan_order_family` (5 rows: streaming-min / bounded-heap / order_then_plain_distinct / fused-prefilter / buffer-helper-dispatch). 4 archetypes: `emit_streaming_min`, `emit_bounded_heap`, `emit_fused_prefilter` (reused by row 5), `emit_buffer_helper_dispatch`. Captures gains `single_name` parallel-table to preserve `normalize_order_reverse` LinqCall.name swap. **Hard-delete imperative body.** | complete |
-| **C** | 3 — SourceAdapter + decs mirrors | Widen `SourceAdapter` to multi-variant + methods. Migrate `plan_decs_reverse / _distinct / _order_family / _unroll` — **reuse array-side rows + emit fns** modulo adapter swap. **Hard-delete decs imperative bodies.** | not started |
+| **C** | 3 — SourceAdapter + decs mirrors | Widen `SourceAdapter` to `Array \| Decs`. Add adapter helpers `adapter_bind_name` (it/decs_tup), `adapter_element_type`, `adapter_wrap_source_loop` (Array for-loop vs Decs `for_each_archetype + build_decs_inner_for_pruned`), `adapter_wrap_invoke` (Array source-arg-invoke vs Decs zero-arg-invoke + optional outer `.to_sequence_move()` wrap). Refactor 7 emit fns to consume adapter; `emit_buffer_helper_dispatch` stays Array-only via `array_source` predicate on its row. `emit_loop_or_count_lane` gains a Decs-arm (`emit_loop_or_count_lane_decs`) that reconstructs a calls array from captures + dispatches to existing `emit_decs_*` lane fns (1st-order adapter per D1). Migrate 4 decs planners to thin pattern-table stubs reusing array-side rows; hard-delete ~970 LOC of imperative decs bodies. Preserve PR #2834's `reverse \|> take(N)` skip-into-tail fast path via dedicated `emit_decs_reverse_skip_into_tail` helper. | complete |
 | **D** | 4 — Group-by + special cases | Reconcile `GroupBySourceAdapter` with `SourceAdapter`. `plan_group_by` + `plan_decs_group_by` → thin pattern rows delegating to existing `plan_group_by_core` (which stays as a sub-codegen). `plan_zip` (1-2 rows, possibly `SourceAdapter::Zip`). `plan_decs_join` (1 row, `SourceAdapter::DecsJoin` or special-case emit). Migrate `emit_reducer_branches` 12-arm if/elif into a `ReducerSpec` data table. | not started |
 
 **Net at end: ~-1750 LOC.**
@@ -264,6 +264,40 @@ Per-archetype unit testing via direct calls is impractical anyway: emit fns are 
 ### PR B2 — shipped
 
 **Scope (delivered):** `plan_order_family` migration (5 rows, 4 emit archetypes) — imperative ~543 LOC body deleted. `Captures.single_name` parallel-table extension preserves the post-`normalize_order_reverse` LinqCall.name so emit fns see the swap (the imperative read `cll._1.name` directly; the pattern walker captures `cll._0` whose `.func.name` reflects source, not the swap). `extract_order_captures` helper centralizes state extraction across all 4 archetypes. Row 5 (`order_then_plain_distinct`) reuses `emit_fused_prefilter` with the `distinct_after` capture key.
+
+### PR C — shipped
+
+**Branch:** `bbatkin/linq-fold-pattern-table-prc`
+
+**Scope (delivered):** SourceAdapter widening + 4 decs planner migrations.
+
+**Kernel changes:**
+- `SourceAdapter` gained `Decs : tuple<DecsBridgeShape?; string>` variant alongside `Array`.
+- 4 new adapter helpers: `adapter_bind_name` (returns `qn("it", at)` for Array, `qn("decs_tup", at)` for Decs — drives `build_decs_inner_for_pruned` pruner pattern matching); `adapter_element_type` (returns cloned source element type from `top._type.firstType` or `bridge.elementType`); `adapter_wrap_source_loop` (Array `for(bindName in srcName) { body }` vs Decs `for_each_archetype(...) { build_decs_inner_for_pruned(bridge, tupName, body) }`); `adapter_wrap_invoke` (Array `invoke($(src):type){body}, $e(top)` vs Decs zero-arg `invoke($():retType{body})` + optional outer `.to_sequence_move()` for iter wrap).
+- New predicate `decs_source` (extract_decs_bridge != null) for rows that should only match decs adapter.
+
+**7 emit fns refactored to consume adapter (zero behavior change on Array side):**
+- PR A: `emit_reverse_counter`, `emit_reverse_walk_overwrite_scalar`, `emit_reverse_buffer_inplace`, `emit_hashtable_dedup`
+- PR B2: `emit_streaming_min`, `emit_bounded_heap`, `emit_fused_prefilter`
+- Untouched (stay Array-only via row predicates): `emit_reverse_backward_index_walk`, `emit_reverse_backward_walk_dset_gate` (existing `array_source`), `emit_buffer_helper_dispatch` (PR C added `array_source` to its row per D4)
+
+**`emit_hashtable_dedup` take(N) early-exit per-adapter inline** — Array uses `break` in for-loop; Decs uses `for_each_archetype_find` with bool-return to stop archetype walk (matches imperative plan_decs_distinct).
+
+**`emit_loop_or_count_lane_decs` (~80 LOC dispatch fn):** When `ctx.src is Decs`, reconstructs a flatten_linq-shaped `calls` array from captures (head + range ops in canonical order + term), runs `extract_decs_ranges` + `compute_decs_chain_info` (the existing helpers plan_decs_unroll imperative used), classifies the terminator (separate isAccum / isEarlyExit / isMinMaxBy / isWalk / isElementAt — decs has dedicated lane fns for the last three), then dispatches to existing `emit_decs_*` lane fns unchanged. Per D1, state-hoist-above-for_each_archetype shape stays per-adapter; 4 array-side lane fns untouched.
+
+**Decs-only fast path preserved:** `emit_decs_count_archsize` invoked as a pre-check inside `emit_loop_or_count_lane_decs` when chain is bare `count()`. PR #2834's `reverse |> take(N) |> to_array` skip-into-tail (2-pass walk: arch.size sum + for_each_archetype_find with whole-arch-skip + partial-arch skip-counter + early-exit) lifted into dedicated `emit_decs_reverse_skip_into_tail` helper that `emit_reverse_buffer_inplace` pre-checks. Preserves the 5.2× perf gain.
+
+**4 decs planners are now thin pattern-table stubs:**
+- `plan_decs_unroll` → `plan_loop_or_count_patterns`
+- `plan_decs_order_family` → `plan_order_family_patterns` (Row 4 `buffer_helper_dispatch` array-only via `array_source`; decs cascades to Row 3 `fused_prefilter`)
+- `plan_decs_reverse` → `plan_reverse_patterns` (backward-index rows already array-only via `array_source`)
+- `plan_decs_distinct` → `plan_distinct_patterns`
+
+Each stub runs the standard pre-passes (`normalize_order_reverse` for reverse + order_family, `collapse_chained_selects`, `collapse_chained_wheres`), then walks its plan table with a Decs adapter. **Hard-deleted ~970 LOC of imperative decs bodies; ~210 LOC of new helpers/stubs/test fixes = -681 LOC net.**
+
+**Parity coverage:** all 198 tests in `tests/linq/test_linq_from_decs.das` pass (after updating 6 splice-shape assertions to the unified naming: `decs_buf` → `order_buf` for order paths / `` `buf `` for distinct paths, `decs_seen` → `order_seen` / `` `seen ``, etc.). Per-archetype decs test files (Step 6 in original plan) deferred — `test_linq_from_decs.das` already provides comprehensive AST-shape + behavioral coverage across all 4 planners.
+
+**Parity GAINS via reuse** (closed for free): `take |> where` on decs unroll (`post_take_where` slot), `order |> distinct |> first` on decs (cascades to `emit_fused_prefilter`), `distinct.count(p)` parity (already mirrored). **Parity GAP deferred (D6):** `reverse |> distinct[_by]` on decs needs a parallel emit fn (decs has no random-access indexing for the backward-walk dset gate); cascades to tier-2 today.
 
 ### Pre-pass (PR B1 ✓)
 
@@ -458,13 +492,22 @@ The imperative code has a few subtle co-occurrence rules that may not map cleanl
 - **2026-05-26 (PR B2)** — `extract_order_captures` helper centralizes captures→state extraction across all 4 emit archetypes. Each archetype starts with `var oc <- extract_order_captures(c, at, itName)` then bails on `!oc.ok` plus path-specific gates. Trade-off vs inlining: helper introduces a struct allocation per call, but emit fns are at compile-time (cost is irrelevant) and the shared extraction kills ~80 LOC of repeated capture-reading boilerplate.
 - **2026-05-26 (PR B2)** — Row 5 (`order_then_plain_distinct`) reuses `emit_fused_prefilter` rather than a 5th dedicated archetype. The runtime behavior is identical: distinct gate per-element push by set-insert on the key, then sort/min/top_n on the prefilter buffer. `extract_order_captures` reads from EITHER `c.single["distinct"]` (Row 4: distinct before order) OR `c.single["distinct_after"]` (Row 5: plain distinct after order) and normalizes both into `oc.distinctName = "distinct"`. distinct_by AFTER order is structurally excluded by the m_literal("distinct") matcher in Row 5 (the position-invariant whole-tuple equality argument only holds for plain distinct).
 - **2026-05-26 (PR B2)** — Pattern row priority order matters: Row 5 (order_then_plain_distinct, c_one on `m_literal("distinct")` after order) must come BEFORE Row 4 (fused_prefilter, c_opt distinct BEFORE order). Otherwise a chain like `[order, distinct, take]` would match Row 4 with no distinct captured (the c_opt distinct slot skips since "distinct" isn't a valid order_family member, then order matches, then take), routing to the no-distinct fused_prefilter path instead of the distinct-gated one. Lint helper `chain_prefix_of` doesn't catch this since neither row is a strict prefix of the other; ordering by specificity is a hand-applied discipline.
+- **2026-05-26 (PR C, D1)** — 1st-order adapter (source-loop swap only), NOT 2nd-order (state-location swap). `emit_loop_or_count_lane` gains a Decs-arm at the top (`emit_loop_or_count_lane_decs`) that dispatches the terminator class to existing `emit_decs_*` lane fns. The 4 array-side lane fns (`emit_counter_lane` / `emit_array_lane` / `emit_accumulator_lane` / `emit_early_exit_lane`) stay UNTOUCHED. Why: array binds source as invoke arg, decs hoists state above for_each_archetype (zero-arg invoke) — these invoke shapes diverge fundamentally. Unifying state location would require deep surgery on PR B1 code with high risk. Pattern recognition unifies (one row table, one terminator dispatch); state-hoisting stays per-adapter. Clean separation, minimal disruption.
+- **2026-05-26 (PR C, D2)** — `array_source` predicate stays semantically unchanged: reads `top._type.isGoodArrayType || top._type.isArray`. For decs sources, `top` is `from_decs_template(...)` (iterator-typed), so `array_source` correctly returns false without semantic shift. Parallel `decs_source` predicate added for rows that should only match Decs adapter.
+- **2026-05-26 (PR C, D3)** — Bind name is a SourceAdapter responsibility. Every emit fn hardcoded `let itName = qn("it", at)` for lambda peeling. For decs, peeling must target `qn("decs_tup", at)` so `build_decs_inner_for_pruned`'s pruner can fire on `tupName.<field>` access patterns. New helper `adapter_bind_name(adapter, at)` returns the right name per adapter; threaded into every `peel_lambda_rename_var` / `peel_lambda_replace_var` / `merge_where_cond` callsite across the 7 refactored emit fns.
+- **2026-05-26 (PR C, D4)** — Row 4 (`buffer_helper_dispatch`) on `plan_order_family_patterns` gated with `array_source` predicate. `emit_buffer_helper_dispatch` calls daslib helpers like `order(top, key)` / `top_n*(top, N)` that need a `top` expression; Decs has no `top`, so decs adapter cascades to Row 3 (`fused_prefilter`) which materializes the buffer. Matches what the imperative decs body did for these shapes anyway.
+- **2026-05-26 (PR C, D5)** — Decs-only fast paths added as pre-checks. `emit_decs_count_archsize` fires as a pre-check inside `emit_loop_or_count_lane_decs` when chain is bare `count()` (no chain head, no range ops). PR #2834's `reverse |> take(N) |> to_array` skip-into-tail (2-pass walk: arch.size sum + for_each_archetype_find with whole-arch-skip + partial-arch skip-counter + early-exit) lifted into a dedicated `emit_decs_reverse_skip_into_tail` helper that `emit_reverse_buffer_inplace` pre-checks before the general buffer path. Preserves the 5.2× perf gain.
+- **2026-05-26 (PR C, D6)** — `reverse |> distinct[_by]` on decs sources deferred to a future PR. The array-side R-2a row (`emit_reverse_backward_walk_dset_gate`) uses backward index walk — requires random access; decs has none. Building a parallel decs emit fn is genuine new work (not adapter swap). For now decs cascades to tier-2 for this shape (matches today's behavior — no regression).
+- **2026-05-26 (PR C impl)** — `emit_hashtable_dedup`'s take(N) early-exit case stays per-adapter inline (Array uses `break` in for-loop; Decs uses `for_each_archetype_find` returning bool to stop archetype walk). Genuine shape divergence — the array's `break` exits the inner-for; the decs `for_each_archetype_find` semantically returns bool from the archetype lambda. Inlining a per-adapter branch is cleaner than adding a `wrap_source_loop_with_stop` variant of the adapter helper. Non-take case uses `adapter_wrap_source_loop` uniformly.
+- **2026-05-26 (PR C impl)** — `emit_loop_or_count_lane_decs` reconstructs a `calls`-shaped array from captures (head + range ops in canonical order + term) so existing `extract_decs_ranges` + `compute_decs_chain_info` helpers run unchanged. LinqCall records pulled from `linqCalls` registry via `addr(linqCalls?[name] ?? default<LinqCall>)` — matches `flatten_linq`'s pattern for ref→pointer conversion.
+- **2026-05-26 (PR C impl)** — Step 6 (4 new per-archetype `tests/linq/test_linq_fold_decs_*.das` files) was deferred. Existing `tests/linq/test_linq_from_decs.das` carries 198 tests across all 4 decs planners (reverse / distinct / order_family / unroll) with both AST-shape splice assertions AND end-to-end behavioral coverage. The unified emit fns are themselves tested through 6 existing themes (1–8) + `test_linq_fold_order_family.das` (12 tests) on the Array side. Adding 4 new files would mostly duplicate existing coverage. Verification of decs migration parity: all 198 `test_linq_from_decs.das` tests pass after migration (6 splice-shape assertions updated to unified naming).
 
 ## Open questions
 
 - **Prefix-conflict lint pass** — in PR A scope or deferred? Lean PR A so it grows with the table.
 - **`plan_zip` / `plan_decs_join` SourceAdapter shape** — defer until PR D scoping. They feel special-case.
 - **Reducer-spec data table** — exact shape (miss/hit template per row) — design during PR D.
-- **`SourceAdapter` method surface** — `wrap_per_element(body, allows_early_exit)` is the minimal contract. Whether `finalize(stmts, retType)` belongs on the adapter or stays as a separate `finalize_*_emission` family — decide during PR C.
+- **`SourceAdapter` method surface** — answered in PR C. The minimal contract turned out to be 4 helpers (`adapter_bind_name`, `adapter_element_type`, `adapter_wrap_source_loop`, `adapter_wrap_invoke`), not a method-on-variant pattern. `finalize_emission_stmts` / `finalize_decs_emission` semantics merged into `adapter_wrap_invoke`. The take(N) early-exit case stayed per-adapter inline rather than via a `wrap_source_loop_with_stop` extension — only emit_hashtable_dedup needed it in PR C, so factoring a helper was premature.
 
 ## See also
 

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -212,6 +212,34 @@ Every array pattern above has a decs mirror that walks each archetype
 of ``T``'s template instead of iterating the array. The body shape is
 identical — only the source iteration changes.
 
+.. note::
+
+   As of PR C, the four ``plan_decs_*`` planners (``_reverse`` /
+   ``_distinct`` / ``_order_family`` / ``_unroll``) are thin pattern-table
+   stubs that reuse the same pattern rows as their array-side siblings
+   (``plan_reverse_patterns`` / ``plan_distinct_patterns`` /
+   ``plan_order_family_patterns`` / ``plan_loop_or_count_patterns``)
+   with a ``SourceAdapter::Decs`` adapter swap. The 7 array-side emit
+   archetypes consume the adapter (``adapter_bind_name`` selects
+   ``it`` vs ``decs_tup`` for lambda peeling; ``adapter_wrap_source_loop``
+   dispatches ``for (it in src)`` vs ``for_each_archetype + build_decs_inner_for_pruned``;
+   ``adapter_wrap_invoke`` dispatches the outer invoke wrap). For
+   ``plan_decs_unroll`` (which feeds ``emit_loop_or_count_lane``), the
+   Decs-arm dispatch (``emit_loop_or_count_lane_decs``) reconstructs a
+   calls array from captures and routes to the existing
+   ``emit_decs_*`` lane fns unchanged (state hoist above
+   ``for_each_archetype`` stays per-adapter; see masterplan D1).
+
+   Two decs-specific fast paths preserved: ``emit_decs_count_archsize``
+   (bare ``count()``) and ``emit_decs_reverse_skip_into_tail``
+   (``reverse |> take(N) |> to_array``). Row 4 of
+   ``plan_order_family_patterns`` (``buffer_helper_dispatch``) is gated
+   to Array adapter via ``array_source`` — decs cascades to Row 3
+   (``fused_prefilter``) which materializes the buffer, matching the
+   imperative decs behavior. ``reverse |> distinct[_by]`` on decs
+   sources cascades to tier-2 (no decs equivalent of the array
+   backward-walk dset gate; deferred per masterplan D6).
+
 .. list-table::
    :header-rows: 1
    :widths: 35 25 40

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -1986,8 +1986,8 @@ def test_unroll5d_order_by_take_splice_shape(t : T?) {
         t |> equal(describe_count(body_expr, "to_sequence"), 0, "order_by+take splice must NOT fall to tier-2 to_sequence (cascade ordering trap)")
         t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype (no eager-bridge wrapping)")
         t |> equal(describe_count(body_expr, "for_each_archetype_find"), 0, "order family uses for_each_archetype (no early-exit needed)")
-        // Buffer hoisted ABOVE for_each_archetype so it survives the archetype walk.
-        t |> success(describe_count(body_expr, "decs_buf") >= 2, "decs_buf declared + populated")
+        // PR C: emit_bounded_heap (unified array+decs) uses `order_buf` instead of decs_buf. Buffer still hoisted above for_each_archetype.
+        t |> success(describe_count(body_expr, "order_buf") >= 2, "order_buf declared + populated")
         // Bounded-heap emit: spliced_push_heap appears twice (fill + replace), spliced_pop_heap once (replace). top_n_by is no longer used.
         t |> equal(describe_count(body_expr, "spliced_push_heap"), 2, "bounded-heap fill + replace each call spliced_push_heap")
         t |> equal(describe_count(body_expr, "spliced_pop_heap"), 1, "bounded-heap replace calls spliced_pop_heap once")
@@ -2011,8 +2011,9 @@ def test_unroll5d_order_by_first_splice_shape(t : T?) {
         // Streaming-min emit: best + seen state vars, no buffer + min_by/top_n.
         t |> equal(describe_count(body_expr, "min_by"), 0, "streaming-min path does NOT call min_by")
         t |> equal(describe_count(body_expr, "top_n_by"), 0, "streaming-min path does NOT call top_n_by")
-        t |> success(describe_count(body_expr, "decs_best") >= 2, "best state var declared + updated")
-        t |> success(describe_count(body_expr, "decs_seen") >= 2, "seen flag declared + updated")
+        // PR C: emit_streaming_min uses `order_best` / `order_seen` (unified array+decs naming).
+        t |> success(describe_count(body_expr, "order_best") >= 2, "order_best state var declared + updated")
+        t |> success(describe_count(body_expr, "order_seen") >= 2, "order_seen flag declared + updated")
         // Empty-source panic guard preserved.
         t |> equal(describe_count(body_expr, "sequence contains no elements"), 1, "panic-on-empty guard for first()")
     }
@@ -2273,8 +2274,9 @@ def test_unroll5c_select_distinct_count_splice_shape(t : T?) {
         t |> equal(describe_count(body_expr, "to_sequence"), 0, "distinct+count splice must NOT fall to tier-2 to_sequence")
         t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype (no _find — no take present)")
         t |> equal(describe_count(body_expr, "for_each_archetype_find"), 0, "no take → no _find")
-        t |> equal(describe_count(body_expr, "decs_buf"), 0, "count terminator elides the buffer")
-        t |> success(describe_count(body_expr, "decs_seen") >= 2, "seen-table declared + queried")
+        // PR C: emit_hashtable_dedup (unified array+decs) uses `buf` / `seen` (drop the `decs_` prefix).
+        t |> equal(describe_count(body_expr, "`buf"), 0, "count terminator elides the buffer")
+        t |> success(describe_count(body_expr, "`seen") >= 2, "seen-table declared + queried")
         t |> equal(describe_count(body_expr, "key_exists"), 1, "single fresh-key check per element")
     }
 }
@@ -2293,9 +2295,10 @@ def test_unroll5c_select_distinct_take_splice_shape(t : T?) {
         t |> equal(describe_count(body_expr, "to_sequence"), 0, "distinct+take splice must NOT fall to tier-2 to_sequence")
         // take present → outer iteration switches to _find so take-cap can stop across archetypes.
         t |> equal(describe_count(body_expr, "for_each_archetype_find"), 1, "take present → for_each_archetype_find")
-        t |> success(describe_count(body_expr, "decs_buf") >= 2, "buffer needed for to_array terminator")
-        t |> success(describe_count(body_expr, "decs_seen") >= 2, "seen-table declared + queried")
-        t |> success(describe_count(body_expr, "decs_taken") >= 2, "taken counter declared + incremented")
+        // PR C: emit_hashtable_dedup (unified array+decs) uses `buf` / `seen` / `taken`.
+        t |> success(describe_count(body_expr, "`buf") >= 2, "buffer needed for to_array terminator")
+        t |> success(describe_count(body_expr, "`seen") >= 2, "seen-table declared + queried")
+        t |> success(describe_count(body_expr, "`taken") >= 2, "taken counter declared + incremented")
     }
 }
 
@@ -2331,8 +2334,9 @@ def test_unroll5c_select_distinct_sum_splice_shape(t : T?) {
         t |> success(r.matched, "qmatch must capture body")
         t |> equal(describe_count(body_expr, "to_sequence"), 0, "distinct+sum splice must NOT fall to tier-2")
         t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "no take → plain for_each_archetype")
-        t |> equal(describe_count(body_expr, "decs_buf"), 0, "sum terminator elides the buffer")
-        t |> success(describe_count(body_expr, "decs_acc") >= 2, "accumulator declared + folded")
+        // PR C: emit_hashtable_dedup (unified array+decs) uses `buf` / `acc`.
+        t |> equal(describe_count(body_expr, "`buf"), 0, "sum terminator elides the buffer")
+        t |> success(describe_count(body_expr, "`acc") >= 2, "accumulator declared + folded")
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of the linq_fold pattern-table refactor (see [`daslib/linq_fold.md`](daslib/linq_fold.md) — PRs A/B1/B2 already merged as #2878/#2881/#2883).

- **SourceAdapter widened** to `Array | Decs`. Four new adapter helpers (`adapter_bind_name`, `adapter_element_type`, `adapter_wrap_source_loop`, `adapter_wrap_invoke`) abstract the source-loop and invoke-wrap shape so emit fns work for both adapters.
- **7 emit fns refactored** to consume the adapter — zero behavior change on Array side; Decs side picks up the unified emit fns.
- **4 imperative decs planners** (`plan_decs_reverse` / `_distinct` / `_order_family` / `_unroll`, ~970 LOC) replaced with thin pattern-table stubs that reuse the existing array-side rows.
- **Decs-arm dispatch in `emit_loop_or_count_lane`** (new `emit_loop_or_count_lane_decs`) reconstructs a calls array from captures and routes to the existing `emit_decs_*` lane fns — D1: 1st-order adapter, lane fns untouched (state-hoist-above-`for_each_archetype` shape stays per-adapter).
- **Decs-specific fast paths preserved**: `emit_decs_count_archsize` (bare `count()`) and PR #2834's `reverse |> take(N) |> to_array` skip-into-tail (lifted into a dedicated `emit_decs_reverse_skip_into_tail` helper).
- **Row 4 of `plan_order_family_patterns`** (`buffer_helper_dispatch`) gated to Array via `array_source` predicate; Decs cascades to Row 3 (`fused_prefilter`) which materializes — matches the imperative decs behavior.

**Net: −610 LOC of production code.** Pure refactor — runtime semantics preserved across all 198 tests in `tests/linq/test_linq_from_decs.das`. 6 splice-shape AST assertions updated to the unified naming (`decs_buf` → `order_buf` / `` `buf ``, `decs_seen` → `order_seen` / `` `seen ``, etc.).

**Deferred (D6):** `reverse |> distinct[_by]` on decs sources cascades to tier-2 — array R-2a row uses backward index walk (random access), decs has none. Future small PR.

Masterplan + decision log + [`linq_fold_patterns.rst`](doc/source/reference/linq_fold_patterns.rst) refreshed.

## Test plan

- [ ] `mcp__daslang__lint daslib/linq_fold.das` — clean (verified)
- [ ] `mcp__daslang__compile_check daslib/linq_fold.das` — clean (verified)
- [ ] `tests/linq/test_linq_from_decs.das` (198 tests — covers all 4 migrated decs planners)
- [ ] `tests/linq/test_linq_fold.das` (385), `test_linq_fold_ast.das` (228)
- [ ] `test_linq_fold_order_family` (12), `test_linq_fold_loop_or_count` (22), `test_linq_fold_terminal_select` (28), `test_linq_fold_iterator_wrap` (34)
- [ ] `test_linq_fold_pattern_walker` (16), `test_linq_fold_collapse_chained_wheres` (18)
- [ ] Themes 2/3/6/7/8 — all green
- [ ] `tests/decs/test_queries`, `test_queries_comprehensive` — green (parity for decs core)
- [ ] Full CI matrix on push (INTERP + AOT + JIT modulo documented 27 master JIT-quote regressions)
- [ ] Bench refresh deferred — pure refactor; will revisit post-merge if any bench shows regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)