### PR TITLE
from_xml_node v1: typed LINQ source over XML child elements

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -60,13 +60,14 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 
 ## sql/
 
-3-lane comparison over the same `Car` schema: `_sql` macro over `:memory:` SQLite vs in-memory `array<Car>` linq splice vs decs (`[decs_template]`) linq splice. Each bench builds the same data three ways via `_common.das` fixtures and runs the same query expression through each lane. See `benchmarks/sql/results.md` for the current ns/op numbers across both INTERP and JIT.
+Multi-lane comparison over the same `Car` schema: `_sql` macro over `:memory:` SQLite vs in-memory `array<Car>` linq splice vs decs (`[decs_template]`) linq splice vs XML (`from_xml_node`). Each bench builds the same data several ways via `_common.das` fixtures and runs the same query expression through each lane. See `benchmarks/sql/results.md` for the current ns/op numbers across both INTERP and JIT.
 
 | Lane | Source | Form |
 |---|---|---|
 | `m1` (SQL) | `:memory:` SQLite | `_sql` macro — compile-time SQL emission, work pushed to the engine |
 | `m3f` (Array) | pre-populated `array<Car>` | `_fold` over `each(arr).chain()` — fuses the chain into a single pass |
 | `m4` (Decs) | decs entities via `[decs_template]` | `_fold` over `from_decs_template(type<DecsCar>).chain()` — fuses into a per-archetype walk |
+| `m5` (XML) | in-memory XML doc (`fixture_xml_string`) | plain loop over `from_xml_node(root, type<Car>)` — **un-fused** v1 baseline; fused `m5f` lands in pass 2. Only 5 files carry this lane so far. |
 
 The `m3` lane (eager linq, no `_fold` splice) was dropped on 2026-05-23; the splice ladder closed the gap between m3f and m4 across the corpus, and m3 was no longer a useful comparison point.
 

--- a/benchmarks/sql/_common.das
+++ b/benchmarks/sql/_common.das
@@ -8,6 +8,8 @@ require sqlite/sqlite_linq public
 require dastest/testing_boost public
 require daslib/fio public
 require daslib/decs_boost public
+require pugixml/PUGIXML_boost public
+require strings public
 
 let public BRAND_COUNT = 5
 let public DEALER_COUNT = 100
@@ -66,6 +68,20 @@ def public fixture_array(n : int) : array<Car> {
         )
     }
     return <- arr
+}
+
+// m5_xml lane: same Car schema, rows materialized from XML child elements via
+// from_xml_node. Attribute names match Car's fields; same deterministic row
+// generator as fixture_array so the XML lane is directly comparable. Built with
+// a string writer (not `+`) to keep fixture construction O(n).
+def public fixture_xml_string(n : int) : string {
+    return build_string() $(var w) {
+        w |> write("<cars>")
+        for (i in range(n)) {
+            w |> write("<car id=\"{i + 1}\" name=\"Car{i}\" price=\"{(i * 37) % 1000}\" brand=\"{i % BRAND_COUNT}\" year=\"{2010 + (i * 7) % 16}\" dealer_id=\"{(i % DEALER_COUNT) + 1}\"/>")
+        }
+        w |> write("</cars>")
+    }
 }
 
 def public fixture_dealers_array() : array<Dealer> {

--- a/benchmarks/sql/aggregate_match.das
+++ b/benchmarks/sql/aggregate_match.das
@@ -48,6 +48,30 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — plain iteration over from_xml_node.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        let root = doc.document_element
+        b |> run("m5_xml/{n}", n) {
+            var total = 0
+            for (car in from_xml_node(root, type<Car>)) {
+                if (car.price > THRESHOLD) {
+                    total += car.price
+                }
+            }
+            b |> accept(total)
+            if (total == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def aggregate_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -61,4 +85,9 @@ def aggregate_match_m3f(b : B?) {
 [benchmark]
 def aggregate_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def aggregate_match_m5(b : B?) {
+    run_m5(b, 100000)
 }

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,8 @@
-# Benchmarks — SQL / Array / Decs comparison
+# Benchmarks — SQL / Array / Decs / XML comparison
 
-Generated 2026-05-28 from PRs `bbatkin/linq-fold-array-join-splice` (chunk N+3 — linq_fold array-side `_join` splice + cross-arm `_join |> _group_by` via new `ArrayJoin` SourceAdapter) + follow-up `bbatkin/linq-fold-join-emit-dedup` (refactor: shared standalone + adapter helpers) + follow-up `bbatkin/linq-fold-decs-reverse-take-select` (extend decs skip-into-tail to handle trailing `_select`) + symmetric m3f follow-up `bbatkin/linq-fold-array-reverse-take-select` (extend array-side R6 backward-index walk to handle trailing `_select`). The first two close the m3f-vs-m4 parity gap across the entire `join_*` family — all 5 cells m3f beats m4 in both INTERP and JIT:
+Updated 2026-05-28 (branch `bbatkin/from-xml-node-linq-source`): added the **XML (m5)** lane — a non-fold baseline that iterates `from_xml_node(root, type<Car>)` (the new typed LINQ-over-XML source in `pugixml/PUGIXML_boost`) and runs the query with a plain loop. v1 has no `_fold` for XML, so m5 is the reference the fused XML lane (`m5f`, pass 2) will be measured against; it is wired into 5 representative single-source files so far (`select_where_count`, `select_where_sum`, `aggregate_match`, `single_match`, `take_count_filtered`) — every other row's m5 cell is `—`. The full-scan cells (~356 ns INTERP) are dominated by materializing all 100k `Car` rows — including a `name` string clone per row the query never reads — which is exactly the per-element materialization a fused lane elides; the early-exit cells (`single_match`, `take_count_filtered`) only materialize rows up to the break.
+
+Prior baseline generated from PRs `bbatkin/linq-fold-array-join-splice` (chunk N+3 — linq_fold array-side `_join` splice + cross-arm `_join |> _group_by` via new `ArrayJoin` SourceAdapter) + follow-up `bbatkin/linq-fold-join-emit-dedup` (refactor: shared standalone + adapter helpers) + follow-up `bbatkin/linq-fold-decs-reverse-take-select` (extend decs skip-into-tail to handle trailing `_select`) + symmetric m3f follow-up `bbatkin/linq-fold-array-reverse-take-select` (extend array-side R6 backward-index walk to handle trailing `_select`). The first two close the m3f-vs-m4 parity gap across the entire `join_*` family — all 5 cells m3f beats m4 in both INTERP and JIT:
 
 | Cell | m3f INTERP before / after | m3f JIT before / after |
 |---|---:|---:|
@@ -25,6 +27,9 @@ catalogued in `doc/source/reference/linq_fold_patterns.rst`.
 - **Array** — `_fold` over `each(arr)` chain, in-memory `array<Car>`.
 - **Decs** — `_fold` over `from_decs_template(type<DecsCar>)`,
   per-archetype walk.
+- **XML** — plain loop over `from_xml_node(root, type<Car>)`, rows
+  materialized from XML child-element attributes. **Un-fused** v1
+  baseline (no `_fold` for XML yet); only 5 files carry this lane.
 - **Decs vs Array** — ratio `decs_ns / array_ns`. Values below 1× mean
   decs wins; values above mean array wins.
 
@@ -35,157 +40,157 @@ before the timer resolution can measure them — they should be read as
 
 ## INTERP
 
-| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
-|---|---:|---:|---:|---:|
-| `aggregate_match` | 32.3 | 5.8 | 5.8 | 1.00× |
-| `all_match` | 26.3 | 3.5 | 3.5 | 1.00× |
-| `any_match` | 0.0 | 0.0 | 0.0 | — |
-| `average_aggregate` | 29.0 | 5.9 | 8.8 | 1.49× |
-| `bare_order_where` | 270.0 | 115.2 | 124.7 | 1.08× |
-| `chained_select_collapse` | — | 17.7 | 17.4 | 0.98× |
-| `chained_where` | 35.5 | 6.6 | 7.1 | 1.08× |
-| `contains_match` | 0.0 | 2.2 | 1.4 | 0.64× |
-| `count_aggregate` | 28.3 | 4.1 | 4.0 | 0.98× |
-| `decs_count_bare_pred` | — | — | 4.1 | — |
-| `distinct_by_count` | 39.8 | 15.5 | 15.7 | 1.01× |
-| `distinct_by_order_take` | 247.9 | 21.6 | 23.9 | 1.11× |
-| `distinct_by_order_to_array` | 236.5 | 21.8 | 23.2 | 1.06× |
-| `distinct_count` | 40.2 | 15.8 | 15.9 | 1.01× |
-| `distinct_count_pred` | 246.2 | 15.7 | 15.8 | 1.01× |
-| `distinct_take` | 0.0 | 0.0 | 0.0 | — |
-| `element_at_match` | 0.0 | 0.0 | 0.0 | — |
-| `first_match` | 0.0 | 0.0 | 0.0 | — |
-| `first_or_default_match` | 0.0 | 0.0 | 0.0 | — |
-| `groupby_average` | 170.1 | 29.7 | 29.7 | 1.00× |
-| `groupby_count` | 139.6 | 19.2 | 19.1 | 0.99× |
-| `groupby_first` | 246.7 | 18.3 | 19.0 | 1.04× |
-| `groupby_having_count` | 139.3 | 19.0 | 19.0 | 1.00× |
-| `groupby_having_hidden_sum` | 173.2 | 23.6 | 24.0 | 1.02× |
-| `groupby_having_post_where` | 168.0 | 18.9 | 18.6 | 0.98× |
-| `groupby_max` | 171.2 | 24.9 | 25.0 | 1.00× |
-| `groupby_min` | 170.2 | 25.4 | 25.6 | 1.01× |
-| `groupby_multi_reducer` | 195.4 | 31.8 | 32.2 | 1.01× |
-| `groupby_select_order` | 168.0 | 18.5 | 18.5 | 1.00× |
-| `groupby_select_sum` | 197.7 | 35.6 | 35.7 | 1.00× |
-| `groupby_sum` | 168.5 | 18.4 | 18.4 | 1.00× |
-| `groupby_where_count` | 74.2 | 14.4 | 14.8 | 1.03× |
-| `groupby_where_sum` | 84.7 | 14.1 | 14.4 | 1.02× |
-| `indexed_lookup` | 1453.2 | 202198.9 | 470.2 | 0.00× |
-| `join_count` | 36.8 | 51.0 | 63.6 | 1.25× |
-| `join_groupby_count` | 153.9 | 78.3 | 90.1 | 1.15× |
-| `join_groupby_to_array` | 186.0 | 78.1 | 91.4 | 1.17× |
-| `join_select` | — | 72.0 | 83.8 | 1.16× |
-| `join_where_count` | 38.3 | 60.1 | 74.3 | 1.24× |
-| `last_match` | 0.0 | 5.7 | 13.9 | 2.44× |
-| `long_count_aggregate` | 28.1 | 4.0 | 4.0 | 1.00× |
-| `max_aggregate` | 29.3 | 6.0 | 6.8 | 1.13× |
-| `min_aggregate` | 29.2 | 6.0 | 6.7 | 1.12× |
-| `order_distinct_take` | 135.7 | 15.6 | 93.6 | 6.00× |
-| `order_reverse_normalized` | 36.4 | 16.0 | 19.8 | 1.24× |
-| `order_take_desc` | 36.3 | 15.9 | 19.8 | 1.25× |
-| `reverse_distinct_by` | 284.8 | 21.3 | — | — |
-| `reverse_take` | 0.1 | 0.0 | 10.0 | — |
-| `reverse_take_select` | 0.0 | 0.0 | 9.2 | — |
-| `select_count` | 0.1 | 0.0 | 2.2 | — |
-| `select_where` | 190.8 | 10.9 | 19.1 | 1.75× |
-| `select_where_count` | 31.4 | 5.1 | 7.3 | 1.43× |
-| `select_where_order_take` | 35.3 | 12.1 | 14.7 | 1.21× |
-| `select_where_sum` | 35.8 | 7.4 | 7.4 | 1.00× |
-| `single_match` | 0.0 | 2.9 | 5.4 | 1.86× |
-| `skip_take` | 0.5 | 0.1 | 0.2 | 2.00× |
-| `skip_while_match` | 3.4 | 5.2 | 5.3 | 1.02× |
-| `sort_first` | 36.6 | 10.9 | 13.2 | 1.21× |
-| `sort_take` | 38.8 | 16.2 | 20.5 | 1.27× |
-| `sort_take_select` | 36.9 | 16.0 | 19.8 | 1.24× |
-| `sum_aggregate` | 29.4 | 2.2 | 2.1 | 0.95× |
-| `sum_where` | 31.4 | 4.2 | 4.2 | 1.00× |
-| `take_count` | 3.6 | 0.2 | 0.4 | 2.00× |
-| `take_count_filtered` | — | 0.2 | 0.2 | 1.00× |
-| `take_sum_aggregate` | — | 0.1 | 0.1 | 1.00× |
-| `take_where_count` | — | 0.1 | 0.1 | 1.00× |
-| `take_while_match` | 7.5 | 2.4 | 2.4 | 1.00× |
-| `to_array_filter` | 68.0 | 11.5 | 11.6 | 1.01× |
-| `zip_count_pred` | — | 15.1 | — | — |
-| `zip_dot_product` | — | 12.5 | 10.9 | 0.87× |
-| `zip_dot_product_3arg` | — | 12.8 | — | — |
-| `zip_reverse_to_array` | — | 31.1 | — | — |
+| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML (m5) | Decs vs Array |
+|---|---:|---:|---:|---:|---:|
+| `aggregate_match` | 32.3 | 5.8 | 5.8 | 356.0 | 1.00× |
+| `all_match` | 26.3 | 3.5 | 3.5 | — | 1.00× |
+| `any_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `average_aggregate` | 29.0 | 5.9 | 8.8 | — | 1.49× |
+| `bare_order_where` | 270.0 | 115.2 | 124.7 | — | 1.08× |
+| `chained_select_collapse` | — | 17.7 | 17.4 | — | 0.98× |
+| `chained_where` | 35.5 | 6.6 | 7.1 | — | 1.08× |
+| `contains_match` | 0.0 | 2.2 | 1.4 | — | 0.64× |
+| `count_aggregate` | 28.3 | 4.1 | 4.0 | — | 0.98× |
+| `decs_count_bare_pred` | — | — | 4.1 | — | — |
+| `distinct_by_count` | 39.8 | 15.5 | 15.7 | — | 1.01× |
+| `distinct_by_order_take` | 247.9 | 21.6 | 23.9 | — | 1.11× |
+| `distinct_by_order_to_array` | 236.5 | 21.8 | 23.2 | — | 1.06× |
+| `distinct_count` | 40.2 | 15.8 | 15.9 | — | 1.01× |
+| `distinct_count_pred` | 246.2 | 15.7 | 15.8 | — | 1.01× |
+| `distinct_take` | 0.0 | 0.0 | 0.0 | — | — |
+| `element_at_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `first_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `first_or_default_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `groupby_average` | 170.1 | 29.7 | 29.7 | — | 1.00× |
+| `groupby_count` | 139.6 | 19.2 | 19.1 | — | 0.99× |
+| `groupby_first` | 246.7 | 18.3 | 19.0 | — | 1.04× |
+| `groupby_having_count` | 139.3 | 19.0 | 19.0 | — | 1.00× |
+| `groupby_having_hidden_sum` | 173.2 | 23.6 | 24.0 | — | 1.02× |
+| `groupby_having_post_where` | 168.0 | 18.9 | 18.6 | — | 0.98× |
+| `groupby_max` | 171.2 | 24.9 | 25.0 | — | 1.00× |
+| `groupby_min` | 170.2 | 25.4 | 25.6 | — | 1.01× |
+| `groupby_multi_reducer` | 195.4 | 31.8 | 32.2 | — | 1.01× |
+| `groupby_select_order` | 168.0 | 18.5 | 18.5 | — | 1.00× |
+| `groupby_select_sum` | 197.7 | 35.6 | 35.7 | — | 1.00× |
+| `groupby_sum` | 168.5 | 18.4 | 18.4 | — | 1.00× |
+| `groupby_where_count` | 74.2 | 14.4 | 14.8 | — | 1.03× |
+| `groupby_where_sum` | 84.7 | 14.1 | 14.4 | — | 1.02× |
+| `indexed_lookup` | 1453.2 | 202198.9 | 470.2 | — | 0.00× |
+| `join_count` | 36.8 | 51.0 | 63.6 | — | 1.25× |
+| `join_groupby_count` | 153.9 | 78.3 | 90.1 | — | 1.15× |
+| `join_groupby_to_array` | 186.0 | 78.1 | 91.4 | — | 1.17× |
+| `join_select` | — | 72.0 | 83.8 | — | 1.16× |
+| `join_where_count` | 38.3 | 60.1 | 74.3 | — | 1.24× |
+| `last_match` | 0.0 | 5.7 | 13.9 | — | 2.44× |
+| `long_count_aggregate` | 28.1 | 4.0 | 4.0 | — | 1.00× |
+| `max_aggregate` | 29.3 | 6.0 | 6.8 | — | 1.13× |
+| `min_aggregate` | 29.2 | 6.0 | 6.7 | — | 1.12× |
+| `order_distinct_take` | 135.7 | 15.6 | 93.6 | — | 6.00× |
+| `order_reverse_normalized` | 36.4 | 16.0 | 19.8 | — | 1.24× |
+| `order_take_desc` | 36.3 | 15.9 | 19.8 | — | 1.25× |
+| `reverse_distinct_by` | 284.8 | 21.3 | — | — | — |
+| `reverse_take` | 0.1 | 0.0 | 10.0 | — | — |
+| `reverse_take_select` | 0.0 | 0.0 | 9.2 | — | — |
+| `select_count` | 0.1 | 0.0 | 2.2 | — | — |
+| `select_where` | 190.8 | 10.9 | 19.1 | — | 1.75× |
+| `select_where_count` | 31.4 | 5.1 | 7.3 | 357.3 | 1.43× |
+| `select_where_order_take` | 35.3 | 12.1 | 14.7 | — | 1.21× |
+| `select_where_sum` | 35.8 | 7.4 | 7.4 | 358.5 | 1.00× |
+| `single_match` | 0.0 | 2.9 | 5.4 | 0.2 | 1.86× |
+| `skip_take` | 0.5 | 0.1 | 0.2 | — | 2.00× |
+| `skip_while_match` | 3.4 | 5.2 | 5.3 | — | 1.02× |
+| `sort_first` | 36.6 | 10.9 | 13.2 | — | 1.21× |
+| `sort_take` | 38.8 | 16.2 | 20.5 | — | 1.27× |
+| `sort_take_select` | 36.9 | 16.0 | 19.8 | — | 1.24× |
+| `sum_aggregate` | 29.4 | 2.2 | 2.1 | — | 0.95× |
+| `sum_where` | 31.4 | 4.2 | 4.2 | — | 1.00× |
+| `take_count` | 3.6 | 0.2 | 0.4 | — | 2.00× |
+| `take_count_filtered` | — | 0.2 | 0.2 | 7.1 | 1.00× |
+| `take_sum_aggregate` | — | 0.1 | 0.1 | — | 1.00× |
+| `take_where_count` | — | 0.1 | 0.1 | — | 1.00× |
+| `take_while_match` | 7.5 | 2.4 | 2.4 | — | 1.00× |
+| `to_array_filter` | 68.0 | 11.5 | 11.6 | — | 1.01× |
+| `zip_count_pred` | — | 15.1 | — | — | — |
+| `zip_dot_product` | — | 12.5 | 10.9 | — | 0.87× |
+| `zip_dot_product_3arg` | — | 12.8 | — | — | — |
+| `zip_reverse_to_array` | — | 31.1 | — | — | — |
 
 ## JIT
 
-| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | Decs vs Array |
-|---|---:|---:|---:|---:|
-| `aggregate_match` | 33.8 | 0.4 | 0.7 | 1.75× |
-| `all_match` | 27.8 | 0.3 | 0.2 | 0.67× |
-| `any_match` | 0.0 | 0.0 | 0.0 | — |
-| `average_aggregate` | 29.0 | 1.0 | 3.5 | 3.50× |
-| `bare_order_where` | 177.2 | 33.9 | 35.2 | 1.04× |
-| `chained_select_collapse` | — | 2.1 | 2.1 | 1.00× |
-| `chained_where` | 35.3 | 0.6 | 0.9 | 1.50× |
-| `contains_match` | 0.0 | 0.2 | 0.1 | 0.50× |
-| `count_aggregate` | 28.9 | 0.4 | 0.6 | 1.50× |
-| `decs_count_bare_pred` | — | — | 0.6 | — |
-| `distinct_by_count` | 40.1 | 2.1 | 2.1 | 1.00× |
-| `distinct_by_order_take` | 235.3 | 2.6 | 3.2 | 1.23× |
-| `distinct_by_order_to_array` | 238.8 | 2.7 | 3.3 | 1.22× |
-| `distinct_count` | 40.5 | 2.1 | 2.1 | 1.00× |
-| `distinct_count_pred` | 246.8 | 2.1 | 2.2 | 1.05× |
-| `distinct_take` | 0.0 | 0.1 | 0.0 | 0.00× |
-| `element_at_match` | 0.0 | 0.0 | 0.0 | — |
-| `first_match` | 0.0 | 0.0 | 0.0 | — |
-| `first_or_default_match` | 0.0 | 0.0 | 0.0 | — |
-| `groupby_average` | 168.6 | 2.6 | 2.9 | 1.12× |
-| `groupby_count` | 141.0 | 2.3 | 2.5 | 1.09× |
-| `groupby_first` | 250.4 | 2.2 | 3.1 | 1.41× |
-| `groupby_having_count` | 146.9 | 2.3 | 2.5 | 1.09× |
-| `groupby_having_hidden_sum` | 171.6 | 2.5 | 2.8 | 1.12× |
-| `groupby_having_post_where` | 167.2 | 2.4 | 2.6 | 1.08× |
-| `groupby_max` | 168.0 | 2.4 | 2.6 | 1.08× |
-| `groupby_min` | 167.5 | 2.4 | 2.6 | 1.08× |
-| `groupby_multi_reducer` | 189.6 | 2.7 | 2.9 | 1.07× |
-| `groupby_select_order` | 168.3 | 2.4 | 2.6 | 1.08× |
-| `groupby_select_sum` | 190.1 | 3.2 | 3.6 | 1.12× |
-| `groupby_sum` | 165.7 | 2.7 | 2.7 | 1.00× |
-| `groupby_where_count` | 73.8 | 1.4 | 1.7 | 1.21× |
-| `groupby_where_sum` | 84.4 | 1.5 | 1.8 | 1.20× |
-| `indexed_lookup` | 1224.3 | 34689.8 | 106.0 | 0.00× |
-| `join_count` | 36.7 | 11.6 | 12.7 | 1.09× |
-| `join_groupby_count` | 153.3 | 19.4 | 21.6 | 1.11× |
-| `join_groupby_to_array` | 187.2 | 19.5 | 21.6 | 1.11× |
-| `join_select` | — | 19.7 | 22.2 | 1.13× |
-| `join_where_count` | 38.2 | 20.4 | 22.5 | 1.10× |
-| `last_match` | 0.0 | 0.5 | 1.4 | 2.80× |
-| `long_count_aggregate` | 28.0 | 0.4 | 0.6 | 1.50× |
-| `max_aggregate` | 29.5 | 0.6 | 0.5 | 0.83× |
-| `min_aggregate` | 29.4 | 0.6 | 0.5 | 0.83× |
-| `order_distinct_take` | 136.1 | 2.1 | 73.9 | 35.19× |
-| `order_reverse_normalized` | 36.5 | 0.7 | 1.3 | 1.86× |
-| `order_take_desc` | 36.5 | 0.7 | 1.3 | 1.86× |
-| `reverse_distinct_by` | 289.8 | 2.6 | — | — |
-| `reverse_take` | 0.0 | 0.0 | 1.1 | — |
-| `reverse_take_select` | 0.0 | 0.0 | 1.1 | — |
-| `select_count` | 0.1 | 0.0 | 0.0 | — |
-| `select_where` | 105.0 | 4.1 | 5.3 | 1.29× |
-| `select_where_count` | 31.3 | 0.4 | 0.6 | 1.50× |
-| `select_where_order_take` | 35.2 | 0.7 | 1.3 | 1.86× |
-| `select_where_sum` | 35.8 | 0.5 | 0.6 | 1.20× |
-| `single_match` | 0.0 | 0.4 | 1.1 | 2.75× |
-| `skip_take` | 0.3 | 0.0 | 0.0 | — |
-| `skip_while_match` | 3.3 | 0.4 | 0.4 | 1.00× |
-| `sort_first` | 36.4 | 0.4 | 1.3 | 3.25× |
-| `sort_take` | 36.4 | 0.7 | 1.3 | 1.86× |
-| `sort_take_select` | 37.1 | 0.7 | 1.4 | 2.00× |
-| `sum_aggregate` | 28.4 | 0.4 | 0.3 | 0.75× |
-| `sum_where` | 31.1 | 0.4 | 0.6 | 1.50× |
-| `take_count` | 1.8 | 0.1 | 0.1 | 1.00× |
-| `take_count_filtered` | — | 0.0 | 0.0 | — |
-| `take_sum_aggregate` | — | 0.0 | 0.0 | — |
-| `take_where_count` | — | 0.0 | 0.0 | — |
-| `take_while_match` | 7.4 | 0.2 | 0.3 | 1.50× |
-| `to_array_filter` | 45.7 | 3.1 | 3.2 | 1.03× |
-| `zip_count_pred` | — | 0.6 | — | — |
-| `zip_dot_product` | — | 0.5 | 0.5 | 1.00× |
-| `zip_dot_product_3arg` | — | 0.5 | — | — |
-| `zip_reverse_to_array` | — | 4.3 | — | — |
+| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML (m5) | Decs vs Array |
+|---|---:|---:|---:|---:|---:|
+| `aggregate_match` | 33.8 | 0.4 | 0.7 | 154.3 | 1.75× |
+| `all_match` | 27.8 | 0.3 | 0.2 | — | 0.67× |
+| `any_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `average_aggregate` | 29.0 | 1.0 | 3.5 | — | 3.50× |
+| `bare_order_where` | 177.2 | 33.9 | 35.2 | — | 1.04× |
+| `chained_select_collapse` | — | 2.1 | 2.1 | — | 1.00× |
+| `chained_where` | 35.3 | 0.6 | 0.9 | — | 1.50× |
+| `contains_match` | 0.0 | 0.2 | 0.1 | — | 0.50× |
+| `count_aggregate` | 28.9 | 0.4 | 0.6 | — | 1.50× |
+| `decs_count_bare_pred` | — | — | 0.6 | — | — |
+| `distinct_by_count` | 40.1 | 2.1 | 2.1 | — | 1.00× |
+| `distinct_by_order_take` | 235.3 | 2.6 | 3.2 | — | 1.23× |
+| `distinct_by_order_to_array` | 238.8 | 2.7 | 3.3 | — | 1.22× |
+| `distinct_count` | 40.5 | 2.1 | 2.1 | — | 1.00× |
+| `distinct_count_pred` | 246.8 | 2.1 | 2.2 | — | 1.05× |
+| `distinct_take` | 0.0 | 0.1 | 0.0 | — | 0.00× |
+| `element_at_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `first_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `first_or_default_match` | 0.0 | 0.0 | 0.0 | — | — |
+| `groupby_average` | 168.6 | 2.6 | 2.9 | — | 1.12× |
+| `groupby_count` | 141.0 | 2.3 | 2.5 | — | 1.09× |
+| `groupby_first` | 250.4 | 2.2 | 3.1 | — | 1.41× |
+| `groupby_having_count` | 146.9 | 2.3 | 2.5 | — | 1.09× |
+| `groupby_having_hidden_sum` | 171.6 | 2.5 | 2.8 | — | 1.12× |
+| `groupby_having_post_where` | 167.2 | 2.4 | 2.6 | — | 1.08× |
+| `groupby_max` | 168.0 | 2.4 | 2.6 | — | 1.08× |
+| `groupby_min` | 167.5 | 2.4 | 2.6 | — | 1.08× |
+| `groupby_multi_reducer` | 189.6 | 2.7 | 2.9 | — | 1.07× |
+| `groupby_select_order` | 168.3 | 2.4 | 2.6 | — | 1.08× |
+| `groupby_select_sum` | 190.1 | 3.2 | 3.6 | — | 1.12× |
+| `groupby_sum` | 165.7 | 2.7 | 2.7 | — | 1.00× |
+| `groupby_where_count` | 73.8 | 1.4 | 1.7 | — | 1.21× |
+| `groupby_where_sum` | 84.4 | 1.5 | 1.8 | — | 1.20× |
+| `indexed_lookup` | 1224.3 | 34689.8 | 106.0 | — | 0.00× |
+| `join_count` | 36.7 | 11.6 | 12.7 | — | 1.09× |
+| `join_groupby_count` | 153.3 | 19.4 | 21.6 | — | 1.11× |
+| `join_groupby_to_array` | 187.2 | 19.5 | 21.6 | — | 1.11× |
+| `join_select` | — | 19.7 | 22.2 | — | 1.13× |
+| `join_where_count` | 38.2 | 20.4 | 22.5 | — | 1.10× |
+| `last_match` | 0.0 | 0.5 | 1.4 | — | 2.80× |
+| `long_count_aggregate` | 28.0 | 0.4 | 0.6 | — | 1.50× |
+| `max_aggregate` | 29.5 | 0.6 | 0.5 | — | 0.83× |
+| `min_aggregate` | 29.4 | 0.6 | 0.5 | — | 0.83× |
+| `order_distinct_take` | 136.1 | 2.1 | 73.9 | — | 35.19× |
+| `order_reverse_normalized` | 36.5 | 0.7 | 1.3 | — | 1.86× |
+| `order_take_desc` | 36.5 | 0.7 | 1.3 | — | 1.86× |
+| `reverse_distinct_by` | 289.8 | 2.6 | — | — | — |
+| `reverse_take` | 0.0 | 0.0 | 1.1 | — | — |
+| `reverse_take_select` | 0.0 | 0.0 | 1.1 | — | — |
+| `select_count` | 0.1 | 0.0 | 0.0 | — | — |
+| `select_where` | 105.0 | 4.1 | 5.3 | — | 1.29× |
+| `select_where_count` | 31.3 | 0.4 | 0.6 | 149.5 | 1.50× |
+| `select_where_order_take` | 35.2 | 0.7 | 1.3 | — | 1.86× |
+| `select_where_sum` | 35.8 | 0.5 | 0.6 | 149.5 | 1.20× |
+| `single_match` | 0.0 | 0.4 | 1.1 | 0.1 | 2.75× |
+| `skip_take` | 0.3 | 0.0 | 0.0 | — | — |
+| `skip_while_match` | 3.3 | 0.4 | 0.4 | — | 1.00× |
+| `sort_first` | 36.4 | 0.4 | 1.3 | — | 3.25× |
+| `sort_take` | 36.4 | 0.7 | 1.3 | — | 1.86× |
+| `sort_take_select` | 37.1 | 0.7 | 1.4 | — | 2.00× |
+| `sum_aggregate` | 28.4 | 0.4 | 0.3 | — | 0.75× |
+| `sum_where` | 31.1 | 0.4 | 0.6 | — | 1.50× |
+| `take_count` | 1.8 | 0.1 | 0.1 | — | 1.00× |
+| `take_count_filtered` | — | 0.0 | 0.0 | 3.4 | — |
+| `take_sum_aggregate` | — | 0.0 | 0.0 | — | — |
+| `take_where_count` | — | 0.0 | 0.0 | — | — |
+| `take_while_match` | 7.4 | 0.2 | 0.3 | — | 1.50× |
+| `to_array_filter` | 45.7 | 3.1 | 3.2 | — | 1.03× |
+| `zip_count_pred` | — | 0.6 | — | — | — |
+| `zip_dot_product` | — | 0.5 | 0.5 | — | 1.00× |
+| `zip_dot_product_3arg` | — | 0.5 | — | — | — |
+| `zip_reverse_to_array` | — | 4.3 | — | — | — |
 
 ## Notes on missing lanes (the `—` cells)
 

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -48,6 +48,32 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — plain iteration over from_xml_node (which
+// materializes a full Car per child element). v1 has no _fold for XML, so this
+// is the reference the fused XML lane (m5f, pass 2) will be measured against.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        let root = doc.document_element
+        b |> run("m5_xml/{n}", n) {
+            var c = 0
+            for (car in from_xml_node(root, type<Car>)) {
+                if (car.price * 2 > THRESHOLD) {
+                    c++
+                }
+            }
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def select_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -61,4 +87,9 @@ def select_where_count_m3f(b : B?) {
 [benchmark]
 def select_where_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def select_where_count_m5(b : B?) {
+    run_m5(b, 100000)
 }

--- a/benchmarks/sql/select_where_sum.das
+++ b/benchmarks/sql/select_where_sum.das
@@ -56,6 +56,31 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — plain iteration over from_xml_node.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        let root = doc.document_element
+        b |> run("m5_xml/{n}", n) {
+            var s = 0
+            for (car in from_xml_node(root, type<Car>)) {
+                let p = car.price * 2
+                if (p > THRESHOLD) {
+                    s += p
+                }
+            }
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def select_where_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -69,4 +94,9 @@ def select_where_sum_m3f(b : B?) {
 [benchmark]
 def select_where_sum_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def select_where_sum_m5(b : B?) {
+    run_m5(b, 100000)
 }

--- a/benchmarks/sql/single_match.das
+++ b/benchmarks/sql/single_match.das
@@ -46,6 +46,32 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — plain iteration over from_xml_node, breaking
+// on the (unique) match.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        let root = doc.document_element
+        b |> run("m5_xml/{n}", n) {
+            var row = default<Car>
+            for (car in from_xml_node(root, type<Car>)) {
+                if (car.id == TARGET_ID) {
+                    row = car
+                    break
+                }
+            }
+            b |> accept(row)
+            if (row.id == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def single_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +85,9 @@ def single_match_m3f(b : B?) {
 [benchmark]
 def single_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def single_match_m5(b : B?) {
+    run_m5(b, 100000)
 }

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -34,6 +34,34 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — plain iteration over from_xml_node, capping
+// at TAKE_N matches.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        let root = doc.document_element
+        b |> run("m5_xml/{n}", n) {
+            var c = 0
+            for (car in from_xml_node(root, type<Car>)) {
+                if (car.price > THRESHOLD) {
+                    c++
+                    if (c >= TAKE_N) {
+                        break
+                    }
+                }
+            }
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def take_count_filtered_m3f(b : B?) {
     run_m3f(b, 100000)
@@ -42,4 +70,9 @@ def take_count_filtered_m3f(b : B?) {
 [benchmark]
 def take_count_filtered_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def take_count_filtered_m5(b : B?) {
+    run_m5(b, 100000)
 }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -818,6 +818,7 @@ def document_module_PUGIXML_boost(root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Block-based iteration", mod, %regex~.*(for_each_child|for_each_attribute|for_each)$%%),
         group_by_regex("Iterator-based iteration", mod, %regex~.*(each|each_child|each_attribute)$%%),
+        group_by_regex("LINQ source", mod, %regex~.*(from_xml_node|build_xml_row)$%%),
         group_by_regex("RAII document handling", mod, %regex~.*(open_xml|parse_xml|with_doc)$%%),
         group_by_regex("Quick accessors", mod, %regex~.*(node_text|node_attr|node_attr_int|node_attr_float|node_attr_bool)$%%),
         group_by_regex("Builder helpers", mod, %regex~.*(add_child|add_child_ex|add_attr)$%%),

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -251,6 +251,7 @@ Run any tutorial from the project root::
    tutorials/dasPUGIXML_02_building.rst
    tutorials/dasPUGIXML_03_xpath.rst
    tutorials/dasPUGIXML_04_serialization.rst
+   tutorials/dasPUGIXML_05_linq.rst
 
 .. _tutorials_dasstbimage:
 

--- a/doc/source/reference/tutorials/dasPUGIXML_04_serialization.rst
+++ b/doc/source/reference/tutorials/dasPUGIXML_04_serialization.rst
@@ -276,3 +276,5 @@ A full game-state roundtrip with nested struct, array, and vector:
    Full source: :download:`tutorials/dasPUGIXML/04_serialization.das <../../../../tutorials/dasPUGIXML/04_serialization.das>`
 
    Previous tutorial: :ref:`tutorial_dasPUGIXML_xpath`
+
+   Next tutorial: :ref:`tutorial_dasPUGIXML_linq`

--- a/doc/source/reference/tutorials/dasPUGIXML_05_linq.rst
+++ b/doc/source/reference/tutorials/dasPUGIXML_05_linq.rst
@@ -1,0 +1,119 @@
+.. _tutorial_dasPUGIXML_linq:
+
+===========================================
+PUGIXML-05 — LINQ over XML
+===========================================
+
+.. index::
+    single: Tutorial; LINQ over XML
+    single: Tutorial; dasPUGIXML
+    single: Tutorial; from_xml_node
+
+This tutorial covers ``from_xml_node`` — a typed, lazy iterator that walks
+the child elements of an XML node and materializes each into a struct, so
+ordinary comprehensions and ``daslib/linq_boost`` queries run straight over an
+XML document. It lives in ``pugixml/PUGIXML_boost``.
+
+Typed rows from attributes
+==========================
+
+``from_xml_node(root, type<Row>)`` walks every child element of ``root`` and
+fills a ``Row`` by reading **same-named attributes**. Each yielded value is
+fully materialized — no XML node escapes into the loop body. A field whose
+attribute is absent keeps the struct's declared default:
+
+.. code-block:: das
+
+   require pugixml/PUGIXML_boost
+
+   struct Car {
+       id : int
+       make : string
+       price : float
+       year : int = 2000        // used when the attribute is absent
+       in_stock : bool
+   }
+
+   let CATALOG = ("<cars>" +
+       "<car id=\"1\" make=\"Audi\"   price=\"45000.0\" year=\"2021\" in_stock=\"true\"/>" +
+       "<car id=\"2\" make=\"Toyota\" price=\"28000.0\" year=\"2020\" in_stock=\"true\"/>" +
+       "<car id=\"3\" make=\"Ford\"   price=\"31000.0\" in_stock=\"false\"/>" +
+       "</cars>")
+
+   parse_xml(CATALOG) $(doc, ok) {
+       let root = doc.document_element
+       for (car in from_xml_node(root, type<Car>)) {
+           print("#{car.id} {car.make} ({car.year})\n")
+       }
+   }
+   // #1 Audi (2021)
+   // #2 Toyota (2020)
+   // #3 Ford (2000)   <- year attribute absent, default kept
+
+Supported field types are the XML scalar attribute types: ``int``, ``uint``,
+``float``, ``double``, ``bool``, ``string``. Fields of other types keep their
+default (child-element / text mapping is a planned growth path).
+
+LINQ comprehensions
+===================
+
+The iterator is just an iterable, so comprehensions filter and project directly:
+
+.. code-block:: das
+
+   parse_xml(CATALOG) $(doc, ok) {
+       let root = doc.document_element
+       let affordable <- [for (car in from_xml_node(root, type<Car>));
+           car.make;
+           where car.in_stock && car.price < 40000.0]
+       print("{affordable}\n")
+       // [ Toyota]
+   }
+
+Tag-filtered walk
+=================
+
+``from_xml_node(root, "tag", type<Row>)`` walks only children with that tag —
+useful when a parent interleaves several element kinds:
+
+.. code-block:: das
+
+   let mixed = ("<fleet>" +
+       "<car id=\"10\" make=\"Mazda\" price=\"26000.0\"/>" +
+       "<note>service due</note>" +
+       "<car id=\"11\" make=\"Honda\" price=\"24000.0\"/>" +
+       "</fleet>")
+   parse_xml(mixed) $(doc, ok) {
+       let root = doc.document_element
+       let ids <- [for (car in from_xml_node(root, "car", type<Car>)); car.id]
+       print("{ids}\n")
+       // [ 10, 11]   <- <note> skipped
+   }
+
+Results outlive the document
+============================
+
+Rows are owned values — string fields are cloned out of the document — so
+collecting them with ``to_array`` and using them after the RAII block closes is
+safe. Because ``from_xml_node`` is an ``[unsafe_outside_of_for]`` iterator,
+consuming it outside a ``for`` loop needs an ``unsafe`` block:
+
+.. code-block:: das
+
+   var inventory : array<Car>
+   parse_xml(CATALOG) $(doc, ok) {
+       let root = doc.document_element
+       unsafe {
+           inventory <- from_xml_node(root, type<Car>) |> to_array()
+       }
+   }
+   // doc is freed here — inventory and its strings remain valid
+   print("{length(inventory)} cars; first = {inventory[0].make}\n")
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasPUGIXML/05_linq_over_xml.das <../../../../tutorials/dasPUGIXML/05_linq_over_xml.das>`
+
+   Previous tutorial: :ref:`tutorial_dasPUGIXML_serialization`
+
+   Related: :ref:`tutorial_linq`, :ref:`comprehensions`

--- a/modules/dasPUGIXML/daslib/PUGIXML_boost.das
+++ b/modules/dasPUGIXML/daslib/PUGIXML_boost.das
@@ -128,6 +128,66 @@ def each_attribute(node : xml_node) : iterator<xml_attribute> {
     }
 }
 
+// ============ LINQ source — typed iteration over child elements ============
+
+def private read_xml_attr(a : xml_attribute; defv : auto(TT)) : TT {
+    return defv     // generic fallback — a field type with no specific reader keeps its default
+}
+def private read_xml_attr(a : xml_attribute; defv : int) : int { return as_int(a, defv); }
+def private read_xml_attr(a : xml_attribute; defv : uint) : uint { return as_uint(a, defv); }
+def private read_xml_attr(a : xml_attribute; defv : float) : float { return as_float(a, defv); }
+def private read_xml_attr(a : xml_attribute; defv : double) : double { return as_double(a, defv); }
+def private read_xml_attr(a : xml_attribute; defv : bool) : bool { return as_bool(a, defv); }
+def private read_xml_attr(a : xml_attribute; defv : string) : string {
+    return clone_string(as_string(a, defv))     // clone out of the document so the row survives the RAII block
+}
+
+def build_xml_row(node : xml_node; var row) {
+    //! Fills *row*'s scalar fields from same-named attributes of *node*. A missing attribute
+    //! leaves the field at its declared default. Supported field types: ``int``, ``uint``,
+    //! ``float``, ``double``, ``bool``, ``string`` — fields of other types keep their default.
+    apply(row) $(name : string; var field) {
+        field = read_xml_attr(node[name], field)
+    }
+}
+
+[unsafe_outside_of_for]
+def from_xml_node(node : xml_node; t : type<auto(TT)>) : iterator<TT> {
+    //! Lazily walks every child element of *node*, materializing each into a *TT* by reading
+    //! same-named attributes (see ``build_xml_row``). Yields owned values, so rows collected via
+    //! ``to_array`` or a comprehension stay valid past the document's RAII block.
+    //! Intended for ``for`` loops and LINQ chains:
+    //!
+    //!   ``for (car in from_xml_node(root, type<Car>)) { ... }``
+    return <- generator<TT> {
+        var ch = node.first_child
+        while (ch.ok) {
+            var next = ch.next_sibling   // capture before yield (user may mutate)
+            var row = default<TT>
+            build_xml_row(ch, row)
+            yield row
+            ch = next
+        }
+        return false
+    }
+}
+
+[unsafe_outside_of_for]
+def from_xml_node(node : xml_node; name : string; t : type<auto(TT)>) : iterator<TT> {
+    //! As ``from_xml_node`` above, but only walks child elements whose tag matches *name*.
+    return <- generator<TT> {
+        var ch = child(node, name)
+        while (ch.ok) {
+            var next = next_sibling(ch, name)   // capture before yield
+            var row = default<TT>
+            build_xml_row(ch, row)
+            yield row
+            ch = next
+        }
+        return false
+    }
+}
+
 // ============ RAII document management ============
 
 def open_xml(filename : string; blk : block<(doc : xml_document?; success : bool) : void>) {
@@ -651,9 +711,7 @@ def from_XML(node : xml_node; anything : auto(TT)) {
     } static_elif (typeinfo is_variant(anything)) {
         var ret : TT
         let index = node_attr_int(node, "_variant", 0)
-        unsafe {
-            set_variant_index(ret, index)
-        }
+        unsafe(set_variant_index(ret, index))
         apply(ret) $(name : string; var field) {
             let ch = child(node, name)
             if (ch.ok) {

--- a/modules/dasPUGIXML/daslib/PUGIXML_boost.das
+++ b/modules/dasPUGIXML/daslib/PUGIXML_boost.das
@@ -152,20 +152,25 @@ def build_xml_row(node : xml_node; var row) {
 }
 
 [unsafe_outside_of_for]
-def from_xml_node(node : xml_node; t : type<auto(TT)>) : iterator<TT> {
-    //! Lazily walks every child element of *node*, materializing each into a *TT* by reading
-    //! same-named attributes (see ``build_xml_row``). Yields owned values, so rows collected via
-    //! ``to_array`` or a comprehension stay valid past the document's RAII block.
+def from_xml_node(node : xml_node; t : type<auto(TT)>) : iterator<TT -const> {
+    //! Lazily walks the child *elements* of *node*, materializing each into a *TT* by reading
+    //! same-named attributes (see ``build_xml_row``). Non-element children (text/PCDATA/comments
+    //! in mixed content) are skipped. Yields owned values, so rows collected via ``to_array`` or a
+    //! comprehension stay valid past the document's RAII block.
     //! Intended for ``for`` loops and LINQ chains:
     //!
     //!   ``for (car in from_xml_node(root, type<Car>)) { ... }``
-    return <- generator<TT> {
+    // -const on the element: type<auto(TT)> binds TT const, so a bare iterator<TT> makes the
+    // consumer's loop var a const struct — which the AOT C++ emitter can't default-initialize.
+    return <- generator<TT -const> {
         var ch = node.first_child
         while (ch.ok) {
-            var next = ch.next_sibling   // capture before yield (user may mutate)
-            var row = default<TT>
-            build_xml_row(ch, row)
-            yield row
+            let next = ch.next_sibling   // capture before yield (user may mutate)
+            if (ch._type == xml_node_type.node_element) {
+                var row = default<TT -const>
+                build_xml_row(ch, row)
+                yield row
+            }
             ch = next
         }
         return false
@@ -173,13 +178,14 @@ def from_xml_node(node : xml_node; t : type<auto(TT)>) : iterator<TT> {
 }
 
 [unsafe_outside_of_for]
-def from_xml_node(node : xml_node; name : string; t : type<auto(TT)>) : iterator<TT> {
-    //! As ``from_xml_node`` above, but only walks child elements whose tag matches *name*.
-    return <- generator<TT> {
+def from_xml_node(node : xml_node; name : string; t : type<auto(TT)>) : iterator<TT -const> {
+    //! As ``from_xml_node`` above, but only walks child elements whose tag matches *name*
+    //! (``child``/``next_sibling`` by name already match elements only).
+    return <- generator<TT -const> {
         var ch = child(node, name)
         while (ch.ok) {
-            var next = next_sibling(ch, name)   // capture before yield
-            var row = default<TT>
+            let next = next_sibling(ch, name)   // capture before yield
+            var row = default<TT -const>
             build_xml_row(ch, row)
             yield row
             ch = next

--- a/skills/xml.md
+++ b/skills/xml.md
@@ -56,6 +56,30 @@ node |> for_each_attribute()   $(a)       { ... }
 
 Manual `node.first_child` / `node.next_sibling` walking still works but is rarely the right choice.
 
+## LINQ source — `from_xml_node`
+
+`from_xml_node(root, type<Row>)` is a typed, lazy iterator over `root`'s child elements: each child is materialized into a `Row` by reading **same-named attributes**, so comprehensions and `daslib/linq_boost` queries run straight over an XML document.
+
+```das
+struct Car {
+    id : int
+    make : string
+    price : float
+    year : int = 2000        // default kept when the attribute is absent
+}
+
+for (car in from_xml_node(root, type<Car>)) { ... }                 // all children
+let makes <- [for (car in from_xml_node(root, type<Car>));          // comprehension
+    car.make; where car.price < 30000.0]
+let cars <- unsafe(from_xml_node(root, "car", type<Car>) |> to_array())   // tag-filtered + collect
+```
+
+- **Field mapping (v1):** every struct field reads from an attribute of the same name. Supported scalar types: `int`, `uint`, `float`, `double`, `bool`, `string`. Fields of other types keep their default. Child-element / text mapping (via `@xml_*` field annotations) is a planned growth path.
+- **Defaults:** a missing attribute leaves the field at its declared default (`year : int = 2000` above), because the field value is passed as the accessor's fallback.
+- **Lifetime-safe:** rows are owned values — string fields are cloned out of the document — so results collected with `to_array` / a comprehension stay valid **past** the `parse_xml` / `open_xml` RAII block. (Contrast: a raw `xml_node` must not escape the block.)
+- **`unsafe` outside a `for`:** `from_xml_node` is `[unsafe_outside_of_for]`. A `for` loop and a comprehension are safe; piping it into `to_array` / `linq_boost` outside a `for` needs an `unsafe` block.
+- A fused `_fold` lane for XML is planned (pass 2); today `from_xml_node` composes with comprehensions / `linq_boost` (the un-fused path). See [tutorials/dasPUGIXML/05_linq_over_xml.das](tutorials/dasPUGIXML/05_linq_over_xml.das).
+
 ## Quick accessors (with defaults)
 
 ```das
@@ -169,6 +193,7 @@ Supports nested structs, enums, arrays, tables, tuples, variants, vector types (
   - [tutorials/dasPUGIXML/02_building_xml.das](tutorials/dasPUGIXML/02_building_xml.das) — `with_doc`, `tag`/`attr` EDSL, serialization
   - [tutorials/dasPUGIXML/03_xpath.das](tutorials/dasPUGIXML/03_xpath.das) — XPath queries, compiled XPath
   - [tutorials/dasPUGIXML/04_serialization.das](tutorials/dasPUGIXML/04_serialization.das) — `to_XML`/`from_XML` round-trip
+  - [tutorials/dasPUGIXML/05_linq_over_xml.das](tutorials/dasPUGIXML/05_linq_over_xml.das) — `from_xml_node` LINQ source (typed rows from attributes)
 - daslib helpers (the source of truth for the EDSL): [modules/dasPUGIXML/daslib/PUGIXML_boost.das](modules/dasPUGIXML/daslib/PUGIXML_boost.das)
 - C++ binding (for adding new functions): [modules/dasPUGIXML/src/dasPUGIXML.h](modules/dasPUGIXML/src/dasPUGIXML.h), `dasPUGIXML.cpp`
 - Tests with patterns: [tests/dasPUGIXML/](tests/dasPUGIXML/) — `test_pugixml_core.das`, `test_pugixml_mutation.das`, `test_pugixml_boost.das`, `test_serial_*.das`

--- a/tests/dasPUGIXML/test_from_xml_node.das
+++ b/tests/dasPUGIXML/test_from_xml_node.das
@@ -55,3 +55,17 @@ def test_from_xml_node_filtered(t : T?) {
         t |> equal(ids[2], 3)
     }
 }
+
+[test]
+def test_from_xml_node_mixed_content(t : T?) {
+    // bare from_xml_node skips non-element children (PCDATA between the cars),
+    // so mixed content yields only the 2 elements — not extra default rows
+    parse_xml("<cars>noise<car id=\"1\"/>more<car id=\"2\"/></cars>") $(doc, ok) {
+        t |> success(ok)
+        let root = doc.document_element
+        let ids <- [for (c in from_xml_node(root, type<XmlCar>)); c.id]
+        t |> equal(length(ids), 2)
+        t |> equal(ids[0], 1)
+        t |> equal(ids[1], 2)
+    }
+}

--- a/tests/dasPUGIXML/test_from_xml_node.das
+++ b/tests/dasPUGIXML/test_from_xml_node.das
@@ -1,0 +1,57 @@
+options gen2
+require pugixml/PUGIXML_boost
+require dastest/testing_boost public
+
+struct XmlCar {
+    id : int
+    name : string
+    price : float
+    ratio : double
+    qty : uint
+    active : bool
+    year : int = 1990          // declared default — survives a missing attribute
+}
+
+[test]
+def test_from_xml_node(t : T?) {
+    // (d) collect rows inside the RAII block, then assert AFTER it closes —
+    // materialized values (incl. strings) must stay valid once the document is freed.
+    var collected : array<XmlCar>
+    parse_xml(("<cars>" +
+        "<car id=\"1\" name=\"alpha\" price=\"9.5\" ratio=\"0.25\" qty=\"7\" active=\"true\" year=\"2001\"/>" +
+        "<car id=\"2\" name=\"beta\" price=\"3.0\" ratio=\"0.5\" qty=\"2\" active=\"false\"/>" +
+        "</cars>")) $(doc, ok) {
+        t |> success(ok)
+        let root = doc.document_element
+        for (c in from_xml_node(root, type<XmlCar>)) {
+            collected |> push(c)
+        }
+    }
+    t |> equal(length(collected), 2)
+    // (a) every supported scalar type reads from its same-named attribute
+    t |> equal(collected[0].id, 1)
+    t |> equal(collected[0].name, "alpha")
+    t |> equal(collected[0].price, 9.5)
+    t |> equal(collected[0].ratio, 0.25lf)
+    t |> equal(collected[0].qty, 7u)
+    t |> success(collected[0].active)
+    t |> equal(collected[0].year, 2001)
+    // (b) the second row omits year → the struct's declared default (1990) is preserved
+    t |> equal(collected[1].name, "beta")
+    t |> success(!collected[1].active)
+    t |> equal(collected[1].year, 1990)
+}
+
+[test]
+def test_from_xml_node_filtered(t : T?) {
+    parse_xml("<root><car id=\"1\"/><other id=\"99\"/><car id=\"2\"/><car id=\"3\"/></root>") $(doc, ok) {
+        t |> success(ok)
+        let root = doc.document_element
+        // (c) tag-filtered overload skips <other>; (e) a comprehension consumes the iterator
+        let ids <- [for (c in from_xml_node(root, "car", type<XmlCar>)); c.id]
+        t |> equal(length(ids), 3)
+        t |> equal(ids[0], 1)
+        t |> equal(ids[1], 2)
+        t |> equal(ids[2], 3)
+    }
+}

--- a/tutorials/dasPUGIXML/05_linq_over_xml.das
+++ b/tutorials/dasPUGIXML/05_linq_over_xml.das
@@ -1,0 +1,154 @@
+// Tutorial PUGIXML-05: LINQ over XML
+//
+// This tutorial covers:
+//   - from_xml_node(root, type<Row>) — a typed, lazy iterator over child elements
+//   - Mapping struct fields to same-named XML attributes (the v1 convention)
+//   - Missing attributes falling back to the field's declared default
+//   - Driving comprehensions and linq_boost queries straight off the iterator
+//   - Why materialized rows stay valid past the document's RAII block
+//   - The tag-filtered overload from_xml_node(root, name, type<Row>)
+//
+// requires: daslib/PUGIXML_boost (re-exports pugixml), daslib/linq_boost
+// Run: daslang.exe tutorials/dasPUGIXML/05_linq_over_xml.das
+
+options gen2
+options persistent_heap
+
+require pugixml/PUGIXML_boost
+require daslib/linq_boost
+
+// A row type. Each field maps to a same-named XML *attribute* on the child
+// element. `year` carries a default — rows that omit the attribute keep it.
+struct Car {
+    id : int
+    make : string
+    price : float
+    year : int = 2000
+    in_stock : bool
+}
+
+// Attribute-style data: one <car .../> child per row. (from_xml_node v1 reads
+// attributes; child-element / text mapping is a planned growth path.)
+let CATALOG = ("<cars>" +
+    "<car id=\"1\" make=\"Audi\"   price=\"45000.0\" year=\"2021\" in_stock=\"true\"/>" +
+    "<car id=\"2\" make=\"Toyota\" price=\"28000.0\" year=\"2020\" in_stock=\"true\"/>" +
+    "<car id=\"3\" make=\"Ford\"   price=\"31000.0\" in_stock=\"false\"/>" +   // no year → default 2000
+    "<car id=\"4\" make=\"Kia\"    price=\"22000.0\" year=\"2022\" in_stock=\"true\"/>" +
+    "</cars>")
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Basics: typed rows straight from attributes
+// ──────────────────────────────────────────────────────────────────────────
+//
+// from_xml_node walks each child of `root` and fills a Car from its attributes.
+// `car` is a fully materialized value — no XML node escapes into the loop body.
+
+def basics() {
+    print("=== Section 1: from_xml_node basics ===\n")
+    parse_xml(CATALOG) $(doc, ok) {
+        if (!ok) {
+            print("parse failed\n")
+            return
+        }
+        let root = doc.document_element
+        for (car in from_xml_node(root, type<Car>)) {
+            print("  #{car.id} {car.make} ${car.price} ({car.year}) in_stock={car.in_stock}\n")
+        }
+    }
+    // Note row #3 (Ford) prints year=2000 — the attribute was absent, so the
+    // struct's declared default stands in.
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — LINQ comprehensions over the iterator
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The iterator is just an iterable, so comprehensions filter + project directly.
+
+def comprehensions() {
+    print("=== Section 2: comprehension filter + project ===\n")
+    parse_xml(CATALOG) $(doc, ok) {
+        if (!ok) return
+        let root = doc.document_element
+        // makes of in-stock cars under $40k, cheapest data first
+        let affordable <- [for (car in from_xml_node(root, type<Car>));
+            car.make;
+            where car.in_stock && car.price < 40000.0]
+        print("  affordable in-stock: {affordable}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — linq_boost aggregates
+// ──────────────────────────────────────────────────────────────────────────
+//
+// linq_boost operators compose with from_xml_node the same way they do with any
+// source — here, the average price across the catalog.
+
+def aggregates() {
+    print("=== Section 3: linq_boost aggregate ===\n")
+    parse_xml(CATALOG) $(doc, ok) {
+        if (!ok) return
+        let root = doc.document_element
+        let prices <- [for (car in from_xml_node(root, type<Car>)); car.price]
+        var total = 0.0
+        for (p in prices) {
+            total += p
+        }
+        print("  {length(prices)} cars, average price ${total / float(length(prices))}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Tag-filtered overload
+// ──────────────────────────────────────────────────────────────────────────
+//
+// from_xml_node(root, "tag", type<Row>) walks only children with that tag —
+// handy when a document interleaves several element kinds under one parent.
+
+def tag_filter() {
+    print("=== Section 4: tag-filtered walk ===\n")
+    let mixed = ("<fleet>" +
+        "<car id=\"10\" make=\"Mazda\" price=\"26000.0\"/>" +
+        "<note>service due</note>" +
+        "<car id=\"11\" make=\"Honda\" price=\"24000.0\"/>" +
+        "</fleet>")
+    parse_xml(mixed) $(doc, ok) {
+        if (!ok) return
+        let root = doc.document_element
+        let ids <- [for (car in from_xml_node(root, "car", type<Car>)); car.id]
+        print("  car ids (note skipped): {ids}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — Lifetime: results outlive the document
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Rows are owned values (strings cloned out of the document), so collecting them
+// with to_array and using them AFTER the RAII block closes is safe.
+
+def lifetime() {
+    print("=== Section 5: results outlive the document ===\n")
+    var inventory : array<Car>
+    parse_xml(CATALOG) $(doc, ok) {
+        if (!ok) return
+        let root = doc.document_element
+        // to_array consumes the iterator outside a for-loop → unsafe (the
+        // [unsafe_outside_of_for] iterator rule); the result is plain owned data
+        unsafe {
+            inventory <- from_xml_node(root, type<Car>) |> to_array()
+        }
+    }
+    // doc is freed here — inventory and its strings remain valid
+    print("  captured {length(inventory)} cars; first make = {inventory[0].make}\n")
+}
+
+[export]
+def main() {
+    basics()
+    comprehensions()
+    aggregates()
+    tag_filter()
+    lifetime()
+}

--- a/tutorials/dasPUGIXML/05_linq_over_xml.das
+++ b/tutorials/dasPUGIXML/05_linq_over_xml.das
@@ -126,7 +126,9 @@ def tag_filter() {
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Rows are owned values (strings cloned out of the document), so collecting them
-// with to_array and using them AFTER the RAII block closes is safe.
+// and using them AFTER the RAII block closes is safe. A for-loop is the safe way
+// to consume the iterator (to_array would need an `unsafe` block — the
+// [unsafe_outside_of_for] rule — since it consumes the iterator outside a for).
 
 def lifetime() {
     print("=== Section 5: results outlive the document ===\n")
@@ -134,10 +136,8 @@ def lifetime() {
     parse_xml(CATALOG) $(doc, ok) {
         if (!ok) return
         let root = doc.document_element
-        // to_array consumes the iterator outside a for-loop → unsafe (the
-        // [unsafe_outside_of_for] iterator rule); the result is plain owned data
-        unsafe {
-            inventory <- from_xml_node(root, type<Car>) |> to_array()
+        for (car in from_xml_node(root, type<Car>)) {
+            inventory |> push(car)
         }
     }
     // doc is freed here — inventory and its strings remain valid

--- a/utils/mcp/main.das
+++ b/utils/mcp/main.das
@@ -16,6 +16,7 @@ options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 
 require protocol public
+require strings
 
 [export]
 def main() {
@@ -57,8 +58,18 @@ def main() {
 
         if (empty(msg)) continue
 
-        let response = dispatch_jsonrpc(msg)
+        var response = dispatch_jsonrpc(msg)
         if (!empty(response)) {
+            // A JSON-RPC frame is one line; the trailing "\n" below is the only
+            // delimiter. Embedded newlines mean stray output (a subtool GC-leak
+            // dump, a panic backtrace, a stray print) leaked into the payload and
+            // would desync the client's line framing for the rest of the session.
+            // Collapse to a single line so only this one request fails, not the
+            // stream, and log it loudly so the leak is diagnosable.
+            if (find(response, "\n") >= 0) {
+                logger_error("mcp.frame", "response contains embedded newline(s) — stray output leaked into JSON-RPC frame; collapsing to keep the stream aligned. preview: {slice(response, 0, 240)}")
+                response = replace(response, "\n", "\\n")
+            }
             fprint(sout, response)
             fprint(sout, "\n")
             fflush(sout)

--- a/utils/mcp/subtools/aot.das
+++ b/utils/mcp/subtools/aot.das
@@ -32,7 +32,7 @@ def collect_aot_functions(program : smart_ptr<Program>) : array<AotFuncInfo> {
                     write(w, "; ")
                 }
                 first = false
-                write(w, "{string(fn.arguments[i].name)} : {describe(fn.arguments[i]._type)}")
+                write(w, "{fn.arguments[i].name} : {describe(fn.arguments[i]._type)}")
             }
             write(w, ")")
             if (fn.result != null && !fn.result.isVoid) {
@@ -129,5 +129,10 @@ def main {
     let file = args[0]
     let func_name = args[1]
     let project = args[2]
-    print(run_aot(file, func_name, project))
+    // run_aot -> run_aot_function builds AST during C++ codegen; without this
+    // guard those nodes leak and the GC dumps "GC APP LEAK ..." to stdout on
+    // exit, corrupting the JSON-RPC frame the MCP server sends to the client.
+    ast_gc_guard() {
+        print(run_aot(file, func_name, project))
+    }
 }


### PR DESCRIPTION
## What

Adds `from_xml_node(node, type<Row>) : iterator<Row>` to `pugixml/PUGIXML_boost` — a typed, lazy LINQ source over an XML node's child elements. Each child materializes into a `Row` by reading **same-named attributes**, so comprehensions / `linq_boost` run straight over an XML document:

```das
struct Car { id : int; make : string; price : float; year : int = 2000 }

for (car in from_xml_node(root, type<Car>)) { ... }
let cheap <- [for (car in from_xml_node(root, type<Car>)); car.make; where car.price < 30000.0]
let cars  <- unsafe(from_xml_node(root, "car", type<Car>) |> to_array())   // tag-filtered + collect
```

This is **pass 1** of the LINQ-over-XML work (the next adapter for the `linq_fold` source abstraction): **zero `linq_fold` code** — `from_xml_node` is a plain generic iterator. It's the XML analogue of the `m1` baseline lane — the un-fused reference the fused `_fold` XML lane (pass 2) will be measured against.

## Design (v1)

- **Generic, not a macro.** `default<TT>` preserves struct field initializers and `apply` exposes them, so a runtime reflection function recovers the `= 2000` default for free. The pass-2 fused path reuses the same `build_xml_row` — no macro in either pass.
- **Attributes-by-convention.** Each field maps to a same-named attribute. Supported scalar types: `int`, `uint`, `float`, `double`, `bool`, `string` (private per-type `read_xml_attr` overloads + a generic fallback that keeps the default for unsupported types). Child-element / text mapping via `@xml_*` field annotations is the documented growth path — `apply` already exposes `annotations`.
- **Defaults preserved.** A missing attribute leaves the field at its declared default (the field value is passed as the accessor's fallback).
- **Lifetime-safe.** Rows are owned values — string fields are cloned out of the document — so results collected with `to_array` / a comprehension stay valid **past** the `parse_xml` / `open_xml` RAII block. No raw `xml_node` escapes.
- `from_xml_node` is `[unsafe_outside_of_for]`: a `for` loop and a comprehension are safe; piping into `to_array` outside a `for` needs `unsafe`.

## Contents (5 commits + bundled MCP fix, unsquashed for bisect)

1. **impl + test** — `from_xml_node` (×2) + `build_xml_row` in `PUGIXML_boost.das`; new `tests/dasPUGIXML/test_from_xml_node.das` (6 scalar types, default fallback, tag-filter, lifetime-escape, for-loop + comprehension). Also narrows one pre-existing `STYLE025` unsafe block in the `from_XML` variant case (touching the file pulls it into CI's lint scope).
2. **doc grouping** — `das2rst.das` "LINQ source" group so the new functions aren't "Uncategorized".
3. **tutorial** — `tutorials/dasPUGIXML/05_linq_over_xml.das` + companion RST + toctree + `04`'s seealso forward-link.
4. **benchmarks** — `_common.das` `fixture_xml_string`; a 4th **XML (m5)** lane (un-fused baseline) on 5 single-source files; `results.md` gains the XML column; README updated.
5. **skills/xml.md** — new "LINQ source" section.
6. **mcp** *(bundled)* — fix the `aot` subtool's GC-leak dump corrupting the JSON-RPC frame.

## Benchmark numbers (n=100k, ns/op)

| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | **XML (m5)** | INTERP/JIT |
|---|---:|---:|---:|---:|---|
| `select_where_count` | 32.8 / 32.5 | 5.2 / 0.4 | 7.4 / 0.6 | **357.3 / 149.5** | full scan |
| `aggregate_match` | 34.9 / 34.1 | 5.9 / 0.4 | 5.9 / 0.6 | **356.0 / 154.3** | full scan |
| `single_match` | 0.0 / 0.0 | 2.9 / 0.4 | 5.4 / 1.1 | **0.2 / 0.1** | early break |
| `take_count_filtered` | — | 0.2 / 0.0 | 0.2 / 0.0 | **7.1 / 3.4** | early break |

Full-scan XML is ~50–70× the fused lanes because `from_xml_node` materializes a whole `Car` per element — including a `name` string clone the query never reads (100k string clones/scan: `888890 SB/op`). That per-element materialization is exactly what the pass-2 fused lane (`m5f`) will elide; early-exit queries are already competitive.

## Verification

- Lint (CI-equivalent) — **0 issues**, 12 changed `.das` files.
- `tests/dasPUGIXML/` — **407 pass**, 0 fail.
- JIT smoke — no verifier errors.
- AOT — emitter produces valid C++ for both `from_xml_node` instantiations (generator → `Sequence`, same lowering as `each_child`); full `test_aot` runs in CI.
- `das2rst` regen clean (no stubs, no Uncategorized); clean Sphinx build, 0 warnings.
- Tutorial runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)