### PR TITLE
dasHV: build OpenSSL under clang-cl (VS ClangCL toolset) + clang-cl CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -685,3 +685,75 @@ jobs:
       # is where libclang/cbind is available (same reason as the self-binder).
       run: ./bin/daslang.exe modules/dasClangBind/tests/test_const_preproc.das
 
+  build_windows_clangcl:
+  ###########################################################
+  # Catches clang-cl (Visual Studio "ClangCL" toolset) build regressions. clang-cl
+  # sets CMake's MSVC=TRUE but uses clang's resource headers, and the toolset puts
+  # that resource include dir on INCLUDE. dasHV builds OpenSSL from source with plain
+  # cl, which rejects clang's #include_next <stdint.h> (C1021) — modules/dasHV/
+  # scrub_clang_include.cmake strips the clang dir from INCLUDE so cl falls back to
+  # MSVC's stdint.h. Without this job that fix — and clang-cl buildability generally —
+  # could silently rot. Same runner pool as the MSVC matrix; separate top-level job.
+  ###########################################################
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: windows-latest-fat
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - name: "Exclude workspace from Defender"
+      shell: pwsh
+      continue-on-error: true
+      run: |
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionProcess "daslang.exe"
+        Add-MpPreference -ExclusionProcess "test_aot.exe"
+
+    - name: "Install nasm (OpenSSL asm)"
+      uses: ilammy/setup-nasm@v1
+
+    # dasHV builds OpenSSL from source here (the path the scrub fix targets), and
+    # nmake is serial — ~7 min. Cache the install so only the first run (or a dasHV
+    # CMakeLists change) pays it; on a hit find_package(OpenSSL) finds it and the
+    # from-source ExternalProject is skipped. (sccache — the matrix's compiler cache
+    # — is not usable here: the VS generator, required for the ClangCL toolset, does
+    # not support CMAKE_CXX_COMPILER_LAUNCHER.)
+    - name: "Cache OpenSSL (clang-cl from-source build)"
+      uses: actions/cache@v4
+      with:
+        path: |
+          build-clangcl/openssl/include
+          build-clangcl/openssl/lib
+          build-clangcl/openssl/bin
+        key: openssl-clangcl-${{ runner.os }}-${{ hashFiles('modules/dasHV/CMakeLists.txt') }}
+
+    - name: "Build: Daslang (clang-cl / VS ClangCL toolset)"
+      shell: pwsh
+      run: |
+        cmake -B build-clangcl -G "Visual Studio 17 2022" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        cmake --build build-clangcl --config Release --parallel
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+
+    - name: "Test: interpreter sweep"
+      shell: pwsh
+      run: |
+        bin\Release\daslang.exe dastest\dastest.das -- --color --failures-only --timeout 900 --test tests
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+
+    - name: "Test: AOT sweep"
+      shell: pwsh
+      run: |
+        cmake --build build-clangcl --config Release --target test_aot --parallel
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        bin\Release\test_aot.exe -use-aot dastest\dastest.das -- --use-aot --color --failures-only --timeout 900 --test tests
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+
+    - name: "Small C++ tests"
+      shell: pwsh
+      run: |
+        cd build-clangcl
+        ctest --build-config Release -L small --output-on-failure
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -25,6 +25,19 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 			set(OPENSSL_LIBRARIES ${OPENSSL_ROOT_DIR}/lib)
 			set(OPENSSL_LIBRARIES_FILES ${OPENSSL_ROOT_DIR}/lib/libcrypto.lib ${OPENSSL_ROOT_DIR}/lib/libssl.lib)
 
+			# clang-cl also satisfies MSVC, but the VS ClangCL toolset puts clang's
+			# resource include (whose <stdint.h>/<vadefs.h> use #include_next) on
+			# INCLUDE; OpenSSL builds with plain cl, which rejects #include_next (C1021).
+			# Run nmake through a wrapper that strips the clang resource dir from INCLUDE
+			# so cl falls back to MSVC's stdint.h. (The strip propagates via env to
+			# nmake's recursive cl children; a `nmake CC=clang-cl` override does not.)
+			IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+				SET(_OSSL_BUILD_CMD ${CMAKE_COMMAND} -P ${DAS_HV_DIR}/scrub_clang_include.cmake -- nmake)
+				SET(_OSSL_INSTALL_CMD ${CMAKE_COMMAND} -P ${DAS_HV_DIR}/scrub_clang_include.cmake -- nmake install_sw)
+			ELSE()
+				SET(_OSSL_BUILD_CMD nmake)
+				SET(_OSSL_INSTALL_CMD nmake install_sw)
+			ENDIF()
 			# Note that under Ninja it should be run from VS developer code Prompt to setup all variables (or call vcvarsall.bat)
 			ExternalProject_Add(openssl_build
 				URL "https://www.openssl.org/source/openssl-3.5.1.tar.gz"
@@ -32,8 +45,8 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 				DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 				PREFIX ${OPENSSL_ROOT_DIR}
 				CONFIGURE_COMMAND perl Configure ${OPENSSL_ARCH} no-shared --prefix=${OPENSSL_ROOT_DIR} --openssldir=${OPENSSL_ROOT_DIR}
-				BUILD_COMMAND nmake
-				INSTALL_COMMAND nmake install_sw
+				BUILD_COMMAND ${_OSSL_BUILD_CMD}
+				INSTALL_COMMAND ${_OSSL_INSTALL_CMD}
 				BUILD_IN_SOURCE 1
 				BUILD_BYPRODUCTS ${OPENSSL_LIBRARIES_FILES}
 			)

--- a/modules/dasHV/scrub_clang_include.cmake
+++ b/modules/dasHV/scrub_clang_include.cmake
@@ -1,0 +1,42 @@
+# Run the command after '--' with clang's resource include dir removed from INCLUDE.
+#
+# Under the VS ClangCL toolset, INCLUDE carries clang's resource headers
+# (.../lib/clang/<ver>/include), whose <stdint.h>/<vadefs.h> use the GNU #include_next.
+# OpenSSL builds with plain `cl` (its VC config), which rejects #include_next (C1021).
+# Stripping INCLUDE here propagates through the process env to nmake's recursive `cl`
+# children, so they fall back to MSVC's stdint.h. (A `nmake CC=clang-cl` override does
+# NOT reach those recursive invocations.)
+
+# Command to run = everything after the literal '--'.
+set(_cmd "")
+set(_sep OFF)
+math(EXPR _last "${CMAKE_ARGC}-1")
+foreach(_i RANGE 0 ${_last})
+    if(_sep)
+        list(APPEND _cmd "${CMAKE_ARGV${_i}}")
+    elseif("${CMAKE_ARGV${_i}}" STREQUAL "--")
+        set(_sep ON)
+    endif()
+endforeach()
+if(NOT _cmd)
+    message(FATAL_ERROR "scrub_clang_include.cmake: no command after '--'. "
+        "Usage: cmake -P scrub_clang_include.cmake -- <command> [args...]")
+endif()
+
+# Drop any INCLUDE entry under a clang resource dir (.../lib/clang/...).
+set(_inc "$ENV{INCLUDE}")
+set(_keep "")
+foreach(_p IN LISTS _inc)
+    file(TO_CMAKE_PATH "${_p}" _pn)
+    string(TOLOWER "${_pn}" _pl)
+    string(FIND "${_pl}" "/lib/clang/" _hit)
+    if(_hit EQUAL -1)
+        list(APPEND _keep "${_p}")
+    endif()
+endforeach()
+set(ENV{INCLUDE} "${_keep}")
+
+execute_process(COMMAND ${_cmd} RESULT_VARIABLE _rv)
+if(_rv)
+    message(FATAL_ERROR "scrub_clang_include: command failed (${_rv}): ${_cmd}")
+endif()


### PR DESCRIPTION
## Summary

Makes dasHV (and daslang generally) build under **clang-cl** (the Visual Studio "ClangCL" toolset) on Windows, and adds a CI job so it can't regress.

## The problem

clang-cl sets CMake's `MSVC=TRUE`, so dasHV takes the MSVC OpenSSL-from-source path (`perl Configure VC-WIN64A` + `nmake`). But the VS ClangCL toolset puts clang's resource include dir (`…/VC/Tools/Llvm/x64/lib/clang/<ver>/include`) on `INCLUDE`, and clang's `<stdint.h>`/`<vadefs.h>` use the GNU `#include_next`. OpenSSL compiles with plain `cl`, which rejects `#include_next`:

```
…/lib/clang/19/include/vadefs.h(18): fatal error C1021: invalid preprocessor command 'include_next'
```

So the whole dasHV build failed under clang-cl (and any clang-cl build of daslang that includes dasHV).

A `nmake CC=clang-cl` override does **not** fix it — OpenSSL's recursive `nmake _build_sw` re-reads `CC=cl`, so the override never reaches the actual compile.

## The fix

Run OpenSSL's `nmake` through a small wrapper, `modules/dasHV/scrub_clang_include.cmake`, that strips clang's resource dir (`…/lib/clang/…`) from `INCLUDE` so `cl` falls back to MSVC's `stdint.h`. The env change **propagates to nmake's recursive `cl` children** (which a `CC=` override does not). Gated on `CMAKE_CXX_COMPILER_ID STREQUAL "Clang"`, so pure-MSVC / mingw-clang / POSIX builds are untouched.

**libhv needed no change** — pinned `5da5fc22` compiles cleanly with clang-cl. OpenSSL's `cl` config was the entire problem.

## CI

Adds `build_windows_clangcl` (VS ClangCL toolset, same runner pool as the MSVC matrix): build all targets → interpreter sweep → AOT sweep → small C++ ctest. So the fix and clang-cl buildability stay covered.

## Validation (local, clang-cl / VS ClangCL toolset, end to end)

- Full all-targets build ✓ (OpenSSL → libhv → dasModuleHV → daslang + all modules + test_aot + tests-cpp)
- **dasHV tests: 136/136** (HTTP client/server, forms, cookies, SSE, websockets — exercises the OpenSSL/clang-cl-compiled TLS + libhv at runtime)
- Interpreter sweep: **9498 tests, 0 failed, 0 errors**
- AOT sweep: **8842 tests, 0 failed, 0 errors**
- Small C++ ctest: **45/45**

## Notes / scope

- The CI job intentionally uses the **VS ClangCL toolset** (not Ninja + clang-cl) because that toolset is what pollutes `INCLUDE` and thus exercises the scrub fix. Ninja + clang-cl from a vcvars env gets a clean `INCLUDE` and wouldn't reproduce the issue.
- LLVM/JIT and dasClangBind are left at their defaults (off) for this first clang-cl job — verifying those under clang-cl is a reasonable follow-up; the core + dasHV coverage is the point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)