### PR TITLE
das: fix ThinLTO SROA miscompile in das_index<Matrix>::at in aot.h

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -833,10 +833,19 @@ namespace das {
         using MatT = Matrix<VecT,size>;
         static __forceinline VecT & at ( MatT & value, int32_t index, Context * __context__ ) {
             if ( index<0 || uint32_t(index)>=uint32_t(size) ) __context__->throw_error_ex("matrix index out of range, %d of %d", index, size);
+#if defined(__clang__) && defined(DAS_STRICT_ALIASING)
+            // Compiler barrier: prevents ThinLTO SROA from substituting a stale virtual-register
+            // value for value.m[idx] after a write through an aliased pointer of a different type
+            // (e.g. TMatrix & aliasing float3x4). No machine instruction is emitted.
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+#endif
             return value.m[index];
         }
         static __forceinline VecT & at ( MatT & value, uint32_t idx, Context * __context__ ) {
             if ( idx>=uint32_t(size) ) __context__->throw_error_ex("matrix index out of range, %u of %d", idx, size);
+#if defined(__clang__) && defined(DAS_STRICT_ALIASING)
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+#endif
             return value.m[idx];
         }
     };


### PR DESCRIPTION
Add std::atomic_signal_fence(memory_order_seq_cst) before reading value.m[idx] in das_index<Matrix<VecT,size>>::at. This is a pure compiler barrier (no machine instruction) that prevents ThinLTO SROA from substituting a stale virtual-register value for the matrix element after a write through an aliased pointer of a different type (e.g. TMatrix& aliasing float3x4 in AOT binding code).

Symptom: turret shoot direction computed incorrectly in rel+ThinLTO builds, causing non-normalized turret_state.shoot.dir values at runtime ("turret_shoot_tm_save_es" messages in gun_es.das and turrett.das in Enlisted).
Root cause: geomtree_get_node_rel_wtm writes via reinterpret_cast<TMatrix&>
into a float3x4 local; without the barrier, SROA keeps the pre-call value in a register and the subsequent das_copy reads stale data.