### PR TITLE
dasOPENAI: tutorials, doc reference page, and struct field docs

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -103,6 +103,15 @@ require daslib/type_traits
 require daslib/typemacro_boost
 require daslib/validate_code
 require dashv/dashv_boost
+require openai/openai_common
+require openai/openai_chat
+require openai/openai_embeddings
+require openai/openai_models
+require openai/openai_completions
+require openai/openai_audio
+require openai/openai_moderations
+require openai/openai_images
+require openai/openai_vision
 require pugixml/PUGIXML_boost
 require stbimage/stbimage_boost
 require stbimage/stbimage_ttf
@@ -247,6 +256,26 @@ def document_module_dashv_boost(_root : string) {
         group_by_regex("HTTP request helpers", mod, %regex~(with_http_request|get_body_bytes)$%%)
     )
     document("High-level HTTP and WebSocket wrappers", mod, "dashv_boost.rst", groups)
+}
+
+def document_module_openai(_root : string) {
+    var mod = [find_module("openai_common"), find_module("openai_chat"),
+        find_module("openai_embeddings"), find_module("openai_models"),
+        find_module("openai_completions"), find_module("openai_audio"),
+        find_module("openai_moderations"), find_module("openai_images"),
+        find_module("openai_vision")]
+    var groups <- array<DocGroup>(
+        group_by_regex("Client and transport", mod, %regex~(openai_client|configure_request|percent_encode|parse_error_body|post_json|get_json|post_for_bytes|post_and_decode|get_and_decode)$%%),
+        group_by_regex("Chat completions", mod, %regex~(chat|chat_text|chat_stream|json_object_format)$%%),
+        group_by_regex("Embeddings", mod, %regex~(embeddings|embed)$%%),
+        group_by_regex("Models", mod, %regex~(list_models|retrieve_model)$%%),
+        group_by_regex("Legacy completions", mod, %regex~(completions|complete)$%%),
+        group_by_regex("Audio (TTS and STT)", mod, %regex~(speech|speak|transcribe|translate)$%%),
+        group_by_regex("Moderations", mod, %regex~(moderations)$%%),
+        group_by_regex("Image generation", mod, %regex~(generate_image)$%%),
+        group_by_regex("Vision", mod, %regex~(chat_vision|vision_request_body)$%%)
+    )
+    documents("OpenAI-compatible API client (chat, embeddings, audio, vision, ...)", mod, "openai.rst", groups)
 }
 
 def document_module_debugapi(_root : string) {
@@ -1622,6 +1651,7 @@ def main {
     document_module_fio(root)
     document_module_network(root)
     document_module_dashv(root)
+    document_module_openai(root)
     document_module_stbimage(root)
     document_module_raster(root)
     document_module_stbtruetype(root)

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -10,7 +10,7 @@ This section provides hands-on tutorials organized by topic:
 * **C Integration Tutorials** — embed daslang in a C host using the ``daScriptC.h`` API
 * **C++ Integration Tutorials** — embed daslang in a C++ host using the native ``daScript.h`` API
 * **Macro Tutorials** — write compile-time code transformations using the daslang macro system
-* **Module Tutorials** — dasHV (HTTP), dasPUGIXML (XML), dasStbImage, dasAudio, dasPEG (parser generator)
+* **Module Tutorials** — dasHV (HTTP), dasOPENAI (LLM / OpenAI-compatible API), dasPUGIXML (XML), dasStbImage, dasAudio, dasPEG (parser generator)
 
 .. _tutorials_language:
 
@@ -229,6 +229,33 @@ Run any tutorial from the project root::
    tutorials/dasHV_05_cookies_and_forms.rst
    tutorials/dasHV_06_websockets.rst
    tutorials/dasHV_07_sse_and_streaming.rst
+
+.. _tutorials_dasopenai:
+
+dasOPENAI (OpenAI-compatible API) Tutorials
+===========================================
+
+These tutorials cover the ``openai`` module — a pure-daslang client for
+OpenAI-compatible APIs (OpenAI, Ollama, OpenRouter, Kokoro, …): chat,
+conversations, structured outputs, function calling, embeddings, models,
+audio, and streaming. Built on ``dashv`` (HTTP) and ``daslib/json_boost``.
+The companion ``.das`` files are in ``tutorials/dasOPENAI/`` and run against a
+local mock server, so no live LLM is required.
+
+Run any tutorial from the project root::
+
+   daslang.exe tutorials/dasOPENAI/01_first_chat.das
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorials/dasOPENAI_01_first_chat.rst
+   tutorials/dasOPENAI_02_conversations_and_params.rst
+   tutorials/dasOPENAI_03_structured_outputs.rst
+   tutorials/dasOPENAI_04_tools_and_function_calling.rst
+   tutorials/dasOPENAI_05_embeddings_and_models.rst
+   tutorials/dasOPENAI_06_audio.rst
+   tutorials/dasOPENAI_07_streaming_chat.rst
 
 .. _tutorials_daspugixml:
 

--- a/doc/source/reference/tutorials/dasOPENAI_01_first_chat.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_01_first_chat.rst
@@ -1,0 +1,106 @@
+.. _tutorial_dasOPENAI_first_chat:
+
+===========================================
+OPENAI-01 — Your First Chat
+===========================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Chat
+    single: Tutorial; LLM
+
+This tutorial introduces the ``openai`` module — a pure-daslang client for
+OpenAI-compatible APIs (OpenAI, Ollama, OpenRouter, Kokoro, and any server that
+speaks the same REST surface). It builds on ``dashv`` for HTTP and
+``daslib/json_boost`` for serialization.
+
+The companion ``.das`` files are in ``tutorials/dasOPENAI/``. They run against a
+small local mock server (``tutorial_openai_server.das``) so no live LLM is
+needed.
+
+Setup
+=====
+
+Require the section module you need and set ``options rtti``:
+
+.. code-block:: das
+
+   options gen2
+   options rtti          // REQUIRED — see below
+
+   require openai/openai_chat
+
+``options rtti`` is mandatory on every dasOPENAI script. Without it the
+``@optional`` / ``@rename`` field annotations are ignored, and requests
+serialize *every* field (e.g. ``"n":0``) — which real servers reject.
+
+Constructing a client
+======================
+
+``openai_client`` takes a base URL (no trailing slash) and an optional API key:
+
+.. code-block:: das
+
+   // local server, no key
+   let client = openai_client("http://localhost:11434/v1")
+
+   // real OpenAI, key from the environment
+   let client = openai_client("https://api.openai.com/v1", get_env("OPENAI_API_KEY"))
+
+The chat_text one-liner
+=======================
+
+``chat_text`` is the simplest entry point: one user turn in, the assistant's
+text out (empty string on error).
+
+.. code-block:: das
+
+   let reply = chat_text(client, "gpt-4o-mini", "Say hello in one short sentence.")
+   print("{reply}\n")
+
+The full chat() call
+====================
+
+``chat`` takes a ``ChatCompletionRequest`` and returns a ``ChatResult``. When
+``ok`` is true, ``response`` holds the decoded reply — choices, the assistant
+message, and token usage:
+
+.. code-block:: das
+
+   let req = ChatCompletionRequest(model = "gpt-4o-mini",
+       messages <- [ChatMessage(role = "user", content = "What is 2+2?")])
+   let res = chat(client, req)
+   if (res.ok) {
+       print("answer: {res.response.choices[0].message.content}\n")
+       print("tokens: {res.response.usage.total_tokens}\n")
+   } else {
+       print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+   }
+
+Handling errors
+===============
+
+Every call returns a unified ``OpenAIError`` rather than crashing. ``kind`` is
+one of ``"transport"`` (could not reach the server), ``"http"``, ``"api"`` (the
+server returned an error body), or ``"decode"`` (the response did not parse).
+
+Quick Reference
+===============
+
+==========================================  ==============================================
+Function                                    Description
+==========================================  ==============================================
+``openai_client(base_url [, api_key])``     Build a client for any OpenAI-compatible server
+``chat_text(client, model, prompt)``        One user turn → assistant text ("" on error)
+``chat(client, req)``                       Full request → ``ChatResult`` (ok/response/error)
+``res.response.choices[0].message``         The assistant ``ChatMessage``
+``res.response.usage.total_tokens``         Token accounting
+``res.error.kind`` / ``.status``            Error category and HTTP status
+==========================================  ==============================================
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/01_first_chat.das <../../../../tutorials/dasOPENAI/01_first_chat.das>`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_conversations`

--- a/doc/source/reference/tutorials/dasOPENAI_02_conversations_and_params.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_02_conversations_and_params.rst
@@ -1,0 +1,81 @@
+.. _tutorial_dasOPENAI_conversations:
+
+===========================================
+OPENAI-02 — Conversations and Parameters
+===========================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Conversation
+    single: Tutorial; Chat Parameters
+
+This tutorial covers multi-turn conversations, the optional request
+parameters, and reading token usage.
+
+Multi-turn conversations
+=========================
+
+A chat request carries the whole conversation as an ordered array of messages.
+The model sees every prior turn. Roles are ``system`` (instructions),
+``user``, ``assistant`` (previous model replies), and ``tool`` (function
+results — see :ref:`tutorial_dasOPENAI_tools`):
+
+.. code-block:: das
+
+   let req = ChatCompletionRequest(model = "gpt-4o-mini", messages <- [
+       ChatMessage(role = "system", content = "You are a terse assistant."),
+       ChatMessage(role = "user", content = "Remember the number 7."),
+       ChatMessage(role = "assistant", content = "Got it — 7."),
+       ChatMessage(role = "user", content = "What number did I ask you to remember?")])
+   let res = chat(client, req)
+
+Optional parameters
+===================
+
+``ChatCompletionRequest`` exposes the common knobs as ``@optional`` fields.
+Because ``options rtti`` is set, default-valued optionals are omitted from the
+wire — only the ones you set are sent. Set them with named arguments
+(use ``<-`` for the array-valued ``stop``):
+
+.. code-block:: das
+
+   let req = ChatCompletionRequest(model = "gpt-4o-mini",
+       messages <- [ChatMessage(role = "user", content = "Write one word.")],
+       temperature = 0.2,
+       max_tokens = 16,
+       seed = 42,
+       stop <- ["\n\n"])
+
+Other optionals include ``top_p``, ``n``, ``max_completion_tokens``,
+``frequency_penalty``, ``presence_penalty``, ``user``, and ``tool_choice``.
+
+Token usage
+===========
+
+Most responses include a ``Usage`` breakdown — prompt, completion, and total
+tokens — useful for cost tracking and staying within context limits:
+
+.. code-block:: das
+
+   let u = res.response.usage
+   print("prompt={u.prompt_tokens} completion={u.completion_tokens} total={u.total_tokens}\n")
+
+Quick Reference
+===============
+
+==========================================  ==============================================
+Field / value                               Meaning
+==========================================  ==============================================
+``messages`` (array of ``ChatMessage``)     The full conversation, in order
+``role``                                     ``system`` / ``user`` / ``assistant`` / ``tool``
+``temperature``, ``top_p``                   Sampling controls
+``max_tokens``, ``seed``, ``stop``           Length cap, determinism, stop sequences
+``response.usage``                           Prompt / completion / total token counts
+==========================================  ==============================================
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/02_conversations_and_params.das <../../../../tutorials/dasOPENAI/02_conversations_and_params.das>`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_structured_outputs`

--- a/doc/source/reference/tutorials/dasOPENAI_03_structured_outputs.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_03_structured_outputs.rst
@@ -1,0 +1,71 @@
+.. _tutorial_dasOPENAI_structured_outputs:
+
+===========================================
+OPENAI-03 — Structured Outputs (JSON mode)
+===========================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; JSON mode
+    single: Tutorial; Structured Outputs
+
+JSON mode asks the server to emit valid JSON as the message content. You then
+decode that content string into your own struct — using the same ``sscan_json``
+machinery the client uses internally.
+
+Requesting JSON
+===============
+
+``json_object_format()`` returns the ``response_format`` value for JSON mode.
+Assign it to the request:
+
+.. code-block:: das
+
+   var req = ChatCompletionRequest(model = "gpt-4o-mini",
+       messages <- [ChatMessage(role = "user",
+           content = "Return the answer to 6*7 as JSON: {\"answer\": N}.")])
+   req.response_format = json_object_format()
+   let res = chat(client, req)
+
+Decoding the content
+====================
+
+Declare a struct matching the JSON you expect, then decode the assistant's
+content into it. With ``options rtti``, ``sscan_json`` maps JSON keys onto the
+struct fields:
+
+.. code-block:: das
+
+   struct Answer {
+       answer : int
+   }
+
+   let content = res.response.choices[0].message.content
+   var parsed : Answer
+   if (sscan_json(content, parsed)) {
+       print("decoded answer = {parsed.answer}\n")
+   }
+
+This is the bridge from "model produced text" to "typed daslang value" — the
+model returns a JSON string, and ``sscan_json`` turns it into a struct you can
+use directly.
+
+Quick Reference
+===============
+
+==========================================  ==============================================
+Function / value                            Description
+==========================================  ==============================================
+``json_object_format()``                    The ``response_format`` value for JSON mode
+``req.response_format = …``                  Enable JSON mode on a request
+``sscan_json(content, parsed)``              Decode a JSON string into a struct (needs rtti)
+==========================================  ==============================================
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/03_structured_outputs.das <../../../../tutorials/dasOPENAI/03_structured_outputs.das>`
+
+   For general JSON handling see :ref:`tutorial_json`.
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_tools`

--- a/doc/source/reference/tutorials/dasOPENAI_04_tools_and_function_calling.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_04_tools_and_function_calling.rst
@@ -1,0 +1,99 @@
+.. _tutorial_dasOPENAI_tools:
+
+===========================================
+OPENAI-04 — Tools and Function Calling
+===========================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Function Calling
+    single: Tutorial; Tools
+
+Function calling lets the model ask your program to run a function. The model
+does not run anything itself — it returns a ``tool_calls`` request, your program
+executes it, and you send the result back so the model can use it.
+
+Declaring a tool
+================
+
+A ``Tool`` wraps a ``FunctionDef``. ``parameters`` is a raw JSON-schema string
+describing the arguments the model should fill in:
+
+.. code-block:: das
+
+   def weather_tool() : Tool {
+       let params = ("\{\"type\":\"object\"," +
+           "\"properties\":\{\"location\":\{\"type\":\"string\"\}\}," +
+           "\"required\":[\"location\"]\}")
+       return Tool(_type = "function",
+           _function = FunctionDef(name = "get_weather",
+               description = "Get the current weather for a location",
+               parameters = params))
+   }
+
+(In daslang string literals ``{`` and ``}`` start interpolation, so literal JSON
+braces are escaped as ``\{`` / ``\}``.)
+
+Reading the tool call
+=====================
+
+Send the tools with the request. When the model wants a tool, ``content`` is
+empty (some servers send ``content:null`` — ``sscan_json`` decodes that fine)
+and ``tool_calls`` is populated:
+
+.. code-block:: das
+
+   let req = ChatCompletionRequest(model = "gpt-4o-mini",
+       messages <- [ChatMessage(role = "user", content = "What's the weather in Paris?")],
+       tools <- [weather_tool()])
+   let res = chat(client, req)
+
+   let tcall = res.response.choices[0].message.tool_calls[0]
+   print("name={tcall._function.name} args={tcall._function.arguments}\n")
+
+Completing the round trip
+=========================
+
+Execute the function yourself, then send the result back as a message with role
+``tool``, tagged with the ``tool_call_id`` the model gave you. The conversation
+includes the user turn, the assistant's tool-call turn, and your tool result:
+
+.. code-block:: das
+
+   let req2 = ChatCompletionRequest(model = "gpt-4o-mini", messages <- [
+       ChatMessage(role = "user", content = "What's the weather in Paris?"),
+       ChatMessage(role = "assistant", content = "",
+           tool_calls <- [ToolCall(id = tcall.id, _type = "function",
+               _function = ToolCallFunction(name = tcall._function.name,
+                   arguments = tcall._function.arguments))]),
+       ChatMessage(role = "tool", tool_call_id = tcall.id,
+           content = "\{\"temp_c\":18,\"sky\":\"clear\"\}")])
+   let res2 = chat(client, req2)
+   // res2 now contains the model's natural-language answer using the tool result
+
+Quick Reference
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Type / field
+     - Description
+   * - ``Tool`` / ``FunctionDef``
+     - A declarable function (``parameters`` = JSON schema)
+   * - ``req.tools <- [ … ]``
+     - Offer tools on a request
+   * - ``message.tool_calls``
+     - The tool calls the model requested
+   * - ``ToolCall._function.name`` / ``.arguments``
+     - Function name + JSON argument string
+   * - ``role = "tool"`` + ``tool_call_id``
+     - Return a tool result to the model
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/04_tools_and_function_calling.das <../../../../tutorials/dasOPENAI/04_tools_and_function_calling.das>`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_embeddings_models`

--- a/doc/source/reference/tutorials/dasOPENAI_05_embeddings_and_models.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_05_embeddings_and_models.rst
@@ -1,0 +1,91 @@
+.. _tutorial_dasOPENAI_embeddings_models:
+
+===========================================
+OPENAI-05 — Embeddings and Models
+===========================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Embeddings
+    single: Tutorial; Models
+
+This tutorial covers text embeddings (and comparing them), listing and
+retrieving models, and why model ids are percent-encoded in the URL path.
+
+Embeddings and cosine similarity
+================================
+
+``embed`` turns a string into a vector of floats. Semantically similar texts
+produce vectors that point in similar directions — measured by cosine
+similarity (1.0 = identical direction, 0.0 = orthogonal):
+
+.. code-block:: das
+
+   require openai/openai_embeddings
+   require math
+
+   let v1 = embed(client, "text-embedding-3-small", "a cat sat on the mat")
+   let v2 = embed(client, "text-embedding-3-small", "the feline rested on the rug")
+
+   def cosine(a, b : array<float>) : float {
+       var dot = 0.0; var na = 0.0; var nb = 0.0
+       for (i in range(length(a))) {
+           dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]
+       }
+       return dot / (sqrt(na) * sqrt(nb))
+   }
+   print("similarity: {cosine(v1, v2)}\n")
+
+For the full ``EmbeddingResponse`` (per-input vectors + usage), use
+``embeddings(client, req)`` with an ``EmbeddingRequest``.
+
+Listing and retrieving models
+=============================
+
+.. code-block:: das
+
+   require openai/openai_models
+
+   let list = list_models(client)
+   for (m in list.models) {
+       print("  {m.id} (owned_by {m.owned_by})\n")
+   }
+
+   let one = retrieve_model(client, "gpt-4o-mini")
+   if (one.ok) {
+       print("retrieved: {one.model.id}\n")
+   }
+
+Percent-encoded model ids
+=========================
+
+Many providers use model ids with slashes (e.g. ``google/gemma-2:free``).
+``retrieve_model`` percent-encodes the id so the ``/`` is not parsed as extra
+path segments. ``percent_encode`` (in ``openai_common``) is the helper that does
+it:
+
+.. code-block:: das
+
+   require openai/openai_common
+   print("{percent_encode("google/gemma-2:free")}\n")
+   // → google%2Fgemma-2%3Afree
+
+Quick Reference
+===============
+
+==========================================  ==============================================
+Function                                    Description
+==========================================  ==============================================
+``embed(client, model, text)``              Single string → vector (``array<float>``)
+``embeddings(client, req)``                 Full ``EmbeddingResult`` (vectors + usage)
+``list_models(client)``                     All available models
+``retrieve_model(client, id)``              One model by id (path-encoded)
+``percent_encode(s)``                       URL-encode a path segment
+==========================================  ==============================================
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/05_embeddings_and_models.das <../../../../tutorials/dasOPENAI/05_embeddings_and_models.das>`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_audio`

--- a/doc/source/reference/tutorials/dasOPENAI_06_audio.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_06_audio.rst
@@ -1,0 +1,68 @@
+.. _tutorial_dasOPENAI_audio:
+
+==================================================
+OPENAI-06 — Audio (Speech and Transcription)
+==================================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Text to Speech
+    single: Tutorial; Transcription
+
+This tutorial covers text-to-speech (TTS) and speech-to-text (STT).
+
+Text to speech
+==============
+
+``speak`` synthesizes text into audio and returns the raw bytes
+(``array<uint8>``, empty on error). Write them to a file to play later, or
+stream them onward — the byte format is whatever the server produced:
+
+.. code-block:: das
+
+   require openai/openai_audio
+   require daslib/fio
+
+   var audio <- speak(client, "tts-1", "alloy", "Hello from daslang.")
+   print("received {length(audio)} audio bytes\n")
+   fopen("out.wav", "wb") $(f) {
+       fwrite(f, audio)
+   }
+   delete audio
+
+For the full request (response format, speed) use ``speech(client, req)`` with a
+``SpeechRequest``.
+
+Speech to text
+==============
+
+``transcribe`` uploads an audio file (multipart) and returns the recognized
+text. ``translate`` is the same but returns English:
+
+.. code-block:: das
+
+   let res = transcribe(client, "whisper-1", "recording.wav")
+   if (res.ok) {
+       print("transcript: {res.text}\n")
+   } else {
+       print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+   }
+
+Quick Reference
+===============
+
+==========================================  ==============================================
+Function                                    Description
+==========================================  ==============================================
+``speak(client, model, voice, text)``       TTS → audio bytes (``array<uint8>``)
+``speech(client, req)``                      Full TTS request (``SpeechResult``)
+``transcribe(client, model, path)``          STT: audio file → text
+``translate(client, model, path)``           STT into English
+==========================================  ==============================================
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/06_audio.das <../../../../tutorials/dasOPENAI/06_audio.das>`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_streaming`

--- a/doc/source/reference/tutorials/dasOPENAI_07_streaming_chat.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_07_streaming_chat.rst
@@ -1,0 +1,75 @@
+.. _tutorial_dasOPENAI_streaming:
+
+===========================================
+OPENAI-07 — Streaming Chat
+===========================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Streaming
+    single: Tutorial; SSE
+
+Streaming delivers the assistant's reply token-by-token over Server-Sent Events
+(SSE) instead of waiting for the whole response. ``chat_stream`` invokes your
+``on_delta`` block for each text increment and also accumulates the full text.
+
+Streaming with on_delta
+=======================
+
+``chat_stream`` sets ``stream = true`` for you. Each text increment is passed to
+the trailing block; the return value carries the full accumulated content and
+the ``finish_reason``:
+
+.. code-block:: das
+
+   var req = ChatCompletionRequest(model = "gpt-4o-mini",
+       messages <- [ChatMessage(role = "user", content = "Stream a short greeting.")])
+
+   let result = chat_stream(client, req) $(delta : string) {
+       print(delta)          // each increment, as it arrives
+   }
+
+   if (result.ok) {
+       print("\naccumulated: {result.content}\n")
+       print("finish_reason: {result.finish_reason}\n")
+   }
+
+How it works
+============
+
+Under the hood ``chat_stream`` reads the SSE response with ``request_cb``,
+splits it into ``data:`` lines, decodes each ``ChatCompletionChunk``, appends
+``choices[0].delta.content``, and stops at ``data: [DONE]``. It tolerates CRLF
+line endings and accumulates increments efficiently (joining once at the end).
+
+Scope
+=====
+
+``chat_stream`` accumulates text deltas (``choices[0].delta.content``) only.
+Streamed tool/function calls are a separate, later feature — for tool calls use
+the non-streaming :ref:`chat() <tutorial_dasOPENAI_tools>`.
+
+Quick Reference
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Function / value
+     - Description
+   * - ``chat_stream(client, req) $(delta) { … }``
+     - Stream a reply; block runs per increment
+   * - ``result.content``
+     - Full accumulated assistant text
+   * - ``result.finish_reason``
+     - Why generation stopped (e.g. ``"stop"``)
+   * - ``result.ok`` / ``result.error``
+     - Success flag / unified error
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/07_streaming_chat.das <../../../../tutorials/dasOPENAI/07_streaming_chat.das>`
+
+   For the SSE protocol and ``request_cb`` see :ref:`tutorial_dasHV_sse_and_streaming`.

--- a/doc/source/stdlib/handmade/module-openai_common.rst
+++ b/doc/source/stdlib/handmade/module-openai_common.rst
@@ -1,0 +1,35 @@
+A pure-daslang client for OpenAI-compatible REST APIs — OpenAI itself, plus any
+server that speaks the same surface (Ollama, OpenRouter, Kokoro, LM Studio,
+vLLM, …). Built on ``dashv`` for HTTP and ``daslib/json_boost`` for
+serialization.
+
+The API is split into one module per section; ``require`` only what you use:
+
+.. code-block:: das
+
+    require openai/openai_chat          // chat completions, tools, JSON mode, streaming
+    require openai/openai_embeddings    // text embeddings
+    require openai/openai_models        // list / retrieve models
+    require openai/openai_completions   // legacy text completions
+    require openai/openai_audio         // text-to-speech and transcription
+    require openai/openai_moderations   // content moderation
+    require openai/openai_images        // image generation
+    require openai/openai_vision        // image-input chat
+
+Each section module re-exports ``openai_common`` (the client, the unified
+``OpenAIError``, and the HTTP transport), so requiring a section is enough.
+
+Every consumer root MUST set ``options rtti`` — otherwise the ``@optional`` /
+``@rename`` field annotations are ignored and requests serialize every field
+(e.g. ``"n":0``), which real servers reject:
+
+.. code-block:: das
+
+    options rtti
+    require openai/openai_chat
+
+    let client = openai_client("https://api.openai.com/v1", get_env("OPENAI_API_KEY"))
+    print("{chat_text(client, "gpt-4o-mini", "Say hi in one sentence.")}\n")
+
+See :ref:`tutorial_dasOPENAI_first_chat` for a hands-on tutorial, or the rest of
+the :ref:`dasOPENAI tutorials <tutorials_dasopenai>`.

--- a/doc/source/stdlib/introduction.rst
+++ b/doc/source/stdlib/introduction.rst
@@ -173,6 +173,7 @@ HTTP and WebSocket
 
 * :doc:`dashv <generated/dashv>` — HTTP client/server and WebSocket bindings (C++ module, based on libhv)
 * :doc:`dashv_boost <generated/dashv_boost>` — dasHV convenience helpers: GET/POST/PUT/PATCH/DELETE, response iteration
+* :doc:`openai <generated/openai>` — OpenAI-compatible API client: chat, tools, embeddings, models, audio, images, vision, streaming
 
 XML
 ---

--- a/doc/source/stdlib/sec_io.rst
+++ b/doc/source/stdlib/sec_io.rst
@@ -12,6 +12,7 @@ File I/O, networking, URI parsing, terminal output, and binary serialization.
    generated/network.rst
    generated/dashv.rst
    generated/dashv_boost.rst
+   generated/openai.rst
    generated/uriparser.rst
    generated/uriparser_boost.rst
    generated/ansi_colors.rst

--- a/modules/dasOPENAI/openai/openai_audio.das
+++ b/modules/dasOPENAI/openai/openai_audio.das
@@ -12,18 +12,18 @@ require openai/openai_common public
 
 struct SpeechRequest {
     //! Request body for ``/audio/speech``. The response is raw audio bytes, not JSON.
-    model : string
-    input : string
-    voice : string
-    @optional response_format : string
-    @optional speed : float
+    model : string                       //!< TTS model id.
+    input : string                       //!< Text to synthesize.
+    voice : string                       //!< Voice name (e.g. "alloy").
+    @optional response_format : string   //!< Audio format ("mp3", "wav", ...); server default if empty.
+    @optional speed : float              //!< Playback speed multiplier (1.0 = normal).
 }
 
 struct SpeechResult {
     //! Outcome of ``speech``: ``audio`` holds the raw bytes when ``ok`` is true.
-    ok : bool
-    audio : array<uint8>
-    error : OpenAIError
+    ok : bool             //!< True when ``audio`` holds the result.
+    audio : array<uint8>  //!< Raw audio bytes on success.
+    error : OpenAIError   //!< Error detail on failure.
 }
 
 def speech(client : OpenAIClient; req : SpeechRequest) : SpeechResult {
@@ -54,9 +54,9 @@ def speak(client : OpenAIClient; model, voice, text : string) : array<uint8> {
 
 struct TranscriptionResult {
     //! Outcome of ``transcribe`` / ``translate``: ``text`` valid when ``ok`` is true.
-    ok : bool
-    text : string
-    error : OpenAIError
+    ok : bool            //!< True when ``text`` is valid.
+    text : string        //!< Recognized text on success.
+    error : OpenAIError  //!< Error detail on failure.
 }
 
 struct private TranscriptionResponse {

--- a/modules/dasOPENAI/openai/openai_chat.das
+++ b/modules/dasOPENAI/openai/openai_chat.das
@@ -14,116 +14,119 @@ require daslib/strings_boost
 
 struct ResponseFormat {
     //! Chat ``response_format``: ``_type`` is "text" | "json_object" | "json_schema".
-    @rename = "type" _type : string
-    @optional @embed json_schema : string
+    @rename = "type" _type : string         //!< "text" | "json_object" | "json_schema".
+    @optional @embed json_schema : string   //!< Raw JSON-schema string, when ``_type`` is "json_schema".
 }
 
 struct FunctionDef {
     //! A tool's function declaration. ``parameters`` is a raw JSON-schema string.
-    name : string
-    @optional description : string
-    @optional @embed parameters : string
+    name : string                       //!< Function name the model may call.
+    @optional description : string      //!< What the function does (helps the model decide when to call it).
+    @optional @embed parameters : string //!< Raw JSON-schema string describing the arguments.
 }
 
 struct Tool {
     //! A tool the model may call. ``_type`` is "function".
-    @rename = "type" _type : string
-    @rename = "function" _function : FunctionDef
+    @rename = "type" _type : string           //!< Tool type ("function").
+    @rename = "function" _function : FunctionDef //!< The function declaration.
 }
 
 struct ToolCallFunction {
-    name : string
-    arguments : string
+    //! The function a tool call targets.
+    name : string       //!< Function name.
+    arguments : string  //!< JSON-encoded argument string.
 }
 
 struct ToolCall {
     //! A tool call requested by the model. ``_function.arguments`` is a JSON string.
-    id : string
-    @rename = "type" _type : string
-    @rename = "function" _function : ToolCallFunction
+    id : string                                  //!< Unique id for this call; echo it back in the tool result.
+    @rename = "type" _type : string              //!< Tool type ("function").
+    @rename = "function" _function : ToolCallFunction //!< The requested function + arguments.
 }
 
 struct ChatMessage {
     //! A single chat message. ``role`` is "system" | "user" | "assistant" | "tool".
-    role : string
-    content : string
-    @optional name : string
-    @optional tool_calls : array<ToolCall>
-    @optional tool_call_id : string
+    role : string                       //!< "system" | "user" | "assistant" | "tool".
+    content : string                    //!< Message text; may be empty when ``tool_calls`` is set.
+    @optional name : string             //!< Optional author name.
+    @optional tool_calls : array<ToolCall> //!< Tool calls the assistant is requesting.
+    @optional tool_call_id : string     //!< For ``role`` "tool": the id of the call this message answers.
 }
 
 struct ChatCompletionRequest {
     //! Request body for ``/chat/completions``. Default-valued optional fields are omitted on send.
-    model : string
-    messages : array<ChatMessage>
-    @optional temperature : float
-    @optional top_p : float
-    @optional n : int
-    @optional stream : bool
-    @optional max_tokens : int
-    @optional max_completion_tokens : int
-    @optional frequency_penalty : float
-    @optional presence_penalty : float
-    @optional seed : int
-    @optional stop : array<string>
-    @optional user : string
-    @optional @embed response_format : string
-    @optional tools : array<Tool>
-    @optional tool_choice : string
+    model : string                       //!< Chat model id.
+    messages : array<ChatMessage>        //!< The conversation, in order.
+    @optional temperature : float        //!< Sampling temperature.
+    @optional top_p : float              //!< Nucleus-sampling probability mass.
+    @optional n : int                    //!< Number of choices to generate.
+    @optional stream : bool              //!< Request a streamed response (set automatically by ``chat_stream``).
+    @optional max_tokens : int           //!< Maximum tokens to generate.
+    @optional max_completion_tokens : int //!< Newer cap on generated tokens.
+    @optional frequency_penalty : float  //!< Penalize tokens by how often they have appeared.
+    @optional presence_penalty : float   //!< Penalize tokens that already appeared at all.
+    @optional seed : int                 //!< Seed for (best-effort) deterministic sampling.
+    @optional stop : array<string>       //!< Stop sequences.
+    @optional user : string              //!< Optional end-user id for abuse monitoring.
+    @optional @embed response_format : string //!< JSON-mode format (see ``json_object_format``).
+    @optional tools : array<Tool>        //!< Tools the model may call.
+    @optional tool_choice : string       //!< Tool selection ("auto", "none", or a specific name).
 }
 
 struct ChatChoice {
-    index : int
-    message : ChatMessage
-    finish_reason : string
+    //! One completion choice.
+    index : int             //!< Index of this choice.
+    message : ChatMessage   //!< The assistant message.
+    finish_reason : string  //!< Why generation stopped ("stop", "length", "tool_calls", ...).
 }
 
 struct ChatCompletionResponse {
     //! Response body for a non-streaming ``/chat/completions`` call.
-    id : string
-    @rename = "object" _object : string
-    created : int64
-    model : string
-    choices : array<ChatChoice>
-    usage : Usage
+    id : string                          //!< Completion id.
+    @rename = "object" _object : string  //!< Object type ("chat.completion").
+    created : int64                      //!< Unix creation time.
+    model : string                       //!< Model that produced the response.
+    choices : array<ChatChoice>          //!< Generated choices.
+    usage : Usage                        //!< Token accounting.
 }
 
 struct ChatResult {
     //! Outcome of ``chat``: when ``ok`` is true ``response`` is valid, else inspect ``error``.
-    ok : bool
-    response : ChatCompletionResponse
-    error : OpenAIError
+    ok : bool                          //!< True when ``response`` is valid.
+    response : ChatCompletionResponse  //!< Decoded response on success.
+    error : OpenAIError                //!< Error detail on failure.
 }
 
 // ===== Streaming chat types =====
 
 struct ChatMessageDelta {
     //! Incremental message fields in a streamed chunk (object == "chat.completion.chunk").
-    @optional role : string
-    @optional content : string
+    @optional role : string     //!< Role, sent on the first delta.
+    @optional content : string  //!< Incremental text content.
 }
 
 struct ChunkChoice {
-    index : int
-    delta : ChatMessageDelta
-    @optional finish_reason : string
+    //! One choice within a streamed chunk.
+    index : int                     //!< Index of this choice.
+    delta : ChatMessageDelta        //!< Incremental message fields for this frame.
+    @optional finish_reason : string //!< Set on the final chunk for this choice.
 }
 
 struct ChatCompletionChunk {
     //! One streamed delta frame.
-    id : string
-    @rename = "object" _object : string
-    created : int64
-    model : string
-    choices : array<ChunkChoice>
+    id : string                          //!< Completion id (stable across chunks).
+    @rename = "object" _object : string  //!< Object type ("chat.completion.chunk").
+    created : int64                      //!< Unix creation time.
+    model : string                       //!< Model producing the stream.
+    choices : array<ChunkChoice>         //!< Incremental choices in this frame.
 }
 
 struct ChatStreamResult {
     //! Outcome of ``chat_stream``: ``content`` is the full accumulated assistant text.
-    ok : bool
-    content : string
-    finish_reason : string
-    error : OpenAIError
+    ok : bool               //!< True on a successful stream.
+    content : string        //!< Full accumulated assistant text.
+    finish_reason : string  //!< Why generation stopped.
+    error : OpenAIError     //!< Error detail on failure.
 }
 
 // ===== Chat =====

--- a/modules/dasOPENAI/openai/openai_common.das
+++ b/modules/dasOPENAI/openai/openai_common.das
@@ -21,11 +21,11 @@ require strings public
 
 struct OpenAIClient {
     //! Connection + auth config. Override ``base_url`` to target any OpenAI-compatible server.
-    base_url : string = "https://api.openai.com/v1"
-    api_key : string
-    organization : string
-    timeout_seconds : int = 60
-    default_model : string
+    base_url : string = "https://api.openai.com/v1"   //!< API base URL, no trailing slash.
+    api_key : string                                  //!< Bearer token; empty for servers that need no auth (e.g. local Ollama).
+    organization : string                             //!< Optional ``OpenAI-Organization`` header value; empty to omit.
+    timeout_seconds : int = 60                        //!< Per-request timeout in seconds; 0 disables it.
+    default_model : string                            //!< Optional default model id for convenience helpers.
 }
 
 def openai_client(base_url : string; api_key : string = "") : OpenAIClient {
@@ -37,11 +37,11 @@ def openai_client(base_url : string; api_key : string = "") : OpenAIClient {
 
 struct OpenAIError {
     //! Unified error. ``kind`` is "transport" | "http" | "api" | "decode".
-    kind : string
-    status : int
-    message : string
-    _type : string
-    code : string
+    kind : string       //!< Error category: "transport" | "http" | "api" | "decode"; empty means no error.
+    status : int        //!< HTTP status code, or 0 when the request never completed.
+    message : string    //!< Human-readable error message.
+    _type : string      //!< Provider error ``type``, when the server returned one.
+    code : string       //!< Provider error ``code``, when the server returned one.
 }
 
 struct private OpenAIErrorBody {
@@ -59,9 +59,9 @@ struct private OpenAIErrorEnvelope {
 
 struct Usage {
     //! Token accounting returned with most responses.
-    prompt_tokens : int
-    completion_tokens : int
-    total_tokens : int
+    prompt_tokens : int       //!< Tokens consumed by the prompt.
+    completion_tokens : int   //!< Tokens in the generated completion.
+    total_tokens : int        //!< Prompt + completion tokens.
 }
 
 // ===== Transport =====
@@ -69,18 +69,18 @@ struct Usage {
 
 struct HttpOutcome {
     //! Internal transport result of a JSON request (``post_json`` / ``get_json``).
-    ok : bool
-    status : int
-    body : string
-    error : OpenAIError
+    ok : bool            //!< True on a 2xx response.
+    status : int         //!< HTTP status code.
+    body : string        //!< Raw response body.
+    error : OpenAIError  //!< Populated when ``ok`` is false.
 }
 
 struct BytesOutcome {
     //! Internal transport result of a binary request (``post_for_bytes``).
-    ok : bool
-    status : int
-    bytes : array<uint8>
-    error : OpenAIError
+    ok : bool             //!< True on a 2xx response.
+    status : int          //!< HTTP status code.
+    bytes : array<uint8>  //!< Raw response bytes (e.g. audio).
+    error : OpenAIError   //!< Populated when ``ok`` is false.
 }
 
 def parse_error_body(status : int; body : string) : OpenAIError {

--- a/modules/dasOPENAI/openai/openai_completions.das
+++ b/modules/dasOPENAI/openai/openai_completions.das
@@ -10,38 +10,39 @@ require openai/openai_common public
 
 struct CompletionRequest {
     //! Request body for the legacy ``/completions`` endpoint.
-    model : string
-    prompt : string
-    @optional max_tokens : int
-    @optional temperature : float
-    @optional top_p : float
-    @optional n : int
-    @optional stop : array<string>
-    @optional seed : int
-    @optional user : string
+    model : string             //!< Completion model id.
+    prompt : string            //!< The prompt to complete.
+    @optional max_tokens : int //!< Maximum tokens to generate.
+    @optional temperature : float  //!< Sampling temperature.
+    @optional top_p : float    //!< Nucleus-sampling probability mass.
+    @optional n : int          //!< Number of completions to generate.
+    @optional stop : array<string>  //!< Stop sequences.
+    @optional seed : int       //!< Seed for (best-effort) deterministic sampling.
+    @optional user : string    //!< Optional end-user id for abuse monitoring.
 }
 
 struct CompletionChoice {
-    text : string
-    index : int
-    finish_reason : string
+    //! One generated completion.
+    text : string           //!< The completion text.
+    index : int             //!< Index of this choice.
+    finish_reason : string  //!< Why generation stopped (e.g. "stop", "length").
 }
 
 struct CompletionResponse {
     //! Response body for ``/completions``.
-    id : string
-    @rename = "object" _object : string
-    created : int64
-    model : string
-    choices : array<CompletionChoice>
-    usage : Usage
+    id : string                          //!< Completion id.
+    @rename = "object" _object : string  //!< Object type ("text_completion").
+    created : int64                      //!< Unix creation time.
+    model : string                       //!< Model that produced the completion.
+    choices : array<CompletionChoice>    //!< Generated choices.
+    usage : Usage                        //!< Token accounting.
 }
 
 struct CompletionResult {
     //! Outcome of ``completions``: ``response`` valid when ``ok`` is true.
-    ok : bool
-    response : CompletionResponse
-    error : OpenAIError
+    ok : bool                   //!< True when ``response`` is valid.
+    response : CompletionResponse  //!< Decoded response on success.
+    error : OpenAIError         //!< Error detail on failure.
 }
 
 def completions(client : OpenAIClient; req : CompletionRequest) : CompletionResult {

--- a/modules/dasOPENAI/openai/openai_embeddings.das
+++ b/modules/dasOPENAI/openai/openai_embeddings.das
@@ -11,37 +11,39 @@ require openai/openai_common public
 struct EmbeddingRequest {
     //! Request body for ``/embeddings``. ``input`` is always sent as an array of strings
     //! (a single string is just a one-element array).
-    model : string
-    input : array<string>
-    @optional encoding_format : string
-    @optional dimensions : int
-    @optional user : string
+    model : string                 //!< Embedding model id.
+    input : array<string>          //!< Texts to embed, one element per string.
+    @optional encoding_format : string  //!< "float" (default) or "base64".
+    @optional dimensions : int     //!< Optional output dimensionality, for models that support it.
+    @optional user : string        //!< Optional end-user id for abuse monitoring.
 }
 
 struct EmbeddingUsage {
-    prompt_tokens : int
-    total_tokens : int
+    //! Token accounting for an embeddings request.
+    prompt_tokens : int   //!< Tokens in the input.
+    total_tokens : int    //!< Total tokens billed.
 }
 
 struct EmbeddingData {
-    @rename = "object" _object : string
-    index : int
-    embedding : array<float>
+    //! One input's embedding.
+    @rename = "object" _object : string  //!< Object type ("embedding").
+    index : int                          //!< Position in the input array.
+    embedding : array<float>             //!< The embedding vector.
 }
 
 struct EmbeddingResponse {
     //! Response body for ``/embeddings``.
-    @rename = "object" _object : string
-    data : array<EmbeddingData>
-    model : string
-    usage : EmbeddingUsage
+    @rename = "object" _object : string  //!< Object type ("list").
+    data : array<EmbeddingData>          //!< One ``EmbeddingData`` per input, in order.
+    model : string                       //!< Model that produced the embeddings.
+    usage : EmbeddingUsage               //!< Token accounting.
 }
 
 struct EmbeddingResult {
     //! Outcome of ``embeddings``: when ``ok`` is true ``response`` is valid, else inspect ``error``.
-    ok : bool
-    response : EmbeddingResponse
-    error : OpenAIError
+    ok : bool                  //!< True when ``response`` is valid.
+    response : EmbeddingResponse  //!< Decoded response on success.
+    error : OpenAIError        //!< Error detail on failure.
 }
 
 def embeddings(client : OpenAIClient; req : EmbeddingRequest) : EmbeddingResult {

--- a/modules/dasOPENAI/openai/openai_images.das
+++ b/modules/dasOPENAI/openai/openai_images.das
@@ -10,33 +10,34 @@ require openai/openai_common public
 
 struct ImageRequest {
     //! Request body for ``/images/generations``.
-    prompt : string
-    @optional model : string
-    @optional n : int
-    @optional size : string
-    @optional quality : string
-    @optional style : string
-    @optional response_format : string
-    @optional user : string
+    prompt : string                      //!< Text description of the desired image.
+    @optional model : string             //!< Image model id.
+    @optional n : int                    //!< Number of images to generate.
+    @optional size : string              //!< Image dimensions (e.g. "1024x1024").
+    @optional quality : string           //!< Quality hint (e.g. "standard", "hd").
+    @optional style : string             //!< Style hint (e.g. "vivid", "natural").
+    @optional response_format : string   //!< "url" or "b64_json".
+    @optional user : string              //!< Optional end-user id for abuse monitoring.
 }
 
 struct ImageData {
-    @optional url : string
-    @optional b64_json : string
-    @optional revised_prompt : string
+    //! One generated image.
+    @optional url : string            //!< Image URL (when ``response_format`` is "url").
+    @optional b64_json : string       //!< Base64-encoded image (when ``response_format`` is "b64_json").
+    @optional revised_prompt : string //!< The prompt the model actually used, if it revised yours.
 }
 
 struct ImageResponse {
     //! Response body for ``/images/generations``.
-    created : int64
-    data : array<ImageData>
+    created : int64           //!< Unix creation time.
+    data : array<ImageData>   //!< Generated images.
 }
 
 struct ImageResult {
     //! Outcome of ``generate_image``: ``response`` valid when ``ok`` is true.
-    ok : bool
-    response : ImageResponse
-    error : OpenAIError
+    ok : bool              //!< True when ``response`` is valid.
+    response : ImageResponse  //!< Decoded response on success.
+    error : OpenAIError    //!< Error detail on failure.
 }
 
 def generate_image(client : OpenAIClient; req : ImageRequest) : ImageResult {

--- a/modules/dasOPENAI/openai/openai_models.das
+++ b/modules/dasOPENAI/openai/openai_models.das
@@ -10,10 +10,10 @@ require openai/openai_common public
 
 struct Model {
     //! A single model entry.
-    id : string
-    @rename = "object" _object : string
-    @optional created : int64
-    @optional owned_by : string
+    id : string                          //!< Model id (e.g. "gpt-4o-mini").
+    @rename = "object" _object : string  //!< Object type ("model").
+    @optional created : int64            //!< Unix creation time, when provided.
+    @optional owned_by : string          //!< Owning organization, when provided.
 }
 
 struct private ModelList {
@@ -23,16 +23,16 @@ struct private ModelList {
 
 struct ModelsResult {
     //! Outcome of ``list_models``: ``models`` valid when ``ok`` is true.
-    ok : bool
-    models : array<Model>
-    error : OpenAIError
+    ok : bool             //!< True when ``models`` is valid.
+    models : array<Model>  //!< Available models on success.
+    error : OpenAIError   //!< Error detail on failure.
 }
 
 struct ModelResult {
     //! Outcome of ``retrieve_model``: ``model`` valid when ``ok`` is true.
-    ok : bool
-    model : Model
-    error : OpenAIError
+    ok : bool            //!< True when ``model`` is valid.
+    model : Model        //!< The retrieved model on success.
+    error : OpenAIError  //!< Error detail on failure.
 }
 
 def list_models(client : OpenAIClient) : ModelsResult {

--- a/modules/dasOPENAI/openai/openai_moderations.das
+++ b/modules/dasOPENAI/openai/openai_moderations.das
@@ -10,30 +10,30 @@ require openai/openai_common public
 
 struct ModerationRequest {
     //! Request body for ``/moderations``. ``input`` is always sent as an array of strings.
-    model : string
-    input : array<string>
+    model : string         //!< Moderation model id.
+    input : array<string>  //!< Texts to classify, one element per string.
 }
 
 struct ModerationCategoryResult {
     //! One moderation verdict. ``categories`` and ``category_scores`` are keyed by category name
     //! (e.g. "violence", "hate/threatening"), so no per-category field declarations are needed.
-    flagged : bool
-    categories : table<string; bool>
-    category_scores : table<string; double>
+    flagged : bool                          //!< True if the input was flagged in any category.
+    categories : table<string; bool>        //!< Per-category boolean verdicts, keyed by category name.
+    category_scores : table<string; double> //!< Per-category confidence scores, keyed by category name.
 }
 
 struct ModerationResponse {
     //! Response body for ``/moderations``.
-    id : string
-    model : string
-    results : array<ModerationCategoryResult>
+    id : string                              //!< Moderation request id.
+    model : string                           //!< Model that produced the verdicts.
+    results : array<ModerationCategoryResult> //!< One verdict per input.
 }
 
 struct ModerationResult {
     //! Outcome of ``moderations``: ``response`` valid when ``ok`` is true.
-    ok : bool
-    response : ModerationResponse
-    error : OpenAIError
+    ok : bool                   //!< True when ``response`` is valid.
+    response : ModerationResponse  //!< Decoded response on success.
+    error : OpenAIError         //!< Error detail on failure.
 }
 
 def moderations(client : OpenAIClient; req : ModerationRequest) : ModerationResult {

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -83,6 +83,14 @@ install(FILES ${JSONRPC_TUTORIAL_SOURCES}
     DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/jsonrpc
 )
 
+# Install dasOPENAI tutorial .das files
+file(GLOB OPENAI_TUTORIAL_SOURCES
+    ${PROJECT_SOURCE_DIR}/tutorials/dasOPENAI/*.das
+)
+install(FILES ${OPENAI_TUTORIAL_SOURCES}
+    DESTINATION ${DAS_INSTALL_TUTORIALSDIR}/dasOPENAI
+)
+
 if (NOT ${DAS_TUTORIAL_DISABLED})
     include(integration/c/CMakeLists.txt)
     include(integration/cpp/CMakeLists.txt)
@@ -108,6 +116,10 @@ IF ((NOT ${DAS_SQLITE_DISABLED}) OR (NOT DEFINED DAS_STBIMAGE_DISABLED))
 ENDIF()
 IF ((NOT ${DAS_AUDIO_DISABLED}) OR (NOT DEFINED DAS_AUDIO_DISABLED))
     list(APPEND ALL_TUTORIAL_SOURCES ${AUDIO_TUTORIAL_SOURCES})
+ENDIF()
+# dasOPENAI tutorials require dasHV (HTTP transport); only dry-run them when HV is enabled.
+IF ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_DISABLED))
+    list(APPEND ALL_TUTORIAL_SOURCES ${OPENAI_TUTORIAL_SOURCES})
 ENDIF()
 
 add_custom_target(dry_run_tutorials)

--- a/tutorials/dasOPENAI/01_first_chat.das
+++ b/tutorials/dasOPENAI/01_first_chat.das
@@ -1,0 +1,92 @@
+// Tutorial OPENAI-01: Your First Chat
+//
+// This tutorial covers:
+//   - Constructing an OpenAIClient (base_url, optional API key)
+//   - The one-liner chat_text helper
+//   - The full chat() call: request, ChatResult, choices, usage
+//   - Handling OpenAIError
+//
+// Prerequisites: none (the tutorial runs against a local mock server)
+//
+// Every dasOPENAI script needs `options rtti` — without it the @optional /
+// @rename field annotations are ignored and requests serialize every field,
+// which real OpenAI-compatible servers reject.
+//
+// To talk to a real server instead of the mock, point base_url at it and pass
+// the key, e.g.:
+//   let client = openai_client("https://api.openai.com/v1", get_env("OPENAI_API_KEY"))
+//
+// Run: daslang.exe tutorials/dasOPENAI/01_first_chat.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_chat
+require tutorial_openai_server
+
+let SERVER_PORT = 18190
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — The chat_text one-liner
+// ──────────────────────────────────────────────────────────────────────────
+//
+// chat_text is the simplest entry point: one user turn in, the assistant's
+// text out (empty string on error). Good for quick prompts and scripts.
+
+def example_chat_text(base_url : string) {
+    let client = openai_client(base_url)
+    let reply = chat_text(client, "mock-model", "Say hello in one short sentence.")
+    print("chat_text -> {reply}\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — The full chat() call
+// ──────────────────────────────────────────────────────────────────────────
+//
+// chat() takes a ChatCompletionRequest and returns a ChatResult. When ok is
+// true, response holds the decoded ChatCompletionResponse — choices, the
+// assistant message, and token usage. Otherwise inspect error.
+
+def example_chat_full(base_url : string) {
+    let client = openai_client(base_url)
+    let req = ChatCompletionRequest(model = "mock-model",
+        messages <- [ChatMessage(role = "user", content = "What is 2+2?")])
+    let res = chat(client, req)
+    if (res.ok) {
+        print("answer: {res.response.choices[0].message.content}\n")
+        print("model:  {res.response.model}\n")
+        print("tokens: {res.response.usage.total_tokens}\n")
+    } else {
+        print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Handling errors
+// ──────────────────────────────────────────────────────────────────────────
+//
+// A client pointed at an unreachable server produces a transport error rather
+// than crashing — ok is false and error.kind is "transport". The same shape
+// surfaces HTTP ("http"), API ("api"), and decode ("decode") failures.
+
+def example_error_handling() {
+    let client = openai_client("http://127.0.0.1:1/v1")   // nothing listens here
+    let reply = chat_text(client, "mock-model", "this will fail")
+    print("unreachable server -> reply is empty: {empty(reply)}\n")
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== chat_text ===\n")
+        example_chat_text(base_url)
+
+        print("\n=== chat (full result) ===\n")
+        example_chat_full(base_url)
+
+        print("\n=== error handling ===\n")
+        example_error_handling()
+    }
+}

--- a/tutorials/dasOPENAI/02_conversations_and_params.das
+++ b/tutorials/dasOPENAI/02_conversations_and_params.das
@@ -1,0 +1,98 @@
+// Tutorial OPENAI-02: Conversations and Parameters
+//
+// This tutorial covers:
+//   - Multi-turn conversations: system / user / assistant message roles
+//   - Optional request parameters (temperature, max_tokens, seed, stop)
+//   - Reading token Usage from the response
+//
+// Prerequisites: Tutorial OPENAI-01 (client construction, chat())
+//
+// Run: daslang.exe tutorials/dasOPENAI/02_conversations_and_params.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_chat
+require tutorial_openai_server
+
+let SERVER_PORT = 18191
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Multi-turn conversations
+// ──────────────────────────────────────────────────────────────────────────
+//
+// A chat request carries the whole conversation as an ordered array of
+// messages. The model sees all prior turns. Roles:
+//   system    — instructions that set behavior
+//   user      — what the human said
+//   assistant — what the model previously replied
+//   tool      — a tool/function result (see Tutorial OPENAI-04)
+
+def example_conversation(base_url : string) {
+    let client = openai_client(base_url)
+    let req = ChatCompletionRequest(model = "mock-model", messages <- [
+        ChatMessage(role = "system", content = "You are a terse assistant."),
+        ChatMessage(role = "user", content = "Remember the number 7."),
+        ChatMessage(role = "assistant", content = "Got it — 7."),
+        ChatMessage(role = "user", content = "What number did I ask you to remember?")])
+    let res = chat(client, req)
+    if (res.ok) {
+        print("assistant: {res.response.choices[0].message.content}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Optional parameters
+// ──────────────────────────────────────────────────────────────────────────
+//
+// ChatCompletionRequest exposes the common knobs as @optional fields. Because
+// `options rtti` is set, default-valued optionals are omitted from the wire —
+// only the ones you set are sent. Set them with named arguments.
+
+def example_parameters(base_url : string) {
+    let client = openai_client(base_url)
+    let req = ChatCompletionRequest(model = "mock-model",
+        messages <- [ChatMessage(role = "user", content = "Write one word.")],
+        temperature = 0.2,
+        max_tokens = 16,
+        seed = 42,
+        stop <- ["\n\n"])
+    let res = chat(client, req)
+    if (res.ok) {
+        print("reply: {res.response.choices[0].message.content}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Token usage
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Most responses include a Usage breakdown — prompt, completion, and total
+// tokens. Useful for cost tracking and staying within context limits.
+
+def example_usage(base_url : string) {
+    let client = openai_client(base_url)
+    let req = ChatCompletionRequest(model = "mock-model",
+        messages <- [ChatMessage(role = "user", content = "Hello.")])
+    let res = chat(client, req)
+    if (res.ok) {
+        let u = res.response.usage
+        print("prompt={u.prompt_tokens} completion={u.completion_tokens} total={u.total_tokens}\n")
+    }
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== multi-turn conversation ===\n")
+        example_conversation(base_url)
+
+        print("\n=== optional parameters ===\n")
+        example_parameters(base_url)
+
+        print("\n=== token usage ===\n")
+        example_usage(base_url)
+    }
+}

--- a/tutorials/dasOPENAI/03_structured_outputs.das
+++ b/tutorials/dasOPENAI/03_structured_outputs.das
@@ -1,0 +1,70 @@
+// Tutorial OPENAI-03: Structured Outputs (JSON mode)
+//
+// This tutorial covers:
+//   - Asking the model for JSON with json_object_format()
+//   - Setting req.response_format
+//   - Decoding the returned JSON content into a typed struct with sscan_json
+//
+// Prerequisites: Tutorial OPENAI-01, OPENAI-02
+//
+// JSON mode tells the server to emit valid JSON as the message content. You
+// then decode that content string into your own struct — the same sscan_json
+// machinery the client uses internally.
+//
+// Run: daslang.exe tutorials/dasOPENAI/03_structured_outputs.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_chat
+require tutorial_openai_server
+
+let SERVER_PORT = 18192
+
+// The shape we expect the model to return. With `options rtti`, sscan_json
+// maps JSON object keys onto these fields.
+struct Answer {
+    answer : int
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Requesting JSON
+// ──────────────────────────────────────────────────────────────────────────
+//
+// json_object_format() returns the response_format value for JSON mode.
+// Assign it to the request's response_format field. (The field is @embed, so
+// the helper hands you the exact JSON the server expects.)
+
+def example_json_mode(base_url : string) {
+    let client = openai_client(base_url)
+    var req = ChatCompletionRequest(model = "mock-model",
+        messages <- [ChatMessage(role = "user",
+            content = "Return the answer to 6*7 as JSON: \{\"answer\": N\}.")])
+    req.response_format = json_object_format()
+
+    let res = chat(client, req)
+    if (!res.ok) {
+        print("error: {res.error.message}\n")
+        return
+    }
+    let content = res.response.choices[0].message.content
+    print("raw JSON content: {content}\n")
+
+    // ── Section 2 — decode the content into our struct ──
+    var parsed : Answer
+    if (sscan_json(content, parsed)) {
+        print("decoded answer = {parsed.answer}\n")
+    } else {
+        print("could not decode content as Answer\n")
+    }
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== JSON mode ===\n")
+        example_json_mode(base_url)
+    }
+}

--- a/tutorials/dasOPENAI/04_tools_and_function_calling.das
+++ b/tutorials/dasOPENAI/04_tools_and_function_calling.das
@@ -1,0 +1,81 @@
+// Tutorial OPENAI-04: Tools and Function Calling
+//
+// This tutorial covers:
+//   - Declaring a Tool (a function the model may call)
+//   - Sending tools with a chat request
+//   - Reading back the model's ToolCall (name + JSON arguments)
+//   - Completing the round trip: feed the tool result back as a "tool" message
+//
+// Prerequisites: Tutorial OPENAI-01, OPENAI-02
+//
+// Function calling lets the model ask your program to run a function. The model
+// does not run anything itself — it returns a tool_calls request, you execute
+// it, and you send the result back so the model can use it.
+//
+// Run: daslang.exe tutorials/dasOPENAI/04_tools_and_function_calling.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_chat
+require tutorial_openai_server
+
+let SERVER_PORT = 18193
+
+// A weather tool. `parameters` is a raw JSON-schema string describing the
+// function's arguments — the model fills it in when it decides to call.
+def weather_tool() : Tool {
+    let params = ("\{\"type\":\"object\"," +
+        "\"properties\":\{\"location\":\{\"type\":\"string\"\}\}," +
+        "\"required\":[\"location\"]\}")
+    return Tool(_type = "function",
+        _function = FunctionDef(name = "get_weather",
+            description = "Get the current weather for a location",
+            parameters = params))
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        let client = openai_client(base_url)
+
+        // ── Section 1 — send the tools, read the tool call ──
+        print("=== model requests a tool call ===\n")
+        let req = ChatCompletionRequest(model = "mock-model",
+            messages <- [ChatMessage(role = "user", content = "What's the weather in Paris?")],
+            tools <- [weather_tool()])
+        let res = chat(client, req)
+        if (!res.ok) {
+            print("error: {res.error.message}\n")
+            return
+        }
+        // When the model wants a tool, content is empty and tool_calls is set.
+        // (Some servers send content:null here — sscan_json decodes that fine.)
+        if (empty(res.response.choices[0].message.tool_calls)) {
+            print("model replied directly: {res.response.choices[0].message.content}\n")
+            return
+        }
+        let tcall = res.response.choices[0].message.tool_calls[0]
+        print("tool call id={tcall.id} name={tcall._function.name}\n")
+        print("arguments: {tcall._function.arguments}\n")
+
+        // ── Section 2 — run the tool, send the result back ──
+        // We "execute" get_weather locally and return its result as a message
+        // with role "tool", tagged with the tool_call_id the model gave us.
+        print("\n=== send the tool result back ===\n")
+        let req2 = ChatCompletionRequest(model = "mock-model", messages <- [
+            ChatMessage(role = "user", content = "What's the weather in Paris?"),
+            ChatMessage(role = "assistant", content = "",
+                tool_calls <- [ToolCall(id = tcall.id, _type = "function",
+                    _function = ToolCallFunction(name = tcall._function.name,
+                        arguments = tcall._function.arguments))]),
+            ChatMessage(role = "tool", tool_call_id = tcall.id,
+                content = "\{\"temp_c\":18,\"sky\":\"clear\"\}")])
+        let res2 = chat(client, req2)
+        if (res2.ok) {
+            print("final answer: {res2.response.choices[0].message.content}\n")
+        }
+    }
+}

--- a/tutorials/dasOPENAI/05_embeddings_and_models.das
+++ b/tutorials/dasOPENAI/05_embeddings_and_models.das
@@ -1,0 +1,102 @@
+// Tutorial OPENAI-05: Embeddings and Models
+//
+// This tutorial covers:
+//   - Embedding text into vectors with embed()
+//   - Comparing vectors with cosine similarity
+//   - Listing models (list_models) and retrieving one (retrieve_model)
+//   - Why model ids are percent-encoded in the URL path
+//
+// Prerequisites: Tutorial OPENAI-01
+//
+// Run: daslang.exe tutorials/dasOPENAI/05_embeddings_and_models.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_embeddings
+require openai/openai_models
+require openai/openai_common   // percent_encode
+require tutorial_openai_server
+require math
+
+let SERVER_PORT = 18194
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Embeddings and cosine similarity
+// ──────────────────────────────────────────────────────────────────────────
+//
+// embed() turns a string into a vector of floats. Semantically similar texts
+// produce vectors that point in similar directions — measured by cosine
+// similarity (1.0 = identical direction, 0.0 = orthogonal).
+//
+// (The mock returns a fixed vector, so the similarity here is 1.0; against a
+// real embeddings model the value reflects actual semantic closeness.)
+
+def cosine(a, b : array<float>) : float {
+    if (length(a) != length(b) || empty(a)) return 0.0
+    var dot = 0.0
+    var na = 0.0
+    var nb = 0.0
+    for (i in range(length(a))) {
+        dot += a[i] * b[i]
+        na += a[i] * a[i]
+        nb += b[i] * b[i]
+    }
+    return dot / (sqrt(na) * sqrt(nb))
+}
+
+def example_embeddings(base_url : string) {
+    let client = openai_client(base_url)
+    let v1 = embed(client, "mock-embed", "a cat sat on the mat")
+    let v2 = embed(client, "mock-embed", "the feline rested on the rug")
+    print("vector length: {length(v1)}\n")
+    print("cosine similarity: {cosine(v1, v2)}\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Listing and retrieving models
+// ──────────────────────────────────────────────────────────────────────────
+
+def example_models(base_url : string) {
+    let client = openai_client(base_url)
+    let list = list_models(client)
+    if (list.ok) {
+        print("available models:\n")
+        for (m in list.models) {
+            print("  {m.id} (owned_by {m.owned_by})\n")
+        }
+    }
+    let one = retrieve_model(client, "mock-model")
+    if (one.ok) {
+        print("retrieved: {one.model.id}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Percent-encoded model ids
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Many providers use model ids with slashes (e.g. "google/gemma-2:free").
+// retrieve_model percent-encodes the id so the '/' is not parsed as extra
+// path segments. percent_encode is the helper that does it.
+
+def example_percent_encode() {
+    let id = "google/gemma-2:free"
+    print("{id} -> {percent_encode(id)}\n")
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== embeddings ===\n")
+        example_embeddings(base_url)
+
+        print("\n=== models ===\n")
+        example_models(base_url)
+
+        print("\n=== percent-encoded ids ===\n")
+        example_percent_encode()
+    }
+}

--- a/tutorials/dasOPENAI/06_audio.das
+++ b/tutorials/dasOPENAI/06_audio.das
@@ -1,0 +1,77 @@
+// Tutorial OPENAI-06: Audio (speech and transcription)
+//
+// This tutorial covers:
+//   - Text-to-speech: speak() returns raw audio bytes
+//   - Writing audio bytes to a file
+//   - Speech-to-text: transcribe() uploads an audio file and returns text
+//
+// Prerequisites: Tutorial OPENAI-01
+//
+// Run: daslang.exe tutorials/dasOPENAI/06_audio.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_audio
+require tutorial_openai_server
+require daslib/fio
+
+let SERVER_PORT = 18195
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Text to speech
+// ──────────────────────────────────────────────────────────────────────────
+//
+// speak() synthesizes text into audio and returns the raw bytes
+// (array<uint8>, empty on error). Write them to a file to play later, or
+// stream them onward. The byte format is whatever the server produced.
+
+def example_tts(base_url : string) {
+    let client = openai_client(base_url)
+    var audio <- speak(client, "mock-tts", "alloy", "Hello from daslang.")
+    print("received {length(audio)} audio bytes\n")
+
+    let path = "tutorial_tts_out.wav"
+    fopen(path, "wb") $(f) {
+        fwrite(f, audio)
+    }
+    print("wrote {path}\n")
+    remove(path)
+    delete audio
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Speech to text
+// ──────────────────────────────────────────────────────────────────────────
+//
+// transcribe() uploads an audio file (multipart) and returns the recognized
+// text. Here we make a throwaway input file; against a real server you would
+// pass a genuine recording.
+
+def example_stt(base_url : string) {
+    let client = openai_client(base_url)
+    let path = "tutorial_stt_in.wav"
+    fopen(path, "wb") $(f) {
+        fwrite(f, "fake wav bytes for the mock server")
+    }
+    let res = transcribe(client, "whisper-1", path)
+    remove(path)
+    if (res.ok) {
+        print("transcript: {res.text}\n")
+    } else {
+        print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+    }
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== text to speech ===\n")
+        example_tts(base_url)
+
+        print("\n=== speech to text ===\n")
+        example_stt(base_url)
+    }
+}

--- a/tutorials/dasOPENAI/07_streaming_chat.das
+++ b/tutorials/dasOPENAI/07_streaming_chat.das
@@ -1,0 +1,63 @@
+// Tutorial OPENAI-07: Streaming Chat
+//
+// This tutorial covers:
+//   - Streaming a chat response with chat_stream
+//   - The on_delta block: handling text increments as they arrive
+//   - The accumulated content and finish_reason in ChatStreamResult
+//
+// Prerequisites: Tutorial OPENAI-01, OPENAI-02
+//
+// Streaming delivers the assistant's reply token-by-token over Server-Sent
+// Events instead of waiting for the whole response. chat_stream invokes your
+// on_delta block for each text increment and also accumulates the full text.
+//
+// Scope: chat_stream accumulates text deltas (choices[0].delta.content) only.
+// Streamed tool/function calls are a separate, later feature — for tool calls
+// use the non-streaming chat() from Tutorial OPENAI-04.
+//
+// Run: daslang.exe tutorials/dasOPENAI/07_streaming_chat.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_chat
+require tutorial_openai_server
+
+let SERVER_PORT = 18196
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Streaming with on_delta
+// ──────────────────────────────────────────────────────────────────────────
+//
+// chat_stream sets stream=true for you. Each text increment is passed to the
+// on_delta block (here we print it immediately, so the reply appears as it
+// streams). The return value carries the full accumulated content.
+
+def example_stream(base_url : string) {
+    let client = openai_client(base_url)
+    var req = ChatCompletionRequest(model = "mock-model",
+        messages <- [ChatMessage(role = "user", content = "Stream a short greeting.")])
+
+    print("live: ")
+    let result = chat_stream(client, req) $(delta : string) {
+        print(delta)   // each increment, as it arrives
+    }
+    print("\n")
+
+    if (result.ok) {
+        print("accumulated: {result.content}\n")
+        print("finish_reason: {result.finish_reason}\n")
+    } else {
+        print("error [{result.error.kind}/{result.error.status}]: {result.error.message}\n")
+    }
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== streaming chat ===\n")
+        example_stream(base_url)
+    }
+}

--- a/tutorials/dasOPENAI/tutorial_openai_server.das
+++ b/tutorials/dasOPENAI/tutorial_openai_server.das
@@ -1,0 +1,206 @@
+// Shared mock OpenAI-compatible server for dasOPENAI tutorials
+//
+// Provides a self-contained HTTP server on localhost that speaks the OpenAI
+// REST surface (chat, embeddings, models, audio, completions) with canned
+// responses, so the tutorials run end-to-end without a live LLM backend.
+//
+// Responses are built from the same typed openai_* structs the client decodes
+// into (via sprint_json), so the mock and the real API agree on wire shape.
+//
+// Endpoints (all under /v1):
+//   POST /chat/completions      — plain reply; or tool_calls / JSON-mode / SSE
+//                                 stream depending on the request body
+//   POST /embeddings            — a small canned embedding vector
+//   GET  /models, /models/:id   — canned model list / single model
+//   POST /audio/speech          — canned audio bytes
+//   POST /audio/transcriptions  — canned transcription text
+//   POST /completions           — canned legacy completion
+//
+// Usage:
+//   require tutorial_openai_server
+//
+//   [export]
+//   def main() {
+//       with_openai_server(18190) $(base_url) {
+//           let client = openai_client(base_url)
+//           ...
+//       }
+//   }
+//
+// Lifecycle (thread + tick loop + shutdown) mirrors tutorials/dasHV/tutorial_server.das.
+
+options gen2
+options rtti   // build canned responses from the typed openai structs via sprint_json
+
+require dashv/dashv_boost public
+require daslib/jobque_boost
+require daslib/fio
+require daslib/json_boost
+require daslib/strings_boost
+require openai/openai_chat public
+require openai/openai_embeddings public
+require openai/openai_models public
+require openai/openai_completions public
+
+// ──────────────────────────────────────────────────────────────────────────
+// Canned response builders
+// ──────────────────────────────────────────────────────────────────────────
+
+// ModelList is private in openai_models, so wrap the list locally.
+struct private MockModelList {
+    @rename = "object" _object : string
+    data : array<Model>
+}
+
+def private sse_frame(json : string) : string {
+    return "data: {json}\n\n"
+}
+
+def private mock_chat_json(content : string) : string {
+    let r = ChatCompletionResponse(id = "chatcmpl-mock", _object = "chat.completion",
+        created = 0, model = "mock-model",
+        choices <- [ChatChoice(index = 0,
+            message <- ChatMessage(role = "assistant", content = content),
+            finish_reason = "stop")],
+        usage = Usage(prompt_tokens = 9, completion_tokens = 7, total_tokens = 16))
+    return sprint_json(r, false)
+}
+
+def private mock_tool_call_json() : string {
+    let r = ChatCompletionResponse(id = "chatcmpl-mock", _object = "chat.completion",
+        created = 0, model = "mock-model",
+        choices <- [ChatChoice(index = 0,
+            message <- ChatMessage(role = "assistant", content = "",
+                tool_calls <- [ToolCall(id = "call_mock_1", _type = "function",
+                    _function = ToolCallFunction(name = "get_weather",
+                        arguments = "\{\"location\":\"Paris\"\}"))]),
+            finish_reason = "tool_calls")],
+        usage = Usage(prompt_tokens = 12, completion_tokens = 8, total_tokens = 20))
+    return sprint_json(r, false)
+}
+
+def private mock_stream_body() : string {
+    let words = ["Hello", " from", " the", " mock", " stream."]
+    var frames : array<string>
+    frames |> reserve(length(words) + 2)
+    for (w in words) {
+        let chunk = ChatCompletionChunk(id = "chatcmpl-mock", _object = "chat.completion.chunk",
+            created = 0, model = "mock-model",
+            choices <- [ChunkChoice(index = 0, delta = ChatMessageDelta(content = w))])
+        frames |> push(sse_frame(sprint_json(chunk, false)))
+    }
+    let fin = ChatCompletionChunk(id = "chatcmpl-mock", _object = "chat.completion.chunk",
+        created = 0, model = "mock-model",
+        choices <- [ChunkChoice(index = 0, delta = ChatMessageDelta(), finish_reason = "stop")])
+    frames |> push(sse_frame(sprint_json(fin, false)))
+    frames |> push("data: [DONE]\n\n")
+    let body = join(frames, "")
+    delete frames
+    return body
+}
+
+def private mock_embedding_json() : string {
+    let r = EmbeddingResponse(_object = "list",
+        data <- [EmbeddingData(_object = "embedding", index = 0,
+            embedding <- [0.10, 0.20, 0.30, 0.40])],
+        model = "mock-embed", usage = EmbeddingUsage(prompt_tokens = 4, total_tokens = 4))
+    return sprint_json(r, false)
+}
+
+def private mock_models_json() : string {
+    let ml = MockModelList(_object = "list",
+        data <- [Model(id = "mock-model", _object = "model", owned_by = "mock"),
+                 Model(id = "mock-embed", _object = "model", owned_by = "mock")])
+    return sprint_json(ml, false)
+}
+
+def private mock_model_json(id : string) : string {
+    let m = Model(id = id, _object = "model", owned_by = "mock")
+    return sprint_json(m, false)
+}
+
+def private mock_completion_json() : string {
+    let r = CompletionResponse(id = "cmpl-mock", _object = "text_completion",
+        created = 0, model = "mock-model",
+        choices <- [CompletionChoice(text = " a mock completion.", index = 0, finish_reason = "stop")],
+        usage = Usage(prompt_tokens = 5, completion_tokens = 4, total_tokens = 9))
+    return sprint_json(r, false)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Server
+// ──────────────────────────────────────────────────────────────────────────
+
+class MockOpenAIServer : HvWebServer {
+    def override onInit {
+        // Chat: branch on the request body the client sent.
+        POST("/v1/chat/completions") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            let body = string(req.body)
+            if (find(body, "\"stream\":true") >= 0) {
+                set_header(resp, "Content-Type", "text/event-stream")
+                return resp |> TEXT_PLAIN(mock_stream_body())
+            }
+            if (find(body, "\"tools\":") >= 0) {
+                return resp |> JSON(mock_tool_call_json())
+            }
+            if (find(body, "\"response_format\":") >= 0) {
+                return resp |> JSON(mock_chat_json("\{\"answer\":42\}"))
+            }
+            return resp |> JSON(mock_chat_json("Hello! This is a mock reply."))
+        }
+        POST("/v1/embeddings") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> JSON(mock_embedding_json())
+        }
+        GET("/v1/models") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> JSON(mock_models_json())
+        }
+        GET("/v1/models/:id") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> JSON(mock_model_json(get_param(req, "id")))
+        }
+        POST("/v1/audio/speech") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            // Canned "audio" bytes — the client returns the body as array<uint8>.
+            return resp |> TEXT_PLAIN("RIFFmock....WAVEmock-audio-bytes")
+        }
+        POST("/v1/audio/transcriptions") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> JSON("\{\"text\":\"a mock transcription of the audio\"\}")
+        }
+        POST("/v1/completions") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> JSON(mock_completion_json())
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Lifecycle helper — runs the server on a worker thread, invokes blk with the
+// /v1 base URL, then shuts the thread down. Mirrors the dasHV tutorial server.
+// ──────────────────────────────────────────────────────────────────────────
+
+def with_openai_server(port : int; blk : block<(base_url : string) : void>) {
+    with_job_status(1) $(started) {
+        with_job_status(1) $(finished) {
+            with_atomic32() $(stop_flag) {
+                new_thread() @() {
+                    var server = new MockOpenAIServer()
+                    server->init(port)
+                    server->start()
+                    started |> notify_and_release
+                    while (stop_flag |> get == 0) {
+                        server->tick()
+                        sleep(10u)
+                    }
+                    server->stop()
+                    server->cleanup()
+                    unsafe {
+                        delete server
+                    }
+                    finished |> notify_and_release
+                }
+                started |> join
+                let base_url = "http://127.0.0.1:{port}/v1"
+                invoke(blk, base_url)
+                stop_flag |> set(1)
+                finished |> join
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the documentation + tutorial surface for the `dasOPENAI` module (merged in #2938), bringing it to parity with dasHV / jsonrpc. Follow-up PR (streaming tool-call reassembly + offline test) is tracked separately.

## What's here

- **7 hands-on tutorials** (`tutorials/dasOPENAI/01`–`07`) — client + first chat, conversations & parameters, structured outputs (JSON mode), tools / function calling, embeddings & models, audio (TTS/STT), and streaming chat.
- **Local mock server** (`tutorials/dasOPENAI/tutorial_openai_server.das`) — a tiny `HvWebServer` on a worker thread (modeled on `tutorials/dasHV/tutorial_server.das`) that builds canned responses from the typed `openai_*` structs via `sprint_json`, and branches the chat route on the request body (`stream` → SSE, `tools` → tool_calls, `response_format` → JSON mode). The tutorials run **fully offline**, so they need no live LLM in CI.
- **Paired RST pages** under `doc/source/reference/tutorials/` + a new `dasOPENAI` section in `tutorials.rst`.
- **CMake** — install rule + a dasHV-gated `-dry-run` compile gate in `tutorials/CMakeLists.txt` (the tutorials are compiled in CI when dasHV is enabled).
- **Generated stdlib reference page** — `document_module_openai` in `das2rst.das` folds all 9 `openai_*` modules into one `openai.rst`, wired into `sec_io.rst` and `introduction.rst` (+ handmade module header).
- **Per-field `//!<` doc-comments** on every public struct across the 9 modules (required by das2rst's strict-struct-fields; also improves IDE / MCP hover).

## Validation

| Check | Result |
|---|---|
| 7 tutorials run end-to-end vs the mock | 7/7 |
| `daslang -dry-run` (CI compile gate) | 8/8 clean |
| Lint (changed `.das`) | 0 issues |
| das2rst reference generation | 0 stubs, 0 Uncategorized |
| Clean Sphinx build | build succeeded, 0 warnings |
| Module sanity (`test_chat_stream`) | 6/6 |
| Format | clean |

Module `.das` changes are **comment-only** (per-field doc-comments) — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)