### PR TITLE
json: cut per-call GC pressure (delete_json/update, ?[] sentinel, free dispatched trees)

### DIFF
--- a/daslib/json.das
+++ b/daslib/json.das
@@ -57,6 +57,21 @@ def JVNull {
     return new JsonValue(value <- JsValue(_null = null))
 }
 
+var private g_json_null_sentinel : JsonValue?
+
+def json_null_sentinel : JsonValue ? {
+    //! Shared, per-context ``null`` JsonValue returned by ``operator ?[]`` / ``?.`` when a
+    //! key/index is absent — so missing-key navigation allocates nothing (a fresh ``JVNull()``
+    //! per miss was a steady GC-pressure source). It preserves the "``?[]`` is never null"
+    //! contract callers rely on. INTERNAL: it is shared and must never be freed, mutated, or
+    //! stored into a tree. ``delete_json`` and ``update`` guard against it; do not ``delete`` a
+    //! ``?[]`` result directly or ``insert`` it into an object/array.
+    if (g_json_null_sentinel == null) {
+        g_json_null_sentinel = JVNull()
+    }
+    return g_json_null_sentinel
+}
+
 def JV(v : string) {
     //! Creates `JsonValue` out of string value.
     return new JsonValue(value <- JsValue(_string = v))
@@ -603,6 +618,36 @@ def write_json(val : JsonValue?#) : string {
     unsafe {// Fine, as json doesn't escape the function
         return write_json(reinterpret<JsonValue?> val)
     }
+}
+
+def delete_json(var jsv : JsonValue?) {
+    //! Free a JsonValue tree. ``JsonValue?`` is owned (this module is
+    //! ``strict_smart_pointers``), so ``delete`` already recurses — finalizing the
+    //! ``_object`` table / ``_array`` deletes the child nodes in turn — and one
+    //! top-level ``delete`` frees the whole tree. This wraps that in the required
+    //! ``unsafe`` plus a null guard, and names the intent at call sites. Pass an owned
+    //! tree you are done with (a parsed ``read_json`` input, a built result, a per-frame
+    //! payload); assumes unique ownership — do not call on a shared/aliased tree. No-op
+    //! on null or on the shared missing-key sentinel (:ref:`json_null_sentinel
+    //! <function-json-json_null_sentinel>`), so freeing a tree that a careless caller
+    //! navigated into is still safe.
+    if (jsv == null || jsv == g_json_null_sentinel) return
+    unsafe { delete jsv; }
+}
+
+def update(var obj : JsonValue?; key : string; var jsv : JsonValue?) {
+    //! Set object field ``key`` to ``jsv``, first freeing (via :ref:`delete_json
+    //! <function-json-delete_json>`) whatever JsonValue was stored at ``key``. Use this
+    //! instead of a bare insert when overwriting a field on a reused/long-lived object
+    //! every frame — a bare ``insert`` drops the old value on the heap. No-op when
+    //! ``obj`` is null or not an ``_object``.
+    if (obj == null || !(obj.value is _object)) return
+    if (key_exists(obj.value as _object, key)) {
+        delete_json((obj.value as _object)[key])
+    }
+    // Never store the shared sentinel into a tree — a later cascade-free would
+    // delete it out from under everyone. Substitute a fresh owned null.
+    (obj.value as _object) |> insert(key, jsv == g_json_null_sentinel ? JVNull() : jsv)
 }
 
 def try_fixing_broken_json(var bad : string) {

--- a/daslib/json.das
+++ b/daslib/json.das
@@ -628,26 +628,31 @@ def delete_json(var jsv : JsonValue?) {
     //! ``unsafe`` plus a null guard, and names the intent at call sites. Pass an owned
     //! tree you are done with (a parsed ``read_json`` input, a built result, a per-frame
     //! payload); assumes unique ownership — do not call on a shared/aliased tree. No-op
-    //! on null or on the shared missing-key sentinel (:ref:`json_null_sentinel
-    //! <function-json-json_null_sentinel>`), so freeing a tree that a careless caller
-    //! navigated into is still safe.
+    //! on null or on the shared missing-key sentinel (``json_null_sentinel``), so freeing
+    //! a tree that a careless caller navigated into is still safe.
     if (jsv == null || jsv == g_json_null_sentinel) return
     unsafe { delete jsv; }
 }
 
 def update(var obj : JsonValue?; key : string; var jsv : JsonValue?) {
-    //! Set object field ``key`` to ``jsv``, first freeing (via :ref:`delete_json
-    //! <function-json-delete_json>`) whatever JsonValue was stored at ``key``. Use this
+    //! Set object field ``key`` to ``jsv``, first freeing (via ``delete_json``) whatever
+    //! JsonValue was stored at ``key``. Use this
     //! instead of a bare insert when overwriting a field on a reused/long-lived object
     //! every frame — a bare ``insert`` drops the old value on the heap. No-op when
     //! ``obj`` is null or not an ``_object``.
     if (obj == null || !(obj.value is _object)) return
-    if (key_exists(obj.value as _object, key)) {
+    // Never store a raw null (write_json deref's object values) or the shared sentinel
+    // (a later cascade-free would delete it out from under everyone) into a tree —
+    // substitute a fresh owned null for both.
+    if (jsv == null || jsv == g_json_null_sentinel) {
+        jsv = JVNull()
+    }
+    // Free the previous value, unless the caller passed back the very pointer already
+    // stored here (freeing then re-inserting it would be a use-after-free).
+    if (key_exists(obj.value as _object, key) && (obj.value as _object)[key] != jsv) {
         delete_json((obj.value as _object)[key])
     }
-    // Never store the shared sentinel into a tree — a later cascade-free would
-    // delete it out from under everyone. Substitute a fresh owned null.
-    (obj.value as _object) |> insert(key, jsv == g_json_null_sentinel ? JVNull() : jsv)
+    (obj.value as _object) |> insert(key, jsv)
 }
 
 def try_fixing_broken_json(var bad : string) {

--- a/daslib/json_boost.das
+++ b/daslib/json_boost.das
@@ -27,32 +27,32 @@ require daslib/constant_expression
 
 def operator ?[] (a : json::JsonValue const? ==const; key : string) : JsonValue? const {
     //! Returns the value of the key in the JSON object, if it exists.
-    return a != null && a.value is _object ? (a.value as _object)?[key] ?? JVNull() : JVNull()
+    return a != null && a.value is _object ? (a.value as _object)?[key] ?? json_null_sentinel() : json_null_sentinel()
 }
 
 def operator ?[] (var a : json::JsonValue? ==const; key : string) : JsonValue? {
     //! Returns the value of the key in the JSON object, if it exists.
-    return a != null && a.value is _object ? (a.value as _object)?[key] ?? JVNull() : JVNull()
+    return a != null && a.value is _object ? (a.value as _object)?[key] ?? json_null_sentinel() : json_null_sentinel()
 }
 
 def operator ?.(a : json::JsonValue const? ==const; key : string) : JsonValue? const {
     //! Returns the value of the key in the JSON object, if it exists.
-    return a != null && a.value is _object ? (a.value as _object)?[key] ?? JVNull() : JVNull()
+    return a != null && a.value is _object ? (a.value as _object)?[key] ?? json_null_sentinel() : json_null_sentinel()
 }
 
 def operator ?.(var a : json::JsonValue? ==const; key : string) : JsonValue? {
     //! Returns the value of the key in the JSON object, if it exists.
-    return a != null && a.value is _object ? (a.value as _object)?[key] ?? JVNull() : JVNull()
+    return a != null && a.value is _object ? (a.value as _object)?[key] ?? json_null_sentinel() : json_null_sentinel()
 }
 
 def operator ?[] (a : json::JsonValue const? ==const; idx : int) : JsonValue? const {
     //! Returns the value of the index in the JSON array, if it exists.
-    return a != null && a.value is _array ? (a.value as _array)?[idx] ?? JVNull() : JVNull()
+    return a != null && a.value is _array ? (a.value as _array)?[idx] ?? json_null_sentinel() : json_null_sentinel()
 }
 
 def operator ?[] (var a : json::JsonValue? ==const; idx : int) : JsonValue? {
     //! Returns the value of the index in the JSON array, if it exists.
-    return a != null && a.value is _array ? (a.value as _array)?[idx] ?? JVNull() : JVNull()
+    return a != null && a.value is _array ? (a.value as _array)?[idx] ?? json_null_sentinel() : json_null_sentinel()
 }
 
 def private null_coalescing(a : json::JsonValue const?; val : auto(TT)) : TT {

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -441,6 +441,7 @@ def document_module_json(_root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Value conversion", mod, %regex~(JV|JVNull)$%%),
         group_by_regex("Read and write", mod, %regex~(read_json|write_json)$%%),
+        group_by_regex("Memory management", mod, %regex~(delete_json|update|json_null_sentinel)$%%),
         group_by_regex("JSON properties", mod, %regex~(set_no_trailing_zeros|set_no_empty_arrays|set_allow_duplicate_keys)$%%),
         group_by_regex("Broken JSON", mod, %regex~(try_fixing_broken_json)$%%)
     )

--- a/modules/dasLiveHost/live/live_commands.das
+++ b/modules/dasLiveHost/live/live_commands.das
@@ -21,7 +21,6 @@ require daslib/json
 require daslib/json_boost
 require daslib/ast_boost
 require daslib/templates_boost
-require daslib/strings_boost
 require live_host
 
 // --- Registry ---
@@ -32,10 +31,7 @@ var public live_command_descriptions : table<string; string>
 // --- Help ---
 
 def private live_help_json() : string {
-    var commands : table<string; string>
-    for (name, desc in keys(live_command_descriptions), values(live_command_descriptions)) {
-        commands[name] = desc
-    }
+    let commands : table<string; string> <- {for (name, desc in keys(live_command_descriptions), values(live_command_descriptions)); name => desc}
     var tab : table<string; JsonValue?>
     tab |> insert("commands", JV(commands))
     return write_json(JV(tab))
@@ -43,26 +39,47 @@ def private live_help_json() : string {
 
 // --- Dispatch (called from [before_update]) ---
 
+// Serialize `jsv` to a JSON string and free it. Centralizes the "build a
+// throwaway JsonValue, write it, drop it" pattern for the dispatch's reply
+// values so none of them leak per command.
+def private take_json(var jsv : JsonValue?) : string {
+    let out = write_json(jsv)
+    delete_json(jsv)
+    return out
+}
+
 [export]
 def public live_dispatch_command(command_json : string) : string {
     //! Parses a command JSON string, looks up the command name in the registry,
     //! calls the handler, and returns the response as a JSON string.
+    //! The parsed input tree and the handler's result tree are both freed before
+    //! returning — every live command thus costs zero net JsonValue heap. This relies
+    //! on the handler contract: a handler returns a freshly-owned tree and never
+    //! retains/returns its `input` (audited across the imgui stack + dasLiveHost).
     var parse_error = ""
     var js = read_json(command_json, parse_error)
-    if (js == null) return write_json(JV("parse error: {parse_error}"))
+    if (js == null) return take_json(JV("parse error: {parse_error}"))
+    var out : string
     let name = js?.name ?? ""
-    if (empty(name)) return write_json(JV("missing command name"))
-    if (name == "help") return live_help_json()
-    if (!key_exists(live_command_registry, name)) return write_json(JV("unknown command: {name}"))
-    var args : JsonValue?
-    if (js.value is _object) {
-        let tab & = unsafe(js.value as _object)
-        args = unsafe(reinterpret<JsonValue?>(tab?["args"] ?? null))
+    if (empty(name)) {
+        out = take_json(JV("missing command name"))
+    } elif (name == "help") {
+        out = live_help_json()
+    } elif (!key_exists(live_command_registry, name)) {
+        out = take_json(JV("unknown command: {name}"))
+    } else {
+        // `args` is a borrowed sub-node of `js` (freed below with the rest of js).
+        var args : JsonValue?
+        if (js.value is _object) {
+            let tab & = unsafe(js.value as _object)
+            args = unsafe(reinterpret<JsonValue?>(tab?["args"] ?? null))
+        }
+        let handler = live_command_registry[name]
+        var result = invoke(handler, args)
+        out = result != null ? take_json(result) : take_json(JV(true))
     }
-    let handler = live_command_registry[name]
-    var result = invoke(handler, args)
-    if (result != null) return write_json(result)
-    return write_json(JV(true))
+    delete_json(js)   // frees the input tree incl. the borrowed `args` sub-node
+    return out
 }
 
 // --- Macro ---

--- a/modules/dasLiveHost/live/live_commands.das
+++ b/modules/dasLiveHost/live/live_commands.das
@@ -34,7 +34,7 @@ def private live_help_json() : string {
     let commands : table<string; string> <- {for (name, desc in keys(live_command_descriptions), values(live_command_descriptions)); name => desc}
     var tab : table<string; JsonValue?>
     tab |> insert("commands", JV(commands))
-    return write_json(JV(tab))
+    return take_json(JV(tab))
 }
 
 // --- Dispatch (called from [before_update]) ---


### PR DESCRIPTION
JSON values are allocated per node on the (now-default) persistent heap. Several hot paths churned them and never freed them — steady GC pressure in any long-running live/imgui app that polls snapshots. This removes the churn at the source.

## `daslib/json`
- **`delete_json(jsv)`** — free a JsonValue tree. `delete` already deep-recurses under this module's `strict_smart_pointers` (the `_object`/`_array` finalizers delete their pointees), so this is a null/sentinel-safe `unsafe`-wrapping convenience that names the intent at call sites.
- **`update(obj, key, v)`** — set an object field, first freeing whatever was stored at `key`. For reused/long-lived objects overwritten every frame, where a bare `insert` drops the old value on the heap.
- **`json_null_sentinel()`** — a shared, per-context `null` JsonValue returned by `?[]`/`?.` on a missing key/index, so missing-key navigation allocates nothing. Previously each miss allocated a fresh `JVNull()` (~80 bytes) that was immediately discarded — pervasive, since every `from_JV` absent-optional and every `snap?[a]?[b] ?? d` with a missing link hit it. Preserves the "`?[]` is never null" contract existing code relies on; protected from deletion (guarded in `delete_json`, and `update` substitutes a fresh null rather than storing the shared one).

## `daslib/json_boost`
The 6 `?[]` / `?.` operators return `json_null_sentinel()` on a miss instead of `JVNull()`.

## `live_commands`
`live_dispatch_command` now frees **both** the parsed input tree and the handler's result tree after serializing the response — every live command nets zero JsonValue heap. Safe by the handler contract (a handler returns a freshly-owned tree and never returns/retains its `input`), which was audited across the imgui stack + dasLiveHost: **73 handlers, 0 violations**. (`args` is a borrowed sub-node of the input, freed with it.)

## Verification
- Missing-key navigation: **80 B/call → ~0** (one-time sentinel alloc, then reused).
- Full dispatch (parse → `from_JV` with absent optionals → handler → serialize → free): **0 net node growth over 1000 calls**.
- `delete_json` frees nodes **and** all key/value strings; non-null contract preserved; `delete_json(sentinel)` is a no-op; storing a nav-result via `update()` then freeing the tree leaves the sentinel alive.
- json suite green (from_json, edge 128, sscan 62, override) — 199 tests.
- Downstream: full dasImgui integration suite shows no regression; a live buttons.das run held the steady heap flat across 5500+ frames including snapshot dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)