### PR TITLE
class_super: CFG-aware super(...) lint + reject super-skip-intermediate

### DIFF
--- a/doc/source/reference/language/classes.rst
+++ b/doc/source/reference/language/classes.rst
@@ -169,7 +169,17 @@ up the inheritance chain to the nearest ancestor that does:
 
 Walk-up matches by argument types, so overloaded ``super(args)`` calls pick the closest
 ancestor whose constructor or method accepts those arguments. If no ancestor matches, the
-call is rejected at compile time.
+call is rejected at compile time. The walk-up may only step past a class that has no
+user-defined constructor (or method, in the case of ``super.method()``); attempting to
+skip a class whose user constructor (or method) would otherwise establish invariants is
+rejected — call the immediate parent and let it chain via its own ``super()``.
+
+Every constructor in a derived class whose parent has a user-defined constructor must call
+``super(...)`` exactly once on every control-flow path. The lint is unconditional:
+
+* zero ``super(...)`` calls on any reachable path → error;
+* two or more ``super(...)`` calls on any path → error;
+* ``super(...)`` inside a loop body → error (call count is not bounded to one).
 
 Inside a derived class's finalizer (``operator delete``), ``delete super.self`` runs the
 parent's finalizer on the current object:
@@ -196,9 +206,6 @@ functions — see :ref:`Structs <structs>`.
 
 Base-class finalization is explicit, not automatic: a derived finalizer that omits
 ``delete super.self`` will not run any ancestor finalizer.
-
-The option ``always_call_super`` can be enabled to require ``super()`` in every constructor
-(see :ref:`Options <options>`).
 
 Alternatively, the parent's method can be called directly using the backtick syntax:
 

--- a/doc/source/reference/language/options.rst
+++ b/doc/source/reference/language/options.rst
@@ -92,10 +92,6 @@ Lint Control
      - bool
      - true
      - Disallows writing to nameless (intermediate) variables on the stack.
-   * - ``always_call_super``
-     - bool
-     - false
-     - Requires ``super()`` to be called in every class constructor.
    * - ``no_unused_function_arguments``
      - bool
      - false

--- a/doc/source/reference/tutorials/18_classes.rst
+++ b/doc/source/reference/tutorials/18_classes.rst
@@ -75,6 +75,67 @@ bypassing virtual dispatch::
 The compiler rewrites ``super()`` to ``Parent`Constructor(self, ...)`` and
 ``super.method()`` to ``Parent`method(self, ...)``.
 
+``super(...)`` is required exactly once per path
+================================================
+
+Every constructor in a derived class whose parent has a user-defined constructor
+must call ``super(...)`` exactly once on every control-flow path. The lint catches:
+
+::
+
+  class Bad : Base {
+      def Bad(f : bool) {
+          if (f) {
+              super()   // ERROR: false branch has zero super() calls
+          }
+      }
+  }
+
+  class AlsoBad : Base {
+      def AlsoBad {
+          super()
+          super()       // ERROR: super() called more than once
+      }
+  }
+
+A call to ``super(...)`` inside a loop is also rejected — the count is not
+bounded to one. To branch on arguments, both branches must call ``super(...)``::
+
+  class OK : Shape {
+      def OK(big : bool) {
+          if (big) {
+              super("Big")
+          } else {
+              super("Small")
+          }
+      }
+  }
+
+``super.X()`` cannot skip an intermediate
+=========================================
+
+``super.X()`` (whether ``X`` is a method or the name of an ancestor class) may
+walk past only intermediate classes that have **no** user-defined constructor or
+matching method. Skipping a class whose user code would otherwise establish
+invariants is rejected. Empty intermediates are still legal::
+
+  class A {
+      def A { /* ... */ }
+  }
+
+  class B : A {
+      def B { super() }     // B has its own ctor
+  }
+
+  class C : B {
+      def C {
+          super.A()         // ERROR: would silently skip B's invariants
+      }
+  }
+
+If you really want only ``A``'s setup, name the immediate parent:
+``super.B()`` (or ``super()``) and let ``B``'s constructor chain to ``A`` itself.
+
 Creating instances
 ==================
 

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1567,7 +1567,6 @@ namespace das
         /*option*/ bool no_unsafe_uninitialized_structures = true; // if true, then unsafe uninitialized structures are not allowed
         /*option*/ bool strict_properties = false;                 // if true, then properties are strict, i.e. a.prop = b does not get promoted to a.prop := b
         /*option*/ bool no_writing_to_nameless = true;             // if true, then writing to nameless variables (intermediate on the stack) is not allowed
-        /*option*/ bool always_call_super = false;                  // if true, then super() needs to be called from every class constructor
     // environment
         /*option*/ bool no_optimizations = false;                  // disable optimizations, regardless of settings
         /*option*/ bool no_infer_time_folding = false;             // disable infer-time constant folding

--- a/modules/dasClangBind/bind/bind_bgfx.das
+++ b/modules/dasClangBind/bind/bind_bgfx.das
@@ -29,8 +29,7 @@ class BgfxGen : CppGenBind {
             "-I{get_full_file_name(inc_bx)}"
         )
         func_per_chunk = 20
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
         init_skip()
         openAllFiles()
     }
@@ -49,10 +48,7 @@ class BgfxGen : CppGenBind {
         }
     }
     def override skip_const(name : string) : bool {
-        if (name |> starts_with("GL_")) {
-            return true
-        }
-        return false
+        return name |> starts_with("GL_")
     }
     def override skip_struct(name : string) {
         return bgfx_skip_struct |> key_exists(name)

--- a/modules/dasClangBind/bind/bind_clangbind.das
+++ b/modules/dasClangBind/bind/bind_clangbind.das
@@ -19,8 +19,7 @@ class ClangGen : CppGenBind {
             "-DCINDEX_EXPORTS"
         )
         func_per_chunk = 20
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
         init_enum_prefix()
         openAllFiles()
     }
@@ -70,15 +69,7 @@ class ClangGen : CppGenBind {
         return true
     }
     def override skip_file(fname : string) : bool {
-        if (fname |> ends_with("CXErrorCode.h")) {
-            return false
-        } elif (fname |> ends_with("CXString.h")) {
-            return false
-        } elif (fname |> ends_with("CXDiagnostic.h")) {
-            return false
-        } elif (fname |> ends_with("CXFile.h")) {
-            return false
-        } elif (fname |> ends_with("CXSourceLocation.h")) {
+        if (fname |> ends_with("CXErrorCode.h") || fname |> ends_with("CXString.h") || fname |> ends_with("CXDiagnostic.h") || fname |> ends_with("CXFile.h") || fname |> ends_with("CXSourceLocation.h")) {
             return false
         }
         return !fname |> ends_with(PARSE_FILE_NAME)

--- a/modules/dasClangBind/bind/bind_llvm.das
+++ b/modules/dasClangBind/bind/bind_llvm.das
@@ -94,8 +94,7 @@ class LlvmGen : CppGenBind {
         let pfn = "cb_dasLLVM.h"
         let pfp = "{get_das_root()}/modules/dasLLVM/src/"
         func_per_chunk = 20
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
 //        init_enum_prefix()
         openAllFiles()
     }
@@ -137,7 +136,7 @@ class LlvmGen : CppGenBind {
 
 class LlvmGenDinamic : DasGenBind {
     def LlvmGenDinamic(pfn, pfp : string; args : array<string>) {
-        init_args(pfn, pfp, args)
+        super(pfn, pfp, args)
     }
     def override skip_const(name : string) : bool {
         return name == "true" || name == "false"

--- a/modules/dasClangBind/bind/bind_opengl.das
+++ b/modules/dasClangBind/bind/bind_opengl.das
@@ -8,7 +8,7 @@ require daslib/fio
 class OpenGLBind : DasGenBind {
     def OpenGLBind(pfn, pfp : string) {
         let args <- array<string>("-DGL_GLEXT_PROTOTYPES")
-        init_args(pfn, pfp, args)
+        super(pfn, pfp, args)
         init_defaults()
     }
     def init_defaults {
@@ -19,10 +19,7 @@ class OpenGLBind : DasGenBind {
         }
     }
     def override skip_const(name : string) : bool {
-        if (name == "true" || name == "false") {
-            return true
-        }
-        return false
+        return name == "true" || name == "false"
     }
     def override functionArgumentRules : TypeRules {
         return (
@@ -47,10 +44,10 @@ class OpenGLBind : DasGenBind {
 [export]
 def main {
     let output_name = "{get_das_root()}/modules/dasOpenGL/opengl/opengl_func.das"
-    fopen(output_name, "wb") <| $(fdf) {
+    fopen(output_name, "wb") $(fdf) {
         fprint(fdf, "require dasbind public\n\n")
         let output_const_name = "{get_das_root()}/modules/dasOpenGL/opengl/opengl_const.das"
-        fopen(output_const_name, "wb") <| $(dcf) {
+        fopen(output_const_name, "wb") $(dcf) {
             let pfn = "glcorearb.h"
             let pfp = "{get_das_root()}/modules/dasOpenGL/opengl/OpenGL/"
             var glbind = new OpenGLBind(pfn, pfp)

--- a/modules/dasClangBind/bind/bind_quirrel.das
+++ b/modules/dasClangBind/bind/bind_quirrel.das
@@ -35,8 +35,7 @@ class QuirrelGen : CppGenBind {
             "-DCINDEX_EXPORTS"
         )
         func_per_chunk = 20
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
 //        init_enum_prefix()
         openAllFiles()
         for (h in quirrel_c_headers) {
@@ -58,10 +57,7 @@ class QuirrelGen : CppGenBind {
     }
     def override skip_file(fname : string) : bool {
         let ufname = to_upper(fname)
-        if (!any <| [iterator for(h in quirrel_c_headers); ufname |> ends_with(h)]) {
-            return true
-        }
-        return false
+        return !any <| [iterator for(h in quirrel_c_headers); ufname |> ends_with(h)]
     }
     def override skip_alias(var c : CXCursor) {
         let aliasn = string(clang_getCursorSpelling(c))
@@ -69,19 +65,13 @@ class QuirrelGen : CppGenBind {
             return true
         }
         let aliasf = to_upper(clang_getCursorLocationFileName(c))
-        if (!any <| [iterator for(h in quirrel_c_headers); aliasf |> ends_with(h)]) {
-            return true
-        }
-        return false
+        return !any <| [iterator for(h in quirrel_c_headers); aliasf |> ends_with(h)]
     }
     def override skip_enum(ns_en, en : string) {
         return false
     }
     def override skip_struct(sn : string) {
-        if (sn |> starts_with("__crt")) {
-            return true
-        }
-        return false
+        return sn |> starts_with("__crt")
     }
     def override skip_function(var c : CXCursor) : bool {
     /*
@@ -91,13 +81,7 @@ class QuirrelGen : CppGenBind {
             return true
     */
         let funf = to_upper(clang_getCursorLocationFileName(c))
-        if (!any <| [iterator for(h in quirrel_c_headers); funf |> ends_with(h)]) {
-            return true
-        }
-        if (skip_anyFunction(c, false)) {
-            return true
-        }
-        return false
+        return !any <| [iterator for(h in quirrel_c_headers); funf |> ends_with(h)] || skip_anyFunction(c, false)
     }
 }
 

--- a/modules/dasClangBind/bind/bind_sfml.das
+++ b/modules/dasClangBind/bind/bind_sfml.das
@@ -31,8 +31,7 @@ class SFMLGen : CppGenBind {
             "-I{get_full_file_name(isfml)}"
         )
         func_per_chunk = 100
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
         init_skip()
         openAllFiles()
     }
@@ -84,10 +83,7 @@ class SFMLGen : CppGenBind {
         return false
     }
     def override skip_struct(name : string) {
-        if (name == "HWND__") {
-            return true
-        }
-        return false
+        return name == "HWND__"
     }
 }
 

--- a/modules/dasClangBind/bind/bind_sqlite.das
+++ b/modules/dasClangBind/bind/bind_sqlite.das
@@ -32,8 +32,7 @@ class SqliteGen : CppGenBind {
             "-DCINDEX_EXPORTS"
         )
         func_per_chunk = 20
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
 //        init_enum_prefix()
         openAllFiles()
         for (h in sqlite_c_headers) {
@@ -55,10 +54,7 @@ class SqliteGen : CppGenBind {
     }
     def override skip_file(fname : string) : bool {
         let ufname = to_upper(fname)
-        if (!any <| [iterator for(h in sqlite_c_headers); ufname |> ends_with(h)]) {
-            return true
-        }
-        return false
+        return !any <| [iterator for(h in sqlite_c_headers); ufname |> ends_with(h)]
     }
     def override skip_alias(var c : CXCursor) {
         let tdn = string(clang_getCursorDisplayName(c))
@@ -68,36 +64,21 @@ class SqliteGen : CppGenBind {
             return true
         }
         let aliasf = to_upper(clang_getCursorLocationFileName(c))
-        if (!any <| [iterator for(h in sqlite_c_headers); aliasf |> ends_with(h)]) {
-            return true
-        }
-        return false
+        return !any <| [iterator for(h in sqlite_c_headers); aliasf |> ends_with(h)]
     }
     def override skip_enum(ns_en, en : string) {
         return false
     }
     def override skip_struct(sn : string) {
-        if (sn |> starts_with("__crt")) {
-            return true
-        }
-        return false
+        return sn |> starts_with("__crt")
     }
     def override skip_function(var c : CXCursor) : bool {
         let fname = string(clang_getCursorSpelling(c))
-        if (fname == "sqlite3_mutex_held" || fname == "sqlite3_mutex_notheld") {
-            return true
-        }
-        if (fname |> starts_with("sqlite3_win32_set_directory")) {
+        if (fname == "sqlite3_mutex_held" || fname == "sqlite3_mutex_notheld" || fname |> starts_with("sqlite3_win32_set_directory")) {
             return true
         }
         let funf = to_upper(clang_getCursorLocationFileName(c))
-        if (!any <| [iterator for(h in sqlite_c_headers); funf |> ends_with(h)]) {
-            return true
-        }
-        if (skip_anyFunction(c, false)) {
-            return true
-        }
-        return false
+        return !any <| [iterator for(h in sqlite_c_headers); funf |> ends_with(h)] || skip_anyFunction(c, false)
     }
 }
 

--- a/modules/dasClangBind/bind/bind_xbyak.das
+++ b/modules/dasClangBind/bind/bind_xbyak.das
@@ -25,8 +25,7 @@ class XbyakGen : CppGenBind {
             "-I{get_full_file_name(pfp)}"
         )
         func_per_chunk = 100
-        init_args(pfn, pfp, args)
-        setDefaultFiles()
+        super(pfn, pfp, args)
         init_skip()
         openAllFiles()
     }

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -38,8 +38,8 @@ let CXTranslationUnit_IgnoreNonErrorsFromIncludedFiles = 0x4000
 let CXTranslationUnit_RetainExcludedConditionalBlocks = 0x8000
 
 def describe(var c : CXCursor) {
-    var sp = clang_getCursorSpelling(c)
-    var kd = clang_getCursorKindSpelling(clang_getCursorKind(c))
+    let sp = clang_getCursorSpelling(c)
+    let kd = clang_getCursorKindSpelling(clang_getCursorKind(c))
     return "<{string(sp)}>:`{string(kd)}`"
 }
 
@@ -116,7 +116,7 @@ def clang_typeToDasTypeUnqEx(var t : CXType; topLevel : bool; rules : TypeRules;
             return "\u00BF"
         }
     } elif (t.kind == CXTypeKind.IncompleteArray) {
-        var pt = clang_getCanonicalType(clang_getPointeeType(t))
+        let pt = clang_getCanonicalType(clang_getPointeeType(t))
         return "void?"
     } elif (t.kind == CXTypeKind.Enum) {
         return string(clang_getTypeSpelling(t))
@@ -164,7 +164,7 @@ def clang_getCursorLocationFileName(var c : CXCursor) {
     var file : CXFile
     var line, column, offset : uint
     clang_getSpellingLocation(clang_getCursorLocation(c), safe_addr(file), safe_addr(line), safe_addr(column), safe_addr(offset))
-    var fname = clang_getFileName(file)
+    let fname = clang_getFileName(file)
     return "{string(fname)}"
 }
 
@@ -177,17 +177,11 @@ def clang_isForwardDeclaration(var cursor : CXCursor) {
 }
 
 def clang_das_isRef(var c : CXType) {
-    if (c.kind == CXTypeKind.LValueReference) {
-        return true
-    }
-    return false
+    return c.kind == CXTypeKind.LValueReference
 }
 
 def clang_das_isCopyOnReturn(var c : CXType) {
-    if (c.kind == CXTypeKind.Record) {
-        return true
-    }
-    return false
+    return c.kind == CXTypeKind.Record
 }
 
 let private unsafe_names <- {
@@ -266,7 +260,7 @@ class AnyGenBind {
     }
     // strip the parsed library's header root — paths stay stable across OS and install folder
     def clang_getCursorLocationDescription(var c : CXCursor) : string {
-        var full = clang_getCursorLocationFullPath(c)
+        let full = clang_getCursorLocationFullPath(c)
         if (!empty(PARSE_FILE_PREFIX) && full |> starts_with(PARSE_FILE_PREFIX)) {
             return full |> slice(length(PARSE_FILE_PREFIX))
         }
@@ -280,7 +274,7 @@ class AnyGenBind {
         var unit = clang_parseTranslationUnit(
             index,
             open_file_name(),
-            length(ARGV) == 0 ? null : unsafe(addr(ARGV[0])), length(ARGV),
+            empty(ARGV) ? null : unsafe(addr(ARGV[0])), length(ARGV),
             null, 0u,
             CXTranslationUnit_SkipFunctionBodies)
         if (unit == null) {
@@ -291,7 +285,7 @@ class AnyGenBind {
         let ndiag = clang_getNumDiagnostics(unit)
         for (i in urange(ndiag)) {
             var diag = clang_getDiagnostic(unit, i)
-            var diags = string(clang_formatDiagnostic(diag, clang_defaultDiagnosticDisplayOptions()))
+            let diags = string(clang_formatDiagnostic(diag, clang_defaultDiagnosticDisplayOptions()))
             print("{diags}\n")
         }
         clang_disposeTranslationUnit(unit)
@@ -309,7 +303,7 @@ class AnyGenBind {
         return unsafe_names?[name] ?? name
     }
     def namespace_struct_name(dash : string = "::") : string {
-        return build_string <| $(wr) {
+        return build_string() $(wr) {
             for (n, i in nspaces, count()) {
                 if (i != 0) {
                     wr |> write(dash)
@@ -319,7 +313,7 @@ class AnyGenBind {
         }
     }
     def namespace_name(name : string; dash : string = "::") : string {
-        return build_string <| $(wr) {
+        return build_string() $(wr) {
             for (n in nspaces) {
                 wr |> write(n)
                 wr |> write(dash)
@@ -353,7 +347,7 @@ class AnyGenBind {
             return true
         }
         if (function_name |> starts_with("operator")) {
-            let Ch = character_at(function_name, 8)
+            let Ch = character_at(function_name, 8) // nolint:PERF003
             if (!(is_alpha(Ch) || is_number(Ch) || Ch == '_')) {
                 if (!isMethod) {
                     to_log(LOG_INFO, "skipping global operator {function_name} at {clang_getCursorLocationDescription(c)}\n")
@@ -411,12 +405,7 @@ class AnyGenBind {
             } elif (rname |> starts_with("class ")) {
                 rname = rname |> slice(6)
             }
-            if (skip_struct_by_access |> key_exists(rname)) {
-                return true
-            }
-            if (skip_struct(rname)) {
-                return true
-            }
+            return true if (skip_struct_by_access |> key_exists(rname) || skip_struct(rname))
         }
         return false
     }
@@ -455,12 +444,12 @@ class AnyGenBind {
         return true
     }
     def parse(var cursor : CXCursor) {
-        clang_visitChildren(cursor) <| $(var c, parent) {
+        clang_visitChildren(cursor) $(var c, parent) {
             var file : CXFile
             var line, column, offset : uint
             clang_getSpellingLocation(clang_getCursorLocation(c), safe_addr(file), safe_addr(line), safe_addr(column), safe_addr(offset))
-            var fname = clang_getFileName(file)
-            peek(fname) <| $(fn) {
+            let fname = clang_getFileName(file)
+            peek(fname) $(fn) {
                 if (prevFileName != fn) {
                     prevFileName := fn
                     if (skip_file(prevFileName) && verbose_file_skipping) {
@@ -584,7 +573,7 @@ class AnyGenBind {
                         if (!skip_struct(struct_name)) {
                             let acs = clang_getCXXAccessSpecifier(c)
                             if (acs != CX_CXXAccessSpecifier.Public && acs != CX_CXXAccessSpecifier.InvalidAccessSpecifier) {
-                                var canonical = clang_getCanonicalType(clang_getCursorType(c))
+                                let canonical = clang_getCanonicalType(clang_getCursorType(c))
                                 let sname = string(clang_getTypeSpelling(clang_getCursorType(c)))
                                 to_log(LOG_INFO, "skipping structure {struct_name} aka {sname} due to access specifier {acs}\n")
                                 skip_struct_by_access |> insert(sname)
@@ -667,14 +656,14 @@ class AnyGenBind {
                 */
                 elif (kind == CXCursorKind.CXXBaseSpecifier) {
                     let class_name = back(nspaces)
-                    var tps = string(clang_getTypeSpelling(clang_getCursorType(c)))
+                    let tps = string(clang_getTypeSpelling(clang_getCursorType(c)))
                     var tpq <- split(tps, "::") // TODO: better inheritance?
                     let base_name = back(tpq)
                     delete tpq
                     if (!(lsp |> key_exists(class_name))) {
                         lsp[class_name] = base_name
                     } else {
-                        var acs = clang_getCXXAccessSpecifier(c)
+                        let acs = clang_getCXXAccessSpecifier(c)
                         if (acs == CX_CXXAccessSpecifier.Public) {
                             interfaces[class_name] |> push(base_name)
                         } else {
@@ -699,16 +688,13 @@ class AnyGenBind {
         return false
     }
     def skip_enum(ns_en, en : string) {
-        if (ns_en |> starts_with("(unnamed enum")) {
-            return true
-        }
-        return false
+        return ns_en |> starts_with("(unnamed enum")
     }
     def getGenConstType(name, default_name : string) {
         return const_type_table?[name] ?? default_name
     }
     def searchAndGenConst(var regex_def : Regex; defTName, suffix : string; hex : bool; var ofs : table<int; bool>; data : string; var dup : table<string; bool>) {
-        regex_foreach(regex_def, data) <| $(r) {
+        regex_foreach(regex_def, data) $(r) {
             if (!ofs |> key_exists(r.x)) {
                 let DEF = regex_group(regex_def, 1, data)
                 let VAL = regex_group(regex_def, 2, data)
@@ -748,7 +734,7 @@ class AnyGenBind {
         var reg_def_UINT64 <- %regex~#define\s+(\w+)\s+UINT64_C\s*\((0x[0-9A-Fa-f]+)\)%%
         // for all the files where we need to generate
         for (fname in fnames) {
-            fopen(fname, "rb") <| $(f) {
+            fopen(fname, "rb") $(f) {
                 if (f == null) {
                     panic("can't open {fname}")
                 }
@@ -792,7 +778,7 @@ class DasGenBind : AnyGenBind {
     }
 
     def DasGenBind(pfn, pfp : string; args : array<string>; mod_name : string = "") {
-        init_args(pfn, pfp, args)
+        super(pfn, pfp, args)
         define_const_file = fstdout()
         func_decl_file = fstdout()
         module_name = mod_name
@@ -825,10 +811,7 @@ class DasGenBind : AnyGenBind {
         fprint(func_decl_file, "[extern(name=\"{function_name}\")]\n")
     }
     def override parse_Struct(var c : CXCursor; struct_name : string) {
-        if (struct_class_file == null) {
-            return
-        }
-        return if (struct_name |> starts_with <| "(") // do nothing for anonymous unions/structs
+        return if (struct_class_file == null || struct_name |> starts_with <| "(") // do nothing for anonymous unions/structs
         let struct_namespace_name = namespace_name(struct_name)
         let dashing_name = namespace_name(struct_name, "_")
         fprint(struct_class_file, "struct {filter_das_words(struct_name)} \{\}\n")
@@ -848,7 +831,7 @@ class DasGenBind : AnyGenBind {
             return
         }
         fprint(enum_class_file, "enum {filter_das_words(enum_name)} \{\n")
-        clang_visitChildren(cursor) <| $(var c, parent) {
+        clang_visitChildren(cursor) $(var c, parent) {
             if (c.kind == CXCursorKind.EnumConstantDecl) {
                 let een = string(clang_getCursorDisplayName(c))
                 let val = clang_getEnumConstantDeclValue(c)
@@ -954,7 +937,7 @@ class CppGenBind : AnyGenBind {
     prefix : string
 
     def CppGenBind(pfn, pfp : string; args : array<string>) {
-        init_args(pfn, pfp, args)
+        super(pfn, pfp, args)
         setDefaultFiles()
     }
     def setDefaultFiles {
@@ -1128,7 +1111,7 @@ class CppGenBind : AnyGenBind {
             return
         }
         let dashing_name = namespace_name(struct_name, "_")
-        let st = build_string() <| $(var writer : StringBuilderWriter) {
+        let st = build_string() $(var writer : StringBuilderWriter) {
             swrite |> push(unsafe(addr(writer)))
             writer |> write("// from {clang_getCursorLocationDescription(c)}\n")
             writer |> write("struct {dashing_name}_GeneratedAnnotation : ManagedStructureAnnotation<{struct_namespace_name}> \{\n")
@@ -1165,7 +1148,7 @@ class CppGenBind : AnyGenBind {
             return nspl
         }
         var t = clang_getCanonicalType(c)
-        var spl = string(clang_getTypeSpelling(t))
+        let spl = string(clang_getTypeSpelling(t))
         if (c.kind == CXTypeKind.Enum) {
             return enum2enum?[spl] ?? spl
         } elif (t.kind == CXTypeKind.Long || t.kind == CXTypeKind.LongLong || t.kind == CXTypeKind.ULong || t.kind == CXTypeKind.ULongLong) {
@@ -1179,7 +1162,7 @@ class CppGenBind : AnyGenBind {
         var res_type = clang_getResultType(fun_type)
         let function_result_type = typeSpelling(res_type)
         let isStatic = clang_Cursor_getStorageClass(c) == CX_StorageClass.Static
-        return build_string() <| $(str) {
+        return build_string() $(str) {
             str |> write("{function_result_type} {function_name}(")
             if (!empty(self_type)) {
                 if (isMethod && (clang_CXXMethod_isConst(c) != 0u || isStatic)) {
@@ -1214,7 +1197,7 @@ class CppGenBind : AnyGenBind {
         }
     }
     def functionPtrSpelling(var c : CXCursor; isMethod : bool) {
-        let function_name = build_string() <| $(str) {
+        let function_name = build_string() $(str) {
             str |> write("(")
             if (isMethod) {
                 for (n in nspaces) {
@@ -1284,7 +1267,7 @@ class CppGenBind : AnyGenBind {
         fprint(func_file_aot_decl, "{header};\n")
         fprint(func_file_aot, "{header} \{\n\t")
         var fun_type = clang_getCursorType(c)
-        var res_type = clang_getCanonicalType(clang_getResultType(fun_type))
+        let res_type = clang_getCanonicalType(clang_getResultType(fun_type))
         if (res_type.kind != CXTypeKind.Void) {
             fprint(func_file_aot, "return ")
         }
@@ -1318,7 +1301,7 @@ class CppGenBind : AnyGenBind {
         var das_function_name = function_name
         var isOperator = false
         if (function_name |> starts_with("operator")) {
-            let Ch = character_at(function_name, 8)
+            let Ch = character_at(function_name, 8) // nolint:PERF003
             if (!(is_alpha(Ch) || is_number(Ch) || Ch == '_')) {
                 das_function_name = function_name |> slice(8)
                 isOperator = true
@@ -1326,7 +1309,7 @@ class CppGenBind : AnyGenBind {
         }
         let isVirtual = clang_CXXMethod_isVirtual(c) != 0u
         var fun_type = clang_getCanonicalType(clang_getCursorType(c))
-        var res_type = clang_getResultType(fun_type)
+        var res_type = clang_getResultType(fun_type) // nolint:LINT003 passed to non-const clang_das_isRef/isCopyOnReturn
         var nc_res_type = clang_getResultType(clang_getCursorType(c))
         let function_cpp_name = namespace_name(function_name)
         das_function_name = rename_function(das_function_name, function_cpp_name)
@@ -1431,7 +1414,7 @@ class CppGenBind : AnyGenBind {
             let aii = int(ai)
             var carg = clang_Cursor_getArgument(c, ai)
             var ct = clang_getCursorType(carg)
-            var cp = getCursorArgType(ct)
+            let cp = getCursorArgType(ct)
             let cv = getCursorInit(carg, cp)
             if (cv != "") {
                 fprint(func_file, "\n\t\t->arg_init({aii},{cv})")
@@ -1460,7 +1443,7 @@ class CppGenBind : AnyGenBind {
                 let value = uint(clang_EvalResult_getAsInt(res))
                 result = "new ExprConstUInt({value})"
             } elif (t.kind == CXTypeKind.Long || t.kind == CXTypeKind.LongLong) {
-                let value = int64(clang_EvalResult_getAsLongLong(res))
+                let value = clang_EvalResult_getAsLongLong(res)
                 result = "new ExprConstInt64({value})"
             } elif (t.kind == CXTypeKind.ULong || t.kind == CXTypeKind.ULongLong) {
                 let value = uint64(clang_EvalResult_getAsLongLong(res))
@@ -1475,7 +1458,7 @@ class CppGenBind : AnyGenBind {
                 let value = clang_EvalResult_getAsInt(res)
                 result = "new ExprConstBool({value != 0})"
             } elif (t.kind == CXTypeKind.Pointer) {
-                var pt = clang_getCanonicalType(clang_getPointeeType(t))
+                let pt = clang_getCanonicalType(clang_getPointeeType(t))
                 if (pt.kind == CXTypeKind.Char_S || pt.kind == CXTypeKind.SChar) {
                     let value = clang_EvalResult_getAsStr(res)
                     result = "new ExprConstString(\"{value}\")"
@@ -1498,7 +1481,7 @@ class CppGenBind : AnyGenBind {
             //      if we see IntegerLiteral - we check if it evals to 0, and if it does - we call it NULL
             if (t.kind == CXTypeKind.Pointer) {
                 var has_null = false
-                clang_visitChildren(c) <| $(var CC, parent) {
+                clang_visitChildren(c) $(var CC, parent) {
                     if (CC.kind == CXCursorKind.IntegerLiteral) {
                         var nres = clang_Cursor_Evaluate(CC)
                         let nres_kind = clang_EvalResult_getKind(nres)
@@ -1520,7 +1503,7 @@ class CppGenBind : AnyGenBind {
                     return CXChildVisitResult.Recurse
                 }
                 if (has_null) {
-                    var pt = clang_getCanonicalType(clang_getPointeeType(t))
+                    let pt = clang_getCanonicalType(clang_getPointeeType(t))
                     if (pt.kind == CXTypeKind.Char_S || pt.kind == CXTypeKind.SChar) {
                         result = "new ExprConstString(\"\")"
                     } else {
@@ -1554,12 +1537,7 @@ class CppGenBind : AnyGenBind {
     def override parse_Enum(var cursor : CXCursor; enum_name : string) {
         let ns_en = namespace_name(enum_name)
         let das_enum_name = dasEnumName(enum_name, ns_en)
-        if (skip_enum(ns_en, enum_name)) {
-            return
-        }
-        if (clang_isForwardDeclaration(cursor)) {
-            return
-        }
+        return if (skip_enum(ns_en, enum_name) || clang_isForwardDeclaration(cursor))
         enumDecl |> push((ns_en = ns_en, enum_name = enum_name))
         let dashing_name = namespace_name(enum_name, "_")
         fprint(enum_class_file, from_comment(cursor))
@@ -1570,7 +1548,7 @@ class CppGenBind : AnyGenBind {
         fprint(enum_class_file, "\t\tcppName = \"{ns_en}\";\n")
         let itype = string(clang_getTypeSpelling(clang_getEnumDeclIntegerType(cursor)))
         fprint(enum_class_file, "\t\tbaseType = (das::Type) das::ToBasicType<{itype}>::type;\n")
-        clang_visitChildren(cursor) <| $(var c, parent) {
+        clang_visitChildren(cursor) $(var c, parent) {
             if (c.kind == CXCursorKind.EnumConstantDecl) {
                 let een = string(clang_getCursorDisplayName(c))
                 let deen = enum_entry_name(enum_name, een)
@@ -1688,7 +1666,7 @@ class CppGenBind : AnyGenBind {
         for (rm in require_modules) {
             module_cpp_file |> fwrite("\tlib.addModule(mod_{rm});\n")
         }
-        if (length(aot_alias) != 0) {
+        if (!empty(aot_alias)) {
             module_cpp_file |> fwrite("\tinitAotAlias();\n")
         }
         if (generate_constant_decl) {
@@ -1723,7 +1701,7 @@ class CppGenBind : AnyGenBind {
         module_h_file |> fwrite("protected:\n")
         module_h_file |> fwrite("virtual bool initDependencies() override;\n")
         module_h_file |> fwrite("\tvoid initMain ();\n")
-        if (length(aot_alias) != 0) {
+        if (!empty(aot_alias)) {
             module_h_file |> fwrite("\tvoid initAotAlias ();\n")
         }
         module_h_file |> fwrite("\tvirtual ModuleAotType aotRequire ( TextWriter & tw ) const override;\n")
@@ -1815,12 +1793,12 @@ def clang_reportAst(PARSE_FILE_NAME, PARSE_FILE_PREFIX : string; ARGV : array<st
         panic("unable to parse translation unit {PARSE_FILE_PREFIX}{PARSE_FILE_NAME}")
     }
     var cursor = clang_getTranslationUnitCursor(unit)
-    var prevFileName : string
-    clang_visitChildren(cursor) <| $(var c, parent) {
+    var _prevFileName : string
+    clang_visitChildren(cursor) $(var c, parent) {
         var file : CXFile
         var line, column, offset : uint
         clang_getSpellingLocation(clang_getCursorLocation(c), safe_addr(file), safe_addr(line), safe_addr(column), safe_addr(offset))
-        var fname = string(clang_getFileName(file))
+        let fname = string(clang_getFileName(file))
         if (fname |> ends_with(PARSE_FILE_NAME)) {
             to_log(LOG_INFO, "{describe(c)} <- {describe(parent)} at {clang_getCursorLocationFullPath(c)}\n")
         }
@@ -1830,7 +1808,7 @@ def clang_reportAst(PARSE_FILE_NAME, PARSE_FILE_PREFIX : string; ARGV : array<st
     let ndiag = clang_getNumDiagnostics(unit)
     for (i in urange(ndiag)) {
         var diag = clang_getDiagnostic(unit, i)
-        var diags = string(clang_formatDiagnostic(diag, clang_defaultDiagnosticDisplayOptions()))
+        let diags = string(clang_formatDiagnostic(diag, clang_defaultDiagnosticDisplayOptions()))
         print("{diags}\n")
     }
     clang_disposeTranslationUnit(unit)

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -13,6 +13,32 @@ namespace das {
     // in ast_handle of all places, due to reporting fields
     void reportTrait(const TypeDeclPtr &type, const string &prefix, const callable<void(const TypeDeclPtr &, const string &)> &report);
 
+    // True if `klass` has any non-generated user-defined function with the given name (mangled
+    // as `Klass`methodName`). For methodName == klass->name, this detects user ctors; for any
+    // other name, it detects user methods. Used at super(...) / super.method() walk-up sites to
+    // reject silent skip of an intermediate class's user-defined invariants.
+    // The class's ctors/methods live in the same module as the class itself (parser registers
+    // them together), so we look up by name hash on `klass->module->functionsByName` /
+    // `genericsByName` instead of scanning the entire library. The `classParent == klass`
+    // identity check defends against same-named classes in other modules bleeding in via
+    // generic instantiation (the in-tree corpus already has multiple `ContextStateAgent`).
+    static bool classHasUserNamedFunction(Program *, Structure * klass, const string & methodName) {
+        if (!klass || !klass->module) return false;
+        string funcName = klass->name + "`" + methodName;
+        uint64_t hName = hash64z(funcName.c_str());
+        if (auto kv = klass->module->functionsByName.find(hName)) {
+            for (auto * fn : kv->second) {
+                if (!fn->generated && fn->classParent == klass) return true;
+            }
+        }
+        if (auto kv = klass->module->genericsByName.find(hName)) {
+            for (auto * fn : kv->second) {
+                if (!fn->generated && fn->classParent == klass) return true;
+            }
+        }
+        return false;
+    }
+
     CaptureLambda::CaptureLambda(bool cm) : inClassMethod(cm) {}
     void CaptureLambda::preVisit(ExprVar *expr) {
         if (!expr->type) { // trying to capture non-inferred section
@@ -1490,6 +1516,25 @@ namespace das {
                                     return Visitor::visit(expr);
                                 }
                             }
+                            // super.<AncestorClassName>() is the legacy form for invoking that
+                            // ancestor's constructor. Allow only when the named class is the
+                            // immediate parent or reachable through an unbroken chain of empty
+                            // intermediates (no user ctors). Skipping a class with a user ctor
+                            // would silently bypass its invariants.
+                            for (Structure * anc = baseClass->parent; anc; anc = anc->parent) {
+                                if (anc->name == eField->name) {
+                                    for (Structure * mid = baseClass; mid != anc; mid = mid->parent) {
+                                        if (classHasUserNamedFunction(program, mid, mid->name)) {
+                                            error("call to super." + eField->name + " in " + func->name
+                                                    + " cannot skip " + mid->name
+                                                    + " which has its own constructor — call super." + mid->name + "(...) instead",
+                                                  "", "", expr->at, CompilationError::invalid_super_call);
+                                            return Visitor::visit(expr);
+                                        }
+                                    }
+                                    break;
+                                }
+                            }
                             vector<TypeDeclPtr> argTypes;
                             auto selfType = new TypeDecl(Type::tStructure);
                             selfType->structType = func->classParent;
@@ -1513,6 +1558,16 @@ namespace das {
                                     error("too many candidates for super call " + callName,
                                     verbose ? program->describeCandidates(fnCandidates) : "", "",
                                         expr->at, CompilationError::ambiguous_super_call);
+                                    return Visitor::visit(expr);
+                                }
+                                // No matching method here. Before walking past, check: does this
+                                // baseClass have a user-defined method with the same name (different
+                                // sig)? If yes, we'd silently skip its definition — reject.
+                                if (classHasUserNamedFunction(program, baseClass, eField->name)) {
+                                    error("call to super." + eField->name + " in " + func->name
+                                            + " cannot skip " + baseClass->name + " which defines its own "
+                                            + eField->name + " — adjust args to match " + baseClass->name + "'s overload",
+                                          "", "", expr->at, CompilationError::invalid_super_call);
                                     return Visitor::visit(expr);
                                 }
                                 baseClass = baseClass->parent;
@@ -5577,6 +5632,9 @@ namespace das {
         // Walks up the inheritance chain looking for a parent class constructor that matches the
         // argument types; this lets `super(...)` call the closest ancestor's constructor when an
         // intermediate class doesn't define its own (mirrors super.method() / delete super.self).
+        // The walk-up may only step past a class with NO user ctor — silently skipping a class
+        // whose user ctor establishes invariants is rejected (use the right `super(args)` shape
+        // to call the immediate parent).
         if (func && func->isClassMethod && func->classParent && expr->name == "super") {
             if (auto baseClass = func->classParent->parent) {
                 vector<TypeDeclPtr> argumentTypes;
@@ -5599,6 +5657,14 @@ namespace das {
                         error("too many candidates for super constructor " + candidateName,
                               verbose ? program->describeCandidates(matching) : "", "",
                               expr->at, CompilationError::ambiguous_super_constructor);
+                        return Visitor::visit(expr);
+                    }
+                    // No matching ctor here. Before walking past, check: does this baseClass
+                    // have ANY user-defined ctor? If yes, we'd silently skip its invariants — reject.
+                    if (classHasUserNamedFunction(program, baseClass, baseClass->name)) {
+                        error("call to super in " + func->name + " cannot skip " + baseClass->name
+                                + " which has its own constructor — adjust super(...) args to match " + baseClass->name,
+                              "", "", expr->at, CompilationError::invalid_super_call);
                         return Visitor::visit(expr);
                     }
                     baseClass = baseClass->parent;

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -123,6 +123,224 @@ namespace das {
         return false;
     }
 
+    // CFG-aware super-call count. Each expression produces:
+    //   - fallsThrough/fallLo/fallHi: count along the path that reaches the end of expr
+    //   - hasExits/exitLo/exitHi: min/max super count over all early-exit (return) paths
+    //     terminating INSIDE expr. break/continue/goto don't escape the function so they
+    //     stop block iteration but don't add to function-level exits.
+    // For loops, inner exits (return) DO propagate; super inside a loop body collapses to
+    // {0, INT_MAX} unbounded since iteration count isn't statically known.
+    // Closures (ExprMakeBlock) are NOT descended into — a super() inside a defer/lambda
+    // is asynchronous and isn't the chain call we're enforcing.
+    static const int kSuperUnbounded = INT_MAX;
+    struct SuperCount {
+        bool    fallsThrough;
+        int     fallLo, fallHi;
+        bool    hasExits;
+        int     exitLo, exitHi;
+        static SuperCount onlyFall ( int lo, int hi ) { return {true, lo, hi, false, 0, 0}; }
+        static SuperCount onlyExit ( int lo, int hi ) { return {false, 0, 0, true, lo, hi}; }
+        static SuperCount dead     ()                  { return {false, 0, 0, false, 0, 0}; }
+    };
+    static int safeAdd ( int a, int b ) {
+        if ( a == kSuperUnbounded || b == kSuperUnbounded ) return kSuperUnbounded;
+        return a + b;
+    }
+    static int safeMax ( int a, int b ) {
+        if ( a == kSuperUnbounded || b == kSuperUnbounded ) return kSuperUnbounded;
+        return a > b ? a : b;
+    }
+    static void mergeExit ( SuperCount & out, int lo, int hi ) {
+        if ( !out.hasExits ) { out.hasExits = true; out.exitLo = lo; out.exitHi = hi; }
+        else { out.exitLo = (lo < out.exitLo) ? lo : out.exitLo; out.exitHi = safeMax(hi, out.exitHi); }
+    }
+    // CFG-agnostic scan: any matching super call anywhere in this subtree?
+    // Used at loop boundaries to defend against paths that countSuperCalls collapses
+    // via break/continue/goto (those terminate dead() and erase prefix super counts on
+    // the way out, so e.g. `if(x){ super(); break }` would otherwise look super-free).
+    // Closures are still skipped (super inside defer/lambda isn't the chain call).
+    bool subtreeHasSuperCall ( const ExpressionPtr & expr, const string & parentMangled ) {
+        if ( !expr ) return false;
+        if ( expr->rtti_isCall() ) {
+            auto call = static_cast<ExprCall*>(expr);
+            if ( call->name == parentMangled || call->name == ("_::" + parentMangled) ) return true;
+            if ( call->func && call->func->module && call->func->module->name == "$"
+                && call->func->name == "builtin_try_recover"
+                && call->arguments.size() >= 2
+                && call->arguments[0]->rtti_isMakeBlock() ) {
+                auto mb = static_cast<ExprMakeBlock*>(call->arguments[0]);
+                return subtreeHasSuperCall(mb->block, parentMangled);
+            }
+            return false;
+        }
+        if ( expr->rtti_isBlock() ) {
+            for ( auto & be : static_cast<ExprBlock*>(expr)->list ) {
+                if ( subtreeHasSuperCall(be, parentMangled) ) return true;
+            }
+            return false;
+        }
+        if ( expr->rtti_isIfThenElse() ) {
+            auto ite = static_cast<ExprIfThenElse*>(expr);
+            return subtreeHasSuperCall(ite->if_true, parentMangled)
+                || subtreeHasSuperCall(ite->if_false, parentMangled);
+        }
+        if ( expr->rtti_isWith() )   return subtreeHasSuperCall(static_cast<ExprWith*>(expr)->body, parentMangled);
+        if ( expr->rtti_isUnsafe() ) return subtreeHasSuperCall(static_cast<ExprUnsafe*>(expr)->body, parentMangled);
+        if ( expr->rtti_isWhile() )  return subtreeHasSuperCall(static_cast<ExprWhile*>(expr)->body, parentMangled);
+        if ( expr->rtti_isFor() )    return subtreeHasSuperCall(static_cast<ExprFor*>(expr)->body, parentMangled);
+        if ( expr->__rtti && strcmp(expr->__rtti, "ExprTryCatch") == 0 ) {
+            // Mirror countSuperCalls: only the try block contributes to chain semantics.
+            // The recover block's super (if any) is irrelevant to the chain check.
+            auto tc = static_cast<ExprTryCatch*>(expr);
+            return subtreeHasSuperCall(tc->try_block, parentMangled);
+        }
+        return false;
+    }
+    SuperCount countSuperCalls ( const ExpressionPtr & expr, const string & parentMangled ) {
+        if ( !expr ) return SuperCount::onlyFall(0, 0);
+        if ( expr->rtti_isCall() ) {
+            auto call = static_cast<ExprCall*>(expr);
+            if ( call->name == parentMangled || call->name == ("_::" + parentMangled) ) {
+                return SuperCount::onlyFall(1, 1);
+            }
+            // JIT-mode rewrite of try/recover: ast_infer_type_op.cpp:1015 emits
+            // `builtin_try_recover(make_block(try), make_block(catch))` and the typer
+            // appends `context` + `at` (final arity = 4). Match the resolved function on
+            // its source module ($) to avoid colliding with any user shadow. Count super
+            // in the try block only; the recover block is fatal-panic-with-diagnostics,
+            // irrelevant to chain semantics (mirrors the direct ExprTryCatch handler below).
+            if ( call->func && call->func->module && call->func->module->name == "$"
+                && call->func->name == "builtin_try_recover"
+                && call->arguments.size() >= 2
+                && call->arguments[0]->rtti_isMakeBlock() ) {
+                auto mb = static_cast<ExprMakeBlock*>(call->arguments[0]);
+                return countSuperCalls(mb->block, parentMangled);
+            }
+            return SuperCount::onlyFall(0, 0);
+        }
+        if ( expr->rtti_isReturn() ) {
+            // Early-exit at this point with the prefix accumulated so far; no super
+            // here, no fall-through. The caller (block walker) folds the prefix in.
+            return SuperCount::onlyExit(0, 0);
+        }
+        if ( expr->rtti_isBreak() || expr->rtti_isContinue() || expr->rtti_isGoto() ) {
+            // Don't escape the function — they stop block iteration (no fall-through) but
+            // contribute no function-level exit path.
+            return SuperCount::dead();
+        }
+        if ( expr->rtti_isBlock() ) {
+            auto blk = static_cast<ExprBlock*>(expr);
+            int prefix_lo = 0, prefix_hi = 0;
+            SuperCount out = SuperCount::onlyFall(0, 0); // exits accumulated as we go
+            out.hasExits = false;
+            bool fallenThrough = true;
+            for ( auto & be : blk->list ) {
+                auto sub = countSuperCalls(be, parentMangled);
+                if ( sub.hasExits ) {
+                    mergeExit(out, safeAdd(prefix_lo, sub.exitLo), safeAdd(prefix_hi, sub.exitHi));
+                }
+                if ( !sub.fallsThrough ) {
+                    fallenThrough = false;
+                    break;
+                }
+                prefix_lo = safeAdd(prefix_lo, sub.fallLo);
+                prefix_hi = safeAdd(prefix_hi, sub.fallHi);
+            }
+            out.fallsThrough = fallenThrough;
+            out.fallLo = prefix_lo;
+            out.fallHi = prefix_hi;
+            return out;
+        }
+        if ( expr->rtti_isIfThenElse() ) {
+            auto ite = static_cast<ExprIfThenElse*>(expr);
+            auto t = countSuperCalls(ite->if_true, parentMangled);
+            // Treat absent else as an empty fall-through branch with 0 super calls.
+            SuperCount e = ite->if_false ? countSuperCalls(ite->if_false, parentMangled)
+                                         : SuperCount::onlyFall(0, 0);
+            SuperCount out = SuperCount::dead();
+            if ( t.hasExits ) mergeExit(out, t.exitLo, t.exitHi);
+            if ( e.hasExits ) mergeExit(out, e.exitLo, e.exitHi);
+            if ( t.fallsThrough && e.fallsThrough ) {
+                out.fallsThrough = true;
+                out.fallLo = (t.fallLo < e.fallLo) ? t.fallLo : e.fallLo;
+                out.fallHi = safeMax(t.fallHi, e.fallHi);
+            } else if ( t.fallsThrough ) {
+                out.fallsThrough = true; out.fallLo = t.fallLo; out.fallHi = t.fallHi;
+            } else if ( e.fallsThrough ) {
+                out.fallsThrough = true; out.fallLo = e.fallLo; out.fallHi = e.fallHi;
+            }
+            return out;
+        }
+        if ( expr->rtti_isWith() ) {
+            auto wth = static_cast<ExprWith*>(expr);
+            return countSuperCalls(wth->body, parentMangled);
+        }
+        if ( expr->rtti_isUnsafe() ) {
+            auto us = static_cast<ExprUnsafe*>(expr);
+            return countSuperCalls(us->body, parentMangled);
+        }
+        if ( expr->rtti_isWhile() || expr->rtti_isFor() ) {
+            ExpressionPtr body = expr->rtti_isWhile()
+                ? static_cast<ExprWhile*>(expr)->body
+                : static_cast<ExprFor*>(expr)->body;
+            auto inner = countSuperCalls(body, parentMangled);
+            // Conservatively: loop iterates 0..N times. If body contains ANY super anywhere
+            // (including paths that terminate via break/continue, which countSuperCalls
+            // collapses to dead()), the loop's fall-through count is unbounded. Inner exits
+            // (return) still propagate as function-level exit paths.
+            SuperCount out = SuperCount::onlyFall(0, 0);
+            if ( subtreeHasSuperCall(body, parentMangled) ) {
+                out.fallLo = 0; out.fallHi = kSuperUnbounded;
+            }
+            if ( inner.hasExits ) mergeExit(out, inner.exitLo, inner.exitHi);
+            return out;
+        }
+        // try / recover: the try block is the normal-flow path — count super there.
+        // The recover block is for diagnostics-before-exit (daslang panic is fatal); a
+        // super call in recover never establishes invariants for a usable object, so skip
+        // it. ExprTryCatch has no rtti_is* — dispatch via __rtti.
+        if ( expr->__rtti && strcmp(expr->__rtti, "ExprTryCatch") == 0 ) {
+            auto tc = static_cast<ExprTryCatch*>(expr);
+            return countSuperCalls(tc->try_block, parentMangled);
+        }
+        return SuperCount::onlyFall(0, 0);
+    }
+    // Reduces a function-body SuperCount to {min, max} over ALL completed CFG paths
+    // (fall-through + every early-exit). The function-level lint compares this to {1, 1}.
+    struct SuperCountReduced { int lo; int hi; };
+    SuperCountReduced reduceSuperCount ( const SuperCount & c ) {
+        if ( !c.fallsThrough && !c.hasExits ) return {0, 0}; // dead body (panic-only)
+        if ( c.fallsThrough && !c.hasExits ) return {c.fallLo, c.fallHi};
+        if ( !c.fallsThrough && c.hasExits ) return {c.exitLo, c.exitHi};
+        int lo = (c.fallLo < c.exitLo) ? c.fallLo : c.exitLo;
+        int hi = safeMax(c.fallHi, c.exitHi);
+        return {lo, hi};
+    }
+
+    // True if `klass` has any non-generated user-defined ctor method (Klass`Klass).
+    // A class's ctor methods always live in the same module as the class itself
+    // (parser registers them together), so we jump straight to `klass->module` and
+    // look up by name hash via functionsByName / genericsByName. The `classParent ==
+    // klass` identity check defends against same-named classes in other modules
+    // bleeding in through generic instantiation (the in-tree corpus already has
+    // multiple `ContextStateAgent` classes).
+    bool parentHasUserCtor ( Program *, Structure * klass ) {
+        if ( !klass || !klass->module ) return false;
+        string ctorName = klass->name + "`" + klass->name;
+        uint64_t hName = hash64z(ctorName.c_str());
+        if ( auto kv = klass->module->functionsByName.find(hName) ) {
+            for ( auto * fn : kv->second ) {
+                if ( !fn->generated && fn->classParent == klass ) return true;
+            }
+        }
+        if ( auto kv = klass->module->genericsByName.find(hName) ) {
+            for ( auto * fn : kv->second ) {
+                if ( !fn->generated && fn->classParent == klass ) return true;
+            }
+        }
+        return false;
+    }
+
     bool needAvoidNullPtr ( const TypeDeclPtr & type, bool allowDim ) {
         if ( !type ) {
             return false;
@@ -208,7 +426,6 @@ namespace das {
         bool disableInit;
         bool noLocalClassMembers;
         bool noWritingToNameless;
-        bool alwaysCallSuper;
     public:
         LintVisitor ( const ProgramPtr & prog ) : program(prog) {
             checkOnlyFastAot = program->options.getBoolOption("only_fast_aot", program->policies.only_fast_aot);
@@ -223,7 +440,6 @@ namespace das {
             disableInit = prog->options.getBoolOption("no_init", prog->policies.no_init);
             noLocalClassMembers = prog->options.getBoolOption("no_local_class_members", prog->policies.no_local_class_members);
             noWritingToNameless = prog->options.getBoolOption("no_writing_to_nameless", prog->policies.no_writing_to_nameless);
-            alwaysCallSuper = prog->options.getBoolOption("always_call_super", prog->policies.always_call_super);
         }
     public:
         void reportUnsafeTypeExpressions() {
@@ -609,12 +825,6 @@ namespace das {
                     verifyToTableMove(expr);
                 }
             }
-            if ( isClassCtor ) {
-                auto baseClass = func->classParent->parent;
-                if ( expr->func->name==(baseClass->name+"`"+baseClass->name) ) {
-                    anySuperCalls = true;
-                }
-            }
         }
         virtual ExpressionPtr visit ( ExprInvoke * expr ) override {
             Visitor::visit(expr);
@@ -810,8 +1020,6 @@ namespace das {
         virtual bool canVisitArgumentInit ( Function *, const VariablePtr &, Expression * ) override {
             return false;
         }
-        bool isClassCtor = false;
-        bool anySuperCalls = false;
         virtual void preVisit ( Function * fn ) override {
             Visitor::preVisit(fn);
             func = fn;
@@ -849,17 +1057,28 @@ namespace das {
                 program->error("[init] is disabled in the options or CodeOfPolicies",  "", "",
                     fn->at, CompilationError::cant_function);
             }
-            if ( alwaysCallSuper && fn->isClassMethod && fn->classParent && fn->classParent->parent && fn->name==(fn->classParent->name+"`"+fn->classParent->name)) {
-                isClassCtor = true; // detect class constructor, but only if we always call super
-            }
         }
         virtual FunctionPtr visit ( Function * fn ) override {
-            if ( isClassCtor && !anySuperCalls ) {
-                program->error("class constructor " + fn->name + " does not call super initializer", "",
-                    "", fn->at, CompilationError::missing_function_body);
+            // Derived class ctor: every CFG path must call super(...) exactly once,
+            // and only when the parent has a user-defined ctor to chain to.
+            if ( fn->isClassMethod && fn->classParent && fn->classParent->parent
+                && !fn->generated
+                && fn->name == fn->classParent->name + "`" + fn->classParent->name ) {
+                Structure * parent = fn->classParent->parent;
+                if ( parentHasUserCtor(program.get(), parent) ) {
+                    string parentMangled = parent->name + "`" + parent->name;
+                    auto count = reduceSuperCount(countSuperCalls(fn->body, parentMangled));
+                    if ( count.lo == 0 ) {
+                        program->error("class constructor " + fn->name + " does not call super(...) on every control-flow path",
+                            "", "call super(...) (or super." + parent->name + "(...)) exactly once per path",
+                            fn->at, CompilationError::missing_function_body);
+                    } else if ( count.hi != count.lo || count.hi > 1 ) {
+                        program->error("class constructor " + fn->name + " calls super(...) more than once on some path",
+                            "", "super(...) must be called exactly once per control-flow path",
+                            fn->at, CompilationError::missing_function_body);
+                    }
+                }
             }
-            anySuperCalls = false;
-            isClassCtor = false;
             func = nullptr;
             return Visitor::visit(fn);
         }
@@ -986,7 +1205,6 @@ namespace das {
     // lint
         "lint",                         Type::tBool,
         "no_writing_to_nameless",       Type::tBool,
-        "always_call_super",            Type::tBool,
     // memory
         "heap_size_limit",              Type::tInt,
         "string_heap_size_limit",       Type::tInt,

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2555,7 +2555,6 @@ namespace das {
               << value.no_unsafe_uninitialized_structures
               << value.strict_properties
               << value.no_writing_to_nameless
-              << value.always_call_super
               << value.no_optimizations
               << value.no_infer_time_folding
               << value.fail_on_no_aot
@@ -2698,7 +2697,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 86;
+        static constexpr uint32_t currentVersion = 87;
         return currentVersion;
     }
 

--- a/tests/language/failed_no_super.das
+++ b/tests/language/failed_no_super.das
@@ -1,0 +1,24 @@
+// Derived ctor must call super() — missing on every path.
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived {
+        // 30308: class constructor does not call super(...) on every control-flow path
+        y = 20
+    }
+}
+
+[export]
+def main {
+    let d = new Derived()
+    feint("d.x={d.x}\n")
+}

--- a/tests/language/failed_super_args_mismatch.das
+++ b/tests/language/failed_super_args_mismatch.das
@@ -1,0 +1,34 @@
+// super(args) cannot skip an intermediate whose ctor takes different arguments.
+options gen2
+expect 30245
+
+class A {
+    a : int = 0
+    def A {
+        a = 1
+    }
+}
+
+class B : A {
+    b : int = 0
+    def B(val : int) {
+        super()
+        b = val
+    }
+}
+
+class C : B {
+    c : int = 0
+    def C {
+        // 30245: super() can't match B(int), but B has a user ctor — silently
+        // walking up to A's 0-arg ctor would skip B's invariants
+        super()
+        c = 3
+    }
+}
+
+[export]
+def main {
+    let c = new C()
+    feint("c.a={c.a}, c.b={c.b}, c.c={c.c}\n")
+}

--- a/tests/language/failed_super_before_loop_with_break.das
+++ b/tests/language/failed_super_before_loop_with_break.das
@@ -1,0 +1,36 @@
+// super() outside loop + super() inside loop on a break-terminated path.
+// Without subtree scanning, the break collapses the inner super to dead() and the lint
+// would miss the path that calls super twice (outer + once inside before break).
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived(n : int) {
+        // 30308: on any iteration where the break fires after super(), the function
+        // calls super twice — outer super (a) + inner super (b). The CFG walker
+        // collapses the break to dead(), so the inner super is invisible to the
+        // straight-line fold; subtreeHasSuperCall catches it at the loop boundary.
+        super()                        // (a)
+        for (i in range(n)) {
+            if (i == 0) {
+                super()                // (b) — runs once then breaks
+                break
+            }
+        }
+        y = 1
+    }
+}
+
+[export]
+def main {
+    let d = new Derived(3)
+    feint("d.x={d.x}\n")
+}

--- a/tests/language/failed_super_early_return.das
+++ b/tests/language/failed_super_early_return.das
@@ -1,0 +1,28 @@
+// Path with early return before super — the if-true branch returns without calling super().
+// Without exit-path tracking the linter would incorrectly fold the suffix's super into the
+// early-return prefix and pass the lint. The CFG walker tracks early-exit paths separately.
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived(skip : bool) {
+        // 30308: skip=true takes the early return, super() never runs on that path
+        if (skip) return
+        super()
+        y = 1
+    }
+}
+
+[export]
+def main {
+    let d = new Derived(true)
+    feint("d.x={d.x}\n")
+}

--- a/tests/language/failed_super_in_loop.das
+++ b/tests/language/failed_super_in_loop.das
@@ -1,0 +1,27 @@
+// Derived ctor must call super() exactly once — call inside a loop is unbounded.
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived {
+        // 30308: super() in a loop body — count is unbounded, not exactly once
+        for (i in range(2)) {
+            super()
+        }
+        y = 20
+    }
+}
+
+[export]
+def main {
+    let d = new Derived()
+    feint("d.x={d.x}\n")
+}

--- a/tests/language/failed_super_in_try_only_recover.das
+++ b/tests/language/failed_super_in_try_only_recover.das
@@ -1,0 +1,29 @@
+// Super absent from try/recover entirely — both branches lack super, no normal path covers it.
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived {
+        // 30308: try block has no super → normal-flow path count is 0;
+        // recover is ignored by the lint (panic-and-exit semantics)
+        try {
+            y = 1
+        } recover {
+            y = -1
+        }
+    }
+}
+
+[export]
+def main {
+    let d = new Derived()
+    feint("d={d.x}\n")
+}

--- a/tests/language/failed_super_on_branch.das
+++ b/tests/language/failed_super_on_branch.das
@@ -1,0 +1,27 @@
+// Derived ctor must call super() on every path — calling only in one if-branch is not enough.
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived(f : bool) {
+        // 30308: false-branch path has zero super() calls
+        if (f) {
+            super()
+        }
+        y = 20
+    }
+}
+
+[export]
+def main {
+    let d = new Derived(true)
+    feint("d.x={d.x}\n")
+}

--- a/tests/language/failed_super_skip_intermediate.das
+++ b/tests/language/failed_super_skip_intermediate.das
@@ -1,0 +1,33 @@
+// super.X() cannot skip an intermediate class whose own ctor would be bypassed.
+options gen2
+expect 30245, 30808, 30838    // 30245 from the rule; 30808/30838 cascade as super stays unresolved
+
+class A {
+    a : int = 0
+    def A {
+        a = 1
+    }
+}
+
+class B : A {
+    b : int = 0
+    def B {
+        super()
+        b = 2
+    }
+}
+
+class C : B {
+    c : int = 0
+    def C {
+        // 30245: super.A() would silently skip B's invariants — rejected
+        super.A()
+        c = 3
+    }
+}
+
+[export]
+def main {
+    let c = new C()
+    feint("c.a={c.a}, c.b={c.b}, c.c={c.c}\n")
+}

--- a/tests/language/failed_super_twice.das
+++ b/tests/language/failed_super_twice.das
@@ -1,0 +1,26 @@
+// Derived ctor must call super() exactly once — duplicate is rejected.
+options gen2
+expect 30308
+
+class Base {
+    x : int = 0
+    def Base {
+        x = 13
+    }
+}
+
+class Derived : Base {
+    y : int = 0
+    def Derived {
+        // 30308: super() called twice on the single path
+        super()
+        super()
+        y = 20
+    }
+}
+
+[export]
+def main {
+    let d = new Derived()
+    feint("d.x={d.x}\n")
+}

--- a/tests/language/super.das
+++ b/tests/language/super.das
@@ -59,6 +59,44 @@ class Derived2 : Derived {
     }
 }
 
+// Both if/else branches call super — CFG walker must accept (min=max=1 per path).
+class CondSuper : Base {
+    z : int = 0
+    def CondSuper(flag : bool) {
+        if (flag) {
+            super(7)
+        } else {
+            super()
+        }
+        z = flag ? 100 : 200
+    }
+}
+
+// super() before an early return — both paths have exactly one super call. CFG walker
+// must accept (the if-true path's super count matches the fall-through path's count).
+class EarlyReturnSuper : Base {
+    z : int = 0
+    def EarlyReturnSuper(early : bool) {
+        super()
+        if (early) return
+        z = 999
+    }
+}
+
+// super() inside a try block — runs on normal path. CFG walker must count it.
+// recover is for diagnostics-before-exit (panic is fatal) and is ignored by the lint.
+class TrySuper : Base {
+    z : int = 0
+    def TrySuper {
+        try {
+            super(5)
+        } recover {
+            z = -1
+        }
+        z = 500
+    }
+}
+
 // Skip-level inheritance: SkipMid is empty (inherits Base's constructor and methods).
 // SkipLeaf calls super() / super.method() — both must walk past SkipMid up to Base.
 class SkipMid : Base {
@@ -89,14 +127,14 @@ class SkipLeaf : SkipMid {
 def test_super(t : T?) {
     t |> run("super() calls parent default constructor") @(t : T?) {
         unsafe {
-            var d = Derived()
+            let d = Derived()
             t |> equal(d.x, 10)
             t |> equal(d.y, 20)
         }
     }
     t |> run("super(args) calls parent parameterized constructor") @(t : T?) {
         unsafe {
-            var d = Derived(5)
+            let d = Derived(5)
             t |> equal(d.x, 5)
             t |> equal(d.y, 10)
         }
@@ -159,14 +197,14 @@ def test_super(t : T?) {
     t |> run("super() walks past empty intermediate class") @(t : T?) {
         unsafe {
             // SkipMid has no constructor of its own; super() in SkipLeaf must reach Base.
-            var s = SkipLeaf()
+            let s = SkipLeaf()
             t |> equal(s.x, 10)   // Base default ctor ran
             t |> equal(s.z, 100)
         }
     }
     t |> run("super(args) walks past empty intermediate class") @(t : T?) {
         unsafe {
-            var s = SkipLeaf(7)
+            let s = SkipLeaf(7)
             t |> equal(s.x, 7)
             t |> equal(s.z, 107)
         }
@@ -184,6 +222,41 @@ def test_super(t : T?) {
             var s = SkipLeaf()
             // SkipLeaf.add calls super.add(a,b) + z; SkipMid has no add, walks to Base: a+b
             t |> equal(s->add(3, 4), 107)
+        }
+    }
+    t |> run("super called on every branch of if/else (CFG-aware lint)") @(t : T?) {
+        var c1 = new CondSuper(true)
+        // flag=true → super(7) → x=7, z=100
+        t |> equal(c1.x, 7)
+        t |> equal(c1.z, 100)
+        var c2 = new CondSuper(false)
+        // flag=false → super() → x=10, z=200
+        t |> equal(c2.x, 10)
+        t |> equal(c2.z, 200)
+        unsafe {
+            delete c1
+            delete c2
+        }
+    }
+    t |> run("super in try block (CFG-aware lint accepts)") @(t : T?) {
+        var ts = new TrySuper()
+        // normal path: try runs super(5), z=500
+        t |> equal(ts.x, 5)
+        t |> equal(ts.z, 500)
+        unsafe { delete ts; }
+    }
+    t |> run("super before early return (both paths have super=1)") @(t : T?) {
+        var e1 = new EarlyReturnSuper(true)
+        // early=true → super ran, then returned before z=999; z stays default 0
+        t |> equal(e1.x, 10)
+        t |> equal(e1.z, 0)
+        var e2 = new EarlyReturnSuper(false)
+        // early=false → super, no return, z=999
+        t |> equal(e2.x, 10)
+        t |> equal(e2.z, 999)
+        unsafe {
+            delete e1
+            delete e2
         }
     }
 }

--- a/tutorials/language/18_classes.das
+++ b/tutorials/language/18_classes.das
@@ -171,6 +171,45 @@ def main {
     // You can also use the backtick syntax directly:
     //     Shape`Shape(self, "Circle")   // same as super("Circle")
 
+    // === super() must be called exactly once per path ===
+
+    // When the parent has a user-defined constructor, the lint requires
+    // every control-flow path through the derived ctor to call super(...)
+    // exactly once:
+    //
+    //   class Bad : Base {
+    //       def Bad(f : bool) {
+    //           if (f) {
+    //               super()       // ERROR: false branch has zero super() calls
+    //           }
+    //       }
+    //   }
+    //
+    //   class AlsoBad : Base {
+    //       def AlsoBad {
+    //           super()
+    //           super()           // ERROR: super() called more than once
+    //       }
+    //   }
+    //
+    // Both if/else branches calling super is fine — the lint sees min=max=1:
+    //   class OK : Shape {
+    //       def OK(big : bool) {
+    //           if (big) { super("Big") } else { super("Small") }
+    //       }
+    //   }
+
+    // === super.X() may not skip an intermediate with its own ctor ===
+
+    //   class A { def A { /* ... */ } }
+    //   class B : A { def B { super() } }     // B has its own ctor
+    //   class C : B {
+    //       def C { super.A() }               // ERROR: would skip B's invariants
+    //   }
+    //
+    // Empty intermediates (no user ctor) are still legal to skip — that's
+    // the SkipMid pattern in tests/language/super.das.
+
     // === Summary ===
 
     // - 'class' defines a type with virtual methods


### PR DESCRIPTION
## Summary

`examples/wip.das` documents three latent footguns in the class system. This PR closes two of them and removes the dormant opt-in lint that was supposed to cover the third. The synth-derived-ctor change is deferred to PR2.

### (1) Every-path super(...) lint — always on, CFG-aware

Every derived-class constructor whose parent has a user-defined ctor must call `super(...)` exactly once on every control-flow path. Replaces the opt-in `always_call_super` single-bool check at [src/ast/ast_lint.cpp:852](src/ast/ast_lint.cpp) (gated behind an option that zero `.das` files in the codebase enabled) with a CFG-aware `{lo, hi}` walker `countSuperCalls` modeled on `exprReturns`.

Caught by the new walker:

| Pattern | Why it errors |
|---|---|
| `def Derived { /* no super */ }` | `lo == 0` |
| `def Derived(f : bool) { if (f) super() }` | false branch contributes `lo = 0` |
| `def Derived { super(); super() }` | `hi == 2 > 1` |
| `def Derived { for (i in range(2)) super() }` | loop body with super → `hi = INT_MAX` |
| `def Derived { try { y = 1 } recover { y = -1 } }` (no super) | try-block `lo == 0`; recover is panic-and-exit, ignored |

`try` / `recover` is handled in both shapes:
- direct `ExprTryCatch` (non-JIT) via `__rtti` string compare
- JIT-mode `builtin_try_recover(make_block, make_block)` rewrite — gated on `call->func->module->name == "$"` + `call->func->name == "builtin_try_recover"` + arity to avoid matching a user shadow

### (2) Reject super-skip-intermediate at the typer

`super(...)` and `super.X()` may only walk past an intermediate class that has **no** user-defined ctor (or matching method, for `super.method()`). Skipping a class with its own user ctor — whose invariants would silently be bypassed — is rejected with `CompilationError::invalid_super_call`.

Walk-up sites updated at [src/ast/ast_infer_type.cpp:5578](src/ast/ast_infer_type.cpp) (super()) and [src/ast/ast_infer_type.cpp:1493](src/ast/ast_infer_type.cpp) (super.method()). New helper `classHasUserNamedFunction` (program library scan) gates the rejection. Empty-intermediate skip (the `SkipMid` pattern at [tests/language/super.das:64](tests/language/super.das)) stays legal.

Includes detection for the legacy `super.<AncestorClassName>()` form — when `X` matches the name of an ancestor class beyond the immediate parent, we walk the intermediate chain and reject if any has a user ctor.

### (3) Hard-remove `always_call_super`

The option is no longer meaningful — enforcement is unconditional. Deleted from policy field, lint binding, options table, serialize stream, and docs.

## Out of scope (PR2)

- Synthesizing a derived default ctor that chains via `super()` when the user provides no explicit ctor. This is the third wip.das footgun (`class B : A {}` silently drops A's ctor). Will land as PR2 alongside the implicit-chain section in the tutorial.

## Test plan

- [x] `tests/language/super.das` — extended with 2 new positive cases (if/else branches both call super, super in `try` block). 14/14 pass.
- [x] 7 new `tests/language/failed_super_*.das` files, one per pathology (no_super, super_on_branch, super_twice, super_in_loop, super_skip_intermediate, super_args_mismatch, super_in_try_only_recover). All produce the expected error codes.
- [x] `tests/language/` full sweep: 1013/1013 pass.
- [x] Class-heavy dirs (`class_boost`, `interfaces`, `data_walker`, `debug_agent`, `dynamic_cast_rtti`, `macro_call`, `decs`, `ast_match`, `aot`): all green (1017 tests).
- [x] AOT full sweep: 8366/8372 pass (6 SKIPPED — missing `FluidR3_GM.sf2` soundfont, unrelated).
- [x] Lint: zero warnings on all 9 changed `.das` files.
- [x] Formatter: clean on all changed `.das` files.
- [x] Sphinx: zero warnings introduced by edits to `classes.rst` / `options.rst` / tutorial RST.
- [x] JIT smoke: no verifier errors (LLVM.dll missing locally — per `make_pr.md` that's an env-only signal, not a codegen issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)