### PR TITLE
ast: describe_function/describe_expression emit gen2 syntax

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -124,6 +124,7 @@ Standalone examples that don't fit neatly into other categories.
 |------|-------------|
 | `base64_generators.das` | Base64 encoder built as a chain of composable generators (deliberately slow — demonstrates generator composition, not production encoding) |
 | `shader_like_validation.das` | Shader-like mode demo — shows how `options shader_like` rejects heap-allocating constructs (arrays, lambdas, `new`) at simulation time |
+| `describe_function.das` | AST introspection — compiles a program at runtime and pretty-prints each function back to gen2 source via `describe_function` (daslib/ast) |
 
 ## hv/ — WebSocket Chat Example
 

--- a/examples/uncategorized/describe_function.das
+++ b/examples/uncategorized/describe_function.das
@@ -1,0 +1,54 @@
+options gen2
+
+// describe_function demo — pretty-prints a compiled function back to source.
+//
+// `describe_function` (daslib/ast) renders an AST Function node as daslang
+// source. It always emits gen2 syntax: braces on every block, parens on
+// control flow. We compile a small program at runtime, grab its module, and
+// print each user function. Run standalone to see the round-tripped source:
+//
+//   daslang.exe describe_function.das
+//
+// The same pattern works for `describe(expr)` on any Expression and
+// `describe(prog)` on a whole Program.
+
+require daslib/ast
+require daslib/rtti
+
+// The embedded source is gen2; its literal { } braces are escaped as \{ \} so
+// they are not read as "{interpolation}" inside this string literal.
+let SAMPLE_SRC = "
+options gen2
+def demo(x : int; var arr : array<int>) : int \{
+    var total = 0
+    for (i in range(x)) \{
+        if (i % 2 == 0) \{
+            total += i
+        \} else \{
+            total -= i
+        \}
+    \}
+    while (total > 100) \{
+        total -= 10
+    \}
+    return total
+\}
+"
+
+[export]
+def main() {
+    compile("demo_module", SAMPLE_SRC, CodeOfPolicies()) $(ok; prog; errors) {
+        if (!ok) {
+            print("compile failed:\n{errors}\n")
+            return
+        }
+        let thisMod = get_this_module(prog)
+        for_each_function(thisMod, "") $(var func) {
+            if (func.flags.builtIn || func.flags.generated || func.flags._lambda) {
+                return
+            }
+            print("// describe_function({func.name}) ->\n")
+            print("{describe_function(func)}\n")
+        }
+    }
+}

--- a/src/ast/ast_print.cpp
+++ b/src/ast/ast_print.cpp
@@ -87,8 +87,11 @@ namespace das {
                 printAliases= program->options.getBoolOption("log_aliasing");
                 printUse = program->options.getBoolOption("print_use");
                 gen2 = program->policies.version_2_syntax;
-                printCStyle = program->options.getBoolOption("print_c_style") || gen2;
+                printCStyle = program->options.getBoolOption("print_c_style");
             }
+            // gen2 always implies C-style braces; keep these consistent even when
+            // there is no program (describe_function / describe_expression path).
+            printCStyle = printCStyle || gen2;
         }
         string str() const { return ss.str(); };
         bool printRef = false;


### PR DESCRIPTION
## Problem

`describe_function` and `describe_expression` (`daslib/ast`) emitted a broken gen1/gen2 **hybrid** — gen2 tokens everywhere (parens on `if`/`for`/`while`, `;` separators, `}` on type decls) but **no braces around blocks**, which fell back to gen1 indentation. The result was neither valid gen1 nor valid gen2:

```
def public sample(...) : int const	var total:int = 0
	for ( i in range(x) )		if ( (i % 2) == 0 )			total += i
 else			total -= i
```

## Root cause

Both functions bottom out in the `print()` template in `src/ast/ast_print.cpp`, which constructs `Printer log(nullptr)`. With no `Program`, the constructor left the default member initializers in place: `gen2 = true` but `printCStyle = false`. Block-brace emission is gated on `printCStyle` while control-flow parens/semicolons are gated on `gen2` — hence the hybrid. The whole-program path (`describe_program`) was unaffected because it recomputes `printCStyle = getBoolOption("print_c_style") || gen2`.

## Fix

Keep `printCStyle` consistent with `gen2` even when there is no program, so the no-program path matches `describe_program`:

```cpp
printCStyle = printCStyle || gen2;
```

After the fix:

```
def public demo(x:int const; var arr:array<int> -const) : int const {
	var total:int = 0;
	for ( i in range(x) ) {
		if ( (i % 2) == 0 ) {
			total += i;
		} else {
			total -= i;
		}
	}
	while ( total > 100 ) {
		total -= 10;
	}
	return total;
}
```

This also fixes the MCP `ast_dump` source mode (which calls `describe_expression(func.body)`).

## Coverage of all `describe` entry points

- `describe_function` → fixed
- `describe_expression` → same `print(nullptr)` path → fixed
- `describe_program` → already correct (uses `Printer(&program)`)
- `describe_typedecl` / `describe_cpp` → render type names only (`array<int>`, `int const`, …) — identical in gen1/gen2, no block syntax, nothing to fix

## Example

Adds `examples/uncategorized/describe_function.das` (+ README row): a standalone `daslang.exe describe_function.das` that compiles a program at runtime, grabs its module, and prints each function back as gen2 source.

## Testing

- Full suite: **10583 passed, 0 failed, 0 errors**
- JIT smoke (`array.das`, `decs/test_bulk_create.das`): no verifier errors
- Lint clean, formatted

AOT not rebuilt: `ast_print.cpp` is the diagnostic/`options log` printer; AOT C++ emission lives in `daslib/aot_cpp.das`, a separate path, so this change cannot affect AOT output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)