### PR TITLE
Add ability to schedule strudel track to the nearest tick

### DIFF
--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -279,6 +279,16 @@ def public strudel_debug_voices() {
 
 // --- Track management ---
 
+def private init_track(var track : StrudelTrack?; startTime : double) {
+    track.sched.cps = g_cps
+    track.sched.startTime = startTime
+    track.sched.lastQueryEnd = (g_wall_time - startTime) * g_cps
+    track.sched.sf2 = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
+    if (g_sf2 != null) {
+        init_reverb(track.sched)
+    }
+}
+
 def public strudel_add_track(var pat : Pattern; gain : float = 1.0) : int {
     //! Add a track playing the given pattern at the given gain. Returns its index (matches g_vis_index for visualizer combinators).
     let idx = g_vis_index
@@ -288,12 +298,29 @@ def public strudel_add_track(var pat : Pattern; gain : float = 1.0) : int {
         target_gain = gain
     ))
     var track = g_tracks[length(g_tracks) - 1]
-    track.sched.cps = g_cps
-    track.sched.lastQueryEnd = g_wall_time * g_cps
-    track.sched.sf2 = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
-    if (g_sf2 != null) {
-        init_reverb(track.sched)
+    init_track(track, 0.0lf)
+    // ensure per-track PCM arrays are big enough
+    while (length(g_track_pcm) <= idx) {
+        var empty : array<float>
+        g_track_pcm |> emplace(empty)
     }
+    g_vis_index ++
+    return idx
+}
+
+def public strudel_add_track_immediate(var pat : Pattern; gain : float = 1.0) : int {
+    //! Like strudel_add_track but aligns the track's cycle origin to the current cycle floor,
+    //! guaranteeing that a note at degree 0 fires on the very first scheduler tick.
+    let idx = g_vis_index
+    g_tracks |> push(new StrudelTrack(
+        pat <- pat,
+        gain = gain,
+        target_gain = gain
+    ))
+    var track = g_tracks[length(g_tracks) - 1]
+    let cycleFloor = floor(g_wall_time * g_cps)
+    let alignedStart = g_wall_time - cycleFloor / g_cps
+    init_track(track, alignedStart)
     // ensure per-track PCM arrays are big enough
     while (length(g_track_pcm) <= idx) {
         var empty : array<float>
@@ -414,7 +441,7 @@ def public strudel_tick() {
         if (track == null) continue
         // sync tempo
         if (track.sched.cps != g_cps) {
-            track.sched.lastQueryEnd = g_wall_time * g_cps
+            track.sched.lastQueryEnd = (g_wall_time - track.sched.startTime) * g_cps
             track.sched.cps = g_cps
         }
         tick(track.sched, track.pat, g_bank, g_wall_time, CHUNK_SEC, g_look_ahead)
@@ -499,7 +526,7 @@ def public strudel_tick_offline() {
         if (track == null) continue
         // sync tempo
         if (track.sched.cps != g_cps) {
-            track.sched.lastQueryEnd = g_wall_time * g_cps
+            track.sched.lastQueryEnd = (g_wall_time - track.sched.startTime) * g_cps
             track.sched.cps = g_cps
         }
         tick(track.sched, track.pat, g_bank, g_wall_time, CHUNK_SEC, g_look_ahead)

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -10,7 +10,6 @@ module strudel_player shared public
 //! Manages tracks, BPM/CPS, sample/SF2 banks, and a command stream for both
 //! main-thread (strudel_tick) and dedicated-thread (strudel_play) playback modes.
 
-require strudel/strudel_event
 require strudel/strudel_time
 require strudel/strudel_pattern
 require strudel/strudel_synth
@@ -630,7 +629,7 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
             }
             // sync tempo
             if (track.sched.cps != g_cps) {
-                track.sched.lastQueryEnd = g_wall_time * g_cps
+                track.sched.lastQueryEnd = (g_wall_time - track.sched.startTime) * g_cps
                 track.sched.cps = g_cps
             }
             tick(track.sched, track.pat, *g_bank_ptr, g_wall_time, CHUNK_SEC, g_look_ahead)


### PR DESCRIPTION
## Summary

Adds `strudel_add_track_immediate` — a variant of `strudel_add_track` that aligns the new track's cycle origin to the current cycle floor, so a note at degree 0 fires on the **first** scheduler tick instead of waiting up to a full cycle for the next cycle boundary.

## Why

The scheduler measures pattern time as `current_cycle = (wall_time - startTime) * cps`. A normal track has `startTime = 0`, so adding it mid-cycle starts the first query at a fractional cycle position — a degree-0 note (which lands on integer cycle boundaries) won't fire until the next boundary, up to ~1 cycle late. For one-shots and synced layering you want the pattern to start *now*.

## How

`strudel_add_track_immediate` sets `startTime = wall_time - floor(wall_time * cps) / cps`, which makes `current_cycle(now)` land exactly on the integer `floor(wall_time * cps)`. The first `queryStart` is then an integer cycle boundary, so a degree-0 event fires on the first tick. `strudel_add_track`'s behavior is unchanged (it uses `startTime = 0`).

Shared track setup is factored into a private `init_track(track, startTime)` helper used by both entry points.

The tempo-sync `lastQueryEnd` reset is now `startTime`-aware in all three tick loops (`strudel_tick`, `strudel_tick_offline`, `strudel_play`), so an immediate track doesn't drop events when the tempo changes.