### PR TITLE
docs/sql: audit tutorials vs implementation — fix stale deferrals, wrong SQL, missing coverage

### DIFF
--- a/doc/source/reference/tutorials/sql_02_insert_data.rst
+++ b/doc/source/reference/tutorials/sql_02_insert_data.rst
@@ -53,18 +53,24 @@ struct's namespace:
 User code rarely calls these directly — the user-facing CRUD generics
 below dispatch to them.
 
-Each field's SQL type is resolved through the convention
-``sqlite_sql_type(witness : T) : string``. Built-in primitives
-(``int``, ``int64``, ``float``, ``double``, ``string``, ``bool``)
-ship with overloads. To support a custom type, add your own
-overload — no registration required:
+Each field is stored through a bidirectional adapter pair defined
+next to its type: ``sql_bind`` maps the value to a SQLite primitive,
+``sql_extract`` maps it back. Built-in primitives (every
+``int``/``uint`` width, ``float``, ``double``, ``string``,
+``array<uint8>``, ``bool``, and enums) ship with pairs. To support a
+custom type, add your own pair — no registration required:
 
 .. code-block:: das
 
-    def sqlite_sql_type(witness : MyType) : string { return "TEXT" }
-    def sqlite_bind(var stmt : sqlite3_stmt?; idx : int; value : MyType) : void { ... }
+    def sql_bind(v : MyType) : string { return ... }
+    [unused_argument(t)]
+    def sql_extract(v : string; t : type<MyType>) : MyType { return ... }
 
-Tutorial 26 covers the custom-type adapter rail in full.
+The primitive ``P`` returned by ``sql_bind`` is one of
+``int64`` / ``double`` / ``string`` / ``array<uint8>``, and that
+return type alone picks the column's storage class — there is no
+separate DDL-type override. Tutorial 26 covers the custom-type
+adapter rail in full.
 
 CREATE / DROP
 =============
@@ -166,8 +172,8 @@ Helper                                                Description
 ``db |> insert(row)``                                 Single-row INSERT, returns assigned rowid
 ``db |> insert(array<row>)``                          Batched INSERT in one transaction
 ``db |> try_insert(row) : Result<int64, string>``     Non-panic single-row INSERT
-``sqlite_sql_type(witness : T)``                      Convention for column-type DDL string
-``sqlite_bind(stmt, idx, value : T)``                 Convention for binding a value to a placeholder
+``def sql_bind(v : T) : P``                           Adapter: value → SQLite primitive ``P``
+``def sql_extract(v : P; t : type<T>) : T``           Adapter: ``P`` → value (``P`` picks storage)
 ====================================================  ================================================
 
 .. seealso::

--- a/doc/source/reference/tutorials/sql_04_select_all.rst
+++ b/doc/source/reference/tutorials/sql_04_select_all.rst
@@ -48,8 +48,9 @@ into ``array<T>``:
 
 The macro emits the SQL ``SELECT "Id", "Name", "Price" FROM "Cars"``
 and the runtime materializes each row into a ``Car`` via the
-per-field ``sqlite_read`` overloads ``[sql_table]`` generates. The
-move-assign ``<-`` is required because ``array<Car>`` is non-copyable.
+generated ``_sql_read_row`` reader, which dispatches to the per-type
+``sql_extract`` adapter. The move-assign ``<-`` is required because
+``array<Car>`` is non-copyable.
 
 Filtering with ``_where`` (bind capture)
 ========================================
@@ -73,9 +74,12 @@ either a column reference (``_.X``) or a captured value (everything
 else), and routes them to the SQL identifier vs. bind list
 accordingly. Multiple ``_where`` calls compose AND-wise.
 
-Supported operators inside ``_where``: ``==``, ``!=``, ``<``, ``<=``,
-``>``, ``>=``, ``&&``, ``||``, ``!``. The captured side may be a
-literal or a free variable from any enclosing scope.
+Comparison/boolean operators recognized here: ``==``, ``!=``, ``<``,
+``<=``, ``>``, ``>=``, ``&&``, ``||``, ``!``. The captured side may be
+a literal or a free variable from any enclosing scope. The predicate
+surface is much wider than this (arithmetic, bitwise, string, and
+function calls all translate) --- see :ref:`tutorial_sql_where` for
+the full set.
 
 Projecting a single column with ``_select``
 ===========================================

--- a/doc/source/reference/tutorials/sql_07_anatomy.rst
+++ b/doc/source/reference/tutorials/sql_07_anatomy.rst
@@ -81,7 +81,7 @@ Each ``_where`` adds another ``AND`` conjunct:
     _sql(db |> select_from(type<Car>)
            |> _where(_.Price > 100)
            |> _where(_.Name |> starts_with("T")))
-    // ... WHERE ("Name" LIKE ? || '%') AND ("Price" > ?)
+    // ... WHERE ("Price" > ?) AND ("Name" LIKE ? ESCAPE '\')
 
 The full ``_where`` translation surface lives in
 :ref:`tutorial_sql_where`.
@@ -127,10 +127,13 @@ Tutorial                                          Surface
 What ``_sql`` refuses
 =====================
 
-If you write a shape outside the translation table --- an arbitrary
-user-defined function in ``_where``, an unsupported math op, a regex
---- compile fails with ``macro_error`` pointing at the offending
-node. Two responses:
+Most predicate shapes translate: arithmetic (``+ - * / %``), bitwise
+(``& | << >>``), unary (``- ~``), string concat (``+`` → ``||``), and
+workhorse casts (``int()`` → ``CAST``) all lower to SQL.
+``[sql_function]``-annotated functions translate too. What hard-rejects
+is narrow --- bitwise XOR (``^``), an *unannotated* user-defined
+function in ``_where``, or a regex --- and compile fails with
+``macro_error`` pointing at the offending node. Two responses:
 
 - Add the rule to the analyzer (fork-and-extend) if the pattern is
   reusable across queries.

--- a/doc/source/reference/tutorials/sql_08_where.rst
+++ b/doc/source/reference/tutorials/sql_08_where.rst
@@ -33,13 +33,23 @@ Source shape                                  Lowered SQL
 ``+`` ``-`` ``*`` ``/`` ``%`` (numeric)       same operators
 ``a + b`` (strings)                           ``(a) || (b)``  (SQL string concatenation)
 ``&`` ``|`` ``<<`` ``>>``, unary ``-`` ``~``  same operators
-``s |> starts_with(p)``                       ``s LIKE ? || '%'``        (``p`` bound)
-``s |> ends_with(p)``                         ``s LIKE '%' || ?``        (``p`` bound)
-``s |> contains(p)``                          ``s LIKE '%' || ? || '%'`` (``p`` bound)
+``s |> starts_with(p)``                       ``s LIKE ? ESCAPE '\'``  (bind ``p`` + ``%``)
+``s |> ends_with(p)``                         ``s LIKE ? ESCAPE '\'``  (bind ``%`` + ``p``)
+``s |> contains(p)``                          ``s LIKE ? ESCAPE '\'``  (bind ``%`` + ``p`` + ``%``)
 ``s |> to_lower()``, ``s |> to_upper()``      ``LOWER(s)``, ``UPPER(s)``
 ``length(s)``                                 ``LENGTH(s)``
 ``x |> abs()``                                ``ABS(x)``
+``x |> is_some``, ``x |> is_none``            ``x IS NOT NULL``, ``x IS NULL``
+``x |> unwrap_or(d)``                         ``COALESCE(x, ?)`` --- the bound default
+``x |> _in(subq)``, ``x |> _not_in(subq)``    ``IN (subquery)``, ``NOT IN (subquery)``
+``x |> _in(arr)`` (captured array)            ``IN (SELECT value FROM json_each(?))``
+``int64(x)``, ``double(x)``, ``string(x)``    ``CAST(x AS INTEGER)`` / ``REAL`` / ``TEXT``
+``_.Col |> text_match(q)``                    ``MATCH ?`` (FTS5 --- see :ref:`tutorial_sql_fts5`)
 ============================================  ============================================================
+
+For the ``LIKE`` shapes, the ``%`` wildcard padding and the escaping of
+literal ``%`` / ``_`` / ``\`` are applied to the **bound value** (not
+concatenated into the SQL), so user input can never inject a wildcard.
 
 Captured-variable equality
 ==========================
@@ -64,8 +74,8 @@ Each ``_where`` adds an AND-clause; chain freely:
     let cheap_F <- _sql(db |> select_from(type<Car>)
                           |> _where(_.Price < 1000)
                           |> _where(_.Name |> starts_with("F")))
-    // emits:  ... WHERE "Price" < ? AND "Name" LIKE ? || '%'
-    // binds:  [1000, "F"]
+    // emits:  ... WHERE ("Price" < ?) AND ("Name" LIKE ? ESCAPE '\')
+    // binds:  [1000, "F%"]
 
 Boolean operators
 =================

--- a/doc/source/reference/tutorials/sql_09_select.rst
+++ b/doc/source/reference/tutorials/sql_09_select.rst
@@ -110,6 +110,13 @@ fields map by position, so no SQL alias is emitted:
 A computed column composes with a computed ``_where`` --- the predicate
 and projection binds are emitted in SQL-clause order.
 
+Any predicate-legal shape works as a column: string concatenation
+(``Label = _.Name + " car"`` → ``("Name") || (?)``) and workhorse casts
+(``AsText = string(_.Price)`` → ``CAST("Price" AS TEXT)``) both render via
+the same translator. The runnable
+:download:`09-select.das <../../../../tutorials/sql/09-select.das>` shows the
+``Bonus = _.Price / 10`` form end-to-end.
+
 Combining with terminals
 ========================
 

--- a/doc/source/reference/tutorials/sql_10_order_by.rst
+++ b/doc/source/reference/tutorials/sql_10_order_by.rst
@@ -21,6 +21,7 @@ Key shape                                       Emitted SQL
 ``(_.k1, _.k2, ...)``                           ``ORDER BY "k1" ASC, "k2" ASC, ...``
 ``_.expr`` (e.g. ``_.Price / 10``)              ``ORDER BY (expr) ASC`` (constants inlined)
 ``_order_by_descending(_.Field)``               ``ORDER BY "Field" DESC``
+``_order_by_keys((_.k1, _.k2), mask)``          ``ORDER BY "k1" ASC, "k2" DESC`` (per bit)
 ==============================================  ===========================================
 
 Single-column order
@@ -80,10 +81,21 @@ reference is instead treated as a dynamic column **name**.)
 Mixed ASC/DESC
 ==============
 
-A single ``_order_by`` step emits all columns in the same direction.
-Mixed ASC/DESC across columns (e.g. ``ORDER BY a ASC, b DESC``) is
-**not yet supported**. Drop down to the raw-SQL escape hatch
-(``query_one`` / ``query_scalar`` / ``exec``) when you need it.
+``_order_by`` and ``_order_by_descending`` emit every column in the
+same direction. For **per-column** direction, use ``_order_by_keys``:
+it takes the key tuple plus a ``uint`` mask, where bit ``i`` sets key
+``i`` to ``DESC`` (LSB = first key, a clear bit stays ``ASC``):
+
+.. code-block:: das
+
+    let mixed <- _sql(db |> select_from(type<Car>)
+                        |> _order_by_keys((_.Price, _.Name), 2u))
+    // ... ORDER BY "Price" ASC, "Name" DESC
+
+Mask ``2u`` is ``0b10`` --- bit 0 clear (``Price`` ASC), bit 1 set
+(``Name`` DESC). ``1u`` flips the first key, ``3u`` flips both, ``0u``
+is all-ascending (same as a plain tuple ``_order_by``). Like the other
+ordering steps, ordering may appear at most once in a chain.
 
 Composes with ``_where`` and ``take``
 =====================================

--- a/doc/source/reference/tutorials/sql_13_aggregates.rst
+++ b/doc/source/reference/tutorials/sql_13_aggregates.rst
@@ -62,6 +62,29 @@ produce ``int64``.
     let mean = _sql(db |> select_from(type<Car>) |> _select(_.Price) |> average())
     // SELECT AVG("Price") FROM "Cars"     -- result type: double
 
+Aggregating a computed expression
+=================================
+
+``_select`` accepts a **computed scalar**, not just a bare column.
+The expression lowers into the aggregate's argument:
+
+.. code-block:: das
+
+    let s = _sql(db |> select_from(type<Car>) |> _select(_.Price + _.Id) |> sum())
+    // SELECT SUM(("Price") + ("Id")) FROM "Cars"
+
+Workhorse casts inside the projection lower to a SQLite ``CAST`` and
+drive the read-back type. Wrapping in ``int64(...)`` makes the
+projection 64-bit, so the SUM reads back faithfully instead of
+truncating at 32-bit scale:
+
+.. code-block:: das
+
+    let s = _sql(db |> select_from(type<Car>)
+                   |> _select(int64(_.Price) * int64(_.Id))
+                   |> sum())
+    // SELECT SUM((CAST("Price" AS INTEGER)) * (CAST("Id" AS INTEGER))) FROM "Cars"
+
 Composing with ``_where``
 =========================
 

--- a/doc/source/reference/tutorials/sql_14_group_by.rst
+++ b/doc/source/reference/tutorials/sql_14_group_by.rst
@@ -119,6 +119,24 @@ Pass a tuple to ``_group_by``. Each tuple field becomes its own
     // SELECT "City", "Age", COUNT(*) FROM "Users"
     // GROUP BY "City", "Age"
 
+Expression group keys
+=====================
+
+``_group_by`` also accepts a **computed key**. Constants inline into
+the rendered fragment (no ``?`` binds), and the same fragment is
+shared by the SELECT and the GROUP BY clause:
+
+.. code-block:: das
+
+    _sql(db |> select_from(type<User>)
+           |> _group_by(_.Age % 100)
+           |> _select((K = _._0, N = _._1 |> length)))
+    // SELECT (("Age") % (100)), COUNT(*) FROM "Users"
+    // GROUP BY (("Age") % (100))
+
+A computed key can sit alongside a plain field key in a multi-key
+tuple --- both render, in order, into SELECT and GROUP BY.
+
 The full reporting query
 ========================
 

--- a/doc/source/reference/tutorials/sql_15_join.rst
+++ b/doc/source/reference/tutorials/sql_15_join.rst
@@ -27,9 +27,10 @@ The ``on`` predicate is locked to the equi-join shape
 --- a 2-arg lambda whose body is one ``==`` comparison between a
 left-side field and a right-side field. Theta joins (``<``, ``>``,
 ``&&``-chained multi-key equality, function calls inside) emit a
-compile-time ``macro_error`` pointing at raw SQL as the escape
+compile-time ``error[50503]`` pointing at raw SQL as the escape
 hatch. The single-key restriction matches the backing ``join`` fn's
-hash-based O(n+m) implementation; multi-key tuple joins land later.
+hash-based O(n+m) implementation; for composite-key joins, use raw
+SQL.
 
 Multi-source mode and table aliases
 ====================================
@@ -133,18 +134,25 @@ read aliases through the same registry. Aliases that don't appear in
 the join's ``into`` projection reject with a clear macro_error listing
 the valid alias names.
 
+Other join shapes
+=================
+
+``_left_join`` / ``_right_join`` / ``_full_outer_join`` /
+``_cross_join`` all ship --- see :ref:`tutorial_sql_left_join`, which
+covers every outer-join shape and the WHERE-on-preserved-side rules.
+
+Three-table joins chain cleanly: each ``_join``'s named ``into``
+projection is referenced by alias in the next join's lambdas (e.g.
+``uo.OrderId``). The one constraint is that each join's RIGHT side
+cannot itself be a join --- chain from the left.
+
 What's not shipped
 ==================
 
-* ``_right_join`` --- trivially ``_left_join`` with swapped sources
-* ``_full_outer_join`` --- rare; raw SQL escape hatch
-* ``_cross_join`` --- footgun; raw SQL escape hatch
-* Three-table joins --- compose syntactically but produce verbose
-  tuple chains; documented as "use 2-table joins idiomatically;
-  3+ either chain with verbose tuple access, or drop to raw SQL"
 * Multi-key equi-joins (``u.Id == o.UserId && u.Tenant == o.Tenant``)
-  --- legitimate, but the backing ``join`` fn's keys are
-  single-column; deferred to a later ``multi_key_join`` extension
+  --- the backing ``join`` fn's keys are single-column, so a
+  ``&&``-chained ``ON`` predicate errors with ``error[50503]``; use
+  raw SQL for composite-key joins.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_17_subqueries.rst
+++ b/doc/source/reference/tutorials/sql_17_subqueries.rst
@@ -57,6 +57,29 @@ For IN-style subqueries, project a single column with
                             |> _where(_.Id._not_in(db |> select_from(type<Order>) |> _select(_.UserId))))
     // ... WHERE "Id" NOT IN (...)
 
+IN / NOT IN with a captured collection
+======================================
+
+``_in`` / ``_not_in`` also accept a **captured daslang collection**
+(an ``array<T>`` in scope). It is JSON-encoded into a single bind and
+queried through SQLite's table-valued ``json_each`` --- EF Core 8's
+default IN-list strategy:
+
+.. code-block:: das
+
+    let want_ids <- [1, 2]
+    let some <- _sql(db |> select_from(type<User>)
+                       |> _where(_.Id._in(want_ids)))
+    // ... WHERE "Id" IN (SELECT value FROM json_each(?))
+
+``NOT IN`` on a **nullable** column adds the ``OR <x> IS NULL`` guard
+so three-valued logic doesn't silently drop ``NULL`` rows:
+
+.. code-block:: das
+
+    // nullable column:
+    // ... WHERE ("Tag" NOT IN (SELECT value FROM json_each(?)) OR "Tag" IS NULL)
+
 EXISTS / NOT EXISTS
 ===================
 

--- a/doc/source/reference/tutorials/sql_21_upsert.rst
+++ b/doc/source/reference/tutorials/sql_21_upsert.rst
@@ -26,6 +26,7 @@ Form                                            Behavior
 ``db |> _sql_upsert(row, on_conflict, ...)``    proper merge --- keep old row, update chosen cols
 ``db |> _sql_upsert_returning(...)``            same, but capture the post-merge row
 ``db |> _sql_try_upsert(...)``                  non-panic ``Result<int, string>``
+``db |> _sql_try_upsert_returning(...)``        non-panic + capture (``Result<array<T>, string>``)
 ==============================================  ===================================================
 
 ``insert_or_ignore`` / ``insert_or_replace`` also have ``try_``
@@ -76,8 +77,8 @@ ON CONFLICT ... DO UPDATE --- the proper merge
         (Hits = _.Hits + 1, Last = _excluded.Last))
     // INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
     //   ON CONFLICT("Id") DO UPDATE SET
-    //     "Hits" = "WordHits"."Hits" + 1,
-    //     "Last" = "excluded"."Last"
+    //     "Hits" = ("Hits") + (?),
+    //     "Last" = excluded."Last"
 
 Composite conflict targets
 ==========================
@@ -105,8 +106,8 @@ list.
         tuple(_.Email, _.Tenant),
         (Name = _excluded.Name))
     // INSERT INTO "UserAccts" (...) VALUES (?,?,?,?)
-    //   ON CONFLICT("Email","Tenant") DO UPDATE SET
-    //     "Name" = "excluded"."Name"
+    //   ON CONFLICT("Email", "Tenant") DO UPDATE SET
+    //     "Name" = excluded."Name"
 
 UPSERT RETURNING
 ================
@@ -121,8 +122,8 @@ practice; the array shape mirrors ``_sql_update_returning``).
         _.Id,
         (Hits = _.Hits + 1))
     // INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
-    //   ON CONFLICT("Id") DO UPDATE SET "Hits" = "WordHits"."Hits" + 1
-    //   RETURNING "Id","Word","Hits","Last"
+    //   ON CONFLICT("Id") DO UPDATE SET "Hits" = ("Hits") + (?)
+    //   RETURNING "Id", "Word", "Hits", "Last"
 
 Non-panic ``try_`` variants
 ===========================

--- a/doc/source/reference/tutorials/sql_26_custom_types.rst
+++ b/doc/source/reference/tutorials/sql_26_custom_types.rst
@@ -63,9 +63,9 @@ Built-in adapters ship in ``sqlite_boost`` for:
   ``uint8`` / ``uint16`` / ``uint64`` round-trip through ``int64``;
   ``float`` round-trips through ``double``; ``bool`` round-trips
   through ``int64`` (``true`` -> ``1``).
-* A single enum generic ``def sql_bind $T (e : T) : int64 where T :
-  enum`` (and the matching ``sql_extract``) so any enum auto-
-  round-trips through ``INTEGER``.
+* A single ``auto``-typed ``sql_bind`` overload (and the matching
+  ``sql_extract``) detects enums via ``typeinfo is_enum`` and
+  round-trips any enum through ``INTEGER``.
 
 User code only writes adapters for domain types.
 

--- a/doc/source/reference/tutorials/sql_29_column_names.rst
+++ b/doc/source/reference/tutorials/sql_29_column_names.rst
@@ -183,6 +183,17 @@ tempting symmetry. Two reasons it does not ship:
 The honest path: Band 1 stays compile-time-typed, Band 3 stays the
 raw-SQL escape hatch, and the boundary is explicit.
 
+.. note::
+
+    What *does* ship for "does my open DB match my ``[sql_table]``
+    type?" is ``check_schema(db, type<T>)`` / ``try_check_schema(db,
+    type<T>)`` --- a typed runtime verifier that diffs the live catalog
+    against ``T``'s fields (name / type / NOT NULL / PRIMARY KEY) and
+    panics / returns ``SqlError`` on mismatch. It answers a yes/no
+    verification question against a known ``T``; it does not return the
+    ColumnInfo-shaped ``schema(name)`` array discussed above, which is
+    the part that stays unshipped.
+
 .. seealso::
 
     Full source: :download:`tutorials/sql/29-column_names.das <../../../../tutorials/sql/29-column_names.das>`

--- a/doc/source/reference/tutorials/sql_30_list_tables.rst
+++ b/doc/source/reference/tutorials/sql_30_list_tables.rst
@@ -112,11 +112,13 @@ Deferred
   Could ship as ``daslib/sql_admin`` once a second provider lands and
   the lowest-common-denominator subset is concrete. Premature to
   design with one backend in hand.
-* **Schema-diff helpers** (compare DB catalog ↔ declared
-  ``[sql_table]`` types). Useful for migration tooling but pushes
-  design choices around what counts as a "diff" (column renames vs.
-  drop+add, index name normalization, view body equivalence). Defer
-  until a real migration story is on the table.
+* **Multi-object schema-diff** (compare the whole DB catalog ↔ declared
+  ``[sql_table]`` types). Single-table verify already ships as
+  ``check_schema(db, type<T>)`` / ``try_check_schema(...)`` --- a typed
+  catalog↔struct diff on name / type / NOT NULL / PRIMARY KEY. What
+  remains deferred is catalog-wide diffing, which pushes design choices
+  around what counts as a "diff" (column renames vs. drop+add, index
+  name normalization, view body equivalence).
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_31_views.rst
+++ b/doc/source/reference/tutorials/sql_31_views.rst
@@ -24,8 +24,9 @@ The contract
   Field annotations are the read-only subset of ``[sql_table]``:
   ``@sql_column = "..."`` (rename) and ``@sql_json`` / ``@sql_blob``
   (non-scalar storage). DDL-affecting annotations on the underlying
-  table --- keys, uniqueness, computed columns, defaults, foreign keys
-  --- are rejected at compile time.
+  table --- keys, uniqueness, computed/stored columns, defaults,
+  foreign keys, indexes, FK actions, and field initializers (among
+  others) --- are rejected at compile time.
 * ``_create_view(type<V>, chain)`` builds the ``CREATE VIEW`` from a
   LINQ-shaped chain. The macro walks it, validates the projection
   against ``V``'s fields (count + per-position type), and emits a
@@ -47,7 +48,8 @@ Views are read-only. Any mutation attempt is blocked:
   Mutate the underlying table(s) and re-query the view."*
 * **Runtime rejection.** Row-form mutations
   (``insert(viewRow)`` / ``update(...)`` / ``delete_(...)``) panic with
-  the same message.
+  an equivalent read-only message (*"[sql_view] <name>: cannot
+  <insert|update|delete> into a view --- views are read-only..."*).
 
 Real mutating workflows update the underlying tables and re-query the
 view to see the new state.
@@ -221,9 +223,8 @@ Production tip
 ==============
 
 In production, view DDL belongs in a migration body so the schema
-lives alongside table DDL. The migration story ships in a future
-chunk; for now the inline ``_create_view`` form is fine for app setup
-and tests.
+lives alongside table DDL --- see :ref:`tutorial_sql_migrations`. For
+quick app setup and tests, the inline ``_create_view`` form is fine.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_35_streaming.rst
+++ b/doc/source/reference/tutorials/sql_35_streaming.rst
@@ -27,14 +27,15 @@ Lifecycle (handled for you)::
     prepare -> bind -> step+yield -> step+yield -> ... -> finalize
 
 The underlying prepared statement is finalized in the generator's
-``finally`` block, which runs on:
+iterator-close ``finally`` block, which runs on:
 
 * normal exhaustion (loop runs to completion);
-* early ``break`` from the for-loop;
-* panic from inside the loop body.
+* early ``break`` from the for-loop.
 
-In every case the statement is released, so subsequent writes to the
-same DB are not blocked by a stale read transaction.
+In both cases the statement is released, so subsequent writes to the
+same DB are not blocked by a stale read transaction. (A ``panic`` from
+the loop body is fatal --- it tears down the process, so the statement
+is reclaimed only as part of that teardown, not a recoverable cleanup.)
 
 End-to-end
 ==========

--- a/doc/source/reference/tutorials/sql_36_attach.rst
+++ b/doc/source/reference/tutorials/sql_36_attach.rst
@@ -27,7 +27,10 @@ The dasSQLITE surface lives in ``sqlite/sqlite_boost``:
   qualified runner cannot outlive its lexical scope (it shares
   ``db``'s libsqlite3 handle; only the original owns lifetime).
 * ``with_attached(db, path, as_name) $(scoped) { ... }`` ---
-  attach + invoke + detach in ``finally`` (covers panic paths).
+  attach + invoke + detach in ``finally`` on normal exit and
+  early return. Panic is fatal, so the connection closes on
+  process exit anyway --- detach is not a recoverable cleanup
+  on panic.
 
 ``:memory:`` is a valid attach target: each ``:memory:`` attach
 creates a fresh, separate in-memory DB. The runnable example

--- a/doc/source/reference/tutorials/sql_37_bulk_operations.rst
+++ b/doc/source/reference/tutorials/sql_37_bulk_operations.rst
@@ -57,8 +57,14 @@ overload uses a single prepared statement reused across rows
     }
     let inserted = db |> insert(events)
 
-Combine ``with_transaction`` + ``insert(rows)`` for the absolute
-fastest path: single transaction, single prepared statement.
+``insert(rows)`` is **already** wrapped in a single
+``BEGIN IMMEDIATE`` / ``COMMIT`` internally --- one ``fsync`` for
+the whole batch (it degrades to ``SAVEPOINT`` / ``RELEASE`` when
+called inside an existing transaction). So you do **not** need an
+outer ``with_transaction`` for the fsync win. Reach for an outer
+``with_transaction`` only to group ``insert(rows)`` atomically
+with **other** statements --- it adds no extra fsync benefit by
+itself.
 
 ``INSERT ... SELECT``
 =====================

--- a/doc/source/reference/tutorials/sql_38_concurrency.rst
+++ b/doc/source/reference/tutorials/sql_38_concurrency.rst
@@ -75,11 +75,11 @@ error. dasSQLITE turns this into a panic in the strict path, or
 
 * **Default (recommended):** ``apply_recommended_pragmas`` plus
   short transactions. Most workloads never hit the 5s ceiling.
-* **Manual retry:** ``try_with_transaction`` returns
+* **Manual retry:** ``try_transaction`` returns
   ``SqlError``; on ``some(err)``, check the error string for
   ``"database is locked"`` / ``"BUSY"``, sleep with jitter,
   retry up to a cap.
-* **Tune the timeout:** ``db |> set_pragma("busy_timeout", 30000)``
+* **Tune the timeout:** ``db |> set_pragma("busy_timeout", 30000l)``
   if you have legitimate load spikes longer than 5s.
 
 What breaks
@@ -96,8 +96,8 @@ What breaks
   WAL mode (no lock acquired).
 * **journal_mode=DELETE (the legacy default).**
   ``apply_recommended_pragmas`` uses WAL. Verify with
-  ``query_scalar("PRAGMA journal_mode")`` if you inherit a DB
-  built elsewhere.
+  ``query_scalar("PRAGMA journal_mode", type<string>)`` if you
+  inherit a DB built elsewhere.
 
 Out of scope
 ============

--- a/doc/source/reference/tutorials/sql_39_schema_from.rst
+++ b/doc/source/reference/tutorials/sql_39_schema_from.rst
@@ -146,8 +146,9 @@ today is what the script reads/writes. ETL between two DBs,
 archival readers, admin tooling --- all good fits.
 
 For "the DB grows over time, run versioned schema migrations at
-startup", a future ``daslib/sqlite_migrate`` module ships
-``[sql_migration(version=N)]`` + a runtime runner. The two are
+startup", the ``daslib/sqlite_migrate`` module ships
+``[sql_migration(version=N)]`` + a runtime runner
+(see :ref:`tutorial_sql_migrations`). The two are
 orthogonal: ``schema_from`` gives compile-time contract checks
 against a known schema; ``sqlite_migrate`` evolves the schema over
 time. See :ref:`tutorial_sql_schema_evolution` for the

--- a/doc/source/reference/tutorials/sql_40_fts5.rst
+++ b/doc/source/reference/tutorials/sql_40_fts5.rst
@@ -198,4 +198,4 @@ code never sees escape sequences:
 
     Full source: :download:`tutorials/sql/40-fts5.das <../../../../tutorials/sql/40-fts5.das>`
 
-    Previous tutorial: :ref:`tutorial_sql_concurrency`
+    Previous tutorial: :ref:`tutorial_sql_schema_from`

--- a/doc/source/reference/tutorials/sql_41_triggers.rst
+++ b/doc/source/reference/tutorials/sql_41_triggers.rst
@@ -27,7 +27,7 @@ daslang-side trigger DSL. Reasons:
   abstraction would lose the parts people actually use
   triggers for.
 * **Schema migrations are the right home for trigger DDL** ---
-  ``tut 32 (migrations, shipping in a later chunk)`` covers this
+  :ref:`tutorial_sql_migrations` covers this
   pattern: each migration can ``exec`` a ``CREATE TRIGGER`` so
   the trigger ships with the schema version that needs it.
 
@@ -78,7 +78,7 @@ Drop / replace
     db |> exec("DROP TRIGGER IF EXISTS articles_audit_insert")
 
 Replace = drop + recreate. The lifecycle is migration-shaped,
-which is why migrations (``tut 32``, shipping in a later chunk)
+which is why :ref:`tutorial_sql_migrations`
 is the natural home for trigger DDL.
 
 The typical anti-pattern

--- a/doc/source/reference/tutorials/sql_42_schema_evolution.rst
+++ b/doc/source/reference/tutorials/sql_42_schema_evolution.rst
@@ -113,8 +113,8 @@ surfaces, you add a third struct + a third loop and the type
 system tells you exactly where to wire it up.
 
 For "my app's schema evolves at runtime; I run migrations at
-startup", a future ``daslib/sqlite_migrate`` module ships a
-different shape: versioned ``[sql_migration(version=N)]``
+startup", ``daslib/sqlite_migrate`` ships a
+different shape (see :ref:`tutorial_sql_migrations`): versioned ``[sql_migration(version=N)]``
 functions applied in order, tracked in ``__schema_version``,
 transactional per migration. The two patterns coexist:
 ``schema_from`` for *code-on-current-schema*, ``sqlite_migrate``
@@ -127,3 +127,5 @@ for the *schema-grows-over-time* runner.
     Background: :ref:`tutorial_sql_schema_from`
 
     Streaming iteration: :ref:`tutorial_sql_streaming`
+
+    Migrations: :ref:`tutorial_sql_migrations`

--- a/doc/source/reference/tutorials/sql_43_migrations.rst
+++ b/doc/source/reference/tutorials/sql_43_migrations.rst
@@ -323,6 +323,19 @@ Path 2 (no legacy struct): hand-written
 ``db |> exec("INSERT INTO users_new (...) SELECT (...) FROM users")``
 also works. The legacy struct is convenience, not a requirement.
 
+.. warning::
+
+   **Runtime-created indexes are dropped by the rebuild.**
+   ``convert_and_rename`` re-emits the current struct's
+   ``[sql_index]`` annotations after the RENAME, but indexes
+   created at runtime via ``create_index`` / ``create_unique_index``
+   (e.g. in an earlier migration) are not ``[sql_index]`` siblings,
+   so the staging table never gets them and they vanish on rebuild.
+   Two fixes: declare such indexes as ``[sql_index(...)]`` siblings
+   on the struct so ``create_table`` emits them during the rebuild,
+   or recreate them after ``convert_and_rename`` via
+   ``create_index`` / ``create_unique_index``.
+
 Adopting migrations on an existing DB
 ======================================
 

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -1,6 +1,6 @@
 # SQL — dasSQLITE
 
-Read this skill before writing or editing any `.das` code that talks to a SQL database. The companion tutorials live under [tutorials/sql/](../tutorials/sql/) (43 files, numbered by teaching order — `01-version.das` through `43-migrations.das`); read the relevant ones for runnable examples of every pattern below. Implementation is in [modules/dasSQLITE/daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das) (runtime + `[sql_table]` / `[sql_view]` / `[sql_fts5]` / `[sql_function]` macros), [modules/dasSQLITE/daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das) (the `_sql(...)` family of call macros), and [modules/dasSQLITE/daslib/sqlite_migrate.das](../modules/dasSQLITE/daslib/sqlite_migrate.das) (`[sql_migration]` + `migrate_to_latest` runner). Design notes, decision logs, and the deferred-feature list live next to the implementation in [modules/dasSQLITE/API_REWORK.md](../modules/dasSQLITE/API_REWORK.md), [TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md), and [API_MIGRATION.md](../modules/dasSQLITE/API_MIGRATION.md).
+Read this skill before writing or editing any `.das` code that talks to a SQL database. The companion tutorials live under [tutorials/sql/](../tutorials/sql/) (45 files, numbered by teaching order — `01-version.das` through `44-in_not_in_collections.das`, plus `12b-set_ops.das`); read the relevant ones for runnable examples of every pattern below. Implementation is in [modules/dasSQLITE/daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das) (runtime + `[sql_table]` / `[sql_view]` / `[sql_fts5]` / `[sql_function]` macros), [modules/dasSQLITE/daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das) (the `_sql(...)` family of call macros), and [modules/dasSQLITE/daslib/sqlite_migrate.das](../modules/dasSQLITE/daslib/sqlite_migrate.das) (`[sql_migration]` + `migrate_to_latest` runner). Design notes, decision logs, and the deferred-feature list live next to the implementation in [modules/dasSQLITE/API_REWORK.md](../modules/dasSQLITE/API_REWORK.md), [TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md), and [API_MIGRATION.md](../modules/dasSQLITE/API_MIGRATION.md).
 
 The shipped backend is **SQLite only**. The split between `daslib/sql` (provider-neutral types — `SqlRunner`, `SqlError`, `SqlType`, `ColumnInfo`, `Option`/`Result`) and `sqlite/sqlite_boost` (provider-specific runtime + macros) keeps user code portable for the day a second backend lands. Until then the names "SQL" and "SQLite" are interchangeable in this skill.
 
@@ -198,7 +198,7 @@ let cars <- _sql(db |> select_from(type<Car>)
 Compile-time `macro_error` pointing at the offending node:
 
 - Unknown function calls in `_where` / `_select`
-- `_select` struct-type projection (a whole-struct project is a deferred follow-up; `_.Field`, named-tuple, and computed-scalar `_.A + _.B` projections are supported). A computed projection containing a type cast (`int64(_.A) * int64(_.B)`) currently fails inference — deferred
+- `_select` struct-type projection — a whole-struct project is a deferred follow-up; `_.Field`, named-tuple, and computed-scalar `_.A + _.B` projections are supported, including workhorse casts (`int64(_.A) * int64(_.B)` lowers to `CAST(...)`)
 - Multiple `_select` calls in one chain
 - Multiple terminals in one chain (`_to_array() |> _first()`)
 - `text_match` on a non-`[sql_fts5]` column (suggests `contains` or `[sql_fts5]`)
@@ -697,7 +697,7 @@ Strings produced by `query` / `_sql` are allocated on the calling context's heap
 
 ## Reference
 
-- Tutorials — every shipped feature has a runnable file under [tutorials/sql/](../tutorials/sql/) (43 files). Teaching order is documented in [modules/dasSQLITE/TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md).
+- Tutorials — every shipped feature has a runnable file under [tutorials/sql/](../tutorials/sql/) (45 files). Teaching order is documented in [modules/dasSQLITE/TUTORIALS.md](../modules/dasSQLITE/TUTORIALS.md).
 - Implementation — [daslib/sqlite_boost.das](../modules/dasSQLITE/daslib/sqlite_boost.das), [daslib/sqlite_linq.das](../modules/dasSQLITE/daslib/sqlite_linq.das), [daslib/sqlite_migrate.das](../modules/dasSQLITE/daslib/sqlite_migrate.das).
 - Design notes — [API_REWORK.md](../modules/dasSQLITE/API_REWORK.md) (the master plan; per-chunk decision log), [API_MIGRATION.md](../modules/dasSQLITE/API_MIGRATION.md) (migrations design walk), [API_CHECKED.md](../modules/dasSQLITE/API_CHECKED.md) (parity audit), [API_MISSING.md](../modules/dasSQLITE/API_MISSING.md) (deferred-feature list).
 - Tests — `tests/dasSQLITE/` — every operator + macro has a focused test, plus `failed_*.das` files for compile-error cases.

--- a/tutorials/sql/07-anatomy.das
+++ b/tutorials/sql/07-anatomy.das
@@ -56,7 +56,7 @@ def main() {
         // default for SQL injection).
         let cutoff = 150
         let sql2 = _sql_text(db |> select_from(type<Car>) |> _where(_.Price > cutoff))
-        to_log(LOG_INFO, "(2) Captured-var WHERE:\n  {sql2}\n")
+        to_log(LOG_INFO, "(2) Captured-var WHERE (cutoff = {cutoff}):\n  {sql2}\n")
 
         // ── (3) Column ref vs bind: which side is which ──────────────────
         // `_.Price` is a column reference (becomes "Price"). `cutoff`
@@ -90,11 +90,13 @@ def main() {
         to_log(LOG_INFO, "(6) raw-SQL total Price = {total}\n")
 
         // ── (7) What `_sql` refuses ──────────────────────────────────────
-        // The translation table is intentionally finite. If you write a
-        // shape the analyzer doesn't recognize — an arbitrary user-
-        // defined function call inside `_where`, an unsupported math
-        // op, a regex — compile fails with `macro_error` pointing at
-        // the offending node. Two possible responses:
+        // The translation surface is wide: arithmetic (+ - * / %), bitwise
+        // (& | << >>), unary (- ~), string concat (+ → ||), and workhorse
+        // casts (int() → CAST) all lower to SQL, and [sql_function]-
+        // annotated functions translate too. Only a few shapes hard-reject —
+        // bitwise XOR (^), an *unannotated* user-defined function inside
+        // `_where`, or a regex — and compile fails with `macro_error`
+        // pointing at the offending node. Two possible responses:
         //   - Add the rule to the analyzer (fork-and-extend) if the
         //     pattern is reusable.
         //   - Use the raw-SQL escape hatch (6) if it's a one-off.

--- a/tutorials/sql/09-select.das
+++ b/tutorials/sql/09-select.das
@@ -21,7 +21,9 @@ require sqlite/sqlite_linq
 //
 // The named-tuple form lets you rename columns at the result-type level
 // (`(Identifier=_.Id, Label=_.Name)` returns rows whose `Identifier` field
-// holds the underlying `Id`).
+// holds the underlying `Id`), and a tuple value may be any computed
+// expression over the row (`(Bonus = _.Price / 10)`), rendered by the same
+// translator that powers `_where`.
 
 [sql_table(name = "Cars")]
 struct Car {
@@ -70,6 +72,17 @@ def main() {
             to_log(LOG_INFO, "  Identifier={r.Identifier} Label={r.Label}\n")
         }
 
+        // ── Computed column — any _where-legal expression as a column ────
+        // A named-tuple value can be a computed expression over the row,
+        // not just a bare `_.Field`. Rendered by the same translator that
+        // powers `_where`; result fields map by position (no SQL alias).
+        let bonuses <- _sql(db |> select_from(type<Car>)
+                              |> _select((Name = _.Name, Bonus = _.Price / 10)))
+        to_log(LOG_INFO, "Computed column (Bonus = Price/10) — {length(bonuses)} rows:\n")
+        for (b in bonuses) {
+            to_log(LOG_INFO, "  {b.Name} bonus={b.Bonus}\n")
+        }
+
         // ── Combining with terminals: _first, _first_opt ─────────────────
         let head = _sql(db |> select_from(type<Car>)
                           |> _select((Name = _.Name, Price = _.Price))
@@ -80,5 +93,9 @@ def main() {
         let sql = _sql_text(db |> select_from(type<Car>)
                               |> _select((Name = _.Name, Price = _.Price)))
         to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+
+        let sql_computed = _sql_text(db |> select_from(type<Car>)
+                                       |> _select((Name = _.Name, Bonus = _.Price / 10)))
+        to_log(LOG_INFO, "  computed-column SQL: {sql_computed}\n")
     }
 }

--- a/tutorials/sql/10-order_by.das
+++ b/tutorials/sql/10-order_by.das
@@ -13,9 +13,8 @@ require sqlite/sqlite_linq
 //   - `(_.k1, _.k2, …)`      → ORDER BY "k1" ASC, "k2" ASC, …
 //   - `_order_by_descending` flips ASC to DESC for the whole chain step
 //
-// Mixed ASC/DESC across columns in a single chain step is **not
-// supported** — use the raw-SQL escape hatch
-// (`db |> query_one("...ORDER BY a, b DESC", ...)`) when you need it.
+// Per-column ASC/DESC mixing uses `_order_by_keys((_.k1, _.k2), mask)`:
+// bit i of the uint mask sets key i to DESC (LSB = first key).
 
 [sql_table(name = "Cars")]
 struct Car {
@@ -63,6 +62,15 @@ def main() {
             to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
         }
 
+        // ── Mixed ASC/DESC — `_order_by_keys((keys), mask)` ──────────────
+        // mask 2u = 0b10: bit 0 clear (Price ASC), bit 1 set (Name DESC).
+        let price_asc_name_desc <- _sql(db |> select_from(type<Car>)
+                                          |> _order_by_keys((_.Price, _.Name), 2u))
+        to_log(LOG_INFO, "Mixed (Price ASC, Name DESC):\n")
+        for (c in price_asc_name_desc) {
+            to_log(LOG_INFO, "  {c.Name}: {c.Price}\n")
+        }
+
         // ── Composes with `_where` and `take` ────────────────────────────
         let cheap_top3 <- _sql(db |> select_from(type<Car>)
                                  |> _where(_.Price > 50)
@@ -77,5 +85,9 @@ def main() {
         let sql = _sql_text(db |> select_from(type<Car>)
                               |> _order_by((_.Price, _.Name)))
         to_log(LOG_INFO, "  emitted SQL: {sql}\n")
+
+        let sql_mixed = _sql_text(db |> select_from(type<Car>)
+                                    |> _order_by_keys((_.Price, _.Name), 2u))
+        to_log(LOG_INFO, "  mixed-direction SQL: {sql_mixed}\n")
     }
 }

--- a/tutorials/sql/12-distinct.das
+++ b/tutorials/sql/12-distinct.das
@@ -11,11 +11,8 @@ require sqlite/sqlite_linq
 // of the chain (column list, WHERE, ORDER BY, LIMIT) composes
 // normally.
 //
-// Set operations (UNION / INTERSECT / EXCEPT) are **deferred to a
-// later chunk**: they need a multi-source / multi-stage analyzer
-// extension that lives alongside joins and subqueries. Until then,
-// the raw-SQL escape hatch (`db |> exec(...)` /
-// `db |> query_one(...)`) handles those cases.
+// Set operations (UNION / INTERSECT / EXCEPT) live in tutorial
+// `12b-set_ops.das`.
 
 [sql_table(name = "Cars")]
 struct Car {
@@ -139,12 +136,7 @@ def main() {
             to_log(LOG_INFO, "  Brand={g.Brand}  FirstCar.Id={g.FirstCar.Id} Price={g.FirstCar.Price}\n")
         }
 
-        // ── Set operations (UNION / INTERSECT / EXCEPT) — deferred ───────
-        // The chain analyzer is single-source today: every SELECT comes
-        // from one `select_from(type<T>)`. Set ops bring in a second
-        // SqlQuery and need a multi-stage emitter — same engine work
-        // joins and subqueries need. Until that lands, drive `sqlite3_*`
-        // directly or `exec` a `CREATE TEMP VIEW` that wraps the union
-        // and `select_from` the view.
+        // ── Set operations (UNION / INTERSECT / EXCEPT) ──────────────────
+        // See tutorial `12b-set_ops.das`.
     }
 }

--- a/tutorials/sql/13-aggregates.das
+++ b/tutorials/sql/13-aggregates.das
@@ -74,6 +74,21 @@ def main() {
                                     |> sum())
         to_log(LOG_INFO, "SUM(Price) WHERE Price>100 = {total_over_100}\n")
 
+        // ── Aggregating a computed expression ────────────────────────────
+        // `_select` takes a computed scalar, not just a bare column —
+        // the expression lowers into the aggregate's argument.
+        // SELECT SUM(("Price") + ("Id")) FROM "Cars"
+        let sum_expr = _sql(db |> select_from(type<Car>) |> _select(_.Price + _.Id) |> sum())
+        to_log(LOG_INFO, "SUM(Price+Id) = {sum_expr}\n")
+
+        // Workhorse casts lower to SQLite CAST and drive read-back precision:
+        // int64(...) keeps the SUM 64-bit (no 32-bit truncation at scale).
+        // SELECT SUM((CAST("Price" AS INTEGER)) * (CAST("Id" AS INTEGER))) FROM "Cars"
+        let sum_cast = _sql(db |> select_from(type<Car>)
+                              |> _select(int64(_.Price) * int64(_.Id))
+                              |> sum())
+        to_log(LOG_INFO, "SUM(int64(Price)*int64(Id)) = {sum_cast}\n")
+
         // ── Inspect emitted SQL ──────────────────────────────────────────
         let sql_sum = _sql_text(db |> select_from(type<Car>)
                                   |> _select(_.Price)
@@ -81,7 +96,11 @@ def main() {
         let sql_avg = _sql_text(db |> select_from(type<Car>)
                                   |> _select(_.Price)
                                   |> average())
+        let sql_expr = _sql_text(db |> select_from(type<Car>)
+                                   |> _select(int64(_.Price) * int64(_.Id))
+                                   |> sum())
         to_log(LOG_INFO, "  SUM SQL: {sql_sum}\n")
         to_log(LOG_INFO, "  AVG SQL: {sql_avg}\n")
+        to_log(LOG_INFO, "  computed SUM SQL: {sql_expr}\n")
     }
 }

--- a/tutorials/sql/14-group_by.das
+++ b/tutorials/sql/14-group_by.das
@@ -130,6 +130,24 @@ def main() {
             to_log(LOG_INFO, "  ({r.City}, age {r.Age}): {r.N}\n")
         }
 
+        // ── Expression group keys ────────────────────────────────────────
+        // `_group_by` accepts a computed key. Constants inline (no `?`
+        // binds); the same fragment is shared by SELECT and GROUP BY.
+        // SELECT (("Age") % (100)), COUNT(*) FROM "Users"
+        //   GROUP BY (("Age") % (100))
+        let by_age_bucket <- _sql(db |> select_from(type<User>)
+                                    |> _group_by(_.Age % 100)
+                                    |> _order_by(_._0)
+                                    |> _select((K = _._0, N = _._1 |> length)))
+        to_log(LOG_INFO, "Users per (Age % 100) bucket:\n")
+        for (r in by_age_bucket) {
+            to_log(LOG_INFO, "  {r.K}: {r.N}\n")
+        }
+        let sql_expr_key = _sql_text(db |> select_from(type<User>)
+                                       |> _group_by(_.Age % 100)
+                                       |> _select((K = _._0, N = _._1 |> length)))
+        to_log(LOG_INFO, "  expr-key SQL: {sql_expr_key}\n")
+
         // ── Full reporting query: WHERE → GROUP BY → HAVING → ORDER BY → LIMIT
         // The chain mirrors SQL clause order one-for-one. Bind ordering
         // tracks: WHERE binds first, HAVING next, LIMIT last.

--- a/tutorials/sql/17-subqueries.das
+++ b/tutorials/sql/17-subqueries.das
@@ -71,6 +71,14 @@ def main {
         to_log(LOG_INFO, "NOT IN subquery — orderless users: {length(no_orders)}")
         // 1 row: Carol.
 
+        // IN with a captured collection — `array<T>` in scope, not a
+        // subquery. JSON-encoded into a single bind, queried via
+        // SQLite's table-valued `json_each` (EF Core 8's default).
+        let want_ids <- [1, 2]
+        let picked <- _sql(db |> select_from(type<User>) |> _where(_.Id._in(want_ids)))
+        to_log(LOG_INFO, "IN(array) — users 1,2: {length(picked)}")
+        // 2 rows: Alice, Bob.
+
         // EXISTS subquery — uncorrelated test (`Orders` non-empty?).
         let any_orders <- _sql(db |> select_from(type<User>)
                                  |> _where((db |> select_from(type<Order>))._any()))
@@ -91,6 +99,8 @@ def main {
         let sql_in = _sql_text(db |> select_from(type<User>)
                                  |> _where(_.Id._in(db |> select_from(type<Order>) |> _select(_.UserId))))
         to_log(LOG_INFO, "SQL (IN): {sql_in}")
+        let sql_in_arr = _sql_text(db |> select_from(type<User>) |> _where(_.Id._in(want_ids)))
+        to_log(LOG_INFO, "SQL (IN array): {sql_in_arr}")
         let sql_exists = _sql_text(db |> select_from(type<User>)
                                      |> _where((db |> select_from(type<Order>))._any(_.Total > 200)))
         to_log(LOG_INFO, "SQL (EXISTS): {sql_exists}")

--- a/tutorials/sql/21-upsert.das
+++ b/tutorials/sql/21-upsert.das
@@ -81,8 +81,8 @@ def main {
         //                INSERT
         // SQL: INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
         //      ON CONFLICT("Id") DO UPDATE SET
-        //         "Hits" = "WordHits"."Hits" + 1,
-        //         "Last" = "excluded"."Last"
+        //         "Hits" = ("Hits") + (?),
+        //         "Last" = excluded."Last"
         let bumped = db |> _sql_upsert(
             WordHit(Id = 1, Word = "hello", Hits = 1, Last = 1234l),
             _.Id,
@@ -95,8 +95,8 @@ def main {
         // PRIMARY KEY or UNIQUE constraint" at runtime if no constraint
         // covers the column list.
         // SQL: INSERT INTO "UserAccts" (...) VALUES (?,?,?,?)
-        //      ON CONFLICT("Email","Tenant") DO UPDATE SET
-        //         "Name" = "excluded"."Name"
+        //      ON CONFLICT("Email", "Tenant") DO UPDATE SET
+        //         "Name" = excluded."Name"
         db |> _sql_upsert(
             UserAcct(Id = 999, Email = "x@y.com", Name = "alice2", Tenant = "acme"),
             tuple(_.Email, _.Tenant),
@@ -106,8 +106,8 @@ def main {
         // `_sql_upsert_returning` returns `array<T>` (always one row in
         // practice; the array shape mirrors `_sql_update_returning`).
         // SQL: INSERT INTO "WordHits" (...) VALUES (?,?,?,?)
-        //      ON CONFLICT("Id") DO UPDATE SET "Hits" = "WordHits"."Hits" + 1
-        //      RETURNING "Id","Word","Hits","Last"
+        //      ON CONFLICT("Id") DO UPDATE SET "Hits" = ("Hits") + (?)
+        //      RETURNING "Id", "Word", "Hits", "Last"
         let after <- db |> _sql_upsert_returning(
             WordHit(Id = 1, Word = "hello", Hits = 1, Last = 0l),
             _.Id,

--- a/tutorials/sql/31-views.das
+++ b/tutorials/sql/31-views.das
@@ -20,7 +20,7 @@ require sqlite/sqlite_linq
 //     panics at runtime with a "views are read-only" message.
 //
 // In production, view DDL belongs in a migration body so the schema
-// lives alongside table DDL — see a future tut covering migrations.
+// lives alongside table DDL — see the migrations tutorial (sql_43).
 // For now we create views inline at app setup.
 
 [sql_table(name = "Customers")]
@@ -44,7 +44,8 @@ struct Order {
 //   - `@sql_column = "..."`           rename the on-disk column
 //   - `@sql_json` / `@sql_blob`       opt non-scalar storage adapters
 // Anything that affects DDL of the underlying table is rejected loud:
-// keys, uniqueness, computed columns, defaults, foreign keys.
+// keys, uniqueness, computed/stored columns, defaults, foreign keys,
+// indexes, FK actions, and field initializers (among others).
 [sql_view(name = "BigOrders")]
 struct BigOrder {
     Id : int
@@ -153,9 +154,10 @@ def main {
 // Mutate the underlying table(s) and re-query the view."
 //
 // The runtime gate fires on row-form mutations (`insert(bigOrderRow)`,
-// `update(bigOrderRow)`, `delete_(bigOrderRow)`) — these panic with the
-// same message. Real mutating workflows update the underlying tables
-// (Customer / Order here) and re-query the view to see the new state.
+// `update(bigOrderRow)`, `delete_(bigOrderRow)`) — these panic with an
+// equivalent read-only message ("[sql_view] BigOrder: cannot insert
+// into a view — views are read-only..."). Real mutating workflows update
+// the underlying tables (Customer / Order here) and re-query the view.
 
 // --- Captured locals via `to_sql_literal` -------------------------------
 //

--- a/tutorials/sql/35-streaming.das
+++ b/tutorials/sql/35-streaming.das
@@ -20,12 +20,13 @@ require sqlite/sqlite_linq
 //   prepare → bind → step+yield → step+yield → ... → finalize
 //
 // The underlying prepared statement is finalized in the generator's
-// `finally` block, which runs on:
+// iterator-close `finally` block, which runs on:
 //   - normal exhaustion (loop runs to completion)
 //   - early `break` from the for-loop
-//   - panic from inside the loop body
-// In every case, the statement is released; subsequent writes to the
-// same DB are NOT blocked by a stale read transaction.
+// In both cases the statement is released; subsequent writes to the same
+// DB are NOT blocked by a stale read transaction. (A `panic` from the loop
+// body is fatal — it tears down the process, so the statement is reclaimed
+// only as part of that teardown, not a recoverable cleanup.)
 
 [sql_table(name = "Logs")]
 struct LogEntry {

--- a/tutorials/sql/36-attach.das
+++ b/tutorials/sql/36-attach.das
@@ -20,7 +20,9 @@ require sqlite/sqlite_linq
 //   with_schema(db, name)       — runner copy that qualifies queries
 //                                  with `"<name>"."<table>"`
 //   with_attached(db, path, as_name) <| $(scoped) { … }
-//                                — attach + invoke + detach (covers panic)
+//                                — attach + invoke + detach in `finally` on
+//                                  normal exit / early return (panic is fatal;
+//                                  the connection closes on process exit)
 //
 // `:memory:` is a valid attach target — each `:memory:` attach creates
 // a fresh, separate in-memory DB. The tutorial uses that so it has no
@@ -69,7 +71,9 @@ def main {
 
         // --- with_attached block — preferred shape ------------------------
         // Attaches, invokes the body with a schema-qualified runner, and
-        // detaches in `finally`. Detach runs even if the body panics.
+        // detaches in `finally` on normal exit / early return. Panic is fatal,
+        // so the connection closes on process exit anyway — detach is not a
+        // recoverable cleanup on panic.
         db |> with_attached(":memory:", "tenant_42") $(tenant) {
             fixture_archive(tenant)
             for (u in _sql(tenant |> select_from(type<User>))) {

--- a/tutorials/sql/38-concurrency.das
+++ b/tutorials/sql/38-concurrency.das
@@ -87,7 +87,7 @@ def main {
 //
 //   - Default (recommended): `apply_recommended_pragmas` + short
 //     transactions. Most workloads never hit the 5 s ceiling.
-//   - Manual retry: `try_with_transaction` (returns SqlError); on Err,
+//   - Manual retry: `try_transaction` (returns SqlError); on Err,
 //     check err substring `"database is locked"` or `"BUSY"`, sleep
 //     with jitter, retry up to a cap.
 //   - PRAGMA `busy_timeout = N`: tune the wait if you have load
@@ -105,8 +105,8 @@ def main {
 //     and commit only the writes, or use a snapshot read connection
 //     in WAL mode (no lock acquired).
 //   - JOURNAL_MODE=DELETE (the legacy default). `apply_recommended_pragmas`
-//     uses WAL. Verify with `query_scalar("PRAGMA journal_mode")` if you
-//     inherit a DB built elsewhere.
+//     uses WAL. Verify with `query_scalar("PRAGMA journal_mode", type<string>)`
+//     if you inherit a DB built elsewhere.
 //
 // --- WHAT'S OUT OF SCOPE FOR THIS TUTORIAL -----------------------------
 //


### PR DESCRIPTION
## What

Audit of all 45 SQL tutorials (`tutorials/sql/` + their `doc/source/reference/tutorials/sql_*.rst` companions) plus the `skills/sql.md` reference, against the current dasSQLITE implementation. The `_sql` macro and the boost layer advanced well past the docs since they were written; this PR brings the docs back in sync.

**37 files** — 24 RST + 12 companion `.das` + `skills/sql.md`. **Docs only, no implementation changes.**

## Stale "deferred / not-implemented" claims → corrected

The docs claimed these were unsupported; they ship today:

- **Mixed ASC/DESC** ordering — now via `_order_by_keys((k1, k2), mask)` (sql_10).
- **`_right_join` / `_full_outer_join` / `_cross_join`** — shipped, documented in sql_16 (sql_15 now cross-refs it instead of listing them as "not shipped").
- **Migrations** — `daslib/sqlite_migrate` shipped as sql_43; was called "a future module" / "tut 32, shipping in a later chunk" in sql_31/39/41/42.
- **Set operations** (UNION/INTERSECT/EXCEPT) — shipped (12-distinct.das called them "deferred to a later chunk").
- **`_sql` refuses-list** (sql_07) — arithmetic/bitwise/unary/string-concat/CAST all translate now; only `^`, unannotated UDFs, and regex reject.
- **skills/sql.md** — dropped the stale "computed cast fails inference — deferred" line; fixed the tutorial count.

## Factual errors → fixed (verified via `_sql_text` / `ast_dump`)

- **LIKE emission**: `starts_with`/`ends_with`/`contains` emit `LIKE ? ESCAPE '\'` with the wildcard escaped into the bound value — docs showed `LIKE ? || '%'` (sql_07, sql_08, 5 spots).
- **Custom-type rail**: the extension points are `sql_bind`/`sql_extract` (sql_02 showed nonexistent `sqlite_sql_type`/`sqlite_bind`); the row reader is `_sql_read_row` (sql_04 said `sqlite_read`).
- **Upsert SQL**: `excluded."Col"` is a bare keyword — docs quoted it `"excluded"."Col"`, which is broken SQL (sql_21).
- **sql_38** compile-broken snippets: `try_transaction` (not `try_with_transaction`), `30000l`, `query_scalar(..., type&lt;string&gt;)`.
- **fts5 nav back-link** pointed past schema_from (sql_40).

## Missing coverage → added (with runnable demos)

Computed aggregates + CAST precision (sql_13), expression group keys (sql_14), `_in`/`_not_in` over captured arrays via `json_each` (sql_17), computed `_select` (sql_09), `IS NULL`/`COALESCE`/`IN`/`CAST`/`MATCH` predicate-table rows (sql_08), `_sql_try_upsert_returning` (sql_21), `check_schema` mention (sql_29), `insert(rows)` is already one transaction (sql_37), index-loss-on-rebuild gotcha (sql_43).

## Verification

- All 12 touched tutorials run clean (exit 0).
- CI lint (`utils/lint/main.das --quiet`): 12 files, 0 issues.
- Clean `sphinx-build -W` (warnings-as-errors): build succeeded, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)