### PR TITLE
bench: full XML coverage — m5 (no-fold) + m5f (fold) lanes across benchmarks/sql

### DIFF
--- a/benchmarks/sql/aggregate_match.das
+++ b/benchmarks/sql/aggregate_match.das
@@ -48,7 +48,7 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — plain iteration over from_xml_node.
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
 def run_m5(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -56,14 +56,9 @@ def run_m5(b : B?; n : int) {
             b->failNow()
             return
         }
-        let root = doc.document_element
         b |> run("m5_xml/{n}", n) {
-            var total = 0
-            for (car in from_xml_node(root, type<Car>)) {
-                if (car.price > THRESHOLD) {
-                    total += car.price
-                }
-            }
+            let total = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD)
+                |> aggregate(0, $(acc : int, c : Car) => acc + c.price))
             b |> accept(total)
             if (total == 0) {
                 b->failNow()
@@ -101,9 +96,8 @@ def run_m5f(b : B?; n : int) {
             b->failNow()
             return
         }
-        var root = doc.document_element
         b |> run("m5f_xml_fold/{n}", n) {
-            let total = _fold(unsafe(from_xml_node(root, type<Car>))._where(_.price > THRESHOLD)
+            let total = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD)
                 .aggregate(0, $(acc : int, c : Car) => acc + c.price))
             b |> accept(total)
             if (total == 0) {

--- a/benchmarks/sql/all_match.das
+++ b/benchmarks/sql/all_match.das
@@ -44,6 +44,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let yes = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _all(_.price < 9999)
+            b |> accept(yes)
+            if (!yes) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let yes = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._all(_.price < 9999))
+            b |> accept(yes)
+            if (!yes) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def all_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +91,14 @@ def all_match_m3f(b : B?) {
 [benchmark]
 def all_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def all_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def all_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/any_match.das
+++ b/benchmarks/sql/any_match.das
@@ -44,6 +44,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let yes = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _any(_.price > THRESHOLD)
+            b |> accept(yes)
+            if (!yes) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let yes = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._any(_.price > THRESHOLD))
+            b |> accept(yes)
+            if (!yes) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def any_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +91,14 @@ def any_match_m3f(b : B?) {
 [benchmark]
 def any_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def any_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def any_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/average_aggregate.das
+++ b/benchmarks/sql/average_aggregate.das
@@ -41,6 +41,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let a = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(double(_.price)) |> average()
+            b |> accept(a)
+            if (a == 0.0lf) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let a = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(double(_.price)).average())
+            b |> accept(a)
+            if (a == 0.0lf) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def average_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +88,14 @@ def average_aggregate_m3f(b : B?) {
 [benchmark]
 def average_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def average_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def average_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/bare_order_where.das
+++ b/benchmarks/sql/bare_order_where.das
@@ -52,6 +52,51 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                        |> _where(_.price > THRESHOLD)
+                        |> _order_by(_.price)
+                        |> to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD)
+                                       ._order_by(_.price)
+                                       .to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def bare_order_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -65,4 +110,14 @@ def bare_order_where_m3f(b : B?) {
 [benchmark]
 def bare_order_where_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def bare_order_where_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def bare_order_where_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/chained_select_collapse.das
+++ b/benchmarks/sql/chained_select_collapse.das
@@ -38,6 +38,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.brand) |> _select(_ + 1) |> distinct() |> count()
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.brand) |> _select(_ + 1) |> distinct() |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def chained_select_collapse_m3f(b : B?) {
     run_m3f(b, 100000)
@@ -46,4 +86,14 @@ def chained_select_collapse_m3f(b : B?) {
 [benchmark]
 def chained_select_collapse_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def chained_select_collapse_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def chained_select_collapse_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/chained_where.das
+++ b/benchmarks/sql/chained_where.das
@@ -53,6 +53,51 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = (unsafe(from_xml_node(doc.document_element, type<Car>))
+                    |> _where(_.price > THRESHOLD)
+                    |> _where(_.year >= YEAR_FLOOR)
+                    |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD)
+                                   ._where(_.year >= YEAR_FLOOR)
+                                   .count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def chained_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -66,4 +111,14 @@ def chained_where_m3f(b : B?) {
 [benchmark]
 def chained_where_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def chained_where_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def chained_where_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/contains_match.das
+++ b/benchmarks/sql/contains_match.das
@@ -45,6 +45,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let yes = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.id) |> contains(TARGET_ID)
+            b |> accept(yes)
+            if (!yes) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let yes = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.id).contains(TARGET_ID))
+            b |> accept(yes)
+            if (!yes) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def contains_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +92,14 @@ def contains_match_m3f(b : B?) {
 [benchmark]
 def contains_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def contains_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def contains_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/count_aggregate.das
+++ b/benchmarks/sql/count_aggregate.das
@@ -44,6 +44,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> count()
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def count_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +91,14 @@ def count_aggregate_m3f(b : B?) {
 [benchmark]
 def count_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def count_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def count_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/distinct_by_count.das
+++ b/benchmarks/sql/distinct_by_count.das
@@ -44,6 +44,42 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _distinct_by(_.brand) |> count()
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._distinct_by(_.brand).count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_by_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +93,14 @@ def distinct_by_count_m3f(b : B?) {
 [benchmark]
 def distinct_by_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def distinct_by_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def distinct_by_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/distinct_by_order_take.das
+++ b/benchmarks/sql/distinct_by_order_take.das
@@ -58,6 +58,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.dealer_id) |> _order_by(_.price) |> take(TAKE_N) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._distinct_by(_.dealer_id)._order_by(_.price).take(TAKE_N).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_by_order_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -71,4 +111,14 @@ def distinct_by_order_take_m3f(b : B?) {
 [benchmark]
 def distinct_by_order_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def distinct_by_order_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def distinct_by_order_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/distinct_by_order_to_array.das
+++ b/benchmarks/sql/distinct_by_order_to_array.das
@@ -55,6 +55,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.dealer_id) |> _order_by(_.price) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._distinct_by(_.dealer_id)._order_by(_.price).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_by_order_to_array_m1(b : B?) {
     run_m1(b, 100000)
@@ -68,4 +108,14 @@ def distinct_by_order_to_array_m3f(b : B?) {
 [benchmark]
 def distinct_by_order_to_array_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def distinct_by_order_to_array_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def distinct_by_order_to_array_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/distinct_count.das
+++ b/benchmarks/sql/distinct_count.das
@@ -45,6 +45,42 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.brand) |> distinct() |> to_array()
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.brand).distinct().to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +94,14 @@ def distinct_count_m3f(b : B?) {
 [benchmark]
 def distinct_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def distinct_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def distinct_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/distinct_count_pred.das
+++ b/benchmarks/sql/distinct_count_pred.das
@@ -60,6 +60,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let c = from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.brand) |> count($(c) => c.year > THRESHOLD)
+                b |> accept(c)
+                if (c == 0) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let c = _fold(from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.brand) |> count($(c) => c.year > THRESHOLD))
+                b |> accept(c)
+                if (c == 0) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_count_pred_m1(b : B?) {
     run_m1(b, 100000)
@@ -73,4 +113,14 @@ def distinct_count_pred_m3f(b : B?) {
 [benchmark]
 def distinct_count_pred_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def distinct_count_pred_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def distinct_count_pred_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/distinct_take.das
+++ b/benchmarks/sql/distinct_take.das
@@ -52,6 +52,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _select(_.brand) |> distinct() |> take(TAKE_N) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._select(_.brand).distinct().take(TAKE_N).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def distinct_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -65,4 +105,14 @@ def distinct_take_m3f(b : B?) {
 [benchmark]
 def distinct_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def distinct_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def distinct_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/element_at_match.das
+++ b/benchmarks/sql/element_at_match.das
@@ -46,6 +46,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> element_at(INDEX)
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).element_at(INDEX))
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def element_at_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +93,14 @@ def element_at_match_m3f(b : B?) {
 [benchmark]
 def element_at_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def element_at_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def element_at_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/first_match.das
+++ b/benchmarks/sql/first_match.das
@@ -43,6 +43,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> first()
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).first())
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def first_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -56,4 +90,14 @@ def first_match_m3f(b : B?) {
 [benchmark]
 def first_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def first_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def first_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/first_or_default_match.das
+++ b/benchmarks/sql/first_or_default_match.das
@@ -47,6 +47,42 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> first_or_default(sentinel)
+            b |> accept(row)
+            if (row.id == SENTINEL_ID) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).first_or_default(sentinel))
+            b |> accept(row)
+            if (row.id == SENTINEL_ID) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def first_or_default_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -60,4 +96,14 @@ def first_or_default_match_m3f(b : B?) {
 [benchmark]
 def first_or_default_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def first_or_default_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def first_or_default_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_average.das
+++ b/benchmarks/sql/groupby_average.das
@@ -54,6 +54,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      AvgPrice = _._1 |> select($(c : Car) => c.price) |> average()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          AvgPrice = _._1 |> select($(c : Car) => c.price) |> average()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_average_m1(b : B?) {
     run_m1(b, 100000)
@@ -67,4 +111,14 @@ def groupby_average_m3f(b : B?) {
 [benchmark]
 def groupby_average_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_average_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_average_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_count.das
+++ b/benchmarks/sql/groupby_count.das
@@ -52,6 +52,48 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0, N = _._1 |> length))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0, N = _._1 |> length))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -65,4 +107,14 @@ def groupby_count_m3f(b : B?) {
 [benchmark]
 def groupby_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_first.das
+++ b/benchmarks/sql/groupby_first.das
@@ -60,6 +60,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      FirstCar = _._1 |> first()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          FirstCar = _._1 |> first()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_first_m1(b : B?) {
     run_m1(b, 100000)
@@ -73,4 +117,14 @@ def groupby_first_m3f(b : B?) {
 [benchmark]
 def groupby_first_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_first_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_first_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_having_count.das
+++ b/benchmarks/sql/groupby_having_count.das
@@ -56,6 +56,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _having(_._1 |> length >= 5)
+                          |> _select((Brand = _._0, N = _._1 |> length))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._having(_._1 |> length >= 5)
+                                ._select((Brand = _._0, N = _._1 |> length))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_having_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -69,4 +113,14 @@ def groupby_having_count_m3f(b : B?) {
 [benchmark]
 def groupby_having_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_having_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_having_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_having_hidden_sum.das
+++ b/benchmarks/sql/groupby_having_hidden_sum.das
@@ -58,6 +58,48 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
+                          |> _select((Brand = _._0, N = _._1 |> length))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
+                                ._select((Brand = _._0, N = _._1 |> length))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_having_hidden_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -71,4 +113,14 @@ def groupby_having_hidden_sum_m3f(b : B?) {
 [benchmark]
 def groupby_having_hidden_sum_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_having_hidden_sum_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_having_hidden_sum_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_having_post_where.das
+++ b/benchmarks/sql/groupby_having_post_where.das
@@ -62,6 +62,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                          |> _where(_.Total > THRESHOLD)
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                                ._where(_.Total > THRESHOLD)
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_having_post_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -75,4 +119,14 @@ def groupby_having_post_where_m3f(b : B?) {
 [benchmark]
 def groupby_having_post_where_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_having_post_where_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_having_post_where_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_max.das
+++ b/benchmarks/sql/groupby_max.das
@@ -54,6 +54,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      MaxPrice = _._1 |> select($(c : Car) => c.price) |> max()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          MaxPrice = _._1 |> select($(c : Car) => c.price) |> max()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_max_m1(b : B?) {
     run_m1(b, 100000)
@@ -67,4 +111,14 @@ def groupby_max_m3f(b : B?) {
 [benchmark]
 def groupby_max_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_max_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_max_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_min.das
+++ b/benchmarks/sql/groupby_min.das
@@ -54,6 +54,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      MinPrice = _._1 |> select($(c : Car) => c.price) |> min()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          MinPrice = _._1 |> select($(c : Car) => c.price) |> min()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_min_m1(b : B?) {
     run_m1(b, 100000)
@@ -67,4 +111,14 @@ def groupby_min_m3f(b : B?) {
 [benchmark]
 def groupby_min_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_min_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_min_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_multi_reducer.das
+++ b/benchmarks/sql/groupby_multi_reducer.das
@@ -60,6 +60,52 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      N = _._1 |> length,
+                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
+                                      MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          N = _._1 |> length,
+                                          TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
+                                          MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_multi_reducer_m1(b : B?) {
     run_m1(b, 100000)
@@ -73,4 +119,14 @@ def groupby_multi_reducer_m3f(b : B?) {
 [benchmark]
 def groupby_multi_reducer_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_multi_reducer_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_multi_reducer_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_select_order.das
+++ b/benchmarks/sql/groupby_select_order.das
@@ -59,6 +59,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                          |> _order_by(_.Total)
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          Total = _._1 |> select($(c : Car) => c.price) |> sum()))
+                                ._order_by(_.Total)
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_select_order_m1(b : B?) {
     run_m1(b, 100000)
@@ -72,4 +116,14 @@ def groupby_select_order_m3f(b : B?) {
 [benchmark]
 def groupby_select_order_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_select_order_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_select_order_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_select_sum.das
+++ b/benchmarks/sql/groupby_select_sum.das
@@ -56,6 +56,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _select(_.price)
+                          |> _group_by(_ % 100)
+                          |> _select((K = _._0, S = _._1 |> sum()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._select(_.price)
+                                ._group_by(_ % 100)
+                                ._select((K = _._0, S = _._1 |> sum()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_select_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -69,4 +113,14 @@ def groupby_select_sum_m3f(b : B?) {
 [benchmark]
 def groupby_select_sum_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_select_sum_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_select_sum_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_sum.das
+++ b/benchmarks/sql/groupby_sum.das
@@ -54,6 +54,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -67,4 +111,14 @@ def groupby_sum_m3f(b : B?) {
 [benchmark]
 def groupby_sum_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_sum_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_sum_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_where_count.das
+++ b/benchmarks/sql/groupby_where_count.das
@@ -54,6 +54,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _where(_.price > 500)
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0, N = _._1 |> length))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._where(_.price > 500)
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0, N = _._1 |> length))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -67,4 +111,14 @@ def groupby_where_count_m3f(b : B?) {
 [benchmark]
 def groupby_where_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_where_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_where_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/groupby_where_sum.das
+++ b/benchmarks/sql/groupby_where_sum.das
@@ -57,6 +57,52 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                          |> _where(_.price > 500)
+                          |> _group_by(_.brand)
+                          |> _select((Brand = _._0,
+                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
+                          |> to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))
+                                ._where(_.price > 500)
+                                ._group_by(_.brand)
+                                ._select((Brand = _._0,
+                                          TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
+                                .to_array())
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def groupby_where_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -70,4 +116,14 @@ def groupby_where_sum_m3f(b : B?) {
 [benchmark]
 def groupby_where_sum_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def groupby_where_sum_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def groupby_where_sum_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/indexed_lookup.das
+++ b/benchmarks/sql/indexed_lookup.das
@@ -36,6 +36,42 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let key = n / 2
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}") {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.id == key) |> count()
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let key = n / 2
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}") {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.id == key).count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 // Decs eid lookup (O(1) hash): query(eid, $(...)) wraps for_eid_archetype, which
 // hashes the eid into entityLookup and dispatches the block once if the archetype
 // matches. The block-arg `car_id` is the request-shape witness AND a fixture-drift
@@ -70,4 +106,14 @@ def indexed_lookup_m3f(b : B?) {
 [benchmark]
 def indexed_lookup_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def indexed_lookup_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def indexed_lookup_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/join_count.das
+++ b/benchmarks/sql/join_count.das
@@ -58,6 +58,51 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
+// The mixed (iterator, array) _join resolves via the linq.das mixed overloads (#2931/#2932).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                                                                    $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                                                                    $(c : Car, d : Dealer) => (c.name, d.name))
+                                                                            |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                                                          $(c : Car, d : Dealer) => (c.name, d.name))
+                                                                 |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def join_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -71,4 +116,14 @@ def join_count_m3f(b : B?) {
 [benchmark]
 def join_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def join_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def join_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/join_groupby_count.das
+++ b/benchmarks/sql/join_groupby_count.das
@@ -70,6 +70,52 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                          $(c : Car, d : Dealer) => (Brand = c.brand, DealerId = d.id))
+                                 |> _group_by(_.Brand)
+                                 |> _select((Brand = _._0, N = _._1 |> count())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                          $(c : Car, d : Dealer) => (Brand = c.brand, DealerId = d.id))
+                                 |> _group_by(_.Brand)
+                                 |> _select((Brand = _._0, N = _._1 |> count())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def join_groupby_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -83,4 +129,14 @@ def join_groupby_count_m3f(b : B?) {
 [benchmark]
 def join_groupby_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def join_groupby_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def join_groupby_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/join_groupby_to_array.das
+++ b/benchmarks/sql/join_groupby_to_array.das
@@ -70,6 +70,54 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                          $(c : Car, _d : Dealer) => (Brand = c.brand, Price = c.price))
+                                 |> _group_by(_.Brand)
+                                 |> _select((Brand = _._0,
+                                             Total = _._1 |> select($(t : tuple<Brand : int; Price : int>) => t.Price) |> sum())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let groups <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                          $(c : Car, _d : Dealer) => (Brand = c.brand, Price = c.price))
+                                 |> _group_by(_.Brand)
+                                 |> _select((Brand = _._0,
+                                             Total = _._1 |> select($(t : tuple<Brand : int; Price : int>) => t.Price) |> sum())))
+            b |> accept(groups)
+            if (empty(groups)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def join_groupby_to_array_m1(b : B?) {
     run_m1(b, 100000)
@@ -83,4 +131,14 @@ def join_groupby_to_array_m3f(b : B?) {
 [benchmark]
 def join_groupby_to_array_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def join_groupby_to_array_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def join_groupby_to_array_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/join_select.das
+++ b/benchmarks/sql/join_select.das
@@ -59,6 +59,50 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                        $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                        $(c : Car, d : Dealer) => (CarName = c.name, DealerId = d.id))
+                               |> _select(_.CarName))
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                        $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                        $(c : Car, d : Dealer) => (CarName = c.name, DealerId = d.id))
+                               |> _select(_.CarName))
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def join_select_m1(b : B?) {
     run_m1(b, 100000)
@@ -72,4 +116,14 @@ def join_select_m3f(b : B?) {
 [benchmark]
 def join_select_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def join_select_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def join_select_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/join_where_count.das
+++ b/benchmarks/sql/join_where_count.das
@@ -36,7 +36,7 @@ def run_m3f(b : B?; n : int) {
         let c = _fold(cars |> _join(dealers,
                                     $(c : Car, d : Dealer) => c.dealer_id == d.id,
                                     $(c : Car, d : Dealer) => (CarPrice = c.price, DealerId = d.id))
-                           |> _where(_.CarPrice > THRESHOLD)
+                           |> _where(_.CarPrice > THRESHOLD)  // nolint:PERF013 macro-generated `+= 1`
                            |> count())
         b |> accept(c)
         if (c == 0) {
@@ -60,6 +60,52 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                    $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                    $(c : Car, d : Dealer) => (CarPrice = c.price, DealerId = d.id))
+                           |> _where(_.CarPrice > THRESHOLD)
+                           |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
+                                    $(c : Car, d : Dealer) => c.dealer_id == d.id,
+                                    $(c : Car, d : Dealer) => (CarPrice = c.price, DealerId = d.id))
+                           |> _where(_.CarPrice > THRESHOLD)
+                           |> count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def join_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -73,4 +119,14 @@ def join_where_count_m3f(b : B?) {
 [benchmark]
 def join_where_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def join_where_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def join_where_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/last_match.das
+++ b/benchmarks/sql/last_match.das
@@ -45,6 +45,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> last()
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).last())
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def last_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +92,14 @@ def last_match_m3f(b : B?) {
 [benchmark]
 def last_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def last_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def last_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -44,6 +44,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> long_count()
+            b |> accept(c)
+            if (c == 0l) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).long_count())
+            b |> accept(c)
+            if (c == 0l) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def long_count_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +91,14 @@ def long_count_aggregate_m3f(b : B?) {
 [benchmark]
 def long_count_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def long_count_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def long_count_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/max_aggregate.das
+++ b/benchmarks/sql/max_aggregate.das
@@ -41,6 +41,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let m = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> max()
+            b |> accept(m)
+            if (m == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let m = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price).max())
+            b |> accept(m)
+            if (m == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def max_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +88,14 @@ def max_aggregate_m3f(b : B?) {
 [benchmark]
 def max_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def max_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def max_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/min_aggregate.das
+++ b/benchmarks/sql/min_aggregate.das
@@ -41,6 +41,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let m = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> min()
+            b |> accept(m)
+            if (m > 999) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let m = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price).min())
+            b |> accept(m)
+            if (m > 999) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def min_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +88,14 @@ def min_aggregate_m3f(b : B?) {
 [benchmark]
 def min_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def min_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def min_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/order_distinct_take.das
+++ b/benchmarks/sql/order_distinct_take.das
@@ -75,6 +75,47 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline. The XML source carries whole Cars, so the brand stream is projected
+// out with a leading _select(_.brand) (the m3f/m4 lanes source a precomputed brand array). Un-fused.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _select(_.brand) |> _order_by(_) |> distinct() |> take(TAKE_N) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node, with the same _select(_.brand) projection prefix.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._select(_.brand)._order_by(_).distinct().take(TAKE_N).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def order_distinct_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -88,4 +129,14 @@ def order_distinct_take_m3f(b : B?) {
 [benchmark]
 def order_distinct_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def order_distinct_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def order_distinct_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/order_reverse_normalized.das
+++ b/benchmarks/sql/order_reverse_normalized.das
@@ -53,6 +53,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _order_by(_.price) |> reverse() |> take(TAKE_N) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._order_by(_.price).reverse().take(TAKE_N).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def order_reverse_normalized_m1(b : B?) {
     run_m1(b, 100000)
@@ -66,4 +106,14 @@ def order_reverse_normalized_m3f(b : B?) {
 [benchmark]
 def order_reverse_normalized_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def order_reverse_normalized_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def order_reverse_normalized_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/order_take_desc.das
+++ b/benchmarks/sql/order_take_desc.das
@@ -46,6 +46,42 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _order_by_descending(_.price) |> take(TAKE_N) |> to_array()
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._order_by_descending(_.price).take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def order_take_desc_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +95,14 @@ def order_take_desc_m3f(b : B?) {
 [benchmark]
 def order_take_desc_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def order_take_desc_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def order_take_desc_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,5 +1,7 @@
 # Benchmarks — SQL / Array / Decs / XML comparison
 
+Updated 2026-05-30 (branch `bbatkin/xml-bench-coverage`): **full XML coverage — both XML lanes (m5, m5f) now wired across every applicable family (67), up from 5.** Two changes: (1) **`m5` redefined** from the hand-written plain loop to the *un-fused tier-2 linq cascade* over the XML iterator — `unsafe(from_xml_node(root, type<Car>)) |> _where(…) |> … |> term()` — the same chain as m3f/m5f but without `_fold`, so **m5 vs m5f is now a clean fused-vs-not comparison on identical logic** (the prior hand-loop was an apples-to-oranges hand-optimal floor). The 5 pre-existing hand-loop m5 lanes were reworked to match. (2) **m5f added** to every family that had an array fold. The headline finding (see "Reading the XML lanes" below): the `XmlAdapter` **fuses the `loop_or_count` family** — where/select/aggregate/count/sum/min/max/average/first/element_at/any/all/contains/take/skip — where m5f runs **5–10× faster than m5** (e.g. INTERP `count_aggregate` 419 → **64**, `aggregate_match` 453 → **65**, `take_count_filtered` 395 → **1.3**), but it **does NOT fuse the cascade families** — group_by / distinct / order / sort / reverse / join — where **m5f ≈ m5** (e.g. `groupby_sum` 462.9 vs 465.1, `distinct_by_count` 393.4 vs 393.5, `sort_take` 1069 vs 1069, `join_count` 521 vs 484): the adapter falls back to full per-element materialization, so folding buys nothing. Those `m5f ≈ m5` cells are the map for the *next* arc (widening `XmlAdapter` to fuse the cascade families). **zip stays `—`** in both XML lanes — its source is a synthetic `make_ints(n)` int stream, not Car/XML, so an XML zip lane would be artificial (and `_fold` over `zip(xmlIter, each(arr))` hits the separate `plan_zip` iterator-preservation gap, a tracked follow-up). Earlier note:
+
 Updated 2026-05-29 (branch `bbatkin/sqlite-linq-computed-select-subqueries`): **two `_sql` surface gains + 5 m1 backfills.** (1) Computed-scalar `_select` — `_select(_.a + _.b) |> sum/min/max/average/count()` now lowers (pred_to_sql renders the arithmetic into the aggregate argument) instead of being rejected as "`_.Field` only". (2) take/skip BEFORE an aggregate — `_where(P) |> take(n) |> count()` / `_select(_.X) |> take(n) |> sum()` wrap the bounded rows into an inner subquery (`SELECT COUNT(*) FROM (SELECT * FROM t WHERE P LIMIT n)`) so the LIMIT applies pre-aggregate, instead of the no-op-LIMIT rejection. New `m1` lanes: `join_select` (into-projection), `take_where_count`, `take_count_filtered`, `take_sum_aggregate`, `zip_count_pred` (degenerate same-row interpretation). The zip dot-product **sum** lanes (`zip_dot_product`, `zip_dot_product_3arg`) stay `—`: `SUM(price*year)` overflows int32 at n=100k and needs an int64-typed computed projection (`int64(...)` in `_select` currently fails inference) — deferred to the computed-cast follow-up. SQL coverage 62 → 67 / 72. Earlier note:
 
 Updated 2026-05-29 (branch `bbatkin/linq-fold-xml-field-pruning`): **field-pruning landed (pass 2b)** — `XmlAdapter` now scans the chain body for the `Row` fields it actually reads and emits one `read_xml_field` per referenced field into scalar locals, dropping the per-element struct and every unread attribute read (notably the `string` clones). The four prunable XML families drop sharply and **JIT now beats SQLite**: `select_where_sum` m5f JIT 149.8 → **18.6** (m1 38.0), `aggregate_match` 153.9 → **21.6** (m1 35.0), `select_where_count` 152.1 → **27.5** (m1 33.2), `take_count_filtered` 3.1 → **0.4** — all alloc-free (the m5 baseline did 2.6M string clones over 100k rows; m5f does 0). `single_match` does **not** prune (`.single()` returns the whole matched row → whole-`it` escape → full `build_xml_row`), but its m5 baseline was **corrected this pass**: it previously did a find-first `break` (~`TARGET_ID` elements, yet still divided by n → a misleadingly tiny ns/op), and now scans-all with single() semantics like the fold lanes. So the fused m5f (146 JIT) correctly edges the generator m5 (152) instead of trailing a fake 0.1. Earlier note:
@@ -33,9 +35,14 @@ catalogued in `doc/source/reference/linq_fold_patterns.rst`.
 - **Array** — `_fold` over `each(arr)` chain, in-memory `array<Car>`.
 - **Decs** — `_fold` over `from_decs_template(type<DecsCar>)`,
   per-archetype walk.
-- **XML** — plain loop over `from_xml_node(root, type<Car>)`, rows
-  materialized from XML child-element attributes. **Un-fused** v1
-  baseline (no `_fold` for XML yet); only 5 files carry this lane.
+- **XML (m5)** — the **un-fused** chain over `from_xml_node(root, type<Car>)`:
+  the same linq pipeline as the array lane but without `_fold`
+  (`unsafe(from_xml_node(…)) |> _where(…) |> … |> term()`), so it runs the
+  tier-2 cascade — a full `Car` materialized per element (every attribute
+  read + string clones), intermediate arrays per stage. The reference the
+  fused lane is measured against.
+- **XML fold (m5f)** — `_fold` over the same `from_xml_node` source. The
+  `XmlAdapter` (`pugixml/linq_fold_xml`) fuses + field-prunes where it can.
 - **Decs vs Array** — ratio `decs_ns / array_ns`. Values below 1× mean
   decs wins; values above mean array wins.
 
@@ -43,163 +50,187 @@ Sub-nanosecond cells (`0.00`) reflect early-exit terminators that exit
 before the timer resolution can measure them — they should be read as
 "effectively free."
 
+### Reading the XML lanes (m5 vs m5f)
+
+m5 is the **un-fused** XML cascade; m5f is the **fused** `_fold`. The two run
+identical logic, so the delta is purely what the `XmlAdapter` fusion buys:
+
+- **m5f ≪ m5 → fusion works.** The adapter inlines the DOM walk and prunes the
+  materialization to the fields the chain reads. This covers the entire
+  `loop_or_count` family — `where` / `select` / `count` / `sum` / `min` / `max`
+  / `average` / `aggregate` / `first` / `last` / `single` / `element_at` / `any`
+  / `all` / `contains` / `take` / `skip` / `take_while` / `skip_while`. Typical
+  INTERP wins are 5–10× (e.g. `count_aggregate` 419 → 64, `aggregate_match`
+  453 → 65; early-exit cells like `take_count_filtered` collapse to ~1).
+- **m5f ≈ m5 → tier-2 fallback (no fusion).** The adapter has no specialized
+  arm for the chain, so `_fold` falls back to full per-element materialization —
+  identical work to the un-fused lane. This is every **cascade family**:
+  `group_by` (incl. `having` / multi-reducer), `distinct[_by]`, `order_by[_descending]`,
+  `sort`, `reverse`, and `join`. These rows are the **work-to-do map** for the
+  next arc (teaching `XmlAdapter` to fuse the cascade families); the number is
+  the honest un-fused cost, not an absent lane.
+
+(The absolute XML numbers stay far above the array/decs lanes either way — XML
+carries DOM-parse + per-element attribute reads + `string` clones the in-memory
+lanes never pay. The m5↔m5f delta, not the XML-vs-array gap, is the fusion signal.)
+
 
 <!-- BENCH:TABLES BEGIN -->
-*Generated 2026-05-29 by `benchmarks/sql/_update_results.das` — ns/op; `—` = absent lane; Decs vs Array = m4/m3f. Edit the prose around the markers, not the tables.*
+*Generated 2026-05-30 by `benchmarks/sql/_update_results.das` — ns/op; `—` = absent lane; Decs vs Array = m4/m3f. Edit the prose around the markers, not the tables.*
 
 ## INTERP
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML (m5) | XML fold (m5f) | Decs vs Array |
 |---|---:|---:|---:|---:|---:|---:|
-| `aggregate_match` | 34.9 | 5.9 | 5.9 | 364.4 | 60.9 | 1.00× |
-| `all_match` | 29.2 | 3.6 | 3.5 | — | — | 0.97× |
-| `any_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `average_aggregate` | 30.3 | 6.1 | 8.8 | — | — | 1.43× |
-| `bare_order_where` | 274.9 | 123.8 | 123.5 | — | — | 1.00× |
-| `chained_select_collapse` | — | 17.9 | 17.6 | — | — | 0.98× |
-| `chained_where` | 36.9 | 7.1 | 7.1 | — | — | 1.00× |
-| `contains_match` | 0.0 | 2.2 | 1.3 | — | — | 0.61× |
-| `count_aggregate` | 29.6 | 4.1 | 4.1 | — | — | 0.99× |
-| `decs_count_bare_pred` | — | — | 4.2 | — | — | — |
-| `distinct_by_count` | 41.1 | 15.9 | 15.8 | — | — | 1.00× |
-| `distinct_by_order_take` | 239.6 | 21.8 | 23.4 | — | — | 1.07× |
-| `distinct_by_order_to_array` | 239.9 | 22.1 | 23.8 | — | — | 1.07× |
-| `distinct_count` | 41.6 | 16.0 | 15.9 | — | — | 0.99× |
-| `distinct_count_pred` | 253.6 | 15.6 | 16.0 | — | — | 1.02× |
-| `distinct_take` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `element_at_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `first_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `first_or_default_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `groupby_average` | 171.7 | 31.5 | 30.5 | — | — | 0.97× |
-| `groupby_count` | 142.7 | 19.4 | 20.4 | — | — | 1.05× |
-| `groupby_first` | 252.4 | 18.5 | 19.2 | — | — | 1.04× |
-| `groupby_having_count` | 142.5 | 19.2 | 20.1 | — | — | 1.04× |
-| `groupby_having_hidden_sum` | 175.9 | 23.9 | 24.5 | — | — | 1.02× |
-| `groupby_having_post_where` | 171.4 | 18.6 | 18.9 | — | — | 1.02× |
-| `groupby_max` | 174.3 | 25.1 | 26.1 | — | — | 1.04× |
-| `groupby_min` | 174.5 | 25.1 | 25.5 | — | — | 1.01× |
-| `groupby_multi_reducer` | 190.3 | 32.2 | 32.5 | — | — | 1.01× |
-| `groupby_select_order` | 178.7 | 18.7 | 18.8 | — | — | 1.01× |
-| `groupby_select_sum` | 201.3 | 36.6 | 36.0 | — | — | 0.98× |
-| `groupby_sum` | 172.8 | 18.7 | 18.8 | — | — | 1.00× |
-| `groupby_where_count` | 76.5 | 14.6 | 15.0 | — | — | 1.03× |
-| `groupby_where_sum` | 87.5 | 14.2 | 14.6 | — | — | 1.03× |
-| `indexed_lookup` | 1444.3 | 203977.9 | 479.1 | — | — | 0.00× |
-| `join_count` | 38.6 | 51.2 | 65.0 | — | — | 1.27× |
-| `join_groupby_count` | 158.2 | 79.9 | 90.3 | — | — | 1.13× |
-| `join_groupby_to_array` | 191.0 | 79.3 | 90.8 | — | — | 1.15× |
-| `join_select` | 148.7 | 72.5 | 85.8 | — | — | 1.18× |
-| `join_where_count` | 39.6 | 63.6 | 75.0 | — | — | 1.18× |
-| `last_match` | 0.0 | 5.8 | 14.1 | — | — | 2.41× |
-| `long_count_aggregate` | 30.0 | 4.1 | 4.1 | — | — | 0.99× |
-| `max_aggregate` | 31.0 | 5.9 | 7.5 | — | — | 1.27× |
-| `min_aggregate` | 31.6 | 6.1 | 6.9 | — | — | 1.13× |
-| `order_distinct_take` | 139.5 | 16.0 | 93.5 | — | — | 5.83× |
-| `order_reverse_normalized` | 38.5 | 16.2 | 20.0 | — | — | 1.24× |
-| `order_take_desc` | 38.7 | 16.1 | 20.1 | — | — | 1.25× |
-| `reverse_distinct_by` | 295.9 | 22.4 | — | — | — | — |
-| `reverse_take` | 0.1 | 0.0 | 9.2 | — | — | — |
-| `reverse_take_select` | 0.0 | 0.0 | 9.2 | — | — | — |
-| `select_count` | 0.1 | 0.0 | 2.2 | — | — | — |
-| `select_where` | 193.7 | 11.2 | 19.9 | — | — | 1.77× |
-| `select_where_count` | 33.1 | 5.2 | 7.4 | 380.8 | 65.5 | 1.44× |
-| `select_where_order_take` | 36.9 | 12.2 | 14.9 | — | — | 1.22× |
-| `select_where_sum` | 37.6 | 7.4 | 7.5 | 373.9 | 71.3 | 1.01× |
-| `single_match` | 0.0 | 3.0 | 5.5 | 358.4 | 327.3 | 1.84× |
-| `skip_take` | 0.5 | 0.1 | 0.2 | — | — | 1.44× |
-| `skip_while_match` | 3.5 | 5.2 | 5.3 | — | — | 1.01× |
-| `sort_first` | 38.4 | 11.1 | 13.3 | — | — | 1.21× |
-| `sort_take` | 38.8 | 16.5 | 23.1 | — | — | 1.40× |
-| `sort_take_select` | 38.9 | 16.1 | 20.1 | — | — | 1.24× |
-| `sum_aggregate` | 30.4 | 2.2 | 2.1 | — | — | 0.98× |
-| `sum_where` | 33.0 | 4.3 | 4.3 | — | — | 1.01× |
-| `take_count` | 3.8 | 0.2 | 0.4 | — | — | 1.91× |
-| `take_count_filtered` | 1.1 | 0.2 | 0.2 | 7.4 | 1.3 | 1.01× |
-| `take_sum_aggregate` | 0.8 | 0.1 | 0.1 | — | — | 1.02× |
-| `take_where_count` | 0.9 | 0.1 | 0.1 | — | — | 1.01× |
-| `take_while_match` | 7.8 | 2.5 | 2.5 | — | — | 0.99× |
-| `to_array_filter` | 70.6 | 11.7 | 11.8 | — | — | 1.01× |
-| `zip_count_pred` | 39.3 | 17.5 | — | — | — | — |
-| `zip_dot_product` | — | 13.8 | 10.9 | — | — | 0.79× |
-| `zip_dot_product_3arg` | — | 14.4 | — | — | — | — |
+| `aggregate_match` | 35.3 | 6.0 | 5.8 | 453.4 | 65.0 | 0.98× |
+| `all_match` | 28.2 | 3.5 | 3.5 | 379.6 | 56.0 | 1.00× |
+| `any_match` | 0.0 | 0.0 | 0.0 | 0.1 | 0.0 | — |
+| `average_aggregate` | 30.7 | 5.9 | 8.8 | 430.0 | 59.8 | 1.49× |
+| `bare_order_where` | 280.9 | 119.6 | 128.5 | 774.4 | 713.1 | 1.07× |
+| `chained_select_collapse` | — | 17.9 | 17.8 | 539.6 | 407.7 | 0.99× |
+| `chained_where` | 36.8 | 6.6 | 7.2 | 451.7 | 106.1 | 1.08× |
+| `contains_match` | 0.0 | 2.3 | 1.4 | 415.5 | 29.0 | 0.61× |
+| `count_aggregate` | 29.9 | 4.1 | 4.1 | 419.5 | 64.5 | 0.99× |
+| `decs_count_bare_pred` | — | — | 4.1 | — | — | — |
+| `distinct_by_count` | 47.6 | 16.0 | 15.9 | 393.4 | 393.5 | 0.99× |
+| `distinct_by_order_take` | 262.2 | 21.9 | 23.3 | 401.1 | 402.5 | 1.06× |
+| `distinct_by_order_to_array` | 241.1 | 22.1 | 23.5 | 402.1 | 401.1 | 1.06× |
+| `distinct_count` | 42.2 | 16.0 | 16.0 | 475.4 | 406.5 | 1.00× |
+| `distinct_count_pred` | 252.9 | 15.9 | 16.0 | 397.2 | 399.0 | 1.01× |
+| `distinct_take` | 0.0 | 0.0 | 0.0 | 391.4 | 408.1 | — |
+| `element_at_match` | 0.0 | 0.0 | 0.0 | 395.3 | 0.7 | — |
+| `first_match` | 0.0 | 0.0 | 0.0 | 392.2 | 0.1 | — |
+| `first_or_default_match` | 0.0 | 0.0 | 0.0 | 393.8 | 0.1 | — |
+| `groupby_average` | 171.5 | 30.5 | 30.1 | 464.8 | 469.3 | 0.99× |
+| `groupby_count` | 143.0 | 19.2 | 19.3 | 431.5 | 437.7 | 1.00× |
+| `groupby_first` | 255.2 | 18.5 | 19.2 | 429.7 | 435.4 | 1.04× |
+| `groupby_having_count` | 141.8 | 19.3 | 19.2 | 437.0 | 446.5 | 1.00× |
+| `groupby_having_hidden_sum` | 175.6 | 24.3 | 24.2 | 470.0 | 480.6 | 0.99× |
+| `groupby_having_post_where` | 175.3 | 18.7 | 18.7 | 459.1 | 464.2 | 1.00× |
+| `groupby_max` | 174.1 | 24.9 | 25.1 | 468.0 | 473.4 | 1.01× |
+| `groupby_min` | 174.1 | 25.2 | 25.1 | 469.0 | 475.6 | 1.00× |
+| `groupby_multi_reducer` | 190.3 | 32.7 | 32.4 | 499.8 | 505.4 | 0.99× |
+| `groupby_select_order` | 171.3 | 18.6 | 18.7 | 458.8 | 462.4 | 1.00× |
+| `groupby_select_sum` | 199.7 | 36.4 | 36.4 | 512.2 | 474.6 | 1.00× |
+| `groupby_sum` | 171.6 | 18.6 | 18.8 | 462.9 | 465.1 | 1.01× |
+| `groupby_where_count` | 75.5 | 14.4 | 15.1 | 458.5 | 437.2 | 1.05× |
+| `groupby_where_sum` | 87.5 | 14.4 | 14.8 | 470.4 | 451.5 | 1.03× |
+| `indexed_lookup` | 1444.1 | 198093.3 | 493.7 | 38299637.9 | 5768781.3 | 0.00× |
+| `join_count` | 38.0 | 51.5 | 64.3 | 521.1 | 483.9 | 1.25× |
+| `join_groupby_count` | 157.8 | 78.7 | 91.1 | 581.6 | 546.4 | 1.16× |
+| `join_groupby_to_array` | 191.5 | 78.5 | 90.0 | 614.1 | 581.5 | 1.15× |
+| `join_select` | 150.2 | 72.2 | 86.3 | 552.7 | 510.6 | 1.19× |
+| `join_where_count` | 39.8 | 61.1 | 75.8 | 569.7 | 511.5 | 1.24× |
+| `last_match` | 0.0 | 5.9 | 14.0 | 422.5 | 337.8 | 2.37× |
+| `long_count_aggregate` | 29.7 | 4.1 | 4.1 | 421.1 | 63.9 | 1.00× |
+| `max_aggregate` | 31.3 | 6.0 | 6.8 | 447.1 | 62.9 | 1.14× |
+| `min_aggregate` | 31.4 | 6.0 | 6.8 | 445.1 | 58.3 | 1.15× |
+| `order_distinct_take` | 138.5 | 15.8 | 93.9 | 2199.0 | 2089.0 | 5.94× |
+| `order_reverse_normalized` | 38.6 | 16.7 | 20.2 | 1139.0 | 1084.3 | 1.21× |
+| `order_take_desc` | 38.6 | 16.2 | 19.9 | 1065.9 | 1065.4 | 1.23× |
+| `reverse_distinct_by` | 297.4 | 21.3 | — | 453.7 | 427.4 | — |
+| `reverse_take` | 0.1 | 0.0 | 9.2 | 378.3 | 393.4 | — |
+| `reverse_take_select` | 0.0 | 0.0 | 9.2 | 384.2 | 395.9 | — |
+| `select_count` | 0.1 | 0.0 | 2.2 | 440.6 | 68.4 | — |
+| `select_where` | 194.0 | 11.0 | 19.4 | 426.1 | 340.0 | 1.76× |
+| `select_where_count` | 32.9 | 5.1 | 7.4 | 481.7 | 65.4 | 1.45× |
+| `select_where_order_take` | 36.8 | 12.3 | 14.9 | 743.2 | 710.4 | 1.21× |
+| `select_where_sum` | 37.4 | 7.4 | 7.5 | 480.7 | 67.3 | 1.01× |
+| `single_match` | 0.0 | 2.8 | 5.5 | 384.1 | 330.2 | 1.97× |
+| `skip_take` | 0.5 | 0.1 | 0.2 | 4.4 | 3.7 | 1.47× |
+| `skip_while_match` | 3.5 | 5.3 | 5.3 | 408.5 | 59.0 | 1.00× |
+| `sort_first` | 38.2 | 11.0 | 13.2 | 1065.0 | 1073.9 | 1.20× |
+| `sort_take` | 38.7 | 16.3 | 20.6 | 1069.1 | 1069.0 | 1.27× |
+| `sort_take_select` | 38.4 | 16.2 | 20.1 | 1076.7 | 1083.9 | 1.24× |
+| `sum_aggregate` | 30.4 | 2.1 | 2.1 | 432.5 | 54.2 | 0.99× |
+| `sum_where` | 33.3 | 4.3 | 4.3 | 450.8 | 64.4 | 0.99× |
+| `take_count` | 3.6 | 0.2 | 0.4 | 4.3 | 3.6 | 1.82× |
+| `take_count_filtered` | 1.1 | 0.2 | 0.2 | 394.7 | 1.3 | 1.14× |
+| `take_sum_aggregate` | 0.8 | 0.1 | 0.1 | 391.7 | 0.6 | 1.05× |
+| `take_where_count` | 0.9 | 0.1 | 0.1 | 4.8 | 0.7 | 1.01× |
+| `take_while_match` | 7.9 | 2.4 | 2.4 | 226.8 | 32.3 | 0.98× |
+| `to_array_filter` | 72.8 | 14.9 | 15.0 | 465.8 | 74.9 | 1.00× |
+| `zip_count_pred` | 39.4 | 17.2 | — | — | — | — |
+| `zip_dot_product` | — | 13.5 | 10.7 | — | — | 0.79× |
+| `zip_dot_product_3arg` | — | 13.5 | — | — | — | — |
 | `zip_reverse_to_array` | — | 31.1 | — | — | — | — |
 
 ## JIT
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML (m5) | XML fold (m5f) | Decs vs Array |
 |---|---:|---:|---:|---:|---:|---:|
-| `aggregate_match` | 35.4 | 0.3 | 0.6 | 153.7 | 18.7 | 1.91× |
-| `all_match` | 27.6 | 0.3 | 0.2 | — | — | 0.61× |
-| `any_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `average_aggregate` | 30.5 | 1.0 | 3.5 | — | — | 3.67× |
-| `bare_order_where` | 187.1 | 33.7 | 34.2 | — | — | 1.02× |
-| `chained_select_collapse` | — | 2.1 | 2.1 | — | — | 1.00× |
-| `chained_where` | 49.8 | 0.6 | 0.9 | — | — | 1.44× |
-| `contains_match` | 0.0 | 0.2 | 0.1 | — | — | 0.63× |
-| `count_aggregate` | 29.6 | 0.3 | 0.6 | — | — | 1.89× |
+| `aggregate_match` | 35.0 | 0.3 | 0.6 | 175.3 | 16.7 | 1.84× |
+| `all_match` | 28.0 | 0.3 | 0.2 | 160.0 | 19.5 | 0.63× |
+| `any_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | — |
+| `average_aggregate` | 30.0 | 1.0 | 3.6 | 168.7 | 18.2 | 3.76× |
+| `bare_order_where` | 186.7 | 34.5 | 35.0 | 282.7 | 268.9 | 1.01× |
+| `chained_select_collapse` | — | 2.1 | 2.1 | 183.8 | 162.7 | 0.99× |
+| `chained_where` | 36.6 | 0.6 | 0.8 | 178.2 | 33.8 | 1.33× |
+| `contains_match` | 0.0 | 0.2 | 0.1 | 163.5 | 17.4 | 0.64× |
+| `count_aggregate` | 29.8 | 0.3 | 0.6 | 169.8 | 16.7 | 1.90× |
 | `decs_count_bare_pred` | — | — | 0.6 | — | — | — |
-| `distinct_by_count` | 41.7 | 2.1 | 2.1 | — | — | 1.00× |
-| `distinct_by_order_take` | 248.7 | 2.6 | 3.2 | — | — | 1.23× |
-| `distinct_by_order_to_array` | 239.4 | 2.7 | 3.3 | — | — | 1.25× |
-| `distinct_count` | 42.3 | 2.7 | 2.2 | — | — | 0.81× |
-| `distinct_count_pred` | 257.7 | 2.1 | 2.4 | — | — | 1.14× |
-| `distinct_take` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `element_at_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `first_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `first_or_default_match` | 0.0 | 0.0 | 0.0 | — | — | — |
-| `groupby_average` | 171.7 | 2.6 | 3.2 | — | — | 1.24× |
-| `groupby_count` | 141.0 | 2.3 | 2.5 | — | — | 1.06× |
-| `groupby_first` | 251.7 | 2.2 | 3.1 | — | — | 1.40× |
-| `groupby_having_count` | 138.0 | 2.4 | 2.4 | — | — | 1.02× |
-| `groupby_having_hidden_sum` | 176.6 | 2.5 | 2.8 | — | — | 1.13× |
-| `groupby_having_post_where` | 170.0 | 2.4 | 2.7 | — | — | 1.12× |
-| `groupby_max` | 173.8 | 2.4 | 2.7 | — | — | 1.11× |
-| `groupby_min` | 173.5 | 2.4 | 2.7 | — | — | 1.11× |
-| `groupby_multi_reducer` | 190.3 | 2.7 | 3.0 | — | — | 1.10× |
-| `groupby_select_order` | 171.2 | 2.4 | 2.7 | — | — | 1.11× |
-| `groupby_select_sum` | 201.2 | 3.2 | 3.7 | — | — | 1.16× |
-| `groupby_sum` | 170.4 | 2.4 | 2.7 | — | — | 1.11× |
-| `groupby_where_count` | 76.1 | 1.5 | 1.8 | — | — | 1.18× |
-| `groupby_where_sum` | 91.0 | 1.5 | 1.8 | — | — | 1.20× |
-| `indexed_lookup` | 1254.6 | 33197.3 | 105.8 | — | — | 0.00× |
-| `join_count` | 38.7 | 11.9 | 12.9 | — | — | 1.08× |
-| `join_groupby_count` | 157.0 | 20.6 | 22.0 | — | — | 1.07× |
-| `join_groupby_to_array` | 191.1 | 19.6 | 21.8 | — | — | 1.11× |
-| `join_select` | 92.6 | 20.3 | 22.6 | — | — | 1.11× |
-| `join_where_count` | 39.6 | 20.1 | 22.0 | — | — | 1.09× |
-| `last_match` | 0.0 | 0.5 | 1.4 | — | — | 2.63× |
-| `long_count_aggregate` | 29.9 | 0.3 | 0.6 | — | — | 1.91× |
-| `max_aggregate` | 31.3 | 0.3 | 0.5 | — | — | 1.50× |
-| `min_aggregate` | 31.1 | 0.3 | 0.5 | — | — | 1.51× |
-| `order_distinct_take` | 138.1 | 2.1 | 75.7 | — | — | 36.12× |
-| `order_reverse_normalized` | 38.6 | 0.7 | 1.4 | — | — | 2.04× |
-| `order_take_desc` | 38.4 | 0.7 | 1.3 | — | — | 1.94× |
-| `reverse_distinct_by` | 296.6 | 2.6 | — | — | — | — |
-| `reverse_take` | 0.0 | 0.0 | 1.1 | — | — | — |
-| `reverse_take_select` | 0.0 | 0.0 | 1.1 | — | — | — |
-| `select_count` | 0.1 | 0.0 | 0.0 | — | — | — |
-| `select_where` | 107.0 | 4.1 | 5.7 | — | — | 1.37× |
-| `select_where_count` | 33.4 | 0.3 | 0.6 | 150.5 | 16.6 | 1.88× |
-| `select_where_order_take` | 36.6 | 0.7 | 1.3 | — | — | 1.86× |
-| `select_where_sum` | 37.5 | 0.4 | 0.6 | 149.3 | 18.7 | 1.58× |
-| `single_match` | 0.0 | 0.4 | 1.1 | 152.5 | 146.8 | 3.21× |
-| `skip_take` | 0.3 | 0.0 | 0.0 | — | — | — |
-| `skip_while_match` | 3.4 | 0.4 | 0.4 | — | — | 1.01× |
-| `sort_first` | 38.4 | 0.4 | 1.3 | — | — | 3.35× |
-| `sort_take` | 38.5 | 0.7 | 1.3 | — | — | 1.92× |
-| `sort_take_select` | 38.8 | 0.8 | 1.4 | — | — | 1.61× |
-| `sum_aggregate` | 30.2 | 0.3 | 0.1 | — | — | 0.15× |
-| `sum_where` | 34.4 | 0.3 | 0.6 | — | — | 1.83× |
-| `take_count` | 1.8 | 0.1 | 0.1 | — | — | 1.75× |
-| `take_count_filtered` | 1.1 | 0.0 | 0.0 | 3.1 | 0.5 | — |
-| `take_sum_aggregate` | 0.8 | 0.0 | 0.0 | — | — | — |
-| `take_where_count` | 0.9 | 0.0 | 0.0 | — | — | — |
-| `take_while_match` | 7.9 | 0.2 | 0.3 | — | — | 1.52× |
-| `to_array_filter` | 48.9 | 3.3 | 3.4 | — | — | 1.04× |
+| `distinct_by_count` | 41.8 | 2.1 | 2.1 | 158.4 | 158.7 | 1.00× |
+| `distinct_by_order_take` | 240.3 | 2.7 | 3.2 | 170.0 | 169.8 | 1.22× |
+| `distinct_by_order_to_array` | 240.3 | 2.7 | 3.3 | 174.4 | 170.5 | 1.21× |
+| `distinct_count` | 41.9 | 2.1 | 2.1 | 168.5 | 161.2 | 1.00× |
+| `distinct_count_pred` | 253.5 | 2.1 | 2.3 | 161.5 | 161.0 | 1.08× |
+| `distinct_take` | 0.0 | 0.0 | 0.0 | 160.0 | 163.4 | — |
+| `element_at_match` | 0.0 | 0.0 | 0.0 | 165.6 | 0.3 | — |
+| `first_match` | 0.0 | 0.0 | 0.0 | 169.9 | 0.0 | — |
+| `first_or_default_match` | 0.0 | 0.0 | 0.0 | 168.6 | 0.0 | — |
+| `groupby_average` | 171.7 | 2.6 | 2.9 | 186.7 | 184.8 | 1.12× |
+| `groupby_count` | 142.7 | 2.4 | 2.5 | 174.9 | 173.2 | 1.06× |
+| `groupby_first` | 252.1 | 2.2 | 3.1 | 175.0 | 173.4 | 1.41× |
+| `groupby_having_count` | 142.9 | 2.4 | 2.5 | 178.7 | 175.6 | 1.06× |
+| `groupby_having_hidden_sum` | 175.6 | 2.5 | 2.8 | 187.7 | 184.7 | 1.13× |
+| `groupby_having_post_where` | 171.8 | 2.4 | 2.7 | 183.6 | 181.9 | 1.12× |
+| `groupby_max` | 173.3 | 2.4 | 2.7 | 183.2 | 181.2 | 1.11× |
+| `groupby_min` | 173.1 | 2.4 | 2.7 | 186.0 | 184.3 | 1.12× |
+| `groupby_multi_reducer` | 190.2 | 2.7 | 3.0 | 191.5 | 190.7 | 1.11× |
+| `groupby_select_order` | 175.4 | 2.4 | 2.7 | 181.6 | 180.2 | 1.11× |
+| `groupby_select_sum` | 199.5 | 3.2 | 3.7 | 203.0 | 191.9 | 1.16× |
+| `groupby_sum` | 171.9 | 2.4 | 2.7 | 184.7 | 183.8 | 1.11× |
+| `groupby_where_count` | 76.3 | 1.5 | 1.8 | 180.9 | 175.6 | 1.21× |
+| `groupby_where_sum` | 87.4 | 1.5 | 1.8 | 187.5 | 182.3 | 1.20× |
+| `indexed_lookup` | 1262.0 | 32575.9 | 107.2 | 15863960.9 | 4704659.3 | 0.00× |
+| `join_count` | 38.5 | 12.3 | 13.0 | 193.5 | 185.9 | 1.05× |
+| `join_groupby_count` | 157.2 | 19.8 | 22.3 | 208.4 | 199.3 | 1.13× |
+| `join_groupby_to_array` | 189.1 | 20.3 | 22.5 | 217.8 | 208.5 | 1.11× |
+| `join_select` | 93.5 | 20.5 | 23.1 | 203.2 | 196.1 | 1.13× |
+| `join_where_count` | 39.5 | 20.0 | 22.4 | 207.3 | 196.3 | 1.12× |
+| `last_match` | 0.0 | 0.5 | 1.4 | 171.3 | 148.6 | 2.59× |
+| `long_count_aggregate` | 29.9 | 0.3 | 0.6 | 168.6 | 26.7 | 1.84× |
+| `max_aggregate` | 31.1 | 0.3 | 0.5 | 167.9 | 16.8 | 1.49× |
+| `min_aggregate` | 30.9 | 0.3 | 0.5 | 167.6 | 17.0 | 1.50× |
+| `order_distinct_take` | 138.7 | 2.2 | 75.4 | 648.4 | 622.4 | 34.84× |
+| `order_reverse_normalized` | 38.6 | 0.7 | 1.4 | 394.0 | 384.7 | 1.95× |
+| `order_take_desc` | 38.6 | 0.7 | 1.4 | 375.5 | 376.9 | 1.94× |
+| `reverse_distinct_by` | 296.7 | 2.6 | — | 170.8 | 166.1 | — |
+| `reverse_take` | 0.0 | 0.0 | 1.1 | 158.1 | 161.3 | — |
+| `reverse_take_select` | 0.0 | 0.0 | 1.1 | 156.2 | 156.8 | — |
+| `select_count` | 0.1 | 0.0 | 0.0 | 167.6 | 66.3 | — |
+| `select_where` | 108.1 | 4.1 | 5.5 | 176.6 | 154.4 | 1.33× |
+| `select_where_count` | 33.1 | 0.3 | 0.6 | 179.0 | 28.1 | 1.87× |
+| `select_where_order_take` | 36.9 | 0.7 | 1.4 | 274.6 | 268.1 | 1.86× |
+| `select_where_sum` | 37.3 | 0.4 | 0.6 | 178.1 | 19.2 | 1.57× |
+| `single_match` | 0.0 | 0.4 | 1.1 | 161.2 | 147.8 | 3.23× |
+| `skip_take` | 0.3 | 0.0 | 0.0 | 1.7 | 1.6 | — |
+| `skip_while_match` | 3.4 | 0.4 | 0.4 | 161.6 | 46.7 | 1.01× |
+| `sort_first` | 38.1 | 0.4 | 1.3 | 378.0 | 374.4 | 3.35× |
+| `sort_take` | 38.6 | 0.7 | 1.4 | 382.3 | 381.2 | 1.93× |
+| `sort_take_select` | 38.5 | 0.7 | 1.4 | 379.0 | 374.5 | 1.94× |
+| `sum_aggregate` | 30.4 | 0.3 | 0.1 | 168.3 | 16.7 | 0.15× |
+| `sum_where` | 33.0 | 0.3 | 0.6 | 177.9 | 16.6 | 1.97× |
+| `take_count` | 1.8 | 0.1 | 0.1 | 1.7 | 1.6 | 1.56× |
+| `take_count_filtered` | 1.1 | 0.0 | 0.0 | 167.0 | 0.4 | — |
+| `take_sum_aggregate` | 0.8 | 0.0 | 0.0 | 162.9 | 0.2 | — |
+| `take_where_count` | 0.9 | 0.0 | 0.0 | 1.8 | 0.2 | — |
+| `take_while_match` | 7.8 | 0.2 | 0.3 | 85.6 | 17.6 | 1.52× |
+| `to_array_filter` | 48.7 | 3.3 | 3.4 | 178.9 | 20.2 | 1.04× |
 | `zip_count_pred` | 39.4 | 0.1 | — | — | — | — |
-| `zip_dot_product` | — | 0.1 | 0.1 | — | — | 0.82× |
+| `zip_dot_product` | — | 0.1 | 0.1 | — | — | 0.77× |
 | `zip_dot_product_3arg` | — | 0.1 | — | — | — | — |
-| `zip_reverse_to_array` | — | 4.5 | — | — | — | — |
+| `zip_reverse_to_array` | — | 4.6 | — | — | — | — |
 <!-- BENCH:TABLES END -->
 
 ## Notes on missing lanes (the `—` cells)
@@ -214,12 +245,14 @@ and which gaps could land in a single PR — see
 - **`chained_select_collapse` SQL** — `_sql` rejects `distinct() |> count()`
   as non-translatable. The equivalent SQL `COUNT(DISTINCT computed-expr)`
   isn't currently emitted by sqlite_linq's surface. By design — no follow-up.
-- **`decs_count_bare_pred` SQL / Array** — covers a Theme 4 root-cause
-  fix specific to the decs lane (bare `from_decs_template(...).count(P)`
+- **`decs_count_bare_pred` SQL / Array / XML (m5, m5f)** — covers a Theme 4
+  root-cause fix specific to the decs lane (bare `from_decs_template(...).count(P)`
   with no upstream where/select previously bailed because
   `forExpr.iteratorVariables` was unpopulated). Array-side bare `count(P)`
   was always reachable; SQL `count(P)` is covered by `count_aggregate.das`
-  with a where shape. By design.
+  with a where shape. Both XML lanes are absent because the family is
+  decs-only (it exists to exercise a decs-walk root cause — no array/XML/SQL
+  analog is meaningful). By design.
 - **`indexed_lookup` Decs vs Array ratio** — the ratio is reported as
   `0.00×` because array's lane measures the unspliced linear scan
   (~204k ns/op), while decs uses `query(eid)` for O(1) lookup. The
@@ -251,6 +284,15 @@ and which gaps could land in a single PR — see
 - **`zip_reverse_to_array` SQL / Decs** — `reverse()` has no SQL order key
   (relational rows are unordered without an `ORDER BY`), and zip is not
   naturally expressible over a single archetype walk. By design, no follow-up.
+- **all four `zip_*` XML lanes (m5, m5f)** — the zip benchmarks source a
+  synthetic `make_ints(n)` int stream (`[0, 1, 2, …]`), not Car/XML data, so
+  an XML zip lane would be artificial — there is no real Car/XML zip workload
+  to measure. Separately, `_fold` over `zip(xmlIter, each(arr))` hits the
+  `plan_zip` iterator-preservation gap (the array-rewrite downgrades the
+  iterator operand to a mixed `zip(array, iterator)` with no overload), a
+  **tracked follow-up** distinct from this arc. An m5-only lane zipping an
+  artificial XML price-stream against a synthetic array was considered and
+  declined (contrived; doesn't mirror the m3f). Both cells stay `—`.
 
 ## Accepted architectural floors (m4 vs m3f)
 

--- a/benchmarks/sql/reverse_distinct_by.das
+++ b/benchmarks/sql/reverse_distinct_by.das
@@ -46,6 +46,46 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> reverse() |> _distinct_by(_.brand) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>).reverse()._distinct_by(_.brand).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def reverse_distinct_by_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +94,14 @@ def reverse_distinct_by_m1(b : B?) {
 [benchmark]
 def reverse_distinct_by_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def reverse_distinct_by_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def reverse_distinct_by_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/reverse_take.das
+++ b/benchmarks/sql/reverse_take.das
@@ -51,6 +51,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> reverse() |> take(TAKE_N) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>).reverse().take(TAKE_N).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def reverse_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -64,4 +104,14 @@ def reverse_take_m3f(b : B?) {
 [benchmark]
 def reverse_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def reverse_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def reverse_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/reverse_take_select.das
+++ b/benchmarks/sql/reverse_take_select.das
@@ -51,6 +51,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> reverse() |> take(TAKE_N) |> _select(_.name) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>).reverse().take(TAKE_N)._select(_.name).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def reverse_take_select_m1(b : B?) {
     run_m1(b, 100000)
@@ -64,4 +104,14 @@ def reverse_take_select_m3f(b : B?) {
 [benchmark]
 def reverse_take_select_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def reverse_take_select_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def reverse_take_select_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -45,6 +45,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price * 2) |> count()
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price * 2).count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def select_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +92,14 @@ def select_count_m3f(b : B?) {
 [benchmark]
 def select_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def select_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def select_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/select_where.das
+++ b/benchmarks/sql/select_where.das
@@ -40,6 +40,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> to_array()
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def select_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -53,4 +87,14 @@ def select_where_m3f(b : B?) {
 [benchmark]
 def select_where_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def select_where_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def select_where_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -48,9 +48,10 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — plain iteration over from_xml_node (which
-// materializes a full Car per child element). v1 has no _fold for XML, so this
-// is the reference the fused XML lane (m5f, pass 2) will be measured against.
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
 def run_m5(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -58,14 +59,8 @@ def run_m5(b : B?; n : int) {
             b->failNow()
             return
         }
-        let root = doc.document_element
         b |> run("m5_xml/{n}", n) {
-            var c = 0
-            for (car in from_xml_node(root, type<Car>)) {
-                if (car.price * 2 > THRESHOLD) {
-                    c++
-                }
-            }
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> count()
             b |> accept(c)
             if (c == 0) {
                 b->failNow()
@@ -103,9 +98,8 @@ def run_m5f(b : B?; n : int) {
             b->failNow()
             return
         }
-        var root = doc.document_element
         b |> run("m5f_xml_fold/{n}", n) {
-            let c = _fold(unsafe(from_xml_node(root, type<Car>))._select(_.price * 2)._where(_ > THRESHOLD).count())
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price * 2)._where(_ > THRESHOLD).count())
             b |> accept(c)
             if (c == 0) {
                 b->failNow()

--- a/benchmarks/sql/select_where_order_take.das
+++ b/benchmarks/sql/select_where_order_take.das
@@ -50,6 +50,53 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- (unsafe(from_xml_node(doc.document_element, type<Car>))
+                        |> _where(_.price > THRESHOLD)
+                        |> _order_by(_.price)
+                        |> take(TAKE_N)
+                        |> to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD)
+                                       ._order_by(_.price)
+                                       .take(TAKE_N)
+                                       .to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def select_where_order_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -63,4 +110,14 @@ def select_where_order_take_m3f(b : B?) {
 [benchmark]
 def select_where_order_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def select_where_order_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def select_where_order_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/select_where_sum.das
+++ b/benchmarks/sql/select_where_sum.das
@@ -56,7 +56,7 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — plain iteration over from_xml_node.
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
 def run_m5(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -64,15 +64,8 @@ def run_m5(b : B?; n : int) {
             b->failNow()
             return
         }
-        let root = doc.document_element
         b |> run("m5_xml/{n}", n) {
-            var s = 0
-            for (car in from_xml_node(root, type<Car>)) {
-                let p = car.price * 2
-                if (p > THRESHOLD) {
-                    s += p
-                }
-            }
+            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> sum()
             b |> accept(s)
             if (s == 0) {
                 b->failNow()
@@ -110,9 +103,8 @@ def run_m5f(b : B?; n : int) {
             b->failNow()
             return
         }
-        var root = doc.document_element
         b |> run("m5f_xml_fold/{n}", n) {
-            let s = _fold(unsafe(from_xml_node(root, type<Car>))._select(_.price * 2)._where(_ > THRESHOLD).sum())
+            let s = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price * 2)._where(_ > THRESHOLD).sum())
             b |> accept(s)
             if (s == 0) {
                 b->failNow()

--- a/benchmarks/sql/single_match.das
+++ b/benchmarks/sql/single_match.das
@@ -46,10 +46,8 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline. Mirrors `.single()` semantics (the m3f/m4/m5f lanes) — a FULL scan
-// asserting exactly one survivor, NOT an early-exit find-first. (A `for ... break` baseline would
-// process ~TARGET_ID elements yet still divide by n, reporting a misleadingly tiny ns/op against the
-// full-scan fold lanes — see results.md.)
+// m5_xml lane: non-fold baseline — the same `.single()` chain over from_xml_node, un-fused
+// (tier-2 cascade). single() is a full scan asserting exactly one survivor, matching the fold lanes.
 def run_m5(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -57,18 +55,10 @@ def run_m5(b : B?; n : int) {
             b->failNow()
             return
         }
-        let root = doc.document_element
         b |> run("m5_xml/{n}", n) {
-            var row = default<Car>
-            var found = 0
-            for (car in from_xml_node(root, type<Car>)) {
-                if (car.id == TARGET_ID) {
-                    row = car
-                    found ++
-                }
-            }
+            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.id == TARGET_ID) |> single()
             b |> accept(row)
-            if (found != 1) {
+            if (row.id == 0) {
                 b->failNow()
             }
         }
@@ -105,9 +95,8 @@ def run_m5f(b : B?; n : int) {
             b->failNow()
             return
         }
-        var root = doc.document_element
         b |> run("m5f_xml_fold/{n}", n) {
-            let row = _fold(unsafe(from_xml_node(root, type<Car>))._where(_.id == TARGET_ID).single())
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.id == TARGET_ID).single())
             b |> accept(row)
             if (row.id == 0) {
                 b->failNow()

--- a/benchmarks/sql/skip_take.das
+++ b/benchmarks/sql/skip_take.das
@@ -46,6 +46,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> skip(SKIP_N) |> take(TAKE_N) |> to_array()
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>)).skip(SKIP_N).take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def skip_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +99,14 @@ def skip_take_m3f(b : B?) {
 [benchmark]
 def skip_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def skip_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def skip_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/skip_while_match.das
+++ b/benchmarks/sql/skip_while_match.das
@@ -49,6 +49,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let total = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _skip_while(_.id < THRESHOLD) |> count()
+            b |> accept(total)
+            if (total == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let total = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._skip_while(_.id < THRESHOLD).count())
+            b |> accept(total)
+            if (total == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def skip_while_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -62,4 +96,14 @@ def skip_while_match_m3f(b : B?) {
 [benchmark]
 def skip_while_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def skip_while_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def skip_while_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/sort_first.das
+++ b/benchmarks/sql/sort_first.das
@@ -42,6 +42,42 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _order_by(_.price) |> first()
+            b |> accept(row)
+            if (row.id == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._order_by(_.price).first())
+            b |> accept(row)
+            if (row.id == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def sort_first_m1(b : B?) {
     run_m1(b, 100000)
@@ -55,4 +91,14 @@ def sort_first_m3f(b : B?) {
 [benchmark]
 def sort_first_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def sort_first_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def sort_first_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/sort_take.das
+++ b/benchmarks/sql/sort_take.das
@@ -49,6 +49,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _order_by(_.price) |> take(TAKE_N) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._order_by(_.price).take(TAKE_N).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def sort_take_m1(b : B?) {
     run_m1(b, 100000)
@@ -62,4 +102,14 @@ def sort_take_m3f(b : B?) {
 [benchmark]
 def sort_take_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def sort_take_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def sort_take_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/sort_take_select.das
+++ b/benchmarks/sql/sort_take_select.das
@@ -50,6 +50,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            unsafe {
+                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _order_by(_.price) |> take(TAKE_N) |> _select(_.name) |> to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over from_xml_node.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            unsafe {
+                let rows <- _fold(from_xml_node(doc.document_element, type<Car>)._order_by(_.price).take(TAKE_N)._select(_.name).to_array())
+                b |> accept(rows)
+                if (empty(rows)) {
+                    b->failNow()
+                }
+            }
+        }
+    }
+}
+
 [benchmark]
 def sort_take_select_m1(b : B?) {
     run_m1(b, 100000)
@@ -63,4 +103,14 @@ def sort_take_select_m3f(b : B?) {
 [benchmark]
 def sort_take_select_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def sort_take_select_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def sort_take_select_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/sum_aggregate.das
+++ b/benchmarks/sql/sum_aggregate.das
@@ -41,6 +41,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> sum()
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let s = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price).sum())
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def sum_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -54,4 +88,14 @@ def sum_aggregate_m3f(b : B?) {
 [benchmark]
 def sum_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def sum_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def sum_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/sum_where.das
+++ b/benchmarks/sql/sum_where.das
@@ -45,6 +45,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> _select(_.price) |> sum()
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let s = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD)._select(_.price).sum())
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def sum_where_m1(b : B?) {
     run_m1(b, 100000)
@@ -58,4 +92,14 @@ def sum_where_m3f(b : B?) {
 [benchmark]
 def sum_where_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def sum_where_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def sum_where_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/take_count.das
+++ b/benchmarks/sql/take_count.das
@@ -44,6 +44,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> take(TAKE_N) |> to_array()
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>)).take(TAKE_N).to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def take_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -57,4 +97,14 @@ def take_count_m3f(b : B?) {
 [benchmark]
 def take_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def take_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def take_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -47,8 +47,7 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — plain iteration over from_xml_node, capping
-// at TAKE_N matches.
+// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
 def run_m5(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -56,17 +55,8 @@ def run_m5(b : B?; n : int) {
             b->failNow()
             return
         }
-        let root = doc.document_element
         b |> run("m5_xml/{n}", n) {
-            var c = 0
-            for (car in from_xml_node(root, type<Car>)) {
-                if (car.price > THRESHOLD) {
-                    c++
-                    if (c >= TAKE_N) {
-                        break
-                    }
-                }
-            }
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> take(TAKE_N) |> count()
             b |> accept(c)
             if (c == 0) {
                 b->failNow()
@@ -104,9 +94,8 @@ def run_m5f(b : B?; n : int) {
             b->failNow()
             return
         }
-        var root = doc.document_element
         b |> run("m5f_xml_fold/{n}", n) {
-            let c = _fold(unsafe(from_xml_node(root, type<Car>))._where(_.price > THRESHOLD).take(TAKE_N).count())
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD).take(TAKE_N).count())
             b |> accept(c)
             if (c == 0) {
                 b->failNow()

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -46,6 +46,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> take(TAKE_N) |> sum()
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let s = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._select(_.price).take(TAKE_N).sum())
+            b |> accept(s)
+            if (s == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def take_sum_aggregate_m1(b : B?) {
     run_m1(b, 100000)
@@ -59,4 +99,14 @@ def take_sum_aggregate_m3f(b : B?) {
 [benchmark]
 def take_sum_aggregate_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def take_sum_aggregate_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def take_sum_aggregate_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/take_where_count.das
+++ b/benchmarks/sql/take_where_count.das
@@ -50,6 +50,46 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
+// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
+// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
+// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> take(TAKE_N) |> _where(_.price > THRESHOLD) |> count()
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
+// child-element walk and field-prunes the materialization to the attributes the chain reads.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(unsafe(from_xml_node(doc.document_element, type<Car>)).take(TAKE_N)._where(_.price > THRESHOLD).count())
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def take_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -63,4 +103,14 @@ def take_where_count_m3f(b : B?) {
 [benchmark]
 def take_where_count_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def take_where_count_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def take_where_count_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/take_while_match.das
+++ b/benchmarks/sql/take_while_match.das
@@ -48,6 +48,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let total = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _take_while(_.id < THRESHOLD) |> count()
+            b |> accept(total)
+            if (total == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let total = _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._take_while(_.id < THRESHOLD).count())
+            b |> accept(total)
+            if (total == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def take_while_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -61,4 +95,14 @@ def take_while_match_m3f(b : B?) {
 [benchmark]
 def take_while_match_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def take_while_match_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def take_while_match_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/to_array_filter.das
+++ b/benchmarks/sql/to_array_filter.das
@@ -43,6 +43,40 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let prices <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> _select(_.price) |> to_array()
+            b |> accept(prices)
+            if (empty(prices)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let prices <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.price > THRESHOLD)._select(_.price).to_array())
+            b |> accept(prices)
+            if (empty(prices)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def to_array_filter_m1(b : B?) {
     run_m1(b, 100000)
@@ -56,4 +90,14 @@ def to_array_filter_m3f(b : B?) {
 [benchmark]
 def to_array_filter_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def to_array_filter_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def to_array_filter_m5f(b : B?) {
+    run_m5f(b, 100000)
 }


### PR DESCRIPTION
## What

Full XML benchmark coverage across `benchmarks/sql/`: wires the two XML lanes — **m5** (XML no-fold) and **m5f** (XML fold) — into every applicable family (**67**), up from the 5 that carried a partial XML lane. This is the deferred benchmark work from the LINQ-over-XML arc (#2920 source / #2924 adapter 2a / #2926 field-pruning 2b / #2931 parity + mixed overloads / #2932 mixed `*_to_array`).

## Lanes

- **m5 (XML no-fold)** — the array chain run over `from_xml_node` un-fused (tier-2 cascade): `unsafe(from_xml_node(root, type<Car>)) |> _where(…) |> … |> term()`. **Redefined** from the prior hand-written plain loop so it runs *identical logic* to m5f — making m5↔m5f a clean fused-vs-not comparison on the same chain (the old hand-loop was an apples-to-oranges hand-optimal floor). The 5 pre-existing hand-loop m5 lanes were reworked to match.
- **m5f (XML fold)** — `_fold` over the same `from_xml_node` source.

## The fusion map (the point of the sweep)

`results.md` now shows, per family, what the `XmlAdapter` fuses — and the delta is the signal: m5 and m5f run identical logic, so any difference is purely what fusion buys.

- **Fuses (m5f ≪ m5):** the `loop_or_count` family — where / select / aggregate / count / sum / min / max / average / first / element_at / any / all / contains / take / skip / take_while / skip_while. INTERP wins 5–10× (e.g. `count_aggregate` 419 → 64, `aggregate_match` 453 → 65, `take_count_filtered` 395 → 1.3).
- **Falls back (m5f ≈ m5):** the cascade families — `group_by` (incl. having / multi-reducer), `distinct[_by]`, `order_by[_descending]`, `sort`, `reverse`, `join`. The adapter has no specialized arm, so `_fold` materializes per element — folding buys nothing. These cells map the **next arc** (widening `XmlAdapter` to fuse the cascades).

## Out of scope / absent lanes (`—`)

- **zip (4 files)** — both XML lanes `—`: the zip benches source a synthetic `make_ints(n)` int stream, not Car/XML, so an XML zip lane would be artificial; and `_fold(zip(xmlIter, each(arr)))` hits the separate `plan_zip` iterator-preservation gap (tracked follow-up).
- **`decs_count_bare_pred`** — `—`: decs-only family.

## Validation

- Full INTERP + JIT sweep (100k rows) over all 72 families — **0 failures, every lane non-zero**; `results.md` matrices regenerated by `benchmarks/sql/_update_results.das`.
- 67 changed files compile + lint clean + formatter-clean. Benchmarks-only change — no `tests/` / `daslib` / `modules` / RST touched, so no test-suite / AOT / das2rst impact.
- The one existing-code touch outside the new lanes: a `// nolint:PERF013` on `join_where_count`'s pre-existing `run_m3f` count loop (matching the suppression `run_m4` already carries) — the whole-file lint surfaces it once the file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)