### PR TITLE
pre-push: format-verify only tracked files (respect .gitignore)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -41,16 +41,18 @@ fi
 
 echo "pre-push: using $DASLANG"
 
-# Formatter: whole tree, verify-only (CI parity). Skip build/ and _build/ output
-# dirs — a locally junctioned module's build output (CMake build/, Sphinx _build/
-# with its _downloads copies) is gitignored and never present in CI's fresh clone,
-# but the whole-tree walk would otherwise trip on it. Masks are SEGMENT-bounded
-# (slashes on both sides) so they match the dirs, not source files like
-# string_builder.das; both slash forms cover Windows (\build\) and POSIX (/build/).
+# Formatter: verify only tracked .das files (the git index), fed via --files-from.
+# This is exactly CI's fresh-clone view, so the hook can't diverge from CI: gitignored
+# scratch (examples/wip.das), build/ and _build/ output, and untracked files that
+# aren't being pushed are all skipped — none of them reach CI.
 echo "pre-push: formatter --verify ..."
-"$DASLANG" "$ROOT/utils/das-fmt/dasfmt.das" -- --path "$ROOT" --verify \
-    --exclude-mask "/build/" --exclude-mask '\build\' \
-    --exclude-mask "/_build/" --exclude-mask '\_build\'
+FMT_LIST="$(mktemp "${TMPDIR:-/tmp}/dasfmt-prepush.XXXXXX")"   # template form: portable across GNU/BSD/macOS/Git Bash
+trap 'rm -f "$FMT_LIST"' EXIT
+git ls-files --cached -- '*.das' > "$FMT_LIST"
+# daslang is a native binary; under Git Bash it needs a Windows path, not /tmp/...
+FMT_LIST_ARG="$FMT_LIST"
+command -v cygpath >/dev/null 2>&1 && FMT_LIST_ARG="$(cygpath -m "$FMT_LIST")"
+"$DASLANG" "$ROOT/utils/das-fmt/dasfmt.das" -- --files-from "$FMT_LIST_ARG" --verify
 
 # Lint: only .das files changed in the pushed range vs remote tip
 # (mirrors CI's `git diff origin/<base>...HEAD`).

--- a/utils/das-fmt/dasfmt.das
+++ b/utils/das-fmt/dasfmt.das
@@ -67,8 +67,7 @@ def private collect_input_paths(args : array<string>; key : string; var paths : 
 }
 
 
-def private collect_files(input_paths : array<string>; var files : array<string>) : bool {
-    var cache : table<string; void?>
+def private collect_files(input_paths : array<string>; var cache : table<string; void?>; var files : array<string>) : bool {
     for (path in input_paths) {
         if (path |> ends_with(".das")) {
             if (!cache |> key_exists(path)) {
@@ -82,8 +81,29 @@ def private collect_files(input_paths : array<string>; var files : array<string>
             }
         }
     }
-    delete cache
     return true
+}
+
+
+def private collect_files_from_list(list_file : string; var cache : table<string; void?>; var files : array<string>) : bool {
+    // Read a newline-separated list of file paths to format/verify.
+    var opened = false
+    fopen(list_file, "rb") $(fr) {
+        if (fr != null) {
+            opened = true   // file opened; an empty list is zero files, not an error
+            fmap(fr) $(data) {
+                for (raw_line in split(string(data), "\n")) {
+                    let line = replace(raw_line, "\r", "")
+                    if (!empty(line) && line |> ends_with(".das") && !cache |> key_exists(line)) {
+                        cache.insert(line, null)
+                        files |> push <| line
+                    }
+                }
+            }
+        }
+    }
+    if (!opened) log::error("Unable to open file list '{list_file}'")
+    return opened
 }
 
 
@@ -103,16 +123,30 @@ def main() {
 
     let startTime = ref_time_ticks()
 
+    var seen : table<string; void?>   // shared across --path and --files-from to skip duplicate files
     var inputPaths : array<string>
     collect_input_paths(args, "--path", inputPaths)
     var files : array<string>
-    if (!collect_files(inputPaths, files)) {
+    if (!collect_files(inputPaths, seen, files)) {
         log::error("Unable to collect files list\n")
         unsafe {
             fio::exit(1)
         }
         return
     }
+
+    var listPaths : array<string>
+    collect_input_paths(args, "--files-from", listPaths)
+    for (lf in listPaths) {
+        if (!collect_files_from_list(lf, seen, files)) {
+            log::error("Unable to collect files list\n")
+            unsafe {
+                fio::exit(1)
+            }
+            return
+        }
+    }
+    delete seen
 
     var excludeMasks : array<string>
     collect_input_paths(args, "--exclude-mask", excludeMasks)


### PR DESCRIPTION
The pre-push hook ran the formatter over the **whole working tree** (`dasfmt --path $ROOT`), so any gitignored `.das` present locally would fail the format check even though CI's fresh clone never sees it. In practice a local scratch file like `examples/wip.das` (gitignored), or stray `build/` / `_build/` output, blocked every `git push` — even on a branch that didn't touch a single `.das`.

This makes the hook match CI: verify only the **tracked** file set (the git index).

## Change

- **`utils/das-fmt/dasfmt.das`** — add `--files-from <list>`, a newline-separated list of files to format/verify (alongside the existing `--path`). An empty list verifies zero files instead of erroring.
- **`.githooks/pre-push`** — build the list with `git ls-files --cached -- '*.das'` (tracked / index) and pass it via `--files-from`. Drops the `build/` / `_build/` exclude-masks (git already ignores them). The temp-file path is converted with `cygpath -m` so the native daslang binary can open it under Git Bash.

## Why this is correct

`git ls-files --cached` is exactly the set of files a fresh clone contains — the same view CI's formatter has — so the hook can no longer diverge from CI on gitignored or untracked local files.

## Validation

- New hook on its own push: `Verified! 2131 files` + lint clean (self-validating).
- Re-introduced unformatted content in gitignored `examples/wip.das`: old (`--path $ROOT`) **fails** on it; new (`--files-from` git index) **skips** it.
- Empty `--files-from` list: `Verified! 0 files` (no spurious error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)