### PR TITLE
stable_sort: adaptive natural-run merge (timsort-lite) primitive

### DIFF
--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -1859,6 +1859,39 @@ def sort(var a : array<auto(TT)> | #; cmp : block<(x, y : TT) : bool>) {
     }
 }
 
+def stable_sort(var a : array<auto(TT)> | #; cmp : block<(x, y : TT) : bool>) {
+    //! Sorts an array in place using `cmp`, preserving the input order of elements that compare equal (stable).
+    if (length(a) <= 1) return
+    unsafe {
+        static_if (typeinfo is_ref_type(type<TT>)) {
+            __builtin_stable_sort_array_any_cblock(a, typeinfo sizeof(a[0]), length(a), cmp)
+        } else {
+            __builtin_stable_sort_array_any_ref_cblock(a, typeinfo sizeof(a[0]), length(a), cmp)
+        }
+    }
+}
+
+def stable_sort(var a : auto(TT)[] | #; cmp : block<(x, y : TT) : bool>) {
+    //! Sorts a fixed array in place using `cmp`, preserving the input order of elements that compare equal (stable).
+    unsafe {
+        static_if (typeinfo is_ref_type(type<TT>)) {
+            __builtin_stable_sort_dim_any_cblock(a, typeinfo sizeof(a[0]), length(a), cmp)
+        } else {
+            __builtin_stable_sort_dim_any_ref_cblock(a, typeinfo sizeof(a[0]), length(a), cmp)
+        }
+    }
+}
+
+def stable_sort(var a : array<auto(TT)> | #) {
+    //! Sorts an array in place ascending, preserving the input order of equal elements (stable).
+    stable_sort(a) $(x, y : TT) : bool { return x < y; }
+}
+
+def stable_sort(var a : auto(TT)[] | #) {
+    //! Sorts a fixed array in place ascending, preserving the input order of equal elements (stable).
+    stable_sort(a) $(x, y : TT) : bool { return x < y; }
+}
+
 def lock(var a : array<auto(TT)> ==const | #; blk : block<(var x : array<TT>#)>) {
     __builtin_array_lock(a)
     invoke(blk, unsafe(reinterpret<array<auto(TT)> -const#> a))

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -163,7 +163,7 @@ def document_module_builtin(_root : string) {
         hide_group(group_by_regex("Internal finalize infrastructure", mod, %regex~finalize%%)),
         group_by_regex("Containers", mod, %regex~(capacity|clear|length|resize|resize_no_init|reserve|each|emplace|emplace_from|erase|find|
 find_for_edit|find_if_exists|find_index|find_index_if|has_value|key_exists|keys|values|get_key|lock|each_enum|each_ref|
-find_for_edit_if_exists|lock_forever|next|nothing|pop|push|push_from|push_clone|push_clone_from|back|sort|to_array|to_table|to_array_move|
+find_for_edit_if_exists|lock_forever|next|nothing|pop|push|push_from|push_clone|push_clone_from|back|sort|stable_sort|to_array|to_table|to_array_move|
 to_table_move|empty|subarray|insert|move_to_ref|copy_to_local|move_to_local|get|remove_value|erase_if|resize_and_init|
 get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_default|modify|long_length|long_capacity|long_find_index)$%%),
         group_by_regex("Character set groups", mod, %regex~(is_alpha|is_number|is_white_space|is_char_in_set)$%%),

--- a/doc/source/stdlib/handmade/function-builtin-stable_sort-0x6a019ff261435c82.rst
+++ b/doc/source/stdlib/handmade/function-builtin-stable_sort-0x6a019ff261435c82.rst
@@ -1,0 +1,1 @@
+Sorts a dynamic array in place using ``cmp``, preserving the input order of elements that compare equal (stable sort).

--- a/doc/source/stdlib/handmade/function-builtin-stable_sort-0xcdc391b60856ee46.rst
+++ b/doc/source/stdlib/handmade/function-builtin-stable_sort-0xcdc391b60856ee46.rst
@@ -1,0 +1,1 @@
+Sorts a fixed array in place using ``cmp``, preserving the input order of elements that compare equal (stable sort).

--- a/doc/source/stdlib/handmade/function-builtin-stable_sort-0xe3fab34f57ad146f.rst
+++ b/doc/source/stdlib/handmade/function-builtin-stable_sort-0xe3fab34f57ad146f.rst
@@ -1,0 +1,1 @@
+Sorts a fixed array in place in ascending order (default ``<``), preserving the input order of equal elements (stable sort).

--- a/doc/source/stdlib/handmade/function-builtin-stable_sort-0xf6f76b970082f143.rst
+++ b/doc/source/stdlib/handmade/function-builtin-stable_sort-0xf6f76b970082f143.rst
@@ -1,0 +1,1 @@
+Sorts a dynamic array in place in ascending order (default ``<``), preserving the input order of equal elements (stable sort).

--- a/examples/sort/CMakeLists.txt
+++ b/examples/sort/CMakeLists.txt
@@ -17,13 +17,18 @@ endif()
 add_executable(example_sort_bench bench_sort_family.cpp)
 target_include_directories(example_sort_bench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
+add_executable(example_stable_sort_bench bench_stable_sort.cpp)
+target_include_directories(example_stable_sort_bench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+
 add_executable(example_byte_swap_bench bench_byte_swap.cpp)
 
 if(MSVC)
     target_compile_options(example_sort_bench PRIVATE /O2 /W4)
+    target_compile_options(example_stable_sort_bench PRIVATE /O2 /W4)
     target_compile_options(example_byte_swap_bench PRIVATE /O2 /W4)
 else()
     target_compile_options(example_sort_bench PRIVATE -O3 -Wall -Wextra)
+    target_compile_options(example_stable_sort_bench PRIVATE -O3 -Wall -Wextra)
     target_compile_options(example_byte_swap_bench PRIVATE -O3 -Wall -Wextra)
 endif()
 
@@ -49,4 +54,18 @@ if(EXAMPLE_SORT_BENCH_GXX)
         COMMENT "Building example_sort_bench_libstdcxx with ${EXAMPLE_SORT_BENCH_GXX}"
         VERBATIM)
     add_custom_target(example_sort_bench_libstdcxx ALL DEPENDS ${_libstdcxx_out})
+
+    set(_stable_libstdcxx_out ${CMAKE_CURRENT_BINARY_DIR}/example_stable_sort_bench_libstdcxx)
+    add_custom_command(
+        OUTPUT ${_stable_libstdcxx_out}
+        COMMAND ${EXAMPLE_SORT_BENCH_GXX}
+                -std=c++17 -O3 -Wall -Wextra
+                -I ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+                ${CMAKE_CURRENT_SOURCE_DIR}/bench_stable_sort.cpp
+                -o ${_stable_libstdcxx_out}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bench_stable_sort.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../include/daScript/simulate/das_qsort_r.h
+        COMMENT "Building example_stable_sort_bench_libstdcxx with ${EXAMPLE_SORT_BENCH_GXX}"
+        VERBATIM)
+    add_custom_target(example_stable_sort_bench_libstdcxx ALL DEPENDS ${_stable_libstdcxx_out})
 endif()

--- a/examples/sort/bench_stable_sort.cpp
+++ b/examples/sort/bench_stable_sort.cpp
@@ -1,0 +1,444 @@
+// Stable-sort algorithm bake-off — three byte-pointer candidates vs std::stable_sort.
+//
+// Candidates (all match the das_*_r surface: void* base, size_t nel, size_t width,
+// inline Compare "less"; equal elements must keep input order):
+//   #1 das_stable_merge_r   — bottom-up merge, ping-pong buffer, insertion base runs (≤32)
+//   #3 das_stable_natural_r — natural-run detection (asc / strict-desc→reverse) + minrun
+//                             extend + bottom-up pairwise merge. Exploits existing order.
+//   #4 das_stable_index_r   — decorate with [0..N) indices, sort them with the (already
+//                             tuned, unstable) das_qsort_r tiebroken by index → stable, then
+//                             apply the gather permutation in place via cycles. Scratch is
+//                             N*4 bytes, not N*width — meant to win on WIDE elements.
+//
+// Baseline: std::stable_sort (typed, on SPayload<W> with operator<). Built in both the
+// libc++ and libstdc++ binaries (see CMakeLists) so we see vs both stdlibs.
+//
+// Stability is VERIFIED, not assumed: every element carries its original index; the
+// comparator compares only the key; after sort we check sorted-by-key AND idx ascending
+// within each equal-key group. An unstable result aborts the run loudly.
+//
+// Pure C++ — no daslang runtime. Just includes das_qsort_r.h (for byte_swap / sized_memcpy
+// / das_qsort_r). Build/run: see examples/sort/CMakeLists.txt.
+
+#include "daScript/simulate/das_qsort_r.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+using namespace das;
+
+namespace {
+
+// ============================================================================
+// Element type — key (sort key) + idx (original position, for stability check).
+// pad makes sizeof == W. W >= 16 so pad is never zero-length.
+// ============================================================================
+
+template <int W> struct SPayload {
+    int32_t key;
+    int32_t idx;
+    char    pad[W - 8];
+    bool operator<(const SPayload & o) const { return key < o.key; }   // key-only → equal keys stay equal
+};
+
+template <typename T> int32_t key_of(const T & v) { return v.key; }
+template <typename T> int32_t idx_of(const T & v) { return v.idx; }
+
+// Byte-pointer comparator over the candidates: key is the first 4 bytes of every SPayload<W>.
+inline bool key_less(const void * a, const void * b) {
+    return *static_cast<const int32_t *>(a) < *static_cast<const int32_t *>(b);
+}
+
+// Stand-in for the daslang interp regime, where `cmp` is a block-eval (key() twice + less),
+// not an inlined int compare. ~24 dummy flops makes the comparator the bottleneck — this is
+// the axis that punishes #4 (which does ~2× comparator calls for its stability tiebreak).
+inline bool key_less_expensive(const void * a, const void * b) {
+    int32_t ka = *static_cast<const int32_t *>(a);
+    int32_t kb = *static_cast<const int32_t *>(b);
+    volatile uint32_t sink = 0u;
+    for (int t = 0; t < 24; t++) sink += (uint32_t(ka) ^ uint32_t(kb + t)) * 2654435761u;
+    (void)sink;
+    return ka < kb;
+}
+template <typename T> struct ExpensiveLess {
+    bool operator()(const T & x, const T & y) const { return key_less_expensive(&x, &y); }
+};
+
+// Comparator-call counter — explains the adaptive wins (a fast result with FEWER comparator
+// calls is doing genuinely less work, not skipping it; correctness is proven separately).
+static uint64_t g_cmp = 0;
+inline bool key_less_counted(const void * a, const void * b) {
+    g_cmp++;
+    return *static_cast<const int32_t *>(a) < *static_cast<const int32_t *>(b);
+}
+template <typename T> struct CountingLess {
+    bool operator()(const T & x, const T & y) const { g_cmp++; return x.key < y.key; }
+};
+// Typed comparator for the typed header path das_stable_sort<T>.
+template <typename T> struct TypedLess {
+    bool operator()(const T & x, const T & y) const { return x.key < y.key; }
+};
+
+// ============================================================================
+// Shared building blocks
+// ============================================================================
+
+// Stable insertion sort over the element range [lo, hi). Only shifts elements that are
+// strictly greater than the held value, so equal elements never cross — stable.
+template <typename Compare>
+static void insertion_run(unsigned char * a, size_t lo, size_t hi, size_t w, Compare cmp, unsigned char * tmp) {
+    for (size_t i = lo + 1; i < hi; i++) {
+        if (!cmp(a + i*w, a + (i-1)*w)) continue;         // a[i] >= a[i-1] already
+        sized_memcpy(tmp, a + i*w, w);
+        size_t j = i;
+        do {
+            sized_memcpy(a + j*w, a + (j-1)*w, w);
+            j--;
+        } while (j > lo && cmp(tmp, a + (j-1)*w));
+        sized_memcpy(a + j*w, tmp, w);
+    }
+}
+
+// Merge sorted runs [l,m) and [m,r) from src into dst. Stable: takes the left element on a
+// tie (right < left is false).
+template <typename Compare>
+static void merge_runs(const unsigned char * src, unsigned char * dst,
+                       size_t l, size_t m, size_t r, size_t w, Compare cmp) {
+    size_t i = l, j = m, k = l;
+    while (i < m && j < r) {
+        if (cmp(src + j*w, src + i*w)) { sized_memcpy(dst + (k++)*w, src + j*w, w); j++; }
+        else                          { sized_memcpy(dst + (k++)*w, src + i*w, w); i++; }
+    }
+    if (i < m) { memcpy(dst + k*w, src + i*w, (m - i)*w); k += (m - i); }
+    if (j < r) { memcpy(dst + k*w, src + j*w, (r - j)*w); }
+}
+
+// ============================================================================
+// #1 — bottom-up merge, ping-pong buffer, insertion base runs
+// ============================================================================
+
+template <typename Compare>
+inline void das_stable_merge_r(void * base, size_t nel, size_t width, Compare cmp) {
+    if (nel <= 1) return;
+    unsigned char * a = static_cast<unsigned char *>(base);
+    const size_t RUN = 32;
+    std::vector<unsigned char> buf(nel * width);
+    std::vector<unsigned char> tmp(width);
+
+    for (size_t lo = 0; lo < nel; lo += RUN)
+        insertion_run(a, lo, std::min(lo + RUN, nel), width, cmp, tmp.data());
+
+    unsigned char * src = a;
+    unsigned char * dst = buf.data();
+    for (size_t runLen = RUN; runLen < nel; runLen *= 2) {
+        for (size_t lo = 0; lo < nel; lo += 2*runLen) {
+            size_t m = std::min(lo + runLen, nel);
+            size_t r = std::min(lo + 2*runLen, nel);
+            if (m >= r) memcpy(dst + lo*width, src + lo*width, (r - lo)*width);  // lone tail run
+            else        merge_runs(src, dst, lo, m, r, width, cmp);
+        }
+        std::swap(src, dst);
+    }
+    if (src != a) memcpy(a, src, nel * width);
+}
+
+// #3 — natural-run merge is now the SHIPPED algorithm: das_stable_sort_r (byte) +
+// das_stable_sort<T> (typed), both in das_qsort_r.h. The bench validates those directly
+// (columns "#3 byte" / "#3 typed").
+
+// ============================================================================
+// #4 — index decoration: sort indices with das_qsort_r (tiebroken → stable),
+//      then apply the gather permutation in place via cycles.
+// ============================================================================
+
+template <typename Compare>
+inline void das_stable_index_r(void * base, size_t nel, size_t width, Compare cmp) {
+    if (nel <= 1) return;
+    unsigned char * a = static_cast<unsigned char *>(base);
+    std::vector<uint32_t> perm(nel);
+    for (uint32_t k = 0; k < uint32_t(nel); k++) perm[k] = k;
+
+    das_qsort_r(perm.data(), nel, sizeof(uint32_t), [&](const void * pa, const void * pb) {
+        uint32_t ia = *static_cast<const uint32_t *>(pa);
+        uint32_t ib = *static_cast<const uint32_t *>(pb);
+        const unsigned char * ea = a + size_t(ia) * width;
+        const unsigned char * eb = a + size_t(ib) * width;
+        if (cmp(ea, eb)) return true;
+        if (cmp(eb, ea)) return false;
+        return ia < ib;                                          // unique tiebreak → stable order
+    });
+
+    // Apply gather permutation final[k] = orig[perm[k]] in place. Each cycle reads each
+    // source exactly once before it is overwritten; orig[k] is parked in tmp.
+    std::vector<unsigned char> tmp(width);
+    const uint32_t DONE = 0xFFFFFFFFu;
+    for (uint32_t k = 0; k < uint32_t(nel); k++) {
+        if (perm[k] == DONE || perm[k] == k) { perm[k] = DONE; continue; }
+        sized_memcpy(tmp.data(), a + size_t(k)*width, width);    // park orig[k]
+        uint32_t cur = k;
+        for (;;) {
+            uint32_t src = perm[cur];
+            if (src == k) { sized_memcpy(a + size_t(cur)*width, tmp.data(), width); perm[cur] = DONE; break; }
+            sized_memcpy(a + size_t(cur)*width, a + size_t(src)*width, width);
+            perm[cur] = DONE;
+            cur = src;
+        }
+    }
+}
+
+// ============================================================================
+// Verification — the gold standard. Checks ALL of:
+//   * permutation: output idx values are exactly {0..n-1} (no drops, no duplicates)
+//   * element integrity: each output element's key matches the input element at that idx
+//     (catches field corruption / key-idx mismatch)
+//   * sorted by key
+//   * stable: idx ascending within each equal-key group
+// A "fast because it skipped work" bug fails the permutation/integrity checks.
+// ============================================================================
+
+template <typename T>
+bool verify_full(const std::vector<T> & out, const std::vector<T> & in) {
+    size_t n = out.size();
+    if (in.size() != n) return false;
+    std::vector<char> seen(n, 0);
+    for (size_t i = 0; i < n; i++) {
+        int32_t ix = idx_of(out[i]);
+        if (ix < 0 || size_t(ix) >= n || seen[ix]) return false;                          // permutation
+        seen[ix] = 1;
+        if (key_of(out[i]) != key_of(in[size_t(ix)])) return false;                        // element integrity
+        if (i && key_of(out[i]) < key_of(out[i-1])) return false;                          // sorted
+        if (i && key_of(out[i]) == key_of(out[i-1]) && idx_of(out[i]) < idx_of(out[i-1])) return false; // stable
+    }
+    return true;
+}
+
+// ============================================================================
+// Input patterns. idx is always the original position (0..n-1).
+// keymod controls collision density (small → many equal-key groups).
+// ============================================================================
+
+enum class Pattern { Random, Dups, Sorted, Partial, Reverse, AllEqual };
+
+const char * pattern_name(Pattern p) {
+    switch (p) {
+        case Pattern::Random:   return "random";
+        case Pattern::Dups:     return "dups(k%256)";
+        case Pattern::Sorted:   return "sorted";
+        case Pattern::Partial:  return "partial95";
+        case Pattern::Reverse:  return "reverse";
+        case Pattern::AllEqual: return "all-equal";
+    }
+    return "?";
+}
+
+template <typename T>
+std::vector<T> make_pattern(Pattern p, size_t n, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::vector<T> v(n);
+    for (size_t i = 0; i < n; i++) v[i].idx = int32_t(i);
+    switch (p) {
+        case Pattern::Random:
+            for (size_t i = 0; i < n; i++) v[i].key = int32_t(rng() & 0xFFFFFF);
+            break;
+        case Pattern::Dups:
+            for (size_t i = 0; i < n; i++) v[i].key = int32_t(rng() % 256);
+            break;
+        case Pattern::Sorted:
+            for (size_t i = 0; i < n; i++) v[i].key = int32_t(i);
+            break;
+        case Pattern::Partial:                                   // sorted, then 5% random swaps
+            for (size_t i = 0; i < n; i++) v[i].key = int32_t(i);
+            for (size_t s = 0; n > 0 && s < n/20; s++) std::swap(v[rng()%n].key, v[rng()%n].key);
+            break;
+        case Pattern::Reverse:
+            for (size_t i = 0; i < n; i++) v[i].key = int32_t(n - i);
+            break;
+        case Pattern::AllEqual:                                  // every key 42 → output must be input order
+            for (size_t i = 0; i < n; i++) v[i].key = 42;
+            break;
+    }
+    return v;
+}
+
+// ============================================================================
+// Timing harness (mirrors bench_sort_family.cpp)
+// ============================================================================
+
+template <typename T, typename Op>
+double time_op(const std::vector<T> & seed, int iters, Op op) {
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
+    for (int i = 0; i < iters; i++) { std::vector<T> a = seed; op(a); }
+    auto t1 = clk::now();
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()) / double(iters);
+}
+
+template <typename T, typename Op>
+double bench_one(const char * name, Pattern pat, const std::vector<T> & seed, int iters, Op op) {
+    std::vector<T> check = seed;
+    op(check);
+    if (!verify_full(check, seed)) {
+        std::fprintf(stderr, "FAIL: '%s' wrong output (pattern=%s, N=%zu, sizeof=%zu)\n",
+                     name, pattern_name(pat), seed.size(), sizeof(T));
+        std::abort();
+    }
+    return time_op(seed, iters, op);
+}
+
+// ============================================================================
+// Edge-case correctness sweep — runs BEFORE any timing. Hammers every candidate
+// over tiny/boundary sizes (around the RUN/MINRUN=32 cutoff), every pattern, and
+// several seeds, asserting verify_full each time. A bug that "wins" by skipping
+// work dies here, loudly, before we ever read a ratio.
+// ============================================================================
+
+template <typename T>
+void correctness_sweep(const char * type_name) {
+    const size_t  ns[]   = { 0, 1, 2, 3, 5, 15, 16, 17, 31, 32, 33, 63, 64, 65, 100, 1000, 4096 };
+    const Pattern pats[] = { Pattern::Random, Pattern::Dups, Pattern::Sorted,
+                             Pattern::Partial, Pattern::Reverse, Pattern::AllEqual };
+    int cases = 0;
+    for (uint32_t seed = 1; seed <= 5; seed++) {
+        for (size_t n : ns) {
+            for (Pattern p : pats) {
+                auto in = make_pattern<T>(p, n, seed * 7919u);
+                // Run each candidate on its own fresh copy, verify against the pristine input.
+                auto fail = [&](const char * nm) {
+                    std::fprintf(stderr, "CORRECTNESS FAIL: %s on %s n=%zu pattern=%s seed=%u\n",
+                                 nm, type_name, n, pattern_name(p), seed);
+                    std::abort();
+                };
+                auto run = [&](const char * nm, auto fn) {
+                    auto out = in;
+                    fn(out.data(), out.size(), sizeof(T), key_less);
+                    if (!verify_full(out, in)) fail(nm);
+                    cases++;
+                };
+                // Shipped functions (das_qsort_r.h): byte + typed.
+                run("#3 byte",  [](void * b, size_t e, size_t w, bool(*c)(const void*, const void*)) { das_stable_sort_r(b, e, w, c); });
+                { auto out = in; das_stable_sort(out.data(), out.data() + out.size(), TypedLess<T>()); if (!verify_full(out, in)) fail("#3 typed"); cases++; }
+                // Reference candidates (bake-off record): #1 dropped, #4 deferred.
+                run("#1 merge", [](void * b, size_t e, size_t w, bool(*c)(const void*, const void*)) { das_stable_merge_r(b, e, w, c); });
+                run("#4 index", [](void * b, size_t e, size_t w, bool(*c)(const void*, const void*)) { das_stable_index_r(b, e, w, c); });
+            }
+        }
+    }
+    std::printf("correctness: %-14s %d cases OK (sorted + stable + permutation + element-integrity)\n", type_name, cases);
+}
+
+int pick_iters(size_t n) {
+    if (n <= 1000)  return 5000;
+    if (n <= 10000) return 500;
+    return 100;
+}
+
+template <typename T>
+void run_for_type(const char * type_name) {
+    const size_t sizes[]      = { 1000, 10000, 100000 };
+    const Pattern patterns[]  = { Pattern::Random, Pattern::Dups, Pattern::Sorted, Pattern::Partial, Pattern::Reverse };
+    std::printf("\n## %s (sizeof=%zu)\n\n", type_name, sizeof(T));
+    std::printf("| N      | pattern    | std::stable | #3 byte   | #3 typed  | #1 merge  | #4 index  | b/std | t/std | i/std |\n");
+    std::printf("|--------|------------|------------:|----------:|----------:|----------:|----------:|------:|------:|------:|\n");
+    for (size_t n : sizes) {
+        int iters = pick_iters(n);
+        for (Pattern pat : patterns) {
+            auto data = make_pattern<T>(pat, n, 0xC0FFEEu);
+
+            double s_std = bench_one("std::stable_sort", pat, data, iters,
+                [](std::vector<T> & a) { std::stable_sort(a.begin(), a.end()); });
+            double d_b = bench_one("#3 byte", pat, data, iters,       // shipped: das_stable_sort_r
+                [](std::vector<T> & a) { das_stable_sort_r(a.data(), a.size(), sizeof(T), key_less); });
+            double d_t = bench_one("#3 typed", pat, data, iters,      // shipped: das_stable_sort<T> (AOT path)
+                [](std::vector<T> & a) { das_stable_sort(a.data(), a.data() + a.size(), TypedLess<T>()); });
+            double d_m = bench_one("#1 merge", pat, data, iters,      // reference (dropped)
+                [](std::vector<T> & a) { das_stable_merge_r(a.data(), a.size(), sizeof(T), key_less); });
+            double d_i = bench_one("#4 index", pat, data, iters,      // reference (deferred)
+                [](std::vector<T> & a) { das_stable_index_r(a.data(), a.size(), sizeof(T), key_less); });
+
+            std::printf("| %-6zu | %-10s | %11.0f | %9.0f | %9.0f | %9.0f | %9.0f | %5.2f | %5.2f | %5.2f |\n",
+                n, pattern_name(pat), s_std, d_b, d_t, d_m, d_i, d_b/s_std, d_t/s_std, d_i/s_std);
+        }
+    }
+}
+
+// Expensive-comparator pass (one width) — simulates the daslang interp regime where the
+// comparator dominates. Shows whether #4's 2× comparator calls flip the movement-bound win.
+template <typename T>
+void run_expensive_cmp(const char * type_name) {
+    const size_t sizes[]     = { 10000, 100000 };
+    const Pattern patterns[] = { Pattern::Random, Pattern::Dups, Pattern::Sorted, Pattern::Partial, Pattern::Reverse };
+    std::printf("\n## EXPENSIVE comparator — %s (sizeof=%zu) — daslang-interp proxy (byte path)\n\n", type_name, sizeof(T));
+    std::printf("| N      | pattern    | std::stable | #3 byte   | #1 merge  | #4 index  | b/std | m/std | i/std |\n");
+    std::printf("|--------|------------|------------:|----------:|----------:|----------:|------:|------:|------:|\n");
+    for (size_t n : sizes) {
+        int iters = pick_iters(n) / 4 + 1;          // expensive cmp → fewer iters
+        for (Pattern pat : patterns) {
+            auto data = make_pattern<T>(pat, n, 0xC0FFEEu);
+            double s_std = bench_one("std::stable_sort", pat, data, iters,
+                [](std::vector<T> & a) { std::stable_sort(a.begin(), a.end(), ExpensiveLess<T>()); });
+            double d_b = bench_one("#3 byte", pat, data, iters,
+                [](std::vector<T> & a) { das_stable_sort_r(a.data(), a.size(), sizeof(T), key_less_expensive); });
+            double d_m = bench_one("#1 merge", pat, data, iters,
+                [](std::vector<T> & a) { das_stable_merge_r(a.data(), a.size(), sizeof(T), key_less_expensive); });
+            double d_i = bench_one("#4 index", pat, data, iters,
+                [](std::vector<T> & a) { das_stable_index_r(a.data(), a.size(), sizeof(T), key_less_expensive); });
+            std::printf("| %-6zu | %-10s | %11.0f | %9.0f | %9.0f | %9.0f | %5.2f | %5.2f | %5.2f |\n",
+                n, pattern_name(pat), s_std, d_b, d_m, d_i, d_b/s_std, d_m/s_std, d_i/s_std);
+        }
+    }
+}
+
+template <typename T>
+void run_cmp_counts(const char * type_name) {
+    const size_t n = 100000;
+    const Pattern pats[] = { Pattern::Random, Pattern::Sorted, Pattern::Reverse, Pattern::Dups, Pattern::AllEqual };
+    std::printf("\n## comparator-call counts — %s, N=%zu (why the adaptive cells are real)\n\n", type_name, n);
+    std::printf("| pattern    | std::stable | #3 byte   | #3 typed  | #1 merge  | #4 index  |\n");
+    std::printf("|------------|------------:|----------:|----------:|----------:|----------:|\n");
+    for (Pattern p : pats) {
+        auto in = make_pattern<T>(p, n, 0xC0FFEEu);
+        auto count = [&](auto fn) -> uint64_t { auto a = in; g_cmp = 0; fn(a); return g_cmp; };
+        uint64_t cs = count([](std::vector<T> & a) { std::stable_sort(a.begin(), a.end(), CountingLess<T>()); });
+        uint64_t cb = count([](std::vector<T> & a) { das_stable_sort_r(a.data(), a.size(), sizeof(T), key_less_counted); });
+        uint64_t ct = count([](std::vector<T> & a) { das_stable_sort(a.data(), a.data() + a.size(), CountingLess<T>()); });
+        uint64_t cm = count([](std::vector<T> & a) { das_stable_merge_r(a.data(), a.size(), sizeof(T), key_less_counted); });
+        uint64_t ci = count([](std::vector<T> & a) { das_stable_index_r(a.data(), a.size(), sizeof(T), key_less_counted); });
+        std::printf("| %-10s | %11llu | %9llu | %9llu | %9llu | %9llu |\n", pattern_name(p),
+                    (unsigned long long)cs, (unsigned long long)cb, (unsigned long long)ct,
+                    (unsigned long long)cm, (unsigned long long)ci);
+    }
+}
+
+} // anonymous
+
+int main() {
+    std::printf("# stable-sort bake-off — das candidates vs std::stable_sort\n\n");
+#if defined(_LIBCPP_VERSION)
+    std::printf("C++ stdlib: **libc++ %d**\n", _LIBCPP_VERSION);
+#elif defined(__GLIBCXX__)
+    std::printf("C++ stdlib: **libstdc++ %d**\n", __GLIBCXX__);
+#else
+    std::printf("C++ stdlib: unknown\n");
+#endif
+    std::printf("\nColumns: ns/op (lower better); ratios are candidate/std::stable_sort (<1 = we win).\n");
+    std::printf("Stability verified per run (idx-within-equal-key check). Timing includes the per-iter vector copy + each algo's own scratch alloc, same as std.\n\n");
+
+    std::printf("### Correctness sweep (runs before timing)\n\n```\n");
+    correctness_sweep<SPayload<16>>("SPayload<16>");
+    correctness_sweep<SPayload<32>>("SPayload<32>");
+    correctness_sweep<SPayload<128>>("SPayload<128>");
+    std::printf("```\n");
+
+    run_for_type<SPayload<16>>("SPayload<16>");
+    run_for_type<SPayload<32>>("SPayload<32>");
+    run_for_type<SPayload<128>>("SPayload<128>");
+    run_expensive_cmp<SPayload<32>>("SPayload<32>");
+    run_cmp_counts<SPayload<32>>("SPayload<32>");
+    return 0;
+}

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -3502,6 +3502,137 @@ namespace das {
     }
 
     // ==========================================================================
+    // stable_sort cblock templates — mirror of scblk / scblk_array above but
+    // routing through the typed das_stable_sort<T> (adaptive natural-run merge).
+    // ==========================================================================
+
+    template <typename CompareFn, typename TT>
+    struct sscblk;
+
+    template <typename CompareFn, typename TT>
+    struct sscblk {
+        template <int dimSize>
+        static __forceinline void srt ( TDim<TT,dimSize> & arr, int32_t, int32_t, CompareFn && cmp, Context *, LineInfoArg * ) {
+            das_stable_sort(arr.data, arr.data + dimSize, cmp);
+        }
+        template <int dimSize>
+        static __forceinline void srtr ( TDim<TT,dimSize> & arr, int32_t elemSize, int32_t length, CompareFn && cmp, Context * context, LineInfoArg * lineinfo ) {
+            srt(arr,elemSize,length,das::forward<CompareFn>(cmp),context,lineinfo);
+        }
+    };
+
+    template <typename TT>
+    struct sscblk < const Block &,TT > {
+        template <int dimSize>
+        static __forceinline void srtr ( TDim<TT,dimSize> & arr, int32_t, int32_t length, const Block & cmp, Context * context, LineInfoArg * lineinfo ) {
+            vec4f bargs[2];
+            auto data = (TT *) arr.data;
+            context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                das_stable_sort ( data, data+length, [&](TT x, TT y) -> bool {
+                    bargs[0] = cast<TT>::from(x);
+                    bargs[1] = cast<TT>::from(y);
+                    return code->evalBool(*context);
+                });
+            },lineinfo);
+        }
+        template <int dimSize>
+        static __forceinline void srt ( TDim<TT,dimSize> & arr, int32_t, int32_t length, const Block & cmp, Context * context, LineInfoArg * lineinfo ) {
+            vec4f bargs[2];
+            auto data = (TT *) arr.data;
+            context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                das_stable_sort ( data, data+length, [&](const TT & x, const TT & y) -> bool {
+                    bargs[0] = cast<const TT &>::from(x);
+                    bargs[1] = cast<const TT &>::from(y);
+                    return code->evalBool(*context);
+                });
+            },lineinfo);
+        }
+    };
+
+    template <typename CompareFn, typename TT, int32_t dimSize>
+    __forceinline void builtin_stable_sort_dim_any_cblock_T ( TDim<TT,dimSize> & arr, int32_t elemSize, int32_t length, CompareFn && cmp, Context * context, LineInfoArg * lineinfo ) {
+        sscblk<CompareFn,TT>::srt(arr,elemSize,length,das::forward<CompareFn>(cmp),context,lineinfo);
+    }
+
+    template <typename CompareFn, typename TT, int32_t dimSize>
+    __forceinline void builtin_stable_sort_dim_any_ref_cblock_T ( TDim<TT,dimSize> & arr, int32_t elemSize, int32_t length, CompareFn && cmp, Context * context, LineInfoArg * lineinfo ) {
+        sscblk<CompareFn,TT>::srtr(arr,elemSize,length,das::forward<CompareFn>(cmp),context,lineinfo);
+    }
+
+    template <typename CompareFn, typename TT>
+    struct sscblk_array;
+
+    template <typename CompareFn, typename TT>
+    struct sscblk_array {
+        static __forceinline void srt ( Array & arr, int32_t, int32_t, CompareFn && cmp, Context * context, LineInfoArg * at ) {
+            if ( arr.size<=1 ) return;
+            array_lock(*context, arr, at);
+            auto sdata = (TT *) arr.data;
+            das_stable_sort (sdata, sdata + arr.size, cmp);
+            array_unlock(*context, arr, at);
+        }
+        static __forceinline void srtr ( Array & arr, int32_t elemSize, int32_t length, CompareFn && cmp, Context * context, LineInfoArg * lineinfo ) {
+            srt(arr,elemSize,length,das::forward<CompareFn>(cmp),context,lineinfo);
+        }
+    };
+
+    template <typename TT>
+    struct sscblk_array < const Block &,TT > {
+        static __forceinline void srtr ( Array & arr, int32_t, int32_t, const Block & cmp, Context * context, LineInfoArg * at ) {
+            if ( arr.size<=1 ) return;
+            auto data = (TT *) arr.data;
+            array_lock(*context, arr, at);
+            if ( cmp.jitFunction ) {
+                using CmpFn = CallJitFn<bool,TT, TT,const Block &,Context *>;
+                das_stable_sort ( data, data+arr.size, [&](TT x, TT y) -> bool {
+                    return CmpFn::static_call(cmp.jitFunction, x,y,cmp,context);
+                });
+            } else {
+                vec4f bargs[2];
+                context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                    das_stable_sort ( data, data+arr.size, [&](TT x, TT y) -> bool {
+                        bargs[0] = cast<TT>::from(x);
+                        bargs[1] = cast<TT>::from(y);
+                        return code->evalBool(*context);
+                    });
+                },at);
+            }
+            array_unlock(*context, arr, at);
+        }
+        static __forceinline void srt ( Array & arr, int32_t, int32_t, const Block & cmp, Context * context, LineInfoArg * at ) {
+            if ( arr.size<=1 ) return;
+            auto data = (TT *) arr.data;
+            array_lock(*context, arr, at);
+            if ( cmp.jitFunction ) {
+                using CmpFn = CallJitFn<bool,const TT &,const TT &,const Block &,Context *>;
+                das_stable_sort ( data, data+arr.size, [&](const TT & x,const TT & y) -> bool {
+                    return CmpFn::static_call(cmp.jitFunction,x,y,cmp,context);
+                });
+            } else {
+                vec4f bargs[2];
+                context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                    das_stable_sort ( data, data+arr.size, [&](const TT & x, const TT & y) -> bool {
+                        bargs[0] = cast<const TT &>::from(x);
+                        bargs[1] = cast<const TT &>::from(y);
+                        return code->evalBool(*context);
+                    });
+                },at);
+            }
+            array_unlock(*context, arr, at);
+        }
+    };
+
+    template <typename CompareFn, typename TT>
+    __forceinline void builtin_stable_sort_array_any_cblock_T ( TArray<TT> & arr, int32_t elemSize, int32_t elemCount, CompareFn && cmp, Context * context, LineInfoArg * lineinfo ) {
+        sscblk_array<CompareFn,TT>::srt(arr,elemSize,elemCount,das::forward<CompareFn>(cmp),context,lineinfo);
+    }
+
+    template <typename CompareFn, typename TT>
+    __forceinline void builtin_stable_sort_array_any_ref_cblock_T ( TArray<TT> & arr, int32_t elemSize, int32_t elemCount, CompareFn && cmp, Context * context, LineInfoArg * lineinfo ) {
+        sscblk_array<CompareFn,TT>::srtr(arr,elemSize,elemCount,das::forward<CompareFn>(cmp),context,lineinfo);
+    }
+
+    // ==========================================================================
     // partial_sort / nth_element / heap-op cblock templates (Phase 0 expansion).
     // Same scblk / scblk_array shape as builtin_sort_cblock above, parameterized
     // on the algorithm being invoked. partial_sort and nth_element take an extra

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -136,6 +136,8 @@ namespace das {
     DAS_API void builtin_sort_string ( void * data, int32_t length );
     DAS_API void builtin_sort_any_cblock ( void * anyData, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * lineinfo );
     DAS_API void builtin_sort_any_ref_cblock ( void * anyData, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * lineinfo );
+    DAS_API void builtin_stable_sort_any_cblock ( void * anyData, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * lineinfo );
+    DAS_API void builtin_stable_sort_any_ref_cblock ( void * anyData, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * lineinfo );
 
     // Sort-family extensions: partial_sort / nth_element / heap ops.
     // Mirrors builtin_sort<TT> for the typed default-comparator path; uses

--- a/include/daScript/simulate/das_qsort_r.h
+++ b/include/daScript/simulate/das_qsort_r.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <utility>
 
@@ -785,6 +786,219 @@ inline void das_partial_sort_r(void *base, size_t nel, size_t n, size_t width, C
         byte_swap(data, data + (len - 1) * width, width);
         das_sift_down_r(data, 0, len - 1, width, cmp);
     }
+}
+
+// ============================================================================
+// Stable sort — adaptive natural-run merge (timsort-lite, no galloping).
+//
+// Detects ascending / strictly-descending(→reversed-in-place) natural runs,
+// extends short runs to MINRUN via stable insertion, then bottom-up pairwise-
+// merges runs with a ping-pong buffer. STABLE (equal elements keep input order).
+// O(N) on already-sorted / reverse input (exactly N-1 comparisons), O(N log N)
+// otherwise. Allocates N-element scratch via malloc (mirrors std::stable_sort's
+// get_temporary_buffer); on OOM falls back to the unstable das_qsort_r / das_sort
+// (only under genuine allocation failure). Won a bake-off vs std::stable_sort and
+// two alternatives (bottom-up merge, index-decoration) — examples/sort/bench_stable_sort.cpp.
+// ============================================================================
+
+static constexpr size_t DAS_STABLE_MINRUN = 32;
+
+// Stable insertion sort over the element range [lo, hi). Shifts only elements
+// strictly greater than the held value, so equal elements never reorder.
+template <typename Compare>
+static inline void das_stable_insertion_run_r(unsigned char *data, size_t lo, size_t hi, size_t width, Compare cmp, unsigned char *tmp)
+{
+    for (size_t i = lo + 1; i < hi; i++) {
+        if (!cmp(data + i * width, data + (i - 1) * width)) continue;   // data[i] >= data[i-1]
+        sized_memcpy(tmp, data + i * width, width);
+        size_t j = i;
+        do {
+            sized_memcpy(data + j * width, data + (j - 1) * width, width);
+            j--;
+        } while (j > lo && cmp(tmp, data + (j - 1) * width));
+        sized_memcpy(data + j * width, tmp, width);
+    }
+}
+
+// Merge sorted runs [l,m) and [m,r) from src into dst. Stable: takes the left
+// element on a tie (right < left false).
+template <typename Compare>
+static inline void das_stable_merge_runs_r(const unsigned char *src, unsigned char *dst,
+                                           size_t l, size_t m, size_t r, size_t width, Compare cmp)
+{
+    size_t i = l, j = m, k = l;
+    while (i < m && j < r) {
+        if (cmp(src + j * width, src + i * width)) { sized_memcpy(dst + (k++) * width, src + j * width, width); j++; }
+        else                                       { sized_memcpy(dst + (k++) * width, src + i * width, width); i++; }
+    }
+    if (i < m) { memcpy(dst + k * width, src + i * width, (m - i) * width); k += (m - i); }
+    if (j < r) { memcpy(dst + k * width, src + j * width, (r - j) * width); }
+}
+
+// Byte-pointer stable sort — the daslang interp any-cblock binding path.
+template <typename Compare>
+inline void das_stable_sort_r(void *base, size_t nel, size_t width, Compare cmp)
+{
+    if (nel <= 1) return;
+    unsigned char *data = (unsigned char *)base;
+    unsigned char *buf = (unsigned char *)malloc(nel * width);
+    if (!buf) { das_qsort_r(base, nel, width, cmp); return; }   // OOM → unstable fallback
+    unsigned char tmpStack[256];
+    unsigned char *tmp = width <= sizeof(tmpStack) ? tmpStack : (unsigned char *)malloc(width);
+    size_t maxRuns = nel / DAS_STABLE_MINRUN + 2;
+    size_t *bndA = (size_t *)malloc((maxRuns + 1) * sizeof(size_t));
+    size_t *bndB = (size_t *)malloc((maxRuns + 1) * sizeof(size_t));
+    if (!tmp || !bndA || !bndB) {
+        if (tmp && tmp != tmpStack) free(tmp);
+        free(bndA); free(bndB); free(buf);
+        das_qsort_r(base, nel, width, cmp);
+        return;
+    }
+
+    // 1. Detect natural runs (ascending, or strictly-descending then reversed),
+    //    each extended to MINRUN via stable insertion. Collect run boundaries.
+    size_t *cur = bndA, *nxt = bndB;
+    size_t nb = 0;
+    cur[nb++] = 0;
+    size_t i = 0;
+    while (i < nel) {
+        size_t runStart = i, j = i + 1;
+        if (j < nel) {
+            if (cmp(data + j * width, data + i * width)) {                  // strictly descending
+                j++;
+                while (j < nel && cmp(data + j * width, data + (j - 1) * width)) j++;
+                for (size_t a = runStart, b = j - 1; a < b; a++, b--)        // reverse → ascending (stable: strict)
+                    byte_swap(data + a * width, data + b * width, width);
+            } else {                                                        // non-decreasing
+                j++;
+                while (j < nel && !cmp(data + j * width, data + (j - 1) * width)) j++;
+            }
+        }
+        if (j - runStart < DAS_STABLE_MINRUN) {
+            size_t hi = (runStart + DAS_STABLE_MINRUN < nel) ? runStart + DAS_STABLE_MINRUN : nel;
+            das_stable_insertion_run_r(data, runStart, hi, width, cmp, tmp);
+            j = hi;
+        }
+        cur[nb++] = j;
+        i = j;
+    }
+
+    // 2. Bottom-up pairwise merge over the run list, ping-pong data <-> buf.
+    unsigned char *src = data, *dst = buf;
+    while (nb - 1 > 1) {                                                    // > 1 run
+        size_t R = nb - 1, nn = 0, t = 0;
+        nxt[nn++] = 0;
+        for (; t + 1 < R; t += 2) {
+            das_stable_merge_runs_r(src, dst, cur[t], cur[t + 1], cur[t + 2], width, cmp);
+            nxt[nn++] = cur[t + 2];
+        }
+        if (t < R) {                                                       // lone last run
+            memcpy(dst + cur[t] * width, src + cur[t] * width, (cur[t + 1] - cur[t]) * width);
+            nxt[nn++] = cur[t + 1];
+        }
+        unsigned char *ts = src; src = dst; dst = ts;
+        size_t *tb = cur; cur = nxt; nxt = tb;
+        nb = nn;
+    }
+    if (src != data) memcpy(data, src, nel * width);
+
+    if (tmp != tmpStack) free(tmp);
+    free(bndA); free(bndB); free(buf);
+}
+
+// ---- Typed twins (the AOT path) ----
+// Element moves go through memcpy(sizeof(T)) — a compile-time size the compiler
+// inlines, unlike the runtime-width byte path — while comparisons use the typed
+// comparator. Requires trivially-relocatable T (the daslang array-element model,
+// same assumption as das_sort<T>).
+
+template <typename T, typename Compare>
+static inline void das_stable_insertion_run_t(T *data, size_t lo, size_t hi, Compare cmp)
+{
+    for (size_t i = lo + 1; i < hi; i++) {
+        if (!cmp(data[i], data[i - 1])) continue;
+        T held = data[i];                                                  // value copy for the comparisons
+        size_t j = i;
+        do {
+            memcpy(&data[j], &data[j - 1], sizeof(T));
+            j--;
+        } while (j > lo && cmp(held, data[j - 1]));
+        memcpy(&data[j], &held, sizeof(T));
+    }
+}
+
+template <typename T, typename Compare>
+static inline void das_stable_merge_runs_t(const T *src, T *dst, size_t l, size_t m, size_t r, Compare cmp)
+{
+    size_t i = l, j = m, k = l;
+    while (i < m && j < r) {
+        if (cmp(src[j], src[i])) { memcpy(&dst[k++], &src[j++], sizeof(T)); }
+        else                     { memcpy(&dst[k++], &src[i++], sizeof(T)); }
+    }
+    if (i < m) { memcpy(&dst[k], &src[i], (m - i) * sizeof(T)); k += (m - i); }
+    if (j < r) { memcpy(&dst[k], &src[j], (r - j) * sizeof(T)); }
+}
+
+// Typed stable sort — the AOT _T binding path. Same algorithm as das_stable_sort_r
+// with compile-time element size + typed comparator.
+template <typename T, typename Compare>
+inline void das_stable_sort(T *first, T *last, Compare cmp)
+{
+    if (last - first <= 1) return;
+    size_t nel = size_t(last - first);
+    T *data = first;
+    T *buf = (T *)malloc(nel * sizeof(T));
+    if (!buf) { das_sort(first, last, cmp); return; }                      // OOM → unstable fallback
+    size_t maxRuns = nel / DAS_STABLE_MINRUN + 2;
+    size_t *bndA = (size_t *)malloc((maxRuns + 1) * sizeof(size_t));
+    size_t *bndB = (size_t *)malloc((maxRuns + 1) * sizeof(size_t));
+    if (!bndA || !bndB) { free(bndA); free(bndB); free(buf); das_sort(first, last, cmp); return; }
+
+    size_t *cur = bndA, *nxt = bndB;
+    size_t nb = 0;
+    cur[nb++] = 0;
+    size_t i = 0;
+    while (i < nel) {
+        size_t runStart = i, j = i + 1;
+        if (j < nel) {
+            if (cmp(data[j], data[i])) {                                   // strictly descending
+                j++;
+                while (j < nel && cmp(data[j], data[j - 1])) j++;
+                using std::swap;
+                for (size_t a = runStart, b = j - 1; a < b; a++, b--) swap(data[a], data[b]);
+            } else {                                                       // non-decreasing
+                j++;
+                while (j < nel && !cmp(data[j], data[j - 1])) j++;
+            }
+        }
+        if (j - runStart < DAS_STABLE_MINRUN) {
+            size_t hi = (runStart + DAS_STABLE_MINRUN < nel) ? runStart + DAS_STABLE_MINRUN : nel;
+            das_stable_insertion_run_t(data, runStart, hi, cmp);
+            j = hi;
+        }
+        cur[nb++] = j;
+        i = j;
+    }
+
+    T *src = data, *dst = buf;
+    while (nb - 1 > 1) {
+        size_t R = nb - 1, nn = 0, t = 0;
+        nxt[nn++] = 0;
+        for (; t + 1 < R; t += 2) {
+            das_stable_merge_runs_t(src, dst, cur[t], cur[t + 1], cur[t + 2], cmp);
+            nxt[nn++] = cur[t + 2];
+        }
+        if (t < R) {
+            memcpy(&dst[cur[t]], &src[cur[t]], (cur[t + 1] - cur[t]) * sizeof(T));
+            nxt[nn++] = cur[t + 1];
+        }
+        T *ts = src; src = dst; dst = ts;
+        size_t *tb = cur; cur = nxt; nxt = tb;
+        nb = nn;
+    }
+    if (src != data) memcpy(data, src, nel * sizeof(T));
+
+    free(bndA); free(bndB); free(buf);
 }
 
 }

--- a/include/daScript/simulate/das_qsort_r.h
+++ b/include/daScript/simulate/das_qsort_r.h
@@ -820,19 +820,53 @@ static inline void das_stable_insertion_run_r(unsigned char *data, size_t lo, si
     }
 }
 
+// Threshold for switching one-at-a-time merge → galloping (batched) mode. Below 7
+// consecutive wins from one side we stay one-at-a-time (no extra comparisons, no
+// memcpy-call overhead on random data); a longer streak triggers a bulk run copy
+// (the case that dominates on partially-ordered input). Classic timsort constant.
+static constexpr int DAS_STABLE_MIN_GALLOP = 7;
+
 // Merge sorted runs [l,m) and [m,r) from src into dst. Stable: takes the left
-// element on a tie (right < left false).
+// element on a tie (right < left false). Galloping batches whole-run copies once
+// one side wins a streak — turns the per-element copy loop into bulk memcpy on
+// structured data, where the element-wise copy would otherwise dominate.
 template <typename Compare>
 static inline void das_stable_merge_runs_r(const unsigned char *src, unsigned char *dst,
                                            size_t l, size_t m, size_t r, size_t width, Compare cmp)
 {
     size_t i = l, j = m, k = l;
     while (i < m && j < r) {
-        if (cmp(src + j * width, src + i * width)) { sized_memcpy(dst + (k++) * width, src + j * width, width); j++; }
-        else                                       { sized_memcpy(dst + (k++) * width, src + i * width, width); i++; }
+        int cl = 0, cr = 0;
+        for (;;) {                                                          // one-at-a-time
+            if (cmp(src + j * width, src + i * width)) {                     // right < left
+                sized_memcpy(dst + k * width, src + j * width, width); k++; j++;
+                cr++; cl = 0;
+                if (j >= r) goto done;
+                if (cr >= DAS_STABLE_MIN_GALLOP) break;
+            } else {                                                        // left <= right (stable)
+                sized_memcpy(dst + k * width, src + i * width, width); k++; i++;
+                cl++; cr = 0;
+                if (i >= m) goto done;
+                if (cl >= DAS_STABLE_MIN_GALLOP) break;
+            }
+        }
+        for (;;) {                                                          // galloping
+            size_t is = i;                                                  // left run: src[i..] <= src[j]
+            while (i < m && !cmp(src + j * width, src + i * width)) i++;
+            size_t lenL = i - is;
+            if (lenL) { memcpy(dst + k * width, src + is * width, lenL * width); k += lenL; if (i >= m) goto done; }
+            sized_memcpy(dst + k * width, src + j * width, width); k++; j++; if (j >= r) goto done;
+            size_t js = j;                                                  // right run: src[j..] < src[i]
+            while (j < r && cmp(src + j * width, src + i * width)) j++;
+            size_t lenR = j - js;
+            if (lenR) { memcpy(dst + k * width, src + js * width, lenR * width); k += lenR; if (j >= r) goto done; }
+            sized_memcpy(dst + k * width, src + i * width, width); k++; i++; if (i >= m) goto done;
+            if (lenL < size_t(DAS_STABLE_MIN_GALLOP) && lenR < size_t(DAS_STABLE_MIN_GALLOP)) break;
+        }
     }
-    if (i < m) { memcpy(dst + k * width, src + i * width, (m - i) * width); k += (m - i); }
-    if (j < r) { memcpy(dst + k * width, src + j * width, (r - j) * width); }
+done:
+    if (i < m) memcpy(dst + k * width, src + i * width, (m - i) * width);
+    if (j < r) memcpy(dst + k * width, src + j * width, (r - j) * width);
 }
 
 // Byte-pointer stable sort — the daslang interp any-cblock binding path.
@@ -932,10 +966,36 @@ static inline void das_stable_merge_runs_t(const T *src, T *dst, size_t l, size_
 {
     size_t i = l, j = m, k = l;
     while (i < m && j < r) {
-        if (cmp(src[j], src[i])) { memcpy(&dst[k++], &src[j++], sizeof(T)); }
-        else                     { memcpy(&dst[k++], &src[i++], sizeof(T)); }
+        int cl = 0, cr = 0;
+        for (;;) {                                                          // one-at-a-time
+            if (cmp(src[j], src[i])) {                                       // right < left
+                memcpy(&dst[k++], &src[j++], sizeof(T));
+                cr++; cl = 0;
+                if (j >= r) goto done;
+                if (cr >= DAS_STABLE_MIN_GALLOP) break;
+            } else {                                                        // left <= right (stable)
+                memcpy(&dst[k++], &src[i++], sizeof(T));
+                cl++; cr = 0;
+                if (i >= m) goto done;
+                if (cl >= DAS_STABLE_MIN_GALLOP) break;
+            }
+        }
+        for (;;) {                                                          // galloping
+            size_t is = i;                                                  // left run: src[i..] <= src[j]
+            while (i < m && !cmp(src[j], src[i])) i++;
+            size_t lenL = i - is;
+            if (lenL) { memcpy(&dst[k], &src[is], lenL * sizeof(T)); k += lenL; if (i >= m) goto done; }
+            memcpy(&dst[k++], &src[j++], sizeof(T)); if (j >= r) goto done;
+            size_t js = j;                                                  // right run: src[j..] < src[i]
+            while (j < r && cmp(src[j], src[i])) j++;
+            size_t lenR = j - js;
+            if (lenR) { memcpy(&dst[k], &src[js], lenR * sizeof(T)); k += lenR; if (j >= r) goto done; }
+            memcpy(&dst[k++], &src[i++], sizeof(T)); if (i >= m) goto done;
+            if (lenL < size_t(DAS_STABLE_MIN_GALLOP) && lenR < size_t(DAS_STABLE_MIN_GALLOP)) break;
+        }
     }
-    if (i < m) { memcpy(&dst[k], &src[i], (m - i) * sizeof(T)); k += (m - i); }
+done:
+    if (i < m) { memcpy(&dst[k], &src[i], (m - i) * sizeof(T)); }
     if (j < r) { memcpy(&dst[k], &src[j], (r - j) * sizeof(T)); }
 }
 

--- a/src/builtin/module_builtin_runtime_sort.cpp
+++ b/src/builtin/module_builtin_runtime_sort.cpp
@@ -101,6 +101,77 @@ namespace das
     }
 
     // ==========================================================================
+    // stable_sort any-path runtime wrappers — mirror of the builtin_sort_*_any_*
+    // surface above, routing through the byte-pointer das_stable_sort_r (adaptive
+    // natural-run merge, stable). Interp path only; AOT uses the typed _T
+    // templates (das_stable_sort<T>) in aot.h.
+    // ==========================================================================
+
+    void builtin_stable_sort_any_cblock ( void * anyData, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * at ) {
+        if ( length<=1 ) return;
+        vec4f bargs[2];
+        context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+            das_stable_sort_r(anyData, length, elementSize, [&](const void * x, const void * y){
+              bargs[0] = cast<void *>::from(x);
+              bargs[1] = cast<void *>::from(y);
+              return code->evalBool(*context);
+            });
+        }, at);
+    }
+
+    void builtin_stable_sort_any_ref_cblock ( void * anyData, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * at ) {
+        if ( length<=1 ) return;
+        vec4f bargs[2];
+        if ( elementSize <= 4 ) {
+            context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                das_stable_sort_r(anyData, length, elementSize, [&](const void * x, const void * y){
+                    bargs[0] = v_ldu_x((const float *)x);
+                    bargs[1] = v_ldu_x((const float *)y);
+                    return code->evalBool(*context);
+                });
+            },at);
+        } else if ( elementSize <= 8 ) {
+            context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                das_stable_sort_r(anyData, length, elementSize, [&](const void * x, const void * y){
+                    bargs[0] = v_ldu_half(x);
+                    bargs[1] = v_ldu_half(y);
+                    return code->evalBool(*context);
+                });
+            }, at);
+        } else {
+            context->invokeEx(cmp, bargs, nullptr, [&](SimNode * code) {
+                das_stable_sort_r(anyData, length, elementSize, [&](const void * x, const void * y){
+                    bargs[0] = v_ldu((const float *)x);
+                    bargs[1] = v_ldu((const float *)y);
+                    return code->evalBool(*context);
+                });
+            }, at);
+        }
+    }
+
+    void builtin_stable_sort_dim_any_cblock ( vec4f anything, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * at ) {
+        builtin_stable_sort_any_cblock(cast<void *>::to(anything), elementSize, length, cmp, context, at);
+    }
+
+    void builtin_stable_sort_dim_any_ref_cblock ( vec4f anything, int32_t elementSize, int32_t length, const Block & cmp, Context * context, LineInfoArg * at ) {
+        builtin_stable_sort_any_ref_cblock(cast<void *>::to(anything), elementSize, length, cmp, context, at);
+    }
+
+    void builtin_stable_sort_array_any_cblock ( Array & arr, int32_t elementSize, int32_t, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "stable_sort");
+        array_lock(*context,arr,at);
+        builtin_stable_sort_any_cblock(arr.data, elementSize, len, cmp, context, at);
+        array_unlock(*context,arr,at);
+    }
+
+    void builtin_stable_sort_array_any_ref_cblock ( Array & arr, int32_t elementSize, int32_t, const Block & cmp, Context * context, LineInfoArg * at ) {
+        int32_t len = sort_array_size_or_panic(arr, context, at, "stable_sort");
+        array_lock(*context,arr,at);
+        builtin_stable_sort_any_ref_cblock(arr.data, elementSize, len, cmp, context, at);
+        array_unlock(*context,arr,at);
+    }
+
+    // ==========================================================================
     // partial_sort / nth_element / heap-op any-path runtime wrappers.
     //
     // Mirrors the builtin_sort_*_any_cblock surface but routes through the
@@ -525,6 +596,27 @@ namespace das
                 ->args({"array","stride","length","block","context","line"})->setAotTemplate()->setAnyTemplate();
         addExtern<DAS_BIND_FUN(builtin_sort_dim_any_ref_cblock)>(*this, lib, "__builtin_sort_dim_any_ref_cblock",
             SideEffects::modifyArgumentAndExternal, "builtin_sort_dim_any_ref_cblock_T")
+                ->args({"array","stride","length","block","context","line"})->setAotTemplate()->setAnyTemplate();
+
+        // stable_sort — any-path only (no numeric/string fast-path; always comparator-based).
+        // Interp: byte das_stable_sort_r. AOT: typed das_stable_sort<T> via the _T templates.
+        addExtern<DAS_BIND_FUN(builtin_stable_sort_any_cblock)>(*this, lib, "__builtin_stable_sort_any_cblock",
+            SideEffects::modifyArgumentAndExternal, "builtin_stable_sort_any_cblock")
+                ->args({"array","stride","length","block","context","line"});
+        addExtern<DAS_BIND_FUN(builtin_stable_sort_any_ref_cblock)>(*this, lib, "__builtin_stable_sort_any_ref_cblock",
+            SideEffects::modifyArgumentAndExternal, "builtin_stable_sort_any_ref_cblock")
+                ->args({"array","stride","length","block","context","line"});
+        addExtern<DAS_BIND_FUN(builtin_stable_sort_array_any_cblock)>(*this, lib, "__builtin_stable_sort_array_any_cblock",
+            SideEffects::modifyArgumentAndExternal, "builtin_stable_sort_array_any_cblock_T")
+                ->args({"array","stride","length","block","context","line"})->setAotTemplate();
+        addExtern<DAS_BIND_FUN(builtin_stable_sort_array_any_ref_cblock)>(*this, lib, "__builtin_stable_sort_array_any_ref_cblock",
+            SideEffects::modifyArgumentAndExternal, "builtin_stable_sort_array_any_ref_cblock_T")
+                ->args({"array","stride","length","block","context","line"})->setAotTemplate();
+        addExtern<DAS_BIND_FUN(builtin_stable_sort_dim_any_cblock)>(*this, lib, "__builtin_stable_sort_dim_any_cblock",
+            SideEffects::modifyArgumentAndExternal, "builtin_stable_sort_dim_any_cblock_T")
+                ->args({"array","stride","length","block","context","line"})->setAotTemplate()->setAnyTemplate();
+        addExtern<DAS_BIND_FUN(builtin_stable_sort_dim_any_ref_cblock)>(*this, lib, "__builtin_stable_sort_dim_any_ref_cblock",
+            SideEffects::modifyArgumentAndExternal, "builtin_stable_sort_dim_any_ref_cblock_T")
                 ->args({"array","stride","length","block","context","line"})->setAotTemplate()->setAnyTemplate();
 
         // ==================================================================

--- a/tests-cpp/small/test_sort_family.cpp
+++ b/tests-cpp/small/test_sort_family.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <random>
 #include <vector>
 
 using namespace das;
@@ -458,4 +459,100 @@ TEST_CASE("bounded-N streaming heap (top_n_by usage pattern)") {
     CHECK(buf[0] == 0);
     CHECK(buf[1] == 1);
     CHECK(buf[2] == 2);
+}
+
+// ============================================================================
+// das_stable_sort_r (byte) + das_stable_sort<T> (typed) — adaptive natural-run
+// merge. Verifies sorted + STABLE (equal keys keep input order) + permutation.
+// ============================================================================
+
+namespace {
+
+    // key drives the sort; idx records original position so stability is observable.
+    struct Keyed { int32_t key; int32_t idx; };
+
+    bool keyed_byte_less(const void * a, const void * b) {
+        return static_cast<const Keyed*>(a)->key < static_cast<const Keyed*>(b)->key;
+    }
+    struct KeyedLess { bool operator()(const Keyed & a, const Keyed & b) const { return a.key < b.key; } };
+
+    // Sorted by key, stable within equal-key groups, and a permutation of the input.
+    bool keyed_sorted_stable_perm(const std::vector<Keyed> & out, const std::vector<Keyed> & in) {
+        if (out.size() != in.size()) return false;
+        std::vector<char> seen(out.size(), 0);
+        for (size_t i = 0; i < out.size(); i++) {
+            int32_t ix = out[i].idx;
+            if (ix < 0 || size_t(ix) >= out.size() || seen[ix]) return false;       // permutation
+            seen[ix] = 1;
+            if (out[i].key != in[size_t(ix)].key) return false;                      // element integrity
+            if (i && out[i].key < out[i-1].key) return false;                        // sorted
+            if (i && out[i].key == out[i-1].key && out[i].idx < out[i-1].idx) return false; // stable
+        }
+        return true;
+    }
+
+    enum class KPat { Random, Dups, Sorted, Reverse, AllEqual };
+    std::vector<Keyed> keyed_pattern(KPat p, size_t n, uint32_t seed) {
+        std::mt19937 rng(seed);
+        std::vector<Keyed> v(n);
+        for (size_t i = 0; i < n; i++) {
+            v[i].idx = int32_t(i);
+            switch (p) {
+                case KPat::Random:   v[i].key = int32_t(rng() & 0x3FFF); break;
+                case KPat::Dups:     v[i].key = int32_t(rng() % 8); break;       // heavy duplicates
+                case KPat::Sorted:   v[i].key = int32_t(i); break;
+                case KPat::Reverse:  v[i].key = int32_t(n - i); break;
+                case KPat::AllEqual: v[i].key = 42; break;
+            }
+        }
+        return v;
+    }
+
+} // namespace
+
+TEST_CASE("das_stable_sort_r — byte path: sorted + stable + permutation") {
+    const KPat pats[] = { KPat::Random, KPat::Dups, KPat::Sorted, KPat::Reverse, KPat::AllEqual };
+    // sizes around the MINRUN=32 cutoff plus larger to exercise galloping + multi-pass merge.
+    const size_t ns[] = { 0, 1, 2, 3, 31, 32, 33, 100, 1000, 5000 };
+    for (uint32_t seed = 1; seed <= 3; seed++) {
+        for (KPat p : pats) {
+            for (size_t n : ns) {
+                auto in = keyed_pattern(p, n, seed * 101u);
+                auto out = in;
+                das_stable_sort_r(out.data(), out.size(), sizeof(Keyed), keyed_byte_less);
+                CHECK(keyed_sorted_stable_perm(out, in));
+            }
+        }
+    }
+}
+
+TEST_CASE("das_stable_sort<T> — typed path: sorted + stable + permutation") {
+    const KPat pats[] = { KPat::Random, KPat::Dups, KPat::Sorted, KPat::Reverse, KPat::AllEqual };
+    const size_t ns[] = { 0, 1, 2, 3, 31, 32, 33, 100, 1000, 5000 };
+    for (uint32_t seed = 1; seed <= 3; seed++) {
+        for (KPat p : pats) {
+            for (size_t n : ns) {
+                auto in = keyed_pattern(p, n, seed * 101u);
+                auto out = in;
+                das_stable_sort(out.data(), out.data() + out.size(), KeyedLess());
+                CHECK(keyed_sorted_stable_perm(out, in));
+            }
+        }
+    }
+}
+
+TEST_CASE("das_stable_sort — adaptivity (already-sorted / reverse use O(N) comparisons)") {
+    // The adaptive natural-run path must produce N-1 comparisons on monotone input.
+    const size_t n = 1000;
+    auto count_byte = [&](KPat p) {
+        auto v = keyed_pattern(p, n, 1u);
+        uint64_t cmps = 0;
+        das_stable_sort_r(v.data(), v.size(), sizeof(Keyed), [&](const void * a, const void * b) {
+            cmps++;
+            return static_cast<const Keyed*>(a)->key < static_cast<const Keyed*>(b)->key;
+        });
+        return cmps;
+    };
+    CHECK(count_byte(KPat::Sorted) == n - 1);   // one ascending run, zero merges
+    CHECK(count_byte(KPat::Reverse) == n - 1);  // one descending run → reversed, zero merges
 }

--- a/tests/language/sort.das
+++ b/tests/language/sort.das
@@ -37,7 +37,7 @@ def test_sort_dupes(t : T?; var arr : auto(TT); expected_sum : auto(SS)) {
 
 def test_sort_comp(t : T?; var arr : auto(TT)) {
     let len = length(arr)
-    sort(arr) <| $(a, b) {
+    sort(arr) $(a, b) {
         return a.x < b.x
     }
     for (i in range(1, len)) {
@@ -54,10 +54,7 @@ def operator <(a, b : Foo) {
 }
 
 def test_vector_sort(t : T?) {
-    var arr : array<float2>
-    push(arr, float2(4, 0))
-    push(arr, float2(3, 1))
-    push(arr, float2(5, 2))
+    var arr <- [float2(4, 0), float2(3, 1), float2(5, 2)]
     test_sort_comp(t, arr)
 }
 
@@ -88,4 +85,51 @@ def test_sort_all(t : T?) {
     test_sort_dupes(t, array<int>(5, 2, 5, 3, 2, 1, 4, 2, 5), 29l)
     test_sort_dupes(t, fixed_array<int>(5, 2, 5, 3, 2, 1, 4, 2, 5), 29l)
     test_sort_dupes(t, array<float>(1.5, 2.5, 1.5, 2.5, 3.5), 11.5lf)
+}
+
+struct Kv {
+    key : int
+    seq : int   // original position — observes stability
+}
+
+// stable_sort by key: equal keys must keep their input order (ascending seq).
+def test_stable(t : T?; var arr : array<Kv>) {
+    let len = length(arr)
+    for (i in range(len)) {
+        arr[i].seq = i
+    }
+    stable_sort(arr) $(a, b : Kv) : bool { return a.key < b.key; }
+    for (i in range(1, len)) {
+        t |> success(!(arr[i].key < arr[i - 1].key))                                  // sorted
+        if (arr[i - 1].key == arr[i].key) {
+            t |> success(arr[i - 1].seq < arr[i].seq)                                  // stable
+        }
+    }
+}
+
+[test]
+def test_stable_sort_all(t : T?) {
+    // stability: many duplicate keys (a reverse-leaning permutation to exercise run reversal)
+    test_stable(t, [Kv(key = 3), Kv(key = 1), Kv(key = 3), Kv(key = 2),
+                    Kv(key = 1), Kv(key = 3), Kv(key = 2), Kv(key = 1),
+                    Kv(key = 2), Kv(key = 3), Kv(key = 1), Kv(key = 2)])
+    // larger run to cross the MINRUN/galloping boundary, still stable
+    var big <- [for (i in range(200)); Kv(key = (i * 7) % 5)]
+    test_stable(t, big)
+    // bare form correctness — array + dim + string
+    var ints = array<int>(5, 2, 5, 3, 2, 1, 4, 2, 5)
+    stable_sort(ints)
+    for (i in range(1, length(ints))) {
+        t |> success(!(ints[i] < ints[i - 1]))
+    }
+    var dim = fixed_array<int>(4, 1, 4, 2, 1, 3)
+    stable_sort(dim) $(a, b : int) : bool { return a < b; }
+    for (i in range(1, length(dim))) {
+        t |> success(!(dim[i] < dim[i - 1]))
+    }
+    var strs = array<string>("b", "a", "b", "c", "a")
+    stable_sort(strs)
+    for (i in range(1, length(strs))) {
+        t |> success(!(strs[i] < strs[i - 1]))
+    }
 }

--- a/tutorials/language/33_algorithm.das
+++ b/tutorials/language/33_algorithm.das
@@ -2,7 +2,8 @@
 //
 // This tutorial covers:
 //   - Searching sorted arrays: lower_bound, upper_bound, binary_search, equal_range
-//   - Sorting: sort (full sort), partial_sort (first N), nth_element (kth-smallest)
+//   - Sorting: sort (full sort), stable_sort (equal elements keep input order),
+//     partial_sort (first N), nth_element (kth-smallest)
 //   - Deduplication: sort_unique, unique
 //   - Heap operations: make_heap, push_heap, pop_heap (binary max-heap)
 //   - Top-N selection: top_n / top_n_by (N smallest via partial-sort or bounded heap)
@@ -82,6 +83,21 @@ def sort_demo() {
         return x > y
     }
     print("sort desc: {b}\n")  // [9, 8, 5, 2, 1]
+
+    // stable_sort: like sort, but elements that compare equal keep their input
+    // order. `sort` may reorder equal elements; `stable_sort` never does. Here we
+    // sort by price only — items with the same price stay in their original order.
+    var items <- [PricePoint(item_id = 1, price = 50), PricePoint(item_id = 2, price = 20),
+                  PricePoint(item_id = 3, price = 50), PricePoint(item_id = 4, price = 20),
+                  PricePoint(item_id = 5, price = 50)]
+    stable_sort(items) $(x, y : PricePoint) : bool {
+        return x.price < y.price
+    }
+    print("stable_sort by price: ")
+    for (it in items) {
+        print("({it.item_id}@{it.price}) ")  // (2@20) (4@20) (1@50) (3@50) (5@50)
+    }
+    print("\n")
 
     // Today's sort is full O(n log n) on the whole array. If you only need
     // the first N sorted, use partial_sort. If you only need the k-th element,


### PR DESCRIPTION
## What

Adds a **stable sort** to daslang — `stable_sort` in `daslib/builtin.das` (4 overloads: `array`/dim × with-comparator/bare), backed by a new adaptive natural-run merge in `das_qsort_r.h`. Stable = elements that compare equal keep their input order (matches `std::stable_sort` / C# `OrderBy`).

Daslang previously had only the unstable `sort` (introsort / `das_qsort_r`).

## Why

It's a generally useful primitive, and it unblocks **multi-key `orderby`** for the linq query syntax (a reverse chain of stable single-key sorts is the clean way to emit `orderby a, b desc, c` over every source).

## Algorithm — chosen by bench, not blindly

`examples/sort/bench_stable_sort.cpp` raced three byte-pointer candidates vs `std::stable_sort` across element widths (16/32/128) × patterns (random / heavy-dups / sorted / 95%-sorted / reverse / all-equal) × sizes, in **both** a cheap-comparator (movement-bound) and an expensive-comparator (daslang-interp proxy) regime, with gold-standard verification (sorted + stable + permutation + element-integrity; thousands of edge cases) and a comparator-call counter:

- **#1 bottom-up merge** — dominated by #3. Dropped.
- **#4 index-decoration + cycle-permute** — wins wide elements in the movement-bound regime, but its stability tiebreak doubles comparator calls and loses in the interp regime. Kept as a bake-off reference; a possible wide-element specialization later.
- **#3 natural-run merge** — **winner.** Adaptive (exactly **N−1** comparisons on already-sorted / reverse input → big wins there), comparison-efficient on random (beats `std::stable_sort` in the comparator-bound regime), single-comparator (robust across all tiers). The multi-key-orderby workload feeds it partially-ordered data — its home turf.

### Galloping
The plain merge copies element-by-element; profiling (`sample`) showed that on partial-sorted data the compiler-inlined per-element copy in the typed path ran ~2× slower than the byte path's `_platform_memmove`-routed copies. Classic **timsort galloping** (`MIN_GALLOP = 7`) fixes it: stay one-at-a-time until a side wins a streak, then bulk-copy whole runs. Random stays one-at-a-time (no extra comparisons / memcpy-call overhead); structured data batches into bulk memmoves. Result: the typed partial-sorted case went from 2.65× → 1.26× vs std, comparison counts unchanged, adaptive wins intact.

## Integration

- `das_qsort_r.h`: byte-pointer `das_stable_sort_r` (interp) + typed `das_stable_sort&lt;T&gt;` (AOT). malloc scratch, unstable fallback on OOM.
- `module_builtin_runtime_sort.cpp` + `aot.h` + `aot_builtin.h`: the any-path runtime wrappers + `sscblk`/`sscblk_array` AOT templates. Stable sort is always comparator-based (no numeric/string fast-path matrix), so the surface is the generic any-path only — no new annotation.
- `daslib/builtin.das`: the 4 `stable_sort` overloads.

## Tests &amp; gates (all green)

- **C++ doctest** (`test_sort_family.cpp`): `das_stable_sort_r` + `das_stable_sort&lt;T&gt;` — sorted + stable + permutation + element-integrity over edge sizes around the MINRUN cutoff, plus an adaptivity N−1 check. 302 assertions.
- **daslang** (`tests/language/sort.das`): stability of equal-key records; array / dim / string; a 200-element run crossing the galloping boundary — **interp / JIT / AOT all green**.
- **bench correctness sweep**: thousands of cases green (byte + typed produce identical comparison counts).
- Full `./tests` interp regression: 10240 passed / 0 failed / 0 errors.
- MCP + CI lint, formatter, das2rst, `sphinx -W` all clean.

## Docs / tutorial

Generated docs (`builtin.rst`) document all 4 overloads (`stable_sort` added to the builtin "Containers" group + handmade descriptions); `tutorials/language/33_algorithm.das` gains a `stable_sort` demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)