### PR TITLE
linq_das: multiple `where` clauses (C# repeatable filter)

### DIFF
--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -411,11 +411,6 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
         macro_error(prog, at, "linq: second range variable '{var2Name}' must differ from '{varName}' and the reserved '{JOIN_TI}'")
         return "(0)"
     }
-    // At most one `where` — its position (before vs after the second source intro) decides pre- vs post.
-    if (firstWhere >= 0 && find_kw_depth0(q, "where", firstWhere + 5) >= 0) {
-        macro_error(prog, at, "linq: at most one 'where' per query is supported")
-        return "(0)"
-    }
     // `into` after a `join … on … equals …` is a group-join (C# GroupJoin) — bound below once the terminal is
     // located. Over a second `from` (cross / SelectMany) it is not supported; single-source query-continuation
     // `into` lives in transpile_query.
@@ -489,24 +484,45 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
             return "(0)"
         }
     }
-    // A `where` is valid before the second source (filters c, single var, no rewrite — pushes to SQL) or
-    // after the tail start (filters the carried pair, transparent-id rewrite). Anywhere else is a grammar
-    // error. Position decides pre- vs post-emit.
-    let hasWhere = firstWhere >= 0
-    let preWhere = hasWhere && firstWhere < secondIntroPos
-    if (hasWhere && !preWhere && firstWhere < tailStart) {
-        if (isJoin) {
-            macro_error(prog, at, "linq: 'where' cannot appear inside the join clause (between 'join' and 'equals')")
-        } else {
-            macro_error(prog, at, "linq: 'where' cannot appear between the second range variable and 'in'")
+    // Collect every `where` and split by position: a `where` BEFORE the second source filters the left
+    // source (single var `c`, no rewrite — pushes to SQL); a `where` AFTER the tail start filters the
+    // carried pair (transparent-id rewrite). A `where` inside the join / second-`from` clause (between the
+    // intro and the tail) is a grammar error. C# allows multiple in each slot; each runs to the next clause.
+    var preWheres : array<string>
+    var postWheres : array<string>
+    var firstPostWhere = -1
+    var wp = firstWhere
+    while (wp >= 0 && wp < termPos) {
+        let wEnd = next_clause_kw(q, wp + 5)
+        let predText = strip(slice(q, wp + 5, wEnd))
+        if (predText == "") {
+            macro_error(prog, at, "linq: empty 'where' predicate")
+            return "(0)"
         }
+        if (wp < secondIntroPos) {
+            preWheres |> push(predText)
+        } elif (wp < tailStart) {
+            if (isJoin) {
+                macro_error(prog, at, "linq: 'where' cannot appear inside the join clause (between 'join' and 'equals')")
+            } else {
+                macro_error(prog, at, "linq: 'where' cannot appear between the second range variable and 'in'")
+            }
+            return "(0)"
+        } else {
+            if (firstPostWhere < 0) { firstPostWhere = wp }
+            postWheres |> push(predText)
+        }
+        wp = find_kw_depth0(q, "where", wEnd)
+    }
+    let hasPostWhere = !empty(postWheres)
+    if (groupInto && hasPostWhere) {
+        macro_error(prog, at, "linq: a 'where' after 'join … into g' is not yet supported — the (outer, g) pair can't be carried; filter with a pre-'join' 'where', or use the pipe form")
         return "(0)"
     }
-    let postWhere = (hasWhere && !preWhere) ? firstWhere : -1
     // The tail (key B / second source expr) ends at the first post clause: orderby, a post-where, or term.
     var tailEnd = termPos
     if (orderByPos >= 0 && orderByPos < tailEnd) { tailEnd = orderByPos }
-    if (postWhere >= 0 && postWhere < tailEnd) { tailEnd = postWhere }
+    if (firstPostWhere >= 0 && firstPostWhere < tailEnd) { tailEnd = firstPostWhere }
     if (groupInto && intoPos < tailEnd) { tailEnd = intoPos }   // join key B ends at `into`, before the group var
     let tail = strip(slice(q, tailStart, tailEnd))
     var srcB = srcBForJoin
@@ -533,19 +549,11 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
             srcB = build_src(rowType2, tail, false)
         }
     }
-    var wherePred = ""
-    if (hasWhere) {
-        let wEnd = preWhere ? secondIntroPos : (orderByPos >= 0 ? orderByPos : termPos)
-        wherePred = strip(slice(q, firstWhere + 5, wEnd))
-        if (wherePred == "") {
-            macro_error(prog, at, "linq: empty 'where' predicate")
-            return "(0)"
-        }
-    }
     var orderKeys : array<string>
     var orderDescMask = 0u
     if (orderByPos >= 0) {
-        let rawOrder = strip(slice(q, orderByPos + 7, termPos))
+        // End at the next clause keyword (a `where` may follow the `orderby`), not the terminal.
+        let rawOrder = strip(slice(q, orderByPos + 7, next_clause_kw(q, orderByPos + 7)))
         var op <- parse_orderby(rawOrder)
         if (!op.ok) {
             macro_error(prog, at, "linq: empty 'orderby' expression")
@@ -603,38 +611,43 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
             macro_error(prog, at, "linq: 'group' over a correlated 'from … from' (flatten) is not supported — the outer row '{varName}' is non-copyable; 'select' the fields you need instead")
             return "(0)"
         }
-        if (postWhere >= 0 && mentions_ident(wherePred, varName)) {
-            macro_error(prog, at, "linq: a post-'from' 'where' over a correlated 'from … from' may reference only the inner range variable '{var2Name}' (it is pushed into the collection before flattening) — referencing the outer '{varName}' would require carrying the non-copyable outer row; filter the outer with a pre-'from' 'where', or restructure")
-            return "(0)"
+        for (pred in postWheres) {
+            if (mentions_ident(pred, varName)) {
+                macro_error(prog, at, "linq: a post-'from' 'where' over a correlated 'from … from' may reference only the inner range variable '{var2Name}' (it is pushed into the collection before flattening) — referencing the outer '{varName}' would require carrying the non-copyable outer row; filter the outer with a pre-'from' 'where', or restructure")
+                return "(0)"
+            }
         }
         // Zero-copy collection selector: `each` borrows the outer's collection — no per-row clone (unlike
         // `to_sequence`, whose const-array overload clones) and no per-row materialize (unlike `where_`'s
-        // array overload). An inner-only post-`where` fuses onto the borrowed iterator (the iterator overload
+        // array overload). Each inner-only post-`where` fuses onto the borrowed iterator (the iterator overload
         // of `where_` stays lazy). `each` outside a for-loop needs the `unsafe` wrap. Borrowing a TEMPORARY
         // tail (e.g. `from x in [c.id]` or a func result) is still safe: daslang heap-allocates arrays and
         // does NOT auto-finalize on scope exit, so the backing storage outlives the borrow (it is reclaimed
         // by GC, not at the end of the enclosing expression) — no use-after-free.
-        if (postWhere >= 0) {
-            srcB = "$({varName}) => unsafe(each({tail})) |> _where($({var2Name}) => {wherePred})"
-        } else {
-            srcB = "$({varName}) => unsafe(each({tail}))"
+        srcB = build_string() $(var sw) {
+            sw |> write("$({varName}) => unsafe(each({tail}))")
+            for (pred in postWheres) {
+                sw |> write(" |> _where($({var2Name}) => {pred})")
+            }
         }
     }
     let carryLambda = "$({varName}, {var2Name}) => ({varName} = {varName}, {var2Name} = {var2Name})"
     let names <- [varName, var2Name]
     let hasOrderBy = orderByPos >= 0
-    // A pre-source `where` (single range var `c`) filters the left source — emitted before the op, no
-    // rewrite; pushes down to SQL. Only a POST-source where/orderby/group forces the transparent-id carry.
-    // Correlated never uses the carry (rejections + push-down above), so it always emits select-terminal.
-    let preWhereClause = preWhere ? " |> _where($({varName}) => {wherePred})" : ""
-    let useTI = !correlated && (postWhere >= 0 || hasOrderBy || isGroup)
+    // Pre-source `where`s (single range var `c`) filter the left source — emitted before the op, no
+    // rewrite; push down to SQL (AND-folded). Only a POST-source where/orderby/group forces the
+    // transparent-id carry. Correlated never uses the carry (rejections + push-down above) → select-terminal.
+    let useTI = !correlated && (hasPostWhere || hasOrderBy || isGroup)
     // group-join emits `_group_join` (result's 2nd param is the match ARRAY `g`, not a single row); the on-key
     // lambda is identical to `_join`. In-memory only — `_group_join` is not a SQL-pushable op (over a SQL source
     // `_sql` rejects it, the documented boundary).
     let opName = groupInto ? "_group_join" : (isJoin ? "_join" : (correlated ? "_select_many" : "_cross_join"))
     let onLambdaPart = isJoin ? "{onLambda}, " : ""
     return build_string() $(var w) {
-        w |> write("( _fold( {srcA}{preWhereClause}")
+        w |> write("( _fold( {srcA}")
+        for (pred in preWheres) {
+            w |> write(" |> _where($({varName}) => {pred})")
+        }
         if (!useTI) {
             // Select-terminal: the `select` projection IS the op's result selector (both range vars in scope —
             // for a group-join the 2nd is the match array `g`). Underscore-prefix a range var the projection
@@ -648,7 +661,9 @@ def private emit_two_source(q : string; nq : int; varName : string; var2Name : s
             // Transparent-id: carry (c, d); post-source clauses rewrite c/d to the carried fields and
             // stream/sort/group the pairs directly (single stage — no pre-materialize).
             w |> write(" |> {opName}({srcB}, {onLambdaPart}{carryLambda})")
-            if (postWhere >= 0) { w |> write(" |> _where($({JOIN_TI}) => {rewrite_idents(wherePred, names, JOIN_TI)})") }
+            for (pred in postWheres) {
+                w |> write(" |> _where($({JOIN_TI}) => {rewrite_idents(pred, names, JOIN_TI)})")
+            }
             if (hasOrderBy) {
                 let rkeys <- [for (k in orderKeys); rewrite_idents(k, names, JOIN_TI)]
                 w |> write(emit_order_op(rkeys, orderDescMask, JOIN_TI))
@@ -968,8 +983,7 @@ def private rewrite_group_var(text : string; gname : string) : string {
 struct private QueryStage {
     rangeVar : string = ""
     isGroupVar : bool = false
-    hasWhere : bool = false
-    predText : string = ""
+    predicates : array<string>   // every `where` before the terminal, in source order (C# allows multiple)
     hasOrderBy : bool = false
     orderKeys : array<string>
     orderDescMask : uint = 0u
@@ -1009,24 +1023,30 @@ def private parse_one_stage(q : string; nq : int; start : int; rangeVar : string
     }
     stage.isGroup = isGroup
     // where / orderby belong to THIS stage only when they precede its terminal (in C# clause order).
-    let wherePos = find_kw_depth0(q, "where", start)
-    stage.hasWhere = wherePos >= 0 && wherePos < termPos
-    let orderByPos = find_kw_depth0(q, "orderby", stage.hasWhere ? wherePos + 5 : start)
+    // Collect every depth-0 `where` before the terminal — C# allows multiple, in any body position. A
+    // `where` after the `orderby` filters the sorted sequence, which (for a total order) yields the same
+    // result as filtering first, so all predicates emit as `_where` ahead of the order op; source order
+    // among the wheres is preserved. Each predicate runs to the next clause keyword.
+    var wherePos = find_kw_depth0(q, "where", start)
+    while (wherePos >= 0 && wherePos < termPos) {
+        let predEnd = next_clause_kw(q, wherePos + 5)
+        let predText = strip(slice(q, wherePos + 5, predEnd))
+        if (predText == "") {
+            macro_error(prog, at, "linq: empty 'where' predicate")
+            return false
+        }
+        stage.predicates |> push(isGroupVar ? rewrite_group_var(predText, rangeVar) : predText)
+        wherePos = find_kw_depth0(q, "where", predEnd)
+    }
+    let orderByPos = find_kw_depth0(q, "orderby", start)
     stage.hasOrderBy = orderByPos >= 0 && orderByPos < termPos
     if (isGroup && stage.hasOrderBy) {
         macro_error(prog, at, "linq: 'orderby' before 'group' is not supported — order the groups after a 'select', or drop the 'orderby'")
         return false
     }
-    if (stage.hasWhere) {
-        let predText = strip(slice(q, wherePos + 5, stage.hasOrderBy ? orderByPos : termPos))
-        if (predText == "") {
-            macro_error(prog, at, "linq: empty 'where' predicate")
-            return false
-        }
-        stage.predText = isGroupVar ? rewrite_group_var(predText, rangeVar) : predText
-    }
     if (stage.hasOrderBy) {
-        let rawOrder = strip(slice(q, orderByPos + 7, termPos))
+        // End at the next clause keyword (a `where` may follow the `orderby`), not the terminal.
+        let rawOrder = strip(slice(q, orderByPos + 7, next_clause_kw(q, orderByPos + 7)))
         var op <- parse_orderby(rawOrder)
         if (!op.ok) {
             macro_error(prog, at, "linq: empty 'orderby' expression")
@@ -1188,8 +1208,8 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
     return build_string() $(var writer) {
         writer |> write("( _fold( {srcBuild}")
         for (s in stages) {
-            if (s.hasWhere) {
-                writer |> write(" |> _where($({s.rangeVar}) => {s.predText})")
+            for (pred in s.predicates) {
+                writer |> write(" |> _where($({s.rangeVar}) => {pred})")
             }
             if (s.isGroup) {
                 writer |> write(" |> _group_by_lazy($({s.rangeVar}) => {s.groupKey})")

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -29,13 +29,13 @@ embedded in a larger expression.
 Clauses
 -------
 
-A query is ``from <var> [ : <Row> ] in <src> [ where <pred> ] [ ( join <var2>
+A query is ``from <var> [ : <Row> ] in <src> ( where <pred> )* [ ( join <var2>
 [ : <Row2> ] in <src2> on <keyA> equals <keyB> [ into <g> ] | from <var2> [ : <Row2> ] in
-<src2> ) ] [ where <pred> ] [ orderby <expr> [ascending|descending] (, <expr> [ascending|descending])* ] ( select <proj> |
+<src2> ) ] ( where <pred> )* [ orderby <expr> [ascending|descending] (, <expr> [ascending|descending])* ] ( select <proj> |
 group <var> by <key> ) [ into <var> <continuation> ] [ iterator ]`` — a second
 range variable comes from **either** a ``join`` **or** a second ``from`` (never
-both), and at most one of the two ``where`` slots may appear (before *or* after
-that clause, never both). ``into`` has two forms: ``join … equals … into <g>`` is
+both); each ``where`` slot accepts any number of predicates (each AND-folds in
+source order). ``into`` has two forms: ``join … equals … into <g>`` is
 a **group join** (``g`` = the array of matching right rows, in scope with the
 left variable — see :ref:`linq_das_join`), while a trailing ``into <var>`` after
 the terminal is a **query continuation** that rebinds the stage's output and
@@ -49,9 +49,13 @@ between body clauses** — it is inlined away before the rest is parsed (see
 - ``let <name> = <expr>`` — optional, repeatable, and free to appear between any
   body clauses; binds a computed value reused in the clauses that follow it (see
   :ref:`linq_das_let`).
-- ``where <predicate>`` — optional. A ``where`` **before** the ``join`` / second
-  ``from`` filters the left source (single range var); a ``where`` **after** it
-  sees both range variables. At most one ``where`` per query.
+- ``where <predicate>`` — optional and **repeatable**. A ``where`` **before** the
+  ``join`` / second ``from`` filters the left source (single range var); a
+  ``where`` **after** it sees both range variables. Several ``where`` clauses may
+  appear in either slot — each emits its own filter, AND-folded in source order
+  (over a SQL source they push down as one ANDed ``WHERE``). A ``where`` written
+  after the ``orderby`` filters the sorted sequence — identical, for a total
+  order, to filtering first — so it emits ahead of the sort.
 - ``join <var2> in <src2> on <keyA> equals <keyB>`` — optional, a single inner
   equi-join introducing a second range variable (see :ref:`linq_das_join`).
 - ``from <var2> in <src2>`` — optional, a second ``from`` introducing a second
@@ -115,6 +119,28 @@ directly. For the SQL source, ``_sql`` resolves a single source against the
 placeholder ``_``; the macro normalizes the single-source lambda parameter to
 ``_`` internally, so the C# variable name is still spliced verbatim at the
 surface.
+
+.. _linq_das_filtering:
+
+Filtering (``where``)
+---------------------
+
+A ``where`` clause is optional and **repeatable** — C# allows several, and each
+emits its own ``_where`` filter, AND-folded in source order:
+
+.. code-block:: das
+
+    // two predicates — both apply
+    var names <- %linq! from c in cars where c.price > 100 where c.brand == "eco" select c.name %%
+    // ≡ _fold( each(cars) |> _where($(c) => c.price > 100) |> _where($(c) => c.brand == "eco") |> _select($(c) => c.name) |> to_array() )
+
+Over a **SQL** source the predicates push down as one ANDed ``WHERE`` (a single
+statement, no intermediate materialize). On a two-source query (``join`` / second
+``from``) the slot still applies: ``where``\ s **before** the second source filter
+the left source (and push to SQL), ``where``\ s **after** it filter the carried
+pair. A ``where`` written **after** the ``orderby`` filters the sorted sequence —
+for a total order that is identical to filtering first, so it emits ahead of the
+sort.
 
 .. _linq_das_let:
 
@@ -323,16 +349,18 @@ projection **pushes down to SQL**; a whole-row ``select c`` is in-memory only
 
 A ``where`` *before* the ``join`` filters the left source (single range var) and
 also pushes down — over an array/decs/XML source it fuses into the join's probe
-loop (no intermediate filtered array):
+loop (no intermediate filtered array). Several pre-join ``where``\ s AND-fold
+(see :ref:`linq_das_filtering`):
 
 .. code-block:: das
 
     var rows <- %linq! from c in cars where c.price >= 150 join b in brands
                        on c.brand equals b.brand select (Name = c.name, Country = b.country) %%
 
-**Transparent identifier** — a post-join ``where`` / ``orderby``, or a ``group``
-terminal. The join carries ``(c, b)`` as a pair so the later clauses can address
-both variables; the reader rewrites ``c`` / ``b`` to the carried fields. This is
+**Transparent identifier** — a post-join ``where`` (one or more) / ``orderby``,
+or a ``group`` terminal. The join carries ``(c, b)`` as a pair so the later
+clauses can address both variables; the reader rewrites ``c`` / ``b`` to the
+carried fields, and each post-join ``where`` becomes its own filter. This is
 **in-memory only** (array / decs / XML) — over a SQL source the carried
 whole-row tuple has no column form and ``_sql`` rejects it (project columns in a
 select-terminal join, or filter pre-join, to push down):
@@ -406,7 +434,7 @@ JOIN**; a scalar / named-tuple projection has a column form, a whole-row
 
 A ``where`` *before* the second ``from`` filters the left source (single range
 var) and pushes down; cross-then-filter on a key equality is the equi-join
-subset:
+subset. Both slots are repeatable (see :ref:`linq_das_filtering`):
 
 .. code-block:: das
 
@@ -436,7 +464,8 @@ than the cross's ``_cross_join``)::
 
 The result selector sees **both** range variables. A ``where`` after the second
 ``from`` that references **only the inner** variable is pushed into the
-collection before flattening (identical semantics, no carry)::
+collection before flattening (identical semantics, no carry); several such
+``where``\ s chain onto the collection::
 
     var rows <- %linq! from o in orders from l in o.lines where l.qty > 1
                        select (Id = o.id, Sku = l.sku) %%

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -132,7 +132,7 @@ emits its own ``_where`` filter, AND-folded in source order:
 
     // two predicates — both apply
     var names <- %linq! from c in cars where c.price > 100 where c.brand == "eco" select c.name %%
-    // ≡ _fold( each(cars) |> _where($(c) => c.price > 100) |> _where($(c) => c.brand == "eco") |> _select($(c) => c.name) |> to_array() )
+    // expands to: _fold( each(cars) |> _where($(c) => c.price > 100) |> _where($(c) => c.brand == "eco") |> _select($(c) => c.name) |> to_array() )
 
 Over a **SQL** source the predicates push down as one ANDed ``WHERE`` (a single
 statement, no intermediate materialize). On a two-source query (``join`` / second

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -187,31 +187,31 @@ Array-source patterns
      - ``plan_loop_or_count`` (predicate-driven ranges)
      - ``take_while`` exits on first non-match; ``skip_while`` toggles state.
    * - ``._order_by(K).first()`` / ``.first_or_default()``
-     - ``plan_order_family`` (streaming-min)
+     - ``plan_order_family`` (streaming-min) → ``emit_streaming_min``
      - Single ``var best`` + ``var seen``, no buffer; one comparison per element.
    * - ``._order_by(K).take(N).to_array()``
-     - ``plan_order_family`` (bounded-heap)
+     - ``plan_order_family`` (bounded-heap) → ``emit_bounded_heap``
      - ``spliced_push_heap`` fill + replace, ``spliced_pop_heap`` on replace, ``order_inplace`` at end. Buffer of size N.
    * - ``._distinct_by(K1)._order_by(K2).take(N).to_array()`` / ``._order_by(K2).distinct().take(N).to_array()`` (plain ``distinct()`` mirror order accepted)
-     - ``plan_order_family`` (bounded-heap + set-gate)
+     - ``plan_order_family`` (bounded-heap + set-gate) → ``emit_bounded_heap``
      - Theme 3 Phase 3 (audit C1/C5). The bounded-heap path gains a leading or middle ``distinct[_by]`` recognizer; per-element push/pop is gated by a set-insert on the distinct key (or whole element for plain ``distinct``). Single source pass, no full distinct materialization. Position of ``distinct`` in the chain (before vs after ``_order_by``) has no bearing on emission for the safe shapes — the set just gates the same heap update. **Bails** (cascades) on ``_order_by(K2).distinct_by(K1)`` because cascade semantics ("min-K2 per K1" — first K1 occurrence in sort order) cannot be honored by a source-walk set-gate, which would keep an arbitrary K1 representative; on ``distinct[_by]`` without ``take`` (would be silently dropped); and on ``take(N).distinct[_by]()`` (would dedup pre-take instead of post-take). Inline-able order key required (cascades otherwise). Composes with ``where_`` (filter before distinct gate) and terminal ``_select`` (project ≤N heap survivors at return).
    * - ``._order_by(K).take(N)._select(F).to_array()`` / ``.first()._select(F)`` / ``.first_or_default()._select(F)``
-     - ``plan_order_family`` (terminal ``_select``)
+     - ``plan_order_family`` (terminal ``_select``) → ``emit_bounded_heap`` / ``emit_streaming_min``
      - Bounded-heap / streaming-min holds the raw element; projection ``F`` runs ≤K times at return. Closes the natural "take top-K then project" idiom.
    * - ``._order_by(K).to_array()`` / ``.order_by_descending(K).to_array()`` / ``.order(K).to_array()`` / ``.order_descending(K).to_array()``
-     - ``plan_order_family`` (full-sort fallback)
+     - ``plan_order_family`` (full-sort fallback) → ``emit_buffer_helper_dispatch``
      - Materializes + sorts. No bounded-heap shortcut.
    * - ``._order_by_keys((K1, K2, …), descMask).to_array()`` / ``._where(P)._order_by_keys((K1, K2), m).to_array()``
      - ``plan_order_family`` (multi-key composite stable sort)
      - Multi-key orderby with per-key direction (``descMask`` bit *i* → key *i* DESC; LSB = first key). With an inline-able tuple key + an upstream ``where`` (no ``take``/``first``/``distinct``), ``emit_fused_prefilter`` builds one composite if-chain comparator (``try_make_inline_cmp_keys``) and emits a **single** ``stable_sort(buf, cmp)`` on the fused buffer — C# ``OrderBy`` / ``ThenBy`` parity, stable on full ties. Bare ``order_by_keys`` (no ``where``) cascades to the eager ``order_by_keys`` op (also ``stable_sort``-backed). **Single-key ``_order_by`` is unchanged** — it keeps the unstable ``order_inplace`` / ``sort`` path (no regression). ``take`` / ``first`` over a multi-key chain cascade to the eager op (multi-key is gated out of the bounded-heap and streaming-min rows, whose min/max-by-first-key collapse is wrong for a composite key). Capped at 4 keys (eager ``less_masked`` ≤ 4-arity).
    * - ``._distinct()`` / ``._distinct_by(K)`` followed by ``.count()`` / ``.to_array()``
-     - ``plan_distinct``
+     - ``plan_distinct`` → ``emit_hashtable_dedup``
      - Single-hash set lane; ``count`` reads ``length(set)``.
    * - ``._distinct()`` / ``._distinct_by(K)`` followed by ``.count(P)`` / ``.long_count(P)``
-     - ``plan_distinct`` (predicate counter)
+     - ``plan_distinct`` (predicate counter) → ``emit_hashtable_dedup``
      - Dedup table is built unconditionally so ``distinct_by`` semantics keep FIRST occurrence per key; a separate ``var acc`` increments only when ``P`` matches that first occurrence. Mirrors tier-2 ``distinct.count(P)`` semantics (distinct-then-filter, not filter-then-distinct).
    * - ``._distinct[_by](K1)._order_by[_descending](K2).to_array()`` / ``._where(P)._distinct[_by](K1)._order_by(K2).to_array()``
-     - ``plan_order_family`` (fused-loop + set-gate)
+     - ``plan_order_family`` (fused-loop + set-gate) → ``emit_fused_prefilter``
      - Theme 8 (audit 3b). The where_+order fused-loop path generalizes: when upstream ``distinct[_by]`` is present, declare ``var order_dset : table<...>`` and wrap the per-element ``push_clone`` with a set-gated ``if (!key_exists(...))`` block. Single source pass + in-place sort, no ``distinct_by_to_array`` intermediate iterator setup. Composes with ``where_`` (filter before distinct gate) and terminal ``_select`` (project at return). **Bails** (cascades) on ``distinct[_by] + order_by + first[_or_default]`` (streaming-min path has no dset hook) and on chains where ``take(N)`` is present (use the bounded-heap path via Theme 3 Phase 3 instead).
    * - ``._group_by(K)._select(reduce).to_array()``
      - pattern ``group_by_array`` (sub-codegen ``plan_group_by_core`` → ``reducer_emitters`` lookup)
@@ -226,17 +226,20 @@ Array-source patterns
      - pattern ``group_by_array`` (sub-codegen ``plan_group_by_core``, trailing ``order_by`` as ORDER BY)
      - Theme 3 Phase 2 (audit C2). Inline-cmp ``sort(buf, ...)`` after the bucket-fill mutates the same output buffer in place — vs the tier-2 cascade's separate ``order_by_inplace`` over a fresh allocation. v1: ``_order_by(K2)`` / ``_order_by_descending(K2)`` with inline-able key only; non-inline keys (side-effects, multi-stmt body) cascade. Composes with HAVING / ``_having(P)``.
    * - ``.reverse().take(N)[._select(F)].to_array()`` (with no pre-reverse ``where`` / ``select``)
-     - ``plan_reverse`` R6 (backward-index walk)
+     - ``plan_reverse`` R6 (backward-index walk) → ``emit_reverse_backward_index_walk``
      - Single loop ``for k in 0..K`` indexes ``arr[len-1-k]`` and K push_clones into a srcElem-typed scratch buffer. When ``_select(F)`` is captured, ``build_terminal_select_tail`` then performs a post-loop projection pass into a separate projElem-typed output buffer (K projection push_clones). Two-buffer/two-pass mirrors the decs sibling ``emit_decs_reverse_skip_into_tail`` (PR #2915) and the R1-R4 catch-all: all source reads complete before any projection-side-effect runs, so impure ``_select`` behaves identically across the three paths. Skips the catch-all's full-source ``push_clone`` walk (N → K raws) + ``reverse_inplace`` + ``resize``. Fast path bails (cascades to R1-R4) when termsel's call-result element type is unresolved at macro stage.
    * - ``[._where(P)][._select(f)].reverse().take(N)._select(F).to_array()`` / ``.reverse()._select(F).first()``
-     - ``plan_reverse`` R1-R4 (terminal ``_select`` on catch-all) / Rb (walk-and-overwrite scalar)
+     - ``plan_reverse`` R1-R4 (terminal ``_select`` on catch-all) → ``emit_reverse_buffer_inplace`` / Rb (walk-and-overwrite scalar) → ``emit_reverse_walk_overwrite_scalar``
      - Catch-all path for chains with pre-reverse ``_where`` / ``_select`` (R6 doesn't accept those slots, cascades here). Projection runs ≤K times at return on the R1-R4 buffer or on the surviving ``last`` value. NOT accepted: ``reverse._select.take`` — user must reorder to ``reverse.take._select``.
    * - ``each(arr).reverse()._distinct[_by](K).to_array()`` (array source)
-     - ``plan_reverse`` R-2a (backward index walk + set-gate)
+     - ``plan_reverse`` R-2a (backward index walk + set-gate) → ``emit_reverse_backward_walk_dset_gate``
      - Theme 8 (audit 2a). Array source only (``array_source`` predicate). Walks source backward via index (``arr[len-1-k]``), maintains ``var rev_dset : table<...>`` and gates push by set-insert on the dedup key (or whole element for plain ``distinct``). LAST-per-key semantics preserved: backward walk picks first-seen-in-reversed-order = last-in-source occurrence, matching tier-2 ``reverse.distinct_by``. Saves cascade's ``reverse_to_array`` allocation AND second ``distinct_by_inplace`` pass. v1 implicit ``to_array`` only; pre-reverse ``_where`` / ``_select`` / ``take`` bail to cascade. Non-array (forward) sources take R-2b below.
    * - ``src.reverse()._distinct[_by](K).to_array()`` (XML / decs / iterator source)
-     - ``plan_reverse`` R-2b (forward keep-last table-overwrite)
+     - ``plan_reverse`` R-2b (forward keep-last table-overwrite) → ``emit_reverse_distinct_forward_keeplast``
      - The exact complement of R-2a (``non_array_source`` predicate): forward-only sources have no random index for the backward walk. One forward pass OVERWRITES ``var rdb_tab : table<key; (seq, val)>`` per element (so the slot ends at the last forward occurrence + its monotonic seq), then sorts survivors by **descending seq** and emits — output-identical to R-2a (descending forward-index of each last occurrence). Source-generic via ``emit_terminator_lane`` + ``wrap_source_loop``: an XML source **defers** (``val`` is the ``xml_node`` handle; ``build_xml_row`` runs only for the K survivors, field-pruned to the key), while decs / iterator store the full element and still win single-pass over the cascade's reverse-buffer + second walk. Closes the decs ``m4`` cell for this shape (D6).
+   * - ``[._where(P)][._select(F)].reverse().count()``
+     - ``plan_reverse`` Ra (counter) → ``emit_reverse_counter``
+     - Reverse is identity for a count, so one forward pass increments a counter — no buffer, no reverse. The projection still fires per match (side-effect parity). Works on iterator and array sources (for-loop body, no indexed access).
 
 Decs-source patterns
 ====================

--- a/tests/dasPUGIXML/test_linq_das_xml.das
+++ b/tests/dasPUGIXML/test_linq_das_xml.das
@@ -32,6 +32,17 @@ def test_xml_where_select(t : T?) {
 }
 
 [test]
+def test_xml_multiple_where(t : T?) {
+    parse_xml(XML) $(doc, ok) {
+        t |> success(ok)
+        // two `where`s prune the DOM walk: price>99 (car1 Ford, car2 Honda) AND brand Ford (car1).
+        let ids <- %linq! from c : Car in doc.document_element where c.price > 99.0 where c.brand == "Ford" select c.id %%
+        t |> equal(length(ids), 1, "both predicates apply over the XML rows")
+        t |> equal(ids[0], 1)
+    }
+}
+
+[test]
 def test_xml_identity_select(t : T?) {
     parse_xml(XML) $(doc, ok) {
         t |> success(ok)

--- a/tests/dasSQLITE/test_linq_das_sql.das
+++ b/tests/dasSQLITE/test_linq_das_sql.das
@@ -39,6 +39,19 @@ def test_sql_where_select(t : T?) {
 }
 
 [test]
+def test_sql_multiple_where(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        fixture(db)
+        // two `where`s push down as a single ANDed SQL WHERE (one statement, no intermediate materialize).
+        let names <- %linq! from c : Car in db where c.price > 150 where c.price < 300 select c.name %%
+        let ref <- _fold(db |> select_from(type<Car>) |> _where(_.price > 150) |> _where(_.price < 300) |> _select(_.name))
+        t |> equal(length(names), 1, "150 < price < 300 → Audi only")
+        t |> equal(names[0], "Audi")
+        t |> equal(length(names), length(ref), "linq_das multi-where ≡ hand-written AND-folded _sql chain")
+    }
+}
+
+[test]
 def test_sql_identity_select(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture(db)

--- a/tests/linq/failed_linq_das.das
+++ b/tests/linq/failed_linq_das.das
@@ -15,7 +15,6 @@ expect 50503   // join … into: post-`into` `orderby` over the (outer, g) pair 
 expect 50503   // join … into: `group` terminal after `into` (select the group instead — not yet)
 expect 50503   // join: a query-continuation `into` AFTER the terminal (single-source only; group-join `into` precedes it)
 expect 50503   // join: `where` inside the join clause (between join and equals)
-expect 50503   // join: two `where` clauses (one pre-join, one post-join)
 expect 50503   // join: range var collides with the reserved transparent-id name
 expect 50503   // multiple-from: three `from` clauses (N-ary SelectMany unsupported)
 expect 50503   // multiple-from: `from … from` combined with `join`
@@ -144,12 +143,6 @@ def trigger_join_into_post_terminal_continuation() {
 def trigger_join_where_inside_clause() {
     var cars <- one_car()
     let x <- %linq! from c in cars join b in cars where c.price > 0 on c.brand equals b.brand select c.name %%
-    unused(x)
-}
-
-def trigger_join_two_wheres() {
-    var cars <- one_car()
-    let x <- %linq! from c in cars where c.price > 0 join b in cars on c.brand equals b.brand where c.name == "a" select c.name %%
     unused(x)
 }
 

--- a/tests/linq/test_linq_das.das
+++ b/tests/linq/test_linq_das.das
@@ -60,6 +60,26 @@ def test_array_where_select(t : T?) {
 }
 
 [test]
+def test_array_multiple_where(t : T?) {
+    let cars <- mk_cars()
+    // C# allows several `where` clauses — each emits its own `_where` (AND-folded, source order).
+    let names <- %linq! from c in cars where c.price > 100 where c.brand == "eco" select c.name %%
+    t |> equal(length(names), 1, "both predicates apply: price>100 (mid,lux) AND eco (mid)")
+    t |> equal(names[0], "mid")
+}
+
+[test]
+def test_array_where_after_orderby(t : T?) {
+    let cars <- mk_cars()
+    // a `where` after the `orderby` filters the sorted sequence — same result as filtering first (total
+    // order), so it emits ahead of the order op. eco → cheap,mid; sorted desc → mid,cheap.
+    let names <- %linq! from c in cars orderby c.price descending where c.brand == "eco" select c.name %%
+    t |> equal(length(names), 2, "where-after-orderby keeps the eco cars, sorted desc")
+    t |> equal(names[0], "mid")
+    t |> equal(names[1], "cheap")
+}
+
+[test]
 def test_array_select_only(t : T?) {
     let cars <- mk_cars()
     let names <- %linq! from c in cars select c.name %%
@@ -150,6 +170,15 @@ def test_decs_where_select(t : T?) {
     seed_decs()
     let names <- %linq! from c : CarComp in decs where c.price > 100 select c.name %%
     t |> equal(length(names), 2, "decs: where filters, select projects")
+}
+
+[test]
+def test_decs_multiple_where(t : T?) {
+    seed_decs()
+    // decs rows: car0(100,a), car1(200,a), car2(300,b). price>100 → car1,car2; brand a → car1.
+    let names <- %linq! from c : CarComp in decs where c.price > 100 where c.brand == "a" select c.name %%
+    t |> equal(length(names), 1, "decs multi-where AND-folds both predicates")
+    t |> equal(names[0], "car1")
 }
 
 [test]
@@ -404,6 +433,44 @@ def test_join_post_join_where(t : T?) {
 }
 
 [test]
+def test_join_multiple_pre_where(t : T?) {
+    let cars <- mk_cars()
+    let brands <- mk_brands()
+    // two pre-join `where`s both filter cars (push to SQL, AND-folded): price>100 (mid,lux) AND eco (mid).
+    let rows <- %linq! from c in cars where c.price > 100 where c.brand == "eco"
+                       join b in brands on c.brand equals b.brand
+                       select (Name = c.name, Country = b.country) %%
+    t |> equal(length(rows), 1, "both pre-join predicates filter the left source")
+    t |> equal(rows[0].Name, "mid")
+    t |> equal(rows[0].Country, "USA")
+}
+
+[test]
+def test_join_multiple_post_where(t : T?) {
+    let cars <- mk_cars()
+    let brands <- mk_brands()
+    // two post-join `where`s filter the carried (c,b) pair: price>100 (mid,lux) AND USA (cheap,mid) → mid.
+    let names <- %linq! from c in cars join b in brands on c.brand equals b.brand
+                        where c.price > 100 where b.country == "USA"
+                        select c.name %%
+    t |> equal(length(names), 1, "both post-join predicates filter the joined pair")
+    t |> equal(names[0], "mid")
+}
+
+[test]
+def test_join_mixed_pre_post_where(t : T?) {
+    let cars <- mk_cars()
+    let brands <- mk_brands()
+    // pre + post `where`s on one join: pre price>=150 (mid,lux); post USA (mid) AND price<300 (mid).
+    let names <- %linq! from c in cars where c.price >= 150
+                        join b in brands on c.brand equals b.brand
+                        where b.country == "USA" where c.price < 300
+                        select c.name %%
+    t |> equal(length(names), 1, "pre-join and post-join wheres combine")
+    t |> equal(names[0], "mid")
+}
+
+[test]
 def test_join_orderby(t : T?) {
     let cars <- mk_cars()
     let brands <- mk_brands()
@@ -627,6 +694,19 @@ def test_multifrom_post_where(t : T?) {
 }
 
 [test]
+def test_multifrom_multiple_where(t : T?) {
+    let cars <- mk_cars()
+    let brands <- mk_brands()
+    // two post-`from` `where`s over the crossed pairs: brand-match (the join subset) AND price>100.
+    let names <- %linq! from c in cars from b in brands
+                        where c.brand == b.brand where c.price > 100
+                        select c.name %%
+    t |> equal(length(names), 2, "brand-match (cheap,mid,lux) AND price>100 (mid,lux)")
+    t |> equal(names[0], "mid")
+    t |> equal(names[1], "lux")
+}
+
+[test]
 def test_multifrom_orderby(t : T?) {
     let cars <- mk_cars()
     let brands <- mk_brands()
@@ -750,6 +830,17 @@ def test_correlated_push_where(t : T?) {
     t |> equal(rows[0].Sku, "a")
     t |> equal(rows[1].Sku, "c")
     t |> equal(rows[2].Sku, "d")
+}
+
+[test]
+def test_correlated_multiple_inner_where(t : T?) {
+    let orders <- mk_orders()
+    // two inner-only post-`from` `where`s both push into the collection (filter before flattening).
+    // qty>1 keeps a(2),c(5),d(3); sku!="c" then drops c → a,d.
+    let rows <- %linq! from o in orders from l in o.lines where l.qty > 1 where l.sku != "c" select (Id = o.id, Sku = l.sku) %%
+    t |> equal(length(rows), 2, "both inner predicates push into the collection")
+    t |> equal(rows[0].Sku, "a")
+    t |> equal(rows[1].Sku, "d")
 }
 
 [test]


### PR DESCRIPTION
## What

Adds support for several `where` clauses in a `%linq!` query — C# allows them, and each emits its own `_where`, AND-folded in source order. Previously the reader capped at one `where` (single-source double-`where` even fell through to an ugly `error[30151]`; two-source had an explicit at-most-one reject).

This is **reader-only — no engine change.** All four sources already chain `_where`: the array path fuses it, SQL AND-pushes it down as one statement, decs/XML ride the same `_fold`.

```das
// single source — several predicates
var names <- %linq! from c in cars where c.price > 100 where c.brand == "eco" select c.name %%

// join — pre-join wheres filter the left source (push to SQL), post-join wheres filter the joined pair
var rows <- %linq! from c in cars where c.price >= 150
                   join b in brands on c.brand equals b.brand
                   where b.country == "USA" where c.price < 300
                   select c.name %%
```

## How

- **`linq_das.das`** — `QueryStage` carries a `predicates` array; `parse_one_stage` collects every depth-0 `where` before the terminal (a `where` after the `orderby` canonicalizes to filter-before-sort — identical result for a total order, so it emits ahead of the sort). `emit_two_source` partitions all `where`s into **pre-source** (filter srcA, single var, push to SQL) and **post-source** (transparent-id carry rewrite, or pushed into the correlated collection) slots — the at-most-one cap is lifted in both; the forbidden-zone (`where` inside the join clause) and empty-predicate rejects are preserved per predicate.
- **tests** — multi-`where` positives across array / decs / XML / SQL (AND-pushdown parity) / join (pre / post / mixed) / cross / correlated. The now-valid two-`where` join case is removed from `failed_linq_das.das`. Green on **interp / JIT / AOT**.
- **docs** — `linq_das.rst` grammar (`where` is now repeatable) + a new Filtering section + join/multifrom/correlated freshness. `linq_fold_patterns.rst` now names the pattern-lane emit fns it described in prose (`emit_bounded_heap` / `emit_streaming_min` / `emit_buffer_helper_dispatch` / `emit_fused_prefilter` / `emit_hashtable_dedup` / the `emit_reverse_*` R-series) and adds the missing **Ra** (reverse + count) row.

## Verification

- MCP lint + CI-form lint (`utils/lint/main.das`): clean on all changed `.das`.
- Tests: `tests/linq` 77/77, `tests/dasSQLITE/test_linq_das_sql` 17/17, `tests/dasPUGIXML/test_linq_das_xml` 15/15, `failed_linq_das` balanced — **interp / JIT / AOT** all green.
- Sphinx `-W` (HTML): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)