### PR TITLE
fix: harden compiler and runtime against fuzzer-found crashes (#2570)

### DIFF
--- a/include/daScript/misc/hal.h
+++ b/include/daScript/misc/hal.h
@@ -41,7 +41,8 @@ __forceinline vec4i v_modi2(vec4i a, vec4i b) {
     } A, B, C;
     A.v = a;
     B.v = b;
-    C.a[0] = A.a[0] % B.a[0];   C.a[1] = A.a[1] % B.a[1];
+    // x % -1 == 0; special-cased to dodge INT_MIN % -1 overflow (matches scalar Mod)
+    C.a[0] = B.a[0]==-1 ? 0 : A.a[0] % B.a[0];   C.a[1] = B.a[1]==-1 ? 0 : A.a[1] % B.a[1];
     return C.v;
 }
 
@@ -63,7 +64,8 @@ __forceinline vec4i v_modi3(vec4i a, vec4i b) {
     } A, B, C;
     A.v = a;
     B.v = b;
-    C.a[0] = A.a[0] % B.a[0];   C.a[1] = A.a[1] % B.a[1];   C.a[2] = A.a[2] % B.a[2];
+    // x % -1 == 0; special-cased to dodge INT_MIN % -1 overflow (matches scalar Mod)
+    C.a[0] = B.a[0]==-1 ? 0 : A.a[0] % B.a[0];   C.a[1] = B.a[1]==-1 ? 0 : A.a[1] % B.a[1];   C.a[2] = B.a[2]==-1 ? 0 : A.a[2] % B.a[2];
     return C.v;
 }
 
@@ -86,7 +88,8 @@ __forceinline vec4i v_modi4(vec4i a, vec4i b) {
     } A, B, C;
     A.v = a;
     B.v = b;
-    C.a[0] = A.a[0] % B.a[0];   C.a[1] = A.a[1] % B.a[1];   C.a[2] = A.a[2] % B.a[2];   C.a[3] = A.a[3] % B.a[3];
+    // x % -1 == 0; special-cased to dodge INT_MIN % -1 overflow (matches scalar Mod)
+    C.a[0] = B.a[0]==-1 ? 0 : A.a[0] % B.a[0];   C.a[1] = B.a[1]==-1 ? 0 : A.a[1] % B.a[1];   C.a[2] = B.a[2]==-1 ? 0 : A.a[2] % B.a[2];   C.a[3] = B.a[3]==-1 ? 0 : A.a[3] % B.a[3];
     return C.v;
 }
 

--- a/include/daScript/simulate/sim_policy.h
+++ b/include/daScript/simulate/sim_policy.h
@@ -455,9 +455,15 @@ namespace  das {
         static __forceinline vec4f Sub ( vec4f a, vec4f b, Context &, LineInfo * ) {
             return v_cast_vec4f(v_subi(v_cast_vec4i(a),v_cast_vec4i(b)));
         }
+        static __forceinline void checkDivOverflow ( vec4i a, vec4i b, Context & context, LineInfo * at ) {
+            // INT_MIN / -1 overflows signed division (idiv #DE); mirror scalar SimPolicy_IntBin::Div
+            if ( v_signmask(v_cast_vec4f(v_andi(v_cmp_eqi(a,v_splatsi(INT32_MIN)),v_cmp_eqi(b,v_splatsi(-1))))) & mask )
+                context.throw_error_at(at,"division overflow");
+        }
         static __forceinline vec4f Div ( vec4f a, vec4f b, Context & context, LineInfo * at ) {
             if ( v_signmask(v_cast_vec4f(v_cmp_eqi(v_cast_vec4i(v_zero()),v_cast_vec4i(b)))) & mask )
                 context.throw_error_at(at,"division by zero");
+            checkDivOverflow(v_cast_vec4i(a),v_cast_vec4i(b),context,at);
                     if ( mask==7 )  return v_cast_vec4f(v_divi3(v_cast_vec4i(a),v_cast_vec4i(b)));
             else    if ( mask==3 )  return v_cast_vec4f(v_divi2(v_cast_vec4i(a),v_cast_vec4i(b)));
             else                    return v_cast_vec4f(v_divi4(v_cast_vec4i(a),v_cast_vec4i(b)));
@@ -513,6 +519,7 @@ namespace  das {
             if ( v_signmask(v_cast_vec4f(v_cmp_eqi(v_cast_vec4i(v_zero()),v_cast_vec4i(b)))) & mask )
                 context.throw_error_at(at,"division by zero");
             TT * pa = (TT *)a;
+            checkDivOverflow(v_cast_vec4i(cast<TT>::from(*pa)),v_cast_vec4i(b),context,at);
                     if ( mask==7 )  *pa = cast<TT>::to (v_cast_vec4f(v_divi3(v_cast_vec4i(cast<TT>::from(*pa)), v_cast_vec4i(b))));
             else    if ( mask==3 )  *pa = cast<TT>::to (v_cast_vec4f(v_divi2(v_cast_vec4i(cast<TT>::from(*pa)), v_cast_vec4i(b))));
             else                    *pa = cast<TT>::to (v_cast_vec4f(v_divi4(v_cast_vec4i(cast<TT>::from(*pa)), v_cast_vec4i(b))));
@@ -564,6 +571,7 @@ namespace  das {
         static __forceinline vec4f DivVecScal ( vec4f a, vec4f b, Context & context, LineInfo * at ) {
             if ( v_extract_xi(v_cast_vec4i(b))==0 )
                 context.throw_error_at(at,"division by zero");
+            checkDivOverflow(v_cast_vec4i(a),v_splat_xi(v_cast_vec4i(b)),context,at);
                     if ( mask==7 )  return v_cast_vec4f(v_divi3(v_cast_vec4i(a),v_splat_xi(v_cast_vec4i(b))));
             else    if ( mask==3 )  return v_cast_vec4f(v_divi2(v_cast_vec4i(a),v_splat_xi(v_cast_vec4i(b))));
             else                    return v_cast_vec4f(v_divi4(v_cast_vec4i(a),v_splat_xi(v_cast_vec4i(b))));
@@ -571,6 +579,7 @@ namespace  das {
         static __forceinline vec4f DivScalVec ( vec4f a, vec4f b, Context & context, LineInfo * at ) {
             if ( v_signmask(v_cast_vec4f(v_cmp_eqi(v_cast_vec4i(v_zero()),v_cast_vec4i(b)))) & mask )
                 context.throw_error_at(at,"division by zero");
+            checkDivOverflow(v_splat_xi(v_cast_vec4i(a)),v_cast_vec4i(b),context,at);
                     if ( mask==7 )  return v_cast_vec4f(v_divi3(v_splat_xi(v_cast_vec4i(a)),v_cast_vec4i(b)));
             else    if ( mask==3 )  return v_cast_vec4f(v_divi2(v_splat_xi(v_cast_vec4i(a)),v_cast_vec4i(b)));
             else                    return v_cast_vec4f(v_divi4(v_splat_xi(v_cast_vec4i(a)),v_cast_vec4i(b)));
@@ -579,6 +588,7 @@ namespace  das {
             if ( v_extract_xi(v_cast_vec4i(b))==0 )
                 context.throw_error_at(at,"division by zero");
             TT * pa = (TT *)a;
+            checkDivOverflow(v_cast_vec4i(cast<TT>::from(*pa)),v_splat_xi(v_cast_vec4i(b)),context,at);
                     if ( mask==7 )  *pa = cast<TT>::to (v_cast_vec4f(v_divi3(v_cast_vec4i(cast<TT>::from(*pa)),v_splat_xi(v_cast_vec4i(b)))));
             else    if ( mask==3 )  *pa = cast<TT>::to (v_cast_vec4f(v_divi2(v_cast_vec4i(cast<TT>::from(*pa)),v_splat_xi(v_cast_vec4i(b)))));
             else                    *pa = cast<TT>::to (v_cast_vec4f(v_divi4(v_cast_vec4i(cast<TT>::from(*pa)),v_splat_xi(v_cast_vec4i(b)))));

--- a/modules/dasUnitTest/bytecode.cpp
+++ b/modules/dasUnitTest/bytecode.cpp
@@ -5,6 +5,10 @@
 namespace das {
 
 int32_t evalByteCode ( const ByteCode * cur, Context * ctx, LineInfoArg * at ) {
+    if ( !cur ) {
+        ctx->throw_error_at(at, "null bytecode");
+        return 0;
+    }
     int32_t a = 0, b = 0, c = 0;
     bool cmp = false;
     while ( true ) {

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -93,6 +93,9 @@ namespace das {
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
+        virtual bool canVisitStructure ( Structure * st ) override {
+            return !st->isTemplate;    // we don't do a thing with templates
+        }
         // virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
         // virtual bool canVisitArgumentInit ( Function * , const VariablePtr &, Expression * ) override { return false; }
         // virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
@@ -509,6 +512,9 @@ namespace das {
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate && funcIsDirty(fun);    // we don't do a thing with templates
         }
+        virtual bool canVisitStructure ( Structure * st ) override {
+            return !st->isTemplate;    // we don't do a thing with templates
+        }
         // function which is fully a nop
         bool isNop ( const FunctionPtr & func ) {
             if ( func->builtIn ) return false;
@@ -760,7 +766,7 @@ namespace das {
     // ExprInvoke
         virtual ExpressionPtr visit ( ExprInvoke * expr ) override {
             auto what = expr->arguments[0];
-            if ( what->type->baseType==Type::tFunction && what->rtti_isAddr() ) {
+            if ( what->type && what->type->baseType==Type::tFunction && what->rtti_isAddr() ) {
                 auto pAddr = static_cast<ExprAddr*>(what);
                 auto funcC = pAddr->func;
                 auto pCall = new ExprCall(expr->at, funcC->name);

--- a/src/ast/ast_export.cpp
+++ b/src/ast/ast_export.cpp
@@ -147,6 +147,9 @@ namespace das {
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
+        virtual bool canVisitStructure ( Structure * st ) override {
+            return !st->isTemplate;    // we don't do a thing with templates
+        }
         virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
         virtual bool canVisitArgumentInit ( Function *, const VariablePtr &, Expression * ) override { return false; }
         // global variable declaration

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -2214,6 +2214,7 @@ namespace das {
         func->result = new TypeDecl(Type::tVoid);
         func->isClassMethod = true;
         func->classParent = baseClass;
+        func->isTemplate = baseClass->isTemplate;
         DAS_ASSERT(func->classParent);
         if ( baseClass->macroInterface ) func->macroFunction = true;
         auto block = new ExprBlock();

--- a/src/ast/ast_infer_type_helper.cpp
+++ b/src/ast/ast_infer_type_helper.cpp
@@ -647,7 +647,7 @@ namespace das {
         if (type->baseType != Type::typeDecl && type->baseType != Type::typeMacro) {
             for (size_t i = 0, is = type->dim.size(); i != is; ++i) {
                 if (type->dim[i] == TypeDecl::dimConst) {
-                    if (type->dimExpr[i]) {
+                    if (i<type->dimExpr.size() && type->dimExpr[i]) {
                         if (auto constExpr = getConstExpr(type->dimExpr[i])) {
                             if (constExpr->type->isIndex()) {
                                 auto cI = static_cast<ExprConstInt*>(constExpr);

--- a/src/ast/ast_infer_type_op.cpp
+++ b/src/ast/ast_infer_type_op.cpp
@@ -909,6 +909,16 @@ namespace das {
                           expr->at, CompilationError::invalid_clone_smart_pointer_type);
                     return Visitor::visit(expr);
                 }
+                if ( !cloneType->firstType->isHandle() ) {
+                    error("can only clone smart pointer to handled type", "", "",
+                          expr->at, CompilationError::invalid_clone_smart_pointer_type);
+                    return Visitor::visit(expr);
+                }
+                if ( !cloneType->firstType->annotation->isSmart() ) {
+                    error("pointer to " + cloneType->describe() + " can't be a smart pointer", "", "",
+                          expr->at, CompilationError::invalid_clone_smart_pointer_type);
+                    return Visitor::visit(expr);
+                }
                 auto fnClone = makeCloneSmartPtr(expr->at, cloneType, expr->right->type);
                 if (program->addFunction(fnClone)) {
                     reportAstChanged();

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -164,7 +164,7 @@ namespace das
         } else {
             for ( size_t i=0, is=dim.size(); i!=is; ++i ) {
                 if ( dim[i]==TypeDecl::dimConst ) {
-                    if ( dimExpr[i] ) {
+                    if ( i<dimExpr.size() && dimExpr[i] ) {
                         dimExpr[i] = dimExpr[i]->visit(vis);
                     }
                 }

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -28,16 +28,19 @@ namespace das
     }
 
     void das_trycatch(callable<void()> tryBody, callable<void(const char * msg)> catchBody) {
-        DAS_ASSERTF(*g_throwBuf==nullptr, "das_trycatch without g_throwBuf");
+        // re-entrant: save/restore the outer frame so das_trycatch can nest (e.g. a fmt
+        // error raised while already formatting another value) — #2570. prevBuf is set
+        // before setjmp and never touched after, so it survives the longjmp.
+        jmp_buf * prevBuf = *g_throwBuf;
         jmp_buf ev;
         *g_throwBuf = &ev;
         if ( !setjmp(ev) ) {
             tryBody();
+            *g_throwBuf = prevBuf;
         } else {
-            *g_throwBuf = nullptr;
+            *g_throwBuf = prevBuf;
             catchBody(g_throwMsg->c_str());
         }
-        *g_throwBuf = nullptr;
     }
     #else
 


### PR DESCRIPTION
Fixes a batch of compiler/runtime crashes found by the grammar-based fuzzer, reported in #2570. Each malformed input now produces a clean compile error or runtime exception instead of a `SIGSEGV` / `SIGFPE` / assert / FATAL abort.

## Fixes

| Area | File(s) | Crash | Fix |
|---|---|---|---|
| Vectorized int div/mod | `hal.h`, `sim_policy.h` | `INT_MIN/-1`, `INT_MIN%-1` → signed-overflow `SIGFPE` | special-case `x % -1 == 0`; div throws `division overflow` (mirrors scalar `SimPolicy_IntBin`) |
| Bytecode eval | `dasUnitTest/bytecode.cpp` | `evalByteCode(null)` → null deref | null-check the argument, throw `null bytecode` |
| Nested fmt error | `runtime_string.cpp` | nested `das_trycatch` → `*g_throwBuf==nullptr` assert | make `das_trycatch` re-entrant (save/restore `g_throwBuf`) |
| Template struct/class | `ast_const_folding.cpp`, `ast_export.cpp`, `ast_generate.cpp` | template field-init folded/visited prematurely → crash | skip templates in `canVisitStructure`; mark generated template-class methods as templates |
| Const-dim arrays | `ast_infer_type_helper.cpp`, `ast_typedecl.cpp` | `dimExpr[i]` out-of-bounds read | bounds-check `dimExpr` access |
| Smart-ptr clone | `ast_infer_type_op.cpp` | clone of non-smart / non-handle inner type → crash | validate the clone target is a smart handled type |

### `runtime_string.cpp` — re-entrant `das_trycatch`

In the no-exceptions build, fmt format errors are bridged through `das_throw`, which longjmps to the global `g_throwBuf` set up by `das_trycatch`. The original `das_trycatch` asserted `*g_throwBuf==nullptr` on entry, so it could not nest — when a fmt error was raised while another value was already being formatted (e.g. const-folding `print("...{~4:1>751}")`, where the `751`-wide spec overflows and the overflow path re-enters formatting), the inner `das_trycatch` tripped the assert.

The fix makes `das_trycatch` save and restore the outer frame instead of asserting, so it nests correctly. Both fmt helpers (`fmt_T`, `fmt_and_write_T`) keep using `das_trycatch`, so fmt format errors are still caught and reported as clean `fmt error: …` exceptions rather than aborting.

## Validation

- Each crash class reproduced on the pre-fix build and confirmed clean afterwards (clean compile error / runtime exception, no crash).
- The #2570 fmt-assert case validated in a **Debug** build (assertions live):
  - **before:** `assertion failed: *g_throwBuf==nullptr, runtime_string.cpp:31`
  - **after:** no assert — compilation proceeds and reports the input's real errors.
- Full test suite green in both **interpreter** and **AOT** modes: `10586` / `9930` tests, `0 failed`, `0 errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)