### PR TITLE
dastest: 1-based isolated-mode --worker-index (keeps live-API 9090 free)

### DIFF
--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -237,7 +237,10 @@ def private run_iso_subprocess(cmd : string; timeoutSec : float; var br : BatchR
 // file in the batch to outputChannel.
 def private run_iso_batch(input : IsoInput#; t : int; perTestTimeout : float; outputChannel : Channel?) {
     let nFiles = length(input.uris)
-    let widx = " --worker-index {t}"
+    // 1-based: clients deriving a port from the worker index (e.g. imgui_playwright
+    // maps worker-index N to live-API port 9090+N) start at 9091, leaving 9090 free
+    // for a dev/attached host.
+    let widx = " --worker-index {t + 1}"
     // Batch timeout: per-test budget scaled by batch size (<=0 means none).
     let batchTimeout = perTestTimeout <= 0.0 ? perTestTimeout : perTestTimeout * float(nFiles)
     var br : BatchRun


### PR DESCRIPTION
In isolated/batch mode each worker forwards `--worker-index` to its test subprocess. Clients that derive a port from it — e.g. `imgui_playwright` maps worker-index `N` to live-API port `9090 + N` — previously put **worker 0 on port 9090**, colliding with any dev or attached `daslang-live` host already listening there (the common case during local iteration / recording).

Make the forwarded index **1-based**, so workers start at **9091** and 9090 stays free. One-line change in `run_iso_batch`; internal thread id stays 0-based, only the externally-forwarded `--worker-index` shifts.

### Validation
Full isolated-mode runs with the change, all green:
- `tests/language` — 1023 tests, 1023 passed (t=1, t=4, batch 1, batch 8)
- dasImgui `tests/integration` — 158 tests, 158 passed (t=4, batch 1 and batch 8)

No collisions observed; 9090 confirmed free across all runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)