### PR TITLE
site: single search box — declutter top bar + drop native RTD docs search

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -27,11 +27,9 @@
     {%- endif %}
   {%- endif %}
 
-  {# DocSearch (Algolia) — sits alongside the native RTD search box below.
-     CSS/JS wired via conf.py html_css_files / html_js_files; _static/docsearch.js
-     targets this container. #}
+  {# DocSearch (Algolia) — the single search box for the docs (replaced the
+     native RTD search). CSS/JS wired via conf.py html_css_files / html_js_files;
+     _static/docsearch.js targets this container. #}
   <div id="docsearch"></div>
-
-  {%- include "searchbox.html" %}
 
 {%- endblock %}

--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -48,12 +48,10 @@
                 </div>
             </div>
             <div class="forge-nav__right">
-                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>
-                <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
-                <a class="forge-nav__install" href="{{root}}index.html#install">install</a>
+                <div id="docsearch"></div>
             </div>
         </div>
     </nav>

--- a/site/daspkg.html
+++ b/site/daspkg.html
@@ -49,12 +49,10 @@
                 </div>
             </div>
             <div class="forge-nav__right">
-                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>
-                <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
-                <a class="forge-nav__install" href="index.html#install">install</a>
+                <div id="docsearch"></div>
             </div>
         </div>
     </nav>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -43,12 +43,10 @@
                 </div>
             </div>
             <div class="forge-nav__right">
-                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>
-                <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
-                <a class="forge-nav__install" href="index.html#install">install</a>
+                <div id="docsearch"></div>
             </div>
         </div>
     </nav>

--- a/site/files/forge.css
+++ b/site/files/forge.css
@@ -122,20 +122,6 @@ button { font: inherit; border: 0; background: none; color: inherit; cursor: poi
     font-size: 12.5px;
 }
 .forge-nav__version { color: var(--fg-faint); }
-.forge-nav__github {
-    color: var(--fg);
-    padding: 6px 12px;
-    border: 1px solid var(--rule);
-    border-radius: 4px;
-}
-.forge-nav__install {
-    color: var(--bg);
-    background: var(--amber);
-    padding: 6px 12px;
-    border-radius: 4px;
-    font-weight: 600;
-}
-.forge-nav__install:hover { color: var(--bg); background: #f4b04a; }
 
 /* "N NEW" blog chip injected by files/blog-counter.js */
 .forge-nav__links a.forge-blog-link {

--- a/site/index.html
+++ b/site/index.html
@@ -60,12 +60,10 @@
                 </div>
             </div>
             <div class="forge-nav__right">
-                <div id="docsearch"></div>
                 <button class="forge-nav__burger" type="button" aria-label="menu"
                     onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
                 <span class="forge-nav__version">v0.6.3</span>
-                <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
-                <a class="forge-nav__install" href="#install">install</a>
+                <div id="docsearch"></div>
             </div>
         </div>
     </nav>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -49,12 +49,10 @@
             </div>
         </div>
         <div class="forge-nav__right">
-            <div id="docsearch"></div>
             <button class="forge-nav__burger" type="button" aria-label="menu"
                 onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
             <span class="forge-nav__version">playground</span>
-            <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
-            <a class="forge-nav__install" href="../index.html#install">install</a>
+            <div id="docsearch"></div>
         </div>
     </div>
 </nav>

--- a/site/playground/placeholder.html
+++ b/site/playground/placeholder.html
@@ -37,8 +37,6 @@
             <button class="forge-nav__burger" type="button" aria-label="menu"
                 onclick="this.closest('.forge-nav').classList.toggle('is-open')">≡</button>
             <span class="forge-nav__version">playground</span>
-            <a class="forge-nav__github" href="https://github.com/GaijinEntertainment/daScript">github ↗</a>
-            <a class="forge-nav__install" href="../index.html#install">install</a>
         </div>
     </div>
 </nav>


### PR DESCRIPTION
Now that DocSearch (Algolia) is in place, consolidate to one search everywhere and slim the Forge top bar.

## Top bar
Removed the `github ↗` link and `install` button from `forge-nav__right` and moved the DocSearch pill to the far right → `… · v0.6.3 · [🔍 Search]`. Nothing is lost: the install funnel still lives in the hero CTA + the on-page `#install` section + footer, the repo link is in the footer/install section, and there's a `downloads` nav link.

## Docs
Removed the native RTD search box from the docs sidebar (`layout.html`) — DocSearch is the single, better search there now.

## Files
- `site/{index,downloads,daspkg}.html`, `site/playground/{index,placeholder}.html`, `site/blog/template.html` — nav change (placeholder has no search box, so it's just the declutter).
- `site/files/forge.css` — dropped the now-dead `forge-nav__github` / `forge-nav__install` rules.
- `doc/source/_templates/layout.html` — removed the `searchbox.html` include.

Blog/news/changelist HTML is regenerated from `template.html` by `build_blog.py` at deploy (those outputs are gitignored), so only the template source changes here. Verified locally: landing, downloads, daspkg, playground, and regenerated blog/changelist all render the new bar; `Ctrl/Cmd+K` search still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)