### PR TITLE
dastest: add --stack-on-exception for at-throw test stack traces

### DIFF
--- a/dastest/README.md
+++ b/dastest/README.md
@@ -36,6 +36,7 @@ Running only **some** selected benchmarks (uses `vector_alloc` as a filtering pr
 - `--isolated-mode`: Run tests in isolated processes, useful to catch crashes
 - `--isolated-mode-threads <n>`: Number of worker threads in isolated mode (defaults to 2x hardware threads when 0)
 - `--batch <n>`: Files per worker subprocess in isolated mode (semi-isolated sharding). `1` (default) is one process per test (full isolation). `>1` amortizes process/compile cold-start across a batch — much faster, especially on Windows. A crash in a batch is auto-recovered: the file that died is reported as crashed and the rest of the batch is re-run one-process-per-file, so isolation is preserved exactly where it is needed.
+- `--stack-on-exception`: On a test panic, walk the call stack *at throw time* (frames intact) and print a real `CALL STACK` trace, instead of the default that reports only the panic message and location. Off by default (a test that swallows a panic via `try`/`recover` would also emit a walk); enable for one-iteration debugging of a failing/crashing test. Works in isolated mode too — the trace is folded under the failing test's log.
 - `--bench`: Enable benchmark execution (all of them)
 - `--bench-names <namePrefix>`: Run top-level benchmark matching "namePrefix"
 - `--bench-format <format>`: Specifies the benchmark output format ("native", "go" or "json")

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -252,18 +252,30 @@ def private run_iso_subprocess(cmd : string; timeoutSec : float; var br : BatchR
         // exit code rather than asserting "crash". A clean run's stderr (e.g.
         // libhv logs) is noise we don't attribute to the test.
         if (br.exitCode != 0) {
+            var folded : array<string>
             fopen(errPath, "rb") $(ef) {
                 if (ef != null) {
-                    var anyErr = false
                     while (!feof(ef)) {
                         let ln = fgets(ef)
                         continue if (empty(ln))
-                        if (!anyErr) {
-                            pending |> push("----- subprocess stderr (abnormal exit {br.exitCode}) -----\n")
-                            anyErr = true
-                        }
-                        pending |> push(ln)
+                        folded |> push(ln)
                     }
+                }
+            }
+            if (!empty(folded)) {
+                let header = "----- subprocess stderr (abnormal exit {br.exitCode}) -----\n"
+                // A caught panic emits a JSON result, so `pending` was already moved into
+                // that result's log above — fold the captured stderr into the last result's
+                // log so the at-throw stack (--stack-on-exception) surfaces under the
+                // failing test. A hard crash emits no result, so fall back to `pending`
+                // (the trailing log attributed to the dead file).
+                if (empty(br.results)) {
+                    pending |> push(header)
+                    pending |> push_from(folded)
+                } else {
+                    let li = length(br.results) - 1
+                    br.results[li].log |> push(header)
+                    br.results[li].log |> push_from(folded)
                 }
             }
         }
@@ -621,8 +633,11 @@ def main() : int {
         let jitstr = jit_enabled() ? "-jit" : ""
         let aotstr = is_in_aot() ? "-use-aot" : ""
         let benchstr = ctx.bench_enabled ? "--bench" : ""
+        // Forward --stack-on-exception to each worker: the flag sets the test
+        // context's at-throw stack walk, and the tests run in the worker, not here.
+        let stackExcFlag = test_args.stack_on_exception ? " --stack-on-exception" : ""
         let cmdPrefix = "{launchPrefix} {jitstr} {aotstr} --"
-        let cmdSuffix = " {benchstr}{log::useTtyColors ? " --color" : ""}{headlessFlag}"
+        let cmdSuffix = " {benchstr}{log::useTtyColors ? " --color" : ""}{headlessFlag}{stackExcFlag}"
         let batchSize = max(1, test_args.batch)
         // Group files into batches of batchSize. Each batch is run by one worker
         // subprocess (batchCmd); per-file singleCmds are kept so a crash can be

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -263,7 +263,7 @@ def private run_iso_subprocess(cmd : string; timeoutSec : float; var br : BatchR
                 }
             }
             if (!empty(folded)) {
-                let header = "----- subprocess stderr (abnormal exit {br.exitCode}) -----\n"
+                let header = "----- worker subprocess stderr (abnormal exit {br.exitCode}; batch>1 may include other files in the worker) -----\n"
                 // A caught panic emits a JSON result, so `pending` was already moved into
                 // that result's log above — fold the captured stderr into the last result's
                 // log so the at-throw stack (--stack-on-exception) surfaces under the

--- a/dastest/dastest_clargs.das
+++ b/dastest/dastest_clargs.das
@@ -86,6 +86,9 @@ struct DastestArgs {
     @clarg_doc = "Set cop.keep_alive so _KeepAlive SimNode variants get dispatched"
     keep_alive : bool = false
 
+    @clarg_doc = "On a test panic, walk the call stack at throw time (real frames + line info, args via context settings) instead of the post-unwind walk that reports sp=0 with no frames. Sets the test context's alwaysStackWalkOnException. Off by default: a test that swallows a panic via try/recover would also emit a walk — enable for debugging a failing/crashing test"
+    stack_on_exception : bool = false
+
     // Could use an enum here, but the strings would
     // be different from the original ones, so may
     // not be worth it.

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -36,6 +36,7 @@ struct SuiteCtx {
     cov_path : string = ""
     debugger : bool = false
     keep_alive : bool = false
+    stackOnException : bool = false
 
     // Testing-related options.
     testNames : array<string>
@@ -91,6 +92,7 @@ def SuiteCtx(args : DastestArgs) : SuiteCtx {
     ctx.bench_enabled = args.bench
     ctx.keep_alive = args.keep_alive
     ctx.debugger = args.debugger
+    ctx.stackOnException = args.stack_on_exception
     let bench_format = args.bench_format
     if (bench_format == "go") {
         ctx.bench_format = BenchmarkOutputFormat.go_export
@@ -107,7 +109,7 @@ struct FileCtx {
     uriPaths : bool = false
     indenting : string = ""
     verbose : bool = false
-    stackOnRecover : bool = true
+    stackOnException : bool = false
     expectFailure : bool = false
 }
 
@@ -122,7 +124,7 @@ def FileCtx(ctx : SuiteCtx) : FileCtx {
 
 
 def private internalFileCtx(ctx : SuiteCtx) : FileCtx {
-    return <- FileCtx(uriPaths = ctx.uriPaths, verbose = ctx.verbose)
+    return <- FileCtx(uriPaths = ctx.uriPaths, verbose = ctx.verbose, stackOnException = ctx.stackOnException)
 }
 
 
@@ -308,6 +310,11 @@ def test_module(var mod : rtti::Module; var context : rtti::Context; var suite_c
         fileCtx.context = addr(context)
         modPtr = addr(mod)
     }
+    // Walk the call stack at throw time (stack intact → real frames) rather than after
+    // the panic unwinds (the old post-unwind walk reported sp=0 with no frames).
+    if (fileCtx.stackOnException) {
+        context.alwaysStackWalkOnException = true
+    }
     modPtr |> module_for_each_function() $(f) {
         if (f.hash == 0ul) return
         let func = context |> get_function_by_mnh(f.hash)
@@ -490,9 +497,6 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
                 if (empty(testLocation)) {
                     testLocation = "{loc}"
                 }
-            }
-            if (context.stackOnRecover) {
-                *context.context |> stackwalk(context.context.exceptionAt)
             }
         }
     }

--- a/dastest/tests/_isolated_fixture/test_worker_index.das
+++ b/dastest/tests/_isolated_fixture/test_worker_index.das
@@ -17,7 +17,10 @@ def test_worker_index_round_trip(tt : T?) {
         if (idx + 1 >= length(args)) {
             return
         }
+        // Worker indices are 1-based (dastest passes --worker-index t+1, so a client
+        // can map index N -> live-API port 9090+N and leave 9090 free); with the 4
+        // threads test_isolated_mode launches, they span [1, 4].
         let val = to_int(args[idx + 1])
-        t |> success(val >= 0 && val < 4, "worker_index {val} out of range [0, 4)")
+        t |> success(val >= 1 && val <= 4, "worker_index {val} out of range [1, 4]")
     }
 }

--- a/dastest/tests/_isolated_fixture_panic/test_panic.das
+++ b/dastest/tests/_isolated_fixture_panic/test_panic.das
@@ -19,5 +19,9 @@ def private deep_panic(n : int) {
 [test]
 def test_panic_emits_stack(t : T?) {
     deep_panic(3)
-    t |> success(true)
+    // deep_panic always panics, so this is unreachable. Fail loudly if a future
+    // change ever lets it return — otherwise the fixture would pass silently and
+    // test_isolated_mode's "no walk without the flag" assertion could go green for
+    // the wrong reason (a fixture that never panicked).
+    t |> success(false, "deep_panic returned without panicking")
 }

--- a/dastest/tests/_isolated_fixture_panic/test_panic.das
+++ b/dastest/tests/_isolated_fixture_panic/test_panic.das
@@ -1,0 +1,23 @@
+options gen2
+
+require dastest/testing_boost public
+
+// Fixture for the --stack-on-exception regression test. A recursive panic gives
+// a multi-frame call chain; with the flag set, the daslang runtime walks the
+// stack AT THROW (frames intact) and prints "CALL STACK ..." to the worker's
+// STDERR, which dastest's isolated runner folds into the failing test's log.
+// Without the flag the post-unwind walk is suppressed, so no stack is emitted.
+// Lives under a `_`-prefixed dir so the normal suite skips it — only
+// test_isolated_mode.das runs it, as a spawned subprocess.
+def private deep_panic(n : int) {
+    if (n <= 0) {
+        panic("intentional panic for the stack-walk fixture")
+    }
+    deep_panic(n - 1)
+}
+
+[test]
+def test_panic_emits_stack(t : T?) {
+    deep_panic(3)
+    t |> success(true)
+}

--- a/dastest/tests/test_isolated_mode.das
+++ b/dastest/tests/test_isolated_mode.das
@@ -94,16 +94,25 @@ def test_isolated_mode(tt : T?) {
         var output : string
         var exit_code : int
         run_dastest(cmd, output, exit_code)
+        // Positive proof the fixture actually ran and panicked (so an absent CALL
+        // STACK below is meaningful, not a subprocess that never ran).
+        t |> success(exit_code != 0, "expected non-zero exit from the panicking fixture, got {exit_code}\n{output}")
+        t |> success(output |> contains("intentional panic"),
+            "expected the fixture's panic message in output, got:\n{output}")
         t |> success(output |> contains("CALL STACK"),
             "expected the at-throw CALL STACK in output, got:\n{output}")
         t |> success(output |> contains("deep_panic"),
             "expected the panicking call chain (deep_panic) in the walk, got:\n{output}")
 
-        // WITHOUT the flag: no stack walk at all — just the panic message + location.
+        // WITHOUT the flag: the fixture still panics (non-zero exit + message), but
+        // no stack walk is emitted.
         let cmd2 = "{exe} {dastest_root()}/dastest.das -- --test {fixture_dir_panic()} --isolated-mode --isolated-mode-threads 1"
         var output2 : string
         var exit_code2 : int
         run_dastest(cmd2, output2, exit_code2)
+        t |> success(exit_code2 != 0, "expected non-zero exit from the panicking fixture, got {exit_code2}\n{output2}")
+        t |> success(output2 |> contains("intentional panic"),
+            "expected the fixture's panic message in output, got:\n{output2}")
         t |> success(!(output2 |> contains("CALL STACK")),
             "without --stack-on-exception there must be no stack walk, got:\n{output2}")
     }

--- a/dastest/tests/test_isolated_mode.das
+++ b/dastest/tests/test_isolated_mode.das
@@ -23,6 +23,10 @@ def fixture_dir_crash() : string {
     return "{dastest_root()}/tests/_isolated_fixture_crash"
 }
 
+def fixture_dir_panic() : string {
+    return "{dastest_root()}/tests/_isolated_fixture_panic"
+}
+
 def run_dastest(cmd : string; var output : string&; var exit_code : int&) {
     output = ""
     unsafe {
@@ -78,5 +82,29 @@ def test_isolated_mode(tt : T?) {
             "expected the captured-stderr header in output, got:\n{output}")
         t |> success(output |> contains("CRASH"),
             "expected the crash-handler 'CRASH' line folded into the log, got:\n{output}")
+    }
+
+    tt |> run("--stack-on-exception folds an at-throw call stack into a panicking worker's log") <| @(t : T?) {
+        // WITH the flag: the worker sets the test context's alwaysStackWalkOnException,
+        // so the panic walks the stack at throw (frames intact) to the worker's stderr,
+        // which the isolated runner folds into the failing test's log. The recursive
+        // fixture means the deep_panic call chain shows up in the walk.
+        let exe = get_command_line_arguments()[0]
+        let cmd = "{exe} {dastest_root()}/dastest.das -- --test {fixture_dir_panic()} --isolated-mode --isolated-mode-threads 1 --stack-on-exception"
+        var output : string
+        var exit_code : int
+        run_dastest(cmd, output, exit_code)
+        t |> success(output |> contains("CALL STACK"),
+            "expected the at-throw CALL STACK in output, got:\n{output}")
+        t |> success(output |> contains("deep_panic"),
+            "expected the panicking call chain (deep_panic) in the walk, got:\n{output}")
+
+        // WITHOUT the flag: no stack walk at all — just the panic message + location.
+        let cmd2 = "{exe} {dastest_root()}/dastest.das -- --test {fixture_dir_panic()} --isolated-mode --isolated-mode-threads 1"
+        var output2 : string
+        var exit_code2 : int
+        run_dastest(cmd2, output2, exit_code2)
+        t |> success(!(output2 |> contains("CALL STACK")),
+            "without --stack-on-exception there must be no stack walk, got:\n{output2}")
     }
 }

--- a/doc/source/reference/utils/dastest.rst
+++ b/doc/source/reference/utils/dastest.rst
@@ -104,6 +104,14 @@ Command-line arguments
    * - ``--test-timeout <seconds>``
      - Per-test-file timeout in isolated mode (seconds).
        ``0`` disables.  Default: ``0`` (no per-file timeout).
+   * - ``--stack-on-exception``
+     - On a test panic, walk the call stack *at throw time* (frames intact)
+       and print a real ``CALL STACK`` trace, instead of the default which
+       reports only the panic message and location.  Off by default — a test
+       that swallows a panic via ``try``/``recover`` would also emit a walk.
+       Enable for one-iteration debugging of a failing or crashing test;
+       works in isolated mode too (the trace is folded under the failing
+       test's log).
    * - ``--timing-outliers <n>``
      - After all tests pass, print the *n* slowest test files
        (timing outliers above 2 standard deviations).


### PR DESCRIPTION
## Problem

When a test panics, dastest reported only `<loc>: <message>` — or, when it walked the stack (`stackOnRecover`), a **useless post-unwind trace showing `sp=0` with no frames**: by the time dastest called `stackwalk(exceptionAt)` the stack had already unwound, so the actual panic call chain was gone.

## Change

An opt-in **`--stack-on-exception`** flag (off by default). It sets the test context's `alwaysStackWalkOnException`, so the daslang runtime walks the stack **at throw time** (frames intact) and emits a real `CALL STACK …` trace with the panic call chain.

**No C++ changes** — the runtime flag already existed (`Context::alwaysStackWalkOnException`, rtti-bound); it just had no switch.

### Before / after (a recursive panic)
```
# default — no stack
<loc>: boom

# --stack-on-exception
from test.das:5:8
CALL STACK (sp=160, …):
deep_panic from test.das:6:4(sp=160, …)
deep_panic from test.das:6:4(sp=128, …)
deep_panic from test.das:6:4(sp=96, …)
deep_panic from test.das:11:4(sp=64, …)
test_x from suite.das:475:36(sp=32, …)
```

### Pieces
- **`dastest_clargs.das`** — the `--stack-on-exception` flag.
- **`suite.das`** — set `alwaysStackWalkOnException` on the test context when the flag is on; drop the post-unwind `stackwalk()` that produced the `sp=0` noise.
- **`dastest.das`** — forward the flag to isolated-mode workers, and fold a worker's captured stderr into the **last emitted result's log** (not the moved-out `pending`) so the at-throw walk surfaces under a *caught-panic* failure in isolated mode too. The hard-crash path (no result emitted) still folds into `pending` — unchanged, so the existing crash-stderr test (#2985) keeps passing.
- **tests** — a panic fixture + a `test_isolated_mode` case asserting the walk shows with the flag and is absent without it.

Off by default because a test that swallows a panic via `try/recover` would also emit a walk; once the legacy `try/recover` tests are swept, this can default on. Intended for one-iteration remote debugging of a failing/crashing test.

## Drive-by

Fix a pre-existing bug in the `test_worker_index` fixture: it checked the worker index against `[0, 4)`, but indices are **1-based** (dastest passes `--worker-index t+1` so a client can map index `N` → port `9090+N`). It failed whenever the fixture landed on the top worker. Corrected to `[1, 4]`.

## Testing
- `utils/lint`: 0 issues across changed files.
- `das-fmt --verify`: all changed files verified.
- `test_isolated_mode.das`: all sub-tests pass (new `--stack-on-exception` case + existing crash-fold case + the fixed worker_index case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)