### PR TITLE
typer: shorten type-alias names in mismatch errors (#2571)

### DIFF
--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -106,6 +106,7 @@ namespace das {
         virtual void reportFolding() override;
         string describeType(const TypeDeclPtr &decl) const;
         string describeType(const TypeDecl *decl) const;
+        string describeType(const TypeDeclPtr &decl, AliasDefs * aliasDefs) const;
         string describeFunction(const FunctionPtr &fun) const;
         string describeFunction(const Function *fun) const;
 

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -29,6 +29,7 @@ namespace das {
 
     typedef das_map<string,TypeDeclPtr> AliasMap;
     typedef das_map<TypeDecl *,int> OptionsMap;
+    typedef vector<pair<string,string>> AliasDefs;
 
     class Visitor;
 
@@ -151,7 +152,7 @@ namespace das {
         int getVariantFieldOffset ( int index ) const;
         int getVariantUniqueFieldIndex ( const TypeDeclPtr & uniqueType ) const;
         int getVectorFieldOffset ( int index ) const;
-        string describe ( DescribeExtra extra = DescribeExtra::yes, DescribeContracts contracts = DescribeContracts::yes, DescribeModule module = DescribeModule::yes) const;
+        string describe ( DescribeExtra extra = DescribeExtra::yes, DescribeContracts contracts = DescribeContracts::yes, DescribeModule module = DescribeModule::yes, AliasDefs * aliasDefs = nullptr, bool topAlias = true ) const;
         bool canCloneFromConst() const;
         __forceinline bool canCopy() const { return canCopy(false); }
         bool canCopy(bool tempMatters) const;

--- a/src/ast/ast_infer_type_helper.cpp
+++ b/src/ast/ast_infer_type_helper.cpp
@@ -69,6 +69,10 @@ namespace das {
     string InferTypes::describeType(const TypeDecl *decl) const {
         return verbose ? decl->describe() : "";
     }
+    string InferTypes::describeType(const TypeDeclPtr &decl, AliasDefs * aliasDefs) const {
+        return verbose ? decl->describe(TypeDecl::DescribeExtra::yes, TypeDecl::DescribeContracts::yes,
+                                        TypeDecl::DescribeModule::yes, aliasDefs) : "";
+    }
     string InferTypes::describeFunction(const FunctionPtr &fun) const {
         return verbose ? fun->describe() : "";
     }

--- a/src/ast/ast_infer_type_report.cpp
+++ b/src/ast/ast_infer_type_report.cpp
@@ -94,8 +94,19 @@ namespace das {
     }
     string InferTypes::describeMismatchingArgument(const string &argName, const TypeDeclPtr &passType, const TypeDeclPtr &argType, int argIndex) const {
         TextWriter ss;
+        AliasDefs aliasDefs;
         ss << "\t\tinvalid argument '" << argName << "' (" << argIndex << "). expecting '"
-           << describeType(argType) << "', passing '" << describeType(passType) << "'\n";
+           << describeType(argType, &aliasDefs) << "', passing '" << describeType(passType, &aliasDefs) << "'\n";
+        if ( !aliasDefs.empty() ) {
+            ss << "\t\twhere ";
+            bool first = true;
+            for ( auto & kv : aliasDefs ) {
+                if ( !first ) ss << "; ";
+                ss << "'" << kv.first << " = " << kv.second << "'";
+                first = false;
+            }
+            ss << "\n";
+        }
         if (passType->isAlias()) {
             ss << "\t\t" << reportAliasError(passType) << "\n";
         }

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -631,12 +631,22 @@ namespace das
 
     // TypeDecl
 
-    string TypeDecl::describe ( DescribeExtra extra, DescribeContracts contracts, DescribeModule dmodule ) const {
+    string TypeDecl::describe ( DescribeExtra extra, DescribeContracts contracts, DescribeModule dmodule, AliasDefs * aliasDefs, bool topAlias ) const {
         TextWriter stream;
         if ( autoToAlias ) {
             stream << "type<";
         }
-        if ( baseType==Type::alias ) {
+        if ( aliasDefs && topAlias && extra==DescribeExtra::yes && baseType!=Type::alias
+                && baseType!=Type::autoinfer && !alias.empty() ) {
+            bool known = false;
+            for ( auto & kv : *aliasDefs ) { if ( kv.first==alias ) { known = true; break; } }
+            if ( !known ) {
+                aliasDefs->emplace_back(alias, string());           // reserve slot, break recursion cycles
+                string def = describe(extra, contracts, dmodule, aliasDefs, false); // expand this node structurally
+                for ( auto & kv : *aliasDefs ) { if ( kv.first==alias ) { kv.second = def; break; } }
+            }
+            stream << alias;
+        } else if ( baseType==Type::alias ) {
             if ( isTag ) {
                 if ( firstType) {
                     stream << "$$(";
@@ -657,7 +667,7 @@ namespace das
             }
         } else if ( baseType==Type::option ) {
             for ( auto & argT : argTypes ) {
-                stream << argT->describe(extra, contracts, dmodule);
+                stream << argT->describe(extra, contracts, dmodule, aliasDefs);
                 if ( argT != argTypes.back() ) {
                     stream << "|";
                 }
@@ -690,13 +700,13 @@ namespace das
             }
         } else if ( baseType==Type::tArray ) {
             if ( firstType ) {
-                stream << "array<" << firstType->describe(extra, contracts, dmodule) << ">";
+                stream << "array<" << firstType->describe(extra, contracts, dmodule, aliasDefs) << ">";
             } else {
                 stream << "array";
             }
         } else if ( baseType==Type::tTable ) {
             if ( firstType && secondType ) {
-                stream << "table<" << firstType->describe(extra, contracts, dmodule) << ";" << secondType->describe(extra, contracts, dmodule) << ">";
+                stream << "table<" << firstType->describe(extra, contracts, dmodule, aliasDefs) << ";" << secondType->describe(extra, contracts, dmodule, aliasDefs) << ">";
             } else {
                 stream << "table";
             }
@@ -712,7 +722,7 @@ namespace das
         } else if ( baseType==Type::tPointer ) {
             if ( smartPtr ) stream << "smart_ptr<";
             if ( firstType ) {
-                stream << firstType->describe(extra, contracts, dmodule);
+                stream << firstType->describe(extra, contracts, dmodule, aliasDefs);
             } else {
                 stream << "void";
             }
@@ -728,7 +738,7 @@ namespace das
             }
         } else if ( baseType==Type::tIterator ) {
             if ( firstType ) {
-                stream << "iterator<" << firstType->describe(extra, contracts, dmodule) << ">";
+                stream << "iterator<" << firstType->describe(extra, contracts, dmodule, aliasDefs) << ">";
             } else {
                 stream << "iterator";
             }
@@ -746,7 +756,7 @@ namespace das
                     } else {
                         stream << "arg" << ai << ":";
                     }
-                    stream << argTypes[ai]->describe(extra, contracts, dmodule);
+                    stream << argTypes[ai]->describe(extra, contracts, dmodule, aliasDefs);
                 }
                 stream << ")";
             }
@@ -754,7 +764,7 @@ namespace das
                 if ( argTypes.size() ) {
                     stream << ":";
                 }
-                stream << firstType->describe(extra, contracts, dmodule);
+                stream << firstType->describe(extra, contracts, dmodule, aliasDefs);
             }
             stream << ">";
             if ( argNames.size() && argNames.size()!=argTypes.size() ) {
@@ -769,7 +779,7 @@ namespace das
                         const auto & argName = argNames[ai];
                         if ( !argName.empty() ) stream << argName << ":";
                     }
-                    stream << arg->describe(extra, contracts, dmodule);
+                    stream << arg->describe(extra, contracts, dmodule, aliasDefs);
                     if ( arg != argTypes.back() ) {
                         stream << ";";
                     }
@@ -786,7 +796,7 @@ namespace das
                         const auto & argName = argNames[ai];
                         if ( !argName.empty() ) stream << argName << ":";
                     }
-                    stream << arg->describe(extra, contracts, dmodule);
+                    stream << arg->describe(extra, contracts, dmodule, aliasDefs);
                     if ( arg != argTypes.back() ) {
                         stream << ";";
                     }
@@ -816,7 +826,7 @@ namespace das
         }else {
             stream << das_to_string(baseType);
         }
-        if ( extra==DescribeExtra::yes && baseType!=Type::autoinfer && baseType!=Type::alias && !alias.empty() ) {
+        if ( !aliasDefs && extra==DescribeExtra::yes && baseType!=Type::autoinfer && baseType!=Type::alias && !alias.empty() ) {
             stream << " aka " << alias;
         }
         if ( constant ) {

--- a/tests/typer_errors/_alias_arg_mismatch.das
+++ b/tests/typer_errors/_alias_arg_mismatch.das
@@ -1,0 +1,17 @@
+// Fixture for test_alias_message.das — intentionally fails to compile with an
+// argument-type mismatch whose expected type carries a deep type alias.
+// `_`-prefix keeps dastest from auto-running it; the `expect` directive makes
+// lint skip it (a non-compiling program never reaches the lint passes).
+expect 30341
+
+options gen2
+
+typedef RttiValue = tuple<argname : string; argvalue : variant<tBool : bool; tInt : int; tString : string>>
+
+def take_args(args : array<RttiValue>) {}
+
+[export]
+def main() {
+    var wrong : array<int>
+    take_args(wrong)
+}

--- a/tests/typer_errors/test_alias_message.das
+++ b/tests/typer_errors/test_alias_message.das
@@ -1,0 +1,40 @@
+// Verifies issue #2571: type-mismatch messages print the alias short name and a
+// single `where '<alias> = <def>'` clause instead of expanding the alias inline.
+options gen2
+options no_aot     // invokes the compiler at runtime (compile_file) — not AOT-linkable
+
+require daslib/rtti
+require strings
+require dastest/testing_boost public
+
+
+def compile_issues(file_path : string) : string {
+    var issuesText = ""
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            compile_file(file_path, access, unsafe(addr(mg)), cop) $(_ok, _program, issues) {
+                issuesText := issues
+            }
+        }
+    }
+    return issuesText
+}
+
+
+[test]
+def test_alias_short_name_in_mismatch(t : T?) {
+    t |> run("argument mismatch prints alias short name + where clause") @(t : T?) {
+        let issues = compile_issues("{get_das_root()}/tests/typer_errors/_alias_arg_mismatch.das")
+        // expecting-clause uses the short alias name, not the expanded tuple
+        t |> success(find(issues, "expecting 'array<RttiValue> const'") >= 0,
+            "short alias name in expecting clause")
+        // the alias is defined once in a trailing where clause
+        t |> success(find(issues, "where 'RttiValue = tuple<argname:string;") >= 0,
+            "where clause defines the alias")
+        // the short name must not be doubled with a stray ` aka `
+        t |> success(find(issues, "RttiValue aka RttiValue") < 0,
+            "no doubled `aka` after the short name")
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #2571 — type-mismatch error messages expanded type aliases inline, producing very long, hard-to-read expected/passing types.

`TypeDecl::describe` now takes an optional alias collector plus a `topAlias` flag. When a collector is supplied, each aliased node prints its short alias name and registers the definition once; `describeMismatchingArgument` then emits a single trailing `where '<alias> = <def>'` clause shared across the expecting/passing sides. Default callers pass no collector, so all other type printing — including AOT `aka` comments — is byte-for-byte unchanged.

### Before
```
invalid argument 'args' (0). expecting 'array<tuple<argname:string;argvalue:variant<tBool:bool;tInt:int;tString:string>> aka RttiValue> const', passing 'array<int>& -const'
```

### After
```
invalid argument 'args' (0). expecting 'array<RttiValue> const', passing 'array<int>& -const'
where 'RttiValue = tuple<argname:string;argvalue:variant<tBool:bool;tInt:int;tString:string>>'
```

## Implementation

- `TypeDecl::describe(..., vector<pair<string,string>>* aliasDefs = nullptr, bool topAlias = true)` — when collecting, a resolved node carrying an alias name (`baseType != alias && !alias.empty()`) prints the short name and records its definition once (deduped). The definition is built by recursing with `topAlias = false`, so no node clone is needed.
- The trailing ` aka` suffix is suppressed while collecting (the short name already names the type).
- `describeMismatchingArgument` shares one collector across both `describeType` calls, so an alias used on either side is defined exactly once.

## Testing

- New `tests/typer_errors/test_alias_message.das` (+ `_alias_arg_mismatch.das` fixture) asserts the short name appears, the `where` clause defines the alias, and there is no doubled ` aka `.
- Full suite: 9351 passed, 0 failed, 0 errors, 6 skipped.
- Default `describe()` output verified unchanged (candidate-function signature line still shows the full `aka` expansion).

AOT codegen is unaffected — `describe` feeds human messages only; mangling uses `getMangledName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
