### PR TITLE
linq_das: multiple-from baseline — projections doc + cross_join/select_many benchmarks

### DIFF
--- a/benchmarks/sql/_common.das
+++ b/benchmarks/sql/_common.das
@@ -199,3 +199,34 @@ def public fixture_decs_capture_mid(n : int) : EntityId {
     }
     return target_eid
 }
+
+// Nested-collection fixture for the correlated select_many benches: an Order carrying an `array<Line>`
+// field, so `from o in orders from l in o.lines` flattens the per-order lines. LINES_PER_ORDER lines each,
+// so the flattened count is n * LINES_PER_ORDER.
+let public LINES_PER_ORDER = 3
+let public CUST_COUNT = 50
+
+struct public Line {
+    sku : string
+    qty : int
+}
+
+struct public OrderWithLines {
+    id       : int
+    customer : string
+    lines    : array<Line>
+}
+
+def public fixture_orders_nested(n : int) : array<OrderWithLines> {
+    var arr : array<OrderWithLines>
+    arr |> resize(n)
+    for (i in range(n)) {
+        arr[i].id = i + 1
+        arr[i].customer = "Cust{i % CUST_COUNT}"
+        arr[i].lines |> resize(LINES_PER_ORDER)
+        for (j in range(LINES_PER_ORDER)) {
+            arr[i].lines[j] = Line(sku = "S{i}_{j}", qty = j + 1)
+        }
+    }
+    return <- arr
+}

--- a/benchmarks/sql/cross_join.das
+++ b/benchmarks/sql/cross_join.das
@@ -1,0 +1,84 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// cross_join(A, B, into) — the Cartesian product of two independent sources, materialized + counted.
+// SQL: SELECT ... FROM Cars, Dealers (pushdown; rows marshalled back). In-memory (m3f/m5f): cross_join()
+// builds the full |A|×|B| product array (UNFUSED — there is no _fold cross splice yet; this is the baseline
+// the fusion optimization will improve). Because the product is O(n·m), n is SMALL here (CROSS_N, vs 100000
+// in the other families) so the product stays ~100k rows.
+//
+// PR1 measures the engine ops in their current WORKING forms (typed lambdas, bare-pipe / _sql), NOT the
+// reader's `_fold` emit (that lands in the cross_join engine PR). Lanes:
+//   m1  SQL   — _sql(select_from |> _cross_join(select_from, into))
+//   m3f array — cross_join(arrA, arrB, into)
+//   m5f XML   — cross_join_to_array(from_xml_node, arrB, into)
+// NO decs lane (m4): a standalone `from_decs_template` source yields anonymous tuples, so there is no clean
+// typed-lambda cross form — decs cross_join arrives with the _fold engine integration (cross_join PR).
+
+let CROSS_N = 1000   // 1000 cars × 100 dealers = 100k pairs
+
+def run_m1(b : B?; n : int) {
+    with_sqlite(":memory:") $(db) {
+        fixture_db(db, n)
+        b |> run("m1_sql/{n}", n) {
+            let rows <- _sql(db |> select_from(type<Car>)
+                                |> _cross_join(db |> select_from(type<Dealer>),
+                                               $(ca : Car, de : Dealer) => (CarId = ca.id, DealerId = de.id)))
+            let c = length(rows)
+            b |> accept(c)
+            if (c != n * DEALER_COUNT) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m3f(b : B?; n : int) {
+    let cars <- fixture_array(n)
+    let dealers <- fixture_dealers_array()
+    b |> run("m3f_array_fold/{n}", n) {
+        let rows <- cross_join(cars, dealers, $(ca : Car, de : Dealer) => (CarId = ca.id, DealerId = de.id))
+        let c = length(rows)
+        b |> accept(c)
+        if (c != n * DEALER_COUNT) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    let dealers <- fixture_dealers_array()
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let rows <- cross_join_to_array(unsafe(from_xml_node(doc.document_element, type<Car>)), dealers,
+                                            $(ca : Car, de : Dealer) => (CarId = ca.id, DealerId = de.id))
+            let c = length(rows)
+            b |> accept(c)
+            if (c != n * DEALER_COUNT) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+[benchmark]
+def cross_join_m1(b : B?) {
+    run_m1(b, CROSS_N)
+}
+
+[benchmark]
+def cross_join_m3f(b : B?) {
+    run_m3f(b, CROSS_N)
+}
+
+[benchmark]
+def cross_join_m5f(b : B?) {
+    run_m5f(b, CROSS_N)
+}

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -116,7 +116,7 @@ DOM-parse + per-element attribute reads + `string` clones the in-memory lanes ne
 | `reverse_take` | 0.1 | 0.0 | 9.2 | 89.7 |
 | `reverse_take_select` | 0.0 | 0.0 | 9.2 | 89.8 |
 | `select_count` | 0.1 | 0.0 | 2.2 | 68.7 |
-| `select_many` | — | 532.5 | — | — |
+| `select_many` | — | 156.0 | — | — |
 | `select_where` | 196.6 | 11.2 | 19.6 | 224.5 |
 | `select_where_count` | 32.9 | 5.2 | 7.5 | 61.9 |
 | `select_where_order_take` | 36.9 | 12.6 | 15.1 | 70.3 |
@@ -196,7 +196,7 @@ DOM-parse + per-element attribute reads + `string` clones the in-memory lanes ne
 | `reverse_take` | 0.0 | 0.0 | 1.1 | 69.3 |
 | `reverse_take_select` | 0.0 | 0.0 | 1.1 | 69.8 |
 | `select_count` | 0.1 | 0.0 | 0.0 | 64.4 |
-| `select_many` | — | 146.5 | — | — |
+| `select_many` | — | 51.6 | — | — |
 | `select_where` | 108.3 | 4.1 | 5.6 | 97.3 |
 | `select_where_count` | 32.7 | 0.3 | 0.6 | 16.4 |
 | `select_where_order_take` | 36.7 | 0.7 | 1.4 | 17.4 |

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,8 @@
 # Benchmarks — SQL / Array / Decs / XML comparison
 
-Updated 2026-06-01 (branch `bbatkin/linq-das-join`): **join now fuses a leading `_where`.** The `join_general` splice arm gained an optional leading `_where` slot — a `where` that filters the left source *before* a `_join` is wrapped into the per-A probe loop as `if (pred(a)) { <probe> }` (shared `build_join_standalone_pieces`, so array / decs / XML all inherit it), so the pre-join filter no longer materializes an intermediate filtered-srcA array. The new **`where_join_count`** family measures this (`_where(price > T) |> _join(...) |> count`) against the trailing-filter `join_where_count`; over SQL the same pre-join `where` pushes down to the left table's `WHERE`. All other cell deltas are long-sweep thermal noise — the existing join families (`join_count` / `join_select` / `join_where_count` / `join_groupby_*`) are unchanged, since the new slot is empty for them.
+Updated 2026-06-02 (branch `bbatkin/linq-das-projections-bench`): **two new families — `cross_join` and `select_many` — establish the multiple-`from` (SelectMany) baseline.** `cross_join` measures the Cartesian product `cross_join(A, B, into)` across SQL / array / XML; `select_many` measures the correlated flatten `select_many(orders, $(o) => o.lines, …)` over an array of nested-collection rows. **Both are UNFUSED** — there is no `_fold` cross-join or select_many splice arm yet, so they run as the plain library calls (the in-memory lanes materialize the full result); this is the baseline the engine-integration PRs improve. `cross_join` uses a smaller n (1000 cars × 100 dealers = 100k pairs) because the product is O(n·m), so its absolute ns are not comparable to the n=100000 families. Empty cells are explained in "Notes on missing lanes". A one-line parity fix in `daslib/linq.das` rode along: the 3-arg `select_many_impl` now reserves `length(src)` up front like the 2-arg form (clears a PERF006).
+
+Earlier (branch `bbatkin/linq-das-join`): **join now fuses a leading `_where`.** The `join_general` splice arm gained an optional leading `_where` slot — a `where` that filters the left source *before* a `_join` is wrapped into the per-A probe loop as `if (pred(a)) { <probe> }` (shared `build_join_standalone_pieces`, so array / decs / XML all inherit it), so the pre-join filter no longer materializes an intermediate filtered-srcA array. The new **`where_join_count`** family measures this (`_where(price > T) |> _join(...) |> count`) against the trailing-filter `join_where_count`; over SQL the same pre-join `where` pushes down to the left table's `WHERE`. All other cell deltas are long-sweep thermal noise — the existing join families (`join_count` / `join_select` / `join_where_count` / `join_groupby_*`) are unchanged, since the new slot is empty for them.
 
 Earlier (branch `bbatkin/linq-fold-sql-passthrough`): **`_fold` routes a SQL source straight to `_sql`.** When a `_fold(...)` chain's source is a `[sql_table]`/`[sql_view]`/`[sql_fts5]` `select_from(db, type<Row>)`, `_fold` re-dispatches the *entire* chain to the `_sql` macro — pure pass-through, observationally identical to writing `_sql(...)` by hand. The **m1 (SQL) lane in every bench is authored as `_fold(db |> select_from(type<Car>) |> ...)`**; the generated SQL and code are identical (early-exit terminals — `first`/`any`/`contains`/`element_at`/`single`/`last` — stay `0.0`, i.e. `LIMIT 1` pushdown, not a full-table materialization). Detection lives in `sqlite/linq_fold_sql` (optional `require ?sqlite` + `static_if (typeinfo builtin_module_exists(sqlite))`, so non-sqlite builds are unaffected) and walks the chain's `arguments[0]` source spine for a SQL-table `select_from`.
 
@@ -57,163 +59,167 @@ DOM-parse + per-element attribute reads + `string` clones the in-memory lanes ne
 
 
 <!-- BENCH:TABLES BEGIN -->
-*Generated 2026-06-01 by `benchmarks/sql/_update_results.das` — ns/op; `—` = absent lane. Edit the prose around the markers, not the tables.*
+*Generated 2026-06-02 by `benchmarks/sql/_update_results.das` — ns/op; `—` = absent lane. Edit the prose around the markers, not the tables.*
 
 ## INTERP
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML fold (m5f) |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 35.4 | 6.0 | 6.0 | 58.5 |
-| `all_match` | 28.1 | 3.6 | 3.4 | 55.9 |
+| `aggregate_match` | 35.2 | 6.0 | 6.0 | 58.6 |
+| `all_match` | 27.9 | 3.5 | 3.5 | 56.3 |
 | `any_match` | 0.0 | 0.0 | 0.0 | 0.0 |
-| `average_aggregate` | 30.7 | 5.9 | 8.7 | 58.3 |
-| `bare_order_where` | 278.3 | 119.3 | 124.4 | 330.6 |
-| `chained_select_collapse` | — | 17.8 | 17.6 | 70.5 |
-| `chained_where` | 37.0 | 6.7 | 7.2 | 103.4 |
-| `contains_match` | 0.0 | 2.2 | 1.4 | 29.1 |
-| `count_aggregate` | 30.3 | 4.2 | 4.2 | 64.5 |
+| `average_aggregate` | 30.3 | 5.9 | 8.8 | 70.2 |
+| `bare_order_where` | 278.9 | 116.6 | 125.6 | 330.9 |
+| `chained_select_collapse` | — | 18.0 | 17.7 | 70.5 |
+| `chained_where` | 37.0 | 6.7 | 7.3 | 103.6 |
+| `contains_match` | 0.0 | 2.2 | 1.4 | 29.2 |
+| `count_aggregate` | 29.7 | 4.1 | 4.1 | 64.7 |
+| `cross_join` | 12681.5 | 3714.8 | — | 4072.1 |
 | `decs_count_bare_pred` | — | — | 4.2 | — |
-| `distinct_by_count` | 41.9 | 15.9 | 16.1 | 72.6 |
-| `distinct_by_order_take` | 239.7 | 21.8 | 23.5 | 126.4 |
-| `distinct_by_order_to_array` | 242.6 | 21.9 | 24.5 | 127.4 |
-| `distinct_count` | 42.0 | 16.0 | 15.8 | 71.1 |
-| `distinct_count_pred` | 252.4 | 15.8 | 15.9 | 112.7 |
+| `distinct_by_count` | 41.3 | 16.1 | 16.2 | 72.5 |
+| `distinct_by_order_take` | 241.6 | 21.9 | 23.3 | 126.4 |
+| `distinct_by_order_to_array` | 248.3 | 22.0 | 23.5 | 126.9 |
+| `distinct_count` | 41.8 | 15.8 | 15.9 | 70.8 |
+| `distinct_count_pred` | 252.2 | 15.9 | 15.9 | 111.7 |
 | `distinct_take` | 0.0 | 0.0 | 0.0 | 0.0 |
 | `element_at_match` | 0.0 | 0.0 | 0.0 | 0.4 |
 | `first_match` | 0.0 | 0.0 | 0.0 | 0.0 |
 | `first_or_default_match` | 0.0 | 0.0 | 0.0 | 0.0 |
-| `groupby_average` | 171.8 | 30.5 | 30.1 | 125.5 |
-| `groupby_count` | 142.6 | 19.2 | 19.2 | 76.4 |
-| `groupby_first` | 255.1 | 18.5 | 19.2 | 72.1 |
-| `groupby_having_count` | 142.6 | 19.2 | 19.2 | 78.5 |
-| `groupby_having_hidden_sum` | 175.2 | 23.7 | 24.1 | 124.0 |
-| `groupby_having_post_where` | 171.7 | 18.6 | 18.8 | 115.3 |
-| `groupby_max` | 173.6 | 25.2 | 25.2 | 121.9 |
-| `groupby_min` | 177.5 | 25.2 | 25.2 | 121.8 |
-| `groupby_multi_reducer` | 191.0 | 32.6 | 32.8 | 126.6 |
-| `groupby_select_order` | 171.4 | 18.7 | 18.9 | 117.6 |
-| `groupby_select_sum` | 201.1 | 36.3 | 36.0 | 98.7 |
-| `groupby_sum` | 173.5 | 18.7 | 18.7 | 115.9 |
-| `groupby_where_count` | 82.1 | 14.4 | 14.9 | 117.4 |
-| `groupby_where_sum` | 86.9 | 14.2 | 14.7 | 117.0 |
-| `indexed_lookup` | 1454.3 | 205643.8 | 503.7 | 5857645.3 |
-| `join_count` | 38.6 | 51.1 | 64.1 | 112.7 |
-| `join_groupby_count` | 158.3 | 78.3 | 90.6 | 180.3 |
-| `join_groupby_to_array` | 191.8 | 78.1 | 90.8 | 215.6 |
-| `join_select` | 148.3 | 72.6 | 86.9 | 190.7 |
-| `join_where_count` | 39.5 | 62.0 | 75.5 | 162.2 |
+| `groupby_average` | 171.6 | 30.5 | 30.1 | 150.3 |
+| `groupby_count` | 142.5 | 19.2 | 19.2 | 76.7 |
+| `groupby_first` | 251.3 | 18.5 | 19.2 | 81.7 |
+| `groupby_having_count` | 142.3 | 19.2 | 21.2 | 79.0 |
+| `groupby_having_hidden_sum` | 175.9 | 23.8 | 24.1 | 123.9 |
+| `groupby_having_post_where` | 171.5 | 18.8 | 18.6 | 116.2 |
+| `groupby_max` | 172.9 | 25.0 | 25.1 | 121.2 |
+| `groupby_min` | 174.5 | 25.1 | 25.2 | 121.6 |
+| `groupby_multi_reducer` | 190.8 | 32.4 | 32.7 | 126.2 |
+| `groupby_select_order` | 171.7 | 18.9 | 18.7 | 118.1 |
+| `groupby_select_sum` | 202.2 | 36.2 | 36.2 | 98.5 |
+| `groupby_sum` | 171.4 | 18.5 | 19.0 | 115.1 |
+| `groupby_where_count` | 75.6 | 14.3 | 14.8 | 119.3 |
+| `groupby_where_sum` | 86.5 | 14.2 | 14.7 | 137.6 |
+| `indexed_lookup` | 1466.7 | 205166.1 | 493.6 | 5837446.7 |
+| `join_count` | 38.4 | 51.5 | 64.5 | 112.8 |
+| `join_groupby_count` | 157.1 | 78.6 | 90.2 | 179.5 |
+| `join_groupby_to_array` | 193.2 | 78.2 | 90.6 | 235.3 |
+| `join_select` | 149.4 | 72.8 | 86.4 | 191.9 |
+| `join_where_count` | 39.6 | 62.0 | 75.0 | 160.5 |
 | `last_match` | 0.0 | 5.8 | 14.0 | 65.8 |
-| `long_count_aggregate` | 30.2 | 4.2 | 4.2 | 64.3 |
-| `max_aggregate` | 31.8 | 6.2 | 6.8 | 58.6 |
-| `min_aggregate` | 31.5 | 6.0 | 6.8 | 58.3 |
-| `order_distinct_take` | 138.4 | 15.8 | 93.9 | 73.0 |
-| `order_reverse_normalized` | 38.5 | 16.3 | 20.0 | 69.7 |
-| `order_take_desc` | 38.5 | 16.3 | 20.7 | 69.7 |
-| `reverse_distinct_by` | 296.4 | 21.4 | 28.1 | 74.9 |
-| `reverse_take` | 0.1 | 0.0 | 9.3 | 89.7 |
-| `reverse_take_select` | 0.0 | 0.0 | 9.2 | 89.5 |
-| `select_count` | 0.1 | 0.0 | 2.2 | 68.2 |
-| `select_where` | 194.5 | 11.1 | 19.5 | 225.5 |
-| `select_where_count` | 33.3 | 5.2 | 7.5 | 62.3 |
-| `select_where_order_take` | 37.5 | 12.4 | 15.0 | 70.7 |
-| `select_where_sum` | 37.3 | 7.4 | 7.6 | 64.0 |
-| `single_match` | 0.0 | 2.8 | 5.6 | 57.7 |
+| `long_count_aggregate` | 30.1 | 4.1 | 4.1 | 64.4 |
+| `max_aggregate` | 31.5 | 6.2 | 6.9 | 58.4 |
+| `min_aggregate` | 31.1 | 6.0 | 6.8 | 58.3 |
+| `order_distinct_take` | 137.6 | 15.8 | 93.7 | 72.7 |
+| `order_reverse_normalized` | 38.6 | 16.3 | 20.1 | 69.6 |
+| `order_take_desc` | 38.7 | 16.2 | 22.0 | 69.5 |
+| `reverse_distinct_by` | 300.8 | 21.9 | 28.3 | 74.2 |
+| `reverse_take` | 0.1 | 0.0 | 9.2 | 89.7 |
+| `reverse_take_select` | 0.0 | 0.0 | 9.2 | 89.8 |
+| `select_count` | 0.1 | 0.0 | 2.2 | 68.7 |
+| `select_many` | — | 532.5 | — | — |
+| `select_where` | 196.6 | 11.2 | 19.6 | 224.5 |
+| `select_where_count` | 32.9 | 5.2 | 7.5 | 61.9 |
+| `select_where_order_take` | 36.9 | 12.6 | 15.1 | 70.3 |
+| `select_where_sum` | 37.2 | 7.4 | 7.6 | 72.6 |
+| `single_match` | 0.0 | 2.8 | 5.5 | 54.7 |
 | `skip_take` | 0.5 | 0.1 | 0.2 | 3.7 |
-| `skip_while_match` | 3.5 | 5.3 | 5.4 | 59.2 |
-| `sort_first` | 38.5 | 11.1 | 13.3 | 64.3 |
-| `sort_take` | 38.8 | 16.4 | 20.1 | 69.2 |
-| `sort_take_select` | 38.9 | 16.3 | 20.1 | 70.9 |
-| `sum_aggregate` | 30.8 | 2.1 | 2.1 | 54.3 |
-| `sum_where` | 33.4 | 4.3 | 4.3 | 61.8 |
+| `skip_while_match` | 3.4 | 5.3 | 5.4 | 56.4 |
+| `sort_first` | 37.8 | 11.0 | 13.2 | 63.8 |
+| `sort_take` | 38.4 | 16.2 | 19.9 | 68.3 |
+| `sort_take_select` | 38.1 | 16.2 | 19.9 | 70.0 |
+| `sum_aggregate` | 30.0 | 2.1 | 2.1 | 53.9 |
+| `sum_where` | 33.0 | 4.3 | 4.3 | 63.0 |
 | `take_count` | 3.6 | 0.2 | 0.5 | 3.5 |
 | `take_count_filtered` | 1.1 | 0.2 | 0.2 | 1.3 |
 | `take_sum_aggregate` | 0.8 | 0.1 | 0.1 | 0.6 |
 | `take_where_count` | 0.9 | 0.1 | 0.1 | 0.7 |
-| `take_while_match` | 7.9 | 2.4 | 2.5 | 29.8 |
-| `to_array_filter` | 71.0 | 11.7 | 11.9 | 72.1 |
-| `where_join_count` | 42.0 | 29.5 | 41.9 | 136.8 |
-| `zip_count_pred` | 39.5 | 15.0 | — | 372.9 |
-| `zip_dot_product` | — | 12.8 | 10.5 | 361.0 |
-| `zip_dot_product_3arg` | — | 12.7 | — | 362.7 |
-| `zip_reverse_to_array` | — | 30.9 | — | 399.0 |
+| `take_while_match` | 7.8 | 2.4 | 2.4 | 28.2 |
+| `to_array_filter` | 71.1 | 11.7 | 11.8 | 71.8 |
+| `where_join_count` | 41.4 | 30.0 | 41.2 | 135.3 |
+| `zip_count_pred` | 39.2 | 15.1 | — | 373.0 |
+| `zip_dot_product` | — | 12.9 | 12.7 | 366.1 |
+| `zip_dot_product_3arg` | — | 12.6 | — | 361.2 |
+| `zip_reverse_to_array` | — | 30.8 | — | 396.5 |
 
 ## JIT
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML fold (m5f) |
 |---|---:|---:|---:|---:|
-| `aggregate_match` | 35.1 | 0.3 | 0.6 | 17.6 |
-| `all_match` | 28.0 | 0.3 | 0.2 | 17.1 |
+| `aggregate_match` | 35.1 | 0.3 | 0.6 | 16.3 |
+| `all_match` | 27.7 | 0.3 | 0.2 | 16.3 |
 | `any_match` | 0.0 | 0.0 | 0.0 | 0.0 |
-| `average_aggregate` | 30.5 | 1.0 | 3.5 | 18.2 |
-| `bare_order_where` | 185.9 | 34.1 | 34.4 | 124.8 |
-| `chained_select_collapse` | — | 2.1 | 2.1 | 21.6 |
-| `chained_where` | 36.8 | 0.6 | 0.8 | 35.6 |
-| `contains_match` | 0.0 | 0.2 | 0.1 | 18.0 |
-| `count_aggregate` | 30.2 | 0.3 | 0.6 | 17.2 |
+| `average_aggregate` | 30.3 | 1.0 | 3.5 | 17.5 |
+| `bare_order_where` | 185.7 | 33.8 | 35.4 | 125.9 |
+| `chained_select_collapse` | — | 2.2 | 2.1 | 21.1 |
+| `chained_where` | 36.5 | 0.6 | 0.8 | 35.6 |
+| `contains_match` | 0.0 | 0.2 | 0.1 | 17.1 |
+| `count_aggregate` | 29.7 | 0.3 | 0.6 | 16.4 |
+| `cross_join` | 5972.5 | 729.7 | — | 885.7 |
 | `decs_count_bare_pred` | — | — | 0.6 | — |
-| `distinct_by_count` | 42.1 | 2.1 | 2.1 | 21.9 |
-| `distinct_by_order_take` | 239.3 | 2.7 | 3.2 | 47.0 |
-| `distinct_by_order_to_array` | 238.8 | 2.7 | 3.2 | 47.8 |
-| `distinct_count` | 41.9 | 2.1 | 2.1 | 21.8 |
-| `distinct_count_pred` | 257.0 | 2.1 | 2.3 | 38.9 |
+| `distinct_by_count` | 41.9 | 2.1 | 2.1 | 21.6 |
+| `distinct_by_order_take` | 242.3 | 2.6 | 3.2 | 46.5 |
+| `distinct_by_order_to_array` | 240.1 | 2.7 | 3.3 | 47.4 |
+| `distinct_count` | 41.4 | 2.1 | 2.1 | 21.3 |
+| `distinct_count_pred` | 252.8 | 2.1 | 2.3 | 39.4 |
 | `distinct_take` | 0.0 | 0.0 | 0.0 | 0.0 |
 | `element_at_match` | 0.0 | 0.0 | 0.0 | 0.2 |
 | `first_match` | 0.0 | 0.0 | 0.0 | 0.0 |
 | `first_or_default_match` | 0.0 | 0.0 | 0.0 | 0.0 |
-| `groupby_average` | 170.6 | 2.6 | 2.9 | 36.9 |
-| `groupby_count` | 142.3 | 2.4 | 2.5 | 21.8 |
-| `groupby_first` | 253.2 | 2.2 | 3.1 | 22.1 |
-| `groupby_having_count` | 142.1 | 2.4 | 2.6 | 22.9 |
-| `groupby_having_hidden_sum` | 175.6 | 2.5 | 2.8 | 37.7 |
-| `groupby_having_post_where` | 171.4 | 2.4 | 2.7 | 36.1 |
-| `groupby_max` | 172.0 | 2.4 | 2.7 | 38.1 |
-| `groupby_min` | 174.1 | 2.4 | 2.7 | 36.2 |
-| `groupby_multi_reducer` | 190.2 | 2.7 | 3.0 | 38.1 |
-| `groupby_select_order` | 171.0 | 2.4 | 2.7 | 35.8 |
-| `groupby_select_sum` | 199.7 | 3.2 | 3.7 | 32.6 |
-| `groupby_sum` | 171.9 | 2.4 | 2.7 | 35.8 |
-| `groupby_where_count` | 76.2 | 1.5 | 1.8 | 36.6 |
-| `groupby_where_sum` | 86.8 | 1.5 | 1.8 | 37.0 |
-| `indexed_lookup` | 1250.7 | 32570.3 | 106.5 | 4701718.4 |
-| `join_count` | 38.6 | 11.8 | 12.9 | 47.9 |
-| `join_groupby_count` | 157.8 | 19.8 | 22.0 | 69.4 |
-| `join_groupby_to_array` | 202.5 | 19.8 | 22.1 | 81.7 |
-| `join_select` | 93.5 | 20.4 | 22.7 | 75.3 |
-| `join_where_count` | 39.6 | 19.5 | 22.0 | 66.4 |
-| `last_match` | 0.0 | 0.5 | 1.4 | 21.3 |
-| `long_count_aggregate` | 29.9 | 0.3 | 0.6 | 17.0 |
-| `max_aggregate` | 31.2 | 0.3 | 0.5 | 24.9 |
-| `min_aggregate` | 31.2 | 0.3 | 0.5 | 17.2 |
-| `order_distinct_take` | 138.6 | 2.1 | 75.0 | 21.6 |
-| `order_reverse_normalized` | 38.6 | 0.7 | 1.3 | 17.0 |
-| `order_take_desc` | 38.4 | 0.7 | 1.3 | 17.2 |
-| `reverse_distinct_by` | 296.4 | 2.6 | 5.0 | 22.4 |
-| `reverse_take` | 0.0 | 0.0 | 1.1 | 70.3 |
-| `reverse_take_select` | 0.0 | 0.0 | 1.1 | 68.2 |
-| `select_count` | 0.1 | 0.0 | 0.0 | 67.1 |
-| `select_where` | 107.1 | 4.2 | 5.5 | 97.6 |
-| `select_where_count` | 33.1 | 0.3 | 0.6 | 16.9 |
-| `select_where_order_take` | 36.9 | 0.7 | 1.4 | 18.1 |
-| `select_where_sum` | 37.6 | 0.4 | 0.6 | 19.0 |
-| `single_match` | 0.0 | 0.4 | 1.1 | 46.8 |
+| `groupby_average` | 171.8 | 2.6 | 2.9 | 36.4 |
+| `groupby_count` | 141.9 | 2.4 | 2.5 | 21.5 |
+| `groupby_first` | 251.4 | 2.2 | 3.1 | 21.7 |
+| `groupby_having_count` | 141.8 | 2.4 | 2.5 | 22.4 |
+| `groupby_having_hidden_sum` | 176.5 | 2.5 | 2.8 | 37.4 |
+| `groupby_having_post_where` | 170.8 | 2.4 | 2.7 | 35.5 |
+| `groupby_max` | 174.1 | 2.4 | 2.7 | 37.8 |
+| `groupby_min` | 173.4 | 2.4 | 2.7 | 35.9 |
+| `groupby_multi_reducer` | 189.9 | 2.7 | 3.0 | 36.1 |
+| `groupby_select_order` | 170.7 | 2.5 | 2.7 | 35.7 |
+| `groupby_select_sum` | 199.1 | 3.2 | 3.7 | 32.5 |
+| `groupby_sum` | 171.9 | 2.4 | 2.7 | 35.7 |
+| `groupby_where_count` | 75.9 | 1.5 | 1.8 | 36.5 |
+| `groupby_where_sum` | 87.4 | 1.5 | 1.8 | 36.9 |
+| `indexed_lookup` | 1246.5 | 32811.0 | 106.2 | 4620313.1 |
+| `join_count` | 38.5 | 11.8 | 12.8 | 46.9 |
+| `join_groupby_count` | 159.2 | 19.7 | 22.0 | 68.7 |
+| `join_groupby_to_array` | 190.3 | 19.7 | 21.9 | 81.2 |
+| `join_select` | 94.4 | 20.4 | 22.6 | 74.9 |
+| `join_where_count` | 39.3 | 19.5 | 22.2 | 66.0 |
+| `last_match` | 0.0 | 0.5 | 1.5 | 21.0 |
+| `long_count_aggregate` | 30.2 | 0.3 | 0.6 | 16.5 |
+| `max_aggregate` | 31.4 | 0.3 | 0.5 | 24.5 |
+| `min_aggregate` | 31.3 | 0.3 | 0.5 | 16.7 |
+| `order_distinct_take` | 138.0 | 2.1 | 75.2 | 21.2 |
+| `order_reverse_normalized` | 38.7 | 0.7 | 1.3 | 16.7 |
+| `order_take_desc` | 38.3 | 0.7 | 1.3 | 16.9 |
+| `reverse_distinct_by` | 296.1 | 2.6 | 5.0 | 22.0 |
+| `reverse_take` | 0.0 | 0.0 | 1.1 | 69.3 |
+| `reverse_take_select` | 0.0 | 0.0 | 1.1 | 69.8 |
+| `select_count` | 0.1 | 0.0 | 0.0 | 64.4 |
+| `select_many` | — | 146.5 | — | — |
+| `select_where` | 108.3 | 4.1 | 5.6 | 97.3 |
+| `select_where_count` | 32.7 | 0.3 | 0.6 | 16.4 |
+| `select_where_order_take` | 36.7 | 0.7 | 1.4 | 17.4 |
+| `select_where_sum` | 37.5 | 0.4 | 0.6 | 18.4 |
+| `single_match` | 0.0 | 0.4 | 1.2 | 45.4 |
 | `skip_take` | 0.3 | 0.0 | 0.0 | 1.6 |
-| `skip_while_match` | 3.5 | 0.4 | 0.4 | 46.8 |
-| `sort_first` | 38.0 | 0.4 | 1.3 | 17.0 |
-| `sort_take` | 38.5 | 0.7 | 1.4 | 17.7 |
-| `sort_take_select` | 38.4 | 0.7 | 1.3 | 17.2 |
-| `sum_aggregate` | 30.3 | 0.3 | 0.1 | 18.4 |
-| `sum_where` | 33.4 | 0.3 | 0.6 | 17.4 |
+| `skip_while_match` | 3.4 | 0.4 | 0.4 | 43.3 |
+| `sort_first` | 38.1 | 0.4 | 1.3 | 16.5 |
+| `sort_take` | 38.3 | 0.7 | 1.4 | 17.9 |
+| `sort_take_select` | 38.5 | 0.7 | 1.4 | 16.7 |
+| `sum_aggregate` | 30.4 | 0.3 | 0.1 | 17.8 |
+| `sum_where` | 33.1 | 0.3 | 0.6 | 16.4 |
 | `take_count` | 1.8 | 0.1 | 0.1 | 1.6 |
 | `take_count_filtered` | 1.1 | 0.0 | 0.0 | 0.5 |
 | `take_sum_aggregate` | 0.8 | 0.0 | 0.0 | 0.2 |
 | `take_where_count` | 0.9 | 0.0 | 0.0 | 0.2 |
-| `take_while_match` | 7.9 | 0.2 | 0.3 | 18.1 |
-| `to_array_filter` | 48.5 | 3.3 | 3.4 | 20.4 |
-| `where_join_count` | 42.0 | 6.4 | 7.4 | 48.4 |
-| `zip_count_pred` | 39.4 | 0.1 | — | 153.4 |
-| `zip_dot_product` | — | 0.1 | 0.1 | 150.6 |
-| `zip_dot_product_3arg` | — | 0.1 | — | 153.5 |
-| `zip_reverse_to_array` | — | 4.6 | — | 162.3 |
+| `take_while_match` | 7.8 | 0.2 | 0.3 | 16.7 |
+| `to_array_filter` | 48.6 | 3.3 | 3.4 | 19.9 |
+| `where_join_count` | 41.6 | 6.4 | 7.4 | 48.3 |
+| `zip_count_pred` | 39.5 | 0.1 | — | 153.9 |
+| `zip_dot_product` | — | 0.1 | 0.1 | 152.7 |
+| `zip_dot_product_3arg` | — | 0.1 | — | 154.4 |
+| `zip_reverse_to_array` | — | 4.6 | — | 161.6 |
 <!-- BENCH:TABLES END -->
 
 ## Notes on missing lanes (the `—` cells)
@@ -228,6 +234,18 @@ and which gaps could land in a single PR — see
 - **`chained_select_collapse` SQL** — `_sql` rejects `distinct() |> count()`
   as non-translatable. The equivalent SQL `COUNT(DISTINCT computed-expr)`
   isn't currently emitted by sqlite_linq's surface. By design — no follow-up.
+- **`cross_join` Decs (m4)** — a standalone `from_decs_template` source yields
+  anonymous row tuples, so there is no clean typed-lambda cross form
+  (`_cross_join` requires typed lambdas and is not `_fold`-integrated yet). The
+  decs lane arrives with the cross-join `_fold` engine integration; SQL / array /
+  XML only for now.
+- **`select_many` SQL (m1) / Decs (m4) / XML (m5f)** — the correlated flatten
+  needs a per-element nested collection (an `array<…>` field). SQL has no
+  nested-collection flatten (correlated select_many over SQL is rejected); a decs
+  component has no `array<…>` field; and the XML linq source `from_xml_node`
+  materializes rows from flat attributes only (`build_xml_row`), so it cannot
+  populate a nested field. Array-only — a source-shape gap, by design for these
+  backends.
 - **`decs_count_bare_pred` SQL / Array / XML (m5f)** — covers a Theme 4
   root-cause fix specific to the decs lane (bare `from_decs_template(...).count(P)`
   with no upstream where/select previously bailed because

--- a/benchmarks/sql/select_many.das
+++ b/benchmarks/sql/select_many.das
@@ -20,7 +20,10 @@ let SM_N = 100000
 def run_m3f(b : B?; n : int) {
     let orders <- fixture_orders_nested(n)
     b |> run("m3f_array_fold/{n}", n) {
-        let rows <- select_many(orders, $(o : OrderWithLines) => o.lines |> to_sequence(), $(l : Line) => l.sku)
+        // collection-selector yields a zero-copy view of o.lines via `each` — NOT `to_sequence`, whose
+        // const-array overload clones the array per order (linq.das `var b := a`); that clone is not part of
+        // select_many and would skew the baseline. This is also the shape the correlated reader should emit.
+        let rows <- select_many(orders, $(o : OrderWithLines) => unsafe(each(o.lines)), $(l : Line) => l.sku)
         let c = length(rows)
         b |> accept(c)
         if (c != n * LINES_PER_ORDER) {

--- a/benchmarks/sql/select_many.das
+++ b/benchmarks/sql/select_many.das
@@ -1,0 +1,35 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// select_many(src, collection_selector, result_selector) — flatten each order's `lines` (the correlated
+// SelectMany: the inner collection is a field of the outer element). Flattened count = n * LINES_PER_ORDER.
+//
+// PR1 uses the EXISTING 1-arg-result form: result_selector sees ONLY the inner `Line`, so the projection is
+// inner-only (`l.sku`). The both-vars `(outer, inner) => …` form — C#'s `select (o.id, l.sku)` — arrives in
+// the correlated select_many engine PR; this file is swapped to it then and re-measured.
+//
+// ARRAY lane only (m3f). No other lane has a nested-collection source: SQL has no nested-collection flatten
+// (correlated select_many over SQL is rejected); a decs component has no `array<…>` field; and the XML linq
+// source `from_xml_node` materializes rows from flat ATTRIBUTES only (`build_xml_row`), so it cannot
+// populate a nested `array<Line>` field. UNFUSED (no _fold select_many splice).
+
+let SM_N = 100000
+
+def run_m3f(b : B?; n : int) {
+    let orders <- fixture_orders_nested(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let rows <- select_many(orders, $(o : OrderWithLines) => o.lines |> to_sequence(), $(l : Line) => l.sku)
+        let c = length(rows)
+        b |> accept(c)
+        if (c != n * LINES_PER_ORDER) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def select_many_m3f(b : B?) {
+    run_m3f(b, SM_N)
+}

--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -3314,6 +3314,11 @@ def select_many_to_array(var src : iterator<auto(TT)>; result_selector) : array<
 def private select_many_impl(var src; tt : auto(TT); collection_selector; result_selector) : array<typedecl(result_selector(iter_type(collection_selector(type<TT>)))) -const -&> {
     //! Projects each element of an iterator to an iterator and flattens the resulting iterators into one array
     var buffer : array<typedecl(result_selector(iter_type(collection_selector(type<TT>)))) -const -&>
+    // Lower-bound reserve when the outer source is length-bearing — flat-map produces ≥ length(src) elements
+    // for non-degenerate inner sequences; reduces realloc count even when the actual output is larger.
+    static_if (typeinfo is_array(src) || typeinfo is_dim(src)) {
+        buffer |> reserve(length(src))
+    }
     for (it in src) {
         for (innerIt in collection_selector(it)) {
             buffer.push_clone(result_selector(innerIt))

--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -29,10 +29,11 @@ require daslib/linq_boost public
 //
 // `join <d> [: RowB] in <B> on <keyA> equals <keyB>` is a single inner equi-join (see transpile_join). A
 // `where` before `join` filters the left source (single range var, pushes down to SQL). A plain `join …
-// select <proj>` is select-terminal — the `select` becomes the join's result row (scalar, tuple, or
-// whole-row, both `c` and `d` in scope), pushing down to SQL. Post-join `where`/`orderby`, and a `group`
-// terminal, carry both `c` and `d` past the join as a `(c, d)` pair (transparent identifier) and run
-// in-memory (over SQL the carried whole-row tuple errors — project columns in a select-terminal join).
+// select <proj>` is select-terminal — the `select` becomes the join's result row, both `c` and `d` in
+// scope. A scalar or named-tuple projection pushes down to SQL; a whole-row `select c` is in-memory only
+// (over SQL it has no column form). Post-join `where`/`orderby`, and a `group` terminal, carry both `c`
+// and `d` past the join as a `(c, d)` pair (transparent identifier) and run in-memory (over SQL the
+// carried whole-row tuple errors — project columns in a select-terminal join).
 
 def private is_ident_byte(c : int) : bool {
     return is_alnum(c) || c == '_'
@@ -640,10 +641,11 @@ class LinqDasReader : AstReaderMacro {
     //! rewrites to a ``_fold(...)`` chain. Sources: array (untyped `from c in arr`), or a typed
     //! ``from c : Row in src`` over decs / SQL / XML. ``orderby`` is a single sort key; ``group c by <key>``
     //! is a terminal yielding ``tuple<key; array<elem>>`` buckets (in-memory sources only). ``join`` is a
-    //! single inner equi-join whose ``select`` must project a tuple; post-join ``where``/``orderby`` and a
-    //! ``group`` terminal carry the ``(c, d)`` pair (in-memory), while a plain ``join … select <tuple>``
-    //! pushes down to SQL. A trailing ``iterator`` keyword yields an ``iterator<T>`` over the materialized
-    //! result instead of the ``array<T>``.
+    //! single inner equi-join; a select-terminal ``join … select <proj>`` projects the join's result row
+    //! (scalar or named-tuple pushes down to SQL; whole-row ``select c`` is in-memory only), while a
+    //! post-join ``where``/``orderby`` or a ``group`` terminal carries the ``(c, d)`` pair (in-memory). A
+    //! trailing ``iterator`` keyword yields an ``iterator<T>`` over the materialized result instead of the
+    //! ``array<T>``.
     def override accept(prog : ProgramPtr; mod : Module?; var expr : ExprReader?; ch : int; info : LineInfo) : bool {
         append(expr.sequence, ch)
         if (ends_with(expr.sequence, "%%")) {

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -31,7 +31,9 @@ Clauses
 
 A query is ``from <var> [ : <Row> ] in <src> [ where <pred> ] [ join <var2>
 [ : <Row2> ] in <src2> on <keyA> equals <keyB> ] [ where <pred> ] [ orderby
-<expr> [descending] ] ( select <proj> | group <var> by <key> ) [ iterator ]``:
+<expr> [descending] ] ( select <proj> | group <var> by <key> ) [ iterator ]``
+— at most one of the two ``where`` slots may appear (before *or* after
+``join``, never both):
 
 - ``from <var> in <source>`` — the element bind ``<var>`` names the per-row
   value. With no type annotation, ``<source>`` is an ``array<T>``.
@@ -163,7 +165,9 @@ textually):
 
 **Select-terminal** — no post-join ``where`` / ``orderby``, terminal is
 ``select``. The ``select`` projection *is* the join's result row (both range
-variables are in scope), so it splices verbatim and **pushes down to SQL**:
+variables are in scope), so it splices verbatim. A scalar or named-tuple
+projection **pushes down to SQL**; a whole-row ``select c`` is in-memory only
+(over SQL it has no column form — project columns instead):
 
 .. code-block:: das
 

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -97,6 +97,39 @@ placeholder ``_``; the macro normalizes the single-source lambda parameter to
 ``_`` internally, so the C# variable name is still spliced verbatim at the
 surface.
 
+.. _linq_das_projections:
+
+Projections
+-----------
+
+The ``select`` clause projects each (joined) row into the result element. Four
+projection forms are supported:
+
+- **Scalar** — a single field or expression: ``select c.name`` →
+  ``array<string>``; ``select c.price * 2`` → ``array<int>``.
+- **Named tuple** — the C# ``select new { … }`` analog, and the way to return
+  more than one column: ``select (Name = c.name, City = c.city)`` → an array of
+  ``tuple<Name:string; City:string>``; read fields by name (``row.Name``).
+- **Whole-row / identity** — ``select c`` returns the rows unchanged
+  (``array<Row>``); it emits no ``_select`` stage. Over a join it yields the left
+  row. Over a **SQL** source whole-row ``select c`` is **in-memory only** — a row
+  has no column form, so project columns (scalar or named tuple) to push down.
+- **String interpolation** — ``select "{c.name}:{b.country}"`` →
+  ``array<string>``. The range variables are rewritten **inside** the ``{ … }``
+  interpolation (so both ``c`` and ``b`` resolve), letting you format a row to a
+  string in one step.
+
+.. code-block:: das
+
+    // scalar
+    var names  <- %linq! from c in cars select c.name %%
+    // named tuple — two columns, read row.Name / row.Price
+    var rows   <- %linq! from c in cars select (Name = c.name, Price = c.price) %%
+    // whole row (identity) — the filtered structs, unchanged
+    var kept   <- %linq! from c in cars where c.price > 100 select c %%
+    // string interpolation — range vars rewritten inside {…}
+    var labels <- %linq! from c in cars select "{c.name} @ {c.price}" %%
+
 .. _linq_das_ordering:
 
 Ordering


### PR DESCRIPTION
## Summary

**PR 1 of the C# multiple-`from` (SelectMany) arc** — docs + benchmarks, near-zero engine risk. Establishes the baseline before the `cross_join` / `select_many` engine work in PRs 2–3.

### Projections doc (`linq_das.rst`)
New **Projections** section documenting all four `select` forms with examples: scalar, **named tuple** (`select (Name = c.name, City = c.city)` — the C# `select new {…}`), whole-row/identity (`select c`), and **string interpolation** (`select "{c.name}:{b.country}"`, range vars rewritten inside `{…}`). Named-tuple and string-interpolation projections were previously only shown inside join examples / undocumented.

### Benchmarks (`benchmarks/sql/`)
Two new families, measuring the engine ops in their **current working forms** (typed lambdas, bare-pipe / `_sql` — the reader's `_fold` emit shape is PR2/PR3 engine work):

- **`cross_join`** — Cartesian product `cross_join(A, B, into)`. SQL / array / XML lanes; **decs absent** — a standalone `from_decs_template` source yields anonymous tuples, so there is no clean typed-lambda cross form (it arrives with the `_fold` engine integration). Uses a smaller n (1000 × 100 = 100k pairs) because the product is O(n·m).
- **`select_many`** — correlated flatten `select_many(orders, $(o) => o.lines, …)`. **Array lane only** — SQL has no nested-collection flatten, a decs component has no `array&lt;…&gt;` field, and `from_xml_node` reads flat attributes only (can't populate a nested field).
- New nested `Order { id, customer, lines : array&lt;Line&gt; }` fixture in `_common.das`.

**Both are UNFUSED** today (no `_fold` cross-join / select_many splice arm yet) — they run as the plain library calls, materializing the full result. This is the baseline the engine PRs improve. `results.md` re-swept (INTERP + JIT, **75 families**) with a header note + "Notes on missing lanes" bullets (the empty cells).

### Library parity fix (`daslib/linq.das`)
The 3-arg `select_many_impl` now reserves `length(src)` up front like the 2-arg form already does — clears a PERF006 the new benchmark surfaced. Behaviorally transparent.

### Copilot follow-ups (#2969)
Also folds in the 4 doc-accuracy follow-ups committed earlier: the rst select-terminal SQL-boundary wording (whole-row `select c` is in-memory only) + the grammar two-`where` clarification.

### Gates
INTERP `./tests` **10171 passed / 0 failed / 6 skipped**; sphinx `-W` exit 0; MCP + CI lint clean; format-verify clean; benchmarks swept INTERP + JIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)