### PR TITLE
uriparser: percent-encode '/'-separated Windows paths in file_name_to_uri

### DIFF
--- a/include/daScript/misc/uric.h
+++ b/include/daScript/misc/uric.h
@@ -4,8 +4,25 @@
 #define URI_STATIC_BUILD
 #endif
 #include "uriparser/Uri.h"
+#include <cstring>
 
 namespace das {
+
+    // uriWindowsFilenameToUriString only treats '\\' as a path separator and
+    // only percent-escapes per segment. daslang normalizes paths to '/', so a
+    // '/'-only path would collapse into one "first segment" and be copied
+    // verbatim (unescaped) -> an invalid URI. Normalize '/' -> '\\' first.
+    // Returns the original pointer (no allocation) when there is no '/'.
+    inline const char * windowsFileNameSlashesToBackslashes ( const char * fileName, string & storage ) {
+        if ( fileName == nullptr || strchr(fileName, '/') == nullptr ) {
+            return fileName;
+        }
+        storage = fileName;
+        for ( auto & c : storage ) {
+            if ( c == '/' ) c = '\\';
+        }
+        return storage.c_str();
+    }
 
     class Uri {
     public:

--- a/src/builtin/module_builtin_uriparser.cpp
+++ b/src/builtin/module_builtin_uriparser.cpp
@@ -112,22 +112,17 @@ char * unix_file_name_to_uri ( char * uristr, Context * context, LineInfoArg * a
 char * windows_file_name_to_uri ( char * uristr, Context * context, LineInfoArg * at ) {
     if ( !uristr ) return nullptr;
     int len = stringLength(*context,uristr);
-    // uriWindowsFilenameToUriStringA only treats '\\' as a path separator and
-    // only percent-escapes per segment. daslang normalizes paths to '/', so a
-    // '/'-only path collapses into a single "first segment" that is copied
-    // verbatim (unescaped) — producing an invalid URI (e.g. a literal space)
-    // that normalize_uri/parse then rejects. Normalize '/' -> '\\' first so each
-    // segment is escaped (the converter turns '\\' back into '/' in the URI).
-    auto tmp = new char[len + 1];
-    for ( int i = 0; i < len; ++i ) tmp[i] = (uristr[i] == '/') ? '\\' : uristr[i];
-    tmp[len] = 0;
+    // Normalize '/' -> '\\' so each path segment is percent-escaped; otherwise a
+    // '/'-only path yields an invalid URI (see windowsFileNameSlashesToBackslashes
+    // in uric.h). No allocation when the path has no '/'.
+    string slashStorage;
+    const char * winName = windowsFileNameSlashesToBackslashes(uristr, slashStorage);
     auto buf = new char[8 + 3 * len + 1];
     char * result = nullptr;
-    if ( uriWindowsFilenameToUriStringA(tmp, buf) == URI_SUCCESS ) {
+    if ( uriWindowsFilenameToUriStringA(winName, buf) == URI_SUCCESS ) {
         result = context->allocateString(buf, uint32_t(strlen(buf)), at);
     }
     delete [] buf;
-    delete [] tmp;
     return result;
 }
 

--- a/src/builtin/module_builtin_uriparser.cpp
+++ b/src/builtin/module_builtin_uriparser.cpp
@@ -112,12 +112,22 @@ char * unix_file_name_to_uri ( char * uristr, Context * context, LineInfoArg * a
 char * windows_file_name_to_uri ( char * uristr, Context * context, LineInfoArg * at ) {
     if ( !uristr ) return nullptr;
     int len = stringLength(*context,uristr);
+    // uriWindowsFilenameToUriStringA only treats '\\' as a path separator and
+    // only percent-escapes per segment. daslang normalizes paths to '/', so a
+    // '/'-only path collapses into a single "first segment" that is copied
+    // verbatim (unescaped) — producing an invalid URI (e.g. a literal space)
+    // that normalize_uri/parse then rejects. Normalize '/' -> '\\' first so each
+    // segment is escaped (the converter turns '\\' back into '/' in the URI).
+    auto tmp = new char[len + 1];
+    for ( int i = 0; i < len; ++i ) tmp[i] = (uristr[i] == '/') ? '\\' : uristr[i];
+    tmp[len] = 0;
     auto buf = new char[8 + 3 * len + 1];
     char * result = nullptr;
-    if ( uriWindowsFilenameToUriStringA(uristr, buf) == URI_SUCCESS ) {
+    if ( uriWindowsFilenameToUriStringA(tmp, buf) == URI_SUCCESS ) {
         result = context->allocateString(buf, uint32_t(strlen(buf)), at);
     }
     delete [] buf;
+    delete [] tmp;
     return result;
 }
 

--- a/src/misc/uric.cpp
+++ b/src/misc/uric.cpp
@@ -207,7 +207,12 @@ namespace das {
         vector<char> result;
         if ( len==-1 ) len = int(strlen(fileName));
         result.resize(8 + 3*len + 1);
-        lastOp = uriWindowsFilenameToUriStringA(fileName, result.data());
+        // Normalize '/' -> '\\' so each segment is escaped; daslang passes
+        // '/'-paths and uriWindowsFilenameToUriStringA only escapes per '\\'
+        // segment (see windowsFileNameSlashesToBackslashes in uric.h).
+        string slashStorage;
+        const char * winName = windowsFileNameSlashesToBackslashes(fileName, slashStorage);
+        lastOp = uriWindowsFilenameToUriStringA(winName, result.data());
         if ( lastOp != URI_SUCCESS) return false;
         return parse(result.data());
     }

--- a/tests/uri/test_uri.das
+++ b/tests/uri/test_uri.das
@@ -1,6 +1,7 @@
 options gen2
 require dastest/testing_boost public
 
+require uriparser
 require daslib/uriparser_boost
 require daslib/strings_boost
 require daslib/defer
@@ -17,7 +18,7 @@ def test_uri(t : T?) {
         t |> equal(uri |> query, "quone=one&qtow=2")
         t |> equal(uri |> fragment, "someframgnet")
         t |> equal(uri |> path, "one/two/three")
-        var spath <- uri_split_full_path(uri)
+        let spath <- uri_split_full_path(uri)
         t |> equal(spath[0], "one")
         t |> equal(spath[1], "two")
         t |> equal(spath[2], "three")
@@ -93,6 +94,37 @@ def test_uri_file_name(t : T?) {
             defer_delete(uri)
             t |> equal(string(uri), "file:///somedir/somefile.txt")
         }
+    }
+}
+
+[test]
+def test_file_name_to_uri_escapes_reserved(t : T?) {
+    // windows_file_name_to_uri only segments/escapes on '\'. daslang normalizes
+    // paths to '/', so a '/'-only Windows path used to be copied verbatim
+    // (unescaped) -> an invalid URI (with a literal space) that normalize_uri
+    // rejects (returns ""), silently dropping the path. Regression test.
+    t |> run("windows '/' path with space is escaped and round-trips") @@(t : T?) {
+        let p = "E:/some dir/with space.das"
+        let uri = windows_file_name_to_uri(p)
+        t |> success(!empty(uri), "windows_file_name_to_uri returned empty for {p}")
+        t |> success(uri |> contains("%20"), "space not percent-encoded: {uri}")
+        t |> success(!(uri |> contains(" ")), "literal space left in uri: {uri}")
+        let norm = uri |> normalize_uri()
+        t |> success(!empty(norm), "normalize_uri rejected {uri}")
+        let back = norm |> uri_to_file_name()
+        t |> success(back |> contains("some dir") && back |> contains("with space.das"),
+            "round-trip lost the path: {back}")
+    }
+    t |> run("unix path with space is escaped and round-trips") @@(t : T?) {
+        let p = "/some dir/with space.das"
+        let uri = unix_file_name_to_uri(p)
+        t |> success(!empty(uri), "unix_file_name_to_uri returned empty for {p}")
+        t |> success(uri |> contains("%20"), "space not percent-encoded: {uri}")
+        let norm = uri |> normalize_uri()
+        t |> success(!empty(norm), "normalize_uri rejected {uri}")
+        let back = norm |> uri_to_file_name()
+        t |> success(back |> contains("some dir") && back |> contains("with space.das"),
+            "round-trip lost the path: {back}")
     }
 }
 

--- a/tests/uri/test_uri.das
+++ b/tests/uri/test_uri.das
@@ -120,6 +120,7 @@ def test_file_name_to_uri_escapes_reserved(t : T?) {
         let uri = unix_file_name_to_uri(p)
         t |> success(!empty(uri), "unix_file_name_to_uri returned empty for {p}")
         t |> success(uri |> contains("%20"), "space not percent-encoded: {uri}")
+        t |> success(!(uri |> contains(" ")), "literal space left in uri: {uri}")
         let norm = uri |> normalize_uri()
         t |> success(!empty(norm), "normalize_uri rejected {uri}")
         let back = norm |> uri_to_file_name()


### PR DESCRIPTION
## The bug

`file_name_to_uri` on Windows maps to `windows_file_name_to_uri` → `uriWindowsFilenameToUriStringA`, which only treats `\` as a path separator and only percent-escapes **per segment**. daslang normalizes paths to `/`, so a `/`-only Windows path (e.g. `E:/some dir/x.das`) collapses into a single "first segment" that uriparser copies **verbatim** (the `C:` drive-letter raw-copy hack at `UriFile.c:113`), leaving reserved characters **unescaped**.

The result is an invalid URI — `file:///E:/some dir/x.das` with a *literal space* — which `normalize_uri`'s parser then rejects, returning `""`.

This silently broke any code round-tripping a reserved-char path through `file_name_to_uri |> normalize_uri |> uri_to_file_name`. Concretely, **dastest collected zero tests** from a path containing a space (e.g. `--test "C:/My Tests"`), in both regular and isolated mode — `fix_path`→`""`→empty `join_path`→invalid `stat`→every file skipped. The Unix variant already segments on `/`, so this was Windows-only.

## The fix

In `windows_file_name_to_uri`, normalize `/` → `\` before conversion so uriparser escapes each segment (it converts `\` back into `/` in the URI output). Now `E:/some dir/x.das` → `file:///E:/some%20dir/x.das`, which `normalize_uri` accepts and `uri_to_file_name` decodes back to the original path.

## Test

Adds `tests/uri/test_file_name_to_uri_escapes_reserved`: both `windows_file_name_to_uri` and `unix_file_name_to_uri` must percent-encode a space and survive the `normalize_uri |> uri_to_file_name` round-trip. Verified locally (debug build with the fix): `tests/uri` 16/16, and dastest now collects from a space-containing path with its *unmodified* `fix_path`.

## Note

Surfaced while making dastest robust ([#2968](https://github.com/GaijinEntertainment/daScript/pull/2968)). That PR carries a defensive `fix_path` fallback for the same symptom; with this root-cause fix that fallback is redundant and can be reverted (separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)