### PR TITLE
linq_das: C#-style %linq! query syntax + named-variable lambdas in _fold ops

### DIFF
--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -41,7 +41,21 @@ class private AstCallMacro_LinqPred2 : AstCallMacro {
         macro_verify(!arg0type.firstType.isAutoOrAlias, prog, call.at, "iterable type cannot be auto or alias")
         // replacing function
         var iterType = clone_iterator_type(arg0type)
-        var res = qmacro($c(predName)($e(arg0), $(_ : $t(iterType)) => $e(call.arguments[1])))
+        var res : ExpressionPtr
+        if (call.arguments[1] is ExprMakeBlock) {
+            // named-variable form: the argument is already a `$(x) => …` block (e.g. emitted by linq_das).
+            // Inject the element type onto the user's parameter and pass the block through, instead of
+            // wrapping a bare expression in `$(_ : iterType) => …`. The C# range variable thus survives verbatim.
+            var blk = call.arguments[1] as ExprMakeBlock
+            var inner = blk._block as ExprBlock
+            macro_verify(length(inner.arguments) == 1, prog, call.at, "{predName}: block argument must take exactly one parameter")
+            if (inner.arguments[0]._type == null || inner.arguments[0]._type.isAutoOrAlias) {
+                inner.arguments[0]._type = clone_type(iterType)
+            }
+            res = qmacro($c(predName)($e(arg0), $e(call.arguments[1])))
+        } else {
+            res = qmacro($c(predName)($e(arg0), $(_ : $t(iterType)) => $e(call.arguments[1])))
+        }
         // allow inner `_` to shadow an outer `_` when chains nest
         // (e.g. `_where(_.x._in(arr |> _select(_.y)))`)
         (((res as ExprCall).arguments[1] as ExprMakeBlock)._block as ExprBlock).arguments[0].flags.can_shadow = true
@@ -304,7 +318,20 @@ class private AstCallMacro_LinqPredII2 : AstCallMacro {
         macro_verify(!call.arguments[0]._type.firstType.isAutoOrAlias, prog, call.at, "iterator or array type cannot be auto or alias")
         // replacing function
         var iterType = clone_iterator_type(call.arguments[0]._type)
-        var res = qmacro($c(predName)($e(call.arguments[0]), $e(call.arguments[1]), $(_ : $t(iterType)) => $e(call.arguments[2])))
+        var res : ExpressionPtr
+        if (call.arguments[2] is ExprMakeBlock) {
+            // named-variable form: the argument is already a `$(x) => …` block — inject the element type
+            // onto the user's parameter and pass it through (see AstCallMacro_LinqPred2 for rationale).
+            var blk = call.arguments[2] as ExprMakeBlock
+            var inner = blk._block as ExprBlock
+            macro_verify(length(inner.arguments) == 1, prog, call.at, "{predName}: block argument must take exactly one parameter")
+            if (inner.arguments[0]._type == null || inner.arguments[0]._type.isAutoOrAlias) {
+                inner.arguments[0]._type = clone_type(iterType)
+            }
+            res = qmacro($c(predName)($e(call.arguments[0]), $e(call.arguments[1]), $e(call.arguments[2])))
+        } else {
+            res = qmacro($c(predName)($e(call.arguments[0]), $e(call.arguments[1]), $(_ : $t(iterType)) => $e(call.arguments[2])))
+        }
         // allow inner `_` to shadow an outer `_` when chains nest
         (((res as ExprCall).arguments[2] as ExprMakeBlock)._block as ExprBlock).arguments[0].flags.can_shadow = true
         res.force_at(call.at)

--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -1,0 +1,178 @@
+options gen2
+
+module linq_das
+
+require strings
+require daslib/ast
+require daslib/ast_boost
+require daslib/linq_boost public
+
+// ===== C#-style LINQ query syntax (linq_das) — v1: array source, from/where/select =====
+//
+// The `%linq! … %%` inline reader macro rewrites a C#-like query into a `_fold(...)` chain:
+//
+//     %linq! from c in cars where c.price > 100 select c.name %%
+//        →   ( _fold( each(cars) |> _where(_.price > 100) |> _select(_.name) |> to_array() ) )
+//
+// v1 covers `from`/`where`/`select` over an array source. The range variable is spliced verbatim as the
+// block parameter (`_where($(c) => ...)`), so the predicate/projection text needs no rewriting; a typed
+// source `from c : T in db` and the `orderby`/`group by`/`join` clauses are not yet supported.
+
+def private is_ident_byte(c : int) : bool {
+    return is_alnum(c) || c == '_'
+}
+
+// Byte offset of the next whole-word `kw` at paren/bracket/brace depth 0 in q[from..], or -1.
+// String literals are skipped so a keyword inside `"..."` never matches, and a word immediately
+// following `.` (a member access like `c.where`) is not treated as a clause keyword.
+def private find_kw_depth0(q : string; kw : string; from : int) : int {
+    var found = -1
+    let m = length(kw)
+    peek_data(q) $(arr) {
+        let n = length(arr)
+        var depth = 0
+        var inStr = false
+        var prevSig = 0   // last significant (non-whitespace) byte, 0 = none
+        var i = from
+        while (i < n && found < 0) {
+            let c = int(arr[i])
+            if (inStr) {
+                if (c == '\\') { i += 2; continue }
+                if (c == '"') { inStr = false; prevSig = c }
+                i++
+                continue
+            }
+            if (c == '"') { inStr = true; prevSig = c; i++; continue }
+            if (c == '(' || c == '[' || c == '{') { depth++; prevSig = c; i++; continue }
+            if (c == ')' || c == ']' || c == '}') { depth--; prevSig = c; i++; continue }
+            // a clause keyword is a depth-0 whole word NOT preceded (ignoring whitespace) by `.`
+            let atWordStart = is_ident_byte(c) && ((i == 0) || !is_ident_byte(int(arr[i - 1]))) && prevSig != '.'
+            if (depth == 0 && atWordStart && i + m <= n && slice(q, i, i + m) == kw) {
+                if (i + m == n || !is_ident_byte(int(arr[i + m]))) {
+                    found = i
+                }
+            }
+            if (!is_white_space(c)) { prevSig = c }
+            i++
+        }
+    }
+    return found
+}
+
+// Read the identifier at/after `from` (skipping leading whitespace); returns (name, endOffset).
+// name is "" when no identifier is present.
+def private read_ident(q : string; from : int) : tuple<string; int> {
+    var s = -1
+    var e = -1
+    peek_data(q) $(arr) {
+        let n = length(arr)
+        var i = from
+        while (i < n && !is_ident_byte(int(arr[i]))) { i++ }
+        s = i
+        while (i < n && is_ident_byte(int(arr[i]))) { i++ }
+        e = i
+    }
+    if (s < 0 || e <= s) { return ("", -1) }
+    return (slice(q, s, e), e)
+}
+
+// Parse the query and emit the `_fold(...)` rewrite text. On a malformed query, register a macro error
+// and emit a benign `(0)` so the surrounding statement still parses (the error is the real signal).
+def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : string {
+    let q = strip(query)
+    let nq = length(q)
+    let fromWord = read_ident(q, 0)
+    if (fromWord._0 != "from") {
+        macro_error(prog, at, "linq: query must start with the 'from' keyword (got: {q})")
+        return "(0)"
+    }
+    let vp = read_ident(q, fromWord._1)
+    let varName = vp._0
+    let afterVar = vp._1
+    if (varName == "") {
+        macro_error(prog, at, "linq: expected a range variable after 'from'")
+        return "(0)"
+    }
+    let inPos = find_kw_depth0(q, "in", afterVar)
+    if (inPos < 0) {
+        macro_error(prog, at, "linq: expected 'in' after range variable '{varName}'")
+        return "(0)"
+    }
+    let between = strip(slice(q, afterVar, inPos))
+    if (starts_with(between, ":")) {
+        macro_error(prog, at, "linq: typed sources ('from c : Type in ...') are not supported yet (v1: array only)")
+        return "(0)"
+    }
+    if (between != "") {
+        macro_error(prog, at, "linq: unexpected '{between}' between range variable and 'in'")
+        return "(0)"
+    }
+    let srcStart = inPos + 2
+    let wherePos = find_kw_depth0(q, "where", srcStart)
+    let selectPos = find_kw_depth0(q, "select", wherePos >= 0 ? wherePos + 5 : srcStart)
+    if (selectPos < 0) {
+        macro_error(prog, at, "linq: query must end with a 'select' clause (v1)")
+        return "(0)"
+    }
+    let srcEnd = wherePos >= 0 ? wherePos : selectPos
+    let srcText = strip(slice(q, srcStart, srcEnd))
+    if (srcText == "") {
+        macro_error(prog, at, "linq: empty source expression after 'in'")
+        return "(0)"
+    }
+    let hasWhere = wherePos >= 0
+    var predText = ""
+    if (hasWhere) {
+        predText = strip(slice(q, wherePos + 5, selectPos))
+        if (predText == "") {
+            macro_error(prog, at, "linq: empty 'where' predicate")
+            return "(0)"
+        }
+    }
+    let projText = strip(slice(q, selectPos + 6, nq))
+    if (projText == "") {
+        macro_error(prog, at, "linq: empty 'select' projection")
+        return "(0)"
+    }
+    // `select c` (the range variable alone) is the identity projection — no `_select` is emitted.
+    let identitySelect = (projText == varName)
+    return build_string() $(var writer) {
+        writer |> write("( _fold( each(")
+        writer |> write(srcText)
+        writer |> write(")")
+        if (hasWhere) {
+            writer |> write(" |> _where($(")
+            writer |> write(varName)
+            writer |> write(") => ")
+            writer |> write(predText)
+            writer |> write(")")
+        }
+        if (!identitySelect) {
+            writer |> write(" |> _select($(")
+            writer |> write(varName)
+            writer |> write(") => ")
+            writer |> write(projText)
+            writer |> write(")")
+        }
+        writer |> write(" |> to_array() ) )")
+    }
+}
+
+[reader_macro(name=linq)]
+class LinqDasReader : AstReaderMacro {
+    //! C#-style LINQ query reader macro. ``%linq! from c in src where <pred> select <proj> %%`` rewrites
+    //! to a ``_fold(...)`` chain over an array source. v1: ``from``/``where``/``select`` only, single
+    //! range variable (spliced verbatim as the block parameter), array source.
+    def override accept(prog : ProgramPtr; mod : Module?; var expr : ExprReader?; ch : int; info : LineInfo) : bool {
+        append(expr.sequence, ch)
+        if (ends_with(expr.sequence, "%%")) {
+            resize(expr.sequence, length(expr.sequence) - 2)
+            return false
+        }
+        return true
+    }
+    def override suffix(prog : ProgramPtr; mod : Module?; var expr : ExprReader?; info : LineInfo;
+                        var outLine : int&; var outFile : FileInfo?&) : string {
+        return transpile_query(string(expr.sequence), prog, info)
+    }
+}

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -28,4 +28,5 @@ THE SOFTWARE.
    utils.rst
    tutorials.rst
    linq_fold_patterns.rst
+   linq_das.rst
    strudel_vs_strudel_cc.rst

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -1,0 +1,78 @@
+.. _linq_das:
+
+============================================================
+C#-style LINQ query syntax (``%linq!``)
+============================================================
+
+``daslib/linq_das`` adds a C#-like query-expression form through the
+``%linq! … %%`` inline reader macro. A query is a purely mechanical,
+compile-time rewrite into a ``_fold(...)`` chain, so it rides the same fused
+execution engine as the pipe-form LINQ operators (see
+:ref:`linq_fold_patterns`) with no runtime cost over the hand-written chain.
+
+.. code-block:: das
+
+    require daslib/linq_das
+
+    var names <- %linq! from c in cars where c.price > 100 select c.name %%
+
+rewrites to, and is re-parsed in place as:
+
+.. code-block:: das
+
+    var names <- ( _fold( each(cars) |> _where($(c) => c.price > 100) |> _select($(c) => c.name) |> to_array() ) )
+
+The macro lives in the lexer's inline reader-macro slot (``%name!``), so a
+query is an ordinary expression — it can be assigned, passed as an argument, or
+embedded in a larger expression.
+
+Clauses (v1)
+------------
+
+Version 1 supports ``from`` / ``where`` / ``select`` over an array source:
+
+- ``from <var> in <source>`` — ``<source>`` is any expression evaluating to an
+  ``array<T>``. The element bind ``<var>`` names the per-row value.
+- ``where <predicate>`` — optional. Omitted when absent.
+- ``select <projection>`` — required. ``select <var>`` (the identity
+  projection) returns the filtered elements unchanged; any other projection is
+  emitted as ``_select(...)``.
+
+The clauses may span multiple lines inside the ``%linq! … %%`` body.
+
+Range variable
+--------------
+
+The range variable is spliced **verbatim** as the lambda parameter — the
+predicate becomes ``_where($(c) => …)`` and the projection ``_select($(c) =>
+…)``, keeping the C# variable name. The predicate and projection text is passed
+through unchanged (no token rewriting). Any identifier name works, and it may
+appear any number of times.
+
+The ``_fold`` operator DSL accepts a named-variable ``$(x) => …`` block
+directly: ``_where`` / ``_select`` (and the rest of the placeholder operators)
+inject the element type onto the parameter and pass the block through. The
+``_`` placeholder form (``_where(_ < 5)``) remains available for hand-written
+chains.
+
+Result
+------
+
+The query materializes to an ``array<T>`` (via ``to_array()``), where ``T`` is
+the projection type — or the source element type for an identity ``select``.
+
+Current limitations (v1)
+------------------------
+
+The following are not yet supported and produce a compile error:
+
+- **Typed sources** — ``from c : Car in db`` (the annotated range variable that
+  selects a non-array source such as SQL, decs, or JSON).
+- **Additional clauses** — ``orderby`` / ``group by`` / ``join``.
+- **Multiple ``from``** (SelectMany), ``let`` bindings, and ``into``
+  continuations.
+
+v1 parses a single ``from``, so a query has one range variable. The operator
+DSL now accepts named-variable blocks (so multiple range variables are
+mechanically expressible), but the multi-variable query forms — joins and
+multiple ``from`` — are not yet parsed by the reader macro.

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -285,6 +285,9 @@ FILE(GLOB AOT_READER_MACRO_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPEND
 # Anchor on '/' so this does not also drop test_inline_reader.das (which ends in inline_reader.das).
 list(FILTER AOT_READER_MACRO_FILES EXCLUDE REGEX "/inline_reader\\.das$")
 
+# AOT for linq_das test files (the %linq! reader macro lives in daslib/linq_das, required transitively)
+FILE(GLOB AOT_LINQ_DAS_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/linq_das/*.das")
+
 # AOT for macro_call test files
 FILE(GLOB AOT_MACRO_CALL_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/macro_call/*.das")
 # Exclude helpers (files prefixed with `_`); they are required transitively
@@ -648,6 +651,10 @@ add_custom_target(test_aot_reader_macro)
 SET(READER_MACRO_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_READER_MACRO_FILES}" READER_MACRO_AOT_GENERATED_SRC test_aot_reader_macro daslang)
 
+add_custom_target(test_aot_linq_das)
+SET(LINQ_DAS_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_LINQ_DAS_FILES}" LINQ_DAS_AOT_GENERATED_SRC test_aot_linq_das daslang)
+
 add_custom_target(test_aot_safe_addr)
 SET(SAFE_ADDR_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_SAFE_ADDR_FILES}" SAFE_ADDR_AOT_GENERATED_SRC test_aot_safe_addr daslang)
@@ -776,6 +783,7 @@ SOURCE_GROUP_FILES("aot generated" MODULE_TESTS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" OPTION_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" REGEX_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" READER_MACRO_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" LINQ_DAS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" SAFE_ADDR_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DELEGATE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" SOA_AOT_GENERATED_SRC)
@@ -850,6 +858,7 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${OPTION_AOT_GENERATED_SRC}
     ${REGEX_AOT_GENERATED_SRC}
     ${READER_MACRO_AOT_GENERATED_SRC}
+    ${LINQ_DAS_AOT_GENERATED_SRC}
     ${SAFE_ADDR_AOT_GENERATED_SRC}
     ${DELEGATE_AOT_GENERATED_SRC}
     ${SOA_AOT_GENERATED_SRC}
@@ -902,7 +911,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_match
     test_aot_math test_aot_math_modules test_aot_module_tests
     test_aot_option
-    test_aot_regex test_aot_reader_macro
+    test_aot_regex test_aot_reader_macro test_aot_linq_das
     test_aot_delegate test_aot_safe_addr test_aot_soa test_aot_spoof test_aot_strings
     test_aot_lint test_aot_promote test_aot_rtti
     test_aot_template test_aot_type_traits test_aot_uri

--- a/tests/linq_das/test_linq_das.das
+++ b/tests/linq_das/test_linq_das.das
@@ -1,0 +1,102 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/linq_das
+
+// linq_das v1: C#-style `%linq! from c in src where <pred> select <proj> %%` over an array source.
+// The reader macro renames the single range variable to the `_` placeholder and emits a `_fold(...)`
+// chain materialized via `to_array()`.
+
+struct Car {
+    name  : string
+    price : int
+}
+
+def private mk_cars() : array<Car> {
+    return <- [Car(name="cheap", price=50),
+               Car(name="mid", price=150),
+               Car(name="lux", price=300)]
+}
+
+[test]
+def test_where_select(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars where c.price > 100 select c.name %%
+    t |> equal(length(names), 2, "where filters, select projects names")
+    t |> equal(names[0], "mid")
+    t |> equal(names[1], "lux")
+}
+
+[test]
+def test_select_only(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars select c.name %%
+    t |> equal(length(names), 3, "no where: every element projected")
+    t |> equal(names[0], "cheap")
+    t |> equal(names[2], "lux")
+}
+
+[test]
+def test_identity_select(t : T?) {
+    // `select c` is identity — no `_select` is emitted; the result is the filtered elements.
+    let cars <- mk_cars()
+    let kept <- %linq! from c in cars where c.price >= 150 select c %%
+    t |> equal(length(kept), 2, "identity select returns filtered structs")
+    t |> equal(kept[0].name, "mid")
+    t |> equal(kept[1].name, "lux")
+}
+
+[test]
+def test_where_no_match(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars where c.price > 10000 select c.name %%
+    t |> equal(length(names), 0, "no element matches → empty result")
+}
+
+[test]
+def test_numeric_projection_and_parens(t : T?) {
+    // parenthesized predicate + multiple range-var refs + numeric projection
+    let cars <- mk_cars()
+    let prices <- %linq! from c in cars where (c.price > 100) && c.price < 300 select c.price %%
+    t |> equal(length(prices), 1, "only mid (150) is >100 and <300")
+    t |> equal(prices[0], 150)
+}
+
+[test]
+def test_string_literal_in_predicate(t : T?) {
+    // the keyword 'select' and the range var 'c' inside a string literal must NOT be touched
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars where c.name == "lux" select c.name %%
+    t |> equal(length(names), 1, "string-literal predicate matches exactly one")
+    t |> equal(names[0], "lux")
+}
+
+[test]
+def test_inline_in_larger_expression(t : T?) {
+    // %linq! is an inline reader macro — it composes inside a larger expression
+    let cars <- mk_cars()
+    let n = length(%linq! from c in cars where c.price > 100 select c.name %%)
+    t |> equal(n, 2, "query result used directly as a call argument")
+}
+
+[test]
+def test_arbitrary_range_var_name(t : T?) {
+    // the range variable is spliced verbatim as the block parameter — any identifier name works,
+    // and it is kept (not rewritten to `_`), appearing in both predicate and projection
+    let cars <- mk_cars()
+    let names <- %linq! from car in cars where car.price > 100 select car.name %%
+    t |> equal(length(names), 2, "multi-char range var splices verbatim")
+    t |> equal(names[0], "mid")
+}
+
+[test]
+def test_multiline_query(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq!
+        from c in cars
+        where c.price > 100
+        select c.name
+    %%
+    t |> equal(length(names), 2, "multi-line query body parses identically")
+    t |> equal(names[0], "mid")
+}


### PR DESCRIPTION
## What

Two things:

1. **`daslib/linq_das`** — C#-style LINQ query syntax via the `%linq! … %%` inline reader macro (built on the Phase-0 expression-level reader macro, PR #2957). A query is a compile-time mechanical rewrite into a `_fold(...)` chain.
2. **Named-variable lambdas in the `_fold` operator DSL** — so the query's range variable splices through **verbatim** (no `c`→`_` rename).

```das
%linq! from c in cars where c.price > 100 select c.name %%
```
rewrites to, and is re-parsed in place as:
```das
( _fold( each(cars) |> _where($(c) => c.price > 100) |> _select($(c) => c.name) |> to_array() ) )
```

so it rides the same fused engine as the pipe-form LINQ operators, with no runtime cost over the hand-written chain.

## linq_das (v1)

- `from` / `where` / `select` over an **array** source.
- The range variable and the predicate/projection text are spliced **verbatim** — no token rewriting. `select c` (identity) returns the filtered elements; the result materializes to an array via `to_array()`.
- The `suffix` is a pure string rewrite: depth- and string-literal-aware clause splitting. Malformed queries surface as `macro_error` diagnostics at parse time.
- Not yet supported (clean compile errors): typed sources (`from c : T in db`), `orderby` / `group by` / `join`, multiple-`from` / `let` / `into`.

## Named-variable lambdas (`linq_boost`)

`AstCallMacro_LinqPred2` / `AstCallMacro_LinqPredII2` — the bases for ~37 ops (`_where` / `_select` / `_min_by` / `_order_by` / `_group_by` / … and the two-iterator `_except_by` / `_intersect_by` / `_union_by` / `_sequence_equal_by`) — now detect when the argument is already a `$(x) => …` block, inject the element type onto the user's parameter, and pass it through, instead of wrapping a bare expression in `$(_ : T) => …`. The bare-expression `_` placeholder path is **unchanged**, so existing chains emit identical AST (the join family already accepted named lambdas).

## Review fixes (round 1)

- `find_kw_depth0` now rejects a clause keyword preceded by `.` (member access). Note: `c.where` / `c.select` / `c.in` aren't actually constructible (those names are reserved and can't be field names), so the guard is defensive.
- `from` must be a standalone keyword — `fromc …` is now rejected with a clear error instead of mis-parsing.

## Verification

- `tests/` INTERP: 10109 passed, 0 failed
- `tests/` AOT: 9453 passed, 0 failed
- `tests/linq_das/`: 9/9 in INTERP, JIT, and AOT; existing linq/sql/decs suites unaffected by the `linq_boost` change
- lint + `das-fmt` verify: clean
- Sphinx `-W`: build succeeded, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)