### PR TITLE
Per-pass AST GC: cap compile-time memory by sweeping infer garbage as it's made

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,6 +760,7 @@ src/ast/ast_derive_alias.cpp
 src/ast/ast_const_folding.cpp
 src/ast/ast_block_folding.cpp
 src/ast/ast_gc_collect.cpp
+src/ast/ast_gc_report.cpp
 src/ast/ast_inscope_pod.cpp
 src/ast/ast_unused.cpp
 src/ast/ast_annotations.cpp
@@ -775,6 +776,7 @@ include/daScript/ast/ast_typefactory.h
 include/daScript/ast/ast.h
 include/daScript/ast/ast_expressions.h
 include/daScript/ast/ast_visitor.h
+include/daScript/ast/ast_gc_report.h
 include/daScript/ast/ast_generate.h
 include/daScript/ast/ast_match.h
 include/daScript/ast/ast_interop.h

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -754,29 +754,33 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
     ctx.whitelist := whitelist
     if (!(func.body is ExprBlock)) return ctx
     let bodyBlk = func.body as ExprBlock
-    var out : array<ExpressionPtr>
-    out |> push <| qmacro_expr(${ var $i(ctx.liveName) = true; })
-    if (ctx.hasRet) {
-        var rt = clone_type(func.result)
-        rt.flags.constant = false
-        out |> push <| qmacro_expr(${ var $i(ctx.retName) : $t(rt); })
+    // Build the lowered body on a scoped gc root: the unroll/fold intermediates are swept on
+    // scope exit, only the live twin body (func.body) is promoted to the enclosing root.
+    ast_gc_collect_scope(func) {
+        var out : array<ExpressionPtr>
+        out |> push <| qmacro_expr(${ var $i(ctx.liveName) = true; })
+        if (ctx.hasRet) {
+            var rt = clone_type(func.result)
+            rt.flags.constant = false
+            out |> push <| qmacro_expr(${ var $i(ctx.retName) : $t(rt); })
+        }
+        lower_list(ctx, bodyBlk, null, out)
+        if (ctx.hasRet) {
+            out |> push <| qmacro_expr(${ return $i(ctx.retName); })
+        }
+        if (ctx.ok) {
+            dse_pass(out)          // drop dead mask-kills (`__flat_live = false`) first…
+            const_prop_pass(out)   // …so an unreassigned `__flat_live` reads as const true → collapse
+            copy_prop_pass(out)    // inline single-def temps (`__flat_ret = c; return __flat_ret` → `return c`)
+            dse_pass(out)          // remove anything left dead (collapsed mask decls, folded temps)
+            ssa_rename_pass(out)   // single-def-ify reassigned user locals → fold_body const-props the chain
+        }
+        var newBody = new ExprBlock(at = func.body.at)
+        for (s in out) {
+            newBody.list |> emplace(s)
+        }
+        func.body = newBody
     }
-    lower_list(ctx, bodyBlk, null, out)
-    if (ctx.hasRet) {
-        out |> push <| qmacro_expr(${ return $i(ctx.retName); })
-    }
-    if (ctx.ok) {
-        dse_pass(out)          // drop dead mask-kills (`__flat_live = false`) first…
-        const_prop_pass(out)   // …so an unreassigned `__flat_live` reads as const true → collapse
-        copy_prop_pass(out)    // inline single-def temps (`__flat_ret = c; return __flat_ret` → `return c`)
-        dse_pass(out)          // remove anything left dead (collapsed mask decls, folded temps)
-        ssa_rename_pass(out)   // single-def-ify reassigned user locals → fold_body const-props the chain
-    }
-    var newBody = new ExprBlock(at = func.body.at)
-    for (s in out) {
-        newBody.list |> emplace(s)
-    }
-    func.body = newBody
     return ctx
 }
 

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -21,65 +21,6 @@ def private is_flat_temp(name : das_string) : bool {
     return name |> starts_with("__flat_")
 }
 
-// Reclaim walker: free the expression + TypeDecl nodes of an orphaned subtree now, instead
-// of leaving them for the gc_guard sweep at the end of the (long) flatten pass. The visitor
-// collects every owned expression and type but never follows ExprVar.variable, so shared
-// bindings are untouched; deleting an ExprVar node frees only the node, not the Variable it
-// points at. The seen-set dedups the visitor's double-presentation of some nodes (a single
-// gc_unlink+delete twice would be a double-free). Caller must own the subtree exclusively.
-//
-// The visitor only descends into SOURCE-level type fields (castType, makeType, var type, …),
-// not the inferred `_type` hanging off every typed expression — so collectType walks that
-// per-expression tree manually. The whole flatten twin is built by cloning, and
-// Expression::clone makes a fresh `new TypeDecl(*type)` whose firstType/secondType/argTypes
-// are deep-copied (AST invariant: no duplicated TypeDecl nodes), so each inferred type is
-// uniquely owned and safe to free. structType/enumType are shared entity pointers — we never
-// follow them, and delete_type frees only the node.
-class private ReclaimWalker : AstVisitor {
-    exprs : array<ExpressionPtr>
-    types : array<TypeDeclPtr>
-    seen : table<uint64>
-    def collectType(var t : TypeDeclPtr) : void {
-        if (t == null) return
-        let key = unsafe(reinterpret<uint64>(t))
-        if (key_exists(seen, key)) return
-        seen |> insert(key)
-        types |> push(t)
-        collectType(t.firstType)
-        collectType(t.secondType)
-        for (i in range(length(t.argTypes))) {
-            collectType(t.argTypes[i])
-        }
-    }
-    def override preVisitExpression(expr : ExpressionPtr) : void {
-        let key = unsafe(reinterpret<uint64>(expr))
-        if (!key_exists(seen, key)) {
-            seen |> insert(key)
-            exprs |> push(unsafe(reinterpret<ExpressionPtr>(expr)))
-        }
-        collectType(unsafe(reinterpret<TypeDecl? -const>(expr._type)))
-    }
-    def override preVisitTypeDecl(typ : TypeDeclPtr) : void {
-        collectType(unsafe(reinterpret<TypeDecl? -const>(typ)))
-    }
-}
-
-def private reclaim_expression(var e : ExpressionPtr) {
-    if (e == null) return
-    var w = new ReclaimWalker()
-    make_visitor(*w) $(adapter) {
-        visit(e, adapter)
-    }
-    for (n in w.exprs) {
-        unsafe { delete_expression(n) }
-    }
-    for (t in w.types) {
-        unsafe { delete_type(t) }
-    }
-    delete w.seen
-    unsafe { delete w }
-}
-
 // ===== Dead-store elimination =====
 //
 // The lowered body is straight-line (no branches), so liveness is a single
@@ -156,7 +97,6 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
         var sub = fold_const(o.subexpr, constmap)
         var bv = false
         if (o.op == "!" && const_bool(sub, bv)) {
-            reclaim_expression(sub)
             return new ExprConstBool(at = e.at, value = !bv)
         }
         return new ExprOp1(at = e.at, atEnclosure = o.atEnclosure, genFlags = o.genFlags,
@@ -172,34 +112,20 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
         let rc = const_bool(r, rb)
         if (o.op == "&&") {
             if (lc) {
-                if (lb) { reclaim_expression(l); return r }
-                reclaim_expression(l)
-                reclaim_expression(r)
+                return r if (lb)
                 return new ExprConstBool(at = e.at, value = false)
             }
             if (rc) {
-                if (rb) { reclaim_expression(r); return l }
-                reclaim_expression(l)
-                reclaim_expression(r)
+                return l if (rb)
                 return new ExprConstBool(at = e.at, value = false)
             }
         } elif (o.op == "||") {
             if (lc) {
-                if (lb) {
-                    reclaim_expression(l)
-                    reclaim_expression(r)
-                    return new ExprConstBool(at = e.at, value = true)
-                }
-                reclaim_expression(l)
+                return new ExprConstBool(at = e.at, value = true) if (lb)
                 return r
             }
             if (rc) {
-                if (rb) {
-                    reclaim_expression(l)
-                    reclaim_expression(r)
-                    return new ExprConstBool(at = e.at, value = true)
-                }
-                reclaim_expression(r)
+                return new ExprConstBool(at = e.at, value = true) if (rb)
                 return l
             }
         }
@@ -211,7 +137,6 @@ def private fold_const(e : ExpressionPtr; constmap : table<uint64; bool>) : Expr
         var c = fold_const(o.subexpr, constmap)
         var cb = false
         if (const_bool(c, cb)) {
-            reclaim_expression(c)
             return cb ? fold_const(o.left, constmap) : fold_const(o.right, constmap)
         }
         return new ExprOp3(at = e.at, atEnclosure = o.atEnclosure, genFlags = o.genFlags,
@@ -253,13 +178,9 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
             if (!is_flat_temp(v.name) || key_exists(reassigned, h) || key_exists(constmap, h) || v.init == null) {
                 continue
             }
-            // fold_const builds a fully-fresh clone tree just to test for a const bool; in a
-            // while(changed) sweep those probe clones otherwise pile up to the end-of-pass
-            // gc_guard sweep. Reclaim each probe the moment we've read its verdict.
             var bv = false
             var probe = fold_const(v.init, constmap)
             let isConst = const_bool(probe, bv)
-            reclaim_expression(probe)
             if (isConst) {
                 constmap[h] = bv
                 changed = true
@@ -271,35 +192,26 @@ def public const_prop_pass(var out : array<ExpressionPtr>) {
         delete constmap
         return
     }
-    // fold_const returns a fresh tree, orphaning the input subtree; reclaim each old subtree
-    // now rather than leaving it for the end-of-pass sweep.
     var i = 0
     while (i < length(out)) {
         var s = out[i]
         if (s is ExprCopy) {
             var cp = s as ExprCopy
-            var old = cp.right
-            cp.right = fold_const(old, constmap)
-            reclaim_expression(old)
+            cp.right = fold_const(cp.right, constmap)
         } elif (s is ExprLet) {
             var lc = s as ExprLet
             for (v in lc.variables) {
                 if (v.init != null) {
-                    var old = v.init
-                    v.init = fold_const(old, constmap)
-                    reclaim_expression(old)
+                    v.init = fold_const(v.init, constmap)
                 }
             }
         } elif (s is ExprReturn) {
             var r = s as ExprReturn
             if (r.subexpr != null) {
-                var old = r.subexpr
-                r.subexpr = fold_const(old, constmap)
-                reclaim_expression(old)
+                r.subexpr = fold_const(r.subexpr, constmap)
             }
         } else {
             out[i] = fold_const(s, constmap)
-            reclaim_expression(s)
         }
         i ++
     }
@@ -490,12 +402,6 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
                 out[j] = apply_template(rules, out[j].at, out[j], false)   // only statements that reference nm
             }
             unsafe { delete rules }
-            // Reclaim the dropped def (+ store) subtrees now (their original source was just
-            // inlined as clones), rather than waiting for the gc_guard sweep.
-            reclaim_expression(out[k])
-            if (si >= 0) {
-                reclaim_expression(out[si])
-            }
             out <- [for (j in range(n)); out[j]; where j != k && j != si]
             changed = true
             break
@@ -579,11 +485,6 @@ def public dse_pass(var out : array<ExpressionPtr>) {
     if (empty(dead)) {
         delete dead
         return
-    }
-    // Reclaim the dead statements now (the comprehension below drops them from `out`,
-    // orphaning them to the end-of-pass sweep otherwise). Safe: the rebuild skips dead j.
-    for (j in keys(dead)) {
-        reclaim_expression(out[j])
     }
     out <- [for (j in range(n)); out[j]; where !key_exists(dead, j)]
     delete dead
@@ -996,12 +897,10 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
             var lc = s as ExprLet
             if (!is_flat_temp(lc.variables[0].name) && lc.variables[0].init != null && is_all_const(lc.variables[0].init)) {
                 // eval_single_expression only READS the tree (throwaway context), so fold the
-                // init in place — no defensive clone. On success the old init subtree is
-                // orphaned (replaced by the folded const); reclaim it now.
+                // init in place — no defensive clone.
                 var oldInit = lc.variables[0].init
                 var folded = eval_to_const(oldInit)
                 if (folded |> is_expr_const() && folded != oldInit) {
-                    reclaim_expression(oldInit)
                     lc.variables[0].init = folded
                     constmap["{lc.variables[0].name}"] = folded
                     changed = true

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -357,7 +357,7 @@ def document_module_ast(_root : string) {
         group_by_regex("Debug info helpers", mod, %regex~(debug_helper_.*)%%),
         group_by_regex("AOT support", mod, %regex~(aot_require|aot_type_ann_get_field_ptr|aot_need_type_info|aot_previsit_get_field_ptr|aot_previsit_get_field|aot_visit_get_field|write_aot_body|write_aot_suffix|write_aot_macro_suffix|write_aot_macro_prefix|macro_aot_infix|getInitSemanticHashWithDep|get_aot_hash_comment)$%%),
         group_by_regex("String builder writer", mod, %regex~(string_builder_str|string_builder_clear)$%%),
-        group_by_regex("GC", mod, %regex~(ast_gc_guard|verify_typedecl_gc|verify_expression_gc|delete_expression|delete_type)$%%),
+        group_by_regex("GC", mod, %regex~(ast_gc_guard|ast_gc_collect_scope|verify_typedecl_gc|verify_expression_gc|delete_expression|delete_type)$%%),
         hide_group(group_by_regex("Internal ast infrastructure", mod, %regex~(builtin_ast_.*)%%))
     )
     documents("AST manipulation library", mod, "ast.rst", groups)

--- a/doc/source/reference/language/options.rst
+++ b/doc/source/reference/language/options.rst
@@ -213,6 +213,21 @@ Memory
      - bool
      - false
      - Context does not release old memory from array or table growth (leaves it to the GC).
+   * - ``gc_infer_collect``
+     - bool
+     - true
+     - Collects the compiler's working AST root during type inference — moves the live tree
+       into a fresh root, swaps it in, and sweeps the rest — capping compile-time memory.
+       Set to ``false`` to keep all infer-time nodes until the module finishes compiling.
+   * - ``gc_infer_collect_nodes``
+     - int
+     - 25000
+     - Collect once the working root has grown by this many nodes since the last collect
+       (roughly 2 MB worth).
+   * - ``gc_infer_collect_pct``
+     - int
+     - 50
+     - ...or once it has grown by this percent of the live set, whichever comes first.
 
 --------------------
 AOT

--- a/doc/source/stdlib/handmade/function-ast-ast_gc_collect_scope-0xca52505f5f702b4d.rst
+++ b/doc/source/stdlib/handmade/function-ast-ast_gc_collect_scope-0xca52505f5f702b4d.rst
@@ -1,0 +1,1 @@
+Runs ``block`` — which is expected to build the body of ``function`` — on a temporary gc-node scope, then keeps the nodes reachable from the function's body and sweeps the rest. Use it to bound the AST-node memory of a tool or macro that constructs a function body at runtime, the way the flatten macro scopes its lowering.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1532,6 +1532,12 @@ namespace das
                                                         // this is slightly faster, but prohibits AOT or patches
         bool        macro_context_persistent_heap = true;   // if true, then persistent heap is used for macro context
         bool        macro_context_collect = false;          // GC collect macro context after major passes
+    // per-pass AST gc during infer: collect the working root's live tree into a fresh root and
+    // swap it in (O(1)), letting the old root's dtor sweep that pass's garbage. Caps the compile
+    // memory peak (infer churns many throwaway TypeDecls/Expressions) at ~no time cost.
+        /*option*/ bool        gc_infer_collect = true;            // enable per-pass collect+swap during inference
+        /*option*/ int32_t     gc_infer_collect_nodes = 25000;     // fire when the root grew by this many nodes since the last collect (~2 MB)
+        /*option*/ int32_t     gc_infer_collect_pct = 50;          // ...or by this percent of the live set, whichever comes first
         uint64_t    max_static_variables_size = 0x100000000;   // 4GB
         /*option*/ uint64_t    max_heap_allocated = 0;
         /*option*/ uint64_t    max_string_heap_allocated = 0;

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1186,7 +1186,7 @@ namespace das
         void serialize( AstSerializer & ser, bool already_exists );
         void setModuleName ( const string & n );
         FileInfo * getFileInfo() const;
-        void gc_collect ( gc_root * from = nullptr );  // move reachable TypeDecl from 'from' root to module_gc_root
+        void gc_collect ( gc_root * from = nullptr, gc_root * target = nullptr );  // move reachable nodes from 'from' to 'target' (default module_gc_root)
     public:
         template <typename RecAnn>
         void initRecAnnotation ( RecAnn * rec, ModuleLibrary & lib ) {
@@ -1242,7 +1242,7 @@ namespace das
         vector<pair<string,bool>>                   keywords;           // keywords (and if they need oxford comma)
         vector<string>                              typeFunctions;      // type functions
         das_insert_only_hash_map<string,Type>       options;            // options
-        gc_root                                     module_gc_root;     // gc_node root for this module's gc-managed AST nodes
+        unique_ptr<gc_root>                         module_gc_root = make_unique<gc_root>();  // this module's gc-managed AST nodes; a pointer so it can be swapped O(1) during compile (collect live into a fresh root, swap, drop the old)
         uint64_t                                    cumulativeHash = 0; // hash of all mangled names in this module (for builtin modules)
         string                                      name;
         string                                      cppClassName;       // C++ class name (e.g. "Module_Math"), set by REGISTER_MODULE

--- a/include/daScript/ast/ast_gc_report.h
+++ b/include/daScript/ast/ast_gc_report.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "daScript/misc/gc_node.h"
+#include "daScript/misc/string_writer.h"
+
+namespace das {
+
+    // Group every gc_node on `root` by source file -> file:line, with per-type counts,
+    // and print sorted by count (descending). Diagnostic. Reads each node's `at` via a
+    // per-tag downcast — only the AST layer knows the concrete subclasses.
+    DAS_API void gcReportHistogram ( const gc_root & root, const char * label, TextWriter & out, uint64_t minCount = 1 );
+
+    // Per-stage leak delta. Snapshots the active gc root, diffs it against the previous
+    // snapshot on this thread, prints what `stage` added/removed (grouped by file -> line),
+    // then stores the new baseline. Resets the baseline when stage == "parse" (start of a
+    // module). The compile unit is labelled by `moduleName`, falling back to `fileName` when
+    // the module is nameless (descriptor parses). Gated by env DAS_GC_STAGE_REPORT — no-op when unset.
+    DAS_API void gcStageReportDelta ( const char * moduleName, const char * fileName, const char * stage, TextWriter & out );
+
+    // True if DAS_GC_STAGE_REPORT is set (cached). Lets call sites skip building strings.
+    DAS_API bool gcStageReportEnabled ();
+
+}

--- a/include/daScript/misc/gc_node.h
+++ b/include/daScript/misc/gc_node.h
@@ -70,6 +70,13 @@ namespace das {
         __forceinline unsigned int use_count() const { return 1; }
     };
 
+    // Optional diagnostic hook: given a node, write a short source location
+    // ("file.das:line:col") into buf. Installed by the AST layer (ast_gc_report.cpp),
+    // which alone can downcast to the concrete subclass and read its `at`. nullptr by
+    // default. Used by gc_root::gc_report so the low-level dump shows where nodes were born.
+    typedef void (*gc_describe_fn)(const gc_node * node, char * buf, int buflen);
+    extern DAS_API gc_describe_fn gc_node_describe_hook;
+
     // gc_root — owns a doubly-linked list of gc_nodes.
     // Thread-local root is the default allocation target.
     // Module has its own root. gc_sweep() deletes all remaining nodes.

--- a/include/daScript/misc/gc_node.h
+++ b/include/daScript/misc/gc_node.h
@@ -139,4 +139,19 @@ namespace das {
         gc_guard & operator = ( const gc_guard & ) = delete;
     };
 
+    // gc_active_scope — redirect the active root to an existing root for the scope,
+    // restoring the previous active root on exit. Unlike gc_guard it neither owns nor
+    // sweeps the root: the root lives elsewhere (e.g. a Module's module_gc_root, which
+    // may be swapped under us per-pass) and must survive the scope. The compile pipeline
+    // uses this so allocations land directly on the module's own root.
+    struct DAS_API gc_active_scope {
+        gc_root *   saved_active;
+
+        explicit gc_active_scope ( gc_root * use );
+        ~gc_active_scope();
+
+        gc_active_scope ( const gc_active_scope & ) = delete;
+        gc_active_scope & operator = ( const gc_active_scope & ) = delete;
+    };
+
 }

--- a/src/ast/ast_gc_report.cpp
+++ b/src/ast/ast_gc_report.cpp
@@ -1,0 +1,238 @@
+#include "daScript/misc/platform.h"
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_expressions.h"
+#include "daScript/ast/ast_gc_report.h"
+
+#include <algorithm>
+#include <stdlib.h>
+#include <string.h>
+
+namespace das {
+
+    // ---- per-tag downcast ----
+    // Only the AST layer knows the concrete subclass behind each gc tag, so this is the
+    // one place that can recover a node's source `at`. MakeStruct (and any untagged node)
+    // carries no `at` of its own -> nullptr.
+    static const LineInfo * gc_node_at ( const gc_node * node ) {
+        switch ( node->gc_type_tag() ) {
+            case GC_TAG_TYPEDECL:       return &static_cast<const TypeDecl*>(node)->at;
+            case GC_TAG_EXPRESSION:     return &static_cast<const Expression*>(node)->at;
+            case GC_TAG_MAKEFIELDDECL:  return &static_cast<const MakeFieldDecl*>(node)->at;
+            case GC_TAG_FUNCTION:       return &static_cast<const Function*>(node)->at;
+            case GC_TAG_ENUMERATION:    return &static_cast<const Enumeration*>(node)->at;
+            case GC_TAG_STRUCTURE:      return &static_cast<const Structure*>(node)->at;
+            case GC_TAG_VARIABLE:       return &static_cast<const Variable*>(node)->at;
+            default:                    return nullptr;     // MakeStruct, untagged, builtins
+        }
+    }
+
+    static const char * gc_tag_name ( uint16_t tag ) {
+        switch ( tag ) {
+            case GC_TAG_TYPEDECL:       return "TypeDecl";
+            case GC_TAG_EXPRESSION:     return "Expr";
+            case GC_TAG_MAKEFIELDDECL:  return "MakeField";
+            case GC_TAG_MAKESTRUCT:     return "MakeStruct";
+            case GC_TAG_FUNCTION:       return "Function";
+            case GC_TAG_ENUMERATION:    return "Enum";
+            case GC_TAG_STRUCTURE:      return "Struct";
+            case GC_TAG_VARIABLE:       return "Variable";
+            default:                    return "other";
+        }
+    }
+
+    // ---- describe hook (installed into gc_node base) ----
+
+    static void gc_describe_impl ( const gc_node * node, char * buf, int buflen ) {
+        const LineInfo * li = gc_node_at(node);
+        if ( li && li->fileInfo ) {
+            snprintf(buf, buflen, "%s:%u:%u", li->fileInfo->name.c_str(), li->line, li->column);
+        } else {
+            buf[0] = 0;
+        }
+    }
+
+    // The hook variable is statically zero-initialized before any dynamic init, so setting
+    // it here (dynamic init) has no ordering hazard. gc_report is a manual diagnostic and is
+    // never called during static init, so lazy-install is unnecessary.
+    static struct GcReportHookInstaller {
+        GcReportHookInstaller () { gc_node_describe_hook = &gc_describe_impl; }
+    } g_gcReportHookInstaller;
+
+    // ---- histogram ----
+
+    namespace {
+        struct TagCounts {
+            uint64_t n[16] = {};
+            uint64_t total = 0;
+            void add ( uint16_t tag ) { n[tag & 0xf]++; total++; }       // tags are < 16
+        };
+        struct FileBucket {
+            TagCounts total;
+            map<uint32_t, TagCounts> byLine;
+        };
+        typedef map<string, FileBucket> Histogram;
+    }
+
+    static void gc_build_histogram ( const gc_root & root, Histogram & histo ) {
+        for ( auto node = root.gc_first; node; node = node->gc_next ) {
+            uint16_t tag = node->gc_type_tag();
+            const LineInfo * li = gc_node_at(node);
+            string key;
+            uint32_t line = 0;
+            if ( li && li->fileInfo ) { key = li->fileInfo->name; line = li->line; }
+            else { key = "<no source>"; }
+            auto & fb = histo[key];
+            fb.total.add(tag);
+            fb.byLine[line].add(tag);
+        }
+    }
+
+    // "[Expr 1200, TypeDecl 900]" — nonzero tags, descending by count.
+    static void gc_format_breakdown ( const TagCounts & c, TextWriter & out ) {
+        vector<pair<uint16_t,uint64_t>> v;
+        for ( uint16_t t=0; t<16; ++t ) if ( c.n[t] ) v.push_back({t, c.n[t]});
+        std::sort(v.begin(), v.end(), [](const pair<uint16_t,uint64_t> & a, const pair<uint16_t,uint64_t> & b){
+            return a.second > b.second;
+        });
+        out << "[";
+        for ( size_t i=0; i<v.size(); ++i ) {
+            if ( i ) out << ", ";
+            out << gc_tag_name(v[i].first) << " " << v[i].second;
+        }
+        out << "]";
+    }
+
+    void gcReportHistogram ( const gc_root & root, const char * label, TextWriter & out, uint64_t minCount ) {
+        Histogram histo;
+        gc_build_histogram(root, histo);
+        // files, descending by total count
+        vector<const pair<const string, FileBucket>*> files;
+        for ( auto & kv : histo ) files.push_back(&kv);
+        std::sort(files.begin(), files.end(),
+            [](const pair<const string, FileBucket>* a, const pair<const string, FileBucket>* b){
+                return a->second.total.total > b->second.total.total;
+            });
+        out << "=== AST gc histogram: " << (label ? label : "") << " — " << root.gc_count << " nodes ===\n";
+        for ( auto fp : files ) {
+            if ( fp->second.total.total < minCount ) continue;
+            out << "  " << fp->first << "  " << fp->second.total.total << "  ";
+            gc_format_breakdown(fp->second.total, out);
+            out << "\n";
+            vector<const pair<const uint32_t, TagCounts>*> lines;
+            for ( auto & lkv : fp->second.byLine ) lines.push_back(&lkv);
+            std::sort(lines.begin(), lines.end(),
+                [](const pair<const uint32_t, TagCounts>* a, const pair<const uint32_t, TagCounts>* b){
+                    return a->second.total > b->second.total;
+                });
+            for ( auto lp : lines ) {
+                if ( lp->second.total < minCount ) continue;
+                out << "    :" << lp->first << "  " << lp->second.total << "  ";
+                gc_format_breakdown(lp->second, out);
+                out << "\n";
+            }
+        }
+    }
+
+    // ---- per-stage delta ----
+
+    bool gcStageReportEnabled () {
+        static int cached = -1;
+        if ( cached < 0 ) cached = getenv("DAS_GC_STAGE_REPORT") ? 1 : 0;
+        return cached != 0;
+    }
+
+    // signed per-(file,line) delta: cur - prev. n[] can go negative when a stage reclaims.
+    namespace {
+        struct SignedCounts {
+            int64_t n[16] = {};
+            int64_t total = 0;
+        };
+    }
+
+    static void gc_format_signed ( const SignedCounts & c, TextWriter & out ) {
+        vector<pair<uint16_t,int64_t>> v;
+        for ( uint16_t t=0; t<16; ++t ) if ( c.n[t] ) v.push_back({t, c.n[t]});
+        std::sort(v.begin(), v.end(), [](const pair<uint16_t,int64_t> & a, const pair<uint16_t,int64_t> & b){
+            return llabs(a.second) > llabs(b.second);
+        });
+        out << "[";
+        for ( size_t i=0; i<v.size(); ++i ) {
+            if ( i ) out << ", ";
+            out << gc_tag_name(v[i].first) << " " << (v[i].second>0?"+":"") << v[i].second;
+        }
+        out << "]";
+    }
+
+    void gcStageReportDelta ( const char * moduleName, const char * fileName, const char * stage, TextWriter & out ) {
+        if ( !gcStageReportEnabled() ) return;
+        static thread_local Histogram prev;          // baseline from the previous stage
+        const bool isParse = stage && strcmp(stage, "parse")==0;
+        if ( isParse ) prev.clear();                 // new module: drop the stale baseline
+        const gc_root & root = *gc_root::gc_get_active_root();
+        const char * unit = (moduleName && moduleName[0]) ? moduleName
+                          : (fileName && fileName[0]) ? fileName : "<main>";
+        Histogram cur;
+        gc_build_histogram(root, cur);
+        // union of file keys present in cur or prev
+        set<string> fileKeys;
+        for ( auto & kv : cur )  fileKeys.insert(kv.first);
+        for ( auto & kv : prev ) fileKeys.insert(kv.first);
+        // per-file signed totals, descending by magnitude
+        struct FileDelta { string name; SignedCounts total; vector<pair<uint32_t,SignedCounts>> lines; };
+        vector<FileDelta> deltas;
+        for ( auto & fk : fileKeys ) {
+            auto ci = cur.find(fk);
+            auto pi = prev.find(fk);
+            const FileBucket * cb = ci!=cur.end()  ? &ci->second : nullptr;
+            const FileBucket * pb = pi!=prev.end() ? &pi->second : nullptr;
+            set<uint32_t> lineKeys;
+            if ( cb ) for ( auto & lk : cb->byLine ) lineKeys.insert(lk.first);
+            if ( pb ) for ( auto & lk : pb->byLine ) lineKeys.insert(lk.first);
+            FileDelta fd;
+            fd.name = fk;
+            for ( auto ln : lineKeys ) {
+                SignedCounts sc;
+                const TagCounts * cc = nullptr;
+                const TagCounts * pc = nullptr;
+                if ( cb ) { auto it = cb->byLine.find(ln); if ( it!=cb->byLine.end() ) cc = &it->second; }
+                if ( pb ) { auto it = pb->byLine.find(ln); if ( it!=pb->byLine.end() ) pc = &it->second; }
+                for ( int t=0; t<16; ++t ) {
+                    int64_t d = (cc?(int64_t)cc->n[t]:0) - (pc?(int64_t)pc->n[t]:0);
+                    sc.n[t] = d; sc.total += d;
+                    fd.total.n[t] += d;
+                }
+                fd.total.total += sc.total;
+                if ( sc.total != 0 ) fd.lines.push_back({ln, sc});
+            }
+            if ( fd.total.total != 0 ) deltas.push_back(std::move(fd));
+        }
+        std::sort(deltas.begin(), deltas.end(), [](const FileDelta & a, const FileDelta & b){
+            return llabs(a.total.total) > llabs(b.total.total);
+        });
+        if ( deltas.empty() ) {
+            out << "=== gc delta @ " << unit << " : " << (stage ? stage : "")
+                << " — no net change (" << root.gc_count << " nodes) ===\n";
+            prev = std::move(cur);
+            return;
+        }
+        out << "=== gc delta @ " << unit << " : " << (stage ? stage : "")
+            << " (active root: " << root.gc_count << " nodes) ===\n";
+        for ( auto & fd : deltas ) {
+            out << "  " << fd.name << "  " << (fd.total.total>0?"+":"") << fd.total.total << "  ";
+            gc_format_signed(fd.total, out);
+            out << "\n";
+            std::sort(fd.lines.begin(), fd.lines.end(),
+                [](const pair<uint32_t,SignedCounts> & a, const pair<uint32_t,SignedCounts> & b){
+                    return llabs(a.second.total) > llabs(b.second.total);
+                });
+            for ( auto & lp : fd.lines ) {
+                out << "    :" << lp.first << "  " << (lp.second.total>0?"+":"") << lp.second.total << "  ";
+                gc_format_signed(lp.second, out);
+                out << "\n";
+            }
+        }
+        prev = std::move(cur);                        // new baseline for the next stage
+    }
+
+}

--- a/src/ast/ast_gc_report.cpp
+++ b/src/ast/ast_gc_report.cpp
@@ -92,7 +92,7 @@ namespace das {
     static void gc_format_breakdown ( const TagCounts & c, TextWriter & out ) {
         vector<pair<uint16_t,uint64_t>> v;
         for ( uint16_t t=0; t<16; ++t ) if ( c.n[t] ) v.push_back({t, c.n[t]});
-        std::sort(v.begin(), v.end(), [](const pair<uint16_t,uint64_t> & a, const pair<uint16_t,uint64_t> & b){
+        sort(v.begin(), v.end(), [](const pair<uint16_t,uint64_t> & a, const pair<uint16_t,uint64_t> & b){
             return a.second > b.second;
         });
         out << "[";
@@ -109,7 +109,7 @@ namespace das {
         // files, descending by total count
         vector<const pair<const string, FileBucket>*> files;
         for ( auto & kv : histo ) files.push_back(&kv);
-        std::sort(files.begin(), files.end(),
+        sort(files.begin(), files.end(),
             [](const pair<const string, FileBucket>* a, const pair<const string, FileBucket>* b){
                 return a->second.total.total > b->second.total.total;
             });
@@ -121,7 +121,7 @@ namespace das {
             out << "\n";
             vector<const pair<const uint32_t, TagCounts>*> lines;
             for ( auto & lkv : fp->second.byLine ) lines.push_back(&lkv);
-            std::sort(lines.begin(), lines.end(),
+            sort(lines.begin(), lines.end(),
                 [](const pair<const uint32_t, TagCounts>* a, const pair<const uint32_t, TagCounts>* b){
                     return a->second.total > b->second.total;
                 });
@@ -153,7 +153,7 @@ namespace das {
     static void gc_format_signed ( const SignedCounts & c, TextWriter & out ) {
         vector<pair<uint16_t,int64_t>> v;
         for ( uint16_t t=0; t<16; ++t ) if ( c.n[t] ) v.push_back({t, c.n[t]});
-        std::sort(v.begin(), v.end(), [](const pair<uint16_t,int64_t> & a, const pair<uint16_t,int64_t> & b){
+        sort(v.begin(), v.end(), [](const pair<uint16_t,int64_t> & a, const pair<uint16_t,int64_t> & b){
             return llabs(a.second) > llabs(b.second);
         });
         out << "[";
@@ -207,7 +207,7 @@ namespace das {
             }
             if ( fd.total.total != 0 ) deltas.push_back(std::move(fd));
         }
-        std::sort(deltas.begin(), deltas.end(), [](const FileDelta & a, const FileDelta & b){
+        sort(deltas.begin(), deltas.end(), [](const FileDelta & a, const FileDelta & b){
             return llabs(a.total.total) > llabs(b.total.total);
         });
         if ( deltas.empty() ) {
@@ -222,7 +222,7 @@ namespace das {
             out << "  " << fd.name << "  " << (fd.total.total>0?"+":"") << fd.total.total << "  ";
             gc_format_signed(fd.total, out);
             out << "\n";
-            std::sort(fd.lines.begin(), fd.lines.end(),
+            sort(fd.lines.begin(), fd.lines.end(),
                 [](const pair<uint32_t,SignedCounts> & a, const pair<uint32_t,SignedCounts> & b){
                     return llabs(a.second.total) > llabs(b.second.total);
                 });

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -5830,9 +5830,8 @@ namespace das {
                                 return newCall;
                             }
                         }
-                        // note: gc will collect, but why waste memory
-                        newCall->gc_unlink(); delete newCall;
-                        self->gc_unlink(); delete self;
+                        // newCall + self are orphaned here; the gc_guard sweep reclaims them
+                        // (per-pass GC replaces the old manual gc_unlink+delete).
                     }
                 }
             }

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -6014,7 +6014,43 @@ namespace das {
             logs << "INITIAL CODE:\n"
                  << *this;
         }
+        // Per-pass collect+swap: infer mints a lot of throwaway TypeDecls/Expressions. When a
+        // pass grows the working root enough, collect the live tree into a fresh root and swap
+        // it in (O(1)); the old root's dtor sweeps that pass's garbage. Fire when growth since
+        // the last collect crosses a node threshold (~2 MB) OR a fraction of the live set.
+        bool gcInferCollect = options.getBoolOption("gc_infer_collect", policies.gc_infer_collect);
+        int32_t gcInferNodes = options.getIntOption("gc_infer_collect_nodes", policies.gc_infer_collect_nodes);
+        int32_t gcInferPct = options.getIntOption("gc_infer_collect_pct", policies.gc_infer_collect_pct);
+        bool gcInferLog = options.getBoolOption("log_gc_infer_collect", false);
+        uint64_t gcLastCount = gc_root::gc_get_active_root()->gc_count;
+        // Collect the module's working root into a fresh root and swap it in (O(1)); the old
+        // root's dtor sweeps the garbage. Returns the live count. No-op outside the normal
+        // compile flow (the active root must BE the module's root) so tool/macro re-infer is safe.
+        auto gcCollectAndSwap = [&]() -> uint64_t {
+            gc_root * cur = gc_root::gc_get_active_root();
+            if ( cur != thisModule->module_gc_root.get() ) return gcLastCount;
+            auto fresh = make_unique<gc_root>();
+            thisModule->gc_collect(cur, fresh.get());        // live cur -> fresh (fresh target: full walk, no early-out)
+            gc_root * live = fresh.get();
+            gc_root::gc_get_active_root() = live;
+            thisModule->module_gc_root = das::move(fresh);   // deletes cur -> sweeps the garbage
+            return live->gc_count;
+        };
         for (pass = 0; pass < maxInferPasses; ++pass) {
+            if ( gcInferCollect && pass > 0 ) {
+                uint64_t curCount = gc_root::gc_get_active_root()->gc_count;
+                uint64_t grown = curCount >= gcLastCount ? curCount - gcLastCount : 0;
+                bool fire = grown >= uint64_t(gcInferNodes)
+                         || ( gcLastCount && grown * 100 >= gcLastCount * uint64_t(gcInferPct) );
+                if ( gcInferLog ) {
+                    logs << "[gc-infer] " << thisModule->name << " pass " << pass
+                         << " live=" << curCount << " grown=" << grown
+                         << " (" << (gcLastCount ? grown * 100 / gcLastCount : 0) << "%)"
+                         << (fire ? " -> COLLECT" : "") << "\n";
+                }
+                if ( fire )
+                    gcLastCount = gcCollectAndSwap();
+            }
             if (macroException)
                 break;
             inferPassesUsed++;   // count each body invocation; avoids undercount when loop breaks early (pass is 0-based)
@@ -6072,5 +6108,10 @@ namespace das {
                   "", "",
                   LineInfo(), CompilationError::exceeds_infer_passes);
         }
+        // End-of-leg collect: sweep this leg's accumulated garbage so the next inferTypes
+        // leg (macro restart / restartInfer) inherits only live nodes, not a compounding
+        // garbage pile. This is the lever that pulls the peak below one leg's worth.
+        if ( gcInferCollect )
+            gcCollectAndSwap();
     }
 }

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -384,8 +384,8 @@ namespace das {
         }
     }
 
-    void Module::gc_collect ( gc_root * from ) {
-        auto target = &module_gc_root;
+    void Module::gc_collect ( gc_root * from, gc_root * targetArg ) {
+        auto target = targetArg ? targetArg : module_gc_root.get();
         // collect alias types
         aliasTypes.foreach([&](auto td) {
             if ( td ) td->gc_collect(target, from);
@@ -821,7 +821,7 @@ namespace das {
         ownFileInfo = access->letGoOfFileInfo(modName);
         DAS_ASSERTF(ownFileInfo,"something went wrong and FileInfo for builtin module can not be obtained");
         auto result = appendBuiltinModuleContent(this, program, modName);
-        program->thisModule->module_gc_root.gc_dump_to_thread_root();
+        program->thisModule->module_gc_root->gc_dump_to_thread_root();
         return result;
     }
 

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -672,26 +672,53 @@ namespace das {
         });
     }
 
+    // compileDaScript runs its top-level post-parse steps (deriveAliases/allocateStack/...)
+    // on a transient gc_guard root; on exit this merges that scratch into the program's
+    // module root, then clears the function/generic lookup caches before the gc_guard
+    // sweeps the rest (see clearAllFunctionLookups above for why). Only the top program
+    // sets prog; per-module parse uses ModuleGcFinalize instead.
     struct GcCollectOnExit {
         gc_guard & scope;
         Program * prog = nullptr;
-        TextWriter * logs = nullptr;
-        GcCollectOnExit(gc_guard & s) : scope(s) {}
-        GcCollectOnExit(gc_guard & s, Program * p) : scope(s), prog(p) {}
+        explicit GcCollectOnExit ( gc_guard & s ) : scope(s) {}
         ~GcCollectOnExit() {
             if ( prog ) {
                 prog->thisModule->gc_collect(&scope.guard_root);
-                // After the collect: module_gc_root holds the live survivors, guard_root holds
-                // the garbage about to be swept. The split = irreducible-live vs reclaimable.
-                if ( logs && gcStageReportEnabled() ) {
-                    *logs << "=== gc survivors @ " << prog->thisModule->name << " : live="
-                          << prog->thisModule->module_gc_root.gc_count << " garbage="
-                          << scope.guard_root.gc_count << " ===\n";
-                    gcReportHistogram(prog->thisModule->module_gc_root, "live", *logs, 200);
-                }
             }
             clearAllFunctionLookups();
         }
+        GcCollectOnExit ( const GcCollectOnExit & ) = delete;
+        GcCollectOnExit & operator = ( const GcCollectOnExit & ) = delete;
+    };
+
+    // parseDaScript runs with the module's own gc_root as the working/active root (via
+    // gc_active_scope), so live nodes accumulate directly on module_gc_root and per-pass
+    // swaps can replace it O(1). At scope exit this does the final collect+swap: walk the
+    // live tree into a fresh root, repoint active to it, then drop the old root (its dtor
+    // sweeps the remaining garbage). module_gc_root ends holding only the live survivors.
+    struct ModuleGcFinalize {
+        Program *   prog = nullptr;
+        TextWriter * logs = nullptr;
+        explicit ModuleGcFinalize ( Program * p ) : prog(p) {}
+        ~ModuleGcFinalize() {
+            if ( prog ) {
+                auto m = prog->thisModule.get();
+                gc_root * oldRoot = m->module_gc_root.get();
+                auto fresh = make_unique<gc_root>();
+                m->gc_collect(oldRoot, fresh.get());   // live oldRoot -> fresh; garbage stays on oldRoot
+                if ( logs && gcStageReportEnabled() ) {
+                    *logs << "=== gc survivors @ " << m->name << " : live="
+                          << fresh->gc_count << " garbage=" << oldRoot->gc_count << " ===\n";
+                    gcReportHistogram(*fresh, "live", *logs, 200);
+                }
+                gc_root * liveRoot = fresh.get();
+                gc_root::gc_get_active_root() = liveRoot;   // repoint active before the move frees oldRoot
+                m->module_gc_root = das::move(fresh);        // deletes oldRoot -> sweeps garbage
+            }
+            clearAllFunctionLookups();
+        }
+        ModuleGcFinalize ( const ModuleGcFinalize & ) = delete;
+        ModuleGcFinalize & operator = ( const ModuleGcFinalize & ) = delete;
     };
 
     ProgramPtr parseDaScript ( const string & fileName,
@@ -704,8 +731,11 @@ namespace das {
                               CodeOfPolicies policies ) {
         CompilationCallbackGuard compilationCallbackGuard(moduleName, fileName);
         ProgramPtr program = make_smart<Program>();
-        gc_guard parse_gc_scope;
-        GcCollectOnExit parse_gc_collect(parse_gc_scope, program.get());
+        // The module's own root is the working/active root for the whole compile, so live
+        // nodes land on module_gc_root and per-pass collects can swap it O(1). The scope
+        // restores the previous active root on exit without sweeping (the module owns it).
+        gc_active_scope parse_gc_scope(program->thisModule->module_gc_root.get());
+        ModuleGcFinalize parse_gc_collect(program.get());
         parse_gc_collect.logs = &logs;
         program->library.renameModule(program->thisModule.get(), moduleName);
         ReuseCacheGuard rcg;

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -3,6 +3,7 @@
 #include "daScript/ast/ast.h"
 #include "daScript/ast/ast_serializer.h"
 #include "daScript/ast/ast_expressions.h"
+#include "daScript/ast/ast_gc_report.h"
 #include "daScript/misc/das_common.h"
 #include "daScript/simulate/aot_builtin_string.h"
 #include "daScript/simulate/aot_builtin_uriparser.h"
@@ -816,6 +817,7 @@ namespace das {
             if ( policies.solid_context || program->options.getBoolOption("solid_context",false) ) {
                 program->thisModule->isSolidContext = true;
             }
+            gcStageReportDelta(moduleName.c_str(), fileName.c_str(), "parse", logs);
             callCompilationCallback(moduleName, fileName, "infer");
             // restartInfer: timer must be inside the label so each leg is timed independently.
             // The pre-edit form (timeI set ONCE before the label) over-counted *totInfer on
@@ -839,6 +841,7 @@ namespace das {
                     goto restartInfer;
                 }
             }
+            gcStageReportDelta(moduleName.c_str(), fileName.c_str(), "infer", logs);
             if ( !program->failed() ) {
                 program->normalizeOptionTypes();
                 if (!program->failed())
@@ -858,6 +861,7 @@ namespace das {
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
                 myOptT = get_time_usec(timeO);
                 *totOpt += myOptT;
+                gcStageReportDelta(moduleName.c_str(), fileName.c_str(), "optimize", logs);
                 if (!program->failed())
                     program->verifyAndFoldContracts();
                 if (!program->failed()) {
@@ -878,6 +882,7 @@ namespace das {
                     program->finalizeAnnotations();
                 if (!program->failed())
                     program->updateSemanticHash();
+                gcStageReportDelta(moduleName.c_str(), fileName.c_str(), "finalize", logs);
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
             }
             if (!program->failed()) {

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -675,11 +675,20 @@ namespace das {
     struct GcCollectOnExit {
         gc_guard & scope;
         Program * prog = nullptr;
+        TextWriter * logs = nullptr;
         GcCollectOnExit(gc_guard & s) : scope(s) {}
         GcCollectOnExit(gc_guard & s, Program * p) : scope(s), prog(p) {}
         ~GcCollectOnExit() {
             if ( prog ) {
                 prog->thisModule->gc_collect(&scope.guard_root);
+                // After the collect: module_gc_root holds the live survivors, guard_root holds
+                // the garbage about to be swept. The split = irreducible-live vs reclaimable.
+                if ( logs && gcStageReportEnabled() ) {
+                    *logs << "=== gc survivors @ " << prog->thisModule->name << " : live="
+                          << prog->thisModule->module_gc_root.gc_count << " garbage="
+                          << scope.guard_root.gc_count << " ===\n";
+                    gcReportHistogram(prog->thisModule->module_gc_root, "live", *logs, 200);
+                }
             }
             clearAllFunctionLookups();
         }
@@ -697,6 +706,7 @@ namespace das {
         ProgramPtr program = make_smart<Program>();
         gc_guard parse_gc_scope;
         GcCollectOnExit parse_gc_collect(parse_gc_scope, program.get());
+        parse_gc_collect.logs = &logs;
         program->library.renameModule(program->thisModule.get(), moduleName);
         ReuseCacheGuard rcg;
         auto time0 = ref_time_ticks();

--- a/src/ast/ast_validate.cpp
+++ b/src/ast/ast_validate.cpp
@@ -284,7 +284,7 @@ namespace das {
         }
         // Phase 3: gc_root cross-check
         for ( auto mod : modules ) {
-            for ( auto node = mod->module_gc_root.gc_first; node; node = node->gc_next ) {
+            for ( auto node = mod->module_gc_root->gc_first; node; node = node->gc_next ) {
                 auto tag = node->gc_type_tag();
                 if ( tag == GC_TAG_TYPEDECL ) {
                     if ( vis.getSeen().find((void *)node) == vis.getSeen().end() ) {

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -408,6 +408,20 @@ namespace das {
         das_invoke<void>::invoke(context,at,block);
     }
 
+    // Build fn->body inside `block` on a fresh scoped gc root; on exit, promote the body's
+    // subtree to the enclosing root and sweep the rest (the lowering intermediates). For
+    // macros that rebuild fn->body wholesale (e.g. [flatten]) and want their transient AST
+    // reclaimed immediately instead of waiting for the end-of-module sweep. We start the walk
+    // at fn->body, not fn: fn already lives on the enclosing root, so fn->gc_collect would hit
+    // the gc_owner==target early-out and collect nothing.
+    void ast_gc_collect_scope ( FunctionPtr fn, const TBlock<void> & block, Context * context, LineInfoArg * at ) {
+        gc_guard scope;
+        das_invoke<void>::invoke(context,at,block);
+        if ( fn && fn->body ) {
+            fn->body->gc_collect(scope.saved_thread_root, &scope.guard_root);
+        }
+    }
+
     // Free a SINGLE orphaned AST expression node mid-compile, instead of waiting for the
     // enclosing gc_guard to sweep it. gc nodes live flat on a root list, so this frees
     // only `expr` itself — its children stay on the root (a caller-side reclaim walker
@@ -1166,6 +1180,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(ast_gc_guard)>(*this, lib,  "ast_gc_guard",
             SideEffects::modifyExternal, "ast_gc_guard")
                 ->args({"block","context","line"});
+        addExtern<DAS_BIND_FUN(ast_gc_collect_scope)>(*this, lib,  "ast_gc_collect_scope",
+            SideEffects::modifyExternal, "ast_gc_collect_scope")
+                ->args({"function","block","context","line"});
         addExtern<DAS_BIND_FUN(for_each_module)>(*this, lib,  "for_each_module",
             SideEffects::accessExternal, "for_each_module")
                 ->args({"program","block","context","line"});

--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -476,7 +476,7 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
             bif->userScenario = true;
             bif->sideEffectFlags = fun->sideEffectFlags | uint32_t(SideEffects::accessExternal);
             // and collect it
-            bif->gc_collect(&module->module_gc_root, gc_root::gc_get_active_root());
+            bif->gc_collect(module->module_gc_root.get(), gc_root::gc_get_active_root());
             // and now try to add or replace the function in the module
             if ( !module->addFunction(bif, true) ) {
                 module->replaceFunction(bif);

--- a/src/misc/gc_node.cpp
+++ b/src/misc/gc_node.cpp
@@ -92,6 +92,8 @@ namespace das {
                 node->~gc_node();
 #ifdef _MSC_VER
                 auto sz = _msize(node);
+#elif defined(__APPLE__)
+                auto sz = malloc_size(node);
 #else
                 auto sz = malloc_usable_size(node);
 #endif

--- a/src/misc/gc_node.cpp
+++ b/src/misc/gc_node.cpp
@@ -11,6 +11,9 @@ namespace das {
 
     static uint64_t gc_break_on_id = 0;
 
+    // installed by the AST layer (ast_gc_report.cpp); see gc_node.h
+    DAS_API gc_describe_fn gc_node_describe_hook = nullptr;
+
     // ---- gc_root statics ----
 
     static thread_local gc_root     s_gc_thread_root;
@@ -115,10 +118,13 @@ namespace das {
 
     void gc_root::gc_report() const {
         DAS_FATAL_LOG("gc_root %p: count=%" PRIu64 "\n", (const void *)this, gc_count);
+        char atbuf[256];
         auto node = gc_first;
         while ( node ) {
-            DAS_FATAL_LOG("  node %p: id=%" PRIu64 " type=%s magic=0x%08x\n",
-                (const void *)node, node->gc_id, node->gc_type_name(), node->gc_magic);
+            atbuf[0] = 0;
+            if ( gc_node_describe_hook ) gc_node_describe_hook(node, atbuf, (int)sizeof(atbuf));
+            DAS_FATAL_LOG("  node %p: id=%" PRIu64 " type=%s magic=0x%08x %s\n",
+                (const void *)node, node->gc_id, node->gc_type_name(), node->gc_magic, atbuf);
             node = node->gc_next;
         }
     }

--- a/src/misc/gc_node.cpp
+++ b/src/misc/gc_node.cpp
@@ -299,4 +299,13 @@ namespace das {
         guard_root.gc_sweep();
     }
 
+    gc_active_scope::gc_active_scope ( gc_root * use ) {
+        saved_active = gc_root::gc_get_active_root();
+        gc_root::gc_get_active_root() = use;
+    }
+
+    gc_active_scope::~gc_active_scope() {
+        gc_root::gc_get_active_root() = saved_active;
+    }
+
 }


### PR DESCRIPTION
## What

Type inference and the flatten lowering mint a large number of throwaway AST nodes (TypeDecls, Expressions) that, until now, piled up on the compile working root until the whole module finished. On a heavy module that's the bulk of the compiler's peak memory.

This makes the AST GC **scoped to each pass**: when the working root grows past a threshold during inference, the live tree is collected into a fresh root and swapped in (O(1)), and the old root's destructor sweeps that pass's garbage. The module finishes holding only its live AST.

## How

The enabler is **the module owning its root as a pointer** — `module_gc_root` goes from a by-value `gc_root` to a `unique_ptr`. With a pointer, "swap the root" is O(1): collect live into a fresh root, repoint, drop the old — no per-node owner fixup, no collect-out-and-back.

- parse now allocates **directly on the module's own root** (new no-sweep `gc_active_scope`), and a final collect+swap at scope exit leaves the module root holding only survivors. `compileDaScript` keeps its transient-root model for top-level post-parse scratch.
- during inference, a per-pass collect fires when the root grew past `gc_infer_collect_nodes` (~2 MB) **or** `gc_infer_collect_pct` of the live set; an **end-of-leg collect** (each inferTypes leg) stops cross-leg garbage compounding — the bigger lever.

The arc, commit by commit: per-stage gc histogram instrumentation → remove the old manual-reclaim machinery → per-pass GC scope for the flatten twin → survivor/garbage report → module owns its root as a pointer (+ final collect+swap) → the per-pass + end-of-leg collect (default on) → macOS `malloc_size` fix for the `DAS_GC_DEBUG` build.

## Settings

In `CodeOfPolicies` (overridable per-module via `options`): `gc_infer_collect` (default **true**), `gc_infer_collect_nodes` (25000), `gc_infer_collect_pct` (50); `log_gc_infer_collect` for the trace. Documented in `reference/language/options.rst`.

## Results

On a heavy real-world module (1081-line file, one `[flatten]`):

| | before | after |
|---|---|---|
| peak RSS | 332 MB | **250 MB (−25%)** |
| peak working-root | 580k nodes | 264k |
| residual garbage | 480k | 52k |
| survivors | 100,899 | **100,899 (identical)** |
| compile time | ~7.8s | ~7.8s (flat) |

## Validation

- Interp suite **10540/0/0** (default-on).
- JIT suite (clean cache) **10140/0/0**.
- `DAS_GC_DEBUG` use-after-sweep poisoning: crash_cand0 + ~2500 macro/linq/decs tests clean.
- Sphinx docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)