### PR TITLE
parser: optional require — `require ?guard target`

### DIFF
--- a/doc/source/reference/language/modules.rst
+++ b/doc/source/reference/language/modules.rst
@@ -62,6 +62,44 @@ In project mode, regular ``.das`` source files have their requires routed
 through ``module_get``; projects that want the same file-path convenience
 must implement it inside their own resolver.
 
+-----------------
+Optional requires
+-----------------
+
+A ``require`` may be **guarded** by a module name written as ``?guard`` directly
+after the ``require`` keyword:
+
+.. code-block:: das
+
+    require ?pugixml pugixml/PUGIXML_boost      // only if module `pugixml` is available
+    require ?pugixml pugixml/PUGIXML_boost public
+
+The require loads its target **only when the guard module is available** (linked
+into this build / registered). When the guard is *absent*, the require is
+**skipped silently** — no dependency is added and no error is raised, even if the
+target itself does not exist. When the guard is *present*, the require behaves
+exactly like an ordinary require, so a missing target still produces the usual
+``missing prerequisite`` error (the guard never masks a genuine resolution
+failure).
+
+The guard module is named separately from the target on purpose: the condition
+to load (``pugixml`` — the C++ module that makes the path resolvable) is distinct
+from what is loaded (``pugixml/PUGIXML_boost``, whose own module name is
+``PUGIXML_boost``).
+
+Pair it with :ref:`typeinfo builtin_module_exists <generic_programming>` to guard
+code that uses the optional target's symbols — ``static_if`` drops the untaken
+branch before name resolution, so the symbols are referenced only when present:
+
+.. code-block:: das
+
+    require ?pugixml pugixml/PUGIXML_boost
+
+    static_if (typeinfo builtin_module_exists(pugixml)) {
+        // resolved only when pugixml is available
+        parse_xml("<root/>") $(doc, ok) { /* ... */ }
+    }
+
 --------------
 Native modules
 --------------

--- a/doc/source/reference/language/modules.rst
+++ b/doc/source/reference/language/modules.rst
@@ -67,7 +67,8 @@ Optional requires
 -----------------
 
 A ``require`` may be **guarded** by a module name written as ``?guard`` directly
-after the ``require`` keyword:
+after the ``require`` keyword (gen2 syntax only — the guard form is not accepted
+under the v1 ``options gen2 = false`` parser):
 
 .. code-block:: das
 

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -77,6 +77,18 @@ For these:
 - **`return <- expr`**: Moves value to return slot and zeroes `expr`. If `expr` is a `&` ref parameter, this zeroes the *caller's* variable since they share memory.
 - **Visitor adapters** (`make_visitor` returns `VisitorAdapterPtr`) need `var inscope adapter <- make_visitor(*v)` and an `unsafe` block at the call site — see `daslib/ast.das` for examples.
 
+## Macro modules each compile into their own context — cross-module registration is intra-context only
+
+Each macro-bearing module is `simulate`d into its **own context** at compile time; its macros run via `invoke_in_context`. Compile-time globals a macro mutates (a pattern/registry table, an adapter list, any `[_macro]`-populated state) live in **that module's** context. A macro in module B **cannot** push state into module A's compile-time registry by calling A's functions — the two run in **separate contexts**, so it would require marshalling the value across the context boundary through the `invoke_in_context` transport layer (copying data between heaps, no shared pointers). Registering a closure/adapter/AST builder that way is impractical: **there is no "self-registration" of macro state across modules.**
+
+The practical pattern: to contribute macro-time state into module A's registry, the contributing code must **compile into A's context** — i.e. **A `require`s the contributor**, pulling its definitions in. Direction is *consumer → contributor*, never contributor-self-registers-into-consumer. (Example: the linq_fold engine's `splice_patterns` table lives in linq_fold's macro context, so a source adapter for an external module is pulled in via `linq_fold` requiring the adapter file — not the module registering itself.)
+
+This forces a hard `require` even when the dependency is logically optional / inverted (core requiring an external module). Make it conditional **later** with two pieces, both currently net-new machinery (verify/implement before relying on them):
+- an **optional require** (require a module only if it's available — a plain top-level `require` is resolved at module-resolution time, *before* `static_if`, so `static_if` alone can't gate it), and
+- a **`static_if typeinfo has_module(...)`**-style guard around the registration call and any dispatcher branch that names the contributor's symbols. As of 2026-05, no `has_module` typeinfo exists yet — adding it is C++-side work.
+
+Note adapters can still *emit* code referencing the contributor's symbols by name (resolved at the user's splice site, like linq_fold_decs emitting `for_each_archetype` without requiring decs) — that's orthogonal to *registering* into the consumer's macro state, which is the part bound by the context model.
+
 ## Structure macros — generating types and functions
 
 - **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -83,9 +83,9 @@ Each macro-bearing module is `simulate`d into its **own context** at compile tim
 
 The practical pattern: to contribute macro-time state into module A's registry, the contributing code must **compile into A's context** — i.e. **A `require`s the contributor**, pulling its definitions in. Direction is *consumer → contributor*, never contributor-self-registers-into-consumer. (Example: the linq_fold engine's `splice_patterns` table lives in linq_fold's macro context, so a source adapter for an external module is pulled in via `linq_fold` requiring the adapter file — not the module registering itself.)
 
-This forces a hard `require` even when the dependency is logically optional / inverted (core requiring an external module). Make it conditional **later** with two pieces, both currently net-new machinery (verify/implement before relying on them):
-- an **optional require** (require a module only if it's available — a plain top-level `require` is resolved at module-resolution time, *before* `static_if`, so `static_if` alone can't gate it), and
-- a **`static_if typeinfo has_module(...)`**-style guard around the registration call and any dispatcher branch that names the contributor's symbols. As of 2026-05, no `has_module` typeinfo exists yet — adding it is C++-side work.
+This forces a hard `require` even when the dependency is logically optional / inverted (core requiring an external module). Make it conditional with two pieces (both available):
+- an **optional require** — `require ?<guard> <target>` (gen2) requires `<target>` only when module `<guard>` is available, and skips silently otherwise (a plain top-level `require` resolves at module-resolution time, *before* `static_if`, so `static_if` alone can't gate it — this is what the `?guard` form solves). See `doc/source/reference/language/modules.rst` "Optional requires".
+- a **`static_if (typeinfo builtin_module_exists(<guard>))`** guard around the registration call and any dispatcher branch that names the contributor's symbols (the `static_if` drops its untaken branch before name resolution, so the symbols resolve only when the module is present).
 
 Note adapters can still *emit* code referencing the contributor's symbols by name (resolved at the user's splice site, like linq_fold_decs emitting `for_each_archetype` without requiring decs) — that's orthogonal to *registering* into the consumer's macro state, which is the part bound by the context model.
 

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -152,6 +152,27 @@ namespace das {
                             if ( src >= src_end ) {
                                 continue;
                             }
+                            // Optional require `require ?guard target`: parse the guard module name.
+                            // When the guard module is unavailable, skip this require entirely (no
+                            // dependency collected, no error). Only `require` is guarded, not `include`.
+                            string reqGuard;
+                            bool hasReqGuard = false;
+                            if ( isReq && src[0]=='?' ) {
+                                hasReqGuard = true;
+                                src ++; // skip '?'
+                                while ( src < src_end && (src[0]==' ' || src[0]=='\t') ) {
+                                    src ++;
+                                }
+                                while ( src < src_end && (isalnumE(src[0]) || src[0]=='_') ) {
+                                    reqGuard += *src ++;
+                                }
+                                while ( src < src_end && (src[0]==' ' || src[0]=='\t') ) {
+                                    src ++;
+                                }
+                                if ( src >= src_end ) {
+                                    continue;
+                                }
+                            }
                             if ( src[0]=='_' || isalphaE(src[0]) || src[0] == '%' || src[0] == '.' || src[0]=='/' ) {
                                 string mod;
                                 mod += *src++;
@@ -159,6 +180,10 @@ namespace das {
                                     mod += *src ++;
                                 }
                                 if ( isReq ) {
+                                    // guarded optional require whose guard module is absent — skip
+                                    if ( hasReqGuard && Module::requireEx(reqGuard, false)==nullptr ) {
+                                        continue;
+                                    }
                                     bool isPublic = false;
                                     while ( src < src_end && src[0] == ' ' ) {
                                         src ++;

--- a/src/parser/ds2_parser.cpp
+++ b/src/parser/ds2_parser.cpp
@@ -366,308 +366,309 @@ enum yysymbol_kind_t
   YYSYMBOL_options_declaration = 227,      /* options_declaration  */
   YYSYMBOL_require_declaration = 228,      /* require_declaration  */
   YYSYMBOL_require_module_name = 229,      /* require_module_name  */
-  YYSYMBOL_require_module = 230,           /* require_module  */
-  YYSYMBOL_is_public_module = 231,         /* is_public_module  */
-  YYSYMBOL_expect_declaration = 232,       /* expect_declaration  */
-  YYSYMBOL_expect_list = 233,              /* expect_list  */
-  YYSYMBOL_expect_error = 234,             /* expect_error  */
-  YYSYMBOL_expression_label = 235,         /* expression_label  */
-  YYSYMBOL_expression_goto = 236,          /* expression_goto  */
-  YYSYMBOL_elif_or_static_elif = 237,      /* elif_or_static_elif  */
-  YYSYMBOL_emit_semis = 238,               /* emit_semis  */
-  YYSYMBOL_optional_emit_semis = 239,      /* optional_emit_semis  */
-  YYSYMBOL_expression_else = 240,          /* expression_else  */
-  YYSYMBOL_241_3 = 241,                    /* $@3  */
-  YYSYMBOL_242_4 = 242,                    /* $@4  */
-  YYSYMBOL_if_or_static_if = 243,          /* if_or_static_if  */
-  YYSYMBOL_expression_else_one_liner = 244, /* expression_else_one_liner  */
-  YYSYMBOL_expression_if_one_liner = 245,  /* expression_if_one_liner  */
-  YYSYMBOL_semis = 246,                    /* semis  */
-  YYSYMBOL_optional_semis = 247,           /* optional_semis  */
-  YYSYMBOL_expression_if_block = 248,      /* expression_if_block  */
-  YYSYMBOL_249_5 = 249,                    /* $@5  */
-  YYSYMBOL_250_6 = 250,                    /* $@6  */
-  YYSYMBOL_251_7 = 251,                    /* $@7  */
-  YYSYMBOL_expression_else_block = 252,    /* expression_else_block  */
-  YYSYMBOL_253_8 = 253,                    /* $@8  */
-  YYSYMBOL_254_9 = 254,                    /* $@9  */
-  YYSYMBOL_255_10 = 255,                   /* $@10  */
-  YYSYMBOL_expression_if_then_else = 256,  /* expression_if_then_else  */
-  YYSYMBOL_257_11 = 257,                   /* $@11  */
-  YYSYMBOL_258_12 = 258,                   /* $@12  */
-  YYSYMBOL_expression_if_then_else_oneliner = 259, /* expression_if_then_else_oneliner  */
-  YYSYMBOL_for_variable_name_with_pos_list = 260, /* for_variable_name_with_pos_list  */
-  YYSYMBOL_expression_for_loop = 261,      /* expression_for_loop  */
-  YYSYMBOL_262_13 = 262,                   /* $@13  */
-  YYSYMBOL_expression_unsafe = 263,        /* expression_unsafe  */
-  YYSYMBOL_expression_while_loop = 264,    /* expression_while_loop  */
-  YYSYMBOL_265_14 = 265,                   /* $@14  */
-  YYSYMBOL_expression_with = 266,          /* expression_with  */
-  YYSYMBOL_267_15 = 267,                   /* $@15  */
-  YYSYMBOL_expression_with_alias = 268,    /* expression_with_alias  */
-  YYSYMBOL_annotation_argument_value = 269, /* annotation_argument_value  */
-  YYSYMBOL_annotation_argument_value_list = 270, /* annotation_argument_value_list  */
-  YYSYMBOL_annotation_argument_name = 271, /* annotation_argument_name  */
-  YYSYMBOL_annotation_argument = 272,      /* annotation_argument  */
-  YYSYMBOL_annotation_argument_list = 273, /* annotation_argument_list  */
-  YYSYMBOL_metadata_argument_list = 274,   /* metadata_argument_list  */
-  YYSYMBOL_optional_for_annotations = 275, /* optional_for_annotations  */
-  YYSYMBOL_annotation_declaration_name = 276, /* annotation_declaration_name  */
-  YYSYMBOL_annotation_declaration_basic = 277, /* annotation_declaration_basic  */
-  YYSYMBOL_annotation_declaration = 278,   /* annotation_declaration  */
-  YYSYMBOL_annotation_list = 279,          /* annotation_list  */
-  YYSYMBOL_optional_annotation_list = 280, /* optional_annotation_list  */
-  YYSYMBOL_optional_annotation_list_with_emit_semis = 281, /* optional_annotation_list_with_emit_semis  */
-  YYSYMBOL_optional_function_argument_list = 282, /* optional_function_argument_list  */
-  YYSYMBOL_optional_function_type = 283,   /* optional_function_type  */
-  YYSYMBOL_function_name = 284,            /* function_name  */
-  YYSYMBOL_das_type_name = 285,            /* das_type_name  */
-  YYSYMBOL_optional_template = 286,        /* optional_template  */
-  YYSYMBOL_global_function_declaration = 287, /* global_function_declaration  */
-  YYSYMBOL_optional_public_or_private_function = 288, /* optional_public_or_private_function  */
-  YYSYMBOL_function_declaration_header = 289, /* function_declaration_header  */
-  YYSYMBOL_function_declaration = 290,     /* function_declaration  */
-  YYSYMBOL_291_16 = 291,                   /* $@16  */
-  YYSYMBOL_expression_block_finally = 292, /* expression_block_finally  */
-  YYSYMBOL_293_17 = 293,                   /* $@17  */
-  YYSYMBOL_294_18 = 294,                   /* $@18  */
-  YYSYMBOL_expression_block = 295,         /* expression_block  */
-  YYSYMBOL_296_19 = 296,                   /* $@19  */
-  YYSYMBOL_297_20 = 297,                   /* $@20  */
-  YYSYMBOL_expr_call_pipe_no_bracket = 298, /* expr_call_pipe_no_bracket  */
-  YYSYMBOL_expression_any = 299,           /* expression_any  */
-  YYSYMBOL_300_21 = 300,                   /* $@21  */
-  YYSYMBOL_301_22 = 301,                   /* $@22  */
-  YYSYMBOL_expressions = 302,              /* expressions  */
-  YYSYMBOL_optional_expr_list = 303,       /* optional_expr_list  */
-  YYSYMBOL_optional_expr_map_tuple_list = 304, /* optional_expr_map_tuple_list  */
-  YYSYMBOL_type_declaration_no_options_list = 305, /* type_declaration_no_options_list  */
-  YYSYMBOL_name_in_namespace = 306,        /* name_in_namespace  */
-  YYSYMBOL_expression_delete = 307,        /* expression_delete  */
-  YYSYMBOL_new_type_declaration = 308,     /* new_type_declaration  */
-  YYSYMBOL_309_23 = 309,                   /* $@23  */
-  YYSYMBOL_310_24 = 310,                   /* $@24  */
-  YYSYMBOL_expr_new = 311,                 /* expr_new  */
-  YYSYMBOL_expression_break = 312,         /* expression_break  */
-  YYSYMBOL_expression_continue = 313,      /* expression_continue  */
-  YYSYMBOL_expression_return = 314,        /* expression_return  */
-  YYSYMBOL_expression_yield = 315,         /* expression_yield  */
-  YYSYMBOL_expression_try_catch = 316,     /* expression_try_catch  */
-  YYSYMBOL_kwd_let_var_or_nothing = 317,   /* kwd_let_var_or_nothing  */
-  YYSYMBOL_kwd_let = 318,                  /* kwd_let  */
-  YYSYMBOL_optional_in_scope = 319,        /* optional_in_scope  */
-  YYSYMBOL_tuple_expansion = 320,          /* tuple_expansion  */
-  YYSYMBOL_tuple_expansion_variable_declaration = 321, /* tuple_expansion_variable_declaration  */
-  YYSYMBOL_expression_let = 322,           /* expression_let  */
-  YYSYMBOL_expr_cast = 323,                /* expr_cast  */
-  YYSYMBOL_324_25 = 324,                   /* $@25  */
-  YYSYMBOL_325_26 = 325,                   /* $@26  */
-  YYSYMBOL_326_27 = 326,                   /* $@27  */
-  YYSYMBOL_327_28 = 327,                   /* $@28  */
-  YYSYMBOL_328_29 = 328,                   /* $@29  */
-  YYSYMBOL_329_30 = 329,                   /* $@30  */
-  YYSYMBOL_expr_type_decl = 330,           /* expr_type_decl  */
-  YYSYMBOL_331_31 = 331,                   /* $@31  */
-  YYSYMBOL_332_32 = 332,                   /* $@32  */
-  YYSYMBOL_expr_type_info = 333,           /* expr_type_info  */
-  YYSYMBOL_expr_list = 334,                /* expr_list  */
-  YYSYMBOL_block_or_simple_block = 335,    /* block_or_simple_block  */
-  YYSYMBOL_block_or_lambda = 336,          /* block_or_lambda  */
-  YYSYMBOL_capture_entry = 337,            /* capture_entry  */
-  YYSYMBOL_capture_list = 338,             /* capture_list  */
-  YYSYMBOL_optional_capture_list = 339,    /* optional_capture_list  */
-  YYSYMBOL_expr_full_block = 340,          /* expr_full_block  */
-  YYSYMBOL_expr_full_block_assumed_piped = 341, /* expr_full_block_assumed_piped  */
-  YYSYMBOL_expr_numeric_const = 342,       /* expr_numeric_const  */
-  YYSYMBOL_expr_assign_no_bracket = 343,   /* expr_assign_no_bracket  */
-  YYSYMBOL_expr_named_call = 344,          /* expr_named_call  */
-  YYSYMBOL_expr_method_call_no_bracket = 345, /* expr_method_call_no_bracket  */
-  YYSYMBOL_func_addr_name = 346,           /* func_addr_name  */
-  YYSYMBOL_func_addr_expr = 347,           /* func_addr_expr  */
-  YYSYMBOL_348_33 = 348,                   /* $@33  */
-  YYSYMBOL_349_34 = 349,                   /* $@34  */
-  YYSYMBOL_350_35 = 350,                   /* $@35  */
-  YYSYMBOL_351_36 = 351,                   /* $@36  */
-  YYSYMBOL_expr_field_no_bracket = 352,    /* expr_field_no_bracket  */
-  YYSYMBOL_353_37 = 353,                   /* $@37  */
-  YYSYMBOL_354_38 = 354,                   /* $@38  */
-  YYSYMBOL_expr_call = 355,                /* expr_call  */
-  YYSYMBOL_expr = 356,                     /* expr  */
-  YYSYMBOL_expr_no_bracket = 357,          /* expr_no_bracket  */
-  YYSYMBOL_358_39 = 358,                   /* $@39  */
-  YYSYMBOL_359_40 = 359,                   /* $@40  */
-  YYSYMBOL_360_41 = 360,                   /* $@41  */
-  YYSYMBOL_361_42 = 361,                   /* $@42  */
-  YYSYMBOL_362_43 = 362,                   /* $@43  */
-  YYSYMBOL_363_44 = 363,                   /* $@44  */
-  YYSYMBOL_expr_generator = 364,           /* expr_generator  */
-  YYSYMBOL_expr_mtag_no_bracket = 365,     /* expr_mtag_no_bracket  */
-  YYSYMBOL_optional_field_annotation = 366, /* optional_field_annotation  */
-  YYSYMBOL_optional_override = 367,        /* optional_override  */
-  YYSYMBOL_optional_constant = 368,        /* optional_constant  */
-  YYSYMBOL_optional_public_or_private_member_variable = 369, /* optional_public_or_private_member_variable  */
-  YYSYMBOL_optional_static_member_variable = 370, /* optional_static_member_variable  */
-  YYSYMBOL_structure_variable_declaration = 371, /* structure_variable_declaration  */
-  YYSYMBOL_struct_variable_declaration_list = 372, /* struct_variable_declaration_list  */
-  YYSYMBOL_373_45 = 373,                   /* $@45  */
-  YYSYMBOL_374_46 = 374,                   /* $@46  */
-  YYSYMBOL_375_47 = 375,                   /* $@47  */
-  YYSYMBOL_function_argument_declaration_no_type = 376, /* function_argument_declaration_no_type  */
-  YYSYMBOL_function_argument_declaration_type = 377, /* function_argument_declaration_type  */
-  YYSYMBOL_function_argument_list = 378,   /* function_argument_list  */
-  YYSYMBOL_tuple_type = 379,               /* tuple_type  */
-  YYSYMBOL_tuple_type_list = 380,          /* tuple_type_list  */
-  YYSYMBOL_tuple_alias_type_list = 381,    /* tuple_alias_type_list  */
-  YYSYMBOL_variant_type = 382,             /* variant_type  */
-  YYSYMBOL_variant_type_list = 383,        /* variant_type_list  */
-  YYSYMBOL_variant_alias_type_list = 384,  /* variant_alias_type_list  */
-  YYSYMBOL_copy_or_move = 385,             /* copy_or_move  */
-  YYSYMBOL_variable_declaration_no_type = 386, /* variable_declaration_no_type  */
-  YYSYMBOL_variable_declaration_type = 387, /* variable_declaration_type  */
-  YYSYMBOL_variable_declaration = 388,     /* variable_declaration  */
-  YYSYMBOL_copy_or_move_or_clone = 389,    /* copy_or_move_or_clone  */
-  YYSYMBOL_optional_ref = 390,             /* optional_ref  */
-  YYSYMBOL_let_variable_name_with_pos_list = 391, /* let_variable_name_with_pos_list  */
-  YYSYMBOL_global_let_variable_name_with_pos_list = 392, /* global_let_variable_name_with_pos_list  */
-  YYSYMBOL_variable_declaration_list = 393, /* variable_declaration_list  */
-  YYSYMBOL_let_variable_declaration = 394, /* let_variable_declaration  */
-  YYSYMBOL_global_let_variable_declaration = 395, /* global_let_variable_declaration  */
-  YYSYMBOL_optional_shared = 396,          /* optional_shared  */
-  YYSYMBOL_optional_public_or_private_variable = 397, /* optional_public_or_private_variable  */
-  YYSYMBOL_global_variable_declaration_list = 398, /* global_variable_declaration_list  */
-  YYSYMBOL_399_48 = 399,                   /* $@48  */
-  YYSYMBOL_global_let = 400,               /* global_let  */
-  YYSYMBOL_401_49 = 401,                   /* $@49  */
-  YYSYMBOL_enum_expression = 402,          /* enum_expression  */
-  YYSYMBOL_commas = 403,                   /* commas  */
-  YYSYMBOL_enum_list = 404,                /* enum_list  */
-  YYSYMBOL_optional_public_or_private_alias = 405, /* optional_public_or_private_alias  */
-  YYSYMBOL_single_alias = 406,             /* single_alias  */
-  YYSYMBOL_407_50 = 407,                   /* $@50  */
-  YYSYMBOL_alias_declaration = 408,        /* alias_declaration  */
-  YYSYMBOL_optional_public_or_private_enum = 409, /* optional_public_or_private_enum  */
-  YYSYMBOL_enum_name = 410,                /* enum_name  */
-  YYSYMBOL_optional_enum_basic_type_declaration = 411, /* optional_enum_basic_type_declaration  */
-  YYSYMBOL_optional_commas = 412,          /* optional_commas  */
-  YYSYMBOL_emit_commas = 413,              /* emit_commas  */
-  YYSYMBOL_optional_emit_commas = 414,     /* optional_emit_commas  */
-  YYSYMBOL_enum_declaration = 415,         /* enum_declaration  */
-  YYSYMBOL_416_51 = 416,                   /* $@51  */
-  YYSYMBOL_417_52 = 417,                   /* $@52  */
-  YYSYMBOL_418_53 = 418,                   /* $@53  */
-  YYSYMBOL_optional_structure_parent = 419, /* optional_structure_parent  */
-  YYSYMBOL_optional_sealed = 420,          /* optional_sealed  */
-  YYSYMBOL_structure_name = 421,           /* structure_name  */
-  YYSYMBOL_class_or_struct = 422,          /* class_or_struct  */
-  YYSYMBOL_optional_public_or_private_structure = 423, /* optional_public_or_private_structure  */
-  YYSYMBOL_optional_struct_variable_declaration_list = 424, /* optional_struct_variable_declaration_list  */
-  YYSYMBOL_structure_declaration = 425,    /* structure_declaration  */
-  YYSYMBOL_426_54 = 426,                   /* $@54  */
-  YYSYMBOL_427_55 = 427,                   /* $@55  */
-  YYSYMBOL_428_56 = 428,                   /* $@56  */
-  YYSYMBOL_variable_name_with_pos_list = 429, /* variable_name_with_pos_list  */
-  YYSYMBOL_basic_type_declaration = 430,   /* basic_type_declaration  */
-  YYSYMBOL_enum_basic_type_declaration = 431, /* enum_basic_type_declaration  */
-  YYSYMBOL_structure_type_declaration = 432, /* structure_type_declaration  */
-  YYSYMBOL_auto_type_declaration = 433,    /* auto_type_declaration  */
-  YYSYMBOL_bitfield_bits = 434,            /* bitfield_bits  */
-  YYSYMBOL_bitfield_alias_bits = 435,      /* bitfield_alias_bits  */
-  YYSYMBOL_bitfield_basic_type_declaration = 436, /* bitfield_basic_type_declaration  */
-  YYSYMBOL_bitfield_type_declaration = 437, /* bitfield_type_declaration  */
-  YYSYMBOL_438_57 = 438,                   /* $@57  */
-  YYSYMBOL_439_58 = 439,                   /* $@58  */
-  YYSYMBOL_c_or_s = 440,                   /* c_or_s  */
-  YYSYMBOL_table_type_pair = 441,          /* table_type_pair  */
-  YYSYMBOL_dim_list = 442,                 /* dim_list  */
-  YYSYMBOL_type_declaration_no_options = 443, /* type_declaration_no_options  */
-  YYSYMBOL_optional_expr_list_in_braces = 444, /* optional_expr_list_in_braces  */
-  YYSYMBOL_type_declaration_no_options_no_dim = 445, /* type_declaration_no_options_no_dim  */
-  YYSYMBOL_446_59 = 446,                   /* $@59  */
-  YYSYMBOL_447_60 = 447,                   /* $@60  */
-  YYSYMBOL_448_61 = 448,                   /* $@61  */
-  YYSYMBOL_449_62 = 449,                   /* $@62  */
-  YYSYMBOL_450_63 = 450,                   /* $@63  */
-  YYSYMBOL_451_64 = 451,                   /* $@64  */
-  YYSYMBOL_452_65 = 452,                   /* $@65  */
-  YYSYMBOL_453_66 = 453,                   /* $@66  */
-  YYSYMBOL_454_67 = 454,                   /* $@67  */
-  YYSYMBOL_455_68 = 455,                   /* $@68  */
-  YYSYMBOL_456_69 = 456,                   /* $@69  */
-  YYSYMBOL_457_70 = 457,                   /* $@70  */
-  YYSYMBOL_458_71 = 458,                   /* $@71  */
-  YYSYMBOL_459_72 = 459,                   /* $@72  */
-  YYSYMBOL_460_73 = 460,                   /* $@73  */
-  YYSYMBOL_461_74 = 461,                   /* $@74  */
-  YYSYMBOL_462_75 = 462,                   /* $@75  */
-  YYSYMBOL_463_76 = 463,                   /* $@76  */
-  YYSYMBOL_464_77 = 464,                   /* $@77  */
-  YYSYMBOL_465_78 = 465,                   /* $@78  */
-  YYSYMBOL_466_79 = 466,                   /* $@79  */
-  YYSYMBOL_467_80 = 467,                   /* $@80  */
-  YYSYMBOL_468_81 = 468,                   /* $@81  */
-  YYSYMBOL_469_82 = 469,                   /* $@82  */
-  YYSYMBOL_470_83 = 470,                   /* $@83  */
-  YYSYMBOL_471_84 = 471,                   /* $@84  */
-  YYSYMBOL_472_85 = 472,                   /* $@85  */
-  YYSYMBOL_473_86 = 473,                   /* $@86  */
-  YYSYMBOL_type_declaration = 474,         /* type_declaration  */
-  YYSYMBOL_tuple_alias_declaration = 475,  /* tuple_alias_declaration  */
-  YYSYMBOL_476_87 = 476,                   /* $@87  */
-  YYSYMBOL_477_88 = 477,                   /* $@88  */
-  YYSYMBOL_478_89 = 478,                   /* $@89  */
-  YYSYMBOL_479_90 = 479,                   /* $@90  */
-  YYSYMBOL_variant_alias_declaration = 480, /* variant_alias_declaration  */
-  YYSYMBOL_481_91 = 481,                   /* $@91  */
-  YYSYMBOL_482_92 = 482,                   /* $@92  */
-  YYSYMBOL_483_93 = 483,                   /* $@93  */
-  YYSYMBOL_484_94 = 484,                   /* $@94  */
-  YYSYMBOL_bitfield_alias_declaration = 485, /* bitfield_alias_declaration  */
-  YYSYMBOL_486_95 = 486,                   /* $@95  */
-  YYSYMBOL_487_96 = 487,                   /* $@96  */
-  YYSYMBOL_488_97 = 488,                   /* $@97  */
-  YYSYMBOL_489_98 = 489,                   /* $@98  */
-  YYSYMBOL_make_decl = 490,                /* make_decl  */
-  YYSYMBOL_make_decl_no_bracket = 491,     /* make_decl_no_bracket  */
-  YYSYMBOL_make_struct_fields = 492,       /* make_struct_fields  */
-  YYSYMBOL_make_variant_dim = 493,         /* make_variant_dim  */
-  YYSYMBOL_make_struct_single = 494,       /* make_struct_single  */
-  YYSYMBOL_make_struct_dim_list = 495,     /* make_struct_dim_list  */
-  YYSYMBOL_make_struct_dim_decl = 496,     /* make_struct_dim_decl  */
-  YYSYMBOL_optional_make_struct_dim_decl = 497, /* optional_make_struct_dim_decl  */
-  YYSYMBOL_use_initializer = 498,          /* use_initializer  */
-  YYSYMBOL_make_struct_decl = 499,         /* make_struct_decl  */
-  YYSYMBOL_500_99 = 500,                   /* $@99  */
-  YYSYMBOL_501_100 = 501,                  /* $@100  */
-  YYSYMBOL_502_101 = 502,                  /* $@101  */
-  YYSYMBOL_503_102 = 503,                  /* $@102  */
-  YYSYMBOL_504_103 = 504,                  /* $@103  */
-  YYSYMBOL_505_104 = 505,                  /* $@104  */
-  YYSYMBOL_506_105 = 506,                  /* $@105  */
-  YYSYMBOL_507_106 = 507,                  /* $@106  */
-  YYSYMBOL_508_107 = 508,                  /* $@107  */
-  YYSYMBOL_509_108 = 509,                  /* $@108  */
-  YYSYMBOL_make_tuple_call = 510,          /* make_tuple_call  */
-  YYSYMBOL_511_109 = 511,                  /* $@109  */
-  YYSYMBOL_512_110 = 512,                  /* $@110  */
-  YYSYMBOL_make_dim_decl = 513,            /* make_dim_decl  */
-  YYSYMBOL_514_111 = 514,                  /* $@111  */
-  YYSYMBOL_515_112 = 515,                  /* $@112  */
-  YYSYMBOL_516_113 = 516,                  /* $@113  */
-  YYSYMBOL_517_114 = 517,                  /* $@114  */
-  YYSYMBOL_518_115 = 518,                  /* $@115  */
-  YYSYMBOL_519_116 = 519,                  /* $@116  */
-  YYSYMBOL_520_117 = 520,                  /* $@117  */
-  YYSYMBOL_521_118 = 521,                  /* $@118  */
-  YYSYMBOL_522_119 = 522,                  /* $@119  */
-  YYSYMBOL_523_120 = 523,                  /* $@120  */
-  YYSYMBOL_expr_map_tuple_list = 524,      /* expr_map_tuple_list  */
-  YYSYMBOL_push_table_nesting = 525,       /* push_table_nesting  */
-  YYSYMBOL_make_table_decl = 526,          /* make_table_decl  */
-  YYSYMBOL_make_table_call = 527,          /* make_table_call  */
-  YYSYMBOL_array_comprehension_where = 528, /* array_comprehension_where  */
-  YYSYMBOL_optional_comma = 529,           /* optional_comma  */
-  YYSYMBOL_table_comprehension = 530,      /* table_comprehension  */
-  YYSYMBOL_array_comprehension = 531       /* array_comprehension  */
+  YYSYMBOL_optional_require_guard = 230,   /* optional_require_guard  */
+  YYSYMBOL_require_module = 231,           /* require_module  */
+  YYSYMBOL_is_public_module = 232,         /* is_public_module  */
+  YYSYMBOL_expect_declaration = 233,       /* expect_declaration  */
+  YYSYMBOL_expect_list = 234,              /* expect_list  */
+  YYSYMBOL_expect_error = 235,             /* expect_error  */
+  YYSYMBOL_expression_label = 236,         /* expression_label  */
+  YYSYMBOL_expression_goto = 237,          /* expression_goto  */
+  YYSYMBOL_elif_or_static_elif = 238,      /* elif_or_static_elif  */
+  YYSYMBOL_emit_semis = 239,               /* emit_semis  */
+  YYSYMBOL_optional_emit_semis = 240,      /* optional_emit_semis  */
+  YYSYMBOL_expression_else = 241,          /* expression_else  */
+  YYSYMBOL_242_3 = 242,                    /* $@3  */
+  YYSYMBOL_243_4 = 243,                    /* $@4  */
+  YYSYMBOL_if_or_static_if = 244,          /* if_or_static_if  */
+  YYSYMBOL_expression_else_one_liner = 245, /* expression_else_one_liner  */
+  YYSYMBOL_expression_if_one_liner = 246,  /* expression_if_one_liner  */
+  YYSYMBOL_semis = 247,                    /* semis  */
+  YYSYMBOL_optional_semis = 248,           /* optional_semis  */
+  YYSYMBOL_expression_if_block = 249,      /* expression_if_block  */
+  YYSYMBOL_250_5 = 250,                    /* $@5  */
+  YYSYMBOL_251_6 = 251,                    /* $@6  */
+  YYSYMBOL_252_7 = 252,                    /* $@7  */
+  YYSYMBOL_expression_else_block = 253,    /* expression_else_block  */
+  YYSYMBOL_254_8 = 254,                    /* $@8  */
+  YYSYMBOL_255_9 = 255,                    /* $@9  */
+  YYSYMBOL_256_10 = 256,                   /* $@10  */
+  YYSYMBOL_expression_if_then_else = 257,  /* expression_if_then_else  */
+  YYSYMBOL_258_11 = 258,                   /* $@11  */
+  YYSYMBOL_259_12 = 259,                   /* $@12  */
+  YYSYMBOL_expression_if_then_else_oneliner = 260, /* expression_if_then_else_oneliner  */
+  YYSYMBOL_for_variable_name_with_pos_list = 261, /* for_variable_name_with_pos_list  */
+  YYSYMBOL_expression_for_loop = 262,      /* expression_for_loop  */
+  YYSYMBOL_263_13 = 263,                   /* $@13  */
+  YYSYMBOL_expression_unsafe = 264,        /* expression_unsafe  */
+  YYSYMBOL_expression_while_loop = 265,    /* expression_while_loop  */
+  YYSYMBOL_266_14 = 266,                   /* $@14  */
+  YYSYMBOL_expression_with = 267,          /* expression_with  */
+  YYSYMBOL_268_15 = 268,                   /* $@15  */
+  YYSYMBOL_expression_with_alias = 269,    /* expression_with_alias  */
+  YYSYMBOL_annotation_argument_value = 270, /* annotation_argument_value  */
+  YYSYMBOL_annotation_argument_value_list = 271, /* annotation_argument_value_list  */
+  YYSYMBOL_annotation_argument_name = 272, /* annotation_argument_name  */
+  YYSYMBOL_annotation_argument = 273,      /* annotation_argument  */
+  YYSYMBOL_annotation_argument_list = 274, /* annotation_argument_list  */
+  YYSYMBOL_metadata_argument_list = 275,   /* metadata_argument_list  */
+  YYSYMBOL_optional_for_annotations = 276, /* optional_for_annotations  */
+  YYSYMBOL_annotation_declaration_name = 277, /* annotation_declaration_name  */
+  YYSYMBOL_annotation_declaration_basic = 278, /* annotation_declaration_basic  */
+  YYSYMBOL_annotation_declaration = 279,   /* annotation_declaration  */
+  YYSYMBOL_annotation_list = 280,          /* annotation_list  */
+  YYSYMBOL_optional_annotation_list = 281, /* optional_annotation_list  */
+  YYSYMBOL_optional_annotation_list_with_emit_semis = 282, /* optional_annotation_list_with_emit_semis  */
+  YYSYMBOL_optional_function_argument_list = 283, /* optional_function_argument_list  */
+  YYSYMBOL_optional_function_type = 284,   /* optional_function_type  */
+  YYSYMBOL_function_name = 285,            /* function_name  */
+  YYSYMBOL_das_type_name = 286,            /* das_type_name  */
+  YYSYMBOL_optional_template = 287,        /* optional_template  */
+  YYSYMBOL_global_function_declaration = 288, /* global_function_declaration  */
+  YYSYMBOL_optional_public_or_private_function = 289, /* optional_public_or_private_function  */
+  YYSYMBOL_function_declaration_header = 290, /* function_declaration_header  */
+  YYSYMBOL_function_declaration = 291,     /* function_declaration  */
+  YYSYMBOL_292_16 = 292,                   /* $@16  */
+  YYSYMBOL_expression_block_finally = 293, /* expression_block_finally  */
+  YYSYMBOL_294_17 = 294,                   /* $@17  */
+  YYSYMBOL_295_18 = 295,                   /* $@18  */
+  YYSYMBOL_expression_block = 296,         /* expression_block  */
+  YYSYMBOL_297_19 = 297,                   /* $@19  */
+  YYSYMBOL_298_20 = 298,                   /* $@20  */
+  YYSYMBOL_expr_call_pipe_no_bracket = 299, /* expr_call_pipe_no_bracket  */
+  YYSYMBOL_expression_any = 300,           /* expression_any  */
+  YYSYMBOL_301_21 = 301,                   /* $@21  */
+  YYSYMBOL_302_22 = 302,                   /* $@22  */
+  YYSYMBOL_expressions = 303,              /* expressions  */
+  YYSYMBOL_optional_expr_list = 304,       /* optional_expr_list  */
+  YYSYMBOL_optional_expr_map_tuple_list = 305, /* optional_expr_map_tuple_list  */
+  YYSYMBOL_type_declaration_no_options_list = 306, /* type_declaration_no_options_list  */
+  YYSYMBOL_name_in_namespace = 307,        /* name_in_namespace  */
+  YYSYMBOL_expression_delete = 308,        /* expression_delete  */
+  YYSYMBOL_new_type_declaration = 309,     /* new_type_declaration  */
+  YYSYMBOL_310_23 = 310,                   /* $@23  */
+  YYSYMBOL_311_24 = 311,                   /* $@24  */
+  YYSYMBOL_expr_new = 312,                 /* expr_new  */
+  YYSYMBOL_expression_break = 313,         /* expression_break  */
+  YYSYMBOL_expression_continue = 314,      /* expression_continue  */
+  YYSYMBOL_expression_return = 315,        /* expression_return  */
+  YYSYMBOL_expression_yield = 316,         /* expression_yield  */
+  YYSYMBOL_expression_try_catch = 317,     /* expression_try_catch  */
+  YYSYMBOL_kwd_let_var_or_nothing = 318,   /* kwd_let_var_or_nothing  */
+  YYSYMBOL_kwd_let = 319,                  /* kwd_let  */
+  YYSYMBOL_optional_in_scope = 320,        /* optional_in_scope  */
+  YYSYMBOL_tuple_expansion = 321,          /* tuple_expansion  */
+  YYSYMBOL_tuple_expansion_variable_declaration = 322, /* tuple_expansion_variable_declaration  */
+  YYSYMBOL_expression_let = 323,           /* expression_let  */
+  YYSYMBOL_expr_cast = 324,                /* expr_cast  */
+  YYSYMBOL_325_25 = 325,                   /* $@25  */
+  YYSYMBOL_326_26 = 326,                   /* $@26  */
+  YYSYMBOL_327_27 = 327,                   /* $@27  */
+  YYSYMBOL_328_28 = 328,                   /* $@28  */
+  YYSYMBOL_329_29 = 329,                   /* $@29  */
+  YYSYMBOL_330_30 = 330,                   /* $@30  */
+  YYSYMBOL_expr_type_decl = 331,           /* expr_type_decl  */
+  YYSYMBOL_332_31 = 332,                   /* $@31  */
+  YYSYMBOL_333_32 = 333,                   /* $@32  */
+  YYSYMBOL_expr_type_info = 334,           /* expr_type_info  */
+  YYSYMBOL_expr_list = 335,                /* expr_list  */
+  YYSYMBOL_block_or_simple_block = 336,    /* block_or_simple_block  */
+  YYSYMBOL_block_or_lambda = 337,          /* block_or_lambda  */
+  YYSYMBOL_capture_entry = 338,            /* capture_entry  */
+  YYSYMBOL_capture_list = 339,             /* capture_list  */
+  YYSYMBOL_optional_capture_list = 340,    /* optional_capture_list  */
+  YYSYMBOL_expr_full_block = 341,          /* expr_full_block  */
+  YYSYMBOL_expr_full_block_assumed_piped = 342, /* expr_full_block_assumed_piped  */
+  YYSYMBOL_expr_numeric_const = 343,       /* expr_numeric_const  */
+  YYSYMBOL_expr_assign_no_bracket = 344,   /* expr_assign_no_bracket  */
+  YYSYMBOL_expr_named_call = 345,          /* expr_named_call  */
+  YYSYMBOL_expr_method_call_no_bracket = 346, /* expr_method_call_no_bracket  */
+  YYSYMBOL_func_addr_name = 347,           /* func_addr_name  */
+  YYSYMBOL_func_addr_expr = 348,           /* func_addr_expr  */
+  YYSYMBOL_349_33 = 349,                   /* $@33  */
+  YYSYMBOL_350_34 = 350,                   /* $@34  */
+  YYSYMBOL_351_35 = 351,                   /* $@35  */
+  YYSYMBOL_352_36 = 352,                   /* $@36  */
+  YYSYMBOL_expr_field_no_bracket = 353,    /* expr_field_no_bracket  */
+  YYSYMBOL_354_37 = 354,                   /* $@37  */
+  YYSYMBOL_355_38 = 355,                   /* $@38  */
+  YYSYMBOL_expr_call = 356,                /* expr_call  */
+  YYSYMBOL_expr = 357,                     /* expr  */
+  YYSYMBOL_expr_no_bracket = 358,          /* expr_no_bracket  */
+  YYSYMBOL_359_39 = 359,                   /* $@39  */
+  YYSYMBOL_360_40 = 360,                   /* $@40  */
+  YYSYMBOL_361_41 = 361,                   /* $@41  */
+  YYSYMBOL_362_42 = 362,                   /* $@42  */
+  YYSYMBOL_363_43 = 363,                   /* $@43  */
+  YYSYMBOL_364_44 = 364,                   /* $@44  */
+  YYSYMBOL_expr_generator = 365,           /* expr_generator  */
+  YYSYMBOL_expr_mtag_no_bracket = 366,     /* expr_mtag_no_bracket  */
+  YYSYMBOL_optional_field_annotation = 367, /* optional_field_annotation  */
+  YYSYMBOL_optional_override = 368,        /* optional_override  */
+  YYSYMBOL_optional_constant = 369,        /* optional_constant  */
+  YYSYMBOL_optional_public_or_private_member_variable = 370, /* optional_public_or_private_member_variable  */
+  YYSYMBOL_optional_static_member_variable = 371, /* optional_static_member_variable  */
+  YYSYMBOL_structure_variable_declaration = 372, /* structure_variable_declaration  */
+  YYSYMBOL_struct_variable_declaration_list = 373, /* struct_variable_declaration_list  */
+  YYSYMBOL_374_45 = 374,                   /* $@45  */
+  YYSYMBOL_375_46 = 375,                   /* $@46  */
+  YYSYMBOL_376_47 = 376,                   /* $@47  */
+  YYSYMBOL_function_argument_declaration_no_type = 377, /* function_argument_declaration_no_type  */
+  YYSYMBOL_function_argument_declaration_type = 378, /* function_argument_declaration_type  */
+  YYSYMBOL_function_argument_list = 379,   /* function_argument_list  */
+  YYSYMBOL_tuple_type = 380,               /* tuple_type  */
+  YYSYMBOL_tuple_type_list = 381,          /* tuple_type_list  */
+  YYSYMBOL_tuple_alias_type_list = 382,    /* tuple_alias_type_list  */
+  YYSYMBOL_variant_type = 383,             /* variant_type  */
+  YYSYMBOL_variant_type_list = 384,        /* variant_type_list  */
+  YYSYMBOL_variant_alias_type_list = 385,  /* variant_alias_type_list  */
+  YYSYMBOL_copy_or_move = 386,             /* copy_or_move  */
+  YYSYMBOL_variable_declaration_no_type = 387, /* variable_declaration_no_type  */
+  YYSYMBOL_variable_declaration_type = 388, /* variable_declaration_type  */
+  YYSYMBOL_variable_declaration = 389,     /* variable_declaration  */
+  YYSYMBOL_copy_or_move_or_clone = 390,    /* copy_or_move_or_clone  */
+  YYSYMBOL_optional_ref = 391,             /* optional_ref  */
+  YYSYMBOL_let_variable_name_with_pos_list = 392, /* let_variable_name_with_pos_list  */
+  YYSYMBOL_global_let_variable_name_with_pos_list = 393, /* global_let_variable_name_with_pos_list  */
+  YYSYMBOL_variable_declaration_list = 394, /* variable_declaration_list  */
+  YYSYMBOL_let_variable_declaration = 395, /* let_variable_declaration  */
+  YYSYMBOL_global_let_variable_declaration = 396, /* global_let_variable_declaration  */
+  YYSYMBOL_optional_shared = 397,          /* optional_shared  */
+  YYSYMBOL_optional_public_or_private_variable = 398, /* optional_public_or_private_variable  */
+  YYSYMBOL_global_variable_declaration_list = 399, /* global_variable_declaration_list  */
+  YYSYMBOL_400_48 = 400,                   /* $@48  */
+  YYSYMBOL_global_let = 401,               /* global_let  */
+  YYSYMBOL_402_49 = 402,                   /* $@49  */
+  YYSYMBOL_enum_expression = 403,          /* enum_expression  */
+  YYSYMBOL_commas = 404,                   /* commas  */
+  YYSYMBOL_enum_list = 405,                /* enum_list  */
+  YYSYMBOL_optional_public_or_private_alias = 406, /* optional_public_or_private_alias  */
+  YYSYMBOL_single_alias = 407,             /* single_alias  */
+  YYSYMBOL_408_50 = 408,                   /* $@50  */
+  YYSYMBOL_alias_declaration = 409,        /* alias_declaration  */
+  YYSYMBOL_optional_public_or_private_enum = 410, /* optional_public_or_private_enum  */
+  YYSYMBOL_enum_name = 411,                /* enum_name  */
+  YYSYMBOL_optional_enum_basic_type_declaration = 412, /* optional_enum_basic_type_declaration  */
+  YYSYMBOL_optional_commas = 413,          /* optional_commas  */
+  YYSYMBOL_emit_commas = 414,              /* emit_commas  */
+  YYSYMBOL_optional_emit_commas = 415,     /* optional_emit_commas  */
+  YYSYMBOL_enum_declaration = 416,         /* enum_declaration  */
+  YYSYMBOL_417_51 = 417,                   /* $@51  */
+  YYSYMBOL_418_52 = 418,                   /* $@52  */
+  YYSYMBOL_419_53 = 419,                   /* $@53  */
+  YYSYMBOL_optional_structure_parent = 420, /* optional_structure_parent  */
+  YYSYMBOL_optional_sealed = 421,          /* optional_sealed  */
+  YYSYMBOL_structure_name = 422,           /* structure_name  */
+  YYSYMBOL_class_or_struct = 423,          /* class_or_struct  */
+  YYSYMBOL_optional_public_or_private_structure = 424, /* optional_public_or_private_structure  */
+  YYSYMBOL_optional_struct_variable_declaration_list = 425, /* optional_struct_variable_declaration_list  */
+  YYSYMBOL_structure_declaration = 426,    /* structure_declaration  */
+  YYSYMBOL_427_54 = 427,                   /* $@54  */
+  YYSYMBOL_428_55 = 428,                   /* $@55  */
+  YYSYMBOL_429_56 = 429,                   /* $@56  */
+  YYSYMBOL_variable_name_with_pos_list = 430, /* variable_name_with_pos_list  */
+  YYSYMBOL_basic_type_declaration = 431,   /* basic_type_declaration  */
+  YYSYMBOL_enum_basic_type_declaration = 432, /* enum_basic_type_declaration  */
+  YYSYMBOL_structure_type_declaration = 433, /* structure_type_declaration  */
+  YYSYMBOL_auto_type_declaration = 434,    /* auto_type_declaration  */
+  YYSYMBOL_bitfield_bits = 435,            /* bitfield_bits  */
+  YYSYMBOL_bitfield_alias_bits = 436,      /* bitfield_alias_bits  */
+  YYSYMBOL_bitfield_basic_type_declaration = 437, /* bitfield_basic_type_declaration  */
+  YYSYMBOL_bitfield_type_declaration = 438, /* bitfield_type_declaration  */
+  YYSYMBOL_439_57 = 439,                   /* $@57  */
+  YYSYMBOL_440_58 = 440,                   /* $@58  */
+  YYSYMBOL_c_or_s = 441,                   /* c_or_s  */
+  YYSYMBOL_table_type_pair = 442,          /* table_type_pair  */
+  YYSYMBOL_dim_list = 443,                 /* dim_list  */
+  YYSYMBOL_type_declaration_no_options = 444, /* type_declaration_no_options  */
+  YYSYMBOL_optional_expr_list_in_braces = 445, /* optional_expr_list_in_braces  */
+  YYSYMBOL_type_declaration_no_options_no_dim = 446, /* type_declaration_no_options_no_dim  */
+  YYSYMBOL_447_59 = 447,                   /* $@59  */
+  YYSYMBOL_448_60 = 448,                   /* $@60  */
+  YYSYMBOL_449_61 = 449,                   /* $@61  */
+  YYSYMBOL_450_62 = 450,                   /* $@62  */
+  YYSYMBOL_451_63 = 451,                   /* $@63  */
+  YYSYMBOL_452_64 = 452,                   /* $@64  */
+  YYSYMBOL_453_65 = 453,                   /* $@65  */
+  YYSYMBOL_454_66 = 454,                   /* $@66  */
+  YYSYMBOL_455_67 = 455,                   /* $@67  */
+  YYSYMBOL_456_68 = 456,                   /* $@68  */
+  YYSYMBOL_457_69 = 457,                   /* $@69  */
+  YYSYMBOL_458_70 = 458,                   /* $@70  */
+  YYSYMBOL_459_71 = 459,                   /* $@71  */
+  YYSYMBOL_460_72 = 460,                   /* $@72  */
+  YYSYMBOL_461_73 = 461,                   /* $@73  */
+  YYSYMBOL_462_74 = 462,                   /* $@74  */
+  YYSYMBOL_463_75 = 463,                   /* $@75  */
+  YYSYMBOL_464_76 = 464,                   /* $@76  */
+  YYSYMBOL_465_77 = 465,                   /* $@77  */
+  YYSYMBOL_466_78 = 466,                   /* $@78  */
+  YYSYMBOL_467_79 = 467,                   /* $@79  */
+  YYSYMBOL_468_80 = 468,                   /* $@80  */
+  YYSYMBOL_469_81 = 469,                   /* $@81  */
+  YYSYMBOL_470_82 = 470,                   /* $@82  */
+  YYSYMBOL_471_83 = 471,                   /* $@83  */
+  YYSYMBOL_472_84 = 472,                   /* $@84  */
+  YYSYMBOL_473_85 = 473,                   /* $@85  */
+  YYSYMBOL_474_86 = 474,                   /* $@86  */
+  YYSYMBOL_type_declaration = 475,         /* type_declaration  */
+  YYSYMBOL_tuple_alias_declaration = 476,  /* tuple_alias_declaration  */
+  YYSYMBOL_477_87 = 477,                   /* $@87  */
+  YYSYMBOL_478_88 = 478,                   /* $@88  */
+  YYSYMBOL_479_89 = 479,                   /* $@89  */
+  YYSYMBOL_480_90 = 480,                   /* $@90  */
+  YYSYMBOL_variant_alias_declaration = 481, /* variant_alias_declaration  */
+  YYSYMBOL_482_91 = 482,                   /* $@91  */
+  YYSYMBOL_483_92 = 483,                   /* $@92  */
+  YYSYMBOL_484_93 = 484,                   /* $@93  */
+  YYSYMBOL_485_94 = 485,                   /* $@94  */
+  YYSYMBOL_bitfield_alias_declaration = 486, /* bitfield_alias_declaration  */
+  YYSYMBOL_487_95 = 487,                   /* $@95  */
+  YYSYMBOL_488_96 = 488,                   /* $@96  */
+  YYSYMBOL_489_97 = 489,                   /* $@97  */
+  YYSYMBOL_490_98 = 490,                   /* $@98  */
+  YYSYMBOL_make_decl = 491,                /* make_decl  */
+  YYSYMBOL_make_decl_no_bracket = 492,     /* make_decl_no_bracket  */
+  YYSYMBOL_make_struct_fields = 493,       /* make_struct_fields  */
+  YYSYMBOL_make_variant_dim = 494,         /* make_variant_dim  */
+  YYSYMBOL_make_struct_single = 495,       /* make_struct_single  */
+  YYSYMBOL_make_struct_dim_list = 496,     /* make_struct_dim_list  */
+  YYSYMBOL_make_struct_dim_decl = 497,     /* make_struct_dim_decl  */
+  YYSYMBOL_optional_make_struct_dim_decl = 498, /* optional_make_struct_dim_decl  */
+  YYSYMBOL_use_initializer = 499,          /* use_initializer  */
+  YYSYMBOL_make_struct_decl = 500,         /* make_struct_decl  */
+  YYSYMBOL_501_99 = 501,                   /* $@99  */
+  YYSYMBOL_502_100 = 502,                  /* $@100  */
+  YYSYMBOL_503_101 = 503,                  /* $@101  */
+  YYSYMBOL_504_102 = 504,                  /* $@102  */
+  YYSYMBOL_505_103 = 505,                  /* $@103  */
+  YYSYMBOL_506_104 = 506,                  /* $@104  */
+  YYSYMBOL_507_105 = 507,                  /* $@105  */
+  YYSYMBOL_508_106 = 508,                  /* $@106  */
+  YYSYMBOL_509_107 = 509,                  /* $@107  */
+  YYSYMBOL_510_108 = 510,                  /* $@108  */
+  YYSYMBOL_make_tuple_call = 511,          /* make_tuple_call  */
+  YYSYMBOL_512_109 = 512,                  /* $@109  */
+  YYSYMBOL_513_110 = 513,                  /* $@110  */
+  YYSYMBOL_make_dim_decl = 514,            /* make_dim_decl  */
+  YYSYMBOL_515_111 = 515,                  /* $@111  */
+  YYSYMBOL_516_112 = 516,                  /* $@112  */
+  YYSYMBOL_517_113 = 517,                  /* $@113  */
+  YYSYMBOL_518_114 = 518,                  /* $@114  */
+  YYSYMBOL_519_115 = 519,                  /* $@115  */
+  YYSYMBOL_520_116 = 520,                  /* $@116  */
+  YYSYMBOL_521_117 = 521,                  /* $@117  */
+  YYSYMBOL_522_118 = 522,                  /* $@118  */
+  YYSYMBOL_523_119 = 523,                  /* $@119  */
+  YYSYMBOL_524_120 = 524,                  /* $@120  */
+  YYSYMBOL_expr_map_tuple_list = 525,      /* expr_map_tuple_list  */
+  YYSYMBOL_push_table_nesting = 526,       /* push_table_nesting  */
+  YYSYMBOL_make_table_decl = 527,          /* make_table_decl  */
+  YYSYMBOL_make_table_call = 528,          /* make_table_call  */
+  YYSYMBOL_array_comprehension_where = 529, /* array_comprehension_where  */
+  YYSYMBOL_optional_comma = 530,           /* optional_comma  */
+  YYSYMBOL_table_comprehension = 531,      /* table_comprehension  */
+  YYSYMBOL_array_comprehension = 532       /* array_comprehension  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -998,16 +999,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   9558
+#define YYLAST   9588
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  208
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  324
+#define YYNNTS  325
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  950
+#define YYNRULES  952
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  1697
+#define YYNSTATES  1700
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   435
@@ -1074,102 +1075,102 @@ static const yytype_uint8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   567,   567,   568,   573,   574,   575,   576,   577,   578,
-     579,   580,   581,   582,   583,   584,   585,   589,   590,   594,
-     595,   599,   605,   606,   607,   611,   612,   616,   617,   621,
-     640,   641,   642,   643,   647,   648,   652,   653,   657,   658,
-     658,   662,   667,   676,   691,   707,   712,   720,   720,   759,
-     773,   777,   780,   784,   788,   792,   796,   802,   811,   814,
-     820,   821,   825,   829,   830,   834,   837,   843,   849,   852,
-     858,   859,   863,   864,   868,   869,   873,   874,   874,   878,
-     878,   887,   888,   892,   893,   899,   900,   901,   902,   903,
-     907,   908,   912,   913,   917,   919,   917,   931,   931,   939,
-     941,   939,   953,   953,   961,   963,   961,   974,   981,   988,
-     993,  1002,  1010,  1016,  1024,  1034,  1034,  1043,  1051,  1051,
-    1065,  1065,  1077,  1081,  1088,  1089,  1090,  1091,  1092,  1093,
-    1097,  1102,  1110,  1111,  1112,  1116,  1117,  1118,  1119,  1120,
-    1121,  1122,  1123,  1124,  1130,  1133,  1139,  1142,  1148,  1151,
-    1154,  1160,  1161,  1162,  1163,  1167,  1185,  1208,  1211,  1221,
-    1236,  1251,  1266,  1269,  1276,  1280,  1287,  1288,  1292,  1293,
-    1297,  1298,  1299,  1303,  1306,  1310,  1317,  1321,  1322,  1323,
-    1324,  1325,  1326,  1327,  1328,  1329,  1330,  1331,  1332,  1333,
-    1334,  1335,  1336,  1337,  1338,  1339,  1340,  1341,  1342,  1343,
-    1344,  1345,  1346,  1347,  1348,  1349,  1350,  1351,  1352,  1353,
-    1354,  1355,  1356,  1357,  1358,  1359,  1360,  1361,  1362,  1363,
-    1364,  1365,  1366,  1367,  1368,  1369,  1370,  1371,  1372,  1373,
-    1374,  1375,  1376,  1377,  1378,  1379,  1380,  1381,  1382,  1383,
-    1384,  1385,  1386,  1387,  1388,  1389,  1390,  1391,  1392,  1393,
-    1394,  1395,  1396,  1397,  1398,  1399,  1400,  1401,  1402,  1403,
-    1404,  1405,  1406,  1407,  1408,  1412,  1413,  1414,  1415,  1416,
-    1417,  1418,  1419,  1420,  1421,  1422,  1423,  1424,  1425,  1426,
-    1427,  1428,  1429,  1430,  1431,  1432,  1433,  1434,  1435,  1436,
-    1440,  1441,  1445,  1464,  1465,  1466,  1470,  1476,  1476,  1493,
-    1496,  1498,  1496,  1506,  1508,  1506,  1523,  1532,  1541,  1554,
-    1555,  1556,  1557,  1558,  1559,  1560,  1561,  1562,  1563,  1564,
-    1565,  1566,  1567,  1568,  1569,  1570,  1571,  1572,  1573,  1575,
-    1573,  1590,  1595,  1601,  1607,  1608,  1612,  1613,  1617,  1621,
-    1628,  1629,  1640,  1644,  1647,  1655,  1655,  1655,  1658,  1664,
-    1667,  1671,  1675,  1682,  1689,  1695,  1699,  1703,  1706,  1709,
-    1717,  1720,  1728,  1734,  1735,  1736,  1740,  1741,  1745,  1746,
-    1750,  1755,  1763,  1769,  1781,  1784,  1787,  1793,  1793,  1793,
-    1796,  1796,  1796,  1801,  1801,  1801,  1809,  1809,  1809,  1815,
-    1825,  1836,  1851,  1854,  1857,  1860,  1866,  1867,  1874,  1885,
-    1886,  1887,  1891,  1892,  1893,  1894,  1895,  1899,  1904,  1912,
-    1913,  1917,  1924,  1928,  1934,  1935,  1936,  1937,  1938,  1939,
-    1940,  1944,  1945,  1946,  1947,  1948,  1949,  1950,  1951,  1952,
-    1953,  1954,  1955,  1956,  1957,  1958,  1959,  1960,  1961,  1962,
-    1963,  1964,  1968,  1974,  1985,  1991,  2002,  2006,  2013,  2016,
-    2016,  2016,  2021,  2021,  2021,  2034,  2038,  2042,  2048,  2056,
-    2064,  2070,  2078,  2078,  2078,  2085,  2089,  2098,  2106,  2114,
-    2118,  2121,  2129,  2130,  2131,  2138,  2139,  2140,  2141,  2142,
-    2143,  2144,  2145,  2146,  2147,  2148,  2149,  2150,  2151,  2152,
-    2153,  2154,  2155,  2156,  2157,  2158,  2159,  2160,  2161,  2162,
-    2163,  2164,  2165,  2166,  2167,  2168,  2169,  2170,  2171,  2172,
-    2173,  2179,  2180,  2181,  2182,  2183,  2198,  2207,  2208,  2209,
-    2210,  2211,  2212,  2213,  2214,  2215,  2216,  2217,  2218,  2219,
-    2220,  2223,  2223,  2223,  2226,  2231,  2235,  2239,  2239,  2239,
-    2244,  2247,  2251,  2251,  2251,  2256,  2259,  2260,  2261,  2262,
-    2263,  2264,  2265,  2266,  2267,  2269,  2273,  2274,  2279,  2285,
-    2291,  2300,  2303,  2306,  2315,  2316,  2317,  2318,  2319,  2320,
-    2321,  2325,  2329,  2333,  2337,  2341,  2345,  2349,  2353,  2357,
-    2364,  2365,  2369,  2370,  2371,  2375,  2376,  2380,  2381,  2382,
-    2386,  2387,  2391,  2403,  2406,  2407,  2411,  2411,  2430,  2429,
-    2444,  2443,  2460,  2472,  2481,  2491,  2492,  2493,  2494,  2495,
-    2499,  2502,  2511,  2512,  2516,  2519,  2523,  2536,  2545,  2546,
-    2550,  2553,  2557,  2570,  2571,  2575,  2581,  2587,  2596,  2599,
-    2606,  2609,  2615,  2616,  2617,  2621,  2622,  2626,  2633,  2638,
-    2647,  2653,  2664,  2671,  2680,  2683,  2686,  2693,  2696,  2701,
-    2712,  2715,  2720,  2732,  2733,  2737,  2738,  2739,  2743,  2746,
-    2749,  2749,  2769,  2772,  2772,  2790,  2795,  2803,  2804,  2808,
-    2811,  2824,  2841,  2842,  2843,  2848,  2848,  2874,  2878,  2879,
-    2880,  2884,  2894,  2897,  2903,  2904,  2908,  2909,  2913,  2914,
-    2918,  2920,  2925,  2918,  2941,  2942,  2946,  2947,  2951,  2957,
-    2958,  2959,  2960,  2964,  2965,  2966,  2970,  2973,  2979,  2981,
-    2986,  2979,  3007,  3014,  3019,  3028,  3034,  3045,  3046,  3047,
-    3048,  3049,  3050,  3051,  3052,  3053,  3054,  3055,  3056,  3057,
-    3058,  3059,  3060,  3061,  3062,  3063,  3064,  3065,  3066,  3067,
-    3068,  3069,  3070,  3071,  3075,  3076,  3077,  3078,  3079,  3080,
-    3081,  3082,  3086,  3097,  3101,  3108,  3120,  3127,  3133,  3142,
-    3147,  3157,  3167,  3177,  3190,  3191,  3192,  3193,  3194,  3198,
-    3202,  3202,  3202,  3216,  3217,  3221,  3225,  3232,  3236,  3240,
-    3244,  3251,  3254,  3272,  3273,  3277,  3278,  3279,  3280,  3281,
-    3281,  3281,  3285,  3290,  3297,  3304,  3304,  3311,  3311,  3318,
-    3322,  3326,  3331,  3336,  3341,  3346,  3350,  3354,  3359,  3363,
-    3367,  3372,  3372,  3372,  3378,  3385,  3385,  3385,  3390,  3390,
-    3390,  3396,  3396,  3396,  3401,  3406,  3406,  3406,  3411,  3411,
-    3411,  3420,  3425,  3425,  3425,  3430,  3430,  3430,  3439,  3444,
-    3444,  3444,  3449,  3449,  3449,  3458,  3458,  3458,  3464,  3464,
-    3464,  3473,  3476,  3487,  3503,  3505,  3510,  3515,  3503,  3541,
-    3543,  3548,  3554,  3541,  3580,  3582,  3587,  3592,  3580,  3633,
-    3634,  3635,  3636,  3637,  3638,  3639,  3643,  3644,  3645,  3646,
-    3647,  3651,  3658,  3665,  3671,  3677,  3684,  3691,  3697,  3706,
-    3709,  3715,  3723,  3728,  3735,  3740,  3746,  3747,  3751,  3752,
-    3756,  3756,  3756,  3764,  3764,  3764,  3771,  3771,  3771,  3782,
-    3782,  3782,  3789,  3789,  3789,  3800,  3806,  3806,  3806,  3820,
-    3839,  3839,  3839,  3849,  3849,  3849,  3863,  3863,  3863,  3877,
-    3886,  3886,  3886,  3906,  3913,  3913,  3913,  3923,  3926,  3937,
-    3943,  3966,  3974,  3994,  4019,  4020,  4024,  4025,  4030,  4033,
-    4043
+       0,   568,   568,   569,   574,   575,   576,   577,   578,   579,
+     580,   581,   582,   583,   584,   585,   586,   590,   591,   595,
+     596,   600,   606,   607,   608,   612,   613,   617,   618,   622,
+     641,   642,   643,   644,   648,   649,   653,   654,   658,   659,
+     659,   663,   668,   677,   692,   708,   713,   721,   721,   760,
+     774,   778,   781,   785,   789,   793,   797,   803,   812,   813,
+     817,   820,   826,   827,   831,   835,   836,   840,   843,   849,
+     855,   858,   864,   865,   869,   870,   874,   875,   879,   880,
+     880,   884,   884,   893,   894,   898,   899,   905,   906,   907,
+     908,   909,   913,   914,   918,   919,   923,   925,   923,   937,
+     937,   945,   947,   945,   959,   959,   967,   969,   967,   980,
+     987,   994,   999,  1008,  1016,  1022,  1030,  1040,  1040,  1049,
+    1057,  1057,  1071,  1071,  1083,  1087,  1094,  1095,  1096,  1097,
+    1098,  1099,  1103,  1108,  1116,  1117,  1118,  1122,  1123,  1124,
+    1125,  1126,  1127,  1128,  1129,  1130,  1136,  1139,  1145,  1148,
+    1154,  1157,  1160,  1166,  1167,  1168,  1169,  1173,  1191,  1214,
+    1217,  1227,  1242,  1257,  1272,  1275,  1282,  1286,  1293,  1294,
+    1298,  1299,  1303,  1304,  1305,  1309,  1312,  1316,  1323,  1327,
+    1328,  1329,  1330,  1331,  1332,  1333,  1334,  1335,  1336,  1337,
+    1338,  1339,  1340,  1341,  1342,  1343,  1344,  1345,  1346,  1347,
+    1348,  1349,  1350,  1351,  1352,  1353,  1354,  1355,  1356,  1357,
+    1358,  1359,  1360,  1361,  1362,  1363,  1364,  1365,  1366,  1367,
+    1368,  1369,  1370,  1371,  1372,  1373,  1374,  1375,  1376,  1377,
+    1378,  1379,  1380,  1381,  1382,  1383,  1384,  1385,  1386,  1387,
+    1388,  1389,  1390,  1391,  1392,  1393,  1394,  1395,  1396,  1397,
+    1398,  1399,  1400,  1401,  1402,  1403,  1404,  1405,  1406,  1407,
+    1408,  1409,  1410,  1411,  1412,  1413,  1414,  1418,  1419,  1420,
+    1421,  1422,  1423,  1424,  1425,  1426,  1427,  1428,  1429,  1430,
+    1431,  1432,  1433,  1434,  1435,  1436,  1437,  1438,  1439,  1440,
+    1441,  1442,  1446,  1447,  1451,  1470,  1471,  1472,  1476,  1482,
+    1482,  1499,  1502,  1504,  1502,  1512,  1514,  1512,  1529,  1538,
+    1547,  1560,  1561,  1562,  1563,  1564,  1565,  1566,  1567,  1568,
+    1569,  1570,  1571,  1572,  1573,  1574,  1575,  1576,  1577,  1578,
+    1579,  1581,  1579,  1596,  1601,  1607,  1613,  1614,  1618,  1619,
+    1623,  1627,  1634,  1635,  1646,  1650,  1653,  1661,  1661,  1661,
+    1664,  1670,  1673,  1677,  1681,  1688,  1695,  1701,  1705,  1709,
+    1712,  1715,  1723,  1726,  1734,  1740,  1741,  1742,  1746,  1747,
+    1751,  1752,  1756,  1761,  1769,  1775,  1787,  1790,  1793,  1799,
+    1799,  1799,  1802,  1802,  1802,  1807,  1807,  1807,  1815,  1815,
+    1815,  1821,  1831,  1842,  1857,  1860,  1863,  1866,  1872,  1873,
+    1880,  1891,  1892,  1893,  1897,  1898,  1899,  1900,  1901,  1905,
+    1910,  1918,  1919,  1923,  1930,  1934,  1940,  1941,  1942,  1943,
+    1944,  1945,  1946,  1950,  1951,  1952,  1953,  1954,  1955,  1956,
+    1957,  1958,  1959,  1960,  1961,  1962,  1963,  1964,  1965,  1966,
+    1967,  1968,  1969,  1970,  1974,  1980,  1991,  1997,  2008,  2012,
+    2019,  2022,  2022,  2022,  2027,  2027,  2027,  2040,  2044,  2048,
+    2054,  2062,  2070,  2076,  2084,  2084,  2084,  2091,  2095,  2104,
+    2112,  2120,  2124,  2127,  2135,  2136,  2137,  2144,  2145,  2146,
+    2147,  2148,  2149,  2150,  2151,  2152,  2153,  2154,  2155,  2156,
+    2157,  2158,  2159,  2160,  2161,  2162,  2163,  2164,  2165,  2166,
+    2167,  2168,  2169,  2170,  2171,  2172,  2173,  2174,  2175,  2176,
+    2177,  2178,  2179,  2185,  2186,  2187,  2188,  2189,  2204,  2213,
+    2214,  2215,  2216,  2217,  2218,  2219,  2220,  2221,  2222,  2223,
+    2224,  2225,  2226,  2229,  2229,  2229,  2232,  2237,  2241,  2245,
+    2245,  2245,  2250,  2253,  2257,  2257,  2257,  2262,  2265,  2266,
+    2267,  2268,  2269,  2270,  2271,  2272,  2273,  2275,  2279,  2280,
+    2285,  2291,  2297,  2306,  2309,  2312,  2321,  2322,  2323,  2324,
+    2325,  2326,  2327,  2331,  2335,  2339,  2343,  2347,  2351,  2355,
+    2359,  2363,  2370,  2371,  2375,  2376,  2377,  2381,  2382,  2386,
+    2387,  2388,  2392,  2393,  2397,  2409,  2412,  2413,  2417,  2417,
+    2436,  2435,  2450,  2449,  2466,  2478,  2487,  2497,  2498,  2499,
+    2500,  2501,  2505,  2508,  2517,  2518,  2522,  2525,  2529,  2542,
+    2551,  2552,  2556,  2559,  2563,  2576,  2577,  2581,  2587,  2593,
+    2602,  2605,  2612,  2615,  2621,  2622,  2623,  2627,  2628,  2632,
+    2639,  2644,  2653,  2659,  2670,  2677,  2686,  2689,  2692,  2699,
+    2702,  2707,  2718,  2721,  2726,  2738,  2739,  2743,  2744,  2745,
+    2749,  2752,  2755,  2755,  2775,  2778,  2778,  2796,  2801,  2809,
+    2810,  2814,  2817,  2830,  2847,  2848,  2849,  2854,  2854,  2880,
+    2884,  2885,  2886,  2890,  2900,  2903,  2909,  2910,  2914,  2915,
+    2919,  2920,  2924,  2926,  2931,  2924,  2947,  2948,  2952,  2953,
+    2957,  2963,  2964,  2965,  2966,  2970,  2971,  2972,  2976,  2979,
+    2985,  2987,  2992,  2985,  3013,  3020,  3025,  3034,  3040,  3051,
+    3052,  3053,  3054,  3055,  3056,  3057,  3058,  3059,  3060,  3061,
+    3062,  3063,  3064,  3065,  3066,  3067,  3068,  3069,  3070,  3071,
+    3072,  3073,  3074,  3075,  3076,  3077,  3081,  3082,  3083,  3084,
+    3085,  3086,  3087,  3088,  3092,  3103,  3107,  3114,  3126,  3133,
+    3139,  3148,  3153,  3163,  3173,  3183,  3196,  3197,  3198,  3199,
+    3200,  3204,  3208,  3208,  3208,  3222,  3223,  3227,  3231,  3238,
+    3242,  3246,  3250,  3257,  3260,  3278,  3279,  3283,  3284,  3285,
+    3286,  3287,  3287,  3287,  3291,  3296,  3303,  3310,  3310,  3317,
+    3317,  3324,  3328,  3332,  3337,  3342,  3347,  3352,  3356,  3360,
+    3365,  3369,  3373,  3378,  3378,  3378,  3384,  3391,  3391,  3391,
+    3396,  3396,  3396,  3402,  3402,  3402,  3407,  3412,  3412,  3412,
+    3417,  3417,  3417,  3426,  3431,  3431,  3431,  3436,  3436,  3436,
+    3445,  3450,  3450,  3450,  3455,  3455,  3455,  3464,  3464,  3464,
+    3470,  3470,  3470,  3479,  3482,  3493,  3509,  3511,  3516,  3521,
+    3509,  3547,  3549,  3554,  3560,  3547,  3586,  3588,  3593,  3598,
+    3586,  3639,  3640,  3641,  3642,  3643,  3644,  3645,  3649,  3650,
+    3651,  3652,  3653,  3657,  3664,  3671,  3677,  3683,  3690,  3697,
+    3703,  3712,  3715,  3721,  3729,  3734,  3741,  3746,  3752,  3753,
+    3757,  3758,  3762,  3762,  3762,  3770,  3770,  3770,  3777,  3777,
+    3777,  3788,  3788,  3788,  3795,  3795,  3795,  3806,  3812,  3812,
+    3812,  3826,  3845,  3845,  3845,  3855,  3855,  3855,  3869,  3869,
+    3869,  3883,  3892,  3892,  3892,  3912,  3919,  3919,  3919,  3929,
+    3932,  3943,  3949,  3972,  3980,  4000,  4025,  4026,  4030,  4031,
+    4036,  4039,  4049
 };
 #endif
 
@@ -1231,10 +1232,10 @@ static const char *const yytname[] =
   "string_constant", "format_string", "optional_format_string", "$@1",
   "string_builder_body", "string_builder", "reader_character_sequence",
   "expr_reader", "$@2", "options_declaration", "require_declaration",
-  "require_module_name", "require_module", "is_public_module",
-  "expect_declaration", "expect_list", "expect_error", "expression_label",
-  "expression_goto", "elif_or_static_elif", "emit_semis",
-  "optional_emit_semis", "expression_else", "$@3", "$@4",
+  "require_module_name", "optional_require_guard", "require_module",
+  "is_public_module", "expect_declaration", "expect_list", "expect_error",
+  "expression_label", "expression_goto", "elif_or_static_elif",
+  "emit_semis", "optional_emit_semis", "expression_else", "$@3", "$@4",
   "if_or_static_if", "expression_else_one_liner",
   "expression_if_one_liner", "semis", "optional_semis",
   "expression_if_block", "$@5", "$@6", "$@7", "expression_else_block",
@@ -1327,12 +1328,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-1521)
+#define YYPACT_NINF (-1522)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-843)
+#define YYTABLE_NINF (-845)
 
 #define yytable_value_is_error(Yyn) \
   ((Yyn) == YYTABLE_NINF)
@@ -1341,176 +1342,176 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-   -1521,    68, -1521, -1521,    45,   -96,   185,   413, -1521,   101,
-   -1521, -1521, -1521, -1521,   330,    40, -1521, -1521, -1521, -1521,
-     145,   145,   145, -1521,   423, -1521,    88, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521,   -87, -1521,    21,
-       8,    24, -1521,    31, -1521,   256,   100,    62, -1521, -1521,
-   -1521,   129,   145, -1521, -1521,    88,   413,   413,   413,   176,
-     238, -1521, -1521, -1521, -1521,    40,    40,    40,   206, -1521,
-     596,   107, -1521, -1521, -1521, -1521,   322, -1521,   320, -1521,
-     649,    26,    45,   260,   -96,   185,   185,   284,   185,   409,
-   -1521,   445,   464, -1521, -1521, -1521,   650,   483,   499,   542,
-   -1521,   551,   398, -1521, -1521,   -49,    45,    40,    40,    40,
-      40,   417, -1521,   671,   721,   523,   544,   723, -1521, -1521,
-     514, -1521, -1521, -1521, -1521, -1521,   595,   118,   568, -1521,
-   -1521, -1521, -1521,   284,   284,   284,   725, -1521, -1521,   619,
-   -1521, -1521,   598,   631,   417,   417, -1521, -1521,   633, -1521,
-     264, -1521,   608,   669,   596, -1521,   652, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521,   682, -1521, -1521, -1521, -1521, -1521,
-   -1521,   629, -1521, -1521, -1521,   655, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521,   285,   684, -1521,  8406,   774, -1521,   624,
-     685, -1521, -1521, -1521, -1521, -1521,  9186, -1521,   675,   749,
-     230,    45,   681,   703, -1521, -1521, -1521,   118, -1521, -1521,
-     692,   698,   732,   701,   734,   735, -1521, -1521, -1521,   705,
-   -1521, -1521, -1521, -1521, -1521,   403, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521,   738, -1521, -1521,
-   -1521,   739,   753, -1521, -1521, -1521, -1521,   755,   756,   740,
-     330,   -57, -1521, -1521, -1521, -1521,   793,   741,   761, -1521,
-   -1521, -1521, -1521, -1521, -1521,   777, -1521,   742,   743,  8594,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521,   914,   917, -1521,   757, -1521,
-     417,   913,   685, -1521,   790,   417, -1521, -1521,   629,   417,
-      45, -1521,   548, -1521, -1521, -1521, -1521, -1521,  7407, -1521,
-   -1521,   792,   778,   -54,   120,   147, -1521, -1521,  7407,    83,
-   -1521,  5306, -1521, -1521, -1521,    66, -1521, -1521, -1521,    53,
-   -1521,  5497,   766,  1899, -1521,   764, -1521, -1521,  9324,  9363,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-     807,   785, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521,   951, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521,   813,   787, -1521,
-   -1521,   -92,   135,   847, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521,   784,   815, -1521,   360, -1521,   417,   830,
-    8406, -1521,   -12,  8406,  8406,  8406,   814,   816, -1521, -1521,
-     136,   330,   817,    35, -1521,   271,   795,   824,   825,   808,
-     836,   818,   294,   839, -1521,   368,    61,   841,  8165,  8165,
-     820,   822,   826,   827,   828,   833, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521,  8165,  8165,  8165,  8165,  8165,
-    3778,  4160, -1521,   831, -1521, -1521, -1521, -1521,   835, -1521,
-   -1521, -1521, -1521,   832, -1521, -1521, -1521,   478, -1521,   478,
-     478,   838,  8746, -1521, -1521,   837, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521,  8406,  8406,   842,   859,  8406,   757,
-    8406,   757,  8406,   757,  8499,   879,   843, -1521,  5306, -1521,
-    8406,  7407,   844,   876, -1521, -1521, -1521, -1521, -1521,   851,
-   -1521, -1521,   853,  5688, -1521,   793, -1521,  8499,   879, -1521,
-   -1521, -1521, -1521, -1521, -1521,  9395,  1260,  2765,   855, -1521,
-      99,   849,   -84,   857,  8406,  8406, -1521,  7787, -1521,   861,
-   -1521, -1521,   330, -1521,   677,   856,  1017,   556, -1521, -1521,
-   -1521,   850, -1521, -1521, -1521,  7407,   534,   578,   887,   488,
-   -1521, -1521, -1521, -1521,   870, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521,   386, -1521,   891,   892,   895, -1521,
-    5306,  8406,  7407,  7407, -1521, -1521,  7407, -1521,  7407, -1521,
-    5306, -1521, -1521,  5306,   896, -1521,  8406,   402,   402,  7407,
-    7407,  7407,  7407,  7407,  7407,   690,   402,   402,   168,   402,
-     402,   880,  1068,   884,   882,   252,   876,   911,   885,   397,
-     417,  2121,    40,  1081,   886, -1521,   832, -1521, -1521, -1521,
-   -1521,  8588,  9066,  8165,  8165, -1521, -1521,  8165,  8165,  8165,
-    8165,   924,  8165,   441,  7407,  8165,  8165,  8165,  8165,  7407,
-    8165,  8165,  8165,  8165,  7976,  8165,  8165,  8165,  8165,  8165,
-    8165,  8165,  8165,  8165,  8165,  9235,  7407,  4351,   614,   621,
-   -1521, -1521,   925,   622,   135,   637,   135,   639,   135,   -25,
-   -1521,   467,   761,   915, -1521,   493, -1521,  8406,   876,   536,
-     761, -1521, -1521,  5879, -1521, -1521, -1521, -1521,   893,   935,
-   -1521,   145, -1521,   145, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521,  7407, -1521, -1521,   366,   -73,   -73,   -73, -1521,
-     761,   761,  8165,  8822, -1521,   939, -1521, -1521, -1521, -1521,
-    7407,   941,   947,  8406,   -12, -1521,  7407,   145, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521,  8406,  8406,  8406,  8406,  3969,
-     952,  7407,  8406, -1521, -1521, -1521,  8406,   876,   394, -1521,
-     943,   918,  8406,  8406,   921,  8406,   926,  8406,   876,  8406,
-    8499,   876, -1521,   879,   949,   928,   931,   940,   942,   946,
-     948, -1521,  7407,   528,   105,   944, -1521,  7407, -1521,  7407,
-   -1521,  7407,   954,   496, -1521, -1521,   950,   964,   151, -1521,
-   -1521,  6070,   137,  3587, -1521,   295,   965,   122,   967,   757,
-   -1521,  2354,  1081,   945,   968, -1521, -1521,   960,   969, -1521,
-   -1521,   559,   559,  1092,  1092,   977,   977,   970,    91,   971,
-   -1521,   953,   164,   164,   837,   559,   559,  8822, -1521, -1521,
-    1302,   745,  1597,  8822,  9097,  8670,  8861,  8898,  8937,  1092,
-    1092,   425,   425,    91,    91,    91,   516,  7407,   972,   973,
-     519,  7407,  1164,   976,   978, -1521,   305, -1521, -1521, -1521,
-     199, -1521,   997, -1521,   999, -1521,  1002,  8406, -1521,  8499,
-    8406, -1521,   879,   566,   983,   985,  8406,  7407, -1521, -1521,
-    1012,   511, -1521,  8311, -1521,   159, -1521,   986,   988,  1146,
-   -1521, -1521,   -69, -1521, -1521, -1521,  1894,  2560,  1016, -1521,
-     511,    36,   990, -1521,  1151,   850,  7407,   145, -1521, -1521,
-   -1521, -1521,   761,  1121,  1170,   653,   539,   309,   994,   995,
-     604,   998,   654,  8406,  8499,   879,  1203,  1001,  1004,  8406,
-    7407,  1005, -1521,  1334,  1442, -1521,  1459, -1521,  1472,  1011,
-    2051,   648,  1013,  8406,   663,  1081, -1521, -1521, -1521, -1521,
-   -1521,  1015,  1022,  1019,  1162,  1050,    25,   105,  1028, -1521,
-   -1521, -1521,  1032,     2,  7407,  7407,  8406,   757,  1033,  1010,
-     943,   202, -1521,  1034,   184,  6261, -1521, -1521, -1521,   251,
-     135, -1521,  6452, -1521, -1521,  6643,  1054,  1071, -1521,   145,
-    1082,  6834,   267,  7025, -1521, -1521, -1521,   145,   145,  1227,
-   -1521,   883, -1521, -1521,  1226, -1521, -1521,  1231, -1521,  1199,
-     145, -1521,   145,   145,   145,   145,   145, -1521,  1176, -1521,
-     145,  1697,   757, -1521,  7407, -1521,  7407,  4542,  7407, -1521,
-    1063,  1044, -1521, -1521,  8165,  1046, -1521,  1048,  7407,  4733,
-    1051, -1521,  1049, -1521,  4924, -1521,  5879, -1521, -1521, -1521,
-    1087, -1521,  1090, -1521, -1521, -1521, -1521, -1521, -1521,   761,
-   -1521, -1521,   761, -1521, -1521,   985, -1521, -1521,   761, -1521,
-    7407, -1521,   235, -1521, -1521, -1521,  1052, -1521,  1055, -1521,
-    7407,  1094,  1097,  8406, -1521,  7407,  1059,  7407,   491, -1521,
-    1103, -1521, -1521,  1247,   629, -1521,  1106, -1521,  7407,   145,
-   -1521, -1521, -1521, -1521,  1069, -1521, -1521, -1521,  1072,  1108,
-   -1521, -1521,  2056,   786,   798, -1521, -1521,  7407,  3520, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,  3775,
-   -1521,   280,  5115, -1521,  1109,  7407,  1116, -1521,   312,  5306,
-     -32,    29,   223,  7407,  7407,  7407,  1083,  1085,  3966,   135,
-     105, -1521, -1521, -1521,   496,  1091,  3587,  1119,  1120,  1088,
-    1124,  1130, -1521,   314,   417,  7407, -1521,  1281,  7407, -1521,
-    1123,  1125, -1521,  1129,  1145, -1521, -1521,  7407, -1521, -1521,
-   -1521, -1521,  1107, -1521, -1521,  1110,   327,   327,  1111, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521,   -47, -1521,  8165,  8165,
-    8165,  8165,  8165,  8165,  8165,  8165,  8165,  8165,  7407,  8165,
-    8165,  8165,  8165,  8165,  8165,  8165,   135,  8406,  1112,  8406,
-    1114, -1521,   339,  1115, -1521,  7407,  1894,  7407, -1521,  1117,
-    3587, -1521,   346,  7407, -1521, -1521, -1521,   362, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521,  1134, -1521,  1113, -1521,
-   -1521,  1128, -1521,  1266,   190, -1521,  1280, -1521, -1521,  1126,
-    1147,   724,  1255,   145, -1521,   145, -1521,  1133,  1135, -1521,
-   -1521,  7407,  1144, -1521, -1521, -1521, -1521,  1136,  1137,  1139,
-    8165,  8165,  8165,  1140,  1256,  1141, -1521,  1143,  7216, -1521,
-   -1521,   388, -1521, -1521,  1149, -1521,  1167, -1521,   389,  1291,
-    1050,  5306,  7407,  7407,  1152, -1521, -1521, -1521, -1521, -1521,
-    1166,    41, -1521,   290, -1521, -1521,  1185, -1521, -1521,   251,
-   -1521,   847, -1521, -1521, -1521,  8406,  7407, -1521, -1521, -1521,
-   -1521,  2767,  7407,  7407,    45,   681,  1154,  1155,  7407,  1050,
-   -1521, -1521, -1521,  8746,  8746,  8746,  8746,  8746,  8746,  8746,
-    8746,  8746,  8746,  8746, -1521, -1521,  8746,  8746,  8746,  8746,
-    8746,  8746,  8746,   417,  4157, -1521,   660, -1521, -1521, -1521,
-    8406,  1156,  1157, -1521,   317, -1521,  1158, -1521,  7407, -1521,
-   -1521,  1197,  7407, -1521, -1521, -1521,  8406, -1521, -1521,   549,
-   -1521,    11, -1521, -1521,  1256,  1256,  1160,  1163,  1165,  1179,
-    1181,  5306, -1521,  7407,  1092,  1092,  1092,  5306, -1521, -1521,
-    1256,  1183,  1256, -1521,  1175, -1521, -1521,  1219, -1521, -1521,
-    1184,  1201,   391,   401, -1521, -1521,   248,   497, -1521,  5306,
-    1186,  1188, -1521, -1521, -1521,   761, -1521,  1190,  1189,  1191,
-     338,   105,  7407,  1196,   405,   139,   847, -1521, -1521,   665,
-   -1521, -1521,  1198, -1521, -1521, -1521, -1521,  1161,   236,  1358,
-      11, -1521, -1521,   724,   205,   205, -1521,  7407,  1256,  1256,
-     539,  1200,  1207,   876,   205,  1256,   539, -1521, -1521,  7407,
-   -1521, -1521,  1194,  7407,  7407, -1521,   497,   411, -1521, -1521,
-    1280,  1388,   417, -1521,    51,  1208,   417,   -97, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-    1358,   366,   539,  1238,  1240, -1521,  1213,  1214,  1216,   205,
-     205,  1238,  1228, -1521, -1521,  1234,  1237,   539,  1239,  1235,
-    7407, -1521, -1521, -1521,  1241, -1521,  7598,   145, -1521,  5306,
-     417, -1521,  8406,   -12, -1521,  2973,  9186, -1521, -1521, -1521,
-   -1521,   412,  1243, -1521, -1521, -1521, -1521,  1245,  1246, -1521,
-   -1521, -1521,  1248, -1521,  1391,  1242,  1235,  7407, -1521, -1521,
-   -1521, -1521, -1521,  8746, -1521,  1249,   414, -1521, -1521,  1018,
-    7407,  1250,   145,  9186, -1521,   539, -1521, -1521, -1521,  7407,
-   -1521,  1252,  1235, -1521,   644,  7598,   417, -1521,  7407,   145,
-   -1521, -1521,   417,   424, -1521, -1521,  1251, -1521,   417, -1521,
-   -1521,  1253, -1521,   145, -1521,   145, -1521, -1521, -1521, -1521,
-    3179, -1521,  7407, -1521, -1521, -1521, -1521,  1254,  1258,  1264,
-    1280, -1521, -1521,  7598,   417, -1521, -1521,   145, -1521,  3385,
-   -1521,  1258,  1261,   644,  1280, -1521, -1521
+   -1522,    70, -1522, -1522,    59,   -55,    15,   324, -1522,   -87,
+   -1522, -1522, -1522, -1522,   298,    24, -1522, -1522, -1522, -1522,
+     134,   134,   134, -1522,    89, -1522,   153, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,    49, -1522,    88,
+      95,   110, -1522,   176,   171, -1522, -1522, -1522,   186,   134,
+   -1522, -1522,   153,   324,   324,   324,   235,   177, -1522, -1522,
+   -1522, -1522,    24,    24,    24,   160, -1522,   851,   191, -1522,
+   -1522, -1522, -1522,   312, -1522,   102, -1522,   605,   142,    59,
+     301,   -55, -1522,   290, -1522,   280,   346,    35, -1522, -1522,
+     669,   375,   448,   462, -1522,   480,   388, -1522, -1522,   -59,
+      59,    24,    24,    24,    24,   518, -1522,   726,   727,   569,
+     601,   739, -1522, -1522,   546, -1522, -1522, -1522, -1522, -1522,
+     842,   162,   566, -1522, -1522, -1522, -1522,   171,   171,   577,
+     171,   628, -1522,   687,   694, -1522,   651, -1522, -1522,   697,
+     712,   518,   518, -1522, -1522,   677, -1522,    -4, -1522,   292,
+     758,   851, -1522,   735, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522,   742, -1522, -1522, -1522, -1522, -1522, -1522,   703, -1522,
+   -1522, -1522,   856, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+      72,   749,   577,   577,   577,   872, -1522, -1522,  8446,   879,
+   -1522,   602,   783, -1522, -1522, -1522, -1522, -1522,  9216, -1522,
+     780,   854,   360,    59,   759,   802, -1522, -1522, -1522,   162,
+   -1522, -1522, -1522,   788,   794,   800,   782,   804,   825, -1522,
+   -1522, -1522,   789, -1522, -1522, -1522, -1522, -1522,   288, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+     827, -1522, -1522, -1522,   837,   838, -1522, -1522, -1522, -1522,
+     846,   848,   795,   298,    -6, -1522, -1522, -1522, -1522,   426,
+     831,   865, -1522, -1522, -1522, -1522, -1522, -1522,   867, -1522,
+     797,   843,  8634, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,  1012,  1016,
+   -1522,   853, -1522,   518,   586,   783, -1522,   906,   518, -1522,
+   -1522,   703,   518,    59, -1522,   490, -1522, -1522, -1522, -1522,
+   -1522,  7353, -1522, -1522,   907,   891,   -63,   -60,   -52, -1522,
+   -1522,  7353,   203, -1522,  5252, -1522, -1522, -1522,    12, -1522,
+   -1522, -1522,     5, -1522,  5443,   875,  8257, -1522,   869, -1522,
+   -1522,  9354,  9393, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522,   912,   877, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,  1056, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+     917,   882, -1522, -1522,   -84,    53,   944, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522,   878,   908, -1522,   -49,
+   -1522,   518,   923,  8446, -1522,   197,  8446,  8446,  8446,   913,
+     920, -1522, -1522,   253,   298,   925,    41, -1522,   361,   892,
+     934,   935,   916,   937,   921,   363,   942, -1522,   438,    25,
+     945,  8111,  8111,   927,   928,   929,   930,   931,   932, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,  8111,  8111,
+    8111,  8111,  8111,  3724,  4106, -1522,   933, -1522, -1522, -1522,
+   -1522,   938, -1522, -1522, -1522, -1522,   936, -1522, -1522, -1522,
+     715, -1522,   715,   715,   940,  1151, -1522, -1522,   939, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,  8446,  8446,   941,
+     952,  8446,   853,  8446,   853,  8446,   853,  8539,   980,   943,
+   -1522,  5252, -1522,  8446,  7353,   947,   972, -1522, -1522, -1522,
+   -1522, -1522,   948, -1522, -1522,   950,  5634, -1522,   426, -1522,
+    8539,   980, -1522, -1522, -1522, -1522, -1522, -1522,  9425,   946,
+     781,   954, -1522,   131,   962,    91,   949,  8446,  8446, -1522,
+    7733, -1522,   963, -1522, -1522,   298, -1522,   486,   967,  1103,
+     585, -1522, -1522, -1522,   122, -1522, -1522, -1522,  7353,   530,
+     654,   971,   395, -1522, -1522, -1522, -1522,   969, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,   439, -1522,   990,
+     994,   997, -1522,  5252,  8446,  7353,  7353, -1522, -1522,  7353,
+   -1522,  7353, -1522,  5252, -1522, -1522,  5252,   998, -1522,  8446,
+     491,   491,  7353,  7353,  7353,  7353,  7353,  7353,   809,   491,
+     491,   113,   491,   491,   979,  1158,   981,   982,   167,   972,
+    1008,   985,   519,   518,  3342,    24,  1183,   987, -1522,   936,
+   -1522, -1522, -1522, -1522,  1838,  8628,  8111,  8111, -1522, -1522,
+    8111,  8111,  8111,  8111,  1025,  8111,   539,  7353,  8111,  8111,
+    8111,  8111,  7353,  8111,  8111,  8111,  8111,  7922,  8111,  8111,
+    8111,  8111,  8111,  8111,  8111,  8111,  8111,  8111,  9265,  7353,
+    4297,   662,   668, -1522, -1522,  1028,   678,    53,   679,    53,
+     681,    53,   -17, -1522,   549,   865,  1017, -1522,   556, -1522,
+    8446,   972,   563,   865, -1522, -1522,  5825, -1522, -1522, -1522,
+   -1522,  1000,  1037, -1522,   134, -1522,   134, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522,  7353, -1522, -1522,   440,   -56,
+     -56,   -56, -1522,   865,   865,  8111,  8710, -1522,  1038, -1522,
+   -1522, -1522, -1522,  7353,  1039,  1040,  8446,   197, -1522,  7353,
+     134, -1522, -1522, -1522, -1522, -1522, -1522, -1522,  8446,  8446,
+    8446,  8446,  3915,  1043,  7353,  8446, -1522, -1522, -1522,  8446,
+     972,   220, -1522,  1034,  1007,  8446,  8446,  1013,  8446,  1014,
+    8446,   972,  8446,  8539,   972, -1522,   980,   791,  1015,  1018,
+    1019,  1020,  1021,  1022, -1522,  7353,   642,   -54,  1009, -1522,
+    7353, -1522,  7353, -1522,  7353,  1023,   580, -1522, -1522,  1026,
+    1027,   -46, -1522, -1522,  6016,   173,  3533, -1522,    84,  1024,
+     271,  1029,   853, -1522,  2061,  1183,  1033,  1030, -1522, -1522,
+    1048,  1031, -1522, -1522,  1066,  1066,  1190,  1190,  1641,  1641,
+    1036,   310,  1041, -1522,  1035,   319,   319,   939,  1066,  1066,
+    8710, -1522, -1522,  8859,  8744,  8832,  8710,  9127,   688,  8947,
+    8974,  9062,  1190,  1190,   451,   451,   310,   310,   310,   593,
+    7353,  1045,  1046,   617,  7353,  1217,  1047,  1054, -1522,   164,
+   -1522, -1522, -1522,   274, -1522,  1058, -1522,  1074, -1522,  1075,
+    8446, -1522,  8539,  8446, -1522,   980,   673,  1057,  1060,  8446,
+    7353, -1522, -1522,  1087,   307, -1522,  8350, -1522,   214, -1522,
+    1064,  1072,  1223, -1522, -1522,   103, -1522, -1522, -1522,   978,
+    2315,  1099, -1522,   307,    33,  1086, -1522,  1251,   122,  7353,
+     134, -1522, -1522, -1522, -1522,   865,   815,  1172,   701,   618,
+     190,  1094,  1097,   757,  1098,   702,  8446,  8539,   980,  1177,
+    1101,  1112,  8446,  7353,  1102, -1522,  1370,  1383, -1522,  1404,
+   -1522,  1413,  1122,  1442,   763,  1126,  8446,   767,  1183, -1522,
+   -1522, -1522, -1522, -1522,  1113,  1162,  1139,  1298,  1179,    40,
+     -54,  1142, -1522, -1522, -1522,  1144,   329,  7353,  7353,  8446,
+     853,  1145,  1140,  1034,   355, -1522,  1149,   294,  6207, -1522,
+   -1522, -1522,   415,    53, -1522,  6398, -1522, -1522,  6589,  1192,
+    1194, -1522,   134,  1204,  6780,   -67,  6971, -1522, -1522, -1522,
+     134,   134,  1351, -1522,   822, -1522, -1522,  1349, -1522, -1522,
+    1354, -1522,  1322,   134, -1522,   134,   134,   134,   134,   134,
+   -1522,  1300, -1522,   134,  1840,   853, -1522,  7353, -1522,  7353,
+    4488,  7353, -1522,  1187,  1168, -1522, -1522,  8111,  1170, -1522,
+    1178,  7353,  4679,  1171, -1522,  1181, -1522,  4870, -1522,  5825,
+   -1522, -1522, -1522,  1215, -1522,  1218, -1522, -1522, -1522, -1522,
+   -1522, -1522,   865, -1522, -1522,   865, -1522, -1522,  1060, -1522,
+   -1522,   865, -1522,  7353, -1522,   575, -1522, -1522, -1522,  1176,
+   -1522,  1180, -1522,  7353,  1222,  1226,  8446, -1522,  7353,  1184,
+    7353,   582, -1522,  1228, -1522, -1522,  1384,   703, -1522,  1231,
+   -1522,  7353,   134, -1522, -1522, -1522, -1522,  1195, -1522, -1522,
+   -1522,  1197,  1232, -1522, -1522,  1475,   777,   839, -1522, -1522,
+    7353,  1609, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522,  1625, -1522,   107,  5061, -1522,  1227,  7353,  1236,
+   -1522,   262,  5252,     4,    44,   356,  7353,  7353,  7353,  1199,
+    1200,  1874,    53,   -54, -1522, -1522, -1522,   580,  1201,  3533,
+    1241,  1242,  1206,  1244,  1245, -1522,   273,   518,  7353, -1522,
+    1395,  7353, -1522,  1237,  1238, -1522,  1239,  1258, -1522, -1522,
+    7353, -1522, -1522, -1522, -1522,  1219, -1522, -1522,  1220,   -92,
+     -92,  1221, -1522, -1522, -1522, -1522, -1522, -1522, -1522,   -77,
+   -1522,  8111,  8111,  8111,  8111,  8111,  8111,  8111,  8111,  8111,
+    8111,  7353,  8111,  8111,  8111,  8111,  8111,  8111,  8111,    53,
+    8446,  1224,  8446,  1233, -1522,   308,  1234, -1522,  7353,   978,
+    7353, -1522,  1235,  3533, -1522,   317,  7353, -1522, -1522, -1522,
+     350, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,  1248,
+   -1522,  1212, -1522, -1522,  1240, -1522,  1380,   135, -1522,  1387,
+   -1522, -1522,  1243,  1255,   764,  1365,   134, -1522,   134, -1522,
+    1247,  1250, -1522, -1522,  7353,  1252, -1522, -1522, -1522, -1522,
+    1253,  1254,  1257,  8111,  8111,  8111,  1259,  1369,  1262, -1522,
+    1263,  7162, -1522, -1522,   366, -1522, -1522,  1265, -1522,  1277,
+   -1522,   373,  1399,  1179,  5252,  7353,  7353,  1267, -1522, -1522,
+   -1522, -1522, -1522,  1270,    45, -1522,   341, -1522, -1522,  1289,
+   -1522, -1522,   415, -1522,   944, -1522, -1522, -1522,  8446,  7353,
+   -1522, -1522, -1522, -1522,  2521,  7353,  7353,    59,   759,  1269,
+    1271,  7353,  1179, -1522, -1522, -1522,  1151,  1151,  1151,  1151,
+    1151,  1151,  1151,  1151,  1151,  1151,  1151, -1522, -1522,  1151,
+    1151,  1151,  1151,  1151,  1151,  1151,   518,  3275, -1522,   720,
+   -1522, -1522, -1522,  8446,  1275,  1276, -1522,   443, -1522,  1278,
+   -1522,  7353, -1522, -1522,  1295,  7353, -1522, -1522, -1522,  8446,
+   -1522, -1522,   579, -1522,     6, -1522, -1522,  1369,  1369,  1279,
+    1272,  1281,  1282,  1283,  5252, -1522,  7353,  1190,  1190,  1190,
+    5252, -1522, -1522,  1369,  1284,  1369, -1522,  1285, -1522, -1522,
+    1303, -1522, -1522,  1274,  1325,   389,   392, -1522, -1522,   358,
+     511, -1522,  5252,  1291,  1292, -1522, -1522, -1522,   865, -1522,
+    1293,  1299,  1304,   458,   -54,  7353,  1305,   403,   246,   944,
+   -1522, -1522,   722, -1522, -1522,  1317, -1522, -1522, -1522, -1522,
+    1280,   -72,  1457,     6, -1522, -1522,   764,   204,   204, -1522,
+    7353,  1369,  1369,   618,  1318,  1319,   972,   204,  1369,   618,
+   -1522, -1522,  7353, -1522, -1522,  1320,  7353,  7353, -1522,   511,
+     411, -1522, -1522,  1387,  1492,   518, -1522,    52,  1321,   518,
+     357, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522,  1457,   440,   618,  1348,  1352, -1522,  1326,
+    1329,  1330,   204,   204,  1348,  1333, -1522, -1522,  1337,  1338,
+     618,  1339,  1340,  7353, -1522, -1522, -1522,  1342, -1522,  7544,
+     134, -1522,  5252,   518, -1522,  8446,   197, -1522,  2728,  9216,
+   -1522, -1522, -1522, -1522,   412,  1347, -1522, -1522, -1522, -1522,
+    1341,  1353, -1522, -1522, -1522,  1355, -1522,  1500,  1358,  1340,
+    7353, -1522, -1522, -1522, -1522, -1522,  1151, -1522,  1362,   413,
+   -1522, -1522,   591,  7353,  1357,   134,  9216, -1522,   618, -1522,
+   -1522, -1522,  7353, -1522,  1360,  1340, -1522,   693,  7544,   518,
+   -1522,  7353,   134, -1522, -1522,   518,   414, -1522, -1522,  1363,
+   -1522,   518, -1522, -1522,  1368, -1522,   134, -1522,   134, -1522,
+   -1522, -1522, -1522,  2934, -1522,  7353, -1522, -1522, -1522, -1522,
+    1366,  1371,  1359,  1387, -1522, -1522,  7544,   518, -1522, -1522,
+     134, -1522,  3140, -1522,  1371,  1367,   693,  1387, -1522, -1522
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -1518,252 +1519,252 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_int16 yydefact[] =
 {
-       2,   168,     1,   366,     0,     0,     0,   672,   367,     0,
-     864,   854,   859,    20,     0,     0,    19,    16,    15,     3,
-       0,     0,     0,     8,   708,     7,   653,     6,    11,     5,
-       4,    13,    12,    14,   133,   134,   132,   142,   144,    49,
-      65,    62,    63,     0,    51,     0,     0,    60,    50,   674,
-     673,     0,     0,    26,    25,   653,   672,   672,   672,     0,
-     340,    47,   152,   153,   154,     0,     0,     0,   155,   157,
-     164,     0,   151,    21,    10,     9,   290,   690,     0,   654,
-     655,     0,     0,     0,     0,     0,     0,    52,     0,     0,
-      61,     0,     0,    58,   675,   677,    22,     0,     0,     0,
-     342,     0,     0,   163,   158,     0,     0,     0,     0,     0,
-       0,    74,   291,   293,   678,   700,   699,   703,   657,   656,
-     663,   140,   141,   138,   139,   136,     0,     0,     0,   135,
-     145,    66,    64,    54,    55,    53,    60,    57,    56,     0,
-      23,    24,    27,   764,    74,    74,   341,    45,    48,   162,
-       0,   159,   160,   161,   165,    72,    75,   169,   295,   294,
-     297,   292,   680,   679,     0,   702,   701,   705,   704,   709,
-     658,   580,    30,    31,    35,     0,   128,   129,   126,   127,
-     125,   124,   130,     0,     0,    59,     0,     0,    29,     0,
-     688,   855,   860,    46,   156,    73,     0,   681,   682,   696,
-     660,     0,   581,     0,    32,    33,    34,     0,   143,   137,
-       0,     0,     0,     0,     0,     0,   717,   737,   718,   753,
-     719,   723,   724,   725,   726,   743,   730,   731,   732,   733,
-     734,   735,   736,   738,   739,   740,   741,   824,   722,   729,
-     742,   831,   838,   720,   727,   721,   728,     0,     0,     0,
-       0,   752,   785,   788,   786,   787,   851,   781,   676,    28,
-     767,   768,   765,   766,   686,   689,   865,     0,     0,     0,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,     0,     0,   176,   170,   264,
-      74,     0,   688,   697,     0,    74,   662,   659,   580,    74,
-       0,   642,   635,   664,   131,   789,   815,   818,     0,   821,
-     811,     0,     0,   825,   832,   839,   845,   848,     0,   783,
-     795,   334,   801,   806,   800,     0,   814,   810,   803,     0,
-     805,     0,   782,     0,   687,     0,   856,   861,   255,   256,
-     253,   179,   180,   182,   181,   183,   184,   185,   186,   212,
-     213,   210,   211,   203,   214,   215,   204,   201,   202,   254,
-     237,     0,   252,   216,   217,   218,   219,   190,   191,   192,
-     187,   188,   189,   200,     0,   206,   207,   205,   198,   199,
-     194,   193,   195,   196,   197,   178,   177,   236,     0,   208,
-     209,   580,   173,   303,   744,   747,   750,   751,   745,   748,
-     746,   749,   683,     0,   694,   710,     0,   146,    74,     0,
-       0,   636,     0,     0,     0,     0,     0,     0,   481,   482,
-       0,     0,     0,     0,   475,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   743,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   569,   414,   416,   415,
-     417,   418,   419,   420,    41,     0,     0,     0,     0,     0,
-     334,     0,   399,   400,   939,   479,   478,   556,   476,   549,
-     548,   547,   546,   166,   552,   477,   551,   550,   523,   483,
-     524,     0,   472,   528,   484,     0,   480,   876,   878,   877,
-     473,   880,   879,   474,     0,     0,     0,   770,     0,   170,
-       0,   170,     0,   170,     0,     0,     0,   797,     0,   794,
-       0,     0,     0,   946,   392,   808,   809,   802,   804,     0,
-     807,   778,     0,     0,   853,   852,   866,   614,   620,   257,
-     259,   258,   260,   251,   235,   261,   238,   220,     0,   171,
-     365,   605,   606,     0,     0,     0,   296,     0,   396,     0,
-     298,   691,     0,   698,     0,     0,   637,   635,   661,   147,
-     643,     0,   633,   634,   632,     0,     0,     0,     0,   775,
-     900,   903,   345,   752,   349,   348,   354,   869,   875,   870,
-     871,   872,   874,   873,     0,   386,     0,     0,     0,   930,
-       0,     0,     0,     0,   377,   380,     0,   383,     0,   934,
-       0,   912,   916,     0,     0,   906,     0,   511,   512,     0,
-       0,     0,     0,     0,     0,     0,   488,   487,   525,   486,
-     485,     0,     0,     0,     0,   340,   946,   946,     0,   401,
-      74,     0,     0,   409,   400,   331,   166,   307,   308,   306,
-     792,     0,     0,     0,     0,   513,   514,     0,     0,     0,
+       2,   170,     1,   368,     0,     0,    58,   674,   369,     0,
+     866,   856,   861,    20,     0,     0,    19,    16,    15,     3,
+       0,     0,     0,     8,   710,     7,   655,     6,    11,     5,
+       4,    13,    12,    14,   135,   136,   134,   144,   146,    49,
+      67,    64,    65,     0,     0,    50,   676,   675,     0,     0,
+      26,    25,   655,   674,   674,   674,     0,   342,    47,   154,
+     155,   156,     0,     0,     0,   157,   159,   166,     0,   153,
+      21,    10,     9,   292,   692,     0,   656,   657,     0,     0,
+       0,     0,    59,     0,    51,     0,     0,    62,   677,   679,
+      22,     0,     0,     0,   344,     0,     0,   165,   160,     0,
+       0,     0,     0,     0,     0,    76,   293,   295,   680,   702,
+     701,   705,   659,   658,   665,   142,   143,   140,   141,   138,
+       0,     0,     0,   137,   147,    68,    66,     0,     0,    52,
+       0,     0,    63,     0,     0,    60,     0,    23,    24,    27,
+     766,    76,    76,   343,    45,    48,   164,     0,   161,   162,
+     163,   167,    74,    77,   171,   297,   296,   299,   294,   682,
+     681,     0,   704,   703,   707,   706,   711,   660,   582,    30,
+      31,    35,     0,   130,   131,   128,   129,   127,   126,   132,
+       0,     0,    54,    55,    53,    62,    57,    56,     0,     0,
+      29,     0,   690,   857,   862,    46,   158,    75,     0,   683,
+     684,   698,   662,     0,   583,     0,    32,    33,    34,     0,
+     145,   139,    61,     0,     0,     0,     0,     0,     0,   719,
+     739,   720,   755,   721,   725,   726,   727,   728,   745,   732,
+     733,   734,   735,   736,   737,   738,   740,   741,   742,   743,
+     826,   724,   731,   744,   833,   840,   722,   729,   723,   730,
+       0,     0,     0,     0,   754,   787,   790,   788,   789,   853,
+     783,   678,    28,   769,   770,   767,   768,   688,   691,   867,
+       0,     0,     0,   267,   268,   269,   270,   271,   272,   273,
+     274,   275,   276,   277,   278,   279,   280,   281,   282,   283,
+     284,   285,   286,   287,   288,   289,   290,   291,     0,     0,
+     178,   172,   266,    76,     0,   690,   699,     0,    76,   664,
+     661,   582,    76,     0,   644,   637,   666,   133,   791,   817,
+     820,     0,   823,   813,     0,     0,   827,   834,   841,   847,
+     850,     0,   785,   797,   336,   803,   808,   802,     0,   816,
+     812,   805,     0,   807,     0,   784,     0,   689,     0,   858,
+     863,   257,   258,   255,   181,   182,   184,   183,   185,   186,
+     187,   188,   214,   215,   212,   213,   205,   216,   217,   206,
+     203,   204,   256,   239,     0,   254,   218,   219,   220,   221,
+     192,   193,   194,   189,   190,   191,   202,     0,   208,   209,
+     207,   200,   201,   196,   195,   197,   198,   199,   180,   179,
+     238,     0,   210,   211,   582,   175,   305,   746,   749,   752,
+     753,   747,   750,   748,   751,   685,     0,   696,   712,     0,
+     148,    76,     0,     0,   638,     0,     0,     0,     0,     0,
+       0,   483,   484,     0,     0,     0,     0,   477,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   745,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   571,
+     416,   418,   417,   419,   420,   421,   422,    41,     0,     0,
+       0,     0,     0,   336,     0,   401,   402,   941,   481,   480,
+     558,   478,   551,   550,   549,   548,   168,   554,   479,   553,
+     552,   525,   485,   526,     0,   474,   530,   486,     0,   482,
+     878,   880,   879,   475,   882,   881,   476,     0,     0,     0,
+     772,     0,   172,     0,   172,     0,   172,     0,     0,     0,
+     799,     0,   796,     0,     0,     0,   948,   394,   810,   811,
+     804,   806,     0,   809,   780,     0,     0,   855,   854,   868,
+     616,   622,   259,   261,   260,   262,   253,   237,   263,   240,
+     222,     0,   173,   367,   607,   608,     0,     0,     0,   298,
+       0,   398,     0,   300,   693,     0,   700,     0,     0,   639,
+     637,   663,   149,   645,     0,   635,   636,   634,     0,     0,
+       0,     0,   777,   902,   905,   347,   754,   351,   350,   356,
+     871,   877,   872,   873,   874,   876,   875,     0,   388,     0,
+       0,     0,   932,     0,     0,     0,     0,   379,   382,     0,
+     385,     0,   936,     0,   914,   918,     0,     0,   908,     0,
+     513,   514,     0,     0,     0,     0,     0,     0,     0,   490,
+     489,   527,   488,   487,     0,     0,     0,     0,   342,   948,
+     948,     0,   403,    76,     0,     0,   411,   402,   333,   168,
+     309,   310,   308,   794,     0,     0,     0,     0,   515,   516,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   462,     0,     0,     0,     0,
-     754,   769,     0,     0,   173,     0,   173,     0,   173,   340,
-     612,     0,   610,     0,   618,     0,   755,     0,   946,     0,
-     338,   393,   793,   947,   335,   799,   777,   780,     0,   759,
-     615,    92,   621,    92,   262,   263,   240,   241,   243,   242,
-     244,   245,   246,   247,   239,   248,   249,   250,   224,   225,
-     227,   226,   228,   229,   230,   231,   222,   223,   232,   233,
-     234,   221,     0,   363,   364,     0,   580,   580,   580,   172,
-     175,   174,     0,   397,   331,   669,   695,   706,   593,   711,
-       0,     0,     0,     0,     0,   650,     0,     0,   790,   816,
-     819,    18,    17,   773,   774,     0,     0,     0,     0,   898,
-       0,     0,     0,   920,   923,   926,     0,   946,     0,   937,
-     946,     0,     0,     0,     0,     0,     0,     0,   946,     0,
-       0,   946,   909,     0,     0,     0,     0,     0,     0,     0,
-       0,    44,     0,    42,     0,     0,   919,     0,   624,     0,
-     623,     0,     0,   947,   891,   516,     0,     0,   449,   446,
-     448,   336,     0,   334,   465,     0,     0,     0,     0,   170,
-     401,     0,   409,     0,     0,   535,   534,     0,     0,   536,
-     540,   489,   490,   502,   503,   500,   501,     0,   529,     0,
-     521,     0,   553,   554,   555,   491,   492,   558,   559,   560,
-     507,   508,   509,   510,     0,     0,   505,   506,   504,   498,
-     499,   494,   493,   495,   496,   497,     0,     0,     0,   455,
-       0,     0,     0,     0,     0,   470,     0,   822,   812,   756,
-       0,   826,     0,   833,     0,   840,     0,     0,   846,     0,
-       0,   849,     0,     0,     0,   783,     0,     0,   394,   779,
-     760,   684,    90,    93,   857,    93,   862,     0,     0,   712,
-     602,   603,   625,   607,   609,   608,   398,     0,   665,   670,
-     684,   596,     0,   639,   640,     0,     0,     0,   652,   791,
-     817,   820,   776,     0,     0,     0,   899,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   464,     0,
+       0,     0,     0,   756,   771,     0,     0,   175,     0,   175,
+       0,   175,   342,   614,     0,   612,     0,   620,     0,   757,
+       0,   948,     0,   340,   395,   795,   949,   337,   801,   779,
+     782,     0,   761,   617,    94,   623,    94,   264,   265,   242,
+     243,   245,   244,   246,   247,   248,   249,   241,   250,   251,
+     252,   226,   227,   229,   228,   230,   231,   232,   233,   224,
+     225,   234,   235,   236,   223,     0,   365,   366,     0,   582,
+     582,   582,   174,   177,   176,     0,   399,   333,   671,   697,
+     708,   595,   713,     0,     0,     0,     0,     0,   652,     0,
+       0,   792,   818,   821,    18,    17,   775,   776,     0,     0,
+       0,     0,   900,     0,     0,     0,   922,   925,   928,     0,
+     948,     0,   939,   948,     0,     0,     0,     0,     0,     0,
+       0,   948,     0,     0,   948,   911,     0,     0,     0,     0,
+       0,     0,     0,     0,    44,     0,    42,     0,     0,   921,
+       0,   626,     0,   625,     0,     0,   949,   893,   518,     0,
+       0,   451,   448,   450,   338,     0,   336,   467,     0,     0,
+       0,     0,   172,   403,     0,   411,     0,     0,   537,   536,
+       0,     0,   538,   542,   491,   492,   504,   505,   502,   503,
+       0,   531,     0,   523,     0,   555,   556,   557,   493,   494,
+     560,   561,   562,   509,   510,   511,   512,     0,     0,   507,
+     508,   506,   500,   501,   496,   495,   497,   498,   499,     0,
+       0,     0,   457,     0,     0,     0,     0,     0,   472,     0,
+     824,   814,   758,     0,   828,     0,   835,     0,   842,     0,
+       0,   848,     0,     0,   851,     0,     0,     0,   785,     0,
+       0,   396,   781,   762,   686,    92,    95,   859,    95,   864,
+       0,     0,   714,   604,   605,   627,   609,   611,   610,   400,
+       0,   667,   672,   686,   598,     0,   641,   642,     0,     0,
+       0,   654,   793,   819,   822,   778,     0,     0,     0,   901,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     947,     0,   526,     0,     0,   527,     0,   557,     0,     0,
-       0,     0,     0,     0,     0,   409,   564,   565,   566,   567,
-     568,     0,    38,     0,   108,     0,     0,     0,     0,   882,
-     881,   515,     0,     0,     0,     0,     0,   170,     0,     0,
-     946,     0,   466,     0,     0,     0,   469,   467,   167,     0,
-     173,   333,   357,   355,   303,     0,     0,     0,   356,     0,
-       0,     0,    74,     0,   328,   413,   309,     0,     0,     0,
-     322,     0,   323,   317,     0,   314,   313,     0,   315,     0,
-       0,   332,     0,    88,    89,    86,    87,   324,   369,   312,
-       0,   421,   170,   531,     0,   537,     0,     0,     0,   519,
-       0,     0,   541,   545,     0,     0,   522,     0,     0,     0,
-       0,   456,     0,   463,     0,   517,     0,   471,   823,   813,
-       0,   771,     0,   827,   829,   834,   836,   841,   843,   611,
-     847,   613,   617,   850,   619,   783,   784,   796,   339,   395,
-       0,   667,   685,   867,    91,   616,     0,   622,     0,   604,
-       0,     0,     0,     0,   626,     0,     0,     0,   685,   692,
-       0,   594,   707,     0,   580,   638,     0,   647,     0,     0,
-     651,   901,   904,   346,     0,   351,   352,   350,     0,     0,
-     389,   387,     0,     0,     0,   931,   929,   336,     0,   938,
-     941,   378,   381,   384,   935,   933,   913,   917,   915,     0,
-     907,    74,     0,    39,     0,     0,     0,   370,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   173,
-       0,   940,   337,   468,     0,     0,   334,     0,     0,     0,
-       0,     0,   407,     0,    74,     0,   358,     0,     0,   343,
-       0,     0,   327,     0,     0,    69,   303,     0,   360,   331,
-     325,   326,     0,    81,    82,     0,   148,   148,     0,   316,
-     311,   318,   319,   320,   321,   368,     0,   310,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   173,     0,     0,     0,
-       0,   444,     0,     0,   542,     0,   530,     0,   520,     0,
-     334,   457,     0,     0,   518,   464,   460,     0,   758,   772,
-     757,   830,   837,   844,   798,   761,   762,   668,     0,   858,
-     863,     0,   714,   715,   628,   627,   299,   666,   671,     0,
-       0,   587,   590,     0,   641,     0,   649,     0,     0,   347,
-     353,     0,     0,   388,   921,   924,   927,     0,     0,     0,
-       0,     0,     0,     0,   898,     0,   910,     0,     0,   303,
-     570,     0,    36,    43,     0,   110,     0,   111,     0,   112,
-       0,     0,     0,     0,     0,   884,   883,   447,   579,   450,
-       0,     0,   442,     0,   404,   405,     0,   403,   402,     0,
-     410,   303,   359,   303,   344,     0,     0,    67,    68,   117,
-     361,     0,     0,     0,     0,   150,     0,     0,     0,     0,
-     644,   375,   374,   433,   434,   436,   435,   437,   427,   428,
-     429,   438,   439,   423,   424,   425,   426,   440,   441,   430,
-     431,   432,   422,    74,     0,   578,     0,   576,   445,   573,
-       0,     0,     0,   572,     0,   458,     0,   461,     0,   868,
-     713,     0,     0,   300,   305,   693,     0,   588,   589,   590,
-     591,   582,   597,   648,   898,   898,     0,     0,     0,     0,
-       0,   334,   942,   336,   379,   382,   385,     0,   899,   914,
-     898,     0,   898,   561,     0,   563,   571,    40,   109,   371,
-       0,     0,     0,     0,   886,   885,     0,     0,   453,     0,
-       0,     0,   408,   411,   362,   123,   122,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   303,   532,   538,     0,
-     577,   575,     0,   574,   763,   716,   629,     0,     0,   585,
-     582,   583,   584,   587,   897,   897,   390,     0,   898,   898,
-     889,     0,     0,   946,   897,   898,   889,   562,    37,     0,
-     113,   114,     0,     0,     0,   451,     0,     0,   443,   406,
-     299,    83,    74,   149,     0,     0,    74,   635,   376,   645,
-     646,   412,   533,   539,   543,   459,   331,   595,   586,   598,
-     585,     0,     0,   894,   946,   896,     0,     0,     0,   897,
-     897,   890,     0,   932,   943,     0,     0,   889,     0,   944,
-       0,   888,   887,   454,     0,   330,     0,     0,   105,     0,
-      74,   303,     0,     0,   544,     0,     0,   600,   631,   630,
-     592,     0,   947,   895,   902,   905,   391,     0,     0,   928,
-     936,   918,     0,   908,     0,     0,   944,     0,    84,    88,
-      89,    86,    87,    85,   107,    97,     0,   303,   121,     0,
-       0,     0,     0,     0,   892,     0,   922,   925,   911,     0,
-     948,     0,   944,    94,    76,     0,    74,   119,     0,     0,
-     302,   599,    74,     0,   945,   949,     0,   331,    74,    70,
-      71,     0,   106,     0,   303,     0,   373,   303,   893,   950,
-       0,    77,     0,    98,   116,   372,   601,     0,   102,     0,
-     299,    99,    78,     0,    74,    96,   331,     0,    79,     0,
-     103,   102,     0,    76,   299,    80,   101
+       0,     0,     0,   949,     0,   528,     0,     0,   529,     0,
+     559,     0,     0,     0,     0,     0,     0,     0,   411,   566,
+     567,   568,   569,   570,     0,    38,     0,   110,     0,     0,
+       0,     0,   884,   883,   517,     0,     0,     0,     0,     0,
+     172,     0,     0,   948,     0,   468,     0,     0,     0,   471,
+     469,   169,     0,   175,   335,   359,   357,   305,     0,     0,
+       0,   358,     0,     0,     0,    76,     0,   330,   415,   311,
+       0,     0,     0,   324,     0,   325,   319,     0,   316,   315,
+       0,   317,     0,     0,   334,     0,    90,    91,    88,    89,
+     326,   371,   314,     0,   423,   172,   533,     0,   539,     0,
+       0,     0,   521,     0,     0,   543,   547,     0,     0,   524,
+       0,     0,     0,     0,   458,     0,   465,     0,   519,     0,
+     473,   825,   815,     0,   773,     0,   829,   831,   836,   838,
+     843,   845,   613,   849,   615,   619,   852,   621,   785,   786,
+     798,   341,   397,     0,   669,   687,   869,    93,   618,     0,
+     624,     0,   606,     0,     0,     0,     0,   628,     0,     0,
+       0,   687,   694,     0,   596,   709,     0,   582,   640,     0,
+     649,     0,     0,   653,   903,   906,   348,     0,   353,   354,
+     352,     0,     0,   391,   389,     0,     0,     0,   933,   931,
+     338,     0,   940,   943,   380,   383,   386,   937,   935,   915,
+     919,   917,     0,   909,    76,     0,    39,     0,     0,     0,
+     372,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   175,     0,   942,   339,   470,     0,     0,   336,
+       0,     0,     0,     0,     0,   409,     0,    76,     0,   360,
+       0,     0,   345,     0,     0,   329,     0,     0,    71,   305,
+       0,   362,   333,   327,   328,     0,    83,    84,     0,   150,
+     150,     0,   318,   313,   320,   321,   322,   323,   370,     0,
+     312,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   175,
+       0,     0,     0,     0,   446,     0,     0,   544,     0,   532,
+       0,   522,     0,   336,   459,     0,     0,   520,   466,   462,
+       0,   760,   774,   759,   832,   839,   846,   800,   763,   764,
+     670,     0,   860,   865,     0,   716,   717,   630,   629,   301,
+     668,   673,     0,     0,   589,   592,     0,   643,     0,   651,
+       0,     0,   349,   355,     0,     0,   390,   923,   926,   929,
+       0,     0,     0,     0,     0,     0,     0,   900,     0,   912,
+       0,     0,   305,   572,     0,    36,    43,     0,   112,     0,
+     113,     0,   114,     0,     0,     0,     0,     0,   886,   885,
+     449,   581,   452,     0,     0,   444,     0,   406,   407,     0,
+     405,   404,     0,   412,   305,   361,   305,   346,     0,     0,
+      69,    70,   119,   363,     0,     0,     0,     0,   152,     0,
+       0,     0,     0,   646,   377,   376,   435,   436,   438,   437,
+     439,   429,   430,   431,   440,   441,   425,   426,   427,   428,
+     442,   443,   432,   433,   434,   424,    76,     0,   580,     0,
+     578,   447,   575,     0,     0,     0,   574,     0,   460,     0,
+     463,     0,   870,   715,     0,     0,   302,   307,   695,     0,
+     590,   591,   592,   593,   584,   599,   650,   900,   900,     0,
+       0,     0,     0,     0,   336,   944,   338,   381,   384,   387,
+       0,   901,   916,   900,     0,   900,   563,     0,   565,   573,
+      40,   111,   373,     0,     0,     0,     0,   888,   887,     0,
+       0,   455,     0,     0,     0,   410,   413,   364,   125,   124,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   305,
+     534,   540,     0,   579,   577,     0,   576,   765,   718,   631,
+       0,     0,   587,   584,   585,   586,   589,   899,   899,   392,
+       0,   900,   900,   891,     0,     0,   948,   899,   900,   891,
+     564,    37,     0,   115,   116,     0,     0,     0,   453,     0,
+       0,   445,   408,   301,    85,    76,   151,     0,     0,    76,
+     637,   378,   647,   648,   414,   535,   541,   545,   461,   333,
+     597,   588,   600,   587,     0,     0,   896,   948,   898,     0,
+       0,     0,   899,   899,   892,     0,   934,   945,     0,     0,
+     891,     0,   946,     0,   890,   889,   456,     0,   332,     0,
+       0,   107,     0,    76,   305,     0,     0,   546,     0,     0,
+     602,   633,   632,   594,     0,   949,   897,   904,   907,   393,
+       0,     0,   930,   938,   920,     0,   910,     0,     0,   946,
+       0,    86,    90,    91,    88,    89,    87,   109,    99,     0,
+     305,   123,     0,     0,     0,     0,     0,   894,     0,   924,
+     927,   913,     0,   950,     0,   946,    96,    78,     0,    76,
+     121,     0,     0,   304,   601,    76,     0,   947,   951,     0,
+     333,    76,    72,    73,     0,   108,     0,   305,     0,   375,
+     305,   895,   952,     0,    79,     0,   100,   118,   374,   603,
+       0,   104,     0,   301,   101,    80,     0,    76,    98,   333,
+       0,    81,     0,   105,   104,     0,    78,   301,    82,   103
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-   -1521, -1521,  -895,    -1, -1521, -1521, -1521, -1521, -1521,   823,
-    1371, -1521, -1521, -1521, -1521, -1521, -1521,  1454, -1521, -1521,
-   -1521,   364, -1521,  1323, -1521, -1521,  1377, -1521, -1521, -1521,
-   -1521,  -140,  -227, -1521, -1521, -1521, -1521, -1520,   746,   747,
-   -1521, -1521, -1521, -1521,  -223, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521,  -982, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521,  1265, -1521, -1521,   -45,  -103,  -337,   237, -1521, -1521,
-     395,   834,   845,   522,  -479,  -672, -1521,  -301, -1521, -1521,
-   -1521, -1278, -1521, -1521, -1494, -1521, -1521, -1020, -1521, -1521,
-   -1521, -1521, -1521, -1521,  -741,  -325, -1139,   770,   -13, -1521,
-   -1521, -1521, -1521, -1521, -1519, -1517, -1509, -1505, -1521, -1521,
-    1477, -1521, -1035, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521,  -456, -1315,   399,   121,
-   -1521,  -802, -1521,   419, -1521, -1521, -1521, -1521, -1404, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,   515,  1086,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,  -163,   -21,
-     -67,   -17,    58, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-     134,  -498,  -767, -1521,  -507,  -750, -1521,  -930,   -63,   -60,
-   -1521,  -562,  -560, -1521, -1521, -1521, -1213, -1521,  1449, -1521,
-   -1521, -1521, -1521, -1521,   370,   560, -1521,   840, -1521, -1521,
-   -1521, -1521, -1521, -1521,   561, -1521,  1212, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521,  -168, -1521,  1095, -1521, -1521, -1521,  1292, -1521,
-   -1521, -1521,  -550, -1521, -1521,  -330,  -887, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521,  -116, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521,  -816, -1387,  -606, -1521, -1521, -1257,
-   -1249,  1096, -1521, -1521, -1521, -1521, -1521, -1521, -1521, -1521,
-   -1521, -1521,  1098, -1521, -1521,  1101, -1521, -1521, -1521, -1521,
-   -1521, -1521, -1521, -1521, -1521, -1521,   919, -1521,  -420,  1118,
-   -1090,  -620,  1127,  -419
+   -1522, -1522,  -897,    -1, -1522, -1522, -1522, -1522, -1522,   953,
+    1493, -1522, -1522, -1522, -1522, -1522, -1522,  1573, -1522, -1522,
+   -1522,   369, -1522, -1522,  1390, -1522, -1522,  1497, -1522, -1522,
+   -1522, -1522,  -132,  -112, -1522, -1522, -1522, -1522, -1521,   861,
+     870, -1522, -1522, -1522, -1522,  -103, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522,  -993, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522,  1391, -1522, -1522,   -43,   -97,  -359,   353, -1522,
+   -1522,   494,   956,   960,   648,  -483,  -667, -1522,  -312, -1522,
+   -1522, -1522, -1229, -1522, -1522, -1488, -1522, -1522, -1023, -1522,
+   -1522, -1522, -1522, -1522, -1522,  -756,  -330, -1154,   895,   -13,
+   -1522, -1522, -1522, -1522, -1522, -1486, -1400, -1396, -1335, -1522,
+   -1522,  1611, -1522,  -992, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,  -452, -1313,   461,
+     238, -1522,  -796, -1522,   521, -1522, -1522, -1522, -1522, -1405,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,   410,
+    1044, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,  -162,
+     100,    51,    99,   174, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522,   279,  -505,  -770, -1522,  -513,  -762, -1522,  -932,    54,
+      55, -1522,  -569,  -563, -1522, -1522, -1522, -1223, -1522,  1570,
+   -1522, -1522, -1522, -1522, -1522,   484,   674, -1522,   991, -1522,
+   -1522, -1522, -1522, -1522, -1522,   676, -1522,  1327, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522,  -135, -1522,  1193, -1522, -1522, -1522,  1402,
+   -1522, -1522, -1522,  -567, -1522, -1522,  -284,  -881, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,  -161, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522,  -823, -1444,  -626, -1522, -1522,
+   -1258, -1295,  1202, -1522, -1522, -1522, -1522, -1522, -1522, -1522,
+   -1522, -1522, -1522,  1203, -1522, -1522,  1205, -1522, -1522, -1522,
+   -1522, -1522, -1522, -1522, -1522, -1522, -1522,  1032, -1522,  -425,
+    1208, -1166,  -615,  1210,  -421
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-       0,     1,   783,   784,    18,   142,    55,   188,    19,   175,
-     181,  1467,  1184,  1342,   625,   475,   148,   476,   102,    21,
-      22,    47,    48,    93,    23,    41,    42,  1047,  1048,  1661,
-     156,   157,  1662,  1678,  1691,  1235,  1587,  1049,   933,   934,
-    1644,  1657,  1677,  1645,  1682,  1686,  1692,  1683,  1050,  1051,
-    1625,  1052,  1006,  1053,  1054,  1055,  1056,  1057,  1058,  1059,
-    1060,   182,   183,    37,    38,    39,   202,  1386,    68,    69,
-      70,    71,   643,    24,   402,   556,   298,   299,   113,    25,
-     160,   300,   161,   196,  1434,  1507,  1631,   558,   559,  1136,
-     477,  1061,  1229,  1487,   851,   633,  1019,   709,   478,  1062,
-     584,   788,  1319,   479,  1063,  1064,  1065,  1066,  1067,   755,
-    1068,  1246,  1188,  1391,  1069,   480,   802,  1330,   803,  1331,
-     805,  1332,   481,   792,  1323,   482,   523,   560,   483,  1212,
-    1213,   849,   484,   647,   485,  1070,   486,   487,   840,   488,
-    1016,  1477,  1017,  1536,   489,   902,  1285,   490,   524,   492,
-    1267,  1552,  1269,  1553,  1420,  1594,   493,   494,   550,  1513,
-    1559,  1439,  1441,  1313,   951,  1144,  1596,  1633,   551,   552,
-     553,   700,   701,   721,   704,   705,   723,   831,   940,   941,
-    1600,   575,   422,   567,   312,  1495,   568,   313,    80,   120,
-     200,   308,    27,   171,   949,  1122,   950,    51,    52,   139,
-      28,   164,   198,   302,  1123,   265,   266,    29,   114,   765,
-    1309,   563,   304,   305,   117,   169,   769,    30,    78,   199,
-     564,   942,   495,   412,   253,   254,   910,   931,   190,   255,
-     692,  1289,   919,   578,   342,   256,   519,   257,   423,   959,
-     520,   707,   505,  1099,   424,   960,   425,   961,   504,  1098,
-     508,  1103,   509,  1291,   510,  1105,   511,  1292,   512,  1107,
-     513,  1293,   514,  1110,   515,  1113,   702,    31,    57,   267,
-     537,  1126,    32,    58,   268,   538,  1128,    33,    56,   345,
-     719,  1298,   586,   496,   637,  1572,   638,  1564,  1565,  1566,
-     969,   497,   786,  1317,   787,  1318,   813,  1337,   993,  1461,
-     809,  1334,   498,   810,  1335,   499,   973,  1448,   974,  1449,
-     975,  1450,   796,  1327,   807,  1333,  1020,   640,   500,   501,
-    1615,   714,   502,   503
+       0,     1,   786,   787,    18,   139,    52,   190,    19,   172,
+     178,  1470,  1187,  1345,   628,   478,   145,   479,    96,    21,
+      22,    87,    44,    45,   135,    23,    41,    42,  1050,  1051,
+    1664,   153,   154,  1665,  1681,  1694,  1238,  1590,  1052,   936,
+     937,  1647,  1660,  1680,  1648,  1685,  1689,  1695,  1686,  1053,
+    1054,  1628,  1055,  1009,  1056,  1057,  1058,  1059,  1060,  1061,
+    1062,  1063,   179,   180,    37,    38,    39,   204,  1389,    65,
+      66,    67,    68,   646,    24,   405,   559,   301,   302,   107,
+      25,   157,   303,   158,   198,  1437,  1510,  1634,   561,   562,
+    1139,   480,  1064,  1232,  1490,   854,   636,  1022,   712,   481,
+    1065,   587,   791,  1322,   482,  1066,  1067,  1068,  1069,  1070,
+     758,  1071,  1249,  1191,  1394,  1072,   483,   805,  1333,   806,
+    1334,   808,  1335,   484,   795,  1326,   485,   526,   563,   486,
+    1215,  1216,   852,   487,   650,   488,  1073,   489,   490,   843,
+     491,  1019,  1480,  1020,  1539,   492,   905,  1288,   493,   527,
+     495,  1270,  1555,  1272,  1556,  1423,  1597,   496,   497,   553,
+    1516,  1562,  1442,  1444,  1316,   954,  1147,  1599,  1636,   554,
+     555,   556,   703,   704,   724,   707,   708,   726,   834,   943,
+     944,  1603,   578,   425,   570,   315,  1498,   571,   316,    77,
+     114,   202,   311,    27,   168,   952,  1125,   953,    48,    49,
+     136,    28,   161,   200,   305,  1126,   268,   269,    29,   108,
+     768,  1312,   566,   307,   308,   111,   166,   772,    30,    75,
+     201,   567,   945,   498,   415,   256,   257,   913,   934,   192,
+     258,   695,  1292,   922,   581,   345,   259,   522,   260,   426,
+     962,   523,   710,   508,  1102,   427,   963,   428,   964,   507,
+    1101,   511,  1106,   512,  1294,   513,  1108,   514,  1295,   515,
+    1110,   516,  1296,   517,  1113,   518,  1116,   705,    31,    54,
+     270,   540,  1129,    32,    55,   271,   541,  1131,    33,    53,
+     348,   722,  1301,   589,   499,   640,  1575,   641,  1567,  1568,
+    1569,   972,   500,   789,  1320,   790,  1321,   816,  1340,   996,
+    1464,   812,  1337,   501,   813,  1338,   502,   976,  1451,   977,
+    1452,   978,  1453,   799,  1330,   810,  1336,  1023,   643,   503,
+     504,  1618,   717,   505,   506
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -1771,1213 +1772,1274 @@ static const yytype_int16 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      17,    61,    72,   150,   191,   192,   522,   774,   203,   776,
-     590,   593,  1135,   535,  1217,   636,   832,   834,   252,    73,
-      74,    75,   912,   947,   914,  1191,   916,  1024,  1328,   785,
-     694,   722,   696,  1392,   698,   846,  1121,   130,  1117,   720,
-     596,   121,   122,   991,  -168,  1189,  1585,   540,   542,  1351,
-    1072,    95,    72,    72,    72,  1121,  1483,  1511,   828,   548,
-      40,  1479,   708,   994,    34,    35,  1618,  1619,     2,  1620,
-     258,  1589,  -828,  1535,    62,     3,  1140,  1621,   548,  1592,
-     614,  1622,   421,  1195,    89,  1459,   527,    81,   924,   757,
-     571,   107,   108,   109,    72,    72,    72,    72,     4,   525,
-       5,   565,     6,    63,  1132,   830,   753,  1133,     7,   549,
-    1134,   201,   651,   652,   101,   572,   566,  1512,     8,    90,
-     758,   573,  -828,   330,     9,  1663,  1619,  -828,  1620,   828,
-     201,  1349,  1583,   176,   177,  1194,  1621,   597,   598,  1578,
-    1622,   426,   427,   331,   797,   416,  -828,    64,    10,   754,
-      79,   917,   149,  1389,   808,   922,   309,   811,  1390,   926,
-     403,   433,   574,  1687,  1619,   415,  1620,   435,  1350,   417,
-      11,    12,    65,   251,  1621,   252,   830,   977,  1622,    59,
-     981,  1551,   123,   968,    83,   845,  1685,   124,   989,   125,
-    1612,   992,   126,  1181,    82,  1514,  1515,    84,  1190,   307,
-    1696,  1141,  1190,    60,   442,   443,  1379,  1163,    36,   655,
-     656,  1524,   956,  1526,  1190,   599,    85,   661,  1361,   662,
-     663,   664,   665,   666,  1190,  1164,   127,  1297,  1294,   128,
-      66,   906,   528,    13,    15,   600,  1023,   329,   445,   446,
-      67,   615,  1142,  1297,   725,   526,  -835,    91,   979,   878,
-     879,   529,   252,  1003,    14,   252,   252,   252,  1567,    92,
-     530,   554,  1353,   517,    53,   418,    15,  1576,  1004,  1569,
-    1570,   798,    16,  -842,   178,    59,  1577,  -452,   569,   179,
-     110,   180,  1550,   518,   126,    88,   814,   565,   685,   686,
-     661,   634,    94,   663,   664,   110,  -835,   663,   664,    60,
-    1021,  -835,   566,    54,    13,  1005,   111,   576,   577,   579,
-      13,   555,  1607,  1608,  1522,  1472,   582,   828,  1632,  1465,
-    -835,  1028,   703,  -842,    13,   115,   116,  -452,  -842,   828,
-     251,    43,  -452,   967,   470,   829,   252,   252,  1022,   100,
-     252,   474,   252,    16,   252,  1548,   252,  -842,    44,    16,
-     828,  -452,   252,  1484,  1494,  1652,  1352,  1204,  1214,   634,
-    1154,   685,   686,    16,   830,   685,   686,   343,  1021,   252,
-    1030,    45,  1100,   926,  1432,   828,   830,   101,  1207,   828,
-    1101,  1533,    46,  1205,  1208,   829,   252,   252,   688,   689,
-    1363,   101,   693,  1148,   695,    13,   697,   830,  1296,   781,
-    1202,    13,    43,  1102,   710,  1562,   106,   251,   782,    87,
-     251,   251,   251,   343,  1209,  1114,   131,   583,   594,    44,
-    1159,  1111,   830,   651,   652,  1210,   830,   332,  1127,   112,
-    1211,    76,   155,   252,    16,  1125,   306,    82,   760,   761,
-      16,    86,    45,   955,   922,   155,   651,   652,   252,   133,
-     134,   601,   135,    46,   333,   334,   963,   964,   207,    77,
-     103,   104,   105,  1204,  1424,   194,   976,   608,  1025,    59,
-      49,   602,   983,   984,   609,   986,    50,   988,  1096,   990,
-    1338,    92,  1096,   856,   860,  1346,   208,  1369,  1381,  1480,
-    1204,   251,   251,    60,   610,   251,  1026,   251,   874,   251,
-     841,   251,   151,   152,   153,   154,  1097,   251,   565,  1544,
-    1155,    82,  1096,  1347,   938,  1370,  1502,   903,   335,  1096,
-     655,   656,   336,   566,   251,  1384,  1641,  1360,   661,   939,
-     201,   663,   664,   665,   666,  1096,    59,  1543,  1199,   252,
-    1418,   251,   251,   655,   656,   836,  1534,  1425,   612,   766,
-     837,   661,  1656,   662,   663,   664,   665,   666,   781,    13,
-      60,  1096,  1096,  1427,  1346,   147,   790,   782,   613,   337,
-     775,  1628,   136,   338,  1096,   978,   339,   838,  1346,   189,
-     651,   652,   155,  -764,  1096,  1204,   791,  1096,   251,  1466,
-    1470,   710,  1531,  1266,  1413,   869,  1509,  1204,    16,   685,
-     686,   340,  1532,   251,   870,   252,  1547,  1647,   137,   682,
-     683,   684,  1584,  1634,   922,  1646,  1440,   252,   252,   252,
-     252,  1272,   685,   686,   252,  1668,   839,   138,   252,    72,
-     165,   781,    13,  1282,   252,   252,    59,   252,  1287,   252,
-     782,   252,   252,  1162,  1674,   836,   143,  1676,   918,  1168,
-    1012,   166,   781,    13,   948,   781,  1658,   781,    13,  1013,
-      60,   782,   144,  1179,   782,   343,   782,  1659,  1660,   962,
-    1085,    16,   965,  1090,   921,   781,   972,   655,   656,  1086,
-     472,   644,  1091,   645,   782,   661,  1198,   662,   663,   664,
-     665,   666,    16,   634,   251,   204,   205,    16,  1563,  1563,
-     781,    13,  1021,   260,  1571,   145,   118,   140,  1563,   782,
-    1571,   343,   119,   141,   146,   778,  1083,   925,   261,   170,
-     932,   419,   932,   262,   420,   263,  1341,   421,   158,   772,
-     781,    13,   773,  1348,   159,   421,   107,   108,   109,   782,
-      16,   680,   681,   682,   683,   684,  1601,  1115,   107,   252,
-     109,   252,   252,  1563,  1563,   343,   685,   686,   252,   779,
-     251,  1571,   172,   173,   174,   252,   651,   652,   781,    13,
-      16,   184,   251,   251,   251,   251,   958,   782,   162,   251,
-     167,  1437,    90,   251,   163,  1158,   168,  1438,   187,   251,
-     251,   343,   251,   186,   251,   907,   251,   251,   343,   343,
-     193,  1109,   908,   911,  1112,   252,   252,   189,    16,   107,
-    1118,   252,   781,    13,   343,  1595,   343,   195,   913,  1653,
-     915,   782,   204,   205,   206,   252,   332,   781,    13,  1177,
-     343,   343,   201,   491,  1153,  1161,   782,   343,  1404,  1405,
-     259,  1498,   343,   516,  1180,   197,  1554,   209,   252,   264,
-    1046,   301,    16,   333,   334,   303,   532,   172,   173,   821,
-     822,   653,   654,   655,   656,   657,   311,    16,   658,   659,
-     660,   661,   315,   662,   663,   664,   665,   666,   316,   667,
-     668,   767,   768,   332,   310,   670,   646,   672,   646,   646,
-     943,   944,   945,  1233,  1234,  1473,    97,    98,    99,  1385,
-    1385,   318,  1226,  1575,   251,   321,   251,   251,   648,   649,
-     333,   334,   317,   251,   319,   320,  1670,   335,   323,   324,
-     251,   336,   675,   676,   677,   678,   679,   680,   681,   682,
-     683,   684,  1124,   325,  1124,   326,   327,  1414,   343,   341,
-     328,   344,   685,   686,  1603,  1689,  1046,   346,   347,   399,
-     781,    13,   400,   414,  1147,   506,  1150,   401,   507,   782,
-     251,   251,   781,    13,   533,   252,   251,  1325,   337,   536,
-     543,   782,   338,   545,   335,   339,   546,   572,   336,  1326,
-     251,  1312,   332,   573,   544,   557,   547,  1593,   404,   561,
-      16,   562,   405,   570,   580,   603,   581,   595,   651,   652,
-     340,  1523,    16,   251,   604,   605,   406,   407,   606,   333,
-     334,   408,   409,   410,   411,    13,   607,  1304,   608,   611,
-     619,   616,   620,  1537,   574,   337,   621,   622,   623,   338,
-     642,  1630,   339,   624,   639,   641,   711,   687,  1222,   650,
-     691,  1339,   703,   690,   706,   712,  1230,  1231,   718,   713,
-     715,   332,   716,   756,    16,   752,   770,   340,   759,  1239,
-     771,  1240,  1241,  1242,  1243,  1244,   764,  1648,   780,  1247,
-     789,   793,   794,   335,  1371,   795,   812,   336,   333,   334,
-     824,   825,   827,   826,   833,   848,   835,   867,   909,   850,
-     777,   920,   929,   653,   654,   655,   656,   657,   930,   252,
-     658,   252,   948,   661,   953,   662,   663,   664,   665,   666,
-     954,   667,   668,   651,   652,   970,   980,   799,   801,   982,
-     251,   804,   985,   806,   337,  1073,  1521,   987,   338,   996,
-     995,   339,   997,  1626,   815,   816,   817,   818,   819,   820,
-    1075,   998,   335,   999,  1007,   572,   336,  1000,  1316,  1001,
-    1014,   573,  1079,  1416,   332,  1011,   340,   678,   679,   680,
-     681,   682,   683,   684,  1015,  1093,  1027,  1029,  1074,  1076,
-    1077,  1078,  1088,  1089,   685,   686,  1094,  1095,  1104,   871,
-    1106,   333,   334,  1108,  1116,   518,  1120,  1129,  1130,  1131,
-    1137,  1145,   574,   337,  1146,  1156,  1157,   338,  1183,  1160,
-     339,   904,  1166,   332,  1167,  1186,  1170,   252,   653,   654,
-     655,   656,  1175,  1187,  1178,  1182,  1201,  1220,   661,  1185,
-     662,   663,   664,   665,   666,   340,   667,   668,   928,  1192,
-     333,   334,  1193,  1200,  1221,  1203,   332,  1232,  1223,  1236,
-    1237,  1238,  1245,  1274,  1275,   335,  1277,  1278,  1284,   336,
-    1288,  1283,   252,  1290,   251,  1311,   251,  1302,  1299,  1485,
-    1303,  1300,  1629,   333,   334,  1306,  1310,   937,   252,  1314,
-    1320,  1322,  1321,  1496,   680,   681,   682,   683,   684,  1345,
-    1343,  1490,  1364,  1365,  1357,   952,  1358,  1367,  1366,   685,
-     686,   957,  1362,  1368,   335,  1373,   337,  1375,   336,  1376,
-     338,  1378,  1151,   339,  1499,  1377,   971,  1382,  1428,  1431,
-    1383,  1388,  1442,  1415,  1443,  1417,  1419,  1433,  1423,  1429,
-    1508,  1436,  1440,   651,   652,  1447,  1458,   335,   340,  1430,
-    1469,   336,  1435,  1444,  1471,  1445,  1451,  1002,  1452,  1453,
-    1457,  1460,  1008,  1462,  1009,   337,  1010,  1478,  1481,   338,
-    1468,  1152,   339,  1476,  1491,  1492,   799,  1500,  1501,  1503,
-    1505,  1516,   251,  1517,  1530,  1518,  1556,   332,   726,   727,
-     728,   729,   730,   731,   732,   733,  1527,   340,   337,  1519,
-    1046,  1520,   338,  1525,  1165,   339,  1528,  1538,  1529,  1539,
-    1541,  1558,  1542,   734,   333,   334,  1540,  1546,  1580,  1555,
-    1586,  1573,  1588,   735,   736,   737,  1591,   251,  1574,  1590,
-     340,  1204,  1087,  1602,  1604,  1605,  1092,  1606,   653,   654,
-     655,   656,   657,   251,   252,   658,   659,   660,   661,  1609,
-     662,   663,   664,   665,   666,  1610,   667,   668,  1611,  1614,
-    1613,  1640,  1119,  1635,  1639,  1617,  1636,  1637,   823,  1638,
-    1627,  1655,   129,  1672,  1643,    20,  1650,  1669,   335,   185,
-    1680,   132,   336,  1681,   839,  1684,  1695,  1694,  1693,   935,
-     936,  1149,   314,  1143,  1387,   332,   847,   923,    26,   675,
-     676,   677,   678,   679,   680,   681,   682,   683,   684,  1560,
-    1482,   852,   332,  1597,  1549,  1169,  1561,  1510,  1598,   685,
-     686,  1599,   333,   334,    96,   332,  1664,  1557,  1308,   337,
-    1138,  1139,  1667,   338,   413,  1171,   339,   322,  1671,   333,
-     334,   800,     0,   839,     0,   585,   587,     0,   588,  1196,
-    1197,   589,   333,   334,   617,   618,     0,     0,     0,     0,
-     928,   340,     0,     0,  1688,     0,     0,  1216,   591,     0,
-    1219,   626,   627,   628,   629,   630,  1225,   592,  1228,     0,
-       0,     0,     0,     0,     0,     0,   335,     0,     0,     0,
-     336,     0,     0,     0,     0,     0,     0,     0,     0,   251,
-       0,     0,     0,   335,     0,     0,  1624,   336,     0,  1268,
-       0,  1270,     0,  1273,  1046,     0,   335,     0,     0,     0,
-     336,     0,     0,  1279,     0,     0,     0,     0,     0,     0,
-       0,   928,     0,     0,     0,     0,     0,   337,   651,   652,
-       0,   338,     0,  1172,   339,     0,     0,     0,     0,     0,
-       0,  1651,     0,     0,   337,  1295,     0,     0,   338,     0,
-    1173,   339,     0,   763,     0,  1301,     0,   337,  1666,   340,
-    1305,   338,  1307,  1174,   339,     0,     0,     0,     0,     0,
-       0,     0,  1673,  1315,  1675,     0,   340,     0,     0,  1046,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   340,
-       0,     0,   799,     0,     0,     0,  1690,     0,  1046,     0,
+      17,    58,    69,   147,   525,   779,   205,   777,   593,   193,
+     194,   950,   596,  1138,  1220,   788,  1331,  1194,   849,    70,
+      71,    72,   639,  1027,   835,   837,  1395,   261,   725,   697,
+     915,   699,   917,   701,   919,   723,   124,  1124,   530,   543,
+     545,  -170,  1462,   994,   617,   528,   599,  1120,    89,    69,
+      69,    69,  1514,   255,   997,  1588,  1124,   131,    59,  1075,
+    1192,  1486,   538,  -830,  1354,  1482,  -837,   551,  1621,   711,
+       2,   568,  1592,  1143,  -844,  1538,    50,     3,    34,    35,
+    -454,   101,   102,   103,  1198,  1581,   569,    60,    69,    69,
+      69,    69,   132,    13,  1006,   551,   927,    73,   152,   568,
+       4,    40,     5,  1622,     6,   346,  1387,   109,   110,  1007,
+       7,   203,  1515,  -830,   569,    51,  -837,   552,  -830,   203,
+       8,  -837,    95,  1392,  -844,    74,     9,  1666,  1393,  -844,
+    -454,    61,    16,   611,  1586,  -454,  1615,  -830,   756,   574,
+    -837,   925,   146,   600,   601,   929,  1008,   203,  -844,   419,
+      10,   800,  1517,  1518,  -454,   335,    62,   115,   116,   920,
+     312,   811,  1622,    56,   814,  1690,   971,  1352,  1527,    79,
+    1529,   406,    11,    12,   333,   254,   418,   173,   174,   557,
+     420,   757,   336,   337,   531,   980,  1554,    57,   984,  1623,
+      43,   529,   848,  1624,   334,  1688,   992,   196,  1144,   995,
+    1622,   310,  1184,   532,  1353,   618,  1382,  1166,   959,  1699,
+    1364,   255,   533,  1193,    63,    76,  1167,  1193,  1193,  1026,
+     133,   602,    36,    78,    64,  1193,  1572,  1573,  1300,   558,
+     831,    15,   134,  1580,   982,    13,   728,  1297,   909,  1145,
+     332,   603,   666,   667,  1300,   209,   338,   881,  1623,   575,
+     339,   882,  1624,   335,  1625,   576,    14,  1028,   429,   430,
+    1570,    79,   831,  1356,   760,   579,   580,   582,    15,  1579,
+     421,    80,   152,   210,    16,  1553,  1135,   833,   436,  1136,
+     336,   337,  1137,    81,   438,  1029,  1623,    13,   255,   572,
+    1624,   255,   255,   255,   831,   761,   577,   340,   117,    13,
+     832,   341,  1525,   118,   342,   119,    95,  1341,   120,   833,
+     688,   689,   346,  1625,  1610,  1611,    95,    83,   175,  1468,
+     801,   445,   446,   176,   575,   177,    16,   637,   120,   343,
+     576,   654,   655,   254,    84,   817,  1024,  1099,    16,    82,
+     970,   833,   121,  1157,   338,   122,   691,   692,   339,    88,
+     696,  1625,   698,  1487,   700,   448,   449,    85,   637,   929,
+     100,  1475,   713,  1099,   104,  1100,  1217,  1024,    86,  1033,
+    1635,   577,   255,   255,  1025,  1435,   255,   706,   255,    13,
+     255,    46,   255,   520,   784,    13,  1366,    47,   255,  1151,
+     105,  1158,    56,   785,   568,   340,   763,   764,    94,   341,
+    1497,   981,   342,   521,  1565,   255,  1162,  1655,  1205,   569,
+     254,    13,  1117,   254,   254,   254,    57,  1114,    16,   106,
+     586,   597,   255,   255,    16,  1130,    83,   343,   658,   659,
+     925,  1128,   101,   585,   103,  1349,   664,    56,   665,   666,
+     667,   668,   669,    84,   104,   664,  1372,  1103,   666,   667,
+      16,   473,  1551,  1644,   129,  1104,   831,   125,   477,   335,
+    1427,    57,  1197,  1350,   191,   128,    85,  1207,  -766,   255,
+    1031,   784,   654,   655,  1373,   127,  1384,    86,  1105,  1659,
+     785,  1099,   831,   831,   255,   831,   336,   337,   832,  1355,
+    1099,  1536,   958,  1208,   254,   254,   182,   183,   254,   184,
+     254,  1547,   254,   833,   254,   966,   967,   688,   689,  1421,
+     254,   844,   654,   655,  1207,   979,   688,   689,  1428,   859,
+     863,   986,   987,  1099,   989,    13,   991,   254,   993,   833,
+     833,   130,   833,  1595,   877,  1363,   424,  1202,   140,  1099,
+    1483,   604,  1210,   612,   254,   254,  1099,  1537,  1211,   713,
+     338,  1430,   769,   906,   339,   144,    97,    98,    99,   784,
+      13,   605,  1349,   613,    16,  1099,   309,  1469,   785,   658,
+     659,  1631,   346,   778,  1473,   255,  1349,   664,  1212,   665,
+     666,   667,   668,   669,  1099,  1207,  1099,  1207,   941,  1213,
+    1534,   254,  1269,  1535,  1214,   148,   149,   150,   151,    16,
+     925,   340,  1416,   942,  1550,   341,   254,  1650,   342,   658,
+     659,   141,  1587,  1637,  1649,  1671,  1207,   664,   615,   793,
+     666,   667,   668,   669,   335,   142,  1512,   965,  1275,   842,
+     968,    79,    69,   343,   975,   685,   686,   687,   616,   794,
+    1285,   255,  1505,   143,  1677,  1290,  1443,  1679,   688,   689,
+      56,   336,   337,   255,   255,   255,   255,  1546,    56,   839,
+     255,   407,   112,   422,   255,   408,   423,   839,   113,   424,
+     255,   255,   840,   255,    57,   255,   162,   255,   255,   409,
+     410,   263,    57,   152,   411,   412,   413,   414,   688,   689,
+     770,   771,  1165,   872,  1566,  1566,   264,   254,  1171,   841,
+    1574,   265,   873,   266,  1566,  1661,  1574,   346,   163,   654,
+     655,   781,  1182,   784,    13,   338,  1662,  1663,   575,   339,
+     784,    13,   785,   935,   576,   935,   137,   784,    13,   785,
+     921,   494,   138,  1344,  1015,  1201,   785,   924,  1299,   784,
+    1351,   519,  1604,  1016,   928,   951,   784,  1088,   785,  1566,
+    1566,   167,  1086,    16,   535,   785,  1089,  1574,   775,  1112,
+      16,   776,  1115,   254,   424,   577,   340,    16,  1121,   181,
+     341,  1093,   637,   342,   134,   254,   254,   254,   254,   961,
+    1094,  1024,   254,   155,   159,   255,   254,   255,   255,   156,
+     160,   185,   254,   254,   255,   254,   164,   254,   343,   254,
+     254,   255,   165,  1598,   656,   657,   658,   659,   660,   206,
+     207,   661,   662,   663,   664,  1656,   665,   666,   667,   668,
+     669,  1440,   670,   671,   335,   188,   672,  1441,   673,   674,
+     675,   346,  1236,  1237,   676,   782,  1407,   784,    13,   346,
+    1408,   255,   255,   910,   195,   346,   785,   255,   335,   911,
+     186,   336,   337,  1049,  1118,   346,   346,   187,   346,   914,
+     916,   255,   918,   677,  1087,   678,   679,   680,   681,   682,
+     683,   684,   685,   686,   687,   336,   337,    16,   346,   346,
+    1388,  1388,  1156,  1164,   255,   688,   689,   189,   191,   741,
+     742,   743,   744,   745,   746,   747,   748,   346,   101,   346,
+     197,  1501,  1476,  1557,  1673,   199,   203,   254,   749,   254,
+     254,  1578,   211,  1229,   750,   338,   254,   475,   647,   339,
+     648,   784,    13,   254,   751,   752,   753,   784,    13,   132,
+     785,   784,    13,  1692,   714,  1127,   785,  1127,  1161,   338,
+     785,   784,    13,   339,  1180,   262,   721,   267,  1183,  1049,
+     785,   649,  1606,   649,   649,   754,   304,  1150,  1328,  1153,
+     306,    16,   313,   254,   254,   314,   340,    16,   318,   254,
+     341,    16,   998,   342,   319,  1307,   169,   170,   824,   825,
+     320,    16,   321,   254,   322,  1315,  1417,  1596,   780,   324,
+     340,   101,   102,   103,   341,   331,  1154,   342,   343,   654,
+     655,   255,   349,   784,    13,   323,   254,   326,  1526,   169,
+     170,   171,   785,   651,   652,   802,   804,   327,   328,   807,
+    1329,   809,   343,   206,   207,   208,   329,  1633,   330,   344,
+    1540,   347,   818,   819,   820,   821,   822,   823,   946,   947,
+     948,  1225,   346,    16,    91,    92,    93,   402,   350,  1233,
+    1234,   403,  1342,   404,   729,   730,   731,   732,   733,   734,
+     735,   736,  1242,  1651,  1243,  1244,  1245,  1246,  1247,   417,
+     509,   510,  1250,   536,   539,   546,   547,   874,   548,   737,
+     549,   550,   560,   564,   565,  1374,   573,   654,   655,   738,
+     739,   740,   606,   583,   656,   657,   658,   659,   660,   907,
+     584,   661,   662,   663,   664,   598,   665,   666,   667,   668,
+     669,  1419,   670,   671,   607,   608,   609,   610,   673,   674,
+     675,   611,   614,   254,  1524,   619,   931,   622,   623,   624,
+     625,   626,   627,   694,   645,   255,   642,   255,   644,   690,
+    1629,   653,   693,   706,   709,   716,   774,   718,   715,   719,
+     762,  1319,   783,   677,   755,   678,   679,   680,   681,   682,
+     683,   684,   685,   686,   687,   940,   759,   773,   767,   792,
+     796,   828,   654,   655,   797,   688,   689,   798,   815,   827,
+     829,   836,   830,   955,   658,   659,   838,   851,   870,   960,
+     853,   912,   664,   923,   665,   666,   667,   668,   669,   932,
+     933,   951,   956,   957,   974,   335,   973,   983,   985,  1010,
+     335,   654,   655,  1076,   988,   990,   999,  1488,  1096,  1000,
+    1001,  1002,  1003,  1004,  1014,  1030,  1017,  1018,  1078,  1032,
+    1077,  1079,   336,   337,  1082,  1005,  1080,   336,   337,  1107,
+    1011,  1081,  1012,   255,  1013,  1091,  1092,  1097,   683,   684,
+     685,   686,   687,  1098,   802,  1109,  1111,   254,  1119,   254,
+     521,  1123,  1502,   688,   689,  1132,  1134,   656,   657,   658,
+     659,   660,  1133,  1140,   661,   662,   663,   664,  1511,   665,
+     666,   667,   668,   669,  1499,   670,   671,  1148,   255,   672,
+    1493,   673,   674,   675,  1149,  1159,   338,   676,  1160,  1163,
+     339,   338,  1169,  1173,   255,   339,   656,   657,   658,   659,
+    1090,  1632,  1170,  1185,  1095,  1445,   664,  1446,   665,   666,
+     667,   668,   669,  1178,   670,   671,   677,  1181,   678,   679,
+     680,   681,   682,   683,   684,   685,   686,   687,  1186,  1188,
+    1122,  1189,  1190,  1195,  1196,  1203,  1204,   340,   688,   689,
+    1206,   341,   340,  1155,   342,  1223,   341,  1224,  1168,   342,
+    1226,  1235,  1239,  1240,  1241,   254,  1248,  1277,  1278,  1152,
+    1280,  1286,   683,   684,   685,   686,   687,  1281,  1291,   343,
+    1287,  1293,  1302,  1049,   343,  1305,  1303,   688,   689,  1306,
+    1309,  1313,  1314,  1172,  1317,  1325,  1323,  1324,  1346,  1348,
+    1360,  1361,  1365,   335,  1367,  1368,  1369,  1370,  1371,  1376,
+     254,  1378,  1379,  1591,  1381,  1380,   335,  1594,  1432,  1385,
+    1386,  1391,  1431,  1434,  1436,  1418,   254,  1199,  1200,  1439,
+     336,   337,  1443,  1450,  1420,  1422,  1426,   335,   931,  1461,
+    1472,  1433,  1474,   336,   337,  1219,   335,  1447,  1222,  1438,
+    1448,  1481,  1484,  1454,  1228,  1455,  1231,  1456,  1508,  1460,
+     255,  1630,  1463,  1465,   336,   337,  1471,   842,  1479,  1494,
+    1531,  1495,  1520,   336,   337,   335,  1503,  1504,  1532,  1506,
+    1519,  1521,  1522,  1523,  1528,  1559,  1530,  1271,  1533,  1273,
+    1561,  1276,  1541,  1542,   338,   620,   621,  1552,   339,  1543,
+    1544,  1282,   336,   337,  1589,  1545,  1549,   338,   335,   931,
+    1560,   339,   629,   630,   631,   632,   633,  1667,  1558,  1576,
+    1577,  1207,  1593,  1670,  1583,  1605,   842,  1607,   338,  1674,
+    1608,  1609,   339,  1298,  1612,   336,   337,   338,  1613,  1614,
+    1616,   339,  1639,  1304,  1617,   340,  1620,  1638,  1308,   341,
+    1310,  1174,   342,  1642,  1640,  1691,  1641,  1643,   340,  1658,
+    1687,  1318,   341,  1653,  1175,   342,   338,  1646,  1675,  1672,
+     339,   123,  1683,  1697,    20,   212,  1684,   343,   126,   340,
+     802,   826,   254,   341,  1698,  1176,   342,   938,   340,  1627,
+     343,  1696,   341,  1390,  1177,   342,   939,  1049,  1347,   338,
+     317,   850,  1146,   339,   766,   926,  1357,  1358,  1359,   855,
+    1485,   343,    26,  1563,  1600,  1564,  1513,   340,  1601,  1602,
+     343,   341,    90,  1179,   342,  1311,   588,  1141,  1375,  1142,
+     325,  1377,   416,     0,  1654,   590,   591,   803,   592,     0,
+    1383,   594,   335,   595,     0,     0,     0,     0,     0,   343,
+     340,  1669,     0,     0,   341,     0,  1327,   342,   335,     0,
+       0,     0,   654,   655,     0,  1676,     0,  1678,     0,   336,
+     337,     0,  1049,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   343,     0,     0,   336,   337,     0,  1424,  1693,
+    1425,  1049,     0,     0,     0,     0,  1429,     0,     0,     0,
+     864,   865,     0,     0,   866,   867,   868,   869,     0,   871,
+       0,     0,   875,   876,   878,   879,   880,   883,   884,   885,
+     886,   888,   889,   890,   891,   892,   893,   894,   895,   896,
+     897,   898,     0,   338,  1449,     0,     0,   339,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   338,
+       0,  1467,     0,   339,     0,     0,     0,   656,   657,   658,
+     659,   660,     0,     0,   661,  1477,  1478,   664,     0,   665,
+     666,   667,   668,   669,     0,   670,   671,     0,     0,     0,
+       0,     0,     0,     0,   340,     0,     0,     0,   341,  1489,
+    1332,   342,     0,     0,     0,  1491,  1492,     0,     0,     0,
+     340,  1496,     0,     0,   341,     0,  1339,   342,     0,   949,
+       0,     0,     0,     0,     0,     0,   343,     0,     0,     0,
+       0,   681,   682,   683,   684,   685,   686,   687,     0,     0,
+       0,     0,   343,     0,     0,     0,     0,     0,   688,   689,
+       0,  1507,     0,     0,     0,  1509,     0,     0,     0,     0,
+     -87,     0,     0,     0,     0,     0,     0,   856,     0,     0,
+       0,   654,   655,     0,     0,     0,   802,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-    1344,     0,     0,     0,     0,     0,     0,   -85,  1354,  1355,
-    1356,     0,     0,   653,   654,   655,   656,   657,   651,   652,
-     658,   659,   660,   661,     0,   662,   663,   664,   665,   666,
-    1372,   667,   668,  1374,     0,     0,     0,   670,     0,   861,
-     862,     0,  1380,   863,   864,   865,   866,     0,   868,     0,
-       0,   872,   873,   875,   876,   877,   880,   881,   882,   883,
-     885,   886,   887,   888,   889,   890,   891,   892,   893,   894,
-     895,     0,     0,     0,   675,   676,   677,   678,   679,   680,
-     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
-    1421,     0,  1422,     0,   685,   686,     0,     0,  1426,     0,
-       0,     0,     0,     0,     0,  1248,  1249,  1250,  1251,  1252,
-    1253,  1254,  1255,   653,   654,   655,   656,   657,  1256,  1257,
-     658,   659,   660,   661,  1258,   662,   663,   664,   665,   666,
-    1259,   667,   668,  1260,  1261,   669,  1446,   670,   671,   672,
-    1262,  1263,  1264,   673,     0,     0,     0,     0,   946,     0,
-       0,     0,     0,  1464,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,  1474,  1475,     0,
-       0,  1265,   674,     0,   675,   676,   677,   678,   679,   680,
-     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
-       0,  1486,     0,     0,   685,   686,     0,  1488,  1489,     0,
-       0,     0,     0,  1493,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   651,   652,     0,   210,     0,
-       0,     0,     0,     0,   211,     0,     0,     0,     0,     0,
-     212,     0,     0,     0,     0,     0,     0,  1071,     0,     0,
-     213,     0,     0,  1504,     0,     0,     0,  1506,   214,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   215,     0,     0,     0,     0,   799,     0,
-     216,   217,   218,   219,   220,   221,   222,   223,   224,   225,
-     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,   237,   238,   239,   240,   241,   242,   243,   244,   245,
-     246,   247,   248,     0,     0,     0,     0,  1545,     0,     0,
-     653,   654,   655,   656,   657,     0,     0,   658,   659,   660,
-     661,     0,   662,   663,   664,   665,   666,     0,   667,   668,
-       0,     0,  1568,  1071,   670,   671,   672,     0,    59,     0,
-       0,     0,     0,     0,  1579,     0,     0,     0,  1581,  1582,
-       0,   249,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    60,     0,     0,     0,     0,     0,     0,   674,
-       0,   675,   676,   677,   678,   679,   680,   681,   682,   683,
-     684,     0,     0,     0,   332,     0,     0,     0,     0,   332,
-       0,   685,   686,     0,     0,  1616,     0,     0,     0,     0,
-       0,   250,     0,     0,     0,     0,   534,     0,     0,     0,
-       0,   333,   334,     0,     0,     0,   333,   334,     0,     0,
-       0,     0,     0,     0,     0,     0,   426,   427,     0,     0,
-       0,     0,  1642,     0,     0,     0,   428,   429,   430,   431,
-     432,     0,     0,     0,     0,  1649,   433,     0,   434,     0,
-       0,     0,   435,     0,  1654,     0,     0,     0,     0,     0,
-     436,     0,     0,  1665,     0,     0,   437,     0,     0,   438,
-    1276,     0,   439,     0,     0,   335,   440,     0,     0,   336,
-     335,     0,     0,     0,   336,     0,   441,  1679,     0,   442,
-     443,   842,   216,   217,   218,     0,   220,   221,   222,   223,
-     224,   444,   226,   227,   228,   229,   230,   231,   232,   233,
-     234,   235,   236,     0,   238,   239,   240,     0,     0,   243,
-     244,   245,   246,   445,   446,   447,   337,     0,     0,     0,
-     338,   337,  1176,   339,     0,   338,     0,  1324,   339,   448,
-     449,     0,     0,     0,     0,     0,     0,     0,   521,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   340,     0,
-      59,     0,     0,   340,     0,     0,     0,     0,   450,   451,
-     452,   453,   454,     0,   455,   634,   456,   457,   458,   459,
-     460,   461,   462,   463,   635,     0,     0,   464,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,  1074,     0,
+       0,     0,     0,     0,     0,  1548,     0,   335,     0,   219,
+     220,   221,     0,   223,   224,   225,   226,   227,   447,   229,
+     230,   231,   232,   233,   234,   235,   236,   237,   238,   239,
+    1571,   241,   242,   243,   336,   337,   246,   247,   248,   249,
+       0,     0,  1582,     0,     0,     0,  1584,  1585,  1251,  1252,
+    1253,  1254,  1255,  1256,  1257,  1258,   656,   657,   658,   659,
+     660,  1259,  1260,   661,   662,   663,   664,  1261,   665,   666,
+     667,   668,   669,  1262,   670,   671,  1263,  1264,   672,     0,
+     673,   674,   675,  1265,  1266,  1267,   676,     0,     0,     0,
+       0,     0,   857,  1619,  1074,     0,     0,     0,   338,     0,
+       0,   858,   339,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,  1268,   677,     0,   678,   679,   680,
+     681,   682,   683,   684,   685,   686,   687,     0,     0,     0,
+    1645,     0,     0,     0,     0,     0,     0,   688,   689,     0,
+       0,     0,     0,  1652,     0,     0,     0,     0,     0,   340,
+       0,     0,  1657,   341,     0,  1362,   342,     0,     0,     0,
+       0,  1668,  1034,     0,     0,     0,   429,   430,     3,     0,
+    -120,  -106,  -106,     0,  -117,     0,   431,   432,   433,   434,
+     435,   343,     0,     0,     0,  1682,   436,  1035,   437,  1036,
+    1037,     0,   438,     0,     0,     0,     0,     0,     0,  1038,
+     439,  1039,     0,  -122,     0,  1040,   440,     0,     0,   441,
+       0,     8,   442,  1041,     0,  1042,   443,     0,     0,  1043,
+    1044,     0,     0,     0,     0,     0,  1045,     0,     0,   445,
+     446,  1279,   219,   220,   221,     0,   223,   224,   225,   226,
+     227,   447,   229,   230,   231,   232,   233,   234,   235,   236,
+     237,   238,   239,     0,   241,   242,   243,     0,     0,   246,
+     247,   248,   249,   448,   449,   450,  1046,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   451,
+     452,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
-     468,   469,     0,     0,     0,     0,     0,     0,     0,   843,
-       0,   471,   844,   472,   473,     0,   474,     0,     0,     0,
-       0,     0,     0,     0,  1393,  1394,  1395,  1396,  1397,  1398,
-    1399,  1400,  1401,  1402,  1403,  1406,  1407,  1408,  1409,  1410,
-    1411,  1412,     0,     0,     0,  1031,     0,     0,     0,   426,
-     427,     3,     0,  -118,  -104,  -104,     0,  -115,     0,   428,
-     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
-    1032,   434,  1033,  1034,     0,   435,     0,     0,     0,     0,
-       0,     0,  1035,   436,  1036,     0,  -120,     0,  1037,   437,
-       0,     0,   438,     0,     8,   439,  1038,     0,  1039,   440,
-       0,     0,  1040,  1041,     0,     0,  1454,  1455,  1456,  1042,
-       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
-     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
-     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
-       0,     0,   243,   244,   245,   246,   445,   446,   447,  1043,
-       0,     0,     0,     0,     0,     0,     0,  1071,     0,     0,
-       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
+      56,     0,     0,     0,     0,     0,     0,     0,   453,   454,
+     455,   456,   457,     0,   458,     0,   459,   460,   461,   462,
+     463,   464,   465,   466,    57,     0,    13,   467,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
-       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
-     457,   458,   459,   460,   461,   462,   463,    60,     0,    13,
-     464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
-      14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
-       0,     0,   470,     0,   471,     0,   472,   473,    16,  1044,
-    1045,  1031,     0,     0,     0,   426,   427,     3,     0,  -118,
-    -104,  -104,     0,  -115,     0,   428,   429,   430,   431,   432,
-       0,     0,     0,     0,     0,   433,  1032,   434,  1033,  1034,
-       0,   435,     0,     0,     0,     0,     0,     0,  1035,   436,
-    1036,     0,  -120,     0,  1037,   437,     0,     0,   438,     0,
-       8,   439,  1038,     0,  1039,   440,     0,     0,  1040,  1041,
-       0,     0,     0,     0,     0,  1042,     0,     0,   442,   443,
-       0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
-     444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
-     235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
-     245,   246,   445,   446,   447,  1043,     0,     0,     0,     0,
-       0,     0,  1623,     0,     0,     0,     0,     0,   448,   449,
-       0,  1071,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
-       0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
-     453,   454,     0,   455,     0,   456,   457,   458,   459,   460,
-     461,   462,   463,    60,     0,    13,   464,     0,     0,     0,
-       0,  1623,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
-     469,     0,     0,     0,     0,     0,  1071,     0,   470,     0,
-     471,     0,   472,   473,    16,  1044,  -304,     0,  1031,  1623,
-       0,     0,   426,   427,     3,  1071,  -118,  -104,  -104,     0,
-    -115,     0,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,  1032,   434,  1033,  1034,     0,   435,     0,
-       0,     0,     0,     0,     0,  1035,   436,  1036,     0,  -120,
-       0,  1037,   437,     0,     0,   438,     0,     8,   439,  1038,
-       0,  1039,   440,     0,     0,  1040,  1041,     0,     0,     0,
-       0,     0,  1042,     0,     0,   442,   443,     0,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,  1043,   738,   739,   740,   741,   742,   743,   744,
-     745,     0,     0,     0,     0,   448,   449,     0,     0,     0,
-       0,     0,   746,     0,     0,     0,     0,     0,   747,     0,
-       0,     0,     0,     0,     0,     0,    59,     0,   748,   749,
-     750,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
-      60,     0,    13,   464,     0,     0,     0,     0,     0,   751,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
-     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,     0,     0,     0,     0,   470,     0,   471,     0,   472,
-     473,    16,  1044,  -329,  1031,     0,     0,     0,   426,   427,
-       3,     0,  -118,  -104,  -104,     0,  -115,     0,   428,   429,
-     430,   431,   432,     0,     0,     0,     0,     0,   433,  1032,
-     434,  1033,  1034,     0,   435,     0,     0,     0,     0,     0,
-       0,  1035,   436,  1036,     0,  -120,     0,  1037,   437,     0,
-       0,   438,     0,     8,   439,  1038,     0,  1039,   440,     0,
-       0,  1040,  1041,     0,     0,     0,     0,     0,  1042,     0,
-       0,   442,   443,     0,   216,   217,   218,     0,   220,   221,
-     222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
-     232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
-       0,   243,   244,   245,   246,   445,   446,   447,  1043,     0,
+       0,     0,     0,   468,   469,   470,     0,    14,     0,     0,
+     471,   472,     0,     0,     0,     0,     0,     0,     0,   473,
+       0,   474,     0,   475,   476,    16,  1047,  1048,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   448,   449,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    59,     0,     0,     0,     0,     0,     0,     0,
-     450,   451,   452,   453,   454,     0,   455,     0,   456,   457,
-     458,   459,   460,   461,   462,   463,    60,     0,    13,   464,
+       0,     0,     0,     0,     0,  1396,  1397,  1398,  1399,  1400,
+    1401,  1402,  1403,  1404,  1405,  1406,  1409,  1410,  1411,  1412,
+    1413,  1414,  1415,     0,     0,     0,  1034,     0,     0,     0,
+     429,   430,     3,     0,  -120,  -106,  -106,     0,  -117,     0,
+     431,   432,   433,   434,   435,     0,     0,     0,     0,     0,
+     436,  1035,   437,  1036,  1037,     0,   438,     0,     0,     0,
+       0,     0,     0,  1038,   439,  1039,     0,  -122,     0,  1040,
+     440,     0,     0,   441,     0,     8,   442,  1041,     0,  1042,
+     443,     0,     0,  1043,  1044,     0,     0,  1457,  1458,  1459,
+    1045,     0,     0,   445,   446,     0,   219,   220,   221,     0,
+     223,   224,   225,   226,   227,   447,   229,   230,   231,   232,
+     233,   234,   235,   236,   237,   238,   239,     0,   241,   242,
+     243,     0,     0,   246,   247,   248,   249,   448,   449,   450,
+    1046,     0,     0,     0,     0,     0,     0,     0,  1074,     0,
+       0,     0,     0,   451,   452,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
-       0,     0,   468,   469,     0,     0,     0,     0,     0,     0,
-       0,   470,     0,   471,     0,   472,   473,    16,  1044,  -301,
-    1031,     0,     0,     0,   426,   427,     3,     0,  -118,  -104,
-    -104,     0,  -115,     0,   428,   429,   430,   431,   432,     0,
-       0,     0,     0,     0,   433,  1032,   434,  1033,  1034,     0,
-     435,     0,     0,     0,     0,     0,     0,  1035,   436,  1036,
-       0,  -120,     0,  1037,   437,     0,     0,   438,     0,     8,
-     439,  1038,     0,  1039,   440,     0,     0,  1040,  1041,     0,
-       0,     0,     0,     0,  1042,     0,     0,   442,   443,     0,
-     216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
-     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
-     246,   445,   446,   447,  1043,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
+       0,     0,     0,     0,    56,     0,     0,     0,     0,     0,
+       0,     0,   453,   454,   455,   456,   457,     0,   458,     0,
+     459,   460,   461,   462,   463,   464,   465,   466,    57,     0,
+      13,   467,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   468,   469,   470,
+       0,    14,     0,     0,   471,   472,     0,     0,     0,     0,
+       0,     0,     0,   473,     0,   474,     0,   475,   476,    16,
+    1047,  -306,  1034,     0,     0,     0,   429,   430,     3,     0,
+    -120,  -106,  -106,     0,  -117,     0,   431,   432,   433,   434,
+     435,     0,     0,     0,     0,     0,   436,  1035,   437,  1036,
+    1037,     0,   438,     0,     0,     0,     0,     0,     0,  1038,
+     439,  1039,     0,  -122,     0,  1040,   440,     0,     0,   441,
+       0,     8,   442,  1041,     0,  1042,   443,     0,     0,  1043,
+    1044,     0,     0,     0,     0,     0,  1045,     0,     0,   445,
+     446,     0,   219,   220,   221,     0,   223,   224,   225,   226,
+     227,   447,   229,   230,   231,   232,   233,   234,   235,   236,
+     237,   238,   239,     0,   241,   242,   243,     0,     0,   246,
+     247,   248,   249,   448,   449,   450,  1046,     0,     0,     0,
+       0,     0,     0,  1626,     0,     0,     0,     0,     0,   451,
+     452,     0,  1074,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
-       0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
-     454,     0,   455,     0,   456,   457,   458,   459,   460,   461,
-     462,   463,    60,     0,    13,   464,     0,     0,     0,     0,
+      56,     0,     0,     0,     0,     0,     0,     0,   453,   454,
+     455,   456,   457,     0,   458,     0,   459,   460,   461,   462,
+     463,   464,   465,   466,    57,     0,    13,   467,     0,     0,
+       0,     0,  1626,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   468,   469,   470,     0,    14,     0,     0,
+     471,   472,     0,     0,     0,     0,     0,  1074,     0,   473,
+       0,   474,     0,   475,   476,    16,  1047,  -331,     0,  1034,
+    1626,     0,     0,   429,   430,     3,  1074,  -120,  -106,  -106,
+       0,  -117,     0,   431,   432,   433,   434,   435,     0,     0,
+       0,     0,     0,   436,  1035,   437,  1036,  1037,     0,   438,
+       0,     0,     0,     0,     0,     0,  1038,   439,  1039,     0,
+    -122,     0,  1040,   440,     0,     0,   441,     0,     8,   442,
+    1041,     0,  1042,   443,     0,     0,  1043,  1044,     0,     0,
+       0,     0,     0,  1045,     0,     0,   445,   446,     0,   219,
+     220,   221,     0,   223,   224,   225,   226,   227,   447,   229,
+     230,   231,   232,   233,   234,   235,   236,   237,   238,   239,
+       0,   241,   242,   243,     0,     0,   246,   247,   248,   249,
+     448,   449,   450,  1046,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   451,   452,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
-       0,     0,     0,     0,     0,     0,     0,   470,     0,   471,
-       0,   472,   473,    16,  1044,   -95,  1031,     0,     0,     0,
-     426,   427,     3,     0,  -118,  -104,  -104,     0,  -115,     0,
-     428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
-     433,  1032,   434,  1033,  1034,     0,   435,     0,     0,     0,
-       0,     0,     0,  1035,   436,  1036,     0,  -120,     0,  1037,
-     437,     0,     0,   438,     0,     8,   439,  1038,     0,  1039,
-     440,     0,     0,  1040,  1041,     0,     0,     0,     0,     0,
-    1042,     0,     0,   442,   443,     0,   216,   217,   218,     0,
-     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
-     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
-    1043,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    56,     0,     0,
+       0,     0,     0,     0,     0,   453,   454,   455,   456,   457,
+       0,   458,     0,   459,   460,   461,   462,   463,   464,   465,
+     466,    57,     0,    13,   467,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
-       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
-     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
-      13,   464,     0,   332,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
-       0,    14,     0,     0,   468,   469,     0,     0,     0,     0,
-     333,   334,     0,   470,     0,   471,     0,   472,   473,    16,
-    1044,  -100,   426,   427,     0,     0,     0,     0,     0,     0,
-     631,     0,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
-       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
-       0,     0,   437,     0,     0,   438,   632,     0,   439,     0,
-       0,     0,   440,     0,   335,     0,     0,     0,   336,     0,
-       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,     0,     0,     0,   337,     0,     0,     0,   338,
-       0,  1329,   339,     0,     0,   448,   449,     0,     0,     0,
-       0,     0,     0,     0,   521,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    59,   340,     0,     0,
-       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,   634,   456,   457,   458,   459,   460,   461,   462,   463,
-     635,     0,     0,   464,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
-     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,     0,     0,   426,   427,   470,     0,   471,     0,   472,
-     473,   631,   474,   428,   429,   430,   431,   432,     0,     0,
-       0,     0,     0,   433,     0,   434,     0,     0,   332,   435,
-       0,     0,     0,     0,     0,     0,     0,   436,     0,     0,
-       0,     0,     0,   437,     0,     0,   438,   632,     0,   439,
-       0,     0,     0,   440,     0,   333,   334,     0,     0,     0,
-       0,     0,     0,   441,     0,     0,   442,   443,     0,   216,
-     217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
-     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
-       0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-     445,   446,   447,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   448,   449,     0,   335,
-       0,     0,     0,   336,     0,   521,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
-       0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
-       0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
-     463,    60,     0,     0,   464,     0,     0,     0,     0,     0,
-     337,     0,     0,     0,   338,     0,  1336,   339,     0,     0,
-     465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
-       0,     0,     0,     0,   426,   427,   470,     0,   471,     0,
-     472,   473,   340,   474,   428,   429,   430,   431,   432,     0,
-       0,     0,     0,     0,   433,     0,   434,     0,     0,   332,
-     435,     0,     0,     0,     0,     0,     0,     0,   436,     0,
-       0,     0,     0,     0,   437,     0,     0,   438,     0,     0,
-     439,     0,     0,     0,   440,     0,   333,   334,     0,     0,
-       0,     0,     0,     0,   441,     0,     0,   442,   443,   966,
-     216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
-     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
-     246,   445,   446,   447,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
-     335,     0,     0,     0,   336,     0,   521,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
-       0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
-     454,     0,   455,   634,   456,   457,   458,   459,   460,   461,
-     462,   463,   635,     0,     0,   464,     0,     0,     0,     0,
-       0,   337,     0,     0,     0,   338,     0,  1359,   339,     0,
-       0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
-       0,     0,     0,     0,     0,   426,   427,   470,     0,   471,
-       0,   472,   473,   340,   474,   428,   429,   430,   431,   432,
-       0,     0,     0,     0,     0,   433,     0,   434,     0,     0,
-     332,   435,     0,     0,     0,     0,     0,     0,     0,   436,
-       0,     0,     0,     0,     0,   437,     0,     0,   438,     0,
-       0,   439,     0,     0,     0,   440,     0,   333,   334,     0,
-       0,     0,     0,     0,     0,   441,     0,     0,   442,   443,
-       0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
-     444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
-     235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
-     245,   246,   445,   446,   447,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   448,   449,
-       0,   335,     0,     0,     0,   336,     0,   521,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
-       0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
-     453,   454,     0,   455,   634,   456,   457,   458,   459,   460,
-     461,   462,   463,   635,     0,     0,   464,     0,     0,     0,
-       0,     0,   337,     0,     0,     0,   338,     0,  1497,   339,
-       0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
-     469,     0,     0,     0,     0,     0,   426,   427,   470,     0,
-     471,     0,   472,   473,   340,   474,   428,   429,   430,   431,
-     432,     0,     0,     0,     0,     0,   433,     0,   434,     0,
-       0,     0,   435,     0,     0,     0,     0,     0,     0,     0,
-     436,     0,     0,     0,     0,     0,   437,     0,     0,   438,
-       0,     0,   439,     0,     0,     0,   440,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   441,     0,     0,   442,
-     443,     0,   216,   217,   218,     0,   220,   221,   222,   223,
-     224,   444,   226,   227,   228,   229,   230,   231,   232,   233,
-     234,   235,   236,     0,   238,   239,   240,     0,     0,   243,
-     244,   245,   246,   445,   446,   447,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   448,
-     449,     0,     0,     0,     0,     0,     0,     0,   521,     0,
+     468,   469,   470,     0,    14,     0,     0,   471,   472,     0,
+       0,     0,     0,     0,     0,     0,   473,     0,   474,     0,
+     475,   476,    16,  1047,  -303,  1034,     0,     0,     0,   429,
+     430,     3,     0,  -120,  -106,  -106,     0,  -117,     0,   431,
+     432,   433,   434,   435,     0,     0,     0,     0,     0,   436,
+    1035,   437,  1036,  1037,     0,   438,     0,     0,     0,     0,
+       0,     0,  1038,   439,  1039,     0,  -122,     0,  1040,   440,
+       0,     0,   441,     0,     8,   442,  1041,     0,  1042,   443,
+       0,     0,  1043,  1044,     0,     0,     0,     0,     0,  1045,
+       0,     0,   445,   446,     0,   219,   220,   221,     0,   223,
+     224,   225,   226,   227,   447,   229,   230,   231,   232,   233,
+     234,   235,   236,   237,   238,   239,     0,   241,   242,   243,
+       0,     0,   246,   247,   248,   249,   448,   449,   450,  1046,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      59,     0,     0,     0,     0,     0,     0,     0,   450,   451,
-     452,   453,   454,     0,   455,     0,   456,   457,   458,   459,
-     460,   461,   462,   463,    60,     0,     0,   464,     0,     0,
+       0,     0,   451,   452,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
-     468,   469,     0,     0,     0,     0,     0,   426,   427,   470,
-       0,   471,   905,   472,   473,     0,   474,   428,   429,   430,
-     431,   432,     0,     0,     0,     0,     0,   433,     0,   434,
-       0,     0,     0,   435,     0,     0,     0,     0,     0,     0,
-       0,   436,     0,     0,     0,     0,     0,   437,     0,     0,
-     438,     0,     0,   439,     0,     0,     0,   440,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   441,     0,     0,
-     442,   443,     0,   216,   217,   218,     0,   220,   221,   222,
-     223,   224,   444,   226,   227,   228,   229,   230,   231,   232,
-     233,   234,   235,   236,     0,   238,   239,   240,     0,     0,
-     243,   244,   245,   246,   445,   446,   447,     0,     0,     0,
+       0,     0,     0,    56,     0,     0,     0,     0,     0,     0,
+       0,   453,   454,   455,   456,   457,     0,   458,     0,   459,
+     460,   461,   462,   463,   464,   465,   466,    57,     0,    13,
+     467,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   468,   469,   470,     0,
+      14,     0,     0,   471,   472,     0,     0,     0,     0,     0,
+       0,     0,   473,     0,   474,     0,   475,   476,    16,  1047,
+     -97,  1034,     0,     0,     0,   429,   430,     3,     0,  -120,
+    -106,  -106,     0,  -117,     0,   431,   432,   433,   434,   435,
+       0,     0,     0,     0,     0,   436,  1035,   437,  1036,  1037,
+       0,   438,     0,     0,     0,     0,     0,     0,  1038,   439,
+    1039,     0,  -122,     0,  1040,   440,     0,     0,   441,     0,
+       8,   442,  1041,     0,  1042,   443,     0,     0,  1043,  1044,
+       0,     0,     0,     0,     0,  1045,     0,     0,   445,   446,
+       0,   219,   220,   221,     0,   223,   224,   225,   226,   227,
+     447,   229,   230,   231,   232,   233,   234,   235,   236,   237,
+     238,   239,     0,   241,   242,   243,     0,     0,   246,   247,
+     248,   249,   448,   449,   450,  1046,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   451,   452,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     448,   449,     0,     0,     0,     0,     0,     0,     0,   521,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    56,
+       0,     0,     0,     0,     0,     0,     0,   453,   454,   455,
+     456,   457,     0,   458,     0,   459,   460,   461,   462,   463,
+     464,   465,   466,    57,     0,    13,   467,     0,   335,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    59,     0,     0,     0,     0,     0,     0,     0,   450,
-     451,   452,   453,   454,     0,   455,     0,   456,   457,   458,
-     459,   460,   461,   462,   463,    60,     0,     0,   464,     0,
+       0,     0,   468,   469,   470,     0,    14,     0,     0,   471,
+     472,     0,     0,     0,     0,   336,   337,     0,   473,     0,
+     474,     0,   475,   476,    16,  1047,  -102,   429,   430,     0,
+       0,     0,     0,     0,     0,     0,     0,   431,   432,   433,
+     434,   435,     0,     0,     0,     0,     0,   436,     0,   437,
+       0,     0,     0,   438,     0,     0,     0,     0,     0,     0,
+       0,   439,     0,     0,     0,     0,     0,   440,     0,     0,
+     441,     0,     0,   442,     0,     0,     0,   443,     0,   338,
+       0,     0,     0,   339,     0,     0,     0,   444,     0,     0,
+     445,   446,   845,   219,   220,   221,     0,   223,   224,   225,
+     226,   227,   447,   229,   230,   231,   232,   233,   234,   235,
+     236,   237,   238,   239,     0,   241,   242,   243,     0,     0,
+     246,   247,   248,   249,   448,   449,   450,     0,     0,     0,
+     340,     0,     0,     0,   341,     0,  1500,   342,     0,     0,
+     451,   452,     0,     0,     0,     0,     0,     0,     0,   524,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   465,   466,   467,     0,    14,     0,
-       0,   468,   469,     0,     0,     0,     0,     0,   426,   427,
-     470,     0,   471,  1271,   472,   473,     0,   474,   428,   429,
-     430,   431,   432,     0,     0,     0,     0,     0,   433,     0,
-     434,     0,     0,     0,   435,     0,     0,     0,     0,     0,
-       0,     0,   436,     0,     0,     0,     0,     0,   437,     0,
-       0,   438,     0,     0,   439,     0,     0,     0,   440,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   441,     0,
-       0,   442,   443,     0,   216,   217,   218,     0,   220,   221,
-     222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
-     232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
-       0,   243,   244,   245,   246,   445,   446,   447,     0,     0,
+       0,    56,   343,     0,     0,     0,     0,     0,     0,   453,
+     454,   455,   456,   457,     0,   458,   637,   459,   460,   461,
+     462,   463,   464,   465,   466,   638,     0,     0,   467,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   448,   449,     0,     0,     0,     0,     0,     0,     0,
-     521,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    59,     0,     0,     0,     0,     0,     0,     0,
-     450,   451,   452,   453,   454,     0,   455,     0,   456,   457,
-     458,   459,   460,   461,   462,   463,    60,     0,     0,   464,
+       0,     0,     0,     0,   468,   469,   470,     0,    14,     0,
+       0,   471,   472,     0,     0,     0,     0,     0,   429,   430,
+     846,     0,   474,   847,   475,   476,   634,   477,   431,   432,
+     433,   434,   435,     0,     0,     0,     0,     0,   436,     0,
+     437,     0,     0,     0,   438,     0,     0,     0,     0,     0,
+       0,     0,   439,     0,     0,     0,     0,     0,   440,     0,
+       0,   441,   635,     0,   442,     0,     0,     0,   443,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   444,     0,
+       0,   445,   446,     0,   219,   220,   221,     0,   223,   224,
+     225,   226,   227,   447,   229,   230,   231,   232,   233,   234,
+     235,   236,   237,   238,   239,     0,   241,   242,   243,     0,
+       0,   246,   247,   248,   249,   448,   449,   450,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
-       0,     0,   468,   469,     0,     0,     0,     0,     0,   426,
-     427,  1280,     0,   471,  1281,   472,   473,     0,   474,   428,
-     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
-       0,   434,     0,     0,     0,   435,     0,     0,     0,     0,
-       0,     0,     0,   436,     0,     0,     0,     0,     0,   437,
-       0,     0,   438,     0,     0,   439,     0,     0,     0,   440,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   441,
-       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
-     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
-     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
-       0,     0,   243,   244,   245,   246,   445,   446,   447,     0,
+       0,   451,   452,     0,     0,     0,     0,     0,     0,     0,
+     524,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    56,     0,     0,     0,     0,     0,     0,     0,
+     453,   454,   455,   456,   457,     0,   458,   637,   459,   460,
+     461,   462,   463,   464,   465,   466,   638,     0,     0,   467,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
-       0,   521,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
-       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
-     457,   458,   459,   460,   461,   462,   463,    60,     0,     0,
-     464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
-      14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
-     426,   427,   470,     0,   471,  1286,   472,   473,     0,   474,
-     428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
-     433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
-       0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
-     437,     0,     0,   438,     0,     0,   439,     0,     0,     0,
-     440,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     441,     0,     0,   442,   443,     0,   216,   217,   218,     0,
-     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
-     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
+       0,     0,     0,     0,     0,   468,   469,   470,     0,    14,
+       0,     0,   471,   472,     0,     0,     0,     0,     0,   429,
+     430,   473,     0,   474,     0,   475,   476,   634,   477,   431,
+     432,   433,   434,   435,     0,     0,     0,     0,     0,   436,
+       0,   437,     0,     0,     0,   438,     0,     0,     0,     0,
+       0,     0,     0,   439,     0,     0,     0,     0,     0,   440,
+       0,     0,   441,   635,     0,   442,     0,     0,     0,   443,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   444,
+       0,     0,   445,   446,     0,   219,   220,   221,     0,   223,
+     224,   225,   226,   227,   447,   229,   230,   231,   232,   233,
+     234,   235,   236,   237,   238,   239,     0,   241,   242,   243,
+       0,     0,   246,   247,   248,   249,   448,   449,   450,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
-       0,     0,   521,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
-       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
-     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
-       0,   464,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
-       0,    14,     0,     0,   468,   469,     0,     0,     0,     0,
-       0,   426,   427,   470,     0,   471,  1340,   472,   473,     0,
-     474,   428,   429,   430,   431,   432,     0,     0,     0,     0,
-       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
-       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
-       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
-       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
-     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
-       0,     0,     0,   521,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
-       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-       0,     0,   426,   427,   470,     0,   471,     0,   472,   473,
-       0,   474,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
-       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
-       0,     0,   437,     0,     0,   438,     0,     0,   439,     0,
-       0,     0,   440,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,   451,   452,     0,     0,     0,     0,     0,     0,
+       0,   524,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    56,     0,     0,     0,     0,     0,     0,
+       0,   453,   454,   455,   456,   457,     0,   458,     0,   459,
+     460,   461,   462,   463,   464,   465,   466,    57,     0,     0,
+     467,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   468,   469,   470,     0,
+      14,     0,     0,   471,   472,     0,     0,     0,     0,     0,
+     429,   430,   473,     0,   474,     0,   475,   476,     0,   477,
+     431,   432,   433,   434,   435,     0,     0,     0,     0,     0,
+     436,     0,   437,     0,     0,     0,   438,     0,     0,     0,
+       0,     0,     0,     0,   439,     0,     0,     0,     0,     0,
+     440,     0,     0,   441,     0,     0,   442,     0,     0,     0,
+     443,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     444,     0,     0,   445,   446,   969,   219,   220,   221,     0,
+     223,   224,   225,   226,   227,   447,   229,   230,   231,   232,
+     233,   234,   235,   236,   237,   238,   239,     0,   241,   242,
+     243,     0,     0,   246,   247,   248,   249,   448,   449,   450,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
-       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
-      60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
-     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,     0,     0,   426,   427,   470,   531,   471,     0,   472,
-     473,     0,   474,   428,   429,   430,   431,   432,     0,     0,
-       0,     0,     0,   433,     0,   434,     0,     0,     0,   435,
-       0,     0,     0,     0,     0,     0,     0,   436,     0,     0,
-       0,     0,     0,   437,     0,     0,   438,     0,     0,   439,
-       0,     0,     0,   440,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   441,     0,     0,   442,   443,     0,   216,
-     217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
-     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
-       0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-     445,   446,   447,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   448,   449,     0,     0,
+       0,     0,     0,   451,   452,     0,     0,     0,     0,     0,
+       0,     0,   524,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    56,     0,     0,     0,     0,     0,
+       0,     0,   453,   454,   455,   456,   457,     0,   458,   637,
+     459,   460,   461,   462,   463,   464,   465,   466,   638,     0,
+       0,   467,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   468,   469,   470,
+       0,    14,     0,     0,   471,   472,     0,     0,     0,     0,
+       0,   429,   430,   473,     0,   474,     0,   475,   476,     0,
+     477,   431,   432,   433,   434,   435,     0,     0,     0,     0,
+       0,   436,     0,   437,     0,     0,     0,   438,     0,     0,
+       0,     0,     0,     0,     0,   439,     0,     0,     0,     0,
+       0,   440,     0,     0,   441,     0,     0,   442,     0,     0,
+       0,   443,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   444,     0,     0,   445,   446,     0,   219,   220,   221,
+       0,   223,   224,   225,   226,   227,   447,   229,   230,   231,
+     232,   233,   234,   235,   236,   237,   238,   239,     0,   241,
+     242,   243,     0,     0,   246,   247,   248,   249,   448,   449,
+     450,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   451,   452,     0,     0,     0,     0,
+       0,     0,     0,   524,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    56,     0,     0,     0,     0,
+       0,     0,     0,   453,   454,   455,   456,   457,     0,   458,
+     637,   459,   460,   461,   462,   463,   464,   465,   466,   638,
+       0,     0,   467,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   468,   469,
+     470,     0,    14,     0,     0,   471,   472,     0,     0,     0,
+       0,     0,   429,   430,   473,     0,   474,     0,   475,   476,
+       0,   477,   431,   432,   433,   434,   435,     0,     0,     0,
+       0,     0,   436,     0,   437,     0,     0,     0,   438,     0,
+       0,     0,     0,     0,     0,     0,   439,     0,     0,     0,
+       0,     0,   440,     0,     0,   441,     0,     0,   442,     0,
+       0,     0,   443,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   444,     0,     0,   445,   446,     0,   219,   220,
+     221,     0,   223,   224,   225,   226,   227,   447,   229,   230,
+     231,   232,   233,   234,   235,   236,   237,   238,   239,     0,
+     241,   242,   243,     0,     0,   246,   247,   248,   249,   448,
+     449,   450,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   451,   452,     0,     0,     0,
+       0,     0,     0,     0,   524,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    56,     0,     0,     0,
+       0,     0,     0,     0,   453,   454,   455,   456,   457,     0,
+     458,     0,   459,   460,   461,   462,   463,   464,   465,   466,
+      57,     0,     0,   467,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   468,
+     469,   470,     0,    14,     0,     0,   471,   472,     0,     0,
+       0,     0,     0,   429,   430,   473,     0,   474,   908,   475,
+     476,     0,   477,   431,   432,   433,   434,   435,     0,     0,
+       0,     0,     0,   436,     0,   437,     0,     0,     0,   438,
+       0,     0,     0,     0,     0,     0,     0,   439,     0,     0,
+       0,     0,     0,   440,     0,     0,   441,     0,     0,   442,
+       0,     0,     0,   443,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   444,     0,     0,   445,   446,     0,   219,
+     220,   221,     0,   223,   224,   225,   226,   227,   447,   229,
+     230,   231,   232,   233,   234,   235,   236,   237,   238,   239,
+       0,   241,   242,   243,     0,     0,   246,   247,   248,   249,
+     448,   449,   450,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   451,   452,     0,     0,
+       0,     0,     0,     0,     0,   524,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    56,     0,     0,
+       0,     0,     0,     0,     0,   453,   454,   455,   456,   457,
+       0,   458,     0,   459,   460,   461,   462,   463,   464,   465,
+     466,    57,     0,     0,   467,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
-       0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
-       0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
-     463,    60,     0,     0,   464,     0,     0,     0,     0,     0,
+     468,   469,   470,     0,    14,     0,     0,   471,   472,     0,
+       0,     0,     0,     0,   429,   430,   473,     0,   474,  1274,
+     475,   476,     0,   477,   431,   432,   433,   434,   435,     0,
+       0,     0,     0,     0,   436,     0,   437,     0,     0,     0,
+     438,     0,     0,     0,     0,     0,     0,     0,   439,     0,
+       0,     0,     0,     0,   440,     0,     0,   441,     0,     0,
+     442,     0,     0,     0,   443,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   444,     0,     0,   445,   446,     0,
+     219,   220,   221,     0,   223,   224,   225,   226,   227,   447,
+     229,   230,   231,   232,   233,   234,   235,   236,   237,   238,
+     239,     0,   241,   242,   243,     0,     0,   246,   247,   248,
+     249,   448,   449,   450,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   451,   452,     0,
+       0,     0,     0,     0,     0,     0,   524,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    56,     0,
+       0,     0,     0,     0,     0,     0,   453,   454,   455,   456,
+     457,     0,   458,     0,   459,   460,   461,   462,   463,   464,
+     465,   466,    57,     0,     0,   467,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
-       0,     0,     0,     0,   426,   427,   470,   717,   471,     0,
-     472,   473,     0,   474,   428,   429,   430,   431,   432,     0,
-       0,     0,     0,     0,   433,     0,   434,     0,     0,     0,
-     435,     0,     0,     0,     0,     0,     0,     0,   436,     0,
-       0,     0,     0,     0,   437,     0,     0,   438,     0,     0,
-     439,     0,     0,     0,   440,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   441,     0,     0,   442,   443,     0,
-     216,   217,   218,     0,   220,   221,   222,   223,   224,   444,
-     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,     0,   238,   239,   240,     0,     0,   243,   244,   245,
-     246,   445,   446,   447,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   448,   449,     0,
-       0,     0,     0,     0,     0,     0,   927,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    59,     0,
-       0,     0,     0,     0,     0,     0,   450,   451,   452,   453,
-     454,     0,   455,     0,   456,   457,   458,   459,   460,   461,
-     462,   463,    60,     0,     0,   464,     0,     0,     0,     0,
+       0,   468,   469,   470,     0,    14,     0,     0,   471,   472,
+       0,     0,     0,     0,     0,   429,   430,  1283,     0,   474,
+    1284,   475,   476,     0,   477,   431,   432,   433,   434,   435,
+       0,     0,     0,     0,     0,   436,     0,   437,     0,     0,
+       0,   438,     0,     0,     0,     0,     0,     0,     0,   439,
+       0,     0,     0,     0,     0,   440,     0,     0,   441,     0,
+       0,   442,     0,     0,     0,   443,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   444,     0,     0,   445,   446,
+       0,   219,   220,   221,     0,   223,   224,   225,   226,   227,
+     447,   229,   230,   231,   232,   233,   234,   235,   236,   237,
+     238,   239,     0,   241,   242,   243,     0,     0,   246,   247,
+     248,   249,   448,   449,   450,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   451,   452,
+       0,     0,     0,     0,     0,     0,     0,   524,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    56,
+       0,     0,     0,     0,     0,     0,     0,   453,   454,   455,
+     456,   457,     0,   458,     0,   459,   460,   461,   462,   463,
+     464,   465,   466,    57,     0,     0,   467,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   465,   466,   467,     0,    14,     0,     0,   468,   469,
-       0,     0,     0,     0,     0,   426,   427,   470,     0,   471,
-       0,   472,   473,  1018,   474,   428,   429,   430,   431,   432,
-       0,     0,     0,     0,     0,   433,     0,   434,     0,     0,
-       0,   435,     0,     0,     0,     0,     0,     0,     0,   436,
-       0,     0,     0,     0,     0,   437,     0,     0,   438,     0,
-       0,   439,     0,     0,     0,   440,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   441,     0,     0,   442,   443,
-       0,   216,   217,   218,     0,   220,   221,   222,   223,   224,
-     444,   226,   227,   228,   229,   230,   231,   232,   233,   234,
-     235,   236,     0,   238,   239,   240,     0,     0,   243,   244,
-     245,   246,   445,   446,   447,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   448,   449,
+       0,     0,   468,   469,   470,     0,    14,     0,     0,   471,
+     472,     0,     0,     0,     0,     0,   429,   430,   473,     0,
+     474,  1289,   475,   476,     0,   477,   431,   432,   433,   434,
+     435,     0,     0,     0,     0,     0,   436,     0,   437,     0,
+       0,     0,   438,     0,     0,     0,     0,     0,     0,     0,
+     439,     0,     0,     0,     0,     0,   440,     0,     0,   441,
+       0,     0,   442,     0,     0,     0,   443,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   444,     0,     0,   445,
+     446,     0,   219,   220,   221,     0,   223,   224,   225,   226,
+     227,   447,   229,   230,   231,   232,   233,   234,   235,   236,
+     237,   238,   239,     0,   241,   242,   243,     0,     0,   246,
+     247,   248,   249,   448,   449,   450,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   451,
+     452,     0,     0,     0,     0,     0,     0,     0,   524,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    59,
-       0,     0,     0,     0,     0,     0,     0,   450,   451,   452,
-     453,   454,     0,   455,     0,   456,   457,   458,   459,   460,
-     461,   462,   463,    60,     0,     0,   464,     0,     0,     0,
+      56,     0,     0,     0,     0,     0,     0,     0,   453,   454,
+     455,   456,   457,     0,   458,     0,   459,   460,   461,   462,
+     463,   464,   465,   466,    57,     0,     0,   467,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   465,   466,   467,     0,    14,     0,     0,   468,
-     469,     0,     0,     0,     0,     0,   426,   427,   470,     0,
-     471,     0,   472,   473,     0,   474,   428,   429,   430,   431,
-     432,     0,     0,     0,     0,     0,   433,     0,   434,     0,
-       0,     0,   435,     0,     0,     0,     0,     0,     0,     0,
-     436,     0,     0,     0,     0,     0,   437,     0,     0,   438,
-       0,     0,   439,     0,     0,     0,   440,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   441,     0,     0,   442,
-     443,     0,   216,   217,   218,     0,   220,   221,   222,   223,
-     224,   444,   226,   227,   228,   229,   230,   231,   232,   233,
-     234,   235,   236,     0,   238,   239,   240,     0,     0,   243,
-     244,   245,   246,   445,   446,   447,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   448,
-     449,     0,     0,     0,     0,     0,     0,     0,   927,     0,
+       0,     0,     0,   468,   469,   470,     0,    14,     0,     0,
+     471,   472,     0,     0,     0,     0,     0,   429,   430,   473,
+       0,   474,  1343,   475,   476,     0,   477,   431,   432,   433,
+     434,   435,     0,     0,     0,     0,     0,   436,     0,   437,
+       0,     0,     0,   438,     0,     0,     0,     0,     0,     0,
+       0,   439,     0,     0,     0,     0,     0,   440,     0,     0,
+     441,     0,     0,   442,     0,     0,     0,   443,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   444,     0,     0,
+     445,   446,     0,   219,   220,   221,     0,   223,   224,   225,
+     226,   227,   447,   229,   230,   231,   232,   233,   234,   235,
+     236,   237,   238,   239,     0,   241,   242,   243,     0,     0,
+     246,   247,   248,   249,   448,   449,   450,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      59,     0,     0,     0,     0,     0,     0,     0,   450,   451,
-     452,   453,   454,     0,   455,     0,   456,   457,   458,   459,
-     460,   461,   462,   463,    60,     0,     0,   464,     0,     0,
+     451,   452,     0,     0,     0,     0,     0,     0,     0,   524,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   465,   466,   467,     0,    14,     0,     0,
-     468,   469,     0,     0,     0,     0,     0,   426,   427,  1206,
-       0,   471,     0,   472,   473,     0,   474,   428,   429,   430,
-     431,   432,     0,     0,     0,     0,     0,   433,     0,   434,
-       0,     0,     0,   435,     0,     0,     0,     0,     0,     0,
-       0,   436,     0,     0,     0,     0,     0,   437,     0,     0,
-     438,     0,     0,   439,     0,     0,     0,   440,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   441,     0,     0,
-     442,   443,     0,   216,   217,   218,     0,   220,   221,   222,
-     223,   224,   444,   226,   227,   228,   229,   230,   231,   232,
-     233,   234,   235,   236,     0,   238,   239,   240,     0,     0,
-     243,   244,   245,   246,   445,   446,   447,     0,     0,     0,
+       0,    56,     0,     0,     0,     0,     0,     0,     0,   453,
+     454,   455,   456,   457,     0,   458,     0,   459,   460,   461,
+     462,   463,   464,   465,   466,    57,     0,     0,   467,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     448,   449,     0,     0,     0,     0,     0,     0,     0,  1215,
+       0,     0,     0,     0,   468,   469,   470,     0,    14,     0,
+       0,   471,   472,     0,     0,     0,     0,     0,   429,   430,
+     473,     0,   474,     0,   475,   476,     0,   477,   431,   432,
+     433,   434,   435,     0,     0,     0,     0,     0,   436,     0,
+     437,     0,     0,     0,   438,     0,     0,     0,     0,     0,
+       0,     0,   439,     0,     0,     0,     0,     0,   440,     0,
+       0,   441,     0,     0,   442,     0,     0,     0,   443,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   444,     0,
+       0,   445,   446,     0,   219,   220,   221,     0,   223,   224,
+     225,   226,   227,   447,   229,   230,   231,   232,   233,   234,
+     235,   236,   237,   238,   239,     0,   241,   242,   243,     0,
+       0,   246,   247,   248,   249,   448,   449,   450,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    59,     0,     0,     0,     0,     0,     0,     0,   450,
-     451,   452,   453,   454,     0,   455,     0,   456,   457,   458,
-     459,   460,   461,   462,   463,    60,     0,     0,   464,     0,
+       0,   451,   452,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   465,   466,   467,     0,    14,     0,
-       0,   468,   469,     0,     0,     0,     0,     0,   426,   427,
-     470,     0,   471,     0,   472,   473,     0,   474,   428,   429,
-     430,   431,   432,     0,     0,     0,     0,     0,   433,     0,
-     434,     0,     0,     0,   435,     0,     0,     0,     0,     0,
-       0,     0,   436,     0,     0,     0,     0,     0,   437,     0,
-       0,   438,     0,     0,   439,     0,     0,     0,   440,     0,
-       0,     0,     0,     0,  1218,     0,     0,     0,   441,     0,
-       0,   442,   443,     0,   216,   217,   218,     0,   220,   221,
-     222,   223,   224,   444,   226,   227,   228,   229,   230,   231,
-     232,   233,   234,   235,   236,     0,   238,   239,   240,     0,
-       0,   243,   244,   245,   246,   445,   446,   447,     0,     0,
+       0,     0,    56,     0,     0,     0,     0,     0,     0,     0,
+     453,   454,   455,   456,   457,     0,   458,     0,   459,   460,
+     461,   462,   463,   464,   465,   466,    57,     0,     0,   467,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   448,   449,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   468,   469,   470,     0,    14,
+       0,     0,   471,   472,     0,     0,     0,     0,     0,   429,
+     430,   473,   534,   474,     0,   475,   476,     0,   477,   431,
+     432,   433,   434,   435,     0,     0,     0,     0,     0,   436,
+       0,   437,     0,     0,     0,   438,     0,     0,     0,     0,
+       0,     0,     0,   439,     0,     0,     0,     0,     0,   440,
+       0,     0,   441,     0,     0,   442,     0,     0,     0,   443,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   444,
+       0,     0,   445,   446,     0,   219,   220,   221,     0,   223,
+     224,   225,   226,   227,   447,   229,   230,   231,   232,   233,
+     234,   235,   236,   237,   238,   239,     0,   241,   242,   243,
+       0,     0,   246,   247,   248,   249,   448,   449,   450,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    59,     0,     0,     0,     0,     0,     0,     0,
-     450,   451,   452,   453,   454,     0,   455,     0,   456,   457,
-     458,   459,   460,   461,   462,   463,    60,     0,     0,   464,
+       0,     0,   451,   452,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   465,   466,   467,     0,    14,
-       0,     0,   468,   469,     0,     0,     0,     0,     0,   426,
-     427,   470,     0,   471,     0,   472,   473,     0,   474,   428,
-     429,   430,   431,   432,     0,     0,     0,     0,     0,   433,
-       0,   434,     0,     0,     0,   435,     0,     0,     0,     0,
-       0,     0,     0,   436,     0,     0,     0,     0,     0,   437,
-       0,     0,   438,     0,     0,   439,     0,     0,     0,   440,
-       0,     0,  1224,     0,     0,     0,     0,     0,     0,   441,
-       0,     0,   442,   443,     0,   216,   217,   218,     0,   220,
-     221,   222,   223,   224,   444,   226,   227,   228,   229,   230,
-     231,   232,   233,   234,   235,   236,     0,   238,   239,   240,
-       0,     0,   243,   244,   245,   246,   445,   446,   447,     0,
+       0,     0,     0,    56,     0,     0,     0,     0,     0,     0,
+       0,   453,   454,   455,   456,   457,     0,   458,     0,   459,
+     460,   461,   462,   463,   464,   465,   466,    57,     0,     0,
+     467,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   468,   469,   470,     0,
+      14,     0,     0,   471,   472,     0,     0,     0,     0,     0,
+     429,   430,   473,   720,   474,     0,   475,   476,     0,   477,
+     431,   432,   433,   434,   435,     0,     0,     0,     0,     0,
+     436,     0,   437,     0,     0,     0,   438,     0,     0,     0,
+       0,     0,     0,     0,   439,     0,     0,     0,     0,     0,
+     440,     0,     0,   441,     0,     0,   442,     0,     0,     0,
+     443,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     444,     0,     0,   445,   446,     0,   219,   220,   221,     0,
+     223,   224,   225,   226,   227,   447,   229,   230,   231,   232,
+     233,   234,   235,   236,   237,   238,   239,     0,   241,   242,
+     243,     0,     0,   246,   247,   248,   249,   448,   449,   450,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   448,   449,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   451,   452,     0,     0,     0,     0,     0,
+       0,     0,   930,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    56,     0,     0,     0,     0,     0,
+       0,     0,   453,   454,   455,   456,   457,     0,   458,     0,
+     459,   460,   461,   462,   463,   464,   465,   466,    57,     0,
+       0,   467,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   468,   469,   470,
+       0,    14,     0,     0,   471,   472,     0,     0,     0,     0,
+       0,   429,   430,   473,     0,   474,     0,   475,   476,  1021,
+     477,   431,   432,   433,   434,   435,     0,     0,     0,     0,
+       0,   436,     0,   437,     0,     0,     0,   438,     0,     0,
+       0,     0,     0,     0,     0,   439,     0,     0,     0,     0,
+       0,   440,     0,     0,   441,     0,     0,   442,     0,     0,
+       0,   443,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   444,     0,     0,   445,   446,     0,   219,   220,   221,
+       0,   223,   224,   225,   226,   227,   447,   229,   230,   231,
+     232,   233,   234,   235,   236,   237,   238,   239,     0,   241,
+     242,   243,     0,     0,   246,   247,   248,   249,   448,   449,
+     450,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   451,   452,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    59,     0,     0,     0,     0,     0,     0,
-       0,   450,   451,   452,   453,   454,     0,   455,     0,   456,
-     457,   458,   459,   460,   461,   462,   463,    60,     0,     0,
-     464,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   465,   466,   467,     0,
-      14,     0,     0,   468,   469,     0,     0,     0,     0,     0,
-     426,   427,   470,     0,   471,     0,   472,   473,     0,   474,
-     428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
-     433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
-       0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
-     437,     0,     0,   438,     0,     0,   439,     0,     0,     0,
-     440,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     441,     0,     0,   442,   443,     0,   216,   217,   218,     0,
-     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
-     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
+       0,     0,     0,     0,     0,    56,     0,     0,     0,     0,
+       0,     0,     0,   453,   454,   455,   456,   457,     0,   458,
+       0,   459,   460,   461,   462,   463,   464,   465,   466,    57,
+       0,     0,   467,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   468,   469,
+     470,     0,    14,     0,     0,   471,   472,     0,     0,     0,
+       0,     0,   429,   430,   473,     0,   474,     0,   475,   476,
+       0,   477,   431,   432,   433,   434,   435,     0,     0,     0,
+       0,     0,   436,     0,   437,     0,     0,     0,   438,     0,
+       0,     0,     0,     0,     0,     0,   439,     0,     0,     0,
+       0,     0,   440,     0,     0,   441,     0,     0,   442,     0,
+       0,     0,   443,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   444,     0,     0,   445,   446,     0,   219,   220,
+     221,     0,   223,   224,   225,   226,   227,   447,   229,   230,
+     231,   232,   233,   234,   235,   236,   237,   238,   239,     0,
+     241,   242,   243,     0,     0,   246,   247,   248,   249,   448,
+     449,   450,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   451,   452,     0,     0,     0,
+       0,     0,     0,     0,   930,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    56,     0,     0,     0,
+       0,     0,     0,     0,   453,   454,   455,   456,   457,     0,
+     458,     0,   459,   460,   461,   462,   463,   464,   465,   466,
+      57,     0,     0,   467,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   468,
+     469,   470,     0,    14,     0,     0,   471,   472,     0,     0,
+       0,     0,     0,   429,   430,  1209,     0,   474,     0,   475,
+     476,     0,   477,   431,   432,   433,   434,   435,     0,     0,
+       0,     0,     0,   436,     0,   437,     0,     0,     0,   438,
+       0,     0,     0,     0,     0,     0,     0,   439,     0,     0,
+       0,     0,     0,   440,     0,     0,   441,     0,     0,   442,
+       0,     0,     0,   443,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   444,     0,     0,   445,   446,     0,   219,
+     220,   221,     0,   223,   224,   225,   226,   227,   447,   229,
+     230,   231,   232,   233,   234,   235,   236,   237,   238,   239,
+       0,   241,   242,   243,     0,     0,   246,   247,   248,   249,
+     448,   449,   450,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   451,   452,     0,     0,
+       0,     0,     0,     0,     0,  1218,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    56,     0,     0,
+       0,     0,     0,     0,     0,   453,   454,   455,   456,   457,
+       0,   458,     0,   459,   460,   461,   462,   463,   464,   465,
+     466,    57,     0,     0,   467,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
-       0,     0,  1227,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
-       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
-     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
-       0,   464,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   465,   466,   467,
-       0,    14,     0,     0,   468,   469,     0,     0,     0,     0,
-       0,   426,   427,   470,     0,   471,     0,   472,   473,     0,
-     474,   428,   429,   430,   431,   432,     0,     0,     0,     0,
-       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
-       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
-       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
-       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
-     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
+     468,   469,   470,     0,    14,     0,     0,   471,   472,     0,
+       0,     0,     0,     0,   429,   430,   473,     0,   474,     0,
+     475,   476,     0,   477,   431,   432,   433,   434,   435,     0,
+       0,     0,     0,     0,   436,     0,   437,     0,     0,     0,
+     438,     0,     0,     0,     0,     0,     0,     0,   439,     0,
+       0,     0,     0,     0,   440,     0,     0,   441,     0,     0,
+     442,     0,     0,     0,   443,     0,     0,     0,     0,     0,
+    1221,     0,     0,     0,   444,     0,     0,   445,   446,     0,
+     219,   220,   221,     0,   223,   224,   225,   226,   227,   447,
+     229,   230,   231,   232,   233,   234,   235,   236,   237,   238,
+     239,     0,   241,   242,   243,     0,     0,   246,   247,   248,
+     249,   448,   449,   450,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   451,   452,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
-       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-       0,     0,   426,   427,   470,     0,   471,  1463,   472,   473,
-       0,   474,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
-       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
-       0,     0,   437,     0,     0,   438,     0,     0,   439,     0,
-       0,     0,   440,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   448,   449,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    56,     0,
+       0,     0,     0,     0,     0,     0,   453,   454,   455,   456,
+     457,     0,   458,     0,   459,   460,   461,   462,   463,   464,
+     465,   466,    57,     0,     0,   467,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
-       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
-      60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
-     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,     0,     0,   426,   427,   470,     0,   471,     0,   472,
-     473,     0,   474,   428,   429,   430,   431,   432,     0,     0,
-       0,     0,     0,   433,  1032,   434,  1033,     0,     0,   435,
-       0,     0,     0,     0,     0,     0,     0,   436,     0,     0,
-       0,     0,     0,   437,     0,     0,   438,     0,     0,   439,
-    1038,     0,     0,   440,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   441,     0,     0,   442,   443,     0,   216,
-     217,   218,     0,   220,   221,   222,   223,   224,   444,   226,
-     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
-       0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-     445,   446,   447,  1043,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   448,   449,     0,     0,
+       0,   468,   469,   470,     0,    14,     0,     0,   471,   472,
+       0,     0,     0,     0,     0,   429,   430,   473,     0,   474,
+       0,   475,   476,     0,   477,   431,   432,   433,   434,   435,
+       0,     0,     0,     0,     0,   436,     0,   437,     0,     0,
+       0,   438,     0,     0,     0,     0,     0,     0,     0,   439,
+       0,     0,     0,     0,     0,   440,     0,     0,   441,     0,
+       0,   442,     0,     0,     0,   443,     0,     0,  1227,     0,
+       0,     0,     0,     0,     0,   444,     0,     0,   445,   446,
+       0,   219,   220,   221,     0,   223,   224,   225,   226,   227,
+     447,   229,   230,   231,   232,   233,   234,   235,   236,   237,
+     238,   239,     0,   241,   242,   243,     0,     0,   246,   247,
+     248,   249,   448,   449,   450,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   451,   452,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    59,     0,     0,
-       0,     0,     0,     0,     0,   450,   451,   452,   453,   454,
-       0,   455,     0,   456,   457,   458,   459,   460,   461,   462,
-     463,    60,     0,     0,   464,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    56,
+       0,     0,     0,     0,     0,     0,     0,   453,   454,   455,
+     456,   457,     0,   458,     0,   459,   460,   461,   462,   463,
+     464,   465,   466,    57,     0,     0,   467,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     465,   466,   467,     0,    14,     0,     0,   468,   469,     0,
-       0,     0,   426,   427,     0,     0,   470,     0,   471,     0,
-     472,   473,   428,   429,   430,   431,   432,     0,     0,     0,
-       0,     0,   433,     0,   434,     0,     0,     0,   435,     0,
-       0,     0,     0,     0,     0,     0,   436,     0,     0,     0,
-       0,     0,   437,     0,     0,   438,     0,     0,   439,     0,
-       0,     0,   440,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   441,     0,     0,   442,   443,     0,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,   445,
-     446,   447,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   448,   449,     0,     0,     0,
-       0,     0,     0,     0,   762,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    59,     0,     0,     0,
-       0,     0,     0,     0,   450,   451,   452,   453,   454,     0,
-     455,     0,   456,   457,   458,   459,   460,   461,   462,   463,
-      60,     0,     0,   464,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   465,
-     466,   467,     0,    14,     0,     0,   468,   469,     0,     0,
-       0,   426,   427,     0,     0,   470,     0,   471,     0,   472,
-     473,   428,   429,   430,   431,   432,     0,     0,   884,     0,
-       0,   433,     0,   434,     0,     0,     0,   435,     0,     0,
-       0,     0,     0,     0,     0,   436,     0,     0,     0,     0,
-       0,   437,     0,     0,   438,     0,     0,   439,     0,     0,
-       0,   440,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   441,     0,     0,   442,   443,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   445,   446,
-     447,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   448,   449,     0,     0,     0,     0,
+       0,     0,   468,   469,   470,     0,    14,     0,     0,   471,
+     472,     0,     0,     0,     0,     0,   429,   430,   473,     0,
+     474,     0,   475,   476,     0,   477,   431,   432,   433,   434,
+     435,     0,     0,     0,     0,     0,   436,     0,   437,     0,
+       0,     0,   438,     0,     0,     0,     0,     0,     0,     0,
+     439,     0,     0,     0,     0,     0,   440,     0,     0,   441,
+       0,     0,   442,     0,     0,     0,   443,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   444,     0,     0,   445,
+     446,     0,   219,   220,   221,     0,   223,   224,   225,   226,
+     227,   447,   229,   230,   231,   232,   233,   234,   235,   236,
+     237,   238,   239,     0,   241,   242,   243,     0,     0,   246,
+     247,   248,   249,   448,   449,   450,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   451,
+     452,     0,     0,     0,     0,     0,     0,     0,  1230,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    59,     0,     0,     0,     0,
-       0,     0,     0,   450,   451,   452,   453,   454,     0,   455,
-       0,   456,   457,   458,   459,   460,   461,   462,   463,    60,
-       0,     0,   464,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   465,   466,
-     467,     0,    14,     0,     0,   468,   469,     0,     0,     0,
-     426,   427,     0,     0,   470,     0,   471,     0,   472,   473,
-     428,   429,   430,   431,   432,     0,     0,     0,     0,     0,
-     433,     0,   434,     0,     0,     0,   435,     0,     0,     0,
-       0,     0,     0,     0,   436,     0,     0,     0,     0,     0,
-     437,     0,     0,   438,     0,     0,   439,     0,     0,     0,
-     440,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     441,     0,     0,   442,   443,     0,   216,   217,   218,     0,
-     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
-     240,     0,     0,   243,   244,   245,   246,   445,   446,   447,
+      56,     0,     0,     0,     0,     0,     0,     0,   453,   454,
+     455,   456,   457,     0,   458,     0,   459,   460,   461,   462,
+     463,   464,   465,   466,    57,     0,     0,   467,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   448,   449,     0,     0,     0,     0,     0,
+       0,     0,     0,   468,   469,   470,     0,    14,     0,     0,
+     471,   472,     0,     0,     0,     0,     0,   429,   430,   473,
+       0,   474,     0,   475,   476,     0,   477,   431,   432,   433,
+     434,   435,     0,     0,     0,     0,     0,   436,     0,   437,
+       0,     0,     0,   438,     0,     0,     0,     0,     0,     0,
+       0,   439,     0,     0,     0,     0,     0,   440,     0,     0,
+     441,     0,     0,   442,     0,     0,     0,   443,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   444,     0,     0,
+     445,   446,     0,   219,   220,   221,     0,   223,   224,   225,
+     226,   227,   447,   229,   230,   231,   232,   233,   234,   235,
+     236,   237,   238,   239,     0,   241,   242,   243,     0,     0,
+     246,   247,   248,   249,   448,   449,   450,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    59,     0,     0,     0,     0,     0,
-       0,     0,   450,   451,   452,   453,   454,     0,   455,     0,
-     456,   457,   458,   459,   460,   461,   462,   463,    60,     0,
-     210,   464,     0,     0,     0,     0,   211,     0,     0,     0,
-       0,     0,   212,     0,     0,     0,     0,   465,   466,   467,
-       0,    14,   213,     0,   468,   469,     0,     0,     0,     0,
-     214,     0,     0,   470,     0,   471,     0,   472,   473,     0,
-       0,     0,     0,     0,     0,   215,     0,     0,     0,     0,
-       0,     0,   216,   217,   218,   219,   220,   221,   222,   223,
-     224,   225,   226,   227,   228,   229,   230,   231,   232,   233,
-     234,   235,   236,   237,   238,   239,   240,   241,   242,   243,
-     244,   245,   246,   247,   248,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   210,     0,     0,     0,     0,
-       0,   211,     0,     0,     0,     0,     0,   212,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   213,     0,     0,
-      59,     0,     0,     0,     0,   214,     0,     0,     0,     0,
-       0,     0,     0,   249,     0,     0,     0,     0,     0,     0,
-     215,     0,     0,     0,   699,     0,    13,   216,   217,   218,
+     451,   452,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,    56,     0,     0,     0,     0,     0,     0,     0,   453,
+     454,   455,   456,   457,     0,   458,     0,   459,   460,   461,
+     462,   463,   464,   465,   466,    57,     0,     0,   467,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   468,   469,   470,     0,    14,     0,
+       0,   471,   472,     0,     0,     0,     0,     0,   429,   430,
+     473,     0,   474,  1466,   475,   476,     0,   477,   431,   432,
+     433,   434,   435,     0,     0,     0,     0,     0,   436,     0,
+     437,     0,     0,     0,   438,     0,     0,     0,     0,     0,
+       0,     0,   439,     0,     0,     0,     0,     0,   440,     0,
+       0,   441,     0,     0,   442,     0,     0,     0,   443,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   444,     0,
+       0,   445,   446,     0,   219,   220,   221,     0,   223,   224,
+     225,   226,   227,   447,   229,   230,   231,   232,   233,   234,
+     235,   236,   237,   238,   239,     0,   241,   242,   243,     0,
+       0,   246,   247,   248,   249,   448,   449,   450,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   451,   452,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    56,     0,     0,     0,     0,     0,     0,     0,
+     453,   454,   455,   456,   457,     0,   458,     0,   459,   460,
+     461,   462,   463,   464,   465,   466,    57,     0,     0,   467,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   468,   469,   470,     0,    14,
+       0,     0,   471,   472,     0,     0,     0,     0,     0,   429,
+     430,   473,     0,   474,     0,   475,   476,     0,   477,   431,
+     432,   433,   434,   435,     0,     0,     0,     0,     0,   436,
+    1035,   437,  1036,     0,     0,   438,     0,     0,     0,     0,
+       0,     0,     0,   439,     0,     0,     0,     0,     0,   440,
+       0,     0,   441,     0,     0,   442,  1041,     0,     0,   443,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   444,
+       0,     0,   445,   446,     0,   219,   220,   221,     0,   223,
+     224,   225,   226,   227,   447,   229,   230,   231,   232,   233,
+     234,   235,   236,   237,   238,   239,     0,   241,   242,   243,
+       0,     0,   246,   247,   248,   249,   448,   449,   450,  1046,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   451,   452,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    56,     0,     0,     0,     0,     0,     0,
+       0,   453,   454,   455,   456,   457,     0,   458,     0,   459,
+     460,   461,   462,   463,   464,   465,   466,    57,     0,     0,
+     467,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   468,   469,   470,     0,
+      14,     0,     0,   471,   472,     0,     0,     0,   429,   430,
+       0,     0,   473,     0,   474,     0,   475,   476,   431,   432,
+     433,   434,   435,     0,     0,     0,     0,     0,   436,     0,
+     437,     0,     0,     0,   438,     0,     0,     0,     0,     0,
+       0,     0,   439,     0,     0,     0,     0,     0,   440,     0,
+       0,   441,     0,     0,   442,     0,     0,     0,   443,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   444,     0,
+       0,   445,   446,     0,   219,   220,   221,     0,   223,   224,
+     225,   226,   227,   447,   229,   230,   231,   232,   233,   234,
+     235,   236,   237,   238,   239,     0,   241,   242,   243,     0,
+       0,   246,   247,   248,   249,   448,   449,   450,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   451,   452,     0,     0,     0,     0,     0,     0,     0,
+     765,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    56,     0,     0,     0,     0,     0,     0,     0,
+     453,   454,   455,   456,   457,     0,   458,     0,   459,   460,
+     461,   462,   463,   464,   465,   466,    57,     0,     0,   467,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   468,   469,   470,     0,    14,
+       0,     0,   471,   472,     0,     0,     0,   429,   430,     0,
+       0,   473,     0,   474,     0,   475,   476,   431,   432,   433,
+     434,   435,     0,     0,   887,     0,     0,   436,     0,   437,
+       0,     0,     0,   438,     0,     0,     0,     0,     0,     0,
+       0,   439,     0,     0,     0,     0,     0,   440,     0,     0,
+     441,     0,     0,   442,     0,     0,     0,   443,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   444,     0,     0,
+     445,   446,     0,   219,   220,   221,     0,   223,   224,   225,
+     226,   227,   447,   229,   230,   231,   232,   233,   234,   235,
+     236,   237,   238,   239,     0,   241,   242,   243,     0,     0,
+     246,   247,   248,   249,   448,   449,   450,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     451,   452,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,    56,     0,     0,     0,     0,     0,     0,     0,   453,
+     454,   455,   456,   457,     0,   458,     0,   459,   460,   461,
+     462,   463,   464,   465,   466,    57,     0,     0,   467,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   468,   469,   470,     0,    14,     0,
+       0,   471,   472,     0,     0,     0,   429,   430,     0,     0,
+     473,     0,   474,     0,   475,   476,   431,   432,   433,   434,
+     435,     0,     0,     0,     0,     0,   436,     0,   437,     0,
+       0,     0,   438,     0,     0,     0,     0,     0,     0,     0,
+     439,     0,     0,     0,     0,     0,   440,     0,     0,   441,
+       0,     0,   442,     0,     0,     0,   443,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   444,     0,     0,   445,
+     446,     0,   219,   220,   221,     0,   223,   224,   225,   226,
+     227,   447,   229,   230,   231,   232,   233,   234,   235,   236,
+     237,   238,   239,     0,   241,   242,   243,     0,     0,   246,
+     247,   248,   249,   448,   449,   450,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   451,
+     452,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      56,     0,     0,     0,     0,     0,     0,     0,   453,   454,
+     455,   456,   457,     0,   458,     0,   459,   460,   461,   462,
+     463,   464,   465,   466,    57,     0,   213,   467,     0,     0,
+       0,     0,   214,     0,     0,     0,     0,     0,   215,     0,
+       0,     0,     0,   468,   469,   470,     0,    14,   216,     0,
+     471,   472,     0,     0,     0,     0,   217,     0,     0,   473,
+       0,   474,     0,   475,   476,     0,     0,     0,     0,     0,
+       0,   218,     0,     0,     0,     0,     0,     0,   219,   220,
+     221,   222,   223,   224,   225,   226,   227,   228,   229,   230,
+     231,   232,   233,   234,   235,   236,   237,   238,   239,   240,
+     241,   242,   243,   244,   245,   246,   247,   248,   249,   250,
+     251,     0,     0,     0,     0,     0,     0,     0,     0,   213,
+       0,     0,     0,     0,     0,   214,     0,     0,     0,     0,
+       0,   215,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   216,     0,     0,     0,     0,    56,     0,     0,   217,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   252,
+       0,     0,     0,     0,   218,     0,     0,     0,     0,     0,
+      57,   219,   220,   221,   222,   223,   224,   225,   226,   227,
+     228,   229,   230,   231,   232,   233,   234,   235,   236,   237,
+     238,   239,   240,   241,   242,   243,   244,   245,   246,   247,
+     248,   249,   250,   251,     0,     0,     0,     0,     0,   253,
+       0,     0,     0,     0,   537,   213,     0,     0,     0,     0,
+       0,   214,     0,     0,     0,     0,     0,   215,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   216,     0,    56,
+       0,     0,     0,     0,     0,   217,     0,     0,     0,     0,
+       0,     0,   252,     0,     0,     0,     0,     0,     0,     0,
+     218,     0,     0,   702,     0,    13,     0,   219,   220,   221,
+     222,   223,   224,   225,   226,   227,   228,   229,   230,   231,
+     232,   233,   234,   235,   236,   237,   238,   239,   240,   241,
+     242,   243,   244,   245,   246,   247,   248,   249,   250,   251,
+       0,     0,   253,     0,    16,     0,     0,     0,   213,     0,
+       0,     0,     0,     0,   214,     0,     0,     0,     0,     0,
+     215,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     216,     0,     0,     0,     0,    56,     0,     0,   217,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   252,     0,
+       0,     0,     0,   218,     0,     0,     0,     0,     0,    57,
      219,   220,   221,   222,   223,   224,   225,   226,   227,   228,
      229,   230,   231,   232,   233,   234,   235,   236,   237,   238,
      239,   240,   241,   242,   243,   244,   245,   246,   247,   248,
-       0,     0,     0,   250,     0,    16,     0,     0,   210,     0,
-       0,     0,     0,     0,   211,     0,     0,     0,     0,     0,
-     212,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     213,     0,     0,     0,     0,    59,     0,     0,   214,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   249,     0,
-       0,     0,     0,   215,     0,     0,     0,     0,     0,    60,
-     216,   217,   218,   219,   220,   221,   222,   223,   224,   225,
-     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
-     236,   237,   238,   239,   240,   241,   242,   243,   244,   245,
-     246,   247,   248,     0,     0,     0,     0,   853,   250,     0,
-       0,     0,     0,     0,     0,   348,   349,     0,     0,     0,
+     249,   250,   251,     0,     0,     0,     0,   860,   253,     0,
+       0,     0,     0,     0,     0,   351,   352,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   350,     0,     0,     0,     0,     0,    59,     0,
+       0,     0,   353,     0,     0,     0,     0,     0,    56,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   249,     0,     0,     0,     0,     0,     0,     0,   216,
-     217,   218,   699,   220,   221,   222,   223,   224,   444,   226,
-     227,   228,   229,   230,   231,   232,   233,   234,   235,   236,
-       0,   238,   239,   240,     0,     0,   243,   244,   245,   246,
-       0,   651,   652,     0,     0,     0,     0,     0,     0,     0,
-       0,   250,   351,   352,   353,   354,   355,   356,   357,   358,
-     359,   360,   361,   362,   363,   364,   365,   366,   367,   368,
-       0,     0,   369,   370,   371,     0,     0,   372,   373,   374,
-     375,   376,     0,     0,   377,   378,   379,   380,   381,   382,
-     383,     0,   854,     0,     0,     0,     0,     0,     0,     0,
-       0,   855,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   651,   652,   384,
-       0,   385,   386,   387,   388,   389,   390,   391,   392,   393,
-     394,     0,     0,   395,   396,     0,   653,   654,   655,   656,
-     657,   397,   398,   658,   659,   660,   661,     0,   662,   663,
-     664,   665,   666,     0,   667,   668,     0,     0,   669,     0,
-     670,   671,   672,     0,     0,     0,   673,     0,     0,     0,
+       0,   252,     0,     0,     0,     0,     0,     0,     0,   219,
+     220,   221,   702,   223,   224,   225,   226,   227,   447,   229,
+     230,   231,   232,   233,   234,   235,   236,   237,   238,   239,
+       0,   241,   242,   243,     0,     0,   246,   247,   248,   249,
+       0,   654,   655,     0,     0,     0,     0,     0,     0,     0,
+       0,   253,   354,   355,   356,   357,   358,   359,   360,   361,
+     362,   363,   364,   365,   366,   367,   368,   369,   370,   371,
+       0,     0,   372,   373,   374,   654,   655,   375,   376,   377,
+     378,   379,     0,     0,   380,   381,   382,   383,   384,   385,
+     386,     0,   861,     0,     0,     0,     0,     0,     0,     0,
+       0,   862,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   387,
+       0,   388,   389,   390,   391,   392,   393,   394,   395,   396,
+     397,     0,     0,   398,   399,     0,   656,   657,   658,   659,
+     660,   400,   401,   661,   662,   663,   664,     0,   665,   666,
+     667,   668,   669,     0,   670,   671,     0,     0,  -845,     0,
+     673,   674,   675,   654,   655,     0,  -845,     0,     0,     0,
+     656,   657,   658,   659,   660,     0,     0,   661,   662,   663,
+     664,     0,   665,   666,   667,   668,   669,     0,   670,   671,
+     654,   655,     0,     0,   673,   677,   675,   678,   679,   680,
+     681,   682,   683,   684,   685,   686,   687,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   688,   689,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   678,   679,   680,   681,   682,   683,   684,   685,   686,
+     687,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   688,   689,     0,     0,     0,     0,     0,   656,   657,
+     658,   659,   660,     0,     0,   661,   662,   663,   664,     0,
+     665,   666,   667,   668,   669,     0,   670,   671,   654,   655,
+       0,     0,   673,     0,     0,   656,   657,   658,   659,   660,
+       0,     0,   661,   662,   663,   664,     0,   665,   666,   667,
+     668,   669,     0,   670,   671,   654,   655,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   678,
+     679,   680,   681,   682,   683,   684,   685,   686,   687,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   688,
+     689,     0,     0,     0,     0,     0,   678,   679,   680,   681,
+     682,   683,   684,   685,   686,   687,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   688,   689,     0,     0,
+       0,     0,     0,   656,   657,   658,   659,   660,     0,     0,
+     661,   662,   663,   664,     0,   665,   666,   667,   668,   669,
+       0,   670,   671,   654,   655,     0,     0,     0,     0,     0,
+     656,   657,   658,   659,   660,     0,     0,   661,   662,   663,
+     664,     0,   665,   666,   667,   668,   669,     0,   670,   671,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   651,   652,   674,  1084,   675,   676,   677,
-     678,   679,   680,   681,   682,   683,   684,     0,     0,     0,
-       0,     0,   653,   654,   655,   656,   657,   685,   686,   658,
-     659,   660,   661,     0,   662,   663,   664,   665,   666,     0,
-     667,   668,   651,   652,   669,     0,   670,   671,   672,     0,
-       0,     0,   673,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   679,   680,   681,   682,   683,
+     684,   685,   686,   687,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   688,   689,  1083,     0,     0,     0,
+       0,     0,     0,   680,   681,   682,   683,   684,   685,   686,
+     687,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   688,   689,     0,     0,     0,     0,     0,   656,   657,
+     658,   659,   660,     0,     0,   661,   662,   663,   664,     0,
+     665,   666,   667,   668,   669,     0,   670,   671,   219,   220,
+     221,     0,   223,   224,   225,   226,   227,   447,   229,   230,
+     231,   232,   233,   234,   235,   236,   237,   238,   239,     0,
+     241,   242,   243,     0,     0,   246,   247,   248,   249,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   651,
-     652,   674,     0,   675,   676,   677,   678,   679,   680,   681,
-     682,   683,   684,     0,     0,     0,     0,     0,   653,   654,
-     655,   656,   657,   685,   686,   658,   659,   660,   661,     0,
-     662,   663,   664,   665,   666,     0,   667,   668,   651,   652,
-    -843,     0,   670,   671,   672,     0,     0,     0,  -843,     0,
-       0,     0,     0,     0,     0,     0,     0,   653,   654,   655,
-     656,   657,     0,     0,   658,   659,   660,   661,     0,   662,
-     663,   664,   665,   666,     0,   667,   668,   674,     0,   675,
-     676,   677,   678,   679,   680,   681,   682,   683,   684,     0,
-       0,     0,     0,     0,   653,   654,   655,   656,   657,   685,
-     686,   658,   659,   660,   661,     0,   662,   663,   664,   665,
-     666,     0,   667,   668,     0,     0,     0,     0,     0,   676,
-     677,   678,   679,   680,   681,   682,   683,   684,     0,     0,
-       0,     0,     0,   653,   654,   655,   656,   657,   685,   686,
-     658,   659,   660,   661,     0,   662,   663,   664,   665,   666,
-       0,   667,   668,     0,     0,     0,     0,   677,   678,   679,
-     680,   681,   682,   683,   684,   857,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   685,   686,     0,     0,     0,
+       0,     0,   681,   682,   683,   684,   685,   686,   687,     0,
+       0,   272,     0,     0,     0,     0,     0,     0,     0,   688,
+     689,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,  1080,   678,   679,   680,
-     681,   682,   683,   684,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   685,   686,     0,   216,   217,   218,
-       0,   220,   221,   222,   223,   224,   444,   226,   227,   228,
-     229,   230,   231,   232,   233,   234,   235,   236,     0,   238,
-     239,   240,     0,     0,   243,   244,   245,   246,   216,   217,
-     218,     0,   220,   221,   222,   223,   224,   444,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,     0,
-     238,   239,   240,     0,     0,   243,   244,   245,   246,     0,
+       0,  1084,     0,     0,     0,     0,     0,   273,     0,   274,
+    1085,   275,   276,   277,   278,   279,     0,   280,   281,   282,
+     283,   284,   285,   286,   287,   288,   289,   290,     0,   291,
+     292,   293,     0,     0,   294,   295,   296,   297,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   298,   299,   219,   220,   221,     0,
+     223,   224,   225,   226,   227,   447,   229,   230,   231,   232,
+     233,   234,   235,   236,   237,   238,   239,     0,   241,   242,
+     243,     0,     0,   246,   247,   248,   249,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   300,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     858,   269,     0,     0,     0,     0,     0,     0,     0,   859,
+       0,     0,     0,     0,   899,   900,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,  1081,     0,     0,     0,     0,     0,   270,     0,   271,
-    1082,   272,   273,   274,   275,   276,     0,   277,   278,   279,
-     280,   281,   282,   283,   284,   285,   286,   287,     0,   288,
-     289,   290,     0,     0,   291,   292,   293,   294,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   295,   296,   216,   217,   218,     0,
-     220,   221,   222,   223,   224,   444,   226,   227,   228,   229,
-     230,   231,   232,   233,   234,   235,   236,     0,   238,   239,
-     240,     0,     0,   243,   244,   245,   246,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   297,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   896,   897,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   898,
-       0,     0,     0,     0,     0,   270,     0,   271,   899,   272,
-     273,   274,   275,   276,     0,   277,   278,   279,   280,   281,
-     282,   283,   284,   285,   286,   287,     0,   288,   289,   290,
-       0,     0,   291,   292,   293,   294,     0,     0,     0,     0,
-       0,     0,   900,   901,   270,     0,   271,     0,   272,   273,
-     274,   275,   276,     0,   277,   278,   279,   280,   281,   282,
-     283,   284,   285,   286,   287,     0,   288,   289,   290,     0,
-       0,   291,   292,   293,   294,     0,   270,     0,   271,     0,
-     272,   273,   274,   275,   276,     0,   277,   278,   279,   280,
-     281,   282,   283,   284,   285,   286,   287,   539,   288,   289,
-     290,     0,     0,   291,   292,   293,   294,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   901,
+       0,     0,     0,     0,     0,   273,     0,   274,   902,   275,
+     276,   277,   278,   279,     0,   280,   281,   282,   283,   284,
+     285,   286,   287,   288,   289,   290,     0,   291,   292,   293,
+       0,     0,   294,   295,   296,   297,     0,     0,     0,     0,
+       0,     0,   903,   904,   273,     0,   274,     0,   275,   276,
+     277,   278,   279,     0,   280,   281,   282,   283,   284,   285,
+     286,   287,   288,   289,   290,     0,   291,   292,   293,     0,
+       0,   294,   295,   296,   297,     0,   273,     0,   274,     0,
+     275,   276,   277,   278,   279,     0,   280,   281,   282,   283,
+     284,   285,   286,   287,   288,   289,   290,   542,   291,   292,
+     293,     0,     0,   294,   295,   296,   297,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   541,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   544,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   724
+       0,     0,     0,     0,     0,     0,     0,     0,   727
 };
 
 static const yytype_int16 yycheck[] =
 {
-       1,    14,    15,   106,   144,   145,   331,   567,   171,   571,
-     430,   430,   942,   343,  1034,   471,   636,   637,   186,    20,
-      21,    22,   694,   764,   696,  1007,   698,   843,  1167,   579,
-     509,   538,   511,  1246,   513,   641,   931,    82,   925,   537,
-       5,    15,    16,   810,     8,    20,  1540,   348,   349,    20,
-     852,    52,    65,    66,    67,   950,  1371,    46,   127,   151,
-     156,    20,   518,   813,    19,    20,  1586,  1586,     0,  1586,
-     186,    20,   126,  1477,    34,     7,    40,  1586,   151,   176,
-      19,  1586,   179,  1013,    22,  1334,    33,   174,   708,   173,
-     420,   140,   141,   142,   107,   108,   109,   110,    30,    33,
-      32,   148,    34,    63,   173,   174,     7,   176,    40,   201,
-     179,   203,    21,    22,   139,   127,   163,   106,    50,    57,
-     204,   133,   176,   180,    56,  1645,  1645,   181,  1645,   127,
-     203,   163,  1536,    15,    16,   133,  1645,   102,   103,  1526,
-    1645,     5,     6,   200,   600,   308,   200,   107,    80,    50,
-      62,   176,   201,   200,   610,   705,   201,   613,   205,   709,
-     300,    25,   174,  1683,  1683,   305,  1683,    31,   200,   309,
-     102,   103,   132,   186,  1683,   343,   174,   797,  1683,   139,
-     800,  1496,   156,   789,   176,   641,  1680,   161,   808,   163,
-    1577,   811,   166,   995,   173,  1444,  1445,   173,   173,   200,
-    1694,   165,   173,   163,    68,    69,  1226,   974,   163,   118,
-     119,  1460,   774,  1462,   173,   180,   185,   126,  1200,   128,
-     129,   130,   131,   132,   173,   975,   200,  1122,  1115,   203,
-     190,   687,   179,   165,   198,   200,   842,   250,   102,   103,
-     200,   180,   206,  1138,   545,   179,   126,   185,   798,   669,
-     669,   198,   420,   148,   186,   423,   424,   425,  1515,   197,
-     207,   126,  1192,   180,   163,   310,   198,  1524,   163,  1518,
-    1519,   601,   204,   126,   156,   139,  1525,   126,   418,   161,
-     173,   163,  1495,   200,   166,   185,   616,   148,   197,   198,
-     126,   154,   163,   129,   130,   173,   176,   129,   130,   163,
-     163,   181,   163,   202,   165,   200,   199,   423,   424,   425,
-     165,   176,  1569,  1570,  1453,  1350,   180,   127,  1596,  1339,
-     200,   199,   163,   176,   165,     5,     6,   176,   181,   127,
-     343,   146,   181,   789,   198,   133,   504,   505,   201,   163,
-     508,   205,   510,   204,   512,   206,   514,   200,   163,   204,
-     127,   200,   520,  1373,  1389,  1633,   133,   173,  1030,   154,
-     966,   197,   198,   204,   174,   197,   198,   177,   163,   537,
-     849,   186,   173,   923,  1304,   127,   174,   139,   127,   127,
-     181,   133,   197,   199,   133,   133,   554,   555,   504,   505,
-    1206,   139,   508,   955,   510,   165,   512,   174,   163,   164,
-    1020,   165,   146,   204,   520,   200,   200,   420,   173,    45,
-     423,   424,   425,   177,   163,   922,   156,   430,   431,   163,
-     970,   919,   174,    21,    22,   174,   174,    33,   935,   107,
-     179,     8,   165,   601,   204,   933,   206,   173,   554,   555,
-     204,   185,   186,   773,   994,   165,    21,    22,   616,    85,
-      86,   180,    88,   197,    60,    61,   786,   787,   173,    36,
-      65,    66,    67,   173,  1280,   201,   796,   200,   173,   139,
-      57,   200,   802,   803,   180,   805,    63,   807,   173,   809,
-     200,   197,   173,   651,   652,   173,   201,   173,  1229,   199,
-     173,   504,   505,   163,   200,   508,   201,   510,   666,   512,
-     640,   514,   107,   108,   109,   110,   201,   520,   148,  1491,
-     201,   173,   173,   201,   148,   201,   199,   685,   124,   173,
-     118,   119,   128,   163,   537,   198,  1616,  1199,   126,   163,
-     203,   129,   130,   131,   132,   173,   139,   199,  1017,   707,
-     201,   554,   555,   118,   119,   148,  1476,   201,   180,   562,
-     153,   126,  1642,   128,   129,   130,   131,   132,   164,   165,
-     163,   173,   173,   201,   173,   167,   180,   173,   200,   175,
-     571,  1591,   163,   179,   173,   181,   182,   180,   173,   176,
-      21,    22,   165,   180,   173,   173,   200,   173,   601,   201,
-     201,   707,   201,  1072,  1266,   154,    47,   173,   204,   197,
-     198,   207,   201,   616,   163,   773,   201,  1627,   163,   184,
-     185,   186,   201,   201,  1164,   201,    67,   785,   786,   787,
-     788,  1077,   197,   198,   792,   201,   639,   163,   796,   642,
-     107,   164,   165,  1089,   802,   803,   139,   805,  1094,   807,
-     173,   809,   810,   973,  1664,   148,   163,  1667,   181,   979,
-     154,   107,   164,   165,   163,   164,    12,   164,   165,   163,
-     163,   173,   163,   993,   173,   177,   173,    23,    24,   785,
-     154,   204,   788,   154,   181,   164,   792,   118,   119,   163,
-     202,   203,   163,   205,   173,   126,  1016,   128,   129,   130,
-     131,   132,   204,   154,   707,   167,   168,   204,  1514,  1515,
-     164,   165,   163,    79,  1520,   163,    57,    57,  1524,   173,
-    1526,   177,    63,    63,   163,   181,   884,   181,    94,   205,
-     721,   173,   723,    99,   176,   101,  1182,   179,    57,   173,
-     164,   165,   176,  1189,    63,   179,   140,   141,   142,   173,
-     204,   182,   183,   184,   185,   186,  1562,   181,   140,   917,
-     142,   919,   920,  1569,  1570,   177,   197,   198,   926,   181,
-     773,  1577,   167,   168,   169,   933,    21,    22,   164,   165,
-     204,   203,   785,   786,   787,   788,   777,   173,    57,   792,
-      57,    57,    57,   796,    63,   181,    63,    63,   190,   802,
-     803,   177,   805,   174,   807,   181,   809,   810,   177,   177,
-     167,   917,   181,   181,   920,   973,   974,   176,   204,   140,
-     926,   979,   164,   165,   177,  1556,   177,   165,   181,  1635,
-     181,   173,   167,   168,   169,   993,    33,   164,   165,   181,
-     177,   177,   203,   318,   181,   181,   173,   177,  1258,  1258,
-      66,   181,   177,   328,   181,   163,   181,   163,  1016,   164,
-     851,   176,   204,    60,    61,   106,   341,   167,   168,   169,
-     170,   116,   117,   118,   119,   120,   163,   204,   123,   124,
-     125,   126,   180,   128,   129,   130,   131,   132,   180,   134,
-     135,   204,   205,    33,   203,   140,   487,   142,   489,   490,
-     756,   757,   758,    10,    11,  1351,    56,    57,    58,  1236,
-    1237,   200,  1042,  1523,   917,   200,   919,   920,   489,   490,
-      60,    61,   180,   926,   180,   180,  1657,   124,   180,   180,
-     933,   128,   177,   178,   179,   180,   181,   182,   183,   184,
-     185,   186,   933,   180,   935,   180,   180,  1267,   177,   198,
-     200,   164,   197,   198,  1564,  1686,   947,   205,   205,    35,
-     164,   165,    35,   163,   955,   163,   957,   200,   180,   173,
-     973,   974,   164,   165,   198,  1133,   979,   181,   175,   205,
-     163,   173,   179,    22,   124,   182,   163,   127,   128,   181,
-     993,  1144,    33,   133,   199,   138,   199,  1547,    75,   205,
-     204,   176,    79,   163,   180,   200,   180,   180,    21,    22,
-     207,  1457,   204,  1016,   180,   180,    93,    94,   200,    60,
-      61,    98,    99,   100,   101,   165,   180,  1133,   200,   180,
-     200,   180,   200,  1479,   174,   175,   200,   200,   200,   179,
-     198,  1593,   182,   200,   203,   200,   521,   200,  1039,   201,
-     181,  1181,   163,   201,   201,   201,  1047,  1048,   533,   173,
-     199,    33,   199,   204,   204,   200,   200,   207,   201,  1060,
-      43,  1062,  1063,  1064,  1065,  1066,   205,  1629,   181,  1070,
-     200,   180,   180,   124,  1214,   180,   180,   128,    60,    61,
-     200,    13,   200,   199,   173,     4,   201,   163,   163,   203,
-     575,   176,   199,   116,   117,   118,   119,   120,   163,  1267,
-     123,  1269,   163,   126,   163,   128,   129,   130,   131,   132,
-     163,   134,   135,    21,    22,   163,   173,   602,   603,   201,
-    1133,   606,   201,   608,   175,   180,  1451,   201,   179,   201,
-     181,   182,   201,  1589,   619,   620,   621,   622,   623,   624,
-     180,   201,   124,   201,   200,   127,   128,   201,  1149,   201,
-     200,   133,   199,  1269,    33,   201,   207,   180,   181,   182,
-     183,   184,   185,   186,   200,     1,   201,   200,   200,   200,
-     200,   200,   200,   200,   197,   198,   200,   199,   181,   664,
-     181,    60,    61,   181,   201,   200,   174,   201,   200,    43,
-     174,   201,   174,   175,    43,   201,   201,   179,   176,   201,
-     182,   686,   201,    33,   200,    43,   201,  1375,   116,   117,
-     118,   119,   201,   163,   201,   200,   206,   163,   126,   200,
-     128,   129,   130,   131,   132,   207,   134,   135,   713,   201,
-      60,    61,   200,   200,   163,   201,    33,    10,   156,    13,
-       9,    42,    66,   180,   200,   124,   200,   199,   199,   128,
-     163,   200,  1420,   163,  1267,     8,  1269,   163,   206,  1375,
-     163,   206,  1592,    60,    61,   206,   163,   752,  1436,   163,
-     201,   163,   200,  1413,   182,   183,   184,   185,   186,   163,
-     171,  1384,   163,   163,   201,   770,   201,   163,   200,   197,
-     198,   776,   201,   163,   124,    14,   175,   174,   128,   174,
-     179,   156,   181,   182,  1420,   176,   791,   200,   174,    43,
-     200,   200,  1313,   201,  1315,   201,   201,    37,   201,   206,
-    1436,   174,    67,    21,    22,   181,    70,   124,   207,   201,
-     163,   128,   206,   200,    43,   200,   200,   822,   201,   200,
-     200,   200,   827,   200,   829,   175,   831,   181,   163,   179,
-     201,   181,   182,   201,   200,   200,   841,   201,   201,   201,
-     163,   201,  1375,   200,   163,   200,   205,    33,   108,   109,
-     110,   111,   112,   113,   114,   115,   201,   207,   175,   200,
-    1381,   200,   179,   200,   181,   182,   167,   201,   204,   201,
-     201,    33,   201,   133,    60,    61,   206,   201,   204,   201,
-      12,   201,  1542,   143,   144,   145,  1546,  1420,   201,   201,
-     207,   173,   897,   173,   201,   201,   901,   201,   116,   117,
-     118,   119,   120,  1436,  1592,   123,   124,   125,   126,   201,
-     128,   129,   130,   131,   132,   201,   134,   135,   201,   204,
-     201,   199,   927,   200,    53,   204,   201,   201,   625,   201,
-    1590,   199,    81,   200,   205,     1,   206,   206,   124,   136,
-     206,    84,   128,   205,  1477,   201,  1693,   206,  1691,   723,
-     723,   956,   207,   951,  1237,    33,   642,   707,     1,   177,
-     178,   179,   180,   181,   182,   183,   184,   185,   186,  1510,
-    1369,   646,    33,  1560,  1495,   980,  1513,  1439,  1561,   197,
-     198,  1561,    60,    61,    55,    33,  1646,  1508,  1138,   175,
-     950,   950,  1652,   179,   302,   181,   182,   225,  1658,    60,
-      61,   602,    -1,  1536,    -1,   430,   430,    -1,   430,  1014,
-    1015,   430,    60,    61,   448,   449,    -1,    -1,    -1,    -1,
-    1025,   207,    -1,    -1,  1684,    -1,    -1,  1032,   430,    -1,
-    1035,   465,   466,   467,   468,   469,  1041,   430,  1043,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   124,    -1,    -1,    -1,
-     128,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,  1592,
-      -1,    -1,    -1,   124,    -1,    -1,  1587,   128,    -1,  1074,
-      -1,  1076,    -1,  1078,  1595,    -1,   124,    -1,    -1,    -1,
-     128,    -1,    -1,  1088,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,  1096,    -1,    -1,    -1,    -1,    -1,   175,    21,    22,
-      -1,   179,    -1,   181,   182,    -1,    -1,    -1,    -1,    -1,
-      -1,  1632,    -1,    -1,   175,  1120,    -1,    -1,   179,    -1,
-     181,   182,    -1,   557,    -1,  1130,    -1,   175,  1649,   207,
-    1135,   179,  1137,   181,   182,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,  1663,  1148,  1665,    -1,   207,    -1,    -1,  1670,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   207,
-      -1,    -1,  1167,    -1,    -1,    -1,  1687,    -1,  1689,    -1,
+       1,    14,    15,   100,   334,   574,   168,   570,   433,   141,
+     142,   767,   433,   945,  1037,   582,  1170,  1010,   644,    20,
+      21,    22,   474,   846,   639,   640,  1249,   188,   541,   512,
+     697,   514,   699,   516,   701,   540,    79,   934,    33,   351,
+     352,     8,  1337,   813,    19,    33,     5,   928,    49,    62,
+      63,    64,    46,   188,   816,  1543,   953,    22,    34,   855,
+      20,  1374,   346,   126,    20,    20,   126,   151,  1589,   521,
+       0,   148,    20,    40,   126,  1480,   163,     7,    19,    20,
+     126,   140,   141,   142,  1016,  1529,   163,    63,   101,   102,
+     103,   104,    57,   165,   148,   151,   711,     8,   165,   148,
+      30,   156,    32,  1589,    34,   177,   198,     5,     6,   163,
+      40,   203,   106,   176,   163,   202,   176,   201,   181,   203,
+      50,   181,   139,   200,   176,    36,    56,  1648,   205,   181,
+     176,   107,   204,   200,  1539,   181,  1580,   200,     7,   423,
+     200,   708,   201,   102,   103,   712,   200,   203,   200,   311,
+      80,   603,  1447,  1448,   200,    33,   132,    15,    16,   176,
+     203,   613,  1648,   139,   616,  1686,   792,   163,  1463,   173,
+    1465,   303,   102,   103,   180,   188,   308,    15,    16,   126,
+     312,    50,    60,    61,   179,   800,  1499,   163,   803,  1589,
+     175,   179,   644,  1589,   200,  1683,   811,   201,   165,   814,
+    1686,   202,   998,   198,   200,   180,  1229,   977,   777,  1697,
+    1203,   346,   207,   173,   190,    62,   978,   173,   173,   845,
+     185,   180,   163,   174,   200,   173,  1521,  1522,  1125,   176,
+     127,   198,   197,  1528,   801,   165,   548,  1118,   690,   206,
+     253,   200,   129,   130,  1141,   173,   124,   672,  1648,   127,
+     128,   672,  1648,    33,  1589,   133,   186,   173,     5,     6,
+    1518,   173,   127,  1195,   173,   426,   427,   428,   198,  1527,
+     313,   176,   165,   201,   204,  1498,   173,   174,    25,   176,
+      60,    61,   179,   173,    31,   201,  1686,   165,   423,   421,
+    1686,   426,   427,   428,   127,   204,   174,   175,   156,   165,
+     133,   179,  1456,   161,   182,   163,   139,   200,   166,   174,
+     197,   198,   177,  1648,  1572,  1573,   139,   146,   156,  1342,
+     604,    68,    69,   161,   127,   163,   204,   154,   166,   207,
+     133,    21,    22,   346,   163,   619,   163,   173,   204,   163,
+     792,   174,   200,   969,   124,   203,   507,   508,   128,   163,
+     511,  1686,   513,  1376,   515,   102,   103,   186,   154,   926,
+     200,  1353,   523,   173,   173,   201,  1033,   163,   197,   852,
+    1599,   174,   507,   508,   201,  1307,   511,   163,   513,   165,
+     515,    57,   517,   180,   164,   165,  1209,    63,   523,   958,
+     199,   201,   139,   173,   148,   175,   557,   558,   163,   179,
+    1392,   181,   182,   200,   200,   540,   973,  1636,  1023,   163,
+     423,   165,   925,   426,   427,   428,   163,   922,   204,   107,
+     433,   434,   557,   558,   204,   938,   146,   207,   118,   119,
+     997,   936,   140,   180,   142,   173,   126,   139,   128,   129,
+     130,   131,   132,   163,   173,   126,   173,   173,   129,   130,
+     204,   198,   206,  1619,    85,   181,   127,   156,   205,    33,
+    1283,   163,   133,   201,   176,   185,   186,   173,   180,   604,
+     199,   164,    21,    22,   201,   185,  1232,   197,   204,  1645,
+     173,   173,   127,   127,   619,   127,    60,    61,   133,   133,
+     173,   133,   776,   199,   507,   508,   127,   128,   511,   130,
+     513,  1494,   515,   174,   517,   789,   790,   197,   198,   201,
+     523,   643,    21,    22,   173,   799,   197,   198,   201,   654,
+     655,   805,   806,   173,   808,   165,   810,   540,   812,   174,
+     174,   185,   174,   176,   669,  1202,   179,  1020,   163,   173,
+     199,   180,   127,   180,   557,   558,   173,  1479,   133,   710,
+     124,   201,   565,   688,   128,   167,    62,    63,    64,   164,
+     165,   200,   173,   200,   204,   173,   206,   201,   173,   118,
+     119,  1594,   177,   574,   201,   710,   173,   126,   163,   128,
+     129,   130,   131,   132,   173,   173,   173,   173,   148,   174,
+     201,   604,  1075,   201,   179,   101,   102,   103,   104,   204,
+    1167,   175,  1269,   163,   201,   179,   619,  1630,   182,   118,
+     119,   163,   201,   201,   201,   201,   173,   126,   180,   180,
+     129,   130,   131,   132,    33,   163,    47,   788,  1080,   642,
+     791,   173,   645,   207,   795,   184,   185,   186,   200,   200,
+    1092,   776,   199,   163,  1667,  1097,    67,  1670,   197,   198,
+     139,    60,    61,   788,   789,   790,   791,   199,   139,   148,
+     795,    75,    57,   173,   799,    79,   176,   148,    63,   179,
+     805,   806,   153,   808,   163,   810,   107,   812,   813,    93,
+      94,    79,   163,   165,    98,    99,   100,   101,   197,   198,
+     204,   205,   976,   154,  1517,  1518,    94,   710,   982,   180,
+    1523,    99,   163,   101,  1527,    12,  1529,   177,   107,    21,
+      22,   181,   996,   164,   165,   124,    23,    24,   127,   128,
+     164,   165,   173,   724,   133,   726,    57,   164,   165,   173,
+     181,   321,    63,  1185,   154,  1019,   173,   181,   163,   164,
+    1192,   331,  1565,   163,   181,   163,   164,   154,   173,  1572,
+    1573,   205,   887,   204,   344,   173,   163,  1580,   173,   920,
+     204,   176,   923,   776,   179,   174,   175,   204,   929,   203,
+     179,   154,   154,   182,   197,   788,   789,   790,   791,   780,
+     163,   163,   795,    57,    57,   920,   799,   922,   923,    63,
+      63,   163,   805,   806,   929,   808,    57,   810,   207,   812,
+     813,   936,    63,  1559,   116,   117,   118,   119,   120,   167,
+     168,   123,   124,   125,   126,  1638,   128,   129,   130,   131,
+     132,    57,   134,   135,    33,   174,   138,    63,   140,   141,
+     142,   177,    10,    11,   146,   181,  1261,   164,   165,   177,
+    1261,   976,   977,   181,   167,   177,   173,   982,    33,   181,
+     163,    60,    61,   854,   181,   177,   177,   163,   177,   181,
+     181,   996,   181,   175,   176,   177,   178,   179,   180,   181,
+     182,   183,   184,   185,   186,    60,    61,   204,   177,   177,
+    1239,  1240,   181,   181,  1019,   197,   198,   190,   176,   108,
+     109,   110,   111,   112,   113,   114,   115,   177,   140,   177,
+     165,   181,  1354,   181,  1660,   163,   203,   920,   127,   922,
+     923,  1526,   163,  1045,   133,   124,   929,   202,   203,   128,
+     205,   164,   165,   936,   143,   144,   145,   164,   165,    57,
+     173,   164,   165,  1689,   524,   936,   173,   938,   181,   124,
+     173,   164,   165,   128,   181,    66,   536,   164,   181,   950,
+     173,   490,  1567,   492,   493,   174,   176,   958,   181,   960,
+     106,   204,   203,   976,   977,   163,   175,   204,   180,   982,
+     179,   204,   181,   182,   180,  1136,   167,   168,   169,   170,
+     180,   204,   200,   996,   180,  1147,  1270,  1550,   578,   200,
+     175,   140,   141,   142,   179,   200,   181,   182,   207,    21,
+      22,  1136,   205,   164,   165,   180,  1019,   180,  1460,   167,
+     168,   169,   173,   492,   493,   605,   606,   180,   180,   609,
+     181,   611,   207,   167,   168,   169,   180,  1596,   180,   198,
+    1482,   164,   622,   623,   624,   625,   626,   627,   759,   760,
+     761,  1042,   177,   204,    53,    54,    55,    35,   205,  1050,
+    1051,    35,  1184,   200,   108,   109,   110,   111,   112,   113,
+     114,   115,  1063,  1632,  1065,  1066,  1067,  1068,  1069,   163,
+     163,   180,  1073,   198,   205,   163,   199,   667,    22,   133,
+     163,   199,   138,   205,   176,  1217,   163,    21,    22,   143,
+     144,   145,   200,   180,   116,   117,   118,   119,   120,   689,
+     180,   123,   124,   125,   126,   180,   128,   129,   130,   131,
+     132,  1272,   134,   135,   180,   180,   200,   180,   140,   141,
+     142,   200,   180,  1136,  1454,   180,   716,   200,   200,   200,
+     200,   200,   200,   181,   198,  1270,   203,  1272,   200,   200,
+    1592,   201,   201,   163,   201,   173,    43,   199,   201,   199,
+     201,  1152,   181,   175,   200,   177,   178,   179,   180,   181,
+     182,   183,   184,   185,   186,   755,   204,   200,   205,   200,
+     180,    13,    21,    22,   180,   197,   198,   180,   180,   200,
+     199,   173,   200,   773,   118,   119,   201,     4,   163,   779,
+     203,   163,   126,   176,   128,   129,   130,   131,   132,   199,
+     163,   163,   163,   163,   794,    33,   163,   173,   201,   200,
+      33,    21,    22,   180,   201,   201,   201,  1378,     1,   201,
+     201,   201,   201,   201,   201,   201,   200,   200,   180,   200,
+     200,   200,    60,    61,   199,   825,   200,    60,    61,   181,
+     830,   200,   832,  1378,   834,   200,   200,   200,   182,   183,
+     184,   185,   186,   199,   844,   181,   181,  1270,   201,  1272,
+     200,   174,  1423,   197,   198,   201,    43,   116,   117,   118,
+     119,   120,   200,   174,   123,   124,   125,   126,  1439,   128,
+     129,   130,   131,   132,  1416,   134,   135,   201,  1423,   138,
+    1387,   140,   141,   142,    43,   201,   124,   146,   201,   201,
+     128,   124,   201,   201,  1439,   128,   116,   117,   118,   119,
+     900,  1595,   200,   200,   904,  1316,   126,  1318,   128,   129,
+     130,   131,   132,   201,   134,   135,   175,   201,   177,   178,
+     179,   180,   181,   182,   183,   184,   185,   186,   176,   200,
+     930,    43,   163,   201,   200,   200,   206,   175,   197,   198,
+     201,   179,   175,   181,   182,   163,   179,   163,   181,   182,
+     156,    10,    13,     9,    42,  1378,    66,   180,   200,   959,
+     200,   200,   182,   183,   184,   185,   186,   199,   163,   207,
+     199,   163,   206,  1384,   207,   163,   206,   197,   198,   163,
+     206,   163,     8,   983,   163,   163,   201,   200,   171,   163,
+     201,   201,   201,    33,   163,   163,   200,   163,   163,    14,
+    1423,   174,   174,  1545,   156,   176,    33,  1549,   206,   200,
+     200,   200,   174,    43,    37,   201,  1439,  1017,  1018,   174,
+      60,    61,    67,   181,   201,   201,   201,    33,  1028,    70,
+     163,   201,    43,    60,    61,  1035,    33,   200,  1038,   206,
+     200,   181,   163,   200,  1044,   201,  1046,   200,   163,   200,
+    1595,  1593,   200,   200,    60,    61,   201,  1480,   201,   200,
+     167,   200,   200,    60,    61,    33,   201,   201,   204,   201,
+     201,   200,   200,   200,   200,   205,   201,  1077,   163,  1079,
+      33,  1081,   201,   201,   124,   451,   452,  1498,   128,   206,
+     201,  1091,    60,    61,    12,   201,   201,   124,    33,  1099,
+    1511,   128,   468,   469,   470,   471,   472,  1649,   201,   201,
+     201,   173,   201,  1655,   204,   173,  1539,   201,   124,  1661,
+     201,   201,   128,  1123,   201,    60,    61,   124,   201,   201,
+     201,   128,   201,  1133,   204,   175,   204,   200,  1138,   179,
+    1140,   181,   182,    53,   201,  1687,   201,   199,   175,   199,
+     201,  1151,   179,   206,   181,   182,   124,   205,   200,   206,
+     128,    78,   206,   206,     1,   185,   205,   207,    81,   175,
+    1170,   628,  1595,   179,  1696,   181,   182,   726,   175,  1590,
+     207,  1694,   179,  1240,   181,   182,   726,  1598,  1188,   124,
+     209,   645,   954,   128,   560,   710,  1196,  1197,  1198,   649,
+    1372,   207,     1,  1513,  1563,  1516,  1442,   175,  1564,  1564,
+     207,   179,    52,   181,   182,  1141,   433,   953,  1218,   953,
+     228,  1221,   305,    -1,  1635,   433,   433,   605,   433,    -1,
+    1230,   433,    33,   433,    -1,    -1,    -1,    -1,    -1,   207,
+     175,  1652,    -1,    -1,   179,    -1,   181,   182,    33,    -1,
+      -1,    -1,    21,    22,    -1,  1666,    -1,  1668,    -1,    60,
+      61,    -1,  1673,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   207,    -1,    -1,    60,    61,    -1,  1278,  1690,
+    1280,  1692,    -1,    -1,    -1,    -1,  1286,    -1,    -1,    -1,
+     656,   657,    -1,    -1,   660,   661,   662,   663,    -1,   665,
+      -1,    -1,   668,   669,   670,   671,   672,   673,   674,   675,
+     676,   677,   678,   679,   680,   681,   682,   683,   684,   685,
+     686,   687,    -1,   124,  1324,    -1,    -1,   128,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   124,
+      -1,  1341,    -1,   128,    -1,    -1,    -1,   116,   117,   118,
+     119,   120,    -1,    -1,   123,  1355,  1356,   126,    -1,   128,
+     129,   130,   131,   132,    -1,   134,   135,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   175,    -1,    -1,    -1,   179,  1379,
+     181,   182,    -1,    -1,    -1,  1385,  1386,    -1,    -1,    -1,
+     175,  1391,    -1,    -1,   179,    -1,   181,   182,    -1,   765,
+      -1,    -1,    -1,    -1,    -1,    -1,   207,    -1,    -1,    -1,
+      -1,   180,   181,   182,   183,   184,   185,   186,    -1,    -1,
+      -1,    -1,   207,    -1,    -1,    -1,    -1,    -1,   197,   198,
+      -1,  1431,    -1,    -1,    -1,  1435,    -1,    -1,    -1,    -1,
+      10,    -1,    -1,    -1,    -1,    -1,    -1,    19,    -1,    -1,
+      -1,    21,    22,    -1,    -1,    -1,  1456,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-    1185,    -1,    -1,    -1,    -1,    -1,    -1,    10,  1193,  1194,
-    1195,    -1,    -1,   116,   117,   118,   119,   120,    21,    22,
-     123,   124,   125,   126,    -1,   128,   129,   130,   131,   132,
-    1215,   134,   135,  1218,    -1,    -1,    -1,   140,    -1,   653,
-     654,    -1,  1227,   657,   658,   659,   660,    -1,   662,    -1,
-      -1,   665,   666,   667,   668,   669,   670,   671,   672,   673,
-     674,   675,   676,   677,   678,   679,   680,   681,   682,   683,
-     684,    -1,    -1,    -1,   177,   178,   179,   180,   181,   182,
-     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
-    1275,    -1,  1277,    -1,   197,   198,    -1,    -1,  1283,    -1,
-      -1,    -1,    -1,    -1,    -1,   108,   109,   110,   111,   112,
-     113,   114,   115,   116,   117,   118,   119,   120,   121,   122,
-     123,   124,   125,   126,   127,   128,   129,   130,   131,   132,
-     133,   134,   135,   136,   137,   138,  1321,   140,   141,   142,
-     143,   144,   145,   146,    -1,    -1,    -1,    -1,   762,    -1,
-      -1,    -1,    -1,  1338,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,  1352,  1353,    -1,
-      -1,   174,   175,    -1,   177,   178,   179,   180,   181,   182,
-     183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,  1376,    -1,    -1,   197,   198,    -1,  1382,  1383,    -1,
-      -1,    -1,    -1,  1388,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    21,    22,    -1,    19,    -1,
-      -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,    -1,
-      31,    -1,    -1,    -1,    -1,    -1,    -1,   851,    -1,    -1,
-      41,    -1,    -1,  1428,    -1,    -1,    -1,  1432,    49,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,  1453,    -1,
-      71,    72,    73,    74,    75,    76,    77,    78,    79,    80,
-      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
-      91,    92,    93,    94,    95,    96,    97,    98,    99,   100,
-     101,   102,   103,    -1,    -1,    -1,    -1,  1492,    -1,    -1,
-     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
-     126,    -1,   128,   129,   130,   131,   132,    -1,   134,   135,
-      -1,    -1,  1517,   947,   140,   141,   142,    -1,   139,    -1,
-      -1,    -1,    -1,    -1,  1529,    -1,    -1,    -1,  1533,  1534,
-      -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   163,    -1,    -1,    -1,    -1,    -1,    -1,   175,
-      -1,   177,   178,   179,   180,   181,   182,   183,   184,   185,
-     186,    -1,    -1,    -1,    33,    -1,    -1,    -1,    -1,    33,
-      -1,   197,   198,    -1,    -1,  1580,    -1,    -1,    -1,    -1,
-      -1,   202,    -1,    -1,    -1,    -1,   207,    -1,    -1,    -1,
-      -1,    60,    61,    -1,    -1,    -1,    60,    61,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,     5,     6,    -1,    -1,
-      -1,    -1,  1617,    -1,    -1,    -1,    15,    16,    17,    18,
-      19,    -1,    -1,    -1,    -1,  1630,    25,    -1,    27,    -1,
-      -1,    -1,    31,    -1,  1639,    -1,    -1,    -1,    -1,    -1,
-      39,    -1,    -1,  1648,    -1,    -1,    45,    -1,    -1,    48,
-    1084,    -1,    51,    -1,    -1,   124,    55,    -1,    -1,   128,
-     124,    -1,    -1,    -1,   128,    -1,    65,  1672,    -1,    68,
-      69,    70,    71,    72,    73,    -1,    75,    76,    77,    78,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   854,    -1,
+      -1,    -1,    -1,    -1,    -1,  1495,    -1,    33,    -1,    71,
+      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+    1520,    93,    94,    95,    60,    61,    98,    99,   100,   101,
+      -1,    -1,  1532,    -1,    -1,    -1,  1536,  1537,   108,   109,
+     110,   111,   112,   113,   114,   115,   116,   117,   118,   119,
+     120,   121,   122,   123,   124,   125,   126,   127,   128,   129,
+     130,   131,   132,   133,   134,   135,   136,   137,   138,    -1,
+     140,   141,   142,   143,   144,   145,   146,    -1,    -1,    -1,
+      -1,    -1,   154,  1583,   950,    -1,    -1,    -1,   124,    -1,
+      -1,   163,   128,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   174,   175,    -1,   177,   178,   179,
+     180,   181,   182,   183,   184,   185,   186,    -1,    -1,    -1,
+    1620,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,    -1,
+      -1,    -1,    -1,  1633,    -1,    -1,    -1,    -1,    -1,   175,
+      -1,    -1,  1642,   179,    -1,   181,   182,    -1,    -1,    -1,
+      -1,  1651,     1,    -1,    -1,    -1,     5,     6,     7,    -1,
+       9,    10,    11,    -1,    13,    -1,    15,    16,    17,    18,
+      19,   207,    -1,    -1,    -1,  1675,    25,    26,    27,    28,
+      29,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    38,
+      39,    40,    -1,    42,    -1,    44,    45,    -1,    -1,    48,
+      -1,    50,    51,    52,    -1,    54,    55,    -1,    -1,    58,
+      59,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,  1087,    71,    72,    73,    -1,    75,    76,    77,    78,
       79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
       89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
-      99,   100,   101,   102,   103,   104,   175,    -1,    -1,    -1,
-     179,   175,   181,   182,    -1,   179,    -1,   181,   182,   118,
-     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   207,    -1,
-     139,    -1,    -1,   207,    -1,    -1,    -1,    -1,   147,   148,
-     149,   150,   151,    -1,   153,   154,   155,   156,   157,   158,
-     159,   160,   161,   162,   163,    -1,    -1,   166,    -1,    -1,
+      99,   100,   101,   102,   103,   104,   105,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,
+     149,   150,   151,    -1,   153,    -1,   155,   156,   157,   158,
+     159,   160,   161,   162,   163,    -1,   165,   166,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,
      189,   190,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   198,
-      -1,   200,   201,   202,   203,    -1,   205,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,  1248,  1249,  1250,  1251,  1252,  1253,
-    1254,  1255,  1256,  1257,  1258,  1259,  1260,  1261,  1262,  1263,
-    1264,  1265,    -1,    -1,    -1,     1,    -1,    -1,    -1,     5,
+      -1,   200,    -1,   202,   203,   204,   205,   206,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,  1251,  1252,  1253,  1254,  1255,
+    1256,  1257,  1258,  1259,  1260,  1261,  1262,  1263,  1264,  1265,
+    1266,  1267,  1268,    -1,    -1,    -1,     1,    -1,    -1,    -1,
+       5,     6,     7,    -1,     9,    10,    11,    -1,    13,    -1,
+      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
+      25,    26,    27,    28,    29,    -1,    31,    -1,    -1,    -1,
+      -1,    -1,    -1,    38,    39,    40,    -1,    42,    -1,    44,
+      45,    -1,    -1,    48,    -1,    50,    51,    52,    -1,    54,
+      55,    -1,    -1,    58,    59,    -1,    -1,  1333,  1334,  1335,
+      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
+      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
+      95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
+     105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,  1384,    -1,
+      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
+     155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
+     165,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
+      -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   198,    -1,   200,    -1,   202,   203,   204,
+     205,   206,     1,    -1,    -1,    -1,     5,     6,     7,    -1,
+       9,    10,    11,    -1,    13,    -1,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    26,    27,    28,
+      29,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    38,
+      39,    40,    -1,    42,    -1,    44,    45,    -1,    -1,    48,
+      -1,    50,    51,    52,    -1,    54,    55,    -1,    -1,    58,
+      59,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
+      79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,   105,    -1,    -1,    -1,
+      -1,    -1,    -1,  1589,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,  1598,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,
+     149,   150,   151,    -1,   153,    -1,   155,   156,   157,   158,
+     159,   160,   161,   162,   163,    -1,   165,   166,    -1,    -1,
+      -1,    -1,  1648,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,
+     189,   190,    -1,    -1,    -1,    -1,    -1,  1673,    -1,   198,
+      -1,   200,    -1,   202,   203,   204,   205,   206,    -1,     1,
+    1686,    -1,    -1,     5,     6,     7,  1692,     9,    10,    11,
+      -1,    13,    -1,    15,    16,    17,    18,    19,    -1,    -1,
+      -1,    -1,    -1,    25,    26,    27,    28,    29,    -1,    31,
+      -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,    -1,
+      42,    -1,    44,    45,    -1,    -1,    48,    -1,    50,    51,
+      52,    -1,    54,    55,    -1,    -1,    58,    59,    -1,    -1,
+      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
+      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+      -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
+     102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
+      -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
+     162,   163,    -1,   165,   166,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   198,    -1,   200,    -1,
+     202,   203,   204,   205,   206,     1,    -1,    -1,    -1,     5,
        6,     7,    -1,     9,    10,    11,    -1,    13,    -1,    15,
       16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
       26,    27,    28,    29,    -1,    31,    -1,    -1,    -1,    -1,
       -1,    -1,    38,    39,    40,    -1,    42,    -1,    44,    45,
       -1,    -1,    48,    -1,    50,    51,    52,    -1,    54,    55,
-      -1,    -1,    58,    59,    -1,    -1,  1330,  1331,  1332,    65,
+      -1,    -1,    58,    59,    -1,    -1,    -1,    -1,    -1,    65,
       -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
       76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
       86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
       -1,    -1,    98,    99,   100,   101,   102,   103,   104,   105,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,  1381,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
@@ -2998,176 +3060,189 @@ static const yytype_int16 yycheck[] =
       80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
       90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
      100,   101,   102,   103,   104,   105,    -1,    -1,    -1,    -1,
-      -1,    -1,  1586,    -1,    -1,    -1,    -1,    -1,   118,   119,
-      -1,  1595,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,
      150,   151,    -1,   153,    -1,   155,   156,   157,   158,   159,
-     160,   161,   162,   163,    -1,   165,   166,    -1,    -1,    -1,
-      -1,  1645,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     160,   161,   162,   163,    -1,   165,   166,    -1,    33,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,
-     190,    -1,    -1,    -1,    -1,    -1,  1670,    -1,   198,    -1,
-     200,    -1,   202,   203,   204,   205,   206,    -1,     1,  1683,
-      -1,    -1,     5,     6,     7,  1689,     9,    10,    11,    -1,
-      13,    -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,
-      -1,    -1,    25,    26,    27,    28,    29,    -1,    31,    -1,
-      -1,    -1,    -1,    -1,    -1,    38,    39,    40,    -1,    42,
-      -1,    44,    45,    -1,    -1,    48,    -1,    50,    51,    52,
-      -1,    54,    55,    -1,    -1,    58,    59,    -1,    -1,    -1,
-      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
-      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
-      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
-      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
-     103,   104,   105,   108,   109,   110,   111,   112,   113,   114,
-     115,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
-      -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,   133,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,   143,   144,
-     145,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
-     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
-     163,    -1,   165,   166,    -1,    -1,    -1,    -1,    -1,   174,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
-     183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   198,    -1,   200,    -1,   202,
-     203,   204,   205,   206,     1,    -1,    -1,    -1,     5,     6,
-       7,    -1,     9,    10,    11,    -1,    13,    -1,    15,    16,
-      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    26,
-      27,    28,    29,    -1,    31,    -1,    -1,    -1,    -1,    -1,
-      -1,    38,    39,    40,    -1,    42,    -1,    44,    45,    -1,
-      -1,    48,    -1,    50,    51,    52,    -1,    54,    55,    -1,
-      -1,    58,    59,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+     190,    -1,    -1,    -1,    -1,    60,    61,    -1,   198,    -1,
+     200,    -1,   202,   203,   204,   205,   206,     5,     6,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    15,    16,    17,
+      18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,
+      -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,
+      48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,   124,
+      -1,    -1,    -1,   128,    -1,    -1,    -1,    65,    -1,    -1,
+      68,    69,    70,    71,    72,    73,    -1,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
+      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
+      98,    99,   100,   101,   102,   103,   104,    -1,    -1,    -1,
+     175,    -1,    -1,    -1,   179,    -1,   181,   182,    -1,    -1,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   139,   207,    -1,    -1,    -1,    -1,    -1,    -1,   147,
+     148,   149,   150,   151,    -1,   153,   154,   155,   156,   157,
+     158,   159,   160,   161,   162,   163,    -1,    -1,   166,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,
+      -1,   189,   190,    -1,    -1,    -1,    -1,    -1,     5,     6,
+     198,    -1,   200,   201,   202,   203,    13,   205,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
+      -1,    48,    49,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
       -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
       77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
       87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
-      -1,    98,    99,   100,   101,   102,   103,   104,   105,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     147,   148,   149,   150,   151,    -1,   153,    -1,   155,   156,
-     157,   158,   159,   160,   161,   162,   163,    -1,   165,   166,
+     147,   148,   149,   150,   151,    -1,   153,   154,   155,   156,
+     157,   158,   159,   160,   161,   162,   163,    -1,    -1,   166,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,
-      -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   198,    -1,   200,    -1,   202,   203,   204,   205,   206,
-       1,    -1,    -1,    -1,     5,     6,     7,    -1,     9,    10,
-      11,    -1,    13,    -1,    15,    16,    17,    18,    19,    -1,
-      -1,    -1,    -1,    -1,    25,    26,    27,    28,    29,    -1,
-      31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,
-      -1,    42,    -1,    44,    45,    -1,    -1,    48,    -1,    50,
-      51,    52,    -1,    54,    55,    -1,    -1,    58,    59,    -1,
-      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
-      71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
-      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
-      91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
-     101,   102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
+      -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,     5,
+       6,   198,    -1,   200,    -1,   202,   203,    13,   205,    15,
+      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
+      -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
+      -1,    -1,    48,    49,    -1,    51,    -1,    -1,    -1,    55,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
+      -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
+      76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
+      86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
+      -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
-     151,    -1,   153,    -1,   155,   156,   157,   158,   159,   160,
-     161,   162,   163,    -1,   165,   166,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,   190,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   198,    -1,   200,
-      -1,   202,   203,   204,   205,   206,     1,    -1,    -1,    -1,
-       5,     6,     7,    -1,     9,    10,    11,    -1,    13,    -1,
+      -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   147,   148,   149,   150,   151,    -1,   153,    -1,   155,
+     156,   157,   158,   159,   160,   161,   162,   163,    -1,    -1,
+     166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,
+     186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,
+       5,     6,   198,    -1,   200,    -1,   202,   203,    -1,   205,
       15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
-      25,    26,    27,    28,    29,    -1,    31,    -1,    -1,    -1,
-      -1,    -1,    -1,    38,    39,    40,    -1,    42,    -1,    44,
-      45,    -1,    -1,    48,    -1,    50,    51,    52,    -1,    54,
-      55,    -1,    -1,    58,    59,    -1,    -1,    -1,    -1,    -1,
-      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
+      25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
+      45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,
+      55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      65,    -1,    -1,    68,    69,    70,    71,    72,    73,    -1,
       75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
       85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
       95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
-     105,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
+      -1,    -1,   147,   148,   149,   150,   151,    -1,   153,   154,
      155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
-     165,   166,    -1,    33,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
       -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
-      60,    61,    -1,   198,    -1,   200,    -1,   202,   203,   204,
-     205,   206,     5,     6,    -1,    -1,    -1,    -1,    -1,    -1,
-      13,    -1,    15,    16,    17,    18,    19,    -1,    -1,    -1,
+      -1,     5,     6,   198,    -1,   200,    -1,   202,   203,    -1,
+     205,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
+      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
+      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
+      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
+      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
+      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
+     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
+     154,   155,   156,   157,   158,   159,   160,   161,   162,   163,
+      -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
+     184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
+      -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,   203,
+      -1,   205,    15,    16,    17,    18,    19,    -1,    -1,    -1,
       -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
-      -1,    -1,    45,    -1,    -1,    48,    49,    -1,    51,    -1,
-      -1,    -1,    55,    -1,   124,    -1,    -1,    -1,   128,    -1,
+      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
+      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
       73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
       83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
       93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
-     103,   104,    -1,    -1,    -1,   175,    -1,    -1,    -1,   179,
-      -1,   181,   182,    -1,    -1,   118,   119,    -1,    -1,    -1,
+     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   139,   207,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
-     153,   154,   155,   156,   157,   158,   159,   160,   161,   162,
+     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
      163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
      183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
-      -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,
-     203,    13,   205,    15,    16,    17,    18,    19,    -1,    -1,
-      -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    33,    31,
+      -1,    -1,    -1,     5,     6,   198,    -1,   200,   201,   202,
+     203,    -1,   205,    15,    16,    17,    18,    19,    -1,    -1,
+      -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
-      -1,    -1,    -1,    45,    -1,    -1,    48,    49,    -1,    51,
-      -1,    -1,    -1,    55,    -1,    60,    61,    -1,    -1,    -1,
+      -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,
+      -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
       72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
       82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
       -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
      102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,   124,
-      -1,    -1,    -1,   128,    -1,   127,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
       -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
      162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,
-     175,    -1,    -1,    -1,   179,    -1,   181,   182,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
      182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
-      -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,
-     202,   203,   207,   205,    15,    16,    17,    18,    19,    -1,
-      -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    33,
+      -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,   201,
+     202,   203,    -1,   205,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,
       31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,
       -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
-      51,    -1,    -1,    -1,    55,    -1,    60,    61,    -1,    -1,
-      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    70,
+      51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
       71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
       81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
       91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
      101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
-     124,    -1,    -1,    -1,   128,    -1,   127,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
-     151,    -1,   153,   154,   155,   156,   157,   158,   159,   160,
+     151,    -1,   153,    -1,   155,   156,   157,   158,   159,   160,
      161,   162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,
-      -1,   175,    -1,    -1,    -1,   179,    -1,   181,   182,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,   190,
       -1,    -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,
-      -1,   202,   203,   207,   205,    15,    16,    17,    18,    19,
+     201,   202,   203,    -1,   205,    15,    16,    17,    18,    19,
       -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
-      33,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
       -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
-      -1,    51,    -1,    -1,    -1,    55,    -1,    60,    61,    -1,
+      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
       -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
       80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
       90,    91,    -1,    93,    94,    95,    -1,    -1,    98,    99,
      100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,
-      -1,   124,    -1,    -1,    -1,   128,    -1,   127,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,
-     150,   151,    -1,   153,   154,   155,   156,   157,   158,   159,
+     150,   151,    -1,   153,    -1,   155,   156,   157,   158,   159,
      160,   161,   162,   163,    -1,    -1,   166,    -1,    -1,    -1,
-      -1,    -1,   175,    -1,    -1,    -1,   179,    -1,   181,   182,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,
      190,    -1,    -1,    -1,    -1,    -1,     5,     6,   198,    -1,
-     200,    -1,   202,   203,   207,   205,    15,    16,    17,    18,
+     200,   201,   202,   203,    -1,   205,    15,    16,    17,    18,
       19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
       -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
@@ -3205,7 +3280,7 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,
       -1,   189,   190,    -1,    -1,    -1,    -1,    -1,     5,     6,
-     198,    -1,   200,   201,   202,   203,    -1,   205,    15,    16,
+     198,    -1,   200,    -1,   202,   203,    -1,   205,    15,    16,
       17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
       27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
@@ -3217,14 +3292,14 @@ static const yytype_int16 yycheck[] =
       -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
      147,   148,   149,   150,   151,    -1,   153,    -1,   155,   156,
      157,   158,   159,   160,   161,   162,   163,    -1,    -1,   166,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,
       -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,     5,
-       6,   198,    -1,   200,   201,   202,   203,    -1,   205,    15,
+       6,   198,   199,   200,    -1,   202,   203,    -1,   205,    15,
       16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
       -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
@@ -3236,14 +3311,14 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   147,   148,   149,   150,   151,    -1,   153,    -1,   155,
      156,   157,   158,   159,   160,   161,   162,   163,    -1,    -1,
      166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,
      186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,
-       5,     6,   198,    -1,   200,   201,   202,   203,    -1,   205,
+       5,     6,   198,   199,   200,    -1,   202,   203,    -1,   205,
       15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
       25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
@@ -3262,7 +3337,7 @@ static const yytype_int16 yycheck[] =
       -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
       -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
-      -1,     5,     6,   198,    -1,   200,   201,   202,   203,    -1,
+      -1,     5,     6,   198,    -1,   200,    -1,   202,   203,    13,
      205,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
       -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
@@ -3274,7 +3349,7 @@ static const yytype_int16 yycheck[] =
       94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
      104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
       -1,   155,   156,   157,   158,   159,   160,   161,   162,   163,
@@ -3293,14 +3368,14 @@ static const yytype_int16 yycheck[] =
       93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
      103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
      153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
      163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
      183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
-      -1,    -1,    -1,     5,     6,   198,   199,   200,    -1,   202,
+      -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,
      203,    -1,   205,    15,    16,    17,    18,    19,    -1,    -1,
       -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
@@ -3312,26 +3387,26 @@ static const yytype_int16 yycheck[] =
       -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
      102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
       -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
      162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
      182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
-      -1,    -1,    -1,    -1,     5,     6,   198,   199,   200,    -1,
+      -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,
      202,   203,    -1,   205,    15,    16,    17,    18,    19,    -1,
       -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,    -1,
       31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,
       -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,
       51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
+      61,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,
       71,    72,    73,    -1,    75,    76,    77,    78,    79,    80,
       81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
       91,    -1,    93,    94,    95,    -1,    -1,    98,    99,   100,
      101,   102,   103,   104,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,
      151,    -1,   153,    -1,   155,   156,   157,   158,   159,   160,
@@ -3339,11 +3414,11 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   182,   183,   184,    -1,   186,    -1,    -1,   189,   190,
       -1,    -1,    -1,    -1,    -1,     5,     6,   198,    -1,   200,
-      -1,   202,   203,    13,   205,    15,    16,    17,    18,    19,
+      -1,   202,   203,    -1,   205,    15,    16,    17,    18,    19,
       -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,    -1,
       -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,
       -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,    -1,
-      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,    -1,
+      -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    58,    -1,
       -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,    69,
       -1,    71,    72,    73,    -1,    75,    76,    77,    78,    79,
       80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
@@ -3388,7 +3463,7 @@ static const yytype_int16 yycheck[] =
       88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
       98,    99,   100,   101,   102,   103,   104,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   127,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,
      148,   149,   150,   151,    -1,   153,    -1,   155,   156,   157,
@@ -3396,12 +3471,12 @@ static const yytype_int16 yycheck[] =
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,
       -1,   189,   190,    -1,    -1,    -1,    -1,    -1,     5,     6,
-     198,    -1,   200,    -1,   202,   203,    -1,   205,    15,    16,
+     198,    -1,   200,   201,   202,   203,    -1,   205,    15,    16,
       17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
       27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
       -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
-      -1,    -1,    -1,    -1,    61,    -1,    -1,    -1,    65,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
       -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
       77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
       87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
@@ -3417,14 +3492,14 @@ static const yytype_int16 yycheck[] =
       -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,     5,
        6,   198,    -1,   200,    -1,   202,   203,    -1,   205,    15,
       16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,
-      -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      26,    27,    28,    -1,    -1,    31,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,
-      -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,
-      -1,    -1,    58,    -1,    -1,    -1,    -1,    -1,    -1,    65,
+      -1,    -1,    48,    -1,    -1,    51,    52,    -1,    -1,    55,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,
       -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,    75,
       76,    77,    78,    79,    80,    81,    82,    83,    84,    85,
       86,    87,    88,    89,    90,    91,    -1,    93,    94,    95,
-      -1,    -1,    98,    99,   100,   101,   102,   103,   104,    -1,
+      -1,    -1,    98,    99,   100,   101,   102,   103,   104,   105,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
@@ -3433,156 +3508,89 @@ static const yytype_int16 yycheck[] =
      156,   157,   158,   159,   160,   161,   162,   163,    -1,    -1,
      166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,
-     186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,    -1,
-       5,     6,   198,    -1,   200,    -1,   202,   203,    -1,   205,
-      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
-      25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
-      45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,
-      55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
-      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
-      95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
+     186,    -1,    -1,   189,   190,    -1,    -1,    -1,     5,     6,
+      -1,    -1,   198,    -1,   200,    -1,   202,   203,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    25,    -1,
+      27,    -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,
+      -1,    48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,
+      -1,    68,    69,    -1,    71,    72,    73,    -1,    75,    76,
+      77,    78,    79,    80,    81,    82,    83,    84,    85,    86,
+      87,    88,    89,    90,    91,    -1,    93,    94,    95,    -1,
+      -1,    98,    99,   100,   101,   102,   103,   104,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
-     155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
-      -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,   184,
-      -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,    -1,
-      -1,     5,     6,   198,    -1,   200,    -1,   202,   203,    -1,
-     205,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
-      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
-      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
-      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
-      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
-      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
-     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
+      -1,   118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     127,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     147,   148,   149,   150,   151,    -1,   153,    -1,   155,   156,
+     157,   158,   159,   160,   161,   162,   163,    -1,    -1,   166,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
-      -1,   155,   156,   157,   158,   159,   160,   161,   162,   163,
-      -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
-     184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
-      -1,    -1,     5,     6,   198,    -1,   200,   201,   202,   203,
-      -1,   205,    15,    16,    17,    18,    19,    -1,    -1,    -1,
-      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
-      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
-      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
-      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
-      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
-      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
-     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,
+      -1,    -1,   189,   190,    -1,    -1,    -1,     5,     6,    -1,
+      -1,   198,    -1,   200,    -1,   202,   203,    15,    16,    17,
+      18,    19,    -1,    -1,    22,    -1,    -1,    25,    -1,    27,
+      -1,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,
+      48,    -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,
+      68,    69,    -1,    71,    72,    73,    -1,    75,    76,    77,
+      78,    79,    80,    81,    82,    83,    84,    85,    86,    87,
+      88,    89,    90,    91,    -1,    93,    94,    95,    -1,    -1,
+      98,    99,   100,   101,   102,   103,   104,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
-     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
-     163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
-     183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
-      -1,    -1,    -1,     5,     6,   198,    -1,   200,    -1,   202,
-     203,    -1,   205,    15,    16,    17,    18,    19,    -1,    -1,
-      -1,    -1,    -1,    25,    26,    27,    28,    -1,    -1,    31,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,
-      -1,    -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,
-      52,    -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,
-      72,    73,    -1,    75,    76,    77,    78,    79,    80,    81,
-      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
-      -1,    93,    94,    95,    -1,    -1,    98,    99,   100,   101,
-     102,   103,   104,   105,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,
+     118,   119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,
-      -1,   153,    -1,   155,   156,   157,   158,   159,   160,   161,
-     162,   163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,
+      -1,   139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,
+     148,   149,   150,   151,    -1,   153,    -1,   155,   156,   157,
+     158,   159,   160,   161,   162,   163,    -1,    -1,   166,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     182,   183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,
-      -1,    -1,     5,     6,    -1,    -1,   198,    -1,   200,    -1,
-     202,   203,    15,    16,    17,    18,    19,    -1,    -1,    -1,
-      -1,    -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,
-      -1,    -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,
-      -1,    -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,
-      73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
-      83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
-      93,    94,    95,    -1,    -1,    98,    99,   100,   101,   102,
-     103,   104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   127,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,
-     153,    -1,   155,   156,   157,   158,   159,   160,   161,   162,
-     163,    -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,
-     183,   184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,
-      -1,     5,     6,    -1,    -1,   198,    -1,   200,    -1,   202,
-     203,    15,    16,    17,    18,    19,    -1,    -1,    22,    -1,
-      -1,    25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,
-      -1,    45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,
-      -1,    55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    65,    -1,    -1,    68,    69,    -1,    71,    72,    73,
-      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
-      94,    95,    -1,    -1,    98,    99,   100,   101,   102,   103,
-     104,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   147,   148,   149,   150,   151,    -1,   153,
-      -1,   155,   156,   157,   158,   159,   160,   161,   162,   163,
-      -1,    -1,   166,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   182,   183,
-     184,    -1,   186,    -1,    -1,   189,   190,    -1,    -1,    -1,
-       5,     6,    -1,    -1,   198,    -1,   200,    -1,   202,   203,
-      15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
-      25,    -1,    27,    -1,    -1,    -1,    31,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    39,    -1,    -1,    -1,    -1,    -1,
-      45,    -1,    -1,    48,    -1,    -1,    51,    -1,    -1,    -1,
-      55,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      65,    -1,    -1,    68,    69,    -1,    71,    72,    73,    -1,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
-      85,    86,    87,    88,    89,    90,    91,    -1,    93,    94,
-      95,    -1,    -1,    98,    99,   100,   101,   102,   103,   104,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   118,   119,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   139,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   147,   148,   149,   150,   151,    -1,   153,    -1,
-     155,   156,   157,   158,   159,   160,   161,   162,   163,    -1,
-      19,   166,    -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,
-      -1,    -1,    31,    -1,    -1,    -1,    -1,   182,   183,   184,
-      -1,   186,    41,    -1,   189,   190,    -1,    -1,    -1,    -1,
-      49,    -1,    -1,   198,    -1,   200,    -1,   202,   203,    -1,
-      -1,    -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,
-      -1,    -1,    71,    72,    73,    74,    75,    76,    77,    78,
+      -1,    -1,    -1,    -1,   182,   183,   184,    -1,   186,    -1,
+      -1,   189,   190,    -1,    -1,    -1,     5,     6,    -1,    -1,
+     198,    -1,   200,    -1,   202,   203,    15,    16,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    25,    -1,    27,    -1,
+      -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      39,    -1,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
+      -1,    -1,    51,    -1,    -1,    -1,    55,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    65,    -1,    -1,    68,
+      69,    -1,    71,    72,    73,    -1,    75,    76,    77,    78,
       79,    80,    81,    82,    83,    84,    85,    86,    87,    88,
-      89,    90,    91,    92,    93,    94,    95,    96,    97,    98,
-      99,   100,   101,   102,   103,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    19,    -1,    -1,    -1,    -1,
+      89,    90,    91,    -1,    93,    94,    95,    -1,    -1,    98,
+      99,   100,   101,   102,   103,   104,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   118,
+     119,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     139,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   147,   148,
+     149,   150,   151,    -1,   153,    -1,   155,   156,   157,   158,
+     159,   160,   161,   162,   163,    -1,    19,   166,    -1,    -1,
+      -1,    -1,    25,    -1,    -1,    -1,    -1,    -1,    31,    -1,
+      -1,    -1,    -1,   182,   183,   184,    -1,   186,    41,    -1,
+     189,   190,    -1,    -1,    -1,    -1,    49,    -1,    -1,   198,
+      -1,   200,    -1,   202,   203,    -1,    -1,    -1,    -1,    -1,
+      -1,    64,    -1,    -1,    -1,    -1,    -1,    -1,    71,    72,
+      73,    74,    75,    76,    77,    78,    79,    80,    81,    82,
+      83,    84,    85,    86,    87,    88,    89,    90,    91,    92,
+      93,    94,    95,    96,    97,    98,    99,   100,   101,   102,
+     103,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    19,
+      -1,    -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    41,    -1,    -1,    -1,    -1,   139,    -1,    -1,    49,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   152,
+      -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    -1,    -1,
+     163,    71,    72,    73,    74,    75,    76,    77,    78,    79,
+      80,    81,    82,    83,    84,    85,    86,    87,    88,    89,
+      90,    91,    92,    93,    94,    95,    96,    97,    98,    99,
+     100,   101,   102,   103,    -1,    -1,    -1,    -1,    -1,   202,
+      -1,    -1,    -1,    -1,   207,    19,    -1,    -1,    -1,    -1,
       -1,    25,    -1,    -1,    -1,    -1,    -1,    31,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    41,    -1,    -1,
-     139,    -1,    -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,
-      64,    -1,    -1,    -1,   163,    -1,   165,    71,    72,    73,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    41,    -1,   139,
+      -1,    -1,    -1,    -1,    -1,    49,    -1,    -1,    -1,    -1,
+      -1,    -1,   152,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      64,    -1,    -1,   163,    -1,   165,    -1,    71,    72,    73,
       74,    75,    76,    77,    78,    79,    80,    81,    82,    83,
       84,    85,    86,    87,    88,    89,    90,    91,    92,    93,
       94,    95,    96,    97,    98,    99,   100,   101,   102,   103,
-      -1,    -1,    -1,   202,    -1,   204,    -1,    -1,    19,    -1,
+      -1,    -1,   202,    -1,   204,    -1,    -1,    -1,    19,    -1,
       -1,    -1,    -1,    -1,    25,    -1,    -1,    -1,    -1,    -1,
       31,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       41,    -1,    -1,    -1,    -1,   139,    -1,    -1,    49,    -1,
@@ -3603,58 +3611,57 @@ static const yytype_int16 yycheck[] =
       -1,    21,    22,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   202,   108,   109,   110,   111,   112,   113,   114,   115,
      116,   117,   118,   119,   120,   121,   122,   123,   124,   125,
-      -1,    -1,   128,   129,   130,    -1,    -1,   133,   134,   135,
+      -1,    -1,   128,   129,   130,    21,    22,   133,   134,   135,
      136,   137,    -1,    -1,   140,   141,   142,   143,   144,   145,
      146,    -1,   154,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   163,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    21,    22,   175,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   175,
       -1,   177,   178,   179,   180,   181,   182,   183,   184,   185,
      186,    -1,    -1,   189,   190,    -1,   116,   117,   118,   119,
      120,   197,   198,   123,   124,   125,   126,    -1,   128,   129,
      130,   131,   132,    -1,   134,   135,    -1,    -1,   138,    -1,
-     140,   141,   142,    -1,    -1,    -1,   146,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    21,    22,   175,   176,   177,   178,   179,
+     140,   141,   142,    21,    22,    -1,   146,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,   132,    -1,   134,   135,
+      21,    22,    -1,    -1,   140,   175,   142,   177,   178,   179,
      180,   181,   182,   183,   184,   185,   186,    -1,    -1,    -1,
-      -1,    -1,   116,   117,   118,   119,   120,   197,   198,   123,
-     124,   125,   126,    -1,   128,   129,   130,   131,   132,    -1,
-     134,   135,    21,    22,   138,    -1,   140,   141,   142,    -1,
-      -1,    -1,   146,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,   198,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    21,
-      22,   175,    -1,   177,   178,   179,   180,   181,   182,   183,
-     184,   185,   186,    -1,    -1,    -1,    -1,    -1,   116,   117,
-     118,   119,   120,   197,   198,   123,   124,   125,   126,    -1,
+      -1,   177,   178,   179,   180,   181,   182,   183,   184,   185,
+     186,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   197,   198,    -1,    -1,    -1,    -1,    -1,   116,   117,
+     118,   119,   120,    -1,    -1,   123,   124,   125,   126,    -1,
      128,   129,   130,   131,   132,    -1,   134,   135,    21,    22,
-     138,    -1,   140,   141,   142,    -1,    -1,    -1,   146,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   116,   117,   118,
-     119,   120,    -1,    -1,   123,   124,   125,   126,    -1,   128,
-     129,   130,   131,   132,    -1,   134,   135,   175,    -1,   177,
+      -1,    -1,   140,    -1,    -1,   116,   117,   118,   119,   120,
+      -1,    -1,   123,   124,   125,   126,    -1,   128,   129,   130,
+     131,   132,    -1,   134,   135,    21,    22,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   177,
      178,   179,   180,   181,   182,   183,   184,   185,   186,    -1,
-      -1,    -1,    -1,    -1,   116,   117,   118,   119,   120,   197,
-     198,   123,   124,   125,   126,    -1,   128,   129,   130,   131,
-     132,    -1,   134,   135,    -1,    -1,    -1,    -1,    -1,   178,
-     179,   180,   181,   182,   183,   184,   185,   186,    -1,    -1,
-      -1,    -1,    -1,   116,   117,   118,   119,   120,   197,   198,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,
+     198,    -1,    -1,    -1,    -1,    -1,   177,   178,   179,   180,
+     181,   182,   183,   184,   185,   186,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   197,   198,    -1,    -1,
+      -1,    -1,    -1,   116,   117,   118,   119,   120,    -1,    -1,
      123,   124,   125,   126,    -1,   128,   129,   130,   131,   132,
-      -1,   134,   135,    -1,    -1,    -1,    -1,   179,   180,   181,
-     182,   183,   184,   185,   186,    19,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   197,   198,    -1,    -1,    -1,
+      -1,   134,   135,    21,    22,    -1,    -1,    -1,    -1,    -1,
+     116,   117,   118,   119,   120,    -1,    -1,   123,   124,   125,
+     126,    -1,   128,   129,   130,   131,   132,    -1,   134,   135,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    19,   180,   181,   182,
+      -1,    -1,    -1,    -1,    -1,   178,   179,   180,   181,   182,
      183,   184,   185,   186,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   197,   198,    -1,    71,    72,    73,
-      -1,    75,    76,    77,    78,    79,    80,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,    -1,    93,
-      94,    95,    -1,    -1,    98,    99,   100,   101,    71,    72,
+      -1,    -1,    -1,    -1,   197,   198,    19,    -1,    -1,    -1,
+      -1,    -1,    -1,   179,   180,   181,   182,   183,   184,   185,
+     186,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   197,   198,    -1,    -1,    -1,    -1,    -1,   116,   117,
+     118,   119,   120,    -1,    -1,   123,   124,   125,   126,    -1,
+     128,   129,   130,   131,   132,    -1,   134,   135,    71,    72,
       73,    -1,    75,    76,    77,    78,    79,    80,    81,    82,
       83,    84,    85,    86,    87,    88,    89,    90,    91,    -1,
       93,    94,    95,    -1,    -1,    98,    99,   100,   101,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     154,    35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   163,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   180,   181,   182,   183,   184,   185,   186,    -1,
+      -1,    35,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   197,
+     198,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,   154,    -1,    -1,    -1,    -1,    -1,    71,    -1,    73,
      163,    75,    76,    77,    78,    79,    -1,    81,    82,    83,
@@ -3695,174 +3702,174 @@ static const yytype_int16 yystos[] =
 {
        0,   209,     0,     7,    30,    32,    34,    40,    50,    56,
       80,   102,   103,   165,   186,   198,   204,   211,   212,   216,
-     225,   227,   228,   232,   281,   287,   318,   400,   408,   415,
-     425,   475,   480,   485,    19,    20,   163,   271,   272,   273,
-     156,   233,   234,   146,   163,   186,   197,   229,   230,    57,
-      63,   405,   406,   163,   202,   214,   486,   476,   481,   139,
-     163,   306,    34,    63,   107,   132,   190,   200,   276,   277,
-     278,   279,   306,   211,   211,   211,     8,    36,   426,    62,
-     396,   174,   173,   176,   173,   185,   185,   229,   185,    22,
-      57,   185,   197,   231,   163,   211,   396,   405,   405,   405,
-     163,   139,   226,   278,   278,   278,   200,   140,   141,   142,
-     173,   199,   107,   286,   416,     5,     6,   422,    57,    63,
-     397,    15,    16,   156,   161,   163,   166,   200,   203,   218,
-     272,   156,   234,   229,   229,   229,   163,   163,   163,   407,
-      57,    63,   213,   163,   163,   163,   163,   167,   224,   201,
-     273,   278,   278,   278,   278,   165,   238,   239,    57,    63,
-     288,   290,    57,    63,   409,   107,   107,    57,    63,   423,
-     205,   401,   167,   168,   169,   217,    15,    16,   156,   161,
-     163,   218,   269,   270,   203,   231,   174,   190,   215,   176,
-     436,   239,   239,   167,   201,   165,   291,   163,   410,   427,
-     398,   203,   274,   366,   167,   168,   169,   173,   201,   163,
-      19,    25,    31,    41,    49,    64,    71,    72,    73,    74,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    84,
-      85,    86,    87,    88,    89,    90,    91,    92,    93,    94,
-      95,    96,    97,    98,    99,   100,   101,   102,   103,   152,
-     202,   306,   430,   432,   433,   437,   443,   445,   474,    66,
-      79,    94,    99,   101,   164,   413,   414,   477,   482,    35,
-      71,    73,    75,    76,    77,    78,    79,    81,    82,    83,
-      84,    85,    86,    87,    88,    89,    90,    91,    93,    94,
-      95,    98,    99,   100,   101,   118,   119,   163,   284,   285,
-     289,   176,   411,   106,   420,   421,   206,   211,   399,   272,
-     203,   163,   392,   395,   269,   180,   180,   180,   200,   180,
-     180,   200,   436,   180,   180,   180,   180,   180,   200,   306,
-     180,   200,    33,    60,    61,   124,   128,   175,   179,   182,
-     207,   198,   442,   177,   164,   487,   205,   205,    21,    22,
-      38,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,   119,   120,   121,   122,   123,   124,   125,   128,
-     129,   130,   133,   134,   135,   136,   137,   140,   141,   142,
-     143,   144,   145,   146,   175,   177,   178,   179,   180,   181,
-     182,   183,   184,   185,   186,   189,   190,   197,   198,    35,
-      35,   200,   282,   239,    75,    79,    93,    94,    98,    99,
-     100,   101,   431,   414,   163,   239,   366,   239,   272,   173,
-     176,   179,   390,   446,   452,   454,     5,     6,    15,    16,
-      17,    18,    19,    25,    27,    31,    39,    45,    48,    51,
-      55,    65,    68,    69,    80,   102,   103,   104,   118,   119,
-     147,   148,   149,   150,   151,   153,   155,   156,   157,   158,
-     159,   160,   161,   162,   166,   182,   183,   184,   189,   190,
-     198,   200,   202,   203,   205,   223,   225,   298,   306,   311,
-     323,   330,   333,   336,   340,   342,   344,   345,   347,   352,
-     355,   356,   357,   364,   365,   430,   491,   499,   510,   513,
-     526,   527,   530,   531,   456,   450,   163,   180,   458,   460,
-     462,   464,   466,   468,   470,   472,   356,   180,   200,   444,
-     448,   127,   303,   334,   356,    33,   179,    33,   179,   198,
-     207,   199,   356,   198,   207,   443,   205,   478,   483,   163,
-     285,   163,   285,   163,   199,    22,   163,   199,   151,   201,
-     366,   376,   377,   378,   126,   176,   283,   138,   295,   296,
-     335,   205,   176,   419,   428,   148,   163,   391,   394,   239,
-     163,   443,   127,   133,   174,   389,   474,   474,   441,   474,
-     180,   180,   180,   306,   308,   432,   490,   499,   510,   513,
-     526,   527,   530,   531,   306,   180,     5,   102,   103,   180,
-     200,   180,   200,   200,   180,   180,   200,   180,   200,   180,
-     200,   180,   180,   200,    19,   180,   180,   357,   357,   200,
-     200,   200,   200,   200,   200,   222,   357,   357,   357,   357,
-     357,    13,    49,   303,   154,   163,   334,   492,   494,   203,
-     525,   200,   198,   280,   203,   205,   336,   341,   341,   341,
-     201,    21,    22,   116,   117,   118,   119,   120,   123,   124,
-     125,   126,   128,   129,   130,   131,   132,   134,   135,   138,
-     140,   141,   142,   146,   175,   177,   178,   179,   180,   181,
-     182,   183,   184,   185,   186,   197,   198,   200,   474,   474,
-     201,   181,   438,   474,   282,   474,   282,   474,   282,   163,
-     379,   380,   474,   163,   382,   383,   201,   449,   334,   305,
-     474,   356,   201,   173,   529,   199,   199,   199,   356,   488,
-     379,   381,   382,   384,   163,   285,   108,   109,   110,   111,
-     112,   113,   114,   115,   133,   143,   144,   145,   108,   109,
-     110,   111,   112,   113,   114,   115,   127,   133,   143,   144,
-     145,   174,   200,     7,    50,   317,   204,   173,   204,   201,
-     474,   474,   127,   357,   205,   417,   306,   204,   205,   424,
-     200,    43,   173,   176,   390,   211,   389,   356,   181,   181,
-     181,   164,   173,   210,   211,   440,   500,   502,   309,   200,
-     180,   200,   331,   180,   180,   180,   520,   334,   443,   356,
-     524,   356,   324,   326,   356,   328,   356,   522,   334,   508,
-     511,   334,   180,   504,   443,   356,   356,   356,   356,   356,
-     356,   169,   170,   217,   200,    13,   199,   200,   127,   133,
-     174,   385,   529,   173,   529,   201,   148,   153,   180,   306,
-     346,   239,    70,   198,   201,   334,   494,   279,     4,   339,
-     203,   302,   280,    19,   154,   163,   430,    19,   154,   163,
-     430,   357,   357,   357,   357,   357,   357,   163,   357,   154,
-     163,   356,   357,   357,   430,   357,   357,   357,   526,   531,
-     357,   357,   357,   357,    22,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   129,   130,   154,   163,
-     197,   198,   353,   430,   356,   201,   334,   181,   181,   163,
-     434,   181,   283,   181,   283,   181,   283,   176,   181,   440,
-     176,   181,   440,   305,   529,   181,   440,   127,   356,   199,
-     163,   435,   211,   246,   247,   246,   247,   356,   148,   163,
-     386,   387,   429,   378,   378,   378,   357,   302,   163,   402,
-     404,   372,   356,   163,   163,   443,   389,   356,   211,   447,
-     453,   455,   474,   443,   443,   474,    70,   334,   494,   498,
-     163,   356,   474,   514,   516,   518,   443,   529,   181,   440,
-     173,   529,   201,   443,   443,   201,   443,   201,   443,   529,
-     443,   380,   529,   506,   383,   181,   201,   201,   201,   201,
-     201,   201,   356,   148,   163,   200,   260,   200,   356,   356,
-     356,   201,   154,   163,   200,   200,   348,   350,    13,   304,
-     524,   163,   201,   494,   492,   173,   201,   201,   199,   200,
-     282,     1,    26,    28,    29,    38,    40,    44,    52,    54,
-      58,    59,    65,   105,   205,   206,   211,   235,   236,   245,
-     256,   257,   259,   261,   262,   263,   264,   265,   266,   267,
-     268,   299,   307,   312,   313,   314,   315,   316,   318,   322,
-     343,   357,   339,   180,   200,   180,   200,   200,   200,   199,
-      19,   154,   163,   430,   176,   154,   163,   356,   200,   200,
-     154,   163,   356,     1,   200,   199,   173,   201,   457,   451,
-     173,   181,   204,   459,   181,   463,   181,   467,   181,   474,
-     471,   379,   474,   473,   382,   181,   201,   444,   474,   356,
-     174,   210,   403,   412,   211,   379,   479,   382,   484,   201,
-     200,    43,   173,   176,   179,   385,   297,   174,   403,   412,
-      40,   165,   206,   281,   373,   201,    43,   211,   389,   356,
-     211,   181,   181,   181,   494,   201,   201,   201,   181,   440,
-     201,   181,   443,   380,   383,   181,   201,   200,   443,   356,
-     201,   181,   181,   181,   181,   201,   181,   181,   201,   443,
-     181,   339,   200,   176,   220,   200,    43,   163,   320,    20,
-     173,   260,   201,   200,   133,   385,   356,   356,   443,   282,
-     200,   206,   529,   201,   173,   199,   198,   127,   133,   163,
-     174,   179,   337,   338,   283,   127,   356,   295,    61,   356,
-     163,   163,   211,   156,    58,   356,   239,   127,   356,   300,
-     211,   211,    10,    10,    11,   243,    13,     9,    42,   211,
-     211,   211,   211,   211,   211,    66,   319,   211,   108,   109,
-     110,   111,   112,   113,   114,   115,   121,   122,   127,   133,
-     136,   137,   143,   144,   145,   174,   282,   358,   356,   360,
-     356,   201,   334,   356,   180,   200,   357,   200,   199,   356,
-     198,   201,   334,   200,   199,   354,   201,   334,   163,   439,
-     163,   461,   465,   469,   444,   356,   163,   210,   489,   206,
-     206,   356,   163,   163,   474,   356,   206,   356,   402,   418,
-     163,     8,   366,   371,   163,   356,   211,   501,   503,   310,
-     201,   200,   163,   332,   181,   181,   181,   521,   304,   181,
-     325,   327,   329,   523,   509,   512,   181,   505,   200,   239,
-     201,   334,   221,   171,   356,   163,   173,   201,   334,   163,
-     200,    20,   133,   385,   356,   356,   356,   201,   201,   181,
-     283,   260,   201,   492,   163,   163,   200,   163,   163,   173,
-     201,   239,   356,    14,   356,   174,   174,   176,   156,   295,
-     356,   302,   200,   200,   198,   274,   275,   275,   200,   200,
-     205,   321,   394,   357,   357,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   526,   531,   357,   357,   357,   357,
-     357,   357,   357,   283,   443,   201,   474,   201,   201,   201,
-     362,   356,   356,   201,   492,   201,   356,   201,   174,   206,
-     201,    43,   385,    37,   292,   206,   174,    57,    63,   369,
-      67,   370,   211,   211,   200,   200,   356,   181,   515,   517,
-     519,   200,   201,   200,   357,   357,   357,   200,    70,   498,
-     200,   507,   200,   201,   356,   295,   201,   219,   201,   163,
-     201,    43,   320,   334,   356,   356,   201,   349,   181,    20,
-     199,   163,   337,   335,   295,   474,   356,   301,   356,   356,
-     273,   200,   200,   356,   320,   393,   239,   181,   181,   474,
-     201,   201,   199,   201,   356,   163,   356,   293,   474,    47,
-     370,    46,   106,   367,   498,   498,   201,   200,   200,   200,
-     200,   303,   304,   334,   498,   200,   498,   201,   167,   204,
-     163,   201,   201,   133,   385,   346,   351,   334,   201,   201,
-     206,   201,   201,   199,   260,   356,   201,   201,   206,   211,
-     394,   335,   359,   361,   181,   201,   205,   211,    33,   368,
-     367,   369,   200,   492,   495,   496,   497,   497,   356,   498,
-     498,   492,   493,   201,   201,   529,   497,   498,   493,   356,
-     204,   356,   356,   346,   201,   292,    12,   244,   239,    20,
-     201,   239,   176,   390,   363,   302,   374,   368,   386,   387,
-     388,   492,   173,   529,   201,   201,   201,   497,   497,   201,
-     201,   201,   493,   201,   204,   528,   356,   204,   245,   312,
-     313,   314,   315,   357,   211,   258,   334,   239,   295,   443,
-     389,   294,   289,   375,   201,   200,   201,   201,   201,    53,
-     199,   528,   356,   205,   248,   251,   201,   295,   389,   356,
-     206,   211,   289,   492,   356,   199,   528,   249,    12,    23,
-      24,   237,   240,   245,   239,   356,   211,   239,   201,   206,
-     302,   239,   200,   211,   295,   211,   295,   250,   241,   356,
-     206,   205,   252,   255,   201,   292,   253,   245,   239,   302,
-     211,   242,   254,   252,   206,   240,   292
+     225,   227,   228,   233,   282,   288,   319,   401,   409,   416,
+     426,   476,   481,   486,    19,    20,   163,   272,   273,   274,
+     156,   234,   235,   175,   230,   231,    57,    63,   406,   407,
+     163,   202,   214,   487,   477,   482,   139,   163,   307,    34,
+      63,   107,   132,   190,   200,   277,   278,   279,   280,   307,
+     211,   211,   211,     8,    36,   427,    62,   397,   174,   173,
+     176,   173,   163,   146,   163,   186,   197,   229,   163,   211,
+     397,   406,   406,   406,   163,   139,   226,   279,   279,   279,
+     200,   140,   141,   142,   173,   199,   107,   287,   417,     5,
+       6,   423,    57,    63,   398,    15,    16,   156,   161,   163,
+     166,   200,   203,   218,   273,   156,   235,   185,   185,   229,
+     185,    22,    57,   185,   197,   232,   408,    57,    63,   213,
+     163,   163,   163,   163,   167,   224,   201,   274,   279,   279,
+     279,   279,   165,   239,   240,    57,    63,   289,   291,    57,
+      63,   410,   107,   107,    57,    63,   424,   205,   402,   167,
+     168,   169,   217,    15,    16,   156,   161,   163,   218,   270,
+     271,   203,   229,   229,   229,   163,   163,   163,   174,   190,
+     215,   176,   437,   240,   240,   167,   201,   165,   292,   163,
+     411,   428,   399,   203,   275,   367,   167,   168,   169,   173,
+     201,   163,   232,    19,    25,    31,    41,    49,    64,    71,
+      72,    73,    74,    75,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    87,    88,    89,    90,    91,
+      92,    93,    94,    95,    96,    97,    98,    99,   100,   101,
+     102,   103,   152,   202,   307,   431,   433,   434,   438,   444,
+     446,   475,    66,    79,    94,    99,   101,   164,   414,   415,
+     478,   483,    35,    71,    73,    75,    76,    77,    78,    79,
+      81,    82,    83,    84,    85,    86,    87,    88,    89,    90,
+      91,    93,    94,    95,    98,    99,   100,   101,   118,   119,
+     163,   285,   286,   290,   176,   412,   106,   421,   422,   206,
+     211,   400,   273,   203,   163,   393,   396,   270,   180,   180,
+     180,   200,   180,   180,   200,   437,   180,   180,   180,   180,
+     180,   200,   307,   180,   200,    33,    60,    61,   124,   128,
+     175,   179,   182,   207,   198,   443,   177,   164,   488,   205,
+     205,    21,    22,    38,   108,   109,   110,   111,   112,   113,
+     114,   115,   116,   117,   118,   119,   120,   121,   122,   123,
+     124,   125,   128,   129,   130,   133,   134,   135,   136,   137,
+     140,   141,   142,   143,   144,   145,   146,   175,   177,   178,
+     179,   180,   181,   182,   183,   184,   185,   186,   189,   190,
+     197,   198,    35,    35,   200,   283,   240,    75,    79,    93,
+      94,    98,    99,   100,   101,   432,   415,   163,   240,   367,
+     240,   273,   173,   176,   179,   391,   447,   453,   455,     5,
+       6,    15,    16,    17,    18,    19,    25,    27,    31,    39,
+      45,    48,    51,    55,    65,    68,    69,    80,   102,   103,
+     104,   118,   119,   147,   148,   149,   150,   151,   153,   155,
+     156,   157,   158,   159,   160,   161,   162,   166,   182,   183,
+     184,   189,   190,   198,   200,   202,   203,   205,   223,   225,
+     299,   307,   312,   324,   331,   334,   337,   341,   343,   345,
+     346,   348,   353,   356,   357,   358,   365,   366,   431,   492,
+     500,   511,   514,   527,   528,   531,   532,   457,   451,   163,
+     180,   459,   461,   463,   465,   467,   469,   471,   473,   357,
+     180,   200,   445,   449,   127,   304,   335,   357,    33,   179,
+      33,   179,   198,   207,   199,   357,   198,   207,   444,   205,
+     479,   484,   163,   286,   163,   286,   163,   199,    22,   163,
+     199,   151,   201,   367,   377,   378,   379,   126,   176,   284,
+     138,   296,   297,   336,   205,   176,   420,   429,   148,   163,
+     392,   395,   240,   163,   444,   127,   133,   174,   390,   475,
+     475,   442,   475,   180,   180,   180,   307,   309,   433,   491,
+     500,   511,   514,   527,   528,   531,   532,   307,   180,     5,
+     102,   103,   180,   200,   180,   200,   200,   180,   180,   200,
+     180,   200,   180,   200,   180,   180,   200,    19,   180,   180,
+     358,   358,   200,   200,   200,   200,   200,   200,   222,   358,
+     358,   358,   358,   358,    13,    49,   304,   154,   163,   335,
+     493,   495,   203,   526,   200,   198,   281,   203,   205,   337,
+     342,   342,   342,   201,    21,    22,   116,   117,   118,   119,
+     120,   123,   124,   125,   126,   128,   129,   130,   131,   132,
+     134,   135,   138,   140,   141,   142,   146,   175,   177,   178,
+     179,   180,   181,   182,   183,   184,   185,   186,   197,   198,
+     200,   475,   475,   201,   181,   439,   475,   283,   475,   283,
+     475,   283,   163,   380,   381,   475,   163,   383,   384,   201,
+     450,   335,   306,   475,   357,   201,   173,   530,   199,   199,
+     199,   357,   489,   380,   382,   383,   385,   163,   286,   108,
+     109,   110,   111,   112,   113,   114,   115,   133,   143,   144,
+     145,   108,   109,   110,   111,   112,   113,   114,   115,   127,
+     133,   143,   144,   145,   174,   200,     7,    50,   318,   204,
+     173,   204,   201,   475,   475,   127,   358,   205,   418,   307,
+     204,   205,   425,   200,    43,   173,   176,   391,   211,   390,
+     357,   181,   181,   181,   164,   173,   210,   211,   441,   501,
+     503,   310,   200,   180,   200,   332,   180,   180,   180,   521,
+     335,   444,   357,   525,   357,   325,   327,   357,   329,   357,
+     523,   335,   509,   512,   335,   180,   505,   444,   357,   357,
+     357,   357,   357,   357,   169,   170,   217,   200,    13,   199,
+     200,   127,   133,   174,   386,   530,   173,   530,   201,   148,
+     153,   180,   307,   347,   240,    70,   198,   201,   335,   495,
+     280,     4,   340,   203,   303,   281,    19,   154,   163,   431,
+      19,   154,   163,   431,   358,   358,   358,   358,   358,   358,
+     163,   358,   154,   163,   357,   358,   358,   431,   358,   358,
+     358,   527,   532,   358,   358,   358,   358,    22,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   129,
+     130,   154,   163,   197,   198,   354,   431,   357,   201,   335,
+     181,   181,   163,   435,   181,   284,   181,   284,   181,   284,
+     176,   181,   441,   176,   181,   441,   306,   530,   181,   441,
+     127,   357,   199,   163,   436,   211,   247,   248,   247,   248,
+     357,   148,   163,   387,   388,   430,   379,   379,   379,   358,
+     303,   163,   403,   405,   373,   357,   163,   163,   444,   390,
+     357,   211,   448,   454,   456,   475,   444,   444,   475,    70,
+     335,   495,   499,   163,   357,   475,   515,   517,   519,   444,
+     530,   181,   441,   173,   530,   201,   444,   444,   201,   444,
+     201,   444,   530,   444,   381,   530,   507,   384,   181,   201,
+     201,   201,   201,   201,   201,   357,   148,   163,   200,   261,
+     200,   357,   357,   357,   201,   154,   163,   200,   200,   349,
+     351,    13,   305,   525,   163,   201,   495,   493,   173,   201,
+     201,   199,   200,   283,     1,    26,    28,    29,    38,    40,
+      44,    52,    54,    58,    59,    65,   105,   205,   206,   211,
+     236,   237,   246,   257,   258,   260,   262,   263,   264,   265,
+     266,   267,   268,   269,   300,   308,   313,   314,   315,   316,
+     317,   319,   323,   344,   358,   340,   180,   200,   180,   200,
+     200,   200,   199,    19,   154,   163,   431,   176,   154,   163,
+     357,   200,   200,   154,   163,   357,     1,   200,   199,   173,
+     201,   458,   452,   173,   181,   204,   460,   181,   464,   181,
+     468,   181,   475,   472,   380,   475,   474,   383,   181,   201,
+     445,   475,   357,   174,   210,   404,   413,   211,   380,   480,
+     383,   485,   201,   200,    43,   173,   176,   179,   386,   298,
+     174,   404,   413,    40,   165,   206,   282,   374,   201,    43,
+     211,   390,   357,   211,   181,   181,   181,   495,   201,   201,
+     201,   181,   441,   201,   181,   444,   381,   384,   181,   201,
+     200,   444,   357,   201,   181,   181,   181,   181,   201,   181,
+     181,   201,   444,   181,   340,   200,   176,   220,   200,    43,
+     163,   321,    20,   173,   261,   201,   200,   133,   386,   357,
+     357,   444,   283,   200,   206,   530,   201,   173,   199,   198,
+     127,   133,   163,   174,   179,   338,   339,   284,   127,   357,
+     296,    61,   357,   163,   163,   211,   156,    58,   357,   240,
+     127,   357,   301,   211,   211,    10,    10,    11,   244,    13,
+       9,    42,   211,   211,   211,   211,   211,   211,    66,   320,
+     211,   108,   109,   110,   111,   112,   113,   114,   115,   121,
+     122,   127,   133,   136,   137,   143,   144,   145,   174,   283,
+     359,   357,   361,   357,   201,   335,   357,   180,   200,   358,
+     200,   199,   357,   198,   201,   335,   200,   199,   355,   201,
+     335,   163,   440,   163,   462,   466,   470,   445,   357,   163,
+     210,   490,   206,   206,   357,   163,   163,   475,   357,   206,
+     357,   403,   419,   163,     8,   367,   372,   163,   357,   211,
+     502,   504,   311,   201,   200,   163,   333,   181,   181,   181,
+     522,   305,   181,   326,   328,   330,   524,   510,   513,   181,
+     506,   200,   240,   201,   335,   221,   171,   357,   163,   173,
+     201,   335,   163,   200,    20,   133,   386,   357,   357,   357,
+     201,   201,   181,   284,   261,   201,   493,   163,   163,   200,
+     163,   163,   173,   201,   240,   357,    14,   357,   174,   174,
+     176,   156,   296,   357,   303,   200,   200,   198,   275,   276,
+     276,   200,   200,   205,   322,   395,   358,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   527,   532,   358,
+     358,   358,   358,   358,   358,   358,   284,   444,   201,   475,
+     201,   201,   201,   363,   357,   357,   201,   493,   201,   357,
+     201,   174,   206,   201,    43,   386,    37,   293,   206,   174,
+      57,    63,   370,    67,   371,   211,   211,   200,   200,   357,
+     181,   516,   518,   520,   200,   201,   200,   358,   358,   358,
+     200,    70,   499,   200,   508,   200,   201,   357,   296,   201,
+     219,   201,   163,   201,    43,   321,   335,   357,   357,   201,
+     350,   181,    20,   199,   163,   338,   336,   296,   475,   357,
+     302,   357,   357,   274,   200,   200,   357,   321,   394,   240,
+     181,   181,   475,   201,   201,   199,   201,   357,   163,   357,
+     294,   475,    47,   371,    46,   106,   368,   499,   499,   201,
+     200,   200,   200,   200,   304,   305,   335,   499,   200,   499,
+     201,   167,   204,   163,   201,   201,   133,   386,   347,   352,
+     335,   201,   201,   206,   201,   201,   199,   261,   357,   201,
+     201,   206,   211,   395,   336,   360,   362,   181,   201,   205,
+     211,    33,   369,   368,   370,   200,   493,   496,   497,   498,
+     498,   357,   499,   499,   493,   494,   201,   201,   530,   498,
+     499,   494,   357,   204,   357,   357,   347,   201,   293,    12,
+     245,   240,    20,   201,   240,   176,   391,   364,   303,   375,
+     369,   387,   388,   389,   493,   173,   530,   201,   201,   201,
+     498,   498,   201,   201,   201,   494,   201,   204,   529,   357,
+     204,   246,   313,   314,   315,   316,   358,   211,   259,   335,
+     240,   296,   444,   390,   295,   290,   376,   201,   200,   201,
+     201,   201,    53,   199,   529,   357,   205,   249,   252,   201,
+     296,   390,   357,   206,   211,   290,   493,   357,   199,   529,
+     250,    12,    23,    24,   238,   241,   246,   240,   357,   211,
+     240,   201,   206,   303,   240,   200,   211,   296,   211,   296,
+     251,   242,   357,   206,   205,   253,   256,   201,   293,   254,
+     246,   240,   303,   211,   243,   255,   253,   206,   241,   293
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
@@ -3874,96 +3881,96 @@ static const yytype_int16 yyr1[] =
      217,   217,   217,   217,   218,   218,   219,   219,   220,   221,
      220,   222,   222,   222,   223,   224,   224,   226,   225,   227,
      228,   229,   229,   229,   229,   229,   229,   229,   230,   230,
-     231,   231,   232,   233,   233,   234,   234,   235,   236,   236,
-     237,   237,   238,   238,   239,   239,   240,   241,   240,   242,
-     240,   243,   243,   244,   244,   245,   245,   245,   245,   245,
-     246,   246,   247,   247,   249,   250,   248,   251,   248,   253,
-     254,   252,   255,   252,   257,   258,   256,   259,   260,   260,
-     260,   260,   260,   260,   260,   262,   261,   263,   265,   264,
-     267,   266,   268,   268,   269,   269,   269,   269,   269,   269,
-     270,   270,   271,   271,   271,   272,   272,   272,   272,   272,
-     272,   272,   272,   272,   273,   273,   274,   274,   275,   275,
-     275,   276,   276,   276,   276,   277,   277,   278,   278,   278,
-     278,   278,   278,   278,   279,   279,   280,   280,   281,   281,
-     282,   282,   282,   283,   283,   283,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   284,   284,   284,   284,   284,
-     284,   284,   284,   284,   284,   285,   285,   285,   285,   285,
+     231,   231,   232,   232,   233,   234,   234,   235,   235,   236,
+     237,   237,   238,   238,   239,   239,   240,   240,   241,   242,
+     241,   243,   241,   244,   244,   245,   245,   246,   246,   246,
+     246,   246,   247,   247,   248,   248,   250,   251,   249,   252,
+     249,   254,   255,   253,   256,   253,   258,   259,   257,   260,
+     261,   261,   261,   261,   261,   261,   261,   263,   262,   264,
+     266,   265,   268,   267,   269,   269,   270,   270,   270,   270,
+     270,   270,   271,   271,   272,   272,   272,   273,   273,   273,
+     273,   273,   273,   273,   273,   273,   274,   274,   275,   275,
+     276,   276,   276,   277,   277,   277,   277,   278,   278,   279,
+     279,   279,   279,   279,   279,   279,   280,   280,   281,   281,
+     282,   282,   283,   283,   283,   284,   284,   284,   285,   285,
      285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
      285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
-     286,   286,   287,   288,   288,   288,   289,   291,   290,   292,
-     293,   294,   292,   296,   297,   295,   298,   298,   298,   299,
-     299,   299,   299,   299,   299,   299,   299,   299,   299,   299,
-     299,   299,   299,   299,   299,   299,   299,   299,   300,   301,
-     299,   302,   302,   302,   303,   303,   304,   304,   305,   305,
-     306,   306,   306,   307,   307,   309,   310,   308,   308,   311,
-     311,   311,   311,   311,   311,   312,   313,   314,   314,   314,
-     315,   315,   316,   317,   317,   317,   318,   318,   319,   319,
-     320,   320,   321,   321,   322,   322,   322,   324,   325,   323,
-     326,   327,   323,   328,   329,   323,   331,   332,   330,   333,
-     333,   333,   334,   334,   334,   334,   335,   335,   335,   336,
-     336,   336,   337,   337,   337,   337,   337,   338,   338,   339,
-     339,   340,   341,   341,   342,   342,   342,   342,   342,   342,
-     342,   343,   343,   343,   343,   343,   343,   343,   343,   343,
-     343,   343,   343,   343,   343,   343,   343,   343,   343,   343,
-     343,   343,   344,   344,   345,   345,   346,   346,   347,   348,
-     349,   347,   350,   351,   347,   352,   352,   352,   352,   352,
-     352,   352,   353,   354,   352,   355,   355,   355,   355,   355,
-     355,   355,   356,   356,   356,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
-     357,   358,   359,   357,   357,   357,   357,   360,   361,   357,
-     357,   357,   362,   363,   357,   357,   357,   357,   357,   357,
-     357,   357,   357,   357,   357,   357,   357,   357,   357,   357,
-     357,   364,   364,   364,   365,   365,   365,   365,   365,   365,
-     365,   365,   365,   365,   365,   365,   365,   365,   365,   365,
-     366,   366,   367,   367,   367,   368,   368,   369,   369,   369,
-     370,   370,   371,   372,   372,   372,   373,   372,   374,   372,
-     375,   372,   376,   377,   377,   378,   378,   378,   378,   378,
-     379,   379,   380,   380,   381,   381,   381,   382,   383,   383,
-     384,   384,   384,   385,   385,   386,   386,   386,   387,   387,
-     388,   388,   389,   389,   389,   390,   390,   391,   391,   391,
-     391,   391,   392,   392,   393,   393,   393,   394,   394,   394,
-     395,   395,   395,   396,   396,   397,   397,   397,   398,   398,
-     399,   398,   400,   401,   400,   402,   402,   403,   403,   404,
-     404,   404,   405,   405,   405,   407,   406,   408,   409,   409,
-     409,   410,   411,   411,   412,   412,   413,   413,   414,   414,
-     416,   417,   418,   415,   419,   419,   420,   420,   421,   422,
-     422,   422,   422,   423,   423,   423,   424,   424,   426,   427,
-     428,   425,   429,   429,   429,   429,   429,   430,   430,   430,
-     430,   430,   430,   430,   430,   430,   430,   430,   430,   430,
-     430,   430,   430,   430,   430,   430,   430,   430,   430,   430,
-     430,   430,   430,   430,   431,   431,   431,   431,   431,   431,
-     431,   431,   432,   433,   433,   433,   434,   434,   434,   435,
-     435,   435,   435,   435,   436,   436,   436,   436,   436,   437,
-     438,   439,   437,   440,   440,   441,   441,   442,   442,   442,
-     442,   443,   443,   444,   444,   445,   445,   445,   445,   446,
-     447,   445,   445,   445,   445,   448,   445,   449,   445,   445,
-     445,   445,   445,   445,   445,   445,   445,   445,   445,   445,
-     445,   450,   451,   445,   445,   452,   453,   445,   454,   455,
-     445,   456,   457,   445,   445,   458,   459,   445,   460,   461,
-     445,   445,   462,   463,   445,   464,   465,   445,   445,   466,
-     467,   445,   468,   469,   445,   470,   471,   445,   472,   473,
-     445,   474,   474,   474,   476,   477,   478,   479,   475,   481,
-     482,   483,   484,   480,   486,   487,   488,   489,   485,   490,
-     490,   490,   490,   490,   490,   490,   491,   491,   491,   491,
-     491,   492,   492,   492,   492,   492,   492,   492,   492,   493,
-     493,   494,   495,   495,   496,   496,   497,   497,   498,   498,
-     500,   501,   499,   502,   503,   499,   504,   505,   499,   506,
-     507,   499,   508,   509,   499,   510,   511,   512,   510,   513,
-     514,   515,   513,   516,   517,   513,   518,   519,   513,   513,
-     520,   521,   513,   513,   522,   523,   513,   524,   524,   525,
-     526,   527,   527,   527,   528,   528,   529,   529,   530,   530,
-     531
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   285,   285,   285,
+     285,   285,   285,   285,   285,   285,   285,   286,   286,   286,
+     286,   286,   286,   286,   286,   286,   286,   286,   286,   286,
+     286,   286,   286,   286,   286,   286,   286,   286,   286,   286,
+     286,   286,   287,   287,   288,   289,   289,   289,   290,   292,
+     291,   293,   294,   295,   293,   297,   298,   296,   299,   299,
+     299,   300,   300,   300,   300,   300,   300,   300,   300,   300,
+     300,   300,   300,   300,   300,   300,   300,   300,   300,   300,
+     301,   302,   300,   303,   303,   303,   304,   304,   305,   305,
+     306,   306,   307,   307,   307,   308,   308,   310,   311,   309,
+     309,   312,   312,   312,   312,   312,   312,   313,   314,   315,
+     315,   315,   316,   316,   317,   318,   318,   318,   319,   319,
+     320,   320,   321,   321,   322,   322,   323,   323,   323,   325,
+     326,   324,   327,   328,   324,   329,   330,   324,   332,   333,
+     331,   334,   334,   334,   335,   335,   335,   335,   336,   336,
+     336,   337,   337,   337,   338,   338,   338,   338,   338,   339,
+     339,   340,   340,   341,   342,   342,   343,   343,   343,   343,
+     343,   343,   343,   344,   344,   344,   344,   344,   344,   344,
+     344,   344,   344,   344,   344,   344,   344,   344,   344,   344,
+     344,   344,   344,   344,   345,   345,   346,   346,   347,   347,
+     348,   349,   350,   348,   351,   352,   348,   353,   353,   353,
+     353,   353,   353,   353,   354,   355,   353,   356,   356,   356,
+     356,   356,   356,   356,   357,   357,   357,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   358,
+     358,   358,   358,   359,   360,   358,   358,   358,   358,   361,
+     362,   358,   358,   358,   363,   364,   358,   358,   358,   358,
+     358,   358,   358,   358,   358,   358,   358,   358,   358,   358,
+     358,   358,   358,   365,   365,   365,   366,   366,   366,   366,
+     366,   366,   366,   366,   366,   366,   366,   366,   366,   366,
+     366,   366,   367,   367,   368,   368,   368,   369,   369,   370,
+     370,   370,   371,   371,   372,   373,   373,   373,   374,   373,
+     375,   373,   376,   373,   377,   378,   378,   379,   379,   379,
+     379,   379,   380,   380,   381,   381,   382,   382,   382,   383,
+     384,   384,   385,   385,   385,   386,   386,   387,   387,   387,
+     388,   388,   389,   389,   390,   390,   390,   391,   391,   392,
+     392,   392,   392,   392,   393,   393,   394,   394,   394,   395,
+     395,   395,   396,   396,   396,   397,   397,   398,   398,   398,
+     399,   399,   400,   399,   401,   402,   401,   403,   403,   404,
+     404,   405,   405,   405,   406,   406,   406,   408,   407,   409,
+     410,   410,   410,   411,   412,   412,   413,   413,   414,   414,
+     415,   415,   417,   418,   419,   416,   420,   420,   421,   421,
+     422,   423,   423,   423,   423,   424,   424,   424,   425,   425,
+     427,   428,   429,   426,   430,   430,   430,   430,   430,   431,
+     431,   431,   431,   431,   431,   431,   431,   431,   431,   431,
+     431,   431,   431,   431,   431,   431,   431,   431,   431,   431,
+     431,   431,   431,   431,   431,   431,   432,   432,   432,   432,
+     432,   432,   432,   432,   433,   434,   434,   434,   435,   435,
+     435,   436,   436,   436,   436,   436,   437,   437,   437,   437,
+     437,   438,   439,   440,   438,   441,   441,   442,   442,   443,
+     443,   443,   443,   444,   444,   445,   445,   446,   446,   446,
+     446,   447,   448,   446,   446,   446,   446,   449,   446,   450,
+     446,   446,   446,   446,   446,   446,   446,   446,   446,   446,
+     446,   446,   446,   451,   452,   446,   446,   453,   454,   446,
+     455,   456,   446,   457,   458,   446,   446,   459,   460,   446,
+     461,   462,   446,   446,   463,   464,   446,   465,   466,   446,
+     446,   467,   468,   446,   469,   470,   446,   471,   472,   446,
+     473,   474,   446,   475,   475,   475,   477,   478,   479,   480,
+     476,   482,   483,   484,   485,   481,   487,   488,   489,   490,
+     486,   491,   491,   491,   491,   491,   491,   491,   492,   492,
+     492,   492,   492,   493,   493,   493,   493,   493,   493,   493,
+     493,   494,   494,   495,   496,   496,   497,   497,   498,   498,
+     499,   499,   501,   502,   500,   503,   504,   500,   505,   506,
+     500,   507,   508,   500,   509,   510,   500,   511,   512,   513,
+     511,   514,   515,   516,   514,   517,   518,   514,   519,   520,
+     514,   514,   521,   522,   514,   514,   523,   524,   514,   525,
+     525,   526,   527,   528,   528,   528,   529,   529,   530,   530,
+     531,   531,   532
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -3974,97 +3981,97 @@ static const yytype_int8 yyr2[] =
        1,     2,     0,     1,     1,     1,     1,     0,     2,     5,
        1,     1,     2,     2,     3,     2,     0,     2,     0,     0,
        3,     0,     2,     5,     3,     1,     2,     0,     4,     2,
-       2,     1,     2,     3,     3,     3,     3,     3,     2,     4,
-       0,     1,     2,     1,     3,     1,     3,     3,     3,     2,
-       1,     1,     1,     2,     0,     1,     0,     0,     4,     0,
-       8,     1,     1,     0,     2,     1,     1,     1,     1,     1,
-       1,     2,     0,     1,     0,     0,     6,     0,     3,     0,
-       0,     6,     0,     3,     0,     0,     9,     7,     1,     4,
-       3,     3,     3,     5,     5,     0,    10,     3,     0,     8,
-       0,     7,     4,     4,     1,     1,     1,     1,     1,     1,
-       1,     3,     1,     1,     1,     3,     3,     5,     3,     3,
-       3,     3,     1,     5,     1,     3,     3,     4,     0,     3,
-       1,     1,     1,     1,     1,     1,     4,     1,     2,     3,
-       3,     3,     3,     2,     1,     3,     0,     3,     0,     4,
-       0,     2,     3,     0,     2,     2,     1,     2,     2,     2,
+       2,     1,     2,     3,     3,     3,     3,     3,     0,     2,
+       3,     5,     0,     1,     2,     1,     3,     1,     3,     3,
+       3,     2,     1,     1,     1,     2,     0,     1,     0,     0,
+       4,     0,     8,     1,     1,     0,     2,     1,     1,     1,
+       1,     1,     1,     2,     0,     1,     0,     0,     6,     0,
+       3,     0,     0,     6,     0,     3,     0,     0,     9,     7,
+       1,     4,     3,     3,     3,     5,     5,     0,    10,     3,
+       0,     8,     0,     7,     4,     4,     1,     1,     1,     1,
+       1,     1,     1,     3,     1,     1,     1,     3,     3,     5,
+       3,     3,     3,     3,     1,     5,     1,     3,     3,     4,
+       0,     3,     1,     1,     1,     1,     1,     1,     4,     1,
+       2,     3,     3,     3,     3,     2,     1,     3,     0,     3,
+       0,     4,     0,     2,     3,     0,     2,     2,     1,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     3,     4,     4,     4,     4,     4,     4,     4,
+       4,     4,     4,     4,     4,     4,     4,     3,     2,     2,
        3,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-       4,     4,     4,     4,     4,     3,     2,     2,     3,     4,
-       4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-       4,     3,     2,     2,     2,     2,     2,     3,     3,     3,
-       3,     3,     4,     4,     1,     1,     1,     1,     1,     1,
+       4,     4,     4,     3,     2,     2,     2,     2,     2,     3,
+       3,     3,     3,     3,     4,     4,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       0,     1,     4,     0,     1,     1,     3,     0,     5,     0,
-       0,     0,     6,     0,     0,     6,     2,     2,     2,     1,
-       2,     2,     1,     1,     1,     1,     2,     1,     2,     2,
-       2,     2,     1,     1,     1,     2,     2,     2,     0,     0,
-       6,     0,     2,     2,     0,     2,     0,     2,     1,     3,
-       1,     3,     2,     2,     3,     0,     0,     5,     1,     2,
-       5,     5,     5,     6,     2,     1,     1,     1,     2,     3,
-       2,     3,     4,     1,     1,     0,     1,     1,     1,     0,
-       1,     3,     8,     7,     3,     3,     5,     0,     0,     7,
-       0,     0,     7,     0,     0,     7,     0,     0,     6,     5,
-       8,    10,     1,     2,     3,     4,     1,     2,     3,     1,
-       1,     2,     2,     2,     2,     2,     4,     1,     3,     0,
-       4,     7,     7,     3,     1,     1,     1,     1,     1,     1,
-       1,     1,     3,     3,     3,     3,     3,     3,     3,     3,
+       1,     1,     0,     1,     4,     0,     1,     1,     3,     0,
+       5,     0,     0,     0,     6,     0,     0,     6,     2,     2,
+       2,     1,     2,     2,     1,     1,     1,     1,     2,     1,
+       2,     2,     2,     2,     1,     1,     1,     2,     2,     2,
+       0,     0,     6,     0,     2,     2,     0,     2,     0,     2,
+       1,     3,     1,     3,     2,     2,     3,     0,     0,     5,
+       1,     2,     5,     5,     5,     6,     2,     1,     1,     1,
+       2,     3,     2,     3,     4,     1,     1,     0,     1,     1,
+       1,     0,     1,     3,     8,     7,     3,     3,     5,     0,
+       0,     7,     0,     0,     7,     0,     0,     7,     0,     0,
+       6,     5,     8,    10,     1,     2,     3,     4,     1,     2,
+       3,     1,     1,     2,     2,     2,     2,     2,     4,     1,
+       3,     0,     4,     7,     7,     3,     1,     1,     1,     1,
+       1,     1,     1,     1,     3,     3,     3,     3,     3,     3,
        3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     6,     8,     5,     6,     1,     4,     3,     0,
-       0,     8,     0,     0,     9,     3,     4,     5,     6,     8,
-       5,     6,     0,     0,     5,     3,     4,     4,     5,     4,
-       3,     4,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     2,     2,     2,     2,     3,
+       3,     3,     3,     3,     6,     8,     5,     6,     1,     4,
+       3,     0,     0,     8,     0,     0,     9,     3,     4,     5,
+       6,     8,     5,     6,     0,     0,     5,     3,     4,     4,
+       5,     4,     3,     4,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     2,     2,     2,
+       2,     3,     3,     3,     3,     3,     3,     3,     3,     3,
        3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     2,     2,     2,     2,     4,     3,     4,     5,     4,
-       5,     3,     4,     1,     1,     2,     4,     4,     1,     3,
-       5,     0,     0,     8,     3,     3,     3,     0,     0,     8,
-       3,     4,     0,     0,     9,     4,     1,     1,     1,     1,
-       1,     1,     1,     3,     3,     3,     1,     4,     3,     3,
-       3,     7,     8,     7,     4,     4,     4,     4,     4,     1,
-       6,     7,     6,     6,     7,     7,     6,     7,     6,     6,
-       0,     1,     0,     1,     1,     0,     1,     0,     1,     1,
-       0,     1,     5,     0,     2,     6,     0,     4,     0,     9,
-       0,    11,     3,     3,     4,     1,     1,     3,     3,     3,
-       1,     3,     1,     3,     0,     1,     3,     3,     1,     3,
-       0,     1,     3,     1,     1,     1,     2,     3,     3,     5,
-       1,     1,     1,     1,     1,     0,     1,     1,     4,     3,
-       3,     5,     1,     3,     0,     2,     2,     4,     6,     5,
-       4,     6,     5,     0,     1,     0,     1,     1,     0,     2,
-       0,     4,     6,     0,     6,     1,     3,     1,     2,     0,
-       1,     3,     0,     1,     1,     0,     5,     3,     0,     1,
-       1,     1,     0,     2,     0,     1,     1,     2,     0,     1,
-       0,     0,     0,    13,     0,     2,     0,     1,     3,     1,
-       1,     2,     2,     0,     1,     1,     1,     3,     0,     0,
-       0,     9,     1,     4,     3,     3,     5,     1,     1,     1,
+       3,     3,     3,     2,     2,     2,     2,     4,     3,     4,
+       5,     4,     5,     3,     4,     1,     1,     2,     4,     4,
+       1,     3,     5,     0,     0,     8,     3,     3,     3,     0,
+       0,     8,     3,     4,     0,     0,     9,     4,     1,     1,
+       1,     1,     1,     1,     1,     3,     3,     3,     1,     4,
+       3,     3,     3,     7,     8,     7,     4,     4,     4,     4,
+       4,     1,     6,     7,     6,     6,     7,     7,     6,     7,
+       6,     6,     0,     1,     0,     1,     1,     0,     1,     0,
+       1,     1,     0,     1,     5,     0,     2,     6,     0,     4,
+       0,     9,     0,    11,     3,     3,     4,     1,     1,     3,
+       3,     3,     1,     3,     1,     3,     0,     1,     3,     3,
+       1,     3,     0,     1,     3,     1,     1,     1,     2,     3,
+       3,     5,     1,     1,     1,     1,     1,     0,     1,     1,
+       4,     3,     3,     5,     1,     3,     0,     2,     2,     4,
+       6,     5,     4,     6,     5,     0,     1,     0,     1,     1,
+       0,     2,     0,     4,     6,     0,     6,     1,     3,     1,
+       2,     0,     1,     3,     0,     1,     1,     0,     5,     3,
+       0,     1,     1,     1,     0,     2,     0,     1,     1,     2,
+       0,     1,     0,     0,     0,    13,     0,     2,     0,     1,
+       3,     1,     1,     2,     2,     0,     1,     1,     1,     3,
+       0,     0,     0,     9,     1,     4,     3,     3,     5,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     4,     4,     1,     3,     3,     0,
-       1,     3,     3,     5,     0,     2,     2,     2,     2,     4,
-       0,     0,     7,     1,     1,     1,     3,     3,     2,     4,
-       3,     1,     2,     0,     4,     1,     1,     1,     1,     0,
-       0,     6,     4,     4,     3,     0,     6,     0,     7,     4,
-       2,     2,     3,     2,     3,     2,     2,     3,     3,     3,
-       2,     0,     0,     6,     2,     0,     0,     6,     0,     0,
-       6,     0,     0,     6,     1,     0,     0,     6,     0,     0,
-       7,     1,     0,     0,     6,     0,     0,     7,     1,     0,
-       0,     6,     0,     0,     7,     0,     0,     6,     0,     0,
-       6,     1,     3,     3,     0,     0,     0,     0,    12,     0,
-       0,     0,     0,    12,     0,     0,     0,     0,    13,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     3,     3,     5,     5,     6,     6,     8,     8,     0,
-       1,     2,     3,     5,     1,     2,     1,     0,     0,     1,
-       0,     0,    10,     0,     0,    10,     0,     0,    10,     0,
-       0,    11,     0,     0,     7,     5,     0,     0,    10,     3,
-       0,     0,    11,     0,     0,    11,     0,     0,    10,     5,
-       0,     0,     9,     5,     0,     0,    10,     1,     3,     0,
-       5,     5,     7,     9,     0,     3,     0,     1,    11,    12,
-      13
+       1,     1,     1,     1,     1,     1,     4,     4,     1,     3,
+       3,     0,     1,     3,     3,     5,     0,     2,     2,     2,
+       2,     4,     0,     0,     7,     1,     1,     1,     3,     3,
+       2,     4,     3,     1,     2,     0,     4,     1,     1,     1,
+       1,     0,     0,     6,     4,     4,     3,     0,     6,     0,
+       7,     4,     2,     2,     3,     2,     3,     2,     2,     3,
+       3,     3,     2,     0,     0,     6,     2,     0,     0,     6,
+       0,     0,     6,     0,     0,     6,     1,     0,     0,     6,
+       0,     0,     7,     1,     0,     0,     6,     0,     0,     7,
+       1,     0,     0,     6,     0,     0,     7,     0,     0,     6,
+       0,     0,     6,     1,     3,     3,     0,     0,     0,     0,
+      12,     0,     0,     0,     0,    12,     0,     0,     0,     0,
+      13,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     3,     3,     5,     5,     6,     6,     8,
+       8,     0,     1,     2,     3,     5,     1,     2,     1,     0,
+       0,     1,     0,     0,    10,     0,     0,    10,     0,     0,
+      10,     0,     0,    11,     0,     0,     7,     5,     0,     0,
+      10,     3,     0,     0,    11,     0,     0,    11,     0,     0,
+      10,     5,     0,     0,     9,     5,     0,     0,    10,     1,
+       3,     0,     5,     5,     7,     9,     0,     3,     0,     1,
+      11,    12,    13
 };
 
 
@@ -4662,6 +4669,10 @@ yydestruct (const char *yymsg,
         break;
 
     case YYSYMBOL_require_module_name: /* require_module_name  */
+            { delete ((*yyvaluep).s); }
+        break;
+
+    case YYSYMBOL_optional_require_guard: /* optional_require_guard  */
             { delete ((*yyvaluep).s); }
         break;
 
@@ -5803,85 +5814,93 @@ yyreduce:
     }
     break;
 
-  case 58: /* require_module: require_module_name is_public_module  */
-                                                         {
-        ast_requireModule(scanner,(yyvsp[-1].s),nullptr,(yyvsp[0].b),tokAt(scanner,(yylsp[-1])));
+  case 58: /* optional_require_guard: %empty  */
+                            { (yyval.s) = nullptr; }
+    break;
+
+  case 59: /* optional_require_guard: '?' "name"  */
+                            { (yyval.s) = (yyvsp[0].s); }
+    break;
+
+  case 60: /* require_module: optional_require_guard require_module_name is_public_module  */
+                                                                                       {
+        ast_requireModule(scanner,(yyvsp[-1].s),nullptr,(yyvsp[0].b),tokAt(scanner,(yylsp[-1])),(yyvsp[-2].s));
     }
     break;
 
-  case 59: /* require_module: require_module_name "as" "name" is_public_module  */
-                                                                              {
-        ast_requireModule(scanner,(yyvsp[-3].s),(yyvsp[-1].s),(yyvsp[0].b),tokAt(scanner,(yylsp[-3])));
+  case 61: /* require_module: optional_require_guard require_module_name "as" "name" is_public_module  */
+                                                                                                            {
+        ast_requireModule(scanner,(yyvsp[-3].s),(yyvsp[-1].s),(yyvsp[0].b),tokAt(scanner,(yylsp[-3])),(yyvsp[-4].s));
     }
     break;
 
-  case 60: /* is_public_module: %empty  */
+  case 62: /* is_public_module: %empty  */
                     { (yyval.b) = false; }
     break;
 
-  case 61: /* is_public_module: "public"  */
+  case 63: /* is_public_module: "public"  */
                     { (yyval.b) = true; }
     break;
 
-  case 65: /* expect_error: "integer constant"  */
+  case 67: /* expect_error: "integer constant"  */
                    {
         yyextra->g_Program->expectErrors[CompilationError((yyvsp[0].i))] ++;
     }
     break;
 
-  case 66: /* expect_error: "integer constant" ':' "integer constant"  */
+  case 68: /* expect_error: "integer constant" ':' "integer constant"  */
                                       {
         yyextra->g_Program->expectErrors[CompilationError((yyvsp[-2].i))] += (yyvsp[0].i);
     }
     break;
 
-  case 67: /* expression_label: "label" "integer constant" ':'  */
+  case 69: /* expression_label: "label" "integer constant" ':'  */
                                           {
         (yyval.pExpression) = new ExprLabel(tokAt(scanner,(yylsp[-2])),(yyvsp[-1].i));
     }
     break;
 
-  case 68: /* expression_goto: "goto" "label" "integer constant"  */
+  case 70: /* expression_goto: "goto" "label" "integer constant"  */
                                                 {
         (yyval.pExpression) = new ExprGoto(tokAt(scanner,(yylsp[-2])),(yyvsp[0].i));
     }
     break;
 
-  case 69: /* expression_goto: "goto" expr  */
+  case 71: /* expression_goto: "goto" expr  */
                                {
         (yyval.pExpression) = new ExprGoto(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 70: /* elif_or_static_elif: "elif"  */
+  case 72: /* elif_or_static_elif: "elif"  */
                           { (yyval.b) = false; }
     break;
 
-  case 71: /* elif_or_static_elif: "static_elif"  */
+  case 73: /* elif_or_static_elif: "static_elif"  */
                           { (yyval.b) = true; }
     break;
 
-  case 76: /* expression_else: %empty  */
+  case 78: /* expression_else: %empty  */
                                                            { (yyval.pExpression) = nullptr; }
     break;
 
-  case 77: /* $@3: %empty  */
+  case 79: /* $@3: %empty  */
                                            {
     }
     break;
 
-  case 78: /* expression_else: "else" optional_emit_semis $@3 expression_else_block  */
+  case 80: /* expression_else: "else" optional_emit_semis $@3 expression_else_block  */
                                    {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 79: /* $@4: %empty  */
+  case 81: /* $@4: %empty  */
                                                                         {
     }
     break;
 
-  case 80: /* expression_else: elif_or_static_elif '(' expr ')' optional_emit_semis $@4 expression_else_block expression_else  */
+  case 82: /* expression_else: elif_or_static_elif '(' expr ')' optional_emit_semis $@4 expression_else_block expression_else  */
                                                          {
         auto eite = new ExprIfThenElse(tokAt(scanner,(yylsp[-7])),(yyvsp[-5].pExpression),(yyvsp[-1].pExpression),(yyvsp[0].pExpression));
         eite->isStatic = (yyvsp[-7].b);
@@ -5889,57 +5908,57 @@ yyreduce:
     }
     break;
 
-  case 81: /* if_or_static_if: "if"  */
+  case 83: /* if_or_static_if: "if"  */
                         { (yyval.b) = false; }
     break;
 
-  case 82: /* if_or_static_if: "static_if"  */
+  case 84: /* if_or_static_if: "static_if"  */
                         { (yyval.b) = true; }
     break;
 
-  case 83: /* expression_else_one_liner: %empty  */
+  case 85: /* expression_else_one_liner: %empty  */
         { (yyval.pExpression) = nullptr; }
     break;
 
-  case 84: /* expression_else_one_liner: "else" expression_if_one_liner  */
+  case 86: /* expression_else_one_liner: "else" expression_if_one_liner  */
                                                       {
             (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 85: /* expression_if_one_liner: expr_no_bracket  */
+  case 87: /* expression_if_one_liner: expr_no_bracket  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 86: /* expression_if_one_liner: expression_return  */
+  case 88: /* expression_if_one_liner: expression_return  */
                                             { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 87: /* expression_if_one_liner: expression_yield  */
+  case 89: /* expression_if_one_liner: expression_yield  */
                                             { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 88: /* expression_if_one_liner: expression_break  */
+  case 90: /* expression_if_one_liner: expression_break  */
                                             { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 89: /* expression_if_one_liner: expression_continue  */
+  case 91: /* expression_if_one_liner: expression_continue  */
                                             { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 94: /* $@5: %empty  */
+  case 96: /* $@5: %empty  */
                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 95: /* $@6: %empty  */
+  case 97: /* $@6: %empty  */
                          {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 96: /* expression_if_block: '{' $@5 expressions $@6 '}' expression_block_finally  */
+  case 98: /* expression_if_block: '{' $@5 expressions $@6 '}' expression_block_finally  */
                                         {
         (yyval.pExpression) = (yyvsp[-3].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-5]),(yylsp[0]));
@@ -5952,31 +5971,31 @@ yyreduce:
     }
     break;
 
-  case 97: /* $@7: %empty  */
+  case 99: /* $@7: %empty  */
        {
         yyextra->das_keyword = false;
     }
     break;
 
-  case 98: /* expression_if_block: $@7 expression_if_one_liner SEMICOLON  */
+  case 100: /* expression_if_block: $@7 expression_if_one_liner SEMICOLON  */
                                                {
         (yyval.pExpression) = (yyvsp[-1].pExpression);
     }
     break;
 
-  case 99: /* $@8: %empty  */
+  case 101: /* $@8: %empty  */
                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 100: /* $@9: %empty  */
+  case 102: /* $@9: %empty  */
                          {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 101: /* expression_else_block: '{' $@8 expressions $@9 '}' expression_block_finally  */
+  case 103: /* expression_else_block: '{' $@8 expressions $@9 '}' expression_block_finally  */
                                         {
         (yyval.pExpression) = (yyvsp[-3].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-5]),(yylsp[0]));
@@ -5989,30 +6008,30 @@ yyreduce:
     }
     break;
 
-  case 102: /* $@10: %empty  */
+  case 104: /* $@10: %empty  */
        {
         yyextra->das_keyword = false;
     }
     break;
 
-  case 103: /* expression_else_block: $@10 expression_if_one_liner SEMICOLON  */
+  case 105: /* expression_else_block: $@10 expression_if_one_liner SEMICOLON  */
                                                {
         (yyval.pExpression) = (yyvsp[-1].pExpression);
     }
     break;
 
-  case 104: /* $@11: %empty  */
+  case 106: /* $@11: %empty  */
         {
         yyextra->das_keyword = true;
     }
     break;
 
-  case 105: /* $@12: %empty  */
+  case 107: /* $@12: %empty  */
                                                                   {
     }
     break;
 
-  case 106: /* expression_if_then_else: $@11 if_or_static_if '(' expr ')' optional_emit_semis $@12 expression_if_block expression_else  */
+  case 108: /* expression_if_then_else: $@11 if_or_static_if '(' expr ')' optional_emit_semis $@12 expression_if_block expression_else  */
                                                        {
         yyextra->das_keyword = false;
         auto blk = (yyvsp[-1].pExpression)->rtti_isBlock() ? static_cast<ExprBlock *>((yyvsp[-1].pExpression)) : ast_wrapInBlock((yyvsp[-1].pExpression));
@@ -6022,13 +6041,13 @@ yyreduce:
     }
     break;
 
-  case 107: /* expression_if_then_else_oneliner: expression_if_one_liner "if" '(' expr ')' expression_else_one_liner SEMICOLON  */
+  case 109: /* expression_if_then_else_oneliner: expression_if_one_liner "if" '(' expr ')' expression_else_one_liner SEMICOLON  */
                                                                                                                       {
         (yyval.pExpression) = new ExprIfThenElse(tokAt(scanner,(yylsp[-5])),(yyvsp[-3].pExpression),ast_wrapInBlock((yyvsp[-6].pExpression)),(yyvsp[-1].pExpression) ? ast_wrapInBlock((yyvsp[-1].pExpression)) : nullptr);
     }
     break;
 
-  case 108: /* for_variable_name_with_pos_list: "name"  */
+  case 110: /* for_variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -6038,7 +6057,7 @@ yyreduce:
     }
     break;
 
-  case 109: /* for_variable_name_with_pos_list: "$i" '(' expr ')'  */
+  case 111: /* for_variable_name_with_pos_list: "$i" '(' expr ')'  */
                                      {
         auto pSL = new vector<VariableNameAndPosition>();
         pSL->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression)));
@@ -6046,7 +6065,7 @@ yyreduce:
     }
     break;
 
-  case 110: /* for_variable_name_with_pos_list: "name" "aka" "name"  */
+  case 112: /* for_variable_name_with_pos_list: "name" "aka" "name"  */
                                          {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -6058,7 +6077,7 @@ yyreduce:
     }
     break;
 
-  case 111: /* for_variable_name_with_pos_list: '(' tuple_expansion ')'  */
+  case 113: /* for_variable_name_with_pos_list: '(' tuple_expansion ')'  */
                                        {
         auto pSL = new vector<VariableNameAndPosition>();
         for ( auto & x : *(yyvsp[-1].pNameList) ) {
@@ -6069,7 +6088,7 @@ yyreduce:
     }
     break;
 
-  case 112: /* for_variable_name_with_pos_list: for_variable_name_with_pos_list ',' "name"  */
+  case 114: /* for_variable_name_with_pos_list: for_variable_name_with_pos_list ',' "name"  */
                                                              {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -6078,7 +6097,7 @@ yyreduce:
     }
     break;
 
-  case 113: /* for_variable_name_with_pos_list: for_variable_name_with_pos_list ',' "name" "aka" "name"  */
+  case 115: /* for_variable_name_with_pos_list: for_variable_name_with_pos_list ',' "name" "aka" "name"  */
                                                                                    {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -6089,7 +6108,7 @@ yyreduce:
     }
     break;
 
-  case 114: /* for_variable_name_with_pos_list: for_variable_name_with_pos_list ',' '(' tuple_expansion ')'  */
+  case 116: /* for_variable_name_with_pos_list: for_variable_name_with_pos_list ',' '(' tuple_expansion ')'  */
                                                                                  {
         for ( auto & x : *(yyvsp[-1].pNameList) ) {
             das_checkName(scanner,x,tokAt(scanner,(yylsp[-1])));
@@ -6099,20 +6118,20 @@ yyreduce:
     }
     break;
 
-  case 115: /* $@13: %empty  */
+  case 117: /* $@13: %empty  */
         {
         yyextra->das_keyword = true;
     }
     break;
 
-  case 116: /* expression_for_loop: $@13 "for" optional_for_annotations '(' for_variable_name_with_pos_list "in" expr_list ')' optional_emit_semis expression_block  */
+  case 118: /* expression_for_loop: $@13 "for" optional_for_annotations '(' for_variable_name_with_pos_list "in" expr_list ')' optional_emit_semis expression_block  */
                                                                                                                                                                     {
         yyextra->das_keyword = false;
         (yyval.pExpression) = ast_forLoop(scanner,(yyvsp[-5].pNameWithPosList),(yyvsp[-3].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-8])),tokAt(scanner,(yylsp[0])),(yyvsp[-7].aaList));
     }
     break;
 
-  case 117: /* expression_unsafe: "unsafe" optional_emit_semis expression_block  */
+  case 119: /* expression_unsafe: "unsafe" optional_emit_semis expression_block  */
                                                                     {
         auto pUnsafe = new ExprUnsafe(tokAt(scanner,(yylsp[-2])));
         pUnsafe->body = (yyvsp[0].pExpression);
@@ -6120,13 +6139,13 @@ yyreduce:
     }
     break;
 
-  case 118: /* $@14: %empty  */
+  case 120: /* $@14: %empty  */
         {
         yyextra->das_keyword = true;
     }
     break;
 
-  case 119: /* expression_while_loop: $@14 "while" optional_for_annotations '(' expr ')' optional_emit_semis expression_block  */
+  case 121: /* expression_while_loop: $@14 "while" optional_for_annotations '(' expr ')' optional_emit_semis expression_block  */
                                                                                                                         {
         yyextra->das_keyword = false;
         auto pWhile = new ExprWhile(tokAt(scanner,(yylsp[-6])));
@@ -6138,13 +6157,13 @@ yyreduce:
     }
     break;
 
-  case 120: /* $@15: %empty  */
+  case 122: /* $@15: %empty  */
         {
         yyextra->das_keyword = true;
     }
     break;
 
-  case 121: /* expression_with: $@15 "with" '(' expr ')' optional_emit_semis expression_block  */
+  case 123: /* expression_with: $@15 "with" '(' expr ')' optional_emit_semis expression_block  */
                                                                                    {
         yyextra->das_keyword = false;
         auto pWith = new ExprWith(tokAt(scanner,(yylsp[-5])));
@@ -6154,45 +6173,45 @@ yyreduce:
     }
     break;
 
-  case 122: /* expression_with_alias: "assume" "name" '=' expr  */
+  case 124: /* expression_with_alias: "assume" "name" '=' expr  */
                                                       {
         (yyval.pExpression) = new ExprAssume(tokAt(scanner,(yylsp[-3])), *(yyvsp[-2].s), ExpressionPtr((yyvsp[0].pExpression)));
         delete (yyvsp[-2].s);
     }
     break;
 
-  case 123: /* expression_with_alias: "typedef" "name" '=' type_declaration  */
+  case 125: /* expression_with_alias: "typedef" "name" '=' type_declaration  */
                                                                 {
         (yyval.pExpression) = new ExprAssume(tokAt(scanner,(yylsp[-3])), *(yyvsp[-2].s), TypeDeclPtr((yyvsp[0].pTypeDecl)));
         delete (yyvsp[-2].s);
     }
     break;
 
-  case 124: /* annotation_argument_value: string_constant  */
+  case 126: /* annotation_argument_value: string_constant  */
                                  { (yyval.aa) = new AnnotationArgument("",*(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 125: /* annotation_argument_value: "name"  */
+  case 127: /* annotation_argument_value: "name"  */
                                  { (yyval.aa) = new AnnotationArgument("",*(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 126: /* annotation_argument_value: "integer constant"  */
+  case 128: /* annotation_argument_value: "integer constant"  */
                                  { (yyval.aa) = new AnnotationArgument("",(yyvsp[0].i)); }
     break;
 
-  case 127: /* annotation_argument_value: "floating point constant"  */
+  case 129: /* annotation_argument_value: "floating point constant"  */
                                  { (yyval.aa) = new AnnotationArgument("",float((yyvsp[0].fd))); }
     break;
 
-  case 128: /* annotation_argument_value: "true"  */
+  case 130: /* annotation_argument_value: "true"  */
                                  { (yyval.aa) = new AnnotationArgument("",true); }
     break;
 
-  case 129: /* annotation_argument_value: "false"  */
+  case 131: /* annotation_argument_value: "false"  */
                                  { (yyval.aa) = new AnnotationArgument("",false); }
     break;
 
-  case 130: /* annotation_argument_value_list: annotation_argument_value  */
+  case 132: /* annotation_argument_value_list: annotation_argument_value  */
                                        {
         (yyval.aaList) = new AnnotationArgumentList();
         (yyval.aaList)->push_back(*(yyvsp[0].aa));
@@ -6200,7 +6219,7 @@ yyreduce:
     }
     break;
 
-  case 131: /* annotation_argument_value_list: annotation_argument_value_list ',' annotation_argument_value  */
+  case 133: /* annotation_argument_value_list: annotation_argument_value_list ',' annotation_argument_value  */
                                                                                 {
             (yyval.aaList) = (yyvsp[-2].aaList);
             (yyval.aaList)->push_back(*(yyvsp[0].aa));
@@ -6208,115 +6227,115 @@ yyreduce:
     }
     break;
 
-  case 132: /* annotation_argument_name: "name"  */
+  case 134: /* annotation_argument_name: "name"  */
                     { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 133: /* annotation_argument_name: "type"  */
+  case 135: /* annotation_argument_name: "type"  */
                     { (yyval.s) = new string("type"); }
     break;
 
-  case 134: /* annotation_argument_name: "in"  */
+  case 136: /* annotation_argument_name: "in"  */
                     { (yyval.s) = new string("in"); }
     break;
 
-  case 135: /* annotation_argument: annotation_argument_name '=' string_constant  */
+  case 137: /* annotation_argument: annotation_argument_name '=' string_constant  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[0].s); delete (yyvsp[-2].s); }
     break;
 
-  case 136: /* annotation_argument: annotation_argument_name '=' "name"  */
+  case 138: /* annotation_argument: annotation_argument_name '=' "name"  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[0].s); delete (yyvsp[-2].s); }
     break;
 
-  case 137: /* annotation_argument: annotation_argument_name '=' '@' '@' "name"  */
+  case 139: /* annotation_argument: annotation_argument_name '=' '@' '@' "name"  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-4].s),*(yyvsp[0].s),tokAt(scanner,(yylsp[-4]))); delete (yyvsp[0].s); delete (yyvsp[-4].s); }
     break;
 
-  case 138: /* annotation_argument: annotation_argument_name '=' "integer constant"  */
+  case 140: /* annotation_argument: annotation_argument_name '=' "integer constant"  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),(yyvsp[0].i),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
     break;
 
-  case 139: /* annotation_argument: annotation_argument_name '=' "floating point constant"  */
+  case 141: /* annotation_argument: annotation_argument_name '=' "floating point constant"  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),float((yyvsp[0].fd)),tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
     break;
 
-  case 140: /* annotation_argument: annotation_argument_name '=' "true"  */
+  case 142: /* annotation_argument: annotation_argument_name '=' "true"  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),true,tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
     break;
 
-  case 141: /* annotation_argument: annotation_argument_name '=' "false"  */
+  case 143: /* annotation_argument: annotation_argument_name '=' "false"  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[-2].s),false,tokAt(scanner,(yylsp[-2]))); delete (yyvsp[-2].s); }
     break;
 
-  case 142: /* annotation_argument: annotation_argument_name  */
+  case 144: /* annotation_argument: annotation_argument_name  */
                                                                     { (yyval.aa) = new AnnotationArgument(*(yyvsp[0].s),true,tokAt(scanner,(yylsp[0]))); delete (yyvsp[0].s); }
     break;
 
-  case 143: /* annotation_argument: annotation_argument_name '=' '(' annotation_argument_value_list ')'  */
+  case 145: /* annotation_argument: annotation_argument_name '=' '(' annotation_argument_value_list ')'  */
                                                                                           {
         { (yyval.aa) = new AnnotationArgument(*(yyvsp[-4].s),(yyvsp[-1].aaList),tokAt(scanner,(yylsp[-4]))); delete (yyvsp[-4].s); }
     }
     break;
 
-  case 144: /* annotation_argument_list: annotation_argument  */
+  case 146: /* annotation_argument_list: annotation_argument  */
                                   {
         (yyval.aaList) = ast_annotationArgumentListEntry(scanner,new AnnotationArgumentList(),(yyvsp[0].aa));
     }
     break;
 
-  case 145: /* annotation_argument_list: annotation_argument_list ',' annotation_argument  */
+  case 147: /* annotation_argument_list: annotation_argument_list ',' annotation_argument  */
                                                                     {
         (yyval.aaList) = ast_annotationArgumentListEntry(scanner,(yyvsp[-2].aaList),(yyvsp[0].aa));
     }
     break;
 
-  case 146: /* metadata_argument_list: '@' annotation_argument optional_emit_semis  */
+  case 148: /* metadata_argument_list: '@' annotation_argument optional_emit_semis  */
                                                          {
         (yyval.aaList) = ast_annotationArgumentListEntry(scanner,new AnnotationArgumentList(),(yyvsp[-1].aa));
     }
     break;
 
-  case 147: /* metadata_argument_list: metadata_argument_list '@' annotation_argument optional_emit_semis  */
+  case 149: /* metadata_argument_list: metadata_argument_list '@' annotation_argument optional_emit_semis  */
                                                                                       {
         (yyval.aaList) = ast_annotationArgumentListEntry(scanner,(yyvsp[-3].aaList),(yyvsp[-1].aa));
     }
     break;
 
-  case 148: /* optional_for_annotations: %empty  */
+  case 150: /* optional_for_annotations: %empty  */
                     {
         (yyval.aaList) = nullptr;
     }
     break;
 
-  case 149: /* optional_for_annotations: '[' annotation_argument_list ']'  */
+  case 151: /* optional_for_annotations: '[' annotation_argument_list ']'  */
                                                {
         (yyval.aaList) = (yyvsp[-1].aaList);
     }
     break;
 
-  case 150: /* optional_for_annotations: metadata_argument_list  */
+  case 152: /* optional_for_annotations: metadata_argument_list  */
                                      {
         (yyval.aaList) = (yyvsp[0].aaList);
     }
     break;
 
-  case 151: /* annotation_declaration_name: name_in_namespace  */
+  case 153: /* annotation_declaration_name: name_in_namespace  */
                                     { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 152: /* annotation_declaration_name: "require"  */
+  case 154: /* annotation_declaration_name: "require"  */
                                     { (yyval.s) = new string("require"); }
     break;
 
-  case 153: /* annotation_declaration_name: "private"  */
+  case 155: /* annotation_declaration_name: "private"  */
                                     { (yyval.s) = new string("private"); }
     break;
 
-  case 154: /* annotation_declaration_name: "template"  */
+  case 156: /* annotation_declaration_name: "template"  */
                                     { (yyval.s) = new string("template"); }
     break;
 
-  case 155: /* annotation_declaration_basic: annotation_declaration_name  */
+  case 157: /* annotation_declaration_basic: annotation_declaration_name  */
                                           {
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner,(yylsp[0]));
@@ -6337,7 +6356,7 @@ yyreduce:
     }
     break;
 
-  case 156: /* annotation_declaration_basic: annotation_declaration_name '(' annotation_argument_list ')'  */
+  case 158: /* annotation_declaration_basic: annotation_declaration_name '(' annotation_argument_list ')'  */
                                                                                  {
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner,(yylsp[-3]));
@@ -6360,13 +6379,13 @@ yyreduce:
     }
     break;
 
-  case 157: /* annotation_declaration: annotation_declaration_basic  */
+  case 159: /* annotation_declaration: annotation_declaration_basic  */
                                           {
         (yyval.fa) = (yyvsp[0].fa);
     }
     break;
 
-  case 158: /* annotation_declaration: '!' annotation_declaration  */
+  case 160: /* annotation_declaration: '!' annotation_declaration  */
                                               {
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
@@ -6379,7 +6398,7 @@ yyreduce:
     }
     break;
 
-  case 159: /* annotation_declaration: annotation_declaration "&&" annotation_declaration  */
+  case 161: /* annotation_declaration: annotation_declaration "&&" annotation_declaration  */
                                                                               {
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
@@ -6397,7 +6416,7 @@ yyreduce:
     }
     break;
 
-  case 160: /* annotation_declaration: annotation_declaration "||" annotation_declaration  */
+  case 162: /* annotation_declaration: annotation_declaration "||" annotation_declaration  */
                                                                             {
         if ( !(yyvsp[-2].fa)->annotation || !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
@@ -6415,7 +6434,7 @@ yyreduce:
     }
     break;
 
-  case 161: /* annotation_declaration: annotation_declaration "^^" annotation_declaration  */
+  case 163: /* annotation_declaration: annotation_declaration "^^" annotation_declaration  */
                                                                               {
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
@@ -6433,549 +6452,549 @@ yyreduce:
     }
     break;
 
-  case 162: /* annotation_declaration: '(' annotation_declaration ')'  */
+  case 164: /* annotation_declaration: '(' annotation_declaration ')'  */
                                             {
         (yyval.fa) = (yyvsp[-1].fa);
     }
     break;
 
-  case 163: /* annotation_declaration: "|>" annotation_declaration  */
+  case 165: /* annotation_declaration: "|>" annotation_declaration  */
                                           {
         (yyval.fa) = (yyvsp[0].fa);
         (yyvsp[0].fa)->inherited = true;
     }
     break;
 
-  case 164: /* annotation_list: annotation_declaration  */
+  case 166: /* annotation_list: annotation_declaration  */
                                     {
             (yyval.faList) = new AnnotationList();
             (yyval.faList)->push_back(AnnotationDeclarationPtr((yyvsp[0].fa)));
     }
     break;
 
-  case 165: /* annotation_list: annotation_list ',' annotation_declaration  */
+  case 167: /* annotation_list: annotation_list ',' annotation_declaration  */
                                                               {
         (yyval.faList) = (yyvsp[-2].faList);
         (yyval.faList)->push_back(AnnotationDeclarationPtr((yyvsp[0].fa)));
     }
     break;
 
-  case 166: /* optional_annotation_list: %empty  */
+  case 168: /* optional_annotation_list: %empty  */
                                        { (yyval.faList) = nullptr; }
     break;
 
-  case 167: /* optional_annotation_list: '[' annotation_list ']'  */
+  case 169: /* optional_annotation_list: '[' annotation_list ']'  */
                                        { (yyval.faList) = (yyvsp[-1].faList); }
     break;
 
-  case 168: /* optional_annotation_list_with_emit_semis: %empty  */
+  case 170: /* optional_annotation_list_with_emit_semis: %empty  */
                                        { (yyval.faList) = nullptr; }
     break;
 
-  case 169: /* optional_annotation_list_with_emit_semis: '[' annotation_list ']' optional_emit_semis  */
+  case 171: /* optional_annotation_list_with_emit_semis: '[' annotation_list ']' optional_emit_semis  */
                                                           { (yyval.faList) = (yyvsp[-2].faList); }
     break;
 
-  case 170: /* optional_function_argument_list: %empty  */
+  case 172: /* optional_function_argument_list: %empty  */
                                                 { (yyval.pVarDeclList) = nullptr; }
     break;
 
-  case 171: /* optional_function_argument_list: '(' ')'  */
+  case 173: /* optional_function_argument_list: '(' ')'  */
                                                 { (yyval.pVarDeclList) = nullptr; }
     break;
 
-  case 172: /* optional_function_argument_list: '(' function_argument_list ')'  */
+  case 174: /* optional_function_argument_list: '(' function_argument_list ')'  */
                                                 { (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList); }
     break;
 
-  case 173: /* optional_function_type: %empty  */
+  case 175: /* optional_function_type: %empty  */
         {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
     }
     break;
 
-  case 174: /* optional_function_type: ':' type_declaration  */
+  case 176: /* optional_function_type: ':' type_declaration  */
                                         {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
 
-  case 175: /* optional_function_type: "->" type_declaration  */
+  case 177: /* optional_function_type: "->" type_declaration  */
                                            {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
 
-  case 176: /* function_name: "name"  */
+  case 178: /* function_name: "name"  */
                           {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyval.s) = (yyvsp[0].s);
     }
     break;
 
-  case 177: /* function_name: "operator" '!'  */
+  case 179: /* function_name: "operator" '!'  */
                              { (yyval.s) = new string("!"); }
     break;
 
-  case 178: /* function_name: "operator" '~'  */
+  case 180: /* function_name: "operator" '~'  */
                              { (yyval.s) = new string("~"); }
     break;
 
-  case 179: /* function_name: "operator" "+="  */
+  case 181: /* function_name: "operator" "+="  */
                              { (yyval.s) = new string("+="); }
     break;
 
-  case 180: /* function_name: "operator" "-="  */
+  case 182: /* function_name: "operator" "-="  */
                              { (yyval.s) = new string("-="); }
     break;
 
-  case 181: /* function_name: "operator" "*="  */
+  case 183: /* function_name: "operator" "*="  */
                              { (yyval.s) = new string("*="); }
     break;
 
-  case 182: /* function_name: "operator" "/="  */
+  case 184: /* function_name: "operator" "/="  */
                              { (yyval.s) = new string("/="); }
     break;
 
-  case 183: /* function_name: "operator" "%="  */
+  case 185: /* function_name: "operator" "%="  */
                              { (yyval.s) = new string("%="); }
     break;
 
-  case 184: /* function_name: "operator" "&="  */
+  case 186: /* function_name: "operator" "&="  */
                              { (yyval.s) = new string("&="); }
     break;
 
-  case 185: /* function_name: "operator" "|="  */
+  case 187: /* function_name: "operator" "|="  */
                              { (yyval.s) = new string("|="); }
     break;
 
-  case 186: /* function_name: "operator" "^="  */
+  case 188: /* function_name: "operator" "^="  */
                              { (yyval.s) = new string("^="); }
     break;
 
-  case 187: /* function_name: "operator" "&&="  */
+  case 189: /* function_name: "operator" "&&="  */
                                 { (yyval.s) = new string("&&="); }
     break;
 
-  case 188: /* function_name: "operator" "||="  */
+  case 190: /* function_name: "operator" "||="  */
                                 { (yyval.s) = new string("||="); }
     break;
 
-  case 189: /* function_name: "operator" "^^="  */
+  case 191: /* function_name: "operator" "^^="  */
                                 { (yyval.s) = new string("^^="); }
     break;
 
-  case 190: /* function_name: "operator" "&&"  */
+  case 192: /* function_name: "operator" "&&"  */
                              { (yyval.s) = new string("&&"); }
     break;
 
-  case 191: /* function_name: "operator" "||"  */
+  case 193: /* function_name: "operator" "||"  */
                              { (yyval.s) = new string("||"); }
     break;
 
-  case 192: /* function_name: "operator" "^^"  */
+  case 194: /* function_name: "operator" "^^"  */
                              { (yyval.s) = new string("^^"); }
     break;
 
-  case 193: /* function_name: "operator" '+'  */
+  case 195: /* function_name: "operator" '+'  */
                              { (yyval.s) = new string("+"); }
     break;
 
-  case 194: /* function_name: "operator" '-'  */
+  case 196: /* function_name: "operator" '-'  */
                              { (yyval.s) = new string("-"); }
     break;
 
-  case 195: /* function_name: "operator" '*'  */
+  case 197: /* function_name: "operator" '*'  */
                              { (yyval.s) = new string("*"); }
     break;
 
-  case 196: /* function_name: "operator" '/'  */
+  case 198: /* function_name: "operator" '/'  */
                              { (yyval.s) = new string("/"); }
     break;
 
-  case 197: /* function_name: "operator" '%'  */
+  case 199: /* function_name: "operator" '%'  */
                              { (yyval.s) = new string("%"); }
     break;
 
-  case 198: /* function_name: "operator" '<'  */
+  case 200: /* function_name: "operator" '<'  */
                              { (yyval.s) = new string("<"); }
     break;
 
-  case 199: /* function_name: "operator" '>'  */
+  case 201: /* function_name: "operator" '>'  */
                              { (yyval.s) = new string(">"); }
     break;
 
-  case 200: /* function_name: "operator" ".."  */
+  case 202: /* function_name: "operator" ".."  */
                              { (yyval.s) = new string("interval"); }
     break;
 
-  case 201: /* function_name: "operator" "=="  */
+  case 203: /* function_name: "operator" "=="  */
                              { (yyval.s) = new string("=="); }
     break;
 
-  case 202: /* function_name: "operator" "!="  */
+  case 204: /* function_name: "operator" "!="  */
                              { (yyval.s) = new string("!="); }
     break;
 
-  case 203: /* function_name: "operator" "<="  */
+  case 205: /* function_name: "operator" "<="  */
                              { (yyval.s) = new string("<="); }
     break;
 
-  case 204: /* function_name: "operator" ">="  */
+  case 206: /* function_name: "operator" ">="  */
                              { (yyval.s) = new string(">="); }
     break;
 
-  case 205: /* function_name: "operator" '&'  */
+  case 207: /* function_name: "operator" '&'  */
                              { (yyval.s) = new string("&"); }
     break;
 
-  case 206: /* function_name: "operator" '|'  */
+  case 208: /* function_name: "operator" '|'  */
                              { (yyval.s) = new string("|"); }
     break;
 
-  case 207: /* function_name: "operator" '^'  */
+  case 209: /* function_name: "operator" '^'  */
                              { (yyval.s) = new string("^"); }
     break;
 
-  case 208: /* function_name: "++" "operator"  */
+  case 210: /* function_name: "++" "operator"  */
                              { (yyval.s) = new string("++"); }
     break;
 
-  case 209: /* function_name: "--" "operator"  */
+  case 211: /* function_name: "--" "operator"  */
                              { (yyval.s) = new string("--"); }
     break;
 
-  case 210: /* function_name: "operator" "++"  */
+  case 212: /* function_name: "operator" "++"  */
                              { (yyval.s) = new string("+++"); }
     break;
 
-  case 211: /* function_name: "operator" "--"  */
+  case 213: /* function_name: "operator" "--"  */
                              { (yyval.s) = new string("---"); }
     break;
 
-  case 212: /* function_name: "operator" "<<"  */
+  case 214: /* function_name: "operator" "<<"  */
                              { (yyval.s) = new string("<<"); }
     break;
 
-  case 213: /* function_name: "operator" ">>"  */
+  case 215: /* function_name: "operator" ">>"  */
                              { (yyval.s) = new string(">>"); }
     break;
 
-  case 214: /* function_name: "operator" "<<="  */
+  case 216: /* function_name: "operator" "<<="  */
                              { (yyval.s) = new string("<<="); }
     break;
 
-  case 215: /* function_name: "operator" ">>="  */
+  case 217: /* function_name: "operator" ">>="  */
                              { (yyval.s) = new string(">>="); }
     break;
 
-  case 216: /* function_name: "operator" "<<<"  */
+  case 218: /* function_name: "operator" "<<<"  */
                              { (yyval.s) = new string("<<<"); }
     break;
 
-  case 217: /* function_name: "operator" ">>>"  */
+  case 219: /* function_name: "operator" ">>>"  */
                              { (yyval.s) = new string(">>>"); }
     break;
 
-  case 218: /* function_name: "operator" "<<<="  */
+  case 220: /* function_name: "operator" "<<<="  */
                              { (yyval.s) = new string("<<<="); }
     break;
 
-  case 219: /* function_name: "operator" ">>>="  */
+  case 221: /* function_name: "operator" ">>>="  */
                              { (yyval.s) = new string(">>>="); }
     break;
 
-  case 220: /* function_name: "operator" '[' ']'  */
+  case 222: /* function_name: "operator" '[' ']'  */
                              { (yyval.s) = new string("[]"); }
     break;
 
-  case 221: /* function_name: "operator" '[' ']' '='  */
+  case 223: /* function_name: "operator" '[' ']' '='  */
                                  { (yyval.s) = new string("[]="); }
     break;
 
-  case 222: /* function_name: "operator" '[' ']' "<-"  */
+  case 224: /* function_name: "operator" '[' ']' "<-"  */
                                     { (yyval.s) = new string("[]<-"); }
     break;
 
-  case 223: /* function_name: "operator" '[' ']' ":="  */
+  case 225: /* function_name: "operator" '[' ']' ":="  */
                                       { (yyval.s) = new string("[]:="); }
     break;
 
-  case 224: /* function_name: "operator" '[' ']' "+="  */
+  case 226: /* function_name: "operator" '[' ']' "+="  */
                                      { (yyval.s) = new string("[]+="); }
     break;
 
-  case 225: /* function_name: "operator" '[' ']' "-="  */
+  case 227: /* function_name: "operator" '[' ']' "-="  */
                                      { (yyval.s) = new string("[]-="); }
     break;
 
-  case 226: /* function_name: "operator" '[' ']' "*="  */
+  case 228: /* function_name: "operator" '[' ']' "*="  */
                                      { (yyval.s) = new string("[]*="); }
     break;
 
-  case 227: /* function_name: "operator" '[' ']' "/="  */
+  case 229: /* function_name: "operator" '[' ']' "/="  */
                                      { (yyval.s) = new string("[]/="); }
     break;
 
-  case 228: /* function_name: "operator" '[' ']' "%="  */
+  case 230: /* function_name: "operator" '[' ']' "%="  */
                                      { (yyval.s) = new string("[]%="); }
     break;
 
-  case 229: /* function_name: "operator" '[' ']' "&="  */
+  case 231: /* function_name: "operator" '[' ']' "&="  */
                                      { (yyval.s) = new string("[]&="); }
     break;
 
-  case 230: /* function_name: "operator" '[' ']' "|="  */
+  case 232: /* function_name: "operator" '[' ']' "|="  */
                                      { (yyval.s) = new string("[]|="); }
     break;
 
-  case 231: /* function_name: "operator" '[' ']' "^="  */
+  case 233: /* function_name: "operator" '[' ']' "^="  */
                                      { (yyval.s) = new string("[]^="); }
     break;
 
-  case 232: /* function_name: "operator" '[' ']' "&&="  */
+  case 234: /* function_name: "operator" '[' ']' "&&="  */
                                         { (yyval.s) = new string("[]&&="); }
     break;
 
-  case 233: /* function_name: "operator" '[' ']' "||="  */
+  case 235: /* function_name: "operator" '[' ']' "||="  */
                                         { (yyval.s) = new string("[]||="); }
     break;
 
-  case 234: /* function_name: "operator" '[' ']' "^^="  */
+  case 236: /* function_name: "operator" '[' ']' "^^="  */
                                         { (yyval.s) = new string("[]^^="); }
     break;
 
-  case 235: /* function_name: "operator" "?[" ']'  */
+  case 237: /* function_name: "operator" "?[" ']'  */
                                 { (yyval.s) = new string("?[]"); }
     break;
 
-  case 236: /* function_name: "operator" '.'  */
+  case 238: /* function_name: "operator" '.'  */
                              { (yyval.s) = new string("."); }
     break;
 
-  case 237: /* function_name: "operator" "?."  */
+  case 239: /* function_name: "operator" "?."  */
                              { (yyval.s) = new string("?."); }
     break;
 
-  case 238: /* function_name: "operator" '.' "name"  */
+  case 240: /* function_name: "operator" '.' "name"  */
                                        { (yyval.s) = new string(".`"+*(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 239: /* function_name: "operator" '.' "name" ":="  */
+  case 241: /* function_name: "operator" '.' "name" ":="  */
                                              { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`clone"); delete (yyvsp[-1].s); }
     break;
 
-  case 240: /* function_name: "operator" '.' "name" "+="  */
+  case 242: /* function_name: "operator" '.' "name" "+="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`+="); delete (yyvsp[-1].s); }
     break;
 
-  case 241: /* function_name: "operator" '.' "name" "-="  */
+  case 243: /* function_name: "operator" '.' "name" "-="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`-="); delete (yyvsp[-1].s); }
     break;
 
-  case 242: /* function_name: "operator" '.' "name" "*="  */
+  case 244: /* function_name: "operator" '.' "name" "*="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`*="); delete (yyvsp[-1].s); }
     break;
 
-  case 243: /* function_name: "operator" '.' "name" "/="  */
+  case 245: /* function_name: "operator" '.' "name" "/="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`/="); delete (yyvsp[-1].s); }
     break;
 
-  case 244: /* function_name: "operator" '.' "name" "%="  */
+  case 246: /* function_name: "operator" '.' "name" "%="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`%="); delete (yyvsp[-1].s); }
     break;
 
-  case 245: /* function_name: "operator" '.' "name" "&="  */
+  case 247: /* function_name: "operator" '.' "name" "&="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`&="); delete (yyvsp[-1].s); }
     break;
 
-  case 246: /* function_name: "operator" '.' "name" "|="  */
+  case 248: /* function_name: "operator" '.' "name" "|="  */
                                           { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`|="); delete (yyvsp[-1].s); }
     break;
 
-  case 247: /* function_name: "operator" '.' "name" "^="  */
+  case 249: /* function_name: "operator" '.' "name" "^="  */
                                            { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`^="); delete (yyvsp[-1].s); }
     break;
 
-  case 248: /* function_name: "operator" '.' "name" "&&="  */
+  case 250: /* function_name: "operator" '.' "name" "&&="  */
                                               { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`&&="); delete (yyvsp[-1].s); }
     break;
 
-  case 249: /* function_name: "operator" '.' "name" "||="  */
+  case 251: /* function_name: "operator" '.' "name" "||="  */
                                             { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`||="); delete (yyvsp[-1].s); }
     break;
 
-  case 250: /* function_name: "operator" '.' "name" "^^="  */
+  case 252: /* function_name: "operator" '.' "name" "^^="  */
                                               { (yyval.s) = new string(".`"+*(yyvsp[-1].s)+"`^^="); delete (yyvsp[-1].s); }
     break;
 
-  case 251: /* function_name: "operator" "?." "name"  */
+  case 253: /* function_name: "operator" "?." "name"  */
                                        { (yyval.s) = new string("?.`"+*(yyvsp[0].s)); delete (yyvsp[0].s);}
     break;
 
-  case 252: /* function_name: "operator" ":="  */
+  case 254: /* function_name: "operator" ":="  */
                                 { (yyval.s) = new string("clone"); }
     break;
 
-  case 253: /* function_name: "operator" "delete"  */
+  case 255: /* function_name: "operator" "delete"  */
                                 { (yyval.s) = new string("finalize"); }
     break;
 
-  case 254: /* function_name: "operator" "??"  */
+  case 256: /* function_name: "operator" "??"  */
                            { (yyval.s) = new string("??"); }
     break;
 
-  case 255: /* function_name: "operator" "is"  */
+  case 257: /* function_name: "operator" "is"  */
                             { (yyval.s) = new string("`is"); }
     break;
 
-  case 256: /* function_name: "operator" "as"  */
+  case 258: /* function_name: "operator" "as"  */
                             { (yyval.s) = new string("`as"); }
     break;
 
-  case 257: /* function_name: "operator" "is" "name"  */
+  case 259: /* function_name: "operator" "is" "name"  */
                                        { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`is`" + *(yyvsp[0].s); }
     break;
 
-  case 258: /* function_name: "operator" "as" "name"  */
+  case 260: /* function_name: "operator" "as" "name"  */
                                        { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`as`" + *(yyvsp[0].s); }
     break;
 
-  case 259: /* function_name: "operator" "is" das_type_name  */
+  case 261: /* function_name: "operator" "is" das_type_name  */
                                                 { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`is`" + *(yyvsp[0].s); }
     break;
 
-  case 260: /* function_name: "operator" "as" das_type_name  */
+  case 262: /* function_name: "operator" "as" das_type_name  */
                                                 { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "`as`" + *(yyvsp[0].s); }
     break;
 
-  case 261: /* function_name: "operator" '?' "as"  */
+  case 263: /* function_name: "operator" '?' "as"  */
                                 { (yyval.s) = new string("?as"); }
     break;
 
-  case 262: /* function_name: "operator" '?' "as" "name"  */
+  case 264: /* function_name: "operator" '?' "as" "name"  */
                                            { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "?as`" + *(yyvsp[0].s); }
     break;
 
-  case 263: /* function_name: "operator" '?' "as" das_type_name  */
+  case 265: /* function_name: "operator" '?' "as" das_type_name  */
                                                     { (yyval.s) = (yyvsp[0].s); *(yyvsp[0].s) = "?as`" + *(yyvsp[0].s); }
     break;
 
-  case 264: /* function_name: das_type_name  */
+  case 266: /* function_name: das_type_name  */
                             { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 265: /* das_type_name: "bool"  */
+  case 267: /* das_type_name: "bool"  */
                      { (yyval.s) = new string("bool"); }
     break;
 
-  case 266: /* das_type_name: "string"  */
+  case 268: /* das_type_name: "string"  */
                      { (yyval.s) = new string("string"); }
     break;
 
-  case 267: /* das_type_name: "int"  */
+  case 269: /* das_type_name: "int"  */
                      { (yyval.s) = new string("int"); }
     break;
 
-  case 268: /* das_type_name: "int2"  */
+  case 270: /* das_type_name: "int2"  */
                      { (yyval.s) = new string("int2"); }
     break;
 
-  case 269: /* das_type_name: "int3"  */
+  case 271: /* das_type_name: "int3"  */
                      { (yyval.s) = new string("int3"); }
     break;
 
-  case 270: /* das_type_name: "int4"  */
+  case 272: /* das_type_name: "int4"  */
                      { (yyval.s) = new string("int4"); }
     break;
 
-  case 271: /* das_type_name: "uint"  */
+  case 273: /* das_type_name: "uint"  */
                      { (yyval.s) = new string("uint"); }
     break;
 
-  case 272: /* das_type_name: "uint2"  */
+  case 274: /* das_type_name: "uint2"  */
                      { (yyval.s) = new string("uint2"); }
     break;
 
-  case 273: /* das_type_name: "uint3"  */
+  case 275: /* das_type_name: "uint3"  */
                      { (yyval.s) = new string("uint3"); }
     break;
 
-  case 274: /* das_type_name: "uint4"  */
+  case 276: /* das_type_name: "uint4"  */
                      { (yyval.s) = new string("uint4"); }
     break;
 
-  case 275: /* das_type_name: "float"  */
+  case 277: /* das_type_name: "float"  */
                      { (yyval.s) = new string("float"); }
     break;
 
-  case 276: /* das_type_name: "float2"  */
+  case 278: /* das_type_name: "float2"  */
                      { (yyval.s) = new string("float2"); }
     break;
 
-  case 277: /* das_type_name: "float3"  */
+  case 279: /* das_type_name: "float3"  */
                      { (yyval.s) = new string("float3"); }
     break;
 
-  case 278: /* das_type_name: "float4"  */
+  case 280: /* das_type_name: "float4"  */
                      { (yyval.s) = new string("float4"); }
     break;
 
-  case 279: /* das_type_name: "range"  */
+  case 281: /* das_type_name: "range"  */
                      { (yyval.s) = new string("range"); }
     break;
 
-  case 280: /* das_type_name: "urange"  */
+  case 282: /* das_type_name: "urange"  */
                      { (yyval.s) = new string("urange"); }
     break;
 
-  case 281: /* das_type_name: "range64"  */
+  case 283: /* das_type_name: "range64"  */
                      { (yyval.s) = new string("range64"); }
     break;
 
-  case 282: /* das_type_name: "urange64"  */
+  case 284: /* das_type_name: "urange64"  */
                      { (yyval.s) = new string("urange64"); }
     break;
 
-  case 283: /* das_type_name: "int64"  */
+  case 285: /* das_type_name: "int64"  */
                      { (yyval.s) = new string("int64"); }
     break;
 
-  case 284: /* das_type_name: "uint64"  */
+  case 286: /* das_type_name: "uint64"  */
                      { (yyval.s) = new string("uint64"); }
     break;
 
-  case 285: /* das_type_name: "double"  */
+  case 287: /* das_type_name: "double"  */
                      { (yyval.s) = new string("double"); }
     break;
 
-  case 286: /* das_type_name: "int8"  */
+  case 288: /* das_type_name: "int8"  */
                      { (yyval.s) = new string("int8"); }
     break;
 
-  case 287: /* das_type_name: "uint8"  */
+  case 289: /* das_type_name: "uint8"  */
                      { (yyval.s) = new string("uint8"); }
     break;
 
-  case 288: /* das_type_name: "int16"  */
+  case 290: /* das_type_name: "int16"  */
                      { (yyval.s) = new string("int16"); }
     break;
 
-  case 289: /* das_type_name: "uint16"  */
+  case 291: /* das_type_name: "uint16"  */
                      { (yyval.s) = new string("uint16"); }
     break;
 
-  case 290: /* optional_template: %empty  */
+  case 292: /* optional_template: %empty  */
                                         { (yyval.b) = false; }
     break;
 
-  case 291: /* optional_template: "template"  */
+  case 293: /* optional_template: "template"  */
                                         { (yyval.b) = true; }
     break;
 
-  case 292: /* global_function_declaration: optional_annotation_list_with_emit_semis "def" optional_template function_declaration  */
+  case 294: /* global_function_declaration: optional_annotation_list_with_emit_semis "def" optional_template function_declaration  */
                                                                                                                               {
         (yyvsp[0].pFuncDecl)->atDecl = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
         (yyvsp[0].pFuncDecl)->isTemplate = (yyvsp[-1].b);
@@ -6994,25 +7013,25 @@ yyreduce:
     }
     break;
 
-  case 293: /* optional_public_or_private_function: %empty  */
+  case 295: /* optional_public_or_private_function: %empty  */
                         { (yyval.b) = yyextra->g_thisStructure ? !yyextra->g_thisStructure->privateStructure : yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 294: /* optional_public_or_private_function: "private"  */
+  case 296: /* optional_public_or_private_function: "private"  */
                         { (yyval.b) = false; }
     break;
 
-  case 295: /* optional_public_or_private_function: "public"  */
+  case 297: /* optional_public_or_private_function: "public"  */
                         { (yyval.b) = true; }
     break;
 
-  case 296: /* function_declaration_header: function_name optional_function_argument_list optional_function_type  */
+  case 298: /* function_declaration_header: function_name optional_function_argument_list optional_function_type  */
                                                                                                 {
         (yyval.pFuncDecl) = ast_functionDeclarationHeader(scanner,(yyvsp[-2].s),(yyvsp[-1].pVarDeclList),(yyvsp[0].pTypeDecl),tokAt(scanner,(yylsp[-2])));
     }
     break;
 
-  case 297: /* $@16: %empty  */
+  case 299: /* $@16: %empty  */
                                                      {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -7021,7 +7040,7 @@ yyreduce:
     }
     break;
 
-  case 298: /* function_declaration: optional_public_or_private_function $@16 function_declaration_header optional_emit_semis block_or_simple_block  */
+  case 300: /* function_declaration: optional_public_or_private_function $@16 function_declaration_header optional_emit_semis block_or_simple_block  */
                                                                                          {
         (yyvsp[-2].pFuncDecl)->body = (yyvsp[0].pExpression);
         (yyvsp[-2].pFuncDecl)->privateFunction = !(yyvsp[-4].b);
@@ -7033,43 +7052,43 @@ yyreduce:
     }
     break;
 
-  case 299: /* expression_block_finally: %empty  */
+  case 301: /* expression_block_finally: %empty  */
         {
         (yyval.pExpression) = nullptr;
     }
     break;
 
-  case 300: /* $@17: %empty  */
+  case 302: /* $@17: %empty  */
                   {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 301: /* $@18: %empty  */
+  case 303: /* $@18: %empty  */
                              {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 302: /* expression_block_finally: "finally" $@17 '{' expressions $@18 '}'  */
+  case 304: /* expression_block_finally: "finally" $@17 '{' expressions $@18 '}'  */
           {
         (yyval.pExpression) = (yyvsp[-2].pExpression);
     }
     break;
 
-  case 303: /* $@19: %empty  */
+  case 305: /* $@19: %empty  */
         {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 304: /* $@20: %empty  */
+  case 306: /* $@20: %empty  */
                                       {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 305: /* expression_block: $@19 '{' expressions $@20 '}' expression_block_finally  */
+  case 307: /* expression_block: $@19 '{' expressions $@20 '}' expression_block_finally  */
                                         {
         (yyval.pExpression) = (yyvsp[-3].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-4]),(yylsp[0]));
@@ -7082,7 +7101,7 @@ yyreduce:
     }
     break;
 
-  case 306: /* expr_call_pipe_no_bracket: expr_call expr_full_block_assumed_piped  */
+  case 308: /* expr_call_pipe_no_bracket: expr_call expr_full_block_assumed_piped  */
                                                            {
         if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
             ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back((yyvsp[0].pExpression));
@@ -7094,7 +7113,7 @@ yyreduce:
     }
     break;
 
-  case 307: /* expr_call_pipe_no_bracket: expr_method_call_no_bracket expr_full_block_assumed_piped  */
+  case 309: /* expr_call_pipe_no_bracket: expr_method_call_no_bracket expr_full_block_assumed_piped  */
                                                                              {
         if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
             ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back((yyvsp[0].pExpression));
@@ -7106,7 +7125,7 @@ yyreduce:
     }
     break;
 
-  case 308: /* expr_call_pipe_no_bracket: expr_field_no_bracket expr_full_block_assumed_piped  */
+  case 310: /* expr_call_pipe_no_bracket: expr_field_no_bracket expr_full_block_assumed_piped  */
                                                                        {
         if ( (yyvsp[-1].pExpression)->rtti_isCallLikeExpr() ) {
             ((ExprLooksLikeCall *)(yyvsp[-1].pExpression))->arguments.push_back((yyvsp[0].pExpression));
@@ -7118,95 +7137,95 @@ yyreduce:
     }
     break;
 
-  case 309: /* expression_any: SEMICOLON  */
+  case 311: /* expression_any: SEMICOLON  */
                                                   { (yyval.pExpression) = nullptr; }
     break;
 
-  case 310: /* expression_any: expr_assign_no_bracket SEMICOLON  */
+  case 312: /* expression_any: expr_assign_no_bracket SEMICOLON  */
                                                     { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 311: /* expression_any: expression_delete SEMICOLON  */
+  case 313: /* expression_any: expression_delete SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 312: /* expression_any: expression_let  */
+  case 314: /* expression_any: expression_let  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 313: /* expression_any: expression_while_loop  */
+  case 315: /* expression_any: expression_while_loop  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 314: /* expression_any: expression_unsafe  */
+  case 316: /* expression_any: expression_unsafe  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 315: /* expression_any: expression_with  */
+  case 317: /* expression_any: expression_with  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 316: /* expression_any: expression_with_alias SEMICOLON  */
+  case 318: /* expression_any: expression_with_alias SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 317: /* expression_any: expression_for_loop  */
+  case 319: /* expression_any: expression_for_loop  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 318: /* expression_any: expression_break SEMICOLON  */
+  case 320: /* expression_any: expression_break SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 319: /* expression_any: expression_continue SEMICOLON  */
+  case 321: /* expression_any: expression_continue SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 320: /* expression_any: expression_return SEMICOLON  */
+  case 322: /* expression_any: expression_return SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 321: /* expression_any: expression_yield SEMICOLON  */
+  case 323: /* expression_any: expression_yield SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 322: /* expression_any: expression_if_then_else  */
+  case 324: /* expression_any: expression_if_then_else  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 323: /* expression_any: expression_if_then_else_oneliner  */
+  case 325: /* expression_any: expression_if_then_else_oneliner  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 324: /* expression_any: expression_try_catch  */
+  case 326: /* expression_any: expression_try_catch  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 325: /* expression_any: expression_label SEMICOLON  */
+  case 327: /* expression_any: expression_label SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 326: /* expression_any: expression_goto SEMICOLON  */
+  case 328: /* expression_any: expression_goto SEMICOLON  */
                                                   { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 327: /* expression_any: "pass" SEMICOLON  */
+  case 329: /* expression_any: "pass" SEMICOLON  */
                                                   { (yyval.pExpression) = nullptr; }
     break;
 
-  case 328: /* $@21: %empty  */
+  case 330: /* $@21: %empty  */
                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 329: /* $@22: %empty  */
+  case 331: /* $@22: %empty  */
                          {
         yyextra->pop_nesteds();
     }
     break;
 
-  case 330: /* expression_any: '{' $@21 expressions $@22 '}' expression_block_finally  */
+  case 332: /* expression_any: '{' $@21 expressions $@22 '}' expression_block_finally  */
                                         {
         (yyval.pExpression) = (yyvsp[-3].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-5]),(yylsp[0]));
@@ -7219,7 +7238,7 @@ yyreduce:
     }
     break;
 
-  case 331: /* expressions: %empty  */
+  case 333: /* expressions: %empty  */
         {
         (yyval.pExpression) = new ExprBlock();
         (yyval.pExpression)->at = LineInfo(yyextra->g_FileAccessStack.back(),
@@ -7227,7 +7246,7 @@ yyreduce:
     }
     break;
 
-  case 332: /* expressions: expressions expression_any  */
+  case 334: /* expressions: expressions expression_any  */
                                                         {
         (yyval.pExpression) = (yyvsp[-1].pExpression);
         if ( (yyvsp[0].pExpression) ) {
@@ -7236,47 +7255,47 @@ yyreduce:
     }
     break;
 
-  case 333: /* expressions: expressions error  */
+  case 335: /* expressions: expressions error  */
                                  {
         (void)(yyvsp[-1].pExpression); /* gc_node — don't delete Expression */ (yyval.pExpression) = nullptr; YYABORT;
     }
     break;
 
-  case 334: /* optional_expr_list: %empty  */
+  case 336: /* optional_expr_list: %empty  */
         { (yyval.pExpression) = nullptr; }
     break;
 
-  case 335: /* optional_expr_list: expr_list optional_comma  */
+  case 337: /* optional_expr_list: expr_list optional_comma  */
                                             { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 336: /* optional_expr_map_tuple_list: %empty  */
+  case 338: /* optional_expr_map_tuple_list: %empty  */
         { (yyval.pExpression) = nullptr; }
     break;
 
-  case 337: /* optional_expr_map_tuple_list: expr_map_tuple_list optional_comma  */
+  case 339: /* optional_expr_map_tuple_list: expr_map_tuple_list optional_comma  */
                                                       { (yyval.pExpression) = (yyvsp[-1].pExpression); }
     break;
 
-  case 338: /* type_declaration_no_options_list: type_declaration  */
+  case 340: /* type_declaration_no_options_list: type_declaration  */
                                {
         (yyval.pTypeDeclList) = new vector<Expression *>();
         (yyval.pTypeDeclList)->push_back(new ExprTypeDecl(tokAt(scanner,(yylsp[0])),(yyvsp[0].pTypeDecl)));
     }
     break;
 
-  case 339: /* type_declaration_no_options_list: type_declaration_no_options_list c_or_s type_declaration  */
+  case 341: /* type_declaration_no_options_list: type_declaration_no_options_list c_or_s type_declaration  */
                                                                               {
         (yyval.pTypeDeclList) = (yyvsp[-2].pTypeDeclList);
         (yyval.pTypeDeclList)->push_back(new ExprTypeDecl(tokAt(scanner,(yylsp[0])),(yyvsp[0].pTypeDecl)));
     }
     break;
 
-  case 340: /* name_in_namespace: "name"  */
+  case 342: /* name_in_namespace: "name"  */
                                                { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 341: /* name_in_namespace: "name" "::" "name"  */
+  case 343: /* name_in_namespace: "name" "::" "name"  */
                                                {
             auto ita = yyextra->das_module_alias.find(*(yyvsp[-2].s));
             if ( ita == yyextra->das_module_alias.end() ) {
@@ -7290,17 +7309,17 @@ yyreduce:
         }
     break;
 
-  case 342: /* name_in_namespace: "::" "name"  */
+  case 344: /* name_in_namespace: "::" "name"  */
                                                { *(yyvsp[0].s) = "::" + *(yyvsp[0].s); (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 343: /* expression_delete: "delete" expr  */
+  case 345: /* expression_delete: "delete" expr  */
                                       {
         (yyval.pExpression) = new ExprDelete(tokAt(scanner,(yylsp[-1])), (yyvsp[0].pExpression));
     }
     break;
 
-  case 344: /* expression_delete: "delete" "explicit" expr  */
+  case 346: /* expression_delete: "delete" "explicit" expr  */
                                                    {
         auto delExpr = new ExprDelete(tokAt(scanner,(yylsp[-2])), (yyvsp[0].pExpression));
         delExpr->native = true;
@@ -7308,47 +7327,47 @@ yyreduce:
     }
     break;
 
-  case 345: /* $@23: %empty  */
+  case 347: /* $@23: %empty  */
            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 346: /* $@24: %empty  */
+  case 348: /* $@24: %empty  */
                                                                            { yyextra->das_arrow_depth --; }
     break;
 
-  case 347: /* new_type_declaration: '<' $@23 type_declaration '>' $@24  */
+  case 349: /* new_type_declaration: '<' $@23 type_declaration '>' $@24  */
                                                                                                             {
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 348: /* new_type_declaration: structure_type_declaration  */
+  case 350: /* new_type_declaration: structure_type_declaration  */
                                                {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 349: /* expr_new: "new" new_type_declaration  */
+  case 351: /* expr_new: "new" new_type_declaration  */
                                                        {
         (yyval.pExpression) = new ExprNew(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pTypeDecl),false);
     }
     break;
 
-  case 350: /* expr_new: "new" new_type_declaration '(' use_initializer ')'  */
+  case 352: /* expr_new: "new" new_type_declaration '(' use_initializer ')'  */
                                                                                      {
         (yyval.pExpression) = new ExprNew(tokAt(scanner,(yylsp[-4])),(yyvsp[-3].pTypeDecl),true);
         ((ExprNew *)(yyval.pExpression))->initializer = (yyvsp[-1].b);
     }
     break;
 
-  case 351: /* expr_new: "new" new_type_declaration '(' expr_list ')'  */
+  case 353: /* expr_new: "new" new_type_declaration '(' expr_list ')'  */
                                                                                     {
         auto pNew = new ExprNew(tokAt(scanner,(yylsp[-4])),(yyvsp[-3].pTypeDecl),true);
         (yyval.pExpression) = parseFunctionArguments(pNew,(yyvsp[-1].pExpression));
     }
     break;
 
-  case 352: /* expr_new: "new" new_type_declaration '(' make_struct_single ')'  */
+  case 354: /* expr_new: "new" new_type_declaration '(' make_struct_single ')'  */
                                                                                       {
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-3]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-3].pTypeDecl);
@@ -7358,7 +7377,7 @@ yyreduce:
     }
     break;
 
-  case 353: /* expr_new: "new" new_type_declaration '(' "uninitialized" make_struct_single ')'  */
+  case 355: /* expr_new: "new" new_type_declaration '(' "uninitialized" make_struct_single ')'  */
                                                                                                         {
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-4]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-4].pTypeDecl);
@@ -7368,33 +7387,33 @@ yyreduce:
     }
     break;
 
-  case 354: /* expr_new: "new" make_decl  */
+  case 356: /* expr_new: "new" make_decl  */
                                     {
         (yyval.pExpression) = new ExprAscend(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 355: /* expression_break: "break"  */
+  case 357: /* expression_break: "break"  */
                        { (yyval.pExpression) = new ExprBreak(tokAt(scanner,(yylsp[0]))); }
     break;
 
-  case 356: /* expression_continue: "continue"  */
+  case 358: /* expression_continue: "continue"  */
                           { (yyval.pExpression) = new ExprContinue(tokAt(scanner,(yylsp[0]))); }
     break;
 
-  case 357: /* expression_return: "return"  */
+  case 359: /* expression_return: "return"  */
                         {
         (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[0])),nullptr);
     }
     break;
 
-  case 358: /* expression_return: "return" expr  */
+  case 360: /* expression_return: "return" expr  */
                                       {
         (yyval.pExpression) = new ExprReturn(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 359: /* expression_return: "return" "<-" expr  */
+  case 361: /* expression_return: "return" "<-" expr  */
                                              {
         auto pRet = new ExprReturn(tokAt(scanner,(yylsp[-2])),(yyvsp[0].pExpression));
         pRet->moveSemantics = true;
@@ -7402,13 +7421,13 @@ yyreduce:
     }
     break;
 
-  case 360: /* expression_yield: "yield" expr  */
+  case 362: /* expression_yield: "yield" expr  */
                                      {
         (yyval.pExpression) = new ExprYield(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression));
     }
     break;
 
-  case 361: /* expression_yield: "yield" "<-" expr  */
+  case 363: /* expression_yield: "yield" "<-" expr  */
                                             {
         auto pRet = new ExprYield(tokAt(scanner,(yylsp[-2])),(yyvsp[0].pExpression));
         pRet->moveSemantics = true;
@@ -7416,41 +7435,41 @@ yyreduce:
     }
     break;
 
-  case 362: /* expression_try_catch: "try" expression_block "recover" expression_block  */
+  case 364: /* expression_try_catch: "try" expression_block "recover" expression_block  */
                                                                                        {
         (yyval.pExpression) = new ExprTryCatch(tokAt(scanner,(yylsp[-3])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
     }
     break;
 
-  case 363: /* kwd_let_var_or_nothing: "let"  */
+  case 365: /* kwd_let_var_or_nothing: "let"  */
                  { (yyval.b) = true; }
     break;
 
-  case 364: /* kwd_let_var_or_nothing: "var"  */
+  case 366: /* kwd_let_var_or_nothing: "var"  */
                  { (yyval.b) = false; }
     break;
 
-  case 365: /* kwd_let_var_or_nothing: %empty  */
+  case 367: /* kwd_let_var_or_nothing: %empty  */
                     { (yyval.b) = true; }
     break;
 
-  case 366: /* kwd_let: "let"  */
+  case 368: /* kwd_let: "let"  */
                  { (yyval.b) = true; }
     break;
 
-  case 367: /* kwd_let: "var"  */
+  case 369: /* kwd_let: "var"  */
                  { (yyval.b) = false; }
     break;
 
-  case 368: /* optional_in_scope: "inscope"  */
+  case 370: /* optional_in_scope: "inscope"  */
                     { (yyval.b) = true; }
     break;
 
-  case 369: /* optional_in_scope: %empty  */
+  case 371: /* optional_in_scope: %empty  */
                      { (yyval.b) = false; }
     break;
 
-  case 370: /* tuple_expansion: "name"  */
+  case 372: /* tuple_expansion: "name"  */
                     {
         (yyval.pNameList) = new vector<string>();
         (yyval.pNameList)->push_back(*(yyvsp[0].s));
@@ -7458,7 +7477,7 @@ yyreduce:
     }
     break;
 
-  case 371: /* tuple_expansion: tuple_expansion ',' "name"  */
+  case 373: /* tuple_expansion: tuple_expansion ',' "name"  */
                                              {
         (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
         delete (yyvsp[0].s);
@@ -7466,7 +7485,7 @@ yyreduce:
     }
     break;
 
-  case 372: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
+  case 374: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                                 {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-6].pNameList),tokAt(scanner,(yylsp[-6])),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -7475,7 +7494,7 @@ yyreduce:
     }
     break;
 
-  case 373: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr SEMICOLON  */
+  case 375: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                         {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-5]));
@@ -7487,47 +7506,47 @@ yyreduce:
     }
     break;
 
-  case 374: /* expression_let: kwd_let optional_in_scope let_variable_declaration  */
+  case 376: /* expression_let: kwd_let optional_in_scope let_variable_declaration  */
                                                                  {
         (yyval.pExpression) = ast_Let(scanner,(yyvsp[-2].b),(yyvsp[-1].b),(yyvsp[0].pVarDecl),tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 375: /* expression_let: kwd_let optional_in_scope tuple_expansion_variable_declaration  */
+  case 377: /* expression_let: kwd_let optional_in_scope tuple_expansion_variable_declaration  */
                                                                              {
         (yyval.pExpression) = ast_Let(scanner,(yyvsp[-2].b),(yyvsp[-1].b),(yyvsp[0].pVarDecl),tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 376: /* expression_let: kwd_let optional_in_scope '{' variable_declaration_list '}'  */
+  case 378: /* expression_let: kwd_let optional_in_scope '{' variable_declaration_list '}'  */
                                                                                {
         (yyval.pExpression) = ast_LetList(scanner,(yyvsp[-4].b),(yyvsp[-3].b),*(yyvsp[-1].pVarDeclList),tokAt(scanner,(yylsp[-4])),tokAt(scanner,(yylsp[-1])));
     }
     break;
 
-  case 377: /* $@25: %empty  */
+  case 379: /* $@25: %empty  */
                           { yyextra->das_arrow_depth ++; }
     break;
 
-  case 378: /* $@26: %empty  */
+  case 380: /* $@26: %empty  */
                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 379: /* expr_cast: "cast" '<' $@25 type_declaration_no_options '>' $@26 expr_no_bracket  */
+  case 381: /* expr_cast: "cast" '<' $@25 type_declaration_no_options '>' $@26 expr_no_bracket  */
                                                                                                                                                            {
         (yyval.pExpression) = new ExprCast(tokAt(scanner,(yylsp[-6])),(yyvsp[0].pExpression),(yyvsp[-3].pTypeDecl));
     }
     break;
 
-  case 380: /* $@27: %empty  */
+  case 382: /* $@27: %empty  */
                             { yyextra->das_arrow_depth ++; }
     break;
 
-  case 381: /* $@28: %empty  */
+  case 383: /* $@28: %empty  */
                                                                                                    { yyextra->das_arrow_depth --; }
     break;
 
-  case 382: /* expr_cast: "upcast" '<' $@27 type_declaration_no_options '>' $@28 expr_no_bracket  */
+  case 384: /* expr_cast: "upcast" '<' $@27 type_declaration_no_options '>' $@28 expr_no_bracket  */
                                                                                                                                                              {
         auto pCast = new ExprCast(tokAt(scanner,(yylsp[-6])),(yyvsp[0].pExpression),(yyvsp[-3].pTypeDecl));
         pCast->upcast = true;
@@ -7535,15 +7554,15 @@ yyreduce:
     }
     break;
 
-  case 383: /* $@29: %empty  */
+  case 385: /* $@29: %empty  */
                                  { yyextra->das_arrow_depth ++; }
     break;
 
-  case 384: /* $@30: %empty  */
+  case 386: /* $@30: %empty  */
                                                                                                         { yyextra->das_arrow_depth --; }
     break;
 
-  case 385: /* expr_cast: "reinterpret" '<' $@29 type_declaration_no_options '>' $@30 expr_no_bracket  */
+  case 387: /* expr_cast: "reinterpret" '<' $@29 type_declaration_no_options '>' $@30 expr_no_bracket  */
                                                                                                                                                                   {
         auto pCast = new ExprCast(tokAt(scanner,(yylsp[-6])),(yyvsp[0].pExpression),(yyvsp[-3].pTypeDecl));
         pCast->reinterpret = true;
@@ -7551,21 +7570,21 @@ yyreduce:
     }
     break;
 
-  case 386: /* $@31: %empty  */
+  case 388: /* $@31: %empty  */
                          { yyextra->das_arrow_depth ++; }
     break;
 
-  case 387: /* $@32: %empty  */
+  case 389: /* $@32: %empty  */
                                                                                      { yyextra->das_arrow_depth --; }
     break;
 
-  case 388: /* expr_type_decl: "type" '<' $@31 type_declaration '>' $@32  */
+  case 390: /* expr_type_decl: "type" '<' $@31 type_declaration '>' $@32  */
                                                                                                                       {
         (yyval.pExpression) = new ExprTypeDecl(tokAt(scanner,(yylsp[-5])),(yyvsp[-2].pTypeDecl));
     }
     break;
 
-  case 389: /* expr_type_info: "typeinfo" name_in_namespace '(' expr ')'  */
+  case 391: /* expr_type_info: "typeinfo" name_in_namespace '(' expr ')'  */
                                                                           {
             if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
                 auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
@@ -7578,7 +7597,7 @@ yyreduce:
     }
     break;
 
-  case 390: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" '>' '(' expr ')'  */
+  case 392: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" '>' '(' expr ')'  */
                                                                                                 {
             if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
                 auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
@@ -7592,7 +7611,7 @@ yyreduce:
     }
     break;
 
-  case 391: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" c_or_s "name" '>' '(' expr ')'  */
+  case 393: /* expr_type_info: "typeinfo" name_in_namespace '<' "name" c_or_s "name" '>' '(' expr ')'  */
                                                                                                                         {
             if ( (yyvsp[-1].pExpression)->rtti_isTypeDecl() ) {
                 auto ptd = (ExprTypeDecl *)(yyvsp[-1].pExpression);
@@ -7607,35 +7626,35 @@ yyreduce:
     }
     break;
 
-  case 392: /* expr_list: expr  */
+  case 394: /* expr_list: expr  */
                       {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 393: /* expr_list: "<-" expr  */
+  case 395: /* expr_list: "<-" expr  */
                              {
             (yyval.pExpression) = ast_makeMoveArgument(scanner, (yyvsp[0].pExpression), tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 394: /* expr_list: expr_list ',' expr  */
+  case 396: /* expr_list: expr_list ',' expr  */
                                         {
             (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-2])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
     }
     break;
 
-  case 395: /* expr_list: expr_list ',' "<-" expr  */
+  case 397: /* expr_list: expr_list ',' "<-" expr  */
                                                    {
             (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-3])),(yyvsp[-3].pExpression),ast_makeMoveArgument(scanner, (yyvsp[0].pExpression), tokAt(scanner,(yylsp[0]))));
     }
     break;
 
-  case 396: /* block_or_simple_block: expression_block  */
+  case 398: /* block_or_simple_block: expression_block  */
                                     { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 397: /* block_or_simple_block: "=>" expr_no_bracket  */
+  case 399: /* block_or_simple_block: "=>" expr_no_bracket  */
                                                    {
             auto retE = new ExprReturn(tokAt(scanner,(yylsp[-1])), (yyvsp[0].pExpression));
             auto blkE = new ExprBlock();
@@ -7645,7 +7664,7 @@ yyreduce:
     }
     break;
 
-  case 398: /* block_or_simple_block: "=>" "<-" expr_no_bracket  */
+  case 400: /* block_or_simple_block: "=>" "<-" expr_no_bracket  */
                                                           {
             auto retE = new ExprReturn(tokAt(scanner,(yylsp[-2])), (yyvsp[0].pExpression));
             retE->moveSemantics = true;
@@ -7656,39 +7675,39 @@ yyreduce:
     }
     break;
 
-  case 399: /* block_or_lambda: '$'  */
+  case 401: /* block_or_lambda: '$'  */
                 { (yyval.i) = 0;   /* block */  }
     break;
 
-  case 400: /* block_or_lambda: '@'  */
+  case 402: /* block_or_lambda: '@'  */
                 { (yyval.i) = 1;   /* lambda */ }
     break;
 
-  case 401: /* block_or_lambda: '@' '@'  */
+  case 403: /* block_or_lambda: '@' '@'  */
                 { (yyval.i) = 2;   /* local function */ }
     break;
 
-  case 402: /* capture_entry: '&' "name"  */
+  case 404: /* capture_entry: '&' "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_reference); delete (yyvsp[0].s); }
     break;
 
-  case 403: /* capture_entry: '=' "name"  */
+  case 405: /* capture_entry: '=' "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_copy); delete (yyvsp[0].s); }
     break;
 
-  case 404: /* capture_entry: "<-" "name"  */
+  case 406: /* capture_entry: "<-" "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_move); delete (yyvsp[0].s); }
     break;
 
-  case 405: /* capture_entry: ":=" "name"  */
+  case 407: /* capture_entry: ":=" "name"  */
                                     { (yyval.pCapt) = new CaptureEntry(*(yyvsp[0].s),CaptureMode::capture_by_clone); delete (yyvsp[0].s); }
     break;
 
-  case 406: /* capture_entry: "name" '(' "name" ')'  */
+  case 408: /* capture_entry: "name" '(' "name" ')'  */
                                     { (yyval.pCapt) = ast_makeCaptureEntry(scanner,tokAt(scanner,(yylsp[-3])),*(yyvsp[-3].s),*(yyvsp[-1].s)); delete (yyvsp[-3].s); delete (yyvsp[-1].s); }
     break;
 
-  case 407: /* capture_list: capture_entry  */
+  case 409: /* capture_list: capture_entry  */
                          {
         (yyval.pCaptList) = new vector<CaptureEntry>();
         (yyval.pCaptList)->push_back(*(yyvsp[0].pCapt));
@@ -7696,7 +7715,7 @@ yyreduce:
     }
     break;
 
-  case 408: /* capture_list: capture_list ',' capture_entry  */
+  case 410: /* capture_list: capture_list ',' capture_entry  */
                                                {
         (yyvsp[-2].pCaptList)->push_back(*(yyvsp[0].pCapt));
         delete (yyvsp[0].pCapt);
@@ -7704,145 +7723,145 @@ yyreduce:
     }
     break;
 
-  case 409: /* optional_capture_list: %empty  */
+  case 411: /* optional_capture_list: %empty  */
         { (yyval.pCaptList) = nullptr; }
     break;
 
-  case 410: /* optional_capture_list: "capture" '(' capture_list ')'  */
+  case 412: /* optional_capture_list: "capture" '(' capture_list ')'  */
                                              { (yyval.pCaptList) = (yyvsp[-1].pCaptList); }
     break;
 
-  case 411: /* expr_full_block: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
+  case 413: /* expr_full_block: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
                                                                                                                 {
         (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-6].i),(yyvsp[-5].faList),(yyvsp[-4].pCaptList),(yyvsp[-3].pVarDeclList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[-4])));
     }
     break;
 
-  case 412: /* expr_full_block_assumed_piped: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
+  case 414: /* expr_full_block_assumed_piped: block_or_lambda optional_annotation_list optional_capture_list optional_function_argument_list optional_function_type optional_emit_semis block_or_simple_block  */
                                                                                                                 {
         (yyval.pExpression) = ast_makeBlock(scanner,(yyvsp[-6].i),(yyvsp[-5].faList),(yyvsp[-4].pCaptList),(yyvsp[-3].pVarDeclList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[-4])));
     }
     break;
 
-  case 413: /* expr_full_block_assumed_piped: '{' expressions '}'  */
+  case 415: /* expr_full_block_assumed_piped: '{' expressions '}'  */
                                    {
         (yyval.pExpression) = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,new TypeDecl(Type::autoinfer),(yyvsp[-1].pExpression),tokAt(scanner,(yylsp[-1])),tokAt(scanner,(yylsp[-1])),LineInfo());
     }
     break;
 
-  case 414: /* expr_numeric_const: "integer constant"  */
+  case 416: /* expr_numeric_const: "integer constant"  */
                                               { (yyval.pExpression) = new ExprConstInt(tokAt(scanner,(yylsp[0])),(int32_t)(yyvsp[0].i)); }
     break;
 
-  case 415: /* expr_numeric_const: "unsigned integer constant"  */
+  case 417: /* expr_numeric_const: "unsigned integer constant"  */
                                               { (yyval.pExpression) = new ExprConstUInt(tokAt(scanner,(yylsp[0])),(uint32_t)(yyvsp[0].ui)); }
     break;
 
-  case 416: /* expr_numeric_const: "long integer constant"  */
+  case 418: /* expr_numeric_const: "long integer constant"  */
                                               { (yyval.pExpression) = new ExprConstInt64(tokAt(scanner,(yylsp[0])),(int64_t)(yyvsp[0].i64)); }
     break;
 
-  case 417: /* expr_numeric_const: "unsigned long integer constant"  */
+  case 419: /* expr_numeric_const: "unsigned long integer constant"  */
                                               { (yyval.pExpression) = new ExprConstUInt64(tokAt(scanner,(yylsp[0])),(uint64_t)(yyvsp[0].ui64)); }
     break;
 
-  case 418: /* expr_numeric_const: "unsigned int8 constant"  */
+  case 420: /* expr_numeric_const: "unsigned int8 constant"  */
                                               { (yyval.pExpression) = new ExprConstUInt8(tokAt(scanner,(yylsp[0])),(uint8_t)(yyvsp[0].ui)); }
     break;
 
-  case 419: /* expr_numeric_const: "floating point constant"  */
+  case 421: /* expr_numeric_const: "floating point constant"  */
                                               { (yyval.pExpression) = new ExprConstFloat(tokAt(scanner,(yylsp[0])),(float)(yyvsp[0].fd)); }
     break;
 
-  case 420: /* expr_numeric_const: "double constant"  */
+  case 422: /* expr_numeric_const: "double constant"  */
                                               { (yyval.pExpression) = new ExprConstDouble(tokAt(scanner,(yylsp[0])),(double)(yyvsp[0].d)); }
     break;
 
-  case 421: /* expr_assign_no_bracket: expr_no_bracket  */
+  case 423: /* expr_assign_no_bracket: expr_no_bracket  */
                                                         { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 422: /* expr_assign_no_bracket: expr_no_bracket '=' expr_no_bracket  */
+  case 424: /* expr_assign_no_bracket: expr_no_bracket '=' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprCopy(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression)); }
     break;
 
-  case 423: /* expr_assign_no_bracket: expr_no_bracket "<-" expr_no_bracket  */
+  case 425: /* expr_assign_no_bracket: expr_no_bracket "<-" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 424: /* expr_assign_no_bracket: expr_no_bracket "<-" make_table_decl  */
+  case 426: /* expr_assign_no_bracket: expr_no_bracket "<-" make_table_decl  */
                                                                    { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 425: /* expr_assign_no_bracket: expr_no_bracket "<-" array_comprehension  */
+  case 427: /* expr_assign_no_bracket: expr_no_bracket "<-" array_comprehension  */
                                                                      { (yyval.pExpression) = new ExprMove(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 426: /* expr_assign_no_bracket: expr_no_bracket ":=" expr_no_bracket  */
+  case 428: /* expr_assign_no_bracket: expr_no_bracket ":=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprClone(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 427: /* expr_assign_no_bracket: expr_no_bracket "&=" expr_no_bracket  */
+  case 429: /* expr_assign_no_bracket: expr_no_bracket "&=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 428: /* expr_assign_no_bracket: expr_no_bracket "|=" expr_no_bracket  */
+  case 430: /* expr_assign_no_bracket: expr_no_bracket "|=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 429: /* expr_assign_no_bracket: expr_no_bracket "^=" expr_no_bracket  */
+  case 431: /* expr_assign_no_bracket: expr_no_bracket "^=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 430: /* expr_assign_no_bracket: expr_no_bracket "&&=" expr_no_bracket  */
+  case 432: /* expr_assign_no_bracket: expr_no_bracket "&&=" expr_no_bracket  */
                                                                       { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 431: /* expr_assign_no_bracket: expr_no_bracket "||=" expr_no_bracket  */
+  case 433: /* expr_assign_no_bracket: expr_no_bracket "||=" expr_no_bracket  */
                                                                       { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 432: /* expr_assign_no_bracket: expr_no_bracket "^^=" expr_no_bracket  */
+  case 434: /* expr_assign_no_bracket: expr_no_bracket "^^=" expr_no_bracket  */
                                                                       { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 433: /* expr_assign_no_bracket: expr_no_bracket "+=" expr_no_bracket  */
+  case 435: /* expr_assign_no_bracket: expr_no_bracket "+=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 434: /* expr_assign_no_bracket: expr_no_bracket "-=" expr_no_bracket  */
+  case 436: /* expr_assign_no_bracket: expr_no_bracket "-=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 435: /* expr_assign_no_bracket: expr_no_bracket "*=" expr_no_bracket  */
+  case 437: /* expr_assign_no_bracket: expr_no_bracket "*=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 436: /* expr_assign_no_bracket: expr_no_bracket "/=" expr_no_bracket  */
+  case 438: /* expr_assign_no_bracket: expr_no_bracket "/=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 437: /* expr_assign_no_bracket: expr_no_bracket "%=" expr_no_bracket  */
+  case 439: /* expr_assign_no_bracket: expr_no_bracket "%=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 438: /* expr_assign_no_bracket: expr_no_bracket "<<=" expr_no_bracket  */
+  case 440: /* expr_assign_no_bracket: expr_no_bracket "<<=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 439: /* expr_assign_no_bracket: expr_no_bracket ">>=" expr_no_bracket  */
+  case 441: /* expr_assign_no_bracket: expr_no_bracket ">>=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 440: /* expr_assign_no_bracket: expr_no_bracket "<<<=" expr_no_bracket  */
+  case 442: /* expr_assign_no_bracket: expr_no_bracket "<<<=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 441: /* expr_assign_no_bracket: expr_no_bracket ">>>=" expr_no_bracket  */
+  case 443: /* expr_assign_no_bracket: expr_no_bracket ">>>=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 442: /* expr_named_call: name_in_namespace '(' '[' make_struct_fields ']' ')'  */
+  case 444: /* expr_named_call: name_in_namespace '(' '[' make_struct_fields ']' ')'  */
                                                                          {
         auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-5])),*(yyvsp[-5].s));
         nc->arguments = (yyvsp[-2].pMakeStruct);
@@ -7851,7 +7870,7 @@ yyreduce:
     }
     break;
 
-  case 443: /* expr_named_call: name_in_namespace '(' expr_list ',' '[' make_struct_fields ']' ')'  */
+  case 445: /* expr_named_call: name_in_namespace '(' expr_list ',' '[' make_struct_fields ']' ')'  */
                                                                                                   {
         auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-7])),*(yyvsp[-7].s));
         nc->nonNamedArguments = sequenceToList((yyvsp[-5].pExpression));
@@ -7861,7 +7880,7 @@ yyreduce:
     }
     break;
 
-  case 444: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' ')'  */
+  case 446: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' ')'  */
                                                                     {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), *(yyvsp[-2].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-4]),(yyloc));
@@ -7870,7 +7889,7 @@ yyreduce:
     }
     break;
 
-  case 445: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' expr_list ')'  */
+  case 447: /* expr_method_call_no_bracket: expr_no_bracket "->" "name" '(' expr_list ')'  */
                                                                                          {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), *(yyvsp[-3].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-5]),(yyloc));
@@ -7881,35 +7900,35 @@ yyreduce:
     }
     break;
 
-  case 446: /* func_addr_name: name_in_namespace  */
+  case 448: /* func_addr_name: name_in_namespace  */
                                     {
         (yyval.pExpression) = new ExprAddr(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 447: /* func_addr_name: "$i" '(' expr ')'  */
+  case 449: /* func_addr_name: "$i" '(' expr ')'  */
                                           {
         auto expr = new ExprAddr(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``ADDR``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression), expr, "i");
     }
     break;
 
-  case 448: /* func_addr_expr: '@' '@' func_addr_name  */
+  case 450: /* func_addr_expr: '@' '@' func_addr_name  */
                                           {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 449: /* $@33: %empty  */
+  case 451: /* $@33: %empty  */
                     { yyextra->das_arrow_depth ++; }
     break;
 
-  case 450: /* $@34: %empty  */
+  case 452: /* $@34: %empty  */
                                                                                                 { yyextra->das_arrow_depth --; }
     break;
 
-  case 451: /* func_addr_expr: '@' '@' '<' $@33 type_declaration_no_options '>' $@34 func_addr_name  */
+  case 453: /* func_addr_expr: '@' '@' '<' $@33 type_declaration_no_options '>' $@34 func_addr_name  */
                                                                                                                                                        {
         auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value));
         expr->funcType = (yyvsp[-3].pTypeDecl);
@@ -7917,15 +7936,15 @@ yyreduce:
     }
     break;
 
-  case 452: /* $@35: %empty  */
+  case 454: /* $@35: %empty  */
                     { yyextra->das_arrow_depth ++; }
     break;
 
-  case 453: /* $@36: %empty  */
+  case 455: /* $@36: %empty  */
                                                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 454: /* func_addr_expr: '@' '@' '<' $@35 optional_function_argument_list optional_function_type '>' $@36 func_addr_name  */
+  case 456: /* func_addr_expr: '@' '@' '<' $@35 optional_function_argument_list optional_function_type '>' $@36 func_addr_name  */
                                                                                                                                                                                      {
         auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value));
         expr->funcType = new TypeDecl(Type::tFunction);
@@ -7938,21 +7957,21 @@ yyreduce:
     }
     break;
 
-  case 455: /* expr_field_no_bracket: expr_no_bracket '.' "name"  */
+  case 457: /* expr_field_no_bracket: expr_no_bracket '.' "name"  */
                                                          {
         (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-2].pExpression), *(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 456: /* expr_field_no_bracket: expr_no_bracket '.' '.' "name"  */
+  case 458: /* expr_field_no_bracket: expr_no_bracket '.' '.' "name"  */
                                                              {
         (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-3].pExpression), *(yyvsp[0].s), true);
         delete (yyvsp[0].s);
     }
     break;
 
-  case 457: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' ')'  */
+  case 459: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' ')'  */
                                                                  {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), *(yyvsp[-2].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-4]),(yyloc));
@@ -7961,7 +7980,7 @@ yyreduce:
     }
     break;
 
-  case 458: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' expr_list ')'  */
+  case 460: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' expr_list ')'  */
                                                                                       {
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), *(yyvsp[-3].s));
         pInvoke->atEnclosure = tokRangeAt(scanner,(yylsp[-5]),(yyloc));
@@ -7972,7 +7991,7 @@ yyreduce:
     }
     break;
 
-  case 459: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' '[' make_struct_fields ']' ')'  */
+  case 461: /* expr_field_no_bracket: expr_no_bracket '.' "name" '(' '[' make_struct_fields ']' ')'  */
                                                                                                   {
         auto nc = new ExprNamedCall(tokAt(scanner,(yylsp[-5])),*(yyvsp[-5].s));
         nc->methodCall = true;
@@ -7983,7 +8002,7 @@ yyreduce:
     }
     break;
 
-  case 460: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' ')'  */
+  case 462: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' ')'  */
                                                                                    {
         auto method_name = das_to_string((yyvsp[-2].type));
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), method_name);
@@ -7992,7 +8011,7 @@ yyreduce:
     }
     break;
 
-  case 461: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' expr_list ')'  */
+  case 463: /* expr_field_no_bracket: expr_no_bracket '.' basic_type_declaration '(' expr_list ')'  */
                                                                                                         {
         auto method_name = das_to_string((yyvsp[-3].type));
         auto pInvoke = makeInvokeMethod(tokAt(scanner,(yylsp[-4])), (yyvsp[-5].pExpression), method_name);
@@ -8003,29 +8022,29 @@ yyreduce:
     }
     break;
 
-  case 462: /* $@37: %empty  */
+  case 464: /* $@37: %empty  */
                                           { yyextra->das_suppress_errors=true; }
     break;
 
-  case 463: /* $@38: %empty  */
+  case 465: /* $@38: %empty  */
                                                                                        { yyextra->das_suppress_errors=false; }
     break;
 
-  case 464: /* expr_field_no_bracket: expr_no_bracket '.' $@37 error $@38  */
+  case 466: /* expr_field_no_bracket: expr_no_bracket '.' $@37 error $@38  */
                                                                                                                                {
         (yyval.pExpression) = new ExprField(tokAt(scanner,(yylsp[-3])), tokAt(scanner,(yylsp[-3])), (yyvsp[-4].pExpression), "");
         yyerrok;
     }
     break;
 
-  case 465: /* expr_call: name_in_namespace '(' ')'  */
+  case 467: /* expr_call: name_in_namespace '(' ')'  */
                                                {
             (yyval.pExpression) = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])),*(yyvsp[-2].s));
             delete (yyvsp[-2].s);
     }
     break;
 
-  case 466: /* expr_call: name_in_namespace '(' "uninitialized" ')'  */
+  case 468: /* expr_call: name_in_namespace '(' "uninitialized" ')'  */
                                                           {
             auto dd = new ExprMakeStruct(tokAt(scanner,(yylsp[-3])));
             dd->at = tokAt(scanner,(yylsp[-3]));
@@ -8037,7 +8056,7 @@ yyreduce:
     }
     break;
 
-  case 467: /* expr_call: name_in_namespace '(' make_struct_single ')'  */
+  case 469: /* expr_call: name_in_namespace '(' make_struct_single ')'  */
                                                                {
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-3]));
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[-3])),*(yyvsp[-3].s));
@@ -8048,7 +8067,7 @@ yyreduce:
     }
     break;
 
-  case 468: /* expr_call: name_in_namespace '(' "uninitialized" make_struct_single ')'  */
+  case 470: /* expr_call: name_in_namespace '(' "uninitialized" make_struct_single ')'  */
                                                                                  {
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->at = tokAt(scanner,(yylsp[-4]));
             ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[-4])),*(yyvsp[-4].s));
@@ -8059,178 +8078,178 @@ yyreduce:
     }
     break;
 
-  case 469: /* expr_call: name_in_namespace '(' expr_list ')'  */
+  case 471: /* expr_call: name_in_namespace '(' expr_list ')'  */
                                                                     {
             (yyval.pExpression) = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),tokAt(scanner,(yylsp[0])),*(yyvsp[-3].s)),(yyvsp[-1].pExpression));
             delete (yyvsp[-3].s);
     }
     break;
 
-  case 470: /* expr_call: basic_type_declaration '(' ')'  */
+  case 472: /* expr_call: basic_type_declaration '(' ')'  */
                                                     {
         (yyval.pExpression) = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[-2].type)));
     }
     break;
 
-  case 471: /* expr_call: basic_type_declaration '(' expr_list ')'  */
+  case 473: /* expr_call: basic_type_declaration '(' expr_list ')'  */
                                                                          {
         (yyval.pExpression) = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[-3].type))),(yyvsp[-1].pExpression));
     }
     break;
 
-  case 472: /* expr: expr_no_bracket  */
+  case 474: /* expr: expr_no_bracket  */
                                        { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 473: /* expr: make_table_decl  */
+  case 475: /* expr: make_table_decl  */
                                      { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 474: /* expr: array_comprehension  */
+  case 476: /* expr: array_comprehension  */
                                      { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 475: /* expr_no_bracket: "null"  */
+  case 477: /* expr_no_bracket: "null"  */
                                               { (yyval.pExpression) = new ExprConstPtr(tokAt(scanner,(yylsp[0])),nullptr); }
     break;
 
-  case 476: /* expr_no_bracket: name_in_namespace  */
+  case 478: /* expr_no_bracket: name_in_namespace  */
                                               { (yyval.pExpression) = new ExprVar(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 477: /* expr_no_bracket: expr_numeric_const  */
+  case 479: /* expr_no_bracket: expr_numeric_const  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 478: /* expr_no_bracket: expr_reader  */
+  case 480: /* expr_no_bracket: expr_reader  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 479: /* expr_no_bracket: string_builder  */
+  case 481: /* expr_no_bracket: string_builder  */
                                               { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 480: /* expr_no_bracket: make_decl_no_bracket  */
+  case 482: /* expr_no_bracket: make_decl_no_bracket  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 481: /* expr_no_bracket: "true"  */
+  case 483: /* expr_no_bracket: "true"  */
                                               { (yyval.pExpression) = new ExprConstBool(tokAt(scanner,(yylsp[0])),true); }
     break;
 
-  case 482: /* expr_no_bracket: "false"  */
+  case 484: /* expr_no_bracket: "false"  */
                                               { (yyval.pExpression) = new ExprConstBool(tokAt(scanner,(yylsp[0])),false); }
     break;
 
-  case 483: /* expr_no_bracket: expr_field_no_bracket  */
+  case 485: /* expr_no_bracket: expr_field_no_bracket  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 484: /* expr_no_bracket: expr_mtag_no_bracket  */
+  case 486: /* expr_no_bracket: expr_mtag_no_bracket  */
                                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 485: /* expr_no_bracket: '!' expr_no_bracket  */
+  case 487: /* expr_no_bracket: '!' expr_no_bracket  */
                                                          { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"!",(yyvsp[0].pExpression)); }
     break;
 
-  case 486: /* expr_no_bracket: '~' expr_no_bracket  */
+  case 488: /* expr_no_bracket: '~' expr_no_bracket  */
                                                          { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"~",(yyvsp[0].pExpression)); }
     break;
 
-  case 487: /* expr_no_bracket: '+' expr_no_bracket  */
+  case 489: /* expr_no_bracket: '+' expr_no_bracket  */
                                                              { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"+",(yyvsp[0].pExpression)); }
     break;
 
-  case 488: /* expr_no_bracket: '-' expr_no_bracket  */
+  case 490: /* expr_no_bracket: '-' expr_no_bracket  */
                                                              { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"-",(yyvsp[0].pExpression)); }
     break;
 
-  case 489: /* expr_no_bracket: expr_no_bracket "<<" expr_no_bracket  */
+  case 491: /* expr_no_bracket: expr_no_bracket "<<" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 490: /* expr_no_bracket: expr_no_bracket ">>" expr_no_bracket  */
+  case 492: /* expr_no_bracket: expr_no_bracket ">>" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 491: /* expr_no_bracket: expr_no_bracket "<<<" expr_no_bracket  */
+  case 493: /* expr_no_bracket: expr_no_bracket "<<<" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<<<", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 492: /* expr_no_bracket: expr_no_bracket ">>>" expr_no_bracket  */
+  case 494: /* expr_no_bracket: expr_no_bracket ">>>" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">>>", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 493: /* expr_no_bracket: expr_no_bracket '+' expr_no_bracket  */
+  case 495: /* expr_no_bracket: expr_no_bracket '+' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"+", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 494: /* expr_no_bracket: expr_no_bracket '-' expr_no_bracket  */
+  case 496: /* expr_no_bracket: expr_no_bracket '-' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"-", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 495: /* expr_no_bracket: expr_no_bracket '*' expr_no_bracket  */
+  case 497: /* expr_no_bracket: expr_no_bracket '*' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"*", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 496: /* expr_no_bracket: expr_no_bracket '/' expr_no_bracket  */
+  case 498: /* expr_no_bracket: expr_no_bracket '/' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"/", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 497: /* expr_no_bracket: expr_no_bracket '%' expr_no_bracket  */
+  case 499: /* expr_no_bracket: expr_no_bracket '%' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"%", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 498: /* expr_no_bracket: expr_no_bracket '<' expr_no_bracket  */
+  case 500: /* expr_no_bracket: expr_no_bracket '<' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 499: /* expr_no_bracket: expr_no_bracket '>' expr_no_bracket  */
+  case 501: /* expr_no_bracket: expr_no_bracket '>' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 500: /* expr_no_bracket: expr_no_bracket "==" expr_no_bracket  */
+  case 502: /* expr_no_bracket: expr_no_bracket "==" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"==", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 501: /* expr_no_bracket: expr_no_bracket "!=" expr_no_bracket  */
+  case 503: /* expr_no_bracket: expr_no_bracket "!=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"!=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 502: /* expr_no_bracket: expr_no_bracket "<=" expr_no_bracket  */
+  case 504: /* expr_no_bracket: expr_no_bracket "<=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"<=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 503: /* expr_no_bracket: expr_no_bracket ">=" expr_no_bracket  */
+  case 505: /* expr_no_bracket: expr_no_bracket ">=" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),">=", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 504: /* expr_no_bracket: expr_no_bracket '&' expr_no_bracket  */
+  case 506: /* expr_no_bracket: expr_no_bracket '&' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 505: /* expr_no_bracket: expr_no_bracket '|' expr_no_bracket  */
+  case 507: /* expr_no_bracket: expr_no_bracket '|' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"|", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 506: /* expr_no_bracket: expr_no_bracket '^' expr_no_bracket  */
+  case 508: /* expr_no_bracket: expr_no_bracket '^' expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 507: /* expr_no_bracket: expr_no_bracket "&&" expr_no_bracket  */
+  case 509: /* expr_no_bracket: expr_no_bracket "&&" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"&&", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 508: /* expr_no_bracket: expr_no_bracket "||" expr_no_bracket  */
+  case 510: /* expr_no_bracket: expr_no_bracket "||" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"||", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 509: /* expr_no_bracket: expr_no_bracket "^^" expr_no_bracket  */
+  case 511: /* expr_no_bracket: expr_no_bracket "^^" expr_no_bracket  */
                                                                    { (yyval.pExpression) = new ExprOp2(tokAt(scanner,(yylsp[-1])),"^^", (yyvsp[-2].pExpression), (yyvsp[0].pExpression)); }
     break;
 
-  case 510: /* expr_no_bracket: expr_no_bracket ".." expr_no_bracket  */
+  case 512: /* expr_no_bracket: expr_no_bracket ".." expr_no_bracket  */
                                                                    {
         auto itv = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-1])),"interval");
         itv->arguments.push_back((yyvsp[-2].pExpression));
@@ -8239,23 +8258,23 @@ yyreduce:
     }
     break;
 
-  case 511: /* expr_no_bracket: "++" expr_no_bracket  */
+  case 513: /* expr_no_bracket: "++" expr_no_bracket  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"++", (yyvsp[0].pExpression)); }
     break;
 
-  case 512: /* expr_no_bracket: "--" expr_no_bracket  */
+  case 514: /* expr_no_bracket: "--" expr_no_bracket  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[-1])),"--", (yyvsp[0].pExpression)); }
     break;
 
-  case 513: /* expr_no_bracket: expr_no_bracket "++"  */
+  case 515: /* expr_no_bracket: expr_no_bracket "++"  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[0])),"+++", (yyvsp[-1].pExpression)); }
     break;
 
-  case 514: /* expr_no_bracket: expr_no_bracket "--"  */
+  case 516: /* expr_no_bracket: expr_no_bracket "--"  */
                                                             { (yyval.pExpression) = new ExprOp1(tokAt(scanner,(yylsp[0])),"---", (yyvsp[-1].pExpression)); }
     break;
 
-  case 515: /* expr_no_bracket: '(' expr_list optional_comma ')'  */
+  case 517: /* expr_no_bracket: '(' expr_list optional_comma ')'  */
                                                          {
             if ( (yyvsp[-2].pExpression)->rtti_isSequence() ) {
                 auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-2])));
@@ -8273,7 +8292,7 @@ yyreduce:
         }
     break;
 
-  case 516: /* expr_no_bracket: '(' make_struct_single ')'  */
+  case 518: /* expr_no_bracket: '(' make_struct_single ')'  */
                                       {
         auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         for ( auto & arg : *(((ExprMakeStruct *)(yyvsp[-1].pExpression))->structs.back()) ) {
@@ -8285,79 +8304,79 @@ yyreduce:
     }
     break;
 
-  case 517: /* expr_no_bracket: expr_no_bracket '[' expr ']'  */
+  case 519: /* expr_no_bracket: expr_no_bracket '[' expr ']'  */
                                                             { (yyval.pExpression) = new ExprAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-3].pExpression), (yyvsp[-1].pExpression)); }
     break;
 
-  case 518: /* expr_no_bracket: expr_no_bracket '.' '[' expr ']'  */
+  case 520: /* expr_no_bracket: expr_no_bracket '.' '[' expr ']'  */
                                                                 { (yyval.pExpression) = new ExprAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-4].pExpression), (yyvsp[-1].pExpression), true); }
     break;
 
-  case 519: /* expr_no_bracket: expr_no_bracket "?[" expr ']'  */
+  case 521: /* expr_no_bracket: expr_no_bracket "?[" expr ']'  */
                                                             { (yyval.pExpression) = new ExprSafeAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-3].pExpression), (yyvsp[-1].pExpression)); }
     break;
 
-  case 520: /* expr_no_bracket: expr_no_bracket '.' "?[" expr ']'  */
+  case 522: /* expr_no_bracket: expr_no_bracket '.' "?[" expr ']'  */
                                                                 { (yyval.pExpression) = new ExprSafeAt(tokAt(scanner,(yylsp[-2])), (yyvsp[-4].pExpression), (yyvsp[-1].pExpression), true); }
     break;
 
-  case 521: /* expr_no_bracket: expr_no_bracket "?." "name"  */
+  case 523: /* expr_no_bracket: expr_no_bracket "?." "name"  */
                                                             { (yyval.pExpression) = new ExprSafeField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-2].pExpression), *(yyvsp[0].s)); delete (yyvsp[0].s); }
     break;
 
-  case 522: /* expr_no_bracket: expr_no_bracket '.' "?." "name"  */
+  case 524: /* expr_no_bracket: expr_no_bracket '.' "?." "name"  */
                                                                 { (yyval.pExpression) = new ExprSafeField(tokAt(scanner,(yylsp[-1])), tokAt(scanner,(yylsp[0])), (yyvsp[-3].pExpression), *(yyvsp[0].s), true); delete (yyvsp[0].s); }
     break;
 
-  case 523: /* expr_no_bracket: func_addr_expr  */
+  case 525: /* expr_no_bracket: func_addr_expr  */
                                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 524: /* expr_no_bracket: expr_call  */
+  case 526: /* expr_no_bracket: expr_call  */
                         { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 525: /* expr_no_bracket: '*' expr_no_bracket  */
+  case 527: /* expr_no_bracket: '*' expr_no_bracket  */
                                                               { (yyval.pExpression) = new ExprPtr2Ref(tokAt(scanner,(yylsp[-1])),(yyvsp[0].pExpression)); }
     break;
 
-  case 526: /* expr_no_bracket: "deref" '(' expr ')'  */
+  case 528: /* expr_no_bracket: "deref" '(' expr ')'  */
                                                    { (yyval.pExpression) = new ExprPtr2Ref(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression)); }
     break;
 
-  case 527: /* expr_no_bracket: "addr" '(' expr ')'  */
+  case 529: /* expr_no_bracket: "addr" '(' expr ')'  */
                                                    { (yyval.pExpression) = new ExprRef2Ptr(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression)); }
     break;
 
-  case 528: /* expr_no_bracket: expr_generator  */
+  case 530: /* expr_no_bracket: expr_generator  */
                                                    { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 529: /* expr_no_bracket: expr_no_bracket "??" expr_no_bracket  */
+  case 531: /* expr_no_bracket: expr_no_bracket "??" expr_no_bracket  */
                                                                          { (yyval.pExpression) = new ExprNullCoalescing(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression)); }
     break;
 
-  case 530: /* expr_no_bracket: expr_no_bracket '?' expr_no_bracket ':' expr_no_bracket  */
+  case 532: /* expr_no_bracket: expr_no_bracket '?' expr_no_bracket ':' expr_no_bracket  */
                                                                                            {
             (yyval.pExpression) = new ExprOp3(tokAt(scanner,(yylsp[-3])),"?",(yyvsp[-4].pExpression),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
         }
     break;
 
-  case 531: /* $@39: %empty  */
+  case 533: /* $@39: %empty  */
                                                           { yyextra->das_arrow_depth ++; }
     break;
 
-  case 532: /* $@40: %empty  */
+  case 534: /* $@40: %empty  */
                                                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 533: /* expr_no_bracket: expr_no_bracket "is" "type" '<' $@39 type_declaration_no_options '>' $@40  */
+  case 535: /* expr_no_bracket: expr_no_bracket "is" "type" '<' $@39 type_declaration_no_options '>' $@40  */
                                                                                                                                                                   {
         (yyval.pExpression) = new ExprIs(tokAt(scanner,(yylsp[-6])),(yyvsp[-7].pExpression),(yyvsp[-2].pTypeDecl));
     }
     break;
 
-  case 534: /* expr_no_bracket: expr_no_bracket "is" basic_type_declaration  */
+  case 536: /* expr_no_bracket: expr_no_bracket "is" basic_type_declaration  */
                                                                           {
         auto vdecl = new TypeDecl((yyvsp[0].type));
         vdecl->at = tokAt(scanner,(yylsp[0]));
@@ -8365,29 +8384,29 @@ yyreduce:
     }
     break;
 
-  case 535: /* expr_no_bracket: expr_no_bracket "is" "name"  */
+  case 537: /* expr_no_bracket: expr_no_bracket "is" "name"  */
                                                          {
         (yyval.pExpression) = new ExprIsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 536: /* expr_no_bracket: expr_no_bracket "as" "name"  */
+  case 538: /* expr_no_bracket: expr_no_bracket "as" "name"  */
                                                          {
         (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 537: /* $@41: %empty  */
+  case 539: /* $@41: %empty  */
                                                           { yyextra->das_arrow_depth ++; }
     break;
 
-  case 538: /* $@42: %empty  */
+  case 540: /* $@42: %empty  */
                                                                                                                       { yyextra->das_arrow_depth --; }
     break;
 
-  case 539: /* expr_no_bracket: expr_no_bracket "as" "type" '<' $@41 type_declaration '>' $@42  */
+  case 541: /* expr_no_bracket: expr_no_bracket "as" "type" '<' $@41 type_declaration '>' $@42  */
                                                                                                                                                        {
         auto vname = (yyvsp[-2].pTypeDecl)->describe();
         (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-6])),(yyvsp[-7].pExpression),vname);
@@ -8395,28 +8414,28 @@ yyreduce:
     }
     break;
 
-  case 540: /* expr_no_bracket: expr_no_bracket "as" basic_type_declaration  */
+  case 542: /* expr_no_bracket: expr_no_bracket "as" basic_type_declaration  */
                                                                           {
         (yyval.pExpression) = new ExprAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),das_to_string((yyvsp[0].type)));
     }
     break;
 
-  case 541: /* expr_no_bracket: expr_no_bracket '?' "as" "name"  */
+  case 543: /* expr_no_bracket: expr_no_bracket '?' "as" "name"  */
                                                              {
         (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-3].pExpression),*(yyvsp[0].s));
         delete (yyvsp[0].s);
     }
     break;
 
-  case 542: /* $@43: %empty  */
+  case 544: /* $@43: %empty  */
                                                               { yyextra->das_arrow_depth ++; }
     break;
 
-  case 543: /* $@44: %empty  */
+  case 545: /* $@44: %empty  */
                                                                                                                           { yyextra->das_arrow_depth --; }
     break;
 
-  case 544: /* expr_no_bracket: expr_no_bracket '?' "as" "type" '<' $@43 type_declaration '>' $@44  */
+  case 546: /* expr_no_bracket: expr_no_bracket '?' "as" "type" '<' $@43 type_declaration '>' $@44  */
                                                                                                                                                            {
         auto vname = (yyvsp[-2].pTypeDecl)->describe();
         (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-6])),(yyvsp[-8].pExpression),vname);
@@ -8424,60 +8443,60 @@ yyreduce:
     }
     break;
 
-  case 545: /* expr_no_bracket: expr_no_bracket '?' "as" basic_type_declaration  */
+  case 547: /* expr_no_bracket: expr_no_bracket '?' "as" basic_type_declaration  */
                                                                               {
         (yyval.pExpression) = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-1])),(yyvsp[-3].pExpression),das_to_string((yyvsp[0].type)));
     }
     break;
 
-  case 546: /* expr_no_bracket: expr_type_info  */
+  case 548: /* expr_no_bracket: expr_type_info  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 547: /* expr_no_bracket: expr_type_decl  */
+  case 549: /* expr_no_bracket: expr_type_decl  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 548: /* expr_no_bracket: expr_cast  */
+  case 550: /* expr_no_bracket: expr_cast  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 549: /* expr_no_bracket: expr_new  */
+  case 551: /* expr_no_bracket: expr_new  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 550: /* expr_no_bracket: expr_method_call_no_bracket  */
+  case 552: /* expr_no_bracket: expr_method_call_no_bracket  */
                                                   { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 551: /* expr_no_bracket: expr_named_call  */
+  case 553: /* expr_no_bracket: expr_named_call  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 552: /* expr_no_bracket: expr_full_block  */
+  case 554: /* expr_no_bracket: expr_full_block  */
                                                 { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 553: /* expr_no_bracket: expr_no_bracket "<|" expr_no_bracket  */
+  case 555: /* expr_no_bracket: expr_no_bracket "<|" expr_no_bracket  */
                                                                       { (yyval.pExpression) = ast_lpipe(scanner,(yyvsp[-2].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-1]))); }
     break;
 
-  case 554: /* expr_no_bracket: expr_no_bracket "|>" expr_no_bracket  */
+  case 556: /* expr_no_bracket: expr_no_bracket "|>" expr_no_bracket  */
                                                                       { (yyval.pExpression) = ast_rpipe(scanner,(yyvsp[-2].pExpression),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-1]))); }
     break;
 
-  case 555: /* expr_no_bracket: expr_no_bracket "|>" basic_type_declaration  */
+  case 557: /* expr_no_bracket: expr_no_bracket "|>" basic_type_declaration  */
                                                                      {
         auto fncall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[0])),das_to_string((yyvsp[0].type)));
         (yyval.pExpression) = ast_rpipe(scanner,(yyvsp[-2].pExpression),fncall,tokAt(scanner,(yylsp[-1])));
     }
     break;
 
-  case 556: /* expr_no_bracket: expr_call_pipe_no_bracket  */
+  case 558: /* expr_no_bracket: expr_call_pipe_no_bracket  */
                                         { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 557: /* expr_no_bracket: "unsafe" '(' expr ')'  */
+  case 559: /* expr_no_bracket: "unsafe" '(' expr ')'  */
                                          {
             (yyvsp[-1].pExpression)->alwaysSafe = true;
             (yyvsp[-1].pExpression)->userSaidItsSafe = true;
@@ -8485,7 +8504,7 @@ yyreduce:
         }
     break;
 
-  case 558: /* expr_no_bracket: expr_no_bracket "=>" expr_no_bracket  */
+  case 560: /* expr_no_bracket: expr_no_bracket "=>" expr_no_bracket  */
                                                                {
         ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         mt->values.push_back((yyvsp[-2].pExpression));
@@ -8494,7 +8513,7 @@ yyreduce:
     }
     break;
 
-  case 559: /* expr_no_bracket: expr_no_bracket "=>" make_table_decl  */
+  case 561: /* expr_no_bracket: expr_no_bracket "=>" make_table_decl  */
                                                                {
         ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         mt->values.push_back((yyvsp[-2].pExpression));
@@ -8503,7 +8522,7 @@ yyreduce:
     }
     break;
 
-  case 560: /* expr_no_bracket: expr_no_bracket "=>" array_comprehension  */
+  case 562: /* expr_no_bracket: expr_no_bracket "=>" array_comprehension  */
                                                                    {
         ExprMakeTuple * mt = new ExprMakeTuple(tokAt(scanner,(yylsp[-1])));
         mt->values.push_back((yyvsp[-2].pExpression));
@@ -8512,19 +8531,19 @@ yyreduce:
     }
     break;
 
-  case 561: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' ')'  */
+  case 563: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' ')'  */
                                                                                                               {
         (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-4].pTypeDecl),(yyvsp[-2].pCaptList),nullptr,tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[-2])));
     }
     break;
 
-  case 562: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' expr ')'  */
+  case 564: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list '(' expr ')'  */
                                                                                                                             {
         (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-5].pTypeDecl),(yyvsp[-3].pCaptList),(yyvsp[-1].pExpression),tokAt(scanner,(yylsp[-7])),tokAt(scanner,(yylsp[-3])));
     }
     break;
 
-  case 563: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list optional_emit_semis expression_block  */
+  case 565: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list optional_emit_semis expression_block  */
                                                                                                                                                   {
         auto closure = new ExprMakeBlock(tokAt(scanner,(yylsp[0])),(yyvsp[0].pExpression));
         ((ExprBlock *)(yyvsp[0].pExpression))->returnType = new TypeDecl(Type::autoinfer);
@@ -8532,149 +8551,149 @@ yyreduce:
     }
     break;
 
-  case 564: /* expr_mtag_no_bracket: "$$" '(' expr ')'  */
+  case 566: /* expr_mtag_no_bracket: "$$" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"e"); }
     break;
 
-  case 565: /* expr_mtag_no_bracket: "$i" '(' expr ')'  */
+  case 567: /* expr_mtag_no_bracket: "$i" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"i"); }
     break;
 
-  case 566: /* expr_mtag_no_bracket: "$v" '(' expr ')'  */
+  case 568: /* expr_mtag_no_bracket: "$v" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"v"); }
     break;
 
-  case 567: /* expr_mtag_no_bracket: "$b" '(' expr ')'  */
+  case 569: /* expr_mtag_no_bracket: "$b" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"b"); }
     break;
 
-  case 568: /* expr_mtag_no_bracket: "$a" '(' expr ')'  */
+  case 570: /* expr_mtag_no_bracket: "$a" '(' expr ')'  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),"a"); }
     break;
 
-  case 569: /* expr_mtag_no_bracket: "..."  */
+  case 571: /* expr_mtag_no_bracket: "..."  */
                                                      { (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[0])),nullptr,"..."); }
     break;
 
-  case 570: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' ')'  */
+  case 572: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' ')'  */
                                                             {
             auto ccall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-5])),tokAt(scanner,(yylsp[0])),"``MACRO``TAG``CALL``");
             (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-5])),(yyvsp[-3].pExpression),ccall,"c");
         }
     break;
 
-  case 571: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' expr_list ')'  */
+  case 573: /* expr_mtag_no_bracket: "$c" '(' expr ')' '(' expr_list ')'  */
                                                                                 {
             auto ccall = parseFunctionArguments(yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[0])),"``MACRO``TAG``CALL``"),(yyvsp[-1].pExpression));
             (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-6])),(yyvsp[-4].pExpression),ccall,"c");
         }
     break;
 
-  case 572: /* expr_mtag_no_bracket: expr_no_bracket '.' "$f" '(' expr ')'  */
+  case 574: /* expr_mtag_no_bracket: expr_no_bracket '.' "$f" '(' expr ')'  */
                                                                            {
         auto cfield = new ExprField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-5].pExpression), "``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 573: /* expr_mtag_no_bracket: expr_no_bracket "?." "$f" '(' expr ')'  */
+  case 575: /* expr_mtag_no_bracket: expr_no_bracket "?." "$f" '(' expr ')'  */
                                                                             {
         auto cfield = new ExprSafeField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-5].pExpression), "``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 574: /* expr_mtag_no_bracket: expr_no_bracket '.' '.' "$f" '(' expr ')'  */
+  case 576: /* expr_mtag_no_bracket: expr_no_bracket '.' '.' "$f" '(' expr ')'  */
                                                                                {
         auto cfield = new ExprField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-6].pExpression), "``MACRO``TAG``FIELD``", true);
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 575: /* expr_mtag_no_bracket: expr_no_bracket '.' "?." "$f" '(' expr ')'  */
+  case 577: /* expr_mtag_no_bracket: expr_no_bracket '.' "?." "$f" '(' expr ')'  */
                                                                                 {
         auto cfield = new ExprSafeField(tokAt(scanner,(yylsp[-4])), tokAt(scanner,(yylsp[-1])), (yyvsp[-6].pExpression), "``MACRO``TAG``FIELD``", true);
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 576: /* expr_mtag_no_bracket: expr_no_bracket "as" "$f" '(' expr ')'  */
+  case 578: /* expr_mtag_no_bracket: expr_no_bracket "as" "$f" '(' expr ')'  */
                                                                               {
         auto cfield = new ExprAsVariant(tokAt(scanner,(yylsp[-4])),(yyvsp[-5].pExpression),"``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 577: /* expr_mtag_no_bracket: expr_no_bracket '?' "as" "$f" '(' expr ')'  */
+  case 579: /* expr_mtag_no_bracket: expr_no_bracket '?' "as" "$f" '(' expr ')'  */
                                                                                   {
         auto cfield = new ExprSafeAsVariant(tokAt(scanner,(yylsp[-4])),(yyvsp[-6].pExpression),"``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 578: /* expr_mtag_no_bracket: expr_no_bracket "is" "$f" '(' expr ')'  */
+  case 580: /* expr_mtag_no_bracket: expr_no_bracket "is" "$f" '(' expr ')'  */
                                                                               {
         auto cfield = new ExprIsVariant(tokAt(scanner,(yylsp[-4])),(yyvsp[-5].pExpression),"``MACRO``TAG``FIELD``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression),cfield,"f");
     }
     break;
 
-  case 579: /* expr_mtag_no_bracket: '@' '@' "$c" '(' expr ')'  */
+  case 581: /* expr_mtag_no_bracket: '@' '@' "$c" '(' expr ')'  */
                                                          {
         auto ccall = new ExprAddr(tokAt(scanner,(yylsp[-4])),"``MACRO``TAG``ADDR``");
         (yyval.pExpression) = new ExprTag(tokAt(scanner,(yylsp[-3])),(yyvsp[-1].pExpression),ccall,"c");
     }
     break;
 
-  case 580: /* optional_field_annotation: %empty  */
+  case 582: /* optional_field_annotation: %empty  */
                                       { (yyval.aaList) = nullptr; }
     break;
 
-  case 581: /* optional_field_annotation: metadata_argument_list  */
+  case 583: /* optional_field_annotation: metadata_argument_list  */
                                       { (yyval.aaList) = (yyvsp[0].aaList); }
     break;
 
-  case 582: /* optional_override: %empty  */
+  case 584: /* optional_override: %empty  */
                       { (yyval.i) = OVERRIDE_NONE; }
     break;
 
-  case 583: /* optional_override: "override"  */
+  case 585: /* optional_override: "override"  */
                       { (yyval.i) = OVERRIDE_OVERRIDE; }
     break;
 
-  case 584: /* optional_override: "sealed"  */
+  case 586: /* optional_override: "sealed"  */
                       { (yyval.i) = OVERRIDE_SEALED; }
     break;
 
-  case 585: /* optional_constant: %empty  */
+  case 587: /* optional_constant: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 586: /* optional_constant: "const"  */
+  case 588: /* optional_constant: "const"  */
                         { (yyval.b) = true; }
     break;
 
-  case 587: /* optional_public_or_private_member_variable: %empty  */
+  case 589: /* optional_public_or_private_member_variable: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 588: /* optional_public_or_private_member_variable: "public"  */
+  case 590: /* optional_public_or_private_member_variable: "public"  */
                         { (yyval.b) = false; }
     break;
 
-  case 589: /* optional_public_or_private_member_variable: "private"  */
+  case 591: /* optional_public_or_private_member_variable: "private"  */
                         { (yyval.b) = true; }
     break;
 
-  case 590: /* optional_static_member_variable: %empty  */
+  case 592: /* optional_static_member_variable: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 591: /* optional_static_member_variable: "static"  */
+  case 593: /* optional_static_member_variable: "static"  */
                         { (yyval.b) = true; }
     break;
 
-  case 592: /* structure_variable_declaration: optional_field_annotation optional_static_member_variable optional_override optional_public_or_private_member_variable variable_declaration  */
+  case 594: /* structure_variable_declaration: optional_field_annotation optional_static_member_variable optional_override optional_public_or_private_member_variable variable_declaration  */
                                                                                                                                                                                       {
         (yyvsp[0].pVarDecl)->override = (yyvsp[-2].i) == OVERRIDE_OVERRIDE;
         (yyvsp[0].pVarDecl)->sealed = (yyvsp[-2].i) == OVERRIDE_SEALED;
@@ -8685,24 +8704,24 @@ yyreduce:
     }
     break;
 
-  case 593: /* struct_variable_declaration_list: %empty  */
+  case 595: /* struct_variable_declaration_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 594: /* struct_variable_declaration_list: struct_variable_declaration_list "new line, semicolon"  */
+  case 596: /* struct_variable_declaration_list: struct_variable_declaration_list "new line, semicolon"  */
                                                                  { (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList); }
     break;
 
-  case 595: /* struct_variable_declaration_list: struct_variable_declaration_list "typedef" "name" '=' type_declaration SEMICOLON  */
+  case 597: /* struct_variable_declaration_list: struct_variable_declaration_list "typedef" "name" '=' type_declaration SEMICOLON  */
                                                                                                                 {
         (yyval.pVarDeclList) = (yyvsp[-5].pVarDeclList);
         ast_structureAlias(scanner,(yyvsp[-3].s),(yyvsp[-1].pTypeDecl),tokAt(scanner,(yylsp[-4])));
     }
     break;
 
-  case 596: /* $@45: %empty  */
+  case 598: /* $@45: %empty  */
                                                {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -8711,7 +8730,7 @@ yyreduce:
     }
     break;
 
-  case 597: /* struct_variable_declaration_list: struct_variable_declaration_list $@45 structure_variable_declaration SEMICOLON  */
+  case 599: /* struct_variable_declaration_list: struct_variable_declaration_list $@45 structure_variable_declaration SEMICOLON  */
                                                      {
         (yyval.pVarDeclList) = (yyvsp[-3].pVarDeclList);
         if ( (yyvsp[-1].pVarDecl) ) (yyvsp[-3].pVarDeclList)->push_back((yyvsp[-1].pVarDecl));
@@ -8727,7 +8746,7 @@ yyreduce:
     }
     break;
 
-  case 598: /* $@46: %empty  */
+  case 600: /* $@46: %empty  */
                                                                                                                      {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[-2]));
@@ -8736,7 +8755,7 @@ yyreduce:
             }
     break;
 
-  case 599: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable "abstract" optional_constant $@46 function_declaration_header SEMICOLON  */
+  case 601: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable "abstract" optional_constant $@46 function_declaration_header SEMICOLON  */
                                                           {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[-1]));
@@ -8747,7 +8766,7 @@ yyreduce:
             }
     break;
 
-  case 600: /* $@47: %empty  */
+  case 602: /* $@47: %empty  */
                                                                                                                                                                          {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[0]));
@@ -8756,7 +8775,7 @@ yyreduce:
             }
     break;
 
-  case 601: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable optional_static_member_variable optional_override optional_constant $@47 function_declaration_header optional_emit_semis expression_block  */
+  case 603: /* struct_variable_declaration_list: struct_variable_declaration_list optional_annotation_list_with_emit_semis "def" optional_public_or_private_member_variable optional_static_member_variable optional_override optional_constant $@47 function_declaration_header optional_emit_semis expression_block  */
                                                                                             {
                 if ( !yyextra->g_CommentReaders.empty() ) {
                     auto tak = tokAt(scanner,(yylsp[0]));
@@ -8767,7 +8786,7 @@ yyreduce:
             }
     break;
 
-  case 602: /* function_argument_declaration_no_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_no_type  */
+  case 604: /* function_argument_declaration_no_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_no_type  */
                                                                                                           {
             (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
             if ( (yyvsp[-1].b) ) {
@@ -8779,7 +8798,7 @@ yyreduce:
         }
     break;
 
-  case 603: /* function_argument_declaration_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_type  */
+  case 605: /* function_argument_declaration_type: optional_field_annotation kwd_let_var_or_nothing variable_declaration_type  */
                                                                                                        {
             (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
             if ( (yyvsp[-1].b) ) {
@@ -8791,7 +8810,7 @@ yyreduce:
         }
     break;
 
-  case 604: /* function_argument_declaration_type: "$a" '(' expr ')'  */
+  case 606: /* function_argument_declaration_type: "$a" '(' expr ')'  */
                                      {
             auto na = new vector<VariableNameAndPosition>();
             na->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1]))));
@@ -8801,33 +8820,33 @@ yyreduce:
         }
     break;
 
-  case 605: /* function_argument_list: function_argument_declaration_no_type  */
+  case 607: /* function_argument_list: function_argument_declaration_no_type  */
                                                                                       { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 606: /* function_argument_list: function_argument_declaration_type  */
+  case 608: /* function_argument_list: function_argument_declaration_type  */
                                                                                       { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 607: /* function_argument_list: function_argument_declaration_no_type ';' function_argument_list  */
+  case 609: /* function_argument_list: function_argument_declaration_no_type ';' function_argument_list  */
                                                                                       { (yyval.pVarDeclList) = (yyvsp[0].pVarDeclList); (yyvsp[0].pVarDeclList)->insert((yyvsp[0].pVarDeclList)->begin(),(yyvsp[-2].pVarDecl)); }
     break;
 
-  case 608: /* function_argument_list: function_argument_declaration_type ';' function_argument_list  */
+  case 610: /* function_argument_list: function_argument_declaration_type ';' function_argument_list  */
                                                                                       { (yyval.pVarDeclList) = (yyvsp[0].pVarDeclList); (yyvsp[0].pVarDeclList)->insert((yyvsp[0].pVarDeclList)->begin(),(yyvsp[-2].pVarDecl)); }
     break;
 
-  case 609: /* function_argument_list: function_argument_declaration_type ',' function_argument_list  */
+  case 611: /* function_argument_list: function_argument_declaration_type ',' function_argument_list  */
                                                                                       { (yyval.pVarDeclList) = (yyvsp[0].pVarDeclList); (yyvsp[0].pVarDeclList)->insert((yyvsp[0].pVarDeclList)->begin(),(yyvsp[-2].pVarDecl)); }
     break;
 
-  case 610: /* tuple_type: type_declaration  */
+  case 612: /* tuple_type: type_declaration  */
                                     {
         (yyval.pVarDecl) = new VariableDeclaration(nullptr,(yyvsp[0].pTypeDecl),nullptr);
     }
     break;
 
-  case 611: /* tuple_type: "name" ':' type_declaration  */
+  case 613: /* tuple_type: "name" ':' type_declaration  */
                                                    {
         auto na = new vector<VariableNameAndPosition>();
         na->push_back(VariableNameAndPosition(*(yyvsp[-2].s),"",tokAt(scanner,(yylsp[-2]))));
@@ -8836,28 +8855,28 @@ yyreduce:
     }
     break;
 
-  case 612: /* tuple_type_list: tuple_type  */
+  case 614: /* tuple_type_list: tuple_type  */
                                                        { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 613: /* tuple_type_list: tuple_type_list c_or_s tuple_type  */
+  case 615: /* tuple_type_list: tuple_type_list c_or_s tuple_type  */
                                                        { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 614: /* tuple_alias_type_list: %empty  */
+  case 616: /* tuple_alias_type_list: %empty  */
       {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 615: /* tuple_alias_type_list: tuple_type  */
+  case 617: /* tuple_alias_type_list: tuple_type  */
                        {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
         (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl));
     }
     break;
 
-  case 616: /* tuple_alias_type_list: tuple_alias_type_list semis tuple_type  */
+  case 618: /* tuple_alias_type_list: tuple_alias_type_list semis tuple_type  */
                                                          {
         (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
         if ( !yyextra->g_CommentReaders.empty() ) {
@@ -8870,7 +8889,7 @@ yyreduce:
     }
     break;
 
-  case 617: /* variant_type: "name" ':' type_declaration  */
+  case 619: /* variant_type: "name" ':' type_declaration  */
                                                    {
         auto na = new vector<VariableNameAndPosition>();
         na->push_back(VariableNameAndPosition(*(yyvsp[-2].s),"",tokAt(scanner,(yylsp[-2]))));
@@ -8879,28 +8898,28 @@ yyreduce:
     }
     break;
 
-  case 618: /* variant_type_list: variant_type  */
+  case 620: /* variant_type_list: variant_type  */
                                                          { (yyval.pVarDeclList) = new vector<VariableDeclaration*>(); (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 619: /* variant_type_list: variant_type_list c_or_s variant_type  */
+  case 621: /* variant_type_list: variant_type_list c_or_s variant_type  */
                                                             { (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl)); }
     break;
 
-  case 620: /* variant_alias_type_list: %empty  */
+  case 622: /* variant_alias_type_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 621: /* variant_alias_type_list: variant_type  */
+  case 623: /* variant_alias_type_list: variant_type  */
                          {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
         (yyval.pVarDeclList)->push_back((yyvsp[0].pVarDecl));
     }
     break;
 
-  case 622: /* variant_alias_type_list: variant_alias_type_list semis variant_type  */
+  case 624: /* variant_alias_type_list: variant_alias_type_list semis variant_type  */
                                                                {
         (yyval.pVarDeclList) = (yyvsp[-2].pVarDeclList); (yyvsp[-2].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
         if ( !yyextra->g_CommentReaders.empty() ) {
@@ -8913,15 +8932,15 @@ yyreduce:
     }
     break;
 
-  case 623: /* copy_or_move: '='  */
+  case 625: /* copy_or_move: '='  */
                     { (yyval.b) = false; }
     break;
 
-  case 624: /* copy_or_move: "<-"  */
+  case 626: /* copy_or_move: "<-"  */
                     { (yyval.b) = true; }
     break;
 
-  case 625: /* variable_declaration_no_type: variable_name_with_pos_list  */
+  case 627: /* variable_declaration_no_type: variable_name_with_pos_list  */
                                           {
         auto autoT = new TypeDecl(Type::autoinfer);
         autoT->at = tokAt(scanner,(yylsp[0]));
@@ -8930,7 +8949,7 @@ yyreduce:
     }
     break;
 
-  case 626: /* variable_declaration_no_type: variable_name_with_pos_list '&'  */
+  case 628: /* variable_declaration_no_type: variable_name_with_pos_list '&'  */
                                               {
         auto autoT = new TypeDecl(Type::autoinfer);
         autoT->at = tokAt(scanner,(yylsp[-1]));
@@ -8939,7 +8958,7 @@ yyreduce:
     }
     break;
 
-  case 627: /* variable_declaration_no_type: variable_name_with_pos_list copy_or_move expr  */
+  case 629: /* variable_declaration_no_type: variable_name_with_pos_list copy_or_move expr  */
                                                                        {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-2]));
@@ -8948,52 +8967,52 @@ yyreduce:
     }
     break;
 
-  case 628: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration  */
+  case 630: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration  */
                                                                           {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),(yyvsp[0].pTypeDecl),nullptr);
     }
     break;
 
-  case 629: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration copy_or_move expr  */
+  case 631: /* variable_declaration_type: variable_name_with_pos_list ':' type_declaration copy_or_move expr  */
                                                                                                       {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),(yyvsp[-2].pTypeDecl),(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
     }
     break;
 
-  case 630: /* variable_declaration: variable_declaration_type  */
+  case 632: /* variable_declaration: variable_declaration_type  */
                                         {
         (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
     }
     break;
 
-  case 631: /* variable_declaration: variable_declaration_no_type  */
+  case 633: /* variable_declaration: variable_declaration_no_type  */
                                            {
         (yyval.pVarDecl) = (yyvsp[0].pVarDecl);
     }
     break;
 
-  case 632: /* copy_or_move_or_clone: '='  */
+  case 634: /* copy_or_move_or_clone: '='  */
                     { (yyval.i) = CorM_COPY; }
     break;
 
-  case 633: /* copy_or_move_or_clone: "<-"  */
+  case 635: /* copy_or_move_or_clone: "<-"  */
                     { (yyval.i) = CorM_MOVE; }
     break;
 
-  case 634: /* copy_or_move_or_clone: ":="  */
+  case 636: /* copy_or_move_or_clone: ":="  */
                     { (yyval.i) = CorM_CLONE; }
     break;
 
-  case 635: /* optional_ref: %empty  */
+  case 637: /* optional_ref: %empty  */
             { (yyval.b) = false; }
     break;
 
-  case 636: /* optional_ref: '&'  */
+  case 638: /* optional_ref: '&'  */
             { (yyval.b) = true; }
     break;
 
-  case 637: /* let_variable_name_with_pos_list: "name"  */
+  case 639: /* let_variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -9003,7 +9022,7 @@ yyreduce:
     }
     break;
 
-  case 638: /* let_variable_name_with_pos_list: "$i" '(' expr ')'  */
+  case 640: /* let_variable_name_with_pos_list: "$i" '(' expr ')'  */
                                      {
         auto pSL = new vector<VariableNameAndPosition>();
         pSL->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression)));
@@ -9011,7 +9030,7 @@ yyreduce:
     }
     break;
 
-  case 639: /* let_variable_name_with_pos_list: "name" "aka" "name"  */
+  case 641: /* let_variable_name_with_pos_list: "name" "aka" "name"  */
                                          {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9023,7 +9042,7 @@ yyreduce:
     }
     break;
 
-  case 640: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name"  */
+  case 642: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name"  */
                                                              {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -9032,7 +9051,7 @@ yyreduce:
     }
     break;
 
-  case 641: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name" "aka" "name"  */
+  case 643: /* let_variable_name_with_pos_list: let_variable_name_with_pos_list ',' "name" "aka" "name"  */
                                                                                    {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9043,7 +9062,7 @@ yyreduce:
     }
     break;
 
-  case 642: /* global_let_variable_name_with_pos_list: "name"  */
+  case 644: /* global_let_variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -9053,7 +9072,7 @@ yyreduce:
     }
     break;
 
-  case 643: /* global_let_variable_name_with_pos_list: global_let_variable_name_with_pos_list ',' "name"  */
+  case 645: /* global_let_variable_name_with_pos_list: global_let_variable_name_with_pos_list ',' "name"  */
                                                                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -9062,32 +9081,32 @@ yyreduce:
     }
     break;
 
-  case 644: /* variable_declaration_list: %empty  */
+  case 646: /* variable_declaration_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 645: /* variable_declaration_list: variable_declaration_list SEMICOLON  */
+  case 647: /* variable_declaration_list: variable_declaration_list SEMICOLON  */
                                                   {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
     }
     break;
 
-  case 646: /* variable_declaration_list: variable_declaration_list let_variable_declaration  */
+  case 648: /* variable_declaration_list: variable_declaration_list let_variable_declaration  */
                                                                        {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
         (yyvsp[-1].pVarDeclList)->push_back((yyvsp[0].pVarDecl));
     }
     break;
 
-  case 647: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
+  case 649: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
                                                                                                   {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),(yyvsp[-1].pTypeDecl),nullptr);
     }
     break;
 
-  case 648: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
+  case 650: /* let_variable_declaration: let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                                         {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameWithPosList),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -9095,7 +9114,7 @@ yyreduce:
     }
     break;
 
-  case 649: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
+  case 651: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                 {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-4]));
@@ -9106,13 +9125,13 @@ yyreduce:
     }
     break;
 
-  case 650: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
+  case 652: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options SEMICOLON  */
                                                                                                          {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),(yyvsp[-1].pTypeDecl),nullptr);
     }
     break;
 
-  case 651: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
+  case 653: /* global_let_variable_declaration: global_let_variable_name_with_pos_list ':' type_declaration_no_options copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                                                {
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameWithPosList),(yyvsp[-3].pTypeDecl),(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -9120,7 +9139,7 @@ yyreduce:
     }
     break;
 
-  case 652: /* global_let_variable_declaration: global_let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
+  case 654: /* global_let_variable_declaration: global_let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                        {
         auto typeDecl = new TypeDecl(Type::autoinfer);
         typeDecl->at = tokAt(scanner,(yylsp[-4]));
@@ -9131,39 +9150,39 @@ yyreduce:
     }
     break;
 
-  case 653: /* optional_shared: %empty  */
+  case 655: /* optional_shared: %empty  */
                      { (yyval.b) = false; }
     break;
 
-  case 654: /* optional_shared: "shared"  */
+  case 656: /* optional_shared: "shared"  */
                      { (yyval.b) = true; }
     break;
 
-  case 655: /* optional_public_or_private_variable: %empty  */
+  case 657: /* optional_public_or_private_variable: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 656: /* optional_public_or_private_variable: "private"  */
+  case 658: /* optional_public_or_private_variable: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 657: /* optional_public_or_private_variable: "public"  */
+  case 659: /* optional_public_or_private_variable: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 658: /* global_variable_declaration_list: %empty  */
+  case 660: /* global_variable_declaration_list: %empty  */
         {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 659: /* global_variable_declaration_list: global_variable_declaration_list SEMICOLON  */
+  case 661: /* global_variable_declaration_list: global_variable_declaration_list SEMICOLON  */
                                                          {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
     }
     break;
 
-  case 660: /* $@48: %empty  */
+  case 662: /* $@48: %empty  */
                                                {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9172,7 +9191,7 @@ yyreduce:
     }
     break;
 
-  case 661: /* global_variable_declaration_list: global_variable_declaration_list $@48 optional_field_annotation let_variable_declaration  */
+  case 663: /* global_variable_declaration_list: global_variable_declaration_list $@48 optional_field_annotation let_variable_declaration  */
                                                                       {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9187,13 +9206,13 @@ yyreduce:
     }
     break;
 
-  case 662: /* global_let: kwd_let optional_shared optional_public_or_private_variable '{' global_variable_declaration_list '}'  */
+  case 664: /* global_let: kwd_let optional_shared optional_public_or_private_variable '{' global_variable_declaration_list '}'  */
                                                                                                                                        {
         ast_globalLetList(scanner,(yyvsp[-5].b),(yyvsp[-4].b),(yyvsp[-3].b),(yyvsp[-1].pVarDeclList));
     }
     break;
 
-  case 663: /* $@49: %empty  */
+  case 665: /* $@49: %empty  */
                                                                                         {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9202,7 +9221,7 @@ yyreduce:
     }
     break;
 
-  case 664: /* global_let: kwd_let optional_shared optional_public_or_private_variable $@49 optional_field_annotation global_let_variable_declaration  */
+  case 666: /* global_let: kwd_let optional_shared optional_public_or_private_variable $@49 optional_field_annotation global_let_variable_declaration  */
                                                                            {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[0]));
@@ -9215,7 +9234,7 @@ yyreduce:
     }
     break;
 
-  case 665: /* enum_expression: "name"  */
+  case 667: /* enum_expression: "name"  */
                    {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyval.pEnumPair) = new EnumPair((yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9223,7 +9242,7 @@ yyreduce:
     }
     break;
 
-  case 666: /* enum_expression: "name" '=' expr  */
+  case 668: /* enum_expression: "name" '=' expr  */
                                    {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         (yyval.pEnumPair) = new EnumPair((yyvsp[-2].s),(yyvsp[0].pExpression),tokAt(scanner,(yylsp[-2])));
@@ -9231,13 +9250,13 @@ yyreduce:
     }
     break;
 
-  case 669: /* enum_list: %empty  */
+  case 671: /* enum_list: %empty  */
         {
         (yyval.pEnumList) = new Enumeration();
     }
     break;
 
-  case 670: /* enum_list: enum_expression  */
+  case 672: /* enum_list: enum_expression  */
                             {
         (yyval.pEnumList) = new Enumeration();
         if ( !(yyval.pEnumList)->add((yyvsp[0].pEnumPair)->name,(yyvsp[0].pEnumPair)->expr,(yyvsp[0].pEnumPair)->at) ) {
@@ -9253,7 +9272,7 @@ yyreduce:
     }
     break;
 
-  case 671: /* enum_list: enum_list commas enum_expression  */
+  case 673: /* enum_list: enum_list commas enum_expression  */
                                                  {
         if ( !(yyvsp[-2].pEnumList)->add((yyvsp[0].pEnumPair)->name,(yyvsp[0].pEnumPair)->expr,(yyvsp[0].pEnumPair)->at) ) {
             das2_yyerror(scanner,"enumeration already declared " + (yyvsp[0].pEnumPair)->name, (yyvsp[0].pEnumPair)->at,
@@ -9269,19 +9288,19 @@ yyreduce:
     }
     break;
 
-  case 672: /* optional_public_or_private_alias: %empty  */
+  case 674: /* optional_public_or_private_alias: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 673: /* optional_public_or_private_alias: "private"  */
+  case 675: /* optional_public_or_private_alias: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 674: /* optional_public_or_private_alias: "public"  */
+  case 676: /* optional_public_or_private_alias: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 675: /* $@50: %empty  */
+  case 677: /* $@50: %empty  */
                                                          {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto pubename = tokAt(scanner,(yylsp[0]));
@@ -9290,7 +9309,7 @@ yyreduce:
     }
     break;
 
-  case 676: /* single_alias: optional_public_or_private_alias "name" $@50 '=' type_declaration  */
+  case 678: /* single_alias: optional_public_or_private_alias "name" $@50 '=' type_declaration  */
                                   {
         das_checkName(scanner,*(yyvsp[-3].s),tokAt(scanner,(yylsp[-3])));
         (yyvsp[0].pTypeDecl)->isPrivateAlias = !(yyvsp[-4].b);
@@ -9311,19 +9330,19 @@ yyreduce:
     }
     break;
 
-  case 678: /* optional_public_or_private_enum: %empty  */
+  case 680: /* optional_public_or_private_enum: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 679: /* optional_public_or_private_enum: "private"  */
+  case 681: /* optional_public_or_private_enum: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 680: /* optional_public_or_private_enum: "public"  */
+  case 682: /* optional_public_or_private_enum: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 681: /* enum_name: "name"  */
+  case 683: /* enum_name: "name"  */
                    {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto pubename = tokAt(scanner,(yylsp[0]));
@@ -9333,25 +9352,25 @@ yyreduce:
     }
     break;
 
-  case 682: /* optional_enum_basic_type_declaration: %empty  */
+  case 684: /* optional_enum_basic_type_declaration: %empty  */
         {
         (yyval.type) = Type::tInt;
     }
     break;
 
-  case 683: /* optional_enum_basic_type_declaration: ':' enum_basic_type_declaration  */
+  case 685: /* optional_enum_basic_type_declaration: ':' enum_basic_type_declaration  */
                                               {
         (yyval.type) = (yyvsp[0].type);
     }
     break;
 
-  case 690: /* $@51: %empty  */
+  case 692: /* $@51: %empty  */
                                                                      {
         yyextra->push_nesteds(DAS_EMIT_COMMA);
     }
     break;
 
-  case 691: /* $@52: %empty  */
+  case 693: /* $@52: %empty  */
                                                                                                                                 {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[-3]));
@@ -9360,7 +9379,7 @@ yyreduce:
     }
     break;
 
-  case 692: /* $@53: %empty  */
+  case 694: /* $@53: %empty  */
                                     {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[-1]));
@@ -9370,7 +9389,7 @@ yyreduce:
     }
     break;
 
-  case 693: /* enum_declaration: optional_annotation_list_with_emit_semis "enum" $@51 optional_public_or_private_enum enum_name optional_enum_basic_type_declaration optional_emit_commas '{' $@52 enum_list optional_commas $@53 '}'  */
+  case 695: /* enum_declaration: optional_annotation_list_with_emit_semis "enum" $@51 optional_public_or_private_enum enum_name optional_enum_basic_type_declaration optional_emit_commas '{' $@52 enum_list optional_commas $@53 '}'  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto pubename = tokAt(scanner,(yylsp[-3]));
@@ -9380,75 +9399,75 @@ yyreduce:
     }
     break;
 
-  case 694: /* optional_structure_parent: %empty  */
+  case 696: /* optional_structure_parent: %empty  */
                                         { (yyval.s) = nullptr; }
     break;
 
-  case 695: /* optional_structure_parent: ':' name_in_namespace  */
+  case 697: /* optional_structure_parent: ':' name_in_namespace  */
                                         { (yyval.s) = (yyvsp[0].s); }
     break;
 
-  case 696: /* optional_sealed: %empty  */
+  case 698: /* optional_sealed: %empty  */
                         { (yyval.b) = false; }
     break;
 
-  case 697: /* optional_sealed: "sealed"  */
+  case 699: /* optional_sealed: "sealed"  */
                         { (yyval.b) = true; }
     break;
 
-  case 698: /* structure_name: optional_sealed "name" optional_structure_parent  */
+  case 700: /* structure_name: optional_sealed "name" optional_structure_parent  */
                                                                            {
         (yyval.pStructure) = ast_structureName(scanner,(yyvsp[-2].b),(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])),(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 699: /* class_or_struct: "class"  */
+  case 701: /* class_or_struct: "class"  */
                     { (yyval.i) = CorS_Class; }
     break;
 
-  case 700: /* class_or_struct: "struct"  */
+  case 702: /* class_or_struct: "struct"  */
                     { (yyval.i) = CorS_Struct; }
     break;
 
-  case 701: /* class_or_struct: "class" "template"  */
+  case 703: /* class_or_struct: "class" "template"  */
                                   { (yyval.i) = CorS_ClassTemplate; }
     break;
 
-  case 702: /* class_or_struct: "struct" "template"  */
+  case 704: /* class_or_struct: "struct" "template"  */
                                   { (yyval.i) = CorS_StructTemplate; }
     break;
 
-  case 703: /* optional_public_or_private_structure: %empty  */
+  case 705: /* optional_public_or_private_structure: %empty  */
                      { (yyval.b) = yyextra->g_Program->thisModule->isPublic; }
     break;
 
-  case 704: /* optional_public_or_private_structure: "private"  */
+  case 706: /* optional_public_or_private_structure: "private"  */
                      { (yyval.b) = false; }
     break;
 
-  case 705: /* optional_public_or_private_structure: "public"  */
+  case 707: /* optional_public_or_private_structure: "public"  */
                      { (yyval.b) = true; }
     break;
 
-  case 706: /* optional_struct_variable_declaration_list: ';'  */
+  case 708: /* optional_struct_variable_declaration_list: ';'  */
             {
         (yyval.pVarDeclList) = new vector<VariableDeclaration*>();
     }
     break;
 
-  case 707: /* optional_struct_variable_declaration_list: '{' struct_variable_declaration_list '}'  */
+  case 709: /* optional_struct_variable_declaration_list: '{' struct_variable_declaration_list '}'  */
                                                        {
         (yyval.pVarDeclList) = (yyvsp[-1].pVarDeclList);
     }
     break;
 
-  case 708: /* $@54: %empty  */
+  case 710: /* $@54: %empty  */
                                                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 709: /* $@55: %empty  */
+  case 711: /* $@55: %empty  */
                                                                          {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto tak = tokAt(scanner,(yylsp[-1]));
@@ -9457,7 +9476,7 @@ yyreduce:
     }
     break;
 
-  case 710: /* $@56: %empty  */
+  case 712: /* $@56: %empty  */
                                              {
         if ( (yyvsp[-1].pStructure) ) {
             (yyvsp[-1].pStructure)->isClass = (yyvsp[-4].i)==CorS_Class || (yyvsp[-4].i)==CorS_ClassTemplate;
@@ -9467,7 +9486,7 @@ yyreduce:
     }
     break;
 
-  case 711: /* structure_declaration: optional_annotation_list_with_emit_semis $@54 class_or_struct optional_public_or_private_structure $@55 structure_name optional_emit_semis $@56 optional_struct_variable_declaration_list  */
+  case 713: /* structure_declaration: optional_annotation_list_with_emit_semis $@54 class_or_struct optional_public_or_private_structure $@55 structure_name optional_emit_semis $@56 optional_struct_variable_declaration_list  */
                                                       {
         yyextra->pop_nesteds();
         if ( (yyvsp[-3].pStructure) ) {
@@ -9482,7 +9501,7 @@ yyreduce:
     }
     break;
 
-  case 712: /* variable_name_with_pos_list: "name"  */
+  case 714: /* variable_name_with_pos_list: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<VariableNameAndPosition>();
@@ -9492,7 +9511,7 @@ yyreduce:
     }
     break;
 
-  case 713: /* variable_name_with_pos_list: "$i" '(' expr ')'  */
+  case 715: /* variable_name_with_pos_list: "$i" '(' expr ')'  */
                                      {
         auto pSL = new vector<VariableNameAndPosition>();
         pSL->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1])),(yyvsp[-1].pExpression)));
@@ -9500,7 +9519,7 @@ yyreduce:
     }
     break;
 
-  case 714: /* variable_name_with_pos_list: "name" "aka" "name"  */
+  case 716: /* variable_name_with_pos_list: "name" "aka" "name"  */
                                          {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9512,7 +9531,7 @@ yyreduce:
     }
     break;
 
-  case 715: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name"  */
+  case 717: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name"  */
                                                          {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameWithPosList)->push_back(VariableNameAndPosition(*(yyvsp[0].s),"",tokAt(scanner,(yylsp[0]))));
@@ -9521,7 +9540,7 @@ yyreduce:
     }
     break;
 
-  case 716: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name" "aka" "name"  */
+  case 718: /* variable_name_with_pos_list: variable_name_with_pos_list ',' "name" "aka" "name"  */
                                                                                {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9532,147 +9551,147 @@ yyreduce:
     }
     break;
 
-  case 717: /* basic_type_declaration: "bool"  */
+  case 719: /* basic_type_declaration: "bool"  */
                         { (yyval.type) = Type::tBool; }
     break;
 
-  case 718: /* basic_type_declaration: "string"  */
+  case 720: /* basic_type_declaration: "string"  */
                         { (yyval.type) = Type::tString; }
     break;
 
-  case 719: /* basic_type_declaration: "int"  */
+  case 721: /* basic_type_declaration: "int"  */
                         { (yyval.type) = Type::tInt; }
     break;
 
-  case 720: /* basic_type_declaration: "int8"  */
+  case 722: /* basic_type_declaration: "int8"  */
                         { (yyval.type) = Type::tInt8; }
     break;
 
-  case 721: /* basic_type_declaration: "int16"  */
+  case 723: /* basic_type_declaration: "int16"  */
                         { (yyval.type) = Type::tInt16; }
     break;
 
-  case 722: /* basic_type_declaration: "int64"  */
+  case 724: /* basic_type_declaration: "int64"  */
                         { (yyval.type) = Type::tInt64; }
     break;
 
-  case 723: /* basic_type_declaration: "int2"  */
+  case 725: /* basic_type_declaration: "int2"  */
                         { (yyval.type) = Type::tInt2; }
     break;
 
-  case 724: /* basic_type_declaration: "int3"  */
+  case 726: /* basic_type_declaration: "int3"  */
                         { (yyval.type) = Type::tInt3; }
     break;
 
-  case 725: /* basic_type_declaration: "int4"  */
+  case 727: /* basic_type_declaration: "int4"  */
                         { (yyval.type) = Type::tInt4; }
     break;
 
-  case 726: /* basic_type_declaration: "uint"  */
+  case 728: /* basic_type_declaration: "uint"  */
                         { (yyval.type) = Type::tUInt; }
     break;
 
-  case 727: /* basic_type_declaration: "uint8"  */
+  case 729: /* basic_type_declaration: "uint8"  */
                         { (yyval.type) = Type::tUInt8; }
     break;
 
-  case 728: /* basic_type_declaration: "uint16"  */
+  case 730: /* basic_type_declaration: "uint16"  */
                         { (yyval.type) = Type::tUInt16; }
     break;
 
-  case 729: /* basic_type_declaration: "uint64"  */
+  case 731: /* basic_type_declaration: "uint64"  */
                         { (yyval.type) = Type::tUInt64; }
     break;
 
-  case 730: /* basic_type_declaration: "uint2"  */
+  case 732: /* basic_type_declaration: "uint2"  */
                         { (yyval.type) = Type::tUInt2; }
     break;
 
-  case 731: /* basic_type_declaration: "uint3"  */
+  case 733: /* basic_type_declaration: "uint3"  */
                         { (yyval.type) = Type::tUInt3; }
     break;
 
-  case 732: /* basic_type_declaration: "uint4"  */
+  case 734: /* basic_type_declaration: "uint4"  */
                         { (yyval.type) = Type::tUInt4; }
     break;
 
-  case 733: /* basic_type_declaration: "float"  */
+  case 735: /* basic_type_declaration: "float"  */
                         { (yyval.type) = Type::tFloat; }
     break;
 
-  case 734: /* basic_type_declaration: "float2"  */
+  case 736: /* basic_type_declaration: "float2"  */
                         { (yyval.type) = Type::tFloat2; }
     break;
 
-  case 735: /* basic_type_declaration: "float3"  */
+  case 737: /* basic_type_declaration: "float3"  */
                         { (yyval.type) = Type::tFloat3; }
     break;
 
-  case 736: /* basic_type_declaration: "float4"  */
+  case 738: /* basic_type_declaration: "float4"  */
                         { (yyval.type) = Type::tFloat4; }
     break;
 
-  case 737: /* basic_type_declaration: "void"  */
+  case 739: /* basic_type_declaration: "void"  */
                         { (yyval.type) = Type::tVoid; }
     break;
 
-  case 738: /* basic_type_declaration: "range"  */
+  case 740: /* basic_type_declaration: "range"  */
                         { (yyval.type) = Type::tRange; }
     break;
 
-  case 739: /* basic_type_declaration: "urange"  */
+  case 741: /* basic_type_declaration: "urange"  */
                         { (yyval.type) = Type::tURange; }
     break;
 
-  case 740: /* basic_type_declaration: "range64"  */
+  case 742: /* basic_type_declaration: "range64"  */
                         { (yyval.type) = Type::tRange64; }
     break;
 
-  case 741: /* basic_type_declaration: "urange64"  */
+  case 743: /* basic_type_declaration: "urange64"  */
                         { (yyval.type) = Type::tURange64; }
     break;
 
-  case 742: /* basic_type_declaration: "double"  */
+  case 744: /* basic_type_declaration: "double"  */
                         { (yyval.type) = Type::tDouble; }
     break;
 
-  case 743: /* basic_type_declaration: "bitfield"  */
+  case 745: /* basic_type_declaration: "bitfield"  */
                         { (yyval.type) = Type::tBitfield; }
     break;
 
-  case 744: /* enum_basic_type_declaration: "int"  */
+  case 746: /* enum_basic_type_declaration: "int"  */
                         { (yyval.type) = Type::tInt; }
     break;
 
-  case 745: /* enum_basic_type_declaration: "int8"  */
+  case 747: /* enum_basic_type_declaration: "int8"  */
                         { (yyval.type) = Type::tInt8; }
     break;
 
-  case 746: /* enum_basic_type_declaration: "int16"  */
+  case 748: /* enum_basic_type_declaration: "int16"  */
                         { (yyval.type) = Type::tInt16; }
     break;
 
-  case 747: /* enum_basic_type_declaration: "uint"  */
+  case 749: /* enum_basic_type_declaration: "uint"  */
                         { (yyval.type) = Type::tUInt; }
     break;
 
-  case 748: /* enum_basic_type_declaration: "uint8"  */
+  case 750: /* enum_basic_type_declaration: "uint8"  */
                         { (yyval.type) = Type::tUInt8; }
     break;
 
-  case 749: /* enum_basic_type_declaration: "uint16"  */
+  case 751: /* enum_basic_type_declaration: "uint16"  */
                         { (yyval.type) = Type::tUInt16; }
     break;
 
-  case 750: /* enum_basic_type_declaration: "int64"  */
+  case 752: /* enum_basic_type_declaration: "int64"  */
                         { (yyval.type) = Type::tInt64; }
     break;
 
-  case 751: /* enum_basic_type_declaration: "uint64"  */
+  case 753: /* enum_basic_type_declaration: "uint64"  */
                         { (yyval.type) = Type::tUInt64; }
     break;
 
-  case 752: /* structure_type_declaration: name_in_namespace  */
+  case 754: /* structure_type_declaration: name_in_namespace  */
                                  {
         (yyval.pTypeDecl) = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
         if ( !(yyval.pTypeDecl) ) {
@@ -9683,14 +9702,14 @@ yyreduce:
     }
     break;
 
-  case 753: /* auto_type_declaration: "auto"  */
+  case 755: /* auto_type_declaration: "auto"  */
                        {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
 
-  case 754: /* auto_type_declaration: "auto" '(' "name" ')'  */
+  case 756: /* auto_type_declaration: "auto" '(' "name" ')'  */
                                             {
         das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
@@ -9700,7 +9719,7 @@ yyreduce:
     }
     break;
 
-  case 755: /* auto_type_declaration: "$t" '(' expr ')'  */
+  case 757: /* auto_type_declaration: "$t" '(' expr ')'  */
                                           {
         (yyval.pTypeDecl) = new TypeDecl(Type::alias);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
@@ -9712,7 +9731,7 @@ yyreduce:
     }
     break;
 
-  case 756: /* bitfield_bits: "name"  */
+  case 758: /* bitfield_bits: "name"  */
                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         auto pSL = new vector<string>();
@@ -9722,7 +9741,7 @@ yyreduce:
     }
     break;
 
-  case 757: /* bitfield_bits: bitfield_bits ';' "name"  */
+  case 759: /* bitfield_bits: bitfield_bits ';' "name"  */
                                            {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
@@ -9731,7 +9750,7 @@ yyreduce:
     }
     break;
 
-  case 758: /* bitfield_bits: bitfield_bits ',' "name"  */
+  case 760: /* bitfield_bits: bitfield_bits ',' "name"  */
                                            {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameList)->push_back(*(yyvsp[0].s));
@@ -9740,7 +9759,7 @@ yyreduce:
     }
     break;
 
-  case 759: /* bitfield_alias_bits: %empty  */
+  case 761: /* bitfield_alias_bits: %empty  */
         {
         auto pSL = new vector<tuple<string,Expression *>>();
         (yyval.pNameExprList) = pSL;
@@ -9748,7 +9767,7 @@ yyreduce:
     }
     break;
 
-  case 760: /* bitfield_alias_bits: "name"  */
+  case 762: /* bitfield_alias_bits: "name"  */
                    {
         (yyval.pNameExprList) = new vector<tuple<string,Expression *>>();
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
@@ -9761,7 +9780,7 @@ yyreduce:
     }
     break;
 
-  case 761: /* bitfield_alias_bits: "name" '=' expr  */
+  case 763: /* bitfield_alias_bits: "name" '=' expr  */
                                    {
         (yyval.pNameExprList) = new vector<tuple<string,Expression *>>();
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
@@ -9774,7 +9793,7 @@ yyreduce:
     }
     break;
 
-  case 762: /* bitfield_alias_bits: bitfield_alias_bits commas "name"  */
+  case 764: /* bitfield_alias_bits: bitfield_alias_bits commas "name"  */
                                                     {
         das_checkName(scanner,*(yyvsp[0].s),tokAt(scanner,(yylsp[0])));
         (yyvsp[-2].pNameExprList)->emplace_back(*(yyvsp[0].s),nullptr);
@@ -9787,7 +9806,7 @@ yyreduce:
     }
     break;
 
-  case 763: /* bitfield_alias_bits: bitfield_alias_bits commas "name" '=' expr  */
+  case 765: /* bitfield_alias_bits: bitfield_alias_bits commas "name" '=' expr  */
                                                                     {
         das_checkName(scanner,*(yyvsp[-2].s),tokAt(scanner,(yylsp[-2])));
         (yyvsp[-4].pNameExprList)->emplace_back(*(yyvsp[-2].s),(yyvsp[0].pExpression));
@@ -9800,42 +9819,42 @@ yyreduce:
     }
     break;
 
-  case 764: /* bitfield_basic_type_declaration: %empty  */
+  case 766: /* bitfield_basic_type_declaration: %empty  */
                              { (yyval.type) = Type::tBitfield; }
     break;
 
-  case 765: /* bitfield_basic_type_declaration: ':' "uint8"  */
+  case 767: /* bitfield_basic_type_declaration: ':' "uint8"  */
                              { (yyval.type) = Type::tBitfield8; }
     break;
 
-  case 766: /* bitfield_basic_type_declaration: ':' "uint16"  */
+  case 768: /* bitfield_basic_type_declaration: ':' "uint16"  */
                              { (yyval.type) = Type::tBitfield16; }
     break;
 
-  case 767: /* bitfield_basic_type_declaration: ':' "uint"  */
+  case 769: /* bitfield_basic_type_declaration: ':' "uint"  */
                              { (yyval.type) = Type::tBitfield; }
     break;
 
-  case 768: /* bitfield_basic_type_declaration: ':' "uint64"  */
+  case 770: /* bitfield_basic_type_declaration: ':' "uint64"  */
                              { (yyval.type) = Type::tBitfield64; }
     break;
 
-  case 769: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' '>'  */
+  case 771: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' '>'  */
                                                                           {
             (yyval.pTypeDecl) = new TypeDecl((yyvsp[-2].type));
             (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-2]));
     }
     break;
 
-  case 770: /* $@57: %empty  */
+  case 772: /* $@57: %empty  */
                                                                      { yyextra->das_arrow_depth ++; }
     break;
 
-  case 771: /* $@58: %empty  */
+  case 773: /* $@58: %empty  */
                                                                                                                             { yyextra->das_arrow_depth --; }
     break;
 
-  case 772: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' $@57 bitfield_bits '>' $@58  */
+  case 774: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' $@57 bitfield_bits '>' $@58  */
                                                                                                                                                              {
             (yyval.pTypeDecl) = new TypeDecl((yyvsp[-5].type));
             (yyval.pTypeDecl)->argNames = *(yyvsp[-2].pNameList);
@@ -9849,55 +9868,55 @@ yyreduce:
     }
     break;
 
-  case 775: /* table_type_pair: type_declaration  */
+  case 777: /* table_type_pair: type_declaration  */
                                       {
         (yyval.aTypePair).firstType = (yyvsp[0].pTypeDecl);
         (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid);
     }
     break;
 
-  case 776: /* table_type_pair: type_declaration c_or_s type_declaration  */
+  case 778: /* table_type_pair: type_declaration c_or_s type_declaration  */
                                                                              {
         (yyval.aTypePair).firstType = (yyvsp[-2].pTypeDecl);
         (yyval.aTypePair).secondType = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 777: /* dim_list: '[' expr ']'  */
+  case 779: /* dim_list: '[' expr ']'  */
                              {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
         appendDimExpr((yyval.pTypeDecl), (yyvsp[-1].pExpression));
     }
     break;
 
-  case 778: /* dim_list: '[' ']'  */
+  case 780: /* dim_list: '[' ']'  */
                 {
         (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
         appendDimExpr((yyval.pTypeDecl), nullptr);
     }
     break;
 
-  case 779: /* dim_list: dim_list '[' expr ']'  */
+  case 781: /* dim_list: dim_list '[' expr ']'  */
                                             {
         (yyval.pTypeDecl) = (yyvsp[-3].pTypeDecl);
         appendDimExpr((yyval.pTypeDecl), (yyvsp[-1].pExpression));
     }
     break;
 
-  case 780: /* dim_list: dim_list '[' ']'  */
+  case 782: /* dim_list: dim_list '[' ']'  */
                               {
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
         appendDimExpr((yyval.pTypeDecl), nullptr);
     }
     break;
 
-  case 781: /* type_declaration_no_options: type_declaration_no_options_no_dim  */
+  case 783: /* type_declaration_no_options: type_declaration_no_options_no_dim  */
                                                      {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 782: /* type_declaration_no_options: type_declaration_no_options_no_dim dim_list  */
+  case 784: /* type_declaration_no_options: type_declaration_no_options_no_dim dim_list  */
                                                                        {
         if ( (yyvsp[-1].pTypeDecl)->baseType==Type::typeDecl ) {
             das2_yyerror(scanner,"type declaration can`t be used as array base type",tokAt(scanner,(yylsp[-1])),
@@ -9914,46 +9933,46 @@ yyreduce:
     }
     break;
 
-  case 783: /* optional_expr_list_in_braces: %empty  */
+  case 785: /* optional_expr_list_in_braces: %empty  */
             { (yyval.pExpression) = nullptr; }
     break;
 
-  case 784: /* optional_expr_list_in_braces: '(' expr_list optional_comma ')'  */
+  case 786: /* optional_expr_list_in_braces: '(' expr_list optional_comma ')'  */
                                                 { (yyval.pExpression) = (yyvsp[-2].pExpression); }
     break;
 
-  case 785: /* type_declaration_no_options_no_dim: basic_type_declaration  */
+  case 787: /* type_declaration_no_options_no_dim: basic_type_declaration  */
                                                             { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type)); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
     break;
 
-  case 786: /* type_declaration_no_options_no_dim: auto_type_declaration  */
+  case 788: /* type_declaration_no_options_no_dim: auto_type_declaration  */
                                                             { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
     break;
 
-  case 787: /* type_declaration_no_options_no_dim: bitfield_type_declaration  */
+  case 789: /* type_declaration_no_options_no_dim: bitfield_type_declaration  */
                                                             { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
     break;
 
-  case 788: /* type_declaration_no_options_no_dim: structure_type_declaration  */
+  case 790: /* type_declaration_no_options_no_dim: structure_type_declaration  */
                                                             { (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl); }
     break;
 
-  case 789: /* $@59: %empty  */
+  case 791: /* $@59: %empty  */
                      { yyextra->das_arrow_depth ++; }
     break;
 
-  case 790: /* $@60: %empty  */
+  case 792: /* $@60: %empty  */
                                                                                      { yyextra->das_arrow_depth --; }
     break;
 
-  case 791: /* type_declaration_no_options_no_dim: "type" '<' $@59 type_declaration '>' $@60  */
+  case 793: /* type_declaration_no_options_no_dim: "type" '<' $@59 type_declaration '>' $@60  */
                                                                                                                       {
         (yyvsp[-2].pTypeDecl)->autoToAlias = true;
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 792: /* type_declaration_no_options_no_dim: "typedecl" '(' expr ')'  */
+  case 794: /* type_declaration_no_options_no_dim: "typedecl" '(' expr ')'  */
                                                {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]),(yylsp[-1]));
@@ -9961,7 +9980,7 @@ yyreduce:
     }
     break;
 
-  case 793: /* type_declaration_no_options_no_dim: name_in_namespace '(' optional_expr_list ')'  */
+  case 795: /* type_declaration_no_options_no_dim: name_in_namespace '(' optional_expr_list ')'  */
                                                                       {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]), (yylsp[-1]));
@@ -9971,7 +9990,7 @@ yyreduce:
     }
     break;
 
-  case 794: /* type_declaration_no_options_no_dim: '$' name_in_namespace optional_expr_list_in_braces  */
+  case 796: /* type_declaration_no_options_no_dim: '$' name_in_namespace optional_expr_list_in_braces  */
                                                                             {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-1]), (yylsp[0]));
@@ -9981,11 +10000,11 @@ yyreduce:
     }
     break;
 
-  case 795: /* $@61: %empty  */
+  case 797: /* $@61: %empty  */
                                     { yyextra->das_arrow_depth ++; }
     break;
 
-  case 796: /* type_declaration_no_options_no_dim: name_in_namespace '<' $@61 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
+  case 798: /* type_declaration_no_options_no_dim: name_in_namespace '<' $@61 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                          {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
@@ -9995,11 +10014,11 @@ yyreduce:
     }
     break;
 
-  case 797: /* $@62: %empty  */
+  case 799: /* $@62: %empty  */
                                         { yyextra->das_arrow_depth ++; }
     break;
 
-  case 798: /* type_declaration_no_options_no_dim: '$' name_in_namespace '<' $@62 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
+  case 800: /* type_declaration_no_options_no_dim: '$' name_in_namespace '<' $@62 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                              {
         (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
@@ -10009,21 +10028,21 @@ yyreduce:
     }
     break;
 
-  case 799: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '[' ']'  */
+  case 801: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '[' ']'  */
                                                           {
         (yyvsp[-3].pTypeDecl)->removeDim = true;
         (yyval.pTypeDecl) = (yyvsp[-3].pTypeDecl);
     }
     break;
 
-  case 800: /* type_declaration_no_options_no_dim: type_declaration_no_options "explicit"  */
+  case 802: /* type_declaration_no_options_no_dim: type_declaration_no_options "explicit"  */
                                                            {
         (yyvsp[-1].pTypeDecl)->isExplicit = true;
         (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
     }
     break;
 
-  case 801: /* type_declaration_no_options_no_dim: type_declaration_no_options "const"  */
+  case 803: /* type_declaration_no_options_no_dim: type_declaration_no_options "const"  */
                                                         {
         (yyvsp[-1].pTypeDecl)->constant = true;
         (yyvsp[-1].pTypeDecl)->removeConstant = false;
@@ -10031,7 +10050,7 @@ yyreduce:
     }
     break;
 
-  case 802: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' "const"  */
+  case 804: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' "const"  */
                                                             {
         (yyvsp[-2].pTypeDecl)->constant = false;
         (yyvsp[-2].pTypeDecl)->removeConstant = true;
@@ -10039,7 +10058,7 @@ yyreduce:
     }
     break;
 
-  case 803: /* type_declaration_no_options_no_dim: type_declaration_no_options '&'  */
+  case 805: /* type_declaration_no_options_no_dim: type_declaration_no_options '&'  */
                                                   {
         (yyvsp[-1].pTypeDecl)->ref = true;
         (yyvsp[-1].pTypeDecl)->removeRef = false;
@@ -10047,7 +10066,7 @@ yyreduce:
     }
     break;
 
-  case 804: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '&'  */
+  case 806: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '&'  */
                                                       {
         (yyvsp[-2].pTypeDecl)->ref = false;
         (yyvsp[-2].pTypeDecl)->removeRef = true;
@@ -10055,21 +10074,21 @@ yyreduce:
     }
     break;
 
-  case 805: /* type_declaration_no_options_no_dim: type_declaration_no_options '#'  */
+  case 807: /* type_declaration_no_options_no_dim: type_declaration_no_options '#'  */
                                                   {
         (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
         (yyval.pTypeDecl)->temporary = true;
     }
     break;
 
-  case 806: /* type_declaration_no_options_no_dim: type_declaration_no_options "implicit"  */
+  case 808: /* type_declaration_no_options_no_dim: type_declaration_no_options "implicit"  */
                                                            {
         (yyval.pTypeDecl) = (yyvsp[-1].pTypeDecl);
         (yyval.pTypeDecl)->implicit = true;
     }
     break;
 
-  case 807: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '#'  */
+  case 809: /* type_declaration_no_options_no_dim: type_declaration_no_options '-' '#'  */
                                                       {
         (yyvsp[-2].pTypeDecl)->temporary = false;
         (yyvsp[-2].pTypeDecl)->removeTemporary = true;
@@ -10077,21 +10096,21 @@ yyreduce:
     }
     break;
 
-  case 808: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" "const"  */
+  case 810: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" "const"  */
                                                                {
         (yyvsp[-2].pTypeDecl)->explicitConst = true;
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 809: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" '&'  */
+  case 811: /* type_declaration_no_options_no_dim: type_declaration_no_options "==" '&'  */
                                                          {
         (yyvsp[-2].pTypeDecl)->explicitRef = true;
         (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
     }
     break;
 
-  case 810: /* type_declaration_no_options_no_dim: type_declaration_no_options '?'  */
+  case 812: /* type_declaration_no_options_no_dim: type_declaration_no_options '?'  */
                                                   {
         (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
@@ -10099,15 +10118,15 @@ yyreduce:
     }
     break;
 
-  case 811: /* $@63: %empty  */
+  case 813: /* $@63: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 812: /* $@64: %empty  */
+  case 814: /* $@64: %empty  */
                                                                                                { yyextra->das_arrow_depth --; }
     break;
 
-  case 813: /* type_declaration_no_options_no_dim: "smart_ptr" '<' $@63 type_declaration '>' $@64  */
+  case 815: /* type_declaration_no_options_no_dim: "smart_ptr" '<' $@63 type_declaration '>' $@64  */
                                                                                                                                 {
         (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10116,7 +10135,7 @@ yyreduce:
     }
     break;
 
-  case 814: /* type_declaration_no_options_no_dim: type_declaration_no_options "??"  */
+  case 816: /* type_declaration_no_options_no_dim: type_declaration_no_options "??"  */
                                                  {
         (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
@@ -10126,15 +10145,15 @@ yyreduce:
     }
     break;
 
-  case 815: /* $@65: %empty  */
+  case 817: /* $@65: %empty  */
                            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 816: /* $@66: %empty  */
+  case 818: /* $@66: %empty  */
                                                                                            { yyextra->das_arrow_depth --; }
     break;
 
-  case 817: /* type_declaration_no_options_no_dim: "array" '<' $@65 type_declaration '>' $@66  */
+  case 819: /* type_declaration_no_options_no_dim: "array" '<' $@65 type_declaration '>' $@66  */
                                                                                                                             {
         (yyval.pTypeDecl) = new TypeDecl(Type::tArray);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10142,15 +10161,15 @@ yyreduce:
     }
     break;
 
-  case 818: /* $@67: %empty  */
+  case 820: /* $@67: %empty  */
                            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 819: /* $@68: %empty  */
+  case 821: /* $@68: %empty  */
                                                                                      { yyextra->das_arrow_depth --; }
     break;
 
-  case 820: /* type_declaration_no_options_no_dim: "table" '<' $@67 table_type_pair '>' $@68  */
+  case 822: /* type_declaration_no_options_no_dim: "table" '<' $@67 table_type_pair '>' $@68  */
                                                                                                                       {
         (yyval.pTypeDecl) = new TypeDecl(Type::tTable);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10159,15 +10178,15 @@ yyreduce:
     }
     break;
 
-  case 821: /* $@69: %empty  */
+  case 823: /* $@69: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 822: /* $@70: %empty  */
+  case 824: /* $@70: %empty  */
                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 823: /* type_declaration_no_options_no_dim: "iterator" '<' $@69 type_declaration '>' $@70  */
+  case 825: /* type_declaration_no_options_no_dim: "iterator" '<' $@69 type_declaration '>' $@70  */
                                                                                                                                   {
         (yyval.pTypeDecl) = new TypeDecl(Type::tIterator);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10175,7 +10194,7 @@ yyreduce:
     }
     break;
 
-  case 824: /* type_declaration_no_options_no_dim: "block"  */
+  case 826: /* type_declaration_no_options_no_dim: "block"  */
                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
         (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
@@ -10183,15 +10202,15 @@ yyreduce:
     }
     break;
 
-  case 825: /* $@71: %empty  */
+  case 827: /* $@71: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 826: /* $@72: %empty  */
+  case 828: /* $@72: %empty  */
                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 827: /* type_declaration_no_options_no_dim: "block" '<' $@71 type_declaration '>' $@72  */
+  case 829: /* type_declaration_no_options_no_dim: "block" '<' $@71 type_declaration '>' $@72  */
                                                                                                                                {
         (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10199,15 +10218,15 @@ yyreduce:
     }
     break;
 
-  case 828: /* $@73: %empty  */
+  case 830: /* $@73: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 829: /* $@74: %empty  */
+  case 831: /* $@74: %empty  */
                                                                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 830: /* type_declaration_no_options_no_dim: "block" '<' $@73 optional_function_argument_list optional_function_type '>' $@74  */
+  case 832: /* type_declaration_no_options_no_dim: "block" '<' $@73 optional_function_argument_list optional_function_type '>' $@74  */
                                                                                                                                                                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
@@ -10219,7 +10238,7 @@ yyreduce:
     }
     break;
 
-  case 831: /* type_declaration_no_options_no_dim: "function"  */
+  case 833: /* type_declaration_no_options_no_dim: "function"  */
                            {
         (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
         (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
@@ -10227,15 +10246,15 @@ yyreduce:
     }
     break;
 
-  case 832: /* $@75: %empty  */
+  case 834: /* $@75: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 833: /* $@76: %empty  */
+  case 835: /* $@76: %empty  */
                                                                                                 { yyextra->das_arrow_depth --; }
     break;
 
-  case 834: /* type_declaration_no_options_no_dim: "function" '<' $@75 type_declaration '>' $@76  */
+  case 836: /* type_declaration_no_options_no_dim: "function" '<' $@75 type_declaration '>' $@76  */
                                                                                                                                  {
         (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10243,15 +10262,15 @@ yyreduce:
     }
     break;
 
-  case 835: /* $@77: %empty  */
+  case 837: /* $@77: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 836: /* $@78: %empty  */
+  case 838: /* $@78: %empty  */
                                                                                                                                          { yyextra->das_arrow_depth --; }
     break;
 
-  case 837: /* type_declaration_no_options_no_dim: "function" '<' $@77 optional_function_argument_list optional_function_type '>' $@78  */
+  case 839: /* type_declaration_no_options_no_dim: "function" '<' $@77 optional_function_argument_list optional_function_type '>' $@78  */
                                                                                                                                                                           {
         (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
@@ -10263,7 +10282,7 @@ yyreduce:
     }
     break;
 
-  case 838: /* type_declaration_no_options_no_dim: "lambda"  */
+  case 840: /* type_declaration_no_options_no_dim: "lambda"  */
                          {
         (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
         (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
@@ -10271,15 +10290,15 @@ yyreduce:
     }
     break;
 
-  case 839: /* $@79: %empty  */
+  case 841: /* $@79: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 840: /* $@80: %empty  */
+  case 842: /* $@80: %empty  */
                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 841: /* type_declaration_no_options_no_dim: "lambda" '<' $@79 type_declaration '>' $@80  */
+  case 843: /* type_declaration_no_options_no_dim: "lambda" '<' $@79 type_declaration '>' $@80  */
                                                                                                                                {
         (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10287,15 +10306,15 @@ yyreduce:
     }
     break;
 
-  case 842: /* $@81: %empty  */
+  case 844: /* $@81: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 843: /* $@82: %empty  */
+  case 845: /* $@82: %empty  */
                                                                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 844: /* type_declaration_no_options_no_dim: "lambda" '<' $@81 optional_function_argument_list optional_function_type '>' $@82  */
+  case 846: /* type_declaration_no_options_no_dim: "lambda" '<' $@81 optional_function_argument_list optional_function_type '>' $@82  */
                                                                                                                                                                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
@@ -10307,15 +10326,15 @@ yyreduce:
     }
     break;
 
-  case 845: /* $@83: %empty  */
+  case 847: /* $@83: %empty  */
                             { yyextra->das_arrow_depth ++; }
     break;
 
-  case 846: /* $@84: %empty  */
+  case 848: /* $@84: %empty  */
                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 847: /* type_declaration_no_options_no_dim: "tuple" '<' $@83 tuple_type_list '>' $@84  */
+  case 849: /* type_declaration_no_options_no_dim: "tuple" '<' $@83 tuple_type_list '>' $@84  */
                                                                                                                         {
         (yyval.pTypeDecl) = new TypeDecl(Type::tTuple);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10324,15 +10343,15 @@ yyreduce:
     }
     break;
 
-  case 848: /* $@85: %empty  */
+  case 850: /* $@85: %empty  */
                               { yyextra->das_arrow_depth ++; }
     break;
 
-  case 849: /* $@86: %empty  */
+  case 851: /* $@86: %empty  */
                                                                                            { yyextra->das_arrow_depth --; }
     break;
 
-  case 850: /* type_declaration_no_options_no_dim: "variant" '<' $@85 variant_type_list '>' $@86  */
+  case 852: /* type_declaration_no_options_no_dim: "variant" '<' $@85 variant_type_list '>' $@86  */
                                                                                                                             {
         (yyval.pTypeDecl) = new TypeDecl(Type::tVariant);
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
@@ -10341,13 +10360,13 @@ yyreduce:
     }
     break;
 
-  case 851: /* type_declaration: type_declaration_no_options  */
+  case 853: /* type_declaration: type_declaration_no_options  */
                                         {
         (yyval.pTypeDecl) = (yyvsp[0].pTypeDecl);
     }
     break;
 
-  case 852: /* type_declaration: type_declaration '|' type_declaration_no_options  */
+  case 854: /* type_declaration: type_declaration '|' type_declaration_no_options  */
                                                                      {
         if ( (yyvsp[-2].pTypeDecl)->baseType==Type::option ) {
             (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
@@ -10361,7 +10380,7 @@ yyreduce:
     }
     break;
 
-  case 853: /* type_declaration: type_declaration '|' '#'  */
+  case 855: /* type_declaration: type_declaration '|' '#'  */
                                              {
         if ( (yyvsp[-2].pTypeDecl)->baseType==Type::option ) {
             (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
@@ -10377,13 +10396,13 @@ yyreduce:
     }
     break;
 
-  case 854: /* $@87: %empty  */
+  case 856: /* $@87: %empty  */
                    {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 855: /* $@88: %empty  */
+  case 857: /* $@88: %empty  */
                                                                              {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-1]));
@@ -10392,7 +10411,7 @@ yyreduce:
     }
     break;
 
-  case 856: /* $@89: %empty  */
+  case 858: /* $@89: %empty  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-3]));
@@ -10401,7 +10420,7 @@ yyreduce:
     }
     break;
 
-  case 857: /* $@90: %empty  */
+  case 859: /* $@90: %empty  */
                                                  {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-6]));
@@ -10411,7 +10430,7 @@ yyreduce:
     }
     break;
 
-  case 858: /* tuple_alias_declaration: "tuple" $@87 optional_public_or_private_alias "name" optional_emit_semis $@88 '{' $@89 tuple_alias_type_list optional_semis $@90 '}'  */
+  case 860: /* tuple_alias_declaration: "tuple" $@87 optional_public_or_private_alias "name" optional_emit_semis $@88 '{' $@89 tuple_alias_type_list optional_semis $@90 '}'  */
           {
         auto vtype = new TypeDecl(Type::tTuple);
         vtype->alias = *(yyvsp[-8].s);
@@ -10431,13 +10450,13 @@ yyreduce:
     }
     break;
 
-  case 859: /* $@91: %empty  */
+  case 861: /* $@91: %empty  */
                      {
         yyextra->push_nesteds(DAS_EMIT_SEMICOLON);
     }
     break;
 
-  case 860: /* $@92: %empty  */
+  case 862: /* $@92: %empty  */
                                                                              {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-1]));
@@ -10446,7 +10465,7 @@ yyreduce:
     }
     break;
 
-  case 861: /* $@93: %empty  */
+  case 863: /* $@93: %empty  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-3]));
@@ -10456,7 +10475,7 @@ yyreduce:
     }
     break;
 
-  case 862: /* $@94: %empty  */
+  case 864: /* $@94: %empty  */
                                                    {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-6]));
@@ -10466,7 +10485,7 @@ yyreduce:
     }
     break;
 
-  case 863: /* variant_alias_declaration: "variant" $@91 optional_public_or_private_alias "name" optional_emit_semis $@92 '{' $@93 variant_alias_type_list optional_semis $@94 '}'  */
+  case 865: /* variant_alias_declaration: "variant" $@91 optional_public_or_private_alias "name" optional_emit_semis $@92 '{' $@93 variant_alias_type_list optional_semis $@94 '}'  */
           {
         auto vtype = new TypeDecl(Type::tVariant);
         vtype->alias = *(yyvsp[-8].s);
@@ -10486,13 +10505,13 @@ yyreduce:
     }
     break;
 
-  case 864: /* $@95: %empty  */
+  case 866: /* $@95: %empty  */
                       {
         yyextra->push_nesteds(DAS_EMIT_COMMA);
     }
     break;
 
-  case 865: /* $@96: %empty  */
+  case 867: /* $@96: %empty  */
                                                                                                                          {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-2]));
@@ -10501,7 +10520,7 @@ yyreduce:
     }
     break;
 
-  case 866: /* $@97: %empty  */
+  case 868: /* $@97: %empty  */
           {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-4]));
@@ -10510,7 +10529,7 @@ yyreduce:
     }
     break;
 
-  case 867: /* $@98: %empty  */
+  case 869: /* $@98: %empty  */
                                                 {
         if ( !yyextra->g_CommentReaders.empty() ) {
             auto atvname = tokAt(scanner,(yylsp[-7]));
@@ -10520,7 +10539,7 @@ yyreduce:
     }
     break;
 
-  case 868: /* bitfield_alias_declaration: "bitfield" $@95 optional_public_or_private_alias "name" bitfield_basic_type_declaration optional_emit_commas $@96 '{' $@97 bitfield_alias_bits optional_commas $@98 '}'  */
+  case 870: /* bitfield_alias_declaration: "bitfield" $@95 optional_public_or_private_alias "name" bitfield_basic_type_declaration optional_emit_commas $@96 '{' $@97 bitfield_alias_bits optional_commas $@98 '}'  */
           {
         auto btype = new TypeDecl((yyvsp[-8].type));
         btype->alias = *(yyvsp[-9].s);
@@ -10554,55 +10573,55 @@ yyreduce:
     }
     break;
 
-  case 869: /* make_decl: make_struct_decl  */
+  case 871: /* make_decl: make_struct_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 870: /* make_decl: make_dim_decl  */
+  case 872: /* make_decl: make_dim_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 871: /* make_decl: make_table_decl  */
+  case 873: /* make_decl: make_table_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 872: /* make_decl: make_table_call  */
+  case 874: /* make_decl: make_table_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 873: /* make_decl: array_comprehension  */
+  case 875: /* make_decl: array_comprehension  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 874: /* make_decl: table_comprehension  */
+  case 876: /* make_decl: table_comprehension  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 875: /* make_decl: make_tuple_call  */
+  case 877: /* make_decl: make_tuple_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 876: /* make_decl_no_bracket: make_struct_decl  */
+  case 878: /* make_decl_no_bracket: make_struct_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 877: /* make_decl_no_bracket: make_dim_decl  */
+  case 879: /* make_decl_no_bracket: make_dim_decl  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 878: /* make_decl_no_bracket: make_tuple_call  */
+  case 880: /* make_decl_no_bracket: make_tuple_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 879: /* make_decl_no_bracket: table_comprehension  */
+  case 881: /* make_decl_no_bracket: table_comprehension  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 880: /* make_decl_no_bracket: make_table_call  */
+  case 882: /* make_decl_no_bracket: make_table_call  */
                                  { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 881: /* make_struct_fields: "name" copy_or_move expr  */
+  case 883: /* make_struct_fields: "name" copy_or_move expr  */
                                                {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         delete (yyvsp[-2].s);
@@ -10612,7 +10631,7 @@ yyreduce:
     }
     break;
 
-  case 882: /* make_struct_fields: "name" ":=" expr  */
+  case 884: /* make_struct_fields: "name" ":=" expr  */
                                       {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),false,true);
         delete (yyvsp[-2].s);
@@ -10622,7 +10641,7 @@ yyreduce:
     }
     break;
 
-  case 883: /* make_struct_fields: make_struct_fields ',' "name" copy_or_move expr  */
+  case 885: /* make_struct_fields: make_struct_fields ',' "name" copy_or_move expr  */
                                                                            {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         delete (yyvsp[-2].s);
@@ -10631,7 +10650,7 @@ yyreduce:
     }
     break;
 
-  case 884: /* make_struct_fields: make_struct_fields ',' "name" ":=" expr  */
+  case 886: /* make_struct_fields: make_struct_fields ',' "name" ":=" expr  */
                                                                   {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s),(yyvsp[0].pExpression),false,true);
         delete (yyvsp[-2].s);
@@ -10640,7 +10659,7 @@ yyreduce:
     }
     break;
 
-  case 885: /* make_struct_fields: "$f" '(' expr ')' copy_or_move expr  */
+  case 887: /* make_struct_fields: "$f" '(' expr ')' copy_or_move expr  */
                                                                    {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10650,7 +10669,7 @@ yyreduce:
     }
     break;
 
-  case 886: /* make_struct_fields: "$f" '(' expr ')' ":=" expr  */
+  case 888: /* make_struct_fields: "$f" '(' expr ')' ":=" expr  */
                                                           {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),false,true);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10660,7 +10679,7 @@ yyreduce:
     }
     break;
 
-  case 887: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' copy_or_move expr  */
+  case 889: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' copy_or_move expr  */
                                                                                                {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),(yyvsp[-1].b),false);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10669,7 +10688,7 @@ yyreduce:
     }
     break;
 
-  case 888: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' ":=" expr  */
+  case 890: /* make_struct_fields: make_struct_fields ',' "$f" '(' expr ')' ":=" expr  */
                                                                                       {
         auto mfd = new MakeFieldDecl(tokAt(scanner,(yylsp[-3])),"``MACRO``TAG``FIELD``",(yyvsp[0].pExpression),false,true);
         mfd->tag = (yyvsp[-3].pExpression);
@@ -10678,19 +10697,19 @@ yyreduce:
     }
     break;
 
-  case 889: /* make_variant_dim: %empty  */
+  case 891: /* make_variant_dim: %empty  */
        {
         (yyval.pExpression) = ast_makeStructToMakeVariant(nullptr, LineInfo());
     }
     break;
 
-  case 890: /* make_variant_dim: make_struct_fields  */
+  case 892: /* make_variant_dim: make_struct_fields  */
                               {
         (yyval.pExpression) = ast_makeStructToMakeVariant((yyvsp[0].pMakeStruct), tokAt(scanner,(yylsp[0])));
     }
     break;
 
-  case 891: /* make_struct_single: make_struct_fields optional_comma  */
+  case 893: /* make_struct_single: make_struct_fields optional_comma  */
                                                {
         auto msd = new ExprMakeStruct();
         msd->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
@@ -10698,7 +10717,7 @@ yyreduce:
     }
     break;
 
-  case 892: /* make_struct_dim_list: '(' make_struct_fields ')'  */
+  case 894: /* make_struct_dim_list: '(' make_struct_fields ')'  */
                                         {
         auto msd = new ExprMakeStruct();
         msd->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
@@ -10706,14 +10725,14 @@ yyreduce:
     }
     break;
 
-  case 893: /* make_struct_dim_list: make_struct_dim_list ',' '(' make_struct_fields ')'  */
+  case 895: /* make_struct_dim_list: make_struct_dim_list ',' '(' make_struct_fields ')'  */
                                                                      {
         ((ExprMakeStruct *) (yyvsp[-4].pExpression))->structs.push_back(MakeStructPtr((yyvsp[-1].pMakeStruct)));
         (yyval.pExpression) = (yyvsp[-4].pExpression);
     }
     break;
 
-  case 894: /* make_struct_dim_decl: make_struct_fields  */
+  case 896: /* make_struct_dim_decl: make_struct_fields  */
                                 {
         auto msd = new ExprMakeStruct();
         msd->structs.push_back(MakeStructPtr((yyvsp[0].pMakeStruct)));
@@ -10721,37 +10740,37 @@ yyreduce:
     }
     break;
 
-  case 895: /* make_struct_dim_decl: make_struct_dim_list optional_comma  */
+  case 897: /* make_struct_dim_decl: make_struct_dim_list optional_comma  */
                                                  {
         (yyval.pExpression) = (yyvsp[-1].pExpression);
     }
     break;
 
-  case 896: /* optional_make_struct_dim_decl: make_struct_dim_decl  */
+  case 898: /* optional_make_struct_dim_decl: make_struct_dim_decl  */
                                   { (yyval.pExpression) = (yyvsp[0].pExpression);  }
     break;
 
-  case 897: /* optional_make_struct_dim_decl: %empty  */
+  case 899: /* optional_make_struct_dim_decl: %empty  */
         {   (yyval.pExpression) = new ExprMakeStruct(); }
     break;
 
-  case 898: /* use_initializer: %empty  */
+  case 900: /* use_initializer: %empty  */
                             { (yyval.b) = true; }
     break;
 
-  case 899: /* use_initializer: "uninitialized"  */
+  case 901: /* use_initializer: "uninitialized"  */
                             { (yyval.b) = false; }
     break;
 
-  case 900: /* $@99: %empty  */
+  case 902: /* $@99: %empty  */
                              { yyextra->das_arrow_depth ++; }
     break;
 
-  case 901: /* $@100: %empty  */
+  case 903: /* $@100: %empty  */
                                                                                                    { yyextra->das_arrow_depth --; }
     break;
 
-  case 902: /* make_struct_decl: "struct" '<' $@99 type_declaration_no_options '>' $@100 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 904: /* make_struct_decl: "struct" '<' $@99 type_declaration_no_options '>' $@100 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                       {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10762,15 +10781,15 @@ yyreduce:
     }
     break;
 
-  case 903: /* $@101: %empty  */
+  case 905: /* $@101: %empty  */
                             { yyextra->das_arrow_depth ++; }
     break;
 
-  case 904: /* $@102: %empty  */
+  case 906: /* $@102: %empty  */
                                                                                                   { yyextra->das_arrow_depth --; }
     break;
 
-  case 905: /* make_struct_decl: "class" '<' $@101 type_declaration_no_options '>' $@102 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 907: /* make_struct_decl: "class" '<' $@101 type_declaration_no_options '>' $@102 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                      {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10780,15 +10799,15 @@ yyreduce:
     }
     break;
 
-  case 906: /* $@103: %empty  */
+  case 908: /* $@103: %empty  */
                                { yyextra->das_arrow_depth ++; }
     break;
 
-  case 907: /* $@104: %empty  */
+  case 909: /* $@104: %empty  */
                                                                                             { yyextra->das_arrow_depth --; }
     break;
 
-  case 908: /* make_struct_decl: "variant" '<' $@103 variant_type_list '>' $@104 '(' use_initializer make_variant_dim ')'  */
+  case 910: /* make_struct_decl: "variant" '<' $@103 variant_type_list '>' $@104 '(' use_initializer make_variant_dim ')'  */
                                                                                                                                                                                   {
         auto mkt = new TypeDecl(Type::tVariant);
         mkt->at = tokAt(scanner,(yylsp[-9]));
@@ -10802,15 +10821,15 @@ yyreduce:
     }
     break;
 
-  case 909: /* $@105: %empty  */
+  case 911: /* $@105: %empty  */
                                         { yyextra->das_arrow_depth ++; }
     break;
 
-  case 910: /* $@106: %empty  */
+  case 912: /* $@106: %empty  */
                                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 911: /* make_struct_decl: "variant" "type" '<' $@105 type_declaration_no_options '>' $@106 '(' use_initializer make_variant_dim ')'  */
+  case 913: /* make_struct_decl: "variant" "type" '<' $@105 type_declaration_no_options '>' $@106 '(' use_initializer make_variant_dim ')'  */
                                                                                                                                                                                                     {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10820,15 +10839,15 @@ yyreduce:
     }
     break;
 
-  case 912: /* $@107: %empty  */
+  case 914: /* $@107: %empty  */
                               { yyextra->das_arrow_depth ++; }
     break;
 
-  case 913: /* $@108: %empty  */
+  case 915: /* $@108: %empty  */
                                                                                                     { yyextra->das_arrow_depth --; }
     break;
 
-  case 914: /* make_struct_decl: "default" '<' $@107 type_declaration_no_options '>' $@108 use_initializer  */
+  case 916: /* make_struct_decl: "default" '<' $@107 type_declaration_no_options '>' $@108 use_initializer  */
                                                                                                                                                            {
         auto msd = new ExprMakeStruct();
         msd->at = tokAt(scanner,(yylsp[-6]));
@@ -10839,7 +10858,7 @@ yyreduce:
     }
     break;
 
-  case 915: /* make_tuple_call: "tuple" '(' expr_list optional_comma ')'  */
+  case 917: /* make_tuple_call: "tuple" '(' expr_list optional_comma ')'  */
                                                                     {
         auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-4])));
         mkt->values = sequenceToList((yyvsp[-2].pExpression));
@@ -10848,15 +10867,15 @@ yyreduce:
     }
     break;
 
-  case 916: /* $@109: %empty  */
+  case 918: /* $@109: %empty  */
                              { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; }
     break;
 
-  case 917: /* $@110: %empty  */
+  case 919: /* $@110: %empty  */
                                                                                                                               { yyextra->das_arrow_depth --; }
     break;
 
-  case 918: /* make_tuple_call: "tuple" '<' $@109 tuple_type_list '>' $@110 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 920: /* make_tuple_call: "tuple" '<' $@109 tuple_type_list '>' $@110 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                                                  {
         auto mkt = new TypeDecl(Type::tTuple);
         mkt->at = tokAt(scanner,(yylsp[-9]));
@@ -10870,7 +10889,7 @@ yyreduce:
     }
     break;
 
-  case 919: /* make_dim_decl: '[' optional_expr_list ']'  */
+  case 921: /* make_dim_decl: '[' optional_expr_list ']'  */
                                                   {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-2])));
@@ -10892,15 +10911,15 @@ yyreduce:
     }
     break;
 
-  case 920: /* $@111: %empty  */
+  case 922: /* $@111: %empty  */
                                        { yyextra->das_arrow_depth ++; }
     break;
 
-  case 921: /* $@112: %empty  */
+  case 923: /* $@112: %empty  */
                                                                                                              { yyextra->das_arrow_depth --; }
     break;
 
-  case 922: /* make_dim_decl: "array" "struct" '<' $@111 type_declaration_no_options '>' $@112 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 924: /* make_dim_decl: "array" "struct" '<' $@111 type_declaration_no_options '>' $@112 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                                 {
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
         ((ExprMakeStruct *)(yyvsp[-1].pExpression))->makeType = (yyvsp[-6].pTypeDecl);
@@ -10913,15 +10932,15 @@ yyreduce:
     }
     break;
 
-  case 923: /* $@113: %empty  */
+  case 925: /* $@113: %empty  */
                                        { yyextra->das_arrow_depth ++; }
     break;
 
-  case 924: /* $@114: %empty  */
+  case 926: /* $@114: %empty  */
                                                                                                   { yyextra->das_arrow_depth --; }
     break;
 
-  case 925: /* make_dim_decl: "array" "tuple" '<' $@113 tuple_type_list '>' $@114 '(' use_initializer optional_make_struct_dim_decl ')'  */
+  case 927: /* make_dim_decl: "array" "tuple" '<' $@113 tuple_type_list '>' $@114 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                      {
         auto mkt = new TypeDecl(Type::tTuple);
         mkt->at = tokAt(scanner,(yylsp[-10]));
@@ -10938,15 +10957,15 @@ yyreduce:
     }
     break;
 
-  case 926: /* $@115: %empty  */
+  case 928: /* $@115: %empty  */
                                          { yyextra->das_arrow_depth ++; }
     break;
 
-  case 927: /* $@116: %empty  */
+  case 929: /* $@116: %empty  */
                                                                                                       { yyextra->das_arrow_depth --; }
     break;
 
-  case 928: /* make_dim_decl: "array" "variant" '<' $@115 variant_type_list '>' $@116 '(' make_variant_dim ')'  */
+  case 930: /* make_dim_decl: "array" "variant" '<' $@115 variant_type_list '>' $@116 '(' make_variant_dim ')'  */
                                                                                                                                                                       {
         auto mkt = new TypeDecl(Type::tVariant);
         mkt->at = tokAt(scanner,(yylsp[-9]));
@@ -10963,7 +10982,7 @@ yyreduce:
     }
     break;
 
-  case 929: /* make_dim_decl: "array" '(' expr_list optional_comma ')'  */
+  case 931: /* make_dim_decl: "array" '(' expr_list optional_comma ')'  */
                                                                    {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -10975,15 +10994,15 @@ yyreduce:
     }
     break;
 
-  case 930: /* $@117: %empty  */
+  case 932: /* $@117: %empty  */
                            { yyextra->das_arrow_depth ++; }
     break;
 
-  case 931: /* $@118: %empty  */
+  case 933: /* $@118: %empty  */
                                                                                                  { yyextra->das_arrow_depth --; }
     break;
 
-  case 932: /* make_dim_decl: "array" '<' $@117 type_declaration_no_options '>' $@118 '(' optional_expr_list ')'  */
+  case 934: /* make_dim_decl: "array" '<' $@117 type_declaration_no_options '>' $@118 '(' optional_expr_list ')'  */
                                                                                                                                                                         {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-8])));
@@ -11006,7 +11025,7 @@ yyreduce:
     }
     break;
 
-  case 933: /* make_dim_decl: "fixed_array" '(' expr_list optional_comma ')'  */
+  case 935: /* make_dim_decl: "fixed_array" '(' expr_list optional_comma ')'  */
                                                                          {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -11016,15 +11035,15 @@ yyreduce:
     }
     break;
 
-  case 934: /* $@119: %empty  */
+  case 936: /* $@119: %empty  */
                                  { yyextra->das_arrow_depth ++; }
     break;
 
-  case 935: /* $@120: %empty  */
+  case 937: /* $@120: %empty  */
                                                                                                        { yyextra->das_arrow_depth --; }
     break;
 
-  case 936: /* make_dim_decl: "fixed_array" '<' $@119 type_declaration_no_options '>' $@120 '(' expr_list optional_comma ')'  */
+  case 938: /* make_dim_decl: "fixed_array" '<' $@119 type_declaration_no_options '>' $@120 '(' expr_list optional_comma ')'  */
                                                                                                                                                                                     {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-9])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -11034,25 +11053,25 @@ yyreduce:
     }
     break;
 
-  case 937: /* expr_map_tuple_list: expr  */
+  case 939: /* expr_map_tuple_list: expr  */
                       {
         (yyval.pExpression) = (yyvsp[0].pExpression);
     }
     break;
 
-  case 938: /* expr_map_tuple_list: expr_map_tuple_list ',' expr  */
+  case 940: /* expr_map_tuple_list: expr_map_tuple_list ',' expr  */
                                                       {
             (yyval.pExpression) = new ExprSequence(tokAt(scanner,(yylsp[-2])),(yyvsp[-2].pExpression),(yyvsp[0].pExpression));
     }
     break;
 
-  case 939: /* push_table_nesting: %empty  */
+  case 941: /* push_table_nesting: %empty  */
                     {
         yyextra->das_nested_parentheses ++;
     }
     break;
 
-  case 940: /* make_table_decl: '{' push_table_nesting optional_emit_semis optional_expr_map_tuple_list '}'  */
+  case 942: /* make_table_decl: '{' push_table_nesting optional_emit_semis optional_expr_map_tuple_list '}'  */
                                                                                                      {
         yyextra->das_nested_parentheses --;
         if ( (yyvsp[-1].pExpression) ) {
@@ -11075,7 +11094,7 @@ yyreduce:
     }
     break;
 
-  case 941: /* make_table_call: "table" '(' expr_map_tuple_list optional_comma ')'  */
+  case 943: /* make_table_call: "table" '(' expr_map_tuple_list optional_comma ')'  */
                                                                              {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
@@ -11086,7 +11105,7 @@ yyreduce:
     }
     break;
 
-  case 942: /* make_table_call: "table" '<' type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
+  case 944: /* make_table_call: "table" '<' type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
                                                                                                                  {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-6])));
@@ -11109,7 +11128,7 @@ yyreduce:
     }
     break;
 
-  case 943: /* make_table_call: "table" '<' type_declaration_no_options c_or_s type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
+  case 945: /* make_table_call: "table" '<' type_declaration_no_options c_or_s type_declaration_no_options '>' '(' optional_expr_map_tuple_list ')'  */
                                                                                                                                                              {
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-8])));
@@ -11134,35 +11153,35 @@ yyreduce:
     }
     break;
 
-  case 944: /* array_comprehension_where: %empty  */
+  case 946: /* array_comprehension_where: %empty  */
                                     { (yyval.pExpression) = nullptr; }
     break;
 
-  case 945: /* array_comprehension_where: ';' "where" expr  */
+  case 947: /* array_comprehension_where: ';' "where" expr  */
                                     { (yyval.pExpression) = (yyvsp[0].pExpression); }
     break;
 
-  case 946: /* optional_comma: %empty  */
+  case 948: /* optional_comma: %empty  */
                 { (yyval.b) = false; }
     break;
 
-  case 947: /* optional_comma: ','  */
+  case 949: /* optional_comma: ','  */
                 { (yyval.b) = true; }
     break;
 
-  case 948: /* table_comprehension: '[' "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
+  case 950: /* table_comprehension: '[' "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
                                                                                                                                                                {
         (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-9])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),false,false);
     }
     break;
 
-  case 949: /* table_comprehension: '[' "iterator" "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
+  case 951: /* table_comprehension: '[' "iterator" "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where ']'  */
                                                                                                                                                                             {
         (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-9])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),true,false);
     }
     break;
 
-  case 950: /* array_comprehension: '{' push_table_nesting optional_emit_semis "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where '}'  */
+  case 952: /* array_comprehension: '{' push_table_nesting optional_emit_semis "for" '(' for_variable_name_with_pos_list "in" expr_list ')' ';' expr array_comprehension_where '}'  */
                                                                                                                                                                                                       {
         yyextra->das_nested_parentheses --;
         (yyval.pExpression) = ast_arrayComprehension(scanner,tokAt(scanner,(yylsp[-9])),(yyvsp[-7].pNameWithPosList),(yyvsp[-5].pExpression),(yyvsp[-2].pExpression),(yyvsp[-1].pExpression),tokRangeAt(scanner,(yylsp[-2]),(yylsp[0])),false,true);

--- a/src/parser/ds2_parser.ypp
+++ b/src/parser/ds2_parser.ypp
@@ -402,6 +402,7 @@
 %type <s>                   das_type_name
 %type <s>                   optional_structure_parent
 %type <s>                   require_module_name
+%type <s>                   optional_require_guard
 %type <s>                   annotation_argument_name
 %type <s>                   format_string
 %type <s>                   optional_format_string
@@ -807,12 +808,17 @@ require_module_name
     }
     ;
 
+optional_require_guard
+    :                       { $$ = nullptr; }
+    |   '?' NAME[g]         { $$ = $g; }
+    ;
+
 require_module
-    :   require_module_name[name]  is_public_module[pub] {
-        ast_requireModule(scanner,$name,nullptr,$pub,tokAt(scanner,@name));
+    :   optional_require_guard[guard] require_module_name[name]  is_public_module[pub] {
+        ast_requireModule(scanner,$name,nullptr,$pub,tokAt(scanner,@name),$guard);
     }
-    |   require_module_name[name] DAS_AS NAME[modalias] is_public_module[pub] {
-        ast_requireModule(scanner,$name,$modalias,$pub,tokAt(scanner,@name));
+    |   optional_require_guard[guard] require_module_name[name] DAS_AS NAME[modalias] is_public_module[pub] {
+        ast_requireModule(scanner,$name,$modalias,$pub,tokAt(scanner,@name),$guard);
     }
     ;
 

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -1113,7 +1113,18 @@ namespace das {
         }
     }
 
-    void ast_requireModule ( yyscan_t scanner, string * name, string * modalias, bool pub, const LineInfo & atName ) {
+    void ast_requireModule ( yyscan_t scanner, string * name, string * modalias, bool pub, const LineInfo & atName, string * guard ) {
+        // Optional require `require ?guard target`: when the guard module is not available, skip the
+        // require entirely (no error). A present guard with a missing target still errors below.
+        if ( guard ) {
+            bool guardAvailable = Module::requireEx(*guard, false) != nullptr;
+            delete guard;
+            if ( !guardAvailable ) {
+                delete name;
+                if ( modalias ) delete modalias;
+                return;
+            }
+        }
         auto info = yyextra->g_Access->getModuleInfo(*name, yyextra->g_FileAccessStack.back()->name);
         if ( auto mod = yyextra->g_Program->addModule(info.moduleName) ) {
             yyextra->g_Program->allRequireDecl.push_back(make_tuple(mod,*name,info.fileName,pub,atName));

--- a/src/parser/parser_impl.h
+++ b/src/parser/parser_impl.h
@@ -106,7 +106,7 @@ namespace das {
     Expression * ast_LetList ( yyscan_t scanner, bool kwd_let, bool inScope, vector<VariableDeclaration *> & decl, const LineInfo & kwd_letAt, const LineInfo & declAt );
     Function * ast_functionDeclarationHeader ( yyscan_t scanner, string * name, vector<VariableDeclaration*> * list,
         TypeDecl * result, const LineInfo & nameAt );
-    void ast_requireModule ( yyscan_t scanner, string * name, string * modalias, bool pub, const LineInfo & atName );
+    void ast_requireModule ( yyscan_t scanner, string * name, string * modalias, bool pub, const LineInfo & atName, string * guard = nullptr );
     Expression * ast_forLoop ( yyscan_t scanner,  vector<VariableNameAndPosition> * iters, Expression * srcs,
         Expression * block, const LineInfo & locAt, const LineInfo & blockAt,
         AnnotationArgumentList * annL = nullptr );

--- a/tests-cpp/small/test_optional_require.cpp
+++ b/tests-cpp/small/test_optional_require.cpp
@@ -1,0 +1,46 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+
+using namespace das;
+
+// Optional require: `require ?guard target` loads *target* only when module *guard* is registered.
+// When *guard* is absent the require is skipped with no error (even if *target* does not exist);
+// when *guard* is present the require behaves exactly like a normal require, so a missing *target*
+// still surfaces as a prerequisite error (no masking).
+
+namespace {
+
+static ProgramPtr compileLiteral(const char * src) {
+    TextPrinter tout;
+    ModuleGroup dummyLibGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+    const string name = "optional_require_test.das";
+    fAccess->setFileInfo(name, make_unique<TextFileInfo>(src, uint32_t(strlen(src)), /*own*/false));
+    return compileDaScript(name, fAccess, tout, dummyLibGroup);
+}
+
+}  // namespace
+
+TEST_CASE("optional require: ?guard target") {
+    SUBCASE("guard absent -> require skipped, no error even when target does not exist") {
+        auto p = compileLiteral("options gen2\nrequire ?no_such_guard_xyz no_such_target_xyz\n");
+        REQUIRE(p);
+        CHECK_FALSE(p->failed());
+    }
+    SUBCASE("guard present + missing target -> real prerequisite error (no masking)") {
+        auto p = compileLiteral("options gen2\nrequire ?strings no_such_target_xyz\n");
+        REQUIRE(p);
+        CHECK(p->failed());
+    }
+    SUBCASE("control: plain (non-optional) require of a missing target still errors") {
+        auto p = compileLiteral("options gen2\nrequire no_such_target_xyz\n");
+        REQUIRE(p);
+        CHECK(p->failed());
+    }
+    SUBCASE("guard present + valid target -> loads normally") {
+        auto p = compileLiteral("options gen2\nrequire ?strings strings\n");
+        REQUIRE(p);
+        CHECK_FALSE(p->failed());
+    }
+}

--- a/tests/language/optional_require.das
+++ b/tests/language/optional_require.das
@@ -1,0 +1,23 @@
+options gen2
+require dastest/testing_boost public
+
+// Optional require: `require ?guard target` loads *target* only when module *guard* is available.
+// When *guard* is absent the require is skipped with no error — even if *target* itself does not
+// exist (proven below: the second require names a nonexistent target yet this file still compiles).
+require ?math math                                  // guard present (math is a core builtin) -> target loaded
+require ?no_such_guard_xyz no_such_target_also_xyz  // guard absent -> skipped (no module-not-found error)
+
+[test]
+def test_optional_require_guard(t : T?) {
+    // builtin_module_exists is the same availability primitive the require guard uses.
+    t |> success(typeinfo builtin_module_exists(math))
+    t |> success(!typeinfo builtin_module_exists(no_such_guard_xyz))
+    // static_if over an absent guard drops its branch *before name resolution*, so the undefined
+    // symbol below is never resolved. This is the invariant that lets a guarded require pair safely
+    // with a guarded use of the (possibly-unloaded) target's symbols.
+    static_if (typeinfo builtin_module_exists(no_such_guard_xyz)) {
+        undefined_symbol_in_dead_branch_xyz()
+    } else {
+        t |> success(true)
+    }
+}


### PR DESCRIPTION
## What

Adds an **optional require** form: `require ?<guard> <target> [public]`.

- Loads `<target>` **only when module `<guard>` is available** (linked into this build / registered).
- When `<guard>` is **absent**, the require is **skipped silently** — no dependency added, no error — *even if `<target>` itself does not exist*.
- When `<guard>` is **present**, the require behaves exactly like an ordinary require, so a missing `<target>` still produces the usual `missing prerequisite` error. The guard never masks a genuine resolution failure.

The guard module (the *condition* to load — e.g. the `pugixml` C++ module) is deliberately spelled separately from the target path (*what* loads — e.g. `pugixml/PUGIXML_boost`, whose own module name is `PUGIXML_boost`). A bare `require?` can't express that split, and decoupling is what prevents error-masking.

```das
require ?pugixml pugixml/PUGIXML_boost

static_if (typeinfo builtin_module_exists(pugixml)) {
    // resolved only when pugixml is available — static_if drops the dead
    // branch before name resolution, so these symbols are referenced only when present
    parse_xml("<root/>") $(doc, ok) { /* ... */ }
}
```

`has_module` needed no new work — it already exists as `typeinfo builtin_module_exists(name)` (semantic: module registered in the environment). This PR pairs cleanly with it.

## Why

Lets **core daslib reference an optional external module without a hard dependency**. The motivating case is the next step of the linq_fold arc (LINQ-over-XML pass 2): `daslib/linq_fold` will pull in an XML source adapter that lives in the `dasPUGIXML` module via `require ?pugixml pugixml/linq_fold_xml`, guarded so builds with `DAS_PUGIXML_DISABLED=ON` stay clean. (Self-registration from the module into linq_fold's macro registry is impossible — separate macro compile-time contexts — so the consumer must require the contributor; this primitive makes that require conditional.)

## How

- **`src/ast/ast_parse.cpp`** (textual prescan `getAllRequireReq`): parse `?guard`, and drop the dependency when `Module::requireEx(guard)` is null.
- **`src/parser/ds2_parser.ypp`**: new nullable `optional_require_guard` nonterminal (`'?' NAME`) threaded into both `require_module` productions. Regenerated `ds2_parser.cpp` (bison 3.8.2, zero grammar conflicts). gen2 parser only — v1 (`ds_parser.ypp`) untouched.
- **`ast_requireModule`** (`parser_impl.{h,cpp}`): gains `string * guard = nullptr` — the default keeps the v1 parser's generated 5-arg calls compiling; skips (frees args, returns, no error) when the guard module is absent.

## Load-bearing invariant

The `static_if (typeinfo builtin_module_exists(guard)) { … }` companion only works because `static_if` drops the untaken branch **before name resolution** — so a guarded use of the (possibly-unloaded) target's symbols never resolves when absent. Verified directly (a live branch with an undefined symbol errors; a dead one compiles) and pinned in the tests.

## Tests

- **`tests-cpp/small/test_optional_require.cpp`** — 4 deterministic subcases: guard-absent skip (even with a nonexistent target), guard-present + missing target → error (no masking), plain non-optional require of a missing target → error, guard-present + valid target → loads.
- **`tests/language/optional_require.das`** — positive `[test]`: absent-guard skip, the `static_if` dead-branch invariant, and `builtin_module_exists` consistency.

## Docs

- `doc/source/reference/language/modules.rst` — new "Optional requires" section (Sphinx builds clean, 0 warnings).
- `skills/das_macros.md` — a note on the macro-module context model that motivates this feature (separate macro contexts ⇒ consumer-requires-contributor).

## Validation (local)

- `tests-cpp-small`: 38 cases / 2839 assertions ✅
- `tests/language`: 1023/1023 ✅ · `tests/decs`: 245/245 ✅
- JIT smoke (array, bulk_create): no verifier errors ✅
- `daslib/linq_fold` + daslib compile clean; new `.das` lint-clean + formatted; Sphinx 0 warnings.
- AOT + the full module matrix (incl. GLFW-on) run on CI.

> Note: local AOT/GLFW lanes are limited in my sandbox (missing Carbon framework — a separate, pre-existing env issue, to be settled after this PR); it's orthogonal to this parser-only change, which CI exercises fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)