### PR TITLE
cbind: generate constants from preprocessor-active macro cursors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -679,3 +679,9 @@ jobs:
         git diff --exit-code -- modules/dasClangBind/src/ \
           || (echo "ERROR: dasClangBind generated files are out of date. Run './bin/daslang modules/dasClangBind/bind/bind_clangbind.das -- --clang_path <libclang-include-path>' locally and commit the result." && exit 1)
 
+    - name: "Run cbind const-gen regression test"
+      # Exercises collectActiveDefines (preprocessor-active constant generation);
+      # main returns non-zero on failure. Lives on the mingw worker because that
+      # is where libclang/cbind is available (same reason as the self-binder).
+      run: ./bin/daslang.exe modules/dasClangBind/tests/test_const_preproc.das
+

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -58,9 +58,7 @@ def clang_typeToDasTypeUnqEx(var t : CXType; topLevel : bool; rules : TypeRules;
     } elif (t.kind == CXTypeKind.Bool) {
         return "bool"
     } elif (t.kind == CXTypeKind.Char_U || t.kind == CXTypeKind.UChar) {
-        if (topLevel && rules.top_level_uint8_is_bool) {
-            return "bool"
-        }
+        if (topLevel && rules.top_level_uint8_is_bool) return "bool"
         return "uint8"
     } elif (t.kind == CXTypeKind.Char_S || t.kind == CXTypeKind.SChar) {
         return "int8"
@@ -170,9 +168,7 @@ def clang_getCursorLocationFileName(var c : CXCursor) {
 
 def clang_isForwardDeclaration(var cursor : CXCursor) {
     var definition = clang_getCursorDefinition(cursor)
-    if (clang_equalCursors(definition, clang_getNullCursor()) != 0u) {
-        return true
-    }
+    if (clang_equalCursors(definition, clang_getNullCursor()) != 0u) return true
     return clang_equalCursors(cursor, definition) == 0u
 }
 
@@ -261,9 +257,7 @@ class AnyGenBind {
     // strip the parsed library's header root — paths stay stable across OS and install folder
     def clang_getCursorLocationDescription(var c : CXCursor) : string {
         let full = clang_getCursorLocationFullPath(c)
-        if (!empty(PARSE_FILE_PREFIX) && full |> starts_with(PARSE_FILE_PREFIX)) {
-            return full |> slice(length(PARSE_FILE_PREFIX))
-        }
+        if (!empty(PARSE_FILE_PREFIX) && full |> starts_with(PARSE_FILE_PREFIX)) return full |> slice(length(PARSE_FILE_PREFIX))
         return full
     }
     def skip_file(fname : string) : bool {
@@ -354,9 +348,7 @@ class AnyGenBind {
                     return true
                 }
                 let op_name = function_name |> slice(8)
-                if (op_name == "=") {
-                    return true
-                }
+                if (op_name == "=") return true
             }
         }
         var fun_type = clang_getCursorType(c)
@@ -388,15 +380,11 @@ class AnyGenBind {
     }
     def skip_type(var _c : CXType) {
         let nc_name = string(clang_getTypeSpelling(_c))
-        if (nc_name == "va_list") {
-            return true
-        }
+        if (nc_name == "va_list") return true
         var c = clang_getCanonicalType(_c)
         if (c.kind == CXTypeKind.Pointer) {
             var pc = clang_getPointeeType(c)
-            if (pc.kind == CXTypeKind.FunctionProto) {
-                return true
-            }
+            if (pc.kind == CXTypeKind.FunctionProto) return true
             return skip_type(pc)
         } elif (c.kind == CXTypeKind.Record) {
             var rname = string(clang_getTypeSpelling(c))
@@ -458,9 +446,7 @@ class AnyGenBind {
                 }
             }
             if (!skip_file(prevFileName)) {
-                if (parent.kind == CXCursorKind.ClassTemplate) {// skipping just about everything from template body
-                    return CXChildVisitResult.Continue
-                }
+                if (parent.kind == CXCursorKind.ClassTemplate) return CXChildVisitResult.Continue // skip template body
                 let kind = clang_getCursorKind(c)
                 if (kind == CXCursorKind.TypedefDecl) {
                     let tdn = string(clang_getCursorDisplayName(c))
@@ -725,6 +711,54 @@ class AnyGenBind {
             return true
         }
     }
+    // Reconstruct only the preprocessor-ACTIVE #define lines of `fname`.
+    // The const regexes are not preprocessor-aware: a header may carry the same
+    // macro twice (e.g. imgui.h's IM_COL32_*_SHIFT under #ifdef
+    // IMGUI_USE_BGRA_PACKED_COLOR / #else), and a raw-text scan picks the first
+    // textual match — which can be the INACTIVE branch. libclang only emits a
+    // MacroDefinition cursor for the branch the preprocessor actually took, so
+    // we slice each such cursor's extent out of `data` and feed the regexes only
+    // the active definitions. Macros from #include'd files are filtered out so
+    // the constant set matches the prior single-file scan.
+    def collectActiveDefines(fname, data : string) : string {
+        var index = clang_createIndex(0, 0)
+        var unit = clang_parseTranslationUnit(
+            index, fname,
+            empty(ARGV) ? null : unsafe(addr(ARGV[0])), length(ARGV),
+            null, 0u,
+            CXTranslationUnit_DetailedPreprocessingRecord)
+        if (unit == null) {
+            clang_disposeIndex(index)
+            to_log(LOG_WARNING, "collectActiveDefines: cannot parse {fname}, falling back to raw scan\n")
+            return data
+        }
+        let result = build_string() $(var wr : StringBuilderWriter) {
+            clang_visitChildren(clang_getTranslationUnitCursor(unit)) $(var c, _parent) {
+                if (clang_getCursorKind(c) == CXCursorKind.MacroDefinition) {
+                    var mfile : CXFile
+                    var ml, mc, mo : uint
+                    clang_getSpellingLocation(clang_getCursorLocation(c), safe_addr(mfile), safe_addr(ml), safe_addr(mc), safe_addr(mo))
+                    // builtin / command-line macros have a null CXFile — skip them
+                    if (mfile != null && string(clang_getFileName(mfile)) |> ends_with(fname)) {
+                        var ext = clang_getCursorExtent(c)
+                        var sfile, efile : CXFile
+                        var sl, scol, so, el, ecol, eo : uint
+                        clang_getSpellingLocation(clang_getRangeStart(ext), safe_addr(sfile), safe_addr(sl), safe_addr(scol), safe_addr(so))
+                        clang_getSpellingLocation(clang_getRangeEnd(ext), safe_addr(efile), safe_addr(el), safe_addr(ecol), safe_addr(eo))
+                        if (eo > so && int(eo) <= length(data)) {
+                            wr |> write("#define ")
+                            wr |> write(data |> slice(int(so), int(eo)))
+                            wr |> write("\n")
+                        }
+                    }
+                }
+                return CXChildVisitResult.Continue
+            }
+        }
+        clang_disposeTranslationUnit(unit)
+        clang_disposeIndex(index)
+        return result
+    }
     def generateConstantsFrom(fnames : array<string>) {
         var reg_def_hex <- %regex~#define\s+(\w+)\s+(0x[0-9A-Fa-f]+)%%
         var reg_def_dec <- %regex~#define\s+(\w+)\s+(\d+)%%
@@ -740,13 +774,14 @@ class AnyGenBind {
                 }
                 var ofs : table<int; bool>
                 let data = fread(f)
+                let activeText = collectActiveDefines(fname, data)
                 var dup : table<string; bool>
-                searchAndGenConst(reg_def_hex, define_const_style_das ? "uint" : "uint32_t", "u", true, ofs, data, dup)
-                searchAndGenConst(reg_def_dec, define_const_style_das ? "int" : "int32_t", "", false, ofs, data, dup)
-                searchAndGenConst(reg_def_UINT8, define_const_style_das ? const_uint8_type : const_uint8_cpp_type, "u", true, ofs, data, dup)
-                searchAndGenConst(reg_def_UINT16, define_const_style_das ? const_uint16_type : const_uint16_cpp_type, "u", true, ofs, data, dup)
-                searchAndGenConst(reg_def_UINT32, define_const_style_das ? "uint" : "uint32_t", "u", true, ofs, data, dup)
-                searchAndGenConst(reg_def_UINT64, define_const_style_das ? "uint64" : "uint64_t", "ul", true, ofs, data, dup)
+                searchAndGenConst(reg_def_hex, define_const_style_das ? "uint" : "uint32_t", "u", true, ofs, activeText, dup)
+                searchAndGenConst(reg_def_dec, define_const_style_das ? "int" : "int32_t", "", false, ofs, activeText, dup)
+                searchAndGenConst(reg_def_UINT8, define_const_style_das ? const_uint8_type : const_uint8_cpp_type, "u", true, ofs, activeText, dup)
+                searchAndGenConst(reg_def_UINT16, define_const_style_das ? const_uint16_type : const_uint16_cpp_type, "u", true, ofs, activeText, dup)
+                searchAndGenConst(reg_def_UINT32, define_const_style_das ? "uint" : "uint32_t", "u", true, ofs, activeText, dup)
+                searchAndGenConst(reg_def_UINT64, define_const_style_das ? "uint64" : "uint64_t", "ul", true, ofs, activeText, dup)
             }
         }
     }
@@ -770,9 +805,7 @@ class DasGenBind : AnyGenBind {
             "options" => "_options",
         }
         for (k, v in keys(to_replace), values(to_replace)) {
-            if (s == k) {
-                return v
-            }
+            if (s == k) return v
         }
         return s
     }
@@ -801,9 +834,7 @@ class DasGenBind : AnyGenBind {
     def clang_knownType(var nctype : CXType; rules : TypeRules) {
         let ncname = string(clang_getTypeSpelling(nctype))
         let tname = known_type?[ncname] ?? ""
-        if (tname != "") {
-            return tname
-        }
+        if (tname != "") return tname
         var ctype = clang_getCanonicalType(nctype)
         return clang_typeToDasType(ctype, rules)
     }
@@ -823,15 +854,11 @@ class DasGenBind : AnyGenBind {
         fprint(struct_class_file, "typedef {tdn} = {src_type}\n")
     }
     def override parse_Enum(var cursor : CXCursor; enum_name : string) {
-        if (enum_class_file == null) {
-            return
-        }
+        if (enum_class_file == null) return
         let ns_en = namespace_name(enum_name)
-        if (skip_enum(ns_en, enum_name)) {
-            return
-        }
+        if (skip_enum(ns_en, enum_name)) return
         fprint(enum_class_file, "enum {filter_das_words(enum_name)} \{\n")
-        clang_visitChildren(cursor) $(var c, parent) {
+        clang_visitChildren(cursor) $(var c, _parent) {
             if (c.kind == CXCursorKind.EnumConstantDecl) {
                 let een = string(clang_getCursorDisplayName(c))
                 let val = clang_getEnumConstantDeclValue(c)
@@ -933,6 +960,12 @@ class CppGenBind : AnyGenBind {
     abstract_class : array<bool>
     wrapper_count : int
     local_type_names : table<string; bool>
+    // Types whose generated annotation should advertise a trivial constructor
+    // (emit hasNonTrivialCtor()->false) and/or value-copyability (canCopy()->true).
+    // Lets a binder mark a bitwise-zero-init-safe handled type as inline-storable
+    // without a manual post-regen patch on the generated struct.class.inc.
+    trivial_ctor_type_names : table<string; bool>
+    copyable_type_names : table<string; bool>
     // Affects // from <prefix>/<actual path>
     prefix : string
 
@@ -1075,6 +1108,12 @@ class CppGenBind : AnyGenBind {
     def isLocalType(name, cppname : string) {
         return local_type_names[name]
     }
+    def isTrivialCtorType(name, cppname : string) {
+        return trivial_ctor_type_names[name]
+    }
+    def isCopyableType(name, cppname : string) {
+        return copyable_type_names[name]
+    }
     def isArgByValue(name : string) {
         return false
     }
@@ -1107,9 +1146,7 @@ class CppGenBind : AnyGenBind {
             return
         }
         struct_ann[struct_namespace_name] = true
-        if (isAotAlias || isAlreadyDefined) {
-            return
-        }
+        if (isAotAlias || isAlreadyDefined) return
         let dashing_name = namespace_name(struct_name, "_")
         let st = build_string() $(var writer : StringBuilderWriter) {
             swrite |> push(unsafe(addr(writer)))
@@ -1118,6 +1155,12 @@ class CppGenBind : AnyGenBind {
             if (isLocalType(struct_name, struct_namespace_name)) {
                 writer |> write("\tvirtual bool isLocal() const override \{ return true; \}\n")
                 writer |> write("\tvirtual bool canBePlacedInContainer() const override \{ return true; \}\n")
+            }
+            if (isTrivialCtorType(struct_name, struct_namespace_name)) {
+                writer |> write("\tvirtual bool hasNonTrivialCtor() const override \{ return false; \}\n")
+            }
+            if (isCopyableType(struct_name, struct_namespace_name)) {
+                writer |> write("\tvirtual bool canCopy() const override \{ return true; \}\n")
             }
             writer |> write("\t{dashing_name}_GeneratedAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation (\"{struct_name}\", ml, \"{struct_namespace_name}\") \{\n")
             writer |> write("\t\}\n")
@@ -1144,16 +1187,11 @@ class CppGenBind : AnyGenBind {
     }
     def typeSpelling(var c : CXType) {
         let nspl = string(clang_getTypeSpelling(c))
-        if (nspl == "size_t" || nspl == "std::size_t" || nspl == "intptr_t" || nspl == "uintptr_t" || nspl == "size_t *") {
-            return nspl
-        }
+        if (nspl == "size_t" || nspl == "std::size_t" || nspl == "intptr_t" || nspl == "uintptr_t" || nspl == "size_t *") return nspl
         var t = clang_getCanonicalType(c)
         let spl = string(clang_getTypeSpelling(t))
-        if (c.kind == CXTypeKind.Enum) {
-            return enum2enum?[spl] ?? spl
-        } elif (t.kind == CXTypeKind.Long || t.kind == CXTypeKind.LongLong || t.kind == CXTypeKind.ULong || t.kind == CXTypeKind.ULongLong) {
-            return nspl // if its a fancy type, which may be different on different platform
-        }
+        if (c.kind == CXTypeKind.Enum) return enum2enum?[spl] ?? spl
+        if (t.kind == CXTypeKind.Long || t.kind == CXTypeKind.LongLong || t.kind == CXTypeKind.ULong || t.kind == CXTypeKind.ULongLong) return nspl // fancy type, may differ per platform
         return spl
     }
     def functionHeaderSpelling(var c : CXCursor; isMethod, needMethodQualifier, needArgumentNames : bool; function_name, self_type : string) {
@@ -1234,9 +1272,7 @@ class CppGenBind : AnyGenBind {
              t.kind == CXTypeKind.Typedef ||
              t.kind == CXTypeKind.Elaborated) {
             let tname = string(clang_getTypeSpelling(t))
-            if (aot_alias |> key_exists(tname)) {
-                return true
-            }
+            if (aot_alias |> key_exists(tname)) return true
         }
         // let tname = string(clang_getTypeSpelling(t))
         // print("NOT AOT ALIAS {tname} {t.kind}\n")
@@ -1481,7 +1517,7 @@ class CppGenBind : AnyGenBind {
             //      if we see IntegerLiteral - we check if it evals to 0, and if it does - we call it NULL
             if (t.kind == CXTypeKind.Pointer) {
                 var has_null = false
-                clang_visitChildren(c) $(var CC, parent) {
+                clang_visitChildren(c) $(var CC, _parent) {
                     if (CC.kind == CXCursorKind.IntegerLiteral) {
                         var nres = clang_Cursor_Evaluate(CC)
                         let nres_kind = clang_EvalResult_getKind(nres)
@@ -1548,7 +1584,7 @@ class CppGenBind : AnyGenBind {
         fprint(enum_class_file, "\t\tcppName = \"{ns_en}\";\n")
         let itype = string(clang_getTypeSpelling(clang_getEnumDeclIntegerType(cursor)))
         fprint(enum_class_file, "\t\tbaseType = (das::Type) das::ToBasicType<{itype}>::type;\n")
-        clang_visitChildren(cursor) $(var c, parent) {
+        clang_visitChildren(cursor) $(var c, _parent) {
             if (c.kind == CXCursorKind.EnumConstantDecl) {
                 let een = string(clang_getCursorDisplayName(c))
                 let deen = enum_entry_name(enum_name, een)
@@ -1593,9 +1629,7 @@ class CppGenBind : AnyGenBind {
     def generateDummy {
         for (k, v in keys(struct_ann), values(struct_ann)) {
             if (!v) {
-                if (aot_alias |> key_exists(k) || already_defined |> key_exists(k)) {
-                    continue
-                }
+                if (aot_alias |> key_exists(k) || already_defined |> key_exists(k)) continue
                 let kname = nsst2st?[k] ?? "MissingDummy"
                 fprint(dummy_add_file, "addAnnotation(new DummyTypeAnnotation(\"{kname}\", \"{k}\", 1, 1));\n")
             }

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -732,6 +732,9 @@ class AnyGenBind {
             to_log(LOG_WARNING, "collectActiveDefines: cannot parse {fname}, falling back to raw scan\n")
             return data
         }
+        // libclang returns backslashes on Windows; normalize both sides so the suffix
+        // match is OS-independent (else every MacroDefinition cursor filters out)
+        let fnameNorm = fname |> replace_multiple([(text = "\\", replacement = "/")])
         let result = build_string() $(var wr : StringBuilderWriter) {
             clang_visitChildren(clang_getTranslationUnitCursor(unit)) $(var c, _parent) {
                 if (clang_getCursorKind(c) == CXCursorKind.MacroDefinition) {
@@ -739,7 +742,7 @@ class AnyGenBind {
                     var ml, mc, mo : uint
                     clang_getSpellingLocation(clang_getCursorLocation(c), safe_addr(mfile), safe_addr(ml), safe_addr(mc), safe_addr(mo))
                     // builtin / command-line macros have a null CXFile — skip them
-                    if (mfile != null && string(clang_getFileName(mfile)) |> ends_with(fname)) {
+                    if (mfile != null && (string(clang_getFileName(mfile)) |> replace_multiple([(text = "\\", replacement = "/")])) |> ends_with(fnameNorm)) {
                         var ext = clang_getCursorExtent(c)
                         var sfile, efile : CXFile
                         var sl, scol, so, el, ecol, eo : uint
@@ -1397,7 +1400,12 @@ class CppGenBind : AnyGenBind {
             for (ai in urange(narg)) {
                 let aii = int(isMethod ? ai + 1u : ai)
                 var carg = clang_Cursor_getArgument(c, ai)
-                let cp = getCursorArgType(clang_getCursorType(carg))     // non-canonical
+                var cp = getCursorArgType(clang_getCursorType(carg))     // non-canonical
+                // a binder may pin a (function,arg) to its raw C int instead of the enum
+                // retype, to preserve a shipped signature; cp="" -> int + ExprConstInt default
+                if (cp != "" && keep_c_arg_type(das_function_name, string(clang_getCursorSpelling(carg)), aii)) {
+                    cp = ""
+                }
                 if (cp != "") {
                     fprint(func_file, "\n\t\t->arg_type({aii},makeType<{cp}>(lib))")
                 }
@@ -1457,6 +1465,10 @@ class CppGenBind : AnyGenBind {
             }
         }
         fprint(func_file, ";\n")
+    }
+    //! Override to keep a specific (function,arg) at its raw C type instead of the enum/alias retype — preserves a shipped public signature.
+    def keep_c_arg_type(funcName, argName : string; argIndex : int) : bool {
+        return false
     }
     def getCursorArgType(var t : CXType) {
         let tn = string(clang_getTypeSpelling(t))

--- a/modules/dasClangBind/tests/const_preproc_fixture.h
+++ b/modules/dasClangBind/tests/const_preproc_fixture.h
@@ -1,0 +1,16 @@
+#pragma once
+// Regression fixture for cbind preprocessor-active constant generation.
+//
+// The opt-in macro CONST_PREPROC_USE_ALT is intentionally left undefined, so
+// the preprocessor-ACTIVE branch is the #else one (value 0). A naive raw-text
+// regex scan would pick the first textual match (the inactive #ifdef branch,
+// value 16); the MacroDefinition-cursor path in cbind_boost.das must pick the
+// active value 0. Mirrors imgui.h's IM_COL32_*_SHIFT under
+// IMGUI_USE_BGRA_PACKED_COLOR.
+#ifdef CONST_PREPROC_USE_ALT
+#define CONST_PREPROC_K 16
+#else
+#define CONST_PREPROC_K 0
+#endif
+
+#define CONST_PREPROC_PLAIN 42

--- a/modules/dasClangBind/tests/test_const_preproc.das
+++ b/modules/dasClangBind/tests/test_const_preproc.das
@@ -1,0 +1,45 @@
+options gen2
+require cbind/cbind_boost
+require daslib/fio
+require strings
+
+// Regression test for cbind preprocessor-active constant generation.
+//
+// const_preproc_fixture.h defines CONST_PREPROC_K twice (16 under an undefined
+// #ifdef, 0 under the active #else). The old raw-text regex scan picked the
+// first textual match (16); collectActiveDefines walks libclang
+// MacroDefinition cursors, which only exist for the preprocessor-active branch,
+// so it must yield 0 with no trace of 16.
+//
+// Runs on the mingw CI worker where libclang/cbind is available (alongside the
+// bind_clangbind self-binder). Returns non-zero on failure so CI can branch.
+[export]
+def main : int {
+    let pfp = "{get_das_root()}/modules/dasClangBind/tests/"
+    let pfn = "const_preproc_fixture.h"
+    let fname = "{pfp}{pfn}"
+    var cgb = new CppGenBind(pfn, pfp, DEFAULT_CLANG_ARGUMENTS)
+    var rc = 1
+    fopen(fname, "rb") $(f) {
+        if (f == null) {
+            to_log(LOG_ERROR, "FAIL: cannot open fixture {fname}\n")
+        } else {
+            let data = fread(f)
+            let active = cgb->collectActiveDefines(fname, data)
+            // the inactive-branch trap (16) must exist in the raw header text...
+            let rawHasTrap = find(data, "16") >= 0
+            // ...but be absent from the preprocessor-active reconstruction
+            let kPresent = find(active, "CONST_PREPROC_K") >= 0
+            let plainPresent = find(active, "CONST_PREPROC_PLAIN") >= 0
+            let activeHasTrap = find(active, "16") >= 0
+            if (rawHasTrap && kPresent && plainPresent && !activeHasTrap) {
+                to_log(LOG_INFO, "PASS: cbind const-gen picks the active #else branch (CONST_PREPROC_K=0; inactive 16 stripped)\n")
+                rc = 0
+            } else {
+                to_log(LOG_ERROR, "FAIL: rawHasTrap={rawHasTrap} kPresent={kPresent} plainPresent={plainPresent} activeHasTrap={activeHasTrap}. Active defines:\n{active}\n")
+            }
+        }
+    }
+    unsafe { delete cgb }
+    return rc
+}


### PR DESCRIPTION
## Problem

The cbind constant generator regex-scanned a header's **raw text** and took the *first* textual `#define` for a name. When a macro is defined twice across an `#ifdef/#else`, that picks whichever branch appears first in the text — which can be the **inactive** one. The result is a silently-wrong constant, and any manual fixup to the generated `.inc` gets reverted on the next regen.

Real-world case (downstream, dasImgui): `imgui.h` defines `IM_COL32_R_SHIFT` as `16` under `#ifdef IMGUI_USE_BGRA_PACKED_COLOR` and `0` under `#else`. BGRA is off, so the active value is `0`, but the regex emitted `16` (R/B channels swapped). Same shape for `IM_UNICODE_CODEPOINT_MAX` under `IMGUI_USE_WCHAR32`.

## Fix

`collectActiveDefines()` reparses the header with `CXTranslationUnit_DetailedPreprocessingRecord` and reconstructs only the `#define` lines that have a libclang `MacroDefinition` cursor — which exist **solely for the branch the preprocessor actually took** — then feeds those to the existing regexes. The active value now wins and the output is **regen-stable** (no manual `.inc` patching).

Constant set/order is otherwise unchanged: for a singly-defined macro the active reconstruction equals the old first-match, so only `#ifdef/#else` duplicates move.

## Also: per-type binder config

Adds `trivial_ctor_type_names` / `copyable_type_names` so a binder can mark a bitwise-zero-init-safe handled type as inline-storable (emit `hasNonTrivialCtor()->false` / `canCopy()->true`) without a manual post-regen patch on the generated `struct.class.inc`. (dasImgui's `ImGuiTextFilter` patch was exactly this.)

## Test

`modules/dasClangBind/tests/` — a fixture header with an `#ifdef/#else` dup-define and an assertion that the active branch wins (and the inactive `16` is stripped). Wired into the mingw worker alongside the `bind_clangbind` self-binder (the only CI job where libclang/cbind is available). `bind_clangbind` itself emits no constants and doesn't use the new config, so its staleness check is unaffected.

The commit also clears pre-existing STYLE005 / LINT013 lint in `cbind_boost.das` — surfaced because `modules/dasClangBind` is outside CI's daslib lint sweep, but the pre-push hook lints every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)