### PR TITLE
flatten: reclaim orphaned AST nodes — cut worst-case compile memory ~50%

### DIFF
--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -910,8 +910,11 @@ def private subst_consts(var e : ExpressionPtr; constmap : table<string; Express
     if (e == null) return null
     var tmpl : Template
     for (nm in keys(constmap)) {
-        let ex = unsafe(constmap?[nm]) ?? null     // non-inserting read (keys() locks the table)
-        tmpl |> replaceVariable(nm, clone_expression(ex))
+        // ?[] yields a const view (non-inserting; keys() locks the table) but the pointed-to
+        // node is genuinely mutable. apply_template clones it per use, so const-strip the raw
+        // pointer instead of pre-cloning (which would orphan a copy every substitution).
+        var ex = unsafe(reinterpret<Expression? -const>(constmap?[nm] ?? null))
+        tmpl |> replaceVariable(nm, ex)
     }
     var res = apply_template(tmpl, e.at, e, false)
     unsafe { delete tmpl }
@@ -943,8 +946,13 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
         if (s is ExprLet && length((s as ExprLet).variables) == 1) {
             var lc = s as ExprLet
             if (!is_flat_temp(lc.variables[0].name) && lc.variables[0].init != null && is_all_const(lc.variables[0].init)) {
-                var folded = eval_to_const(clone_expression(lc.variables[0].init))
-                if (folded |> is_expr_const()) {
+                // eval_single_expression only READS the tree (throwaway context), so fold the
+                // init in place — no defensive clone. On success the old init subtree is
+                // orphaned (replaced by the folded const); reclaim it now.
+                var oldInit = lc.variables[0].init
+                var folded = eval_to_const(oldInit)
+                if (folded |> is_expr_const() && folded != oldInit) {
+                    reclaim_expression(oldInit)
                     lc.variables[0].init = folded
                     constmap["{lc.variables[0].name}"] = folded
                     changed = true

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -224,8 +224,14 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
             if (!is_flat_temp(v.name) || key_exists(reassigned, h) || key_exists(constmap, h) || v.init == null) {
                 continue
             }
+            // fold_const builds a fully-fresh clone tree just to test for a const bool; in a
+            // while(changed) sweep those probe clones otherwise pile up to the end-of-pass
+            // gc_guard sweep. Reclaim each probe the moment we've read its verdict.
             var bv = false
-            if (const_bool(fold_const(v.init, constmap), bv)) {
+            var probe = fold_const(v.init, constmap)
+            let isConst = const_bool(probe, bv)
+            reclaim_expression(probe)
+            if (isConst) {
                 constmap[h] = bv
                 changed = true
             }
@@ -236,26 +242,35 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
         delete constmap
         return
     }
+    // fold_const returns a fresh tree, orphaning the input subtree; reclaim each old subtree
+    // now rather than leaving it for the end-of-pass sweep.
     var i = 0
     while (i < length(out)) {
         var s = out[i]
         if (s is ExprCopy) {
             var cp = s as ExprCopy
-            cp.right = fold_const(cp.right, constmap)
+            var old = cp.right
+            cp.right = fold_const(old, constmap)
+            reclaim_expression(old)
         } elif (s is ExprLet) {
             var lc = s as ExprLet
             for (v in lc.variables) {
                 if (v.init != null) {
-                    v.init = fold_const(v.init, constmap)
+                    var old = v.init
+                    v.init = fold_const(old, constmap)
+                    reclaim_expression(old)
                 }
             }
         } elif (s is ExprReturn) {
             var r = s as ExprReturn
             if (r.subexpr != null) {
-                r.subexpr = fold_const(r.subexpr, constmap)
+                var old = r.subexpr
+                r.subexpr = fold_const(old, constmap)
+                reclaim_expression(old)
             }
         } else {
             out[i] = fold_const(s, constmap)
+            reclaim_expression(s)
         }
         i ++
     }
@@ -535,6 +550,11 @@ def public dse_pass(var out : array<ExpressionPtr>) {
     if (empty(dead)) {
         delete dead
         return
+    }
+    // Reclaim the dead statements now (the comprehension below drops them from `out`,
+    // orphaning them to the end-of-pass sweep otherwise). Safe: the rebuild skips dead j.
+    for (j in keys(dead)) {
+        reclaim_expression(out[j])
     }
     out <- [for (j in range(n)); out[j]; where !key_exists(dead, j)]
     delete dead

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -21,6 +21,48 @@ def private is_flat_temp(name : das_string) : bool {
     return name |> starts_with("__flat_")
 }
 
+// Reclaim walker: free the expression + TypeDecl nodes of an orphaned subtree now, instead
+// of leaving them for the gc_guard sweep at the end of the (long) flatten pass. The visitor
+// collects every owned expression and type but never follows ExprVar.variable, so shared
+// bindings are untouched; deleting an ExprVar node frees only the node, not the Variable it
+// points at. The seen-set dedups the visitor's double-presentation of some nodes (a single
+// gc_unlink+delete twice would be a double-free). Caller must own the subtree exclusively.
+class private ReclaimWalker : AstVisitor {
+    exprs : array<ExpressionPtr>
+    types : array<TypeDeclPtr>
+    seen : table<uint64>
+    def override preVisitExpression(expr : ExpressionPtr) : void {
+        let key = unsafe(reinterpret<uint64>(expr))
+        if (!key_exists(seen, key)) {
+            seen |> insert(key)
+            exprs |> push(unsafe(reinterpret<ExpressionPtr>(expr)))
+        }
+    }
+    def override preVisitTypeDecl(typ : TypeDeclPtr) : void {
+        let key = unsafe(reinterpret<uint64>(typ))
+        if (!key_exists(seen, key)) {
+            seen |> insert(key)
+            types |> push(unsafe(reinterpret<TypeDeclPtr>(typ)))
+        }
+    }
+}
+
+def private reclaim_expression(var e : ExpressionPtr) {
+    if (e == null) return
+    var w = new ReclaimWalker()
+    make_visitor(*w) $(adapter) {
+        visit(e, adapter)
+    }
+    for (n in w.exprs) {
+        unsafe { delete_expression(n) }
+    }
+    for (t in w.types) {
+        unsafe { delete_type(t) }
+    }
+    delete w.seen
+    unsafe { delete w }
+}
+
 // ===== Dead-store elimination =====
 //
 // The lowered body is straight-line (no branches), so liveness is a single
@@ -189,7 +231,11 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
             }
         }
     }
-    if (empty(constmap)) return
+    delete reassigned
+    if (empty(constmap)) {
+        delete constmap
+        return
+    }
     var i = 0
     while (i < length(out)) {
         var s = out[i]
@@ -213,6 +259,7 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
         }
         i ++
     }
+    delete constmap
 }
 
 // ===== Copy propagation of single-assignment flatten temps =====
@@ -331,20 +378,25 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             }
         }
         var srcReads : table<uint64>
+        var useJs : array<int>   // hoisted: cleared per candidate, freed once per pass
         for (k in range(n)) {
             if (!(out[k] is ExprLet)) continue
-            let lc = out[k] as ExprLet
+            var lc = out[k] as ExprLet
             if (length(lc.variables) != 1 || !is_flat_temp(lc.variables[0].name)) continue
             let hk = hash(lc.variables[0].name)
             let nStores = key_exists(storeIdx, hk) ? length(storeIdx[hk]) : 0
-            // Single definition: decl-init + no stores, OR no-init decl + one store.
+            // Single definition: decl-init + no stores, OR no-init decl + one store. Use the
+            // ORIGINAL source (no clone) — apply_template clones it per use, and the original
+            // lives in out[k]/out[si], reclaimed when we drop them. Cloning here would orphan a
+            // copy on every non-folding candidate (re-examined each while-restart → millions).
             var src : ExpressionPtr = null
             var si = -1
             if (lc.variables[0].init != null && nStores == 0) {
-                src = clone_expression(lc.variables[0].init)   // decl-init is the single definition
+                src = lc.variables[0].init                    // decl-init is the single definition
             } elif (lc.variables[0].init == null && nStores == 1) {
                 si = storeIdx[hk][0]
-                src = clone_expression((out[si] as ExprCopy).right)   // no-init decl + single store
+                var cp = out[si] as ExprCopy
+                src = cp.right                                // no-init decl + single store
             } else {
                 continue                                      // multi-def (e.g. early-return mask) — leave it
             }
@@ -358,7 +410,7 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             let refCount = (key_exists(ub.nameCount, hk) ? ub.nameCount[hk] : 0) - (si >= 0 ? 1 : 0)
             var firstRef = n
             var maxUseIdx = -1
-            var useJs : array<int>
+            clear(useJs)
             if (key_exists(ub.nameUses, hk)) {
                 for (j in ub.nameUses[hk]) {
                     if (j == k || j == si) continue
@@ -389,9 +441,16 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             // Inline the source at every use, then drop the def (+ store).
             let nm = "{lc.variables[0].name}"
             var rules : Template
-            rules |> replaceVariable(nm, clone_expression(src))
+            rules |> replaceVariable(nm, src)   // store src directly; apply_template clones per use
             for (j in useJs) {
                 out[j] = apply_template(rules, out[j].at, out[j], false)   // only statements that reference nm
+            }
+            unsafe { delete rules }
+            // Reclaim the dropped def (+ store) subtrees now (their original source was just
+            // inlined as clones), rather than waiting for the gc_guard sweep.
+            reclaim_expression(out[k])
+            if (si >= 0) {
+                reclaim_expression(out[si])
             }
             out <- [for (j in range(n)); out[j]; where j != k && j != si]
             changed = true
@@ -399,6 +458,7 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
         }
         delete srcReads
         delete storeIdx
+        delete useJs
         unsafe {
             delete ub
         }
@@ -418,16 +478,17 @@ def public dse_pass(var out : array<ExpressionPtr>) {
     }
     var live : table<uint64>
     var dead : table<int>
+    var reads : table<uint64>   // hoisted: one scratch table, cleared per statement (was n allocations)
     var i = n - 1
     while (i >= 0) {
         var stmt = out[i]
         var handled = false
+        clear(reads)
         if (stmt is ExprCopy) {
             var cp = stmt as ExprCopy
             if (cp.left is ExprVar && is_flat_temp((cp.left as ExprVar).name)) {
                 handled = true
                 let lh = hash((cp.left as ExprVar).name)
-                var reads : table<uint64>
                 var risky = false
                 scan_flat(cp.right, reads, risky)
                 if (!key_exists(live, lh) && !risky) {
@@ -445,7 +506,6 @@ def public dse_pass(var out : array<ExpressionPtr>) {
             if (length(lc.variables) == 1 && is_flat_temp(lc.variables[0].name)) {
                 handled = true
                 let dh = hash(lc.variables[0].name)
-                var reads : table<uint64>
                 var risky = false
                 scan_flat(lc.variables[0].init, reads, risky)
                 if (!key_exists(live, dh) && !key_exists(storeTargets, dh) && !risky) {
@@ -461,7 +521,6 @@ def public dse_pass(var out : array<ExpressionPtr>) {
         if (!handled) {
             // Decl / return / global write / bare expr — over-approximate: every
             // flat var it mentions becomes live (never wrongly removes a store).
-            var reads : table<uint64>
             var risky = false
             scan_flat(stmt, reads, risky)
             for (nm in keys(reads)) {
@@ -470,8 +529,15 @@ def public dse_pass(var out : array<ExpressionPtr>) {
         }
         i --
     }
-    if (empty(dead)) return
+    delete storeTargets
+    delete live
+    delete reads
+    if (empty(dead)) {
+        delete dead
+        return
+    }
     out <- [for (j in range(n)); out[j]; where !key_exists(dead, j)]
+    delete dead
 }
 
 // ===== SSA-rename of reassigned user locals =====
@@ -496,7 +562,9 @@ def private rename_reads(var e : ExpressionPtr; current : table<string; string>)
         any = true
     }
     if (!any) return e
-    return apply_template(tmpl, e.at, e, false)
+    var res = apply_template(tmpl, e.at, e, false)
+    unsafe { delete tmpl }
+    return res
 }
 
 def public ssa_rename_pass(var out : array<ExpressionPtr>) {
@@ -508,7 +576,10 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
             if (!is_flat_temp(v.name) && v.init != null) declaredInit |> insert(hash(v.name))
         }
     }
-    if (empty(declaredInit)) return
+    if (empty(declaredInit)) {
+        delete declaredInit
+        return
+    }
     // (2) of those, the ones reassigned via a plain `var = ...` (multi-def)
     var ssaNames : table<uint64>
     for (s in out) {
@@ -517,7 +588,11 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
             if (key_exists(declaredInit, h)) ssaNames |> insert(h)
         }
     }
-    if (empty(ssaNames)) return
+    delete declaredInit
+    if (empty(ssaNames)) {
+        delete ssaNames
+        return
+    }
     // (3) forward rename: each read maps to the current version; each write mints a new
     // version (after resolving the RHS reads, so a self-ref reads the prior version).
     var current : table<string; string>
@@ -546,6 +621,8 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
         }
         i ++
     }
+    delete ssaNames
+    delete current
 }
 
 class private FoldVisitor : AstVisitor {
@@ -836,7 +913,9 @@ def private subst_consts(var e : ExpressionPtr; constmap : table<string; Express
         let ex = unsafe(constmap?[nm]) ?? null     // non-inserting read (keys() locks the table)
         tmpl |> replaceVariable(nm, clone_expression(ex))
     }
-    return apply_template(tmpl, e.at, e, false)
+    var res = apply_template(tmpl, e.at, e, false)
+    unsafe { delete tmpl }
+    return res
 }
 
 def private body_read_count(var blk : ExprBlock?; nm : string) : int {
@@ -897,6 +976,7 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
             }
             changed = true
         }
+        delete dead
     }
     return changed
 }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -357,7 +357,7 @@ def document_module_ast(_root : string) {
         group_by_regex("Debug info helpers", mod, %regex~(debug_helper_.*)%%),
         group_by_regex("AOT support", mod, %regex~(aot_require|aot_type_ann_get_field_ptr|aot_need_type_info|aot_previsit_get_field_ptr|aot_previsit_get_field|aot_visit_get_field|write_aot_body|write_aot_suffix|write_aot_macro_suffix|write_aot_macro_prefix|macro_aot_infix|getInitSemanticHashWithDep|get_aot_hash_comment)$%%),
         group_by_regex("String builder writer", mod, %regex~(string_builder_str|string_builder_clear)$%%),
-        group_by_regex("GC", mod, %regex~(ast_gc_guard|verify_typedecl_gc|verify_expression_gc)$%%),
+        group_by_regex("GC", mod, %regex~(ast_gc_guard|verify_typedecl_gc|verify_expression_gc|delete_expression|delete_type)$%%),
         hide_group(group_by_regex("Internal ast infrastructure", mod, %regex~(builtin_ast_.*)%%))
     )
     documents("AST manipulation library", mod, "ast.rst", groups)

--- a/doc/source/stdlib/handmade/function-ast-delete_expression-0xb0b5dc4b8aa7bb34.rst
+++ b/doc/source/stdlib/handmade/function-ast-delete_expression-0xb0b5dc4b8aa7bb34.rst
@@ -1,0 +1,1 @@
+Frees a single orphaned AST expression node mid-compile instead of waiting for the enclosing ast_gc_guard to sweep it; only the node itself is freed (its children remain on the gc root, so a caller-side walker must delete them too). Unsafe: the caller must own the node exclusively.

--- a/doc/source/stdlib/handmade/function-ast-delete_type-0xe22d33c2e0265b29.rst
+++ b/doc/source/stdlib/handmade/function-ast-delete_type-0xe22d33c2e0265b29.rst
@@ -1,0 +1,1 @@
+Frees a single orphaned AST TypeDecl node mid-compile (sibling of delete_expression); only the node itself is freed, not its sub-types or the shared structType/enumType it points at. Unsafe: the caller must own the node exclusively.

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -515,6 +515,8 @@ namespace das {
     __forceinline void verify_expression_gc ( ExpressionPtr value ) { if ( value ) value->gc_verify(); }
     __forceinline StructurePtr clone_structure ( const Structure * value ) { return value ? value->clone() : nullptr; }
     __forceinline VariablePtr clone_variable ( VariablePtr value ) { return value ? value->clone() : nullptr; }
+    DAS_API void delete_expression ( ExpressionPtr expr );
+    DAS_API void delete_type ( TypeDeclPtr typ );
     DAS_API void forceAtRaw ( Expression * expr, const LineInfo & at );
     DAS_API void getAstContext ( smart_ptr_raw<Program> prog, Expression * expr, const TBlock<void,bool,AstContext> & block, Context * context, LineInfoArg * at );
     DAS_API char * get_mangled_name ( Function * func, Context * context, LineInfoArg * at );

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -408,6 +408,30 @@ namespace das {
         das_invoke<void>::invoke(context,at,block);
     }
 
+    // Free a SINGLE orphaned AST expression node mid-compile, instead of waiting for the
+    // enclosing gc_guard to sweep it. gc nodes live flat on a root list, so this frees
+    // only `expr` itself — its children stay on the root (a caller-side reclaim walker
+    // deletes them one by one). We must NOT use gc_collect here: that traversal follows
+    // shared cross-references (ExprVar->Variable, TypeDecl->Structure/Enumeration) and
+    // would sweep live module entities. gc_unlink first so ~gc_node doesn't re-unlink
+    // (and so DAS_GC_DEBUG's "deleted outside gc_sweep" assert stays quiet).
+    // UNSAFE: the caller must own `expr` exclusively.
+    void delete_expression ( ExpressionPtr expr ) {
+        if ( !expr ) return;
+        expr->gc_unlink();
+        delete expr;
+    }
+
+    // Free a SINGLE orphaned TypeDecl node (sibling of delete_expression). Only the node
+    // itself — sub-types (firstType/argTypes/...) are separate gc_nodes a reclaim walker
+    // deletes individually. Does NOT touch shared structType/enumType (those are pointers
+    // the dtor never follows). UNSAFE: caller must own the node.
+    void delete_type ( TypeDeclPtr typ ) {
+        if ( !typ ) return;
+        typ->gc_unlink();
+        delete typ;
+    }
+
     void for_each_module ( Program * prog, const TBlock<void,Module *> & block, Context * context, LineInfoArg * at ) {
         prog->library.foreach_in_order([&](auto mod){
             das_invoke<void>::invoke<Module *>(context,at,block,mod);
@@ -1271,6 +1295,12 @@ namespace das {
         addExtern<DAS_BIND_FUN(clone_expression)>(*this, lib,  "clone_expression",
             SideEffects::none, "clone_expression")
                 ->arg("expression");
+        addExtern<DAS_BIND_FUN(delete_expression)>(*this, lib,  "delete_expression",
+            SideEffects::modifyExternal, "delete_expression")
+                ->arg("expression")->unsafeOperation = true;
+        addExtern<DAS_BIND_FUN(delete_type)>(*this, lib,  "delete_type",
+            SideEffects::modifyExternal, "delete_type")
+                ->arg("type")->unsafeOperation = true;
         addExtern<DAS_BIND_FUN(clone_function)>(*this, lib,  "clone_function",
             SideEffects::none, "clone_function")
                 ->arg("function");


### PR DESCRIPTION
## Summary

Cuts `[flatten]` compile-time memory by reclaiming orphaned AST nodes during lowering/opt instead of leaving them all for the end-of-pass `gc_guard` sweep, and by not creating the orphans in the first place where the clone was pure waste. Measured on the flatten fuzzer's worst case (`crash_cand0`, a 1081-line source whose twin lowers to ~2900 statements):

| | RSS | peak footprint |
|---|---|---|
| before (post #3032) | 744 MB | 688 MB |
| after | **387 MB** | **328 MB** |

**−48% RSS, −52% peak.** Output is byte-identical to before — every change is either a dropped redundant clone (the substitution machinery already clones per use) or an immediate free of an already-orphaned subtree.

## Changes

1. **Reclaim infrastructure + the headline fix.** New `delete_expression` / `delete_type` AST builtins (single-node `gc_unlink` + `delete` — deliberately NOT `gc_collect`, which would follow shared `ExprVar`→`Variable` / `TypeDecl`→`Structure` references and sweep live module entities), plus a `reclaim_expression` walker that frees an orphaned subtree's expression+type nodes now. `copy_prop_pass` was cloning the propagation source for every single-def candidate, but `apply_template` already clones each substitution per use and the original lives in the body — and blocked candidates were re-examined every `while`-restart, piling up ~1.4M orphan clones. Use the original source directly and reclaim the dropped def/store. (688→338 MB peak on its own.)

2. **Drop clone-then-discard in the const-prop fold path.** `eval_single_expression` only reads its argument, so `const_prop_locals` need not clone the init before `eval_to_const`; and `subst_consts` had the PERF023 double-clone (`apply_template` re-clones each substitution anyway). Fold in place, reclaim the orphaned original.

3. **Reclaim opt-pass orphans.** `const_prop_pass`'s detection sweep runs `fold_const` in a `while`-loop purely to test each `__flat_*` bool init, throwing the clone away — reclaim each probe immediately. Same for the application loop's replaced subtrees and `dse_pass`'s dropped dead statements.

4. **Docs.** Group the new builtins under the "GC" das2rst group + handmade descriptions (otherwise Uncategorized fails the Sphinx `-W` gate).

## Notes

- The remaining peak is dominated by the **live inflated twin body + re-inference type nodes**, not reclaimable garbage — clone+reclaim is near its floor here. The next chunk (~50 MB of `fold_const`'s internal clone churn) wants an in-place `fold_const`, cleanest once #3033 lands (then a non-cloning const-bool detection becomes safe too).
- #3033 (a recursive `var T&` out-param read in a condition is miscompiled) was found and filed while exploring the non-cloning path; the clone+reclaim approach here sidesteps it entirely.

## Verification

- Interp suite: **10528 passed / 0 failed / 0 errors** (6 skipped)
- Flatten unit tests: 116/116
- Fuzzer value-differential: 20 batches × 20 units × 45 inputs, all `f == f_flat`
- JIT smoke: no verifier errors
- AOT suite: **9872 passed / 0 failed / 0 errors** (6 skipped); flatten AOT 116/116 with no hash mismatch (output byte-identical)
- Lint: 0 issues on changed `.das`; das-fmt clean; Sphinx `-W` build succeeded with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)