### PR TITLE
dasLLVM: fix mingw CI — fall back to prebuilt download when system LLVM lacks Windows-release layout

### DIFF
--- a/modules/dasLLVM/CMakeLists.txt
+++ b/modules/dasLLVM/CMakeLists.txt
@@ -32,6 +32,21 @@ IF ((NOT DAS_LLVM_INCLUDED) AND ((NOT ${DAS_LLVM_DISABLED}) OR (NOT DEFINED DAS_
 
     IF (DAS_LLVM_REFETCH)
         find_package(LLVM ${DAS_LLVM_TARGET_VERSION})
+        # A system LLVM is only usable here if it ships the prebuilt-release
+        # layout we copy from. On Windows that means bin/clang-cl.exe +
+        # bin/LLVM-C.dll. msys2/mingw clang64 provides LLVMConfig.cmake but lays
+        # the binaries out differently (libLLVM-NN.dll, no LLVM-C.dll); a
+        # 2026-06 msys2 package update started reporting a matching version so
+        # find_package now succeeds where it used to fail the version match.
+        # Treat that as not-found and fall through to the prebuilt download.
+        IF (LLVM_FOUND AND WIN32 AND
+            ((NOT EXISTS "${LLVM_INSTALL_PREFIX}/bin/clang-cl.exe") OR
+             (NOT EXISTS "${LLVM_INSTALL_PREFIX}/bin/LLVM-C.dll")))
+            MESSAGE(STATUS "dasLlvm: system LLVM at ${LLVM_INSTALL_PREFIX} lacks "
+                "Windows-release clang-cl.exe/LLVM-C.dll (msys2/mingw layout); "
+                "using prebuilt download")
+            SET(LLVM_FOUND FALSE)
+        ENDIF()
         IF (LLVM_FOUND)
             MESSAGE(STATUS "LLVM found at: ${LLVM_INSTALL_PREFIX}")
             IF(WIN32)


### PR DESCRIPTION
## Problem

`build_windows_mingw` started failing at the CMake-configure step on every PR (e.g. [#2991](https://github.com/GaijinEntertainment/daScript/pull/2991)), even on changes that touch no CMake/LLVM code:

```
CMake Error at modules/dasLLVM/CMakeLists.txt:39 (FILE):
  FILE COPY cannot find "C:/a/_temp/msys64/clang64/bin/clang-cl.exe"
CMake Error: File C:/a/_temp/msys64/clang64/bin/LLVM-C.dll does not exist.
```

This is an **environment regression**, not a source change. Comparing a passing mingw run (12:10 UTC) with a failing one (19:13 UTC) on the *same* master SHA:

- **Passing:** `find_package(LLVM 22.1.5)` found msys2's `LLVM-Config.cmake` but it reported `version: unknown` → the `22.1.5` version constraint failed → `LLVM_FOUND` false → fell through to the **prebuilt download** (`win64_llvm.tar.gz`).
- **Failing:** a 2026-06 msys2 `clang64` package update made that config report a concrete matching version, so `find_package(LLVM 22.1.5)` now **succeeds** → takes the `WIN32` branch → tries to copy `clang-cl.exe` / `LLVM-C.dll` from msys2's prefix. msys2 lays its binaries out differently (`libLLVM-NN.dll`, no `LLVM-C.dll`), so configure fails.

## Change

Only use a system LLVM on Windows when it actually ships the prebuilt-release files we copy from (`bin/clang-cl.exe` + `bin/LLVM-C.dll`). Otherwise clear `LLVM_FOUND` and fall through to the prebuilt download. This restores the prior, working mingw behavior and is robust to any system LLVM whose layout doesn't match what the WIN32 copy step expects.

Single-file change in `modules/dasLLVM/CMakeLists.txt`; no behavior change for platforms/installs that already had a usable system LLVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)