### PR TITLE
CI: build.yml Windows jobs on Ninja + Defender exclusion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
 
           - target: windows
             build_system: cmake
-            cmake_generator: Visual Studio 17 2022
+            cmake_generator: Ninja
 
           - target: darwin15
             build_system: cmake
@@ -163,7 +163,7 @@ jobs:
             runner: windows-latest-fat
             archive_ext: zip
             build_system: cmake
-            cmake_generator: Visual Studio 17 2022
+            cmake_generator: Ninja
             release_target: windows
             release_arch: x86_64
             architecture_string: x64
@@ -203,11 +203,33 @@ jobs:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
 
+    - name: "Exclude workspace from Windows Defender"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      continue-on-error: true
+      # Real-time Defender scans every .obj/.exe/.dll the build writes and every
+      # test process/DLL load; excluding the workspace cuts Windows CI wall-time.
+      # continue-on-error: a managed-Defender runner must not fail the job.
+      run: |
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionProcess "daslang.exe"
+        Add-MpPreference -ExclusionProcess "test_aot.exe"
+
     - name: "Install CMake and Ninja"
       uses: lukka/get-cmake@latest
 
     - if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@v1 # need nasm for openssl
+
+    - name: "Set up MSVC environment (Windows)"
+      if: runner.os == 'Windows'
+      # cl.exe on PATH so the bash build step drives Ninja with MSVC. arch
+      # follows the matrix (x86 for the 32-bit job). MUST run BEFORE the vcpkg
+      # openssl step: msvc-dev-cmd's vcvars sets VCPKG_ROOT to the VS-bundled
+      # vcpkg, so the openssl step has to write our VCPKG_ROOT last.
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.architecture == 32 && 'x86' || 'x64' }}
 
     - name: "Cache vcpkg + openssl"
       if: runner.os == 'Windows'
@@ -317,12 +339,12 @@ jobs:
                 ;;
               windows32)
                 export PATH="/c/Strawberry/perl/bin:$PATH" # prepend Strawberry perl to path, so openssl will use it.
-                cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -T host=x64 -A ${{ matrix.architecture_string }} -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+                cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_preset }} -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
                 cmake --build ./build --config ${{ matrix.cmake_preset }} --parallel
                 ;;
               windows64)
                 export PATH="/c/Strawberry/perl/bin:$PATH" # prepend Strawberry perl to path, so openssl will use it.
-                cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -T host=x64 -A ${{ matrix.architecture_string }} -DDAS_LLVM_DISABLED=${{ env.das_llvm_disabled }} -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+                cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_preset }} -DDAS_LLVM_DISABLED=${{ env.das_llvm_disabled }} -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
                 cmake --build ./build --config ${{ matrix.cmake_preset }} --parallel
                 ;;
               linux_arm*)
@@ -410,11 +432,11 @@ jobs:
             fi
             ;;
            windows32)
-            cd bin/"${{ matrix.cmake_preset }}"
+            cd bin
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test _dasroot_/tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test _dasroot_/tests
             ;;
            windows*)
-            cd bin/"${{ matrix.cmake_preset }}"
+            cd bin
             [ "${{ env.das_llvm_disabled }}" = "ON" ] || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --timeout 900 --color --failures-only --test _dasroot_/tests || ./daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --isolated-mode --timeout 3600 --test _dasroot_/tests
             ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --timeout 900 --test _dasroot_/tests || ./daslang _dasroot_/dastest/dastest.das -- --color --failures-only --isolated-mode --timeout 3600 --test _dasroot_/tests
             ;;
@@ -460,7 +482,7 @@ jobs:
             echo "Skipping AOT tests on 32-bit Windows"
             ;;
            windows*)
-            cd bin/"${{ matrix.cmake_preset }}"
+            cd bin
             ./test_aot -use-aot _dasroot_/dastest/dastest.das -- --use-aot --color --failures-only --timeout 900 --test _dasroot_/tests
             ;;
            *)


### PR DESCRIPTION
Step 4 of the Windows-CI Ninja sweep (after #2961 did `extended_checks.yml`). Switches `build.yml`'s Windows build matrix — **win32, win64, and RelWithDebInfo** — from the Visual Studio 17 2022 generator to Ninja, and excludes the workspace from Windows Defender.

## Changes
- **Matrix:** `cmake_generator: Visual Studio 17 2022` → `Ninja` (both the windows cmake entry and the RelWithDebInfo entry).
- **New "Set up MSVC environment (Windows)" step** (`ilammy/msvc-dev-cmd`, `arch` = `x86` for the 32-bit job, `x64` otherwise) so the bash build step can drive Ninja with `cl.exe`. It runs **before** the vcpkg/openssl steps on purpose: msvc-dev-cmd's vcvars sets `VCPKG_ROOT` to the VS-bundled vcpkg, so the openssl step has to write our `VCPKG_ROOT` last — otherwise the toolchain points at the wrong, empty vcpkg. (This exact ordering bug just bit the dasImgui/node-editor PRs; fixed there too.)
- **Build branches:** drop `-T host=x64 -A <arch>`, add `-DCMAKE_BUILD_TYPE:STRING=<preset>`. Quoted toolchain path unchanged. `--config <preset>` on the build/test commands is a harmless no-op under single-config Ninja.
- **Layout:** single-config flattens `bin/<preset>` → `bin`, so the Windows test/AOT steps now `cd bin`.
- **Windows Defender exclusion** step (`continue-on-error`): real-time scanning taxes every built artifact and every test process/DLL load.

## Verification (local, Windows)
- x64 Ninja+MSVC against the full `ci/release_modules.txt` set already builds clean (proven in #2961).
- **32-bit (x86)** Ninja+MSVC daslang smoke-builds to a `PE32 executable … Intel 80386` binary, **0 link errors**. openssl-x86 is vcpkg-provided in CI (same mechanism as the green x64 path).
- RelWithDebInfo is just `CMAKE_BUILD_TYPE=RelWithDebInfo` (trivial config variation).

## Deliberately NOT here
- **sccache on Windows** (the other big lever — Ninja honors `CMAKE_*_COMPILER_LAUNCHER` where MSBuild ignored it) is a **separate follow-up**: sccache can't cache MSVC `/Zi` separate-PDB debug info (needs `/Z7`), so enabling it naively would break the RelWithDebInfo job. It deserves its own PR with the `/Z7` handling.
- `release.yml` (artifact builds) and `msvc.yml` (the `/analyze` job whose purpose is the VS path) still on VS generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)