### PR TITLE
flatten + memory: 64-bit shoe allocator, unroll cap, copy_prop O(n^3)→O(n^2)

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -98,6 +98,26 @@ def private get_flatten_strict(func : FunctionPtr) : bool {
     return false
 }
 
+//! Default cap on the product of nested constant-loop iteration counts a twin may
+//! unroll to. Unrolling multiplies across nesting (`range(20)^4` = 160k body copies),
+//! so without a bound deep nests blow the heap. 4096 is generous for real shader
+//! unrolling yet far below the blowup zone; `[flatten(max_unroll=N)]` overrides it
+//! per-function, and direct `flatten_function` callers pass their own.
+let public FLATTEN_MAX_UNROLL = 4096
+
+def private get_flatten_max_unroll(func : FunctionPtr) : int {
+    //! Reads the opt-in `[flatten(max_unroll=N)]` argument: the cap on the product of
+    //! nested constant-loop iteration counts the twin may unroll to. Exceeding it is a
+    //! clean compile error, not an exponential-expansion blowup. Default FLATTEN_MAX_UNROLL.
+    for (ann in func.annotations) {
+        if (ann.annotation.name == "flatten") {
+            let mv = find_arg(ann.arguments, "max_unroll")
+            if (mv is tInt) return mv as tInt
+        }
+    }
+    return FLATTEN_MAX_UNROLL
+}
+
 // ===== Predicated lowering (return-elim + if-conversion + call inlining) =====
 //
 // Shared state lives on FlatCtx (one instance per twin, threaded by pointer so
@@ -123,6 +143,8 @@ class private FlatCtx {
     worklist  : array<string>
     loopMasks : array<LoopMask>   // enclosing loops' break/continue masks (innermost last)
     whitelist : table<string>     // leaf-builtin names allowed to survive (backend-supplied)
+    unrollFactor : int            // running product of enclosing loop iteration counts (1 at top)
+    maxUnroll : int               // cap on unrollFactor*count before bailing (FLATTEN_MAX_UNROLL default)
     ok        : bool
     err      : string
 }
@@ -653,6 +675,18 @@ def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : Expressi
         }
         substs <- [for (v in mk.values); clone_expression(v)]
     }
+    // Unrolling multiplies across nesting: this loop emits `length(substs)` body copies
+    // per enclosing iteration, so the running product (int64, overflow-safe) is the true
+    // expansion. Bail BEFORE the clones if it exceeds the cap — converts a heap blowup
+    // into a clean error. Restore the factor on exit so sibling loops start fresh.
+    let projected = int64(ctx.unrollFactor) * int64(length(substs))
+    if (projected > int64(ctx.maxUnroll)) {
+        ctx.ok = false
+        ctx.err = "flatten: loop unrolling exceeds max_unroll={ctx.maxUnroll} (would expand to {projected} iterations); reduce the range/nesting or raise [flatten(max_unroll=N)]"
+        return
+    }
+    let savedFactor = ctx.unrollFactor
+    ctx.unrollFactor = int(projected)
     let van = "{efor.iterators[0]}"
     let localNames <- collect_let_names(efor.body)
     // Allocate break/continue masks only if THIS loop uses them (depth-0 scan).
@@ -691,28 +725,32 @@ def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : Expressi
             if (pushed) {
                 ctx.loopMasks |> pop()
             }
+            ctx.unrollFactor = savedFactor
             return
         }
     }
     if (pushed) {
         ctx.loopMasks |> pop()
     }
+    ctx.unrollFactor = savedFactor
 }
 
 [macro_function]
-def public flatten_function(var func : FunctionPtr; whitelist : table<string>) : FlatCtx? {
+def public flatten_function(var func : FunctionPtr; whitelist : table<string>; maxUnroll : int = FLATTEN_MAX_UNROLL) : FlatCtx? {
     //! Flatten `func`'s body in place to branchless, call-free form: every user
     //! call inlined, all control flow lowered to predicated `?:` selects, early
     //! `return` to a runtime live mask. `whitelist` is the set of leaf-builtin
     //! names permitted to survive into the output (must be pure / branch-safe /
-    //! backend-expressible). Returns the FlatCtx — inspect `.ok` and `.err`.
+    //! backend-expressible). `maxUnroll` caps the product of nested constant-loop
+    //! iteration counts (exceeding it is a clean error, not a heap blowup). Returns
+    //! the FlatCtx — inspect `.ok` and `.err`.
     //!
     //! Backends call this directly with their own primitive set, before their own
     //! macro walks the result; `[flatten]` calls it with the std default. The
     //! body is uninferred after this — re-infer (e.g. via patch + astChanged)
     //! before reading types or running the shape check.
     var ctx = new FlatCtx(counter = 0, liveName = "__flat_live", retName = "__flat_ret",
-        hasRet = !func.result.isVoid, ok = true)
+        hasRet = !func.result.isVoid, unrollFactor = 1, maxUnroll = maxUnroll, ok = true)
     ctx.whitelist := whitelist
     if (!(func.body is ExprBlock)) return ctx
     let bodyBlk = func.body as ExprBlock
@@ -880,7 +918,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // Cycle 1: lower the twin with the std whitelist, then re-infer so
             // call.func resolves. (Backends call flatten_function directly with
             // their own primitive set instead of going through this annotation.)
-            var ctx = flatten_function(twin, STD_WHITELIST)
+            var ctx = flatten_function(twin, STD_WHITELIST, get_flatten_max_unroll(func))
             if (!ctx.ok) {
                 errors := ctx.err
                 return false

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -17,7 +17,7 @@ require daslib/macro_boost
 require daslib/rtti
 require strings
 
-def private is_flat_temp(name : string) : bool {
+def private is_flat_temp(name : das_string) : bool {
     return name |> starts_with("__flat_")
 }
 
@@ -31,11 +31,10 @@ def private is_flat_temp(name : string) : bool {
 // exactly the live-mask kills (`__flat_live = false`, per-frame mask updates).
 
 class private FlatScan : AstVisitor {
-    reads : table<string>
+    reads : table<uint64>
     risky : bool
     def override preVisitExprVar(expr : ExprVar?) : void {
-        let nm = "{expr.name}"
-        if (is_flat_temp(nm)) reads |> insert(nm)
+        if (is_flat_temp(expr.name)) reads |> insert(hash(expr.name))
     }
     def override preVisitExprCall(expr : ExprCall?) : void {
         risky = true
@@ -52,7 +51,7 @@ class private FlatScan : AstVisitor {
 
 // Scan a subtree for the `__flat_*` names it reads and whether it carries a
 // fault-capable / side-effecting node (call, index, division).
-def private scan_flat(var e : ExpressionPtr; var reads : table<string>; var risky : bool&) {
+def private scan_flat(var e : ExpressionPtr; var reads : table<uint64>; var risky : bool&) {
     if (e == null) return
     var v = new FlatScan()
     make_visitor(*v) $(adapter) {
@@ -86,11 +85,11 @@ def private const_bool(e : ExpressionPtr; var val : bool&) : bool {
     return false
 }
 
-def private fold_const(e : ExpressionPtr; constmap : table<string; bool>) : ExpressionPtr {
+def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : ExpressionPtr {
     if (e == null) return null
     if (e is ExprVar) {
-        let nm = "{(e as ExprVar).name}"
-        if (key_exists(constmap, nm)) return new ExprConstBool(at = e.at, value = constmap?[nm] ?? false)
+        let h = hash((e as ExprVar).name)
+        if (key_exists(constmap, h)) return new ExprConstBool(at = e.at, value = constmap?[h] ?? false)
         return clone_expression(e)
     }
     if (e is ExprOp1) {
@@ -163,14 +162,14 @@ def private fold_const(e : ExpressionPtr; constmap : table<string; bool>) : Expr
 def public const_prop_pass(var out : array<ExpressionPtr>) {
     // A `__flat_*` bool temp is constant when it is declared with a const-foldable
     // init and never reassigned. Reassigned temps (early-return live masks) stay.
-    var reassigned : table<string>
+    var reassigned : table<uint64>
     for (s in out) {
         if (s is ExprCopy && (s as ExprCopy).left is ExprVar) {
-            let nm = "{((s as ExprCopy).left as ExprVar).name}"
-            if (is_flat_temp(nm)) reassigned |> insert(nm)
+            let lv = (s as ExprCopy).left as ExprVar
+            if (is_flat_temp(lv.name)) reassigned |> insert(hash(lv.name))
         }
     }
-    var constmap : table<string; bool>
+    var constmap : table<uint64; bool>
     var changed = true
     while (changed) {
         changed = false
@@ -179,13 +178,13 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
             let lc = s as ExprLet
             if (length(lc.variables) != 1) continue
             let v = lc.variables[0]
-            let nm = "{v.name}"
-            if (!is_flat_temp(nm) || key_exists(reassigned, nm) || key_exists(constmap, nm) || v.init == null) {
+            let h = hash(v.name)
+            if (!is_flat_temp(v.name) || key_exists(reassigned, h) || key_exists(constmap, h) || v.init == null) {
                 continue
             }
             var bv = false
             if (const_bool(fold_const(v.init, constmap), bv)) {
-                constmap[nm] = bv
+                constmap[h] = bv
                 changed = true
             }
         }
@@ -252,10 +251,10 @@ def private count_refs(var e : ExpressionPtr; name : string) : int {
 }
 
 class private FlatScanAll : AstVisitor {
-    reads : table<string>
+    reads : table<uint64>
     risky : bool
     def override preVisitExprVar(expr : ExprVar?) : void {
-        reads |> insert("{expr.name}")
+        reads |> insert(hash(expr.name))
     }
     def override preVisitExprCall(expr : ExprCall?) : void {
         risky = true
@@ -272,7 +271,7 @@ class private FlatScanAll : AstVisitor {
 
 // Collect every variable name read by `e` (not just flatten temps) and whether it
 // carries a fault-capable / re-evaluation-sensitive node.
-def private scan_src(var e : ExpressionPtr; var reads : table<string>; var risky : bool&) {
+def private scan_src(var e : ExpressionPtr; var reads : table<uint64>; var risky : bool&) {
     if (e == null) return
     var v = new FlatScanAll()
     make_visitor(*v) $(adapter) {
@@ -298,18 +297,17 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
         // is only unsafe if V is reassigned BETWEEN this temp's def and a use — a
         // reassignment fully before the def (e.g. an accumulator finalized into the
         // return temp) leaves the captured value intact, so it must not block.
-        var storeIdx : table<string; array<int>>
+        var storeIdx : table<uint64; array<int>>
         for (j in range(n)) {
             if (out[j] is ExprCopy && (out[j] as ExprCopy).left is ExprVar) {
-                storeIdx["{((out[j] as ExprCopy).left as ExprVar).name}"] |> push(j)
+                storeIdx[hash(((out[j] as ExprCopy).left as ExprVar).name)] |> push(j)
             }
         }
         for (k in range(n)) {
             if (!(out[k] is ExprLet)) continue
             let lc = out[k] as ExprLet
-            if (length(lc.variables) != 1) continue
+            if (length(lc.variables) != 1 || !is_flat_temp(lc.variables[0].name)) continue
             let nm = "{lc.variables[0].name}"
-            if (!is_flat_temp(nm)) continue
             // Single definition: decl-init + no stores, OR no-init decl + one store.
             let stores <- [for (j in range(n)); j;
                 where out[j] is ExprCopy && (out[j] as ExprCopy).left is ExprVar &&
@@ -325,19 +323,21 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
                 continue                                   // multi-def (e.g. early-return mask) — leave it
             }
             let defIdx = si >= 0 ? si : k
-            var srcReads : table<string>
+            var srcReads : table<uint64>
             var srcRisky = false
             scan_src(src, srcReads, srcRisky)
-            if (key_exists(srcReads, nm)) continue         // self-referential source — never fold
+            if (key_exists(srcReads, hash(lc.variables[0].name))) continue         // self-referential source — never fold
             // Uses must follow the def; track the last one for the reassignment window.
             var refCount = 0
             var firstRef = n
             var maxUseIdx = -1
+            var useJs : array<int>
             for (j in range(n)) {
                 if (j == k || j == si) continue
                 let c = count_refs(out[j], nm)
                 if (c > 0) {
                     refCount += c
+                    useJs |> push(j)
                     if (j < firstRef) {
                         firstRef = j
                     }
@@ -364,9 +364,8 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             // Inline the source at every use, then drop the def (+ store).
             var rules : Template
             rules |> replaceVariable(nm, clone_expression(src))
-            for (j in range(n)) {
-                if (j == k || j == si) continue
-                out[j] = apply_template(rules, out[j].at, out[j], false)
+            for (j in useJs) {
+                out[j] = apply_template(rules, out[j].at, out[j], false)   // only statements that reference nm
             }
             var dead : table<int>
             dead |> insert(k)
@@ -382,14 +381,14 @@ def public dse_pass(var out : array<ExpressionPtr>) {
     let n = length(out)
     // Names that are ever an assignment target: their decl must stay even if the
     // init value is dead (only fully-unreferenced decls are removable).
-    var storeTargets : table<string>
+    var storeTargets : table<uint64>
     for (s in out) {
         if (s is ExprCopy && (s as ExprCopy).left is ExprVar) {
-            let nm = "{((s as ExprCopy).left as ExprVar).name}"
-            if (is_flat_temp(nm)) storeTargets |> insert(nm)
+            let lv = (s as ExprCopy).left as ExprVar
+            if (is_flat_temp(lv.name)) storeTargets |> insert(hash(lv.name))
         }
     }
-    var live : table<string>
+    var live : table<uint64>
     var dead : table<int>
     var i = n - 1
     while (i >= 0) {
@@ -397,16 +396,16 @@ def public dse_pass(var out : array<ExpressionPtr>) {
         var handled = false
         if (stmt is ExprCopy) {
             var cp = stmt as ExprCopy
-            if (cp.left is ExprVar && is_flat_temp("{(cp.left as ExprVar).name}")) {
+            if (cp.left is ExprVar && is_flat_temp((cp.left as ExprVar).name)) {
                 handled = true
-                let lnm = "{(cp.left as ExprVar).name}"
-                var reads : table<string>
+                let lh = hash((cp.left as ExprVar).name)
+                var reads : table<uint64>
                 var risky = false
                 scan_flat(cp.right, reads, risky)
-                if (!key_exists(live, lnm) && !risky) {
+                if (!key_exists(live, lh) && !risky) {
                     dead |> insert(i)   // target not live afterward, RHS pure → dead
                 } else {
-                    live |> erase(lnm)
+                    live |> erase(lh)
                     for (nm in keys(reads)) {
                         live |> insert(nm)
                     }
@@ -415,16 +414,16 @@ def public dse_pass(var out : array<ExpressionPtr>) {
         }
         if (!handled && stmt is ExprLet) {
             var lc = stmt as ExprLet
-            if (length(lc.variables) == 1 && is_flat_temp("{lc.variables[0].name}")) {
+            if (length(lc.variables) == 1 && is_flat_temp(lc.variables[0].name)) {
                 handled = true
-                let dnm = "{lc.variables[0].name}"
-                var reads : table<string>
+                let dh = hash(lc.variables[0].name)
+                var reads : table<uint64>
                 var risky = false
                 scan_flat(lc.variables[0].init, reads, risky)
-                if (!key_exists(live, dnm) && !key_exists(storeTargets, dnm) && !risky) {
+                if (!key_exists(live, dh) && !key_exists(storeTargets, dh) && !risky) {
                     dead |> insert(i)   // declared temp fully unreferenced, init pure → dead
                 } else {
-                    live |> erase(dnm)
+                    live |> erase(dh)
                     for (nm in keys(reads)) {
                         live |> insert(nm)
                     }
@@ -434,7 +433,7 @@ def public dse_pass(var out : array<ExpressionPtr>) {
         if (!handled) {
             // Decl / return / global write / bare expr — over-approximate: every
             // flat var it mentions becomes live (never wrongly removes a store).
-            var reads : table<string>
+            var reads : table<uint64>
             var risky = false
             scan_flat(stmt, reads, risky)
             for (nm in keys(reads)) {
@@ -474,21 +473,20 @@ def private rename_reads(var e : ExpressionPtr; current : table<string; string>)
 
 def public ssa_rename_pass(var out : array<ExpressionPtr>) {
     // (1) user locals declared (single-var) with an initializer
-    var declaredInit : table<string>
+    var declaredInit : table<uint64>
     for (s in out) {
         if (s is ExprLet && length((s as ExprLet).variables) == 1) {
             let v = (s as ExprLet).variables[0]
-            let nm = "{v.name}"
-            if (!is_flat_temp(nm) && v.init != null) declaredInit |> insert(nm)
+            if (!is_flat_temp(v.name) && v.init != null) declaredInit |> insert(hash(v.name))
         }
     }
     if (empty(declaredInit)) return
     // (2) of those, the ones reassigned via a plain `var = ...` (multi-def)
-    var ssaNames : table<string>
+    var ssaNames : table<uint64>
     for (s in out) {
         if (s is ExprCopy && (s as ExprCopy).left is ExprVar) {
-            let nm = "{((s as ExprCopy).left as ExprVar).name}"
-            if (key_exists(declaredInit, nm)) ssaNames |> insert(nm)
+            let h = hash(((s as ExprCopy).left as ExprVar).name)
+            if (key_exists(declaredInit, h)) ssaNames |> insert(h)
         }
     }
     if (empty(ssaNames)) return
@@ -500,7 +498,7 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
     while (i < length(out)) {
         var s = out[i]
         if (s is ExprLet && length((s as ExprLet).variables) == 1 &&
-                key_exists(ssaNames, "{(s as ExprLet).variables[0].name}")) {
+                key_exists(ssaNames, hash((s as ExprLet).variables[0].name))) {
             let orig = "{(s as ExprLet).variables[0].name}"
             let newInit = rename_reads((s as ExprLet).variables[0].init, current)
             counter ++
@@ -508,7 +506,7 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
             out[i] = qmacro_expr(${ var $i(vn) = $e(newInit); })
             current[orig] = vn
         } elif (s is ExprCopy && (s as ExprCopy).left is ExprVar &&
-                key_exists(ssaNames, "{((s as ExprCopy).left as ExprVar).name}")) {
+                key_exists(ssaNames, hash(((s as ExprCopy).left as ExprVar).name))) {
             let orig = "{((s as ExprCopy).left as ExprVar).name}"
             let newRhs = rename_reads((s as ExprCopy).right, current)
             counter ++
@@ -837,12 +835,11 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
         var s = blk.list[i]
         if (s is ExprLet && length((s as ExprLet).variables) == 1) {
             var lc = s as ExprLet
-            let nm = "{lc.variables[0].name}"
-            if (!is_flat_temp(nm) && lc.variables[0].init != null && is_all_const(lc.variables[0].init)) {
+            if (!is_flat_temp(lc.variables[0].name) && lc.variables[0].init != null && is_all_const(lc.variables[0].init)) {
                 var folded = eval_to_const(clone_expression(lc.variables[0].init))
                 if (folded |> is_expr_const()) {
                     lc.variables[0].init = folded
-                    constmap[nm] = folded
+                    constmap["{lc.variables[0].name}"] = folded
                     changed = true
                 }
             }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -288,55 +288,80 @@ def private scan_src(var e : ExpressionPtr; var reads : table<uint64>; var risky
     }
 }
 
+// Per-pass reference index: name-hash -> the statement indices that reference it
+// (deduped per statement) plus the total occurrence count. Built once per copy_prop
+// pass in a single walk, replacing the old per-candidate count_refs sweep that made
+// the pass O(n^3) on large bodies (one full-body walk per candidate per fold-restart).
+class private FlatUsesBuilder : AstVisitor {
+    nameUses : table<uint64; array<int>>
+    nameCount : table<uint64; int>
+    seen : table<uint64>
+    j : int
+    def override preVisitExprVar(expr : ExprVar?) : void {
+        let h = hash(expr.name)
+        nameCount[h] ++
+        if (!key_exists(seen, h)) {
+            seen |> insert(h)
+            nameUses[h] |> push(j)
+        }
+    }
+}
+
 def public copy_prop_pass(var out : array<ExpressionPtr>) {
     var changed = true
     while (changed) {
         changed = false
         let n = length(out)
-        // Map every assignment target to its store indices. A source reading var V
-        // is only unsafe if V is reassigned BETWEEN this temp's def and a use — a
-        // reassignment fully before the def (e.g. an accumulator finalized into the
-        // return temp) leaves the captured value intact, so it must not block.
+        // Precompute once per pass (not per candidate): every store target's indices,
+        // and a name -> (referencing statements, occurrence count) index. A source
+        // reading var V is only unsafe if V is reassigned BETWEEN this temp's def and a
+        // use — a reassignment fully before the def leaves the captured value intact.
         var storeIdx : table<uint64; array<int>>
         for (j in range(n)) {
             if (out[j] is ExprCopy && (out[j] as ExprCopy).left is ExprVar) {
                 storeIdx[hash(((out[j] as ExprCopy).left as ExprVar).name)] |> push(j)
             }
         }
+        var ub = new FlatUsesBuilder()
+        make_visitor(*ub) $(adapter) {
+            for (j in range(n)) {
+                ub.j = j
+                clear(ub.seen)
+                visit(out[j], adapter)
+            }
+        }
+        var srcReads : table<uint64>
         for (k in range(n)) {
             if (!(out[k] is ExprLet)) continue
             let lc = out[k] as ExprLet
             if (length(lc.variables) != 1 || !is_flat_temp(lc.variables[0].name)) continue
-            let nm = "{lc.variables[0].name}"
+            let hk = hash(lc.variables[0].name)
+            let nStores = key_exists(storeIdx, hk) ? length(storeIdx[hk]) : 0
             // Single definition: decl-init + no stores, OR no-init decl + one store.
-            let stores <- [for (j in range(n)); j;
-                where out[j] is ExprCopy && (out[j] as ExprCopy).left is ExprVar &&
-                    ((out[j] as ExprCopy).left as ExprVar).name == nm]
             var src : ExpressionPtr = null
             var si = -1
-            if (lc.variables[0].init != null && empty(stores)) {
+            if (lc.variables[0].init != null && nStores == 0) {
                 src = clone_expression(lc.variables[0].init)   // decl-init is the single definition
-            } elif (lc.variables[0].init == null && length(stores) == 1) {
-                si = stores[0]
+            } elif (lc.variables[0].init == null && nStores == 1) {
+                si = storeIdx[hk][0]
                 src = clone_expression((out[si] as ExprCopy).right)   // no-init decl + single store
             } else {
-                continue                                   // multi-def (e.g. early-return mask) — leave it
+                continue                                      // multi-def (e.g. early-return mask) — leave it
             }
             let defIdx = si >= 0 ? si : k
-            var srcReads : table<uint64>
+            clear(srcReads)
             var srcRisky = false
             scan_src(src, srcReads, srcRisky)
-            if (key_exists(srcReads, hash(lc.variables[0].name))) continue         // self-referential source — never fold
-            // Uses must follow the def; track the last one for the reassignment window.
-            var refCount = 0
+            if (key_exists(srcReads, hk)) continue            // self-referential source — never fold
+            // Uses (excluding def k and store si) straight from the precomputed index.
+            // nameCount includes the store's lvalue occurrence (1), which is not a use.
+            let refCount = (key_exists(ub.nameCount, hk) ? ub.nameCount[hk] : 0) - (si >= 0 ? 1 : 0)
             var firstRef = n
             var maxUseIdx = -1
             var useJs : array<int>
-            for (j in range(n)) {
-                if (j == k || j == si) continue
-                let c = count_refs(out[j], nm)
-                if (c > 0) {
-                    refCount += c
+            if (key_exists(ub.nameUses, hk)) {
+                for (j in ub.nameUses[hk]) {
+                    if (j == k || j == si) continue
                     useJs |> push(j)
                     if (j < firstRef) {
                         firstRef = j
@@ -362,17 +387,20 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             }
             if (blocked) continue
             // Inline the source at every use, then drop the def (+ store).
+            let nm = "{lc.variables[0].name}"
             var rules : Template
             rules |> replaceVariable(nm, clone_expression(src))
             for (j in useJs) {
                 out[j] = apply_template(rules, out[j].at, out[j], false)   // only statements that reference nm
             }
-            var dead : table<int>
-            dead |> insert(k)
-            if (si >= 0) dead |> insert(si)
-            out <- [for (j in range(n)); out[j]; where !key_exists(dead, j)]
+            out <- [for (j in range(n)); out[j]; where j != k && j != si]
             changed = true
             break
+        }
+        delete srcReads
+        delete storeIdx
+        unsafe {
+            delete ub
         }
     }
 }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -231,7 +231,10 @@ class private FlatVarRef : AstVisitor {
     name  : string
     count : int
     def override preVisitExprVar(expr : ExprVar?) : void {
-        if ("{expr.name}" == name) count ++
+        // das_string compares with string directly — never build a temp string here:
+        // count_refs walks the whole tree per candidate, so a per-ExprVar allocation
+        // is O(n^2) persistent strings on large bodies (the heap-overflow amplifier).
+        if (expr.name == name) count ++
     }
 }
 
@@ -310,7 +313,7 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             // Single definition: decl-init + no stores, OR no-init decl + one store.
             let stores <- [for (j in range(n)); j;
                 where out[j] is ExprCopy && (out[j] as ExprCopy).left is ExprVar &&
-                    "{((out[j] as ExprCopy).left as ExprVar).name}" == nm]
+                    ((out[j] as ExprCopy).left as ExprVar).name == nm]
             var src : ExpressionPtr = null
             var si = -1
             if (lc.variables[0].init != null && empty(stores)) {

--- a/doc/source/stdlib/handmade/function-strings-starts_with-0x79f2177b31f224a3.rst
+++ b/doc/source/stdlib/handmade/function-strings-starts_with-0x79f2177b31f224a3.rst
@@ -1,0 +1,1 @@
+Returns true if das-string `str` begins with the string `cmp`, false otherwise. Tests the prefix in place without allocating an intermediate string.

--- a/include/daScript/misc/memory_model.h
+++ b/include/daScript/misc/memory_model.h
@@ -22,8 +22,11 @@ namespace das {
     struct LineInfo;
 
     struct Deck {
-        Deck( uint32_t ne, uint32_t es, Deck * n ) {
-            total = (ne+31) & ~31;
+        // ne (entry count) and the byte totals are 64-bit: with geometric chunk
+        // growth a single size-class chunk can exceed 4 GB, and `total * size` must
+        // not wrap (the missed 64-bit migration that produced das_aligned_alloc16(0)).
+        Deck( uint64_t ne, uint32_t es, Deck * n ) {
+            total = (ne+31) & ~uint64_t(31);
             size = es;
             totalBytes = total * size;
             data = (char*) das_aligned_alloc16(totalBytes);
@@ -70,23 +73,23 @@ namespace das {
         __forceinline bool isAllocatedPtr ( char * ptr ) {
             ptrdiff_t idx = (ptr - data) / size;
             DAS_ASSERT ( idx>=0 && idx<ptrdiff_t(total) );
-            uint32_t uidx = uint32_t(idx);
-            uint32_t i = uidx >> 5;
-            uint32_t j = uidx & 31;
+            uint64_t uidx = uint64_t(idx);
+            uint64_t i = uidx >> 5;
+            uint32_t j = uint32_t(uidx & 31);
             uint32_t b = bits[i];
             return ((b & (1u<<j))!=0);
         }
         __forceinline char * allocate ( ) {
             if ( allocated == total ) return nullptr;
-            uint32_t maxt = total / 32;
-            for ( uint32_t t=0; t!=maxt; ++t ) {
+            uint64_t maxt = total / 32;
+            for ( uint64_t t=0; t!=maxt; ++t ) {
                 uint32_t b = bits[look];
                 uint32_t nb = ~b;
                 if ( nb ) {
                     uint32_t j = 31 - das_clz(nb);
                     bits[look] = b | (1u<<j);
                     allocated ++;
-                    uint32_t ofs = (look * 32 + j);
+                    uint64_t ofs = (look * 32 + j);
                     DAS_ASSERT(ofs < total);
                     return data + ofs * size;
                 }
@@ -99,9 +102,9 @@ namespace das {
         __forceinline void free ( char * ptr ) {
             ptrdiff_t idx = (ptr - data) / size;
             DAS_ASSERT ( idx>=0 && idx<ptrdiff_t(total) );
-            uint32_t uidx = uint32_t(idx);
-            uint32_t i = uidx >> 5;
-            uint32_t j = uidx & 31;
+            uint64_t uidx = uint64_t(idx);
+            uint64_t i = uidx >> 5;
+            uint32_t j = uint32_t(uidx & 31);
             uint32_t b = bits[i];
             DAS_ASSERT((b & (1u<<j))!=0 && "calling free on the pointer, which is already free");
             bits[i] = b ^ (1u<<j);
@@ -111,9 +114,9 @@ namespace das {
         __forceinline bool mark ( char * ptr ) {
             ptrdiff_t idx = (ptr - data) / size;
             DAS_ASSERT ( idx>=0 && idx<ptrdiff_t(total) );
-            uint32_t uidx = uint32_t(idx);
-            uint32_t i = uidx >> 5;
-            uint32_t j = uidx & 31;
+            uint64_t uidx = uint64_t(idx);
+            uint64_t i = uidx >> 5;
+            uint32_t j = uint32_t(uidx & 31);
             uint32_t b = gc_bits[i];
             if ( !(b & (1u<<j)) ) {
                 gc_bits[i] = b | (1u<<j);
@@ -123,14 +126,14 @@ namespace das {
             return false;
         }
         char *      data = nullptr;
-        uint32_t *  bits = nullptr;
+        uint32_t *  bits = nullptr;          // 32-bit bitset words; indices are 64-bit
         uint32_t *  gc_bits = nullptr;
-        uint32_t    total = 0;
-        uint32_t    size = 0;
-        uint32_t    totalBytes = 0;
-        uint32_t    look = 0;
-        uint32_t    allocated = 0;
-        uint32_t    gc_allocated = 0;
+        uint64_t    total = 0;               // entry count (can exceed 2^32 via growth)
+        uint32_t    size = 0;                // element size in bytes (<= DAS_MAX_SHOE_ALLOCATION)
+        uint64_t    totalBytes = 0;          // total * size — 64-bit so it cannot wrap
+        uint64_t    look = 0;
+        uint64_t    allocated = 0;
+        uint64_t    gc_allocated = 0;
         Deck *      next = nullptr;
     };
 
@@ -269,7 +272,7 @@ namespace das {
         mutable Deck *  lastChunk;
     };
 
-    typedef function<int(int)> CustomGrowFunction;
+    typedef function<uint64_t(uint64_t)> CustomGrowFunction;
 
     struct DAS_API MemoryModel : ptr_ref_count {
         enum { default_initial_size = 65536 };
@@ -280,7 +283,7 @@ namespace das {
         virtual void reset();
         virtual void shrink();
         void setInitialSize ( uint64_t size );
-        uint32_t grow ( uint32_t si );
+        uint64_t grow ( uint32_t si );
         virtual void sweep();
         char * allocate ( uint64_t size );
         bool free ( char * ptr, uint64_t size );

--- a/include/daScript/simulate/aot_builtin_string.h
+++ b/include/daScript/simulate/aot_builtin_string.h
@@ -83,6 +83,7 @@ namespace das {
     DAS_API const char * das_to_cpp_float ( float val, Context * context, LineInfoArg * at );
     DAS_API void builtin_append_char_to_string(string & str, int32_t Ch);
     DAS_API bool builtin_string_ends_with(const string &str, char * substr, Context * context);
+    DAS_API bool builtin_string_starts_with(const string &str, const char * cmp, Context * context);
     DAS_API int32_t builtin_ext_string_length(const string & str);
     DAS_API void builtin_resize_string(string & str, int32_t newLength);
     DAS_API char * string_repeat ( const char * str, int count, Context * context, LineInfoArg * at );

--- a/src/builtin/module_builtin_string.cpp
+++ b/src/builtin/module_builtin_string.cpp
@@ -76,6 +76,14 @@ namespace das
         return cmpLen == 0 || ((cmpLen <= strLen) && memcmp(str, cmp, cmpLen) == 0);
     }
 
+    // das_string overload: prefix-test the das_string in place (no allocation),
+    // sibling to builtin_string_ends_with. Lets AST/lint passes that hold names as
+    // das_string do `name |> starts_with("...")` without materializing a string.
+    bool builtin_string_starts_with ( const string & str, const char * cmp, Context * context ) {
+        const uint32_t cmpLen = stringLengthSafe ( *context, cmp );
+        return cmpLen == 0 || ((cmpLen <= str.length()) && memcmp(str.data(), cmp, cmpLen) == 0);
+    }
+
     bool builtin_string_startswith2 ( const char * str, const char * cmp, uint32_t cmpLen, Context * context ) {
         const uint32_t strLen = stringLengthSafe ( *context, str );
         cmpLen = min(cmpLen, stringLengthSafe ( *context, cmp ));
@@ -969,6 +977,8 @@ namespace das
                 SideEffects::none, "builtin_string_startswith3")->args({"str","offset","cmp","context"});
             addExtern<DAS_BIND_FUN(builtin_string_startswith4)>(*this, lib, "starts_with",
                 SideEffects::none, "builtin_string_startswith4")->args({"str","offset","cmp","cmpLen","context"});
+            addExtern<DAS_BIND_FUN(builtin_string_starts_with)>(*this, lib, "starts_with",
+                SideEffects::none, "builtin_string_starts_with")->args({"str","cmp","context"});
             addExtern<DAS_BIND_FUN(builtin_string_strip)>(*this, lib, "strip",
                 SideEffects::none, "builtin_string_strip")->args({"str","context","at"});
             addExtern<DAS_BIND_FUN(builtin_string_strip_right)>(*this, lib, "strip_right",

--- a/src/misc/memory_model.cpp
+++ b/src/misc/memory_model.cpp
@@ -96,9 +96,9 @@ namespace das {
 #endif
     }
 
-    uint32_t MemoryModel::grow ( uint32_t si ) {
+    uint64_t MemoryModel::grow ( uint32_t si ) {
         if ( shoe.chunks[si] ) {
-            uint32_t size = shoe.chunks[si]->total;
+            uint64_t size = shoe.chunks[si]->total;
             if ( customGrow ) {
                 size = customGrow(size);
             } else {
@@ -109,11 +109,9 @@ namespace das {
             if ( !initialSize ) {
                 initialSize = default_initial_size;
             }
-            // Shoe per-chunk byte total is 32-bit bounded (max 256B per element,
-            // total chunk size capped). If initialSize > UINT32_MAX*divisor (>68GB),
-            // clamp so the shoe still gets a workable chunk size.
-            uint64_t per = initialSize / ((uint64_t(si)+1)<<4);
-            return per > uint64_t(UINT32_MAX) ? UINT32_MAX : uint32_t(per);
+            // Entry count for the first chunk of this size-class. 64-bit throughout
+            // (Deck::total and totalBytes are 64-bit), so no UINT32 clamp is needed.
+            return initialSize / ((uint64_t(si)+1)<<4);
         }
     }
 
@@ -140,7 +138,7 @@ namespace das {
             size = (size + 15) & ~15;
             DAS_ASSERT(size && size<=DAS_MAX_SHOE_ALLOCATION);
             uint32_t si = uint32_t((size >> 4) - 1);
-            uint32_t total = grow(si);
+            uint64_t total = grow(si);
             shoe.chunks[si] = new Deck(total, uint32_t(size), shoe.chunks[si]);
             return shoe.chunks[si]->allocate();
         }
@@ -267,9 +265,9 @@ namespace das {
         for ( uint32_t si=0; si!=DAS_MAX_SHOE_CUNKS; ++si ) {   // we re-track all small allocations
             for ( auto ch=shoe.chunks[si]; ch; ch=ch->next ) {
                 ch->afterGC();
-                uint32_t utotal = ch->total / 32;
+                uint64_t utotal = ch->total / 32;
 #if DAS_SANITIZER
-                for ( uint32_t i=0; i!=utotal; ++i ) {
+                for ( uint64_t i=0; i!=utotal; ++i ) {
                     uint32_t b = ch->bits[i];
                     for ( uint32_t j=0; j!=32; ++j ) {
                         if ( b & (1<<j) ) {
@@ -280,11 +278,11 @@ namespace das {
                     }
                 }
 #else
-                uint32_t live = 0;                              // popcount instead of per-bit scan
-                for ( uint32_t i=0; i!=utotal; ++i ) {
+                uint64_t live = 0;                              // popcount instead of per-bit scan
+                for ( uint64_t i=0; i!=utotal; ++i ) {
                     live += das_popcount(ch->bits[i]);
                 }
-                totalAllocated += uint64_t(live) * ch->size;
+                totalAllocated += live * ch->size;
 #endif
             }
         }
@@ -329,7 +327,10 @@ namespace das {
     }
 
     uint32_t LinearChunkAllocator::grow ( uint32_t size ) {
-        return customGrow ? customGrow(size) : size * 2;
+        // HeapChunk is uint32-bounded by design (see allocate's DAS_VERIFYF); the
+        // grow hook is 64-bit, so clamp its result back into the per-chunk cap.
+        uint64_t ng = customGrow ? customGrow(size) : uint64_t(size) * 2;
+        return uint32_t(das::min(ng, uint64_t(UINT32_MAX)));
     }
 
     char * LinearChunkAllocator::allocate ( uint64_t s ) {

--- a/src/runtime/context.cpp
+++ b/src/runtime/context.cpp
@@ -408,7 +408,7 @@ namespace das
         SimNodeRelocator rel;
         rel.context = this;
         rel.newCode = make_shared<NodeAllocator>();
-        rel.newCode->customGrow = [&](int ) { return 4000; };   // because SimNode_Aot is 80 bytes
+        rel.newCode->customGrow = [&](uint64_t ) { return uint64_t(4000); };   // because SimNode_Aot is 80 bytes
         uint32_t codeSize = uint32_t(code->bytesAllocated());
         if ( code->prefixWithHeader && !pwh ) {
             // printf("[REL] %i adjusting\n", code->totalNodesAllocated);

--- a/src/simulate/heap.cpp
+++ b/src/simulate/heap.cpp
@@ -165,8 +165,8 @@ namespace das {
     void PersistentStringAllocator::forEachString ( const callable<void (const char *)> & fn ) {
         for ( uint32_t si=0; si!=DAS_MAX_SHOE_CUNKS; ++si ) {
             for ( auto ch=model.shoe.chunks[si]; ch; ch=ch->next ) {
-                uint32_t utotal = ch->total / 32;
-                for ( uint32_t i=0; i!=utotal; ++i ) {
+                uint64_t utotal = ch->total / 32;
+                for ( uint64_t i=0; i!=utotal; ++i ) {
                     uint32_t b = ch->bits[i];
                     for ( uint32_t j=0; j!=32; ++j ) {    // todo: simpler bit loop
                         if ( b & (1<<j) ) {
@@ -412,8 +412,8 @@ namespace das {
                 totalChunks ++;
                 tout << "\t" << HEX << "[" << uint64_t(ch->data) << ".." << (uint64_t(ch->data)+(ch->size*ch->total)) << ")\n" << DEC;
                 tout << "\t" << ch->allocated << " of " << ch->total << ", " << (ch->allocated*ch->size) << " of " << ch->totalBytes << " bytes\n";
-                uint32_t utotal = ch->total / 32;
-                for ( uint32_t i=0; i!=utotal; ++i ) {
+                uint64_t utotal = ch->total / 32;
+                for ( uint64_t i=0; i!=utotal; ++i ) {
                     uint32_t b = ch->bits[i];
                     for ( uint32_t j=0; j!=32; ++j ) {
                         if ( b & (1<<j) ) {

--- a/tests-cpp/big/memory_model_4gb/CMakeLists.txt
+++ b/tests-cpp/big/memory_model_4gb/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Big test: shoe-allocator 4 GB-boundary regression (das::Deck 64-bit migration).
+# Allocates a real >4 GB chunk to prove total*size no longer wraps to 0, so it is
+# local-only (`ninja test-big`), not part of CI.
+
+add_executable(test_memory_model_4gb test_memory_model_4gb.cpp)
+target_link_libraries(test_memory_model_4gb PRIVATE
+    libDaScript ${SRC_LIBRARIES} ${DAS_MODULES_LIBS})
+target_include_directories(test_memory_model_4gb PRIVATE ${NEED_MODULES_PATH})
+SETUP_CPP11(test_memory_model_4gb)
+set_target_properties(test_memory_model_4gb PROPERTIES FOLDER "tests-cpp/big")
+
+add_test(NAME memory_model_4gb COMMAND test_memory_model_4gb
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_tests_properties(memory_model_4gb PROPERTIES LABELS "big")
+
+add_dependencies(test-big test_memory_model_4gb)

--- a/tests-cpp/big/memory_model_4gb/test_memory_model_4gb.cpp
+++ b/tests-cpp/big/memory_model_4gb/test_memory_model_4gb.cpp
@@ -1,0 +1,62 @@
+// Big test: regression for the 64-bit migration of the shoe allocator (das::Deck).
+//
+// Before the fix, Deck::total and Deck::totalBytes were uint32_t, so a size-class
+// chunk whose byte total reached 2^32 wrapped to 0 -> das_aligned_alloc16(0) ->
+// (Debug) assert / (Release) a 0-byte pointer the next write trampled (the
+// "name string dereferenced as a pointer" crash the flatten fuzzer surfaced).
+//
+// Verifying the fix needs a real >4 GB allocation, so this is a local-only "big"
+// test (`ninja test-big`), not part of CI.
+
+#include "daScript/misc/platform.h"     // memory_model.h is not self-contained
+#include "daScript/misc/memory_model.h"
+
+#include <cstdio>
+#include <cstring>
+
+using namespace das;
+
+static int g_failures = 0;
+#define BIGCHECK(cond) do { if(!(cond)){ printf("FAIL line %d: %s\n", __LINE__, #cond); ++g_failures; } } while(0)
+
+int main() {
+    // ne * es crosses exactly 2^32: 2^28 entries * 16 bytes = 2^32 (the value that
+    // wrapped to 0 in the lldb backtrace: Deck::Deck(ne=268435456, es=16)).
+    const uint64_t ne = uint64_t(1) << 28;   // 268,435,456
+    const uint32_t es = 16;
+    {
+        Deck d(ne, es, nullptr);
+        BIGCHECK(d.total == ne);
+        BIGCHECK(d.totalBytes == ne * uint64_t(es));
+        BIGCHECK(d.totalBytes == (uint64_t(1) << 32));   // the pre-fix wrap target
+        BIGCHECK(d.totalBytes != 0);
+        BIGCHECK(d.data != nullptr);
+
+        // A few entries from the chunk: distinct, 16-aligned, owned, writable.
+        char * a = d.allocate();
+        char * b = d.allocate();
+        char * c = d.allocate();
+        BIGCHECK(a != nullptr && b != nullptr && c != nullptr);
+        BIGCHECK(a != b && b != c && a != c);
+        BIGCHECK((reinterpret_cast<uintptr_t>(a) & 15) == 0);
+        BIGCHECK(d.isOwnPtr(a) && d.isOwnPtr(b) && d.isOwnPtr(c));
+        memset(a, 0xAB, es); memset(b, 0xCD, es); memset(c, 0xEF, es);
+        BIGCHECK((unsigned char)a[0] == 0xAB);
+        BIGCHECK((unsigned char)b[0] == 0xCD);
+        BIGCHECK((unsigned char)c[es-1] == 0xEF);
+
+        // The far end of the 4 GB buffer must be addressable and in-range — proves
+        // totalBytes is the full 2^32, not a truncated value.
+        char * tail = d.data + (d.totalBytes - es);
+        BIGCHECK(d.isOwnPtr(tail));
+        tail[0] = 0x5A; tail[es-1] = 0x5A;
+        BIGCHECK((unsigned char)tail[0] == 0x5A && (unsigned char)tail[es-1] == 0x5A);
+    }   // ~Deck releases the 4 GB buffer
+
+    if ( g_failures ) {
+        printf("memory_model_4gb: %d failure(s)\n", g_failures);
+        return 1;
+    }
+    printf("memory_model_4gb: OK\n");
+    return 0;
+}

--- a/tests-cpp/small/test_memory_model_growth.cpp
+++ b/tests-cpp/small/test_memory_model_growth.cpp
@@ -1,0 +1,60 @@
+#include <doctest/doctest.h>
+
+#include "daScript/misc/platform.h"     // memory_model.h is not self-contained
+#include "daScript/misc/memory_model.h"
+
+#include <vector>
+#include <cstring>
+
+using namespace das;
+
+// Exercises the shoe allocator's chunk-growth path (Deck chain) at a moderate,
+// CI-friendly scale: enough allocations to force several geometric grow() steps so
+// the 64-bit Deck index/byte math is exercised, without the 4 GB the actual overflow
+// boundary needs (that lives in tests-cpp/big/memory_model_4gb).
+TEST_CASE("MemoryModel shoe growth: many small allocations stay valid across chunks") {
+    MemoryModel mm;
+    const uint64_t es = 256;            // largest shoe size-class
+    const int N = 200000;               // ~50 MB — multiple chunk growths
+    std::vector<char*> ptrs;
+    ptrs.reserve(N);
+    for ( int i=0; i<N; ++i ) {
+        char * p = mm.allocate(es);
+        REQUIRE(p != nullptr);
+        REQUIRE((reinterpret_cast<uintptr_t>(p) & 15) == 0);   // 16-aligned
+        memset(p, char(i & 0xff), size_t(es));                  // write the whole block
+        ptrs.push_back(p);
+    }
+    // Every pointer is owned by the model and its bytes survived (no aliasing/overlap).
+    for ( int i=0; i<N; ++i ) {
+        CHECK(mm.isOwnPtr(ptrs[i], es));
+        CHECK(ptrs[i][0] == char(i & 0xff));
+        CHECK(ptrs[i][es-1] == char(i & 0xff));
+    }
+    CHECK(mm.bytesAllocated() == uint64_t(N) * es);
+
+    // Free every other block, then re-allocate the same count — exercises the free
+    // bitmap + reuse path across the grown chunks.
+    for ( int i=0; i<N; i+=2 ) mm.free(ptrs[i], es);
+    CHECK(mm.bytesAllocated() == uint64_t(N/2) * es);
+    for ( int i=0; i<N/2; ++i ) {
+        char * p = mm.allocate(es);
+        REQUIRE(p != nullptr);
+    }
+    CHECK(mm.bytesAllocated() == uint64_t(N) * es);
+}
+
+// grow() returns a 64-bit entry count: it must carry a value above UINT32_MAX
+// without truncation (the old code returned uint32_t and clamped the first-chunk
+// path to UINT32_MAX). Drive grow() directly via customGrow — no 4 GB allocation
+// (the real boundary lives in tests-cpp/big/memory_model_4gb).
+TEST_CASE("MemoryModel::grow is 64-bit (no UINT32 clamp / truncation)") {
+    MemoryModel mm;
+    mm.setInitialSize(4096);
+    char * p = mm.allocate(16);            // materialize the 16-byte-class chunk (si==0)
+    REQUIRE(p != nullptr);
+    // With a chunk present, grow() consults customGrow(currentTotal); returning a
+    // value past 2^32 must round-trip intact through the uint64_t return.
+    mm.customGrow = [](uint64_t) -> uint64_t { return uint64_t(1) << 33; };
+    CHECK(mm.grow(0) == (uint64_t(1) << 33));
+}

--- a/tests/flatten/_err_unroll.das
+++ b/tests/flatten/_err_unroll.das
@@ -1,0 +1,25 @@
+options gen2
+options indenting = 4
+
+require daslib/flatten
+
+// Nested constant loops unroll multiplicatively (20^3 = 8000 > the 4096 default cap):
+// the twin must bail with a clean max_unroll error instead of expanding to a
+// multi-gigabyte body and crashing the macro.
+[flatten]
+def blowup(x : int) : int {
+    var acc = x
+    for (a in range(20)) {
+        for (b in range(20)) {
+            for (c in range(20)) {
+                acc += a + b + c
+            }
+        }
+    }
+    return acc
+}
+
+[export]
+def main {
+    print("{blowup(1)}\n")
+}

--- a/tests/flatten/_err_unroll_override.das
+++ b/tests/flatten/_err_unroll_override.das
@@ -1,0 +1,22 @@
+options gen2
+options indenting = 4
+
+require daslib/flatten
+
+// max_unroll=8 lowers the cap below this 3x3 = 9 nest, proving the annotation arg is
+// honored (the 4096 default would accept 9 fine). Tiny so the test stays fast.
+[flatten(max_unroll=8)]
+def small(x : int) : int {
+    var acc = x
+    for (a in range(3)) {
+        for (b in range(3)) {
+            acc += a + b
+        }
+    }
+    return acc
+}
+
+[export]
+def main {
+    print("{small(1)}\n")
+}

--- a/tests/flatten/test_flatten_errors.das
+++ b/tests/flatten/test_flatten_errors.das
@@ -50,4 +50,12 @@ def test_flatten_boundaries(t : T?) {
         let issues = compile_issues("{get_das_root()}/tests/flatten/_err_move.das")
         t |> success(find(issues, "cannot be predicated") >= 0, "expected move/clone error, got: {issues}")
     }
+    t |> run("over-cap loop unrolling is rejected") @(t : T?) {
+        let issues = compile_issues("{get_das_root()}/tests/flatten/_err_unroll.das")
+        t |> success(find(issues, "exceeds max_unroll") >= 0, "expected unroll-cap error, got: {issues}")
+    }
+    t |> run("[flatten(max_unroll=N)] override is honored") @(t : T?) {
+        let issues = compile_issues("{get_das_root()}/tests/flatten/_err_unroll_override.das")
+        t |> success(find(issues, "exceeds max_unroll=8") >= 0, "expected lowered-cap error, got: {issues}")
+    }
 }

--- a/utils/flatten-fuzz/README.md
+++ b/utils/flatten-fuzz/README.md
@@ -70,9 +70,18 @@ offending unit is bisected out and dumped as a standalone reproducer
 - The inlined-callee-local shadowing bug (`inline_call` not uniquifying callee
   locals across multiple inline sites) — fixed in the same change that added
   this tool.
-- At `--depth 4+`, deeply-nested constant `for` loops unroll without any
-  expansion cap, so the flattened twin grows exponentially → very slow compiles
-  and a heap-layout-dependent SIGSEGV during the macro. Diagnosis: `lower_for`
-  has no unroll-size guard; the flatten opt passes are bounded but super-linear
-  in body size. The compiler's own `max_infer_passes` (default 50) bounds infer,
-  so this is blowup, not an infinite loop. Default depth is 3 (clean at scale).
+- Unbounded loop unrolling: deeply-nested constant `for` loops unroll
+  multiplicatively (`range(20)^4` = 160k body copies) with no expansion cap, so
+  the flattened twin blows the heap to multiple GB. **Fixed** — `lower_for` now
+  caps the product of nested iteration counts (`FLATTEN_MAX_UNROLL`, default 4096;
+  `[flatten(max_unroll=N)]` overrides), bailing with a clean error before cloning.
+- A deterministic compiler crash (the SIGSEGV/SIGBUS whose faulting address was
+  always ASCII bytes of a flatten-generated name like `__flat_loop` / `v46_0`).
+  Root cause was **not** in flatten: an incomplete 64-bit migration of the core
+  shoe allocator (`MemoryModel::Deck`) — `total * size` (entry count × element
+  size) overflowed `uint32_t` once a string-heap size-class grew past 4 GB, so
+  `das_aligned_alloc16(0)` returned a degenerate pointer the next string
+  overwrote. **Fixed** by widening the allocator's byte/count fields to 64-bit
+  (regression: `tests-cpp/big/memory_model_4gb`). flatten amplified it via a
+  per-`ExprVar` `"{name}"` string built inside the O(n²) opt-pass tree walks;
+  that churn is now allocation-free (`das_string` compares). Default depth is 3.


### PR DESCRIPTION
## Summary

Bundles the flatten fuzzer's follow-up fixes plus the core-allocator bug it surfaced:

1. **64-bit migration of the shoe memory allocator** (`MemoryModel::Deck`). The fuzzer hit a deterministic compiler crash whose faulting address was always ASCII bytes of a flatten-generated name. Root cause was **not** in flatten: `Deck::total * size` (entry count × element size, both `uint32_t`) overflowed once a string-heap size-class grew past 4 GB, so `das_aligned_alloc16(0)` handed back a degenerate pointer the next string overwrote. Widened the allocator's byte/count fields to 64-bit. Regression tests: `tests-cpp/small/test_memory_model_growth.cpp` (CI) and `tests-cpp/big/memory_model_4gb` (local-only, needs a real >4 GB allocation).

2. **Cap flatten loop unrolling.** Deeply-nested constant `for` loops unrolled multiplicatively with no bound, blowing the heap to multiple GB. `lower_for` now caps the product of nested iteration counts (`FLATTEN_MAX_UNROLL`, default 4096; `[flatten(max_unroll=N)]` overrides), bailing with a clean error before cloning. Regression fixtures under `tests/flatten/`.

3. **copy_prop performance — the headline.** On the fuzzer's worst case (a 2690-statement flattened body) compiling one function took **247 s / 1.79e12 instructions / 1.35 GB**. Two root causes, both fixed:
   - **Memory:** the substitution loop ran `apply_template` over *all* statements per fold, cloning every statement's tree (even the ~2688 that don't reference the folded temp) and orphaning the old subtrees. Restricted it to the statements that actually reference the temp.
   - **Time:** `count_refs` walked the whole body once per *candidate*, and `while(changed)` re-ran the candidate sweep after every single fold — O(n^3). Now a `FlatUsesBuilder` builds a name-to-(referencing-statements, occurrence-count) index **once per pass**, so each candidate's analysis is an O(1) lookup; the single-def store set comes from the already-built `storeIdx`. Per-pass tables are freed explicitly.
   - Also: the opt-pass working tables were keyed by variable name as a freshly-built string (`"{expr.name}"`) — re-converting the das_string `.name` on every probe. They now key by `hash(.name)` (uint64), and a new `starts_with(das_string)` builtin (sibling to `ends_with`) lets `is_flat_temp` prefix-check without materializing a string. (Measured: this churn was negligible on its own — the win was the algorithm; included as cleanup.)

   **Result on cand_0: 247 s → 9.2 s (27×), 1.35 GB → 746 MB, 1.79e12 → 6.2e10 instructions.**

## Design note

Several opt-pass tables now key by `hash(.name)` (uint64) and rely on 64-bit hash uniqueness over the small per-function name set — the same assumption used throughout the codebase. Tables whose keys feed `replaceVariable` / `count_refs` (which need the actual name, not a hash) stay string-keyed.

## Verification

- Interp suite: **10528 passed / 0 failed / 0 errors** (6 skipped)
- AOT suite: **9872 passed / 0 failed / 0 errors** (6 skipped)
- Flatten unit tests: 116/116; strings tests: 363/363
- Fuzzer **value-differential**: 40 batches × 20 units × 45 inputs = ~36k `f == f_flat` checks, all pass
- JIT smoke: no verifier errors
- Lint: 0 issues on the 5 changed `.das` files; das-fmt `--verify` clean; Sphinx `-W` build succeeded with 0 warnings

Note: the strict_fold oracle reports 2 pre-existing missed-folds (bisected to before this branch's work, ≥ `5990cc344`) — a fold-completeness corner, value-correct, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)