### PR TITLE
JIT packed find: per-key-type codegen (early-out for string, SIMD for int)

### DIFF
--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -457,3 +457,32 @@ against an un-optimized master build — is the final section below / the PR bod
   with a find-with-precomputed-hash seam when we build item 4.
 - **Threshold:** start at 8 (conservative), 16 well-supported by the data. A single
   global value captures most of the win for both key types; per-type is optional polish.
+
+## JIT packed find — per-key-type codegen (SHIPPED, follow-up)
+
+The JIT emitted a branchless `<N x T>` SIMD compare for every packed find. A/B against an
+unrolled scalar early-out (`JIT_PACKED_FIND_{INT,STR}_EARLY_OUT`) shows the optimum is
+**per key type** — `int` keeps SIMD, `string` switches to early-out:
+
+| lane (JIT ns/op) | SIMD | early-out | split |
+|---|---|---|---|
+| int hit/8 | 1.9 | 2.4 | **1.9** |
+| int miss/8 | 1.6 | 3.2 | **1.5** |
+| string hit/8 | 6.2 | 4.6 | **3.8** |
+| string miss/8 | 7.2 | 6.7 | **5.9** |
+| json_find (literal key) | 2.3 | 1.5 | **1.5** (−35%) |
+| bad_json_find (parsed key) | 2.5 | 1.6 | **1.4** (−44%) |
+| json_at | 1.7 | 1.3 | **1.3** |
+
+- **int**: `8×i32` is one cheap 256-bit `vpcmpeqd`, nearly free — and it crushes the
+  early-out on a **miss** (early-out scans all 8 with an `i<sz` guard, no early exit).
+- **string**: `8×i64` is 512 bits → `2× vpcmpeqq` + a `vextracti128`/`vpackssdw` mask
+  reduction (heavy setup). The scalar early-out exits on the first hit, has no size guard
+  (the packed-string hash tail is always 0), and beats SIMD on the realistic literal-key
+  read by ~35%.
+
+Interp packed find is left on its early-out scan: MSVC has no SLP vectorizer (the fixed
+loop unrolls scalar, `/Qvec-report` reason 1100), and a branchless rewrite measured 20–42%
+*slower* there (no SIMD + loses the hit early-exit). Even under clang the branchless form
+ties-or-loses the early-out, and `[[likely]]`/`[[unlikely]]` is a no-op (ignored in C++17,
+identical codegen in C++20 — MSVC already lays the match out as a cold forward branch).

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -36,6 +36,15 @@ require llvm/llvm_debug
 
 var active_filenames : table<string>
 
+// Packed-find codegen per key type (measured on benchmarks/core/small_table, JIT):
+//  - INT keys: SIMD wins. 8xi32 is one cheap 256-bit vpcmpeqd, and it crushes early-out on a
+//    miss (early-out scans all 8 with an i<sz guard, no early exit).
+//  - STRING keys: early-out wins. 8xi64 is 512 bits -> 2x vpcmpeqq + mask reduction (heavy);
+//    the scalar early-out exits on the first hit and has no size guard. json_find -35%.
+// Flip + bump LLVM_JIT_CODEGEN_VERSION to re-A/B.
+let JIT_PACKED_FIND_INT_EARLY_OUT = false
+let JIT_PACKED_FIND_STR_EARLY_OUT = true
+
 // VarInfo annotation type on c++ side is `vector`.
 // They cannot be allocated as global variable and require
 // Memory managment - ctors/dtors, same as FileInfo.
@@ -1938,6 +1947,9 @@ class public LlvmJitVisitor : AstVisitor {
     // bitcast to i8, cttz -> first set lane; no match -> -1. Used by both the integer key-scan and
     // the string 64-bit-hash scan (keyElemTy = i64, keysPtr = the hashes array).
     def packed_find_vector_keys(keysPtr : LLVMOpaqueValue?; keyVal : LLVMOpaqueValue?; keyElemTy : LLVMOpaqueType?; sizeI32 : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        if (JIT_PACKED_FIND_INT_EARLY_OUT) {
+            return packed_find_earlyout(keysPtr, keyVal, keyElemTy, sizeI32, true, 1u)
+        }
         var keyVecTy = LLVMVectorType(keyElemTy, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
         var i32VecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
         var kvp = LLVMBuildPointerCast(g_builder, keysPtr, LLVMPointerType(keyVecTy, 0u), "k.vp")
@@ -1962,6 +1974,9 @@ class public LlvmJitVisitor : AstVisitor {
     // 64-bit width) and a real hash is >1, so the tail never matches — unlike the integer key-data
     // scan, whose tail can hold a valid 0 key and needs the size mask. Exact: no strcmp.
     def packed_find_hashes64(hashesPtr : LLVMOpaqueValue?; hash : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+        if (JIT_PACKED_FIND_STR_EARLY_OUT) {
+            return packed_find_earlyout(hashesPtr, hash, types.t_int64, null, false, 8u)
+        }
         var vecTy = LLVMVectorType(types.t_int64, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
         var i32VecTy = LLVMVectorType(types.t_int32, uint(JIT_TABLE_MAX_LINEAR_CAPACITY))
         var hvp = LLVMBuildPointerCast(g_builder, hashesPtr, LLVMPointerType(vecTy, 0u), "h.vp")
@@ -1971,6 +1986,46 @@ class public LlvmJitVisitor : AstVisitor {
         var splat = LLVMBuildShuffleVector(g_builder, ins, LLVMGetUndef(vecTy), LLVMConstNull(i32VecTy), "h.splat")
         var eqv = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, hv, splat, "h.eqv")
         return first_set_lane_or_neg1(LLVMBuildBitCast(g_builder, eqv, types.t_int8, "h.mask"))
+    }
+
+    // Unrolled scalar early-out packed find: for i in [0,N): if ([i<sz when guarded] && elem[i]==q)
+    // return i; -1 if none. Mirrors the C++ PackedPolicy early-out; emitted when the toggle is on.
+    def packed_find_earlyout(elemPtr : LLVMOpaqueValue?; queryVal : LLVMOpaqueValue?; elemTy : LLVMOpaqueType?;
+                             sizeI32 : LLVMOpaqueValue?; useSizeGuard : bool; loadAlign : uint) : LLVMOpaqueValue? {
+        let N = JIT_TABLE_MAX_LINEAR_CAPACITY
+        var parent = LLVMGetBasicBlockParent(LLVMGetInsertBlock(g_builder))
+        var bb_merge = LLVMAppendBasicBlockInContext(g_ctx, parent, "pf.merge")
+        var bb_nf = LLVMAppendBasicBlockInContext(g_ctx, parent, "pf.nf")
+        var checks <- [for (_i in range(N)); LLVMAppendBasicBlockInContext(g_ctx, parent, "pf.chk")]
+        var founds <- [for (_i in range(N)); LLVMAppendBasicBlockInContext(g_ctx, parent, "pf.found")]
+        LLVMBuildBr(g_builder, checks[0])
+        for (i in range(N)) {
+            LLVMPositionBuilderAtEnd(g_builder, checks[i])
+            var ci = types.ConstI32(uint64(i))
+            var ptr = LLVMBuildGEP2(g_builder, elemTy, elemPtr, ci, "pf.gep")
+            var ld = LLVMBuildLoad2(g_builder, elemTy, ptr, "pf.ld")
+            LLVMSetAlignment(ld, loadAlign)
+            var hit = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntEQ, ld, queryVal, "pf.eq")
+            if (useSizeGuard) {
+                var live = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntULT, ci, sizeI32, "pf.live")
+                hit = LLVMBuildAnd(g_builder, hit, live, "pf.hit")
+            }
+            let nextBB = (i + 1 < N) ? checks[i + 1] : bb_nf
+            LLVMBuildCondBr(g_builder, hit, founds[i], nextBB)
+            LLVMPositionBuilderAtEnd(g_builder, founds[i])
+            LLVMBuildBr(g_builder, bb_merge)
+        }
+        LLVMPositionBuilderAtEnd(g_builder, bb_nf)
+        LLVMBuildBr(g_builder, bb_merge)
+        LLVMPositionBuilderAtEnd(g_builder, bb_merge)
+        var phi = LLVMBuildPhi(g_builder, types.t_int32, "pf.idx")
+        var vals <- [for (i in range(N)); types.ConstI32(uint64(i))]
+        vals |> push(types.ConstI32(uint64(-1)))
+        var blks <- [for (i in range(N)); founds[i]]
+        blks |> push(bb_nf)
+        LLVMAddIncoming(phi, vals, blks)
+        unsafe { delete checks; delete founds; delete vals; delete blks; }
+        return phi
     }
 
     // String tab?[key] / find: packed -> inline 64-bit-hash SIMD scan (exact, no strcmp — a 64-bit

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x18ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x19ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 


### PR DESCRIPTION
## Summary

Follow-up to #3013. The JIT packed (small-table) find emitted a branchless `<N x T>` SIMD compare for **every** key type. Benchmarking that against an unrolled scalar early-out, head to head on `benchmarks/core/small_table`, shows the optimum is **per key type** — `int` keeps SIMD, `string` switches to early-out. No interpreter or AOT change; no API change.

## Why per-type

- **int keys → SIMD.** `8×i32` is one cheap 256-bit `vpcmpeqd`, nearly free, and it beats the scalar early-out decisively on a **miss** (early-out scans all 8 slots with an `i<sz` guard and no early exit).
- **string keys → early-out.** `8×i64` is 512 bits, which lowers to `2× vpcmpeqq` + a `vextracti128`/`vpackssdw` mask reduction — heavy setup. The scalar early-out exits on the first hit, has no size guard (the packed-string hash tail is always 0, and a real hash is >1, so the tail never matches), and wins on the realistic literal-key read.

## Perf (JIT, ns/op, `benchmarks/core/small_table`)

| lane | SIMD (before) | early-out | **split (this PR)** |
|---|---|---|---|
| int hit/8 | 1.9 | 2.4 | **1.9** |
| int miss/8 | 1.6 | 3.2 | **1.5** |
| string hit/8 | 6.2 | 4.6 | **3.8** |
| string miss/8 | 7.2 | 6.7 | **5.9** |
| **json_find** (literal key) | 2.3 | 1.5 | **1.5** (−35%) |
| **bad_json_find** (parsed key) | 2.5 | 1.6 | **1.4** (−44%) |
| json_at | 1.7 | 1.3 | **1.3** |

The realistic JSON read (string-keyed) drops ~35-44% with no integer-key regression.

## Implementation

- Adds `packed_find_earlyout` — an unrolled scalar early-out IR builder (per-slot compare → first-hit `phi`, mirroring the C++ `PackedPolicy` early-out) — in `modules/dasLLVM/daslib/llvm_jit.das`.
- Routes it in via two module-level toggles, so the strategies stay A/B-able per type:
  - `JIT_PACKED_FIND_INT_EARLY_OUT = false` (int stays SIMD)
  - `JIT_PACKED_FIND_STR_EARLY_OUT = true` (string switches to early-out)
- Bumps `LLVM_JIT_CODEGEN_VERSION` `0x18 → 0x19` to invalidate cached JIT DLLs.

## Why the interpreter is left on early-out (not in this PR)

For completeness — the same SIMD-vs-early-out question was investigated for the **C++ interpreter** packed find and the answer is the opposite, so it's intentionally unchanged:

- MSVC (the shipping Windows compiler) has **no SLP vectorizer** — the fixed `TABLE_MAX_LINEAR_CAPACITY` loop unrolls to a scalar compare ladder (`/Qvec-report` reason 1100). A branchless rewrite measured **20-42% slower** there (no SIMD + loses the hit early-exit).
- Even under clang the branchless form ties-or-loses the early-out, and `[[likely]]`/`[[unlikely]]` is a no-op for this find (ignored in C++17; under C++20 it produces byte-identical codegen — MSVC already lays the match out as a cold forward branch).

`benchmarks/core/small_table/results.md` records the full analysis.

## Testing

- Full **JIT** suite: `9109 tests, 9103 passed, 0 failed, 0 errors, 6 skipped`.
- `tests/table_packed/` (packed correctness, swap-remove, promotion, the 32-bit-hashKey collision pair, all WithHash nodes) passes under both interpreter and JIT.
- JIT verifier smoke clean (`tests/jit_tests/array.das`, `tests/decs/test_bulk_create.das`).
- Lint clean (0 issues), formatter-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)