### PR TITLE
linq: mixed (iterator, array) *_to_array overloads for binary ops

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -183,6 +183,16 @@ def concat_to_array(var a, b : iterator<auto(TT)>) : array<TT -const -&> {
     return <- concat_impl(a, b, type<TT -const -&>, 0)
 }
 
+def concat_to_array(var a : iterator<auto(TT) const>; b : array<TT>) : array<TT -const -&> {
+    //! Concatenates an iterator and an array, returning an array
+    return <- concat_impl_const(a, b, type<TT -const -&>, 0)
+}
+
+def concat_to_array(a : array<TT>; var b : iterator<auto(TT) const>) : array<TT -const -&> {
+    //! Concatenates an array and an iterator, returning an array
+    return <- concat_impl_const(a, b, type<TT -const -&>, 0)
+}
+
 def concat(var a : iterator<auto(TT) const>; b : array<TT>) : iterator<TT -const -&> {
     //! Concatenates an iterator and an array. Materializes eagerly (unlike the lazy iterator+iterator form).
     return <- concat_impl_const(a, b, type<TT -const -&>, 0).to_sequence_move()
@@ -1729,6 +1739,16 @@ def join_to_array(var srca : iterator<auto(TA)>; var srcb : iterator<auto(TB)>; 
     return <- join_impl(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
 }
 
+def join_to_array(var srca : iterator<auto(TA) const>; srcb : array<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<TA>, type<TB>)) -const -&> {
+    //! Inner join of an iterator (left) and an array (right), returning an array
+    return <- join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def join_to_array(srca : array<auto(TA)>; var srcb : iterator<auto(TB) const>; keya, keyb; result) : array<typedecl(result(type<TA>, type<TB>)) -const -&> {
+    //! Inner join of an array (left) and an iterator (right), returning an array
+    return <- join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
 [unused_argument(ta, tb)]
 def private group_join_impl(var srca; var srcb; ta : auto(TA); tb : auto(TB); keya, keyb; result) : array<typedecl(result(type<TA>, type<array<TB -const -&>>)) -const -&> {
     // we pass TA, and sequence of TB to 'result'
@@ -1775,6 +1795,16 @@ def group_join(srca : array<auto(TA)>; srcb : array<auto(TB)>; keya, keyb; resul
 def group_join_to_array(var srca : iterator<auto(TA)>; var srcb : iterator<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<TA>, type<array<TB -const -&>>)) -const -&> {
     //! we pass TA, and sequence of TB to 'result'
     return <- group_join_impl(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def group_join_to_array(var srca : iterator<auto(TA) const>; srcb : array<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<TA>, type<array<TB -const -&>>)) -const -&> {
+    //! Group join of an iterator (left) and an array (right), returning an array
+    return <- group_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def group_join_to_array(srca : array<auto(TA)>; var srcb : iterator<auto(TB) const>; keya, keyb; result) : array<typedecl(result(type<TA>, type<array<TB -const -&>>)) -const -&> {
+    //! Group join of an array (left) and an iterator (right), returning an array
+    return <- group_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
 }
 
 [unused_argument(ta, tb)]
@@ -1832,6 +1862,16 @@ def left_join_to_array(var srca : iterator<auto(TA)>; var srcb : iterator<auto(T
     return <- left_join_impl(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
 }
 
+def left_join_to_array(var srca : iterator<auto(TA) const>; srcb : array<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<TA>, type<$Option<TB -const -&>>)) -const -&> {
+    //! Left outer join of an iterator (left) and an array (right), returning an array
+    return <- left_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def left_join_to_array(srca : array<auto(TA)>; var srcb : iterator<auto(TB) const>; keya, keyb; result) : array<typedecl(result(type<TA>, type<$Option<TB -const -&>>)) -const -&> {
+    //! Left outer join of an array (left) and an iterator (right), returning an array
+    return <- left_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
 [unused_argument(ta, tb)]
 def private right_join_impl(var srca; var srcb; ta : auto(TA); tb : auto(TB); keya, keyb; result) : array<typedecl(result(type<$Option<TA -const -&>>, type<TB>)) -const -&> {
     // Hash-build on srca; iterate srcb. For huge LEFT + tiny RIGHT this wastes memory — future optimizer may pick the smaller side.
@@ -1885,6 +1925,16 @@ def right_join(srca : array<auto(TA)>; srcb : array<auto(TB)>; keya, keyb; resul
 def right_join_to_array(var srca : iterator<auto(TA)>; var srcb : iterator<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<$Option<TA -const -&>>, type<TB>)) -const -&> {
     //! Right outer join returning an array
     return <- right_join_impl(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def right_join_to_array(var srca : iterator<auto(TA) const>; srcb : array<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<$Option<TA -const -&>>, type<TB>)) -const -&> {
+    //! Right outer join of an iterator (left) and an array (right), returning an array
+    return <- right_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def right_join_to_array(srca : array<auto(TA)>; var srcb : iterator<auto(TB) const>; keya, keyb; result) : array<typedecl(result(type<$Option<TA -const -&>>, type<TB>)) -const -&> {
+    //! Right outer join of an array (left) and an iterator (right), returning an array
+    return <- right_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
 }
 
 [unused_argument(ta, tb)]
@@ -1953,6 +2003,16 @@ def full_outer_join_to_array(var srca : iterator<auto(TA)>; var srcb : iterator<
     return <- full_outer_join_impl(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
 }
 
+def full_outer_join_to_array(var srca : iterator<auto(TA) const>; srcb : array<auto(TB)>; keya, keyb; result) : array<typedecl(result(type<$Option<TA -const -&>>, type<$Option<TB -const -&>>)) -const -&> {
+    //! Full outer join of an iterator (left) and an array (right), returning an array
+    return <- full_outer_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
+def full_outer_join_to_array(srca : array<auto(TA)>; var srcb : iterator<auto(TB) const>; keya, keyb; result) : array<typedecl(result(type<$Option<TA -const -&>>, type<$Option<TB -const -&>>)) -const -&> {
+    //! Full outer join of an array (left) and an iterator (right), returning an array
+    return <- full_outer_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, keya, keyb, result)
+}
+
 [unused_argument(ta, tb)]
 def private cross_join_impl(var srca; srcb : array<auto(TB) -const -&>; ta : auto(TA); tb : auto(TB); result) : array<typedecl(result(type<TA>, type<TB>)) -const -&> {
     var buffer : array<typedecl(result(type<TA>, type<TB>)) -const -&>
@@ -1995,6 +2055,17 @@ def cross_join_to_array(var srca : iterator<auto(TA)>; var srcb : iterator<auto(
     //! Cross join returning an array. srcb is materialized first.
     let srcb_arr <- to_array(srcb)
     return <- cross_join_impl(srca, srcb_arr, type<TA -const -&>, type<TB -const -&>, result)
+}
+
+def cross_join_to_array(var srca : iterator<auto(TA) const>; srcb : array<auto(TB)>; result) : array<typedecl(result(type<TA>, type<TB>)) -const -&> {
+    //! Cross join of an iterator (left) and an array (right), returning an array
+    return <- cross_join_impl_const(srca, srcb, type<TA -const -&>, type<TB -const -&>, result)
+}
+
+def cross_join_to_array(srca : array<auto(TA)>; var srcb : iterator<auto(TB) const>; result) : array<typedecl(result(type<TA>, type<TB>)) -const -&> {
+    //! Cross join of an array (left) and an iterator (right), returning an array. The iterator is materialized first (cross re-iterates the right side per left row).
+    let srcb_arr <- to_array(srcb)
+    return <- cross_join_impl_const(srca, srcb_arr, type<TA -const -&>, type<TB -const -&>, result)
 }
 
 [unused_argument(tt)]
@@ -2135,6 +2206,16 @@ def union_to_array(var srca, srcb : iterator<auto(TT)>) : array<TT -const -&> {
     return <- union_impl(srca, srcb, type<TT -const -&>)
 }
 
+def union_to_array(var srca : iterator<auto(TT) const>; srcb : array<TT>) : array<TT -const -&> {
+    //! Distinct elements from the concatenation of an iterator and an array, returning an array
+    return <- union_impl_const(srca, srcb, type<TT -const -&>)
+}
+
+def union_to_array(srca : array<TT>; var srcb : iterator<auto(TT) const>) : array<TT -const -&> {
+    //! Distinct elements from the concatenation of an array and an iterator, returning an array
+    return <- union_impl_const(srca, srcb, type<TT -const -&>)
+}
+
 [unused_argument(tt)]
 def private union_by_impl(var srca; var srcb; tt : auto(TT); key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
     //! Returns distinct elements from the concatenation of two iterators by key
@@ -2185,6 +2266,16 @@ def union_by(srca, srcb : array<auto(TT)>; key : block<(arg : TT -&) : auto>) : 
 def union_by_to_array(var srca, srcb : iterator<auto(TT)>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
     //! Returns distinct elements from the concatenation of two iterators by key and returns an array
     return <- union_by_impl(srca, srcb, type<TT -const -&>, key)
+}
+
+def union_by_to_array(var srca : iterator<auto(TT) const>; srcb : array<TT>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! Distinct elements from the concatenation of an iterator and an array by key, returning an array
+    return <- union_by_impl_const(srca, srcb, type<TT -const -&>, key)
+}
+
+def union_by_to_array(srca : array<TT>; var srcb : iterator<auto(TT) const>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! Distinct elements from the concatenation of an array and an iterator by key, returning an array
+    return <- union_by_impl_const(srca, srcb, type<TT -const -&>, key)
 }
 
 def any(src : array<auto(TT)>) : bool {
@@ -2334,6 +2425,16 @@ def except_to_array(var src, exclude : iterator<auto(TT)>) : array<TT -const -&>
     return <- except_impl(src, exclude, type<TT -const -&>)
 }
 
+def except_to_array(var src : iterator<auto(TT) const>; exclude : array<TT>) : array<TT -const -&> {
+    //! Elements from an iterator (left) not present in an array (right), returning an array
+    return <- except_impl_const(src, exclude, type<TT -const -&>)
+}
+
+def except_to_array(src : array<TT>; var exclude : iterator<auto(TT) const>) : array<TT -const -&> {
+    //! Elements from an array (left) not present in an iterator (right), returning an array
+    return <- except_impl_const(src, exclude, type<TT -const -&>)
+}
+
 [unused_argument(tt)]
 def private except_by_impl(var src, exclude; tt : auto(TT); key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
     //! Returns distinct elements from the first iterator that are not in the second iterator by key
@@ -2380,6 +2481,16 @@ def except_by(src, exclude : array<auto(TT)>; key : block<(arg : TT -&) : auto>)
 def except_by_to_array(var src, exclude : iterator<auto(TT)>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
     //! Returns elements from the first iterator that are not in the second iterator by key and returns an array
     return <- except_by_impl(src, exclude, type<TT -const -&>, key)
+}
+
+def except_by_to_array(var src : iterator<auto(TT) const>; exclude : array<TT>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! Elements from an iterator (left) not present in an array (right) by key, returning an array
+    return <- except_by_impl_const(src, exclude, type<TT -const -&>, key)
+}
+
+def except_by_to_array(src : array<TT>; var exclude : iterator<auto(TT) const>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! Elements from an array (left) not present in an iterator (right) by key, returning an array
+    return <- except_by_impl_const(src, exclude, type<TT -const -&>, key)
 }
 
 [unused_argument(tt)]
@@ -2430,6 +2541,16 @@ def intersect_to_array(var srca, srcb : iterator<auto(TT)>) : array<TT -const -&
     return <- intersect_impl(srca, srcb, type<TT -const -&>)
 }
 
+def intersect_to_array(var srca : iterator<auto(TT) const>; srcb : array<TT>) : array<TT -const -&> {
+    //! Elements present in both an iterator and an array, returning an array
+    return <- intersect_impl_const(srca, srcb, type<TT -const -&>)
+}
+
+def intersect_to_array(srca : array<TT>; var srcb : iterator<auto(TT) const>) : array<TT -const -&> {
+    //! Elements present in both an array and an iterator, returning an array
+    return <- intersect_impl_const(srca, srcb, type<TT -const -&>)
+}
+
 [unused_argument(tt)]
 def private intersect_by_impl(var srca, srcb; tt : auto(TT); key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
     //! Returns elements that are present in both iterators by key
@@ -2476,6 +2597,16 @@ def intersect_by(srca, srcb : array<auto(TT)>; key : block<(arg : TT -&) : auto>
 def intersect_by_to_array(var srca, srcb : iterator<auto(TT)>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
     //! Returns elements that are present in both iterators by key and returns an array
     return <- intersect_by_impl(srca, srcb, type<TT -const -&>, key)
+}
+
+def intersect_by_to_array(var srca : iterator<auto(TT) const>; srcb : array<TT>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! Elements present in both an iterator and an array by key, returning an array
+    return <- intersect_by_impl_const(srca, srcb, type<TT -const -&>, key)
+}
+
+def intersect_by_to_array(srca : array<TT>; var srcb : iterator<auto(TT) const>; key : block<(arg : TT -&) : auto>) : array<TT -const -&> {
+    //! Elements present in both an array and an iterator by key, returning an array
+    return <- intersect_by_impl_const(srca, srcb, type<TT -const -&>, key)
 }
 
 [unused_argument(tt)]

--- a/tests/linq/test_linq_mixed_to_array.das
+++ b/tests/linq/test_linq_mixed_to_array.das
@@ -1,0 +1,170 @@
+options gen2
+require daslib/linq_boost public
+require daslib/linq_fold
+require dastest/testing_boost public
+
+// Mixed-source *_to_array overloads: every binary linq op that materializes to an array now accepts
+// ONE array + ONE iterator source in both directions (not just both-array or both-iterator). These
+// are what the _fold binary-op array-rewrite needs — `_fold(each(a) |> _join(arr) |> count())`
+// lowers to join_to_array(iterator, array, ...), which previously failed to resolve. Each mixed
+// _to_array delegates to the same *_impl_const as the mixed iterator-returning overload, so each
+// test asserts the array result (both directions) equals the all-array ground truth, and the final
+// test exercises the _fold consumer directly (count and to_array terminals).
+
+struct L { id : int; k : int }
+struct R { k : int; v : int }
+
+def fixture_a() : array<int> {
+    return <- [1, 2, 3, 3]
+}
+def fixture_b() : array<int> {
+    return <- [3, 4, 4, 5]
+}
+def fixture_l() : array<L> {
+    return <- [L(id = 1, k = 1), L(id = 2, k = 2), L(id = 3, k = 1)]
+}
+def fixture_r() : array<R> {
+    return <- [R(k = 1, v = 10), R(k = 2, v = 20), R(k = 1, v = 30)]
+}
+
+// Both lanes run the same *_impl_const, so output order matches the array ground truth — a direct
+// element-wise compare (not a checksum) is valid. `got` is moved in and deleted here.
+def same_arr(t : T?; name : string; ref : array<int>; var got : array<int>) {
+    t |> equal(length(got), length(ref), name)
+    if (length(got) == length(ref)) {
+        for (i in range(length(ref))) {
+            t |> equal(got[i], ref[i], name)
+        }
+    }
+    delete got
+}
+
+[test]
+def test_concat_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> concat(b))
+    same_arr(t, "concat_to_array iter+array", ref, concat_to_array(unsafe(each(a)), b))
+    same_arr(t, "concat_to_array array+iter", ref, concat_to_array(a, unsafe(each(b))))
+}
+
+[test]
+def test_union_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> union(b))
+    same_arr(t, "union_to_array iter+array", ref, union_to_array(unsafe(each(a)), b))
+    same_arr(t, "union_to_array array+iter", ref, union_to_array(a, unsafe(each(b))))
+}
+
+[test]
+def test_union_by_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> union_by(b, $(x : int) => x % 10))
+    same_arr(t, "union_by_to_array iter+array", ref, union_by_to_array(unsafe(each(a)), b, $(x : int) => x % 10))
+    same_arr(t, "union_by_to_array array+iter", ref, union_by_to_array(a, unsafe(each(b)), $(x : int) => x % 10))
+}
+
+[test]
+def test_intersect_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> intersect(b))
+    same_arr(t, "intersect_to_array iter+array", ref, intersect_to_array(unsafe(each(a)), b))
+    same_arr(t, "intersect_to_array array+iter", ref, intersect_to_array(a, unsafe(each(b))))
+}
+
+[test]
+def test_intersect_by_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> intersect_by(b, $(x : int) => x % 10))
+    same_arr(t, "intersect_by_to_array iter+array", ref, intersect_by_to_array(unsafe(each(a)), b, $(x : int) => x % 10))
+    same_arr(t, "intersect_by_to_array array+iter", ref, intersect_by_to_array(a, unsafe(each(b)), $(x : int) => x % 10))
+}
+
+[test]
+def test_except_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> except(b))
+    same_arr(t, "except_to_array iter+array", ref, except_to_array(unsafe(each(a)), b))
+    same_arr(t, "except_to_array array+iter", ref, except_to_array(a, unsafe(each(b))))
+}
+
+[test]
+def test_except_by_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let ref <- (a |> except_by(b, $(x : int) => x % 10))
+    same_arr(t, "except_by_to_array iter+array", ref, except_by_to_array(unsafe(each(a)), b, $(x : int) => x % 10))
+    same_arr(t, "except_by_to_array array+iter", ref, except_by_to_array(a, unsafe(each(b)), $(x : int) => x % 10))
+}
+
+[test]
+def test_join_to_array(t : T?) {
+    let a <- fixture_l(); let b <- fixture_r()
+    let ref <- (join(a, b, $(l : L) => l.k, $(r : R) => r.k, $(l : L, r : R) => l.id + r.v))
+    same_arr(t, "join_to_array iter+array", ref,
+        join_to_array(unsafe(each(a)), b, $(l : L) => l.k, $(r : R) => r.k, $(l : L, r : R) => l.id + r.v))
+    same_arr(t, "join_to_array array+iter", ref,
+        join_to_array(a, unsafe(each(b)), $(l : L) => l.k, $(r : R) => r.k, $(l : L, r : R) => l.id + r.v))
+}
+
+[test]
+def test_group_join_to_array(t : T?) {
+    let a <- fixture_l(); let b <- fixture_r()
+    let ref <- (group_join(a, b, $(l : L) => l.k, $(r : R) => r.k, $(l : L, rs : array<R>) => l.id + length(rs)))
+    same_arr(t, "group_join_to_array iter+array", ref,
+        group_join_to_array(unsafe(each(a)), b, $(l : L) => l.k, $(r : R) => r.k, $(l : L, rs : array<R>) => l.id + length(rs)))
+    same_arr(t, "group_join_to_array array+iter", ref,
+        group_join_to_array(a, unsafe(each(b)), $(l : L) => l.k, $(r : R) => r.k, $(l : L, rs : array<R>) => l.id + length(rs)))
+}
+
+[test]
+def test_left_join_to_array(t : T?) {
+    let a <- fixture_l(); let b <- fixture_r()
+    let ref <- (left_join(a, b, $(l : L) => l.k, $(r : R) => r.k, $(l : L, r : Option<R>) => l.id + (r |> is_some ? 1 : 0)))
+    same_arr(t, "left_join_to_array iter+array", ref,
+        left_join_to_array(unsafe(each(a)), b, $(l : L) => l.k, $(r : R) => r.k, $(l : L, r : Option<R>) => l.id + (r |> is_some ? 1 : 0)))
+    same_arr(t, "left_join_to_array array+iter", ref,
+        left_join_to_array(a, unsafe(each(b)), $(l : L) => l.k, $(r : R) => r.k, $(l : L, r : Option<R>) => l.id + (r |> is_some ? 1 : 0)))
+}
+
+[test]
+def test_right_join_to_array(t : T?) {
+    let a <- fixture_l(); let b <- fixture_r()
+    let ref <- (right_join(a, b, $(l : L) => l.k, $(r : R) => r.k, $(l : Option<L>, r : R) => (l |> is_some ? 1 : 0) + r.v))
+    same_arr(t, "right_join_to_array iter+array", ref,
+        right_join_to_array(unsafe(each(a)), b, $(l : L) => l.k, $(r : R) => r.k, $(l : Option<L>, r : R) => (l |> is_some ? 1 : 0) + r.v))
+    same_arr(t, "right_join_to_array array+iter", ref,
+        right_join_to_array(a, unsafe(each(b)), $(l : L) => l.k, $(r : R) => r.k, $(l : Option<L>, r : R) => (l |> is_some ? 1 : 0) + r.v))
+}
+
+[test]
+def test_full_outer_join_to_array(t : T?) {
+    let a <- fixture_l(); let b <- fixture_r()
+    let ref <- (full_outer_join(a, b, $(l : L) => l.k, $(r : R) => r.k,
+        $(l : Option<L>, r : Option<R>) => (l |> is_some ? 1 : 0) + (r |> is_some ? 1 : 0)))
+    same_arr(t, "full_outer_join_to_array iter+array", ref,
+        full_outer_join_to_array(unsafe(each(a)), b, $(l : L) => l.k, $(r : R) => r.k,
+            $(l : Option<L>, r : Option<R>) => (l |> is_some ? 1 : 0) + (r |> is_some ? 1 : 0)))
+    same_arr(t, "full_outer_join_to_array array+iter", ref,
+        full_outer_join_to_array(a, unsafe(each(b)), $(l : L) => l.k, $(r : R) => r.k,
+            $(l : Option<L>, r : Option<R>) => (l |> is_some ? 1 : 0) + (r |> is_some ? 1 : 0)))
+}
+
+[test]
+def test_cross_join_to_array(t : T?) {
+    let a <- fixture_l(); let b <- fixture_r()
+    let ref <- (cross_join(a, b, $(l : L, r : R) => l.id * r.v))
+    same_arr(t, "cross_join_to_array iter+array", ref,
+        cross_join_to_array(unsafe(each(a)), b, $(l : L, r : R) => l.id * r.v))
+    same_arr(t, "cross_join_to_array array+iter", ref,
+        cross_join_to_array(a, unsafe(each(b)), $(l : L, r : R) => l.id * r.v))
+}
+
+[test]
+def test_fold_join_consumer(t : T?) {
+    // The reason these overloads exist: _fold lowers `_join |> count()` to join_to_array(iterator,
+    // array, ...) internally — without the mixed overload this fails to resolve. Both directions.
+    let a <- fixture_l(); let b <- fixture_r()
+    let c1 = _fold(unsafe(each(a)) |> _join(b, $(l : L, r : R) => l.k == r.k, $(l : L, r : R) => l.id + r.v) |> count())
+    let c2 = _fold(a |> _join(unsafe(each(b)), $(l : L, r : R) => l.k == r.k, $(l : L, r : R) => l.id + r.v) |> count())
+    t |> equal(c1, 5)
+    t |> equal(c2, 5)
+}


### PR DESCRIPTION
## What

Completes the mixed-source LINQ overload family started in #2931 by adding the `*_to_array` counterparts. #2931 added mixed `(iterator, array)` / `(array, iterator)` forms for the binary ops (`join`/`union`/`intersect`/`except`/`concat`/...) but deliberately skipped the `*_to_array` variants as "redundant with `mixedForm |> to_array()`".

They are **not** redundant for `_fold`: the binary-op array-rewrite lowers

```
_fold(each(a) |> _join(arr) |> count())
```

to `join_to_array(iterator, array, ...)` internally, which had no matching overload (only both-iterator and both-array existed), so the chain failed to resolve.

## Change

- **`daslib/linq.das`** — 26 mixed `*_to_array` overloads (both directions) for every binary op that materializes to an array: join / group_join / left_join / right_join / full_outer_join / cross_join + union / union_by / intersect / intersect_by / except / except_by / concat. Each delegates to the same `*_impl_const` as the mixed iterator-returning form. `sequence_equal[_by]` excluded (return `bool`).
- **cross_join fix** — the `(array, iterator)` direction materializes the iterator first, since `cross_join_impl_const` reinterprets the right operand as an array (cross re-iterates the right side per left row). Mirrors the mixed-plain `cross_join(array, iterator)`. Caught by the regression test (memory corruption otherwise).
- **`tests/linq/test_linq_mixed_to_array.das`** — 14 tests: both directions per op against the all-array ground truth, plus the `_fold` consumer.

## Why now (separate PR)

Prerequisite for the XML benchmark-coverage work: `_fold` over a `from_xml_node` iterator joined with an in-memory array (the XML join bench lane) needs exactly this. Split out as its own PR because it's a self-contained completion of the mixed-overload family.

## Validation

- **Interp:** new file 14/14; no regression — `test_linq_mixed_source` 16/16, `test_linq_join` 52/52, `test_linq_set` 41/41, `test_linq_concat` 18/18.
- **AOT:** `test_aot` regenerated (new `*_impl_const` instantiations); new file 14/14.
- **Lint + format** clean; **das2rst** regenerates with no new stub/Uncategorized (docstrings render in `linq.rst`); **Sphinx** `build succeeded.` no warnings.
- **results.md** intentionally **not** refreshed: the new overloads have no existing benchmark caller (consumed only by the upcoming XML lanes), and existing overload resolution is unchanged, so the matrix cannot move. The XML bench-coverage PR re-runs the full sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)