### PR TITLE
bench: Theme 8 splice coverage + sqlite_linq gaps catalog

### DIFF
--- a/benchmarks/sql/distinct_by_order_to_array.das
+++ b/benchmarks/sql/distinct_by_order_to_array.das
@@ -1,0 +1,55 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// _distinct_by(_.dealer_id) |> _order_by(_.price) |> to_array — pick first car per
+// dealer, sort by price. NO take suffix (compare against distinct_by_order_take,
+// which adds `take(N)` and routes through emit_bounded_heap). n=100k, DEALER_COUNT=100
+// → output is 100 rows. Theme 8 audit 3b (PR #2875).
+// Both lanes splice through emit_fused_prefilter (linq_fold.das:2351) — single fused
+// loop: per-element dset gate (`var order_dset : table<int>`) writes into fresh
+// `buf`, then `order_inplace(buf, ...)` tail. Saves cascade's distinct_by_to_array
+// intermediate iterator setup. Composes across source modes via the shared FoldArraySpec
+// dispatch (PR F4) — same emit fn drives array (each(arr)) and decs
+// (from_decs_template(...)) sources.
+// SQL (m1) — same window-function story as distinct_by_order_take: "one row per
+// dealer" needs `ROW_NUMBER() OVER (PARTITION BY dealer_id ORDER BY price) WHERE rn=1`.
+// sqlite_linq does not currently lower window functions — see
+// benchmarks/sql/sqlite_linq_gaps.md "window functions".
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(arr)._distinct_by(_.dealer_id)._order_by(_.price).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>)._distinct_by(_.dealer_id)._order_by(_.price).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def distinct_by_order_to_array_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def distinct_by_order_to_array_m4(b : B?) {
+    run_m4(b, 100000)
+}

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,6 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-27 from `ee2f1fe77` (PR F4.3 — `order_distinct_take` decs lane via DecsBrand fixture). Matrix refreshed for the new m4 cell: `_order_by(K) |> distinct() |> take(N) |> to_array` on a decs source now reports honest cost via a duplicate-prone single-int template. The m4 cell lands at 95.0 ns/op INTERP / 74.8 JIT vs m3f at 15.9 / 2.1 — the ratio is NOT apples-to-apples (see `order_distinct_take` note below). Other drift is bench-suite ordering noise: `sort_first` m4 INTERP drifted +28% on the F4.2 baseline, now drifts back -22% on this run (long-running pattern on this lane); `select_where_order_take` ±6-8% INTERP noise; sub-nanosecond JIT drifts at measurement floor.
+Generated 2026-05-27 from `39ab7624f` + 3 new Theme 8 benches. Three previously-uncovered splice arms from the Theme 8 fusion PR (#2875) now have benches: `reverse_distinct_by` (audit 2a, array-only), `distinct_by_order_to_array` (audit 3b, array + decs), `zip_reverse_to_array` (audit C4, zip array lane). All three splice on the first INTERP run (per-op cost in expected range, 1 alloc/op for the result buffer). SQL holes that won't get a bench under current sqlite_linq surface are now catalogued in [`sqlite_linq_gaps.md`](sqlite_linq_gaps.md) — by-design exclusions, deferred window-function lowerings, and zip's lack of relational form, each cross-referenced to the bench file that surfaces it.
 Fixture size: n = 100 000 (cars), 100 dealers, 5 brands. Each row is
 one bench family in `benchmarks/sql/`; columns are nanoseconds per
 logical operation. `—` marks an intentionally absent lane — see
@@ -39,6 +39,7 @@ before the timer resolution can measure them — they should be read as
 | `decs_count_bare_pred` | — | — | 4.2 | — |
 | `distinct_by_count` | 41.8 | 15.8 | 15.8 | 1.00× |
 | `distinct_by_order_take` | — | 21.8 | 23.4 | 1.07× |
+| `distinct_by_order_to_array` | — | 22.0 | 24.0 | 1.09× |
 | `distinct_count` | 41.7 | 16.0 | 15.9 | 0.99× |
 | `distinct_count_pred` | — | 16.2 | 16.2 | 1.00× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
@@ -72,6 +73,7 @@ before the timer resolution can measure them — they should be read as
 | `order_distinct_take` | — | 15.9 | 95.0 | 5.97× |
 | `order_reverse_normalized` | 38.6 | 16.3 | 20.0 | 1.23× |
 | `order_take_desc` | 38.5 | 16.2 | 19.9 | 1.23× |
+| `reverse_distinct_by` | — | 21.5 | — | — |
 | `reverse_take` | 0.10 | 0.00 | 10.2 | — |
 | `reverse_take_select` | 0.00 | 34.3 | 48.4 | 1.41× |
 | `select_count` | 0.10 | 0.00 | 2.2 | — |
@@ -96,6 +98,7 @@ before the timer resolution can measure them — they should be read as
 | `zip_count_pred` | — | 15.1 | — | — |
 | `zip_dot_product` | — | 12.7 | 10.7 | 0.84× |
 | `zip_dot_product_3arg` | — | 12.8 | — | — |
+| `zip_reverse_to_array` | — | 31.1 | — | — |
 
 ## JIT
 
@@ -113,6 +116,7 @@ before the timer resolution can measure them — they should be read as
 | `decs_count_bare_pred` | — | — | 0.60 | — |
 | `distinct_by_count` | 41.4 | 2.1 | 2.1 | 1.00× |
 | `distinct_by_order_take` | — | 2.7 | 3.2 | 1.19× |
+| `distinct_by_order_to_array` | — | 2.7 | 3.3 | 1.22× |
 | `distinct_count` | 41.5 | 2.1 | 2.1 | 1.00× |
 | `distinct_count_pred` | — | 2.1 | 2.3 | 1.10× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
@@ -146,6 +150,7 @@ before the timer resolution can measure them — they should be read as
 | `order_distinct_take` | — | 2.1 | 74.8 | 35.62× |
 | `order_reverse_normalized` | 38.3 | 0.70 | 1.3 | 1.86× |
 | `order_take_desc` | 38.4 | 0.70 | 1.3 | 1.86× |
+| `reverse_distinct_by` | — | 2.6 | — | — |
 | `reverse_take` | 0.00 | 0.00 | 1.1 | — |
 | `reverse_take_select` | 0.00 | 8.5 | 10.5 | 1.24× |
 | `select_count` | 0.10 | 0.00 | 0.00 | — |
@@ -170,12 +175,17 @@ before the timer resolution can measure them — they should be read as
 | `zip_count_pred` | — | 0.70 | — | — |
 | `zip_dot_product` | — | 0.50 | 0.50 | 1.00× |
 | `zip_dot_product_3arg` | — | 0.50 | — | — |
+| `zip_reverse_to_array` | — | 4.5 | — | — |
 
 
 ## Notes on missing lanes (the `—` cells)
 
 The reasons each cell is empty are also recorded as a comment in the
 corresponding `.das` bench file; the bullets below quote that comment.
+For deeper detail on SQL cells — what query each would lower to,
+whether the gap is window-function / surface-limitation / by-design,
+and which gaps could land in a single PR — see
+[`sqlite_linq_gaps.md`](sqlite_linq_gaps.md).
 
 - **`chained_select_collapse` SQL** — `_sql` rejects `distinct() |> count()`
   as non-translatable. The equivalent SQL `COUNT(DISTINCT computed-expr)`
@@ -190,7 +200,11 @@ corresponding `.das` bench file; the bullets below quote that comment.
   per dealer, sort by price, take N" needs window functions
   (`ROW_NUMBER() OVER (PARTITION BY dealer_id ORDER BY price)` + outer
   `WHERE rn=1` + `LIMIT N`); sqlite_linq does not currently lower window
-  functions. Follow-up TODO 2026-05-25.
+  functions. Follow-up TODO 2026-05-25 — see `sqlite_linq_gaps.md`
+  "Window-function lowerings".
+- **`distinct_by_order_to_array` SQL** — same window-function blocker as
+  `distinct_by_order_take`, drop the `LIMIT N`. See
+  `sqlite_linq_gaps.md` "Window-function lowerings".
 - **`distinct_count_pred` SQL** — sqlite_linq's `_distinct_by` + 2-arg
   `count(P)` shape isn't surfaced through `_sql` (would lower as
   `COUNT(*) FILTER WHERE ...`, not currently emitted). By design.
@@ -212,6 +226,13 @@ corresponding `.das` bench file; the bullets below quote that comment.
   bare `_` (only the `into` lambda's parameter names are valid
   receivers; computed projections would need to be inlined into the
   `into` lambda). By design — sqlite_linq surface limitation.
+- **`reverse_distinct_by` SQL / Decs** — SQL: same window-function
+  blocker as `distinct_by_order_take`, with descending key
+  (`ROW_NUMBER() OVER (PARTITION BY brand ORDER BY id DESC) WHERE rn=1`
+  picks "last-per-group"); see `sqlite_linq_gaps.md`. Decs: splice arm
+  is array-only (`array_source` predicate in
+  `daslib/linq_fold.das:3221`) because backward-index walk has no
+  archetype analog.
 - **`order_distinct_take` Decs vs Array ratio** — m4 (95.0 INTERP /
   74.8 JIT) vs m3f (15.9 INTERP / 2.1 JIT) is NOT apples-to-apples.
   `unique_key` (`daslib/linq.das:614`) short-circuits to a direct
@@ -250,6 +271,11 @@ corresponding `.das` bench file; the bullets below quote that comment.
   This row exercises the 3-arg `zip(a, b, sel)` pre-lowering (Theme 1,
   audit 7a); a companion to `zip_dot_product` with the explicit 2-arg
   + `_select` form. By design, no follow-up.
+- **`zip_reverse_to_array` SQL / Decs** — same `zip-not-relational`
+  reason as `zip_count_pred`. This row exercises the Theme 8 audit C4
+  splice — trailing `reverse()` on the zip array lane emits
+  `_::reverse_inplace` after the zip lockstep buffer fill. By design,
+  no follow-up.
 
 ## How to re-run
 

--- a/benchmarks/sql/reverse_distinct_by.das
+++ b/benchmarks/sql/reverse_distinct_by.das
@@ -1,0 +1,37 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// each(arr).reverse()._distinct_by(_.brand).to_array() — pick LAST row per brand
+// in source order. n=100k, BRAND_COUNT=5 → output is 5 rows (the last car seen
+// for each brand). Theme 8 audit 2a (PR #2875, R-2a row in linq_fold.das:3215).
+// Array m3f splices through emit_reverse_backward_walk_dset_gate: single backward
+// `for (k in 0..length(arr))` walk over `arr[length-1-k]`, `var rev_dset : table<int>`
+// gating push by !key_exists. Saves cascade's reverse_to_array allocation AND second
+// distinct_by_inplace pass — single source pass with set-gate.
+// Decs (m4) — splice gates on `array_source` predicate (linq_fold.das:3221), so the
+// arm is array-only. plan_decs_reverse has no backward-index analog (archetype walk
+// is forward-only). Skip — see benchmarks/sql/sqlite_linq_gaps.md "decs scope".
+// SQL (m1) — no faithful form. "Last row per group" requires
+// `ROW_NUMBER() OVER (PARTITION BY brand ORDER BY id DESC) WHERE rn=1` (window
+// function). sqlite_linq does not currently lower window functions — see
+// sqlite_linq_gaps.md "window functions".
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(arr).reverse()._distinct_by(_.brand).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def reverse_distinct_by_m3f(b : B?) {
+    run_m3f(b, 100000)
+}

--- a/benchmarks/sql/sqlite_linq_gaps.md
+++ b/benchmarks/sql/sqlite_linq_gaps.md
@@ -1,0 +1,171 @@
+# sqlite_linq lowering gaps — bench cells marked `—`
+
+Catalogues every `—` SQL cell in [`results.md`](results.md), split by **what's
+missing** rather than by bench. Each gap is either:
+
+- **window functions** — the canonical SQL form requires `ROW_NUMBER() OVER (...)` /
+  `PARTITION BY` / `LAG` / `LAG`, and `sqlite_linq` does not currently lower any
+  window-function surface. One follow-up PR could open the whole group.
+- **other deferred lowerings** — narrower surface gaps (`COUNT(DISTINCT
+  computed-expr)`, `COUNT(*) FILTER (WHERE ...)`, `_select` after `_join`,
+  LIMIT-before-WHERE semantics) where `sqlite_linq` has nothing equivalent
+  today but each could land independently.
+- **by design** — the chain has no faithful SQL form (zip is not relational;
+  LIMIT after an aggregate is a no-op).
+
+Cross-reference back to the `.das` bench file at each row — that's where the
+gap is documented inline.
+
+---
+
+## Window-function lowerings
+
+All of these chains pick "one row per group" or "the row matching
+`min/max/first ...` per group", which in SQL canonically uses
+`ROW_NUMBER() OVER (PARTITION BY k ORDER BY ...)` filtered by `rn = 1` (or
+`LIMIT 1`). Sometimes wrapped in a derived table. None of these forms are
+emitted by today's `sqlite_linq` surface.
+
+If one PR opens window-function lowering in `sqlite_linq` (e.g. a new
+`_partition_by` / `_row_number` surface, or an internal `_window_first`
+helper), all five of these cells can flip in the same change.
+
+| Bench | Chain | What SQL would lower |
+|---|---|---|
+| [`distinct_by_order_take`](distinct_by_order_take.das) | `_distinct_by(_.dealer_id) \|> _order_by(_.price) \|> take(N) \|> to_array` | `SELECT ... FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY dealer_id ORDER BY price) AS rn FROM Cars) WHERE rn = 1 LIMIT N` |
+| [`distinct_by_order_to_array`](distinct_by_order_to_array.das) | `_distinct_by(_.dealer_id) \|> _order_by(_.price) \|> to_array` | Same as above without `LIMIT N` |
+| [`groupby_first`](groupby_first.das) | `_group_by(_.brand) \|> _select(g => g.first())` | `SELECT ... FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY brand ORDER BY id) AS rn FROM Cars) WHERE rn = 1` |
+| [`reverse_distinct_by`](reverse_distinct_by.das) | `each(arr) \|> reverse() \|> _distinct_by(_.brand) \|> to_array` ("last per group") | `SELECT ... FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY brand ORDER BY id DESC) AS rn FROM Cars) WHERE rn = 1` |
+| [`order_distinct_take`](order_distinct_take.das) | `_order_by(_) \|> distinct() \|> take(N) \|> to_array` on bare scalar | Independent of window functions — see "Other deferred lowerings" below |
+
+**Original TODO dates** (carried in `results.md` Notes before this doc):
+`distinct_by_order_take` 2026-05-25, `groupby_first` 2026-05-23. The new
+2026-05-27 entries (`reverse_distinct_by`, `distinct_by_order_to_array`)
+inherit the same blocker.
+
+---
+
+## Other deferred lowerings (independent, each its own PR)
+
+### `_group_by` after `_join` — group key from joined projection
+
+Benches: [`join_groupby_count`](join_groupby_count.das),
+[`join_groupby_to_array`](join_groupby_to_array.das).
+
+`sqlite_linq`'s `_group_by` after `_join` doesn't lower today because the
+group key column comes from the join's `into` projection, not from a
+base-table column. The lowering would need to either emit the `JOIN` as a
+subquery and `GROUP BY` over the subquery's column, or surface the
+projection-column → SQL-fragment mapping into `_group_by`'s key-extractor
+logic. Originally TODO'd 2026-05-25.
+
+### `COUNT(*) FILTER (WHERE ...)` — 2-arg `count(P)` after `_distinct_by`
+
+Bench: [`distinct_count_pred`](distinct_count_pred.das).
+
+`_distinct_by(K) |> count(P)` would lower as
+`SELECT COUNT(*) FILTER (WHERE P) FROM (SELECT DISTINCT K FROM ...)`. The
+`FILTER (WHERE ...)` clause is SQLite-supported (>= 3.30) but
+`sqlite_linq` doesn't currently emit it. By design today, but a real
+surface candidate.
+
+### `COUNT(DISTINCT computed-expr)`
+
+Bench: [`chained_select_collapse`](chained_select_collapse.das).
+
+`distinct() |> count()` after a `_select` rejects today because the
+collapsed `_select` projects a computed expression, and SQLite's
+`COUNT(DISTINCT x)` accepts only column references in its grammar (or
+`COUNT(DISTINCT expr)` with parenthesization, depending on dialect).
+`sqlite_linq`'s emitter doesn't form the `DISTINCT computed-expr` shape
+yet. Plausible to lower if the projected expression has no aggregates,
+side effects, or non-pure functions.
+
+### `_select` after `_join` — bare `_` rejected
+
+Bench: [`join_select`](join_select.das).
+
+`_sql`'s `_select` after `_join` only accepts the `into` lambda's
+parameter names as receivers — bare `_` and computed projections are
+rejected. The fix would be to inline the projection into the `into`
+lambda before lowering, or surface a separate `_select` arm that
+post-projects the join result via a derived table. Surface limitation, not
+a query-shape impossibility.
+
+### `LIMIT` semantics edge cases
+
+Benches: [`take_count_filtered`](take_count_filtered.das),
+[`take_sum_aggregate`](take_sum_aggregate.das),
+[`take_where_count`](take_where_count.das).
+
+In SQL:
+- `LIMIT` after `COUNT(*)` / `SUM(...)` is a no-op (the aggregate collapses
+  to one row).
+- `LIMIT` applies after `WHERE`, not before, so `take(N) |> _where(P) |>
+  count()` ("first N rows, count matching") would need a derived-table
+  form (`SELECT COUNT(*) FROM (SELECT ... LIMIT N) WHERE ...`).
+
+`sqlite_linq` doesn't currently lower the derived-table form. Each of
+these can be addressed independently, but in practice the bench cells will
+likely stay `—` because the chain shape is unusual in SQL idiom (it's a
+fold-fold idiom).
+
+### `order_distinct_take` — bare key on synthesized scalar
+
+Bench: [`order_distinct_take`](order_distinct_take.das).
+
+`_sql`'s `_order_by` requires a `_.Field` (column-ref) key, not bare `_`.
+The bench operates on a synthesized `array<int>` with no named column, so
+the SQL form has no `.Field` to project. Independent of window functions
+— `distinct_take` proves `_sql` does lower
+`distinct() |> take(N)` when the source has a named column. Adding the
+SQL lane would need a 1-column table fixture and `_order_by(_.col)`.
+Cosmetic gap; low priority.
+
+---
+
+## By design — no SQL form possible
+
+### `zip` family — not a relational operation
+
+Benches: [`zip_count_pred`](zip_count_pred.das),
+[`zip_dot_product`](zip_dot_product.das),
+[`zip_dot_product_3arg`](zip_dot_product_3arg.das),
+[`zip_reverse_to_array`](zip_reverse_to_array.das).
+
+`zip(a, b)` pairs elements by position across two unrelated sequences.
+SQL has no concept of positional pairing across tables (joins are
+key-based, not index-based). A `ROW_NUMBER()`-joined emulation
+(`a JOIN b ON a.rn = b.rn`) would technically work but would be
+fundamentally different from the in-memory zip — different cost model,
+no real-world SQL idiom.
+
+These cells will stay `—` permanently.
+
+### `decs_count_bare_pred` — decs-specific Theme 4 root-cause fix
+
+Bench: [`decs_count_bare_pred`](decs_count_bare_pred.das).
+
+Covers a Theme 4 fix specific to the decs lane (bare
+`from_decs_template(...).count(P)` with no upstream where/select
+previously bailed because `forExpr.iteratorVariables` was unpopulated).
+Array-side bare `count(P)` was always reachable;
+SQL `count(P)` is covered by [`count_aggregate`](count_aggregate.das)
+with a where shape. The `—` Array and SQL cells aren't gaps — this bench
+is decs-only by design.
+
+---
+
+## Decs lane absent (not a SQL gap, but for symmetry)
+
+### `reverse_distinct_by` decs
+
+Bench: [`reverse_distinct_by`](reverse_distinct_by.das).
+
+The Theme 8 2a splice arm requires `array_source` (see
+[`daslib/linq_fold.das:3221`](../../daslib/linq_fold.das#L3221)) because the
+backward-index walk (`arr[length-1-k]`) has no natural decs analog —
+archetype walks are forward-only. A decs lane would need a new
+plan_decs_reverse rewrite that collects the forward walk into a temp buffer
+and then back-walks it (defeating the splice's whole "saves cascade's
+reverse_to_array allocation" point). Closed by design.

--- a/benchmarks/sql/zip_reverse_to_array.das
+++ b/benchmarks/sql/zip_reverse_to_array.das
@@ -1,0 +1,45 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// zip(a, b) |> reverse() |> to_array — pairwise zip with trailing reverse.
+// Theme 8 audit C4 (PR #2875, plan_zip array lane). Two int sequences of n elements
+// each → output is `array<tuple<int; int>>` reversed. Splice emits the zip lockstep
+// loop into `buf`, then `_::reverse_inplace($i(bufName))` tail. Skips the cascade's
+// zip_to_array iterator wrap + separate reverse_inplace pass.
+// The accumulator lane (zip+select+reverse+sum) is identity — reverse drops out,
+// the spliced code is equivalent to plain zip+sum (see zip_dot_product). The
+// to_array lane is the one where the trailing reverse actually does work, so
+// that's what this bench exercises.
+// SQL (m1) / Decs (m4) — by design: `zip` is not a relational operation (no SQL
+// form) and not naturally expressible over a single archetype walk (no decs form).
+// See benchmarks/sql/sqlite_linq_gaps.md "zip family".
+
+def make_ints(n : int) : array<int> {
+    var a : array<int>
+    a |> resize(n)
+    for (i in range(n)) {
+        a[i] = i
+    }
+    return <- a
+}
+
+def run_m3f(b : B?; n : int) {
+    let xs <- make_ints(n)
+    let ys <- make_ints(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        unsafe {
+            let rows <- _fold(each(xs) |> zip(each(ys)) |> reverse() |> to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def zip_reverse_to_array_m3f(b : B?) {
+    run_m3f(b, 100000)
+}


### PR DESCRIPTION
## Summary

Backfills bench coverage for the three Theme 8 splice arms that PR #2875 closed but the bench-rollup PR (#2870) didn't pick up (it covered Themes 1-7 only). Also opens [`benchmarks/sql/sqlite_linq_gaps.md`](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/bench-theme8-coverage/benchmarks/sql/sqlite_linq_gaps.md) as the deep-dive catalog for SQL `—` cells, splitting them into window-function lowerings (5 benches that one PR could close), other independently-deferred lowerings, and permanent by-design exclusions.

### Three new benches

| Bench | Splice arm | Lanes |
|---|---|---|
| `reverse_distinct_by` | audit 2a (`emit_reverse_backward_walk_dset_gate`) | m3f only — array-only via `array_source` predicate |
| `distinct_by_order_to_array` | audit 3b (`emit_fused_prefilter`, no-take mirror of `distinct_by_order_take`) | m3f + m4 |
| `zip_reverse_to_array` | audit C4 (`plan_zip` trailing `reverse_inplace`) | m3f only — `zip` is array-only |

### INTERP / JIT cells (verified splice on first run)

| Bench | m3f INTERP | m4 INTERP | m3f JIT | m4 JIT |
|---|---:|---:|---:|---:|
| `reverse_distinct_by` | 21.5 | — | 2.6 | — |
| `distinct_by_order_to_array` | 22.0 | 24.0 | 2.7 | 3.3 |
| `zip_reverse_to_array` | 31.1 | — | 4.5 | — |

`distinct_by_order_to_array` m3f/m4 cells land within 2-3% of `distinct_by_order_take` (22.0 vs 21.8 m3f; 24.0 vs 23.4 m4) — same `emit_fused_prefilter` path, only the no-take tail differs. Per-element cost is in the expected band, no cascade.

### sqlite_linq_gaps.md

The new doc catalogues every `—` SQL cell in `results.md` by **what's missing** (window functions / other deferred surface gaps / by-design), not by bench. Five benches share the window-function blocker (`groupby_first`, `distinct_by_order_take`, `distinct_by_order_to_array`, `reverse_distinct_by`, `order_distinct_take`) — one follow-up PR opening `ROW_NUMBER() OVER (PARTITION BY ...)` lowering in `sqlite_linq` would flip all five cells at once. The other independently-deferred lowerings (`COUNT(DISTINCT computed-expr)`, `COUNT(*) FILTER (WHERE ...)`, `_select` after `_join`, derived-table forms for `LIMIT`-before-`WHERE`) each get their own section with the canonical query, the bench that surfaces it, and what would need to change in `sqlite_linq`. By-design exclusions (`zip` family — not relational) are explicitly closed.

### Why no `daslib/` changes

Splice paths already verified by `tests/linq/test_linq_fold_theme8_fusion_arms.das` (36 tests, all passing). This PR is bench coverage + documentation only; no library surface touched.

## Test plan

- [x] `mcp__daslang__format_file` — all 3 `.das` files no-op
- [x] `mcp__daslang__lint` — all 3 `.das` files clean
- [x] Sanity-bench each new file INTERP + JIT — all splice on first run, cells in expected range
- [x] `tests/linq/test_linq_fold_theme8_fusion_arms.das` — 36/36 passing (no regression from new bench file additions)
- [ ] CI green (waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)