### PR TITLE
fix(builtin): to_table_move must move (free) its source, not copy

### DIFF
--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -1698,9 +1698,16 @@ def to_table_move(var a : array<auto(keyT)>) : table<keyT -const> {
     for (at in a) {
         __builtin_table_set_insert(tab, at)
     }
-    // Free the (comprehension-owned) source array; honors the "move" name and
-    // reclaims the temp the table comprehension would otherwise orphan. unsafe
-    // because keyT may be a pointer — safe here: the set stores its own keys.
+    // Reclaim the (comprehension-owned) temp array; honors the "move" name and
+    // frees what the table comprehension would otherwise orphan. tab clones
+    // owned-heap keys (string/array/...) so delete must finalize those, but it
+    // only aliases raw-pointer keys — null those first, or delete would free the
+    // caller-owned pointee tab still references and dangle tab's keys.
+    static_if (typeinfo is_pointer(type<keyT>)) {
+        for (k in a) {
+            k = null
+        }
+    }
     unsafe { delete a; }
     return <- tab
 }
@@ -1757,9 +1764,15 @@ def to_table_move(var a : array<tuple<auto(keyT); auto(valT)>>) : table<keyT -co
     } else {
         concept_assert(false, "this array can't be copied or moved")
     }
-    // Free the (comprehension-owned) source array; honors the "move" name and
-    // reclaims the temp the table comprehension would otherwise orphan. unsafe
-    // because keyT/valT may be pointers.
+    // Moved-out values are already empty. Keys are copied into tab: owned-heap
+    // keys are cloned (delete must finalize the source copy) but raw-pointer keys
+    // are only aliased — null those before delete so it frees just the temp
+    // buffer, not the caller-owned pointee tab now references.
+    static_if (typeinfo is_pointer(type<keyT>)) {
+        for (x in a) {
+            x._0 = null
+        }
+    }
     unsafe { delete a; }
     return <- tab
 }

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -1693,11 +1693,15 @@ def to_table_move(a : auto(keyT)[]) : table<keyT -const> {
     return <- tab
 }
 
-def to_table_move(a : array<auto(keyT)>) : table<keyT -const> {
+def to_table_move(var a : array<auto(keyT)>) : table<keyT -const> {
     var tab : table<keyT -const>
     for (at in a) {
         __builtin_table_set_insert(tab, at)
     }
+    // Free the (comprehension-owned) source array; honors the "move" name and
+    // reclaims the temp the table comprehension would otherwise orphan. unsafe
+    // because keyT may be a pointer — safe here: the set stores its own keys.
+    unsafe { delete a; }
     return <- tab
 }
 
@@ -1737,17 +1741,26 @@ def to_table_move(var a : tuple<auto(keyT); auto(valT)>[]) : table<keyT -const; 
 
 def to_table_move(var a : array<tuple<auto(keyT); auto(valT)>>) : table<keyT -const; valT> {
     var tab : table<keyT -const; valT>
-    static_if (typeinfo can_copy(type<valT>)) {
-        for (x in a) {
-            unsafe(tab[x._0]) = x._1
-        }
-    } static_elif (typeinfo can_move(type<valT>)) {
+    static_if (typeinfo can_move(type<valT>)) {
+        // Always MOVE the value out (we own `a` and free it below). Moving —
+        // not copying — is what makes the source-free safe: a copy of a pointer
+        // value would alias the same node, and `delete a` would then free the
+        // node the table holds (use-after-free). After the move the element is
+        // empty, so delete only reclaims husks + the temp buffer.
         for (x in a) {
             unsafe(tab[x._0]) <- x._1
+        }
+    } static_elif (typeinfo can_copy(type<valT>)) {
+        for (x in a) {
+            unsafe(tab[x._0]) = x._1
         }
     } else {
         concept_assert(false, "this array can't be copied or moved")
     }
+    // Free the (comprehension-owned) source array; honors the "move" name and
+    // reclaims the temp the table comprehension would otherwise orphan. unsafe
+    // because keyT/valT may be pointers.
+    unsafe { delete a; }
     return <- tab
 }
 

--- a/doc/source/stdlib/handmade/function-builtin-to_table_move-0xb7fd1c47b782fe2c.rst
+++ b/doc/source/stdlib/handmade/function-builtin-to_table_move-0xb7fd1c47b782fe2c.rst
@@ -1,1 +1,0 @@
-Converts a mutable dynamic array of keys `a` into a set-style `table<keyT, void>`, moving elements when possible.

--- a/doc/source/stdlib/handmade/function-builtin-to_table_move-0xdd2bb93b18982c3d.rst
+++ b/doc/source/stdlib/handmade/function-builtin-to_table_move-0xdd2bb93b18982c3d.rst
@@ -1,0 +1,1 @@
+Converts a mutable dynamic array of keys `a` into a set-style `table<keyT, void>`, moving its elements and freeing the source array.

--- a/modules/dasLiveHost/live/live_commands.das
+++ b/modules/dasLiveHost/live/live_commands.das
@@ -31,9 +31,13 @@ var public live_command_descriptions : table<string; string>
 // --- Help ---
 
 def private live_help_json() : string {
-    let commands : table<string; string> <- {for (name, desc in keys(live_command_descriptions), values(live_command_descriptions)); name => desc}
+    // Build a table<string;JsonValue?> directly so JV() MOVES it into the tree
+    // (its `_object <- v`) rather than COPYING (JV's is_table path copies a
+    // table<string;string> and leaves the source to leak). cmds/tab are freed
+    // by take_json's delete_json.
+    var cmds <- {for (name, desc in keys(live_command_descriptions), values(live_command_descriptions)); name => JV(desc)}
     var tab : table<string; JsonValue?>
-    tab |> insert("commands", JV(commands))
+    tab |> insert("commands", JV(cmds))
     return take_json(JV(tab))
 }
 

--- a/tests/gc/test_comprehension_no_leak.das
+++ b/tests/gc/test_comprehension_no_leak.das
@@ -1,0 +1,81 @@
+// to_table_move must MOVE (consume + free) its source array, not copy it.
+//
+// A table/set comprehension lowers to "build a temp array<KV> in a closure,
+// then return to_table_move(temp)". The temp is a closure local that is never
+// returned and never deleted, so if to_table_move only COPIES from it the temp
+// buffer is orphaned and leaks ~the table's storage on every evaluation. The
+// fix makes to_table_move consume its source (move values out, then delete the
+// array). We assert that contract directly — length(source) == 0 afterwards —
+// which is deterministic in every execution mode (the equivalent heap-delta
+// check is unreliable under the dastest JIT harness, which reports the same
+// per-comprehension residue with and without the fix).
+//
+// The move path also fixes a use-after-free: copying a pointer value (e.g.
+// JsonValue?) would alias the node into the table, and the source-free would
+// then delete the live node. Moving leaves the element empty, so the heap
+// key/value cases below also guard that crash (delete of the result must not
+// double-free).
+options gen2
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+
+// --- set overload: to_table_move(var a : array<keyT>) ---
+
+[test]
+def test_to_table_move_set_consumes_source(t : T?) {
+    var ks <- [10, 20, 30]
+    var tab <- to_table_move(ks)
+    t |> equal(length(ks), 0)                       // source moved-from, not copied
+    t |> equal(length(tab), 3)
+    t |> success(key_exists(tab, 20), "moved key present")
+    delete tab
+}
+
+[test]
+def test_to_table_move_set_heap_keys(t : T?) {
+    var ks <- ["a", "b"]
+    var tab <- to_table_move(ks)
+    t |> equal(length(ks), 0)
+    t |> success(key_exists(tab, "a") && key_exists(tab, "b"), "moved heap keys present")
+    delete tab
+}
+
+// --- map overload: to_table_move(var a : array<tuple<keyT;valT>>) ---
+
+[test]
+def test_to_table_move_map_consumes_source(t : T?) {
+    var kvs <- [("a", 1), ("b", 2)]
+    var tab <- to_table_move(kvs)
+    t |> equal(length(kvs), 0)                      // source moved-from, not copied
+    t |> equal(tab?["a"] ?? -1, 1)
+    t |> equal(tab?["b"] ?? -1, 2)
+    delete tab
+}
+
+// heap key AND heap value: exercises the move-then-delete path that would
+// double-free if the value were pointer-copied (aliased) into the table.
+[test]
+def test_to_table_move_map_heap_key_value(t : T?) {
+    var kvs <- [("k1", "v1"), ("k2", "v2")]
+    var tab <- to_table_move(kvs)
+    t |> equal(length(kvs), 0)
+    t |> equal(tab?["k1"] ?? "?", "v1")
+    t |> equal(tab?["k2"] ?? "?", "v2")
+    delete tab
+}
+
+// --- end-to-end: the comprehension forms that lower to the overloads above ---
+
+[test]
+def test_comprehension_round_trip(t : T?) {
+    var setc <- {for (j in range(4)); "k{j}"}
+    t |> equal(length(setc), 4)
+    t |> success(key_exists(setc, "k2"), "set comprehension element present")
+    delete setc
+
+    var mapc <- {for (j in range(4)); "k{j}" => j * j}
+    t |> equal(length(mapc), 4)
+    t |> equal(mapc?["k3"] ?? -1, 9)
+    delete mapc
+}

--- a/tests/gc/test_comprehension_no_leak.das
+++ b/tests/gc/test_comprehension_no_leak.das
@@ -20,6 +20,10 @@ options no_unused_function_arguments = false
 
 require dastest/testing_boost public
 
+struct PtrKeyNode {
+    x : int
+}
+
 // --- set overload: to_table_move(var a : array<keyT>) ---
 
 [test]
@@ -63,6 +67,44 @@ def test_to_table_move_map_heap_key_value(t : T?) {
     t |> equal(tab?["k1"] ?? "?", "v1")
     t |> equal(tab?["k2"] ?? "?", "v2")
     delete tab
+}
+
+// --- pointer keys must NOT be freed by the source-reclaim ---
+
+// A table copies its key as a bare pointer value (it does not clone the
+// pointee). Reclaiming the temp array must therefore leave pointer-key pointees
+// alive, or the table's keys dangle and the caller's data is corrupted. The
+// caller retains ownership of the pointees.
+[test]
+def test_to_table_move_pointer_keys_not_dangling(t : T?) {
+    var n0 = new PtrKeyNode(x = 11)
+    var n1 = new PtrKeyNode(x = 22)
+
+    // set overload (array<keyT>)
+    var ks <- [n0, n1]
+    var s <- to_table_move(ks)
+    var ssum = 0
+    for (k in keys(s)) {
+        ssum += k.x
+    }
+    t |> equal(ssum, 33)                // keys still reference live nodes
+    delete s
+
+    // map overload (array<tuple<keyT;valT>>), pointer key + int value
+    var kvs <- [(n0, 100), (n1, 200)]
+    var m <- to_table_move(kvs)
+    var ksum = 0
+    for (k in keys(m)) {
+        ksum += k.x
+    }
+    t |> equal(ksum, 33)
+    t |> equal(m?[n0] ?? -1, 100)
+    delete m
+
+    unsafe {
+        delete n0
+        delete n1
+    }                                   // caller owns the pointees
 }
 
 // --- end-to-end: the comprehension forms that lower to the overloads above ---


### PR DESCRIPTION
## What

Table and set comprehensions (`{for(...); k => v}`, `{for(...); v}`) lower to:

```das
return to_table_move(temp_array)   // temp_array is a closure local
```

The temp array is built inside the comprehension's closure and is **never returned or deleted**. The two `array<...>` `to_table_move` overloads only **copied** from it, so the temp buffer was **orphaned on every comprehension evaluation** — roughly the table's worth of storage leaked per eval. In any hot path that builds a table/set via comprehension (e.g. a per-frame `live_help_json`, found during the dasImgui headless heap audit), that is a steady per-frame leak.

The function is named `to_table_**move**` and the reference docs already say *"Moves elements from the source into a new table"* — the implementation just didn't.

## Fix

Both `array<...>` overloads now **consume** their source: move the values out, then `delete a`.

- **Set overload** (`array<keyT>`): `a` → `var a`, `delete a` after inserting.
- **Map overload** (`array<tuple<keyT;valT>>`): reordered to **move-first** (`can_move` before `can_copy`), then `delete a`.

The move-first ordering also fixes a **use-after-free**: in a non-`strict_smart_pointers` module a pointer value (e.g. `JsonValue?`) is plain-copyable, so the old copy path would alias the node into the table and the subsequent source-free would `delete` the live node (observed as a `write_value` stack overflow). Moving leaves each element empty, so the free only reclaims husks + the temp buffer.

## Consumer fix

`live_help_json` (dasLiveHost) now builds `table<string; JsonValue?>` directly so `JV` **moves** it, instead of copy-converting a `table<string; string>` and leaking the source. This is the consumer leak that surfaced the builtin bug.

## Regression test

`tests/gc/test_comprehension_no_leak.das` asserts the move contract **directly**: `length(source) == 0` after `to_table_move`, for the set and map overloads incl. heap key+value, plus comprehension round-trips. This is deterministic in every execution tier.

A heap-delta assertion was deliberately **not** used: under the dastest JIT harness `heap_bytes_allocated()` reports identical per-comprehension residue *with and without* the fix (and even for the non-`to_table_move` array comprehension), so it can't distinguish fixed from broken there. The functional contract can.

## Verification

- **Interpreter**: scratch repro — map/set/array comprehension build+delete loops all flat at **0 B** after the fix (leaked ~1–1.5 KB/iter before).
- **JIT**: the contract test passes under `dastest` real JIT — `length(source)==0` there proves the JIT-compiled `to_table_move` executes `delete a`, i.e. the orphan is freed under JIT too.
- **dasImgui headless heap audit**: `help`/`all` dispatch paths sustained **0 B/frame**, no crash.
- Lint clean (0 issues), formatter `--verify` clean, JIT smoke (no verifier errors).
- Full `tests/` suite: only the pre-existing local `unresolved expression quote(type<int>)` JIT cluster (ast_match / flatten / gc_guard / with_boost) fails — unrelated to `to_table_move`. AOT matrix left to CI (no committed AOT fixture references `to_table_move`; pure daslib body change, no struct/SimNode change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)