### PR TITLE
linq: mixed 2-source zip / zip_to_array (iterator, array) overloads + zip XML bench lanes

### DIFF
--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,8 @@
 # Benchmarks — SQL / Array / Decs / XML comparison
 
-Updated 2026-05-30 (branch `bbatkin/xml-bench-coverage`): **full XML coverage — both XML lanes (m5, m5f) now wired across every applicable family (67), up from 5.** Two changes: (1) **`m5` redefined** from the hand-written plain loop to the *un-fused tier-2 linq cascade* over the XML iterator — `unsafe(from_xml_node(root, type<Car>)) |> _where(…) |> … |> term()` — the same chain as m3f/m5f but without `_fold`, so **m5 vs m5f is now a clean fused-vs-not comparison on identical logic** (the prior hand-loop was an apples-to-oranges hand-optimal floor). The 5 pre-existing hand-loop m5 lanes were reworked to match. (2) **m5f added** to every family that had an array fold. The headline finding (see "Reading the XML lanes" below): the `XmlAdapter` **fuses the `loop_or_count` family** — where/select/aggregate/count/sum/min/max/average/first/element_at/any/all/contains/take/skip — where m5f runs **5–10× faster than m5** (e.g. INTERP `count_aggregate` 419 → **64**, `aggregate_match` 453 → **65**, `take_count_filtered` 395 → **1.3**), but it **does NOT fuse the cascade families** — group_by / distinct / order / sort / reverse / join — where **m5f ≈ m5** (e.g. `groupby_sum` 462.9 vs 465.1, `distinct_by_count` 393.4 vs 393.5, `sort_take` 1069 vs 1069, `join_count` 521 vs 484): the adapter falls back to full per-element materialization, so folding buys nothing. Those `m5f ≈ m5` cells are the map for the *next* arc (widening `XmlAdapter` to fuse the cascade families). **zip stays `—`** in both XML lanes — its source is a synthetic `make_ints(n)` int stream, not Car/XML, so an XML zip lane would be artificial (and `_fold` over `zip(xmlIter, each(arr))` hits the separate `plan_zip` iterator-preservation gap, a tracked follow-up). Earlier note:
+Updated 2026-05-30 (branch `bbatkin/linq-fold-zip-iterator-preservation`): **zip XML lanes (m5, m5f) now landed** across all four `zip_*` benches. The blocker was a real bug, not just an artificial source: `zip` had no mixed `(iterator, array)` overload, so `zip(xmlIter, arr)` — the natural ceremony-free form — failed to resolve, and `_fold`'s array-rewrite couldn't lower it (it produced `zip_to_array(iterator, array)`, also unoverloaded). The fix adds 2-source mixed `zip`/`zip_to_array` overloads (iterator-preserving; the private `zip_impl` already walked mixed sources). Each zip bench now zips the XML `Car` price-stream against a synthetic int array. **Finding: m5f modestly beats m5** (INTERP ~10–24%, JIT ~3–14% — e.g. `zip_dot_product` 508.7 → 431.3 INTERP, 181.6 → 165.0 JIT), so the zip splice *does* partially fuse over XML (unlike the cascade families, where m5f ≈ m5), but both lanes still pay the full unpruned `Car` materialization — every row clones its unused `name` string (~888k string-bytes/op) — which dominates the absolute cost. Field-pruning the zip source is the next lever. Earlier note:
+
+Updated 2026-05-30 (branch `bbatkin/xml-bench-coverage`): **full XML coverage — both XML lanes (m5, m5f) now wired across every applicable family (67), up from 5.** Two changes: (1) **`m5` redefined** from the hand-written plain loop to the *un-fused tier-2 linq cascade* over the XML iterator — `unsafe(from_xml_node(root, type<Car>)) |> _where(…) |> … |> term()` — the same chain as m3f/m5f but without `_fold`, so **m5 vs m5f is now a clean fused-vs-not comparison on identical logic** (the prior hand-loop was an apples-to-oranges hand-optimal floor). The 5 pre-existing hand-loop m5 lanes were reworked to match. (2) **m5f added** to every family that had an array fold. The headline finding (see "Reading the XML lanes" below): the `XmlAdapter` **fuses the `loop_or_count` family** — where/select/aggregate/count/sum/min/max/average/first/element_at/any/all/contains/take/skip — where m5f runs **5–10× faster than m5** (e.g. INTERP `count_aggregate` 419 → **64**, `aggregate_match` 453 → **65**, `take_count_filtered` 395 → **1.3**), but it **does NOT fuse the cascade families** — group_by / distinct / order / sort / reverse / join — where **m5f ≈ m5** (e.g. `groupby_sum` 462.9 vs 465.1, `distinct_by_count` 393.4 vs 393.5, `sort_take` 1069 vs 1069, `join_count` 521 vs 484): the adapter falls back to full per-element materialization, so folding buys nothing. Those `m5f ≈ m5` cells are the map for the *next* arc (widening `XmlAdapter` to fuse the cascade families). **zip stayed `—` in this PR** — its source is a synthetic `make_ints(n)` int stream, not Car/XML, and the mixed `zip(iterator, array)` overload was still missing; both were addressed in the follow-up noted above. Earlier note:
 
 Updated 2026-05-29 (branch `bbatkin/sqlite-linq-computed-select-subqueries`): **two `_sql` surface gains + 5 m1 backfills.** (1) Computed-scalar `_select` — `_select(_.a + _.b) |> sum/min/max/average/count()` now lowers (pred_to_sql renders the arithmetic into the aggregate argument) instead of being rejected as "`_.Field` only". (2) take/skip BEFORE an aggregate — `_where(P) |> take(n) |> count()` / `_select(_.X) |> take(n) |> sum()` wrap the bounded rows into an inner subquery (`SELECT COUNT(*) FROM (SELECT * FROM t WHERE P LIMIT n)`) so the LIMIT applies pre-aggregate, instead of the no-op-LIMIT rejection. New `m1` lanes: `join_select` (into-projection), `take_where_count`, `take_count_filtered`, `take_sum_aggregate`, `zip_count_pred` (degenerate same-row interpretation). The zip dot-product **sum** lanes (`zip_dot_product`, `zip_dot_product_3arg`) stay `—`: `SUM(price*year)` overflows int32 at n=100k and needs an int64-typed computed projection (`int64(...)` in `_select` currently fails inference) — deferred to the computed-cast follow-up. SQL coverage 62 → 67 / 72. Earlier note:
 
@@ -150,10 +152,10 @@ lanes never pay. The m5↔m5f delta, not the XML-vs-array gap, is the fusion sig
 | `take_where_count` | 0.9 | 0.1 | 0.1 | 4.8 | 0.7 | 1.01× |
 | `take_while_match` | 7.9 | 2.4 | 2.4 | 226.8 | 32.3 | 0.98× |
 | `to_array_filter` | 72.8 | 14.9 | 15.0 | 465.8 | 74.9 | 1.00× |
-| `zip_count_pred` | 39.4 | 17.2 | — | — | — | — |
-| `zip_dot_product` | — | 13.5 | 10.7 | — | — | 0.79× |
-| `zip_dot_product_3arg` | — | 13.5 | — | — | — | — |
-| `zip_reverse_to_array` | — | 31.1 | — | — | — | — |
+| `zip_count_pred` | 39.4 | 17.2 | — | 535.4 | 451.9 | — |
+| `zip_dot_product` | — | 13.5 | 10.7 | 508.7 | 431.3 | 0.79× |
+| `zip_dot_product_3arg` | — | 13.5 | — | 431.5 | 392.6 | — |
+| `zip_reverse_to_array` | — | 31.1 | — | 529.6 | 403.3 | — |
 
 ## JIT
 
@@ -227,10 +229,10 @@ lanes never pay. The m5↔m5f delta, not the XML-vs-array gap, is the fusion sig
 | `take_where_count` | 0.9 | 0.0 | 0.0 | 1.8 | 0.2 | — |
 | `take_while_match` | 7.8 | 0.2 | 0.3 | 85.6 | 17.6 | 1.52× |
 | `to_array_filter` | 48.7 | 3.3 | 3.4 | 178.9 | 20.2 | 1.04× |
-| `zip_count_pred` | 39.4 | 0.1 | — | — | — | — |
-| `zip_dot_product` | — | 0.1 | 0.1 | — | — | 0.77× |
-| `zip_dot_product_3arg` | — | 0.1 | — | — | — | — |
-| `zip_reverse_to_array` | — | 4.6 | — | — | — | — |
+| `zip_count_pred` | 39.4 | 0.1 | — | 185.6 | 168.2 | — |
+| `zip_dot_product` | — | 0.1 | 0.1 | 181.6 | 165.0 | 0.77× |
+| `zip_dot_product_3arg` | — | 0.1 | — | 170.4 | 165.0 | — |
+| `zip_reverse_to_array` | — | 4.6 | — | 189.5 | 163.0 | — |
 <!-- BENCH:TABLES END -->
 
 ## Notes on missing lanes (the `—` cells)
@@ -284,15 +286,13 @@ and which gaps could land in a single PR — see
 - **`zip_reverse_to_array` SQL / Decs** — `reverse()` has no SQL order key
   (relational rows are unordered without an `ORDER BY`), and zip is not
   naturally expressible over a single archetype walk. By design, no follow-up.
-- **all four `zip_*` XML lanes (m5, m5f)** — the zip benchmarks source a
-  synthetic `make_ints(n)` int stream (`[0, 1, 2, …]`), not Car/XML data, so
-  an XML zip lane would be artificial — there is no real Car/XML zip workload
-  to measure. Separately, `_fold` over `zip(xmlIter, each(arr))` hits the
-  `plan_zip` iterator-preservation gap (the array-rewrite downgrades the
-  iterator operand to a mixed `zip(array, iterator)` with no overload), a
-  **tracked follow-up** distinct from this arc. An m5-only lane zipping an
-  artificial XML price-stream against a synthetic array was considered and
-  declined (contrived; doesn't mirror the m3f). Both cells stay `—`.
+- **`zip_*` XML lanes (m5, m5f)** — now landed (see the top banner). Each zip
+  bench zips the XML `Car` price-stream against a synthetic int array via the
+  mixed `zip(iterator, array)` overload; m5f modestly beats m5 (the zip splice
+  partially fuses over XML), with both lanes still paying the unpruned `Car`
+  materialization. The remaining `—` zip cells are **SQL (m1)** and **Decs
+  (m4)**: `zip` is not a relational op and not expressible over a single
+  archetype walk (see the two bullets above).
 
 ## Accepted architectural floors (m4 vs m3f)
 

--- a/benchmarks/sql/zip_count_pred.das
+++ b/benchmarks/sql/zip_count_pred.das
@@ -56,6 +56,48 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: zip the XML Car price-stream against a synthetic int array, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let c = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> zip(ys)
+                     |> _select(int64(_._0.price) * int64(_._1))
+                     |> count($(v) => v > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the same zip(from_xml_node, array) with trailing count(P).
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let c = _fold(zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
+                          ._select(int64(_._0.price) * int64(_._1))
+                          .count($(v) => v > THRESHOLD))
+            b |> accept(c)
+            if (c == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def zip_count_pred_m1(b : B?) {
     run_m1(b, 100000)
@@ -64,4 +106,14 @@ def zip_count_pred_m1(b : B?) {
 [benchmark]
 def zip_count_pred_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def zip_count_pred_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def zip_count_pred_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/zip_dot_product.das
+++ b/benchmarks/sql/zip_dot_product.das
@@ -44,6 +44,48 @@ def run_m4(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: zip the XML Car price-stream against a synthetic int array, un-fused (tier-2 cascade).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let s = (zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
+                     |> _select(int64(_._0.price) * int64(_._1))
+                     |> sum())
+            b |> accept(s)
+            if (s == 0l) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the same zip(from_xml_node, array).
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let s = _fold(zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
+                          ._select(int64(_._0.price) * int64(_._1))
+                          .sum())
+            b |> accept(s)
+            if (s == 0l) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def zip_dot_product_m3f(b : B?) {
     run_m3f(b, 100000)
@@ -52,4 +94,14 @@ def zip_dot_product_m3f(b : B?) {
 [benchmark]
 def zip_dot_product_m4(b : B?) {
     run_m4(b, 100000)
+}
+
+[benchmark]
+def zip_dot_product_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def zip_dot_product_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/zip_dot_product_3arg.das
+++ b/benchmarks/sql/zip_dot_product_3arg.das
@@ -33,7 +33,57 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: 3-arg zip of the XML Car price-stream against a synthetic int array, un-fused (tier-2).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let s = (zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys,
+                         $(c : Car; y : int) => int64(c.price) * int64(y)) |> sum())
+            b |> accept(s)
+            if (s == 0l) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the same 3-arg zip(from_xml_node, array, sel).
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let s = _fold(zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys,
+                              $(c : Car; y : int) => int64(c.price) * int64(y)).sum())
+            b |> accept(s)
+            if (s == 0l) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def zip_dot_product_3arg_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def zip_dot_product_3arg_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def zip_dot_product_3arg_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/benchmarks/sql/zip_reverse_to_array.das
+++ b/benchmarks/sql/zip_reverse_to_array.das
@@ -39,7 +39,58 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
+// m5_xml lane: zip the XML Car stream against a synthetic int array, reverse + to_array, un-fused (tier-2).
+def run_m5(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5_xml/{n}", n) {
+            let rows <- (zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
+                         |> reverse() |> to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+// m5f_xml_fold lane: fused _fold over the same zip(from_xml_node, array) with trailing reverse + to_array.
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let ys <- make_ints(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- _fold(zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
+                              .reverse()
+                              .to_array())
+            b |> accept(rows)
+            if (empty(rows)) {
+                b->failNow()
+            }
+        }
+    }
+}
+
 [benchmark]
 def zip_reverse_to_array_m3f(b : B?) {
     run_m3f(b, 100000)
+}
+
+[benchmark]
+def zip_reverse_to_array_m5(b : B?) {
+    run_m5(b, 100000)
+}
+
+[benchmark]
+def zip_reverse_to_array_m5f(b : B?) {
+    run_m5f(b, 100000)
 }

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -3370,9 +3370,29 @@ def zip(a : array<auto(TT)>; b : array<auto(UU)>) : array<tuple<TT -const -&, UU
     return <- zip_impl_const(a, type<TT -const -&>, b, type<UU -const -&>)
 }
 
+def zip(var a : iterator<auto(TT)>; b : array<auto(UU)>) : iterator<tuple<TT -const -&, UU -const -&>> {
+    //! Merges an iterator and an array into an iterator of tuples (iterator-preserving).
+    return <- zip(a, unsafe(each(b)))
+}
+
+def zip(a : array<auto(TT)>; var b : iterator<auto(UU)>) : iterator<tuple<TT -const -&, UU -const -&>> {
+    //! Merges an array and an iterator into an iterator of tuples (iterator-preserving).
+    return <- zip(unsafe(each(a)), b)
+}
+
 def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>) : array<tuple<TT -const -&, UU -const -&>> {
     //! Merges two iterators into an array of tuples
     return <- zip_impl(a, type<TT -const -&>, b, type<UU -const -&>)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; b : array<auto(UU)>) : array<tuple<TT -const -&, UU -const -&>> {
+    //! Merges an iterator and an array into an array of tuples.
+    return <- zip_to_array(a, unsafe(each(b)))
+}
+
+def zip_to_array(a : array<auto(TT)>; var b : iterator<auto(UU)>) : array<tuple<TT -const -&, UU -const -&>> {
+    //! Merges an array and an iterator into an array of tuples.
+    return <- zip_to_array(unsafe(each(a)), b)
 }
 
 [unused_argument(tt, uu)]
@@ -3402,9 +3422,29 @@ def zip(a : array<auto(TT)>; b : array<auto(UU)>; result_selector : block<(l : T
     return <- zip_impl_const(a, type<TT -const -&>, b, type<UU -const -&>, result_selector)
 }
 
+def zip(var a : iterator<auto(TT)>; b : array<auto(UU)>; result_selector : block<(l : TT -&; r : UU -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>)) -const -&> {
+    //! Merges an iterator and an array into an iterator by applying a specified function (iterator-preserving).
+    return <- zip(a, unsafe(each(b)), result_selector)
+}
+
+def zip(a : array<auto(TT)>; var b : iterator<auto(UU)>; result_selector : block<(l : TT -&; r : UU -&) : auto>) : iterator<typedecl(result_selector(type<TT>, type<UU>)) -const -&> {
+    //! Merges an array and an iterator into an iterator by applying a specified function (iterator-preserving).
+    return <- zip(unsafe(each(a)), b, result_selector)
+}
+
 def zip_to_array(var a : iterator<auto(TT)>; var b : iterator<auto(UU)>; result_selector : block<(l : TT -&; r : UU -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>)) -const -&> {
     //! Merges two iterators into an array by applying a specified function
     return <- zip_impl(a, type<TT -const -&>, b, type<UU -const -&>, result_selector)
+}
+
+def zip_to_array(var a : iterator<auto(TT)>; b : array<auto(UU)>; result_selector : block<(l : TT -&; r : UU -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>)) -const -&> {
+    //! Merges an iterator and an array into an array by applying a specified function.
+    return <- zip_to_array(a, unsafe(each(b)), result_selector)
+}
+
+def zip_to_array(a : array<auto(TT)>; var b : iterator<auto(UU)>; result_selector : block<(l : TT -&; r : UU -&) : auto>) : array<typedecl(result_selector(type<TT>, type<UU>)) -const -&> {
+    //! Merges an array and an iterator into an array by applying a specified function.
+    return <- zip_to_array(unsafe(each(a)), b, result_selector)
 }
 
 // zip with 3 sources

--- a/skills/linq.md
+++ b/skills/linq.md
@@ -54,7 +54,7 @@ LINQ is the chainable iterator surface in `daslib/linq` plus the pipe/dot-syntax
 - Transforms: `select`, `select_to_array`, `select_many`, `zip`.
 - Materialize: `*_to_array` variants for any of the above.
 
-The **binary two-source** ops — `join` / `group_join` / `left_join` / `right_join` / `full_outer_join` / `cross_join`, `union` / `union_by` / `intersect` / `intersect_by` / `except` / `except_by` / `concat`, and `sequence_equal` / `sequence_equal_by` — accept **one `array` and one `iterator` source mixed** (e.g. `from_xml_node(...) |> _join(dealersArray, ...)` or `eachIter |> union(otherArray)`), not just both-array or both-iterator. `zip` is the exception: it is N-ary, so mix its operands with `each(arr)` rather than a mixed overload.
+The **binary two-source** ops — `join` / `group_join` / `left_join` / `right_join` / `full_outer_join` / `cross_join`, `union` / `union_by` / `intersect` / `intersect_by` / `except` / `except_by` / `concat`, and `sequence_equal` / `sequence_equal_by` — accept **one `array` and one `iterator` source mixed** (e.g. `from_xml_node(...) |> _join(dealersArray, ...)` or `eachIter |> union(otherArray)`), not just both-array or both-iterator. `zip` accepts a mixed source in its **2-source** forms too — `zip(xmlIter, arr)` / `zip(arr, xmlIter)`, with or without a result selector (`zip_to_array` likewise) — so an XML iterator zips with a bare in-memory array without `each(...)`. `zip` is N-ary (up to 8 sources), and full mixed coverage across all arities is combinatorial; for **3-or-more-source** `zip`, mix the operands with `each(arr)` rather than a per-combination overload.
 
 ```das
 require daslib/linq_boost

--- a/tests/linq/test_linq_mixed_zip.das
+++ b/tests/linq/test_linq_mixed_zip.das
@@ -1,0 +1,97 @@
+options gen2
+require daslib/linq public
+require daslib/linq_boost public
+require daslib/linq_fold
+require dastest/testing_boost public
+
+// Mixed-source zip overloads: zip / zip_to_array accept ONE array and ONE iterator source, not just
+// both-array or both-iterator. Each test runs the op three ways — all-array (ground truth),
+// (iterator, array), and (array, iterator) — and asserts the mixed results match. The iterator side
+// is produced with each(...). `a` is longer than `b` so every lane also exercises lockstep stop at
+// the shorter source. The _fold lane exercises the fold's array-rewrite, which lowers an
+// iterator-sourced zip to zip_to_array(iterator, array) — the path that needed the mixed overload.
+
+def fixture_a() : array<int> {
+    return <- [10, 20, 30, 40]
+}
+def fixture_b() : array<int> {
+    return <- [1, 2, 3]
+}
+
+// Compare two tuple<int;int> arrays element-wise. All zip lanes share zip_impl, so order is
+// identical — a direct compare (not a checksum) is valid. auto(TT) dodges the exact tuple spelling.
+def same_pairs(t : T?; name : string; refArr : array<auto(TT)>; gotArr : array<TT>) {
+    t |> equal(length(gotArr), length(refArr), name)
+    if (length(gotArr) == length(refArr)) {
+        for (i in range(length(refArr))) {
+            t |> equal(gotArr[i]._0, refArr[i]._0, name)
+            t |> equal(gotArr[i]._1, refArr[i]._1, name)
+        }
+    }
+}
+
+def same_ints(t : T?; name : string; refArr : array<int>; gotArr : array<int>) {
+    t |> equal(length(gotArr), length(refArr), name)
+    if (length(gotArr) == length(refArr)) {
+        for (i in range(length(refArr))) {
+            t |> equal(gotArr[i], refArr[i], name)
+        }
+    }
+}
+
+[test]
+def test_mixed_zip(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let refArr <- zip(a, b)
+    var m1 <- zip(unsafe(each(a)), b) |> to_array()
+    var m2 <- zip(a, unsafe(each(b))) |> to_array()
+    same_pairs(t, "zip iter+array", refArr, m1)
+    same_pairs(t, "zip array+iter", refArr, m2)
+    delete m1; delete m2
+}
+
+[test]
+def test_mixed_zip_selector(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let refSum <- [for (p in zip(a, b)); p._0 + p._1]
+    var g1 <- zip(unsafe(each(a)), b, $(x : int; y : int) => x + y) |> to_array()
+    var g2 <- zip(a, unsafe(each(b)), $(x : int; y : int) => x + y) |> to_array()
+    same_ints(t, "zip selector iter+array", refSum, g1)
+    same_ints(t, "zip selector array+iter", refSum, g2)
+    delete g1; delete g2
+}
+
+[test]
+def test_mixed_zip_to_array(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let refArr <- zip(a, b)
+    var m1 <- zip_to_array(unsafe(each(a)), b)
+    var m2 <- zip_to_array(a, unsafe(each(b)))
+    same_pairs(t, "zip_to_array iter+array", refArr, m1)
+    same_pairs(t, "zip_to_array array+iter", refArr, m2)
+    delete m1; delete m2
+}
+
+[test]
+def test_mixed_zip_to_array_selector(t : T?) {
+    let a <- fixture_a(); let b <- fixture_b()
+    let refSum <- [for (p in zip(a, b)); p._0 + p._1]
+    var g1 <- zip_to_array(unsafe(each(a)), b, $(x : int; y : int) => x + y)
+    var g2 <- zip_to_array(a, unsafe(each(b)), $(x : int; y : int) => x + y)
+    same_ints(t, "zip_to_array selector iter+array", refSum, g1)
+    same_ints(t, "zip_to_array selector array+iter", refSum, g2)
+    delete g1; delete g2
+}
+
+[test]
+def test_mixed_zip_fold(t : T?) {
+    // _fold over an iterator-sourced zip with a bare-array operand: the fold's array-rewrite lowers
+    // this to zip_to_array(iterator, array). count stops at min(4,3)=3; sum = (10+1)+(20+2)+(30+3)=66.
+    let a <- fixture_a(); let b <- fixture_b()
+    let cnt = _fold(zip(unsafe(each(a)), b).count())
+    let s = _fold(zip(unsafe(each(a)), b)._select(_._0 + _._1).sum())
+    t |> equal(cnt, 3, "zip fold count")
+    t |> equal(s, 66, "zip fold sum")
+    let cnt2 = _fold(zip(a, unsafe(each(b))).count())
+    t |> equal(cnt2, 3, "zip fold count array+iter")
+}


### PR DESCRIPTION
## The bug

`zip` was the one binary linq op without a mixed `(iterator, array)` source form. It had only `(iterator, iterator)` and `(array, array)`, so the natural, ceremony-free `zip(xmlIter, arr)` failed to resolve:

```
error[30341]: no matching functions or generics: zip(iterator<Car>, array<int>)
```

The `_fold` path made it worse: its array-rewrite lowers an iterator-sourced zip to `zip_to_array(iterator, array)` — also unoverloaded — so `_fold(zip(xmlIter, arr)...)` failed too. (The `each()`-wrapped form `zip(xmlIter, each(arr))` already worked, since `each()` makes both operands iterators.)

This broke the invariant #2931 established for the other binary ops (join / union / intersect / except / concat / sequence_equal): an iterator — e.g. the `from_xml_node` XML source — should be a first-class peer of an array. zip was the lone holdout.

## The fix

The private `zip_impl` already walks mixed sources (its `for (itA, itB in a, b)` loop handles arrays and iterators uniformly) — only the public surface was missing. This adds **8 thin 2-source overloads** in `daslib/linq.das`: `zip` and `zip_to_array`, each × {no-selector, result-selector} × {`(iterator, array)`, `(array, iterator)`}, delegating to the all-iterator form via `unsafe(each(...))`, **iterator-preserving** (return iterator).

**Scope is 2-source only.** zip is N-ary (2–8 sources); full mixed coverage across all arities is combinatorial (~490 kinds), so 3-or-more-source zip keeps mixing operands with `each(arr)` (documented in `skills/linq.md`). The 2-source forms match the parity of the other binary ops and cover the entire zip bench surface.

## Bench lanes (now unblocked)

With the overload in place, the four `zip_*` benches get their XML lanes — **m5** (un-fused tier-2 cascade) and **m5f** (`_fold`) — zipping the XML `Car` price-stream against a synthetic int array, up from the `—` they carried while the overload was missing.

**Finding:** m5f modestly beats m5 (INTERP ~10–24%, JIT ~3–14% — e.g. `zip_dot_product` 508.7 → 431.3 INTERP, 181.6 → 165.0 JIT), so the zip splice *does* partially fuse over XML (unlike the cascade families, where m5f ≈ m5). But both lanes still pay the full unpruned `Car` materialization — every row clones its unused `name` string (~888k string-bytes/op) — which dominates the absolute cost. Field-pruning the zip source is the next lever. The remaining `—` zip cells (SQL m1 / Decs m4) stay: zip is not relational and not a single-archetype walk.

## Validation

- **INTERP**: `tests/linq` 1765 + `tests/dasPUGIXML` 453 — 0 failures
- **JIT**: new regression test 5 — 0 failures
- **AOT**: `tests/linq` 1765 (incl. the new file, auto-discovered) — 0 failures
- Lint + format clean on all 6 changed/new `.das` files
- das2rst clean (no new stubs/Uncategorized); Sphinx **build succeeded** (0 warnings)
- All 4 zip benches run clean (every lane non-zero) INTERP + JIT

New regression test `tests/linq/test_linq_mixed_zip.das` (5 tests): both directions, no-selector/selector, `zip`/`zip_to_array`, the `_fold` rewrite path, and mismatched-length lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)