### PR TITLE
benchmarks/sql: drop the un-fused XML (m5) lane + column; relocate finalize_decs_emission to decs

### DIFF
--- a/benchmarks/sql/_common.das
+++ b/benchmarks/sql/_common.das
@@ -70,7 +70,7 @@ def public fixture_array(n : int) : array<Car> {
     return <- arr
 }
 
-// m5_xml lane: same Car schema, rows materialized from XML child elements via
+// XML fold lane (m5f): same Car schema, rows materialized from XML child elements via
 // from_xml_node. Attribute names match Car's fields; same deterministic row
 // generator as fixture_array so the XML lane is directly comparable. Built with
 // a string writer (not `+`) to keep fixture construction O(n).
@@ -112,7 +112,7 @@ struct public DecsDealer {
 
 def public fixture_decs(n : int) {
     restart()
-    create_entities(n) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+    create_entities(n) $(_eid : EntityId; i : int; var cmp : ComponentMap) {
         apply_decs_template(cmp, DecsCar(
             id = i + 1,
             name = "Car{i}",
@@ -127,7 +127,7 @@ def public fixture_decs(n : int) {
 // Cars + Dealers together for the decs join lane. Both archetypes co-exist in the same decs world; plan_decs_join builds an in-query hash from the smaller side (dealers) then walks the larger side (cars).
 def public fixture_decs_cars_and_dealers(n : int) {
     restart()
-    create_entities(n) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+    create_entities(n) $(_eid : EntityId; i : int; var cmp : ComponentMap) {
         apply_decs_template(cmp, DecsCar(
             id = i + 1,
             name = "Car{i}",
@@ -137,7 +137,7 @@ def public fixture_decs_cars_and_dealers(n : int) {
             dealer_id = (i % DEALER_COUNT) + 1
         ))
     }
-    create_entities(DEALER_COUNT) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+    create_entities(DEALER_COUNT) $(_eid : EntityId; i : int; var cmp : ComponentMap) {
         apply_decs_template(cmp, DecsDealer(
             id = i + 1,
             name = "Dealer{i}"
@@ -155,7 +155,7 @@ struct public DecsBrand {
 
 def public fixture_decs_brands(n : int) {
     restart()
-    create_entities(n) $(eid : EntityId; i : int; var cmp : ComponentMap) {
+    create_entities(n) $(_eid : EntityId; i : int; var cmp : ComponentMap) {
         apply_decs_template(cmp, DecsBrand(value = i % BRAND_COUNT))
     }
 }

--- a/benchmarks/sql/_update_results.das
+++ b/benchmarks/sql/_update_results.das
@@ -46,8 +46,8 @@ struct Config {
     help : bool
 }
 
-let LANES = ["m1", "m3f", "m4", "m5", "m5f"]
-let HEADERS = ["SQL (m1)", "Array (m3f)", "Decs (m4)", "XML (m5)", "XML fold (m5f)"]
+let LANES = ["m1", "m3f", "m4", "m5f"]
+let HEADERS = ["SQL (m1)", "Array (m3f)", "Decs (m4)", "XML fold (m5f)"]
 let BEGIN_MARKER = "<!-- BENCH:TABLES BEGIN -->"
 let END_MARKER = "<!-- BENCH:TABLES END -->"
 

--- a/benchmarks/sql/_update_results.das
+++ b/benchmarks/sql/_update_results.das
@@ -89,7 +89,12 @@ def build_table(cells : table<string; double>; families : array<string>) : strin
             w |> write(" {h} |")
         }
         w |> write("\n")
-        w |> write("|---|---:|---:|---:|---:|---:|\n")
+        // Generate the alignment row from HEADERS so it stays in sync when a lane is added/dropped.
+        w |> write("|---|")
+        for (_h in HEADERS) {
+            w |> write("---:|")
+        }
+        w |> write("\n")
         for (fam in families) {
             w |> write("| `{fam}` |")
             for (lane in LANES) {

--- a/benchmarks/sql/aggregate_match.das
+++ b/benchmarks/sql/aggregate_match.das
@@ -48,25 +48,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let total = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD)
-                |> aggregate(0, $(acc : int, c : Car) => acc + c.price))
-            b |> accept(total)
-            if (total == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 [benchmark]
 def aggregate_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -82,13 +63,6 @@ def aggregate_match_m4(b : B?) {
     run_m4(b, 100000)
 }
 
-[benchmark]
-def aggregate_match_m5(b : B?) {
-    run_m5(b, 100000)
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {

--- a/benchmarks/sql/all_match.das
+++ b/benchmarks/sql/all_match.das
@@ -44,23 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let yes = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _all(_.price < 9999)
-            b |> accept(yes)
-            if (!yes) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -91,11 +74,6 @@ def all_match_m3f(b : B?) {
 [benchmark]
 def all_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def all_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/any_match.das
+++ b/benchmarks/sql/any_match.das
@@ -44,23 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let yes = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _any(_.price > THRESHOLD)
-            b |> accept(yes)
-            if (!yes) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -91,11 +74,6 @@ def any_match_m3f(b : B?) {
 [benchmark]
 def any_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def any_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/average_aggregate.das
+++ b/benchmarks/sql/average_aggregate.das
@@ -41,23 +41,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let a = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(double(_.price)) |> average()
-            b |> accept(a)
-            if (a == 0.0lf) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -88,11 +71,6 @@ def average_aggregate_m3f(b : B?) {
 [benchmark]
 def average_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def average_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/bare_order_where.das
+++ b/benchmarks/sql/bare_order_where.das
@@ -52,32 +52,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                        |> _where(_.price > THRESHOLD)
-                        |> _order_by(_.price)
-                        |> to_array())
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -110,11 +84,6 @@ def bare_order_where_m3f(b : B?) {
 [benchmark]
 def bare_order_where_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def bare_order_where_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/chained_select_collapse.das
+++ b/benchmarks/sql/chained_select_collapse.das
@@ -38,29 +38,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.brand) |> _select(_ + 1) |> distinct() |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -86,11 +63,6 @@ def chained_select_collapse_m3f(b : B?) {
 [benchmark]
 def chained_select_collapse_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def chained_select_collapse_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/chained_where.das
+++ b/benchmarks/sql/chained_where.das
@@ -53,32 +53,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = (unsafe(from_xml_node(doc.document_element, type<Car>))
-                    |> _where(_.price > THRESHOLD)
-                    |> _where(_.year >= YEAR_FLOOR)
-                    |> count())
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +85,6 @@ def chained_where_m3f(b : B?) {
 [benchmark]
 def chained_where_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def chained_where_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/contains_match.das
+++ b/benchmarks/sql/contains_match.das
@@ -45,23 +45,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let yes = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.id) |> contains(TARGET_ID)
-            b |> accept(yes)
-            if (!yes) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -92,11 +75,6 @@ def contains_match_m3f(b : B?) {
 [benchmark]
 def contains_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def contains_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/count_aggregate.das
+++ b/benchmarks/sql/count_aggregate.das
@@ -44,23 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -91,11 +74,6 @@ def count_aggregate_m3f(b : B?) {
 [benchmark]
 def count_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def count_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_by_count.das
+++ b/benchmarks/sql/distinct_by_count.das
@@ -44,25 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _distinct_by(_.brand) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -93,11 +74,6 @@ def distinct_by_count_m3f(b : B?) {
 [benchmark]
 def distinct_by_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def distinct_by_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_by_order_take.das
+++ b/benchmarks/sql/distinct_by_order_take.das
@@ -58,27 +58,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.dealer_id) |> _order_by(_.price) |> take(TAKE_N) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +90,6 @@ def distinct_by_order_take_m3f(b : B?) {
 [benchmark]
 def distinct_by_order_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def distinct_by_order_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_by_order_to_array.das
+++ b/benchmarks/sql/distinct_by_order_to_array.das
@@ -55,27 +55,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.dealer_id) |> _order_by(_.price) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -108,11 +87,6 @@ def distinct_by_order_to_array_m3f(b : B?) {
 [benchmark]
 def distinct_by_order_to_array_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def distinct_by_order_to_array_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_count.das
+++ b/benchmarks/sql/distinct_count.das
@@ -45,25 +45,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.brand) |> distinct() |> to_array()
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -94,11 +75,6 @@ def distinct_count_m3f(b : B?) {
 [benchmark]
 def distinct_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def distinct_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_count_pred.das
+++ b/benchmarks/sql/distinct_count_pred.das
@@ -60,27 +60,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let c = from_xml_node(doc.document_element, type<Car>) |> _distinct_by(_.brand) |> count($(c) => c.year > THRESHOLD)
-                b |> accept(c)
-                if (c == 0) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -113,11 +92,6 @@ def distinct_count_pred_m3f(b : B?) {
 [benchmark]
 def distinct_count_pred_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def distinct_count_pred_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/distinct_take.das
+++ b/benchmarks/sql/distinct_take.das
@@ -52,27 +52,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _select(_.brand) |> distinct() |> take(TAKE_N) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -105,11 +84,6 @@ def distinct_take_m3f(b : B?) {
 [benchmark]
 def distinct_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def distinct_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/element_at_match.das
+++ b/benchmarks/sql/element_at_match.das
@@ -46,23 +46,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> element_at(INDEX)
-            b |> accept(row)
-            if (row.price == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -93,11 +76,6 @@ def element_at_match_m3f(b : B?) {
 [benchmark]
 def element_at_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def element_at_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/first_match.das
+++ b/benchmarks/sql/first_match.das
@@ -43,23 +43,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> first()
-            b |> accept(row)
-            if (row.price == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -90,11 +73,6 @@ def first_match_m3f(b : B?) {
 [benchmark]
 def first_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def first_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/first_or_default_match.das
+++ b/benchmarks/sql/first_or_default_match.das
@@ -47,24 +47,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> first_or_default(sentinel)
-            b |> accept(row)
-            if (row.id == SENTINEL_ID) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let sentinel = Car(id = SENTINEL_ID, name = "none", price = 0, brand = 0, year = 0, dealer_id = 0)
@@ -96,11 +78,6 @@ def first_or_default_match_m3f(b : B?) {
 [benchmark]
 def first_or_default_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def first_or_default_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_average.das
+++ b/benchmarks/sql/groupby_average.das
@@ -54,29 +54,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      AvgPrice = _._1 |> select($(c : Car) => c.price) |> average()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +88,6 @@ def groupby_average_m3f(b : B?) {
 [benchmark]
 def groupby_average_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_average_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_count.das
+++ b/benchmarks/sql/groupby_count.das
@@ -52,28 +52,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0, N = _._1 |> length))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -107,11 +85,6 @@ def groupby_count_m3f(b : B?) {
 [benchmark]
 def groupby_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_first.das
+++ b/benchmarks/sql/groupby_first.das
@@ -60,29 +60,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      FirstCar = _._1 |> first()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -117,11 +94,6 @@ def groupby_first_m3f(b : B?) {
 [benchmark]
 def groupby_first_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_first_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_having_count.das
+++ b/benchmarks/sql/groupby_having_count.das
@@ -56,29 +56,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _having(_._1 |> length >= 5)
-                          |> _select((Brand = _._0, N = _._1 |> length))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -113,11 +90,6 @@ def groupby_having_count_m3f(b : B?) {
 [benchmark]
 def groupby_having_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_having_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_having_hidden_sum.das
+++ b/benchmarks/sql/groupby_having_hidden_sum.das
@@ -58,27 +58,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _having(_._1 |> select($(c : Car) => c.price) |> sum > 50000)
-                          |> _select((Brand = _._0, N = _._1 |> length))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -113,11 +92,6 @@ def groupby_having_hidden_sum_m3f(b : B?) {
 [benchmark]
 def groupby_having_hidden_sum_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_having_hidden_sum_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_having_post_where.das
+++ b/benchmarks/sql/groupby_having_post_where.das
@@ -62,28 +62,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      Total = _._1 |> select($(c : Car) => c.price) |> sum()))
-                          |> _where(_.Total > THRESHOLD)
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -119,11 +97,6 @@ def groupby_having_post_where_m3f(b : B?) {
 [benchmark]
 def groupby_having_post_where_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_having_post_where_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_max.das
+++ b/benchmarks/sql/groupby_max.das
@@ -54,29 +54,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      MaxPrice = _._1 |> select($(c : Car) => c.price) |> max()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +88,6 @@ def groupby_max_m3f(b : B?) {
 [benchmark]
 def groupby_max_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_max_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_min.das
+++ b/benchmarks/sql/groupby_min.das
@@ -54,29 +54,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      MinPrice = _._1 |> select($(c : Car) => c.price) |> min()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +88,6 @@ def groupby_min_m3f(b : B?) {
 [benchmark]
 def groupby_min_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_min_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_multi_reducer.das
+++ b/benchmarks/sql/groupby_multi_reducer.das
@@ -60,29 +60,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      N = _._1 |> length,
-                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum(),
-                                      MaxPrice   = _._1 |> select($(c : Car) => c.price) |> max()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -119,11 +96,6 @@ def groupby_multi_reducer_m3f(b : B?) {
 [benchmark]
 def groupby_multi_reducer_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_multi_reducer_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_select_order.das
+++ b/benchmarks/sql/groupby_select_order.das
@@ -59,28 +59,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      Total = _._1 |> select($(c : Car) => c.price) |> sum()))
-                          |> _order_by(_.Total)
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -116,11 +94,6 @@ def groupby_select_order_m3f(b : B?) {
 [benchmark]
 def groupby_select_order_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_select_order_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_select_sum.das
+++ b/benchmarks/sql/groupby_select_sum.das
@@ -56,29 +56,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _select(_.price)
-                          |> _group_by(_ % 100)
-                          |> _select((K = _._0, S = _._1 |> sum()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -113,11 +90,6 @@ def groupby_select_sum_m3f(b : B?) {
 [benchmark]
 def groupby_select_sum_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_select_sum_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_sum.das
+++ b/benchmarks/sql/groupby_sum.das
@@ -54,29 +54,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +88,6 @@ def groupby_sum_m3f(b : B?) {
 [benchmark]
 def groupby_sum_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_sum_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_where_count.das
+++ b/benchmarks/sql/groupby_where_count.das
@@ -54,29 +54,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _where(_.price > 500)
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0, N = _._1 |> length))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -111,11 +88,6 @@ def groupby_where_count_m3f(b : B?) {
 [benchmark]
 def groupby_where_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_where_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/groupby_where_sum.das
+++ b/benchmarks/sql/groupby_where_sum.das
@@ -57,30 +57,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                          |> _where(_.price > 500)
-                          |> _group_by(_.brand)
-                          |> _select((Brand = _._0,
-                                      TotalPrice = _._1 |> select($(c : Car) => c.price) |> sum()))
-                          |> to_array())
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -116,11 +92,6 @@ def groupby_where_sum_m3f(b : B?) {
 [benchmark]
 def groupby_where_sum_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def groupby_where_sum_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/indexed_lookup.das
+++ b/benchmarks/sql/indexed_lookup.das
@@ -36,24 +36,6 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let key = n / 2
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}") {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.id == key) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let key = n / 2
@@ -106,11 +88,6 @@ def indexed_lookup_m3f(b : B?) {
 [benchmark]
 def indexed_lookup_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def indexed_lookup_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_count.das
+++ b/benchmarks/sql/join_count.das
@@ -58,30 +58,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
-// The mixed (iterator, array) _join resolves via the linq.das mixed overloads (#2931/#2932).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let dealers <- fixture_dealers_array()
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
-                                                                                    $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                                                                                    $(c : Car, d : Dealer) => (c.name, d.name))
-                                                                            |> count())
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let dealers <- fixture_dealers_array()
@@ -116,11 +92,6 @@ def join_count_m3f(b : B?) {
 [benchmark]
 def join_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def join_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_groupby_count.das
+++ b/benchmarks/sql/join_groupby_count.das
@@ -70,30 +70,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let dealers <- fixture_dealers_array()
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
-                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                                          $(c : Car, d : Dealer) => (Brand = c.brand, DealerId = d.id))
-                                 |> _group_by(_.Brand)
-                                 |> _select((Brand = _._0, N = _._1 |> count())))
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let dealers <- fixture_dealers_array()
@@ -129,11 +105,6 @@ def join_groupby_count_m3f(b : B?) {
 [benchmark]
 def join_groupby_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def join_groupby_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_groupby_to_array.das
+++ b/benchmarks/sql/join_groupby_to_array.das
@@ -70,31 +70,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let dealers <- fixture_dealers_array()
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let groups <- (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
-                                          $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                                          $(c : Car, _d : Dealer) => (Brand = c.brand, Price = c.price))
-                                 |> _group_by(_.Brand)
-                                 |> _select((Brand = _._0,
-                                             Total = _._1 |> select($(t : tuple<Brand : int; Price : int>) => t.Price) |> sum())))
-            b |> accept(groups)
-            if (empty(groups)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let dealers <- fixture_dealers_array()
@@ -131,11 +106,6 @@ def join_groupby_to_array_m3f(b : B?) {
 [benchmark]
 def join_groupby_to_array_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def join_groupby_to_array_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_select.das
+++ b/benchmarks/sql/join_select.das
@@ -59,29 +59,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let dealers <- fixture_dealers_array()
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
-                                        $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                                        $(c : Car, d : Dealer) => (CarName = c.name, DealerId = d.id))
-                               |> _select(_.CarName))
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let dealers <- fixture_dealers_array()
@@ -116,11 +93,6 @@ def join_select_m3f(b : B?) {
 [benchmark]
 def join_select_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def join_select_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/join_where_count.das
+++ b/benchmarks/sql/join_where_count.das
@@ -60,30 +60,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the XML iterator joined with the dealers array, un-fused.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let dealers <- fixture_dealers_array()
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> _join(dealers,
-                                    $(c : Car, d : Dealer) => c.dealer_id == d.id,
-                                    $(c : Car, d : Dealer) => (CarPrice = c.price, DealerId = d.id))
-                           |> _where(_.CarPrice > THRESHOLD)
-                           |> count())
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the XML iterator joined with the dealers array.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let dealers <- fixture_dealers_array()
@@ -119,11 +95,6 @@ def join_where_count_m3f(b : B?) {
 [benchmark]
 def join_where_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def join_where_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/last_match.das
+++ b/benchmarks/sql/last_match.das
@@ -45,23 +45,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> last()
-            b |> accept(row)
-            if (row.price == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -92,11 +75,6 @@ def last_match_m3f(b : B?) {
 [benchmark]
 def last_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def last_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/long_count_aggregate.das
+++ b/benchmarks/sql/long_count_aggregate.das
@@ -44,23 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> long_count()
-            b |> accept(c)
-            if (c == 0l) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -91,11 +74,6 @@ def long_count_aggregate_m3f(b : B?) {
 [benchmark]
 def long_count_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def long_count_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/max_aggregate.das
+++ b/benchmarks/sql/max_aggregate.das
@@ -41,23 +41,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let m = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> max()
-            b |> accept(m)
-            if (m == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -88,11 +71,6 @@ def max_aggregate_m3f(b : B?) {
 [benchmark]
 def max_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def max_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/min_aggregate.das
+++ b/benchmarks/sql/min_aggregate.das
@@ -41,23 +41,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let m = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> min()
-            b |> accept(m)
-            if (m > 999) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -88,11 +71,6 @@ def min_aggregate_m3f(b : B?) {
 [benchmark]
 def min_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def min_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/order_distinct_take.das
+++ b/benchmarks/sql/order_distinct_take.das
@@ -75,28 +75,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline. The XML source carries whole Cars, so the brand stream is projected
-// out with a leading _select(_.brand) (the m3f/m4 lanes source a precomputed brand array). Un-fused.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _select(_.brand) |> _order_by(_) |> distinct() |> take(TAKE_N) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node, with the same _select(_.brand) projection prefix.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -129,11 +107,6 @@ def order_distinct_take_m3f(b : B?) {
 [benchmark]
 def order_distinct_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def order_distinct_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/order_reverse_normalized.das
+++ b/benchmarks/sql/order_reverse_normalized.das
@@ -53,27 +53,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _order_by(_.price) |> reverse() |> take(TAKE_N) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -106,11 +85,6 @@ def order_reverse_normalized_m3f(b : B?) {
 [benchmark]
 def order_reverse_normalized_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def order_reverse_normalized_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/order_take_desc.das
+++ b/benchmarks/sql/order_take_desc.das
@@ -46,25 +46,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _order_by_descending(_.price) |> take(TAKE_N) |> to_array()
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -95,11 +76,6 @@ def order_take_desc_m3f(b : B?) {
 [benchmark]
 def order_take_desc_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def order_take_desc_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -16,60 +16,41 @@ catalogued in `doc/source/reference/linq_fold_patterns.rst`.
 - **Array** — `_fold` over `each(arr)` chain, in-memory `array<Car>`.
 - **Decs** — `_fold` over `from_decs_template(type<DecsCar>)`,
   per-archetype walk.
-- **XML (m5)** — the **un-fused** chain over `from_xml_node(root, type<Car>)`:
-  the same linq pipeline as the array lane but without `_fold`
-  (`unsafe(from_xml_node(…)) |> _where(…) |> … |> term()`), so it runs the
-  tier-2 cascade — a full `Car` materialized per element (every attribute
-  read + string clones), intermediate arrays per stage. The reference the
-  fused lane is measured against.
-- **XML fold (m5f)** — `_fold` over the same `from_xml_node` source. The
+- **XML fold (m5f)** — `_fold` over a `from_xml_node(root, type<Car>)` source. The
   `XmlAdapter` (`pugixml/linq_fold_xml`) fuses + field-prunes where it can.
 
 Sub-nanosecond cells (`0.00`) reflect early-exit terminators that exit
 before the timer resolution can measure them — they should be read as
 "effectively free."
 
-### Reading the XML lanes (m5 vs m5f)
+### Reading the XML fold lane (m5f)
 
-m5 is the **un-fused** XML cascade; m5f is the **fused** `_fold`. The two run
-identical logic, so the delta is purely what the `XmlAdapter` fusion buys:
+The `XmlAdapter` fuses the chain into a single DOM walk and field-prunes the row
+materialization to just the fields the chain reads. What it covers:
 
-- **m5f ≪ m5 → fusion works.** The adapter inlines the DOM walk and prunes the
-  materialization to the fields the chain reads. This covers the `loop_or_count`
-  family — `where` / `select` / `count` / `sum` / `min` / `max` / `average` /
-  `aggregate` / `first` / `last` / `single` / `element_at` / `any` / `all` /
-  `contains` / `take` / `skip` / `take_while` / `skip_while` (5–10× INTERP, e.g.
-  `count_aggregate` 419 → 64; early-exit cells like `take_count_filtered` → ~1) —
-  **the cascade families** `group_by` (incl. `having` / multi-reducer),
-  `distinct[_by]`, `order_by[_descending]`, `sort`, `reverse`, which ride the
-  cascade planners over the DOM walk, **and `join`** (incl. `group_by` with an
-  upstream `join`) — the in-memory srcB is collected into a hash and srcA is
-  probed from the DOM walk. The win tracks whether field-pruning fires:
-  reducing/projecting/key-only shapes drop the per-row `name` clone (e.g.
-  `groupby_sum` 462 → 115, `distinct_by_count` 392 → 71, `distinct_take` → 0,
-  `join_count` 519 → 114 with 0 clones, `join_groupby_count` 581 → 182,
-  `order_distinct_take` 2092 → 72 — a leading `_select(_.brand)` projection is
-  absorbed into the source walk by `ProjectedSourceAdapter`, so even an
-  `order |> distinct |> take` chain prunes to just the projected field).
-  `join_select` 510 → 192 (2.65×) also fuses now: a bare `join |> select` (no
-  terminator, iterator-typed) builds the field-pruned result in one pass and
-  exposes it as a sequence (`wrapIter`), eliding tier-2's separate `join_to_array`
-  — though its `name`-keeping selector leaves the per-row string-clone floor, so
-  the win is the elided intermediate, not 0 clones.
-- **m5f < m5 via materialize-under-guard.** When the whole row escapes but only behind a
-  `where`-gate (`where(p) |> single/last/first`, `where(p) |> to_array`, `where(p) |> order_by`),
-  the per-element walk reads just the predicate's fields and builds the full row (its `name` clone)
-  only for *matching* elements — the clone count drops to the number of survivors, not the source
-  length. `single_match` 330 → 57 (100k → 1 clone), `select_where` 339 → 227, `bare_order_where` 447 → 331
-  (`last_match` and `select_where_order_take` have since graduated to the handle-buffer floor — see banner).
-- **m5f ≈ m5 → modest fusion only.** Whole-row escapes that are NOT behind a field-only gate keep the
-  full per-element clone: `reverse |> to_array` (reverse buffers whole rows), un-filtered `sort` /
-  `order_by` (no `where` to gate behind). Only the intermediate array is elided; the string-clone floor
-  remains.
+- **Fused families.** The `loop_or_count` family — `where` / `select` / `count` /
+  `sum` / `min` / `max` / `average` / `aggregate` / `first` / `last` / `single` /
+  `element_at` / `any` / `all` / `contains` / `take` / `skip` / `take_while` /
+  `skip_while`; the cascade families `group_by` (incl. `having` / multi-reducer),
+  `distinct[_by]`, `order_by[_descending]`, `sort`, `reverse`; and `join` (incl.
+  `group_by` with an upstream `join`, where the in-memory srcB is collected into a
+  hash and srcA is probed from the DOM walk).
+- **Field-pruning wins.** Reducing / projecting / key-only shapes drop the per-row
+  `name` clone entirely; a leading `_select(_.brand)` projection is absorbed into the
+  source walk by `ProjectedSourceAdapter`, so even `order |> distinct |> take` prunes
+  to just the projected field. A bare `join |> select` (iterator-typed) builds the
+  field-pruned result in one pass and exposes it as a sequence (`wrapIter`), eliding
+  tier-2's separate `join_to_array`.
+- **Materialize-under-guard.** When the whole row escapes but only behind a `where`-gate
+  (`where(p) |> single/last/first`, `where(p) |> to_array`, `where(p) |> order_by`), the
+  walk reads just the predicate's fields and builds the full row only for *matching*
+  elements — clone count drops to the survivor count, not the source length.
+- **String-clone floor.** Whole-row escapes with no field-only gate (`reverse |> to_array`,
+  un-filtered `sort` / `order_by`) keep the full per-element clone — only the intermediate
+  array is elided.
 
-(The absolute XML numbers stay far above the array/decs lanes either way — XML
-carries DOM-parse + per-element attribute reads + `string` clones the in-memory
-lanes never pay. The m5↔m5f delta, not the XML-vs-array gap, is the fusion signal.)
+(The absolute XML numbers stay above the array/decs lanes either way — XML carries
+DOM-parse + per-element attribute reads + `string` clones the in-memory lanes never pay.)
 
 
 <!-- BENCH:TABLES BEGIN -->
@@ -77,157 +58,157 @@ lanes never pay. The m5↔m5f delta, not the XML-vs-array gap, is the fusion sig
 
 ## INTERP
 
-| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML (m5) | XML fold (m5f) |
-|---|---:|---:|---:|---:|---:|
-| `aggregate_match` | 35.3 | 6.0 | 5.9 | 451.0 | 60.5 |
-| `all_match` | 28.0 | 3.5 | 3.5 | 376.7 | 56.5 |
-| `any_match` | 0.0 | 0.0 | 0.0 | 0.1 | 0.0 |
-| `average_aggregate` | 30.5 | 5.9 | 8.8 | 426.7 | 58.7 |
-| `bare_order_where` | 278.9 | 117.0 | 124.2 | 776.8 | 329.8 |
-| `chained_select_collapse` | — | 17.9 | 18.0 | 537.3 | 70.9 |
-| `chained_where` | 36.8 | 6.7 | 7.2 | 449.0 | 105.8 |
-| `contains_match` | 0.0 | 2.2 | 1.4 | 408.2 | 28.2 |
-| `count_aggregate` | 30.1 | 4.2 | 4.1 | 414.1 | 64.9 |
-| `decs_count_bare_pred` | — | — | 4.2 | — | — |
-| `distinct_by_count` | 42.1 | 15.7 | 16.1 | 390.7 | 70.8 |
-| `distinct_by_order_take` | 239.0 | 21.7 | 23.6 | 396.6 | 126.5 |
-| `distinct_by_order_to_array` | 239.7 | 21.9 | 23.3 | 397.9 | 127.2 |
-| `distinct_count` | 41.7 | 15.8 | 15.7 | 472.3 | 70.9 |
-| `distinct_count_pred` | 255.6 | 15.8 | 16.2 | 388.4 | 115.4 |
-| `distinct_take` | 0.0 | 0.0 | 0.0 | 395.0 | 0.0 |
-| `element_at_match` | 0.0 | 0.0 | 0.0 | 390.8 | 0.5 |
-| `first_match` | 0.0 | 0.0 | 0.0 | 390.9 | 0.0 |
-| `first_or_default_match` | 0.0 | 0.0 | 0.0 | 390.8 | 0.0 |
-| `groupby_average` | 170.3 | 30.4 | 30.3 | 461.6 | 124.7 |
-| `groupby_count` | 143.3 | 19.2 | 19.6 | 435.4 | 76.9 |
-| `groupby_first` | 253.3 | 18.5 | 19.2 | 425.3 | 72.5 |
-| `groupby_having_count` | 146.6 | 19.2 | 19.2 | 430.0 | 76.9 |
-| `groupby_having_hidden_sum` | 175.9 | 24.2 | 24.2 | 459.2 | 122.1 |
-| `groupby_having_post_where` | 170.9 | 18.7 | 18.7 | 456.1 | 115.5 |
-| `groupby_max` | 174.1 | 25.0 | 25.1 | 468.1 | 120.9 |
-| `groupby_min` | 173.8 | 25.2 | 25.4 | 469.2 | 121.0 |
-| `groupby_multi_reducer` | 191.0 | 32.5 | 32.5 | 493.9 | 127.9 |
-| `groupby_select_order` | 171.0 | 18.6 | 18.8 | 463.0 | 116.4 |
-| `groupby_select_sum` | 202.0 | 36.6 | 36.3 | 512.5 | 101.0 |
-| `groupby_sum` | 170.9 | 18.5 | 18.7 | 453.1 | 115.0 |
-| `groupby_where_count` | 76.4 | 14.4 | 15.0 | 449.3 | 118.1 |
-| `groupby_where_sum` | 87.2 | 14.2 | 14.8 | 468.1 | 119.3 |
-| `indexed_lookup` | 1482.6 | 197868.4 | 483.9 | 37882359.0 | 5744900.5 |
-| `join_count` | 38.7 | 51.5 | 64.7 | 517.4 | 114.5 |
-| `join_groupby_count` | 157.0 | 79.2 | 91.3 | 574.5 | 181.8 |
-| `join_groupby_to_array` | 190.9 | 78.2 | 91.9 | 604.3 | 218.2 |
-| `join_select` | 149.9 | 72.0 | 85.7 | 547.8 | 190.3 |
-| `join_where_count` | 39.7 | 61.6 | 75.9 | 567.0 | 164.9 |
-| `last_match` | 0.0 | 5.8 | 14.0 | 414.7 | 65.8 |
-| `long_count_aggregate` | 30.2 | 4.1 | 4.1 | 413.6 | 64.1 |
-| `max_aggregate` | 31.3 | 6.0 | 6.9 | 442.3 | 59.0 |
-| `min_aggregate` | 31.3 | 6.1 | 7.0 | 445.4 | 58.9 |
-| `order_distinct_take` | 138.9 | 15.8 | 91.7 | 2206.0 | 73.1 |
-| `order_reverse_normalized` | 38.8 | 16.2 | 20.1 | 1149.9 | 69.3 |
-| `order_take_desc` | 38.6 | 16.4 | 20.0 | 1062.9 | 69.7 |
-| `reverse_distinct_by` | 295.8 | 21.5 | 27.6 | 451.0 | 74.5 |
-| `reverse_take` | 0.1 | 0.0 | 9.2 | 376.6 | 89.5 |
-| `reverse_take_select` | 0.0 | 0.0 | 9.3 | 379.2 | 89.7 |
-| `select_count` | 0.1 | 0.0 | 2.2 | 431.1 | 68.6 |
-| `select_where` | 193.4 | 11.1 | 19.3 | 424.9 | 225.4 |
-| `select_where_count` | 33.2 | 5.2 | 7.4 | 478.8 | 65.8 |
-| `select_where_order_take` | 37.1 | 12.5 | 15.0 | 741.0 | 71.2 |
-| `select_where_sum` | 37.7 | 7.4 | 7.5 | 492.9 | 67.8 |
-| `single_match` | 0.0 | 2.8 | 5.6 | 379.2 | 57.4 |
-| `skip_take` | 0.5 | 0.1 | 0.2 | 4.4 | 3.7 |
-| `skip_while_match` | 3.5 | 5.2 | 5.4 | 402.5 | 61.2 |
-| `sort_first` | 38.0 | 11.1 | 13.3 | 1072.3 | 65.0 |
-| `sort_take` | 38.8 | 16.2 | 20.2 | 1062.3 | 69.2 |
-| `sort_take_select` | 38.8 | 16.1 | 20.1 | 1064.0 | 70.7 |
-| `sum_aggregate` | 30.6 | 2.1 | 2.1 | 427.4 | 54.3 |
-| `sum_where` | 33.4 | 4.3 | 4.3 | 447.5 | 64.6 |
-| `take_count` | 3.6 | 0.2 | 0.4 | 4.3 | 3.5 |
-| `take_count_filtered` | 1.1 | 0.2 | 0.2 | 392.4 | 1.3 |
-| `take_sum_aggregate` | 0.8 | 0.1 | 0.1 | 390.2 | 0.6 |
-| `take_where_count` | 0.9 | 0.1 | 0.1 | 4.7 | 0.7 |
-| `take_while_match` | 7.9 | 2.4 | 2.4 | 224.7 | 29.7 |
-| `to_array_filter` | 70.4 | 11.7 | 11.8 | 459.1 | 72.4 |
-| `zip_count_pred` | 39.7 | 15.3 | — | 532.2 | 375.9 |
-| `zip_dot_product` | — | 12.8 | 10.9 | 507.3 | 365.1 |
-| `zip_dot_product_3arg` | — | 12.8 | — | 425.4 | 366.2 |
-| `zip_reverse_to_array` | — | 30.8 | — | 526.9 | 400.3 |
+| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML fold (m5f) |
+|---|---:|---:|---:|---:|
+| `aggregate_match` | 35.3 | 6.0 | 5.9 | 60.5 |
+| `all_match` | 28.0 | 3.5 | 3.5 | 56.5 |
+| `any_match` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `average_aggregate` | 30.5 | 5.9 | 8.8 | 58.7 |
+| `bare_order_where` | 278.9 | 117.0 | 124.2 | 329.8 |
+| `chained_select_collapse` | — | 17.9 | 18.0 | 70.9 |
+| `chained_where` | 36.8 | 6.7 | 7.2 | 105.8 |
+| `contains_match` | 0.0 | 2.2 | 1.4 | 28.2 |
+| `count_aggregate` | 30.1 | 4.2 | 4.1 | 64.9 |
+| `decs_count_bare_pred` | — | — | 4.2 | — |
+| `distinct_by_count` | 42.1 | 15.7 | 16.1 | 70.8 |
+| `distinct_by_order_take` | 239.0 | 21.7 | 23.6 | 126.5 |
+| `distinct_by_order_to_array` | 239.7 | 21.9 | 23.3 | 127.2 |
+| `distinct_count` | 41.7 | 15.8 | 15.7 | 70.9 |
+| `distinct_count_pred` | 255.6 | 15.8 | 16.2 | 115.4 |
+| `distinct_take` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `element_at_match` | 0.0 | 0.0 | 0.0 | 0.5 |
+| `first_match` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `first_or_default_match` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `groupby_average` | 170.3 | 30.4 | 30.3 | 124.7 |
+| `groupby_count` | 143.3 | 19.2 | 19.6 | 76.9 |
+| `groupby_first` | 253.3 | 18.5 | 19.2 | 72.5 |
+| `groupby_having_count` | 146.6 | 19.2 | 19.2 | 76.9 |
+| `groupby_having_hidden_sum` | 175.9 | 24.2 | 24.2 | 122.1 |
+| `groupby_having_post_where` | 170.9 | 18.7 | 18.7 | 115.5 |
+| `groupby_max` | 174.1 | 25.0 | 25.1 | 120.9 |
+| `groupby_min` | 173.8 | 25.2 | 25.4 | 121.0 |
+| `groupby_multi_reducer` | 191.0 | 32.5 | 32.5 | 127.9 |
+| `groupby_select_order` | 171.0 | 18.6 | 18.8 | 116.4 |
+| `groupby_select_sum` | 202.0 | 36.6 | 36.3 | 101.0 |
+| `groupby_sum` | 170.9 | 18.5 | 18.7 | 115.0 |
+| `groupby_where_count` | 76.4 | 14.4 | 15.0 | 118.1 |
+| `groupby_where_sum` | 87.2 | 14.2 | 14.8 | 119.3 |
+| `indexed_lookup` | 1482.6 | 197868.4 | 483.9 | 5744900.5 |
+| `join_count` | 38.7 | 51.5 | 64.7 | 114.5 |
+| `join_groupby_count` | 157.0 | 79.2 | 91.3 | 181.8 |
+| `join_groupby_to_array` | 190.9 | 78.2 | 91.9 | 218.2 |
+| `join_select` | 149.9 | 72.0 | 85.7 | 190.3 |
+| `join_where_count` | 39.7 | 61.6 | 75.9 | 164.9 |
+| `last_match` | 0.0 | 5.8 | 14.0 | 65.8 |
+| `long_count_aggregate` | 30.2 | 4.1 | 4.1 | 64.1 |
+| `max_aggregate` | 31.3 | 6.0 | 6.9 | 59.0 |
+| `min_aggregate` | 31.3 | 6.1 | 7.0 | 58.9 |
+| `order_distinct_take` | 138.9 | 15.8 | 91.7 | 73.1 |
+| `order_reverse_normalized` | 38.8 | 16.2 | 20.1 | 69.3 |
+| `order_take_desc` | 38.6 | 16.4 | 20.0 | 69.7 |
+| `reverse_distinct_by` | 295.8 | 21.5 | 27.6 | 74.5 |
+| `reverse_take` | 0.1 | 0.0 | 9.2 | 89.5 |
+| `reverse_take_select` | 0.0 | 0.0 | 9.3 | 89.7 |
+| `select_count` | 0.1 | 0.0 | 2.2 | 68.6 |
+| `select_where` | 193.4 | 11.1 | 19.3 | 225.4 |
+| `select_where_count` | 33.2 | 5.2 | 7.4 | 65.8 |
+| `select_where_order_take` | 37.1 | 12.5 | 15.0 | 71.2 |
+| `select_where_sum` | 37.7 | 7.4 | 7.5 | 67.8 |
+| `single_match` | 0.0 | 2.8 | 5.6 | 57.4 |
+| `skip_take` | 0.5 | 0.1 | 0.2 | 3.7 |
+| `skip_while_match` | 3.5 | 5.2 | 5.4 | 61.2 |
+| `sort_first` | 38.0 | 11.1 | 13.3 | 65.0 |
+| `sort_take` | 38.8 | 16.2 | 20.2 | 69.2 |
+| `sort_take_select` | 38.8 | 16.1 | 20.1 | 70.7 |
+| `sum_aggregate` | 30.6 | 2.1 | 2.1 | 54.3 |
+| `sum_where` | 33.4 | 4.3 | 4.3 | 64.6 |
+| `take_count` | 3.6 | 0.2 | 0.4 | 3.5 |
+| `take_count_filtered` | 1.1 | 0.2 | 0.2 | 1.3 |
+| `take_sum_aggregate` | 0.8 | 0.1 | 0.1 | 0.6 |
+| `take_where_count` | 0.9 | 0.1 | 0.1 | 0.7 |
+| `take_while_match` | 7.9 | 2.4 | 2.4 | 29.7 |
+| `to_array_filter` | 70.4 | 11.7 | 11.8 | 72.4 |
+| `zip_count_pred` | 39.7 | 15.3 | — | 375.9 |
+| `zip_dot_product` | — | 12.8 | 10.9 | 365.1 |
+| `zip_dot_product_3arg` | — | 12.8 | — | 366.2 |
+| `zip_reverse_to_array` | — | 30.8 | — | 400.3 |
 
 ## JIT
 
-| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML (m5) | XML fold (m5f) |
-|---|---:|---:|---:|---:|---:|
-| `aggregate_match` | 35.1 | 0.3 | 0.6 | 173.7 | 17.0 |
-| `all_match` | 27.8 | 0.3 | 0.2 | 158.8 | 20.1 |
-| `any_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
-| `average_aggregate` | 30.5 | 1.0 | 3.5 | 167.6 | 18.6 |
-| `bare_order_where` | 185.3 | 34.1 | 34.3 | 277.3 | 122.9 |
-| `chained_select_collapse` | — | 2.1 | 2.1 | 181.6 | 21.6 |
-| `chained_where` | 36.7 | 0.6 | 0.8 | 177.0 | 34.2 |
-| `contains_match` | 0.0 | 0.2 | 0.1 | 163.8 | 17.2 |
-| `count_aggregate` | 30.0 | 0.3 | 0.6 | 168.2 | 17.5 |
-| `decs_count_bare_pred` | — | — | 0.6 | — | — |
-| `distinct_by_count` | 41.7 | 2.1 | 2.1 | 157.5 | 21.3 |
-| `distinct_by_order_take` | 239.8 | 2.6 | 3.2 | 170.5 | 47.7 |
-| `distinct_by_order_to_array` | 238.7 | 2.7 | 3.2 | 169.5 | 46.2 |
-| `distinct_count` | 41.8 | 2.1 | 2.1 | 172.4 | 21.7 |
-| `distinct_count_pred` | 251.9 | 2.1 | 2.3 | 159.9 | 40.8 |
-| `distinct_take` | 0.0 | 0.0 | 0.0 | 160.2 | 0.0 |
-| `element_at_match` | 0.0 | 0.0 | 0.0 | 165.4 | 0.2 |
-| `first_match` | 0.0 | 0.0 | 0.0 | 167.5 | 0.0 |
-| `first_or_default_match` | 0.0 | 0.0 | 0.0 | 166.8 | 0.0 |
-| `groupby_average` | 170.1 | 2.6 | 2.9 | 186.7 | 37.4 |
-| `groupby_count` | 141.8 | 2.3 | 2.5 | 170.6 | 23.7 |
-| `groupby_first` | 251.3 | 2.2 | 3.1 | 170.0 | 22.1 |
-| `groupby_having_count` | 141.4 | 2.4 | 2.5 | 173.3 | 21.8 |
-| `groupby_having_hidden_sum` | 175.3 | 2.5 | 2.8 | 183.2 | 37.8 |
-| `groupby_having_post_where` | 170.3 | 2.4 | 2.7 | 178.5 | 37.7 |
-| `groupby_max` | 173.1 | 2.4 | 2.7 | 183.6 | 36.7 |
-| `groupby_min` | 172.5 | 2.4 | 2.7 | 184.1 | 37.3 |
-| `groupby_multi_reducer` | 190.0 | 2.7 | 3.0 | 186.9 | 38.2 |
-| `groupby_select_order` | 171.1 | 2.4 | 2.7 | 183.8 | 38.5 |
-| `groupby_select_sum` | 200.6 | 3.2 | 3.7 | 199.1 | 32.2 |
-| `groupby_sum` | 171.2 | 2.4 | 2.7 | 179.5 | 37.3 |
-| `groupby_where_count` | 75.8 | 1.5 | 1.8 | 178.1 | 37.3 |
-| `groupby_where_sum` | 86.5 | 1.5 | 1.8 | 186.8 | 37.0 |
-| `indexed_lookup` | 1244.4 | 32402.2 | 105.7 | 15681509.9 | 4639576.4 |
-| `join_count` | 38.6 | 11.8 | 12.8 | 194.7 | 48.8 |
-| `join_groupby_count` | 156.8 | 19.4 | 21.8 | 210.4 | 70.6 |
-| `join_groupby_to_array` | 188.5 | 19.6 | 21.9 | 216.3 | 80.8 |
-| `join_select` | 92.2 | 20.0 | 22.7 | 205.1 | 75.9 |
-| `join_where_count` | 39.5 | 19.9 | 21.6 | 207.2 | 66.0 |
-| `last_match` | 0.0 | 0.5 | 1.4 | 169.8 | 21.5 |
-| `long_count_aggregate` | 29.6 | 0.3 | 0.6 | 167.4 | 26.9 |
-| `max_aggregate` | 31.3 | 0.3 | 0.5 | 167.0 | 17.6 |
-| `min_aggregate` | 31.2 | 0.3 | 0.5 | 166.9 | 17.5 |
-| `order_distinct_take` | 138.1 | 2.1 | 73.7 | 638.1 | 22.7 |
-| `order_reverse_normalized` | 38.5 | 0.7 | 1.4 | 387.2 | 19.2 |
-| `order_take_desc` | 38.4 | 0.7 | 1.3 | 368.3 | 17.1 |
-| `reverse_distinct_by` | 295.3 | 2.6 | 5.0 | 168.9 | 22.2 |
-| `reverse_take` | 0.0 | 0.0 | 1.1 | 154.3 | 68.4 |
-| `reverse_take_select` | 0.0 | 0.0 | 1.1 | 155.0 | 68.4 |
-| `select_count` | 0.1 | 0.0 | 0.0 | 166.3 | 65.8 |
-| `select_where` | 105.6 | 4.2 | 5.4 | 172.5 | 95.5 |
-| `select_where_count` | 33.1 | 0.3 | 0.6 | 178.2 | 28.5 |
-| `select_where_order_take` | 36.9 | 0.7 | 1.4 | 273.4 | 18.4 |
-| `select_where_sum` | 37.2 | 0.4 | 0.6 | 176.6 | 19.0 |
-| `single_match` | 0.0 | 0.4 | 1.1 | 158.7 | 46.7 |
-| `skip_take` | 0.3 | 0.0 | 0.0 | 1.7 | 1.6 |
-| `skip_while_match` | 3.5 | 0.4 | 0.4 | 160.6 | 47.1 |
-| `sort_first` | 38.1 | 0.4 | 1.3 | 374.2 | 17.2 |
-| `sort_take` | 38.6 | 0.7 | 1.4 | 376.8 | 17.9 |
-| `sort_take_select` | 38.7 | 0.7 | 1.3 | 375.2 | 17.0 |
-| `sum_aggregate` | 30.1 | 0.3 | 0.1 | 166.8 | 17.6 |
-| `sum_where` | 33.3 | 0.3 | 0.6 | 175.7 | 17.5 |
-| `take_count` | 1.8 | 0.1 | 0.1 | 1.7 | 1.6 |
-| `take_count_filtered` | 1.1 | 0.0 | 0.0 | 164.8 | 0.4 |
-| `take_sum_aggregate` | 0.8 | 0.0 | 0.0 | 160.5 | 0.2 |
-| `take_where_count` | 0.9 | 0.0 | 0.0 | 1.8 | 0.2 |
-| `take_while_match` | 7.8 | 0.2 | 0.3 | 84.8 | 17.6 |
-| `to_array_filter` | 47.5 | 3.2 | 3.3 | 178.5 | 20.3 |
-| `zip_count_pred` | 39.4 | 0.1 | — | 187.9 | 150.2 |
-| `zip_dot_product` | — | 0.1 | 0.1 | 196.3 | 152.4 |
-| `zip_dot_product_3arg` | — | 0.1 | — | 169.0 | 153.1 |
-| `zip_reverse_to_array` | — | 4.5 | — | 186.8 | 160.3 |
+| Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML fold (m5f) |
+|---|---:|---:|---:|---:|
+| `aggregate_match` | 35.1 | 0.3 | 0.6 | 17.0 |
+| `all_match` | 27.8 | 0.3 | 0.2 | 20.1 |
+| `any_match` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `average_aggregate` | 30.5 | 1.0 | 3.5 | 18.6 |
+| `bare_order_where` | 185.3 | 34.1 | 34.3 | 122.9 |
+| `chained_select_collapse` | — | 2.1 | 2.1 | 21.6 |
+| `chained_where` | 36.7 | 0.6 | 0.8 | 34.2 |
+| `contains_match` | 0.0 | 0.2 | 0.1 | 17.2 |
+| `count_aggregate` | 30.0 | 0.3 | 0.6 | 17.5 |
+| `decs_count_bare_pred` | — | — | 0.6 | — |
+| `distinct_by_count` | 41.7 | 2.1 | 2.1 | 21.3 |
+| `distinct_by_order_take` | 239.8 | 2.6 | 3.2 | 47.7 |
+| `distinct_by_order_to_array` | 238.7 | 2.7 | 3.2 | 46.2 |
+| `distinct_count` | 41.8 | 2.1 | 2.1 | 21.7 |
+| `distinct_count_pred` | 251.9 | 2.1 | 2.3 | 40.8 |
+| `distinct_take` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `element_at_match` | 0.0 | 0.0 | 0.0 | 0.2 |
+| `first_match` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `first_or_default_match` | 0.0 | 0.0 | 0.0 | 0.0 |
+| `groupby_average` | 170.1 | 2.6 | 2.9 | 37.4 |
+| `groupby_count` | 141.8 | 2.3 | 2.5 | 23.7 |
+| `groupby_first` | 251.3 | 2.2 | 3.1 | 22.1 |
+| `groupby_having_count` | 141.4 | 2.4 | 2.5 | 21.8 |
+| `groupby_having_hidden_sum` | 175.3 | 2.5 | 2.8 | 37.8 |
+| `groupby_having_post_where` | 170.3 | 2.4 | 2.7 | 37.7 |
+| `groupby_max` | 173.1 | 2.4 | 2.7 | 36.7 |
+| `groupby_min` | 172.5 | 2.4 | 2.7 | 37.3 |
+| `groupby_multi_reducer` | 190.0 | 2.7 | 3.0 | 38.2 |
+| `groupby_select_order` | 171.1 | 2.4 | 2.7 | 38.5 |
+| `groupby_select_sum` | 200.6 | 3.2 | 3.7 | 32.2 |
+| `groupby_sum` | 171.2 | 2.4 | 2.7 | 37.3 |
+| `groupby_where_count` | 75.8 | 1.5 | 1.8 | 37.3 |
+| `groupby_where_sum` | 86.5 | 1.5 | 1.8 | 37.0 |
+| `indexed_lookup` | 1244.4 | 32402.2 | 105.7 | 4639576.4 |
+| `join_count` | 38.6 | 11.8 | 12.8 | 48.8 |
+| `join_groupby_count` | 156.8 | 19.4 | 21.8 | 70.6 |
+| `join_groupby_to_array` | 188.5 | 19.6 | 21.9 | 80.8 |
+| `join_select` | 92.2 | 20.0 | 22.7 | 75.9 |
+| `join_where_count` | 39.5 | 19.9 | 21.6 | 66.0 |
+| `last_match` | 0.0 | 0.5 | 1.4 | 21.5 |
+| `long_count_aggregate` | 29.6 | 0.3 | 0.6 | 26.9 |
+| `max_aggregate` | 31.3 | 0.3 | 0.5 | 17.6 |
+| `min_aggregate` | 31.2 | 0.3 | 0.5 | 17.5 |
+| `order_distinct_take` | 138.1 | 2.1 | 73.7 | 22.7 |
+| `order_reverse_normalized` | 38.5 | 0.7 | 1.4 | 19.2 |
+| `order_take_desc` | 38.4 | 0.7 | 1.3 | 17.1 |
+| `reverse_distinct_by` | 295.3 | 2.6 | 5.0 | 22.2 |
+| `reverse_take` | 0.0 | 0.0 | 1.1 | 68.4 |
+| `reverse_take_select` | 0.0 | 0.0 | 1.1 | 68.4 |
+| `select_count` | 0.1 | 0.0 | 0.0 | 65.8 |
+| `select_where` | 105.6 | 4.2 | 5.4 | 95.5 |
+| `select_where_count` | 33.1 | 0.3 | 0.6 | 28.5 |
+| `select_where_order_take` | 36.9 | 0.7 | 1.4 | 18.4 |
+| `select_where_sum` | 37.2 | 0.4 | 0.6 | 19.0 |
+| `single_match` | 0.0 | 0.4 | 1.1 | 46.7 |
+| `skip_take` | 0.3 | 0.0 | 0.0 | 1.6 |
+| `skip_while_match` | 3.5 | 0.4 | 0.4 | 47.1 |
+| `sort_first` | 38.1 | 0.4 | 1.3 | 17.2 |
+| `sort_take` | 38.6 | 0.7 | 1.4 | 17.9 |
+| `sort_take_select` | 38.7 | 0.7 | 1.3 | 17.0 |
+| `sum_aggregate` | 30.1 | 0.3 | 0.1 | 17.6 |
+| `sum_where` | 33.3 | 0.3 | 0.6 | 17.5 |
+| `take_count` | 1.8 | 0.1 | 0.1 | 1.6 |
+| `take_count_filtered` | 1.1 | 0.0 | 0.0 | 0.4 |
+| `take_sum_aggregate` | 0.8 | 0.0 | 0.0 | 0.2 |
+| `take_where_count` | 0.9 | 0.0 | 0.0 | 0.2 |
+| `take_while_match` | 7.8 | 0.2 | 0.3 | 17.6 |
+| `to_array_filter` | 47.5 | 3.2 | 3.3 | 20.3 |
+| `zip_count_pred` | 39.4 | 0.1 | — | 150.2 |
+| `zip_dot_product` | — | 0.1 | 0.1 | 152.4 |
+| `zip_dot_product_3arg` | — | 0.1 | — | 153.1 |
+| `zip_reverse_to_array` | — | 4.5 | — | 160.3 |
 <!-- BENCH:TABLES END -->
 
 ## Notes on missing lanes (the `—` cells)
@@ -242,7 +223,7 @@ and which gaps could land in a single PR — see
 - **`chained_select_collapse` SQL** — `_sql` rejects `distinct() |> count()`
   as non-translatable. The equivalent SQL `COUNT(DISTINCT computed-expr)`
   isn't currently emitted by sqlite_linq's surface. By design — no follow-up.
-- **`decs_count_bare_pred` SQL / Array / XML (m5, m5f)** — covers a Theme 4
+- **`decs_count_bare_pred` SQL / Array / XML (m5f)** — covers a Theme 4
   root-cause fix specific to the decs lane (bare `from_decs_template(...).count(P)`
   with no upstream where/select previously bailed because
   `forExpr.iteratorVariables` was unpopulated). Array-side bare `count(P)`
@@ -284,13 +265,12 @@ and which gaps could land in a single PR — see
 - **`zip_reverse_to_array` SQL / Decs** — `reverse()` has no SQL order key
   (relational rows are unordered without an `ORDER BY`), and zip is not
   naturally expressible over a single archetype walk. By design, no follow-up.
-- **`zip_*` XML lanes (m5, m5f)** — now landed (see the top banner). Each zip
+- **`zip_*` XML lane (m5f)** — now landed (see the top banner). Each zip
   bench zips the XML `Car` price-stream against a synthetic int array via the
-  mixed `zip(iterator, array)` overload; m5f modestly beats m5 (the zip splice
-  partially fuses over XML), with both lanes still paying the unpruned `Car`
-  materialization. The remaining `—` zip cells are **SQL (m1)** and **Decs
-  (m4)**: `zip` is not a relational op and not expressible over a single
-  archetype walk (see the two bullets above).
+  mixed `zip(iterator, array)` overload; the zip splice partially fuses over XML,
+  still paying the unpruned `Car` materialization. The remaining `—` zip cells are
+  **SQL (m1)** and **Decs (m4)**: `zip` is not a relational op and not expressible
+  over a single archetype walk (see the two bullets above).
 
 ## Accepted architectural floors (m4 vs m3f)
 

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -265,7 +265,7 @@ and which gaps could land in a single PR — see
 - **`zip_reverse_to_array` SQL / Decs** — `reverse()` has no SQL order key
   (relational rows are unordered without an `ORDER BY`), and zip is not
   naturally expressible over a single archetype walk. By design, no follow-up.
-- **`zip_*` XML lane (m5f)** — now landed (see the top banner). Each zip
+- **`zip_*` XML lane (m5f)** — each zip
   bench zips the XML `Car` price-stream against a synthetic int array via the
   mixed `zip(iterator, array)` overload; the zip splice partially fuses over XML,
   still paying the unpruned `Car` materialization. The remaining `—` zip cells are

--- a/benchmarks/sql/reverse_distinct_by.das
+++ b/benchmarks/sql/reverse_distinct_by.das
@@ -62,27 +62,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> reverse() |> _distinct_by(_.brand) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -115,11 +94,6 @@ def reverse_distinct_by_m3f(b : B?) {
 [benchmark]
 def reverse_distinct_by_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def reverse_distinct_by_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/reverse_take.das
+++ b/benchmarks/sql/reverse_take.das
@@ -51,27 +51,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> reverse() |> take(TAKE_N) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -104,11 +83,6 @@ def reverse_take_m3f(b : B?) {
 [benchmark]
 def reverse_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def reverse_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/reverse_take_select.das
+++ b/benchmarks/sql/reverse_take_select.das
@@ -51,27 +51,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> reverse() |> take(TAKE_N) |> _select(_.name) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -104,11 +83,6 @@ def reverse_take_select_m3f(b : B?) {
 [benchmark]
 def reverse_take_select_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def reverse_take_select_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_count.das
+++ b/benchmarks/sql/select_count.das
@@ -45,23 +45,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price * 2) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -92,11 +75,6 @@ def select_count_m3f(b : B?) {
 [benchmark]
 def select_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def select_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where.das
+++ b/benchmarks/sql/select_where.das
@@ -40,23 +40,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> to_array()
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -87,11 +70,6 @@ def select_where_m3f(b : B?) {
 [benchmark]
 def select_where_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def select_where_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where_count.das
+++ b/benchmarks/sql/select_where_count.das
@@ -48,27 +48,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 [benchmark]
 def select_where_count_m1(b : B?) {
     run_m1(b, 100000)
@@ -84,13 +63,6 @@ def select_where_count_m4(b : B?) {
     run_m4(b, 100000)
 }
 
-[benchmark]
-def select_where_count_m5(b : B?) {
-    run_m5(b, 100000)
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {

--- a/benchmarks/sql/select_where_order_take.das
+++ b/benchmarks/sql/select_where_order_take.das
@@ -50,33 +50,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- (unsafe(from_xml_node(doc.document_element, type<Car>))
-                        |> _where(_.price > THRESHOLD)
-                        |> _order_by(_.price)
-                        |> take(TAKE_N)
-                        |> to_array())
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -110,11 +83,6 @@ def select_where_order_take_m3f(b : B?) {
 [benchmark]
 def select_where_order_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def select_where_order_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/select_where_sum.das
+++ b/benchmarks/sql/select_where_sum.das
@@ -56,24 +56,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price * 2) |> _where(_ > THRESHOLD) |> sum()
-            b |> accept(s)
-            if (s == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 [benchmark]
 def select_where_sum_m1(b : B?) {
     run_m1(b, 100000)
@@ -89,13 +71,6 @@ def select_where_sum_m4(b : B?) {
     run_m4(b, 100000)
 }
 
-[benchmark]
-def select_where_sum_m5(b : B?) {
-    run_m5(b, 100000)
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {

--- a/benchmarks/sql/single_match.das
+++ b/benchmarks/sql/single_match.das
@@ -46,25 +46,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same `.single()` chain over from_xml_node, un-fused
-// (tier-2 cascade). single() is a full scan asserting exactly one survivor, matching the fold lanes.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.id == TARGET_ID) |> single()
-            b |> accept(row)
-            if (row.id == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 [benchmark]
 def single_match_m1(b : B?) {
     run_m1(b, 100000)
@@ -80,14 +61,6 @@ def single_match_m4(b : B?) {
     run_m4(b, 100000)
 }
 
-[benchmark]
-def single_match_m5(b : B?) {
-    run_m5(b, 100000)
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk; `.single()` returns the whole row, so the scanner sees a whole-row escape and
-// keeps the full build_xml_row materialization (field-pruning applies to filter/project/aggregate chains).
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {

--- a/benchmarks/sql/skip_take.das
+++ b/benchmarks/sql/skip_take.das
@@ -46,29 +46,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> skip(SKIP_N) |> take(TAKE_N) |> to_array()
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -99,11 +76,6 @@ def skip_take_m3f(b : B?) {
 [benchmark]
 def skip_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def skip_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/skip_while_match.das
+++ b/benchmarks/sql/skip_while_match.das
@@ -49,23 +49,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let total = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _skip_while(_.id < THRESHOLD) |> count()
-            b |> accept(total)
-            if (total == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -96,11 +79,6 @@ def skip_while_match_m3f(b : B?) {
 [benchmark]
 def skip_while_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def skip_while_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_first.das
+++ b/benchmarks/sql/sort_first.das
@@ -42,25 +42,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let row = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _order_by(_.price) |> first()
-            b |> accept(row)
-            if (row.id == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -91,11 +72,6 @@ def sort_first_m3f(b : B?) {
 [benchmark]
 def sort_first_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def sort_first_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_take.das
+++ b/benchmarks/sql/sort_take.das
@@ -49,27 +49,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _order_by(_.price) |> take(TAKE_N) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -102,11 +81,6 @@ def sort_take_m3f(b : B?) {
 [benchmark]
 def sort_take_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def sort_take_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sort_take_select.das
+++ b/benchmarks/sql/sort_take_select.das
@@ -50,27 +50,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            unsafe {
-                let rows <- (from_xml_node(doc.document_element, type<Car>) |> _order_by(_.price) |> take(TAKE_N) |> _select(_.name) |> to_array())
-                b |> accept(rows)
-                if (empty(rows)) {
-                    b->failNow()
-                }
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over from_xml_node.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -103,11 +82,6 @@ def sort_take_select_m3f(b : B?) {
 [benchmark]
 def sort_take_select_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def sort_take_select_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sum_aggregate.das
+++ b/benchmarks/sql/sum_aggregate.das
@@ -41,23 +41,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> sum()
-            b |> accept(s)
-            if (s == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -88,11 +71,6 @@ def sum_aggregate_m3f(b : B?) {
 [benchmark]
 def sum_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def sum_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/sum_where.das
+++ b/benchmarks/sql/sum_where.das
@@ -45,23 +45,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> _select(_.price) |> sum()
-            b |> accept(s)
-            if (s == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -92,11 +75,6 @@ def sum_where_m3f(b : B?) {
 [benchmark]
 def sum_where_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def sum_where_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_count.das
+++ b/benchmarks/sql/take_count.das
@@ -44,29 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> take(TAKE_N) |> to_array()
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -97,11 +74,6 @@ def take_count_m3f(b : B?) {
 [benchmark]
 def take_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def take_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_count_filtered.das
+++ b/benchmarks/sql/take_count_filtered.das
@@ -47,24 +47,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same chain over from_xml_node, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> take(TAKE_N) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 [benchmark]
 def take_count_filtered_m1(b : B?) {
     run_m1(b, 100000)
@@ -80,13 +62,6 @@ def take_count_filtered_m4(b : B?) {
     run_m4(b, 100000)
 }
 
-[benchmark]
-def take_count_filtered_m5(b : B?) {
-    run_m5(b, 100000)
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {

--- a/benchmarks/sql/take_sum_aggregate.das
+++ b/benchmarks/sql/take_sum_aggregate.das
@@ -46,29 +46,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let s = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _select(_.price) |> take(TAKE_N) |> sum()
-            b |> accept(s)
-            if (s == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -99,11 +76,6 @@ def take_sum_aggregate_m3f(b : B?) {
 [benchmark]
 def take_sum_aggregate_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def take_sum_aggregate_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_where_count.das
+++ b/benchmarks/sql/take_where_count.das
@@ -50,29 +50,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: non-fold baseline — the same linq chain over from_xml_node, un-fused
-// (tier-2 cascade, materializes a full Car per element + intermediate stages). This is
-// the reference the fused XML lane (m5f) is measured against: m5f ≈ m5 means the adapter
-// is falling back to materialization (no fusion); m5f << m5 means fusion is working.
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = unsafe(from_xml_node(doc.document_element, type<Car>)) |> take(TAKE_N) |> _where(_.price > THRESHOLD) |> count()
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused `_fold` over from_xml_node (pass 2b). XmlAdapter emits an inlined
-// child-element walk and field-prunes the materialization to the attributes the chain reads.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -103,11 +80,6 @@ def take_where_count_m3f(b : B?) {
 [benchmark]
 def take_where_count_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def take_where_count_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/take_while_match.das
+++ b/benchmarks/sql/take_while_match.das
@@ -48,23 +48,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let total = unsafe(from_xml_node(doc.document_element, type<Car>)) |> _take_while(_.id < THRESHOLD) |> count()
-            b |> accept(total)
-            if (total == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -95,11 +78,6 @@ def take_while_match_m3f(b : B?) {
 [benchmark]
 def take_while_match_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def take_while_match_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/to_array_filter.das
+++ b/benchmarks/sql/to_array_filter.das
@@ -43,23 +43,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let prices <- unsafe(from_xml_node(doc.document_element, type<Car>)) |> _where(_.price > THRESHOLD) |> _select(_.price) |> to_array()
-            b |> accept(prices)
-            if (empty(prices)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     parse_xml(xml) $(doc, ok) {
@@ -90,11 +73,6 @@ def to_array_filter_m3f(b : B?) {
 [benchmark]
 def to_array_filter_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def to_array_filter_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/zip_count_pred.das
+++ b/benchmarks/sql/zip_count_pred.das
@@ -56,28 +56,6 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: zip the XML Car price-stream against a synthetic int array, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let ys <- make_ints(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let c = (unsafe(from_xml_node(doc.document_element, type<Car>)) |> zip(ys)
-                     |> _select(int64(_._0.price) * int64(_._1))
-                     |> count($(v) => v > THRESHOLD))
-            b |> accept(c)
-            if (c == 0) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the same zip(from_xml_node, array) with trailing count(P).
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let ys <- make_ints(n)
@@ -106,11 +84,6 @@ def zip_count_pred_m1(b : B?) {
 [benchmark]
 def zip_count_pred_m3f(b : B?) {
     run_m3f(b, 100000)
-}
-
-[benchmark]
-def zip_count_pred_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/zip_dot_product.das
+++ b/benchmarks/sql/zip_dot_product.das
@@ -44,28 +44,6 @@ def run_m4(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: zip the XML Car price-stream against a synthetic int array, un-fused (tier-2 cascade).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let ys <- make_ints(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let s = (zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
-                     |> _select(int64(_._0.price) * int64(_._1))
-                     |> sum())
-            b |> accept(s)
-            if (s == 0l) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the same zip(from_xml_node, array).
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let ys <- make_ints(n)
@@ -94,11 +72,6 @@ def zip_dot_product_m3f(b : B?) {
 [benchmark]
 def zip_dot_product_m4(b : B?) {
     run_m4(b, 100000)
-}
-
-[benchmark]
-def zip_dot_product_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/zip_dot_product_3arg.das
+++ b/benchmarks/sql/zip_dot_product_3arg.das
@@ -33,27 +33,6 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: 3-arg zip of the XML Car price-stream against a synthetic int array, un-fused (tier-2).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let ys <- make_ints(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let s = (zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys,
-                         $(c : Car; y : int) => int64(c.price) * int64(y)) |> sum())
-            b |> accept(s)
-            if (s == 0l) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the same 3-arg zip(from_xml_node, array, sel).
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let ys <- make_ints(n)
@@ -76,11 +55,6 @@ def run_m5f(b : B?; n : int) {
 [benchmark]
 def zip_dot_product_3arg_m3f(b : B?) {
     run_m3f(b, 100000)
-}
-
-[benchmark]
-def zip_dot_product_3arg_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/benchmarks/sql/zip_reverse_to_array.das
+++ b/benchmarks/sql/zip_reverse_to_array.das
@@ -39,27 +39,6 @@ def run_m3f(b : B?; n : int) {
     }
 }
 
-// m5_xml lane: zip the XML Car stream against a synthetic int array, reverse + to_array, un-fused (tier-2).
-def run_m5(b : B?; n : int) {
-    let xml = fixture_xml_string(n)
-    let ys <- make_ints(n)
-    parse_xml(xml) $(doc, ok) {
-        if (!ok) {
-            b->failNow()
-            return
-        }
-        b |> run("m5_xml/{n}", n) {
-            let rows <- (zip(unsafe(from_xml_node(doc.document_element, type<Car>)), ys)
-                         |> reverse() |> to_array())
-            b |> accept(rows)
-            if (empty(rows)) {
-                b->failNow()
-            }
-        }
-    }
-}
-
-// m5f_xml_fold lane: fused _fold over the same zip(from_xml_node, array) with trailing reverse + to_array.
 def run_m5f(b : B?; n : int) {
     let xml = fixture_xml_string(n)
     let ys <- make_ints(n)
@@ -83,11 +62,6 @@ def run_m5f(b : B?; n : int) {
 [benchmark]
 def zip_reverse_to_array_m3f(b : B?) {
     run_m3f(b, 100000)
-}
-
-[benchmark]
-def zip_reverse_to_array_m5(b : B?) {
-    run_m5(b, 100000)
 }
 
 [benchmark]

--- a/daslib/linq_fold_common.das
+++ b/daslib/linq_fold_common.das
@@ -2234,16 +2234,6 @@ def build_join_adapter_pieces(
 
 
 [macro_function]
-def finalize_decs_emission(var emission : Expression?; at : LineInfo; wrapToIter : bool) : Expression? {
-    emission.force_at(at)
-    emission.force_generated(true)
-    if (wrapToIter) {
-        emission = qmacro($e(emission).to_sequence_move())
-    }
-    return emission
-}
-
-[macro_function]
 def buffer_return(bufName : string; isIterator : bool) : Expression? {
     if (isIterator) return <- qmacro_expr() {
         return <- $i(bufName).to_sequence_move()

--- a/daslib/linq_fold_decs.das
+++ b/daslib/linq_fold_decs.das
@@ -17,6 +17,18 @@ require daslib/macro_boost
 require strings
 require daslib/linq_fold_common public
 
+// Stamp the assembled decs walk with the call-site LineInfo + the generated flag, optionally
+// wrapping it back into an iterator. Decs-only finalizer for the adapter emit paths below.
+[macro_function]
+def finalize_decs_emission(var emission : Expression?; at : LineInfo; wrapToIter : bool) : Expression? {
+    emission.force_at(at)
+    emission.force_generated(true)
+    if (wrapToIter) {
+        emission = qmacro($e(emission).to_sequence_move())
+    }
+    return emission
+}
+
 // Hashed equi-join payload — feeds the per-pair `let resBindName = result(tupA,tupB)` bind used by both GroupBy's decs-join arm and `emit_decs_join_impl`. The 2 consumers differ on whether the per-pair loop is the right granularity (GroupBy: yes; emit_decs_join_impl keeps a bucket-length fast path for count-no-where).
 struct DecsJoinShape {
     bridgeA, bridgeB : DecsBridgeShape?


### PR DESCRIPTION
Two small post-G3d cleanups in the linq_fold / benchmark area.

## 1. Drop the un-fused XML (m5) benchmark lane + results column

The `benchmarks/sql` matrix carried two XML lanes: **m5** (un-fused — drop `_fold(`, source the rows via `from_xml_node`, pipe with `|>`) and **m5f** (the fused `_fold` adapter path). Now that the XML adapter is mature, m5 no longer earns its keep — across the whole suite m5 ≈ m5f for cascades and m5f wins where the adapter fuses, so the un-fused lane adds noise without signal. This mirrors the earlier drop of the un-fused **m3** array lane.

- 71 bench files: removed `def run_m5(...)` + `[benchmark] def X_m5(...)` wrappers + orphaned `// m5_xml lane:` comments. m5f intact.
- `_update_results.das`: m5 removed from `LANES` / `HEADERS`.
- `results.md`: m5 column removed from both tables (m1/m3f/m4/m5f values preserved — textual edit, no re-sweep); the "Reading the XML lanes (m5 vs m5f)" section reframed in absolute terms for m5f alone (fused families / field-pruning wins / materialize-under-guard / string-clone floor).
- `_common.das`: fixed 4 pre-existing LINT013 unused-`eid` block args (surfaced because touching the file makes CI lint it whole).

## 2. Relocate `finalize_decs_emission` to `linq_fold_decs`

`finalize_decs_emission` is decs-only — all 4 callers live in `linq_fold_decs.das`. It sat in `linq_fold_common` as a leftover from before the decs adapter owned its emit paths (pre-G3d). Moved it next to its callers; nothing else references it. Pure relocation, emission unchanged.

## Verification

- INTERP / JIT / AOT all green: `tests/decs` 245, `tests/linq` 1781 — no AOT semantic-hash desync.
- Lint + format clean on both changed `.das` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)