### PR TITLE
fixed-array rework stage 0: characterization suite + target spec

### DIFF
--- a/FIXED_ARRAY_REWORK.md
+++ b/FIXED_ARRAY_REWORK.md
@@ -123,6 +123,9 @@ The indivisible piece, sub-staged for review:
   initializers, inferTypeExpr (dimConst resolution per node), variable checks.
 - **1e** Simulate lowering: ExprAt/iterator SimNode emission computed from nested type
   (same SimNodes), the fakeVariable flatten hack (ast_simulate.cpp ~:949), ExprNew dims.
+  Note: gen2 `new Foo[3]` parses as `(new Foo)[3]` (pointer index), NOT new-dim — the
+  ExprNew-with-dim / das_new_dim path is reachable via other routes (gen1 et al.);
+  map its actual reachability during this sub-stage before porting it.
 - **1f** debug-info helper flatten; AST serializer (+version bump); module_builtin_ast
   bindings: expose new fields + computed read-only `.dim`/`.dimExpr` compat.
 Inference semantics flip in this stage; fallout fixes in tests/daslib land here.
@@ -142,7 +145,11 @@ Delete the `[]` workaround families in builtin.das (table get x4 / get_value / i
 insert_clone x2 / emplace / values x2 / get_key; array push/emplace/push_clone siblings);
 verify base generics cover them. Generalize `each`/`sort`/`find_index`/`subarray`/`clone`/
 `finalize_dim`. Un-reject fixed arrays in apply.das / contracts.das where they now just work.
-Exit: new multi-dim/typedef'd-array tests pass through the generic stdlib; LOC visibly negative.
+The broken-on-master get_key(table<K;V[N]>) overload is NOT fixed in place (it gets deleted
+here) — the get_key target subtest in tests/fixed_array stays disabled until THIS stage and
+its enablement is part of this stage's exit gate.
+Exit: new multi-dim/typedef'd-array tests pass through the generic stdlib (incl. get_key on
+FA values); LOC visibly negative.
 
 ### Stage 5 — Macro/tooling ports
 ast_match.das (structural FA matching), match.das, typemacro_boost (field rename), lints

--- a/FIXED_ARRAY_REWORK.md
+++ b/FIXED_ARRAY_REWORK.md
@@ -1,0 +1,160 @@
+# Fixed Array Rework — `tFixedArray` as a structural type
+
+Master plan for replacing the flattened `dim`/`dimExpr` vectors on `TypeDecl` with a
+structural `Type::tFixedArray` node, so fixed arrays resolve through the same recursive
+machinery as every other container type. Living document on the
+`bbatkin/fixed-array-type` branch; every stage is review-gated (plan first, then commits).
+
+## Problem
+
+`dim` is a qualifier vector bolted onto every `TypeDecl` instead of type structure.
+Verified consequences on master:
+
+```
+take_plain(a : auto(TT))   <- int[4]      =>  TT = int          // array-ness silently stripped
+take_dim1(a : auto(TT)[])  <- float[4][4] =>  NO MATCH          // dim.size() 1 != 2
+take_dim1(a : auto(TT)[])  <- M4[10]      =>  NO MATCH          // M4=float[4][4] flattens to float[10][4][4]
+var a : M4[3]              =>  a is float[3][4][4]              // M4 identity destroyed at declaration
+a[0]                       =>  float[4][4]                      // anonymous; should be M4
+```
+
+Root causes:
+
+- `updateAliasMap` clears `dim` when recording `auto(TT)` — dim sits in the qualifier set
+  next to `constant`/`ref`/`temporary`, so the deduced alias lies about the type
+  (body sees `int const[4]`, `TT` claims `int`, `default<TT>` gives `int`).
+- `inferGenericType` requires exact dim-count match; `auto[]` can never peel one level off
+  a multi-dim array because there is no "rest of the type" node to bind.
+- Alias expansion concatenates dim vectors, destroying typedef boundaries irrecoverably.
+- Every `isX()` predicate pays a `dim.size()==0` tax; daslib carries ~25 workaround
+  overloads (`table<K; auto(valT)[]>` get/get_value/insert/insert_clone/emplace/values/get_key
+  families, `array<auto(numT)[]>` push/emplace/push_clone siblings), each reconstructing the
+  thrown-away type via `valT[typeinfo dim_table_value(Tab)]` — and covering only ONE `[]` level.
+  `apply.das`/`contracts.das` simply reject fixed arrays.
+
+Meanwhile `array<T>`, `table<K;V>`, pointers, iterators all infer correctly — they are
+structural nodes with `firstType` recursion. Fixed arrays are the only container that isn't.
+
+## Settled design
+
+- **`Type::tFixedArray`**, appended at the END of the `Type` enum (existing values stay
+  stable for serialized data). Element type in `firstType`.
+- **Strict nesting, one size per node**, outermost first:
+  - `float[4][4]` = `FA(4, FA(4, float))`
+  - `M4[3]` (M4 = `float[4][4]`) = `FA(3, FA(4, FA(4, float)) alias="M4")`
+  - Alias is a display label (same as `aka` today); identity stays plain structural
+    recursion. One type, one shape — no flatten-canonicalization anywhere.
+- **`TypeDecl` fields**: `dim` and `dimExpr` deleted. Added:
+  - `int32_t fixedDim` — size; `dimAuto`/`dimConst` sentinels kept (`int[]` param =
+    `FA(dimAuto, int)`); meaningful only on tFixedArray nodes
+  - `ExpressionPtr fixedDimExpr` — size expression when `fixedDim == dimConst`
+  - `vector<ExpressionPtr> typeMacroExpr` — typeMacro/typeDecl/tag payload, contents and
+    conventions byte-identical to today's dimExpr usage (typeMacro: `[0]`=name string,
+    `[1..]`=args, type-args arrive as `ExprTypeDecl`; typeDecl/tag: `[0]`=the expr).
+    No typemacro argument-model redesign in this train.
+  - Net ~−12B per node; every predicate drops the `dim.size()` branch.
+- `isNativeDim` moves onto the FA node; `typeFactory<TT[dim]>` wraps instead of pushes.
+- **Qualifier discipline**: `constant`/`ref`/`temporary` on the OUTER node describe the
+  whole object — same rule as `tArray`. Peeling a level (`a[i]`, iteration, `auto(TT)[]`)
+  = `firstType` plus the same constness propagation tArray element access uses.
+- `-[]` (`removeDim`) = unwrap one FA level; kept parsing, mostly obsolete.
+- **New inference semantics (no compat shim)**:
+  - `auto(TT)` <- `int[4]`        => `TT = int[4]` (whole array, consistent with `array<int>`)
+  - `auto(TT)[]` <- `float[4][4]` => `TT = float[4]` (new match)
+  - `auto(TT)[]` <- `M4[10]`      => `TT = M4` (alias preserved on the node)
+  - `a[0]` on `M4[3]`             => `M4`
+  - Overload ranking must keep `auto[]` more specific than plain `auto` so existing call
+    sites don't go ambiguous.
+- **Runtime `TypeInfo` stays flattened forever** — `dim`/`dimSize` describe memory layout,
+  and the flattened form IS the layout. Single AST->runtime conversion point
+  (`ast_debug_info_helper.cpp`) walks the nested chain and emits `dim[]={3,4,4}` exactly as
+  today. GC walker, data walker, debug print, JIT TypeInfo globals, `daslib/rtti` untouched.
+- **Mangled-name TEXT unchanged** (`[3][4][4]f` is already a nested prefix encoding):
+  emitted from nesting, parsed into nesting. AOT symbol names don't churn. Semantic-hash,
+  AST-serializer, and `LLVM_JIT_CODEGEN_VERSION` bumps happen once.
+- **Same SimNodes emitted** — interpreter/runtime untouched; stride/count computed from the
+  nested type instead of the dim vector.
+- **das macro API**: during migration, read-only computed `.dim`/`.dimExpr` compat
+  properties (flattened view) keep aot_cpp.das / llvm_jit.das / macros green while they
+  port to the structural API (`baseType==tFixedArray`, `.fixedDim`, `.fixedDimExpr`,
+  `.firstType`, `.typeMacroExpr`). Compat properties are DELETED after the sweep
+  (optionally keep a `dims(td)` helper in ast_boost for code that wants the flattened list).
+- Parser keeps the existing `MyMacro(...)[N]` / `typedecl(...)[N]` errors (behavior-
+  preserving); lifting them becomes representable and is a separate later decision.
+
+## Stages
+
+Each stage: plan discussion -> implementation -> commit review. CI + /test green at every gate.
+
+### Stage 0 — Characterization & target tests
+Pin current must-not-change behavior as a dastest suite run against master semantics:
+layout (sizeof/alignof/stride/field offsets incl. C++ handled types, tuples, variants with
+FA fields), copy/clone/init semantics, indexing + bounds, iteration, `table<K;V[]>` /
+`array<T[]>` operations, serialization round-trip, AOT, `typeinfo dim` traits, current
+overload preference (`auto` vs `auto[]` with FA arg). Plus the TARGET-behavior tests
+(initially disabled) encoding the new inference semantics and M4 preservation.
+Exit: suite green on the branch point; target tests reviewed as the spec.
+
+### Stage 1 — Core representation flip
+The indivisible piece, sub-staged for review:
+- **1a** TypeDecl fields + `Type::tFixedArray` + predicates + clone/visit/gc/sanitize +
+  describe + mangled name (emit + parse) + `isSameType` + semantic/lookup hash +
+  getSizeOf/stride/align family.
+- **1b** Parsers (ds2 + ds1 + parser_impl): build nested FA chains; typeMacro/typeDecl/tag
+  move to `typeMacroExpr`; keep existing grammar errors.
+- **1c** typeFactory / interop (`TT[dim]`, `TDim<>`, `isNativeDim`, makeArgumentType,
+  ast_handle).
+- **1d** Infer: inferAlias (WRAP, don't concatenate — alias label preserved),
+  inferGenericType / updateAliasMap / applyAutoContracts (dim arms deleted; FA rides the
+  firstType recursion), ExprAt/ExprSafeAt result typing, for-loop sources, make-array /
+  initializers, inferTypeExpr (dimConst resolution per node), variable checks.
+- **1e** Simulate lowering: ExprAt/iterator SimNode emission computed from nested type
+  (same SimNodes), the fakeVariable flatten hack (ast_simulate.cpp ~:949), ExprNew dims.
+- **1f** debug-info helper flatten; AST serializer (+version bump); module_builtin_ast
+  bindings: expose new fields + computed read-only `.dim`/`.dimExpr` compat.
+Inference semantics flip in this stage; fallout fixes in tests/daslib land here.
+Exit: full CI green with aot_cpp.das / llvm_jit.das / macro daslib UNMODIFIED (riding compat).
+
+### Stage 2 — AOT emitter
+`daslib/aot_cpp.das` ports to the structural API; nested `TDim` emission becomes natural
+recursion; AOT version bump. Exit: tests/aot + AOT CI green.
+
+### Stage 3 — JIT
+`modules/dasLLVM/daslib/llvm_jit.das` port (element type, bounds checks, loop ranges from
+nesting; TypeInfo globals unchanged — flattened); bump `LLVM_JIT_CODEGEN_VERSION`.
+Exit: JIT tests green.
+
+### Stage 4 — daslib payoff
+Delete the `[]` workaround families in builtin.das (table get x4 / get_value / insert x2 /
+insert_clone x2 / emplace / values x2 / get_key; array push/emplace/push_clone siblings);
+verify base generics cover them. Generalize `each`/`sort`/`find_index`/`subarray`/`clone`/
+`finalize_dim`. Un-reject fixed arrays in apply.das / contracts.das where they now just work.
+Exit: new multi-dim/typedef'd-array tests pass through the generic stdlib; LOC visibly negative.
+
+### Stage 5 — Macro/tooling ports
+ast_match.das (structural FA matching), match.das, typemacro_boost (field rename), lints
+(perf_lint/style_lint), is_local, templates_boost, decs_boost, clargs, rst.das; decision on
+utils/dasFormatter's vendored parser (port vs freeze); MCP describe_type sanity.
+Exit: no in-tree consumers of the compat properties left.
+
+### Stage 6 — Externals + compat removal
+Sweep D:\DASPKG modules (dasImgui, dasSQLITE, ...); delete `.dim`/`.dimExpr` compat
+properties; optional `dims(td)` helper lands in ast_boost.
+Exit: grep-clean everywhere.
+
+### Stage 7 — Docs + merge
+RST (type system, generic programming), CHANGELOG, version bump; final full-matrix CI +
+AOT + JIT verification; merge to master. Optional separate decision: lift the
+`MyMacro(...)[N]` parser restriction.
+
+## Standing risk ledger (checked at every stage gate)
+
+1. **const/ref/temporary propagation through FA levels** — the subtle-bug budget; audited
+   with targeted tests per stage.
+2. **Layout invariance** — Stage 0 is the gate; any diff is a stop-the-line bug
+   (C++ interop depends on identical layout).
+3. **Overload-resolution shifts** — new `auto[]` matches that didn't exist before;
+   explicit ranking rule + tests.
+4. Known generic-instance mangling collisions (error 50609) may surface new shapes.
+5. AOT hash desync / serialization — version bumps; skills/aot_hash_desync_debugging.md.
+6. gen1 parser (`ds_parser.ypp`) parity with gen2.

--- a/FIXED_ARRAY_REWORK.md
+++ b/FIXED_ARRAY_REWORK.md
@@ -79,6 +79,10 @@ structural nodes with `firstType` recursion. Fixed arrays are the only container
   port to the structural API (`baseType==tFixedArray`, `.fixedDim`, `.fixedDimExpr`,
   `.firstType`, `.typeMacroExpr`). Compat properties are DELETED after the sweep
   (optionally keep a `dims(td)` helper in ast_boost for code that wants the flattened list).
+  The compat `.dimExpr` property must be **baseType-aware** — on typeMacro/typeDecl/tag
+  nodes it returns `typeMacroExpr` (so typemacro_boost works unmodified until its Stage-5
+  rename); on tFixedArray nodes it returns the size-expr view. "Whatever dimExpr used to
+  hold for this baseType."
 - Parser keeps the existing `MyMacro(...)[N]` / `typedecl(...)[N]` errors (behavior-
   preserving); lifting them becomes representable and is a separate later decision.
 
@@ -87,12 +91,21 @@ structural nodes with `firstType` recursion. Fixed arrays are the only container
 Each stage: plan discussion -> implementation -> commit review. CI + /test green at every gate.
 
 ### Stage 0 — Characterization & target tests
-Pin current must-not-change behavior as a dastest suite run against master semantics:
-layout (sizeof/alignof/stride/field offsets incl. C++ handled types, tuples, variants with
-FA fields), copy/clone/init semantics, indexing + bounds, iteration, `table<K;V[]>` /
-`array<T[]>` operations, serialization round-trip, AOT, `typeinfo dim` traits, current
-overload preference (`auto` vs `auto[]` with FA arg). Plus the TARGET-behavior tests
-(initially disabled) encoding the new inference semantics and M4 preservation.
+Pin current must-not-change behavior as a dastest suite (`tests/fixed_array/`) run against
+master semantics: layout (sizeof/alignof/stride/field offsets incl. C++ handled types,
+tuples, variants with FA fields), copy/clone/init semantics, indexing + bounds, iteration,
+`table<K;V[]>` / `array<T[]>` operations, serialization round-trip, AOT, `typeinfo dim`
+traits, current overload preference (`auto` vs `auto[]` with FA arg). Plus the
+TARGET-behavior tests (initially disabled via leading-`_` filenames) encoding the new
+inference semantics and M4 preservation.
+Also `tests/typemacro/test_basic.das` — direct coverage of the typeMacro payload surface
+that Stage 1b migrates (all four grammar forms; `typemacro_argument` const-extraction for
+int/bool/string; `typeMacroName`; `typedecl(expr)`). Deep indirect coverage already exists
+via tests/option + tests/hash_map + tests/delegate (Option/Result/hash tables are
+typemacro_boost-based), but the raw grammar forms and const-arg extraction had none.
+Known-broken-on-master, expected fixed by this rework (target spec, NOT characterization):
+`get_key(table<K;V[]>, v)` fails to resolve its own `valT const[-2]` contortion
+(builtin.das:1407).
 Exit: suite green on the branch point; target tests reviewed as the spec.
 
 ### Stage 1 — Core representation flip

--- a/FIXED_ARRAY_REWORK.md
+++ b/FIXED_ARRAY_REWORK.md
@@ -133,7 +133,10 @@ Exit: full CI green with aot_cpp.das / llvm_jit.das / macro daslib UNMODIFIED (r
 
 ### Stage 2 — AOT emitter
 `daslib/aot_cpp.das` ports to the structural API; nested `TDim` emission becomes natural
-recursion; AOT version bump. Exit: tests/aot + AOT CI green.
+recursion; AOT version bump. Also fixes issue #3077 (iterate/pass/copy of a NATIVE C-array
+field emits non-compiling C++ — found by Stage 0, test_interop.das AOT-excluded since) if
+not fixed earlier; re-include test_interop in the AOT glob to verify.
+Exit: tests/aot + AOT CI green, test_interop back in the AOT set.
 
 ### Stage 3 — JIT
 `modules/dasLLVM/daslib/llvm_jit.das` port (element type, bounds checks, loop ranges from

--- a/skills/aot_testing.md
+++ b/skills/aot_testing.md
@@ -81,7 +81,13 @@ The `-use-aot` flag enables AOT for sub-compiled test files even when the host b
 
 This applies to ALL test directories (e.g., `tests/fio/`, `tests/fs/`, `tests/json/`), not just `tests/aot/`. See the "Registering a New Test Directory" section below.
 
-**Do NOT use `options no_aot`** to suppress AOT link failures — register the tests properly in CMake instead.
+**Do NOT use `options no_aot`** to mask a missing CMake registration — register the tests properly instead.
+
+**Exception — a file that genuinely can't AOT** (codegen/emitter bug, interpreted-only by design): use BOTH markers together, each with a comment + issue link:
+1. `options no_aot` in the file — makes test_aot's `fail_on_no_aot` skip AOT linking for it at runtime;
+2. exclude it from the directory's AOT glob in `tests/aot/CMakeLists.txt` — skips generating stubs that wouldn't compile.
+
+**Trap:** glob exclusion ALONE is not enough. `test_aot` runs every file under `tests/` regardless of what was stub-generated, so an excluded-but-not-`no_aot` file fails at runtime with `error[50101]` on all its functions (precedent: `tests/fixed_array/test_interop.das`, issue #3077).
 
 ## Adding a New AOT Test in `tests/aot/`
 

--- a/skills/aot_testing.md
+++ b/skills/aot_testing.md
@@ -368,6 +368,6 @@ SOURCE_GROUP_FILES("aot generated" FOO_AOT_GENERATED_SRC)
 
 **Step 5** — Add `test_aot_foo` to the `ADD_DEPENDENCIES(test_aot ...)` list.
 
-**Why this matters**: CI builds `test_aot` on Linux/macOS and runs ALL tests under `tests/` with AOT enabled (`cop.fail_on_no_aot = true`). Without registration, the test's functions won't have AOT stubs → `error[50101]: AOT link failed`. The `test_aot` target is only built on non-Windows platforms (`NOT WIN32` guard in root CMakeLists.txt), so this failure won't be caught locally on Windows.
+**Why this matters**: CI builds `test_aot` on Linux/macOS/Windows-64 and runs ALL tests under `tests/` with AOT enabled (`cop.fail_on_no_aot = true`). Without registration, the test's functions won't have AOT stubs → `error[50101]: AOT link failed`. `test_aot` builds and runs fine on Windows (only 32-bit Windows is excluded — `NOT (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)` gate in root CMakeLists.txt); it requires tests and AOT examples enabled in the CMake configure.
 
 Also ensure that wrapper functions in builtin `.das` files (like `src/builtin/fio.das`) are marked `[generic]` — otherwise AOT can't inline them and will try to link against a non-existent concrete stub from the builtin module.

--- a/skills/writing_tests.md
+++ b/skills/writing_tests.md
@@ -2,6 +2,19 @@
 
 Tests use the `dastest` framework. Test files live in `tests/` with per-module subfolders.
 
+## AOT registration (REQUIRED for new test directories)
+
+CI's `test_aot` binary runs EVERY test under `tests/` with AOT enabled (`fail_on_no_aot`).
+Creating a new test directory ⇒ register it in `tests/aot/CMakeLists.txt` (5-step pattern in
+`skills/aot_testing.md` § "Registering a New Test Directory"), or CI fails with
+`error[50101]: AOT link failed`.
+
+If a specific file genuinely can't AOT (emitter bug, interpreted-only by design): put
+`options no_aot` IN THE FILE **and** exclude it from the directory's AOT glob, with a
+comment + issue link on both. Glob exclusion alone is NOT enough — test_aot still *runs*
+the file and trips 50101 on its missing stubs; `options no_aot` is what makes the runtime
+skip AOT linking for it.
+
 ## Test file structure
 
 ```das

--- a/tests/README.md
+++ b/tests/README.md
@@ -386,7 +386,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_containers.das | `array<int[4]>` push/push_clone/emplace, `table<K;int[4]>` insert/get/get_value/values/insert_clone (get_key excluded — broken on master, see target spec) | |
 | test_generics_current.das | Must-survive inference — 1D FA prefers `auto[]` overload, dynamic containers bind whole to `auto(TT)`, unsized `int[]` params, `==const` | |
 | test_typeinfo.das | typeinfo surface — `dim`, non-alias typename strings, can_copy/is_pod, sizeof≡dim×elem | |
-| test_interop.das | C++ native-dim field (TestObjectFoo.fooArray) — read/write, typename, iteration, unsized param, copy-out | |
+| test_interop.das | C++ native-dim field (TestObjectFoo.fooArray) — read/write, typename, iteration, unsized param, copy-out. AOT-excluded: emitter bug #3077 | |
 | failed_zero_dim.das | dimension 0 rejected | **expect** 30109 |
 | failed_nonconst_dim.das | runtime dim value rejected | **expect** 30109, 30838 |
 | failed_void_array.das | array of void rejected | **expect** 30108 |

--- a/tests/README.md
+++ b/tests/README.md
@@ -373,6 +373,29 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | glob_test.das | Pathname glob — `match_glob` (literal, `*`, `**`, `?`, `[a-z]`, `[!abc]`, edge cases), `glob`, `glob_filtered` walk, `is_glob_pattern` | |
 | popen_argv.das | `popen_argv` — basic invocation, non-zero exit on unknown flag, exit code capture | |
 
+## fixed_array/
+
+> Stage 0 characterization suite for the tFixedArray rework (`FIXED_ARRAY_REWORK.md`). Pins current fixed-array behavior that must survive the representation flip; `_target_*.das` files are the (skipped) acceptance spec for the new inference semantics, enabled at Stage 1.
+
+| File | Description | Expects errors |
+|---|---|---|
+| test_layout.das | Memory layout — sizeof/alignof, element stride via addresses, 2D contiguity, FA field offsets in structs/tuples/variants, packed float3 stride | |
+| test_semantics.das | Value semantics — whole-array assign/init-copy/`:=`/`clone()`, 2D assign, zero-init, `fixed_array()` literal types, FA returns, struct-field deep copy, non-copyable elements + `finalize_dim` | |
+| test_indexing.das | Indexing — read/write at every depth, index expressions, partial 2D index yields row copy, const globals, struct fields, `subarray` + range-index sugar | |
+| test_iteration.das | Iteration — for-loops 1D/2D, mutation through loop ref, FA of structs, `each()`, parallel iteration with range/array | |
+| test_containers.das | `array<int[4]>` push/push_clone/emplace, `table<K;int[4]>` insert/get/get_value/values/insert_clone (get_key excluded — broken on master, see target spec) | |
+| test_generics_current.das | Must-survive inference — 1D FA prefers `auto[]` overload, dynamic containers bind whole to `auto(TT)`, unsized `int[]` params, `==const` | |
+| test_typeinfo.das | typeinfo surface — `dim`, non-alias typename strings, can_copy/is_pod, sizeof≡dim×elem | |
+| test_interop.das | C++ native-dim field (TestObjectFoo.fooArray) — read/write, typename, iteration, unsized param, copy-out | |
+| failed_zero_dim.das | dimension 0 rejected | **expect** 30109 |
+| failed_nonconst_dim.das | runtime dim value rejected | **expect** 30109, 30838 |
+| failed_void_array.das | array of void rejected | **expect** 30108 |
+| failed_typedecl_dim.das | `typedecl(...)[N]` rejected as array base | **expect** 30112 |
+| failed_new_fixed_array.das | `new` of FA type rejected | **expect** 30214 |
+| failed_copy_noncopyable.das | `=` on FA of array<int> rejected | **expect** 30950 |
+| _target_inference.das | *(skipped)* Stage 1 acceptance spec — `auto(TT)` binds whole FA, `auto(TT)[]` peels one level, get_key fix | |
+| _target_alias.das | *(skipped)* Stage 1 acceptance spec — typedef name survives declaration/indexing/generic binding | |
+
 ## functional/
 
 | File | Description | Expects errors |
@@ -917,6 +940,15 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 |---|---|---|
 | test_bitfields.das | bitfield_trait — each_bit_name iteration | |
 | test_traits.das | type_traits — fields_count for struct/derived struct | |
+
+## typemacro/
+
+> Direct coverage of the raw `AstTypeMacro` payload surface (Stage 0 of `FIXED_ARRAY_REWORK.md` — the dimExpr payload migrates to a dedicated field at Stage 1b). Deep indirect coverage lives in option/hash_map/delegate suites via typemacro_boost.
+
+| File | Description | Expects errors |
+|---|---|---|
+| test_basic.das | All four grammar forms (`name(args)`, `$name(args)`, `name<types>(args)`, `$name<types>(args)`), const int/bool/string argument extraction, `typedecl(expr)` | |
+| _typemacro_mod.das | *(helper)* `tm_make` raw AstTypeMacro — resolves `tm_make(type<T>, N, wrap, tag)` to `T[N]` or `T` | |
 
 ## unsafe/
 

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -423,6 +423,9 @@ FILE(GLOB AOT_TABLE_PACKED_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPEND
 FILE(GLOB AOT_FIXED_ARRAY_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/fixed_array/*.das")
 # Exclude failed_* expect-fixtures and _-prefixed target-spec files (enabled at Stage 1)
 list(FILTER AOT_FIXED_ARRAY_FILES EXCLUDE REGEX "failed_|/_")
+# test_interop: AOT emitter produces non-compiling C++ for iterate/pass/copy of a native
+# C-array field (issue #3077) — interpreted-only until fixed; re-include to verify the fix
+list(FILTER AOT_FIXED_ARRAY_FILES EXCLUDE REGEX "test_interop")
 
 # AOT for typemacro test files
 FILE(GLOB AOT_TYPEMACRO_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/typemacro/*.das")

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -419,6 +419,16 @@ list(FILTER AOT_RTTI_FILES EXCLUDE REGEX "/_")
 # AOT for packed small-table test files
 FILE(GLOB AOT_TABLE_PACKED_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/table_packed/*.das")
 
+# AOT for fixed_array test files (tFixedArray rework characterization, FIXED_ARRAY_REWORK.md)
+FILE(GLOB AOT_FIXED_ARRAY_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/fixed_array/*.das")
+# Exclude failed_* expect-fixtures and _-prefixed target-spec files (enabled at Stage 1)
+list(FILTER AOT_FIXED_ARRAY_FILES EXCLUDE REGEX "failed_|/_")
+
+# AOT for typemacro test files
+FILE(GLOB AOT_TYPEMACRO_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/typemacro/*.das")
+# Exclude the _-prefixed macro module (compile-time only, options no_aot)
+list(FILTER AOT_TYPEMACRO_FILES EXCLUDE REGEX "/_")
+
 # AOT for language test files
 FILE(GLOB AOT_LANGUAGE_TEST_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/language/*.das")
 # Exclude expect-error tests and no_aot files
@@ -726,6 +736,14 @@ add_custom_target(test_aot_loops)
 SET(LOOPS_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_LOOPS_FILES}" LOOPS_AOT_GENERATED_SRC test_aot_loops daslang)
 
+add_custom_target(test_aot_fixed_array)
+SET(FIXED_ARRAY_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_FIXED_ARRAY_FILES}" FIXED_ARRAY_AOT_GENERATED_SRC test_aot_fixed_array daslang)
+
+add_custom_target(test_aot_typemacro)
+SET(TYPEMACRO_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_TYPEMACRO_FILES}" TYPEMACRO_AOT_GENERATED_SRC test_aot_typemacro daslang)
+
 add_custom_target(test_aot_language)
 SET(LANGUAGE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_LANGUAGE_TEST_FILES}" LANGUAGE_AOT_GENERATED_SRC test_aot_language daslang)
@@ -769,6 +787,8 @@ SOURCE_GROUP_FILES("aot generated" BITFIELDS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" BOOL_ARRAY_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" CLASS_BOOST_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DATA_WALKER_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" FIXED_ARRAY_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" TYPEMACRO_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DEBUG_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DEBUG_AGENT_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASPEG_AOT_GENERATED_SRC)
@@ -889,6 +909,8 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${LPIPE_AOT_GENERATED_SRC}
     ${JIT_AOT_GENERATED_SRC}
     ${LOOPS_AOT_GENERATED_SRC}
+    ${FIXED_ARRAY_AOT_GENERATED_SRC}
+    ${TYPEMACRO_AOT_GENERATED_SRC}
     ${LANGUAGE_AOT_GENERATED_SRC}
     ${LANGUAGE_MODULES_AOT_GENERATED_SRC}
     ${DASLIB_MODULES_AOT_GENERATED_SRC}
@@ -934,6 +956,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_lpipe
     test_aot_jit
     test_aot_loops
+    test_aot_fixed_array test_aot_typemacro
     test_aot_language test_aot_language_modules
     test_aot_daslib_modules test_aot_decs_modules
     test_aot_daslib

--- a/tests/fixed_array/_target_alias.das
+++ b/tests/fixed_array/_target_alias.das
@@ -1,0 +1,49 @@
+// TARGET SPEC for the tFixedArray rework (FIXED_ARRAY_REWORK.md) — Part B.
+// Leading underscore: dastest SKIPS this file. Stage 1 renames it to
+// test_target_alias.das when alias-preserving nesting lands.
+//
+// On master, typedef boundaries are destroyed by dim flattening:
+//   var a : M4[3]   =>  a is float[3][4][4]   (M4 gone at declaration)
+//   a[0]            =>  float[4][4]           (anonymous)
+// Target: alias survives as a label on the nested tFixedArray node:
+//   typename(a)    contains M4   ("M4[3]")
+//   typename(a[0]) is M4
+// Exact describe format ("M4[3]" vs "float[4][4] aka M4[3]") to be settled at the
+// Stage 1 review — adjust the expected strings then; the invariant is that the
+// alias name SURVIVES declaration, indexing, and generic binding.
+//
+// The `expect` line below documents how master FAILS this spec today (and keeps
+// lint/CI off the file until then; dastest already skips it via the `_` prefix):
+//   30341 — M4[10] flattens to float[10][4][4], so auto(TT)[] has no match
+// Stage 1: delete the `expect` line and rename the file to test_target_alias.das.
+options gen2
+expect 30341
+require dastest/testing_boost public
+
+typedef M4 = float[4][4]
+
+def dim_name(a : auto(TT)[]) : string {
+    return typeinfo typename(type<TT>)
+}
+
+[test]
+def test_alias_preserved(t : T?) {
+    t |> run("declaration keeps the typedef name") @(t : T?) {
+        var a : M4[3]
+        t |> equal(typeinfo typename(a), "M4[3]")
+    }
+    t |> run("indexing returns the typedef") @(t : T?) {
+        var a : M4[3]
+        t |> equal(typeinfo typename(a[0]), "M4")
+    }
+    t |> run("generic binding recovers the typedef") @(t : T?) {
+        var a : M4[10]
+        t |> equal(dim_name(a), "M4 const")
+    }
+    t |> run("typedef'd FA still indexes to elements") @(t : T?) {
+        var a : M4[3]
+        a[1][2][3] = 7.0
+        t |> equal(a[1][2][3], 7.0)
+        t |> equal(typeinfo typename(a[1][2]), "float[4]")
+    }
+}

--- a/tests/fixed_array/_target_inference.das
+++ b/tests/fixed_array/_target_inference.das
@@ -1,0 +1,93 @@
+// TARGET SPEC for the tFixedArray rework (FIXED_ARRAY_REWORK.md) — Part B.
+// Leading underscore: dastest SKIPS this file. Stage 1 renames it to
+// test_target_inference.das when the new inference semantics land. Until then this
+// file is the reviewed acceptance criteria; it does NOT compile/pass on master.
+//
+// New semantics (agreed, no compat shim):
+//   auto(TT)   <- int[4]       =>  TT = int[4]      (whole array, like array<int>)
+//   auto(TT)[] <- float[4][4]  =>  TT = float[4]    (peel one level)
+//   auto(TT)[] <- M4[10]       =>  TT = M4          (alias preserved)
+//   default<TT> after FA binding => zeroed FA
+// Exact const decoration in the TT strings ("int[4]" vs "int const[4]") to be
+// settled at the Stage 1 review — adjust the expected strings then.
+//
+// The `expect` line below documents how master FAILS this spec today (and keeps
+// lint/CI off the file until then; dastest already skips it via the `_` prefix):
+//   30192 — auto(TT) <- int[4] binds TT=int, so `for (x in default<TT>)` iterates an int
+//   30341 x2 — auto(TT)[] can't take float[4][4]; get_key(table<K;V[N]>) can't resolve
+// Stage 1: delete the `expect` line and rename the file to test_target_inference.das.
+options gen2
+expect 30192, 30341:2
+require dastest/testing_boost public
+
+typedef M4 = float[4][4]
+
+def plain_name(a : auto(TT)) : string {
+    return typeinfo typename(type<TT>)
+}
+
+def dim_name(a : auto(TT)[]) : string {
+    return typeinfo typename(type<TT>)
+}
+
+def zeroed_count(a : auto(TT)) : int {
+    var z = default<TT>
+    var n = 0
+    for (x in z) {
+        n ++
+    }
+    return n
+}
+
+def pick(a : auto(TT)) : string {
+    return "plain"
+}
+
+def pick(a : auto(TT)[]) : string {
+    return "dim"
+}
+
+[test]
+def test_whole_array_binding(t : T?) {
+    t |> run("auto(TT) binds the whole fixed array") @(t : T?) {
+        var i4 : int[4]
+        t |> equal(plain_name(i4), "int const[4]")
+    }
+    t |> run("default<TT> is a zeroed FA") @(t : T?) {
+        var i4 : int[4]
+        t |> equal(zeroed_count(i4), 4)
+    }
+}
+
+[test]
+def test_peel_one_level(t : T?) {
+    t |> run("auto(TT)[] peels one level off multi-dim") @(t : T?) {
+        var m : float[4][4]
+        t |> equal(dim_name(m), "float const[4]")
+    }
+    t |> run("multi-dim now prefers the dim overload") @(t : T?) {
+        // characterized on master as "plain" (test_generics_current.das documents
+        // the old behavior); the rework makes auto[] match and win
+        var m : float[2][3]
+        t |> equal(pick(m), "dim")
+    }
+    t |> run("1D keeps preferring the dim overload") @(t : T?) {
+        var i4 : int[4]
+        t |> equal(pick(i4), "dim")
+    }
+}
+
+[test]
+def test_get_key_fixed(t : T?) {
+    t |> run("get_key on table<K;V[N]> resolves") @(t : T?) {
+        // broken on master: builtin.das:1407 fails to resolve valT const[-2]
+        var tab : table<string; int[4]>
+        var v : int[4]
+        for (i in range(4)) {
+            v[i] = i + 1
+        }
+        tab |> insert("a", v)
+        t |> equal(get_key(tab, v), "a")
+        delete tab
+    }
+}

--- a/tests/fixed_array/_target_inference.das
+++ b/tests/fixed_array/_target_inference.das
@@ -77,6 +77,10 @@ def test_peel_one_level(t : T?) {
     }
 }
 
+// NOTE: unlike the rest of this file (enabled at Stage 1), this subtest is gated on
+// STAGE 4 — the broken builtin.das:1407 overload is deleted (not fixed) there, and only
+// then does the base get_key generic cover FA values. If Stage 1 enablement trips on it,
+// split it out and keep it disabled until Stage 4.
 [test]
 def test_get_key_fixed(t : T?) {
     t |> run("get_key on table<K;V[N]> resolves") @(t : T?) {

--- a/tests/fixed_array/failed_copy_noncopyable.das
+++ b/tests/fixed_array/failed_copy_noncopyable.das
@@ -1,0 +1,11 @@
+// Stage 0 characterization (FIXED_ARRAY_REWORK.md): plain assignment of a fixed array
+// with non-copyable elements (array<int>) is a compile error — use := (clone).
+options gen2
+expect 30950
+
+[export]
+def main {
+    var a : array<int>[3]
+    var b : array<int>[3]
+    b = a
+}

--- a/tests/fixed_array/failed_new_fixed_array.das
+++ b/tests/fixed_array/failed_new_fixed_array.das
@@ -1,0 +1,11 @@
+// Stage 0 characterization (FIXED_ARRAY_REWORK.md): `new` of a fixed-array type is
+// a compile error — only tuples, variants, structures and handled types heap-allocate.
+options gen2
+expect 30214
+
+typedef IntArr4 = int[4]
+
+[export]
+def main {
+    var p = new IntArr4
+}

--- a/tests/fixed_array/failed_nonconst_dim.das
+++ b/tests/fixed_array/failed_nonconst_dim.das
@@ -1,0 +1,11 @@
+// Stage 0 characterization (FIXED_ARRAY_REWORK.md): dimension must be a compile-time
+// constant; a runtime value is a compile error.
+options gen2
+expect 30109, 30838
+
+[export]
+def main {
+    var n = 4
+    var a : int[n]
+    a[0] = 1
+}

--- a/tests/fixed_array/failed_typedecl_dim.das
+++ b/tests/fixed_array/failed_typedecl_dim.das
@@ -1,0 +1,11 @@
+// Stage 0 characterization (FIXED_ARRAY_REWORK.md): typedecl(...) can't be an array
+// base type — the parser rejects it (dims and the expression payload shared dimExpr
+// historically; the restriction is preserved by the rework).
+options gen2
+expect 30112
+
+[export]
+def main {
+    var x = 5
+    var a : typedecl(x)[3]
+}

--- a/tests/fixed_array/failed_void_array.das
+++ b/tests/fixed_array/failed_void_array.das
@@ -1,0 +1,8 @@
+// Stage 0 characterization (FIXED_ARRAY_REWORK.md): array of void is a compile error.
+options gen2
+expect 30108
+
+[export]
+def main {
+    var a : void[4]
+}

--- a/tests/fixed_array/failed_zero_dim.das
+++ b/tests/fixed_array/failed_zero_dim.das
@@ -1,0 +1,9 @@
+// Stage 0 characterization (FIXED_ARRAY_REWORK.md): dimension <= 0 is a compile error.
+options gen2
+expect 30109
+
+[export]
+def main {
+    var a : int[0]
+    a[0] = 1
+}

--- a/tests/fixed_array/test_containers.das
+++ b/tests/fixed_array/test_containers.das
@@ -1,0 +1,117 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins container interop: array<T[N]> and table<K; T[N]> operations. These exact
+// behaviors must survive Stage 4 when the dedicated `[]` overload families in
+// builtin.das are deleted in favor of the base generics.
+// NOTE deliberately absent: get_key(table<K;V[]>, v) — broken on master
+// (builtin.das:1407 overload fails to resolve its own valT[-2] contortion);
+// covered by the target spec instead.
+options gen2
+require dastest/testing_boost public
+
+def make_iota() : int[4] {
+    var r : int[4]
+    for (i in range(4)) {
+        r[i] = i + 1
+    }
+    return r
+}
+
+[test]
+def test_array_of_fa(t : T?) {
+    t |> run("push / push_clone / emplace") @(t : T?) {
+        var v = make_iota()
+        var arr : array<int[4]>
+        arr |> push(v)
+        arr |> push_clone(v)
+        var v2 : int[4]
+        v2[0] = 99
+        arr |> emplace(v2)
+        t |> equal(length(arr), 3)
+        t |> equal(arr[0][0], 1)
+        t |> equal(arr[1][3], 4)
+        t |> equal(arr[2][0], 99)
+        // push copied — source intact
+        t |> equal(v[0], 1)
+        delete arr
+    }
+    t |> run("mutate element in place") @(t : T?) {
+        var arr : array<int[4]>
+        arr |> push(make_iota())
+        arr[0][2] = 77
+        t |> equal(arr[0][2], 77)
+        delete arr
+    }
+    t |> run("iterate array of FA") @(t : T?) {
+        var arr : array<int[4]>
+        arr |> push(make_iota())
+        arr |> push(make_iota())
+        var total = 0
+        for (fa in arr) {
+            for (x in fa) {
+                total += x
+            }
+        }
+        t |> equal(total, 20)
+        delete arr
+    }
+}
+
+[test]
+def test_table_of_fa(t : T?) {
+    t |> run("insert / get / get_value") @(t : T?) {
+        var tab : table<string; int[4]>
+        var v = make_iota()
+        tab |> insert("a", v)
+        var found = false
+        tab |> get("a") $(p) {
+            found = true
+            t |> equal(p[0], 1)
+            t |> equal(p[3], 4)
+        }
+        t |> success(found)
+        let gv = tab |> get_value("a")
+        t |> equal(gv[1], 2)
+        delete tab
+    }
+    t |> run("mutating get writes through") @(t : T?) {
+        var tab : table<string; int[4]>
+        tab |> insert("k", make_iota())
+        tab |> get("k") $(var p) {
+            p[0] = 555
+        }
+        t |> equal((tab |> get_value("k"))[0], 555)
+        delete tab
+    }
+    t |> run("values() iterates FA refs") @(t : T?) {
+        var tab : table<string; int[4]>
+        tab |> insert("a", make_iota())
+        var count = 0
+        for (val in values(tab)) {
+            count ++
+            t |> equal(val[0], 1)
+        }
+        t |> equal(count, 1)
+        delete tab
+    }
+    t |> run("insert_clone") @(t : T?) {
+        var tab : table<string; int[4]>
+        var v = make_iota()
+        tab |> insert_clone("c", v)
+        v[0] = 1000
+        t |> equal((tab |> get_value("c"))[0], 1)
+        delete tab
+    }
+}
+
+[test]
+def test_struct_with_fa_in_containers(t : T?) {
+    t |> run("struct holding FA inside array") @(t : T?) {
+        var arr : array<tuple<name : string; data : float[2]>>
+        var tp : tuple<name : string; data : float[2]>
+        tp.name = "p"
+        tp.data[1] = 3.5
+        arr |> push(tp)
+        t |> equal(arr[0].data[1], 3.5)
+        delete arr
+    }
+}

--- a/tests/fixed_array/test_generics_current.das
+++ b/tests/fixed_array/test_generics_current.das
@@ -1,0 +1,90 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins the generic-inference behaviors that MUST SURVIVE the rework:
+//   - 1-D fixed array prefers the auto(TT)[] overload over plain auto(TT)
+//   - array<T>/table<K;V> bind the WHOLE container to auto(TT)
+//   - unsized T[] params accept any size; ==const propagates caller constness
+//
+// NOT pinned here (intentionally — these CHANGE with the rework, see _target_inference.das):
+//   - what TT binds to for plain auto(TT) <- int[4]  (today: int; target: int[4])
+//   - which overload a MULTI-dim array picks          (today: plain; target: auto[])
+//   - typename strings for typedef'd FAs              (today: flattened; target: alias kept)
+options gen2
+require dastest/testing_boost public
+
+def pick(a : auto(TT)) : string {
+    return "plain"
+}
+
+def pick(a : auto(TT)[]) : string {
+    return "dim"
+}
+
+def container_name(a : auto(TT)) : string {
+    return typeinfo typename(type<TT>)
+}
+
+def sum_unsized(a : int[]) : int {
+    var sum = 0
+    for (x in a) {
+        sum += x
+    }
+    return sum
+}
+
+def fill_unsized(var a : int[] ==const) {
+    for (i in range(length(a))) {
+        a[i] = i * 2
+    }
+}
+
+def first_exact(a : int[4]) : int {
+    return a[0]
+}
+
+[test]
+def test_overload_preference(t : T?) {
+    t |> run("1D FA prefers the dim overload") @(t : T?) {
+        let i4 : int[4]
+        t |> equal(pick(i4), "dim")
+    }
+    t |> run("dynamic containers go to plain") @(t : T?) {
+        let ai : array<int>
+        t |> equal(pick(ai), "plain")
+        let tab : table<string; int>
+        t |> equal(pick(tab), "plain")
+    }
+}
+
+[test]
+def test_container_binding(t : T?) {
+    t |> run("auto(TT) binds whole dynamic container") @(t : T?) {
+        let ai : array<int>
+        t |> equal(container_name(ai), "array<int> const")
+        let tab : table<string; float>
+        t |> equal(container_name(tab), "table<string;float> const")
+    }
+}
+
+[test]
+def test_unsized_params(t : T?) {
+    t |> run("int[] accepts any size") @(t : T?) {
+        var a : int[4]
+        for (i in range(4)) {
+            a[i] = i + 1
+        }
+        t |> equal(sum_unsized(a), 10)
+        var b : int[7]
+        b[6] = 5
+        t |> equal(sum_unsized(b), 5)
+    }
+    t |> run("length() inside unsized param sees real size") @(t : T?) {
+        var w : int[6]
+        fill_unsized(w)
+        t |> equal(w[5], 10)
+    }
+    t |> run("exact-size param matches") @(t : T?) {
+        var a : int[4]
+        a[0] = 13
+        t |> equal(first_exact(a), 13)
+    }
+}

--- a/tests/fixed_array/test_indexing.das
+++ b/tests/fixed_array/test_indexing.das
@@ -1,0 +1,97 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins indexing: read/write at every depth, index expressions, const sources,
+// range slicing via subarray, indexing through struct fields.
+options gen2
+require dastest/testing_boost public
+
+struct Holder {
+    grid : int[3][3]
+}
+
+let g_const : int[4] = fixed_array(10, 20, 30, 40)
+
+[test]
+def test_index_rw(t : T?) {
+    t |> run("1D read/write") @(t : T?) {
+        var a : int[4]
+        for (i in range(4)) {
+            a[i] = i * i
+        }
+        t |> equal(a[0], 0)
+        t |> equal(a[3], 9)
+    }
+    t |> run("2D and 3D read/write") @(t : T?) {
+        var m : int[2][3]
+        for (y in range(2)) {
+            for (x in range(3)) {
+                m[y][x] = y * 10 + x
+            }
+        }
+        t |> equal(m[1][2], 12)
+        var c : int[2][2][2]
+        c[1][0][1] = 42
+        t |> equal(c[1][0][1], 42)
+        t |> equal(c[0][0][0], 0)
+    }
+    t |> run("index with expressions") @(t : T?) {
+        var a : int[8]
+        for (i in range(8)) {
+            a[i] = i
+        }
+        let k = 3
+        t |> equal(a[k + 1], 4)
+        t |> equal(a[k * 2], 6)
+    }
+    t |> run("partial index of 2D yields row") @(t : T?) {
+        var m : float[2][3]
+        m[1][0] = 7.0
+        t |> equal(typeinfo typename(m[1]), "float[3]")
+        let row = m[1]      // copies the row
+        t |> equal(row[0], 7.0)
+        m[1][0] = 8.0
+        t |> equal(row[0], 7.0)
+    }
+}
+
+[test]
+def test_const_and_fields(t : T?) {
+    t |> run("const global FA reads") @(t : T?) {
+        t |> equal(g_const[0], 10)
+        t |> equal(g_const[3], 40)
+    }
+    t |> run("indexing through struct field") @(t : T?) {
+        var h : Holder
+        h.grid[2][1] = 21
+        t |> equal(h.grid[2][1], 21)
+        t |> equal(h.grid[0][0], 0)
+    }
+}
+
+[test]
+def test_subarray(t : T?) {
+    t |> run("subarray range view") @(t : T?) {
+        var s : int[4]
+        for (i in range(4)) {
+            s[i] = i * 10
+        }
+        var got : array<int>
+        for (v in subarray(s, range(1, 3))) {
+            got |> push(v)
+        }
+        t |> equal(length(got), 2)
+        t |> equal(got[0], 10)
+        t |> equal(got[1], 20)
+        delete got
+    }
+    t |> run("range-index sugar a[r]") @(t : T?) {
+        var s : int[4]
+        for (i in range(4)) {
+            s[i] = i + 1
+        }
+        var sum = 0
+        for (v in s[range(0, 2)]) {
+            sum += v
+        }
+        t |> equal(sum, 3)
+    }
+}

--- a/tests/fixed_array/test_interop.das
+++ b/tests/fixed_array/test_interop.das
@@ -2,9 +2,13 @@
 // Pins C++ interop: a handled type's native C-array field (TestObjectFoo.fooArray,
 // bound via typeFactory<TT[dim]> with isNativeDim) must keep reading/writing and
 // keep its type identity through the representation flip.
-// AOT-EXCLUDED (tests/aot/CMakeLists.txt): iterate/pass/copy of a native dim field
-// emits non-compiling C++ on master — issue #3077. Interpreted-only until fixed.
+// INTERPRETED-ONLY (options no_aot + excluded from the AOT glob in
+// tests/aot/CMakeLists.txt): iterate/pass/copy of a native dim field emits
+// non-compiling C++ on master — issue #3077. Both markers go together: the glob
+// exclusion skips stub generation, no_aot keeps test_aot's fail_on_no_aot off
+// this file at runtime. Remove BOTH to verify the fix.
 options gen2
+options no_aot
 require UnitTest
 require dastest/testing_boost public
 

--- a/tests/fixed_array/test_interop.das
+++ b/tests/fixed_array/test_interop.das
@@ -1,0 +1,59 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins C++ interop: a handled type's native C-array field (TestObjectFoo.fooArray,
+// bound via typeFactory<TT[dim]> with isNativeDim) must keep reading/writing and
+// keep its type identity through the representation flip.
+options gen2
+require UnitTest
+require dastest/testing_boost public
+
+[test]
+def test_native_dim_field(t : T?) {
+    t |> run("read/write native int[3] field") @(t : T?) {
+        var foo : TestObjectFoo
+        for (i in range(3)) {
+            foo.fooArray[i] = (i + 1) * 11
+        }
+        t |> equal(foo.fooArray[0], 11)
+        t |> equal(foo.fooArray[1], 22)
+        t |> equal(foo.fooArray[2], 33)
+    }
+    t |> run("native field typename") @(t : T?) {
+        var _foo : TestObjectFoo
+        t |> equal(typeinfo typename(_foo.fooArray), "int[3]")
+        t |> equal(typeinfo dim(_foo.fooArray), 3)
+    }
+    t |> run("native field iterates") @(t : T?) {
+        var foo : TestObjectFoo
+        for (i in range(3)) {
+            foo.fooArray[i] = i + 1
+        }
+        var sum = 0
+        for (x in foo.fooArray) {
+            sum += x
+        }
+        t |> equal(sum, 6)
+    }
+    t |> run("native field passes to unsized param") @(t : T?) {
+        var foo : TestObjectFoo
+        for (i in range(3)) {
+            foo.fooArray[i] = i + 10
+        }
+        t |> equal(sum_unsized(foo.fooArray), 33)
+    }
+    t |> run("native field copies out to das FA") @(t : T?) {
+        var foo : TestObjectFoo
+        foo.fooArray[1] = 42
+        var local : int[3]
+        local = foo.fooArray
+        foo.fooArray[1] = 0
+        t |> equal(local[1], 42)
+    }
+}
+
+def sum_unsized(a : int[]) : int {
+    var sum = 0
+    for (x in a) {
+        sum += x
+    }
+    return sum
+}

--- a/tests/fixed_array/test_interop.das
+++ b/tests/fixed_array/test_interop.das
@@ -2,6 +2,8 @@
 // Pins C++ interop: a handled type's native C-array field (TestObjectFoo.fooArray,
 // bound via typeFactory<TT[dim]> with isNativeDim) must keep reading/writing and
 // keep its type identity through the representation flip.
+// AOT-EXCLUDED (tests/aot/CMakeLists.txt): iterate/pass/copy of a native dim field
+// emits non-compiling C++ on master — issue #3077. Interpreted-only until fixed.
 options gen2
 require UnitTest
 require dastest/testing_boost public

--- a/tests/fixed_array/test_iteration.das
+++ b/tests/fixed_array/test_iteration.das
@@ -1,0 +1,92 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins iteration: for-loops at every depth, mutation through the loop ref,
+// each(), parallel iteration with other sources.
+options gen2
+require dastest/testing_boost public
+
+struct Cell {
+    v : int
+}
+
+[test]
+def test_for_loops(t : T?) {
+    t |> run("1D for") @(t : T?) {
+        var a : int[4]
+        for (i in range(4)) {
+            a[i] = i + 1
+        }
+        var sum = 0
+        for (x in a) {
+            sum += x
+        }
+        t |> equal(sum, 10)
+    }
+    t |> run("2D for yields rows") @(t : T?) {
+        var m : int[2][3]
+        for (y in range(2)) {
+            for (x in range(3)) {
+                m[y][x] = y * 3 + x
+            }
+        }
+        var rows = 0
+        var total = 0
+        for (row in m) {
+            rows ++
+            for (x in row) {
+                total += x
+            }
+        }
+        t |> equal(rows, 2)
+        t |> equal(total, 15)
+    }
+    t |> run("mutation through loop ref") @(t : T?) {
+        var a : int[4]
+        for (x in a) {
+            x = 7
+        }
+        var sum = 0
+        for (x in a) {
+            sum += x
+        }
+        t |> equal(sum, 28)
+    }
+    t |> run("iterate FA of structs by ref") @(t : T?) {
+        var cells : Cell[3]
+        for (c in cells) {
+            c.v = 5
+        }
+        t |> equal(cells[0].v + cells[1].v + cells[2].v, 15)
+    }
+}
+
+[test]
+def test_each_and_parallel(t : T?) {
+    t |> run("each() over 1D") @(t : T?) {
+        var s : int[4]
+        for (i in range(4)) {
+            s[i] = i * 10
+        }
+        var sum = 0
+        for (v in each(s)) {
+            sum += v
+        }
+        t |> equal(sum, 60)
+    }
+    t |> run("parallel iteration FA + range") @(t : T?) {
+        var a : int[4]
+        for (x, i in a, range(4)) {
+            x = i * 2
+        }
+        t |> equal(a[3], 6)
+    }
+    t |> run("parallel iteration FA + array") @(t : T?) {
+        var a : int[3]
+        var b <- [10, 20, 30]
+        var sum = 0
+        for (x, y in a, b) {
+            sum += x + y
+        }
+        t |> equal(sum, 60)
+        delete b
+    }
+}

--- a/tests/fixed_array/test_layout.das
+++ b/tests/fixed_array/test_layout.das
@@ -1,0 +1,128 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins memory layout of fixed arrays: sizes, alignment, element stride, field offsets.
+// C++ interop depends on this layout staying byte-identical — any diff after the
+// representation flip is a stop-the-line bug.
+options gen2
+require dastest/testing_boost public
+
+struct Packed {
+    a : int8
+    b : int
+    c : int8
+}
+
+struct WithFA {
+    tag : int8
+    data : float[3]
+    tail : int8
+}
+
+variant VarFA {
+    ints : int[4]
+    one : float
+}
+
+[test]
+def test_sizes(t : T?) {
+    t |> run("scalar element sizes") @(t : T?) {
+        var _i4 : int[4]
+        var _b3 : int8[3]
+        var _d2 : double[2]
+        t |> equal(typeinfo sizeof(_i4), 16)
+        t |> equal(typeinfo alignof(_i4), 4)
+        t |> equal(typeinfo sizeof(_b3), 3)     // no padding between int8 elements
+        t |> equal(typeinfo alignof(_b3), 1)
+        t |> equal(typeinfo sizeof(_d2), 16)
+        t |> equal(typeinfo alignof(_d2), 8)
+    }
+    t |> run("multi-dim sizes multiply") @(t : T?) {
+        var _m : float[2][3]
+        var _c : int[2][3][4]
+        t |> equal(typeinfo sizeof(_m), 24)
+        t |> equal(typeinfo sizeof(_c), 96)
+    }
+    t |> run("vector elements use packed stride") @(t : T?) {
+        // float3 inside a fixed array packs to 12 bytes, NOT the standalone 16-byte vec4f
+        var _v3 : float3[4]
+        var _v2 : float2[3]
+        var _v4 : float4[2]
+        t |> equal(typeinfo sizeof(_v3), 48)
+        t |> equal(typeinfo alignof(_v3), 4)
+        t |> equal(typeinfo sizeof(_v2), 24)
+        t |> equal(typeinfo sizeof(_v4), 32)
+    }
+    t |> run("struct element stride = struct size") @(t : T?) {
+        var _ps : Packed[2]
+        t |> equal(typeinfo sizeof(type<Packed>), 12)
+        t |> equal(typeinfo sizeof(_ps), 24)
+    }
+}
+
+[test]
+def test_addresses(t : T?) {
+    t |> run("element stride via addresses") @(t : T?) {
+        var s : Packed[2]
+        unsafe {
+            let p0 = intptr(addr(s[0]))
+            let p1 = intptr(addr(s[1]))
+            t |> equal(int(p1 - p0), 12)
+        }
+        var m : float[2][3]
+        unsafe {
+            let r0 = intptr(addr(m[0]))
+            let r1 = intptr(addr(m[1]))
+            t |> equal(int(r1 - r0), 12)        // row stride = 3 floats
+            let e0 = intptr(addr(m[0][0]))
+            let e1 = intptr(addr(m[0][1]))
+            t |> equal(int(e1 - e0), 4)
+        }
+    }
+    t |> run("2D rows are contiguous") @(t : T?) {
+        var m : float[2][3]
+        unsafe {
+            let lastOfRow0 = intptr(addr(m[0][2]))
+            let firstOfRow1 = intptr(addr(m[1][0]))
+            t |> equal(int(firstOfRow1 - lastOfRow0), 4)
+        }
+    }
+    t |> run("FA field offsets inside struct") @(t : T?) {
+        var w : WithFA
+        unsafe {
+            let base = intptr(addr(w.tag))
+            t |> equal(int(intptr(addr(w.data[0])) - base), 4)   // aligned to float
+            t |> equal(int(intptr(addr(w.data[2])) - base), 12)
+            t |> equal(int(intptr(addr(w.tail)) - base), 16)
+        }
+        t |> equal(typeinfo sizeof(type<WithFA>), 20)
+    }
+}
+
+[test]
+def test_composite_layout(t : T?) {
+    t |> run("tuple with FA member") @(t : T?) {
+        var tp : tuple<flag : int8; arr : int[3]>
+        t |> equal(typeinfo sizeof(tp), 16)
+        unsafe {
+            let base = intptr(addr(tp.flag))
+            t |> equal(int(intptr(addr(tp.arr[0])) - base), 4)
+        }
+    }
+    t |> run("variant with FA arm") @(t : T?) {
+        var vf : VarFA
+        t |> equal(typeinfo sizeof(vf), 20)     // 16 payload + index
+        unsafe {
+            vf.ints[1] = 7
+        }
+        t |> success(vf is ints)
+        t |> equal((vf as ints)[1], 7)
+    }
+    t |> run("FA of tuples") @(t : T?) {
+        var ta : tuple<a : int; b : int8>[3]
+        t |> equal(typeinfo sizeof(ta), 24)     // tuple size 8 (padded), x3
+        unsafe {
+            let p0 = intptr(addr(ta[0]))
+            let p1 = intptr(addr(ta[1]))
+            t |> equal(int(p1 - p0), 8)
+        }
+    }
+}

--- a/tests/fixed_array/test_layout.das
+++ b/tests/fixed_array/test_layout.das
@@ -42,7 +42,9 @@ def test_sizes(t : T?) {
         t |> equal(typeinfo sizeof(_c), 96)
     }
     t |> run("vector elements use packed stride") @(t : T?) {
-        // float3 inside a fixed array packs to 12 bytes, NOT the standalone 16-byte vec4f
+        // float3 inside a fixed array packs to 12 bytes, NOT the standalone 16-byte
+        // vec4f — by design, memory matters; loads go through v_ldu when unaligned
+        // vector loads are explicitly enabled (asan off)
         var _v3 : float3[4]
         var _v2 : float2[3]
         var _v4 : float4[2]

--- a/tests/fixed_array/test_semantics.das
+++ b/tests/fixed_array/test_semantics.das
@@ -1,0 +1,110 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins value semantics: assignment, init-copy, clone, zero-init, returns,
+// struct-field copies, and non-copyable element handling.
+options gen2
+require dastest/testing_boost public
+
+struct WithFA {
+    name : string
+    data : float[3]
+}
+
+def make_iota() : int[4] {
+    var r : int[4]
+    for (i in range(4)) {
+        r[i] = i + 1
+    }
+    return r
+}
+
+[test]
+def test_copy_semantics(t : T?) {
+    t |> run("whole-array assignment copies") @(t : T?) {
+        var a = make_iota()
+        var b : int[4]
+        b = a
+        a[0] = 100
+        t |> equal(b[0], 1)         // deep copy, not aliased
+        t |> equal(b[3], 4)
+    }
+    t |> run("init-copy from variable") @(t : T?) {
+        var a = make_iota()
+        let c = a
+        a[1] = 200
+        t |> equal(c[1], 2)
+    }
+    t |> run("clone operator") @(t : T?) {
+        let a = make_iota()
+        var d : int[4]
+        d := a
+        t |> equal(d[2], 3)
+    }
+    t |> run("clone() builtin returns FA") @(t : T?) {
+        var a = make_iota()
+        let e = clone(a)
+        t |> equal(e[3], 4)
+        a[3] = 0
+        t |> equal(e[3], 4)
+    }
+    t |> run("2D assignment") @(t : T?) {
+        var m : float[2][2]
+        m[0][0] = 1.0
+        m[1][1] = 2.0
+        var n : float[2][2]
+        n = m
+        t |> equal(n[0][0], 1.0)
+        t |> equal(n[1][1], 2.0)
+    }
+}
+
+[test]
+def test_init_and_return(t : T?) {
+    t |> run("zero-initialized by default") @(t : T?) {
+        var a : int[8]
+        var sum = 0
+        for (x in a) {
+            sum += x
+        }
+        t |> equal(sum, 0)
+    }
+    t |> run("fixed_array literal types") @(t : T?) {
+        t |> equal(typeinfo typename(fixed_array(10, 20, 30)), "int[3]")
+        let fa = fixed_array(10, 20, 30)
+        t |> equal(fa[1], 20)
+        t |> equal(typeinfo typename(fixed_array<float>(1.5, 2.5)), "float[2]")
+        let fa2 = fixed_array<float>(1.5, 2.5)
+        t |> equal(fa2[1], 2.5)
+    }
+    t |> run("function returns FA by value") @(t : T?) {
+        let r = make_iota()
+        t |> equal(r[0], 1)
+        t |> equal(r[3], 4)
+    }
+    t |> run("struct with FA field copies deep") @(t : T?) {
+        var s1 = WithFA(name = "x")
+        s1.data[1] = 5.0
+        let s2 = s1
+        s1.data[1] = 9.0
+        t |> equal(s2.data[1], 5.0)
+    }
+}
+
+[test]
+def test_noncopyable_elements(t : T?) {
+    t |> run("FA of array<int>: clone + finalize_dim") @(t : T?) {
+        var na : array<int>[3]
+        na[0] |> push(1)
+        na[0] |> push(2)
+        na[2] |> push(9)
+        var nb : array<int>[3]
+        nb := na
+        t |> equal(length(nb[0]), 2)
+        t |> equal(nb[2][0], 9)
+        na[0][0] = 100
+        t |> equal(nb[0][0], 1)     // deep clone
+        finalize_dim(na)
+        t |> equal(length(na[0]), 0)
+        t |> equal(length(na[2]), 0)
+        finalize_dim(nb)
+    }
+}

--- a/tests/fixed_array/test_typeinfo.das
+++ b/tests/fixed_array/test_typeinfo.das
@@ -1,0 +1,55 @@
+// Stage 0 characterization for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Pins the typeinfo surface for fixed arrays: dim, sizeof, typename strings
+// (NON-alias only — typedef'd FA typenames change with the rework and live in
+// _target_alias.das), trait queries.
+options gen2
+require dastest/testing_boost public
+
+[test]
+def test_dim_trait(t : T?) {
+    t |> run("typeinfo dim returns outer size") @(t : T?) {
+        var _a : int[4]
+        var _m : float[2][3]
+        t |> equal(typeinfo dim(_a), 4)
+        t |> equal(typeinfo dim(_m), 2)     // outermost dimension
+        t |> equal(typeinfo dim(_m[0]), 3)
+    }
+}
+
+[test]
+def test_typenames(t : T?) {
+    t |> run("non-alias typename strings") @(t : T?) {
+        var _a : int[4]
+        var _m : float[2][3]
+        var _v : float3[2]
+        t |> equal(typeinfo typename(_a), "int[4]")
+        t |> equal(typeinfo typename(_m), "float[2][3]")
+        t |> equal(typeinfo typename(_m[0]), "float[3]")
+        t |> equal(typeinfo typename(_v), "float3[2]")
+    }
+    t |> run("FA inside container typenames") @(t : T?) {
+        var arr : array<int[4]>
+        var tab : table<string; int[4]>
+        t |> equal(typeinfo typename(arr), "array<int[4]>")
+        t |> equal(typeinfo typename(tab), "table<string;int[4]>")
+        delete arr
+        delete tab
+    }
+}
+
+[test]
+def test_traits(t : T?) {
+    t |> run("copy/pod traits on FA") @(t : T?) {
+        var _a : int[4]
+        t |> success(typeinfo can_copy(_a))
+        t |> success(typeinfo is_pod(_a))
+        var _na : array<int>[2]
+        t |> success(!typeinfo can_copy(_na))   // non-copyable elements
+    }
+    t |> run("sizeof composes with dim") @(t : T?) {
+        var _a : int[4]
+        t |> equal(typeinfo sizeof(_a), typeinfo dim(_a) * typeinfo sizeof(_a[0]))
+        var _m : float[2][3]
+        t |> equal(typeinfo sizeof(_m), typeinfo dim(_m) * typeinfo sizeof(_m[0]))
+    }
+}

--- a/tests/typemacro/_typemacro_mod.das
+++ b/tests/typemacro/_typemacro_mod.das
@@ -1,4 +1,4 @@
-﻿// Stage 0 coverage for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Stage 0 coverage for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
 // Raw AstTypeMacro exercising the typeMacro argument payload that Stage 1b moves
 // from TypeDecl.dimExpr to the dedicated typeMacroExpr field:
 //   dimExpr[0] — ExprConstString with the macro name

--- a/tests/typemacro/_typemacro_mod.das
+++ b/tests/typemacro/_typemacro_mod.das
@@ -1,0 +1,65 @@
+﻿// Stage 0 coverage for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Raw AstTypeMacro exercising the typeMacro argument payload that Stage 1b moves
+// from TypeDecl.dimExpr to the dedicated typeMacroExpr field:
+//   dimExpr[0] — ExprConstString with the macro name
+//   dimExpr[1] — type argument (ExprTypeDecl)
+//   dimExpr[2] — ExprConstInt (size)
+//   dimExpr[3] — ExprConstBool (wrap into an array or not)
+//   dimExpr[4] — ExprConstString (mode tag, "arr" expected when wrapping)
+// NOTE: this module reads .dimExpr and writes .dim directly — it is itself a
+// consumer the rework migrates (kept on the old API until the compat property
+// lands in Stage 1, ported to typeMacroExpr in Stage 5).
+options gen2
+options no_aot
+
+module _typemacro_mod shared private
+
+require daslib/ast
+require daslib/ast_boost
+
+// resolves tm_make(type<T>, N, true, "arr") -> T[N]; tm_make(type<T>, N, false, "plain") -> T
+[type_macro(name="tm_make")]
+class TmMakeTypeMacro : AstTypeMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; td : TypeDeclPtr; passT : TypeDeclPtr) : TypeDeclPtr {
+        if (length(td.dimExpr) != 5) {
+            macro_error(compiling_program(), td.at, "tm_make expects 4 arguments: type, size, wrap, tag")
+            return <- TypeDeclPtr()
+        }
+        if (!(td.dimExpr[2] is ExprConstInt)) {
+            macro_error(compiling_program(), td.at, "tm_make: size must be a constant integer")
+            return <- TypeDeclPtr()
+        }
+        if (!(td.dimExpr[3] is ExprConstBool)) {
+            macro_error(compiling_program(), td.at, "tm_make: wrap must be a constant bool")
+            return <- TypeDeclPtr()
+        }
+        if (!(td.dimExpr[4] is ExprConstString)) {
+            macro_error(compiling_program(), td.at, "tm_make: tag must be a constant string")
+            return <- TypeDeclPtr()
+        }
+        let count = (td.dimExpr[2] as ExprConstInt).value
+        let wrap = (td.dimExpr[3] as ExprConstBool).value
+        if (wrap && (td.dimExpr[4] as ExprConstString).value != "arr") {
+            macro_error(compiling_program(), td.at, "tm_make: wrapping requires the 'arr' tag, got '{(td.dimExpr[4] as ExprConstString).value}'")
+            return <- TypeDeclPtr()
+        }
+        // generic path: type argument not inferred yet — return auto so the compiler retries
+        if (td.dimExpr[1]._type == null) {
+            var auto_type : TypeDeclPtr
+            if (td.dimExpr[1] is ExprTypeDecl) {
+                auto_type = clone_type((td.dimExpr[1] as ExprTypeDecl).typeexpr)
+            } else {
+                auto_type = new TypeDecl(baseType = Type.autoinfer)
+            }
+            if (wrap) {
+                auto_type.dim |> push(count)
+            }
+            return <- auto_type
+        }
+        var final_type = clone_type(td.dimExpr[1]._type)
+        if (wrap) {
+            final_type.dim |> push(count)
+        }
+        return <- final_type
+    }
+}

--- a/tests/typemacro/test_basic.das
+++ b/tests/typemacro/test_basic.das
@@ -1,0 +1,66 @@
+// Stage 0 coverage for the tFixedArray rework (FIXED_ARRAY_REWORK.md).
+// Direct tests for the typeMacro payload surface that Stage 1b migrates off
+// TypeDecl.dimExpr: all four grammar forms, const-argument extraction
+// (int/bool/string), type arguments, and typedecl(expr).
+// Deep indirect coverage lives in tests/option + tests/hash_map + tests/delegate
+// (typemacro_boost-based); this file covers the raw forms those don't touch.
+options gen2
+require dastest/testing_boost public
+require _typemacro_mod
+
+[test]
+def test_grammar_forms(t : T?) {
+    t |> run("name(args) form") @(t : T?) {
+        var a : tm_make(type<float>, 4, true, "arr")
+        t |> equal(typeinfo typename(a), "float[4]")
+        a[3] = 1.5
+        t |> equal(a[3], 1.5)
+    }
+    t |> run("$name(args) form") @(t : T?) {
+        var _a : $tm_make(type<float>, 4, true, "arr")
+        t |> equal(typeinfo typename(_a), "float[4]")
+    }
+    t |> run("name<types>(args) form") @(t : T?) {
+        var _a : tm_make<float>(4, true, "arr")
+        t |> equal(typeinfo typename(_a), "float[4]")
+    }
+    t |> run("$name<types>(args) form") @(t : T?) {
+        var _a : $tm_make < float > (4, true, "arr")
+        t |> equal(typeinfo typename(_a), "float[4]")
+    }
+}
+
+[test]
+def test_const_arguments(t : T?) {
+    t |> run("bool argument switches result shape") @(t : T?) {
+        var _plain : tm_make(type<int>, 1, false, "plain")
+        t |> equal(typeinfo typename(_plain), "int")
+        var _wrapped : tm_make(type<int>, 7, true, "arr")
+        t |> equal(typeinfo typename(_wrapped), "int[7]")
+    }
+    t |> run("int argument carries the size") @(t : T?) {
+        var _a : tm_make(type<int8>, 13, true, "arr")
+        t |> equal(typeinfo dim(_a), 13)
+        t |> equal(typeinfo sizeof(_a), 13)
+    }
+    t |> run("macro composes with structs") @(t : T?) {
+        var a : tm_make(type<tuple<x : int; y : int>>, 2, true, "arr")
+        a[1].x = 5
+        t |> equal(a[1].x, 5)
+        t |> equal(a[0].x, 0)
+    }
+}
+
+[test]
+def test_typedecl_payload(t : T?) {
+    t |> run("typedecl(expr) resolves to expression type") @(t : T?) {
+        var _x = 5
+        var y : typedecl(_x)
+        y = 9
+        t |> equal(typeinfo typename(y), "int")
+        t |> equal(y, 9)
+        var _f = 1.5
+        var _g : typedecl(_f)
+        t |> equal(typeinfo typename(_g), "float")
+    }
+}


### PR DESCRIPTION
Stage 0 of the tFixedArray rework (`FIXED_ARRAY_REWORK.md`, included): replace the flattened `dim`/`dimExpr` vectors on `TypeDecl` with a structural `Type::tFixedArray` node so fixed arrays resolve through the same `firstType` recursion as every other container. This PR is tests-only — it pins the current behavior that must survive the representation flip, before any compiler change.

## What's in here

**`tests/fixed_array/`** — 86 characterization tests:
- layout: sizes/alignment, element stride via addresses, 2D contiguity, FA field offsets in structs/tuples/variants, packed `float3[N]` 12-byte stride (intended — memory matters; v_ldu loads when explicitly enabled)
- value semantics: whole-array `=` / `:=` / `clone()`, zero-init, `fixed_array()` literals, FA returns, deep struct-field copies, non-copyable elements + `finalize_dim`
- indexing, iteration (incl. mutation through loop refs, parallel sources), `array<T[N]>` / `table<K;T[N]>` container ops
- must-survive inference: 1-D FA prefers the `auto(TT)[]` overload; dynamic containers bind whole to `auto(TT)`; unsized `int[]` params
- typeinfo surface, native C++ dim field interop (`TestObjectFoo.fooArray`)
- six `failed_*` error-code pins (zero/negative dim, void array, non-const dim, `typedecl(...)[N]`, `new` of FA, `=` on non-copyable FA)

**`_target_*.das`** — the Stage 1 acceptance spec, disabled (dastest `_`-prefix skip) and `expect`-headed so lint/CI treat them as intentional-error fixtures while the syntax stays parsed. They encode the agreed new semantics: `auto(TT)` binds the whole FA, `auto(TT)[]` peels one level, typedef aliases survive declaration/indexing/binding. The `get_key` subtest is gated on Stage 4 (the broken overload gets deleted, not fixed).

**`tests/typemacro/`** — 11 tests covering the raw `AstTypeMacro` payload surface that Stage 1b migrates off `dimExpr`: all four grammar forms, const int/bool/string argument extraction, `typedecl(expr)`.

Both directories AOT-registered in `tests/aot/CMakeLists.txt` (5-step pattern); `tests/README.md` updated.

## Found while characterizing

- `get_key(table<K;V[N]>, v)` is **broken on master** — builtin.das:1407's own `valT const[-2]` contortion fails to resolve. Recorded in the target spec; fixed by Stage 4's overload-family deletion.
- Formatter mangles the `$name<types>(args)` type-macro form → filed as #3074.

## Markdown changes (for explicit review)

- `FIXED_ARRAY_REWORK.md` — new: the staged master plan for the rework
- `tests/README.md` — new `fixed_array/` and `typemacro/` sections

Local full-suite run: 10721 tests, 6 errors all from a stale local binary vs post-build master tests (`bare_block` piped-padding, `gc` escape) — none in this PR's scope; fresh-build CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)