### PR TITLE
das2rst: per-symbol nosearch to keep oversized symbol tables out of search

### DIFF
--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -40,6 +40,11 @@ var public {
 
 var private seen_function_labels : table<string; uint>
 
+// symbol names whose value/field tables are wrapped in `.. container:: nosearch`
+// (the search crawler drops them; the symbol + its description stay indexed).
+// populated per-module by `documents()` from its `nosearch` argument.
+var private nosearch_symbols : table<string>
+
 
 
 def PANIC(message : string) {
@@ -658,6 +663,26 @@ def make_table(title : string; tab : array<array<string>>) {
     }
 }
 
+def private is_nosearch(name : string) : bool {
+    return key_exists(nosearch_symbols, name)
+}
+
+def private indent_block(text : string) : string {
+    return build_string() $(writer) {
+        let lines <- split(text, "\n")
+        for (line, i in lines, count()) {
+            if (i > 0) { write(writer, "\n") }
+            if (!empty(line)) { write(writer, "   {line}") }
+        }
+    }
+}
+
+// emits the symbol's value/field table, optionally wrapped so the search crawler skips it.
+def private table_block(header : string; tab : array<array<string>>; nosearch : bool) : string {
+    let t = make_table(header, tab)
+    return t if (!nosearch)
+    return ".. container:: nosearch\n\n{indent_block(t)}"
+}
 
 
 def make_table_(tab : array<array<string>>; withHeader : bool = false) {
@@ -812,11 +837,11 @@ def document_function_topic(doc_file : file; resType : TypeDecl?&; topic, conten
     }
 }
 
-def document_topic(header : string; doc_file : file; topic, content : string implicit; var tab : array<array<string>>) {
+def document_topic(header : string; doc_file : file; topic, content : string implicit; var tab : array<array<string>>; nosearch : bool = false) {
     document_topic(doc_file, topic, content) $(txt; handmade) {
         if (add_stub_header && txt |> starts_with(STUB)) {
             if (length(tab) > 1) {
-                fwrite(doc_file, make_table(header, tab))
+                fwrite(doc_file, table_block(header, tab, nosearch))
             }
             return txt
         }
@@ -846,7 +871,7 @@ def document_topic(header : string; doc_file : file; topic, content : string imp
                 }
 
                 if (length(tab) > 1) {
-                    fwrite(doc_file, make_table(header, tab))
+                    fwrite(doc_file, table_block(header, tab, nosearch))
                 }
 
                 hasDoc = true
@@ -869,7 +894,7 @@ def document_topic(header : string; doc_file : file; topic, content : string imp
             tab[0] |> push("description")
 
             if (length(tab) > 1) {
-                fwrite(doc_file, make_table(header, tab))
+                fwrite(doc_file, table_block(header, tab, nosearch))
             }
             hasDoc = true
         }
@@ -877,7 +902,7 @@ def document_topic(header : string; doc_file : file; topic, content : string imp
         return "" if (hasDoc)
 
         if (length(tab) > 1) {
-            fwrite(doc_file, make_table(header, tab))
+            fwrite(doc_file, table_block(header, tab, nosearch))
         }
         return txt
     }
@@ -942,7 +967,7 @@ def document_bitfield(mod : Module?; doc_file : file; name : string; value : Typ
         }
     }
 
-    document_topic("Fields", doc_file, topic("typedef", mod, name), describe(value), tab)
+    document_topic("Fields", doc_file, topic("typedef", mod, name), describe(value), tab, is_nosearch(name))
 }
 
 def document_variant(mod : Module?; doc_file : file; name : string; value : TypeDeclPtr) {
@@ -952,7 +977,7 @@ def document_variant(mod : Module?; doc_file : file; name : string; value : Type
         var line <- [string(an), describe_type(at)]
         emplace(tab, line)
     }
-    document_topic("Variants", doc_file, topic("typedef", mod, name), describe(value), tab)
+    document_topic("Variants", doc_file, topic("typedef", mod, name), describe(value), tab, is_nosearch(name))
 }
 
 def document_typedef(doc_file : file; mod : Module?; name : string implicit; value) {
@@ -1061,7 +1086,7 @@ def public document_enumeration(doc_file : file; mod : Module?; value) {
         push(line, short_enum_value(describe(en.value)))
         emplace(tab, line)
     }
-    document_topic("Values", doc_file, topic("enumeration", mod, string(value.name)), "enum {value.name}", tab)
+    document_topic("Values", doc_file, topic("enumeration", mod, string(value.name)), "enum {value.name}", tab, is_nosearch(string(value.name)))
 }
 
 
@@ -1306,7 +1331,7 @@ def document_classes(doc_file : file; mods : array<Module?>) {
                 }
             }
 
-            document_topic("Fields", doc_file, topic("class", mod, string(value.name)), "class {value.name}", fields)
+            document_topic("Fields", doc_file, topic("class", mod, string(value.name)), "class {value.name}", fields, is_nosearch(string(value.name)))
 
             for (fld in value.fields) {
                 if (is_class_method(value, fld) && !(fld.flags.generated) && !fld.flags.privateField && !(fld.flags.parentType) && (fld.flags.implemented)) {
@@ -1424,7 +1449,7 @@ def document_structure(doc_file : file; mod : Module?; var value : StructurePtr)
     }
     // fwrite(doc_file,"{value.name} fields are\n\n")
     // fwrite(doc_file,make_table(tab))
-    document_topic("Fields", doc_file, topic("structure", mod, string(value.name)), "struct {value.name}", tab)
+    document_topic("Fields", doc_file, topic("structure", mod, string(value.name)), "struct {value.name}", tab, is_nosearch(string(value.name)))
 
     for (fld in value.fields) {
         if (is_class_method(value, fld) && !fld.flags.generated && !fld.flags.privateField && !fld.flags.parentType && fld.flags.implemented) {
@@ -1535,7 +1560,7 @@ def document_structure_annotation(doc_file : file; mod : Module?; value) {
         emplace(tab, line)
     }
 
-    document_topic("Fields", doc_file, topic("structure_annotation", mod, string(value.name)), "Annotation {value.name}", tab)
+    document_topic("Fields", doc_file, topic("structure_annotation", mod, string(value.name)), "Annotation {value.name}", tab, is_nosearch(string(value.name)))
 }
 
 def document_structure_annotations(doc_file : file; mods : array<Module?>; var hook = DocsHook()) {
@@ -2118,6 +2143,12 @@ def public document(name : string; var mod : Module?; fname : string; var groups
     documents(name, mods, fname, groups, hook)
 }
 
+def public document(name : string; var mod : Module?; fname : string; var groups : array<DocGroup>; var hook : DocsHook; nosearch : array<string>) {
+    //! Same as `document`, with a per-module `nosearch` symbol-name list (see `documents`).
+    let mods : array<Module?> = [mod]
+    documents(name, mods, fname, groups, hook, nosearch)
+}
+
 struct public DocsHook {
     //! Callback hooks for customizing RST documentation output.
     annotationFilter : lambda<(ann : rtti::Annotation const) : bool>
@@ -2127,7 +2158,18 @@ struct public DocsHook {
 
 def public documents(name : string; mods : array<Module?>; fname : string; var groups : array<DocGroup>; var hook : DocsHook = DocsHook()) {
     //! Generates complete RST documentation for a set of modules into the specified file.
+    let none : array<string>
+    documents(name, mods, fname, groups, hook, none)
+}
+
+def public documents(name : string; mods : array<Module?>; fname : string; var groups : array<DocGroup>; var hook : DocsHook; nosearch : array<string>) {
+    //! Same as `documents`, plus `nosearch`: symbol names whose value/field tables are
+    //! excluded from the search index (the symbol and its description stay indexed).
     clear(seen_function_labels)
+    clear(nosearch_symbols)
+    for (n in nosearch) {
+        nosearch_symbols |> insert(n)
+    }
     static_if (log_documentation) {
         print("Documenting {name} into {fname}\n")
     }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -325,7 +325,9 @@ def document_module_rtti(_root : string) {
         group_by_regex("Tuple and variant access", mod, %regex~(get_tuple_field_offset|get_variant_field_offset)$%%),
         group_by_regex("Lint suppression", mod, %regex~(rtti_get_source_line|rtti_is_nolint_suppressed|is_lint_suppressed|extract_lint_code)$%%),
         group_by_regex("Iteration", mod, %regex~(each)$%%))
-    documents("Runtime type information library", mod, "rtti.rst", groups)
+    // CompilationError's 580-value list blows the search crawler's per-record size cap;
+    // exclude it from search (the symbol + its description stay indexed).
+    documents("Runtime type information library", mod, "rtti.rst", groups, DocsHook(), ["CompilationError"])
 }
 
 def document_module_ast(_root : string) {

--- a/site/algolia/crawler-config.js
+++ b/site/algolia/crawler-config.js
@@ -39,7 +39,12 @@ new Crawler({
     {
       indexName: "daslang.io crawler",
       pathsToMatch: ["https://daslang.io/doc/**"],
-      recordExtractor: ({ helpers }) => {
+      recordExtractor: ({ helpers, $ }) => {
+        // Drop blocks das2rst marked `.. container:: nosearch` (e.g. rtti's
+        // 580-value CompilationError enum, which alone blew the per-record size
+        // cap): the symbol <dt> + its description stay indexed, only the oversized
+        // value/field table is removed. Toggle by symbol name in das2rst.das.
+        $(".nosearch").remove();
         return helpers.docsearch({
           recordProps: {
             lvl0: {
@@ -49,10 +54,17 @@ new Crawler({
             lvl1: ".rst-content h1",
             lvl2: ".rst-content h2",
             lvl3: ".rst-content h3",
-            lvl4: ".rst-content dt.sig",
+            // [id] = canonical signatures only; overloads carry no id, so they
+            // don't each spawn a level record (this is what kept ast/builtin
+            // from blowing the 750-records-per-page cap).
+            lvl4: ".rst-content dt.sig[id]",
             lvl5: ".rst-content h4",
             lvl6: ".rst-content h5",
-            content: ".rst-content p, .rst-content li",
+            // exclude the nav toctree: index pages embed the sidebar tree as
+            // li.toctree-l1..l4 INSIDE .rst-content, which would otherwise be
+            // counted as content and balloon the record count.
+            content:
+              ".rst-content p, .rst-content li:not(.toctree-l1):not(.toctree-l2):not(.toctree-l3):not(.toctree-l4)",
           },
           indexHeadings: true,
           aggregateContent: true,
@@ -68,7 +80,10 @@ new Crawler({
     {
       indexName: "daslang.io crawler",
       pathsToMatch: ["https://daslang.io/**", "!https://daslang.io/doc/**"],
-      recordExtractor: ({ helpers }) => {
+      recordExtractor: ({ helpers, $ }) => {
+        // Harmless here (the hand-authored site/blog carry no `.nosearch`), kept
+        // identical to Action 1 so the two extractors don't drift.
+        $(".nosearch").remove();
         return helpers.docsearch({
           recordProps: {
             lvl0: { selectors: "", defaultValue: "Documentation" },


### PR DESCRIPTION
## Problem

The Algolia DocSearch crawler caps records at ~97 KB. `rtti`'s `CompilationError` enum renders its **580 values as a single field list** that alone exceeds that cap, so `rtti.html` fails to index (`Record extracted is too big`). It's one fat symbol, not many small ones — so the fix is to drop that one table from search while keeping the symbol itself findable.

## Solution

A per-module, **by-symbol-name** `nosearch` list in the RST doc engine. Listed symbols get their value/field table wrapped in `.. container:: nosearch`; the crawler strips `.nosearch` before extraction. The symbol's `<dt>` anchor **and its description paragraph stay indexed** — only the oversized table is removed.

- **`daslib/rst.das`** — module-level `nosearch_symbols` set + `is_nosearch` / `indent_block` / `table_block` helpers. `nosearch` threaded through new `documents()` / `document()` overloads into `document_topic`, which wraps the `make_table` output for listed symbols. Wired at all six table-emitting call sites (enum / struct / class / bitfield / variant / struct-annotation), so the knob works for any symbol kind.
- **`doc/reflections/das2rst.das`** — `rtti` passes `nosearch = ["CompilationError"]`. Future fat enums: add a name here.
- **`site/algolia/crawler-config.js`** — `recordExtractor` now strips `.nosearch`; also folds in the live-but-unmirrored selectors this reference had drifted from (canonical-only `dt.sig[id]` + toctree-`:not()` content exclusion).

## Verification (local)

- Regenerated RST: exactly **one** `container:: nosearch` across the whole generated tree — on `CompilationError` only.
- Built HTML: `div.nosearch` wraps the 580-`li` field list; `dt#rtti.CompilationError` and its description sit **outside** it (still indexed).
- After `$('.nosearch').remove()`, rtti's max content run drops **67.9 KB → 14.0 KB** → record comfortably under the cap.
- Full-tree record sweep (433 pages): no regressions. `ast.html`'s record **count** (1153 > 750) remains a separate, known item — not addressable by per-symbol nosearch (546 small symbols, no single offender).
- `bin/Release/daslang.exe doc/reflections/das2rst.das` clean; clean `sphinx-build` succeeds with **zero** warnings; lint clean on both `.das` files.

## Note

The committed crawler config is a mirror — the **Algolia dashboard** Action 1 still needs `$(".nosearch").remove()` added to its `recordExtractor` for the next crawl to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)