### PR TITLE
site: news — 0.6.3-RC1 is out

### DIFF
--- a/site/_news/2026-06-10-0-6-3-rc1-is-out-final-stretch.md
+++ b/site/_news/2026-06-10-0-6-3-rc1-is-out-final-stretch.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-10
+tag: 0.6.3-rc1
+title: 0.6.3-RC1 is out! Final stretch.
+link: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC1-take2
+---


### PR DESCRIPTION
News entry under `site/_news` announcing the 0.6.3 release candidate, linking to [v0.6.3-RC1-take2](https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC1-take2). Frontmatter-only, same shape as the 0.6.2 RC entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)