### PR TITLE
linq_fold: extend decs skip-into-tail to handle trailing `_select` (close 1 of 3 m4 holdouts)

### DIFF
--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,6 @@
 # Benchmarks — SQL / Array / Decs comparison
 
-Generated 2026-05-28 from PR `bbatkin/linq-fold-array-join-splice` (chunk N+3 — linq_fold array-side `_join` splice + cross-arm `_join |> _group_by` via new `ArrayJoin` SourceAdapter) + follow-up `bbatkin/linq-fold-join-emit-dedup` (refactor: shared standalone + adapter helpers). Closes the m3f-vs-m4 parity gap across the entire `join_*` family — all 5 cells m3f beats m4 in both INTERP and JIT:
+Generated 2026-05-28 from PRs `bbatkin/linq-fold-array-join-splice` (chunk N+3 — linq_fold array-side `_join` splice + cross-arm `_join |> _group_by` via new `ArrayJoin` SourceAdapter) + follow-up `bbatkin/linq-fold-join-emit-dedup` (refactor: shared standalone + adapter helpers) + follow-up `bbatkin/linq-fold-decs-reverse-take-select` (extend decs skip-into-tail to handle trailing `_select`). The first two close the m3f-vs-m4 parity gap across the entire `join_*` family — all 5 cells m3f beats m4 in both INTERP and JIT:
 
 | Cell | m3f INTERP before / after | m3f JIT before / after |
 |---|---:|---:|
@@ -85,7 +85,7 @@ before the timer resolution can measure them — they should be read as
 | `order_take_desc` | 36.3 | 15.9 | 19.8 | 1.25× |
 | `reverse_distinct_by` | 284.8 | 21.3 | — | — |
 | `reverse_take` | 0.1 | 0.0 | 10.0 | — |
-| `reverse_take_select` | 0.0 | 33.4 | 47.4 | 1.42× |
+| `reverse_take_select` | 0.0 | 33.4 | 9.2 | 0.28× |
 | `select_count` | 0.1 | 0.0 | 2.2 | — |
 | `select_where` | 190.8 | 10.9 | 19.1 | 1.75× |
 | `select_where_count` | 31.4 | 5.1 | 7.3 | 1.43× |
@@ -162,7 +162,7 @@ before the timer resolution can measure them — they should be read as
 | `order_take_desc` | 36.5 | 0.7 | 1.3 | 1.86× |
 | `reverse_distinct_by` | 289.8 | 2.6 | — | — |
 | `reverse_take` | 0.0 | 0.0 | 1.1 | — |
-| `reverse_take_select` | 0.0 | 8.1 | 9.9 | 1.22× |
+| `reverse_take_select` | 0.0 | 8.1 | 1.1 | 0.14× |
 | `select_count` | 0.1 | 0.0 | 0.0 | — |
 | `select_where` | 105.0 | 4.1 | 5.3 | 1.29× |
 | `select_where_count` | 31.3 | 0.4 | 0.6 | 1.50× |
@@ -254,6 +254,42 @@ and which gaps could land in a single PR — see
   splice — trailing `reverse()` on the zip array lane emits
   `_::reverse_inplace` after the zip lockstep buffer fill. By design,
   no follow-up.
+
+## Accepted architectural floors (m4 vs m3f)
+
+Three cells where m4 stays ≥1.5× m3f INTERP and the gap is structural,
+not a splice/emit oversight. Documented here so the close-out doesn't
+keep chasing them.
+
+- **`last_match` m4 +8.2 ns INTERP (m3f 5.7 → m4 13.9, 2.44×)** — m3f's
+  iterator `last()` walks an `array<T>` and rebinds a single `var last : TT -&`
+  reference on each match (O(1) per match, one final clone at return).
+  m4 walks `for_each_archetype` and emits a 6-column lockstep
+  `for (car_id, car_name, car_price, car_brand, car_year, car_dealer_id in
+  get_default_ro(arch, ...) × 6)` — every element pays for all six
+  `get_default_ro` advances regardless of match status, then on match
+  constructs a tuple and `:=` clone-assigns it (which deep-clones the
+  string field). The fetch-all-columns model is the cost of decs columnar
+  storage; reducing it would require redesigning the per-element walk to
+  fetch the predicate column first and defer the rest until match —
+  significant infrastructure change for an 8 ns cell.
+- **`select_where` m4 +8.2 ns INTERP (m3f 10.9 → m4 19.1, 1.75×)** — same
+  root cause as `last_match`: 6-column lockstep fetch per element plus
+  per-match `push_clone(tuple(...))` (string clone) into the output
+  buffer. The `to_array` shape can't avoid materializing each match, so
+  the per-match clone is structural; the per-element fetch cost is the
+  same decs columnar overhead.
+- **`order_distinct_take` m4 +78 ns INTERP, 35× JIT** — `unique_key`
+  string-interpolation path on non-workhorse `DecsBrand` keys (already
+  documented in "Notes on missing lanes" above — not closeable without
+  a struct-aware hashing scheme).
+
+`reverse_take_select` USED to be on this list (m4 was +14 ns INTERP at
+the catch-all path). It is NOT a floor — closed by extending the decs
+skip-into-tail fast path to handle a trailing `_select` (was previously
+gated to bail out when termsel was present, forcing fall-through to the
+expensive full-buffer-then-reverse-then-resize-then-project path that
+did N push_clones with string clones for N=100K to keep just K=10).
 
 ## How to re-run
 

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3165,9 +3165,9 @@ def private emit_reverse_backward_walk_dset_gate(var c : Captures; var ctx : Emi
     return emit_fold_array_lane(spec, ctx.src, at)
 }
 
-// Decs `reverse |> take(N) |> to_array` skip-into-tail: 2-pass walk (arch.size sum, then for_each_archetype_find with whole-arch-skip + partial-arch skip-counter + early-exit). Preserves PR #2834's 5.2× gain.
+// Decs `reverse |> take(N) [|> _select(F)] |> to_array` skip-into-tail: 2-pass walk (arch.size sum, then for_each_archetype_find with whole-arch-skip + partial-arch skip-counter + early-exit). Preserves PR #2834's 5.2× gain. When terminalSelectLam != null, projects the K reversed elements at the end (K push_clones of projection vs N push_clones of full tuple in the catch-all path).
 [macro_function]
-def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBridgeShape?; tupName : string; needIterWrap : bool; at : LineInfo) : Expression? {
+def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBridgeShape?; tupName : string; needIterWrap : bool; var terminalSelectLam : Expression?; at : LineInfo) : Expression? {
     let bufName = qn("buf", at)
     let takeNName = qn("take_n", at)
     let totalName = qn("decs_total", at)
@@ -3175,9 +3175,19 @@ def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge 
     let skipName = qn("decs_skip", at)
     let seenName = qn("decs_seen", at)
     let skipsLeftName = qn("decs_skips", at)
+    let projElemName = qn("decs_rts_e", at)
+    let projBufName = qn("decs_rts_buf", at)
     let archName = bridge.archName
     var bufElemType = strip_const_ref(clone_type(bridge.elementType))
     let tupBind = build_decs_tup_bind(bridge, tupName, at)
+    var projBody : Expression?
+    var projType : TypeDeclPtr
+    if (terminalSelectLam != null) {
+        projBody = peel_lambda_rename_var(terminalSelectLam, projElemName)
+        if (projBody == null || projBody._type == null) return null
+        projType = strip_const_ref(clone_type(projBody._type))
+        if (projType == null) return null
+    }
     var innerBody : Expression? = qmacro_block() {
         if ($i(skipsLeftName) > 0_l) {
             $i(skipsLeftName) --
@@ -3194,33 +3204,69 @@ def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge 
     var newForBody = new ExprBlock(at = at)
     newForBody.list |> push(innerBody)
     clonedFor.body = newForBody
-    var emission : Expression? = qmacro(invoke($() : array<$t(bufElemType)> {
-        var $i(totalName) = 0_l
-        for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
-            $i(totalName) += $i(archName).size
-        })
-        let $i(takeNName) = $e(takeExpr)
-        let $i(actualName) = ($i(takeNName) <= 0) ? 0_l : ((int64($i(takeNName)) < $i(totalName)) ? int64($i(takeNName)) : $i(totalName))
-        let $i(skipName) = $i(totalName) - $i(actualName)
-        var $i(bufName) : array<$t(bufElemType)>
-        if ($i(actualName) == 0_l) {
-            return <- $i(bufName)
-        }
-        $i(bufName) |> reserve(int($i(actualName)))
-        var $i(seenName) = 0_l
-        for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
-            if ($i(seenName) + $i(archName).size <= $i(skipName)) {
-                $i(seenName) += $i(archName).size
-                return false
+    var emission : Expression?
+    if (terminalSelectLam == null) {
+        emission = qmacro(invoke($() : array<$t(bufElemType)> {
+            var $i(totalName) = 0_l
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $i(totalName) += $i(archName).size
+            })
+            let $i(takeNName) = $e(takeExpr)
+            let $i(actualName) = ($i(takeNName) <= 0) ? 0_l : ((int64($i(takeNName)) < $i(totalName)) ? int64($i(takeNName)) : $i(totalName))
+            let $i(skipName) = $i(totalName) - $i(actualName)
+            var $i(bufName) : array<$t(bufElemType)>
+            if ($i(actualName) == 0_l) {
+                return <- $i(bufName)
             }
-            var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
-            $e(clonedForExpr)
-            $i(seenName) += $i(archName).size
-            return long_length($i(bufName)) >= $i(actualName)
-        })
-        _::reverse_inplace($i(bufName))
-        return <- $i(bufName)
-    }))
+            $i(bufName) |> reserve(int($i(actualName)))
+            var $i(seenName) = 0_l
+            for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+                if ($i(seenName) + $i(archName).size <= $i(skipName)) {
+                    $i(seenName) += $i(archName).size
+                    return false
+                }
+                var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
+                $e(clonedForExpr)
+                $i(seenName) += $i(archName).size
+                return long_length($i(bufName)) >= $i(actualName)
+            })
+            _::reverse_inplace($i(bufName))
+            return <- $i(bufName)
+        }))
+    } else {
+        emission = qmacro(invoke($() : array<$t(projType)> {
+            var $i(totalName) = 0_l
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $i(totalName) += $i(archName).size
+            })
+            let $i(takeNName) = $e(takeExpr)
+            let $i(actualName) = ($i(takeNName) <= 0) ? 0_l : ((int64($i(takeNName)) < $i(totalName)) ? int64($i(takeNName)) : $i(totalName))
+            let $i(skipName) = $i(totalName) - $i(actualName)
+            var $i(bufName) : array<$t(bufElemType)>
+            var $i(projBufName) : array<$t(projType)>
+            if ($i(actualName) == 0_l) {
+                return <- $i(projBufName)
+            }
+            $i(bufName) |> reserve(int($i(actualName)))
+            var $i(seenName) = 0_l
+            for_each_archetype_find($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) : bool {
+                if ($i(seenName) + $i(archName).size <= $i(skipName)) {
+                    $i(seenName) += $i(archName).size
+                    return false
+                }
+                var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
+                $e(clonedForExpr)
+                $i(seenName) += $i(archName).size
+                return long_length($i(bufName)) >= $i(actualName)
+            })
+            _::reverse_inplace($i(bufName))
+            $i(projBufName) |> reserve(length($i(bufName)))
+            for ($i(projElemName) in $i(bufName)) {
+                $i(projBufName) |> push_clone($e(projBody))
+            }
+            return <- $i(projBufName)
+        }))
+    }
     return finalize_decs_emission(emission, at, needIterWrap)
 }
 
@@ -3241,9 +3287,9 @@ def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at 
     if (c.single |> key_exists("termsel")) {
         terminalSelectLam_check = c.single["termsel"].arguments[1]
     }
-    // Decs skip-into-tail fast path for `reverse |> take(N) |> to_array` (no where/select/termsel) — preserves PR #2834's 5.2× perf gain; otherwise the unified path walks all entities then resizes.
-    if (ctx.src is Decs && (c.single |> key_exists("take")) && whereCond == null && projection == null && terminalSelectLam_check == null)
-        return emit_decs_reverse_skip_into_tail(c.single["take"].arguments[1], (ctx.src as Decs)._0, (ctx.src as Decs)._1, ctx.expr_is_iterator, at)
+    // Decs skip-into-tail fast path for `reverse |> take(N) [|> _select(F)] |> to_array` (no where, no pre-reverse select) — preserves PR #2834's 5.2× perf gain and extends to the trailing-select case so the catch-all (which walks ALL N entities, push_clones full tuples, reverses, resizes, then projects) is reserved for shapes that genuinely need it (pre-reverse where_/select).
+    if (ctx.src is Decs && (c.single |> key_exists("take")) && whereCond == null && projection == null)
+        return emit_decs_reverse_skip_into_tail(c.single["take"].arguments[1], (ctx.src as Decs)._0, (ctx.src as Decs)._1, ctx.expr_is_iterator, terminalSelectLam_check, at)
     var takeExpr : Expression?
     if (c.single |> key_exists("take")) {
         takeExpr = clone_expression(c.single["take"].arguments[1])

--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -3166,8 +3166,9 @@ def private emit_reverse_backward_walk_dset_gate(var c : Captures; var ctx : Emi
 }
 
 // Decs `reverse |> take(N) [|> _select(F)] |> to_array` skip-into-tail: 2-pass walk (arch.size sum, then for_each_archetype_find with whole-arch-skip + partial-arch skip-counter + early-exit). Preserves PR #2834's 5.2× gain. When terminalSelectLam != null, projects the K reversed elements at the end (K push_clones of projection vs N push_clones of full tuple in the catch-all path).
+// `terminalSelectElemType` must be the typer-resolved element type of the termsel call result (caller reads it from `c.single["termsel"]._type.firstType`) — peel_lambda_rename_var's invoke-fallback shape for non-peelable lambdas has a null `_type` at macro stage, so deriving projType from the peeled body would mis-classify those as untyped and bail. Caller is responsible for ensuring termselElemType is non-null before this fast-path is selected; otherwise the gate falls through to the catch-all which has its own termsel handling.
 [macro_function]
-def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBridgeShape?; tupName : string; needIterWrap : bool; var terminalSelectLam : Expression?; at : LineInfo) : Expression? {
+def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBridgeShape?; tupName : string; needIterWrap : bool; var terminalSelectLam : Expression?; terminalSelectElemType : TypeDeclPtr; at : LineInfo) : Expression? {
     let bufName = qn("buf", at)
     let takeNName = qn("take_n", at)
     let totalName = qn("decs_total", at)
@@ -3184,8 +3185,8 @@ def private emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge 
     var projType : TypeDeclPtr
     if (terminalSelectLam != null) {
         projBody = peel_lambda_rename_var(terminalSelectLam, projElemName)
-        if (projBody == null || projBody._type == null) return null
-        projType = strip_const_ref(clone_type(projBody._type))
+        if (projBody == null) return null
+        projType = strip_const_ref(clone_type(terminalSelectElemType))
         if (projType == null) return null
     }
     var innerBody : Expression? = qmacro_block() {
@@ -3284,12 +3285,20 @@ def private emit_reverse_buffer_inplace(var c : Captures; var ctx : EmitCtx; at 
         projection = peel_lambda_rename_var(c.single["preproj"].arguments[1], bindName)
     }
     var terminalSelectLam_check : Expression?
+    var terminalSelectElemType_check : TypeDeclPtr
+    var termsel_fast_path_ok = true
     if (c.single |> key_exists("termsel")) {
         terminalSelectLam_check = c.single["termsel"].arguments[1]
+        // Fast path needs termsel's typer-resolved element type (see helper docstring). If missing, fall through to the catch-all which has its own termsel handling.
+        if (terminalSelectLam_check == null || c.single["termsel"]._type == null || c.single["termsel"]._type.firstType == null) {
+            termsel_fast_path_ok = false
+        } else {
+            terminalSelectElemType_check = c.single["termsel"]._type.firstType
+        }
     }
-    // Decs skip-into-tail fast path for `reverse |> take(N) [|> _select(F)] |> to_array` (no where, no pre-reverse select) — preserves PR #2834's 5.2× perf gain and extends to the trailing-select case so the catch-all (which walks ALL N entities, push_clones full tuples, reverses, resizes, then projects) is reserved for shapes that genuinely need it (pre-reverse where_/select).
-    if (ctx.src is Decs && (c.single |> key_exists("take")) && whereCond == null && projection == null)
-        return emit_decs_reverse_skip_into_tail(c.single["take"].arguments[1], (ctx.src as Decs)._0, (ctx.src as Decs)._1, ctx.expr_is_iterator, terminalSelectLam_check, at)
+    // Decs skip-into-tail fast path for `reverse |> take(N) [|> _select(F)] |> to_array` (no where, no pre-reverse select) — preserves PR #2834's 5.2× perf gain and extends to the trailing-select case so the catch-all (which walks ALL N entities, push_clones full tuples, reverses, resizes, then projects) is reserved for shapes that genuinely need it (pre-reverse where_/select, or termsel without a resolved element type).
+    if (ctx.src is Decs && (c.single |> key_exists("take")) && whereCond == null && projection == null && termsel_fast_path_ok)
+        return emit_decs_reverse_skip_into_tail(c.single["take"].arguments[1], (ctx.src as Decs)._0, (ctx.src as Decs)._1, ctx.expr_is_iterator, terminalSelectLam_check, terminalSelectElemType_check, at)
     var takeExpr : Expression?
     if (c.single |> key_exists("take")) {
         takeExpr = clone_expression(c.single["take"].arguments[1])

--- a/tests/linq/test_linq_fold_terminal_select.das
+++ b/tests/linq/test_linq_fold_terminal_select.das
@@ -204,8 +204,42 @@ def test_reverse_take_select_decs(t : T?) {
             apply_decs_template(cmp, DecsSound(id = i + 1, x = float(i)))
         }
         unsafe {
+            // ids: [1,2,3,4]; reverse: [4,3,2,1]; take 2: [4,3]; select _.id: [4,3]
             let ids <- _fold(from_decs_template(type<DecsSound>).reverse().take(2)._select(_.id).to_array())
             tt |> equal(length(ids), 2)
+            tt |> equal(ids[0], 4)
+            tt |> equal(ids[1], 3)
+        }
+        restart()
+    }
+}
+
+[test]
+def test_reverse_take_select_decs_take_exceeds(t : T?) {
+    t |> run("plan_decs_reverse: reverse + take(N>total) + terminal _select clamps to total") @(tt : T?) {
+        restart()
+        create_entities(3) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+            apply_decs_template(cmp, DecsSound(id = i + 10, x = float(i)))
+        }
+        unsafe {
+            // ids: [10,11,12]; reverse: [12,11,10]; take 100 clamps to 3: [12,11,10]; select _.id
+            let ids <- _fold(from_decs_template(type<DecsSound>).reverse().take(100)._select(_.id).to_array())
+            tt |> equal(length(ids), 3)
+            tt |> equal(ids[0], 12)
+            tt |> equal(ids[1], 11)
+            tt |> equal(ids[2], 10)
+        }
+        restart()
+    }
+}
+
+[test]
+def test_reverse_take_select_decs_empty(t : T?) {
+    t |> run("plan_decs_reverse: reverse + take + terminal _select on empty source") @(tt : T?) {
+        restart()
+        unsafe {
+            let ids <- _fold(from_decs_template(type<DecsSound>).reverse().take(5)._select(_.id).to_array())
+            tt |> equal(length(ids), 0)
         }
         restart()
     }


### PR DESCRIPTION
## Summary

Close-out PR for the m4 "close enough" roadmap. After surveying the 3 remaining m4 INTERP outliers (`last_match` +8.2ns, `select_where` +8.2ns, `reverse_take_select` +14ns), one turned out to be a real splice gap that closes cleanly; the other two are architectural floors that are documented here.

## The fix

`reverse |> take(K) |> _select(F) |> to_array` on decs sources was hitting the catch-all `emit_reverse_buffer_inplace` path because the fast-path gate at [linq_fold.das:3245](daslib/linq_fold.das#L3245) required `termsel == null`. That path walks ALL N entities, push_clones full tuples (with string clones!) into an intermediate buffer, reverses in place, resizes to K, then projects K. For typical N=100K / K=10 that's 100K wasted push_clones to keep 10.

Extend `emit_decs_reverse_skip_into_tail` to optionally take a terminal `_select` lambda. When present, after the existing skip-collect-reverse walk (which fills `buf` with the K raw tuples in correct order), do a projection pass — peel the select lambda, declare `proj_buf : array<projType>`, push_clone each projection. Drop the `terminalSelectLam_check == null` clause from the gate so the fast path now fires for both `to_array` and trailing `_select` shapes.

## Bench

`reverse_take_select_m4` (n=100K, K=10):

| Lane | Before | After | Δ |
|---|---:|---:|---:|
| INTERP | 47.4 ns/op | **9.2 ns/op** | -38.2 ns (5.15×) |
| JIT | 9.9 ns/op | **1.1 ns/op** | -8.8 ns (9.0×) |

m4 now beats m3f by 3.7× INTERP and 7.6× JIT on this cell (m3f stays at 34.1 / 8.4).

## Symmetric m3f follow-up (not in this PR)

m3f's `plan_reverse R6` ([linq_fold.das:3329-3337](daslib/linq_fold.das#L3329-L3337)) also has a `no_terminator` gate that excludes termsel, so m3f still goes through the catch-all `emit_reverse_buffer_inplace` for `reverse.take.select.to_array`. Porting the same termsel extension to the array side would close it symmetrically — left for a follow-up.

## Accepted architectural floors (not closed by this PR)

Documented in the new "Accepted architectural floors" section of `results.md`:

- **`last_match` m4 +8.2 ns INTERP (2.44×)** — m3f's iterator `last()` walks `array<T>` and rebinds a single `var last : TT -&` reference per match (O(1) per match, one final clone at return). m4 walks `for_each_archetype` and emits a 6-column lockstep `for (car_id, car_name, car_price, car_brand, car_year, car_dealer_id in get_default_ro(arch, ...) × 6)` — every element pays for all 6 `get_default_ro` advances regardless of match status, then on match constructs a tuple and `:=` clone-assigns it (which deep-clones the string field). Reducing this requires redesigning the per-element walk to fetch the predicate column first and defer the rest until match — significant infrastructure change for an 8 ns cell.
- **`select_where` m4 +8.2 ns INTERP (1.75×)** — same 6-column fetch root cause plus per-match `push_clone(tuple(...))` (unavoidable since `to_array` needs to materialize each match).
- **`order_distinct_take` m4 +78 ns INTERP / 35× JIT** — `unique_key` string-interpolation path on non-workhorse `DecsBrand` keys (already documented).

## Test plan

3 new sub-tests in `tests/linq/test_linq_fold_terminal_select.das`:
- `test_reverse_take_select_decs` — extended to value-check (not just length) — `[1,2,3,4].reverse().take(2)._select(_.id)` → `[4, 3]`
- `test_reverse_take_select_decs_take_exceeds` — `take(100)` on a 3-entity source clamps to 3
- `test_reverse_take_select_decs_empty` — empty source returns empty result without panic

- [x] `mcp__daslang__format_file daslib/linq_fold.das` — clean
- [x] `mcp__daslang__lint daslib/linq_fold.das` — clean
- [x] Full `tests/linq/` sweep — no failures
- [x] INTERP+JIT bench × 3 iterations — m4 stable at 9.2/1.1
- [x] `results.md` refreshed (cell + Accepted floors section + attribution header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)