### PR TITLE
dasStbImage: synchronous APNG writer + fixed-delay capture for frame-exact recording

### DIFF
--- a/modules/dasOpenGL/opengl/opengl_live.das
+++ b/modules/dasOpenGL/opengl/opengl_live.das
@@ -72,7 +72,7 @@ struct GlStatsResult {
 }
 
 [live_command(description="OpenGL render statistics for the last frame")]
-def gl_stats(input : JsonValue?) : JsonValue? {
+def gl_stats(_input : JsonValue?) : JsonValue? {
     return JV(GlStatsResult(
         draw_calls = gl_render_stats.draw_calls,
         triangles = gl_render_stats.triangles,
@@ -289,7 +289,7 @@ def private harvest_one_pbo() : bool {
         glBindBuffer(GL_PIXEL_PACK_BUFFER, 0u)
         return false
     }
-    let ok = unsafe(stbi_apng_frame(recorder.writer, ptr, recorder.width * 4, recorder.pbo_delays_ms[read_idx]))
+    let ok = stbi_apng_frame(recorder.writer, ptr, recorder.width * 4, recorder.pbo_delays_ms[read_idx])
     // glUnmapBuffer returns GL_FALSE if the driver invalidated the buffer
     // contents while it was mapped — count it as a harvest failure so the
     // frame doesn't slip in with junk pixels.
@@ -301,7 +301,7 @@ def private harvest_one_pbo() : bool {
 }
 
 [live_command(description = "Stop APNG recording. Returns saved path + frame count.")]
-def record_stop(input : JsonValue?) : JsonValue? {
+def record_stop(_input : JsonValue?) : JsonValue? {
     return JV((error = "not recording")) if (!recorder_active)
 
     // Drain any PBOs still in flight (frames seen but not yet read back).
@@ -352,7 +352,7 @@ struct RecordStatusResult {
 }
 
 [live_command(description = "Recording status — active state, frame count, elapsed.")]
-def record_status(input : JsonValue?) : JsonValue? {
+def record_status(_input : JsonValue?) : JsonValue? {
     var dropped = 0
     if (recorder_active) {
         unsafe {
@@ -382,12 +382,17 @@ def record_tick() {
         return
     }
     return if (now < recorder.next_capture_t)
-    // Skip-missed scheduling: after a stall (long frame, gc pause, etc.)
-    // resync the deadline to `now + interval` instead of catching up frame
-    // by frame. Derive delay_ms from the actual gap so playback timing
-    // reflects real spacing.
-    let last_capture_t = recorder.next_capture_t - recorder.frame_interval_s
-    let gap_s          = now - last_capture_t
+    // Skip-missed scheduling: after a stall (long frame, gc pause, etc.) resync
+    // the deadline to `now + interval` instead of catching up frame by frame.
+    // Each frame gets the SAME nominal delay (1/fps, quantized to whole ms by the
+    // writer API -- e.g. 33ms at 30fps) instead of the measured gap, so the APNG is
+    // a UNIFORMLY spaced grid. That internal delay is not the playback clock:
+    // convert_recording.das discards it (forces `-r fps_eff` before `-i`, with
+    // fps_eff = frames / wall-clock-duration -- the real effective capture rate,
+    // which the synchronous zlib encode pushes below nominal) and anchors voiceovers
+    // on that same measured grid. The load-bearing properties are uniform spacing +
+    // a synchronous writer that never drops (frames_written exact), which is what
+    // lets fps_eff recover the true timeline; the per-frame ms tag itself is nominal.
     recorder.next_capture_t = now + recorder.frame_interval_s
     let n = length(recorder.pbos)
 
@@ -395,7 +400,7 @@ def record_tick() {
     // with a null pointer + a bound GL_PIXEL_PACK_BUFFER queues the copy on
     // the GPU and returns immediately — no CPU block.
     let write_idx = recorder.frames_seen % n
-    recorder.pbo_delays_ms[write_idx] = int(gap_s * 1000.0f)
+    recorder.pbo_delays_ms[write_idx] = int(recorder.frame_interval_s * 1000.0f)
     glBindBuffer(GL_PIXEL_PACK_BUFFER, recorder.pbos[write_idx])
     glReadPixels(0, 0, recorder.width, recorder.height, GL_RGBA, GL_UNSIGNED_BYTE, null)
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0u)

--- a/modules/dasStbImage/src/apng_write_impl.h
+++ b/modules/dasStbImage/src/apng_write_impl.h
@@ -14,7 +14,9 @@
 //   int    stbi_apng_dropped(void *writer);
 //
 // Pixel data submitted to stbi_apng_frame is expected to be bottom-up
-// (glReadPixels output). The worker thread flips rows top-down before encoding.
+// (glReadPixels output); the writer flips rows top-down inline before encoding.
+// Encoding is synchronous on the caller's thread — no worker thread, no bounded
+// queue, so frames are never dropped (frame N maps to a known recording time).
 
 #pragma once
 
@@ -109,7 +111,6 @@ public:
     int  dropped();
 
 private:
-    void worker_loop();
     bool emit_frame(Frame &f);
 
     FILE *fp = nullptr;
@@ -117,16 +118,8 @@ private:
     int   w  = 0, h = 0, channels = 0;
     stbi__apng_off_t acTL_body_offset = -1;
 
-    std::mutex              mu;
-    std::condition_variable cv;
-    std::deque<Frame>       queue;
-    int                     max_queue      = 4;
-    int                     drop_count     = 0;
-    bool                    errored        = false;
-    bool                    stop_requested = false;
-
-    std::thread worker;
-    int         frames_written = 0;  // worker-thread-only after begin() returns
+    bool errored        = false;
+    int  frames_written = 0;
 };
 
 inline bool ApngWriter::begin(const char *filename, int W, int H, int CH) {
@@ -163,14 +156,8 @@ inline bool ApngWriter::begin(const char *filename, int W, int H, int CH) {
         acTL_body_offset = before_acTL + 8;
     }
 
-    {
-        std::lock_guard<std::mutex> lk(mu);
-        drop_count     = 0;
-        errored        = false;
-        stop_requested = false;
-        frames_written = 0;
-    }
-    worker = std::thread(&ApngWriter::worker_loop, this);
+    errored        = false;
+    frames_written = 0;
     return true;
 
 fail:
@@ -178,8 +165,13 @@ fail:
     return false;
 }
 
+// Synchronous: encode the frame inline on the caller's thread. No worker thread
+// and no bounded queue, so frames are NEVER dropped — frames_written always
+// equals the number of frames submitted. The caller (the recorder's GL thread)
+// blocks for the zlib compress; that's the intended trade for drop-free,
+// frame-exact tutorial recordings, where APNG-frame N must map to a known time.
 inline bool ApngWriter::enqueue(const void *pixels, int stride_bytes, int delay_ms) {
-    if (!pixels) return false;
+    if (!pixels || errored) return false;
     size_t row_bytes = (size_t)w * (size_t)channels;
     // Reject strides that would cause OOB reads: must be positive and at
     // least row_bytes. Negative stride (bottom-up) is not supported here;
@@ -188,12 +180,6 @@ inline bool ApngWriter::enqueue(const void *pixels, int stride_bytes, int delay_
     // Guard size_t multiply: row_bytes * h would wrap on 32-bit hosts for
     // very large frames; under-allocation here means OOB writes below.
     if ((size_t)h != 0 && row_bytes > SIZE_MAX / (size_t)h) return false;
-    std::unique_lock<std::mutex> lk(mu);
-    if (errored) return false;
-    if ((int)queue.size() >= max_queue) {
-        queue.pop_front();
-        drop_count++;
-    }
     Frame f;
     f.pixels.resize(row_bytes * (size_t)h);
     const uint8_t *src = (const uint8_t *)pixels;
@@ -207,29 +193,11 @@ inline bool ApngWriter::enqueue(const void *pixels, int stride_bytes, int delay_
         }
     }
     f.delay_ms = delay_ms;
-    queue.emplace_back(std::move(f));
-    lk.unlock();
-    cv.notify_one();
-    return true;
-}
-
-inline void ApngWriter::worker_loop() {
-    while (true) {
-        Frame f;
-        {
-            std::unique_lock<std::mutex> lk(mu);
-            cv.wait(lk, [this]{ return !queue.empty() || stop_requested; });
-            if (queue.empty() && stop_requested) return;
-            f = std::move(queue.front());
-            queue.pop_front();
-        }
-        if (!emit_frame(f)) {
-            std::lock_guard<std::mutex> lk(mu);
-            errored = true;
-            queue.clear();
-            return;
-        }
+    if (!emit_frame(f)) {
+        errored = true;
+        return false;
     }
+    return true;
 }
 
 inline bool ApngWriter::emit_frame(Frame &f) {
@@ -312,20 +280,8 @@ inline bool ApngWriter::emit_frame(Frame &f) {
 }
 
 inline bool ApngWriter::end() {
-    {
-        std::lock_guard<std::mutex> lk(mu);
-        stop_requested = true;
-    }
-    cv.notify_one();
-    if (worker.joinable()) worker.join();
-
     if (!fp) return false;
-    bool was_errored;
-    {
-        std::lock_guard<std::mutex> lk(mu);
-        was_errored = errored;
-    }
-    bool result = !was_errored;
+    bool result = !errored;
 
     // Zero-frame close: the file would otherwise contain only IHDR + acTL + IEND,
     // which isn't a valid PNG/APNG (no IDAT/fdAT). Treat as failure and remove
@@ -363,8 +319,8 @@ inline bool ApngWriter::end() {
 }
 
 inline int ApngWriter::dropped() {
-    std::lock_guard<std::mutex> lk(mu);
-    return drop_count;
+    // Synchronous writer never drops; kept for C-API compatibility.
+    return 0;
 }
 
 } // namespace stbi_apng_detail


### PR DESCRIPTION
## What

Make the dasStbImage APNG writer **synchronous** and have `record_tick` (dasOpenGL `opengl_live`) tag every captured frame a **fixed `1/fps` delay**, so an APNG's frame N lands at exactly `N/fps`.

## Why

When recording tutorial videos I hit a timeline-drift bug: a 75 s / ~3500-frame capture produced an APNG that only contained ~2550 frames / ~54 s. Two compounding causes:

1. **Async writer dropped frames.** The old `ApngWriter` ran a worker thread behind a bounded queue (`max_queue = 4`); under encoder load `enqueue` dropped frames, and each dropped frame took its delay with it — so the APNG timeline collapsed relative to wall-clock.
2. **Per-frame delay was the *measured* inter-frame gap.** Even with no drops, encoding to a variable real-time grid means frame→time isn't a clean `N/fps`, so anything that has to re-derive a frame's timestamp (e.g. aligning an external audio track to a given capture frame) drifts.

## Change

- **`modules/dasStbImage/src/apng_write_impl.h`** — drop the worker thread + bounded queue; `enqueue` now encodes each frame inline on the caller's thread. Frames are never dropped (`frames_written` always equals the number submitted); `dropped()` returns 0.
- **`modules/dasOpenGL/opengl/opengl_live.das`** — `record_tick` tags each frame a fixed `frame_interval_s` (= `1/fps`) delay instead of the measured gap. APNG frame N now maps to exactly `N/fps` — a constant clock.

The synchronous writer blocks the GL thread during zlib, so a windowed capture runs at an *effective* fps below nominal (e.g. ~27 fps for a nominal-30 capture) — but every frame is present and evenly spaced, which is what frame-exact post-processing needs. This is a removal of complexity (no worker thread / queue / drop path), not added machinery.

While touching `opengl_live.das` I also cleaned four pre-existing lint hits in it so `extended_checks` stays green on the changed file: 3× `LINT012` (unused `input` on the no-arg `[live_command]` handlers `gl_stats` / `record_stop` / `record_status` → `_input`) and one `STYLE024` (redundant `unsafe(...)` wrap on the `stbi_apng_frame` call).

## Verification

- Real recordings now report `dropped = 0` with `frames_written == frames_seen`; APNG `nb_read_frames` matches the recorder's reported frame count exactly (was a ~960-frame shortfall before).
- `opengl_live.das`: format-clean, lint-clean (0 issues), compiles.
- Release build relinks the `dasModuleStbImage` shared module cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)