### PR TITLE
daslang-live: POST /reset (re-simulate, no recompile) + reload generation counter

### DIFF
--- a/modules/dasLiveHost/live/live_api.das
+++ b/modules/dasLiveHost/live/live_api.das
@@ -102,6 +102,7 @@ struct LiveStatus {
     paused : bool
     dt : float
     has_error : bool
+    generation : int    // bumped on every completed reload/reset; poll for a deterministic "done" signal
 }
 
 // --- Compilation error guard ---
@@ -124,10 +125,11 @@ def compilation_error_response(resp : HttpResponse?) : http_status {
 def live_api_help_json() : string {
     //! Returns JSON help listing all endpoints with descriptions and curl examples.
     var endpoints : array<JsonValue?>  // nolint:STYLE012 — values reference cmd_desc/cmd_curl defined later; literal would break decl order
-    endpoints |> push(JV({ "method" => "GET", "path" => "/status", "description" => "JSON with fps, uptime, paused, dt, has_error", "curl" => "curl http://localhost:{live_api_port}/status" }))
+    endpoints |> push(JV({ "method" => "GET", "path" => "/status", "description" => "JSON with fps, uptime, paused, dt, has_error, generation", "curl" => "curl http://localhost:{live_api_port}/status" }))
     endpoints |> push(JV({ "method" => "GET", "path" => "/error", "description" => "Last compilation error (plain text, or null)", "curl" => "curl http://localhost:{live_api_port}/error" }))
     endpoints |> push(JV({ "method" => "POST", "path" => "/reload", "description" => "Trigger incremental reload", "curl" => "curl -X POST http://localhost:{live_api_port}/reload" }))
     endpoints |> push(JV({ "method" => "POST", "path" => "/reload/full", "description" => "Trigger full recompile", "curl" => "curl -X POST http://localhost:{live_api_port}/reload/full" }))
+    endpoints |> push(JV({ "method" => "POST", "path" => "/reset", "description" => "Reset to a fresh context (re-simulate, no recompile; clears @live vars)", "curl" => "curl -X POST http://localhost:{live_api_port}/reset" }))
     endpoints |> push(JV({ "method" => "POST", "path" => "/pause", "description" => "Pause the host", "curl" => "curl -X POST http://localhost:{live_api_port}/pause" }))
     endpoints |> push(JV({ "method" => "POST", "path" => "/unpause", "description" => "Unpause the host", "curl" => "curl -X POST http://localhost:{live_api_port}/unpause" }))
     endpoints |> push(JV({ "method" => "POST", "path" => "/shutdown", "description" => "Graceful shutdown", "curl" => "curl -X POST http://localhost:{live_api_port}/shutdown" }))
@@ -158,7 +160,8 @@ class LiveApiServer : HvWebServer {
                 uptime = get_uptime(),
                 paused = is_paused(),
                 dt = get_dt(),
-                has_error = !empty(get_last_error())
+                has_error = !empty(get_last_error()),
+                generation = int(get_reload_generation())
             )
             return resp |> JSON(write_json(JV(status)), http_status.OK)
         }
@@ -178,6 +181,11 @@ class LiveApiServer : HvWebServer {
 
         POST("/reload/full") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             request_reload(true)
+            return resp |> JSON(write_json(JV(true)), http_status.OK)
+        }
+
+        POST("/reset") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            request_reset()
             return resp |> JSON(write_json(JV(true)), http_status.OK)
         }
 
@@ -299,6 +307,7 @@ class LiveApiAgent : DapiDebugAgent {
     }
 }
 
+[unused_argument(ctx)]
 def debug_agent(ctx : Context) {
     assert(this_context().category.debug_context)
     install_new_debug_agent(new LiveApiAgent(), "live_api")

--- a/modules/dasLiveHost/src/dasLiveHost.cpp
+++ b/modules/dasLiveHost/src/dasLiveHost.cpp
@@ -37,6 +37,7 @@ extern "C" {
     DAS_EXPORT_DLL bool live_host_exit_requested()      { return g_state.exit_requested; }
     DAS_EXPORT_DLL bool live_host_reload_requested()    { return g_state.reload_requested; }
     DAS_EXPORT_DLL bool live_host_full_reload()         { return g_state.full_reload; }
+    DAS_EXPORT_DLL bool live_host_reset_requested()     { return g_state.reset_requested; }
     DAS_EXPORT_DLL bool live_host_is_paused()           { return g_state.paused; }
     DAS_EXPORT_DLL bool live_host_files_changed()       { return g_state.files_changed; }
 
@@ -47,10 +48,12 @@ extern "C" {
     DAS_EXPORT_DLL void live_host_set_fps(float v)      { g_state.fps = v; }
     DAS_EXPORT_DLL void live_host_set_is_reload(bool v) { g_state.is_reload = v; }
     DAS_EXPORT_DLL void live_host_set_paused(bool v)    { g_state.paused = v; }
+    DAS_EXPORT_DLL void live_host_bump_reload_generation() { g_state.reload_generation++; }
 
     DAS_EXPORT_DLL void live_host_clear_reload_flags() {
         g_state.reload_requested = false;
         g_state.full_reload = false;
+        g_state.reset_requested = false;
         g_state.files_changed = false;
     }
     DAS_EXPORT_DLL void live_host_clear_live_vars() {
@@ -127,6 +130,14 @@ bool live_exit_requested() {
 void live_request_reload(bool full) {
     g_state.reload_requested = true;
     if (full) g_state.full_reload = true;
+}
+
+void live_request_reset() {
+    g_state.reset_requested = true;
+}
+
+uint64_t live_get_reload_generation() {
+    return g_state.reload_generation;
 }
 
 bool live_is_reload() {
@@ -373,6 +384,10 @@ public:
         addExtern<DAS_BIND_FUN(live_request_reload)>(*this, lib, "request_reload",
             SideEffects::modifyExternal, "das::live_request_reload")
                 ->args({"full"});
+        addExtern<DAS_BIND_FUN(live_request_reset)>(*this, lib, "request_reset",
+            SideEffects::modifyExternal, "das::live_request_reset");
+        addExtern<DAS_BIND_FUN(live_get_reload_generation)>(*this, lib, "get_reload_generation",
+            SideEffects::accessGlobal, "das::live_get_reload_generation");
         addExtern<DAS_BIND_FUN(live_is_reload)>(*this, lib, "is_reload",
             SideEffects::accessGlobal, "das::live_is_reload");
 

--- a/modules/dasLiveHost/src/dasLiveHost.h
+++ b/modules/dasLiveHost/src/dasLiveHost.h
@@ -12,11 +12,16 @@ namespace das {
         bool exit_requested = false;
         bool reload_requested = false;
         bool full_reload = false;
+        bool reset_requested = false;   // re-simulate the compiled program, no recompile (clean-slate)
 
         // Flags (set by host, read by script)
         bool live_mode = false;
         bool is_reload = false;
         bool paused = false;
+
+        // Bumped by host after every completed reload/reset. Clients poll /status and
+        // wait for this to change for a deterministic "reload/reset done" signal.
+        uint64_t reload_generation = 0;
 
         // Timing (set by host, or computed internally)
         float dt = 0.0f;
@@ -57,6 +62,8 @@ namespace das {
     void live_request_exit();
     bool live_exit_requested();
     void live_request_reload(bool full);
+    void live_request_reset();
+    uint64_t live_get_reload_generation();
     bool live_is_reload();
     float live_get_dt();
     float live_get_uptime();

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -61,6 +61,7 @@ typedef void (*SetBoolFn)(bool);
 static BoolFn  dll_exit_requested = nullptr;
 static BoolFn  dll_reload_requested = nullptr;
 static BoolFn  dll_full_reload = nullptr;
+static BoolFn  dll_reset_requested = nullptr;
 static BoolFn  dll_is_paused = nullptr;
 static BoolFn  dll_files_changed = nullptr;
 static SetFloatFn dll_set_dt = nullptr;
@@ -69,6 +70,7 @@ static SetFloatFn dll_set_fps = nullptr;
 static SetBoolFn  dll_set_is_reload = nullptr;
 static SetBoolFn  dll_set_paused = nullptr;
 static VoidFn  dll_clear_reload_flags = nullptr;
+static VoidFn  dll_bump_reload_generation = nullptr;
 static VoidFn  dll_clear_live_vars = nullptr;
 static VoidFn  dll_clear_store = nullptr;
 static VoidFn  dll_clear_error = nullptr;
@@ -99,6 +101,7 @@ static bool load_live_host_functions() {
     dll_exit_requested    = (BoolFn)get_dll_symbol("live_host_exit_requested");
     dll_reload_requested  = (BoolFn)get_dll_symbol("live_host_reload_requested");
     dll_full_reload       = (BoolFn)get_dll_symbol("live_host_full_reload");
+    dll_reset_requested   = (BoolFn)get_dll_symbol("live_host_reset_requested");
     dll_is_paused         = (BoolFn)get_dll_symbol("live_host_is_paused");
     dll_files_changed     = (BoolFn)get_dll_symbol("live_host_files_changed");
     dll_set_dt            = (SetFloatFn)get_dll_symbol("live_host_set_dt");
@@ -107,6 +110,7 @@ static bool load_live_host_functions() {
     dll_set_is_reload     = (SetBoolFn)get_dll_symbol("live_host_set_is_reload");
     dll_set_paused        = (SetBoolFn)get_dll_symbol("live_host_set_paused");
     dll_clear_reload_flags = (VoidFn)get_dll_symbol("live_host_clear_reload_flags");
+    dll_bump_reload_generation = (VoidFn)get_dll_symbol("live_host_bump_reload_generation");
     dll_clear_live_vars   = (VoidFn)get_dll_symbol("live_host_clear_live_vars");
     dll_clear_store       = (VoidFn)get_dll_symbol("live_host_clear_store");
     dll_clear_error       = (VoidFn)get_dll_symbol("live_host_clear_error");
@@ -439,11 +443,21 @@ static int run_lifecycle(const string & fn) {
         // Auto-tick debug agents
         auto_tick_agents();
 
-        // Check for reload
-        bool needsReload = (dll_reload_requested && dll_reload_requested())
-                        || (dll_files_changed && dll_files_changed());
+        // Check for reload / reset. A recompile (file change / POST /reload) supersedes
+        // a reset: it produces a fresh context too, plus new code — so if both are
+        // pending in one tick, take the recompile and let the reset be absorbed.
+        // Otherwise clear_reload_flags below would drop the pending files_changed
+        // silently and leave stale code running.
+        bool reloadPending = (dll_reload_requested && dll_reload_requested())
+                          || (dll_files_changed && dll_files_changed());
+        bool isReset = !reloadPending && dll_reset_requested && dll_reset_requested();
+        bool needsReload = reloadPending || isReset;
         if (needsReload) {
-            tout << "daslang-live: reloading...\n";
+            tout << (isReset ? "daslang-live: resetting...\n" : "daslang-live: reloading...\n");
+            // reload_generation must advance on EVERY terminal outcome (success or
+            // failure) so clients polling /status get a deterministic signal even when
+            // a reload/reset fails (they then read has_error). Bump at each block exit.
+            auto bumpGen = [&]{ if (dll_bump_reload_generation) dll_bump_reload_generation(); };
 
             // Set reload flag BEFORE shutdown so is_reload() returns true
             if (dll_set_is_reload) dll_set_is_reload(true);
@@ -465,28 +479,53 @@ static int run_lifecycle(const string & fn) {
                 }
             }
 
-            // Recompile
-            auto newCr = compile_script(fn);
-            if (!newCr.ctx) {
-                tout << "daslang-live: reload FAILED, keeping old context (paused)\n";
-                if (dll_set_last_error) dll_set_last_error(newCr.errors.c_str());
-                if (dll_set_paused) dll_set_paused(true);
-                if (dll_clear_reload_flags) dll_clear_reload_flags();
-                // Re-init old context if we have one (shutdown was already called)
-                if (ctx && !ctx_had_exception) {
-                    if (dll_set_is_reload) dll_set_is_reload(true);
-                    ctx->restart();
-                    call_annotated_list(ctx, g_annotated.after_reload);
-                    if (fnInit) {
-                        ctx->evalWithCatch(fnInit, nullptr);
-                    }
+            // Reset (POST /reset): re-simulate the already-compiled program into a
+            // fresh context — no parse / no infer. simulate is ~1/10th of compile, so
+            // this turns a ~10s reload into ~1s; used to reset state between subtests
+            // without respawning the host. A fresh context zeroes globals; clear the
+            // live-var store too so [after_reload] can't restore prior-subtest state
+            // (clean-slate). Reload (file change / POST /reload) still recompiles below.
+            if (isReset && cr.program) {
+                tout << "daslang-live: reset (re-simulate, no recompile)\n";
+                auto newCtx = SimulateWithErrReport(cr.program, tout);
+                if (!newCtx) {
+                    tout << "daslang-live: reset FAILED (simulate), paused\n";
+                    if (dll_set_last_error) dll_set_last_error("reset: simulate failed");
+                    if (dll_set_paused) dll_set_paused(true);
+                    if (dll_clear_reload_flags) dll_clear_reload_flags();
+                    ctx_had_exception = true;
+                    bumpGen();
+                    continue;
                 }
-                continue;
-            }
+                if (dll_clear_live_vars) dll_clear_live_vars();
+                if (dll_clear_store) dll_clear_store();
+                cr.ctx = das::move(newCtx);   // swap only the context; program/moduleGroup/access stay alive
+                ctx = cr.ctx.get();
+            } else {
+                // Recompile
+                auto newCr = compile_script(fn);
+                if (!newCr.ctx) {
+                    tout << "daslang-live: reload FAILED, keeping old context (paused)\n";
+                    if (dll_set_last_error) dll_set_last_error(newCr.errors.c_str());
+                    if (dll_set_paused) dll_set_paused(true);
+                    if (dll_clear_reload_flags) dll_clear_reload_flags();
+                    // Re-init old context if we have one (shutdown was already called)
+                    if (ctx && !ctx_had_exception) {
+                        if (dll_set_is_reload) dll_set_is_reload(true);
+                        ctx->restart();
+                        call_annotated_list(ctx, g_annotated.after_reload);
+                        if (fnInit) {
+                            ctx->evalWithCatch(fnInit, nullptr);
+                        }
+                    }
+                    bumpGen();
+                    continue;
+                }
 
-            // Swap to new context
-            cr = das::move(newCr);
-            ctx = cr.ctx.get();
+                // Swap to new context
+                cr = das::move(newCr);
+                ctx = cr.ctx.get();
+            }
 
             // Re-find functions
             fnInit = find_void_function(ctx, "init");
@@ -497,6 +536,7 @@ static int run_lifecycle(const string & fn) {
                 tout << "ERROR: reloaded script missing init() or update()\n";
                 if (dll_set_paused) dll_set_paused(true);
                 if (dll_clear_reload_flags) dll_clear_reload_flags();
+                bumpGen();
                 continue;
             }
 
@@ -531,6 +571,7 @@ static int run_lifecycle(const string & fn) {
                 if (dll_set_paused) dll_set_paused(true);
                 if (dll_clear_store) dll_clear_store();
                 ctx_had_exception = true;
+                bumpGen();
                 continue;
             }
 
@@ -545,7 +586,8 @@ static int run_lifecycle(const string & fn) {
                 ctx_had_exception = true;
             }
 
-            tout << "daslang-live: reload complete\n";
+            bumpGen();
+            tout << (isReset ? "daslang-live: reset complete\n" : "daslang-live: reload complete\n");
         }
     }
 


### PR DESCRIPTION
## Why

Reloading a `daslang-live` host recompiles from source every time — ~10s for a heavy `require` chain (e.g. dasImgui). For **resetting state between test subtests** that's almost all waste: the compile is identical run-to-run; only the *context* needs to be fresh. Today each `with_imgui_app` test respawns a host and pays the full compile, so a file with N subtests pays N × ~10s.

## What

**`POST /reset`** — re-simulates the already-compiled program into a fresh context (no parse / no infer), swapping *only* the context while program + loaded modules stay resident, and clears the `@live` var store for a clean slate. `simulate` is ~1/10th of compile (in practice far less once the process is warm), so a reset is ~**100× cheaper** than a respawn.

**`reload_generation`** — a counter bumped on every completed reload *and* reset, exposed in `/status`. Clients read it before triggering and poll until it advances — a deterministic "done" signal, instead of polling `has_error` (which can read the pre-reload state and return early). This also makes the existing `/reload` path race-free.

## Changes
- `modules/dasLiveHost/src/dasLiveHost.{cpp,h}`: `reset_requested` flag + `reload_generation`; exports `live_host_reset_requested` / `live_host_bump_reload_generation`; `request_reset` + `get_reload_generation` bound to script; `clear_reload_flags` also clears `reset_requested`.
- `modules/dasLiveHost/live/live_api.das`: `POST /reset` handler; `generation` field in `LiveStatus` + `/status`; help-endpoint entry. (Also clears a pre-existing LINT012 in `debug_agent`, since the file is now in the lint set.)
- `utils/daslang-live/main.cpp`: reset path re-simulates `cr.program` and swaps only `cr.ctx`; generation bumped on every completed reload/reset.

## Validation
Built `daslang-live` + `dasModuleLiveHost`; lint clean. End-to-end: a 6-subtest dasImgui docking test driven by `POST /reset` between subtests runs in **11.0s vs 62.9s** for the six-respawn form, all subtests passing — including one that depends on a prior subtest's dock mutation being reset (proves the context genuinely resets). The dasImgui-side `reset()` wrapper + test refactor that consume this land in a follow-up dasImgui PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)