### PR TITLE
flatten: fix multi-site inline local shadowing + add flatten-fuzz fuzzer

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -221,6 +221,18 @@ def private inline_call(var ctx : FlatCtx?; call : ExprCall?; structPred : Expre
         out |> push <| qmacro_expr(${ var $i(argN) = $e(lifted); })
         subst |> replaceVariable(string(p.name)) <| qmacro($i(argN))
     }
+    // Uniquify the callee's own locals per inline. Inlining the same helper at
+    // multiple sites — distinct call sites, or one site multiplied by loop
+    // unrolling — would otherwise emit colliding `var` decls in the single
+    // flattened scope (error[30704]). Mirrors lower_for's per-copy local rename.
+    var seenLocals : array<string>
+    let calleeLocals <- collect_let_names(callee.body)
+    for (ln in calleeLocals) {
+        if (!(seenLocals |> contains(ln))) {
+            seenLocals |> push(ln)
+            subst |> renameVariable(ln, fresh(ctx, "__flat_loc"))
+        }
+    }
     // The callee runs where the caller's full predicate holds — funcLive AND every
     // enclosing loop's break/continue masks AND structPred — all baked into the frame
     // seed. The callee body then lowers with this seed as its base mask and an EMPTY

--- a/tests/flatten/test_flatten_basic.das
+++ b/tests/flatten/test_flatten_basic.das
@@ -79,6 +79,30 @@ def with_builtin(x : int) : int {
     return max(x, 0) + min(x, 5)
 }
 
+// helper WITH a local — inlining it at multiple sites (loop unroll, or two direct
+// call sites) must uniquify the callee's locals, else the copies emit a colliding
+// `var t` in the single flattened scope (error[30704]). Every other helper here is
+// a single-expression return with no locals, so this case was previously uncovered.
+def withlocal(a : int) : int {
+    let t = a * 3
+    let u = t + 1
+    return u * t
+}
+
+[flatten]
+def inline_loop(x : int) : int {
+    var acc = 0
+    for (i in range(3)) {
+        acc += withlocal(x + i)
+    }
+    return acc
+}
+
+[flatten]
+def inline_twice(x : int) : int {
+    return withlocal(x) + withlocal(x + 1)
+}
+
 // ----- differential driver -----
 
 var GRID : array<int>
@@ -118,6 +142,16 @@ def test_flatten_equivalence(t : T?) {
     t |> run("whitelisted builtins") @(t : T?) {
         for (v in GRID) {
             t |> equal(with_builtin_flat(v), with_builtin(v))
+        }
+    }
+    t |> run("helper-with-local inlined across an unrolled loop") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(inline_loop_flat(v), inline_loop(v))
+        }
+    }
+    t |> run("helper-with-local inlined at two direct call sites") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(inline_twice_flat(v), inline_twice(v))
         }
     }
 }

--- a/utils/flatten-fuzz/README.md
+++ b/utils/flatten-fuzz/README.md
@@ -1,0 +1,78 @@
+# flatten-fuzz
+
+A metamorphic differential fuzzer for [`daslib/flatten`](../../daslib/flatten.das).
+
+It generates random daslang functions, compiles them **in-process** (the
+integrated compiler — no subprocess), and checks the flattened twin against the
+pristine original over many integer inputs:
+
+```
+f(x) == f_flat(x)   for all generated f, for all x
+```
+
+`[flatten] def f` leaves `f` untouched (real control flow) and emits the
+branchless `f_flat` twin, so the un-flattened `f` is a **free, independent ground
+truth** that never trusts flatten. The fuzzer is, in effect, an auto-generated,
+randomized, at-scale [`tests/flatten/test_flatten_basic.das`](../../tests/flatten/test_flatten_basic.das).
+
+## Run
+
+```
+daslang utils/flatten-fuzz/main.das -- [flags]
+```
+
+| flag | meaning |
+|---|---|
+| `-s, --seed N` | base RNG seed (default 1) |
+| `-u, --units N` | function pairs per batch (default 20) |
+| `-n, --inputs N` | random inputs per unit (default 40) |
+| `-d, --depth N` | max nesting / expression depth (default 3) |
+| `-b, --batches N` | run seeds `seed .. seed+N-1` (default 1) |
+| `-f, --strict-fold` | enable the `strict_fold` structural oracle + const-density bias |
+| `-k, --keep` | keep the generated temp source (don't delete) |
+| `-L, --log-infer` | emit `options log_infer_passes` in generated source (dump the compiler's per-infer-pass AST) |
+| `-?, --show-help` | help |
+
+`--log-infer` makes the fuzzer a probe for the **compiler** too, not just flatten:
+the per-pass AST dump exposes infer non-convergence / oscillation on
+flatten-generated code. The in-process compiler routes that log into the
+compile-result string (not stdout), so the tool surfaces it explicitly.
+
+Exit code is non-zero if any batch fails. On a mismatch or compile failure the
+offending unit is bisected out and dumped as a standalone reproducer
+(`flatten_fuzz_fail_seed<S>_unit<N>.das`).
+
+## Two oracles
+
+- **Value-differential** (default) — `f(x) == f_flat(x)`. Catches semantic
+  divergence in the mask machinery (early-return / break / continue / nested
+  loops / inlining).
+- **Structural** (`--strict-fold`) — compiles the twins with
+  `[flatten(strict_fold=true)]` and biases the grammar toward constants, so a
+  *missed* constant fold becomes a compile error. This is the "did the fold
+  fire" half that value equivalence can't see.
+
+## Design
+
+- **Integer domain only** — the differential is then *exact* (no float epsilon).
+- **Trap-free** — no `/`, `%`, or array indexing; shift counts masked to `& 31`.
+  Predication executes *both* arms, so a trapping op in an untaken branch would
+  panic in the twin but not the original — an inherent property of predication,
+  not a flatten bug (and the shader backends flatten targets are trap-free
+  anyway).
+- **Mask-biased grammar** — if/elif/else, early return, `range`/const-array
+  loops, break/continue, nested loops, helper inlining, compound assignment.
+  That combinatorial surface is where flatten bugs live.
+- **Pure-functional** — params + locals + return value; no globals (yet).
+
+## Found
+
+- The inlined-callee-local shadowing bug (`inline_call` not uniquifying callee
+  locals across multiple inline sites) — fixed in the same change that added
+  this tool.
+- At `--depth 4+`, deeply-nested constant `for` loops unroll without any
+  expansion cap, so the flattened twin grows exponentially → very slow compiles
+  and a heap-layout-dependent SIGSEGV during the macro. Diagnosis: `lower_for`
+  has no unroll-size guard; the flatten opt passes are bounded but super-linear
+  in body size. The compiler's own `max_infer_passes` (default 50) bounds infer,
+  so this is blowup, not an infinite loop. Default depth is 3 (clean at scale).

--- a/utils/flatten-fuzz/main.das
+++ b/utils/flatten-fuzz/main.das
@@ -1,0 +1,550 @@
+// flatten-fuzz — metamorphic differential fuzzer for daslib/flatten.
+//
+// Generates random trap-free, pure-integer daslang functions, compiles them
+// in-process, and checks the flattened twin against the pristine original over
+// many integer inputs: `f(x) == f_flat(x)` must hold for all x. The un-flattened
+// original is a free, independent ground truth that never trusts flatten.
+//
+// Mask-biased grammar (if/early-return/break/continue/nested loops/inlining) —
+// that combinatorial surface is where flatten bugs live. Integer domain only, so
+// the differential is EXACT. Trap-free (no div/mod/array-index, shift counts
+// masked) because predication executes both arms, and a trapping op in an
+// untaken branch would panic in the twin but not the original.
+options gen2
+
+require daslib/rtti
+require daslib/fio
+require daslib/debugger
+require daslib/random
+require daslib/clargs
+require math
+
+// ===== generator config + state =====
+
+struct GenCfg {
+    maxDepth : int      // expression / nesting depth budget
+    maxStmts : int      // max statements per block
+    literalPct : int    // leaf literal probability (vs in-scope var)
+    constBias : int     // 0..100 — bias toward const subtrees (strict_fold mode)
+}
+
+struct Var {
+    name : string
+    mutable : bool
+}
+
+struct Gen {
+    seed : int4
+    counter : int
+    helperDefs : array<string>  // per-unit accumulator of inlinable helpers
+    unitIdx : int
+    noHelpers : bool            // true while generating a helper body (no nesting)
+    cfg : GenCfg
+}
+
+def rnd(var g : Gen&; n : int) : int {
+    return random_int(g.seed) % n
+}
+
+def chance(var g : Gen&; pct : int) : bool {
+    return rnd(g, 100) < pct
+}
+
+def next_id(var g : Gen&) : int {
+    let i = g.counter
+    g.counter++
+    return i
+}
+
+// ===== expressions / conditions (trap-free integer) =====
+
+def gen_leaf(var g : Gen&; scope : array<Var>) : string {
+    if (empty(scope) || rnd(g, 100) < max(g.cfg.literalPct, g.cfg.constBias)) {
+        return "{rnd(g, 21) - 10}"
+    }
+    return scope[rnd(g, length(scope))].name
+}
+
+def gen_expr(var g : Gen&; scope : array<Var>; depth : int) : string {
+    if (depth <= 0 || chance(g, g.cfg.constBias / 2)) {
+        return gen_leaf(g, scope)
+    }
+    let k = rnd(g, 100)
+    if (k < 55) {
+        let ops = fixed_array("+", "-", "*", "&", "|", "^")
+        let op = ops[rnd(g, length(ops))]
+        let l = gen_expr(g, scope, depth - 1)
+        let r = gen_expr(g, scope, depth - 1)
+        return "({l} {op} {r})"
+    } elif (k < 70) {
+        let op = rnd(g, 2) == 0 ? "<<" : ">>"
+        let l = gen_expr(g, scope, depth - 1)
+        let r = gen_expr(g, scope, depth - 1)
+        return "({l} {op} ({r} & 31))"   // mask shift count: avoid UB
+    } elif (k < 82) {
+        let op = rnd(g, 2) == 0 ? "-" : "~"
+        let e = gen_expr(g, scope, depth - 1)
+        return "({op} {e})"   // space: avoid `--`/`-~` token glue on negative literals
+    }
+    return gen_leaf(g, scope)
+}
+
+def gen_cmp(var g : Gen&; scope : array<Var>) : string {
+    let cmps = fixed_array("<", "<=", ">", ">=", "==", "!=")
+    let op = cmps[rnd(g, length(cmps))]
+    let l = gen_expr(g, scope, 2)
+    let r = gen_expr(g, scope, 2)
+    return "({l} {op} {r})"
+}
+
+def gen_cond(var g : Gen&; scope : array<Var>; depth : int) : string {
+    if (depth <= 0) {
+        return gen_cmp(g, scope)
+    }
+    let k = rnd(g, 100)
+    if (k < 62) {
+        return gen_cmp(g, scope)
+    } elif (k < 86) {
+        let op = rnd(g, 2) == 0 ? "&&" : "||"
+        let l = gen_cond(g, scope, depth - 1)
+        let r = gen_cond(g, scope, depth - 1)
+        return "({l} {op} {r})"
+    }
+    let c = gen_cond(g, scope, depth - 1)
+    return "(!{c})"
+}
+
+// ===== statements / blocks =====
+
+def pick_mutable(var g : Gen&; scope : array<Var>) : string {
+    let muts <- [for (v in scope); v.name; where v.mutable]
+    if (empty(muts)) {
+        return ""
+    }
+    return muts[rnd(g, length(muts))]
+}
+
+// A bare exit terminating an if-branch. break/continue only inside a loop.
+def emit_exit(var g : Gen&; scope : array<Var>; loopDepth : int; indent : string) : string {
+    if (loopDepth > 0) {
+        let k = rnd(g, 3)
+        if (k == 0) {
+            return "{indent}break\n"
+        }
+        if (k == 1) {
+            return "{indent}continue\n"
+        }
+    }
+    return "{indent}return {gen_expr(g, scope, 2)}\n"
+}
+
+// Generate a branch/loop body. `allowExit` permits a single bare trailing exit
+// (the branch unconditionally returns/breaks/continues when taken). Returns the
+// source plus whether a bare exit was appended.
+def gen_branch(var g : Gen&; var scope : array<Var>; depth, loopDepth : int; indent : string; allowExit : bool) : tuple<string; bool> {
+    let mark = length(scope)
+    let n = 1 + rnd(g, g.cfg.maxStmts)
+    var exited = false
+    let s = build_string() $(var w) {
+        for (_j in range(n)) {
+            write(w, gen_stmt(g, scope, depth, loopDepth, indent))
+        }
+        if (allowExit && chance(g, 45)) {
+            write(w, emit_exit(g, scope, loopDepth, indent))
+            exited = true
+        }
+    }
+    resize(scope, mark)
+    return s => exited
+}
+
+// at most ONE branch ever exits, so the if as a whole always falls through →
+// the function's final return stays reachable, no unreachable-code errors.
+def gen_if(var g : Gen&; var scope : array<Var>; depth, loopDepth : int; indent : string) : string {
+    let inner = "{indent}    "
+    var s = "{indent}if ({gen_cond(g, scope, 1)}) \{\n"
+    let thenR = gen_branch(g, scope, depth - 1, loopDepth, inner, true)
+    s += thenR._0
+    s += "{indent}\}\n"
+    let k = rnd(g, 100)
+    if (k < 30) {
+        s += "{indent}elif ({gen_cond(g, scope, 1)}) \{\n"
+        let er = gen_branch(g, scope, depth - 1, loopDepth, inner, !thenR._1)
+        s += er._0
+        s += "{indent}\}\n"
+    } elif (k < 55) {
+        s += "{indent}else \{\n"
+        let er = gen_branch(g, scope, depth - 1, loopDepth, inner, !thenR._1)
+        s += er._0
+        s += "{indent}\}\n"
+    }
+    return s
+}
+
+def gen_loop_source(var g : Gen&) : string {
+    let k = rnd(g, 3)
+    if (k == 0) {
+        return "range({1 + rnd(g, 4)})"
+    }
+    if (k == 1) {
+        let a = rnd(g, 3)
+        let b = a + 1 + rnd(g, 3)
+        return "range({a}, {b})"
+    }
+    return "[{rnd(g, 9) - 4}, {rnd(g, 9) - 4}, {rnd(g, 9) - 4}]"
+}
+
+// loop bodies never bare-exit at top level (allowExit=false) so control always
+// falls through the loop; nested if-branches inside may still break/continue/return.
+def gen_for(var g : Gen&; var scope : array<Var>; depth, loopDepth : int; indent : string) : string {
+    let iv = "i{next_id(g)}"
+    let src = gen_loop_source(g)
+    let inner = "{indent}    "
+    var s = "{indent}for ({iv} in {src}) \{\n"
+    let mark = length(scope)
+    scope |> push(Var(name = iv, mutable = false))
+    let br = gen_branch(g, scope, depth - 1, loopDepth + 1, inner, false)
+    s += br._0
+    resize(scope, mark)
+    s += "{indent}\}\n"
+    return s
+}
+
+// A standalone helper function (inlining surface). No nested helper calls.
+def make_helper(var g : Gen&) : string {
+    let hn = "helper_{g.unitIdx}_{next_id(g)}"
+    let savedNo = g.noHelpers
+    g.noHelpers = true
+    var hscope <- [Var(name = "p0", mutable = false), Var(name = "p1", mutable = false)]   // nolint:LINT003 -- gen_branch mutates scope by-ref
+    let br = gen_branch(g, hscope, min(2, g.cfg.maxDepth), 0, "    ", false)
+    let fin = gen_expr(g, hscope, 2)
+    g.noHelpers = savedNo
+    g.helperDefs |> push("def {hn}(p0, p1 : int) : int \{\n{br._0}    return {fin}\n\}\n\n")
+    return hn
+}
+
+def gen_stmt(var g : Gen&; var scope : array<Var>; depth, loopDepth : int; indent : string) : string {
+    let mut = pick_mutable(g, scope)
+    let canAssign = !empty(mut)
+    let canNest = depth > 0
+    let canBreak = loopDepth > 0
+    let k = rnd(g, 100)
+    if (canNest && k < 22) {
+        return gen_if(g, scope, depth, loopDepth, indent)
+    }
+    if (canNest && k < 34) {
+        return gen_for(g, scope, depth, loopDepth, indent)
+    }
+    if (canAssign && k < 56) {
+        let kk = rnd(g, 6)
+        if (kk == 4) {
+            return "{indent}{mut}++\n"
+        }
+        if (kk == 5) {
+            return "{indent}{mut}--\n"
+        }
+        let ops = fixed_array("=", "+=", "-=", "*=")
+        return "{indent}{mut} {ops[kk]} {gen_expr(g, scope, 2)}\n"
+    }
+    if (k < 74) {
+        return "{indent}return {gen_expr(g, scope, 2)} if ({gen_cond(g, scope, 1)})\n"
+    }
+    if (canBreak && k < 86) {
+        let bc = rnd(g, 2) == 0 ? "break" : "continue"
+        return "{indent}{bc} if ({gen_cond(g, scope, 1)})\n"
+    }
+    if (!g.noHelpers && chance(g, 55)) {
+        let hn = make_helper(g)
+        let a1 = gen_expr(g, scope, 2)
+        let a2 = gen_expr(g, scope, 2)
+        let nm = "v{next_id(g)}"
+        scope |> push(Var(name = nm, mutable = true))
+        return "{indent}var {nm} = {hn}({a1}, {a2})\n"
+    }
+    let nm = "v{next_id(g)}"
+    let e = gen_expr(g, scope, 2)
+    scope |> push(Var(name = nm, mutable = true))
+    return "{indent}var {nm} = {e}\n"
+}
+
+def gen_function_body(var g : Gen&) : string {
+    var scope <- [Var(name = "a", mutable = false), Var(name = "b", mutable = false), Var(name = "c", mutable = false)]
+    let br = gen_branch(g, scope, g.cfg.maxDepth, 0, "    ", false)
+    let fin = gen_expr(g, scope, 3)
+    return "{br._0}    return {fin}\n"
+}
+
+// One self-contained unit: helpers + [flatten] fn (leaves the pristine original
+// AND emits the _flat twin) + an [export,pinvoke] driver calling both.
+def gen_unit(var g : Gen&; idx : int; strict : bool) : string {
+    g.unitIdx = idx
+    resize(g.helperDefs, 0)
+    let body = gen_function_body(g)
+    let ann = strict ? "[flatten(strict_fold=true)]" : "[flatten]"
+    return build_string() $(var w) {
+        for (h in g.helperDefs) {
+            write(w, h)
+        }
+        write(w, "{ann}\ndef cand_{idx}(a, b, c : int) : int \{\n{body}\}\n\n")
+        write(w, "[export, pinvoke]\ndef drive_{idx}(a, b, c : int; var o_orig : int?; var o_flat : int?) \{\n")
+        write(w, "    unsafe \{\n")
+        write(w, "        *o_orig = cand_{idx}(a, b, c)\n")
+        write(w, "        *o_flat = cand_{idx}_flat(a, b, c)\n")
+        write(w, "    \}\n\}\n\n")
+    }
+}
+
+// ===== harness =====
+
+// Set once in main. When true, generated files carry `options log_infer_passes`,
+// which dumps the compiler's per-infer-pass AST — to catch daslang infer bugs
+// (non-convergence / oscillation), not just flatten lowering bugs.
+var g_log_infer = false
+
+// Per-process unique suffix for temp files (set once in main) so concurrent
+// flatten-fuzz runs never clobber each other's generated source / read a stale one.
+var g_tmp_suffix = ""
+
+def tmp_path(kind : string) : string {
+    return path_join(get_das_root(), "_flatten_fuzz_{kind}_{g_tmp_suffix}.das")
+}
+
+def build_file(units : array<string>) : string {
+    return build_string() $(var w) {
+        write(w, "options gen2\n")
+        write(w, "options no_unused_function_arguments = false\n")
+        if (g_log_infer) {
+            write(w, "options log_infer_passes = true\n")
+        }
+        write(w, "require daslib/flatten\n\n")
+        for (u in units) {
+            write(w, u)
+        }
+    }
+}
+
+def write_source(path, src : string) : bool {
+    var ok = false
+    fopen(path, "wb") $(fw) {
+        if (fw == null) {
+            return
+        }
+        ok = true
+        fw |> fwrite(src)
+    }
+    return ok
+}
+
+def gen_inputs(var g : Gen&; n : int) : array<int3> {
+    var res <- [int3(0, 0, 0), int3(1, 1, 1), int3(-1, -1, -1), int3(2, -3, 5), int3(-7, 7, 0)]
+    res |> reserve(length(res) + n)
+    for (_i in range(n)) {
+        res |> push(int3(rnd(g, 201) - 100, rnd(g, 201) - 100, rnd(g, 201) - 100))
+    }
+    return <- res
+}
+
+def try_compile(src : string; var issues : string&) : bool {
+    let tmp = tmp_path("chk")
+    if (!write_source(tmp, src)) {
+        issues = "cannot write temp file {tmp}"
+        return false
+    }
+    var compiled = false
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.ignore_shared_modules = true
+            compile_file(tmp, access, unsafe(addr(mg)), cop) $(ok; _program; iss) {
+                if (!ok) {
+                    issues = string(iss)
+                } else {
+                    compiled = true
+                }
+            }
+        }
+    }
+    remove(tmp)
+    return compiled
+}
+
+def dump_reproducer(unitSrc : string; seedArg, idx : int) {
+    let fn = "flatten_fuzz_fail_seed{seedArg}_unit{idx}.das"
+    if (write_source(fn, build_file([unitSrc]))) {
+        to_log(LOG_ERROR, "  dumped reproducer: {fn}\n")
+    }
+}
+
+// On a batch compile failure, find and dump the offending unit(s).
+def bisect_compile(units : array<string>; seedArg : int) {
+    var found = false
+    for (idx in range(length(units))) {
+        var issues : string
+        if (!try_compile(build_file([units[idx]]), issues)) {
+            found = true
+            to_log(LOG_ERROR, "COMPILE-FAIL unit {idx} (seed {seedArg}):\n{issues}\n")
+            dump_reproducer(units[idx], seedArg, idx)
+        }
+    }
+    if (!found) {
+        to_log(LOG_ERROR, "batch failed to compile but no single unit reproduces it (cross-unit interaction?)\n")
+    }
+}
+
+// Returns (#value mismatches, compiled?).
+def run_batch(units : array<string>; inputs : array<int3>; seedArg : int; keep : bool) : tuple<int; bool> {
+    let nUnits = length(units)
+    let src = build_file(units)
+    let tmp = tmp_path("gen")
+    if (!write_source(tmp, src)) {
+        to_log(LOG_ERROR, "cannot write {tmp}\n")
+        return 0 => false
+    }
+    var mismatches = 0
+    var compiled = false
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.ignore_shared_modules = true
+            compile_file(tmp, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                // log_infer_passes output is routed into `iss` (not stdout) by the
+                // in-process compile, so surface it here when requested.
+                if (g_log_infer && !empty(iss)) {
+                    to_log(LOG_INFO, "{iss}\n")
+                }
+                if (!ok) {
+                    return
+                }
+                compiled = true
+                simulate(program) $(sok; var ctx; serrors) {
+                    if (!sok) {
+                        to_log(LOG_ERROR, "simulate failed:\n{serrors}\n")
+                        return
+                    }
+                    for (idx in range(nUnits)) {
+                        for (inp in inputs) {
+                            var r_orig = 0
+                            var r_flat = 0
+                            unsafe {
+                                invoke_in_context(*ctx, "drive_{idx}", inp.x, inp.y, inp.z, addr(r_orig), addr(r_flat))
+                            }
+                            if (r_orig != r_flat) {
+                                mismatches++
+                                to_log(LOG_ERROR, "MISMATCH unit {idx} a={inp.x} b={inp.y} c={inp.z}: orig={r_orig} flat={r_flat}\n")
+                                dump_reproducer(units[idx], seedArg, idx)
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (keep) {
+        to_log(LOG_INFO, "kept generated source: {tmp}\n")
+    } else {
+        remove(tmp)
+    }
+    return mismatches => compiled
+}
+
+// One batch at a given seed: generate units, compile, run the differential.
+// Returns true on a clean batch. A compile failure triggers bisect+dump (in
+// strict_fold mode that includes missed-fold structural findings).
+def fuzz_one(seedArg, nUnits, nInputs : int; cfg : GenCfg; strict, keep : bool) : bool {
+    var g = Gen(seed = random_seed(seedArg), cfg = cfg)
+    let units <- [for (i in range(nUnits)); gen_unit(g, i, strict)]
+    let inputs <- gen_inputs(g, nInputs)
+    let r = run_batch(units, inputs, seedArg, keep)
+    if (!r._1) {
+        to_log(LOG_ERROR, "seed {seedArg}: batch compile failed — isolating\n")
+        bisect_compile(units, seedArg)
+        return false
+    }
+    if (r._0 == 0) {
+        to_log(LOG_INFO, "seed {seedArg}: PASS ({nUnits} units x {length(inputs)} inputs)\n")
+        return true
+    }
+    to_log(LOG_ERROR, "seed {seedArg}: FAIL ({r._0} unit(s) diverged)\n")
+    return false
+}
+
+[CommandLineArgs]
+struct Config {
+    @clarg_short = "s"
+    @clarg_doc = "Base RNG seed (default 1)"
+    seed : int
+
+    @clarg_short = "u"
+    @clarg_doc = "Units (function pairs) per batch (default 20)"
+    units : int
+
+    @clarg_short = "n"
+    @clarg_doc = "Random inputs per unit (default 40)"
+    inputs : int
+
+    @clarg_short = "d"
+    @clarg_doc = "Max nesting/expression depth (default 3)"
+    depth : int
+
+    @clarg_short = "b"
+    @clarg_doc = "Batches to run, seeds seed..seed+b-1 (default 1)"
+    batches : int
+
+    @clarg_short = "f"
+    @clarg_doc = "strict_fold structural oracle + const-density bias"
+    strict_fold : bool
+
+    @clarg_short = "k"
+    @clarg_doc = "Keep generated temp source (don't delete)"
+    keep : bool
+
+    @clarg_short = "L"
+    @clarg_doc = "Emit 'options log_infer_passes' in generated source (diagnose compiler infer)"
+    log_infer : bool
+
+    @clarg_short = "?"
+    @clarg_name = "show-help"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+[export]
+def main : int {
+    var ar <- parse_args(type<Config>, get_cli_arguments())
+    if (ar |> is_err) {
+        to_log(LOG_ERROR, "error: {ar |> unwrap_err}\n")
+        print_help(get_command_info(type<Config>), "flatten-fuzz")
+        return 2
+    }
+    let cfg_args <- ar |> move_unwrap
+    if (cfg_args.help) {
+        print_help(get_command_info(type<Config>), "flatten-fuzz")
+        return 0
+    }
+    let baseSeed = cfg_args.seed != 0 ? cfg_args.seed : 1
+    let nUnits = cfg_args.units > 0 ? cfg_args.units : 20
+    let nInputs = cfg_args.inputs > 0 ? cfg_args.inputs : 40
+    let depth = cfg_args.depth > 0 ? cfg_args.depth : 3
+    let batches = cfg_args.batches > 0 ? cfg_args.batches : 1
+    let strict = cfg_args.strict_fold
+    g_log_infer = cfg_args.log_infer
+    g_tmp_suffix = "{ref_time_ticks()}"
+    let cfg = GenCfg(maxDepth = depth, maxStmts = 4, literalPct = 40, constBias = strict ? 55 : 0)
+
+    to_log(LOG_INFO, "flatten-fuzz: seeds {baseSeed}..{baseSeed + batches - 1} units={nUnits} inputs/unit~{nInputs} depth={depth} strict_fold={strict}\n")
+    var failed = 0
+    for (b in range(batches)) {
+        if (!fuzz_one(baseSeed + b, nUnits, nInputs, cfg, strict, cfg_args.keep)) {
+            failed++
+        }
+    }
+    if (failed == 0) {
+        to_log(LOG_INFO, "flatten-fuzz: ALL {batches} batch(es) PASS\n")
+        return 0
+    }
+    to_log(LOG_ERROR, "flatten-fuzz: {failed}/{batches} batch(es) FAILED — see dumps\n")
+    return 1
+}


### PR DESCRIPTION
## Summary

Two related things:

1. **Fix** a `daslib/flatten` bug. `inline_call` substituted only the callee's **parameters** into the inlined body, never its **local variables**. So inlining a helper that declares a local at two or more sites — two direct call sites, or one site multiplied by loop unrolling — emitted colliding `var` decls in the single flattened scope → `error[30704]: local variable ... is shadowed`. Every existing test inlined only no-local helpers (`square`, `addk`, `cc`, ...), so the gap was uncovered. The fix mirrors `lower_for`'s per-copy local rename: `collect_let_names` + `renameVariable` + `fresh`. No-local helpers stay byte-identical (empty rename set).

2. **New tool** `utils/flatten-fuzz/` — a metamorphic differential fuzzer for `daslib/flatten` that found the bug above on its first real run.

## The fuzzer

- Generates random trap-free, pure-integer daslang functions, compiles them **in-process** (integrated compiler — no subprocess), and checks the flattened twin against the pristine original over many integer inputs: `f(x) == f_flat(x)`. `[flatten]` leaves `f` untouched, so it is a free, independent ground truth that never trusts flatten.
- **Mask-biased grammar** (if / early-return / break / continue / nested loops / inlining) — the combinatorial surface where flatten bugs live. **Integer domain** keeps the differential exact. **Trap-free** (no div/mod/index, masked shift counts) because predication executes both arms.
- **Batch + bisect** — a value mismatch dumps a minimal reproducer; a compile failure is bisected to the offending unit.
- **Two oracles** — value-differential (default) and the `strict_fold` structural oracle (`--strict-fold`).
- `--log-infer` emits `options log_infer_passes` so the compiler's per-pass infer AST surfaces (the in-process compiler routes that log into the compile-result string, not stdout, so the tool surfaces it explicitly) — turning the fuzzer into a probe for compiler infer bugs too, not just flatten lowering.

CLI via `daslib/clargs`.

## Verification

- Regression test added to `tests/flatten/test_flatten_basic.das` (helper-with-local inlined across an unrolled loop, and at two direct call sites): fails to compile before, passes after.
- All 9 flatten unit test files (interp + JIT), the 61-shader `examples/flatten` regression, and the 12 capability checks are green.
- Fuzzer runs clean at scale (default depth 3, dozens of batches / thousands of differential checks).
- Full `tests/` suite: 10526 passed, 0 failed, 0 errors.

## Known / follow-up (not in this PR)

At `--depth 4+` the fuzzer surfaces unbounded loop-unroll expansion in flatten: deeply-nested constant `for` loops unroll with no size cap, so the flattened twin grows exponentially → very slow compiles and a heap-layout-dependent SIGSEGV during the macro. `lower_for` has no unroll-size guard; the opt passes are bounded but super-linear in body size (the compiler's `max_infer_passes=50` bounds infer, so this is blowup, not an infinite loop). Documented in the tool README; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)