### PR TITLE
table: drop the per-slot hash for non-string keys (packed + large)

### DIFF
--- a/benchmarks/core/small_table/results.md
+++ b/benchmarks/core/small_table/results.md
@@ -486,3 +486,57 @@ loop unrolls scalar, `/Qvec-report` reason 1100), and a branchless rewrite measu
 *slower* there (no SIMD + loses the hit early-exit). Even under clang the branchless form
 ties-or-loses the early-out, and `[[likely]]`/`[[unlikely]]` is a no-op (ignored in C++17,
 identical codegen in C++20 — MSVC already lays the match out as a cold forward branch).
+
+## Non-string no-hash — master-vs-branch MEASURED (the workhorse follow-up)
+
+Two commits drop the per-slot hash for NON-STRING keys (strings keep it — they need the
+strcmp skip): **(A)** packed (cap ≤ 8) non-string store no hash at all; **(B)** large
+(cap > 8) non-string replace the 32-bit hash with a 1-byte control state (EMPTY/TOMBSTONE/
+OCCUPIED) and compare keys directly. master = `origin/master` (pre-PR), branch = A+B, same
+machine, same bench files. B/op is the deterministic headline (memory); ns is JIT warm.
+
+### Large tables — `core/table/test02` (N = 64 / 256 / 1024, cache-resident), JIT
+
+| lane | master ns (B/op) | branch ns (B/op) | Δ |
+|---|---|---|---|
+| int_build/64   | 22.2 (44) | 21.4 (**33**) | B/op −25% |
+| int_build/256  | 18.1 (47) | 17.7 (**36**) | B/op −23% |
+| int_build/1024 | 18.0 (48) | 16.4 (**36**) | B/op −25%, −9% ns |
+| int_hit/64     | 6.2 | **5.1** | −18% |
+| int_hit/256    | 6.5 | **6.0** | −8% |
+| int_hit/1024   | 8.7 | **7.9** | −9% |
+| int_miss/64    | 6.7 | **4.9** | −27% |
+| int_miss/256   | 6.2 | **5.1** | −18% |
+| int_miss/1024  | 10.1 | **8.7** | −14% |
+| str_build/1024 | 22.0 (64) | 21.8 (64) | flat (no regression) |
+| str_hit/1024   | 13.4 | 13.8 | flat |
+| str_miss/1024  | 8.2 | 8.7 | flat |
+
+Per-slot int/int large goes 4(val)+4(key)+**4**(hash) → 4+4+**1**(control), i.e. 12→9
+bytes — the **−25% B/op** confirms it (the residual >25% B/op is the grow-chain's
+intermediate allocations). Find/miss drop **−8 to −27%** purely from the denser control
+array (fewer cache lines walked per probe — a cache win, not ALU; the `KeyCompare` is the
+same int `==`). Strings are flat: they keep the 32-bit hash, and the `if constexpr` split
+adds no runtime branch. INTERP shows the same B/op (44→33, −25%) with the per-SimNode
+dispatch floor compressing the ns deltas (e.g. int_miss/64 14.8→12.7).
+
+### Packed tables — `small_table/test04` (4096 × 8) + `test07`, JIT
+
+| lane | master B/op | branch B/op | Δ |
+|---|---|---|---|
+| int_build/8 (t04) | 24 | **16** | **−33%** |
+| str_build/8 (t04) | 28 | 28 | flat (string keeps hash) |
+
+Packed int memory drops **−33%** (the 64-bit hash, 8 bytes/slot, is gone); string packed is
+unchanged. The timing micro-lanes (int/str hit/miss/query/update, 2–19 ns) are dominated by
+run-to-run variance on this machine — repeated warm passes swing ±5 ns and straddle the master
+numbers in both directions (e.g. int_update/8 read 4.5 / 4.4 / 4.7 across one warm triple, then
+3.4 on the next pass, vs master 3.2; str_build/8 similarly 13–19), so there is no measurable
+timing change to report there. Expected: no hot-path code changed — the int packed find already
+read keys (not the hash), and insert delegates to the C++ after-packed-miss helper whose hash
+store is now a no-op. The packed win is memory. (One caveat parked for later: int_update/8 reads
+slightly high on some warm passes with no code mechanism — identical JIT IR, no C++ call on a
+hit — so it looks like DLL-placement noise, but a warm master-vs-branch confirm was deferred.)
+
+**Net:** non-string table memory **−25% (large) / −33% (packed)**, large-table find/miss
+**−8 to −27%**, no string regression on any tier.

--- a/benchmarks/core/table/test02.das
+++ b/benchmarks/core/table/test02.das
@@ -1,0 +1,139 @@
+options gen2
+options persistent_heap
+
+// Large (open-addressed) table benchmarks: N >> TABLE_MAX_LINEAR_CAPACITY (8), so these run on the
+// hashed regime, not the packed small mode (that is core/small_table). They quantify the non-string
+// control-byte change: a large non-string table stores a 1-byte control state per slot instead of a
+// 32-bit hash and compares keys directly. The int lanes show the effect (memory via B/op + cache
+// density on the probe walk); the string lanes guard against regression (strings keep their 32-bit
+// hash). Sizes stay cache-resident so the number reflects the algorithm, not DRAM latency.
+//
+// hit/miss repeat the N-key sweep REPS times (chunk = N*REPS) to amortize fixed harness overhead.
+
+require dastest/testing_boost
+
+let SIZES = [64, 256, 1024]
+let REPS = 16
+
+// ---- int keys (the control-byte change) ----
+
+[benchmark]
+def large_int_build(b : B?) {
+    for (n in SIZES) {
+        b |> run("int_build/{n}", n) {
+            var tab : table<int; int>  // nolint:STYLE027  measuring the build (watch B/op)
+            for (i in range(n)) {
+                unsafe(tab[i]) = i * 2
+            }
+            unsafe { delete tab; }
+        }
+    }
+}
+
+[benchmark]
+def large_int_hit(b : B?) {
+    for (n in SIZES) {
+        var tab <- {for (i in range(n)); i => i * 2}
+        let expected = REPS * (n - 1) * n     // REPS * sum(i*2, i in 0..n-1)
+        b |> run("int_hit/{n}", n * REPS) {
+            var s = 0
+            for (_r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[i] ?? 0
+                }
+            }
+            if (s != expected) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+    }
+}
+
+[benchmark]
+def large_int_miss(b : B?) {
+    for (n in SIZES) {
+        var tab <- {for (i in range(n)); i => i * 2}
+        b |> run("int_miss/{n}", n * REPS) {
+            var s = 0
+            for (_r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[i + n] ?? 0     // keys [n, 2n) were never inserted
+                }
+            }
+            if (s != 0) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+    }
+}
+
+// ---- string keys (no-regression guard; strings keep their 32-bit hash) ----
+
+def build_keys(n : int; prefix : string) : array<string> {
+    var keys <- [for (i in range(n)); "{prefix}_{i}"]
+    return <- keys
+}
+
+[benchmark]
+def large_str_build(b : B?) {
+    for (n in SIZES) {
+        var keys <- build_keys(n, "key")
+        b |> run("str_build/{n}", n) {
+            var tab : table<string; int>  // nolint:STYLE027  measuring the build
+            for (i in range(n)) {
+                unsafe(tab[keys[i]]) = i * 2
+            }
+            unsafe { delete tab; }
+        }
+        delete keys
+    }
+}
+
+[benchmark]
+def large_str_hit(b : B?) {
+    for (n in SIZES) {
+        var keys <- build_keys(n, "key")
+        var probe <- build_keys(n, "key")    // distinct pointers -> real strcmp confirm
+        var tab <- {for (i in range(n)); keys[i] => i * 2}
+        let expected = REPS * (n - 1) * n
+        b |> run("str_hit/{n}", n * REPS) {
+            var s = 0
+            for (_r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[probe[i]] ?? 0
+                }
+            }
+            if (s != expected) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+        delete keys
+        delete probe
+    }
+}
+
+[benchmark]
+def large_str_miss(b : B?) {
+    for (n in SIZES) {
+        var keys <- build_keys(n, "key")
+        var misses <- build_keys(n, "absent")
+        var tab <- {for (i in range(n)); keys[i] => i * 2}
+        b |> run("str_miss/{n}", n * REPS) {
+            var s = 0
+            for (_r in range(REPS)) {
+                for (i in range(n)) {
+                    s += tab?[misses[i]] ?? 0
+                }
+            }
+            if (s != 0) {
+                b->failNow()
+            }
+        }
+        unsafe { delete tab; }
+        delete keys
+        delete misses
+    }
+}

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -166,6 +166,7 @@ namespace das {
                 bool shared : 1;
                 bool hopeless : 1;          // needs to be deleted without fuss (exceptions)
                 bool forego_lock_check : 1; // don't need to check if elements are locked
+                bool tableNoHash : 1;       // Table only: key type stores no per-slot hash (non-string) - see tableHashSlotBytes
             };
             uint32_t flags;
         };

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1855,7 +1855,8 @@ namespace das {
         static __forceinline void clear ( Context * __context__, TTable<TKey,TVal> & tab ) {
             if ( tab.data ) {
                 if ( !tab.isLocked() ) {
-                    uint64_t hashBytes = (tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<TKey>::hashBytes) : uint64_t(sizeof(TableHashKey));
+                    uint64_t hashBytes = (tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<TKey>::hashBytes)
+                        : (PackedPolicy<TKey>::storesHash ? uint64_t(sizeof(TableHashKey)) : uint64_t(1));
                     uint64_t oldSize = uint64_t(tab.capacity)*(sizeof(TKey)+sizeof(TVal)+hashBytes);
                     __context__->free(tab.data, oldSize);
                 } else {

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -71,13 +71,16 @@ namespace das
         return tab.hashes[i] > HASH_KILLED64;
     }
 
-    // Bytes per hash slot, a pure function of capacity for the type-erased table-size
-    // computations (free / GC range) that only have sizes, not a C++ KeyType. PACKED tables hold
-    // 64-bit hashes (so the string find can compare the full hash with no strcmp; non-string keys
-    // store but ignore it — reclaimed in a follow-up), LARGE tables 32-bit. Must agree with
-    // PackedPolicy<KeyType>::hashBytes.
-    __forceinline uint64_t tableHashSlotBytes ( uint64_t capacity ) {
-        return ( capacity <= TABLE_MAX_LINEAR_CAPACITY ) ? uint64_t(sizeof(uint64_t)) : uint64_t(sizeof(TableHashKey));
+    // Bytes per hash slot for the type-erased table-size computations (free / GC range) that have
+    // no C++ KeyType. The width is NOT a pure function of capacity: a non-string key stores no
+    // per-slot hash (tableNoHash flag, set in reserveInternal from PackedPolicy::storesHash), so two
+    // same-capacity tables can differ. PACKED string = 64-bit (full-hash compare, no strcmp); PACKED
+    // non-string = none. LARGE string = 32-bit; LARGE non-string = 0 (commit B: 1-byte control).
+    // Must agree with PackedPolicy<KeyType>::hashBytes and the large-table store width.
+    __forceinline uint64_t tableHashSlotBytes ( const Table & tab ) {
+        if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY )
+            return tab.tableNoHash ? uint64_t(0) : uint64_t(sizeof(uint64_t));
+        return uint64_t(sizeof(TableHashKey));
     }
 
     // Packed tables store 64-bit hashes in the `hashes` block (declared TableHashKey*=uint32_t*).
@@ -117,7 +120,8 @@ namespace das
     //    a 64-bit collision is treated as impossible.
     template <typename KeyType>
     struct PackedPolicy {
-        static constexpr uint32_t hashBytes = sizeof(uint64_t);
+        static constexpr bool storesHash = false;     // non-string packed: no per-slot hash at all
+        static constexpr uint32_t hashBytes = 0;
         static __forceinline int64_t find ( const Table & tab, const KeyType & key, uint64_t ) {
             auto pKeys = (const KeyType *) tab.keys;
             uint32_t sz = (uint32_t) tab.size;
@@ -126,23 +130,18 @@ namespace das
             }
             return -1;
         }
-        static __forceinline void insertHash ( Table & tab, uint64_t slot, uint64_t hash ) {
-            storeHash64(tab.hashes, slot, hash);
-        }
-        static __forceinline void moveHash ( Table & tab, uint64_t to, uint64_t from ) {
-            storeHash64(tab.hashes, to, loadHash64(tab.hashes, from));
-        }
-        static __forceinline void clearHash ( Table & tab, uint64_t slot ) {
-            storeHash64(tab.hashes, slot, 0);
-        }
-        // 64-bit key used to re-bucket into the large (32-bit) target during promotion.
-        static __forceinline uint64_t promoteHash ( const Table & tab, uint64_t slot, const KeyType &, Context * ) {
-            return loadHash64(tab.hashes, slot);
+        static __forceinline void insertHash ( Table &, uint64_t, uint64_t ) {}
+        static __forceinline void moveHash ( Table &, uint64_t, uint64_t ) {}
+        static __forceinline void clearHash ( Table &, uint64_t ) {}
+        // No stored hash: re-derive it from the key to re-bucket into the large target on promotion.
+        static __forceinline uint64_t promoteHash ( const Table &, uint64_t, const KeyType & key, Context * ctx ) {
+            return hash_function(*ctx, key);
         }
     };
 
     template <>
     struct PackedPolicy<char *> {
+        static constexpr bool storesHash = true;
         static constexpr uint32_t hashBytes = sizeof(uint64_t);
         static __forceinline int64_t find ( const Table & tab, char * const &, uint64_t hash ) {
             // All-8 scan: the tail is always 0 (alloc / erase / table_clear clear the full 64-bit
@@ -170,6 +169,7 @@ namespace das
 
     template <>
     struct PackedPolicy<const char *> {
+        static constexpr bool storesHash = true;
         static constexpr uint32_t hashBytes = sizeof(uint64_t);
         static __forceinline int64_t find ( const Table & tab, const char * const &, uint64_t hash ) {
             for ( uint32_t i=0; i!=TABLE_MAX_LINEAR_CAPACITY; ++i ) {
@@ -426,6 +426,11 @@ namespace das
             newTab.lock = tab.lock;
             newTab.magic = 0;
             newTab.flags = tab.flags;
+            // Record the per-slot-hash representation on the instance so the type-erased
+            // tableHashSlotBytes / tableLiveSlot can read it without a KeyType. Constant per
+            // KeyType, so this is idempotent across reallocs (and corrects a fresh table whose
+            // flags started at 0).
+            newTab.tableNoHash = !PackedPolicy<KeyType>::storesHash;
             newTab.tombstones = 0;
             if ( valueTypeSize ) memset(newTab.data, 0, size_t(newCapacity)*size_t(valueTypeSize));
             auto pHashes = newTab.hashes;

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -92,7 +92,8 @@ namespace das
         return tab.tableNoHash ? uint64_t(1) : uint64_t(sizeof(TableHashKey));
     }
 
-    // Packed tables store 64-bit hashes in the `hashes` block (declared TableHashKey*=uint32_t*).
+    // Packed STRING tables store 64-bit hashes in the `hashes` block (declared TableHashKey*=uint32_t*);
+    // packed non-string tables store no hash at all, so these helpers are only used on the string path.
     // Access them via memcpy: a direct ((uint64_t*)hashes)[i] lets clang -O3 assume 8-byte alignment
     // and vectorize the fixed packed-find scan into an aligned 16-byte load that faults on linux/wasm
     // (the block is only 8-aligned). memcpy lowers to the same unaligned load with no UB.
@@ -116,17 +117,15 @@ namespace das
         }
     }
 
-    // Per-key-type policy for the PACKED (small-table) regime: how a packed slot's hash is
-    // compared on find, stored on insert, moved on swap-remove, and read back for promotion, plus
-    // how wide the packed hash array is. TableHash delegates here so its packed paths stay
-    // key-agnostic.
-    // The packed hash array is uint64_t for EVERY key type (uniform width — a pure function of
-    // capacity, so the type-erased free/GC size math stays keytype-free). Only `find` differs:
-    //  - Workhorse keys (this generic): find compares key DATA over the dense [0,size) prefix; the
-    //    stored 64-bit hash is unused on find, kept only so promotion can re-bucket (a follow-up
-    //    will drop it for these keys and reclaim the slot).
-    //  - String keys (specialization): find compares the full 64-bit hash EXACTLY — no strcmp, and
-    //    a 64-bit collision is treated as impossible.
+    // Per-key-type policy for the PACKED (small-table) regime: how a packed slot's hash is compared
+    // on find, stored on insert, moved on swap-remove, and read back for promotion, plus how wide the
+    // packed hash array is (`hashBytes`) and whether one exists at all (`storesHash`). TableHash
+    // delegates here so its packed paths stay key-agnostic; reserveInternal records `!storesHash` in
+    // the table's `tableNoHash` flag so the type-erased free/GC size math can read the width.
+    //  - Workhorse keys (this generic): storesHash=false, hashBytes=0 — NO per-slot hash. find
+    //    compares key DATA over the dense [0,size) prefix; promotion recomputes the hash from the key.
+    //  - String keys (specialization): storesHash=true, 64-bit hash. find compares the full 64-bit
+    //    hash EXACTLY — no strcmp, and a 64-bit collision is treated as impossible.
     template <typename KeyType>
     struct PackedPolicy {
         static constexpr bool storesHash = false;     // non-string packed: no per-slot hash at all
@@ -332,7 +331,7 @@ namespace das
         // that shortcut: it skips the dedup scan and goes straight to the dense append, or
         // promotes to open addressing first if the packed table is full. PRECONDITION: the
         // table is packed and the key is genuinely absent — 0 < capacity <= the linear cap,
-        // and no live slot carries this key's hashKey. Calling it on a non-packed table, or
+        // and no live slot carries this key. Calling it on a non-packed table, or
         // with a key that is actually present, double-inserts. Not a general reserve; use
         // reserve() unless you just did the packed find yourself and it missed.
         __forceinline int64_t reserveAfterPackedMiss ( Table & tab, KeyType key, uint64_t hash, LineInfo * at = nullptr ) {

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -61,13 +61,22 @@ namespace das
         else return hash;
     }
 
+    // Large (open-addressed) NON-STRING tables (tableNoHash) store a 1-byte control state per slot in
+    // place of the 32-bit hash: keys compare cheaply, so the hash earns nothing on find. Values mirror
+    // HASH_EMPTY64 / HASH_KILLED64 so the liveness test stays "control > TOMBSTONE".
+    constexpr static uint8_t CTRL_EMPTY = 0;        // == HASH_EMPTY64
+    constexpr static uint8_t CTRL_TOMBSTONE = 1;    // == HASH_KILLED64
+    constexpr static uint8_t CTRL_OCCUPIED = 2;     // any live slot (no per-slot hash to distinguish)
+
     // Liveness of slot i. Packed tables are dense in [0,size) (insertion order, swap-remove on
-    // erase), so a slot is live iff i<size — no hash read. Large tables are open-addressed: live
-    // iff the 32-bit hash is past the KILLED sentinel. EVERY liveness scan (GC, RTTI/data walk,
-    // iterators) must route through this: a packed STRING table stores 64-bit hashes (PackedPolicy
-    // below), so a raw 32-bit `hashes[i] > KILLED` read would misindex it.
+    // erase), so a slot is live iff i<size — no hash read. Large tables are open-addressed: a string
+    // table is live iff the 32-bit hash is past the KILLED sentinel; a non-string table iff the 1-byte
+    // control is past TOMBSTONE. EVERY liveness scan (GC, RTTI/data walk, iterators) must route through
+    // this: representation varies by capacity AND key type (a packed string table stores 64-bit
+    // hashes), so a raw 32-bit `hashes[i] > KILLED` read would misindex it.
     __forceinline bool tableLiveSlot ( const Table & tab, uint64_t i ) {
         if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) return i < tab.size;
+        if ( tab.tableNoHash ) return ((const uint8_t *) tab.hashes)[i] > CTRL_TOMBSTONE;
         return tab.hashes[i] > HASH_KILLED64;
     }
 
@@ -75,12 +84,12 @@ namespace das
     // no C++ KeyType. The width is NOT a pure function of capacity: a non-string key stores no
     // per-slot hash (tableNoHash flag, set in reserveInternal from PackedPolicy::storesHash), so two
     // same-capacity tables can differ. PACKED string = 64-bit (full-hash compare, no strcmp); PACKED
-    // non-string = none. LARGE string = 32-bit; LARGE non-string = 0 (commit B: 1-byte control).
-    // Must agree with PackedPolicy<KeyType>::hashBytes and the large-table store width.
+    // non-string = none. LARGE string = 32-bit hash; LARGE non-string = 1-byte control (CTRL_*).
+    // Must agree with PackedPolicy<KeyType>::hashBytes and reserveInternal's large store width.
     __forceinline uint64_t tableHashSlotBytes ( const Table & tab ) {
         if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY )
             return tab.tableNoHash ? uint64_t(0) : uint64_t(sizeof(uint64_t));
-        return uint64_t(sizeof(TableHashKey));
+        return tab.tableNoHash ? uint64_t(1) : uint64_t(sizeof(TableHashKey));
     }
 
     // Packed tables store 64-bit hashes in the `hashes` block (declared TableHashKey*=uint32_t*).
@@ -211,19 +220,32 @@ namespace das
             if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed: exact (string 64-bit hash / other data)
                 return PackedPolicy<KeyType>::find(tab, key, hash);
             }
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             auto pKeys = (const KeyType *) tab.keys;
-            auto pHashes = tab.hashes;
             uint64_t mask = tab.capacity - 1;
             uint64_t index = hash & mask;
-            while ( true ) {
-                auto kh = pHashes[index];
-                if ( kh==HASH_EMPTY64 ) {
-                    return -1;
-                } else if ( kh==hashKey && KeyCompare<KeyType>()(pKeys[index],key) ) {
-                    return (int64_t) index;
+            if constexpr ( PackedPolicy<KeyType>::storesHash ) {  // string: 32-bit hash reject + confirm
+                auto hashKey = hashToHashKey(TableHashKey(hash));
+                auto pHashes = tab.hashes;
+                while ( true ) {
+                    auto kh = pHashes[index];
+                    if ( kh==HASH_EMPTY64 ) {
+                        return -1;
+                    } else if ( kh==hashKey && KeyCompare<KeyType>()(pKeys[index],key) ) {
+                        return (int64_t) index;
+                    }
+                    index = (index + 1) & mask;
                 }
-                index = (index + 1) & mask;
+            } else {  // non-string: 1-byte control + direct key compare
+                auto pCtrl = (const uint8_t *) tab.hashes;
+                while ( true ) {
+                    auto c = pCtrl[index];
+                    if ( c==CTRL_EMPTY ) {
+                        return -1;
+                    } else if ( c==CTRL_OCCUPIED && KeyCompare<KeyType>()(pKeys[index],key) ) {
+                        return (int64_t) index;
+                    }
+                    index = (index + 1) & mask;
+                }
             }
         }
 
@@ -252,32 +274,55 @@ namespace das
                 tab.size++;
                 return (int64_t) i;
             }
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             if ( tab.size >= (tab.capacity/2) ) grow(tab, at);
             else if ( (tab.capacity-tab.size)/2 < tab.tombstones ) rehash(tab, at);
             uint64_t mask = tab.capacity - 1;
             uint64_t index = hash & mask;
             uint64_t insertI = ~uint64_t(0);
             auto pKeys = (KeyType *) tab.keys;
-            auto pHashes = tab.hashes;
-            while ( true ) {
-                auto kh = pHashes[index];
-                if (kh == HASH_EMPTY64 ) {
-                    if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
-                    if ( insertI != ~uint64_t(0) ) {
-                        index = insertI;
-                        tab.tombstones--;
+            if constexpr ( PackedPolicy<KeyType>::storesHash ) {  // string: 32-bit hash
+                auto hashKey = hashToHashKey(TableHashKey(hash));
+                auto pHashes = tab.hashes;
+                while ( true ) {
+                    auto kh = pHashes[index];
+                    if (kh == HASH_EMPTY64 ) {
+                        if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
+                        if ( insertI != ~uint64_t(0) ) {
+                            index = insertI;
+                            tab.tombstones--;
+                        }
+                        pHashes[index] = hashKey;
+                        pKeys[index] = key;
+                        tab.size++;
+                        return (int64_t)index;
+                    } else if (kh == HASH_KILLED64) {
+                        if ( insertI == ~uint64_t(0) ) insertI = index;
+                    } else if (kh == hashKey && KeyCompare<KeyType>()(pKeys[index], key)) {
+                        return (int64_t)index;
                     }
-                    pHashes[index] = hashKey;
-                    pKeys[index] = key;
-                    tab.size++;
-                    return (int64_t)index;
-                } else if (kh == HASH_KILLED64) {
-                    if ( insertI == ~uint64_t(0) ) insertI = index;
-                } else if (kh == hashKey && KeyCompare<KeyType>()(pKeys[index], key)) {
-                    return (int64_t)index;
+                    index = (index + 1) & mask;
                 }
-                index = (index + 1) & mask;
+            } else {  // non-string: 1-byte control
+                auto pCtrl = (uint8_t *) tab.hashes;
+                while ( true ) {
+                    auto c = pCtrl[index];
+                    if (c == CTRL_EMPTY ) {
+                        if ( tab.isLocked() ) context->throw_error_at(at, "can't insert into locked table");
+                        if ( insertI != ~uint64_t(0) ) {
+                            index = insertI;
+                            tab.tombstones--;
+                        }
+                        pCtrl[index] = CTRL_OCCUPIED;
+                        pKeys[index] = key;
+                        tab.size++;
+                        return (int64_t)index;
+                    } else if (c == CTRL_TOMBSTONE) {
+                        if ( insertI == ~uint64_t(0) ) insertI = index;
+                    } else if (KeyCompare<KeyType>()(pKeys[index], key)) {  // c == CTRL_OCCUPIED
+                        return (int64_t)index;
+                    }
+                    index = (index + 1) & mask;
+                }
             }
         }
 
@@ -326,23 +371,40 @@ namespace das
                 tab.size--;
                 return (int64_t) i;
             }
-            auto hashKey = hashToHashKey(TableHashKey(hash));
             auto pKeys = (KeyType *) tab.keys;
-            auto pHashes = tab.hashes;
             uint64_t mask = tab.capacity - 1;
             uint64_t index = hash & mask;
-            while ( true ) {
-                auto kh = pHashes[index];
-                if ( kh==HASH_EMPTY64 ) {
-                    return -1;
-                } else if ( kh==hashKey && KeyCompare<KeyType>()(pKeys[index],key) ) {
-                    tab.size--;
-                    tab.tombstones++;
-                    pHashes[index] = HASH_KILLED64;
-                    memset(tab.data + index*valueTypeSize, 0, valueTypeSize);
-                    return (int64_t) index;
+            if constexpr ( PackedPolicy<KeyType>::storesHash ) {  // string: 32-bit hash
+                auto hashKey = hashToHashKey(TableHashKey(hash));
+                auto pHashes = tab.hashes;
+                while ( true ) {
+                    auto kh = pHashes[index];
+                    if ( kh==HASH_EMPTY64 ) {
+                        return -1;
+                    } else if ( kh==hashKey && KeyCompare<KeyType>()(pKeys[index],key) ) {
+                        tab.size--;
+                        tab.tombstones++;
+                        pHashes[index] = HASH_KILLED64;
+                        memset(tab.data + index*valueTypeSize, 0, valueTypeSize);
+                        return (int64_t) index;
+                    }
+                    index = (index + 1) & mask;
                 }
-                index = (index + 1) & mask;
+            } else {  // non-string: 1-byte control
+                auto pCtrl = (uint8_t *) tab.hashes;
+                while ( true ) {
+                    auto c = pCtrl[index];
+                    if ( c==CTRL_EMPTY ) {
+                        return -1;
+                    } else if ( c==CTRL_OCCUPIED && KeyCompare<KeyType>()(pKeys[index],key) ) {
+                        tab.size--;
+                        tab.tombstones++;
+                        pCtrl[index] = CTRL_TOMBSTONE;
+                        memset(tab.data + index*valueTypeSize, 0, valueTypeSize);
+                        return (int64_t) index;
+                    }
+                    index = (index + 1) & mask;
+                }
             }
         }
 
@@ -389,13 +451,19 @@ namespace das
             DAS_ASSERT(hash>1);
             uint64_t mask = tab.capacity - 1;
             uint64_t index = hash & mask;
-            auto pHashes = tab.hashes;
-            while ( true ) {
-                auto kh = pHashes[index];
-                if ( kh==HASH_EMPTY64 ) {
-                    return (int64_t) index;
+            // Called only on a freshly allocated (all-empty, no-tombstone) target during rehash.
+            if constexpr ( PackedPolicy<KeyType>::storesHash ) {
+                auto pHashes = tab.hashes;
+                while ( true ) {
+                    if ( pHashes[index]==HASH_EMPTY64 ) return (int64_t) index;
+                    index = (index + 1) & mask;
                 }
-                index = (index + 1) & mask;
+            } else {
+                auto pCtrl = (const uint8_t *) tab.hashes;
+                while ( true ) {
+                    if ( pCtrl[index]==CTRL_EMPTY ) return (int64_t) index;
+                    index = (index + 1) & mask;
+                }
             }
         }
 
@@ -406,10 +474,12 @@ namespace das
                 return false;
             }
             Table newTab;
-            // Hash-region width is a function of capacity: packed string tables hold 64-bit
-            // hashes (PackedPolicy<char*>::hashBytes), everything else 32-bit.
+            // Hash-region width by (regime x key type): packed string = 64-bit hash, packed non-string
+            // = none (PackedPolicy::hashBytes); large string = 32-bit hash, large non-string = 1-byte
+            // control. Must agree with tableHashSlotBytes.
             bool newPacked = newCapacity <= TABLE_MAX_LINEAR_CAPACITY;
-            uint64_t newHashBytes = newPacked ? uint64_t(PackedPolicy<KeyType>::hashBytes) : uint64_t(sizeof(TableHashKey));
+            uint64_t newHashBytes = newPacked ? uint64_t(PackedPolicy<KeyType>::hashBytes)
+                : (PackedPolicy<KeyType>::storesHash ? uint64_t(sizeof(TableHashKey)) : uint64_t(1));
             uint64_t perSlot = uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + newHashBytes;
             if ( perSlot && newCapacity > UINT64_MAX / perSlot ) {
                 context->throw_error_ex("can't grow table, capacity*perSlot overflows uint64 [capacity=%llu]", (unsigned long long)newCapacity);
@@ -436,24 +506,28 @@ namespace das
             auto pHashes = newTab.hashes;
             memset(pHashes, 0, size_t(newCapacity) * size_t(newHashBytes));
             if ( tab.size ) {
-                // Entries are only ever copied into a LARGE (open-addressed) target: the sole
-                // packed target is the cap-0 -> minCapacity first allocation, which has no
-                // entries. So the target hash store below is always 32-bit. The SOURCE may be
-                // packed (dense [0,size), hash via PackedPolicy::promoteHash) or large (a 32-bit
-                // probe scan over [0,capacity)).
+                // Entries are only ever copied into a LARGE (open-addressed) target: the sole packed
+                // target is the cap-0 -> minCapacity first allocation, which has no entries. So the
+                // target store is the large form for KeyType (string = 32-bit hash, non-string =
+                // 1-byte control). The SOURCE may be packed (dense [0,size), hash via promoteHash) or
+                // large (string: 32-bit probe scan; non-string: control scan + recomputed hash).
                 auto pKeys = (KeyType *) newTab.keys;
                 auto pOldValues = tab.data;
                 auto pValues = newTab.data;
                 auto pOldKeys = (const KeyType *) tab.keys;
-                if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed source: dense
+                if ( tab.capacity <= TABLE_MAX_LINEAR_CAPACITY ) {  // packed source: dense [0,size)
                     for ( uint64_t i=0, is=tab.size; i!=is; ++i ) {
                         uint64_t hash = PackedPolicy<KeyType>::promoteHash(tab, i, pOldKeys[i], context);
                         int64_t index = insertNew(newTab, hash);
-                        pHashes[index] = hashToHashKey(TableHashKey(hash));
+                        if constexpr ( PackedPolicy<KeyType>::storesHash ) {
+                            pHashes[index] = hashToHashKey(TableHashKey(hash));
+                        } else {
+                            ((uint8_t *) newTab.hashes)[index] = CTRL_OCCUPIED;
+                        }
                         pKeys[index] = pOldKeys[i];
                         memcpy ( pValues + index*valueTypeSize, pOldValues + i*valueTypeSize, valueTypeSize );
                     }
-                } else {  // large source: 32-bit hashes, skip empty/killed
+                } else if constexpr ( PackedPolicy<KeyType>::storesHash ) {  // large string source: 32-bit hashes
                     auto pOldHashes = tab.hashes;
                     for ( uint64_t i=0, is=tab.capacity; i!=is; ++i ) {
                         auto hash = pOldHashes[i];
@@ -464,10 +538,22 @@ namespace das
                             memcpy ( pValues + index*valueTypeSize, pOldValues + i*valueTypeSize, valueTypeSize );
                         }
                     }
+                } else {  // large non-string source: 1-byte control, recompute the hash to re-bucket
+                    auto pOldCtrl = (const uint8_t *) tab.hashes;
+                    for ( uint64_t i=0, is=tab.capacity; i!=is; ++i ) {
+                        if ( pOldCtrl[i] > CTRL_TOMBSTONE ) {
+                            uint64_t hash = hash_function(*context, pOldKeys[i]);
+                            int64_t index = insertNew(newTab, hash);
+                            ((uint8_t *) newTab.hashes)[index] = CTRL_OCCUPIED;
+                            pKeys[index] = pOldKeys[i];
+                            memcpy ( pValues + index*valueTypeSize, pOldValues + i*valueTypeSize, valueTypeSize );
+                        }
+                    }
                 }
             }
             if (tab.capacity && !context->verySafeContext) {
-                uint64_t oldHashBytes = (tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<KeyType>::hashBytes) : uint64_t(sizeof(TableHashKey));
+                uint64_t oldHashBytes = (tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<KeyType>::hashBytes)
+                    : (PackedPolicy<KeyType>::storesHash ? uint64_t(sizeof(TableHashKey)) : uint64_t(1));
                 uint64_t oldSize = tab.capacity * (uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + oldHashBytes);
                 context->free(tab.data, oldSize, at);
             }

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x19ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x1aul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1255,7 +1255,7 @@ namespace das
     void builtin_table_free ( Table & tab, int szk, int szv, Context * __context__, LineInfoArg * at ) {
         if ( tab.data ) {
             if ( !tab.isLocked() || tab.hopeless ) {
-                uint64_t oldSize = tab.capacity*(uint64_t(szk)+uint64_t(szv)) + tab.capacity*tableHashSlotBytes(tab.capacity);
+                uint64_t oldSize = tab.capacity*(uint64_t(szk)+uint64_t(szv)) + tab.capacity*tableHashSlotBytes(tab);
                 __context__->free(tab.data, oldSize, at);
             } else {
                 __context__->throw_error_at(at, "can't delete locked table");

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -1275,7 +1275,7 @@ void das_table_clear ( das_context * context, das_table * tab, int key_base_type
         uint32_t key_size = 0;
         DAS_TABLE_DISPATCH(key_base_type, { key_size = sizeof(KEY_TYPE); })
         if ( !key_size ) return; // throw_error already raised
-        uint64_t total = t->capacity * (uint64_t(value_size) + uint64_t(key_size)) + t->capacity*das::tableHashSlotBytes(t->capacity);
+        uint64_t total = t->capacity * (uint64_t(value_size) + uint64_t(key_size)) + t->capacity*das::tableHashSlotBytes(*t);
         ((Context *)context)->free(t->data, total, nullptr);
     }
     memset(t, 0, sizeof(Table));

--- a/src/simulate/runtime_table.cpp
+++ b/src/simulate/runtime_table.cpp
@@ -58,7 +58,7 @@ namespace das
     void table_clear ( Context & context, Table & arr, LineInfo * at ) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't clear locked table");
         if ( arr.data ) {
-            memset(arr.hashes, 0, arr.capacity*tableHashSlotBytes(arr.capacity));
+            memset(arr.hashes, 0, arr.capacity*tableHashSlotBytes(arr));
             memset(arr.data, 0, arr.keys - arr.data);
         }
         arr.size = 0;
@@ -228,7 +228,7 @@ namespace das
         for ( uint32_t i=0, is=total; i!=is; ++i, pTable-- ) {
             if ( pTable->data ) {
                 if ( !pTable->isLocked() ) {
-                    uint64_t oldSize = pTable->capacity * uint64_t(vts_add_kts) + pTable->capacity*tableHashSlotBytes(pTable->capacity);
+                    uint64_t oldSize = pTable->capacity * uint64_t(vts_add_kts) + pTable->capacity*tableHashSlotBytes(*pTable);
                     context.free(pTable->data, oldSize, &debugInfo);
                 } else {
                     context.throw_error_at(debugInfo, "deleting locked table%s", errorMessage);

--- a/src/simulate/runtime_table.cpp
+++ b/src/simulate/runtime_table.cpp
@@ -157,15 +157,19 @@ namespace das
             table_end = data + table->capacity*stride;
             size_t index = nextValid(0);
             data += index * stride;
-            if ( data ) *(KeyType *)_value = *(KeyType *)data;
+            // Only read the key when the slot is real: an empty / fully-erased table lands data at
+            // table_end (one past the keys block). For a non-string packed table the keys block is
+            // the last region (no hash array follows), so dereferencing there is a heap overflow.
+            if ( data != table_end ) *(KeyType *)_value = *(KeyType *)data;
             return (bool) table->size;
         }
         virtual bool next  ( Context &, char * _value ) override {
             size_t index = (data-originData)/stride;
             index = nextValid(index + 1);
             data = originData + index * stride;
-            *(KeyType *)_value = *(KeyType *)data;
-            return data != table_end;
+            bool more = data != table_end;
+            if ( more ) *(KeyType *)_value = *(KeyType *)data;   // skip the past-end read on exhaustion
+            return more;
         }
         virtual void close ( Context & context, char * ) override {
             if ( getData()!=originData ) {

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -391,8 +391,8 @@ namespace das
             popRange();
         }
         virtual void beforeTable ( Table * PT, TypeInfo * ti ) override {
-            auto tsize = (ti->firstType->size + ti->secondType->size) * PT->capacity + tableHashSlotBytes(PT->capacity)*PT->capacity;
-            DAS_ASSERT(tsize==(getTypeSize(ti->firstType)+getTypeSize(ti->secondType))*PT->capacity + tableHashSlotBytes(PT->capacity)*PT->capacity);
+            auto tsize = (ti->firstType->size + ti->secondType->size) * PT->capacity + tableHashSlotBytes(*PT)*PT->capacity;
+            DAS_ASSERT(tsize==(getTypeSize(ti->firstType)+getTypeSize(ti->secondType))*PT->capacity + tableHashSlotBytes(*PT)*PT->capacity);
             char * pa = PT->data;
             PtrRange rdata(pa, tsize);
             if ( reportHeap && tsize && markRange(rdata) ) {
@@ -787,7 +787,7 @@ namespace das
             popRange();
         }
         virtual void beforeTable ( Table * PT, TypeInfo * ti ) override {
-            PtrRange rdata(PT->data, (ti->firstType->size+ti->secondType->size)*size_t(PT->capacity) + size_t(tableHashSlotBytes(PT->capacity))*size_t(PT->capacity));
+            PtrRange rdata(PT->data, (ti->firstType->size+ti->secondType->size)*size_t(PT->capacity) + size_t(tableHashSlotBytes(*PT))*size_t(PT->capacity));
             markAndPushRange(rdata);
         }
         virtual void afterTable ( Table *, TypeInfo * ) override {
@@ -1105,7 +1105,7 @@ namespace das
         virtual void afterTable ( Table * pa, TypeInfo * ti ) override {
             if ( pa->data ) {
                 if ( !pa->isLocked() || pa->hopeless ) {
-                    uint64_t oldSize = pa->capacity*uint64_t(ti->firstType->size+ti->secondType->size) + pa->capacity*tableHashSlotBytes(pa->capacity);
+                    uint64_t oldSize = pa->capacity*uint64_t(ti->firstType->size+ti->secondType->size) + pa->capacity*tableHashSlotBytes(*pa);
                     __context__->free(pa->data, oldSize, __at__);
                 } else {
                     __context__->throw_error_at(__at__, "can't delete locked table");

--- a/tests/table_packed/test_packed_large.das
+++ b/tests/table_packed/test_packed_large.das
@@ -189,3 +189,30 @@ def test_promote_packed_to_large(t : T?) {
     }
     unsafe { delete tab; }
 }
+
+[test]
+def test_keys_iter_packed_no_overread(t : T?) {
+    // Regression: TableKeysIterator must not read the key one-past the keys block. A non-string
+    // packed table has no hash region after keys, so the past-end read on exhaustion / empty
+    // iteration ran off the allocation (ASan heap-buffer-overflow). Cover a full iteration (the
+    // final next lands on table_end) and an emptied table (first lands on table_end).
+    var tab : table<int; int>    // nolint:STYLE027  packed table iterated under test
+    for (i in range(5)) {
+        unsafe(tab[i]) = i
+    }
+    var n1 = 0
+    for (_k in keys(tab)) {
+        n1++
+    }
+    t |> equal(n1, 5)
+    for (i in range(5)) {
+        erase(tab, i)
+    }
+    t |> equal(length(tab), 0)
+    var n2 = 0
+    for (_k in keys(tab)) {
+        n2++
+    }
+    t |> equal(n2, 0)
+    unsafe { delete tab; }
+}

--- a/tests/table_packed/test_packed_large.das
+++ b/tests/table_packed/test_packed_large.das
@@ -1,0 +1,191 @@
+options gen2
+
+require dastest/testing_boost
+
+// Large (open-addressed) table regression for the non-string control-byte representation
+// (commit B): N > TABLE_MAX_LINEAR_CAPACITY (8) forces promotion past the packed regime, so a
+// non-string table stores a 1-byte control state per slot and compares keys directly. Strings keep
+// their 32-bit hash; the string lane here guards that the shared (if-constexpr-split) large-table
+// find/reserve/erase still works.
+
+// Distinct-pointer string key (fresh each call) so queries differ from the stored pointers,
+// forcing a real KeyCompare on the large-table string path.
+def dkey(i : int) : string {
+    return "key_{i}"
+}
+
+def sorted_int_keys(tab : table<int; int>) : array<int> {
+    var got <- [for (k in keys(tab)); k]
+    sort(got)
+    return <- got
+}
+
+def check_int_keys(t : T?; tab : table<int; int>; expected : array<int>) {
+    var got <- sorted_int_keys(tab)
+    t |> equal(length(got), length(expected))
+    if (length(got) == length(expected)) {
+        for (a, b in got, expected) {
+            t |> equal(a, b)
+        }
+    }
+    delete got
+}
+
+[test]
+def test_large_int_hit_miss(t : T?) {
+    var tab : table<int; int>    // nolint:STYLE027  index-assign builds the large table under test
+    for (i in range(40)) {        // 40 > 8 -> open-addressed
+        unsafe(tab[i]) = i * 10
+    }
+    t |> equal(length(tab), 40)
+    for (i in range(40)) {
+        t |> equal(tab?[i] ?? -1, i * 10)        // hit
+    }
+    t |> equal(tab?[999] ?? -1, -1)              // miss past the end
+    t |> equal(tab?[-7] ?? -1, -1)               // miss (negative key)
+    t |> equal(key_exists(tab, 17), true)
+    t |> equal(key_exists(tab, 100), false)
+    var expected <- [for (i in range(40)); i]
+    check_int_keys(t, tab, expected)
+    delete expected
+    unsafe { delete tab; }
+}
+
+[test]
+def test_large_int_erase_tombstone(t : T?) {
+    var tab : table<int; int>    // nolint:STYLE027  index-assign + erase under test
+    for (i in range(40)) {
+        unsafe(tab[i]) = i
+    }
+    // erase every third key -> tombstones scattered through the probe chains
+    for (i in range(40)) {
+        if (i % 3 == 0) {
+            t |> equal(erase(tab, i), true)
+        }
+    }
+    for (i in range(40)) {
+        if (i % 3 == 0) {
+            t |> equal(tab?[i] ?? -1, -1)        // erased -> miss (probe skips the tombstone)
+            t |> equal(key_exists(tab, i), false)
+        } else {
+            t |> equal(tab?[i] ?? -1, i)         // survivor still findable
+        }
+    }
+    // reinsert the erased keys -> tombstone reuse
+    for (i in range(40)) {
+        if (i % 3 == 0) {
+            unsafe(tab[i]) = i + 1000
+        }
+    }
+    for (i in range(40)) {
+        let want = (i % 3 == 0) ? i + 1000 : i
+        t |> equal(tab?[i] ?? -1, want)
+    }
+    t |> equal(length(tab), 40)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_large_int_grow_rehash(t : T?) {
+    // grow through several doublings; each grow rehashes the control-byte source, recomputing
+    // every live key's hash to re-bucket into the larger target.
+    var tab : table<int; int>    // nolint:STYLE027  index-assign drives repeated grow
+    for (i in range(300)) {
+        unsafe(tab[i]) = i * 2
+    }
+    t |> equal(length(tab), 300)
+    for (i in range(300)) {
+        t |> equal(tab?[i] ?? -1, i * 2)
+    }
+    t |> equal(tab?[300] ?? -1, -1)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_large_int_churn(t : T?) {
+    // insert/erase churn builds tombstones -> same-capacity rehash on the control-byte path.
+    var tab : table<int; int>    // nolint:STYLE027  churn under test
+    let lastRound = 5
+    for (round in range(lastRound + 1)) {
+        for (i in range(50)) {
+            unsafe(tab[i]) = round * 1000 + i
+        }
+        for (i in range(50)) {
+            if (i % 2 == 0) {
+                erase(tab, i)
+            }
+        }
+    }
+    // odd keys carry the last round's value; even keys were erased last
+    for (i in range(50)) {
+        if (i % 2 == 0) {
+            t |> equal(key_exists(tab, i), false)
+        } else {
+            t |> equal(tab?[i] ?? -1, lastRound * 1000 + i)
+        }
+    }
+    unsafe { delete tab; }
+}
+
+[test]
+def test_large_string(t : T?) {
+    var tab : table<string; int>    // nolint:STYLE027  index-assign builds the large string table
+    for (i in range(40)) {
+        unsafe(tab[dkey(i)]) = i * 7
+    }
+    for (i in range(40)) {
+        t |> equal(tab?[dkey(i)] ?? -1, i * 7)   // distinct-pointer query (real KeyCompare)
+    }
+    t |> equal(tab?[dkey(999)] ?? -1, -1)
+    t |> equal(key_exists(tab, dkey(13)), true)
+    t |> equal(erase(tab, dkey(13)), true)
+    t |> equal(key_exists(tab, dkey(13)), false)
+    t |> equal(tab?[dkey(14)] ?? -1, 98)
+    t |> equal(length(tab), 39)
+    unsafe { delete tab; }
+}
+
+struct LargeVal {
+    a : int
+    b : int
+    c : int
+}
+
+[test]
+def test_large_struct_value(t : T?) {
+    // struct value larger than a workhorse: exercises valueTypeSize movement in the large-table
+    // erase + rehash copy.
+    var tab : table<int; LargeVal>    // nolint:STYLE027  struct-value large table under test
+    for (i in range(40)) {
+        unsafe(tab[i]) = LargeVal(a = i, b = i * 2, c = i * 3)
+    }
+    t |> equal(erase(tab, 10), true)
+    t |> equal(erase(tab, 20), true)
+    let v = unsafe(tab?[30])
+    t |> success(v != null)
+    if (v != null) {
+        t |> equal(v.a, 30)
+        t |> equal(v.b, 60)
+        t |> equal(v.c, 90)
+    }
+    t |> equal(key_exists(tab, 10), false)
+    t |> equal(length(tab), 38)
+    unsafe { delete tab; }
+}
+
+[test]
+def test_promote_packed_to_large(t : T?) {
+    // 8 packed entries, then the 9th promotes to open addressing: the packed source copies into the
+    // control-byte target. Every key must survive.
+    var tab : table<int; int>    // nolint:STYLE027  index-assign exercises packed->large promotion
+    for (i in range(8)) {
+        unsafe(tab[i]) = i * 100
+    }
+    t |> equal(length(tab), 8)
+    unsafe(tab[8]) = 800     // 9th insert -> promote
+    t |> equal(length(tab), 9)
+    for (i in range(9)) {
+        t |> equal(tab?[i] ?? -1, i * 100)
+    }
+    unsafe { delete tab; }
+}


### PR DESCRIPTION
## What

For **non-string** `table<K;V>` keys, the find-time confirm is a cheap integer/vec `==` — the same cost as the hash compare it gates — so storing a per-slot hash earns nothing. This drops it in two regimes (two commits, so a regression bisects cleanly). **String keys keep their hash** (it skips `strcmp`).

- **Commit A — packed (cap ≤ 8) non-string: store no hash at all.** Packed mode is dense (`i < size` liveness, swap-remove, no tombstones), so a non-string packed table needs *zero* per-slot metadata. Halves the small-table allocation (int/int cap-8: 128B → 64B) — and small tables dominate real code (per-entity maps, config, decs stores).
- **Commit B — large (cap > 8) non-string: a 1-byte control state instead of the 32-bit hash.** Open addressing still needs per-slot *empty / tombstone / occupied* state — 1 byte, not 4. The home bucket is still `hash(key) & mask`; we stop *storing* the hash, not computing it, and compare key values directly.

## How

The per-slot-hash width is no longer a pure function of capacity (two same-capacity tables differ by key type), which is what blocked the type-erased `tableHashSlotBytes`. Fix: record the representation as a **`tableNoHash` flag on the `Table` instance** (one bit in the existing `flags` union), set once in `TableHash::reserveInternal` from the compile-time `PackedPolicy<KeyType>::storesHash` trait. `tableHashSlotBytes(const Table&)` / `tableLiveSlot` read the flag; their callers (GC mark/free, data walker, C-ABI free, table clear/free) just pass the `Table`. The find/reserve/erase/rehash paths select representation per KeyType via `if constexpr (storesHash)`.

Resulting 4-way matrix: packed-string (64-bit hash) / packed-non-string (none) / large-string (32-bit hash) / large-non-string (1-byte control). All three tiers inherit: AOT `TTable` and the JIT C++ helpers route through `TableHash`; the JIT inlined fast path is packed-only and already reads KEYS, not the hash — so no codegen change beyond a `LLVM_JIT_CODEGEN_VERSION` bump to invalidate cached DLLs against the new layout.

## Tests

`tests/table_packed/test_packed_large.das` (new, AOT-registered): int/string/struct-value large tables — hit/miss, erase + tombstone reuse, grow rehash, insert/erase churn (same-cap rehash), packed→large promotion. All three tiers green: `table_packed` 21/21 interp/jit/aot; full interp 9576 / jit 9187 (0 failed, no GC leaks); aot language 1026/1026.

## Numbers (master vs branch, this machine; B/op is the deterministic headline)

New bench `benchmarks/core/table/test02.das` (large int+string × hit/miss) closes the large-string-no-regression and large-miss gaps. Full tables in `benchmarks/core/small_table/results.md`.

| | memory (B/op) | find/miss |
|---|---|---|
| **Large non-string** | **−25%** (int/int 12→9 bytes/slot) | JIT −8…−27%, interp −10…−29% |
| **Packed non-string** | **−33%** (8-byte hash gone) | flat (no hot-path change) |
| **Strings** | unchanged | flat — no regression on any tier |

Packed micro-timing (2–19 ns lanes) is dominated by run-to-run variance (±5 ns); the packed win is memory. One caveat parked for later: `int_update/8` reads slightly high on some warm passes with no code mechanism (identical JIT IR, no C++ call on a hit) — looks like DLL-placement noise; a warm master-vs-branch confirm was deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)