### PR TITLE
linq docs: keep C# references on-topic + document the XML fold path

### DIFF
--- a/daslib/linq_boost.das
+++ b/daslib/linq_boost.das
@@ -45,7 +45,7 @@ class private AstCallMacro_LinqPred2 : AstCallMacro {
         if (call.arguments[1] is ExprMakeBlock) {
             // named-variable form: the argument is already a `$(x) => …` block (e.g. emitted by linq_das).
             // Inject the element type onto the user's parameter and pass the block through, instead of
-            // wrapping a bare expression in `$(_ : iterType) => …`. The C# range variable thus survives verbatim.
+            // wrapping a bare expression in `$(_ : iterType) => …`. The query's range variable thus survives verbatim.
             var blk = call.arguments[1] as ExprMakeBlock
             var inner = blk._block as ExprBlock
             macro_verify(length(inner.arguments) == 1, prog, call.at, "{predName}: block argument must take exactly one parameter")

--- a/daslib/linq_das.das
+++ b/daslib/linq_das.das
@@ -214,7 +214,7 @@ def private read_ident(q : string; from : int) : tuple<string; int> {
         while (i < n && is_ident_byte(int(arr[i]))) { i++ }
         e = i
     }
-    if (s < 0 || e <= s) { return ("", -1) }
+    if (s < 0 || e <= s) return ("", -1)
     return (slice(q, s, e), e)
 }
 
@@ -224,12 +224,12 @@ def private strip_trailing_keyword(text : string; kw : string) : tuple<string; b
     let p = strip(text)
     let m = length(kw)
     let n = length(p)
-    if (n <= m || !ends_with(p, kw)) { return (p, false) }
+    if (n <= m || !ends_with(p, kw)) return (p, false)
     var wsBefore = false
     peek_data(p) $(arr) {
         wsBefore = is_white_space(int(arr[n - m - 1]))
     }
-    if (wsBefore) { return (strip(slice(p, 0, n - m)), true) }
+    if (wsBefore) return (strip(slice(p, 0, n - m)), true)
     return (p, false)
 }
 
@@ -240,8 +240,8 @@ def private strip_trailing_keyword(text : string; kw : string) : tuple<string; b
 // cross_join overload is selected). array (untyped) → each(...) / bare; decs (keyword marker) →
 // from_decs_template; any other typed value source → from_in (dispatches by the source value's type).
 def private build_src(rowType : string; srcText : string; fused : bool) : string {
-    if (rowType == "") { return fused ? "each({srcText})" : "({srcText})" }
-    if (srcText == "decs") { return "from_decs_template(type<{rowType}>)" }
+    if (rowType == "") return fused ? "each({srcText})" : "({srcText})"
+    if (srcText == "decs") return "from_decs_template(type<{rowType}>)"
     return "from_in({srcText}, type<{rowType}>)"
 }
 
@@ -804,7 +804,7 @@ def private next_clause_kw(q : string; from : int) : int {
     return best
 }
 
-// Extract C# `let` bindings (Approach A — textual inlining). `let n = <expr>` introduces a computed range
+// Extract `let` bindings (Approach A — textual inlining). `let n = <expr>` introduces a computed range
 // variable; every downstream reference is replaced with `(<expr>)`, yielding a `let`-free query the rest of
 // the reader handles unchanged — in every context (single / join / second-`from`), and inlined computed
 // columns/keys push down to SQL. Chained lets resolve in order (a later RHS inlines the earlier bindings).
@@ -873,7 +873,7 @@ def private extract_lets(q : string; bodyStart : int; rangeVar : string;
         cuts |> push((lp, rhsEnd, name))
         searchFrom = rhsEnd
     }
-    if (empty(subs)) { return (true, q) }
+    if (empty(subs)) return (true, q)
     // Rebuild: source region (< srcEnd) verbatim; each `let` span dropped (replaced by a space); each clause
     // segment inlined with only the bindings introduced BEFORE it, so a reference preceding a binding stays.
     let body = build_string() $(var w) {
@@ -1161,7 +1161,7 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
     // `let` bindings are inlined away first, so the rest of the reader sees a `let`-free query in every
     // context (the substitution rewrites the whole body, including a join/second-`from` tail).
     let lets = extract_lets(q, srcStart, varName, prog, at)
-    if (!lets._0) { return "(0)" }
+    if (!lets._0) return "(0)"
     q = lets._1
     let nq = length(q)
     // A `join` or a second `from` introduces a second range variable — each has its own grammar and emit
@@ -1172,12 +1172,10 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
         macro_error(prog, at, "linq: combining 'join' with a second 'from' (SelectMany) in one query is not yet supported")
         return "(0)"
     }
-    if (secondFromPos >= 0) {
+    if (secondFromPos >= 0)
         return transpile_cross(q, nq, varName, rowType, srcStart, secondFromPos, prog, at)
-    }
-    if (joinPos >= 0) {
+    if (joinPos >= 0)
         return transpile_join(q, nq, varName, rowType, srcStart, joinPos, prog, at)
-    }
     let srcEnd = next_clause_kw(q, srcStart)
     let srcText = strip(slice(q, srcStart, srcEnd))
     if (srcText == "") {
@@ -1194,12 +1192,12 @@ def private transpile_query(query : string; prog : ProgramPtr; at : LineInfo) : 
     var pstart = srcEnd
     while (true) {
         var stage <- QueryStage()
-        if (!parse_one_stage(q, nq, pstart, curVar, curIsGroup, prog, at, stage)) { return "(0)" }
+        if (!parse_one_stage(q, nq, pstart, curVar, curIsGroup, prog, at, stage)) return "(0)"
         let contVar = stage.intoVar
         let contStart = stage.nextStart
         let contIsGroup = stage.isGroup
         stages |> emplace(stage)
-        if (contVar == "") { break }
+        if (contVar == "") break
         curVar = contVar
         curIsGroup = contIsGroup
         pstart = contStart
@@ -1248,14 +1246,12 @@ class FromInMacro : AstCallMacro {
         }
         // SQL: db is a sqlite_boost::SqlRunner → select_from(db, type<Row>)
         if (srcT.structType != null && srcT.structType.name == "SqlRunner"
-                && srcT.structType._module != null && srcT.structType._module.name == "sqlite_boost") {
+                && srcT.structType._module != null && srcT.structType._module.name == "sqlite_boost")
             return qmacro($c("select_from")($e(call.arguments[0]), $e(call.arguments[1])))
-        }
         // XML: node is a pugixml `xml_node` (handled type) → unsafe(from_xml_node(node, type<Row>)).
         // from_xml_node is [unsafe_outside_of_for]; the unsafe wrap is required in a `_fold` chain.
-        if (srcT.isHandle && srcT.annotation != null && srcT.annotation.name == "xml_node") {
+        if (srcT.isHandle && srcT.annotation != null && srcT.annotation.name == "xml_node")
             return qmacro(unsafe($c("from_xml_node")($e(call.arguments[0]), $e(call.arguments[1]))))
-        }
         macro_error(prog, call.at, "linq: unsupported source for `from c : Row in <src>` — expected a SQL runner or an XML node (use `in decs` for decs, or an array for the untyped `from c in <arr>` form)")
         return call
     }

--- a/daslib/linq_fold_common.das
+++ b/daslib/linq_fold_common.das
@@ -2207,11 +2207,10 @@ def emit_loop_or_count_lane(var c : Captures; var ctx : EmitCtx; at : LineInfo) 
         var sc = ctx.src->count_shortcut(lastName, at)   // source owns its O(1) applicability; null → walk
         if (sc != null) return sc
     }
-    if (lane == LinqLane.ACCUMULATOR && !counting) {     // value reducers only; long_count rides the counter lane
+    if (lane == LinqLane.ACCUMULATOR && !counting)     // value reducers only; long_count rides the counter lane
         return emit_accumulator_lane(lastName, ctx.src, projection, whereCond, postTakeWhereCond,
             intermediateBinds, preCondStmts, elementType, accName, itName, names,
             skipExpr, takeExpr, skipWhileCond, takeWhileCond, at)
-    }
     if (lane == LinqLane.EARLY_EXIT) {
         let terminatorCall = c.single["term"]
         let isAnyNoPred = lastName == "any" && length(terminatorCall.arguments) == 1
@@ -2450,7 +2449,7 @@ def make_inline_less_call(orderKey : Expression?; orderName : string;
 
 [macro_function]
 def private renamed_key_clone(body : Expression?; argName, newName : string) : Expression? {
-    // Clone a key-element body and rename its single block param (the C# range var) to v1 / v2.
+    // Clone a key-element body and rename its single block param (the query's range var) to v1 / v2.
     return clone_and_rename_var(body, argName, newName)
 }
 
@@ -2855,9 +2854,8 @@ def private build_surrogate_type(keyType : TypeDeclPtr; handleType : TypeDeclPtr
 // comparator over surrogate keys (._0); flipped for descending. Reused across heap push/pop + order_inplace.
 [macro_function, unused_argument(at)]
 def private build_surrogate_cmp(descending : bool; at : LineInfo) : Expression? {
-    if (descending) {
+    if (descending)
         return qmacro($(v1, v2) { return _::less(v2._0, v1._0) })
-    }
     return qmacro($(v1, v2) { return _::less(v1._0, v2._0) })
 }
 
@@ -4494,9 +4492,8 @@ def emit_reducer_branches(spec : ReducerSpec; at : LineInfo; entryName, itName :
                           var adapter : SourceAdapter? = null) : tuple<Expression?; Expression?> {
     // (missInit, hitUpdate); hitUpdate null for first* (subsequent same-key elements ignored).
     // Whole-element `first` over a deferring source materializes from the handle in the miss-branch.
-    if (spec.name == "first" && adapter != null && adapter->handle_type() != null) {
+    if (spec.name == "first" && adapter != null && adapter->handle_type() != null)
         return mk_reducer_first_deferred(spec, at, entryName, itName, adapter)
-    }
     let emitter = reducer_emitters?[spec.name] ?? default<ReducerEmitterFn>
     return (null, null) if (emitter == null)
     return invoke(emitter, spec, at, entryName, itName)

--- a/doc/source/reference/linq_das.rst
+++ b/doc/source/reference/linq_das.rst
@@ -111,13 +111,13 @@ Range variable
 
 The range variable is spliced **verbatim** as the lambda parameter — the
 predicate becomes ``_where($(c) => …)`` and the projection ``_select($(c) =>
-…)``, keeping the C# variable name; the predicate and projection text is passed
+…)``, keeping the range-variable name; the predicate and projection text is passed
 through unchanged. Any identifier name works.
 
 The ``_fold`` operator DSL accepts a named-variable ``$(x) => …`` block
 directly. For the SQL source, ``_sql`` resolves a single source against the
 placeholder ``_``; the macro normalizes the single-source lambda parameter to
-``_`` internally, so the C# variable name is still spliced verbatim at the
+``_`` internally, so the range-variable name is still spliced verbatim at the
 surface.
 
 .. _linq_das_filtering:
@@ -125,8 +125,8 @@ surface.
 Filtering (``where``)
 ---------------------
 
-A ``where`` clause is optional and **repeatable** — C# allows several, and each
-emits its own ``_where`` filter, AND-folded in source order:
+A ``where`` clause is optional and **repeatable** (as in C#) — each emits its
+own ``_where`` filter, AND-folded in source order:
 
 .. code-block:: das
 
@@ -147,7 +147,7 @@ sort.
 Let bindings
 ------------
 
-``let <name> = <expr>`` introduces a computed value (a new range variable in C#)
+``let <name> = <expr>`` introduces a computed value (what C# calls a new range variable)
 that is reused in the clauses that follow it:
 
 .. code-block:: das

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -147,7 +147,7 @@ Source-side entry points
      - Runtime component-name list form. Same decs splices as the template form.
    * - ``unsafe(from_xml_node(node[, name], type<Row>))``
      - ``extract_xml_source`` (``XmlAdapter``, ``modules/dasPUGIXML/daslib/linq_fold_xml.das``)
-     - Optional source — only when the ``pugixml`` module is linked (``require ?pugixml`` + ``static_if (typeinfo builtin_module_exists(pugixml))``). Emits an inlined DOM child-element walk replacing the generator, and **field-prunes** the per-element materialization (pass 2b): the chain body is scanned for the ``Row`` fields it reads, and only those attributes are read via ``read_xml_field`` into scalar locals — unread fields (notably ``string`` fields, whose ``clone_string`` is the alloc cost) are never touched, so a float-only chain runs alloc-free and JIT beats the equivalent SQLite query. A whole-row escape (``to_array`` / identity ``_select(_)`` / pass-to-fn) routes to the full ``build_xml_row`` instead. Only the ``loop_or_count_general`` row fuses (count / sum / min / max / average / any / first / take / to-array with ``_where`` / ``_select``); other chain shapes fall back to the unfused tier-2 pipeline. ``unsafe`` is required (the source is ``[unsafe_outside_of_for]``) and the node is passed by value (``var root`` — ``_fold``'s macro-arg inference skips the const&→value copy).
+     - Optional source — only when the ``pugixml`` module is linked (``require ?pugixml`` + ``static_if (typeinfo builtin_module_exists(pugixml))``). Emits an inlined DOM child-element walk replacing the generator, and **field-prunes** the per-element materialization (pass 2b): the chain body is scanned for the ``Row`` fields it reads, and only those attributes are read via ``read_xml_field`` into scalar locals — unread fields (notably ``string`` fields, whose ``clone_string`` is the alloc cost) are never touched, so a float-only chain runs alloc-free and JIT beats the equivalent SQLite query. A whole-row escape (``to_array`` / identity ``_select(_)`` / pass-to-fn) routes to the full ``build_xml_row`` instead. The ``XmlAdapter`` **rides every pattern row** (``try_splice_patterns`` runs with no ``onlyRow`` restriction); per-row ``requires`` predicates and the adapter's capability hooks (``can_join`` / ``can_group_by`` / ``defers_materialization`` / the ``non_array_source`` gate) decide what fuses, and a shape it can't fuse cascades to tier-2 — see :ref:`linq_fold_xml_patterns` for the full fuse/defer breakdown. ``unsafe`` is required (the source is ``[unsafe_outside_of_for]``) and the node is passed by value (``var root`` — ``_fold``'s macro-arg inference skips the const&→value copy).
 
 Array-source patterns
 =====================
@@ -482,6 +482,104 @@ equi-key gate as the decs side; non-primitive keys cascade to
        Same v1 constraints as the decs-side cross-arm: primitive
        equi-key, no segments between ``join`` and ``group_by_lazy``,
        HAVING defers to v2.
+
+.. _linq_fold_xml_patterns:
+
+XML-source patterns
+===================
+
+An ``unsafe(from_xml_node(node[, name], type<Row>))`` source folds through
+``XmlAdapter`` (``modules/dasPUGIXML/daslib/linq_fold_xml.das``), loaded only when
+the ``pugixml`` module is linked. Unlike a hard-coded source row, the adapter
+**rides every pattern row** the array / decs planners expose — ``try_splice_patterns``
+runs with no ``onlyRow`` restriction, and per-row ``requires`` predicates plus the
+adapter's capability hooks decide what fuses. Three mechanics make the emitted loop
+differ from the array and decs lanes.
+
+**Single flat DOM walk, forward-only.** The adapter emits one ``while`` over the
+node's child elements (``first_child`` / ``next_sibling``, or ``child(node, name)``
+for the 3-arg named overload), like the array lane and unlike decs's two-level
+archetype walk. But an XML node has **no random index**, so XML matches the
+``non_array_source`` rows (e.g. the R-2b forward keep-last reverse-distinct) and is
+**excluded** from the ``array_source``-only rows (Row 5 ``buffer_helper_dispatch``
+direct-helper, R-2a backward-index reverse-distinct). Bare ``order_by`` / ``order``
+therefore cascades to the ``fused_prefilter`` row (materialized buffer), not the
+direct daslib helper — the same fall-through decs takes.
+
+**Field-pruning (pass 2b).** Before emitting the per-element body the chain is
+scanned (``XmlRowUsageScanner``) for the ``Row`` fields it actually reads. Only
+those attributes are read — each via ``read_xml_field`` into a scalar local, with
+the body's ``it.<field>`` rewritten to that local and the ``Row`` struct dropped
+entirely. Unread fields are never touched, so a chain that reads only numeric
+fields runs **alloc-free** (the per-string ``clone_string`` is the materialization
+cost). Three outcomes:
+
+- **Pruned** — body reads only ``it.<field>`` scalars: one ``let xf_<f> =
+  read_xml_field(...)`` per referenced field, struct dropped.
+- **Whole-row escape** — body references the bind ``it`` as a whole value
+  (``to_array``, identity ``_select(_)``, pass-to-user-fn): falls back to the full
+  ``build_xml_row``.
+- **Guarded escape** — the whole row escapes only inside a bare ``if (cond) { … }``:
+  the predicate's fields are read cheaply via ``peek_xml_field`` (borrowed
+  ``string#``, no clone) and the full ``build_xml_row`` runs **only for matching
+  elements**.
+
+**Deferred materialization.** A buffered reducer (order / take, ``distinct_by``)
+holds ``(key, xml_node)`` *handle surrogates* rather than built rows, and runs
+``build_xml_row`` only for the K survivors at return — ``defers_materialization()``
+is true, ``current_handle_expr`` is the per-element ``xcur`` node, and
+``materialize_handle`` emits the deferred ``build_xml_row``. A 1000-element document
+feeding ``order_by(K).take(10)`` builds 10 rows, not 1000.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Chain shape (XML source)
+     - Splice arm
+     - Notes
+   * - ``…<terminator>`` with ``_where`` / ``_select`` (count / long_count / sum / average / min / max / any / all / contains / first / last / single / element_at / take / take_while / skip_while / to_array)
+     - ``loop_or_count_general`` (``XmlAdapter`` swap)
+     - The base lane — the same emit archetypes as the array side, over the field-pruned DOM walk. ``take`` / ``where`` / ``select`` fuse into the body.
+   * - ``._order_by(K).first()`` / ``.first_or_default()``
+     - ``plan_order_family`` (streaming-min) + deferral
+     - One handle held in ``var best``; ``build_xml_row`` runs once at return.
+   * - ``._order_by(K).take(N).to_array()`` / ``…._select(F).to_array()``
+     - ``plan_order_family`` (bounded-heap) + deferral
+     - Heap of N ``(key, node)`` surrogates; ``build_xml_row`` (and any terminal ``_select``) runs ≤N times at return.
+   * - ``._order_by(K).to_array()`` / ``._where(P)._order_by(K).to_array()``
+     - ``plan_order_family`` (``fused_prefilter``) + deferral
+     - ``array_source`` Row 5 excludes XML, so bare order cascades to the materialized-buffer row — the buffer holds node handles, rows built for survivors only.
+   * - ``._distinct_by(K).to_array()`` / ``._distinct_by(K)._order_by(K2)…``
+     - ``plan_distinct`` / ``plan_order_family`` + deferral
+     - Dedup set over the key; the kept slot stores the node handle (``distinct_by`` defers; plain ``distinct`` over the whole row materializes per element).
+   * - ``.reverse()._distinct[_by](K).to_array()``
+     - ``plan_reverse`` R-2b (``non_array_source``) → ``emit_reverse_distinct_forward_keeplast``
+     - Forward keep-last table-overwrite (no backward index); the slot stores the ``xml_node`` handle, ``build_xml_row`` (field-pruned to the key) runs for the K survivors. The one row shared by decs / iterators / XML.
+   * - ``from_xml_node(…) |> _join(arrB, ka, kb, result)`` (+ optional leading / trailing ``_where``, trailing ``_select``; count / to_array / iterator)
+     - pattern ``join_general`` → ``XmlAdapter.emit_join_hook``
+     - Hashed equi-join: srcB (an **in-memory array**) collected into ``table<KEY; array<TUPB>>``, probed from the field-pruned DOM walk. Primitive equi-key only. Mirrors ``emit_array_join`` with srcA = the XML node.
+   * - ``from_xml_node(…) |> _join(arrB, …) |> _group_by(K) |> _select(reduce) |> to_array()`` / ``.count()``
+     - ``plan_group_by_core`` via ``XmlJoinAdapter``
+     - Cross-arm: the join's per-pair result feeds the bucket update directly — one pass, no intermediate join array. Same v1 constraints as the array / decs cross-arm (primitive key, no segments between ``join`` and ``group_by``, HAVING defers to v2).
+   * - ``from_xml_node(…) |> _group_by(K) |> _select(reduce) |> to_array()`` (+ HAVING / trailing ``order_by``)
+     - ``plan_group_by_core`` (``XmlAdapter`` via ``build_group_by_adapter``)
+     - Per-key bucket reducer over the DOM walk; shares the array path's reducer dispatch and the trailing HAVING / ORDER BY extensions.
+   * - ``source |> _select(f) |> <order/distinct/take>``
+     - leading-``_select`` absorption (``ProjectedSourceAdapter`` wrap)
+     - The leading projection is absorbed into the source walk and **field-pruning is preserved** — ``f``'s ``it.<field>`` reads still reach the materializer (see *Pre-dispatch normalizations*).
+
+**Defers to tier-2** (the ``XmlAdapter`` hook returns null, so the chain cascades):
+
+- **Group join** (``_group_join`` / ``join … into``) — ``emit_join_hook`` returns
+  null for the ``group_join`` literal.
+- **Non-primitive join keys** / **non-array srcB** — the same gate as the array /
+  decs join (tuple keys cascade to ``join_impl``).
+- **Correlated nested-collection flatten** (``from o … from l in o.lines``) —
+  ``from_xml_node`` reads scalar attributes only; there is no nested collection to
+  flatten.
+- **Mixed-source operators** (``union`` / ``except`` / ``intersect`` / ``concat``)
+  — fall back exactly as for array / decs sources.
 
 Zip patterns
 ============


### PR DESCRIPTION
## What

An audit of the LINQ reference docs, in two parts.

### 1. C# references stay "the equivalent of C#'s X", not the subject

The LINQ docs lean on C# analogies (reasonable — it's where the query syntax comes from), but a few spots had drifted into attributing a **daslang** construct to C#, e.g. "keeping **the C# variable name**" when the range variable is a daslang identifier the user typed. Fixed in `linq_das.rst` and three `daslib` comments:

| Was | Now |
|---|---|
| "keeping **the C# variable name**" (×2) | "keeping the range-variable name" |
| "repeatable — **C# allows several, and each** emits its own `_where`" (reads as if C# emits `_where`) | "repeatable (as in C#) — each emits its own `_where`" |
| "a computed value (**a new range variable in C#**)" | "(what C# calls a new range variable)" |
| comments: "The **C#** range variable", "(the **C#** range var)", "Extract **C#** `let` bindings" | name the daslang thing |

References that describe C#'s *spec* (the behavior the macro mirrors — "C# forward-only `let` scoping", "C# `GroupJoin`", "C# `OrderBy`/`ThenBy` parity") were left intact; those are correct analogies.

### 2. XML fold coverage in `linq_fold_patterns.rst` — was stale + incomplete

The XML source-entry row claimed **"only the `loop_or_count_general` row fuses … other chain shapes fall back to tier-2."** That contradicts the source: `linq_fold.das` says *"the XmlAdapter rides every pattern row (no `onlyRow` restriction)"*, and `linq_fold_xml.das` implements join (`emit_join_hook`), group_by + group_by-after-join (`XmlJoinAdapter`), distinct+take, and deferred-materialization order family.

- Corrected the stale claim.
- Added an **"XML-source patterns"** section (parallel to the Array / Decs sections) documenting the two mechanics that make XML fold differently — **field-pruning (pass 2b)** (read only the `Row` fields the chain touches; float-only chains run alloc-free) and **deferred materialization** (buffers hold `(key, xml_node)` handle surrogates, `build_xml_row` runs only for the K survivors) — plus the forward-only exclusions and a fuse/defer table.

### 3. Drive-by lint cleanup

Touching the three `daslib/*.das` files for the comment edits means CI's `extended_checks` lints the whole changed file, so I cleaned the **16 pre-existing STYLE005** warnings (braced single-statement early-exits → braceless) in `linq_das.das` / `linq_fold_common.das`.

## Verification

- **Lint**: `linq_boost.das` / `linq_das.das` / `linq_fold_common.das` — 0 issues.
- **Tests**: `test_linq_das.das` 77/77, `test_linq_fold.das` 385/385 (exercise the edited transpiler + emit-lane dispatch).
- **Format**: all three `.das` files already-formatted; pre-push formatter verified 3007 files.
- **Docs**: clean Sphinx HTML build; `linq_das.rst` / `linq_fold_patterns.rst` produce zero warnings (the 2 build warnings are pre-existing, in unrelated `generated/openai` / `sec_io.rst`).

Docs + comments + style only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)