### PR TITLE
json: serialize OR-combined flag enums as their number, not empty

### DIFF
--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -308,6 +308,11 @@ namespace das {
                         return;
                     }
                 }
+                // No enumerator matches this value (e.g. an OR-combined flag enum like
+                // `OpenOnArrow | DefaultOpen`). Emit the number rather than nothing — emitting
+                // nothing produced invalid JSON ({"flags": ,...}) and dropped the whole object.
+                // The numeric form round-trips: scanEnum already accepts a bare integer.
+                ss << value;
             }
         }
         virtual void WalkEnumeration ( int32_t & value, EnumInfo * info ) override {

--- a/tests/json/test_json_enum_flags.das
+++ b/tests/json/test_json_enum_flags.das
@@ -1,0 +1,76 @@
+options gen2
+options rtti
+require dastest/testing_boost public
+require daslib/rtti
+require daslib/json
+require daslib/json_boost
+require strings
+
+// ============================================================
+//  Enum-as-flags JSON serialization.
+//
+//  An OR-combined enum value (e.g. ImGui's `OpenOnArrow | DefaultOpen`)
+//  matches no single enumerator. The reflective JSON writer used to emit
+//  NOTHING for such a value, producing invalid JSON ({"flags": ,...}) that
+//  dropped the entire surrounding object on parse. It now emits the number,
+//  which round-trips (scanEnum already accepts a bare integer).
+// ============================================================
+
+enum private TreeFlag {
+    none       = 0
+    on_arrow   = 1
+    default_on = 2
+    framed     = 4
+}
+
+var private g_single   = TreeFlag.default_on
+var private g_none     : TreeFlag
+var private g_combined : TreeFlag
+
+struct private WidgetState {
+    flags  : TreeFlag
+    opened : bool
+}
+var private g_widget : WidgetState
+
+[init]
+def setup() {
+    // on_arrow | default_on == 3 — no single enumerator equals 3. Plain enums don't
+    // define `|` (ImGui's flag enums get it from their C++ binding); build the combined
+    // value the way it actually arrives in memory — an OR'd int reinterpreted as the enum.
+    g_combined = unsafe(reinterpret<TreeFlag>(int(TreeFlag.on_arrow) | int(TreeFlag.default_on)))
+    g_widget.flags = g_combined
+    g_widget.opened = true
+}
+
+[test]
+def test_enum_flags_serialize(tt : T?) {
+    tt |> run("single value serializes to its name") @(t : T?) {
+        let s = sprint_json_at(unsafe(addr(g_single)), typeinfo rtti_typeinfo(g_single), false)
+        t |> equal(s, "\"default_on\"")
+    }
+    tt |> run("zero value serializes to its name") @(t : T?) {
+        let s = sprint_json_at(unsafe(addr(g_none)), typeinfo rtti_typeinfo(g_none), false)
+        t |> equal(s, "\"none\"")
+    }
+    tt |> run("combined value serializes to the number, not empty") @(t : T?) {
+        let s = sprint_json_at(unsafe(addr(g_combined)), typeinfo rtti_typeinfo(g_combined), false)
+        t |> equal(s, "3")
+    }
+    tt |> run("combined value round-trips through sscan") @(t : T?) {
+        var back : TreeFlag
+        let ok = sscan_json_at("3", unsafe(addr(back)), typeinfo rtti_typeinfo(back))
+        t |> equal(ok, true)
+        t |> equal(int(back), 3)
+    }
+    tt |> run("struct with a combined enum field stays parseable") @(t : T?) {
+        // The regression: a combined flags field used to blank out, leaving
+        // {"flags": ,"opened":true} — invalid, so the whole object dropped.
+        let s = sprint_json_at(unsafe(addr(g_widget)), typeinfo rtti_typeinfo(g_widget), false)
+        var err : string
+        let parsed = read_json(s, err)
+        t |> equal(parsed != null, true)
+        t |> equal(parsed?["opened"] ?? false, true)
+        t |> equal(parsed?["flags"] ?? 0, 3)
+    }
+}


### PR DESCRIPTION
## The bug

The reflective JSON writer (`debug_json_value`, behind `sprint_json` / `sprint_json_at`) emitted **nothing** for an enum value that matches no single enumerator — e.g. an OR-combined flag like ImGui's `OpenOnArrow | DefaultOpen` (= 3). That produced invalid JSON:

```json
{"flags": ,"opened":true}
```

which fails to parse, so the **entire surrounding object drops to null**. Any snapshot or struct carrying a combined-flag enum field serialized to nothing.

Single-bit and zero values were fine (they match an enumerator and emit the name); only OR-combined values hit the empty-string path.

## The fix

`src/simulate/json_print.cpp`, `Enum()`: emit the numeric value when no enumerator matches, symmetric with the existing branch that already emits a bare number for a *nameless* matching enumerator. It round-trips — `scanEnum` ([src/simulate/json_scan.cpp](src/simulate/json_scan.cpp)) already accepts a bare integer for an enum.

```cpp
for ( uint32_t t=0; t!=info->count; ++t ) {
    if ( info->fields[t]->value==value ) { ...name or number...; return; }
}
ss << value;   // no enumerator matches (OR-combined flag) — emit the number, not nothing
```

## Test

`tests/json/test_json_enum_flags.das` (auto-discovered by `dastest --test tests`):
- single value → `"name"`
- zero value → `"name"`
- combined value (3) → `3` (the regression — was empty)
- combined value round-trips through `sscan_json_at`
- a struct with a combined-flag field stays parseable (the real-world drop)

Local: the new file's 6 cases pass, and the full `tests/json` suite (294 tests) is green with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)