### PR TITLE
linq_das: orderby (single-key) + group … by clauses

### DIFF
--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -8,18 +8,22 @@ require daslib/ast_boost
 require daslib/templates_boost
 require daslib/linq_boost public
 
-// ===== C#-style LINQ query syntax (linq_das) — from/where/select over any _fold source =====
+// ===== C#-style LINQ query syntax (linq_das) — from/where/orderby/select|group over any _fold source =====
 //
 // The `%linq! … %%` inline reader macro rewrites a C#-like query into a `_fold(...)` chain:
 //
-//     %linq! from c in cars where c.price > 100 select c.name %%
-//        →   ( _fold( each(cars) |> _where($(c) => c.price > 100) |> _select($(c) => c.name) |> to_array() ) )
+//     %linq! from c in cars where c.price > 100 orderby c.price select c.name %%
+//        →   ( _fold( each(cars) |> _where($(c) => c.price > 100) |> _order_by($(c) => c.price) |> _select($(c) => c.name) |> to_array() ) )
+//     %linq! from c in cars group c by c.brand %%
+//        →   ( _fold( each(cars) |> _group_by_lazy($(c) => c.brand) |> to_array() ) )
 //
 // An untyped `from c in <arr>` is an array source. A typed `from c : Row in <src>` selects a non-array
 // source: `decs` (a keyword marker → `from_decs_template`), or any value whose type the `from_in` call
 // macro dispatches (a SQL runner → `select_from`, an XML node → `from_xml_node`). The range variable is
-// spliced verbatim as the block parameter. A trailing `iterator` keyword yields an `iterator<T>` over
-// the materialized (fused) result (via `to_sequence()`) instead of the default `array<T>` — not lazy streaming.
+// spliced verbatim as the block parameter. `orderby <expr> [descending]` is a single sort key. `group c
+// by <key>` is a terminal yielding `tuple<key; array<elem>>` per bucket — IGrouping, in-memory sources
+// only (over SQL it errors: SQL needs an aggregating projection). A trailing `iterator` keyword yields an
+// `iterator<T>` over the materialized (fused) result (via `to_sequence()`) instead of the default `array<T>`.
 
 def private is_ident_byte(c : int) : bool {
     return is_alnum(c) || c == '_'
@@ -116,11 +120,10 @@ def private read_ident(q : string; from : int) : tuple<string; int> {
     return (slice(q, s, e), e)
 }
 
-// If the projection ends with a standalone `iterator` keyword (preceded by whitespace, so a member
-// access like `c.iterator` is not matched), strip it and request iterator output.
-def private strip_trailing_iterator(proj : string) : tuple<string; bool> {
-    let p = strip(proj)
-    let kw = "iterator"
+// If `text` ends with a standalone `kw` keyword (preceded by whitespace, so a member access like
+// `c.iterator` / `c.descending` is not matched), strip it and return (remainder, true).
+def private strip_trailing_keyword(text : string; kw : string) : tuple<string; bool> {
+    let p = strip(text)
     let m = length(kw)
     let n = length(p)
     if (n <= m || !ends_with(p, kw)) { return (p, false) }
@@ -167,14 +170,31 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
         macro_error(prog, at, "linq: unexpected '{between}' between range variable and 'in'")
         return "(0)"
     }
+    // Clauses in C# order, each searched after the previous so positions stay ordered:
+    //   from … [where <pred>] [orderby <expr> [descending]] ( select <proj> | group <var> by <key> ) [iterator]
     let srcStart = inPos + 2
     let wherePos = find_kw_depth0(q, "where", srcStart)
-    let selectPos = find_kw_depth0(q, "select", wherePos >= 0 ? wherePos + 5 : srcStart)
-    if (selectPos < 0) {
-        macro_error(prog, at, "linq: query must end with a 'select' clause")
+    let afterWhere = wherePos >= 0 ? wherePos + 5 : srcStart
+    let orderByPos = find_kw_depth0(q, "orderby", afterWhere)
+    let afterOrderBy = orderByPos >= 0 ? orderByPos + 7 : afterWhere
+    let selectPos = find_kw_depth0(q, "select", afterOrderBy)
+    let groupPos = find_kw_depth0(q, "group", afterOrderBy)
+    if (selectPos < 0 && groupPos < 0) {
+        macro_error(prog, at, "linq: query must end with a 'select' or 'group … by …' clause")
         return "(0)"
     }
-    let srcEnd = wherePos >= 0 ? wherePos : selectPos
+    if (selectPos >= 0 && groupPos >= 0) {
+        macro_error(prog, at, "linq: query cannot have both 'select' and 'group' — they are alternative terminals")
+        return "(0)"
+    }
+    let isGroup = groupPos >= 0
+    let termPos = isGroup ? groupPos : selectPos
+    // `orderby` before `group` would emit `_order_by |> _group_by_lazy`, which `_fold` does not fuse.
+    if (isGroup && orderByPos >= 0) {
+        macro_error(prog, at, "linq: 'orderby' before 'group' is not supported — order the groups after a 'select', or drop the 'orderby'")
+        return "(0)"
+    }
+    let srcEnd = wherePos >= 0 ? wherePos : (orderByPos >= 0 ? orderByPos : termPos)
     let srcText = strip(slice(q, srcStart, srcEnd))
     if (srcText == "") {
         macro_error(prog, at, "linq: empty source expression after 'in'")
@@ -183,22 +203,67 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
     let hasWhere = wherePos >= 0
     var predText = ""
     if (hasWhere) {
-        predText = strip(slice(q, wherePos + 5, selectPos))
+        predText = strip(slice(q, wherePos + 5, orderByPos >= 0 ? orderByPos : termPos))
         if (predText == "") {
             macro_error(prog, at, "linq: empty 'where' predicate")
             return "(0)"
         }
     }
-    let rawProj = strip(slice(q, selectPos + 6, nq))
-    let pj = strip_trailing_iterator(rawProj)
-    let projText = pj._0
-    let wantIterator = pj._1
-    if (projText == "") {
-        macro_error(prog, at, "linq: empty 'select' projection")
-        return "(0)"
+    // orderby clause (select-terminated only): `<expr> [descending|ascending]`.
+    let hasOrderBy = orderByPos >= 0
+    var orderKey = ""
+    var orderDesc = false
+    if (hasOrderBy) {
+        let rawOrder = strip(slice(q, orderByPos + 7, termPos))
+        let od = strip_trailing_keyword(rawOrder, "descending")
+        if (od._1) {
+            orderKey = od._0; orderDesc = true
+        } else {
+            // a trailing `ascending` is the default — strip it if present
+            orderKey = strip_trailing_keyword(rawOrder, "ascending")._0
+        }
+        if (orderKey == "") {
+            macro_error(prog, at, "linq: empty 'orderby' expression")
+            return "(0)"
+        }
     }
-    // `select c` (the range variable alone) is the identity projection — no `_select` is emitted.
-    let identitySelect = (projText == varName)
+    // Terminal: select projection, or group element/key.
+    var projText = ""
+    var identitySelect = false
+    var groupKey = ""
+    var wantIterator = false
+    if (isGroup) {
+        // `group <elem> by <key> [iterator]` — element must be the range variable (identity; element
+        // selectors are deferred). The group yields `tuple<key; array<elem>>` per bucket (IGrouping).
+        let groupBody = strip(slice(q, termPos + 5, nq))
+        let byPos = find_kw_depth0(groupBody, "by", 0)
+        if (byPos < 0) {
+            macro_error(prog, at, "linq: 'group' requires a 'by' clause (e.g. `group {varName} by {varName}.field`)")
+            return "(0)"
+        }
+        let elem = strip(slice(groupBody, 0, byPos))
+        if (elem != varName) {
+            macro_error(prog, at, "linq: 'group' element must be the range variable '{varName}' — element selectors are not yet supported (write `group {varName} by …`)")
+            return "(0)"
+        }
+        let gk = strip_trailing_keyword(strip(slice(groupBody, byPos + 2, length(groupBody))), "iterator")
+        groupKey = gk._0
+        wantIterator = gk._1
+        if (groupKey == "") {
+            macro_error(prog, at, "linq: empty 'group … by' key expression")
+            return "(0)"
+        }
+    } else {
+        let pj = strip_trailing_keyword(strip(slice(q, termPos + 6, nq)), "iterator")
+        projText = pj._0
+        wantIterator = pj._1
+        if (projText == "") {
+            macro_error(prog, at, "linq: empty 'select' projection")
+            return "(0)"
+        }
+        // `select c` (the range variable alone) is the identity projection — no `_select` is emitted.
+        identitySelect = (projText == varName)
+    }
     // Source builder: array (untyped) → each(...); decs (keyword marker) → from_decs_template;
     // any other typed value source → from_in (dispatches by the source value's type).
     var srcBuild = ""
@@ -214,8 +279,15 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
         if (hasWhere) {
             writer |> write(" |> _where($({varName}) => {predText})")
         }
-        if (!identitySelect) {
-            writer |> write(" |> _select($({varName}) => {projText})")
+        if (isGroup) {
+            writer |> write(" |> _group_by_lazy($({varName}) => {groupKey})")
+        } else {
+            if (hasOrderBy) {
+                writer |> write(" |> {orderDesc ? "_order_by_descending" : "_order_by"}($({varName}) => {orderKey})")
+            }
+            if (!identitySelect) {
+                writer |> write(" |> _select($({varName}) => {projText})")
+            }
         }
         writer |> write(" |> to_array() )")
         if (wantIterator) {
@@ -258,10 +330,13 @@ class FromInMacro : AstCallMacro {
 
 [reader_macro(name=linq)]
 class LinqDasReader : AstReaderMacro {
-    //! C#-style LINQ query reader macro. ``%linq! from c [: Row] in src [where <pred>] select <proj> [iterator] %%``
+    //! C#-style LINQ query reader macro.
+    //! ``%linq! from c [: Row] in src [where <pred>] [orderby <expr> [descending]] ( select <proj> | group c by <key> ) [iterator] %%``
     //! rewrites to a ``_fold(...)`` chain. Sources: array (untyped `from c in arr`), or a typed
-    //! ``from c : Row in src`` over decs / SQL / XML. A trailing ``iterator`` keyword yields an
-    //! ``iterator<T>`` over the materialized result instead of the ``array<T>``. Single range variable, spliced verbatim.
+    //! ``from c : Row in src`` over decs / SQL / XML. ``orderby`` is a single sort key; ``group c by <key>``
+    //! is a terminal yielding ``tuple<key; array<elem>>`` buckets (in-memory sources only). A trailing
+    //! ``iterator`` keyword yields an ``iterator<T>`` over the materialized result instead of the
+    //! ``array<T>``. Single range variable, spliced verbatim.
     def override accept(prog : ProgramPtr; mod : Module?; var expr : ExprReader?; ch : int; info : LineInfo) : bool {
         append(expr.sequence, ch)
         if (ends_with(expr.sequence, "%%")) {

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -29,15 +29,20 @@ embedded in a larger expression.
 Clauses
 -------
 
-A query is ``from <var> [ : <Row> ] in <src> [ where <pred> ] select <proj> [ iterator ]``:
+A query is ``from <var> [ : <Row> ] in <src> [ where <pred> ] [ orderby <expr>
+[descending] ] ( select <proj> | group <var> by <key> ) [ iterator ]``:
 
 - ``from <var> in <source>`` — the element bind ``<var>`` names the per-row
   value. With no type annotation, ``<source>`` is an ``array<T>``.
 - ``where <predicate>`` — optional. Omitted from the chain when absent.
-- ``select <projection>`` — required. ``select <var>`` (the identity
-  projection) returns the rows unchanged; any other projection emits
-  ``_select(...)``.
+- ``orderby <expr> [descending]`` — optional, a **single** sort key (see
+  :ref:`linq_das_ordering`). Omitted when absent.
+- ``select <projection>`` — ``select <var>`` (the identity projection) returns
+  the rows unchanged; any other projection emits ``_select(...)``.
+- ``group <var> by <key>`` — the alternative terminal to ``select`` (see
+  :ref:`linq_das_grouping`).
 
+A query ends with **either** ``select`` **or** ``group … by`` — exactly one.
 Clauses may span multiple lines inside the ``%linq! … %%`` body.
 
 Sources
@@ -85,6 +90,58 @@ placeholder ``_``; the macro normalizes the single-source lambda parameter to
 ``_`` internally, so the C# variable name is still spliced verbatim at the
 surface.
 
+.. _linq_das_ordering:
+
+Ordering
+--------
+
+``orderby <expr> [descending]`` sorts by a **single** key, emitting
+``_order_by($(c) => <expr>)`` (or ``_order_by_descending(...)``) between the
+``where`` and the ``select``. ``descending`` (and the default-explicit
+``ascending``) are recognized as trailing keywords:
+
+.. code-block:: das
+
+    // ascending (default)
+    var byPrice <- %linq! from c in cars orderby c.price select c.name %%
+
+    // descending, after a where
+    var top <- %linq! from c in cars where c.price > 100 orderby c.price descending select c.name %%
+
+Works over all four sources (SQL emits ``ORDER BY … [DESC]``; array / decs / XML
+sort the materialized rows). **Multi-key** ordering (``orderby a, b descending``)
+is not yet supported — there is no ``_then_by`` operator; use a single key for
+now.
+
+.. _linq_das_grouping:
+
+Grouping
+--------
+
+``group <var> by <key>`` is a terminal (it replaces ``select``). It emits
+``_group_by_lazy($(c) => <key>)`` and yields one ``tuple<key; array<elem>>``
+bucket per distinct key — the C# *IGrouping* shape. Read the key as ``._0`` and
+the group's elements as ``._1``:
+
+.. code-block:: das
+
+    var byBrand <- %linq! from c in cars group c by c.brand %%
+    for (g in byBrand) {
+        print("{g._0}: {g._1 |> length} cars\n")   // key, then count of that bucket
+    }
+
+A ``where`` may precede the ``group``; ``orderby`` may not (ordering the groups
+needs the deferred ``into`` continuation). The group element must be the range
+variable (``group c by …``) — element selectors are not yet supported.
+
+**Grouping is an in-memory feature** (array / decs / XML). Over a **SQL** source
+it is rejected at compile time: SQL ``GROUP BY`` has no all-rows-per-group form,
+only aggregates. Use the aggregate pipe form for SQL grouping —
+``db |> select_from(type<Car>) |> _group_by(_.brand) |> _select((B = _._0, N = _._1 |> count())) |> _sql()``
+— until the ``group … into`` continuation lands. (Over decs these minimal
+``orderby`` / ``group`` chains currently materialize rather than fuse — correct,
+but a ``_fold`` perf advisory fires; a decs-adapter gap, not a query-syntax one.)
+
 Iterator vs array output
 ------------------------
 
@@ -123,6 +180,10 @@ Current limitations
 The following are not yet supported:
 
 - **JSON** as a source (the planned 5th adapter).
-- **Additional clauses** — ``orderby`` / ``group by`` / ``join``.
+- ``join`` — joining a second source (introduces a second range variable).
+- **Multi-key ``orderby``** (``orderby a, b descending``) — a single sort key
+  only, for now.
+- **``group … by`` over a SQL source**, and the ``group … into`` aggregate
+  continuation (SQL grouping rides ``into``).
 - **Multiple ``from``** (SelectMany), ``let`` bindings, and ``into``
   continuations — a query parses a single ``from`` (one range variable).

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -4393,6 +4393,18 @@ def private normalize_single_source_arg_names(var node : ExpressionPtr) {
     normalize_chain_blocks(node)
 }
 
+// A `_group_by` with no projecting `_select` falls through to the default full-row projection, which
+// emits `SELECT * ... GROUP BY k` — one arbitrary row per group, NOT the `(key, [rows])` IGrouping an
+// in-memory `_group_by` yields. Reject so the silent shape divergence surfaces at compile time.
+[macro_function]
+def private reject_bare_group_by(q : SqlQuery; prog : ProgramPtr; at : LineInfo) : bool {
+    if (q.seenGroupBy && !q.seenSelect && q.proj == ProjectionShape.FullRow) {
+        macro_error(prog, at, "_sql: `_group_by` requires a following `_select` with aggregates (e.g. `|> _select((K = _._0, N = _._1 |> count()))`) — a bare `_group_by` over a SQL source has no meaningful translation (SQLite would return one arbitrary row per group). For IGrouping-style `(key, [rows])` groups use an in-memory source (array / decs / XML).")
+        return false
+    }
+    return true
+}
+
 [macro_function]
 def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; isTry : bool) : ExpressionPtr {
     var argT = call.arguments[0]._type
@@ -4400,7 +4412,7 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     macro_verify(!argT.isAutoOrAlias, prog, call.at, "_sql/_try_sql: chain type is auto/alias after inference")
     normalize_single_source_arg_names(call.arguments[0])
     var q = SqlQuery()
-    if (!analyze_chain(call.arguments[0], q, prog, call.at)) return null
+    if (!analyze_chain(call.arguments[0], q, prog, call.at) || !reject_bare_group_by(q, prog, call.at)) return null
     // distinct() upstream of an aggregate is a no-op in SQL — meaningful form is COUNT(DISTINCT col), not yet implemented.
     if (q.proj == ProjectionShape.Aggregate && q.distinctFlag) {
         macro_error(prog, call.at, "_sql: distinct() before an aggregate is not translatable — `SELECT DISTINCT` over a single-row aggregate result is always a no-op; the meaningful form is `COUNT(DISTINCT col)` etc. (aggregate-distinct), which is not yet implemented")
@@ -4467,7 +4479,7 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
     macro_verify(!argT.isAutoOrAlias, prog, call.at, "_each_sql: chain type is auto/alias after inference")
     normalize_single_source_arg_names(call.arguments[0])
     var q = SqlQuery()
-    if (!analyze_chain(call.arguments[0], q, prog, call.at)) return null
+    if (!analyze_chain(call.arguments[0], q, prog, call.at) || !reject_bare_group_by(q, prog, call.at)) return null
     // Reject terminals (iterator, not scalar/row/array). Order matters: aggregates set both Aggregate+One, so dispatch on proj first.
     if (q.seenToArray) {
         macro_error(prog, call.at, "_each_sql: chain ends in `_to_array()` — _each_sql streams rows lazily; drop the terminal, or switch to `_sql(...)` for materialization")

--- a/tests/dasPUGIXML/test_linq_das_xml.das
+++ b/tests/dasPUGIXML/test_linq_das_xml.das
@@ -50,3 +50,40 @@ def test_xml_iterator_output(t : T?) {
         t |> equal(length(brands), 2, "xml iterator output")
     }
 }
+
+[test]
+def test_xml_orderby(t : T?) {
+    parse_xml(XML) $(doc, ok) {
+        t |> success(ok)
+        // ORDER BY price ASC → 50, 100, 300 → ids 3, 1, 2
+        let ids <- %linq! from c : Car in doc.document_element orderby c.price select c.id %%
+        t |> equal(length(ids), 3)
+        t |> equal(ids[0], 3)
+        t |> equal(ids[1], 1)
+        t |> equal(ids[2], 2)
+    }
+}
+
+[test]
+def test_xml_orderby_descending(t : T?) {
+    parse_xml(XML) $(doc, ok) {
+        t |> success(ok)
+        let ids <- %linq! from c : Car in doc.document_element orderby c.price descending select c.id %%
+        t |> equal(ids[0], 2)   // 300
+        t |> equal(ids[2], 3)   // 50
+    }
+}
+
+[test]
+def test_xml_group_by(t : T?) {
+    parse_xml(XML) $(doc, ok) {
+        t |> success(ok)
+        // Ford: car1+car3, Honda: car2 → 2 buckets
+        let groups <- %linq! from c : Car in doc.document_element group c by c.brand %%
+        t |> equal(length(groups), 2, "xml group buckets Ford/Honda")
+        for (g in groups) {
+            if (g._0 == "Ford")  { t |> equal(length(g._1), 2) }
+            if (g._0 == "Honda") { t |> equal(length(g._1), 1) }
+        }
+    }
+}

--- a/tests/dasSQLITE/failed_linq_das_sql.das
+++ b/tests/dasSQLITE/failed_linq_das_sql.das
@@ -1,0 +1,27 @@
+options gen2
+
+// linq_das `group c by k` over a SQL source. C# `group … by` (no `into`) means IGrouping = all rows
+// per group; SQL has no such form (a bare GROUP BY returns one arbitrary row per group, a different
+// shape). `_sql` rejects the bare `_group_by` the reader emits — use an aggregate pipe form, or an
+// in-memory source. One macro_error (50503), no cascade (the `_sql` macro returns null cleanly).
+expect 50503
+
+require daslib/linq_das
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key id : int
+    name  : string
+    brand : string
+}
+
+def trigger() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        let g <- %linq! from c : Car in db group c by c.brand %%
+        unused(g)
+    }
+}

--- a/tests/dasSQLITE/test_linq_das_sql.das
+++ b/tests/dasSQLITE/test_linq_das_sql.das
@@ -56,3 +56,29 @@ def test_sql_iterator_output(t : T?) {
         t |> equal(length(names), 2, "sql iterator output")
     }
 }
+
+[test]
+def test_sql_orderby_ascending(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // ORDER BY price ASC over the SQL source
+        let names <- %linq! from c : Car in db orderby c.price select c.name %%
+        let ref <- _fold(db |> select_from(type<Car>) |> _order_by(_.price) |> _select(_.name))
+        t |> equal(length(names), 3)
+        t |> equal(names[0], "BMW")     // 100
+        t |> equal(names[2], "Tesla")   // 300
+        t |> equal(length(names), length(ref), "linq_das orderby ≡ hand-written _sql chain")
+    }
+}
+
+[test]
+def test_sql_orderby_descending_with_where(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // WHERE price >= 200 then ORDER BY price DESC → Tesla(300), Audi(200)
+        let names <- %linq! from c : Car in db where c.price >= 200 orderby c.price descending select c.name %%
+        t |> equal(length(names), 2, "sql where + order by desc")
+        t |> equal(names[0], "Tesla")
+        t |> equal(names[1], "Audi")
+    }
+}

--- a/tests/linq/failed_linq_das.das
+++ b/tests/linq/failed_linq_das.das
@@ -1,8 +1,11 @@
 options gen2
 
-// linq_das must reject a query whose first word is not the standalone `from` keyword.
-// `fromc` (missing the space) is read as a single identifier, not `from` + range var.
-expect 50503
+// linq_das reader-macro rejections. Each malformed query emits one macro_error (50503) and a benign
+// `(0)` fallback, so the surrounding statement still parses — one 50503 per bad query, no cascade.
+expect 50503   // `fromc` — not the standalone `from` keyword (read as one identifier)
+expect 50503   // `orderby` before `group` (would emit a non-fusing _order_by |> _group_by_lazy)
+expect 50503   // group element is not the range variable (element selectors unsupported)
+expect 50503   // `group` with no `by` clause
 
 require daslib/linq_das
 require strings
@@ -10,10 +13,33 @@ require strings
 struct Car {
     name  : string
     price : int
+    brand : string
 }
 
-def trigger() {
-    var cars <- [Car(name = "a", price = 50)]
+def private one_car() {
+    return <- [Car(name = "a", price = 50, brand = "x")]
+}
+
+def trigger_bad_keyword() {
+    var cars <- one_car()
     let x <- %linq! fromc in cars select c %%
+    unused(x)
+}
+
+def trigger_orderby_before_group() {
+    var cars <- one_car()
+    let x <- %linq! from c in cars orderby c.price group c by c.brand %%
+    unused(x)
+}
+
+def trigger_group_element_mismatch() {
+    var cars <- one_car()
+    let x <- %linq! from c in cars group c.name by c.brand %%
+    unused(x)
+}
+
+def trigger_group_missing_by() {
+    var cars <- one_car()
+    let x <- %linq! from c in cars group c %%
     unused(x)
 }

--- a/tests/linq/test_linq_das.das
+++ b/tests/linq/test_linq_das.das
@@ -1,30 +1,37 @@
 options gen2
 options rtti
+// decs `orderby` / `group` chains have no dedicated decs splice arm for these minimal shapes, so they
+// fall to the tier-2 materialize path and emit a `_fold` perf advisory. Correct, just unfused — suppress
+// the cosmetic warning here (a decs-fold gap, not a linq_das issue).
+options _no_linq_perf_warn = true
 
 require dastest/testing_boost public
 require daslib/linq_das
 require daslib/decs_boost
 
-// linq_das: C#-style `%linq! from c [: Row] in src [where <pred>] select <proj> [iterator] %%` reader
-// macro. Array source (untyped) and decs source (`from c : CarComp in decs`) are covered here; SQL and
-// XML live with their modules (tests/dasSQLITE, tests/dasPUGIXML). The range variable is spliced
-// verbatim as the block parameter; a trailing `iterator` keyword yields a lazy `iterator<T>`.
+// linq_das: C#-style `%linq! from c [: Row] in src [where <pred>] [orderby <expr> [descending]]
+// ( select <proj> | group c by <key> ) [iterator] %%` reader macro. Array source (untyped) and decs
+// source (`from c : CarComp in decs`) are covered here; SQL and XML live with their modules
+// (tests/dasSQLITE, tests/dasPUGIXML). The range variable is spliced verbatim as the block parameter;
+// a trailing `iterator` keyword yields an `iterator<T>` over the materialized result.
 
 struct Car {
     name  : string
     price : int
+    brand : string
 }
 
 def private mk_cars() : array<Car> {
-    return <- [Car(name = "cheap", price = 50),
-               Car(name = "mid", price = 150),
-               Car(name = "lux", price = 300)]
+    return <- [Car(name = "cheap", price = 50,  brand = "eco"),
+               Car(name = "mid",   price = 150, brand = "eco"),
+               Car(name = "lux",   price = 300, brand = "lux")]
 }
 
 [decs_template(prefix = "ld_")]
 struct CarComp {
     name  : string
     price : int
+    brand : string
 }
 
 def private seed_decs() {
@@ -33,7 +40,8 @@ def private seed_decs() {
         create_entity() @(eid, cmp) {
             cmp.eid := eid
             cmp.ld_name := "car{i}"
-            cmp.ld_price := 100 * (i + 1)   // 100, 200, 300
+            cmp.ld_price := 100 * (i + 1)        // 100, 200, 300
+            cmp.ld_brand := i < 2 ? "a" : "b"    // a, a, b
         }
     }
     commit()
@@ -155,4 +163,105 @@ def test_decs_iterator_output(t : T?) {
     seed_decs()
     let names <- [for (nm in %linq! from c : CarComp in decs where c.price > 100 select c.name iterator %%); nm]
     t |> equal(length(names), 2, "decs iterator output")
+}
+
+// ===== orderby (single key, optional `descending`) =====
+
+[test]
+def test_array_orderby_asc(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars orderby c.price select c.name %%
+    t |> equal(length(names), 3)
+    t |> equal(names[0], "cheap")   // 50
+    t |> equal(names[1], "mid")     // 150
+    t |> equal(names[2], "lux")     // 300
+}
+
+[test]
+def test_array_orderby_descending(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars orderby c.price descending select c.name %%
+    t |> equal(names[0], "lux")
+    t |> equal(names[1], "mid")
+    t |> equal(names[2], "cheap")
+}
+
+[test]
+def test_array_where_orderby(t : T?) {
+    let cars <- mk_cars()
+    let names <- %linq! from c in cars where c.price >= 150 orderby c.price descending select c.name %%
+    t |> equal(length(names), 2, "where then sort")
+    t |> equal(names[0], "lux")
+    t |> equal(names[1], "mid")
+}
+
+[test]
+def test_array_orderby_identity_select(t : T?) {
+    let cars <- mk_cars()
+    let rows <- %linq! from c in cars orderby c.price select c %%
+    t |> equal(length(rows), 3)
+    t |> equal(rows[0].name, "cheap")
+    t |> equal(rows[2].name, "lux")
+}
+
+[test]
+def test_array_orderby_iterator(t : T?) {
+    let cars <- mk_cars()
+    let got <- [for (nm in %linq! from c in cars orderby c.price descending select c.name iterator %%); nm]
+    t |> equal(got[0], "lux")
+    t |> equal(got[2], "cheap")
+}
+
+[test]
+def test_decs_orderby(t : T?) {
+    seed_decs()
+    let names <- %linq! from c : CarComp in decs orderby c.price descending select c.name %%
+    t |> equal(length(names), 3)
+    t |> equal(names[0], "car2")   // price 300
+    t |> equal(names[2], "car0")   // price 100
+}
+
+// ===== group … by (terminal; IGrouping `(key, [elems])` per bucket; in-memory sources) =====
+
+[test]
+def test_array_group_by(t : T?) {
+    let cars <- mk_cars()
+    let groups <- %linq! from c in cars group c by c.brand %%
+    t |> equal(length(groups), 2, "two brand buckets")
+    var ecoN = 0
+    var luxN = 0
+    for (g in groups) {
+        if (g._0 == "eco") { ecoN = length(g._1) }
+        if (g._0 == "lux") { luxN = length(g._1) }
+    }
+    t |> equal(ecoN, 2, "eco bucket has cheap+mid")
+    t |> equal(luxN, 1, "lux bucket has lux")
+}
+
+[test]
+def test_array_group_with_where(t : T?) {
+    let cars <- mk_cars()
+    // price>=150 keeps mid(eco), lux(lux) → one element each
+    let groups <- %linq! from c in cars where c.price >= 150 group c by c.brand %%
+    t |> equal(length(groups), 2, "filtered then grouped")
+    for (g in groups) { t |> equal(length(g._1), 1) }
+}
+
+[test]
+def test_array_group_iterator(t : T?) {
+    let cars <- mk_cars()
+    var n = 0
+    for (_g in %linq! from c in cars group c by c.brand iterator %%) { n++ }
+    t |> equal(n, 2, "group iterator yields the buckets")
+}
+
+[test]
+def test_decs_group_by(t : T?) {
+    seed_decs()
+    let groups <- %linq! from c : CarComp in decs group c by c.brand %%
+    t |> equal(length(groups), 2, "decs group buckets a/b")
+    for (g in groups) {
+        if (g._0 == "a") { t |> equal(length(g._1), 2, "bucket a: car0+car1") }
+        if (g._0 == "b") { t |> equal(length(g._1), 1, "bucket b: car2") }
+    }
 }


### PR DESCRIPTION
## Summary

Adds the next two C# query clauses to the `%linq!` reader macro — the third linq_das stage, after v1 (array, #2958) and v2 (typed sources decs/SQL/XML, #2960):

- **`orderby &lt;expr&gt; [descending]`** — a **single** sort key, emitted as `_order_by` / `_order_by_descending` between `where` and `select`. Works over all four sources (SQL emits `ORDER BY … [DESC]`; array/decs/XML sort the materialized rows). `ascending` is accepted as the no-op default.
- **`group &lt;var&gt; by &lt;key&gt;`** — a terminal (alternative to `select`) yielding `tuple&lt;key; array&lt;elem&gt;&gt;` IGrouping buckets via `_group_by_lazy` (read `._0` / `._1`). In-memory sources (array/decs/XML); the group element must be the range variable.

## SQL grouping → compile-time error, not a silent shape change

C# `group c by k` means *all rows per group*. SQL `GROUP BY` has no such form — it collapses to one arbitrary row per group, a different result shape. A bare `_group_by` over a SQL source previously **silently** compiled to `array&lt;Row&gt;`. This PR adds `reject_bare_group_by` in `sqlite_linq`: a `_group_by` with no aggregating `_select` now errors at compile time, pointing the user to the aggregate pipe form or an in-memory source. `_group_by` and `_group_by_lazy` are identical after expansion, so `_sql` can't distinguish "lazy" from "aggregate" intent — the guard keys on the resulting default full-row projection. Every existing SQL group chain has a select, so this is purely additive (857 dasSQLITE tests stay green).

## Rejections (clear `macro_error`s, covered by `failed_` tests)

- `orderby` before `group` (would emit a non-fusing `_order_by |> _group_by_lazy`)
- group element ≠ range variable (element selectors unsupported)
- `group` with no `by`
- `group … by` over a SQL source

## Deferred (documented in `linq_das.rst`)

- **Multi-key `orderby`** (`orderby a, b descending`) — no `_then_by` fold op yet.
- **`join`** — a second range variable; the next stage.
- **`group … into`** aggregate continuation (which would also enable SQL grouping).

## Known follow-up

decs `orderby` / `group` produce correct results but currently **materialize** (a `_fold` tier-2 perf advisory) — those minimal decs shapes have no splice arm. Array and XML fuse cleanly. This is a pre-existing decs-adapter gap (a hand-written decs `orderby` warns identically), suppressed in the test file via `options _no_linq_perf_warn = true` with a documenting comment. Tracked as a follow-up to add the decs splice arms.

## Tests / docs

- `tests/linq/test_linq_das.das` — array+decs orderby asc/desc/identity/iterator, group/where/iterator (+10)
- `tests/linq/failed_linq_das.das` — +3 reject cases
- `tests/dasSQLITE/test_linq_das_sql.das` — SQL orderby asc/desc (+2)
- `tests/dasSQLITE/failed_linq_das_sql.das` — SQL-group reject (new)
- `tests/dasPUGIXML/test_linq_das_xml.das` — XML orderby / group (+3)
- `doc/source/reference/linq_das.rst` — Ordering + Grouping sections; limitations refreshed

## Verification

INTERP full `./tests` 10136/0 · JIT 23/5/6 · AOT `--use-aot` 23/5/6 (no 50101) · dasfmt `--verify` · MCP + CI lint clean · Sphinx `-W` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)