### PR TITLE
flatten: constant reassociation — gather scattered consts + canonical var sort

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -908,6 +908,10 @@ class private FoldResidualVisitor : AstVisitor {
     def override preVisitExprOp2(expr : ExprOp2?) : void {
         if (is_unfolded_identity_op2(expr)) {
             found |> push("an unfolded algebraic identity ('{expr.op}')")
+        } elif (is_all_const(expr) && eval_to_const_supported(expr._type)) {
+            found |> push("an unfolded all-const arithmetic ('{expr.op}')")
+        } elif (has_scattered_consts(expr)) {
+            found |> push("a scattered const chain ('{expr.op}') reassoc should gather")
         }
     }
     def override preVisitExprOp1(expr : ExprOp1?) : void {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -554,6 +554,16 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
 class private FoldVisitor : AstVisitor {
     changed : bool
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
+        // A fully-constant arithmetic ExprOp2 the typer left unfolded — it folds scalar const
+        // arithmetic during re-infer (`2+3→6`) but leaves vector const arithmetic
+        // (`float3(2)+float3(3)`), which survives here and is what reassoc's gathered const
+        // groups become. Fold to one literal via the evaluator (mirrors the visitExprCall arm).
+        // eval_to_const_supported is null-safe, so an un-inferred node (the group reassoc just
+        // built this pass) is skipped and folded on the next re-infer cycle.
+        if (is_all_const(that) && eval_to_const_supported(that._type)) {
+            var folded = eval_to_const(that)
+            if (folded |> is_expr_const()) { changed = true; return folded }
+        }
         // Algebraic identities over the scalar + vector (float/int/uint) family. Integer
         // arms are exact (two's-complement, `e*-1==-e` even at INT_MIN); float arms fire
         // under flatten's fast-math assumption (every consumer is a shader backend) — `x*1`/
@@ -870,11 +880,44 @@ def public eval_to_const_supported(t : TypeDeclPtr) : bool {
         bt == Type.tUInt || bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4)
 }
 
+// True if every operator / call node in the subtree carries a settled type. eval_single_expression
+// builds sim-nodes assuming inference is complete — an un-inferred operator node has a null `.func`
+// and crashes the simulator. Const literals need no inference (exempt); a var would already have
+// failed is_all_const. Guards eval against a not-yet-re-inferred subtree — e.g. an is_all_const
+// tree whose inferred root has an operand the fold replaced this same pass with a fresh (un-typed)
+// const-arithmetic node.
+def private fully_inferred(e : ExpressionPtr) : bool {
+    if (e == null) return false
+    if (e is ExprOp1) {
+        return e._type != null && fully_inferred((e as ExprOp1).subexpr)
+    }
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        return e._type != null && fully_inferred(o.left) && fully_inferred(o.right)
+    }
+    if (e is ExprOp3) {
+        let o = e as ExprOp3
+        return e._type != null && fully_inferred(o.subexpr) && fully_inferred(o.left) && fully_inferred(o.right)
+    }
+    if (e is ExprCall) {
+        if (e._type == null) {
+            return false
+        }
+        for (a in (e as ExprCall).arguments) {
+            if (!fully_inferred(a)) {
+                return false
+            }
+        }
+        return true
+    }
+    return true
+}
+
 // Evaluate a literal-only (is_all_const) inferred expression to one const literal of
 // its type, via the exact runtime evaluator. Returns `e` unchanged if eval fails or
 // the type is unsupported. The fresh const is un-inferred; the macro re-infers it.
 def private eval_to_const(var e : ExpressionPtr) : ExpressionPtr {
-    if (e == null || e._type == null) return e
+    if (e == null || e._type == null || !fully_inferred(e)) return e
     var ok = false
     var val : float4
     unsafe {
@@ -1006,12 +1049,231 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
     return changed
 }
 
+// ===== Constant reassociation =====
+//
+// Gather scattered constants in associative/commutative `+`/`-` and `*` chains into one
+// adjacent group: `0.5 + a + b + 0.6` → `a + b + (0.5 + 0.6)`, `2.0 * a * 3.0` → `a * (2.0 * 3.0)`.
+// Reassoc only REORDERS (structural) — the FoldVisitor all-const arm + the typer's re-infer then
+// collapse the grouped const sub-expression to one literal. The typer folds only ADJACENT const
+// arithmetic and never reassociates (float rounding); flatten assumes fast-math, so it can.
+// Integer `+`/`*` are exact; integer `/` is non-associative (no `/` here — reciprocal grouping
+// is a follow-up). Const terms are side-effect-free (is_all_const), so gathering them to the tail
+// is unconditional; the var terms are additionally sorted into a canonical (describe) order so
+// commutative chains converge to one form for a later CSE — gated on every var term being
+// side-effect-free, so a side-effecting term's evaluation order is never observably reordered.
+
+struct private ReTerm {
+    neg : bool          //!< additive term is subtracted (always false for the `*` monoid in v1)
+    e : ExpressionPtr
+}
+
+// Flatten a maximal additive chain into signed terms (left-to-right = source order). Descends
+// `+`/`-` ExprOp2 and unary `-`; everything else (vars, calls, `*`/`/` sub-exprs, const literals)
+// is a leaf. No same-base-type gate: vector±scalar does not compile, so an additive chain is
+// always same-type.
+def private collect_add(var e : ExpressionPtr; neg : bool; var terms : array<ReTerm>) {
+    if (e == null) return
+    if (e is ExprOp2) {
+        var o = e as ExprOp2
+        if (o.op == "+" || o.op == "-") {
+            collect_add(o.left, neg, terms)
+            collect_add(o.right, o.op == "-" ? !neg : neg, terms)
+            return
+        }
+    } elif (e is ExprOp1) {
+        var o = e as ExprOp1
+        if (o.op == "-") {
+            collect_add(o.subexpr, !neg, terms)
+            return
+        }
+    }
+    terms |> push(ReTerm(neg = neg, e = e))
+}
+
+// Flatten a maximal `*` chain into factors (no `/` in v1). Descends `*` ExprOp2 only.
+def private collect_mul(var e : ExpressionPtr; var terms : array<ReTerm>) {
+    if (e == null) return
+    if (e is ExprOp2) {
+        var o = e as ExprOp2
+        if (o.op == "*") {
+            collect_mul(o.left, terms)
+            collect_mul(o.right, terms)
+            return
+        }
+    }
+    terms |> push(ReTerm(neg = false, e = e))
+}
+
+// True if the chain rooted at `e` (walked over `addOp`'s monoid: `+`/`-` for "+", `*` for "*")
+// has any const leaf. Backs the already-grouped check.
+def private chain_has_const(e : ExpressionPtr; addOp : string) : bool {
+    if (e == null) return false
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        let isChainOp = addOp == "+" ? (o.op == "+" || o.op == "-") : (o.op == addOp)
+        if (isChainOp) {
+            return chain_has_const(o.left, addOp) || chain_has_const(o.right, addOp)
+        }
+    } elif (e is ExprOp1) {
+        let o = e as ExprOp1
+        if (addOp == "+" && o.op == "-") {
+            return chain_has_const(o.subexpr, addOp)
+        }
+    }
+    return is_all_const(e)
+}
+
+// The canonical reassoc output is `<vars> addOp <all-const-group>` with no const in the var
+// part. Recognizing it makes reassoc idempotent — a fired chain lands here and never re-fires,
+// so the macro's fixpoint terminates. (The const group is folded separately by FoldVisitor.)
+def private already_grouped(that : ExprOp2?; addOp : string) : bool {
+    return that.op == addOp && is_all_const(that.right) && !chain_has_const(that.left, addOp)
+}
+
+// Build a left-leaning `<t0> op <t1> op …` tree from non-empty `terms`, REUSING the operand
+// nodes (each leaf appears once in the flattened term list, so it lands in exactly one slot of
+// the rebuilt tree; the old chain wrappers are dropped when the visitor replaces `that` with the
+// result — the same move-not-clone pattern FoldVisitor uses returning `that.left`). A negative
+// first term becomes a unary `-`; subsequent terms pick addOp/subOp by sign.
+def private build_chain(var terms : array<ReTerm>; at : LineInfo; addOp, subOp : string) : ExpressionPtr {
+    var acc = terms[0].neg ? negate(terms[0].e) : terms[0].e
+    for (i in range(1, length(terms))) {
+        acc = new ExprOp2(at = at, op := terms[i].neg ? subOp : addOp, left = acc, right = terms[i].e)
+    }
+    return acc
+}
+
+// True if the var terms are already in canonical (describe-ascending) order. Lets the sort fire
+// only when needed, so a canonicalized chain is a no-op (idempotent → the macro fixpoint ends).
+def private vars_sorted(vars : array<ReTerm>) : bool {
+    for (i in range(1, length(vars))) {
+        if (describe(vars[i].e) < describe(vars[i - 1].e)) {
+            return false
+        }
+    }
+    return true
+}
+
+// Partition `terms` into var/const and rebuild as `<vars> addOp <consts>` (consts to the tail).
+// Two canonicalizations: gather ≥2 scattered consts into one group (folded by the all-const arm /
+// re-infer), and SORT the var terms into a structural (describe) order so commutative chains
+// converge to one form (`b + a` and `a + b` both → `a + b`) — which lets a later CSE pass match
+// them. Sorting reorders var terms relative to each other, so it is gated on every var term being
+// side-effect-free (shaders are pure, so this always holds there); const terms are pure, so the
+// gather is unconditional. Returns null when neither canonicalization applies, or the chain is
+// all-const (the all-const ExprOp2 arm folds that).
+def private regroup(that : ExprOp2?; var terms : array<ReTerm>; addOp, subOp : string) : ExpressionPtr {
+    var vars : array<ReTerm>
+    var consts : array<ReTerm>
+    for (t in terms) {
+        if (is_all_const(t.e)) {
+            consts |> push(t)
+        } else {
+            vars |> push(t)
+        }
+    }
+    if (empty(vars)) {
+        return null
+    }
+    var pure = true
+    for (t in vars) {
+        if (has_sideeffects(t.e)) {
+            pure = false
+            break
+        }
+    }
+    let needs_gather = length(consts) >= 2 && !already_grouped(that, addOp)
+    let needs_sort = pure && length(vars) >= 2 && !vars_sorted(vars)
+    if (!needs_gather && !needs_sort) {
+        return null
+    }
+    if (pure) {
+        sort(vars) $(a, b : ReTerm) : bool {
+            return describe(a.e) < describe(b.e)
+        }
+    }
+    var vt = build_chain(vars, that.at, addOp, subOp)
+    if (empty(consts)) {
+        return vt
+    }
+    var ct = build_chain(consts, that.at, addOp, subOp)
+    return new ExprOp2(at = that.at, op := addOp, left = vt, right = ct)
+}
+
+// Count the var / const terms in a chain (walked over `addOp`'s monoid) without building a term
+// list — const-friendly, since the residual oracle only needs the tallies.
+def private count_terms(e : ExpressionPtr; addOp : string; var nv : int&; var nc : int&) {
+    if (e == null) return
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        let isChainOp = addOp == "+" ? (o.op == "+" || o.op == "-") : (o.op == addOp)
+        if (isChainOp) {
+            count_terms(o.left, addOp, nv, nc)
+            count_terms(o.right, addOp, nv, nc)
+            return
+        }
+    } elif (e is ExprOp1) {
+        let o = e as ExprOp1
+        if (addOp == "+" && o.op == "-") {
+            count_terms(o.subexpr, addOp, nv, nc)
+            return
+        }
+    }
+    if (is_all_const(e)) {
+        nc ++
+    } else {
+        nv ++
+    }
+}
+
+// True if reassoc WOULD gather this chain: ≥1 var term, ≥2 scattered const terms, not already
+// grouped. The fold-completeness oracle (flatten.das FoldResidualVisitor) mirrors the transform's
+// exact gate through this, so it flags only genuine misses — never a chain reassoc legitimately
+// leaves alone (single const, already grouped, no var).
+def public has_scattered_consts(that : ExprOp2?) : bool {
+    if (that == null) return false
+    var nv = 0
+    var nc = 0
+    if (that.op == "+" || that.op == "-") {
+        if (already_grouped(that, "+")) return false
+        count_terms(that, "+", nv, nc)
+    } elif (that.op == "*") {
+        if (already_grouped(that, "*")) return false
+        count_terms(that, "*", nv, nc)
+    } else {
+        return false
+    }
+    return nv >= 1 && nc >= 2
+}
+
+class private ReassocVisitor : AstVisitor {
+    changed : bool
+    def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
+        var res : ExpressionPtr = null
+        if (that.op == "*") {
+            var terms : array<ReTerm>
+            collect_mul(that, terms)
+            res = regroup(that, terms, "*", "/")
+        } elif (that.op == "+" || that.op == "-") {
+            var terms : array<ReTerm>
+            collect_add(that, false, terms)
+            res = regroup(that, terms, "+", "-")
+        }
+        if (res != null) {
+            changed = true
+            return res
+        }
+        return that
+    }
+}
+
 def public fold_body(var func : FunctionPtr) : bool {
     //! Post-infer fold over a flattened body: const-propagate single-def user locals
-    //! (accumulator chains → a constant), collapse `const ? a : b` to the live arm,
-    //! fold algebraic / boolean identities and const constructors, drop the
-    //! side-effect-free `lhs = lhs` self-assigns a folded false-select leaves behind,
-    //! and strip redundant zero/default inits (`var acc = 0` → `var acc : int`). Call
+    //! (accumulator chains → a constant), reassociate scattered constants in `+`/`-`/`*`
+    //! chains into one adjacent group (folded by the all-const arm / re-infer), collapse
+    //! `const ? a : b` to the live arm, fold algebraic / boolean identities and const
+    //! constructors, drop the side-effect-free `lhs = lhs` self-assigns a folded false-select
+    //! leaves behind, and strip redundant zero/default inits (`var acc = 0` → `var acc : int`). Call
     //! AFTER re-inference (conditions must be `ExprConstBool`, types must be settled).
     //! A SINGLE pass — multi-step cascades that route through re-inference (a folded
     //! `0*s → 0` makes a local const, which the next re-infer settles so it can be
@@ -1019,6 +1281,19 @@ def public fold_body(var func : FunctionPtr) : bool {
     //! caller's re-infer loop (see [flatten]'s patch and the [pixel_shader] patch).
     if (!(func.body is ExprBlock)) return false
     var changed = const_prop_locals(func.body as ExprBlock)
+    // Reassociate BEFORE the fold — gather scattered consts into one adjacent group so the
+    // FoldVisitor all-const arm (and the typer's re-infer) can collapse them. After const-prop,
+    // which is what scatters consts (a substituted single-def local lands mid-chain).
+    var rv = new ReassocVisitor()
+    make_visitor(*rv) $(adapter) {
+        visit(func.body, adapter)
+    }
+    if (rv.changed) {
+        changed = true
+    }
+    unsafe {
+        delete rv
+    }
     var v = new FoldVisitor()
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -128,10 +128,18 @@ zero (``*-1`` is signed-only — an unsigned "-1" is not a negation factor). It 
 the boolean ``true && x``, ``c ? true : false``, ``!const``; collapses constant vector
 constructors (``float3(1, 2, 3)``, ``uint3(1, 2, 3)``) and const-argument pure builtins
 (``float(7)``, ``min(2, 3)``) to literals; and constant-propagates single-definition
-locals — so a fully-constant accumulator loop reduces to its final constant. These are
-exactly the folds the general compiler leaves for the downstream tiers (it folds constant
-*arithmetic* but not constant *constructors*, and never a runtime-operand identity), done
-here under a shader's fast-math assumption (``x*0 → 0`` always fires).
+locals — so a fully-constant accumulator loop reduces to its final constant. It also
+**reassociates** scattered constants in commutative ``+``/``-`` and ``*`` chains —
+``0.5 + x + 0.6 → x + 1.1``, ``2 * x * 3 → x * 6`` — gathering the constant operands the
+general compiler leaves non-adjacent (it folds only *adjacent* constant arithmetic and never
+reassociates, for float rounding) into one adjacent group the all-const fold then collapses.
+The same pass sorts the chain's *variable* terms into a canonical (structural) order, so
+commutative chains converge to one form (``b + a`` and ``a + b`` both become ``a + b``) —
+gated on every term being side-effect-free, and intended to feed a later common-subexpression
+pass. Integer ``+``/``*`` reassociate exactly; integer ``/`` is non-associative and excluded.
+These are exactly the folds the general compiler leaves for the downstream tiers (it folds
+constant *arithmetic* but not constant *constructors*, and never a runtime-operand identity
+or reassociation), done here under a shader's fast-math assumption (``x*0 → 0`` always fires).
 
 The fold and the typer's const-fold are *mutually-enabling*, so the fold phase
 **iterates to a fixpoint**. Flattening folds the runtime-operand identities the

--- a/examples/flatten/capability/cap_fold_reassoc.shader
+++ b/examples/flatten/capability/cap_fold_reassoc.shader
@@ -1,0 +1,28 @@
+require engine.render.shader_dsl
+
+// Capability demo: constant reassociation. The source spells a scattered-const additive chain
+// `0.3 + gain + 0.4` on a runtime material prop. The general compiler can't fold it (the consts
+// are non-adjacent and it never reassociates), and the backend has no const-fold — so without
+// flatten this emits TWO add nodes. flatten reassociates under fast-math, gathering the consts
+// into `gain + 0.7`, so the emitted graph carries exactly ONE add (and the one genuine `base * k`
+// multiply).
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    gain = 1.0
+}
+
+[pixel_shader]
+def cap_fold_reassoc(inp : PbrInput) : PbrOutput {
+    let base = tex2d(albedo_texture, inp.uv).xyz
+    let k = 0.3 + gain + 0.4
+    let result = base * k
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -49,6 +49,10 @@
 #      flatten SSA-renames the reassigned accumulator to single-def versions and const-
 #      props the chain to one constant: 0 add nodes, result = base * <const>. Without it
 #      the backend rejects the self-referential accumulator (50503).
+#
+#  13. cap_fold_reassoc.shader (scattered const chain `0.3 + gain + 0.4`) -> `gain + 0.7`.
+#      The typer can't fold non-adjacent consts and never reassociates; flatten does (fast-math),
+#      gathering them so exactly 1 add survives (not the 2 the source spells), + 1 base*k mul.
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -236,6 +240,24 @@ if [[ "$errs" -eq 0 && "$adds" -eq 0 && "$muls" -ge 1 ]]; then
     echo "   ok — compiles ($nodes nodes), 0 add (accumulator folded), $muls mul (base*const)"
 else
     echo "   FAIL — errors=$errs adds=$adds muls=$muls (expected 0 add, >=1 mul)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "13. cap_fold_reassoc.shader (scattered const chain 0.3+gain+0.4 -> gain+0.7)"
+out="$(compile "$here/cap_fold_reassoc.shader")"
+nodes="$(echo "$out" | grep -c '^node ')"
+adds="$(echo "$out" | grep -c ' add ')"
+muls="$(echo "$out" | grep -c ' mul ')"
+errs="$(echo "$out" | grep -ci error)"
+# The source spells two adds (`(0.3 + gain) + 0.4`); the typer can't fold them (consts non-
+# adjacent, gain is a runtime prop) and the backend has no const-fold. flatten reassociates the
+# chain to `gain + 0.7`, so exactly ONE add survives, plus the one genuine `base * k` multiply.
+# Without reassoc this graph carries two adds.
+if [[ "$errs" -eq 0 && "$adds" -eq 1 && "$muls" -eq 1 ]]; then
+    echo "   ok — compiles ($nodes nodes), 1 add (gain+0.7, consts gathered), 1 mul (base*k)"
+else
+    echo "   FAIL — errors=$errs adds=$adds muls=$muls (expected 1 add, 1 mul)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/examples/flatten/shaders/features/reassoc_grade.shader
+++ b/examples/flatten/shaders/features/reassoc_grade.shader
@@ -1,0 +1,32 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    exposure = 1.0
+    tint = 0.0
+}
+
+// Feature fixture for constant reassociation. A small colour grade whose constants the author
+// wrote in natural reading order, scattered around the runtime `exposure` / `tint` props:
+//   • additive: `float3(0.05) + c*exposure + float3(0.05)` — the two black-lift consts gather
+//     into `c*exposure + float3(0.1)` (one vector add, not two).
+//   • multiplicative: `3.0 * lifted * 0.5` — the const factors gather into `lifted * 1.5`
+//     (one multiply by a single folded factor, not two).
+// The typer folds neither (the consts are non-adjacent and the props are runtime), and the
+// backend has no const-fold; flatten reassociates under fast-math. Run
+// `./run.sh --das reassoc_grade` to see the gathered form.
+[pixel_shader]
+def reassoc_grade(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let lifted = float3(0.05) + c * exposure + float3(0.05)
+    let graded = 3.0 * lifted * 0.5
+    let result = graded + float3(tint)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/tests/flatten/test_flatten_const.das
+++ b/tests/flatten/test_flatten_const.das
@@ -4,6 +4,7 @@ options no_unused_function_arguments = false
 
 require dastest/testing_boost public
 require daslib/flatten
+require math
 
 //! Verification net for the flatten const-optimization arc — two layers per case
 //! (numbered per the arc's 5-layer verification framework; Layer 1, the randomized
@@ -519,6 +520,78 @@ def f_fix_inline(b : int) : int {
     return fix_callee((0 * b) + 24, b + 7)
 }
 
+// ----- reassociation (#1c): scattered consts gather into one folded literal -----
+//
+// `0.5 + x + 0.6` is NOT foldable by the typer (consts are non-adjacent; the typer folds only
+// adjacent const arithmetic and never reassociates). flatten reassociates under fast-math, so the
+// twin collapses to `x + 1.1` / `x * 6` / `x + 5` etc. Float arms use the relative-tolerance
+// `fapprox` (reassoc genuinely changes rounding); integer arms are exact (`+`/`*` are associative).
+
+[flatten]
+def f_re_add(x : float) : float {
+    return 0.5 + x + 0.6
+}
+
+[flatten]
+def f_re_add2(x : float; y : float) : float {
+    return 0.5 + x + y + 0.6
+}
+
+[flatten]
+def f_re_sub(x : float) : float {
+    return x - 0.3 - 0.2
+}
+
+[flatten]
+def f_re_mul(x : float) : float {
+    return 2.0 * x * 3.0
+}
+
+// Scalar consts broadcast over a vector var: `0.5 * 2.0 = 1.0`, then `v * 1.0 → v`. Reassoc must
+// preserve the float3 result type through the gather (the `*1` cleanup carries its own
+// same_base_type gate). Exact (1.0 is exact).
+[flatten]
+def f_re_broad(v : float3) : float3 {
+    return v * 0.5 * 2.0
+}
+
+// Vector-const operands gather + fold via the all-const ExprOp2 arm (the typer leaves vector const
+// arithmetic). `float3(0.5) + v + float3(0.6) → v + float3(1.1)`.
+[flatten]
+def f_re_vec(v : float3) : float3 {
+    return float3(0.5) + v + float3(0.6)
+}
+
+[flatten]
+def f_re_iadd(x : int) : int {
+    return 2 + x + 3
+}
+
+[flatten]
+def f_re_imul(x : int) : int {
+    return 2 * x * 3
+}
+
+[flatten]
+def f_re_isub(x : int) : int {
+    return x - 3 - 2
+}
+
+// Var terms are sorted into a canonical (structural) order so commutative chains converge to one
+// form (for a later CSE). Vars written out of order here (c, a, b) + scattered consts must give
+// the same value as the original; the twin gathers to a sorted `((a + b) + c) + <const>`.
+[flatten]
+def f_re_sort(a : int; b : int; c : int) : int {
+    return c + 3 + a + 1 + b
+}
+
+// Subtraction with out-of-order vars: sorting must carry the sign (`b - a` canonicalizes via
+// `-a + b`), so the value is preserved.
+[flatten]
+def f_re_sortsub(a : int; b : int) : int {
+    return b - a + 10 - 4
+}
+
 // ----- differential driver -----
 
 var GRID : array<float>
@@ -545,6 +618,17 @@ def cmp3i(t : T?; a, b : int3) {
 
 def cmp3u(t : T?; a, b : uint3) {
     t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
+}
+
+// Relative-tolerance float compare for the reassociation arms, where the regrouped twin rounds
+// differently from the left-to-right original (the fast-math contract reassoc trades on).
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "reassoc approx mismatch: {a} vs {b}")
+}
+
+def cmp3f_approx(t : T?; a, b : float3) {
+    fapprox(t, a.x, b.x); fapprox(t, a.y, b.y); fapprox(t, a.z, b.z)
 }
 
 [test]
@@ -813,6 +897,42 @@ def test_flatten_const(t : T?) {
             t |> equal(f_fix_local_flat(n), n + 7)
             t |> equal(f_fix_inline_flat(n), f_fix_inline(n))
             t |> equal(f_fix_inline_flat(n), n + 7)
+        }
+    }
+    t |> run("reassoc: scattered float consts gather (approx — rounding differs)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, f_re_add_flat(v), f_re_add(v))
+            fapprox(t, f_re_sub_flat(v), f_re_sub(v))
+            fapprox(t, f_re_mul_flat(v), f_re_mul(v))
+            for (w in GRID) {
+                fapprox(t, f_re_add2_flat(v, w), f_re_add2(v, w))
+            }
+        }
+    }
+    t |> run("reassoc: scalar broadcast (v*0.5*2.0 -> v) + vector-const gather") @(t : T?) {
+        for (v in GRID) {
+            let vv = float3(v, v * 2.0, -v)
+            cmp3f(t, f_re_broad_flat(vv), f_re_broad(vv))
+            cmp3f_approx(t, f_re_vec_flat(vv), f_re_vec(vv))
+        }
+    }
+    t |> run("reassoc: integer chains are exact") @(t : T?) {
+        for (n in IGRID) {
+            t |> equal(f_re_iadd_flat(n), f_re_iadd(n))
+            t |> equal(f_re_iadd_flat(n), n + 5)
+            t |> equal(f_re_imul_flat(n), f_re_imul(n))
+            t |> equal(f_re_imul_flat(n), n * 6)
+            t |> equal(f_re_isub_flat(n), f_re_isub(n))
+            t |> equal(f_re_isub_flat(n), n - 5)
+        }
+    }
+    t |> run("reassoc: out-of-order vars are sorted, value preserved") @(t : T?) {
+        for (a in IGRID) {
+            for (b in IGRID) {
+                t |> equal(f_re_sort_flat(a, b, 0), f_re_sort(a, b, 0))
+                t |> equal(f_re_sortsub_flat(a, b), f_re_sortsub(a, b))
+                t |> equal(f_re_sortsub_flat(a, b), b - a + 6)
+            }
         }
     }
 }


### PR DESCRIPTION
## What

The typer folds only **adjacent** constant arithmetic and never reassociates (float rounding), so `0.5 + x + 0.6` or `2 * x * 3` reach the branchless shader backend with constants scattered — and the backend has no const-fold. `[flatten]` already assumes fast-math, so it reassociates.

A new post-infer `ReassocVisitor` (in `fold_body`, after `const_prop_locals`, before `FoldVisitor`) does two canonicalizations on each `+`/`-`/`*` chain:

- **Gather** the const operands into one adjacent group (`x + (0.5+0.6)`, `x * (2*3)`), which a new `FoldVisitor` all-const-`ExprOp2` arm + the typer's re-infer collapse to one literal (`x + 1.1`, `x * 6`). Vector const arithmetic the typer leaves (`float3(2)+float3(3)`) folds via the same arm.
- **Sort** the variable terms into a canonical (`describe`) order, so commutative chains converge to one form (`b + a` and `a + b` both → `a + b`) — readying them for a later CSE. Sorting reorders terms, so it is gated on every var term being side-effect-free (shaders are pure); const gathering is unconditional (consts are pure).

Purely structural (clones operand nodes, no eval); **idempotent** (a fired chain is already grouped + sorted, so it never re-fires → the macro fixpoint terminates). Integer `+`/`*` are exact; integer `/` is non-associative and **excluded** (no `/` in v1). Scalar-broadcast mul (`v:float3 * 0.5 * 2.0`) gathers correctly — the result type is preserved and `FoldVisitor`'s `*1` arm's own `same_base_type` gate cleans up.

This is **opt 1 of 2** from the arithmetic-optimization arc; it is the enabler for the CSE/preshader pass (canonical operand order + folded consts → value-numbering actually matches `a+b` vs `b+a`).

## Crash fix (the fuzzer surfaced it)

`eval_single_expression` builds sim-nodes assuming inference is complete, so an un-inferred operator node (null `.func`) as a descendant of an inferred all-const tree segfaults the simulator. `is_all_const` + `eval_to_const_supported` only check the **root**, not descendants — so a transient mid-pass fold state (an inferred all-const root over a freshly-built, not-yet-re-inferred operand) crashed eval. A `fully_inferred` guard in `eval_to_const` skips such trees (folded on the next re-infer cycle instead); also hardens the pre-existing `visitExprCall` all-const arm.

## Completeness oracle

`FoldResidualVisitor` flags an unfolded all-const arithmetic `ExprOp2` and a scattered-const chain reassoc should gather (`has_scattered_consts`). The curated corpus folds clean; the fuzzer's adversarial units surface only the known run-ordering-limit residuals.

## Tests

- **11 differential twins** in `test_flatten_const.das` — exact `equal` for int, relative `fapprox` for float (reassoc changes rounding); covers sorted out-of-order vars + sign-carrying subtraction.
- **no_aot residual gate** (completeness).
- **`cap_fold_reassoc.shader`** + `check.sh` case 13 (backend node-count: scattered chain → 1 add + 1 mul).
- **`reassoc_grade.shader`** feature shader (visual; `./run.sh --das reassoc_grade` shows the gathered form).

Verified: interp **140** / JIT **140** / AOT **45**, `run.sh` **66/0**, capability **13/13**, flatten-fuzz **80/80** exact (no crash, converges), lint + format + `sphinx -W` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)