### PR TITLE
tree-sitter: support 0.6.3 syntax — expression reader macros + optional require

### DIFF
--- a/tree-sitter-daslang/grammar.js
+++ b/tree-sitter-daslang/grammar.js
@@ -167,6 +167,7 @@ module.exports = grammar({
 
     require_declaration: $ => seq(
       'require',
+      optional(field('guard', seq('?', $.identifier))),  // optional require: `require ?guard target`
       field('module', $.require_module_name),
       optional(seq('as', field('alias', $.identifier))),
       optional('public'),
@@ -1215,12 +1216,12 @@ module.exports = grammar({
       seq('clone', '(', $.identifier, ')'),
     ),
 
-    // ---- Reader macro: %name~ content %% ----
+    // ---- Reader macro: %name~ content %% (module-level) / %name! content %% (expression-level) ----
 
     reader_macro: $ => seq(
       '%',
       field('name', $.identifier),
-      token.immediate('~'),
+      token.immediate(choice('~', '!')),
       field('content', optional($.reader_macro_content)),
       '%%',
     ),

--- a/tree-sitter-daslang/queries/highlights.scm
+++ b/tree-sitter-daslang/queries/highlights.scm
@@ -106,6 +106,8 @@
 ; Require (import)
 (require_declaration
   (require_module_name) @module)
+(require_declaration
+  guard: (identifier) @module)
 
 ; Struct/class names
 (structure_declaration

--- a/tree-sitter-daslang/src/grammar.json
+++ b/tree-sitter-daslang/src/grammar.json
@@ -232,6 +232,31 @@
           "value": "require"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "guard",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "?"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "FIELD",
           "name": "module",
           "content": {
@@ -7438,8 +7463,17 @@
         {
           "type": "IMMEDIATE_TOKEN",
           "content": {
-            "type": "STRING",
-            "value": "~"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "~"
+              },
+              {
+                "type": "STRING",
+                "value": "!"
+              }
+            ]
           }
         },
         {

--- a/tree-sitter-daslang/src/node-types.json
+++ b/tree-sitter-daslang/src/node-types.json
@@ -3126,6 +3126,20 @@
           }
         ]
       },
+      "guard": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "?",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
       "module": {
         "multiple": false,
         "required": true,

--- a/tree-sitter-daslang/test/corpus/declarations.txt
+++ b/tree-sitter-daslang/test/corpus/declarations.txt
@@ -328,3 +328,32 @@ def foo(t : type<array<int>>) {
           type: (array_type
             (basic_type)))))
     body: (block)))
+
+================================================================================
+Optional require
+================================================================================
+
+require ?math math
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (require_declaration
+    guard: (identifier)
+    module: (require_module_name
+      (identifier))))
+
+================================================================================
+Optional require with path target and public
+================================================================================
+
+require ?pugixml pugixml/linq_fold_xml public
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (require_declaration
+    guard: (identifier)
+    module: (require_module_name
+      (identifier)
+      (identifier))))

--- a/tree-sitter-daslang/test/corpus/expressions.txt
+++ b/tree-sitter-daslang/test/corpus/expressions.txt
@@ -164,3 +164,39 @@ def test() {
             (integer_literal)
             (integer_literal)
             (integer_literal)))))))
+
+================================================================================
+Expression-level reader macro
+================================================================================
+
+def test() {
+  let names <- %linq! from c in cars where c.price > 100 select c.name %%
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    (function_argument_list)
+    body: (block
+      (variable_declaration_statement
+        (variable_binding
+          name: (identifier)
+          value: (reader_macro
+            name: (identifier)
+            content: (reader_macro_content)))))))
+
+================================================================================
+Module-level reader macro
+================================================================================
+
+%define~ foo %%
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (reader_macro
+    name: (identifier)
+    content: (reader_macro_content)))


### PR DESCRIPTION
Updates the bundled tree-sitter grammar for the two language-surface additions in 0.6.3 that it didn't yet parse.

## Changes
- **Expression-level reader macros** (#2957) — accept `%name! … %%` alongside the existing module-level `%name~ … %%`. This is the form the C# `%linq!` query DSL uses. `reader_macro` already appeared in both statement and expression positions; the only gap was the hard-coded `~` separator, now `choice('~', '!')`.
- **Optional require** (#2921) — `require ?guard target`: an optional `?guard` identifier before the module name (e.g. `require ?pugixml pugixml/linq_fold_xml`).

## Already parsed (verified by probing, no change needed)
Loop annotations (`for [unroll, vectorize] (…)`, `for @unroll_full(…)`, `while [unroll_disable] (…)`), one-liner brace blocks, OR-type params (`int | float | double`), and `type<T>` in type position.

## Validation
- Regenerated `parser.c` with `--abi 14` (ABI unchanged). `parser.c` is a full LR-table regen, as always for a grammar change — the reviewable diff is `grammar.json` (+38/-2: the `guard` field + the `~`/`!` separator).
- **Baseline diff** over `tests/` + `daslib/`: **+12 `.das` files now parse** (`optional_require`, `test_linq_das`, `linq_fold`, `test_linq_das_into`, `failed_linq_das`, the `linq_das_sql`/`xml` suites, `reader_macro/test_inline_reader`), **zero regressions** (66 → 54 pre-existing parse gaps).
- Corpus suite **38/38** (4 new: optional require ×2, expression + module reader macro).
- `highlights.scm`: highlight the optional-require guard as a module.

No `.das` files changed, so the lint/test/AOT/format gates don't apply. The local `daslang.dylib` (gitignored) was rebuilt so the MCP tree-sitter tools pick up the grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)