### PR TITLE
dyn_modules: route -load_module shadow warning to stderr; strip MCP subtool preamble

### DIFF
--- a/src/ast/dyn_modules.cpp
+++ b/src/ast/dyn_modules.cpp
@@ -6,6 +6,7 @@
 #include <daScript/misc/sysos.h>
 #include <daScript/misc/string_writer.h>       // TextWriter
 #include <cctype>                              // tolower (case-insensitive basename normalize)
+#include <cstdio>                              // fprintf(stderr) for the shadow-shadows-global diagnostic
 
 das::FileAccessPtr get_file_access( char * pak );
 
@@ -163,7 +164,9 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
                 continue;
             }
             if (skip_set && skip_set->count(normalize_module_name(das::string(c_file.name)))) {
-                tout << "Warning: local '" << c_file.name << "' shadows global — using local\n";
+                // stderr, not `tout`: this is a diagnostic, and `tout` is stdout — which for the MCP server /
+                // dastest JSON / any stdout-parsing pipeline is a structured data channel a stray line corrupts.
+                fprintf(stderr, "Warning: local '%s' shadows global — using local\n", c_file.name);
                 continue;
             }
             all_good &= Result::OK == init_dyn_modules(fa, modules_path + c_file.name, tout, false);
@@ -179,7 +182,9 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
                 continue;
             }
             if (skip_set && skip_set->count(normalize_module_name(das::string(ent->d_name)))) {
-                tout << "Warning: local '" << ent->d_name << "' shadows global — using local\n";
+                // stderr, not `tout`: this is a diagnostic, and `tout` is stdout — which for the MCP server /
+                // dastest JSON / any stdout-parsing pipeline is a structured data channel a stray line corrupts.
+                fprintf(stderr, "Warning: local '%s' shadows global — using local\n", ent->d_name);
                 continue;
             }
             all_good &= Result::OK == init_dyn_modules(fa, modules_path + ent->d_name, tout, false);

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -384,6 +384,15 @@ def run_mcp_subtool(subtool_name : string; args : array<string>;
     let exit_code = run_and_capture(argv, output, timeout_sec)
     if (exit_code == popen_timed_out) return make_tool_result("MCP subtool '{subtool_name}' timed out after {timeout_sec}s:\n{output}", true)
     if (exit_code != 0) return make_tool_result("MCP subtool '{subtool_name}' failed (exit {exit_code}):\n{output}", true)
+    // The subtool emits a single-line JSON-RPC result object on stdout, but run_and_capture merges in any
+    // compiler / dyn-module diagnostics printed before it — e.g. `Warning: local 'X' shadows global — using
+    // local` from a `-load_module` shadow (it prints at the child's startup, before the subtool's `main`).
+    // The server splices this return value verbatim into the `result` field, so a stray preamble desyncs the
+    // JSON-RPC stream (same class as the 776c10658 GC-leak-dump fix). Strip everything before the JSON object.
+    let brace = find(output, "\{")
+    if (brace > 0) {
+        output = strip(slice(output, brace))
+    }
     return output
 }
 

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -384,14 +384,17 @@ def run_mcp_subtool(subtool_name : string; args : array<string>;
     let exit_code = run_and_capture(argv, output, timeout_sec)
     if (exit_code == popen_timed_out) return make_tool_result("MCP subtool '{subtool_name}' timed out after {timeout_sec}s:\n{output}", true)
     if (exit_code != 0) return make_tool_result("MCP subtool '{subtool_name}' failed (exit {exit_code}):\n{output}", true)
-    // The subtool emits a single-line JSON-RPC result object on stdout, but run_and_capture merges in any
+    // The subtool emits a single-line ToolResult JSON object on stdout, but run_and_capture merges in any
     // compiler / dyn-module diagnostics printed before it — e.g. `Warning: local 'X' shadows global — using
-    // local` from a `-load_module` shadow (it prints at the child's startup, before the subtool's `main`).
+    // local` from a `-load_module` shadow, or a loaded module's compile-error report (which contains daslang
+    // source snippets with `{`). Both print at the child's startup, before the subtool's `main`, and a broken
+    // module does NOT abort the run (require_dynamic_modules continues), so the subtool still exits 0.
     // The server splices this return value verbatim into the `result` field, so a stray preamble desyncs the
-    // JSON-RPC stream (same class as the 776c10658 GC-leak-dump fix). Strip everything before the JSON object.
-    let brace = find(output, "\{")
-    if (brace > 0) {
-        output = strip(slice(output, brace))
+    // JSON-RPC stream (same class as the 776c10658 GC-leak-dump fix). Anchor on the ToolResult envelope marker
+    // (`content` is its first field) rather than the first `{`, which a source-snippet preamble would match.
+    let envStart = find(output, "\{\"content")
+    if (envStart > 0) {
+        output = strip(slice(output, envStart))
     }
     return output
 }


### PR DESCRIPTION
A `-load_module` whose basename shadows a global module printed `Warning: local 'X' shadows global — using local` to **stdout** at child startup. stdout is a structured channel for any parsing pipeline — the MCP server splices a subtool's stdout verbatim as the JSON-RPC `result`, so the stray line desyncs the frame (same class as the `776c10658` GC-leak-dump fix).

### Fix
- **`src/ast/dyn_modules.cpp`** — emit the shadow diagnostic via `fprintf(stderr, …)` instead of the `tout` stdout writer, on both the MSVC `_findfirst` and POSIX `readdir` arms.
- **`utils/mcp/tools/common.das`** (`run_mcp_subtool`) — defensively strip any preamble before the JSON object, since `run_and_capture` merges the child's stderr back into the captured output (so the stderr move alone is not enough for this consumer).

Verified: a `-load_module` with a shadowing basename now prints the warning on stderr, and the MCP subtool result is pure JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)