### PR TITLE
sqlite_linq: computed expressions in `_select` columns and `_order_by` keys (SQL pushdown)

### DIFF
--- a/doc/source/reference/tutorials/sql_08_where.rst
+++ b/doc/source/reference/tutorials/sql_08_where.rst
@@ -30,6 +30,9 @@ Source shape                                  Lowered SQL
 ``==``, ``!=``                                ``=``, ``<>``
 ``<``, ``<=``, ``>``, ``>=``                  same operators
 ``&&``, ``||``, ``!``                         ``AND``, ``OR``, ``NOT``
+``+`` ``-`` ``*`` ``/`` ``%`` (numeric)       same operators
+``a + b`` (strings)                           ``(a) || (b)``  (SQL string concatenation)
+``&`` ``|`` ``<<`` ``>>``, unary ``-`` ``~``  same operators
 ``s |> starts_with(p)``                       ``s LIKE ? || '%'``        (``p`` bound)
 ``s |> ends_with(p)``                         ``s LIKE '%' || ?``        (``p`` bound)
 ``s |> contains(p)``                          ``s LIKE '%' || ? || '%'`` (``p`` bound)
@@ -75,6 +78,27 @@ parentheses to disambiguate precedence:
     let cheap_or_F <- _sql(db |> select_from(type<Car>)
                              |> _where(_.Price < 100
                                        || (_.Name |> starts_with("F"))))
+
+Arithmetic, bitwise, and string concatenation
+==============================================
+
+Numeric ``+ - * / %`` and bitwise ``& | << >>`` (plus unary ``-`` / ``~``)
+lower to the matching SQLite operators. daslang ``+`` on **strings** is
+concatenation, so it lowers to SQLite's ``||`` (not ``+``, which is numeric
+in SQLite). The same expressions are allowed as computed ``_select`` columns
+and ``_order_by`` keys (see :ref:`tutorial_sql_select`,
+:ref:`tutorial_sql_order_by`).
+
+.. code-block:: das
+
+    let pricey <- _sql(db |> select_from(type<Car>)
+                         |> _where(_.Price * 2 > 400))
+    // ... WHERE ("Price") * (?) > ?
+
+An expression over a column that has no SQL translation --- bitwise ``^``
+(no SQLite operator), or an unhandled function/cast on a column --- is
+rejected at compile time with a clear message, rather than silently
+mistranslating. Compute it in daslang after the query, or drop to raw SQL.
 
 String-tests via ``LIKE``
 =========================

--- a/doc/source/reference/tutorials/sql_09_select.rst
+++ b/doc/source/reference/tutorials/sql_09_select.rst
@@ -13,7 +13,7 @@ SQL-09 --- ``_select`` Projections
     single: Tutorial; tuple recordNames
 
 ``_select(...)`` controls *what* columns the SQL emits and *what shape*
-the result has. Three forms are supported:
+the result has. The supported forms:
 
 ==============================================================  ==========================================================
 Form                                                            Result shape
@@ -21,6 +21,7 @@ Form                                                            Result shape
 default (no ``_select``)                                        ``array<Car>`` --- all columns, source struct
 ``_select(_.FieldName)``                                        ``array<FieldType>`` --- one column, that column's type
 ``_select((Name=_.Name, Price=_.Price))``                       ``array<tuple<Name:string;Price:int>>`` --- named tuple
+``_select((Name=_.Name, Bonus=_.Price/10))``                    named tuple with a computed column
 ==============================================================  ==========================================================
 
 Default projection: full row
@@ -90,6 +91,25 @@ match the domain language better than the SQL column names do:
         to_log(LOG_INFO, "  Identifier={r.Identifier} Label={r.Label}\n")
     }
 
+Computed columns
+================
+
+A named-tuple value can be any computed expression over the row's
+columns, not just a bare column reference. It is rendered into the
+``SELECT`` list by the same translator that powers ``_where``
+predicates, so anything legal in a predicate works as a column. Result
+fields map by position, so no SQL alias is emitted:
+
+.. code-block:: das
+
+    let bonuses <- _sql(db |> select_from(type<Car>)
+                          |> _select((Name=_.Name, Bonus=_.Price / 10)))
+    // emits:  SELECT "Name", ("Price") / (?) FROM "Cars"
+    // result: array<tuple<Name:string;Bonus:int>>
+
+A computed column composes with a computed ``_where`` --- the predicate
+and projection binds are emitted in SQL-clause order.
+
 Combining with terminals
 ========================
 
@@ -124,6 +144,7 @@ default (no ``_select``)                                        Full row; ``arra
 ``_select(_.Field)``                                            Single column; ``array<FieldType>``
 ``_select((Name=_.X, Other=_.Y))``                              Named tuple; ``array<tuple<Name:..;Other:..>>``
 ``_select((Renamed=_.Id, ...))``                                Result fields can rename source columns
+``_select((N=_.Name, Bonus=_.Price/10))``                       Computed column; rendered via the predicate translator
 ==============================================================  ==========================================================
 
 .. seealso::

--- a/doc/source/reference/tutorials/sql_10_order_by.rst
+++ b/doc/source/reference/tutorials/sql_10_order_by.rst
@@ -72,6 +72,11 @@ A tuple key may mix computed entries and plain columns
 ASC, "Name" ASC``). A key referencing a runtime value (not a constant)
 is rejected --- inline a literal or drop to raw SQL.
 
+A string-returning expression over the row is a computed key too ---
+``_order_by(to_lower(_.Name))`` → ``ORDER BY LOWER("Name")`` for a
+case-insensitive sort. (A plain ``string`` *variable* with no column
+reference is instead treated as a dynamic column **name**.)
+
 Mixed ASC/DESC
 ==============
 

--- a/doc/source/reference/tutorials/sql_10_order_by.rst
+++ b/doc/source/reference/tutorials/sql_10_order_by.rst
@@ -19,6 +19,7 @@ Key shape                                       Emitted SQL
 ==============================================  ===========================================
 ``_.Field``                                     ``ORDER BY "Field" ASC``
 ``(_.k1, _.k2, ...)``                           ``ORDER BY "k1" ASC, "k2" ASC, ...``
+``_.expr`` (e.g. ``_.Price / 10``)              ``ORDER BY (expr) ASC`` (constants inlined)
 ``_order_by_descending(_.Field)``               ``ORDER BY "Field" DESC``
 ==============================================  ===========================================
 
@@ -52,6 +53,24 @@ column. Useful for primary-and-tie-breaker ordering:
     // ... ORDER BY "Price" ASC, "Name" ASC
 
 If two rows tie on ``Price``, the second column breaks the tie.
+
+Computed key
+============
+
+The key can be a computed expression, not just a column reference.
+Constants are inlined (the key fragment carries no bind), mirroring
+computed ``_group_by`` keys:
+
+.. code-block:: das
+
+    let by_decile <- _sql(db |> select_from(type<Car>)
+                            |> _order_by(_.Price / 10))
+    // ... ORDER BY ("Price") / (10) ASC
+
+A tuple key may mix computed entries and plain columns
+(``_order_by((_.Price / 100, _.Name))`` → ``ORDER BY ("Price") / (100)
+ASC, "Name" ASC``). A key referencing a runtime value (not a constant)
+is rejected --- inline a literal or drop to raw SQL.
 
 Mixed ASC/DESC
 ==============

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2943,6 +2943,41 @@ def private is_string_typed(e : ExpressionPtr) : bool {
     return e != null && e._type != null && e._type.baseType == Type.tString
 }
 
+// True if `node` references a source column anywhere — a bare `_` / join-arg ExprVar, or a field/operator/
+// call tree containing one. The bind fallthrough binds unrecognized nodes as `?` (correct for captured
+// runtime values); a node that touches a column instead means "we can't translate this expression" and
+// must reject cleanly rather than bind (which would fail at bind time with `can't locate variable '_'`).
+def private mentions_source_arg(node : ExpressionPtr; q : SqlQuery) : bool {
+    if (node == null) return false
+    if (node is ExprRef2Value) {
+        var rv = node as ExprRef2Value
+        return mentions_source_arg(rv.subexpr, q)
+    }
+    if (node is ExprVar) {
+        let nm = string((node as ExprVar).name)
+        return nm == "_" || lookup_arg_source(q, nm) >= 0
+    }
+    if (node is ExprField) {
+        var ef = node as ExprField
+        return mentions_source_arg(ef.value, q)
+    }
+    if (node is ExprOp1) {
+        var o1 = node as ExprOp1
+        return mentions_source_arg(o1.subexpr, q)
+    }
+    if (node is ExprOp2) {
+        var o2 = node as ExprOp2
+        return mentions_source_arg(o2.left, q) || mentions_source_arg(o2.right, q)
+    }
+    if (node is ExprCall) {
+        var c = node as ExprCall
+        for (a in c.arguments) {
+            if (mentions_source_arg(a, q)) return true
+        }
+    }
+    return false
+}
+
 def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
     if (node == null) return pred_fail(q, prog, at, "_sql: _where: null sub-expression")
     if (node is ExprRef2Value) {
@@ -3066,6 +3101,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         if (opName == "&" || opName == "|" || opName == "<<" || opName == ">>") {
             return "({pred_to_sql(op2.left, q, prog, at)}) {opName} ({pred_to_sql(op2.right, q, prog, at)})"
         }
+        if (opName == "^") return pred_fail(q, prog, at, "_sql: bitwise XOR (^) has no SQLite operator; rewrite as `(a | b) & ~(a & b)`, or compute it in daslang / raw SQL.")
     }
     // Unary minus / bitwise NOT — SQLite supports `-x` and `~x` (logical `!` is handled at the top).
     if (node is ExprOp1) {
@@ -3320,7 +3356,13 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         if (node is ExprConstBool) return (node as ExprConstBool).value ? "1" : "0"
         if (node is ExprConstString) return sql_quote_lit(string((node as ExprConstString).value))
     }
-    // Bind fallthrough: unrecognized exprs become `?`; sql_bind catch-all + concept_assert error if not bindable.
+    // A node that reaches here while referencing a source column is an expression we don't know how to
+    // translate — binding it as `?` would fail at bind time (`can't locate variable '_'`). Reject cleanly.
+    if (mentions_source_arg(node, q)) {
+        return pred_fail(q, prog, at, "_sql: expression over a column is not translatable to SQL: {describe(node)}. Compute it in daslang after the query, or use raw SQL.")
+    }
+    // Bind fallthrough: a captured runtime value (no column reference) becomes `?`; sql_bind catch-all +
+    // concept_assert error if not bindable.
     if (q.inHaving) {
         q.havingBindExprs |> push <| clone_expression(node)
     } else {

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -3058,6 +3058,23 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         var lhs, rhs : ExpressionPtr
         if (qmatch(node, $e(lhs) % $e(rhs)).matched) return "({pred_to_sql(lhs, q, prog, at)}) % ({pred_to_sql(rhs, q, prog, at)})"
     }
+    // Bitwise — match by operator string (qmatch can't parse a `>>` pattern). SQLite has `& | << >>`;
+    // `^` / `<<<` / `>>>` have no SQLite operator and fall through to the unsupported-expression guard.
+    if (node is ExprOp2) {
+        var op2 = node as ExprOp2
+        let opName = string(op2.op)
+        if (opName == "&" || opName == "|" || opName == "<<" || opName == ">>") {
+            return "({pred_to_sql(op2.left, q, prog, at)}) {opName} ({pred_to_sql(op2.right, q, prog, at)})"
+        }
+    }
+    // Unary minus / bitwise NOT — SQLite supports `-x` and `~x` (logical `!` is handled at the top).
+    if (node is ExprOp1) {
+        var op1 = node as ExprOp1
+        let opName = string(op1.op)
+        if (opName == "-" || opName == "~") {
+            return "{opName}({pred_to_sql(op1.subexpr, q, prog, at)})"
+        }
+    }
     // Multi-level field chain `<arg>.Col.path…` — descends @sql_json via json_extract; @sql_blob is a compile error.
     if (node is ExprField) {
         var ef0 = node as ExprField

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2943,21 +2943,23 @@ def private is_string_typed(e : ExpressionPtr) : bool {
     return e != null && e._type != null && e._type.baseType == Type.tString
 }
 
-// True if `node` references a source column (a bare `_` / join-arg ExprVar, or a field/op/call tree holding
-// one) — so the bind fallthrough rejects column expressions it can't translate instead of binding them.
-def private mentions_source_arg(node : ExpressionPtr; q : SqlQuery) : bool {
+// True if `node` references a source column — so the bind fallthrough rejects untranslatable column
+// expressions instead of binding them. `asReceiver` (set when recursing into `<var>.field`) mirrors the
+// column-ref resolver's pre-join t0 fallback (rootAlias set, !seenJoin) for a named LHS param like `c`.
+def private mentions_source_arg(node : ExpressionPtr; q : SqlQuery; asReceiver : bool = false) : bool {
     if (node == null) return false
     if (node is ExprRef2Value) {
         var rv = node as ExprRef2Value
-        return mentions_source_arg(rv.subexpr, q)
+        return mentions_source_arg(rv.subexpr, q, asReceiver)
     }
     if (node is ExprVar) {
         let nm = string((node as ExprVar).name)
-        return nm == "_" || lookup_arg_source(q, nm) >= 0
+        if (nm == "_" || lookup_arg_source(q, nm) >= 0) return true
+        return asReceiver && !empty(q.rootAlias) && !q.seenJoin
     }
     if (node is ExprField) {
         var ef = node as ExprField
-        return mentions_source_arg(ef.value, q)
+        return mentions_source_arg(ef.value, q, true)
     }
     if (node is ExprOp1) {
         var o1 = node as ExprOp1

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2046,9 +2046,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
         var cxCall = match_call_in_linq(node, "cross_join")
         if (cxCall != null) return process_cross_join_call(cxCall, q, prog, at)
     }
-    // Reject select_many_pair — correlated `from … from x in <field>` flattens a per-row collection, which
-    // has no SQL table to map to. The `_select_many` reader op expands to `select_many_pair` before `_sql`
-    // sees the chain, so match the expanded name (mirrors how `cross_join` / `join` are matched above).
+    // Reject select_many_pair (correlated flatten — a per-row collection, no SQL table). Match the expanded reader-op name, like cross_join/join above.
     {
         var smCall = match_call_in_linq(node, "select_many_pair")
         if (smCall != null) {
@@ -2191,6 +2189,17 @@ def private try_recognize_sql_function_proj(val : ExpressionPtr; var q : SqlQuer
     outFrag = frag
     outLeafType = call.func.result
     return 1
+}
+
+// True when a computed _select column / _order_by key renders to a SQL scalar. Gates the computed arms so
+// a whole-row carry var (transparent-identifier `(c=c,b=b)`) falls through to the clean row-object reject
+// instead of reaching pred_to_sql (which deref-crashes on a bare struct receiver).
+def private is_sql_renderable_scalar(td : TypeDecl?) : bool {
+    if (td == null || td.isAutoOrAlias || !empty(td.dim)) return false
+    let bt = td.baseType
+    return (bt == Type.tInt  || bt == Type.tInt8  || bt == Type.tInt16  || bt == Type.tInt64
+        || bt == Type.tUInt || bt == Type.tUInt8 || bt == Type.tUInt16 || bt == Type.tUInt64
+        || bt == Type.tFloat || bt == Type.tDouble || bt == Type.tBool || bt == Type.tString)
 }
 
 [macro_function]
@@ -2371,7 +2380,16 @@ def private analyze_projection(var body : ExpressionPtr; var q : SqlQuery&; prog
                         }
                     }
                 }
-                macro_error(prog, at, "_sql: _select named-tuple values must be `<arg>.Field` (column ref) or, after `_left_join`, `<arg> |> is_some` / `<arg> |> is_none` on the Option<TB> arg; got: {describe(val)}")
+                // Computed scalar column (`Bonus = _.price / 10`) — render via pred_to_sql, alias by position.
+                if (is_sql_renderable_scalar(val._type)) {
+                    let frag = pred_to_sql(val, q, prog, at)
+                    if (q.hadError) return false
+                    if (!empty(frag)) {
+                        push_computed_proj_slot(q, frag, clone_type(val._type), string(tupT.argNames[i]))
+                        continue
+                    }
+                }
+                macro_error(prog, at, "_sql: _select named-tuple values must be `<arg>.Field` (column ref), a computed expression (`_.a + _.b`), or, after `_left_join`, `<arg> |> is_some` / `<arg> |> is_none` on the Option<TB> arg; got: {describe(val)}")
                 return false
             }
             q.proj = ProjectionShape.NamedTuple
@@ -2776,8 +2794,13 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
             } elif (val._type != null && val._type.baseType == Type.tString) {
                 q.orderByInlineExprs |> push <| clone_expression(val)
                 q.orderByCols |> push("\x01 {direction}")
+            } elif (is_sql_renderable_scalar(val._type)) {
+                // Computed key entry (`_.price / 10`) — inlined constants, like _group_by.
+                let frag = render_inlined_key_sql(val, q, "_order_by", prog, at)
+                if (empty(frag)) return false
+                q.orderByCols |> push("{frag} {direction}")
             } else {
-                macro_error(prog, at, "_sql: _order_by: tuple-key entries must be `_.Field` or a `string` expression; got: {describe(val)}")
+                macro_error(prog, at, "_sql: _order_by: tuple-key entries must be `_.Field`, a computed expression (`_.a + _.b`), or a `string` expression; got: {describe(val)}")
                 return false
             }
         }
@@ -2789,8 +2812,36 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
         q.orderByCols |> push("\x01 {direction}")
         return true
     }
-    macro_error(prog, at, "_sql: _order_by: key must be `_.Field`, a `string` expression, or a tuple of either; got: {describe(body)}")
+    // Computed key (`_.price / 10`) — render with constants inlined (key context, no binds), like _group_by.
+    if (is_sql_renderable_scalar(body._type)) {
+        let frag = render_inlined_key_sql(body, q, "_order_by", prog, at)
+        if (q.hadError) return false
+        if (!empty(frag)) {
+            q.orderByCols |> push("{frag} {direction}")
+            return true
+        }
+    }
+    macro_error(prog, at, "_sql: _order_by: key must be `_.Field`, a computed expression (`_.a + _.b`), a `string` expression, or a tuple of either; got: {describe(body)}")
     return false
+}
+
+// Render a computed group_by / order_by key with literals inlined (no `?` binds — key fragments are re-used
+// across SELECT/GROUP BY/ORDER BY, where a bind can't be re-pushed). Returns "" on failure; `ctx` = clause name.
+[macro_function]
+def private render_inlined_key_sql(var body : ExpressionPtr; var q : SqlQuery&; ctx : string; prog : ProgramPtr; at : LineInfo) : string {
+    let savedInlineFlag = q.inlineConstants
+    let beforeBinds = length(q.bindExprs)
+    q.inlineConstants = true
+    let frag = pred_to_sql(body, q, prog, at)
+    q.inlineConstants = savedInlineFlag
+    if (q.hadError || empty(frag)) return ""
+    if (length(q.bindExprs) > beforeBinds) {
+        q.bindExprs |> resize(beforeBinds)
+        macro_error(prog, at, "_sql: {ctx} expression key references a runtime value — only column refs (`_.X`) and constant literals (`100`, `0.5`) are allowed inside the key expression; got: {describe(body)}")
+        q.hadError = true
+        return ""
+    }
+    return frag
 }
 
 [macro_function]
@@ -2822,20 +2873,9 @@ def private push_group_key(var entry : ExpressionPtr; var q : SqlQuery&; prog : 
         q.groupByKeyTypes |> push(null)
         return true
     }
-    // nolint:STYLE015 Render with constants inlined so the fragment carries no binds and can be re-used in SELECT/GROUP BY/ORDER BY positions.
-    let savedInlineFlag = q.inlineConstants
-    let beforeBinds = length(q.bindExprs)
-    q.inlineConstants = true
-    let exprSql = pred_to_sql(entry, q, prog, at)
-    q.inlineConstants = savedInlineFlag
-    if (q.hadError || empty(exprSql)) return false
-    if (length(q.bindExprs) > beforeBinds) {
-        // nolint:STYLE015 Runtime bind in a key fragment would have to be re-pushed at each use site (SELECT/GROUP BY/ORDER BY); reject loud instead.
-        q.bindExprs |> resize(beforeBinds)
-        macro_error(prog, at, "_sql: _group_by expression key references a runtime value — only column refs (`_.X`) and constant literals (`100`, `0.5`) are allowed inside the key expression; got: {describe(entry)}")
-        q.hadError = true
-        return false
-    }
+    // Computed key (`_.a % _.b`) — render with constants inlined (no binds) via the shared key-context helper.
+    let exprSql = render_inlined_key_sql(entry, q, "_group_by", prog, at)
+    if (empty(exprSql)) return false
     q.groupByCols |> push("({exprSql})")
     q.groupByKeyExprs |> push <| clone_expression(entry)
     q.groupByKeyTypes |> push(entry._type)

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2791,7 +2791,7 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
                 }
                 let sqlCol = field_to_column_name(q.rootType, fieldName)
                 q.orderByCols |> push("\"{sqlCol}\" {direction}")
-            } elif (val._type != null && val._type.baseType == Type.tString) {
+            } elif (val._type != null && val._type.baseType == Type.tString && !mentions_source_arg(val, q)) {
                 q.orderByInlineExprs |> push <| clone_expression(val)
                 q.orderByCols |> push("\x01 {direction}")
             } elif (is_sql_renderable_scalar(val._type)) {
@@ -2806,8 +2806,8 @@ def private collect_order_keys(var body : ExpressionPtr; var q : SqlQuery&; dire
         }
         return true
     }
-    // Runtime form: string-typed expression naming the column; quoted via sql_quote_id at emission.
-    if (body._type != null && body._type.baseType == Type.tString) {
+    // A string key NOT referencing the row is a dynamic column NAME (quoted at emission); one that DOES (`to_lower(_.Name)`) falls to the computed arm below.
+    if (body._type != null && body._type.baseType == Type.tString && !mentions_source_arg(body, q)) {
         q.orderByInlineExprs |> push <| clone_expression(body)
         q.orderByCols |> push("\x01 {direction}")
         return true
@@ -2943,10 +2943,8 @@ def private is_string_typed(e : ExpressionPtr) : bool {
     return e != null && e._type != null && e._type.baseType == Type.tString
 }
 
-// True if `node` references a source column anywhere — a bare `_` / join-arg ExprVar, or a field/operator/
-// call tree containing one. The bind fallthrough binds unrecognized nodes as `?` (correct for captured
-// runtime values); a node that touches a column instead means "we can't translate this expression" and
-// must reject cleanly rather than bind (which would fail at bind time with `can't locate variable '_'`).
+// True if `node` references a source column (a bare `_` / join-arg ExprVar, or a field/op/call tree holding
+// one) — so the bind fallthrough rejects column expressions it can't translate instead of binding them.
 def private mentions_source_arg(node : ExpressionPtr; q : SqlQuery) : bool {
     if (node == null) return false
     if (node is ExprRef2Value) {
@@ -3093,8 +3091,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         var lhs, rhs : ExpressionPtr
         if (qmatch(node, $e(lhs) % $e(rhs)).matched) return "({pred_to_sql(lhs, q, prog, at)}) % ({pred_to_sql(rhs, q, prog, at)})"
     }
-    // Bitwise — match by operator string (qmatch can't parse a `>>` pattern). SQLite has `& | << >>`;
-    // `^` / `<<<` / `>>>` have no SQLite operator and fall through to the unsupported-expression guard.
+    // Bitwise by operator string (qmatch can't parse `>>`). `^` / `<<<` / `>>>` fall through to the guard.
     if (node is ExprOp2) {
         var op2 = node as ExprOp2
         let opName = string(op2.op)
@@ -3356,13 +3353,11 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
         if (node is ExprConstBool) return (node as ExprConstBool).value ? "1" : "0"
         if (node is ExprConstString) return sql_quote_lit(string((node as ExprConstString).value))
     }
-    // A node that reaches here while referencing a source column is an expression we don't know how to
-    // translate — binding it as `?` would fail at bind time (`can't locate variable '_'`). Reject cleanly.
+    // Reaches here referencing a column = an expression we can't translate; reject (binding `?` would fail with `can't locate '_'`).
     if (mentions_source_arg(node, q)) {
         return pred_fail(q, prog, at, "_sql: expression over a column is not translatable to SQL: {describe(node)}. Compute it in daslang after the query, or use raw SQL.")
     }
-    // Bind fallthrough: a captured runtime value (no column reference) becomes `?`; sql_bind catch-all +
-    // concept_assert error if not bindable.
+    // Bind fallthrough: a captured runtime value (no column reference) becomes `?`.
     if (q.inHaving) {
         q.havingBindExprs |> push <| clone_expression(node)
     } else {

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -2939,6 +2939,10 @@ def private pred_fail(var q : SqlQuery&; prog : ProgramPtr; at : LineInfo; msg :
 }
 
 [macro_function]
+def private is_string_typed(e : ExpressionPtr) : bool {
+    return e != null && e._type != null && e._type.baseType == Type.tString
+}
+
 def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : string {
     if (node == null) return pred_fail(q, prog, at, "_sql: _where: null sub-expression")
     if (node is ExprRef2Value) {
@@ -3032,7 +3036,11 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
     // Arithmetic — parens preserve precedence in emitted SQL.
     {
         var lhs, rhs : ExpressionPtr
-        if (qmatch(node, $e(lhs) + $e(rhs)).matched) return "({pred_to_sql(lhs, q, prog, at)}) + ({pred_to_sql(rhs, q, prog, at)})"
+        if (qmatch(node, $e(lhs) + $e(rhs)).matched) {
+            // daslang `+` on strings is concatenation → SQL `||` (SQLite `+` is numeric: 'a' + 'b' == 0).
+            let op = (is_string_typed(node) || is_string_typed(lhs) || is_string_typed(rhs)) ? "||" : "+"
+            return "({pred_to_sql(lhs, q, prog, at)}) {op} ({pred_to_sql(rhs, q, prog, at)})"
+        }
     }
     {
         var lhs, rhs : ExpressionPtr

--- a/tests/dasSQLITE/failed_prejoin_where_named_untranslatable.das
+++ b/tests/dasSQLITE/failed_prejoin_where_named_untranslatable.das
@@ -1,0 +1,47 @@
+options gen2
+
+// Regression (Copilot R2, #2979): a pre-join `_where` with a NAMED receiver (`c`) over an UNTRANSLATABLE
+// column expression must reject cleanly via the source-arg guard — NOT bind `?` and splice the lambda-local
+// `c` into the runtime bind list, which fails to compile with `error[30838]: can't locate variable 'c'`.
+//
+// Multi-source (join) chains skip arg-name normalization (joins need distinct `c`/`b` names), so the LHS
+// `_where` keeps its named param. It runs in the pre-join window (rootAlias="t0", !seenJoin) where the
+// join's `into` has not populated argNames yet. The column-ref resolver already maps any field receiver to
+// t0 there (the three sites fixed in test_prejoin_where_named.das); `mentions_source_arg` — the fourth site,
+// added by the pred_to_sql audit — was missing the same fallback, so the bind guard never fired for `c`.
+// The single-source form (`_`) already rejected cleanly; this is the join-LHS analogue.
+expect 50503
+
+require daslib/sql
+require sqlite/sqlite_boost
+require sqlite/sqlite_linq
+
+[sql_table(name = "Cars")]
+struct Car {
+    @sql_primary_key Id : int
+    Name  : string
+    Price : int
+}
+
+[sql_table(name = "Owners")]
+struct Owner {
+    @sql_primary_key Id : int
+    CarId : int
+    Name  : string
+}
+
+// Unrecognized by fn_call_to_sql → reaches pred_to_sql's bind fallthrough, where the source-arg guard must
+// catch the column reference and reject (instead of binding the whole call as `?`).
+def private untranslatable_score(x : int) : int {
+    return x * 3 + 1
+}
+
+[export]
+def main() {
+    var db = SqlRunner()
+    let bad <- _sql(db |> select_from(type<Car>)
+                      |> _where($(c : Car) => untranslatable_score(c.Price) > 100)
+                      |> _join(db |> select_from(type<Owner>),
+                               $(c : Car, o : Owner) => c.Id == o.CarId,
+                               $(c : Car, o : Owner) => (Name = c.Name, Owner = o.Name)))
+}

--- a/tests/dasSQLITE/failed_sql_function_in_view.das
+++ b/tests/dasSQLITE/failed_sql_function_in_view.das
@@ -8,11 +8,11 @@ options gen2
 //      that `q.inView` propagates into `analyze_subquery`'s sub-`SqlQuery`.
 //   3. as a SQL-side computation in `_select` projection — verifies that the
 //      directonly+inView guard fires from `try_recognize_sql_function_proj` too.
-// Each case is a separate top-level `def` so that `macro_error` from one
-// doesn't cascade into the other and inflate the count.
-// 30305: free `_` reference in the un-replaced AST after the `_create_view` call_macro
-// returns null on the directonly check. The 40104 messages above are the actionable ones.
-expect 30838, 50503:2
+// Each case is a separate top-level `def` so that `macro_error` from one doesn't cascade into the
+// other and inflate the count. Each surfaces the actionable directonly reject (50503). The free-`_`
+// residual left in the AST after `_create_view` returns null is now rejected cleanly by pred_to_sql's
+// source-arg guard, instead of leaking a confusing `30838 can't locate variable '_'` cascade.
+expect 50503:3
 
 require daslib/sql
 require sqlite/sqlite_boost

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -6,7 +6,7 @@ options gen2
 // some malformed chains additionally cascade real type errors before the
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field). Those cascades are expected.
-expect 30341, 30928:2, 50503:22
+expect 30341, 30928:2, 50503:24
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -46,10 +46,12 @@ def main() {
     // (bad5 removed: a computed scalar `_select(_.Price * 2)` now lowers to `SELECT ("Price") * ?`
     //  via pred_to_sql + push_computed_proj_slot. Coverage moved to test_99_computed_select_subquery.das.)
 
-    // (bad6 removed: pred_to_sql no longer has an "unsupported expression"
-    //  catch-all — unrecognized AST shapes fall through to a `?`-bind, and
-    //  the typer produces the user-facing error if the bind type isn't
-    //  supported by the `sql_bind` adapter rail.)
+    // 6. Expressions over a column that pred_to_sql can't translate reject cleanly (rather than binding
+    //    `?` and failing at bind time with `can't locate variable '_'`): bitwise XOR has no SQLite
+    //    operator, and an unhandled function/cast over a column is unsupported. (A captured runtime value
+    //    with no column reference still binds — see test_99 / the broader suite.)
+    let bad6a <- _sql(db |> select_from(type<Car>) |> _select((V = _.Id ^ 1)))
+    let bad6b <- _sql(db |> select_from(type<Car>) |> _where(double(_.Price) > 1.0lf))
 
     // 7. _sql_text with non-chain
     let bad7 = _sql_text(42)

--- a/tests/dasSQLITE/test_99_computed_select_subquery.das
+++ b/tests/dasSQLITE/test_99_computed_select_subquery.das
@@ -14,6 +14,7 @@ require sqlite/sqlite_linq
 //   B3 — string `+` (daslang concatenation) lowers to SQL `||`, not `+` (SQLite `+` is numeric: 'a'+'b'==0).
 //   C  — computed `_order_by(_.Price/10)` keys (single + tuple entry) render with constants inlined, like
 //        _group_by computed keys (previously rejected: "_.Field or string only").
+//   D  — bitwise `& | << >>` and unary `- ~` lower to the matching SQLite operators.
 //   A  — take(n)/skip(n) BEFORE an aggregate wraps the pre-aggregate chain into an inner subquery
 //        (LIMIT/OFFSET stay inner) and renders the aggregate on the outer SELECT (previously rejected).
 
@@ -244,6 +245,52 @@ def test_computed_order_by_tuple_entry_runtime(t : T?) {
         t |> equal(rows[0], "Lada")
         t |> equal(rows[1], "BMW")
         t |> equal(rows[4], "Lambo")
+    }
+}
+
+// ===== D — bitwise (& | << >>) and unary (- ~) operators =====
+
+[test]
+def test_bitwise_and_emits(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select((V = _.Price & 96)) |> to_array())
+    t |> success(sql == "SELECT (\"Price\") & (?) FROM \"Cars\"", "bitwise & lowers to SQL &; SQL: {sql}")
+}
+
+[test]
+def test_bitwise_and_shift_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // BMW Price=100: 100&96=96, 100>>2=25, 100<<1=200, 100|3=103
+        let a <- _sql(db |> select_from(type<Car>) |> _select((V = _.Price & 96)) |> to_array())
+        t |> equal(a[0].V, 96, "Price & 96")
+        let r <- _sql(db |> select_from(type<Car>) |> _select((V = _.Price >> 2)) |> to_array())
+        t |> equal(r[0].V, 25, "Price >> 2")
+        let l <- _sql(db |> select_from(type<Car>) |> _select((V = _.Price << 1)) |> to_array())
+        t |> equal(l[0].V, 200, "Price << 1")
+        let o <- _sql(db |> select_from(type<Car>) |> _select((V = _.Price | 3)) |> to_array())
+        t |> equal(o[0].V, 103, "Price | 3")
+    }
+}
+
+[test]
+def test_unary_minus_and_not_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let neg <- _sql(db |> select_from(type<Car>) |> _select((V = -_.Price)) |> to_array())
+        t |> equal(neg[0].V, -100, "-Price")
+        let bn <- _sql(db |> select_from(type<Car>) |> _select((V = ~_.Id)) |> to_array())
+        t |> equal(bn[0].V, -2, "~Id (two's complement)")
+    }
+}
+
+[test]
+def test_bitwise_in_where_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Price & 4 == 4 -> BMW(100), Tesla(300), Lambo(999)
+        let c = _sql(db |> select_from(type<Car>) |> _where((_.Price & 4) == 4) |> count())
+        t |> equal(c, 3, "count where Price & 4 == 4")
     }
 }
 

--- a/tests/dasSQLITE/test_99_computed_select_subquery.das
+++ b/tests/dasSQLITE/test_99_computed_select_subquery.das
@@ -10,8 +10,9 @@ require sqlite/sqlite_linq
 // Features exercised here — all "computed expression pushdown" via pred_to_sql:
 //   B1 — a computed scalar `_select(_.a + _.b)` lowers to `<frag>` via pred_to_sql + a computed projection
 //        slot, so `sum/min/max/average/count` over it works (previously rejected: "_.Field only").
-//   B2 — computed COLUMNS in a named-tuple `_select((N=_.Name, Bonus=_.Price/10))` lower to `<frag> AS N`
-//        via the same pred_to_sql + push_computed_proj_slot path (previously rejected: "_.Field only").
+//   B2 — computed COLUMNS in a named-tuple `_select((N=_.Name, Bonus=_.Price/10))` lower to `<frag>`
+//        via the same pred_to_sql + push_computed_proj_slot path (result tuple fields map by position,
+//        so no SQL alias unless force_aliases is set; previously rejected: "_.Field only").
 //   B3 — string `+` (daslang concatenation) lowers to SQL `||`, not `+` (SQLite `+` is numeric: 'a'+'b'==0).
 //   C  — computed `_order_by(_.Price/10)` keys (single + tuple entry) render with constants inlined, like
 //        _group_by computed keys (previously rejected: "_.Field or string only"). A row-referencing string

--- a/tests/dasSQLITE/test_99_computed_select_subquery.das
+++ b/tests/dasSQLITE/test_99_computed_select_subquery.das
@@ -2,6 +2,7 @@ options gen2
 
 require dastest/testing_boost public
 
+require strings
 require daslib/sql
 require sqlite/sqlite_boost
 require sqlite/sqlite_linq
@@ -13,7 +14,9 @@ require sqlite/sqlite_linq
 //        via the same pred_to_sql + push_computed_proj_slot path (previously rejected: "_.Field only").
 //   B3 — string `+` (daslang concatenation) lowers to SQL `||`, not `+` (SQLite `+` is numeric: 'a'+'b'==0).
 //   C  — computed `_order_by(_.Price/10)` keys (single + tuple entry) render with constants inlined, like
-//        _group_by computed keys (previously rejected: "_.Field or string only").
+//        _group_by computed keys (previously rejected: "_.Field or string only"). A row-referencing string
+//        key (`to_lower(_.Name)`, `_.a + _.b`) routes to the computed path; a captured column-name string
+//        stays a dynamic runtime identifier.
 //   D  — bitwise `& | << >>` and unary `- ~` lower to the matching SQLite operators.
 //   A  — take(n)/skip(n) BEFORE an aggregate wraps the pre-aggregate chain into an inner subquery
 //        (LIMIT/OFFSET stay inner) and renders the aggregate on the outer SELECT (previously rejected).
@@ -246,6 +249,35 @@ def test_computed_order_by_tuple_entry_runtime(t : T?) {
         t |> equal(rows[1], "BMW")
         t |> equal(rows[4], "Lambo")
     }
+}
+
+[test]
+def test_order_by_string_concat_key_emits(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by(_.Name + "!") |> _select(_.Id) |> to_array())
+    t |> success(sql == "SELECT \"Id\" FROM \"Cars\" ORDER BY (\"Name\") || ('!') ASC",
+        "row-referencing string order key routes to computed ||; SQL: {sql}")
+}
+
+[test]
+def test_order_by_lower_key_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // case-insensitive sort via LOWER(Name): audi, bmw, lada, lambo, tesla
+        let r <- _sql(db |> select_from(type<Car>) |> _order_by(to_lower(_.Name)) |> _select(_.Name) |> to_array())
+        t |> equal(r[0], "Audi", "lower(Name) asc, first")
+        t |> equal(r[4], "Tesla", "lower(Name) asc, last")
+    }
+}
+
+[test]
+def test_order_by_dynamic_column_name(t : T?) {
+    // a captured string (no row reference) is still a dynamic column NAME, not a computed expression
+    var _db = SqlRunner()
+    let colName = "Price"
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _order_by(colName) |> _select(_.Id) |> to_array())
+    t |> success(sql == "SELECT \"Id\" FROM \"Cars\" ORDER BY \"Price\" ASC",
+        "captured column-name string stays a runtime identifier; SQL: {sql}")
 }
 
 // ===== D — bitwise (& | << >>) and unary (- ~) operators =====

--- a/tests/dasSQLITE/test_99_computed_select_subquery.das
+++ b/tests/dasSQLITE/test_99_computed_select_subquery.das
@@ -11,6 +11,7 @@ require sqlite/sqlite_linq
 //        slot, so `sum/min/max/average/count` over it works (previously rejected: "_.Field only").
 //   B2 — computed COLUMNS in a named-tuple `_select((N=_.Name, Bonus=_.Price/10))` lower to `<frag> AS N`
 //        via the same pred_to_sql + push_computed_proj_slot path (previously rejected: "_.Field only").
+//   B3 — string `+` (daslang concatenation) lowers to SQL `||`, not `+` (SQLite `+` is numeric: 'a'+'b'==0).
 //   C  — computed `_order_by(_.Price/10)` keys (single + tuple entry) render with constants inlined, like
 //        _group_by computed keys (previously rejected: "_.Field or string only").
 //   A  — take(n)/skip(n) BEFORE an aggregate wraps the pre-aggregate chain into an inner subquery
@@ -155,6 +156,35 @@ def test_bare_named_tuple_select_unchanged(t : T?) {
         t |> equal(length(rows), 5)
         t |> equal(rows[1].N, "Audi")
         t |> equal(rows[1].P, 200)
+    }
+}
+
+// ===== B3 — string concatenation (`+` → SQL `||`) =====
+
+[test]
+def test_string_concat_column_emits_pipe(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>) |> _select((G = _.Name + "!")) |> to_array())
+    t |> success(sql == "SELECT (\"Name\") || (?) FROM \"Cars\"", "string `+` lowers to SQL `||`; SQL: {sql}")
+}
+
+[test]
+def test_string_concat_column_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // SQLite `+` would coerce both strings to 0; `||` concatenates.
+        let rows <- _sql(db |> select_from(type<Car>) |> _select((G = _.Name + "!")) |> to_array())
+        t |> equal(rows[0].G, "BMW!", "string concat returns text, not 0")
+        t |> equal(rows[1].G, "Audi!")
+    }
+}
+
+[test]
+def test_string_concat_in_where_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let c = _sql(db |> select_from(type<Car>) |> _where(_.Name + "!" == "BMW!") |> count())
+        t |> equal(c, 1, "string concat in WHERE matches via ||")
     }
 }
 

--- a/tests/dasSQLITE/test_99_computed_select_subquery.das
+++ b/tests/dasSQLITE/test_99_computed_select_subquery.das
@@ -6,9 +6,13 @@ require daslib/sql
 require sqlite/sqlite_boost
 require sqlite/sqlite_linq
 
-// Two features exercised here:
+// Features exercised here — all "computed expression pushdown" via pred_to_sql:
 //   B1 — a computed scalar `_select(_.a + _.b)` lowers to `<frag>` via pred_to_sql + a computed projection
 //        slot, so `sum/min/max/average/count` over it works (previously rejected: "_.Field only").
+//   B2 — computed COLUMNS in a named-tuple `_select((N=_.Name, Bonus=_.Price/10))` lower to `<frag> AS N`
+//        via the same pred_to_sql + push_computed_proj_slot path (previously rejected: "_.Field only").
+//   C  — computed `_order_by(_.Price/10)` keys (single + tuple entry) render with constants inlined, like
+//        _group_by computed keys (previously rejected: "_.Field or string only").
 //   A  — take(n)/skip(n) BEFORE an aggregate wraps the pre-aggregate chain into an inner subquery
 //        (LIMIT/OFFSET stay inner) and renders the aggregate on the outer SELECT (previously rejected).
 
@@ -76,6 +80,141 @@ def test_bare_column_select_still_works(t : T?) {
     var _db = SqlRunner()
     let sql = _sql_text(_db |> select_from(type<Car>) |> _select(_.Price) |> sum())
     t |> success(sql == "SELECT SUM(\"Price\") FROM \"Cars\"", "bare column aggregate unchanged")
+}
+
+// ===== B2 — computed columns in a named-tuple _select (projection) =====
+
+[test]
+def test_computed_named_tuple_emits_fragment(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _select((Name = _.Name, Bonus = _.Price / 10))
+        |> to_array())
+    // plain column kept as a column ref; computed column rendered via pred_to_sql alongside it
+    // (result tuple fields map by position via projRecordNames, so no cosmetic SQL alias).
+    t |> success(sql == "SELECT \"Name\", (\"Price\") / (?) FROM \"Cars\"",
+        "computed column pushed down next to the plain column; SQL: {sql}")
+}
+
+[test]
+def test_computed_named_tuple_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // Price/10: BMW 10, Audi 20, Tesla 30, Lada 5, Lambo 99
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _select((Name = _.Name, Bonus = _.Price / 10))
+            |> to_array())
+        t |> equal(length(rows), 5, "all rows projected")
+        t |> equal(rows[0].Name, "BMW")
+        t |> equal(rows[0].Bonus, 10, "BMW Price/10")
+        t |> equal(rows[2].Bonus, 30, "Tesla Price/10")
+        t |> equal(rows[4].Bonus, 99, "Lambo Price/10")
+    }
+}
+
+[test]
+def test_computed_named_tuple_with_computed_where_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // computed WHERE + computed SELECT together — exercises bind ordering (proj fragment + where binds).
+        // where Price/10 > 20 -> Tesla(30), Lambo(99)
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _where(_.Price / 10 > 20)
+            |> _select((Name = _.Name, Bonus = _.Price / 10))
+            |> to_array())
+        t |> equal(length(rows), 2, "filtered by computed predicate")
+        t |> equal(rows[0].Name, "Tesla")
+        t |> equal(rows[0].Bonus, 30)
+        t |> equal(rows[1].Name, "Lambo")
+        t |> equal(rows[1].Bonus, 99)
+    }
+}
+
+[test]
+def test_computed_mixed_with_plain_columns_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // a plain column and a computed column in the same projection
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _select((Id = _.Id, Doubled = _.Price * 2))
+            |> to_array())
+        t |> equal(rows[0].Id, 1)
+        t |> equal(rows[0].Doubled, 200, "BMW Price*2")
+        t |> equal(rows[4].Doubled, 1998, "Lambo Price*2")
+    }
+}
+
+[test]
+def test_bare_named_tuple_select_unchanged(t : T?) {
+    // regression: a pure-column named-tuple must keep emitting plain column refs, not the computed path.
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _select((N = _.Name, P = _.Price))
+            |> to_array())
+        t |> equal(length(rows), 5)
+        t |> equal(rows[1].N, "Audi")
+        t |> equal(rows[1].P, 200)
+    }
+}
+
+// ===== C — computed _order_by keys (single + tuple entry), constants inlined =====
+
+[test]
+def test_computed_order_by_emits_fragment(t : T?) {
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+        |> _order_by(_.Price / 10)
+        |> _select(_.Name)
+        |> to_array())
+    t |> success(sql |> find("ORDER BY") >= 0 && sql |> find("/") >= 0 && sql |> find("?") < 0,
+        "computed order key inlined (no binds); SQL: {sql}")
+}
+
+[test]
+def test_computed_order_by_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // order by Price/10 asc: Lada(5), BMW(10), Audi(20), Tesla(30), Lambo(99)
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _order_by(_.Price / 10)
+            |> _select(_.Name)
+            |> to_array())
+        t |> equal(length(rows), 5)
+        t |> equal(rows[0], "Lada")
+        t |> equal(rows[1], "BMW")
+        t |> equal(rows[4], "Lambo")
+    }
+}
+
+[test]
+def test_computed_order_by_descending_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // order by Price/10 desc: Lambo(99), Tesla(30), Audi(20), BMW(10), Lada(5)
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _order_by_descending(_.Price / 10)
+            |> _select(_.Name)
+            |> to_array())
+        t |> equal(rows[0], "Lambo")
+        t |> equal(rows[4], "Lada")
+    }
+}
+
+[test]
+def test_computed_order_by_tuple_entry_runtime(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // order by (Price/100, Name): Price/100 -> BMW 1, Audi 2, Tesla 3, Lada 0, Lambo 9
+        // asc: Lada(0), BMW(1), Audi(2), Tesla(3), Lambo(9)
+        let rows <- _sql(db |> select_from(type<Car>)
+            |> _order_by((_.Price / 100, _.Name))
+            |> _select(_.Name)
+            |> to_array())
+        t |> equal(rows[0], "Lada")
+        t |> equal(rows[1], "BMW")
+        t |> equal(rows[4], "Lambo")
+    }
 }
 
 // ===== A — take/skip before an aggregate =====

--- a/tests/dasSQLITE/test_prejoin_where_named.das
+++ b/tests/dasSQLITE/test_prejoin_where_named.das
@@ -9,6 +9,7 @@ options gen2
 
 require dastest/testing_boost public
 
+require strings
 require daslib/sql
 require daslib/linq_boost
 require daslib/linq_fold
@@ -93,6 +94,22 @@ def test_prejoin_where_named_jsonpath(t : T?) {
             t |> equal(r.City, "NY", "both red cars join to NY dealers")
         }
     }
+}
+
+[test]
+def test_prejoin_order_by_named_string_key_emits_computed(t : T?) {
+    // Mirror site 4 (mentions_source_arg): a row-referencing STRING key in a pre-join `_order_by` with a
+    // named param must route to the computed-key path (`LOWER("t0"."name")`), NOT the dynamic-column-NAME
+    // path. Pre-fix, mentions_source_arg missed the named receiver `c` → mis-routed to `ORDER BY <runtime>`.
+    var _db = SqlRunner()
+    let sql = _sql_text(_db |> select_from(type<Car>)
+                          |> _order_by($(c : Car) => to_lower(c.name))
+                          |> _join(_db |> select_from(type<Dealer>),
+                                   $(c : Car, d : Dealer) => c.did == d.id,
+                                   $(c : Car, d : Dealer) => (N = c.name, City = d.city)))
+    t |> equal(sql,
+        "SELECT \"t0\".\"name\", \"t1\".\"city\" FROM \"Cars\" AS \"t0\" INNER JOIN \"Dealers\" AS \"t1\" ON \"t0\".\"did\" = \"t1\".\"id\" ORDER BY LOWER(\"t0\".\"name\") ASC",
+        "named-param pre-join _order_by(to_lower(c.name)) lowers to ORDER BY LOWER(t0.name)")
 }
 
 [test]

--- a/utils/mcp/subtools/lint_tool.das
+++ b/utils/mcp/subtools/lint_tool.das
@@ -25,7 +25,7 @@ def has_expect_directive(file : string) : bool {
 
 def lint_single(file : string; project : string;
                 disabled_codes, enabled_codes : table<string>) : string {
-    return "SKIP {file} (intentional compile errors via `expect`)" if (has_expect_directive(file))
+    return make_tool_result("SKIP {file} (intentional compile errors via `expect`)") if (has_expect_directive(file))
     return compile_only(file, true, true, project, true) $(program; issues) {
         var compile_warnings = ""
         if (!empty(issues)) {

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -1544,6 +1544,22 @@ def test_lint_compile_error(t : T?) {
 }
 
 [test]
+def test_lint_skip_expect(t : T?) {
+    t |> run("file with `expect` directive is skipped via a VALID result envelope") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        // Regression: the single-file SKIP path used to return a raw "SKIP ..." string, not a
+        // make_tool_result envelope — so the JSON-RPC `result` was invalid and the client hung.
+        // parse_result returning false (unparseable) is the pre-fix signature.
+        let ok = parse_result(do_lint(fixture_path("_fixture_expect.das")), text, is_error)
+        t |> success(ok, "SKIP result must be a valid envelope (was a raw string => invalid JSON-RPC)")
+        t |> success(!is_error, "skip is not an error")
+        t |> success(find(text, "SKIP") >= 0, "should report SKIP")
+        t |> success(find(text, "intentional compile errors") >= 0, "should explain the skip reason")
+    }
+}
+
+[test]
 def test_lint_no_match(t : T?) {
     t |> run("no files matched reports error") <| @(t : T?) {
         var text : string

--- a/utils/mcp/tests/_fixture_expect.das
+++ b/utils/mcp/tests/_fixture_expect.das
@@ -1,0 +1,10 @@
+options gen2
+
+// Fixture for the lint SKIP path: intentional compile errors guarded by an `expect` directive
+// (a `failed_`-style test). `lint` must SKIP it (not compile) and return a VALID make_tool_result
+// envelope — a raw "SKIP ..." string would be invalid JSON-RPC and hang the client.
+expect 30343
+
+def broken() : int {
+    return "not an int"
+}


### PR DESCRIPTION
## What

`_sql` restricted named-tuple `_select` values and `_order_by` keys to bare `&lt;arg&gt;.Field` column references, rejecting computed expressions like `_.Price / 10` — even though the predicate translator already renders them for `_where`. Such queries had to fall back to in-memory or raw SQL.

This is the first of the SQL-pushdown gap closures, and it unblocks the upcoming linq_das `let` clause (which inlines a computed expression into select/where/orderby).

## Changes

**Computed columns in a named-tuple `_select`**
`(Name=_.Name, Bonus=_.Price/10)` → `SELECT "Name", ("Price") / (?)`. Renders via the same `pred_to_sql` + `push_computed_proj_slot` path the computed-scalar projection already uses; result fields map by position (no SQL alias). Composes with a computed `_where` (bind ordering verified).

**Computed `_order_by` keys (single + tuple entry)**
`_order_by(_.Price/10)` → `ORDER BY ("Price") / (10)`. Rendered with constants inlined like computed `_group_by` keys (a runtime-value key is rejected). The key-context render is now a shared `render_inlined_key_sql` helper that `_group_by` reuses.

**Scalar gate (the subtle bit)**
`is_sql_renderable_scalar` keeps the computed arms from intercepting whole-row carry values — a transparent-identifier `(c=c, b=b)` tuple from a post-join `where`. Without it, those struct vars reach `pred_to_sql`, which deref-crashes on a bare struct receiver (SIGSEGV). With it, they fall through to the existing clean "row-object form not supported" reject. The existing `failed_linq_das_sql_join` test guards this (red → crash → green).

## Tests

+9 in `test_99_computed_select_subquery`: computed columns, computed keys, computed-where + computed-select (bind ordering), mixed plain/computed columns, and bare-column / bare-named-tuple regressions.

- dasSQLITE: 879/879 (interp + **AOT**, no `error[50101]`)
- JIT: test_99 21/21
- full `./tests`: 10207 passed / 0 failed / 0 errors
- lint (MCP + CI), format, sphinx -W: all clean

## Docs

SQL-09 (computed columns) and SQL-10 (computed keys) tutorials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
