### PR TITLE
dastest: forward --worker-index N + --headless in isolated-mode subprocess cmd

### DIFF
--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -103,9 +103,7 @@ def private collect_files(input_paths : array<string>; var files : array<string>
             let das_test_path = path |> fs::join_path(".das_test")
             let das_test_stat = stat(das_test_path)
             if (das_test_stat.is_reg) {
-                if (!collect_files_filtered(path, das_test_path, cache, files)) {
-                    return false
-                }
+                return false if (!collect_files_filtered(path, das_test_path, cache, files))
             } else {
                 if (!fs::scan_dir(path, cache, files, ".das")) {
                     log::error("Unable to scan given path '{path}'")
@@ -161,9 +159,7 @@ def serialize_path(ctx : SuiteCtx, files : array<string>, out_file : string) {
             // are expected-failure compile tests anywhere in the tests tree;
             // they have nothing to serialize.
             let base = base_name(file)
-            if (base |> starts_with("cant_") || base |> starts_with("failed_") || base |> starts_with("invalid_")) {
-                continue
-            }
+            continue if (base |> starts_with("cant_") || base |> starts_with("failed_") || base |> starts_with("invalid_"))
             using() $(var mg : ModuleGroup) {
                 using() $(var cop : CodeOfPolicies) {
                     cop.aot_module = true
@@ -189,7 +185,7 @@ def serialize_path(ctx : SuiteCtx, files : array<string>, out_file : string) {
         }
         fwrite(f, res.total)
         ast_serializer_get_data(ser) $(data) {
-            var sz = uint64(length(data))
+            let sz = uint64(length(data))
             fwrite(f, sz)
             fwrite(f, data)
         }
@@ -225,17 +221,15 @@ def deserialize_path(var ctx : SuiteCtx, files : array<string>, in_file : string
         log::info("Deserializing {count:d} programs from {in_file}")
         var ser = create_ast_deserializer(data)
         using() $(var mg : ModuleGroup) {
-            for (i in range(int(count))) {
-                deserialize_program(ser) <| $(ok, program, error) {
+            for (i in range(count)) {
+                deserialize_program(ser) $(ok, program, error) {
                     if (!ok) {
                         log::error("Deserialization failed at program {i}: {error}")
                         res.errors++
                         res.total++
                         return
                     }
-                    if (program._options |> find_arg("rtti") ?as tBool ?? false) {
-                        return
-                    }
+                    return if (program._options |> find_arg("rtti") ?as tBool ?? false)
                     simulate(program) $(sok, context, serrors) {
                         if (!sok) {
                             log::error("Failed to simulate program {i}\n{serrors}")
@@ -265,7 +259,7 @@ def main() : int {
     // Captured for isolated-mode subprocess invocation; raw_args[0] is the
     // daslang interpreter path and raw_args[1] is dastest.das.  Everything
     // else for this main() comes from the parsed test_args below.
-    var raw_args <- get_command_line_arguments()
+    let raw_args <- get_command_line_arguments()
 
     var parse_result <- parse_args(type<DastestArgs>)
     if (parse_result |> is_err) {
@@ -279,7 +273,7 @@ def main() : int {
         // `--run=X` forms because parse_args has already populated the field.
         let res = suite::test_file(test_args.run, SuiteCtx(test_args))
         // Send full report with per-test details for isolated mode JSON collection
-        var report = JsonTestReport(
+        let report = JsonTestReport(
             file = test_args.run,
             total = res.total,
             passed = res.passed,
@@ -326,9 +320,7 @@ def main() : int {
 
     var inputPaths := test_args.test_files
     var files : array<string>
-    if (!collect_files(inputPaths, files)) {
-        return 1
-    }
+    return 1 if (!collect_files(inputPaths, files))
     if (!empty(test_args.exclude_files)) {
         files |> erase_if() $(f) {
             let base = base_name(f)
@@ -378,7 +370,7 @@ def main() : int {
                 }
             } else {
                 log::red("FAIL {uri} {time_dt_hr(fileDt)}")
-                var reason = "{status.failed} failed, {status.errors} errors"
+                let reason = "{status.failed} failed, {status.errors} errors"
                 failedFiles |> push(FailedFile(uri = clone_string(uri), reason = clone_string(reason)))
             }
             if (timingOutliers > 0) {
@@ -474,10 +466,7 @@ def main() : int {
                     for (isoRes in each_clone(outputChannel, type<IsolatedResult>)) {
                         res += isoRes.status
                         for (tr in isoRes.tests) {
-                            var msgs : array<string>
-                            for (m in tr.messages) {
-                                msgs |> push(clone_string(m))
-                            }
+                            var msgs <- [for (m in tr.messages); clone_string(m)]
                             suite::test_results |> emplace(SuiteTestResult(
                                 name = clone_string(tr.name),
                                 passed = tr.passed,
@@ -505,8 +494,8 @@ def main() : int {
                             log::red("FAIL {isoRes.uri} {time_dt_hr(isoRes.fileDt)}")
                             var reason = ""
                             if (isoRes.exitCode != 0 || !isoRes.parsedResult) {
-                                res.total += 1
-                                res.errors += 1
+                                res.total++
+                                res.errors++
                             }
                             if (isoRes.exitCode == popen_timed_out) {
                                 reason = "timed out after {testTimeout}s"
@@ -537,8 +526,8 @@ def main() : int {
 
 [export, pinvoke]
 def timeout_tests(var res : SuiteResult; start_time : int64; timeout_sec : float) {
-    res.errors += 1
-    res.total += 1
+    res.errors++
+    res.total++
     log::error("Test timed out after {timeout_sec}s")
     // timeout fires from a worker thread; fio::exit is the cross-thread
     // cancellation mechanism (bypasses shutdown dump — acceptable for this path).
@@ -570,20 +559,16 @@ def private print_timing_outliers() {
     let count = min(timingOutliers, n)
     let threshold = mean + 2.0lf * stddev
     // only print if there are actual outliers (top entry above threshold) or if few files
-    var meanStr = ""
-    meanStr = fmt(":.3f", mean / 1000000.0lf)
-    var stddevStr = ""
-    stddevStr = fmt(":.3f", stddev / 1000000.0lf)
-    var thresholdStr = ""
-    thresholdStr = fmt(":.3f", threshold / 1000000.0lf)
+    let meanStr = fmt(":.3f", mean / 1000000.0lf)
+    let stddevStr = fmt(":.3f", stddev / 1000000.0lf)
+    let thresholdStr = fmt(":.3f", threshold / 1000000.0lf)
     log::info("Timing: mean {meanStr}s, stddev {stddevStr}s, threshold {thresholdStr}s")
     log::info("Top {count} slowest files:")
     for (i in range(count)) {
         let dtSec = double(fileTimings[i].dt) / 1000000.0lf
         let marker = double(fileTimings[i].dt) > threshold ? " [outlier]" : ""
-        var dtStr = ""
-        dtStr = fmt(":.3f", dtSec)
-        var line = "  {dtStr}s  {fileTimings[i].uri}{marker}"
+        let dtStr = fmt(":.3f", dtSec)
+        let line = "  {dtStr}s  {fileTimings[i].uri}{marker}"
         log::info(line)
     }
 }
@@ -599,7 +584,7 @@ def finish_tests(res : SuiteResult; start_time : int64) : int {
     if (resCode == 0) {
         log::green("SUCCESS! {time_dt_hr(totalDt)}")
     } else {
-        if (length(failedFiles) > 0) {
+        if (!empty(failedFiles)) {
             log::red("\nFAILURES:")
             for (ff in failedFiles) {
                 log::red("  {ff.uri} — {ff.reason}")
@@ -609,7 +594,7 @@ def finish_tests(res : SuiteResult; start_time : int64) : int {
         log::red("FAILED! {time_dt_hr(totalDt)}")
     }
     if (!empty(jsonFilePath)) {
-        var report = JsonTestReport(
+        let report = JsonTestReport(
             file = jsonTestFile,
             total = res.total,
             passed = res.passed,

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -393,23 +393,33 @@ def main() : int {
             totalThreads = get_total_hw_threads() * 2
         }
         let testTimeout = test_args.test_timeout
+        // --headless is a pass-through flag (not parsed by DastestArgs); detect once
+        // here so each spawned --run subprocess re-receives it via singleTest cmd.
+        // Without this, the post-`--` slice in the child loses --headless and any
+        // playwright/harness that depends on it reverts to windowed mode.
+        let headlessFlag = find_index(raw_args, "--headless") >= 0 ? " --headless" : ""
         log::info("Running {totalFiles} tests in isolated mode with {totalThreads} threads\n")
         with_channel(totalFiles) $(inputChannel) {
             with_channel(totalFiles) $(outputChannel) {
                 with_job_status(totalThreads) $(completion) {
 
                     for (t in range(totalThreads)) {
-                        new_thread <| @ {
+                        new_thread <| @capture(= t) {
                             for_each_clone(inputChannel) $(input : IsoInput#) {
                                 var isoRes : IsolatedResult
                                 isoRes.uri = clone_string(input.uri)
-                                isoRes.cmd = clone_string(input.cmd)
+                                // Append --worker-index at pull time, not push time: the
+                                // worker that pulls a task gets to brand the cmd with its
+                                // own t. Tests read --worker-index from get_user_args() to
+                                // pick per-worker resources (e.g. unique TCP ports).
+                                let workerCmd = "{input.cmd} --worker-index {t}"
+                                isoRes.cmd = clone_string(workerCmd)
                                 let fileTime = ref_time_ticks()
                                 unsafe {
-                                    isoRes.exitCode = popen_timeout(input.cmd, testTimeout) $(f) {
+                                    isoRes.exitCode = popen_timeout(workerCmd, testTimeout) $(f) {
                                         if (f == null) {
-                                            // log::error("Internal error: Failed to execute cmd > {input.cmd}")
-                                            isoRes.err |> push("Internal error: Failed to execute cmd > {input.cmd}")
+                                            // log::error("Internal error: Failed to execute cmd > {workerCmd}")
+                                            isoRes.err |> push("Internal error: Failed to execute cmd > {workerCmd}")
                                             return
                                         }
                                         var readJson = false
@@ -456,7 +466,7 @@ def main() : int {
                         let jitstr = jit_enabled() ? "-jit" : ""
                         let aotstr = is_in_aot() ? "-use-aot" : ""
                         let benchstr = ctx.bench_enabled ? "--bench" : ""
-                        let singleTest = "{raw_args[0]} {raw_args[1]} {jitstr} {aotstr} -- --run {file} {benchstr} {log::useTtyColors ? " --color" : ""}"
+                        let singleTest = "{raw_args[0]} {raw_args[1]} {jitstr} {aotstr} -- --run {file} {benchstr} {log::useTtyColors ? " --color" : ""}{headlessFlag}"
                         inputChannel |> push_clone(IsoInput(uri = clone_string(uri), cmd = clone_string(singleTest)))
                         inputChannel |> notify()
                     }

--- a/dastest/dastest_clargs.das
+++ b/dastest/dastest_clargs.das
@@ -36,6 +36,9 @@ struct DastestArgs {
     @clarg_doc = "Number of threads to use in isolated mode; defaults to 2x the number of hardware threads when 0"
     isolated_mode_threads : int
 
+    @clarg_doc = "Stable worker index passed by parent dastest in isolated mode; tests read it from get_user_args() to derive per-worker ports/paths"
+    worker_index : int = 0
+
     @clarg_doc = "Run all benchmarks this number of times (useful for sample collection)"
     count : int = 1
 

--- a/dastest/tests/_isolated_fixture/test_one.das
+++ b/dastest/tests/_isolated_fixture/test_one.das
@@ -1,0 +1,8 @@
+options gen2
+
+require dastest/testing_boost public
+
+[test]
+def test_one(t : T?) {
+    t |> success(true, "ok")
+}

--- a/dastest/tests/_isolated_fixture/test_three.das
+++ b/dastest/tests/_isolated_fixture/test_three.das
@@ -1,0 +1,8 @@
+options gen2
+
+require dastest/testing_boost public
+
+[test]
+def test_three(t : T?) {
+    t |> success(true, "ok")
+}

--- a/dastest/tests/_isolated_fixture/test_two.das
+++ b/dastest/tests/_isolated_fixture/test_two.das
@@ -1,0 +1,8 @@
+options gen2
+
+require dastest/testing_boost public
+
+[test]
+def test_two(t : T?) {
+    t |> success(true, "ok")
+}

--- a/dastest/tests/_isolated_fixture/test_worker_index.das
+++ b/dastest/tests/_isolated_fixture/test_worker_index.das
@@ -1,0 +1,23 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/clargs
+require strings
+
+[test]
+def test_worker_index_round_trip(tt : T?) {
+    tt |> run("--worker-index N is visible via get_user_args() and in range") <| @(t : T?) {
+        let args <- get_user_args()
+        let idx = find_index(args, "--worker-index")
+        t |> success(idx >= 0, "--worker-index not found in get_user_args() args={args}")
+        if (idx < 0) {
+            return
+        }
+        t |> success(idx + 1 < length(args), "no value after --worker-index")
+        if (idx + 1 >= length(args)) {
+            return
+        }
+        let val = to_int(args[idx + 1])
+        t |> success(val >= 0 && val < 4, "worker_index {val} out of range [0, 4)")
+    }
+}

--- a/dastest/tests/test_isolated_mode.das
+++ b/dastest/tests/test_isolated_mode.das
@@ -1,0 +1,42 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require daslib/fio
+require daslib/strings_boost
+require strings
+
+def dastest_root() : string {
+    return "{get_das_root()}/dastest"
+}
+
+def fixture_dir() : string {
+    return "{dastest_root()}/tests/_isolated_fixture"
+}
+
+def run_isolated(var output : string&; var exit_code : int&) {
+    let exe = get_command_line_arguments()[0]
+    let cmd = "{exe} {dastest_root()}/dastest.das -- --test {fixture_dir()} --isolated-mode --isolated-mode-threads 4"
+    output = ""
+    unsafe {
+        exit_code = popen(cmd) $(f) {
+            if (f != null) {
+                while (!feof(f)) {
+                    output += fgets(f)
+                }
+            }
+        }
+    }
+}
+
+[test]
+def test_isolated_mode(tt : T?) {
+    tt |> run("isolated mode spawns 4 workers, fixture suite all passes, --worker-index round-trips") <| @(t : T?) {
+        var output : string
+        var exit_code : int
+        run_isolated(output, exit_code)
+        t |> equal(exit_code, 0)
+        t |> success(output |> contains("SUCCESS"), "expected SUCCESS in dastest output, got:\n{output}")
+    }
+}


### PR DESCRIPTION
## Summary

Currently dastest's isolated-mode singleTest cmd is `daslang dastest.das -- --run <file> [--bench] [--color]` — neither `--worker-index` nor `--headless` is plumbed. The former blocks any parallel test that needs per-worker resources (e.g. dasImgui's live-API port 9090, where 4 parallel workers all try to bind the same port); the latter is a latent bug that surfaces the moment CI combines `--isolated-mode` with `--headless`.

This PR threads both:

- **`DastestArgs`** gains a `worker_index` field (purely to silence `parse_args` on the spawned subprocess; dastest itself doesn't consume the value).
- The **isolated-mode worker lambda** captures its thread index `t` via `@capture(= t)` and appends `--worker-index {t}` to the cmd **at pull time** (worker that pulls a task brands the cmd with its own `t` — order matters, not the push order).
- `raw_args` is scanned once for `--headless` and that flag is conditionally appended to every `singleTest` cmd.

Tests read `--worker-index` via `get_user_args()` to derive per-worker ports/paths (e.g. `port = DEFAULT + worker_index`).

## New coverage

`dastest/tests/test_isolated_mode.das` spawns dastest-on-dastest with `--isolated-mode --isolated-mode-threads 4` against `dastest/tests/_isolated_fixture/` (3 trivial pass tests + `test_worker_index.das`). The fixture subdir is prefixed `_` so the outer dastest sweep skips it; the explicit `--test <path>` form still picks up its contents.

`test_worker_index.das` asserts `--worker-index` is visible in `get_user_args()` and the value is in `[0, 4)`. Negative case verified: removing the new plumbing trips this assertion immediately, proving the round-trip.

## Lint cleanup (separate commit)

Pre-push hook trips on 17 pre-existing lint warnings in `dastest.das` (LINT003 / LINT010 / PERF013 / PERF017 / PERF020 / STYLE001 / STYLE005 / STYLE027). Per repo policy, fixed at source in this PR — split into its own commit so the worker-index diff stays focused. All mechanical and behavior-preserving (var→let for never-reassigned, dead-store elimination, `+= 1` → `++`, comprehension for push-only loop, postfix early-exit braces collapsed).

## Unblocks

dasImgui CI flip to `--isolated-mode --isolated-mode-threads 4` for parallel integration tests (~3× wall-time reduction expected). Follow-up PR in dasImgui repo will add `playwright_worker_index()` reader + per-worker `--live-port` derivation.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test dastest/tests` — 8/8 pass.
- [x] Direct invocation: `daslang dastest.das -- --run test_worker_index.das --worker-index 2` passes.
- [x] Negative case: same invocation without `--worker-index` correctly fails the round-trip assertion.
- [x] Lint clean on all changed files (MCP `lint` + pre-push hook).
- [ ] CI green across all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)