### PR TITLE
flatten: mad/lerp disassemble-early + re-fuse-late (PHASE_FUSED), extraction joint-fixpoint, positives-first reassoc, zero-init materialization

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -752,8 +752,8 @@ def public flatten_optimize(var func : FunctionPtr; barriers : table<string>) : 
 [macro_function]
 def public flatten_fuse(var func : FunctionPtr) : bool {
     //! PHASE_FUSED finishing pass (delegates to `fuse_body`): re-pack `a*b ± c` into `mad(a,b,c)`
-    //! and the expanded lerp shape back into `lerp(a,b,t)`. Run ONCE on the optimized, re-inferred
-    //! body (the type gates need settled types). Returns true if anything changed.
+    //! and the expanded lerp shape back into `lerp(a,b,t)`. Call on the optimized, re-inferred body and
+    //! repeat across re-inference until it returns false (the type gates need each round's settled types).
     return fuse_body(func)
 }
 

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -446,6 +446,9 @@ def private lower_stmt(var ctx : FlatCtx?; stmt : ExpressionPtr; structPred : Ex
         for (v in lc.variables) {
             if (v.init != null) {
                 v.init = lower_value(ctx, v.init, structPred, out)
+            } else {
+                // materialize the implicit zero-init — the predicated store's false path READS it
+                v.init = zero_const_of(v._type, v.at)
             }
         }
         out |> push <| letClone

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -33,6 +33,7 @@ require daslib/flatten_opt
 let private PHASE_LOWERED = 1
 let private PHASE_FOLDED = 2
 let private PHASE_OPTIMIZED = 3
+let private PHASE_FUSED = 4
 let private PHASE_DONE = 999
 
 // Calls that must stay per-pixel (can't run in the per-draw preshader). The [flatten] annotation
@@ -745,6 +746,14 @@ def public flatten_optimize(var func : FunctionPtr; barriers : table<string>) : 
     return flatten_preshade_cse(func, barriers)
 }
 
+[macro_function]
+def public flatten_fuse(var func : FunctionPtr) : bool {
+    //! PHASE_FUSED finishing pass (delegates to `fuse_body`): re-pack `a*b ± c` into `mad(a,b,c)`
+    //! and the expanded lerp shape back into `lerp(a,b,t)`. Run ONCE on the optimized, re-inferred
+    //! body (the type gates need settled types). Returns true if anything changed.
+    return fuse_body(func)
+}
+
 def public flatten_opt_residuals(var func : FunctionPtr) : array<string> {
     //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin
     //! has no un-extracted uniform subtree and no un-CSE'd repeat. Test-framework / fuzzer facing.
@@ -870,7 +879,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             errors := "flatten: twin {twin_name(func)} was not declared"
             return false
         }
-        if (ph != PHASE_LOWERED && ph != PHASE_FOLDED && ph != PHASE_OPTIMIZED) {
+        if (ph != PHASE_LOWERED && ph != PHASE_FOLDED && ph != PHASE_OPTIMIZED && ph != PHASE_FUSED) {
             // Cycle 1: lower the twin with the std whitelist, then re-infer so
             // call.func resolves. (Backends call flatten_function directly with
             // their own primitive set instead of going through this annotation.)
@@ -895,9 +904,19 @@ class FlattenAnnotation : AstFunctionAnnotation {
             }
             // Fold fixpoint reached → run the optimize pass once on the canonical body: hoist uniform
             // subtrees to top-of-body `_preshader_` lets, CSE-dedup repeated subtrees. Re-infer to
-            // type the new lets, then fall through to the shape check next cycle.
+            // type the new lets, then fuse next cycle.
             set_flatten_phase(func, PHASE_OPTIMIZED)
             if (flatten_optimize(twin, FLATTEN_BARRIERS)) {
+                astChanged = true
+                return true
+            }
+        }
+        if (get_flatten_phase(func) == PHASE_OPTIMIZED || get_flatten_phase(func) == PHASE_FUSED) {
+            // Optimize converged → re-pack `a*b ± c` into `mad` and the lerp shape back into
+            // `lerp`, re-inferring to resolve the new calls; iterates (each round strictly
+            // drops a `+`/`-`, so it converges), a clean round falls through to the shape check.
+            set_flatten_phase(func, PHASE_FUSED)
+            if (flatten_fuse(twin)) {
                 astChanged = true
                 return true
             }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1133,11 +1133,13 @@ def private build_chain(var terms : array<ReTerm>; at : LineInfo; addOp, subOp :
     return acc
 }
 
-// True if the var terms are already in canonical (describe-ascending) order. Lets the sort fire
-// only when needed, so a canonicalized chain is a no-op (idempotent → the macro fixpoint ends).
+// True if the var terms are already canonical: positives first (so build_chain emits `b - a`,
+// never `-a + b` = neg + add, whose uniform `-a` would hoist into a `_preshader_ = -_preshader_`
+// alias), describe-ascending per sign group. Mirrors the regroup sort exactly (idempotence).
 def private vars_sorted(vars : array<ReTerm>) : bool {
     for (i in range(1, length(vars))) {
-        if (describe(vars[i].e) < describe(vars[i - 1].e)) {
+        if ((vars[i - 1].neg && !vars[i].neg) ||
+            (vars[i - 1].neg == vars[i].neg && describe(vars[i].e) < describe(vars[i - 1].e))) {
             return false
         }
     }
@@ -1174,6 +1176,9 @@ def private regroup(that : ExprOp2?; var terms : array<ReTerm>; addOp, subOp : s
     }
     if (pure) {
         sort(vars) $(a, b : ReTerm) : bool {
+            if (a.neg != b.neg) {
+                return !a.neg
+            }
             return describe(a.e) < describe(b.e)
         }
     }
@@ -2081,6 +2086,9 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
         if (fr.foundLerp) {
             res |> push("an un-refused lerp shape (mad(b-a,t,a))")
         }
+        if (fr.foundNegAdd) {
+            res |> push("an un-packed neg-add ('-a + b' should be 'b - a')")
+        }
         unsafe {
             delete fr
         }
@@ -2232,8 +2240,26 @@ def private match_mad(var that : ExprOp2?; var ma, mb, mc : ExpressionPtr&) : bo
     return true
 }
 
+// `(-a) + b` / `b + (-a)` → `b - a`: one sub node instead of neg + add. Reassoc no longer emits
+// the form (positives-first canonical order), so this catches the other producers — the `0 - x`
+// and `*-1` fold arms. Shared by fuser AND residual.
+def private match_neg_add(var that : ExprOp2?; var pos, neg : ExpressionPtr&) : bool {
+    if (that == null || that.op != "+" || !is_mad_elem(expr_bt(that))) return false
+    if (that.left is ExprOp1 && (that.left as ExprOp1).op == "-") {
+        pos = that.right
+        neg = (that.left as ExprOp1).subexpr
+        return true
+    }
+    if (that.right is ExprOp1 && (that.right as ExprOp1).op == "-") {
+        pos = that.left
+        neg = (that.right as ExprOp1).subexpr
+        return true
+    }
+    return false
+}
+
 // `mad(b - a, t, a)` → `lerp(a, b, t)`: the re-packed expansion shape, `a` matched by
-// describe-equality. Reassoc canonicalizes `b - a` into `-a + b`, so both forms must match.
+// describe-equality. The neg-add form is matched too (defense — reassoc no longer emits it).
 // Deliberately misses a CSE-shared `b - a` (behind a `_cse_` var — keeping the share IS the win).
 def private match_lerp(var cll : ExprCall?; var la, lb, lt : ExpressionPtr&) : bool {
     if (cll == null || length(cll.arguments) != 3 ||
@@ -2275,6 +2301,12 @@ class private MadFuseVisitor : AstVisitor {
             emplace(cll.arguments, mc)
             return cll
         }
+        var pos : ExpressionPtr
+        var neg : ExpressionPtr
+        if (match_neg_add(that, pos, neg)) {
+            changed = true
+            return new ExprOp2(at = that.at, op := "-", left = pos, right = neg)
+        }
         return that
     }
 }
@@ -2303,12 +2335,18 @@ class private FuseResidualVisitor : AstVisitor {
     checkLerp : bool
     foundMad : bool
     foundLerp : bool
+    foundNegAdd : bool
     def override preVisitExprOp2(var expr : ExprOp2?) : void {
         var ma : ExpressionPtr
         var mb : ExpressionPtr
         var mc : ExpressionPtr
         if (match_mad(expr, ma, mb, mc)) {
             foundMad = true
+        }
+        var pos : ExpressionPtr
+        var neg : ExpressionPtr
+        if (match_neg_add(expr, pos, neg)) {
+            foundNegAdd = true
         }
     }
     def override preVisitExprCall(var expr : ExprCall?) : void {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -1339,6 +1339,16 @@ def private psh_reserved(name : das_string) : bool {
     return name |> starts_with("__flat_") || name |> starts_with("__ssa_") || name |> starts_with("_preshader_")
 }
 
+// Parse `name` as `prefix` + decimal digits, -1 when it isn't. The round-trip check rejects
+// foreign suffixes — `_preshader_cse_3` against prefix `_preshader_` belongs to the cse counter.
+def private name_counter_suffix(name : das_string; prefix : string) : int {
+    if (!(name |> starts_with(prefix))) return -1
+    let s = slice("{name}", length(prefix))
+    if (empty(s)) return -1
+    let v = to_int(s)
+    return "{v}" == s ? v : -1
+}
+
 // True if the subtree carries a graph node (operator or call) — i.e. hoisting it saves per-pixel
 // work. A bare var / const / member access alone is trivial (no node), so it is inlined as an alias
 // rather than hoisted.
@@ -1508,6 +1518,11 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
                 pe.dedup["{describe(lv.init)}"] = "{lv.name}"
             }
             pe.localColor["{lv.name}"] = true
+            // existing names own their suffixes — a fresh caller's counter must not re-mint them
+            let cnum = name_counter_suffix(lv.name, "_preshader_")
+            if (cnum >= pe.counter) {
+                pe.counter = cnum + 1
+            }
             oldPrefix ++
         } else {
             break
@@ -1820,6 +1835,18 @@ def private preshader_prefix_len(blk : ExprBlock?) : int {
 def private cse_body(var blk : ExprBlock?; var counter : int&) : bool {
     var anyChange = false
     var guard = 0
+    // existing share names own their suffixes — never re-mint them (shares splice mid-body, so scan all)
+    for (s in blk.list) {
+        if (s is ExprLet && length((s as ExprLet).variables) == 1) {
+            var cnum = name_counter_suffix((s as ExprLet).variables[0].name, "_preshader_cse_")
+            if (cnum < 0) {
+                cnum = name_counter_suffix((s as ExprLet).variables[0].name, "_cse_")
+            }
+            if (cnum >= counter) {
+                counter = cnum + 1
+            }
+        }
+    }
     // Reassigned vars are stable across rounds (cse only ever adds `let`s), so collect once.
     var mutableVars <- collect_mutable(blk)
     while (guard < 4096) {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -7,7 +7,8 @@ module flatten_opt shared private
 
 //! Internal optimization passes for daslib/flatten: constant folding, constant
 //! propagation, copy propagation, and dead-store elimination over a flattened
-//! twin's straight-line body, plus the post-infer select-fold (`fold_body`).
+//! twin's straight-line body, plus the post-infer select-fold (`fold_body`),
+//! the preshader/CSE optimize pass and the mad/lerp re-fusion finishing pass.
 //! Not a public API — `require`d by daslib/flatten; the lowering machinery stays
 //! in flatten.das.
 
@@ -553,6 +554,12 @@ class private FoldVisitor : AstVisitor {
         } elif (that.op == "-") {
             if (is_zero_const_op(that.right)) { changed = true; return that.left }
             if (is_zero_const_op(that.left)) { changed = true; return negate(that.right) }
+            // `x - x → 0` — purity-gated like `*0` (and like it, inf/NaN operands aside:
+            // fast-math charter). Identical describe ⇒ identical purity, so one check.
+            if (describe(that.left) == describe(that.right) && !has_sideeffects(that.left)) {
+                var z = zero_const_of(that._type, that.at)
+                if (z != null) { changed = true; return z }
+            }
         } elif (that.op == "&&") {
             // Short-circuit `&&`: `false && x` never evaluates x, so dropping x is
             // safe; `x && false` DOES evaluate x, so that drop is gated on purity.
@@ -612,6 +619,36 @@ class private FoldVisitor : AstVisitor {
             if (!(folded is ExprCall)) {   // eval_to_const returns the call unchanged on failure
                 changed = true
                 return folded
+            }
+        }
+        // DISASSEMBLE lerp/mad into raw arithmetic so the identity/const folds, reassoc and CSE
+        // see through them; the PHASE_FUSED finishing pass re-packs survivors. Type-gated to the
+        // das math overload set — a loose DSL-stub instantiation must not expand into ill-typed ops.
+        if (that.func != null && length(that.arguments) == 3) {
+            let fname = psh_simple_name("{that.func.name}")
+            let ta = expr_bt(that.arguments[0])
+            let tb = expr_bt(that.arguments[1])
+            let tc = expr_bt(that.arguments[2])
+            if (fname == "lerp" && lerp_shape(ta, tb, tc)) {
+                var aArg = that.arguments[0]
+                var bArg = that.arguments[1]
+                var tArg = that.arguments[2]
+                // const-selector short-circuits — exact, and no expand/refuse round trip
+                if (is_zero_const_op(tArg) && !has_sideeffects(bArg)) { changed = true; return aArg }
+                if (is_one_const_op(tArg) && !has_sideeffects(aArg)) { changed = true; return bArg }
+                if (describe(aArg) == describe(bArg) && !has_sideeffects(bArg) && !has_sideeffects(tArg)) {
+                    changed = true
+                    return aArg
+                }
+                changed = true
+                var sub = new ExprOp2(at = that.at, op := "-", left = bArg, right = clone_expression(aArg))
+                var mul = new ExprOp2(at = that.at, op := "*", left = sub, right = tArg)
+                return new ExprOp2(at = that.at, op := "+", left = mul, right = aArg)
+            }
+            if (fname == "mad" && mad_shape(ta, tb, tc)) {
+                changed = true
+                var mul = new ExprOp2(at = that.at, op := "*", left = that.arguments[0], right = that.arguments[1])
+                return new ExprOp2(at = that.at, op := "+", left = mul, right = that.arguments[2])
             }
         }
         return that
@@ -784,6 +821,43 @@ def private zero_const_of(t : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
     if (bt == Type.tUInt3) return new ExprConstUInt3(at = at, value = uint3(0u))
     if (bt == Type.tUInt4) return new ExprConstUInt4(at = at, value = uint4(0u))
     return null
+}
+
+def private expr_bt(e : ExpressionPtr) : Type {
+    return (e == null || e._type == null) ? Type.none : e._type.baseType
+}
+
+// Scalar element of a vector baseType (tFloat3 → tFloat); Type.none for non-vectors.
+def private vec_elem_bt(bt : Type) : Type {
+    if (bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4) return Type.tFloat
+    if (bt == Type.tInt2 || bt == Type.tInt3 || bt == Type.tInt4) return Type.tInt
+    if (bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4) return Type.tUInt
+    return Type.none
+}
+
+def private is_float_family(bt : Type) : bool {
+    return bt == Type.tFloat || bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4
+}
+
+// The (T,T,T) element family das `mad` covers: float/int/uint scalar+vector, double scalar.
+def private is_mad_elem(bt : Type) : bool {
+    return (is_float_family(bt) || bt == Type.tDouble ||
+        bt == Type.tInt || bt == Type.tInt2 || bt == Type.tInt3 || bt == Type.tInt4 ||
+        bt == Type.tUInt || bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4)
+}
+
+// `mad(a, b, c)` overload shapes (das math): (T,T,T) over the numeric family, or the
+// vec-scalar-vec broadcast form (MadS). The single gate for expand, fuse AND residual.
+def private mad_shape(ta, tb, tc : Type) : bool {
+    if (ta == tb && tb == tc) return is_mad_elem(ta)
+    return ta == tc && tb != Type.none && vec_elem_bt(ta) == tb
+}
+
+// `lerp(a, b, t)` shapes safe to expand AND re-fuse: float family with scalar `t` only — the
+// one shape every provider has (das math AND the scalar-`t` backend DSL stubs). A vector-`t`
+// re-fusion of raw `(b-a)*tv + a` arithmetic would emit a call a DSL-only module can't resolve.
+def private lerp_shape(ta, tb, tt : Type) : bool {
+    return ta == tb && is_float_family(ta) && tt == Type.tFloat
 }
 
 // True if `e` is built only from const literals and pure ops/builtins — no var/global read,
@@ -1410,17 +1484,40 @@ def private pex_extract(var pe : PEX; barriers : table<string>; var e : Expressi
     return e
 }
 
-def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barriers : table<string>) : bool {
+// `counter` is owned by the caller's optimize loop — extraction re-runs per round, and a fresh
+// per-call numbering would collide a later round's `_preshader_0` with the surviving first one.
+def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barriers : table<string>; var counter : int&) : bool {
     var pe : PEX
+    pe.counter = counter
     for (a in func.arguments) {
         pe.paramNames |> insert("{a.name}")
     }
     pe.mutableVars <- collect_mutable(blk)
+    // re-entry seeding: prefix lets pre-fill dedup + colour (a re-hoist of one's own init would self-collapse)
+    var oldPrefix = 0
+    for (s in blk.list) {
+        if (s is ExprLet && length((s as ExprLet).variables) == 1 &&
+                (s as ExprLet).variables[0].name |> starts_with("_preshader_")) {
+            let lv = (s as ExprLet).variables[0]
+            if (lv.init != null) {
+                pe.dedup["{describe(lv.init)}"] = "{lv.name}"
+            }
+            pe.localColor["{lv.name}"] = true
+            oldPrefix ++
+        } else {
+            break
+        }
+    }
     var body : array<ExpressionPtr>
     for (s0 in blk.list) {
         var s = s0
         if (!empty(pe.rename) && reads_any(s, pe.rename)) {
             s = subst_consts(s, pe.rename)
+        }
+        if (s is ExprLet && length((s as ExprLet).variables) == 1 &&
+                (s as ExprLet).variables[0].name |> starts_with("_preshader_")) {
+            body |> push(s)
+            continue
         }
         if (s is ExprLet && length((s as ExprLet).variables) == 1 && !psh_reserved((s as ExprLet).variables[0].name)) {
             var lc = s as ExprLet
@@ -1459,18 +1556,22 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
         body |> push(s)
     }
     if (pe.changed) {
-        // Replace the body in place: preshader group on top, then the (extracted) varying body.
+        // old prefix first, then fresh hoists (they may reference earlier `_preshader_` names), then the body
         while (!empty(blk.list)) {
             blk.list |> erase(length(blk.list) - 1)
+        }
+        for (i in range(oldPrefix)) {
+            blk.list |> emplace(body[i])
         }
         for (t in pe.top) {
             blk.list |> emplace(t)
         }
-        for (b in body) {
-            blk.list |> emplace(b)
+        for (i in range(oldPrefix, length(body))) {
+            blk.list |> emplace(body[i])
         }
     }
     let result = pe.changed
+    counter = pe.counter
     delete pe.paramNames
     delete pe.localColor
     delete pe.mutableVars
@@ -1966,6 +2067,24 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
             }
         }
     }
+    // Fusion residual: a fusable mul-add (`a*b ± c`) PHASE_FUSED should have re-packed into
+    // `mad`, or a mad still carrying the lerp shape — gated on the same module visibility.
+    if (fuse_callable(func._module, "mad")) {
+        var fr = new FuseResidualVisitor()
+        fr.checkLerp = fuse_callable(func._module, "lerp")
+        make_visitor(*fr) $(a) {
+            visit(func.body, a)
+        }
+        if (fr.foundMad) {
+            res |> push("an un-fused mul-add ('a*b ± c' should be mad)")
+        }
+        if (fr.foundLerp) {
+            res |> push("an un-refused lerp shape (mad(b-a,t,a))")
+        }
+        unsafe {
+            delete fr
+        }
+    }
     delete pe.paramNames
     delete pe.localColor
     delete pe.mutableVars
@@ -1975,19 +2094,23 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
 
 def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>) : bool {
     //! Post-fold optimize pass: hoist uniform (globals+literals) subtrees to top-of-body
-    //! `_preshader_N` lets, then CSE-dedup repeated subtrees. `barriers` = sampler/noise call names
-    //! that must stay per-pixel. Runs once after the fold fixpoint; caller re-infers after.
+    //! `_preshader_N` lets, CSE-dedup repeats, collapse pure aliases — a joint fixpoint.
+    //! `barriers` = sampler/noise names that stay per-pixel. Post-fold, once; caller re-infers.
     if (!(func.body is ExprBlock)) return false
     var blk = func.body as ExprBlock
-    var changed = extract_preshader(func, blk, barriers)
-    // cse and alias enable each other (a collapsed alias canonicalises names, exposing fresh dups),
-    // so iterate the pair to a fixpoint. Converges in a couple of iterations now that the tally is
-    // occurrence-exact; an exhausted guard means an oscillation regression — warn, never hang.
+    // The passes enable each other — an alias subst / CSE share can re-expose uniform compute in
+    // the varying region (`!_preshader_0`) that only re-extraction hoists, so iterate the triple
+    // to a fixpoint. An exhausted guard means an oscillation regression — warn, never hang.
+    var changed = false
     var guard = 0
     var cseCounter = 0
+    var preCounter = 0
     while (guard < 16) {
         guard ++
         var round = false
+        if (extract_preshader(func, blk, barriers, preCounter)) {
+            round = true
+        }
         if (cse_body(blk, cseCounter)) {
             round = true
         }
@@ -2001,6 +2124,234 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
     }
     if (guard >= 16) {
         to_log(LOG_WARNING, "flatten: cse/alias loop guard exhausted in {func.name} (oscillation?)\n")
+    }
+    return changed
+}
+
+// ===== mad/lerp re-fusion (PHASE_FUSED finishing pass) =====
+// The fold DISASSEMBLES lerp/mad into raw arithmetic (identities fold, reassoc/CSE see through);
+// this re-packs survivors: `a*b ± c` → mad, then `mad(b - a, t, a)` → lerp — one node each.
+
+// A negated copy of a scalar/vector float/int const literal; null for any other node
+// (uint excluded — modular negation is value-correct but backend-hostile).
+def private negate_const(e : ExpressionPtr) : ExpressionPtr {
+    if (e == null) return null
+    if (e is ExprConstFloat) return new ExprConstFloat(at = e.at, value = -(e as ExprConstFloat).value)
+    if (e is ExprConstDouble) return new ExprConstDouble(at = e.at, value = -(e as ExprConstDouble).value)
+    if (e is ExprConstInt) return new ExprConstInt(at = e.at, value = -(e as ExprConstInt).value)
+    if (e is ExprConstFloat2) return new ExprConstFloat2(at = e.at, value = -(e as ExprConstFloat2).value)
+    if (e is ExprConstFloat3) return new ExprConstFloat3(at = e.at, value = -(e as ExprConstFloat3).value)
+    if (e is ExprConstFloat4) return new ExprConstFloat4(at = e.at, value = -(e as ExprConstFloat4).value)
+    if (e is ExprConstInt2) return new ExprConstInt2(at = e.at, value = -(e as ExprConstInt2).value)
+    if (e is ExprConstInt3) return new ExprConstInt3(at = e.at, value = -(e as ExprConstInt3).value)
+    if (e is ExprConstInt4) return new ExprConstInt4(at = e.at, value = -(e as ExprConstInt4).value)
+    return null
+}
+
+def private has_3arg_named(mod : Module?; fname : string) : bool {
+    var found = false
+    for_each_function(mod, fname) $(fn) {
+        if (length(fn.arguments) == 3) {
+            found = true
+        }
+    }
+    for_each_generic(mod, fname) $(fn) {
+        if (length(fn.arguments) == 3) {
+            found = true
+        }
+    }
+    return found
+}
+
+def private fuse_callable(mod : Module?; fname : string) : bool {
+    if (mod == null) return false
+    if (has_3arg_named(mod, fname)) return true
+    var found = false
+    module_for_each_dependency(mod) $(dep, _isPub) {
+        if (!found && has_3arg_named(dep, fname)) {
+            found = true
+        }
+    }
+    return found
+}
+
+// Match `m ± c` / `c ± m` (m = a*b; `-` needs a const-negatable side) against the das mad shapes;
+// out-params carry (a, b, c) with the vec-scalar swap + negation applied. The ONE gate for fuser AND
+// residual; no purity gate — flat-body calls are pure by contract (and has_sideeffects is timing-dependent).
+def private match_mad(var that : ExprOp2?; var ma, mb, mc : ExpressionPtr&) : bool {
+    if (that == null) return false
+    var mul : ExprOp2?
+    var other : ExpressionPtr
+    var negOther = false        // `m - C`  → c = -C
+    var negFactor = false       // `C - m`  → negate a const factor of m
+    if (that.op == "+" || that.op == "-") {
+        if (that.left is ExprOp2 && (that.left as ExprOp2).op == "*") {
+            mul = that.left as ExprOp2
+            other = that.right
+            negOther = that.op == "-"
+        } elif (that.right is ExprOp2 && (that.right as ExprOp2).op == "*") {
+            mul = that.right as ExprOp2
+            other = that.left
+            negFactor = that.op == "-"
+        }
+    }
+    if (mul == null) return false
+    var fa = mul.left
+    var fb = mul.right
+    // types captured BEFORE negation — a fresh negated literal is untyped until re-infer
+    var bta = expr_bt(fa)
+    var btb = expr_bt(fb)
+    let btc = expr_bt(other)
+    if (negFactor) {
+        var nf = negate_const(fa)
+        if (nf != null) {
+            fa = nf
+        } else {
+            nf = negate_const(fb)
+            if (nf == null) return false
+            fb = nf
+        }
+    }
+    if (negOther) {
+        other = negate_const(other)
+        if (other == null) return false
+    }
+    // a scalar-left mul swaps to the MadS (vec, scalar, vec) form
+    if (vec_elem_bt(btb) != Type.none && bta == vec_elem_bt(btb)) {
+        var tmp = fa
+        fa = fb
+        fb = tmp
+        let tmpbt = bta
+        bta = btb
+        btb = tmpbt
+    }
+    if (!mad_shape(bta, btb, btc)) return false
+    ma = fa
+    mb = fb
+    mc = other
+    return true
+}
+
+// `mad(b - a, t, a)` → `lerp(a, b, t)`: the re-packed expansion shape, `a` matched by
+// describe-equality. Reassoc canonicalizes `b - a` into `-a + b`, so both forms must match.
+// Deliberately misses a CSE-shared `b - a` (behind a `_cse_` var — keeping the share IS the win).
+def private match_lerp(var cll : ExprCall?; var la, lb, lt : ExpressionPtr&) : bool {
+    if (cll == null || length(cll.arguments) != 3 ||
+        psh_simple_name("{cll.name}") != "mad" || !(cll.arguments[0] is ExprOp2)) return false
+    var diff = cll.arguments[0] as ExprOp2
+    var db : ExpressionPtr      // b — the minuend
+    var da : ExpressionPtr      // a — the subtrahend
+    if (diff.op == "-") {
+        db = diff.left
+        da = diff.right
+    } elif (diff.op == "+") {
+        if (diff.left is ExprOp1 && (diff.left as ExprOp1).op == "-") {
+            da = (diff.left as ExprOp1).subexpr
+            db = diff.right
+        } elif (diff.right is ExprOp1 && (diff.right as ExprOp1).op == "-") {
+            da = (diff.right as ExprOp1).subexpr
+            db = diff.left
+        }
+    }
+    if (da == null || describe(da) != describe(cll.arguments[2]) ||
+        !lerp_shape(expr_bt(da), expr_bt(db), expr_bt(cll.arguments[1]))) return false
+    la = cll.arguments[2]
+    lb = db
+    lt = cll.arguments[1]
+    return true
+}
+
+class private MadFuseVisitor : AstVisitor {
+    changed : bool
+    def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
+        var ma : ExpressionPtr
+        var mb : ExpressionPtr
+        var mc : ExpressionPtr
+        if (match_mad(that, ma, mb, mc)) {
+            changed = true
+            var cll = new ExprCall(at = that.at, name := "mad")
+            emplace(cll.arguments, ma)
+            emplace(cll.arguments, mb)
+            emplace(cll.arguments, mc)
+            return cll
+        }
+        return that
+    }
+}
+
+class private LerpFuseVisitor : AstVisitor {
+    changed : bool
+    def override visitExprCall(var that : ExprCall?) : ExpressionPtr {
+        var la : ExpressionPtr
+        var lb : ExpressionPtr
+        var lt : ExpressionPtr
+        if (match_lerp(that, la, lb, lt)) {
+            changed = true
+            var cll = new ExprCall(at = that.at, name := "lerp")
+            emplace(cll.arguments, la)
+            emplace(cll.arguments, lb)
+            emplace(cll.arguments, lt)
+            return cll
+        }
+        return that
+    }
+}
+
+// Fusion residuals — mirrors the fuser's matchers EXACTLY (same gates, same shapes), so a
+// survivor means the PHASE_FUSED pass missed, never that the gate was narrower here.
+class private FuseResidualVisitor : AstVisitor {
+    checkLerp : bool
+    foundMad : bool
+    foundLerp : bool
+    def override preVisitExprOp2(var expr : ExprOp2?) : void {
+        var ma : ExpressionPtr
+        var mb : ExpressionPtr
+        var mc : ExpressionPtr
+        if (match_mad(expr, ma, mb, mc)) {
+            foundMad = true
+        }
+    }
+    def override preVisitExprCall(var expr : ExprCall?) : void {
+        if (checkLerp) {
+            var la : ExpressionPtr
+            var lb : ExpressionPtr
+            var lt : ExpressionPtr
+            if (match_lerp(expr, la, lb, lt)) {
+                foundLerp = true
+            }
+        }
+    }
+}
+
+def public fuse_body(var func : FunctionPtr) : bool {
+    //! PHASE_FUSED finishing pass: re-pack `a*b ± c` into `mad(a,b,c)` and the expanded lerp
+    //! shape `mad(b - a, t, a)` back into `lerp(a, b, t)` over the optimized, re-inferred body
+    //! (the type gates need settled types). Caller re-infers after to type the new calls.
+    if (!(func.body is ExprBlock) || !fuse_callable(func._module, "mad")) return false
+    var changed = false
+    var v = new MadFuseVisitor()
+    make_visitor(*v) $(adapter) {
+        visit(func.body, adapter)
+    }
+    if (v.changed) {
+        changed = true
+    }
+    unsafe {
+        delete v
+    }
+    // lerp re-fusion is a separate walk over the fresh mads — a visitor never descends into
+    // the node it just returned, so the mad → lerp chain can't happen in one pass.
+    if (fuse_callable(func._module, "lerp")) {
+        var lv = new LerpFuseVisitor()
+        make_visitor(*lv) $(adapter) {
+            visit(func.body, adapter)
+        }
+        if (lv.changed) {
+            changed = true
+        }
+        unsafe {
+            delete lv
+        }
     }
     return changed
 }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -795,10 +795,10 @@ def private negate(var e : ExpressionPtr) : ExpressionPtr {
     return new ExprOp1(at = e.at, op := "-", subexpr = e)
 }
 
-// A fresh zero literal of `t` (the RESULT type of `X * 0`), over the numeric scalar + vector
-// family; null otherwise. Keying on the result type (not the zero operand's) lets both
-// `v:float3 * 0.0` and `v * float3(0)` fold to a width-matched `float3(0)` with no mistype.
-def private zero_const_of(t : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
+// A fresh zero literal of `t` (the RESULT type of `X * 0`; also the lowering's materialized
+// implicit zero-init on bare decls), over the numeric scalar + vector family; null otherwise.
+// Keying on the result type lets both `v * 0.0` and `v * float3(0)` fold width-matched.
+def public zero_const_of(t : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
     if (t == null) return null
     let bt = t.baseType
     if (bt == Type.tInt) return new ExprConstInt(at = at, value = 0)

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -136,7 +136,9 @@ reassociates, for float rounding) into one adjacent group the all-const fold the
 The same pass sorts the chain's *variable* terms into a canonical (structural) order, so
 commutative chains converge to one form (``b + a`` and ``a + b`` both become ``a + b``) —
 gated on every term being side-effect-free, and intended to feed a later common-subexpression
-pass. Integer ``+``/``*`` reassociate exactly; integer ``/`` is non-associative and excluded.
+pass. Positive terms sort before subtracted ones, so the rebuilt chain spells ``b - a``
+(one sub node) rather than ``-a + b`` (a negate plus an add — whose uniform ``-a`` the
+preshader pass would hoist into a pass-through ``_preshader_ = -_preshader_`` alias). Integer ``+``/``*`` reassociate exactly; integer ``/`` is non-associative and excluded.
 These are exactly the folds the general compiler leaves for the downstream tiers (it folds
 constant *arithmetic* but not constant *constructors*, and never a runtime-operand identity
 or reassociation), done here under a shader's fast-math assumption (``x*0 → 0`` always fires).
@@ -196,7 +198,9 @@ converges, a finishing **fuse** pass (``PHASE_FUSED``) re-packs what survived:
 become one ``mad(a, b, c)`` node — including the vector·scalar broadcast form —
 and a mad still carrying the lerp shape, ``mad(b - a, t, a)``, becomes one
 ``lerp(a, b, t)`` node. Hand-written ``(b - a)*t + a`` arithmetic that never
-spelled ``lerp`` canonicalises into the lerp node the same way. Type gates keep
+spelled ``lerp`` canonicalises into the lerp node the same way. A leftover
+``(-a) + b`` (the ``0 - x`` / ``*-1`` folds produce bare negates) re-packs into
+``b - a``. Type gates keep
 the rewrites inside the das ``math`` overload set (float / int / uint, scalar +
 vector; lerp with scalar ``t``), and fusion only runs when a 3-argument
 ``mad`` / ``lerp`` is visible from the twin's module (``math`` or a backend DSL).

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -234,6 +234,8 @@ Supported subset
      - flattened in place / unwrapped to its body
    * - copyable value assignment
      - selects support scalars, vectors (``float4`` …), structs and tuples
+   * - bare local decl (``var a : float3``), partially assigned under a branch
+     - the implicit zero-init is materialized, so the predicated select's false path reads a real node
    * - ``void`` functions
      - predicated writes to output globals (the writes-to-globals shader model)
 

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -171,13 +171,37 @@ common-subexpression elimination (``flatten_optimize``):
   neither ``X`` nor ``V`` reassigned) into direct references to ``V`` and drops the ``let``. CSE can
   leave such copies (a later round rewrites an earlier ``_cse_`` let's whole RHS down to
   a bare var) and the unroll / fold can leave them (``let p_0 = ro``); both are
-  pass-through graph nodes for nothing. CSE and alias elimination iterate to a fixpoint,
-  since an eliminated alias can canonicalise a variable and expose a fresh dup.
+  pass-through graph nodes for nothing. All three passes iterate to a **joint
+  fixpoint**: an eliminated alias can expose a fresh dup, and a CSE share or alias
+  substitution can re-expose *uniform* compute in the varying region (``!_preshader_0``,
+  a ``_cse_`` let whose operands converge to all-preshader references) that only
+  re-extraction hoists to the per-draw group.
 
 Both passes are **value-exact** — they only hoist and share existing subtrees, never
 regroup or round — and both exclude any subtree that reads a **reassigned** variable
 (a live/loop mask, a written global, or the base of an indexed store — ``G[i] = v``
 makes every ``G[...]`` read unstable), whose value is not stable across the body.
+
+**mad / lerp: disassemble early, re-fuse late.** ``lerp`` and ``mad`` are pure
+arithmetic wearing a call: the fold phase **expands** them in place —
+``mad(a, b, c) → a*b + c``, ``lerp(a, b, t) → (b - a)*t + a`` — so every
+downstream pass sees through them: the existing identity arms collapse the
+constant selectors (``lerp(a, b, 0) → a``, ``lerp(a, b, 1) → b``,
+``lerp(a, a, t) → a``, ``mad(a, 1, c) → a + c``, ``lerp(1.0, d, 1.0) → d``)
+with **no per-builtin identity table**, reassociation canonicalises the exposed
+operands, CSE shares a repeated ``b - a`` across lerps, and preshader extraction
+hoists a uniform ``b - a`` even when ``t`` is varying. Once the optimize pass
+converges, a finishing **fuse** pass (``PHASE_FUSED``) re-packs what survived:
+``a*b + c`` / ``c + a*b`` (and the const-negatable ``a*b - C`` / ``C - a*b``)
+become one ``mad(a, b, c)`` node — including the vector·scalar broadcast form —
+and a mad still carrying the lerp shape, ``mad(b - a, t, a)``, becomes one
+``lerp(a, b, t)`` node. Hand-written ``(b - a)*t + a`` arithmetic that never
+spelled ``lerp`` canonicalises into the lerp node the same way. Type gates keep
+the rewrites inside the das ``math`` overload set (float / int / uint, scalar +
+vector; lerp with scalar ``t``), and fusion only runs when a 3-argument
+``mad`` / ``lerp`` is visible from the twin's module (``math`` or a backend DSL).
+Fusion is the one pass that is **not value-exact on floats**: a fused ``mad``
+single-rounds where ``a*b + c`` rounds twice (integer fusion is exact).
 
 Supported subset
 ================
@@ -299,19 +323,29 @@ Public API
     (``{ "tex2d", "noise" }``) — those stay per-pixel. ``[flatten]`` runs it
     automatically; the ``[pixel_shader]`` backend runs it after its fold fixpoint.
 
+``flatten_fuse(var func) : bool``
+    The finishing fuse pass: re-pack ``a*b ± c`` into ``mad(a, b, c)`` and the
+    expanded lerp shape ``mad(b - a, t, a)`` back into ``lerp(a, b, t)``. Run it
+    after ``flatten_optimize``'s re-infer (the type gates need settled types) and
+    **iterate across re-inference while it reports change**, exactly like the
+    fold — each round strictly drops a ``+``/``-`` node, so it converges.
+    ``[flatten]`` runs it automatically; the ``[pixel_shader]`` backend mirrors it.
+
 ``flatten_opt_residuals(var func) : array<string>``
     The optimize-completeness oracle (sibling of ``flatten_fold_residuals``):
     walks a compiled twin and returns a description for each missed optimization —
     a maximal uniform subtree still inline in the varying body, a pure subtree
-    computed twice or more left un-shared, or a pure-alias ``let`` copy left
-    uncollapsed. Empty means complete. Drives the same
+    computed twice or more left un-shared, a pure-alias ``let`` copy left
+    uncollapsed, a fusable mul-add left un-packed, or a mad still carrying the
+    lerp shape. Empty means complete. Drives the same
     ``tests/flatten/test_flatten_fold.das`` corpus and the ``flatten-fuzz``
     strict mode.
 
 A backend's typical pipeline is therefore: ``flatten_function`` → re-infer →
 ``flatten_fold`` (to a fixpoint) → re-infer → ``flatten_optimize`` → re-infer →
-walk the now-branchless, call-free twin and emit its dataflow graph (mapping
-``?:`` to a *select* node and the bool masks to a 0/1 selector).
+``flatten_fuse`` (to a fixpoint) → walk the now-branchless, call-free twin and
+emit its dataflow graph (mapping ``?:`` to a *select* node and the bool masks
+to a 0/1 selector).
 
 .. seealso::
 

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1611,6 +1611,16 @@ class PixelShaderMacro : AstFunctionAnnotation {
                     return true
                 }
             }
+            // Optimize converged → re-pack `a*b ± c` into `mad` and the expanded lerp shape
+            // back into `lerp` (one [hint] node each), re-inferring to resolve the new calls.
+            // Mirrors daslib/flatten's PHASE_FUSED loop (converges — each round drops a `+`/`-`).
+            if (!shader_annotation_arg(func, "fused")) {
+                if (flatten_fuse(func)) {
+                    astChanged = true
+                    return true
+                }
+                set_shader_annotation_flag(func, "fused")
+            }
             set_shader_annotation_flag(func, "folded")
             return true
         }

--- a/examples/flatten/backend/shader_dsl_primitives.das
+++ b/examples/flatten/backend/shader_dsl_primitives.das
@@ -152,7 +152,7 @@ def ceil(x : float3) : float3 {}
 [stub, hint(ceil)]
 def ceil(x : float4) : float4 {}
 
-// mad: a * b + c
+// mad: a * b + c (b may be a scalar broadcast)
 [stub, hint(mad)]
 def mad(a : float | int, b : float | int, c : float | int) : float {}
 [stub, hint(mad)]
@@ -161,6 +161,12 @@ def mad(a : float2, b : float2, c : float2) : float2 {}
 def mad(a : float3, b : float3, c : float3) : float3 {}
 [stub, hint(mad)]
 def mad(a : float4, b : float4, c : float4) : float4 {}
+[stub, hint(mad)]
+def mad(a : float2, b : float, c : float2) : float2 {}
+[stub, hint(mad)]
+def mad(a : float3, b : float, c : float3) : float3 {}
+[stub, hint(mad)]
+def mad(a : float4, b : float, c : float4) : float4 {}
 
 // lerp: a, b are AnyFloat; t is a float scalar
 [stub, hint(lerp)]

--- a/examples/flatten/capability/cap_mad.shader
+++ b/examples/flatten/capability/cap_mad.shader
@@ -1,0 +1,28 @@
+require engine.render.shader_dsl
+
+// Capability demo: mad/lerp re-fusion. The fold DISASSEMBLES lerp/mad into raw arithmetic so
+// identities/CSE see through them, then the finishing pass re-packs every surviving `a*b + c`
+// into ONE mad node (`lum * 0.5 + 0.5` and the scalar-broadcast `c * remap + bias`), and
+// re-packs the hand-written lerp shape `(white - c) * t + c` into ONE lerp node — the backend
+// gets single instructions where the source spelled two or three.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+[pixel_shader]
+def cap_mad(inp : PbrInput) : PbrOutput {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let lum = dot(c, float3(0.299, 0.587, 0.114))
+    let remap = lum * 0.5 + 0.5
+    let tinted = c * remap + float3(0.04, 0.04, 0.04)
+    let edge = (float3(1.0, 1.0, 1.0) - c) * remap + c
+    return PbrOutput(
+        albedo = tinted,
+        emission = edge,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -61,6 +61,10 @@
 #
 #  15. cap_cse.shader (repeated `dot(c, LUMA)`) -> one shared node. Neither the compiler nor the
 #      backend CSEs; flatten value-numbers the body and shares the repeat, so 1 dot node (not 2).
+#
+#  16. cap_mad.shader (mul-adds + a hand-written lerp shape) -> fused. The finishing pass packs
+#      `a*b + c` into mad nodes (incl. the scalar-broadcast form) and `(b-a)*t + a` into a lerp
+#      node, so the graph carries 2 mad + 1 lerp instead of mul/add/sub chains.
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -298,6 +302,22 @@ if [[ "$errs" -eq 0 && "$dots" -eq 1 ]]; then
     echo "   ok — compiles ($nodes nodes), 1 dot node (the repeat was CSE'd)"
 else
     echo "   FAIL — errors=$errs dots=$dots (expected 1)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "16. cap_mad.shader (mul-adds + lerp shape -> 2 mad + 1 lerp nodes)"
+out="$(compile "$here/cap_mad.shader")"
+nodes="$(echo "$out" | grep -c '^node ')"
+mads="$(echo "$out" | grep '^node ' | grep -cw 'mad')"
+lerps="$(echo "$out" | grep '^node ' | grep -cw 'lerp')"
+errs="$(echo "$out" | grep -ci error)"
+# `lum*0.5 + 0.5` and `c*remap + bias` each pack into one mad; `(white - c)*remap + c` re-fuses
+# into one lerp. An un-fused body would carry the raw mul/add/sub nodes instead.
+if [[ "$errs" -eq 0 && "$mads" -eq 2 && "$lerps" -eq 1 ]]; then
+    echo "   ok — compiles ($nodes nodes), 2 mad + 1 lerp (mul-adds fused)"
+else
+    echo "   FAIL — errors=$errs mads=$mads lerps=$lerps (expected 2 and 1)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/examples/flatten/shaders/features/branch_partial.shader
+++ b/examples/flatten/shaders/features/branch_partial.shader
@@ -1,0 +1,31 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+// Feature fixture for PARTIALLY-assigned locals under a branch: `a` is written only on the then
+// path, `b` only on the else path — each keeps its zero default on the other path (daslang
+// zero-inits locals). flatten lowers the branch to predicated selects over the zero-init temps
+// (`a = P ? red : a`), so the merged `a + b` picks exactly one color per pixel with no branch.
+// Run `./run.sh --das branch_partial` to see the select pair.
+[pixel_shader]
+def branch_partial(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    var a : float3
+    var b : float3
+    if (inp.uv.x > 0.5) {
+        a = float3(1.0, 0.0, 0.0)
+    } else {
+        b = float3(0.0, 1.0, 0.0)
+    }
+    let result = c * (a + b)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/tests/.das_test
+++ b/tests/.das_test
@@ -40,11 +40,12 @@ def can_visit_folder(folder_name : string; var result : bool?) {
         }
     }
     // A meta-test that requires the compiler frontend at runtime (e.g. daslib/flatten ->
-    // macro_boost) can't AOT-link in the full-tree batch — exclude such folders under AOT.
+    // macro_boost) can't AOT-link in the full-tree batch, and one that runs qmacro at runtime
+    // (flatten_optimize re-entry) carries quote nodes LLVM JIT can't codegen — interp only.
     if (folder_name == "no_aot") {
         let args <- get_command_line_arguments()
         for (arg in args) {
-            if (arg == "--use-aot") {
+            if (arg == "--use-aot" || arg == "-jit") {
                 *result = false
                 return
             }

--- a/tests/flatten/no_aot/_reentry_fixture.das
+++ b/tests/flatten/no_aot/_reentry_fixture.das
@@ -1,0 +1,26 @@
+options gen2
+options indenting = 4
+
+require daslib/flatten
+
+//! `[flatten]` unit for the optimize re-entry test — NOT a [test] file; it is compiled by
+//! tests/flatten/no_aot/test_flatten_reentry.das, which then mutates the twin's body (the way a
+//! backend rewrite would) and calls `flatten_optimize` a second time. The twin is shaped to keep
+//! one `_preshader_0` let (the uniform `u` chain) and one `_cse_0` let (the duplicated varying
+//! `(x + 1.0) * x`) in its final body, so a re-entered pass with un-seeded counters would mint
+//! colliding names.
+
+var G_REENTRY = 2.5
+
+[flatten]
+def reentry(x : float) : float {
+    let u = G_REENTRY * 2.0 + 1.0
+    let d = (x + 1.0) * x
+    let e2 = (x + 1.0) * x
+    return u * d + e2
+}
+
+[export]
+def main() {
+    print("{reentry_flat(3.0)}\n")
+}

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -86,6 +86,10 @@ def test_flatten_fold(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_opt.das")
         t |> success(n >= 7, "expected >=7 twins, checked {n}")
     }
+    t |> run("mad/lerp corpus fuses clean (test_flatten_mad.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_mad.das")
+        t |> success(n >= 20, "expected >=20 twins, checked {n}")
+    }
     t |> run("every example shader folds clean (pixel_shader path)") @(t : T?) {
         let proj = "{root}/examples/flatten/flatten_shaders.das_project"
         let base = "{root}/examples/flatten/shaders"

--- a/tests/flatten/no_aot/test_flatten_reentry.das
+++ b/tests/flatten/no_aot/test_flatten_reentry.das
@@ -1,0 +1,103 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require daslib/ast
+require daslib/ast_boost
+require daslib/templates_boost
+require daslib/rtti
+require strings
+
+//! Re-entry contract for `flatten_optimize`: a backend may rewrite an already-optimized body and
+//! call the pass again. The pass seeds its `_preshader_N` / `_cse_N` counters from the names
+//! already present, so a second call must hoist NEW work under FRESH names instead of re-minting
+//! `_preshader_0` / `_cse_0` (a duplicate-name compile error once the body re-infers). The test
+//! compiles _reentry_fixture.das (its twin keeps one of each name), injects a new uniform let and
+//! a new duplicated varying pair — the way a backend rewrite would — re-runs the pass, and
+//! asserts every preshader/cse name in the block is still unique.
+
+def private let_name(s : ExpressionPtr) : string {
+    if (s is ExprLet && length((s as ExprLet).variables) == 1) {
+        return "{(s as ExprLet).variables[0].name}"
+    }
+    return ""
+}
+
+// Partition the block's single-var let names into the two counter classes:
+// `_preshader_cse_*`/`_cse_*` belong to the cse counter, remaining `_preshader_*` to extraction.
+def private collect_class_names(blk : ExprBlock?; var pres : array<string>; var cses : array<string>) {
+    for (s in blk.list) {
+        let nm = let_name(s)
+        if (empty(nm)) {
+            continue
+        }
+        if (nm |> starts_with("_preshader_cse_") || nm |> starts_with("_cse_")) {
+            cses |> push(nm)
+        } elif (nm |> starts_with("_preshader_")) {
+            pres |> push(nm)
+        }
+    }
+}
+
+def private has_dup(names : array<string>) : bool {
+    var seen : table<string>
+    for (n in names) {
+        if (key_exists(seen, n)) return true
+        seen |> insert(n)
+    }
+    return false
+}
+
+[test]
+def test_flatten_reentry(t : T?) {
+    let root = get_das_root()
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.version_2_syntax = true
+            compile_file("{root}/tests/flatten/no_aot/_reentry_fixture.das", access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                if (!ok) {
+                    t |> failure("compile failed: _reentry_fixture.das\n{iss}")
+                    return
+                }
+                var checked = 0
+                program_for_each_module(program) $(mod) {
+                    for_each_function(mod, "") $(func) {
+                        if ("{func.name}" != "reentry_flat" || func.body == null) {
+                            return
+                        }
+                        checked ++
+                        ast_gc_guard() {
+                            var blk = func.body as ExprBlock
+                            var pres1 : array<string>
+                            var cses1 : array<string>
+                            collect_class_names(blk, pres1, cses1)
+                            // fixture sanity: the pipeline run must have left one name of each class
+                            t |> success(!empty(pres1), "fixture twin must keep a _preshader_ let, got {pres1}")
+                            t |> success(!empty(cses1), "fixture twin must keep a _cse_ let, got {cses1}")
+                            // a backend-style rewrite: fresh uniform compute + a fresh duplicated varying pair
+                            var injU = qmacro_expr(${ let _reentry_u = G_REENTRY * G_REENTRY - 3.0; })
+                            var injD1 = qmacro_expr(${ let _reentry_d1 = (x - 2.0) * x; })
+                            var injD2 = qmacro_expr(${ let _reentry_d2 = (x - 2.0) * x; })
+                            blk.list |> emplace(injU)
+                            blk.list |> emplace(injD1)
+                            blk.list |> emplace(injD2)
+                            let nobarriers : table<string>
+                            t |> success(flatten_optimize(func, nobarriers), "re-entered optimize must hoist the injected work")
+                            var pres2 : array<string>
+                            var cses2 : array<string>
+                            collect_class_names(blk, pres2, cses2)
+                            t |> success(length(pres2) > length(pres1), "new uniform compute must hoist a fresh _preshader_ let, got {pres2}")
+                            t |> success(length(cses2) > length(cses1), "new varying dup must share into a fresh _cse_ let, got {cses2}")
+                            t |> success(!has_dup(pres2), "re-entry minted a colliding _preshader_ name: {pres2}")
+                            t |> success(!has_dup(cses2), "re-entry minted a colliding _cse_ name: {cses2}")
+                        }
+                    }
+                }
+                t |> equal(checked, 1, "expected exactly one reentry_flat twin")
+            }
+        }
+    }
+}

--- a/tests/flatten/test_flatten_basic.das
+++ b/tests/flatten/test_flatten_basic.das
@@ -127,6 +127,30 @@ def struct_guard(x : float; c : bool) : Pt {
     return Pt(b = x)
 }
 
+// ----- partially-assigned bare decls: each branch writes a DIFFERENT var; the other keeps its
+// implicit zero (the lowering materializes the zero-init the predicated select's false path reads) -----
+
+[flatten]
+def partial_vec(x : float) : float3 {
+    var a : float3
+    var b : float3
+    if (x > 0.5) {
+        a = float3(1.0, 0.0, 0.0)
+    } else {
+        b = float3(0.0, 1.0, 0.0)
+    }
+    return a + b
+}
+
+[flatten]
+def partial_scalar(x : float) : float {
+    var s : float
+    if (x > 0.5) {
+        s = x * 2.0
+    }
+    return s + 1.0
+}
+
 // ----- differential driver -----
 
 var GRID : array<int>
@@ -176,6 +200,17 @@ def test_flatten_equivalence(t : T?) {
     t |> run("helper-with-local inlined at two direct call sites") @(t : T?) {
         for (v in GRID) {
             t |> equal(inline_twice_flat(v), inline_twice(v))
+        }
+    }
+    t |> run("partially-assigned bare decls (each branch writes a different var)") @(t : T?) {
+        for (v in GRID) {
+            let fv = float(v) * 0.1
+            let pv = partial_vec_flat(fv)
+            let ev = partial_vec(fv)
+            t |> equal(pv.x, ev.x)
+            t |> equal(pv.y, ev.y)
+            t |> equal(pv.z, ev.z)
+            t |> equal(partial_scalar_flat(fv), partial_scalar(fv))
         }
     }
     t |> run("struct return type, unconditional + early return (was error[31016])") @(t : T?) {

--- a/tests/flatten/test_flatten_mad.das
+++ b/tests/flatten/test_flatten_mad.das
@@ -1,0 +1,271 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Differential net for the mad/lerp DISASSEMBLE → re-fuse arc. The fold expands `lerp`/`mad`
+//! calls into raw arithmetic (const selectors then collapse through the existing identity arms,
+//! and reassoc/CSE see through the operators); the PHASE_FUSED finishing pass re-packs surviving
+//! `a*b ± c` into `mad(a,b,c)` and the lerp shape `mad(b-a, t, a)` back into `lerp(a,b,t)`.
+//! Exactness per twin: int twins and same-builtin-both-sides round trips compare exact; ANY
+//! float twin comparing raw interp ops against a `mad`/`lerp` builtin compares approx — the
+//! vector builtins are hardware-fused (NEON FMLA / x86 FMADD), and even the scalar C++ impls
+//! (`a*b + c`, `(b-a)*t + a`) get FMA-contracted by the host compiler, so the rounding is
+//! platform-dependent. The FIRED structural proof (an actual `mad`/`lerp` call, no `a*b + c`
+//! residual) lives in `no_aot/test_flatten_fold.das` via the fusion arms of
+//! `flatten_opt_residuals`.
+
+// Module globals are UNIFORM (preshader-eligible); function params are VARYING.
+var G_A = 0.25
+var G_B = 4.0
+
+// ----- mad fusion: plain mul-add, both operand orders -----
+[flatten]
+def m_basic(a : float; b : float; c : float) : float {
+    return a * b + c
+}
+
+[flatten]
+def m_right(a : float; b : float; c : float) : float {
+    return c + a * b
+}
+
+// ----- the shader remap idiom x*C + C -----
+[flatten]
+def m_remap(x : float) : float {
+    return x * 0.5 + 0.5
+}
+
+// ----- `-` forms: const-negatable addend / const factor -----
+[flatten]
+def m_subc(a : float; b : float) : float {
+    return a * b - 1.0
+}
+
+[flatten]
+def m_csub(b : float) : float {
+    return 1.0 - 2.0 * b
+}
+
+// ----- two muls: greedy fuse absorbs one, the other stays mad's addend -----
+[flatten]
+def m_chain(a : float; b : float; c : float; d : float) : float {
+    return a * b + c * d
+}
+
+// ----- int mad (exact in every tier) -----
+[flatten]
+def m_int(a : int; b : int; c : int) : int {
+    return a * b + c
+}
+
+// ----- vector mad + the MadS scalar-broadcast form (hardware-fused -> approx) -----
+[flatten]
+def m_vec(a : float3; b : float3; c : float3) : float3 {
+    return a * b + c
+}
+
+[flatten]
+def m_vecs(v : float3; s : float; w : float3) : float3 {
+    return v * s + w
+}
+
+// ----- int vector mad + int MadS (exact) -----
+[flatten]
+def m_veci(a : int3; b : int3; c : int3) : int3 {
+    return a * b + c
+}
+
+[flatten]
+def m_intvs(v : int3; s : int; w : int3) : int3 {
+    return v * s + w
+}
+
+// ----- lerp const-selector short-circuits -----
+[flatten]
+def l_t0(a : float; b : float) : float {
+    return lerp(a, b, 0.0)
+}
+
+[flatten]
+def l_t1(a : float; b : float) : float {
+    return lerp(a, b, 1.0)
+}
+
+[flatten]
+def l_same(a : float; t : float) : float {
+    return lerp(a, a, t)
+}
+
+// ----- lerp where expansion exposes a full fold: lerp(1, d, 1) -> d -----
+[flatten]
+def l_const1(d : float) : float {
+    return lerp(1.0, d, 1.0)
+}
+
+// ----- lerp round trip: expand -> nothing folds -> refuse to the same call -----
+[flatten]
+def l_round(a : float; b : float; t : float) : float {
+    return lerp(a, b, t)
+}
+
+[flatten]
+def l_vec(a : float3; b : float3; t : float) : float3 {
+    return lerp(a, b, t)
+}
+
+// ----- raw arithmetic canonicalized INTO lerp (never spelled `lerp` in source) -----
+[flatten]
+def l_manual(a : float; b : float; t : float) : float {
+    return (b - a) * t + a
+}
+
+[flatten]
+def l_vec_manual(a : float3; b : float3; t : float) : float3 {
+    return (b - a) * t + a
+}
+
+// ----- uniform lerp bounds: the preshader split beats the lerp node (mad(_preshader_, x, G_A)) -----
+[flatten]
+def p_lerp(x : float) : float {
+    return lerp(G_A, G_B, x)
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "fused-mad approx mismatch: {a} vs {b}")
+}
+
+def cmp3f_approx(t : T?; a, b : float3) {
+    fapprox(t, a.x, b.x); fapprox(t, a.y, b.y); fapprox(t, a.z, b.z)
+}
+
+def cmp3i(t : T?; a, b : int3) {
+    t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
+}
+
+[test]
+def test_flatten_mad(t : T?) {
+    t |> run("mad: a*b + c fuses (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, m_basic_flat(v, v * 0.5 - 1.0, 3.0), m_basic(v, v * 0.5 - 1.0, 3.0))
+        }
+    }
+    t |> run("mad: c + a*b fuses (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, m_right_flat(v, v + 2.0, -v), m_right(v, v + 2.0, -v))
+        }
+    }
+    t |> run("mad: x*C + C remap (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, m_remap_flat(v), m_remap(v))
+        }
+    }
+    t |> run("mad: a*b - C negates the addend (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, m_subc_flat(v, v - 3.0), m_subc(v, v - 3.0))
+        }
+    }
+    t |> run("mad: C - a*b negates the const factor (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, m_csub_flat(v), m_csub(v))
+        }
+    }
+    t |> run("mad: a*b + c*d absorbs one mul (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, m_chain_flat(v, 2.0, v - 1.0, 3.0), m_chain(v, 2.0, v - 1.0, 3.0))
+        }
+    }
+    t |> run("mad: int (exact)") @(t : T?) {
+        for (v in GRID) {
+            let n = int(v)
+            t |> equal(m_int_flat(n, n + 3, 7), m_int(n, n + 3, 7))
+        }
+    }
+    t |> run("mad: float3 (approx — hardware-fused)") @(t : T?) {
+        for (v in GRID) {
+            let a = float3(v, -v, v * 0.5)
+            cmp3f_approx(t, m_vec_flat(a, a + float3(1.0), a - float3(2.0)), m_vec(a, a + float3(1.0), a - float3(2.0)))
+        }
+    }
+    t |> run("mad: float3 * scalar + float3 MadS (approx)") @(t : T?) {
+        for (v in GRID) {
+            let w = float3(v, v + 1.0, -v)
+            cmp3f_approx(t, m_vecs_flat(w, v * 0.25, w * 2.0), m_vecs(w, v * 0.25, w * 2.0))
+        }
+    }
+    t |> run("mad: int3 (exact)") @(t : T?) {
+        for (v in GRID) {
+            let n = int(v)
+            let a = int3(n, n + 1, -n)
+            cmp3i(t, m_veci_flat(a, a + int3(2), a - int3(3)), m_veci(a, a + int3(2), a - int3(3)))
+        }
+    }
+    t |> run("mad: int3 * scalar + int3 MadS (exact)") @(t : T?) {
+        for (v in GRID) {
+            let n = int(v)
+            let a = int3(n, n - 2, n + 5)
+            cmp3i(t, m_intvs_flat(a, n + 1, a * 2), m_intvs(a, n + 1, a * 2))
+        }
+    }
+    t |> run("lerp: t=0 -> a (exact)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(l_t0_flat(v, v * 3.0), l_t0(v, v * 3.0))
+        }
+    }
+    t |> run("lerp: t=1 -> b (approx — twin computes a + (b-a))") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, l_t1_flat(v, v * 3.0 + 1.0), l_t1(v, v * 3.0 + 1.0))
+        }
+    }
+    t |> run("lerp: a==b -> a (exact)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(l_same_flat(v, v * 0.5), l_same(v, v * 0.5))
+        }
+    }
+    t |> run("lerp: lerp(1, d, 1) folds to d (exact)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(l_const1_flat(v), l_const1(v))
+        }
+    }
+    t |> run("lerp: scalar round trip (exact — same builtin both sides)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(l_round_flat(v, v + 5.0, 0.25), l_round(v, v + 5.0, 0.25))
+        }
+    }
+    t |> run("lerp: vector round trip (exact — same builtin both sides)") @(t : T?) {
+        for (v in GRID) {
+            let a = float3(v, -v, v + 1.0)
+            let b = a * 2.0 + float3(1.0)
+            t |> equal(l_vec_flat(a, b, 0.75).x, l_vec(a, b, 0.75).x)
+            t |> equal(l_vec_flat(a, b, 0.75).y, l_vec(a, b, 0.75).y)
+            t |> equal(l_vec_flat(a, b, 0.75).z, l_vec(a, b, 0.75).z)
+        }
+    }
+    t |> run("lerp: raw (b-a)*t + a canonicalizes INTO lerp (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, l_manual_flat(v, v * 2.0 - 3.0, 0.4), l_manual(v, v * 2.0 - 3.0, 0.4))
+        }
+    }
+    t |> run("lerp: raw vector form -> lerp (approx — builtin is fused)") @(t : T?) {
+        for (v in GRID) {
+            let a = float3(v, v * 0.5, -v)
+            let b = float3(-v, v + 2.0, v)
+            cmp3f_approx(t, l_vec_manual_flat(a, b, 0.3), l_vec_manual(a, b, 0.3))
+        }
+    }
+    t |> run("lerp: uniform bounds -> preshader split + mad (exact)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(p_lerp_flat(v), p_lerp(v))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_opt.das
+++ b/tests/flatten/test_flatten_opt.das
@@ -8,11 +8,13 @@ require math
 
 //! Differential net for the flatten OPTIMIZE arc (preshader extraction + CSE).
 //! Both passes are VALUE-EXACT — they only hoist and dedup pure subtrees, never
-//! regroup or round — so every twin compares with exact `equal` (unlike the
-//! reassoc arc, which reserves `equal_approx`). The FIRED proof (a `_preshader_`
-//! let on top, a shared `_cse_` let) lives in `no_aot/test_flatten_fold.das`
-//! (empty `flatten_opt_residuals`) and the cap_preshader / cap_cse node-count
-//! shaders; here we only assert the optimization preserved the result.
+//! regroup or round — so twins compare with exact `equal` (unlike the reassoc
+//! arc). ONE carve-out: PHASE_FUSED re-packs a vector mul-add into `mad`, which
+//! runs hardware-fused (FMA, single rounding), so a vector twin where that fires
+//! (p_vec) compares approx. The FIRED proof (a `_preshader_` let on top, a shared
+//! `_cse_` let) lives in `no_aot/test_flatten_fold.das` (empty
+//! `flatten_opt_residuals`) and the cap_preshader / cap_cse node-count shaders;
+//! here we only assert the optimization preserved the result.
 
 // Module globals are UNIFORM (preshader-eligible); function params are VARYING.
 var G_GAIN = 2.5
@@ -132,6 +134,15 @@ def cmp3f(t : T?; a, b : float3) {
     t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
 }
 
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "fused-mad approx mismatch: {a} vs {b}")
+}
+
+def cmp3f_approx(t : T?; a, b : float3) {
+    fapprox(t, a.x, b.x); fapprox(t, a.y, b.y); fapprox(t, a.z, b.z)
+}
+
 [test]
 def test_flatten_opt(t : T?) {
     t |> run("preshader: whole-uniform let -> _preshader_") @(t : T?) {
@@ -149,9 +160,9 @@ def test_flatten_opt(t : T?) {
             t |> equal(p_chain_flat(v), p_chain(v))
         }
     }
-    t |> run("preshader: vector-typed uniform") @(t : T?) {
+    t |> run("preshader: vector-typed uniform (approx — fused mad in the preshader)") @(t : T?) {
         for (v in GRID) {
-            cmp3f(t, p_vec_flat(float3(v, -v, v * 2.0)), p_vec(float3(v, -v, v * 2.0)))
+            cmp3f_approx(t, p_vec_flat(float3(v, -v, v * 2.0)), p_vec(float3(v, -v, v * 2.0)))
         }
     }
     t |> run("CSE: varying dup -> _cse_") @(t : T?) {

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -101,13 +101,13 @@ foreach(util ${DAS_UTILS})
 endforeach()
 add_dependencies(all_utils_exe dastest_exe)
 
-# Prewarm the JIT dll cache for the whole test tree, except the gc folder (which
-# dastest also excludes under -jit — it uses runtime quote/qmacro the JIT can't
-# lower). Reuses the jit_exe target built by the foreach above (bin/jit.exe, built
+# Prewarm the JIT dll cache for the whole test tree, except the folders dastest
+# also excludes under -jit (gc, ast_match, no_aot — they use runtime quote/qmacro
+# the JIT can't lower). Reuses the jit_exe target built by the foreach above (bin/jit.exe, built
 # with --jit-register-all-modules). Run explicitly:
 #   ninja jit_cache_all_tests
 add_custom_target(jit_cache_all_tests
-    COMMAND ${UTIL_BIN_DIR}/jit.exe ${PROJECT_SOURCE_DIR}/tests --parallel 0 $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3> --exclude gc --exclude dasHV --exclude dasPUGIXML --exclude dasSQLITE --exclude stbimage --exclude live_host --exclude audio --exclude strudel --exclude ast_match
+    COMMAND ${UTIL_BIN_DIR}/jit.exe ${PROJECT_SOURCE_DIR}/tests --parallel 0 $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3> --exclude gc --exclude dasHV --exclude dasPUGIXML --exclude dasSQLITE --exclude stbimage --exclude live_host --exclude audio --exclude strudel --exclude ast_match --exclude no_aot
     DEPENDS jit_exe
     WORKING_DIRECTORY ${UTIL_BIN_DIR}
     COMMENT "JIT-compiling tests/ into the .jitted_scripts cache"

--- a/utils/flatten-fuzz/main.das
+++ b/utils/flatten-fuzz/main.das
@@ -116,6 +116,13 @@ def gen_expr(var g : Gen&; scope : array<Var>; depth : int) : string {
         let op = rnd(g, 2) == 0 ? "-" : "~"
         let e = gen_expr(g, scope, depth - 1)
         return "({op} {e})"   // space: avoid `--`/`-~` token glue on negative literals
+    } elif (k < 90) {
+        // exercises the lerp/mad disassemble -> re-fuse arc (int mad is exact, so the
+        // differential oracle rides free; strict mode checks the fusion residual arms)
+        let a = gen_expr(g, scope, depth - 1)
+        let b = gen_expr(g, scope, depth - 1)
+        let c = gen_expr(g, scope, depth - 1)
+        return "mad({a}, {b}, {c})"
     }
     return gen_leaf(g, scope)
 }
@@ -472,7 +479,8 @@ def build_file(units : array<string>) : string {
         if (g_log_infer) {
             write(w, "options log_infer_passes = true\n")
         }
-        write(w, "require daslib/flatten\n\n")
+        write(w, "require daslib/flatten\n")
+        write(w, "require math\n\n")
         if (g_use_globals) {
             write(w, G_DEFS)
         }


### PR DESCRIPTION
# flatten Optimization 3 — mad/lerp fusion

`lerp` and `mad` are pure arithmetic wearing a call. The fold phase now **disassembles** them in place — `mad(a, b, c) → a*b + c`, `lerp(a, b, t) → (b - a)*t + a` — so every downstream pass sees through them; once the optimize pass converges, a new **PHASE_FUSED** finishing pass **re-packs** what survived into single backend nodes. The target backend is a GPU-side bytecode interpreter, so node count is the objective function outright.

## What expansion buys

- **Const selectors collapse through the existing identity arms, with no per-builtin identity table**: `lerp(a,b,0) → a`, `lerp(a,b,1) → b`, `lerp(a,a,t) → a`, `mad(a,1,c) → a + c`, and raymarch's `lerp(1.0, d, 1.0) → d` across its unrolled iterations.
- Reassoc canonicalises the exposed operands, CSE shares a repeated `b - a` across lerps, and preshader extraction hoists a uniform `b - a` even when `t` is varying.
- New `x - x → 0` fold arm (purity-gated like `*0`).

## What re-fusion packs

- `a*b + c` / `c + a*b` → `mad(a, b, c)` — including the vec·scalar MadS broadcast and the const-negation forms `a*b - C` / `C - a*b`.
- A mad still carrying the lerp shape — `mad(b - a, t, a)` → `lerp(a, b, t)`. Hand-written `(b - a)*t + a` arithmetic that never spelled `lerp` canonicalises into the lerp node the same way (cap_mad proves it).
- `(-a) + b` → `b - a` (one sub instead of neg + add) for negates the `0 - x` / `*-1` folds produce.
- Type gates mirror the das `math` overload set (float/int/uint scalar + vector; lerp scalar-`t` only — the one shape every provider has; a vector-`t` re-fusion would emit a call the scalar-`t` DSL stubs can't resolve). Fusion is gated on a 3-arg `mad`/`lerp` visible from the twin's module. The matchers carry **no purity gate** — flat-body calls are pure by the verify_flat contract, and `has_sideeffects` is timing-dependent (`noSideEffects` node flags only settle post-compile, so the fuser and the residual oracle would disagree on DSL stub calls like `tex2d`).
- PHASE_FUSED iterates with re-infer between rounds (each round strictly drops a `+`/`-`, so it converges); the `[pixel_shader]` backend mirrors the loop via a `fused` annotation flag.

## Eyeball results

loop_multi's weighted accumulator chain:
```
var __ssa_acc_3:float3 = mad(tex2d(albedo_texture,inp.uv).xyz,0.5f,__ssa_acc_2);
var __ssa_acc_4:float3 = mad(tex2d(albedo_texture,_preshader_1 + inp.uv).xyz,0.25f,__ssa_acc_3);
```

raymarch_spheres: 16 mads — each smooth-min step is `saturate(mad((d - ds)/smoothK, 0.5, 0.5))` + `mad((h-1)*h, smoothK, (ds-d)*h) + d`, the march step is `mad(rd, depth, ro)`, the cosine palette is `mad(float3(0.5), cos(...), float3(0.5))`. Across all 61 lerp-using shaders, 45 end with **zero** lerps in the output (folded or packed); the survivors are genuine all-varying round trips (e.g. shadow_2d) or the type-gated mixed-int-literal case (fresnel's `lerp(0.2, 10, daylight)` — hoisted whole into the preshader anyway).

## Extraction joins the optimize fixpoint

The fuzzer surfaced a pre-existing gap this arc amplified 5x: cse/alias rounds re-expose **uniform compute in the varying region** (an alias subst creates `!_preshader_0`; a `_cse_` let's operands converge to all-preshader refs), which position-based naming then leaves running per-pixel. `extract_preshader` now iterates with cse/alias to a joint fixpoint, with re-entry support: a caller-owned name counter, the existing prefix seeds the dedup map + coloring (so a re-hoist reuses the old name and a prefix let never re-hoists its own init), and fresh hoists splice after the old prefix. Fuzzer strict residuals dropped 65 → 13 per 8 batches (the remainder is the known post-fold late-materialization class).

## Positives-first reassoc order

Reassoc's canonical var sort now orders positive terms before subtracted ones, so `build_chain` emits `b - a` instead of `-a + b` (negate + add). Besides the extra body node, the neg-add form made extraction hoist a uniform `-a` into a pass-through `_preshader_N = -_preshader_M` alias — raymarch carried three; its preshader drops 8 → 5 lets. `vars_sorted` mirrors the new order exactly (idempotence).

## Zero-init materialization (partially-assigned locals)

```das
var a : float3
var b : float3
if (x > 0.5) { a = float3(1,0,0) } else { b = float3(0,1,0) }
```
worked at das level but the IR builder rejected the bare decls (its accumulator rail binds to the init's pin). The lowering now materializes daslang's implicit zero-init on init-less locals of supported types; const-prop then inlines the zero into the selects and the decls die before reaching the IR. New `branch_partial.shader` feature fixture + `partial_vec`/`partial_scalar` differential twins.

## Tests / oracles

- `tests/flatten/test_flatten_mad.das` — 21 differential twins. Int twins and same-builtin round trips compare exact; ANY float twin comparing raw interp ops against a `mad`/`lerp` builtin compares approx — the vector builtins are hardware-fused (NEON FMLA / x86 FMADD), and even the scalar C++ impls get FMA-contracted by the host compiler.
- Fusion-residual arms in `flatten_opt_residuals` (un-fused mul-add, un-refused lerp shape, un-packed neg-add) share the exact matcher functions with the fuser; the no_aot meta-test runs them over the mad corpus and every example shader.
- `cap_mad.shader` capability case: 2 mad + 1 lerp graph nodes asserted in check.sh.
- flatten-fuzz: `mad(e,e,e)` in the int grammar (exact differential rides free) + `require math` in generated units.
- The example DSL gains three `mad(fN, float, fN)` broadcast stubs (fusing `v*s + w` needs them); the `[pixel_shader]` macro mirrors the fuse stage.

## Verification

interp full suite 10690/0/0 · AOT full suite (CI form, rebuilt test_aot) 10028/0/0 · JIT tests/flatten 177/177 + verifier smoke clean · run.sh 69/0 · capability check.sh 16/16 · no_aot residual oracle green over all corpora + 60+ shaders · flatten-fuzz 40 value + 40 strict batches PASS, zero fail dumps · Sphinx clean build, 0 warnings · CI-form lint 0 issues · dupe check: no new non-test duplication.

Follow-ups queued (not in this PR): const-distribution `(a + C1)*C2 → mad(a, C2, C1*C2)` incl. the uniform-operand variant; division-by-uniform → `rcp` preshader reciprocal; both behind a fast-math user option (`options _no_fast_math` style opt-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)