### PR TITLE
flatten: cut fold_const compile memory — fresh-construct + reclaim inferred types

### DIFF
--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -152,13 +152,15 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
         return clone_expression(e)
     }
     if (e is ExprOp1) {
-        var sub = fold_const((e as ExprOp1).subexpr, constmap)
+        let o = e as ExprOp1
+        var sub = fold_const(o.subexpr, constmap)
         var bv = false
-        if ((e as ExprOp1).op == "!" && const_bool(sub, bv)) {
+        if (o.op == "!" && const_bool(sub, bv)) {
             reclaim_expression(sub)
             return new ExprConstBool(at = e.at, value = !bv)
         }
-        return new ExprOp1(at = e.at, op := (e as ExprOp1).op, subexpr = sub)
+        return new ExprOp1(at = e.at, atEnclosure = o.atEnclosure, genFlags = o.genFlags,
+            op := o.op, subexpr = sub)
     }
     if (e is ExprOp2) {
         let o = e as ExprOp2
@@ -201,7 +203,8 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
                 return l
             }
         }
-        return new ExprOp2(at = e.at, op := o.op, left = l, right = r)
+        return new ExprOp2(at = e.at, atEnclosure = o.atEnclosure, genFlags = o.genFlags,
+            op := o.op, left = l, right = r)
     }
     if (e is ExprOp3) {
         let o = e as ExprOp3
@@ -211,13 +214,14 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
             reclaim_expression(c)
             return cb ? fold_const(o.left, constmap) : fold_const(o.right, constmap)
         }
-        return new ExprOp3(at = e.at, op := o.op, subexpr = c,
+        return new ExprOp3(at = e.at, atEnclosure = o.atEnclosure, genFlags = o.genFlags,
+            op := o.op, subexpr = c,
             left = fold_const(o.left, constmap),
             right = fold_const(o.right, constmap))
     }
     if (e is ExprCall) {
         let o = e as ExprCall
-        var n = new ExprCall(at = e.at, name := o.name)
+        var n = new ExprCall(at = e.at, atEnclosure = o.atEnclosure, genFlags = o.genFlags, name := o.name)
         for (ai in range(length(o.arguments))) {
             emplace_new(n.arguments) <| fold_const(o.arguments[ai], constmap)
         }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -27,23 +27,40 @@ def private is_flat_temp(name : das_string) : bool {
 // bindings are untouched; deleting an ExprVar node frees only the node, not the Variable it
 // points at. The seen-set dedups the visitor's double-presentation of some nodes (a single
 // gc_unlink+delete twice would be a double-free). Caller must own the subtree exclusively.
+//
+// The visitor only descends into SOURCE-level type fields (castType, makeType, var type, …),
+// not the inferred `_type` hanging off every typed expression — so collectType walks that
+// per-expression tree manually. The whole flatten twin is built by cloning, and
+// Expression::clone makes a fresh `new TypeDecl(*type)` whose firstType/secondType/argTypes
+// are deep-copied (AST invariant: no duplicated TypeDecl nodes), so each inferred type is
+// uniquely owned and safe to free. structType/enumType are shared entity pointers — we never
+// follow them, and delete_type frees only the node.
 class private ReclaimWalker : AstVisitor {
     exprs : array<ExpressionPtr>
     types : array<TypeDeclPtr>
     seen : table<uint64>
+    def collectType(var t : TypeDeclPtr) : void {
+        if (t == null) return
+        let key = unsafe(reinterpret<uint64>(t))
+        if (key_exists(seen, key)) return
+        seen |> insert(key)
+        types |> push(t)
+        collectType(t.firstType)
+        collectType(t.secondType)
+        for (i in range(length(t.argTypes))) {
+            collectType(t.argTypes[i])
+        }
+    }
     def override preVisitExpression(expr : ExpressionPtr) : void {
         let key = unsafe(reinterpret<uint64>(expr))
         if (!key_exists(seen, key)) {
             seen |> insert(key)
             exprs |> push(unsafe(reinterpret<ExpressionPtr>(expr)))
         }
+        collectType(unsafe(reinterpret<TypeDecl? -const>(expr._type)))
     }
     def override preVisitTypeDecl(typ : TypeDeclPtr) : void {
-        let key = unsafe(reinterpret<uint64>(typ))
-        if (!key_exists(seen, key)) {
-            seen |> insert(key)
-            types |> push(unsafe(reinterpret<TypeDeclPtr>(typ)))
-        }
+        collectType(unsafe(reinterpret<TypeDecl? -const>(typ)))
     }
 }
 

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -138,11 +138,10 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
         var sub = fold_const((e as ExprOp1).subexpr, constmap)
         var bv = false
         if ((e as ExprOp1).op == "!" && const_bool(sub, bv)) {
+            reclaim_expression(sub)
             return new ExprConstBool(at = e.at, value = !bv)
         }
-        var n = clone_expression(e)
-        (n as ExprOp1).subexpr = sub
-        return n
+        return new ExprOp1(at = e.at, op := (e as ExprOp1).op, subexpr = sub)
     }
     if (e is ExprOp2) {
         let o = e as ExprOp2
@@ -154,47 +153,56 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
         let rc = const_bool(r, rb)
         if (o.op == "&&") {
             if (lc) {
-                if (lb) return r
+                if (lb) { reclaim_expression(l); return r }
+                reclaim_expression(l)
+                reclaim_expression(r)
                 return new ExprConstBool(at = e.at, value = false)
             }
             if (rc) {
-                if (rb) return l
+                if (rb) { reclaim_expression(r); return l }
+                reclaim_expression(l)
+                reclaim_expression(r)
                 return new ExprConstBool(at = e.at, value = false)
             }
         } elif (o.op == "||") {
             if (lc) {
-                if (lb) return new ExprConstBool(at = e.at, value = true)
+                if (lb) {
+                    reclaim_expression(l)
+                    reclaim_expression(r)
+                    return new ExprConstBool(at = e.at, value = true)
+                }
+                reclaim_expression(l)
                 return r
             }
             if (rc) {
-                if (rb) return new ExprConstBool(at = e.at, value = true)
+                if (rb) {
+                    reclaim_expression(l)
+                    reclaim_expression(r)
+                    return new ExprConstBool(at = e.at, value = true)
+                }
+                reclaim_expression(r)
                 return l
             }
         }
-        var n = clone_expression(e)
-        (n as ExprOp2).left = l
-        (n as ExprOp2).right = r
-        return n
+        return new ExprOp2(at = e.at, op := o.op, left = l, right = r)
     }
     if (e is ExprOp3) {
         let o = e as ExprOp3
         var c = fold_const(o.subexpr, constmap)
         var cb = false
         if (const_bool(c, cb)) {
+            reclaim_expression(c)
             return cb ? fold_const(o.left, constmap) : fold_const(o.right, constmap)
         }
-        var n = clone_expression(e)
-        (n as ExprOp3).subexpr = c
-        (n as ExprOp3).left = fold_const(o.left, constmap)
-        (n as ExprOp3).right = fold_const(o.right, constmap)
-        return n
+        return new ExprOp3(at = e.at, op := o.op, subexpr = c,
+            left = fold_const(o.left, constmap),
+            right = fold_const(o.right, constmap))
     }
     if (e is ExprCall) {
         let o = e as ExprCall
-        var n = clone_expression(e)
-        var nc = n as ExprCall
+        var n = new ExprCall(at = e.at, name := o.name)
         for (ai in range(length(o.arguments))) {
-            nc.arguments[ai] = fold_const(o.arguments[ai], constmap)
+            emplace_new(n.arguments) <| fold_const(o.arguments[ai], constmap)
         }
         return n
     }


### PR DESCRIPTION
## Summary

Two follow-ups to #3035, both cutting `[flatten]` compile-time memory on the constant-fold / opt path. Measured on the flatten fuzzer's worst case (`crash_cand0`, a 1081-line source whose twin lowers to ~2900 statements):

| | peak footprint |
|---|---|
| after #3035 (master) | 329 MB |
| after this PR | **272 MB** |

**−17% on top of #3035; −60% from the pre-#3035 original (688 MB).** Output is byte-identical.

## Changes (2 commits)

**1. Fresh-construct the folded node instead of clone-then-overwrite.**
`fold_const` rebuilt each `ExprOp1` / `ExprOp2` / `ExprOp3` / `ExprCall` by `clone_expression(e)` — a *deep* clone — and then overwrote the cloned children with their folded versions, allocating and immediately discarding a full child clone on every node, with the orphans surviving to the end-of-pass `gc_guard` sweep. Construct the result node fresh (`new ExprOp1` / `ExprOp2` / `ExprOp3` / `ExprCall`) and attach the already-folded children directly; between-cycle re-inference re-fills the inferred type and the resolved operator func, exactly as the existing fresh op-node construction in `flatten.das` / `ast_boost.das` already relies on. No deep child clone is allocated at all, so this cuts both the instantaneous clone spike and the accumulated orphan leak. Also reclaims the genuinely-orphaned folded operand on each boolean collapse path (`!const`, `&&` / `||` short-circuit, `const ? a : b`). 329 → 281 MB.

**2. Reclaim the inferred type tree of orphaned expressions.**
The reclaim walker freed expression nodes and source-level TypeDecls (cast type, make type, variable type, …), but the AST visitor never descends into the inferred type that hangs off every typed expression — the same blind spot that forces `aot_cpp` to `mark(expr._type)` by hand. On `crash_cand0` ~1080 of the reclaimed orphan roots are typed, so their whole inferred-type trees survived to the sweep. `collectType` now walks that per-expression type recursively (firstType / secondType / argTypes). Safe by the AST no-duplicated-TypeDecl invariant: the flatten twin is built by cloning, and `Expression::clone` makes a fresh `new TypeDecl(*type)` whose nested types are deep-copied, so every inferred type is uniquely owned; the shared structType / enumType pointers are never followed and `delete_type` frees only the node. 281 → 272 MB.

All changes live in `def private` / `class private` symbols in `daslib/flatten_opt.das` — no public API, doc-comment, or C++ binding change.

## Verification

- full interp suite: **10528 passed / 0 failed / 0 errors** (6 skipped)
- full AOT suite (`--use-aot`): **9872 passed / 0 failed / 0 errors** (6 skipped); flatten AOT 116/116, no hash mismatch (output byte-identical)
- flatten interp: 9/9 files (116 tests)
- fuzzer value-differential: 20 batches × 20 units × 45 inputs, all `f == f_flat`
- JIT smoke: no verifier errors
- lint: 0 issues on the changed file; das-fmt clean; dupe-check: `collectType` novel

🤖 Generated with [Claude Code](https://claude.com/claude-code)