### PR TITLE
with_boost: hygienic names + finally preservation + void return pin

### DIFF
--- a/daslib/with_boost.das
+++ b/daslib/with_boost.das
@@ -83,6 +83,8 @@ class private WithMacro : AstCallMacro {
             let aiNode = ai as ExprAt
             macro_verify(aiNode.subexpr._type != null, prog, call.at,
                 "with_ arg #{i} container type not inferred yet — got null _type on {describe(aiNode.subexpr)}")
+            macro_verify(ai._type != null, prog, call.at,
+                "with_ arg #{i} element type not inferred yet — got null _type on the ExprAt itself")
             let ki = container_kind(aiNode)
             macro_verify(ki != "", prog, call.at,
                 "with_ arg #{i} container must be array or table, got {describe(aiNode.subexpr._type)}")
@@ -123,6 +125,12 @@ class private WithMacro : AstCallMacro {
             for (st in userBlock.list) {
                 newBlock.list |> emplace_new(clone_expression(st))
             }
+            // Preserve any user-attached `finally { ... }` on the default-_ form
+            // so its semantics match the explicit-params path (which clones the
+            // whole block via clone_expression).
+            for (st in userBlock.finalList) {
+                newBlock.finalList |> emplace_new(clone_expression(st))
+            }
             rewrittenBlock = new ExprMakeBlock(at = call.at, _block = newBlock)
             rewrittenInner = newBlock
         } else {
@@ -130,6 +138,11 @@ class private WithMacro : AstCallMacro {
                 "with_ block-param count must match container-arg count: {containerCount} containers, {userArgCount} block params")
             rewrittenBlock = clone_expression(mblk) as ExprMakeBlock
             rewrittenInner = rewrittenBlock._block as ExprBlock
+            // Pin the block to `: void` so a stray `return value` in the user
+            // body is rejected by the typer. The userArgCount==0 branch
+            // already constructs newBlock with void returnType; we do the
+            // same here so behavior matches across both shapes.
+            rewrittenInner.returnType = new TypeDecl(at = userBlock.at, baseType = Type.tVoid)
             for (i in range(containerCount)) {
                 var arg = rewrittenInner.arguments[i]
                 arg._type = clone_type(call.arguments[i]._type)
@@ -163,7 +176,9 @@ class private WithMacro : AstCallMacro {
         for (i in range(containerCount)) {
             let ai = call.arguments[i] as ExprAt
             let ki = container_kind(ai)
-            let cName = "__with_c_{i}"
+            // Hygienic names — make_unique_private_name guarantees no
+            // collision with user-visible identifiers at this call site.
+            let cName = make_unique_private_name("__with_c_{i}", call.at)
             preStmts |> push <| qmacro_expr() {
                 var $i(cName) & = unsafe($e(ai.subexpr))
             }
@@ -176,7 +191,7 @@ class private WithMacro : AstCallMacro {
                 }
                 argRefs |> push <| qmacro($i(cName)[$e(ai.index)])
             } else {  // table
-                let trefName = "__with_tref_{i}"
+                let trefName = make_unique_private_name("__with_tref_{i}", call.at)
                 preStmts |> push <| qmacro_expr() {
                     var $i(trefName) & = unsafe($i(cName)[$e(ai.index)])
                 }

--- a/doc/source/reference/tutorials/macros/18_with_boost.rst
+++ b/doc/source/reference/tutorials/macros/18_with_boost.rst
@@ -109,9 +109,11 @@ Section 4 — Tables
 ===================
 
 Tables work the same way; ``tab[key]`` upserts (creates a default entry
-if the key is missing). Only **one** table-keyed arg per call — any
-second insert into a table during the body would rehash and invalidate
-the pinned entry, so the macro refuses anything past the first:
+if the key is missing). Only **one** table-keyed arg per call — a 2nd
+upsert into the SAME table during the body would rehash and invalidate
+the first pinned entry. The macro can't prove two table-keyed args refer
+to distinct tables, so the rule is conservative: even
+``with_(tab1[k1], tab2[k2])`` (distinct tables) is refused:
 
 .. code-block:: das
 
@@ -132,7 +134,7 @@ the failure mode the typer was trying to prevent at compile time:
 
    var arr = [A(f1 = 1, f2 = 2)]
    with_(arr[0]) $(a) {
-       arr |> push(A(f1 = 1000, f2 = 2000))   // panics: "can't push into locked array"
+       arr |> push(A(f1 = 1000, f2 = 2000))   // panics — array is locked
    }
 
 daslang panic is fatal (not a C++/JS-style exception) — the program

--- a/tests/with_boost/test_with_lock_panics.das
+++ b/tests/with_boost/test_with_lock_panics.das
@@ -1,13 +1,19 @@
 options gen2
 options indenting = 4
+// Block-arg `$(a)` / `$(v)` etc. are present for syntax coverage but
+// the body only exercises the lock-vs-mutation path on the container,
+// not the bound element. Suppress unused-block-arg lint here.
+options no_unused_block_arguments = false
 
 require dastest/testing_boost public
 require daslib/with_boost
 
-//! When the with_ body panics, the lock leaks (daslang issue #2532).
-//! These tests deliberately don't try to ``delete`` the leaked-locked
-//! containers afterwards — that would compound the failure. We only
-//! verify the panic is caught at the with_ boundary.
+//! When the with_ body panics inside the macro's invoke target, the
+//! lock is intentionally not released (daslang panic is fatal — see
+//! CLAUDE.md "Panic is fatal, not an exception"). These tests
+//! deliberately don't try to ``delete`` the leaked-locked containers
+//! afterwards — that would compound the failure. We only verify the
+//! panic is caught at the with_ boundary via try/recover.
 
 struct A {
     f1 : int

--- a/tutorials/macros/18_with_boost.das
+++ b/tutorials/macros/18_with_boost.das
@@ -99,9 +99,11 @@ def main {
     // ──────────────────────────────────────────────────────────────────
     //
     // Tables work the same way; `tab[key]` upserts (creates a default
-    // entry if missing). At most ONE table-keyed arg per call (any
-    // second insert into the same table would rehash and invalidate
-    // the pinned entry).
+    // entry if missing). At most ONE table-keyed arg per call — the
+    // macro can't prove two table-keyed args refer to distinct tables,
+    // and a 2nd upsert into the SAME table would rehash and invalidate
+    // the first pinned entry. The rule is conservative across the board
+    // (no alias analysis), so `with_(tab1[k1], tab2[k2])` is also refused.
 
     var tab : table<string; A>
     tab |> insert("k", A(f1 = 11, f2 = 22))


### PR DESCRIPTION
Follow-up cleanup on top of #2880. Four small fixes plus matching doc/test prose:

1. **Hygienic generated names.** Replace hardcoded `__with_c_{i}` / `__with_tref_{i}` with `make_unique_private_name(..., call.at)` so a user identifier named `__with_c_0` at the same scope can't collide with the macro's expansion.

2. **Preserve `finally { ... }` on the default-`_` form.** The explicit-params path already cloned the whole `ExprMakeBlock` via `clone_expression`, but the default-`_` path rebuilt the block from scratch by copying `userBlock.list` and dropping `userBlock.finalList`. Both paths now copy the final-list too.

3. **Pin the explicit-params block to `: void`.** The default-`_` path already constructs `newBlock` with void returnType; the explicit-params path inherited whatever the user wrote, so `with_(arr[0]) $(a) { return 42 }` typed differently on each path. Pin to void on both so a stray `return X` in the body is rejected at the typer level on either shape.

4. **Extra `macro_verify` for `ExprAt._type` null.** Previously segfaulted when the `ExprAt` itself had null `_type` (not just `subexpr._type`); now produces a clean diagnostic.

**Doc/test prose** also updated: the table-rule explanation reads as a conservative rule (the macro can't prove two table-keyed args refer to distinct tables) rather than implying "more than one insert" semantics. Drop the stale issue-#2532 attribution from the panic-test docstring — that issue was closed not-planned 2026-05-25 since panic-is-fatal is by design (see CLAUDE.md "Panic is fatal, not an exception").

## Test plan
- [x] `tests/with_boost/` — 31/31 pass (covers default-`_`, explicit-params, lock-panic, n-arg, table, workhorse, and the failure-mode `failed_with_*` set)
- [x] `tutorials/macros/18_with_boost.das` runs clean
- [x] Lint: 0 issues, 0 errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
