### PR TITLE
CI: extended_checks Windows on Ninja + Defender exclusion; fix libhv build-type for single-config generators

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -56,7 +56,7 @@ jobs:
           - target: windows
             runner: windows-latest-fat
             build_system: cmake
-            cmake_generator: Visual Studio 17 2022
+            cmake_generator: Ninja
             architecture_string: x64
 
         exclude:
@@ -74,11 +74,28 @@ jobs:
         # Full history so the lint step can `git diff` against the PR base branch.
         fetch-depth: 0
 
+    - name: "Exclude workspace from Windows Defender"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      continue-on-error: true
+      # Real-time Defender scans every .obj/.exe/.dll the build writes and every
+      # process + DLL load at test time; excluding the workspace cuts Windows CI
+      # wall-time. continue-on-error: a managed-Defender runner must not fail CI.
+      run: |
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionProcess "daslang.exe"
+        Add-MpPreference -ExclusionProcess "daslang_static.exe"
+
     - name: "Install CMake and Ninja"
       uses: lukka/get-cmake@latest
 
     - if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@v1
+
+    - if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
 
     - name: "Install: Required Dev Packages"
       run: |
@@ -126,9 +143,12 @@ jobs:
         ACTIVE_MODULES=$(grep -v "^#" ci/release_modules.txt | cut -d':' -f2 | sed 's|^|-D|' | xargs)
         case "${{ matrix.target }}" in
           windows)
-            echo "BIN=./bin/Release" >> $GITHUB_ENV
+            # Ninja single-config: binaries land in ./bin (not ./bin/Release);
+            # cl.exe is on PATH via the msvc-dev-cmd step; OpenSSL comes from
+            # vcpkg so dasHV skips its perl+nmake source build.
+            echo "BIN=./bin" >> $GITHUB_ENV
             export PATH="/c/Strawberry/perl/bin:$PATH"
-            cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -T host=x64 -A ${{ matrix.architecture_string }} \
+            cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE:STRING=Release \
               $ACTIVE_MODULES -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
             cmake --build ./build --config Release --target daslang das-fmt daslang_static --parallel
             ;;

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -74,6 +74,12 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 
 
 	SET(HV_CMAKE_FLAGS
+		# Pin the libhv sub-build's config. Multi-config generators (VS) honor
+		# the --config in BUILD/INSTALL_COMMAND below; single-config ones (Ninja)
+		# ignore --config, so without this libhv defaults to Debug and its
+		# debug-CRT hv_static.lib fails to link into Release dasModuleHV on MSVC
+		# (unresolved __imp__CrtDbgReport).
+		-DCMAKE_BUILD_TYPE=$<CONFIG>
 		-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
 		-DCMAKE_INSTALL_PREFIX=${DAS_HV_DIR}/hv/Release
 		-DBUILD_EXAMPLES=OFF


### PR DESCRIPTION
Windows CI is the slow outlier on both compile and test wall-time. Two root causes — addressed here for `extended_checks.yml`, the first of the VS-generator Windows jobs.

## Blocker found while switching to Ninja (the real fix)
`modules/dasHV/CMakeLists.txt` builds the libhv `ExternalProject` with `--config $<CONFIG>` in its BUILD/INSTALL commands. **Single-config generators (Ninja) ignore `--config`**, and the `CMAKE_ARGS` never set `CMAKE_BUILD_TYPE` — so under Ninja+MSVC libhv defaulted to Debug, producing a debug-CRT `hv_static.lib` that fails to link into Release `dasModuleHV`:

```
hv_static.lib(...) : error LNK2001: unresolved external symbol __imp__CrtDbgReport
dasModuleHV.shared_module : fatal error LNK1120: 2 unresolved externals
```

The VS multi-config generator masks this because `--config Release` actually takes effect there — which is why current CI is green on the VS generator only.

`dasGlfw`'s `ExternalProject` already pins `-DCMAKE_BUILD_TYPE=Release`; libhv just missed it. Fix: add `-DCMAKE_BUILD_TYPE=$<CONFIG>` to the libhv `CMAKE_ARGS`. No-op for multi-config VS (the `--config` there still drives it); on POSIX Ninja it additionally yields a properly-optimized Release libhv instead of the previous unspecified default.

## CI changes (`extended_checks.yml`, Windows job)
- **Generator: `Visual Studio 17 2022` → `Ninja`.** MSBuild parallelizes the module build ~1.5–2× slower than Ninja's global dependency graph. Adds an `ilammy/msvc-dev-cmd` step so `cl.exe`/`link.exe` are on PATH for the bash build; drops `-T host=x64 -A x64`, adds `-DCMAKE_BUILD_TYPE=Release`, and sets `BIN=./bin` (single-config has no `bin/Release`). vcpkg OpenSSL + Strawberry Perl are unchanged.
- **Windows Defender exclusion step.** Real-time protection scans every `.obj`/`.exe`/`.dll` the build writes and every process + DLL load at test time; excluding the workspace + daslang binaries cuts both compile and run wall-time. `continue-on-error` so a managed-Defender runner can't fail the job.

## Verification (local, Windows, Ninja + MSVC)
Built the full `ci/release_modules.txt` set — `dasHV`, `dasLLVM`, `dasAudio`, `dasPUGIXML`, `dasSQLITE`, `dasGlfw` — targeting `daslang das-fmt daslang_static` + the six smoke modules. **0 link errors**; `daslang_static.exe` runs. Before the libhv fix, `dasModuleHV` failed to link exactly as above.

## Deliberately not in this PR
`build.yml` (release/test matrix — produces `.zip` artifacts, has 32-bit + RelWithDebInfo configs), `release.yml` (artifacts), and `msvc.yml` (whose purpose is exercising the VS-project path) still use the VS generator. They can follow up; the Defender exclusion alone would also help `build.yml`'s heavy Windows test job if wanted.

First in a sequence: this unblocks the same Ninja + Defender switch in dasImgui and dasImguiNodeEditor CI (which check out daslang `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)