### PR TITLE
linq_das: into continuation (group-into aggregation / select-into; SQL GROUP BY pushdown)

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -3421,7 +3421,9 @@ def select_many_to_array(var src : iterator<auto(TT)>; collection_selector; resu
 [unused_argument(tt)]
 def private select_many_pair_impl(var src; tt : auto(TT); collection_selector; result_selector) : array<typedecl(result_selector(type<TT>, iter_type(collection_selector(type<TT>)))) -const -&> {
     var buffer : array<typedecl(result_selector(type<TT>, iter_type(collection_selector(type<TT>)))) -const -&>
-    // Lower-bound reserve when the outer source is length-bearing — flat-map produces ≥ length(src) elements.
+    // Capacity hint when the outer source is length-bearing — one slot per outer row. The true count is the
+    // sum of the inner collection lengths (so it may be more, or fewer when some inner collections are empty);
+    // `length(src)` is just a reasonable starting capacity that avoids reallocating from zero.
     static_if (typeinfo is_array(src) || typeinfo is_dim(src)) {
         buffer |> reserve(length(src))
     }

--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -109,8 +109,10 @@ def private find_kw_depth0(q : string; kw : string; from : int) : int {
             if (c == '"') { inStr = true; prevSig = c; i++; continue }
             if (c == '(' || c == '[' || c == '{') { depth++; prevSig = c; i++; continue }
             if (c == ')' || c == ']' || c == '}') { depth--; prevSig = c; i++; continue }
-            // a clause keyword is a depth-0 whole word NOT preceded (ignoring whitespace) by `.`
-            let atWordStart = is_ident_byte(c) && ((i == 0) || !is_ident_byte(int(arr[i - 1]))) && prevSig != '.'
+            // A clause keyword is a depth-0 whole word NOT preceded (ignoring whitespace) by `.` (member
+            // access) or `>` (the tail of a pipe `|>`, lambda arrow `=>`, or `->`) — so an aggregate like
+            // `g |> select(...) |> sum` inside an orderby/where body is not mistaken for a `select` clause.
+            let atWordStart = is_ident_byte(c) && ((i == 0) || !is_ident_byte(int(arr[i - 1]))) && prevSig != '.' && prevSig != '>'
             if (depth == 0 && atWordStart && i + m <= n && slice(q, i, i + m) == kw) {
                 if (i + m == n || !is_ident_byte(int(arr[i + m]))) {
                     found = i
@@ -410,9 +412,10 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
         macro_error(prog, at, "linq: at most one 'where' per query is supported")
         return "(0)"
     }
-    // `join … into g` (group-join) and `select … into` continuations are not yet supported.
+    // `into` continuations are supported only on single-source queries in this release. Over a `join` /
+    // second-`from` they are not yet supported (group-join `join … into` is coming).
     if (find_kw_depth0(q, "into", tailStart) >= 0) {
-        macro_error(prog, at, "linq: 'into' continuations (group-join `join … into`, query continuation) are not yet supported")
+        macro_error(prog, at, "linq: 'into' continuations over a 'join' / second 'from' are not yet supported — they work on single-source queries (`from … group … into g select …`); 'join … into' group-join is coming")
         return "(0)"
     }
     let orderByPos = find_kw_depth0(q, "orderby", tailStart)
@@ -560,7 +563,10 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
         // Zero-copy collection selector: `each` borrows the outer's collection — no per-row clone (unlike
         // `to_sequence`, whose const-array overload clones) and no per-row materialize (unlike `where_`'s
         // array overload). An inner-only post-`where` fuses onto the borrowed iterator (the iterator overload
-        // of `where_` stays lazy). `each` outside a for-loop needs the `unsafe` wrap.
+        // of `where_` stays lazy). `each` outside a for-loop needs the `unsafe` wrap. Borrowing a TEMPORARY
+        // tail (e.g. `from x in [c.id]` or a func result) is still safe: daslang heap-allocates arrays and
+        // does NOT auto-finalize on scope exit, so the backing storage outlives the borrow (it is reclaimed
+        // by GC, not at the end of the enclosing expression) — no use-after-free.
         if (postWhere >= 0) {
             srcB = "$({varName}) => unsafe(each({tail})) |> _where($({var2Name}) => {wherePred})"
         } else {
@@ -817,6 +823,226 @@ def private extract_lets(q : string; bodyStart : int; rangeVar : string;
     return (true, "{slice(q, 0, srcEnd)}{body}")
 }
 
+// A2 rewrite for a `group … into g` continuation: the group is a `tuple<key; array<members>>`, so `g.key`
+// addresses the key (`g._0`) and a bare `g` is the member collection (`g._1`). Scans like substitute_idents
+// (string/interpolation aware, member access after `.` skipped), but specialised: a standalone `g` followed
+// by `.key` (a full word) becomes `g._0` (consuming the `.key`); any other standalone `g` becomes `g._1`.
+def private rewrite_group_var(text : string; gname : string) : string {
+    return build_string() $(var w) {
+        peek_data(text) $(arr) {
+            let n = length(arr)
+            var i = 0
+            var inStr = false   // inside a "…" literal (plain content portion)
+            var interp = 0      // brace depth inside a string interpolation (>0 ⇒ code mode within the string)
+            var prevSig = 0     // last significant (non-whitespace) byte, 0 = none
+            while (i < n) {
+                let c = int(arr[i])
+                if (inStr && interp == 0) {
+                    if (c == '\\' && i + 1 < n) { w |> write(slice(text, i, i + 2)); i += 2; continue }
+                    w |> write(slice(text, i, i + 1))
+                    if (c == '"') { inStr = false; prevSig = c }
+                    elif (c == '{') { interp = 1; prevSig = 0 }
+                    i++
+                    continue
+                }
+                if (c == '"') {
+                    if (interp > 0) {
+                        w |> write(slice(text, i, i + 1)); i++
+                        while (i < n) {
+                            let cc = int(arr[i])
+                            if (cc == '\\' && i + 1 < n) { w |> write(slice(text, i, i + 2)); i += 2; continue }
+                            w |> write(slice(text, i, i + 1)); i++
+                            if (cc == '"') break
+                        }
+                        prevSig = '"'
+                        continue
+                    }
+                    inStr = true; prevSig = c; w |> write(slice(text, i, i + 1)); i++
+                    continue
+                }
+                if (interp > 0 && c == '{') { interp ++; w |> write(slice(text, i, i + 1)); prevSig = c; i++; continue }
+                if (interp > 0 && c == '}') {
+                    interp --
+                    w |> write(slice(text, i, i + 1))
+                    prevSig = interp == 0 ? '"' : c
+                    i++
+                    continue
+                }
+                let atWordStart = is_ident_byte(c) && (i == 0 || !is_ident_byte(int(arr[i - 1])))
+                if (atWordStart) {
+                    var j = i
+                    while (j < n && is_ident_byte(int(arr[j]))) { j++ }
+                    let word = slice(text, i, j)
+                    if (prevSig != '.' && word == gname) {
+                        // bare `g` (→ `g._1`) unless followed by `.key` (→ `g._0`).
+                        var keyEnd = -1
+                        if (j < n && int(arr[j]) == '.') {
+                            var k = j + 1
+                            while (k < n && is_ident_byte(int(arr[k]))) { k++ }
+                            if (slice(text, j + 1, k) == "key") { keyEnd = k }
+                        }
+                        if (keyEnd >= 0) {
+                            w |> write("{gname}._0")
+                            i = keyEnd
+                        } else {
+                            w |> write("{gname}._1")
+                            i = j
+                        }
+                        prevSig = '_'   // last emitted token is identifier-like, not a `.`
+                        continue
+                    }
+                    w |> write(word)
+                    prevSig = int(arr[j - 1])
+                    i = j
+                    continue
+                }
+                w |> write(slice(text, i, i + 1))
+                if (!is_white_space(c)) { prevSig = c }
+                i++
+            }
+        }
+    }
+}
+
+// One query stage: `[where] [orderby] (select <proj> | group <var> by <key>) [iterator]`, optionally followed
+// by `into <var>` which begins the next stage (C# query continuation). `rangeVar` binds this stage's rows;
+// `isGroupVar` is true when `rangeVar` came from a prior `group … into` (so its clause text gets the A2 rewrite).
+struct private QueryStage {
+    rangeVar : string = ""
+    isGroupVar : bool = false
+    hasWhere : bool = false
+    predText : string = ""
+    hasOrderBy : bool = false
+    orderKeys : array<string>
+    orderDescMask : uint = 0u
+    isGroup : bool = false
+    groupKey : string = ""
+    projText : string = ""
+    identitySelect : bool = false
+    wantIterator : bool = false
+    intoVar : string = ""       // continuation range variable, "" if this is the terminal stage
+    nextStart : int = 0         // offset just past `into <var>` (start of the next stage)
+}
+
+// Parse one stage of a single-source query starting at `start`, binding `rangeVar`. Fills `stage` (incl. the
+// optional `into` continuation). Returns false (after a macro_error) on a malformed stage.
+def private parse_one_stage(q : string; nq : int; start : int; rangeVar : string; isGroupVar : bool;
+                            prog : ProgramPtr; at : LineInfo; var stage : QueryStage) : bool {
+    stage.rangeVar = rangeVar
+    stage.isGroupVar = isGroupVar
+    // The terminal is the earliest select/group from `start` — found FIRST, independent of where/orderby, so
+    // a LATER stage's `where` (after this stage's `into`) cannot hijack this stage's terminal lookup.
+    let selectPos = find_kw_depth0(q, "select", start)
+    let groupPos = find_kw_depth0(q, "group", start)
+    if (selectPos < 0 && groupPos < 0) {
+        macro_error(prog, at, "linq: query must end with a 'select' or 'group … by …' clause")
+        return false
+    }
+    let isGroup = groupPos >= 0 && (selectPos < 0 || groupPos < selectPos)
+    let termPos = isGroup ? groupPos : selectPos
+    let otherPos = isGroup ? selectPos : groupPos
+    let termKwEnd = isGroup ? termPos + 5 : termPos + 6
+    // An `into` after the terminal ends this stage and begins the next.
+    let intoPos = find_kw_depth0(q, "into", termKwEnd)
+    let termEnd = intoPos >= 0 ? intoPos : nq
+    if (otherPos >= 0 && otherPos < termEnd) {
+        macro_error(prog, at, "linq: query cannot have both 'select' and 'group' — they are alternative terminals")
+        return false
+    }
+    stage.isGroup = isGroup
+    // where / orderby belong to THIS stage only when they precede its terminal (in C# clause order).
+    let wherePos = find_kw_depth0(q, "where", start)
+    stage.hasWhere = wherePos >= 0 && wherePos < termPos
+    let orderByPos = find_kw_depth0(q, "orderby", stage.hasWhere ? wherePos + 5 : start)
+    stage.hasOrderBy = orderByPos >= 0 && orderByPos < termPos
+    if (isGroup && stage.hasOrderBy) {
+        macro_error(prog, at, "linq: 'orderby' before 'group' is not supported — order the groups after a 'select', or drop the 'orderby'")
+        return false
+    }
+    if (stage.hasWhere) {
+        let predText = strip(slice(q, wherePos + 5, stage.hasOrderBy ? orderByPos : termPos))
+        if (predText == "") {
+            macro_error(prog, at, "linq: empty 'where' predicate")
+            return false
+        }
+        stage.predText = isGroupVar ? rewrite_group_var(predText, rangeVar) : predText
+    }
+    if (stage.hasOrderBy) {
+        let rawOrder = strip(slice(q, orderByPos + 7, termPos))
+        var op <- parse_orderby(rawOrder)
+        if (!op.ok) {
+            macro_error(prog, at, "linq: empty 'orderby' expression")
+            return false
+        }
+        if (length(op.keys) > 4) {
+            macro_error(prog, at, "linq: 'orderby' supports at most 4 keys (got {length(op.keys)})")
+            return false
+        }
+        if (isGroupVar) {
+            stage.orderKeys <- [for (k in op.keys); rewrite_group_var(k, rangeVar)]
+        } else {
+            stage.orderKeys <- op.keys
+        }
+        stage.orderDescMask = op.descMask
+    }
+    if (isGroup) {
+        let groupBody = strip(slice(q, termPos + 5, termEnd))
+        let byPos = find_kw_depth0(groupBody, "by", 0)
+        if (byPos < 0) {
+            macro_error(prog, at, "linq: 'group' requires a 'by' clause (e.g. `group {rangeVar} by {rangeVar}.field`)")
+            return false
+        }
+        let elem = strip(slice(groupBody, 0, byPos))
+        if (elem != rangeVar) {
+            macro_error(prog, at, "linq: 'group' element must be the range variable '{rangeVar}' — element selectors are not yet supported (write `group {rangeVar} by …`)")
+            return false
+        }
+        let gk = strip_trailing_keyword(strip(slice(groupBody, byPos + 2, length(groupBody))), "iterator")
+        let groupKey = gk._0
+        stage.wantIterator = gk._1
+        if (groupKey == "") {
+            macro_error(prog, at, "linq: empty 'group … by' key expression")
+            return false
+        }
+        stage.groupKey = isGroupVar ? rewrite_group_var(groupKey, rangeVar) : groupKey
+    } else {
+        let pj = strip_trailing_keyword(strip(slice(q, termPos + 6, termEnd)), "iterator")
+        let projText = pj._0
+        stage.wantIterator = pj._1
+        if (projText == "") {
+            macro_error(prog, at, "linq: empty 'select' projection")
+            return false
+        }
+        stage.identitySelect = (projText == rangeVar)
+        stage.projText = (isGroupVar && !stage.identitySelect) ? rewrite_group_var(projText, rangeVar) : projText
+    }
+    if (intoPos >= 0) {
+        if (stage.wantIterator) {
+            macro_error(prog, at, "linq: 'iterator' must be the final clause — it cannot precede an 'into' continuation")
+            return false
+        }
+        let iv = read_ident(q, intoPos + 4)
+        if (iv._0 == "") {
+            macro_error(prog, at, "linq: 'into' requires a continuation range variable (e.g. `… into g select …`)")
+            return false
+        }
+        if (iv._0 == JOIN_TI) {
+            macro_error(prog, at, "linq: continuation range variable '{JOIN_TI}' is reserved")
+            return false
+        }
+        if (strip(slice(q, iv._1, nq)) == "") {
+            macro_error(prog, at, "linq: 'into {iv._0}' has no continuation — add a 'where'/'orderby'/'select'/'group' after it")
+            return false
+        }
+        stage.intoVar = iv._0
+        stage.nextStart = iv._1
+    } else {
+        stage.intoVar = ""
+        stage.nextStart = nq
+    }
+    return true
+}
+
 // Parse the query and emit the `_fold(...)` rewrite text. On a malformed query, register a macro error
 // and emit a benign `(0)` so the surrounding statement still parses (the error is the real signal).
 def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : string {
@@ -874,111 +1100,48 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
     if (joinPos >= 0) {
         return transpile_join(q, nq, varName, rowType, srcStart, joinPos, prog, at)
     }
-    let wherePos = find_kw_depth0(q, "where", srcStart)
-    let afterWhere = wherePos >= 0 ? wherePos + 5 : srcStart
-    let orderByPos = find_kw_depth0(q, "orderby", afterWhere)
-    let afterOrderBy = orderByPos >= 0 ? orderByPos + 7 : afterWhere
-    let selectPos = find_kw_depth0(q, "select", afterOrderBy)
-    let groupPos = find_kw_depth0(q, "group", afterOrderBy)
-    if (selectPos < 0 && groupPos < 0) {
-        macro_error(prog, at, "linq: query must end with a 'select' or 'group … by …' clause")
-        return "(0)"
-    }
-    if (selectPos >= 0 && groupPos >= 0) {
-        macro_error(prog, at, "linq: query cannot have both 'select' and 'group' — they are alternative terminals")
-        return "(0)"
-    }
-    let isGroup = groupPos >= 0
-    let termPos = isGroup ? groupPos : selectPos
-    // `orderby` before `group` would emit `_order_by |> _group_by_lazy`, which `_fold` does not fuse.
-    if (isGroup && orderByPos >= 0) {
-        macro_error(prog, at, "linq: 'orderby' before 'group' is not supported — order the groups after a 'select', or drop the 'orderby'")
-        return "(0)"
-    }
-    let srcEnd = wherePos >= 0 ? wherePos : (orderByPos >= 0 ? orderByPos : termPos)
+    let srcEnd = next_clause_kw(q, srcStart)
     let srcText = strip(slice(q, srcStart, srcEnd))
     if (srcText == "") {
         macro_error(prog, at, "linq: empty source expression after 'in'")
         return "(0)"
     }
-    let hasWhere = wherePos >= 0
-    var predText = ""
-    if (hasWhere) {
-        predText = strip(slice(q, wherePos + 5, orderByPos >= 0 ? orderByPos : termPos))
-        if (predText == "") {
-            macro_error(prog, at, "linq: empty 'where' predicate")
-            return "(0)"
-        }
-    }
-    // orderby clause (select-terminated only): `<expr> [descending|ascending]`.
-    let hasOrderBy = orderByPos >= 0
-    var orderKeys : array<string>
-    var orderDescMask = 0u
-    if (hasOrderBy) {
-        let rawOrder = strip(slice(q, orderByPos + 7, termPos))
-        var op <- parse_orderby(rawOrder)
-        if (!op.ok) {
-            macro_error(prog, at, "linq: empty 'orderby' expression")
-            return "(0)"
-        }
-        if (length(op.keys) > 4) {
-            macro_error(prog, at, "linq: 'orderby' supports at most 4 keys (got {length(op.keys)})")
-            return "(0)"
-        }
-        orderKeys <- op.keys
-        orderDescMask = op.descMask
-    }
-    // Terminal: select projection, or group element/key.
-    var projText = ""
-    var identitySelect = false
-    var groupKey = ""
-    var wantIterator = false
-    if (isGroup) {
-        // `group <elem> by <key> [iterator]` — element must be the range variable (identity; element
-        // selectors are deferred). The group yields `tuple<key; array<elem>>` per bucket (IGrouping).
-        let groupBody = strip(slice(q, termPos + 5, nq))
-        let byPos = find_kw_depth0(groupBody, "by", 0)
-        if (byPos < 0) {
-            macro_error(prog, at, "linq: 'group' requires a 'by' clause (e.g. `group {varName} by {varName}.field`)")
-            return "(0)"
-        }
-        let elem = strip(slice(groupBody, 0, byPos))
-        if (elem != varName) {
-            macro_error(prog, at, "linq: 'group' element must be the range variable '{varName}' — element selectors are not yet supported (write `group {varName} by …`)")
-            return "(0)"
-        }
-        let gk = strip_trailing_keyword(strip(slice(groupBody, byPos + 2, length(groupBody))), "iterator")
-        groupKey = gk._0
-        wantIterator = gk._1
-        if (groupKey == "") {
-            macro_error(prog, at, "linq: empty 'group … by' key expression")
-            return "(0)"
-        }
-    } else {
-        let pj = strip_trailing_keyword(strip(slice(q, termPos + 6, nq)), "iterator")
-        projText = pj._0
-        wantIterator = pj._1
-        if (projText == "") {
-            macro_error(prog, at, "linq: empty 'select' projection")
-            return "(0)"
-        }
-        // `select c` (the range variable alone) is the identity projection — no `_select` is emitted.
-        identitySelect = (projText == varName)
-    }
     let srcBuild = build_src(rowType, srcText, true)
+    // Parse the stage chain. Each stage ends in select/group; an `into <var>` continuation rebinds a new
+    // range variable to that stage's output and appends more clauses on the SAME `_fold` chain (no
+    // inter-stage materialization — fusion and the SQL single-statement pushdown are preserved).
+    var stages : array<QueryStage>
+    var curVar = varName
+    var curIsGroup = false
+    var pstart = srcEnd
+    while (true) {
+        var stage <- QueryStage()
+        if (!parse_one_stage(q, nq, pstart, curVar, curIsGroup, prog, at, stage)) { return "(0)" }
+        let contVar = stage.intoVar
+        let contStart = stage.nextStart
+        let contIsGroup = stage.isGroup
+        stages |> emplace(stage)
+        if (contVar == "") { break }
+        curVar = contVar
+        curIsGroup = contIsGroup
+        pstart = contStart
+    }
+    let wantIterator = stages[length(stages) - 1].wantIterator
     return build_string() $(var writer) {
         writer |> write("( _fold( {srcBuild}")
-        if (hasWhere) {
-            writer |> write(" |> _where($({varName}) => {predText})")
-        }
-        if (isGroup) {
-            writer |> write(" |> _group_by_lazy($({varName}) => {groupKey})")
-        } else {
-            if (hasOrderBy) {
-                writer |> write(emit_order_op(orderKeys, orderDescMask, varName))
+        for (s in stages) {
+            if (s.hasWhere) {
+                writer |> write(" |> _where($({s.rangeVar}) => {s.predText})")
             }
-            if (!identitySelect) {
-                writer |> write(" |> _select($({varName}) => {projText})")
+            if (s.isGroup) {
+                writer |> write(" |> _group_by_lazy($({s.rangeVar}) => {s.groupKey})")
+            } else {
+                if (s.hasOrderBy) {
+                    writer |> write(emit_order_op(s.orderKeys, s.orderDescMask, s.rangeVar))
+                }
+                if (!s.identitySelect) {
+                    writer |> write(" |> _select($({s.rangeVar}) => {s.projText})")
+                }
             }
         }
         writer |> write(" |> to_array() )")

--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -878,9 +878,12 @@ def private rewrite_group_var(text : string; gname : string) : string {
                     while (j < n && is_ident_byte(int(arr[j]))) { j++ }
                     let word = slice(text, i, j)
                     if (prevSig != '.' && word == gname) {
-                        // bare `g` (→ `g._1`) unless followed by `.key` (→ `g._0`).
+                        // `g.key` → `g._0`; truly bare `g` → `g._1` (the members array). Any other `g.<member>`
+                        // (explicit `g._0` / `g._1`, or an invalid `g.foo`) is left untouched so raw tuple access
+                        // keeps working and invalid members error naturally — never rewrite `g._0` into `g._1._0`.
+                        let dotFollows = j < n && int(arr[j]) == '.'
                         var keyEnd = -1
-                        if (j < n && int(arr[j]) == '.') {
+                        if (dotFollows) {
                             var k = j + 1
                             while (k < n && is_ident_byte(int(arr[k]))) { k++ }
                             if (slice(text, j + 1, k) == "key") { keyEnd = k }
@@ -888,12 +891,15 @@ def private rewrite_group_var(text : string; gname : string) : string {
                         if (keyEnd >= 0) {
                             w |> write("{gname}._0")
                             i = keyEnd
-                        } else {
+                            prevSig = '_'   // last emitted token is identifier-like, not a `.`
+                            continue
+                        } elif (!dotFollows) {
                             w |> write("{gname}._1")
                             i = j
+                            prevSig = '_'
+                            continue
                         }
-                        prevSig = '_'   // last emitted token is identifier-like, not a `.`
-                        continue
+                        // g.<member> other than .key: fall through, leave the explicit access intact.
                     }
                     w |> write(word)
                     prevSig = int(arr[j - 1])

--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -96,29 +96,33 @@ def private find_kw_depth0(q : string; kw : string; from : int) : int {
         let n = length(arr)
         var depth = 0
         var inStr = false
-        var prevSig = 0   // last significant (non-whitespace) byte, 0 = none
+        var prevSig = 0    // last significant (non-whitespace) byte, 0 = none
+        var prevSig2 = 0   // significant byte before prevSig — disambiguates a `>` tail
         var i = from
         while (i < n && found < 0) {
             let c = int(arr[i])
             if (inStr) {
                 if (c == '\\') { i += 2; continue }
-                if (c == '"') { inStr = false; prevSig = c }
+                if (c == '"') { inStr = false; prevSig2 = prevSig; prevSig = c }
                 i++
                 continue
             }
-            if (c == '"') { inStr = true; prevSig = c; i++; continue }
-            if (c == '(' || c == '[' || c == '{') { depth++; prevSig = c; i++; continue }
-            if (c == ')' || c == ']' || c == '}') { depth--; prevSig = c; i++; continue }
-            // A clause keyword is a depth-0 whole word NOT preceded (ignoring whitespace) by `.` (member
-            // access) or `>` (the tail of a pipe `|>`, lambda arrow `=>`, or `->`) — so an aggregate like
-            // `g |> select(...) |> sum` inside an orderby/where body is not mistaken for a `select` clause.
-            let atWordStart = is_ident_byte(c) && ((i == 0) || !is_ident_byte(int(arr[i - 1]))) && prevSig != '.' && prevSig != '>'
+            if (c == '"') { inStr = true; prevSig2 = prevSig; prevSig = c; i++; continue }
+            if (c == '(' || c == '[' || c == '{') { depth++; prevSig2 = prevSig; prevSig = c; i++; continue }
+            if (c == ')' || c == ']' || c == '}') { depth--; prevSig2 = prevSig; prevSig = c; i++; continue }
+            // A clause keyword is a depth-0 whole word NOT preceded (ignoring whitespace) by `.` (member access)
+            // or by a `>` that is the tail of a pipe `|>` / lambda arrow `=>` / `->` — so an aggregate like
+            // `g |> select(...) |> sum` inside an orderby/where body is not mistaken for a `select` clause. A `>`
+            // from a type/generic bracket (`default<int>`, `type<Foo>`) or comparison is NOT excluded, so a
+            // clause keyword that legitimately follows one (e.g. `let d = default<int> select …`) still matches.
+            let afterPipeTail = prevSig == '>' && (prevSig2 == '|' || prevSig2 == '=' || prevSig2 == '-')
+            let atWordStart = is_ident_byte(c) && ((i == 0) || !is_ident_byte(int(arr[i - 1]))) && prevSig != '.' && !afterPipeTail
             if (depth == 0 && atWordStart && i + m <= n && slice(q, i, i + m) == kw) {
                 if (i + m == n || !is_ident_byte(int(arr[i + m]))) {
                     found = i
                 }
             }
-            if (!is_white_space(c)) { prevSig = c }
+            if (!is_white_space(c)) { prevSig2 = prevSig; prevSig = c }
             i++
         }
     }

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -32,9 +32,12 @@ Clauses
 A query is ``from <var> [ : <Row> ] in <src> [ where <pred> ] [ ( join <var2>
 [ : <Row2> ] in <src2> on <keyA> equals <keyB> | from <var2> [ : <Row2> ] in
 <src2> ) ] [ where <pred> ] [ orderby <expr> [ascending|descending] (, <expr> [ascending|descending])* ] ( select <proj> |
-group <var> by <key> ) [ iterator ]`` — a second range variable comes from
-**either** a ``join`` **or** a second ``from`` (never both), and at most one of
-the two ``where`` slots may appear (before *or* after that clause, never both).
+group <var> by <key> ) [ into <var> <continuation> ] [ iterator ]`` — a second
+range variable comes from **either** a ``join`` **or** a second ``from`` (never
+both), and at most one of the two ``where`` slots may appear (before *or* after
+that clause, never both). A trailing ``into <var>`` rebinds the stage's output to
+a new range variable and the query continues from there (see
+:ref:`linq_das_into`); ``into`` is supported on **single-source** queries.
 Separately, a ``let <name> = <expr>`` binding may appear **any number of times
 between body clauses** — it is inlined away before the rest is parsed (see
 :ref:`linq_das_let`):
@@ -59,8 +62,11 @@ between body clauses** — it is inlined away before the rest is parsed (see
   the rows unchanged; any other projection emits ``_select(...)``.
 - ``group <var> by <key>`` — the alternative terminal to ``select`` (see
   :ref:`linq_das_grouping`).
+- ``into <var>`` — optional query continuation after the terminal: rebinds the
+  prior stage's output to ``<var>`` and continues with more clauses, all on the
+  same fused chain (see :ref:`linq_das_into`).
 
-A query ends with **either** ``select`` **or** ``group … by`` — exactly one.
+Each stage ends with **either** ``select`` **or** ``group … by`` — exactly one.
 Clauses may span multiple lines inside the ``%linq! … %%`` body.
 
 Sources
@@ -228,17 +234,65 @@ the group's elements as ``._1``:
         print("{g._0}: {g._1 |> length} cars\n")   // key, then count of that bucket
     }
 
-A ``where`` may precede the ``group``; ``orderby`` may not (ordering the groups
-needs the deferred ``into`` continuation). The group element must be the range
-variable (``group c by …``) — element selectors are not yet supported.
+A ``where`` may precede the ``group``; ``orderby`` may not directly (order the
+groups in an ``into`` continuation instead — see :ref:`linq_das_into`). The group
+element must be the range variable (``group c by …``) — element selectors are not
+yet supported.
 
-**Grouping is an in-memory feature** (array / decs / XML). Over a **SQL** source
-it is rejected at compile time: SQL ``GROUP BY`` has no all-rows-per-group form,
-only aggregates. Use the aggregate pipe form for SQL grouping —
-``db |> select_from(type<Car>) |> _group_by(_.brand) |> _select((B = _._0, N = _._1 |> count())) |> _sql()``
-— until the ``group … into`` continuation lands. (Over decs these minimal
-``orderby`` / ``group`` chains currently materialize rather than fuse — correct,
-but a ``_fold`` perf advisory fires; a decs-adapter gap, not a query-syntax one.)
+A **bare** ``group … by`` (no continuation) keeps the whole ``(key, [rows])``
+group, so it is an **in-memory feature** (array / decs / XML); over a **SQL**
+source it is rejected (SQL ``GROUP BY`` has no all-rows-per-group form). To
+aggregate per group — the common case — add an ``into`` continuation
+(``group c by k into g select (…, g |> length, g |> select(…) |> sum)``), which
+**does** push down to SQL ``GROUP BY`` (see :ref:`linq_das_into`). (Over decs
+these minimal ``orderby`` / ``group`` chains currently materialize rather than
+fuse — correct, but a ``_fold`` perf advisory fires; a decs-adapter gap, not a
+query-syntax one.)
+
+.. _linq_das_into:
+
+Query continuation (``into``)
+-----------------------------
+
+``into <var>`` rebinds the prior stage's output to a new range variable and
+continues the query with more clauses — all on the **same** fused ``_fold``
+chain, with no materialization between stages. It is supported on single-source
+queries. C# uses it for grouped aggregation and to chain query stages.
+
+**Group continuation** — after ``group c by k into g``, the new range variable
+``g`` is the group. With the *A2* convention, ``g.key`` is the key and a bare
+``g`` is the member collection:
+
+.. code-block:: das
+
+    var report <- %linq! from c in cars
+                         group c by c.brand into g
+                         select (brand = g.key,
+                                 count = g |> length,
+                                 total = g |> select($(u : Car) => u.price) |> sum) %%
+
+A continuation may itself contain ``where`` / ``orderby`` / ``select`` / ``group``
+over the groups — e.g. ``where g |> length > 1`` (drop singleton buckets) or
+``orderby g |> select($(u : Car) => u.price) |> sum descending`` (order buckets by
+total).
+
+**Select continuation** — ``select <proj> into n`` rebinds the projected value to
+``n`` and continues:
+
+.. code-block:: das
+
+    var kept <- %linq! from c in cars select c.price into p where p > 100 select p %%
+
+Continuations chain (``… into x … into y …``), so a query can group, aggregate,
+then filter/order the aggregated rows in one fused pass.
+
+**SQL pushdown.** A group continuation whose select is **aggregate-only** —
+``g.key`` plus ``g |> length`` (→ ``COUNT(*)``), ``g |> select(…) |> sum/average/min/max``
+(→ ``SUM/AVG/MIN/MAX``), or ``g |> first()`` — pushes down to a SQL ``GROUP BY``
+over a SQL source, exactly like the hand-written ``_group_by`` pipe form. A
+**member-keeping** continuation (identity ``select g``, which keeps the whole
+``(key, [rows])`` group) has no SQL form and is **in-memory only** (array / decs /
+XML) — over a SQL source it is rejected, like a bare ``group … by``.
 
 .. _linq_das_join:
 

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -84,6 +84,7 @@ introduced in earlier tutorials.
    tutorials/53_clargs.rst
    tutorials/54_glob.rst
    tutorials/55_linq_decs.rst
+   tutorials/56_linq_query.rst
 
 .. _tutorials_building_from_sdk:
 

--- a/doc/source/reference/tutorials/55_linq_decs.rst
+++ b/doc/source/reference/tutorials/55_linq_decs.rst
@@ -153,3 +153,5 @@ live in ``benchmarks/sql/results.md`` in the source tree.
    Full source: :download:`tutorials/language/55_linq_decs.das <../../../../tutorials/language/55_linq_decs.das>`
 
    Previous tutorial: :ref:`tutorial_glob`
+
+   Next tutorial: :ref:`tutorial_linq_query`

--- a/doc/source/reference/tutorials/56_linq_query.rst
+++ b/doc/source/reference/tutorials/56_linq_query.rst
@@ -1,0 +1,131 @@
+.. _tutorial_linq_query:
+
+==========================================
+C#-style LINQ query syntax (``%linq!``)
+==========================================
+
+.. index::
+    single: Tutorial; LINQ query syntax
+    single: Tutorial; linq_das
+    single: Tutorial; query continuation
+    single: Tutorial; group into
+
+This tutorial covers ``daslib/linq_das`` — the ``%linq! ... %%`` reader macro
+that adds a C#-like query-expression form on top of the ``_fold`` engine. A
+query is a purely compile-time rewrite into a fused ``_fold(...)`` chain, so it
+costs nothing over the hand-written pipe form, and the same query runs over
+arrays, decs, SQL, and XML.
+
+It assumes you have read :ref:`tutorial_linq` (the pipe-form linq surface and the
+``_fold`` macro). The full clause grammar and per-source details live in the
+:ref:`linq_das` reference page.
+
+from / where / select
+=====================
+
+The range variable (``c``) is spliced verbatim as the lambda parameter.
+``select c`` (the variable alone) is the identity projection; any other
+projection emits a ``_select``.
+
+.. code-block:: das
+
+    let names <- %linq! from c in cars where c.price > 100 select c.name %%
+    print("expensive: {names}\n")
+    // output: expensive: [ m3, a4, a8]
+
+orderby (multi-key)
+===================
+
+Comma-separated keys, each with its own optional ``ascending`` / ``descending``.
+More than one key emits a single composite stable sort.
+
+.. code-block:: das
+
+    let sorted <- %linq! from c in cars orderby c.brand, c.price descending
+                         select (b = c.brand, p = c.price) %%
+    // audi 400, audi 200, bmw 250, bmw 100, kia 50
+
+group ... by  (IGrouping)
+=========================
+
+A bare ``group c by k`` yields one ``(key, [members])`` tuple per bucket. Read
+the key as ``._0`` and the members as ``._1``.
+
+.. code-block:: das
+
+    let buckets <- %linq! from c in cars group c by c.brand %%
+    for (g in buckets) {
+        print("{g._0}: {g._1 |> length} cars\n")
+    }
+
+group ... into g ... select  (grouped aggregation)
+==================================================
+
+``into g`` rebinds the group to a new range variable and continues the query.
+With the *A2* convention ``g.key`` is the bucket key and a bare ``g`` is the
+member collection, so the familiar LINQ aggregates read naturally. This is the
+canonical C# grouped-aggregation idiom, and over a SQL source it pushes straight
+down to ``GROUP BY`` + ``COUNT/SUM/AVG/...``.
+
+.. code-block:: das
+
+    let report <- %linq! from c in cars
+                         group c by c.brand into g
+                         select (brand = g.key,
+                                 count = g |> length,
+                                 total = g |> select($(u : Car) => u.price) |> sum) %%
+    // audi: count=2 total=600 ; kia: count=1 total=50 ; bmw: count=2 total=350
+
+The continuation may itself filter / order the groups:
+
+.. code-block:: das
+
+    let bigBrands <- %linq! from c in cars
+                            group c by c.brand into g
+                            where g |> length > 1
+                            orderby g |> select($(u : Car) => u.price) |> sum descending
+                            select g.key %%
+    // output: [ audi, bmw]
+
+select ... into n  (projection continuation)
+============================================
+
+``select <proj> into n`` rebinds the projected value. Continuations chain, so a
+query can project, filter, then re-order, all fused on one pass with no
+intermediate array.
+
+.. code-block:: das
+
+    let dear <- %linq! from c in cars
+                       select c.price into p
+                       where p >= 200
+                       orderby p descending
+                       select p %%
+    // output: [ 400, 250, 200]
+
+let bindings and join
+=====================
+
+``let`` introduces a computed value reused downstream (inlined at compile time).
+``join ... on ... equals ...`` is a single inner equi-join introducing a second
+range variable.
+
+.. code-block:: das
+
+    let located <- %linq! from c in cars join h in hqs on c.brand equals h.brand
+                          select (car = c.name, country = h.country) %%
+
+.. seealso::
+
+   :ref:`linq_das` — the full ``%linq!`` clause grammar, the four sources, and
+   the aggregate-vs-member-keeping rules for ``into`` over SQL.
+
+   :doc:`/reference/linq_fold_patterns` — catalog of chain shapes that ``_fold``
+   recognizes, and the splice arm each one fires.
+
+   :ref:`tutorial_linq` — the underlying pipe-form linq surface and the
+   ``_fold`` macro.
+
+   Full source: :download:`tutorials/language/56_linq_query.das <../../../../tutorials/language/56_linq_query.das>`
+
+   Previous tutorial: :ref:`tutorial_linq_decs`

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -1765,7 +1765,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             let dr = maybe_divert(q, PHASE_ORDER_BY, node, prog, at)
             if (dr != 0) return dr > 0
             if (q.seenOrderBy) {
-                macro_error(prog, at, "_sql: ordering can appear at most once in the chain (use `_order_by_keys((_.k1, _.k2), mask)` for mixed directions, or `_order_by((_.k1, _.k2))` for all-ascending multi-column)")
+                macro_error(prog, at, "_sql: ordering can appear at most once in the chain (use `_order_by_keys((_.k1, _.k2), mask)` for mixed directions, `_order_by((_.k1, _.k2))` for all-ascending, or `_order_by_descending((_.k1, _.k2))` for all-descending multi-column)")
                 return false
             }
             var body = peel_lambda_single_return(obCall.arguments[1])
@@ -1786,7 +1786,7 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             let dr = maybe_divert(q, PHASE_ORDER_BY, node, prog, at)
             if (dr != 0) return dr > 0
             if (q.seenOrderBy) {
-                macro_error(prog, at, "_sql: ordering can appear at most once in the chain (use `_order_by_keys((_.k1, _.k2), mask)` for mixed directions, or `_order_by((_.k1, _.k2))` for all-ascending multi-column)")
+                macro_error(prog, at, "_sql: ordering can appear at most once in the chain (use `_order_by_keys((_.k1, _.k2), mask)` for mixed directions, `_order_by((_.k1, _.k2))` for all-ascending, or `_order_by_descending((_.k1, _.k2))` for all-descending multi-column)")
                 return false
             }
             var body = peel_lambda_single_return(odCall.arguments[1])

--- a/tests/dasSQLITE/failed_linq_das_sql.das
+++ b/tests/dasSQLITE/failed_linq_das_sql.das
@@ -3,7 +3,8 @@ options gen2
 // linq_das `group c by k` over a SQL source. C# `group … by` (no `into`) means IGrouping = all rows
 // per group; SQL has no such form (a bare GROUP BY returns one arbitrary row per group, a different
 // shape). `_sql` rejects the bare `_group_by` the reader emits — use an aggregate pipe form, or an
-// in-memory source. One macro_error (50503), no cascade (the `_sql` macro returns null cleanly).
+// in-memory source. Two such rejects below (bare-group + member-keeping); each is a single
+// macro_error (50503), no cascade (the `_sql` macro returns null cleanly).
 expect 50503   // bare `group … by` (no continuation) over SQL
 // A `group … into g` continuation that KEEPS the members (identity `select g` — the whole `(key, [rows])`
 // group) has no SQL form either: SQL returns flat rows, not arrays-per-row. It lowers to the same bare

--- a/tests/dasSQLITE/failed_linq_das_sql.das
+++ b/tests/dasSQLITE/failed_linq_das_sql.das
@@ -4,7 +4,11 @@ options gen2
 // per group; SQL has no such form (a bare GROUP BY returns one arbitrary row per group, a different
 // shape). `_sql` rejects the bare `_group_by` the reader emits — use an aggregate pipe form, or an
 // in-memory source. One macro_error (50503), no cascade (the `_sql` macro returns null cleanly).
-expect 50503
+expect 50503   // bare `group … by` (no continuation) over SQL
+// A `group … into g` continuation that KEEPS the members (identity `select g` — the whole `(key, [rows])`
+// group) has no SQL form either: SQL returns flat rows, not arrays-per-row. It lowers to the same bare
+// `_group_by_lazy` and rejects identically. Aggregate continuations DO push down (see the test file).
+expect 50503   // group-into member-keeping (identity `select g`) over SQL
 
 require daslib/linq_das
 require daslib/sql
@@ -22,6 +26,15 @@ def trigger() {
     with_sqlite(":memory:") $(db) {
         db |> create_table(type<Car>)
         let g <- %linq! from c : Car in db group c by c.brand %%
+        unused(g)
+    }
+}
+
+def trigger_group_into_member_keeping() {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Car>)
+        // identity `select grp` keeps the whole `(key, [rows])` group — no SQL form
+        let g <- %linq! from c : Car in db group c by c.brand into grp select grp %%
         unused(g)
     }
 }

--- a/tests/dasSQLITE/test_linq_das_sql.das
+++ b/tests/dasSQLITE/test_linq_das_sql.das
@@ -106,8 +106,10 @@ def test_sql_orderby_multi_key(t : T?) {
     }
 }
 
-// ===== join over SQL — select-terminal + pre-join where push down (post-join transparent-id is the
-// documented boundary: it would carry a whole-row tuple `_sql` rejects; see failed_linq_das_sql.das) =====
+// ===== group … into g … select (grouped aggregation) over SQL — the reader emits the canonical
+// `_group_by_lazy |> _select((_._0, _._1 |> agg))` shape, which `_sql` pushes down to GROUP BY +
+// aggregate columns (no in-memory step). Member-keeping / non-SQL aggregates reject (see
+// failed_linq_das_sql.das). The fixture reuses JCar below — brand "de" repeats. =====
 
 [sql_table(name = "JCars")]
 struct JCar {
@@ -116,6 +118,44 @@ struct JCar {
     brand : string
     price : int
 }
+
+[test]
+def test_sql_group_into_aggregate(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        join_fixture(db)
+        // group by brand: de {BMW 100, Audi 200} → n=2 total=300 ; us {Tesla 300} → n=1 total=300
+        let rep <- %linq! from c : JCar in db
+                          group c by c.brand into g
+                          select (brand = g.key, n = g |> length, total = g |> select($(u : JCar) => u.price) |> sum) %%
+        // parity with the hand-written grouped-aggregate _sql chain
+        let ref <- _fold(db |> select_from(type<JCar>)
+            |> _group_by(_.brand)
+            |> _select((brand = _._0, n = _._1 |> length, total = _._1 |> select($(u : JCar) => u.price) |> sum)))
+        t |> equal(length(rep), 2, "two brand buckets")
+        t |> equal(length(rep), length(ref), "linq_das group-into ≡ hand-written grouped-aggregate _sql chain")
+        for (r in rep) {
+            if (r.brand == "de") { t |> equal(r.n, 2); t |> equal(r.total, 300) }
+            if (r.brand == "us") { t |> equal(r.n, 1); t |> equal(r.total, 300) }
+        }
+    }
+}
+
+[test]
+def test_sql_group_into_emits_group_by(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        join_fixture(db)
+        // confirm the reader's emit shape pushes down to a SQL GROUP BY (not an in-memory group)
+        let sqlText = _sql_text(db |> select_from(type<JCar>)
+            |> _group_by(_.brand)
+            |> _select((brand = _._0, n = _._1 |> length, total = _._1 |> select($(u : JCar) => u.price) |> sum)) |> to_array())
+        t |> success(sqlText |> find("GROUP BY") >= 0, "SQL: {sqlText}")
+        t |> success(sqlText |> find("COUNT(*)") >= 0, "COUNT pushed down: {sqlText}")
+        t |> success(sqlText |> find("SUM(\"price\")") >= 0, "SUM pushed down: {sqlText}")
+    }
+}
+
+// ===== join over SQL — select-terminal + pre-join where push down (post-join transparent-id is the
+// documented boundary: it would carry a whole-row tuple `_sql` rejects; see failed_linq_das_sql.das) =====
 
 [sql_table(name = "JBrands")]
 struct JBrand {

--- a/tests/linq/failed_linq_das.das
+++ b/tests/linq/failed_linq_das.das
@@ -29,6 +29,10 @@ expect 50503   // let: binding reuses the second range variable (a `let` after t
 expect 50503   // let: binding reuses the second range variable (a `let` before the join)
 expect 50503   // orderby: more than 4 keys (eager less_masked caps at 4-arity)
 expect 50503   // orderby: a direction-only segment (no key expression)
+expect 50503   // into: missing continuation range variable
+expect 50503   // into: `into <id>` with no following clause (continuation is empty)
+expect 50503   // into: continuation range var collides with the reserved transparent-id name
+expect 50503   // into: trailing `iterator` cannot precede an `into` continuation
 
 require daslib/linq_das
 require strings
@@ -226,5 +230,32 @@ def trigger_orderby_direction_only_segment() {
     var cars <- one_car()
     // a comma segment that is only a direction keyword has no key expression
     let x <- %linq! from c in cars orderby c.price, descending select c %%
+    unused(x)
+}
+
+def trigger_into_missing_var() {
+    var cars <- one_car()
+    // `into` with no continuation range variable
+    let x <- %linq! from c in cars select c.name into %%
+    unused(x)
+}
+
+def trigger_into_no_continuation() {
+    var cars <- one_car()
+    // `into n` with nothing after it — the continuation is empty
+    let x <- %linq! from c in cars select c.name into n %%
+    unused(x)
+}
+
+def trigger_into_reserved_var_name() {
+    var cars <- one_car()
+    let x <- %linq! from c in cars select c.name into linq_join_ti select linq_join_ti %%
+    unused(x)
+}
+
+def trigger_into_iterator_before_into() {
+    var cars <- one_car()
+    // a trailing `iterator` must be the final clause, not before an `into`
+    let x <- %linq! from c in cars select c.name iterator into n select n %%
     unused(x)
 }

--- a/tests/linq/test_linq_das_into.das
+++ b/tests/linq/test_linq_das_into.das
@@ -1,0 +1,211 @@
+options gen2
+options rtti
+// decs group/orderby chains fall to the tier-2 materialize path (no dedicated decs splice arm) and emit a
+// cosmetic `_fold` perf advisory — suppress it here (a decs-fold gap, not a linq_das issue).
+options _no_linq_perf_warn = true
+
+require dastest/testing_boost public
+require daslib/linq_das
+require daslib/decs_boost
+require daslib/linq
+require daslib/linq_boost
+require daslib/linq_fold
+
+// linq_das query continuation (`into`): `group c by k into g …` rebinds the group `g` (A2: `g.key` is the
+// key, a bare `g` is the member collection), and `select p into n …` rebinds the projected value. Both
+// continue on the SAME `_fold` chain. Array + decs sources here; SQL parity lives in tests/dasSQLITE.
+
+struct Car {
+    name  : string
+    price : int
+    brand : string
+}
+
+def private mk_cars() : array<Car> {
+    return <- [Car(name = "cheap", price = 50,  brand = "eco"),
+               Car(name = "mid",   price = 150, brand = "eco"),
+               Car(name = "lux",   price = 300, brand = "lux")]
+}
+
+[decs_template(prefix = "ld_")]
+struct CarComp {
+    name  : string
+    price : int
+    brand : string
+}
+
+def private seed_decs() {
+    restart()
+    for (i in range(3)) {
+        create_entity() @(eid, cmp) {
+            cmp.eid := eid
+            cmp.ld_name := "car{i}"
+            cmp.ld_price := 100 * (i + 1)        // 100, 200, 300
+            cmp.ld_brand := i < 2 ? "a" : "b"    // a, a, b
+        }
+    }
+    commit()
+}
+
+// ===== group … into g … select  (grouped aggregation) =====
+
+[test]
+def test_group_into_aggregate(t : T?) {
+    let cars <- mk_cars()
+    let rep <- %linq! from c in cars
+                      group c by c.brand into g
+                      select (brand = g.key,
+                              n     = g |> length,
+                              total = g |> select($(u : Car) => u.price) |> sum,
+                              lo    = g |> select($(u : Car) => u.price) |> min,
+                              hi    = g |> select($(u : Car) => u.price) |> max) %%
+    t |> equal(length(rep), 2, "two brand buckets")
+    for (r in rep) {
+        if (r.brand == "eco") {
+            t |> equal(r.n, 2, "eco count")
+            t |> equal(r.total, 200, "eco total 50+150")
+            t |> equal(r.lo, 50)
+            t |> equal(r.hi, 150)
+        }
+        if (r.brand == "lux") {
+            t |> equal(r.n, 1, "lux count")
+            t |> equal(r.total, 300)
+            t |> equal(r.lo, 300)
+            t |> equal(r.hi, 300)
+        }
+    }
+}
+
+[test]
+def test_group_into_average(t : T?) {
+    let cars <- mk_cars()
+    let rep <- %linq! from c in cars
+                      group c by c.brand into g
+                      select (brand = g.key, avg = g |> select($(u : Car) => u.price) |> average) %%
+    for (r in rep) {
+        if (r.brand == "eco") { t |> equal(r.avg, 100.0lf, "eco avg (50+150)/2") }
+        if (r.brand == "lux") { t |> equal(r.avg, 300.0lf, "lux avg") }
+    }
+}
+
+[test]
+def test_group_into_where_on_groups(t : T?) {
+    let cars <- mk_cars()
+    // keep only buckets with >1 member → just eco
+    let rep <- %linq! from c in cars
+                      group c by c.brand into g
+                      where g |> length > 1
+                      select (brand = g.key, n = g |> length) %%
+    t |> equal(length(rep), 1, "only multi-member buckets survive")
+    t |> equal(rep[0].brand, "eco")
+    t |> equal(rep[0].n, 2)
+}
+
+[test]
+def test_group_into_orderby_on_groups(t : T?) {
+    let cars <- mk_cars()
+    // order buckets by their total, descending → lux(300) before eco(200)
+    let rep <- %linq! from c in cars
+                      group c by c.brand into g
+                      orderby g |> select($(u : Car) => u.price) |> sum descending
+                      select (brand = g.key, total = g |> select($(u : Car) => u.price) |> sum) %%
+    t |> equal(length(rep), 2)
+    t |> equal(rep[0].brand, "lux", "highest total first")
+    t |> equal(rep[1].brand, "eco")
+}
+
+[test]
+def test_group_into_member_keeping_identity(t : T?) {
+    let cars <- mk_cars()
+    // `select g` is the identity continuation — yields the group tuples (key, members) unchanged.
+    let rep <- %linq! from c in cars group c by c.brand into g select g %%
+    t |> equal(length(rep), 2)
+    for (g in rep) {
+        if (g._0 == "eco") { t |> equal(length(g._1), 2) }
+        if (g._0 == "lux") { t |> equal(length(g._1), 1) }
+    }
+}
+
+[test]
+def test_group_into_pre_where(t : T?) {
+    let cars <- mk_cars()
+    // a pre-group `where` filters rows before grouping; the continuation aggregates the survivors.
+    let rep <- %linq! from c in cars
+                      where c.price >= 150
+                      group c by c.brand into g
+                      select (brand = g.key, n = g |> length) %%
+    t |> equal(length(rep), 2, "mid→eco, lux→lux: one each")
+    for (r in rep) { t |> equal(r.n, 1) }
+}
+
+// ===== select … into n … (projection continuation) =====
+
+[test]
+def test_select_into_then_where(t : T?) {
+    let cars <- mk_cars()
+    let rep <- %linq! from c in cars
+                      select c.price into p
+                      where p > 100
+                      select p %%
+    t |> equal(length(rep), 2, "prices 150, 300 survive p>100")
+    t |> equal(rep[0], 150)
+    t |> equal(rep[1], 300)
+}
+
+[test]
+def test_select_into_orderby(t : T?) {
+    let cars <- mk_cars()
+    let rep <- %linq! from c in cars
+                      select c.price into p
+                      orderby p descending
+                      select p %%
+    t |> equal(rep[0], 300, "descending by projected value")
+    t |> equal(rep[2], 50)
+}
+
+[test]
+def test_multi_stage_group_then_project_then_filter(t : T?) {
+    let cars <- mk_cars()
+    // 3 stages: group → aggregate → filter+order the aggregated rows.
+    let rep <- %linq! from c in cars
+                      group c by c.brand into g
+                      select (brand = g.key, total = g |> select($(u : Car) => u.price) |> sum) into agg
+                      where agg.total > 100
+                      orderby agg.total descending
+                      select agg.brand %%
+    t |> equal(length(rep), 2)
+    t |> equal(rep[0], "lux", "lux total 300 first")
+    t |> equal(rep[1], "eco")
+}
+
+[test]
+def test_group_into_iterator_output(t : T?) {
+    let cars <- mk_cars()
+    var n = 0
+    for (_r in %linq! from c in cars group c by c.brand into g select (brand = g.key, n = g |> length) iterator %%) { n++ }
+    t |> equal(n, 2, "iterator over the aggregated buckets")
+}
+
+// ===== decs source =====
+
+[test]
+def test_decs_group_into_aggregate(t : T?) {
+    seed_decs()
+    // count per brand bucket via the group continuation (a/a/b → a:2, b:1).
+    let rep <- %linq! from c : CarComp in decs group c by c.brand into g select (brand = g.key, n = g |> length) %%
+    t |> equal(length(rep), 2, "decs buckets a/b")
+    for (r in rep) {
+        if (r.brand == "a") { t |> equal(r.n, 2) }
+        if (r.brand == "b") { t |> equal(r.n, 1) }
+    }
+}
+
+[test]
+def test_decs_select_into(t : T?) {
+    seed_decs()
+    let rep <- %linq! from c : CarComp in decs
+                      select c.price into p
+                      where p > 100
+                      select p %%
+    t |> equal(length(rep), 2, "decs prices 200,300 survive p>100")
+}

--- a/tests/linq/test_linq_das_into.das
+++ b/tests/linq/test_linq_das_into.das
@@ -186,6 +186,23 @@ def test_group_into_iterator_output(t : T?) {
     t |> equal(n, 2, "iterator over the aggregated buckets")
 }
 
+// ===== type-bracket clause body (find_kw_depth0 regression) =====
+
+[test]
+def test_type_bracket_body_before_keyword(t : T?) {
+    let cars <- mk_cars()
+    // A clause body that ends in a type/generic bracket `>` at depth 0 (`default<int>`) must NOT swallow the
+    // following clause keyword. The `>` suppression only fires for the tail of `|>` / `=>` / `->`, never a
+    // type bracket — see find_kw_depth0. (Was: error[50503] "'let z' has no following clause".)
+    let rep <- %linq! from c in cars
+                      let z = default<int>
+                      where c.price + z > 100
+                      select c.price + z %%
+    t |> equal(length(rep), 2, "prices 150,300 survive (z = 0)")
+    t |> equal(rep[0], 150)
+    t |> equal(rep[1], 300)
+}
+
 // ===== decs source =====
 
 [test]

--- a/tests/linq/test_linq_das_into.das
+++ b/tests/linq/test_linq_das_into.das
@@ -115,6 +115,24 @@ def test_group_into_orderby_on_groups(t : T?) {
 }
 
 [test]
+def test_group_into_explicit_tuple_access(t : T?) {
+    let cars <- mk_cars()
+    // The group `g` is a `tuple<key; members>`; explicit `g._0` (key) / `g._1` (members array) must pass
+    // through the A2 rewrite untouched — only `g.key` → `g._0` and bare `g` → `g._1` are rewritten, never
+    // `g._0` → `g._1._0`. Mix all three forms in one projection.
+    let rep <- %linq! from c in cars
+                      group c by c.brand into g
+                      select (k = g._0, viaKey = g.key, n = g._1 |> length, total = g |> length) %%
+    t |> equal(length(rep), 2)
+    for (r in rep) {
+        t |> equal(r.k, r.viaKey, "g._0 and g.key are the same key")
+        t |> equal(r.n, r.total, "g._1 and bare g are the same members array")
+        if (r.k == "eco") { t |> equal(r.n, 2) }
+        if (r.k == "lux") { t |> equal(r.n, 1) }
+    }
+}
+
+[test]
 def test_group_into_member_keeping_identity(t : T?) {
     let cars <- mk_cars()
     // `select g` is the identity continuation — yields the group tuples (key, members) unchanged.

--- a/tutorials/language/56_linq_query.das
+++ b/tutorials/language/56_linq_query.das
@@ -1,0 +1,127 @@
+options gen2
+
+require daslib/linq_das
+require daslib/linq
+require daslib/linq_boost
+require daslib/linq_fold
+
+// Tutorial language-56: C#-style LINQ query syntax (`%linq!`)
+//
+// This tutorial covers:
+//   - the `%linq! … %%` reader macro: from / where / select
+//   - orderby (single and multi-key, ascending / descending)
+//   - group … by (IGrouping) and the `into` group-continuation (grouped aggregation)
+//   - select … into (projection continuation) and multi-stage chains
+//   - let bindings and a single inner join
+//
+// `%linq!` is a purely compile-time rewrite into a fused `_fold(...)` chain — it costs nothing over the
+// hand-written pipe form, and the same query works over arrays, decs, SQL and XML (the typed `: Row` form).
+//
+// Run: daslang.exe tutorials/language/56_linq_query.das
+
+struct Car {
+    name  : string
+    brand : string
+    price : int
+}
+
+struct BrandHQ {
+    brand   : string
+    country : string
+}
+
+def private fleet() : array<Car> {
+    return <- [Car(name = "i3",   brand = "bmw",  price = 100),
+               Car(name = "m3",   brand = "bmw",  price = 250),
+               Car(name = "a4",   brand = "audi", price = 200),
+               Car(name = "a8",   brand = "audi", price = 400),
+               Car(name = "rio",  brand = "kia",  price = 50)]
+}
+
+[export]
+def main {
+    let cars <- fleet()
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Section 1 — from / where / select
+    // ──────────────────────────────────────────────────────────────────────────
+    //
+    // The range variable (`c`) is spliced verbatim as the lambda parameter. `select c` (the variable
+    // alone) is the identity projection; any other projection emits a `_select`.
+    let names <- %linq! from c in cars where c.price > 100 select c.name %%
+    print("expensive: {names}\n")    // [ m3, a4, a8]
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Section 2 — orderby (multi-key, per-key direction)
+    // ──────────────────────────────────────────────────────────────────────────
+    //
+    // Comma-separated keys, each with its own optional `ascending` / `descending`. More than one key
+    // emits a single composite stable sort.
+    let sorted <- %linq! from c in cars orderby c.brand, c.price descending select (b = c.brand, p = c.price) %%
+    print("by brand, then price desc:\n")
+    for (r in sorted) { print("  {r.b} {r.p}\n") }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Section 3 — group … by  (IGrouping)
+    // ──────────────────────────────────────────────────────────────────────────
+    //
+    // A bare `group c by k` yields one `(key, [members])` tuple per bucket — read the key as `._0` and
+    // the members as `._1`.
+    let buckets <- %linq! from c in cars group c by c.brand %%
+    print("buckets:\n")
+    for (g in buckets) { print("  {g._0}: {g._1 |> length} cars\n") }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Section 4 — group … into g … select  (grouped aggregation)  ★ the headline
+    // ──────────────────────────────────────────────────────────────────────────
+    //
+    // `into g` rebinds the group to a new range variable and continues the query. With the A2 convention
+    // `g.key` is the bucket key and a bare `g` is the member collection — so the familiar LINQ aggregates
+    // read naturally. This is the canonical C# grouped-aggregation idiom, and over a SQL source it pushes
+    // straight down to `GROUP BY` + `COUNT/SUM/AVG/...`.
+    let report <- %linq! from c in cars
+                         group c by c.brand into g
+                         select (brand = g.key,
+                                 count = g |> length,
+                                 total = g |> select($(u : Car) => u.price) |> sum,
+                                 avg   = g |> select($(u : Car) => u.price) |> average) %%
+    print("brand report:\n")
+    for (r in report) { print("  {r.brand}: count={r.count} total={r.total} avg={r.avg}\n") }
+
+    // The continuation may itself filter / order the groups. Here: drop singleton buckets, order by total.
+    let bigBrands <- %linq! from c in cars
+                            group c by c.brand into g
+                            where g |> length > 1
+                            orderby g |> select($(u : Car) => u.price) |> sum descending
+                            select g.key %%
+    print("multi-car brands, richest first: {bigBrands}\n")    // [ audi, bmw]
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Section 5 — select … into n …  (projection continuation, multi-stage)
+    // ──────────────────────────────────────────────────────────────────────────
+    //
+    // `select <proj> into n` rebinds the projected value. Continuations chain, so a query can project,
+    // filter, then re-order — all fused on one pass, no intermediate array.
+    let dear <- %linq! from c in cars
+                       select c.price into p
+                       where p >= 200
+                       orderby p descending
+                       select p %%
+    print("prices >= 200, desc: {dear}\n")    // [ 400, 250, 200]
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Section 6 — let bindings and a single inner join
+    // ──────────────────────────────────────────────────────────────────────────
+    //
+    // `let` introduces a computed value reused downstream (inlined at compile time). `join … on … equals …`
+    // is a single inner equi-join introducing a second range variable.
+    let discounted <- %linq! from c in cars let net = c.price - 20 where net > 100 select (n = c.name, p = net) %%
+    print("net (price-20) > 100:\n")
+    for (r in discounted) { print("  {r.n}: {r.p}\n") }
+
+    let hqs <- [BrandHQ(brand = "bmw", country = "DE"), BrandHQ(brand = "audi", country = "DE"),
+                BrandHQ(brand = "kia", country = "KR")]
+    let located <- %linq! from c in cars join h in hqs on c.brand equals h.brand select (car = c.name, country = h.country) %%
+    print("car → country:\n")
+    for (r in located) { print("  {r.car}: {r.country}\n") }
+}


### PR DESCRIPTION
## What

Adds C# **query continuation** (`into`) to the `%linq!` reader. A stage's terminal output is rebound to a new range variable and the query continues on the **same fused `_fold` chain** — no inter-stage materialization, so fusion and SQL single-statement pushdown are preserved. Single-source queries this release.

The headline is **grouped aggregation** — the canonical C# reporting idiom, previously impossible inside `%linq!`:

```das
var report <- %linq! from c in cars
                     group c by c.brand into g
                     select (brand = g.key,
                             count = g |> length,
                             total = g |> select($(u : Car) => u.price) |> sum) %%
```

Over a SQL source this pushes straight down to `SELECT brand, COUNT(*), SUM("price") ... GROUP BY brand` through the existing grouped-projection machinery — verified end-to-end.

> **Stacked on #2987** (multi-key orderby) — the reader uses its `emit_order_by` / multi-key infrastructure. Base is `bbatkin/linq-das-multi-key-orderby`; retarget to `master` once #2987 merges.

## Reader (`daslib/linq_das.das`)

- `transpile_query` is now an **N-stage loop**; `parse_one_stage` parses one `[where] [orderby] (select | group by) [into var]` stage. **Single-stage emit is byte-identical to before** → zero regression on existing queries.
- `rewrite_group_var` — **A2** group addressing for a `group … into g` continuation: `g.key` becomes the key (`._0`), a bare `g` becomes the member collection (`._1`), so the familiar LINQ aggregates read naturally.
- `find_kw_depth0` root fix: a clause keyword can no longer be the target of `|>` / `=>` / `->`, so an aggregate like `g |> select(...) |> sum` inside an orderby/where body is not mistaken for a `select` clause.
- The two-source `into` reject is reworded (group-join `join … into` lands in the follow-up PR).

## Scope (in-memory vs SQL)

- **Aggregate** continuation (`g.key` + `g |> length` / `select(...) |> sum/avg/min/max`): all four sources — array / decs / XML in-memory **and** SQL GROUP BY pushdown.
- **Member-keeping** (identity `select g`, the whole `(key, [rows])` group) and non-SQL aggregates: in-memory only; reject over SQL via the backend's existing messages.

## Tests — all three tiers green (interp / JIT / AOT): linq **1867**, sql **902**

- `tests/linq/test_linq_das_into.das` (new): group-into aggregate, member-keeping, select-into, multi-stage, where/orderby on groups (array + decs); 4 `into` error cases in `failed_linq_das.das`.
- `tests/dasSQLITE`: group-into parity vs hand-written `_group_by` chain, emit-shape (`GROUP BY` / `COUNT` / `SUM`), and a member-keeping reject.

## Docs

- `linq_das.rst`: grammar update + new "Query continuation (`into`)" section.
- **New `tutorials/language/56_linq_query.das`** — the first `%linq!` tutorial — plus RST + toctree wiring. Sphinx builds clean.

## Folded-in nits

- The deferred #2987 order-once messages now list the all-descending `_order_by_descending((...))` form.
- Two deferred #2978 review follow-ups: the correlated `each(temporary)` borrow-safety comment (heap-alloc + no auto-finalize → no UAF) and the `select_many_pair` reserve-comment reword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)