### PR TITLE
flatten: preshader extraction + CSE + pure-alias elimination (Opt 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ doc/sphinx-build-latex/environment.pickle
 opencode.json
 test-results/
 logs/
+# flatten-fuzz transient dumps (generated source + failure/residual reproducers)
+_flatten_fuzz_*.das
+flatten_fuzz_fail_*.das
+flatten_fuzz_residual_*.das

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options strict_smart_pointers = true
+options _comment_hygiene = true
 
 module flatten shared private
 
@@ -81,17 +82,12 @@ def private set_flatten_phase(var func : FunctionPtr; ph : int) {
     }
 }
 
-//! Default cap on the product of nested constant-loop iteration counts a twin may
-//! unroll to. Unrolling multiplies across nesting (`range(20)^4` = 160k body copies),
-//! so without a bound deep nests blow the heap. 4096 is generous for real shader
-//! unrolling yet far below the blowup zone; `[flatten(max_unroll=N)]` overrides it
-//! per-function, and direct `flatten_function` callers pass their own.
+//! Default cap on the product of nested constant-loop iteration counts a twin may unroll
+//! to — unrolling multiplies across nesting, so an unbounded deep nest blows the heap.
+//! `[flatten(max_unroll=N)]` overrides per-function.
 let public FLATTEN_MAX_UNROLL = 4096
 
 def private get_flatten_max_unroll(func : FunctionPtr) : int {
-    //! Reads the opt-in `[flatten(max_unroll=N)]` argument: the cap on the product of
-    //! nested constant-loop iteration counts the twin may unroll to. Exceeding it is a
-    //! clean compile error, not an exponential-expansion blowup. Default FLATTEN_MAX_UNROLL.
     for (ann in func.annotations) {
         if (ann.annotation.name == "flatten") {
             let mv = find_arg(ann.arguments, "max_unroll")
@@ -102,17 +98,9 @@ def private get_flatten_max_unroll(func : FunctionPtr) : int {
 }
 
 // ===== Predicated lowering (return-elim + if-conversion + call inlining) =====
-//
-// Shared state lives on FlatCtx (one instance per twin, threaded by pointer so
-// the gensym counter and recursion worklist are shared across inline frames).
-// liveName/retName/hasRet are the CURRENT frame; inline_call saves & restores
-// them when it descends into a callee. structPred is the AND of enclosing
-// if-conditions on the path (null == statically true).
 
-// One stack entry per enclosing flattened loop (innermost last). `loopLive` is the
-// break mask (declared once, persists across unrolled copies); `iterLive` is the
-// continue mask (re-declared `= true` at each copy head). Either is "" when that
-// flavor is absent in the loop body — live_pred skips empty names.
+// One stack entry per enclosing flattened loop: loopLive = break mask (persists across
+// copies), iterLive = continue mask (re-declared each copy); "" when that flavor is absent.
 struct private LoopMask {
     loopLive : string
     iterLive : string
@@ -163,11 +151,9 @@ def private p_and(a, b : ExpressionPtr) : ExpressionPtr {
     return qmacro($e(a) && $e(b))
 }
 
-// The write predicate at the current point: the AND of every active mask
-// (funcLive plus each enclosing loop's loopLive/iterLive) and structPred. Passing
-// `exclude` drops that one mask from the AND — used to build a narrow term, where
-// the target mask cancels itself out (`M = M && !(rest)`). Returns null if nothing
-// remains (statically true), which the callers treat as `= false` on a narrow.
+// The write predicate here: AND of every active mask (funcLive + each loop's loopLive/
+// iterLive) and structPred. `exclude` drops one mask (self-cancels in a narrow term);
+// null return = statically true.
 def private live_pred(ctx : FlatCtx?; structPred : ExpressionPtr; exclude : string = "") : ExpressionPtr {
     var acc : ExpressionPtr = null
     if (ctx.liveName != exclude) {
@@ -218,18 +204,12 @@ def private inline_call(var ctx : FlatCtx?; call : ExprCall?; structPred : Expre
     var subst : Template
     for (p, ai in callee.arguments, count()) {
         let argN = fresh(ctx, "__flat_arg")
-        // Lift the argument FIRST (under the caller's predicate): a nested user call
-        // gets its own inline frame, a nested builtin is whitelist-checked. Without
-        // this, `f(g(x))` would bind `var __flat_arg = g(x)` verbatim — leaving `g`
-        // un-inlined and any non-whitelisted builtin in the arg unchecked.
+        // Lift the arg first (own inline frame / whitelist check) so `f(g(x))` inlines g.
         let lifted = lift_expr(ctx, call.arguments[ai], structPred, out)
         out |> push <| qmacro_expr(${ var $i(argN) = $e(lifted); })
         subst |> replaceVariable(string(p.name)) <| qmacro($i(argN))
     }
-    // Uniquify the callee's own locals per inline. Inlining the same helper at
-    // multiple sites — distinct call sites, or one site multiplied by loop
-    // unrolling — would otherwise emit colliding `var` decls in the single
-    // flattened scope (error[30704]). Mirrors lower_for's per-copy local rename.
+    // Uniquify the callee's locals per inline — else repeated inlining collides decls (30704).
     var seenLocals : array<string>
     let calleeLocals <- collect_let_names(callee.body)
     for (ln in calleeLocals) {
@@ -238,22 +218,16 @@ def private inline_call(var ctx : FlatCtx?; call : ExprCall?; structPred : Expre
             subst |> renameVariable(ln, fresh(ctx, "__flat_loc"))
         }
     }
-    // The callee runs where the caller's full predicate holds — funcLive AND every
-    // enclosing loop's break/continue masks AND structPred — all baked into the frame
-    // seed. The callee body then lowers with this seed as its base mask and an EMPTY
-    // loop stack (its returns narrow only this frame; it cannot break the caller's loop).
+    // Seed the callee frame with the caller's full predicate; it lowers with an empty loop stack.
     let seed = live_pred(ctx, structPred)
     out |> push <| qmacro_expr(${ var $i(liveN) = $e(seed); })
-    // Result temp only for value-returning callees. A void callee is inlined
-    // for its side effects (e.g. predicated writes to output globals); it has
-    // no value to bind, so emitting `default<void>` would be a type error.
+    // Result temp only for value-returning callees (a void callee has no value to bind).
     var retN = ""
     if (!isVoidCallee) {
         retN = fresh(ctx, "__flat_ret")
         var crt = clone_type(callee.result)
         crt.flags.constant = false
-        // Bare decl: das auto-inits to default<T>, so the explicit init is
-        // redundant. The first write self-reads the auto-init value.
+        // Bare decl: das auto-inits to default<T>; the first write self-reads it.
         out |> push <| qmacro_expr(${ var $i(retN) : $t(crt); })
     }
     let savedLive = ctx.liveName
@@ -276,22 +250,15 @@ def private inline_call(var ctx : FlatCtx?; call : ExprCall?; structPred : Expre
     return qmacro($i(retN))
 }
 
-// Lift every user call out of a value expression (at any depth) into inline
-// frames, in evaluation order, returning the call-free rewrite. Plain
-// recursion — NOT a visitor — because inlining a call recurses back through
-// the lowering pipeline, and nested make_visitor traversals corrupt the
-// visitor machinery. Operand order matches daslang left-to-right evaluation.
+// Lift every user call out of a value expression into inline frames, in eval order,
+// returning the call-free rewrite. Plain recursion, NOT a visitor — inlining recurses back
+// through the pipeline, and nested make_visitor traversals corrupt the visitor machinery.
 def private lift_expr(var ctx : FlatCtx?; e : ExpressionPtr; structPred : ExpressionPtr; var out : array<ExpressionPtr>) : ExpressionPtr {
     if (e == null) return null
     if (e is ExprCall) {
         let c = e as ExprCall
         let bname = string(c.name)
-        // Whitelist takes precedence over inlining: a whitelisted leaf primitive is
-        // KEPT (args lifted), even if it has a body. Backend [hint] primitives are
-        // [stub] functions — non-null (empty) body — so without this they'd be
-        // treated as user calls and inlined away to nothing. Match the SIMPLE name:
-        // OR-type generics monomorphize to `<scope>`<name>`<hash>`, but the backend
-        // whitelists by the bare name.
+        // Whitelisted leaf primitive KEPT (args lifted); match simple name (generics mangle).
         if (key_exists(ctx.whitelist, simple_name(bname))) {
             var n = clone_expression(e)
             var o = n as ExprCall
@@ -304,12 +271,7 @@ def private lift_expr(var ctx : FlatCtx?; e : ExpressionPtr; structPred : Expres
         if (is_user_call(e)) {
             return inline_call(ctx, c, structPred, out)
         }
-        // A pure builtin with all-constant arguments (e.g. `float(2)`, `float3(0.5)`,
-        // `min(2,3)`) is a compile-time constant — eval_to_const collapses it at the
-        // post-infer fold, so no runtime primitive reaches the backend and the
-        // (runtime-primitive) whitelist does not apply. Keep it, lifting any nested
-        // calls in its args. Gated to the evaluator's foldable types so a non-foldable
-        // const builtin still errors here rather than leaking past the fold.
+        // All-const pure builtin folds at the post-infer fold (foldable-type-gated); keep it, lift arg calls.
         if (is_all_const(e) && eval_to_const_supported(e._type)) {
             var n = clone_expression(e)
             var o = n as ExprCall
@@ -347,11 +309,7 @@ def private lift_expr(var ctx : FlatCtx?; e : ExpressionPtr; structPred : Expres
         o.right = lift_expr(ctx, oe.right, structPred, out)
         return n
     }
-    // Member / index / cast / constructor expressions: a user call can hide inside
-    // the operand of a swizzle (`f(x).xyz`), a struct field read (`f(x).a`), a cast,
-    // an index, or a constructor field (`Out(emission = f(x))`). Recurse into the
-    // operands so the call still gets inlined — without these, the call survives
-    // lowering and the post-pass verify scan rejects it as an "internal error".
+    // A user call can hide in a swizzle/field/cast/index/ctor operand — recurse so it inlines.
     if (e is ExprField) {
         var n = clone_expression(e)
         var o = n as ExprField
@@ -396,8 +354,7 @@ def private lift_expr(var ctx : FlatCtx?; e : ExpressionPtr; structPred : Expres
         }
         return n
     }
-    // Typer-inserted ref/value/pointer conversion wrappers (e.g. ExprRef2Value
-    // around a field read `f(x).a`). Recurse through to reach the buried call.
+    // Typer-inserted ref/value/ptr conversion wrappers — recurse through to the buried call.
     if (e is ExprRef2Value) {
         var n = clone_expression(e)
         var o = n as ExprRef2Value
@@ -431,10 +388,9 @@ def private lower_branch(var ctx : FlatCtx?; br : ExpressionPtr; structPred : Ex
     }
 }
 
-// Lower a `break` (isBreak) or `continue` by narrowing the innermost loop's mask.
-// The narrow term excludes the target mask (it cancels) and is gated by every other
-// active mask + structPred, so a prior return/break/continue on the same path
-// correctly suppresses this one.
+// Lower `break`/`continue` by narrowing the innermost loop's mask. The narrow term excludes
+// the target mask (self-cancels) and is gated by the other active masks + structPred, so a
+// prior exit on the same path suppresses this one.
 def private lower_loop_exit(var ctx : FlatCtx?; structPred : ExpressionPtr; var out : array<ExpressionPtr>; isBreak : bool) {
     if (empty(ctx.loopMasks)) {
         ctx.ok = false
@@ -459,9 +415,7 @@ def private lower_stmt(var ctx : FlatCtx?; stmt : ExpressionPtr; structPred : Ex
             let pred = live_pred(ctx, structPred)
             out |> push <| qmacro_expr(${ $i(ctx.retName) = $e(pred) ? $e(valExpr) : $i(ctx.retName); })
         }
-        // Narrow funcLive on the executing path. The term is every OTHER active mask
-        // (enclosing loop masks) AND structPred — funcLive itself cancels. With no
-        // enclosing loop this reduces to the old `funcLive = funcLive && !structPred`.
+        // Narrow funcLive on the executing path (funcLive self-cancels in the term).
         emit_narrow(out, ctx.liveName, live_pred(ctx, structPred, ctx.liveName))
     } elif (stmt is ExprIfThenElse) {
         let ite = stmt as ExprIfThenElse
@@ -477,8 +431,7 @@ def private lower_stmt(var ctx : FlatCtx?; stmt : ExpressionPtr; structPred : Ex
         let pred = live_pred(ctx, structPred)
         out |> push <| qmacro_expr(${ $e(cp.left) = $e(pred) ? $e(rhs) : $e(cp.left); })
     } elif (stmt is ExprLet) {
-        // A local declaration always executes; inline any user-call initializer
-        // (its frame already encodes the path predicate via the live mask).
+        // A local decl always executes; inline any user-call initializer (its frame is predicated).
         var letClone = clone_expression(stmt)
         var lc = letClone as ExprLet
         for (v in lc.variables) {
@@ -493,12 +446,10 @@ def private lower_stmt(var ctx : FlatCtx?; stmt : ExpressionPtr; structPred : Ex
         ctx.ok = false
         ctx.err = "flatten: while loops are not supported; use a fixed range(N) or array-literal for loop"
     } elif (stmt is ExprBreak) {
-        // Narrow the innermost loop's break mask: it persists across unrolled copies,
-        // so once a copy breaks, the rest of it and every later copy mask off.
+        // Narrow the loop's break mask: persists across copies, so a break masks off the rest.
         lower_loop_exit(ctx, structPred, out, true)
     } elif (stmt is ExprContinue) {
-        // Narrow the innermost loop's per-iteration mask: the rest of THIS copy masks
-        // off; the next copy re-declares it `= true`.
+        // Narrow the per-iteration mask: the rest of THIS copy masks off; next copy resets it.
         lower_loop_exit(ctx, structPred, out, false)
     } elif (stmt is ExprMove || stmt is ExprClone) {
         ctx.ok = false
@@ -512,9 +463,7 @@ def private lower_stmt(var ctx : FlatCtx?; stmt : ExpressionPtr; structPred : Ex
             right = lower_value(ctx, o.right, structPred, out))
         out |> push <| qmacro_expr(${ $e(o.left) = $e(pred) ? $e(combined) : $e(o.left); })
     } elif (stmt is ExprOp1 && ("{(stmt as ExprOp1).op}" == "++" || "{(stmt as ExprOp1).op}" == "--")) {
-        // `x++` / `x--` as a statement → `x = P ? (x +/- 1) : x` (the postfix value
-        // is discarded at statement level, so pre/post is irrelevant here). Same
-        // drop-if-unhandled hazard as compound assignment; PERF013 nudges toward these.
+        // `x++`/`x--` statement → `x = P ? (x +/- 1) : x` (postfix value discarded at stmt level).
         let o = stmt as ExprOp1
         let bop = "{o.op}" == "++" ? "+" : "-"
         let pred = live_pred(ctx, structPred)
@@ -525,18 +474,10 @@ def private lower_stmt(var ctx : FlatCtx?; stmt : ExpressionPtr; structPred : Ex
         // Bare lexical scope — flatten its statements under the same predicate.
         lower_list(ctx, stmt as ExprBlock, structPred, out)
     } elif (stmt is ExprWith) {
-        // `with (x) { body }` is pure infer-time name resolution: post-infer the
-        // body's accesses are already bound to x's fields, and the node simulates
-        // to its body alone (ast_simulate.cpp: visit(ExprWith) = body). So unwrap
-        // it — lower the body under the same predicate, exactly like a bare block.
+        // `with (x) { body }` is infer-time only; post-infer it simulates to its body — unwrap it.
         lower_branch(ctx, (stmt as ExprWith).body, structPred, out)
     } else {
-        // Bare expression statement (a discarded value). Lifting emits any inline
-        // frames and their side effects (global writes, etc.) as their own
-        // statements; the residual value is unused, so it is NOT emitted. A bare
-        // pure expression is dead — and e.g. `x * x` as a statement is a hard
-        // compile error (30151 "no side effect operation"). Copy-prop would
-        // otherwise fold a discarded result temp into exactly that.
+        // Bare expr statement: lift emits side-effecting frames; the unused pure value is dropped.
         lower_value(ctx, stmt, structPred, out)
     }
 }
@@ -565,11 +506,9 @@ def private collect_let_names(body : ExpressionPtr) : array<string> {
     return <- result
 }
 
-// Does THIS loop's body contain a break / continue that targets THIS loop? A
-// nested for/while owns its own break/continue, so we only count those at nesting
-// depth 0 (the depth counter ignores any inside a deeper loop). Drives whether
-// lower_for allocates the loopLive (break) / iterLive (continue) masks at all —
-// a loop with neither stays byte-identical to the pre-M4.1 output.
+// Does THIS loop's body have a break/continue targeting it? A nested loop owns its own, so
+// count only at depth 0. Drives whether lower_for allocates the break/continue masks — a loop
+// with neither stays byte-identical to the pre-mask output.
 class private BreakContinueScan : AstVisitor {
     depth       : int
     hasBreak    : bool
@@ -632,9 +571,7 @@ def private for_source_substs(var ctx : FlatCtx?; src : Expression?; at : LineIn
             substs |> push(e)   // nolint:PERF006 -- macro-time, count is the (small) unroll bound
         }
     } else {
-        // Array-literal source: `for (v in [a, b, c])` parses as
-        // `to_array_move([[a, b, c]])` (ExprCall wrapping ExprMakeArray), or a bare
-        // ExprMakeArray. Each element expression substitutes for one iteration.
+        // Array-literal source (`for (v in [a,b,c])`): each element substitutes for one iteration.
         var mk : ExprMakeArray? = null
         if (src is ExprMakeArray) {
             mk = src as ExprMakeArray
@@ -652,16 +589,9 @@ def private for_source_substs(var ctx : FlatCtx?; src : Expression?; at : LineIn
     return <- substs
 }
 
-// Fixed-count loop unrolling (M4). A `for` over a constant `range(N)` or an array
-// literal has a compile-time-known iteration count: clone the body once per
-// iteration, substitute the loop variable with that iteration's constant, and lower
-// each unrolled copy under the SAME predicate (an unrolled body always executes).
-// Per-iteration locals are renamed (`o` → `o_0`, `o_1`, …) so the copies don't
-// shadow each other in the flattened scope. Mirrors daslib/unroll.das. break /
-// continue (M4.1) allocate runtime masks — loopLive (persists across copies) for
-// break, a per-copy iterLive for continue — pushed on ctx.loopMasks for the body to
-// narrow; absent both, the loop is byte-identical to the pre-M4.1 output. while
-// loops and non-constant sources error.
+// Fixed-count loop unrolling: a `for` over a constant range/array literal clones its body once
+// per iteration (loop var → that iteration's constant), each copy lowered under the SAME
+// predicate; per-copy locals are renamed. break/continue allocate runtime masks. while errors.
 def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : ExpressionPtr; var out : array<ExpressionPtr>) {
     let nIter = length(efor.iterators)
     if (nIter == 0 || length(efor.sources) != nIter) {
@@ -669,9 +599,7 @@ def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : Expressi
         ctx.err = "flatten: a for loop needs one source per iterator"
         return
     }
-    // Build the per-iteration value list for each source. Multiple iterators
-    // (`for (a, b in [...], [...])`) unroll in lockstep, so every source must
-    // yield the same count. perSource[v][k] is iterator v's value for copy k.
+    // Per-iteration value list per source; parallel iterators unroll in lockstep (same count).
     var perSource : array<array<ExpressionPtr>>
     perSource |> reserve(nIter)
     var count = -1
@@ -688,11 +616,7 @@ def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : Expressi
         count = length(s)
         perSource |> emplace(s)
     }
-    // `count` is the (shared) iteration count of every source.
-    // Unrolling multiplies across nesting: this loop emits `count` body copies
-    // per enclosing iteration, so the running product (int64, overflow-safe) is the true
-    // expansion. Bail BEFORE the clones if it exceeds the cap — converts a heap blowup
-    // into a clean error. Restore the factor on exit so sibling loops start fresh.
+    // Unrolling multiplies across nesting; bail before cloning if the int64 product exceeds the cap.
     let projected = int64(ctx.unrollFactor) * int64(count)
     if (projected > int64(ctx.maxUnroll)) {
         ctx.ok = false
@@ -725,15 +649,13 @@ def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : Expressi
         }
         var iblk = clone_expression(efor.body)
         var rules : Template
-        // Substitute every iterator with its value for copy k (one iterator for a
-        // plain loop, several for `for (a, b in [...], [...])` unrolled in lockstep).
+        // Substitute every iterator with its copy-k value (several for a lockstep parallel loop).
         for (vi in range(nIter)) {
             let van = "{efor.iterators[vi]}"
             remove_deref(van, iblk)            // strip ExprRef2Value around the workhorse loop var
             rules |> replaceVariable(van) <| perSource[vi][k]
         }
-        // Rename this copy's locals uniquely so the unrolled bodies don't shadow
-        // each other once flattened into one scope.
+        // Rename this copy's locals uniquely so unrolled bodies don't shadow in the flat scope.
         for (ln in localNames) {
             rules |> renameVariable(ln, "{ln}_{k}")
         }
@@ -755,18 +677,9 @@ def private lower_for(var ctx : FlatCtx?; efor : ExprFor?; structPred : Expressi
 
 [macro_function]
 def public flatten_function(var func : FunctionPtr; whitelist : table<string>; maxUnroll : int = FLATTEN_MAX_UNROLL) : FlatCtx? {
-    //! Flatten `func`'s body in place to branchless, call-free form: every user
-    //! call inlined, all control flow lowered to predicated `?:` selects, early
-    //! `return` to a runtime live mask. `whitelist` is the set of leaf-builtin
-    //! names permitted to survive into the output (must be pure / branch-safe /
-    //! backend-expressible). `maxUnroll` caps the product of nested constant-loop
-    //! iteration counts (exceeding it is a clean error, not a heap blowup). Returns
-    //! the FlatCtx — inspect `.ok` and `.err`.
-    //!
-    //! Backends call this directly with their own primitive set, before their own
-    //! macro walks the result; `[flatten]` calls it with the std default. The
-    //! body is uninferred after this — re-infer (e.g. via patch + astChanged)
-    //! before reading types or running the shape check.
+    //! Flatten `func`'s body in place to branchless, call-free form: user calls inlined, control
+    //! flow → predicated `?:`, early `return` → a live mask. `whitelist` = leaf builtins allowed to
+    //! survive; `maxUnroll` caps unroll. Returns FlatCtx (`.ok`/`.err`); body is uninferred after.
     var ctx = new FlatCtx(counter = 0, liveName = "__flat_live", retName = "__flat_ret",
         hasRet = !func.result.isVoid, unrollFactor = 1, maxUnroll = maxUnroll, ok = true)
     ctx.whitelist := whitelist
@@ -780,13 +693,9 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
         if (ctx.hasRet) {
             var rt = clone_type(func.result)
             rt.flags.constant = false
-            // The return accumulator is read self-referentially by every `__flat_ret = pred
-            // ? v : __flat_ret` write (lower_stmt), so its first read is the bare decl. That
-            // read is always a discarded placeholder — overwritten by the taken return, or
-            // kept only on the not-taken path — so the uninitialized read is safe by design.
-            // copy_prop's mask-fold collapses it away when the live mask folds (single return), but
-            // a live early-return leaves the self-ref intact, and `var x : Struct` is otherwise
-            // rejected (error[31016]) for any struct return type.
+            // The return accumulator is read self-referentially by every `__flat_ret = pred ? v :
+            // __flat_ret` write; the first (bare-decl) read is a discarded placeholder, so it is
+            // safeWhenUninitialized — else `var x : Struct` is rejected (error[31016]).
             rt.flags.safeWhenUninitialized = true
             out |> push <| qmacro_expr(${ var $i(ctx.retName) : $t(rt); })
         }
@@ -810,44 +719,19 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
     return ctx
 }
 
-// ===== Post-infer select folding (infer_type_fold) =====
-//
-// The typer folds constant comparisons during re-infer (`0 >= 2` → false) but
-// leaves the wrapping `?:` in place: at infer time it lacks the side-effect flags
-// to prove the dead arm droppable, so a const-condition select survives — and a
-// predicated self-assign then collapses (post-typer) to `acc = acc`, which a
-// dataflow backend cannot resolve (an accumulator that reads itself with no
-// producer). This pass runs AFTER re-infer, where the conditions are already
-// `ExprConstBool`: it collapses every `const ? a : b` to the live arm (full tree,
-// so deeply-buried selects fold too), drops the resulting `lhs = lhs` self-assigns
-// whose lvalue is provably side-effect-free, and strips redundant zero/default
-// initializers (`var acc = 0` → `var acc : int`). The cleanups the compiler will
-// not do at infer time, done here with the lint side-effect estimate.
+// ===== Post-infer select folding =====
 
 [macro_function]
 def public flatten_fold(var func : FunctionPtr) : bool {
-    //! Post-infer select-folding pass: collapse `const ? a : b` to the live arm, drop
-    //! the side-effect-free `lhs = lhs` self-assigns left behind by a folded false-select,
-    //! and strip redundant zero/default initializers (`var acc = 0` → `var acc : int`).
-    //! Run it AFTER re-inference — the constant conditions must already be `ExprConstBool`,
-    //! which only the typer produces (and the var types must be settled). Returns true if anything
-    //! changed (the caller should then re-infer for clean codegen). `[flatten]` runs
-    //! this automatically between lowering and the shape check; backends calling
-    //! `flatten_function` run it after their own re-infer, before consuming the twin.
+    //! Post-infer fold pass (delegates to `fold_body`): collapse `const ? a : b`, drop pure
+    //! `lhs = lhs` self-assigns, strip redundant zero inits. Run AFTER re-inference (conditions
+    //! must be `ExprConstBool`). Returns true if anything changed — re-infer then for clean codegen.
     return fold_body(func)
 }
 
-// ===== Post-inference shape verification =====
-//
-// After lowering + re-infer, the twin must be branchless and call-free: no
-// ExprIfThenElse (all if/else became `?:` selects) and no surviving user call
-// (all inlined). A violation is a lowering bug — fail loudly rather than hand a
-// branchful/callful twin to a backend that cannot represent it. Runs in cycle 2
-// (post-infer) because user-call detection needs the resolved `call.func`.
-//
-// Fold completeness (a missed const-fold) is NOT checked here — that is a
-// suboptimal-but-correct outcome, validated post-compile by the test framework
-// via `flatten_fold_residuals`, not gated at transform time.
+// ===== Post-inference shape verification — twin must be branchless + call-free =====
+// A violation is a lowering bug (fail loudly). Runs cycle 2 (user-call detection needs the
+// resolved `call.func`); fold completeness is a separate, correctness-irrelevant concern.
 
 class private FlatVerify : AstVisitor {
     sawBranch   : bool
@@ -882,16 +766,8 @@ def private verify_flat(var twin : FunctionPtr) : string {
 }
 
 // ===== Fold-completeness validation (test-framework facing) =====
-//
-// `flatten_fold_residuals` is the ONLY fold-completeness check — there is no compile-time
-// flag, because a missed fold is suboptimal, not wrong. It walks a COMPILED twin's final
-// AST and collects every const-foldable residual a complete fold should have collapsed —
-// an unconditional algebraic identity (`x*1`/`x+0`/`x-0`/`x*-1`, scalar or vector), an
-// all-const call of an eval-foldable type, a const-condition `?:`, a const `!`. Empty
-// result = clean. It runs over the ACTUAL compiled output (not at transform time), so it
-// covers the `[pixel_shader]` backend path uniformly with `[flatten]`. (Branch / user-call
-// survivors are a DIFFERENT class — a lowering failure — and stay a hard compile error in
-// patch via verify_flat; they never reach a successfully compiled unit.)
+// `flatten_fold_residuals` is the ONLY fold-completeness check — a missed fold is suboptimal,
+// not wrong, so it's validated over the COMPILED twin's AST, never gated at compile time.
 
 class private FoldResidualVisitor : AstVisitor {
     found : array<string>
@@ -962,10 +838,8 @@ class FlattenAnnotation : AstFunctionAnnotation {
     def override patch(var func : FunctionPtr; var group : ModuleGroup;
                        args, progArgs : AnnotationArgumentList; var errors : das_string;
                        var astChanged : bool&) : bool {
-        // Lint runs with constant folding off, so `range(N)` is not yet an
-        // ExprConstRange and the generated twin is irrelevant to linting the source
-        // anyway. Leave the twin as the inert clone from `apply` (mirrors how
-        // daslib/unroll.das skips unrolling under is_in_lint_check()).
+        // Lint runs with const-folding off, so `range(N)` isn't an ExprConstRange yet and the twin
+        // is irrelevant to linting; leave it the inert clone from `apply` (mirrors unroll.das).
         if (is_in_lint_check()) return true
         let ph = get_flatten_phase(func)
         if (ph == PHASE_DONE) return true
@@ -988,15 +862,9 @@ class FlattenAnnotation : AstFunctionAnnotation {
             return true
         }
         if (ph == PHASE_LOWERED || ph == PHASE_FOLDED) {
-            // Cycle 2+: the twin is inferred — collapse const-condition selects, fold
-            // algebraic identities, and drop the resulting pure self-assigns. Re-infer
-            // if anything changed so the verify scan and codegen see clean types.
-            //
-            // Iterate to a fixpoint: flatten_fold folds runtime-operand identities the
-            // typer will not (`0*b → 0`, `x*-1 → -x`); the re-infer between passes then
-            // const-folds the freshly-constant operands (`24 >> (24 & 31) → 0`), which
-            // can expose a new identity (`x - 0`) for the next pass. A single fold pass
-            // is therefore not enough — re-run until nothing folds.
+            // Cycle 2+: fold the inferred twin (const selects, algebraic identities, pure self-
+            // assigns), re-infer if anything changed. Iterate to a fixpoint — fold and the typer's
+            // re-infer const-fold are mutually-enabling, so one pass isn't enough.
             let folded = flatten_fold(twin)
             set_flatten_phase(func, PHASE_FOLDED)
             if (folded) {

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -32,7 +32,15 @@ require daslib/flatten_opt
 // PHASE_DONE so the entry never re-transforms.
 let private PHASE_LOWERED = 1
 let private PHASE_FOLDED = 2
+let private PHASE_OPTIMIZED = 3
 let private PHASE_DONE = 999
+
+// Calls that must stay per-pixel (can't run in the per-draw preshader). The [flatten] annotation
+// path is pure math (STD_WHITELIST), so these never appear here — listed for robustness; a backend
+// driving flatten_function directly passes its own sampler/intrinsic set to flatten_preshade_cse.
+let private FLATTEN_BARRIERS : table<string> <- {
+    "tex2d", "noise"
+}
 
 // Leaf builtins permitted to survive into flattened output: pure, branch-safe,
 // GPU-expressible. Everything else (print, allocation, I/O, ...) is rejected.
@@ -729,6 +737,14 @@ def public flatten_fold(var func : FunctionPtr) : bool {
     return fold_body(func)
 }
 
+[macro_function]
+def public flatten_optimize(var func : FunctionPtr; barriers : table<string>) : bool {
+    //! Post-fold optimize pass (delegates to `flatten_preshade_cse`): hoist uniform subtrees to
+    //! per-draw `_preshader_` lets + CSE-dedup. Run ONCE after the `flatten_fold` fixpoint converges;
+    //! `barriers` = the backend's sampler/intrinsic call names. Returns true if anything changed.
+    return flatten_preshade_cse(func, barriers)
+}
+
 // ===== Post-inference shape verification — twin must be branchless + call-free =====
 // A violation is a lowering bug (fail loudly). Runs cycle 2 (user-call detection needs the
 // resolved `call.func`); fold completeness is a separate, correctness-irrelevant concern.
@@ -848,7 +864,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             errors := "flatten: twin {twin_name(func)} was not declared"
             return false
         }
-        if (ph != PHASE_LOWERED && ph != PHASE_FOLDED) {
+        if (ph != PHASE_LOWERED && ph != PHASE_FOLDED && ph != PHASE_OPTIMIZED) {
             // Cycle 1: lower the twin with the std whitelist, then re-infer so
             // call.func resolves. (Backends call flatten_function directly with
             // their own primitive set instead of going through this annotation.)
@@ -871,7 +887,14 @@ class FlattenAnnotation : AstFunctionAnnotation {
                 astChanged = true
                 return true
             }
-            // Nothing left to fold — fall through to the shape check this cycle.
+            // Fold fixpoint reached → run the optimize pass once on the canonical body: hoist uniform
+            // subtrees to top-of-body `_preshader_` lets, CSE-dedup repeated subtrees. Re-infer to
+            // type the new lets, then fall through to the shape check next cycle.
+            set_flatten_phase(func, PHASE_OPTIMIZED)
+            if (flatten_optimize(twin, FLATTEN_BARRIERS)) {
+                astChanged = true
+                return true
+            }
         }
         // Final cycle: verify the twin is branchless and call-free.
         let problem = verify_flat(twin)

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -745,6 +745,12 @@ def public flatten_optimize(var func : FunctionPtr; barriers : table<string>) : 
     return flatten_preshade_cse(func, barriers)
 }
 
+def public flatten_opt_residuals(var func : FunctionPtr) : array<string> {
+    //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin
+    //! has no un-extracted uniform subtree and no un-CSE'd repeat. Test-framework / fuzzer facing.
+    return <- opt_residuals(func, FLATTEN_BARRIERS)
+}
+
 // ===== Post-inference shape verification — twin must be branchless + call-free =====
 // A violation is a lowering bug (fail loudly). Runs cycle 2 (user-call detection needs the
 // resolved `call.func`); fold completeness is a separate, correctness-irrelevant concern.

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1666,6 +1666,54 @@ def private cse_body(var blk : ExprBlock?) : bool {
     return anyChange
 }
 
+// ===== Pure-alias elimination =====
+// Collapse `let X = <bare var V>` copies (V not reassigned) into direct refs to V and drop the let —
+// clears CSE's `_cse_a = _cse_b` leftovers and unroll/fold's `p_0 = ro`. General, not CSE-specific.
+
+// The bare ExprVar under any chain of ExprRef2Value wrappers, else null.
+def private alias_source(e : Expression const?) : ExpressionPtr {
+    if (e == null) return null
+    if (e is ExprRef2Value) return alias_source((e as ExprRef2Value).subexpr)
+    return e is ExprVar ? unsafe(reinterpret<Expression? -const>(e)) : null
+}
+
+def private eliminate_aliases(var blk : ExprBlock?) : bool {
+    var mutableVars <- collect_mutable(blk)
+    var rename : table<string; ExpressionPtr>
+    var body : array<ExpressionPtr>
+    var changed = false
+    for (s0 in blk.list) {
+        // Resolve already-collapsed aliases first, so chains (let a = b; let b = c) fold in one pass.
+        var s = !empty(rename) && reads_any(s0, rename) ? subst_consts(s0, rename) : s0
+        if (s is ExprLet && length((s as ExprLet).variables) == 1) {
+            let lvName = "{(s as ExprLet).variables[0].name}"
+            let src = alias_source((s as ExprLet).variables[0].init)
+            // Skip if either the alias var X or the source V is reassigned — renaming a reassigned X rewrites its stores onto the const source.
+            if (src != null && !key_exists(mutableVars, lvName) &&
+                    !key_exists(mutableVars, "{(src as ExprVar).name}")) {
+                rename[lvName] = clone_expression(src)
+                changed = true
+                continue
+            }
+        }
+        body |> push(s)
+    }
+    if (changed) {
+        while (!empty(blk.list)) {
+            blk.list |> erase(length(blk.list) - 1)
+        }
+        for (b in body) {
+            blk.list |> emplace(b)
+        }
+    }
+    delete mutableVars
+    unsafe {
+        delete rename
+        delete body
+    }
+    return changed
+}
+
 // ===== Completeness oracle (test-framework facing) =====
 // Mirrors flatten.das FoldResidualVisitor: flags a uniform subtree still inline in the varying body
 // or a pure subtree computed >=2x un-shared. Empty ⇒ complete; checked over the COMPILED twin.
@@ -1765,6 +1813,19 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
             break
         }
     }
+    // Alias residual: a pure single-def `let X = <bare var V>` copy (neither X nor V reassigned)
+    // the cleanup should collapse. A reassigned X (`var X = V` reused across copies) is a real var.
+    for (s in blk.list) {
+        if (s is ExprLet && length((s as ExprLet).variables) == 1) {
+            let lvName = "{(s as ExprLet).variables[0].name}"
+            let src = alias_source((s as ExprLet).variables[0].init)
+            if (src != null && !key_exists(pe.mutableVars, lvName) &&
+                    !key_exists(pe.mutableVars, "{(src as ExprVar).name}")) {
+                res |> push("a pure alias let '{lvName}' = '{(src as ExprVar).name}'")
+                break
+            }
+        }
+    }
     delete pe.paramNames
     delete pe.localColor
     delete pe.mutableVars
@@ -1780,6 +1841,11 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
     var blk = func.body as ExprBlock
     var changed = extract_preshader(func, blk, barriers)
     if (cse_body(blk)) {
+        changed = true
+    }
+    // Collapse every pure copy-let — CSE's `_cse_a = _cse_b` leftovers AND the unroll/fold's
+    // `p_0 = ro`. `eliminate_aliases` is general, so one post-CSE sweep clears them all.
+    if (eliminate_aliases(blk)) {
         changed = true
     }
     return changed

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1269,6 +1269,12 @@ def private psh_has_compute(e : ExpressionPtr) : bool {
     if (e is ExprOp1 || e is ExprOp2 || e is ExprOp3 || e is ExprCall) return true
     if (e is ExprField) return psh_has_compute((e as ExprField).value)
     if (e is ExprSwizzle) return psh_has_compute((e as ExprSwizzle).value)
+    if (e is ExprCast) return psh_has_compute((e as ExprCast).subexpr)
+    if (e is ExprPtr2Ref) return psh_has_compute((e as ExprPtr2Ref).subexpr)
+    if (e is ExprAt) {
+        let o = e as ExprAt
+        return psh_has_compute(o.subexpr) || psh_has_compute(o.index)
+    }
     return false
 }
 
@@ -1297,6 +1303,18 @@ def private pex_eligible(pe : PEX; barriers : table<string>; e : ExpressionPtr) 
     if (e is ExprRef2Value) return pex_eligible(pe, barriers, (e as ExprRef2Value).subexpr)
     if (e is ExprField) return pex_eligible(pe, barriers, (e as ExprField).value)
     if (e is ExprSwizzle) return pex_eligible(pe, barriers, (e as ExprSwizzle).value)
+    if (e is ExprCast) return pex_eligible(pe, barriers, (e as ExprCast).subexpr)
+    if (e is ExprPtr2Ref) return pex_eligible(pe, barriers, (e as ExprPtr2Ref).subexpr)
+    if (e is ExprAt) {
+        let o = e as ExprAt
+        return pex_eligible(pe, barriers, o.subexpr) && pex_eligible(pe, barriers, o.index)
+    }
+    if (e is ExprMakeTuple) {
+        for (v in (e as ExprMakeTuple).values) {
+            if (!pex_eligible(pe, barriers, v)) return false
+        }
+        return true
+    }
     if (e is ExprOp1) return pex_eligible(pe, barriers, (e as ExprOp1).subexpr)
     if (e is ExprOp2) {
         let o = e as ExprOp2
@@ -1366,6 +1384,21 @@ def private pex_extract(var pe : PEX; barriers : table<string>; var e : Expressi
     } elif (e is ExprRef2Value) {
         var o = e as ExprRef2Value
         o.subexpr = pex_extract(pe, barriers, o.subexpr)
+    } elif (e is ExprCast) {
+        var o = e as ExprCast
+        o.subexpr = pex_extract(pe, barriers, o.subexpr)
+    } elif (e is ExprPtr2Ref) {
+        var o = e as ExprPtr2Ref
+        o.subexpr = pex_extract(pe, barriers, o.subexpr)
+    } elif (e is ExprAt) {
+        var o = e as ExprAt
+        o.subexpr = pex_extract(pe, barriers, o.subexpr)
+        o.index = pex_extract(pe, barriers, o.index)
+    } elif (e is ExprMakeTuple) {
+        var o = e as ExprMakeTuple
+        for (vi in range(length(o.values))) {
+            o.values[vi] = pex_extract(pe, barriers, o.values[vi])
+        }
     } elif (e is ExprMakeStruct) {
         var ms = e as ExprMakeStruct
         for (si in range(length(ms.structs))) {
@@ -1481,13 +1514,52 @@ def private collect_mutable(blk : ExprBlock?) : table<string> {
     return <- r
 }
 
+// One structural walk (O(size)) over the closed post-flatten node set, replacing the old
+// O(#mutableVars * size) per-name count_refs loop. An unknown node kind is conservatively treated
+// as reading a mutable (never CSE through it) — correctness over completeness for this safety gate.
 def private reads_mutable(e : ExpressionPtr; mutableVars : table<string>) : bool {
-    if (empty(mutableVars)) return false
-    var ec = unsafe(reinterpret<Expression? -const>(e))
-    for (nm in keys(mutableVars)) {
-        if (count_refs(ec, nm) > 0) return true
+    if (e == null || empty(mutableVars) || e |> is_expr_const()) return false
+    if (e is ExprVar) return key_exists(mutableVars, "{(e as ExprVar).name}")
+    if (e is ExprRef2Value) return reads_mutable((e as ExprRef2Value).subexpr, mutableVars)
+    if (e is ExprField) return reads_mutable((e as ExprField).value, mutableVars)
+    if (e is ExprSwizzle) return reads_mutable((e as ExprSwizzle).value, mutableVars)
+    if (e is ExprCast) return reads_mutable((e as ExprCast).subexpr, mutableVars)
+    if (e is ExprPtr2Ref) return reads_mutable((e as ExprPtr2Ref).subexpr, mutableVars)
+    if (e is ExprOp1) return reads_mutable((e as ExprOp1).subexpr, mutableVars)
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        return reads_mutable(o.left, mutableVars) || reads_mutable(o.right, mutableVars)
     }
-    return false
+    if (e is ExprOp3) {
+        let o = e as ExprOp3
+        return reads_mutable(o.subexpr, mutableVars) || reads_mutable(o.left, mutableVars) || reads_mutable(o.right, mutableVars)
+    }
+    if (e is ExprAt) {
+        let o = e as ExprAt
+        return reads_mutable(o.subexpr, mutableVars) || reads_mutable(o.index, mutableVars)
+    }
+    if (e is ExprCall) {
+        for (a in (e as ExprCall).arguments) {
+            if (reads_mutable(a, mutableVars)) return true
+        }
+        return false
+    }
+    if (e is ExprMakeTuple) {
+        for (v in (e as ExprMakeTuple).values) {
+            if (reads_mutable(v, mutableVars)) return true
+        }
+        return false
+    }
+    if (e is ExprMakeStruct) {
+        var ms = e as ExprMakeStruct
+        for (si in range(length(ms.structs))) {
+            for (fld in *(ms.structs[si])) {
+                if (reads_mutable(fld.value, mutableVars)) return true
+            }
+        }
+        return false
+    }
+    return true
 }
 
 class private CseTally : AstVisitor {
@@ -1539,6 +1611,21 @@ def private cse_replace_expr(var e : ExpressionPtr; key, refName : string) : Exp
     } elif (e is ExprRef2Value) {
         var o = e as ExprRef2Value
         o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+    } elif (e is ExprCast) {
+        var o = e as ExprCast
+        o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+    } elif (e is ExprPtr2Ref) {
+        var o = e as ExprPtr2Ref
+        o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+    } elif (e is ExprAt) {
+        var o = e as ExprAt
+        o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+        o.index = cse_replace_expr(o.index, key, refName)
+    } elif (e is ExprMakeTuple) {
+        var o = e as ExprMakeTuple
+        for (vi in range(length(o.values))) {
+            o.values[vi] = cse_replace_expr(o.values[vi], key, refName)
+        }
     } elif (e is ExprMakeStruct) {
         var ms = e as ExprMakeStruct
         for (si in range(length(ms.structs))) {
@@ -1740,6 +1827,18 @@ def private pex_residual_expr(pe : PEX; barriers : table<string>; e : Expression
     if (e is ExprField) return pex_residual_expr(pe, barriers, (e as ExprField).value)
     if (e is ExprSwizzle) return pex_residual_expr(pe, barriers, (e as ExprSwizzle).value)
     if (e is ExprRef2Value) return pex_residual_expr(pe, barriers, (e as ExprRef2Value).subexpr)
+    if (e is ExprCast) return pex_residual_expr(pe, barriers, (e as ExprCast).subexpr)
+    if (e is ExprPtr2Ref) return pex_residual_expr(pe, barriers, (e as ExprPtr2Ref).subexpr)
+    if (e is ExprAt) {
+        let o = e as ExprAt
+        return pex_residual_expr(pe, barriers, o.subexpr) || pex_residual_expr(pe, barriers, o.index)
+    }
+    if (e is ExprMakeTuple) {
+        for (v in (e as ExprMakeTuple).values) {
+            if (pex_residual_expr(pe, barriers, v)) return true
+        }
+        return false
+    }
     if (e is ExprMakeStruct) {
         var ms = e as ExprMakeStruct
         for (si in range(length(ms.structs))) {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1243,3 +1243,391 @@ def public fold_body(var func : FunctionPtr) : bool {
     }
     return changed
 }
+
+// ===== Preshader extraction + CSE =====
+// Two pure-AST passes on the converged body: hoist maximal globals-only subtrees to top-of-body
+// `_preshader_N` lets, then CSE-dedup repeated subtrees. See flatten.rst / the plan for the why.
+
+def private psh_simple_name(fullname : string) : string {
+    let t1 = find(fullname, 96, 0)
+    if (t1 < 0) return fullname
+    let t2 = find(fullname, 96, t1 + 1)
+    let endp = t2 < 0 ? length(fullname) : t2
+    return slice(fullname, t1 + 1, endp)
+}
+
+def private psh_reserved(name : das_string) : bool {
+    return name |> starts_with("__flat_") || name |> starts_with("__ssa_") || name |> starts_with("_preshader_")
+}
+
+// True if the subtree carries a graph node (operator or call) — i.e. hoisting it saves per-pixel
+// work. A bare var / const / member access alone is trivial (no node), so it is inlined as an alias
+// rather than hoisted.
+def private psh_has_compute(e : ExpressionPtr) : bool {
+    if (e == null) return false
+    if (e is ExprRef2Value) return psh_has_compute((e as ExprRef2Value).subexpr)
+    if (e is ExprOp1 || e is ExprOp2 || e is ExprOp3 || e is ExprCall) return true
+    if (e is ExprField) return psh_has_compute((e as ExprField).value)
+    if (e is ExprSwizzle) return psh_has_compute((e as ExprSwizzle).value)
+    return false
+}
+
+struct private PEX {
+    paramNames : table<string>
+    localColor : table<string; bool>    // local name -> uniform (preshader-eligible)?
+    top : array<ExpressionPtr>          // hoisted `_preshader_N` lets, in dependency order
+    dedup : table<string; string>       // describe(init) -> preshader name
+    rename : table<string; ExpressionPtr>   // old local name -> replacement (alias inline / preshader ref)
+    counter : int
+    changed : bool
+}
+
+// Uniform = depends only on globals + literals, no barrier (sampler/noise) call. Leaf rule: a param
+// read is varying; a local read inherits its colored value; anything else is a module global (uniform).
+def private pex_eligible(pe : PEX; barriers : table<string>; e : ExpressionPtr) : bool {
+    if (e == null) return false
+    if (e |> is_expr_const()) return true
+    if (e is ExprVar) {
+        let nm = "{(e as ExprVar).name}"
+        if (key_exists(pe.localColor, nm)) return pe.localColor?[nm] ?? false
+        return !key_exists(pe.paramNames, nm)   // a non-param, non-local read is a module global → uniform
+    }
+    if (e is ExprRef2Value) return pex_eligible(pe, barriers, (e as ExprRef2Value).subexpr)
+    if (e is ExprField) return pex_eligible(pe, barriers, (e as ExprField).value)
+    if (e is ExprSwizzle) return pex_eligible(pe, barriers, (e as ExprSwizzle).value)
+    if (e is ExprOp1) return pex_eligible(pe, barriers, (e as ExprOp1).subexpr)
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        return pex_eligible(pe, barriers, o.left) && pex_eligible(pe, barriers, o.right)
+    }
+    if (e is ExprOp3) {
+        let o = e as ExprOp3
+        return pex_eligible(pe, barriers, o.subexpr) && pex_eligible(pe, barriers, o.left) && pex_eligible(pe, barriers, o.right)
+    }
+    if (e is ExprCall) {
+        let c = e as ExprCall
+        // Surviving calls are all whitelisted pure GPU math; only the caller's barriers (sampler/noise) bar a preshader.
+        if (key_exists(barriers, psh_simple_name("{c.name}"))) return false
+        for (a in c.arguments) {
+            if (!pex_eligible(pe, barriers, a)) return false
+        }
+        return true
+    }
+    return false
+}
+
+// Hoist an eligible+nontrivial subtree into a `_preshader_N` let (deduped by describe), returning
+// the let name. The fresh let is un-inferred; the macro re-infers it after the pass.
+def private pex_hoist_name(var pe : PEX; var e : ExpressionPtr) : string {
+    let key = describe(e)
+    if (key_exists(pe.dedup, key)) return pe.dedup[key]
+    let nm = "_preshader_{pe.counter}"
+    pe.counter ++
+    pe.dedup[key] = nm
+    pe.localColor[nm] = true
+    pe.top |> push <| qmacro_expr(${ let $i(nm) = $e(e); })
+    return nm
+}
+
+// Top-down maximal-subtree extraction: the first eligible+nontrivial node going down is hoisted and
+// replaced with a ref; otherwise recurse children. Handles the bounded post-flatten node set.
+def private pex_extract(var pe : PEX; barriers : table<string>; var e : ExpressionPtr) : ExpressionPtr {
+    if (e == null) return null
+    if (psh_has_compute(e) && pex_eligible(pe, barriers, e)) {
+        let nm = pex_hoist_name(pe, e)
+        pe.changed = true
+        return new ExprVar(at = e.at, name := nm)
+    }
+    if (e is ExprOp1) {
+        var o = e as ExprOp1
+        o.subexpr = pex_extract(pe, barriers, o.subexpr)
+    } elif (e is ExprOp2) {
+        var o = e as ExprOp2
+        o.left = pex_extract(pe, barriers, o.left)
+        o.right = pex_extract(pe, barriers, o.right)
+    } elif (e is ExprOp3) {
+        var o = e as ExprOp3
+        o.subexpr = pex_extract(pe, barriers, o.subexpr)
+        o.left = pex_extract(pe, barriers, o.left)
+        o.right = pex_extract(pe, barriers, o.right)
+    } elif (e is ExprCall) {
+        var c = e as ExprCall
+        for (i in range(length(c.arguments))) {
+            c.arguments[i] = pex_extract(pe, barriers, c.arguments[i])
+        }
+    } elif (e is ExprField) {
+        var o = e as ExprField
+        o.value = pex_extract(pe, barriers, o.value)
+    } elif (e is ExprSwizzle) {
+        var o = e as ExprSwizzle
+        o.value = pex_extract(pe, barriers, o.value)
+    } elif (e is ExprRef2Value) {
+        var o = e as ExprRef2Value
+        o.subexpr = pex_extract(pe, barriers, o.subexpr)
+    } elif (e is ExprMakeStruct) {
+        var ms = e as ExprMakeStruct
+        for (si in range(length(ms.structs))) {
+            for (fld in *(ms.structs[si])) {
+                fld.value = pex_extract(pe, barriers, fld.value)
+            }
+        }
+    }
+    return e
+}
+
+def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barriers : table<string>) : bool {
+    var pe : PEX
+    for (a in func.arguments) {
+        pe.paramNames |> insert("{a.name}")
+    }
+    var body : array<ExpressionPtr>
+    for (s0 in blk.list) {
+        var s = s0
+        if (!empty(pe.rename) && reads_any(s, pe.rename)) {
+            s = subst_consts(s, pe.rename)
+        }
+        if (s is ExprLet && length((s as ExprLet).variables) == 1 && !psh_reserved((s as ExprLet).variables[0].name)) {
+            var lc = s as ExprLet
+            let vname = "{lc.variables[0].name}"
+            var init = lc.variables[0].init
+            if (init != null && pex_eligible(pe, barriers, init)) {
+                if (psh_has_compute(init)) {
+                    // Whole uniform let: hoist its init, rename refs to the preshader temp, drop the decl.
+                    let nm = pex_hoist_name(pe, init)
+                    pe.rename[vname] = new ExprVar(at = init.at, name := nm)
+                    pe.changed = true
+                } else {
+                    // Trivial uniform alias (a bare global / member read): inline it at every use.
+                    pe.rename[vname] = clone_expression(init)
+                    pe.changed = true
+                }
+                continue
+            }
+        }
+        // Varying / reserved / multi-var statement: extract buried uniform subtrees, then emit.
+        if (s is ExprLet) {
+            var lc = s as ExprLet
+            for (lv in lc.variables) {
+                if (lv.init != null) {
+                    lv.init = pex_extract(pe, barriers, lv.init)
+                }
+                pe.localColor["{lv.name}"] = false
+            }
+        } elif (s is ExprCopy) {
+            var cp = s as ExprCopy
+            cp.right = pex_extract(pe, barriers, cp.right)
+        } elif (s is ExprReturn) {
+            var rt = s as ExprReturn
+            rt.subexpr = pex_extract(pe, barriers, rt.subexpr)
+        }
+        body |> push(s)
+    }
+    if (pe.changed) {
+        // Replace the body in place: preshader group on top, then the (extracted) varying body.
+        while (!empty(blk.list)) {
+            blk.list |> erase(length(blk.list) - 1)
+        }
+        for (t in pe.top) {
+            blk.list |> emplace(t)
+        }
+        for (b in body) {
+            blk.list |> emplace(b)
+        }
+    }
+    let result = pe.changed
+    delete pe.paramNames
+    delete pe.localColor
+    delete pe.dedup
+    unsafe {
+        delete pe.rename
+        delete pe.top
+        delete body
+    }
+    return result
+}
+
+// ===== CSE (local value numbering) =====
+// The body is one basic block, so LVN is complete. Value-number pure subtrees by `describe()`, dedup
+// any computed >=2x into one shared let before its first use; uniform dups route to the preshader.
+
+class private CseTally : AstVisitor {
+    counts : table<string; int>
+    sample : table<string; ExpressionPtr>
+    def override preVisitExpression(expr : ExpressionPtr) : void {
+        if (psh_has_compute(expr)) {
+            let k = "{describe(expr)}"
+            counts[k] = (counts?[k] ?? 0) + 1
+            if (!key_exists(sample, k)) {
+                sample[k] = clone_expression(expr)
+            }
+        }
+    }
+}
+
+// Replace every subtree whose describe matches `key` with a ref to `refName`. Top-down: a match is
+// replaced (no recursion into it); otherwise recurse children (the bounded post-flatten node set).
+def private cse_replace_expr(var e : ExpressionPtr; key, refName : string) : ExpressionPtr {
+    if (e == null) return null
+    if (psh_has_compute(e) && "{describe(e)}" == key) {
+        return new ExprVar(at = e.at, name := refName)
+    }
+    if (e is ExprOp1) {
+        var o = e as ExprOp1
+        o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+    } elif (e is ExprOp2) {
+        var o = e as ExprOp2
+        o.left = cse_replace_expr(o.left, key, refName)
+        o.right = cse_replace_expr(o.right, key, refName)
+    } elif (e is ExprOp3) {
+        var o = e as ExprOp3
+        o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+        o.left = cse_replace_expr(o.left, key, refName)
+        o.right = cse_replace_expr(o.right, key, refName)
+    } elif (e is ExprCall) {
+        var c = e as ExprCall
+        for (i in range(length(c.arguments))) {
+            c.arguments[i] = cse_replace_expr(c.arguments[i], key, refName)
+        }
+    } elif (e is ExprField) {
+        var o = e as ExprField
+        o.value = cse_replace_expr(o.value, key, refName)
+    } elif (e is ExprSwizzle) {
+        var o = e as ExprSwizzle
+        o.value = cse_replace_expr(o.value, key, refName)
+    } elif (e is ExprRef2Value) {
+        var o = e as ExprRef2Value
+        o.subexpr = cse_replace_expr(o.subexpr, key, refName)
+    } elif (e is ExprMakeStruct) {
+        var ms = e as ExprMakeStruct
+        for (si in range(length(ms.structs))) {
+            for (fld in *(ms.structs[si])) {
+                fld.value = cse_replace_expr(fld.value, key, refName)
+            }
+        }
+    }
+    return e
+}
+
+def private cse_replace_stmt(var s : ExpressionPtr; key, refName : string) {
+    if (s is ExprLet) {
+        var lc = s as ExprLet
+        for (lv in lc.variables) {
+            if (lv.init != null) {
+                lv.init = cse_replace_expr(lv.init, key, refName)
+            }
+        }
+    } elif (s is ExprCopy) {
+        var cp = s as ExprCopy
+        cp.right = cse_replace_expr(cp.right, key, refName)
+    } elif (s is ExprReturn) {
+        var rt = s as ExprReturn
+        rt.subexpr = cse_replace_expr(rt.subexpr, key, refName)
+    }
+}
+
+// Count leading contiguous `_preshader_*` lets — the preshader region. A CSE dup whose first use
+// falls inside it is uniform (Pass A already pulled every nontrivial uniform subtree out of the
+// body), so it routes to the preshader.
+def private preshader_prefix_len(blk : ExprBlock?) : int {
+    var k = 0
+    for (s in blk.list) {
+        if (s is ExprLet && length((s as ExprLet).variables) == 1 &&
+                (s as ExprLet).variables[0].name |> starts_with("_preshader_")) {
+            k ++
+        } else {
+            break
+        }
+    }
+    return k
+}
+
+def private cse_body(var blk : ExprBlock?) : bool {
+    var anyChange = false
+    var counter = 0
+    var guard = 0
+    while (guard < 4096) {
+        guard ++
+        // Tally every nontrivial subtree across the block, recording its first statement index.
+        var counts : table<string; int>
+        var sample : table<string; ExpressionPtr>
+        var firstStmt : table<string; int>
+        for (i in range(length(blk.list))) {
+            var ct = new CseTally()
+            make_visitor(*ct) $(a) {
+                visit(blk.list[i], a)
+            }
+            for (k in keys(ct.counts)) {
+                counts[k] = (counts?[k] ?? 0) + (ct.counts?[k] ?? 0)
+                if (!key_exists(firstStmt, k)) {
+                    firstStmt[k] = i
+                    sample[k] = ct.sample?[k] ?? null
+                }
+            }
+            unsafe {
+                delete ct
+            }
+        }
+        // Pick the largest subtree computed >=2x (largest → fewer rounds; nested dups surface next).
+        var bestKey = ""
+        var bestLen = 0
+        for (k in keys(counts)) {
+            if ((counts?[k] ?? 0) >= 2 && length(k) > bestLen) {
+                bestKey = k
+                bestLen = length(k)
+            }
+        }
+        if (bestKey == "") {
+            delete counts
+            delete firstStmt
+            unsafe {
+                delete sample
+            }
+            break
+        }
+        let fi = firstStmt?[bestKey] ?? 0
+        let uniform = fi < preshader_prefix_len(blk)
+        let nm = uniform ? "_preshader_cse_{counter}" : "_cse_{counter}"
+        counter ++
+        // `sample` holds a tally-time (pre-replace) clone; cse_replace mutates the tree, not it.
+        var src = sample?[bestKey] ?? null
+        for (s in blk.list) {
+            cse_replace_stmt(s, bestKey, nm)
+        }
+        var theLet = qmacro_expr(${ let $i(nm) = $e(src); })
+        var newlist : array<ExpressionPtr>
+        newlist |> reserve(length(blk.list) + 1)
+        for (i in range(length(blk.list))) {
+            if (i == fi) {
+                newlist |> push(theLet)
+            }
+            newlist |> push(blk.list[i])
+        }
+        while (!empty(blk.list)) {
+            blk.list |> erase(length(blk.list) - 1)
+        }
+        for (m in newlist) {
+            blk.list |> emplace(m)
+        }
+        delete counts
+        delete firstStmt
+        unsafe {
+            delete sample
+            delete newlist
+        }
+        anyChange = true
+    }
+    return anyChange
+}
+
+def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>) : bool {
+    //! Post-fold optimize pass: hoist uniform (globals+literals) subtrees to top-of-body
+    //! `_preshader_N` lets, then CSE-dedup repeated subtrees. `barriers` = sampler/noise call names
+    //! that must stay per-pixel. Runs once after the fold fixpoint; caller re-infers after.
+    if (!(func.body is ExprBlock)) return false
+    var blk = func.body as ExprBlock
+    var changed = extract_preshader(func, blk, barriers)
+    if (cse_body(blk)) {
+        changed = true
+    }
+    return changed
+}

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1275,6 +1275,7 @@ def private psh_has_compute(e : ExpressionPtr) : bool {
 struct private PEX {
     paramNames : table<string>
     localColor : table<string; bool>    // local name -> uniform (preshader-eligible)?
+    mutableVars : table<string>         // reassigned names (incl. written globals) — never uniform
     top : array<ExpressionPtr>          // hoisted `_preshader_N` lets, in dependency order
     dedup : table<string; string>       // describe(init) -> preshader name
     rename : table<string; ExpressionPtr>   // old local name -> replacement (alias inline / preshader ref)
@@ -1289,6 +1290,7 @@ def private pex_eligible(pe : PEX; barriers : table<string>; e : ExpressionPtr) 
     if (e |> is_expr_const()) return true
     if (e is ExprVar) {
         let nm = "{(e as ExprVar).name}"
+        if (key_exists(pe.mutableVars, nm)) return false   // reassigned (e.g. a written global) → not stable
         if (key_exists(pe.localColor, nm)) return pe.localColor?[nm] ?? false
         return !key_exists(pe.paramNames, nm)   // a non-param, non-local read is a module global → uniform
     }
@@ -1380,6 +1382,7 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
     for (a in func.arguments) {
         pe.paramNames |> insert("{a.name}")
     }
+    pe.mutableVars <- collect_mutable(blk)
     var body : array<ExpressionPtr>
     for (s0 in blk.list) {
         var s = s0
@@ -1437,6 +1440,7 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
     let result = pe.changed
     delete pe.paramNames
     delete pe.localColor
+    delete pe.mutableVars
     delete pe.dedup
     unsafe {
         delete pe.rename
@@ -1450,12 +1454,49 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
 // The body is one basic block, so LVN is complete. Value-number pure subtrees by `describe()`, dedup
 // any computed >=2x into one shared let before its first use; uniform dups route to the preshader.
 
+// Names reassigned somewhere in the block (live/loop masks `__flat_*`, any reassigned user `var`).
+// A subtree reading one of these is NOT value-stable — CSE must not share it (its value differs
+// per occurrence), so it is excluded from value numbering. Single-def `__ssa_*` / `let` are safe.
+class private MutCollect : AstVisitor {
+    names : table<string>
+    def override preVisitExprCopy(expr : ExprCopy?) : void {
+        if (expr.left is ExprVar) {
+            names |> insert("{(expr.left as ExprVar).name}")
+        }
+    }
+}
+
+def private collect_mutable(blk : ExprBlock?) : table<string> {
+    var mc = new MutCollect()
+    make_visitor(*mc) $(a) {
+        visit(blk, a)
+    }
+    var r : table<string>
+    for (n in keys(mc.names)) {
+        r |> insert(n)
+    }
+    unsafe {
+        delete mc
+    }
+    return <- r
+}
+
+def private reads_mutable(e : ExpressionPtr; mutableVars : table<string>) : bool {
+    if (empty(mutableVars)) return false
+    var ec = unsafe(reinterpret<Expression? -const>(e))
+    for (nm in keys(mutableVars)) {
+        if (count_refs(ec, nm) > 0) return true
+    }
+    return false
+}
+
 class private CseTally : AstVisitor {
     collectSample : bool        // clone a representative node per key (cse_body only; the oracle just counts)
     counts : table<string; int>
     sample : table<string; ExpressionPtr>
+    mutableVars : table<string>
     def override preVisitExpression(expr : ExpressionPtr) : void {
-        if (psh_has_compute(expr)) {
+        if (psh_has_compute(expr) && !reads_mutable(expr, mutableVars)) {
             let k = "{describe(expr)}"
             counts[k] = (counts?[k] ?? 0) + 1
             if (collectSample && !key_exists(sample, k)) {
@@ -1546,6 +1587,8 @@ def private cse_body(var blk : ExprBlock?) : bool {
     var anyChange = false
     var counter = 0
     var guard = 0
+    // Reassigned vars are stable across rounds (cse only ever adds `let`s), so collect once.
+    var mutableVars <- collect_mutable(blk)
     while (guard < 4096) {
         guard ++
         // Tally every nontrivial subtree across the block, recording its first statement index.
@@ -1555,6 +1598,7 @@ def private cse_body(var blk : ExprBlock?) : bool {
         for (i in range(length(blk.list))) {
             var ct = new CseTally()
             ct.collectSample = true
+            ct.mutableVars := mutableVars
             make_visitor(*ct) $(a) {
                 visit(blk.list[i], a)
             }
@@ -1618,6 +1662,7 @@ def private cse_body(var blk : ExprBlock?) : bool {
         }
         anyChange = true
     }
+    delete mutableVars
     return anyChange
 }
 
@@ -1667,6 +1712,7 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
     for (a in func.arguments) {
         pe.paramNames |> insert("{a.name}")
     }
+    pe.mutableVars <- collect_mutable(blk)
     for (s in blk.list) {
         if (s is ExprLet) {
             for (lv in (s as ExprLet).variables) {
@@ -1698,10 +1744,11 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
             break
         }
     }
-    // CSE residual: any pure subtree still computed >=2x across the block.
+    // CSE residual: any pure subtree (no mutable read) still computed >=2x across the block.
     var counts : table<string; int>
     for (i in range(length(blk.list))) {
         var ct = new CseTally()
+        ct.mutableVars := pe.mutableVars
         make_visitor(*ct) $(a) {
             visit(blk.list[i], a)
         }
@@ -1720,6 +1767,7 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
     }
     delete pe.paramNames
     delete pe.localColor
+    delete pe.mutableVars
     delete counts
     return <- res
 }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options strict_smart_pointers = true
+options _comment_hygiene = true
 
 module flatten_opt shared private
 
@@ -22,13 +23,8 @@ def private is_flat_temp(name : das_string) : bool {
 }
 
 // ===== Dead-store elimination =====
-//
-// The lowered body is straight-line (no branches), so liveness is a single
-// backward scan. We only ever touch flatten-introduced `__flat_*` locals — never
-// user locals or globals (a `g_out = ...` is observable output, never "dead").
-// A `__flat_*` store is removed when its target is not live afterward AND its RHS
-// is side-effect-free / non-faulting (no call, index, or division) — which is
-// exactly the live-mask kills (`__flat_live = false`, per-frame mask updates).
+// Straight-line body → liveness is one backward scan. Touches only `__flat_*` locals (never
+// user locals/globals); drops a store whose target is dead afterward and whose RHS is pure.
 
 class private FlatScan : AstVisitor {
     reads : table<uint64>
@@ -69,13 +65,8 @@ def private scan_flat(var e : ExpressionPtr; var reads : table<uint64>; var risk
 }
 
 // ===== Boolean const-fold of live masks =====
-//
-// When a function has no early returns, `__flat_live` is never reassigned, so it is
-// constant `true` — and so is every per-frame `__flat_live_N` derived from it. copy_prop
-// inlines such a single-def mask, then `fold_stmt` collapses the selects it exposes
-// (`true ? a : b → a`, `true && x → x`), unwinding the whole mask scaffolding into clean
-// dataflow. fold_const / const_bool / fold_stmt are copy_prop's folding helpers; they only
-// simplify literal const-bools, never user/global vars.
+// With no early return `__flat_live` stays constant `true`; copy_prop inlines the single-def
+// mask and fold_stmt collapses the selects it exposes (`true ? a:b → a`), unwinding the scaffold.
 
 def private const_bool(e : ExpressionPtr; var val : bool&) : bool {
     if (e == null) return false
@@ -183,15 +174,8 @@ def private fold_stmt(var s : ExpressionPtr; constmap : table<uint64; bool>) : E
 }
 
 // ===== Copy propagation of single-assignment flatten temps =====
-//
-// A `__flat_*` temp with exactly one definition (a decl-init, or a no-init decl
-// plus a single store) and whose source reads no later-reassigned variable is a
-// pure forward copy: inline its source at every use and drop the temp. This folds
-// the output scaffold away — `__flat_ret = c; return __flat_ret` → `return c`, and
-// `var __flat_arg = x` → `x` — so a branchless shader flattens byte-identical to
-// its source (the parity goal). Substitution is delegated to `apply_template`
-// (peel-aware, clones the source per hit). A risky source (call / index / divide)
-// is inlined only at a single use, never duplicated.
+// A single-def `__flat_*` temp whose source reads no later-reassigned var is a pure forward copy:
+// inline the source at every use, drop the temp (a risky call/index/divide source only at one use).
 
 class private FlatVarRef : AstVisitor {
     name  : string
@@ -255,10 +239,9 @@ def private scan_src(var e : ExpressionPtr; var reads : table<uint64>; var risky
     }
 }
 
-// Per-pass reference index: name-hash -> the statement indices that reference it
-// (deduped per statement) plus the total occurrence count. Built once per copy_prop
-// pass in a single walk, replacing the old per-candidate count_refs sweep that made
-// the pass O(n^3) on large bodies (one full-body walk per candidate per fold-restart).
+// Per-pass reference index: name-hash -> referencing statement indices (deduped) + total count.
+// Built once per copy_prop pass, replacing the old per-candidate count_refs sweep that was
+// O(n^3) on large bodies.
 class private FlatUsesBuilder : AstVisitor {
     nameUses : table<uint64; array<int>>
     nameCount : table<uint64; int>
@@ -283,10 +266,9 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
     while (changed) {
         changed = false
         let n = length(out)
-        // Precompute once per pass (not per candidate): every store target's indices,
-        // and a name -> (referencing statements, occurrence count) index. A source
-        // reading var V is only unsafe if V is reassigned BETWEEN this temp's def and a
-        // use — a reassignment fully before the def leaves the captured value intact.
+        // Precompute once per pass: each store target's indices + a name -> (ref statements, count)
+        // index. A source reading V is unsafe only if V is reassigned BETWEEN this temp's def and a
+        // use (a reassignment fully before the def leaves the captured value intact).
         var storeIdx : table<uint64; array<int>>
         for (j in range(n)) {
             if (out[j] is ExprCopy && (out[j] as ExprCopy).left is ExprVar) {
@@ -309,10 +291,9 @@ def public copy_prop_pass(var out : array<ExpressionPtr>) {
             if (length(lc.variables) != 1 || !is_flat_temp(lc.variables[0].name)) continue
             let hk = hash(lc.variables[0].name)
             let nStores = key_exists(storeIdx, hk) ? length(storeIdx[hk]) : 0
-            // Single definition: decl-init + no stores, OR no-init decl + one store. Use the
-            // ORIGINAL source (no clone) — apply_template clones it per use, and the original
-            // lives in out[k]/out[si], reclaimed when we drop them. Cloning here would orphan a
-            // copy on every non-folding candidate (re-examined each while-restart → millions).
+            // Single definition: decl-init + no stores, OR no-init decl + one store. Use the ORIGINAL
+            // source (no clone) — apply_template clones per use; pre-cloning would orphan a copy on
+            // every non-folding candidate (re-examined each while-restart).
             var src : ExpressionPtr = null
             var si = -1
             if (lc.variables[0].init != null && nStores == 0) {
@@ -464,19 +445,8 @@ def public dse_pass(var out : array<ExpressionPtr>) {
 }
 
 // ===== SSA-rename of reassigned user locals =====
-//
-// flatten's body is straight-line (if → ?:, loops unrolled, no user calls), so a
-// reassigned local has a single linear chain of definitions — no control-flow merges,
-// hence no phi nodes. Renaming each write to a fresh version (`acc = acc + 3` →
-// `var __ssa_acc_2 = __ssa_acc_1 + 3`) makes every local single-definition, which lets the
-// post-infer const-prop (fold_body) fold the chain through the existing single-def
-// path. We rename only user locals that are declared WITH an initializer (single-var)
-// and reassigned at least once — never `__flat_*` masks (folded by copy_prop),
-// globals (observable), or params (not declared here). A self-referential select
-// (`acc = c ? e : acc`) resolves correctly: its read picks the PRIOR version. The `__ssa_`
-// prefix is compiler-reserved (a user can't declare `__`-names), so the versions never
-// collide with a user local — and it is disjoint from `__flat_`, so is_flat_temp still
-// classifies them as user locals (folded here, not by the mask/copy/dse passes).
+// Straight-line body → a reassigned local is a linear def-chain (no phi); renaming each write to a
+// fresh single-def `__ssa_` version lets post-infer const-prop fold the chain (declared-with-init only).
 
 def private rename_reads(var e : ExpressionPtr; current : table<string; string>) : ExpressionPtr {
     if (e == null) return null
@@ -554,29 +524,16 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
 class private FoldVisitor : AstVisitor {
     changed : bool
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
-        // A fully-constant arithmetic ExprOp2 the typer left unfolded — it folds scalar const
-        // arithmetic during re-infer (`2+3→6`) but leaves vector const arithmetic
-        // (`float3(2)+float3(3)`), which survives here and is what reassoc's gathered const
-        // groups become. Fold to one literal via the evaluator (mirrors the visitExprCall arm).
-        // eval_to_const_supported is null-safe, so an un-inferred node (the group reassoc just
-        // built this pass) is skipped and folded on the next re-infer cycle.
+        // A fully-constant ExprOp2 the typer left unfolded — it folds scalar const arithmetic but
+        // leaves vector const (`float3(2)+float3(3)`), what reassoc's gathered groups become. Fold
+        // to one literal via the evaluator; an un-inferred node is skipped (folded next re-infer).
         if (is_all_const(that) && eval_to_const_supported(that._type)) {
             var folded = eval_to_const(that)
             if (folded |> is_expr_const()) { changed = true; return folded }
         }
-        // Algebraic identities over the scalar + vector (float/int/uint) family. Integer
-        // arms are exact (two's-complement, `e*-1==-e` even at INT_MIN); float arms fire
-        // under flatten's fast-math assumption (every consumer is a shader backend) — `x*1`/
-        // `x*-1` are exact for all floats, while `x*0`/`x+0`/`x-0` are lossy (NaN·0=NaN;
-        // +0.0 flips -0.0) but enabled by decision. `*1`/`*-1` RETURN the non-const operand
-        // and so gate on `same_base_type(that, returned)`: scalar*vector broadcast IS valid
-        // (`s:float * float3(1)` is `float3(s,s,s)`, NOT `s`), so dropping the const must not
-        // mistype to the scalar. `+`/`-` need NO such gate — vector±scalar does not compile,
-        // so a valid `+`/`-` always has same-type operands and the non-const operand already
-        // carries the result type; omitting the gate also lets a freshly-inlined (un-inferred,
-        // hence `_type == null`) `v + 0` fold without waiting on a re-infer. `*0` DROPS an
-        // operand (purity gate) and returns a zero of the RESULT type via zero_const_of — so
-        // `v * 0.0` / `v * float3(0)` fold to a width-matched vector zero with no mistype.
+        // Algebraic identities over the scalar + vector (float/int/uint) family, under fast-math.
+        // `*1`/`*-1` return the non-const operand and gate on `same_base_type` (scalar*vector
+        // broadcast must not mistype to scalar); `*0` returns a RESULT-typed zero via zero_const_of.
         if (that.op == "*") {
             if (is_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return that.left }
             if (is_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return that.right }
@@ -647,11 +604,9 @@ class private FoldVisitor : AstVisitor {
         return that
     }
     def override visitExprCall(var that : ExprCall?) : ExpressionPtr {
-        // A fully-constant, side-effect-free call — a vector constructor (`float3(0)`
-        // stays `float3(0f,0f,0f)`, never a const) or a pure builtin over const args —
-        // folds to a single const literal. The typer folds scalar const ARITHMETIC
-        // during re-infer (`2*3 → 6`) but leaves const CONSTRUCTORS; this collapses
-        // them. Post-order, so const-folded args are visible here.
+        // A fully-constant, side-effect-free call (vector constructor or pure builtin over const
+        // args) folds to one literal. The typer folds const ARITHMETIC but leaves const
+        // CONSTRUCTORS; this collapses them. Post-order, so const-folded args are visible.
         if (is_all_const(that)) {
             var folded = eval_to_const(that)
             if (!(folded is ExprCall)) {   // eval_to_const returns the call unchanged on failure
@@ -663,11 +618,9 @@ class private FoldVisitor : AstVisitor {
     }
 }
 
-// A scalar zero/default literal: `default<T>` for every workhorse scalar is the
-// zero bit-pattern (int 0, float 0.0, bool false, …). A `var x = <this>` initializer
-// is therefore redundant with daslang's guaranteed zero-init of a bare `var x : T`,
-// so it can be dropped. Non-scalar inits (vector/struct ctors like `float3(0)`) are
-// NOT literals here and are left alone — conservative by design.
+// A scalar zero/default literal (int 0, float 0.0, bool false, …). A `var x = <this>` init is
+// redundant with daslang's zero-init of a bare `var x : T`, so it can be dropped. Non-scalar
+// inits (vector/struct ctors) are not literals here and left alone.
 def private is_zero_const(e : ExpressionPtr) : bool {
     if (e == null) return false
     if (e is ExprConstInt) return (e as ExprConstInt).value == 0
@@ -723,10 +676,9 @@ def private is_real_val(e : ExpressionPtr; want : double) : bool {
     return false
 }
 
-// An all-lanes-equal float vector const (ExprConstFloat2/3/4) equal to `want`. Extends the
-// scalar is_real_val so the float identities fire for vector-const operands too
-// (`v * float3(1)`, `v + float3(0)`, …). `want` is exact (0/1/-1) so the widening compare
-// is exact.
+// An all-lanes-equal float vector const (ExprConstFloat2/3/4) equal to `want`. Extends scalar
+// is_real_val so the float identities fire for vector-const operands (`v * float3(1)`); `want`
+// is exact (0/1/-1) so the widening compare is exact.
 def private is_real_vec_val(e : ExpressionPtr; want : double) : bool {
     if (e == null) return false
     if (e is ExprConstFloat2) { let v = (e as ExprConstFloat2).getValue; return double(v.x) == want && double(v.y) == want }
@@ -782,13 +734,9 @@ def private is_bool_val(e : ExpressionPtr; want : bool) : bool {
     return false
 }
 
-// True if `e` is an op2 that FoldVisitor's identity arms would have rewritten away:
-// `x*1`/`1*x`/`x*-1`/`-1*x`, `x+0`/`0+x`, `x-0`/`0-x` (scalar OR all-lanes-equal vector
-// const). MIRRORS the fold arms exactly: the `*1`/`*-1` arms carry a `same_base_type` gate
-// (scalar*vector broadcast is valid, so `s * float3(1)` is correctly NOT folded and must not
-// be flagged); `+`/`-` have no gate (vector±scalar does not compile, so they always fold).
-// `x*0` is excluded — it carries a purity gate, so a survivor is not a miss. The typer never
-// folds a runtime-operand identity, so a survivor here is a genuine const-fold miss.
+// True if `e` is an op2 FoldVisitor's identity arms would rewrite away (`x*1`/`x*-1`/`x+0`/`x-0`,
+// scalar or vector const). MIRRORS the fold arms exactly — `*1`/`*-1` carry the `same_base_type`
+// gate, `+`/`-` don't, `x*0` is excluded (purity-gated, so a survivor isn't a miss).
 def public is_unfolded_identity_op2(e : ExprOp2?) : bool {
     if (e == null) return false
     if (e.op == "*") {
@@ -810,10 +758,9 @@ def private negate(var e : ExpressionPtr) : ExpressionPtr {
     return new ExprOp1(at = e.at, op := "-", subexpr = e)
 }
 
-// A fresh zero literal of `t` (the RESULT type of an `X * 0`), over the numeric scalar +
-// vector family; null otherwise (→ the fold bails). Keying on the result type — not the
-// zero operand's type — is what lets a scalar-broadcast `v:float3 * 0.0` and a vector-const
-// `v * float3(0)` both fold to a width-matched `float3(0)` with no float3→float mistype.
+// A fresh zero literal of `t` (the RESULT type of `X * 0`), over the numeric scalar + vector
+// family; null otherwise. Keying on the result type (not the zero operand's) lets both
+// `v:float3 * 0.0` and `v * float3(0)` fold to a width-matched `float3(0)` with no mistype.
 def private zero_const_of(t : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
     if (t == null) return null
     let bt = t.baseType
@@ -839,11 +786,9 @@ def private zero_const_of(t : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
     return null
 }
 
-// True if `e` is built only from const literals and pure ops/builtins over them — NO
-// variable/global reference and NO user call anywhere. eval_single_expression runs in a
-// bare context with no globals (a global read dereferences null) and no user functions
-// linked (a user call can't be evaluated), so the tree must bottom out in literals and
-// pure builtins. Conservative: an unknown node kind returns false.
+// True if `e` is built only from const literals and pure ops/builtins — no var/global read,
+// no user call. eval_single_expression runs in a bare context (no globals, no user functions),
+// so the tree must bottom out in literals and pure builtins. Unknown node → false.
 def public is_all_const(e : ExpressionPtr) : bool {
     if (e == null) return false
     if (e |> is_expr_const()) return true
@@ -880,12 +825,9 @@ def public eval_to_const_supported(t : TypeDeclPtr) : bool {
         bt == Type.tUInt || bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4)
 }
 
-// True if every operator / call node in the subtree carries a settled type. eval_single_expression
-// builds sim-nodes assuming inference is complete — an un-inferred operator node has a null `.func`
-// and crashes the simulator. Const literals need no inference (exempt); a var would already have
-// failed is_all_const. Guards eval against a not-yet-re-inferred subtree — e.g. an is_all_const
-// tree whose inferred root has an operand the fold replaced this same pass with a fresh (un-typed)
-// const-arithmetic node.
+// True if every operator/call node in the subtree carries a settled type. eval_single_expression
+// assumes inference is complete (an un-inferred operator has null `.func` → crash), so this guards
+// eval against a not-yet-re-inferred subtree (a fold-built operand under an inferred all-const root).
 def private fully_inferred(e : ExpressionPtr) : bool {
     if (e == null) return false
     if (e is ExprOp1) {
@@ -943,14 +885,8 @@ def private eval_to_const(var e : ExpressionPtr) : ExpressionPtr {
 }
 
 // ===== Generalized const-propagation of single-def user locals =====
-//
-// After SSA-rename every user local is single-definition, so a `var x = <const>` can
-// be substituted at all of x's uses and dropped. Because flatten linearized the body,
-// one forward pass folds a whole accumulator chain: each link's init is substituted
-// with the prior constants and evaluated exactly via the shared runtime evaluator
-// (types are present post-infer), so `var __ssa_acc_1=5; var __ssa_acc_2=__ssa_acc_1+3; …` collapses
-// to a single constant in place — no re-infer leg per link. Masks (`__flat_*`) are folded
-// by copy_prop (pre-infer); globals/fields are never substituted (only their read operands).
+// Post-SSA-rename every user local is single-def, so a `var x = <const>` substitutes at all uses and
+// drops. One forward pass folds a whole accumulator chain; masks are copy_prop's job, globals never.
 
 def private reads_any(var e : ExpressionPtr; names : table<string; ExpressionPtr>) : bool {
     for (nm in keys(names)) {
@@ -963,9 +899,7 @@ def private subst_consts(var e : ExpressionPtr; constmap : table<string; Express
     if (e == null) return null
     var tmpl : Template
     for (nm in keys(constmap)) {
-        // ?[] yields a const view (non-inserting; keys() locks the table) but the pointed-to
-        // node is genuinely mutable. apply_template clones it per use, so const-strip the raw
-        // pointer instead of pre-cloning (which would orphan a copy every substitution).
+        // ?[] yields a const view; const-strip the raw pointer (apply_template clones per use anyway).
         var ex = unsafe(reinterpret<Expression? -const>(constmap?[nm] ?? null))
         tmpl |> replaceVariable(nm, ex)
     }
@@ -987,29 +921,23 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
     var constmap : table<string; ExpressionPtr>
     var i = 0
     while (i < length(blk.list)) {
-        // Substitute already-known constants into this statement's reads (the next
-        // link's init, a final `g_out = acc`, a `return acc`, …).
+        // Substitute already-known constants into this statement's reads.
         if (!empty(constmap) && reads_any(blk.list[i], constmap)) {
             blk.list[i] = subst_consts(blk.list[i], constmap)
             changed = true
         }
-        // A single-def user local whose (now-substituted) init is literal-only folds to
-        // one constant and joins the map for the rest of the pass.
+        // A single-def user local with a now-literal init folds to a constant and joins the map.
         var s = blk.list[i]
         if (s is ExprLet && length((s as ExprLet).variables) == 1) {
             var lc = s as ExprLet
             if (!is_flat_temp(lc.variables[0].name) && lc.variables[0].init != null && is_all_const(lc.variables[0].init)) {
                 var oldInit = lc.variables[0].init
                 if (oldInit |> is_expr_const()) {
-                    // Already a literal — e.g. a fold-produced `0f` whose `0*s` collapsed.
-                    // eval_to_const bails on its null _type, but it IS the constant; map it
-                    // directly so its uses inline (revealing identities like `v + 0`) and the
-                    // dead decl drops. Without this the local survives to the backend.
+                    // Already a literal (e.g. a fold-produced `0f`): map it directly so its uses inline.
                     constmap["{lc.variables[0].name}"] = oldInit
                     changed = true
                 } else {
-                    // A const expression (`2.0 * 3.0`): eval to its literal. eval_single_expression
-                    // only READS the tree (throwaway context), so fold the init in place.
+                    // A const expression (`2.0 * 3.0`): eval to its literal, folding the init in place.
                     var folded = eval_to_const(oldInit)
                     if (folded |> is_expr_const() && folded != oldInit) {
                         lc.variables[0].init = folded
@@ -1050,27 +978,17 @@ def private const_prop_locals(var blk : ExprBlock?) : bool {
 }
 
 // ===== Constant reassociation =====
-//
-// Gather scattered constants in associative/commutative `+`/`-` and `*` chains into one
-// adjacent group: `0.5 + a + b + 0.6` → `a + b + (0.5 + 0.6)`, `2.0 * a * 3.0` → `a * (2.0 * 3.0)`.
-// Reassoc only REORDERS (structural) — the FoldVisitor all-const arm + the typer's re-infer then
-// collapse the grouped const sub-expression to one literal. The typer folds only ADJACENT const
-// arithmetic and never reassociates (float rounding); flatten assumes fast-math, so it can.
-// Integer `+`/`*` are exact; integer `/` is non-associative (no `/` here — reciprocal grouping
-// is a follow-up). Const terms are side-effect-free (is_all_const), so gathering them to the tail
-// is unconditional; the var terms are additionally sorted into a canonical (describe) order so
-// commutative chains converge to one form for a later CSE — gated on every var term being
-// side-effect-free, so a side-effecting term's evaluation order is never observably reordered.
+// Gather scattered consts in `+`/`-`/`*` chains into one adjacent group (`0.5 + a + 0.6` → `a +
+// (0.5+0.6)`) for the all-const arm to fold; also sort var terms into a canonical order (for a later CSE).
 
 struct private ReTerm {
-    neg : bool          //!< additive term is subtracted (always false for the `*` monoid in v1)
+    neg : bool          // subtracted (additive chains); always false for the `*` monoid
     e : ExpressionPtr
 }
 
 // Flatten a maximal additive chain into signed terms (left-to-right = source order). Descends
-// `+`/`-` ExprOp2 and unary `-`; everything else (vars, calls, `*`/`/` sub-exprs, const literals)
-// is a leaf. No same-base-type gate: vector±scalar does not compile, so an additive chain is
-// always same-type.
+// `+`/`-` ExprOp2 and unary `-`; everything else is a leaf. No same-base-type gate (vector±scalar
+// does not compile, so an additive chain is always same-type).
 def private collect_add(var e : ExpressionPtr; neg : bool; var terms : array<ReTerm>) {
     if (e == null) return
     if (e is ExprOp2) {
@@ -1130,11 +1048,9 @@ def private already_grouped(that : ExprOp2?; addOp : string) : bool {
     return that.op == addOp && is_all_const(that.right) && !chain_has_const(that.left, addOp)
 }
 
-// Build a left-leaning `<t0> op <t1> op …` tree from non-empty `terms`, REUSING the operand
-// nodes (each leaf appears once in the flattened term list, so it lands in exactly one slot of
-// the rebuilt tree; the old chain wrappers are dropped when the visitor replaces `that` with the
-// result — the same move-not-clone pattern FoldVisitor uses returning `that.left`). A negative
-// first term becomes a unary `-`; subsequent terms pick addOp/subOp by sign.
+// Build a left-leaning `<t0> op <t1> …` tree from non-empty `terms`, REUSING the operand nodes
+// (each leaf appears once, so it lands in one slot; the old chain wrappers drop when the visitor
+// replaces `that`). A negative first term becomes unary `-`; later terms pick addOp/subOp by sign.
 def private build_chain(var terms : array<ReTerm>; at : LineInfo; addOp, subOp : string) : ExpressionPtr {
     var acc = terms[0].neg ? negate(terms[0].e) : terms[0].e
     for (i in range(1, length(terms))) {
@@ -1154,14 +1070,9 @@ def private vars_sorted(vars : array<ReTerm>) : bool {
     return true
 }
 
-// Partition `terms` into var/const and rebuild as `<vars> addOp <consts>` (consts to the tail).
-// Two canonicalizations: gather ≥2 scattered consts into one group (folded by the all-const arm /
-// re-infer), and SORT the var terms into a structural (describe) order so commutative chains
-// converge to one form (`b + a` and `a + b` both → `a + b`) — which lets a later CSE pass match
-// them. Sorting reorders var terms relative to each other, so it is gated on every var term being
-// side-effect-free (shaders are pure, so this always holds there); const terms are pure, so the
-// gather is unconditional. Returns null when neither canonicalization applies, or the chain is
-// all-const (the all-const ExprOp2 arm folds that).
+// Partition `terms` into var/const and rebuild as `<vars> addOp <consts>`. Two canonicalizations:
+// gather ≥2 scattered consts into one group, and sort the var terms into a canonical order (for a
+// later CSE) — the sort gated on side-effect freedom. Null when neither applies / the chain is all-const.
 def private regroup(that : ExprOp2?; var terms : array<ReTerm>; addOp, subOp : string) : ExpressionPtr {
     var vars : array<ReTerm>
     var consts : array<ReTerm>
@@ -1226,10 +1137,9 @@ def private count_terms(e : ExpressionPtr; addOp : string; var nv : int&; var nc
     }
 }
 
-// True if reassoc WOULD gather this chain: ≥1 var term, ≥2 scattered const terms, not already
-// grouped. The fold-completeness oracle (flatten.das FoldResidualVisitor) mirrors the transform's
-// exact gate through this, so it flags only genuine misses — never a chain reassoc legitimately
-// leaves alone (single const, already grouped, no var).
+// True if reassoc WOULD gather this chain: ≥1 var term, ≥2 scattered consts, not already grouped.
+// The fold-completeness oracle (flatten.das FoldResidualVisitor) mirrors the transform's exact gate
+// through this, so it flags only genuine misses.
 def public has_scattered_consts(that : ExprOp2?) : bool {
     if (that == null) return false
     var nv = 0
@@ -1268,17 +1178,9 @@ class private ReassocVisitor : AstVisitor {
 }
 
 def public fold_body(var func : FunctionPtr) : bool {
-    //! Post-infer fold over a flattened body: const-propagate single-def user locals
-    //! (accumulator chains → a constant), reassociate scattered constants in `+`/`-`/`*`
-    //! chains into one adjacent group (folded by the all-const arm / re-infer), collapse
-    //! `const ? a : b` to the live arm, fold algebraic / boolean identities and const
-    //! constructors, drop the side-effect-free `lhs = lhs` self-assigns a folded false-select
-    //! leaves behind, and strip redundant zero/default inits (`var acc = 0` → `var acc : int`). Call
-    //! AFTER re-inference (conditions must be `ExprConstBool`, types must be settled).
-    //! A SINGLE pass — multi-step cascades that route through re-inference (a folded
-    //! `0*s → 0` makes a local const, which the next re-infer settles so it can be
-    //! const-propagated, revealing a fresh identity) are driven to a fixpoint by the
-    //! caller's re-infer loop (see [flatten]'s patch and the [pixel_shader] patch).
+    //! Post-infer fold over a flattened body: const-propagate single-def locals, reassociate
+    //! scattered consts, collapse `const ? a : b`, fold algebraic/boolean identities + const
+    //! constructors, drop pure self-assigns, strip zero inits. SINGLE pass (caller's re-infer loops it).
     if (!(func.body is ExprBlock)) return false
     var changed = const_prop_locals(func.body as ExprBlock)
     // Reassociate BEFORE the fold — gather scattered consts into one adjacent group so the
@@ -1320,14 +1222,9 @@ def public fold_body(var func : FunctionPtr) : bool {
         }
         si --
     }
-    // Cleanup 2 — strip a redundant zero/default init (`var acc = 0` → `var acc : int`,
-    // the bare decl already zero-inits). DEFERRED to a converged pass: a const-folded
-    // scalar local (`let k = 0f`) must keep its init until const_prop_locals propagates
-    // it into the local's uses (`v + k → v + 0 → v`); nulling it earlier strands the use
-    // as a non-foldable read of a now-uninitialized local. So strip only when const-prop
-    // + fold + self-assign-drop made no other change this pass — by then const-prop has
-    // run to completion. Sets changed=true, so the caller re-infers after the strip
-    // (the strip mutates decls; the next quiet pass then converges).
+    // Cleanup 2 — strip a redundant zero/default init (`var acc = 0` → `var acc : int`). DEFERRED
+    // to a converged pass: a const-folded local must keep its init until const_prop_locals
+    // propagates it into uses; nulling it earlier strands the use. Sets changed → caller re-infers.
     if (!changed) {
         si = length(blk.list) - 1
         while (si >= 0) {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1487,14 +1487,27 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
 // The body is one basic block, so LVN is complete. Value-number pure subtrees by `describe()`, dedup
 // any computed >=2x into one shared let before its first use; uniform dups route to the preshader.
 
+// The base ExprVar of a store target, digging through index/field/swizzle/deref wrappers —
+// `G[i] = v` makes G's reads value-unstable exactly like `G = v` does.
+def private store_base(e : Expression const?) : ExpressionPtr {
+    if (e == null) return null
+    if (e is ExprAt) return store_base((e as ExprAt).subexpr)
+    if (e is ExprField) return store_base((e as ExprField).value)
+    if (e is ExprSwizzle) return store_base((e as ExprSwizzle).value)
+    if (e is ExprPtr2Ref) return store_base((e as ExprPtr2Ref).subexpr)
+    if (e is ExprRef2Value) return store_base((e as ExprRef2Value).subexpr)
+    return e is ExprVar ? unsafe(reinterpret<Expression? -const>(e)) : null
+}
+
 // Names reassigned somewhere in the block (live/loop masks `__flat_*`, any reassigned user `var`).
 // A subtree reading one of these is NOT value-stable — CSE must not share it (its value differs
 // per occurrence), so it is excluded from value numbering. Single-def `__ssa_*` / `let` are safe.
 class private MutCollect : AstVisitor {
     names : table<string>
     def override preVisitExprCopy(expr : ExprCopy?) : void {
-        if (expr.left is ExprVar) {
-            names |> insert("{(expr.left as ExprVar).name}")
+        let base = store_base(expr.left)
+        if (base != null) {
+            names |> insert("{(base as ExprVar).name}")
         }
     }
 }
@@ -1568,6 +1581,12 @@ class private CseTally : AstVisitor {
     sample : table<string; ExpressionPtr>
     mutableVars : table<string>
     def override preVisitExpression(expr : ExpressionPtr) : void {
+        // ExprRef2Value is describe-transparent: tallying wrapper AND wrappee double-counts every
+        // ref-rooted dup (an array/field read), so its count never drops below 2 after sharing and
+        // the round loop spins. Tally the wrappee only.
+        if (expr is ExprRef2Value) {
+            return
+        }
         if (psh_has_compute(expr) && !reads_mutable(expr, mutableVars)) {
             let k = "{describe(expr)}"
             counts[k] = (counts?[k] ?? 0) + 1
@@ -1654,6 +1673,26 @@ def private cse_replace_stmt(var s : ExpressionPtr; key, refName : string) {
     }
 }
 
+// Tally EXACTLY the regions cse_replace_stmt rewrites (let inits, copy RHS, return expr) — NOT the
+// whole statement. A dup counted in an unrewritable position (a store's lvalue) can never drop
+// below 2, so the round loop would re-pick the same key and spin to the guard.
+def private cse_tally_stmt(s : ExpressionPtr; a) {
+    if (s is ExprLet) {
+        for (lv in (s as ExprLet).variables) {
+            if (lv.init != null) {
+                visit(lv.init, a)
+            }
+        }
+    } elif (s is ExprCopy) {
+        visit((s as ExprCopy).right, a)
+    } elif (s is ExprReturn) {
+        let rt = s as ExprReturn
+        if (rt.subexpr != null) {
+            visit(rt.subexpr, a)
+        }
+    }
+}
+
 // Count leading contiguous `_preshader_*` lets — the preshader region. A CSE dup whose first use
 // falls inside it is uniform (Pass A already pulled every nontrivial uniform subtree out of the
 // body), so it routes to the preshader.
@@ -1670,9 +1709,10 @@ def private preshader_prefix_len(blk : ExprBlock?) : int {
     return k
 }
 
-def private cse_body(var blk : ExprBlock?) : bool {
+// `counter` is owned by the caller's cse/alias loop — fresh per-call numbering would collide a
+// second call's `_cse_0` with a surviving first-call `_cse_0` (error[30704] shadowing).
+def private cse_body(var blk : ExprBlock?; var counter : int&) : bool {
     var anyChange = false
-    var counter = 0
     var guard = 0
     // Reassigned vars are stable across rounds (cse only ever adds `let`s), so collect once.
     var mutableVars <- collect_mutable(blk)
@@ -1687,7 +1727,7 @@ def private cse_body(var blk : ExprBlock?) : bool {
             ct.collectSample = true
             ct.mutableVars := mutableVars
             make_visitor(*ct) $(a) {
-                visit(blk.list[i], a)
+                cse_tally_stmt(blk.list[i], a)
             }
             for (k in keys(ct.counts)) {
                 counts[k] = (counts?[k] ?? 0) + (ct.counts?[k] ?? 0)
@@ -1891,13 +1931,14 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
             break
         }
     }
-    // CSE residual: any pure subtree (no mutable read) still computed >=2x across the block.
+    // CSE residual: any pure subtree (no mutable read) still computed >=2x — tallying the same
+    // rewritable regions cse_body does, so an unrewritable lvalue dup is not a false positive.
     var counts : table<string; int>
     for (i in range(length(blk.list))) {
         var ct = new CseTally()
         ct.mutableVars := pe.mutableVars
         make_visitor(*ct) $(a) {
-            visit(blk.list[i], a)
+            cse_tally_stmt(blk.list[i], a)
         }
         for (k in keys(ct.counts)) {
             counts[k] = (counts?[k] ?? 0) + (ct.counts?[k] ?? 0)
@@ -1939,13 +1980,27 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
     if (!(func.body is ExprBlock)) return false
     var blk = func.body as ExprBlock
     var changed = extract_preshader(func, blk, barriers)
-    if (cse_body(blk)) {
+    // cse and alias enable each other (a collapsed alias canonicalises names, exposing fresh dups),
+    // so iterate the pair to a fixpoint. Converges in a couple of iterations now that the tally is
+    // occurrence-exact; an exhausted guard means an oscillation regression — warn, never hang.
+    var guard = 0
+    var cseCounter = 0
+    while (guard < 16) {
+        guard ++
+        var round = false
+        if (cse_body(blk, cseCounter)) {
+            round = true
+        }
+        if (eliminate_aliases(blk)) {
+            round = true
+        }
+        if (!round) {
+            break
+        }
         changed = true
     }
-    // Collapse every pure copy-let — CSE's `_cse_a = _cse_b` leftovers AND the unroll/fold's
-    // `p_0 = ro`. `eliminate_aliases` is general, so one post-CSE sweep clears them all.
-    if (eliminate_aliases(blk)) {
-        changed = true
+    if (guard >= 16) {
+        to_log(LOG_WARNING, "flatten: cse/alias loop guard exhausted in {func.name} (oscillation?)\n")
     }
     return changed
 }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1451,13 +1451,14 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
 // any computed >=2x into one shared let before its first use; uniform dups route to the preshader.
 
 class private CseTally : AstVisitor {
+    collectSample : bool        // clone a representative node per key (cse_body only; the oracle just counts)
     counts : table<string; int>
     sample : table<string; ExpressionPtr>
     def override preVisitExpression(expr : ExpressionPtr) : void {
         if (psh_has_compute(expr)) {
             let k = "{describe(expr)}"
             counts[k] = (counts?[k] ?? 0) + 1
-            if (!key_exists(sample, k)) {
+            if (collectSample && !key_exists(sample, k)) {
                 sample[k] = clone_expression(expr)
             }
         }
@@ -1553,6 +1554,7 @@ def private cse_body(var blk : ExprBlock?) : bool {
         var firstStmt : table<string; int>
         for (i in range(length(blk.list))) {
             var ct = new CseTally()
+            ct.collectSample = true
             make_visitor(*ct) $(a) {
                 visit(blk.list[i], a)
             }
@@ -1617,6 +1619,109 @@ def private cse_body(var blk : ExprBlock?) : bool {
         anyChange = true
     }
     return anyChange
+}
+
+// ===== Completeness oracle (test-framework facing) =====
+// Mirrors flatten.das FoldResidualVisitor: flags a uniform subtree still inline in the varying body
+// or a pure subtree computed >=2x un-shared. Empty ⇒ complete; checked over the COMPILED twin.
+
+// True if the subtree hides a maximal eligible-nontrivial node (one preshader extraction missed).
+def private pex_residual_expr(pe : PEX; barriers : table<string>; e : ExpressionPtr) : bool {
+    if (e == null) return false
+    if (psh_has_compute(e) && pex_eligible(pe, barriers, e)) return true
+    if (e is ExprOp1) return pex_residual_expr(pe, barriers, (e as ExprOp1).subexpr)
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        return pex_residual_expr(pe, barriers, o.left) || pex_residual_expr(pe, barriers, o.right)
+    }
+    if (e is ExprOp3) {
+        let o = e as ExprOp3
+        return pex_residual_expr(pe, barriers, o.subexpr) || pex_residual_expr(pe, barriers, o.left) || pex_residual_expr(pe, barriers, o.right)
+    }
+    if (e is ExprCall) {
+        for (a in (e as ExprCall).arguments) {
+            if (pex_residual_expr(pe, barriers, a)) return true
+        }
+        return false
+    }
+    if (e is ExprField) return pex_residual_expr(pe, barriers, (e as ExprField).value)
+    if (e is ExprSwizzle) return pex_residual_expr(pe, barriers, (e as ExprSwizzle).value)
+    if (e is ExprRef2Value) return pex_residual_expr(pe, barriers, (e as ExprRef2Value).subexpr)
+    if (e is ExprMakeStruct) {
+        var ms = e as ExprMakeStruct
+        for (si in range(length(ms.structs))) {
+            for (fld in *(ms.structs[si])) {
+                if (pex_residual_expr(pe, barriers, fld.value)) return true
+            }
+        }
+    }
+    return false
+}
+
+def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : array<string> {
+    var res : array<string>
+    if (func == null || func.body == null || !(func.body is ExprBlock)) return <- res
+    var blk = func.body as ExprBlock
+    // Post-optimize coloring: a `_preshader_*` let is uniform, every other local is varying.
+    var pe : PEX
+    for (a in func.arguments) {
+        pe.paramNames |> insert("{a.name}")
+    }
+    for (s in blk.list) {
+        if (s is ExprLet) {
+            for (lv in (s as ExprLet).variables) {
+                pe.localColor["{lv.name}"] = lv.name |> starts_with("_preshader_")
+            }
+        }
+    }
+    // Preshader residual: a uniform subtree still inline in the varying region (index >= prefix).
+    let prefix = preshader_prefix_len(blk)
+    for (i in range(length(blk.list))) {
+        if (i < prefix) {
+            continue
+        }
+        let s = blk.list[i]
+        var hit = false
+        if (s is ExprLet) {
+            for (lv in (s as ExprLet).variables) {
+                if (lv.init != null && pex_residual_expr(pe, barriers, lv.init)) {
+                    hit = true
+                }
+            }
+        } elif (s is ExprCopy) {
+            hit = pex_residual_expr(pe, barriers, (s as ExprCopy).right)
+        } elif (s is ExprReturn) {
+            hit = pex_residual_expr(pe, barriers, (s as ExprReturn).subexpr)
+        }
+        if (hit) {
+            res |> push("an un-extracted uniform subtree (preshader miss)")
+            break
+        }
+    }
+    // CSE residual: any pure subtree still computed >=2x across the block.
+    var counts : table<string; int>
+    for (i in range(length(blk.list))) {
+        var ct = new CseTally()
+        make_visitor(*ct) $(a) {
+            visit(blk.list[i], a)
+        }
+        for (k in keys(ct.counts)) {
+            counts[k] = (counts?[k] ?? 0) + (ct.counts?[k] ?? 0)
+        }
+        unsafe {
+            delete ct
+        }
+    }
+    for (k in keys(counts)) {
+        if ((counts?[k] ?? 0) >= 2) {
+            res |> push("a repeated subtree '{k}' (>=2x) not CSE'd")
+            break
+        }
+    }
+    delete pe.paramNames
+    delete pe.localColor
+    delete counts
+    return <- res
 }
 
 def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>) : bool {

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -149,6 +149,29 @@ which can expose a fresh identity (``x - 0``) for the next pass. A single pass i
 therefore not enough — the fold re-runs until nothing changes before the twin is
 handed to the backend.
 
+**Preshader extraction and CSE.** Once the fold fixpoint converges, a final
+optimize pass runs **once** on the canonical body — preshader extraction then
+common-subexpression elimination (``flatten_optimize``):
+
+* **Preshader extraction** colours each subtree *uniform* (it reads only material
+  props / shader globals + literals) or *varying* (it transitively reads a function
+  parameter). Every maximal uniform subtree is hoisted to a top-of-body
+  ``_preshader_N`` ``let``; a backend recognises the name prefix and routes the node
+  to the **per-draw preshader**, so uniform work the general compiler would re-run
+  per pixel runs once per draw. Sampler / procedural intrinsics (``tex2d``, ``noise``)
+  are *barriers* — they cannot run in a preshader, so a subtree containing one stays
+  per-pixel even when its inputs are uniform.
+* **CSE** value-numbers the (now-canonical) body by structural key and shares any
+  pure subtree computed twice or more into one ``let`` before its first use, so the
+  backend emits one graph node and *N* links instead of *N* recomputations. The
+  reassociation pass's canonical operand order is what makes the key match across
+  ``a + b`` and ``b + a``; a uniform repeat routes to the preshader
+  (``_preshader_cse_``), a varying one stays in the body (``_cse_``).
+
+Both passes are **value-exact** — they only hoist and share existing subtrees, never
+regroup or round — and both exclude any subtree that reads a **reassigned** variable
+(a live/loop mask or a written global), whose value is not stable across the body.
+
 Supported subset
 ================
 
@@ -259,10 +282,27 @@ Public API
     check — there is no compile-time flag; a missed fold is suboptimal, not an
     error, so it is validated by tests rather than gated in the macro.
 
+``flatten_optimize(var func, barriers : table<string>) : bool``
+    The post-fold optimize pass: hoist maximal uniform subtrees to per-draw
+    ``_preshader_`` lets, then CSE-dedup repeated subtrees. Run it **once** after
+    the ``flatten_fold`` fixpoint converges (and *not* before — reassociation runs
+    in the fold and would reorder a hoisted reference back into a fresh uniform
+    subtree). ``barriers`` is the backend's sampler / intrinsic call-name set
+    (``{ "tex2d", "noise" }``) — those stay per-pixel. ``[flatten]`` runs it
+    automatically; the ``[pixel_shader]`` backend runs it after its fold fixpoint.
+
+``flatten_opt_residuals(var func) : array<string>``
+    The optimize-completeness oracle (sibling of ``flatten_fold_residuals``):
+    walks a compiled twin and returns a description for each missed optimization —
+    a maximal uniform subtree still inline in the varying body, or a pure subtree
+    computed twice or more left un-shared. Empty means complete. Drives the same
+    ``tests/flatten/test_flatten_fold.das`` corpus and the ``flatten-fuzz``
+    strict mode.
+
 A backend's typical pipeline is therefore: ``flatten_function`` → re-infer →
-``flatten_fold`` → re-infer → walk the now-branchless, call-free twin and emit
-its dataflow graph (mapping ``?:`` to a *select* node and the bool masks to a
-0/1 selector).
+``flatten_fold`` (to a fixpoint) → re-infer → ``flatten_optimize`` → re-infer →
+walk the now-branchless, call-free twin and emit its dataflow graph (mapping
+``?:`` to a *select* node and the bool masks to a 0/1 selector).
 
 .. seealso::
 

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -168,7 +168,7 @@ common-subexpression elimination (``flatten_optimize``):
   ``a + b`` and ``b + a``; a uniform repeat routes to the preshader
   (``_preshader_cse_``), a varying one stays in the body (``_cse_``).
 * **Alias elimination** then collapses every pure ``let X = <bare var V>`` copy (with
-  ``V`` not reassigned) into direct references to ``V`` and drops the ``let``. CSE can
+  neither ``X`` nor ``V`` reassigned) into direct references to ``V`` and drops the ``let``. CSE can
   leave such copies (a later round rewrites an earlier ``_cse_`` let's whole RHS down to
   a bare var) and the unroll / fold can leave them (``let p_0 = ro``); both are
   pass-through graph nodes for nothing. CSE and alias elimination iterate to a fixpoint,
@@ -176,7 +176,8 @@ common-subexpression elimination (``flatten_optimize``):
 
 Both passes are **value-exact** — they only hoist and share existing subtrees, never
 regroup or round — and both exclude any subtree that reads a **reassigned** variable
-(a live/loop mask or a written global), whose value is not stable across the body.
+(a live/loop mask, a written global, or the base of an indexed store — ``G[i] = v``
+makes every ``G[...]`` read unstable), whose value is not stable across the body.
 
 Supported subset
 ================

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -167,6 +167,12 @@ common-subexpression elimination (``flatten_optimize``):
   reassociation pass's canonical operand order is what makes the key match across
   ``a + b`` and ``b + a``; a uniform repeat routes to the preshader
   (``_preshader_cse_``), a varying one stays in the body (``_cse_``).
+* **Alias elimination** then collapses every pure ``let X = <bare var V>`` copy (with
+  ``V`` not reassigned) into direct references to ``V`` and drops the ``let``. CSE can
+  leave such copies (a later round rewrites an earlier ``_cse_`` let's whole RHS down to
+  a bare var) and the unroll / fold can leave them (``let p_0 = ro``); both are
+  pass-through graph nodes for nothing. CSE and alias elimination iterate to a fixpoint,
+  since an eliminated alias can canonicalise a variable and expose a fresh dup.
 
 Both passes are **value-exact** — they only hoist and share existing subtrees, never
 regroup or round — and both exclude any subtree that reads a **reassigned** variable
@@ -284,7 +290,8 @@ Public API
 
 ``flatten_optimize(var func, barriers : table<string>) : bool``
     The post-fold optimize pass: hoist maximal uniform subtrees to per-draw
-    ``_preshader_`` lets, then CSE-dedup repeated subtrees. Run it **once** after
+    ``_preshader_`` lets, CSE-dedup repeated subtrees, then collapse pure-alias
+    ``let`` copies — CSE and alias elimination iterating to a fixpoint. Run it **once** after
     the ``flatten_fold`` fixpoint converges (and *not* before — reassociation runs
     in the fold and would reorder a hoisted reference back into a fresh uniform
     subtree). ``barriers`` is the backend's sampler / intrinsic call-name set
@@ -294,8 +301,9 @@ Public API
 ``flatten_opt_residuals(var func) : array<string>``
     The optimize-completeness oracle (sibling of ``flatten_fold_residuals``):
     walks a compiled twin and returns a description for each missed optimization —
-    a maximal uniform subtree still inline in the varying body, or a pure subtree
-    computed twice or more left un-shared. Empty means complete. Drives the same
+    a maximal uniform subtree still inline in the varying body, a pure subtree
+    computed twice or more left un-shared, or a pure-alias ``let`` copy left
+    uncollapsed. Empty means complete. Drives the same
     ``tests/flatten/test_flatten_fold.das`` corpus and the ``flatten-fuzz``
     strict mode.
 

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1597,13 +1597,14 @@ class PixelShaderMacro : AstFunctionAnnotation {
             // folding; mark "folded" (terminal) only once it reports no further change.
             // Mirrors daslib/flatten's own patch loop (daScript #3048) — without it, shaders
             // leave const-foldable residuals the branchless backend then has to emit.
-            if (flatten_fold(func)) {
-                astChanged = true
-                return true
-            }
-            // Fold converged → hoist uniform subtrees to per-draw `_preshader_` lets + CSE-dedup,
-            // then re-infer once to type them. tex2d/noise stay per-pixel (can't sample in a preshader).
+            // Fold fixpoint, THEN optimize once — both gated on !optimized so fold/reassoc never runs
+            // after optimize (else reassoc reorders a hoisted ref into a fresh un-extracted uniform
+            // subtree, e.g. `uv - _preshader` → `-_preshader + uv`). tex2d/noise stay per-pixel.
             if (!shader_annotation_arg(func, "optimized")) {
+                if (flatten_fold(func)) {
+                    astChanged = true
+                    return true
+                }
                 set_shader_annotation_flag(func, "optimized")
                 if (flatten_optimize(func, SHADER_BARRIERS)) {
                     astChanged = true

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -81,6 +81,12 @@ let HINT_WHITELIST : table<string> <- {
     "float2", "float3", "float4", "int2", "int3", "int4"
 }
 
+// Surviving intrinsics that can't run in the per-draw preshader (texture sample / procedural
+// noise). flatten_optimize keeps these per-pixel; everything else uniform is hoisted.
+let SHADER_BARRIERS : table<string> <- {
+    "tex2d", "noise"
+}
+
 let UV = "uv";
 let GTime = "gTime";
 let WorldPos = "worldPos";
@@ -1594,6 +1600,15 @@ class PixelShaderMacro : AstFunctionAnnotation {
             if (flatten_fold(func)) {
                 astChanged = true
                 return true
+            }
+            // Fold converged → hoist uniform subtrees to per-draw `_preshader_` lets + CSE-dedup,
+            // then re-infer once to type them. tex2d/noise stay per-pixel (can't sample in a preshader).
+            if (!shader_annotation_arg(func, "optimized")) {
+                set_shader_annotation_flag(func, "optimized")
+                if (flatten_optimize(func, SHADER_BARRIERS)) {
+                    astChanged = true
+                    return true
+                }
             }
             set_shader_annotation_flag(func, "folded")
             return true

--- a/examples/flatten/capability/cap_cse.shader
+++ b/examples/flatten/capability/cap_cse.shader
@@ -1,0 +1,26 @@
+require engine.render.shader_dsl
+
+// Capability demo: common-subexpression elimination. `dot(c, LUMA)` is spelled TWICE (in `a` and
+// `b`); the general compiler and the backend don't CSE, so without flatten this emits TWO dot
+// nodes. flatten value-numbers the body and shares the repeat into one `_cse_` let, so the graph
+// carries exactly ONE dot node feeding both consumers.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+[pixel_shader]
+def cap_cse(inp : PbrInput) : PbrOutput {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let a = dot(c, float3(0.299, 0.587, 0.114)) * 2.0
+    let b = dot(c, float3(0.299, 0.587, 0.114)) + 0.1
+    let result = float3(a, b, a)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/cap_preshader.shader
+++ b/examples/flatten/capability/cap_preshader.shader
@@ -1,0 +1,27 @@
+require engine.render.shader_dsl
+
+// Capability demo: preshader extraction. `factor` depends only on material props (brightness,
+// tint) and literals — it is UNIFORM, identical for every pixel of a draw. The general compiler
+// evaluates it per-pixel; flatten hoists the whole subtree to a top-of-body `_preshader_` let the
+// backend routes to the per-draw preshader, so the per-pixel graph carries only `base * factor`.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    brightness = 1.5
+    tint = float3(0.3, 0.6, 0.1)
+}
+
+[pixel_shader]
+def cap_preshader(inp : PbrInput) : PbrOutput {
+    let base = tex2d(albedo_texture, inp.uv).xyz
+    let factor = brightness * 2.0 + dot(tint, float3(0.299, 0.587, 0.114))
+    let result = base * factor
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -53,6 +53,14 @@
 #  13. cap_fold_reassoc.shader (scattered const chain `0.3 + gain + 0.4`) -> `gain + 0.7`.
 #      The typer can't fold non-adjacent consts and never reassociates; flatten does (fast-math),
 #      gathering them so exactly 1 add survives (not the 2 the source spells), + 1 base*k mul.
+#
+#  14. cap_preshader.shader (uniform `factor` = props-only) -> hoisted to a per-draw `_preshader_`
+#      let. Uniform work the general compiler runs per-pixel; flatten routes it to the preshader so
+#      the per-pixel graph is only `base * factor`. Asserted on the --das dump (per-draw routing is
+#      not a node-count change).
+#
+#  15. cap_cse.shader (repeated `dot(c, LUMA)`) -> one shared node. Neither the compiler nor the
+#      backend CSEs; flatten value-numbers the body and shares the repeat, so 1 dot node (not 2).
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -258,6 +266,38 @@ if [[ "$errs" -eq 0 && "$adds" -eq 1 && "$muls" -eq 1 ]]; then
     echo "   ok — compiles ($nodes nodes), 1 add (gain+0.7, consts gathered), 1 mul (base*k)"
 else
     echo "   FAIL — errors=$errs adds=$adds muls=$muls (expected 1 add, 1 mul)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "14. cap_preshader.shader (uniform factor -> hoisted to a per-draw _preshader_ let)"
+# `factor` reads only props (brightness/tint) + literals, so it is uniform: identical every pixel.
+# flatten hoists the whole subtree to a `_preshader_` let the backend routes to the per-draw
+# preshader, leaving only `base * factor` per-pixel. Asserted on the --das dump (preshader routing
+# is per-draw vs per-pixel, not a node-count change).
+out="$(FLATTEN_DUMP_DAS=1 compile "$here/cap_preshader.shader")"
+pre="$(echo "$out" | grep -c 'let _preshader_')"
+errs="$(echo "$out" | grep -ci error)"
+if [[ "$errs" -eq 0 && "$pre" -ge 1 ]]; then
+    echo "   ok — $pre _preshader_ let(s) hoisted; per-pixel body is only base * factor"
+else
+    echo "   FAIL — errors=$errs preshader_lets=$pre (expected >=1)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "15. cap_cse.shader (repeated dot(c,LUMA) -> one shared node)"
+out="$(compile "$here/cap_cse.shader")"
+nodes="$(echo "$out" | grep -c '^node ')"
+dots="$(echo "$out" | grep -c 'dot')"
+errs="$(echo "$out" | grep -ci error)"
+# `dot(c, LUMA)` is spelled twice; neither the compiler nor the backend CSEs, so without flatten
+# this is 2 dot nodes. flatten value-numbers the body and shares the repeat into one `_cse_` let,
+# so exactly ONE dot node reaches the backend.
+if [[ "$errs" -eq 0 && "$dots" -eq 1 ]]; then
+    echo "   ok — compiles ($nodes nodes), 1 dot node (the repeat was CSE'd)"
+else
+    echo "   FAIL — errors=$errs dots=$dots (expected 1)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/examples/flatten/shaders/features/cse_taps.shader
+++ b/examples/flatten/shaders/features/cse_taps.shader
@@ -1,0 +1,31 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+// Feature fixture for CSE. A fresnel-like rim term `pow(1.0 - dot(n, v), 5.0)` is spelled THREE
+// times — once per output channel. It is varying (it reads the surface normal + view dir), so it
+// is not a preshader candidate, but neither the general compiler nor the backend dedups it: without
+// flatten the graph carries three identical pow/dot/sub chains. flatten value-numbers the body and
+// shares the repeat into one `_cse_` let feeding all three channels. Run `./run.sh --das cse_taps`
+// to see the single shared let.
+[pixel_shader]
+def cse_taps(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let n = inp.worldNormal
+    let v = inp.viewDir
+    let result = float3(
+        pow(1.0 - dot(n, v), 5.0) * c.x,
+        pow(1.0 - dot(n, v), 5.0) * c.y,
+        pow(1.0 - dot(n, v), 5.0) + c.z
+    )
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/features/preshader_grade.shader
+++ b/examples/flatten/shaders/features/preshader_grade.shader
@@ -1,0 +1,34 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    exposure = 1.2
+    contrast = 1.1
+    whiteBalance = float3(1.0, 0.95, 0.9)
+}
+
+// Feature fixture for preshader extraction. A small colour grade whose tuning is computed entirely
+// from material props (exposure / contrast / whiteBalance) — UNIFORM, identical for every pixel —
+// but written inline in a per-pixel chain:
+//   • `gain  = pow(2.0, exposure - 1.0)`            (exposure stop -> linear gain)
+//   • `pivot = 0.5 * contrast + 0.25 * (1.0 - contrast)`
+// The general compiler evaluates both per-pixel (the props are runtime); flatten colours them
+// uniform and hoists each to a top-of-body `_preshader_` let the backend routes to the per-draw
+// preshader, leaving only the `c`-dependent arithmetic per-pixel. Run `./run.sh --das
+// preshader_grade` to see the `_preshader_` group gathered on top.
+[pixel_shader]
+def preshader_grade(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let gain = pow(2.0, exposure - 1.0)
+    let pivot = 0.5 * contrast + 0.25 * (1.0 - contrast)
+    let graded = (c * gain - float3(pivot)) * contrast + float3(pivot)
+    let result = graded * whiteBalance
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -61,6 +61,8 @@ def private check_unit(t : T?; proj, path : string) : int {
                         checked ++
                         let r <- flatten_fold_residuals(func)
                         t |> equal(length(r), 0, "{base_name(path)}::{func.name}: {r}")
+                        let optr <- flatten_opt_residuals(func)
+                        t |> equal(length(optr), 0, "{base_name(path)}::{func.name} (opt): {optr}")
                     }
                 }
             }
@@ -79,6 +81,10 @@ def test_flatten_fold(t : T?) {
     t |> run("const-identity corpus folds clean (test_flatten_const.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_const.das")
         t |> success(n >= 70, "expected >=70 twins, checked {n}")
+    }
+    t |> run("optimize corpus folds clean (test_flatten_opt.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_opt.das")
+        t |> success(n >= 7, "expected >=7 twins, checked {n}")
     }
     t |> run("every example shader folds clean (pixel_shader path)") @(t : T?) {
         let proj = "{root}/examples/flatten/flatten_shaders.das_project"

--- a/tests/flatten/test_flatten_opt.das
+++ b/tests/flatten/test_flatten_opt.das
@@ -1,0 +1,122 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Differential net for the flatten OPTIMIZE arc (preshader extraction + CSE).
+//! Both passes are VALUE-EXACT — they only hoist and dedup pure subtrees, never
+//! regroup or round — so every twin compares with exact `equal` (unlike the
+//! reassoc arc, which reserves `equal_approx`). The FIRED proof (a `_preshader_`
+//! let on top, a shared `_cse_` let) lives in `no_aot/test_flatten_fold.das`
+//! (empty `flatten_opt_residuals`) and the cap_preshader / cap_cse node-count
+//! shaders; here we only assert the optimization preserved the result.
+
+// Module globals are UNIFORM (preshader-eligible); function params are VARYING.
+var G_GAIN = 2.5
+var G_BIAS = -0.75
+var G_TINT = float3(0.3, 0.59, 0.11)
+
+// ----- preshader extraction: whole-uniform let -----
+[flatten]
+def p_whole(x : float) : float {
+    let u = G_GAIN * 2.0 + 1.0
+    return x * u + u
+}
+
+// ----- preshader: a uniform subtree BURIED under a varying parent -----
+[flatten]
+def p_buried(x : float3) : float3 {
+    return x * (dot(G_TINT, float3(1.0, 1.0, 1.0)) + G_GAIN)
+}
+
+// ----- preshader: uniform local feeding another uniform local (topological order) -----
+[flatten]
+def p_chain(x : float) : float {
+    let a = G_GAIN * 2.0
+    let b = a + G_BIAS
+    return x * b
+}
+
+// ----- preshader: vector-typed uniform -----
+[flatten]
+def p_vec(x : float3) : float3 {
+    let tint = G_TINT * G_GAIN + float3(G_BIAS, G_BIAS, G_BIAS)
+    return x + tint
+}
+
+// ----- CSE: a varying subtree computed twice -----
+[flatten]
+def c_var(x : float) : float {
+    let a = (x * x + 1.0) * 2.0
+    let b = (x * x + 1.0) * 3.0
+    return a + b
+}
+
+// ----- CSE: commutative-reordered dup must match (reassoc canonical key) -----
+[flatten]
+def c_commute(x : float; y : float) : float {
+    let a = x * y + 1.0
+    let b = y * x + 2.0
+    return a + b
+}
+
+// ----- CSE: a uniform dup → shared let in the preshader region -----
+[flatten]
+def c_uni(x : float) : float {
+    let p = G_GAIN * G_GAIN + 1.0
+    let q = (G_GAIN * G_GAIN + 1.0) * 2.0
+    return x * p + x * q
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def cmp3f(t : T?; a, b : float3) {
+    t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
+}
+
+[test]
+def test_flatten_opt(t : T?) {
+    t |> run("preshader: whole-uniform let -> _preshader_") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(p_whole_flat(v), p_whole(v))
+        }
+    }
+    t |> run("preshader: buried uniform subtree in return") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, p_buried_flat(float3(v, v * 0.5, -v)), p_buried(float3(v, v * 0.5, -v)))
+        }
+    }
+    t |> run("preshader: uniform local chain (topological order)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(p_chain_flat(v), p_chain(v))
+        }
+    }
+    t |> run("preshader: vector-typed uniform") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, p_vec_flat(float3(v, -v, v * 2.0)), p_vec(float3(v, -v, v * 2.0)))
+        }
+    }
+    t |> run("CSE: varying dup -> _cse_") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(c_var_flat(v), c_var(v))
+        }
+    }
+    t |> run("CSE: commutative-reordered dup matches") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(c_commute_flat(v, v * 0.5 - 1.0), c_commute(v, v * 0.5 - 1.0))
+        }
+    }
+    t |> run("CSE: uniform dup -> preshader region") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(c_uni_flat(v), c_uni(v))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_opt.das
+++ b/tests/flatten/test_flatten_opt.das
@@ -18,6 +18,11 @@ require math
 var G_GAIN = 2.5
 var G_BIAS = -0.75
 var G_TINT = float3(0.3, 0.59, 0.11)
+var G_SEED = 5
+
+def gi(p : int) : int {
+    return p * 3 + 1
+}
 
 // ----- preshader extraction: whole-uniform let -----
 [flatten]
@@ -71,6 +76,27 @@ def c_uni(x : float) : float {
     return x * p + x * q
 }
 
+// ----- alias elimination: a pure `let b = a` copy must collapse (b -> a), value unchanged -----
+[flatten]
+def c_alias(x : float) : float {
+    let a = x * x + 1.0
+    let b = a
+    return a * 2.0 + b * 3.0
+}
+
+// ----- value coverage: a uniform helper call reused inside an unrolled loop. The inliner can emit
+// a reassigned `var __flat_loc = _preshader` slot; alias elimination must leave it alone (collapsing
+// a reassigned var onto its const source is a compile error — the deterministic repro is flatten-fuzz
+// seed 3, fixed by the X-mutability guard in eliminate_aliases). -----
+[flatten]
+def c_loop_uni(x : int) : int {
+    var acc = 0
+    for (_i in range(2)) {
+        acc += gi(G_SEED) + x
+    }
+    return acc
+}
+
 var GRID : array<float>
 
 [init]
@@ -117,6 +143,17 @@ def test_flatten_opt(t : T?) {
     t |> run("CSE: uniform dup -> preshader region") @(t : T?) {
         for (v in GRID) {
             t |> equal(c_uni_flat(v), c_uni(v))
+        }
+    }
+    t |> run("alias: pure copy let collapses") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(c_alias_flat(v), c_alias(v))
+        }
+    }
+    t |> run("alias: reassigned var from uniform is NOT collapsed") @(t : T?) {
+        for (v in GRID) {
+            let n = int(v)
+            t |> equal(c_loop_uni_flat(n), c_loop_uni(n))
         }
     }
 }

--- a/tests/flatten/test_flatten_opt.das
+++ b/tests/flatten/test_flatten_opt.das
@@ -108,6 +108,18 @@ def c_at(a : int; b : int) : float {
     return PAL[(a * 3 + b) & 3] + PAL[(a * 3 + b) & 3]
 }
 
+var G_BUF : int[8]
+
+// ----- indexed STORE marks the base var mutable: G_BUF[...] reads must NOT be CSE-shared across
+// the stores (a hoisted pre-store read returns the stale value). The ExprAt lvalue hides the base
+// from a naive `ExprCopy.left is ExprVar` check. -----
+[flatten]
+def c_store(a : int; b : int) : int {
+    G_BUF[(a * 3 + b) & 7] = a * 2
+    G_BUF[(a * 3 + b) & 7] ++
+    return G_BUF[(a * 3 + b) & 7]
+}
+
 var GRID : array<float>
 
 [init]
@@ -172,6 +184,21 @@ def test_flatten_opt(t : T?) {
         for (v in GRID) {
             let n = int(v)
             t |> equal(c_at_flat(n, n + 1), c_at(n, n + 1))
+        }
+    }
+    t |> run("CSE: indexed-store base is mutable (no read shared across stores)") @(t : T?) {
+        for (v in GRID) {
+            let n = int(v)
+            // Reset the buffer before EACH twin: a stale shared read would otherwise pick up the
+            // previous twin's result and mask the bug.
+            for (i in range(8)) {
+                G_BUF[i] = 0
+            }
+            let want = c_store(n, n + 1)
+            for (i in range(8)) {
+                G_BUF[i] = 0
+            }
+            t |> equal(c_store_flat(n, n + 1), want)
         }
     }
 }

--- a/tests/flatten/test_flatten_opt.das
+++ b/tests/flatten/test_flatten_opt.das
@@ -97,11 +97,23 @@ def c_loop_uni(x : int) : int {
     return acc
 }
 
+var PAL : array<float>
+
+// ----- CSE under a wrapper node: the repeated index `(a*3+b)&3` sits under two ExprAt nodes.
+// flatten preserves ExprAt/ExprCast/ExprMakeTuple/ExprPtr2Ref (see lift_expr), and the opt-pass
+// recursions must descend through them — else the dup is tallied (universal visitor) but never
+// replaced (manual dispatch), leaving a CSE residual and spinning the round loop. -----
+[flatten]
+def c_at(a : int; b : int) : float {
+    return PAL[(a * 3 + b) & 3] + PAL[(a * 3 + b) & 3]
+}
+
 var GRID : array<float>
 
 [init]
 def fill_grid {
     GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+    PAL <- [1.0, 2.0, 3.0, 4.0]
 }
 
 def cmp3f(t : T?; a, b : float3) {
@@ -154,6 +166,12 @@ def test_flatten_opt(t : T?) {
         for (v in GRID) {
             let n = int(v)
             t |> equal(c_loop_uni_flat(n), c_loop_uni(n))
+        }
+    }
+    t |> run("CSE: repeated index under ExprAt is deduped") @(t : T?) {
+        for (v in GRID) {
+            let n = int(v)
+            t |> equal(c_at_flat(n, n + 1), c_at(n, n + 1))
         }
     }
 }

--- a/utils/flatten-fuzz/main.das
+++ b/utils/flatten-fuzz/main.das
@@ -339,6 +339,7 @@ def make_helper(var g : Gen&) : string {
     let savedNo = g.noHelpers
     g.noHelpers = true
     var hscope <- [Var(name = "p0", mutable = false), Var(name = "p1", mutable = false)]   // nolint:LINT003 -- gen_branch mutates scope by-ref
+    add_globals(hscope)
     let br = gen_branch(g, hscope, min(2, g.cfg.maxDepth), 0, "    ", false)
     let fin = gen_expr(g, hscope, 2)
     g.noHelpers = savedNo
@@ -396,6 +397,7 @@ def gen_stmt(var g : Gen&; var scope : array<Var>; depth, loopDepth : int; inden
 
 def gen_function_body(var g : Gen&) : string {
     var scope <- [Var(name = "a", mutable = false), Var(name = "b", mutable = false), Var(name = "c", mutable = false)]
+    add_globals(scope)
     let br = gen_branch(g, scope, g.cfg.maxDepth, 0, "    ", false)
     let fin = gen_expr(g, scope, 3)
     return "{br._0}    return {fin}\n"
@@ -436,6 +438,21 @@ def gen_unit(var g : Gen&; idx : int) : string {
 // (non-convergence / oscillation), not just flatten lowering bugs.
 var g_log_infer = false
 
+// Set once in main (int domain only). When true, generated units reference read-only module
+// globals — UNIFORM leaves that exercise preshader extraction (the twin hoists globals-only
+// subtrees to `_preshader_` lets). Read-only, so they never write shared state across the
+// orig/flat differential calls. Bool domain skips them (int globals don't type in a bool expr).
+var g_use_globals = false
+let G_DEFS = "var G0 = 7\nvar G1 = -3\nvar G2 = 11\n\n"
+
+def add_globals(var scope : array<Var>) {
+    if (g_use_globals) {
+        scope |> push(Var(name = "G0", mutable = false))
+        scope |> push(Var(name = "G1", mutable = false))
+        scope |> push(Var(name = "G2", mutable = false))
+    }
+}
+
 // Tally of post-flatten fold residuals seen across all batches in --strict-fold mode.
 // Non-fatal (see run_batch) — reported as a summary line at the end.
 var g_residual_warnings = 0
@@ -456,6 +473,9 @@ def build_file(units : array<string>) : string {
             write(w, "options log_infer_passes = true\n")
         }
         write(w, "require daslib/flatten\n\n")
+        if (g_use_globals) {
+            write(w, G_DEFS)
+        }
         for (u in units) {
             write(w, u)
         }
@@ -585,7 +605,8 @@ def run_batch(units : array<string>; inputs : array<int3>; seedArg : int; strict
                             if (func.body == null || func.flags.builtIn || !(func.name |> ends_with("_flat"))) {
                                 return
                             }
-                            let res <- flatten_fold_residuals(func)
+                            var res <- flatten_fold_residuals(func)
+                            res |> push_clone_from(flatten_opt_residuals(func))
                             if (!empty(res)) {
                                 g_residual_warnings ++
                                 to_log(LOG_WARNING, "RESIDUAL (post-flatten, non-fatal) {func.name}: {res}\n")
@@ -720,6 +741,7 @@ def main : int {
     let batches = cfg_args.batches > 0 ? cfg_args.batches : 1
     let strict = cfg_args.strict_fold
     g_log_infer = cfg_args.log_infer
+    g_use_globals = !cfg_args.bool_domain
     g_tmp_suffix = "{ref_time_ticks()}"
     let cfg = GenCfg(maxDepth = depth, maxStmts = 4, literalPct = 40, constBias = strict ? 55 : 0, boolDomain = cfg_args.bool_domain)
     let domain = cfg_args.bool_domain ? "bool(exhaustive 2^3)" : "int(sampled ~{nInputs})"


### PR DESCRIPTION
## What

`[flatten]` Optimization 2: a post-fold **optimize pass** on the converged shader twin that
hoists uniform work to the per-draw preshader, dedups repeated subtrees (CSE), and collapses the
pure-alias copy-lets those passes leave behind. Runs once after the fold fixpoint
(`flatten_optimize`), then the macro re-infers to type the new lets.

The flattened twin carries arithmetic the typer won't touch (conservative re float rounding) and
the backend can't fold; the unroll *manufactures* redundancy; and uniform work — anything computed
purely from material props / shader globals — is evaluated **per-pixel** when it could run once per
draw. flatten already assumes fast-math (every consumer is a GPU shader-graph backend), so it can
hoist/dedup where the general compiler can't.

Three sub-passes, all pure-AST on the one flat `ExprBlock`:

- **Preshader extraction** — colour each subtree *uniform* (reads only globals + literals) or
  *varying* (transitively reads a function parameter). Every maximal uniform subtree is hoisted to a
  top-of-body `_preshader_N` `let`; the backend keys on the name prefix and routes the node to the
  per-draw preshader. Sampler / procedural intrinsics (`tex2d`, `noise`) are *barriers* — a subtree
  containing one stays per-pixel even if its inputs are uniform.
- **CSE** (local value numbering) — value-number every pure subtree by structural `describe()` key
  and share any computed ≥2× into one `let` before its first use. The reassociation pass (Opt 1,
  #3064) canonicalised commutative operand order, so the key matches across `a + b` and `b + a`. A
  uniform repeat routes to the preshader (`_preshader_cse_`), a varying one stays in the body (`_cse_`).
- **Alias elimination** — collapse every pure `let X = V` copy (V a bare var) into direct refs to V
  and drop the let. CSE can leave `let _cse_a = _cse_b` (a later round rewrites an earlier `_cse_` let's
  whole RHS down to a bare var); the unroll/fold leaves `let p_0 = ro`. Both are pass-through graph
  nodes for nothing. **Correctness guard:** skip when the alias var X (or source V) is reassigned — a
  reassigned `var X = bareVar` (e.g. an inlined helper-result slot reused across unrolled loop
  copies) is a write target, and renaming it would rewrite its stores onto the const source.

All three are **value-exact** (hoist/share existing subtrees, never regroup or round) and all exclude
any subtree reading a **reassigned** variable (live/loop mask or written global), whose value is not
stable across the body. A completeness oracle `flatten_opt_residuals` (sibling of
`flatten_fold_residuals`) flags an un-extracted uniform subtree, an un-shared ≥2× repeat, or an
uncollapsed pure alias — driving the no_aot residual corpus and the fuzzer's strict mode.

## Examples (real EdenSpark shaders, `run.sh --das`)

### electric_3d — preshader split + two varying CSEs

Uniform time/light setup hoisted to `_preshader_0..5`; `worldPos*noiseScale` shared across both
noise taps (`_cse_0`), and `(n1*n2)*2` shared across `bolt`+`glow` (`_cse_1`):

```
def electric_3d (inp:PbrInput const) : PbrOutput
 {
	let _preshader_0:float const = (g_Time * speed);
	let _preshader_1:float3 const = float3(_preshader_0,0,0);
	let _preshader_2:float3 const = float3(0,_preshader_0,0);
	let _preshader_3:float const = ((sin(_preshader_0 * 3f) * 0.5f) + 0.5f);
	let _preshader_4:float const = saturate(g_LightDirection.y);
	let _preshader_5:float const = lerp(0.5f,2.5f,_preshader_4);
	let _cse_0:float3 const = (inp.worldPos * noiseScale);
	let n1:float const = noise(_cse_0 + _preshader_1);
	let n2:float const = noise((_cse_0 * 2f) - _preshader_2);
	let _cse_1:float const = ((n1 * n2) * 2f);
	let bolt:float const = step(0.75f,_cse_1);
	let glow:float const = smooth_step(0.5f,0.75f,_cse_1);
	return struct&lt;PbrOutput&gt;(albedo = float3(0f,0f,0f), emission = (((bolt * coreColor) * _preshader_3) + (electricColor * glow)), emissionStrength = ((((glow * 0.5f) + bolt) * _preshader_3) * _preshader_5), metalness = 0f, roughness = 1f, ao = 1f);
}
```

### cel_shading — shared `normalize(worldNormal)`

`normalize(lightDir)` and the daylight term are uniform (`_preshader_0..2`); `normalize(inp.worldNormal)`
is varying but spelled twice (diffuse `nDotL` + specular `nDotH`), so it shares into one `_cse_0`:

```
def cel_shading (inp:PbrInput const) : PbrOutput
 {
	let _preshader_0:float3 const = normalize(lightDir);
	let _preshader_1:float const = saturate(g_LightDirection.y);
	let _preshader_2:float const = lerp(0.1f,0.8f,_preshader_1);
	let _cse_0:float3 const = normalize(inp.worldNormal);
	let nDotL:float const = saturate(dot(_cse_0,_preshader_0));
	let stepped:float const = (floor(bands * nDotL) / bands);
	let cel:float3 const = lerp(shadowColor,baseColor,stepped);
	let h:float3 const = normalize(_preshader_0 + normalize(inp.viewDir));
	let nDotH:float const = saturate(dot(_cse_0,h));
	let spec:float const = step(specularThreshold,pow(nDotH,specularPower));
	let f:float const = fresnel(outlineSharpness,inp.worldNormal,inp.viewDir);
	let outline:float const = step(outlineThreshold,f);
	let noOutline:float const = (1f - outline);
	return struct&lt;PbrOutput&gt;(albedo = float3(0f,0f,0f), emission = (lerp(cel,specularColor,spec) * noOutline), emissionStrength = (noOutline * _preshader_2), metalness = 0f, roughness = 1f, ao = 1f);
}
```

## Commits

- `flatten: enable _comment_hygiene + trim excessive comments` — comment-only, no codegen impact (enables `options _comment_hygiene` in flatten.das/flatten_opt.das and trims the blocks it flags).
- preshader extraction + CSE core, completeness oracle + differential twins + fold-order fix, capability + feature shaders, reassigned-var exclusion (correctness), docs, fuzzer (read-only module globals + opt-residual oracle), pure-alias elimination.

## Tests

- **Differential** (`tests/flatten/test_flatten_opt.das`) — value-exact `equal` twins: whole/buried/chained/vector preshader, varying & uniform & commutative CSE, pure-alias + reassigned-var-from-uniform.
- **Completeness** (`tests/flatten/no_aot/test_flatten_fold.das`) — `flatten_opt_residuals` empty over the twins + every example shader.
- **Capability** (`examples/flatten/capability/`) — `cap_preshader` (≥1 `_preshader_` let, per-pixel body is only the genuine multiply) + `cap_cse` (one shared `dot` node) node-count checks.
- **Feature eyeball** (`examples/flatten/shaders/features/`) — `preshader_grade`, `cse_taps`.
- **Fuzzer** (`utils/flatten-fuzz`) — read-only module globals exercise preshader; `--strict` flags opt residuals.

## Verification

interp / AOT / JIT on `tests/flatten` green; `run.sh` 68/0; `capability/check.sh` 15/15; no_aot oracle
clean; flatten-fuzz 40 value + 40 strict batches PASS (value-clean, zero alias residuals). Sphinx `-W`
clean. No `LLVM_JIT_CODEGEN_VERSION` bump (source-level daslib macro work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)