### PR TITLE
blog: render GFM ~~strikethrough~~ as &lt;del&gt;

### DIFF
--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -41,8 +41,9 @@ from pathlib import Path
 
 try:
     import markdown
+    from markdown.inlinepatterns import SimpleTagInlineProcessor
 except ImportError as e:
-    sys.exit(f"build_blog.py requires `markdown`: pip install markdown  ({e})")
+    sys.exit(f"build_blog.py requires markdown >= 3.0: pip install -U markdown  ({e})")
 
 
 # ─── Front matter ────────────────────────────────────────────────────
@@ -216,12 +217,22 @@ def split_excerpt(md_body: str) -> tuple[str, str]:
 
 # ─── Markdown renderer ───────────────────────────────────────────────
 
+class StrikethroughExtension(markdown.extensions.Extension):
+    """GFM `~~text~~` → `<del>text</del>`. Python-Markdown ships no
+    strikethrough; registered below the backtick processor so code spans
+    and fences are stashed first and never struck through."""
+    def extendMarkdown(self, md):
+        md.inlinePatterns.register(
+            SimpleTagInlineProcessor(r'(~~)(.+?)~~', 'del'), 'strikethrough', 175)
+
+
 def make_md():
     # No codehilite — daslang isn't in pygments. We emit standard
     # CommonMark `<pre><code class="language-X">` and let
     # site/files/highlight.js tokenize daslang blocks client-side.
     return markdown.Markdown(
-        extensions=['fenced_code', 'tables', 'def_list', 'attr_list'],
+        extensions=['fenced_code', 'tables', 'def_list', 'attr_list',
+                    StrikethroughExtension()],
     )
 
 


### PR DESCRIPTION
## Problem

Python-Markdown (the engine in `site/blog/build_blog.py`) has no built-in strikethrough — it's a GFM extension, not CommonMark. So `~~text~~` was rendering as literal tildes on the live site. The newly-shipped *Kibble* post hit it (`~~Sparta~~`), but two older posts were already broken too:

- `how-to-edsl` — `~~die~~ EDSL`
- `pattern-matching` — `~~en example~~ a sample`

## Fix

A zero-dependency inline-processor extension (`StrikethroughExtension`) registered at priority 175 — **below** the backtick processor (190), so code spans and fenced blocks are stashed first and never struck through. No new pip dependency; CI's `pip install markdown` is untouched.

`pages.yml` regenerates every post from `_posts/*.md` on each master push, so this repairs all three posts on the next deploy with no edits to the post sources.

## Verification

Ran the real builder on the real posts (36 posts, no errors):

```
kibble.html          : <del>Sparta</del>
how-to-edsl.html     : <del>die</del> / <del>die</del>
pattern-matching.html: <del>en example</del>
```

Edge cases confirmed: inline code `` `a ~~ b` `` and fenced ```` ```daslang x ~~ y``` ```` are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)