### PR TITLE
recording: keep daslang-live rendering on macOS during capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1259,6 +1259,8 @@ if (NOT ${DAS_TOOLS_DISABLED})
             INSTALL_RPATH "@loader_path/../lib"
             CMAKE_MACOSX_RPATH ON
         )
+        # Foundation: NSProcessInfo, used to disable App Nap at startup (dasImgui #190).
+        TARGET_LINK_LIBRARIES(daslang-live "-framework Foundation")
     elseif(UNIX)
         SET_TARGET_PROPERTIES(daslang-live PROPERTIES
             INSTALL_RPATH "\$ORIGIN/../lib"

--- a/modules/dasOpenGL/opengl/opengl_live.das
+++ b/modules/dasOpenGL/opengl/opengl_live.das
@@ -12,6 +12,7 @@ module opengl_live shared public
 //!   screenshot — captures the current framebuffer to a PNG file
 
 require opengl/opengl
+require glfw
 require live/glfw_live
 require math
 require stbimage
@@ -194,6 +195,16 @@ struct RecordStartResult {
     pbo_count   : int
 }
 
+def private gl_string(name : uint) : string {
+    let p = glGetString(name)
+    return "?" if (p == null)
+    return clone_string(unsafe(reinterpret<string>(p)))
+}
+
+def private log_gl_backend() {
+    to_log(LOG_INFO, "[opengl_live] GL_VENDOR='{gl_string(GL_VENDOR)}' GL_RENDERER='{gl_string(GL_RENDERER)}' GL_VERSION='{gl_string(GL_VERSION)}'")
+}
+
 [live_command(description = "Begin APNG recording. Args: file, fps, max_seconds, pbo_count.")]
 def record_start(input : JsonValue?) : JsonValue? {
     return JV((error = "already recording")) if (recorder_active)
@@ -272,6 +283,13 @@ def record_start(input : JsonValue?) : JsonValue? {
     // the synchronous encode allows; wall-clock speed no longer matters. record_stop
     // restores wall-clock.
     set_fixed_dt(recorder.frame_interval_s)
+    // Drop vsync for the session: a swap must never block on an absent vblank when the
+    // window is offscreen / occluded (macOS headless-runner throttle, dasImgui #190).
+    // record_stop restores it.
+    glfwSwapInterval(0)
+    // Log the GL backend so CI surfaces the recording host's actual video hardware / driver —
+    // diagnostic for the macOS recording-throttle issue (dasImgui #190).
+    log_gl_backend()
     return JV(RecordStartResult(
         file        = args.file,
         fps         = effective_fps,
@@ -319,6 +337,8 @@ def record_stop(_input : JsonValue?) : JsonValue? {
     // Return the host clock to wall-clock immediately, so the drain + any
     // post-record frames run at real time again.
     set_fixed_dt(0.0f)
+    // Restore vsync (record_start dropped it for the recording session).
+    glfwSwapInterval(1)
 
     // Drain any PBOs still in flight (frames seen but not yet read back).
     // Best effort: a failed harvest here breaks the drain loop and leaves the

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -27,6 +27,12 @@
 #include <dlfcn.h>
 #endif
 
+#if defined(__APPLE__)
+#include <objc/objc.h>
+#include <objc/runtime.h>
+#include <objc/message.h>
+#endif
+
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -746,6 +752,36 @@ static void release_single_instance() {
 
 // --- Entry point ---
 
+#if defined(__APPLE__)
+// Disable macOS App Nap for this process. On a headless / offscreen CI runner the
+// daslang-live window is unfocused, so macOS throttles the process during input-less
+// recording holds — the render loop stalls and frame capture flatlines (dasImgui #190).
+// beginActivityWithOptions:NSActivityUserInitiatedAllowingIdleSystemSleep keeps the process
+// at full scheduling for its lifetime (idle *system* sleep is still permitted). Driven via
+// the objc runtime so main.cpp stays plain C++ (no .mm); Foundation is linked on Apple in
+// CMakeLists. No-op if Foundation / NSProcessInfo can't be resolved.
+static void disable_app_nap_macos() {
+    Class piClass = objc_getClass("NSProcessInfo");
+    if (!piClass) return;
+    id processInfo = ((id(*)(Class, SEL))objc_msgSend)(piClass, sel_registerName("processInfo"));
+    if (!processInfo) return;
+    Class strClass = objc_getClass("NSString");
+    if (!strClass) return;
+    id reason = ((id(*)(Class, SEL, const char*))objc_msgSend)(
+        strClass, sel_registerName("stringWithUTF8String:"),
+        "daslang-live: continuous render for recording capture (#190)");
+    const unsigned long long NSActivityUserInitiatedAllowingIdleSystemSleep = 0x00FFFFFFULL;
+    id activity = ((id(*)(id, SEL, unsigned long long, id))objc_msgSend)(
+        processInfo, sel_registerName("beginActivityWithOptions:reason:"),
+        NSActivityUserInitiatedAllowingIdleSystemSleep, reason);
+    if (activity) {
+        // Retain for the process lifetime (no ARC); intentionally never released.
+        ((id(*)(id, SEL))objc_msgSend)(activity, sel_registerName("retain"));
+        tout << "daslang-live: macOS App Nap disabled (NSActivityUserInitiatedAllowingIdleSystemSleep)\n";
+    }
+}
+#endif
+
 int main(int argc, char * argv[]) {
 #if defined(_WIN32) && defined(_DEBUG)
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
@@ -753,6 +789,10 @@ int main(int argc, char * argv[]) {
 
     install_das_crash_handler();
     das::arm_alloc_tracking();
+
+#if defined(__APPLE__)
+    disable_app_nap_macos();
+#endif
 
     // Forward full argv so scripts can read get_user_args() (post-`--` slice).
     // Matches daslang.exe's behavior — daslang-live ignores everything after


### PR DESCRIPTION
## Summary

The macOS-side fix for [dasImgui#190](https://github.com/borisbat/dasImgui/issues/190) — APNG recording frame-capture stalls during input-less holds.

Recording spawns a windowed `daslang-live` host (real GLFW window + GL context, even when the test suite is headless) and captures every rendered frame via `record_tick` (`[before_update]` in `opengl_live.das`). Frame production is gated by the main loop calling `update()`. On a headless/offscreen macOS CI runner the host window is unfocused, so macOS throttles the process during input-less recording holds — `update()` stalls, `record_tick` stops firing, the captured-frame counter flatlines, and the consumer-side content-time wait spins to its cap (a hang). ubuntu/Windows render continuously and are unaffected.

## Changes

- **daslang-live: disable macOS App Nap at startup.** `NSProcessInfo beginActivityWithOptions:NSActivityUserInitiatedAllowingIdleSystemSleep` (idle *system* sleep still permitted) keeps the process at full scheduling regardless of window focus/occlusion. Driven through the objc runtime so `main.cpp` stays plain C++ (no `.mm`); `Foundation` is linked on Apple in CMakeLists. No-op if Foundation/NSProcessInfo can't be resolved. macOS-only.
- **opengl_live `record_start`: drop vsync for the recording session** (`glfwSwapInterval(0)`) so a buffer swap never blocks on an absent vblank for an offscreen window; `record_stop` restores it. Recording is paced by the synchronous encode (fixed-dt lockstep), so vsync isn't needed during capture.
- **opengl_live `record_start`: log the GL backend** (`GL_VENDOR` / `GL_RENDERER` / `GL_VERSION`) so CI surfaces the runner's actual video hardware/driver — a diagnostic for #190.

## Verification (macOS, Apple M1 Max)

- App Nap log fires at startup: `daslang-live: macOS App Nap disabled (...)`.
- GL log fires at `record_start`: `[opengl_live] GL_VENDOR='Apple' GL_RENDERER='Apple M1 Max' GL_VERSION='4.1 Metal - 90.5'`.
- Recording produces frames (data_table: 1069); `opengl_live.das` lints clean; headless integration sample stays green. `glfw_live.das` left untouched.

The exact macOS-runner throttle can only be confirmed on a headless runner (a developer Mac with a live window server renders fine even with a hidden window), so the real validation is the dasImgui macOS CI once this lands. The companion dasImgui doc-note PR (recording-bearing tests must not run under `--isolated-mode`) follows after this merges.

Refs https://github.com/borisbat/dasImgui/issues/190

🤖 Generated with [Claude Code](https://claude.com/claude-code)