### PR TITLE
docs: emit doc/sitemap.xml via sphinx-sitemap for crawler discovery

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
+sphinx-sitemap==2.6.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,7 +31,8 @@ import time
 # ones.
 sys.path.insert(0, os.path.abspath('.'))
 extensions = [
-  'daslang'
+  'daslang',
+  'sphinx_sitemap',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -172,6 +173,14 @@ html_js_files = [
     'https://cdn.jsdelivr.net/npm/@docsearch/js@3',
     'docsearch.js',
 ]
+
+# sphinx-sitemap: emit doc/sitemap.xml so the Algolia crawler can discover the
+# full doc tree (link-following alone never reaches the thousands of stdlib
+# pages). The docs are served under daslang.io/doc/. The default url scheme is
+# "{lang}{version}/{link}" — we serve flat, so force "{link}" or the sitemap
+# URLs would 404 with an en/<version>/ prefix.
+html_baseurl = 'https://daslang.io/doc/'
+sitemap_url_scheme = '{link}'
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://daslang.io/doc/sitemap.xml


### PR DESCRIPTION
Part A of fixing DocSearch crawler coverage (follow-up to #3060).

## Problem
The Algolia crawler reached only **~52 URLs** — the hand-authored site + blog — and **never walked into the `/doc/` tree**, so the Sphinx docs were absent from the index ("ignored all sphinx generated documentation"). The crawler monitoring also flagged **"Sitemap not found"**. Link-following alone never reaches the deep stdlib pages.

## Fix
Generate `doc/sitemap.xml` and point `robots.txt` at it so the crawler can discover the full doc tree.

- **conf.py**: enable `sphinx_sitemap`, set `html_baseurl = https://daslang.io/doc/`, and force `sitemap_url_scheme = '{link}'`. The sphinx-sitemap default scheme is `{lang}{version}/{link}`, which would emit `en/<version>/` prefixes that 404 — we serve the docs flat under `/doc/`.
- **requirements.txt**: pin `sphinx-sitemap==2.6.0`.
- **robots.txt**: add `Sitemap: https://daslang.io/doc/sitemap.xml`.

No `pages.yml` change needed — sphinx-sitemap writes `sitemap.xml` into the Sphinx output, which CI already copies to `_site/doc/`.

## Verified locally
Built with the CI flags (`sphinx-build -W --keep-going -b html`), exit 0. The generated sitemap has **435 URLs**, all correctly formatted as `https://daslang.io/doc/...` (no `en/<version>/` prefix), including deep stdlib pages.

**Doc-only — does not affect blog/main-site indexing.** The sitemap lists exclusively `/doc/` URLs (verified: zero non-doc entries); the hand-authored site and the `build_blog.py` pipeline are untouched. A sitemap only adds discovery hints, it never restricts what the crawler indexes.

## Follow-up (not in this PR)
Part B — scope the crawler's record extraction to `.rst-content` (excluding the 1688-link RTD nav sidebar that bloats every doc page to ~365 KB) to resolve the "records too big" warning. That's a crawler-dashboard change, not a repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)