### PR TITLE
site: fix news tag chip overlapping title text

### DIFF
--- a/site/files/forge.css
+++ b/site/files/forge.css
@@ -737,7 +737,7 @@ button { font: inherit; border: 0; background: none; color: inherit; cursor: poi
 }
 .forge-news__row {
     display: grid;
-    grid-template-columns: 120px 90px 1fr;
+    grid-template-columns: 120px 150px 1fr;
     gap: 18px;
     padding: 18px 0;
     border-top: 1px solid var(--rule);
@@ -755,6 +755,9 @@ button { font: inherit; border: 0; background: none; color: inherit; cursor: poi
     text-transform: lowercase;
 }
 .forge-news__title { color: var(--fg); font-size: 14.5px; line-height: 1.4; }
+/* Long module-name tags (e.g. dasImguiNodeEditor) must stay inside their grid
+   track — cap at the column width and break rather than overlap the title. */
+.forge-news__row .forge-news__tag { max-width: 100%; overflow-wrap: anywhere; }
 
 /* ───── Blog: listing + post ───── */
 


### PR DESCRIPTION
## Problem

On `daslang.io/#news`, the two latest changelog entries are tagged with module names (`dasImguiNodeEditor`, `dasImguiImplot`). These tags overflowed their fixed 90px grid track and ran **under the title text**:

The `.forge-news__row` grid used `120px 90px 1fr`, but `dasImguiNodeEditor` renders at ~135px and `dasImguiImplot` at ~109px — both wider than the 90px tag column. With `justify-self: start` the chip sizes to its content and spills into the title column.

## Fix

`site/files/forge.css` only:

- Widen the tag column `90px → 150px` so module-name tags fit on one line and titles stay aligned across all rows.
- Add a scoped safety net — `.forge-news__row .forge-news__tag { max-width: 100%; overflow-wrap: anywhere }` — so any *future* tag longer than the column breaks inside its chip instead of overlapping the title again.

Verified live by injecting the same CSS on the deployed page: all affected rows now show a positive gap between chip and title, chips fully contained, columns aligned. The mobile breakpoint (tag drops to its own full-width row) is unaffected, and the blog-meta reuse of `.forge-news__tag` (forge.css:810) is untouched since the safety rule is scoped to `.forge-news__row`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)