### PR TITLE
typer: honor user-defined operators over mismatched enums

### DIFF
--- a/src/ast/ast_infer_type_op.cpp
+++ b/src/ast/ast_infer_type_op.cpp
@@ -447,10 +447,9 @@ namespace das {
                 }
             }
         }
-        if (expr->left->type->isEnum() && expr->right->type->isEnum())
-            if (!expr->left->type->isSameType(*expr->right->type, RefMatters::no, ConstMatters::no, TemporaryMatters::no))
-                error("operations on different enumerations are prohibited", "", "",
-                      expr->at, CompilationError::invalid_enumeration);
+        // NOTE: mismatched-enum operands are gated AFTER the custom-operator lookup
+        // below (see reportOp2Errors) — a user-defined operator |(E1;E2) must win over
+        // the "different enumerations" error, so the gate can't run before resolution.
         // try promoting int literal on either side to match the other side's type
         {
             bool rangeError = false;

--- a/src/ast/ast_infer_type_report.cpp
+++ b/src/ast/ast_infer_type_report.cpp
@@ -814,6 +814,15 @@ namespace das {
                 }
             }
         }
+        // Mismatched-enum operands are only an error if no custom operator matched —
+        // this runs after the operator lookup failed, so a user operator |(E1;E2)
+        // would already have been picked up. (Moved here from visit(ExprOp2).)
+        if (expr_left->type->isEnum() && expr_right->type->isEnum()
+            && !expr_left->type->isSameType(*expr_right->type, RefMatters::no, ConstMatters::no, TemporaryMatters::no)) {
+            error("operations on different enumerations are prohibited", "", "",
+                  expr->at, CompilationError::invalid_enumeration);
+            return true;
+        }
         return false;
     }
     void InferTypes::collectMissingOperators(const string &opN, MatchingFunctions &mf, bool identicalName) {

--- a/tests/language/enumerations.das
+++ b/tests/language/enumerations.das
@@ -49,3 +49,18 @@ def test_enum_macro_conversions(t : T?) {
     }
 }
 
+// Regression: a user-defined operator over two DIFFERENT enums must be honored.
+// The "operations on different enumerations are prohibited" gate now runs only
+// AFTER operator-overload lookup fails (reportOp2Errors), so this overload wins.
+def operator |(a : Foo; b : Bar) : Foo {
+    return unsafe(reinterpret<Foo>(int(a) | int(b)))
+}
+
+[test]
+def test_cross_enum_operator(t : T?) {
+    t |> run("user operator | combines two different enums") @(t : T?) {
+        let r = Foo.two | Bar.three     // 1 | 2 == 3
+        t |> equal(3, int(r))
+    }
+}
+


### PR DESCRIPTION
## Problem

A user-defined `operator |(E1; E2)` over two *different* enum types is never honored — the typer rejects the expression outright with `error[30145]: operations on different enumerations are prohibited`, even when a matching overload exists.

The cause is ordering in `InferTypes::visit(ExprOp2)` ([ast_infer_type_op.cpp](src/ast/ast_infer_type_op.cpp)): the "different enumerations" gate ran **before** the operator-overload lookup (`inferFunctionCall(..., operatorOp2)`), so the custom operator never got a chance.

## Fix

Move the gate so it runs **only after** the operator lookup fails. The lookup's no-match path already routes through `reportOp2Errors` ([ast_infer_type_report.cpp](src/ast/ast_infer_type_report.cpp)) — the natural home for operator-specific diagnostics — so the check now lives there:

- A matching cross-enum `operator |(E1; E2)` **wins** and is used.
- When no operator resolves, the prohibition still fires with the **same message and code** (`CompilationError::invalid_enumeration`).

Net diff is tiny (the gate's 4 lines move from `visit(ExprOp2)` into `reportOp2Errors`).

## Why

This unblocks cross-enum flag rails — e.g. combining a public flag enum with its internal "private" extension enum (which the C++ side treats as one int-backed flag set) through a single `|` instead of manual `int(a) | int(b)` casts.

## Test

`tests/language/enumerations.das` — a user `operator |(Foo; Bar)` combines two distinct enums and the result equals the bitwise OR. (The negative case — a mismatch with *no* operator still erroring 30145 — is preserved by `reportOp2Errors` and verified manually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)