### PR TITLE
blog: add "Kibble" post

### DIFF
--- a/site/blog/_posts/kibble.md
+++ b/site/blog/_posts/kibble.md
@@ -1,0 +1,29 @@
+---
+title: Kibble
+date: 2026-06-02 01:38:00
+tags:
+    - daScript
+    - Claude
+---
+
+So meta. Much wow.
+
+<!-- more -->
+
+I am the biggest fan of dogfooding imaginable. Kind of hard not to be with game development background. Its not like u can not play the game u develop, or not use the tools u build to develop said game. But then again I've met some interesting people back in 1812.
+
+I've mostly done engine/tools, and lately language work. That red lightsabre sits tightly; the dark side of gamedev has been embraced in full, cookies taste bitter - figures its because those are dog treats.
+
+Tools are a new meta. But we can go deeper. AI needs to talk to your tools from day one - MCP or CLI. Its trivial with the command-line tools. Its kind of okay with the web-based ones. It even works with your ugly graphics ones - just give it screenshot, mouse, keyboard, key to the SSH, blood of your firstborn - and u r good to go. It will crawl.
+
+But this is ~~Sparta~~ gamedev - the land of [Dear Imgui](https://github.com/ocornut/imgui) - the [daslang province](https://borisbat.github.io/dasImgui/index.html). I've tried both - web and embedded, and this really is the lesser evil. So here I am, leading forces of darkness to fight forces of real darkness - one button at a time.
+
+So lets get evil. Wrappers are here to stay, because mismatching begin/end pairs crash, because UI does not belong to C++, because manual sunrise is not a thing, because manually declaring state for widgets is silly, and lastly, because reasons.
+
+Once u get wrappers, u want the non-wrapper version to die horrible death - together with whoever writes it. This is where u unfold lint, white list 'safe' choices. Embrace the hate.
+
+Once u get wrappers, u want to be friends. With benefits. Or else. So u get your external controls "for free". U get curl to query, u get curl to set. U get an MCP because curl is for the weak. Once u do - that control goes poof. U don't want curl. U r not touching no stinking MCP. Thats what friends are for. Let Claude do the dirty - because screenshot sux.
+
+Once u get wrappers, u want the playwright. First for tests, then for tutorials. At this point u wonder, who u r making the tutorials for. U can't help but wonder - Claude already knows your UI inside out (remember that MCP). It can look without touching (screenshot) - and more fluent with your tools than u are. Your tools? Lol.
+
+I like tutorials, a lot. Music plays. Emma speaks in that wonderful accent of hers. All those little widgets I had no clue were available all these years - are now at the fingertips. Wish I had them when they were made for me. So meta. Much wow.


### PR DESCRIPTION
New blog post under `site/blog/_posts/` — dogfooding the tools/AI loop: MCP & CLI, wrappers + lint, dasImgui as the "lesser evil", and Claude-driven tutorials.

Text only. Typo-level edits applied (kept the rough voice intact); bare URLs fused into the nouns they describe; frontmatter date zero-padded to match the other posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)