### PR TITLE
Add dasOPENAI: OpenAI-compatible API client module

### DIFF
--- a/modules/dasOPENAI/.das_module
+++ b/modules/dasOPENAI/.das_module
@@ -1,0 +1,14 @@
+options gen2
+require daslib/fio
+
+[export]
+def initialize(project_path : string) {
+    let files = [
+        "openai_common", "openai_chat", "openai_embeddings", "openai_models",
+        "openai_completions", "openai_audio", "openai_moderations", "openai_images",
+        "openai_vision"
+    ]
+    for (f in files) {
+        register_native_path("openai", "{f}", "{project_path}/openai/{f}.das")
+    }
+}

--- a/modules/dasOPENAI/CMakeLists.txt
+++ b/modules/dasOPENAI/CMakeLists.txt
@@ -1,0 +1,28 @@
+# dasOPENAI depends on dasHV (dashv/dashv_boost); only register it when dasHV is enabled,
+# otherwise consumers hit confusing `require dashv/...` failures.
+IF ((NOT DAS_OPENAI_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_DISABLED)))
+    SET(DAS_OPENAI_INCLUDED TRUE)
+    MESSAGE(STATUS "dasOPENAI module included.")
+
+    # Pure-das module (HTTP transport via dasHV, JSON via daslib/json_boost).
+    # One module per section; openai_common holds the shared client + error + transport.
+    # require openai/openai_<section> -> modules/dasOPENAI/openai/openai_<section>.das
+    ADD_MODULE_DAS(openai openai openai_common)
+    ADD_MODULE_DAS(openai openai openai_chat)
+    ADD_MODULE_DAS(openai openai openai_embeddings)
+    ADD_MODULE_DAS(openai openai openai_models)
+    ADD_MODULE_DAS(openai openai openai_completions)
+    ADD_MODULE_DAS(openai openai openai_audio)
+    ADD_MODULE_DAS(openai openai openai_moderations)
+    ADD_MODULE_DAS(openai openai openai_images)
+    ADD_MODULE_DAS(openai openai openai_vision)
+
+    install(DIRECTORY ${PROJECT_SOURCE_DIR}/modules/dasOPENAI/openai
+        DESTINATION ${DAS_INSTALL_MODULESDIR}/dasOPENAI
+        FILES_MATCHING
+        PATTERN "*.das"
+    )
+    install(FILES ${PROJECT_SOURCE_DIR}/modules/dasOPENAI/.das_module
+        DESTINATION ${DAS_INSTALL_MODULESDIR}/dasOPENAI
+    )
+ENDIF()

--- a/modules/dasOPENAI/examples/example_chat.das
+++ b/modules/dasOPENAI/examples/example_chat.das
@@ -1,0 +1,25 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_chat
+
+[export]
+def main {
+    let model = "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M"
+    let client = openai_client("http://localhost:11434/v1")
+
+    print("--- chat_text ---\n")
+    let reply = chat_text(client, model, "Say hello in exactly one short sentence.")
+    print("reply: {reply}\n")
+
+    print("--- chat (full result) ---\n")
+    let req = ChatCompletionRequest(model = model,
+        messages <- [ChatMessage(role = "user", content = "What is 2+2? Reply with just the number.")])
+    let res = chat(client, req)
+    if (res.ok) {
+        print("answer: {res.response.choices[0].message.content}\n")
+        print("model:  {res.response.model}\n")
+        print("tokens: {res.response.usage.total_tokens}\n")
+    } else {
+        print("error [{res.error.kind}/{res.error.status}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_chat_stream.das
+++ b/modules/dasOPENAI/examples/example_chat_stream.das
@@ -1,0 +1,18 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_chat
+
+[export]
+def main {
+    let model = "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M"
+    let client = openai_client("http://localhost:11434/v1")
+
+    var req = ChatCompletionRequest(model = model,
+        messages <- [ChatMessage(role = "user", content = "Count from 1 to 5, one number per line.")])
+
+    print("streaming: ")
+    let res = chat_stream(client, req) $(delta : string) {
+        print(delta)
+    }
+    print("\n--- done: ok={res.ok} finish={res.finish_reason} ---\n")
+}

--- a/modules/dasOPENAI/examples/example_completions.das
+++ b/modules/dasOPENAI/examples/example_completions.das
@@ -1,0 +1,11 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_completions
+
+[export]
+def main {
+    let client = openai_client("http://localhost:11434/v1")
+    let text = complete(client, "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M",
+        "The capital of France is")
+    print("completion: {text}\n")
+}

--- a/modules/dasOPENAI/examples/example_embeddings.das
+++ b/modules/dasOPENAI/examples/example_embeddings.das
@@ -1,0 +1,24 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_embeddings
+
+[export]
+def main {
+    let client = openai_client("http://localhost:11434/v1")
+
+    // convenience: single string -> vector
+    let v = embed(client, "nomic-embed-text", "The quick brown fox.")
+    print("embedding dim: {length(v)}\n")
+    if (length(v) >= 3) {
+        print("first 3: {v[0]}, {v[1]}, {v[2]}\n")
+    }
+
+    // full API: batch of inputs
+    let req = EmbeddingRequest(model = "nomic-embed-text", input <- ["hello", "world", "embeddings"])
+    let res = embeddings(client, req)
+    if (res.ok) {
+        print("batch count: {length(res.response.data)} total_tokens: {res.response.usage.total_tokens}\n")
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_images.das
+++ b/modules/dasOPENAI/examples/example_images.das
@@ -1,0 +1,22 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_images
+require daslib/fio
+
+// Image generation has no local backend — run against OpenAI with OPENAI_API_KEY set.
+[export]
+def main {
+    if (!has_env_variable("OPENAI_API_KEY")) {
+        print("set OPENAI_API_KEY to run this example (image generation is OpenAI-cloud only)\n")
+        return
+    }
+    let client = openai_client("https://api.openai.com/v1", get_env_variable("OPENAI_API_KEY"))
+    let req = ImageRequest(prompt = "a friendly robot reading a book, flat illustration",
+        model = "dall-e-3", size = "1024x1024", n = 1)
+    let res = generate_image(client, req)
+    if (res.ok && !empty(res.response.data)) {
+        print("image url: {res.response.data[0].url}\n")
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_models.das
+++ b/modules/dasOPENAI/examples/example_models.das
@@ -1,0 +1,23 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_models
+
+[export]
+def main {
+    let client = openai_client("http://localhost:11434/v1")
+
+    let res = list_models(client)
+    if (res.ok) {
+        print("Ollama models ({length(res.models)}):\n")
+        for (m in res.models) {
+            print("  {m.id} (owned_by={m.owned_by})\n")
+        }
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+
+    let one = retrieve_model(client, "nomic-embed-text")
+    if (one.ok) {
+        print("retrieved: {one.model.id} object={one.model._object} owned_by={one.model.owned_by}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_moderations.das
+++ b/modules/dasOPENAI/examples/example_moderations.das
@@ -1,0 +1,21 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_moderations
+require daslib/fio
+
+// Moderations has no local backend — run against OpenAI with OPENAI_API_KEY set.
+[export]
+def main {
+    if (!has_env_variable("OPENAI_API_KEY")) {
+        print("set OPENAI_API_KEY to run this example (moderations is OpenAI-cloud only)\n")
+        return
+    }
+    let client = openai_client("https://api.openai.com/v1", get_env_variable("OPENAI_API_KEY"))
+    let req = ModerationRequest(model = "omni-moderation-latest", input <- ["I want to hurt someone."])
+    let res = moderations(client, req)
+    if (res.ok && !empty(res.response.results)) {
+        print("flagged: {res.response.results[0].flagged} (across {length(res.response.results[0].categories)} categories)\n")
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_speech.das
+++ b/modules/dasOPENAI/examples/example_speech.das
@@ -1,0 +1,20 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_audio
+require daslib/fio
+
+[export]
+def main {
+    // Point base_url at any local OpenAI-compatible TTS server (e.g. Kokoro-FastAPI on :8880).
+    let client = openai_client("http://localhost:8880/v1")
+
+    let audio = speak(client, "kokoro", "af_heart",
+        "Welcome to daslang. This narration was synthesized locally through the OpenAI compatible module.")
+    print("audio bytes: {length(audio)}\n")
+    if (!empty(audio)) {
+        fopen("tts_example.wav", "wb") $(f) {
+            fwrite(f, audio)
+        }
+        print("wrote tts_example.wav\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_structured.das
+++ b/modules/dasOPENAI/examples/example_structured.das
@@ -1,0 +1,18 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_chat
+
+[export]
+def main {
+    let client = openai_client("http://localhost:11434/v1")
+    let req = ChatCompletionRequest(model = "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M",
+        messages <- [ChatMessage(role = "user",
+            content = "Give me a JSON object with name and city for a fictional person.")],
+        response_format = json_object_format(), max_tokens = 128)
+    let res = chat(client, req)
+    if (res.ok && !empty(res.response.choices)) {
+        print("json reply: {res.response.choices[0].message.content}\n")
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_tools.das
+++ b/modules/dasOPENAI/examples/example_tools.das
@@ -1,0 +1,35 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_chat
+require strings
+
+[export]
+def main {
+    let client = openai_client("http://localhost:11434/v1")
+
+    var tool : Tool
+    tool._type = "function"
+    tool._function.name = "get_weather"
+    tool._function.description = "Get the current weather for a location"
+    tool._function.parameters = write_json(%json~
+        {"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}
+    %%)
+
+    let req = ChatCompletionRequest(model = "qwen2.5-coder:7b",
+        messages <- [ChatMessage(role = "user", content = "What is the weather in Paris?")],
+        tools <- [tool], tool_choice = "auto")
+
+    let res = chat(client, req)
+    if (res.ok && !empty(res.response.choices)) {
+        let n = length(res.response.choices[0].message.tool_calls)
+        print("tool calls: {n}\n")
+        if (n > 0) {
+            print("  -> {res.response.choices[0].message.tool_calls[0]._function.name}" +
+                "({res.response.choices[0].message.tool_calls[0]._function.arguments})\n")
+        } else {
+            print("  (model replied with text instead)\n")
+        }
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_transcribe.das
+++ b/modules/dasOPENAI/examples/example_transcribe.das
@@ -1,0 +1,23 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_audio
+require daslib/fio
+
+[export]
+def main {
+    let client = openai_client("http://localhost:8880/v1")
+
+    // synthesize, then transcribe back — a full audio round-trip
+    let audio = speak(client, "kokoro", "af_heart", "Daslang transcription round trip.")
+    let path = "rt_example.wav"
+    fopen(path, "wb") $(f) {
+        fwrite(f, audio)
+    }
+
+    let res = transcribe(client, "whisper-1", path)
+    if (res.ok) {
+        print("transcript: {res.text}\n")
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/examples/example_vision.das
+++ b/modules/dasOPENAI/examples/example_vision.das
@@ -1,0 +1,21 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+require openai/openai_vision
+require daslib/fio
+
+// Vision needs a vision-capable model — run against OpenRouter with OPENROUTER_API_KEY set.
+[export]
+def main {
+    if (!has_env_variable("OPENROUTER_API_KEY")) {
+        print("set OPENROUTER_API_KEY to run this vision example\n")
+        return
+    }
+    let client = openai_client("https://openrouter.ai/api/v1", get_env_variable("OPENROUTER_API_KEY"))
+    let image = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/240px-Cat03.jpg"
+    let res = chat_vision(client, "google/gemma-4-31b-it:free", "What animal is in this image? Answer in one word.", image)
+    if (res.ok && !empty(res.response.choices)) {
+        print("vision reply: {res.response.choices[0].message.content}\n")
+    } else {
+        print("error [{res.error.kind}] {res.error.message}\n")
+    }
+}

--- a/modules/dasOPENAI/openai/openai_audio.das
+++ b/modules/dasOPENAI/openai/openai_audio.das
@@ -1,0 +1,117 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — audio: speech synthesis (TTS) and transcription / translation (STT).
+
+module openai_audio shared public
+
+require openai/openai_common public
+
+// ===== Speech (TTS) =====
+
+struct SpeechRequest {
+    //! Request body for ``/audio/speech``. The response is raw audio bytes, not JSON.
+    model : string
+    input : string
+    voice : string
+    @optional response_format : string
+    @optional speed : float
+}
+
+struct SpeechResult {
+    //! Outcome of ``speech``: ``audio`` holds the raw bytes when ``ok`` is true.
+    ok : bool
+    audio : array<uint8>
+    error : OpenAIError
+}
+
+def speech(client : OpenAIClient; req : SpeechRequest) : SpeechResult {
+    //! Synthesizes speech (POST /audio/speech); returns the raw audio bytes.
+    var result : SpeechResult
+    var out <- post_for_bytes(client, "/audio/speech", sprint_json(req, false))
+    result.ok = out.ok
+    if (!out.ok) {
+        result.error = out.error
+        return <- result
+    }
+    result.audio <- out.bytes
+    return <- result
+}
+
+def speak(client : OpenAIClient; model, voice, text : string) : array<uint8> {
+    //! Convenience: synthesize ``text`` with ``voice``, returns audio bytes (empty on error).
+    var bytes : array<uint8>
+    let req = SpeechRequest(model = model, voice = voice, input = text)
+    var res <- speech(client, req)
+    if (res.ok) {
+        bytes <- res.audio
+    }
+    return <- bytes
+}
+
+// ===== Transcriptions / translations (STT) =====
+
+struct TranscriptionResult {
+    //! Outcome of ``transcribe`` / ``translate``: ``text`` valid when ``ok`` is true.
+    ok : bool
+    text : string
+    error : OpenAIError
+}
+
+struct private TranscriptionResponse {
+    text : string
+}
+
+def private post_audio_file(client : OpenAIClient; path, file_path, model : string) : HttpOutcome {
+    var out : HttpOutcome
+    with_http_request() $(var hreq : HttpRequest?#) {
+        hreq.method = http_method.POST
+        hreq.url := "{client.base_url}{path}"
+        configure_request(hreq, client)
+        set_form_file(hreq, "file", file_path)
+        set_form_data(hreq, "model", model)
+        set_form_data(hreq, "response_format", "json")
+        request(hreq) $(var resp : HttpResponse?) {
+            if (resp == null) {
+                out.error = OpenAIError(kind = "transport", message = "no response from {client.base_url}{path}")
+                return
+            }
+            out.status = int(resp.status_code)
+            out.body = "{resp.body}"
+            if (out.status >= 200 && out.status < 300) {
+                out.ok = true
+            } else {
+                out.error = parse_error_body(out.status, out.body)
+            }
+        }
+    }
+    return out
+}
+
+def private decode_transcription(out : HttpOutcome) : TranscriptionResult {
+    var result : TranscriptionResult
+    result.ok = out.ok
+    if (!out.ok) {
+        result.error = out.error
+        return result
+    }
+    var resp : TranscriptionResponse
+    if (sscan_json(out.body, resp)) {
+        result.text = resp.text
+    } else {
+        result.ok = false
+        result.error = OpenAIError(kind = "decode", status = out.status, message = "failed to decode transcription")
+    }
+    return result
+}
+
+def transcribe(client : OpenAIClient; model : string; file_path : string) : TranscriptionResult {
+    //! Transcribes the audio file at ``file_path`` (POST /audio/transcriptions).
+    return decode_transcription(post_audio_file(client, "/audio/transcriptions", file_path, model))
+}
+
+def translate(client : OpenAIClient; model : string; file_path : string) : TranscriptionResult {
+    //! Translates the audio file at ``file_path`` into English (POST /audio/translations).
+    return decode_transcription(post_audio_file(client, "/audio/translations", file_path, model))
+}

--- a/modules/dasOPENAI/openai/openai_chat.das
+++ b/modules/dasOPENAI/openai/openai_chat.das
@@ -1,0 +1,222 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — chat completions: non-streaming ``chat``, streaming ``chat_stream``,
+//! tools / function-calling, and structured outputs (JSON mode).
+
+module openai_chat shared public
+
+require openai/openai_common public
+require daslib/strings_boost
+
+// ===== Chat types =====
+
+struct ResponseFormat {
+    //! Chat ``response_format``: ``_type`` is "text" | "json_object" | "json_schema".
+    @rename = "type" _type : string
+    @optional @embed json_schema : string
+}
+
+struct FunctionDef {
+    //! A tool's function declaration. ``parameters`` is a raw JSON-schema string.
+    name : string
+    @optional description : string
+    @optional @embed parameters : string
+}
+
+struct Tool {
+    //! A tool the model may call. ``_type`` is "function".
+    @rename = "type" _type : string
+    @rename = "function" _function : FunctionDef
+}
+
+struct ToolCallFunction {
+    name : string
+    arguments : string
+}
+
+struct ToolCall {
+    //! A tool call requested by the model. ``_function.arguments`` is a JSON string.
+    id : string
+    @rename = "type" _type : string
+    @rename = "function" _function : ToolCallFunction
+}
+
+struct ChatMessage {
+    //! A single chat message. ``role`` is "system" | "user" | "assistant" | "tool".
+    role : string
+    content : string
+    @optional name : string
+    @optional tool_calls : array<ToolCall>
+    @optional tool_call_id : string
+}
+
+struct ChatCompletionRequest {
+    //! Request body for ``/chat/completions``. Default-valued optional fields are omitted on send.
+    model : string
+    messages : array<ChatMessage>
+    @optional temperature : float
+    @optional top_p : float
+    @optional n : int
+    @optional stream : bool
+    @optional max_tokens : int
+    @optional max_completion_tokens : int
+    @optional frequency_penalty : float
+    @optional presence_penalty : float
+    @optional seed : int
+    @optional stop : array<string>
+    @optional user : string
+    @optional @embed response_format : string
+    @optional tools : array<Tool>
+    @optional tool_choice : string
+}
+
+struct ChatChoice {
+    index : int
+    message : ChatMessage
+    finish_reason : string
+}
+
+struct ChatCompletionResponse {
+    //! Response body for a non-streaming ``/chat/completions`` call.
+    id : string
+    @rename = "object" _object : string
+    created : int64
+    model : string
+    choices : array<ChatChoice>
+    usage : Usage
+}
+
+struct ChatResult {
+    //! Outcome of ``chat``: when ``ok`` is true ``response`` is valid, else inspect ``error``.
+    ok : bool
+    response : ChatCompletionResponse
+    error : OpenAIError
+}
+
+// ===== Streaming chat types =====
+
+struct ChatMessageDelta {
+    //! Incremental message fields in a streamed chunk (object == "chat.completion.chunk").
+    @optional role : string
+    @optional content : string
+}
+
+struct ChunkChoice {
+    index : int
+    delta : ChatMessageDelta
+    @optional finish_reason : string
+}
+
+struct ChatCompletionChunk {
+    //! One streamed delta frame.
+    id : string
+    @rename = "object" _object : string
+    created : int64
+    model : string
+    choices : array<ChunkChoice>
+}
+
+struct ChatStreamResult {
+    //! Outcome of ``chat_stream``: ``content`` is the full accumulated assistant text.
+    ok : bool
+    content : string
+    finish_reason : string
+    error : OpenAIError
+}
+
+// ===== Chat =====
+
+def chat(client : OpenAIClient; req : ChatCompletionRequest) : ChatResult {
+    //! Sends a non-streaming ``/chat/completions`` request and decodes the response.
+    var response : ChatCompletionResponse
+    let err = post_and_decode(client, "/chat/completions", sprint_json(req, false), response)
+    return ChatResult(ok = empty(err.kind), response <- response, error = err)
+}
+
+def json_object_format() : string {
+    //! Returns the ``response_format`` value for JSON mode (assign to ``req.response_format``).
+    return sprint_json(ResponseFormat(_type = "json_object"), false)
+}
+
+def chat_text(client : OpenAIClient; model : string; prompt : string) : string {
+    //! Convenience: one user turn, returns the assistant's text ("" on error).
+    let req = ChatCompletionRequest(model = model, messages <- [ChatMessage(role = "user", content = prompt)])
+    let res = chat(client, req)
+    if (!res.ok || empty(res.response.choices)) return ""
+    return res.response.choices[0].message.content
+}
+
+// ===== Streaming chat =====
+
+def chat_stream(client : OpenAIClient; var req : ChatCompletionRequest;
+                on_delta : block<(delta : string) : void>) : ChatStreamResult {
+    //! Streams a ``/chat/completions`` response, invoking ``on_delta`` with each text
+    //! increment as it arrives. Returns the full accumulated content plus status.
+    //!
+    //! Accumulates text deltas (``choices[0].delta.content``) only — streamed tool/function
+    //! calls are not reassembled. For tool calls, use the non-streaming ``chat``.
+    req.stream = true
+    let body_json = sprint_json(req, false)
+    let url = "{client.base_url}/chat/completions"
+
+    var result : ChatStreamResult
+    var buffer = ""
+    var parts : array<string>   // accumulate deltas, join once at the end (avoid O(n^2) string growth)
+    var finish = ""
+
+    with_http_request() $(var hreq : HttpRequest?#) {
+        hreq.method = http_method.POST
+        hreq.url := url
+        hreq.body := body_json
+        set_content_type(hreq, "application/json")
+        configure_request(hreq, client)
+        request_cb(hreq,
+            $(chunk : string) {
+                buffer += chunk
+                var nl = find(buffer, "\n")
+                while (nl >= 0) {
+                    var line = slice(buffer, 0, nl)
+                    buffer = slice(buffer, nl + 1, length(buffer))
+                    // tolerate CRLF line endings: drop a trailing '\r' so payload + [DONE] parse cleanly
+                    if (ends_with(line, "\r")) {
+                        line = slice(line, 0, length(line) - 1)
+                    }
+                    if (starts_with(line, "data: ")) {
+                        let payload = slice(line, 6, length(line))
+                        if (payload != "[DONE]") {
+                            var frame : ChatCompletionChunk
+                            if (sscan_json(payload, frame) && !empty(frame.choices)) {
+                                let d = frame.choices[0].delta.content
+                                if (!empty(d)) {
+                                    parts |> push(d)
+                                    invoke(on_delta, d)
+                                }
+                                if (!empty(frame.choices[0].finish_reason)) {
+                                    finish = frame.choices[0].finish_reason
+                                }
+                            }
+                        }
+                    }
+                    nl = find(buffer, "\n")
+                }
+            },
+            $(var resp : HttpResponse?) {
+                if (resp == null) {
+                    result.error = OpenAIError(kind = "transport", message = "no response from {url}")
+                } else {
+                    let code = int(resp.status_code)
+                    if (code >= 200 && code < 300) {
+                        result.ok = true
+                    } else {
+                        result.error = parse_error_body(code, "{resp.body}")
+                    }
+                }
+            })
+    }
+    result.content = join(parts, "")
+    delete parts
+    result.finish_reason = finish
+    return result
+}

--- a/modules/dasOPENAI/openai/openai_common.das
+++ b/modules/dasOPENAI/openai/openai_common.das
@@ -1,0 +1,236 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename in this module's structs (consumer roots must also set it)
+
+//! OpenAI-compatible API — shared core: client config, the unified error type, and the HTTP
+//! transport (JSON POST/GET, POST-for-bytes) reused by every endpoint module.
+//!
+//! Pure-das over ``dashv`` (HTTP transport) + ``daslib/json_boost`` (serialization).
+//!
+//! IMPORTANT: consumer root scripts MUST set ``options rtti`` — otherwise the ``@optional`` /
+//! ``@rename`` field annotations are ignored and requests serialize every field (e.g. ``"n":0``),
+//! which real OpenAI rejects.
+
+module openai_common shared public
+
+require dashv/dashv_boost public
+require daslib/json_boost public
+require strings public
+
+// ===== Client =====
+
+struct OpenAIClient {
+    //! Connection + auth config. Override ``base_url`` to target any OpenAI-compatible server.
+    base_url : string = "https://api.openai.com/v1"
+    api_key : string
+    organization : string
+    timeout_seconds : int = 60
+    default_model : string
+}
+
+def openai_client(base_url : string; api_key : string = "") : OpenAIClient {
+    //! Builds a client for the given base URL (no trailing slash) and optional API key.
+    return OpenAIClient(base_url = base_url, api_key = api_key)
+}
+
+// ===== Errors =====
+
+struct OpenAIError {
+    //! Unified error. ``kind`` is "transport" | "http" | "api" | "decode".
+    kind : string
+    status : int
+    message : string
+    _type : string
+    code : string
+}
+
+struct private OpenAIErrorBody {
+    message : string
+    @rename = "type" _type : string
+    @optional param : string
+    @optional code : string
+}
+
+struct private OpenAIErrorEnvelope {
+    error : OpenAIErrorBody
+}
+
+// ===== Shared types =====
+
+struct Usage {
+    //! Token accounting returned with most responses.
+    prompt_tokens : int
+    completion_tokens : int
+    total_tokens : int
+}
+
+// ===== Transport =====
+// Public so endpoint modules (openai_chat, openai_embeddings, ...) can reuse them.
+
+struct HttpOutcome {
+    //! Internal transport result of a JSON request (``post_json`` / ``get_json``).
+    ok : bool
+    status : int
+    body : string
+    error : OpenAIError
+}
+
+struct BytesOutcome {
+    //! Internal transport result of a binary request (``post_for_bytes``).
+    ok : bool
+    status : int
+    bytes : array<uint8>
+    error : OpenAIError
+}
+
+def parse_error_body(status : int; body : string) : OpenAIError {
+    //! Decodes an OpenAI ``{"error":{...}}`` body into an ``OpenAIError`` (falls back to a plain HTTP error).
+    var err = OpenAIError(kind = "http", status = status, message = "HTTP {status}")
+    var env : OpenAIErrorEnvelope
+    if (sscan_json(body, env) && !empty(env.error.message)) {
+        err.kind = "api"
+        err.message = env.error.message
+        err._type = env.error._type
+        err.code = env.error.code
+    }
+    return err
+}
+
+def configure_request(var req : HttpRequest?#; client : OpenAIClient) {
+    //! Applies auth (Bearer), the optional OpenAI-Organization header, and the client timeout to a
+    //! manually-built request — shared by every transport path so they behave identically.
+    if (!empty(client.api_key)) {
+        set_bearer_token_auth(req, client.api_key)
+    }
+    if (!empty(client.organization)) {
+        set_header(req, "OpenAI-Organization", client.organization)
+    }
+    if (client.timeout_seconds > 0) {
+        set_timeout(req, client.timeout_seconds)
+    }
+}
+
+def percent_encode(s : string) : string {
+    //! Percent-encodes a string for safe use as a single URL path segment (e.g. a model id like
+    //! "google/gemma-..." whose '/' would otherwise be parsed as extra path segments).
+    let HEX = "0123456789ABCDEF"
+    var out = ""
+    peek_data(s) $(bytes) {
+        for (i in range(length(bytes))) {
+            let c = int(bytes[i])
+            // unreserved per RFC 3986: ALPHA / DIGIT / '-' / '_' / '.' / '~'
+            if (is_alpha(c) || is_number(c) || c == 45 || c == 95 || c == 46 || c == 126) {
+                out += slice(s, i, i + 1)
+            } else {
+                out += "%"
+                out += slice(HEX, c / 16, c / 16 + 1)
+                out += slice(HEX, c % 16, c % 16 + 1)
+            }
+        }
+    }
+    return out
+}
+
+def post_json(client : OpenAIClient; path : string; body_json : string) : HttpOutcome {
+    //! POSTs a JSON body and returns the raw outcome (status + body, or error).
+    var out : HttpOutcome
+    let url = "{client.base_url}{path}"
+    with_http_request() $(var req : HttpRequest?#) {
+        req.method = http_method.POST
+        req.url := url
+        req.body := body_json
+        set_content_type(req, "application/json")
+        configure_request(req, client)
+        request(req) $(var resp : HttpResponse?) {
+            if (resp == null) {
+                out.error = OpenAIError(kind = "transport", message = "no response from {url}")
+                return
+            }
+            out.status = int(resp.status_code)
+            out.body = "{resp.body}"
+            if (out.status >= 200 && out.status < 300) {
+                out.ok = true
+            } else {
+                out.error = parse_error_body(out.status, out.body)
+            }
+        }
+    }
+    return out
+}
+
+def get_json(client : OpenAIClient; path : string) : HttpOutcome {
+    //! GETs ``path`` (with auth + org header + timeout) and returns the raw outcome.
+    var out : HttpOutcome
+    let url = "{client.base_url}{path}"
+    with_http_request() $(var req : HttpRequest?#) {
+        req.method = http_method.GET
+        req.url := url
+        configure_request(req, client)
+        request(req) $(var resp : HttpResponse?) {
+            if (resp == null) {
+                out.error = OpenAIError(kind = "transport", message = "no response from {url}")
+                return
+            }
+            out.status = int(resp.status_code)
+            out.body = "{resp.body}"
+            if (out.status >= 200 && out.status < 300) {
+                out.ok = true
+            } else {
+                out.error = parse_error_body(out.status, out.body)
+            }
+        }
+    }
+    return out
+}
+
+def post_for_bytes(client : OpenAIClient; path : string; body_json : string) : BytesOutcome {
+    //! POSTs a JSON body and returns the raw response bytes (e.g. audio), or a parsed error.
+    var out : BytesOutcome
+    let url = "{client.base_url}{path}"
+    with_http_request() $(var req : HttpRequest?#) {
+        req.method = http_method.POST
+        req.url := url
+        req.body := body_json
+        set_content_type(req, "application/json")
+        configure_request(req, client)
+        request(req) $(var resp : HttpResponse?) {
+            if (resp == null) {
+                out.error = OpenAIError(kind = "transport", message = "no response from {url}")
+                return
+            }
+            out.status = int(resp.status_code)
+            if (out.status >= 200 && out.status < 300) {
+                out.ok = true
+                out.bytes <- get_body_bytes(resp)
+            } else {
+                out.error = parse_error_body(out.status, "{resp.body}")
+            }
+        }
+    }
+    return <- out
+}
+
+// ===== Decode helpers =====
+// The typed "send request -> decode JSON response into a struct" wrappers in each endpoint
+// module are identical except for the path and response type; these capture that body once.
+
+def post_and_decode(client : OpenAIClient; path, body_json : string; var response : auto(RT)) : OpenAIError {
+    //! POSTs a JSON body, then decodes a 2xx response into ``response``.
+    //! Returns a default (empty-``kind``) OpenAIError on success, or the transport/decode error.
+    let out = post_json(client, path, body_json)
+    if (!out.ok) return out.error
+    if (!sscan_json(out.body, response)) {
+        return OpenAIError(kind = "decode", status = out.status, message = "failed to decode {path} response")
+    }
+    return OpenAIError()
+}
+
+def get_and_decode(client : OpenAIClient; path : string; var response : auto(RT)) : OpenAIError {
+    //! GETs ``path``, then decodes a 2xx response into ``response`` (see ``post_and_decode``).
+    let out = get_json(client, path)
+    if (!out.ok) return out.error
+    if (!sscan_json(out.body, response)) {
+        return OpenAIError(kind = "decode", status = out.status, message = "failed to decode {path} response")
+    }
+    return OpenAIError()
+}

--- a/modules/dasOPENAI/openai/openai_completions.das
+++ b/modules/dasOPENAI/openai/openai_completions.das
@@ -1,0 +1,60 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — legacy text completions.
+
+module openai_completions shared public
+
+require openai/openai_common public
+
+struct CompletionRequest {
+    //! Request body for the legacy ``/completions`` endpoint.
+    model : string
+    prompt : string
+    @optional max_tokens : int
+    @optional temperature : float
+    @optional top_p : float
+    @optional n : int
+    @optional stop : array<string>
+    @optional seed : int
+    @optional user : string
+}
+
+struct CompletionChoice {
+    text : string
+    index : int
+    finish_reason : string
+}
+
+struct CompletionResponse {
+    //! Response body for ``/completions``.
+    id : string
+    @rename = "object" _object : string
+    created : int64
+    model : string
+    choices : array<CompletionChoice>
+    usage : Usage
+}
+
+struct CompletionResult {
+    //! Outcome of ``completions``: ``response`` valid when ``ok`` is true.
+    ok : bool
+    response : CompletionResponse
+    error : OpenAIError
+}
+
+def completions(client : OpenAIClient; req : CompletionRequest) : CompletionResult {
+    //! Sends a legacy ``/completions`` request and decodes the response.
+    var response : CompletionResponse
+    let err = post_and_decode(client, "/completions", sprint_json(req, false), response)
+    return CompletionResult(ok = empty(err.kind), response <- response, error = err)
+}
+
+def complete(client : OpenAIClient; model : string; prompt : string) : string {
+    //! Convenience: completes ``prompt``, returns the text ("" on error).
+    let req = CompletionRequest(model = model, prompt = prompt, max_tokens = 64)
+    let res = completions(client, req)
+    if (!res.ok || empty(res.response.choices)) return ""
+    return res.response.choices[0].text
+}

--- a/modules/dasOPENAI/openai/openai_embeddings.das
+++ b/modules/dasOPENAI/openai/openai_embeddings.das
@@ -1,0 +1,63 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — text embeddings.
+
+module openai_embeddings shared public
+
+require openai/openai_common public
+
+struct EmbeddingRequest {
+    //! Request body for ``/embeddings``. ``input`` is always sent as an array of strings
+    //! (a single string is just a one-element array).
+    model : string
+    input : array<string>
+    @optional encoding_format : string
+    @optional dimensions : int
+    @optional user : string
+}
+
+struct EmbeddingUsage {
+    prompt_tokens : int
+    total_tokens : int
+}
+
+struct EmbeddingData {
+    @rename = "object" _object : string
+    index : int
+    embedding : array<float>
+}
+
+struct EmbeddingResponse {
+    //! Response body for ``/embeddings``.
+    @rename = "object" _object : string
+    data : array<EmbeddingData>
+    model : string
+    usage : EmbeddingUsage
+}
+
+struct EmbeddingResult {
+    //! Outcome of ``embeddings``: when ``ok`` is true ``response`` is valid, else inspect ``error``.
+    ok : bool
+    response : EmbeddingResponse
+    error : OpenAIError
+}
+
+def embeddings(client : OpenAIClient; req : EmbeddingRequest) : EmbeddingResult {
+    //! Sends an ``/embeddings`` request and decodes the response.
+    var response : EmbeddingResponse
+    let err = post_and_decode(client, "/embeddings", sprint_json(req, false), response)
+    return EmbeddingResult(ok = empty(err.kind), response <- response, error = err)
+}
+
+def embed(client : OpenAIClient; model : string; text : string) : array<float> {
+    //! Convenience: embed a single string, returns the vector (empty on error).
+    var out : array<float>
+    let req = EmbeddingRequest(model = model, input <- [text])
+    let res = embeddings(client, req)
+    if (res.ok && !empty(res.response.data)) {
+        out := res.response.data[0].embedding
+    }
+    return <- out
+}

--- a/modules/dasOPENAI/openai/openai_images.das
+++ b/modules/dasOPENAI/openai/openai_images.das
@@ -1,0 +1,47 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — image generation.
+
+module openai_images shared public
+
+require openai/openai_common public
+
+struct ImageRequest {
+    //! Request body for ``/images/generations``.
+    prompt : string
+    @optional model : string
+    @optional n : int
+    @optional size : string
+    @optional quality : string
+    @optional style : string
+    @optional response_format : string
+    @optional user : string
+}
+
+struct ImageData {
+    @optional url : string
+    @optional b64_json : string
+    @optional revised_prompt : string
+}
+
+struct ImageResponse {
+    //! Response body for ``/images/generations``.
+    created : int64
+    data : array<ImageData>
+}
+
+struct ImageResult {
+    //! Outcome of ``generate_image``: ``response`` valid when ``ok`` is true.
+    ok : bool
+    response : ImageResponse
+    error : OpenAIError
+}
+
+def generate_image(client : OpenAIClient; req : ImageRequest) : ImageResult {
+    //! Generates images from a prompt (POST /images/generations).
+    var response : ImageResponse
+    let err = post_and_decode(client, "/images/generations", sprint_json(req, false), response)
+    return ImageResult(ok = empty(err.kind), response <- response, error = err)
+}

--- a/modules/dasOPENAI/openai/openai_models.das
+++ b/modules/dasOPENAI/openai/openai_models.das
@@ -1,0 +1,51 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — model listing and retrieval.
+
+module openai_models shared public
+
+require openai/openai_common public
+
+struct Model {
+    //! A single model entry.
+    id : string
+    @rename = "object" _object : string
+    @optional created : int64
+    @optional owned_by : string
+}
+
+struct private ModelList {
+    @rename = "object" _object : string
+    data : array<Model>
+}
+
+struct ModelsResult {
+    //! Outcome of ``list_models``: ``models`` valid when ``ok`` is true.
+    ok : bool
+    models : array<Model>
+    error : OpenAIError
+}
+
+struct ModelResult {
+    //! Outcome of ``retrieve_model``: ``model`` valid when ``ok`` is true.
+    ok : bool
+    model : Model
+    error : OpenAIError
+}
+
+def list_models(client : OpenAIClient) : ModelsResult {
+    //! Lists available models (GET /models).
+    var list : ModelList
+    let err = get_and_decode(client, "/models", list)
+    if (!empty(err.kind)) return ModelsResult(error = err)
+    return ModelsResult(ok = true, models <- list.data)
+}
+
+def retrieve_model(client : OpenAIClient; model : string) : ModelResult {
+    //! Retrieves a single model by id (GET /models/{id}).
+    var m : Model
+    let err = get_and_decode(client, "/models/{percent_encode(model)}", m)
+    return ModelResult(ok = empty(err.kind), model = m, error = err)
+}

--- a/modules/dasOPENAI/openai/openai_moderations.das
+++ b/modules/dasOPENAI/openai/openai_moderations.das
@@ -1,0 +1,44 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — content moderation.
+
+module openai_moderations shared public
+
+require openai/openai_common public
+
+struct ModerationRequest {
+    //! Request body for ``/moderations``. ``input`` is always sent as an array of strings.
+    model : string
+    input : array<string>
+}
+
+struct ModerationCategoryResult {
+    //! One moderation verdict. ``categories`` and ``category_scores`` are keyed by category name
+    //! (e.g. "violence", "hate/threatening"), so no per-category field declarations are needed.
+    flagged : bool
+    categories : table<string; bool>
+    category_scores : table<string; double>
+}
+
+struct ModerationResponse {
+    //! Response body for ``/moderations``.
+    id : string
+    model : string
+    results : array<ModerationCategoryResult>
+}
+
+struct ModerationResult {
+    //! Outcome of ``moderations``: ``response`` valid when ``ok`` is true.
+    ok : bool
+    response : ModerationResponse
+    error : OpenAIError
+}
+
+def moderations(client : OpenAIClient; req : ModerationRequest) : ModerationResult {
+    //! Classifies text for policy violations (POST /moderations).
+    var response : ModerationResponse
+    let err = post_and_decode(client, "/moderations", sprint_json(req, false), response)
+    return ModerationResult(ok = empty(err.kind), response <- response, error = err)
+}

--- a/modules/dasOPENAI/openai/openai_vision.das
+++ b/modules/dasOPENAI/openai/openai_vision.das
@@ -1,0 +1,51 @@
+options gen2
+options indenting = 4
+options rtti  // honor @optional / @rename (consumer roots must also set it)
+
+//! OpenAI-compatible API — vision (image input) chat helper.
+//! Multimodal messages use an array-of-parts content shape that the typed ChatMessage
+//! (content : string) can't express, so the request is built as a JsonValue tree.
+
+module openai_vision shared public
+
+require openai/openai_chat public
+
+def private vision_text_part(text : string) : JsonValue? {
+    var tab : table<string; JsonValue?>
+    tab["type"] = JV("text")
+    tab["text"] = JV(text)
+    return JV(tab)
+}
+
+def private vision_image_part(image_url : string) : JsonValue? {
+    var inner : table<string; JsonValue?>
+    inner["url"] = JV(image_url)
+    var tab : table<string; JsonValue?>
+    tab["type"] = JV("image_url")
+    tab["image_url"] = JV(inner)
+    return JV(tab)
+}
+
+def vision_request_body(model, text, image_url : string; max_tokens : int = 300) : string {
+    //! Builds the JSON body for a one-shot vision request (a user turn with text + one image).
+    var content <- [vision_text_part(text), vision_image_part(image_url)]
+    var msg : table<string; JsonValue?>
+    msg["role"] = JV("user")
+    msg["content"] = JV(content)
+    var msgs : array<JsonValue?>
+    msgs |> push(JV(msg))
+    var body_tree : table<string; JsonValue?>
+    body_tree["model"] = JV(model)
+    body_tree["messages"] = JV(msgs)
+    body_tree["max_tokens"] = JV(max_tokens)
+    return write_json(JV(body_tree))
+}
+
+def chat_vision(client : OpenAIClient; model, text, image_url : string; max_tokens : int = 300) : ChatResult {
+    //! One-shot vision request: a single user turn with text plus an image (http(s) URL or
+    //! a ``data:`` URL). Returns the normal chat result (assistant text in choices[0].message.content).
+    var response : ChatCompletionResponse
+    let err = post_and_decode(client, "/chat/completions",
+        vision_request_body(model, text, image_url, max_tokens), response)
+    return ChatResult(ok = empty(err.kind), response <- response, error = err)
+}

--- a/modules/dasOPENAI/tests/test_chat.das
+++ b/modules/dasOPENAI/tests/test_chat.das
@@ -1,0 +1,105 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_chat
+require strings
+require daslib/fio
+
+// ===== Unit: serialization (no backend needed) =====
+
+[test]
+def test_chat_request_serialization(t : T?) {
+    t |> run("request includes set fields and omits unset optionals") @(t : T?) {
+        var req : ChatCompletionRequest
+        req.model = "m1"
+        req.messages <- [ChatMessage(role = "user", content = "hi")]
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"model\":\"m1\"") >= 0, "model present")
+        t |> success(find(js, "\"role\":\"user\"") >= 0, "message role present")
+        t |> success(find(js, "\"content\":\"hi\"") >= 0, "message content present")
+        t |> success(find(js, "\"temperature\"") == -1, "unset temperature omitted")
+        t |> success(find(js, "\"stop\"") == -1, "unset stop array omitted")
+
+        req.temperature = 0.7
+        req.max_tokens = 32
+        let js2 = sprint_json(req, false)
+        t |> success(find(js2, "\"temperature\"") >= 0, "set temperature included")
+        t |> success(find(js2, "\"max_tokens\"") >= 0, "set max_tokens included")
+    }
+}
+
+[test]
+def test_chat_response_decode(t : T?) {
+    t |> run("chat.completion round-trips through sprint_json/sscan_json") @(t : T?) {
+        var resp : ChatCompletionResponse
+        resp.id = "chatcmpl-123"
+        resp._object = "chat.completion"
+        resp.created = 1700000000
+        resp.model = "test-model"
+        resp.choices <- [ChatChoice(index = 0,
+            message = ChatMessage(role = "assistant", content = "Hello there"),
+            finish_reason = "stop")]
+        resp.usage = Usage(prompt_tokens = 9, completion_tokens = 3, total_tokens = 12)
+
+        let js = sprint_json(resp, false)
+        // @rename = "object" must surface as the JSON key "object"
+        t |> success(find(js, "\"object\":\"chat.completion\"") >= 0, "renamed object key emitted")
+
+        var back : ChatCompletionResponse
+        t |> success(sscan_json(js, back), "sscan_json succeeds")
+        t |> equal(back.id, "chatcmpl-123")
+        t |> equal(back._object, "chat.completion")
+        t |> equal(back.model, "test-model")
+        t |> equal(length(back.choices), 1)
+        t |> equal(back.choices[0].message.role, "assistant")
+        t |> equal(back.choices[0].message.content, "Hello there")
+        t |> equal(back.choices[0].finish_reason, "stop")
+        t |> equal(back.usage.total_tokens, 12)
+    }
+}
+
+// ===== Live integration (requires a running backend) =====
+
+[test]
+def test_chat_live_ollama(t : T?) {
+    t |> run("live chat against Ollama") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        var req : ChatCompletionRequest
+        req.model = "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M"
+        req.messages <- [ChatMessage(role = "user", content = "Reply with exactly the word: pong")]
+        req.max_tokens = 16
+        let res = chat(client, req)
+        t |> success(res.ok, "chat ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(!empty(res.response.choices), "response has choices")
+            t |> success(res.response.usage.total_tokens > 0, "usage reported")
+        }
+    }
+}
+
+[test]
+def test_chat_live_openrouter(t : T?) {
+    t |> run("live chat against OpenRouter (validates Bearer auth)") @(t : T?) {
+        if (!has_env_variable("OPENROUTER_API_KEY")) {
+            t |> success(true, "OPENROUTER_API_KEY not set - skipped")
+            return
+        }
+        let client = openai_client("https://openrouter.ai/api/v1", get_env_variable("OPENROUTER_API_KEY"))
+        var req : ChatCompletionRequest
+        req.model = "liquid/lfm-2.5-1.2b-instruct:free"
+        req.messages <- [ChatMessage(role = "user", content = "Reply with exactly the word: pong")]
+        req.max_tokens = 16
+        let res = chat(client, req)
+        if (!res.ok && res.error.status == 429) {
+            t |> success(true, "OpenRouter free-tier rate-limited (429) - skipped")
+            return
+        }
+        t |> success(res.ok, "chat ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(!empty(res.response.choices), "response has choices")
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_chat_stream.das
+++ b/modules/dasOPENAI/tests/test_chat_stream.das
@@ -1,0 +1,85 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_chat
+require strings
+require daslib/fio
+
+// ===== Unit: chunk serialization (no backend needed) =====
+
+[test]
+def test_stream_chunk_decode(t : T?) {
+    t |> run("chat.completion.chunk round-trips through sprint_json/sscan_json") @(t : T?) {
+        var frame : ChatCompletionChunk
+        frame.id = "chunk-1"
+        frame._object = "chat.completion.chunk"
+        frame.choices <- [ChunkChoice(index = 0,
+            delta = ChatMessageDelta(role = "assistant", content = "Hel"),
+            finish_reason = "")]
+        let js = sprint_json(frame, false)
+        t |> success(find(js, "\"object\":\"chat.completion.chunk\"") >= 0, "renamed object key emitted")
+
+        var back : ChatCompletionChunk
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> equal(back._object, "chat.completion.chunk")
+        t |> equal(length(back.choices), 1)
+        t |> equal(back.choices[0].delta.role, "assistant")
+        t |> equal(back.choices[0].delta.content, "Hel")
+    }
+}
+
+// ===== Live integration (requires a running backend) =====
+
+[test]
+def test_stream_live_ollama(t : T?) {
+    t |> run("live streaming against Ollama") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        var req : ChatCompletionRequest
+        req.model = "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M"
+        req.messages <- [ChatMessage(role = "user", content = "Say: streaming works")]
+        req.max_tokens = 32
+        var deltas = 0
+        var acc = ""
+        let res = chat_stream(client, req) $(delta : string) {
+            deltas++
+            acc += delta
+        }
+        t |> success(res.ok, "stream ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(deltas > 0, "received {deltas} delta(s)")
+            t |> success(!empty(res.content), "accumulated content non-empty")
+            t |> equal(res.content, acc)
+        }
+    }
+}
+
+[test]
+def test_stream_live_openrouter(t : T?) {
+    t |> run("live streaming against OpenRouter") @(t : T?) {
+        if (!has_env_variable("OPENROUTER_API_KEY")) {
+            t |> success(true, "OPENROUTER_API_KEY not set - skipped")
+            return
+        }
+        let client = openai_client("https://openrouter.ai/api/v1", get_env_variable("OPENROUTER_API_KEY"))
+        var req : ChatCompletionRequest
+        req.model = "liquid/lfm-2.5-1.2b-instruct:free"
+        req.messages <- [ChatMessage(role = "user", content = "Say: streaming works")]
+        req.max_tokens = 32
+        var deltas = 0
+        let res = chat_stream(client, req) $(delta : string) {
+            deltas++
+        }
+        if (!res.ok && res.error.status == 429) {
+            t |> success(true, "OpenRouter free-tier rate-limited (429) - skipped")
+            return
+        }
+        t |> success(res.ok, "stream ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(deltas > 0, "received {deltas} delta(s)")
+            t |> success(!empty(res.content), "content non-empty")
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_completions.das
+++ b/modules/dasOPENAI/tests/test_completions.das
@@ -1,0 +1,49 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_completions
+require strings
+
+[test]
+def test_completion_request_serialization(t : T?) {
+    t |> run("completion request includes fields, omits unset optionals") @(t : T?) {
+        var req : CompletionRequest
+        req.model = "m"
+        req.prompt = "hello"
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"model\":\"m\"") >= 0, "model present")
+        t |> success(find(js, "\"prompt\":\"hello\"") >= 0, "prompt present")
+        t |> success(find(js, "\"temperature\"") == -1, "unset temperature omitted")
+    }
+}
+
+[test]
+def test_completion_response_decode(t : T?) {
+    t |> run("completion response round-trips through sprint_json/sscan_json") @(t : T?) {
+        var resp : CompletionResponse
+        resp.id = "cmpl-1"
+        resp._object = "text_completion"
+        resp.model = "m"
+        resp.choices <- [CompletionChoice(text = "Paris", index = 0, finish_reason = "stop")]
+        resp.usage = Usage(prompt_tokens = 3, completion_tokens = 1, total_tokens = 4)
+        let js = sprint_json(resp, false)
+        var back : CompletionResponse
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> equal(back._object, "text_completion")
+        t |> equal(back.choices[0].text, "Paris")
+        t |> equal(back.usage.total_tokens, 4)
+    }
+}
+
+[test]
+def test_completion_live_ollama(t : T?) {
+    t |> run("live completion against Ollama") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        let text = complete(client, "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M",
+            "The capital of France is")
+        t |> success(!empty(text), "got completion text")
+    }
+}

--- a/modules/dasOPENAI/tests/test_embeddings.das
+++ b/modules/dasOPENAI/tests/test_embeddings.das
@@ -1,0 +1,56 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_embeddings
+require strings
+
+// ===== Unit: serialization (no backend needed) =====
+
+[test]
+def test_embeddings_request_serialization(t : T?) {
+    t |> run("embeddings request includes input array, omits unset optionals") @(t : T?) {
+        var req : EmbeddingRequest
+        req.model = "m"
+        req.input <- ["a", "b"]
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"model\":\"m\"") >= 0, "model present")
+        t |> success(find(js, "\"input\":[\"a\",\"b\"]") >= 0, "input array present")
+        t |> success(find(js, "\"dimensions\"") == -1, "unset dimensions omitted")
+    }
+}
+
+[test]
+def test_embeddings_response_decode(t : T?) {
+    t |> run("embeddings response round-trips through sprint_json/sscan_json") @(t : T?) {
+        var resp : EmbeddingResponse
+        resp._object = "list"
+        resp.model = "test-embed"
+        resp.data <- [EmbeddingData(_object = "embedding", index = 0, embedding <- [0.1f, 0.2f, 0.3f])]
+        resp.usage = EmbeddingUsage(prompt_tokens = 4, total_tokens = 4)
+        let js = sprint_json(resp, false)
+        var back : EmbeddingResponse
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> equal(back._object, "list")
+        t |> equal(length(back.data), 1)
+        t |> equal(back.data[0].index, 0)
+        t |> equal(length(back.data[0].embedding), 3)
+        t |> equal(back.usage.total_tokens, 4)
+    }
+}
+
+// ===== Live integration (requires Ollama with nomic-embed-text) =====
+
+[test]
+def test_embeddings_live_ollama(t : T?) {
+    t |> run("live embeddings against Ollama (nomic-embed-text)") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        let v = embed(client, "nomic-embed-text", "hello world")
+        t |> success(!empty(v), "embedding vector non-empty")
+        if (!empty(v)) {
+            t |> equal(length(v), 768)
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_images.das
+++ b/modules/dasOPENAI/tests/test_images.das
@@ -1,0 +1,40 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_images
+require strings
+
+// Fixture-only: no local backend implements /images/generations.
+
+[test]
+def test_image_request_serialization(t : T?) {
+    t |> run("image request includes prompt, omits unset optionals") @(t : T?) {
+        var req : ImageRequest
+        req.prompt = "a red cube"
+        req.model = "dall-e-3"
+        req.size = "1024x1024"
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"prompt\":\"a red cube\"") >= 0, "prompt present")
+        t |> success(find(js, "\"model\":\"dall-e-3\"") >= 0, "model present")
+        t |> success(find(js, "\"size\":\"1024x1024\"") >= 0, "size present")
+        t |> success(find(js, "\"quality\"") == -1, "unset quality omitted")
+    }
+}
+
+[test]
+def test_image_response_decode(t : T?) {
+    t |> run("image response round-trips through sprint_json/sscan_json") @(t : T?) {
+        var resp : ImageResponse
+        resp.created = 1700000000
+        resp.data <- [ImageData(url = "https://example.com/img.png", revised_prompt = "a bright red cube")]
+        let js = sprint_json(resp, false)
+        var back : ImageResponse
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> equal(length(back.data), 1)
+        t |> equal(back.data[0].url, "https://example.com/img.png")
+        t |> equal(back.data[0].revised_prompt, "a bright red cube")
+    }
+}

--- a/modules/dasOPENAI/tests/test_models.das
+++ b/modules/dasOPENAI/tests/test_models.das
@@ -1,0 +1,76 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_models
+require strings
+require daslib/fio
+
+// ===== Unit: serialization (no backend needed) =====
+
+[test]
+def test_model_decode(t : T?) {
+    t |> run("model entry round-trips through sprint_json/sscan_json") @(t : T?) {
+        var m : Model
+        m.id = "gpt-test"
+        m._object = "model"
+        m.created = 1700000000
+        m.owned_by = "openai"
+        let js = sprint_json(m, false)
+        t |> success(find(js, "\"object\":\"model\"") >= 0, "renamed object key emitted")
+        var back : Model
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> equal(back.id, "gpt-test")
+        t |> equal(back._object, "model")
+        t |> equal(back.owned_by, "openai")
+    }
+}
+
+// ===== Live integration =====
+
+[test]
+def test_models_live_ollama(t : T?) {
+    t |> run("live list_models against Ollama") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        let res = list_models(client)
+        t |> success(res.ok, "list ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(!empty(res.models), "models non-empty ({length(res.models)})")
+        }
+    }
+}
+
+[test]
+def test_models_retrieve_ollama(t : T?) {
+    t |> run("live retrieve_model against Ollama") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        let res = retrieve_model(client, "nomic-embed-text")
+        t |> success(res.ok, "retrieve ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> equal(res.model.id, "nomic-embed-text")
+            t |> equal(res.model._object, "model")
+        }
+    }
+}
+
+[test]
+def test_models_live_openrouter(t : T?) {
+    t |> run("live list_models against OpenRouter (validates GET Bearer auth)") @(t : T?) {
+        if (!has_env_variable("OPENROUTER_API_KEY")) {
+            t |> success(true, "OPENROUTER_API_KEY not set - skipped")
+            return
+        }
+        let client = openai_client("https://openrouter.ai/api/v1", get_env_variable("OPENROUTER_API_KEY"))
+        let res = list_models(client)
+        if (!res.ok && res.error.status == 429) {
+            t |> success(true, "OpenRouter free-tier rate-limited (429) - skipped")
+            return
+        }
+        t |> success(res.ok, "list ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(length(res.models) > 10, "many models ({length(res.models)})")
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_moderations.das
+++ b/modules/dasOPENAI/tests/test_moderations.das
@@ -1,0 +1,47 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_moderations
+require strings
+
+// Fixture-only: no local backend implements /moderations (OpenAI cloud only).
+
+[test]
+def test_moderation_request_serialization(t : T?) {
+    t |> run("moderation request serializes input array") @(t : T?) {
+        var req : ModerationRequest
+        req.model = "omni-moderation-latest"
+        req.input <- ["some text"]
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"model\":\"omni-moderation-latest\"") >= 0, "model present")
+        t |> success(find(js, "\"input\":[\"some text\"]") >= 0, "input array present")
+    }
+}
+
+[test]
+def test_moderation_response_decode(t : T?) {
+    t |> run("moderation response round-trips with table-keyed categories") @(t : T?) {
+        var resp : ModerationResponse
+        resp.id = "modr-1"
+        resp.model = "omni-moderation-latest"
+        var r : ModerationCategoryResult
+        r.flagged = true
+        r.categories["violence"] = false
+        r.categories["hate"] = true
+        r.category_scores["violence"] = 0.01lf
+        r.category_scores["hate"] = 0.93lf
+        resp.results |> emplace(r)
+
+        let js = sprint_json(resp, false)
+        var back : ModerationResponse
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> equal(length(back.results), 1)
+        t |> success(back.results[0].flagged, "flagged is true")
+        t |> success(back.results[0].categories["hate"], "category hate decoded true")
+        t |> success(!back.results[0].categories["violence"], "category violence decoded false")
+        t |> success(back.results[0].category_scores["hate"] > 0.9lf, "hate score decoded")
+    }
+}

--- a/modules/dasOPENAI/tests/test_speech.das
+++ b/modules/dasOPENAI/tests/test_speech.das
@@ -1,0 +1,43 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_audio
+require strings
+
+// ===== Unit: serialization (no backend needed) =====
+
+[test]
+def test_speech_request_serialization(t : T?) {
+    t |> run("speech request includes fields, omits unset speed") @(t : T?) {
+        let req = SpeechRequest(model = "kokoro", input = "hi", voice = "af_heart", response_format = "wav")
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"model\":\"kokoro\"") >= 0, "model present")
+        t |> success(find(js, "\"input\":\"hi\"") >= 0, "input present")
+        t |> success(find(js, "\"voice\":\"af_heart\"") >= 0, "voice present")
+        t |> success(find(js, "\"response_format\":\"wav\"") >= 0, "format present")
+        t |> success(find(js, "\"speed\"") == -1, "unset speed omitted")
+    }
+}
+
+// ===== Live integration (requires the Kokoro TTS server on :8880) =====
+
+[test]
+def test_speech_live_kokoro(t : T?) {
+    t |> run("live TTS against the Kokoro server") @(t : T?) {
+        let client = openai_client("http://localhost:8880/v1")
+        let req = SpeechRequest(model = "kokoro", input = "The quick brown fox.", voice = "af_heart", response_format = "wav")
+        let res <- speech(client, req)
+        t |> success(res.ok, "speech ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok) {
+            t |> success(length(res.audio) > 1000, "got audio bytes ({length(res.audio)})")
+            if (length(res.audio) >= 4) {
+                let riff = (res.audio[0] == uint8(82) && res.audio[1] == uint8(73) &&
+                    res.audio[2] == uint8(70) && res.audio[3] == uint8(70))
+                t |> success(riff, "WAV RIFF header present")
+            }
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_structured.das
+++ b/modules/dasOPENAI/tests/test_structured.das
@@ -1,0 +1,43 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_chat
+require strings
+
+[test]
+def test_response_format_serialization(t : T?) {
+    t |> run("json mode sets response_format, plain request omits it") @(t : T?) {
+        var req : ChatCompletionRequest
+        req.model = "m"
+        req.messages <- [ChatMessage(role = "user", content = "hi")]
+        t |> success(find(sprint_json(req, false), "response_format") == -1, "omitted when unset")
+        req.response_format = json_object_format()
+        let js2 = sprint_json(req, false)
+        t |> success(find(js2, "response_format") >= 0 && find(js2, "json_object") >= 0,
+            "json_object response_format embedded")
+    }
+}
+
+[test]
+def test_structured_live_ollama(t : T?) {
+    t |> run("live JSON mode against Ollama") @(t : T?) {
+        let client = openai_client("http://localhost:11434/v1")
+        var req : ChatCompletionRequest
+        req.model = "hf.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M"
+        req.messages <- [ChatMessage(role = "user",
+            content = "Return a JSON object with keys name and age for a person named Alice aged 30.")]
+        req.response_format = json_object_format()
+        req.max_tokens = 128
+        let res = chat(client, req)
+        t |> success(res.ok, "chat ok (kind={res.error.kind} {res.error.message})")
+        if (res.ok && !empty(res.response.choices)) {
+            let content = res.response.choices[0].message.content
+            var err : string
+            let parsed = read_json(content, err)
+            t |> success(parsed != null, "response content is valid JSON ({content})")
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_tools.das
+++ b/modules/dasOPENAI/tests/test_tools.das
@@ -1,0 +1,87 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_chat
+require strings
+require daslib/fio
+
+def private weather_tool() : Tool {
+    var tool : Tool
+    tool._type = "function"
+    tool._function.name = "get_weather"
+    tool._function.description = "Get the current weather for a location"
+    tool._function.parameters = write_json(%json~
+        {"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}
+    %%)
+    return tool
+}
+
+[test]
+def test_tool_serialization(t : T?) {
+    t |> run("tool serializes into request with function + parameters") @(t : T?) {
+        var req : ChatCompletionRequest
+        req.model = "m"
+        req.messages <- [ChatMessage(role = "user", content = "weather?")]
+        req.tools |> push(weather_tool())
+        req.tool_choice = "auto"
+        let js = sprint_json(req, false)
+        t |> success(find(js, "\"name\":\"get_weather\"") >= 0, "function name present")
+        t |> success(find(js, "\"tool_choice\":\"auto\"") >= 0, "tool_choice present")
+        // parameters is embedded raw JSON (write_json is pretty-printed, so match key fragments)
+        t |> success(find(js, "\"parameters\":") >= 0, "parameters key present")
+        t |> success(find(js, "location") >= 0 && find(js, "required") >= 0, "parameters schema embedded")
+    }
+}
+
+[test]
+def test_tool_call_response_decode(t : T?) {
+    t |> run("assistant tool_calls round-trip through sprint_json/sscan_json") @(t : T?) {
+        let args = write_json(%json~ {"location":"Paris"} %%)
+        var resp : ChatCompletionResponse
+        resp.id = "x"
+        resp._object = "chat.completion"
+        var msg : ChatMessage
+        msg.role = "assistant"
+        msg.tool_calls |> push(ToolCall(id = "call_1", _type = "function",
+            _function = ToolCallFunction(name = "get_weather", arguments = args)))
+        resp.choices |> emplace(ChatChoice(index = 0, message <- msg, finish_reason = "tool_calls"))
+
+        let js = sprint_json(resp, false)
+        var back : ChatCompletionResponse
+        t |> success(sscan_json(js, back), "decode ok")
+        t |> success(!empty(back.choices[0].message.tool_calls), "tool_calls decoded")
+        t |> equal(back.choices[0].message.tool_calls[0]._function.name, "get_weather")
+        t |> equal(back.choices[0].message.tool_calls[0].id, "call_1")
+    }
+}
+
+[test]
+def test_tools_live_openrouter(t : T?) {
+    t |> run("live tool calling against OpenRouter") @(t : T?) {
+        if (!has_env_variable("OPENROUTER_API_KEY")) {
+            t |> success(true, "OPENROUTER_API_KEY not set - skipped")
+            return
+        }
+        let client = openai_client("https://openrouter.ai/api/v1", get_env_variable("OPENROUTER_API_KEY"))
+        var req : ChatCompletionRequest
+        req.model = "deepseek/deepseek-v4-flash:free"
+        req.messages <- [ChatMessage(role = "user", content = "What is the weather in Paris? Use the get_weather tool.")]
+        req.tools |> push(weather_tool())
+        req.tool_choice = "auto"
+        let res = chat(client, req)
+        if (!res.ok && res.error.status == 429) {
+            t |> success(true, "OpenRouter free-tier rate-limited (429) - skipped")
+            return
+        }
+        t |> success(res.ok, "chat ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok && !empty(res.response.choices)) {
+            t |> success(!empty(res.response.choices[0].message.tool_calls), "model returned tool_calls")
+            if (!empty(res.response.choices[0].message.tool_calls)) {
+                t |> equal(res.response.choices[0].message.tool_calls[0]._function.name, "get_weather")
+            }
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_transcribe.das
+++ b/modules/dasOPENAI/tests/test_transcribe.das
@@ -1,0 +1,57 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_audio
+require strings
+require daslib/fio
+
+def private synth_wav(t : T?; client : OpenAIClient; text, path : string) : bool {
+    let sreq = SpeechRequest(model = "kokoro", input = text, voice = "af_heart", response_format = "wav")
+    let sres <- speech(client, sreq)
+    if (!sres.ok) {
+        t |> failure("TTS setup failed: {sres.error.message}")
+        return false
+    }
+    fopen(path, "wb") $(f) {
+        fwrite(f, sres.audio)
+    }
+    return true
+}
+
+// ===== Live integration (requires the Kokoro+Whisper server on :8880) =====
+
+[test]
+def test_transcribe_live_round_trip(t : T?) {
+    t |> run("TTS -> STT round trip against the local server") @(t : T?) {
+        let client = openai_client("http://localhost:8880/v1")
+        let path = "test_stt_rt.wav"
+        if (synth_wav(t, client, "The quick brown fox.", path)) {
+            let res = transcribe(client, "whisper-1", path)
+            remove(path)
+            t |> success(res.ok, "transcribe ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+            if (res.ok) {
+                t |> success(!empty(res.text), "got transcript ({res.text})")
+                t |> success(find(res.text, "fox") >= 0, "transcript mentions 'fox'")
+            }
+        }
+    }
+}
+
+[test]
+def test_translate_live(t : T?) {
+    t |> run("translation endpoint against the local server") @(t : T?) {
+        let client = openai_client("http://localhost:8880/v1")
+        let path = "test_translate_rt.wav"
+        if (synth_wav(t, client, "Hello world.", path)) {
+            let res = translate(client, "whisper-1", path)
+            remove(path)
+            t |> success(res.ok, "translate ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+            if (res.ok) {
+                t |> success(!empty(res.text), "got translation ({res.text})")
+            }
+        }
+    }
+}

--- a/modules/dasOPENAI/tests/test_vision.das
+++ b/modules/dasOPENAI/tests/test_vision.das
@@ -1,0 +1,43 @@
+options gen2
+options rtti  // required so sprint_json/sscan_json honor @optional / @rename
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require openai/openai_vision
+require strings
+require daslib/fio
+
+// 1x1 PNG data URL — enough to exercise the multimodal request plumbing.
+let PIXEL_PNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+[test]
+def test_vision_body_serialization(t : T?) {
+    t |> run("vision request body carries text + image_url parts") @(t : T?) {
+        let body = vision_request_body("m", "What is this?", "https://example.com/x.png")
+        t |> success(find(body, "image_url") >= 0, "image_url part present")
+        t |> success(find(body, "What is this?") >= 0, "text part present")
+        t |> success(find(body, "https://example.com/x.png") >= 0, "image url present")
+    }
+}
+
+[test]
+def test_vision_live_openrouter(t : T?) {
+    t |> run("live vision (image input) against OpenRouter") @(t : T?) {
+        if (!has_env_variable("OPENROUTER_API_KEY")) {
+            t |> success(true, "OPENROUTER_API_KEY not set - skipped")
+            return
+        }
+        let client = openai_client("https://openrouter.ai/api/v1", get_env_variable("OPENROUTER_API_KEY"))
+        let res = chat_vision(client, "google/gemma-4-31b-it:free", "Describe this image in one word.", PIXEL_PNG)
+        if (!res.ok && res.error.status == 429) {
+            t |> success(true, "OpenRouter free-tier rate-limited (429) - skipped")
+            return
+        }
+        t |> success(res.ok, "vision chat ok (kind={res.error.kind} status={res.error.status} {res.error.message})")
+        if (res.ok && !empty(res.response.choices)) {
+            t |> success(!empty(res.response.choices[0].message.content),
+                "got description ({res.response.choices[0].message.content})")
+        }
+    }
+}

--- a/skills/das_formatting.md
+++ b/skills/das_formatting.md
@@ -4,9 +4,16 @@ After creating or modifying any `.das` file that is part of the project (daslib 
 
 **Formatter:** MCP `format_file` tool (calls `daslib/das_source_formatter` directly)
 
-> **WARNING:** Do NOT confuse formatting with `utils/dasFormatter/` — that is a **v1→v2 syntax converter** (`das-fmt`), not a code formatter.
+**CLI fallback (when the MCP server is unavailable):** the formatter and linter also run as in-tree daslang scripts:
 
-**CI check:** The GitHub Actions CI workflow clones [profelis/das-fmt](https://github.com/profelis/das-fmt) and runs `dasfmt.das --path ./ --verify`, which internally calls `daslib/das_source_formatter` — the same formatter engine used by the MCP `format_file` tool. If CI reports `[E] Unformatted file`, it means the file was not formatted.
+- Format: `bin/Release/daslang.exe utils/das-fmt/dasfmt.das -- --path <dirOrFile>` — formats in place; add `--verify` for a dry-run check (changes nothing, fails on any unformatted file — same as CI).
+- Lint: `bin/Release/daslang.exe utils/lint/main.das -- <dirOrFile>` — STYLE/PERF/LINT rules; `0 issue(s), 0 error(s)` is clean.
+
+For a module under `modules/` whose files `require` sibling modules (e.g. `require openai/openai_chat`), pass `-load_module <moduleDir>` before `--` so cross-module requires resolve. The formatter only parses, so it works regardless; lint reports `SKIP … missing prerequisite` for files it can't fully resolve (e.g. examples/tests before the module is registered/installed).
+
+> **WARNING:** `utils/das-fmt/` (script `dasfmt.das`) is the formatter. Do NOT confuse it with `utils/dasFormatter/` — a *different* directory holding the **v1→v2 syntax converter**, which is not a code formatter.
+
+**CI check:** The `extended_checks` job builds `das-fmt` from the in-tree `utils/das-fmt/dasfmt.das` and runs the formatter over the whole tree twice — interpreted (`daslang utils/das-fmt/dasfmt.das -- --path ./ --verify`) and compiled (`das-fmt.exe --path ./ --verify`). Both call `daslib/das_source_formatter` — the same engine as the MCP `format_file` tool. If CI reports `[E] Unformatted file`, the file was not formatted.
 
 **Procedure:**
 


### PR DESCRIPTION
## dasOPENAI — OpenAI-compatible API client (pure-das module)

A pure-das module providing an OpenAI-compatible API client over **dasHV** (HTTP transport) and **daslib/json_boost** (serialization). Point `OpenAIClient.base_url` at OpenAI, Ollama, OpenRouter, vLLM, LM Studio, Kokoro-FastAPI, or any server speaking the OpenAI REST contract.

### Structure
One module per section, sharing an `openai_common` transport core (client config, the unified `OpenAIError`, JSON/bytes transport, and generic `post_and_decode` / `get_and_decode` helpers). **No aggregator** — consumers `require openai/openai_<section>` and pay only for what they use. Registered in both binaries via `.das_module` (dynamic) and `ADD_MODULE_DAS` (static), like dasPEG.

| Module | Endpoints |
|---|---|
| `openai_chat` | chat completions (streaming + non-streaming), tools / function-calling, structured outputs (JSON mode) |
| `openai_embeddings` | embeddings |
| `openai_models` | models list / retrieve |
| `openai_completions` | legacy completions |
| `openai_audio` | speech (TTS), transcriptions / translations (STT) |
| `openai_moderations` | moderations |
| `openai_images` | image generation |
| `openai_vision` | vision (image input) chat |

### Tests & examples
12 runnable examples + 12 dastest suites (**64 cases**): serialization round-trips (CI-safe, no backend) + gated live integration against Ollama, OpenRouter (`:free` models, 429-tolerant), and a local Kokoro+Whisper server. The dasOPENAI tests are **not** wired into the repo's `tests/` (intentional — they need live backends); run them with:

```
bin/Release/daslang.exe dastest/dastest.das -- --test modules/dasOPENAI/tests/
```

### Known caveats / not yet done
- **`options rtti` is required in consumer root scripts** — without it, `@optional` / `@rename` field annotations are ignored and requests serialize every field (e.g. `"n":0`), which real OpenAI rejects. Documented in `openai_common`'s docstring and every example/test. A more robust fix (rtti-independent request building, or letting a required module force program-wide rtti) is deferred to a separate PR.
- Not implemented: `images` edits/variations (multipart), a `response_format` json_schema helper (raw schema works via the `@embed` field), object-form `tool_choice`, and streaming for non-chat endpoints.
- `moderations` and `images/generations` have no local test backend → serialization (fixture) tests only; live calls do reach real OpenAI (auth + error parsing confirmed).

### Also
Clarifies `skills/das_formatting.md`: `utils/das-fmt` is the formatter (distinct from the v1→v2 converter `utils/dasFormatter`), and documents the das-fmt / lint CLI fallback for when the MCP server is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)