### PR TITLE
release: fix RC1 full-matrix failures (z3 dep, Intel drop, Ninja util install, vcpkg ssl DLLs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [linux, linux_arm, darwin15, darwin26, windows]
+        # darwin15 (macOS Intel x86_64) was dropped after 0.6.2: the LLVM 22
+        # bump has no Intel-mac prebuilt at aleksisch/llvm-shared-builds (the
+        # LLVM 16 era did), and build.yml stopped gating on Intel for the same
+        # reason. 0.6.2 is the last release with a darwin15-x86_64 bundle.
+        target: [linux, linux_arm, darwin26, windows]
         architecture: [32, 64, arm64]
         cmake_preset: [ Release ]
 
@@ -73,22 +77,11 @@ jobs:
             architecture_string: arm64
             archive_ext: tar.gz
 
-          - target: darwin15
-            release_target: darwin15
-            release_arch: x86_64
-            runner: macos-15-large # Intel x86_64
-            architecture_string: x86_64
-            archive_ext: tar.gz
-
           - target: windows
             runner: windows-latest-fat
             archive_ext: zip
 
           - target: windows
-            build_system: cmake
-            cmake_generator: Ninja
-
-          - target: darwin15
             build_system: cmake
             cmake_generator: Ninja
 
@@ -111,12 +104,6 @@ jobs:
             architecture_string: x64
 
         exclude:
-          - target: darwin15
-            architecture: 32
-
-          - target: darwin15
-            architecture: arm64
-
           - target: darwin26
             architecture: 32
 
@@ -203,16 +190,15 @@ jobs:
                 libxinerama-dev \
                 libxi-dev
               ;;
-            darwin15arm64|darwin26arm64)
-              brew install bison openssl
+            darwin26arm64)
+              # z3 is a runtime dependency of the prebuilt LLVM.dll on macOS
+              # arm64: its install_name hardcodes
+              # /opt/homebrew/opt/z3/lib/libz3.4.15.dylib, so dlopen("LLVM.dll")
+              # fails unless homebrew z3 is present (build.yml installs it for
+              # the same reason).
+              brew install bison openssl z3
               echo 'export PATH="/usr/local/opt/bison/bin:$PATH"' >> ~/.bash_profile
               export LDFLAGS="-L/usr/local/opt/bison/lib -L$(brew --prefix openssl)/lib"
-              export CPPFLAGS="-I$(brew --prefix openssl)/include"
-              ;;
-            darwin1564|darwin2664)
-              arch -x86_64 brew install bison openssl
-              echo 'export PATH="/opt/homebrew/opt/bison/bin:$PATH"' >> ~/.bash_profile
-              export LDFLAGS="-L/opt/homebrew/opt/bison/lib -L$(brew --prefix openssl)/lib"
               export CPPFLAGS="-I$(brew --prefix openssl)/include"
               ;;
           esac

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -174,12 +174,16 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 	SETUP_HV(libDasModuleHV)
 	SETUP_HV(dasModuleHV)
 
-	IF(WIN32 AND NOT MSVC)
-		# mingw: land libssl-*.dll + libcrypto-*.dll NEXT TO daslang.exe so
-		# dasModuleHV.shared_module can resolve its openssl deps at dlopen
-		# time. MSVC has its own openssl build path (no-shared above), so it
-		# doesn't need this. Without these copies, build-time AOT codegen
-		# fails silently because register_dynamic_module's default overload
+	IF(WIN32)
+		# Shared-OpenSSL builds (mingw sysroot, MSVC+vcpkg): land libssl-*.dll +
+		# libcrypto-*.dll NEXT TO daslang.exe so dasModuleHV.shared_module can
+		# resolve its openssl deps at dlopen time, and INSTALL them next to the
+		# .shared_module so release bundles work too (sysos.cpp loads modules
+		# with LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR — deps colocated under
+		# modules/dasHV/ resolve). The MSVC openssl-from-source path builds
+		# no-shared, so both globs stay empty there and this is a no-op.
+		# Without these copies, dlopen fails silently because
+		# register_dynamic_module's default overload
 		# (register_dynamic_module_silent) suppresses the LoadLibrary error
 		# and `require dashv` then surfaces as 20605 missing-prerequisite.
 		# Glob picks up the version suffix (libssl-3-x64.dll today, future
@@ -187,6 +191,12 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 		FILE(GLOB _DAS_HV_OPENSSL_DLLS
 			"${OPENSSL_ROOT_DIR}/bin/libssl-*.dll"
 			"${OPENSSL_ROOT_DIR}/bin/libcrypto-*.dll")
+		IF(NOT _DAS_HV_OPENSSL_DLLS AND OPENSSL_INCLUDE_DIR)
+			# vcpkg layout: <triplet-root>/include + <triplet-root>/bin DLLs.
+			FILE(GLOB _DAS_HV_OPENSSL_DLLS
+				"${OPENSSL_INCLUDE_DIR}/../bin/libssl-*.dll"
+				"${OPENSSL_INCLUDE_DIR}/../bin/libcrypto-*.dll")
+		ENDIF()
 		IF(_DAS_HV_OPENSSL_DLLS)
 			# Mirror dasGlfw's multi-config / single-config split — Ninja
 			# (mingw default) is single-config; left in for symmetry with
@@ -201,7 +211,10 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 					${_DAS_HV_OPENSSL_DLLS}
 					"${_DAS_HV_COPY_DIR}/"
 			)
-		ELSE()
+			install(FILES ${_DAS_HV_OPENSSL_DLLS}
+				DESTINATION ${DAS_INSTALL_MODULESDIR}/dasHV
+			)
+		ELSEIF(NOT MSVC)
 			MESSAGE(WARNING "dasHV mingw: no libssl/libcrypto DLLs found under ${OPENSSL_ROOT_DIR}/bin — dasModuleHV.shared_module may fail to load at runtime")
 		ENDIF()
 	ENDIF()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -47,9 +47,12 @@ file(GLOB DASLIB_SOURCES ${PROJECT_SOURCE_DIR}/daslib/*.das)
 file(GLOB_RECURSE DASLLVM_DASLIB_SOURCES ${PROJECT_SOURCE_DIR}/modules/dasLLVM/*.das)
 
 # daslang -exe appends `.exe` to the output path.
-# On multi-config generators (MSVC), place next to daslang in bin/<Config>/.
-# On single-config generators (Make/Ninja), place in bin/.
-if(MSVC)
+# On multi-config generators (Visual Studio), place next to daslang in
+# bin/<Config>/. On single-config generators (Make/Ninja), place in bin/.
+# Key on the GENERATOR, not the compiler: MSVC+Ninja (release CI) is
+# single-config and its exes land in plain bin/.
+get_property(_DAS_UTILS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_DAS_UTILS_MULTI_CONFIG)
     set(UTIL_BIN_DIR ${PROJECT_SOURCE_DIR}/bin/${CMAKE_CFG_INTDIR})
 else()
     set(UTIL_BIN_DIR ${PROJECT_SOURCE_DIR}/bin)
@@ -138,7 +141,9 @@ ADD_CUSTOM_TARGET(run_utils_tests
 # Install utility executables (OPTIONAL — only present when -exe targets are built).
 # UTIL_BIN_DIR uses CMAKE_CFG_INTDIR which doesn't resolve at install time on
 # multi-config generators. Use install(CODE) with CMAKE_INSTALL_CONFIG_NAME.
-if(MSVC)
+# Same generator-keyed split as UTIL_BIN_DIR above — under MSVC+Ninja the exes
+# are in plain bin/, and bin/${CMAKE_INSTALL_CONFIG_NAME} would miss them all.
+if(_DAS_UTILS_MULTI_CONFIG)
     set(_UTIL_INSTALL_PATTERN "${PROJECT_SOURCE_DIR}/bin/\${CMAKE_INSTALL_CONFIG_NAME}")
 else()
     set(_UTIL_INSTALL_PATTERN "${PROJECT_SOURCE_DIR}/bin")


### PR DESCRIPTION
The v0.6.3-RC1 release run ([27257175905](https://github.com/GaijinEntertainment/daScript/actions/runs/27257175905)) failed on 3 of 5 platforms. None of these can be caught by regular PR CI: the full-matrix bundle smoke test (#2823) ran for the first time at this RC cut (PR-time `bundle_smoke` is Linux-only), and two of the failures live in release.yml's own matrix/deps which build.yml diverged from.

**darwin26 arm64** — every dasLLVM `[extern]` failed during AOT because the prebuilt `LLVM.dll` hardcodes `/opt/homebrew/opt/z3/lib/libz3.4.15.dylib`. build.yml installs z3 with a comment documenting exactly this; release.yml didn't. Fix: `brew install bison openssl z3`.

**darwin15 x86_64 (Intel)** — `aleksisch/llvm-shared-builds v22.1.5` ships no Intel-mac prebuilt (the LLVM-16-era `llvm-16-prebuilt v2.0.0` used at 0.6.2 had `mac_64`), so dasLLVM configure fatals. build.yml already dropped Intel coverage entirely for the same reason. Fix: drop the darwin15 cell — 0.6.2 is the last release with a `daslang-bundle-darwin15-x86_64.zip`.

**Windows: 8 util exes missing from the bundle** — `utils/CMakeLists.txt` keyed the `daslang -exe` output/install path on `if(MSVC)`, but MSVC+Ninja (release CI since #2961) is single-config: the exes land in plain `bin/` while install looked in `bin/${CMAKE_INSTALL_CONFIG_NAME}` and silently skipped all of them (the install rules are `if(EXISTS)`-guarded). Fix: key on `GENERATOR_IS_MULTI_CONFIG` instead of the compiler.

**Windows: bundle `mcp` fails `error[20605] missing prerequisite 'dashv'`** — the classic silent-LoadLibrary signature. dasHV links vcpkg's *dynamic* OpenSSL (`vcpkg/installed/x64-windows/lib/libcrypto.lib` per the build log), but `libssl-3-x64.dll` / `libcrypto-3-x64.dll` were never installed into the bundle. In-tree tests pass because vcpkg applocal drops the DLLs next to built targets; `cmake --install` misses them. The existing mingw copy block's "MSVC has its own openssl build path (no-shared), so it doesn't need this" comment predates vcpkg in CI. Fix: extend the block to `WIN32`, add a vcpkg-layout glob fallback (`${OPENSSL_INCLUDE_DIR}/../bin`), and `install(FILES …)` the DLLs next to the `.shared_module` — `sysos.cpp` loads modules with `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`, whose comment explicitly anticipates deps colocated under `modules/<X>/`. The MSVC source-build path stays no-shared → globs empty → no-op. (dasGlfw already installs its `glfw3.dll`; dasHV was the only gap.)

Validation plan after merge: `workflow_dispatch` release.yml on master — it runs the full build + smoke matrix without uploading assets — then re-create the v0.6.3-RC1 prerelease at the fixed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)