### PR TITLE
linq_fold: decs random-indexes boundary archetype tail (bare last + reverse|>take)

### DIFF
--- a/benchmarks/micro/bare_last_decs_shapes.das
+++ b/benchmarks/micro/bare_last_decs_shapes.das
@@ -1,0 +1,189 @@
+options gen2
+options persistent_heap
+
+require daslib/linq_fold public
+require daslib/linq_boost public
+require daslib/decs_boost public
+require dastest/testing_boost public
+require strings
+
+// Micro-bench: bare `last()` (no predicate, no range, no projection) over a decs / array source.
+// Question: is decs `last()` an O(N) full forward walk today, and how much would a tail fast path save?
+//
+//   C (current)  — `source.last()`: the no-predicate-last fast path is unimplemented for decs, so it
+//                  falls through emit_early_exit_lane to the generic full walk, rebinding the whole row
+//                  on EVERY element. O(N).
+//   A (fast path) — `source.reverse().take(1).to_array()[0]`: rides the SHIPPED skip-into-tail machinery
+//                   (emit_decs_reverse_skip_into_tail / array equivalent) — sums archetype sizes, skips
+//                   whole archetypes to the boundary, collects only the last element. O(num_archetypes).
+//                   A faithful proxy for what a wired-up `last()` fast path would emit (it would return the
+//                   scalar directly instead of a 1-element array, so it'd be marginally faster still).
+//   count        — `source.count()`: the arch.size O(1) shortcut. Touch-no-entities floor for the decs walk.
+//
+// Self-contained (no _common dependency) so it stays out of the results.md sweep over benchmarks/sql/.
+
+let N = 100000
+let BRAND_COUNT = 5
+let DEALER_COUNT = 100
+
+struct Car {
+    id        : int
+    name      : string
+    price     : int
+    brand     : int
+    year      : int
+    dealer_id : int
+}
+
+[decs_template(prefix = "car_")]
+struct DecsCar {
+    id        : int
+    name      : string
+    price     : int
+    brand     : int
+    year      : int
+    dealer_id : int
+}
+
+def fixture_array(n : int) : array<Car> {
+    var arr : array<Car>
+    arr |> resize(n)
+    for (i in range(n)) {
+        arr[i] = Car(
+            id = i + 1,
+            name = "Car{i}",
+            price = (i * 37) % 1000,
+            brand = i % BRAND_COUNT,
+            year = 2010 + (i * 7) % 16,
+            dealer_id = (i % DEALER_COUNT) + 1
+        )
+    }
+    return <- arr
+}
+
+def fixture_decs(n : int) {
+    restart()
+    create_entities(n) $(_eid : EntityId; i : int; var cmp : ComponentMap) {
+        apply_decs_template(cmp, DecsCar(
+            id = i + 1,
+            name = "Car{i}",
+            price = (i * 37) % 1000,
+            brand = i % BRAND_COUNT,
+            year = 2010 + (i * 7) % 16,
+            dealer_id = (i % DEALER_COUNT) + 1
+        ))
+    }
+}
+
+// touch the whole survivor (id + name length) so the name clone can't be elided.
+// generic so it accepts both the array Car struct and the decs source's anonymous named tuple.
+def check(c) : int {
+    return c.id + length(c.name)
+}
+
+// ===== decs lanes =====
+
+def run_decs_last_current(b : B?) {
+    fixture_decs(N)
+    b |> run("C_decs_last_current/{N}", N) {
+        let r = _fold(from_decs_template(type<DecsCar>).last())
+        if (check(r) == 0) { b->failNow() }
+    }
+}
+
+def run_decs_last_tail(b : B?) {
+    fixture_decs(N)
+    b |> run("A_decs_last_tail/{N}", N) {
+        unsafe {
+            let rows <- _fold(from_decs_template(type<DecsCar>).reverse().take(1).to_array())
+            if (empty(rows) || check(rows[0]) == 0) { b->failNow() }
+        }
+    }
+}
+
+def run_decs_count_ref(b : B?) {
+    fixture_decs(N)
+    b |> run("R_decs_count_archsize/{N}", N) {
+        let c = _fold(from_decs_template(type<DecsCar>).count())
+        if (c != N) { b->failNow() }
+    }
+}
+
+// B (true floor) — random-index the last entity of the last non-empty archetype. for_each_archetype
+// visits matching archetypes in order, skipping empties, so the last one visited holds the global-last;
+// read entity [size-1] directly via get_ro (no per-entity walk). O(num_archetypes), NOT O(N). This is
+// what a proper decs `last()` fast path would emit — the existing reverse-into-tail can't reach it
+// because it continue-walks the boundary archetype instead of indexing into it.
+def run_decs_last_floor(b : B?) {
+    fixture_decs(N)
+    var erq : EcsRequest
+    erq.req <- ["car_id", "car_name", "car_price", "car_brand", "car_year", "car_dealer_id"]
+    compile_request(erq)
+    b |> run("B_decs_last_floor/{N}", N) {
+        var res : Car
+        var any = false
+        for_each_archetype(erq) $(arch : Archetype) {
+            unsafe {
+                let li = int(arch.size) - 1
+                res.id = get_ro(arch, "car_id", 0)[li]
+                res.name := get_ro(arch, "car_name", "")[li]
+                res.price = get_ro(arch, "car_price", 0)[li]
+                res.brand = get_ro(arch, "car_brand", 0)[li]
+                res.year = get_ro(arch, "car_year", 0)[li]
+                res.dealer_id = get_ro(arch, "car_dealer_id", 0)[li]
+            }
+            any = true
+        }
+        if (!any || check(res) == 0) { b->failNow() }
+    }
+}
+
+// ===== array lanes (context) =====
+
+def run_array_last_current(b : B?) {
+    let arr <- fixture_array(N)
+    b |> run("C_array_last_current/{N}", N) {
+        let r = _fold(each(arr).last())
+        if (check(r) == 0) { b->failNow() }
+    }
+}
+
+def run_array_last_tail(b : B?) {
+    let arr <- fixture_array(N)
+    b |> run("A_array_last_tail/{N}", N) {
+        unsafe {
+            let rows <- _fold(each(arr).reverse().take(1).to_array())
+            if (empty(rows) || check(rows[0]) == 0) { b->failNow() }
+        }
+    }
+}
+
+[benchmark]
+def probe_decs_last_C_current(b : B?) {
+    run_decs_last_current(b)
+}
+
+[benchmark]
+def probe_decs_last_A_tail(b : B?) {
+    run_decs_last_tail(b)
+}
+
+[benchmark]
+def probe_decs_count_R_ref(b : B?) {
+    run_decs_count_ref(b)
+}
+
+[benchmark]
+def probe_decs_last_B_floor(b : B?) {
+    run_decs_last_floor(b)
+}
+
+[benchmark]
+def probe_array_last_C_current(b : B?) {
+    run_array_last_current(b)
+}
+
+[benchmark]
+def probe_array_last_A_tail(b : B?) {
+    run_array_last_tail(b)
+}

--- a/benchmarks/sql/bare_last.das
+++ b/benchmarks/sql/bare_last.das
@@ -1,0 +1,85 @@
+options gen2
+options persistent_heap
+
+require _common public
+
+// Bare `.last()` — no predicate, no order. The last element in source/storage/document order.
+//
+// No m1 (SQL) lane: SQL has no inherent row ordering, so `_sql` rejects bare `reverse()` / `last()`
+// (sqlite_linq.das — "use _order_by_descending(...) for sort reversal"). Bare last is only meaningful
+// for sources with a natural order: array (index), decs (archetype storage order), XML (document order),
+// JSON (array order).
+//
+// Decs (m4): reads the last archetype's [size-1] directly via get_ro index (emit_decs_last_random_index),
+// O(num_archetypes) — was a full O(N) walk before. XML (m5f): backward DOM step (PR #3009). JSON (m6f):
+// random-indexes the backing array. Array (m3f): arr[len-1].
+
+def run_m3f(b : B?; n : int) {
+    let arr <- fixture_array(n)
+    b |> run("m3f_array_fold/{n}", n) {
+        let row = _fold(each(arr).last())
+        b |> accept(row)
+        if (row.price == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m4(b : B?; n : int) {
+    fixture_decs(n)
+    b |> run("m4_decs_fold/{n}", n) {
+        let row = _fold(from_decs_template(type<DecsCar>).last())
+        b |> accept(row)
+        if (row.price == 0) {
+            b->failNow()
+        }
+    }
+}
+
+def run_m5f(b : B?; n : int) {
+    let xml = fixture_xml_string(n)
+    parse_xml(xml) $(doc, ok) {
+        if (!ok) {
+            b->failNow()
+            return
+        }
+        b |> run("m5f_xml_fold/{n}", n) {
+            let row = _fold(unsafe(from_xml_node(doc.document_element, type<Car>)).last())
+            b |> accept(row)
+            if (row.price == 0) {
+                b->failNow()
+            }
+        }
+    }
+}
+
+def run_m6f(b : B?; n : int) {
+    let jv = fixture_json(n)
+    b |> run("m6f_json_fold/{n}", n) {
+        let row = _fold(unsafe(from_json(jv, type<Car>)).last())
+        b |> accept(row)
+        if (row.price == 0) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def bare_last_m3f(b : B?) {
+    run_m3f(b, 100000)
+}
+
+[benchmark]
+def bare_last_m4(b : B?) {
+    run_m4(b, 100000)
+}
+
+[benchmark]
+def bare_last_m5f(b : B?) {
+    run_m5f(b, 100000)
+}
+
+[benchmark]
+def bare_last_m6f(b : B?) {
+    run_m6f(b, 100000)
+}

--- a/benchmarks/sql/results.md
+++ b/benchmarks/sql/results.md
@@ -1,6 +1,8 @@
 # Benchmarks — SQL / Array / Decs / XML / JSON comparison
 
-Updated 2026-06-04 (branch `bbatkin/xml-reverse-emission`): **the XmlAdapter now walks the DOM backward for bounded-reverse shapes.** `reverse |> take(K) [|> select]` and a **no-predicate** `last()` / `reverse |> first` fuse to an O(K) backward walk via pugixml's O(1) `last_child()` / `previous_sibling()` — visiting only the kept tail instead of scanning all *n* forward then reversing. This closes the gap JSON's array-backed random access used to hold: **`reverse_take` m5f 85.8 → 0.0, `reverse_take_select` m5f 84.6 → 0.0 INTERP** (71.0 / 69.1 → 0.0 JIT), now level with the array / JSON tail walk. **Predicated `[where] |> last` deliberately stays on the forward walk** — reverse DOM traversal is ~2× cache-hostile per node (pugixml lays nodes out in forward document order, so `previous_sibling` defeats the prefetcher; profiled `count.backward` 119 vs `count.forward` 63 ns/elem INTERP), so a match far from the end would regress ~2.6× — `last_match` m5f is unchanged (66.3). **This sweep also captures the deferred apply-hybrid (#3008) read-path inline** that landed after the previous sweep: the `from_xml_node` field/row materializer now inlines its per-field `apply` block instead of routing each field through a per-field `invoke`, so XML m5f field-reading lanes drop broadly vs the previous (pre-#3008) sweep — `select_where` 253.3 → **196.0**, `bare_order_where` 332.5 → **303.8** INTERP, and the single-field reduce / aggregate lanes settle at ~16.5 ns under JIT (`count_aggregate` 27.2 → **16.5**, `sum_aggregate` 23.6 → **16.8**, `max_aggregate` 24.6 → **16.7**). Only the XML read-path (m5f) and the two reverse lanes moved; m1 / m3f / m4 / m6f cells are stable within long-sweep thermal noise.
+Updated 2026-06-04 (branch `bbatkin/decs-reverse-random-index`): **the DecsAdapter now random-indexes the boundary archetype tail.** Bare `last()` / `last_or_default()` (no `where` / `select` / range) read the last non-empty archetype's `[size-1]` directly via `get_ro(arch, comp, def)[idx]` (`emit_decs_last_random_index`, O(num_archetypes)); `reverse |> take(K)` random-indexes the boundary archetype's tail `[size-K .. size)` instead of `continue`-walking its head (`build_decs_index_collect`). **`reverse_take` / `reverse_take_select` m4 9.2/9.3 → 0.2 INTERP (1.1 → 0.0 JIT), and the new `bare_last` m4 is 0.0** (the O(*n*) walk it replaces cost ~17 ns/elem INTERP / ~1.2 JIT — `benchmarks/micro/bare_last_decs_shapes.das`) — decs is now level with the XML backward-DOM path (m5f 0.0) and below array's still-walking `last()` (m3f 4.2). **Indexable sources only** — a `[decs_template]` field with a default-init compiles to `get_default_ro` (an iterator), so `decs_can_random_index` returns false and the chain falls back to the per-entity walk (behavior-identical); predicated / `_select`'d `last` likewise keeps the walk (the last-match position is unknown). Only the decs (m4) `bare_last` + `reverse_take[_select]` cells moved; all other cells are stable within long-sweep thermal noise.
+
+Earlier (branch `bbatkin/xml-reverse-emission`): **the XmlAdapter now walks the DOM backward for bounded-reverse shapes.** `reverse |> take(K) [|> select]` and a **no-predicate** `last()` / `reverse |> first` fuse to an O(K) backward walk via pugixml's O(1) `last_child()` / `previous_sibling()` — visiting only the kept tail instead of scanning all *n* forward then reversing. This closes the gap JSON's array-backed random access used to hold: **`reverse_take` m5f 85.8 → 0.0, `reverse_take_select` m5f 84.6 → 0.0 INTERP** (71.0 / 69.1 → 0.0 JIT), now level with the array / JSON tail walk. **Predicated `[where] |> last` deliberately stays on the forward walk** — reverse DOM traversal is ~2× cache-hostile per node (pugixml lays nodes out in forward document order, so `previous_sibling` defeats the prefetcher; profiled `count.backward` 119 vs `count.forward` 63 ns/elem INTERP), so a match far from the end would regress ~2.6× — `last_match` m5f is unchanged (66.3). **This sweep also captures the deferred apply-hybrid (#3008) read-path inline** that landed after the previous sweep: the `from_xml_node` field/row materializer now inlines its per-field `apply` block instead of routing each field through a per-field `invoke`, so XML m5f field-reading lanes drop broadly vs the previous (pre-#3008) sweep — `select_where` 253.3 → **196.0**, `bare_order_where` 332.5 → **303.8** INTERP, and the single-field reduce / aggregate lanes settle at ~16.5 ns under JIT (`count_aggregate` 27.2 → **16.5**, `sum_aggregate` 23.6 → **16.8**, `max_aggregate` 24.6 → **16.7**). Only the XML read-path (m5f) and the two reverse lanes moved; m1 / m3f / m4 / m6f cells are stable within long-sweep thermal noise.
 
 Earlier (branch `bbatkin/linq-json-self-materialize`): **`from_json` is now a by-name flat query source (Option B)** — the fused `JsonAdapter` and `from_json` / `read_json_field` materialize each JSON object the way `from_xml_node` does (top-level fields read by key, via `apply_imm` over the struct fields reading each `JsValue` straight off the variant), and **never honor a whole-row `from_JV(Row)` override** (the escape hatch is an explicit `[for (e in jv.value as _array); from_JV(e, type<Row>)]` first). Two wins compound. **(1) By-name materialize** removes the old per-result-row `from_JV` allocation (`select_where` 405 → 21 B/op) that ran ~n times on **lanes that build a large result set** — a full projection-to-array or a sort-everything. **(2) A direct per-field read** then attacks the per-field floor that (1) left untouched: `read_json_field` now reads a `table<string; JsonValue?>` slot pointer via `(jv ?as _object)?[key]` (null ⇔ key absent) instead of routing through the `operator ?[]` call frame + a `JVNull()`-sentinel `_null`-tag round-trip, and `from_json_row` reads each basic value straight off the `JsValue` variant — probing the `TT`-matching tag first (JSON ints land in `_longint`, reals in `_number` — a `static_if`, no runtime branch) — instead of the `from_JV` scalar wrapper. That drops a per-field interpreter call frame (plus the absent-key allocation), so **every field-reading lane falls ~15–31% INTERP**, not just the big-materialize ones: `select_where` 697.3 → **192.1** (−72%), `bare_order_where` 780.6 → **302.8** (−61%), and the reduce / count / group lanes that the by-name pass left flat now drop too (`count_aggregate` 214.0 → **156.3**, `sum_aggregate` 198.4 → **144.5**, `groupby_sum` 276.0 → **201.6**). Lanes that read **no field** are unchanged (`select_count` 2.2, `reverse_take` 25.2 — the array-backed O(K) tail walk). **Under JIT the per-field path is already inlined, so m6f is flat** (`aggregate_match` 38.3 → 41.4, `select_where` 38.0 → 37.4 — jitter). **Net vs XML:** the big-materialize lanes that trailed XML ~3× in INTERP now reach roughly parity (`select_where` 192.1 vs XML ~226–253, `bare_order_where` 302.8 vs 332.5), and **under JIT stay JSON-faster** (`select_where` 37.4 vs 95.2 = 0.39×, `bare_order_where` 58.3 vs 123.8 = 0.47×) — the das-side by-name build compiles to native while XML's per-row C++ assembly is fixed. The single-field-int **reduce** lanes still trail XML in INTERP (`count_aggregate` 156.3 vs 64.6 ≈ 2.4×, down from ~3×) and ~1.2× under JIT — the irreducible string-hashed `table` lookup vs XML's C++ pointer read. Only the m6f (JSON) path changed; every m1 / m3f / m4 / m5f cell is stable within long-sweep thermal noise (the `select_where` m5f 226.5 → 253.3 jitter is one such — XML is untouched here).
 
@@ -126,163 +128,165 @@ two lanes sit on opposite corners:
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML fold (m5f) | JSON fold (m6f) |
 |---|---:|---:|---:|---:|---:|
-| `aggregate_match` | 35.4 | 6.0 | 5.9 | 58.6 | 162.5 |
-| `all_match` | 28.1 | 3.6 | 3.4 | 55.7 | 153.9 |
+| `aggregate_match` | 35.3 | 6.0 | 5.9 | 58.7 | 163.8 |
+| `all_match` | 27.9 | 3.6 | 3.4 | 55.7 | 154.1 |
 | `any_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
-| `average_aggregate` | 30.7 | 5.8 | 8.8 | 60.0 | 163.6 |
-| `bare_order_where` | 282.0 | 116.6 | 126.2 | 303.8 | 298.6 |
-| `chained_select_collapse` | — | 17.8 | 17.8 | 70.3 | 164.0 |
-| `chained_where` | 36.6 | 7.0 | 7.3 | 103.6 | 196.6 |
-| `contains_match` | 0.0 | 2.2 | 1.4 | 27.7 | 71.0 |
-| `count_aggregate` | 29.8 | 4.1 | 4.1 | 64.2 | 151.2 |
-| `cross_join` | 12729.3 | 3713.8 | — | 4014.6 | 4033.0 |
+| `average_aggregate` | 30.7 | 5.8 | 8.8 | 59.8 | 165.6 |
+| `bare_last` | — | 4.2 | 0.0 | 0.0 | 4.2 |
+| `bare_order_where` | 283.0 | 116.8 | 126.1 | 304.2 | 301.5 |
+| `chained_select_collapse` | — | 17.9 | 17.8 | 70.5 | 169.7 |
+| `chained_where` | 36.9 | 6.6 | 7.3 | 103.0 | 204.8 |
+| `contains_match` | 0.0 | 2.3 | 1.4 | 31.1 | 74.1 |
+| `count_aggregate` | 30.1 | 4.1 | 4.1 | 64.5 | 157.4 |
+| `cross_join` | 12765.7 | 3724.1 | — | 4040.5 | 4111.5 |
 | `decs_count_bare_pred` | — | — | 4.1 | — | — |
-| `distinct_by_count` | 41.7 | 15.7 | 16.0 | 73.4 | 164.4 |
-| `distinct_by_order_take` | 240.6 | 21.8 | 23.6 | 127.2 | 164.4 |
-| `distinct_by_order_to_array` | 241.2 | 21.7 | 23.4 | 127.2 | 165.6 |
-| `distinct_count` | 41.6 | 15.8 | 15.8 | 70.7 | 164.8 |
-| `distinct_count_pred` | 253.6 | 16.0 | 16.2 | 112.8 | 183.6 |
+| `distinct_by_count` | 42.0 | 15.8 | 16.1 | 72.8 | 170.3 |
+| `distinct_by_order_take` | 240.2 | 21.7 | 23.6 | 127.1 | 170.1 |
+| `distinct_by_order_to_array` | 241.2 | 21.9 | 23.6 | 127.9 | 168.8 |
+| `distinct_count` | 41.8 | 15.8 | 15.9 | 70.8 | 172.6 |
+| `distinct_count_pred` | 253.8 | 16.0 | 16.2 | 113.4 | 188.4 |
 | `distinct_take` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
 | `element_at_match` | 0.0 | 0.0 | 0.0 | 0.4 | 0.4 |
 | `first_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
 | `first_or_default_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
-| `groupby_average` | 171.4 | 30.4 | 29.8 | 124.7 | 211.1 |
-| `groupby_count` | 141.8 | 20.5 | 20.5 | 76.2 | 168.6 |
-| `groupby_first` | 250.9 | 19.8 | 20.5 | 72.3 | 166.9 |
-| `groupby_having_count` | 142.7 | 20.5 | 20.5 | 78.0 | 168.9 |
-| `groupby_having_hidden_sum` | 175.4 | 23.9 | 24.1 | 124.4 | 208.1 |
-| `groupby_having_post_where` | 172.3 | 19.9 | 19.8 | 116.1 | 201.9 |
-| `groupby_max` | 174.2 | 25.0 | 25.1 | 122.6 | 205.6 |
-| `groupby_min` | 174.2 | 25.3 | 25.3 | 122.1 | 205.7 |
-| `groupby_multi_reducer` | 190.7 | 32.6 | 32.2 | 126.8 | 213.3 |
-| `groupby_select_order` | 170.5 | 19.8 | 19.8 | 117.2 | 202.2 |
-| `groupby_select_sum` | 202.3 | 37.2 | 36.5 | 99.2 | 207.6 |
-| `groupby_sum` | 170.9 | 19.8 | 19.8 | 115.9 | 200.2 |
-| `groupby_where_count` | 76.8 | 14.5 | 14.9 | 117.6 | 200.1 |
-| `groupby_where_sum` | 87.6 | 14.2 | 14.6 | 117.1 | 201.2 |
-| `indexed_lookup` | 1456.7 | 205331.3 | 480.4 | 5575539.7 | 14621795.6 |
-| `join_count` | 40.0 | 51.5 | 64.1 | 113.2 | 182.0 |
-| `join_groupby_count` | 157.0 | 78.5 | 95.6 | 180.1 | 247.2 |
-| `join_groupby_to_array` | 192.5 | 78.2 | 90.9 | 215.1 | 219.9 |
-| `join_select` | 150.8 | 71.9 | 85.4 | 189.9 | 230.1 |
-| `join_where_count` | 39.5 | 61.9 | 77.4 | 166.7 | 204.4 |
-| `last_match` | 0.0 | 5.8 | 13.9 | 66.3 | 155.3 |
-| `long_count_aggregate` | 30.0 | 4.1 | 4.1 | 64.0 | 152.3 |
-| `max_aggregate` | 31.2 | 6.2 | 6.8 | 58.4 | 158.3 |
-| `min_aggregate` | 31.0 | 6.1 | 6.7 | 58.2 | 158.1 |
-| `order_by_multi_key` | 345.4 | 272.7 | 280.7 | 460.2 | 455.8 |
-| `order_distinct_take` | 138.1 | 15.7 | 96.2 | 73.3 | 166.4 |
-| `order_reverse_normalized` | 38.4 | 16.1 | 19.9 | 68.8 | 174.7 |
-| `order_take_desc` | 38.5 | 16.1 | 20.2 | 68.9 | 173.0 |
-| `reverse_distinct_by` | 296.0 | 21.8 | 33.5 | 74.4 | 163.1 |
-| `reverse_take` | 0.1 | 0.0 | 9.2 | 0.0 | 25.5 |
-| `reverse_take_select` | 0.0 | 0.0 | 9.3 | 0.0 | 25.4 |
-| `select_count` | 0.1 | 0.0 | 2.1 | 63.7 | 2.2 |
-| `select_many` | — | 190.7 | — | — | — |
-| `select_where` | 196.3 | 11.2 | 19.5 | 196.0 | 192.8 |
-| `select_where_count` | 32.9 | 5.2 | 7.4 | 62.2 | 155.4 |
-| `select_where_order_take` | 36.7 | 12.3 | 14.9 | 70.7 | 161.9 |
-| `select_where_sum` | 37.2 | 7.5 | 7.4 | 63.8 | 158.1 |
-| `single_match` | 0.0 | 2.8 | 5.4 | 54.7 | 146.8 |
+| `groupby_average` | 171.5 | 30.4 | 29.7 | 125.2 | 222.9 |
+| `groupby_count` | 140.9 | 20.5 | 20.5 | 76.9 | 176.5 |
+| `groupby_first` | 252.3 | 19.8 | 20.5 | 72.3 | 170.9 |
+| `groupby_having_count` | 142.5 | 20.6 | 20.5 | 78.2 | 176.0 |
+| `groupby_having_hidden_sum` | 175.9 | 24.0 | 24.1 | 123.6 | 214.3 |
+| `groupby_having_post_where` | 172.3 | 19.9 | 19.9 | 115.6 | 208.0 |
+| `groupby_max` | 175.1 | 25.1 | 25.2 | 122.2 | 213.4 |
+| `groupby_min` | 174.2 | 25.4 | 25.3 | 122.7 | 213.4 |
+| `groupby_multi_reducer` | 190.8 | 32.7 | 32.3 | 126.8 | 220.6 |
+| `groupby_select_order` | 171.9 | 19.9 | 19.8 | 117.8 | 209.2 |
+| `groupby_select_sum` | 199.9 | 37.3 | 36.7 | 99.3 | 216.8 |
+| `groupby_sum` | 171.9 | 19.9 | 19.8 | 116.2 | 207.6 |
+| `groupby_where_count` | 76.1 | 14.5 | 14.9 | 117.8 | 207.2 |
+| `groupby_where_sum` | 88.8 | 14.2 | 14.6 | 117.0 | 208.1 |
+| `indexed_lookup` | 1458.7 | 205928.9 | 473.7 | 5827978.4 | 15265537.5 |
+| `join_count` | 38.5 | 51.4 | 64.7 | 113.0 | 187.3 |
+| `join_groupby_count` | 158.0 | 78.6 | 92.4 | 179.5 | 254.6 |
+| `join_groupby_to_array` | 191.0 | 78.6 | 91.4 | 220.1 | 223.4 |
+| `join_select` | 151.4 | 72.7 | 84.8 | 192.5 | 238.4 |
+| `join_where_count` | 39.6 | 62.2 | 75.2 | 161.8 | 211.3 |
+| `last_match` | 0.0 | 5.9 | 13.9 | 65.6 | 160.6 |
+| `long_count_aggregate` | 30.3 | 4.1 | 4.1 | 64.3 | 157.8 |
+| `max_aggregate` | 31.1 | 6.2 | 6.8 | 58.5 | 164.2 |
+| `min_aggregate` | 31.4 | 6.1 | 6.7 | 58.5 | 165.6 |
+| `order_by_multi_key` | 343.5 | 273.0 | 281.3 | 460.6 | 460.6 |
+| `order_distinct_take` | 138.8 | 15.8 | 94.4 | 72.9 | 173.5 |
+| `order_reverse_normalized` | 38.8 | 16.1 | 20.0 | 69.6 | 182.1 |
+| `order_take_desc` | 38.5 | 16.1 | 20.2 | 69.0 | 181.3 |
+| `reverse_distinct_by` | 297.0 | 21.9 | 34.0 | 74.5 | 170.7 |
+| `reverse_take` | 0.1 | 0.0 | 0.2 | 0.0 | 25.7 |
+| `reverse_take_select` | 0.0 | 0.0 | 0.2 | 0.0 | 25.4 |
+| `select_count` | 0.1 | 0.0 | 2.2 | 67.6 | 2.2 |
+| `select_many` | — | 191.8 | — | — | — |
+| `select_where` | 196.6 | 11.2 | 19.5 | 196.6 | 193.0 |
+| `select_where_count` | 32.8 | 5.2 | 7.4 | 62.2 | 161.4 |
+| `select_where_order_take` | 37.0 | 12.3 | 15.0 | 70.9 | 168.4 |
+| `select_where_sum` | 37.4 | 7.5 | 7.4 | 64.0 | 164.9 |
+| `single_match` | 0.0 | 2.8 | 5.4 | 57.3 | 149.5 |
 | `skip_take` | 0.5 | 0.1 | 0.2 | 3.1 | 3.1 |
-| `skip_while_match` | 3.5 | 5.3 | 5.4 | 56.4 | 149.7 |
-| `sort_first` | 38.3 | 11.0 | 13.3 | 64.3 | 170.4 |
-| `sort_take` | 38.2 | 16.3 | 20.0 | 68.7 | 174.5 |
-| `sort_take_select` | 38.4 | 16.2 | 20.3 | 69.8 | 175.1 |
-| `sum_aggregate` | 30.4 | 2.1 | 2.1 | 53.9 | 144.9 |
-| `sum_where` | 33.2 | 4.3 | 4.3 | 61.3 | 151.4 |
-| `take_count` | 3.6 | 0.2 | 0.4 | 3.1 | 2.9 |
+| `skip_while_match` | 3.5 | 5.3 | 5.4 | 58.7 | 154.1 |
+| `sort_first` | 38.2 | 11.1 | 13.4 | 64.5 | 178.4 |
+| `sort_take` | 38.5 | 16.4 | 20.1 | 69.1 | 182.6 |
+| `sort_take_select` | 38.6 | 16.3 | 20.5 | 70.5 | 184.3 |
+| `sum_aggregate` | 30.4 | 2.1 | 2.1 | 54.3 | 150.8 |
+| `sum_where` | 33.3 | 4.3 | 4.3 | 61.2 | 157.6 |
+| `take_count` | 3.6 | 0.2 | 0.4 | 3.0 | 3.0 |
 | `take_count_filtered` | 1.1 | 0.2 | 0.2 | 1.3 | 1.1 |
 | `take_sum_aggregate` | 0.8 | 0.1 | 0.1 | 0.6 | 0.6 |
 | `take_where_count` | 0.9 | 0.1 | 0.1 | 0.7 | 0.6 |
-| `take_while_match` | 7.8 | 2.4 | 2.4 | 28.7 | 73.7 |
-| `to_array_filter` | 70.3 | 12.3 | 12.4 | 72.2 | 170.4 |
-| `where_join_count` | 41.6 | 29.5 | 41.4 | 135.2 | 172.9 |
-| `zip_count_pred` | 39.4 | 15.0 | — | 320.5 | 339.7 |
-| `zip_dot_product` | 47.0 | 12.6 | 10.5 | 315.5 | 338.4 |
-| `zip_dot_product_3arg` | 46.7 | 12.9 | — | 314.7 | 337.6 |
-| `zip_reverse_to_array` | — | 31.0 | — | 346.3 | 372.4 |
+| `take_while_match` | 7.8 | 2.4 | 2.4 | 29.6 | 76.3 |
+| `to_array_filter` | 70.7 | 12.3 | 12.4 | 72.3 | 168.8 |
+| `where_join_count` | 41.7 | 29.6 | 41.5 | 135.5 | 177.3 |
+| `zip_count_pred` | 39.4 | 15.0 | — | 320.7 | 341.4 |
+| `zip_dot_product` | 47.2 | 12.6 | 10.5 | 318.6 | 338.9 |
+| `zip_dot_product_3arg` | 47.0 | 12.9 | — | 314.9 | 337.9 |
+| `zip_reverse_to_array` | — | 31.0 | — | 344.9 | 372.0 |
 
 ## JIT
 
 | Benchmark | SQL (m1) | Array (m3f) | Decs (m4) | XML fold (m5f) | JSON fold (m6f) |
 |---|---:|---:|---:|---:|---:|
-| `aggregate_match` | 34.9 | 0.3 | 0.7 | 16.5 | 34.1 |
-| `all_match` | 27.8 | 0.3 | 0.2 | 16.5 | 33.6 |
+| `aggregate_match` | 35.1 | 0.3 | 0.7 | 16.6 | 35.6 |
+| `all_match` | 28.1 | 0.3 | 0.2 | 16.6 | 35.2 |
 | `any_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
-| `average_aggregate` | 30.4 | 1.0 | 3.6 | 16.5 | 34.0 |
-| `bare_order_where` | 185.5 | 34.2 | 35.5 | 106.5 | 60.1 |
-| `chained_select_collapse` | — | 2.1 | 2.2 | 21.4 | 37.6 |
-| `chained_where` | 36.6 | 0.6 | 0.8 | 40.7 | 17.4 |
-| `contains_match` | 0.0 | 0.2 | 0.1 | 14.7 | 13.8 |
-| `count_aggregate` | 30.0 | 0.3 | 0.6 | 16.5 | 33.9 |
-| `cross_join` | 6016.6 | 720.3 | — | 848.9 | 772.0 |
+| `average_aggregate` | 30.6 | 1.0 | 3.5 | 16.5 | 36.1 |
+| `bare_last` | — | 0.4 | 0.0 | 0.0 | 0.0 |
+| `bare_order_where` | 186.0 | 34.2 | 35.4 | 106.4 | 60.4 |
+| `chained_select_collapse` | — | 2.1 | 2.1 | 21.4 | 39.7 |
+| `chained_where` | 36.6 | 0.6 | 0.8 | 40.7 | 18.6 |
+| `contains_match` | 0.0 | 0.2 | 0.1 | 17.6 | 13.6 |
+| `count_aggregate` | 29.9 | 0.3 | 0.6 | 16.7 | 36.3 |
+| `cross_join` | 5969.5 | 723.3 | — | 856.9 | 779.2 |
 | `decs_count_bare_pred` | — | — | 0.6 | — | — |
-| `distinct_by_count` | 41.7 | 2.1 | 2.1 | 21.3 | 48.0 |
-| `distinct_by_order_take` | 240.6 | 2.6 | 3.2 | 45.5 | 52.2 |
-| `distinct_by_order_to_array` | 237.8 | 2.7 | 3.3 | 48.0 | 50.4 |
-| `distinct_count` | 41.6 | 2.1 | 2.1 | 21.2 | 38.2 |
-| `distinct_count_pred` | 252.4 | 2.1 | 2.3 | 39.4 | 44.7 |
-| `distinct_take` | 0.0 | 0.0 | 0.0 | 0.0 | 0.1 |
+| `distinct_by_count` | 41.6 | 2.1 | 2.1 | 21.4 | 50.1 |
+| `distinct_by_order_take` | 239.8 | 2.6 | 3.2 | 45.6 | 52.4 |
+| `distinct_by_order_to_array` | 239.7 | 2.7 | 3.3 | 48.2 | 53.2 |
+| `distinct_count` | 41.9 | 2.1 | 2.1 | 21.3 | 40.5 |
+| `distinct_count_pred` | 251.9 | 2.1 | 2.3 | 39.4 | 47.4 |
+| `distinct_take` | 0.0 | 0.0 | 0.0 | 0.1 | 0.2 |
 | `element_at_match` | 0.0 | 0.0 | 0.0 | 0.1 | 0.0 |
 | `first_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
 | `first_or_default_match` | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
-| `groupby_average` | 175.9 | 2.6 | 2.9 | 35.9 | 63.2 |
-| `groupby_count` | 141.3 | 2.4 | 2.5 | 21.3 | 38.4 |
-| `groupby_first` | 250.6 | 2.3 | 3.1 | 21.3 | 38.4 |
-| `groupby_having_count` | 141.6 | 2.4 | 2.5 | 21.4 | 38.1 |
-| `groupby_having_hidden_sum` | 175.0 | 2.5 | 2.8 | 38.1 | 63.0 |
-| `groupby_having_post_where` | 170.8 | 2.4 | 2.7 | 35.6 | 62.7 |
-| `groupby_max` | 174.2 | 2.4 | 2.7 | 36.0 | 62.3 |
-| `groupby_min` | 173.2 | 2.4 | 2.7 | 38.2 | 62.9 |
-| `groupby_multi_reducer` | 189.9 | 2.7 | 3.0 | 36.1 | 63.7 |
-| `groupby_select_order` | 170.6 | 2.4 | 2.7 | 38.2 | 62.2 |
-| `groupby_select_sum` | 202.7 | 3.2 | 3.7 | 33.7 | 46.7 |
-| `groupby_sum` | 170.7 | 2.4 | 2.7 | 35.7 | 62.7 |
-| `groupby_where_count` | 75.8 | 1.5 | 1.8 | 38.0 | 58.5 |
-| `groupby_where_sum` | 87.0 | 1.5 | 1.8 | 35.4 | 57.2 |
-| `indexed_lookup` | 1257.2 | 32478.1 | 106.3 | 4365676.5 | 3059866.5 |
-| `join_count` | 38.4 | 11.8 | 12.9 | 47.9 | 66.4 |
-| `join_groupby_count` | 157.3 | 19.7 | 22.0 | 68.0 | 84.2 |
-| `join_groupby_to_array` | 189.8 | 19.8 | 22.0 | 80.3 | 39.9 |
-| `join_select` | 93.9 | 20.2 | 22.7 | 74.7 | 99.2 |
-| `join_where_count` | 39.2 | 20.5 | 21.7 | 66.0 | 65.5 |
-| `last_match` | 0.0 | 0.6 | 1.4 | 20.3 | 34.1 |
-| `long_count_aggregate` | 29.8 | 0.3 | 0.6 | 16.5 | 33.9 |
-| `max_aggregate` | 31.1 | 0.3 | 0.5 | 16.7 | 33.8 |
-| `min_aggregate` | 31.3 | 0.3 | 0.5 | 16.7 | 33.7 |
-| `order_by_multi_key` | 245.6 | 53.8 | 54.8 | 125.6 | 76.3 |
-| `order_distinct_take` | 138.0 | 2.1 | 76.3 | 21.2 | 38.1 |
-| `order_reverse_normalized` | 38.5 | 0.7 | 1.4 | 20.8 | 33.5 |
-| `order_take_desc` | 38.3 | 0.7 | 1.4 | 21.1 | 33.5 |
-| `reverse_distinct_by` | 294.3 | 2.6 | 5.0 | 22.0 | 41.7 |
-| `reverse_take` | 0.0 | 0.0 | 1.1 | 0.0 | 3.6 |
-| `reverse_take_select` | 0.0 | 0.0 | 1.1 | 0.0 | 3.7 |
-| `select_count` | 0.1 | 0.0 | 0.0 | 63.4 | 0.0 |
-| `select_many` | — | 61.4 | — | — | — |
-| `select_where` | 108.4 | 4.2 | 5.5 | 76.5 | 27.5 |
-| `select_where_count` | 32.9 | 0.3 | 0.6 | 16.4 | 34.1 |
-| `select_where_order_take` | 36.8 | 0.7 | 1.4 | 20.3 | 35.2 |
-| `select_where_sum` | 37.3 | 0.4 | 0.6 | 16.4 | 33.8 |
-| `single_match` | 0.0 | 0.4 | 1.1 | 44.4 | 36.1 |
+| `groupby_average` | 174.4 | 2.6 | 2.9 | 35.8 | 66.0 |
+| `groupby_count` | 142.8 | 2.3 | 2.5 | 21.3 | 40.1 |
+| `groupby_first` | 262.9 | 2.2 | 3.1 | 21.3 | 40.7 |
+| `groupby_having_count` | 144.5 | 2.3 | 2.5 | 21.4 | 40.4 |
+| `groupby_having_hidden_sum` | 179.0 | 2.5 | 2.8 | 38.2 | 66.6 |
+| `groupby_having_post_where` | 175.9 | 2.4 | 2.7 | 35.7 | 65.7 |
+| `groupby_max` | 178.0 | 2.4 | 2.7 | 36.0 | 66.1 |
+| `groupby_min` | 177.4 | 2.4 | 2.7 | 38.2 | 65.6 |
+| `groupby_multi_reducer` | 202.6 | 2.7 | 3.0 | 36.2 | 66.6 |
+| `groupby_select_order` | 174.6 | 2.4 | 2.7 | 38.2 | 65.3 |
+| `groupby_select_sum` | 200.1 | 3.2 | 3.7 | 33.9 | 49.7 |
+| `groupby_sum` | 170.7 | 2.4 | 2.7 | 35.8 | 66.1 |
+| `groupby_where_count` | 75.8 | 1.5 | 1.8 | 37.8 | 62.1 |
+| `groupby_where_sum` | 86.5 | 1.5 | 1.8 | 35.4 | 60.3 |
+| `indexed_lookup` | 1248.1 | 33115.9 | 105.5 | 4525953.3 | 3080167.2 |
+| `join_count` | 38.6 | 11.8 | 12.9 | 48.1 | 68.9 |
+| `join_groupby_count` | 157.2 | 19.6 | 22.0 | 68.3 | 85.8 |
+| `join_groupby_to_array` | 190.6 | 19.7 | 21.9 | 80.6 | 40.8 |
+| `join_select` | 93.2 | 20.2 | 22.6 | 74.9 | 103.5 |
+| `join_where_count` | 39.3 | 19.8 | 21.6 | 66.0 | 68.2 |
+| `last_match` | 0.0 | 0.5 | 1.4 | 20.2 | 36.2 |
+| `long_count_aggregate` | 29.7 | 0.3 | 0.6 | 16.7 | 35.9 |
+| `max_aggregate` | 31.2 | 0.3 | 0.5 | 16.9 | 35.8 |
+| `min_aggregate` | 31.1 | 0.3 | 0.5 | 16.9 | 35.7 |
+| `order_by_multi_key` | 250.0 | 53.6 | 54.8 | 125.7 | 79.3 |
+| `order_distinct_take` | 139.2 | 2.1 | 76.3 | 21.4 | 40.2 |
+| `order_reverse_normalized` | 38.5 | 0.7 | 1.3 | 20.9 | 35.7 |
+| `order_take_desc` | 38.3 | 0.7 | 1.4 | 21.3 | 35.4 |
+| `reverse_distinct_by` | 295.3 | 2.6 | 5.0 | 22.0 | 44.0 |
+| `reverse_take` | 0.0 | 0.0 | 0.0 | 0.0 | 3.7 |
+| `reverse_take_select` | 0.0 | 0.0 | 0.0 | 0.0 | 3.8 |
+| `select_count` | 0.1 | 0.0 | 0.0 | 65.5 | 0.0 |
+| `select_many` | — | 63.0 | — | — | — |
+| `select_where` | 108.0 | 4.2 | 5.5 | 76.7 | 28.9 |
+| `select_where_count` | 32.9 | 0.3 | 0.6 | 16.7 | 35.3 |
+| `select_where_order_take` | 37.0 | 0.7 | 1.4 | 20.4 | 37.3 |
+| `select_where_sum` | 37.1 | 0.4 | 0.6 | 16.6 | 35.7 |
+| `single_match` | 0.0 | 0.4 | 1.1 | 45.1 | 37.9 |
 | `skip_take` | 0.3 | 0.0 | 0.0 | 1.3 | 0.3 |
-| `skip_while_match` | 3.4 | 0.4 | 0.4 | 43.9 | 28.9 |
-| `sort_first` | 38.1 | 0.4 | 1.3 | 19.4 | 33.0 |
-| `sort_take` | 38.5 | 0.7 | 1.4 | 21.1 | 33.5 |
-| `sort_take_select` | 38.3 | 0.7 | 1.4 | 20.1 | 33.3 |
-| `sum_aggregate` | 30.7 | 0.3 | 0.1 | 16.8 | 33.9 |
-| `sum_where` | 33.1 | 0.3 | 0.6 | 16.4 | 33.7 |
-| `take_count` | 1.8 | 0.1 | 0.1 | 1.2 | 0.4 |
+| `skip_while_match` | 3.5 | 0.4 | 0.4 | 46.3 | 30.2 |
+| `sort_first` | 38.1 | 0.4 | 1.3 | 19.6 | 35.0 |
+| `sort_take` | 38.4 | 0.7 | 1.3 | 21.3 | 35.4 |
+| `sort_take_select` | 38.4 | 0.7 | 1.4 | 20.3 | 35.5 |
+| `sum_aggregate` | 30.4 | 0.3 | 0.1 | 16.8 | 35.8 |
+| `sum_where` | 33.3 | 0.3 | 0.6 | 16.6 | 35.8 |
+| `take_count` | 1.8 | 0.1 | 0.1 | 1.3 | 0.4 |
 | `take_count_filtered` | 1.1 | 0.0 | 0.0 | 0.4 | 0.2 |
 | `take_sum_aggregate` | 0.8 | 0.0 | 0.0 | 0.2 | 0.1 |
 | `take_where_count` | 0.9 | 0.0 | 0.0 | 0.2 | 0.1 |
-| `take_while_match` | 7.8 | 0.2 | 0.3 | 16.2 | 13.1 |
-| `to_array_filter` | 48.3 | 3.3 | 3.4 | 20.0 | 41.2 |
-| `where_join_count` | 41.1 | 6.4 | 7.4 | 47.8 | 51.6 |
-| `zip_count_pred` | 39.3 | 0.1 | — | 115.0 | 36.5 |
-| `zip_dot_product` | 46.8 | 0.1 | 0.1 | 114.8 | 36.6 |
-| `zip_dot_product_3arg` | 47.3 | 0.1 | — | 115.1 | 38.4 |
-| `zip_reverse_to_array` | — | 4.6 | — | 122.5 | 49.0 |
+| `take_while_match` | 7.8 | 0.2 | 0.3 | 16.5 | 13.4 |
+| `to_array_filter` | 48.5 | 3.3 | 3.4 | 20.2 | 44.1 |
+| `where_join_count` | 41.6 | 6.4 | 7.4 | 48.1 | 52.5 |
+| `zip_count_pred` | 39.2 | 0.1 | — | 115.1 | 37.4 |
+| `zip_dot_product` | 47.0 | 0.1 | 0.1 | 114.6 | 37.8 |
+| `zip_dot_product_3arg` | 46.8 | 0.1 | — | 116.0 | 36.7 |
+| `zip_reverse_to_array` | — | 4.6 | — | 123.1 | 49.1 |
 <!-- BENCH:TABLES END -->
 
 ## Notes on missing lanes (the `—` cells)
@@ -294,6 +298,11 @@ whether the gap is window-function / surface-limitation / by-design,
 and which gaps could land in a single PR — see
 [`sqlite_linq_gaps.md`](sqlite_linq_gaps.md).
 
+- **`bare_last` SQL (m1)** — bare `.last()` has no SQL analog: SQLite has no
+  inherent row ordering, so `_sql` rejects bare `reverse()` / `last()` (use
+  `_order_by_descending(...)` for sort reversal). Bare last is only meaningful for
+  sources with a natural order — array (index), decs (archetype storage order),
+  XML (document order), JSON (array order). By design.
 - **`chained_select_collapse` SQL** — `_sql` rejects `distinct() |> count()`
   as non-translatable. The equivalent SQL `COUNT(DISTINCT computed-expr)`
   isn't currently emitted by sqlite_linq's surface. By design — no follow-up.
@@ -396,9 +405,12 @@ srcElem-typed scratch buffer during the backward loop, then a post-loop
 typed output buffer (K projection push_clones). Two-buffer/two-pass
 mirrors the decs sibling and R1-R4 catch-all discipline (all source
 reads complete before any projection runs — impure `_select` semantics
-match across the three paths). Both m3f and m4 are now sub-resolution
-per-op (the 2K push_clones for K=10 amortize over chunk_size=100K and
-round to 0.0 ns/op in INTERP and JIT).
+match across the three paths). m3f went sub-resolution then (the 2K
+push_clones for K=10 amortize over chunk_size=100K and round to 0.0).
+m4 followed only once the boundary archetype was **random-indexed**
+rather than `continue`-walked (`reverse_take[_select]` m4 9.3 → 0.2
+INTERP, 1.1 → 0.0 JIT — see the header note); the projection amortizes
+to 0.0 on both.
 
 ## How to re-run
 

--- a/daslib/linq_fold_decs.das
+++ b/daslib/linq_fold_decs.das
@@ -14,7 +14,6 @@ require daslib/ast_boost
 require daslib/ast_match
 require daslib/templates_boost
 require daslib/macro_boost
-require strings
 require daslib/linq_fold_common public
 
 // Stamp the assembled decs walk with the call-site LineInfo + the generated flag, optionally
@@ -363,6 +362,19 @@ def emit_loop_or_count_lane_decs(var bridge : DecsBridgeShape?; tupName : string
     }
     if (isMinMaxBy) return emit_decs_min_max_by(bridge, termName, chainInfo, rangeInfo, calls, rangeInfo.chainEnd, termCall, at)
     if (isEarlyExit || isWalk || isElementAt) {
+        // No-predicate `last()` / `last_or_default()` over indexable decs sources: read the last
+        // archetype's [size-1] directly (O(num_archetypes)), behavior-identical to the walk. Predicated/
+        // chained/ranged last can't random-index → keeps the walk. Gate: empty chain, no ranges, indexable.
+        if ((termName == "last" || termName == "last_or_default")
+                && rangeInfo.chainEnd == 0
+                && rangeInfo.skipExpr == null && rangeInfo.takeExpr == null
+                && rangeInfo.skipWhileCond == null && rangeInfo.takeWhileCond == null
+                && rangeInfo.postTakeWhereCond == null
+                && chainInfo.selectCount == 0
+                && decs_can_random_index(bridge)) {
+            var fast = emit_decs_last_random_index(bridge, termName, termCall, chainInfo.finalType, at)
+            if (fast != null) return fast
+        }
         // first/first_or_default/any/all/contains/last/single/single_or_default/aggregate/element_at — the
         // shared early-exit lane. The DecsAdapter walks (chain+ranges+for_each{,_find}); the lane supplies the
         // per-op !supports_direct_return state path + the adapter's effective dispatch (Each→Find under take).
@@ -422,7 +434,6 @@ def emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBr
     let projBufName = qn("decs_rts_buf", at)
     let archName = bridge.archName
     var bufElemType = strip_const_ref(clone_type(bridge.elementType))
-    let tupBind = build_decs_tup_bind(bridge, tupName, at)
     var projBody : Expression?
     var projType : TypeDeclPtr
     if (terminalSelectLam != null) {
@@ -431,22 +442,32 @@ def emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBr
         projType = strip_const_ref(clone_type(terminalSelectElemType))
         if (projType == null) return null
     }
-    var innerBody : Expression? = qmacro_block() {
-        if ($i(skipsLeftName) > 0_l) {
-            $i(skipsLeftName) --
-            continue
+    // Per-archetype tail collection. Indexable sources (get_ro): random-index the boundary archetype's
+    // tail [skipsLeft .. arch.size) instead of continue-walking its head (O(K), not O(N)). Iterator
+    // sources (default-init field → get_default_ro): keep the walk-and-skip. Both fill buf forward.
+    var collectExpr : Expression?
+    if (decs_can_random_index(bridge)) {
+        collectExpr = build_decs_index_collect(bridge, bufName, skipsLeftName, actualName, at)
+    } else {
+        let tupBind = build_decs_tup_bind(bridge, tupName, at)
+        var innerBody : Expression? = qmacro_block() {
+            if ($i(skipsLeftName) > 0_l) {
+                $i(skipsLeftName) --
+                continue
+            }
+            $e(tupBind)
+            $i(bufName) |> push_clone($i(tupName))
+            if (long_length($i(bufName)) >= $i(actualName)) {
+                break
+            }
         }
-        $e(tupBind)
-        $i(bufName) |> push_clone($i(tupName))
-        if (long_length($i(bufName)) >= $i(actualName)) {
-            break
-        }
+        var clonedForExpr = clone_expression(bridge.forExpr)
+        var clonedFor = clonedForExpr as ExprFor
+        var newForBody = new ExprBlock(at = at)
+        newForBody.list |> push(innerBody)
+        clonedFor.body = newForBody
+        collectExpr = clonedForExpr
     }
-    var clonedForExpr = clone_expression(bridge.forExpr)
-    var clonedFor = clonedForExpr as ExprFor
-    var newForBody = new ExprBlock(at = at)
-    newForBody.list |> push(innerBody)
-    clonedFor.body = newForBody
     var emission : Expression?
     if (terminalSelectLam == null) {
         emission = qmacro(invoke($() : array<$t(bufElemType)> {
@@ -469,7 +490,7 @@ def emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBr
                     return false
                 }
                 var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
-                $e(clonedForExpr)
+                $e(collectExpr)
                 $i(seenName) += $i(archName).size
                 return long_length($i(bufName)) >= $i(actualName)
             })
@@ -498,7 +519,7 @@ def emit_decs_reverse_skip_into_tail(var takeExpr : Expression?; bridge : DecsBr
                     return false
                 }
                 var $i(skipsLeftName) = ($i(skipName) > $i(seenName)) ? ($i(skipName) - $i(seenName)) : 0_l
-                $e(clonedForExpr)
+                $e(collectExpr)
                 $i(seenName) += $i(archName).size
                 return long_length($i(bufName)) >= $i(actualName)
             })
@@ -525,6 +546,113 @@ def build_decs_tup_bind(bridge : DecsBridgeShape?; tupName : string; at : LineIn
     return qmacro_expr() {
         var $i(tupName) = $e(mkTup)
     }
+}
+
+[macro_function]
+def decs_can_random_index(bridge : DecsBridgeShape?) : bool {
+    // Random-index needs every component source to be an indexable array (get_ro). A [decs_template]
+    // field carrying a default-init compiles to get_default_ro → an iterator (not indexable) → bail.
+    if (bridge == null || !(bridge.forExpr is ExprFor)) return false
+    var fe = bridge.forExpr as ExprFor
+    if (empty(fe.sources)) return false
+    for (s in fe.sources) {
+        if (s == null || s._type == null || s._type.baseType != Type.tArray) return false
+    }
+    return true
+}
+
+[macro_function]
+def build_decs_index_tup(bridge : DecsBridgeShape?; idxName : string; at : LineInfo) : Expression? {
+    // Named tuple `(userName_i = get_ro(arch, comp_i, def)[idx], ...)` — the bridge's component sources,
+    // indexed directly. get_ro is [unsafe_outside_of_for]; mark each source + the index read alwaysSafe
+    // (mirrors decs_boost append_index_lookup) so no `unsafe` wrap is needed.
+    var fe = bridge.forExpr as ExprFor
+    var mkTup = new ExprMakeTuple(at = at)
+    mkTup.recordNames |> resize(length(bridge.userNames))
+    for (i in 0 .. length(bridge.userNames)) {
+        mkTup.recordNames[i] := bridge.userNames[i]
+        var src = clone_expression(fe.sources[i])
+        src.genFlags.alwaysSafe = true
+        force_generated(src, true)
+        var idxExpr : Expression? = qmacro_expr() {
+            $e(src)[$i(idxName)]
+        }
+        idxExpr.genFlags.alwaysSafe = true
+        force_generated(idxExpr, true)
+        mkTup.values |> emplace_new(idxExpr)
+    }
+    return mkTup
+}
+
+[macro_function]
+def build_decs_index_collect(bridge : DecsBridgeShape?; bufName : string; skipsLeftName : string;
+                             actualName : string; at : LineInfo) : Expression? {
+    // reverse|>take tail collect: random-index [skipsLeft .. arch.size) into buf. Boundary archetype skips
+    // its head by indexing past it; later archetypes have skipsLeft==0. get_ro lives inside the idx for-loop.
+    let archName = bridge.archName
+    let idxName = qn("decs_rix", at)
+    var tup = build_decs_index_tup(bridge, idxName, at)
+    return qmacro_block() {
+        for ($i(idxName) in range64($i(skipsLeftName), $i(archName).size)) {
+            $i(bufName) |> push_clone($e(tup))
+            break if (long_length($i(bufName)) >= $i(actualName))
+        }
+    }
+}
+
+[macro_function]
+def emit_decs_last_random_index(bridge : DecsBridgeShape?; termName : string; var termCall : ExprCall?;
+                                elemType : TypeDeclPtr; at : LineInfo) : Expression? {
+    // No-predicate decs `last()` / `last_or_default()`: read the last non-empty archetype's [size-1]
+    // directly instead of walking all N. for_each_archetype visits in order + skips empties, so the last
+    // overwrite of res is the global-last (O(num_archetypes)). Caller gates trivial-chain + indexable.
+    var bt = strip_const_ref(clone_type(elemType))
+    if (bt == null) return null
+    let archName = bridge.archName
+    let liName = qn("decs_rli", at)
+    let foundName = qn("decs_rfound", at)
+    let resName = qn("decs_rres", at)
+    var tup = build_decs_index_tup(bridge, liName, at)
+    var archBody = qmacro_block() {
+        let $i(liName) = $i(archName).size - 1_l   // arch.size is int64 — no int truncation for >INT_MAX archetypes
+        $i(resName) := $e(tup)
+        $i(foundName) = true
+    }
+    var emission : Expression?
+    if (termName == "last") {
+        emission = qmacro(invoke($() : $t(bt) {
+            var $i(foundName) = false
+            var $i(resName) = default<$t(bt)>
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $e(archBody)
+            })
+            if (!$i(foundName)) {
+                panic("sequence contains no elements")
+            }
+            return <- $i(resName)
+        }))
+    } else {
+        // last_or_default: bind the user default EAGERLY before iteration (matches the walk lane's
+        // emit_default_bind, linq_fold_common) so its side effects fire even on a non-empty query;
+        // early-return it when empty. Lazy tail-only eval would diverge from the walk / iterator fallback.
+        let dvalName = qn("decs_rdval", at)
+        let dvCanCopy = (termCall.arguments[1]._type != null && termCall.arguments[1]._type.canCopy)
+        var bindStmt = emit_default_bind(dvalName, termCall.arguments[1], dvCanCopy)
+        var retStmt = emit_default_return(dvalName, dvCanCopy)
+        emission = qmacro(invoke($() : $t(bt) {
+            var $i(foundName) = false
+            var $i(resName) = default<$t(bt)>
+            $e(bindStmt)
+            for_each_archetype($e(bridge.reqHashExpr), $e(bridge.erqExpr), $($i(archName) : Archetype) {
+                $e(archBody)
+            })
+            if (!$i(foundName)) {
+                $e(retStmt)
+            }
+            return <- $i(resName)
+        }))
+    }
+    return finalize_decs_emission(emission, at, false)
 }
 
 [macro_function]

--- a/doc/source/reference/linq_fold_patterns.rst
+++ b/doc/source/reference/linq_fold_patterns.rst
@@ -309,7 +309,10 @@ identical — only the source iteration changes.
      - Per-archetype accumulator; pruner keeps only the components read by ``F``.
    * - ``from_decs_template(...).first()`` / ``.first_or_default()`` / ``.last()`` / ``.last_or_default()`` / ``.single()`` / ``.single_or_default()`` / ``.element_at(N)`` / ``.element_at_or_default(N)`` / ``.aggregate(...)``
      - ``plan_decs_unroll`` → ``emit_decs_walk_lane`` / ``emit_decs_element_at``
-     - Walk lane reads one component per loop iteration; element_at uses cumulative-size short-circuit.
+     - Walk lane reads one component per loop iteration; element_at uses cumulative-size short-circuit. Bare ``.last()`` / ``.last_or_default()`` (no ``_where`` / ``_select`` / range) over indexable sources take the random-index row below instead of this walk.
+   * - ``from_decs_template(...).last()`` / ``.last_or_default(D)`` — **bare** (no ``_where`` / ``_select`` / range)
+     - ``emit_decs_last_random_index``
+     - Reads the last non-empty archetype's ``[size-1]`` directly (``get_ro(arch, comp, def)[idx]``) — O(num_archetypes), no per-entity walk. ``for_each_archetype`` visits in order + skips empties, so the last overwrite is the global-last; behavior-identical to the walk lane. **Indexable sources only** — a ``[decs_template]`` field with a default-init compiles to ``get_default_ro`` (an iterator), so ``decs_can_random_index`` returns false and the chain cascades to the ``emit_decs_walk_lane`` row above.
    * - ``from_decs_template(...).any()`` / ``.all(P)`` / ``.contains(V)``
      - ``plan_decs_unroll`` → ``emit_decs_early_exit``
      - Boolean fast-path; walks until first match or end.
@@ -338,8 +341,8 @@ identical — only the source iteration changes.
      - ``plan_decs_distinct`` (predicate counter)
      - Decs mirror of the array-side predicate-distinct splice. Same dedup-unconditional / counter-gated-on-P shape across archetypes.
    * - ``from_decs_template(...).reverse().take(N)[._select(F)].to_array()``
-     - ``plan_decs_reverse`` (skip-into-tail; extended for terminal ``_select`` in PR #2915)
-     - Whole-archetype skip + partial-archetype skip-counter + early-exit. When trailing ``_select(F)`` is captured (no pre-reverse ``_where`` / ``_select``), the K reversed survivors are projected into a separate buffer typed by termsel's call-result element type — saves the catch-all's N push_clones + full reverse_inplace + project pass. Bails (cascades to R1-R4) when termsel's call-result element type is unresolved at macro stage.
+     - ``plan_decs_reverse`` (skip-into-tail; extended for terminal ``_select`` in PR #2915; boundary random-index added later)
+     - Whole-archetype skip + early-exit. For **indexable** sources the boundary archetype is **random-indexed** (``get_ro(arch, comp, def)[idx]`` over ``[skipsLeft .. size)`` via ``build_decs_index_collect``) instead of continue-walking its head — O(K) on a single archetype, not O(N). **Iterator** sources (a ``[decs_template]`` field with a default-init → ``get_default_ro``) fall back to the partial-archetype skip-counter walk. When trailing ``_select(F)`` is captured (no pre-reverse ``_where`` / ``_select``), the K reversed survivors are projected into a separate buffer typed by termsel's call-result element type — saves the catch-all's N push_clones + full reverse_inplace + project pass. Bails (cascades to R1-R4) when termsel's call-result element type is unresolved at macro stage.
    * - ``from_decs_template(...).reverse()._select(F).first()``
      - ``plan_decs_reverse`` (Rb walk-and-overwrite scalar with terminal ``_select``)
      - Decs mirror of ``plan_reverse``'s Rb walk-and-overwrite scalar. Projection applies to the surviving ``last`` value at return.

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -3526,3 +3526,178 @@ def test_decs_join_to_array_projection(t : T?) {
     t |> equal(length(seen), 6, "all 6 distinct car ids present")
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Random-index tail fast path: BARE last() / last_or_default() (no where/select)
+// over indexable decs sources read the last archetype's [size-1] directly instead
+// of walking all N. (Predicated / _select'd last keeps the walk — Slice 5f above.)
+// reverse|>take's random-index branch is exercised by the Unroll5dRow / RevTakeMultiArch
+// tests; here we add the get_default_ro iterator-source FALLBACK those don't reach.
+// ─────────────────────────────────────────────────────────────────────────────
+
+typedef UnrollTuple = tuple<val : int; flag : int>
+
+[export, marker(no_coverage)]
+def target_bare_last_fold() : UnrollTuple {
+    return _fold(from_decs_template(type<UnrollChainRow>).last())
+}
+
+[export, marker(no_coverage)]
+def target_bare_last_cascade() : UnrollTuple {
+    return from_decs_template(type<UnrollChainRow>) |> last()
+}
+
+[export, marker(no_coverage)]
+def target_bare_last_or_default_fold() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>).last_or_default((val = -1, flag = -1))).val
+}
+
+[test]
+def test_bare_last_parity(t : T?) {
+    fixture_unroll2(7)
+    let fast = target_bare_last_fold()
+    let cascade = target_bare_last_cascade()
+    // single archetype = insertion order → last is the 7th entity (val 6)
+    t |> equal(fast.val, 6, "bare last() reads the last entity")
+    t |> equal(fast.val, cascade.val, "bare last val == tier-2 cascade")
+    t |> equal(fast.flag, cascade.flag, "bare last flag == tier-2 cascade")
+}
+
+[test]
+def test_bare_last_or_default_empty(t : T?) {
+    restart()
+    commit()
+    t |> equal(target_bare_last_or_default_fold(), -1, "bare last_or_default empty → explicit default")
+}
+
+[test]
+def test_bare_last_or_default_nonempty(t : T?) {
+    fixture_unroll2(5)
+    t |> equal(target_bare_last_or_default_fold(), 4, "bare last_or_default nonempty → last val")
+}
+
+// Eager-eval regression: the default expr must be bound BEFORE iteration (matches the walk lane),
+// so its side effects fire even when the query is non-empty. A lazy tail-only eval would skip them.
+var g_bare_default_evals = 0
+
+def private bare_side_effecting_default() : UnrollTuple {
+    g_bare_default_evals++
+    return (val = -77, flag = -77)
+}
+
+[export, marker(no_coverage)]
+def target_bare_last_or_default_sidefx() : int {
+    return _fold(from_decs_template(type<UnrollChainRow>).last_or_default(bare_side_effecting_default())).val
+}
+
+[test]
+def test_bare_last_or_default_eager_eval(t : T?) {
+    fixture_unroll2(5)
+    g_bare_default_evals = 0
+    let v = target_bare_last_or_default_sidefx()
+    t |> equal(v, 4, "non-empty → last val, not the default")
+    t |> equal(g_bare_default_evals, 1, "default expr evaluated eagerly even when query non-empty")
+}
+
+// Proves the random-index fast path fired: bare last() emits a single void
+// for_each_archetype with NO per-entity inner for-loop (the walk path clones the
+// bridge for-loop → count_expr_for >= 1). No to_sequence, no _find.
+[test]
+def test_bare_last_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_bare_last_fold)
+        t |> success(func != null, "RTTI must resolve target_bare_last_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> equal(describe_count(body_expr, "to_sequence"), 0, "bare last must NOT call to_sequence")
+        t |> equal(describe_count(body_expr, "for_each_archetype_find"), 0, "bare last uses void for_each_archetype")
+        t |> equal(describe_count(body_expr, "for_each_archetype"), 1, "exactly one for_each_archetype")
+        t |> equal(count_expr_for(body_expr), 0, "random-index last has NO per-entity inner for-loop")
+    }
+}
+
+// Iterator fallback: a default-init field compiles to get_default_ro (an iterator,
+// not an indexable array), so decs_can_random_index → false. bare last() / reverse.take
+// must still be correct via the walk fallback — checked vs the tier-2 cascade.
+[decs_template(prefix = "fb_")]
+struct FallbackRow {
+    val : int
+    hp  : int = 100
+}
+
+def private fixture_fallback(n : int) {
+    restart()
+    create_entities(n) $(_eid : EntityId; i : int; var cmp : ComponentMap) {
+        apply_decs_template(cmp, FallbackRow(val = i, hp = i + 1))
+    }
+}
+
+[export, marker(no_coverage)]
+def target_fb_last_fold() : tuple<val : int; hp : int> {
+    return _fold(from_decs_template(type<FallbackRow>).last())
+}
+
+[export, marker(no_coverage)]
+def target_fb_last_cascade() : tuple<val : int; hp : int> {
+    return from_decs_template(type<FallbackRow>) |> last()
+}
+
+[export, marker(no_coverage)]
+def target_fb_reverse_take_fold() : array<tuple<val : int; hp : int>> {
+    return <- _fold(from_decs_template(type<FallbackRow>).reverse().take(2).to_array())
+}
+
+[export, marker(no_coverage)]
+def target_fb_reverse_take_cascade() : array<tuple<val : int; hp : int>> {
+    return <- (from_decs_template(type<FallbackRow>) |> reverse() |> take(2) |> to_array())
+}
+
+[test]
+def test_fb_last_parity(t : T?) {
+    fixture_fallback(6)
+    let fast = target_fb_last_fold()
+    let cascade = target_fb_last_cascade()
+    // assert the default-init field hp too (= i+1 = 6) — that's what forces the iterator-source fallback
+    t |> equal(fast.val, 5, "fallback bare last() correct via walk")
+    t |> equal(fast.hp, 6, "fallback bare last() default-init field via walk")
+    t |> equal(fast.val, cascade.val, "fallback last val == cascade")
+    t |> equal(fast.hp, cascade.hp, "fallback last hp == cascade")
+}
+
+[test]
+def test_fb_reverse_take_parity(t : T?) {
+    fixture_fallback(6)
+    let fast <- target_fb_reverse_take_fold()
+    let cascade <- target_fb_reverse_take_cascade()
+    t |> equal(length(fast), 2, "fallback reverse.take(2) → 2 elements")
+    t |> equal(length(fast), length(cascade), "fallback fast len == cascade len")
+    for (a, b in fast, cascade) {
+        t |> equal(a.val, b.val, "fallback reverse take val parity")
+        t |> equal(a.hp, b.hp, "fallback reverse take hp parity")   // hp is the default-init field forcing the fallback
+    }
+    t |> equal(fast[0].val, 5, "fallback reverse take [0] val")
+    t |> equal(fast[0].hp, 6, "fallback reverse take [0] hp")
+    t |> equal(fast[1].val, 4, "fallback reverse take [1] val")
+    t |> equal(fast[1].hp, 5, "fallback reverse take [1] hp")
+}
+
+// The fallback emission must take the walk (clones the bridge for-loop) — proven by
+// the presence of a per-entity inner for-loop, which the random-index path lacks.
+[test]
+def test_fb_last_splice_shape(t : T?) {
+    ast_gc_guard() {
+        var func = find_module_function_via_rtti(compiling_module(), @@target_fb_last_fold)
+        t |> success(func != null, "RTTI must resolve target_fb_last_fold")
+        if (func == null) return
+        var body_expr : ExpressionPtr
+        let r = qmatch_function(func) $() {
+            return <- $e(body_expr)
+        }
+        t |> success(r.matched && body_expr is ExprInvoke, "expected splice invoke wrapper")
+        t |> success(count_expr_for(body_expr) >= 1, "fallback last walks → has a per-entity inner for-loop")
+    }
+}
+


### PR DESCRIPTION
## What

The `DecsAdapter` is random-access SoA storage, but the `_fold` decs lane never exploited it for tail-bounded shapes. Two no-predicate ops paid an O(*N*) walk to reach the **end** of storage:

| Shape | Before | After |
|---|---|---|
| `from_decs_template(T).last()` / `.last_or_default(D)` | generic forward walk, rebinds the whole tuple per element | reads the last non-empty archetype's `[size-1]` directly (`emit_decs_last_random_index`, O(num_archetypes)) |
| `from_decs_template(T).reverse() \|> take(K)` | whole-archetype skip, but **`continue`-walked the boundary archetype's head** (O(*N*) on one archetype) | random-indexes the boundary archetype's tail `[skipsLeft .. size)` (`build_decs_index_collect`, O(*K*)) |

Both now read `get_ro(arch, comp, def)[idx]` directly. Behavior-identical to the walk (same `for_each_archetype` order, same index pick); the result tuple is **clone-assigned** (`:=`) so string fields are owned, not dangling `comp.data` views.

This mirrors the XML backward-DOM reverse work (#3009) for the decs source. decs query order **is** storage order (entities append at `arch.size++`), so `last()` = last-created and `reverse \|> take(K)` = last *K* — no more arbitrary than `array.last()`, which `_fold` already optimizes.

## Scope / safety

- **Indexable sources only.** A `[decs_template]` field with a default-init compiles to `get_default_ro` (an iterator, not random-indexable), so `decs_can_random_index` returns `false` and the chain **cascades to the existing walk lane** — graceful, behavior-identical, regression-free. A dedicated test exercises this fallback.
- **No-predicate / no-chain only.** Predicated or `_select`'d `last` keeps the walk (the last-*match* position is unknown). Gate: empty chain, no ranges, `selectCount == 0`, all sources indexable.
- The `get_ro` reads (`[unsafe_outside_of_for]`) are marked `genFlags.alwaysSafe` (the documented `decs_boost` `append_index_lookup` idiom) — no `unsafe` syntax in the emission.

## Perf (`benchmarks/sql`, ns/op @ N=100k)

| family · m4 (decs) | before | after |
|---|---|---|
| `bare_last` (new) | ~17 / ~1.2 | **0.0 / 0.0** |
| `reverse_take` | 9.2 / 1.1 | **0.2 / 0.0** |
| `reverse_take_select` | 9.3 / 1.1 | **0.2 / 0.0** |

decs is now level with the XML backward-DOM path (m5f 0.0) and below array's still-walking `last()` (m3f 4.2). Full `benchmarks/sql` re-sweep done; only the decs (m4) cells for these families moved — all others stable within long-sweep thermal noise.

## Tests / verification

- **INTERP** `tests/` full: 10372/10379 pass (the lone error was `tests/language/enumerations.das` needing #3010's typer fix, which a local rebuild picked up — unrelated to this change).
- **AOT** full suite: 9723 passed, 0 failed, 0 errors (regenerated `_aot_generated` cpp with the new emission).
- **JIT** smoke: verifier-clean; `test_linq_from_decs.das` 216/216 under `-jit`.
- New tests assert the fast path fires (splice-shape: no inner `for`-loop) **and** the iterator source walks (the fallback).
- CI lint clean (4 files, 0 issues); formatter `--verify` clean; Sphinx `-W` HTML clean.

## Files

- `daslib/linq_fold_decs.das` — `decs_can_random_index` guard, `build_decs_index_tup` / `build_decs_index_collect`, `emit_decs_last_random_index` + the `isWalk` gate, random-index branch in `emit_decs_reverse_skip_into_tail`
- `tests/linq/test_linq_from_decs.das` — bare `last`/`last_or_default` parity + splice-shape + iterator-fallback
- `benchmarks/sql/bare_last.das` (new 4-lane; SQL omitted — no inherent row order), `benchmarks/micro/bare_last_decs_shapes.das` (floor-evidence probe)
- `benchmarks/sql/results.md` (re-swept + prose), `doc/source/reference/linq_fold_patterns.rst` (decs reverse/last rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)