### PR TITLE
dasStrudel: int|float|double numeric widening, expose set_X, add freq/euclidRot/chop/slice + bd(3,8) mini

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ All code MUST use gen2 syntax (add `options gen2` at the top of every file). Key
 - **`==const`** on a parameter type — propagates the caller's constness (NOT "always non-const"): `def foo(self : MyStruct ==const)` accepts either `MyStruct` or `MyStruct const`, and inside the body `self`'s constness matches what the caller passed. Use plain `Foo?` for non-const-only, `Foo const?` for const-only, `Foo? ==const` when you want the callee to accept either and inherit the caller's view
 - **`-const`** strips constness in type expressions — used with `reinterpret` for interior mutability: `unsafe(reinterpret<MyStruct? -const>(addr(self)))`
 - **Function pointer with explicit type:** `@@<(var self : T) : RetT> funcName` — specifies the exact parameter/return types of a function pointer literal
+- **OR types in params** (`T1 | T2 | …`) — a parameter may list alternative accepted types: `int | float | double`, or heterogeneous forms like `array<int> | table<auto> | auto(NT)`. This is a **generic "OR" type, NOT a runtime tagged variant** — the function is monomorphized per the concrete argument type that matches one alternative, so each instantiation sees that concrete type with no per-call dispatch or unpacking cost. Don't "hoist the union cast out of the loop" — there is no union value; a cast like `float(n)` inside the body is just a trivial concrete cast in each instantiation. Use it to widen an overload set in one signature (e.g. `def fast(n : int | float | double)` accepting bare ints, floats, and doubles at the same call site)
 
 ### Important defaults
 

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -1611,9 +1611,9 @@ def document_module_strudel_pattern(_root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Pattern construction", mod, %regex~(pure|silence|atom|querySpan|queryArc|patternType)$%%),
         group_by_regex("Time manipulation", mod, %regex~(fast|slow|stack|cat|fastcat|weighted_fastcat|fmap)$%%),
-        group_by_regex("Combinators", mod, %regex~(rev|jux|off|layer|superimpose|euclid|palindrome|ply|iter|iterBack|when_cycle|linger|hurry|compress|chunk|striate|struct_|mask|choose|wchoose|randcat|chooseCycles|shuffle|scramble|echo|stut|transpose|add|innerJoin|combineWith|combineWithStr|degrade|degradeBy|every|bjorklund|sometimes|often|sometimesby)$%%),
+        group_by_regex("Combinators", mod, %regex~(rev|jux|off|layer|superimpose|euclid|euclidRot|palindrome|ply|iter|iterBack|when_cycle|linger|hurry|compress|chunk|striate|chop|slice|struct_|mask|choose|wchoose|randcat|chooseCycles|shuffle|scramble|echo|stut|transpose|add|innerJoin|combineWith|combineWithStr|degrade|degradeBy|every|bjorklund|sometimes|often|sometimesby)$%%),
         group_by_regex("Setter primitives", mod, %regex~set_.*$%%),
-        group_by_regex("Fluent control: dynamics and routing", mod, %regex~(gain|velocity|vel|pan|speed|note|sound|cut|orbit|begin|end_pos)$%%),
+        group_by_regex("Fluent control: dynamics and routing", mod, %regex~(gain|velocity|vel|pan|speed|note|freq|sound|cut|orbit|begin|end_pos)$%%),
         group_by_regex("Fluent control: 3D positioning (HRTF)", mod, %regex~(hrtf|hrtf_azimuth|hrtf_elevation)$%%),
         group_by_regex("Fluent control: effects sends", mod, %regex~(room|roomsize|size|delay|delaytime|dt|delayfeedback|dfb|delaysync|chorus)$%%),
         group_by_regex("Fluent control: filters", mod, %regex~(lpf|lp|hpf|hp|lpq|resonance|hpq|bpf|bpq|djf)$%%),
@@ -1621,7 +1621,10 @@ def document_module_strudel_pattern(_root : string) {
         group_by_regex("Fluent control: synthesis and shaping", mod, %regex~(fm|fmh|crush|coarse|shape)$%%),
         group_by_regex("Fluent control: modulation FX", mod, %regex~(phaser|ph|phaserdepth|phd|phasercenter|phc|phasersweep|phs|tremolo|trem|tremolodepth|tremdepth|compressor.*)$%%),
         group_by_regex("Fluent control: SF2", mod, %regex~sf2.*$%%),
-        group_by_regex("Signals", mod, %regex~(signal|signal_.*|sine|cosine|saw|tri|perlin|range|square|isaw|itri|sine2|cosine2|saw2|tri2|square2|isaw2|itri2|rand|rand2|irand|run)$%%)
+        group_by_regex("Signals", mod, %regex~(signal|signal_.*|sine|cosine|saw|tri|perlin|range|square|isaw|itri|sine2|cosine2|saw2|tri2|square2|isaw2|itri2|rand|rand2|irand|run)$%%),
+        // public only so union-widened combinators' captured lambdas resolve them
+        // cross-module — not user-facing API
+        hide_group(group_by_regex("Internal", mod, %regex~(strudel_hash01|strudel_hash32)$%%))
     )
     document("Pattern algebra, combinators, and fluent control API", mod, "strudel_pattern.rst", groups)
 }

--- a/doc/source/reference/strudel_vs_strudel_cc.rst
+++ b/doc/source/reference/strudel_vs_strudel_cc.rst
@@ -86,8 +86,8 @@ Parity or near-parity with strudel.cc:
        ``sometimesby``, ``degrade``, ``degradeBy``
    * - Euclidean rhythms
      - ``strudel_pattern``
-     - ``euclid(k, n)``, ``bjorklund``.  (``euclidRot`` and
-       mini-notation ``bd(3,8)`` forms are gaps — see below.)
+     - ``euclid(k, n)``, ``euclidRot(k, n, rot)``, ``bjorklund``, and
+       the mini-notation ``"bd(3,8)"`` / ``"bd(3,8,2)"`` forms
    * - Scales
      - ``strudel_scales``
      - ``scale("c:minor")``, ``note`` with scale context, modes
@@ -101,9 +101,10 @@ Parity or near-parity with strudel.cc:
      - ``strudel_synth``
      - oscillators (``sine``, ``sawtooth``, ``square``, ``triangle``,
        ``supersaw``), noise (``white``, ``pink``), FM via ``fm`` +
-       ``fmh``, vowel/formant filter, per-voice biquads. Note
-       ``sawtooth`` is spelled out — there is no ``saw`` alias (unlike
-       strudel.cc)
+       ``fmh``, ``freq`` for direct-Hz pitch, vowel/formant filter,
+       per-voice biquads. Note the oscillator *sound* is named
+       ``sawtooth`` — there is a ``saw`` *signal* generator (a ramp
+       LFO) but no ``saw`` sound-name alias
    * - Samples
      - ``strudel_samples``
      - WAV / MP3 / FLAC / OGG loading via ``load_audio_file`` /
@@ -130,9 +131,22 @@ Parity or near-parity with strudel.cc:
        number routes to one ``OrbitBus``
    * - Effects (per-voice)
      - ``strudel_synth`` (``VoiceFX``)
-     - Phaser, tremolo, compressor, waveshaper, DJ filter, bitcrush,
-       sample-rate reduction — all applied per voice before the
+     - ``lpf``/``hpf``/``bpf`` filters, phaser, tremolo, compressor,
+       waveshaper (``shape``), DJ filter, bitcrush (``crush``),
+       sample-rate reduction (``coarse``), plus ``gain``/``pan``/
+       ``speed``/``fm``/``vowel`` — all applied per voice before the
        orbit mix
+   * - Pattern-valued setters
+     - ``strudel_pattern``
+     - Every scalar setter (``gain``, ``lpf``, ``pan``, ``speed``,
+       ``freq``, …) also has a *pattern* overload: pass a signal or
+       pattern and it is sampled per event — e.g.
+       ``lpf(p, sine() |> range(200, 2000))`` or ``gain(p, saw())``
+   * - Numeric arguments
+     - ``strudel_pattern``
+     - Every scalar modifier accepts ``int``, ``float`` **or**
+       ``double`` — ``fast(2)``, ``gain(0.5)``, and ``speed(2.0lf)``
+       all work; no ``.0`` / ``lf`` suffix juggling needed
 
 
 .. _strudel_cc_missing:
@@ -142,14 +156,12 @@ What we don't have (yet)
 
 Features that are present in strudel.cc and absent in the daslang port:
 
-* **``euclidRot``** — Euclidean rotation helper.  Not implemented;
-  compose ``euclid`` with ``rev`` or ``off`` for a workaround.
-* **Mini-notation ``bd(3,8)`` form** — tokens ``(`` / ``)`` are
-  lexed but not parsed into Euclidean rhythms.  Use the
-  ``euclid(pat, 3, 8)`` function form instead.
-* **``jux_rev`` / ``chop`` / other convenience aliases** — the
-  parametric forms (``jux(pat, fn)``, ``stutter``, etc.) are
-  public; a few one-letter convenience wrappers were not ported.
+* **``jux_rev`` and other one-letter convenience wrappers** — the
+  parametric forms (``jux(pat, fn)``, ``stutter``, etc.) are public;
+  a few bare-name convenience wrappers were not ported.  Note
+  ``chop`` and ``slice`` *are* available (granulation via the sample
+  ``begin``/``end`` window), as are ``euclidRot`` and the
+  mini-notation ``"bd(3,8)"`` Euclidean form.
 * **Web sample packs** — strudel.cc streams sample packs from
   the web at runtime; daslang loads local samples from disk (via
   ``strudel_load_sample_dir``).  Bring your own sample library.
@@ -198,23 +210,27 @@ fills one cycle at the current tempo.
 
 See the ``adsr-defaults`` branch history for the full introduction.
 
-Per-voice FX chain
-------------------
+Per-voice vs per-orbit FX
+-------------------------
 
-**Divergence:** ``phaser``, ``tremolo``, ``compressor``, ``shape``,
-``crush``, ``coarse``, and ``djf`` are applied **per voice**, inside
-the voice renderer, before the orbit mix.  strudel.cc applies most
-of these after the send-bus mix.
+daslang splits effects into two groups, and this matches strudel.cc's
+model closely:
 
-**Why:** Per-voice FX gives a cleaner sound for polyphonic patterns
-(one voice's compressor can't duck another voice's transient) and
-integrates tightly with the ``VoiceFX`` struct, which the per-voice
-synth engine already carries.
+* **Per-voice** — ``lpf``/``hpf``/``bpf``, ``phaser``, ``tremolo``,
+  ``compressor``, ``shape``, ``crush``, ``coarse``, ``djf``, plus
+  ``gain``/``pan``/``speed``/``fm``/``vowel``.  These are baked into
+  each playing voice (the ``VoiceFX`` struct) and run *before* the
+  voice is mixed into its orbit.  strudel.cc likewise applies these
+  per event — daslang does **not** diverge here.
+* **Per-orbit (send bus)** — ``room``/``roomsize`` (reverb),
+  ``delay``/``delaytime``/``delayfeedback``, and ``chorus``.  One
+  shared instance per orbit number; voices send wet/dry into it.
 
-**How to apply:** for patterns that rely on strudel.cc's post-bus
-phaser, use ``room`` / ``delay`` bus routing (per-orbit) instead.
-Per-voice combinators like ``jux`` interact with per-voice FX
-differently — each transformed voice carries its own FX chain.
+**How to apply:** because the first group is per-voice, two stacked
+voices stay independent — each transformed copy from ``jux`` /
+``superimpose`` carries its own FX chain.  For shared reverb/delay,
+route patterns to the same ``orbit`` number (see below); for
+independent bus FX, split orbits.
 
 Orbit bus model
 ---------------
@@ -348,11 +364,14 @@ for ~95% of primitives.  When it differs:
      - ``note("c4")``
      - identical; for scale-degree use ``note(0.0)`` after ``scale(...)``
    * - ``.fast(2)``
-     - ``|> fast(2.0)``
-     - same name; pipe syntax preferred but method-chain also works
+     - ``|> fast(2)``
+     - same name; bare int / float / double all accepted.  Use the
+       pipe ``|>`` — ``Pattern`` is a lambda, so ``.method()`` does
+       **not** work on it
    * - ``.jux(rev)``
      - ``|> jux(@(x) => rev(x))``
-     - daslang expects a typed fn; lambda literal is normal
+     - daslang expects a typed lambda — use ``@(x) =>``, **not**
+       ``@@(x) =>`` (a function pointer won't match ``PatternTransform``)
    * - ``.velocity(0.5)`` / ``.vel(...)``
      - ``|> velocity(0.5)`` / ``|> vel(...)``
      - both aliases exist
@@ -360,11 +379,17 @@ for ~95% of primitives.  When it differs:
      - ``stack(a, b)``
      - top-level function, not a method
    * - ``.euclidRot(3, 8, 1)``
-     - *not available*
-     - use ``euclid(pat, 3, 8) |> off(1.0/8.0, @(x) => x)``
+     - ``|> euclidRot(3, 8, 1)``
+     - same name; rotates the Euclidean pattern left by ``rot`` steps
    * - ``"bd(3,8)"``
-     - ``euclid(s("bd"), 3, 8)``
-     - mini-notation Euclid form not parsed
+     - ``s("bd(3,8)")`` or ``euclid(s("bd"), 3, 8)``
+     - mini-notation Euclid form is parsed; ``"bd(3,8,2)"`` adds rotation
+   * - ``.chop(4)`` / ``.slice(4, "0 1 2 3")``
+     - ``|> chop(4)`` / ``|> slice(4, note("0 1 2 3"))``
+     - sample granulation via the ``begin``/``end`` window
+   * - ``.freq(440)``
+     - ``|> freq(440)``
+     - sets oscillator frequency in Hz directly, overriding ``note``
 
 For everything else, assume the name is identical.  Use the MCP
 ``list_module_api`` tool on ``strudel_pattern`` /

--- a/examples/daStrudel/features/combinator_chop.das
+++ b/examples/daStrudel/features/combinator_chop.das
@@ -1,0 +1,24 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// chop(n) subdivides each event in place into n back-to-back sample slices.
+// Unlike striate (which spreads slices across the whole cycle), chop keeps the
+// slices inside each event's own time slot.
+// Hear: one gong sample walked through in 8 consecutive grains.
+/*
+s("gong").chop(8)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let media = "{get_das_root()}/examples/media"
+    let pat <- s("gong") |> chop(8) |> gain(0.6)
+    play_feature_cps(pat, 0.5lf) {
+        // index :0 is gong.wav (audio/ sorted alphabetically)
+        strudel_load_sound("{media}/audio", "gong")
+    }
+}

--- a/examples/daStrudel/features/combinator_euclid_rot.das
+++ b/examples/daStrudel/features/combinator_euclid_rot.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// euclidRot(k, n, rot) is a Euclidean rhythm rotated left by `rot` steps.
+// Hear: euclid(3,8) is the tresillo (onsets 0,3,6); rotating by 2 shifts the
+// accent pattern, giving the same density with a different feel.
+/*
+s("bd").euclidRot(3, 8, 2)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let media = "{get_das_root()}/examples/media"
+    let pat <- s("bd") |> euclidRot(3, 8, 2) |> gain(0.7)
+    play_feature_cps(pat, 0.5lf) {
+        strudel_load_sound("{media}/drums/bd", "bd")
+    }
+}

--- a/examples/daStrudel/features/combinator_slice.das
+++ b/examples/daStrudel/features/combinator_slice.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// slice(n, idx_pat) cuts the sample into n slices and plays them in the order
+// (and rhythm) given by idx_pat. Structure comes from idx_pat, the sample from
+// the source. Hear: the gong reshuffled into a non-linear order.
+/*
+s("gong").slice(8, "0 2 4 6 1 3 5 7")
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let media = "{get_das_root()}/examples/media"
+    let pat <- s("gong") |> slice(8, note("0 2 4 6 1 3 5 7")) |> gain(0.6)
+    play_feature_cps(pat, 0.5lf) {
+        strudel_load_sound("{media}/audio", "gong")
+    }
+}

--- a/examples/daStrudel/features/mini_euclid_paren.das
+++ b/examples/daStrudel/features/mini_euclid_paren.das
@@ -1,0 +1,27 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// Euclidean rhythms straight from mini-notation: "name(k,n)" expands to
+// euclid(k,n), and "name(k,n,rot)" to euclidRot(k,n,rot). Composes with the
+// rest of the mini-notation grammar inside one string.
+// Hear: a tresillo kick under a 5-in-8 hat, both written inline.
+/*
+s("bd(3,8), hh(5,8,1)")
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let media = "{get_das_root()}/examples/media"
+    let pat <- stack([
+        s("bd(3,8)") |> gain(0.8),
+        s("hh(5,8,1)") |> gain(0.4)
+    ])
+    play_feature_cps(pat, 0.5lf) {
+        strudel_load_sound("{media}/drums/bd", "bd")
+        strudel_load_sound("{media}/drums/hh", "hh")
+    }
+}

--- a/examples/daStrudel/features/synth_freq_direct.das
+++ b/examples/daStrudel/features/synth_freq_direct.das
@@ -1,0 +1,24 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+// freq(hz) sets the oscillator frequency directly in Hz, bypassing the MIDI
+// note → frequency conversion. A frequency pattern drives an arpeggio in raw Hz.
+// Hear: a sawtooth stepping through 220 / 277 / 330 / 440 Hz (an A-major-ish chord).
+/*
+s("sawtooth*4").freq("220 277 330 440")
+  .lpf(2500).release(0.2)
+  .cps(0.5)
+*/
+
+require feature_common
+
+[export]
+def main() {
+    let pat <- (
+        s("sawtooth*4")
+        |> freq(note("220 277 330 440"))
+        |> lpf(2500) |> release(0.2) |> gain(0.5)
+    )
+    play_feature_cps(pat, 0.5lf)
+}

--- a/modules/dasAudio/strudel/strudel_event.das
+++ b/modules/dasAudio/strudel/strudel_event.das
@@ -15,6 +15,9 @@ struct Event {
         //! Sound/sample name (`"bd"`, `"sd"`, `"sawtooth"`, `"sine"`, ...).
     note    : float = 60.0      // MIDI note number (60 = middle C)
         //! MIDI note number (60 = middle C).
+    freq    : float = 0.0       // explicit frequency in Hz (0 = unset → derived from note)
+        //! Explicit oscillator frequency in Hz. `0` = unset (derive from `note`); any
+        //! positive value overrides `note`. Matches strudel.cc `.freq(440)`.
     n       : int = 0           // sample variation index (bd:0, bd:1, bd:2)
         //! Sample variation index within a bank (`bd:0`, `bd:1`, `bd:2`).
     gain    : float = 0.8       // amplitude 0.0–1.0 (applied after rendering)

--- a/modules/dasAudio/strudel/strudel_mini.das
+++ b/modules/dasAudio/strudel/strudel_mini.das
@@ -285,6 +285,20 @@ def private parse_element(var p : Parser) : Pattern {
                 var r = e; r.n = idx; return r
             }
             pat <- pat |> fmap(fn)
+        } elif (k == TokenKind.LPAREN) {
+            // Euclidean rhythm: "bd(3,8)" → euclid(3,8); "bd(3,8,1)" → euclidRot(3,8,1)
+            advance(p)
+            let kk = to_int(expect_token(p, TokenKind.NUMBER).text)
+            expect_token(p, TokenKind.COMMA)
+            let nn = to_int(expect_token(p, TokenKind.NUMBER).text)
+            if (peek(p).kind == TokenKind.COMMA) {
+                advance(p)
+                let rot = to_int(expect_token(p, TokenKind.NUMBER).text)
+                pat <- pat |> euclidRot(kk, nn, rot)
+            } else {
+                pat <- pat |> euclid(kk, nn)
+            }
+            expect_token(p, TokenKind.RPAREN)
         } else {
             break
         }
@@ -363,8 +377,8 @@ def parse_note_name(name : string) : float {
             octaveIdx = 2
         }
         let octCh = int(bytes[octaveIdx])
-        if (octCh < '0' || octCh > '9') return
-        let octave = octCh - int('0')
+        if (!is_number(octCh)) return
+        let octave = octCh - '0'
         result = float((octave + 1) * 12 + semitone)
     }
     return result
@@ -401,8 +415,8 @@ def parse_note_name_default(name : string; default_oct : int) : float {
         }
         if (nextIdx < n) {
             let octCh = int(bytes[nextIdx])
-            if (octCh < '0' || octCh > '9') return
-            octave = octCh - int('0')
+            if (!is_number(octCh)) return
+            octave = octCh - '0'
         }
         result = float((octave + 1) * 12 + semitone)
     }
@@ -552,7 +566,7 @@ def seq(notation : string; sound : string = "sine") : Pattern {
 // These re-parse the notation to create two independent patterns,
 // since lambdas aren't copyable.
 
-def every_fast(n : int; factor : double; notation : string) : Pattern {
+def every_fast(n : int; factor : int | float | double; notation : string) : Pattern {
     //! Apply `fast(factor)` to the pattern every `n`th cycle. Example:
     //! `every_fast(4, 2.0, "bd sd hh cp")` plays at double speed on cycles 4, 8, 12, ...
     let on <- s(notation) |> fast(factor)
@@ -560,7 +574,7 @@ def every_fast(n : int; factor : double; notation : string) : Pattern {
     return <- every(n, on, off)
 }
 
-def every_slow(n : int; factor : double; notation : string) : Pattern {
+def every_slow(n : int; factor : int | float | double; notation : string) : Pattern {
     //! Apply `slow(factor)` to the pattern every `n`th cycle. Example:
     //! `every_slow(4, 2.0, "bd sd hh cp")` plays at half speed on cycles 4, 8, 12, ...
     let on <- s(notation) |> slow(factor)
@@ -568,7 +582,7 @@ def every_slow(n : int; factor : double; notation : string) : Pattern {
     return <- every(n, on, off)
 }
 
-def every_degrade(n : int; prob : float; notation : string) : Pattern {
+def every_degrade(n : int; prob : int | float | double; notation : string) : Pattern {
     //! Randomly drop events from the pattern every `n`th cycle. Example:
     //! `every_degrade(4, 0.5, "bd sd hh cp")` drops ~half the events on cycles 4, 8, ...
     let on <- s(notation) |> degrade(prob)

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -930,7 +930,7 @@ def rev(var pat : Pattern) : Pattern {
 // Stereo split: original panned left, transformed panned right.
 // jux(s("bd sd"), @(x) => rev(x)) — classic stereo widening
 def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
-    //! Stereo split: original is panned left, `transform(pat)` is panned right. Example: `s("bd sd") |> jux(@@(x) => rev(x))`.
+    //! Stereo split: original is panned left, `transform(pat)` is panned right. Example: `s("bd sd") |> jux(@(x) => rev(x))`.
     var transformed <- invoke(transform, pat) // nolint:LINT003
     var left <- pat |> set_pan(0.0)
     var right <- transformed |> set_pan(1.0)
@@ -943,7 +943,7 @@ def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
 // Overlay pattern with a time-shifted copy.
 // off(s("bd sd"), 0.125, @(x) => transpose(x, 7.0)) — canon at the fifth
 def off(var pat : Pattern; time : int | float | double; transform : PatternTransform) : Pattern {
-    //! Overlays `pat` with a time-shifted copy transformed by `transform`. Example: `s("bd sd") |> off(0.125, @@(x) => transpose(x, 7.0))` — canon at the fifth.
+    //! Overlays `pat` with a time-shifted copy transformed by `transform`. Example: `s("bd sd") |> off(0.125, @(x) => transpose(x, 7.0))` — canon at the fifth.
     var shifted <- invoke(transform, pat) |> late(numd(time))
     var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| pat
@@ -991,7 +991,7 @@ def private degrade_drop(var pat : Pattern; prob : float) : Pattern {
 // Matches strudel: stack(degrade(pat, prob), transform(undegrade(pat, prob)))
 // Randomness is decided at original event positions, BEFORE transform reshuffles timing.
 def sometimesby(var pat : Pattern; prob : float; transform : PatternTransform) : Pattern {
-    //! Applies `transform` to each event with probability `prob` (0..1). Example: `s("bd*8") |> sometimesby(0.3, @@(x) => fast(x, 2.0lf))`.
+    //! Applies `transform` to each event with probability `prob` (0..1). Example: `s("bd*8") |> sometimesby(0.3, @(x) => fast(x, 2.0lf))`.
     var degraded <- degrade_keep(pat, prob)
     var undegraded <- degrade_drop(pat, prob) // nolint:LINT003
     var transformed <- invoke(transform, undegraded) // nolint:LINT003
@@ -1748,7 +1748,7 @@ def palindrome(var pat : Pattern) : Pattern {
 // Stack original + transformed copy.
 // superimpose(pat, @(x) => fast(x, 2.0lf)) — layer faster copy on top
 def superimpose(var pat : Pattern; transform : PatternTransform) : Pattern {
-    //! Stacks `pat` with `transform(pat)`, both playing simultaneously. Example: `pat |> superimpose(@@(x) => fast(x, 2.0lf))`.
+    //! Stacks `pat` with `transform(pat)`, both playing simultaneously. Example: `pat |> superimpose(@(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
     var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| pat
@@ -1901,7 +1901,7 @@ def iterBack(var pat : Pattern; n : int) : Pattern {
 // Conditional transform based on cycle number.
 // when_cycle(pat, @(c) => c % 4 == 0, @(x) => fast(x, 2.0lf))
 def when_cycle(var pat : Pattern; var cond : lambda<(cycle : int) : bool>; transform : PatternTransform) : Pattern {
-    //! Applies `transform` to `pat` on cycles where `cond(cycle)` is true, leaving others untouched. Example: `pat |> when_cycle(@(c) => c % 4 == 0, @@(x) => fast(x, 2.0lf))`.
+    //! Applies `transform` to `pat` on cycles where `cond(cycle)` is true, leaving others untouched. Example: `pat |> when_cycle(@(c) => c % 4 == 0, @(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
     return @capture(<- pat, <- transformed, <- cond) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -2022,7 +2022,7 @@ def compress(var pat : Pattern; b, e : int | float | double) : Pattern {
 // Apply function to the nth chunk each cycle (rotating).
 // chunk(pat, 4, @(x) => fast(x, 2.0lf)) — doubles speed of chunk 0, then 1, then 2, then 3
 def chunk(var pat : Pattern; n : int; transform : PatternTransform) : Pattern {
-    //! Divides each cycle into `n` chunks, applying `transform` to a different chunk each cycle (rotating). Example: `pat |> chunk(4, @@(x) => fast(x, 2.0lf))`.
+    //! Divides each cycle into `n` chunks, applying `transform` to a different chunk each cycle (rotating). Example: `pat |> chunk(4, @(x) => fast(x, 2.0lf))`.
     var transformed <- invoke(transform, pat)
     let nf = double(n)
     return @capture(= n, = nf, <- pat, <- transformed) (span : TimeSpan) : array<Hap> {
@@ -2066,6 +2066,7 @@ def chunk(var pat : Pattern; n : int; transform : PatternTransform) : Pattern {
 // Behavior: progressive slices reveal later parts of the sample envelope.
 def striate(var pat : Pattern; n : int) : Pattern {
     //! Cuts each sample into `n` slices and plays them in sequence. Slice `i` gets `begin=i/n`, `end=(i+1)/n`. Example: `pat |> striate(4)`.
+    return <- pat if (n <= 0)
     let nf = double(n)
     let nfinv = 1.0 / float(n)
     return @capture(= n, = nf, = nfinv, <- pat) (span : TimeSpan) : array<Hap> {
@@ -2094,6 +2095,7 @@ def striate(var pat : Pattern; n : int) : Pattern {
 // pat |> chop(4) — subdivide each event into n consecutive sample slices
 def chop(var pat : Pattern; n : int) : Pattern {
     //! Subdivides each event in place into `n` back-to-back slices of its sample (slice `i` = `begin..end` window `i/n`). Unlike `striate`, slices stay within each event's own time slot. Example: `s("bev") |> chop(4)`.
+    return <- pat if (n <= 0)
     let nfinv = 1.0 / float(n)
     return @capture(= n, = nfinv, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
@@ -2133,9 +2135,10 @@ def chop(var pat : Pattern; n : int) : Pattern {
 
 // pat |> slice(4, n("0 1 2 3")) — play sample slices in the order given by idx_pat
 def slice(var pat : Pattern; n : int; var idx_pat : Pattern) : Pattern {
-    //! Cuts the sample into `n` slices and plays them in the order/rhythm of `idx_pat` (whose `note` values are slice indices). Structure comes from `idx_pat`, the sample from `pat`. Example: `s("bev") |> slice(4, note("0 2 1 3"))`.
+    //! Cuts the sample into `n` slices and plays them in the order/rhythm of `idx_pat` (whose `note` values are slice indices). Structure comes from `idx_pat`, the sample from `pat`. Out-of-range indices wrap modulo `n`. Example: `s("bev") |> slice(4, note("0 2 1 3"))`.
+    return <- pat if (n <= 0)
     let nfinv = 1.0 / float(n)
-    return @capture(= nfinv, <- pat, <- idx_pat) (span : TimeSpan) : array<Hap> {
+    return @capture(= n, = nfinv, <- pat, <- idx_pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var ihaps <- idx_pat(span)
         result |> reserve(length(ihaps))
@@ -2144,7 +2147,8 @@ def slice(var pat : Pattern; n : int; var idx_pat : Pattern) : Pattern {
             var shaps <- pat(TimeSpan(start = onset, stop = onset + 0.001lf))
             var ev = length(shaps) > 0 ? shaps[0].value : ih.value
             delete shaps
-            let i = int(ih.value.note)
+            // wrap the slice index into [0, n-1] so out-of-range values cycle (live-coding: never crash)
+            let i = ((int(ih.value.note) % n) + n) % n
             ev.begin = float(i) * nfinv
             ev.end_pos = float(i + 1) * nfinv
             result |> push(Hap( // nolint:PERF006

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -2149,8 +2149,11 @@ def slice(var pat : Pattern; n : int; var idx_pat : Pattern) : Pattern {
             delete shaps
             // wrap the slice index into [0, n-1] so out-of-range values cycle (live-coding: never crash)
             let i = ((int(ih.value.note) % n) + n) % n
-            ev.begin = float(i) * nfinv
-            ev.end_pos = float(i + 1) * nfinv
+            // subdivide the sample's existing [begin, end_pos] window (composes like chop)
+            let b0 = ev.begin
+            let win = ev.end_pos - b0
+            ev.begin = b0 + float(i) * nfinv * win
+            ev.end_pos = b0 + float(i + 1) * nfinv * win
             result |> push(Hap( // nolint:PERF006
                 whole = ih.whole,
                 part = ih.part,

--- a/modules/dasAudio/strudel/strudel_pattern.das
+++ b/modules/dasAudio/strudel/strudel_pattern.das
@@ -11,7 +11,10 @@ module strudel_pattern shared public
 
 require strudel/strudel_event
 require strudel/strudel_time
-require math
+// Re-exported publicly: widened (int|float|double) combinators like `linger` and
+// `compress` return captured lambdas that call math builtins (floor/min/max).
+// Those lambdas re-instantiate in consumer modules, so math must be visible there.
+require math public
 
 //! A Pattern is a pure function from a query `TimeSpan` to the `Hap`s
 //! (events with timing info) that fall within it. No side effects, no audio —
@@ -21,6 +24,18 @@ typedef Pattern = lambda<(span : TimeSpan) : array<Hap>>
 //! to describe how the transformed copy of a pattern should differ from the
 //! original. Use ``@(x) => rev(x)`` for a lambda literal at call sites.
 typedef PatternTransform = lambda<(var pat : Pattern) : Pattern>
+
+// Numeric coercion for the `int | float | double` scalar parameters used across
+// the fluent API — lets call sites accept bare ints (`fast(2)`), floats
+// (`gain(0.5)`), and doubles (`fast(2.0lf)`) uniformly. The PERF020 suppression
+// is centralized here: `double(n)`/`float(n)` is a no-op for the same-type union
+// member, but is required to cover the other two.
+def private numd(n : int | float | double) : double {
+    return double(n) // nolint:PERF020
+}
+def private numf(n : int | float | double) : float {
+    return float(n) // nolint:PERF020
+}
 
 // ─── Constructors ───
 
@@ -57,17 +72,18 @@ def atom(name : string) : Pattern {
 // ─── Time Manipulation ───
 
 // Speed up by factor n. The pattern repeats n times per cycle.
-def fast(var pat : Pattern; n : double) : Pattern {
-    //! Speeds up `pat` by factor `n` — the pattern repeats `n` times per cycle. Example: `s("bd") |> fast(2.0lf)`.
-    return @capture(= n, <- pat) (span : TimeSpan) : array<Hap> {
+def fast(var pat : Pattern; n : int | float | double) : Pattern {
+    //! Speeds up `pat` by factor `n` — the pattern repeats `n` times per cycle. Example: `s("bd") |> fast(2)`.
+    let nn = numd(n)
+    return @capture(= nn, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
-        let innerSpan = TimeSpan(start = span.start * n, stop = span.stop * n)
+        let innerSpan = TimeSpan(start = span.start * nn, stop = span.stop * nn)
         var haps <- pat(innerSpan)
         result |> reserve(length(haps))
         for (h in haps) {
             result |> push(Hap(
-                whole = TimeSpan(start = h.whole.start / n, stop = h.whole.stop / n),
-                part = TimeSpan(start = h.part.start / n, stop = h.part.stop / n),
+                whole = TimeSpan(start = h.whole.start / nn, stop = h.whole.stop / nn),
+                part = TimeSpan(start = h.part.start / nn, stop = h.part.stop / nn),
                 has_whole = h.has_whole,
                 value = h.value
             ))
@@ -78,9 +94,9 @@ def fast(var pat : Pattern; n : double) : Pattern {
 }
 
 // Slow down by factor n.
-def slow(var pat : Pattern; n : double) : Pattern {
-    //! Slows down `pat` by factor `n` — `pat` takes `n` cycles to complete once. Example: `s("bd sd") |> slow(2.0lf)`.
-    return fast(pat, 1.0lf / n)
+def slow(var pat : Pattern; n : int | float | double) : Pattern {
+    //! Slows down `pat` by factor `n` — `pat` takes `n` cycles to complete once. Example: `s("bd sd") |> slow(2)`.
+    return fast(pat, 1.0lf / numd(n))
 }
 
 // Shift pattern earlier in time by `offset` cycles.
@@ -233,14 +249,15 @@ def fmap(var pat : Pattern; var fn : lambda<(e : Event) : Event>) : Pattern {
 
 // Randomly remove events with given probability.
 // Uses deterministic hash of cycle position — same cycle = same result.
-def degrade(var pat : Pattern; prob : float) : Pattern {
+def degrade(var pat : Pattern; prob : int | float | double) : Pattern {
     //! Randomly drops events from `pat` with probability `prob` (0..1). Deterministic — same time yields same result. Example: `s("bd*8") |> degrade(0.3)`.
-    return @capture(= prob, <- pat) (span : TimeSpan) : array<Hap> {
+    let pf = numf(prob)
+    return @capture(= pf, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var haps <- pat(span)
         for (h in haps) {
             let r = strudel_hash01(h.whole.start, 0)
-            if (r >= prob) {
+            if (r >= pf) {
                 result |> push(h)
             }
         }
@@ -309,78 +326,88 @@ def bjorklund(k, n : int) : array<bool> {
 // Each sets a single Event field via fmap.
 
 // pat |> set_gain(0.5) — set amplitude
-def set_gain(var pat : Pattern; g : float) : Pattern {
+def set_gain(var pat : Pattern; g : int | float | double) : Pattern {
     //! Sets the `gain` (amplitude, 0..1) field on every event in `pat`. Example: `pat |> set_gain(0.5)`.
     let fn <- @capture(= g) (e : Event) : Event {
-        var r = e; r.gain = g; return r
+        var r = e; r.gain = numf(g); return r
     }
     return <- fmap(pat, fn)
 }
 
-// pat |> set_velocity(0.5) — set expression/velocity
-def private set_velocity(var pat : Pattern; v : float) : Pattern {
+def set_velocity(var pat : Pattern; v : int | float | double) : Pattern {
+    //! Sets the `velocity` (MIDI-like expression, 0..1) field on every event in `pat`.
     let fn <- @capture(= v) (e : Event) : Event {
-        var r = e; r.velocity = v; return r
+        var r = e; r.velocity = numf(v); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_pan(0.0) — set stereo position (0=left, 0.5=center, 1=right)
-def set_pan(var pat : Pattern; p : float) : Pattern {
+def set_pan(var pat : Pattern; p : int | float | double) : Pattern {
     //! Sets the `pan` (stereo position: 0=left, 0.5=center, 1=right) field on every event in `pat`.
     let fn <- @capture(= p) (e : Event) : Event {
-        var r = e; r.pan = p; return r
+        var r = e; r.pan = numf(p); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_hrtf_azimuth(-45.0) — set 3D HRTF azimuth (degrees, -180..180); pan still controls source width.
-def set_hrtf_azimuth(var pat : Pattern; deg : float) : Pattern {
+def set_hrtf_azimuth(var pat : Pattern; deg : int | float | double) : Pattern {
     //! Sets the HRTF azimuth (degrees, -180..180) on every event in `pat` and engages HRTF positioning.
     //! 0 = directly ahead, +90 = right, -90 = left. Under the binaural-stereo HRTF render `pan` still
     //! controls source width / L/R balance feeding the spatialiser; HRTF controls 3D position.
     let fn <- @capture(= deg) (e : Event) : Event {
-        var r = e; r.hrtf_azimuth = deg; r.hrtf_active = true; return r
+        var r = e; r.hrtf_azimuth = numf(deg); r.hrtf_active = true; return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_hrtf_elevation(15.0) — set 3D HRTF elevation (degrees, -90..90); pan still controls source width.
-def set_hrtf_elevation(var pat : Pattern; deg : float) : Pattern {
+def set_hrtf_elevation(var pat : Pattern; deg : int | float | double) : Pattern {
     //! Sets the HRTF elevation (degrees, -90..90) on every event in `pat` and engages HRTF positioning.
     //! 0 = horizontal plane, positive = up. Under the binaural-stereo HRTF render `pan` still controls
     //! source width / L/R balance feeding the spatialiser; HRTF controls 3D position.
     let fn <- @capture(= deg) (e : Event) : Event {
-        var r = e; r.hrtf_elevation = deg; r.hrtf_active = true; return r
+        var r = e; r.hrtf_elevation = numf(deg); r.hrtf_active = true; return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_hrtf(-45.0, 0.0) — set both HRTF azimuth and elevation in one call; pan still controls source width.
-def set_hrtf(var pat : Pattern; az, el : float) : Pattern {
+def set_hrtf(var pat : Pattern; az, el : int | float | double) : Pattern {
     //! Sets HRTF azimuth and elevation in one call and engages HRTF positioning.
     //! Azimuth (-180..180): 0 = ahead, +90 = right, -90 = left. Elevation (-90..90): 0 = horizontal.
     //! Under the binaural-stereo HRTF render `pan` still controls source width / L/R balance feeding
     //! the spatialiser; HRTF controls 3D position.
     let fn <- @capture(= az, = el) (e : Event) : Event {
-        var r = e; r.hrtf_azimuth = az; r.hrtf_elevation = el; r.hrtf_active = true; return r
+        var r = e; r.hrtf_azimuth = numf(az); r.hrtf_elevation = numf(el); r.hrtf_active = true; return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_speed(2.0) — set sample playback speed
-def private set_speed(var pat : Pattern; spd : float) : Pattern {
+def set_speed(var pat : Pattern; spd : int | float | double) : Pattern {
+    //! Sets the sample playback `speed` on every event in `pat` (1.0 = normal, 2.0 = double pitch/rate).
     let fn <- @capture(= spd) (e : Event) : Event {
-        var r = e; r.speed = spd; return r
+        var r = e; r.speed = numf(spd); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_note(48.0) — set MIDI note number
-def set_note(var pat : Pattern; n : float) : Pattern {
+def set_note(var pat : Pattern; n : int | float | double) : Pattern {
     //! Sets the MIDI `note` number on every event in `pat`. Example: `pat |> set_note(48.0)` (C3).
     let fn <- @capture(= n) (e : Event) : Event {
-        var r = e; r.note = n; return r
+        var r = e; r.note = numf(n); return r
+    }
+    return <- fmap(pat, fn)
+}
+
+// pat |> set_freq(440.0) — set explicit oscillator frequency in Hz (overrides note)
+def set_freq(var pat : Pattern; f : int | float | double) : Pattern {
+    //! Sets the explicit oscillator frequency `freq` (Hz) on every event in `pat`, overriding `note`. Example: `atom("sawtooth") |> set_freq(440.0)`.
+    let fn <- @capture(= f) (e : Event) : Event {
+        var r = e; r.freq = numf(f); return r
     }
     return <- fmap(pat, fn)
 }
@@ -412,54 +439,54 @@ def private set_cut(var pat : Pattern; c : int) : Pattern {
 }
 
 // pat |> set_room(0.5) — set reverb send amount
-def set_room(var pat : Pattern; r : float) : Pattern {
+def set_room(var pat : Pattern; r : int | float | double) : Pattern {
     //! Sets the reverb send amount `room` (0..1) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
-        var ev = e; ev.room = r; return ev
+        var ev = e; ev.room = numf(r); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_roomsize(0.8) — set reverb room size
-def set_roomsize(var pat : Pattern; r : float) : Pattern {
+def set_roomsize(var pat : Pattern; r : int | float | double) : Pattern {
     //! Sets the reverb room size `roomsize` (larger = more sustained reverb) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
-        var ev = e; ev.roomsize = r; return ev
+        var ev = e; ev.roomsize = numf(r); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_delay(0.5) — set delay send amount
-def set_delay(var pat : Pattern; d : float) : Pattern {
+def set_delay(var pat : Pattern; d : int | float | double) : Pattern {
     //! Sets the delay send amount (`delay_amount`, 0..1) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
-        var ev = e; ev.delay_amount = d; return ev
+        var ev = e; ev.delay_amount = numf(d); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_delaytime(0.25) — set delay time in seconds
-def set_delaytime(var pat : Pattern; d : float) : Pattern {
+def set_delaytime(var pat : Pattern; d : int | float | double) : Pattern {
     //! Sets the delay time `delaytime` (seconds) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
-        var ev = e; ev.delaytime = d; return ev
+        var ev = e; ev.delaytime = numf(d); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_delayfeedback(0.7) — set delay feedback
-def set_delayfeedback(var pat : Pattern; d : float) : Pattern {
+def set_delayfeedback(var pat : Pattern; d : int | float | double) : Pattern {
     //! Sets the delay feedback `delayfeedback` (0..<1) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
-        var ev = e; ev.delayfeedback = d; return ev
+        var ev = e; ev.delayfeedback = numf(d); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_delaysync(0.1875) — set delay time in cycles (tempo-synced delay)
-def private set_delaysync(var pat : Pattern; d : float) : Pattern {
+def private set_delaysync(var pat : Pattern; d : int | float | double) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
-        var ev = e; ev.delaysync = d; return ev
+        var ev = e; ev.delaysync = numf(d); return ev
     }
     return <- fmap(pat, fn)
 }
@@ -474,42 +501,43 @@ def set_orbit(var pat : Pattern; o : int) : Pattern {
 }
 
 // pat |> set_fm(2.0) — set FM modulation depth
-def set_fm(var pat : Pattern; f : float) : Pattern {
+def set_fm(var pat : Pattern; f : int | float | double) : Pattern {
     //! Sets the FM modulation depth `fm` (modulator amplitude) on every event in `pat`.
     let fn <- @capture(= f) (e : Event) : Event {
-        var ev = e; ev.fm = f; return ev
+        var ev = e; ev.fm = numf(f); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_fmh(1.5) — set FM harmonicity ratio
-def set_fmh(var pat : Pattern; f : float) : Pattern {
+def set_fmh(var pat : Pattern; f : int | float | double) : Pattern {
     //! Sets the FM harmonicity ratio `fmh` (modulator frequency / carrier frequency) on every event in `pat`.
     let fn <- @capture(= f) (e : Event) : Event {
-        var ev = e; ev.fmh = f; return ev
+        var ev = e; ev.fmh = numf(f); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // ─── Sample Region & Audio Effects ───
 
-def private set_begin(var pat : Pattern; b : float) : Pattern {
+def private set_begin(var pat : Pattern; b : int | float | double) : Pattern {
     let fn <- @capture(= b) (e : Event) : Event {
-        var r = e; r.begin = b; return r
+        var r = e; r.begin = numf(b); return r
     }
     return <- fmap(pat, fn)
 }
 
-def private set_end(var pat : Pattern; e_val : float) : Pattern {
+def private set_end(var pat : Pattern; e_val : int | float | double) : Pattern {
     let fn <- @capture(= e_val) (e : Event) : Event {
-        var r = e; r.end_pos = e_val; return r
+        var r = e; r.end_pos = numf(e_val); return r
     }
     return <- fmap(pat, fn)
 }
 
-def private set_crush(var pat : Pattern; c : float) : Pattern {
+def set_crush(var pat : Pattern; c : int | float | double) : Pattern {
+    //! Sets the bit-`crush` amount on every event in `pat` (lower = more bit-depth reduction).
     let fn <- @capture(= c) (e : Event) : Event {
-        var r = e; r.crush = c; return r
+        var r = e; r.crush = numf(c); return r
     }
     return <- fmap(pat, fn)
 }
@@ -521,110 +549,115 @@ def private set_coarse(var pat : Pattern; c : int) : Pattern {
     return <- fmap(pat, fn)
 }
 
-def private set_shape(var pat : Pattern; s : float) : Pattern {
+def set_shape(var pat : Pattern; s : int | float | double) : Pattern {
+    //! Sets the waveshape/distortion amount `shape` (0..1) on every event in `pat`.
     let fn <- @capture(= s) (e : Event) : Event {
-        var r = e; r.shape = s; return r
+        var r = e; r.shape = numf(s); return r
     }
     return <- fmap(pat, fn)
 }
 
-def private set_djf(var pat : Pattern; d : float) : Pattern {
+def private set_djf(var pat : Pattern; d : int | float | double) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
-        var r = e; r.djf = d; return r
+        var r = e; r.djf = numf(d); return r
     }
     return <- fmap(pat, fn)
 }
 
-def private set_bpf(var pat : Pattern; freq : float) : Pattern {
+def set_bpf(var pat : Pattern; freq : int | float | double) : Pattern {
+    //! Sets the band-pass filter cutoff `bpf` (Hz) on every event in `pat`.
     let fn <- @capture(= freq) (e : Event) : Event {
-        var r = e; r.bpf = freq; return r
+        var r = e; r.bpf = numf(freq); return r
     }
     return <- fmap(pat, fn)
 }
 
-def private set_bpq(var pat : Pattern; q : float) : Pattern {
+def private set_bpq(var pat : Pattern; q : int | float | double) : Pattern {
     let fn <- @capture(= q) (e : Event) : Event {
-        var r = e; r.bpq = q; return r
+        var r = e; r.bpq = numf(q); return r
     }
     return <- fmap(pat, fn)
 }
 
 // Phaser: rate in Hz (0 disables). Modulates a single notch biquad.
-def private set_phaser(var pat : Pattern; r : float) : Pattern {
+def set_phaser(var pat : Pattern; r : int | float | double) : Pattern {
+    //! Sets the phaser rate `phaser` (Hz, 0 disables) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
-        var ev = e; ev.phaser = r; return ev
+        var ev = e; ev.phaser = numf(r); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_phaserdepth(var pat : Pattern; d : float) : Pattern {
+def private set_phaserdepth(var pat : Pattern; d : int | float | double) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
-        var ev = e; ev.phaserdepth = d; return ev
+        var ev = e; ev.phaserdepth = numf(d); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_phasercenter(var pat : Pattern; c : float) : Pattern {
+def private set_phasercenter(var pat : Pattern; c : int | float | double) : Pattern {
     let fn <- @capture(= c) (e : Event) : Event {
-        var ev = e; ev.phasercenter = c; return ev
+        var ev = e; ev.phasercenter = numf(c); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_phasersweep(var pat : Pattern; s : float) : Pattern {
+def private set_phasersweep(var pat : Pattern; s : int | float | double) : Pattern {
     let fn <- @capture(= s) (e : Event) : Event {
-        var ev = e; ev.phasersweep = s; return ev
+        var ev = e; ev.phasersweep = numf(s); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // Tremolo: rate in Hz (0 disables), amplitude modulation.
-def private set_tremolo(var pat : Pattern; r : float) : Pattern {
+def set_tremolo(var pat : Pattern; r : int | float | double) : Pattern {
+    //! Sets the tremolo rate `tremolo` (Hz, 0 disables — amplitude modulation) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
-        var ev = e; ev.tremolo = r; return ev
+        var ev = e; ev.tremolo = numf(r); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_tremolodepth(var pat : Pattern; d : float) : Pattern {
+def private set_tremolodepth(var pat : Pattern; d : int | float | double) : Pattern {
     let fn <- @capture(= d) (e : Event) : Event {
-        var ev = e; ev.tremolodepth = d; return ev
+        var ev = e; ev.tremolodepth = numf(d); return ev
     }
     return <- fmap(pat, fn)
 }
 
 // Compressor: threshold in dB (>=0 = bypass). Negative values activate.
-def private set_compressor(var pat : Pattern; thr_db : float) : Pattern {
+def set_compressor(var pat : Pattern; thr_db : int | float | double) : Pattern {
+    //! Sets the compressor threshold `compressor` (dB; >=0 bypasses, negative activates) on every event in `pat`.
     let fn <- @capture(= thr_db) (e : Event) : Event {
-        var ev = e; ev.compressor = thr_db; return ev
+        var ev = e; ev.compressor = numf(thr_db); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_compressor_ratio(var pat : Pattern; ratio : float) : Pattern {
+def private set_compressor_ratio(var pat : Pattern; ratio : int | float | double) : Pattern {
     let fn <- @capture(= ratio) (e : Event) : Event {
-        var ev = e; ev.compressor_ratio = ratio; return ev
+        var ev = e; ev.compressor_ratio = numf(ratio); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_compressor_knee(var pat : Pattern; knee : float) : Pattern {
+def private set_compressor_knee(var pat : Pattern; knee : int | float | double) : Pattern {
     let fn <- @capture(= knee) (e : Event) : Event {
-        var ev = e; ev.compressor_knee = knee; return ev
+        var ev = e; ev.compressor_knee = numf(knee); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_compressor_attack(var pat : Pattern; a : float) : Pattern {
+def private set_compressor_attack(var pat : Pattern; a : int | float | double) : Pattern {
     let fn <- @capture(= a) (e : Event) : Event {
-        var ev = e; ev.compressor_attack = a; return ev
+        var ev = e; ev.compressor_attack = numf(a); return ev
     }
     return <- fmap(pat, fn)
 }
 
-def private set_compressor_release(var pat : Pattern; r : float) : Pattern {
+def private set_compressor_release(var pat : Pattern; r : int | float | double) : Pattern {
     let fn <- @capture(= r) (e : Event) : Event {
-        var ev = e; ev.compressor_release = r; return ev
+        var ev = e; ev.compressor_release = numf(r); return ev
     }
     return <- fmap(pat, fn)
 }
@@ -751,105 +784,106 @@ def private set_sf2_bank(var pat : Pattern; bank : int) : Pattern {
 }
 
 // pat |> set_sf2_expression(0.5) — set SF2 expression CC11 (0.0–1.0)
-def private set_sf2_expression(var pat : Pattern; v : float) : Pattern {
+def private set_sf2_expression(var pat : Pattern; v : int | float | double) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
-        var r = e; r.sf2_expression = v; return r
+        var r = e; r.sf2_expression = numf(v); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_sf2_mod_wheel(0.5) — set SF2 mod wheel CC1 (0.0–1.0, vibrato depth)
-def private set_sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
+def private set_sf2_mod_wheel(var pat : Pattern; v : int | float | double) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
-        var r = e; r.sf2_mod_wheel = v; return r
+        var r = e; r.sf2_mod_wheel = numf(v); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_sf2_pitch_bend(0.6) — set SF2 pitch bend (0.0–1.0, 0.5 = center)
-def private set_sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
+def private set_sf2_pitch_bend(var pat : Pattern; v : int | float | double) : Pattern {
     let fn <- @capture(= v) (e : Event) : Event {
-        var r = e; r.sf2_pitch_bend = v; return r
+        var r = e; r.sf2_pitch_bend = numf(v); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_chorus(0.5) — set chorus send amount (0.0–1.0)
-def private set_chorus(var pat : Pattern; c : float) : Pattern {
+def set_chorus(var pat : Pattern; c : int | float | double) : Pattern {
+    //! Sets the chorus send amount `chorus` (0..1) on every event in `pat`.
     let fn <- @capture(= c) (e : Event) : Event {
-        var r = e; r.chorus = c; return r
+        var r = e; r.chorus = numf(c); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_lpq(5.0) — set low-pass filter resonance
-def set_lpq(var pat : Pattern; q : float) : Pattern {
+def set_lpq(var pat : Pattern; q : int | float | double) : Pattern {
     //! Sets the low-pass filter resonance `lpq` (Q factor) on every event in `pat`.
     let fn <- @capture(= q) (e : Event) : Event {
-        var r = e; r.lpq = q; return r
+        var r = e; r.lpq = numf(q); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_hpq(5.0) — set high-pass filter resonance
-def set_hpq(var pat : Pattern; q : float) : Pattern {
+def set_hpq(var pat : Pattern; q : int | float | double) : Pattern {
     //! Sets the high-pass filter resonance `hpq` (Q factor) on every event in `pat`.
     let fn <- @capture(= q) (e : Event) : Event {
-        var r = e; r.hpq = q; return r
+        var r = e; r.hpq = numf(q); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_lpf(1000.0) — set low-pass filter cutoff
-def set_lpf(var pat : Pattern; freq : float) : Pattern {
+def set_lpf(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Sets the low-pass filter cutoff `lpf` (Hz) on every event in `pat`.
     let fn <- @capture(= freq) (e : Event) : Event {
-        var r = e; r.lpf = freq; return r
+        var r = e; r.lpf = numf(freq); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_hpf(200.0) — set high-pass filter cutoff
-def set_hpf(var pat : Pattern; freq : float) : Pattern {
+def set_hpf(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Sets the high-pass filter cutoff `hpf` (Hz) on every event in `pat`.
     let fn <- @capture(= freq) (e : Event) : Event {
-        var r = e; r.hpf = freq; return r
+        var r = e; r.hpf = numf(freq); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_attack(0.1) — set envelope attack time
-def set_attack(var pat : Pattern; a : float) : Pattern {
+def set_attack(var pat : Pattern; a : int | float | double) : Pattern {
     //! Sets the amp-envelope `attack` time (seconds) on every event in `pat`.
     let fn <- @capture(= a) (e : Event) : Event {
-        var r = e; r.attack = a; return r
+        var r = e; r.attack = numf(a); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_decay(0.3) — set envelope decay time
-def set_decay(var pat : Pattern; d : float) : Pattern {
+def set_decay(var pat : Pattern; d : int | float | double) : Pattern {
     //! Sets the amp-envelope `decay` time (seconds) on every event in `pat`.
     let fn <- @capture(= d) (e : Event) : Event {
-        var r = e; r.decay = d; return r
+        var r = e; r.decay = numf(d); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_sustain(0.7) — set envelope sustain level
-def set_sustain(var pat : Pattern; s : float) : Pattern {
+def set_sustain(var pat : Pattern; s : int | float | double) : Pattern {
     //! Sets the amp-envelope `sustain` level (0..1) on every event in `pat`.
     let fn <- @capture(= s) (e : Event) : Event {
-        var r = e; r.sustain = s; return r
+        var r = e; r.sustain = numf(s); return r
     }
     return <- fmap(pat, fn)
 }
 
 // pat |> set_release(0.5) — set envelope release time
-def set_release(var pat : Pattern; r : float) : Pattern {
+def set_release(var pat : Pattern; r : int | float | double) : Pattern {
     //! Sets the amp-envelope `release` time (seconds) on every event in `pat`.
     let fn <- @capture(= r) (e : Event) : Event {
-        var ev = e; ev.release = r; return ev
+        var ev = e; ev.release = numf(r); return ev
     }
     return <- fmap(pat, fn)
 }
@@ -908,9 +942,9 @@ def jux(var pat : Pattern; transform : PatternTransform) : Pattern {
 
 // Overlay pattern with a time-shifted copy.
 // off(s("bd sd"), 0.125, @(x) => transpose(x, 7.0)) — canon at the fifth
-def off(var pat : Pattern; time : double; transform : PatternTransform) : Pattern {
+def off(var pat : Pattern; time : int | float | double; transform : PatternTransform) : Pattern {
     //! Overlays `pat` with a time-shifted copy transformed by `transform`. Example: `s("bd sd") |> off(0.125, @@(x) => transpose(x, 7.0))` — canon at the fifth.
-    var shifted <- invoke(transform, pat) |> late(time)
+    var shifted <- invoke(transform, pat) |> late(numd(time))
     var layers : array<Pattern> // nolint:STYLE012
     layers |> emplace <| pat
     layers |> emplace <| shifted
@@ -993,16 +1027,16 @@ def layer(var pats : array<Pattern>; var base : Pattern) : Pattern {
 }
 
 // Shift note by semitones. transpose(pat, 7) = up a fifth.
-def transpose(var pat : Pattern; semitones : float) : Pattern {
+def transpose(var pat : Pattern; semitones : int | float | double) : Pattern {
     //! Shifts every event's MIDI note by `semitones`. Example: `pat |> transpose(7.0)` transposes up a fifth.
     let fn <- @capture(= semitones) (e : Event) : Event {
-        var r = e; r.note += semitones; return r
+        var r = e; r.note += numf(semitones); return r
     }
     return <- fmap(pat, fn)
 }
 
 // Alias: add is the same as transpose (matches strudel naming).
-def add(var pat : Pattern; semitones : float) : Pattern {
+def add(var pat : Pattern; semitones : int | float | double) : Pattern {
     //! Alias for `transpose` — adds `semitones` to each event's note. Matches strudel naming.
     return <- transpose(pat, semitones)
 }
@@ -1175,12 +1209,13 @@ def signal_perlin() : Pattern {
 }
 
 // Scale a signal from 0..1 to lo..hi.
-def signal_range(var pat : Pattern; lo, hi : float) : Pattern {
+def signal_range(var pat : Pattern; lo, hi : int | float | double) : Pattern {
     //! Scales a signal pattern from `0..1` to `lo..hi`. Example: `sine() |> signal_range(200.0, 4000.0)` for a 200..4000 Hz filter sweep.
-    let span = hi - lo
-    return fmap(pat, @capture(= lo, = span) (e : Event) : Event {
+    let vlo = numf(lo)
+    let span = numf(hi) - vlo
+    return fmap(pat, @capture(= vlo, = span) (e : Event) : Event {
         var r = e
-        r.note = lo + r.note * span
+        r.note = vlo + r.note * span
         return r
     })
 }
@@ -1233,6 +1268,13 @@ def set_note(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     //! Pattern-valued `set_note` — samples `mod_pat` at each event onset to set `note`. Example: `pat |> set_note(saw() |> range(48.0, 72.0))`.
     return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
         var r = e; r.note = val; return r
+    })
+}
+
+def set_freq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-valued `set_freq` — samples `mod_pat` at each event onset to set `freq` (Hz, overrides note).
+    return combineWith(pat, mod_pat, @(e : Event; val : float) : Event {
+        var r = e; r.freq = val; return r
     })
 }
 
@@ -1621,6 +1663,43 @@ def euclid(var pat : Pattern; k, n : int) : Pattern {
     }
 }
 
+// pat |> euclidRot(3, 8, 1) — Euclidean rhythm rotated by `rot` steps
+def euclidRot(var pat : Pattern; k, n, rot : int) : Pattern {
+    //! Euclidean rhythm like `euclid`, then rotated left by `rot` steps. Example: `atom("bd") |> euclidRot(3, 8, 1)` shifts the tresillo onsets one step earlier.
+    var base <- bjorklund(k, n)
+    let steps = length(base)
+    var rhythm : array<bool>
+    if (steps > 0) {
+        rhythm |> resize(steps)
+        let r = ((rot % steps) + steps) % steps
+        for (i in range(steps)) {
+            rhythm[i] = base[(i + r) % steps]
+        }
+    }
+    delete base
+    let nf = double(n)
+    return @capture(<- rhythm, = nf, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        let steps = length(rhythm)
+        return <- result if (steps == 0)
+        let innerSpan = TimeSpan(start = span.start * nf, stop = span.stop * nf)
+        var haps <- pat(innerSpan)
+        for (h in haps) {
+            let step = int(sameCycle(h.whole.start)) % steps
+            if (rhythm[step]) {
+                result |> push(Hap(
+                    whole = TimeSpan(start = h.whole.start / nf, stop = h.whole.stop / nf),
+                    part = TimeSpan(start = h.part.start / nf, stop = h.part.stop / nf),
+                    has_whole = h.has_whole,
+                    value = h.value
+                ))
+            }
+        }
+        delete haps
+        return <- result
+    }
+}
+
 // ─── Additional Combinators ───
 
 // Play forward on even cycles, reversed on odd cycles.
@@ -1679,20 +1758,22 @@ def superimpose(var pat : Pattern; transform : PatternTransform) : Pattern {
 
 // Repeat events with time offset and gain decay.
 // echo(pat, 3, 0.25, 0.5) — 3 echoes, 0.25 cycles apart, each 50% quieter
-def echo(var pat : Pattern; times : int; time : double; feedback : float) : Pattern {
+def echo(var pat : Pattern; times : int; time : int | float | double; feedback : int | float | double) : Pattern {
     //! Repeats every event `times` times, offset by `time` cycles each, with each repeat scaled by `feedback`. Example: `pat |> echo(3, 0.25lf, 0.5)`.
     // Build gain table and offsets, then query pat once per span and duplicate haps
+    let vtime = numd(time)
+    let vfeedback = numf(feedback)
     var gains : array<float>
     var offsets : array<double>
     gains |> reserve(times)
     offsets |> reserve(times)
     gains |> push(1.0)       // original at full gain
     offsets |> push(0.0lf)   // original at zero offset
-    var current_gain = feedback
+    var current_gain = vfeedback
     for (i in range(1, times)) {
         gains |> push(current_gain)
-        offsets |> push(time * double(i))
-        current_gain *= feedback
+        offsets |> push(vtime * double(i))
+        current_gain *= vfeedback
     }
     let n = length(gains)
     return @capture(= n, <- gains, <- offsets, <- pat) (span : TimeSpan) : array<Hap> {
@@ -1720,7 +1801,7 @@ def echo(var pat : Pattern; times : int; time : double; feedback : float) : Patt
 }
 
 // stut — alias for echo with reordered parameters (times, feedback, time).
-def stut(var pat : Pattern; times : int; feedback : float; time : double) : Pattern {
+def stut(var pat : Pattern; times : int; feedback : int | float | double; time : int | float | double) : Pattern {
     //! Alias for `echo` with argument order `(times, feedback, time)`. Example: `pat |> stut(3, 0.5, 0.125lf)`.
     return <- echo(pat, times, time, feedback)
 }
@@ -1847,11 +1928,12 @@ def when_cycle(var pat : Pattern; var cond : lambda<(cycle : int) : bool>; trans
 
 // Loop first fraction of pattern. linger(pat, 0.25) — first quarter looped to fill each cycle.
 // Semantics: output(T) = pat(T mod t). Equivalent to pat.zoom(0, t).slow(t).
-def linger(var pat : Pattern; t : double) : Pattern {
-    //! Loops the first `t`-cycle fraction of `pat` to fill each cycle. Example: `pat |> linger(0.25lf)` loops the first quarter.
-    return @capture(= t, <- pat) (span : TimeSpan) : array<Hap> {
+def linger(var pat : Pattern; t : int | float | double) : Pattern {
+    //! Loops the first `t`-cycle fraction of `pat` to fill each cycle. Example: `pat |> linger(0.25)` loops the first quarter.
+    let tt = numd(t)
+    return @capture(= tt, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
-        return <- result if (t <= 0.0lf)
+        return <- result if (tt <= 0.0lf)
         var inscope split = splitSpans(span)
         for (sub in split) {
             let cycle = floor(sub.start)
@@ -1860,9 +1942,9 @@ def linger(var pat : Pattern; t : double) : Pattern {
             // iterate each period-t chunk overlapping [relStart, relStop]
             var i = 0
             while (true) {
-                let chunkStart = double(i) * t
+                let chunkStart = double(i) * tt
                 break if (chunkStart >= 1.0lf || chunkStart >= relStop)
-                let chunkStop = chunkStart + t
+                let chunkStop = chunkStart + tt
                 if (chunkStop > relStart) {
                     let overlapStart = max(chunkStart, relStart)
                     let overlapStop = min(min(chunkStop, 1.0lf), relStop)
@@ -1891,23 +1973,24 @@ def linger(var pat : Pattern; t : double) : Pattern {
 }
 
 // Combined fast + speed. hurry(pat, 2.0) speeds up pattern AND sample playback.
-def hurry(var pat : Pattern; factor : double) : Pattern {
+def hurry(var pat : Pattern; factor : int | float | double) : Pattern {
     //! Combined `fast` + `set_speed` — speeds up both pattern timing AND sample playback by `factor`. Example: `pat |> hurry(2.0lf)`.
-    return <- fast(pat, factor) |> set_speed(float(factor))
+    return <- fast(pat, factor) |> set_speed(factor)
 }
 
 // Squeeze pattern into time window [b,e] within each cycle.
 // compress(pat, 0.25, 0.75) — pattern plays in middle half of each cycle
-def compress(var pat : Pattern; b, e : double) : Pattern {
-    //! Squeezes `pat` into the cycle-time window `[b, e]`. Example: `pat |> compress(0.25lf, 0.75lf)` plays the pattern in the middle half.
-    let dur = e - b
-    return @capture(= b, = dur, <- pat) (span : TimeSpan) : array<Hap> {
+def compress(var pat : Pattern; b, e : int | float | double) : Pattern {
+    //! Squeezes `pat` into the cycle-time window `[b, e]`. Example: `pat |> compress(0.25, 0.75)` plays the pattern in the middle half.
+    let bb = numd(b)
+    let dur = numd(e) - bb
+    return @capture(= bb, = dur, <- pat) (span : TimeSpan) : array<Hap> {
         var result : array<Hap>
         var inscope split = splitSpans(span)
         for (sub in split) {
             let cycle = floor(sub.start)
-            let winStart = cycle + b
-            let winStop = cycle + b + dur
+            let winStart = cycle + bb
+            let winStop = cycle + bb + dur
             let overStart = max(sub.start, winStart)
             let overStop = min(sub.stop, winStop)
             if (overStart >= overStop) continue
@@ -2004,6 +2087,74 @@ def striate(var pat : Pattern; n : int) : Pattern {
             ))
         }
         delete haps
+        return <- result
+    }
+}
+
+// pat |> chop(4) — subdivide each event into n consecutive sample slices
+def chop(var pat : Pattern; n : int) : Pattern {
+    //! Subdivides each event in place into `n` back-to-back slices of its sample (slice `i` = `begin..end` window `i/n`). Unlike `striate`, slices stay within each event's own time slot. Example: `s("bev") |> chop(4)`.
+    let nfinv = 1.0 / float(n)
+    return @capture(= n, = nfinv, <- pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var haps <- pat(span)
+        result |> reserve(length(haps) * n)
+        for (h in haps) {
+            let wstart = h.whole.start
+            let wdur = h.whole.stop - h.whole.start
+            if (wdur <= 0.0lf) {
+                result |> push(h) // nolint:PERF006
+                continue
+            }
+            // subdivide the sample's existing [begin, end_pos] window into n parts
+            let b0 = h.value.begin
+            let win = h.value.end_pos - b0
+            for (i in range(n)) {
+                let subStart = wstart + wdur * (double(i) / double(n))
+                let subStop = wstart + wdur * (double(i + 1) / double(n))
+                let pStart = max(subStart, h.part.start)
+                let pStop = min(subStop, h.part.stop)
+                continue if (pStart >= pStop)
+                var ev = h.value
+                ev.begin = b0 + float(i) * nfinv * win
+                ev.end_pos = b0 + float(i + 1) * nfinv * win
+                result |> push(Hap( // nolint:PERF006
+                    whole = TimeSpan(start = subStart, stop = subStop),
+                    part = TimeSpan(start = pStart, stop = pStop),
+                    has_whole = h.has_whole,
+                    value = ev
+                ))
+            }
+        }
+        delete haps
+        return <- result
+    }
+}
+
+// pat |> slice(4, n("0 1 2 3")) — play sample slices in the order given by idx_pat
+def slice(var pat : Pattern; n : int; var idx_pat : Pattern) : Pattern {
+    //! Cuts the sample into `n` slices and plays them in the order/rhythm of `idx_pat` (whose `note` values are slice indices). Structure comes from `idx_pat`, the sample from `pat`. Example: `s("bev") |> slice(4, note("0 2 1 3"))`.
+    let nfinv = 1.0 / float(n)
+    return @capture(= nfinv, <- pat, <- idx_pat) (span : TimeSpan) : array<Hap> {
+        var result : array<Hap>
+        var ihaps <- idx_pat(span)
+        result |> reserve(length(ihaps))
+        for (ih in ihaps) {
+            let onset = ih.has_whole ? ih.whole.start : ih.part.start
+            var shaps <- pat(TimeSpan(start = onset, stop = onset + 0.001lf))
+            var ev = length(shaps) > 0 ? shaps[0].value : ih.value
+            delete shaps
+            let i = int(ih.value.note)
+            ev.begin = float(i) * nfinv
+            ev.end_pos = float(i + 1) * nfinv
+            result |> push(Hap( // nolint:PERF006
+                whole = ih.whole,
+                part = ih.part,
+                has_whole = ih.has_whole,
+                value = ev
+            ))
+        }
+        delete ihaps
         return <- result
     }
 }
@@ -2134,7 +2285,10 @@ def chooseCycles(var pats : array<Pattern>) : Pattern {
 //   apply Murmur3 finalizer for full avalanche
 // This replaces earlier LCG/single-multiply hashes whose middle bits correlated
 // across consecutive slots (the "same-note-in-a-row" bug in scramble/shuffle).
-def private strudel_hash32(t : double; slot : int) : uint {
+def strudel_hash32(t : double; slot : int) : uint {
+    //! Deterministic 32-bit hash of a query time + slot index, used by the random combinators
+    //! (`degrade`, `shuffle`, `scramble`, `choose`). Public so their captured lambdas resolve it
+    //! when re-instantiated in a consumer module.
     let Ti = int64(t * 536870912.0lf)
     let lo = uint(Ti)
     let hi = uint(Ti >> 32l)
@@ -2149,7 +2303,9 @@ def private strudel_hash32(t : double; slot : int) : uint {
 }
 
 // Same hash, mapped to float in [0, 1).
-def private strudel_hash01(t : double; slot : int) : float {
+def strudel_hash01(t : double; slot : int) : float {
+    //! `strudel_hash32` mapped to a float in `[0, 1)`. Public so the random combinators' captured
+    //! lambdas resolve it when re-instantiated in a consumer module.
     return float(strudel_hash32(t, slot)) / 4294967296.0
 }
 
@@ -2368,40 +2524,40 @@ def private signal_run(n : int) : Pattern {
 
 // ── Scalar parameter aliases ──
 
-def gain(var pat : Pattern; g : float) : Pattern {
+def gain(var pat : Pattern; g : int | float | double) : Pattern {
     //! Fluent shorthand for `set_gain`. Sets amplitude (0..1) on every event.
     return <- set_gain(pat, g)
 }
-def velocity(var pat : Pattern; v : float) : Pattern {
+def velocity(var pat : Pattern; v : int | float | double) : Pattern {
     //! Fluent shorthand for `set_velocity`. Sets MIDI-like velocity (0..1) on every event.
     return <- set_velocity(pat, v)
 }
-def vel(var pat : Pattern; v : float) : Pattern {
+def vel(var pat : Pattern; v : int | float | double) : Pattern {
     //! Alias for `velocity`.
     return <- set_velocity(pat, v)
 }
-def pan(var pat : Pattern; p : float) : Pattern {
+def pan(var pat : Pattern; p : int | float | double) : Pattern {
     //! Fluent shorthand for `set_pan`. Sets stereo position (0=L, 0.5=C, 1=R).
     return <- set_pan(pat, p)
 }
-def hrtf_azimuth(var pat : Pattern; deg : float) : Pattern {
+def hrtf_azimuth(var pat : Pattern; deg : int | float | double) : Pattern {
     //! Fluent shorthand for `set_hrtf_azimuth`. Engages HRTF positioning; `pan` still controls source width.
     return <- set_hrtf_azimuth(pat, deg)
 }
-def hrtf_elevation(var pat : Pattern; deg : float) : Pattern {
+def hrtf_elevation(var pat : Pattern; deg : int | float | double) : Pattern {
     //! Fluent shorthand for `set_hrtf_elevation`. Engages HRTF positioning; `pan` still controls source width.
     return <- set_hrtf_elevation(pat, deg)
 }
-def hrtf(var pat : Pattern; az, el : float) : Pattern {
+def hrtf(var pat : Pattern; az, el : int | float | double) : Pattern {
     //! Fluent shorthand for `set_hrtf` — sets HRTF azimuth + elevation and engages 3D positioning;
     //! `pan` still controls source width.
     return <- set_hrtf(pat, az, el)
 }
-def speed(var pat : Pattern; spd : float) : Pattern {
+def speed(var pat : Pattern; spd : int | float | double) : Pattern {
     //! Fluent shorthand for `set_speed`. Sets sample playback speed.
     return <- set_speed(pat, spd)
 }
-def note(var pat : Pattern; n : float) : Pattern {
+def note(var pat : Pattern; n : int | float | double) : Pattern {
     //! Fluent shorthand for `set_note`. Sets MIDI note number on every event.
     return <- set_note(pat, n)
 }
@@ -2413,39 +2569,39 @@ def cut(var pat : Pattern; c : int) : Pattern {
     //! Fluent shorthand for `set_cut`. Sets the cut group (new voice kills previous in same group).
     return <- set_cut(pat, c)
 }
-def room(var pat : Pattern; r : float) : Pattern {
+def room(var pat : Pattern; r : int | float | double) : Pattern {
     //! Fluent shorthand for `set_room`. Sets reverb send amount (0..1).
     return <- set_room(pat, r)
 }
-def roomsize(var pat : Pattern; r : float) : Pattern {
+def roomsize(var pat : Pattern; r : int | float | double) : Pattern {
     //! Fluent shorthand for `set_roomsize`. Sets reverb room size.
     return <- set_roomsize(pat, r)
 }
-def size(var pat : Pattern; r : float) : Pattern {
+def size(var pat : Pattern; r : int | float | double) : Pattern {
     //! Alias for `roomsize`.
     return <- set_roomsize(pat, r)
 }
-def delay(var pat : Pattern; d : float) : Pattern {
+def delay(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_delay`. Sets delay send amount (0..1).
     return <- set_delay(pat, d)
 }
-def delaytime(var pat : Pattern; d : float) : Pattern {
+def delaytime(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_delaytime`. Sets delay time in seconds.
     return <- set_delaytime(pat, d)
 }
-def dt(var pat : Pattern; d : float) : Pattern {
+def dt(var pat : Pattern; d : int | float | double) : Pattern {
     //! Alias for `delaytime`.
     return <- set_delaytime(pat, d)
 }
-def delayfeedback(var pat : Pattern; d : float) : Pattern {
+def delayfeedback(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_delayfeedback`. Sets delay feedback (0..<1).
     return <- set_delayfeedback(pat, d)
 }
-def dfb(var pat : Pattern; d : float) : Pattern {
+def dfb(var pat : Pattern; d : int | float | double) : Pattern {
     //! Alias for `delayfeedback`.
     return <- set_delayfeedback(pat, d)
 }
-def delaysync(var pat : Pattern; d : float) : Pattern {
+def delaysync(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_delaysync`. Sets delay time in cycles (tempo-synced delay).
     return <- set_delaysync(pat, d)
 }
@@ -2453,90 +2609,90 @@ def orbit(var pat : Pattern; o : int) : Pattern {
     //! Fluent shorthand for `set_orbit`. Sets the effect-bus routing index.
     return <- set_orbit(pat, o)
 }
-def fm(var pat : Pattern; f : float) : Pattern {
+def fm(var pat : Pattern; f : int | float | double) : Pattern {
     //! Fluent shorthand for `set_fm`. Sets FM modulation depth.
     return <- set_fm(pat, f)
 }
-def fmh(var pat : Pattern; f : float) : Pattern {
+def fmh(var pat : Pattern; f : int | float | double) : Pattern {
     //! Fluent shorthand for `set_fmh`. Sets FM harmonicity ratio.
     return <- set_fmh(pat, f)
 }
-def lpf(var pat : Pattern; freq : float) : Pattern {
+def lpf(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Fluent shorthand for `set_lpf`. Sets low-pass cutoff (Hz).
     return <- set_lpf(pat, freq)
 }
-def lp(var pat : Pattern; freq : float) : Pattern {
+def lp(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Alias for `lpf`.
     return <- set_lpf(pat, freq)
 }
-def hpf(var pat : Pattern; freq : float) : Pattern {
+def hpf(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Fluent shorthand for `set_hpf`. Sets high-pass cutoff (Hz).
     return <- set_hpf(pat, freq)
 }
-def hp(var pat : Pattern; freq : float) : Pattern {
+def hp(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Alias for `hpf`.
     return <- set_hpf(pat, freq)
 }
-def lpq(var pat : Pattern; q : float) : Pattern {
+def lpq(var pat : Pattern; q : int | float | double) : Pattern {
     //! Fluent shorthand for `set_lpq`. Sets low-pass filter resonance.
     return <- set_lpq(pat, q)
 }
-def resonance(var pat : Pattern; q : float) : Pattern {
+def resonance(var pat : Pattern; q : int | float | double) : Pattern {
     //! Alias for `lpq`.
     return <- set_lpq(pat, q)
 }
-def hpq(var pat : Pattern; q : float) : Pattern {
+def hpq(var pat : Pattern; q : int | float | double) : Pattern {
     //! Fluent shorthand for `set_hpq`. Sets high-pass filter resonance.
     return <- set_hpq(pat, q)
 }
-def attack(var pat : Pattern; a : float) : Pattern {
+def attack(var pat : Pattern; a : int | float | double) : Pattern {
     //! Fluent shorthand for `set_attack`. Sets envelope attack (seconds).
     return <- set_attack(pat, a)
 }
-def att(var pat : Pattern; a : float) : Pattern {
+def att(var pat : Pattern; a : int | float | double) : Pattern {
     //! Alias for `attack`.
     return <- set_attack(pat, a)
 }
-def decay(var pat : Pattern; d : float) : Pattern {
+def decay(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_decay`. Sets envelope decay (seconds).
     return <- set_decay(pat, d)
 }
-def dec(var pat : Pattern; d : float) : Pattern {
+def dec(var pat : Pattern; d : int | float | double) : Pattern {
     //! Alias for `decay`.
     return <- set_decay(pat, d)
 }
-def sustain(var pat : Pattern; s : float) : Pattern {
+def sustain(var pat : Pattern; s : int | float | double) : Pattern {
     //! Fluent shorthand for `set_sustain`. Sets envelope sustain level (0..1).
     return <- set_sustain(pat, s)
 }
-def sus(var pat : Pattern; s : float) : Pattern {
+def sus(var pat : Pattern; s : int | float | double) : Pattern {
     //! Alias for `sustain`.
     return <- set_sustain(pat, s)
 }
-def release(var pat : Pattern; r : float) : Pattern {
+def release(var pat : Pattern; r : int | float | double) : Pattern {
     //! Fluent shorthand for `set_release`. Sets envelope release (seconds).
     return <- set_release(pat, r)
 }
-def rel(var pat : Pattern; r : float) : Pattern {
+def rel(var pat : Pattern; r : int | float | double) : Pattern {
     //! Alias for `release`.
     return <- set_release(pat, r)
 }
-def chorus(var pat : Pattern; c : float) : Pattern {
+def chorus(var pat : Pattern; c : int | float | double) : Pattern {
     //! Fluent shorthand for `set_chorus`. Sets chorus send amount (0..1).
     return <- set_chorus(pat, c)
 }
 
 // ── Sample region & effects aliases ──
 
-def begin(var pat : Pattern; b : float) : Pattern {
+def begin(var pat : Pattern; b : int | float | double) : Pattern {
     //! Fluent shorthand for `set_begin`. Sets sample start position (0..1).
     return <- set_begin(pat, b)
 }
-def end_pos(var pat : Pattern; e_val : float) : Pattern {
+def end_pos(var pat : Pattern; e_val : int | float | double) : Pattern {
     //! Fluent shorthand for `set_end`. Sets sample end position (0..1).
     return <- set_end(pat, e_val)
 }
-def crush(var pat : Pattern; c : float) : Pattern {
+def crush(var pat : Pattern; c : int | float | double) : Pattern {
     //! Fluent shorthand for `set_crush`. Sets bit-crush amount.
     return <- set_crush(pat, c)
 }
@@ -2544,109 +2700,109 @@ def coarse(var pat : Pattern; c : int) : Pattern {
     //! Fluent shorthand for `set_coarse`. Sets sample-rate reduction factor.
     return <- set_coarse(pat, c)
 }
-def shape(var pat : Pattern; s : float) : Pattern {
+def shape(var pat : Pattern; s : int | float | double) : Pattern {
     //! Fluent shorthand for `set_shape`. Sets waveshape/distortion amount.
     return <- set_shape(pat, s)
 }
-def djf(var pat : Pattern; d : float) : Pattern {
+def djf(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_djf`. Sets DJ-filter position (<0.5 = LP, >0.5 = HP).
     return <- set_djf(pat, d)
 }
-def bpf(var pat : Pattern; freq : float) : Pattern {
+def bpf(var pat : Pattern; freq : int | float | double) : Pattern {
     //! Fluent shorthand for `set_bpf`. Sets band-pass filter cutoff (Hz).
     return <- set_bpf(pat, freq)
 }
-def bpq(var pat : Pattern; q : float) : Pattern {
+def bpq(var pat : Pattern; q : int | float | double) : Pattern {
     //! Fluent shorthand for `set_bpq`. Sets band-pass filter Q.
     return <- set_bpq(pat, q)
 }
 
 // ── Phaser / Tremolo / Compressor aliases ──
 
-def phaser(var pat : Pattern; r : float) : Pattern {
+def phaser(var pat : Pattern; r : int | float | double) : Pattern {
     //! Fluent shorthand for `set_phaser`. Sets phaser rate in Hz (0 disables).
     return <- set_phaser(pat, r)
 }
-def ph(var pat : Pattern; r : float) : Pattern {
+def ph(var pat : Pattern; r : int | float | double) : Pattern {
     //! Alias for `phaser`.
     return <- set_phaser(pat, r)
 }
-def phaserdepth(var pat : Pattern; d : float) : Pattern {
+def phaserdepth(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_phaserdepth`. Sets phaser depth.
     return <- set_phaserdepth(pat, d)
 }
-def phd(var pat : Pattern; d : float) : Pattern {
+def phd(var pat : Pattern; d : int | float | double) : Pattern {
     //! Alias for `phaserdepth`.
     return <- set_phaserdepth(pat, d)
 }
-def phasercenter(var pat : Pattern; c : float) : Pattern {
+def phasercenter(var pat : Pattern; c : int | float | double) : Pattern {
     //! Fluent shorthand for `set_phasercenter`. Sets phaser center frequency.
     return <- set_phasercenter(pat, c)
 }
-def phc(var pat : Pattern; c : float) : Pattern {
+def phc(var pat : Pattern; c : int | float | double) : Pattern {
     //! Alias for `phasercenter`.
     return <- set_phasercenter(pat, c)
 }
-def phasersweep(var pat : Pattern; s : float) : Pattern {
+def phasersweep(var pat : Pattern; s : int | float | double) : Pattern {
     //! Fluent shorthand for `set_phasersweep`. Sets phaser sweep range.
     return <- set_phasersweep(pat, s)
 }
-def phs(var pat : Pattern; s : float) : Pattern {
+def phs(var pat : Pattern; s : int | float | double) : Pattern {
     //! Alias for `phasersweep`.
     return <- set_phasersweep(pat, s)
 }
 
-def tremolo(var pat : Pattern; r : float) : Pattern {
+def tremolo(var pat : Pattern; r : int | float | double) : Pattern {
     //! Fluent shorthand for `set_tremolo`. Sets tremolo rate in Hz (0 disables).
     return <- set_tremolo(pat, r)
 }
-def trem(var pat : Pattern; r : float) : Pattern {
+def trem(var pat : Pattern; r : int | float | double) : Pattern {
     //! Alias for `tremolo`.
     return <- set_tremolo(pat, r)
 }
-def tremolodepth(var pat : Pattern; d : float) : Pattern {
+def tremolodepth(var pat : Pattern; d : int | float | double) : Pattern {
     //! Fluent shorthand for `set_tremolodepth`. Sets tremolo depth.
     return <- set_tremolodepth(pat, d)
 }
-def tremdepth(var pat : Pattern; d : float) : Pattern {
+def tremdepth(var pat : Pattern; d : int | float | double) : Pattern {
     //! Alias for `tremolodepth`.
     return <- set_tremolodepth(pat, d)
 }
 
-def compressor(var pat : Pattern; thr_db : float) : Pattern {
+def compressor(var pat : Pattern; thr_db : int | float | double) : Pattern {
     //! Fluent shorthand for `set_compressor`. Sets compressor threshold in dB (>=0 bypasses).
     return <- set_compressor(pat, thr_db)
 }
 // camelCase aliases; also expose snake_case for daScript-idiomatic callers.
-def compressorRatio(var pat : Pattern; r : float) : Pattern {
+def compressorRatio(var pat : Pattern; r : int | float | double) : Pattern {
     //! camelCase fluent shorthand for `set_compressor_ratio`. Sets compressor ratio.
     return <- set_compressor_ratio(pat, r)
 }
-def compressor_ratio(var pat : Pattern; r : float) : Pattern {
+def compressor_ratio(var pat : Pattern; r : int | float | double) : Pattern {
     //! snake_case fluent shorthand for `set_compressor_ratio`. Sets compressor ratio.
     return <- set_compressor_ratio(pat, r)
 }
-def compressorKnee(var pat : Pattern; k : float) : Pattern {
+def compressorKnee(var pat : Pattern; k : int | float | double) : Pattern {
     //! camelCase fluent shorthand for `set_compressor_knee`. Sets compressor knee (dB).
     return <- set_compressor_knee(pat, k)
 }
-def compressor_knee(var pat : Pattern; k : float) : Pattern {
+def compressor_knee(var pat : Pattern; k : int | float | double) : Pattern {
     //! snake_case fluent shorthand for `set_compressor_knee`. Sets compressor knee (dB).
     return <- set_compressor_knee(pat, k)
 }
-def compressorAttack(var pat : Pattern; a : float) : Pattern {
+def compressorAttack(var pat : Pattern; a : int | float | double) : Pattern {
     //! camelCase fluent shorthand for `set_compressor_attack`. Sets compressor attack (seconds).
     return <- set_compressor_attack(pat, a)
 }
-def compressor_attack(var pat : Pattern; a : float) : Pattern {
+def compressor_attack(var pat : Pattern; a : int | float | double) : Pattern {
     //! snake_case fluent shorthand for `set_compressor_attack`. Sets compressor attack (seconds).
     return <- set_compressor_attack(pat, a)
 }
-def compressorRelease(var pat : Pattern; r : float) : Pattern {
+def compressorRelease(var pat : Pattern; r : int | float | double) : Pattern {
     //! camelCase fluent shorthand for `set_compressor_release`. Sets compressor release (seconds).
     return <- set_compressor_release(pat, r)
 }
-def compressor_release(var pat : Pattern; r : float) : Pattern {
+def compressor_release(var pat : Pattern; r : int | float | double) : Pattern {
     //! snake_case fluent shorthand for `set_compressor_release`. Sets compressor release (seconds).
     return <- set_compressor_release(pat, r)
 }
@@ -2665,15 +2821,15 @@ def sf2_bank(var pat : Pattern; bank : int) : Pattern {
     //! Fluent shorthand for `set_sf2_bank`. Sets SF2 bank (0 = melodic, 128 = percussion).
     return <- set_sf2_bank(pat, bank)
 }
-def sf2_expression(var pat : Pattern; v : float) : Pattern {
+def sf2_expression(var pat : Pattern; v : int | float | double) : Pattern {
     //! Fluent shorthand for `set_sf2_expression`. Sets SF2 expression CC11 (0..1).
     return <- set_sf2_expression(pat, v)
 }
-def sf2_mod_wheel(var pat : Pattern; v : float) : Pattern {
+def sf2_mod_wheel(var pat : Pattern; v : int | float | double) : Pattern {
     //! Fluent shorthand for `set_sf2_mod_wheel`. Sets SF2 mod wheel CC1 (0..1, vibrato depth).
     return <- set_sf2_mod_wheel(pat, v)
 }
-def sf2_pitch_bend(var pat : Pattern; v : float) : Pattern {
+def sf2_pitch_bend(var pat : Pattern; v : int | float | double) : Pattern {
     //! Fluent shorthand for `set_sf2_pitch_bend`. Sets SF2 pitch bend (0..1, 0.5 = center).
     return <- set_sf2_pitch_bend(pat, v)
 }
@@ -2711,6 +2867,14 @@ def speed(var pat : Pattern; var mod_pat : Pattern) : Pattern {
 def note(var pat : Pattern; var mod_pat : Pattern) : Pattern {
     //! Pattern-modulated `note` — sampled from `mod_pat` per event.
     return <- set_note(pat, mod_pat)
+}
+def freq(var pat : Pattern; f : int | float | double) : Pattern {
+    //! Fluent shorthand for `set_freq`. Sets explicit oscillator frequency (Hz), overriding note. Example: `atom("sawtooth") |> freq(440)`.
+    return <- set_freq(pat, f)
+}
+def freq(var pat : Pattern; var mod_pat : Pattern) : Pattern {
+    //! Pattern-modulated `freq` — Hz sampled from `mod_pat` per event.
+    return <- set_freq(pat, mod_pat)
 }
 def sound(var pat : Pattern; var sound_pat : Pattern) : Pattern {
     //! Pattern-valued `sound` — sound name sampled from `sound_pat.s` per event. Example: `note("c3") |> sound(s("<saw tri>"))`.
@@ -2967,7 +3131,7 @@ def perlin() : Pattern {
     //! Unipolar Perlin-noise signal `0..1`. Alias for `signal_perlin`.
     return <- signal_perlin()
 }
-def range(var pat : Pattern; lo, hi : float) : Pattern {
+def range(var pat : Pattern; lo, hi : int | float | double) : Pattern {
     //! Scales a signal pattern from `0..1` to `lo..hi`. Alias for `signal_range`. Example: `sine() |> range(200.0, 4000.0)`.
     return <- signal_range(pat, lo, hi)
 }
@@ -3030,7 +3194,7 @@ def run(n : int) : Pattern {
 
 // ── Additional aliases ──
 
-def degradeBy(var pat : Pattern; prob : float) : Pattern {
+def degradeBy(var pat : Pattern; prob : int | float | double) : Pattern {
     //! Alias for `degrade` with explicit probability. Randomly drops events with probability `prob`. Example: `pat |> degradeBy(0.3)`.
     return <- degrade(pat, prob)
 }

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -339,6 +339,7 @@ def public strudel_command(cmd : string) {
     }
 }
 
+[unused_argument(cmd)]
 def public strudel_noop_cmd(cmd : string) {
     //! No-op command handler — default argument when no user command dispatcher is needed.
     pass

--- a/modules/dasAudio/strudel/strudel_samples.das
+++ b/modules/dasAudio/strudel/strudel_samples.das
@@ -180,7 +180,7 @@ def render_sample(bank : SampleBank; name : string; variation : int; speed : flo
             ma_resample_algorithm.ma_resample_algorithm_linear
         )
         ma_resampler_init(unsafe(addr(resampler_config)), unsafe(addr(resampler)))
-        var outFrames = uint64(ma_resampler_get_expected_output_frame_count(unsafe(addr(resampler)), uint64(sliceFrames)))
+        var outFrames = ma_resampler_get_expected_output_frame_count(unsafe(addr(resampler)), uint64(sliceFrames))
         var resampled : array<float>
         resampled |> resize(int(outFrames) * int(srcChannels))
         var inFrames = uint64(sliceFrames)

--- a/modules/dasAudio/strudel/strudel_scales.das
+++ b/modules/dasAudio/strudel/strudel_scales.das
@@ -82,7 +82,7 @@ def private parse_scale_root(root_str : string) : int {
             if (idx < n) {
                 let octCh = int(bytes[idx])
                 if (is_number(octCh)) {
-                    octave = octCh - int('0')
+                    octave = octCh - '0'
                 }
             }
         }

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -964,7 +964,8 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     let adsr = resolve_adsr(h.value.attack, h.value.decay, h.value.sustain, h.value.release)
                     var oscv = OscVoice(
                         osc_type = oscType,
-                        freq = note_to_freq(h.value.note),
+                        // explicit freq() overrides note; 0 = derive from note (strudel.cc parity)
+                        freq = h.value.freq > 0.0 ? h.value.freq : note_to_freq(h.value.note),
                         duration = durSec,
                         attack = adsr._0,
                         decay = adsr._1,
@@ -1066,7 +1067,7 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     sched.voice_fx_buf |> resize(chunk_samples)
                 }
                 let pan = clamp(voice.pan, -1.0, 1.0)
-                let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
+                let angle = (pan + 1.0) * 0.25 * (TWO_PI / 2.0)
                 let lGain = voice.gain * cos(angle)
                 let rGain = voice.gain * sin(angle)
                 for (f in range(nf)) {
@@ -1113,7 +1114,7 @@ def tick(var sched : Scheduler; var pat : Pattern; bank : SampleBank; wall_time 
                     )
                 }
                 let pan = clamp(voice.pan, -1.0, 1.0)
-                let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
+                let angle = (pan + 1.0) * 0.25 * (TWO_PI / 2.0)
                 // reverb send for pre-rendered voices
                 if (voice.reverb_send > 0.0 && reverb_buf != null) {
                     let sL = voice.gain * voice.reverb_send * cos(angle)

--- a/modules/dasAudio/strudel/strudel_sf2.das
+++ b/modules/dasAudio/strudel/strudel_sf2.das
@@ -483,6 +483,7 @@ def public get_generator_range(zone : SF2Zone; oper : int) : int2 {
     return int2(0, 127)
 }
 
+[unused_argument(terminal_oper)]
 def private resolve_zones(bags : array<RawBag>; all_gens : array<SF2Generator>; all_mods : array<SF2Modulator>;
                           bag_start, bag_end : int; terminal_oper : int) : array<SF2Zone?> {
     var zones : array<SF2Zone?>

--- a/modules/dasAudio/strudel/strudel_sf2_voice.das
+++ b/modules/dasAudio/strudel/strudel_sf2_voice.das
@@ -583,6 +583,7 @@ def public sf2_recalc_atten(atten_state : SF2VoiceAttenState; cc_values : int[12
 
 // ─── C Voice Creation (populates ma_sf2_voice from SF2 generators) ───
 
+[unused_argument(channel)]
 def public sf2_create_c_voice(sf2 : SF2File; inst_idx, izone_idx : int;
                               pzone : SF2Zone const?; global_pzone : SF2Zone const?;
                               note, velocity, channel : int;
@@ -594,7 +595,7 @@ def public sf2_create_c_voice(sf2 : SF2File; inst_idx, izone_idx : int;
     let inst = sf2.instruments[inst_idx]
     let izone = inst.zones[izone_idx]
     let global_izone = inst.global_zone
-    let sr = float(SF2_SAMPLE_RATE)
+    let sr = SF2_SAMPLE_RATE
 
     let sid = get_gen(*izone, global_izone, pzone, global_pzone, int(SF2GenOper.sampleID), -1)
     if (sid < 0 || sid >= length(sf2.samples)) return false

--- a/modules/dasAudio/strudel/strudel_synth.das
+++ b/modules/dasAudio/strudel/strudel_synth.das
@@ -104,7 +104,7 @@ def render_bd(duration : float; gain : float) : array<float> {
     var phase = 0.0
     var seed = 22222u
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     // bandpass for subtle beater click
     var attack_bp = BiquadState()
     biquad_bandpass(attack_bp, 1500.0, 1.5, float(SAMPLE_RATE))
@@ -139,7 +139,7 @@ def render_sd(duration : float; gain : float) : array<float> {
     var phase = 0.0
     var seed = 12345u
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     // snare wires: HPF at 1.5kHz to get the sizzle
     var wire_hpf = BiquadState()
     biquad_highpass(wire_hpf, 1500.0, float(SAMPLE_RATE))
@@ -170,7 +170,7 @@ def render_hh(duration : float; gain : float) : array<float> {
     // add tonal component (~200Hz) like SF2 — the "bell" of the hi-hat
     var phase = 0.0
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     let inc = tp * 180.0 * iSr
     for (i in range(nsamples)) {
         let t = float(i) * iSr
@@ -218,7 +218,7 @@ struct private BiquadState {
 }
 
 def private biquad_highpass(var bq : BiquadState; freq, sample_rate : float) {
-    let w0 = float(TWO_PI) * freq / sample_rate
+    let w0 = TWO_PI * freq / sample_rate
     let cs = cos(w0)
     let sn = sin(w0)
     let alpha = sn / (2.0 * 0.707)  // Q = 0.707 (Butterworth)
@@ -231,7 +231,7 @@ def private biquad_highpass(var bq : BiquadState; freq, sample_rate : float) {
 }
 
 def private biquad_bandpass(var bq : BiquadState; freq, q, sample_rate : float) {
-    let w0 = float(TWO_PI) * freq / sample_rate
+    let w0 = TWO_PI * freq / sample_rate
     let cs = cos(w0)
     let sn = sin(w0)
     let alpha = sn / (2.0 * q)
@@ -264,7 +264,7 @@ def private render_metallic(duration : float; gain : float; decay_rate : float; 
     samples |> resize(nsamples)
     var phases : float[6]
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     // two bandpass stages at ~3.4kHz and ~7.1kHz (808 circuit) + HPF
     var bp1 = BiquadState()
     biquad_bandpass(bp1, 3400.0, 1.5, float(SAMPLE_RATE))
@@ -311,7 +311,7 @@ def render_tom(duration : float; gain : float; base_freq : float) : array<float>
     var phase = 0.0
     var seed = 33333u
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     var attack_bp = BiquadState()
     biquad_bandpass(attack_bp, 1500.0, 1.5, float(SAMPLE_RATE))
     var impulse_lp = BiquadState()
@@ -353,7 +353,7 @@ def render_ride(duration : float; gain : float) : array<float> {
     var bell_phase1 = 0.0
     var bell_phase2 = 0.0
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     var hpf = BiquadState()
     biquad_highpass(hpf, 200.0, float(SAMPLE_RATE))
     let bell_inc1 = tp * 340.0 * iSr
@@ -387,7 +387,7 @@ def render_crash(duration : float; gain : float) : array<float> {
     var bell_phase1 = 0.0
     var bell_phase2 = 0.0
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     var hpf = BiquadState()
     biquad_highpass(hpf, 4000.0, float(SAMPLE_RATE))
     let bell_inc1 = tp * 180.0 * iSr
@@ -420,7 +420,7 @@ def render_rimshot(duration : float; gain : float) : array<float> {
     var phase1 = 0.0
     var seed = 44444u
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     let inc1 = tp * 200.0 * iSr
     var snap_bp = BiquadState()
     biquad_bandpass(snap_bp, 800.0, 0.8, float(SAMPLE_RATE))
@@ -448,7 +448,7 @@ def render_cowbell(duration : float; gain : float) : array<float> {
     var phase1 = 0.0
     var phase2 = 0.0
     let iSr = 1.0 / float(SAMPLE_RATE)
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     let inc1 = tp * 375.0 * iSr
     let inc2 = tp * 504.0 * iSr
     var bpf = BiquadState()
@@ -939,7 +939,7 @@ def osc_voice_init_supersaw(var voice : OscVoice) {
     //! Seed the supersaw unison phases with randomised offsets so the detuned voices don't start in phase.
     var seed = 99999u
     for (i in range(SUPERSAW_VOICES)) {
-        voice.supersaw_phases[i] = float(noise(seed) * 0.5 + 0.5)  // [0,1)
+        voice.supersaw_phases[i] = (noise(seed) * 0.5 + 0.5)  // [0,1)
     }
 }
 
@@ -1193,9 +1193,9 @@ def osc_render_chunk(var voice : OscVoice; var output : array<float>; var reverb
     // hoist invariants
     let iSr = 1.0 / float(SAMPLE_RATE)
     let phaseInc = voice.freq * iSr
-    let tp = float(TWO_PI)
+    let tp = TWO_PI
     let pan = clamp(voice.pan, -1.0, 1.0)
-    let angle = (pan + 1.0) * 0.25 * float(TWO_PI / 2.0)
+    let angle = (pan + 1.0) * 0.25 * (TWO_PI / 2.0)
     let lGain = voice.gain * OSC_TURN_DOWN * cos(angle)
     let rGain = voice.gain * OSC_TURN_DOWN * sin(angle)
     let hasSend = voice.reverb_send > 0.0 && length(reverb_send_buf) >= chunkFrames * 2

--- a/skills/strudel_port.md
+++ b/skills/strudel_port.md
@@ -58,21 +58,25 @@ let pat <- (
 Without the surrounding parens the chain must be on one line
 (statement-level parsing is line-oriented).
 
-### 2. Numeric literals need a type
+### 2. Numeric literals just work
 
-strudel.cc accepts bare integers everywhere; daslang is typed:
+Every scalar pattern modifier accepts ``int``, ``float``, **or**
+``double`` (the param type is the union ``int | float | double``), so
+bare strudel.cc numbers translate directly — no suffix juggling:
 
 ```
-.fast(2)        →  |> fast(2.0)
-.gain(0.5)      →  |> gain(0.5)     // already OK
-.note(60)       →  |> note(60.0)
+.fast(2)        →  |> fast(2)       // bare int is fine
+.gain(0.5)      →  |> gain(0.5)
+.note(60)       →  |> note(60)
+.speed(2)       →  |> speed(2)      // (used to need 2.0)
 .delay(0.25)    →  |> delay(0.25)
-.orbit(1)       →  |> orbit(1)      // orbit is int — OK
+.orbit(1)       →  |> orbit(1)
 ```
 
-Rule: when in doubt, write the float with an explicit ``.0``. The
-compiler error for ``int`` where ``float`` is expected is loud and
-immediate.
+``2``, ``2.0``, and ``2.0lf`` are all accepted at the same call site.
+(This is a recent change — older code wrote ``fast(2.0lf)`` /
+``speed(2.0)`` because time funcs took ``double`` and effect funcs
+took ``float``. Both forms still compile; bare ints are now simplest.)
 
 ### 3. Bare identifiers as transforms → lambda literals
 
@@ -81,9 +85,15 @@ typed lambda:
 
 ```
 .jux(rev)              →  |> jux(@(x) => rev(x))
-.off(1/8, fast(2))     →  |> off(0.125, @(x) => fast(x, 2.0))
+.off(1/8, fast(2))     →  |> off(0.125, @(x) => fast(x, 2))
 .every(4, rev)         →  |> every(4, @(x) => rev(x))
 ```
+
+**Use ``@(x) =>`` (a capture lambda), NOT ``@@(x) =>``.** Combinators
+(``jux``, ``off``, ``sometimes``, ``superimpose``, ``chunk``,
+``when_cycle``, …) take ``PatternTransform = lambda<(Pattern):Pattern>``.
+A no-capture ``@@(x) =>`` is a *function pointer*, which does not match
+the ``lambda`` type and fails type inference. ``@(x) =>`` is correct.
 
 The ``@(x) => ...`` form is an inline lambda. See
 :ref:`tutorial_lambdas` for the syntax. If the transform itself is a
@@ -237,29 +247,29 @@ externalisation isn't needed. See
 
 ### Mini-notation ``bd(3,8)`` Euclidean form
 
-strudel.cc parses the integer-pair inside the string as Euclidean
-rhythm; daslang's mini-notation lexes the parens but does not parse
-them. **Rewrite** as an explicit combinator call::
+Parses directly — paste it verbatim::
 
-    // strudel.cc
-    s("bd(3,8)")
+    s("bd(3,8)")        // = euclid(s("bd"), 3, 8)
+    s("bd(3,8,2)")      // = euclidRot(s("bd"), 3, 8, 2)
 
-    // daslang
-    euclid(s("bd"), 3, 8)
+The function forms ``euclid(pat, k, n)`` and ``euclidRot(pat, k, n, rot)``
+are also public.
 
-### ``euclidRot``
+### Sample granulation: ``chop`` / ``slice`` / ``striate``
 
-Not implemented. Compose ``euclid`` with rotation via ``off`` or
-``rev``. See :ref:`strudel_vs_strudel_cc` for the full gap list.
+All available::
+
+    .chop(4)              →  |> chop(4)                    // n slices per event, in place
+    .striate(4)           →  |> striate(4)                 // n slices spread across the cycle
+    .slice(4, "0 1 2 3")  →  |> slice(4, note("0 1 2 3"))  // slices in index-pattern order
 
 ### Method aliases that don't exist
 
-``jux_rev``, ``chop``, and a few one-letter convenience wrappers are
-absent. Expand to the parametric form:
+``jux_rev`` and a few one-letter convenience wrappers are absent.
+Expand to the parametric form:
 
 ```
 .jux_rev()   →  |> jux(@(x) => rev(x))
-.chop(4)     →  |> striate(4)       // nearest equivalent
 ```
 
 ### Backtick-heavy mini-notation
@@ -303,8 +313,9 @@ If ``gain("1 0.5")`` doesn't compile, wrap the pattern literal in
 3. **If it sounds wrong:** check the three most common culprits in
    order — (a) missing samples falling back to silence, (b)
    tempo-aware ADSR making the envelope feel different, (c) a
-   combinator rewrite (``jux_rev``, ``chop``, ``euclidRot``) that
-   silently did nothing because the rewrite was wrong.
+   transform passed as ``@@(x) =>`` (function pointer) instead of
+   ``@(x) =>`` (lambda), which fails to compile against
+   ``PatternTransform``.
 
 ## Quick reference card
 
@@ -315,19 +326,23 @@ If ``gain("1 0.5")`` doesn't compile, wrap the pattern literal in
    * - strudel.cc
      - daslang
    * - ``s("bd").fast(2)``
-     - ``s("bd") \|> fast(2.0)``
+     - ``s("bd") \|> fast(2)``
    * - ``.jux(rev)``
      - ``\|> jux(@(x) => rev(x))``
    * - ``.every(4, fast(2))``
-     - ``\|> every(4, @(x) => fast(x, 2.0))``
+     - ``\|> every(4, @(x) => fast(x, 2))``
    * - ``stack(a, b, c)``
      - ``stack([a, b, c])``
    * - ``"bd(3,8)"``
-     - ``euclid(s("bd"), 3, 8)``
+     - ``s("bd(3,8)")`` (parses directly)
+   * - ``.euclidRot(3,8,2)`` / ``.chop(4)``
+     - ``\|> euclidRot(3,8,2)`` / ``\|> chop(4)``
+   * - ``.freq(440)``
+     - ``\|> freq(440)``
    * - ``.gain("1 0.5")``
      - ``\|> gain(s("1 0.5"))``
    * - ``.note(60)``
-     - ``\|> note(60.0)``
+     - ``\|> note(60)``
    * - ``s("saw")``
      - ``s("sawtooth")`` — no ``saw`` alias
    * - auto-play

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -186,6 +186,9 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_combinators.das
         tests/strudel/test_delay.das
         tests/strudel/test_effects.das
+        tests/strudel/test_fx_routing.das
+        tests/strudel/test_new_features.das
+        tests/strudel/test_numeric_widening.das
         tests/strudel/test_hrtf_pos.das
         tests/strudel/test_new_combinators.das
         tests/strudel/test_integration.das

--- a/tests/strudel/test_fx_routing.das
+++ b/tests/strudel/test_fx_routing.das
@@ -1,0 +1,72 @@
+options gen2
+options indenting = 4
+
+// Locks the per-voice vs per-orbit FX classification (the distinction tutorials
+// 07/08 disagreed on). Ground truth from the engine signal flow:
+//   per-orbit / bus : room/roomsize, delay/delaytime/delayfeedback, chorus
+//   per-voice       : lpf/hpf/bpf, phaser, tremolo, compressor, shape, crush,
+//                     coarse, djf, gain, pan, speed, fm, vowel
+// Per-orbit effects allocate a shared bus instance lazily per orbit; per-voice
+// effects only set Event fields and never allocate an orbit bus.
+
+require dastest/testing_boost
+require strudel/strudel
+require strudel/strudel_synth
+require strudel/strudel_scheduler
+require strudel/strudel_samples
+require math
+
+[test]
+def test_per_orbit_effects_allocate_bus(t : T?) {
+    t |> run("room/delay/chorus each lazily allocate their orbit bus on send") @(t : T?) {
+        // reverb (room) on orbit 0
+        var inscope s1 : Scheduler
+        s1.cps = 1.0lf
+        let pr <- atom("sine") |> room(0.6) |> set_orbit(0)
+        let bank : SampleBank
+        tick(s1, pr, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_reverb(s1, 0) != null, "room should allocate orbit reverb")
+
+        // delay on orbit 1
+        var inscope s2 : Scheduler
+        s2.cps = 1.0lf
+        let pd <- atom("sine") |> delay(0.5) |> set_orbit(1)
+        tick(s2, pd, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_delay(s2, 1) != null, "delay should allocate orbit delay")
+
+        // chorus on orbit 2
+        var inscope s3 : Scheduler
+        s3.cps = 1.0lf
+        let pc <- atom("sine") |> chorus(0.6) |> set_orbit(2)
+        tick(s3, pc, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_chorus(s3, 2) != null, "chorus should allocate orbit chorus")
+    }
+}
+
+[test]
+def test_per_voice_effects_do_not_allocate_orbit_bus(t : T?) {
+    t |> run("per-voice FX set event fields but allocate no orbit bus") @(t : T?) {
+        var inscope sched : Scheduler
+        sched.cps = 1.0lf
+        // lpf, phaser, crush, shape are per-voice — none should create an orbit bus
+        let pat <- atom("sawtooth") |> lpf(800.0) |> phaser(2.0) |> crush(6.0) |> shape(0.4) |> set_orbit(0)
+        let bank : SampleBank
+        tick(sched, pat, bank, 0.0lf, 0.05)
+        t |> success(get_orbit_reverb(sched, 0) == null, "per-voice FX must not allocate reverb")
+        t |> success(get_orbit_delay(sched, 0) == null, "per-voice FX must not allocate delay")
+        t |> success(get_orbit_chorus(sched, 0) == null, "per-voice FX must not allocate chorus")
+    }
+}
+
+[test]
+def test_per_voice_effects_set_event_fields(t : T?) {
+    // per-voice FX live on the Event payload
+    let p <- atom("sawtooth") |> lpf(800.0) |> hpf(200.0) |> bpf(1000.0) |> crush(6.0) |> shape(0.4) |> phaser(2.0) |> tremolo(3.0)
+    let h <- p(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> equal(length(h), 1)
+    let e = h[0].value
+    t |> success(abs(e.lpf - 800.0) < 0.001)
+    t |> success(abs(e.hpf - 200.0) < 0.001)
+    t |> success(abs(e.crush - 6.0) < 0.001)
+    t |> success(abs(e.shape - 0.4) < 0.001)
+}

--- a/tests/strudel/test_new_features.das
+++ b/tests/strudel/test_new_features.das
@@ -1,0 +1,102 @@
+options gen2
+options indenting = 4
+
+// Phase C/D features: freq() control, euclidRot, chop, slice, and the
+// bd(3,8) Euclidean mini-notation form.
+
+require dastest/testing_boost
+require strudel/strudel
+require strudel/strudel_time
+require math
+
+def private at(d : double) : TimeSpan {
+    return TimeSpan(start = 0.0lf, stop = d)
+}
+
+[test]
+def test_freq_sets_field(t : T?) {
+    let p <- atom("sawtooth") |> freq(440.0)
+    let h <- p(at(1.0lf))
+    t |> equal(length(h), 1)
+    t |> success(abs(h[0].value.freq - 440.0) < 0.001)
+    // default is 0 (derive from note)
+    let p2 <- atom("sawtooth")
+    let h2 <- p2(at(1.0lf))
+    t |> success(abs(h2[0].value.freq) < 0.001)
+}
+
+[test]
+def test_freq_pattern_overload(t : T?) {
+    // pattern-valued freq still resolves and samples
+    let p <- atom("sawtooth") |> freq(note("220 440"))
+    let h <- p(at(1.0lf))
+    t |> success(!empty(h))
+}
+
+[test]
+def test_note_to_freq_exists(t : T?) {
+    // feedback claimed this was missing — it is not
+    t |> success(abs(note_to_freq(69.0) - 440.0) < 0.5)
+}
+
+[test]
+def test_euclidRot(t : T?) {
+    // euclid(3,8) onsets: steps 0,3,6 -> 0, 0.375, 0.75
+    let e0 <- atom("bd") |> euclid(3, 8)
+    let h0 <- e0(at(1.0lf))
+    t |> equal(length(h0), 3)
+    t |> success(abs(h0[0].whole.start - 0.0lf) < 0.001lf)
+    // euclidRot(3,8,1): rotate left by 1 -> steps 2,5,7 -> 0.25, 0.625, 0.875
+    let e1 <- atom("bd") |> euclidRot(3, 8, 1)
+    let h1 <- e1(at(1.0lf))
+    t |> equal(length(h1), 3)
+    t |> success(abs(h1[0].whole.start - 0.25lf) < 0.001lf)
+    t |> success(abs(h1[1].whole.start - 0.625lf) < 0.001lf)
+    t |> success(abs(h1[2].whole.start - 0.875lf) < 0.001lf)
+}
+
+[test]
+def test_chop(t : T?) {
+    // chop(4): one held sample -> 4 back-to-back slices in [0,1)
+    let p <- atom("bev") |> chop(4)
+    let h <- p(at(1.0lf))
+    t |> equal(length(h), 4)
+    t |> success(abs(h[0].value.begin - 0.0) < 0.001)
+    t |> success(abs(h[0].value.end_pos - 0.25) < 0.001)
+    t |> success(abs(h[3].value.begin - 0.75) < 0.001)
+    t |> success(abs(h[3].value.end_pos - 1.0) < 0.001)
+    // whole subdivided
+    t |> success(abs(h[0].whole.start - 0.0lf) < 0.001lf)
+    t |> success(abs(h[0].whole.stop - 0.25lf) < 0.001lf)
+}
+
+[test]
+def test_slice(t : T?) {
+    // slice(4, "0 2 1 3"): structure from idx pattern; begin/end from index
+    let p <- s("bev") |> slice(4, note("0 2 1 3"))
+    let h <- p(at(1.0lf))
+    t |> equal(length(h), 4)
+    // slot 0 plays slice 0
+    t |> success(abs(h[0].value.begin - 0.0) < 0.001)
+    // slot 1 plays slice 2 -> begin 0.5
+    t |> success(abs(h[1].value.begin - 0.5) < 0.001)
+    // slot 2 plays slice 1 -> begin 0.25
+    t |> success(abs(h[2].value.begin - 0.25) < 0.001)
+    // sound carried from pat
+    t |> equal(h[0].value.s, "bev")
+}
+
+[test]
+def test_mini_euclid_paren(t : T?) {
+    // "bd(3,8)" -> euclid(3,8)
+    let p <- s("bd(3,8)")
+    let h <- p(at(1.0lf))
+    t |> equal(length(h), 3)
+    t |> success(abs(h[0].whole.start - 0.0lf) < 0.001lf)
+    t |> success(abs(h[1].whole.start - 0.375lf) < 0.001lf)
+    t |> success(abs(h[2].whole.start - 0.75lf) < 0.001lf)
+    // "bd(3,8,2)" -> rotated; composes in a sequence with another atom
+    let p2 <- s("bd(3,8) sd")
+    let h2 <- p2(at(1.0lf))
+    t |> equal(length(h2), 4)
+}

--- a/tests/strudel/test_new_features.das
+++ b/tests/strudel/test_new_features.das
@@ -13,6 +13,11 @@ def private at(d : double) : TimeSpan {
     return TimeSpan(start = 0.0lf, stop = d)
 }
 
+def private hc(p : Pattern) : int {
+    let h <- p(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    return length(h)
+}
+
 [test]
 def test_freq_sets_field(t : T?) {
     let p <- atom("sawtooth") |> freq(440.0)
@@ -84,6 +89,21 @@ def test_slice(t : T?) {
     t |> success(abs(h[2].value.begin - 0.25) < 0.001)
     // sound carried from pat
     t |> equal(h[0].value.s, "bev")
+    // out-of-range indices wrap modulo n: "4 5" with n=4 -> slices 0, 1
+    let pw <- s("bev") |> slice(4, note("4 5"))
+    let hw <- pw(at(1.0lf))
+    t |> equal(length(hw), 2)
+    t |> success(abs(hw[0].value.begin - 0.0) < 0.001)
+    t |> success(abs(hw[1].value.begin - 0.25) < 0.001)
+}
+
+[test]
+def test_granulation_guards(t : T?) {
+    // live-coding safety: n <= 0 must not crash — returns the pattern unchanged
+    t |> equal(hc(atom("bev") |> chop(0)), 1)
+    t |> equal(hc(atom("bev") |> chop(-2)), 1)
+    t |> equal(hc(atom("bev") |> striate(0)), 1)
+    t |> equal(hc(s("bev") |> slice(0, note("0 1"))), 1)
 }
 
 [test]
@@ -95,7 +115,14 @@ def test_mini_euclid_paren(t : T?) {
     t |> success(abs(h[0].whole.start - 0.0lf) < 0.001lf)
     t |> success(abs(h[1].whole.start - 0.375lf) < 0.001lf)
     t |> success(abs(h[2].whole.start - 0.75lf) < 0.001lf)
-    // "bd(3,8,2)" -> rotated; composes in a sequence with another atom
+    // "bd(3,8,2)" -> euclidRot(3,8,2): rotate left by 2 -> steps 1,4,6 -> 0.125, 0.5, 0.75
+    let pr <- s("bd(3,8,2)")
+    let hr <- pr(at(1.0lf))
+    t |> equal(length(hr), 3)
+    t |> success(abs(hr[0].whole.start - 0.125lf) < 0.001lf)
+    t |> success(abs(hr[1].whole.start - 0.5lf) < 0.001lf)
+    t |> success(abs(hr[2].whole.start - 0.75lf) < 0.001lf)
+    // composes in a sequence with another atom
     let p2 <- s("bd(3,8) sd")
     let h2 <- p2(at(1.0lf))
     t |> equal(length(h2), 4)

--- a/tests/strudel/test_numeric_widening.das
+++ b/tests/strudel/test_numeric_widening.das
@@ -1,0 +1,98 @@
+options gen2
+options indenting = 4
+
+// Compile-coverage for the int|float|double numeric widening (Phase A/B).
+// The POINT of this file is that it COMPILES: every widened public modifier is
+// exercised with int, float, AND double literals (one shallow chain per modifier
+// — kept shallow because deep fmap chains overflow the query stack). If any
+// variant regresses to a single concrete numeric type, this file fails to build
+// and CI catches it. Runtime behaviour is covered by the other strudel tests.
+
+require dastest/testing_boost
+require strudel/strudel
+require math
+
+// hap count over one cycle
+def private hc(p : Pattern) : int {
+    let h <- p(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    return length(h)
+}
+
+[test]
+def test_effect_setters_accept_int_float_double(t : T?) {
+    // each modifier called with int, then float, then double — non-structural,
+    // so the single held event survives the depth-3 chain.
+    t |> equal(hc(atom("sawtooth") |> gain(1) |> gain(0.5) |> gain(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> velocity(1) |> velocity(0.5) |> velocity(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> pan(0) |> pan(0.5) |> pan(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> speed(2) |> speed(1.5) |> speed(1.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> note(60) |> note(60.0) |> note(60.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> freq(440) |> freq(440.0) |> freq(440.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> room(1) |> room(0.5) |> room(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> roomsize(2) |> roomsize(2.0) |> roomsize(2.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> delay(1) |> delay(0.5) |> delay(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> delaytime(1) |> delaytime(0.25) |> delaytime(0.25lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> delayfeedback(1) |> delayfeedback(0.5) |> delayfeedback(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> fm(2) |> fm(2.0) |> fm(2.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> fmh(1) |> fmh(1.5) |> fmh(1.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> lpf(1000) |> lpf(1000.0) |> lpf(1000.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> hpf(200) |> hpf(200.0) |> hpf(200.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> lpq(5) |> lpq(5.0) |> lpq(5.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> hpq(5) |> hpq(5.0) |> hpq(5.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> attack(0) |> attack(0.01) |> attack(0.01lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> decay(0) |> decay(0.1) |> decay(0.1lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> sustain(1) |> sustain(0.5) |> sustain(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> release(1) |> release(0.5) |> release(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> chorus(1) |> chorus(0.5) |> chorus(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> crush(4) |> crush(4.0) |> crush(4.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> shape(0) |> shape(0.5) |> shape(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> djf(0) |> djf(0.5) |> djf(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> bpf(800) |> bpf(800.0) |> bpf(800.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> bpq(5) |> bpq(5.0) |> bpq(5.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> phaser(1) |> phaser(2.0) |> phaser(2.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> tremolo(2) |> tremolo(2.0) |> tremolo(2.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> compressor(-20) |> compressor(-20.0) |> compressor(-20.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> begin(0) |> begin(0.25) |> begin(0.25lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> transpose(7) |> transpose(7.0) |> transpose(7.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> add(0) |> add(2.0) |> add(2.0lf)), 1)
+}
+
+[test]
+def test_newly_public_set_x_scalars(t : T?) {
+    // the 9 set_X scalars exposed in Phase B accept int / float / double
+    t |> equal(hc(atom("sawtooth") |> set_speed(2) |> set_speed(1.5) |> set_speed(1.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_velocity(1) |> set_velocity(0.5) |> set_velocity(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_chorus(1) |> set_chorus(0.5) |> set_chorus(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_crush(4) |> set_crush(4.0) |> set_crush(4.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_shape(0) |> set_shape(0.5) |> set_shape(0.5lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_phaser(1) |> set_phaser(2.0) |> set_phaser(2.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_tremolo(2) |> set_tremolo(2.0) |> set_tremolo(2.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_compressor(-20) |> set_compressor(-20.0) |> set_compressor(-20.0lf)), 1)
+    t |> equal(hc(atom("sawtooth") |> set_bpf(800) |> set_bpf(800.0) |> set_bpf(800.0lf)), 1)
+    // field actually written
+    let sp <- atom("sawtooth") |> set_crush(4)
+    let h <- sp(TimeSpan(start = 0.0lf, stop = 1.0lf))
+    t |> success(abs(h[0].value.crush - 4.0) < 0.001)
+}
+
+[test]
+def test_time_funcs_accept_int_float_double(t : T?) {
+    t |> equal(hc(s("bd sd") |> fast(2)), 4)
+    t |> equal(hc(s("bd sd") |> fast(2.0)), 4)
+    t |> equal(hc(s("bd sd") |> fast(2.0lf)), 4)
+    let _a <- s("bd sd") |> slow(2) |> hurry(2)
+    let _b <- s("bd") |> linger(1) |> linger(0.5) |> linger(0.5lf)
+    t |> equal(hc(s("bd") |> compress(0, 1)), 1)
+    t |> equal(hc(s("bd") |> compress(0.25, 0.75)), 1)
+    t |> equal(hc(s("bd") |> compress(0.25lf, 0.75lf)), 1)
+}
+
+[test]
+def test_pattern_overload_still_resolves(t : T?) {
+    // widening must NOT shadow the Pattern (mod_pat) overload
+    var p <- s("bd sd")
+    p <- speed(p, s("1 2"))
+    p <- gain(p, s("0.5 1.0"))
+    p <- fast(p, s("1 2"))
+    t |> success(hc(p) > 0)
+}

--- a/tutorials/daStrudel/daStrudel_07_per_voice_fx.das
+++ b/tutorials/daStrudel/daStrudel_07_per_voice_fx.das
@@ -7,10 +7,10 @@
 //   - chunk(pat, n, fn)  : apply fn to every n-th chunk in turn
 //
 // It also introduces daslang's *per-voice FX* (phaser, tremolo, compressor,
-// shape) which differ from typical live-coding systems where these effects
-// are placed on a shared bus. In daslang each playing voice carries its own
-// FX chain — the FX run BEFORE the voices are mixed into the orbit, so
-// per-note timbral variation is possible.
+// shape). Like strudel.cc, daslang applies these per event: each playing voice
+// carries its own FX chain, run BEFORE the voices are mixed into the orbit, so
+// two simultaneous notes can carry different settings without bleeding into each
+// other. (Only room/delay/chorus are shared per-orbit send buses — see tut 08.)
 //
 // Run: daslang.exe tutorials/daStrudel/daStrudel_07_per_voice_fx.das
 
@@ -93,10 +93,10 @@ def example_chunk_fast() {
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Per-voice FX — phaser, tremolo, compressor, shape — are baked into each
-// playing voice. This is a daslang divergence from systems where these are
-// global bus effects. Because the FX live with the voice, two simultaneous
-// notes in a single stack can carry DIFFERENT phaser rates without leaking
-// into each other.
+// playing voice (as in strudel.cc). Because the FX live with the voice, two
+// simultaneous notes in a single stack can carry DIFFERENT phaser rates without
+// leaking into each other. (room/delay/chorus differ — those are per-orbit
+// send buses; see tutorial 08.)
 
 def example_per_voice_phaser() {
     print("\n=== Section 4: per-voice phaser at two different rates ===\n")


### PR DESCRIPTION
## dasStrudel: numeric ergonomics, `set_X` exposure, missing features

Addresses feedback that several dasStrudel knobs were awkward or appeared missing. Library + tests + examples + docs only — the full tutorial rewrite is a planned follow-up PR.

### Numeric ergonomics (the main ask)
Every scalar pattern modifier now takes `int | float | double` and casts to the canonical field type internally (via two private `numd`/`numf` helpers that centralize the one unavoidable `// nolint:PERF020`). So `fast(2)`, `gain(0.5)`, and `speed(2.0lf)` all work at the same call site — no more remembering which knob wanted `double` (`2.0lf`) vs `float` (`2.0`). The `Pattern` (modulation) overloads are untouched and still resolve.

- `linger`/`compress` are widened too; their captured lambdas call `math` builtins, so `strudel_pattern` now `require math public` (the union widening makes these combinators re-instantiate in consumer modules, which need `math` visible). `strudel_hash01`/`strudel_hash32` are made public for the same cross-module-instantiation reason (hidden from docs via `hide_group`).

### `set_X` scalars exposed
The scalar forms of `set_speed`/`set_velocity`/`set_chorus`/`set_crush`/`set_shape`/`set_phaser`/`set_tremolo`/`set_compressor`/`set_bpf` were `private` (only the `mod_pat: Pattern` overload was visible). They're now public + widened, matching the already-public `set_lpf`/`set_room`/etc.

### New features
- **`freq()`** — sets oscillator frequency in Hz directly (new `Event.freq` field; the scheduler uses it over `note` when set). Matches strudel.cc `.freq(440)`. (`note_to_freq` already existed — the feedback that it was "missing" was incorrect.)
- **`euclidRot(k, n, rot)`** — Euclidean rhythm rotated left by `rot` steps.
- **`chop(n)` / `slice(n, idx_pat)`** — sample granulation on the `begin`/`end` window (`chop` subdivides each event in place; `slice` plays slices in index-pattern order).
- **Mini-notation `"bd(3,8)"` / `"bd(3,8,2)"`** — Euclidean form now parsed in `s()`/`n()`/`note()` strings.

### Docs
- `strudel_vs_strudel_cc.rst`: corrected the per-voice vs per-orbit FX classification (per-voice FX match strudel.cc — not a divergence; only room/delay/chorus are send buses); documented pattern-valued setters and the numeric-union behavior; moved `freq`/`euclidRot`/`chop`/`slice`/`bd(3,8)` to "available"; fixed the wrong "no `saw` alias" claim.
- `skills/strudel_port.md`: numeric guidance (bare ints work), combinators take `@(x) =>` not `@@(x) =>`.
- tutorial 07: removed the incorrect "per-voice FX differ from typical live-coding systems" framing.

### Note on `@@` combinators
The feedback that `jux`/`off`/etc. are broken with `@@(x) =>` is a usage error, not a bug: `PatternTransform` is a `lambda`, so transforms must use `@(x) =>` (capture lambda), not `@@(x) =>` (function pointer). Documented in the skill + reference.

### Lint
Cleaned up pre-existing PERF020/LINT012 warnings across the strudel module so the whole module is lint-clean (15 files, 0 issues).

### Tests
3 new dastest files: `test_numeric_widening` (compile-coverage: every widened modifier × int/float/double), `test_new_features` (freq/euclidRot/chop/slice/bd(3,8)), `test_fx_routing` (locks the per-voice/per-orbit classification). Full strudel suite passes in **both** interpreter and AOT: 595 tests, 589 passed, 0 failed, 6 skipped. 5 new per-feature examples under `examples/daStrudel/features/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)