### PR TITLE
flatten: fix struct early-return (mark return accumulator safe-when-uninitialized)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 - Class methods: `def const`, `def abstract const`, `def static`; call syntax `obj.method()`, `obj->method()`, `obj |> method()`
 - **`is`/`as` on handled types checks EXACT type**, not C++ inheritance — `expr is ExprField` is `false` when `expr` is `ExprSafeField`. `as` on wrong type crashes. Must handle each concrete type explicitly.
 - `#pragma optimize` in AOT-generated code must be wrapped in `#ifdef _MSC_VER` — Clang warns on unknown pragmas
-- **Macro-generated struct variables** need `default<$t(st)>` initialization (not `var x : $t(st)`) — avoids "uninitialized variable" errors for structs without field defaults
+- **Macro-generated `var x : $t(st)`** (no init) trips `error[31016]` "uninitialized variable is unsafe" for **any** struct result/local type — field defaults do **not** exempt it. Fixes: `= default<$t(st)>` when the type is default-constructible; but for handled/backend types `default<>` is `error[50503] unsupported variable type` — then set `td.flags.safeWhenUninitialized = true` on the (cloned) decl type when the uninitialized read is intentional and discarded (canonical: the `[flatten]` return accumulator in `daslib/flatten.das`)
 - `print` is for user-facing scripts only. In `tests/`, `daslib/`, `utils/`: use `to_log(LOG_INFO|LOG_WARNING|LOG_ERROR)` — same stdout, but level-tagged and filterable. Canonical example: `utils/detect-dupe/main.das`
 
 ### Code style — prefer idiomatic forms

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -797,6 +797,14 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
         if (ctx.hasRet) {
             var rt = clone_type(func.result)
             rt.flags.constant = false
+            // The return accumulator is read self-referentially by every `__flat_ret = pred
+            // ? v : __flat_ret` write (lower_stmt), so its first read is the bare decl. That
+            // read is always a discarded placeholder — overwritten by the taken return, or
+            // kept only on the not-taken path — so the uninitialized read is safe by design.
+            // const_prop_pass collapses it away when the live mask folds (single return), but
+            // a live early-return leaves the self-ref intact, and `var x : Struct` is otherwise
+            // rejected (error[31016]) for any struct return type.
+            rt.flags.safeWhenUninitialized = true
             out |> push <| qmacro_expr(${ var $i(ctx.retName) : $t(rt); })
         }
         lower_list(ctx, bodyBlk, null, out)
@@ -806,6 +814,7 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
         if (ctx.ok) {
             dse_pass(out)          // drop dead mask-kills (`__flat_live = false`) first…
             const_prop_pass(out)   // …so an unreassigned `__flat_live` reads as const true → collapse
+
             copy_prop_pass(out)    // inline single-def temps (`__flat_ret = c; return __flat_ret` → `return c`)
             dse_pass(out)          // remove anything left dead (collapsed mask decls, folded temps)
             ssa_rename_pass(out)   // single-def-ify reassigned user locals → fold_body const-props the chain

--- a/tests/flatten/test_flatten_basic.das
+++ b/tests/flatten/test_flatten_basic.das
@@ -103,6 +103,30 @@ def inline_twice(x : int) : int {
     return withlocal(x) + withlocal(x + 1)
 }
 
+// A STRUCT return type with an early return: the predicated `__flat_ret = pred ? v :
+// __flat_ret` write reads the bare accumulator decl, which a live early return leaves
+// intact (const_prop_pass can only collapse it for a single unconditional return). For a
+// struct (unsafe-when-uninitialized) result that read was previously rejected
+// (error[31016]); the lowering now marks the accumulator safe-when-uninitialized because
+// the placeholder read is always discarded.
+struct Pt {
+    a : float3 = float3(0)
+    b : float = 1.0
+}
+
+[flatten]
+def struct_uncond(x : float) : Pt {
+    return Pt(a = float3(x))
+}
+
+[flatten]
+def struct_guard(x : float; c : bool) : Pt {
+    if (c) {
+        return Pt(a = float3(x))
+    }
+    return Pt(b = x)
+}
+
 // ----- differential driver -----
 
 var GRID : array<int>
@@ -152,6 +176,21 @@ def test_flatten_equivalence(t : T?) {
     t |> run("helper-with-local inlined at two direct call sites") @(t : T?) {
         for (v in GRID) {
             t |> equal(inline_twice_flat(v), inline_twice(v))
+        }
+    }
+    t |> run("struct return type, unconditional + early return (was error[31016])") @(t : T?) {
+        for (v in GRID) {
+            let fv = float(v)
+            let u = struct_uncond_flat(fv)
+            let eu = struct_uncond(fv)
+            t |> equal(u.a.x, eu.a.x)
+            t |> equal(u.b, eu.b)
+            for (c in fixed_array(false, true)) {
+                let g = struct_guard_flat(fv, c)
+                let eg = struct_guard(fv, c)
+                t |> equal(g.a.x, eg.a.x)
+                t |> equal(g.b, eg.b)
+            }
         }
     }
 }


### PR DESCRIPTION
## Bug

`[flatten]` on a function with a **live early return** and a **struct** (or any `is_unsafe_when_uninitialized`) result type fails to compile:

```
error[31016]: Uninitialized variable __flat_ret is unsafe.
```

Predicated lowering writes the return as `__flat_ret = pred ? v : __flat_ret`, so every write reads the prior accumulator — and the first read is the bare `var __flat_ret : RetT` decl. `const_prop_pass` collapses that self-ref away **only** when the live mask folds to a constant (a single unconditional return — the shader idiom). A live early return leaves the select intact, and `var x : Struct` with no init is rejected for any struct result type. Int/float returns were unaffected (safe to zero-init), which is why it went unnoticed.

## Fix

The placeholder read is **always discarded** (overwritten by the taken return, or kept only on the not-taken path), so it's safe by design — set `safeWhenUninitialized` on the accumulator's decl type. `default<RetT>` is not an option: it's `error[50503]` for handled/backend result types (e.g. a shader's `PbrOutput`).

## Test

`test_flatten_basic.das` gains a struct-returning twin (unconditional + early return), differential-checked against its original. It fails with `error[31016]` without the fix.

interp **136/136**, JIT, AOT codegen all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)