### PR TITLE
dastest: preserve every pre-`--` daslang flag in isolated-mode subprocess cmd

### DIFF
--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -395,15 +395,20 @@ def main() : int {
         // dastest.das, --, ...], the old "raw_args[0] raw_args[1]" reconstruction
         // produced "daslang -load_module" — losing the flag value, breaking
         // local runs that point dastest at an external module via -load_module.
-        // Findex of `--` ≥ 0 always (dastest was invoked with `--` to receive
+        // Find index of `--` ≥ 0 always (dastest was invoked with `--` to receive
         // its own args); fall back to all raw_args if not, matching the old
-        // 2-arg implicit assumption.
+        // 2-arg implicit assumption. Quote any arg containing a space so paths
+        // like `C:/Program Files/...` survive popen's shell-split on the other
+        // side; both cmd.exe and /bin/sh honor double-quote-wrapped args.
         let dashdash = find_index(raw_args, "--")
         let launchPrefix = build_string() $(var w) {
             let n = dashdash > 0 ? dashdash : length(raw_args)
             for (i in range(n)) {
                 if (i > 0) w |> write(" ")
+                let needs_quote = raw_args[i] |> contains(" ")
+                if (needs_quote) w |> write("\"")
                 w |> write(raw_args[i])
+                if (needs_quote) w |> write("\"")
             }
         }
         log::info("Running {totalFiles} tests in isolated mode with {totalThreads} threads\n")

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -390,6 +390,22 @@ def main() : int {
         // Without this, the post-`--` slice in the child loses --headless and any
         // playwright/harness that depends on it reverts to windowed mode.
         let headlessFlag = find_index(raw_args, "--headless") >= 0 ? " --headless" : ""
+        // Preserve EVERY pre-`--` arg (daslang flags + script path), not just
+        // raw_args[0..1]. With raw_args = [daslang, -load_module, <path>,
+        // dastest.das, --, ...], the old "raw_args[0] raw_args[1]" reconstruction
+        // produced "daslang -load_module" — losing the flag value, breaking
+        // local runs that point dastest at an external module via -load_module.
+        // Findex of `--` ≥ 0 always (dastest was invoked with `--` to receive
+        // its own args); fall back to all raw_args if not, matching the old
+        // 2-arg implicit assumption.
+        let dashdash = find_index(raw_args, "--")
+        let launchPrefix = build_string() $(var w) {
+            let n = dashdash > 0 ? dashdash : length(raw_args)
+            for (i in range(n)) {
+                if (i > 0) w |> write(" ")
+                w |> write(raw_args[i])
+            }
+        }
         log::info("Running {totalFiles} tests in isolated mode with {totalThreads} threads\n")
         with_channel(totalFiles) $(inputChannel) {
             with_channel(totalFiles) $(outputChannel) {
@@ -458,7 +474,7 @@ def main() : int {
                         let jitstr = jit_enabled() ? "-jit" : ""
                         let aotstr = is_in_aot() ? "-use-aot" : ""
                         let benchstr = ctx.bench_enabled ? "--bench" : ""
-                        let singleTest = "{raw_args[0]} {raw_args[1]} {jitstr} {aotstr} -- --run {file} {benchstr} {log::useTtyColors ? " --color" : ""}{headlessFlag}"
+                        let singleTest = "{launchPrefix} {jitstr} {aotstr} -- --run {file} {benchstr} {log::useTtyColors ? " --color" : ""}{headlessFlag}"
                         inputChannel |> push_clone(IsoInput(uri = clone_string(uri), cmd = clone_string(singleTest)))
                         inputChannel |> notify()
                     }

--- a/dastest/tests/_isolated_fixture_pre_dashdash/test_preserved_flag.das
+++ b/dastest/tests/_isolated_fixture_pre_dashdash/test_preserved_flag.das
@@ -1,0 +1,23 @@
+options gen2
+
+require dastest/testing_boost public
+require strings
+
+// This fixture asserts that a daslang flag passed BEFORE the dastest.das
+// script (e.g. `daslang -dasroot <path> dastest.das -- ...`) is preserved
+// through dastest's isolated-mode singleTest cmd reconstruction. The outer
+// test_isolated_mode.das spawns dastest with a pre-`--` `-dasroot` flag;
+// this fixture runs in the spawned subprocess and checks that `-dasroot`
+// is in its own raw argv (because dastest preserved it via launchPrefix).
+[test]
+def test_preserved_flag_round_trip(tt : T?) {
+    tt |> run("dastest preserves pre-`--` daslang flags in isolated-mode subprocess argv") <| @(t : T?) {
+        let argv <- get_command_line_arguments()
+        let idx = find_index(argv, "-dasroot")
+        t |> success(idx >= 0, "expected -dasroot in argv, got argv={argv}")
+        if (idx < 0) {
+            return
+        }
+        t |> success(idx + 1 < length(argv), "-dasroot has no following path arg in argv")
+    }
+}

--- a/dastest/tests/test_isolated_mode.das
+++ b/dastest/tests/test_isolated_mode.das
@@ -15,9 +15,11 @@ def fixture_dir() : string {
     return "{dastest_root()}/tests/_isolated_fixture"
 }
 
-def run_isolated(var output : string&; var exit_code : int&) {
-    let exe = get_command_line_arguments()[0]
-    let cmd = "{exe} {dastest_root()}/dastest.das -- --test {fixture_dir()} --isolated-mode --isolated-mode-threads 4"
+def fixture_dir_pre_dashdash() : string {
+    return "{dastest_root()}/tests/_isolated_fixture_pre_dashdash"
+}
+
+def run_dastest(cmd : string; var output : string&; var exit_code : int&) {
     output = ""
     unsafe {
         exit_code = popen(cmd) $(f) {
@@ -33,9 +35,26 @@ def run_isolated(var output : string&; var exit_code : int&) {
 [test]
 def test_isolated_mode(tt : T?) {
     tt |> run("isolated mode spawns 4 workers, fixture suite all passes, --worker-index round-trips") <| @(t : T?) {
+        let exe = get_command_line_arguments()[0]
+        let cmd = "{exe} {dastest_root()}/dastest.das -- --test {fixture_dir()} --isolated-mode --isolated-mode-threads 4"
         var output : string
         var exit_code : int
-        run_isolated(output, exit_code)
+        run_dastest(cmd, output, exit_code)
+        t |> equal(exit_code, 0)
+        t |> success(output |> contains("SUCCESS"), "expected SUCCESS in dastest output, got:\n{output}")
+    }
+
+    tt |> run("isolated mode preserves pre-`--` daslang flags (-dasroot) in singleTest cmd") <| @(t : T?) {
+        // Pass `-dasroot {existing-dasroot}` — a no-op pre-`--` flag — to the outer
+        // dastest. Pre-fix, dastest's singleTest reconstruction used
+        // `raw_args[0] raw_args[1]` which dropped everything between exe and
+        // dastest.das. The fixture test under fixture_dir_pre_dashdash() asserts
+        // -dasroot survives into the spawned subprocess's argv.
+        let exe = get_command_line_arguments()[0]
+        let cmd = "{exe} -dasroot {get_das_root()} {dastest_root()}/dastest.das -- --test {fixture_dir_pre_dashdash()} --isolated-mode --isolated-mode-threads 1"
+        var output : string
+        var exit_code : int
+        run_dastest(cmd, output, exit_code)
         t |> equal(exit_code, 0)
         t |> success(output |> contains("SUCCESS"), "expected SUCCESS in dastest output, got:\n{output}")
     }


### PR DESCRIPTION
## Summary

dastest's isolated-mode subprocess cmd reconstruction at [dastest.das:464](dastest/dastest.das#L464) used `raw_args[0] raw_args[1]` — exe + script path. That implicitly assumed `daslang dastest.das -- ...` with no daslang flags between exe and script. Any other daslang flag — `-load_module <path>`, `-project_root <path>`, `-dasroot <path>` — was silently dropped from the subprocess cmd.

**Surface:** running an external-module workflow locally with `-load_module D:/DASPKG/<pkg>` + `--isolated-mode` produces a broken subprocess:

```
daslang.exe -load_module   -- --run X.das ...
```

`-load_module` has no path argument, daslang prints help, exits non-zero, the test "crashes". CI never hit this because CI invokes dastest without daslang flags (daspkg has installed the module globally).

**Fix:** scan `raw_args` for the `--` boundary, take everything before it as the launch prefix, and reconstruct `singleTest` using the full prefix rather than just the first two args. Falls back to all of `raw_args` if `--` is missing (matches the old 2-arg implicit assumption).

## Unblocks

Local validation of `--isolated-mode` for external-module work (any daspkg-style package: dasImgui, dasPUGIXML, dasSQLITE, …). Specifically: the dasImgui parallel-integration-tests follow-up (PR in [borisbat/dasImgui](https://github.com/borisbat/dasImgui)) needs this to verify locally before flipping CI.

## Test plan

- [x] `bin/Release/daslang.exe dastest/dastest.das -- --test dastest/tests` — 8/8 pass (full dastest self-test sweep).
- [x] `bin/Release/daslang.exe -load_module D:/DASPKG/dasImgui dastest/dastest.das -- --test D:/DASPKG/dasImgui/tests/integration --isolated-mode --isolated-mode-threads 4 --headless ...` — full dasImgui integration sweep runs cleanly (subprocess cmd preserves `-load_module`).
- [x] Lint clean on `dastest.das`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)