### PR TITLE
playground: fix broken URL shortener (is.gd CORS) with a 3-service fallback chain

### DIFF
--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -62,7 +62,7 @@
 <script type="text/javascript" src="./playground-init.js"></script>
 <script type="text/javascript" src="./main.js"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=2"></script>
-<script type="text/javascript" src="./playground-share.js?v=2"></script>
+<script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>
 
 <div class="main">

--- a/site/playground/playground-share.js
+++ b/site/playground/playground-share.js
@@ -1,9 +1,50 @@
 // ↗ share — generate a URL containing every file in pgState, lz-compressed
 // into the hash. Click opens a small popover with the URL, a Copy button,
-// and an optional "Shorten to is.gd" action.
+// and an optional "Shorten URL" action.
 
 (function () {
-    const SHORTENER = 'https://is.gd/create.php?format=simple&url=';
+    // Free, no-auth shorteners tried in order until one returns a URL. Each
+    // `run` performs its own fetch + parse and returns the short URL string;
+    // the chain validates the `https?://` shape. is.gd/v.gd are intentionally
+    // absent — they send no CORS headers, so a browser fetch from daslang.io is
+    // always blocked. da.gd/tinyurl (plain-text GET) and spoo.me (form POST +
+    // JSON) do send them. A longer chain survives any one service rate-limiting
+    // or dropping CORS later.
+    async function getText(url, name) {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(name + ' error ' + resp.status);
+        return (await resp.text()).trim();
+    }
+
+    const SHORTENERS = [
+        { name: 'da.gd', run: (u, name) => getText('https://da.gd/s?url=' + encodeURIComponent(u), name) },
+        { name: 'tinyurl', run: (u, name) => getText('https://tinyurl.com/api-create.php?url=' + encodeURIComponent(u), name) },
+        { name: 'spoo.me', run: async (u, name) => {
+            const resp = await fetch('https://spoo.me/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json' },
+                body: 'url=' + encodeURIComponent(u),
+            });
+            if (!resp.ok) throw new Error(name + ' error ' + resp.status);
+            // spoo.me returns { short_url: "http://spoo.me/xxxx" } — upgrade to https.
+            return ((await resp.json()).short_url || '').replace(/^http:/, 'https:');
+        } },
+    ];
+
+    async function shortenWithFallback(longUrl) {
+        let lastErr = null;
+        for (const svc of SHORTENERS) {
+            try {
+                const short = (await svc.run(longUrl, svc.name)).trim();
+                if (!/^https?:\/\//.test(short)) throw new Error(svc.name + ' non-URL: ' + short.slice(0, 60));
+                return { short, name: svc.name };
+            } catch (e) {
+                lastErr = e;
+                console.warn('share-shorten:', e);
+            }
+        }
+        throw lastErr || new Error('no shortener available');
+    }
 
     function buildShareUrl() {
         if (!window.pgState || !window.LZString) return null;
@@ -34,7 +75,7 @@
                 '<button class="pg-share__copy" type="button">Copy</button>' +
             '</div>' +
             '<div class="pg-share__footer">' +
-                '<button class="pg-share__shorten" type="button">↘ Shorten to is.gd</button>' +
+                '<button class="pg-share__shorten" type="button">↘ Shorten URL</button>' +
                 '<span class="pg-share__meta">' + esc(fileCount() + ' file' + (fileCount() === 1 ? '' : 's')) + '</span>' +
             '</div>'
         );
@@ -77,18 +118,15 @@
             shortenBtn.disabled = true;
             shortenBtn.textContent = '…';
             try {
-                const resp = await fetch(SHORTENER + encodeURIComponent(input.value));
-                if (!resp.ok) throw new Error('is.gd error ' + resp.status);
-                const short = (await resp.text()).trim();
-                if (!/^https?:\/\//.test(short)) throw new Error('non-URL response: ' + short.slice(0, 60));
+                const { short, name } = await shortenWithFallback(input.value);
                 input.value = short;
-                shortenBtn.textContent = '✓ shortened';
+                shortenBtn.textContent = '✓ via ' + name;
             } catch (e) {
                 shortenBtn.textContent = 'shorten failed';
                 console.warn('share-shorten:', e);
             } finally {
                 setTimeout(() => {
-                    shortenBtn.textContent = '↘ Shorten to is.gd';
+                    shortenBtn.textContent = '↘ Shorten URL';
                     shortenBtn.disabled = false;
                 }, 2000);
             }

--- a/site/tests/playground/share.spec.js
+++ b/site/tests/playground/share.spec.js
@@ -1,6 +1,6 @@
-// ↗ share — compressed multi-file state in a URL hash, with optional is.gd
-// shortener. is.gd is stubbed via Playwright's route() so the test does not
-// depend on the external service.
+// ↗ share — compressed multi-file state in a URL hash, with an optional
+// shortener that tries da.gd, then tinyurl, then spoo.me. All three are stubbed
+// via Playwright's route() so the tests do not depend on the external services.
 
 const { test, expect } = require('./fixtures.js');
 
@@ -77,13 +77,13 @@ test('shared URL restores state in a fresh context', async ({ playground, browse
     await ctx.close();
 });
 
-test('Shorten button replaces the URL with the is.gd response', async ({ playground }) => {
-    // Stub is.gd so the test is self-contained.
-    await playground.route('https://is.gd/create.php**', route => {
+test('Shorten button replaces the URL with the da.gd response', async ({ playground }) => {
+    // Stub the primary shortener so the test is self-contained.
+    await playground.route('https://da.gd/s**', route => {
         return route.fulfill({
             status: 200,
             contentType: 'text/plain',
-            body: 'https://is.gd/ABCxyz',
+            body: 'https://da.gd/ABCxyz\n',
         });
     });
 
@@ -92,12 +92,52 @@ test('Shorten button replaces the URL with the is.gd response', async ({ playgro
     await playground.locator('#share').click();
     await playground.locator('.pg-share__shorten').click();
 
-    await expect(playground.locator('.pg-share__url')).toHaveValue('https://is.gd/ABCxyz');
-    await expect(playground.locator('.pg-share__shorten')).toHaveText(/shortened/);
+    await expect(playground.locator('.pg-share__url')).toHaveValue('https://da.gd/ABCxyz');
+    await expect(playground.locator('.pg-share__shorten')).toHaveText(/via da\.gd/);
 });
 
-test('Shorten button surfaces a failure', async ({ playground }) => {
-    await playground.route('https://is.gd/create.php**', route => route.fulfill({ status: 502, body: '' }));
+test('Shorten falls back to tinyurl when da.gd fails', async ({ playground }) => {
+    await playground.route('https://da.gd/s**', route => route.fulfill({ status: 502, body: '' }));
+    await playground.route('https://tinyurl.com/api-create.php**', route => {
+        return route.fulfill({
+            status: 200,
+            contentType: 'text/plain',
+            body: 'https://tinyurl.com/abc123',
+        });
+    });
+
+    await waitTabsReady(playground);
+    await playground.locator('#share').click();
+    await playground.locator('.pg-share__shorten').click();
+
+    await expect(playground.locator('.pg-share__url')).toHaveValue('https://tinyurl.com/abc123');
+    await expect(playground.locator('.pg-share__shorten')).toHaveText(/via tinyurl/);
+});
+
+test('Shorten falls back to spoo.me and upgrades http to https', async ({ playground }) => {
+    await playground.route('https://da.gd/s**', route => route.fulfill({ status: 502, body: '' }));
+    await playground.route('https://tinyurl.com/api-create.php**', route => route.fulfill({ status: 502, body: '' }));
+    // spoo.me answers with JSON and an http:// short_url; the client upgrades it.
+    await playground.route('https://spoo.me/**', route => {
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ short_url: 'http://spoo.me/xyz789', domain: 'spoo.me' }),
+        });
+    });
+
+    await waitTabsReady(playground);
+    await playground.locator('#share').click();
+    await playground.locator('.pg-share__shorten').click();
+
+    await expect(playground.locator('.pg-share__url')).toHaveValue('https://spoo.me/xyz789');
+    await expect(playground.locator('.pg-share__shorten')).toHaveText(/via spoo\.me/);
+});
+
+test('Shorten button surfaces a failure when every service fails', async ({ playground }) => {
+    await playground.route('https://da.gd/s**', route => route.fulfill({ status: 502, body: '' }));
+    await playground.route('https://tinyurl.com/api-create.php**', route => route.fulfill({ status: 502, body: '' }));
+    await playground.route('https://spoo.me/**', route => route.fulfill({ status: 502, body: '' }));
 
     await waitTabsReady(playground);
     await playground.locator('#share').click();


### PR DESCRIPTION
## Problem

The playground's share popover "Shorten" button failed **100% of the time**. Root cause confirmed live from the `daslang.io` origin:

> Access to fetch at `https://is.gd/create.php?...` from origin `https://daslang.io` has been blocked by **CORS policy: No 'Access-Control-Allow-Origin' header is present**.

`is.gd`'s `create.php` is a server-side API that sends no CORS headers, so the browser blocks every cross-origin `fetch()` before our code sees the response (`TypeError: Failed to fetch`). It has nothing to do with payload size — the failing share URL was only ~246 chars.

## Fix

Replace the single hardcoded `is.gd` call with a fallback chain of free, no-auth, **CORS-enabled** shorteners, tried in order until one returns a valid `https?://` URL:

| Service | Shape | Notes |
|---|---|---|
| **da.gd** (primary) | GET, plain text | privacy-friendly, cleanest |
| **tinyurl** | GET, plain text | fallback |
| **spoo.me** | POST form + JSON | `http://` short_url upgraded to `https://` |

Each service has its own `run()`, so the heterogeneous GET-text vs POST-JSON shapes compose cleanly; the chain validates the URL shape once. A longer chain also survives any one service rate-limiting or dropping CORS later (tinyurl's `api-create.php` CORS isn't contractually guaranteed — it works today).

The button is now brand-neutral ("↘ Shorten URL") and reports the winning service ("✓ via da.gd"). On total failure the long URL is left intact so the user still has a working share.

## Validation (live, from the daslang.io origin)

All three produce working short URLs and **round-trip** back to the full `#z=` playground state:
- da.gd → `https://da.gd/sfX8Pl`
- tinyurl → `https://tinyurl.com/2bq64s7y`
- spoo.me → `https://spoo.me/tNBYaj` (correctly upgraded to https)

`is.gd`/`v.gd`/`ulvis.net`/`cleanuri.com` were all tested and confirmed to be CORS-blocked from the browser — they're server-side-only and excluded by design.

## Changes
- `site/playground/playground-share.js` — 3-service fallback chain with per-service `run()`.
- `site/playground/index.html` — cache-buster `?v=2` → `?v=3` so deployed clients drop the stale broken script.
- `site/tests/playground/share.spec.js` — re-stubbed success (da.gd), added fallback-to-tinyurl, fallback-to-spoo.me (asserts the http→https upgrade), and all-three-fail tests.

Pure static-site JS/HTML — no daslang/CMake surface. The Playwright e2e specs are exercised by CI (the spec edits are structural mirrors of the existing passing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)