### PR TITLE
glfw: forward macOS SDK sysroot into the GLFW sub-build

### DIFF
--- a/modules/dasGlfw/CMakeLists.txt
+++ b/modules/dasGlfw/CMakeLists.txt
@@ -37,6 +37,18 @@ IF((NOT DAS_GLFW_INCLUDED) AND ((NOT ${DAS_GLFW_DISABLED}) OR (NOT DEFINED DAS_G
 	MACRO(BUILD_GLFW glfw_libraries glfw3_target build_shared_libs install_prefix prefix_dir)
 		LIST(APPEND CMAKE_MODULE_PATH ${DAS_GLFW_DIR})
 		IF(APPLE)
+			# Forward the macOS SDK sysroot into the GLFW sub-build. Without it the
+			# ExternalProject configures with no -isysroot and falls back to the
+			# header-less /System/Library/Frameworks, so framework headers Apple now
+			# ships SDK-only (e.g. Carbon.h) are not found. Guard against an unset
+			# value so we don't clobber CMake's own SDK auto-detection in the child.
+			SET(GLFW_APPLE_SDK_ARGS "")
+			IF(CMAKE_OSX_SYSROOT)
+				LIST(APPEND GLFW_APPLE_SDK_ARGS -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
+			ENDIF()
+			IF(CMAKE_OSX_DEPLOYMENT_TARGET)
+				LIST(APPEND GLFW_APPLE_SDK_ARGS -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+			ENDIF()
 			ExternalProject_Add(
 				${glfw3_target}
 				URL ${GLFW_URL}
@@ -51,6 +63,7 @@ IF((NOT DAS_GLFW_INCLUDED) AND ((NOT ${DAS_GLFW_DISABLED}) OR (NOT DEFINED DAS_G
 					-DGLFW_BUILD_TESTS=OFF
 					-DGLFW_BUILD_DOCS=OFF
 					-DBUILD_SHARED_LIBS=${build_shared_libs}
+					${GLFW_APPLE_SDK_ARGS}
 				BUILD_BYPRODUCTS ${glfw_libraries}
 				BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG>
 				INSTALL_COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR> --config $<CONFIG> --prefix ${install_prefix}/$<CONFIG>


### PR DESCRIPTION
## What

Forward `CMAKE_OSX_SYSROOT` (and `CMAKE_OSX_DEPLOYMENT_TARGET`) from the parent build into the bundled GLFW `ExternalProject` on macOS.

## Why

The `dasGLFW` `ExternalProject` configured GLFW with **no `-isysroot`**, so it fell back to the header-less `/System/Library/Frameworks`. Recent macOS SDKs ship framework headers SDK-only — including `Carbon.h`, which GLFW's Cocoa backend pulls in transitively via `glfw3native.h` → `ApplicationServices.h`. The result on a clean dev machine:

```
fatal error: 'Carbon/Carbon.h' file not found
```

CI release runners have an ambient `SDKROOT` in the environment, so clang there picked up the SDK as an implicit sysroot and the release matrix was unaffected — the breakage only bit **local** macOS builds whose shell did not already export `SDKROOT`.

## Fix

```cmake
SET(GLFW_APPLE_SDK_ARGS "")
IF(CMAKE_OSX_SYSROOT)
    LIST(APPEND GLFW_APPLE_SDK_ARGS -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
ENDIF()
IF(CMAKE_OSX_DEPLOYMENT_TARGET)
    LIST(APPEND GLFW_APPLE_SDK_ARGS -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
ENDIF()
```

…appended to the APPLE branch's `CMAKE_ARGS`. CMake auto-detects the current SDK during `project()` even when `SDKROOT` is unset, so a fresh configure now propagates a correct sysroot to the sub-build with **no environment setup**. The values are guarded so an unset variable never clobbers the child's own auto-detection.

## Verification

Fresh configure + `GLFW3` / `GLFW3_DYN` build with `SDKROOT` explicitly **unset** (`env -u SDKROOT`):

- Configure + build: **rc=0**, **zero** `Carbon` errors (was: `Carbon.h` not found).
- Both sub-build caches received the forwarded path:
  ```
  libglfw_static/.../GLFW3-build/CMakeCache.txt:CMAKE_OSX_SYSROOT:PATH=…/MacOSX26.5.sdk
  libglfw_dyn/.../GLFW3_DYN-build/CMakeCache.txt:CMAKE_OSX_SYSROOT:PATH=…/MacOSX26.5.sdk
  ```

Non-Apple branches and existing Apple `CMAKE_ARGS` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)