### PR TITLE
linq_fold/sqlite_linq: fix 3 join-pipeline engine bugs

### DIFF
--- a/daslib/linq_fold.das
+++ b/daslib/linq_fold.das
@@ -74,7 +74,12 @@ def private fold_linq_default(var expr : Expression?) : Expression? {
             var newCall = qmacro($c(callName)($e(topValue)))
             let numArgs = cll._0.arguments |> length
             for (i in 1..numArgs) {
-                (newCall as ExprCall).arguments |> emplace_new <| clone_expression(cll._0.arguments[i])
+                var argClone = clone_expression(cll._0.arguments[i])
+                // A bare `each(arr)` srcB arg (join/zip/set-op) lands as a call argument, not a for-source — mark safe or it trips error[31013].
+                if (match_call_in_module(argClone, "each", "builtin") != null) {
+                    argClone.genFlags.alwaysSafe = true
+                }
+                (newCall as ExprCall).arguments |> emplace_new <| argClone
             }
             if (inplace) {
                 blk.list |> emplace(newCall)

--- a/daslib/linq_fold_common.das
+++ b/daslib/linq_fold_common.das
@@ -5358,7 +5358,10 @@ def build_join_standalone_pieces(
             if (selBody == null || selBody._type == null) return null
             resultType = strip_const_ref(clone_type(selBody._type))
         } else {
-            resultType = clone_type(resultLam._type.firstType)
+            // strip_const_ref: a scalar/field result (`$(c,d)=>c.name`, `string const&`) would make the buffer
+            // `array<string const>` and push_clone fail (error[30913]). A named-tuple result is already a
+            // fresh non-const value (no-op there) — which is why only bare-scalar join projections tripped it.
+            resultType = strip_const_ref(clone_type(resultLam._type.firstType))
         }
         if (resultType == null) return null
         invokeRetType = new TypeDecl(baseType = Type.tArray, firstType = clone_type(resultType), at = at)

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2233,6 +2233,11 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
             return false
         }
     }
+    // Bare-var (identity / whole-row `$(x)=>x`) projection has no SQL column form — reject cleanly (else the computed-scalar `pred_to_sql` path below null-derefs on the whole-row var → SIGSEGV).
+    if (body is ExprVar) {
+        macro_error(prog, at, "_sql: identity / whole-row `_select` (e.g. `$(x) => x`) is not supported — project columns, e.g. `_select((Name = c.name, City = d.city))`")
+        return false
+    }
     // Multi-level field chain `<arg>.Col.path…` — descends via json_extract for @sql_json.
     {
         var frag : string

--- a/tests/dasSQLITE/failed_sql_join_identity_select.das
+++ b/tests/dasSQLITE/failed_sql_join_identity_select.das
@@ -1,0 +1,41 @@
+options gen2
+
+// Regression: an identity / whole-row `_select($(x) => x)` over a SQL `_join` previously crashed the
+// `_sql` analyzer (SIGSEGV — `pred_to_sql` dereferenced a null rendering the bare-variable row). It must
+// instead be a clean macro_error (50503): a whole-row select has no SQL column form. One reject (the
+// trailing cascade from the now-untyped result is expected).
+expect 50503
+
+require daslib/sql
+require daslib/linq_boost
+require daslib/linq_fold
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key id : int
+    name  : string
+    brand : string
+}
+
+[sql_table(name = "Dealers")]
+struct Dealer {
+    @sql_primary_key id : int
+    brand : string
+    city  : string
+}
+
+def trigger() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        db |> create_table(type<Dealer>)
+        let r <- _fold(db |> select_from(type<Car>)
+            |> _join(db |> select_from(type<Dealer>),
+                     $(c, d) => c.brand == d.brand,
+                     $(c, d) => c.name)
+            |> _select($(x) => x)
+            |> to_array())
+        unused(r)
+    }
+}

--- a/tests/linq/test_linq_join.das
+++ b/tests/linq/test_linq_join.das
@@ -858,3 +858,76 @@ def test_array_join_splice(t : T?) {
         t |> equal(n, 3)
     }
 }
+
+// Regression — `_join` followed by a materializing op (`_order_by` / `_group_by_lazy`), and a
+// scalar `_join` result, over `each(...)` sources. These fall to the tier-2 `fold_linq_default`
+// fallback: the bare `each(srcB)` argument used to trip error[31013] ("each unsafe outside a
+// for-loop"), and a scalar join result used to build a const buffer tripping error[30913].
+[test]
+def test_join_fused_regressions(t : T?) {
+    t |> run("each |> _join |> _order_by — was error[31013]") @(t : T?) {
+        let cars <- aj_cars()
+        let dealers <- aj_dealers()
+        let rows <- _fold(each(cars) |> _join(each(dealers),
+                                              $(c : AJCar, d : AJDealer) => c.dealer_id == d.id,
+                                              $(c : AJCar, d : AJDealer) => (Name = c.name, Price = c.price))
+                                     |> _order_by($(r) => r.Price)
+                                     |> to_array())
+        t |> equal(length(rows), 4, "4 matched pairs (orphan dropped)")
+        t |> equal(rows[0].Name, "C1")   // 1000
+        t |> equal(rows[3].Name, "C4")   // 4000
+    }
+    t |> run("each |> _join |> _order_by_descending |> _select") @(t : T?) {
+        let cars <- aj_cars()
+        let dealers <- aj_dealers()
+        let names <- _fold(each(cars) |> _join(each(dealers),
+                                               $(c : AJCar, d : AJDealer) => c.dealer_id == d.id,
+                                               $(c : AJCar, d : AJDealer) => (Name = c.name, Price = c.price))
+                                      |> _order_by_descending($(r) => r.Price)
+                                      |> _select($(r) => r.Name)
+                                      |> to_array())
+        t |> equal(length(names), 4)
+        t |> equal(names[0], "C4")
+        t |> equal(names[3], "C1")
+    }
+    t |> run("each |> _join |> _group_by_lazy — IGrouping after join, was error[31013]") @(t : T?) {
+        let cars <- aj_cars()
+        let dealers <- aj_dealers()
+        // brands: D10=Acme(C1,C2), D20=Beta(C3), D30=Acme(C4) → Acme:3, Beta:1
+        let groups <- _fold(each(cars) |> _join(each(dealers),
+                                                $(c : AJCar, d : AJDealer) => c.dealer_id == d.id,
+                                                $(c : AJCar, d : AJDealer) => (Brand = d.brand, Name = c.name))
+                                       |> _group_by_lazy($(r) => r.Brand)
+                                       |> to_array())
+        t |> equal(length(groups), 2, "Acme + Beta buckets")
+        for (g in groups) {
+            if (g._0 == "Acme") { t |> equal(length(g._1), 3, "Acme: C1,C2,C4") }
+            if (g._0 == "Beta") { t |> equal(length(g._1), 1, "Beta: C3") }
+        }
+    }
+    t |> run("each |> _join scalar result |> to_array — was error[30913] const push") @(t : T?) {
+        let cars <- aj_cars()
+        let dealers <- aj_dealers()
+        let names <- _fold(each(cars) |> _join(each(dealers),
+                                               $(c : AJCar, d : AJDealer) => c.dealer_id == d.id,
+                                               $(c : AJCar, d : AJDealer) => c.name)
+                                      |> to_array())
+        t |> equal(length(names), 4, "scalar (string) join result materializes")
+        var hasC1 = false
+        for (nm in names) {
+            if (nm == "C1") { hasC1 = true }
+        }
+        t |> success(hasC1)
+    }
+    t |> run("each |> _join scalar result |> _order_by — scalar + materializing op") @(t : T?) {
+        let cars <- aj_cars()
+        let dealers <- aj_dealers()
+        let names <- _fold(each(cars) |> _join(each(dealers),
+                                               $(c : AJCar, d : AJDealer) => c.dealer_id == d.id,
+                                               $(c : AJCar, d : AJDealer) => c.name)
+                                      |> _order_by($(n) => n)
+                                      |> to_array())
+        t |> equal(length(names), 4)
+        t |> equal(names[0], "C1")
+    }
+}


### PR DESCRIPTION
Three bugs in the shared `_fold` engine / `sqlite_linq`, surfaced while building C#-style `join` for `linq_das`. Fixed at the source (with regression tests) rather than worked around in the reader — each is a real bug independent of `linq_das`, hitting the pipe-form `_join` (and set-ops) directly.

## Bug 1 — `error[31013]` "each unsafe outside a for-loop"
Chains like `each(a) |> _join(each(b), on, result) |> _order_by(k)` (also `|> _group_by_lazy`, and pre-join `_where |> _join`) failed to compile.

**Root cause:** these fall to the tier-2 fallback (`fold_linq_default`). It marks the chain's *top* `each(...)` `alwaysSafe`, but when it clones a join's/zip's/set-op's srcB — a bare `each(arr)` — as a **call argument**, it doesn't mark it. `each` is `[unsafe_outside_of_for]`, so the bare srcB trips the unsafe check. (Recursive linq-call args are rewritten to `_fold(...)`; a plain `each(arr)` isn't an `is_linq_call`, so it reaches the clone unwrapped.)

**Fix:** mark bare `each(arr)` source args `alwaysSafe` in `fold_linq_default`. General — also covers `zip` / `concat` / `union` / `except` / `intersect`.

## Bug 2 — `error[30913]` "can't write to a constant value"
A scalar `_join` result — `... |> _join(b, on, $(c,d) => c.name) |> to_array()` — failed.

**Root cause:** in `build_join_standalone_pieces`, the no-select branch built the result buffer as `array&lt;typedecl(result)&gt;` **without** `strip_const_ref`. A const-ref field result (`c.name` is `string const&`) produced an `array&lt;string const&gt;` buffer, and `push_clone` can't write const slots. Every other branch (select, count+where, the result-bind type) already stripped — this one was missed. (A named-tuple result is a fresh non-const value, so only bare-scalar projections tripped it.)

**Fix:** add `strip_const_ref`.

## Bug 3 — SIGSEGV in the `_sql` analyzer
An identity `_select($(x) => x)` after a SQL `_join` crashed the compiler.

**Root cause:** a bare-variable (identity / whole-row) projection falls through to the computed-scalar path, where `pred_to_sql` null-derefs trying to render the whole-row var as a column.

**Fix:** reject a bare-variable projection with a clean `macro_error` (50503) — a whole-row select has no SQL column form — before the computed-scalar path. (Also cleans up the single-source identity, which previously gave a confusing `sql_bind` error.)

## Tests
- `tests/linq/test_linq_join.das` — `test_join_fused_regressions`: `_join |> _order_by`, `_join |> _order_by_descending |> _select`, `_join |> _group_by_lazy` (IGrouping after join), scalar `_join` result `|> to_array`, scalar `|> _order_by`.
- `tests/dasSQLITE/failed_sql_join_identity_select.das` — identity select over a SQL join → `expect 50503` (was the SIGSEGV).

## Verification
- INTERP: full `./tests` sweep — 10143 passed, 0 failed, 6 skipped.
- JIT + AOT (rebuilt `test_aot`): `tests/linq` (1811), `tests/dasSQLITE` (858), `tests/dasPUGIXML` (483) all green.
- Lint (MCP + CI `utils/lint`) and `das-fmt --verify` clean on all touched files.

Files: `daslib/linq_fold.das`, `daslib/linq_fold_common.das`, `modules/dasSQLITE/daslib/sqlite_linq.das` + the two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)