### PR TITLE
fix: record recursive ref-arg writes in side-effect analysis (#3033)

### DIFF
--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -528,11 +528,16 @@ namespace das {
             if ( expr->initializer ) {
                 // if modified, modify CALL
                 auto sef = getSideEffects(expr->func);
-                if ( sef & uint32_t(SideEffects::modifyArgument) ) {
+                // see ExprCall: a recursive initializer call is still mid-analysis here
+                const bool inCycle = !expr->func->knownSideEffects
+                    && asked.find(expr->func) != asked.end();
+                if ( inCycle || (sef & uint32_t(SideEffects::modifyArgument)) ) {
                     for ( size_t ai=0, ais=expr->arguments.size(); ai!=ais; ++ai ) {
                         const auto & argT = expr->func->arguments[ai]->type;
                         if ( argT->canWrite() ) {
-                            if ( !expr->func->builtIn ) {
+                            if ( inCycle ) {
+                                propagateWrite(expr->arguments[ai]);
+                            } else if ( !expr->func->builtIn ) {
                                 if ( expr->func->knownSideEffects ) {
                                     propagateWrite(expr->arguments[ai]);
                                 }
@@ -576,11 +581,19 @@ namespace das {
             }
             // if modified, modify NEW
             auto sef = getSideEffects(expr->func);
-            if ( sef & uint32_t(SideEffects::modifyArgument) ) {
+            // a recursive (or mutually-recursive) callee is still mid-analysis here, so
+            // its modifyArgument / knownSideEffects are not established yet — fall back to
+            // the conservative signature rule (a writable-ref argument may be written),
+            // exactly as unresolved calls and invokes already do (issue #3033)
+            const bool inCycle = !expr->func->knownSideEffects
+                && asked.find(expr->func) != asked.end();
+            if ( inCycle || (sef & uint32_t(SideEffects::modifyArgument)) ) {
                 for ( size_t ai=0, ais=expr->arguments.size(); ai!=ais; ++ai ) {
                     const auto & argT = expr->func->arguments[ai]->type;
                     if ( argT->canWrite() ) {
-                        if ( !expr->func->builtIn ) {
+                        if ( inCycle ) {
+                            propagateWrite(expr->arguments[ai]);
+                        } else if ( !expr->func->builtIn ) {
                             if ( expr->func->knownSideEffects ) {
                                 propagateWrite(expr->arguments[ai]);
                             }

--- a/tests/language/recursive_ref_out_param.das
+++ b/tests/language/recursive_ref_out_param.das
@@ -1,0 +1,82 @@
+options gen2
+options no_unused_function_arguments = false
+require dastest/testing_boost public
+
+// Regression for the recursive `var T&` out-param miscompile (issue #3033).
+// The write a recursive self-call performs through a writable-reference argument
+// must be recorded by the access analysis, so a later r2v read of that local
+// (condition / return / arithmetic) is NOT const-folded back to its initializer.
+
+// direct recursion, result read in a condition
+def rec_cond(n : int; var out : bool&) : bool {
+    if (n <= 1) { out = true; return true }
+    var inner = false
+    let unused = rec_cond(n - 1, inner)
+    if (inner) { return true } // nolint:STYLE017 — condition-read is the exact #3033 surface, must not collapse to `return inner`
+    return false
+}
+
+// direct recursion, result read as a returned value
+def rec_ret(n : int; var out : bool&) : bool {
+    if (n <= 1) { out = true; return true }
+    var inner = false
+    let unused = rec_ret(n - 1, inner)
+    return inner
+}
+
+// direct recursion, int out-param read in a condition
+def rec_int(n : int; var acc : int&) : int {
+    if (n <= 0) { acc = 100; return 100 }
+    var inner = 0
+    let unused = rec_int(n - 1, inner)
+    if (inner == 100) { return inner }
+    return -1
+}
+
+// mutual recursion through a cycle — both back-edge and forward-edge must record the write
+def mr_a(n : int; var out : bool&) : bool {
+    if (n <= 1) { out = true; return true }
+    var inner = false
+    let unused = mr_b(n - 1, inner)
+    return inner
+}
+def mr_b(n : int; var out : bool&) : bool {
+    if (n <= 1) { out = true; return true }
+    var inner = false
+    let unused = mr_a(n - 1, inner)
+    return inner
+}
+
+// non-recursive control — was always correct; guards against over-eager folding
+def leaf(x : int; var out : bool&) : bool { out = x > 0; return out }
+def caller(x : int) : bool {
+    var inner = false
+    let unused = leaf(x, inner)
+    if (inner) { return true } // nolint:STYLE017 — mirrors rec_cond's condition-read shape
+    return false
+}
+
+[test]
+def test_recursive_ref_out_param(t : T?) {
+    t |> run("direct recursion, condition read") @(t : T?) {
+        var b = false
+        t |> success(rec_cond(2, b), "recursive write read in a condition")
+    }
+    t |> run("direct recursion, return read") @(t : T?) {
+        var b = false
+        t |> success(rec_ret(2, b), "recursive write read as a return value")
+    }
+    t |> run("direct recursion, int condition read") @(t : T?) {
+        var a = 0
+        t |> equal(rec_int(1, a), 100)
+    }
+    t |> run("mutual recursion") @(t : T?) {
+        var b1 = false
+        var b2 = false
+        t |> success(mr_a(2, b1), "mutual recursion a->b")
+        t |> success(mr_b(2, b2), "mutual recursion b->a")
+    }
+    t |> run("non-recursive control") @(t : T?) {
+        t |> success(caller(5), "non-recursive write read in a condition")
+    }
+}


### PR DESCRIPTION
## Summary

A **recursive** (or mutually-recursive) call that passes a local to its own writable-reference argument (`var T&`) never marked that local as *written*. As a result the local was treated as constant-equal-to-its-initializer, which produced two correlated symptoms:

1. a `LINT003` "variable can be made const" **false positive**, and
2. a **miscompile** — the const-folder rewrote reads of the local back to its initializer, silently dropping the write the recursive call performs.

Fixes #3033.

## Root cause

The side-effect analysis (`src/ast/ast_unused.cpp`, `TrackFieldAndAtFlags::getSideEffects`) uses an `asked` set as a recursion guard. The per-function `modifyArgument` flag is *derived* — and `knownSideEffects` is *set* — only **after** a function's whole body is walked. So while `rec`'s body is being analyzed and we reach the self-call `rec(n-1, inner)`, the nested `getSideEffects(rec)` hits the guard and returns flags that don't yet contain `modifyArgument`, with `knownSideEffects` still `false`. Both gates in `preVisit(ExprCall*)` therefore fail and `propagateWrite(inner)` never runs.

`inner`'s `access_ref` then stays `false`, and the folder at `visit(ExprVar*)` / `visitLet` (both gated on `!access_ref`) replaces the read with the initializer.

This affects **mutual recursion** too — any callee currently in `asked`, not just direct self-calls.

### A note on the issue's repro

The issue's runtime repro prints `b=false` and expects `true`, but **`b=false` is actually correct semantics there**: the observed branch is `if (inner) { return true }`, which never writes `out`, so `b` is never written regardless of the bug — that program prints `b=false, ok=true` whether buggy or fixed. The "expected true" was a misread of the repro.

The bug is real and is demonstrated instead by:
- the `LINT003` false positive (now gone), and
- any **value-read** (r2v) of the recursively-written local — a condition, a `return inner`, or arithmetic. A depth-2 probe `return inner` read `false` before this change and `true` after.

The "read in a condition" framing in the issue is slightly narrow: the trigger is any r2v read. Control 1 (`out = inner`) in the issue only *looks* correct because a copy-from-ref read is not r2v, so the folder skips it and the genuine runtime write survives.

## Fix

When the callee is still mid-analysis (in `asked` and `!knownSideEffects`), fall back to the **conservative signature rule** — a writable-reference argument may be written — exactly as `ExprLooksLikeCall` and `ExprInvoke` already do. Applied to both `ExprCall` and the `ExprNew` initializer-call site. The fallback fires **only** for in-cycle callees, so non-recursive code is byte-identical.

## Tests

New `tests/language/recursive_ref_out_param.das`: direct recursion (condition read, return read, int condition read), mutual recursion (both edges), and a non-recursive control. **4 of its cases failed before the fix and all pass after** (interp + JIT). `mr_a` passing while `mr_b` failed pre-fix confirmed the back-edge analysis exactly.

## Validation

- Full interpreter suite: **10534 passed / 0 failed / 0 errors** (6 skipped) — no regressions from the conservative over-marking.
- Full AOT suite (`--use-aot`): **9878 passed / 0 failed / 0 errors** (6 skipped) — no hash mismatch.
- New regression test: **6/6** under both interpreter and JIT.
- CI: **all 30 checks green** (all-platform builds + AOT, `extended_checks` lint, JIT, wasm).
- Lint clean (CI `utils/lint` + MCP); format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)