### PR TITLE
site+docs: integrate Algolia DocSearch

### DIFF
--- a/doc/source/_static/docsearch.css
+++ b/doc/source/_static/docsearch.css
@@ -1,0 +1,83 @@
+/* Algolia DocSearch — Forge theme overlay for daslang.io.
+ *
+ * Maps the @docsearch/css@3 custom properties onto the Forge dark tokens
+ * (defined in files/forge.css for the site, and doc/source/_static/custom.css
+ * for the Sphinx docs — both expose the same --bg/--fg/--amber/--rule names).
+ * Literal-hex fallbacks keep this working even where the tokens are absent.
+ *
+ * NOTE: a byte-identical copy lives at doc/source/_static/docsearch.css for the
+ * Sphinx docs (separate static tree). Keep the two in sync. */
+
+:root {
+    --docsearch-primary-color:              var(--amber, #e8a13a);
+    --docsearch-text-color:                 var(--fg, #e8e2d2);
+    --docsearch-muted-color:                var(--fg-dim, #9b9281);
+    --docsearch-spacing:                    12px;
+
+    /* Backdrop + modal */
+    --docsearch-container-background:       rgba(13, 12, 10, 0.78);
+    --docsearch-modal-background:           var(--bg-2, #15130f);
+    --docsearch-modal-shadow:               0 0 0 1px var(--rule, #2a2620),
+                                            0 14px 44px rgba(0, 0, 0, 0.6);
+
+    /* Search box inside the modal */
+    --docsearch-searchbox-background:       var(--bg-3, #1c1a14);
+    --docsearch-searchbox-focus-background: var(--bg-3, #1c1a14);
+    --docsearch-searchbox-shadow:           inset 0 0 0 1px var(--amber, #e8a13a);
+
+    /* Result hits */
+    --docsearch-hit-color:                  var(--fg, #e8e2d2);
+    --docsearch-hit-background:             var(--bg-3, #1c1a14);
+    --docsearch-hit-active-color:           var(--bg, #0d0c0a);
+    --docsearch-hit-shadow:                 none;
+
+    /* Footer + keyboard hint keys */
+    --docsearch-footer-background:          var(--bg-2, #15130f);
+    --docsearch-footer-shadow:              0 -1px 0 0 var(--rule, #2a2620);
+    --docsearch-key-gradient:               linear-gradient(-225deg, #2a2620, #1c1a14);
+    --docsearch-key-shadow:                 none;
+    --docsearch-logo-color:                 var(--fg-dim, #9b9281);
+}
+
+/* ───── Trigger button inside the Forge nav (site + blog) ───── */
+.forge-nav #docsearch { display: flex; align-items: center; }
+.forge-nav .DocSearch-Button {
+    margin: 0;
+    height: 32px;
+    padding: 0 8px 0 10px;
+    border: 1px solid var(--rule, #2a2620);
+    border-radius: 4px;
+    background: transparent;
+    font-family: var(--font-mono, "JetBrains Mono", monospace);
+    font-size: 12.5px;
+    color: var(--fg-dim, #9b9281);
+}
+.forge-nav .DocSearch-Button:hover {
+    box-shadow: none;
+    border-color: var(--amber-dim, #a87420);
+    background: var(--bg-3, #1c1a14);
+}
+.forge-nav .DocSearch-Button:active,
+.forge-nav .DocSearch-Button:focus { box-shadow: none; outline: none; }
+.forge-nav .DocSearch-Button .DocSearch-Search-Icon {
+    width: 15px; height: 15px;
+    color: var(--fg-dim, #9b9281);
+}
+.forge-nav .DocSearch-Button-Placeholder { padding: 0 8px; font-size: 12.5px; }
+.forge-nav .DocSearch-Button-Keys { min-width: auto; }
+.forge-nav .DocSearch-Button-Key {
+    background: var(--bg-3, #1c1a14);
+    box-shadow: none;
+    border: 1px solid var(--rule, #2a2620);
+    color: var(--fg-faint, #5b5547);
+    padding: 0;
+}
+
+/* ───── Trigger button inside the RTD docs sidebar (Sphinx) ───── */
+.wy-side-nav-search #docsearch { margin: 0 0 8px; }
+.wy-side-nav-search .DocSearch-Button {
+    width: 100%;
+    margin: 0;
+    border-radius: 4px;
+    background: var(--bg-3, #1c1a14);
+}

--- a/doc/source/_static/docsearch.js
+++ b/doc/source/_static/docsearch.js
@@ -1,0 +1,29 @@
+// Algolia DocSearch init for daslang.io.
+//
+// The apiKey below is the PUBLIC search-only key — DocSearch always ships it to
+// the client; the admin/write key is never exposed here.
+//
+// Runs DOM-ready-safe so the same file works whether it's loaded with `defer`
+// (the hand-authored + blog pages) or injected into <head> non-deferred (the
+// Sphinx docs, via conf.py html_js_files). The @docsearch/js UMD bundle is
+// always loaded before this file, so the global `docsearch` is defined.
+//
+// NOTE: a byte-identical copy lives at doc/source/_static/docsearch.js for the
+// Sphinx docs (separate static tree). Keep the two in sync.
+(function () {
+  function init() {
+    if (typeof docsearch !== 'function') return;
+    if (!document.querySelector('#docsearch')) return;
+    docsearch({
+      container: '#docsearch',
+      appId: 'Z88JBBPHHH',
+      indexName: 'daslang.io crawler',
+      apiKey: '09d715f38753c82d2f87a9824ac81c3f',
+    });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -27,6 +27,11 @@
     {%- endif %}
   {%- endif %}
 
+  {# DocSearch (Algolia) — sits alongside the native RTD search box below.
+     CSS/JS wired via conf.py html_css_files / html_js_files; _static/docsearch.js
+     targets this container. #}
+  <div id="docsearch"></div>
+
   {%- include "searchbox.html" %}
 
 {%- endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -157,7 +157,21 @@ html_static_path = ['_static']
 
 # Custom CSS — Forge token overlay on top of sphinx_rtd_theme.
 # See doc/source/_static/custom.css for the retoken rules.
-html_css_files = ['custom.css', 'custom-patch.css']
+# DocSearch: base CSS from CDN + the Forge theme overlay (docsearch.css).
+html_css_files = [
+    'custom.css', 'custom-patch.css',
+    'https://cdn.jsdelivr.net/npm/@docsearch/css@3',
+    'docsearch.css',
+]
+
+# DocSearch: UMD bundle from CDN (defines global `docsearch`) + the init
+# that wires it to the #docsearch container in _templates/layout.html.
+# Sphinx appends html_js_files in order and emits <script defer> for them,
+# so the bundle is loaded before the init.
+html_js_files = [
+    'https://cdn.jsdelivr.net/npm/@docsearch/js@3',
+    'docsearch.js',
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -20,6 +20,12 @@
     <!-- Analytics -->
     <script data-goatcounter="https://borisbat.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
+
+    <!-- Algolia DocSearch -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+    <link rel="stylesheet" href="{{root}}files/docsearch.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" defer></script>
+    <script src="{{root}}files/docsearch.js" defer></script>
 </head>
 <body>
 <div class="forge-page">
@@ -42,6 +48,7 @@
                 </div>
             </div>
             <div class="forge-nav__right">
+                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>

--- a/site/daspkg.html
+++ b/site/daspkg.html
@@ -18,6 +18,12 @@
     <!-- Analytics -->
     <script data-goatcounter="https://borisbat.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
+
+    <!-- Algolia DocSearch -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+    <link rel="stylesheet" href="files/docsearch.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" defer></script>
+    <script src="files/docsearch.js" defer></script>
 </head>
 <body>
 <div class="forge-page">
@@ -43,6 +49,7 @@
                 </div>
             </div>
             <div class="forge-nav__right">
+                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -13,6 +13,12 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" />
     <link rel="stylesheet" href="files/forge.css" />
+
+    <!-- Algolia DocSearch -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+    <link rel="stylesheet" href="files/docsearch.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" defer></script>
+    <script src="files/docsearch.js" defer></script>
 </head>
 <body>
 <div class="forge-page">
@@ -37,6 +43,7 @@
                 </div>
             </div>
             <div class="forge-nav__right">
+                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>

--- a/site/files/docsearch.css
+++ b/site/files/docsearch.css
@@ -1,0 +1,83 @@
+/* Algolia DocSearch — Forge theme overlay for daslang.io.
+ *
+ * Maps the @docsearch/css@3 custom properties onto the Forge dark tokens
+ * (defined in files/forge.css for the site, and doc/source/_static/custom.css
+ * for the Sphinx docs — both expose the same --bg/--fg/--amber/--rule names).
+ * Literal-hex fallbacks keep this working even where the tokens are absent.
+ *
+ * NOTE: a byte-identical copy lives at doc/source/_static/docsearch.css for the
+ * Sphinx docs (separate static tree). Keep the two in sync. */
+
+:root {
+    --docsearch-primary-color:              var(--amber, #e8a13a);
+    --docsearch-text-color:                 var(--fg, #e8e2d2);
+    --docsearch-muted-color:                var(--fg-dim, #9b9281);
+    --docsearch-spacing:                    12px;
+
+    /* Backdrop + modal */
+    --docsearch-container-background:       rgba(13, 12, 10, 0.78);
+    --docsearch-modal-background:           var(--bg-2, #15130f);
+    --docsearch-modal-shadow:               0 0 0 1px var(--rule, #2a2620),
+                                            0 14px 44px rgba(0, 0, 0, 0.6);
+
+    /* Search box inside the modal */
+    --docsearch-searchbox-background:       var(--bg-3, #1c1a14);
+    --docsearch-searchbox-focus-background: var(--bg-3, #1c1a14);
+    --docsearch-searchbox-shadow:           inset 0 0 0 1px var(--amber, #e8a13a);
+
+    /* Result hits */
+    --docsearch-hit-color:                  var(--fg, #e8e2d2);
+    --docsearch-hit-background:             var(--bg-3, #1c1a14);
+    --docsearch-hit-active-color:           var(--bg, #0d0c0a);
+    --docsearch-hit-shadow:                 none;
+
+    /* Footer + keyboard hint keys */
+    --docsearch-footer-background:          var(--bg-2, #15130f);
+    --docsearch-footer-shadow:              0 -1px 0 0 var(--rule, #2a2620);
+    --docsearch-key-gradient:               linear-gradient(-225deg, #2a2620, #1c1a14);
+    --docsearch-key-shadow:                 none;
+    --docsearch-logo-color:                 var(--fg-dim, #9b9281);
+}
+
+/* ───── Trigger button inside the Forge nav (site + blog) ───── */
+.forge-nav #docsearch { display: flex; align-items: center; }
+.forge-nav .DocSearch-Button {
+    margin: 0;
+    height: 32px;
+    padding: 0 8px 0 10px;
+    border: 1px solid var(--rule, #2a2620);
+    border-radius: 4px;
+    background: transparent;
+    font-family: var(--font-mono, "JetBrains Mono", monospace);
+    font-size: 12.5px;
+    color: var(--fg-dim, #9b9281);
+}
+.forge-nav .DocSearch-Button:hover {
+    box-shadow: none;
+    border-color: var(--amber-dim, #a87420);
+    background: var(--bg-3, #1c1a14);
+}
+.forge-nav .DocSearch-Button:active,
+.forge-nav .DocSearch-Button:focus { box-shadow: none; outline: none; }
+.forge-nav .DocSearch-Button .DocSearch-Search-Icon {
+    width: 15px; height: 15px;
+    color: var(--fg-dim, #9b9281);
+}
+.forge-nav .DocSearch-Button-Placeholder { padding: 0 8px; font-size: 12.5px; }
+.forge-nav .DocSearch-Button-Keys { min-width: auto; }
+.forge-nav .DocSearch-Button-Key {
+    background: var(--bg-3, #1c1a14);
+    box-shadow: none;
+    border: 1px solid var(--rule, #2a2620);
+    color: var(--fg-faint, #5b5547);
+    padding: 0;
+}
+
+/* ───── Trigger button inside the RTD docs sidebar (Sphinx) ───── */
+.wy-side-nav-search #docsearch { margin: 0 0 8px; }
+.wy-side-nav-search .DocSearch-Button {
+    width: 100%;
+    margin: 0;
+    border-radius: 4px;
+    background: var(--bg-3, #1c1a14);
+}

--- a/site/files/docsearch.js
+++ b/site/files/docsearch.js
@@ -1,0 +1,29 @@
+// Algolia DocSearch init for daslang.io.
+//
+// The apiKey below is the PUBLIC search-only key — DocSearch always ships it to
+// the client; the admin/write key is never exposed here.
+//
+// Runs DOM-ready-safe so the same file works whether it's loaded with `defer`
+// (the hand-authored + blog pages) or injected into <head> non-deferred (the
+// Sphinx docs, via conf.py html_js_files). The @docsearch/js UMD bundle is
+// always loaded before this file, so the global `docsearch` is defined.
+//
+// NOTE: a byte-identical copy lives at doc/source/_static/docsearch.js for the
+// Sphinx docs (separate static tree). Keep the two in sync.
+(function () {
+  function init() {
+    if (typeof docsearch !== 'function') return;
+    if (!document.querySelector('#docsearch')) return;
+    docsearch({
+      container: '#docsearch',
+      appId: 'Z88JBBPHHH',
+      indexName: 'daslang.io crawler',
+      apiKey: '09d715f38753c82d2f87a9824ac81c3f',
+    });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -10,6 +10,9 @@
     <meta name="description" content="Daslang is a strong, statically-typed programming language with three execution tiers — interpreter, AOT to C++, JIT via LLVM. Embed it in your C++ engine, or build a standalone application end-to-end." />
     <meta name="keywords" content="daslang, daScript, programming language, game development, JIT, AOT, C++ scripting" />
 
+    <!-- Algolia Crawler domain verification (DocSearch) -->
+    <meta name="algolia-site-verification" content="5E2859D3649D63BC" />
+
     <link rel="icon" type="image/svg+xml" href="files/daslang-favicon.svg" />
     <link rel="alternate icon" type="image/x-icon" href="files/daslang.ico" />
     <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="blog/feed.xml" />
@@ -26,6 +29,12 @@
     <!-- Analytics -->
     <script data-goatcounter="https://borisbat.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
+
+    <!-- Algolia DocSearch -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+    <link rel="stylesheet" href="files/docsearch.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" defer></script>
+    <script src="files/docsearch.js" defer></script>
 </head>
 <body>
 <div class="forge-page">
@@ -51,6 +60,7 @@
                 </div>
             </div>
             <div class="forge-nav__right">
+                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -20,6 +20,12 @@
     <link rel="stylesheet" href="../files/cm/codemirror.min.css" />
     <link rel="stylesheet" href="../files/cm/cm-forge.css" />
     <link rel="stylesheet" href="./forge-skin.css" />
+
+    <!-- Algolia DocSearch -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+    <link rel="stylesheet" href="../files/docsearch.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" defer></script>
+    <script src="../files/docsearch.js" defer></script>
 </head>
 <body onload="pageInit()">
 
@@ -43,6 +49,7 @@
             </div>
         </div>
         <div class="forge-nav__right">
+            <div id="docsearch"></div>
             <button class="forge-nav__burger" type="button" aria-label="menu"
                 onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
             <span class="forge-nav__version">playground</span>


### PR DESCRIPTION
Integrates Algolia DocSearch (v3 — classic search modal + Ctrl/Cmd-K, **no** Ask AI) across every daslang.io surface. Everything is driven from **tracked** sources; CI rebuilds the gitignored `site/doc/` and `site/blog/*.html`.

## Surfaces
| Surface | Files | Asset paths |
|---|---|---|
| Hand-authored pages (home, downloads, daspkg, playground) | `site/index.html`, `site/downloads.html`, `site/daspkg.html`, `site/playground/index.html` | `files/…` |
| Blog + news + changelist | `site/blog/template.html` | `{{root}}files/…` |
| Sphinx docs (alongside the native RTD search box) | `doc/source/conf.py`, `doc/source/_templates/layout.html` | `_static/…` via `html_css_files`/`html_js_files` |

A search button renders as the first item in the Forge nav's right group; in the docs it sits above the native RTD search box (kept as fallback, along with `/search.html`).

## Shared assets
`site/files/` and a **byte-identical** copy in `doc/source/_static/`:
- **docsearch.js** — the init wiring appId / indexName / search key. **DOM-ready-safe** because Sphinx injects `html_js_files` into `<head>` non-deferred (the CDN bundle still loads before the init).
- **docsearch.css** — maps the `@docsearch/css@3` custom properties onto the Forge dark tokens (`--bg`/`--fg`/`--amber`/`--rule`, defined in both `forge.css` and the Sphinx `custom.css`), with literal-hex fallbacks. Includes a compact nav-button style and an RTD-sidebar variant.

The `apiKey` is the **public search-only** key — DocSearch always ships it client-side; the admin/write key is never here.

## Domain verification
Adds the Algolia Crawler `algolia-site-verification` meta tag to the homepage `<head>` (served at the daslang.io root by `pages.yml`). Use the dialog's **Meta Tag** tab to verify.

## Verification done locally
- Full Sphinx HTML build (exit 0): `_static/docsearch.{js,css}` copied, CDN + local CSS/JS emitted in the right order, `#docsearch` container rendered in the sidebar.
- `build_blog.py` run: `{{root}}` resolves correctly per depth (root → `files/…`, posts → `../files/…`), no leftover placeholders.

## ⚠️ Goes live on deploy
Both the search results and the domain verification hit the **live** daslang.io, so they only work after `pages.yml` republishes on merge. `indexName` (`'daslang.io crawler'`) is taken verbatim from the Algolia snippet — easy to spot-fix if the real index id differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)