### PR TITLE
Faster small string-keyed tables: packed mode, 64-bit hash, JIT + interp const-key fast paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,6 +883,7 @@ src/simulate/simulate_fusion_op2_scalar_vec.cpp
 src/simulate/simulate_fusion_at.cpp
 src/simulate/simulate_fusion_at_array.cpp
 src/simulate/simulate_fusion_tableindex.cpp
+src/simulate/simulate_fusion_tablewithhash.cpp
 src/simulate/simulate_fusion_misc_copy.cpp
 src/simulate/simulate_fusion_call1.cpp
 src/simulate/simulate_fusion_call2.cpp

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,6 +51,7 @@ Small-table regime micro-benchmarks (N from 1 to 64) — the load profile the la
 | `test04.das` | Many small tables (decs/per-entity shape) — thousands of independent N-element tables, build (watch B/op for item 1 memory) and cold-sweep query (cache locality) |
 | `test05.das` | Crossover prototype — inlined hash-only linear scan (`lin_*`) vs real open-addressed `?[]` (`hash_*`) over N, short and long keys; predicts `maxLinearCapacity` before packed mode exists |
 | `test06.das` | Lookup-only (never insert) packed string-table find at N=8 — const/var keys, hit and miss; A/B/C harness for the JIT inlined packed find (`JIT_STRING_FIND` none/scalar/vector) |
+| `test07.das` | Packed (N=8) integer-key find (hit/miss, no-hash SIMD key compare) and `tab[k]++` update fast-path (string + int) — the paths added when the inline find was extended to integer keys and to insert |
 
 ## core/array/
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,6 +50,7 @@ Small-table regime micro-benchmarks (N from 1 to 64) — the load profile the la
 | `test03.das` | Constant string-literal keys (`const_*`) vs runtime-array keys (`var_*`) — baseline for item 4 (precomputed-hash specialization of constant keys) |
 | `test04.das` | Many small tables (decs/per-entity shape) — thousands of independent N-element tables, build (watch B/op for item 1 memory) and cold-sweep query (cache locality) |
 | `test05.das` | Crossover prototype — inlined hash-only linear scan (`lin_*`) vs real open-addressed `?[]` (`hash_*`) over N, short and long keys; predicts `maxLinearCapacity` before packed mode exists |
+| `test06.das` | Lookup-only (never insert) packed string-table find at N=8 — const/var keys, hit and miss; A/B/C harness for the JIT inlined packed find (`JIT_STRING_FIND` none/scalar/vector) |
 
 ## core/array/
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -39,6 +39,18 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 |---|---|
 | `test01.das` | `get_key(tab, v)` vs `keys(tab)+values(tab)` — single iterator with pointer arithmetic vs two parallel iterators (1K, 10K, 100K entries) |
 
+## core/small_table/
+
+Small-table regime micro-benchmarks (N from 1 to 64) — the load profile the large-table `core/hash/` suite does not cover. Used to locate the linear-vs-hashed crossover (`maxLinearCapacity`) and to measure the string-key and constant-key paths.
+
+| File | Description |
+|---|---|
+| `test01.das` | Integer-keyed small tables — build (insert+alloc), positive lookup (hit), negative lookup (miss), swept across N |
+| `test02.das` | String-keyed small tables — build/hit/miss sweep; hit queries with distinct-pointer keys (strcmp fires, realistic), keys pre-built outside the measured block |
+| `test03.das` | Constant string-literal keys (`const_*`) vs runtime-array keys (`var_*`) — baseline for item 4 (precomputed-hash specialization of constant keys) |
+| `test04.das` | Many small tables (decs/per-entity shape) — thousands of independent N-element tables, build (watch B/op for item 1 memory) and cold-sweep query (cache locality) |
+| `test05.das` | Crossover prototype — inlined hash-only linear scan (`lin_*`) vs real open-addressed `?[]` (`hash_*`) over N, short and long keys; predicts `maxLinearCapacity` before packed mode exists |
+
 ## core/array/
 
 | File | Description |

--- a/benchmarks/core/hash/test13.das
+++ b/benchmarks/core/hash/test13.das
@@ -12,10 +12,7 @@ require dastest/testing_boost
 let N = 256
 
 def build_keys(prefix : string) : array<string> {
-    var keys : array<string>
-    for (i in range(N)) {
-        keys |> push("{prefix}{i}")
-    }
+    var keys <- [for (i in range(N)); "{prefix}{i}"]
     return <- keys
 }
 

--- a/benchmarks/core/hash/test13.das
+++ b/benchmarks/core/hash/test13.das
@@ -1,0 +1,46 @@
+options gen2
+options persistent_heap
+
+// hash(string) microbenchmark. Under -jit, hash(k) lowers to the inlined FNV
+// intrinsic (llvm_jit_intrin.das); under interp it is the bound C++ builtin.
+// Short and long keys show how the inline-vs-call win scales with key length.
+// To measure the bound JIT path for an A/B, disable the "$::hash" entry in
+// g_intrin_lookup (and bump LLVM_JIT_CODEGEN_VERSION) and re-run.
+
+require dastest/testing_boost
+
+let N = 256
+
+def build_keys(prefix : string) : array<string> {
+    var keys : array<string>
+    for (i in range(N)) {
+        keys |> push("{prefix}{i}")
+    }
+    return <- keys
+}
+
+def run_hash(b : B?; name : string; keys : array<string>) {
+    b |> run(name, N) {
+        var acc = 0ul
+        for (k in keys) {
+            acc ^= hash(k)
+        }
+        if (acc == 0ul) {
+            b->failNow()
+        }
+    }
+}
+
+[benchmark]
+def hash_short(b : B?) {
+    var keys <- build_keys("k")
+    run_hash(b, "short/{N}", keys)
+    delete keys
+}
+
+[benchmark]
+def hash_long(b : B?) {
+    var keys <- build_keys("this/is/a/fairly/long/identifier/")
+    run_hash(b, "long/{N}", keys)
+    delete keys
+}

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -231,7 +231,12 @@ the SIMD compare *is* the whole operation. Inserts of genuinely new keys also sk
 redundant C++ `PackedFind` dedup the JIT already performed. Integer keys only
 (`int`/`uint` ×8/16/32/64); float/double/struct keep the C++ path.
 
-## Correctness: 32-bit hashKey collisions — confirm on find (SUPERSEDES the hash-only numbers above)
+## Correctness: 32-bit hashKey collisions — confirm on find (SUPERSEDED by §"64-bit packed hash")
+
+> **Superseded.** The confirm-on-find / promote-on-collision design below was the intermediate
+> step. It is **replaced** by the 64-bit packed hash (final section) — packed string find now
+> compares a full 64-bit hash exactly, with no strcmp and no confirm. Read this section for the
+> *why* (32-bit hashKey is too narrow to trust); read §"64-bit packed hash" for shipped behavior.
 
 The hash-only string path above is **incorrect**: `TableHashKey` is `uint32_t`, so distinct keys
 can share a hashKey and a hash-only match returns a false positive. Fix (all tiers):
@@ -316,6 +321,82 @@ assembled at runtime (`var foo = "fo"; foo += "o"`), so the stored key is a dist
   op. So const-pull is worth ~2.5ns/lookup on a hit, on every tier.
 - const-pull also makes these keys' hash a foldable constant — the unexploited item-4 headroom
   sitting under the good lanes.
+
+## 64-bit packed hash — strcmp eliminated (SHIPPED, supersedes the confirm approach)
+
+The confirm approach (32-bit `TableHashKey` + a `KeyCompare` / bound `jit_string_equal` confirm on
+every hash-candidate hit, promote-to-open-addressing on the first hashKey collision) is **replaced**.
+Packed small tables (`capacity <= TABLE_MAX_LINEAR_CAPACITY`) now store a **64-bit** hash per slot
+(uniform for *all* key types — the width is a pure function of capacity, so type-erased free/GC sites
+need no keytype); large tables keep the 32-bit `TableHashKey`. Packed string find compares the full
+64-bit hash **exactly** and returns the slot — **no strcmp, no confirm, no collision-promote** (a
+64-bit hash collision between two distinct live keys in an ≤8-slot table is not a real-world event).
+Packed workhorse find compares key *data* (the 64-bit hash is stored-but-unused on that path — the
++32B/table it costs is reclaimed by the deferred workhorse-no-hash follow-up).
+
+The clean-tail invariant makes the string scan branch-free over all 8 slots: alloc / erase /
+`table_clear` clear the full 64-bit width, a real hash is always `> HASH_KILLED64`, so the dead tail
+(value 0) never matches — no size mask needed.
+
+### JIT ns/op — 64-bit packed vs the confirm build (3-run warm)
+
+| lane | hashed baseline | confirm (32-bit + strcmp) | **64-bit packed** | Δ vs confirm |
+|---|---|---|---|---|
+| const_hit (t06)  | ~9–18 | 6.8  | **2.3**  | −66% |
+| const_miss (t06) | ~9–18 | 1.1  | **1.8**  | +0.7 (no strcmp either way) |
+| var_hit (t06)    | ~9–18 | 10.6 | **5.5**  | −48% |
+| var_miss (t06)   | ~9–18 | 4.0  | **5.6**  | +1.6 |
+| const_short (t03)| ~9–18 | 6.8  | **3.5**  | −49% |
+| const_long (t03) | ~9–18 | 20.8 | **2.2**  | **−89%** (strcmp(38) gone) |
+| var_short (t03)  | ~9–18 | 10.5 | **8.8**  | −16% |
+| var_long (t03)   | ~9–18 | 43.5 | **20.6** | **−53%** (now pure hash, no strcmp) |
+| int_hit (t07)    | ~4–5  | 1.8  | **2.6**  | +0.8 (data compare unchanged; noise) |
+| int_miss (t07)   | ~4–5  | 1.7  | **1.9**  | ~flat |
+| int_update (t07) | —     | 3.8  | **4.3**  | +0.5 |
+| str_update (t07) | —     | 9.9  | **5.7**  | −42% |
+
+Reading it:
+- **String hits no longer strcmp.** `const_long` 20.8 → **2.2** is the whole story: that 20.8 was
+  almost entirely `strcmp(38)`, and it's gone — `const_long` (2.2) now equals `const_short` (3.5),
+  key length is free for constant keys. `var_long` 43.5 → **20.6** drops by the same ~23ns strcmp; the
+  residual 20.6 is the *runtime hash* of the 38-char key (the find itself is the cheap 64-bit compare).
+- **Short-key string hits** drop ~−16 to −66% — the confirm's bound-call overhead is gone with it.
+- **The int data path is unchanged** (SIMD key-data compare, no hash); the sub-nanosecond up-tick on
+  the int lanes is run-to-run noise plus the wider (64- vs 32-bit) hash array touching one more line.
+
+### INTERP ns/op — 64-bit packed (per-SimNode dispatch floor compresses the deltas)
+
+| lane | INTERP | | lane | INTERP |
+|---|---|---|---|---|
+| const_hit  | 12.0 | | int_hit    | 11.2 |
+| const_miss | 14.9 | | int_miss   | 13.3 |
+| var_hit    | 12.6 | | int_update | 10.6 |
+| var_miss   | 13.7 | | str_update | 11.1 |
+| const_short| 12.0 | | const_long | 21.8 |
+| var_short  | 11.8 | | var_long   | 29.2 |
+
+INTERP `const_long` 21.8 / `var_long` 29.2: the strcmp is gone here too (`const_long` was ~strcmp-
+dominated under confirm), the residual long-key cost is the hash. The ~10–15ns floor on the short
+lanes is fixed SimNode dispatch, not the table op.
+
+### Realistic JSON read — good vs bad now CONVERGE (test08, the headline)
+
+The §"Realistic literal-keyed JSON read" `bad_*` control existed to isolate the strcmp tax: `good`
+keys are const-pooled (`a==b` skips strcmp), `bad` keys are runtime-assembled distinct pointers
+(parsed-data shape, strcmp every lookup). **With no strcmp anywhere, that distinction collapses** —
+both lanes compare the 64-bit hash:
+
+| lane | INTERP confirm → 64-bit | JIT confirm → 64-bit |
+|---|---|---|
+| json_find (good)     | 11.8 → **11.2** | 3.6 → **2.1** |
+| json_at (good)       | 10.0 → **10.0** | 3.4 → **1.7** |
+| bad_json_find (parsed)| 14.0 → **11.4** | 6.3 → **2.3** |
+| bad_json_at (parsed) | 12.5 → **10.0** | 5.8 → **1.5** |
+| **good/bad gap (JIT)** | | **2.5 → ~0.2** |
+
+The parsed-data case (`bad_json_find` 6.3 → **2.3** JIT) was the one paying strcmp; it now matches the
+const-pooled case (`json_find` 2.1). **A table built from parsed/IO keys reads as fast as one built
+from string literals** — the strcmp tax that const-pooling used to dodge no longer exists for anyone.
 
 ## Synthesis for the plan
 

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -177,6 +177,41 @@ anything for constant keys. `var_*` (runtime keys) still hash; the inlined loop 
 C++ call (cf. test13), so the straight-line microbench shows little there — the runtime-key
 win is loop hoisting / CSE of an invariant key, which this per-key-once bench doesn't expose.
 
+## Inlined packed find — 3-way A/B/C MEASURED (JIT, `JIT_STRING_FIND` none/scalar/vector)
+
+String-key `?[]` find previously always called the C++ helper (which hashes, then for a
+packed table runs `PackedFind`). We can inline that fixed 8-slot uint32 hash scan on the JIT
+side when the table is small (`cap != 0 && cap <= 8`), falling back to the C++ call for
+empty/hashed. Three variants — `NONE` (always C++), `SCALAR` (unrolled 8× select fold),
+`VECTOR` (`<8 x i32>` compare + `cttz`). Lookup-only benches, ns/op:
+
+| lane | NONE | SCALAR | VECTOR |
+|---|---|---|---|
+| const_hit (t06)  | 4.4 | 2.9 | **1.4** |
+| const_miss (t06) | 5.9 | 2.6 | **1.2** |
+| var_hit (t06)    | 7.0 | 6.9 | **4.8** |
+| var_miss (t06)   | 7.8 | 6.7 | **4.7** |
+| const_short (t03)| 4.7 | 2.9 | **1.4** |
+| const_long (t03) | 4.4 | 3.0 | **1.3** |
+| var_short (t03)  | 6.2 | 7.0 | **4.6** |
+| var_long (t03)   | 17.2 | 20.0 | 17.8 |
+
+**VECTOR wins across the board and is the pick.**
+- Constant keys drop to **~1.3ns** (folded-hash immediate + one SIMD compare) — −70% vs the
+  C++ call. `const_miss` is the sharpest (5.9 → 1.2): the C++ path pays call overhead + a full
+  scan on a miss, while the vector compare costs the same hit or miss.
+- Runtime short keys: ~4.7ns vs ~7 (−33%).
+- `var_long` is *hash*-dominated (a long runtime key costs ~14ns to hash), so the find win is
+  masked — VECTOR ≈ NONE (17.8 vs 17.2). SCALAR even regresses there (20.0) from its extra
+  scalar ops.
+
+**SCALAR** helps constants but is a wash-to-regression on runtime keys — not worth shipping.
+The `JIT_STRING_FIND` toggle stays in the source (defaulting to `VECTOR`) for future A/Bs.
+Gate is `cap != 0 && cap <= TABLE_MAX_LINEAR_CAPACITY` (mirrors C++ `find`: cap==0 → −1, then
+packed); the inlined scan reduces the 64-bit hash to the 32-bit `TableHashKey` exactly as
+`hashToHashKey` does. Covers `?[]`, `key_exists`, and `find` (all route through
+`build_table_find`); `[]`/insert keeps the C++ `at` path.
+
 ## Synthesis for the plan
 
 - **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -287,6 +287,26 @@ The §"Inlined packed find — 3-way" VECTOR column and the `str_update` row in 
 are the pre-confirm (hash-only) measurements; keep them for the SIMD-scan A/B but read the table
 above for shipped behavior.
 
+## Realistic literal-keyed "JSON" read — const-string pooling (test08)
+
+4096 small string-keyed records (6 fields, packed), summed by addressing each field with a string
+LITERAL. daslang pools constant strings, so the literal that *built* a field (`tab["foo"] = 1`)
+and the literal that *reads* it (`tab?["foo"]` / `tab["foo"]`) are the same pointer — the find's
+candidate confirm hits KeyCompare's `a==b` fast path and skips strcmp. This is the common case for
+fixed-field-name access (config, JSON-shaped data, per-entity property maps).
+
+| lane | ns/op | path |
+|---|---|---|
+| json_find (`tab?[k] ?? 0`) | **~3.5** | find (ExprSafeAt) |
+| json_at (`tab[k]`)         | **~3.1** | at/index (ExprAt) |
+
+~3ns/lookup — **~3× faster than the distinct-pointer string hit** (test06 `var_hit` 10.6). The win
+is the `a==b` confirm (no strcmp) on top of a cheap short-key hash and the SIMD packed scan;
+`json_at` edges `json_find` by the `?? 0` null-coalesce the find lane carries. So literal-keyed
+record access is already near int-key cost — the strcmp tax only shows up for keys that arrive by
+distinct pointer (I/O / parsing). const-pull also makes these keys' hash a foldable constant, the
+unexploited item-4 headroom.
+
 ## Synthesis for the plan
 
 - **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -231,6 +231,51 @@ the SIMD compare *is* the whole operation. Inserts of genuinely new keys also sk
 redundant C++ `PackedFind` dedup the JIT already performed. Integer keys only
 (`int`/`uint` ×8/16/32/64); float/double/struct keep the C++ path.
 
+## Correctness: 32-bit hashKey collisions — confirm on find (SUPERSEDES the hash-only numbers above)
+
+The hash-only string path above is **incorrect**: `TableHashKey` is `uint32_t`, so distinct keys
+can share a hashKey and a hash-only match returns a false positive. Fix (all tiers):
+- packed string find returns a hash *candidate*; the caller confirms it with one `KeyCompare`
+  (C++) / bound `jit_string_equal` (JIT). Misses with no hash match never reach the confirm.
+- `reserve` promotes a packed table to open addressing on the first hashKey collision (a
+  confirmed hash-match with a *different* key), so a packed table never holds two same-hashKey
+  slots — the single candidate is always exact. The int/data path is unaffected (exact compare,
+  no hash, no confirm).
+
+Corrected JIT ns/op (warm, 3-run avg), vs the hash-only (wrong) figures and the pre-plan hashed
+baseline (§"Baseline find cost"):
+
+| lane | hashed baseline | hash-only (WRONG) | confirmed (correct) |
+|---|---|---|---|
+| const_hit (t06)  | ~9–18 | 1.4 | **7.7** |
+| const_miss (t06) | ~9–18 | 1.2 | **1.4** |
+| var_hit (t06)    | ~9–18 | 4.8 | **7.7** |
+| var_miss (t06)   | ~9–18 | 4.7 | **4.8** |
+| const_short (t03)| ~9–18 | 1.4 | **7.0** |
+| const_long (t03) | ~9–18 | 1.3 | **21.3** |
+| var_short (t03)  | ~9–18 | 4.6 | **6.7** |
+| var_long (t03)   | ~9–18 | 17.8 | **19.6** |
+| int_hit (t07)    | ~4–5 | 1.8 | **1.9** |
+| int_miss (t07)   | ~4–5 | 1.6 | **1.8** |
+| int_update (t07) | — | 4.5 | **3.8** |
+| str_update (t07) | — | 4.1 | **6.5** |
+
+Reading it:
+- **Misses and the whole int path are unchanged** — the confirm only fires on a hash-candidate
+  hit, and ints never hash/confirm. `const_miss` ~1.4ns and `int_hit` ~1.9ns stand.
+- **String hits now pay one strcmp confirm** — short keys +~5–6ns (≈7ns total), the 38-char key
+  +~18ns (≈21ns). `const_hit` ≈ `var_hit` because the strcmp+call dominates and the folded-hash
+  saving is now a small fraction. The confirm is a *bound call* — its fixed overhead is the bulk
+  of the short-key cost; an inlined/generated `string==` is the obvious next lever.
+- **Still beats the hashed baseline across the board**: packed short-string hit ~7ns vs hashed
+  ~9–18; packed miss ~1.4ns vs ~9–18; int hit ~1.9ns vs ~4–5. The confirm removes the (illusory)
+  hash-only speedup, not the packed win — packed pays the *same* one strcmp a hashed hit pays,
+  on top of a cheaper scan, and skips strcmp entirely on a miss.
+
+The §"Inlined packed find — 3-way" VECTOR column and the `str_update` row in §"Integer-key find"
+are the pre-confirm (hash-only) measurements; keep them for the SIMD-scan A/B but read the table
+above for shipped behavior.
+
 ## Synthesis for the plan
 
 - **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -242,35 +242,46 @@ can share a hashKey and a hash-only match returns a false positive. Fix (all tie
   slots — the single candidate is always exact. The int/data path is unaffected (exact compare,
   no hash, no confirm).
 
+**Benchmark fix:** the `var_*` HIT lanes previously queried with the *stored* key pointer
+(`let k = KEYS[i]`), so the confirm hit `KeyCompare`'s `a==b` pointer-identity fast path and
+**never ran strcmp** — flattering every string hit. They now query distinct-pointer copies
+(`clone_string`), the realistic case (a key from I/O / parsing is never the stored pointer). The
+`var_*` MISS lanes and the int lanes are unaffected (a miss never confirms; ints never strcmp).
+
 Corrected JIT ns/op (warm, 3-run avg), vs the hash-only (wrong) figures and the pre-plan hashed
-baseline (§"Baseline find cost"):
+baseline (§"Baseline find cost"). `confirmed` = honest distinct-pointer measurement:
 
 | lane | hashed baseline | hash-only (WRONG) | confirmed (correct) |
 |---|---|---|---|
-| const_hit (t06)  | ~9–18 | 1.4 | **7.7** |
-| const_miss (t06) | ~9–18 | 1.2 | **1.4** |
-| var_hit (t06)    | ~9–18 | 4.8 | **7.7** |
-| var_miss (t06)   | ~9–18 | 4.7 | **4.8** |
-| const_short (t03)| ~9–18 | 1.4 | **7.0** |
-| const_long (t03) | ~9–18 | 1.3 | **21.3** |
-| var_short (t03)  | ~9–18 | 4.6 | **6.7** |
-| var_long (t03)   | ~9–18 | 17.8 | **19.6** |
-| int_hit (t07)    | ~4–5 | 1.8 | **1.9** |
-| int_miss (t07)   | ~4–5 | 1.6 | **1.8** |
+| const_hit (t06)  | ~9–18 | 1.4 | **6.8** |
+| const_miss (t06) | ~9–18 | 1.2 | **1.1** |
+| var_hit (t06)    | ~9–18 | 4.8 | **10.6** |
+| var_miss (t06)   | ~9–18 | 4.7 | **4.0** |
+| const_short (t03)| ~9–18 | 1.4 | **6.8** |
+| const_long (t03) | ~9–18 | 1.3 | **20.8** |
+| var_short (t03)  | ~9–18 | 4.6 | **10.5** |
+| var_long (t03)   | ~9–18 | 17.8 | **43.5** |
+| int_hit (t07)    | ~4–5 | 1.8 | **1.8** |
+| int_miss (t07)   | ~4–5 | 1.6 | **1.7** |
 | int_update (t07) | — | 4.5 | **3.8** |
-| str_update (t07) | — | 4.1 | **6.5** |
+| str_update (t07) | — | 4.1 | **9.9** |
 
 Reading it:
 - **Misses and the whole int path are unchanged** — the confirm only fires on a hash-candidate
-  hit, and ints never hash/confirm. `const_miss` ~1.4ns and `int_hit` ~1.9ns stand.
-- **String hits now pay one strcmp confirm** — short keys +~5–6ns (≈7ns total), the 38-char key
-  +~18ns (≈21ns). `const_hit` ≈ `var_hit` because the strcmp+call dominates and the folded-hash
-  saving is now a small fraction. The confirm is a *bound call* — its fixed overhead is the bulk
-  of the short-key cost; an inlined/generated `string==` is the obvious next lever.
-- **Still beats the hashed baseline across the board**: packed short-string hit ~7ns vs hashed
-  ~9–18; packed miss ~1.4ns vs ~9–18; int hit ~1.9ns vs ~4–5. The confirm removes the (illusory)
-  hash-only speedup, not the packed win — packed pays the *same* one strcmp a hashed hit pays,
-  on top of a cheaper scan, and skips strcmp entirely on a miss.
+  hit, and ints never hash/confirm. `const_miss` ~1.1ns and `int_hit` ~1.8ns stand.
+- **The const-vs-var gap is now the runtime hash** (both lanes pay one strcmp): short keys
+  ~3.7ns (10.5 − 6.8), the 38-char key **~22.7ns** (43.5 − 20.8). That gap is exactly item 4's
+  target — folding a constant key's hash to an immediate. `const_long` ≈ 20.8 is almost entirely
+  the strcmp (hash folds to 0), so **strcmp(38) ≈ 20ns and hash(38) ≈ 22ns** — both O(len) walks
+  of the same bytes.
+- **String hits pay one strcmp confirm** — the cost the hash-only path skipped (incorrectly).
+  The confirm is a *bound call*; its fixed overhead is a large slice of the short-key cost
+  (`const_hit` 6.8 for a ≤7-char key), so an inlined/generated `string==` is the obvious next
+  lever — it cannot help the long-key strcmp itself, but removes the call overhead on short keys.
+- **Vs the hashed baseline:** packed wins on misses (skips strcmp entirely: ~1.1–4ns vs ~9–18)
+  and on int (~1.8 vs ~4–5). For string hits packed pays the *same* one strcmp a hashed hit pays
+  on a cheaper scan, so it is at worst a wash and better for short keys; long-key hits are
+  hash+strcmp-dominated either way (the scan saving is in the noise).
 
 The §"Inlined packed find — 3-way" VECTOR column and the `str_update` row in §"Integer-key find"
 are the pre-confirm (hash-only) measurements; keep them for the SIMD-scan A/B but read the table

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -1,0 +1,132 @@
+# Small-table benchmark results
+
+Pre-plan measurements for the builtin-table perf work (minCapacity, linear/packed
+small mode, hash-only compare, const-key hash). All numbers are ns/op on this
+machine; treat as relative, not absolute. `[JIT]` = `-jit`, else interpreter.
+
+Methodology notes:
+- hit/miss lanes repeat the N-key sweep REPS=64× inside the measured block so fixed
+  per-`run` harness overhead amortizes to ~0 and ns/op reflects one lookup at size N.
+- String lookups query with **distinct-pointer** keys (content-equal, freshly built)
+  so the `KeyCompare a==b` fast path misses and a real strcmp runs — the realistic
+  case. Querying with the stored pointers hits the fast path and understates find by
+  the strcmp (~5ns short key, ~23ns for a 38-char key).
+
+## Baseline find cost (current hashed table)
+
+| op | INTERP tail | JIT tail | notes |
+|---|---|---|---|
+| int hit/miss | ~10–11ns | ~4–5ns | O(1), flat across N |
+| string hit (short key, distinct-ptr) | ~22–30ns | ~9–18ns | rises with N (probe growth) |
+
+The strcmp tiebreak measured directly (38-char key, distinct vs same pointer):
+**+22.7ns INTERP / +22.8ns JIT**. This is the cost item 3 (hash-only compare) removes.
+
+## #3 minCapacity 8 → 4 (standalone, A/B build)
+
+| N | min8 ns / B/op | min4 ns / B/op | verdict |
+|---|---|---|---|
+| 1 | 93.7 / 96 | 106.6 / **48** | half the memory, same rehash |
+| 2 | 50.4 / 48 | 57.2 / **24** | half the memory, same rehash |
+| 3 | 36.3 / 32 | 54.6 / 48 | **+18ns** extra rehash, no mem gain |
+| 4 | 30.7 / 24 | 42.5 / 36 | **+12ns** extra rehash |
+| 8 | 26.6 | 32.5 | +6ns; many-tables B/op 44 → 50 (worse) |
+| 64 | 26.8 | 27.1 | amortized away |
+
+**Conclusion: minCapacity 8→4 helps only N=1–2 (halves the alloc), regresses N≥3**
+(one extra rehash to reach the *same* final capacity). Do NOT ship item 1 standalone;
+it is only a clean win coupled with packed mode (cap-4 holds 4 at load factor 1.0,
+no early rehash).
+
+## #2 Many small tables (4096 tables × 8 elems, decs/per-entity shape)
+
+| | INTERP | JIT | B/op |
+|---|---|---|---|
+| int_build | 30.0 | 18.2 | 44 |
+| int_query (cold sweep) | 11.2 | 5.1 | 0 |
+| str_build | 42.2 | 28.6 | 56 |
+| str_query (cold sweep) | 20.5 | 14.1 | 0 |
+
+Cold-sweep query ≈ hot single-table query (4096 tables ≈ 1–2MB fits L2, sequential
+prefetch). **Cache locality is a minor factor at this scale; the item-1 lever is
+memory (B/op), not cache.** The cache angle would only bite at far higher table
+counts / randomized access.
+
+## #4 Crossover prototype — predicts maxLinearCapacity
+
+`lin_*` = inlined hash-only linear scan over array<uint64> (packed-find shape);
+`hash_*` = real open-addressed `?[]`. **Only the JIT tier is a valid predictor** —
+in INTERP the linear lane is interpreted das while the hashed lane is a single
+compiled C++ SimNode, so INTERP unfairly buries linear (ignore those rows).
+
+JIT (ns/op):
+
+| N | lin_short | hash_short | lin_long | hash_long |
+|---|---|---|---|---|
+| 2  | 4.7 | 7.8 | 14.7 | 39.2 |
+| 4  | 5.1 | 8.4 | 14.7 | 39.8 |
+| 8  | 6.1 | 9.8 | 15.8 | 41.2 |
+| 12 | 7.2 | 10.5 | 17.4 | 40.3 |
+| 16 | 7.9 | 10.4 | 17.7 | 41.0 |
+| 24 | 9.3 | 11.1 | 19.5 | 41.5 |
+| 32 | 11.2 | 11.0 | 21.3 | 44.1 |
+
+**Hash-only linear scan beats hashed find up to N≈24–32 for short keys, and well
+beyond 32 for long keys** (where the ~23ns strcmp the linear scan skips dominates).
+This is a **conservative lower bound**: the linear lane is handicapped by a bound
+`hash()` call + bounds-checked array indexing that a real C++ packed find would not
+have. Linear-scan cost grows only ~0.2ns/element.
+
+**Conclusion: maxLinearCapacity = 8 is very safe, 16 is comfortable, and even 32 is
+defensible — especially for string keys. The crossover win is dominated by skipping
+strcmp (item 3), which is why it scales with key length.**
+
+## Packed mode — MEASURED (post-implementation, `maxLinearCapacity = 8`, `minCapacity = 8`)
+
+Re-ran `test01`/`test02`/`test04` against the packed build (items 2 + 3 landed: dense
+insertion-order slots at load factor 1.0, hash-only string compare, swap-remove erase,
+promote to open-addressing on the 9th insert). Baseline columns are the hashed-table
+numbers above. Same machine, same methodology.
+
+### test04 — many small tables (4096 × 8, the decs/per-entity shape) — the headline
+
+| op | INTERP base → packed | JIT base → packed | B/op base → packed |
+|---|---|---|---|
+| int_build | 30.0 → **24.2** (−19%) | 18.2 → **14.9** (−18%) | 44 → **20** (−55%) |
+| int_query | 11.2 → 11.4 (flat)     | 5.1 → 5.9 (+16%, scan tax) | 0 → 0 |
+| str_build | 42.2 → **30.2** (−28%) | 28.6 → **13.7** (−52%) | 56 → **24** (−57%) |
+| str_query | 20.5 → 20.0 (−2%)      | 14.1 → **7.5** (−47%) | 0 → 0 |
+
+**Memory roughly halves across the board** (load factor 1.0 + cap-8 vs cap-16-at-0.5).
+String build/query roughly halve in JIT. The only regression is int_query (+0.8ns JIT):
+the linear scan walks the slots while the hashed path was O(1), and int keys get no
+strcmp-skip to pay for it. In INTERP the SimNode-dispatch floor masks both effects.
+
+### test01 / test02 — single-table N sweep (packed for N ≤ 8, hashed N ≥ 12)
+
+- **int build** (JIT): `build/8` 16.1ns vs baseline-min8 26.6ns; B/op 12 vs 96-at-N=1.
+- **int hit/miss** (JIT): packed `hit/8` 6.5ns, `miss/8` 7.7ns — slightly above the hashed
+  N≥12 floor (~4ns). The scan tax, small in absolute terms.
+- **str hit** (JIT): packed `hit/8` 7.2ns, flat in N; hashed regime in the same run rises
+  (`hit/12` 9.5 → `hit/64` 15.6). Win confirmed even on **short** keys (`key_0`..`key_7`);
+  it grows with key length (the +22.8ns long-key strcmp the hash-only path skips).
+- INTERP shows the same ordering with the dispatch floor compressing the deltas.
+
+**Verdict: ship.** Build + memory win is uniform and large (the decs case ~halves both);
+the string-find win is real and length-scaling; the lone cost is a sub-nanosecond int-query
+scan tax that the build/memory win dwarfs. `maxLinearCapacity = 8` is validated; 16 remains
+defensible for string-heavy workloads (revisit in sub-phase 3 follow-up alongside
+`minCapacity 8→4`).
+
+## Synthesis for the plan
+
+- **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor
+  1.0, linear hash-only scan, swap-remove erase, promote to open-addressing past the
+  threshold) is the structural core. minCapacity 4 only makes sense inside it.
+- **Item 3 is the dominant string win** and is the main reason linear scan wins; it
+  rides inside packed mode (trust the 64-bit hash, skip strcmp — small-table mode only).
+- **Item 4** (const-key precomputed hash) validated independently: a JIT hash intrinsic
+  const-folds a literal-key hash to an immediate (free). Currently disabled; wire it in
+  with a find-with-precomputed-hash seam when we build item 4.
+- **Threshold:** start at 8 (conservative), 16 well-supported by the data. A single
+  global value captures most of the win for both key types; per-type is optional polish.

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -398,6 +398,53 @@ The parsed-data case (`bad_json_find` 6.3 → **2.3** JIT) was the one paying st
 const-pooled case (`json_find` 2.1). **A table built from parsed/IO keys reads as fast as one built
 from string literals** — the strcmp tax that const-pooling used to dodge no longer exists for anyone.
 
+## Interpreter const-string key fast path — SimNode_*_WithHash + OP1 fusion (SHIPPED)
+
+The 64-bit packed change above removed strcmp on every tier. The remaining per-lookup cost for a
+string key in the *interpreter* is the `hash_blockz64` byte walk over the key (JIT/AOT already fold a
+constant key's hash to an immediate; the interpreter still hashed at runtime — this was the interp↔JIT
+gap, e.g. JSON const lane ~2ns JIT vs ~11ns interp). When the key is an `ExprConstString` its bytes
+and hash are known at simulate time, so we bake both into a dedicated node and skip the walk.
+
+- **WithHash nodes** (`runtime_table_nodes.h`): `SimNode_TableIndex_WithHash` (`tab["lit"]`),
+  `SimNode_SafeTableIndex_WithHash` (`tab?["lit"]`), `SimNode_TableFind_WithHash` /
+  `SimNode_KeyExists_WithHash` (the `__builtin_table_find` / `__builtin_table_key_exists` intrinsics).
+  `reserve`/`find` already take the hash as a parameter, so the node passes the baked hash directly;
+  the key string is carried only for the large-table `KeyCompare` confirm. Interpreter-only — JIT and
+  AOT lower from the AST and keep their own const-hash folding. `find`/`key_exists` *user* calls route
+  through non-inlined daslib generic wrappers, so the literal only reaches the node via the
+  `__builtin_table_*` intrinsics today (and via the wrappers once they inline).
+- **OP1 fusion** (`simulate_fusion_tablewithhash.cpp`): each WithHash node has a single sub-node — the
+  table container (`tabExpr` → `Table*`). Fuse that container load in, dropping one virtual dispatch
+  per lookup. The container is an lvalue address, so it uses the OP1-SET matcher (`GetLocal` /
+  `GetGlobal` / `GetLocalRefOff` / argument / block-arg shapes — the same set OP2-SET's left/container
+  side matches for array-at), extended to the full 7-shape set so tables reached as locals, globals,
+  struct fields, array/loop-variable elements, and argument fields all fuse. Shapes outside the set
+  fall back to the un-fused WithHash node (also the Debug path — both are exercised and correct).
+
+### Interp ns/op — within-branch progression (baseline = the 64-bit packed build above)
+
+| lane | 64-bit packed | +WithHash | +fusion (local var) |
+|---|---|---|---|
+| const_long (38-char literal) | 21.8 | **8.5** | **7.6** |
+| const_short | 12.0 | 8.6 | **7.9** |
+| const_hit | 12.0 | 8.6 | **7.6** |
+| const_miss | 14.9 | 11.2 | **9.8** |
+| json_find / json_at | 11.2 / 10.0 | 8.6 / 9.2 | 8.6 / 9.2 |
+
+Reading it:
+- **WithHash is the lever**: `const_long` 21.8 → **8.5** — the 38-char hash walk is gone, key length is
+  now free for a literal key (`const_long` ≈ `const_short`), exactly mirroring the JIT's item-4 fold.
+- **Fusion** shaves ~1ns more on the single-local-table case (`const_hit` 8.6 → 7.6) and removes the
+  extra container node across every shape. For ref-off container shapes (loop variable, array element,
+  struct field — e.g. the `for (tab in tables)` json loop, which fuses as `…WithHashLocro`) the shave
+  is roughly flat: `computeLocalRefOff` costs about what the separate dispatch did. So json holds at
+  ~8.6/9.2 — the WithHash win is already banked there; fusion is node-cleanliness, not extra speed.
+- Runtime-key lanes (`var_*`) are unchanged — only literal keys fold.
+
+(End-to-end master-vs-branch before/after — measured on the same machine with the same bench files run
+against an un-optimized master build — is the final section below / the PR body.)
+
 ## Synthesis for the plan
 
 - **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -206,8 +206,8 @@ empty/hashed. Three variants — `NONE` (always C++), `SCALAR` (unrolled 8× sel
   scalar ops.
 
 **SCALAR** helps constants but is a wash-to-regression on runtime keys — not worth shipping.
-The `JIT_STRING_FIND` toggle stays in the source (defaulting to `VECTOR`) for future A/Bs.
-Gate is `cap != 0 && cap <= TABLE_MAX_LINEAR_CAPACITY` (mirrors C++ `find`: cap==0 → −1, then
+VECTOR shipped; the NONE/SCALAR paths and the `JIT_STRING_FIND` toggle were stripped (no dead
+code). Gate is `cap != 0 && cap <= TABLE_MAX_LINEAR_CAPACITY` (mirrors C++ `find`: cap==0 → −1, then
 packed); the inlined scan reduces the 64-bit hash to the 32-bit `TableHashKey` exactly as
 `hashToHashKey` does. Covers `?[]`, `key_exists`, and `find` (all route through
 `build_table_find`); `[]`/insert keeps the C++ `at` path.

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -212,6 +212,25 @@ packed); the inlined scan reduces the 64-bit hash to the 32-bit `TableHashKey` e
 `hashToHashKey` does. Covers `?[]`, `key_exists`, and `find` (all route through
 `build_table_find`); `[]`/insert keeps the C++ `at` path.
 
+## Integer-key find + tab[key] update — MEASURED (JIT, test07)
+
+The inline packed find was extended to integer keys (a `<8 x KeyT>` compare of the key data
+over `[0,size)` with a liveness mask — no hash on the packed path) and to the insert path
+(`tab[key]`: SIMD find first; a hit returns the slot, a miss inserts via
+`reserveAfterPackedMiss`, skipping the C++ packed dedup).
+
+| lane | ns/op | note |
+|---|---|---|
+| int_hit  | 1.8 | pure SIMD key compare, **no hash** (vs ~5.1 baseline C++ int find → −65%) |
+| int_miss | 1.6 | same cost as hit (branch-free) |
+| int_update (`tab[k]++`) | 4.5 | find-first hit → slot, no C++ `at` call |
+| str_update (`tab[k]++`) | 4.1 | same fast-path on the string `at` |
+
+Integer find is the standout: with no hash to compute, a small int-keyed lookup is ~1.7ns —
+the SIMD compare *is* the whole operation. Inserts of genuinely new keys also skip the
+redundant C++ `PackedFind` dedup the JIT already performed. Integer keys only
+(`int`/`uint` ×8/16/32/64); float/double/struct keep the C++ path.
+
 ## Synthesis for the plan
 
 - **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -118,6 +118,65 @@ scan tax that the build/memory win dwarfs. `maxLinearCapacity = 8` is validated;
 defensible for string-heavy workloads (revisit in sub-phase 3 follow-up alongside
 `minCapacity 8→4`).
 
+## Hash intrinsic — A/B MEASURED (JIT, fast 16-bit-load `$::hash` on vs off)
+
+A/B by toggling the `$::hash` registration in `llvm_jit_intrin.das` (cache cleared
+between runs); "on" = inlined 16-bit-load intrinsic, "off" = runtime call into
+`hash_blockz64`. Numbers are stable over 3 runs (the first cold-codegen run reads
+high — discard it).
+
+### Bare `hash(string)` — `core/hash/test13`, 256 runtime keys
+
+| key | intrinsic on | call (off) | verdict |
+|---|---|---|---|
+| short (`k0`..`k255`) | **1.9ns** | 2.9ns | −34% — call overhead removed |
+| long (38-char) | 12.7ns | 12.1ns | ~on par (the win is no-call-overhead; the
+  MSVC-optimized `hash_blockz64` loop body is otherwise as good as the JIT's) |
+
+So the 16-bit version meets the bar: faster on short (the common key shape), on par
+on long. The earlier byte-by-byte version lost on long; the 16-bit load (half the
+iterations) closes that gap.
+
+### Table lookup `tab?[key]` — `core/small_table/test03`, 8-elem table
+
+The intrinsic does **not** reach table lookups, and the numbers confirm it: with vs
+without the `$::hash` intrinsic, every lane is identical (3-run stable).
+
+| lane | intrinsic on | intrinsic off |
+|---|---|---|
+| const_short | 7.0 | 7.0 |
+| var_short | 7.0 | 7.0 |
+| const_long | 16.2 | 16.7 |
+| var_long | 16.5 | 17.0 |
+
+Why: `tab?[key]` lowers to `build_table_find` → the C++ `jit_table_find(tab, key,
+valueTypeSize, ctx)` (llvm_jit.das:1856), which takes the **key** and computes the
+hash *internally*. The JIT-side `$::hash` intrinsic is never invoked on this path, so
+toggling it changes nothing. `const_* == var_*` for the same reason — nothing folds.
+
+(An earlier single-run A/B mis-measured this as −30-38%; that "off" run was an outlier
+under background load. The 3-run numbers above are the truth: zero current effect.)
+
+**This was the gap — now closed.** Added `jit_string_table_find_with_hash` /
+`jit_string_table_at_with_hash` (C++, take a precomputed hash) and routed string-key
+`?[]`/`[]` through them, emitting `hash(key)` via `build_string_hash` (the shared
+intrinsic IR). String-only, find+at — 2 functions, not the whole matrix.
+
+### Table lookup `tab?[key]` — with-hash lowering MEASURED (JIT, 3-run stable)
+
+| lane | before (hash in C++) | with-hash | Δ |
+|---|---|---|---|
+| const_short | 7.0 | **4.7** | −33% |
+| const_long | 16.2 | **4.5** | **−72%** |
+| var_short | 7.0 | 6.3 | −10% |
+| var_long | 16.5 | 17.2 | ~flat |
+
+**Pure item 4 is realized:** a literal key's hash folds to an immediate and disappears —
+`const_long` (4.5) now equals `const_short` (4.7), i.e. key length no longer costs
+anything for constant keys. `var_*` (runtime keys) still hash; the inlined loop ≈ the old
+C++ call (cf. test13), so the straight-line microbench shows little there — the runtime-key
+win is loop hoisting / CSE of an invariant key, which this per-key-once bench doesn't expose.
+
 ## Synthesis for the plan
 
 - **Items 1 + 2 are coupled.** Packed small mode (insertion-dense slots, load factor

--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -295,17 +295,27 @@ and the literal that *reads* it (`tab?["foo"]` / `tab["foo"]`) are the same poin
 candidate confirm hits KeyCompare's `a==b` fast path and skips strcmp. This is the common case for
 fixed-field-name access (config, JSON-shaped data, per-entity property maps).
 
-| lane | ns/op | path |
-|---|---|---|
-| json_find (`tab?[k] ?? 0`) | **~3.5** | find (ExprSafeAt) |
-| json_at (`tab[k]`)         | **~3.1** | at/index (ExprAt) |
+The `bad_*` lanes are the control: same scan (const literals) but the table is built with keys
+assembled at runtime (`var foo = "fo"; foo += "o"`), so the stored key is a distinct heap pointer,
+`a==b` misses, and a real strcmp runs every lookup (the table-from-parsed-data case).
 
-~3ns/lookup — **~3× faster than the distinct-pointer string hit** (test06 `var_hit` 10.6). The win
-is the `a==b` confirm (no strcmp) on top of a cheap short-key hash and the SIMD packed scan;
-`json_at` edges `json_find` by the `?? 0` null-coalesce the find lane carries. So literal-keyed
-record access is already near int-key cost — the strcmp tax only shows up for keys that arrive by
-distinct pointer (I/O / parsing). const-pull also makes these keys' hash a foldable constant, the
-unexploited item-4 headroom.
+| lane | INTERP | JIT | path |
+|---|---|---|---|
+| json_find (good, const-pull `a==b`)   | ~11.8 | **~3.6** | find (ExprSafeAt) |
+| json_at (good)                        | ~10.0 | **~3.4** | at/index (ExprAt) |
+| bad_json_find (distinct ptr, strcmp)  | ~14.0 | ~6.3 | find |
+| bad_json_at (distinct ptr, strcmp)    | ~12.5 | ~5.8 | at |
+| **strcmp tax (bad − good)**           | **~2.3** | **~2.5** | short 3–4 char key |
+
+- Literal-keyed access is **~3ns JIT / ~10–12ns interp** — near int-key cost, and **~3× faster
+  than the distinct-pointer string hit** (test06 `var_hit` 10.6). The win is the `a==b` confirm
+  (no strcmp) on a cheap short-key hash + the SIMD packed scan; `json_at` edges `json_find` by the
+  `?? 0` the find lane carries.
+- **The strcmp tax is tier-independent (~2.5ns for a 3–4 char key)** — it is the same C++ compare
+  on both tiers; the ~3.3× interp/JIT gap is fixed per-node dispatch layered on top, not the table
+  op. So const-pull is worth ~2.5ns/lookup on a hit, on every tier.
+- const-pull also makes these keys' hash a foldable constant — the unexploited item-4 headroom
+  sitting under the good lanes.
 
 ## Synthesis for the plan
 

--- a/benchmarks/core/small_table/test01.das
+++ b/benchmarks/core/small_table/test01.das
@@ -1,0 +1,74 @@
+options gen2
+options persistent_heap
+
+// Small integer-keyed table micro-benchmarks.
+// Sweeps table size N across the small regime to locate the linear-vs-hashed
+// crossover (maxLinearCapacity). Three decisive operations: build (insert+alloc),
+// positive lookup (hit), negative lookup (miss, worst case for a linear scan).
+//
+// hit/miss repeat the N-key sweep REPS times inside the measured block (chunk =
+// N*REPS) so fixed per-run harness overhead amortizes away and ns/op reflects a
+// single lookup at table-size N — the number the crossover decision turns on.
+
+require dastest/testing_boost
+
+let SIZES = [1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64]
+let REPS = 64
+
+[benchmark]
+def small_int_build(b : B?) {
+    for (n in SIZES) {
+        b |> run("build/{n}", n) {
+            var tab : table<int; int>
+            for (i in range(n)) {
+                unsafe(tab[i]) = i * 2
+            }
+            unsafe { delete tab; }
+        }
+    }
+}
+
+[benchmark]
+def small_int_hit(b : B?) {
+    for (n in SIZES) {
+        var tab : table<int; int>
+        for (i in range(n)) {
+            unsafe(tab[i]) = i * 2
+        }
+        let expected = REPS * (n - 1) * n     // REPS * sum(i*2, i in 0..n-1)
+        b |> run("hit/{n}", n * REPS) {
+            var s = 0
+            for (r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[i] ?? 0
+                }
+            }
+            if (s != expected) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+    }
+}
+
+[benchmark]
+def small_int_miss(b : B?) {
+    for (n in SIZES) {
+        var tab : table<int; int>
+        for (i in range(n)) {
+            unsafe(tab[i]) = i * 2
+        }
+        b |> run("miss/{n}", n * REPS) {
+            var s = 0
+            for (r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[i + 1000000] ?? 0
+                }
+            }
+            if (s != 0) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+    }
+}

--- a/benchmarks/core/small_table/test01.das
+++ b/benchmarks/core/small_table/test01.das
@@ -19,7 +19,7 @@ let REPS = 64
 def small_int_build(b : B?) {
     for (n in SIZES) {
         b |> run("build/{n}", n) {
-            var tab : table<int; int>
+            var tab : table<int; int>  // nolint:STYLE027  measuring the build
             for (i in range(n)) {
                 unsafe(tab[i]) = i * 2
             }
@@ -31,14 +31,11 @@ def small_int_build(b : B?) {
 [benchmark]
 def small_int_hit(b : B?) {
     for (n in SIZES) {
-        var tab : table<int; int>
-        for (i in range(n)) {
-            unsafe(tab[i]) = i * 2
-        }
+        var tab <- {for (i in range(n)); i => i * 2}
         let expected = REPS * (n - 1) * n     // REPS * sum(i*2, i in 0..n-1)
         b |> run("hit/{n}", n * REPS) {
             var s = 0
-            for (r in range(REPS)) {
+            for (_r in range(REPS)) {
                 for (i in range(n)) {
                     s += tab?[i] ?? 0
                 }
@@ -54,13 +51,10 @@ def small_int_hit(b : B?) {
 [benchmark]
 def small_int_miss(b : B?) {
     for (n in SIZES) {
-        var tab : table<int; int>
-        for (i in range(n)) {
-            unsafe(tab[i]) = i * 2
-        }
+        var tab <- {for (i in range(n)); i => i * 2}
         b |> run("miss/{n}", n * REPS) {
             var s = 0
-            for (r in range(REPS)) {
+            for (_r in range(REPS)) {
                 for (i in range(n)) {
                     s += tab?[i + 1000000] ?? 0
                 }

--- a/benchmarks/core/small_table/test02.das
+++ b/benchmarks/core/small_table/test02.das
@@ -1,0 +1,95 @@
+options gen2
+options persistent_heap
+
+// Small string-keyed table micro-benchmarks.
+// Same N sweep as test01 but with string keys, where the hash (strlen + block)
+// and the strcmp tiebreak dominate. Key strings are pre-built outside the measured
+// block so we isolate table find/insert cost from string construction.
+// This is the regime items 2 (linear scan), 3 (hash-only compare) target.
+//
+// hit/miss repeat the sweep REPS times (chunk = N*REPS) to amortize harness
+// overhead — see test01 for the rationale.
+
+require dastest/testing_boost
+
+let SIZES = [1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64]
+let REPS = 64
+
+def build_keys(n : int; prefix : string) : array<string> {
+    var keys : array<string>
+    for (i in range(n)) {
+        keys |> push("{prefix}_{i}")
+    }
+    return <- keys
+}
+
+[benchmark]
+def small_str_build(b : B?) {
+    for (n in SIZES) {
+        var keys <- build_keys(n, "key")
+        b |> run("build/{n}", n) {
+            var tab : table<string; int>
+            for (i in range(n)) {
+                unsafe(tab[keys[i]]) = i * 2
+            }
+            unsafe { delete tab; }
+        }
+        delete keys
+    }
+}
+
+[benchmark]
+def small_str_hit(b : B?) {
+    for (n in SIZES) {
+        var keys <- build_keys(n, "key")
+        // probe holds the SAME content but distinct pointers, so the KeyCompare a==b
+        // fast path misses and a real strcmp runs — the realistic lookup case (keys
+        // are parsed/built independently of what was stored), not interned reuse.
+        var probe <- build_keys(n, "key")
+        var tab : table<string; int>
+        for (i in range(n)) {
+            unsafe(tab[keys[i]]) = i * 2
+        }
+        let expected = REPS * (n - 1) * n     // REPS * sum(i*2, i in 0..n-1)
+        b |> run("hit/{n}", n * REPS) {
+            var s = 0
+            for (r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[probe[i]] ?? 0
+                }
+            }
+            if (s != expected) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+        delete keys
+        delete probe
+    }
+}
+
+[benchmark]
+def small_str_miss(b : B?) {
+    for (n in SIZES) {
+        var keys <- build_keys(n, "key")
+        var misses <- build_keys(n, "absent")
+        var tab : table<string; int>
+        for (i in range(n)) {
+            unsafe(tab[keys[i]]) = i * 2
+        }
+        b |> run("miss/{n}", n * REPS) {
+            var s = 0
+            for (r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[misses[i]] ?? 0
+                }
+            }
+            if (s != 0) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+        delete keys
+        delete misses
+    }
+}

--- a/benchmarks/core/small_table/test02.das
+++ b/benchmarks/core/small_table/test02.das
@@ -16,10 +16,7 @@ let SIZES = [1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64]
 let REPS = 64
 
 def build_keys(n : int; prefix : string) : array<string> {
-    var keys : array<string>
-    for (i in range(n)) {
-        keys |> push("{prefix}_{i}")
-    }
+    var keys <- [for (i in range(n)); "{prefix}_{i}"]
     return <- keys
 }
 
@@ -28,7 +25,7 @@ def small_str_build(b : B?) {
     for (n in SIZES) {
         var keys <- build_keys(n, "key")
         b |> run("build/{n}", n) {
-            var tab : table<string; int>
+            var tab : table<string; int>  // nolint:STYLE027  measuring the build
             for (i in range(n)) {
                 unsafe(tab[keys[i]]) = i * 2
             }
@@ -46,14 +43,11 @@ def small_str_hit(b : B?) {
         // fast path misses and a real strcmp runs — the realistic lookup case (keys
         // are parsed/built independently of what was stored), not interned reuse.
         var probe <- build_keys(n, "key")
-        var tab : table<string; int>
-        for (i in range(n)) {
-            unsafe(tab[keys[i]]) = i * 2
-        }
+        var tab <- {for (i in range(n)); keys[i] => i * 2}
         let expected = REPS * (n - 1) * n     // REPS * sum(i*2, i in 0..n-1)
         b |> run("hit/{n}", n * REPS) {
             var s = 0
-            for (r in range(REPS)) {
+            for (_r in range(REPS)) {
                 for (i in range(n)) {
                     s += tab?[probe[i]] ?? 0
                 }
@@ -73,13 +67,10 @@ def small_str_miss(b : B?) {
     for (n in SIZES) {
         var keys <- build_keys(n, "key")
         var misses <- build_keys(n, "absent")
-        var tab : table<string; int>
-        for (i in range(n)) {
-            unsafe(tab[keys[i]]) = i * 2
-        }
+        var tab <- {for (i in range(n)); keys[i] => i * 2}
         b |> run("miss/{n}", n * REPS) {
             var s = 0
-            for (r in range(REPS)) {
+            for (_r in range(REPS)) {
                 for (i in range(n)) {
                     s += tab?[misses[i]] ?? 0
                 }

--- a/benchmarks/core/small_table/test03.das
+++ b/benchmarks/core/small_table/test03.das
@@ -1,0 +1,133 @@
+options gen2
+options persistent_heap
+
+// Constant-string-key lookup micro-benchmark (item 4 target).
+// `const_*` lanes use string literals as keys — the hash (and strlen) are
+// compile-time constant and can be baked into a specialized node. `var_*` lanes
+// look up the same strings via a prebuilt array (runtime hash) as the control.
+// At baseline both lanes cost the same; the const lane is what item 4 speeds up.
+//
+// Short- and long-key lanes: item 4's win scales with key length (the hash walk
+// it removes is O(len)), so the long lane shows the headroom the short lane hides.
+
+require dastest/testing_boost
+
+let REPS = 64
+
+let SHORT_KEYS = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"]
+let LONG_KEYS = [
+    "this/is/a/fairly/long/identifier/alpha",
+    "this/is/a/fairly/long/identifier/bravo",
+    "this/is/a/fairly/long/identifier/charlie",
+    "this/is/a/fairly/long/identifier/delta",
+    "this/is/a/fairly/long/identifier/echo",
+    "this/is/a/fairly/long/identifier/foxtrot",
+    "this/is/a/fairly/long/identifier/golf",
+    "this/is/a/fairly/long/identifier/hotel"
+]
+
+def fill(var tab : table<string; int>; keys : array<string>) {
+    for (i in range(length(keys))) {
+        unsafe(tab[keys[i]]) = i + 1
+    }
+}
+
+[benchmark]
+def const_short(b : B?) {
+    var tab : table<string; int>
+    fill(tab, SHORT_KEYS)
+    b |> run("const_short/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?["alpha"] ?? 0
+            s += tab?["bravo"] ?? 0
+            s += tab?["charlie"] ?? 0
+            s += tab?["delta"] ?? 0
+            s += tab?["echo"] ?? 0
+            s += tab?["foxtrot"] ?? 0
+            s += tab?["golf"] ?? 0
+            s += tab?["hotel"] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+// var lanes mirror the const lanes' straight-line shape exactly — 8 inlined
+// lookups, not a loop — so the only difference from const is that the key is a
+// runtime string (hash computed at run time) rather than a foldable literal.
+// At baseline const == var; item 4 makes const drop below var.
+[benchmark]
+def var_short(b : B?) {
+    var tab : table<string; int>
+    fill(tab, SHORT_KEYS)
+    let k0 = SHORT_KEYS[0]; let k1 = SHORT_KEYS[1]; let k2 = SHORT_KEYS[2]; let k3 = SHORT_KEYS[3]
+    let k4 = SHORT_KEYS[4]; let k5 = SHORT_KEYS[5]; let k6 = SHORT_KEYS[6]; let k7 = SHORT_KEYS[7]
+    b |> run("var_short/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?[k0] ?? 0
+            s += tab?[k1] ?? 0
+            s += tab?[k2] ?? 0
+            s += tab?[k3] ?? 0
+            s += tab?[k4] ?? 0
+            s += tab?[k5] ?? 0
+            s += tab?[k6] ?? 0
+            s += tab?[k7] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def const_long(b : B?) {
+    var tab : table<string; int>
+    fill(tab, LONG_KEYS)
+    b |> run("const_long/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?["this/is/a/fairly/long/identifier/alpha"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/bravo"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/charlie"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/delta"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/echo"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/foxtrot"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/golf"] ?? 0
+            s += tab?["this/is/a/fairly/long/identifier/hotel"] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def var_long(b : B?) {
+    var tab : table<string; int>
+    fill(tab, LONG_KEYS)
+    let k0 = LONG_KEYS[0]; let k1 = LONG_KEYS[1]; let k2 = LONG_KEYS[2]; let k3 = LONG_KEYS[3]
+    let k4 = LONG_KEYS[4]; let k5 = LONG_KEYS[5]; let k6 = LONG_KEYS[6]; let k7 = LONG_KEYS[7]
+    b |> run("var_long/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?[k0] ?? 0
+            s += tab?[k1] ?? 0
+            s += tab?[k2] ?? 0
+            s += tab?[k3] ?? 0
+            s += tab?[k4] ?? 0
+            s += tab?[k5] ?? 0
+            s += tab?[k6] ?? 0
+            s += tab?[k7] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}

--- a/benchmarks/core/small_table/test03.das
+++ b/benchmarks/core/small_table/test03.das
@@ -32,6 +32,15 @@ def fill(var tab : table<string; int>; keys : array<string>) {
     }
 }
 
+// Distinct-pointer copy (same content, fresh allocation). The var_* lanes query with these so
+// the find's candidate confirm runs a real strcmp instead of hitting KeyCompare's a==b
+// pointer-identity fast path — the realistic case (a key from I/O / parsing is never the stored
+// pointer). Querying with the stored array element (KEYS[i]) would short-circuit the strcmp and
+// understate find, badly so for long keys.
+def fresh(s : string) : string {
+    return clone_string(s)
+}
+
 [benchmark]
 def const_short(b : B?) {
     var tab : table<string; int>
@@ -63,8 +72,8 @@ def const_short(b : B?) {
 def var_short(b : B?) {
     var tab : table<string; int>
     fill(tab, SHORT_KEYS)
-    let k0 = SHORT_KEYS[0]; let k1 = SHORT_KEYS[1]; let k2 = SHORT_KEYS[2]; let k3 = SHORT_KEYS[3]
-    let k4 = SHORT_KEYS[4]; let k5 = SHORT_KEYS[5]; let k6 = SHORT_KEYS[6]; let k7 = SHORT_KEYS[7]
+    let k0 = fresh(SHORT_KEYS[0]); let k1 = fresh(SHORT_KEYS[1]); let k2 = fresh(SHORT_KEYS[2]); let k3 = fresh(SHORT_KEYS[3])
+    let k4 = fresh(SHORT_KEYS[4]); let k5 = fresh(SHORT_KEYS[5]); let k6 = fresh(SHORT_KEYS[6]); let k7 = fresh(SHORT_KEYS[7])
     b |> run("var_short/8", 8 * REPS) {
         var s = 0
         for (r in range(REPS)) {
@@ -111,8 +120,8 @@ def const_long(b : B?) {
 def var_long(b : B?) {
     var tab : table<string; int>
     fill(tab, LONG_KEYS)
-    let k0 = LONG_KEYS[0]; let k1 = LONG_KEYS[1]; let k2 = LONG_KEYS[2]; let k3 = LONG_KEYS[3]
-    let k4 = LONG_KEYS[4]; let k5 = LONG_KEYS[5]; let k6 = LONG_KEYS[6]; let k7 = LONG_KEYS[7]
+    let k0 = fresh(LONG_KEYS[0]); let k1 = fresh(LONG_KEYS[1]); let k2 = fresh(LONG_KEYS[2]); let k3 = fresh(LONG_KEYS[3])
+    let k4 = fresh(LONG_KEYS[4]); let k5 = fresh(LONG_KEYS[5]); let k6 = fresh(LONG_KEYS[6]); let k7 = fresh(LONG_KEYS[7])
     b |> run("var_long/8", 8 * REPS) {
         var s = 0
         for (r in range(REPS)) {

--- a/benchmarks/core/small_table/test03.das
+++ b/benchmarks/core/small_table/test03.das
@@ -47,7 +47,7 @@ def const_short(b : B?) {
     fill(tab, SHORT_KEYS)
     b |> run("const_short/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?["alpha"] ?? 0
             s += tab?["bravo"] ?? 0
             s += tab?["charlie"] ?? 0
@@ -76,7 +76,7 @@ def var_short(b : B?) {
     let k4 = fresh(SHORT_KEYS[4]); let k5 = fresh(SHORT_KEYS[5]); let k6 = fresh(SHORT_KEYS[6]); let k7 = fresh(SHORT_KEYS[7])
     b |> run("var_short/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?[k0] ?? 0
             s += tab?[k1] ?? 0
             s += tab?[k2] ?? 0
@@ -99,7 +99,7 @@ def const_long(b : B?) {
     fill(tab, LONG_KEYS)
     b |> run("const_long/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?["this/is/a/fairly/long/identifier/alpha"] ?? 0
             s += tab?["this/is/a/fairly/long/identifier/bravo"] ?? 0
             s += tab?["this/is/a/fairly/long/identifier/charlie"] ?? 0
@@ -124,7 +124,7 @@ def var_long(b : B?) {
     let k4 = fresh(LONG_KEYS[4]); let k5 = fresh(LONG_KEYS[5]); let k6 = fresh(LONG_KEYS[6]); let k7 = fresh(LONG_KEYS[7])
     b |> run("var_long/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?[k0] ?? 0
             s += tab?[k1] ?? 0
             s += tab?[k2] ?? 0

--- a/benchmarks/core/small_table/test04.das
+++ b/benchmarks/core/small_table/test04.das
@@ -1,0 +1,111 @@
+options gen2
+options persistent_heap
+
+// Many small tables (the decs / per-entity shape): thousands of independent
+// N-element tables rather than one hot table hammered. This is where item 1
+// (smaller minCapacity -> less memory per table) and cache locality matter —
+// each table's keys/hashes live on different cache lines, so a sweep touches
+// cold memory, unlike the single-table micros that stay in L1.
+//
+// build/* measures the full alloc+insert+free lifecycle per element (watch B/op).
+// query/* sweeps one lookup across every table once, so no table stays hot.
+
+require dastest/testing_boost
+
+let NUM_TABLES = 4096
+let TABLE_N = 8
+
+[benchmark]
+def many_int_build(b : B?) {
+    b |> run("int_build/{TABLE_N}", NUM_TABLES * TABLE_N) {
+        var tabs : array<table<int; int>>
+        tabs |> resize(NUM_TABLES)
+        for (ti in range(NUM_TABLES)) {
+            for (k in range(TABLE_N)) {
+                unsafe(tabs[ti][k]) = k * 2
+            }
+        }
+        for (ti in range(NUM_TABLES)) {
+            unsafe { delete tabs[ti]; }
+        }
+        delete tabs
+    }
+}
+
+[benchmark]
+def many_int_query(b : B?) {
+    var tabs : array<table<int; int>>
+    tabs |> resize(NUM_TABLES)
+    for (ti in range(NUM_TABLES)) {
+        for (k in range(TABLE_N)) {
+            unsafe(tabs[ti][k]) = k * 2
+        }
+    }
+    b |> run("int_query/{TABLE_N}", NUM_TABLES) {
+        var s = 0
+        for (ti in range(NUM_TABLES)) {
+            s += tabs[ti]?[3] ?? -1
+        }
+        if (s != NUM_TABLES * 6) {
+            b->failNow()
+        }
+    }
+    for (ti in range(NUM_TABLES)) {
+        unsafe { delete tabs[ti]; }
+    }
+    delete tabs
+}
+
+[benchmark]
+def many_str_build(b : B?) {
+    var keys : array<string>
+    for (k in range(TABLE_N)) {
+        keys |> push("prop_{k}")
+    }
+    b |> run("str_build/{TABLE_N}", NUM_TABLES * TABLE_N) {
+        var tabs : array<table<string; int>>
+        tabs |> resize(NUM_TABLES)
+        for (ti in range(NUM_TABLES)) {
+            for (k in range(TABLE_N)) {
+                unsafe(tabs[ti][keys[k]]) = k * 2
+            }
+        }
+        for (ti in range(NUM_TABLES)) {
+            unsafe { delete tabs[ti]; }
+        }
+        delete tabs
+    }
+    delete keys
+}
+
+[benchmark]
+def many_str_query(b : B?) {
+    var keys : array<string>
+    var probe : array<string>
+    for (k in range(TABLE_N)) {
+        keys |> push("prop_{k}")
+        probe |> push("prop_{k}")
+    }
+    var tabs : array<table<string; int>>
+    tabs |> resize(NUM_TABLES)
+    for (ti in range(NUM_TABLES)) {
+        for (k in range(TABLE_N)) {
+            unsafe(tabs[ti][keys[k]]) = k * 2
+        }
+    }
+    b |> run("str_query/{TABLE_N}", NUM_TABLES) {
+        var s = 0
+        for (ti in range(NUM_TABLES)) {
+            s += tabs[ti]?[probe[3]] ?? -1
+        }
+        if (s != NUM_TABLES * 6) {
+            b->failNow()
+        }
+    }
+    for (ti in range(NUM_TABLES)) {
+        unsafe { delete tabs[ti]; }
+    }
+    delete tabs
+    delete keys
+    delete probe
+}

--- a/benchmarks/core/small_table/test04.das
+++ b/benchmarks/core/small_table/test04.das
@@ -58,10 +58,7 @@ def many_int_query(b : B?) {
 
 [benchmark]
 def many_str_build(b : B?) {
-    var keys : array<string>
-    for (k in range(TABLE_N)) {
-        keys |> push("prop_{k}")
-    }
+    var keys <- [for (k in range(TABLE_N)); "prop_{k}"]
     b |> run("str_build/{TABLE_N}", NUM_TABLES * TABLE_N) {
         var tabs : array<table<string; int>>
         tabs |> resize(NUM_TABLES)
@@ -82,6 +79,8 @@ def many_str_build(b : B?) {
 def many_str_query(b : B?) {
     var keys : array<string>
     var probe : array<string>
+    keys |> reserve(TABLE_N)
+    probe |> reserve(TABLE_N)
     for (k in range(TABLE_N)) {
         keys |> push("prop_{k}")
         probe |> push("prop_{k}")

--- a/benchmarks/core/small_table/test05.das
+++ b/benchmarks/core/small_table/test05.das
@@ -1,0 +1,92 @@
+options gen2
+options persistent_heap
+
+// Crossover prototype: predicts maxLinearCapacity BEFORE packed mode exists.
+// `lin_*` lanes inline a hash-only linear scan over an array<uint64> of stored
+// hashes — the exact shape a packed small-table find would take (hash the query
+// once, scan slots comparing 64-bit hashes, no strcmp, no probe). `hash_*` lanes
+// run the real open-addressed table ?[] for the same lookups. The N where lin
+// crosses above hash is the predicted threshold. Short vs long keys because the
+// strcmp the linear scan skips scales with key length, so the crossover does too.
+//
+// Query keys are distinct pointers from stored (strcmp actually fires in hash_*).
+// The das hash() builtin and the table's internal hash are both hash_blockz64,
+// so the per-query hash cost is common to both lanes and cancels in the crossover.
+
+require dastest/testing_boost
+
+let SIZES = [2, 4, 8, 12, 16, 24, 32]
+let REPS = 64
+
+def build_keys(n : int; prefix : string) : array<string> {
+    var keys : array<string>
+    for (i in range(n)) {
+        keys |> push("{prefix}{i}")
+    }
+    return <- keys
+}
+
+def run_lanes(b : B?; n : int; tag : string; prefix : string) {
+    var keys <- build_keys(n, prefix)
+    var probe <- build_keys(n, prefix)
+    var hashes : array<uint64>
+    var vals : array<int>
+    var tab : table<string; int>
+    for (i in range(n)) {
+        hashes |> push(hash(keys[i]))
+        vals |> push(i * 2)
+        unsafe(tab[keys[i]]) = i * 2
+    }
+    let expected = REPS * (n - 1) * n
+    // linear: hash-only scan, inlined (packed-find shape)
+    b |> run("lin_{tag}/{n}", n * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            for (i in range(n)) {
+                let h = hash(probe[i])
+                var idx = -1
+                for (j in range(n)) {
+                    if (hashes[j] == h) {
+                        idx = j
+                        break
+                    }
+                }
+                s += idx >= 0 ? vals[idx] : 0
+            }
+        }
+        if (s != expected) {
+            b->failNow()
+        }
+    }
+    // hashed: real open-addressed table find
+    b |> run("hash_{tag}/{n}", n * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            for (i in range(n)) {
+                s += tab?[probe[i]] ?? 0
+            }
+        }
+        if (s != expected) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+    delete keys
+    delete probe
+    delete hashes
+    delete vals
+}
+
+[benchmark]
+def crossover_short(b : B?) {
+    for (n in SIZES) {
+        run_lanes(b, n, "short", "key")
+    }
+}
+
+[benchmark]
+def crossover_long(b : B?) {
+    for (n in SIZES) {
+        run_lanes(b, n, "long", "this/is/a/fairly/long/identifier/")
+    }
+}

--- a/benchmarks/core/small_table/test05.das
+++ b/benchmarks/core/small_table/test05.das
@@ -19,10 +19,7 @@ let SIZES = [2, 4, 8, 12, 16, 24, 32]
 let REPS = 64
 
 def build_keys(n : int; prefix : string) : array<string> {
-    var keys : array<string>
-    for (i in range(n)) {
-        keys |> push("{prefix}{i}")
-    }
+    var keys <- [for (i in range(n)); "{prefix}{i}"]
     return <- keys
 }
 
@@ -32,6 +29,8 @@ def run_lanes(b : B?; n : int; tag : string; prefix : string) {
     var hashes : array<uint64>
     var vals : array<int>
     var tab : table<string; int>
+    hashes |> reserve(n)
+    vals |> reserve(n)
     for (i in range(n)) {
         hashes |> push(hash(keys[i]))
         vals |> push(i * 2)
@@ -41,7 +40,7 @@ def run_lanes(b : B?; n : int; tag : string; prefix : string) {
     // linear: hash-only scan, inlined (packed-find shape)
     b |> run("lin_{tag}/{n}", n * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             for (i in range(n)) {
                 let h = hash(probe[i])
                 var idx = -1
@@ -61,7 +60,7 @@ def run_lanes(b : B?; n : int; tag : string; prefix : string) {
     // hashed: real open-addressed table find
     b |> run("hash_{tag}/{n}", n * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             for (i in range(n)) {
                 s += tab?[probe[i]] ?? 0
             }

--- a/benchmarks/core/small_table/test06.das
+++ b/benchmarks/core/small_table/test06.das
@@ -1,0 +1,120 @@
+options gen2
+options persistent_heap
+
+// Lookup-only (never insert) micro-benchmark for the packed (N=8) string-table find.
+// Every lane uses tab?[key] (ExprSafeAt = find-only); the table is filled once outside the
+// measured block. Targets the JIT-side inlined packed find (none / scalar / vector, toggled
+// by JIT_STRING_FIND in llvm_jit_common.das). Miss is the worst case — it scans all 8 slots —
+// and is where the branch-free vector scan should pull ahead of scalar / the C++ call.
+//
+// const_* keys are string literals (hash folds to an immediate); var_* keys arrive through a
+// prebuilt array (runtime hash). hit looks up the 8 present keys; miss looks up 8 absent ones.
+
+require dastest/testing_boost
+
+let REPS = 64
+
+let KEYS = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"]
+let ABSENT = ["alpha_x", "bravo_x", "charlie_x", "delta_x", "echo_x", "foxtrot_x", "golf_x", "hotel_x"]
+
+def fill(var tab : table<string; int>) {
+    for (i in range(length(KEYS))) {
+        unsafe(tab[KEYS[i]]) = i + 1
+    }
+}
+
+[benchmark]
+def const_hit(b : B?) {
+    var tab : table<string; int>
+    fill(tab)
+    b |> run("const_hit/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?["alpha"] ?? 0
+            s += tab?["bravo"] ?? 0
+            s += tab?["charlie"] ?? 0
+            s += tab?["delta"] ?? 0
+            s += tab?["echo"] ?? 0
+            s += tab?["foxtrot"] ?? 0
+            s += tab?["golf"] ?? 0
+            s += tab?["hotel"] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def const_miss(b : B?) {
+    var tab : table<string; int>
+    fill(tab)
+    b |> run("const_miss/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?["alpha_x"] ?? 0
+            s += tab?["bravo_x"] ?? 0
+            s += tab?["charlie_x"] ?? 0
+            s += tab?["delta_x"] ?? 0
+            s += tab?["echo_x"] ?? 0
+            s += tab?["foxtrot_x"] ?? 0
+            s += tab?["golf_x"] ?? 0
+            s += tab?["hotel_x"] ?? 0
+        }
+        if (s != 0) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def var_hit(b : B?) {
+    var tab : table<string; int>
+    fill(tab)
+    let k0 = KEYS[0]; let k1 = KEYS[1]; let k2 = KEYS[2]; let k3 = KEYS[3]
+    let k4 = KEYS[4]; let k5 = KEYS[5]; let k6 = KEYS[6]; let k7 = KEYS[7]
+    b |> run("var_hit/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?[k0] ?? 0
+            s += tab?[k1] ?? 0
+            s += tab?[k2] ?? 0
+            s += tab?[k3] ?? 0
+            s += tab?[k4] ?? 0
+            s += tab?[k5] ?? 0
+            s += tab?[k6] ?? 0
+            s += tab?[k7] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def var_miss(b : B?) {
+    var tab : table<string; int>
+    fill(tab)
+    let k0 = ABSENT[0]; let k1 = ABSENT[1]; let k2 = ABSENT[2]; let k3 = ABSENT[3]
+    let k4 = ABSENT[4]; let k5 = ABSENT[5]; let k6 = ABSENT[6]; let k7 = ABSENT[7]
+    b |> run("var_miss/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?[k0] ?? 0
+            s += tab?[k1] ?? 0
+            s += tab?[k2] ?? 0
+            s += tab?[k3] ?? 0
+            s += tab?[k4] ?? 0
+            s += tab?[k5] ?? 0
+            s += tab?[k6] ?? 0
+            s += tab?[k7] ?? 0
+        }
+        if (s != 0) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}

--- a/benchmarks/core/small_table/test06.das
+++ b/benchmarks/core/small_table/test06.das
@@ -23,6 +23,14 @@ def fill(var tab : table<string; int>) {
     }
 }
 
+// Distinct-pointer copy (same content, fresh allocation) so the find's candidate confirm runs a
+// real strcmp instead of hitting KeyCompare's a==b pointer-identity fast path. var_hit queries
+// with these (the realistic case); querying with the stored KEYS[i] would short-circuit the
+// strcmp and understate find. (var_miss is unaffected — a miss never reaches the confirm.)
+def fresh(s : string) : string {
+    return clone_string(s)
+}
+
 [benchmark]
 def const_hit(b : B?) {
     var tab : table<string; int>
@@ -73,8 +81,8 @@ def const_miss(b : B?) {
 def var_hit(b : B?) {
     var tab : table<string; int>
     fill(tab)
-    let k0 = KEYS[0]; let k1 = KEYS[1]; let k2 = KEYS[2]; let k3 = KEYS[3]
-    let k4 = KEYS[4]; let k5 = KEYS[5]; let k6 = KEYS[6]; let k7 = KEYS[7]
+    let k0 = fresh(KEYS[0]); let k1 = fresh(KEYS[1]); let k2 = fresh(KEYS[2]); let k3 = fresh(KEYS[3])
+    let k4 = fresh(KEYS[4]); let k5 = fresh(KEYS[5]); let k6 = fresh(KEYS[6]); let k7 = fresh(KEYS[7])
     b |> run("var_hit/8", 8 * REPS) {
         var s = 0
         for (r in range(REPS)) {

--- a/benchmarks/core/small_table/test06.das
+++ b/benchmarks/core/small_table/test06.das
@@ -37,7 +37,7 @@ def const_hit(b : B?) {
     fill(tab)
     b |> run("const_hit/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?["alpha"] ?? 0
             s += tab?["bravo"] ?? 0
             s += tab?["charlie"] ?? 0
@@ -60,7 +60,7 @@ def const_miss(b : B?) {
     fill(tab)
     b |> run("const_miss/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?["alpha_x"] ?? 0
             s += tab?["bravo_x"] ?? 0
             s += tab?["charlie_x"] ?? 0
@@ -85,7 +85,7 @@ def var_hit(b : B?) {
     let k4 = fresh(KEYS[4]); let k5 = fresh(KEYS[5]); let k6 = fresh(KEYS[6]); let k7 = fresh(KEYS[7])
     b |> run("var_hit/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?[k0] ?? 0
             s += tab?[k1] ?? 0
             s += tab?[k2] ?? 0
@@ -110,7 +110,7 @@ def var_miss(b : B?) {
     let k4 = ABSENT[4]; let k5 = ABSENT[5]; let k6 = ABSENT[6]; let k7 = ABSENT[7]
     b |> run("var_miss/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?[k0] ?? 0
             s += tab?[k1] ?? 0
             s += tab?[k2] ?? 0

--- a/benchmarks/core/small_table/test07.das
+++ b/benchmarks/core/small_table/test07.das
@@ -31,6 +31,12 @@ def fill_str(var tab : table<string; int>) {
     }
 }
 
+// Distinct-pointer copy so str_update's at-hit confirm runs a real strcmp rather than KeyCompare's
+// a==b pointer-identity fast path (querying with the stored SKEYS[i] would understate the update).
+def fresh(s : string) : string {
+    return clone_string(s)
+}
+
 [benchmark]
 def int_hit(b : B?) {
     var tab : table<int; int>
@@ -88,8 +94,8 @@ def int_update(b : B?) {
 def str_update(b : B?) {
     var tab : table<string; int>
     fill_str(tab)
-    let k0 = SKEYS[0]; let k1 = SKEYS[1]; let k2 = SKEYS[2]; let k3 = SKEYS[3]
-    let k4 = SKEYS[4]; let k5 = SKEYS[5]; let k6 = SKEYS[6]; let k7 = SKEYS[7]
+    let k0 = fresh(SKEYS[0]); let k1 = fresh(SKEYS[1]); let k2 = fresh(SKEYS[2]); let k3 = fresh(SKEYS[3])
+    let k4 = fresh(SKEYS[4]); let k5 = fresh(SKEYS[5]); let k6 = fresh(SKEYS[6]); let k7 = fresh(SKEYS[7])
     b |> run("str_update/8", 8 * REPS) {
         for (r in range(REPS)) {
             unsafe(tab[k0]) += 1; unsafe(tab[k1]) += 1; unsafe(tab[k2]) += 1; unsafe(tab[k3]) += 1

--- a/benchmarks/core/small_table/test07.das
+++ b/benchmarks/core/small_table/test07.das
@@ -1,0 +1,100 @@
+options gen2
+options persistent_heap
+
+// Packed (N=8) integer-key find and tab[key] update micro-benchmarks — the paths added
+// when the inline SIMD packed find was extended to integer keys and to the insert path.
+//
+//   int_hit / int_miss : tab?[k] on an int-keyed table. The packed path is a pure <8 x i32>
+//                        key compare with a liveness mask — NO hash at all (unlike strings).
+//   str_update / int_update : tab[k] = v on keys already present. The at path runs the same
+//                        SIMD find; a hit returns the slot with no insert and no C++ call.
+//
+// All tables are filled once outside the measured block; find lanes never insert.
+
+require dastest/testing_boost
+
+let REPS = 64
+
+let IKEYS = [10, 20, 30, 40, 50, 60, 70, 80]
+let IABSENT = [11, 21, 31, 41, 51, 61, 71, 81]
+let SKEYS = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"]
+
+def fill_int(var tab : table<int; int>) {
+    for (i in range(length(IKEYS))) {
+        unsafe(tab[IKEYS[i]]) = i + 1
+    }
+}
+
+def fill_str(var tab : table<string; int>) {
+    for (i in range(length(SKEYS))) {
+        unsafe(tab[SKEYS[i]]) = i + 1
+    }
+}
+
+[benchmark]
+def int_hit(b : B?) {
+    var tab : table<int; int>
+    fill_int(tab)
+    let k0 = IKEYS[0]; let k1 = IKEYS[1]; let k2 = IKEYS[2]; let k3 = IKEYS[3]
+    let k4 = IKEYS[4]; let k5 = IKEYS[5]; let k6 = IKEYS[6]; let k7 = IKEYS[7]
+    b |> run("int_hit/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?[k0] ?? 0; s += tab?[k1] ?? 0; s += tab?[k2] ?? 0; s += tab?[k3] ?? 0
+            s += tab?[k4] ?? 0; s += tab?[k5] ?? 0; s += tab?[k6] ?? 0; s += tab?[k7] ?? 0
+        }
+        if (s != REPS * 36) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def int_miss(b : B?) {
+    var tab : table<int; int>
+    fill_int(tab)
+    let k0 = IABSENT[0]; let k1 = IABSENT[1]; let k2 = IABSENT[2]; let k3 = IABSENT[3]
+    let k4 = IABSENT[4]; let k5 = IABSENT[5]; let k6 = IABSENT[6]; let k7 = IABSENT[7]
+    b |> run("int_miss/8", 8 * REPS) {
+        var s = 0
+        for (r in range(REPS)) {
+            s += tab?[k0] ?? 0; s += tab?[k1] ?? 0; s += tab?[k2] ?? 0; s += tab?[k3] ?? 0
+            s += tab?[k4] ?? 0; s += tab?[k5] ?? 0; s += tab?[k6] ?? 0; s += tab?[k7] ?? 0
+        }
+        if (s != 0) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def int_update(b : B?) {
+    var tab : table<int; int>
+    fill_int(tab)
+    let k0 = IKEYS[0]; let k1 = IKEYS[1]; let k2 = IKEYS[2]; let k3 = IKEYS[3]
+    let k4 = IKEYS[4]; let k5 = IKEYS[5]; let k6 = IKEYS[6]; let k7 = IKEYS[7]
+    b |> run("int_update/8", 8 * REPS) {
+        for (r in range(REPS)) {
+            unsafe(tab[k0]) += 1; unsafe(tab[k1]) += 1; unsafe(tab[k2]) += 1; unsafe(tab[k3]) += 1
+            unsafe(tab[k4]) += 1; unsafe(tab[k5]) += 1; unsafe(tab[k6]) += 1; unsafe(tab[k7]) += 1
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[benchmark]
+def str_update(b : B?) {
+    var tab : table<string; int>
+    fill_str(tab)
+    let k0 = SKEYS[0]; let k1 = SKEYS[1]; let k2 = SKEYS[2]; let k3 = SKEYS[3]
+    let k4 = SKEYS[4]; let k5 = SKEYS[5]; let k6 = SKEYS[6]; let k7 = SKEYS[7]
+    b |> run("str_update/8", 8 * REPS) {
+        for (r in range(REPS)) {
+            unsafe(tab[k0]) += 1; unsafe(tab[k1]) += 1; unsafe(tab[k2]) += 1; unsafe(tab[k3]) += 1
+            unsafe(tab[k4]) += 1; unsafe(tab[k5]) += 1; unsafe(tab[k6]) += 1; unsafe(tab[k7]) += 1
+        }
+    }
+    unsafe { delete tab; }
+}

--- a/benchmarks/core/small_table/test07.das
+++ b/benchmarks/core/small_table/test07.das
@@ -45,7 +45,7 @@ def int_hit(b : B?) {
     let k4 = IKEYS[4]; let k5 = IKEYS[5]; let k6 = IKEYS[6]; let k7 = IKEYS[7]
     b |> run("int_hit/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?[k0] ?? 0; s += tab?[k1] ?? 0; s += tab?[k2] ?? 0; s += tab?[k3] ?? 0
             s += tab?[k4] ?? 0; s += tab?[k5] ?? 0; s += tab?[k6] ?? 0; s += tab?[k7] ?? 0
         }
@@ -64,7 +64,7 @@ def int_miss(b : B?) {
     let k4 = IABSENT[4]; let k5 = IABSENT[5]; let k6 = IABSENT[6]; let k7 = IABSENT[7]
     b |> run("int_miss/8", 8 * REPS) {
         var s = 0
-        for (r in range(REPS)) {
+        for (_r in range(REPS)) {
             s += tab?[k0] ?? 0; s += tab?[k1] ?? 0; s += tab?[k2] ?? 0; s += tab?[k3] ?? 0
             s += tab?[k4] ?? 0; s += tab?[k5] ?? 0; s += tab?[k6] ?? 0; s += tab?[k7] ?? 0
         }
@@ -82,9 +82,9 @@ def int_update(b : B?) {
     let k0 = IKEYS[0]; let k1 = IKEYS[1]; let k2 = IKEYS[2]; let k3 = IKEYS[3]
     let k4 = IKEYS[4]; let k5 = IKEYS[5]; let k6 = IKEYS[6]; let k7 = IKEYS[7]
     b |> run("int_update/8", 8 * REPS) {
-        for (r in range(REPS)) {
-            unsafe(tab[k0]) += 1; unsafe(tab[k1]) += 1; unsafe(tab[k2]) += 1; unsafe(tab[k3]) += 1
-            unsafe(tab[k4]) += 1; unsafe(tab[k5]) += 1; unsafe(tab[k6]) += 1; unsafe(tab[k7]) += 1
+        for (_r in range(REPS)) {
+            unsafe(tab[k0]) ++; unsafe(tab[k1]) ++; unsafe(tab[k2]) ++; unsafe(tab[k3]) ++
+            unsafe(tab[k4]) ++; unsafe(tab[k5]) ++; unsafe(tab[k6]) ++; unsafe(tab[k7]) ++
         }
     }
     unsafe { delete tab; }
@@ -97,9 +97,9 @@ def str_update(b : B?) {
     let k0 = fresh(SKEYS[0]); let k1 = fresh(SKEYS[1]); let k2 = fresh(SKEYS[2]); let k3 = fresh(SKEYS[3])
     let k4 = fresh(SKEYS[4]); let k5 = fresh(SKEYS[5]); let k6 = fresh(SKEYS[6]); let k7 = fresh(SKEYS[7])
     b |> run("str_update/8", 8 * REPS) {
-        for (r in range(REPS)) {
-            unsafe(tab[k0]) += 1; unsafe(tab[k1]) += 1; unsafe(tab[k2]) += 1; unsafe(tab[k3]) += 1
-            unsafe(tab[k4]) += 1; unsafe(tab[k5]) += 1; unsafe(tab[k6]) += 1; unsafe(tab[k7]) += 1
+        for (_r in range(REPS)) {
+            unsafe(tab[k0]) ++; unsafe(tab[k1]) ++; unsafe(tab[k2]) ++; unsafe(tab[k3]) ++
+            unsafe(tab[k4]) ++; unsafe(tab[k5]) ++; unsafe(tab[k6]) ++; unsafe(tab[k7]) ++
         }
     }
     unsafe { delete tab; }

--- a/benchmarks/core/small_table/test08.das
+++ b/benchmarks/core/small_table/test08.das
@@ -37,6 +37,34 @@ def make_tables(var tables : array<table<string; int>>) {
     }
 }
 
+// "bad" build: keys assembled at RUNTIME (var + concat) -> distinct heap pointers, NOT the const
+// pool. The bad_* scans below still read with const literals ("foo", ...), so the stored pointer
+// never equals the query pointer, KeyCompare's a==b misses, and a real strcmp runs on every
+// lookup. This is the table-built-from-data case (parsed keys) queried by fixed field name.
+def build_record_bad(var tab : table<string; int>) {
+    var foo = "fo"; foo += "o"
+    var bar = "ba"; bar += "r"
+    var far = "fa"; far += "r"
+    var baz = "ba"; baz += "z"
+    var qux = "qu"; qux += "x"
+    var quux = "quu"; quux += "x"
+    tab[foo] = 1
+    tab[bar] = 2
+    tab[far] = 3
+    tab[baz] = 4
+    tab[qux] = 5
+    tab[quux] = 6
+}
+
+def make_tables_bad(var tables : array<table<string; int>>) {
+    tables |> reserve(NTABLES)
+    for (i in range(NTABLES)) {
+        var tab : table<string; int>
+        build_record_bad(tab)
+        tables |> emplace(tab)
+    }
+}
+
 def free_tables(var tables : array<table<string; int>>) {
     for (t in tables) {
         unsafe { delete t; }
@@ -72,6 +100,50 @@ def json_at(b : B?) {
     var tables : array<table<string; int>>
     make_tables(tables)
     b |> run("json_at/6", NTABLES * NKEYS) {
+        var count = 0
+        for (tab in tables) {
+            count += tab["foo"]
+            count += tab["bar"]
+            count += tab["far"]
+            count += tab["baz"]
+            count += tab["qux"]
+            count += tab["quux"]
+        }
+        if (count != EXPECTED) {
+            b->failNow()
+        }
+    }
+    free_tables(tables)
+}
+
+// bad v1 — distinct-pointer stored keys, const-literal scan -> strcmp on every find
+[benchmark]
+def bad_json_find(b : B?) {
+    var tables : array<table<string; int>>
+    make_tables_bad(tables)
+    b |> run("bad_json_find/6", NTABLES * NKEYS) {
+        var count = 0
+        for (tab in tables) {
+            count += tab?["foo"] ?? 0
+            count += tab?["bar"] ?? 0
+            count += tab?["far"] ?? 0
+            count += tab?["baz"] ?? 0
+            count += tab?["qux"] ?? 0
+            count += tab?["quux"] ?? 0
+        }
+        if (count != EXPECTED) {
+            b->failNow()
+        }
+    }
+    free_tables(tables)
+}
+
+// bad v2 — distinct-pointer stored keys, const-literal scan -> strcmp on every at
+[benchmark]
+def bad_json_at(b : B?) {
+    var tables : array<table<string; int>>
+    make_tables_bad(tables)
+    b |> run("bad_json_at/6", NTABLES * NKEYS) {
         var count = 0
         for (tab in tables) {
             count += tab["foo"]

--- a/benchmarks/core/small_table/test08.das
+++ b/benchmarks/core/small_table/test08.das
@@ -30,7 +30,7 @@ def build_record(var tab : table<string; int>) {
 
 def make_tables(var tables : array<table<string; int>>) {
     tables |> reserve(NTABLES)
-    for (i in range(NTABLES)) {
+    for (_i in range(NTABLES)) {
         var tab : table<string; int>
         build_record(tab)
         tables |> emplace(tab)
@@ -58,7 +58,7 @@ def build_record_bad(var tab : table<string; int>) {
 
 def make_tables_bad(var tables : array<table<string; int>>) {
     tables |> reserve(NTABLES)
-    for (i in range(NTABLES)) {
+    for (_i in range(NTABLES)) {
         var tab : table<string; int>
         build_record_bad(tab)
         tables |> emplace(tab)

--- a/benchmarks/core/small_table/test08.das
+++ b/benchmarks/core/small_table/test08.das
@@ -1,0 +1,89 @@
+options gen2
+options persistent_heap
+
+// Realistic "JSON" read: an array of many small string-keyed records (objects), summed by
+// looking up each field with a STRING LITERAL key. daslang pools constant strings, so the
+// literal used to build a field (`tab["foo"] = 1`) and the literal used to read it
+// (`tab?["foo"]` / `tab["foo"]`) are the *same pointer* — the packed find's candidate confirm
+// then hits KeyCompare's `a==b` fast path and skips strcmp. This is the common case for code
+// that addresses records by fixed field names (config, JSON-shaped data, per-entity property
+// maps), as opposed to the distinct-pointer lanes in test03/06 (keys arriving from I/O).
+//
+//   json_find (v1): count += tab?["foo"] ?? 0   -- the find path (ExprSafeAt)
+//   json_at   (v2): count += tab["foo"]          -- the at/index path (ExprAt)
+
+require dastest/testing_boost
+
+let NTABLES = 4096
+let NKEYS = 6                       // <= 8 -> every record stays packed
+let PER_TABLE_SUM = 21              // 1+2+3+4+5+6
+let EXPECTED = NTABLES * PER_TABLE_SUM
+
+def build_record(var tab : table<string; int>) {
+    tab["foo"] = 1
+    tab["bar"] = 2
+    tab["far"] = 3
+    tab["baz"] = 4
+    tab["qux"] = 5
+    tab["quux"] = 6
+}
+
+def make_tables(var tables : array<table<string; int>>) {
+    tables |> reserve(NTABLES)
+    for (i in range(NTABLES)) {
+        var tab : table<string; int>
+        build_record(tab)
+        tables |> emplace(tab)
+    }
+}
+
+def free_tables(var tables : array<table<string; int>>) {
+    for (t in tables) {
+        unsafe { delete t; }
+    }
+    unsafe { delete tables; }
+}
+
+// v1 — find path: tab?[key] ?? 0
+[benchmark]
+def json_find(b : B?) {
+    var tables : array<table<string; int>>
+    make_tables(tables)
+    b |> run("json_find/6", NTABLES * NKEYS) {
+        var count = 0
+        for (tab in tables) {
+            count += tab?["foo"] ?? 0
+            count += tab?["bar"] ?? 0
+            count += tab?["far"] ?? 0
+            count += tab?["baz"] ?? 0
+            count += tab?["qux"] ?? 0
+            count += tab?["quux"] ?? 0
+        }
+        if (count != EXPECTED) {
+            b->failNow()
+        }
+    }
+    free_tables(tables)
+}
+
+// v2 — at/index path: tab[key] (keys all present, so it reads; routes through the insert-or-get at)
+[benchmark]
+def json_at(b : B?) {
+    var tables : array<table<string; int>>
+    make_tables(tables)
+    b |> run("json_at/6", NTABLES * NKEYS) {
+        var count = 0
+        for (tab in tables) {
+            count += tab["foo"]
+            count += tab["bar"]
+            count += tab["far"]
+            count += tab["baz"]
+            count += tab["qux"]
+            count += tab["quux"]
+        }
+        if (count != EXPECTED) {
+            b->failNow()
+        }
+    }
+    free_tables(tables)
+}

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -175,7 +175,7 @@ get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_defau
         group_by_regex("Smart ptr infrastructure", mod, %regex~(add_ptr_ref|smart_ptr|get_const_ptr|move|move_new|get_ptr$)%%),
         group_by_regex("Macro infrastructure", mod, %regex~(is_folding|is_compiling|is_in_completion|is_in_lint_check|is_reporting_compilation_errors)%%),
         group_by_regex("Profiler", mod, %regex~(profile|reset_profiler|dump_profile_info|collect_profile_info)$%%),
-        group_by_regex("System infrastructure", mod, %regex~(panic|print|feint|sprint|sprint_json|sscan_json|to_log|to_compiler_log|error|terminate|breakpoint|stackwalk|get_das_root|get_das_version|is_in_aot|aot_enabled|is_intern_strings|eval_main_loop|shared_module_extension)$%%),
+        group_by_regex("System infrastructure", mod, %regex~(panic|print|feint|sprint|sprint_json|sscan_json|to_log|to_compiler_log|error|terminate|breakpoint|stackwalk|get_das_root|get_das_version|is_in_aot|aot_enabled|is_intern_strings|is_safe_hash|eval_main_loop|shared_module_extension)$%%),
         group_by_regex("Memory manipulation", mod, %regex~(intptr|memcmp|variant_index|set_variant_index|hash|memcpy|lock_data|map_to_array|map_to_ro_array)$%%),
         group_by_regex("Binary serializer", mod, %regex~(binary_load|binary_save)$%%),
         group_by_regex("Path and command line", mod, %regex~(get_command_line_arguments|with_argv)$%%),

--- a/doc/source/stdlib/handmade/function-builtin-is_safe_hash-0x63d8d2a75e659412.rst
+++ b/doc/source/stdlib/handmade/function-builtin-is_safe_hash-0x63d8d2a75e659412.rst
@@ -1,0 +1,1 @@
+Returns true when the runtime computes string hashes with the safe byte-at-a-time algorithm rather than the faster word-at-a-time one. JIT string-hash code generation reads this so it can emit a hash body that matches the host runtime exactly.

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1855,7 +1855,8 @@ namespace das {
         static __forceinline void clear ( Context * __context__, TTable<TKey,TVal> & tab ) {
             if ( tab.data ) {
                 if ( !tab.isLocked() ) {
-                    uint64_t oldSize = uint64_t(tab.capacity)*(sizeof(TKey)+sizeof(TVal)+sizeof(TableHashKey));
+                    uint64_t hashBytes = (tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<TKey>::hashBytes) : uint64_t(sizeof(TableHashKey));
+                    uint64_t oldSize = uint64_t(tab.capacity)*(sizeof(TKey)+sizeof(TVal)+hashBytes);
                     __context__->free(tab.data, oldSize);
                 } else {
                     __context__->throw_error("can't delete locked table");

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -185,6 +185,33 @@ namespace das
             }
         }
 
+        // Insert a key the caller has ALREADY PROVEN absent from a packed table — the JIT
+        // path runs the SIMD packed find inline, and on a miss it knows the key is not there,
+        // so re-running PackedFind here (as reserve() does to dedup) is wasted work. This is
+        // that shortcut: it skips the dedup scan and goes straight to the dense append, or
+        // promotes to open addressing first if the packed table is full. PRECONDITION: the
+        // table is packed and the key is genuinely absent — 0 < capacity <= the linear cap,
+        // and no live slot carries this key's hashKey. Calling it on a non-packed table, or
+        // with a key that is actually present, double-inserts. Not a general reserve; use
+        // reserve() unless you just did the packed find yourself and it missed.
+        __forceinline int64_t reserveAfterPackedMiss ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {
+            DAS_ASSERT(hash>1);
+            DAS_ASSERT(tab.capacity!=0 && tab.capacity<=TABLE_MAX_LINEAR_CAPACITY);
+            if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
+            if ( tab.size >= tab.capacity ) {
+                // full packed table -> promote to open addressing, then insert via the hashed
+                // path (no packed dedup re-run, since it is now hashed).
+                reserveInternal(tab, tab.capacity*4, at);
+                return reserve(tab, key, hash, at);
+            }
+            auto hashKey = hashToHashKey(TableHashKey(hash));
+            uint64_t i = tab.size;
+            tab.hashes[i] = hashKey;
+            ((KeyType *) tab.keys)[i] = key;
+            tab.size++;
+            return (int64_t) i;
+        }
+
         __forceinline int64_t erase ( Table & tab, KeyType key, uint64_t hash ) {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -218,6 +218,9 @@ namespace das
 
         __forceinline int64_t reserve ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {
             DAS_ASSERT(hash>1);
+            // A promote/alloc re-dispatches by looping back here, not by a recursive call:
+            // gcc -flto rejects a recursive always_inline function (MSVC tolerates it).
+          retry:
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: dense, load factor 1.0
                 if ( tab.capacity != 0 ) {  // dedup against existing (skip on an unallocated table)
                     int64_t idx = PackedPolicy<KeyType>::find(tab, key, hash);  // exact (no confirm needed)
@@ -230,7 +233,7 @@ namespace das
                 if ( tab.size >= tab.capacity ) {
                     uint64_t newCapacity = (tab.capacity == 0) ? minCapacity : tab.capacity*4;
                     reserveInternal(tab, newCapacity, at);
-                    return reserve(tab, key, hash, at);  // re-dispatch: now hashed (or the freshly allocated packed table)
+                    goto retry;  // re-dispatch: now hashed (or the freshly allocated packed table)
                 }
                 uint64_t i = tab.size;
                 PackedPolicy<KeyType>::insertHash(tab, i, hash);

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -80,6 +80,17 @@ namespace das
         return ( capacity <= TABLE_MAX_LINEAR_CAPACITY ) ? uint64_t(sizeof(uint64_t)) : uint64_t(sizeof(TableHashKey));
     }
 
+    // Packed tables store 64-bit hashes in the `hashes` block (declared TableHashKey*=uint32_t*).
+    // Access them via memcpy: a direct ((uint64_t*)hashes)[i] lets clang -O3 assume 8-byte alignment
+    // and vectorize the fixed packed-find scan into an aligned 16-byte load that faults on linux/wasm
+    // (the block is only 8-aligned). memcpy lowers to the same unaligned load with no UB.
+    __forceinline uint64_t loadHash64 ( const void * hashes, uint64_t slot ) {
+        uint64_t h; memcpy(&h, (const char *)hashes + slot * sizeof(uint64_t), sizeof(uint64_t)); return h;
+    }
+    __forceinline void storeHash64 ( void * hashes, uint64_t slot, uint64_t h ) {
+        memcpy((char *)hashes + slot * sizeof(uint64_t), &h, sizeof(uint64_t));
+    }
+
     // Iterate a table's live (key,value) slots from C++. ALWAYS use this (or tableLiveSlot) instead
     // of a raw `for (i in [0,capacity)) if (hashes[i] > KILLED)` scan: a packed table stores 64-bit
     // hashes (PackedPolicy), so a 32-bit `((TableHashKey*)hashes)[i]` read misindexes it. fn is
@@ -116,17 +127,17 @@ namespace das
             return -1;
         }
         static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
-            ((uint64_t *) tab.hashes)[slot] = hash;
+            storeHash64(tab.hashes, slot, hash);
         }
         static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
-            ((uint64_t *) tab.hashes)[to] = ((uint64_t *) tab.hashes)[from];
+            storeHash64(tab.hashes, to, loadHash64(tab.hashes, from));
         }
         static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
-            ((uint64_t *) tab.hashes)[slot] = 0;
+            storeHash64(tab.hashes, slot, 0);
         }
         // 64-bit key used to re-bucket into the large (32-bit) target during promotion.
         static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, const KeyType &, Context * ) {
-            return ((const uint64_t *) tab.hashes)[slot];
+            return loadHash64(tab.hashes, slot);
         }
     };
 
@@ -136,23 +147,24 @@ namespace das
         static __forceinline int64_t find ( const Table & tab, char * const &, uint64_t hash ) {
             // All-8 scan: the tail is always 0 (alloc / erase / table_clear clear the full 64-bit
             // width) and a real hash is >1, so the tail never matches — no size guard needed.
-            auto p = (const uint64_t *) tab.hashes;
+            // loadHash64 reads unaligned — see its definition for why a raw (uint64_t*) cast here
+            // faults under clang -O3 on linux/wasm.
             for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
-                if ( p[i]==hash ) return (int64_t) i;
+                if ( loadHash64(tab.hashes, i)==hash ) return (int64_t) i;
             }
             return -1;
         }
         static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
-            ((uint64_t *) tab.hashes)[slot] = hash;  // full 64-bit; hash_blockz64 already clamps 0/1
+            storeHash64(tab.hashes, slot, hash);  // full 64-bit; hash_blockz64 already clamps 0/1
         }
         static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
-            ((uint64_t *) tab.hashes)[to] = ((uint64_t *) tab.hashes)[from];
+            storeHash64(tab.hashes, to, loadHash64(tab.hashes, from));
         }
         static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
-            ((uint64_t *) tab.hashes)[slot] = 0;
+            storeHash64(tab.hashes, slot, 0);
         }
         static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, char * const &, Context * ) {
-            return ((const uint64_t *) tab.hashes)[slot];
+            return loadHash64(tab.hashes, slot);
         }
     };
 
@@ -160,23 +172,22 @@ namespace das
     struct PackedPolicy<const char *> {
         static constexpr uint32_t hashBytes = sizeof(uint64_t);
         static __forceinline int64_t find ( const Table & tab, const char * const &, uint64_t hash ) {
-            auto p = (const uint64_t *) tab.hashes;
             for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
-                if ( p[i]==hash ) return (int64_t) i;
+                if ( loadHash64(tab.hashes, i)==hash ) return (int64_t) i;
             }
             return -1;
         }
         static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
-            ((uint64_t *) tab.hashes)[slot] = hash;
+            storeHash64(tab.hashes, slot, hash);
         }
         static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
-            ((uint64_t *) tab.hashes)[to] = ((uint64_t *) tab.hashes)[from];
+            storeHash64(tab.hashes, to, loadHash64(tab.hashes, from));
         }
         static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
-            ((uint64_t *) tab.hashes)[slot] = 0;
+            storeHash64(tab.hashes, slot, 0);
         }
         static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, const char * const &, Context * ) {
-            return ((const uint64_t *) tab.hashes)[slot];
+            return loadHash64(tab.hashes, slot);
         }
     };
 

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -55,10 +55,15 @@ namespace das
 
     // Packed (small-table) find, specialized per key type so each instantiation is a flat,
     // unrollable/vectorizable scan rather than a generic loop with a per-element compare.
-    // String keys scan the hash slots and trust the 64-bit hash (no strcmp); the empty tail
-    // (hash 0) never matches a real key hash (>1), so the loop runs the full fixed capacity.
-    // Every other key type compares keys directly over the live prefix [0,size) and never
-    // touches the hash array (the `i<sz` guard short-circuits the stale tail).
+    // String keys scan only the 32-bit hash slots and return the first hash match as a
+    // *candidate* — the caller (find/reserve/erase) confirms it with KeyCompare (one strcmp).
+    // Hashes are only 32 bits so distinct keys can collide, but insert-time promotion to open
+    // addressing on the first collision (see reserve) guarantees a packed table never holds two
+    // slots with the same hashKey, so a single candidate is exact. The empty tail (hash 0) never
+    // matches a real key hash (>1), so the loop runs the full fixed capacity. Every other key
+    // type compares keys directly over the live prefix [0,size) and never touches the hash array
+    // (the `i<sz` guard short-circuits the stale tail), so its result is already exact and the
+    // caller's KeyCompare is a no-op confirm.
     template <typename KeyType>
     struct PackedFind {
         static __forceinline int64_t find ( const Table & tab, const KeyType & key, TableHashKey ) {
@@ -117,7 +122,10 @@ namespace das
             if ( tab.capacity==0 ) return -1;
             auto hashKey = hashToHashKey(TableHashKey(hash));
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed
-                return PackedFind<KeyType>::find(tab, key, hashKey);
+                int64_t idx = PackedFind<KeyType>::find(tab, key, hashKey);
+                // PackedFind<char*> returns a hash-only candidate; confirm the key (one strcmp).
+                // Other key types already compared data, so KeyCompare here is a trivial no-op.
+                return ( idx>=0 && KeyCompare<KeyType>()(((const KeyType *)tab.keys)[idx], key) ) ? idx : -1;
             }
             auto pKeys = (const KeyType *) tab.keys;
             auto pHashes = tab.hashes;
@@ -138,15 +146,23 @@ namespace das
             DAS_ASSERT(hash>1);
             auto hashKey = hashToHashKey(TableHashKey(hash));
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: dense, load factor 1.0
+                bool hashCollision = false;
                 if ( tab.capacity != 0 ) {  // dedup against existing (skip on an unallocated table)
-                    int64_t found = PackedFind<KeyType>::find(tab, key, hashKey);
-                    if ( found>=0 ) return found;
+                    int64_t idx = PackedFind<KeyType>::find(tab, key, hashKey);
+                    if ( idx>=0 ) {
+                        // confirm the candidate; for non-string keys this already-data-matched.
+                        if ( KeyCompare<KeyType>()(((const KeyType *)tab.keys)[idx], key) ) return idx;
+                        hashCollision = true;   // hash matched but key differs -> 32-bit collision (string keys)
+                    }
                 }
                 if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
-                if ( tab.size >= tab.capacity ) {
-                    // cap-0 -> first allocation (stays packed); a full packed table promotes
-                    // to open addressing. *4 gives the hashed table load-factor headroom so it
-                    // does not immediately re-grow (cap*2 would land exactly on the 0.5 trigger).
+                // Promote out of packed mode on a full table (load factor 1.0) OR a 32-bit hashKey
+                // collision with a different stored key — open addressing confirms every hit with
+                // KeyCompare, so a collision-free packed table keeps find at one candidate + one
+                // strcmp. *4 gives the hashed table load-factor headroom so it does not immediately
+                // re-grow (cap*2 would land exactly on the 0.5 trigger).
+                if ( hashCollision || tab.size >= tab.capacity ) {
+                    // cap-0 -> first allocation (stays packed); otherwise grow to open addressing.
                     uint64_t newCapacity = (tab.capacity == 0) ? minCapacity : tab.capacity*4;
                     reserveInternal(tab, newCapacity, at);
                     return reserve(tab, key, hash, at);  // re-dispatch: now hashed (or the freshly allocated packed table)
@@ -219,9 +235,12 @@ namespace das
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: locate, then swap-remove the last live slot into the hole
                 int64_t fidx = PackedFind<KeyType>::find(tab, key, hashKey);
                 if ( fidx<0 ) return -1;
-                uint64_t i = (uint64_t) fidx;
                 auto pHashes = tab.hashes;
                 auto pKeys = (KeyType *) tab.keys;
+                // PackedFind<char*> is hash-only; confirm the candidate before removing it, or a
+                // colliding query would swap-remove the wrong key. Other key types already matched.
+                if ( !KeyCompare<KeyType>()(pKeys[fidx], key) ) return -1;
+                uint64_t i = (uint64_t) fidx;
                 uint64_t last = tab.size - 1;
                 if ( i != last ) {
                     pHashes[i] = pHashes[last];

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -44,14 +44,64 @@ namespace das
         }
     };
 
+    // Tables with capacity <= this use packed storage: keys/values/hashes are dense in
+    // [0,size) (insertion order, load factor 1.0) and find/erase are a flat linear scan
+    // instead of a hash probe. Crossing this on insert promotes to open addressing.
+    // It must equal TableHash::minCapacity (static_assert below) so every packed table is
+    // exactly this many slots — PackedFind scans a fixed count and would read out of bounds
+    // otherwise. (Decoupling them — e.g. a smaller minCapacity for memory — means switching
+    // PackedFind back to a capacity-bounded scan, losing the fixed unroll.)
+    constexpr static uint32_t TABLE_MAX_LINEAR_CAPACITY = 8;
+
+    // Packed (small-table) find, specialized per key type so each instantiation is a flat,
+    // unrollable/vectorizable scan rather than a generic loop with a per-element compare.
+    // String keys scan the hash slots and trust the 64-bit hash (no strcmp); the empty tail
+    // (hash 0) never matches a real key hash (>1), so the loop runs the full fixed capacity.
+    // Every other key type compares keys directly over the live prefix [0,size) and never
+    // touches the hash array (the `i<sz` guard short-circuits the stale tail).
+    template <typename KeyType>
+    struct PackedFind {
+        static __forceinline int64_t find ( const Table & tab, const KeyType & key, TableHashKey ) {
+            auto pKeys = (const KeyType *) tab.keys;
+            uint32_t sz = (uint32_t) tab.size;
+            for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
+                if ( i<sz && KeyCompare<KeyType>()(pKeys[i], key) ) return (int64_t) i;
+            }
+            return -1;
+        }
+    };
+
+    template <>
+    struct PackedFind<char *> {
+        static __forceinline int64_t find ( const Table & tab, char * const &, TableHashKey hashKey ) {
+            auto pHashes = tab.hashes;
+            for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
+                if ( pHashes[i]==hashKey ) return (int64_t) i;
+            }
+            return -1;
+        }
+    };
+
+    template <>
+    struct PackedFind<const char *> {
+        static __forceinline int64_t find ( const Table & tab, const char * const &, TableHashKey hashKey ) {
+            auto pHashes = tab.hashes;
+            for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
+                if ( pHashes[i]==hashKey ) return (int64_t) i;
+            }
+            return -1;
+        }
+    };
+
     template <typename KeyType>
     class TableHash {
         Context *   context = nullptr;
         uint32_t    valueTypeSize = 0;
         enum {
-            minCapacity = 8,
-            minLookups = 4
+            minCapacity = 8
         };
+        static_assert(minCapacity == TABLE_MAX_LINEAR_CAPACITY,
+            "PackedFind scans a fixed TABLE_MAX_LINEAR_CAPACITY slots, so every packed table must be exactly that many slots");
     public:
         TableHash () = delete;
         TableHash ( const TableHash & ) = delete;
@@ -65,11 +115,14 @@ namespace das
         __forceinline int64_t find ( const Table & tab, KeyType key, uint64_t hash ) const {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
-            uint64_t mask = tab.capacity - 1;
-            uint64_t index = hash & mask;
+            auto hashKey = hashToHashKey(TableHashKey(hash));
+            if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed
+                return PackedFind<KeyType>::find(tab, key, hashKey);
+            }
             auto pKeys = (const KeyType *) tab.keys;
             auto pHashes = tab.hashes;
-            auto hashKey = hashToHashKey(TableHashKey(hash));
+            uint64_t mask = tab.capacity - 1;
+            uint64_t index = hash & mask;
             while ( true ) {
                 auto kh = pHashes[index];
                 if ( kh==HASH_EMPTY64 ) {
@@ -83,6 +136,27 @@ namespace das
 
         __forceinline int64_t reserve ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {
             DAS_ASSERT(hash>1);
+            auto hashKey = hashToHashKey(TableHashKey(hash));
+            if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: dense, load factor 1.0
+                if ( tab.capacity != 0 ) {  // dedup against existing (skip on an unallocated table)
+                    int64_t found = PackedFind<KeyType>::find(tab, key, hashKey);
+                    if ( found>=0 ) return found;
+                }
+                if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
+                if ( tab.size >= tab.capacity ) {
+                    // cap-0 -> first allocation (stays packed); a full packed table promotes
+                    // to open addressing. *4 gives the hashed table load-factor headroom so it
+                    // does not immediately re-grow (cap*2 would land exactly on the 0.5 trigger).
+                    uint64_t newCapacity = (tab.capacity == 0) ? minCapacity : tab.capacity*4;
+                    reserveInternal(tab, newCapacity, at);
+                    return reserve(tab, key, hash, at);  // re-dispatch: now hashed (or the freshly allocated packed table)
+                }
+                uint64_t i = tab.size;
+                tab.hashes[i] = hashKey;
+                ((KeyType *) tab.keys)[i] = key;
+                tab.size++;
+                return (int64_t) i;
+            }
             if ( tab.size >= (tab.capacity/2) ) grow(tab, at);
             else if ( (tab.capacity-tab.size)/2 < tab.tombstones ) rehash(tab, at);
             uint64_t mask = tab.capacity - 1;
@@ -90,7 +164,6 @@ namespace das
             uint64_t insertI = ~uint64_t(0);
             auto pKeys = (KeyType *) tab.keys;
             auto pHashes = tab.hashes;
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             while ( true ) {
                 auto kh = pHashes[index];
                 if (kh == HASH_EMPTY64 ) {
@@ -115,11 +188,28 @@ namespace das
         __forceinline int64_t erase ( Table & tab, KeyType key, uint64_t hash ) {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
+            auto hashKey = hashToHashKey(TableHashKey(hash));
+            if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: locate, then swap-remove the last live slot into the hole
+                int64_t fidx = PackedFind<KeyType>::find(tab, key, hashKey);
+                if ( fidx<0 ) return -1;
+                uint64_t i = (uint64_t) fidx;
+                auto pHashes = tab.hashes;
+                auto pKeys = (KeyType *) tab.keys;
+                uint64_t last = tab.size - 1;
+                if ( i != last ) {
+                    pHashes[i] = pHashes[last];
+                    pKeys[i] = pKeys[last];
+                    memcpy(tab.data + i*valueTypeSize, tab.data + last*valueTypeSize, valueTypeSize);
+                }
+                pHashes[last] = HASH_EMPTY64;
+                memset(tab.data + last*valueTypeSize, 0, valueTypeSize);
+                tab.size--;
+                return (int64_t) i;
+            }
+            auto pKeys = (KeyType *) tab.keys;
+            auto pHashes = tab.hashes;
             uint64_t mask = tab.capacity - 1;
             uint64_t index = hash & mask;
-            auto pKeys = (const KeyType *) tab.keys;
-            auto pHashes = tab.hashes;
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             while ( true ) {
                 auto kh = pHashes[index];
                 if ( kh==HASH_EMPTY64 ) {
@@ -216,6 +306,9 @@ namespace das
             auto pHashes = newTab.hashes;
             memset(pHashes, 0, size_t(newCapacity) * sizeof(TableHashKey));
             if ( tab.size ) {
+                // Entries are only ever copied into a hashed (open-addressed) target: the
+                // sole packed target is the cap-0 -> minCapacity first allocation, which has
+                // no entries. So a packed-dense copy path here would be dead code.
                 auto pKeys = (KeyType *) newTab.keys;
                 auto pOldValues = tab.data;
                 auto pValues = newTab.data;

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -53,20 +53,61 @@ namespace das
     // PackedFind back to a capacity-bounded scan, losing the fixed unroll.)
     constexpr static uint32_t TABLE_MAX_LINEAR_CAPACITY = 8;
 
-    // Packed (small-table) find, specialized per key type so each instantiation is a flat,
-    // unrollable/vectorizable scan rather than a generic loop with a per-element compare.
-    // String keys scan only the 32-bit hash slots and return the first hash match as a
-    // *candidate* — the caller (find/reserve/erase) confirms it with KeyCompare (one strcmp).
-    // Hashes are only 32 bits so distinct keys can collide, but insert-time promotion to open
-    // addressing on the first collision (see reserve) guarantees a packed table never holds two
-    // slots with the same hashKey, so a single candidate is exact. The empty tail (hash 0) never
-    // matches a real key hash (>1), so the loop runs the full fixed capacity. Every other key
-    // type compares keys directly over the live prefix [0,size) and never touches the hash array
-    // (the `i<sz` guard short-circuits the stale tail), so its result is already exact and the
-    // caller's KeyCompare is a no-op confirm.
+    // Reduce a 64-bit hash to the 32-bit hashKey stored in LARGE (open-addressed) tables. The
+    // 0/1 sentinels (EMPTY/KILLED) remap to the FNV-32 prime so a real key never reads as an
+    // empty/killed slot. Packed tables do not use this — see PackedPolicy.
+    __forceinline TableHashKey hashToHashKey ( TableHashKey hash ) {
+        if ( sizeof(TableHashKey)==4 ) return hash <= 1 ? 16777619u : hash; // this should optimize out
+        else return hash;
+    }
+
+    // Liveness of slot i. Packed tables are dense in [0,size) (insertion order, swap-remove on
+    // erase), so a slot is live iff i<size — no hash read. Large tables are open-addressed: live
+    // iff the 32-bit hash is past the KILLED sentinel. EVERY liveness scan (GC, RTTI/data walk,
+    // iterators) must route through this: a packed STRING table stores 64-bit hashes (PackedPolicy
+    // below), so a raw 32-bit `hashes[i] > KILLED` read would misindex it.
+    __forceinline bool tableLiveSlot ( const Table & tab, uint64_t i ) {
+        if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) return i < tab.size;
+        return tab.hashes[i] > HASH_KILLED64;
+    }
+
+    // Bytes per hash slot, a pure function of capacity for the type-erased table-size
+    // computations (free / GC range) that only have sizes, not a C++ KeyType. PACKED tables hold
+    // 64-bit hashes (so the string find can compare the full hash with no strcmp; non-string keys
+    // store but ignore it — reclaimed in a follow-up), LARGE tables 32-bit. Must agree with
+    // PackedPolicy<KeyType>::hashBytes.
+    __forceinline uint64_t tableHashSlotBytes ( uint64_t capacity ) {
+        return ( capacity <= TABLE_MAX_LINEAR_CAPACITY ) ? uint64_t(sizeof(uint64_t)) : uint64_t(sizeof(TableHashKey));
+    }
+
+    // Iterate a table's live (key,value) slots from C++. ALWAYS use this (or tableLiveSlot) instead
+    // of a raw `for (i in [0,capacity)) if (hashes[i] > KILLED)` scan: a packed table stores 64-bit
+    // hashes (PackedPolicy), so a 32-bit `((TableHashKey*)hashes)[i]` read misindexes it. fn is
+    // called as fn(const TK & key, const TV & value); TV's size must match the table's value stride.
+    template <typename TK, typename TV, typename Fn>
+    __forceinline void table_for_each ( const Table & tab, Fn && fn ) {
+        auto pk = (const TK *) tab.keys;
+        auto pv = (const TV *) tab.data;
+        for ( uint64_t i=0, n=tab.capacity; i!=n; ++i ) {
+            if ( tableLiveSlot(tab, i) ) fn(pk[i], pv[i]);
+        }
+    }
+
+    // Per-key-type policy for the PACKED (small-table) regime: how a packed slot's hash is
+    // compared on find, stored on insert, moved on swap-remove, and read back for promotion, plus
+    // how wide the packed hash array is. TableHash delegates here so its packed paths stay
+    // key-agnostic.
+    // The packed hash array is uint64_t for EVERY key type (uniform width — a pure function of
+    // capacity, so the type-erased free/GC size math stays keytype-free). Only `find` differs:
+    //  - Workhorse keys (this generic): find compares key DATA over the dense [0,size) prefix; the
+    //    stored 64-bit hash is unused on find, kept only so promotion can re-bucket (a follow-up
+    //    will drop it for these keys and reclaim the slot).
+    //  - String keys (specialization): find compares the full 64-bit hash EXACTLY — no strcmp, and
+    //    a 64-bit collision is treated as impossible.
     template <typename KeyType>
-    struct PackedFind {
-        static __forceinline int64_t find ( const Table & tab, const KeyType & key, TableHashKey ) {
+    struct PackedPolicy {
+        static constexpr uint32_t hashBytes = sizeof(uint64_t);
+        static __forceinline int64_t find ( const Table & tab, const KeyType & key, uint64_t ) {
             auto pKeys = (const KeyType *) tab.keys;
             uint32_t sz = (uint32_t) tab.size;
             for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
@@ -74,27 +115,68 @@ namespace das
             }
             return -1;
         }
-    };
-
-    template <>
-    struct PackedFind<char *> {
-        static __forceinline int64_t find ( const Table & tab, char * const &, TableHashKey hashKey ) {
-            auto pHashes = tab.hashes;
-            for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
-                if ( pHashes[i]==hashKey ) return (int64_t) i;
-            }
-            return -1;
+        static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
+            ((uint64_t *) tab.hashes)[slot] = hash;
+        }
+        static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
+            ((uint64_t *) tab.hashes)[to] = ((uint64_t *) tab.hashes)[from];
+        }
+        static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
+            ((uint64_t *) tab.hashes)[slot] = 0;
+        }
+        // 64-bit key used to re-bucket into the large (32-bit) target during promotion.
+        static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, const KeyType &, Context * ) {
+            return ((const uint64_t *) tab.hashes)[slot];
         }
     };
 
     template <>
-    struct PackedFind<const char *> {
-        static __forceinline int64_t find ( const Table & tab, const char * const &, TableHashKey hashKey ) {
-            auto pHashes = tab.hashes;
+    struct PackedPolicy<char *> {
+        static constexpr uint32_t hashBytes = sizeof(uint64_t);
+        static __forceinline int64_t find ( const Table & tab, char * const &, uint64_t hash ) {
+            // All-8 scan: the tail is always 0 (alloc / erase / table_clear clear the full 64-bit
+            // width) and a real hash is >1, so the tail never matches — no size guard needed.
+            auto p = (const uint64_t *) tab.hashes;
             for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
-                if ( pHashes[i]==hashKey ) return (int64_t) i;
+                if ( p[i]==hash ) return (int64_t) i;
             }
             return -1;
+        }
+        static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
+            ((uint64_t *) tab.hashes)[slot] = hash;  // full 64-bit; hash_blockz64 already clamps 0/1
+        }
+        static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
+            ((uint64_t *) tab.hashes)[to] = ((uint64_t *) tab.hashes)[from];
+        }
+        static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
+            ((uint64_t *) tab.hashes)[slot] = 0;
+        }
+        static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, char * const &, Context * ) {
+            return ((const uint64_t *) tab.hashes)[slot];
+        }
+    };
+
+    template <>
+    struct PackedPolicy<const char *> {
+        static constexpr uint32_t hashBytes = sizeof(uint64_t);
+        static __forceinline int64_t find ( const Table & tab, const char * const &, uint64_t hash ) {
+            auto p = (const uint64_t *) tab.hashes;
+            for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
+                if ( p[i]==hash ) return (int64_t) i;
+            }
+            return -1;
+        }
+        static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
+            ((uint64_t *) tab.hashes)[slot] = hash;
+        }
+        static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
+            ((uint64_t *) tab.hashes)[to] = ((uint64_t *) tab.hashes)[from];
+        }
+        static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
+            ((uint64_t *) tab.hashes)[slot] = 0;
+        }
+        static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, const char * const &, Context * ) {
+            return ((const uint64_t *) tab.hashes)[slot];
         }
     };
 
@@ -106,27 +188,19 @@ namespace das
             minCapacity = 8
         };
         static_assert(minCapacity == TABLE_MAX_LINEAR_CAPACITY,
-            "PackedFind scans a fixed TABLE_MAX_LINEAR_CAPACITY slots, so every packed table must be exactly that many slots");
+            "PackedPolicy scans a fixed TABLE_MAX_LINEAR_CAPACITY slots, so every packed table must be exactly that many slots");
     public:
         TableHash () = delete;
         TableHash ( const TableHash & ) = delete;
         TableHash ( Context * ctx, uint32_t vs ) : context(ctx), valueTypeSize(vs) {}
 
-        __forceinline TableHashKey hashToHashKey ( TableHashKey hash ) const {
-            if ( sizeof(TableHashKey)==4 ) return hash <= 1 ? 16777619u : hash; // this should optimize out
-            else return hash;
-        }
-
         __forceinline int64_t find ( const Table & tab, KeyType key, uint64_t hash ) const {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
-            auto hashKey = hashToHashKey(TableHashKey(hash));
-            if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed
-                int64_t idx = PackedFind<KeyType>::find(tab, key, hashKey);
-                // PackedFind<char*> returns a hash-only candidate; confirm the key (one strcmp).
-                // Other key types already compared data, so KeyCompare here is a trivial no-op.
-                return ( idx>=0 && KeyCompare<KeyType>()(((const KeyType *)tab.keys)[idx], key) ) ? idx : -1;
+            if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: exact (string 64-bit hash / other data)
+                return PackedPolicy<KeyType>::find(tab, key, hash);
             }
+            auto hashKey = hashToHashKey(TableHashKey(hash));
             auto pKeys = (const KeyType *) tab.keys;
             auto pHashes = tab.hashes;
             uint64_t mask = tab.capacity - 1;
@@ -144,35 +218,27 @@ namespace das
 
         __forceinline int64_t reserve ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {
             DAS_ASSERT(hash>1);
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: dense, load factor 1.0
-                bool hashCollision = false;
                 if ( tab.capacity != 0 ) {  // dedup against existing (skip on an unallocated table)
-                    int64_t idx = PackedFind<KeyType>::find(tab, key, hashKey);
-                    if ( idx>=0 ) {
-                        // confirm the candidate; for non-string keys this already-data-matched.
-                        if ( KeyCompare<KeyType>()(((const KeyType *)tab.keys)[idx], key) ) return idx;
-                        hashCollision = true;   // hash matched but key differs -> 32-bit collision (string keys)
-                    }
+                    int64_t idx = PackedPolicy<KeyType>::find(tab, key, hash);  // exact (no confirm needed)
+                    if ( idx>=0 ) return idx;
                 }
                 if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
-                // Promote out of packed mode on a full table (load factor 1.0) OR a 32-bit hashKey
-                // collision with a different stored key — open addressing confirms every hit with
-                // KeyCompare, so a collision-free packed table keeps find at one candidate + one
-                // strcmp. *4 gives the hashed table load-factor headroom so it does not immediately
-                // re-grow (cap*2 would land exactly on the 0.5 trigger).
-                if ( hashCollision || tab.size >= tab.capacity ) {
-                    // cap-0 -> first allocation (stays packed); otherwise grow to open addressing.
+                // A full packed table promotes to open addressing. *4 gives the hashed table
+                // load-factor headroom so it does not immediately re-grow (cap*2 would land exactly
+                // on the 0.5 trigger). cap-0 -> first allocation (stays packed).
+                if ( tab.size >= tab.capacity ) {
                     uint64_t newCapacity = (tab.capacity == 0) ? minCapacity : tab.capacity*4;
                     reserveInternal(tab, newCapacity, at);
                     return reserve(tab, key, hash, at);  // re-dispatch: now hashed (or the freshly allocated packed table)
                 }
                 uint64_t i = tab.size;
-                tab.hashes[i] = hashKey;
+                PackedPolicy<KeyType>::insertHash(tab, i, hash);
                 ((KeyType *) tab.keys)[i] = key;
                 tab.size++;
                 return (int64_t) i;
             }
+            auto hashKey = hashToHashKey(TableHashKey(hash));
             if ( tab.size >= (tab.capacity/2) ) grow(tab, at);
             else if ( (tab.capacity-tab.size)/2 < tab.tombstones ) rehash(tab, at);
             uint64_t mask = tab.capacity - 1;
@@ -220,9 +286,8 @@ namespace das
                 reserveInternal(tab, tab.capacity*4, at);
                 return reserve(tab, key, hash, at);
             }
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             uint64_t i = tab.size;
-            tab.hashes[i] = hashKey;
+            PackedPolicy<KeyType>::insertHash(tab, i, hash);
             ((KeyType *) tab.keys)[i] = key;
             tab.size++;
             return (int64_t) i;
@@ -231,27 +296,23 @@ namespace das
         __forceinline int64_t erase ( Table & tab, KeyType key, uint64_t hash ) {
             DAS_ASSERT(hash>1);
             if ( tab.capacity==0 ) return -1;
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: locate, then swap-remove the last live slot into the hole
-                int64_t fidx = PackedFind<KeyType>::find(tab, key, hashKey);
+                int64_t fidx = PackedPolicy<KeyType>::find(tab, key, hash);  // exact
                 if ( fidx<0 ) return -1;
-                auto pHashes = tab.hashes;
                 auto pKeys = (KeyType *) tab.keys;
-                // PackedFind<char*> is hash-only; confirm the candidate before removing it, or a
-                // colliding query would swap-remove the wrong key. Other key types already matched.
-                if ( !KeyCompare<KeyType>()(pKeys[fidx], key) ) return -1;
                 uint64_t i = (uint64_t) fidx;
                 uint64_t last = tab.size - 1;
                 if ( i != last ) {
-                    pHashes[i] = pHashes[last];
+                    PackedPolicy<KeyType>::moveHash(tab, i, last);
                     pKeys[i] = pKeys[last];
                     memcpy(tab.data + i*valueTypeSize, tab.data + last*valueTypeSize, valueTypeSize);
                 }
-                pHashes[last] = HASH_EMPTY64;
+                PackedPolicy<KeyType>::clearHash(tab, last);
                 memset(tab.data + last*valueTypeSize, 0, valueTypeSize);
                 tab.size--;
                 return (int64_t) i;
             }
+            auto hashKey = hashToHashKey(TableHashKey(hash));
             auto pKeys = (KeyType *) tab.keys;
             auto pHashes = tab.hashes;
             uint64_t mask = tab.capacity - 1;
@@ -331,7 +392,11 @@ namespace das
                 return false;
             }
             Table newTab;
-            uint64_t perSlot = uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + uint64_t(sizeof(TableHashKey));
+            // Hash-region width is a function of capacity: packed string tables hold 64-bit
+            // hashes (PackedPolicy<char*>::hashBytes), everything else 32-bit.
+            bool newPacked = newCapacity <= TABLE_MAX_LINEAR_CAPACITY;
+            uint64_t newHashBytes = newPacked ? uint64_t(PackedPolicy<KeyType>::hashBytes) : uint64_t(sizeof(TableHashKey));
+            uint64_t perSlot = uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + newHashBytes;
             if ( perSlot && newCapacity > UINT64_MAX / perSlot ) {
                 context->throw_error_ex("can't grow table, capacity*perSlot overflows uint64 [capacity=%llu]", (unsigned long long)newCapacity);
                 return false;
@@ -350,28 +415,41 @@ namespace das
             newTab.tombstones = 0;
             if ( valueTypeSize ) memset(newTab.data, 0, size_t(newCapacity)*size_t(valueTypeSize));
             auto pHashes = newTab.hashes;
-            memset(pHashes, 0, size_t(newCapacity) * sizeof(TableHashKey));
+            memset(pHashes, 0, size_t(newCapacity) * size_t(newHashBytes));
             if ( tab.size ) {
-                // Entries are only ever copied into a hashed (open-addressed) target: the
-                // sole packed target is the cap-0 -> minCapacity first allocation, which has
-                // no entries. So a packed-dense copy path here would be dead code.
+                // Entries are only ever copied into a LARGE (open-addressed) target: the sole
+                // packed target is the cap-0 -> minCapacity first allocation, which has no
+                // entries. So the target hash store below is always 32-bit. The SOURCE may be
+                // packed (dense [0,size), hash via PackedPolicy::promoteHash) or large (a 32-bit
+                // probe scan over [0,capacity)).
                 auto pKeys = (KeyType *) newTab.keys;
                 auto pOldValues = tab.data;
                 auto pValues = newTab.data;
                 auto pOldKeys = (const KeyType *) tab.keys;
-                auto pOldHashes = tab.hashes;
-                for ( uint64_t i=0, is=tab.capacity; i!=is; ++i ) {
-                    auto hash = pOldHashes[i];
-                    if ( hash>HASH_KILLED64 ) {
+                if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed source: dense
+                    for ( uint64_t i=0, is=tab.size; i!=is; ++i ) {
+                        uint64_t hash = PackedPolicy<KeyType>::promoteHash(tab, i, pOldKeys[i], context);
                         int64_t index = insertNew(newTab, hash);
-                        pHashes[index] = hash;
+                        pHashes[index] = hashToHashKey(TableHashKey(hash));
                         pKeys[index] = pOldKeys[i];
                         memcpy ( pValues + index*valueTypeSize, pOldValues + i*valueTypeSize, valueTypeSize );
+                    }
+                } else {  // large source: 32-bit hashes, skip empty/killed
+                    auto pOldHashes = tab.hashes;
+                    for ( uint64_t i=0, is=tab.capacity; i!=is; ++i ) {
+                        auto hash = pOldHashes[i];
+                        if ( hash>HASH_KILLED64 ) {
+                            int64_t index = insertNew(newTab, hash);
+                            pHashes[index] = hash;
+                            pKeys[index] = pOldKeys[i];
+                            memcpy ( pValues + index*valueTypeSize, pOldValues + i*valueTypeSize, valueTypeSize );
+                        }
                     }
                 }
             }
             if (tab.capacity && !context->verySafeContext) {
-                uint64_t oldSize = tab.capacity * perSlot;
+                uint64_t oldHashBytes = (tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<KeyType>::hashBytes) : uint64_t(sizeof(TableHashKey));
+                uint64_t oldSize = tab.capacity * (uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + oldHashBytes);
                 context->free(tab.data, oldSize, at);
             }
             swap ( newTab, tab );

--- a/include/daScript/simulate/runtime_table_nodes.h
+++ b/include/daScript/simulate/runtime_table_nodes.h
@@ -177,6 +177,101 @@ namespace das
         }
     };
 
+    // String-key table access with a precomputed hash. Emitted only when the key is an
+    // ExprConstString: the key bytes and their hash are baked at simulate time, so the
+    // runtime skips the per-lookup hash_blockz64 byte walk. The key string is carried
+    // only for the large-table KeyCompare confirm; the packed path compares hashOf alone.
+    struct SimNode_TableWithHash : SimNode {
+        SimNode_TableWithHash(const LineInfo & at, SimNode * t, char * k, uint64_t h, uint32_t vts)
+            : SimNode(at), tabExpr(t), key(k), hashOf(h), valueTypeSize(vts) {}
+        SimNode * visitWithHash ( SimVisitor & vis, const char * op ) {
+            V_BEGIN();
+            vis.op(op);
+            V_SUB(tabExpr);
+            V_ARG(key);
+            V_ARG(hashOf);
+            V_ARG(valueTypeSize);
+            V_END();
+        }
+        SimNode * tabExpr;
+        char *    key;
+        uint64_t  hashOf;
+        uint32_t  valueTypeSize;
+    };
+
+    struct SimNode_TableIndex_WithHash : SimNode_TableWithHash {
+        DAS_PTR_NODE;
+        SimNode_TableIndex_WithHash(const LineInfo & at, SimNode * t, char * k, uint64_t h, uint32_t vts, uint32_t o)
+            : SimNode_TableWithHash(at,t,k,h,vts), offset(o) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override {
+            V_BEGIN();
+            V_OP(TableIndexWithHash);
+            V_SUB(tabExpr);
+            V_ARG(key);
+            V_ARG(hashOf);
+            V_ARG(valueTypeSize);
+            V_ARG(offset);
+            V_END();
+        }
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Table * tab = (Table *) tabExpr->evalPtr(context);
+            if ( tab->isLocked() ) context.throw_error_at(debugInfo, "can't insert to a locked table");
+            TableHash<char*> thh(&context,valueTypeSize);
+            int64_t index = thh.reserve(*tab, key, hashOf, &debugInfo);
+            return tab->data + index * valueTypeSize + offset;
+        }
+        uint32_t offset;
+    };
+
+    struct SimNode_SafeTableIndex_WithHash : SimNode_TableWithHash {
+        DAS_PTR_NODE;
+        SimNode_SafeTableIndex_WithHash(const LineInfo & at, SimNode * t, char * k, uint64_t h, uint32_t vts)
+            : SimNode_TableWithHash(at,t,k,h,vts) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override {
+            return visitWithHash(vis,"SafeTableIndexWithHash");
+        }
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Table * tab = (Table *) tabExpr->evalPtr(context);
+            if (!tab) return nullptr;
+            TableHash<char*> thh(&context,valueTypeSize);
+            int64_t index = thh.find(*tab, key, hashOf);
+            return index!=-1 ? tab->data + index * valueTypeSize : nullptr;
+        }
+    };
+
+    struct SimNode_TableFind_WithHash : SimNode_TableWithHash {
+        DAS_PTR_NODE;
+        SimNode_TableFind_WithHash(const LineInfo & at, SimNode * t, char * k, uint64_t h, uint32_t vts)
+            : SimNode_TableWithHash(at,t,k,h,vts) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override {
+            return visitWithHash(vis,"TableFindWithHash");
+        }
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Table * tab = (Table *) tabExpr->evalPtr(context);
+            TableHash<char*> thh(&context,valueTypeSize);
+            int64_t index = thh.find(*tab, key, hashOf);
+            return index!=-1 ? tab->data + index * valueTypeSize : nullptr;
+        }
+    };
+
+    struct SimNode_KeyExists_WithHash : SimNode_TableWithHash {
+        DAS_BOOL_NODE;
+        SimNode_KeyExists_WithHash(const LineInfo & at, SimNode * t, char * k, uint64_t h, uint32_t vts)
+            : SimNode_TableWithHash(at,t,k,h,vts) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override {
+            return visitWithHash(vis,"KeyExistsWithHash");
+        }
+        __forceinline bool compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Table * tab = (Table *) tabExpr->evalPtr(context);
+            TableHash<char*> thh(&context,valueTypeSize);
+            return thh.find(*tab, key, hashOf) != -1;
+        }
+    };
+
     struct TableIterator : Iterator {
         TableIterator ( const Table * tab, uint32_t st, LineInfo * at ) : Iterator(at), table(tab), stride(st) {}
         size_t nextValid ( size_t index ) const;

--- a/include/daScript/simulate/simulate_fusion.h
+++ b/include/daScript/simulate/simulate_fusion.h
@@ -124,6 +124,7 @@ namespace das {
     void createFusionEngine_at();
     void createFusionEngine_at_array();
     void createFusionEngine_tableindex();
+    void createFusionEngine_tablewithhash();
     // call
     void createFusionEngine_call1();
     void createFusionEngine_call2();

--- a/include/daScript/simulate/simulate_fusion_op1_set_impl.h
+++ b/include/daScript/simulate/simulate_fusion_op1_set_impl.h
@@ -1,15 +1,23 @@
 #define IMPLEMENT_SET_OP1_FUSION_POINT(INLINE,OPNAME,TYPE,CTYPE,RCTYPE) \
     struct Op1FusionPoint_##OPNAME##_##CTYPE : FusionPointOp1 { \
         Op1FusionPoint_##OPNAME##_##CTYPE ( ) {} \
+        IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,Global); \
         IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,Local); \
-        IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,Argument); \
+        IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,CMResOfs); \
+        IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,LocalRefOff); \
         IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,ArgumentRef); \
+        IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,ArgumentRefOff); \
+        IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,ThisBlockArgumentRef); \
         virtual SimNode * match(const SimNodeInfoLookup & info, SimNode *, SimNode * node_x, Context * context) override { \
             auto & ccode = *(context->code); \
             if ( !node_x ) { return nullptr; } \
+            MATCH_ANY_OP1_NODE(CTYPE,"GetGlobal",Global) \
             MATCH_ANY_OP1_NODE(CTYPE,"GetLocal",Local) \
+            MATCH_ANY_OP1_NODE(CTYPE,"GetCMResOfs",CMResOfs) \
+            MATCH_ANY_OP1_NODE(CTYPE,"GetLocalRefOff",LocalRefOff) \
             MATCH_ANY_OP1_NODE(CTYPE,"GetArgument",ArgumentRef) \
-            MATCH_ANY_OP1_NODE(CTYPE,"GetArgumentRef",Argument) \
+            MATCH_ANY_OP1_NODE(CTYPE,"GetArgumentRefOff",ArgumentRefOff) \
+            MATCH_ANY_OP1_NODE(CTYPE,"GetThisBlockArgument",ThisBlockArgumentRef) \
             return nullptr; \
         } \
         virtual void set(SimNode_Op1Fusion * result, SimNode * node) override { \

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -722,14 +722,9 @@ void das_httpr_set_header ( HttpRequest * req, const char * key, const char * va
 
 http_headers das_req_table_to_headers ( const TTable<char *,char *> & tab) {
     http_headers headers;
-    char ** keys = (char **)tab.keys;
-    char ** values = (char **)tab.data;
-    auto * hashes = (TableHashKey *)tab.hashes;
-    for ( uint32_t i=0; i!=tab.capacity; ++i ) {
-        if ( hashes[i]!=HASH_EMPTY64 && hashes[i]!=HASH_KILLED64 ) {
-            headers[keys[i]] = values[i];
-        }
-    }
+    table_for_each<char *, char *>(tab, [&]( char * key, char * value ) {
+        headers[key] = value;
+    });
     return headers;
 }
 
@@ -763,23 +758,17 @@ void das_req_POST_HF ( const char * url, const char * text, const TTable<char *,
     req->url = url ? url : "";
     req->headers =das_req_table_to_headers(tab);
     req->body = text ? text : "";
-    char ** keys = (char **)from.keys;
-    char ** values = (char **)from.data;
-    auto * hashes = (TableHashKey *)from.hashes;
-    for ( uint32_t i=0; i!=from.capacity; ++i ) {
-        if ( hashes[i]!=HASH_EMPTY64 && hashes[i]!=HASH_KILLED64 ) {
-            hv::FormData data;
-            auto value = values[i];
-            if ( value != nullptr ) {
-                if (*value == '@') {
-                    data.filename = value+1;
-                } else {
-                    data.content = value;
-                }
+    table_for_each<char *, char *>(from, [&]( char * key, char * value ) {
+        hv::FormData data;
+        if ( value != nullptr ) {
+            if (*value == '@') {
+                data.filename = value+1;
+            } else {
+                data.content = value;
             }
-            req->form[keys[i] ? keys[i] : ""] = data;
         }
-    }
+        req->form[key ? key : ""] = data;
+    });
     auto resp = request(req);
     das_invoke<void>::invoke<HttpResponse*>(context,at,block,resp.get());
 }
@@ -804,23 +793,17 @@ void das_req_PUT_HF ( const char * url, const char * text, const TTable<char *,c
     req->url = url ? url : "";
     req->headers = das_req_table_to_headers(tab);
     req->body = text ? text : "";
-    char ** keys = (char **)from.keys;
-    char ** values = (char **)from.data;
-    auto * hashes = (TableHashKey *)from.hashes;
-    for ( uint32_t i=0; i!=from.capacity; ++i ) {
-        if ( hashes[i]!=HASH_EMPTY64 && hashes[i]!=HASH_KILLED64 ) {
-            hv::FormData data;
-            auto value = values[i];
-            if ( value != nullptr ) {
-                if (*value == '@') {
-                    data.filename = value+1;
-                } else {
-                    data.content = value;
-                }
+    table_for_each<char *, char *>(from, [&]( char * key, char * value ) {
+        hv::FormData data;
+        if ( value != nullptr ) {
+            if (*value == '@') {
+                data.filename = value+1;
+            } else {
+                data.content = value;
             }
-            req->form[keys[i] ? keys[i] : ""] = data;
         }
-    }
+        req->form[key ? key : ""] = data;
+    });
     auto resp = request(req);
     das_invoke<void>::invoke<HttpResponse*>(context,at,block,resp.get());
 }
@@ -845,23 +828,17 @@ void das_req_PATCH_HF ( const char * url, const char * text, const TTable<char *
     req->url = url ? url : "";
     req->headers = das_req_table_to_headers(tab);
     req->body = text ? text : "";
-    char ** keys = (char **)from.keys;
-    char ** values = (char **)from.data;
-    auto * hashes = (TableHashKey *)from.hashes;
-    for ( uint32_t i=0; i!=from.capacity; ++i ) {
-        if ( hashes[i]!=HASH_EMPTY64 && hashes[i]!=HASH_KILLED64 ) {
-            hv::FormData data;
-            auto value = values[i];
-            if ( value != nullptr ) {
-                if (*value == '@') {
-                    data.filename = value+1;
-                } else {
-                    data.content = value;
-                }
+    table_for_each<char *, char *>(from, [&]( char * key, char * value ) {
+        hv::FormData data;
+        if ( value != nullptr ) {
+            if (*value == '@') {
+                data.filename = value+1;
+            } else {
+                data.content = value;
             }
-            req->form[keys[i] ? keys[i] : ""] = data;
         }
-    }
+        req->form[key ? key : ""] = data;
+    });
     auto resp = request(req);
     das_invoke<void>::invoke<HttpResponse*>(context,at,block,resp.get());
 }

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -48,6 +48,8 @@ class CollectExternVisitor : AstVisitor {
     tab_erase_accessor : LLVMOpaqueValue?
     tab_find_wh_accessor : LLVMOpaqueValue?
     tab_at_wh_accessor : LLVMOpaqueValue?
+    tab_at_apm_accessor : LLVMOpaqueValue?
+    tab_at_apm_typed_accessor : LLVMOpaqueValue?
     reg_extern_tab_type : LLVMOpaqueType?
     reg_extern_tab_wh_type : LLVMOpaqueType?
     trap_typ : LLVMOpaqueType?
@@ -155,6 +157,13 @@ class CollectExternVisitor : AstVisitor {
         reg_extern_tab_wh_type = LLVMFunctionType(types.LLVMVoidPtrType(), [])
         tab_find_wh_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_string_table_find_with_hash", reg_extern_tab_wh_type)
         tab_at_wh_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_string_table_at_with_hash", reg_extern_tab_wh_type)
+
+        // Insert-after-packed-miss globals (the inline packed find calls these on a miss). The
+        // string accessor is nullary; the per-type one shares get_jit_table_at's (baseType,ctx,at)
+        // shape. Without baking these in the exe, the glob keeps its compile-process address and
+        // faults under ASLR (works on Windows only because the DLL loads at the same base).
+        tab_at_apm_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_string_table_at_after_packed_miss", reg_extern_tab_wh_type)
+        tab_at_apm_typed_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_table_at_after_packed_miss", reg_extern_tab_type)
 
         trap_typ = LLVMFunctionType(types.t_void, [])
         trap_ptr = LLVMAddFunctionWithType(g_mod, "jit_trap", trap_typ)
@@ -452,11 +461,17 @@ class CollectExternVisitor : AstVisitor {
     def add_table_at_call(index_t : TypeDeclPtr) {
         let typ = get_table_t(index_t)
         if (typ == Type.tString) {
-            // string keys route through the precomputed-hash at (see build_table_at); bake that glob
+            // string keys route through the precomputed-hash at (see build_table_at); bake that
+            // glob plus its after-packed-miss insert helper
             let tab_ptr = LLVMBuildCall2(builder, reg_extern_tab_wh_type, tab_at_wh_accessor, [], "")
             let tab_method = LLVMGetNamedGlobal(g_mod, DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH()).glob())
             if (tab_method != null) {
                 LLVMBuildStore(builder, tab_ptr, tab_method)
+            }
+            let apm_ptr = LLVMBuildCall2(builder, reg_extern_tab_wh_type, tab_at_apm_accessor, [], "")
+            let apm_method = LLVMGetNamedGlobal(g_mod, DllName(FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS()).glob())
+            if (apm_method != null) {
+                LLVMBuildStore(builder, apm_ptr, apm_method)
             }
             return
         }
@@ -466,6 +481,17 @@ class CollectExternVisitor : AstVisitor {
 
         let tab_method = LLVMGetNamedGlobal(g_mod, DllName(FN_JIT_TABLE_AT(typ)).glob())
         LLVMBuildStore(builder, tab_ptr, tab_method)
+
+        // SIMD-packed integer keys run an inline packed find that, on a miss, calls the
+        // after-packed-miss insert helper — bake that glob too (see bind_jit_table_at_glob)
+        if (is_simd_packed_key(typ)) {
+            var apm_args = array<LLVMValueRef>(types.ConstI32(uint64(typ)), null_ptr, null_ptr)
+            let apm_ptr = LLVMBuildCall2(builder, reg_extern_tab_type, tab_at_apm_typed_accessor, apm_args, "")
+            let apm_method = LLVMGetNamedGlobal(g_mod, DllName(FN_JIT_TABLE_AT_AFTER_PACKED_MISS(typ)).glob())
+            if (apm_method != null) {
+                LLVMBuildStore(builder, apm_ptr, apm_method)
+            }
+        }
     }
 
     def add_table_find_call(index_t : TypeDeclPtr) {

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -22,11 +22,9 @@ require daslib/safe_addr
 require daslib/strings_boost
 require daslib/defer
 require daslib/lpipe
-require daslib/debugger
+require daslib/rtti
 require daslib/clargs
-require daslib/json
 require daslib/json_boost
-require math
 require jit
 require daslib/fio
 
@@ -48,7 +46,10 @@ class CollectExternVisitor : AstVisitor {
     tab_at_accessor : LLVMOpaqueValue?
     tab_find_accessor : LLVMOpaqueValue?
     tab_erase_accessor : LLVMOpaqueValue?
+    tab_find_wh_accessor : LLVMOpaqueValue?
+    tab_at_wh_accessor : LLVMOpaqueValue?
     reg_extern_tab_type : LLVMOpaqueType?
+    reg_extern_tab_wh_type : LLVMOpaqueType?
     trap_typ : LLVMOpaqueType?
     trap_ptr : LLVMOpaqueValue?
     reg_standalone_fn_type : LLVMOpaqueType?
@@ -148,6 +149,12 @@ class CollectExternVisitor : AstVisitor {
         tab_at_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_table_at", reg_extern_tab_type)
         tab_find_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_table_find", reg_extern_tab_type)
         tab_erase_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_table_erase", reg_extern_tab_type)
+
+        // void * get_jit_string_table_{find,at}_with_hash ( ) — string keys route through the
+        // precomputed-hash globals, so the standalone exe bakes those instead of the per-type ones.
+        reg_extern_tab_wh_type = LLVMFunctionType(types.LLVMVoidPtrType(), [])
+        tab_find_wh_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_string_table_find_with_hash", reg_extern_tab_wh_type)
+        tab_at_wh_accessor = LLVMAddFunctionWithType(g_mod, "get_jit_string_table_at_with_hash", reg_extern_tab_wh_type)
 
         trap_typ = LLVMFunctionType(types.t_void, [])
         trap_ptr = LLVMAddFunctionWithType(g_mod, "jit_trap", trap_typ)
@@ -250,7 +257,7 @@ class CollectExternVisitor : AstVisitor {
         if (key_exists(registered_modules, mod_name) || key_exists(dynamic_modules, mod_name)) return
         registered_modules[mod_name] = true
         // First ensure all dependencies of this module are registered
-        module_for_each_dependency(m) $(var dep : Module?; var pub : bool) {
+        module_for_each_dependency(m) $(var dep : Module?; var _pub : bool) {
             ensure_module(dep)
         }
         let cpp_name = string(m.cppClassName)
@@ -444,6 +451,15 @@ class CollectExternVisitor : AstVisitor {
     // Pass null for both to match the C++ signature without a real Context.
     def add_table_at_call(index_t : TypeDeclPtr) {
         let typ = get_table_t(index_t)
+        if (typ == Type.tString) {
+            // string keys route through the precomputed-hash at (see build_table_at); bake that glob
+            let tab_ptr = LLVMBuildCall2(builder, reg_extern_tab_wh_type, tab_at_wh_accessor, [], "")
+            let tab_method = LLVMGetNamedGlobal(g_mod, DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH()).glob())
+            if (tab_method != null) {
+                LLVMBuildStore(builder, tab_ptr, tab_method)
+            }
+            return
+        }
         let null_ptr = LLVMConstPointerNull(types.LLVMVoidPtrType())
         var call_args = array<LLVMValueRef>(types.ConstI32(uint64(typ)), null_ptr, null_ptr)
         let tab_ptr = LLVMBuildCall2(builder, reg_extern_tab_type, tab_at_accessor, call_args, "")
@@ -454,6 +470,15 @@ class CollectExternVisitor : AstVisitor {
 
     def add_table_find_call(index_t : TypeDeclPtr) {
         let typ = get_table_t(index_t)
+        if (typ == Type.tString) {
+            // string keys route through the precomputed-hash find (see build_table_find); bake that glob
+            let tab_ptr = LLVMBuildCall2(builder, reg_extern_tab_wh_type, tab_find_wh_accessor, [], "")
+            let tab_method = LLVMGetNamedGlobal(g_mod, DllName(FN_JIT_STRING_TABLE_FIND_WITH_HASH()).glob())
+            if (tab_method != null) {
+                LLVMBuildStore(builder, tab_ptr, tab_method)
+            }
+            return
+        }
         let null_ptr = LLVMConstPointerNull(types.LLVMVoidPtrType())
         var call_args = array<LLVMValueRef>(types.ConstI32(uint64(typ)), null_ptr, null_ptr)
         let tab_ptr = LLVMBuildCall2(builder, reg_extern_tab_type, tab_find_accessor, call_args, "")
@@ -704,7 +729,7 @@ def private write_release_deps(prog : Program?) {
     // alongside `--force-shared-module dasglfw` (the daslang-side name).
     var by_das : table<string; SharedModuleEntry>
     var by_pkg : table<string; SharedModuleEntry>
-    for_each_registered_dynamic_module() $(path, mod_name, das_name) {
+    for_each_registered_dynamic_module() $(path, _mod_name, das_name) {
         let abs = path
         let rel = compute_modules_relative_suffix(abs)
         let entry = SharedModuleEntry(rel = rel, abs = abs, das_name = das_name)
@@ -848,7 +873,7 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
 
     // Collect dynamic module names — used by CollectExternVisitor to skip dlopen'd modules
     var dynamic_modules : table<string; bool>
-    for_each_registered_dynamic_module() $(path, mod_name, das_name) {
+    for_each_registered_dynamic_module() $(_path, _mod_name, das_name) {
         dynamic_modules[das_name] = true
     }
 

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -21,7 +21,7 @@ require daslib/safe_addr
 require daslib/strings_boost
 require daslib/defer
 require daslib/lpipe
-require daslib/debugger
+require daslib/rtti
 require math
 require jit
 require daslib/fio
@@ -96,7 +96,7 @@ def set_public_linkage(value : LLVMOpaqueValue?) {
 }
 
 [macro_function]
-def get_file_info_global(g_builder : LLVMOpaqueBuilder?; types : PrimitiveTypes?; name : string) : LLVMOpaqueValue? {
+def get_file_info_global(_g_builder : LLVMOpaqueBuilder?; types : PrimitiveTypes?; name : string) : LLVMOpaqueValue? {
     let sz = typeinfo sizeof(type<FileInfo>)
     let file_info_type = LLVMArrayType(types.t_int8, uint(sz))
     let filename_var = "fileinfo_{name}"
@@ -1946,10 +1946,7 @@ class public LlvmJitVisitor : AstVisitor {
         var kins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(keyVecTy), keyVal, LLVMConstInt(types.t_int32, 0ul, 0), "k.ins")
         var ksplat = LLVMBuildShuffleVector(g_builder, kins, LLVMGetUndef(keyVecTy), LLVMConstNull(i32VecTy), "k.splat")
         var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, kv, ksplat, "k.eqv")
-        var idxConsts : array<LLVMOpaqueValue?>
-        for (i in range(JIT_TABLE_MAX_LINEAR_CAPACITY)) {
-            idxConsts |> push(LLVMConstInt(types.t_int32, uint64(i), 0))
-        }
+        var idxConsts <- [for (i in range(JIT_TABLE_MAX_LINEAR_CAPACITY)); LLVMConstInt(types.t_int32, uint64(i), 0)]
         var idxVec = LLVMConstVector(array_data_ptr(idxConsts), uint(length(idxConsts)))
         unsafe { delete idxConsts; }
         var sins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(i32VecTy), sizeI32, LLVMConstInt(types.t_int32, 0ul, 0), "sz.ins")

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1918,16 +1918,6 @@ class public LlvmJitVisitor : AstVisitor {
         return ccall
     }
 
-    // hashToHashKey(TableHashKey(hash)) from runtime_table.h: truncate the 64-bit hash to the
-    // 32-bit TableHashKey, then map 0/1 -> 16777619 so it can't alias EMPTY/KILLED slots.
-    def reduce_hash_to_key32(h : LLVMOpaqueValue?) : LLVMOpaqueValue? {
-        var hk = LLVMBuildTrunc(g_builder, h, types.t_int32, "hk.trunc")
-        var one = LLVMConstInt(types.t_int32, 1ul, 0)
-        var prime = LLVMConstInt(types.t_int32, 16777619ul, 0)
-        var le1 = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULE, hk, one, "hk.le1")
-        return LLVMBuildSelect(g_builder, le1, prime, hk, "hk")
-    }
-
     // First set lane of an N-bit (i8) match mask -> i32 index, or -1 if the mask is empty.
     // (N == TABLE_MAX_LINEAR_CAPACITY == 8, so the mask is exactly i8 and cttz.i8 fits.)
     def first_set_lane_or_neg1(maskI8 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
@@ -1942,25 +1932,11 @@ class public LlvmJitVisitor : AstVisitor {
         return LLVMBuildSelect(g_builder, none, types.ConstI32(uint64(-1)), ctz32, "lane.idx")
     }
 
-    // PackedFind<char*> as one <N x i32> SIMD compare: load the hash slots, compare against
-    // the splatted 32-bit key, bitcast the mask to i8, cttz -> first set lane; empty -> -1.
-    // The empty tail (hash 0) never matches the clamped key, so no size guard is needed.
-    // (Measured fastest of none/scalar/vector — see benchmarks/core/small_table/results.md.)
-    def packed_find_vector(hashes : LLVMOpaqueValue?; hk32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
-        var vecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
-        var hvp = LLVMBuildPointerCast(g_builder, hashes, LLVMPointerType(vecTy, 0u), "h.vp")
-        var hv = LLVMBuildLoad2(g_builder, vecTy, hvp, "h.vec")
-        LLVMSetAlignment(hv, 4u)
-        var ins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(vecTy), hk32, LLVMConstInt(types.t_int32, 0ul, 0), "h.ins")
-        var splat = LLVMBuildShuffleVector(g_builder, ins, LLVMGetUndef(vecTy), LLVMConstNull(vecTy), "h.splat")
-        var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, splat, "h.eqv")
-        return first_set_lane_or_neg1(LLVMBuildBitCast(g_builder, eqv, types.t_int8, "h.mask"))
-    }
-
-    // The non-string mirror — generic PackedFind<KeyType>: compare actual KEY data (not
-    // hashes) over [0,size). Load <N x KeyT>, compare to the splatted key, AND with a
-    // liveness mask (lane i live iff i < size) — non-string tails are not sentinel-zeroed,
-    // so stale tail keys must be masked out (strings dodge this via the 0 hash sentinel).
+    // Packed find as one <N x T> SIMD compare over [0,size): load the slots (key DATA for
+    // workhorse keys, or the 64-bit hash array for string keys), splat the query value, icmp eq,
+    // AND a liveness mask (lane i live iff i < size, since the tail is not relied on to be clean),
+    // bitcast to i8, cttz -> first set lane; no match -> -1. Used by both the integer key-scan and
+    // the string 64-bit-hash scan (keyElemTy = i64, keysPtr = the hashes array).
     def packed_find_vector_keys(keysPtr : LLVMOpaqueValue?; keyVal : LLVMOpaqueValue?; keyElemTy : LLVMOpaqueType?; sizeI32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
         var keyVecTy = LLVMVectorType(keyElemTy, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
         var i32VecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
@@ -1984,66 +1960,39 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
 
-    // Confirm a packed string candidate: load keys[idxLane] and jit_string_equal it against the
-    // query key. The SIMD scan matches only the 32-bit hash (collidable), so this is the real
-    // compare; insert-time collision promotion guarantees at most one hash-match, so one strcmp is
-    // exact. Returns the i32 0/1 result. Caller must be in a block where idxLane is a genuine
-    // candidate (>=0) — a clean miss (no hash match) never reaches here, so it stays strcmp-free.
-    def emit_string_key_equal(keysV : LLVMOpaqueValue?; key : LLVMOpaqueValue?; idxLane : LLVMOpaqueValue?) : LLVMOpaqueValue? {
-        var i8ptr = LLVMPointerType(types.t_int8, 0u)
-        var keysArr = LLVMBuildPointerCast(g_builder, keysV, LLVMPointerType(i8ptr, 0u), "keys.arr")
-        var idxv = idxLane
-        var slotPtr = LLVMBuildGEP2(g_builder, i8ptr, keysArr, idxv, "cf.slotp")
-        var slotKey = LLVMBuildLoad2(g_builder, i8ptr, slotPtr, "cf.key")
-        var (eq_fun, eq_typ) = get_string_equal(g_builder, g_mod, types)
-        var eqArgs <- [ slotKey, key ]
-        var eqCall = LLVMBuildCall2(g_builder, eq_typ, eq_fun, eqArgs, "cf.eq")
-        LLVMAddCallSiteAttribute(eqCall, -1 |> uint(), attributes.nounwind)
-        LLVMAddCallSiteAttribute(eqCall, -1 |> uint(), attributes.willreturn)
-        return eqCall
+    // String packed find: one <N x i64> SIMD compare of the 64-bit hash array, no liveness mask.
+    // The packed-string hash tail is always 0 (alloc / erase / table_clear all clear the full
+    // 64-bit width) and a real hash is >1, so the tail never matches — unlike the integer key-data
+    // scan, whose tail can hold a valid 0 key and needs the size mask. Exact: no strcmp.
+    def packed_find_hashes64(hashesPtr : LLVMOpaqueValue?; hash : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var vecTy = LLVMVectorType(types.t_int64, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
+        var i32VecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
+        var hvp = LLVMBuildPointerCast(g_builder, hashesPtr, LLVMPointerType(vecTy, 0u), "h.vp")
+        var hv = LLVMBuildLoad2(g_builder, vecTy, hvp, "h.vec")
+        LLVMSetAlignment(hv, 8u)
+        var ins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(vecTy), hash, LLVMConstInt(types.t_int32, 0ul, 0), "h.ins")
+        var splat = LLVMBuildShuffleVector(g_builder, ins, LLVMGetUndef(vecTy), LLVMConstNull(i32VecTy), "h.splat")
+        var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, splat, "h.eqv")
+        return first_set_lane_or_neg1(LLVMBuildBitCast(g_builder, eqv, types.t_int8, "h.mask"))
     }
 
+    // String tab?[key] / find: packed -> inline 64-bit-hash SIMD scan (exact, no strcmp — a 64-bit
+    // collision is treated as impossible); large/empty -> C++ find-with-hash.
     def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
         var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
-        // Read capacity + hashes from the table header. Small (packed) iff cap != 0 && cap <=
-        // TABLE_MAX_LINEAR_CAPACITY -> inlined SIMD scan; else C++ (cap==0 empty, or hashed).
-        let hdrTy = table_header_llvm_type(types)
-        var tabHdr = LLVMBuildLoad2(g_builder, hdrTy, LLVMBuildPointerCast(g_builder, tab, LLVMPointerType(hdrTy, 0u), "tab.hdrp"), "tab.hdr")
-        var cap = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.CAPACITY), "cap")
-        var hashesV = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.HASHES), "hashes.v")
-        var hashes = LLVMBuildPointerCast(g_builder, hashesV, LLVMPointerType(types.t_int32, 0u), "hashes")
-        var keysV = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.KEYS), "keys.v")
-        var hk32 = reduce_hash_to_key32(h)
+        var hdr = load_table_header(tab)
+        var cap = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.CAPACITY), "cap")
+        var hashesV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.HASHES), "hashes.v")
+        var isSmall = packed_cap_cond(cap)
 
-        var find_entry = LLVMGetInsertBlock(g_builder)
-        var find_parent = LLVMGetBasicBlockParent(find_entry)
+        var find_parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
         var bb_small = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.small")
         var bb_large = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.large")
         var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.merge")
-        var nz = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, cap, LLVMConstInt(types.t_int64, 0ul, 0), "cap.nz")
-        var le = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULE, cap, LLVMConstInt(types.t_int64, uint64(JIT_TABLE_MAX_LINEAR_CAPACITY), 0), "cap.le")
-        var isSmall = LLVMBuildAnd(g_builder, nz, le, "cap.small")
         LLVMBuildCondBr(g_builder, isSmall, bb_small, bb_large)
 
-        // packed: SIMD hash scan -> candidate; confirm the real string (skip on a clean miss).
         LLVMPositionBuilderAtEnd(g_builder, bb_small)
-        var idxRaw = packed_find_vector(hashes, hk32)
-        var hasCand = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, idxRaw, types.ConstI32(uint64(-1)), "find.has")
-        var smallSrc = LLVMGetInsertBlock(g_builder)
-        var bb_confirm = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.confirm")
-        var bb_small2 = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.small2")
-        LLVMBuildCondBr(g_builder, hasCand, bb_confirm, bb_small2)
-
-        LLVMPositionBuilderAtEnd(g_builder, bb_confirm)
-        var eq = emit_string_key_equal(keysV, key, idxRaw)
-        var ok = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, eq, types.ConstI32(0ul), "find.ok")
-        var idxConf = LLVMBuildSelect(g_builder, ok, idxRaw, types.ConstI32(uint64(-1)), "find.conf")
-        var confEnd = LLVMGetInsertBlock(g_builder)
-        LLVMBuildBr(g_builder, bb_small2)
-
-        LLVMPositionBuilderAtEnd(g_builder, bb_small2)
-        var idxSmall = LLVMBuildPhi(g_builder, types.t_int32, "find.small.idx")
-        LLVMAddIncoming(idxSmall, [ types.ConstI32(uint64(-1)), idxConf ], [ smallSrc, confEnd ])
+        var idxSmall = packed_find_hashes64(hashesV, h)
         var smallEnd = LLVMGetInsertBlock(g_builder)
         LLVMBuildBr(g_builder, bb_merge)
 
@@ -2125,49 +2074,30 @@ class public LlvmJitVisitor : AstVisitor {
         return LLVMBuildAnd(g_builder, nz, le, "cap.small")
     }
 
-    // String tab[key]: packed -> SIMD hash scan + string confirm. Three packed outcomes:
-    //  - confirmed hit -> return the slot, no insert;
-    //  - hash candidate but string differs -> a 32-bit collision; route to the full C++ at, which
-    //    promotes to open addressing (keeps packed tables collision-free);
-    //  - no hash candidate at all -> genuinely absent, insert via the skip-packed reserve.
-    // The collision/clean-miss fork is free: it reuses the SIMD match mask. Large/empty -> C++ at.
+    // String tab[key]: packed -> inline 64-bit-hash SIMD scan over [0,size); hit returns the slot,
+    // miss inserts via the skip-packed reserve (no strcmp, no collision fork — 64-bit exact).
+    // large/empty -> full C++ at. Same shape as build_int_table_at_fast over the hash array (i64).
     def build_string_table_at_fast(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
         var hdr = load_table_header(tab)
         var cap = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.CAPACITY), "cap")
         var hashesV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.HASHES), "hashes.v")
-        var hashes = LLVMBuildPointerCast(g_builder, hashesV, LLVMPointerType(types.t_int32, 0u), "hashes")
-        var keysV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.KEYS), "keys.v")
         var isSmall = packed_cap_cond(cap)
 
         var at_parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
         var bb_packed = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.packed")
-        var bb_confirm = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.confirm")
-        var bb_collision = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.collision")
-        var bb_cleanmiss = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.cleanmiss")
+        var bb_miss = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.miss")
         var bb_large = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.large")
         var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.merge")
         LLVMBuildCondBr(g_builder, isSmall, bb_packed, bb_large)
 
         LLVMPositionBuilderAtEnd(g_builder, bb_packed)
         var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
-        var idxRaw = packed_find_vector(hashes, reduce_hash_to_key32(h))
-        var hasCand = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, idxRaw, types.ConstI32(uint64(-1)), "at.has")
+        var idxFound = packed_find_hashes64(hashesV, h)
+        var isMiss = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, idxFound, types.ConstI32(uint64(-1)), "at.ismiss")
         var packedEnd = LLVMGetInsertBlock(g_builder)
-        LLVMBuildCondBr(g_builder, hasCand, bb_confirm, bb_cleanmiss)
+        LLVMBuildCondBr(g_builder, isMiss, bb_miss, bb_merge)
 
-        // candidate present: confirm the real string. hit -> merge(slot); differs -> collision.
-        LLVMPositionBuilderAtEnd(g_builder, bb_confirm)
-        var eq = emit_string_key_equal(keysV, key, idxRaw)
-        var ok = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, eq, types.ConstI32(0ul), "at.ok")
-        var confirmEnd = LLVMGetInsertBlock(g_builder)
-        LLVMBuildCondBr(g_builder, ok, bb_merge, bb_collision)
-
-        LLVMPositionBuilderAtEnd(g_builder, bb_collision)
-        var idxColl = build_string_table_at_with_hash(tab, key, valueTypeSize, at)   // promotes, returns slot
-        var collEnd = LLVMGetInsertBlock(g_builder)
-        LLVMBuildBr(g_builder, bb_merge)
-
-        LLVMPositionBuilderAtEnd(g_builder, bb_cleanmiss)
+        LLVMPositionBuilderAtEnd(g_builder, bb_miss)
         var idxMiss = build_string_table_at_after_packed_miss(tab, key, h, valueTypeSize, at)
         var missEnd = LLVMGetInsertBlock(g_builder)
         LLVMBuildBr(g_builder, bb_merge)
@@ -2179,7 +2109,7 @@ class public LlvmJitVisitor : AstVisitor {
 
         LLVMPositionBuilderAtEnd(g_builder, bb_merge)
         var res = LLVMBuildPhi(g_builder, types.t_int32, "at.idx")
-        LLVMAddIncoming(res, [ idxRaw, idxColl, idxMiss, idxLarge ], [ confirmEnd, collEnd, missEnd, largeEnd ])
+        LLVMAddIncoming(res, [ idxFound, idxMiss, idxLarge ], [ packedEnd, missEnd, largeEnd ])
         return res
     }
 
@@ -6872,7 +6802,6 @@ class public ResolveExternVisitor : AstVisitor {
     def bind_jit_table_find_glob(t : Type) {
         if (t == Type.tString) {
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_FIND_WITH_HASH()), get_jit_string_table_find_with_hash())
-            dll.set_glob_address(DllName(FN_JIT_STRING_EQUAL()), get_jit_string_equal())
         } else {
             dll.set_glob_address(DllName(FN_JIT_TABLE_FIND(t)), get_jit_table_find(unsafe(reinterpret<int> t)))
         }
@@ -6881,7 +6810,6 @@ class public ResolveExternVisitor : AstVisitor {
         if (t == Type.tString) {
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH()), get_jit_string_table_at_with_hash())
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS()), get_jit_string_table_at_after_packed_miss())
-            dll.set_glob_address(DllName(FN_JIT_STRING_EQUAL()), get_jit_string_equal())
         } else {
             dll.set_glob_address(DllName(FN_JIT_TABLE_AT(t)), get_jit_table_at(unsafe(reinterpret<int> t)))
             if (is_simd_packed_key(t)) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -317,6 +317,14 @@ bitfield public LlvmJitFlags {
     need_di,
 }
 
+// Integer key types the SIMD packed key-scan handles (plain icmp eq). float/double/struct
+// keys keep the C++ path — fcmp / custom KeyCompare aren't worth a special case. Free
+// function so both the codegen visitor and the extern-resolver (glob binding) can call it.
+def public is_simd_packed_key(t : Type) : bool {
+    return (t == Type.tInt || t == Type.tUInt || t == Type.tInt64 || t == Type.tUInt64
+        || t == Type.tInt8 || t == Type.tUInt8 || t == Type.tInt16 || t == Type.tUInt16)
+}
+
 [macro]
 class public LlvmJitVisitor : AstVisitor {
     adapter : VisitorAdapter?
@@ -1835,12 +1843,7 @@ class public LlvmJitVisitor : AstVisitor {
         LLVMPositionBuilderAtEnd(g_builder, check_end)
     }
 
-    def build_table_at(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
-        // String keys: hash inline (foldable for a constant key) and call the with-hash
-        // variant, instead of recomputing the hash inside the C++ helper.
-        if (ttype == Type.tString) {
-            return build_string_table_at_with_hash(tab, key, valueTypeSize, at)
-        }
+    def build_table_at_call(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
         var params = fixed_array(
             tab,                                                        // table ptr
             key,                                                        // key
@@ -1852,18 +1855,12 @@ class public LlvmJitVisitor : AstVisitor {
         let ccall = LLVMBuildCall2(g_builder, typ, tab_fun, params, "")
         LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.nounwind)     // TODO: better no-unwind?
         LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.willreturn)
-
         LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
         LLVMAddCallSiteAttribute(ccall, 4u, attributes.nocapture)
         return ccall
     }
 
-    def build_table_find(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
-        // String keys: hash inline (foldable for a constant key) and call the with-hash
-        // variant, instead of recomputing the hash inside the C++ helper.
-        if (ttype == Type.tString) {
-            return build_string_table_find_with_hash(tab, key, valueTypeSize)
-        }
+    def build_table_find_call(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
         var params = fixed_array(
             tab,                                                        // table ptr
             key,                                                        // key
@@ -1874,10 +1871,31 @@ class public LlvmJitVisitor : AstVisitor {
         let ccall = LLVMBuildCall2(g_builder, typ, fun_ptr, params, "")
         LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.nounwind)     // TODO: better no-unwind?
         LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.willreturn)
-
         LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
         LLVMAddCallSiteAttribute(ccall, 4u, attributes.nocapture)
         return ccall
+    }
+
+    // tab[key] (insert-or-get). String + integer keys run the inline SIMD packed find first
+    // (skipping the C++ packed dedup on a miss); other key types call the C++ at directly.
+    def build_table_at(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        if (ttype == Type.tString) {
+            return build_string_table_at_fast(tab, key, valueTypeSize, at)
+        } elif (is_simd_packed_key(ttype)) {
+            return build_int_table_at_fast(ttype, tab, key, valueTypeSize, at)
+        }
+        return build_table_at_call(ttype, tab, key, valueTypeSize, at)
+    }
+
+    // tab?[key] / key_exists / find. String + integer keys run the inline SIMD packed find for
+    // small tables (C++ for large/empty); other key types call the C++ find directly.
+    def build_table_find(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
+        if (ttype == Type.tString) {
+            return build_string_table_find_with_hash(tab, key, valueTypeSize)
+        } elif (is_simd_packed_key(ttype)) {
+            return build_int_table_find(ttype, tab, key, valueTypeSize)
+        }
+        return build_table_find_call(ttype, tab, key, valueTypeSize)
     }
 
     // String-key find/at via the precomputed-hash C++ helpers: emit hash(key) inline
@@ -1910,6 +1928,20 @@ class public LlvmJitVisitor : AstVisitor {
         return LLVMBuildSelect(g_builder, le1, prime, hk, "hk")
     }
 
+    // First set lane of an N-bit (i8) match mask -> i32 index, or -1 if the mask is empty.
+    // (N == TABLE_MAX_LINEAR_CAPACITY == 8, so the mask is exactly i8 and cttz.i8 fits.)
+    def first_set_lane_or_neg1(maskI8 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var argTypes <- [ types.t_int8 ]
+        let id = LLVMLookupIntrinsicID("llvm.cttz.i8")
+        var decl = LLVMGetIntrinsicDeclaration(g_mod, id, argTypes)
+        var cttzTy = LLVMFunctionType(types.t_int8, [ types.t_int8, types.t_int1 ])
+        var cttzArgs <- [ maskI8, LLVMConstInt(types.t_int1, 0ul, 0) ]
+        var ctz = LLVMBuildCall2(g_builder, cttzTy, decl, cttzArgs, "lane.cttz")
+        var ctz32 = LLVMBuildZExt(g_builder, ctz, types.t_int32, "lane.cttz32")
+        var none = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, maskI8, LLVMConstInt(types.t_int8, 0ul, 0), "lane.none")
+        return LLVMBuildSelect(g_builder, none, types.ConstI32(uint64(-1)), ctz32, "lane.idx")
+    }
+
     // PackedFind<char*> as one <N x i32> SIMD compare: load the hash slots, compare against
     // the splatted 32-bit key, bitcast the mask to i8, cttz -> first set lane; empty -> -1.
     // The empty tail (hash 0) never matches the clamped key, so no size guard is needed.
@@ -1922,17 +1954,35 @@ class public LlvmJitVisitor : AstVisitor {
         var ins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(vecTy), hk32, LLVMConstInt(types.t_int32, 0ul, 0), "h.ins")
         var splat = LLVMBuildShuffleVector(g_builder, ins, LLVMGetUndef(vecTy), LLVMConstNull(vecTy), "h.splat")
         var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, splat, "h.eqv")
-        var maskI8 = LLVMBuildBitCast(g_builder, eqv, types.t_int8, "h.mask")
-        var argTypes <- [ types.t_int8 ]
-        let id = LLVMLookupIntrinsicID("llvm.cttz.i8")
-        var decl = LLVMGetIntrinsicDeclaration(g_mod, id, argTypes)
-        var cttzTy = LLVMFunctionType(types.t_int8, [ types.t_int8, types.t_int1 ])
-        var cttzArgs <- [ maskI8, LLVMConstInt(types.t_int1, 0ul, 0) ]
-        var ctz = LLVMBuildCall2(g_builder, cttzTy, decl, cttzArgs, "h.cttz")
-        var ctz32 = LLVMBuildZExt(g_builder, ctz, types.t_int32, "h.cttz32")
-        var none = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, maskI8, LLVMConstInt(types.t_int8, 0ul, 0), "h.none")
-        return LLVMBuildSelect(g_builder, none, types.ConstI32(uint64(-1)), ctz32, "h.vidx")
+        return first_set_lane_or_neg1(LLVMBuildBitCast(g_builder, eqv, types.t_int8, "h.mask"))
     }
+
+    // The non-string mirror — generic PackedFind<KeyType>: compare actual KEY data (not
+    // hashes) over [0,size). Load <N x KeyT>, compare to the splatted key, AND with a
+    // liveness mask (lane i live iff i < size) — non-string tails are not sentinel-zeroed,
+    // so stale tail keys must be masked out (strings dodge this via the 0 hash sentinel).
+    def packed_find_vector_keys(keysPtr : LLVMOpaqueValue?; keyVal : LLVMOpaqueValue?; keyElemTy : LLVMOpaqueType?; sizeI32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var keyVecTy = LLVMVectorType(keyElemTy, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
+        var i32VecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
+        var kvp = LLVMBuildPointerCast(g_builder, keysPtr, LLVMPointerType(keyVecTy, 0u), "k.vp")
+        var kv = LLVMBuildLoad2(g_builder, keyVecTy, kvp, "k.vec")
+        LLVMSetAlignment(kv, 1u)
+        var kins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(keyVecTy), keyVal, LLVMConstInt(types.t_int32, 0ul, 0), "k.ins")
+        var ksplat = LLVMBuildShuffleVector(g_builder, kins, LLVMGetUndef(keyVecTy), LLVMConstNull(i32VecTy), "k.splat")
+        var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, kv, ksplat, "k.eqv")
+        var idxConsts : array<LLVMOpaqueValue?>
+        for (i in range(JIT_TABLE_MAX_LINEAR_CAPACITY)) {
+            idxConsts |> push(LLVMConstInt(types.t_int32, uint64(i), 0))
+        }
+        var idxVec = LLVMConstVector(array_data_ptr(idxConsts), uint(length(idxConsts)))
+        unsafe { delete idxConsts; }
+        var sins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(i32VecTy), sizeI32, LLVMConstInt(types.t_int32, 0ul, 0), "sz.ins")
+        var ssplat = LLVMBuildShuffleVector(g_builder, sins, LLVMGetUndef(i32VecTy), LLVMConstNull(i32VecTy), "sz.splat")
+        var live = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, idxVec, ssplat, "k.live")
+        var both = LLVMBuildAnd(g_builder, eqv, live, "k.both")
+        return first_set_lane_or_neg1(LLVMBuildBitCast(g_builder, both, types.t_int8, "k.mask"))
+    }
+
 
     def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
         var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
@@ -1988,6 +2038,163 @@ class public LlvmJitVisitor : AstVisitor {
         LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
         LLVMAddCallSiteAttribute(ccall, 5u, attributes.nocapture)
         return ccall
+    }
+
+    // Load the Table header (Array base + keys/hashes/tombstones) as an aggregate so the
+    // caller can extractvalue capacity / hashes / keys / size for the inline packed paths.
+    def load_table_header(tab : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        let hdrTy = table_header_llvm_type(types)
+        return LLVMBuildLoad2(g_builder, hdrTy, LLVMBuildPointerCast(g_builder, tab, LLVMPointerType(hdrTy, 0u), "tab.hdrp"), "tab.hdr")
+    }
+
+    // Insert emitters that skip the C++ packed dedup (caller already ran the packed find and
+    // missed). String takes the JIT hash; the per-type form lets the C++ recompute it.
+    def build_string_table_at_after_packed_miss(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; h : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        var params = fixed_array(
+            tab, key, h,
+            types.ConstI32(uint64(valueTypeSize)),
+            get_context_param(),
+            get_line_info_ptr(at)
+        )
+        var (tab_fun, typ) = get_string_table_at_after_packed_miss(g_builder, g_mod, types)
+        let ccall = LLVMBuildCall2(g_builder, typ, tab_fun, params, "")
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.nounwind)
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.willreturn)
+        LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
+        LLVMAddCallSiteAttribute(ccall, 5u, attributes.nocapture)
+        return ccall
+    }
+
+    def build_table_at_after_packed_miss(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        var params = fixed_array(
+            tab, key,
+            types.ConstI32(uint64(valueTypeSize)),
+            get_context_param(),
+            get_line_info_ptr(at)
+        )
+        var (tab_fun, typ) = get_table_at_after_packed_miss(g_builder, g_mod, ttype, types)
+        let ccall = LLVMBuildCall2(g_builder, typ, tab_fun, params, "")
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.nounwind)
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.willreturn)
+        LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
+        LLVMAddCallSiteAttribute(ccall, 4u, attributes.nocapture)
+        return ccall
+    }
+
+    // Shared cap-gate cond: cap != 0 && cap <= TABLE_MAX_LINEAR_CAPACITY (the packed regime).
+    def packed_cap_cond(cap : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var nz = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, cap, LLVMConstInt(types.t_int64, 0ul, 0), "cap.nz")
+        var le = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULE, cap, LLVMConstInt(types.t_int64, uint64(JIT_TABLE_MAX_LINEAR_CAPACITY), 0), "cap.le")
+        return LLVMBuildAnd(g_builder, nz, le, "cap.small")
+    }
+
+    // String tab[key]: packed -> SIMD find; found returns the slot (no insert), miss inserts
+    // via the skip-packed reserve (reusing the same hash); large/empty -> full C++ at.
+    def build_string_table_at_fast(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        var hdr = load_table_header(tab)
+        var cap = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.CAPACITY), "cap")
+        var hashesV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.HASHES), "hashes.v")
+        var hashes = LLVMBuildPointerCast(g_builder, hashesV, LLVMPointerType(types.t_int32, 0u), "hashes")
+        var isSmall = packed_cap_cond(cap)
+
+        var at_parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
+        var bb_packed = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.packed")
+        var bb_miss = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.miss")
+        var bb_large = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.large")
+        var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.merge")
+        LLVMBuildCondBr(g_builder, isSmall, bb_packed, bb_large)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_packed)
+        var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
+        var idxFound = packed_find_vector(hashes, reduce_hash_to_key32(h))
+        var isMiss = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, idxFound, types.ConstI32(uint64(-1)), "at.ismiss")
+        var packedEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildCondBr(g_builder, isMiss, bb_miss, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_miss)
+        var idxMiss = build_string_table_at_after_packed_miss(tab, key, h, valueTypeSize, at)
+        var missEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_large)
+        var idxLarge = build_string_table_at_with_hash(tab, key, valueTypeSize, at)
+        var largeEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_merge)
+        var res = LLVMBuildPhi(g_builder, types.t_int32, "at.idx")
+        LLVMAddIncoming(res, [ idxFound, idxMiss, idxLarge ], [ packedEnd, missEnd, largeEnd ])
+        return res
+    }
+
+    // Integer tab?[key] / find: packed -> SIMD key-scan (no hash); large/empty -> C++ find.
+    def build_int_table_find(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
+        var hdr = load_table_header(tab)
+        var cap = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.CAPACITY), "cap")
+        var keysV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.KEYS), "keys.v")
+        var sizeI32 = LLVMBuildTrunc(g_builder, LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.SIZE), "size"), types.t_int32, "size32")
+        var keyElemTy = base_type_to_llvm_type(ttype)
+        var isSmall = packed_cap_cond(cap)
+
+        var find_parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
+        var bb_small = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "ifind.small")
+        var bb_large = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "ifind.large")
+        var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "ifind.merge")
+        LLVMBuildCondBr(g_builder, isSmall, bb_small, bb_large)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_small)
+        var idxSmall = packed_find_vector_keys(keysV, key, keyElemTy, sizeI32)
+        var smallEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_large)
+        var idxLarge = build_table_find_call(ttype, tab, key, valueTypeSize)
+        var largeEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_merge)
+        var res = LLVMBuildPhi(g_builder, types.t_int32, "ifind.idx")
+        LLVMAddIncoming(res, [ idxSmall, idxLarge ], [ smallEnd, largeEnd ])
+        return res
+    }
+
+    // Integer tab[key]: packed -> SIMD key-scan; found returns the slot, miss inserts via the
+    // skip-packed reserve; large/empty -> full C++ at.
+    def build_int_table_at_fast(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        var hdr = load_table_header(tab)
+        var cap = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.CAPACITY), "cap")
+        var keysV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.KEYS), "keys.v")
+        var sizeI32 = LLVMBuildTrunc(g_builder, LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.SIZE), "size"), types.t_int32, "size32")
+        var keyElemTy = base_type_to_llvm_type(ttype)
+        var isSmall = packed_cap_cond(cap)
+
+        var at_parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
+        var bb_packed = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "iat.packed")
+        var bb_miss = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "iat.miss")
+        var bb_large = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "iat.large")
+        var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "iat.merge")
+        LLVMBuildCondBr(g_builder, isSmall, bb_packed, bb_large)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_packed)
+        var idxFound = packed_find_vector_keys(keysV, key, keyElemTy, sizeI32)
+        var isMiss = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, idxFound, types.ConstI32(uint64(-1)), "iat.ismiss")
+        var packedEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildCondBr(g_builder, isMiss, bb_miss, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_miss)
+        var idxMiss = build_table_at_after_packed_miss(ttype, tab, key, valueTypeSize, at)
+        var missEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_large)
+        var idxLarge = build_table_at_call(ttype, tab, key, valueTypeSize, at)
+        var largeEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_merge)
+        var res = LLVMBuildPhi(g_builder, types.t_int32, "iat.idx")
+        LLVMAddIncoming(res, [ idxFound, idxMiss, idxLarge ], [ packedEnd, missEnd, largeEnd ])
+        return res
     }
 
     def build_array_index(var data, tidx : LLVMOpaqueValue?; elemType : TypeDeclPtr; name : string) {
@@ -6616,8 +6823,12 @@ class public ResolveExternVisitor : AstVisitor {
     def bind_jit_table_at_glob(t : Type) {
         if (t == Type.tString) {
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH()), get_jit_string_table_at_with_hash())
+            dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS()), get_jit_string_table_at_after_packed_miss())
         } else {
             dll.set_glob_address(DllName(FN_JIT_TABLE_AT(t)), get_jit_table_at(unsafe(reinterpret<int> t)))
+            if (is_simd_packed_key(t)) {
+                dll.set_glob_address(DllName(FN_JIT_TABLE_AT_AFTER_PACKED_MISS(t)), get_jit_table_at_after_packed_miss(unsafe(reinterpret<int> t)))
+            }
         }
     }
 

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1984,6 +1984,25 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
 
+    // Confirm a packed string candidate: load keys[idxLane] and jit_string_equal it against the
+    // query key. The SIMD scan matches only the 32-bit hash (collidable), so this is the real
+    // compare; insert-time collision promotion guarantees at most one hash-match, so one strcmp is
+    // exact. Returns the i32 0/1 result. Caller must be in a block where idxLane is a genuine
+    // candidate (>=0) — a clean miss (no hash match) never reaches here, so it stays strcmp-free.
+    def emit_string_key_equal(keysV : LLVMOpaqueValue?; key : LLVMOpaqueValue?; idxLane : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var i8ptr = LLVMPointerType(types.t_int8, 0u)
+        var keysArr = LLVMBuildPointerCast(g_builder, keysV, LLVMPointerType(i8ptr, 0u), "keys.arr")
+        var idxv = idxLane
+        var slotPtr = LLVMBuildGEP2(g_builder, i8ptr, keysArr, idxv, "cf.slotp")
+        var slotKey = LLVMBuildLoad2(g_builder, i8ptr, slotPtr, "cf.key")
+        var (eq_fun, eq_typ) = get_string_equal(g_builder, g_mod, types)
+        var eqArgs <- [ slotKey, key ]
+        var eqCall = LLVMBuildCall2(g_builder, eq_typ, eq_fun, eqArgs, "cf.eq")
+        LLVMAddCallSiteAttribute(eqCall, -1 |> uint(), attributes.nounwind)
+        LLVMAddCallSiteAttribute(eqCall, -1 |> uint(), attributes.willreturn)
+        return eqCall
+    }
+
     def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
         var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
         // Read capacity + hashes from the table header. Small (packed) iff cap != 0 && cap <=
@@ -1993,6 +2012,7 @@ class public LlvmJitVisitor : AstVisitor {
         var cap = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.CAPACITY), "cap")
         var hashesV = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.HASHES), "hashes.v")
         var hashes = LLVMBuildPointerCast(g_builder, hashesV, LLVMPointerType(types.t_int32, 0u), "hashes")
+        var keysV = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.KEYS), "keys.v")
         var hk32 = reduce_hash_to_key32(h)
 
         var find_entry = LLVMGetInsertBlock(g_builder)
@@ -2005,8 +2025,25 @@ class public LlvmJitVisitor : AstVisitor {
         var isSmall = LLVMBuildAnd(g_builder, nz, le, "cap.small")
         LLVMBuildCondBr(g_builder, isSmall, bb_small, bb_large)
 
+        // packed: SIMD hash scan -> candidate; confirm the real string (skip on a clean miss).
         LLVMPositionBuilderAtEnd(g_builder, bb_small)
-        var idxSmall = packed_find_vector(hashes, hk32)
+        var idxRaw = packed_find_vector(hashes, hk32)
+        var hasCand = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, idxRaw, types.ConstI32(uint64(-1)), "find.has")
+        var smallSrc = LLVMGetInsertBlock(g_builder)
+        var bb_confirm = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.confirm")
+        var bb_small2 = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.small2")
+        LLVMBuildCondBr(g_builder, hasCand, bb_confirm, bb_small2)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_confirm)
+        var eq = emit_string_key_equal(keysV, key, idxRaw)
+        var ok = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, eq, types.ConstI32(0ul), "find.ok")
+        var idxConf = LLVMBuildSelect(g_builder, ok, idxRaw, types.ConstI32(uint64(-1)), "find.conf")
+        var confEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_small2)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_small2)
+        var idxSmall = LLVMBuildPhi(g_builder, types.t_int32, "find.small.idx")
+        LLVMAddIncoming(idxSmall, [ types.ConstI32(uint64(-1)), idxConf ], [ smallSrc, confEnd ])
         var smallEnd = LLVMGetInsertBlock(g_builder)
         LLVMBuildBr(g_builder, bb_merge)
 
@@ -2088,30 +2125,49 @@ class public LlvmJitVisitor : AstVisitor {
         return LLVMBuildAnd(g_builder, nz, le, "cap.small")
     }
 
-    // String tab[key]: packed -> SIMD find; found returns the slot (no insert), miss inserts
-    // via the skip-packed reserve (reusing the same hash); large/empty -> full C++ at.
+    // String tab[key]: packed -> SIMD hash scan + string confirm. Three packed outcomes:
+    //  - confirmed hit -> return the slot, no insert;
+    //  - hash candidate but string differs -> a 32-bit collision; route to the full C++ at, which
+    //    promotes to open addressing (keeps packed tables collision-free);
+    //  - no hash candidate at all -> genuinely absent, insert via the skip-packed reserve.
+    // The collision/clean-miss fork is free: it reuses the SIMD match mask. Large/empty -> C++ at.
     def build_string_table_at_fast(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
         var hdr = load_table_header(tab)
         var cap = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.CAPACITY), "cap")
         var hashesV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.HASHES), "hashes.v")
         var hashes = LLVMBuildPointerCast(g_builder, hashesV, LLVMPointerType(types.t_int32, 0u), "hashes")
+        var keysV = LLVMBuildExtractValue(g_builder, hdr, uint(JIT_TABLE.KEYS), "keys.v")
         var isSmall = packed_cap_cond(cap)
 
         var at_parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
         var bb_packed = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.packed")
-        var bb_miss = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.miss")
+        var bb_confirm = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.confirm")
+        var bb_collision = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.collision")
+        var bb_cleanmiss = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.cleanmiss")
         var bb_large = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.large")
         var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, at_parent, "at.merge")
         LLVMBuildCondBr(g_builder, isSmall, bb_packed, bb_large)
 
         LLVMPositionBuilderAtEnd(g_builder, bb_packed)
         var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
-        var idxFound = packed_find_vector(hashes, reduce_hash_to_key32(h))
-        var isMiss = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, idxFound, types.ConstI32(uint64(-1)), "at.ismiss")
+        var idxRaw = packed_find_vector(hashes, reduce_hash_to_key32(h))
+        var hasCand = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, idxRaw, types.ConstI32(uint64(-1)), "at.has")
         var packedEnd = LLVMGetInsertBlock(g_builder)
-        LLVMBuildCondBr(g_builder, isMiss, bb_miss, bb_merge)
+        LLVMBuildCondBr(g_builder, hasCand, bb_confirm, bb_cleanmiss)
 
-        LLVMPositionBuilderAtEnd(g_builder, bb_miss)
+        // candidate present: confirm the real string. hit -> merge(slot); differs -> collision.
+        LLVMPositionBuilderAtEnd(g_builder, bb_confirm)
+        var eq = emit_string_key_equal(keysV, key, idxRaw)
+        var ok = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, eq, types.ConstI32(0ul), "at.ok")
+        var confirmEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildCondBr(g_builder, ok, bb_merge, bb_collision)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_collision)
+        var idxColl = build_string_table_at_with_hash(tab, key, valueTypeSize, at)   // promotes, returns slot
+        var collEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_cleanmiss)
         var idxMiss = build_string_table_at_after_packed_miss(tab, key, h, valueTypeSize, at)
         var missEnd = LLVMGetInsertBlock(g_builder)
         LLVMBuildBr(g_builder, bb_merge)
@@ -2123,7 +2179,7 @@ class public LlvmJitVisitor : AstVisitor {
 
         LLVMPositionBuilderAtEnd(g_builder, bb_merge)
         var res = LLVMBuildPhi(g_builder, types.t_int32, "at.idx")
-        LLVMAddIncoming(res, [ idxFound, idxMiss, idxLarge ], [ packedEnd, missEnd, largeEnd ])
+        LLVMAddIncoming(res, [ idxRaw, idxColl, idxMiss, idxLarge ], [ confirmEnd, collEnd, missEnd, largeEnd ])
         return res
     }
 
@@ -6816,6 +6872,7 @@ class public ResolveExternVisitor : AstVisitor {
     def bind_jit_table_find_glob(t : Type) {
         if (t == Type.tString) {
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_FIND_WITH_HASH()), get_jit_string_table_find_with_hash())
+            dll.set_glob_address(DllName(FN_JIT_STRING_EQUAL()), get_jit_string_equal())
         } else {
             dll.set_glob_address(DllName(FN_JIT_TABLE_FIND(t)), get_jit_table_find(unsafe(reinterpret<int> t)))
         }
@@ -6824,6 +6881,7 @@ class public ResolveExternVisitor : AstVisitor {
         if (t == Type.tString) {
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH()), get_jit_string_table_at_with_hash())
             dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS()), get_jit_string_table_at_after_packed_miss())
+            dll.set_glob_address(DllName(FN_JIT_STRING_EQUAL()), get_jit_string_equal())
         } else {
             dll.set_glob_address(DllName(FN_JIT_TABLE_AT(t)), get_jit_table_at(unsafe(reinterpret<int> t)))
             if (is_simd_packed_key(t)) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1910,22 +1910,10 @@ class public LlvmJitVisitor : AstVisitor {
         return LLVMBuildSelect(g_builder, le1, prime, hk, "hk")
     }
 
-    // PackedFind<char*>: scan hashes[0..N) (uint32), lowest i with hashes[i]==hk32 else -1.
-    // Branch-free unrolled scalar fold (apply i=N-1..0 so the lowest match sticks).
-    def packed_find_scalar(hashes : LLVMOpaqueValue?; hk32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
-        var idx = types.ConstI32(uint64(-1))
-        for (k in range(JIT_TABLE_MAX_LINEAR_CAPACITY)) {
-            let j = JIT_TABLE_MAX_LINEAR_CAPACITY - 1 - k
-            var slot = LLVMBuildGEP2(g_builder, types.t_int32, hashes, LLVMConstInt(types.t_int64, uint64(j), 0), "h.slot")
-            var hv = LLVMBuildLoad2(g_builder, types.t_int32, slot, "h.v")
-            var eq = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, hk32, "h.eq")
-            idx = LLVMBuildSelect(g_builder, eq, types.ConstI32(uint64(j)), idx, "h.idx")
-        }
-        return idx
-    }
-
-    // Same scan as one <N x i32> SIMD compare: load the hash slots, compare against the
-    // splatted key, bitcast the mask to i8, cttz -> first set lane; empty mask -> -1.
+    // PackedFind<char*> as one <N x i32> SIMD compare: load the hash slots, compare against
+    // the splatted 32-bit key, bitcast the mask to i8, cttz -> first set lane; empty -> -1.
+    // The empty tail (hash 0) never matches the clamped key, so no size guard is needed.
+    // (Measured fastest of none/scalar/vector — see benchmarks/core/small_table/results.md.)
     def packed_find_vector(hashes : LLVMOpaqueValue?; hk32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
         var vecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
         var hvp = LLVMBuildPointerCast(g_builder, hashes, LLVMPointerType(vecTy, 0u), "h.vp")
@@ -1948,11 +1936,8 @@ class public LlvmJitVisitor : AstVisitor {
 
     def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
         var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
-        if (JIT_STRING_FIND == JIT_STRING_FIND_MODE.NONE) {
-            return build_string_table_find_call(tab, key, h, valueTypeSize)
-        }
         // Read capacity + hashes from the table header. Small (packed) iff cap != 0 && cap <=
-        // TABLE_MAX_LINEAR_CAPACITY -> inlined fixed scan; else C++ (cap==0 empty, or hashed).
+        // TABLE_MAX_LINEAR_CAPACITY -> inlined SIMD scan; else C++ (cap==0 empty, or hashed).
         let hdrTy = table_header_llvm_type(types)
         var tabHdr = LLVMBuildLoad2(g_builder, hdrTy, LLVMBuildPointerCast(g_builder, tab, LLVMPointerType(hdrTy, 0u), "tab.hdrp"), "tab.hdr")
         var cap = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.CAPACITY), "cap")
@@ -1971,12 +1956,7 @@ class public LlvmJitVisitor : AstVisitor {
         LLVMBuildCondBr(g_builder, isSmall, bb_small, bb_large)
 
         LLVMPositionBuilderAtEnd(g_builder, bb_small)
-        var idxSmall : LLVMOpaqueValue?
-        if (JIT_STRING_FIND == JIT_STRING_FIND_MODE.VECTOR) {
-            idxSmall = packed_find_vector(hashes, hk32)
-        } else {
-            idxSmall = packed_find_scalar(hashes, hk32)
-        }
+        var idxSmall = packed_find_vector(hashes, hk32)
         var smallEnd = LLVMGetInsertBlock(g_builder)
         LLVMBuildBr(g_builder, bb_merge)
 

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1836,6 +1836,11 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def build_table_at(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        // String keys: hash inline (foldable for a constant key) and call the with-hash
+        // variant, instead of recomputing the hash inside the C++ helper.
+        if (ttype == Type.tString) {
+            return build_string_table_at_with_hash(tab, key, valueTypeSize, at)
+        }
         var params = fixed_array(
             tab,                                                        // table ptr
             key,                                                        // key
@@ -1854,6 +1859,11 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def build_table_find(ttype : Type; tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
+        // String keys: hash inline (foldable for a constant key) and call the with-hash
+        // variant, instead of recomputing the hash inside the C++ helper.
+        if (ttype == Type.tString) {
+            return build_string_table_find_with_hash(tab, key, valueTypeSize)
+        }
         var params = fixed_array(
             tab,                                                        // table ptr
             key,                                                        // key
@@ -1867,6 +1877,46 @@ class public LlvmJitVisitor : AstVisitor {
 
         LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
         LLVMAddCallSiteAttribute(ccall, 4u, attributes.nocapture)
+        return ccall
+    }
+
+    // String-key find/at via the precomputed-hash C++ helpers: emit hash(key) inline
+    // (build_string_hash folds it to an immediate for a constant key) and pass it through,
+    // so the hash is hoistable/CSE-able and a literal key costs no hashing.
+    def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
+        var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
+        var params = fixed_array(
+            tab,                                                        // table ptr
+            key,                                                        // key
+            h,                                                          // precomputed hash
+            types.ConstI32(uint64(valueTypeSize)),    // valueTypeSize
+            get_context_param()
+        )
+        var (fun_ptr, typ) = get_string_table_find_with_hash(g_builder, g_mod, types)
+        let ccall = LLVMBuildCall2(g_builder, typ, fun_ptr, params, "")
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.nounwind)
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.willreturn)
+        LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
+        LLVMAddCallSiteAttribute(ccall, 5u, attributes.nocapture)
+        return ccall
+    }
+
+    def build_string_table_at_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {
+        var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
+        var params = fixed_array(
+            tab,                                                        // table ptr
+            key,                                                        // key
+            h,                                                          // precomputed hash
+            types.ConstI32(uint64(valueTypeSize)),    // valueTypeSize
+            get_context_param(),
+            get_line_info_ptr(at)
+        )
+        var (tab_fun, typ) = get_string_table_at_with_hash(g_builder, g_mod, types)
+        let ccall = LLVMBuildCall2(g_builder, typ, tab_fun, params, "")
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.nounwind)
+        LLVMAddCallSiteAttribute(ccall, -1 |> uint(), attributes.willreturn)
+        LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
+        LLVMAddCallSiteAttribute(ccall, 5u, attributes.nocapture)
         return ccall
     }
 
@@ -6483,27 +6533,45 @@ class public ResolveExternVisitor : AstVisitor {
         }
     }
 
+    // Pre-bind the JIT table-fn globals for the standalone-exe / cache-reload path. String
+    // keys route through the precomputed-hash helpers (see build_table_find/at), so bind
+    // those globals instead of the per-type ones.
+    def bind_jit_table_find_glob(t : Type) {
+        if (t == Type.tString) {
+            dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_FIND_WITH_HASH()), get_jit_string_table_find_with_hash())
+        } else {
+            dll.set_glob_address(DllName(FN_JIT_TABLE_FIND(t)), get_jit_table_find(unsafe(reinterpret<int> t)))
+        }
+    }
+    def bind_jit_table_at_glob(t : Type) {
+        if (t == Type.tString) {
+            dll.set_glob_address(DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH()), get_jit_string_table_at_with_hash())
+        } else {
+            dll.set_glob_address(DllName(FN_JIT_TABLE_AT(t)), get_jit_table_at(unsafe(reinterpret<int> t)))
+        }
+    }
+
     def override preVisitExprAt(expr : ExprAt?) {
         assume subExprT = expr.subexpr._type
         if (subExprT.isGoodTableType) {
             let t = get_table_t(subExprT)
-            dll.set_glob_address(DllName(FN_JIT_TABLE_AT(t)), get_jit_table_at(unsafe(reinterpret<int> t)))
+            bind_jit_table_at_glob(t)
         }
     }
 
     def override preVisitExprSetInsert(expr : ExprSetInsert?) {
         let t = get_table_t(expr.arguments[0]._type)
-        dll.set_glob_address(DllName(FN_JIT_TABLE_AT(t)), get_jit_table_at(unsafe(reinterpret<int> t)))
+        bind_jit_table_at_glob(t)
     }
 
     def override preVisitExprKeyExists(expr : ExprKeyExists?) {
         let t = get_table_t(expr.arguments[0]._type)
-        dll.set_glob_address(DllName(FN_JIT_TABLE_FIND(t)), get_jit_table_find(unsafe(reinterpret<int> t)))
+        bind_jit_table_find_glob(t)
     }
 
     def override preVisitExprFind(expr : ExprFind?) {
         let t = get_table_t(expr.arguments[0]._type)
-        dll.set_glob_address(DllName(FN_JIT_TABLE_FIND(t)), get_jit_table_find(unsafe(reinterpret<int> t)))
+        bind_jit_table_find_glob(t)
     }
 
     def override preVisitExprSafeAt(expr : ExprSafeAt?) {
@@ -6511,7 +6579,7 @@ class public ResolveExternVisitor : AstVisitor {
         if (subExprT.isGoodTableType || (subExprT.isPointer && subExprT.firstType.isGoodTableType)) {
             var etype = subExprT.isPointer ? subExprT.firstType : subExprT
             let t = get_table_t(etype)
-            dll.set_glob_address(DllName(FN_JIT_TABLE_FIND(t)), get_jit_table_find(unsafe(reinterpret<int> t)))
+            bind_jit_table_find_glob(t)
         }
     }
 

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1883,8 +1883,7 @@ class public LlvmJitVisitor : AstVisitor {
     // String-key find/at via the precomputed-hash C++ helpers: emit hash(key) inline
     // (build_string_hash folds it to an immediate for a constant key) and pass it through,
     // so the hash is hoistable/CSE-able and a literal key costs no hashing.
-    def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
-        var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
+    def build_string_table_find_call(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; h : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
         var params = fixed_array(
             tab,                                                        // table ptr
             key,                                                        // key
@@ -1899,6 +1898,97 @@ class public LlvmJitVisitor : AstVisitor {
         LLVMAddCallSiteAttribute(ccall, 1u, attributes.nocapture)
         LLVMAddCallSiteAttribute(ccall, 5u, attributes.nocapture)
         return ccall
+    }
+
+    // hashToHashKey(TableHashKey(hash)) from runtime_table.h: truncate the 64-bit hash to the
+    // 32-bit TableHashKey, then map 0/1 -> 16777619 so it can't alias EMPTY/KILLED slots.
+    def reduce_hash_to_key32(h : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var hk = LLVMBuildTrunc(g_builder, h, types.t_int32, "hk.trunc")
+        var one = LLVMConstInt(types.t_int32, 1ul, 0)
+        var prime = LLVMConstInt(types.t_int32, 16777619ul, 0)
+        var le1 = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULE, hk, one, "hk.le1")
+        return LLVMBuildSelect(g_builder, le1, prime, hk, "hk")
+    }
+
+    // PackedFind<char*>: scan hashes[0..N) (uint32), lowest i with hashes[i]==hk32 else -1.
+    // Branch-free unrolled scalar fold (apply i=N-1..0 so the lowest match sticks).
+    def packed_find_scalar(hashes : LLVMOpaqueValue?; hk32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var idx = types.ConstI32(uint64(-1))
+        for (k in range(JIT_TABLE_MAX_LINEAR_CAPACITY)) {
+            let j = JIT_TABLE_MAX_LINEAR_CAPACITY - 1 - k
+            var slot = LLVMBuildGEP2(g_builder, types.t_int32, hashes, LLVMConstInt(types.t_int64, uint64(j), 0), "h.slot")
+            var hv = LLVMBuildLoad2(g_builder, types.t_int32, slot, "h.v")
+            var eq = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, hk32, "h.eq")
+            idx = LLVMBuildSelect(g_builder, eq, types.ConstI32(uint64(j)), idx, "h.idx")
+        }
+        return idx
+    }
+
+    // Same scan as one <N x i32> SIMD compare: load the hash slots, compare against the
+    // splatted key, bitcast the mask to i8, cttz -> first set lane; empty mask -> -1.
+    def packed_find_vector(hashes : LLVMOpaqueValue?; hk32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        var vecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
+        var hvp = LLVMBuildPointerCast(g_builder, hashes, LLVMPointerType(vecTy, 0u), "h.vp")
+        var hv = LLVMBuildLoad2(g_builder, vecTy, hvp, "h.vec")
+        LLVMSetAlignment(hv, 4u)
+        var ins = LLVMBuildInsertElement(g_builder, LLVMGetUndef(vecTy), hk32, LLVMConstInt(types.t_int32, 0ul, 0), "h.ins")
+        var splat = LLVMBuildShuffleVector(g_builder, ins, LLVMGetUndef(vecTy), LLVMConstNull(vecTy), "h.splat")
+        var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, splat, "h.eqv")
+        var maskI8 = LLVMBuildBitCast(g_builder, eqv, types.t_int8, "h.mask")
+        var argTypes <- [ types.t_int8 ]
+        let id = LLVMLookupIntrinsicID("llvm.cttz.i8")
+        var decl = LLVMGetIntrinsicDeclaration(g_mod, id, argTypes)
+        var cttzTy = LLVMFunctionType(types.t_int8, [ types.t_int8, types.t_int1 ])
+        var cttzArgs <- [ maskI8, LLVMConstInt(types.t_int1, 0ul, 0) ]
+        var ctz = LLVMBuildCall2(g_builder, cttzTy, decl, cttzArgs, "h.cttz")
+        var ctz32 = LLVMBuildZExt(g_builder, ctz, types.t_int32, "h.cttz32")
+        var none = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, maskI8, LLVMConstInt(types.t_int8, 0ul, 0), "h.none")
+        return LLVMBuildSelect(g_builder, none, types.ConstI32(uint64(-1)), ctz32, "h.vidx")
+    }
+
+    def build_string_table_find_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int) : LLVMOpaqueValue? {
+        var h = build_string_hash(JitCtx(ctx = g_ctx, builder = g_builder, types = types), key)
+        if (JIT_STRING_FIND == JIT_STRING_FIND_MODE.NONE) {
+            return build_string_table_find_call(tab, key, h, valueTypeSize)
+        }
+        // Read capacity + hashes from the table header. Small (packed) iff cap != 0 && cap <=
+        // TABLE_MAX_LINEAR_CAPACITY -> inlined fixed scan; else C++ (cap==0 empty, or hashed).
+        let hdrTy = table_header_llvm_type(types)
+        var tabHdr = LLVMBuildLoad2(g_builder, hdrTy, LLVMBuildPointerCast(g_builder, tab, LLVMPointerType(hdrTy, 0u), "tab.hdrp"), "tab.hdr")
+        var cap = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.CAPACITY), "cap")
+        var hashesV = LLVMBuildExtractValue(g_builder, tabHdr, uint(JIT_TABLE.HASHES), "hashes.v")
+        var hashes = LLVMBuildPointerCast(g_builder, hashesV, LLVMPointerType(types.t_int32, 0u), "hashes")
+        var hk32 = reduce_hash_to_key32(h)
+
+        var find_entry = LLVMGetInsertBlock(g_builder)
+        var find_parent = LLVMGetBasicBlockParent(find_entry)
+        var bb_small = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.small")
+        var bb_large = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.large")
+        var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, find_parent, "find.merge")
+        var nz = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntNE, cap, LLVMConstInt(types.t_int64, 0ul, 0), "cap.nz")
+        var le = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULE, cap, LLVMConstInt(types.t_int64, uint64(JIT_TABLE_MAX_LINEAR_CAPACITY), 0), "cap.le")
+        var isSmall = LLVMBuildAnd(g_builder, nz, le, "cap.small")
+        LLVMBuildCondBr(g_builder, isSmall, bb_small, bb_large)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_small)
+        var idxSmall : LLVMOpaqueValue?
+        if (JIT_STRING_FIND == JIT_STRING_FIND_MODE.VECTOR) {
+            idxSmall = packed_find_vector(hashes, hk32)
+        } else {
+            idxSmall = packed_find_scalar(hashes, hk32)
+        }
+        var smallEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_large)
+        var idxLarge = build_string_table_find_call(tab, key, h, valueTypeSize)
+        var largeEnd = LLVMGetInsertBlock(g_builder)
+        LLVMBuildBr(g_builder, bb_merge)
+
+        LLVMPositionBuilderAtEnd(g_builder, bb_merge)
+        var res = LLVMBuildPhi(g_builder, types.t_int32, "find.idx")
+        LLVMAddIncoming(res, [ idxSmall, idxLarge ], [ smallEnd, largeEnd ])
+        return res
     }
 
     def build_string_table_at_with_hash(tab : LLVMOpaqueValue?; key : LLVMOpaqueValue?; valueTypeSize : int, at : LineInfo) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -184,6 +184,21 @@ enum public JIT_SIMFUNCTION {
     FLAGS
 }
 
+// Must match TABLE_MAX_LINEAR_CAPACITY in runtime_table.h. A packed string table has
+// exactly this many uint32 hash slots, so the inlined packed find scans a fixed count.
+let public JIT_TABLE_MAX_LINEAR_CAPACITY = 8
+
+// Inlined small-table string find on the JIT side. NONE = always call the C++ helper;
+// SCALAR = inline an unrolled 8-slot scan for small tables (C++ for large); VECTOR = the
+// same scan as a <8 x i32> SIMD compare. A/B/C perf experiment; flip + clear .jitted_scripts.
+enum public JIT_STRING_FIND_MODE {
+    NONE
+    SCALAR
+    VECTOR
+}
+
+let public JIT_STRING_FIND = JIT_STRING_FIND_MODE.VECTOR
+
 enum public JIT_FUNCTION {
     SIM_FUNCTION
 }
@@ -319,6 +334,23 @@ def public get_string_table_at_with_hash(g_builder : LLVMOpaqueBuilder?; llvm_mo
     assert(tab_fun != null)
     tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_wh")
     return (tab_fun, at_type)
+}
+
+// Generic Table header (Array base + keys/hashes/tombstones) with pointer fields as void*,
+// so it is independent of key/value type. Field order matches JIT_TABLE; used only to read
+// capacity / hashes for the inlined packed find.
+def public table_header_llvm_type(var types : PrimitiveTypes?) : LLVMOpaqueType? {
+    return types |> StructType(fixed_array(
+        types.LLVMVoidPtrType(),   // DATA
+        types.t_int64,             // SIZE
+        types.t_int64,             // CAPACITY
+        types.t_int32,             // MAGIC
+        types.t_int32,             // LOCK
+        types.t_int32,             // FLAGS
+        types.t_int32,             // PAD_AFTER_FLAGS
+        types.LLVMVoidPtrType(),   // KEYS
+        types.LLVMVoidPtrType(),   // HASHES (TableHashKey* = uint32*)
+        types.t_int64))            // TOMBSTONES
 }
 
 def public get_table_erase(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; t : Type; var types : PrimitiveTypes?) {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -242,6 +242,11 @@ def public FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS() {
     return "`jit`string_table_at_after_packed_miss`"
 }
 
+// Confirm a packed-find candidate's actual string (the SIMD scan matches only the 32-bit hash).
+def public FN_JIT_STRING_EQUAL() {
+    return "`jit`string_equal`"
+}
+
 def private add_table_linkage(val : LLVMOpaqueValue?) {
     // DLLExport storage so ResolveExternVisitor's set_glob_address (GetProcAddress
     // on Windows) can find the slot on cache-hit reload; otherwise #2802 stale-addr.
@@ -367,6 +372,19 @@ def public get_string_table_at_after_packed_miss(g_builder : LLVMOpaqueBuilder?;
     assert(tab_fun != null)
     tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_apm")
     return (tab_fun, at_type)
+}
+
+def public get_string_equal(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; var types : PrimitiveTypes?) {
+    assume fn_ptr = get_jit_string_equal()
+    // int32_t jit_string_equal ( char * a, char * b )
+    assume eq_type = LLVMFunctionType(types.t_int32,
+        fixed_array<LLVMTypeRef>(base_type_to_llvm_type(Type.tString),   // a (char*)
+        base_type_to_llvm_type(Type.tString)))                          // b (char*)
+    let fn_name = DllName(FN_JIT_STRING_EQUAL())
+    var fn : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, eq_type, fn_ptr)
+    assert(fn != null)
+    fn = LLVMBuildLoad2(g_builder, LLVMPointerType(eq_type, 0u), fn, "func_streq")
+    return (fn, eq_type)
 }
 
 // Generic Table header (Array base + keys/hashes/tombstones) with pointer fields as void*,

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -224,6 +224,11 @@ def public FN_JIT_TABLE_FIND(t : Type) {
     return "`jit`table_find`{t}`"
 }
 
+// Insert that skips the C++ packed dedup (the JIT already ran the packed find and missed).
+def public FN_JIT_TABLE_AT_AFTER_PACKED_MISS(t : Type) {
+    return "`jit`table_at_after_packed_miss`{t}`"
+}
+
 // String-key find/at that take a precomputed hash (string-only, no per-type matrix).
 def public FN_JIT_STRING_TABLE_FIND_WITH_HASH() {
     return "`jit`string_table_find_with_hash`"
@@ -231,6 +236,10 @@ def public FN_JIT_STRING_TABLE_FIND_WITH_HASH() {
 
 def public FN_JIT_STRING_TABLE_AT_WITH_HASH() {
     return "`jit`string_table_at_with_hash`"
+}
+
+def public FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS() {
+    return "`jit`string_table_at_after_packed_miss`"
 }
 
 def private add_table_linkage(val : LLVMOpaqueValue?) {
@@ -271,6 +280,23 @@ def public get_table_at(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaque
     var tab_fun : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, at_type, fn_ptr)
     assert(tab_fun != null)
     tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at")
+    return (tab_fun, at_type)
+}
+
+def public get_table_at_after_packed_miss(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; t : Type; var types : PrimitiveTypes?) {
+    assume fn_ptr = get_jit_table_at_after_packed_miss(unsafe(reinterpret<int> t))
+    // int32_t jit_table_at_after_packed_miss ( Table*, KeyType key, int32_t valueTypeSize, Context*, LineInfoArg* ) — same shape as jit_table_at
+    assume at_type = LLVMFunctionType(types.t_int32,
+        fixed_array<LLVMTypeRef>(types.LLVMVoidPtrType(), // table ptr
+        base_type_to_llvm_type(t),                           // key
+        types.t_int32,                                    // valueTypeSize
+        types.LLVMVoidPtrType(),                          // context
+        types.LLVMVoidPtrType(),                          // at
+    ))
+    let fn_name = DllName(FN_JIT_TABLE_AT_AFTER_PACKED_MISS(t))
+    var tab_fun : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, at_type, fn_ptr)
+    assert(tab_fun != null)
+    tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_apm")
     return (tab_fun, at_type)
 }
 
@@ -322,6 +348,24 @@ def public get_string_table_at_with_hash(g_builder : LLVMOpaqueBuilder?; llvm_mo
     var tab_fun : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, at_type, fn_ptr)
     assert(tab_fun != null)
     tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_wh")
+    return (tab_fun, at_type)
+}
+
+def public get_string_table_at_after_packed_miss(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; var types : PrimitiveTypes?) {
+    assume fn_ptr = get_jit_string_table_at_after_packed_miss()
+    // int32_t jit_string_table_at_after_packed_miss ( Table*, char* key, uint64_t hfn, int32_t valueTypeSize, Context*, LineInfoArg* )
+    assume at_type = LLVMFunctionType(types.t_int32,
+        fixed_array<LLVMTypeRef>(types.LLVMVoidPtrType(), // table ptr
+        base_type_to_llvm_type(Type.tString),                // key
+        types.t_int64,                                    // precomputed hash
+        types.t_int32,                                    // valueTypeSize
+        types.LLVMVoidPtrType(),                          // context
+        types.LLVMVoidPtrType(),                          // at
+    ))
+    let fn_name = DllName(FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS())
+    var tab_fun : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, at_type, fn_ptr)
+    assert(tab_fun != null)
+    tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_apm")
     return (tab_fun, at_type)
 }
 

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -220,6 +220,15 @@ def public FN_JIT_TABLE_FIND(t : Type) {
     return "`jit`table_find`{t}`"
 }
 
+// String-key find/at that take a precomputed hash (string-only, no per-type matrix).
+def public FN_JIT_STRING_TABLE_FIND_WITH_HASH() {
+    return "`jit`string_table_find_with_hash`"
+}
+
+def public FN_JIT_STRING_TABLE_AT_WITH_HASH() {
+    return "`jit`string_table_at_with_hash`"
+}
+
 def private add_table_linkage(val : LLVMOpaqueValue?) {
     // DLLExport storage so ResolveExternVisitor's set_glob_address (GetProcAddress
     // on Windows) can find the slot on cache-hit reload; otherwise #2802 stale-addr.
@@ -275,6 +284,41 @@ def public get_table_find(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaq
     assert(tab_fun != null)
     tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(find_type, 0u), tab_fun, "func_find")
     return (tab_fun, find_type)
+}
+
+def public get_string_table_find_with_hash(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; var types : PrimitiveTypes?) {
+    assume fn_ptr = get_jit_string_table_find_with_hash()
+    // int32_t jit_string_table_find_with_hash ( Table * tab, char * key, uint64_t hfn, int32_t valueTypeSize, Context * context )
+    let find_type = LLVMFunctionType(types.t_int32,   // int32_t result
+            fixed_array<LLVMTypeRef>(types.LLVMVoidPtrType(),   // table ptr
+            base_type_to_llvm_type(Type.tString),               // key
+            types.t_int64,                                    // precomputed hash
+            types.t_int32,                                    // valueTypeSize
+            types.LLVMVoidPtrType()                 // context
+            ))
+    let fn_name = DllName(FN_JIT_STRING_TABLE_FIND_WITH_HASH())
+    var tab_fun : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, find_type, fn_ptr)
+    assert(tab_fun != null)
+    tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(find_type, 0u), tab_fun, "func_find_wh")
+    return (tab_fun, find_type)
+}
+
+def public get_string_table_at_with_hash(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; var types : PrimitiveTypes?) {
+    assume fn_ptr = get_jit_string_table_at_with_hash()
+    // int32_t jit_string_table_at_with_hash ( Table * tab, char * key, uint64_t hfn, int32_t valueTypeSize, Context * context, LineInfoArg * at )
+    assume at_type = LLVMFunctionType(types.t_int32,   // int32_t result
+        fixed_array<LLVMTypeRef>(types.LLVMVoidPtrType(), // table ptr
+        base_type_to_llvm_type(Type.tString),                // key
+        types.t_int64,                                    // precomputed hash
+        types.t_int32,                                    // valueTypeSize
+        types.LLVMVoidPtrType(),                          // context
+        types.LLVMVoidPtrType(),                          // at
+    ))
+    let fn_name = DllName(FN_JIT_STRING_TABLE_AT_WITH_HASH())
+    var tab_fun : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, at_type, fn_ptr)
+    assert(tab_fun != null)
+    tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_wh")
+    return (tab_fun, at_type)
 }
 
 def public get_table_erase(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; t : Type; var types : PrimitiveTypes?) {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -184,20 +184,9 @@ enum public JIT_SIMFUNCTION {
     FLAGS
 }
 
-// Must match TABLE_MAX_LINEAR_CAPACITY in runtime_table.h. A packed string table has
-// exactly this many uint32 hash slots, so the inlined packed find scans a fixed count.
+// Must match TABLE_MAX_LINEAR_CAPACITY in runtime_table.h. A packed table has exactly this
+// many slots, so the inlined packed find scans a fixed count (and can vectorize it).
 let public JIT_TABLE_MAX_LINEAR_CAPACITY = 8
-
-// Inlined small-table string find on the JIT side. NONE = always call the C++ helper;
-// SCALAR = inline an unrolled 8-slot scan for small tables (C++ for large); VECTOR = the
-// same scan as a <8 x i32> SIMD compare. A/B/C perf experiment; flip + clear .jitted_scripts.
-enum public JIT_STRING_FIND_MODE {
-    NONE
-    SCALAR
-    VECTOR
-}
-
-let public JIT_STRING_FIND = JIT_STRING_FIND_MODE.VECTOR
 
 enum public JIT_FUNCTION {
     SIM_FUNCTION

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -242,10 +242,6 @@ def public FN_JIT_STRING_TABLE_AT_AFTER_PACKED_MISS() {
     return "`jit`string_table_at_after_packed_miss`"
 }
 
-// Confirm a packed-find candidate's actual string (the SIMD scan matches only the 32-bit hash).
-def public FN_JIT_STRING_EQUAL() {
-    return "`jit`string_equal`"
-}
 
 def private add_table_linkage(val : LLVMOpaqueValue?) {
     // DLLExport storage so ResolveExternVisitor's set_glob_address (GetProcAddress
@@ -372,19 +368,6 @@ def public get_string_table_at_after_packed_miss(g_builder : LLVMOpaqueBuilder?;
     assert(tab_fun != null)
     tab_fun = LLVMBuildLoad2(g_builder, LLVMPointerType(at_type, 0u), tab_fun, "func_at_apm")
     return (tab_fun, at_type)
-}
-
-def public get_string_equal(g_builder : LLVMOpaqueBuilder?; llvm_module : LLVMOpaqueModule?; var types : PrimitiveTypes?) {
-    assume fn_ptr = get_jit_string_equal()
-    // int32_t jit_string_equal ( char * a, char * b )
-    assume eq_type = LLVMFunctionType(types.t_int32,
-        fixed_array<LLVMTypeRef>(base_type_to_llvm_type(Type.tString),   // a (char*)
-        base_type_to_llvm_type(Type.tString)))                          // b (char*)
-    let fn_name = DllName(FN_JIT_STRING_EQUAL())
-    var fn : LLVMOpaqueValue? = get_or_create_table_fn(llvm_module, types, fn_name, eq_type, fn_ptr)
-    assert(fn != null)
-    fn = LLVMBuildLoad2(g_builder, LLVMPointerType(eq_type, 0u), fn, "func_streq")
-    return (fn, eq_type)
 }
 
 // Generic Table header (Array base + keys/hashes/tombstones) with pointer fields as void*,

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -27,7 +27,7 @@ let g_intrin_lookup <- {
     // misc
         "$::length" => @@intrinsic_builtin_length,
         "$::is_standalone_exe" => @@intrinsic_is_standalone_exe,
-        // "$::hash" => @@intrinsic_builtin_hash_string,   // disabled: re-enable when wiring const-key table lookup (item 4)
+        "$::hash" => @@intrinsic_builtin_hash_string,
     // pointer math
         "$::i_das_ptr_set_add" => @@intrinsic_das_ptr_set_add,
         "$::i_das_ptr_add" => @@intrinsic_das_ptr_add,
@@ -136,8 +136,11 @@ def public has_intrinsic(expr : ExprCallFunc?) {
     // First guard: $::length only handles arrays (not table<string; json::JsonValue>
     // or $::dasvector`ptr`Variable&). Second: intrinsics can't have handle types
     // (e.g. int64(clock)).
+    // $::hash is inlined only for string keys and only when the host runtime uses the
+    // fast 16-bit-over-read hash (DAS_SAFE_HASH==0); under safe-hash we fall back to the
+    // runtime call so the JIT never over-reads where the runtime carefully does not.
     if ((call_name == "$::length" && !argType.isGoodArrayType)
-        || (call_name == "$::hash" && argType.baseType != Type.tString)
+        || (call_name == "$::hash" && (argType.baseType != Type.tString || is_safe_hash()))
         || (!expr.arguments |> empty() && argType.isHandle)) return false
     g_intrin_lookup |> get(call_name) $(pfun) {
         result = true
@@ -183,17 +186,24 @@ def intrinsic_is_standalone_exe(var ctx : JitCtx; expr : ExprCallFunc?; argument
     return LLVMConstInt(ctx.types.t_int1, g_jit_exe_mode ? 1ul : 0ul, 0)
 }
 
-// hash(string) -> uint64, inlined. Reproduces hash_blockz64 (anyhash.h) bit-for-bit:
-// FNV-1a, two bytes per round, zero-terminated; null -> FNV basis; final clamp h<=1 -> prime.
-// Equality with the C++ runtime hash is what lets a JIT-emitted hash feed a table lookup.
+// hash(string) -> uint64, inlined. Reproduces hash_blockz64's DAS_SAFE_HASH==0 path
+// (anyhash.h) bit-for-bit: FNV-1a over zero-terminated 16-bit words via a single
+// unaligned 2-byte load per round (the same over-read the fast runtime path does);
+// null -> FNV basis; final clamp h<=1 -> prime. Only emitted when !is_safe_hash(), so
+// the over-read never fires under ASAN/safe-hash builds (has_intrinsic falls back to a
+// runtime call there). Matching the C++ hash bit-for-bit is what lets a JIT-emitted hash
+// feed a table lookup; for a constant key the optimizer folds the whole loop to a literal.
 def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     if (empty(arguments) || expr.arguments[0]._type.baseType != Type.tString) return null
     let i8ptr = LLVMPointerType(ctx.types.t_int8, 0u)
+    let i16ptr = LLVMPointerType(ctx.types.t_int16, 0u)
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], i8ptr, "hash.str")
     var basis = LLVMConstInt(ctx.types.t_int64, 14695981039346656037ul, 0)
     var prime = LLVMConstInt(ctx.types.t_int64, 1099511628211ul, 0)
     var one64 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
-    var zero8 = LLVMConstInt(ctx.types.t_int8, 0ul, 0)
+    var c256 = LLVMConstInt(ctx.types.t_int64, 256ul, 0)
+    var lowmask = LLVMConstInt(ctx.types.t_int64, 255ul, 0)
+    var zero64 = LLVMConstInt(ctx.types.t_int64, 0ul, 0)
 
     var entry = LLVMGetInsertBlock(ctx.builder)
     var ffunc = LLVMGetBasicBlockParent(entry)
@@ -206,28 +216,24 @@ def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; argume
     var is_null = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, ptr, LLVMConstPointerNull(i8ptr), "hash.isnull")
     LLVMBuildCondBr(ctx.builder, is_null, bb_merge, bb_loop)
 
-    // loop: carry running hash h and cursor p
+    // loop: v = *(uint16_t*)p (unaligned, zero-extended); if (v & 0xff)==0 break with h
     LLVMPositionBuilderAtEnd(ctx.builder, bb_loop)
     var h_phi = LLVMBuildPhi(ctx.builder, ctx.types.t_int64, "hash.h")
     var p_phi = LLVMBuildPhi(ctx.builder, i8ptr, "hash.p")
-    var a = LLVMBuildLoad2(ctx.builder, ctx.types.t_int8, p_phi, "hash.a")
-    var a_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, a, zero8, "hash.a0")
-    LLVMBuildCondBr(ctx.builder, a_is_zero, bb_merge, bb_body)
+    var p16 = LLVMBuildPointerCast(ctx.builder, p_phi, i16ptr, "hash.p16")
+    var v16 = LLVMBuildLoad2(ctx.builder, ctx.types.t_int16, p16, "hash.v16")
+    LLVMSetAlignment(v16, 1u)
+    var v = LLVMBuildZExt(ctx.builder, v16, ctx.types.t_int64, "hash.v")
+    var lo = LLVMBuildAnd(ctx.builder, v, lowmask, "hash.lo")
+    var lo_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, lo, zero64, "hash.lo0")
+    LLVMBuildCondBr(ctx.builder, lo_is_zero, bb_merge, bb_body)
 
-    // body: v = a | (b<<8); h = (h ^ v) * prime
+    // body: h = (h ^ v) * prime; if v < 0x100 (high byte 0) break with hmul
     LLVMPositionBuilderAtEnd(ctx.builder, bb_body)
-    var a64 = LLVMBuildZExt(ctx.builder, a, ctx.types.t_int64, "hash.a64")
-    var idx1 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
-    var p1 = LLVMBuildGEP2(ctx.builder, ctx.types.t_int8, p_phi, idx1, "hash.p1")
-    var bbyte = LLVMBuildLoad2(ctx.builder, ctx.types.t_int8, p1, "hash.b")
-    var b64 = LLVMBuildZExt(ctx.builder, bbyte, ctx.types.t_int64, "hash.b64")
-    var sh8 = LLVMConstInt(ctx.types.t_int64, 8ul, 0)
-    var bsh = LLVMBuildShl(ctx.builder, b64, sh8, "hash.bsh")
-    var v = LLVMBuildOr(ctx.builder, a64, bsh, "hash.v")
     var hx = LLVMBuildXor(ctx.builder, h_phi, v, "hash.hx")
     var hmul = LLVMBuildMul(ctx.builder, hx, prime, "hash.hmul")
-    var b_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, bbyte, zero8, "hash.b0")
-    LLVMBuildCondBr(ctx.builder, b_is_zero, bb_merge, bb_cont)
+    var v_lt_256 = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntULT, v, c256, "hash.vlt")
+    LLVMBuildCondBr(ctx.builder, v_lt_256, bb_merge, bb_cont)
 
     // cont: advance two bytes, loop
     LLVMPositionBuilderAtEnd(ctx.builder, bb_cont)

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -141,7 +141,7 @@ def public has_intrinsic(expr : ExprCallFunc?) {
     if ((call_name == "$::length" && !argType.isGoodArrayType)
         || (call_name == "$::hash" && argType.baseType != Type.tString)
         || (!expr.arguments |> empty() && argType.isHandle)) return false
-    g_intrin_lookup |> get(call_name) $(pfun) {
+    g_intrin_lookup |> get(call_name) $(_pfun) {
         result = true
     }
     return result
@@ -160,11 +160,11 @@ def public lookup_intinsic(g_ctx : LLVMContextRef; g_builder : LLVMOpaqueBuilder
 
 // intrinsics, $ aka builtin
 
-def intrinsic_builtin_variant_index(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_variant_index(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     return LLVMBuildLoad2(ctx.builder, ctx.types.t_int32, arguments[0], "$::variant_index")
 }
 
-def intrinsic_builtin_set_variant_index(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_set_variant_index(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     return LLVMBuildStore2(ctx.builder, ctx.types, ctx.types.t_int32, arguments[1], arguments[0])
 }
 
@@ -181,7 +181,7 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
     }
 }
 
-def intrinsic_is_standalone_exe(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_is_standalone_exe(var ctx : JitCtx; _expr : ExprCallFunc?; _arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     return LLVMConstInt(ctx.types.t_int1, g_jit_exe_mode ? 1ul : 0ul, 0)
 }
 
@@ -846,7 +846,7 @@ def build_fsqrt(var ctx : JitCtx; v2 : LLVMOpaqueValue?; name : string) : LLVMOp
     return LLVMBuildCall2(ctx.builder, typ, decl_fsqrt, args_fsqrt, name)
 }
 
-def build_frcp(var ctx : JitCtx; v2 : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
+def build_frcp(var ctx : JitCtx; v2 : LLVMOpaqueValue?; _name : string) : LLVMOpaqueValue? {
     var one = LLVMConstReal(ctx.types.t_float, 1.0lf)
     var fdiv = LLVMBuildFDiv(ctx.builder, one, v2, "")
     return fdiv
@@ -1131,7 +1131,7 @@ def build_memset_64(var ctx : JitCtx; ptr_type : LLVMOpaqueType?; _ptr, val, _si
     return build_memset_128(ctx, ptr, value, size)
 }
 
-def intrinsic_memset64(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_memset64(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     var size = LLVMBuildZExtOrBitCast(ctx.builder, arguments[2], ctx.types.t_int64, "")
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], LLVMPointerType(ctx.types.t_int64, 0u), "")
     return build_memset_64(ctx, ctx.types.t_int64, ptr, arguments[1], size)
@@ -1146,7 +1146,7 @@ def build_memset_32(var ctx : JitCtx; ptr_type : LLVMOpaqueType?; _ptr, val, _si
     return build_memset_64(ctx, ctx.types.t_int64, ptr, value, size)
 }
 
-def intrinsic_memset32(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_memset32(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     var size = LLVMBuildZExtOrBitCast(ctx.builder, arguments[2], ctx.types.t_int64, "")
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], LLVMPointerType(ctx.types.t_int32, 0u), "")
     return build_memset_32(ctx, ctx.types.t_int32, ptr, arguments[1], size)
@@ -1161,13 +1161,13 @@ def build_memset_16(var ctx : JitCtx; ptr_type : LLVMOpaqueType?; _ptr, val, _si
     return build_memset_32(ctx, ctx.types.t_int32, ptr, value, size)
 }
 
-def intrinsic_memset16(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_memset16(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     var size = LLVMBuildZExtOrBitCast(ctx.builder, arguments[2], ctx.types.t_int64, "")
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], LLVMPointerType(ctx.types.t_int16, 0u), "")
     return build_memset_16(ctx, ctx.types.t_int16, ptr, arguments[1], size)
 }
 
-def intrinsic_math_gather(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_math_gather(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], LLVMPointerType(ctx.types.t_int32, 0u), "")
     var ix = LLVMBuildExtractElement(ctx.builder, arguments[1], ctx.types.ConstI32(0ul), "")
     var iy = LLVMBuildExtractElement(ctx.builder, arguments[1], ctx.types.ConstI32(1ul), "")
@@ -1185,7 +1185,7 @@ def intrinsic_math_gather(var ctx : JitCtx; expr : ExprCallFunc?; arguments : ar
     return res
 }
 
-def intrinsic_math_store_neq_mask(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_math_store_neq_mask(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], LLVMPointerType(ctx.types.LLVMInt4Type(), 0u), "")
     var value = arguments[1]
     var mask_v = arguments[2]
@@ -1205,7 +1205,7 @@ def intrinsic_math_gather_store_mask(var ctx : JitCtx; expr : ExprCallFunc?; arg
     return intrinsic_math_store_neq_mask(ctx, expr, arg_store_mask)
 }
 
-def intrinsic_math_gather_store_stride(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_math_gather_store_stride(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     // gather
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[2], LLVMPointerType(ctx.types.t_int32, 0u), "")
     var ix = LLVMBuildExtractElement(ctx.builder, arguments[3], ctx.types.ConstI32(0ul), "")
@@ -1258,7 +1258,7 @@ def intrinsic_math_gather_store_stride(var ctx : JitCtx; expr : ExprCallFunc?; a
 // gather_store_neq_mask
 // def intrinsic_gather_store_neq_mask
 
-def intrinsic_math_u8x4_gather_store(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_math_u8x4_gather_store(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     // gather
     var ptr = LLVMBuildPointerCast(ctx.builder, arguments[1], LLVMPointerType(ctx.types.t_int8, 0u), "")
     var ix = LLVMBuildExtractElement(ctx.builder, arguments[2], ctx.types.ConstI32(0ul), "")
@@ -1327,7 +1327,7 @@ def intrinsic_math_sign(var ctx : JitCtx; expr : ExprCallFunc?; arguments : arra
     }
 }
 
-def intrinsic_mul_128(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_mul_128(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     var a = arguments[0]
     var b = arguments[1]
     var A = LLVMBuildZExtOrBitCast(ctx.builder, a, ctx.types.t_int128, "")

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -12,7 +12,7 @@ require llvm/daslib/llvm_jit_common
 require daslib/ast_boost
 require strings
 
-struct JitCtx {
+struct public JitCtx {
     ctx : LLVMContextRef
     types : PrimitiveTypes -const? -const
     builder : LLVMOpaqueBuilder -const? -const
@@ -136,11 +136,10 @@ def public has_intrinsic(expr : ExprCallFunc?) {
     // First guard: $::length only handles arrays (not table<string; json::JsonValue>
     // or $::dasvector`ptr`Variable&). Second: intrinsics can't have handle types
     // (e.g. int64(clock)).
-    // $::hash is inlined only for string keys and only when the host runtime uses the
-    // fast 16-bit-over-read hash (DAS_SAFE_HASH==0); under safe-hash we fall back to the
-    // runtime call so the JIT never over-reads where the runtime carefully does not.
+    // $::hash is inlined for string keys; build_string_hash picks the fast (2-byte) or
+    // safe (1-byte) round body by is_safe_hash() so it matches the host runtime exactly.
     if ((call_name == "$::length" && !argType.isGoodArrayType)
-        || (call_name == "$::hash" && (argType.baseType != Type.tString || is_safe_hash()))
+        || (call_name == "$::hash" && argType.baseType != Type.tString)
         || (!expr.arguments |> empty() && argType.isHandle)) return false
     g_intrin_lookup |> get(call_name) $(pfun) {
         result = true
@@ -186,18 +185,22 @@ def intrinsic_is_standalone_exe(var ctx : JitCtx; expr : ExprCallFunc?; argument
     return LLVMConstInt(ctx.types.t_int1, g_jit_exe_mode ? 1ul : 0ul, 0)
 }
 
-// hash(string) -> uint64, inlined. Reproduces hash_blockz64's DAS_SAFE_HASH==0 path
-// (anyhash.h) bit-for-bit: FNV-1a over zero-terminated 16-bit words via a single
-// unaligned 2-byte load per round (the same over-read the fast runtime path does);
-// null -> FNV basis; final clamp h<=1 -> prime. Only emitted when !is_safe_hash(), so
-// the over-read never fires under ASAN/safe-hash builds (has_intrinsic falls back to a
-// runtime call there). Matching the C++ hash bit-for-bit is what lets a JIT-emitted hash
-// feed a table lookup; for a constant key the optimizer folds the whole loop to a literal.
-def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
-    if (empty(arguments) || expr.arguments[0]._type.baseType != Type.tString) return null
+// Inlined hash(string) -> uint64, reproducing hash_blockz64 (anyhash.h) bit-for-bit:
+// FNV-1a over a zero-terminated 16-bit word stream; null -> FNV basis; final clamp
+// h<=1 -> prime. is_safe_hash() picks the round body to match the host runtime exactly:
+// the fast path does one unaligned 2-byte load per round (over-reading 1 byte past the
+// null, as DAS_SAFE_HASH==0 does), the safe path loads byte-by-byte (no over-read, for
+// ASAN/DAS_SAFE_HASH==1). Both compute the same value. Shared by the $::hash intrinsic
+// and the string-keyed table lookup lowering; for a constant key the optimizer folds the
+// whole loop to an immediate (item 4).
+def public build_string_hash(var ctx : JitCtx; strPtr : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    return is_safe_hash() ? build_string_hash_safe(ctx, strPtr) : build_string_hash_fast(ctx, strPtr)
+}
+
+def build_string_hash_fast(var ctx : JitCtx; strPtr : LLVMOpaqueValue?) : LLVMOpaqueValue? {
     let i8ptr = LLVMPointerType(ctx.types.t_int8, 0u)
     let i16ptr = LLVMPointerType(ctx.types.t_int16, 0u)
-    var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], i8ptr, "hash.str")
+    var ptr = LLVMBuildPointerCast(ctx.builder, strPtr, i8ptr, "hash.str")
     var basis = LLVMConstInt(ctx.types.t_int64, 14695981039346656037ul, 0)
     var prime = LLVMConstInt(ctx.types.t_int64, 1099511628211ul, 0)
     var one64 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
@@ -250,6 +253,70 @@ def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; argume
     LLVMAddIncoming(hres, [basis, h_phi, hmul], [entry, bb_loop, bb_body])
     var clamp = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntULE, hres, one64, "hash.clamp")
     return LLVMBuildSelect(ctx.builder, clamp, prime, hres, "hash")
+}
+
+def build_string_hash_safe(var ctx : JitCtx; strPtr : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    let i8ptr = LLVMPointerType(ctx.types.t_int8, 0u)
+    var ptr = LLVMBuildPointerCast(ctx.builder, strPtr, i8ptr, "hash.str")
+    var basis = LLVMConstInt(ctx.types.t_int64, 14695981039346656037ul, 0)
+    var prime = LLVMConstInt(ctx.types.t_int64, 1099511628211ul, 0)
+    var one64 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
+    var zero8 = LLVMConstInt(ctx.types.t_int8, 0ul, 0)
+
+    var entry = LLVMGetInsertBlock(ctx.builder)
+    var ffunc = LLVMGetBasicBlockParent(entry)
+    var bb_loop = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.loop")
+    var bb_body = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.body")
+    var bb_cont = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.cont")
+    var bb_merge = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.merge")
+
+    // entry: null string -> basis, else enter loop
+    var is_null = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, ptr, LLVMConstPointerNull(i8ptr), "hash.isnull")
+    LLVMBuildCondBr(ctx.builder, is_null, bb_merge, bb_loop)
+
+    // loop: a = p[0]; if a==0 break with h (never reads past the null)
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_loop)
+    var h_phi = LLVMBuildPhi(ctx.builder, ctx.types.t_int64, "hash.h")
+    var p_phi = LLVMBuildPhi(ctx.builder, i8ptr, "hash.p")
+    var a = LLVMBuildLoad2(ctx.builder, ctx.types.t_int8, p_phi, "hash.a")
+    var a_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, a, zero8, "hash.a0")
+    LLVMBuildCondBr(ctx.builder, a_is_zero, bb_merge, bb_body)
+
+    // body: b = p[1]; v = a | (b<<8); h = (h ^ v) * prime; if b==0 break with hmul
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_body)
+    var a64 = LLVMBuildZExt(ctx.builder, a, ctx.types.t_int64, "hash.a64")
+    var idx1 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
+    var p1 = LLVMBuildGEP2(ctx.builder, ctx.types.t_int8, p_phi, idx1, "hash.p1")
+    var bbyte = LLVMBuildLoad2(ctx.builder, ctx.types.t_int8, p1, "hash.b")
+    var b64 = LLVMBuildZExt(ctx.builder, bbyte, ctx.types.t_int64, "hash.b64")
+    var sh8 = LLVMConstInt(ctx.types.t_int64, 8ul, 0)
+    var bsh = LLVMBuildShl(ctx.builder, b64, sh8, "hash.bsh")
+    var v = LLVMBuildOr(ctx.builder, a64, bsh, "hash.v")
+    var hx = LLVMBuildXor(ctx.builder, h_phi, v, "hash.hx")
+    var hmul = LLVMBuildMul(ctx.builder, hx, prime, "hash.hmul")
+    var b_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, bbyte, zero8, "hash.b0")
+    LLVMBuildCondBr(ctx.builder, b_is_zero, bb_merge, bb_cont)
+
+    // cont: advance two bytes, loop
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_cont)
+    var idx2 = LLVMConstInt(ctx.types.t_int64, 2ul, 0)
+    var p2 = LLVMBuildGEP2(ctx.builder, ctx.types.t_int8, p_phi, idx2, "hash.p2")
+    LLVMBuildBr(ctx.builder, bb_loop)
+
+    LLVMAddIncoming(h_phi, [basis, hmul], [entry, bb_cont])
+    LLVMAddIncoming(p_phi, [ptr, p2], [entry, bb_cont])
+
+    // merge: pick the hash at whichever exit fired, then clamp h<=1 -> prime
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_merge)
+    var hres = LLVMBuildPhi(ctx.builder, ctx.types.t_int64, "hash.res")
+    LLVMAddIncoming(hres, [basis, h_phi, hmul], [entry, bb_loop, bb_body])
+    var clamp = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntULE, hres, one64, "hash.clamp")
+    return LLVMBuildSelect(ctx.builder, clamp, prime, hres, "hash")
+}
+
+def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    if (empty(arguments) || expr.arguments[0]._type.baseType != Type.tString) return null
+    return build_string_hash(ctx, arguments[0])
 }
 
 def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -27,6 +27,7 @@ let g_intrin_lookup <- {
     // misc
         "$::length" => @@intrinsic_builtin_length,
         "$::is_standalone_exe" => @@intrinsic_is_standalone_exe,
+        // "$::hash" => @@intrinsic_builtin_hash_string,   // disabled: re-enable when wiring const-key table lookup (item 4)
     // pointer math
         "$::i_das_ptr_set_add" => @@intrinsic_das_ptr_set_add,
         "$::i_das_ptr_add" => @@intrinsic_das_ptr_add,
@@ -136,6 +137,7 @@ def public has_intrinsic(expr : ExprCallFunc?) {
     // or $::dasvector`ptr`Variable&). Second: intrinsics can't have handle types
     // (e.g. int64(clock)).
     if ((call_name == "$::length" && !argType.isGoodArrayType)
+        || (call_name == "$::hash" && argType.baseType != Type.tString)
         || (!expr.arguments |> empty() && argType.isHandle)) return false
     g_intrin_lookup |> get(call_name) $(pfun) {
         result = true
@@ -179,6 +181,69 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
 
 def intrinsic_is_standalone_exe(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     return LLVMConstInt(ctx.types.t_int1, g_jit_exe_mode ? 1ul : 0ul, 0)
+}
+
+// hash(string) -> uint64, inlined. Reproduces hash_blockz64 (anyhash.h) bit-for-bit:
+// FNV-1a, two bytes per round, zero-terminated; null -> FNV basis; final clamp h<=1 -> prime.
+// Equality with the C++ runtime hash is what lets a JIT-emitted hash feed a table lookup.
+def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    if (empty(arguments) || expr.arguments[0]._type.baseType != Type.tString) return null
+    let i8ptr = LLVMPointerType(ctx.types.t_int8, 0u)
+    var ptr = LLVMBuildPointerCast(ctx.builder, arguments[0], i8ptr, "hash.str")
+    var basis = LLVMConstInt(ctx.types.t_int64, 14695981039346656037ul, 0)
+    var prime = LLVMConstInt(ctx.types.t_int64, 1099511628211ul, 0)
+    var one64 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
+    var zero8 = LLVMConstInt(ctx.types.t_int8, 0ul, 0)
+
+    var entry = LLVMGetInsertBlock(ctx.builder)
+    var ffunc = LLVMGetBasicBlockParent(entry)
+    var bb_loop = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.loop")
+    var bb_body = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.body")
+    var bb_cont = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.cont")
+    var bb_merge = LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, "hash.merge")
+
+    // entry: null string -> basis, else enter loop
+    var is_null = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, ptr, LLVMConstPointerNull(i8ptr), "hash.isnull")
+    LLVMBuildCondBr(ctx.builder, is_null, bb_merge, bb_loop)
+
+    // loop: carry running hash h and cursor p
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_loop)
+    var h_phi = LLVMBuildPhi(ctx.builder, ctx.types.t_int64, "hash.h")
+    var p_phi = LLVMBuildPhi(ctx.builder, i8ptr, "hash.p")
+    var a = LLVMBuildLoad2(ctx.builder, ctx.types.t_int8, p_phi, "hash.a")
+    var a_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, a, zero8, "hash.a0")
+    LLVMBuildCondBr(ctx.builder, a_is_zero, bb_merge, bb_body)
+
+    // body: v = a | (b<<8); h = (h ^ v) * prime
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_body)
+    var a64 = LLVMBuildZExt(ctx.builder, a, ctx.types.t_int64, "hash.a64")
+    var idx1 = LLVMConstInt(ctx.types.t_int64, 1ul, 0)
+    var p1 = LLVMBuildGEP2(ctx.builder, ctx.types.t_int8, p_phi, idx1, "hash.p1")
+    var bbyte = LLVMBuildLoad2(ctx.builder, ctx.types.t_int8, p1, "hash.b")
+    var b64 = LLVMBuildZExt(ctx.builder, bbyte, ctx.types.t_int64, "hash.b64")
+    var sh8 = LLVMConstInt(ctx.types.t_int64, 8ul, 0)
+    var bsh = LLVMBuildShl(ctx.builder, b64, sh8, "hash.bsh")
+    var v = LLVMBuildOr(ctx.builder, a64, bsh, "hash.v")
+    var hx = LLVMBuildXor(ctx.builder, h_phi, v, "hash.hx")
+    var hmul = LLVMBuildMul(ctx.builder, hx, prime, "hash.hmul")
+    var b_is_zero = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, bbyte, zero8, "hash.b0")
+    LLVMBuildCondBr(ctx.builder, b_is_zero, bb_merge, bb_cont)
+
+    // cont: advance two bytes, loop
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_cont)
+    var idx2 = LLVMConstInt(ctx.types.t_int64, 2ul, 0)
+    var p2 = LLVMBuildGEP2(ctx.builder, ctx.types.t_int8, p_phi, idx2, "hash.p2")
+    LLVMBuildBr(ctx.builder, bb_loop)
+
+    LLVMAddIncoming(h_phi, [basis, hmul], [entry, bb_cont])
+    LLVMAddIncoming(p_phi, [ptr, p2], [entry, bb_cont])
+
+    // merge: pick the hash at whichever exit fired, then clamp h<=1 -> prime
+    LLVMPositionBuilderAtEnd(ctx.builder, bb_merge)
+    var hres = LLVMBuildPhi(ctx.builder, ctx.types.t_int64, "hash.res")
+    LLVMAddIncoming(hres, [basis, h_phi, hmul], [entry, bb_loop, bb_body])
+    var clamp = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntULE, hres, one64, "hash.clamp")
+    return LLVMBuildSelect(ctx.builder, clamp, prime, hres, "hash")
 }
 
 def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x14ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x15ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x17ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x18ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x15ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x16ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x10ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x11ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -16,7 +16,8 @@ require daslib/strings_boost
 require daslib/defer
 
 require daslib/fio
-require daslib/clargs
+require daslib/option
+require daslib/result
 require jit
 
 module llvm_jit_run shared private

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x0cul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x10ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x11ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x12ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x13ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x14ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x16ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x17ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -32,7 +32,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x12ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x13ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -120,6 +120,18 @@ namespace das
         }
     };
 
+    // Const-string table key: bake the key bytes (into the const-string heap) and their hash
+    // at simulate time so the runtime node skips the per-lookup hash_blockz64 walk. Returns the
+    // baked key char* (and sets outHash) when keyType is string and keyExpr is an ExprConstString;
+    // nullptr otherwise (caller falls back to the regular hashing node).
+    static __forceinline char * bakeConstStringKey ( Context & context, Expression * keyExpr,
+            const TypeDecl * keyType, uint64_t & outHash ) {
+        if ( keyType->baseType != Type::tString || !keyExpr->rtti_isStringConstant() ) return nullptr;
+        char * keyStr = context.constStringHeap->impl_allocateString(static_cast<ExprConstString*>(keyExpr)->getValue());
+        outHash = hash_blockz64((uint8_t *)keyStr);
+        return keyStr;
+    }
+
     struct SimulateVisitor : Visitor {
         Context & context;
         das_hash_map<const Expression*, SimNode*> e2v;
@@ -1619,18 +1631,24 @@ namespace das
     ExpressionPtr SimulateVisitor::visit(ExprFind * expr) {
         const auto &at = expr->at;
         auto cont = getE(expr->arguments[0]);
-        auto val = getE(expr->arguments[1]);
         if ( expr->arguments[0]->type->isGoodTableType() ) {
             uint32_t valueTypeSize = expr->arguments[0]->type->secondType->getSizeOf();
-            Type valueType;
-            if ( expr->arguments[0]->type->firstType->isWorkhorseType() ) {
-                valueType = expr->arguments[0]->type->firstType->baseType;
+            const auto & keyT = expr->arguments[0]->type->firstType;
+            uint64_t keyHash = 0u;
+            if ( char * keyStr = bakeConstStringKey(context, expr->arguments[1], keyT, keyHash) ) {
+                setE(expr, context.code->makeNode<SimNode_TableFind_WithHash>(at, cont, keyStr, keyHash, valueTypeSize));
             } else {
-                auto valueT = expr->arguments[0]->type->firstType->annotation->makeValueType();
-                valueType = valueT->baseType;
-                val = context.code->makeNode<SimNode_CastToWorkhorse>(at, val);
+                auto val = getE(expr->arguments[1]);
+                Type valueType;
+                if ( keyT->isWorkhorseType() ) {
+                    valueType = keyT->baseType;
+                } else {
+                    auto valueT = keyT->annotation->makeValueType();
+                    valueType = valueT->baseType;
+                    val = context.code->makeNode<SimNode_CastToWorkhorse>(at, val);
+                }
+                setE(expr, context.code->makeValueNode<SimNode_TableFind>(valueType, at, cont, val, valueTypeSize));
             }
-            setE(expr, context.code->makeValueNode<SimNode_TableFind>(valueType, at, cont, val, valueTypeSize));
         } else {
             DAS_ASSERTF(0, "we should not even be here. find can only accept tables. infer type should have failed.");
             context.thisProgram->error("internal compilation error, generating find for non-table type", "", "", at, CompilationError::internal_table);
@@ -1642,18 +1660,24 @@ namespace das
     ExpressionPtr SimulateVisitor::visit(ExprKeyExists * expr) {
         const auto &at = expr->at;
         auto cont = getE(expr->arguments[0]);
-        auto val = getE(expr->arguments[1]);
         if ( expr->arguments[0]->type->isGoodTableType() ) {
             uint32_t valueTypeSize = expr->arguments[0]->type->secondType->getSizeOf();
-            Type valueType;
-            if ( expr->arguments[0]->type->firstType->isWorkhorseType() ) {
-                valueType = expr->arguments[0]->type->firstType->baseType;
+            const auto & keyT = expr->arguments[0]->type->firstType;
+            uint64_t keyHash = 0u;
+            if ( char * keyStr = bakeConstStringKey(context, expr->arguments[1], keyT, keyHash) ) {
+                setE(expr, context.code->makeNode<SimNode_KeyExists_WithHash>(at, cont, keyStr, keyHash, valueTypeSize));
             } else {
-                auto valueT = expr->arguments[0]->type->firstType->annotation->makeValueType();
-                valueType = valueT->baseType;
-                val = context.code->makeNode<SimNode_CastToWorkhorse>(at, val);
+                auto val = getE(expr->arguments[1]);
+                Type valueType;
+                if ( keyT->isWorkhorseType() ) {
+                    valueType = keyT->baseType;
+                } else {
+                    auto valueT = keyT->annotation->makeValueType();
+                    valueType = valueT->baseType;
+                    val = context.code->makeNode<SimNode_CastToWorkhorse>(at, val);
+                }
+                setE(expr, context.code->makeValueNode<SimNode_KeyExists>(valueType, at, cont, val, valueTypeSize));
             }
-            setE(expr, context.code->makeValueNode<SimNode_KeyExists>(valueType, at, cont, val, valueTypeSize));
         } else {
             DAS_ASSERTF(0, "we should not even be here. find can only accept tables. infer type should have failed.");
             context.thisProgram->error("internal compilation error, generating find for non-table type", "", "", at, CompilationError::internal_table);
@@ -1996,17 +2020,24 @@ namespace das
             }
         } else if ( expr->subexpr->type->isGoodTableType() ) {
             auto prv = getE(expr->subexpr);
-            auto pidx = getE(expr->index);
             uint32_t valueTypeSize = expr->subexpr->type->secondType->getSizeOf();
-            Type keyType;
-            if ( expr->subexpr->type->firstType->isWorkhorseType() ) {
-                keyType = expr->subexpr->type->firstType->baseType;
+            const auto & keyT = expr->subexpr->type->firstType;
+            SimNode * res = nullptr;
+            uint64_t keyHash = 0u;
+            if ( char * keyStr = bakeConstStringKey(context, expr->index, keyT, keyHash) ) {
+                res = context.code->makeNode<SimNode_TableIndex_WithHash>(at, prv, keyStr, keyHash, valueTypeSize, 0);
             } else {
-                auto keyValueType = expr->subexpr->type->firstType->annotation->makeValueType();
-                keyType = keyValueType->baseType;
-                pidx = context.code->makeNode<SimNode_CastToWorkhorse>(at, pidx);
+                auto pidx = getE(expr->index);
+                Type keyType;
+                if ( keyT->isWorkhorseType() ) {
+                    keyType = keyT->baseType;
+                } else {
+                    auto keyValueType = keyT->annotation->makeValueType();
+                    keyType = keyValueType->baseType;
+                    pidx = context.code->makeNode<SimNode_CastToWorkhorse>(at, pidx);
+                }
+                res = context.code->makeValueNode<SimNode_TableIndex>(keyType, at, prv, pidx, valueTypeSize, 0);
             }
-            auto res = context.code->makeValueNode<SimNode_TableIndex>(keyType, at, prv, pidx, valueTypeSize, 0);
             if ( expr->r2v ) {
                 setE(expr, GetR2V(context, at, expr->type, res));
             } else {
@@ -2038,17 +2069,22 @@ namespace das
                 }
             } else if ( seT->isGoodTableType() ) {
                 auto prv = getE(expr->subexpr);
-                auto pidx = getE(expr->index);
                 uint32_t valueTypeSize = seT->secondType->getSizeOf();
-                Type valueType;
-                if ( seT->firstType->isWorkhorseType() ) {
-                    valueType = seT->firstType->baseType;
+                uint64_t keyHash = 0u;
+                if ( char * keyStr = bakeConstStringKey(context, expr->index, seT->firstType, keyHash) ) {
+                    setE(expr, context.code->makeNode<SimNode_SafeTableIndex_WithHash>(at, prv, keyStr, keyHash, valueTypeSize));
                 } else {
-                    auto valueT = seT->firstType->annotation->makeValueType();
-                    valueType = valueT->baseType;
-                    pidx = context.code->makeNode<SimNode_CastToWorkhorse>(at, pidx);
+                    auto pidx = getE(expr->index);
+                    Type valueType;
+                    if ( seT->firstType->isWorkhorseType() ) {
+                        valueType = seT->firstType->baseType;
+                    } else {
+                        auto valueT = seT->firstType->annotation->makeValueType();
+                        valueType = valueT->baseType;
+                        pidx = context.code->makeNode<SimNode_CastToWorkhorse>(at, pidx);
+                    }
+                    setE(expr, context.code->makeValueNode<SimNode_SafeTableIndex>(valueType, at, prv, pidx, valueTypeSize, 0));
                 }
-                setE(expr, context.code->makeValueNode<SimNode_SafeTableIndex>(valueType, at, prv, pidx, valueTypeSize, 0));
             } else if ( seT->dim.size() ) {
                 uint32_t range = seT->dim[0];
                 uint32_t stride = seT->getStride();
@@ -2089,17 +2125,22 @@ namespace das
                 }
             } else if ( expr->subexpr->type->isGoodTableType() ) {
                 auto prv = getE(expr->subexpr);
-                auto pidx = getE(expr->index);
                 uint32_t valueTypeSize = seT->secondType->getSizeOf();
-                Type valueType;
-                if ( seT->firstType->isWorkhorseType() ) {
-                    valueType = seT->firstType->baseType;
+                uint64_t keyHash = 0u;
+                if ( char * keyStr = bakeConstStringKey(context, expr->index, seT->firstType, keyHash) ) {
+                    setE(expr, context.code->makeNode<SimNode_SafeTableIndex_WithHash>(at, prv, keyStr, keyHash, valueTypeSize));
                 } else {
-                    auto valueT = seT->firstType->annotation->makeValueType();
-                    valueType = valueT->baseType;
-                    pidx = context.code->makeNode<SimNode_CastToWorkhorse>(at, pidx);
+                    auto pidx = getE(expr->index);
+                    Type valueType;
+                    if ( seT->firstType->isWorkhorseType() ) {
+                        valueType = seT->firstType->baseType;
+                    } else {
+                        auto valueT = seT->firstType->annotation->makeValueType();
+                        valueType = valueT->baseType;
+                        pidx = context.code->makeNode<SimNode_CastToWorkhorse>(at, pidx);
+                    }
+                    setE(expr, context.code->makeValueNode<SimNode_SafeTableIndex>(valueType, at, prv, pidx, valueTypeSize, 0));
                 }
-                setE(expr, context.code->makeValueNode<SimNode_SafeTableIndex>(valueType, at, prv, pidx, valueTypeSize, 0));
             } else if ( seT->dim.size() ) {
                 uint32_t range = seT->dim[0];
                 uint32_t stride = seT->getStride();

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -380,7 +380,7 @@ namespace das {
         char * values = tab->data;
         char * keys = tab->keys;
         for ( uint32_t index=0, indexs=tab->capacity; index!=indexs; index++, keys+=keyStride, values+=valueStride ) {
-            if ( tab->hashes[index] > HASH_KILLED64 ) {
+            if ( tableLiveSlot(*tab, index) ) {
                 das_invoke<void>::invoke<void *,void *>(context,at,blk,(void*)keys,(void*)values);
             }
         }

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1364,6 +1364,14 @@ namespace das
         return false;
     }
 
+    // DAS_SAFE_HASH of the host binary (anyhash.h). When 0, string hashing uses the
+    // fast 16-bit-over-read load; the JIT can then inline a matching hash. When 1
+    // (e.g. ASAN), the runtime reads byte-by-byte and the JIT must not over-read, so
+    // it falls back to the runtime call instead of emitting the fast intrinsic.
+    bool is_safe_hash ( ) {
+        return DAS_SAFE_HASH != 0;
+    }
+
     DAS_API uint64_t get_context_share_counter ( Context * context ) {
         return (uint64_t) context->code.use_count();
     }
@@ -1888,6 +1896,8 @@ namespace das
                 ->arg("arguments");
         addExtern<DAS_BIND_FUN(is_standalone_exe)>(*this, lib, "is_standalone_exe",
             SideEffects::accessExternal, "is_standalone_exe");
+        addExtern<DAS_BIND_FUN(is_safe_hash)>(*this, lib, "is_safe_hash",
+            SideEffects::none, "is_safe_hash");
         addExtern<DAS_BIND_FUN(withCommandLineArguments)>(*this, lib,  "with_argv",
             SideEffects::invoke, "withArgv")
                 ->args({"new_arguments", "block","context","line"});

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1255,7 +1255,7 @@ namespace das
     void builtin_table_free ( Table & tab, int szk, int szv, Context * __context__, LineInfoArg * at ) {
         if ( tab.data ) {
             if ( !tab.isLocked() || tab.hopeless ) {
-                uint64_t oldSize = tab.capacity*uint64_t(szk+szv+sizeof(TableHashKey));
+                uint64_t oldSize = tab.capacity*(uint64_t(szk)+uint64_t(szv)) + tab.capacity*tableHashSlotBytes(tab.capacity);
                 __context__->free(tab.data, oldSize, at);
             } else {
                 __context__->throw_error_at(at, "can't delete locked table");

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -785,6 +785,14 @@ extern "C" {
         DAS_API void * get_jit_table_erase ( int32_t baseType, Context * context, LineInfoArg * at ) {
             return das_get_jit_table_erase(baseType, context, at);
         }
+        // String-key find/at route through these precomputed-hash globals (see llvm_jit.das
+        // build_table_find/at); the standalone-exe glob baking needs them as linkable symbols.
+        DAS_API void * get_jit_string_table_find_with_hash ( ) {
+            return das_get_jit_string_table_find_with_hash();
+        }
+        DAS_API void * get_jit_string_table_at_with_hash ( ) {
+            return das_get_jit_string_table_at_with_hash();
+        }
         DAS_API void * das_get_jit_new ( TypeAnnotation *annotation ) {
             return annotation->jitGetNew();
         }

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -757,6 +757,17 @@ extern "C" {
         JIT_TABLE_FUNCTION(&jit_table_at_after_packed_miss);
     }
 
+    // Confirm a packed-find candidate: the inline SIMD scan matches on the 32-bit hash, which can
+    // collide, so the JIT calls this on the single candidate lane to confirm the actual string.
+    // Same null=="" semantics as KeyCompare<char*> (null is the empty string in daslang).
+    int32_t jit_string_equal ( char * a, char * b ) {
+        return KeyCompare<char *>()(a,b) ? 1 : 0;
+    }
+
+    void * das_get_jit_string_equal ( ) {
+        return (void*)&jit_string_equal;
+    }
+
 
     uint64_t das_get_global_variable_offset( const Context * ctx, int id ) {
         return ctx->getGlobalVariable(id).offset;
@@ -1206,6 +1217,8 @@ extern "C" {
                 SideEffects::none, "das_get_jit_string_table_at_after_packed_miss");
             addExtern<DAS_BIND_FUN(das_get_jit_table_at_after_packed_miss)>(*this, lib, "get_jit_table_at_after_packed_miss",
                 SideEffects::none, "das_get_jit_table_at_after_packed_miss");
+            addExtern<DAS_BIND_FUN(das_get_jit_string_equal)>(*this, lib, "get_jit_string_equal",
+                SideEffects::none, "das_get_jit_string_equal");
             addExtern<DAS_BIND_FUN(das_get_global_variable_offset)>(*this, lib, "get_global_variable_offset",
                 SideEffects::none, "das_get_global_variable_offset");
             addExtern<DAS_BIND_FUN(das_get_global_variable_mnh)>(*this, lib, "get_global_variable_mnh",

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -757,16 +757,6 @@ extern "C" {
         JIT_TABLE_FUNCTION(&jit_table_at_after_packed_miss);
     }
 
-    // Confirm a packed-find candidate: the inline SIMD scan matches on the 32-bit hash, which can
-    // collide, so the JIT calls this on the single candidate lane to confirm the actual string.
-    // Same null=="" semantics as KeyCompare<char*> (null is the empty string in daslang).
-    int32_t jit_string_equal ( char * a, char * b ) {
-        return KeyCompare<char *>()(a,b) ? 1 : 0;
-    }
-
-    void * das_get_jit_string_equal ( ) {
-        return (void*)&jit_string_equal;
-    }
 
 
     uint64_t das_get_global_variable_offset( const Context * ctx, int id ) {
@@ -1217,8 +1207,6 @@ extern "C" {
                 SideEffects::none, "das_get_jit_string_table_at_after_packed_miss");
             addExtern<DAS_BIND_FUN(das_get_jit_table_at_after_packed_miss)>(*this, lib, "get_jit_table_at_after_packed_miss",
                 SideEffects::none, "das_get_jit_table_at_after_packed_miss");
-            addExtern<DAS_BIND_FUN(das_get_jit_string_equal)>(*this, lib, "get_jit_string_equal",
-                SideEffects::none, "das_get_jit_string_equal");
             addExtern<DAS_BIND_FUN(das_get_global_variable_offset)>(*this, lib, "get_global_variable_offset",
                 SideEffects::none, "das_get_global_variable_offset");
             addExtern<DAS_BIND_FUN(das_get_global_variable_mnh)>(*this, lib, "get_global_variable_mnh",

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -729,6 +729,34 @@ extern "C" {
         return (void*)&jit_string_table_at_with_hash;
     }
 
+    // Insert after the JIT's inline packed find already proved the key absent from a packed
+    // table — skips the C++ packed dedup. See TableHash::reserveAfterPackedMiss (which checks
+    // the lock itself). String form takes the JIT-computed hash; the non-string template
+    // computes the (cheap) integer hash here rather than threading it from the JIT.
+    int32_t jit_string_table_at_after_packed_miss ( Table * tab, char * key, uint64_t hfn, int32_t valueTypeSize, Context * context, LineInfoArg * at ) {
+        TableHash<char *> thh(context,valueTypeSize);
+        int64_t idx = thh.reserveAfterPackedMiss(*tab, key, hfn, at);
+        if ( idx > int64_t(INT32_MAX) ) context->throw_error_at(at, "JIT table slot index %lld exceeds INT32_MAX; JIT does not yet support tables past INT_MAX slots", (long long)idx);
+        return (int32_t) idx;
+    }
+
+    void * das_get_jit_string_table_at_after_packed_miss ( ) {
+        return (void*)&jit_string_table_at_after_packed_miss;
+    }
+
+    template <typename KeyType>
+    int32_t jit_table_at_after_packed_miss ( Table * tab, KeyType key, int32_t valueTypeSize, Context * context, LineInfoArg * at ) {
+        TableHash<KeyType> thh(context,valueTypeSize);
+        auto hfn = hash_function(*context, key);
+        int64_t idx = thh.reserveAfterPackedMiss(*tab, key, hfn, at);
+        if ( idx > int64_t(INT32_MAX) ) context->throw_error_at(at, "JIT table slot index %lld exceeds INT32_MAX; JIT does not yet support tables past INT_MAX slots", (long long)idx);
+        return (int32_t) idx;
+    }
+
+    void * das_get_jit_table_at_after_packed_miss ( int32_t baseType, Context * context, LineInfoArg * at ) {
+        JIT_TABLE_FUNCTION(&jit_table_at_after_packed_miss);
+    }
+
 
     uint64_t das_get_global_variable_offset( const Context * ctx, int id ) {
         return ctx->getGlobalVariable(id).offset;
@@ -1174,6 +1202,10 @@ extern "C" {
                 SideEffects::none, "das_get_jit_string_table_find_with_hash");
             addExtern<DAS_BIND_FUN(das_get_jit_string_table_at_with_hash)>(*this, lib, "get_jit_string_table_at_with_hash",
                 SideEffects::none, "das_get_jit_string_table_at_with_hash");
+            addExtern<DAS_BIND_FUN(das_get_jit_string_table_at_after_packed_miss)>(*this, lib, "get_jit_string_table_at_after_packed_miss",
+                SideEffects::none, "das_get_jit_string_table_at_after_packed_miss");
+            addExtern<DAS_BIND_FUN(das_get_jit_table_at_after_packed_miss)>(*this, lib, "get_jit_table_at_after_packed_miss",
+                SideEffects::none, "das_get_jit_table_at_after_packed_miss");
             addExtern<DAS_BIND_FUN(das_get_global_variable_offset)>(*this, lib, "get_global_variable_offset",
                 SideEffects::none, "das_get_global_variable_offset");
             addExtern<DAS_BIND_FUN(das_get_global_variable_mnh)>(*this, lib, "get_global_variable_mnh",

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -702,6 +702,33 @@ extern "C" {
         JIT_TABLE_FUNCTION(&jit_table_find);
     }
 
+    // String-key find/at that take a precomputed hash, so the JIT emits the hash inline
+    // (foldable to an immediate for a constant key) instead of recomputing it in C++.
+    // String-only — no per-baseType matrix; the key is still passed for the KeyCompare
+    // strcmp once a table promotes past packed small-mode.
+    int32_t jit_string_table_find_with_hash ( Table * tab, char * key, uint64_t hfn, int32_t valueTypeSize, Context * context ) {
+        TableHash<char *> thh(context,valueTypeSize);
+        int64_t idx = thh.find(*tab, key, hfn);
+        if ( idx > int64_t(INT32_MAX) ) context->throw_error("JIT table slot index exceeds INT32_MAX; JIT does not yet support tables past INT_MAX slots");
+        return (int32_t) idx;
+    }
+
+    void * das_get_jit_string_table_find_with_hash ( ) {
+        return (void*)&jit_string_table_find_with_hash;
+    }
+
+    int32_t jit_string_table_at_with_hash ( Table * tab, char * key, uint64_t hfn, int32_t valueTypeSize, Context * context, LineInfoArg * at ) {
+        if ( tab->isLocked() ) context->throw_error_at(at, "can't insert to a locked table");
+        TableHash<char *> thh(context,valueTypeSize);
+        int64_t idx = thh.reserve(*tab, key, hfn, at);
+        if ( idx > int64_t(INT32_MAX) ) context->throw_error_at(at, "JIT table slot index %lld exceeds INT32_MAX; JIT does not yet support tables past INT_MAX slots", (long long)idx);
+        return (int32_t) idx;
+    }
+
+    void * das_get_jit_string_table_at_with_hash ( ) {
+        return (void*)&jit_string_table_at_with_hash;
+    }
+
 
     uint64_t das_get_global_variable_offset( const Context * ctx, int id ) {
         return ctx->getGlobalVariable(id).offset;
@@ -1143,6 +1170,10 @@ extern "C" {
                 SideEffects::none, "das_get_jit_table_erase");
             addExtern<DAS_BIND_FUN(das_get_jit_table_find)>(*this, lib, "get_jit_table_find",
                 SideEffects::none, "das_get_jit_table_find");
+            addExtern<DAS_BIND_FUN(das_get_jit_string_table_find_with_hash)>(*this, lib, "get_jit_string_table_find_with_hash",
+                SideEffects::none, "das_get_jit_string_table_find_with_hash");
+            addExtern<DAS_BIND_FUN(das_get_jit_string_table_at_with_hash)>(*this, lib, "get_jit_string_table_at_with_hash",
+                SideEffects::none, "das_get_jit_string_table_at_with_hash");
             addExtern<DAS_BIND_FUN(das_get_global_variable_offset)>(*this, lib, "get_global_variable_offset",
                 SideEffects::none, "das_get_global_variable_offset");
             addExtern<DAS_BIND_FUN(das_get_global_variable_mnh)>(*this, lib, "get_global_variable_mnh",

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -793,6 +793,15 @@ extern "C" {
         DAS_API void * get_jit_string_table_at_with_hash ( ) {
             return das_get_jit_string_table_at_with_hash();
         }
+        // Insert-after-packed-miss globals: the JIT's inline packed find calls these on a miss.
+        // The standalone-exe baker (llvm_exe.das add_table_at_call) stores the in-exe address
+        // here; without it the glob keeps its compile-process address and faults under ASLR.
+        DAS_API void * get_jit_string_table_at_after_packed_miss ( ) {
+            return das_get_jit_string_table_at_after_packed_miss();
+        }
+        DAS_API void * get_jit_table_at_after_packed_miss ( int32_t baseType, Context * context, LineInfoArg * at ) {
+            return das_get_jit_table_at_after_packed_miss(baseType, context, at);
+        }
         DAS_API void * das_get_jit_new ( TypeAnnotation *annotation ) {
             return annotation->jitGetNew();
         }

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -1275,7 +1275,7 @@ void das_table_clear ( das_context * context, das_table * tab, int key_base_type
         uint32_t key_size = 0;
         DAS_TABLE_DISPATCH(key_base_type, { key_size = sizeof(KEY_TYPE); })
         if ( !key_size ) return; // throw_error already raised
-        uint64_t total = t->capacity * (uint64_t(value_size) + uint64_t(key_size) + uint64_t(sizeof(TableHashKey)));
+        uint64_t total = t->capacity * (uint64_t(value_size) + uint64_t(key_size)) + t->capacity*das::tableHashSlotBytes(t->capacity);
         ((Context *)context)->free(t->data, total, nullptr);
     }
     memset(t, 0, sizeof(Table));

--- a/src/simulate/data_walker.cpp
+++ b/src/simulate/data_walker.cpp
@@ -143,7 +143,7 @@ namespace das {
         int valueSize = info->secondType->size;
         uint64_t count = 0;
         for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
-            if ( tab->hashes[i] > HASH_KILLED64 ) {
+            if ( tableLiveSlot(*tab, i) ) {
                 bool last = (count == (tab->size-1));
                 // key
                 char * key = tab->keys + i*keySize;

--- a/src/simulate/runtime_table.cpp
+++ b/src/simulate/runtime_table.cpp
@@ -58,7 +58,7 @@ namespace das
     void table_clear ( Context & context, Table & arr, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't clear locked table");
         if ( arr.data ) {
-            memset(arr.hashes, 0, arr.capacity*sizeof(TableHashKey));
+            memset(arr.hashes, 0, arr.capacity*tableHashSlotBytes(arr.capacity));
             memset(arr.data, 0, arr.keys - arr.data);
         }
         arr.size = 0;
@@ -102,7 +102,7 @@ namespace das
 
     size_t TableIterator::nextValid ( size_t index ) const {
         for ( auto indexs=table->capacity; index < indexs; index++) {
-            if (table->hashes[index] > HASH_KILLED64) {
+            if (tableLiveSlot(*table, index)) {
                 break;
             }
         }
@@ -212,7 +212,7 @@ namespace das
             return;
         }
         ptrdiff_t index = offset / value_stride;
-        if ( tab.hashes[index] <= HASH_KILLED64 ) {
+        if ( !tableLiveSlot(tab, (uint64_t)index) ) {
             __context__->throw_error_at(at, "get_key: value points to an empty or deleted table slot");
             return;
         }
@@ -228,7 +228,7 @@ namespace das
         for ( uint32_t i=0, is=total; i!=is; ++i, pTable-- ) {
             if ( pTable->data ) {
                 if ( !pTable->isLocked() ) {
-                    uint64_t oldSize = pTable->capacity * uint64_t(vts_add_kts + sizeof(TableHashKey));
+                    uint64_t oldSize = pTable->capacity * uint64_t(vts_add_kts) + pTable->capacity*tableHashSlotBytes(pTable->capacity);
                     context.free(pTable->data, oldSize, &debugInfo);
                 } else {
                     context.throw_error_at(debugInfo, "deleting locked table%s", errorMessage);

--- a/src/simulate/simulate_fusion.cpp
+++ b/src/simulate/simulate_fusion.cpp
@@ -163,6 +163,7 @@ namespace das {
             createFusionEngine_at();
             createFusionEngine_at_array();
             createFusionEngine_tableindex();
+            createFusionEngine_tablewithhash();
             // call
             createFusionEngine_call1();
             createFusionEngine_call2();

--- a/src/simulate/simulate_fusion_tablewithhash.cpp
+++ b/src/simulate/simulate_fusion_tablewithhash.cpp
@@ -1,0 +1,125 @@
+#include "daScript/misc/platform.h"
+
+#ifdef _MSC_VER
+#pragma warning(disable:4505)
+#endif
+
+#include "daScript/simulate/simulate_fusion.h"
+
+#if DAS_FUSION
+
+#include "daScript/simulate/sim_policy.h"
+#include "daScript/ast/ast.h"
+#include "daScript/simulate/simulate_fusion_op1.h"
+#include "daScript/simulate/runtime_table_nodes.h"
+#include "daScript/simulate/simulate_visit_op.h"
+
+// OP1 fusion for the const-string-key table nodes (SimNode_*_WithHash). Their single sub-node is
+// the table container (tabExpr), evaluated to a Table* via GetLocal / GetArgument / GetArgumentRef;
+// the key and hash are baked. Fusing folds that container load into the node, dropping one virtual
+// dispatch per lookup. Uses the OP1-SET matcher (container/lvalue shapes), not the OP1 value matcher.
+
+namespace das {
+
+    /* TableIndexWithHash (insert/index, ptr, offset) */
+
+    struct SimNode_Op1TableIndexWithHash : SimNode_Op1Fusion {
+        virtual SimNode * visit(SimVisitor & vis) override {
+            V_BEGIN();
+            string name = op;
+            name += getSimSourceName(subexpr.type);
+            vis.op(name.c_str());
+            subexpr.visit(vis);
+            V_ARG(key);
+            V_ARG(hashOf);
+            V_ARG(valueTypeSize);
+            V_ARG(offset);
+            V_END();
+        }
+        char *    key;
+        uint64_t  hashOf;
+        uint32_t  valueTypeSize;
+        uint32_t  offset;
+    };
+
+#undef IMPLEMENT_ANY_OP1_SET_NODE
+#define IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
+    struct SimNode_Op1##COMPUTE : SimNode_Op1TableIndexWithHash { \
+        INLINE char * compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            Table * tab = (Table *) subexpr.compute##COMPUTE(context); \
+            if ( tab->isLocked() ) context.throw_error_at(debugInfo, "can't insert to a locked table"); \
+            TableHash<char*> thh(&context, valueTypeSize); \
+            int64_t index = thh.reserve(*tab, key, hashOf, &debugInfo); \
+            return tab->data + index * valueTypeSize + offset; \
+        } \
+        DAS_PTR_NODE; \
+    };
+
+#undef IMPLEMENT_OP1_SETUP_NODE
+#define IMPLEMENT_OP1_SETUP_NODE(result,node) \
+    auto rn = (SimNode_Op1TableIndexWithHash *)result; \
+    auto sn = (SimNode_TableIndex_WithHash *)node; \
+    rn->key = sn->key; \
+    rn->hashOf = sn->hashOf; \
+    rn->valueTypeSize = sn->valueTypeSize; \
+    rn->offset = sn->offset;
+
+#undef FUSION_OP1_SUBEXPR
+#define FUSION_OP1_SUBEXPR(CTYPE,node)      ((static_cast<SimNode_TableIndex_WithHash*>(node))->tabExpr)
+
+    IMPLEMENT_SET_OP1_FUSION_POINT(__forceinline, TableIndexWithHash, Ptr, VoidPtr, VoidPtr);
+
+    /* SafeTableIndexWithHash (find, ptr, null-check) */
+
+    struct SimNode_Op1SafeTableIndexWithHash : SimNode_Op1Fusion {
+        virtual SimNode * visit(SimVisitor & vis) override {
+            V_BEGIN();
+            string name = op;
+            name += getSimSourceName(subexpr.type);
+            vis.op(name.c_str());
+            subexpr.visit(vis);
+            V_ARG(key);
+            V_ARG(hashOf);
+            V_ARG(valueTypeSize);
+            V_END();
+        }
+        char *    key;
+        uint64_t  hashOf;
+        uint32_t  valueTypeSize;
+    };
+
+#undef IMPLEMENT_ANY_OP1_SET_NODE
+#define IMPLEMENT_ANY_OP1_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,RCTYPE,COMPUTE) \
+    struct SimNode_Op1##COMPUTE : SimNode_Op1SafeTableIndexWithHash { \
+        INLINE char * compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            Table * tab = (Table *) subexpr.compute##COMPUTE(context); \
+            if ( !tab ) return nullptr; \
+            TableHash<char*> thh(&context, valueTypeSize); \
+            int64_t index = thh.find(*tab, key, hashOf); \
+            return index!=-1 ? tab->data + index * valueTypeSize : nullptr; \
+        } \
+        DAS_PTR_NODE; \
+    };
+
+#undef IMPLEMENT_OP1_SETUP_NODE
+#define IMPLEMENT_OP1_SETUP_NODE(result,node) \
+    auto rn = (SimNode_Op1SafeTableIndexWithHash *)result; \
+    auto sn = (SimNode_SafeTableIndex_WithHash *)node; \
+    rn->key = sn->key; \
+    rn->hashOf = sn->hashOf; \
+    rn->valueTypeSize = sn->valueTypeSize;
+
+#undef FUSION_OP1_SUBEXPR
+#define FUSION_OP1_SUBEXPR(CTYPE,node)      ((static_cast<SimNode_SafeTableIndex_WithHash*>(node))->tabExpr)
+
+    IMPLEMENT_SET_OP1_FUSION_POINT(__forceinline, SafeTableIndexWithHash, Ptr, VoidPtr, VoidPtr);
+
+    void createFusionEngine_tablewithhash() {
+        (*getFusionEngine())["TableIndexWithHash"].emplace_back(new Op1FusionPoint_TableIndexWithHash_VoidPtr());
+        (*getFusionEngine())["SafeTableIndexWithHash"].emplace_back(new Op1FusionPoint_SafeTableIndexWithHash_VoidPtr());
+    }
+}
+
+#endif

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -134,7 +134,7 @@ namespace das
             if (info->firstType->flags & gcFlags) {
                 if (info->secondType->flags & gcFlags) {
                     for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
-                        if ( tab->hashes[i] > HASH_KILLED64 ) {
+                        if ( tableLiveSlot(*tab, i) ) {
                             // key
                             char * key = tab->keys + i*keySize;
                             walk ( key, info->firstType );
@@ -145,7 +145,7 @@ namespace das
                     }
                 } else {
                     for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
-                        if ( tab->hashes[i] > HASH_KILLED64 ) {
+                        if ( tableLiveSlot(*tab, i) ) {
                             // key
                             char * key = tab->keys + i*keySize;
                             walk ( key, info->firstType );
@@ -154,7 +154,7 @@ namespace das
                 }
             } else {
                 for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
-                    if ( tab->hashes[i] > HASH_KILLED64 ) {
+                    if ( tableLiveSlot(*tab, i) ) {
                         // value
                         char * value = tab->data + i*valueSize;
                         walk ( value, info->secondType );
@@ -391,8 +391,8 @@ namespace das
             popRange();
         }
         virtual void beforeTable ( Table * PT, TypeInfo * ti ) override {
-            auto tsize = (ti->firstType->size + ti->secondType->size + sizeof(TableHashKey)) * PT->capacity;
-            DAS_ASSERT(tsize==(getTypeSize(ti->firstType)+getTypeSize(ti->secondType)+sizeof(TableHashKey))*PT->capacity);
+            auto tsize = (ti->firstType->size + ti->secondType->size) * PT->capacity + tableHashSlotBytes(PT->capacity)*PT->capacity;
+            DAS_ASSERT(tsize==(getTypeSize(ti->firstType)+getTypeSize(ti->secondType))*PT->capacity + tableHashSlotBytes(PT->capacity)*PT->capacity);
             char * pa = PT->data;
             PtrRange rdata(pa, tsize);
             if ( reportHeap && tsize && markRange(rdata) ) {
@@ -600,7 +600,7 @@ namespace das
             int valueSize = info->secondType->size;
             uint64_t count = 0;
             for ( uint64_t i=0, is=tab->capacity; i!=is; ++i ) {
-                if ( tab->hashes[i] > HASH_KILLED64 ) {
+                if ( tableLiveSlot(*tab, i) ) {
                     bool last = (count == (tab->size-1));
                     // key
                     char * key = tab->keys + i*keySize;
@@ -787,7 +787,7 @@ namespace das
             popRange();
         }
         virtual void beforeTable ( Table * PT, TypeInfo * ti ) override {
-            PtrRange rdata(PT->data, (ti->firstType->size+ti->secondType->size+sizeof(TableHashKey))*size_t(PT->capacity));
+            PtrRange rdata(PT->data, (ti->firstType->size+ti->secondType->size)*size_t(PT->capacity) + size_t(tableHashSlotBytes(PT->capacity))*size_t(PT->capacity));
             markAndPushRange(rdata);
         }
         virtual void afterTable ( Table *, TypeInfo * ) override {
@@ -1105,7 +1105,7 @@ namespace das
         virtual void afterTable ( Table * pa, TypeInfo * ti ) override {
             if ( pa->data ) {
                 if ( !pa->isLocked() || pa->hopeless ) {
-                    uint64_t oldSize = pa->capacity*(ti->firstType->size+ti->secondType->size+sizeof(TableHashKey));
+                    uint64_t oldSize = pa->capacity*uint64_t(ti->firstType->size+ti->secondType->size) + pa->capacity*tableHashSlotBytes(pa->capacity);
                     __context__->free(pa->data, oldSize, __at__);
                 } else {
                     __context__->throw_error_at(__at__, "can't delete locked table");

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -408,6 +408,9 @@ list(FILTER AOT_PROMOTE_FILES EXCLUDE REGEX "failed_")
 FILE(GLOB AOT_RTTI_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/rtti/*.das")
 list(FILTER AOT_RTTI_FILES EXCLUDE REGEX "/_")
 
+# AOT for packed small-table test files
+FILE(GLOB AOT_TABLE_PACKED_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/table_packed/*.das")
+
 # AOT for language test files
 FILE(GLOB AOT_LANGUAGE_TEST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/language/*.das")
 # Exclude expect-error tests and no_aot files
@@ -679,6 +682,10 @@ add_custom_target(test_aot_promote)
 SET(PROMOTE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_PROMOTE_FILES}" PROMOTE_AOT_GENERATED_SRC test_aot_promote daslang)
 
+add_custom_target(test_aot_table_packed)
+SET(TABLE_PACKED_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_TABLE_PACKED_FILES}" TABLE_PACKED_AOT_GENERATED_SRC test_aot_table_packed daslang)
+
 add_custom_target(test_aot_rtti)
 SET(RTTI_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_RTTI_FILES}" RTTI_AOT_GENERATED_SRC test_aot_rtti daslang)
@@ -860,6 +867,7 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${STRINGS_AOT_GENERATED_SRC}
     ${LINT_AOT_GENERATED_SRC}
     ${PROMOTE_AOT_GENERATED_SRC}
+    ${TABLE_PACKED_AOT_GENERATED_SRC}
     ${RTTI_AOT_GENERATED_SRC}
     ${TEMPLATE_AOT_GENERATED_SRC}
     ${TYPE_TRAITS_AOT_GENERATED_SRC}
@@ -907,7 +915,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_option
     test_aot_regex test_aot_reader_macro
     test_aot_delegate test_aot_safe_addr test_aot_soa test_aot_spoof test_aot_strings
-    test_aot_lint test_aot_promote test_aot_rtti
+    test_aot_lint test_aot_promote test_aot_table_packed test_aot_rtti
     test_aot_template test_aot_type_traits test_aot_uri
     test_aot_lpipe
     test_aot_jit

--- a/tests/language/set_table.das
+++ b/tests/language/set_table.das
@@ -2,6 +2,28 @@ options gen2
 options no_unused_function_arguments = false
 require dastest/testing_boost public
 
+// Tables/sets are unordered; iteration order is an implementation detail (it changed
+// when small tables moved to packed insertion-order storage). Compare contents sorted.
+def sorted_keys(tab : table<int>) : array<int> {
+    var got : array<int>
+    for (k in keys(tab)) {
+        got |> push(k)
+    }
+    sort(got)
+    return <- got
+}
+
+def check(t : T?; tab : table<int>; expected : array<int>) {
+    var got <- sorted_keys(tab)
+    t |> equal(length(got), length(expected))
+    if (length(got) == length(expected)) {
+        for (a, b in got, expected) {
+            t |> equal(a, b)
+        }
+    }
+    delete got
+}
+
 [test]
 def test_set_table(t : T?) {
     t |> run("insert and iterate") @(t : T?) {
@@ -10,9 +32,7 @@ def test_set_table(t : T?) {
         for (i in 3..6) {
             tab |> insert(i)
         }
-        for (k, i in keys(tab), array<int>(5, 4, 3)) {
-            t |> equal(k, i)
-        }
+        check(t, tab, [3, 4, 5])
     }
     t |> run("erase and iterate") @(t : T?) {
         var tab : table<int>
@@ -20,9 +40,7 @@ def test_set_table(t : T?) {
             tab |> insert(i)
         }
         tab |> erase(4)
-        for (k, i in keys(tab), array<int>(5, 3)) {
-            t |> equal(k, i)
-        }
+        check(t, tab, [3, 5])
     }
     t |> run("clone set") @(t : T?) {
         var tab : table<int>
@@ -31,20 +49,14 @@ def test_set_table(t : T?) {
         }
         tab |> erase(4)
         var tc := tab
-        for (k, i in keys(tc), array<int>(5, 3)) {
-            t |> equal(k, i)
-        }
+        check(t, tc, [3, 5])
         t |> success(tc |> key_exists(3))
         t |> success(!tc |> key_exists(4))
     }
     t |> run("literal and to_table") @(t : T?) {
         var ttt <- {1, 2, 3, 4}
-        for (k, i in keys(ttt), array<int>(4, 3, 2, 1)) {
-            t |> equal(k, i)
-        }
+        check(t, ttt, [1, 2, 3, 4])
         var qqq <- to_table(fixed_array<int>(1, 2, 3, 4))
-        for (k, i in keys(qqq), array<int>(4, 3, 2, 1)) {
-            t |> equal(k, i)
-        }
+        check(t, qqq, [1, 2, 3, 4])
     }
 }

--- a/tests/language/set_table.das
+++ b/tests/language/set_table.das
@@ -5,10 +5,7 @@ require dastest/testing_boost public
 // Tables/sets are unordered; iteration order is an implementation detail (it changed
 // when small tables moved to packed insertion-order storage). Compare contents sorted.
 def sorted_keys(tab : table<int>) : array<int> {
-    var got : array<int>
-    for (k in keys(tab)) {
-        got |> push(k)
-    }
+    var got <- [for (k in keys(tab)); k]
     sort(got)
     return <- got
 }
@@ -48,15 +45,15 @@ def test_set_table(t : T?) {
             tab |> insert(i)
         }
         tab |> erase(4)
-        var tc := tab
+        let tc := tab
         check(t, tc, [3, 5])
         t |> success(tc |> key_exists(3))
         t |> success(!tc |> key_exists(4))
     }
     t |> run("literal and to_table") @(t : T?) {
-        var ttt <- {1, 2, 3, 4}
+        let ttt <- {1, 2, 3, 4}
         check(t, ttt, [1, 2, 3, 4])
-        var qqq <- to_table(fixed_array<int>(1, 2, 3, 4))
+        let qqq <- to_table(fixed_array<int>(1, 2, 3, 4))
         check(t, qqq, [1, 2, 3, 4])
     }
 }

--- a/tests/linq/test_linq_join.das
+++ b/tests/linq/test_linq_join.das
@@ -366,6 +366,19 @@ def test_groupjoin(t : T?) {
     }
 }
 
+// group_by output order follows first-seen-key (insertion) order — an implementation
+// detail that shifted when small tables became packed. The pet-age groups are unordered,
+// so compare them sorted by key.
+def check_pet_age_groups(t : T?; var got : array<tuple<float; int; float; float>>) {
+    sort(got) $(a, b) => a._0 < b._0
+    t |> equal(length(got), 3)
+    if (length(got) == 3) {
+        t |> equal(got[0]._0, 1.); t |> equal(got[0]._1, 1); t |> equal(got[0]._2, 1.5); t |> equal(got[0]._3, 1.5)
+        t |> equal(got[1]._0, 4.); t |> equal(got[1]._1, 2); t |> equal(got[1]._2, 4.3); t |> equal(got[1]._3, 4.9)
+        t |> equal(got[2]._0, 8.); t |> equal(got[2]._1, 1); t |> equal(got[2]._2, 8.3); t |> equal(got[2]._3, 8.3)
+    }
+}
+
 [test]
 def test_groupby(t : T?) {
     t |> run("basic group by") @(t : T?) {
@@ -378,17 +391,12 @@ def test_groupby(t : T?) {
                 return (baseAge, aa.length(), aa.to_sequence().min(), aa.to_sequence().max())
             }
         )
-        var expected = [
-            (4., 2, 4.3, 4.9),
-            (1., 1, 1.5, 1.5),
-            (8., 1, 8.3, 8.3)
-        ]
-        for (c, e in query, expected) {
-            t |> equal(c._0, e._0)
-            t |> equal(c._1, e._1)
-            t |> equal(c._2, e._2)
-            t |> equal(c._3, e._3)
+        var got : array<tuple<float; int; float; float>>
+        for (c in query) {
+            got |> push(c)
         }
+        check_pet_age_groups(t, got)
+        delete got
     }
     t |> run("complex group by") @(t : T?) {
         var qcomplex = group_by(
@@ -421,17 +429,12 @@ def test_groupby(t : T?) {
                 return (baseAge, aa.length(), aa.to_sequence().min(), aa.to_sequence().max())
             }
         )
-        var expected = [
-            (4., 2, 4.3, 4.9),
-            (1., 1, 1.5, 1.5),
-            (8., 1, 8.3, 8.3)
-        ]
-        for (c, e in query, expected) {
-            t |> equal(c._0, e._0)
-            t |> equal(c._1, e._1)
-            t |> equal(c._2, e._2)
-            t |> equal(c._3, e._3)
+        var got : array<tuple<float; int; float; float>>
+        for (c in query) {
+            got |> push(c)
         }
+        check_pet_age_groups(t, got)
+        delete got
     }
     t |> run("group by to array") @(t : T?) {
         var query = group_by_to_array(
@@ -443,17 +446,12 @@ def test_groupby(t : T?) {
                 return (baseAge, aa.length(), aa.to_sequence().min(), aa.to_sequence().max())
             }
         )
-        var expected = [
-            (4., 2, 4.3, 4.9),
-            (1., 1, 1.5, 1.5),
-            (8., 1, 8.3, 8.3)
-        ]
-        for (c, e in query, expected) {
-            t |> equal(c._0, e._0)
-            t |> equal(c._1, e._1)
-            t |> equal(c._2, e._2)
-            t |> equal(c._3, e._3)
+        var got : array<tuple<float; int; float; float>>
+        for (c in query) {
+            got |> push(c)
         }
+        check_pet_age_groups(t, got)
+        delete got
     }
     t |> run("group by to sequence") @(t : T?) {
         var query = group_by_to_array(
@@ -465,17 +463,12 @@ def test_groupby(t : T?) {
                 return (baseAge, aa.length(), aa.to_sequence().min(), aa.to_sequence().max())
             }
         ).to_sequence()
-        var expected = [
-            (4., 2, 4.3, 4.9),
-            (1., 1, 1.5, 1.5),
-            (8., 1, 8.3, 8.3)
-        ]
-        for (c, e in query, expected) {
-            t |> equal(c._0, e._0)
-            t |> equal(c._1, e._1)
-            t |> equal(c._2, e._2)
-            t |> equal(c._3, e._3)
+        var got : array<tuple<float; int; float; float>>
+        for (c in query) {
+            got |> push(c)
         }
+        check_pet_age_groups(t, got)
+        delete got
     }
 }
 

--- a/tests/long_array_table/test_dapi_layout.das
+++ b/tests/long_array_table/test_dapi_layout.das
@@ -56,7 +56,7 @@ def test_dapi_table_keys_hashes_non_null(t : T?) {
 def test_dapi_table_tombstones_after_erase(t : T?) {
     // Small (packed) tables erase via swap-remove and leave no tombstone; tombstones only
     // exist in the open-addressed regime, so grow past maxLinearCapacity (8) first.
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via real insert path then erased to exercise tombstone layout
     for (i in range(10)) {
         tab |> insert(i, i * 100)
     }
@@ -72,7 +72,7 @@ def test_dapi_table_keys_offset_matches_runtime(t : T?) {
     // In the C++ Table memory layout, `keys` points to `data + capacity * sizeof(value)`.
     // If DapiArray's pad/size disagrees with das::Array's, DapiTable.keys reads from
     // the wrong slot and the equality below fails — independent of platform.
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via real insert path to validate keys-offset layout
     for (i in range(8)) {
         tab |> insert(i, i * 10)
     }

--- a/tests/long_array_table/test_dapi_layout.das
+++ b/tests/long_array_table/test_dapi_layout.das
@@ -54,12 +54,15 @@ def test_dapi_table_keys_hashes_non_null(t : T?) {
 
 [test]
 def test_dapi_table_tombstones_after_erase(t : T?) {
+    // Small (packed) tables erase via swap-remove and leave no tombstone; tombstones only
+    // exist in the open-addressed regime, so grow past maxLinearCapacity (8) first.
     var tab : table<int; int>
-    tab |> insert(1, 100)
-    tab |> insert(2, 200)
-    tab |> erase(1)
+    for (i in range(10)) {
+        tab |> insert(i, i * 100)
+    }
+    tab |> erase(3)
     let view = unsafe(reinterpret<DapiTable?>(unsafe(addr(tab))))
-    t |> equal(view.size, uint64(1))
+    t |> equal(view.size, uint64(9))
     t |> equal(view.tombstones, uint64(1))
 }
 

--- a/tests/strings/strings_hash.das
+++ b/tests/strings/strings_hash.das
@@ -33,6 +33,24 @@ def test_hash_builder(t : T?) {
 
 
 [test]
+def test_hash_string_reference(t : T?) {
+    // Pins hash(string) to known hash_blockz64 (FNV-1a) values across lengths and
+    // parities, including the empty string (-> FNV basis). Under JIT this validates
+    // the inlined hash intrinsic; under interp, the bound builtin. Both must agree.
+    t |> equal(hash(""), 0xcbf29ce484222325ul)
+    t |> equal(hash("a"), 0xaf63dc4c8601ec8cul)
+    t |> equal(hash("ab"), 0xaf81dc4c8634e68cul)
+    t |> equal(hash("abc"), 0x6e9045080be4681dul)
+    t |> equal(hash("abcd"), 0x6e2c45080b3a7c1dul)
+    t |> equal(hash("abcde"), 0x6fb5c4ab14617fe8ul)
+    t |> equal(hash("hello world"), 0x408bf6d7388fe711ul)
+    t |> equal(hash("this/is/a/fairly/long/identifier/alpha"), 0xa31f63a5100a123dul)
+    t |> equal(hash("x"), 0xaf63f54c86021707ul)
+    t |> equal(hash("key_0"), 0x63f98bc40fe415bbul)
+    t |> equal(hash("key_15"), 0x64248ac4102d2508ul)
+}
+
+[test]
 def test_hash_builder4(t : T?) {
     var fake <- Faker()
     fuzz() {

--- a/tests/strings/strings_hash.das
+++ b/tests/strings/strings_hash.das
@@ -51,6 +51,20 @@ def test_hash_string_reference(t : T?) {
 }
 
 [test]
+def test_hash_string_runtime(t : T?) {
+    // Same pins as test_hash_string_reference, but keys are built at runtime and read
+    // back through a heap array so the JIT hash intrinsic cannot const-fold them — this
+    // exercises the actual 16-bit-load loop (not the folded immediate), bit-for-bit.
+    var ks : array<string>
+    for (i in range(16)) {
+        ks |> push("key_{i}")
+    }
+    t |> equal(hash(ks[0]), 0x63f98bc40fe415bbul)    // "key_0"
+    t |> equal(hash(ks[15]), 0x64248ac4102d2508ul)   // "key_15"
+    delete ks
+}
+
+[test]
 def test_hash_builder4(t : T?) {
     var fake <- Faker()
     fuzz() {

--- a/tests/strings/strings_hash.das
+++ b/tests/strings/strings_hash.das
@@ -55,10 +55,7 @@ def test_hash_string_runtime(t : T?) {
     // Same pins as test_hash_string_reference, but keys are built at runtime and read
     // back through a heap array so the JIT hash intrinsic cannot const-fold them — this
     // exercises the actual 16-bit-load loop (not the folded immediate), bit-for-bit.
-    var ks : array<string>
-    for (i in range(16)) {
-        ks |> push("key_{i}")
-    }
+    var ks <- [for (i in range(16)); "key_{i}"]
     t |> equal(hash(ks[0]), 0x63f98bc40fe415bbul)    // "key_0"
     t |> equal(hash(ks[15]), 0x64248ac4102d2508ul)   // "key_15"
     delete ks

--- a/tests/table_packed/test_packed.das
+++ b/tests/table_packed/test_packed.das
@@ -1,0 +1,163 @@
+options gen2
+
+require dastest/testing_boost
+require strings
+
+// Distinct-pointer key: built fresh each call so query pointers differ from stored
+// ones, forcing a real KeyCompare (not the a==b fast path).
+def dkey(prefix : string; i : int) : string {
+    return "{prefix}_{i}"
+}
+
+def sorted_keys(tab : table<int; int>) : array<int> {
+    var got : array<int>
+    for (k in keys(tab)) {
+        got |> push(k)
+    }
+    sort(got)
+    return <- got
+}
+
+def check_keys(t : T?; tab : table<int; int>; expected : array<int>) {
+    var got <- sorted_keys(tab)
+    t |> equal(length(got), length(expected))
+    if (length(got) == length(expected)) {
+        for (a, b in got, expected) {
+            t |> equal(a, b)
+        }
+    }
+    delete got
+}
+
+[test]
+def test_packed_int_basic(t : T?) {
+    var tab : table<int; int>
+    for (i in range(6)) {              // 6 <= maxLinearCapacity (8) -> packed
+        unsafe(tab[i]) = i * 10
+    }
+    t |> equal(length(tab), 6)
+    for (i in range(6)) {
+        t |> equal(tab?[i] ?? -1, i * 10)        // hit
+    }
+    t |> equal(tab?[99] ?? -1, -1)               // miss
+    t |> equal(key_exists(tab, 3), true)
+    t |> equal(key_exists(tab, 99), false)
+    check_keys(t, tab, [0, 1, 2, 3, 4, 5])
+    unsafe { delete tab; }
+}
+
+[test]
+def test_packed_string(t : T?) {
+    var tab : table<string; int>
+    for (i in range(6)) {
+        unsafe(tab[dkey("k", i)]) = i * 10
+    }
+    for (i in range(6)) {
+        t |> equal(tab?[dkey("k", i)] ?? -1, i * 10)   // distinct-pointer query
+    }
+    t |> equal(tab?[dkey("k", 99)] ?? -1, -1)
+    t |> equal(key_exists(tab, dkey("k", 2)), true)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_packed_promote(t : T?) {
+    // insert past the threshold -> promotes to hashed; everything stays findable
+    var tab : table<int; int>
+    for (i in range(20)) {
+        unsafe(tab[i]) = i * 10
+    }
+    t |> equal(length(tab), 20)
+    for (i in range(20)) {
+        t |> equal(tab?[i] ?? -1, i * 10)
+    }
+    t |> equal(tab?[100] ?? -1, -1)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_packed_erase_swap(t : T?) {
+    // swap-remove: erase first / last / middle; survivors stay findable, iteration complete
+    var tab : table<int; int>
+    for (i in range(6)) {
+        unsafe(tab[i]) = i * 10
+    }
+    t |> equal(erase(tab, 0), true)    // first
+    t |> equal(erase(tab, 5), true)    // last
+    t |> equal(erase(tab, 2), true)    // middle
+    t |> equal(erase(tab, 99), false)  // absent
+    t |> equal(length(tab), 3)
+    t |> equal(tab?[1] ?? -1, 10)
+    t |> equal(tab?[3] ?? -1, 30)
+    t |> equal(tab?[4] ?? -1, 40)
+    t |> equal(key_exists(tab, 0), false)
+    t |> equal(key_exists(tab, 2), false)
+    t |> equal(key_exists(tab, 5), false)
+    check_keys(t, tab, [1, 3, 4])
+    unsafe { delete tab; }
+}
+
+[test]
+def test_packed_erase_reinsert(t : T?) {
+    // dense append after a swap-remove leaves a hole at the tail
+    var tab : table<int; int>
+    for (i in range(4)) {
+        unsafe(tab[i]) = i
+    }
+    t |> equal(erase(tab, 1), true)
+    unsafe(tab[10]) = 100
+    t |> equal(length(tab), 4)
+    t |> equal(tab?[10] ?? -1, 100)
+    t |> equal(tab?[1] ?? -1, -1)
+    check_keys(t, tab, [0, 2, 3, 10])
+    unsafe { delete tab; }
+}
+
+[test]
+def test_packed_grow_then_shrink(t : T?) {
+    // grow past threshold (hashed), erase back below it -> stays hashed & correct (one-way)
+    var tab : table<int; int>
+    for (i in range(20)) {
+        unsafe(tab[i]) = i
+    }
+    for (i in range(18)) {
+        erase(tab, i)
+    }
+    t |> equal(length(tab), 2)
+    t |> equal(tab?[18] ?? -1, 18)
+    t |> equal(tab?[19] ?? -1, 19)
+    t |> equal(key_exists(tab, 0), false)
+    unsafe { delete tab; }
+}
+
+struct PackVal {
+    a : int
+    b : int
+    c : int
+}
+
+[test]
+def test_packed_struct_value(t : T?) {
+    // value larger than a workhorse: exercises valueTypeSize movement in swap-remove + dense copy
+    var tab : table<int; PackVal>
+    for (i in range(5)) {
+        unsafe(tab[i]) = PackVal(a = i, b = i * 2, c = i * 3)
+    }
+    t |> equal(erase(tab, 2), true)   // swap-removes: last entry's PackVal moves into the hole
+    let v3 = unsafe(tab?[3])
+    t |> success(v3 != null)
+    if (v3 != null) {
+        t |> equal(v3.a, 3)
+        t |> equal(v3.b, 6)
+        t |> equal(v3.c, 9)
+    }
+    let v4 = unsafe(tab?[4])
+    t |> success(v4 != null)
+    if (v4 != null) {
+        t |> equal(v4.a, 4)
+        t |> equal(v4.b, 8)
+        t |> equal(v4.c, 12)
+    }
+    t |> equal(key_exists(tab, 2), false)
+    unsafe { delete tab; }
+}

--- a/tests/table_packed/test_packed.das
+++ b/tests/table_packed/test_packed.das
@@ -9,6 +9,11 @@ def dkey(prefix : string; i : int) : string {
     return "{prefix}_{i}"
 }
 
+// Fresh string copy with exact content "k{n}" (distinct pointer each call, forcing real strcmp).
+def kcopy(n : int) : string {
+    return "k{n}"
+}
+
 def sorted_keys(tab : table<int; int>) : array<int> {
     var got : array<int>
     for (k in keys(tab)) {
@@ -57,6 +62,37 @@ def test_packed_string(t : T?) {
     }
     t |> equal(tab?[dkey("k", 99)] ?? -1, -1)
     t |> equal(key_exists(tab, dkey("k", 2)), true)
+    unsafe { delete tab; }
+}
+
+// "k1832" and "k16303" share the same 32-bit table hashKey (0xf9102e8c) but are different
+// strings — found by brute force over uint(hash(s)). Hashes are only 32 bits, so packed string
+// tables must promote on the first such collision (open addressing confirms every hit with a
+// strcmp); the inline packed find relies on at most one slot per hashKey.
+[test]
+def test_packed_string_collision_promotes(t : T?) {
+    var tab : table<string; int>
+    unsafe(tab[kcopy(1832)]) = 111
+    unsafe(tab[kcopy(16303)]) = 222          // same hashKey, different string -> promotes out of packed
+    t |> equal(length(tab), 2)
+    t |> equal(tab?[kcopy(1832)] ?? -1, 111)  // distinct-pointer queries -> real strcmp
+    t |> equal(tab?[kcopy(16303)] ?? -1, 222)
+    t |> equal(key_exists(tab, kcopy(1832)), true)
+    t |> equal(key_exists(tab, kcopy(16303)), true)
+    t |> equal(tab?[kcopy(9999)] ?? -1, -1)
+    unsafe { delete tab; }
+}
+
+// False-positive guard: a single-entry (still packed) table whose only key collides on hashKey
+// with the query must MISS — the packed find confirms the actual string, not just the hash.
+[test]
+def test_packed_string_hash_collision_miss(t : T?) {
+    var tab : table<string; int>
+    unsafe(tab[kcopy(1832)]) = 111            // single entry -> stays packed
+    t |> equal(length(tab), 1)
+    t |> equal(tab?[kcopy(16303)] ?? -777, -777)   // collides on hashKey, must not false-positive
+    t |> equal(key_exists(tab, kcopy(16303)), false)
+    t |> equal(tab?[kcopy(1832)] ?? -1, 111)       // the real key still hits
     unsafe { delete tab; }
 }
 

--- a/tests/table_packed/test_packed.das
+++ b/tests/table_packed/test_packed.das
@@ -66,16 +66,16 @@ def test_packed_string(t : T?) {
 }
 
 // "k1832" and "k16303" share the same 32-bit table hashKey (0xf9102e8c) but are different
-// strings — found by brute force over uint(hash(s)). Hashes are only 32 bits, so packed string
-// tables must promote on the first such collision (open addressing confirms every hit with a
-// strcmp); the inline packed find relies on at most one slot per hashKey.
+// strings (found by brute force over uint(hash(s))). Packed string tables store the full 64-bit
+// hash and compare it exactly, so these two 32-bit-colliding keys coexist in packed mode with no
+// strcmp and no promotion — the 64-bit hashes differ. Both must remain findable with their values.
 [test]
-def test_packed_string_collision_promotes(t : T?) {
+def test_packed_string_hashkey32_collision(t : T?) {
     var tab : table<string; int>
     unsafe(tab[kcopy(1832)]) = 111
-    unsafe(tab[kcopy(16303)]) = 222          // same hashKey, different string -> promotes out of packed
+    unsafe(tab[kcopy(16303)]) = 222
     t |> equal(length(tab), 2)
-    t |> equal(tab?[kcopy(1832)] ?? -1, 111)  // distinct-pointer queries -> real strcmp
+    t |> equal(tab?[kcopy(1832)] ?? -1, 111)  // distinct-pointer queries (clean 64-bit hash compare)
     t |> equal(tab?[kcopy(16303)] ?? -1, 222)
     t |> equal(key_exists(tab, kcopy(1832)), true)
     t |> equal(key_exists(tab, kcopy(16303)), true)
@@ -83,14 +83,14 @@ def test_packed_string_collision_promotes(t : T?) {
     unsafe { delete tab; }
 }
 
-// False-positive guard: a single-entry (still packed) table whose only key collides on hashKey
-// with the query must MISS — the packed find confirms the actual string, not just the hash.
+// False-positive guard: a single-entry packed table whose only key shares a 32-bit hashKey with
+// the query must MISS — the packed find compares the full 64-bit hash, so the 32-bit clash is moot.
 [test]
-def test_packed_string_hash_collision_miss(t : T?) {
+def test_packed_string_hashkey32_miss(t : T?) {
     var tab : table<string; int>
-    unsafe(tab[kcopy(1832)]) = 111            // single entry -> stays packed
+    unsafe(tab[kcopy(1832)]) = 111
     t |> equal(length(tab), 1)
-    t |> equal(tab?[kcopy(16303)] ?? -777, -777)   // collides on hashKey, must not false-positive
+    t |> equal(tab?[kcopy(16303)] ?? -777, -777)   // 32-bit hashKey clash, distinct 64-bit hash -> miss
     t |> equal(key_exists(tab, kcopy(16303)), false)
     t |> equal(tab?[kcopy(1832)] ?? -1, 111)       // the real key still hits
     unsafe { delete tab; }

--- a/tests/table_packed/test_packed.das
+++ b/tests/table_packed/test_packed.das
@@ -1,7 +1,6 @@
 options gen2
 
 require dastest/testing_boost
-require strings
 
 // Distinct-pointer key: built fresh each call so query pointers differ from stored
 // ones, forcing a real KeyCompare (not the a==b fast path).
@@ -15,10 +14,7 @@ def kcopy(n : int) : string {
 }
 
 def sorted_keys(tab : table<int; int>) : array<int> {
-    var got : array<int>
-    for (k in keys(tab)) {
-        got |> push(k)
-    }
+    var got <- [for (k in keys(tab)); k]
     sort(got)
     return <- got
 }
@@ -36,7 +32,7 @@ def check_keys(t : T?; tab : table<int; int>; expected : array<int>) {
 
 [test]
 def test_packed_int_basic(t : T?) {
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via packed index-assign path under test
     for (i in range(6)) {              // 6 <= maxLinearCapacity (8) -> packed
         unsafe(tab[i]) = i * 10
     }
@@ -53,7 +49,7 @@ def test_packed_int_basic(t : T?) {
 
 [test]
 def test_packed_string(t : T?) {
-    var tab : table<string; int>
+    var tab : table<string; int>    // nolint:STYLE027  built via packed index-assign path under test
     for (i in range(6)) {
         unsafe(tab[dkey("k", i)]) = i * 10
     }
@@ -99,7 +95,7 @@ def test_packed_string_hashkey32_miss(t : T?) {
 [test]
 def test_packed_promote(t : T?) {
     // insert past the threshold -> promotes to hashed; everything stays findable
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via index-assign to exercise packed->hashed promotion
     for (i in range(20)) {
         unsafe(tab[i]) = i * 10
     }
@@ -114,7 +110,7 @@ def test_packed_promote(t : T?) {
 [test]
 def test_packed_erase_swap(t : T?) {
     // swap-remove: erase first / last / middle; survivors stay findable, iteration complete
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via index-assign then swap-erased under test
     for (i in range(6)) {
         unsafe(tab[i]) = i * 10
     }
@@ -136,7 +132,7 @@ def test_packed_erase_swap(t : T?) {
 [test]
 def test_packed_erase_reinsert(t : T?) {
     // dense append after a swap-remove leaves a hole at the tail
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via index-assign then erase+reinsert under test
     for (i in range(4)) {
         unsafe(tab[i]) = i
     }
@@ -152,7 +148,7 @@ def test_packed_erase_reinsert(t : T?) {
 [test]
 def test_packed_grow_then_shrink(t : T?) {
     // grow past threshold (hashed), erase back below it -> stays hashed & correct (one-way)
-    var tab : table<int; int>
+    var tab : table<int; int>    // nolint:STYLE027  built via index-assign to exercise grow-then-shrink regime
     for (i in range(20)) {
         unsafe(tab[i]) = i
     }
@@ -175,7 +171,7 @@ struct PackVal {
 [test]
 def test_packed_struct_value(t : T?) {
     // value larger than a workhorse: exercises valueTypeSize movement in swap-remove + dense copy
-    var tab : table<int; PackVal>
+    var tab : table<int; PackVal>    // nolint:STYLE027  built via index-assign to exercise struct-value swap-remove
     for (i in range(5)) {
         unsafe(tab[i]) = PackVal(a = i, b = i * 2, c = i * 3)
     }

--- a/tests/table_packed/test_packed_constkey.das
+++ b/tests/table_packed/test_packed_constkey.das
@@ -1,0 +1,81 @@
+options gen2
+
+require dastest/testing_boost
+
+// Const-string table keys exercise the SimNode_*_WithHash interpreter path: the key bytes and
+// their hash are baked at simulate time, so the lookup skips the per-call hash walk. tab["lit"]
+// and tab?["lit"] are direct intrinsics (ExprAt / ExprSafeAt); find / key_exists go through daslib
+// generic wrappers, so the WithHash nodes for those only fire when __builtin_table_* is called
+// directly (until the wrappers inline) — tested here via the __builtin_ forms.
+
+[test]
+def test_constkey_index(t : T?) {
+    var tab : table<string; int>
+    tab["foo"] = 1                                   // TableIndex_WithHash (insert)
+    tab["bar"] = 2
+    tab["baz"] = 3
+    t |> equal(length(tab), 3)
+    t |> equal(tab["foo"], 1)                         // TableIndex_WithHash (hit, r2v)
+    t |> equal(tab["bar"], 2)
+    t |> equal(tab["baz"], 3)
+    tab["foo"] = 11                                   // overwrite, no new slot
+    t |> equal(tab["foo"], 11)
+    t |> equal(length(tab), 3)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_constkey_safe_index(t : T?) {
+    var tab : table<string; int>
+    tab["foo"] = 1
+    tab["bar"] = 2
+    t |> equal(tab?["foo"] ?? -1, 1)                  // SafeTableIndex_WithHash (hit)
+    t |> equal(tab?["bar"] ?? -1, 2)
+    t |> equal(tab?["missing"] ?? -1, -1)             // SafeTableIndex_WithHash (miss, no insert)
+    t |> equal(length(tab), 2)                        // safe-index miss did not grow the table
+    unsafe { delete tab; }
+}
+
+[test]
+def test_constkey_builtin_key_exists(t : T?) {
+    var tab : table<string; int>
+    tab["foo"] = 1
+    tab["bar"] = 2
+    t |> equal(__builtin_table_key_exists(tab, "foo"), true)    // KeyExists_WithHash (hit)
+    t |> equal(__builtin_table_key_exists(tab, "bar"), true)
+    t |> equal(__builtin_table_key_exists(tab, "missing"), false) // KeyExists_WithHash (miss)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_constkey_builtin_find(t : T?) {
+    var tab : table<string; int>
+    tab["foo"] = 10
+    tab["bar"] = 20
+    let pf = __builtin_table_find(tab, "foo")        // TableFind_WithHash (hit)
+    t |> success(pf != null)
+    if (pf != null) {
+        t |> equal(*(unsafe(reinterpret<int?>(pf))), 10)
+    }
+    let pm = __builtin_table_find(tab, "missing")    // TableFind_WithHash (miss)
+    t |> equal(pm == null, true)
+    unsafe { delete tab; }
+}
+
+// "k1832" and "k16303" share the same 32-bit table hashKey but differ in the full 64-bit hash.
+// As literal keys the WithHash node bakes each one's 64-bit hash, so a packed table holds both
+// with no strcmp and no promotion; each must be found with its own value, and a 32-bit-colliding
+// third literal must miss.
+[test]
+def test_constkey_hashkey32_collision(t : T?) {
+    var tab : table<string; int>
+    tab["k1832"] = 111                               // TableIndex_WithHash
+    tab["k16303"] = 222
+    t |> equal(length(tab), 2)
+    t |> equal(tab?["k1832"] ?? -1, 111)             // SafeTableIndex_WithHash, exact 64-bit hash
+    t |> equal(tab?["k16303"] ?? -1, 222)
+    t |> equal(__builtin_table_key_exists(tab, "k1832"), true)
+    t |> equal(__builtin_table_key_exists(tab, "k16303"), true)
+    t |> equal(tab?["k9999"] ?? -1, -1)
+    unsafe { delete tab; }
+}


### PR DESCRIPTION
## Summary

Makes small string-keyed builtin `table` lookups substantially faster and smaller — the per-entity property maps, config lookups, and JSON-shaped records that dominate real code. No API change; interpreter, AOT, and JIT all benefit.

The work is a stack of four layers:

**1. Packed small-table mode.** A table with `capacity <= TABLE_MAX_LINEAR_CAPACITY` (8) is stored as dense insertion-order slots with a linear scan at load factor 1.0, promoting to open-addressing past the threshold (swap-remove on erase, one-way). Roughly halves memory (cap-8 @ 1.0 vs cap-16 @ 0.5) and speeds up build. Mode is implied by capacity — no flag, no ABI change.

**2. 64-bit packed hash — strcmp eliminated.** Packed tables store a 64-bit hash per slot (uniform across key types — width is a pure function of capacity); large tables keep the 32-bit `TableHashKey`. Packed string find compares the full 64-bit hash **exactly** — no strcmp, no candidate-confirm, no collision-promote (a 64-bit collision between two live keys in an <=8-slot table is not a real-world event). New C++ iteration rail — `tableLiveSlot` / `tableHashSlotBytes` / `table_for_each` — is now the sanctioned way to walk a table's slots; any code reading `tab.hashes` with the old 32-bit stride misindexes a packed table (the dasHV module was the one in-tree offender — fixed).

**3. JIT const-key fast path.** A literal key's hash folds to an immediate; string `?[]` / `[]` / `find` lower through precomputed-hash helpers, and the packed find inlines as an `<8 x i64>` SIMD scan. Integer-key packed find is a pure SIMD key compare (no hash at all).

**4. Interpreter const-key fast path.** The interp analogue of (3): when a table key is an `ExprConstString`, bake its bytes + hash at simulate time into `SimNode_*_WithHash` nodes (skipping the per-lookup `hash_blockz64` byte walk), then OP1-fuse the table-container load so the lookup is a single node. Interpreter-only — JIT/AOT lower from the AST and keep their own const-hash folding.

## Perf — master vs branch (end-to-end, same machine)

Same eight bench files (`benchmarks/core/small_table/test01–08`) run against an un-optimized **master** build and this branch on the same machine. ns/op; single-digit lanes carry ~±1 ns run-to-run noise.

### Strings — the headline (win everywhere)

| lane | INTERP master → PR | JIT master → PR |
|---|---|---|
| find, literal key (`const_long`, 38ch) | 21.5 → **7.6** (−65%) | 41.3 → **2.6** (−94%) |
| find, literal key (`const_short`) | 10.2 → **8.5** (−17%) | 9.2 → **2.4** (−74%) |
| find, runtime key (`var_long`) | 49.9 → **21.6** (−57%) | 41.2 → **22.2** (−46%) |
| find, runtime key (`var_short`) | 15.3 → **11.4** (−25%) | 9.5 → **4.8** (−49%) |
| hit, small (N=8) | 21.5 → **16.3** (−24%) | 11.3 → **4.9** (−57%) |
| query, larger (N=8 of 256) | 28.2 → **15.6** (−45%) | 11.2 → **6.3** (−44%) |
| JSON read, literal keys (`json_find` / `json_at`) | 10.8 / 10.2 → **8.2 / 8.9** | 5.2 / 6.3 → **2.0 / 1.4** (−62% / −78%) |
| JSON read, parsed keys (`bad_json_find` / `bad_json_at`) | 16.2 / 15.0 → **8.6 / 10.0** (−47% / −33%) | 7.4 / 8.0 → **2.5 / 1.3** (−66% / −84%) |

Literal-key string find drops up to **−94% on JIT**. The strcmp tax that const-pooling used to dodge is gone for everyone, so a table built from parsed / IO keys (`bad_json_*`) now reads as fast as one built from string literals — the good/bad gap collapses.

### Integers — mixed, by design

Packed mode swaps hashed O(1) for a dense linear scan. With no strcmp to save, that only pays off where the scan itself is cheap:

| lane | INTERP master → PR | JIT master → PR |
|---|---|---|
| hit, small (N=8, packed) | 9.2 → 10.8 (+17%) | 4.1 → **1.8** (−56%) |
| miss, small (N=8, packed) | 9.7 → 14.0 (+44%) | 4.7 → **1.6** (−66%) |
| hit, large (N=64, hashed) | 13.0 → **10.8** (−17%) | 5.4 → 6.6 (+22%) |
| miss, large (N=64, hashed) | 11.9 → **11.1** (−7%) | 4.4 → 6.5 (+48%) |

- **JIT small int** wins big — the packed find is a branchless SIMD key-scan (−56–66%).
- **Interp small int** regresses on miss (+44%): a scalar 8-wide linear scan vs a hashed quick-reject, with no strcmp to amortize it.
- **Large int in JIT** pays ~+1.5 ns: every lookup loads `capacity` to pick packed-vs-hashed — a dependent load master's direct C++ find doesn't have. (Trimming the gate to a single capacity load was tried and measured neutral — the load itself is the irreducible cost — so it was dropped.)

**Net: string-keyed tables — the PR's target — win across both interpreter and JIT.** Integer tables are a wash (JIT-positive, interp-mixed on small-table miss), and large integer tables in JIT pay a small constant gate. Within-branch tier-by-tier progression and full methodology are in `benchmarks/core/small_table/results.md`.

## Testing

- Full **interpreter** suite (9498 tests) and **JIT** suite (9109 tests) — 0 failed, 0 errors, 0 leaks.
- New `tests/table_packed/` covers packed correctness, swap-remove stability, promotion across the threshold, the 32-bit-hashKey collision pair (proves the 64-bit hash discriminates), and all four WithHash nodes (including via the `__builtin_table_find` / `__builtin_table_key_exists` intrinsics).
- `tests/table_packed/` registered for AOT in `tests/aot/CMakeLists.txt`.
- `benchmarks/core/small_table/` (test01–08) is the measurement harness; methodology + numbers in `results.md`.
- All CI green across the matrix (Windows / Linux / macOS / 32-bit / wasm, including `extended_checks` and `wasm_cross`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)