### PR TITLE
mcp(live): remind to disable user control before driving synth input

### DIFF
--- a/utils/mcp/tools/live.das
+++ b/utils/mcp/tools/live.das
@@ -281,7 +281,7 @@ def do_live_launch(file, project, project_root : string; port : string = ""; loa
         sleep(500u)
         if (live_is_running(p)) {
             let status = live_get("/status", p)
-            return make_tool_result("daslang-live started successfully on port {p}.\n{status}")
+            return make_tool_result("daslang-live started successfully on port {p}.\nReminder: to drive synthetic mouse/keyboard input, first post set_user_control with enabled=false, or the real OS cursor races GLFW's poll and clobbers synth IO (gestures miss; snapshots read the OS cursor). with_recording_app / the dastest harness do this for you; a manual probe host does not.\n{status}")
         }
     }
     return make_tool_result("daslang-live launched but did not respond on port {p} within 10 seconds. Check the console for errors.", true)


### PR DESCRIPTION
## What

`mcp__daslang__live_launch`'s success message now appends a one-line reminder: to drive synthetic mouse/keyboard input, first post `set_user_control` with `enabled=false`.

## Why

A daslang-live host launched **by hand** for probing (via `live_launch` or the CLI) starts with user-control **ON**. The real OS cursor then races GLFW's poll and clobbers `io.MousePos`, so synthetic gestures land at the wrong place (or not at all) and `imgui_snapshot`'s `mouse_pos` reads the OS cursor rather than the synth position. `with_recording_app` and the dastest harness already post `set_user_control{false}` for you — a bare probe host does not, and forgetting it produces silent, confusing "the gesture didn't land" symptoms.

Surfacing the reminder at the exact moment you launch a host removes that footgun.

## Scope

One-line string change in `utils/mcp/tools/live.das` (the `live_launch` success path). No behavior change to the server. Companion docs added in dasImgui (`skills/recording.md`, `skills/playwright.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)