### PR TITLE
docs+site: link external ImGui modules (dasImguiNodeEditor + dasImguiImplot)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -41,9 +41,16 @@ fi
 
 echo "pre-push: using $DASLANG"
 
-# Formatter: whole tree, verify-only (CI parity).
+# Formatter: whole tree, verify-only (CI parity). Skip build/ and _build/ output
+# dirs — a locally junctioned module's build output (CMake build/, Sphinx _build/
+# with its _downloads copies) is gitignored and never present in CI's fresh clone,
+# but the whole-tree walk would otherwise trip on it. Masks are SEGMENT-bounded
+# (slashes on both sides) so they match the dirs, not source files like
+# string_builder.das; both slash forms cover Windows (\build\) and POSIX (/build/).
 echo "pre-push: formatter --verify ..."
-"$DASLANG" "$ROOT/utils/das-fmt/dasfmt.das" -- --path "$ROOT" --verify
+"$DASLANG" "$ROOT/utils/das-fmt/dasfmt.das" -- --path "$ROOT" --verify \
+    --exclude-mask "/build/" --exclude-mask '\build\' \
+    --exclude-mask "/_build/" --exclude-mask '\_build\'
 
 # Lint: only .das files changed in the pushed range vs remote tip
 # (mirrors CI's `git diff origin/<base>...HEAD`).

--- a/doc/source/external_modules/dasimguiimplot.rst
+++ b/doc/source/external_modules/dasimguiimplot.rst
@@ -1,0 +1,38 @@
+dasImguiImplot
+==============
+
+dasImguiImplot is the daslang binding for `ImPlot
+<https://github.com/epezent/implot>`_, the immediate-mode plotting library for
+Dear ImGui. Like :doc:`dasimguinodeeditor`, it sits beside :doc:`dasimgui` as an
+ImGui-extension binding — it depends on dasImgui and loads alongside it, without
+modifying it.
+
+Where to go
+-----------
+
+* **Documentation**: https://borisbat.github.io/dasImguiImplot/
+* **Repository**: https://github.com/borisbat/dasImguiImplot
+
+What's there
+------------
+
+* Bindings covering the ImPlot item surface — line / scatter / bars / stairs /
+  shaded / stems / inf-lines / error-bars / digital / heatmap / histogram, plus
+  the categorical bar-groups and pie items, over ``float`` / ``double`` / ``int``
+  data.
+* Two wrapper tiers: a thin v1 ``imgui_implot_boost`` and the v2 DSL
+  ``imgui_implot_boost_v2`` with RAII ``plot`` / ``subplots`` scopes, axis setup,
+  ``SetNext*`` styling, colormaps, and interactive drag tools.
+* A snapshot-based test/playwright layer (``imgui_implot_playwright``) that
+  serializes plot state — geometry, axis limits, hovered, mouse-plot-position,
+  legend entries — each frame, so plots are queryable and testable headlessly
+  under ``dastest``.
+* Eleven progressive tutorials, each with a voiced, self-verifying screen
+  recording, runnable as a standalone binary and live-reloaded under
+  ``daslang-live``.
+
+Versioning
+----------
+
+The documentation tracks **ImPlot v0.16**, the release that matches dasImgui's
+pinned Dear ImGui version.

--- a/doc/source/external_modules/dasimguinodeeditor.rst
+++ b/doc/source/external_modules/dasimguinodeeditor.rst
@@ -1,0 +1,34 @@
+dasImguiNodeEditor
+==================
+
+dasImguiNodeEditor is the daslang binding for `imgui-node-editor
+<https://github.com/thedmd/imgui-node-editor>`_, the node/graph editor built on
+Dear ImGui. It sits beside :doc:`dasimgui` as a second ImGui-extension binding —
+it depends on dasImgui and loads alongside it, without modifying it.
+
+Where to go
+-----------
+
+* **Documentation**: https://borisbat.github.io/dasImguiNodeEditor/
+* **Repository**: https://github.com/borisbat/dasImguiNodeEditor
+
+What's there
+------------
+
+* Bindings covering the imgui-node-editor surface — nodes, pins, links, the
+  app-owned editor context, selection, context menus, node drag and link flow,
+  groups, style vars/colors, pin pivots, view operations, the node-background
+  drawlist, canvas theming, and clipboard/shortcuts.
+* A ``boost`` macro layer (``imgui_node_editor_boost_v2``) that wraps the
+  ``Begin*`` / ``End*`` pairs into scoped blocks, mirroring dasImgui's v2 style.
+* A snapshot-based test/playwright layer (``imgui_node_editor_playwright``) that
+  drives the graph headlessly under ``dastest``, so node editors are testable in
+  CI without a GL context.
+* Examples and tutorials, each runnable as a standalone binary and live-reloaded
+  under ``daslang-live``.
+
+Versioning
+----------
+
+The documentation tracks the **v2** surface, matching dasImgui's pinned Dear ImGui
+release.

--- a/doc/source/external_modules/index.rst
+++ b/doc/source/external_modules/index.rst
@@ -9,3 +9,5 @@ module does and where its docs live.
    :maxdepth: 1
 
    dasimgui
+   dasimguinodeeditor
+   dasimguiimplot

--- a/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguiimplot.md
+++ b/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguiimplot.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-06
+tag: dasImguiImplot
+title: 0.6.3 is just around the corner. In the meantime, check out dasImguiImplot — immediate-mode plotting for daslang.
+link: https://borisbat.github.io/dasImguiImplot/
+---

--- a/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguinodeeditor.md
+++ b/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguinodeeditor.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-06
+tag: dasImguiNodeEditor
+title: 0.6.3 is just around the corner. In the meantime, check out dasImguiNodeEditor — node and graph editing on top of dasImgui.
+link: https://borisbat.github.io/dasImguiNodeEditor/
+---


### PR DESCRIPTION
Links the two ImGui-extension bindings into the daslang docs + site, the way dasImgui is linked.

## Docs — `doc/source/external_modules/`
- **`dasimguiimplot.rst`** — new pointer page for [dasImguiImplot](https://borisbat.github.io/dasImguiImplot/) (ImPlot v0.16 binding), mirroring the existing `dasimgui.rst` (intro + Documentation/Repository links + What's there + Versioning).
- **`dasimguinodeeditor.rst`** — new pointer page for [dasImguiNodeEditor](https://borisbat.github.io/dasImguiNodeEditor/). This one had **no** pointer page before — only untracked, locally-generated stdlib artifacts referenced it — so it's added here for parity, leaving the section listing all three siblings.
- **`index.rst`** — toctree now lists `dasimgui`, `dasimguinodeeditor`, `dasimguiimplot`.

Clean Sphinx build (`build succeeded`); the only 2 warnings are pre-existing and unrelated (a stray `generated/openai` toctree ref from local stdlib artifacts).

## Site — `site/_news/`
Two news items spotlighting each module while 0.6.3 bakes, in the format of the existing "0.6.3 is just around the corner" entries, each linking to the module's own docs site.

## Tooling — `.githooks/pre-push`
The whole-tree formatter check (`dasfmt --path ROOT --verify`) descends into a locally-junctioned module's gitignored build output (CMake `build/`, Sphinx `_build/` with its `_downloads` copies), which a fresh CI clone never has — so it tripped on stale artifacts unrelated to any commit. Added segment-bounded `--exclude-mask` entries for `/build/` and `/_build/` (plus the `\…\` Windows forms) so the masks match the *directories*, not source files like `string_builder.das`, keeping the hook in CI parity without scanning build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)