### PR TITLE
sqlite_linq: _distinct_by as chain operator + first-row aggregates

### DIFF
--- a/benchmarks/sql/_common.das
+++ b/benchmarks/sql/_common.das
@@ -144,6 +144,24 @@ def public fixture_decs_brands(n : int) {
     }
 }
 
+// SQL-side mirror of DecsBrand / make_brands. n rows of `value = i % BRAND_COUNT`
+// gives dense duplicates so the SQL DISTINCT lane has meaningful work to do.
+[sql_table(name = "Brands")]
+struct public Brand {
+    @sql_primary_key id : int
+    value : int
+}
+
+def public fixture_db_brands(db : SqlRunner; n : int) {
+    db |> create_table(type<Brand>)
+    var brands : array<Brand>
+    brands |> resize(n)
+    for (i in range(n)) {
+        brands[i] = Brand(id = i + 1, value = i % BRAND_COUNT)
+    }
+    db |> insert(brands)
+}
+
 // Same fixture as fixture_decs, but returns the eid of the n/2-th entity for indexed-lookup benches.
 // The decs O(1) lookup path keys on EntityId (not the Car.id column), so the bench needs an actual eid
 // captured at creation time. fixture_decs has no return so call sites can't reuse it for this.

--- a/benchmarks/sql/distinct_count_pred.das
+++ b/benchmarks/sql/distinct_count_pred.das
@@ -7,13 +7,32 @@ let THRESHOLD = 2009
 
 // _distinct_by(_.brand) |> count(P) — distinct brands whose first-occurrence Car
 // satisfies P (Theme 4, audit 3c).
-// SQL: no clean form — sqlite_linq's `_distinct_by + count(P)` 2-arg shape isn't
-// surfaced through `_sql` (count with predicate after distinct lowers as
-// `COUNT(* FILTER WHERE ...)` which the lowerer doesn't emit). By design.
+// SQL (m1) uses the SQLite bare-aggregate `_distinct_by` wrap added in
+// sqlite_linq.das::finalize_distinct_by_count_wrap: emits
+// `SELECT COUNT(*) FROM (SELECT *, MIN("id") FROM "Cars" GROUP BY "brand") WHERE "year" > ?`.
+// The inner subquery's MIN(id) drives SQLite's bare-aggregate optimization to
+// pick the row with the smallest Id per brand — matches linq's "first row per key"
+// semantics when Id is monotonic with insertion order (fixture sets Id = i + 1).
+// User idiom inside `_sql(...)` is the `_count(_.field > X)` linq_boost shorthand,
+// NOT the explicit `count($(c) => ...)` lambda form which sqlite_linq's macro
+// boundary can't type-bind.
 // Array/Decs splice through plan_distinct / plan_decs_distinct's 2-arg-count extension:
 // dedup table built unconditionally so `distinct_by` semantics keeps FIRST occurrence
 // per key; a separate counter increments only when P matches that first occurrence.
 // Companion to distinct_by_count.das which has no predicate.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let c = _sql(db |> select_from(type<Car>) |> _distinct_by(_.brand) |> _count(_.year > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
 
 def run_m3f(b : B?; n : int) {
     let arr <- fixture_array(n)
@@ -39,6 +58,11 @@ def run_m4(b : B?; n : int) {
             }
         }
     }
+}
+
+[benchmark]
+def distinct_count_pred_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/order_distinct_take.das
+++ b/benchmarks/sql/order_distinct_take.das
@@ -21,13 +21,11 @@ let TAKE_N = 5
 // cost, not decs-walk vs array-walk. For a key-based dedup variant on decs that
 // avoids unique_key's string path entirely, see `distinct_by_count_m4` which dedups
 // on a workhorse key via `_distinct_by(_.brand)`.
-// SQL: `_sql`'s `_order_by` requires a `_.Field` (column-ref) key, not bare `_`
-// (`error[50503]: _sql: _order_by: key must be `_.Field`, a `string` expression,
-// or a tuple of either; got: _`). This is independent of distinct/take ordering —
-// `distinct_take.das` shows `_sql` does lower `distinct() |> take(N)` when the
-// source has a named column. Bench operates on a synthesized bare-scalar
-// `array<int>`, so the SQL form has no `.Field` to project. By design — to add
-// a SQL lane we'd need a 1-column table fixture and lower `_order_by(_.col)`.
+// SQL (m1) uses the `Brand` 1-column fixture (`_common.das`) — `_sql`'s
+// `_order_by` requires a `_.Field` (column-ref) key, not bare `_`, so the
+// chain wraps the single column in a named tuple via `_select((value=_.value))`
+// before sorting. Emits the clean `SELECT DISTINCT "value" FROM "Brands"
+// ORDER BY "value" ASC LIMIT ?` form (no subquery wrap).
 
 def make_brands(n : int) : array<int> {
     var a : array<int>
@@ -36,6 +34,19 @@ def make_brands(n : int) : array<int> {
         a[i] = i % BRAND_COUNT
     }
     return <- a
+}
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db_brands(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let rows <- _sql(db |> select_from(type<Brand>) |> _select((value = _.value)) |> distinct() |> _order_by(_.value) |> take(TAKE_N))
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
 }
 
 def run_m3f(b : B?; n : int) {
@@ -62,6 +73,11 @@ def run_m4(b : B?; n : int) {
             }
         }
     }
+}
+
+[benchmark]
+def order_distinct_take_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,6 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-27 from `39ab7624f` + 3 new Theme 8 benches. Three previously-uncovered splice arms from the Theme 8 fusion PR (#2875) now have benches: `reverse_distinct_by` (audit 2a, array-only), `distinct_by_order_to_array` (audit 3b, array + decs), `zip_reverse_to_array` (audit C4, zip array lane). All three splice on the first INTERP run (per-op cost in expected range, 1 alloc/op for the result buffer). SQL holes that won't get a bench under current sqlite_linq surface are now catalogued in [`sqlite_linq_gaps.md`](sqlite_linq_gaps.md) — by-design exclusions, deferred window-function lowerings, and zip's lack of relational form, each cross-referenced to the bench file that surfaces it.
+Generated 2026-05-27 from PR `bbatkin/sqlite-linq-distinct-by-aggregates` (sqlite_linq `_distinct_by` as chain operator + first-row aggregates). Two SQL `—` cells now populated: `order_distinct_take` m1 = 139.2 INTERP / 138.2 JIT via a new 1-column `Brand` table fixture (named-tuple projection lets `_sql` lower to clean `SELECT DISTINCT "value" FROM "Brands" ORDER BY "value" ASC LIMIT ?`); `distinct_count_pred` m1 = 253.1 INTERP / 252.8 JIT via the new bare-aggregate `_distinct_by(K) |> _count(P)` wrap (lowers to `SELECT COUNT(*) FROM (SELECT *, MIN("id") FROM "Cars" GROUP BY "brand") WHERE "year" > ?`). The remaining SQL `—` cells stay catalogued in [`sqlite_linq_gaps.md`](sqlite_linq_gaps.md). Other drift is bench-suite ordering noise: `distinct_by_order_take` m4 INTERP 23.4 → 30.9 (+32%), `groupby_select_order` m4 INTERP 18.7 → 24.2 (+29%), `select_where_order_take` m3f/m4 INTERP ±6-8% — same long-running pattern as prior PRs; sub-nanosecond JIT cells drift at measurement floor.
 Fixture size: n = 100 000 (cars), 100 dealers, 5 brands. Each row is
 one bench family in `benchmarks/sql/`; columns are nanoseconds per
 logical operation. `—` marks an intentionally absent lane — see
@@ -38,10 +38,10 @@ before the timer resolution can measure them — they should be read as
 | `count_aggregate` | 30.0 | 4.2 | 4.1 | 0.98× |
 | `decs_count_bare_pred` | — | — | 4.2 | — |
 | `distinct_by_count` | 41.8 | 15.8 | 15.8 | 1.00× |
-| `distinct_by_order_take` | — | 21.8 | 23.4 | 1.07× |
+| `distinct_by_order_take` | — | 21.8 | 30.9 | 1.42× |
 | `distinct_by_order_to_array` | — | 22.0 | 24.0 | 1.09× |
 | `distinct_count` | 41.7 | 16.0 | 15.9 | 0.99× |
-| `distinct_count_pred` | — | 16.2 | 16.2 | 1.00× |
+| `distinct_count_pred` | 253.1 | 15.9 | 16.0 | 1.01× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
@@ -55,7 +55,7 @@ before the timer resolution can measure them — they should be read as
 | `groupby_max` | 174.2 | 25.0 | 25.6 | 1.02× |
 | `groupby_min` | 176.3 | 25.0 | 25.2 | 1.01× |
 | `groupby_multi_reducer` | 190.1 | 32.5 | 33.0 | 1.02× |
-| `groupby_select_order` | 169.9 | 18.6 | 18.7 | 1.01× |
+| `groupby_select_order` | 171.4 | 18.6 | 24.2 | 1.30× |
 | `groupby_select_sum` | 200.9 | 36.5 | 35.9 | 0.98× |
 | `groupby_sum` | 172.6 | 18.8 | 18.8 | 1.00× |
 | `groupby_where_count` | 75.9 | 14.5 | 15.0 | 1.03× |
@@ -70,7 +70,7 @@ before the timer resolution can measure them — they should be read as
 | `long_count_aggregate` | 30.0 | 4.2 | 4.1 | 0.98× |
 | `max_aggregate` | 31.4 | 6.0 | 6.9 | 1.15× |
 | `min_aggregate` | 31.5 | 6.2 | 6.9 | 1.11× |
-| `order_distinct_take` | — | 15.9 | 95.0 | 5.97× |
+| `order_distinct_take` | 139.2 | 15.8 | 95.5 | 6.04× |
 | `order_reverse_normalized` | 38.6 | 16.3 | 20.0 | 1.23× |
 | `order_take_desc` | 38.5 | 16.2 | 19.9 | 1.23× |
 | `reverse_distinct_by` | — | 21.5 | — | — |
@@ -79,7 +79,7 @@ before the timer resolution can measure them — they should be read as
 | `select_count` | 0.10 | 0.00 | 2.2 | — |
 | `select_where` | 195.7 | 11.3 | 19.9 | 1.76× |
 | `select_where_count` | 33.3 | 5.2 | 7.5 | 1.44× |
-| `select_where_order_take` | 37.1 | 13.3 | 15.9 | 1.20× |
+| `select_where_order_take` | 37.0 | 12.3 | 14.9 | 1.21× |
 | `select_where_sum` | 37.3 | 7.6 | 7.6 | 1.00× |
 | `single_match` | 0.00 | 2.9 | 5.5 | 1.90× |
 | `skip_take` | 0.50 | 0.10 | 0.20 | 2.00× |
@@ -118,7 +118,7 @@ before the timer resolution can measure them — they should be read as
 | `distinct_by_order_take` | — | 2.7 | 3.2 | 1.19× |
 | `distinct_by_order_to_array` | — | 2.7 | 3.3 | 1.22× |
 | `distinct_count` | 41.5 | 2.1 | 2.1 | 1.00× |
-| `distinct_count_pred` | — | 2.1 | 2.3 | 1.10× |
+| `distinct_count_pred` | 252.8 | 2.1 | 2.3 | 1.10× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
@@ -147,7 +147,7 @@ before the timer resolution can measure them — they should be read as
 | `long_count_aggregate` | 29.9 | 0.40 | 0.60 | 1.50× |
 | `max_aggregate` | 31.3 | 0.60 | 0.50 | 0.83× |
 | `min_aggregate` | 31.2 | 0.60 | 0.50 | 0.83× |
-| `order_distinct_take` | — | 2.1 | 74.8 | 35.62× |
+| `order_distinct_take` | 138.2 | 2.1 | 74.9 | 35.67× |
 | `order_reverse_normalized` | 38.3 | 0.70 | 1.3 | 1.86× |
 | `order_take_desc` | 38.4 | 0.70 | 1.3 | 1.86× |
 | `reverse_distinct_by` | — | 2.6 | — | — |
@@ -205,9 +205,6 @@ and which gaps could land in a single PR — see
 - **`distinct_by_order_to_array` SQL** — same window-function blocker as
   `distinct_by_order_take`, drop the `LIMIT N`. See
   `sqlite_linq_gaps.md` "Window-function lowerings".
-- **`distinct_count_pred` SQL** — sqlite_linq's `_distinct_by` + 2-arg
-  `count(P)` shape isn't surfaced through `_sql` (would lower as
-  `COUNT(*) FILTER WHERE ...`, not currently emitted). By design.
 - **`groupby_first` SQL** — no direct SQL aggregator for "first
   source-order row per group". Window functions (`ROW_NUMBER() OVER
   (PARTITION BY brand ORDER BY id)` + outer `WHERE rn=1`) would be the
@@ -233,8 +230,8 @@ and which gaps could land in a single PR — see
   is array-only (`array_source` predicate in
   `daslib/linq_fold.das:3221`) because backward-index walk has no
   archetype analog.
-- **`order_distinct_take` Decs vs Array ratio** — m4 (95.0 INTERP /
-  74.8 JIT) vs m3f (15.9 INTERP / 2.1 JIT) is NOT apples-to-apples.
+- **`order_distinct_take` Decs vs Array ratio** — m4 (95.5 INTERP /
+  74.9 JIT) vs m3f (15.8 INTERP / 2.1 JIT) is NOT apples-to-apples.
   `unique_key` (`daslib/linq.das:614`) short-circuits to a direct
   return for workhorse types and falls back to `"{a}"` string
   interpolation for everything else. Array m3f operates on
@@ -245,13 +242,6 @@ and which gaps could land in a single PR — see
   key-based dedup variant on decs that avoids `unique_key`'s string
   path see `distinct_by_count` (`_distinct_by(_.brand)` over decs,
   m4 = 15.8 INTERP / 2.1 JIT = parity with the array fast path).
-- **`order_distinct_take` SQL** — `_sql`'s `_order_by` requires a
-  `_.Field` (column-ref) key, not bare `_`. Bench operates on a
-  synthesized `array<int>` (no named column to project), so the SQL
-  form has no `.Field` to pass. Independent of distinct/take ordering
-  — `distinct_take.das` proves `_sql` does lower `distinct() |> take(N)`
-  when the source has a named column. By design — adding a SQL lane
-  would need a 1-column table fixture and `_order_by(_.col)`.
 - **`take_count_filtered` SQL** — by design. In SQL, LIMIT after an
   aggregate has no effect (the aggregate collapses to one row), so the
   bound-then-count shape has no faithful SQL translation. No follow-up.

--- a/benchmarks/sql/sqlite_linq_gaps.md
+++ b/benchmarks/sql/sqlite_linq_gaps.md
@@ -42,7 +42,7 @@ helper), all five of these cells can flip in the same change.
 2026-05-27 entries (`reverse_distinct_by`, `distinct_by_order_to_array`)
 inherit the same blocker.
 
-**Closed in PR #XXXX** (sqlite_linq `_distinct_by` as chain operator + first-row aggregates, 2026-05-27):
+**Closed in PR #2906** (sqlite_linq `_distinct_by` as chain operator + first-row aggregates, 2026-05-27):
 - `order_distinct_take` — closed by 1-column `Brand` table fixture (not window functions).
 - `distinct_count_pred` — closed by the SQLite bare-aggregate wrap
   (`SELECT COUNT(*) FROM (SELECT *, MIN(pk) FROM t GROUP BY K) WHERE P`).

--- a/benchmarks/sql/sqlite_linq_gaps.md
+++ b/benchmarks/sql/sqlite_linq_gaps.md
@@ -36,12 +36,20 @@ helper), all five of these cells can flip in the same change.
 | [`distinct_by_order_to_array`](distinct_by_order_to_array.das) | `_distinct_by(_.dealer_id) \|> _order_by(_.price) \|> to_array` | Same as above without `LIMIT N` |
 | [`groupby_first`](groupby_first.das) | `_group_by(_.brand) \|> _select(g => g.first())` | `SELECT ... FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY brand ORDER BY id) AS rn FROM Cars) WHERE rn = 1` |
 | [`reverse_distinct_by`](reverse_distinct_by.das) | `each(arr) \|> reverse() \|> _distinct_by(_.brand) \|> to_array` ("last per group") | `SELECT ... FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY brand ORDER BY id DESC) AS rn FROM Cars) WHERE rn = 1` |
-| [`order_distinct_take`](order_distinct_take.das) | `_order_by(_) \|> distinct() \|> take(N) \|> to_array` on bare scalar | Independent of window functions — see "Other deferred lowerings" below |
 
 **Original TODO dates** (carried in `results.md` Notes before this doc):
 `distinct_by_order_take` 2026-05-25, `groupby_first` 2026-05-23. The new
 2026-05-27 entries (`reverse_distinct_by`, `distinct_by_order_to_array`)
 inherit the same blocker.
+
+**Closed in PR #XXXX** (sqlite_linq `_distinct_by` as chain operator + first-row aggregates, 2026-05-27):
+- `order_distinct_take` — closed by 1-column `Brand` table fixture (not window functions).
+- `distinct_count_pred` — closed by the SQLite bare-aggregate wrap
+  (`SELECT COUNT(*) FROM (SELECT *, MIN(pk) FROM t GROUP BY K) WHERE P`).
+  The original gaps doc misidentified the lowering as `COUNT(*) FILTER (WHERE P)`
+  over `SELECT DISTINCT K` — incorrect because `SELECT DISTINCT K` only projects
+  K and P can't reference other columns. The bare-aggregate form preserves all
+  `SELECT *` columns at the min-PK row, matching linq `_distinct_by` semantics.
 
 ---
 
@@ -58,16 +66,6 @@ base-table column. The lowering would need to either emit the `JOIN` as a
 subquery and `GROUP BY` over the subquery's column, or surface the
 projection-column → SQL-fragment mapping into `_group_by`'s key-extractor
 logic. Originally TODO'd 2026-05-25.
-
-### `COUNT(*) FILTER (WHERE ...)` — 2-arg `count(P)` after `_distinct_by`
-
-Bench: [`distinct_count_pred`](distinct_count_pred.das).
-
-`_distinct_by(K) |> count(P)` would lower as
-`SELECT COUNT(*) FILTER (WHERE P) FROM (SELECT DISTINCT K FROM ...)`. The
-`FILTER (WHERE ...)` clause is SQLite-supported (>= 3.30) but
-`sqlite_linq` doesn't currently emit it. By design today, but a real
-surface candidate.
 
 ### `COUNT(DISTINCT computed-expr)`
 
@@ -109,18 +107,6 @@ In SQL:
 these can be addressed independently, but in practice the bench cells will
 likely stay `—` because the chain shape is unusual in SQL idiom (it's a
 fold-fold idiom).
-
-### `order_distinct_take` — bare key on synthesized scalar
-
-Bench: [`order_distinct_take`](order_distinct_take.das).
-
-`_sql`'s `_order_by` requires a `_.Field` (column-ref) key, not bare `_`.
-The bench operates on a synthesized `array<int>` with no named column, so
-the SQL form has no `.Field` to project. Independent of window functions
-— `distinct_take` proves `_sql` does lower
-`distinct() |> take(N)` when the source has a named column. Adding the
-SQL lane would need a 1-column table fixture and `_order_by(_.col)`.
-Cosmetic gap; low priority.
 
 ---
 

--- a/doc/source/reference/tutorials/sql_12_distinct.rst
+++ b/doc/source/reference/tutorials/sql_12_distinct.rst
@@ -49,6 +49,54 @@ Composes with ``_where``
                                  |> distinct())
     // SELECT DISTINCT "Name" FROM "Cars" WHERE "Price" > ?
 
+Distinct + first-row aggregates
+===============================
+
+``_distinct_by(_.K)`` followed by an aggregate terminator
+(``_count(_.field > X)`` / ``_long_count(_.field > X)``, or
+``_select(_.F) |> sum()`` / ``min()`` / ``max()`` / ``average()``)
+lowers to a SQLite bare-aggregate subquery that picks the row with the
+smallest ``@sql_primary_key`` per group:
+
+.. code-block:: das
+
+    // Count distinct brands whose first-encountered Car has Year > 2009
+    let n = _sql(db |> select_from(type<Car>)
+                    |> _distinct_by(_.Brand)
+                    |> _count(_.Year > 2009))
+    // SELECT COUNT(*) FROM (SELECT *, MIN("Id") FROM "Cars" GROUP BY "Brand") AS "t0" WHERE "Year" > ?
+
+    // Same shape with long_count for int64 result
+    let n64 = _sql(db |> select_from(type<Car>)
+                      |> _distinct_by(_.Brand)
+                      |> _long_count(_.Year > 2009))
+    // (identical SQL; result type widens to int64)
+
+    // Sum of price of the first-encountered Car per brand
+    let total = _sql(db |> select_from(type<Car>)
+                        |> _distinct_by(_.Brand)
+                        |> _select(_.Price)
+                        |> sum())
+    // SELECT SUM("Price") FROM (SELECT *, MIN("Id") FROM "Cars" GROUP BY "Brand") AS "t0"
+
+"First-encountered" = the row with the minimum ``@sql_primary_key`` value
+per group. For tables where the PK is monotonic with insertion order (the
+common case), this matches the array/decs ``_distinct_by`` semantics
+("first row by source order"). Requires a single-column
+``@sql_primary_key`` on the source table; composite keys reject.
+
+Inside ``_sql(...)`` you must use the ``_count(_.field > X)`` /
+``_long_count(_.field > X)`` linq_boost shorthand for the predicate form
+— the explicit lambda form ``count($(c) => c.field > X)`` fails type
+inference because ``_sql``'s macro boundary blocks the typer from
+binding ``c`` through unexpanded chain operators (same constraint as
+``_where(_.field > X)``).
+
+For the no-predicate form ``_distinct_by(_.K) |> count()`` /
+``long_count()``, ``_sql`` continues to emit the simpler
+``COUNT(DISTINCT "K")`` (no subquery wrap); see
+:ref:`tutorial_sql_aggregates`.
+
 For ``UNION`` / ``INTERSECT`` / ``EXCEPT`` see :ref:`tutorial_sql_set_ops`.
 
 .. seealso::

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -5430,6 +5430,81 @@ The `_sql` translator side stays unchanged — `text_match` on an
 query string to SQLite verbatim. The full-grammar in-memory matcher
 just removes the panic when those same chains run without `_sql`.
 
+## Shipped — chunk N: `_distinct_by` as chain operator + first-row aggregates (branch `bbatkin/sqlite-linq-distinct-by-aggregates`)
+
+### Surface in this PR
+
+`_distinct_by(_.K)` is now a first-class chain operator (previously
+recognized only inside `peel_count_terminal`'s `try_peel_distinct_by_field`
+helper). When followed by an aggregate terminator, lowers to a SQLite
+bare-aggregate subquery:
+
+- `_distinct_by(_.K) |> _count(P)` / `_long_count(P)`
+  → `SELECT COUNT(*) FROM (SELECT *, MIN("pk") FROM "table" GROUP BY "K") WHERE <P>`
+- `_distinct_by(_.K) |> _select(_.F) |> sum()` / `min()` / `max()` / `average()`
+  → `SELECT <AGG>("F") FROM (SELECT *, MIN("pk") FROM "table" GROUP BY "K")`
+
+Existing fast path preserved: `_distinct_by(_.K) |> count()` (no predicate)
+continues to emit `COUNT(DISTINCT "K")` — single SELECT, no subquery wrap.
+
+User idiom inside `_sql(...)` for the predicate form is the linq_boost
+`_count(_.field > X)` / `_long_count(_.field > X)` shorthand (parallel
+to `_where(_.field > X)`). The explicit `count($(c) => c.field > X)`
+lambda form fails type inference because `_sql`'s macro boundary blocks
+the typer from binding `c` through unexpanded chain operators.
+
+### Why the bare-aggregate trick
+
+SQLite documents that `SELECT *, MIN(<col>) FROM table GROUP BY K` returns
+non-aggregate columns from the row with the minimum `<col>` per group
+(the "bare aggregate" optimization). With `<col>` set to the table's
+`@sql_primary_key`, "row with min PK per K" = "first row by source order"
+when the PK is monotonic with insertion (the common case). This matches
+linq's `_distinct_by` "first row per key" semantics without window
+functions.
+
+### Constraints (v1)
+
+- Source must have exactly one `@sql_primary_key` field (composite PKs reject).
+- `_distinct_by` appears at most once in the chain.
+- `_distinct_by` must apply to a single source table (no `_join` upstream).
+- No other chain ops between `_distinct_by` and the terminator (other than
+  the optional `_select(_.F)` for column aggregates) — `_where` / `_order_by` /
+  `take` / `skip` etc. in between cleanly reject with macro_error.
+
+### Tests
+
+`tests/dasSQLITE/test_32_distinct.das` — 8 new tests (3 → 11 total)
+covering each new chain shape + emit-shape assertions + runtime correctness
+on a fixture with duplicate names and monotonic PKs.
+
+Rejection paths (no-pk / composite-pk / double `_distinct_by` / chain ops
+between distinct_by and terminator) wired via explicit macro_error calls in
+`sqlite_linq.das` but NOT added as `failed_*.das` probes — the linq
+generic-instantiation cascade after `_sql` returns null is brittle to
+maintain (couples to internal linq.das line numbers). Code-review covers
+the rejection sites.
+
+### Benches
+
+`benchmarks/sql/distinct_count_pred.das` — `m1` row now populated
+(uses the new `_count(_.year > THRESHOLD)` shorthand inside `_sql`).
+`benchmarks/sql/order_distinct_take.das` — `m1` row now populated via
+new 1-column `Brand` table fixture in `_common.das`.
+`benchmarks/sql/results.md` refreshed. `sqlite_linq_gaps.md` updated to
+note both gaps closed.
+
+### Deferred to chunk N+1
+
+- MAX(pk) variant for `each |> reverse |> _distinct_by(K) |> ...` ("last per K"
+  semantics — corresponds to bench `reverse_distinct_by`'s SQL gap).
+- Composition with other chain ops between `_distinct_by` and the
+  terminator: `_where(P) |> _distinct_by(K) |> ...` (where-then-distinct
+  vs. distinct-then-where semantic split), `_distinct_by(K) |> _order_by` /
+  `take` / `skip` (each needs explicit composition logic in `build_sql_string`).
+- Composite-PK support (would need a tuple-key MIN like `MIN(pk1, pk2)` or
+  a synthetic row-id projection).
+
 ## Plan (to be written after all tutorials are reviewed)
 
 _TBD — this section is filled in once we have notes from every tutorial._

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -561,19 +561,19 @@ def private build_distinct_by_inner_subquery(var q : SqlQuery&; pkField : string
     return "SELECT *, MIN(\"{pkCol}\") FROM \"{q.tableName}\" GROUP BY \"{sqlK}\""
 }
 
-// nolint:STYLE015 Reject any chain op between `_distinct_by(K)` and the aggregate terminator. v1 keeps the lowering simple by only supporting the direct shapes: `_distinct_by(K) |> {count,long_count}(P)` and `_distinct_by(K) |> _select(F) |> {sum,min,max,average}()`. Other compositions (_where / _order_by / take / skip / etc.) deferred to chunk N+1.
+// nolint:STYLE015 v1 only supports `_distinct_by` applied directly to a single `select_from` source, with no other chain operators anywhere in the chain. Supported terminators: `_distinct_by(K) |> {count,long_count}(P)` and `_distinct_by(K) |> _select(F) |> {sum,min,max,average}()`. Compositions with `_where` / `_order_by` / `take` / `skip` / `_join` / `_group_by` / set ops / additional `distinct` are deferred to chunk N+1.
 [macro_function]
 def private check_distinct_by_v1_gating(var q : SqlQuery&; linqName : string; allowSelectCol : bool;
                                         prog : ProgramPtr; at : LineInfo) : bool {
     if (!empty(q.whereSql) || q.seenJoin || q.seenSetOp
             || q.seenGroupBy || q.seenHaving || q.seenTake || q.seenSkip
             || q.seenOrderBy || q.seenDistinct) {
-        macro_error(prog, at, "_sql: chain operators between `_distinct_by` and `{linqName}` are not yet supported; restructure the chain so `_distinct_by` sits directly under the terminator")
+        macro_error(prog, at, "_sql: `_distinct_by(K) |> {linqName}(...)` v1 requires `_distinct_by` applied directly to a single `select_from` source — other chain operators (`_where` / `_order_by` / `take` / `skip` / `_join` / `_group_by` / set ops / additional `distinct`) are not yet supported in the same chain")
         q.hadError = true
         return false
     }
     if (!allowSelectCol && !empty(q.selectCols)) {
-        macro_error(prog, at, "_sql: `_select` between `_distinct_by` and `{linqName}` is not yet supported")
+        macro_error(prog, at, "_sql: `_distinct_by(K) |> {linqName}(P)` v1 does not support `_select` in the chain; remove `_select`, or use `_distinct_by(K) |> _select(F) |> \{sum,min,max,average\}()` for the column-aggregate shape")
         q.hadError = true
         return false
     }
@@ -730,8 +730,7 @@ def private peel_count_terminal(var node : ExpressionPtr; var q : SqlQuery&;
             q.hadError = true
             return true
         }
-        // Pre-set Aggregate so analyze_chain's `select_from` bottom doesn't fill default columns
-        // into q.selectCols (mirrors the 1-arg branch below at line ~720).
+        // Pre-set Aggregate so analyze_chain's `select_from` bottom doesn't fill q.selectCols (mirrors the 1-arg branch below).
         q.proj = ProjectionShape.Aggregate
         if (!analyze_chain(cCall.arguments[0], q, prog, at)) return true
         if (empty(q.distinctByCol)) {

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -553,6 +553,70 @@ def private is_nullable_column_ref(var node : ExpressionPtr; var q : SqlQuery&) 
 
 // ===== Chain analysis (walk pipe-composed chain backwards) =====
 
+// nolint:STYLE015 Shared subquery-wrap: SQLite's bare-aggregate optimization — `SELECT *, MIN(pk) FROM t GROUP BY K` picks the row with the minimum pk per K, preserving all `*` columns at those values. Matches linq `_distinct_by`'s "first row per K" semantics when pk is monotonic with insertion order.
+[macro_function]
+def private build_distinct_by_inner_subquery(var q : SqlQuery&; pkField : string) : string {
+    let sqlK = field_to_column_name(q.rootType, q.distinctByCol)
+    let pkCol = field_to_column_name(q.rootType, pkField)
+    return "SELECT *, MIN(\"{pkCol}\") FROM \"{q.tableName}\" GROUP BY \"{sqlK}\""
+}
+
+// nolint:STYLE015 Reject any chain op between `_distinct_by(K)` and the aggregate terminator. v1 keeps the lowering simple by only supporting the direct shapes: `_distinct_by(K) |> {count,long_count}(P)` and `_distinct_by(K) |> _select(F) |> {sum,min,max,average}()`. Other compositions (_where / _order_by / take / skip / etc.) deferred to chunk N+1.
+[macro_function]
+def private check_distinct_by_v1_gating(var q : SqlQuery&; linqName : string; allowSelectCol : bool;
+                                        prog : ProgramPtr; at : LineInfo) : bool {
+    if (!empty(q.whereSql) || q.seenJoin || q.seenSetOp
+            || q.seenGroupBy || q.seenHaving || q.seenTake || q.seenSkip
+            || q.seenOrderBy || q.seenDistinct) {
+        macro_error(prog, at, "_sql: chain operators between `_distinct_by` and `{linqName}` are not yet supported; restructure the chain so `_distinct_by` sits directly under the terminator")
+        q.hadError = true
+        return false
+    }
+    if (!allowSelectCol && !empty(q.selectCols)) {
+        macro_error(prog, at, "_sql: `_select` between `_distinct_by` and `{linqName}` is not yet supported")
+        q.hadError = true
+        return false
+    }
+    return true
+}
+
+[macro_function]
+def private finalize_distinct_by_count_wrap(var q : SqlQuery&; isLong : bool; predSql : string;
+                                            prog : ProgramPtr; at : LineInfo) {
+    let pkField = find_single_pk_field(q.rootType, prog, at)
+    if (empty(pkField)) {
+        q.hadError = true
+        return
+    }
+    q.innerSql := build_distinct_by_inner_subquery(q, pkField)
+    q.fromRowType = q.rootType
+    q.whereSql := predSql
+    q.aggregateExpr := "COUNT(*)"
+    let countBaseType = isLong ? Type.tInt64 : Type.tInt
+    q.aggregateType = new TypeDecl(at = at, baseType = countBaseType)
+    q.proj = ProjectionShape.Aggregate
+    q.matr = Materializer.One
+    q.seenTerminal = true
+}
+
+[macro_function]
+def private finalize_distinct_by_aggregate_wrap(var q : SqlQuery&; sqlOp : string; sqlCol : string;
+                                                var aggregateType : TypeDeclPtr;
+                                                prog : ProgramPtr; at : LineInfo) {
+    let pkField = find_single_pk_field(q.rootType, prog, at)
+    if (empty(pkField)) {
+        q.hadError = true
+        return
+    }
+    q.innerSql := build_distinct_by_inner_subquery(q, pkField)
+    q.fromRowType = q.rootType
+    q.aggregateExpr := "{sqlOp}(\"{sqlCol}\")"
+    q.aggregateType = aggregateType
+    q.proj = ProjectionShape.Aggregate
+    q.matr = Materializer.One
+    q.seenTerminal = true
+}
+
 [macro_function]
 def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
                                   linqName : string; sqlOp : string; promote_to_double : bool;
@@ -574,6 +638,18 @@ def private peel_column_aggregate(var node : ExpressionPtr; var q : SqlQuery&;
     }
     let col = q.selectCols[0]
     let sqlCol = field_to_column_name(q.rootType, col)
+    // nolint:STYLE015 Bare-aggregate `_distinct_by(_.K) |> _select(_.F) |> {agg}()` wrap: same SQL as for count(P) but with SUM/MIN/MAX/AVG over the projected column and no outer WHERE.
+    if (!empty(q.distinctByCol)) {
+        if (!check_distinct_by_v1_gating(q, linqName, true, prog, at)) return true
+        var aggType : TypeDeclPtr
+        if (promote_to_double) {
+            aggType = new TypeDecl(at = at, baseType = Type.tDouble)
+        } else {
+            aggType = lookup_struct_field_type(q.rootType, col)
+        }
+        finalize_distinct_by_aggregate_wrap(q, sqlOp, sqlCol, aggType, prog, at)
+        return true
+    }
     q.aggregateExpr = "{sqlOp}(\"{sqlCol}\")"
     if (promote_to_double) {
         q.aggregateType = new TypeDecl(at = at, baseType = Type.tDouble)
@@ -646,10 +722,28 @@ def private peel_count_terminal(var node : ExpressionPtr; var q : SqlQuery&;
         q.hadError = true
         return true
     }
-    if (cCall.arguments |> length != 1) {
-        macro_error(prog, at, "_sql: `{linqName}(predicate)` is not yet supported — use `|> _where(predicate) |> {linqName}()` instead")
-        q.hadError = true
-        return true
+    // nolint:STYLE015 2-arg `count(P)` / `long_count(P)`: only supported when fronted by `_distinct_by(_.K)` — emits the SQLite bare-aggregate inner-subquery wrap (`SELECT COUNT(*) FROM (SELECT *, MIN(pk) FROM t GROUP BY K) WHERE P`).
+    if (cCall.arguments |> length == 2) {
+        var body = peel_lambda_single_return(cCall.arguments[1])
+        if (body == null) {
+            macro_error(prog, at, "_sql: `{linqName}(P)` predicate lambda has unexpected shape")
+            q.hadError = true
+            return true
+        }
+        // Pre-set Aggregate so analyze_chain's `select_from` bottom doesn't fill default columns
+        // into q.selectCols (mirrors the 1-arg branch below at line ~720).
+        q.proj = ProjectionShape.Aggregate
+        if (!analyze_chain(cCall.arguments[0], q, prog, at)) return true
+        if (empty(q.distinctByCol)) {
+            macro_error(prog, at, "_sql: `{linqName}(P)` is currently only supported when fronted by `_distinct_by(_.col)`; use `|> _where(P) |> {linqName}()` for the standalone form")
+            q.hadError = true
+            return true
+        }
+        if (!check_distinct_by_v1_gating(q, linqName, false, prog, at)) return true
+        let predSql = pred_to_sql(body, q, prog, at)
+        if (q.hadError) return true
+        finalize_distinct_by_count_wrap(q, isLong, predSql, prog, at)
+        return !q.hadError
     }
     q.matr = Materializer.One
     q.seenTerminal = true

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -157,6 +157,11 @@ struct private SqlQuery {
     limitBindExpr : ExpressionPtr
     offsetBindExpr : ExpressionPtr
     distinctFlag : bool
+    // nolint:STYLE014 Set to the key column when `_distinct_by(_.K)` appears as a wrapped chain op
+    // (i.e. NOT consumed by `peel_count_terminal`'s 1-arg fast path → `COUNT(DISTINCT K)`).
+    // Triggers the SQLite bare-aggregate inner-subquery wrap (`SELECT *, MIN(pk) FROM t GROUP BY K`)
+    // in `peel_count_terminal`'s 2-arg `count(P)` branch and `peel_column_aggregate` distinct path.
+    distinctByCol : string
     orderByCols : array<string>
     orderByInlineExprs : array<ExpressionPtr>
     groupByCols : array<string>
@@ -779,6 +784,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.limitBindExpr = null
     q.offsetBindExpr = null
     q.distinctFlag = false
+    q.distinctByCol := ""
     q.orderByCols |> clear
     q.orderByInlineExprs |> clear
     q.groupByCols |> clear
@@ -1431,6 +1437,23 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             q.distinctFlag = true
             q.seenDistinct = true
             return analyze_chain(dCall.arguments[0], q, prog, at)
+        }
+    }
+    // nolint:STYLE015 Stage op: `_distinct_by(_.K)` records the key for the bare-aggregate inner-subquery wrap that the outer aggregate terminator applies. Skipped by `peel_count_terminal`'s 1-arg fast path (`COUNT(DISTINCT K)`); reached only when `_distinct_by` is wrapped by other chain ops or the terminator is `count(P)` / `long_count(P)`.
+    {
+        var dbCall = match_call_in_linq(node, "distinct_by")
+        if (dbCall != null) {
+            let dr = maybe_divert(q, PHASE_DISTINCT, node, prog, at)
+            if (dr != 0) return dr > 0
+            if (!empty(q.distinctByCol)) {
+                macro_error(prog, at, "_sql: `_distinct_by` can appear at most once in the chain")
+                return false
+            }
+            var distinctSource : ExpressionPtr
+            let distinctField = try_peel_distinct_by_field(node, distinctSource, q, prog, at)
+            if (empty(distinctField)) return false        // try_peel_distinct_by_field emitted macro_error
+            q.distinctByCol = distinctField
+            return analyze_chain(distinctSource, q, prog, at)
         }
     }
     // Peel take(prev, n) — sets LIMIT n; bind emitted after WHERE so placeholder index lines up.
@@ -3699,6 +3722,36 @@ def private find_field_annotation_string(rootT : TypeDeclPtr; fieldName : string
 [macro_function]
 def private field_to_column_name(rootT : TypeDeclPtr; fieldName : string) : string {
     return find_field_annotation_string(rootT, fieldName, "sql_column", fieldName)
+}
+
+[macro_function]
+def private find_single_pk_field(rootT : TypeDeclPtr; prog : ProgramPtr; at : LineInfo) : string {
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, at, "_sql: bare-aggregate `_distinct_by` wrap requires a single `@sql_primary_key` field on the source table; rootType not a struct")
+        return ""
+    }
+    var found : string
+    for (field in rootT.structType.fields) {
+        var hasPk = false
+        for (annDecl in field.annotation) {
+            if (annDecl.name == "sql_primary_key") {
+                hasPk = true
+                break
+            }
+        }
+        if (hasPk) {
+            if (!empty(found)) {
+                macro_error(prog, at, "_sql: bare-aggregate `_distinct_by` wrap requires exactly one `@sql_primary_key` field; got multiple (`{found}`, `{field.name}`) — composite primary keys not supported in this lowering")
+                return ""
+            }
+            found = string(field.name)
+        }
+    }
+    if (empty(found)) {
+        macro_error(prog, at, "_sql: bare-aggregate `_distinct_by` wrap requires a single `@sql_primary_key` field on the source table; none found")
+        return ""
+    }
+    return found
 }
 
 [macro_function]

--- a/tests/dasSQLITE/test_32_distinct.das
+++ b/tests/dasSQLITE/test_32_distinct.das
@@ -62,3 +62,113 @@ def test_distinct_full_row_runtime(t : T?) {
         t |> equal(length(rows), 5, "all 5 PK-distinct rows survive full-row DISTINCT")
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// `_distinct_by(_.K) |> _count(P) / _long_count(P)` and
+// `_distinct_by(_.K) |> _select(_.F) |> sum() / min() / max() / average()`
+// — the SQLite bare-aggregate wrap added in chunk N. Inner subquery
+// `SELECT *, MIN("Id") FROM "Cars" GROUP BY "K"` picks the row with the
+// smallest PK per group (first-row-per-K semantics matching linq
+// _distinct_by); outer SELECT applies the aggregate over those rows.
+//
+// Fixture has 5 rows across 3 distinct names (BMW×2, Audi×2, Tesla×1).
+// First-encountered (by Id) is BMW=100, Audi=200, Tesla=300.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_distinct_by_count_pred_emits_subquery_form(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                            |> _distinct_by(_.Name)
+                            |> _count(_.Price > 150))
+    t |> equal(sql,
+        "SELECT COUNT(*) FROM (SELECT *, MIN(\"Id\") FROM \"Cars\" GROUP BY \"Name\") AS \"t0\" WHERE \"Price\" > ?",
+        "_distinct_by + _count(P) emits COUNT(*) FROM (bare-aggregate subquery) WHERE")
+}
+
+[test]
+def test_distinct_by_count_pred_returns_first_row_match_count(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        // First-encountered per Name: BMW=100, Audi=200, Tesla=300.
+        // Count first-rows where Price > 150 → Audi(200) + Tesla(300) = 2.
+        let n = _sql(db |> select_from(type<Car>)
+                        |> _distinct_by(_.Name)
+                        |> _count(_.Price > 150))
+        t |> equal(n, 2, "first-row semantics: BMW(100) excluded, Audi(200) + Tesla(300) match")
+    }
+}
+
+[test]
+def test_distinct_by_long_count_pred_returns_int64(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        let n64 = _sql(db |> select_from(type<Car>)
+                          |> _distinct_by(_.Name)
+                          |> _long_count(_.Price > 150))
+        t |> equal(n64, 2l, "long_count(P) returns int64 with first-row semantics")
+    }
+}
+
+[test]
+def test_distinct_by_select_sum_emits_subquery_form(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                            |> _distinct_by(_.Name)
+                            |> _select(_.Price)
+                            |> sum())
+    t |> equal(sql,
+        "SELECT SUM(\"Price\") FROM (SELECT *, MIN(\"Id\") FROM \"Cars\" GROUP BY \"Name\") AS \"t0\"",
+        "_distinct_by + _select(F) + sum() emits SUM(F) FROM (bare-aggregate subquery)")
+}
+
+[test]
+def test_distinct_by_select_sum_returns_first_row_sum(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        // First-row prices per Name: 100 + 200 + 300 = 600.
+        let s = _sql(db |> select_from(type<Car>)
+                        |> _distinct_by(_.Name)
+                        |> _select(_.Price)
+                        |> sum())
+        t |> equal(s, 600, "sum of first-row prices per Name = 100+200+300 = 600")
+    }
+}
+
+[test]
+def test_distinct_by_select_min_returns_smallest_first_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        // First-row prices per Name: BMW=100, Audi=200, Tesla=300; min = 100.
+        let m = _sql(db |> select_from(type<Car>)
+                        |> _distinct_by(_.Name)
+                        |> _select(_.Price)
+                        |> min())
+        t |> equal(m, 100, "min of first-row prices = BMW(100)")
+    }
+}
+
+[test]
+def test_distinct_by_select_max_returns_largest_first_row(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        let m = _sql(db |> select_from(type<Car>)
+                        |> _distinct_by(_.Name)
+                        |> _select(_.Price)
+                        |> max())
+        t |> equal(m, 300, "max of first-row prices = Tesla(300)")
+    }
+}
+
+[test]
+def test_distinct_by_select_average_returns_double(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture_with_dupes(db)
+        // Average of {100, 200, 300} = 200.0
+        let a = _sql(db |> select_from(type<Car>)
+                        |> _distinct_by(_.Name)
+                        |> _select(_.Price)
+                        |> average())
+        t |> equal(a, 200.0lf, "average of first-row prices = 200.0 (DOUBLE)")
+    }
+}

--- a/tutorials/sql/12-distinct.das
+++ b/tutorials/sql/12-distinct.das
@@ -71,6 +71,36 @@ def main() {
                               |> distinct())
         to_log(LOG_INFO, "  emitted SQL: {sql}\n")
 
+        // ── Distinct + first-row aggregates ──────────────────────────────
+        // `_distinct_by(_.K)` followed by an aggregate terminator
+        // (`_count(P)` / `_long_count(P)`, or `_select(_.F) |> sum/min/max/average()`)
+        // lowers to a SQLite bare-aggregate subquery picking the row with the
+        // smallest @sql_primary_key per group — matches linq's "first row per K"
+        // semantics when PKs are monotonic with insertion. For the predicate-count
+        // form, use the `_count(_.field > X)` linq_boost shorthand inside `_sql`;
+        // explicit lambdas don't type-bind through `_sql`'s macro boundary.
+
+        // Count distinct names whose first-encountered Car has Price > 150.
+        // Fixture: BMW first @100 (no), Audi first @200 (yes), Tesla first @300 (yes) → 2.
+        let n_first = _sql(db |> select_from(type<Car>)
+                              |> _distinct_by(_.Name)
+                              |> _count(_.Price > 150))
+        to_log(LOG_INFO, "DISTINCT names with first-row Price>150: {n_first}\n")
+
+        // Sum of first-row prices per Name: 100 + 200 + 300 = 600.
+        let total_first = _sql(db |> select_from(type<Car>)
+                                  |> _distinct_by(_.Name)
+                                  |> _select(_.Price)
+                                  |> sum())
+        to_log(LOG_INFO, "Sum of first-row prices per Name: {total_first}\n")
+
+        // Inspect the emitted SQL — `SELECT *, MIN("Id") FROM "Cars" GROUP BY "Name"`
+        // is the bare-aggregate inner subquery; outer SELECT applies the aggregate.
+        let sql_first = _sql_text(db |> select_from(type<Car>)
+                                     |> _distinct_by(_.Name)
+                                     |> _count(_.Price > 150))
+        to_log(LOG_INFO, "  emitted SQL: {sql_first}\n")
+
         // ── Set operations (UNION / INTERSECT / EXCEPT) — deferred ───────
         // The chain analyzer is single-source today: every SELECT comes
         // from one `select_from(type<T>)`. Set ops bring in a second


### PR DESCRIPTION
## Summary

Closes 2 of the SQL `—` cells catalogued in [`benchmarks/sql/sqlite_linq_gaps.md`](https://github.com/GaijinEntertainment/daScript/blob/master/benchmarks/sql/sqlite_linq_gaps.md) (PR #2905):

- **`order_distinct_take`** SQL lane — bench-only fix via a new 1-column `Brand` table fixture + named-tuple projection (`_select((value=_.value))`). Lowers to clean `SELECT DISTINCT "value" FROM "Brands" ORDER BY "value" ASC LIMIT ?`. No sqlite_linq surface change.
- **`distinct_count_pred`** SQL lane — new sqlite_linq surface: `_distinct_by(_.K)` is now a first-class chain operator that, when followed by an aggregate terminator, lowers to the SQLite bare-aggregate inner-subquery wrap:
  ```sql
  SELECT <aggregate> FROM (
      SELECT *, MIN("<pk>") FROM "<table>" GROUP BY "<K>"
  ) AS t0 [WHERE <P>]
  ```
  Uses SQLite's [bare-aggregate optimization](https://www.sqlite.org/lang_select.html#bareagg) — non-aggregate columns take values from the `MIN(pk)` row, matching linq's "first row per K" semantics when PKs are monotonic.

## New chain shapes

| # | Chain | SQL |
|---|---|---|
| 1 | `_distinct_by(_.K) \|> _count(P)` | `SELECT COUNT(*) FROM (firsts) WHERE <P>` |
| 2 | `_distinct_by(_.K) \|> _long_count(P)` | Same as #1, int64 result |
| 3 | `_distinct_by(_.K) \|> _select(_.F) \|> sum()` | `SELECT SUM("F") FROM (firsts)` |
| 4 | `_distinct_by(_.K) \|> _select(_.F) \|> min()` | `SELECT MIN("F") FROM (firsts)` |
| 5 | `_distinct_by(_.K) \|> _select(_.F) \|> max()` | `SELECT MAX("F") FROM (firsts)` |
| 6 | `_distinct_by(_.K) \|> _select(_.F) \|> average()` | `SELECT AVG("F") FROM (firsts)` (DOUBLE) |

**Preserved fast path** (no subquery wrap): `_distinct_by(_.K) |> count()` / `long_count()` (no predicate) continues to emit `COUNT(DISTINCT "K")`.

**User idiom inside `_sql(...)`** for predicate-counts: `_count(_.field > X)` / `_long_count(_.field > X)` linq_boost shorthand. The explicit `count($(c) => c.field > X)` lambda form fails type inference because `_sql`'s macro boundary blocks the typer from binding `c` through unexpanded chain operators (same constraint as `_where(_.field > X)`).

## v1 Constraints (each a clean macro_error)

- Source must have exactly one `@sql_primary_key` field (composite PKs reject)
- `_distinct_by` appears at most once in the chain
- `_distinct_by` must apply to a single source table (no `_join` upstream)
- No chain ops between `_distinct_by` and the terminator (other than the optional `_select(_.F)` for column aggregates)

Composition with `_where` / `_order_by` / `take` / `skip` between `_distinct_by` and terminator, plus the MAX(pk) "last per K" variant for `each |> reverse |> _distinct_by`, deferred to chunk N+1.

## Bench cells flipped

| Bench | INTERP m1 | JIT m1 |
|---|---:|---:|
| `order_distinct_take` | — → 139.2 | — → 138.2 |
| `distinct_count_pred` | — → 253.1 | — → 252.8 |

Full bench rerun completed (`benchmarks/sql/*.das` INTERP + JIT). Drift outside the 2 flipped cells: `distinct_by_order_take` m4 INTERP +32%, `groupby_select_order` m4 INTERP +29%, `select_where_order_take` m3f/m4 ±6-8% — bench-suite ordering noise (same long-running pattern documented in prior PRs).

## Tests

- `tests/dasSQLITE/test_32_distinct.das`: 3 → 11 (added 8 tests covering each new chain shape, emit-shape + runtime correctness on a fixture with duplicate names + monotonic PKs)
- `tests/dasSQLITE/test_31_long_count_distinct_by_canary.das`: 8/8 (regression — fast path preserved)
- `tests/dasSQLITE/parity_check_12_distinct.das`: 3/3 (regression)

Compile-time rejection paths (no-pk, composite-pk, double `_distinct_by`, chain ops between `_distinct_by` and terminator) wired via explicit `macro_error` calls in `sqlite_linq.das` but NOT added as `failed_*.das` probes — the linq generic-instantiation cascade after `_sql` returns null is brittle to maintain (couples to internal linq.das line numbers). Code-review covers the rejection sites.

## Docs

- [`doc/source/reference/tutorials/sql_12_distinct.rst`](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/sqlite-linq-distinct-by-aggregates/doc/source/reference/tutorials/sql_12_distinct.rst) — new "Distinct + first-row aggregates" section
- [`modules/dasSQLITE/API_REWORK.md`](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/sqlite-linq-distinct-by-aggregates/modules/dasSQLITE/API_REWORK.md) — new "Shipped — chunk N" section at end
- [`benchmarks/sql/sqlite_linq_gaps.md`](https://github.com/GaijinEntertainment/daScript/blob/bbatkin/sqlite-linq-distinct-by-aggregates/benchmarks/sql/sqlite_linq_gaps.md) — 2 entries closed, "COUNT(*) FILTER (WHERE)" subsection dropped (was misidentified as the lowering — bare-aggregate is the correct form)

## Test plan

- [x] `mcp__daslang__lint` + `mcp__daslang__format_file` on all touched `.das` files
- [x] `mcp__daslang__run_test tests/dasSQLITE/test_32_distinct.das` (11/11)
- [x] `mcp__daslang__run_test tests/dasSQLITE/test_31_long_count_distinct_by_canary.das` (8/8)
- [x] `mcp__daslang__run_test tests/dasSQLITE/parity_check_12_distinct.das` (3/3)
- [x] `mcp__daslang__run_test tests/dasSQLITE/failed_sql_macro.das` (existing rejections still pass)
- [x] Sanity-bench `order_distinct_take` + `distinct_count_pred` (INTERP + JIT, both lanes splice on first run)
- [x] Full INTERP + JIT rerun across `benchmarks/sql/*.das` (drift documented in results.md header)
- [x] End-to-end probe of all 6 new chain shapes returns correct values
- [ ] CI green (waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)