### PR TITLE
sqlite_linq: resolve `_.<alias>` after _join via projection registry (chunk N+2)

### DIFF
--- a/benchmarks/sql/join_groupby_count.das
+++ b/benchmarks/sql/join_groupby_count.das
@@ -6,15 +6,34 @@ require _common public
 // _join(cars, dealers) |> _group_by(_.Brand) |> _select((Brand, N=_._1|>count)) — joined+grouped,
 // per-group counts returned as an array of (Brand, N) tuples (no terminal count;
 // the inner `count()` is the per-bucket reducer).
-// SQL: SELECT brand, COUNT(*) FROM Cars c JOIN Dealers d ON c.dealer_id = d.id GROUP BY brand.
-// sqlite_linq's `_group_by` after `_join` doesn't currently lower (key column is from
-// the joined projection, not a base table column). Follow-up TODO 2026-05-25.
+// SQL (m1): `SELECT ("t0"."brand"), COUNT(*) FROM "Cars" AS "t0" INNER JOIN "Dealers" AS "t1"
+// ON "t0"."dealer_id" = "t1"."id" GROUP BY ("t0"."brand")`. push_group_key resolves the
+// `_.Brand` key against the join's `into` projection registry — emits the qualified source
+// column (`"t0"."brand"`) rather than the bare alias name. Chunk N+2 (sqlite_linq.das).
 // Decs (m4): plan_decs_group_by's `isDecsJoin` adapter mode (Theme 3 Phase 1, audit C3).
 // Single pass — hashB-collect + srcA-probe emits per-pair result-lam bind directly
 // into plan_group_by_core's bucket update. Vs the tier-2 cascade's 3 intermediate
 // allocations (dealers-array → join-array → group-map → output-array). plan_group_by_core
 // itself is untouched — the abstraction holds.
 // Array (m3f): no array-side join splice; cascade baseline for comparison.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                |> _join(db |> select_from(type<Dealer>),
+                         $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                         $(c : Car, d : Dealer) => (Brand = c.brand, DealerId = d.id))
+                |> _group_by(_.Brand)
+                |> _select((Brand = _._0, N = _._1 |> count())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
 
 def run_m3f(b : B?; n : int) {
     let cars <- fixture_array(n)
@@ -49,6 +68,11 @@ def run_m4(b : B?; n : int) {
             }
         }
     }
+}
+
+[benchmark]
+def join_groupby_count_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_groupby_to_array.das
+++ b/benchmarks/sql/join_groupby_to_array.das
@@ -4,13 +4,34 @@ options persistent_heap
 require _common public
 
 // _join(cars, dealers) |> _group_by(_.Brand) |> _select((Brand, Total=sum price)) |> to_array.
-// SQL: SELECT brand, SUM(price) FROM Cars c JOIN Dealers d ON c.dealer_id = d.id GROUP BY brand.
-// sqlite_linq's `_group_by` after `_join` doesn't currently lower (key column is from
-// the joined projection). Follow-up TODO 2026-05-25.
+// SQL (m1): `SELECT ("t0"."brand"), SUM("t0"."price") FROM "Cars" AS "t0" INNER JOIN
+// "Dealers" AS "t1" ON "t0"."dealer_id" = "t1"."id" GROUP BY ("t0"."brand")`.
+// push_group_key resolves the `_.Brand` key, and try_translate_group_aggregate resolves
+// the inner `_select(_.Price)` to the qualified column — both consult the join's `into`
+// projection snapshot. Chunk N+2 (sqlite_linq.das).
 // Decs (m4): plan_decs_group_by's `isDecsJoin` adapter mode (Theme 3 Phase 1, audit C3).
 // Same shape as join_groupby_count.das but with a reducing aggregate. Single pass,
 // no intermediate allocations.
 // Array (m3f): no array-side join splice; cascade baseline for comparison.
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let groups <- _sql(db |> select_from(type<Car>)
+                |> _join(db |> select_from(type<Dealer>),
+                         $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                         $(c : Car, d : Dealer) => (Brand = c.brand, Price = c.price))
+                |> _group_by(_.Brand)
+                |> _select((Brand = _._0,
+                            Total = _._1 |> _select(_.Price) |> sum())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
 
 def run_m3f(b : B?; n : int) {
     let cars <- fixture_array(n)
@@ -47,6 +68,11 @@ def run_m4(b : B?; n : int) {
             }
         }
     }
+}
+
+[benchmark]
+def join_groupby_to_array_m1(b : B?) {
+    run_m1(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,12 +1,10 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-27 from PR `bbatkin/sqlite-linq-distinct-by-composition` (sqlite_linq `_distinct_by` composition + `reverse() |> _distinct_by` MAX(pk) + `_group_by |> first()` row projection). Four SQL `—` cells now populated, draining the entire "window-function lowerings" group from [`sqlite_linq_gaps.md`](sqlite_linq_gaps.md) — none of them actually needed window functions, all lower via SQLite's bare-aggregate optimization with outer ORDER BY / LIMIT or MAX(pk) variant:
-- `distinct_by_order_take` m1 = 240.5 INTERP / 253.6 JIT
-- `distinct_by_order_to_array` m1 = 240.6 INTERP / 239.3 JIT
-- `reverse_distinct_by` m1 = 312.5 INTERP / 297.1 JIT (MAX(pk) variant)
-- `groupby_first` m1 = 255.1 INTERP / 252.4 JIT (tuple-with-row projection)
+Generated 2026-05-27 from PR `bbatkin/sqlite-linq-join-groupby-alias` (chunk N+2 — sqlite_linq projection-alias resolver: post-join `_.<alias>` resolves through the join's `into` projection registry, transitively enabling `_group_by` / `_having` / `_order_by` / aggregates / computed-key in chains following a `_join`). Two SQL `—` cells now populated, draining the "`_group_by` after `_join`" entry from [`sqlite_linq_gaps.md`](sqlite_linq_gaps.md):
+- `join_groupby_count` m1 = 160.7 INTERP / 157.8 JIT (beats `m3f` 186.2 / 47.2 in INTERP but JIT m3f still wins)
+- `join_groupby_to_array` m1 = 189.9 INTERP / 190.3 JIT (similar shape)
 
-Drift is minor and mostly converges back toward pre-#2906 baselines: `distinct_by_order_take` m4 INTERP 30.9 → 23.8 (-23%) and `groupby_select_order` m4 INTERP 24.2 → 18.8 (-22%) reverse the post-#2906 drift entries. `indexed_lookup` m4 now populated (482.9 INTERP / 107.5 JIT) — earlier `—` was stale bench-output parsing. Remaining JIT cells drift ±5% at measurement floor.
+Drift across the rest of the matrix is at measurement floor (±5% INTERP, ±10% JIT). The `_join`-side surface didn't touch any non-join planner, so the row-level changes are noise.
 Fixture size: n = 100 000 (cars), 100 dealers, 5 brands. Each row is
 one bench family in `benchmarks/sql/`; columns are nanoseconds per
 logical operation. `—` marks an intentionally absent lane — see
@@ -33,151 +31,151 @@ before the timer resolution can measure them — they should be read as
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 34.8 | 6.0 | 5.9 | 0.98× |
-| `all_match` | 27.8 | 3.6 | 3.5 | 0.97× |
+| `aggregate_match` | 34.2 | 6.0 | 6.0 | 1.00× |
+| `all_match` | 27.7 | 3.6 | 3.6 | 1.00× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 30.2 | 5.9 | 8.8 | 1.49× |
-| `bare_order_where` | 276.7 | 117.6 | 123.5 | 1.05× |
-| `chained_select_collapse` | — | 17.9 | 17.6 | 0.98× |
-| `chained_where` | 36.9 | 6.7 | 7.1 | 1.06× |
-| `contains_match` | 0.00 | 2.2 | 1.4 | 0.64× |
-| `count_aggregate` | 29.8 | 4.2 | 4.1 | 0.98× |
-| `decs_count_bare_pred` | — | — | 4.2 | — |
-| `distinct_by_count` | 41.4 | 15.7 | 15.7 | 1.00× |
-| `distinct_by_order_take` | 240.5 | 21.9 | 23.8 | 1.09× |
-| `distinct_by_order_to_array` | 240.6 | 22.2 | 23.3 | 1.05× |
-| `distinct_count` | 42.0 | 16.1 | 15.9 | 0.99× |
-| `distinct_count_pred` | 253.2 | 15.8 | 16.1 | 1.02× |
+| `average_aggregate` | 30.0 | 6.0 | 8.9 | 1.48× |
+| `bare_order_where` | 286.5 | 118.0 | 128.2 | 1.09× |
+| `chained_select_collapse` | — | 18.3 | 18.3 | 1.00× |
+| `chained_where` | 36.3 | 6.8 | 7.7 | 1.13× |
+| `contains_match` | 0.00 | 2.3 | 1.5 | 0.65× |
+| `count_aggregate` | 29.5 | 4.2 | 4.4 | 1.05× |
+| `decs_count_bare_pred` | — | — | 4.3 | — |
+| `distinct_by_count` | 41.1 | 15.9 | 16.1 | 1.01× |
+| `distinct_by_order_take` | 242.4 | 22.0 | 24.0 | 1.09× |
+| `distinct_by_order_to_array` | 239.8 | 22.1 | 23.6 | 1.07× |
+| `distinct_count` | 41.3 | 16.0 | 16.1 | 1.01× |
+| `distinct_count_pred` | 253.8 | 16.1 | 16.0 | 0.99× |
 | `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 172.6 | 30.1 | 30.3 | 1.01× |
-| `groupby_count` | 142.5 | 19.4 | 19.5 | 1.01× |
-| `groupby_first` | 255.1 | 18.5 | 19.2 | 1.04× |
-| `groupby_having_count` | 143.0 | 19.3 | 19.2 | 0.99× |
-| `groupby_having_hidden_sum` | 176.0 | 23.8 | 24.4 | 1.03× |
-| `groupby_having_post_where` | 172.7 | 18.6 | 18.8 | 1.01× |
-| `groupby_max` | 175.5 | 25.2 | 25.2 | 1.00× |
-| `groupby_min` | 173.2 | 25.5 | 25.8 | 1.01× |
-| `groupby_multi_reducer` | 191.2 | 32.1 | 32.5 | 1.01× |
-| `groupby_select_order` | 175.4 | 18.6 | 18.8 | 1.01× |
-| `groupby_select_sum` | 202.2 | 36.5 | 35.8 | 0.98× |
-| `groupby_sum` | 175.9 | 18.7 | 18.6 | 0.99× |
-| `groupby_where_count` | 75.5 | 14.5 | 14.9 | 1.03× |
-| `groupby_where_sum` | 86.4 | 14.2 | 14.5 | 1.02× |
-| `indexed_lookup` | 1442.6 | 202815.2 | 482.9 | 0.00× |
-| `join_count` | 38.5 | 120.6 | 64.0 | 0.53× |
-| `join_groupby_count` | — | 186.6 | 91.7 | 0.49× |
-| `join_groupby_to_array` | — | 217.1 | 92.6 | 0.43× |
-| `join_select` | — | 148.7 | 85.8 | 0.58× |
-| `join_where_count` | 39.4 | 147.2 | 74.2 | 0.50× |
-| `last_match` | 0.00 | 5.8 | 14.0 | 2.41× |
-| `long_count_aggregate` | 29.7 | 4.2 | 4.1 | 0.98× |
-| `max_aggregate` | 31.3 | 6.0 | 6.9 | 1.15× |
-| `min_aggregate` | 31.2 | 6.1 | 6.9 | 1.13× |
-| `order_distinct_take` | 140.2 | 15.9 | 94.8 | 5.96× |
-| `order_reverse_normalized` | 38.4 | 16.2 | 20.1 | 1.24× |
-| `order_take_desc` | 38.4 | 16.0 | 20.0 | 1.25× |
-| `reverse_distinct_by` | 312.5 | 21.8 | — | — |
+| `groupby_average` | 173.2 | 30.9 | 30.3 | 0.98× |
+| `groupby_count` | 146.6 | 19.4 | 19.4 | 1.00× |
+| `groupby_first` | 253.3 | 18.6 | 19.2 | 1.03× |
+| `groupby_having_count` | 142.9 | 19.3 | 19.4 | 1.01× |
+| `groupby_having_hidden_sum` | 178.1 | 24.0 | 24.5 | 1.02× |
+| `groupby_having_post_where` | 173.8 | 19.1 | 18.8 | 0.98× |
+| `groupby_max` | 175.0 | 25.4 | 25.5 | 1.00× |
+| `groupby_min` | 177.7 | 26.0 | 26.0 | 1.00× |
+| `groupby_multi_reducer` | 191.3 | 32.3 | 32.7 | 1.01× |
+| `groupby_select_order` | 173.4 | 18.9 | 18.7 | 0.99× |
+| `groupby_select_sum` | 208.8 | 36.8 | 36.5 | 0.99× |
+| `groupby_sum` | 173.4 | 18.6 | 18.8 | 1.01× |
+| `groupby_where_count` | 75.9 | 14.7 | 15.0 | 1.02× |
+| `groupby_where_sum` | 87.5 | 14.3 | 14.7 | 1.03× |
+| `indexed_lookup` | 1457.1 | 205119.6 | 482.2 | 0.00× |
+| `join_count` | 37.9 | 128.2 | 65.4 | 0.51× |
+| `join_groupby_count` | 160.7 | 186.2 | 90.4 | 0.49× |
+| `join_groupby_to_array` | 189.9 | 217.8 | 93.1 | 0.43× |
+| `join_select` | — | 148.1 | 85.3 | 0.58× |
+| `join_where_count` | 39.3 | 148.5 | 74.4 | 0.50× |
+| `last_match` | 0.00 | 5.8 | 14.3 | 2.47× |
+| `long_count_aggregate` | 29.5 | 4.1 | 4.1 | 1.00× |
+| `max_aggregate` | 30.5 | 6.0 | 7.0 | 1.17× |
+| `min_aggregate` | 30.5 | 6.1 | 6.8 | 1.11× |
+| `order_distinct_take` | 139.1 | 15.8 | 97.2 | 6.15× |
+| `order_reverse_normalized` | 38.0 | 16.2 | 20.1 | 1.24× |
+| `order_take_desc` | 37.9 | 16.2 | 20.0 | 1.23× |
+| `reverse_distinct_by` | 292.5 | 21.4 | — | — |
 | `reverse_take` | 0.1 | 0.00 | 10.1 | — |
-| `reverse_take_select` | 0.00 | 34.6 | 48.4 | 1.40× |
+| `reverse_take_select` | 0.00 | 33.8 | 48.3 | 1.43× |
 | `select_count` | 0.1 | 0.00 | 2.2 | — |
-| `select_where` | 193.8 | 11.3 | 19.8 | 1.75× |
-| `select_where_count` | 33.1 | 5.2 | 7.4 | 1.42× |
-| `select_where_order_take` | 37.0 | 12.3 | 15.0 | 1.22× |
-| `select_where_sum` | 37.3 | 7.5 | 7.5 | 1.00× |
-| `single_match` | 0.00 | 2.9 | 5.6 | 1.93× |
+| `select_where` | 193.2 | 11.1 | 19.6 | 1.77× |
+| `select_where_count` | 32.4 | 5.2 | 7.5 | 1.44× |
+| `select_where_order_take` | 36.3 | 12.3 | 15.0 | 1.22× |
+| `select_where_sum` | 37.0 | 7.5 | 7.6 | 1.01× |
+| `single_match` | 0.00 | 2.9 | 5.5 | 1.90× |
 | `skip_take` | 0.5 | 0.1 | 0.2 | 2.00× |
-| `skip_while_match` | 3.5 | 5.2 | 5.3 | 1.02× |
-| `sort_first` | 38.1 | 11.0 | 13.5 | 1.23× |
-| `sort_take` | 38.7 | 16.5 | 20.7 | 1.25× |
-| `sort_take_select` | 38.4 | 16.1 | 20.0 | 1.24× |
+| `skip_while_match` | 3.5 | 5.3 | 5.3 | 1.00× |
+| `sort_first` | 37.7 | 11.1 | 13.3 | 1.20× |
+| `sort_take` | 37.9 | 16.4 | 20.8 | 1.27× |
+| `sort_take_select` | 37.9 | 16.2 | 20.1 | 1.24× |
 | `sum_aggregate` | 30.2 | 2.2 | 2.1 | 0.95× |
-| `sum_where` | 32.9 | 4.3 | 4.3 | 1.00× |
-| `take_count` | 3.6 | 0.2 | 0.5 | 2.50× |
+| `sum_where` | 32.3 | 4.3 | 4.2 | 0.98× |
+| `take_count` | 3.6 | 0.2 | 0.4 | 2.00× |
 | `take_count_filtered` | — | 0.2 | 0.2 | 1.00× |
 | `take_sum_aggregate` | — | 0.1 | 0.1 | 1.00× |
 | `take_where_count` | — | 0.1 | 0.1 | 1.00× |
-| `take_while_match` | 7.8 | 2.4 | 2.4 | 1.00× |
-| `to_array_filter` | 70.2 | 11.7 | 11.8 | 1.01× |
-| `zip_count_pred` | — | 15.2 | — | — |
-| `zip_dot_product` | — | 12.6 | 10.6 | 0.84× |
-| `zip_dot_product_3arg` | — | 12.7 | — | — |
-| `zip_reverse_to_array` | — | 31.2 | — | — |
+| `take_while_match` | 7.8 | 2.4 | 2.5 | 1.04× |
+| `to_array_filter` | 70.1 | 11.7 | 11.8 | 1.01× |
+| `zip_count_pred` | — | 15.3 | — | — |
+| `zip_dot_product` | — | 12.8 | 10.9 | 0.85× |
+| `zip_dot_product_3arg` | — | 12.9 | — | — |
+| `zip_reverse_to_array` | — | 31.0 | — | — |
 
 ## JIT
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 34.8 | 0.4 | 0.7 | 1.75× |
-| `all_match` | 27.7 | 0.3 | 0.2 | 0.67× |
+| `aggregate_match` | 34.6 | 0.4 | 0.7 | 1.75× |
+| `all_match` | 27.6 | 0.3 | 0.2 | 0.67× |
 | `any_match` | 0.00 | 0.00 | 0.00 | — |
-| `average_aggregate` | 30.2 | 1.0 | 3.6 | 3.60× |
-| `bare_order_where` | 185.6 | 34.1 | 34.1 | 1.00× |
-| `chained_select_collapse` | — | 2.1 | 2.1 | 1.00× |
-| `chained_where` | 36.9 | 0.6 | 0.9 | 1.50× |
+| `average_aggregate` | 29.8 | 1.0 | 3.6 | 3.60× |
+| `bare_order_where` | 196.3 | 35.4 | 36.8 | 1.04× |
+| `chained_select_collapse` | — | 2.2 | 2.2 | 1.00× |
+| `chained_where` | 36.4 | 0.6 | 0.9 | 1.50× |
 | `contains_match` | 0.00 | 0.2 | 0.1 | 0.50× |
-| `count_aggregate` | 29.7 | 0.4 | 0.6 | 1.50× |
+| `count_aggregate` | 29.0 | 0.4 | 0.6 | 1.50× |
 | `decs_count_bare_pred` | — | — | 0.6 | — |
-| `distinct_by_count` | 42.0 | 2.1 | 2.1 | 1.00× |
-| `distinct_by_order_take` | 253.6 | 2.6 | 3.2 | 1.23× |
-| `distinct_by_order_to_array` | 239.3 | 2.7 | 3.2 | 1.19× |
-| `distinct_count` | 42.2 | 2.1 | 2.1 | 1.00× |
-| `distinct_count_pred` | 253.0 | 2.1 | 2.3 | 1.10× |
-| `distinct_take` | 0.00 | 0.1 | 0.00 | 0.00× |
+| `distinct_by_count` | 40.8 | 2.2 | 2.1 | 0.95× |
+| `distinct_by_order_take` | 247.0 | 2.7 | 3.3 | 1.22× |
+| `distinct_by_order_to_array` | 240.3 | 2.8 | 3.3 | 1.18× |
+| `distinct_count` | 41.2 | 2.1 | 2.1 | 1.00× |
+| `distinct_count_pred` | 250.2 | 2.1 | 2.3 | 1.10× |
+| `distinct_take` | 0.00 | 0.00 | 0.00 | — |
 | `element_at_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_match` | 0.00 | 0.00 | 0.00 | — |
 | `first_or_default_match` | 0.00 | 0.00 | 0.00 | — |
-| `groupby_average` | 171.9 | 2.6 | 2.9 | 1.12× |
-| `groupby_count` | 142.9 | 2.4 | 2.5 | 1.04× |
-| `groupby_first` | 252.4 | 2.2 | 3.1 | 1.41× |
-| `groupby_having_count` | 142.3 | 2.4 | 2.5 | 1.04× |
-| `groupby_having_hidden_sum` | 176.1 | 2.5 | 2.8 | 1.12× |
-| `groupby_having_post_where` | 172.4 | 2.4 | 2.7 | 1.13× |
-| `groupby_max` | 173.8 | 2.4 | 2.7 | 1.13× |
-| `groupby_min` | 181.6 | 2.4 | 2.7 | 1.13× |
-| `groupby_multi_reducer` | 190.9 | 2.7 | 3.0 | 1.11× |
-| `groupby_select_order` | 171.5 | 2.4 | 2.7 | 1.13× |
-| `groupby_select_sum` | 199.7 | 3.2 | 3.7 | 1.16× |
-| `groupby_sum` | 172.5 | 2.4 | 2.7 | 1.13× |
-| `groupby_where_count` | 76.2 | 1.5 | 1.8 | 1.20× |
+| `groupby_average` | 174.9 | 2.6 | 2.9 | 1.12× |
+| `groupby_count` | 142.7 | 2.4 | 2.5 | 1.04× |
+| `groupby_first` | 251.9 | 2.6 | 3.1 | 1.19× |
+| `groupby_having_count` | 148.8 | 2.4 | 2.5 | 1.04× |
+| `groupby_having_hidden_sum` | 175.4 | 2.5 | 2.8 | 1.12× |
+| `groupby_having_post_where` | 175.7 | 2.4 | 2.7 | 1.13× |
+| `groupby_max` | 183.8 | 2.4 | 2.7 | 1.13× |
+| `groupby_min` | 172.8 | 2.4 | 2.7 | 1.13× |
+| `groupby_multi_reducer` | 190.1 | 2.7 | 3.0 | 1.11× |
+| `groupby_select_order` | 170.5 | 2.4 | 2.7 | 1.13× |
+| `groupby_select_sum` | 201.4 | 3.2 | 3.7 | 1.16× |
+| `groupby_sum` | 170.1 | 2.4 | 2.7 | 1.13× |
+| `groupby_where_count` | 75.7 | 1.5 | 1.8 | 1.20× |
 | `groupby_where_sum` | 86.9 | 1.5 | 1.8 | 1.20× |
-| `indexed_lookup` | 1265.6 | 35161.7 | 107.5 | 0.00× |
-| `join_count` | 38.4 | 34.5 | 12.8 | 0.37× |
-| `join_groupby_count` | — | 47.1 | 21.9 | 0.46× |
-| `join_groupby_to_array` | — | 54.7 | 21.9 | 0.40× |
-| `join_select` | — | 41.8 | 22.6 | 0.54× |
-| `join_where_count` | 39.5 | 41.5 | 22.9 | 0.55× |
+| `indexed_lookup` | 1256.0 | 35187.8 | 108.3 | 0.00× |
+| `join_count` | 37.9 | 34.6 | 14.2 | 0.41× |
+| `join_groupby_count` | 157.8 | 47.2 | 22.1 | 0.47× |
+| `join_groupby_to_array` | 190.3 | 55.5 | 21.9 | 0.39× |
+| `join_select` | — | 41.6 | 22.6 | 0.54× |
+| `join_where_count` | 39.0 | 41.2 | 22.8 | 0.55× |
 | `last_match` | 0.00 | 0.5 | 1.4 | 2.80× |
-| `long_count_aggregate` | 29.5 | 0.4 | 0.6 | 1.50× |
-| `max_aggregate` | 31.1 | 0.6 | 0.5 | 0.83× |
-| `min_aggregate` | 31.2 | 0.6 | 0.5 | 0.83× |
-| `order_distinct_take` | 138.7 | 2.1 | 75.1 | 35.76× |
-| `order_reverse_normalized` | 38.3 | 0.7 | 1.3 | 1.86× |
-| `order_take_desc` | 38.2 | 0.7 | 1.3 | 1.86× |
-| `reverse_distinct_by` | 297.1 | 2.7 | — | — |
+| `long_count_aggregate` | 29.0 | 0.4 | 0.6 | 1.50× |
+| `max_aggregate` | 30.8 | 0.6 | 0.5 | 0.83× |
+| `min_aggregate` | 30.8 | 0.6 | 0.5 | 0.83× |
+| `order_distinct_take` | 138.1 | 2.1 | 74.7 | 35.57× |
+| `order_reverse_normalized` | 37.8 | 0.7 | 1.3 | 1.86× |
+| `order_take_desc` | 37.9 | 0.7 | 1.3 | 1.86× |
+| `reverse_distinct_by` | 295.8 | 2.6 | — | — |
 | `reverse_take` | 0.00 | 0.00 | 1.1 | — |
-| `reverse_take_select` | 0.00 | 8.7 | 11.2 | 1.29× |
+| `reverse_take_select` | 0.00 | 8.3 | 10.1 | 1.22× |
 | `select_count` | 0.1 | 0.00 | 0.00 | — |
-| `select_where` | 106.1 | 4.3 | 5.7 | 1.33× |
-| `select_where_count` | 32.9 | 0.4 | 0.6 | 1.50× |
-| `select_where_order_take` | 36.8 | 0.7 | 1.4 | 2.00× |
-| `select_where_sum` | 37.6 | 0.5 | 0.6 | 1.20× |
+| `select_where` | 105.0 | 4.1 | 5.6 | 1.37× |
+| `select_where_count` | 32.5 | 0.4 | 0.6 | 1.50× |
+| `select_where_order_take` | 36.9 | 0.7 | 1.3 | 1.86× |
+| `select_where_sum` | 37.3 | 0.5 | 0.6 | 1.20× |
 | `single_match` | 0.00 | 0.4 | 1.1 | 2.75× |
 | `skip_take` | 0.3 | 0.00 | 0.00 | — |
-| `skip_while_match` | 3.5 | 0.4 | 0.4 | 1.00× |
-| `sort_first` | 38.2 | 0.4 | 1.3 | 3.25× |
-| `sort_take` | 38.3 | 0.7 | 1.4 | 2.00× |
-| `sort_take_select` | 38.4 | 0.7 | 1.4 | 2.00× |
-| `sum_aggregate` | 30.4 | 0.4 | 0.3 | 0.75× |
-| `sum_where` | 32.9 | 0.4 | 0.6 | 1.50× |
+| `skip_while_match` | 3.4 | 0.4 | 0.4 | 1.00× |
+| `sort_first` | 37.6 | 0.4 | 1.3 | 3.25× |
+| `sort_take` | 38.1 | 0.7 | 1.3 | 1.86× |
+| `sort_take_select` | 38.2 | 0.7 | 1.3 | 1.86× |
+| `sum_aggregate` | 29.9 | 0.4 | 0.3 | 0.75× |
+| `sum_where` | 32.4 | 0.4 | 0.6 | 1.50× |
 | `take_count` | 1.8 | 0.1 | 0.1 | 1.00× |
 | `take_count_filtered` | — | 0.00 | 0.00 | — |
 | `take_sum_aggregate` | — | 0.00 | 0.00 | — |
 | `take_where_count` | — | 0.00 | 0.00 | — |
 | `take_while_match` | 7.8 | 0.2 | 0.3 | 1.50× |
-| `to_array_filter` | 48.3 | 3.3 | 3.4 | 1.03× |
+| `to_array_filter` | 48.3 | 3.2 | 3.4 | 1.06× |
 | `zip_count_pred` | — | 0.7 | — | — |
 | `zip_dot_product` | — | 0.5 | 0.5 | 1.00× |
 | `zip_dot_product_3arg` | — | 0.5 | — | — |
@@ -206,10 +204,6 @@ and which gaps could land in a single PR — see
   (~204k ns/op), while decs uses `query(eid)` for O(1) lookup. The
   ratio is mathematically tiny but the comparison is between two
   fundamentally different algorithms — not a like-for-like benchmark.
-- **`join_groupby_count` SQL** — sqlite_linq's `_group_by` after `_join`
-  doesn't currently lower (group key column is from the joined
-  projection, not a base-table column). Follow-up TODO 2026-05-25.
-- **`join_groupby_to_array` SQL** — same reason as `join_groupby_count`.
 - **`join_select` SQL** — sqlite_linq's `_select` after `_join` rejects
   bare `_` (only the `into` lambda's parameter names are valid
   receivers; computed projections would need to be inlined into the

--- a/benchmarks/sql/sqlite_linq_gaps.md
+++ b/benchmarks/sql/sqlite_linq_gaps.md
@@ -51,10 +51,10 @@ require them.
 
 ---
 
-## ~~`_group_by` after `_join`~~ — closed in PR #2911
+## ~~`_group_by` after `_join`~~ — closed in PR #2910
 
 Originally catalogued 2 cells as blocked on resolving `_group_by` keys against
-the join's `into` projection. Closed in PR #2911 (chunk N+2) via a central
+the join's `into` projection. Closed in PR #2910 (chunk N+2) via a central
 `pred_to_sql` extension that consults a snapshot of the join's projection
 registry — single hook transitively enables alias resolution in `_group_by` /
 `_having` / `_order_by` / `try_translate_group_aggregate` / computed-expression

--- a/benchmarks/sql/sqlite_linq_gaps.md
+++ b/benchmarks/sql/sqlite_linq_gaps.md
@@ -51,19 +51,24 @@ require them.
 
 ---
 
+## ~~`_group_by` after `_join`~~ — closed in PR #2911
+
+Originally catalogued 2 cells as blocked on resolving `_group_by` keys against
+the join's `into` projection. Closed in PR #2911 (chunk N+2) via a central
+`pred_to_sql` extension that consults a snapshot of the join's projection
+registry — single hook transitively enables alias resolution in `_group_by` /
+`_having` / `_order_by` / `try_translate_group_aggregate` / computed-expression
+keys.
+
+**Closed cells**:
+- `join_groupby_count` — `_join |> _group_by(_.Brand) |> _select((Brand=_._0, N=_._1|>count()))`.
+- `join_groupby_to_array` — `_join |> _group_by(_.Brand) |> _select((Brand=_._0, Total=_._1|>_select(_.Price)|>sum()))`.
+
+The fix surfaced one residual: HAVING with an alias-resolved aggregate in the
+`_sql(...)` runtime form hits a typer-ordering quirk; `_sql_text` emit is
+correct, runtime path deferred to chunk N+3.
+
 ## Other deferred lowerings (independent, each its own PR)
-
-### `_group_by` after `_join` — group key from joined projection
-
-Benches: [`join_groupby_count`](join_groupby_count.das),
-[`join_groupby_to_array`](join_groupby_to_array.das).
-
-`sqlite_linq`'s `_group_by` after `_join` doesn't lower today because the
-group key column comes from the join's `into` projection, not from a
-base-table column. The lowering would need to either emit the `JOIN` as a
-subquery and `GROUP BY` over the subquery's column, or surface the
-projection-column → SQL-fragment mapping into `_group_by`'s key-extractor
-logic. Originally TODO'd 2026-05-25.
 
 ### `COUNT(DISTINCT computed-expr)`
 

--- a/doc/source/reference/tutorials/sql_15_join.rst
+++ b/doc/source/reference/tutorials/sql_15_join.rst
@@ -90,6 +90,49 @@ Single-column and named-tuple projections both work. Per-source
 projections (``_select(...)`` on the right side) are rejected ---
 the join's ``into`` lambda is the only projection.
 
+Joining + grouping
+==================
+
+``_group_by`` / ``_having`` / ``_order_by`` after ``_join`` accept the
+join's ``into``-projection alias names as keys, not base-table fields.
+The translator resolves each alias through the join's projection
+registry and emits the underlying qualified column (``"t0"."brand"``,
+``"t1"."Id"``) in the GROUP BY / HAVING / ORDER BY clauses, so the
+SQL composes cleanly with the JOIN:
+
+.. code-block:: das
+
+    let groups <- _sql(db |> select_from(type<Car>)
+        |> _join(db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                 $(c : Car, d : Dealer) => (Brand = c.brand, Price = c.price))
+        |> _group_by(_.Brand)
+        |> _select((Brand = _._0, N = _._1 |> count())))
+    // SELECT ("t0"."brand"), COUNT(*)
+    //   FROM "Cars" AS "t0" INNER JOIN "Dealers" AS "t1"
+    //     ON "t0"."dealer_id" = "t1"."id"
+    //   GROUP BY ("t0"."brand")
+
+Per-group aggregates over a projection alias resolve the same way ---
+``_._1 |> _select(_.Price) |> sum()`` becomes ``SUM("t0"."price")``,
+not the bare alias:
+
+.. code-block:: das
+
+    let totals <- _sql(db |> select_from(type<Car>)
+        |> _join(db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                 $(c : Car, d : Dealer) => (Brand = c.brand, Price = c.price))
+        |> _group_by(_.Brand)
+        |> _select((Brand = _._0,
+                    Total = _._1 |> _select(_.Price) |> sum())))
+    // ... SUM("t0"."price") ... GROUP BY ("t0"."brand")
+
+``_order_by`` and computed-expression group keys (``_group_by(_.Price / 100)``)
+read aliases through the same registry. Aliases that don't appear in
+the join's ``into`` projection reject with a clear macro_error listing
+the valid alias names.
+
 What's not shipped
 ==================
 

--- a/modules/dasSQLITE/API_REWORK.md
+++ b/modules/dasSQLITE/API_REWORK.md
@@ -5570,6 +5570,46 @@ All 4 m1 lanes backfilled in `benchmarks/sql/{distinct_by_order_take,distinct_by
 - **Pre-distinct phase-divert composition** (Copilot R1 #2909). Chains like `take(N) |> _distinct_by(K)` or `skip(N) |> _distinct_by(K)` trigger `divert_to_inner` BEFORE `_distinct_by` peels — `q.innerSql`/`q.innerBindExprs` get populated by the take's inner subquery, and chunk N+1's passthrough finalize would overwrite the inner SQL while orphaning the take's bind. Currently rejected with a clear macro_error pointing the user to restructure as `_distinct_by(K) |> take(N)` (cap-after-distinct semantics). A future composition would 2-level wrap: `SELECT … FROM (SELECT *, MIN(pk) FROM ({prior_innerSql}) GROUP BY K) AS t0` to preserve cap-before-distinct semantics — needs design + tests for arbitrary phase-divert combinations.
 - **Whole-row projection as inner subquery** (Copilot R1 #2909). `_group_by(K) |> _select((K=_._0, R=_._1 |> first())) |> _where(P) |> to_array` triggers `divert_to_inner` (PHASE_WHERE forces a SELECT divert), which would wrap the grouped+first projection as inner. The row entry expands to N source columns without `AS <alias>` under `force_aliases=true`, and `apply_passthrough_projection` expects 1 column per record name. Currently rejected with a clear macro_error pointing the user to restructure (run the wrap-triggering op before `_group_by`, or split into separate `_sql` calls). Resolution options: (a) emit deterministic per-field aliases (`"col1" AS "<RecordName>_col1"`) under `force_aliases` and teach `apply_passthrough_projection` to reconstruct the row entry from those, or (b) keep the rejection and document the constraint. Same PR could lift the v1 single-key-only constraint on `first()` projections.
 
+## Shipped — chunk N+2: `_group_by` / `_having` / `_order_by` after `_join` via projection-alias resolution (branch `bbatkin/sqlite-linq-join-groupby-alias`)
+
+### Surface in this PR
+
+Closes 2 SQL bench cells from [`benchmarks/sql/sqlite_linq_gaps.md`](../../benchmarks/sql/sqlite_linq_gaps.md)'s "`_group_by` after `_join`" section. After this PR, every chain operator that references a column reads the join's `into`-projection alias through a single registry — fields named in the `into` lambda's named tuple (`(Brand = c.brand, Price = c.price)`) become first-class names for subsequent `_group_by` / `_having` / `_order_by` / aggregate / computed-key operations:
+
+- `_join(...) |> _group_by(_.Brand) |> _select((Brand=_._0, N=_._1|>count()))` lowers to `SELECT ("t0"."brand"), COUNT(*) FROM "Cars" AS "t0" INNER JOIN ... GROUP BY ("t0"."brand")`.
+- `_join(...) |> _group_by(_.Brand) |> _select((Brand=_._0, Total=_._1|>_select(_.Price)|>sum()))` lowers to `... SUM("t0"."price") ... GROUP BY ("t0"."brand")`.
+- `_join(...) |> _having(_._1 |> _select(_.Price) |> sum() > 200) |> _select(...)` resolves the alias inside HAVING.
+- `_join(...) |> _order_by(_.Brand)` resolves the alias inside ORDER BY.
+- `_join(...) |> _group_by(_.Price / 100) |> _select(...)` resolves the alias inside a computed group key.
+
+### Architecture
+
+Single load-bearing change: `pred_to_sql`'s column-reference branch consults a new `joinProjRecordNames` snapshot of the join's `into` projection (captured at the end of `process_join_call`, preserved across `analyze_grouped_projection`'s clear-and-repopulate of `projRecordNames`). New helpers `find_projection_alias(q, name)` and `render_projection_alias_sql(q, idx)` resolve aliases to qualified SQL fragments. Bare-`_.Field` fast paths in `push_group_key`, `collect_order_keys`, and `try_translate_group_aggregate` mirror the same lookup so they don't bypass `pred_to_sql`. v1 supports `t0` / `t1` aliases (the 2-source `_join` shape); other aliases (multi-source / nested joins) reject loudly.
+
+### Constraints (v1)
+
+- 2-source `_join` only (carries forward from chunks N / N+1).
+- The join's `into` lambda's named-tuple aliases are the field namespace post-join — base-table column names ARE NOT available unqualified. Users referring to base-table fields by name post-join get a `not a projection alias` error listing the valid alias names.
+- HAVING with alias-resolved aggregate (`_._1 |> _select(_.X) |> sum() > N`) has a known typer-ordering quirk: in compilation units with multiple `_sql` calls referencing the same chain shape, the typer pre-folds the predicate's aggregate side and the runtime `_sql` form fails to bind `_` for the row builder. The SQL emit itself is correct (verified via `_sql_text`), so chains that don't need to materialize the predicate body at runtime work. Investigating in chunk N+3.
+
+### Tests
+
+`tests/dasSQLITE/test_33_join_groupby.das` — 12 new tests covering Arm B (4: emit + runtime × 2 chain shapes), Arm C (4: emit + runtime + min/max/avg + multi-aggregate), and transitive coverage via HAVING / ORDER BY / computed-key (4: emit-shape + runtime mix). 3 new `failed_*.das` rejection probes:
+- `failed_join_groupby_unknown_alias.das` — `_group_by(_.NotAnAlias)` after join rejects with alias list
+- `failed_join_groupby_aggregate_unknown_alias.das` — `_._1 |> _select(_.NotAField) |> sum()` rejects similarly
+- `failed_join_order_by_unknown_alias.das` — `_order_by(_.NotAnAlias)` after join rejects similarly
+
+### Benches
+
+Both `benchmarks/sql/join_groupby_count.das` and `benchmarks/sql/join_groupby_to_array.das` got `run_m1` lanes. INTERP m1 beats array-fold m3f baselines (158 vs 184 ns/op for count; 191 vs 216 for to_array). `benchmarks/sql/results.md` refreshed. `sqlite_linq_gaps.md` "`_group_by` after `_join`" section struck.
+
+### Deferred to chunk N+3
+
+- **HAVING with alias-resolved aggregate in `_sql(...)` runtime form** — typer-ordering quirk noted above. `_sql_text(...)` emit is correct; only the row-binder in `_sql(...)` is affected. Workaround for now: split the chain into a separate `_sql_text` probe for verification, or restructure to use bare `count()` predicates.
+- Nested / multi-way joins (`_join |> _join |> ...`) — chunks N / N+1 already constrain to 2-source; `render_projection_alias_sql` rejects aliases beyond `t0`/`t1`. A future extension would generalize `source_rootType_for_alias` over an N-source join chain.
+- HAVING / ORDER BY / computed-key composition with `_distinct_by` (orthogonal to this chunk's _join surface; deferred from N+1's "where-then-distinct" follow-up).
+- Real window functions — still no bench needs them.
+
 ## Plan (to be written after all tutorials are reviewed)
 
 _TBD — this section is filled in once we have notes from every tutorial._

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -150,6 +150,12 @@ struct private SqlQuery {
     selectColTypes : array<TypeDeclPtr>
     selectColSqlFragments : array<string>
     projRecordNames : array<string>
+    // nolint:STYLE014 Snapshot of the join's `into` projection registry, captured at the end of process_join_call. Survives `analyze_grouped_projection`'s clear-and-repopulate of projRecordNames (which holds the outer named-tuple's record names mid-projection). Read by find_projection_alias / render_projection_alias_sql so post-join `_.<alias>` resolution inside aggregates / HAVING / ORDER BY / computed group keys keeps pointing at the join's projected slots, not the outer projection's freshly-clobbered names.
+    joinProjRecordNames : array<string>
+    joinSelectCols : array<string>
+    joinSelectColAliases : array<string>
+    joinSelectColTypes : array<TypeDeclPtr>
+    joinSelectColSqlFragments : array<string>
     aggregateExpr : string
     aggregateType : TypeDeclPtr
     whereSql    : string
@@ -464,6 +470,39 @@ def private lookup_arg_source(q : SqlQuery; argName : string) : int {
         if (q.argNames[i] == argName) return q.argSourceIdx[i]
     }
     return -1
+}
+
+// Looks up a join's `into`-projection alias by name. Reads from the snapshot in joinProjRecordNames (preserved across analyze_grouped_projection's clear of projRecordNames), so post-join lookups inside grouped projections still resolve against the join's slots.
+[macro_function]
+def private find_projection_alias(q : SqlQuery; name : string) : int {
+    let n = length(q.joinProjRecordNames)
+    for (i in range(n)) {
+        if (q.joinProjRecordNames[i] == name) return i
+    }
+    return -1
+}
+
+[macro_function]
+def private projection_alias_list(q : SqlQuery) : string {
+    if (empty(q.joinProjRecordNames)) return "(none)"
+    return build_string() $(var w) {
+        for (i in range(length(q.joinProjRecordNames))) {
+            if (i > 0) w |> write(", ")
+            w |> write("`{q.joinProjRecordNames[i]}`")
+        }
+    }
+}
+
+// nolint:STYLE015 Renders a join's `into`-projection alias as a fully-qualified SQL column fragment. Computed slots (e.g. LEFT JOIN's `is_some` probe at analyze_projection's named-tuple branch) carry a pre-rendered fragment in `q.joinSelectColSqlFragments[i]`; simple field projections rebuild it from `(alias, srcRootType, srcField)`. Returns `""` if the alias's source can't be resolved (defensive — should not happen for joins that v1 supports).
+[macro_function]
+def private render_projection_alias_sql(var q : SqlQuery&; aliasIdx : int) : string {
+    if (!empty(q.joinSelectColSqlFragments[aliasIdx])) {
+        return q.joinSelectColSqlFragments[aliasIdx]
+    }
+    let alias = q.joinSelectColAliases[aliasIdx]
+    let rootT = source_rootType_for_alias(q, alias)
+    if (rootT == null) return ""
+    return column_sql_for_alias(alias, rootT, q.joinSelectCols[aliasIdx])
 }
 
 [macro_function]
@@ -1187,6 +1226,25 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         if (savedAggProj) {
             q.proj = ProjectionShape.Aggregate
         }
+    }
+    // Snapshot the join's projection registry — preserved across analyze_grouped_projection's clear-and-repopulate so downstream `_.<alias>` lookups inside aggregates / HAVING / ORDER BY / computed group keys still resolve against the join's projected slots.
+    let nProj = length(q.projRecordNames)
+    q.joinProjRecordNames |> clear
+    q.joinSelectCols |> clear
+    q.joinSelectColAliases |> clear
+    q.joinSelectColTypes |> clear
+    q.joinSelectColSqlFragments |> clear
+    q.joinProjRecordNames |> reserve(nProj)
+    q.joinSelectCols |> reserve(nProj)
+    q.joinSelectColAliases |> reserve(nProj)
+    q.joinSelectColTypes |> reserve(nProj)
+    q.joinSelectColSqlFragments |> reserve(nProj)
+    for (i in range(nProj)) {
+        q.joinProjRecordNames |> push(q.projRecordNames[i]) // nolint:PERF006 reserved above
+        q.joinSelectCols |> push(q.selectCols[i]) // nolint:PERF006 reserved above
+        q.joinSelectColAliases |> push(q.selectColAliases[i]) // nolint:PERF006 reserved above
+        q.joinSelectColTypes |> push(q.selectColTypes[i]) // nolint:PERF006 reserved above
+        q.joinSelectColSqlFragments |> push(q.selectColSqlFragments[i]) // nolint:PERF006 reserved above
     }
     q.seenSelect = true
     return true
@@ -2270,7 +2328,7 @@ def private group_key_column_name(q : SqlQuery; idx : int) : string {
 }
 
 [macro_function]
-def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery; prog : ProgramPtr; at : LineInfo;
+def private try_translate_group_aggregate(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo;
                                           var sqlOut : string&; var typeOut : TypeDeclPtr&) : bool {
     var n = node
     if (n is ExprRef2Value) {
@@ -2317,6 +2375,26 @@ def private try_translate_group_aggregate(var node : ExpressionPtr; q : SqlQuery
                     sqlOp = "MIN"
                 } else {
                     sqlOp = "MAX"
+                }
+                // Post-join: `col` refers to a projection alias (e.g. `Price` from `(Brand=d.brand, Price=c.price)`), not a base-table field. Resolve through the projection registry so the SUM/MIN/MAX/AVG wraps the fully-qualified source column.
+                if (q.seenJoin && !empty(q.joinProjRecordNames)) {
+                    let aliasIdx = find_projection_alias(q, col)
+                    if (aliasIdx < 0) {
+                        macro_error(prog, at, "_sql: {fname}(_.{col}): '{col}' is not a projection alias of the preceding _join (valid aliases: {projection_alias_list(q)})")
+                        return true
+                    }
+                    let frag = render_projection_alias_sql(q, aliasIdx)
+                    if (empty(frag)) {
+                        macro_error(prog, at, "_sql: {fname}(_.{col}): cannot render projection alias (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
+                        return true
+                    }
+                    sqlOut = "{sqlOp}({frag})"
+                    if (fname == "average") {
+                        typeOut = new TypeDecl(at = at, baseType = Type.tDouble)
+                    } else {
+                        typeOut = q.joinSelectColTypes[aliasIdx]
+                    }
+                    return true
                 }
                 sqlOut = "{sqlOp}(\"{col}\")"
                 if (fname == "average") {
@@ -2569,6 +2647,21 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
     {
         var fieldName : string
         if (qmatch(body, _.$f(fieldName)).matched) {
+            // Post-join: `_.<alias>` resolves through the join's projection registry → qualified column.
+            if (q.seenJoin && !empty(q.joinProjRecordNames)) {
+                let aliasIdx = find_projection_alias(q, fieldName)
+                if (aliasIdx < 0) {
+                    macro_error(prog, at, "_sql: _order_by(_.{fieldName}): '{fieldName}' is not a projection alias of the preceding _join (valid aliases: {projection_alias_list(q)})")
+                    return false
+                }
+                let frag = render_projection_alias_sql(q, aliasIdx)
+                if (empty(frag)) {
+                    macro_error(prog, at, "_sql: _order_by(_.{fieldName}): cannot render projection alias (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
+                    return false
+                }
+                q.orderByCols |> push("{frag} {direction}")
+                return true
+            }
             let sqlCol = field_to_column_name(q.rootType, fieldName)
             q.orderByCols |> push("\"{sqlCol}\" {direction}")
             return true
@@ -2585,6 +2678,20 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
             var val = mkTup.values[i]
             var fieldName : string
             if (qmatch(val, _.$f(fieldName)).matched) {
+                if (q.seenJoin && !empty(q.joinProjRecordNames)) {
+                    let aliasIdx = find_projection_alias(q, fieldName)
+                    if (aliasIdx < 0) {
+                        macro_error(prog, at, "_sql: _order_by(_.{fieldName}): '{fieldName}' is not a projection alias of the preceding _join (valid aliases: {projection_alias_list(q)})")
+                        return false
+                    }
+                    let frag = render_projection_alias_sql(q, aliasIdx)
+                    if (empty(frag)) {
+                        macro_error(prog, at, "_sql: _order_by(_.{fieldName}): cannot render projection alias (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
+                        return false
+                    }
+                    q.orderByCols |> push("{frag} {direction}")
+                    continue
+                }
                 let sqlCol = field_to_column_name(q.rootType, fieldName)
                 q.orderByCols |> push("\"{sqlCol}\" {direction}")
             } elif (val._type != null && val._type.baseType == Type.tString) {
@@ -2611,6 +2718,26 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
 def private push_group_key(var entry : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
     var fieldName : string
     if (qmatch(entry, _.$f(fieldName)).matched) {
+        // Post-join: `_.<alias>` refers to the join's `into` projection slot, not a base-table column. Route through the computed-expression key path so the SQL emitter writes the pre-resolved fragment (e.g. `"t0"."brand"`) verbatim. Downstream analyze_grouped_projection sees groupByKeyExprs[i] != null and reuses the same fragment for the outer SELECT.
+        if (q.seenJoin && !empty(q.joinProjRecordNames)) {
+            let aliasIdx = find_projection_alias(q, fieldName)
+            if (aliasIdx >= 0) {
+                let frag = render_projection_alias_sql(q, aliasIdx)
+                if (empty(frag)) {
+                    macro_error(prog, at, "_sql: _group_by(_.{fieldName}): cannot render projection alias (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
+                    q.hadError = true
+                    return false
+                }
+                q.groupByCols |> push("({frag})")
+                q.groupByKeyExprs |> push <| clone_expression(entry)
+                q.groupByKeyTypes |> push(q.joinSelectColTypes[aliasIdx])
+                return true
+            }
+            // Fall through — `_.Field` not in projection registry: user typoed an alias, or referenced a base-table column post-join (not v1 supported). Emit a clear error rather than falling through to the bare-field path (which would silently emit invalid SQL).
+            macro_error(prog, at, "_sql: _group_by(_.{fieldName}): '{fieldName}' is not a projection alias of the preceding _join (valid aliases: {projection_alias_list(q)})")
+            q.hadError = true
+            return false
+        }
         q.groupByCols |> push("\"{fieldName}\"")
         q.groupByKeyExprs |> push(null)
         q.groupByKeyTypes |> push(null)
@@ -2866,6 +2993,16 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             let argName = string((receiver as ExprVar).name)
             // Alias-qualification is driven by rootAlias != "", NOT seenJoin (right-side subQ runs with rootAlias="t1" but seenJoin=false).
             if (!empty(q.rootAlias)) {
+                // Post-join `_` refers to the joined-tuple row whose fields are projection aliases, not base-table columns. Consult the `into` projection registry before falling through to base-table resolution; this single hook transitively enables alias references in _group_by / _having / _order_by / computed-expression keys / try_translate_group_aggregate (all of which call pred_to_sql).
+                if (argName == "_" && q.seenJoin && !empty(q.joinProjRecordNames)) {
+                    let aliasIdx = find_projection_alias(q, fieldName)
+                    if (aliasIdx >= 0) {
+                        let frag = render_projection_alias_sql(q, aliasIdx)
+                        if (empty(frag)) return pred_fail(q, prog, at, "_sql: cannot render projection alias '{fieldName}' (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
+                        return frag
+                    }
+                    // Fall through to base-table resolution — user may have typoed an alias; the existing path either resolves or fails with a column-not-found message.
+                }
                 var srcIdx = lookup_arg_source(q, argName)
                 // Pre-join `_where` references root through `_` — arg-binding stack only populated inside `into` projection.
                 if (srcIdx < 0 && argName == "_") {

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2993,15 +2993,15 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
             let argName = string((receiver as ExprVar).name)
             // Alias-qualification is driven by rootAlias != "", NOT seenJoin (right-side subQ runs with rootAlias="t1" but seenJoin=false).
             if (!empty(q.rootAlias)) {
-                // Post-join `_` refers to the joined-tuple row whose fields are projection aliases, not base-table columns. Consult the `into` projection registry before falling through to base-table resolution; this single hook transitively enables alias references in _group_by / _having / _order_by / computed-expression keys / try_translate_group_aggregate (all of which call pred_to_sql).
+                // Post-join `_` refers to the joined-tuple row whose fields are projection aliases, not base-table columns. Consult the `into` projection registry; this single hook transitively enables alias references in _having / _order_by / computed-expression keys / try_translate_group_aggregate (all of which call pred_to_sql). On miss, reject loudly — `push_group_key` / `collect_order_keys` / `try_translate_group_aggregate` all reject the same way; falling through to base-table resolution here would leak the unqualified base-table namespace into post-join `_having` / computed-key predicates inconsistently with the bare-`_.Field` fast paths (Copilot R1 #2910).
                 if (argName == "_" && q.seenJoin && !empty(q.joinProjRecordNames)) {
                     let aliasIdx = find_projection_alias(q, fieldName)
-                    if (aliasIdx >= 0) {
-                        let frag = render_projection_alias_sql(q, aliasIdx)
-                        if (empty(frag)) return pred_fail(q, prog, at, "_sql: cannot render projection alias '{fieldName}' (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
-                        return frag
+                    if (aliasIdx < 0) {
+                        return pred_fail(q, prog, at, "_sql: post-join `_.{fieldName}`: '{fieldName}' is not a projection alias of the preceding _join (valid aliases: {projection_alias_list(q)})")
                     }
-                    // Fall through to base-table resolution — user may have typoed an alias; the existing path either resolves or fails with a column-not-found message.
+                    let frag = render_projection_alias_sql(q, aliasIdx)
+                    if (empty(frag)) return pred_fail(q, prog, at, "_sql: cannot render projection alias '{fieldName}' (alias source '{q.joinSelectColAliases[aliasIdx]}' unresolved — multi-source joins beyond t0/t1 not supported in v1)")
+                    return frag
                 }
                 var srcIdx = lookup_arg_source(q, argName)
                 // Pre-join `_where` references root through `_` — arg-binding stack only populated inside `into` projection.

--- a/tests/dasSQLITE/failed_join_groupby_aggregate_unknown_alias.das
+++ b/tests/dasSQLITE/failed_join_groupby_aggregate_unknown_alias.das
@@ -5,7 +5,12 @@ options gen2
 // the join's `into` projection. The fix path is in try_translate_group_aggregate's
 // post-join branch — when the col name isn't found in joinProjRecordNames,
 // emit a macro_error listing the available aliases.
+//
+// macro_error fires but typer cascade adds typer-level errors for the unknown
+// tuple field in the inner _select lambda; probe expects all 3 codes.
 expect 50503
+expect 30831
+expect 30341
 
 require daslib/sql
 require sqlite/sqlite_boost

--- a/tests/dasSQLITE/failed_join_groupby_aggregate_unknown_alias.das
+++ b/tests/dasSQLITE/failed_join_groupby_aggregate_unknown_alias.das
@@ -1,0 +1,36 @@
+options gen2
+
+// `_join |> _group_by(_.K) |> _select((K=_._0, X=_._1|>_select(_.<bad>)|>sum()))`
+// rejects when the aggregate's inner _select references a column that's not in
+// the join's `into` projection. The fix path is in try_translate_group_aggregate's
+// post-join branch — when the col name isn't found in joinProjRecordNames,
+// emit a macro_error listing the available aliases.
+expect 50503
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Price : int
+    DealerId : int
+}
+
+[sql_table(name = "Dealers")]
+struct Dealer {
+    @sql_primary_key Id : int
+    Brand : string
+}
+
+[export]
+def main() {
+    var _db = SqlRunner()
+    let _ = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Brand)
+        |> _select((Brand = _._0, Total = _._1 |> _select(_.NotAField) |> sum())))
+}

--- a/tests/dasSQLITE/failed_join_groupby_unknown_alias.das
+++ b/tests/dasSQLITE/failed_join_groupby_unknown_alias.das
@@ -1,0 +1,35 @@
+options gen2
+
+// `_join |> _group_by(_.<not-an-alias>)` rejects with a clear error message
+// listing the valid projection aliases. The fix path lives in push_group_key's
+// post-join branch (sqlite_linq.das): when `q.seenJoin` is true and the
+// `_.<field>` name is not in `q.joinProjRecordNames`, emit a macro_error.
+expect 50503
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Price : int
+    DealerId : int
+}
+
+[sql_table(name = "Dealers")]
+struct Dealer {
+    @sql_primary_key Id : int
+    Brand : string
+}
+
+[export]
+def main() {
+    var _db = SqlRunner()
+    let _ = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.NotAnAlias)
+        |> _select((K = _._0, N = _._1 |> count())))
+}

--- a/tests/dasSQLITE/failed_join_groupby_unknown_alias.das
+++ b/tests/dasSQLITE/failed_join_groupby_unknown_alias.das
@@ -4,7 +4,20 @@ options gen2
 // listing the valid projection aliases. The fix path lives in push_group_key's
 // post-join branch (sqlite_linq.das): when `q.seenJoin` is true and the
 // `_.<field>` name is not in `q.joinProjRecordNames`, emit a macro_error.
+//
+// The macro_error fires but the typer continues expanding the chain because
+// `_sql_text` returns null when its macro errors out — `_._0`/`_._1` in the
+// trailing `_select` then cascade to additional typer errors (linq generic
+// instantiation for group_by_lazy with an invalid tuple). Probe expects the
+// full cascade so the test is stable across linq.das internal changes.
 expect 50503
+expect 50503
+expect 30831
+expect 30341
+expect 30838
+expect 30838
+expect 30808
+expect 30808
 
 require daslib/sql
 require sqlite/sqlite_boost

--- a/tests/dasSQLITE/failed_join_order_by_unknown_alias.das
+++ b/tests/dasSQLITE/failed_join_order_by_unknown_alias.das
@@ -3,7 +3,12 @@ options gen2
 // `_join |> _order_by(_.<not-an-alias>)` rejects with a clear error listing the
 // valid projection aliases. collect_order_keys has a post-join branch that consults
 // the projection registry and emits a macro_error when the field name isn't found.
+//
+// macro_error fires but typer cascade adds typer-level errors for the unknown
+// tuple field; probe expects all 3 codes.
 expect 50503
+expect 30831
+expect 30341
 
 require daslib/sql
 require sqlite/sqlite_boost

--- a/tests/dasSQLITE/failed_join_order_by_unknown_alias.das
+++ b/tests/dasSQLITE/failed_join_order_by_unknown_alias.das
@@ -1,0 +1,33 @@
+options gen2
+
+// `_join |> _order_by(_.<not-an-alias>)` rejects with a clear error listing the
+// valid projection aliases. collect_order_keys has a post-join branch that consults
+// the projection registry and emits a macro_error when the field name isn't found.
+expect 50503
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Price : int
+    DealerId : int
+}
+
+[sql_table(name = "Dealers")]
+struct Dealer {
+    @sql_primary_key Id : int
+    Brand : string
+}
+
+[export]
+def main() {
+    var _db = SqlRunner()
+    let _ = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _order_by(_.NotAnAlias))
+}

--- a/tests/dasSQLITE/test_33_join_groupby.das
+++ b/tests/dasSQLITE/test_33_join_groupby.das
@@ -1,0 +1,285 @@
+options gen2
+
+require dastest/testing_boost public
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name="Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name : string
+    Price : int
+    DealerId : int
+}
+
+[sql_table(name="Dealers")]
+struct Dealer {
+    @sql_primary_key Id : int
+    Brand : string
+}
+
+def private fixture(db : SqlRunner) {
+    db |> create_table(type<Car>)
+    db |> create_table(type<Dealer>)
+    db |> insert(Dealer(Id = 1, Brand = "BMW"))
+    db |> insert(Dealer(Id = 2, Brand = "Audi"))
+    db |> insert(Dealer(Id = 3, Brand = "Tesla"))
+    db |> insert(Car(Id = 1, Name = "x1", Price = 100, DealerId = 1))
+    db |> insert(Car(Id = 2, Name = "x2", Price = 200, DealerId = 1))
+    db |> insert(Car(Id = 3, Name = "x3", Price = 150, DealerId = 2))
+    db |> insert(Car(Id = 4, Name = "x4", Price = 300, DealerId = 3))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Arm B — `_join |> _group_by(_.<alias>) |> _select((K=_._0, N=_._1|>count()))`
+// The group key references the join's `into` projection alias (`Brand`),
+// not a base-table column. push_group_key resolves through the projection
+// registry to emit `GROUP BY ("t1"."Brand")` against the joined sources.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_join_groupby_count_emits_alias_resolved_group_by(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Brand)
+        |> _select((Brand = _._0, N = _._1 |> count())))
+    t |> equal(sql,
+        "SELECT (\"t1\".\"Brand\"), COUNT(*) FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY (\"t1\".\"Brand\")",
+        "_join |> _group_by(_.<alias>) resolves the alias against the projection registry — emits the underlying source column in GROUP BY and SELECT")
+}
+
+[test]
+def test_join_groupby_count_returns_per_group_counts(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                     $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+            |> _group_by(_.Brand)
+            |> _select((Brand = _._0, N = _._1 |> count())))
+        t |> equal(length(groups), 3, "3 distinct brands across joined cars")
+        var counts <- {for (g in groups); g.Brand => g.N}
+        t |> equal(counts["BMW"], 2, "BMW has 2 cars")
+        t |> equal(counts["Audi"], 1, "Audi has 1 car")
+        t |> equal(counts["Tesla"], 1, "Tesla has 1 car")
+    }
+}
+
+[test]
+def test_join_groupby_aliased_left_side_field_emits_t0_alias(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (PriceCol = c.Price, BrandCol = d.Brand))
+        |> _group_by(_.PriceCol)
+        |> _select((P = _._0, N = _._1 |> count())))
+    t |> equal(sql,
+        "SELECT (\"t0\".\"Price\"), COUNT(*) FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY (\"t0\".\"Price\")",
+        "alias on the LEFT side (t0) resolves through the registry same as t1")
+}
+
+[test]
+def test_join_groupby_count_returns_correct_runtime_per_left_field(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                     $(c : Car, d : Dealer) => (PriceCol = c.Price, BrandCol = d.Brand))
+            |> _group_by(_.PriceCol)
+            |> _select((P = _._0, N = _._1 |> count())))
+        // 4 distinct prices: 100, 200, 150, 300 → 4 single-element groups.
+        t |> equal(length(groups), 4, "4 distinct prices, each unique → 4 groups of 1")
+        var total = 0
+        for (g in groups) {
+            total += g.N
+        }
+        t |> equal(total, 4, "sum of group counts = total cars")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Arm C — aggregate over join-projection alias.
+// `_._1 |> _select(_.<alias>) |> sum/min/max/average()` resolves the alias
+// through the join's snapshot registry; emit wraps the qualified column
+// (e.g. `SUM("t0"."Price")`) rather than the raw alias name.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_join_groupby_sum_alias_emits_qualified_column(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Brand)
+        |> _select((Brand = _._0, Total = _._1 |> _select(_.Price) |> sum())))
+    t |> equal(sql,
+        "SELECT (\"t1\".\"Brand\"), SUM(\"t0\".\"Price\") FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY (\"t1\".\"Brand\")",
+        "sum over join-projection alias `Price` emits SUM(\"t0\".\"Price\") with the qualified source column")
+}
+
+[test]
+def test_join_groupby_sum_alias_returns_per_group_totals(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                     $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+            |> _group_by(_.Brand)
+            |> _select((Brand = _._0, Total = _._1 |> _select(_.Price) |> sum())))
+        t |> equal(length(groups), 3, "3 distinct brands")
+        var totals <- {for (g in groups); g.Brand => g.Total}
+        // BMW (dealer 1) → cars Id 1,2 (Price 100+200) = 300
+        // Audi (dealer 2) → car Id 3 (Price 150) = 150
+        // Tesla (dealer 3) → car Id 4 (Price 300) = 300
+        t |> equal(totals["BMW"], 300, "BMW total = 100+200")
+        t |> equal(totals["Audi"], 150, "Audi total = 150")
+        t |> equal(totals["Tesla"], 300, "Tesla total = 300")
+    }
+}
+
+[test]
+def test_join_groupby_min_max_average_alias(t : T?) {
+    var _db = SqlRunner()
+    let sqlMin = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Brand)
+        |> _select((B = _._0, M = _._1 |> _select(_.Price) |> min())))
+    t |> equal(sqlMin,
+        "SELECT (\"t1\".\"Brand\"), MIN(\"t0\".\"Price\") FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY (\"t1\".\"Brand\")",
+        "min over alias emits MIN(qualified)")
+    let sqlMax = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Brand)
+        |> _select((B = _._0, M = _._1 |> _select(_.Price) |> max())))
+    t |> equal(sqlMax,
+        "SELECT (\"t1\".\"Brand\"), MAX(\"t0\".\"Price\") FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY (\"t1\".\"Brand\")",
+        "max over alias emits MAX(qualified)")
+    let sqlAvg = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Brand)
+        |> _select((B = _._0, A = _._1 |> _select(_.Price) |> average())))
+    t |> equal(sqlAvg,
+        "SELECT (\"t1\".\"Brand\"), AVG(\"t0\".\"Price\") FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY (\"t1\".\"Brand\")",
+        "average over alias emits AVG(qualified)")
+}
+
+[test]
+def test_join_groupby_multi_aggregate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let groups <- _sql(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                     $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+            |> _group_by(_.Brand)
+            |> _select((Brand = _._0,
+                        N = _._1 |> count(),
+                        Total = _._1 |> _select(_.Price) |> sum())))
+        t |> equal(length(groups), 3, "3 distinct brands")
+        var byBrand <- {for (g in groups); g.Brand => g}
+        t |> equal(byBrand["BMW"].N, 2, "BMW has 2 cars")
+        t |> equal(byBrand["BMW"].Total, 300, "BMW total = 300")
+        t |> equal(byBrand["Audi"].N, 1, "Audi has 1 car")
+        t |> equal(byBrand["Audi"].Total, 150, "Audi total = 150")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Transitive coverage — HAVING / ORDER BY / computed-key group keys all
+// flow through pred_to_sql's central alias hook. No additional Arm code,
+// just exercise the chains to confirm runtime correctness. The HAVING
+// emit-shape isn't asserted here because daslang's typer occasionally
+// pre-folds the predicate's aggregate-side before _sql sees it (when
+// adjacent tests in the same compilation unit instantiate matching
+// generic chains); the runtime path verifies the SQL actually
+// computed what it should.
+// ──────────────────────────────────────────────────────────────────────────
+
+[test]
+def test_join_groupby_having_count_filters_groups(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Fixture: BMW=2 cars, Audi=1, Tesla=1. HAVING COUNT(*) > 1 keeps BMW only.
+        let groups <- _sql(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                     $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+            |> _group_by(_.Brand)
+            |> _having(_._1 |> count() > 1)
+            |> _select((Brand = _._0, N = _._1 |> count())))
+        t |> equal(length(groups), 1, "HAVING COUNT(*) > 1 keeps 1 group")
+        t |> equal(groups[0].Brand, "BMW", "BMW survives (2 cars)")
+        t |> equal(groups[0].N, 2, "BMW count = 2")
+    }
+}
+
+// HAVING with alias-resolved aggregate (`_._1 |> _select(_.<alias>) |> sum() > N`) hits a
+// known typer-ordering quirk when other tests in the same compilation unit instantiate
+// the same `_._1 |> _select(_.X) |> sum()` chain in projection context first: the typer
+// pre-folds the predicate's aggregate side before `_sql` sees it, and the chain inside
+// `_sql(...)` (vs `_sql_text(...)`) fails to bind `_` for the runtime row builder. The
+// SQL emit is correct (verified standalone via _sql_text); skip the runtime+emit test
+// here and revisit in chunk N+3 once the typer side is investigated.
+
+[test]
+def test_join_order_by_alias_emits_qualified(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _order_by(_.Brand))
+    t |> equal(sql,
+        "SELECT \"t1\".\"Brand\", \"t0\".\"Price\" FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" ORDER BY \"t1\".\"Brand\" ASC",
+        "ORDER BY by join alias emits the qualified source column — collect_order_keys consults the projection registry post-join")
+}
+
+[test]
+def test_join_groupby_computed_key_buckets_emit_arithmetic(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _join(_db |> select_from(type<Dealer>),
+                 $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                 $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+        |> _group_by(_.Price / 100)
+        |> _select((Bucket = _._0, N = _._1 |> count())))
+    t |> equal(sql,
+        "SELECT ((\"t0\".\"Price\") / (100)), COUNT(*) FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"DealerId\" = \"t1\".\"Id\" GROUP BY ((\"t0\".\"Price\") / (100))",
+        "computed-expression group key over join alias resolves through pred_to_sql, emits arithmetic over qualified column")
+}
+
+[test]
+def test_join_groupby_computed_key_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Prices: 100, 200, 150, 300. Buckets (/100): 1, 2, 1, 3 → 3 unique buckets.
+        // Bucket 1: 2 cars (Price 100, 150). Bucket 2: 1 car (200). Bucket 3: 1 car (300).
+        let groups <- _sql(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c : Car, d : Dealer) => c.DealerId == d.Id,
+                     $(c : Car, d : Dealer) => (Brand = d.Brand, Price = c.Price))
+            |> _group_by(_.Price / 100)
+            |> _select((Bucket = _._0, N = _._1 |> count())))
+        t |> equal(length(groups), 3, "3 distinct price buckets")
+        var byBucket <- {for (g in groups); g.Bucket => g.N}
+        t |> equal(byBucket[1], 2, "bucket 1 (prices 100,150) → 2 cars")
+        t |> equal(byBucket[2], 1, "bucket 2 (price 200) → 1 car")
+        t |> equal(byBucket[3], 1, "bucket 3 (price 300) → 1 car")
+    }
+}

--- a/tutorials/sql/15-join.das
+++ b/tutorials/sql/15-join.das
@@ -109,5 +109,38 @@ def main {
                                        $(u : User, o : Order) => u.Id == o.UserId,
                                        $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total)))
         to_log(LOG_INFO, "SQL: {sql}")
+
+        // ── Joining + grouping ──────────────────────────────────────────
+        // `_group_by(_.<alias>)` after `_join` reads the projection alias
+        // through the join's `into` registry and emits the qualified source
+        // column in GROUP BY. Aggregates over alias names (`_._1 |> _select(_.X)
+        // |> sum()`) resolve the same way.
+        let per_user <- _sql(db |> select_from(type<User>)
+                               |> _join(db |> select_from(type<Order>),
+                                        $(u : User, o : Order) => u.Id == o.UserId,
+                                        $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total))
+                               |> _group_by(_.UserName)
+                               |> _select((Name = _._0,
+                                           N = _._1 |> count(),
+                                           Spend = _._1 |> _select(_.OrderTotal) |> sum())))
+        to_log(LOG_INFO, "per-user totals ({length(per_user)} users):")
+        for (g in per_user) {
+            to_log(LOG_INFO, "  {g.Name}: {g.N} orders totalling {g.Spend}")
+        }
+        // Expected:
+        //   Alice: 2 orders totalling 350
+        //   Bob:   1 orders totalling 50
+
+        // The emitted SQL — GROUP BY uses the qualified source column,
+        // SUM wraps it too.
+        let per_user_sql = _sql_text(db |> select_from(type<User>)
+                                       |> _join(db |> select_from(type<Order>),
+                                                $(u : User, o : Order) => u.Id == o.UserId,
+                                                $(u : User, o : Order) => (UserName = u.Name, OrderTotal = o.Total))
+                                       |> _group_by(_.UserName)
+                                       |> _select((Name = _._0,
+                                                   N = _._1 |> count(),
+                                                   Spend = _._1 |> _select(_.OrderTotal) |> sum())))
+        to_log(LOG_INFO, "SQL: {per_user_sql}")
     }
 }


### PR DESCRIPTION
## Summary

Closes the **`_group_by` after `_join`** gap from [`benchmarks/sql/sqlite_linq_gaps.md`](https://github.com/GaijinEntertainment/daScript/blob/master/benchmarks/sql/sqlite_linq_gaps.md), draining 2 SQL bench cells (`join_groupby_count`, `join_groupby_to_array`). One central change in `pred_to_sql` — consult a snapshot of the join's `into` projection registry when resolving `_.<alias>` post-join — transitively enables alias resolution everywhere `pred_to_sql` is called: `_group_by`, `_having`, `_order_by`, `try_translate_group_aggregate` (SUM/MIN/MAX/AVG), computed-expression group keys.

This is chunk N+2 of the sqlite_linq composition arc started in PR #2906 (chunk N — bare-aggregate foundation) and continued in PR #2909 (chunk N+1 — `_distinct_by` composition + `reverse()` + `_group_by |> first()`).

## Architecture

- **`SqlQuery.joinProjRecordNames` + parallel arrays** — snapshot of the join's `into` projection registry, captured at the end of `process_join_call`. Preserved across `analyze_grouped_projection`'s clear-and-repopulate of the live `projRecordNames`.
- **New helpers** `find_projection_alias(q, name)` (~10 LOC) + `render_projection_alias_sql(q, idx)` (~15 LOC) — resolve aliases to qualified SQL fragments. The latter handles both pre-rendered fragments (LEFT JOIN's `is_some` probe) and the common simple-field case.
- **`pred_to_sql`** consults the snapshot when `q.seenJoin && argName == "_"` — single hook flowing through every downstream site.
- **Bare-`_.Field` fast paths** in `push_group_key`, `collect_order_keys`, and `try_translate_group_aggregate` mirror the same lookup so they don't bypass `pred_to_sql`. Each emits a clear macro_error listing valid aliases when the name isn't found.
- v1 supports `t0` / `t1` aliases (2-source `_join` shape); others reject loudly.

## Surface this PR enables

```das
// Group key by join projection alias
_sql(db |> select_from(type<Car>)
        |> _join(db |> select_from(type<Dealer>),
                 $(c, d) => c.dealer_id == d.id,
                 $(c, d) => (Brand = d.brand, Price = c.price))
        |> _group_by(_.Brand)
        |> _select((Brand = _._0, N = _._1 |> count())))
// SELECT ("t1"."brand"), COUNT(*) FROM "Cars" AS "t0" INNER JOIN "Dealers" AS "t1"
//   ON "t0"."dealer_id" = "t1"."id" GROUP BY ("t1"."brand")

// Aggregate over alias
... |> _select((Brand = _._0,
                Total = _._1 |> _select(_.Price) |> sum()))
// ... SUM("t0"."price") ... GROUP BY ("t1"."brand")
```

Also transitively unlocked (no extra LOC): `_having` / `_order_by` / `_group_by(_.X op Y)` over join projection aliases.

## Test plan

- [x] `mcp__daslang__lint` clean on `sqlite_linq.das` + all touched `.das` files
- [x] 12 new tests in `tests/dasSQLITE/test_33_join_groupby.das` — Arm B (group-by + count), Arm C (sum/min/max/avg), HAVING + ORDER BY + computed-key transitive coverage
- [x] 3 new rejection probes — `failed_join_groupby_unknown_alias.das`, `failed_join_groupby_aggregate_unknown_alias.das`, `failed_join_order_by_unknown_alias.das`
- [x] All 94 existing `tests/dasSQLITE/` tests green (test_32_distinct + test_31_long_count_distinct_by_canary + test_38_join + test_39_left_join + everything else)
- [x] `tutorials/sql/15-join.das` extended with joining + grouping section; runs via `mcp__daslang__run_script`
- [x] `benchmarks/sql/results.md` refreshed with full INTERP+JIT rerun (72 benches × 2 modes); 2 m1 cells populated

## Known constraints / deferred

- **HAVING with alias-resolved aggregate in `_sql(...)` runtime form** has a typer-ordering quirk when compilation units contain multiple `_sql` calls referencing the same chain shape — the typer pre-folds the predicate's aggregate side and the row-binder in `_sql(...)` fails to bind `_`. The SQL emit itself is correct (verified standalone via `_sql_text`), so `_sql_text` shows the right SQL and runtime works in clean files. Investigating in chunk N+3. Test `test_33_join_groupby.das` carries a runtime smoke test using the simpler `_._1 |> count() > 1` HAVING shape; the alias-aggregate HAVING runtime is covered by `_sql_text` emit verification standalone.
- Nested / multi-way joins (`_join |> _join |> ...`) — `render_projection_alias_sql` rejects aliases beyond `t0`/`t1`. Future extension would generalize `source_rootType_for_alias` over an N-source join chain.

Full deferred list documented in `modules/dasSQLITE/API_REWORK.md` under "Shipped — chunk N+2 ... Deferred to chunk N+3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)