### PR TITLE
Dynamic modules: order-independent loading (defer failed dlopen + fixed-point retry)

### DIFF
--- a/src/ast/dyn_modules.cpp
+++ b/src/ast/dyn_modules.cpp
@@ -11,6 +11,10 @@ das::FileAccessPtr get_file_access( char * pak );
 
 namespace das {
 
+// Defined in module_builtin_fio.cpp — re-attempts modules whose dlopen was
+// deferred during the folder scan (sibling-module dependency loaded out of order).
+void retry_pending_dynamic_modules();
+
 static constexpr const char *MODULE_SUFFIX = ".das_module";
 static constexpr const char *INIT_NAME = "initialize";
 
@@ -240,6 +244,12 @@ bool require_dynamic_modules(FileAccessPtr file_access,
     for (const auto &p : load_modules) {
         all_good &= (Result::OK == init_dyn_modules(file_access, p, tout));
     }
+    // Module .so's may carry DT_NEEDED on sibling-module .so's (e.g. node-editor ->
+    // dasModuleImgui) that live in modules/<dep>/ and aren't on RUNPATH. Directory
+    // enumeration order is unsorted on Linux (readdir), so a dependent can be visited
+    // before its dependency — its register_dynamic_module dlopen then fails and is
+    // deferred. Retry the deferred set in fixed-point passes so order stops mattering.
+    retry_pending_dynamic_modules();
     return all_good;
 }
 

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -13,6 +13,7 @@
 
 #include "daScript/misc/performance_time.h"
 #include "daScript/misc/sysos.h"
+#include "daScript/misc/string_writer.h"   // LOG / LogLevel — env-gated module-load trace
 
 #include <sstream>
 #include <chrono>
@@ -1320,6 +1321,22 @@ namespace das {
 
     static vector<tuple<string,string,string>> g_registered_dynamic_modules; // path, cpp_class_name, daslang_name
     static vector<tuple<string,string,string>> g_registered_native_paths;
+    // Modules whose dlopen failed in Quiet mode — typically a sibling-module
+    // DT_NEEDED dependency (e.g. node-editor -> dasModuleImgui) not yet loaded.
+    // retry_pending_dynamic_modules() re-attempts these in fixed-point passes
+    // after the folder scan, so module enumeration order stops mattering.
+    static vector<tuple<string,string>> g_pending_dynamic_modules; // path, cpp_class_name
+
+    // Env-gated per-attempt module-load trace (default off). Set
+    // DAS_TRACE_MODULE_LOAD=1 to surface each dlopen — turns a swallowed
+    // 'missing prerequisite' into a visible "FAILED — <dlerror>" line.
+    static bool trace_module_load() {
+        static const bool on = []{
+            const char * e = getenv("DAS_TRACE_MODULE_LOAD");
+            return e && e[0] && e[0] != '0';
+        }();
+        return on;
+    }
 
     // Returns DLL handle.
     void *register_dynamic_module(const char *path, const char *mod_name, int on_error, Context * context, LineInfoArg * at ) {
@@ -1333,15 +1350,26 @@ namespace das {
         }
 #endif
         auto lib = loadDynamicLibrary(actualPath.c_str());
+        // Capture the dlopen error once, before anything else can clear it.
+        string dlErr = lib ? string() : getDynamicLibraryError();
+        if ( trace_module_load() ) {
+            LOG(LogLevel::info) << "[module] " << (mod_name ? mod_name : "(null)") << " <- " << actualPath
+                << " : " << (lib ? "loaded" : ("FAILED — " + dlErr)) << "\n";
+        }
         if (!lib) {
             if (static_cast<RegisterOnError>(on_error) != RegisterOnError::Quiet) {
-                auto dlErr = getDynamicLibraryError();
                 auto err_msg = "dynamic module `" + string(mod_name) + "` — failed to load: " + actualPath
                     + (dlErr.empty() ? string("\n") : (" (" + dlErr + ")\n"));
                 context->to_err(at, err_msg.c_str());
                 if (static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                     context->throw_error(err_msg.c_str());
                 }
+            } else {
+                // Quiet: a sibling-module DT_NEEDED dependency may not be loaded yet
+                // (module .so's live in modules/<dep>/, not on RUNPATH, so a dependent
+                // enumerated before its dependency fails dlopen). Defer; the post-scan
+                // retry_pending_dynamic_modules() re-attempts once deps are loaded.
+                g_pending_dynamic_modules.emplace_back(string(path), string(mod_name));
             }
             return nullptr;
         }
@@ -1349,8 +1377,8 @@ namespace das {
         auto rawFn = getFunctionAddress(lib, regName.c_str());
         if (!rawFn) {
             auto err_msg = "dynamic module `" + string(mod_name) + "` — function `" + regName + "` not found in `" + path + "`\n";
-            context->to_err(at, err_msg.c_str());
-            if (static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
+            if (context) context->to_err(at, err_msg.c_str());
+            if (context && static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                 context->throw_error(err_msg.c_str());
             }
             closeLibrary(lib);
@@ -1360,8 +1388,8 @@ namespace das {
         auto mod = fn(DAS_BUILD_ID);
         if (!mod) {
             auto err_msg = "dynamic module `" + string(mod_name) + "` — build-id mismatch (host " + to_string(DAS_BUILD_ID) + "); rebuild the module for current configuration\n";
-            context->to_err(at, err_msg.c_str());
-            if (static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
+            if (context) context->to_err(at, err_msg.c_str());
+            if (context && static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                 context->throw_error(err_msg.c_str());
             }
             closeLibrary(lib);
@@ -1373,6 +1401,28 @@ namespace das {
     }
     void *register_dynamic_module_silent(const char *path, const char *mod_name, Context * context, LineInfoArg * at ) {
         return register_dynamic_module(path, mod_name, static_cast<int>(RegisterOnError::Quiet), context, at);
+    }
+
+    // Re-attempt modules whose dlopen was deferred (Quiet failure during the
+    // module-folder scan — usually a sibling-module DT_NEEDED dep not yet loaded
+    // because directory enumeration visited the dependent before its dependency).
+    // Fixed-point: each pass retries every deferred module; one whose deps loaded
+    // in a prior pass now succeeds and may unblock others. Keep iterating while a
+    // pass loads at least one; stop when a pass makes no progress (remaining
+    // entries have genuinely-missing .so files — left silent, matching Quiet).
+    void retry_pending_dynamic_modules() {
+        bool progress = true;
+        while (progress && !g_pending_dynamic_modules.empty()) {
+            progress = false;
+            vector<tuple<string,string>> pending;
+            pending.swap(g_pending_dynamic_modules); // drain; failures re-push into the now-empty global
+            for (auto & pr : pending) {
+                if (register_dynamic_module(get<0>(pr).c_str(), get<1>(pr).c_str(),
+                        static_cast<int>(RegisterOnError::Quiet), nullptr, nullptr) != nullptr) {
+                    progress = true;
+                }
+            }
+        }
     }
 
     void register_native_path(const char *mod_name, const char *src_path, const char *dst_path, Context * /*context*/, LineInfoArg * /*at*/ ) {


### PR DESCRIPTION
## Problem

Dynamic modules are loaded by walking `modules/` in **raw directory-enumeration order** (`init_modules_for_folder` in `src/ast/dyn_modules.cpp`: `readdir` on POSIX, `_findnext` on Windows). A module `.so` that carries a `DT_NEEDED` on a **sibling-module** `.so` — e.g. `dasImguiNodeEditor` → `dasModuleImgui` → `dasModuleGlfw` — can only resolve that dependency if the dependency is already loaded: the sibling `.so` lives in `modules/<dep>/`, **not** on the `.so`'s `RUNPATH` (`lib/`).

When enumeration visits a *dependent* before its *dependency*, the dependent's `dlopen` fails, and `register_dynamic_module`'s `Quiet` mode **silently swallows** it. The module never registers, surfacing much later as a misleading `error[20605]: missing prerequisite '<module>'`.

Because this depends on directory-enumeration order, it was platform-split:

- **Windows CI — reliably green.** NTFS `_findnext` returns entries **sorted by name**, and alphabetical order happened to match dependency order (`dasGlfw` < `dasImgui` < `dasImguiNodeEditor`), so every dependency loaded before its dependents.
- **Linux/macOS CI — flaky.** `readdir` order is **unsorted** (ext4 hash order) and machine-dependent. When a dependent was enumerated first, *all* of that module's tests failed to compile with `20605`. This is the intermittent `dasImguiNodeEditor` POSIX failure.

## Fix

When a `Quiet` `dlopen` fails, **defer** `(path, module)` instead of dropping it, then retry the deferred set in **fixed-point passes** after the folder scan (`retry_pending_dynamic_modules`):

- each pass re-attempts every deferred module; one whose dependency loaded in a prior pass now succeeds and may unblock others;
- iterate while a pass loads at least one module; stop when a pass makes no progress (the remaining entries are genuinely-missing optional `.so` files — left silent, exactly as before).

Order-independent, handles arbitrary dependency depth, and each module's `initialize()` still runs **exactly once** (so no duplicate `register_native_path` entries). On Windows nothing is ever deferred (sorted enumeration), so the retry pass is a no-op there — no behavior change.

## Diagnostics

Adds an env-gated per-attempt trace (`DAS_TRACE_MODULE_LOAD=1`, off by default) that logs each `dlopen` via the daScript logger:

```
[module] <name> <- <path> : loaded | FAILED — <dlerror>
```

This turns a swallowed prerequisite error into a visible cause ("re-run with it enabled" rather than re-instrumenting). The factory-missing and build-id-mismatch error paths are now null-context-guarded so the context-less retry can't dereference a null `Context`.

## Verification

Reproduced in an Ubuntu-24.04 WSL environment replicating the `dasImguiNodeEditor` integration CI job **verbatim** (fresh clones at the CI refs, CI's exact cmake flags, `daspkg install --global` order, headless test command):

- **before:** `32 tests, 0 passed, 32 errors` — every file fails to compile with `20605` (worst-case `readdir` order; node-editor enumerated before imgui before glfw).
- **after:** `21 tests, 20 passed, 1 failed, 0 errors` — **identical to the Windows CI result** (the lone remaining failure is an unrelated test assertion).

The `DAS_TRACE_MODULE_LOAD=1` trace shows the deferred modules failing on the scan pass and then loading on a retry pass once their dependencies are in.

Compiles clean on clang 18 (Linux) and MSVC (`libDaScript`).

## Follow-up (separate PR)

A topological sort of packages by their declared `require_package` dependencies, so modules are loaded in dependency order in the first place. The defer+retry here gives correctness now without needing the dependency graph; the topo-sort is the "load in the right order up front" refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)