### PR TITLE
flatten: iterate the fold phase to a fixpoint (strict_fold completeness)

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -966,17 +966,23 @@ class FlattenAnnotation : AstFunctionAnnotation {
             astChanged = true
             return true
         }
-        if (ph == PHASE_LOWERED) {
-            // Cycle 2: the twin is inferred — collapse const-condition selects and
-            // drop the resulting pure self-assigns. Re-infer if anything changed so
-            // the verify scan and codegen see clean types.
+        if (ph == PHASE_LOWERED || ph == PHASE_FOLDED) {
+            // Cycle 2+: the twin is inferred — collapse const-condition selects, fold
+            // algebraic identities, and drop the resulting pure self-assigns. Re-infer
+            // if anything changed so the verify scan and codegen see clean types.
+            //
+            // Iterate to a fixpoint: flatten_fold folds runtime-operand identities the
+            // typer will not (`0*b → 0`, `x*-1 → -x`); the re-infer between passes then
+            // const-folds the freshly-constant operands (`24 >> (24 & 31) → 0`), which
+            // can expose a new identity (`x - 0`) for the next pass. A single fold pass
+            // is therefore not enough — re-run until nothing folds.
             let folded = flatten_fold(twin)
             set_flatten_phase(func, PHASE_FOLDED)
             if (folded) {
                 astChanged = true
                 return true
             }
-            // Nothing to fold — fall through to the shape check this cycle.
+            // Nothing left to fold — fall through to the shape check this cycle.
         }
         // Final cycle: verify the twin is branchless and call-free (and, under
         // strict_fold, free of const-foldable residuals).

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -125,6 +125,14 @@ downstream tiers (it folds constant *arithmetic* but not constant *constructors*
 and never a runtime-operand identity), done here under a shader's fast-math
 assumption (scalar ``x*0 → 0`` always fires).
 
+The fold and the typer's const-fold are *mutually-enabling*, so the fold phase
+**iterates to a fixpoint**. Flattening folds the runtime-operand identities the
+typer will not (``0*b → 0``); the re-infer between passes then const-folds the
+freshly-constant operands the fold does not touch (``24 >> (24 & 31) → 0``),
+which can expose a fresh identity (``x - 0``) for the next pass. A single pass is
+therefore not enough — the fold re-runs until nothing changes before the twin is
+handed to the backend.
+
 Supported subset
 ================
 

--- a/tests/flatten/test_flatten_const.das
+++ b/tests/flatten/test_flatten_const.das
@@ -356,6 +356,39 @@ def f_cast_accum : float {
     return acc
 }
 
+// ----- fold fixpoint across the typer boundary (#3) -----
+//
+// flatten's fold and the typer's const-fold are mutually-enabling, so the fold phase
+// must iterate to a fixpoint — a single pass is not enough. flatten folds the operands
+// the typer leaves (a const-propagated local `p`, a runtime-operand identity `0*b`);
+// the re-infer THEN const-folds the freshly-constant `p >> (p & 31)` / `24 >> (24 & 31)`
+// to `0` (a shift/mask the FoldVisitor does not touch), which exposes a NEW `x - 0`
+// identity that only a SECOND fold pass can collapse. Under strict_fold the surviving
+// `x - 0` is a hard compile error, so these COMPILING proves the fixpoint loop holds;
+// both reduce to `b + 7`.
+
+// const-prop reveals the constant: `p → 24`, then the typer folds `24 >> (24 & 31) → 0`.
+// `var` (not `let`) is load-bearing: an immutable `let p` is const-propagated early, so
+// the typer folds the shift before fold_body runs and a single pass suffices. `var`
+// defeats that early propagation, forcing the cascade into the post-fold re-infer — the
+// path the fixpoint loop exists to handle.
+[flatten(strict_fold=true)]
+def f_fix_local(b : int) : int {
+    var p = 24   // nolint:LINT003 -- var defeats early const-prop; see note above
+    return (b + 7) - (p >> (p & 31))
+}
+
+// inline-substitution reveals it via a runtime-operand identity flatten folds but the
+// typer will not: `(0 * b) + 24 → 24`, then the typer folds the shift to `0`.
+def fix_callee(p0, q : int) : int {
+    return q - (p0 >> (p0 & 31))
+}
+
+[flatten(strict_fold=true)]
+def f_fix_inline(b : int) : int {
+    return fix_callee((0 * b) + 24, b + 7)
+}
+
 // ----- differential driver -----
 
 var GRID : array<float>
@@ -578,5 +611,13 @@ def test_flatten_const(t : T?) {
     }
     t |> run("const cast in accumulator folds (was whitelist-rejected)") @(t : T?) {
         t |> equal(f_cast_accum_flat(), f_cast_accum())
+    }
+    t |> run("fold reaches a fixpoint across the typer boundary -> b + 7") @(t : T?) {
+        for (n in IGRID) {
+            t |> equal(f_fix_local_flat(n), f_fix_local(n))
+            t |> equal(f_fix_local_flat(n), n + 7)
+            t |> equal(f_fix_inline_flat(n), f_fix_inline(n))
+            t |> equal(f_fix_inline_flat(n), n + 7)
+        }
     }
 }


### PR DESCRIPTION
## The gap

`daslib/flatten`'s fold and the daslang typer's const-fold are **mutually-enabling**, but the fold phase ran exactly **once** before verifying. So under `[flatten(strict_fold=true)]` a const-foldable residual could survive:

1. flatten folds the runtime-operand identities the typer will not (`0*b` &rarr; `0`) — its `FoldVisitor` handles only `* + - && ||`, never `&gt;&gt;` / `&amp;`.
2. The re-infer between passes then const-folds the freshly-constant operands the fold never touches (`24 &gt;&gt; (24 &amp; 31)` &rarr; `0`).
3. That exposes a **new** `x - 0` identity — which only a *second* fold pass can collapse. With one pass, `x - 0` survives &rarr; hard `error[50501]` ("an unfolded algebraic identity ('-') survived the fold").

This is the pre-existing fold-completeness gap the `flatten-fuzz` strict-fold sweep kept surfacing (and it was misfiled earlier as a possibly-missing `0-x` arm — it is **not** a missing arm; the FoldVisitor already handles `x-0`/`0-x`).

## The fix

One-line condition change in the `[flatten]` annotation `patch`: re-enter the existing fold phase while `flatten_fold` reports progress (`PHASE_LOWERED` &rarr; `PHASE_LOWERED || PHASE_FOLDED`). The two folders now alternate (each pass followed by the macro's re-infer) until stable, then verify. `fold_body` is monotonic-reducing so it converges; the compiler's infer-pass cap is a backstop.

Chose iteration over duplicating the typer's integer const-folding into `flatten_opt` — it respects the division of labor (typer folds constants, flatten folds runtime-operand identities, they alternate to a fixpoint).

## Regression test

`tests/flatten/test_flatten_const.das` gains a fixpoint section — two distinct trigger paths, both reduce to `b + 7`, both **fail to compile without the loop** (verified by reverting the condition):

- `f_fix_local` — `var p = 24; (b + 7) - (p &gt;&gt; (p &amp; 31))`. The `var` is **load-bearing**: an immutable `let p` is const-propagated early and folds in a single pass, so the cascade never triggers; `var` defeats early propagation, forcing it into the post-fold re-infer. Carries a justified `// nolint:LINT003`.
- `f_fix_inline` — inlined `0*b` runtime-identity path (reveals the const via flatten's fold, not const-prop).

## Validation

- flatten **interp / JIT / AOT 126 / 126** each
- full interp suite **10558 passed / 0 failed / 0 errors**
- `flatten-fuzz` strict **120 / 120 batches, 0 failures** (prior failing seeds 30/32/53/56/85 now clean)
- **61 / 61** shader examples (`examples/flatten/run.sh`)
- Sphinx `-W`, CI lint, MCP lint, format — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)