### PR TITLE
examples/flatten: add loop-unroll feature fixtures (array / parallel / urange)

### DIFF
--- a/examples/flatten/README.md
+++ b/examples/flatten/README.md
@@ -22,6 +22,7 @@ call-free code.
 | Path | What |
 |---|---|
 | `shaders/user_shaders/`, `shaders/user_shaders_2d/` | The real EdenSpark sample shaders (3D + 2D post-fx), **unedited**. |
+| `shaders/features/` | Loop-unroll feature fixtures (array-literal / parallel multi-iterator / `urange` sources). The backend bans `ExprFor`, so these compile **only** because flatten unrolls them — flatten is load-bearing, not transparent. |
 | `backend/shader_dsl_primitives.das` | The `[hint]`/`[stub]` leaf primitives + I/O contract structs (`PbrInput`/`PbrOutput`). |
 | `backend/shader_dsl_boost.das` | The validator + graph IR builder + the `[pixel_shader]` annotation. **This is where flatten is wired in.** |
 | `backend/shader_graph_ir_builder.das` | Print-only stand-in for the engine's native `sg_ir_*` graph sink — dumps human-readable opcodes. |
@@ -39,10 +40,13 @@ consume flatten's `?:` output.
 
 ## Two tiers
 
-- **Regression** — all 61 real shaders are already 100% branchless dataflow (there is
-  no control-flow primitive in the DSL *yet* — flatten is what adds one). flatten must
+- **Regression** — the real `user_shaders*` are already 100% branchless dataflow (there
+  is no control-flow primitive in the DSL *yet* — flatten is what adds one). flatten must
   be **transparent** on them: the emitted graph is the same one the backend produces
-  without flatten. `./run.sh` checks every shader compiles clean and emits a graph.
+  without flatten. The `shaders/features/` fixtures additionally exercise the loop-unroll
+  source forms (`for…in` array literal, parallel `(a, b in xs, ys)`, `urange`) — there
+  flatten is load-bearing, but the same compile-clean check covers them. `./run.sh`
+  checks every shader compiles clean and emits a graph.
 - **Capability** *(`capability/check.sh`)* — shaders written with constructs the
   backend rejects today, made to compile by flatten. This is the feature flatten
   exists to deliver:

--- a/examples/flatten/shaders/features/loop_array.shader
+++ b/examples/flatten/shaders/features/loop_array.shader
@@ -1,0 +1,27 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    blurSize = 0.01
+}
+
+// Fixture for `for v in [literal array]` unrolling + accumulator.
+// A horizontal 3-tap blur whose tap offsets come straight from an array literal
+// in the loop header (no index — the iterator IS the offset value).
+[pixel_shader]
+def loop_array(inp : PbrInput) {
+    let s = blurSize
+    var acc = float3(0.0, 0.0, 0.0)
+    for (off in [float2(-s, 0.0), float2(0.0, 0.0), float2(s, 0.0)]) {
+        acc += tex2d(albedo_texture, inp.uv + off).xyz
+    }
+    let result = acc * (1.0 / 3.0)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/features/loop_multi.shader
+++ b/examples/flatten/shaders/features/loop_multi.shader
@@ -1,0 +1,26 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    blurSize = 0.01
+}
+
+// Fixture for the multi-iterator form `for (a, b in [...], [...])` — two parallel
+// arrays unrolled in lockstep: each tap has its own offset AND its own weight,
+// neither derivable from the other.
+[pixel_shader]
+def loop_multi(inp : PbrInput) {
+    let s = blurSize
+    var acc = float3(0.0, 0.0, 0.0)
+    for (off, weight in [float2(-s, 0.0), float2(0.0, 0.0), float2(s, 0.0)], [0.25, 0.5, 0.25]) {
+        acc += tex2d(albedo_texture, inp.uv + off).xyz * weight
+    }
+    return PbrOutput(
+        albedo = acc,
+        emission = acc,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/features/loop_urange.shader
+++ b/examples/flatten/shaders/features/loop_urange.shader
@@ -1,0 +1,27 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    blurSize = 0.01
+}
+
+// Fixture for `for i in urange(N)` unrolling — iterator is a uint constant
+// (0u, 1u, 2u), used in float math via float(i).
+[pixel_shader]
+def loop_urange(inp : PbrInput) {
+    let s = blurSize
+    var acc = float3(0.0, 0.0, 0.0)
+    for (i in urange(3u)) {
+        let off = float2(float(i) * s, 0.0)
+        acc += tex2d(albedo_texture, inp.uv + off).xyz
+    }
+    let result = acc * (1.0 / 3.0)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}


### PR DESCRIPTION
Adds three `[pixel_shader]` fixtures under a new `examples/flatten/shaders/features/` directory, exercising the loop-source forms `daslib/flatten` unrolls:

| Fixture | Loop form | Folded output |
|---|---|---|
| `loop_array` | `for (off in [float2(...), ...])` — array literal | 3 taps; zero-offset center tap folds to bare `inp.uv` |
| `loop_multi` | `for (off, weight in [...], [...])` — parallel lockstep | 3 taps, each with its own `* weight` |
| `loop_urange` | `for (i in urange(3u))` — uint counter via `float(i)` | 3 taps; `off_0 = 0` folds to `inp.uv`, `off_1 = s`, `off_2 = s*2` |

These differ from the real `user_shaders*` (which are already branchless, so flatten is *transparent* on them): the backend bans `ExprFor`, so each of these compiles **only** because flatten unrolls it — flatten is load-bearing here. The zero-offset center tap folding to bare `inp.uv` exercises the vector-const fold from #3053.

Picked up automatically by `run.sh`'s `shaders/*/*.shader` sweep (now **65 pass**, was 62). README Layout table + tier note updated to document the new directory and its load-bearing-flatten distinction.

No core/daslib/doc changes — fixtures + README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)