### PR TITLE
site: news nav link with "N NEW" chip + dasImgui announcement

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -7,6 +7,7 @@ blog/feed.xml
 changelist.html
 news/
 files/news.json
+files/news-meta.json
 files/blog.json
 
 # Playground: vendored from web/ui/src/ for local-dev preview only.

--- a/site/_news/2026-05-27-0-6-3-is-just-around-the-corner-in-the.md
+++ b/site/_news/2026-05-27-0-6-3-is-just-around-the-corner-in-the.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-27
+tag: dasImgui
+title: 0.6.3 is just around the corner. In the meantime, check out dasImgui — now with imgui_playwright.
+link: https://borisbat.github.io/dasImgui/
+---

--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -13,7 +13,9 @@ Output (under out_dir):
     blog/feed.xml           — Atom feed of posts
     news/<slug>.html        — one per news entry that has a body
     changelist.html         — full long-form news list (all entries by date desc)
-    files/news.json         — top-N news for forge.js to render landing § 05
+    files/news.json         — top-N news for forge.js to render landing § 06
+    files/news-meta.json    — newest_date + baseline_date + all dates, drives
+                              the "N NEW" nav chip via files/news-counter.js
 
 Hexo extensions translated:
     <!-- more -->            → excerpt boundary (excerpt above used on index)
@@ -552,6 +554,20 @@ def main():
     }
     (out / 'files' / 'blog.json').write_text(
         json.dumps(blog_data, indent=2), encoding='utf-8')
+
+    # 8. news-meta.json — parallel of blog.json for the news feed; same
+    #    metadata fields (newest_date, baseline_date), entries live under
+    #    `news` instead of `posts`. Drives the "N NEW" chip on the news
+    #    nav link via news-counter.js.
+    newest_news = news[0].date if news else '1970-01-01'
+    baseline_news = news[1].date if len(news) >= 2 else '1970-01-01'
+    news_meta = {
+        'newest_date': newest_news,
+        'baseline_date': baseline_news,
+        'news': [{'slug': n.slug, 'date': n.date} for n in news],
+    }
+    (out / 'files' / 'news-meta.json').write_text(
+        json.dumps(news_meta, indent=2), encoding='utf-8')
 
     print(f"built {len(posts)} posts, {len(news)} news entries -> {out}/")
 

--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -15,6 +15,7 @@
     <script src="{{root}}files/cm/daslang-keywords.js" defer></script>
     <script src="{{root}}files/highlight.js" defer></script>
     <script src="{{root}}files/blog-counter.js" defer></script>
+    <script src="{{root}}files/news-counter.js" defer></script>
 
     <!-- Analytics -->
     <script data-goatcounter="https://borisbat.goatcounter.com/count"
@@ -31,6 +32,7 @@
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
+                    <a href="{{root}}index.html#news">news</a>
                     <a href="{{root}}doc/index.html">docs</a>
                     <a href="{{root}}index.html#benchmarks">benchmarks</a>
                     <a href="{{root}}downloads.html">downloads</a>

--- a/site/daspkg.html
+++ b/site/daspkg.html
@@ -32,6 +32,7 @@
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
+                    <a href="index.html#news">news</a>
                     <a href="doc/index.html">docs</a>
                     <a href="index.html#benchmarks">benchmarks</a>
                     <a href="downloads.html">downloads</a>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -26,6 +26,7 @@
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
+                    <a href="index.html#news">news</a>
                     <a href="doc/index.html">docs</a>
                     <a href="index.html#benchmarks">benchmarks</a>
                     <a href="downloads.html">downloads</a>
@@ -206,5 +207,6 @@
 
 </div>
 <script src="files/blog-counter.js" defer></script>
+<script src="files/news-counter.js" defer></script>
 </body>
 </html>

--- a/site/files/forge.js
+++ b/site/files/forge.js
@@ -494,7 +494,7 @@ def main() {
             `<a href="/playground/index.html?example=${slug}">try <span class="forge-bench__playground-test">${escapeHtml(benchBm)}</span> on the playground →</a>`;
     }
 
-    // ─── § 05 News feed (top 5 from news.json) ─────────────────────
+    // ─── § 06 News feed (top 5 from news.json) ─────────────────────
     async function loadNews() {
         const rowsEl = document.getElementById('news-rows');
         if (!rowsEl) return;

--- a/site/files/news-counter.js
+++ b/site/files/news-counter.js
@@ -1,0 +1,115 @@
+/* Forge nav — "N NEW" news chip.
+ *
+ * Data source: files/news-meta.json (built by site/blog/build_blog.py).
+ * Storage:     localStorage["daslang:news:lastSeen"] = "YYYY-MM-DD".
+ *
+ * Semantics (mirrors blog-counter.js):
+ *   - First-time visitor (no key)   → seeded from news-meta.json baseline_date,
+ *                                     which is the 2nd-newest entry's date.
+ *                                     So count = 1 (just the newest).
+ *   - Landing with hash "#news"     → key set to newest_date; chip clears.
+ *   - Click on the news nav link    → key set to newest_date.
+ *   - count > 9                     → render "9+ NEW".
+ *   - count === 0                   → chip not rendered.
+ *
+ * Nav anchors are matched by link.hash === "#news" so the same script works
+ * from any page that links to "#news" / "index.html#news" / "../index.html#news".
+ */
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'daslang:news:lastSeen';
+
+    function readLastSeen() {
+        try { return window.localStorage.getItem(STORAGE_KEY); }
+        catch (_) { return null; }
+    }
+
+    function writeLastSeen(date) {
+        try { window.localStorage.setItem(STORAGE_KEY, date); }
+        catch (_) { /* private mode / quota — silent */ }
+    }
+
+    function newsJsonUrl() {
+        // Locate our own <script> tag and derive news-meta.json next to it.
+        var scripts = document.getElementsByTagName('script');
+        for (var i = 0; i < scripts.length; i++) {
+            var src = scripts[i].getAttribute('src') || '';
+            if (src.indexOf('news-counter.js') !== -1) {
+                return src.replace(/news-counter\.js(\?.*)?$/, 'news-meta.json');
+            }
+        }
+        return 'files/news-meta.json';
+    }
+
+    function findNewsLinks() {
+        // Match any nav link whose URL hash is "#news" — works for
+        // "#news", "index.html#news", "../index.html#news".
+        var links = document.querySelectorAll('.forge-nav__links a[href]');
+        var out = [];
+        for (var i = 0; i < links.length; i++) {
+            if (links[i].hash === '#news') out.push(links[i]);
+        }
+        return out;
+    }
+
+    function renderChip(anchor, count) {
+        if (anchor.querySelector('.forge-blog-chip')) return;
+        var chip = document.createElement('span');
+        chip.className = 'forge-blog-chip';
+        chip.textContent = (count > 9 ? '9+' : count) + ' NEW';
+        anchor.appendChild(chip);
+        anchor.classList.add('forge-blog-link');
+    }
+
+    function clearChips() {
+        var chips = document.querySelectorAll('.forge-nav__links a .forge-blog-chip');
+        for (var i = 0; i < chips.length; i++) {
+            var parent = chips[i].parentNode;
+            if (parent && parent.hash === '#news') {
+                chips[i].remove();
+            }
+        }
+    }
+
+    function update(data) {
+        // Landing-with-#news: mark seen and render nothing. Early-return so
+        // that a silently-failed writeLastSeen (private mode / quota) cannot
+        // still cause the chip to render — we are already on the destination.
+        if (window.location.hash === '#news') {
+            writeLastSeen(data.newest_date);
+            return;
+        }
+        var anchors = findNewsLinks();
+        for (var k = 0; k < anchors.length; k++) {
+            (function (a) {
+                a.addEventListener('click', function () {
+                    writeLastSeen(data.newest_date);
+                    clearChips();
+                });
+            })(anchors[k]);
+        }
+        var lastSeen = readLastSeen() || data.baseline_date;
+        var count = 0;
+        for (var i = 0; i < data.news.length; i++) {
+            if (data.news[i].date > lastSeen) count++;
+        }
+        if (count <= 0) return;
+        for (var j = 0; j < anchors.length; j++) {
+            renderChip(anchors[j], count);
+        }
+    }
+
+    function start() {
+        fetch(newsJsonUrl(), { cache: 'no-cache' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) { if (data) update(data); })
+            .catch(function () { /* offline / missing — silent */ });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -40,6 +40,7 @@
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
+                    <a href="#news">news</a>
                     <a href="doc/index.html">docs</a>
                     <a href="#benchmarks">benchmarks</a>
                     <a href="downloads.html">downloads</a>
@@ -374,7 +375,7 @@ def main() {
     </section>
 
     <!-- ───── § 06 Changelog / news ───── -->
-    <section class="forge-section forge-section--alt">
+    <section class="forge-section forge-section--alt" id="news">
         <div class="forge-container">
             <div class="forge-section-label">
                 <span class="forge-section-label__num">§ 06</span>
@@ -452,5 +453,6 @@ def main() {
 <script src="files/runner.js" defer></script>
 <script src="files/forge.js" defer></script>
 <script src="files/blog-counter.js" defer></script>
+<script src="files/news-counter.js" defer></script>
 </body>
 </html>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -33,6 +33,7 @@
                 <span class="forge-mark__tld">.io</span>
             </a>
             <div class="forge-nav__links">
+                <a href="../index.html#news">news</a>
                 <a href="../doc/index.html">docs</a>
                 <a href="../index.html#benchmarks">benchmarks</a>
                 <a href="../downloads.html">downloads</a>


### PR DESCRIPTION
## Summary

- New `news` link in the top nav (before `docs`) on every hand-authored page — anchor-jumps to § 06 "Recent activity" on the landing.
- "N NEW" chip on the nav link, identical to the existing blog chip — driven by `files/news-meta.json` and a new `files/news-counter.js`. Marks seen on landing-with-`#news`-hash OR on click of the nav link; localStorage key `daslang:news:lastSeen`.
- New `_news` entry: "0.6.3 is just around the corner. In the meantime, check out dasImgui — now with imgui_playwright." linking to https://borisbat.github.io/dasImgui/

## Changes

- **Anchor + nav (5 nav copies):** `id="news"` added to § 06 of `site/index.html`. `<a href=".../index.html#news">news</a>` inserted before `docs` in `index.html`, `downloads.html`, `daspkg.html`, `playground/index.html`, and `blog/template.html` (regenerates all blog posts, news pages, changelist).
- **Counter script (`site/files/news-counter.js`, new):** mirrors `blog-counter.js`. Reuses the `.forge-blog-chip` CSS class (visually identical) — no new styles. Matches nav anchors by `link.hash === '#news'`, so the same script works whether the href is `#news`, `index.html#news`, or `../index.html#news`. Wired into the same 3 pages that already include `blog-counter.js`: `index.html`, `downloads.html`, `blog/template.html`. `daspkg.html` and `playground/index.html` show the nav link but no chip, matching the prior `blog-counter.js` scope.
- **Builder (`site/blog/build_blog.py`):** emits `site/files/news-meta.json` alongside the existing `news.json` / `blog.json`. Same shape as `blog.json` — `newest_date`, `baseline_date`, `items: [{slug, date}]`. Gitignored.
- **News entry:** `site/_news/2026-05-27-0-6-3-is-just-around-the-corner-in-the.md` — front-matter-only (no body page), surfaces in the landing news section and changelist.

## Test plan

- [x] `python3 blog/build_blog.py --posts blog/_posts --news _news --template blog/template.html --out .` — clean (34 posts, 31 news, all three JSON files emitted)
- [x] `python3 -m http.server` + browser:
  - [x] Landing nav: `news` link visible before `docs` with `1 NEW` chip
  - [x] Clicking `news` smooth-scrolls to § 06; chip clears; localStorage updated
  - [x] § 06 first row shows the dasImgui entry (date / `dasImgui` tag / link)
  - [x] Sub-pages (`/blog/`, `/downloads.html`, `/daspkg.html`, `/playground/`) — `news` link present in nav, anchors back to `index.html#news`
  - [x] Reset via `localStorage.removeItem('daslang:news:lastSeen')` → chip returns on reload
- [x] Pre-push hook: formatter verified, lint skipped (no `.das` files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)