### PR TITLE
builtin: native empty(array)/empty(table) + JIT intrinsic

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -74,6 +74,12 @@ Small-table regime micro-benchmarks (N from 1 to 64) — the load profile the la
 |---|---|
 | `test01.das` | emplace, emplace_grow, move, and reserve on arrays of locked vs `[skip_field_lock_check]` struct elements — measures array lock overhead |
 
+## core/builtin_ops/
+
+| File | Description |
+|---|---|
+| `test01.das` | `empty()` / `length()` call throughput on `array<int>` and `table<int;int>` — walks a prebuilt vector of half-filled/half-empty containers (no const-fold). `empty/*` lanes vs `length/*` reference lanes isolate the cost of the native `empty` extern; INTERP is the apples-to-apples target (JIT lanes are asymmetric — `length(table)` is not JIT-inlined) |
+
 ## fusion/
 
 | File | Description |

--- a/benchmarks/core/builtin_ops/test01.das
+++ b/benchmarks/core/builtin_ops/test01.das
@@ -1,0 +1,114 @@
+options gen2
+options persistent_heap
+
+// empty() / length() call-throughput micro-benchmark for array and table.
+//
+// Each lane walks a prebuilt vector of containers (half filled, half empty) and either counts
+// the empty ones (empty lanes) or sums their lengths (length reference lanes). The vector is
+// built outside the measured block; every call reads a distinct runtime element with a
+// data-dependent result, so nothing const-folds and the verified accumulator defeats DCE.
+//
+// Target measurement is INTERP: there all four lanes are plain extern calls, so empty/array
+// and empty/table can be compared directly to the length/* reference lanes. Note the JIT
+// numbers are asymmetric — length(table) is NOT JIT-inlined today, while empty(array),
+// empty(table) and length(array) all inline — so only use JIT output as a smoke check.
+
+require dastest/testing_boost
+
+let N = 1000           // containers per vector (N/2 filled, N/2 empty)
+let FILL = 4           // elements pushed into each filled container
+
+def build_arrays : array<array<int>> {
+    var arrs : array<array<int>>
+    arrs |> reserve(N)
+    for (i in range(N)) {
+        var a : array<int>
+        if ((i & 1) == 1) {
+            a |> reserve(FILL)
+            for (j in range(FILL)) {
+                a |> push(j)
+            }
+        }
+        arrs |> emplace(a)
+    }
+    return <- arrs
+}
+
+def build_tables : array<table<int; int>> {
+    var tabs : array<table<int; int>>
+    tabs |> reserve(N)
+    for (i in range(N)) {
+        var t : table<int; int>
+        if ((i & 1) == 1) {
+            for (j in range(FILL)) {
+                t |> insert(j, j)
+            }
+        }
+        tabs |> emplace(t)
+    }
+    return <- tabs
+}
+
+[benchmark]
+def empty_array(b : B?) {
+    var arrs <- build_arrays()
+    b |> run("empty/array", N) {
+        var cnt = 0
+        for (a in arrs) {
+            if (empty(a)) {
+                cnt++
+            }
+        }
+        if (cnt != N / 2) {
+            b->failNow()
+        }
+    }
+    unsafe { delete arrs; }
+}
+
+[benchmark]
+def empty_table(b : B?) {
+    var tabs <- build_tables()
+    b |> run("empty/table", N) {
+        var cnt = 0
+        for (t in tabs) {
+            if (empty(t)) {
+                cnt++
+            }
+        }
+        if (cnt != N / 2) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tabs; }
+}
+
+[benchmark]
+def length_array(b : B?) {
+    var arrs <- build_arrays()
+    b |> run("length/array", N) {
+        var total = 0
+        for (a in arrs) {
+            total += length(a)
+        }
+        if (total != (N / 2) * FILL) {
+            b->failNow()
+        }
+    }
+    unsafe { delete arrs; }
+}
+
+[benchmark]
+def length_table(b : B?) {
+    var tabs <- build_tables()
+    b |> run("length/table", N) {
+        var total = 0
+        for (t in tabs) {
+            total += length(t)
+        }
+        if (total != (N / 2) * FILL) {
+            b->failNow()
+        }
+    }
+    unsafe { delete tabs; }
+}

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -692,15 +692,7 @@ def length(a : auto | #) : int {
     return typeinfo dim(a)
 }
 
-def empty(a : array<auto> | #) : bool {
-    return length(a) == 0
-}
-
 // table
-
-def empty(a : table<auto; auto> | #) : bool {
-    return length(a) == 0
-}
 
 def reserve(var Tab : table<auto(keyT); auto>; newSize : int) {
     return if (newSize < 0)

--- a/doc/source/stdlib/handmade/function-builtin-empty-0x6f8cd6101fbd3580.rst
+++ b/doc/source/stdlib/handmade/function-builtin-empty-0x6f8cd6101fbd3580.rst
@@ -1,0 +1,1 @@
+Checks whether the array has no elements and returns `true` if so.

--- a/doc/source/stdlib/handmade/function-builtin-empty-0x81cd7e89966250aa.rst
+++ b/doc/source/stdlib/handmade/function-builtin-empty-0x81cd7e89966250aa.rst
@@ -1,1 +1,0 @@
-Checks whether the array `a` has no elements and returns `true` if so.

--- a/doc/source/stdlib/handmade/function-builtin-empty-0xebe551ccb5484d5f.rst
+++ b/doc/source/stdlib/handmade/function-builtin-empty-0xebe551ccb5484d5f.rst
@@ -1,1 +1,0 @@
-Checks whether the table `a` has no entries and returns `true` if so.

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -44,6 +44,7 @@ namespace das {
     DAS_API void builtin_stackwalk ( bool args, bool vars, Context * context, LineInfoArg * lineInfo );
     DAS_API void builtin_terminate ( Context * context, LineInfoArg * lineInfo );
     DAS_API int builtin_table_size ( const Table & arr );
+    DAS_API bool builtin_table_empty ( const Table & arr );
     DAS_API int builtin_table_capacity ( const Table & arr );
     DAS_API int64_t builtin_table_long_size ( const Table & arr );
     DAS_API int64_t builtin_table_long_capacity ( const Table & arr );
@@ -74,6 +75,7 @@ namespace das {
     DAS_API void builtin_table_unlock ( Table & arr, Context * context, LineInfoArg * at );
     DAS_API void builtin_table_clear_lock ( const Table & arr, Context * context );
     DAS_API int builtin_array_size ( const Array & arr );
+    DAS_API bool builtin_array_empty ( const Array & arr );
     DAS_API int builtin_array_capacity ( const Array & arr );
     DAS_API int64_t builtin_array_long_size ( const Array & arr );
     DAS_API int64_t builtin_array_long_capacity ( const Array & arr );

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -26,6 +26,7 @@ let g_intrin_lookup <- {
 // $, aka builtin
     // misc
         "$::length" => @@intrinsic_builtin_length,
+        "$::empty" => @@intrinsic_builtin_empty,
         "$::is_standalone_exe" => @@intrinsic_is_standalone_exe,
         "$::hash" => @@intrinsic_builtin_hash_string,
     // pointer math
@@ -139,6 +140,7 @@ def public has_intrinsic(expr : ExprCallFunc?) {
     // $::hash is inlined for string keys; build_string_hash picks the fast (2-byte) or
     // safe (1-byte) round body by is_safe_hash() so it matches the host runtime exactly.
     if ((call_name == "$::length" && !argType.isGoodArrayType)
+        || (call_name == "$::empty" && !(argType.isGoodArrayType || argType.isGoodTableType))
         || (call_name == "$::hash" && argType.baseType != Type.tString)
         || (!expr.arguments |> empty() && argType.isHandle)) return false
     g_intrin_lookup |> get(call_name) $(_pfun) {
@@ -176,6 +178,19 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
         // builtin length() returns int32; Array.size is uint64. Truncate.
         // TODO Phase 7: emit panic if size > INT32_MAX to match C++ builtin_array_size.
         return LLVMBuildTruncOrBitCast(ctx.builder, size_i64, ctx.types.t_int32, "array.size.i32")
+    } else {
+        return null
+    }
+}
+
+// empty(array) / empty(table) -> size == 0. SIZE is field 1 in both the Array and Table LLVM
+// structs (Table inherits Array), so one body covers both. Returns i1 directly (no truncation).
+def intrinsic_builtin_empty(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume argType = expr.arguments[0]._type
+    if (argType.isGoodArrayType || argType.isGoodTableType) {
+        var cont = LLVMBuildLoad2(ctx.builder, type_to_llvm_type(expr.arguments[0]._type), arguments[0], "cont")
+        var size_i64 = LLVMBuildExtractValue(ctx.builder, cont, uint(JIT_ARRAY.SIZE), "cont.size")
+        return LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, size_i64, LLVMConstInt(ctx.types.t_int64, 0ul, 0), "cont.empty")
     } else {
         return null
     }

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x20ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x21ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -18,6 +18,10 @@ namespace das {
         return int(arr.size);
     }
 
+    bool builtin_array_empty ( const Array & arr ) {
+        return arr.size == 0;
+    }
+
     int builtin_array_capacity ( const Array & arr ) {
         DAS_VERIFYF(arr.capacity <= uint64_t(INT32_MAX), "array capacity %llu exceeds INT_MAX; use long_capacity() instead", (unsigned long long)arr.capacity);
         return int(arr.capacity);
@@ -152,6 +156,9 @@ namespace das {
                 ->args({"array","context","at"});
         addExtern<DAS_BIND_FUN(builtin_array_size)>(*this, lib, "length",
             SideEffects::none, "builtin_array_size")
+                ->arg("array");
+        addExtern<DAS_BIND_FUN(builtin_array_empty)>(*this, lib, "empty",
+            SideEffects::none, "builtin_array_empty")
                 ->arg("array");
         addExtern<DAS_BIND_FUN(builtin_array_capacity)>(*this, lib, "capacity",
             SideEffects::none, "builtin_array_capacity")

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -814,6 +814,10 @@ namespace das
         return int(arr.size);
     }
 
+    bool builtin_table_empty ( const Table & arr ) {
+        return arr.size == 0;
+    }
+
     int builtin_table_capacity ( const Table & arr ) {
         DAS_VERIFYF(arr.capacity <= uint64_t(INT32_MAX), "table capacity %llu exceeds INT_MAX; use long_capacity() instead", (unsigned long long)arr.capacity);
         return int(arr.capacity);
@@ -2113,6 +2117,9 @@ namespace das
                 ->args({"table","context","at"});
         addExtern<DAS_BIND_FUN(builtin_table_size)>(*this, lib, "length",
             SideEffects::none, "builtin_table_size")
+                ->arg("table");
+        addExtern<DAS_BIND_FUN(builtin_table_empty)>(*this, lib, "empty",
+            SideEffects::none, "builtin_table_empty")
                 ->arg("table");
         addExtern<DAS_BIND_FUN(builtin_table_capacity)>(*this, lib, "capacity",
             SideEffects::none, "builtin_table_capacity")


### PR DESCRIPTION
## Summary

`empty(array)` and `empty(table)` were daslib functions defined as `length(a) == 0`. In the **interpreter** each call paid for a full interpreted function frame **plus** an `ExtFuncCall` into the C++ `length` builtin — making `empty` ~30% slower than `length` itself, even though it does strictly less work.

This binds `empty` natively in C++ for `array` and `table` (mirroring `builtin_array_size` / `builtin_table_size`, returning `arr.size == 0`), adds a dasLLVM JIT intrinsic, and removes the daslib definitions.

## Changes

- **C++ binding** — `builtin_array_empty` / `builtin_table_empty` (`return arr.size == 0`), registered as `empty` (`SideEffects::none`) in `module_builtin_array.cpp` / `module_builtin_runtime.cpp`; declared in `aot_builtin.h` for AOT.
- **JIT intrinsic** — `$::empty` → `intrinsic_builtin_empty` (loads the container struct, extracts the `SIZE` field, `icmp eq 0` → `i1`), inlined for **both** array and table. The `has_intrinsic` guard requires `isGoodArrayType || isGoodTableType` so string / iterator / dasvector `empty` falls through to the C++ call (keeps the `lookup_intinsic` consistency `verify` happy). `LLVM_JIT_CODEGEN_VERSION` bumped `0x20` → `0x21`.
- **daslib** — removed the two `empty` defs from `daslib/builtin.das`.
- **Benchmark** — `benchmarks/core/builtin_ops/test01.das` measures `empty`/`length` throughput over a vector of half-empty containers (no const-fold), with `length` reference lanes.
- **Docs** — added the array-`empty` handmade description; dropped two daslib `empty` handmade docs that the daslib→C++ migration orphaned (confirmed via `das2rst` — no stub regenerated for them).

## Results

The load-independent metric is the within-run `empty`-vs-`length` ratio (the benchmark's `length` lanes are the control):

| | `empty` vs `length` before | after |
|---|---|---|
| INTERP array | **+31%** (12.2 / 9.3 ns/op) | **−5%** (6.0 / 6.3) |
| INTERP table | **+29%** (12.4 / 9.6 ns/op) | **−9%** (6.0 / 6.6) |

`empty` now matches/marginally beats `length` (single extern, no `INT32_MAX` guard). Under JIT both `empty(array)` and `empty(table)` inline to a `size == 0` compare (`empty/table` 0.8 ns/op vs the not-JIT-inlined `length/table` 2.1 ns/op).

## Verification

- Interpreter full suite: **10566/10566**
- AOT full suite (`test_aot`, `fail_on_no_aot`, all `_aot_generated` wiped + regenerated): **10566/10566, zero `error[50101]`** — no hash desync
- JIT: `tests/jit_tests` 285/285; confirmed the `has_intrinsic` guard (string `empty` falls through, no consistency-`verify` panic)
- `tests/algorithm` clean under interp + AOT — no overload ambiguity with `array_boost`'s generic `empty`
- Format-verified + lint-clean (0 issues) on all touched `.das`; clean Sphinx `-W` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)