### PR TITLE
perf_lint: PERF014 also flags negated out-of-range char-class checks

### DIFF
--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -1259,9 +1259,12 @@ class PerfLintVisitor : AstVisitor {
                 }
             }
         }
-        // PERF014: closed-interval char-class range check
+        // PERF014: closed in-range (&&) and negated out-of-range (||) char-class checks
         if (expr.op == "&&") {
-            check_perf014_char_class(expr)
+            check_perf014_char_class(expr, false)
+        }
+        if (expr.op == "||") {
+            check_perf014_char_class(expr, true)
         }
         // PERF017: length(s) <op> 0 / 1 → empty(s) / !empty(s)
         if (expr.op == "==" || expr.op == "!=" || expr.op == "<" || expr.op == "<=" || expr.op == ">" || expr.op == ">=") {
@@ -1395,26 +1398,30 @@ class PerfLintVisitor : AstVisitor {
         perf_warning("PERF021: redundant per-branch {lname}(...) cast in ternary — hoist as {lname}(cond ? a : b)", expr.at)
     }
 
-    // --- PERF014: closed-interval char-class range checks ---
+    // --- PERF014: char-class range checks (closed in-range && / negated out-of-range ||) ---
 
-    def parse_range_leg(leg : Expression?; var v_out : Expression?&; var bound_out : int&; var is_hi_out : bool&) : bool {
-        //! Parse `var <op> const` or `const <op> var` where op is `<=` or `>=`.
-        //! Returns true and fills outputs with: the variable expression,
-        //! the int bound, and whether this leg expresses an upper bound on var.
+    def parse_range_leg(leg : Expression?; upper_op, lower_op : string; var v_out : Expression?&; var bound_out : int&; var is_hi_out : bool&) : bool {
+        //! Parse `var <op> const` or `const <op> var` where op is `upper_op` or
+        //! `lower_op`. Returns true and fills outputs with: the variable
+        //! expression, the int bound, and whether this leg expresses the upper
+        //! bound of the range on var. `upper_op` is the var-on-left operator that
+        //! marks the upper-bound leg ("<=" closed-in-range, ">" open-out-of-range);
+        //! `lower_op` the lower-bound one (">=" / "<"). Yoda (const-on-left) forms
+        //! flip, so the const-on-left arm tests against `lower_op`.
         if (leg == null || !(leg is ExprOp2)) return false
         var op2 = leg as ExprOp2
         let opname = string(op2.op)
-        if (opname != "<=" && opname != ">=") return false
+        if (opname != upper_op && opname != lower_op) return false
         if (op2.right is ExprConstInt && op2.left != null) {
             v_out = op2.left
             bound_out = (op2.right as ExprConstInt).value
-            is_hi_out = opname == "<="
+            is_hi_out = opname == upper_op
             return true
         }
         if (op2.left is ExprConstInt && op2.right != null) {
             v_out = op2.right
             bound_out = (op2.left as ExprConstInt).value
-            is_hi_out = opname == ">="
+            is_hi_out = opname == lower_op
             return true
         }
         return false
@@ -1428,7 +1435,12 @@ class PerfLintVisitor : AstVisitor {
                 || (lo == 65 && hi == 90))     // 'A'..'Z' — is_alpha (upper half)
     }
 
-    def check_perf014_char_class(expr : ExprOp2?) : void {
+    def check_perf014_char_class(expr : ExprOp2?; negated : bool) : void {
+        //! `negated == false`: closed in-range `c >= lo && c <= hi` → is_*(c).
+        //! `negated == true`:  open  out-of-range `c < lo || c > hi` → !is_*(c)
+        //! (the De Morgan complement, written with strict `<`/`>`).
+        let upper_op = negated ? ">"  : "<="
+        let lower_op = negated ? "<"  : ">="
         var va : Expression? = null
         var vb : Expression? = null
         var bound_a = 0
@@ -1437,8 +1449,8 @@ class PerfLintVisitor : AstVisitor {
         var hi_b = false
         // Both legs must parse, constrain the SAME expression, and split into
         // one upper / one lower bound.
-        if (!parse_range_leg(expr.left, va, bound_a, hi_a)
-            || !parse_range_leg(expr.right, vb, bound_b, hi_b)
+        if (!parse_range_leg(expr.left, upper_op, lower_op, va, bound_a, hi_a)
+            || !parse_range_leg(expr.right, upper_op, lower_op, vb, bound_b, hi_b)
             || !expr_equal_struct(va, vb)
             || hi_a == hi_b) return
         let lo = hi_a ? bound_b : bound_a
@@ -1448,12 +1460,13 @@ class PerfLintVisitor : AstVisitor {
         // BOTH cases, so for a single-case range ('a'..'z' or 'A'..'Z') it's a
         // broader replacement, not an exact one — call that out so the user
         // doesn't replace lower-only with a both-cases check.
+        let neg = negated ? "!" : ""
         if (lo == 48 && hi == 57) {
-            perf_warning("PERF014: char-class range check '0'..'9' — use 'is_number(c)' from strings module", expr.at)
+            perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} '0'..'9' — use '{neg}is_number(c)' from strings module", expr.at)
         } else {
             // 'a'..'z' or 'A'..'Z'
             let case_kind = (lo == 97) ? "lowercase" : "uppercase"
-            perf_warning("PERF014: char-class range check ({case_kind} only) — consider 'is_alpha(c)' from strings module (note: is_alpha matches both cases, broader than this range)", expr.at)
+            perf_warning("PERF014: char-class range check ({case_kind} only{negated ? ", negated" : ""}) — consider '{neg}is_alpha(c)' from strings module (note: is_alpha matches both cases, broader than this range)", expr.at)
         }
     }
 

--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -1259,12 +1259,16 @@ class PerfLintVisitor : AstVisitor {
                 }
             }
         }
-        // PERF014: closed in-range (&&) and negated out-of-range (||) char-class checks
+        // PERF014: exact char-class checks. Digit range is a single bounded range
+        // (closed joins with &&, negated complement with ||). Alpha is the both-case
+        // compound (closed = || of two ranges, negated = && of two complements).
         if (expr.op == "&&") {
-            check_perf014_char_class(expr, false)
+            check_perf014_digit(expr, false)
+            check_perf014_alpha(expr, true)
         }
         if (expr.op == "||") {
-            check_perf014_char_class(expr, true)
+            check_perf014_digit(expr, true)
+            check_perf014_alpha(expr, false)
         }
         // PERF017: length(s) <op> 0 / 1 → empty(s) / !empty(s)
         if (expr.op == "==" || expr.op == "!=" || expr.op == "<" || expr.op == "<=" || expr.op == ">" || expr.op == ">=") {
@@ -1398,7 +1402,7 @@ class PerfLintVisitor : AstVisitor {
         perf_warning("PERF021: redundant per-branch {lname}(...) cast in ternary — hoist as {lname}(cond ? a : b)", expr.at)
     }
 
-    // --- PERF014: char-class range checks (closed in-range && / negated out-of-range ||) ---
+    // --- PERF014: exact char-class checks — is_number (digit range) / is_alpha (both-case compound) ---
 
     def parse_range_leg(leg : Expression?; upper_op, lower_op : string; var v_out : Expression?&; var bound_out : int&; var is_hi_out : bool&) : bool {
         //! Parse `var <op> const` or `const <op> var` where op is `upper_op` or
@@ -1427,47 +1431,70 @@ class PerfLintVisitor : AstVisitor {
         return false
     }
 
-    def is_known_char_class_range(lo : int; hi : int) : bool {
-        //! Three closed ranges hint at the strings is_*() helpers.
-        //! Hex extras ('a'..'f', 'A'..'F') are excluded — is_hex is broader.
-        return ((lo == 48 && hi == 57)         // '0'..'9' — is_number
-                || (lo == 97 && hi == 122)     // 'a'..'z' — is_alpha (lower half)
-                || (lo == 65 && hi == 90))     // 'A'..'Z' — is_alpha (upper half)
-    }
-
-    def check_perf014_char_class(expr : ExprOp2?; negated : bool) : void {
-        //! `negated == false`: closed in-range `c >= lo && c <= hi` → is_*(c).
-        //! `negated == true`:  open  out-of-range `c < lo || c > hi` → !is_*(c)
-        //! (the De Morgan complement, written with strict `<`/`>`).
-        let upper_op = negated ? ">"  : "<="
-        let lower_op = negated ? "<"  : ">="
+    def parse_bounded_range(expr : ExprOp2?; negated : bool; var v_out : Expression?&; var lo_out : int&; var hi_out : int&) : bool {
+        //! Parse a single bounded range on one variable from a two-leg ExprOp2.
+        //! Closed (`negated == false`): `c >= lo && c <= hi` (join `&&`, legs <=/>=).
+        //! Open   (`negated == true`):  `c < lo || c > hi`   (join `||`, legs </>).
+        //! Both legs must constrain the SAME (pure) expression — one upper, one
+        //! lower bound. Fills v_out / lo_out / hi_out; returns true on clean parse.
+        if (expr == null || expr.op != (negated ? "||" : "&&")) return false
+        let upper_op = negated ? ">" : "<="
+        let lower_op = negated ? "<" : ">="
         var va : Expression? = null
         var vb : Expression? = null
         var bound_a = 0
         var bound_b = 0
         var hi_a = false
         var hi_b = false
-        // Both legs must parse, constrain the SAME expression, and split into
-        // one upper / one lower bound.
         if (!parse_range_leg(expr.left, upper_op, lower_op, va, bound_a, hi_a)
             || !parse_range_leg(expr.right, upper_op, lower_op, vb, bound_b, hi_b)
             || !expr_equal_struct(va, vb)
-            || hi_a == hi_b) return
+            || hi_a == hi_b) return false
         let lo = hi_a ? bound_b : bound_a
         let hi = hi_a ? bound_a : bound_b
-        if (lo >= hi || !is_known_char_class_range(lo, hi)) return
-        // Pick the helper that matches the detected range. Note: is_alpha covers
-        // BOTH cases, so for a single-case range ('a'..'z' or 'A'..'Z') it's a
-        // broader replacement, not an exact one — call that out so the user
-        // doesn't replace lower-only with a both-cases check.
+        if (lo >= hi) return false
+        v_out = va
+        lo_out = lo
+        hi_out = hi
+        return true
+    }
+
+    def check_perf014_digit(expr : ExprOp2?; negated : bool) : void {
+        //! Exact: `c >= '0' && c <= '9'` → is_number(c); the negated De Morgan
+        //! complement `c < '0' || c > '9'` → !is_number(c).
+        var v : Expression? = null
+        var lo = 0
+        var hi = 0
+        if (!parse_bounded_range(expr, negated, v, lo, hi) || lo != 48 || hi != 57) return
         let neg = negated ? "!" : ""
-        if (lo == 48 && hi == 57) {
-            perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} '0'..'9' — use '{neg}is_number(c)' from strings module", expr.at)
-        } else {
-            // 'a'..'z' or 'A'..'Z'
-            let case_kind = (lo == 97) ? "lowercase" : "uppercase"
-            perf_warning("PERF014: char-class range check ({case_kind} only{negated ? ", negated" : ""}) — consider '{neg}is_alpha(c)' from strings module (note: is_alpha matches both cases, broader than this range)", expr.at)
-        }
+        perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} '0'..'9' — use '{neg}is_number(c)' from strings module", expr.at)
+    }
+
+    def check_perf014_alpha(expr : ExprOp2?; negated : bool) : void {
+        //! Exact: `('a'..'z') || ('A'..'Z')` → is_alpha(c). Its De Morgan negation
+        //! `(c < 'a' || c > 'z') && (c < 'A' || c > 'Z')` → !is_alpha(c). is_alpha
+        //! is DEFINED as exactly this both-case union, so a single-case range is
+        //! intentionally NOT flagged (no equivalent helper). The top-level join is
+        //! `||` for the closed form / `&&` for the negated form; each child is a
+        //! bounded range of the matching polarity.
+        if (expr == null || expr.op != (negated ? "&&" : "||")
+            || expr.left == null || expr.right == null
+            || !(expr.left is ExprOp2) || !(expr.right is ExprOp2)) return
+        var vL : Expression? = null
+        var vR : Expression? = null
+        var loL = 0
+        var hiL = 0
+        var loR = 0
+        var hiR = 0
+        if (!parse_bounded_range(expr.left as ExprOp2, negated, vL, loL, hiL)
+            || !parse_bounded_range(expr.right as ExprOp2, negated, vR, loR, hiR)
+            || !expr_equal_struct(vL, vR)) return
+        // One half must be 'a'..'z' (97..122), the other 'A'..'Z' (65..90).
+        let lowerUpper = loL == 97 && hiL == 122 && loR == 65 && hiR == 90
+        let upperLower = loL == 65 && hiL == 90 && loR == 97 && hiR == 122
+        if (!lowerUpper && !upperLower) return
+        let neg = negated ? "!" : ""
+        perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} 'a'..'z' + 'A'..'Z' — use '{neg}is_alpha(c)' from strings module", expr.at)
     }
 
     // --- PERF017: length(collection) <op> 0/1 → empty / !empty ---

--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -1467,7 +1467,7 @@ class PerfLintVisitor : AstVisitor {
         var hi = 0
         if (!parse_bounded_range(expr, negated, v, lo, hi) || lo != 48 || hi != 57) return
         let neg = negated ? "!" : ""
-        perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} '0'..'9' — use '{neg}is_number(c)' from strings module", expr.at)
+        perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} '0'..'9' — use '{neg}is_number({describe(v)})' from strings module", expr.at)
     }
 
     def check_perf014_alpha(expr : ExprOp2?; negated : bool) : void {
@@ -1494,7 +1494,7 @@ class PerfLintVisitor : AstVisitor {
         let upperLower = loL == 65 && hiL == 90 && loR == 97 && hiR == 122
         if (!lowerUpper && !upperLower) return
         let neg = negated ? "!" : ""
-        perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} 'a'..'z' + 'A'..'Z' — use '{neg}is_alpha(c)' from strings module", expr.at)
+        perf_warning("PERF014: char-class range check{negated ? " (negated)" : ""} 'a'..'z' + 'A'..'Z' — use '{neg}is_alpha({describe(vL)})' from strings module", expr.at)
     }
 
     // --- PERF017: length(collection) <op> 0/1 → empty / !empty ---

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -665,9 +665,9 @@ locale/codepoint behaviour. Only ranges that are **exactly** equivalent
 to a helper are flagged, so the suggested rewrite never changes
 behaviour:
 
-* ``c >= '0' && c <= '9'`` ⟺ ``is_number(c)``
-* ``(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')`` ⟺ ``is_alpha(c)``
-  (``is_alpha`` is *defined* as exactly this both-case union)
+* ``c >= '0' && c <= '9'`` is exactly ``is_number(c)``
+* ``(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')`` is exactly
+  ``is_alpha(c)`` (``is_alpha`` is *defined* as this both-case union)
 
 Both the closed forms above and their De Morgan negations (out-of-range
 forms, suggesting ``!is_number`` / ``!is_alpha``) are flagged.

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -659,33 +659,39 @@ skipped. ``+= -1`` is also flagged (same effect as ``-= 1``).
 PERF014 — char-class range check
 ================================
 
-Hand-rolled ranges like ``c >= 'a' && c <= 'z'`` reimplement
-``strings::is_alpha``/``is_alnum``/``is_number``/``is_white_space``/etc.
-The helper functions read clearer and centralise locale/codepoint
-behaviour. Both the closed in-range form (``&&``) and its negated
-out-of-range complement (``||`` with strict ``<``/``>``) are flagged.
-Only three ranges are recognised:
+Hand-rolled char ranges reimplement ``strings::is_number`` /
+``strings::is_alpha``. The helpers read clearer and centralise
+locale/codepoint behaviour. Only ranges that are **exactly** equivalent
+to a helper are flagged, so the suggested rewrite never changes
+behaviour:
 
-* ``'0'..'9'`` (48..57) — ``is_number``
-* ``'a'..'z'`` (97..122) — ``is_alpha`` lower half
-* ``'A'..'Z'`` (65..90) — ``is_alpha`` upper half
+* ``c >= '0' && c <= '9'`` ⟺ ``is_number(c)``
+* ``(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')`` ⟺ ``is_alpha(c)``
+  (``is_alpha`` is *defined* as exactly this both-case union)
 
-The hex extras ``'a'..'f'`` / ``'A'..'F'`` are deliberately **not**
-flagged — ``is_hex`` is broader. An ``&&`` of strict inequalities
-(``c > '0' && c < '9'``) is an open *intersection* with different
-endpoints, so it is skipped — distinct from the ``||`` strict-inequality
-*complement* (``c < '0' || c > '9'``) which is flagged.
+Both the closed forms above and their De Morgan negations (out-of-range
+forms, suggesting ``!is_number`` / ``!is_alpha``) are flagged.
+
+Deliberately **not** flagged:
+
+* A **single-case** range (``c >= 'a' && c <= 'z'`` on its own) — there is
+  no ``is_lower`` / ``is_upper`` helper, so no exact rewrite exists.
+* Hex extras (``'a'..'f'`` / ``'A'..'F'``) — ``is_hex`` is broader.
+* An ``&&`` of strict inequalities (``c > '0' && c < '9'``) — an open
+  *intersection* with different endpoints, distinct from the ``||``
+  strict-inequality *complement* (``c < '0' || c > '9'``) which is flagged.
 
 .. code-block:: das
 
     // Bad
-    if (c >= 'a' && c <= 'z') { ... }           // PERF014
-    if (c >= 48  && c <= 57)  { ... }           // PERF014 (raw int form)
-    if (c < '0' || c > '9')   { ... }           // PERF014 (negated / out-of-range)
+    if (c >= '0' && c <= '9') { ... }                          // PERF014 (→ is_number)
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) { }  // PERF014 (→ is_alpha)
+    if (c < '0' || c > '9')   { ... }                          // PERF014 (negated → !is_number)
 
     // Good
-    if (is_alpha(c))  { ... }
     if (is_number(c)) { ... }
+    if (is_alpha(c))  { ... }
+    if (c >= 'a' && c <= 'z') { ... }           // single case — no exact helper, not flagged
     if (!is_number(c)) { ... }                  // negated form
 
 PERF015 — ternary min / max

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -656,31 +656,37 @@ skipped. ``+= -1`` is also flagged (same effect as ``-= 1``).
     a ++
     a --
 
-PERF014 — closed-interval char-class range check
-==================================================
+PERF014 — char-class range check
+================================
 
 Hand-rolled ranges like ``c >= 'a' && c <= 'z'`` reimplement
 ``strings::is_alpha``/``is_alnum``/``is_number``/``is_white_space``/etc.
 The helper functions read clearer and centralise locale/codepoint
-behaviour. Only three closed ranges are flagged:
+behaviour. Both the closed in-range form (``&&``) and its negated
+out-of-range complement (``||`` with strict ``<``/``>``) are flagged.
+Only three ranges are recognised:
 
 * ``'0'..'9'`` (48..57) — ``is_number``
 * ``'a'..'z'`` (97..122) — ``is_alpha`` lower half
 * ``'A'..'Z'`` (65..90) — ``is_alpha`` upper half
 
 The hex extras ``'a'..'f'`` / ``'A'..'F'`` are deliberately **not**
-flagged — ``is_hex`` is broader. Open intervals (``c > '0' && c < '9'``)
-have different endpoints, so they are also skipped.
+flagged — ``is_hex`` is broader. An ``&&`` of strict inequalities
+(``c > '0' && c < '9'``) is an open *intersection* with different
+endpoints, so it is skipped — distinct from the ``||`` strict-inequality
+*complement* (``c < '0' || c > '9'``) which is flagged.
 
 .. code-block:: das
 
     // Bad
     if (c >= 'a' && c <= 'z') { ... }           // PERF014
     if (c >= 48  && c <= 57)  { ... }           // PERF014 (raw int form)
+    if (c < '0' || c > '9')   { ... }           // PERF014 (negated / out-of-range)
 
     // Good
     if (is_alpha(c))  { ... }
     if (is_number(c)) { ... }
+    if (!is_number(c)) { ... }                  // negated form
 
 PERF015 — ternary min / max
 ============================

--- a/skills/perf_lint.md
+++ b/skills/perf_lint.md
@@ -119,7 +119,7 @@ After compilation, `Expression._type` is resolved. Check `expr._type.baseType ==
 | PERF011 | `get_ptr(x).field` | Low | unnecessary; smart_ptr auto-dereferences for field access |
 | PERF012 | `find(string(das_string), ...)` | Medium | unnecessary allocation; use `peek(das_string)` instead |
 | PERF013 | `a += 1` / `a -= 1` (six numeric scalars) | Low | use postfix `a++` / `a--` (single SimNode, idiomatic) |
-| PERF014 | char-class range (`'0'..'9'` / `'a'..'z'` / `'A'..'Z'`) — closed in-range (`c >= lo && c <= hi`) **and** negated out-of-range (`c < lo \|\| c > hi`, strict `<`/`>`) | Info | use `strings::is_number` / `is_alpha` (negated form suggests `!is_number` / `!is_alpha`) |
+| PERF014 | **exact** char-class ranges only: digit `c >= '0' && c <= '9'` → `is_number`; both-case compound `(c >= 'a' && c <= 'z') \|\| (c >= 'A' && c <= 'Z')` → `is_alpha` (is_alpha is *defined* as this union). Plus De Morgan negations (out-of-range forms → `!is_number` / `!is_alpha`). Single-case ranges (`'a'..'z'` alone) NOT flagged — no `is_lower`/`is_upper` helper exists, so no exact rewrite. Hex (`'a'..'f'`) and `&&`-strict intersection (`c > '0' && c < '9'`) also skipped | Info | `strings::is_number` / `is_alpha` |
 | PERF015 | ternary min/max (`a < b ? a : b`) | Low | use `math::min(a, b)` / `max(a, b)` |
 | PERF016 | ternary abs (`x < 0 ? -x : x`) | Low | use `math::abs(x)` (negabs `x < 0 ? x : -x` not flagged) |
 | PERF017 | `length(x) == 0` / `> 0` / `>= 1` etc. | Medium | use `empty(x)` / `!empty(x)`; avoids strlen on strings |

--- a/skills/perf_lint.md
+++ b/skills/perf_lint.md
@@ -119,7 +119,7 @@ After compilation, `Expression._type` is resolved. Check `expr._type.baseType ==
 | PERF011 | `get_ptr(x).field` | Low | unnecessary; smart_ptr auto-dereferences for field access |
 | PERF012 | `find(string(das_string), ...)` | Medium | unnecessary allocation; use `peek(das_string)` instead |
 | PERF013 | `a += 1` / `a -= 1` (six numeric scalars) | Low | use postfix `a++` / `a--` (single SimNode, idiomatic) |
-| PERF014 | closed-interval char-class range (`'0'..'9'` / `'a'..'z'` / `'A'..'Z'`) | Info | use `strings::is_alpha` / `is_alnum` / `is_number` |
+| PERF014 | char-class range (`'0'..'9'` / `'a'..'z'` / `'A'..'Z'`) — closed in-range (`c >= lo && c <= hi`) **and** negated out-of-range (`c < lo \|\| c > hi`, strict `<`/`>`) | Info | use `strings::is_number` / `is_alpha` (negated form suggests `!is_number` / `!is_alpha`) |
 | PERF015 | ternary min/max (`a < b ? a : b`) | Low | use `math::min(a, b)` / `max(a, b)` |
 | PERF016 | ternary abs (`x < 0 ? -x : x`) | Low | use `math::abs(x)` (negabs `x < 0 ? x : -x` not flagged) |
 | PERF017 | `length(x) == 0` / `> 0` / `>= 1` etc. | Medium | use `empty(x)` / `!empty(x)`; avoids strlen on strings |

--- a/utils/lint/main.das
+++ b/utils/lint/main.das
@@ -160,7 +160,7 @@ def is_valid_rule_code(code : string) : bool {
     var all_digits = true
     peek_data(digits) $(d) {
         for (c in d) {
-            if (int(c) < '0' || int(c) > '9') {
+            if (!is_number(int(c))) {
                 all_digits = false
             }
         }

--- a/utils/lint/tests/perf014_char_class_range.das
+++ b/utils/lint/tests/perf014_char_class_range.das
@@ -10,15 +10,17 @@ options gen2
 // Bad pattern:
 //   if (c >= 'a' && c <= 'z') { ... }
 //   if (c >= 48  && c <= 57)  { ... }       // '0'..'9' as raw int
+//   if (c < '0' || c > '9')   { ... }       // negated / out-of-range form
 //
 // Good pattern:
 //   if (is_alpha(c))   { ... }              // covers a-z, A-Z (and your locale)
 //   if (is_number(c))  { ... }
+//   if (!is_number(c)) { ... }              // negated form
 //
 // Hex extras ('a'..'f' / 'A'..'F') deliberately do NOT trigger — is_hex is
 // broader and would change behavior for the digit half.
 
-expect 31208:5
+expect 31208:9
 
 require daslib/perf_lint
 require strings
@@ -45,6 +47,25 @@ def bad_yoda_form(c : int) : bool {
     return 'a' <= c && c <= 'z'                // PERF014 (mixed const-on-left)
 }
 
+// Negated (out-of-range) form: c < lo || c > hi is the De Morgan complement
+// of the closed in-range check, so it maps to the negated helper.
+
+def bad_neg_digits(c : int) : bool {
+    return c < '0' || c > '9'                  // PERF014 (negated → !is_number)
+}
+
+def bad_neg_lower_alpha(c : int) : bool {
+    return c < 'a' || c > 'z'                  // PERF014 (negated → !is_alpha lower)
+}
+
+def bad_neg_yoda(c : int) : bool {
+    return '0' > c || '9' < c                  // PERF014 (negated, const-on-left)
+}
+
+def bad_neg_cast(c : uint8) : bool {
+    return int(c) < '0' || int(c) > '9'        // PERF014 (negated, with int() cast)
+}
+
 // --- Good patterns (no warnings) ---
 
 def good_is_alpha(c : int) : bool {
@@ -60,7 +81,15 @@ def good_hex_upper(c : int) : bool {
 }
 
 def good_open_range(c : int) : bool {
-    return c > '0' && c < '9'                  // open interval — NOT flagged
+    return c > '0' && c < '9'                  // open interval (&&-intersection) — NOT flagged
+}
+
+def good_neg_always_true(c : int) : bool {
+    return c < '9' || c > '0'                  // degenerate always-true (lo>=hi) — NOT flagged
+}
+
+def good_neg_hex(c : int) : bool {
+    return c < 'a' || c > 'f'                  // hex complement — NOT flagged (is_hex broader)
 }
 
 def good_partial_range(c : int) : bool {
@@ -83,4 +112,8 @@ def impure_helper(c : int) : int {
 
 def good_impure_call(c : int) : bool {
     return impure_helper(c) >= 'a' && impure_helper(c) <= 'z'   // NOT flagged (impure)
+}
+
+def good_neg_impure(c : int) : bool {
+    return impure_helper(c) < 'a' || impure_helper(c) > 'z'     // NOT flagged (impure, negated)
 }

--- a/utils/lint/tests/perf014_char_class_range.das
+++ b/utils/lint/tests/perf014_char_class_range.das
@@ -25,7 +25,7 @@ options gen2
 // is_upper helper, so no exact rewrite exists. Hex extras ('a'..'f') are not
 // flagged either (is_hex is broader).
 
-expect 31208:8
+expect 31208:9
 
 require daslib/perf_lint
 require strings
@@ -66,6 +66,11 @@ def bad_alpha_compound(c : int) : bool {
 
 def bad_neg_alpha_compound(c : int) : bool {
     return (c < 'a' || c > 'z') && (c < 'A' || c > 'Z')       // PERF014 (negated → !is_alpha)
+}
+
+def bad_alpha_compound_cast(c : uint8) : bool {
+    // non-trivial checked expression — suggestion must name int(c), not c
+    return (int(c) >= 'a' && int(c) <= 'z') || (int(c) >= 'A' && int(c) <= 'Z')   // PERF014 (→ is_alpha(int(c)))
 }
 
 // --- Good patterns (no warnings) ---

--- a/utils/lint/tests/perf014_char_class_range.das
+++ b/utils/lint/tests/perf014_char_class_range.das
@@ -1,79 +1,99 @@
 options gen2
-// PERF014: closed-interval char-class range checks
+// PERF014: exact char-class range checks
 //
 // Problem:
-//   Hand-written ranges like `c >= 'a' && c <= 'z'` reimplement the strings
-//   module's is_alpha/is_alnum/is_number/is_white_space/etc. helpers. Using
-//   the helper makes intent obvious and lets future codepoint widening
-//   propagate automatically.
+//   Hand-written ranges reimplement the strings module's is_number / is_alpha
+//   helpers. Only patterns that are EXACTLY equivalent to a helper are flagged,
+//   so the suggested rewrite never changes behavior.
+//
+// Exact equivalences (is_alpha is DEFINED as the both-case union):
+//   is_number(c)  <=>  c >= '0' && c <= '9'
+//   is_alpha(c)   <=>  (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+// plus their De Morgan negations (out-of-range forms).
 //
 // Bad pattern:
-//   if (c >= 'a' && c <= 'z') { ... }
-//   if (c >= 48  && c <= 57)  { ... }       // '0'..'9' as raw int
-//   if (c < '0' || c > '9')   { ... }       // negated / out-of-range form
+//   if (c >= '0' && c <= '9') { ... }                         // → is_number
+//   if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {}  // → is_alpha
+//   if (c < '0' || c > '9') { ... }                           // → !is_number
 //
 // Good pattern:
-//   if (is_alpha(c))   { ... }              // covers a-z, A-Z (and your locale)
 //   if (is_number(c))  { ... }
-//   if (!is_number(c)) { ... }              // negated form
+//   if (is_alpha(c))   { ... }
+//   if (!is_number(c)) { ... }
 //
-// Hex extras ('a'..'f' / 'A'..'F') deliberately do NOT trigger — is_hex is
-// broader and would change behavior for the digit half.
+// A SINGLE case range ('a'..'z' alone) is NOT flagged — there is no is_lower /
+// is_upper helper, so no exact rewrite exists. Hex extras ('a'..'f') are not
+// flagged either (is_hex is broader).
 
-expect 31208:9
+expect 31208:8
 
 require daslib/perf_lint
 require strings
 
 // --- Bad patterns (PERF014) ---
 
-def bad_lower_alpha(c : int) : bool {
-    return c >= 'a' && c <= 'z'                // PERF014
-}
-
-def bad_upper_alpha(c : int) : bool {
-    return c >= 'A' && c <= 'Z'                // PERF014
-}
+// Digit range — single bounded range, exact match to is_number.
 
 def bad_digits_char(c : int) : bool {
-    return c >= '0' && c <= '9'                // PERF014
+    return c >= '0' && c <= '9'                // PERF014 (→ is_number)
 }
 
 def bad_digits_int(c : int) : bool {
     return c >= 48 && c <= 57                  // PERF014 (raw int form)
 }
 
-def bad_yoda_form(c : int) : bool {
-    return 'a' <= c && c <= 'z'                // PERF014 (mixed const-on-left)
+def bad_digits_yoda(c : int) : bool {
+    return '0' <= c && c <= '9'                // PERF014 (const-on-left)
 }
-
-// Negated (out-of-range) form: c < lo || c > hi is the De Morgan complement
-// of the closed in-range check, so it maps to the negated helper.
 
 def bad_neg_digits(c : int) : bool {
     return c < '0' || c > '9'                  // PERF014 (negated → !is_number)
 }
 
-def bad_neg_lower_alpha(c : int) : bool {
-    return c < 'a' || c > 'z'                  // PERF014 (negated → !is_alpha lower)
-}
-
-def bad_neg_yoda(c : int) : bool {
+def bad_neg_digits_yoda(c : int) : bool {
     return '0' > c || '9' < c                  // PERF014 (negated, const-on-left)
 }
 
-def bad_neg_cast(c : uint8) : bool {
+def bad_neg_digits_cast(c : uint8) : bool {
     return int(c) < '0' || int(c) > '9'        // PERF014 (negated, with int() cast)
 }
 
+// Alpha — both-case compound, exact match to is_alpha.
+
+def bad_alpha_compound(c : int) : bool {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')   // PERF014 (→ is_alpha)
+}
+
+def bad_neg_alpha_compound(c : int) : bool {
+    return (c < 'a' || c > 'z') && (c < 'A' || c > 'Z')       // PERF014 (negated → !is_alpha)
+}
+
 // --- Good patterns (no warnings) ---
+
+def good_is_number(c : int) : bool {
+    return is_number(c)
+}
 
 def good_is_alpha(c : int) : bool {
     return is_alpha(c)
 }
 
+// Single-case ranges: no is_lower / is_upper helper exists, so NOT flagged.
+
+def good_single_lower(c : int) : bool {
+    return c >= 'a' && c <= 'z'                // single case — NOT flagged
+}
+
+def good_single_upper(c : int) : bool {
+    return c >= 'A' && c <= 'Z'                // single case — NOT flagged
+}
+
+def good_neg_single_lower(c : int) : bool {
+    return c < 'a' || c > 'z'                  // single case, negated — NOT flagged
+}
+
 def good_hex_lower(c : int) : bool {
-    return c >= 'a' && c <= 'f'                // hex range — NOT flagged
+    return c >= 'a' && c <= 'f'                // hex range — NOT flagged (is_hex broader)
 }
 
 def good_hex_upper(c : int) : bool {
@@ -88,10 +108,6 @@ def good_neg_always_true(c : int) : bool {
     return c < '9' || c > '0'                  // degenerate always-true (lo>=hi) — NOT flagged
 }
 
-def good_neg_hex(c : int) : bool {
-    return c < 'a' || c > 'f'                  // hex complement — NOT flagged (is_hex broader)
-}
-
 def good_partial_range(c : int) : bool {
     return c >= 'a' && c <= 'b'                // not a known class — NOT flagged
 }
@@ -100,8 +116,12 @@ def good_different_vars(a, b : int) : bool {
     return a >= 'a' && b <= 'z'                // two different vars — NOT flagged
 }
 
-// Side-effectful subexpressions: replacing `f() >= 'a' && f() <= 'z'` with
-// `is_alpha(f())` would call f() once instead of twice — silently changing
+def good_alpha_compound_diff_vars(a, b : int) : bool {
+    return (a >= 'a' && a <= 'z') || (b >= 'A' && b <= 'Z')   // halves on diff vars — NOT flagged
+}
+
+// Side-effectful subexpressions: replacing `f() >= '0' && f() <= '9'` with
+// `is_number(f())` would call f() once instead of twice — silently changing
 // semantics. The rule must NOT fire when operands aren't pure.
 
 [unused_argument(c)]
@@ -111,9 +131,9 @@ def impure_helper(c : int) : int {
 }
 
 def good_impure_call(c : int) : bool {
-    return impure_helper(c) >= 'a' && impure_helper(c) <= 'z'   // NOT flagged (impure)
+    return impure_helper(c) >= '0' && impure_helper(c) <= '9'   // NOT flagged (impure)
 }
 
 def good_neg_impure(c : int) : bool {
-    return impure_helper(c) < 'a' || impure_helper(c) > 'z'     // NOT flagged (impure, negated)
+    return impure_helper(c) < '0' || impure_helper(c) > '9'     // NOT flagged (impure, negated)
 }


### PR DESCRIPTION
## Summary

PERF014 previously matched only the **closed in-range** digit/alpha form (`c >= '0' && c <= '9'`). This PR extends it to the **out-of-range** (De Morgan negated) form and makes the whole rule **exact-only** — it now fires only on patterns that are byte-for-byte equivalent to a `strings` helper, so every suggested rewrite is behavior-preserving.

Exact equivalences flagged (and their negations):

| Pattern | Suggestion |
|---|---|
| `c >= '0' && c <= '9'` | `is_number(c)` |
| `c < '0' \|\| c > '9'` | `!is_number(c)` |
| `(c>='a'&&c<='z') \|\| (c>='A'&&c<='Z')` | `is_alpha(c)` |
| `(c<'a'\|\|c>'z') && (c<'A'\|\|c>'Z')` | `!is_alpha(c)` |

`is_alpha` is *defined* (in `aot_builtin_string.h`) as exactly that both-case union, so the compound form is the only accurate trigger for it.

## Deliberately not flagged

- **Single-case ranges** (`c >= 'a' && c <= 'z'` alone) — there is no `is_lower`/`is_upper` helper, so no exact rewrite exists. (This replaces the earlier inaccurate "consider is_alpha (broader)" suggestion — see resolved Copilot thread.)
- **Hex extras** (`'a'..'f'`) — `is_hex` is broader.
- **`&&`-strict intersection** (`c > '0' && c < '9'`) — a small open interval, not a char class. Distinct from the `||`-strict complement, which is flagged.

## How

- `parse_range_leg` generalized to an `(upper_op, lower_op)` operator pair.
- `parse_bounded_range` extracts one bounded range from a two-leg `ExprOp2` (verifying the join op + purity via `expr_equal_struct`).
- `check_perf014_digit` (single range) and `check_perf014_alpha` (two-half compound) dispatch off `&&` / `||`. Compound legs don't self-trigger, so no double-firing.
- **Dogfood:** the rule caught a real out-of-range digit check in `utils/lint/main.das`, rewritten to `!is_number(int(c))`.

## Test plan

- [x] `utils/lint/tests/perf014_char_class_range.das` rewritten — 8 exact bad cases (digit + compound alpha, both directions, incl. Yoda + `int()` cast), single-case/hex/intersection/diff-var/impure as good cases. dastest: **PASS**, exactly `31208:8`.
- [x] `tests/lint`: 25/25.
- [x] Lint of changed `.das`: 0 issues (incl. self-dogfood of perf_lint.das). Formatter `--verify`: clean.
- [x] Docs: `doc/source/reference/language/lint.rst` + `skills/perf_lint.md` updated; Sphinx clean for the edited page.

Lint-macro-only change: no runtime/AOT/JIT codepath touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)