### PR TITLE
ci(release.yml): Windows release build on Ninja + Defender exclusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
           - target: windows
             build_system: cmake
-            cmake_generator: Visual Studio 17 2022
+            cmake_generator: Ninja
 
           - target: darwin15
             build_system: cmake
@@ -151,11 +151,33 @@ jobs:
       - name: "SCM Checkout"
         uses: actions/checkout@v4
 
+      - name: "Exclude workspace from Windows Defender"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        # Real-time Defender scans every .obj/.exe/.dll the build writes;
+        # excluding the workspace cuts Windows CI wall-time. continue-on-error:
+        # a managed-Defender runner must not fail the job.
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionProcess "daslang.exe"
+          Add-MpPreference -ExclusionProcess "test_aot.exe"
+
       - name: "Install CMake and Ninja"
         uses: lukka/get-cmake@latest
 
       - if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1 # need nasm for openssl
+
+      - name: "Set up MSVC environment (Windows)"
+        if: runner.os == 'Windows'
+        # cl.exe on PATH so the bash build step drives Ninja with MSVC. MUST run
+        # BEFORE the vcpkg openssl step: msvc-dev-cmd's vcvars sets VCPKG_ROOT to
+        # the VS-bundled vcpkg, so the openssl step has to write our VCPKG_ROOT
+        # last. (release.yml Windows is x64 only.)
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: "Install: Required Dev Packages"
         run: |
@@ -243,7 +265,9 @@ jobs:
           ACTIVE_MODULES=$(cat ci/release_modules.txt | grep -v "^#" | cut -d':' -f2 | sed 's|^|-D|' | xargs)
           case "${{ matrix.build_system }}" in
             cmake)
-              cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -T host=${{ matrix.architecture == 32 && 'x86' || 'x64' }} -A ${{ matrix.architecture_string }} \
+              # Ninja is single-config: -DCMAKE_BUILD_TYPE replaces the VS
+              # generator's -T host / -A arch (cl arch comes from msvc-dev-cmd).
+              cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_preset }} \
                 $ACTIVE_MODULES -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
               cmake --build ./build --config ${{ matrix.cmake_preset }} --parallel
               ;;
@@ -253,8 +277,8 @@ jobs:
         if: matrix.architecture_string != 'Win32'
         run: |
           if [[ "${{ matrix.target }}" == windows* ]]; then
-            cd "bin/${{ matrix.cmake_preset }}"
-            TEST_PATH="../../tests"
+            cd bin
+            TEST_PATH="../tests"
             EXEC=".exe"
           else
             cd bin


### PR DESCRIPTION
Step 5 of the Windows-CI-speedup sequence (after extended_checks #2961, dasImgui/node-editor tests, build.yml #2963/#2964). Moves the **release** Windows job off the Visual Studio generator to Ninja and excludes the workspace from Defender, matching the rest of CI.

## Changes

- `cmake_generator: Visual Studio 17 2022` → **Ninja** (Windows release cell).
- Defender exclusion step after SCM Checkout.
- `ilammy/msvc-dev-cmd@v1` (arch x64) so `cl.exe` is on PATH for the Ninja build — placed **before** the vcpkg openssl step so our `VCPKG_ROOT` is the last writer (msvc-dev-cmd's vcvars clobbers it otherwise — the gotcha that bit #106/#22).
- Windows configure: drop `-T host / -A arch` (VS-only), add `-DCMAKE_BUILD_TYPE=Release` for the single-config generator.
- Run-tests step: Ninja puts binaries in `bin/`, not `bin/Release/`.

## Scope / safety

- release.yml is **Release-only**, so the `/Z7` + sccache work from #2964 is moot here. No sccache added — keep the artifact-producing workflow simple (matches extended_checks).
- The install bundle is produced via `cmake --install` (generator-agnostic), so the shipped `.zip` layout is unchanged; only the test step's hardcoded `bin/Release` path needed fixing.
- The Windows-Ninja build path itself is already green in CI twice (extended_checks #2961, build.yml #2963/#2964).

## Validation

Triggered via `workflow_dispatch` on this branch — that runs build + install + smoke-test but does **not** upload assets (the upload step gates on `github.event_name == 'release'`), so it's a full dry-run of the artifact build without touching real release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)