### PR TITLE
daStrudel tutorials: new Signals & Modulation tutorial + content expansion

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -419,14 +419,15 @@ For the strudel-to-strudel.cc feature comparison, see
    tutorials/daStrudel_06_stacking_combining.rst
    tutorials/daStrudel_07_per_voice_fx.rst
    tutorials/daStrudel_08_effects_filters.rst
-   tutorials/daStrudel_09_adsr_envelopes.rst
-   tutorials/daStrudel_10_scales_music_theory.rst
-   tutorials/daStrudel_11_synthesis.rst
-   tutorials/daStrudel_12_samples.rst
-   tutorials/daStrudel_13_sf2_soundfont.rst
-   tutorials/daStrudel_14_midi_files.rst
-   tutorials/daStrudel_15_live_reloading.rst
-   tutorials/daStrudel_16_hrtf_position.rst
+   tutorials/daStrudel_09_signals_modulation.rst
+   tutorials/daStrudel_10_adsr_envelopes.rst
+   tutorials/daStrudel_11_scales_music_theory.rst
+   tutorials/daStrudel_12_synthesis.rst
+   tutorials/daStrudel_13_samples.rst
+   tutorials/daStrudel_14_sf2_soundfont.rst
+   tutorials/daStrudel_15_midi_files.rst
+   tutorials/daStrudel_16_live_reloading.rst
+   tutorials/daStrudel_17_hrtf_position.rst
 
 .. _tutorials_jsonrpc:
 

--- a/doc/source/reference/tutorials/daStrudel_03_mini_notation_advanced.rst
+++ b/doc/source/reference/tutorials/daStrudel_03_mini_notation_advanced.rst
@@ -10,6 +10,7 @@ STRUDEL-03 — Mini-Notation Advanced
     single: Tutorial; Strudel; Elongation
     single: Tutorial; Strudel; Degrade
     single: Tutorial; Strudel; Replicate
+    single: Tutorial; Strudel; Euclidean
 
 The four operators in this tutorial — ``<...>``, ``@N``, ``?``, and
 ``!N`` — are what take you from drum-machine patterns to genuinely
@@ -103,6 +104,40 @@ followed by a snare in the second.
 The mental model: ``*N`` divides time, ``!N`` adds slots. Use ``*`` to
 make things faster within one slot, ``!`` to repeat the same element
 across the parent sequence.
+
+Part E: Euclidean rhythms with ``(k,n)`` and ``(k,n,rot)``
+==========================================================
+
+Postfix ``(k,n)`` spreads ``k`` onsets as evenly as possible over ``n``
+steps. ``bd(3,8)`` is the classic tresillo — three kicks across eight
+slots:
+
+.. code-block:: das
+
+    var pat <- s("bd(3,8)")
+    var haps <- invoke(pat, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    for (h in haps) {
+        print("  onset at {h.whole.start}\n")
+    }
+    play(pat, 4.0)
+
+Querying one cycle ``[0,1)`` by hand and printing ``h.whole.start`` shows
+exactly where the hits land — ``0``, ``0.375``, ``0.75`` for the 3-in-8
+tresillo. The parser rewrites ``(k,n)`` to the ``euclid(pat, k, n)``
+combinator.
+
+The three-argument form ``(k,n,rot)`` rotates the onset pattern left by
+``rot`` steps — the rhythm is the same, only its starting offset moves:
+
+.. code-block:: das
+
+    var pat <- s("bd(3,8,2)")
+    play(pat, 4.0)
+
+This rewrites to ``euclidRot(pat, k, n, rot)``. The function forms
+``euclid`` and ``euclidRot`` are public and covered in tutorial 05 — use
+them directly when ``k``/``n`` come from variables rather than a literal
+string.
 
 Where next
 ==========

--- a/doc/source/reference/tutorials/daStrudel_04_time_manipulation.rst
+++ b/doc/source/reference/tutorials/daStrudel_04_time_manipulation.rst
@@ -10,6 +10,13 @@ STRUDEL-04 — Time Manipulation
     single: Tutorial; Strudel; slow
     single: Tutorial; Strudel; rev
     single: Tutorial; Strudel; hurry
+    single: Tutorial; Strudel; ply
+    single: Tutorial; Strudel; iter
+    single: Tutorial; Strudel; palindrome
+    single: Tutorial; Strudel; linger
+    single: Tutorial; Strudel; compress
+    single: Tutorial; Strudel; striate
+    single: Tutorial; Strudel; chop
 
 So far every Pattern played at one cycle per cycle, in forward order.
 This tutorial introduces the **time algebra**: four functions that take
@@ -67,7 +74,7 @@ Part C: ``rev``
 The arpeggio plays backward as ``c5 g4 e4 c4``. This is per-cycle
 mirroring — not a global reverse. Each cycle stands alone, so
 ``rev |> rev`` is the identity. Combine it with ``jux`` to get instant
-stereo widening (tutorial 06 covers combinators).
+stereo widening (tutorial 07 covers combinators).
 
 ``rev`` is callable bare or with parentheses: ``pat |> rev`` and
 ``pat |> rev()`` are equivalent.
@@ -107,6 +114,86 @@ operator like any other transform:
 Order matters — ``rev |> slow(2)`` reverses then stretches; ``slow(2) |>
 rev`` stretches then reverses (and the two produce different rhythms in
 general because ``rev`` operates per-cycle).
+
+Part F: ``ply(N)`` — repeat each event in place
+===============================================
+
+Where ``fast`` repeats the *whole* pattern, ``ply(N)`` subdivides each
+event locally, playing it N times back-to-back inside its own slot:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.3) |> ply(3)
+    play(pat, 4.0)
+
+The four-note phrase becomes twelve notes — each one stuttered three
+times. This is the canonical way to add a roll or ratchet to selected
+notes without changing the overall phrase length.
+
+Part G: ``iter`` / ``iterBack`` / ``palindrome``
+================================================
+
+These three restructure the pattern across *cycles* rather than within
+one. ``iter(N)`` rotates the start point left by ``1/N`` each cycle, so
+``c-e-g-a`` becomes ``e-g-a-c``, then ``g-a-c-e``, walking through every
+rotation over N cycles. ``iterBack(N)`` rotates the other direction.
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 a4", "sine") |> iter(4)
+    play(pat, 8.0)
+
+``palindrome`` alternates the pattern forward on even cycles and reversed
+on odd cycles — an ascending scale on cycle 0, descending on cycle 1:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5", "sine") |> palindrome
+    play(pat, 8.0)
+
+Part H: ``linger`` / ``compress`` — looping and windowing
+=========================================================
+
+``linger(t)`` keeps only the first fraction ``t`` of the cycle and loops
+it to fill the rest. ``linger(0.5)`` plays the first half twice:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5 a4 g4 e4 c4", "sine") |> linger(0.5lf)
+    play(pat, 4.0)
+
+``compress(b, e)`` squeezes the whole pattern into the ``[b, e)`` window
+of each cycle, leaving silence before ``b`` and after ``e``:
+
+.. code-block:: das
+
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.3) |> compress(0.25lf, 0.75lf)
+    play(pat, 4.0)
+
+The arguments are cycle fractions, so ``compress(0.25, 0.75)`` confines
+the phrase to the middle half. It is the inverse of ``fast`` plus an
+offset — density unchanged, just relocated in time.
+
+Part I: ``striate`` / ``chop`` — granular sample slicing
+========================================================
+
+Both cut a sample into N pieces, but distribute them differently.
+``striate(N)`` spreads the N slices across the *whole cycle*, so
+successive events reveal later portions of the sample. ``chop(N)`` keeps
+the slices inside each event's own slot — an in-place grain walk:
+
+.. code-block:: das
+
+    let pat <- s("bd sd hh cp") |> striate(4) |> gain(0.4)
+    play(pat, 4.0)
+
+    let pat2 <- s("bd") |> chop(4) |> gain(0.6)
+    play(pat2, 4.0)
+
+These need a sample-ish source. The built-in drum synth (``bd``, ``sd``,
+``hh``, ``cp``) works for a quick demo; load a real sample bank for the
+classic granular textures. Use ``striate`` to smear a sample over the bar
+and ``chop`` to granulate individual hits.
 
 A note on ``early`` and ``late``
 ================================

--- a/doc/source/reference/tutorials/daStrudel_05_euclidean_rhythms.rst
+++ b/doc/source/reference/tutorials/daStrudel_05_euclidean_rhythms.rst
@@ -111,24 +111,49 @@ takes ``array<Pattern>`` and ``emplace`` needs to **move** the lambda
 (Patterns are non-copyable lambdas) — that requires a mutable
 binding.
 
+Part E: ``euclidRot(pat, k, n, rot)`` — rotate the onsets
+=========================================================
+
+``euclidRot`` is ``euclid`` with the Bjorklund pattern rotated **left by
+rot steps**. The density is unchanged — still ``k`` onsets over ``n``
+steps — but the accents land on a different set of grid positions, which
+shifts the *feel* without adding or removing hits. ``euclid(3, 8)`` hits
+steps 0, 3, 6; ``euclidRot(3, 8, 2)`` shifts that window two steps:
+
+.. code-block:: das
+
+    let kick <- atom("bd") |> euclid(3, 8)
+    play(kick, 4.0)
+
+    let hat <- atom("hh") |> euclidRot(5, 8, 2)
+    play(hat, 4.0)
+
+Query one cycle by hand to see the onset positions move:
+
+.. code-block:: das
+
+    var rotd <- atom("bd") |> euclidRot(3, 8, 2)
+    var haps <- invoke(rotd, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    for (h in haps) {
+        print("{h.whole.start} ")
+    }
+    delete haps
+
 Note on the ``bd(3,8)`` mini-notation form
 ==========================================
 
 In the original Tidal/Strudel mini-notation, ``"bd(3,8)"`` is an inline
-shorthand for euclid. **This daStrudel build does not parse parentheses
-inside mini-notation strings** — the parser tokenises ``(`` and ``)``
-but does not assemble them into the euclid form. Use the function
-directly:
+shorthand for euclid and ``"bd(3,8,2)"`` adds rotation. daStrudel
+supports both — :ref:`tutorial 03 <tutorial_dastrudel_mini_advanced>`
+(Section 5) demonstrates ``s("bd(3,8)")`` and ``s("bd(3,8,2)")``, which
+the parser expands directly to the ``euclid()`` / ``euclidRot()``
+function forms shown above. The function forms are the explicit
+equivalents and read well in a pipe:
 
 .. code-block:: das
 
-    s("bd sd") |> euclid(5, 8)
-    atom("hh") |> euclid(3, 8)
-
-Rotation (Tidal's ``bd(3,8,1)``, the JS Strudel ``euclidRot``) is
-likewise not exposed as a standalone function in this build. To get a
-rotated rhythm you can reorder the elements inside the pattern fed to
-``euclid``, or chain ``rev`` / ``slow`` against a control pattern.
+    s("bd sd") |> euclid(5, 8)         // same as s("bd sd(5,8)")
+    atom("hh") |> euclidRot(5, 8, 2)   // same as s("hh(5,8,2)")
 
 Where next
 ==========

--- a/doc/source/reference/tutorials/daStrudel_06_stacking_combining.rst
+++ b/doc/source/reference/tutorials/daStrudel_06_stacking_combining.rst
@@ -92,6 +92,79 @@ we add a faster octave-up echo on top:
 The lambda has type ``@(Pattern) => Pattern`` — the same shape every
 transforming combinator (``jux``, ``off``, ``superimpose``, …) expects.
 
+Part E: ``fastcat`` — squeeze all patterns into one cycle
+=========================================================
+
+Where ``cat`` gives each pattern a whole cycle in turn, ``fastcat``
+squeezes **all** of them into a single cycle side by side.  With *N*
+patterns each one fills ``1/N`` of every cycle — it is exactly
+``fast(cat(pats), N)``:
+
+.. code-block:: das
+
+    let pat <- fastcat([
+        s("bd"),
+        s("hh"),
+        s("sd"),
+        s("hh")
+    ])
+
+Four sounds, one per quarter of the cycle, looping every cycle.
+
+Part F: ``randcat`` / ``chooseCycles`` — pick one pattern per cycle
+===================================================================
+
+``randcat`` picks one of the patterns at random each cycle.  The choice
+is **deterministic** — a given cycle index always selects the same
+pattern — so the result is reproducible.  ``chooseCycles`` is an alias
+for the same per-cycle behaviour; in this build both are aliases of
+``choose``.  Use them to vary a phrase from cycle to cycle without
+spelling out every variation:
+
+.. code-block:: das
+
+    let pat <- randcat([
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+        note("c4 g4 e4 c4", "sine") |> sustain(0.4),
+        note("c4 d4 e4 f4", "sine") |> sustain(0.4)
+    ])
+
+Part G: ``choose`` — the per-cycle pick that backs ``randcat``
+==============================================================
+
+In daStrudel ``choose`` performs the same discrete, per-cycle random
+pick that ``randcat`` and ``chooseCycles`` do — those two are aliases of
+``choose``.  (Some pattern libraries make ``choose`` a *continuous*
+per-event signal; daStrudel keeps it per-cycle so that note patterns do
+not glitch mid-phrase.)
+
+.. code-block:: das
+
+    let pat <- choose([
+        note("c4 e4 g4", "sine") |> sustain(0.4),
+        note("d4 f4 a4", "sine") |> sustain(0.4),
+        note("e4 g4 b4", "sine") |> sustain(0.4)
+    ])
+
+Part H: ``wchoose`` — weighted per-cycle pick
+=============================================
+
+``wchoose`` takes **two** arrays: the patterns, then a parallel array of
+``float`` weights.  Each cycle a pattern is chosen with probability equal
+to its weight divided by the sum of all weights.  Here ``bd`` is three
+times as likely as ``cp`` or ``sd``:
+
+.. code-block:: das
+
+    let pat <- wchoose([
+        s("bd*4"),
+        s("cp*4"),
+        s("sd*4")
+    ], [3.0, 1.0, 1.0])
+
+The weights array must be the same length as the patterns array and uses
+plain ``float`` literals.
+
 .. seealso::
 
    Full source: :download:`tutorials/daStrudel/daStrudel_06_stacking_combining.das <../../../../tutorials/daStrudel/daStrudel_06_stacking_combining.das>`

--- a/doc/source/reference/tutorials/daStrudel_07_per_voice_fx.rst
+++ b/doc/source/reference/tutorials/daStrudel_07_per_voice_fx.rst
@@ -87,10 +87,66 @@ Above, the C voice carries a slow phaser sweep while the G voice
 carries a fast one.  On a shared-bus system both voices would have to
 share the same rate.
 
-The per-voice setters available today: ``lpf``, ``hpf``, ``phaser`` /
-``ph``, ``tremolo`` / ``trem``, ``compressor``, ``shape``, ``crush``,
-``coarse``.  The shared-bus setters (``room``, ``delay``, ``chorus``)
-are covered in the next tutorial.
+The full split (the same table appears in tutorial 08):
+
+.. list-table:: Per-voice vs per-orbit FX
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Scope
+     - Setters
+   * - Per-voice (independent per note)
+     - ``gain``, ``pan``, ``speed``, ``lpf``, ``hpf``, ``bpf``, ``phaser``,
+       ``tremolo``, ``compressor``, ``shape``, ``crush``, ``coarse``,
+       ``djf``, ``fm``, ``vowel``
+   * - Per-orbit (one shared bus per orbit)
+     - ``room`` / ``roomsize``, ``delay`` / ``delaytime`` /
+       ``delayfeedback``, ``chorus``
+
+Part E: probabilistic combinators — ``sometimes``, ``degradeBy``
+================================================================
+
+``sometimes(pat, fn)`` applies ``fn`` to a random ~50% of events;
+``degradeBy(prob)`` randomly **drops** events with the given probability.
+Both turn a rigid loop into something that breathes:
+
+.. code-block:: das
+
+    let pat <- sometimes(s("bd sd hh cp"), @(x) => fast(x, 2.0lf))
+    // and: s("hh*8") |> degradeBy(0.4)   // thin a hi-hat run
+
+Part F: cycle-conditional — ``every``, ``when_cycle``
+=====================================================
+
+``every(n, pat_on, pat_off)`` plays ``pat_on`` on cycles 0, n, 2n, ... and
+``pat_off`` otherwise. Note daslang's ``every`` takes two **patterns**, not
+a transform — build the variant explicitly:
+
+.. code-block:: das
+
+    let pat <- every(4, note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> rev(),
+                        note("c4 e4 g4 c5", "sine") |> sustain(0.4))
+
+``when_cycle(pat, cond, fn)`` applies ``fn`` only on cycles where
+``cond(cycle)`` is true (``cond`` is a ``lambda<(cycle:int):bool>``):
+
+.. code-block:: das
+
+    let pat <- when_cycle(note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+                          @(c) => c % 2 == 0, @(x) => fast(x, 2.0lf))
+
+Part G: reordering & gating — ``shuffle``, ``scramble``, ``mask``
+=================================================================
+
+``shuffle(n)`` cuts the cycle into ``n`` slices and plays them in a
+shuffled order (a permutation — each slice once); ``scramble(n)`` picks
+``n`` slices at random (repeats allowed). ``mask(pat, bool_pat)`` gates
+events through a ``1``/``~`` pattern:
+
+.. code-block:: das
+
+    note("c4 d4 e4 f4 g4 a4 b4 c5", "sine") |> sustain(0.4) |> shuffle(8)
+    note("c4 d4 e4 f4", "sine") |> sustain(0.4) |> mask(s("1 ~ 1 ~"))
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/daStrudel_08_effects_filters.rst
+++ b/doc/source/reference/tutorials/daStrudel_08_effects_filters.rst
@@ -13,22 +13,27 @@ STRUDEL-08 — Effects & Filters
     single: Tutorial; Strudel; phaser
 
 Strudel splits effects into two groups, distinguished by where they live
-in the signal graph:
+in the signal graph (the same table appears in tutorial 07):
 
-================== =========================== ================================================
-Group              Setters                     Lifetime
-================== =========================== ================================================
-Per-orbit bus FX   ``room``, ``delay``,        one shared instance per orbit; voices send wet
-                   ``chorus``                  / dry into it
-Per-voice FX       ``lpf``, ``hpf``,           baked into each individual voice; runs before
-                   ``phaser``, ``tremolo``,    mixdown into the orbit
-                   ``compressor``, ``shape``,
-                   ``crush``, ``coarse``
-================== =========================== ================================================
+.. list-table:: Per-voice vs per-orbit FX
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Scope
+     - Setters
+   * - Per-voice (independent per note)
+     - ``gain``, ``pan``, ``speed``, ``lpf``, ``hpf``, ``bpf``, ``phaser``,
+       ``tremolo``, ``compressor``, ``shape``, ``crush``, ``coarse``,
+       ``djf``, ``fm``, ``vowel``
+   * - Per-orbit (one shared bus per orbit)
+     - ``room`` / ``roomsize``, ``delay`` / ``delaytime`` /
+       ``delayfeedback``, ``chorus``
 
 This split lets you give each layer of a stack its own reverb and delay
 character (per-orbit), while still personalising every note's filter and
-modulation (per-voice).
+modulation (per-voice). Every per-voice setter also has a pattern-valued
+overload — feed it a signal to make the parameter move over time; see
+tutorial 09.
 
 Part A: per-voice filters — ``lpf`` and ``hpf``
 ===============================================
@@ -66,7 +71,7 @@ Part C: per-orbit delay — tempo-aware by default
 drive the orbit's delay line.  ``delaytime`` defaults to a tempo-aware
 3/16 cycle (resolved from ``delaysync`` and the current cps), so plain
 ``delay(0.5)`` already locks to the tempo even without a ``delaytime``
-setter.  Tutorial 09 covers the resolver in detail.
+setter.  Tutorial 10 covers the resolver in detail.
 
 .. code-block:: das
 
@@ -100,10 +105,57 @@ in a tight small room while orbit 1 sits inside a cathedral:
 The pluck on orbit 0 sounds tight; the pad on orbit 1 swims in
 reverb — neither bleeds into the other.
 
+Part F: crush & shape — per-voice waveshaping
+=============================================
+
+``crush(bits)`` reduces bit depth for lo-fi grit; ``coarse(n)`` decimates
+the sample rate by a factor of ``n``; ``shape(amount)`` is a waveshaper
+that adds harmonic distortion. All per-voice:
+
+.. code-block:: das
+
+    note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> crush(4.0) |> coarse(4)
+    note("c3 e3 g3 c4", "sine")     |> sustain(0.8) |> shape(0.6)
+
+Part G: tremolo & compressor — per-voice amplitude FX
+=====================================================
+
+``tremolo(rateHz)`` pulses the amplitude (``tremolodepth`` sets the
+depth); ``compressor(thresholdDb)`` tames dynamics so quiet and loud
+notes sit closer together:
+
+.. code-block:: das
+
+    note("d3 d3 d#3 d3", "supersaw") |> sustain(1.0) |> release(0.5) |> tremolo(8.0) |> tremolodepth(0.8)
+    s("bd sd hh cp") |> compressor(-20.0)
+
+Part H: ``bpf`` & ``djf`` — more per-voice filters
+==================================================
+
+``bpf(freq)`` is a band-pass filter (``bpq`` sets resonance/Q); ``djf(x)``
+is a single DJ-style filter knob — below ``0.5`` it acts as a low-pass,
+above ``0.5`` a high-pass, so one parameter sweeps muffled to thin:
+
+.. code-block:: das
+
+    note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> bpf(800.0) |> bpq(6.0)
+    note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> djf(0.8)
+
+Part I: ``chorus`` — per-orbit bus
+==================================
+
+``chorus(amount)`` thickens a sound with slightly detuned copies. Like
+``room`` and ``delay`` it lives on the orbit bus, so all voices on the
+same orbit share one chorus instance:
+
+.. code-block:: das
+
+    note("<[c3,e3,g3] [f3,a3,c4] [g3,b3,d4] [a3,c4,e4]>", "sawtooth") |> chorus(0.5) |> attack(0.05) |> decay(0.1) |> sustain(0.6) |> release(0.3) |> gain(0.4)
+
 .. seealso::
 
    Full source: :download:`tutorials/daStrudel/daStrudel_08_effects_filters.das <../../../../tutorials/daStrudel/daStrudel_08_effects_filters.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_per_voice_fx`
 
-   Next tutorial: :ref:`tutorial_dastrudel_adsr_envelopes`
+   Next tutorial: :ref:`tutorial_dastrudel_signals_modulation`

--- a/doc/source/reference/tutorials/daStrudel_09_signals_modulation.rst
+++ b/doc/source/reference/tutorials/daStrudel_09_signals_modulation.rst
@@ -1,0 +1,137 @@
+.. _tutorial_dastrudel_signals_modulation:
+
+=================================
+STRUDEL-09 — Signals & Modulation
+=================================
+
+.. index::
+    single: Tutorial; Strudel; Signals
+    single: Tutorial; Strudel; Modulation
+    single: Tutorial; Strudel; sine
+    single: Tutorial; Strudel; Pattern-valued setter
+
+So far every effect parameter has been a constant — ``lpf(800)``,
+``gain(0.5)``. This tutorial introduces **signals**: patterns whose Haps
+carry *numbers* instead of sounds, and the **pattern-valued setters** that
+let a signal drive any effect parameter over time. A filter that sweeps, a
+gain that swells, a pan that drifts — all of it is one idea: feed a signal
+where you used to write a constant.
+
+A signal is just a pattern
+==========================
+
+A signal is an ordinary ``Pattern``; the difference is what its Haps carry.
+Query one by hand and you get a number, not a drum hit. ``sine()`` is a
+*continuous* signal — one query window yields one Hap holding the wave's
+value at the start of that window:
+
+.. code-block:: das
+
+    let sig <- sine()
+    var h <- invoke(sig, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    print("value = {h[0].value.note}\n")
+    // output: value = 0.5
+
+At phase 0 a strudel sine sits at its midpoint, ``0.5`` — it sweeps
+``0 -> 1 -> 0`` across each cycle. ``run(n)`` is a *discrete* signal: ``n``
+equal steps valued ``0, 1, ... n-1``:
+
+.. code-block:: das
+
+    var hr <- invoke(run(4), TimeSpan(start = 0.0lf, stop = 1.0lf))
+    // four haps: 0  1  2  3   (one per quarter cycle)
+
+The full signal zoo: continuous ``sine``, ``cosine``, ``saw``, ``isaw``,
+``tri``, ``itri``, ``square``, ``perlin``, ``rand`` (all running ``0..1``);
+discrete ``run(n)`` and ``irand(n)``.
+
+range: remap into a useful span
+===============================
+
+The continuous signals all run ``0..1``. ``range(lo, hi)`` stretches that
+into the span you actually want — a cutoff in Hz, a gain, a pan position.
+``run()`` can drive pitch directly; ``run(8) |> add(48)`` is a chromatic
+ramp from MIDI 48 (C3) upward:
+
+.. code-block:: das
+
+    let pat <- run(8) |> add(48.0) |> sound("sine") |> sustain(0.3)
+    play(pat, 0.5lf)
+
+Pattern-valued setters: a moving filter
+=======================================
+
+This is the headline. Every per-event setter (``lpf``, ``gain``, ``pan``,
+``speed``, ...) has an overload that takes a **Pattern** instead of a
+constant. Feed it a signal and the parameter tracks that signal over time:
+
+.. code-block:: das
+
+    let pat <- (
+        atom("sawtooth") |> note(48.0) |> sustain(1.0)
+        |> lpf(sine() |> range(200.0, 4000.0) |> slow(4.0lf))
+    )
+    play(pat, 0.5lf, 8.0lf)
+
+``sine() |> range(200, 4000) |> slow(4)`` sweeps the cutoff from 200 Hz to
+4 kHz and back over four cycles — the classic filter-sweep pad. Note the
+surrounding parens: a multi-line pipe chain at statement level must be
+wrapped in ``(...)``.
+
+Modulating gain and pan
+=======================
+
+The same trick works for any setter. A slow sine on ``gain`` is a smooth
+volume swell; a slow sine on ``pan`` drifts the sound across the stereo
+field. Stack them and one sustained tone breathes and moves:
+
+.. code-block:: das
+
+    let pat <- (
+        atom("sine") |> note(48.0) |> sustain(1.0)
+        |> gain(sine() |> slow(2.0lf))
+        |> pan(sine() |> slow(4.0lf))
+    )
+    play(pat, 0.5lf, 8.0lf)
+
+The noisy signals: perlin and rand
+==================================
+
+``rand()`` is white-noise random — a fresh value every query, good for
+scattering pan or velocity. ``perlin()`` is smooth/organic random — it
+wanders instead of jumping, ideal for slow, living modulation:
+
+.. code-block:: das
+
+    // perlin drives a slow, unpredictable gain swell on a pad
+    let pad <- (
+        atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(800.0)
+        |> gain(perlin() |> range(0.1, 0.8) |> slow(4.0lf))
+    )
+    // rand scatters each note to a random stereo position
+    let mel <- note("c4 e4 g4 a4 g4 e4", "sine") |> sustain(0.5) |> pan(rand())
+
+Where next
+==========
+
+You now know:
+
+- A signal is a ``Pattern`` whose Haps carry numbers (in the ``note`` field)
+- ``range(lo, hi)`` remaps a ``0..1`` signal into any span
+- Every setter has a **pattern-valued** overload — feed it a signal to make
+  the parameter move over time
+- ``slow()`` stretches a signal's motion across several cycles
+- ``perlin`` wanders smoothly; ``rand`` jumps
+
+Tutorial 10 covers **ADSR envelopes** — shaping the amplitude of each note
+over its lifetime, the other half of "sound that changes over time".
+
+.. seealso::
+
+   Full source: :download:`tutorials/daStrudel/daStrudel_09_signals_modulation.das <../../../../tutorials/daStrudel/daStrudel_09_signals_modulation.das>`
+
+   Previous tutorial: :ref:`tutorial_dastrudel_effects_filters`
+
+   Next tutorial: :ref:`tutorial_dastrudel_adsr_envelopes`
+
+   Related: :ref:`tutorial_dastrudel_effects_filters` — the constant-valued setters these signals replace

--- a/doc/source/reference/tutorials/daStrudel_10_adsr_envelopes.rst
+++ b/doc/source/reference/tutorials/daStrudel_10_adsr_envelopes.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_adsr_envelopes:
 
 ====================================
-STRUDEL-09 — ADSR & Envelope Shaping
+STRUDEL-10 — ADSR & Envelope Shaping
 ====================================
 
 .. index::
@@ -118,7 +118,7 @@ Each voice keeps the same plucky envelope but a different peak level.
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_09_adsr_envelopes.das <../../../../tutorials/daStrudel/daStrudel_09_adsr_envelopes.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_10_adsr_envelopes.das <../../../../tutorials/daStrudel/daStrudel_10_adsr_envelopes.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_effects_filters`
 

--- a/doc/source/reference/tutorials/daStrudel_11_scales_music_theory.rst
+++ b/doc/source/reference/tutorials/daStrudel_11_scales_music_theory.rst
@@ -95,6 +95,58 @@ bass + lead pair from one scale — switch the scale root (``C4`` vs
 
 Same scale, two octaves, two different envelopes — instant counterpoint.
 
+Part F: ``degree_to_note`` — the primitive under ``scale``
+==========================================================
+
+``scale`` is built on ``degree_to_note(degree, root_midi, intervals)``,
+which converts a single scale degree to a MIDI note.  Degree 0 is the
+root, degree 7 wraps up an octave, and negative degrees wrap backwards.
+``get_scale_intervals_by_name`` returns the semitone table for a named
+scale, so you can resolve degrees by hand and feed the MIDI numbers
+straight into ``note()``:
+
+.. code-block:: das
+
+    let root = 60   // C4
+    let intervals <- get_scale_intervals_by_name("major")
+    for (deg in range(0, 8)) {
+        let midi = degree_to_note(deg, root, intervals)
+        print("  degree {deg} -> MIDI {int(midi)}\n")
+    }
+
+This is the same mapping ``n("0 2 4") |> scale("C4:major")`` performs
+internally — reaching for it directly is useful when you need the MIDI
+numbers themselves rather than a finished pattern.
+
+Part G: ``add`` — shift notes by semitones
+==========================================
+
+``add(pat, n)`` adds ``n`` semitones to every event's note — the
+chromatic-shift alias of ``transpose``.  ``run(8)`` produces a 0..7 ramp
+across the cycle, and ``add(48)`` lifts it into the audible C3..G3 range
+as a rising chromatic line:
+
+.. code-block:: das
+
+    let pat <- run(8) |> add(48.0) |> sound("sine") |> sustain(0.3)
+
+Part H: ``freq`` — pitch directly in Hz
+=======================================
+
+``note()`` derives the playback frequency from a MIDI number via
+``note_to_freq``.  ``freq()`` bypasses that path and sets an absolute
+frequency in Hz, so you can use tunings or raw frequency sweeps that
+have no MIDI name.  Here a sawtooth steps through 220 / 277 / 330 / 440
+Hz (an A-major-ish chord):
+
+.. code-block:: das
+
+    let pat <- (
+        s("sawtooth*4")
+        |> freq(note("220 277 330 440"))
+        |> lpf(2500.0) |> release(0.2) |> gain(0.5)
+    )
+
 .. seealso::
 
    Full source: :download:`tutorials/daStrudel/daStrudel_11_scales_music_theory.das <../../../../tutorials/daStrudel/daStrudel_11_scales_music_theory.das>`

--- a/doc/source/reference/tutorials/daStrudel_11_scales_music_theory.rst
+++ b/doc/source/reference/tutorials/daStrudel_11_scales_music_theory.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_scales_music_theory:
 
 ==================================
-STRUDEL-10 — Scales & Music Theory
+STRUDEL-11 — Scales & Music Theory
 ==================================
 
 .. index::
@@ -97,7 +97,7 @@ Same scale, two octaves, two different envelopes — instant counterpoint.
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_10_scales_music_theory.das <../../../../tutorials/daStrudel/daStrudel_10_scales_music_theory.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_11_scales_music_theory.das <../../../../tutorials/daStrudel/daStrudel_11_scales_music_theory.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_adsr_envelopes`
 

--- a/doc/source/reference/tutorials/daStrudel_12_synthesis.rst
+++ b/doc/source/reference/tutorials/daStrudel_12_synthesis.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_synthesis:
 
 ==========================
-STRUDEL-11 — Synthesis
+STRUDEL-12 — Synthesis
 ==========================
 
 .. index::
@@ -92,7 +92,7 @@ chain of modifiers — each ``|>`` returns a new ``Pattern``.
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_11_synthesis.das <../../../../tutorials/daStrudel/daStrudel_11_synthesis.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_12_synthesis.das <../../../../tutorials/daStrudel/daStrudel_12_synthesis.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_scales_music_theory`
 

--- a/doc/source/reference/tutorials/daStrudel_12_synthesis.rst
+++ b/doc/source/reference/tutorials/daStrudel_12_synthesis.rst
@@ -90,6 +90,41 @@ The ``note("c5", "sine")`` form is shorthand for
 See :ref:`tutorial_lambdas` for how ``|>`` threads a pattern through a
 chain of modifiers — each ``|>`` returns a new ``Pattern``.
 
+Part E: Shaping FM timbre with ``fm`` and ``fmh``
+=================================================
+
+The two FM knobs interact.  ``fm(index)`` is modulation depth — more
+index means a brighter, busier spectrum.  ``fmh(harmonicity)`` is the
+modulator-to-carrier ratio, which sets *where* the partials land:
+integer ratios stay harmonic (brass, organ), while non-integer ratios
+smear the partials into inharmonic, metallic, or industrial tones.
+Compare a harsh non-integer ratio against a clean integer one:
+
+.. code-block:: das
+
+    // Harsh, inharmonic — non-integer ratio
+    let harsh <- note("c3", "sine") |> fm(5.0) |> fmh(1.4) |> attack(0.01) |> decay(0.2) |> release(0.3)
+
+    // Bright but musical — integer ratio
+    let bright <- note("c3", "sine") |> fm(3.0) |> fmh(3.0) |> attack(0.01) |> decay(0.1) |> sustain(0.8) |> release(0.3)
+
+Part F: Direct-Hz synthesis with ``freq``
+=========================================
+
+``note()`` derives the oscillator frequency from a MIDI number;
+``freq()`` sets the frequency directly in Hz, bypassing the
+note-name → MIDI → Hz path.  Use it for raw frequency content or
+non-equal-tempered tunings.  Here a sawtooth steps through
+220 / 277 / 330 / 440 Hz (an A-major-ish chord):
+
+.. code-block:: das
+
+    let pat <- (
+        s("sawtooth*4")
+        |> freq(note("220 277 330 440"))
+        |> lpf(2500.0) |> release(0.2) |> gain(0.5)
+    )
+
 .. seealso::
 
    Full source: :download:`tutorials/daStrudel/daStrudel_12_synthesis.das <../../../../tutorials/daStrudel/daStrudel_12_synthesis.das>`

--- a/doc/source/reference/tutorials/daStrudel_13_samples.rst
+++ b/doc/source/reference/tutorials/daStrudel_13_samples.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_samples:
 
 ==========================
-STRUDEL-12 — Samples
+STRUDEL-13 — Samples
 ==========================
 
 .. index::
@@ -101,7 +101,7 @@ always check before using the data.
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_12_samples.das <../../../../tutorials/daStrudel/daStrudel_12_samples.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_13_samples.das <../../../../tutorials/daStrudel/daStrudel_13_samples.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_synthesis`
 

--- a/doc/source/reference/tutorials/daStrudel_13_samples.rst
+++ b/doc/source/reference/tutorials/daStrudel_13_samples.rst
@@ -99,6 +99,54 @@ struct:
 An empty ``Sample`` (``length(data) == 0``) signals a decode failure —
 always check before using the data.
 
+Part E: Playing a Slice with ``begin`` / ``end_pos``
+====================================================
+
+``begin(x)`` and ``end_pos(x)`` take normalized positions in 0..1 and
+play only the ``[begin, end)`` window of a sample.  ``begin(0.3)`` skips
+the first 30 % of the file; ``end_pos(0.8)`` trims the last 20 %.  (The
+setter is ``end_pos`` because ``end`` is a reserved word.)
+
+.. code-block:: das
+
+    let pat <- s("gong") |> begin(0.3) |> end_pos(0.8) |> gain(0.6)
+
+This skips the gong's bright attack and exposes its softer middle decay.
+
+Part F: Granulation — ``chop`` / ``striate`` / ``slice``
+========================================================
+
+Three ways to cut a sample into ``n`` grains:
+
+- ``chop(n)`` cuts each event in place into ``n`` back-to-back slices —
+  the slices stay inside that event's own time slot.
+- ``striate(n)`` spreads ``n`` slices across the whole cycle, so
+  successive events reveal progressively later parts of the sample.
+- ``slice(n, p)`` cuts into ``n`` slices and plays them in the order and
+  rhythm of index pattern ``p`` — structure comes from ``p``, the sound
+  from the source pattern.
+
+.. code-block:: das
+
+    let chopped  <- s("gong") |> chop(8) |> gain(0.6)
+    let striated <- s("bd sd hh cp") |> striate(4) |> gain(0.4)
+    let sliced   <- s("gong") |> slice(8, note("0 2 4 6 1 3 5 7")) |> gain(0.6)
+
+Part G: Loading a Whole Directory with ``strudel_load_sample_dir``
+==================================================================
+
+``strudel_load_sample_dir(root)`` loads every audio file directly under
+``root``, using each filename as the sound name.  It is the quick way to
+bring in an external pack such as `tidalcycles/dirt-samples
+<https://github.com/tidalcycles/dirt-samples>`_.  The built-in drums
+need no loading at all, so reach for this only when you want sounds
+beyond ``bd`` / ``sd`` / ``hh`` / ``cp``:
+
+.. code-block:: das
+
+    strudel_load_sample_dir("{MEDIA}/audio")
+    let pat <- s("gong") |> gain(0.6)
+
 .. seealso::
 
    Full source: :download:`tutorials/daStrudel/daStrudel_13_samples.das <../../../../tutorials/daStrudel/daStrudel_13_samples.das>`

--- a/doc/source/reference/tutorials/daStrudel_14_sf2_soundfont.rst
+++ b/doc/source/reference/tutorials/daStrudel_14_sf2_soundfont.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_sf2_soundfont:
 
 ===================================
-STRUDEL-13 — SF2 SoundFont Playback
+STRUDEL-14 — SF2 SoundFont Playback
 ===================================
 
 .. index::
@@ -113,7 +113,7 @@ standard mini-notation.  See :ref:`mini-notation compatibility
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_13_sf2_soundfont.das <../../../../tutorials/daStrudel/daStrudel_13_sf2_soundfont.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_14_sf2_soundfont.das <../../../../tutorials/daStrudel/daStrudel_14_sf2_soundfont.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_samples`
 

--- a/doc/source/reference/tutorials/daStrudel_15_midi_files.rst
+++ b/doc/source/reference/tutorials/daStrudel_15_midi_files.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_midi_files:
 
 ==========================
-STRUDEL-14 — MIDI Files
+STRUDEL-15 — MIDI Files
 ==========================
 
 .. index::
@@ -100,7 +100,7 @@ live patterns.
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_14_midi_files.das <../../../../tutorials/daStrudel/daStrudel_14_midi_files.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_15_midi_files.das <../../../../tutorials/daStrudel/daStrudel_15_midi_files.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_sf2_soundfont`
 

--- a/doc/source/reference/tutorials/daStrudel_16_live_reloading.rst
+++ b/doc/source/reference/tutorials/daStrudel_16_live_reloading.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_live_reloading:
 
 ====================================
-STRUDEL-15 — Live-Reloading Patterns
+STRUDEL-16 — Live-Reloading Patterns
 ====================================
 
 .. index::
@@ -19,7 +19,7 @@ Run this tutorial under the live host:
 
 ::
 
-   bin/Release/daslang-live.exe tutorials/daStrudel/daStrudel_15_live_reloading.das
+   bin/Release/daslang-live.exe tutorials/daStrudel/daStrudel_16_live_reloading.das
 
 It also runs under plain ``daslang.exe`` — the file works in both hosts.
 In standalone mode there is no hot-reload and the lifecycle collapses to
@@ -152,7 +152,7 @@ Workflow Tips
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_15_live_reloading.das <../../../../tutorials/daStrudel/daStrudel_15_live_reloading.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_16_live_reloading.das <../../../../tutorials/daStrudel/daStrudel_16_live_reloading.das>`
 
    Previous tutorial: :ref:`tutorial_dastrudel_midi_files`
 

--- a/doc/source/reference/tutorials/daStrudel_17_hrtf_position.rst
+++ b/doc/source/reference/tutorials/daStrudel_17_hrtf_position.rst
@@ -1,7 +1,7 @@
 .. _tutorial_dastrudel_hrtf_position:
 
 ====================================================
-STRUDEL-16 — HRTF: 3D Positional Override for Pan
+STRUDEL-17 — HRTF: 3D Positional Override for Pan
 ====================================================
 
 .. index::
@@ -134,7 +134,7 @@ itself HRTF-positioned, so the room follows the source through space.
 
 .. seealso::
 
-   Full source: :download:`tutorials/daStrudel/daStrudel_16_hrtf_position.das <../../../../tutorials/daStrudel/daStrudel_16_hrtf_position.das>`
+   Full source: :download:`tutorials/daStrudel/daStrudel_17_hrtf_position.das <../../../../tutorials/daStrudel/daStrudel_17_hrtf_position.das>`
 
    Standalone examples: ``examples/daStrudel/features/hrtf_basic.das``,
    ``examples/daStrudel/features/hrtf_animated.das``,

--- a/skills/strudel_port.md
+++ b/skills/strudel_port.md
@@ -86,7 +86,7 @@ typed lambda:
 ```
 .jux(rev)              →  |> jux(@(x) => rev(x))
 .off(1/8, fast(2))     →  |> off(0.125, @(x) => fast(x, 2))
-.every(4, rev)         →  |> every(4, @(x) => rev(x))
+.sometimes(fast(2))    →  |> sometimes(@(x) => fast(x, 2))
 ```
 
 **Use ``@(x) =>`` (a capture lambda), NOT ``@@(x) =>``.** Combinators
@@ -94,6 +94,19 @@ typed lambda:
 ``when_cycle``, …) take ``PatternTransform = lambda<(Pattern):Pattern>``.
 A no-capture ``@@(x) =>`` is a *function pointer*, which does not match
 the ``lambda`` type and fails type inference. ``@(x) =>`` is correct.
+
+**``every`` is the exception — it takes two PATTERNS, not a transform.**
+daslang's signature is ``every(n, pat_on, pat_off)``: it plays ``pat_on``
+on cycles 0, n, 2n, … and ``pat_off`` otherwise. There is no
+``every(n, transform)`` overload, so build both branches explicitly
+(construct the pattern twice rather than aliasing one — ``every`` moves
+both into its closure):
+
+```
+// strudel.cc:  s("c4 e4 g4").every(4, rev)
+// daslang:
+every(4, note("c4 e4 g4") |> rev(), note("c4 e4 g4"))
+```
 
 The ``@(x) => ...`` form is an inline lambda. See
 :ref:`tutorial_lambdas` for the syntax. If the transform itself is a
@@ -329,8 +342,8 @@ If ``gain("1 0.5")`` doesn't compile, wrap the pattern literal in
      - ``s("bd") \|> fast(2)``
    * - ``.jux(rev)``
      - ``\|> jux(@(x) => rev(x))``
-   * - ``.every(4, fast(2))``
-     - ``\|> every(4, @(x) => fast(x, 2))``
+   * - ``p.every(4, rev)``
+     - ``every(4, p_rev, p)`` — two patterns, not a transform
    * - ``stack(a, b, c)``
      - ``stack([a, b, c])``
    * - ``"bd(3,8)"``

--- a/tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
+++ b/tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
@@ -112,6 +112,7 @@ def example_euclid() {
     for (h in haps) {
         print("  onset at {h.whole.start}\n")
     }
+    delete haps
     play(pat, 4.0)
 }
 
@@ -122,6 +123,7 @@ def example_euclid_rotated() {
     for (h in haps) {
         print("  onset at {h.whole.start}\n")
     }
+    delete haps
     play(pat, 4.0)
 }
 

--- a/tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
+++ b/tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
@@ -5,6 +5,7 @@
 //   - Elongation @N — make an element occupy N units of its parent
 //   - Degrade ? — randomly drop events with 50% probability
 //   - Replicate !N — repeat an element N times in its parent sequence
+//   - Euclidean (k,n) / (k,n,rot) — spread k onsets over n steps, optional rotation
 //
 // Run: daslang.exe tutorials/daStrudel/daStrudel_03_mini_notation_advanced.das
 
@@ -94,6 +95,36 @@ def example_replicate() {
     play(pat, 4.0)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — Euclidean rhythms with (k,n) and (k,n,rot)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Postfix "(k,n)" spreads k onsets as evenly as possible over n steps —
+// "bd(3,8)" is the classic tresillo. "(k,n,rot)" rotates the result left
+// by rot steps. The parser expands these to euclid()/euclidRot() FUNCTION
+// forms (see tutorial 05); here we both query and play to see WHERE hits land.
+
+def example_euclid() {
+    print("\n=== Section 5: \"bd(3,8)\" — 3 onsets over 8 steps (tresillo) ===\n")
+    let pat <- s("bd(3,8)")
+    // Query one cycle [0,1) by hand and print each onset position.
+    var haps <- invoke(pat, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    for (h in haps) {
+        print("  onset at {h.whole.start}\n")
+    }
+    play(pat, 4.0)
+}
+
+def example_euclid_rotated() {
+    print("\n=== Section 5b: \"bd(3,8,2)\" — same rhythm rotated left by 2 ===\n")
+    let pat <- s("bd(3,8,2)")
+    var haps <- invoke(pat, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    for (h in haps) {
+        print("  onset at {h.whole.start}\n")
+    }
+    play(pat, 4.0)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-03: Mini-Notation Advanced\n\n")
@@ -102,5 +133,7 @@ def main() {
     example_elongation()
     example_degrade()
     example_replicate()
+    example_euclid()
+    example_euclid_rotated()
     print("\nDone!\n")
 }

--- a/tutorials/daStrudel/daStrudel_04_time_manipulation.das
+++ b/tutorials/daStrudel/daStrudel_04_time_manipulation.das
@@ -5,6 +5,9 @@
 //   - slow(N): stretch one copy of the pattern over N cycles
 //   - rev: reverse event positions within each cycle
 //   - hurry(N): like fast(N), but also pitch-shifts samples up
+//   - ply / iter / iterBack / palindrome: per-event and per-cycle restructuring
+//   - linger / compress: loop a fraction / squeeze into a window
+//   - striate / chop: granular sample slicing
 //
 // Run: daslang.exe tutorials/daStrudel/daStrudel_04_time_manipulation.das
 
@@ -66,7 +69,7 @@ def example_slow() {
 // at the mirrored position, then mirrors the results back. The result:
 // "c4 e4 g4 c5" plays backward as "c5 g4 e4 c4". Per-cycle reversal — not
 // a global reverse. Combine with jux for instant stereo widening (see
-// tutorial 06: combinators).
+// tutorial 07: combinators).
 
 def example_rev() {
     print("\n=== Section 3: rev — \"c4 e4 g4 c5\" played backward ===\n")
@@ -103,6 +106,86 @@ def example_composition() {
     play(pat, 6.0)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — ply(N): repeat each event in place
+// ──────────────────────────────────────────────────────────────────────────
+//
+// ply(N) plays each event N times back-to-back inside its own slot. Unlike
+// fast (which repeats the WHOLE pattern), ply subdivides each note locally —
+// a stutter effect. "c4 e4 g4 c5" |> ply(3) gives nine notes, three per slot.
+
+def example_ply() {
+    print("\n=== Section 6: ply(3) — each note stuttered three times ===\n")
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.3) |> ply(3)
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 7 — iter / iterBack / palindrome: per-cycle rotation
+// ──────────────────────────────────────────────────────────────────────────
+//
+// iter(N) rotates the pattern start by 1/N each cycle, walking through every
+// rotation over N cycles. iterBack(N) rotates the other direction. palindrome
+// alternates the pattern forward then reversed on successive cycles.
+
+def example_iter() {
+    print("\n=== Section 7: iter(4) — phrase rotates start point each cycle ===\n")
+    let pat <- note("c4 e4 g4 a4", "sine") |> iter(4)
+    play(pat, 8.0)
+}
+
+def example_iter_back() {
+    print("\n=== Section 7b: iterBack(4) — rotation in reverse direction ===\n")
+    let pat <- note("c4 e4 g4 a4", "sine") |> iterBack(4)
+    play(pat, 8.0)
+}
+
+def example_palindrome() {
+    print("\n=== Section 7c: palindrome — forward then reversed each cycle ===\n")
+    let pat <- note("c4 e4 g4 c5", "sine") |> palindrome
+    play(pat, 8.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 8 — linger / compress: looping and windowing
+// ──────────────────────────────────────────────────────────────────────────
+//
+// linger(t) loops the first fraction t of the cycle, filling the rest by
+// repeating it. compress(b,e) squeezes the whole pattern into the [b,e)
+// window of the cycle, leaving silence before b and after e.
+
+def example_linger() {
+    print("\n=== Section 8: linger(0.5) — loop the first half of the phrase ===\n")
+    let pat <- note("c4 e4 g4 c5 a4 g4 e4 c4", "sine") |> linger(0.5lf)
+    play(pat, 4.0)
+}
+
+def example_compress() {
+    print("\n=== Section 8b: compress(0.25, 0.75) — play only the middle half ===\n")
+    let pat <- note("c4 e4 g4 c5", "sine") |> sustain(0.3) |> compress(0.25lf, 0.75lf)
+    play(pat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 9 — striate / chop: granular sample slicing
+// ──────────────────────────────────────────────────────────────────────────
+//
+// striate(N) cuts a sample into N pieces and spreads those pieces across the
+// whole cycle. chop(N) also cuts into N pieces but keeps the slices inside
+// each event's own slot. Both need a sample-ish source — here the synth "bd".
+
+def example_striate() {
+    print("\n=== Section 9: striate(4) — sample sliced across the cycle ===\n")
+    let pat <- s("bd sd hh cp") |> striate(4) |> gain(0.4)
+    play(pat, 4.0)
+}
+
+def example_chop() {
+    print("\n=== Section 9b: chop(4) — each event cut into 4 in-place slices ===\n")
+    let pat <- s("bd") |> chop(4) |> gain(0.6)
+    play(pat, 4.0)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-04: Time Manipulation\n\n")
@@ -111,5 +194,13 @@ def main() {
     example_rev()
     example_hurry()
     example_composition()
+    example_ply()
+    example_iter()
+    example_iter_back()
+    example_palindrome()
+    example_linger()
+    example_compress()
+    example_striate()
+    example_chop()
     print("\nDone!\n")
 }

--- a/tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das
+++ b/tutorials/daStrudel/daStrudel_05_euclidean_rhythms.das
@@ -103,19 +103,55 @@ def example_polyrhythm() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Section 5 — euclidRot(pat, k, n, rot): rotate the onset pattern
+// ──────────────────────────────────────────────────────────────────────────
+//
+// euclidRot(pat, k, n, rot) is euclid with the Bjorklund pattern rotated
+// LEFT by rot steps. Same density (k onsets over n steps), different accent
+// placement. euclid(3, 8) hits steps 0,3,6; euclidRot(3, 8, 2) shifts the
+// window so onsets land on a different set of grid positions, changing the
+// feel without changing how many hits there are.
+
+def example_euclid_function_forms() {
+    print("\n=== Section 5: euclid(3, 8) vs euclidRot(3, 8, 2) ===\n")
+
+    // Query one cycle of each by hand to see the onset positions.
+    let base <- atom("bd") |> euclid(3, 8)
+    var basHaps <- invoke(base, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    print("  euclid(3, 8)        onsets at: ")
+    for (h in basHaps) {
+        print("{h.whole.start} ")
+    }
+    print("\n")
+    delete basHaps
+
+    let rotd <- atom("bd") |> euclidRot(3, 8, 2)
+    var rotHaps <- invoke(rotd, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    print("  euclidRot(3, 8, 2)  onsets at: ")
+    for (h in rotHaps) {
+        print("{h.whole.start} ")
+    }
+    print("\n")
+    delete rotHaps
+
+    let kick <- atom("bd") |> euclid(3, 8)
+    play(kick, 4.0)
+
+    let hat <- atom("hh") |> euclidRot(5, 8, 2)
+    play(hat, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // A note on syntax
 // ──────────────────────────────────────────────────────────────────────────
 //
 // In the original Tidal/Strudel mini-notation, "bd(3,8)" is the inline form
-// for euclid. THIS daStrudel build does not parse parentheses inside
-// mini-notation — you call euclid(pat, k, n) as a normal function. The
-// fluent pipe style stays compact:
-//   atom("bd") |> euclid(3, 8)
-//   s("bd sd") |> euclid(5, 8)
-//
-// Rotation (Tidal's `bd(3,8,1)`, `euclidRot`) is not yet exposed as a
-// standalone function in this build. Achieve it for now by reordering
-// elements inside the pattern fed to euclid, or with rev/slow chains.
+// for euclid and "bd(3,8,2)" adds rotation. daStrudel supports both: tutorial
+// 03 (Section 5) shows s("bd(3,8)") and s("bd(3,8,2)") — the parser expands
+// those directly to the euclid() / euclidRot() function forms used here.
+// The function forms are the explicit equivalents and read well in a pipe:
+//   atom("bd") |> euclid(3, 8)         // same as s("bd(3,8)")
+//   s("hh")    |> euclidRot(5, 8, 2)   // same as s("hh(5,8,2)")
 
 [export]
 def main() {
@@ -124,5 +160,6 @@ def main() {
     example_tresillo()
     example_clave_family()
     example_polyrhythm()
+    example_euclid_function_forms()
     print("\nDone!\n")
 }

--- a/tutorials/daStrudel/daStrudel_06_stacking_combining.das
+++ b/tutorials/daStrudel/daStrudel_06_stacking_combining.das
@@ -103,6 +103,89 @@ def example_superimpose() {
     play(pat, 0.5lf)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — fastcat: squeeze all patterns into ONE cycle
+// ──────────────────────────────────────────────────────────────────────────
+//
+// cat gives each pattern a whole cycle in turn; fastcat squeezes ALL of
+// them into a single cycle, side by side. With N patterns each fills 1/N
+// of every cycle. It is exactly fast(cat(pats), N).
+
+def example_fastcat() {
+    print("\n=== Section 5: fastcat ===\n")
+    let pat <- fastcat([
+        s("bd"),
+        s("hh"),
+        s("sd"),
+        s("hh")
+    ])
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — randcat / chooseCycles: pick one pattern per cycle
+// ──────────────────────────────────────────────────────────────────────────
+//
+// randcat picks one of the patterns at random each cycle (deterministic —
+// the same cycle index always picks the same pattern). chooseCycles is an
+// alias for the same per-cycle behaviour; both are aliases of choose in this
+// build. Use them to vary a phrase from cycle to cycle without writing out
+// every variation by hand.
+
+def example_randcat() {
+    print("\n=== Section 6: randcat / chooseCycles ===\n")
+    let pat <- randcat([
+        note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+        note("c4 g4 e4 c4", "sine") |> sustain(0.4),
+        note("c4 d4 e4 f4", "sine") |> sustain(0.4)
+    ])
+    play(pat, 0.5lf, 6.0lf)
+
+    // chooseCycles is the same per-cycle pick under a different name.
+    let pat2 <- chooseCycles([
+        s("bd hh sd hh"),
+        s("bd bd sd hh")
+    ])
+    play(pat2, 0.5lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 7 — choose: pick one pattern per cycle (randcat's base)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// In this build choose performs the same discrete, per-cycle random pick
+// that randcat and chooseCycles do — randcat / chooseCycles are aliases of
+// choose. (Some pattern libraries make choose a continuous per-event signal;
+// daStrudel keeps it per-cycle so note patterns do not glitch.)
+
+def example_choose() {
+    print("\n=== Section 7: choose ===\n")
+    let pat <- choose([
+        note("c4 e4 g4", "sine") |> sustain(0.4),
+        note("d4 f4 a4", "sine") |> sustain(0.4),
+        note("e4 g4 b4", "sine") |> sustain(0.4)
+    ])
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 8 — wchoose: weighted per-cycle pick
+// ──────────────────────────────────────────────────────────────────────────
+//
+// wchoose takes TWO arrays — the patterns, then a parallel array of float
+// weights. A pattern's chance of being chosen each cycle is its weight over
+// the sum of all weights. Here bd is three times as likely as cp or sd.
+
+def example_wchoose() {
+    print("\n=== Section 8: wchoose ===\n")
+    let pat <- wchoose([
+        s("bd*4"),
+        s("cp*4"),
+        s("sd*4")
+    ], [3.0, 1.0, 1.0])
+    play(pat, 0.5lf, 6.0lf)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-06: Stacking & Combining\n")
@@ -110,5 +193,9 @@ def main() {
     example_cat()
     example_layer_chord()
     example_superimpose()
+    example_fastcat()
+    example_randcat()
+    example_choose()
+    example_wchoose()
     print("\nDone.\n")
 }

--- a/tutorials/daStrudel/daStrudel_07_per_voice_fx.das
+++ b/tutorials/daStrudel/daStrudel_07_per_voice_fx.das
@@ -97,6 +97,12 @@ def example_chunk_fast() {
 // simultaneous notes in a single stack can carry DIFFERENT phaser rates without
 // leaking into each other. (room/delay/chorus differ — those are per-orbit
 // send buses; see tutorial 08.)
+//
+// The full split (shared with tutorial 08):
+//   Per-voice  (independent per note): gain, pan, speed, lpf, hpf, bpf,
+//              phaser, tremolo, compressor, shape, crush, coarse, djf, fm, vowel
+//   Per-orbit  (one shared bus instance per orbit): room/roomsize,
+//              delay/delaytime/delayfeedback, chorus
 
 def example_per_voice_phaser() {
     print("\n=== Section 4: per-voice phaser at two different rates ===\n")
@@ -107,6 +113,72 @@ def example_per_voice_phaser() {
     play(pat, 0.5lf, 6.0lf)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — probabilistic combinators: sometimes, degradeBy
+// ──────────────────────────────────────────────────────────────────────────
+//
+// sometimes(pat, fn) applies fn to a random ~50% of events; degradeBy(prob)
+// randomly DROPS events with the given probability. Both are how you turn a
+// rigid loop into something that breathes — humanised fills and thinning.
+
+def example_sometimes() {
+    print("\n=== Section 5a: sometimes — half the hits play twice as fast ===\n")
+    let pat <- sometimes(s("bd sd hh cp"), @(x) => fast(x, 2.0lf))
+    play(pat, 0.5lf, 6.0lf)
+}
+
+def example_degrade() {
+    print("\n=== Section 5b: degradeBy(0.4) — randomly drop 40% of a hi-hat run ===\n")
+    let pat <- s("hh*8") |> degradeBy(0.4)
+    play(pat, 0.5lf, 6.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — cycle-conditional: every, when_cycle
+// ──────────────────────────────────────────────────────────────────────────
+//
+// every(n, pat_on, pat_off) plays pat_on on cycles 0, n, 2n, ... and pat_off
+// otherwise — note daslang's every takes two PATTERNS, not a transform.
+// when_cycle(pat, cond, fn) applies fn only on cycles where cond(cycle) is true.
+
+def example_every() {
+    print("\n=== Section 6a: every 4th cycle, the line reverses ===\n")
+    // every() moves both patterns into its closure, so build the line twice
+    // (an independent copy for each branch) rather than aliasing one.
+    let pat <- every(4, note("c4 e4 g4 c5", "sine") |> sustain(0.4) |> rev(),
+                        note("c4 e4 g4 c5", "sine") |> sustain(0.4))
+    play(pat, 0.5lf, 8.0lf)
+}
+
+def example_when_cycle() {
+    print("\n=== Section 6b: when_cycle — speed up on even cycles only ===\n")
+    let pat <- when_cycle(note("c4 e4 g4 c5", "sine") |> sustain(0.4),
+                          @(c) => c % 2 == 0, @(x) => fast(x, 2.0lf))
+    play(pat, 0.5lf, 8.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 7 — reordering & gating: shuffle, scramble, mask
+// ──────────────────────────────────────────────────────────────────────────
+//
+// shuffle(n) cuts the cycle into n slices and plays them in a shuffled order
+// (a permutation — every slice once); scramble(n) picks n slices at random
+// (repeats allowed). mask(pat, bool_pat) gates events through a 1/~ pattern.
+
+def example_shuffle_scramble() {
+    print("\n=== Section 7a: shuffle vs scramble of an 8-note scale ===\n")
+    let shuf <- note("c4 d4 e4 f4 g4 a4 b4 c5", "sine") |> sustain(0.4) |> shuffle(8)
+    play(shuf, 0.5lf, 4.0lf)
+    let scrm <- note("c4 d4 e4 f4 g4 a4 b4 c5", "sine") |> sustain(0.4) |> scramble(8)
+    play(scrm, 0.5lf, 4.0lf)
+}
+
+def example_mask() {
+    print("\n=== Section 7b: mask — gate a melody through \"1 ~ 1 ~\" ===\n")
+    let pat <- note("c4 d4 e4 f4", "sine") |> sustain(0.4) |> mask(s("1 ~ 1 ~"))
+    play(pat, 0.5lf)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-07: Per-Voice FX & Combinators\n")
@@ -115,5 +187,11 @@ def main() {
     example_off_canon()
     example_chunk_fast()
     example_per_voice_phaser()
+    example_sometimes()
+    example_degrade()
+    example_every()
+    example_when_cycle()
+    example_shuffle_scramble()
+    example_mask()
     print("\nDone.\n")
 }

--- a/tutorials/daStrudel/daStrudel_08_effects_filters.das
+++ b/tutorials/daStrudel/daStrudel_08_effects_filters.das
@@ -1,15 +1,17 @@
 // Tutorial DASTRUDEL-08: Effects & Filters
 //
-// daslang's strudel splits effects into two groups:
+// daslang's strudel splits effects into two groups (shared with tutorial 07):
 //
-//   Per-orbit bus FX     — room (reverb), delay, chorus
-//                          one shared instance per orbit, voices send wet/dry
-//   Per-voice FX         — lpf, hpf, phaser, tremolo, compressor, shape, crush
-//                          baked into each individual voice
+//   Per-orbit bus FX  — room/roomsize, delay/delaytime/delayfeedback, chorus
+//                       one shared instance per orbit; voices send wet/dry
+//   Per-voice FX      — gain, pan, speed, lpf, hpf, bpf, phaser, tremolo,
+//                       compressor, shape, crush, coarse, djf, fm, vowel
+//                       baked into each individual voice
 //
 // Use orbit(N) to route a pattern to a specific bus so each layer can carry
 // its own reverb size and delay time. Use the per-voice setters to colour
-// individual notes.
+// individual notes. (Every setter below also has a pattern-valued overload —
+// feed it a signal to make the parameter move; see tutorial 09.)
 //
 // Run: daslang.exe tutorials/daStrudel/daStrudel_08_effects_filters.das
 
@@ -110,6 +112,71 @@ def example_orbit_busses() {
     play(pat, 0.5lf, 6.0lf)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — crush & shape (per-voice waveshaping)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// crush(bits) reduces bit depth for a lo-fi grit; coarse(n) drops the sample
+// rate by a factor of n (decimation). shape(amount) is a waveshaper that adds
+// harmonic distortion. All per-voice.
+
+def example_crush_shape() {
+    print("\n=== Section 6: crush + coarse, then shape (waveshaper) ===\n")
+    let pat_crush <- note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> crush(4.0) |> coarse(4)
+    play(pat_crush, 0.8lf, 4.0lf)
+
+    let pat_shape <- note("c3 e3 g3 c4", "sine") |> sustain(0.8) |> shape(0.6)
+    play(pat_shape, 0.8lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 7 — tremolo & compressor (per-voice amplitude FX)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// tremolo(rateHz) modulates amplitude for a pulsing effect (tremolodepth sets
+// how deep); compressor(thresholdDb) tames dynamics so quiet and loud notes
+// sit closer together.
+
+def example_tremolo_compressor() {
+    print("\n=== Section 7: tremolo, then compressor ===\n")
+    let pat_trem <- note("d3 d3 d#3 d3", "supersaw") |> sustain(1.0) |> release(0.5) |> tremolo(8.0) |> tremolodepth(0.8)
+    play(pat_trem, 0.5lf, 4.0lf)
+
+    let pat_comp <- s("bd sd hh cp") |> compressor(-20.0)
+    play(pat_comp, 0.5lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 8 — bpf & djf (more per-voice filters)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// bpf(freq) is a band-pass filter (bpq sets resonance/Q); djf(x) is a single
+// DJ-style filter knob — below 0.5 it acts as a low-pass, above 0.5 a
+// high-pass, so one parameter sweeps from muffled to thin.
+
+def example_bpf_djf() {
+    print("\n=== Section 8: band-pass, then DJ filter ===\n")
+    let pat_bpf <- note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> bpf(800.0) |> bpq(6.0)
+    play(pat_bpf, 0.8lf, 4.0lf)
+
+    let pat_djf <- note("c3 e3 g3 c4", "sawtooth") |> sustain(0.8) |> djf(0.8)
+    play(pat_djf, 0.8lf, 4.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 9 — chorus (per-orbit bus)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// chorus(amount) thickens a sound by mixing in slightly detuned copies. Like
+// room and delay it lives on the orbit bus, so all voices on the same orbit
+// share one chorus instance.
+
+def example_chorus() {
+    print("\n=== Section 9: chorus on a chord progression ===\n")
+    let pat <- note("<[c3,e3,g3] [f3,a3,c4] [g3,b3,d4] [a3,c4,e4]>", "sawtooth") |> chorus(0.5) |> attack(0.05) |> decay(0.1) |> sustain(0.6) |> release(0.3) |> gain(0.4)
+    play(pat, 0.5lf, 8.0lf)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-08: Effects & Filters\n")
@@ -118,5 +185,9 @@ def main() {
     example_delay()
     example_phaser()
     example_orbit_busses()
+    example_crush_shape()
+    example_tremolo_compressor()
+    example_bpf_djf()
+    example_chorus()
     print("\nDone.\n")
 }

--- a/tutorials/daStrudel/daStrudel_08_effects_filters.das
+++ b/tutorials/daStrudel/daStrudel_08_effects_filters.das
@@ -72,7 +72,7 @@ def example_room() {
 //
 // delay(amount), delaytime(seconds), delayfeedback(0..1) drive the orbit's
 // delay line. delaytime defaults to a tempo-aware 3/16 cycle (see tutorial
-// 09 for the resolver), so plain `delay(0.5)` already locks to the cps.
+// 10 for the resolver), so plain `delay(0.5)` already locks to the cps.
 
 def example_delay() {
     print("\n=== Section 3: delay echo on a pluck ===\n")

--- a/tutorials/daStrudel/daStrudel_09_signals_modulation.das
+++ b/tutorials/daStrudel/daStrudel_09_signals_modulation.das
@@ -1,0 +1,151 @@
+// Tutorial DASTRUDEL-09: Signals & Modulation
+//
+// This tutorial covers:
+//   - Signals — continuous patterns of numbers: sine, saw, tri, square,
+//     perlin, rand, and the discrete run / irand
+//   - range(lo, hi) — remap a signal's native 0..1 into any span
+//   - Pattern-valued setters — feed a signal into lpf / gain / pan / ...
+//     so an effect parameter MOVES over time (the flagship feature)
+//   - slow() on a signal — stretch the modulation across several cycles
+//
+// A signal is just a Pattern like any other — but instead of notes or
+// drum hits it carries a number in each Hap. The same combinators
+// (slow, fast, range) that shape rhythmic patterns also shape signals.
+//
+// Run: daslang.exe tutorials/daStrudel/daStrudel_09_signals_modulation.das
+
+options gen2
+options persistent_heap
+options indenting = 4
+
+require strudel/strudel public
+require strudel/strudel_player public
+require strudel/strudel_time
+require audio/audio_boost
+require daslib/fio
+
+def play(var pat : Pattern; cps : double = 0.5lf; seconds : double = 4.0lf) {
+    with_audio_system() {
+        strudel_create_channel()
+        strudel_set_cps(cps)
+        strudel_add_track(pat)
+        let t0 = ref_time_ticks()
+        while (double(get_time_usec(t0)) / 1000000.0lf < seconds) {
+            strudel_tick()
+            sleep(5u)
+        }
+        strudel_shutdown()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — A signal is a pattern of numbers
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Query a signal by hand and you get Haps whose value is a number, not a
+// sound. sine() is a *continuous* signal: one query window yields one Hap
+// carrying the wave's value at the start of that window. At phase 0 a
+// strudel sine sits at its midpoint, 0.5 (it sweeps 0 -> 1 -> 0 per cycle).
+// run(n) is a *discrete* signal: n equal steps valued 0, 1, ... n-1.
+
+def example_query_signal() {
+    print("=== Section 1: query signals by hand ===\n")
+    let sig <- sine()
+    var h <- invoke(sig, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    print("  sine() over [0,1) -> {length(h)} hap, value = {h[0].value.note}\n")
+    delete h
+
+    let rn <- run(4)
+    var hr <- invoke(rn, TimeSpan(start = 0.0lf, stop = 1.0lf))
+    print("  run(4) over [0,1) -> {length(hr)} haps: ")
+    for (x in hr) {
+        print("{x.value.note} ")
+    }
+    print("\n")
+    delete hr
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — range: remap a signal into a useful span
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Every continuous signal (sine, cosine, saw, isaw, tri, itri, square,
+// perlin, rand) runs 0..1. range(lo, hi) stretches that into the span you
+// actually want — a filter cutoff in Hz, a gain in 0..1, a pan position.
+// Here run() drives pitch directly: run(8) |> add(48) makes a chromatic
+// ramp from MIDI 48 (C3) upward, one step per eighth of the cycle.
+
+def example_run_melody() {
+    print("\n=== Section 2: run() as a melodic ramp (C3 chromatic, 8 steps) ===\n")
+    let pat <- run(8) |> add(48.0) |> sound("sine") |> sustain(0.3)
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — pattern-valued lpf: a moving filter sweep
+// ──────────────────────────────────────────────────────────────────────────
+//
+// This is the headline. Every per-event setter (lpf, gain, pan, speed, ...)
+// has an overload that takes a *Pattern* instead of a constant. Feed it a
+// signal and the parameter tracks the signal over time. sine() |> range(200,
+// 4000) |> slow(4) sweeps the cutoff from 200 Hz to 4 kHz and back over four
+// cycles — the classic filter-sweep pad.
+
+def example_lpf_sweep() {
+    print("\n=== Section 3: sine -> lpf sweep on a sawtooth ===\n")
+    let pat <- (
+        atom("sawtooth") |> note(48.0) |> sustain(1.0)
+        |> lpf(sine() |> range(200.0, 4000.0) |> slow(4.0lf))
+    )
+    play(pat, 0.5lf, 8.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — modulating gain and pan
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The same trick works for any setter. A slow sine on gain gives a smooth
+// volume swell (tremolo by hand); a slow sine on pan drifts the sound across
+// the stereo field. Stack them and one sustained tone breathes and moves.
+
+def example_gain_pan() {
+    print("\n=== Section 4: sine -> gain swell + sine -> pan drift ===\n")
+    let pat <- (
+        atom("sine") |> note(48.0) |> sustain(1.0)
+        |> gain(sine() |> slow(2.0lf))
+        |> pan(sine() |> slow(4.0lf))
+    )
+    play(pat, 0.5lf, 8.0lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — the noisy signals: perlin and rand
+// ──────────────────────────────────────────────────────────────────────────
+//
+// rand() is white-noise-random — a fresh value every query, good for
+// scattering pan or velocity. perlin() is smooth/organic random — it wanders
+// instead of jumping, ideal for slow, living modulation. Here perlin drives
+// gain on a pad for an unpredictable swell, while rand scatters pan per note.
+
+def example_perlin_rand() {
+    print("\n=== Section 5: perlin -> gain swell, rand -> pan scatter ===\n")
+    let pad <- (
+        atom("sawtooth") |> note(48.0) |> sustain(1.0) |> lpf(800.0)
+        |> gain(perlin() |> range(0.1, 0.8) |> slow(4.0lf))
+    )
+    play(pad, 0.5lf, 6.0lf)
+
+    let mel <- note("c4 e4 g4 a4 g4 e4", "sine") |> sustain(0.5) |> pan(rand())
+    play(mel, 0.5lf)
+}
+
+[export]
+def main() {
+    print("DASTRUDEL-09: Signals & Modulation\n\n")
+    example_query_signal()
+    example_run_melody()
+    example_lpf_sweep()
+    example_gain_pan()
+    example_perlin_rand()
+    print("\nDone.\n")
+}

--- a/tutorials/daStrudel/daStrudel_10_adsr_envelopes.das
+++ b/tutorials/daStrudel/daStrudel_10_adsr_envelopes.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-09: ADSR & Envelope Shaping
+// Tutorial DASTRUDEL-10: ADSR & Envelope Shaping
 //
 // An ADSR envelope shapes a note's amplitude over time:
 //   Attack  — time from key-down to peak
@@ -15,7 +15,7 @@
 // This lets `note(...).s("sine")` ring out for the full note, instead of
 // decaying to silence in 50ms like older defaults.
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_09_adsr_envelopes.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_10_adsr_envelopes.das
 
 options gen2
 options persistent_heap
@@ -125,7 +125,7 @@ def example_velocity_curve() {
 
 [export]
 def main() {
-    print("DASTRUDEL-09: ADSR & Envelope Shaping\n")
+    print("DASTRUDEL-10: ADSR & Envelope Shaping\n")
     example_default_held()
     example_pluck()
     example_pad()

--- a/tutorials/daStrudel/daStrudel_11_scales_music_theory.das
+++ b/tutorials/daStrudel/daStrudel_11_scales_music_theory.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-10: Scales & Music Theory
+// Tutorial DASTRUDEL-11: Scales & Music Theory
 //
 // Scales let you write melodies in terms of degrees (0, 1, 2, ...) instead
 // of absolute pitches. Combined with a scale name like "C4:major" or
@@ -10,7 +10,7 @@
 //   - modes: dorian, mixolydian, lydian, phrygian, locrian
 //   - transposition by switching the scale root or by transpose(semitones)
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_10_scales_music_theory.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_11_scales_music_theory.das
 
 options gen2
 options persistent_heap
@@ -123,7 +123,7 @@ def example_two_octaves() {
 
 [export]
 def main() {
-    print("DASTRUDEL-10: Scales & Music Theory\n")
+    print("DASTRUDEL-11: Scales & Music Theory\n")
     example_major_vs_minor()
     example_pentatonic()
     example_modes()

--- a/tutorials/daStrudel/daStrudel_11_scales_music_theory.das
+++ b/tutorials/daStrudel/daStrudel_11_scales_music_theory.das
@@ -121,6 +121,67 @@ def example_two_octaves() {
     play(pat, 0.5lf, 5.0lf)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — degree_to_note: the primitive under scale()
+// ──────────────────────────────────────────────────────────────────────────
+//
+// scale() is built on degree_to_note(degree, root_midi, intervals), which
+// converts one scale degree to a MIDI note. Degree 0 = root, degree 7 wraps
+// up an octave, negative degrees wrap backwards. get_scale_intervals_by_name
+// returns the semitone table for a named scale, so you can resolve degrees
+// by hand and feed the MIDI numbers straight into note().
+
+def example_degree_to_note() {
+    print("\n=== Section 6: degree_to_note maps degrees to MIDI notes ===\n")
+    let root = 60   // C4
+    let intervals <- get_scale_intervals_by_name("major")
+    // Resolve a 0..7 run by hand and print the MIDI numbers.
+    for (deg in range(0, 8)) {
+        let midi = degree_to_note(deg, root, intervals)
+        print("  degree {deg} -> MIDI {int(midi)}\n")
+    }
+    // Play degrees 0,2,4,7 resolved through the same primitive.
+    let n0 = degree_to_note(0, root, intervals)
+    let n2 = degree_to_note(2, root, intervals)
+    let n4 = degree_to_note(4, root, intervals)
+    let n7 = degree_to_note(7, root, intervals)
+    let pat <- s("sine sine sine sine") |> note(note("{int(n0)} {int(n2)} {int(n4)} {int(n7)}")) |> decay(0.15) |> release(0.2)
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 7 — add: shift notes by semitones
+// ──────────────────────────────────────────────────────────────────────────
+//
+// add(pat, n) adds n semitones to every event's note — the chromatic-shift
+// alias of transpose. run(8) produces a 0..7 ramp across the cycle; add(48)
+// lifts it into the audible C3..G3 range as a rising chromatic line.
+
+def example_add() {
+    print("\n=== Section 7: add() shifts a degree ramp into the audible range ===\n")
+    let pat <- run(8) |> add(48.0) |> sound("sine") |> sustain(0.3)
+    play(pat, 0.5lf)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 8 — freq: pitch directly in Hz
+// ──────────────────────────────────────────────────────────────────────────
+//
+// note() derives the playback frequency from a MIDI number via note_to_freq.
+// freq() bypasses that path entirely and sets an absolute frequency in Hz, so
+// you can use tuning systems or raw frequency sweeps that have no MIDI name.
+// Here a sawtooth steps through 220 / 277 / 330 / 440 Hz (an A-major-ish chord).
+
+def example_freq() {
+    print("\n=== Section 8: freq() sets pitch directly in Hz ===\n")
+    let pat <- (
+        s("sawtooth*4")
+        |> freq(note("220 277 330 440"))
+        |> lpf(2500.0) |> release(0.2) |> gain(0.5)
+    )
+    play(pat, 0.5lf)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-11: Scales & Music Theory\n")
@@ -129,5 +190,8 @@ def main() {
     example_modes()
     example_transpose()
     example_two_octaves()
+    example_degree_to_note()
+    example_add()
+    example_freq()
     print("\nDone.\n")
 }

--- a/tutorials/daStrudel/daStrudel_12_synthesis.das
+++ b/tutorials/daStrudel/daStrudel_12_synthesis.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-11: Synthesis
+// Tutorial DASTRUDEL-12: Synthesis
 //
 // This tutorial covers:
 //   - Oscillator sources via s("sine"|"sawtooth"|"square"|"triangle"|"supersaw")
@@ -6,7 +6,7 @@
 //   - Noise sources ("white", "pink", "brown")
 //   - FM synthesis with fm() and fmh() (modulation index and harmonicity)
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_11_synthesis.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_12_synthesis.das
 
 options gen2
 options indenting = 4
@@ -105,7 +105,7 @@ def example_fm_gentle() {
 
 [export]
 def main() {
-    print("DASTRUDEL-11: Synthesis\n\n")
+    print("DASTRUDEL-12: Synthesis\n\n")
     example_oscillators()
     example_supersaw()
     example_noise()

--- a/tutorials/daStrudel/daStrudel_12_synthesis.das
+++ b/tutorials/daStrudel/daStrudel_12_synthesis.das
@@ -103,6 +103,46 @@ def example_fm_gentle() {
     play(pat, 4.0)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — Shaping FM timbre with fm() and fmh()
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The two FM knobs interact:
+//   - fm(index):       modulation depth — more index = brighter, busier spectrum
+//   - fmh(harmonicity): modulator/carrier ratio — sets WHERE the partials land
+// Integer fmh stays harmonic (brass, organ); non-integer fmh smears the
+// partials into inharmonic, metallic, or industrial tones. Compare a clean
+// integer ratio against a harsh non-integer one.
+
+def example_fm_shaping() {
+    print("\n=== Section 5a: harsh FM (fm=5, fmh=1.4) — non-integer ratio ===\n")
+    let harsh <- note("c3", "sine") |> fm(5.0) |> fmh(1.4) |> attack(0.01) |> decay(0.2) |> release(0.3)
+    play(harsh, 4.0)
+
+    print("\n=== Section 5b: bright integer FM (fm=3, fmh=3) ===\n")
+    let bright <- note("c3", "sine") |> fm(3.0) |> fmh(3.0) |> attack(0.01) |> decay(0.1) |> sustain(0.8) |> release(0.3)
+    play(bright, 4.0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — Direct-Hz synthesis with freq()
+// ──────────────────────────────────────────────────────────────────────────
+//
+// note() derives the oscillator frequency from a MIDI number; freq() sets the
+// frequency directly in Hz, bypassing the note-name -> MIDI -> Hz path. Use it
+// for raw frequency content or non-equal-tempered tunings. Here a sawtooth
+// steps through 220 / 277 / 330 / 440 Hz (an A-major-ish chord).
+
+def example_freq_direct() {
+    print("\n=== Section 6: freq() — pitch directly in Hz ===\n")
+    let pat <- (
+        s("sawtooth*4")
+        |> freq(note("220 277 330 440"))
+        |> lpf(2500.0) |> release(0.2) |> gain(0.5)
+    )
+    play(pat, 4.0)
+}
+
 [export]
 def main() {
     print("DASTRUDEL-12: Synthesis\n\n")
@@ -111,5 +151,7 @@ def main() {
     example_noise()
     example_fm_bells()
     example_fm_gentle()
+    example_fm_shaping()
+    example_freq_direct()
     print("\nDone!\n")
 }

--- a/tutorials/daStrudel/daStrudel_13_samples.das
+++ b/tutorials/daStrudel/daStrudel_13_samples.das
@@ -121,6 +121,78 @@ def example_decode() {
     print("  duration:    {float(length(sample.data)) / float(sample.channels * sample.sample_rate):.3f} s\n")
 }
 
+def load_gong() {
+    // The audio/ folder holds gong.wav (index :0, sorted alphabetically).
+    strudel_load_sound("{MEDIA}/audio", "gong")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 5 — begin() / end_pos(): play a slice of the sample
+// ──────────────────────────────────────────────────────────────────────────
+//
+// begin(x) and end_pos(x) take normalized positions in 0..1 and play only the
+// [begin, end) window of the sample. begin(0.5) skips the first half; end_pos
+// trims the tail. (The setter is end_pos, because `end` is a reserved word.)
+// Here the gong's bright attack is skipped to expose its softer middle decay.
+
+def example_begin_end() {
+    print("\n=== Section 5: begin()/end_pos() play a [begin, end) window ===\n")
+    let pat <- s("gong") |> begin(0.3) |> end_pos(0.8) |> gain(0.6)
+    play(pat, 4.0, 0.5lf) {
+        load_gong()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 6 — Granulation: striate / chop / slice
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Three ways to cut a sample into n grains:
+//   - chop(n):     cuts each event in place into n back-to-back slices —
+//                  the slices stay inside that event's own time slot.
+//   - striate(n):  spreads n slices across the whole cycle — successive
+//                  events reveal progressively later parts of the sample.
+//   - slice(n, p): cuts into n slices and plays them in the order/rhythm of
+//                  index pattern p, so structure comes from p, sound from pat.
+
+def example_granulation() {
+    print("\n=== Section 6a: chop(8) — 8 grains inside one event ===\n")
+    let chopped <- s("gong") |> chop(8) |> gain(0.6)
+    play(chopped, 4.0, 0.5lf) {
+        load_gong()
+    }
+
+    print("\n=== Section 6b: striate(4) — slices spread across the cycle ===\n")
+    let striated <- s("bd sd hh cp") |> striate(4) |> gain(0.4)
+    play(striated, 4.0, 0.5lf) {
+        load_drum_bank()
+    }
+
+    print("\n=== Section 6c: slice(8, idx) — slices reshuffled by an index pattern ===\n")
+    let sliced <- s("gong") |> slice(8, note("0 2 4 6 1 3 5 7")) |> gain(0.6)
+    play(sliced, 4.0, 0.5lf) {
+        load_gong()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 7 — Loading a whole sample directory
+// ──────────────────────────────────────────────────────────────────────────
+//
+// strudel_load_sample_dir(root) loads every audio file directly under root,
+// using each filename as the sound name. It is the quick way to bring in an
+// external pack (e.g. tidalcycles/dirt-samples). The built-in drums work with
+// no loading at all, so this is only needed for sounds beyond bd/sd/hh/cp.
+
+def example_load_dir() {
+    print("\n=== Section 7: strudel_load_sample_dir loads a whole folder ===\n")
+    let pat <- s("gong") |> gain(0.6)
+    play(pat, 3.0, 0.5lf) {
+        // Loads gong.wav (and any other files) under audio/ by filename.
+        strudel_load_sample_dir("{MEDIA}/audio")
+    }
+}
+
 [export]
 def main() {
     print("DASTRUDEL-13: Samples\n\n")
@@ -128,5 +200,8 @@ def main() {
     example_variations()
     example_speed_shift()
     example_decode()
+    example_begin_end()
+    example_granulation()
+    example_load_dir()
     print("\nDone!\n")
 }

--- a/tutorials/daStrudel/daStrudel_13_samples.das
+++ b/tutorials/daStrudel/daStrudel_13_samples.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-12: Samples
+// Tutorial DASTRUDEL-13: Samples
 //
 // This tutorial covers:
 //   - Loading audio files into named sample banks with strudel_load_sound
@@ -7,7 +7,7 @@
 //   - Pitch-shifting samples with speed() (2.0 = one octave up)
 //   - Decoding a single file with load_audio_file
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_12_samples.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_13_samples.das
 
 options gen2
 options indenting = 4
@@ -123,7 +123,7 @@ def example_decode() {
 
 [export]
 def main() {
-    print("DASTRUDEL-12: Samples\n\n")
+    print("DASTRUDEL-13: Samples\n\n")
     example_drum_pattern()
     example_variations()
     example_speed_shift()

--- a/tutorials/daStrudel/daStrudel_14_sf2_soundfont.das
+++ b/tutorials/daStrudel/daStrudel_14_sf2_soundfont.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-13: SF2 SoundFont Playback
+// Tutorial DASTRUDEL-14: SF2 SoundFont Playback
 //
 // This tutorial covers:
 //   - Loading a General MIDI SoundFont with strudel_load_sf2
@@ -7,7 +7,7 @@
 //   - The GM drum map on bank 128: sf2(0) |> sf2_bank(128)
 //   - Per-note expression and velocity: sf2_expression / velocity
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_13_sf2_soundfont.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_14_sf2_soundfont.das
 //
 // Requires: a General MIDI .sf2 file (e.g. FluidR3_GM.sf2) under
 // examples/daStrudel/midi_sf2_demo/ — see that folder's README.md for
@@ -125,7 +125,7 @@ def example_expression(sf2_path : string) {
 
 [export]
 def main() {
-    print("DASTRUDEL-13: SF2 SoundFont\n\n")
+    print("DASTRUDEL-14: SF2 SoundFont\n\n")
     let sf2_path = find_sf2()
     if (empty(sf2_path)) {
         print("No SF2 found — place a GM SoundFont under examples/daStrudel/midi_sf2_demo/\n")

--- a/tutorials/daStrudel/daStrudel_15_midi_files.das
+++ b/tutorials/daStrudel/daStrudel_15_midi_files.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-14: MIDI Files
+// Tutorial DASTRUDEL-15: MIDI Files
 //
 // This tutorial covers:
 //   - Parsing MIDI files with load_midi (format 0 and format 1)
@@ -7,7 +7,7 @@
 //   - Playback with built-in sample banks via midi_play
 //   - Switching to SF2 synthesis with midi_load_sf2
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_14_midi_files.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_15_midi_files.das
 
 options gen2
 options indenting = 4
@@ -146,7 +146,7 @@ def example_play_sf2() {
 
 [export]
 def main() {
-    print("DASTRUDEL-14: MIDI Files\n\n")
+    print("DASTRUDEL-15: MIDI Files\n\n")
     example_parse()
     example_tempo()
     example_play_samples()

--- a/tutorials/daStrudel/daStrudel_16_live_reloading.das
+++ b/tutorials/daStrudel/daStrudel_16_live_reloading.das
@@ -100,13 +100,13 @@ def cmd_set_volume(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Pause playback")]
-def cmd_pause(input : JsonValue?) : JsonValue? {
+def cmd_pause(_input : JsonValue?) : JsonValue? {
     strudel_set_pause(true)
     return JV("paused")
 }
 
 [live_command(description="Unpause playback")]
-def cmd_unpause(input : JsonValue?) : JsonValue? {
+def cmd_unpause(_input : JsonValue?) : JsonValue? {
     strudel_set_pause(false)
     return JV("unpaused")
 }

--- a/tutorials/daStrudel/daStrudel_16_live_reloading.das
+++ b/tutorials/daStrudel/daStrudel_16_live_reloading.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-15: Live-Reloading Patterns
+// Tutorial DASTRUDEL-16: Live-Reloading Patterns
 //
 // This tutorial covers:
 //   - Running daStrudel under daslang-live.exe for instant code reload
@@ -8,10 +8,10 @@
 //   - The persistent byte store: live_store_bytes / live_load_bytes
 //
 // Run (live mode, recommended):
-//   bin/Release/daslang-live.exe tutorials/daStrudel/daStrudel_15_live_reloading.das
+//   bin/Release/daslang-live.exe tutorials/daStrudel/daStrudel_16_live_reloading.das
 //
 // Also works in standalone mode:
-//   bin/Release/daslang.exe tutorials/daStrudel/daStrudel_15_live_reloading.das
+//   bin/Release/daslang.exe tutorials/daStrudel/daStrudel_16_live_reloading.das
 //
 // In live mode, edit this file and save — the pattern updates without
 // stopping the audio stream. The SID stays the same, the sample bank stays
@@ -150,7 +150,7 @@ var asch : AudioSystemChannels
 
 [export]
 def init() {
-    print("daStrudel tutorial 15 — live reload\n")
+    print("daStrudel tutorial 16 — live reload\n")
     if (get_audio_command_stream() == null) {
         asch = audio_system_create()
     }
@@ -174,7 +174,7 @@ def shutdown() {
 // Standalone fallback — if run under daslang.exe, act as a regular demo.
 [export]
 def main() {
-    print("daStrudel tutorial 15 (standalone — no hot-reload)\n")
+    print("daStrudel tutorial 16 (standalone — no hot-reload)\n")
     with_audio_system() {
         load_samples()
         strudel_init(@@strudel_main)

--- a/tutorials/daStrudel/daStrudel_17_hrtf_position.das
+++ b/tutorials/daStrudel/daStrudel_17_hrtf_position.das
@@ -1,4 +1,4 @@
-// Tutorial DASTRUDEL-16: HRTF — 3D positional override for stereo pan
+// Tutorial DASTRUDEL-17: HRTF — 3D positional override for stereo pan
 //
 // daslang exposes a per-event HRTF position (azimuth, elevation). When set,
 // HRTF positioning REPLACES the equal-power stereo pan path: the dry signal
@@ -28,7 +28,7 @@
 // of the source (L/R balance feeding the spatialiser), HRTF positions the
 // source in 3D.
 //
-// Run: daslang.exe tutorials/daStrudel/daStrudel_16_hrtf_position.das
+// Run: daslang.exe tutorials/daStrudel/daStrudel_17_hrtf_position.das
 
 options gen2
 options persistent_heap
@@ -141,7 +141,7 @@ def example_mixed() {
 
 [export]
 def main() {
-    print("DASTRUDEL-16: HRTF — 3D positional override for stereo pan\n")
+    print("DASTRUDEL-17: HRTF — 3D positional override for stereo pan\n")
     print("Best heard on headphones.\n")
     example_static_positions()
     example_animated_azimuth()


### PR DESCRIPTION
Follow-up to #2995 (the library PR). That PR widened the numeric API, exposed the `set_X` scalars, and added `freq`/`euclidRot`/`chop`/`slice` + the `bd(3,8)` mini-notation form. This PR is the deferred tutorial half: the daStrudel tutorial set lacked coverage of large parts of the public API, and the per-voice vs per-orbit FX split was stated inconsistently between tutorials 07 and 08.

## Renumber (first commit)
Inserted a new tutorial **09 — Signals & Modulation** and renumbered the old 09–16 → 10–17 (`git mv`, history preserved). RST labels are topic-based, so all `:ref:` cross-references survive; only the internal number strings, the toctree, and the two prose refs to the relocated ADSR/delay-resolver content needed updating.

## New tutorial 09 — Signals & Modulation (the flagship gap)
Signal generators (`sine`/`cosine`/`saw`/`tri`/`square`/`perlin`/`rand`, discrete `run`/`irand`), `range()` remapping, and the **pattern-valued setters** that let a signal drive any effect parameter over time — a moving `lpf` sweep, a `gain` swell, a `pan` drift. Signal-query output (`sine()` → 0.5 at phase 0; `run(4)` → 0/1/2/3) verified by hand against the engine.

## Content added to existing tutorials
| Tut | Added |
|---|---|
| 03 mini-notation | `bd(3,8)` / `bd(3,8,2)` Euclidean mini form |
| 04 time | `ply`, `iter`/`iterBack`, `palindrome`, `linger`, `compress`, `striate`, `chop` |
| 05 euclid | `euclid()` / `euclidRot()` function forms (cross-ref the mini form) |
| 06 stacking | `fastcat`, `randcat`, `chooseCycles`, `choose`, `wchoose` |
| 07 per-voice | `sometimes`, `degradeBy`, `every`, `when_cycle`, `shuffle`, `scramble`, `mask` |
| 08 effects | `crush`/`coarse`, `shape`, `tremolo`, `compressor`, `bpf`, `djf`, `chorus` |
| 11 scales | `degree_to_note`, `add`, direct-Hz `freq()` |
| 12 synthesis | `fm`/`fmh` shaping, direct-Hz `freq()` |
| 13 samples | `begin`/`end_pos` slices, granulation, sample-dir loading |

## Correctness fixes
- **One authoritative per-voice vs per-orbit table**, shared verbatim by tutorials 07 and 08. Per-voice: `gain`, `pan`, `speed`, `lpf`, `hpf`, `bpf`, `phaser`, `tremolo`, `compressor`, `shape`, `crush`, `coarse`, `djf`, `fm`, `vowel`. Per-orbit bus: `room`/`roomsize`, `delay`/`delaytime`/`delayfeedback`, `chorus`.
- **`skills/strudel_port.md`**: corrected the `every` entries — daslang's `every(n, pat_on, pat_off)` takes two **patterns**, not a transform. (Discovered while authoring tut 07; the old skill text would not compile.)
- Agents also caught and corrected stale claims in the existing tutorials (e.g. tut 05 wrongly said the build "does not parse parens in mini-notation" / "euclidRot is not exposed" — both false now).

## Verification
- All **17** tutorials compile (`daslang -compile-only`), **lint clean** (`utils/lint/main.das`, 0 issues), **formatter-verified** (whole tree, 2360 files).
- **Sphinx build succeeds with no warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)