### PR TITLE
flatten: _flatten_no_fast_math option, division → reciprocal, ctor lane algebra

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -758,17 +758,22 @@ def public flatten_optimize(var func : FunctionPtr; barriers : table<string>; no
 }
 
 [macro_function]
-def public flatten_fuse(var func : FunctionPtr) : bool {
-    //! PHASE_FUSED finishing pass (delegates to `fuse_body`): re-pack `a*b ± c` into `mad(a,b,c)`
-    //! and the expanded lerp shape back into `lerp(a,b,t)`. Call on the optimized, re-inferred body and
-    //! repeat across re-inference until it returns false (the type gates need each round's settled types).
-    return fuse_body(func)
+def public flatten_fuse(var func : FunctionPtr; no_fast_math : bool = false) : bool {
+    //! PHASE_FUSED finishing pass (delegates to `fuse_body`): re-pack ctor lane patterns, `a*b ± c`
+    //! into `mad(a,b,c)`, and the expanded lerp shape back into `lerp(a,b,t)`. Call on the optimized,
+    //! re-inferred body and repeat across re-inference until it returns false.
+    return fuse_body(func, no_fast_math)
 }
 
 def public flatten_opt_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {
     //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin
-    //! has no un-extracted uniform subtree, no un-CSE'd repeat, no un-rcp'd uniform division.
-    return <- opt_residuals(func, FLATTEN_BARRIERS, no_fast_math)
+    //! has no un-extracted uniform subtree, no un-CSE'd repeat, no un-rcp'd uniform division,
+    //! no un-packed ctor lane pattern.
+    var res : array<string>
+    ast_gc_guard() {
+        res <- opt_residuals(func, FLATTEN_BARRIERS, no_fast_math)
+    }
+    return <- res
 }
 
 // ===== Post-inference shape verification — twin must be branchless + call-free =====
@@ -824,7 +829,7 @@ class private FoldResidualVisitor : AstVisitor {
             found |> push("an unfolded const-condition select")
         }
     }
-    def override preVisitExprOp2(expr : ExprOp2?) : void {
+    def override preVisitExprOp2(var expr : ExprOp2?) : void {
         if (is_unfolded_identity_op2(expr)) {
             found |> push("an unfolded algebraic identity ('{expr.op}')")
         } elif (is_all_const(expr) && eval_to_const_supported(expr._type)) {
@@ -833,6 +838,10 @@ class private FoldResidualVisitor : AstVisitor {
             found |> push("a scattered const chain ('{expr.op}') reassoc should gather")
         } elif (!noFastMath && is_unrcp_const_div(expr)) {
             found |> push("an un-rewritten const division ('x / C' should be 'x * (1/C)')")
+        } elif (is_uncollapsed_splat_op2(expr)) {
+            found |> push("an uncollapsed splat operand ('v {expr.op} floatN(s)' should use the scalar)")
+        } elif (is_unkilled_ctor_zero_lane(expr, noFastMath)) {
+            found |> push("an un-killed ctor lane under a zero const lane")
         }
     }
     def override preVisitExprOp1(expr : ExprOp1?) : void {
@@ -850,14 +859,18 @@ def public flatten_fold_residuals(var func : FunctionPtr; no_fast_math : bool = 
     if (func == null || func.body == null) {
         return <- res
     }
-    var v = new FoldResidualVisitor()
-    v.noFastMath = no_fast_math
-    make_visitor(*v) $(adapter) {
-        visit(func.body, adapter)
-    }
-    res <- v.found
-    unsafe {
-        delete v
+    // the probe matchers (recip_const, ctor_fuse_rewrite) clone AST nodes; at runtime (tests,
+    // fuzzer) those land on the thread root — guard the walk so they are swept, not leaked
+    ast_gc_guard() {
+        var v = new FoldResidualVisitor()
+        v.noFastMath = no_fast_math
+        make_visitor(*v) $(adapter) {
+            visit(func.body, adapter)
+        }
+        res <- v.found
+        unsafe {
+            delete v
+        }
     }
     return <- res
 }
@@ -931,7 +944,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // `lerp`, re-inferring to resolve the new calls; iterates (each round strictly
             // drops a `+`/`-`, so it converges), a clean round falls through to the shape check.
             set_flatten_phase(func, PHASE_FUSED)
-            if (flatten_fuse(twin)) {
+            if (flatten_fuse(twin, flatten_no_fast_math())) {
                 astChanged = true
                 return true
             }

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -734,27 +734,27 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
 // ===== Post-infer select folding =====
 
 [macro_function]
-def public flatten_fast_math : bool {
-    //! True unless the COMPILING module sets `options _flatten_no_fast_math = true` — the user
+def public flatten_no_fast_math : bool {
+    //! True when the COMPILING module sets `options _flatten_no_fast_math = true` — the user
     //! opt-out of flatten's value-changing rewrites; bit-exact passes ignore it. COMPILE-TIME ONLY
     //! (panics outside a compile): patch code reads it once, runtime tools pass their flag explicitly.
-    return !(compiling_program()._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false)
+    return compiling_program()._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false
 }
 
 [macro_function]
-def public flatten_fold(var func : FunctionPtr; fast_math : bool = true) : bool {
+def public flatten_fold(var func : FunctionPtr; no_fast_math : bool = false) : bool {
     //! Post-infer fold pass (delegates to `fold_body`): collapse `const ? a : b`, fold identities,
     //! drop pure self-assigns. Run AFTER re-inference; returns true if anything changed. Compile-time
-    //! callers pass `flatten_fast_math()` to honor `options _flatten_no_fast_math`.
-    return fold_body(func, fast_math)
+    //! callers pass `flatten_no_fast_math()` to honor the module option; the default is fast-math ON.
+    return fold_body(func, no_fast_math)
 }
 
 [macro_function]
-def public flatten_optimize(var func : FunctionPtr; barriers : table<string>) : bool {
+def public flatten_optimize(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false) : bool {
     //! Post-fold optimize pass (delegates to `flatten_preshade_cse`): hoist uniform subtrees to
-    //! per-draw `_preshader_` lets + CSE-dedup. Run ONCE after the `flatten_fold` fixpoint converges;
-    //! `barriers` = the backend's sampler/intrinsic call names. Returns true if anything changed.
-    return flatten_preshade_cse(func, barriers)
+    //! per-draw `_preshader_` lets + CSE-dedup + rcp-rewrite divisions by a uniform (fast-math).
+    //! Run after the `flatten_fold` fixpoint; `barriers` = the backend's sampler/intrinsic names.
+    return flatten_preshade_cse(func, barriers, no_fast_math)
 }
 
 [macro_function]
@@ -765,10 +765,10 @@ def public flatten_fuse(var func : FunctionPtr) : bool {
     return fuse_body(func)
 }
 
-def public flatten_opt_residuals(var func : FunctionPtr) : array<string> {
+def public flatten_opt_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {
     //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin
-    //! has no un-extracted uniform subtree and no un-CSE'd repeat. Test-framework / fuzzer facing.
-    return <- opt_residuals(func, FLATTEN_BARRIERS)
+    //! has no un-extracted uniform subtree, no un-CSE'd repeat, no un-rcp'd uniform division.
+    return <- opt_residuals(func, FLATTEN_BARRIERS, no_fast_math)
 }
 
 // ===== Post-inference shape verification — twin must be branchless + call-free =====
@@ -813,7 +813,7 @@ def private verify_flat(var twin : FunctionPtr) : string {
 
 class private FoldResidualVisitor : AstVisitor {
     found : array<string>
-    fastMath : bool = true
+    noFastMath : bool
     def override preVisitExprCall(expr : ExprCall?) : void {
         if (expr.func != null && expr.func.flags.builtIn && is_all_const(expr) && eval_to_const_supported(expr._type)) {
             found |> push("an unfolded all-const call '{expr.name}'")
@@ -829,8 +829,10 @@ class private FoldResidualVisitor : AstVisitor {
             found |> push("an unfolded algebraic identity ('{expr.op}')")
         } elif (is_all_const(expr) && eval_to_const_supported(expr._type)) {
             found |> push("an unfolded all-const arithmetic ('{expr.op}')")
-        } elif (has_scattered_consts(expr, fastMath)) {
+        } elif (has_scattered_consts(expr, noFastMath)) {
             found |> push("a scattered const chain ('{expr.op}') reassoc should gather")
+        } elif (!noFastMath && is_unrcp_const_div(expr)) {
+            found |> push("an un-rewritten const division ('x / C' should be 'x * (1/C)')")
         }
     }
     def override preVisitExprOp1(expr : ExprOp1?) : void {
@@ -840,16 +842,16 @@ class private FoldResidualVisitor : AstVisitor {
     }
 }
 
-def public flatten_fold_residuals(var func : FunctionPtr; fast_math : bool = true) : array<string> {
+def public flatten_fold_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {
     //! Collect the const-foldable residuals left in `func`'s (post-flatten) body — empty means the
     //! fold is complete; reuses the exact predicates the macro's own fold uses (test/fuzzer facing).
-    //! Pass `fast_math = false` for a unit compiled under `options _flatten_no_fast_math`.
+    //! Pass `no_fast_math = true` for a unit compiled under `options _flatten_no_fast_math`.
     var res : array<string>
     if (func == null || func.body == null) {
         return <- res
     }
     var v = new FoldResidualVisitor()
-    v.fastMath = fast_math
+    v.noFastMath = no_fast_math
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)
     }
@@ -909,7 +911,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // Cycle 2+: fold the inferred twin (const selects, algebraic identities, pure self-
             // assigns), re-infer if anything changed. Iterate to a fixpoint — fold and the typer's
             // re-infer const-fold are mutually-enabling, so one pass isn't enough.
-            let folded = flatten_fold(twin, flatten_fast_math())
+            let folded = flatten_fold(twin, flatten_no_fast_math())
             set_flatten_phase(func, PHASE_FOLDED)
             if (folded) {
                 astChanged = true
@@ -919,7 +921,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // subtrees to top-of-body `_preshader_` lets, CSE-dedup repeated subtrees. Re-infer to
             // type the new lets, then fuse next cycle.
             set_flatten_phase(func, PHASE_OPTIMIZED)
-            if (flatten_optimize(twin, FLATTEN_BARRIERS)) {
+            if (flatten_optimize(twin, FLATTEN_BARRIERS, flatten_no_fast_math())) {
                 astChanged = true
                 return true
             }

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -734,11 +734,19 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
 // ===== Post-infer select folding =====
 
 [macro_function]
-def public flatten_fold(var func : FunctionPtr) : bool {
-    //! Post-infer fold pass (delegates to `fold_body`): collapse `const ? a : b`, drop pure
-    //! `lhs = lhs` self-assigns, strip redundant zero inits. Run AFTER re-inference (conditions
-    //! must be `ExprConstBool`). Returns true if anything changed — re-infer then for clean codegen.
-    return fold_body(func)
+def public flatten_fast_math : bool {
+    //! True unless the COMPILING module sets `options _flatten_no_fast_math = true` — the user
+    //! opt-out of flatten's value-changing rewrites; bit-exact passes ignore it. COMPILE-TIME ONLY
+    //! (panics outside a compile): patch code reads it once, runtime tools pass their flag explicitly.
+    return !(compiling_program()._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false)
+}
+
+[macro_function]
+def public flatten_fold(var func : FunctionPtr; fast_math : bool = true) : bool {
+    //! Post-infer fold pass (delegates to `fold_body`): collapse `const ? a : b`, fold identities,
+    //! drop pure self-assigns. Run AFTER re-inference; returns true if anything changed. Compile-time
+    //! callers pass `flatten_fast_math()` to honor `options _flatten_no_fast_math`.
+    return fold_body(func, fast_math)
 }
 
 [macro_function]
@@ -805,6 +813,7 @@ def private verify_flat(var twin : FunctionPtr) : string {
 
 class private FoldResidualVisitor : AstVisitor {
     found : array<string>
+    fastMath : bool = true
     def override preVisitExprCall(expr : ExprCall?) : void {
         if (expr.func != null && expr.func.flags.builtIn && is_all_const(expr) && eval_to_const_supported(expr._type)) {
             found |> push("an unfolded all-const call '{expr.name}'")
@@ -820,7 +829,7 @@ class private FoldResidualVisitor : AstVisitor {
             found |> push("an unfolded algebraic identity ('{expr.op}')")
         } elif (is_all_const(expr) && eval_to_const_supported(expr._type)) {
             found |> push("an unfolded all-const arithmetic ('{expr.op}')")
-        } elif (has_scattered_consts(expr)) {
+        } elif (has_scattered_consts(expr, fastMath)) {
             found |> push("a scattered const chain ('{expr.op}') reassoc should gather")
         }
     }
@@ -831,15 +840,16 @@ class private FoldResidualVisitor : AstVisitor {
     }
 }
 
-def public flatten_fold_residuals(var func : FunctionPtr) : array<string> {
-    //! Collect the const-foldable residuals left in `func`'s (post-flatten) body — empty
-    //! means the fold is complete. For test-framework / fuzzer verification of a compiled
-    //! flattened twin; reuses the same predicates the macro's own fold uses.
+def public flatten_fold_residuals(var func : FunctionPtr; fast_math : bool = true) : array<string> {
+    //! Collect the const-foldable residuals left in `func`'s (post-flatten) body — empty means the
+    //! fold is complete; reuses the exact predicates the macro's own fold uses (test/fuzzer facing).
+    //! Pass `fast_math = false` for a unit compiled under `options _flatten_no_fast_math`.
     var res : array<string>
     if (func == null || func.body == null) {
         return <- res
     }
     var v = new FoldResidualVisitor()
+    v.fastMath = fast_math
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)
     }
@@ -899,7 +909,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // Cycle 2+: fold the inferred twin (const selects, algebraic identities, pure self-
             // assigns), re-infer if anything changed. Iterate to a fixpoint — fold and the typer's
             // re-infer const-fold are mutually-enabling, so one pass isn't enough.
-            let folded = flatten_fold(twin)
+            let folded = flatten_fold(twin, flatten_fast_math())
             set_flatten_phase(func, PHASE_FOLDED)
             if (folded) {
                 astChanged = true

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -524,7 +524,7 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
 
 class private FoldVisitor : AstVisitor {
     changed : bool
-    fastMath : bool = true
+    noFastMath : bool
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
         // A fully-constant ExprOp2 the typer left unfolded — it folds scalar const arithmetic but
         // leaves vector const (`float3(2)+float3(3)`), what reassoc's gathered groups become. Fold
@@ -542,11 +542,11 @@ class private FoldVisitor : AstVisitor {
             if (is_neg_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return negate(that.left) }
             if (is_neg_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return negate(that.right) }
             // `*0` changes inf/NaN propagation — float forms are fast-math only (int exact)
-            if (is_zero_const_op(that.right) && !has_sideeffects(that.left) && (fastMath || !is_float_valued(that))) {
+            if (is_zero_const_op(that.right) && !has_sideeffects(that.left) && (!noFastMath || !is_float_valued(that))) {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
             }
-            if (is_zero_const_op(that.left) && !has_sideeffects(that.right) && (fastMath || !is_float_valued(that))) {
+            if (is_zero_const_op(that.left) && !has_sideeffects(that.right) && (!noFastMath || !is_float_valued(that))) {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
             }
@@ -559,9 +559,19 @@ class private FoldVisitor : AstVisitor {
             // `x - x → 0` — purity-gated like `*0` (and like it, inf/NaN operands aside:
             // fast-math charter). Identical describe ⇒ identical purity, so one check.
             if (describe(that.left) == describe(that.right) && !has_sideeffects(that.left) &&
-                    (fastMath || !is_float_valued(that))) {
+                    (!noFastMath || !is_float_valued(that))) {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
+            }
+        } elif (that.op == "/") {
+            // `x / C → x * (1/C)` — a mul instead of a div; the reciprocal rounds (fast-math).
+            // Float-family only (int division has no reciprocal); zero lanes keep the div.
+            if (!noFastMath && is_float_valued(that)) {
+                var rec = recip_const(that.right)
+                if (rec != null) {
+                    changed = true
+                    return new ExprOp2(at = that.at, op := "*", left = that.left, right = rec)
+                }
             }
         } elif (that.op == "&&") {
             // Short-circuit `&&`: `false && x` never evaluates x, so dropping x is
@@ -638,7 +648,7 @@ class private FoldVisitor : AstVisitor {
                 var tArg = that.arguments[2]
                 // const-selector short-circuits — no expand/refuse round trip. They DROP an
                 // argument (`(b-a)*0` would still propagate b's inf/NaN) → fast-math only.
-                if (fastMath) {
+                if (!noFastMath) {
                     if (is_zero_const_op(tArg) && !has_sideeffects(bArg)) { changed = true; return aArg }
                     if (is_one_const_op(tArg) && !has_sideeffects(aArg)) { changed = true; return bArg }
                     if (describe(aArg) == describe(bArg) && !has_sideeffects(bArg) && !has_sideeffects(tArg)) {
@@ -1233,8 +1243,8 @@ def private count_terms(e : ExpressionPtr; addOp : string; var nv : int&; var nc
 // True if reassoc WOULD gather this chain: ≥1 var term, ≥2 scattered consts, not already grouped.
 // The fold-completeness oracle (flatten.das FoldResidualVisitor) mirrors the transform's exact gate
 // through this — incl. `fast_math` (float chains stay scattered under `_flatten_no_fast_math`).
-def public has_scattered_consts(that : ExprOp2?; fast_math : bool = true) : bool {
-    if (that == null || (!fast_math && is_float_valued(that))) return false
+def public has_scattered_consts(that : ExprOp2?; no_fast_math : bool = false) : bool {
+    if (that == null || (no_fast_math && is_float_valued(that))) return false
     var nv = 0
     var nc = 0
     if (that.op == "+" || that.op == "-") {
@@ -1251,11 +1261,11 @@ def public has_scattered_consts(that : ExprOp2?; fast_math : bool = true) : bool
 
 class private ReassocVisitor : AstVisitor {
     changed : bool
-    fastMath : bool = true
+    noFastMath : bool
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
         // Both the const-gather and the canonical re-sort rebuild the chain — a float
         // sum/product picks up a different association order, so floats are fast-math only.
-        if (!fastMath && is_float_valued(that)) {
+        if (noFastMath && is_float_valued(that)) {
             return that
         }
         var res : ExpressionPtr = null
@@ -1276,18 +1286,18 @@ class private ReassocVisitor : AstVisitor {
     }
 }
 
-def public fold_body(var func : FunctionPtr; fast_math : bool = true) : bool {
+def public fold_body(var func : FunctionPtr; no_fast_math : bool = false) : bool {
     //! Post-infer fold over a flattened body: const-propagate single-def locals, reassociate
     //! scattered consts, collapse `const ? a : b`, fold identities/const ctors, drop pure self-assigns.
-    //! SINGLE pass (caller re-infers and loops); `fast_math = false` skips the value-changing arms.
+    //! SINGLE pass (caller re-infers and loops); `no_fast_math = true` skips the value-changing arms.
     if (!(func.body is ExprBlock)) return false
-    let fm = fast_math
+    let nfm = no_fast_math
     var changed = const_prop_locals(func.body as ExprBlock)
     // Reassociate BEFORE the fold — gather scattered consts into one adjacent group so the
     // FoldVisitor all-const arm (and the typer's re-infer) can collapse them. After const-prop,
     // which is what scatters consts (a substituted single-def local lands mid-chain).
     var rv = new ReassocVisitor()
-    rv.fastMath = fm
+    rv.noFastMath = nfm
     make_visitor(*rv) $(adapter) {
         visit(func.body, adapter)
     }
@@ -1298,7 +1308,7 @@ def public fold_body(var func : FunctionPtr; fast_math : bool = true) : bool {
         delete rv
     }
     var v = new FoldVisitor()
-    v.fastMath = fm
+    v.noFastMath = nfm
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)
     }
@@ -1399,6 +1409,16 @@ struct private PEX {
     rename : table<string; ExpressionPtr>   // old local name -> replacement (alias inline / preshader ref)
     counter : int
     changed : bool
+    noFastMath : bool                       // zero-init false = fast-math ON (the default)
+}
+
+// `x / U` rcp-candidate: a varying division by a preshader-eligible scalar-float NON-const
+// divisor — shared verbatim by the extraction rewrite and the opt residual oracle. A wholly-
+// uniform division hoists intact (maximal arm); a const divisor belongs to the fold arm.
+def private is_rcp_candidate(pe : PEX; barriers : table<string>; o : ExprOp2?) : bool {
+    return (o.op == "/" && expr_bt(o.right) == Type.tFloat && is_float_valued(o) &&
+        !(o.right |> is_expr_const()) && !pex_eligible(pe, barriers, o) &&
+        pex_eligible(pe, barriers, o.right))
 }
 
 // Uniform = depends only on globals + literals, no barrier (sampler/noise) call. Leaf rule: a param
@@ -1475,6 +1495,16 @@ def private pex_extract(var pe : PEX; barriers : table<string>; var e : Expressi
         o.subexpr = pex_extract(pe, barriers, o.subexpr)
     } elif (e is ExprOp2) {
         var o = e as ExprOp2
+        // `x / U` → `x * (1f/U)` — reciprocal hoisted per-draw, dedup'd by describe (fast-math)
+        if (!pe.noFastMath && is_rcp_candidate(pe, barriers, o)) {
+            var one = new ExprConstFloat(at = o.at, value = 1.0)
+            var recip = new ExprOp2(at = o.at, op := "/", left = one, right = o.right)
+            let nm = pex_hoist_name(pe, recip)
+            pe.changed = true
+            return new ExprOp2(at = o.at, op := "*",
+                left = pex_extract(pe, barriers, o.left),
+                right = new ExprVar(at = o.at, name := nm))
+        }
         o.left = pex_extract(pe, barriers, o.left)
         o.right = pex_extract(pe, barriers, o.right)
     } elif (e is ExprOp3) {
@@ -1524,9 +1554,8 @@ def private pex_extract(var pe : PEX; barriers : table<string>; var e : Expressi
 
 // `counter` is owned by the caller's optimize loop — extraction re-runs per round, and a fresh
 // per-call numbering would collide a later round's `_preshader_0` with the surviving first one.
-def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barriers : table<string>; var counter : int&) : bool {
-    var pe : PEX
-    pe.counter = counter
+def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barriers : table<string>; var counter : int&; no_fast_math : bool) : bool {
+    var pe = PEX(counter = counter, noFastMath = no_fast_math)
     for (a in func.arguments) {
         pe.paramNames |> insert("{a.name}")
     }
@@ -2046,7 +2075,53 @@ def private pex_residual_expr(pe : PEX; barriers : table<string>; e : Expression
     return false
 }
 
-def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : array<string> {
+// Oracle mirror of the extraction rcp rewrite — any descendant division `is_rcp_candidate`
+// would have become `* _preshader(1/U)`. Same closed node set as pex_residual_expr.
+def private rcp_residual_expr(pe : PEX; barriers : table<string>; e : ExpressionPtr) : bool {
+    if (e == null) return false
+    if (e is ExprOp1) return rcp_residual_expr(pe, barriers, (e as ExprOp1).subexpr)
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        if (is_rcp_candidate(pe, barriers, o)) return true
+        return rcp_residual_expr(pe, barriers, o.left) || rcp_residual_expr(pe, barriers, o.right)
+    }
+    if (e is ExprOp3) {
+        let o = e as ExprOp3
+        return rcp_residual_expr(pe, barriers, o.subexpr) || rcp_residual_expr(pe, barriers, o.left) || rcp_residual_expr(pe, barriers, o.right)
+    }
+    if (e is ExprCall) {
+        for (a in (e as ExprCall).arguments) {
+            if (rcp_residual_expr(pe, barriers, a)) return true
+        }
+        return false
+    }
+    if (e is ExprField) return rcp_residual_expr(pe, barriers, (e as ExprField).value)
+    if (e is ExprSwizzle) return rcp_residual_expr(pe, barriers, (e as ExprSwizzle).value)
+    if (e is ExprRef2Value) return rcp_residual_expr(pe, barriers, (e as ExprRef2Value).subexpr)
+    if (e is ExprCast) return rcp_residual_expr(pe, barriers, (e as ExprCast).subexpr)
+    if (e is ExprPtr2Ref) return rcp_residual_expr(pe, barriers, (e as ExprPtr2Ref).subexpr)
+    if (e is ExprAt) {
+        let o = e as ExprAt
+        return rcp_residual_expr(pe, barriers, o.subexpr) || rcp_residual_expr(pe, barriers, o.index)
+    }
+    if (e is ExprMakeTuple) {
+        for (v in (e as ExprMakeTuple).values) {
+            if (rcp_residual_expr(pe, barriers, v)) return true
+        }
+        return false
+    }
+    if (e is ExprMakeStruct) {
+        var ms = e as ExprMakeStruct
+        for (si in range(length(ms.structs))) {
+            for (fld in *(ms.structs[si])) {
+                if (rcp_residual_expr(pe, barriers, fld.value)) return true
+            }
+        }
+    }
+    return false
+}
+
+def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false) : array<string> {
     var res : array<string>
     if (func == null || func.body == null || !(func.body is ExprBlock)) return <- res
     var blk = func.body as ExprBlock
@@ -2085,6 +2160,31 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
         if (hit) {
             res |> push("an un-extracted uniform subtree (preshader miss)")
             break
+        }
+    }
+    // rcp residual: a varying division by a preshader-eligible scalar still inline (fast-math only).
+    if (!no_fast_math) {
+        for (i in range(length(blk.list))) {
+            if (i < prefix) {
+                continue
+            }
+            let s = blk.list[i]
+            var hit = false
+            if (s is ExprLet) {
+                for (lv in (s as ExprLet).variables) {
+                    if (lv.init != null && rcp_residual_expr(pe, barriers, lv.init)) {
+                        hit = true
+                    }
+                }
+            } elif (s is ExprCopy) {
+                hit = rcp_residual_expr(pe, barriers, (s as ExprCopy).right)
+            } elif (s is ExprReturn) {
+                hit = rcp_residual_expr(pe, barriers, (s as ExprReturn).subexpr)
+            }
+            if (hit) {
+                res |> push("an un-rewritten division by a uniform ('x / U' should be 'x * _preshader(1/U)')")
+                break
+            }
         }
     }
     // CSE residual: any pure subtree (no mutable read) still computed >=2x — tallying the same
@@ -2150,7 +2250,7 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>) : arr
     return <- res
 }
 
-def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>) : bool {
+def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false) : bool {
     //! Post-fold optimize pass: hoist uniform (globals+literals) subtrees to top-of-body
     //! `_preshader_N` lets, CSE-dedup repeats, collapse pure aliases — a joint fixpoint.
     //! `barriers` = sampler/noise names that stay per-pixel. Post-fold, once; caller re-infers.
@@ -2166,7 +2266,7 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
     while (guard < 16) {
         guard ++
         var round = false
-        if (extract_preshader(func, blk, barriers, preCounter)) {
+        if (extract_preshader(func, blk, barriers, preCounter, no_fast_math)) {
             round = true
         }
         if (cse_body(blk, cseCounter)) {
@@ -2189,6 +2289,44 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
 // ===== mad/lerp re-fusion (PHASE_FUSED finishing pass) =====
 // The fold DISASSEMBLES lerp/mad into raw arithmetic (identities fold, reassoc/CSE see through);
 // this re-packs survivors: `a*b ± c` → mad, then `mad(b - a, t, a)` → lerp — one node each.
+
+// A reciprocal copy of a scalar/vector float const literal (`C` → `1/C`); null for any other
+// node or when any lane is zero (no inf literals). Backs the `x / C → x * (1/C)` fold arm.
+def private recip_const(e : ExpressionPtr) : ExpressionPtr {
+    if (e == null) return null
+    if (e is ExprConstFloat) {
+        let v = (e as ExprConstFloat).value
+        if (v == 0.0) return null
+        return new ExprConstFloat(at = e.at, value = 1.0 / v)
+    }
+    if (e is ExprConstDouble) {
+        let v = (e as ExprConstDouble).value
+        if (v == 0.0lf) return null
+        return new ExprConstDouble(at = e.at, value = 1.0lf / v)
+    }
+    if (e is ExprConstFloat2) {
+        let v = (e as ExprConstFloat2).value
+        if (v.x == 0.0 || v.y == 0.0) return null
+        return new ExprConstFloat2(at = e.at, value = float2(1.0 / v.x, 1.0 / v.y))
+    }
+    if (e is ExprConstFloat3) {
+        let v = (e as ExprConstFloat3).value
+        if (v.x == 0.0 || v.y == 0.0 || v.z == 0.0) return null
+        return new ExprConstFloat3(at = e.at, value = float3(1.0 / v.x, 1.0 / v.y, 1.0 / v.z))
+    }
+    if (e is ExprConstFloat4) {
+        let v = (e as ExprConstFloat4).value
+        if (v.x == 0.0 || v.y == 0.0 || v.z == 0.0 || v.w == 0.0) return null
+        return new ExprConstFloat4(at = e.at, value = float4(1.0 / v.x, 1.0 / v.y, 1.0 / v.z, 1.0 / v.w))
+    }
+    return null
+}
+
+// Oracle mirror for the `x / C → x * (1/C)` fold arm: true when the (fast-math) rewrite would fire.
+def public is_unrcp_const_div(e : ExprOp2?) : bool {
+    if (e == null || e.op != "/" || !is_float_valued(e)) return false
+    return recip_const(e.right) != null
+}
 
 // A negated copy of a scalar/vector float/int const literal; null for any other node
 // (uint excluded — modular negation is value-correct but backend-hostile).

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -950,6 +950,15 @@ def private const_vec_zero_mask(e : ExpressionPtr) : int {
     } elif (e is ExprConstInt4) {
         let v = (e as ExprConstInt4).value
         if (v.x == 0) { m |= 1; }; if (v.y == 0) { m |= 2; }; if (v.z == 0) { m |= 4; }; if (v.w == 0) { m |= 8; }
+    } elif (e is ExprConstUInt2) {
+        let v = (e as ExprConstUInt2).value
+        if (v.x == 0u) { m |= 1; }; if (v.y == 0u) { m |= 2; }
+    } elif (e is ExprConstUInt3) {
+        let v = (e as ExprConstUInt3).value
+        if (v.x == 0u) { m |= 1; }; if (v.y == 0u) { m |= 2; }; if (v.z == 0u) { m |= 4; }
+    } elif (e is ExprConstUInt4) {
+        let v = (e as ExprConstUInt4).value
+        if (v.x == 0u) { m |= 1; }; if (v.y == 0u) { m |= 2; }; if (v.z == 0u) { m |= 4; }; if (v.w == 0u) { m |= 8; }
     }
     return m
 }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -524,6 +524,7 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
 
 class private FoldVisitor : AstVisitor {
     changed : bool
+    fastMath : bool = true
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
         // A fully-constant ExprOp2 the typer left unfolded — it folds scalar const arithmetic but
         // leaves vector const (`float3(2)+float3(3)`), what reassoc's gathered groups become. Fold
@@ -540,11 +541,12 @@ class private FoldVisitor : AstVisitor {
             if (is_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return that.right }
             if (is_neg_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return negate(that.left) }
             if (is_neg_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return negate(that.right) }
-            if (is_zero_const_op(that.right) && !has_sideeffects(that.left)) {
+            // `*0` changes inf/NaN propagation — float forms are fast-math only (int exact)
+            if (is_zero_const_op(that.right) && !has_sideeffects(that.left) && (fastMath || !is_float_valued(that))) {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
             }
-            if (is_zero_const_op(that.left) && !has_sideeffects(that.right)) {
+            if (is_zero_const_op(that.left) && !has_sideeffects(that.right) && (fastMath || !is_float_valued(that))) {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
             }
@@ -556,7 +558,8 @@ class private FoldVisitor : AstVisitor {
             if (is_zero_const_op(that.left)) { changed = true; return negate(that.right) }
             // `x - x → 0` — purity-gated like `*0` (and like it, inf/NaN operands aside:
             // fast-math charter). Identical describe ⇒ identical purity, so one check.
-            if (describe(that.left) == describe(that.right) && !has_sideeffects(that.left)) {
+            if (describe(that.left) == describe(that.right) && !has_sideeffects(that.left) &&
+                    (fastMath || !is_float_valued(that))) {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
             }
@@ -633,12 +636,15 @@ class private FoldVisitor : AstVisitor {
                 var aArg = that.arguments[0]
                 var bArg = that.arguments[1]
                 var tArg = that.arguments[2]
-                // const-selector short-circuits — exact, and no expand/refuse round trip
-                if (is_zero_const_op(tArg) && !has_sideeffects(bArg)) { changed = true; return aArg }
-                if (is_one_const_op(tArg) && !has_sideeffects(aArg)) { changed = true; return bArg }
-                if (describe(aArg) == describe(bArg) && !has_sideeffects(bArg) && !has_sideeffects(tArg)) {
-                    changed = true
-                    return aArg
+                // const-selector short-circuits — no expand/refuse round trip. They DROP an
+                // argument (`(b-a)*0` would still propagate b's inf/NaN) → fast-math only.
+                if (fastMath) {
+                    if (is_zero_const_op(tArg) && !has_sideeffects(bArg)) { changed = true; return aArg }
+                    if (is_one_const_op(tArg) && !has_sideeffects(aArg)) { changed = true; return bArg }
+                    if (describe(aArg) == describe(bArg) && !has_sideeffects(bArg) && !has_sideeffects(tArg)) {
+                        changed = true
+                        return aArg
+                    }
                 }
                 changed = true
                 var sub = new ExprOp2(at = that.at, op := "-", left = bArg, right = clone_expression(aArg))
@@ -838,6 +844,14 @@ def private vec_elem_bt(bt : Type) : Type {
 def private is_float_family(bt : Type) : bool {
     return bt == Type.tFloat || bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4
 }
+
+// Float-valued (float/double scalar or float vector) — the fast-math gates key on this:
+// integer/bool identities are exact, floating-point ones change inf/NaN/rounding behavior.
+def private is_float_valued(e : ExpressionPtr) : bool {
+    let bt = expr_bt(e)
+    return is_float_family(bt) || bt == Type.tDouble
+}
+
 
 // The (T,T,T) element family das `mad` covers: float/int/uint scalar+vector, double scalar.
 def private is_mad_elem(bt : Type) : bool {
@@ -1218,9 +1232,9 @@ def private count_terms(e : ExpressionPtr; addOp : string; var nv : int&; var nc
 
 // True if reassoc WOULD gather this chain: ≥1 var term, ≥2 scattered consts, not already grouped.
 // The fold-completeness oracle (flatten.das FoldResidualVisitor) mirrors the transform's exact gate
-// through this, so it flags only genuine misses.
-def public has_scattered_consts(that : ExprOp2?) : bool {
-    if (that == null) return false
+// through this — incl. `fast_math` (float chains stay scattered under `_flatten_no_fast_math`).
+def public has_scattered_consts(that : ExprOp2?; fast_math : bool = true) : bool {
+    if (that == null || (!fast_math && is_float_valued(that))) return false
     var nv = 0
     var nc = 0
     if (that.op == "+" || that.op == "-") {
@@ -1237,7 +1251,13 @@ def public has_scattered_consts(that : ExprOp2?) : bool {
 
 class private ReassocVisitor : AstVisitor {
     changed : bool
+    fastMath : bool = true
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
+        // Both the const-gather and the canonical re-sort rebuild the chain — a float
+        // sum/product picks up a different association order, so floats are fast-math only.
+        if (!fastMath && is_float_valued(that)) {
+            return that
+        }
         var res : ExpressionPtr = null
         if (that.op == "*") {
             var terms : array<ReTerm>
@@ -1256,16 +1276,18 @@ class private ReassocVisitor : AstVisitor {
     }
 }
 
-def public fold_body(var func : FunctionPtr) : bool {
+def public fold_body(var func : FunctionPtr; fast_math : bool = true) : bool {
     //! Post-infer fold over a flattened body: const-propagate single-def locals, reassociate
-    //! scattered consts, collapse `const ? a : b`, fold algebraic/boolean identities + const
-    //! constructors, drop pure self-assigns, strip zero inits. SINGLE pass (caller's re-infer loops it).
+    //! scattered consts, collapse `const ? a : b`, fold identities/const ctors, drop pure self-assigns.
+    //! SINGLE pass (caller re-infers and loops); `fast_math = false` skips the value-changing arms.
     if (!(func.body is ExprBlock)) return false
+    let fm = fast_math
     var changed = const_prop_locals(func.body as ExprBlock)
     // Reassociate BEFORE the fold — gather scattered consts into one adjacent group so the
     // FoldVisitor all-const arm (and the typer's re-infer) can collapse them. After const-prop,
     // which is what scatters consts (a substituted single-def local lands mid-chain).
     var rv = new ReassocVisitor()
+    rv.fastMath = fm
     make_visitor(*rv) $(adapter) {
         visit(func.body, adapter)
     }
@@ -1276,6 +1298,7 @@ def public fold_body(var func : FunctionPtr) : bool {
         delete rv
     }
     var v = new FoldVisitor()
+    v.fastMath = fm
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)
     }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -550,6 +550,29 @@ class private FoldVisitor : AstVisitor {
                 var z = zero_const_of(that._type, that.at)
                 if (z != null) { changed = true; return z }
             }
+            // ctor-lane kill: a zero lane of a const vector factor zeroes the matching lane of a
+            // full-arity ctor factor IN PLACE — the lane compute dies (DSE) without distributing
+            // the multiply. Same inf/NaN class as scalar `*0` → float forms are fast-math only.
+            if (!noFastMath || !is_float_valued(that)) {
+                if (ctor_lane_kill(that.left, that.right) || ctor_lane_kill(that.right, that.left)) {
+                    changed = true
+                    return that
+                }
+            }
+            // splat collapse: `v * floatN(s) → v * s` (either side) — das vec×scalar is native, the
+            // splat ctor node disappears. Bit-exact (same per-lane product), so never gated.
+            var spm = splat_scalar_arg(that.right)
+            if (spm != null && is_float_vec(expr_bt(that.left))) {
+                changed = true
+                that.right = spm
+                return that
+            }
+            spm = splat_scalar_arg(that.left)
+            if (spm != null && is_float_vec(expr_bt(that.right))) {
+                changed = true
+                that.left = spm
+                return that
+            }
         } elif (that.op == "+") {
             if (is_zero_const_op(that.right)) { changed = true; return that.left }
             if (is_zero_const_op(that.left)) { changed = true; return that.right }
@@ -572,6 +595,20 @@ class private FoldVisitor : AstVisitor {
                     changed = true
                     return new ExprOp2(at = that.at, op := "*", left = that.left, right = rec)
                 }
+            }
+            // splat collapse for division: `v / floatN(s) → v / s`, `floatN(s) / v → s / v` —
+            // both vec÷scalar forms are native das. Bit-exact, never gated.
+            var spd = splat_scalar_arg(that.right)
+            if (spd != null && is_float_vec(expr_bt(that.left))) {
+                changed = true
+                that.right = spd
+                return that
+            }
+            spd = splat_scalar_arg(that.left)
+            if (spd != null && is_float_vec(expr_bt(that.right))) {
+                changed = true
+                that.left = spd
+                return that
             }
         } elif (that.op == "&&") {
             // Short-circuit `&&`: `false && x` never evaluates x, so dropping x is
@@ -860,6 +897,112 @@ def private is_float_family(bt : Type) : bool {
 def private is_float_valued(e : ExpressionPtr) : bool {
     let bt = expr_bt(e)
     return is_float_family(bt) || bt == Type.tDouble
+}
+
+// Full-arity float/int/uint vector ctor call (`float3(a,b,c)` — one scalar arg per lane):
+// returns the lane count; 0 for splats, mixed-arity ctors (`float3(v2,z)`) and non-ctor calls.
+def private ctor_dim_by_name(c : ExprCall?) : int {
+    if (c == null) return 0
+    let nm = psh_simple_name("{c.name}")
+    var d = 0
+    if (nm == "float2" || nm == "int2" || nm == "uint2") {
+        d = 2
+    } elif (nm == "float3" || nm == "int3" || nm == "uint3") {
+        d = 3
+    } elif (nm == "float4" || nm == "int4" || nm == "uint4") {
+        d = 4
+    }
+    return length(c.arguments) == d ? d : 0
+}
+
+def private is_float_vec(bt : Type) : bool {
+    return bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4
+}
+
+// The scalar argument of a float splat ctor (`floatN(s)`); null otherwise.
+def private splat_scalar_arg(e : ExpressionPtr) : ExpressionPtr {
+    if (e == null || !(e is ExprCall)) return null
+    var c = e as ExprCall
+    let nm = psh_simple_name("{c.name}")
+    if ((nm != "float2" && nm != "float3" && nm != "float4") || length(c.arguments) != 1) return null
+    return expr_bt(c.arguments[0]) == Type.tFloat ? c.arguments[0] : null
+}
+
+// Bitmask of zero lanes of a const float/int/uint vector literal; 0 when none (or not one).
+def private const_vec_zero_mask(e : ExpressionPtr) : int {
+    if (e == null) return 0
+    var m = 0
+    if (e is ExprConstFloat2) {
+        let v = (e as ExprConstFloat2).value
+        if (v.x == 0.0) { m |= 1; }; if (v.y == 0.0) { m |= 2; }
+    } elif (e is ExprConstFloat3) {
+        let v = (e as ExprConstFloat3).value
+        if (v.x == 0.0) { m |= 1; }; if (v.y == 0.0) { m |= 2; }; if (v.z == 0.0) { m |= 4; }
+    } elif (e is ExprConstFloat4) {
+        let v = (e as ExprConstFloat4).value
+        if (v.x == 0.0) { m |= 1; }; if (v.y == 0.0) { m |= 2; }; if (v.z == 0.0) { m |= 4; }; if (v.w == 0.0) { m |= 8; }
+    } elif (e is ExprConstInt2) {
+        let v = (e as ExprConstInt2).value
+        if (v.x == 0) { m |= 1; }; if (v.y == 0) { m |= 2; }
+    } elif (e is ExprConstInt3) {
+        let v = (e as ExprConstInt3).value
+        if (v.x == 0) { m |= 1; }; if (v.y == 0) { m |= 2; }; if (v.z == 0) { m |= 4; }
+    } elif (e is ExprConstInt4) {
+        let v = (e as ExprConstInt4).value
+        if (v.x == 0) { m |= 1; }; if (v.y == 0) { m |= 2; }; if (v.z == 0) { m |= 4; }; if (v.w == 0) { m |= 8; }
+    }
+    return m
+}
+
+// Zero the full-arity ctor lanes under a zero lane of the const multiplier — the lane compute
+// dies (DSE) without distributing the multiply. Skips already-zero lanes (fixpoint). NO purity
+// gate: flat lanes are pure by contract, and macro-time has_sideeffects calls DSL stubs impure.
+def private ctor_lane_kill(var ctorE : ExpressionPtr; constE : ExpressionPtr) : bool {
+    if (ctorE == null || !(ctorE is ExprCall)) return false
+    var c = ctorE as ExprCall
+    let d = ctor_dim_by_name(c)
+    if (d == 0) return false
+    let m = const_vec_zero_mask(constE)
+    if (m == 0) return false
+    var any = false
+    for (i in range(d)) {
+        if ((m & (1 << i)) != 0 && !is_zero_const(c.arguments[i])) {
+            var z = zero_const_of(c.arguments[i]._type, c.arguments[i].at)
+            if (z != null) {
+                c.arguments[i] = z
+                any = true
+            }
+        }
+    }
+    return any
+}
+
+// Oracle mirrors for the ctor fold arms (FoldResidualVisitor in flatten.das).
+def public is_uncollapsed_splat_op2(var e : ExprOp2?) : bool {
+    if (e == null || (e.op != "*" && e.op != "/")) return false
+    return ((splat_scalar_arg(e.left) != null && is_float_vec(expr_bt(e.right))) ||
+        (splat_scalar_arg(e.right) != null && is_float_vec(expr_bt(e.left))))
+}
+
+def public is_unkilled_ctor_zero_lane(var e : ExprOp2?; no_fast_math : bool = false) : bool {
+    // the float gate mirrors the kill arm's
+    if (e == null || e.op != "*" || (no_fast_math && is_float_valued(e))) return false
+    var ctorE = e.left
+    var constE = e.right
+    if (const_vec_zero_mask(constE) == 0) {
+        ctorE = e.right
+        constE = e.left
+    }
+    if (!(ctorE is ExprCall)) return false
+    var c = ctorE as ExprCall
+    let d = ctor_dim_by_name(c)
+    if (d == 0) return false
+    let m = const_vec_zero_mask(constE)
+    if (m == 0) return false
+    for (i in range(d)) {
+        if ((m & (1 << i)) != 0 && !is_zero_const(c.arguments[i])) return true
+    }
+    return false
 }
 
 
@@ -2223,25 +2366,27 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
         }
     }
     // Fusion residual: a fusable mul-add (`a*b ± c`) PHASE_FUSED should have re-packed into
-    // `mad`, or a mad still carrying the lerp shape — gated on the same module visibility.
-    if (fuse_callable(func._module, "mad")) {
-        var fr = new FuseResidualVisitor()
-        fr.checkLerp = fuse_callable(func._module, "lerp")
-        make_visitor(*fr) $(a) {
-            visit(func.body, a)
-        }
-        if (fr.foundMad) {
-            res |> push("an un-fused mul-add ('a*b ± c' should be mad)")
-        }
-        if (fr.foundLerp) {
-            res |> push("an un-refused lerp shape (mad(b-a,t,a))")
-        }
-        if (fr.foundNegAdd) {
-            res |> push("an un-packed neg-add ('-a + b' should be 'b - a')")
-        }
-        unsafe {
-            delete fr
-        }
+    // `mad` (or a mad still carrying the lerp shape) — gated on the same module visibility —
+    // plus an un-packed ctor lane pattern (re-vectorize / shared factor), which needs no callable.
+    let cm = fuse_callable(func._module, "mad")
+    var fr = new FuseResidualVisitor(checkMad = cm, checkLerp = cm && fuse_callable(func._module, "lerp"), noFastMath = no_fast_math)
+    make_visitor(*fr) $(a) {
+        visit(func.body, a)
+    }
+    if (fr.foundMad) {
+        res |> push("an un-fused mul-add ('a*b ± c' should be mad)")
+    }
+    if (fr.foundLerp) {
+        res |> push("an un-refused lerp shape (mad(b-a,t,a))")
+    }
+    if (fr.foundNegAdd) {
+        res |> push("an un-packed neg-add ('-a + b' should be 'b - a')")
+    }
+    if (fr.foundCtor) {
+        res |> push("an un-packed ctor lane pattern (should re-vectorize / extract the shared factor)")
+    }
+    unsafe {
+        delete fr
     }
     delete pe.paramNames
     delete pe.localColor
@@ -2475,6 +2620,328 @@ def private match_lerp(var cll : ExprCall?; var la, lb, lt : ExpressionPtr&) : b
     return true
 }
 
+// All-const lanes become a const VECTOR LITERAL (the fold phase is over by fuse time, so an
+// all-const ctor CALL would survive un-folded and trip the fold-residual oracle).
+def private make_float_ctor(d : int; at : LineInfo; var lanes : array<ExpressionPtr>) : ExpressionPtr {
+    var c0 = 0.0
+    var c1 = 0.0
+    var c2 = 0.0
+    var c3 = 0.0
+    if (scalar_float_const(lanes[0], c0) && scalar_float_const(lanes[1], c1) &&
+            (d < 3 || scalar_float_const(lanes[2], c2)) && (d < 4 || scalar_float_const(lanes[3], c3))) {
+        if (d == 2) return new ExprConstFloat2(at = at, value = float2(c0, c1))
+        if (d == 3) return new ExprConstFloat3(at = at, value = float3(c0, c1, c2))
+        return new ExprConstFloat4(at = at, value = float4(c0, c1, c2, c3))
+    }
+    let nm = d == 2 ? "float2" : (d == 3 ? "float3" : "float4")
+    var c = new ExprCall(at = at, name := nm)
+    for (l in lanes) {
+        emplace(c.arguments, l)
+    }
+    return c
+}
+
+// Single-component read (`b.x` … `b.w`) of a float vector — ExprSwizzle post-infer, ExprField
+// when freshly built. Yields the base, its describe key, and the component letter.
+def private component_read_of(var e : ExpressionPtr; var baseKey : string&; var base : ExpressionPtr&; var comp : string&) : bool {
+    if (e == null) return false
+    if (e is ExprRef2Value) return component_read_of((e as ExprRef2Value).subexpr, baseKey, base, comp)
+    var v : ExpressionPtr
+    var nm = ""
+    if (e is ExprSwizzle) {
+        var sw = e as ExprSwizzle
+        nm = "{sw.mask}"
+        v = sw.value
+    } elif (e is ExprField) {
+        var fl = e as ExprField
+        nm = "{fl.name}"
+        v = fl.value
+    } else {
+        return false
+    }
+    if ((nm != "x" && nm != "y" && nm != "z" && nm != "w") ||
+        !is_float_vec(expr_bt(v)) || expr_bt(e) != Type.tFloat) return false
+    base = v
+    baseKey = describe(v)
+    comp = nm
+    return true
+}
+
+let private SIDE_NONE = 0
+let private SIDE_EQUAL = 1       // every lane carries the SAME scalar (describe-equal)
+let private SIDE_COMPONENT = 2   // lane i reads component_i of one shared vector base
+let private SIDE_GATHER = 3      // arbitrary scalars — packed into a fresh ctor (or const literal)
+
+// Vectorize one side (lefts or rights) of a ctor whose lanes are same-op ExprOp2: classify the
+// d side-exprs and build the vector replacement from CLONES. SIDE_COMPONENT with the natural
+// full mask collapses to the base itself (no swizzle node).
+def private vectorize_side(var that : ExprCall?; d : int; takeLeft : bool; var node : ExpressionPtr&) : int {
+    var sides : array<ExpressionPtr>
+    sides |> reserve(d)
+    for (i in range(d)) {
+        var li = that.arguments[i] as ExprOp2
+        sides |> push(takeLeft ? li.left : li.right)
+    }
+    // EQUAL — all lanes the same pure scalar
+    if (expr_bt(sides[0]) == Type.tFloat) {
+        let key0 = describe(sides[0])
+        var eq = true
+        for (i in range(1, d)) {
+            if (describe(sides[i]) != key0) {
+                eq = false
+                break
+            }
+        }
+        if (eq) {
+            node = clone_expression(sides[0])
+            unsafe {
+                delete sides
+            }
+            return SIDE_EQUAL
+        }
+    }
+    // COMPONENT — lane i reads a component of one shared base; the masks concatenate to a swizzle
+    var baseKey = ""
+    var base : ExpressionPtr
+    var mask = ""
+    var isComp = true
+    for (i in range(d)) {
+        var bk = ""
+        var b : ExpressionPtr
+        var c = ""
+        if (!component_read_of(sides[i], bk, b, c) || (i > 0 && bk != baseKey)) {
+            isComp = false
+            break
+        }
+        baseKey = bk
+        base = b
+        mask += c // nolint:PERF001 — at most 4 single-char appends
+    }
+    if (isComp) {
+        let dim = expr_bt(base) == Type.tFloat2 ? 2 : (expr_bt(base) == Type.tFloat3 ? 3 : 4)
+        if (dim == d && mask == slice("xyzw", 0, d)) {
+            node = clone_expression(base)
+        } else {
+            node = new ExprField(at = that.at, value = clone_expression(base), name := mask)
+        }
+        unsafe {
+            delete sides
+        }
+        return SIDE_COMPONENT
+    }
+    // GATHER — pack the scalars into a fresh ctor (a const literal when every lane is const)
+    var lanes <- [for (sd in sides); clone_expression(sd)]
+    node = make_float_ctor(d, that.at, lanes)
+    unsafe {
+        delete lanes
+        delete sides
+    }
+    return SIDE_GATHER
+}
+
+def private scalar_float_const(e : ExpressionPtr; var v : float&) : bool {
+    if (e == null || !(e is ExprConstFloat)) return false
+    v = (e as ExprConstFloat).value
+    return true
+}
+
+// The ctor re-pack PHASE_FUSED applies (CLONE-built so the residual oracle probes with it
+// non-destructively): re-vectorize lanes / extract a shared factor or divisor (exact), or
+// compensate a majority const factor (fast-math, only when the multiply count strictly drops).
+def private make_float_splat(d : int; at : LineInfo; var sc : ExpressionPtr) : ExpressionPtr {
+    let nm = d == 2 ? "float2" : (d == 3 ? "float3" : "float4")
+    var c = new ExprCall(at = at, name := nm)
+    emplace(c.arguments, sc)
+    return c
+}
+
+def private ctor_fuse_rewrite(var that : ExprCall?; no_fast_math : bool) : ExpressionPtr {
+    let d = ctor_dim_by_name(that)
+    if (d < 2 || !is_float_vec(expr_bt(that))) return null
+    // re-vectorize same-op lanes: `floatN(v.x + c1, v.y + c2, …) → v + floatN(c1,c2,…)` (exact)
+    var sameOp = ""
+    if (that.arguments[0] is ExprOp2) {
+        let op0 = "{(that.arguments[0] as ExprOp2).op}"
+        if (op0 == "+" || op0 == "-" || op0 == "*" || op0 == "/") {
+            sameOp = op0
+            for (i in range(1, d)) {
+                if (!(that.arguments[i] is ExprOp2) || "{(that.arguments[i] as ExprOp2).op}" != op0) {
+                    sameOp = ""
+                    break
+                }
+            }
+        }
+    }
+    if (sameOp != "") {
+        var aN : ExpressionPtr
+        var bN : ExpressionPtr
+        let ka = vectorize_side(that, d, true, aN)
+        let kb = vectorize_side(that, d, false, bN)
+        // profitability bar: a component pattern on a side (EQUAL/GATHER pairs are node-neutral)
+        if (ka == SIDE_COMPONENT || kb == SIDE_COMPONENT) {
+            // a lone EQUAL scalar broadcasts natively under * and /; + and - need a splat ctor
+            if (ka == SIDE_EQUAL && (sameOp == "+" || sameOp == "-")) {
+                aN = make_float_splat(d, that.at, aN)
+            }
+            if (kb == SIDE_EQUAL && (sameOp == "+" || sameOp == "-")) {
+                bN = make_float_splat(d, that.at, bN)
+            }
+            return new ExprOp2(at = that.at, op := sameOp, left = aN, right = bN)
+        }
+    }
+    // shared factor / divisor, keyed on lane 0's candidates (describe equality across lanes)
+    if (that.arguments[0] is ExprOp2) {
+        var l0 = that.arguments[0] as ExprOp2
+        if (l0.op == "*" || l0.op == "/") {
+            for (ci in range(l0.op == "*" ? 2 : 1)) {
+                var cand = (l0.op == "/" || ci == 1) ? l0.right : l0.left
+                if (expr_bt(cand) != Type.tFloat) {
+                    continue
+                }
+                let key = describe(cand)
+                var rests : array<ExpressionPtr>
+                var allMatch = true
+                for (i in range(d)) {
+                    var ok = false
+                    if (that.arguments[i] is ExprOp2) {
+                        var li = that.arguments[i] as ExprOp2
+                        if (li.op == l0.op) {
+                            if (li.op == "*" && describe(li.left) == key && expr_bt(li.left) == Type.tFloat) {
+                                rests |> push(clone_expression(li.right))
+                                ok = true
+                            } elif (describe(li.right) == key && expr_bt(li.right) == Type.tFloat) {
+                                rests |> push(clone_expression(li.left))
+                                ok = true
+                            }
+                        }
+                    }
+                    if (!ok) {
+                        allMatch = false
+                        break
+                    }
+                }
+                if (allMatch) {
+                    var nc = make_float_ctor(d, that.at, rests)
+                    var sc = clone_expression(cand)
+                    unsafe {
+                        delete rests
+                    }
+                    return new ExprOp2(at = that.at, op := l0.op, left = nc, right = sc)
+                }
+                unsafe {
+                    delete rests
+                }
+            }
+        }
+    }
+    // majority const factor with compensation (fast-math): most frequent lane factor C ≠ 0,1 wins
+    if (no_fast_math) return null
+    var laneC : array<float>
+    var laneV : array<float>
+    var laneE : array<ExpressionPtr>
+    for (i in range(d)) {
+        var cv = 0.0
+        if (scalar_float_const(that.arguments[i], cv)) {
+            laneC |> push(0.0)
+            laneV |> push(cv)
+            laneE |> push(null)
+            continue
+        }
+        var ci = 1.0
+        var ei = that.arguments[i]
+        if (that.arguments[i] is ExprOp2) {
+            var li = that.arguments[i] as ExprOp2
+            if (li.op == "*") {
+                if (scalar_float_const(li.right, cv) && !(li.left |> is_expr_const())) {
+                    ci = cv
+                    ei = li.left
+                } elif (scalar_float_const(li.left, cv) && !(li.right |> is_expr_const())) {
+                    ci = cv
+                    ei = li.right
+                }
+            }
+        }
+        laneC |> push(ci)
+        laneV |> push(0.0)
+        laneE |> push(ei)
+    }
+    var bestC = 0.0
+    var bestN = 0
+    for (i in range(d)) {
+        if (laneE[i] == null || laneC[i] == 1.0 || laneC[i] == 0.0) {
+            continue
+        }
+        var n = 0
+        for (j in range(d)) {
+            if (laneE[j] != null && laneC[j] == laneC[i]) {
+                n ++
+            }
+        }
+        if (n > bestN) {
+            bestN = n
+            bestC = laneC[i]
+        }
+    }
+    if (bestN < 2) {
+        delete laneC
+        delete laneV
+        unsafe {
+            delete laneE
+        }
+        return null
+    }
+    var before = 0
+    var after = 1
+    for (i in range(d)) {
+        if (laneE[i] != null && laneC[i] != 1.0) {
+            before ++
+        }
+        if (laneE[i] != null && laneC[i] != bestC) {
+            after ++
+        }
+    }
+    if (after >= before) {
+        delete laneC
+        delete laneV
+        unsafe {
+            delete laneE
+        }
+        return null
+    }
+    var lanes : array<ExpressionPtr>
+    for (i in range(d)) {
+        if (laneE[i] == null) {
+            lanes |> push(new ExprConstFloat(at = that.at, value = laneV[i] / bestC))
+        } elif (laneC[i] == bestC) {
+            lanes |> push(clone_expression(laneE[i]))
+        } else {
+            var comp : ExpressionPtr = new ExprConstFloat(at = that.at, value = laneC[i] / bestC)
+            lanes |> push(new ExprOp2(at = that.at, op := "*", left = clone_expression(laneE[i]), right = comp))
+        }
+    }
+    var nc = make_float_ctor(d, that.at, lanes)
+    delete laneC
+    delete laneV
+    unsafe {
+        delete lanes
+        delete laneE
+    }
+    return new ExprOp2(at = that.at, op := "*", left = nc, right = new ExprConstFloat(at = that.at, value = bestC))
+}
+
+class private CtorFuseVisitor : AstVisitor {
+    changed : bool
+    noFastMath : bool
+    def override visitExprCall(var that : ExprCall?) : ExpressionPtr {
+        var r = ctor_fuse_rewrite(that, noFastMath)
+        if (r != null) {
+            changed = true
+            return r
+        }
+        return that
+    }
+}
+
 class private MadFuseVisitor : AstVisitor {
     changed : bool
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
@@ -2520,11 +2987,17 @@ class private LerpFuseVisitor : AstVisitor {
 // Fusion residuals — mirrors the fuser's matchers EXACTLY (same gates, same shapes), so a
 // survivor means the PHASE_FUSED pass missed, never that the gate was narrower here.
 class private FuseResidualVisitor : AstVisitor {
+    checkMad : bool
     checkLerp : bool
+    noFastMath : bool
     foundMad : bool
     foundLerp : bool
     foundNegAdd : bool
+    foundCtor : bool
     def override preVisitExprOp2(var expr : ExprOp2?) : void {
+        if (!checkMad) {
+            return
+        }
         var ma : ExpressionPtr
         var mb : ExpressionPtr
         var mc : ExpressionPtr
@@ -2546,15 +3019,31 @@ class private FuseResidualVisitor : AstVisitor {
                 foundLerp = true
             }
         }
+        if (ctor_fuse_rewrite(expr, noFastMath) != null) {
+            foundCtor = true
+        }
     }
 }
 
-def public fuse_body(var func : FunctionPtr) : bool {
-    //! PHASE_FUSED finishing pass: re-pack `a*b ± c` into `mad(a,b,c)` and the expanded lerp
-    //! shape `mad(b - a, t, a)` back into `lerp(a, b, t)` over the optimized, re-inferred body
-    //! (the type gates need settled types). Caller re-infers after to type the new calls.
-    if (!(func.body is ExprBlock) || !fuse_callable(func._module, "mad")) return false
+def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool {
+    //! PHASE_FUSED finishing pass: re-pack ctor lane patterns (re-vectorize / shared factor),
+    //! `a*b ± c` into `mad(a,b,c)`, and the expanded lerp shape `mad(b - a, t, a)` back into
+    //! `lerp(a, b, t)` over the optimized, re-inferred body. Caller re-infers after each round.
+    if (!(func.body is ExprBlock)) return false
     var changed = false
+    // ctor re-pack first — its `ctor * s` / vector-op output feeds the mad walk this same round
+    var cv = new CtorFuseVisitor()
+    cv.noFastMath = no_fast_math
+    make_visitor(*cv) $(adapter) {
+        visit(func.body, adapter)
+    }
+    if (cv.changed) {
+        changed = true
+    }
+    unsafe {
+        delete cv
+    }
+    if (!fuse_callable(func._module, "mad")) return changed
     var v = new MadFuseVisitor()
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -218,13 +218,13 @@ literal is minted), and the optimize pass rewrites a *varying* division by a
 ``let _preshader_N = 1f / U`` hoisted per draw — deduplicated by structural key,
 so N divisions by the same uniform share ONE reciprocal (raymarch's six
 smooth-min ``/ smoothK`` divides become six muls against one per-draw rcp, and
-the muls then mad-fuse). Both rewrites round (≈1 ulp) and are **fast-math gated**.
+the muls then mad-fuse). Both rewrites round (~1 ulp) and are **fast-math gated**.
 
 **Ctor lane algebra.** Per-lane scalar arithmetic wrapped in a vector
 constructor is the manual-vectorization tax shaders pay everywhere; flatten
 re-packs it from both ends:
 
-* **Zero-lane kill** (fold): ``floatN(e₀, e₁, …) * constVec`` with a zero const
+* **Zero-lane kill** (fold): ``floatN(e0, e1, …) * constVec`` with a zero const
   lane zeroes the matching ctor lanes *in place* — no distribution — so the
   dead lane's compute (a ``sin``, a texture-free chain) is eliminated by DSE,
   and a fully-const product collapses to an embedded constant:
@@ -258,7 +258,7 @@ value-changing rewrite — the float ``x*0 → 0`` / ``x - x → 0`` folds (inf/
 propagation), float reassociation (association order), the ``lerp``
 const-selector short-circuits (they drop an argument), division→reciprocal,
 the float zero-lane kill, and majority-factor compensation — assumes finite
-inputs and tolerates ≈1-ulp drift. A module that cannot accept that opts out
+inputs and tolerates ~1-ulp drift. A module that cannot accept that opts out
 with a user option:
 
 .. code-block:: das

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -141,7 +141,8 @@ pass. Positive terms sort before subtracted ones, so the rebuilt chain spells ``
 preshader pass would hoist into a pass-through ``_preshader_ = -_preshader_`` alias). Integer ``+``/``*`` reassociate exactly; integer ``/`` is non-associative and excluded.
 These are exactly the folds the general compiler leaves for the downstream tiers (it folds
 constant *arithmetic* but not constant *constructors*, and never a runtime-operand identity
-or reassociation), done here under a shader's fast-math assumption (``x*0 → 0`` always fires).
+or reassociation), done here under a shader's fast-math assumption (``x*0 → 0`` fires by
+default; ``options _flatten_no_fast_math`` turns the float forms off — see below).
 
 The fold and the typer's const-fold are *mutually-enabling*, so the fold phase
 **iterates to a fixpoint**. Flattening folds the runtime-operand identities the
@@ -179,8 +180,9 @@ common-subexpression elimination (``flatten_optimize``):
   a ``_cse_`` let whose operands converge to all-preshader references) that only
   re-extraction hoists to the per-draw group.
 
-Both passes are **value-exact** — they only hoist and share existing subtrees, never
-regroup or round — and both exclude any subtree that reads a **reassigned** variable
+Hoisting and sharing are **value-exact** — existing subtrees move, nothing regroups or
+rounds (the one exception is the fast-math division→reciprocal rewrite below) — and both
+passes exclude any subtree that reads a **reassigned** variable
 (a live/loop mask, a written global, or the base of an indexed store — ``G[i] = v``
 makes every ``G[...]`` read unstable), whose value is not stable across the body.
 
@@ -204,8 +206,73 @@ spelled ``lerp`` canonicalises into the lerp node the same way. A leftover
 the rewrites inside the das ``math`` overload set (float / int / uint, scalar +
 vector; lerp with scalar ``t``), and fusion only runs when a 3-argument
 ``mad`` / ``lerp`` is visible from the twin's module (``math`` or a backend DSL).
-Fusion is the one pass that is **not value-exact on floats**: a fused ``mad``
-single-rounds where ``a*b + c`` rounds twice (integer fusion is exact).
+Fusion is value-exact at the das level (das ``mad`` computes ``a*b + c``); the
+*backend* may contract it to a single-rounding FMA — that is its call.
+
+**Division becomes a reciprocal multiply.** A divide is the most expensive
+arithmetic node a shader carries, and most divisors never change per pixel. The
+fold rewrites ``x / C`` (const ``C``, float family) into ``x * (1/C)`` with the
+reciprocal computed at compile time (a zero lane keeps the division — no ``inf``
+literal is minted), and the optimize pass rewrites a *varying* division by a
+**uniform** scalar, ``x / U``, into ``x * _preshader_N`` with
+``let _preshader_N = 1f / U`` hoisted per draw — deduplicated by structural key,
+so N divisions by the same uniform share ONE reciprocal (raymarch's six
+smooth-min ``/ smoothK`` divides become six muls against one per-draw rcp, and
+the muls then mad-fuse). Both rewrites round (≈1 ulp) and are **fast-math gated**.
+
+**Ctor lane algebra.** Per-lane scalar arithmetic wrapped in a vector
+constructor is the manual-vectorization tax shaders pay everywhere; flatten
+re-packs it from both ends:
+
+* **Zero-lane kill** (fold): ``floatN(e₀, e₁, …) * constVec`` with a zero const
+  lane zeroes the matching ctor lanes *in place* — no distribution — so the
+  dead lane's compute (a ``sin``, a texture-free chain) is eliminated by DSE,
+  and a fully-const product collapses to an embedded constant:
+  ``float2(sin(x)*12.0, 13.0) * float2(0.0, 123.0) → float2(0f, 1599f)``.
+  Float forms are fast-math (inf/NaN class); integer forms are exact.
+* **Splat collapse** (fold): ``v * floatN(s)`` / ``v / floatN(s)`` /
+  ``floatN(s) / v`` use das's native vector·scalar forms — the splat ctor node
+  disappears (``an / float3(sumW) → an / sumW``). Bit-exact, never gated.
+* **Lane re-vectorization** (fuse): same-op lanes whose sides vectorize re-pack
+  into one vector op — ``sin(float3(c.x + 0.1, c.y + 0.2, c.z + 0.3)) →
+  sin(c + float3(0.1, 0.2, 0.3))``: d scalar ops + d component reads collapse
+  to one add, the const gather embeds as a literal. Any component permutation
+  of one base becomes a swizzle (the natural full mask becomes the base
+  itself); an equal-scalar side broadcasts (``*``/``/``) or splats (``+``/``-``).
+  Bit-exact (the same per-lane IEEE ops), never gated.
+* **Shared-factor extraction** (fuse): every lane carrying the same scalar
+  factor or divisor re-packs to a broadcast —
+  ``float3(g*1.08, g*0.86, g*0.66) → float3(1.08, 0.86, 0.66) * g`` (3 muls +
+  ctor → 1 mul against an embedded const). Bit-exact, never gated.
+* **Majority-factor compensation** (fuse): when most lanes share a const factor
+  and the odd lane does not, the odd lane is compensated by the const ratio —
+  ``float3(x*13.0, y*13.0, z*12.0) → float3(x, y, z*(12.0/13.0)) * 13.0`` —
+  fired only when the per-pixel multiply count strictly drops. The ratio
+  rounds → **fast-math gated**.
+
+The fast-math opt-out
+=====================
+
+flatten's default contract is a shader compiler's: fast math. Every
+value-changing rewrite — the float ``x*0 → 0`` / ``x - x → 0`` folds (inf/NaN
+propagation), float reassociation (association order), the ``lerp``
+const-selector short-circuits (they drop an argument), division→reciprocal,
+the float zero-lane kill, and majority-factor compensation — assumes finite
+inputs and tolerates ≈1-ulp drift. A module that cannot accept that opts out
+with a user option:
+
+.. code-block:: das
+
+    options _flatten_no_fast_math = true
+
+The option is module-local (it applies to the shaders/twins *written in* that
+module) and turns off exactly the value-changing set; everything bit-exact —
+flattening, predication, unrolling, preshader extraction, CSE, alias
+elimination, the mad/lerp expand/re-fuse round trip, splat collapse, lane
+re-vectorization, shared-factor extraction, and every *integer* fold — stays
+on. Under the option a twin computes bit-identical results to its original.
+The residual oracles take the same flag, so a unit compiled under the option
+validates clean without flagging the deliberately-skipped rewrites.
 
 Supported subset
 ================
@@ -293,7 +360,13 @@ Public API
     their own macro walks the result. Inspect ``.ok`` / ``.err``. The body is
     uninferred afterward — re-infer before reading types.
 
-``flatten_fold(var func) : bool``
+``flatten_no_fast_math : bool``
+    True when the *compiling* module sets ``options _flatten_no_fast_math = true``.
+    Compile-time only (annotation/backend patch code reads it once per cycle and
+    threads the bool into the passes below); a runtime tool driving the passes
+    directly passes its own flag instead.
+
+``flatten_fold(var func, no_fast_math = false) : bool``
     The post-inference fold pass: collapse ``const ? a : b`` selects, drop the
     pure ``lhs = lhs`` self-assigns, strip redundant zero initializers. Run it
     *after* re-inference (the constant conditions must already be folded to
@@ -306,7 +379,7 @@ Public API
     re-inference until it reports no change** — exactly as ``[flatten]``'s own
     patch does (and as the ``[pixel_shader]`` backend now does).
 
-``flatten_fold_residuals(var func) : array<string>``
+``flatten_fold_residuals(var func, no_fast_math = false) : array<string>``
     Test-framework / fuzzer introspection: walks a compiled twin's final body
     and returns a description for each const-foldable residual a complete fold
     should have collapsed — an unconditional algebraic identity (``x*1``,
@@ -319,31 +392,35 @@ Public API
     check — there is no compile-time flag; a missed fold is suboptimal, not an
     error, so it is validated by tests rather than gated in the macro.
 
-``flatten_optimize(var func, barriers : table<string>) : bool``
+``flatten_optimize(var func, barriers : table<string>, no_fast_math = false) : bool``
     The post-fold optimize pass: hoist maximal uniform subtrees to per-draw
-    ``_preshader_`` lets, CSE-dedup repeated subtrees, then collapse pure-alias
-    ``let`` copies — CSE and alias elimination iterating to a fixpoint. Run it **once** after
+    ``_preshader_`` lets, rewrite divisions by a uniform into per-draw
+    reciprocal multiplies (fast-math), CSE-dedup repeated subtrees, then
+    collapse pure-alias ``let`` copies — iterating to a joint fixpoint. Run it **once** after
     the ``flatten_fold`` fixpoint converges (and *not* before — reassociation runs
     in the fold and would reorder a hoisted reference back into a fresh uniform
     subtree). ``barriers`` is the backend's sampler / intrinsic call-name set
     (``{ "tex2d", "noise" }``) — those stay per-pixel. ``[flatten]`` runs it
     automatically; the ``[pixel_shader]`` backend runs it after its fold fixpoint.
 
-``flatten_fuse(var func) : bool``
-    The finishing fuse pass: re-pack ``a*b ± c`` into ``mad(a, b, c)`` and the
-    expanded lerp shape ``mad(b - a, t, a)`` back into ``lerp(a, b, t)``. Run it
+``flatten_fuse(var func, no_fast_math = false) : bool``
+    The finishing fuse pass: re-pack ctor lane patterns (re-vectorization,
+    shared-factor extraction, majority compensation), ``a*b ± c`` into
+    ``mad(a, b, c)``, and the expanded lerp shape ``mad(b - a, t, a)`` back
+    into ``lerp(a, b, t)``. Run it
     after ``flatten_optimize``'s re-infer (the type gates need settled types) and
     **iterate across re-inference while it reports change**, exactly like the
     fold — each round strictly drops a ``+``/``-`` node, so it converges.
     ``[flatten]`` runs it automatically; the ``[pixel_shader]`` backend mirrors it.
 
-``flatten_opt_residuals(var func) : array<string>``
+``flatten_opt_residuals(var func, no_fast_math = false) : array<string>``
     The optimize-completeness oracle (sibling of ``flatten_fold_residuals``):
     walks a compiled twin and returns a description for each missed optimization —
-    a maximal uniform subtree still inline in the varying body, a pure subtree
-    computed twice or more left un-shared, a pure-alias ``let`` copy left
-    uncollapsed, a fusable mul-add left un-packed, or a mad still carrying the
-    lerp shape. Empty means complete. Drives the same
+    a maximal uniform subtree still inline in the varying body, an un-rewritten
+    division by a uniform, a pure subtree computed twice or more left un-shared,
+    a pure-alias ``let`` copy left uncollapsed, a fusable mul-add left un-packed,
+    a mad still carrying the lerp shape, or an un-packed ctor lane pattern.
+    Empty means complete. Drives the same
     ``tests/flatten/test_flatten_fold.das`` corpus and the ``flatten-fuzz``
     strict mode.
 

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1615,7 +1615,7 @@ class PixelShaderMacro : AstFunctionAnnotation {
             // back into `lerp` (one [hint] node each), re-inferring to resolve the new calls.
             // Mirrors daslib/flatten's PHASE_FUSED loop (converges — each round drops a `+`/`-`).
             if (!shader_annotation_arg(func, "fused")) {
-                if (flatten_fuse(func)) {
+                if (flatten_fuse(func, flatten_no_fast_math())) {
                     astChanged = true
                     return true
                 }

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1601,7 +1601,7 @@ class PixelShaderMacro : AstFunctionAnnotation {
             // after optimize (else reassoc reorders a hoisted ref into a fresh un-extracted uniform
             // subtree, e.g. `uv - _preshader` → `-_preshader + uv`). tex2d/noise stay per-pixel.
             if (!shader_annotation_arg(func, "optimized")) {
-                if (flatten_fold(func)) {
+                if (flatten_fold(func, flatten_fast_math())) {
                     astChanged = true
                     return true
                 }

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1601,12 +1601,12 @@ class PixelShaderMacro : AstFunctionAnnotation {
             // after optimize (else reassoc reorders a hoisted ref into a fresh un-extracted uniform
             // subtree, e.g. `uv - _preshader` → `-_preshader + uv`). tex2d/noise stay per-pixel.
             if (!shader_annotation_arg(func, "optimized")) {
-                if (flatten_fold(func, flatten_fast_math())) {
+                if (flatten_fold(func, flatten_no_fast_math())) {
                     astChanged = true
                     return true
                 }
                 set_shader_annotation_flag(func, "optimized")
-                if (flatten_optimize(func, SHADER_BARRIERS)) {
+                if (flatten_optimize(func, SHADER_BARRIERS, flatten_no_fast_math())) {
                     astChanged = true
                     return true
                 }

--- a/examples/flatten/capability/cap_ctor.shader
+++ b/examples/flatten/capability/cap_ctor.shader
@@ -1,0 +1,25 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+// Ctor lane algebra, on the two motivating shapes. The zero-lane product collapses to an
+// embedded constant (lane 0 dies under the zero const lane — the sin never executes — and
+// lane 1 const-folds), and the per-component adds re-vectorize into ONE vector add
+// (`sin(c + float3(...))`), so the graph carries a single sin and no per-lane add chain.
+[pixel_shader]
+def cap_ctor(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let zk = float2(sin(inp.uv.x) * 12.0, 13.0) * float2(0.0, 123.0)
+    let rv = sin(float3(c.x + 0.1, c.y + 0.2, c.z + 0.3))
+    let result = rv * 0.25 + float3(zk.x, zk.y * 0.0001, 0.0)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/cap_rcp.shader
+++ b/examples/flatten/capability/cap_rcp.shader
@@ -1,0 +1,26 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    exposure = 2.5
+}
+
+// Two per-pixel divisions by the same uniform prop. flatten hoists ONE shared per-draw
+// reciprocal (`_preshader_N = 1f / exposure`) and turns both divisions into muls — the
+// per-pixel graph carries no division by `exposure` at all. Fast-math (the reciprocal
+// rounds); `options _flatten_no_fast_math` keeps the divisions.
+[pixel_shader]
+def cap_rcp(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let toned = c / exposure
+    let glow = (c.x + c.y) / exposure
+    let result = toned + float3(glow * 0.1, 0.0, 0.0)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -69,6 +69,10 @@
 #  17. cap_rcp.shader (two per-pixel '/ exposure') -> ONE shared per-draw reciprocal
 #      (`_preshader_N = 1f / exposure`) and two muls; the per-pixel graph carries no division
 #      by the uniform. Asserted on the --das dump (fast-math; the reciprocal rounds).
+#
+#  18. cap_ctor.shader (ctor lane algebra) -> the zero-lane product collapses to an embedded
+#      constant (its sin lane dies) and the per-component adds re-vectorize into one vector
+#      add feeding one sin: exactly 1 sin + 1 add node in the whole graph.
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -337,6 +341,21 @@ if [[ "$errs" -eq 0 && "$rcps" -eq 1 && "$divs" -eq 0 ]]; then
     echo "   ok — one shared reciprocal preshader let; no per-pixel division by the uniform"
 else
     echo "   FAIL — errors=$errs rcp_lets=$rcps residual_divs=$divs (expected 1 and 0)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "18. cap_ctor.shader (zero-lane kill collapses; per-component adds re-vectorize)"
+out="$(compile "$here/cap_ctor.shader")"
+sins="$(echo "$out" | grep '^node ' | grep -cw 'sin')"
+adds="$(echo "$out" | grep '^node ' | grep -cw 'add')"
+errs="$(echo "$out" | grep -ci error)"
+# the zk product folds to a constant (its sin lane is killed by the zero const lane), and
+# `float3(c.x+0.1, c.y+0.2, c.z+0.3)` re-packs as `c + float3(...)` — one add, one sin.
+if [[ "$errs" -eq 0 && "$sins" -eq 1 && "$adds" -eq 1 ]]; then
+    echo "   ok — 1 sin + 1 add (zero-lane product folded; adds re-vectorized)"
+else
+    echo "   FAIL — errors=$errs sins=$sins adds=$adds (expected 1 and 1)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -65,6 +65,10 @@
 #  16. cap_mad.shader (mul-adds + a hand-written lerp shape) -> fused. The finishing pass packs
 #      `a*b + c` into mad nodes (incl. the scalar-broadcast form) and `(b-a)*t + a` into a lerp
 #      node, so the graph carries 2 mad + 1 lerp instead of mul/add/sub chains.
+#
+#  17. cap_rcp.shader (two per-pixel '/ exposure') -> ONE shared per-draw reciprocal
+#      (`_preshader_N = 1f / exposure`) and two muls; the per-pixel graph carries no division
+#      by the uniform. Asserted on the --das dump (fast-math; the reciprocal rounds).
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -318,6 +322,21 @@ if [[ "$errs" -eq 0 && "$mads" -eq 2 && "$lerps" -eq 1 ]]; then
     echo "   ok — compiles ($nodes nodes), 2 mad + 1 lerp (mul-adds fused)"
 else
     echo "   FAIL — errors=$errs mads=$mads lerps=$lerps (expected 2 and 1)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "17. cap_rcp.shader (per-pixel '/ uniform' -> one shared per-draw reciprocal)"
+out="$(FLATTEN_DUMP_DAS=1 compile "$here/cap_rcp.shader")"
+rcps="$(echo "$out" | grep -c 'let _preshader_.*1f / exposure')"
+divs="$(echo "$out" | grep -v 'let _preshader_' | grep -c '/ exposure')"
+errs="$(echo "$out" | grep -ci error)"
+# both `c / exposure` and `(c.x+c.y) / exposure` ride the same `_preshader_N = 1f / exposure`;
+# the per-pixel body must carry only muls by it.
+if [[ "$errs" -eq 0 && "$rcps" -eq 1 && "$divs" -eq 0 ]]; then
+    echo "   ok — one shared reciprocal preshader let; no per-pixel division by the uniform"
+else
+    echo "   FAIL — errors=$errs rcp_lets=$rcps residual_divs=$divs (expected 1 and 0)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -55,16 +55,16 @@ def private check_unit(t : T?; proj, path : string) : int {
                 }
                 // honor the unit's own `options _flatten_no_fast_math` — gated rewrites are
                 // skipped there by design, and the oracle must mirror that (no false flags)
-                let fastMath = !(program._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false)
+                let noFastMath = program._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false
                 program_for_each_module(program) $(mod) {
                     for_each_function(mod, "") $(func) {
                         if (func.body == null || func.flags.builtIn || !is_flatten_output(func)) {
                             return
                         }
                         checked ++
-                        let r <- flatten_fold_residuals(func, fastMath)
+                        let r <- flatten_fold_residuals(func, noFastMath)
                         t |> equal(length(r), 0, "{base_name(path)}::{func.name}: {r}")
-                        let optr <- flatten_opt_residuals(func)
+                        let optr <- flatten_opt_residuals(func, noFastMath)
                         t |> equal(length(optr), 0, "{base_name(path)}::{func.name} (opt): {optr}")
                     }
                 }
@@ -121,9 +121,13 @@ def test_flatten_fold(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_mad.das")
         t |> success(n >= 20, "expected >=20 twins, checked {n}")
     }
+    t |> run("rcp corpus rewrites clean (test_flatten_rcp.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_rcp.das")
+        t |> success(n >= 8, "expected >=8 twins, checked {n}")
+    }
     t |> run("no-fast-math corpus: option-aware oracle clean") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_nofastmath.das")
-        t |> success(n >= 9, "expected >=9 twins, checked {n}")
+        t |> success(n >= 11, "expected >=11 twins, checked {n}")
     }
     t |> run("no-fast-math corpus: gated shapes survive (skip-proof)") @(t : T?) {
         var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_nofastmath.das")
@@ -143,6 +147,10 @@ def test_flatten_fold(t : T?) {
         t |> success(ire |> find("2 +") < 0, "int consts must gather+fold: {ire}")
         let pre = bodies?["nf_preshader_flat"] ?? ""
         t |> success(pre |> find("_preshader_0") >= 0, "preshader extraction must still run: {pre}")
+        let dv = bodies?["nf_div_flat"] ?? ""
+        t |> success(dv |> find("/ 3f") >= 0, "x / C must survive: {dv}")
+        let udv = bodies?["nf_unidiv_flat"] ?? ""
+        t |> success(udv |> find("/ G_NF") >= 0, "x / uniform must survive (no rcp): {udv}")
         delete bodies
     }
     t |> run("every example shader folds clean (pixel_shader path)") @(t : T?) {

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -53,13 +53,16 @@ def private check_unit(t : T?; proj, path : string) : int {
                     t |> failure("compile failed: {path}\n{iss}")
                     return
                 }
+                // honor the unit's own `options _flatten_no_fast_math` — gated rewrites are
+                // skipped there by design, and the oracle must mirror that (no false flags)
+                let fastMath = !(program._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false)
                 program_for_each_module(program) $(mod) {
                     for_each_function(mod, "") $(func) {
                         if (func.body == null || func.flags.builtIn || !is_flatten_output(func)) {
                             return
                         }
                         checked ++
-                        let r <- flatten_fold_residuals(func)
+                        let r <- flatten_fold_residuals(func, fastMath)
                         t |> equal(length(r), 0, "{base_name(path)}::{func.name}: {r}")
                         let optr <- flatten_opt_residuals(func)
                         t |> equal(length(optr), 0, "{base_name(path)}::{func.name} (opt): {optr}")
@@ -69,6 +72,34 @@ def private check_unit(t : T?; proj, path : string) : int {
         }
     }
     return checked
+}
+
+// Compile `path` and return describe() of each `*_flat` twin body, keyed by twin name — the
+// structural skip-proof half of the `_flatten_no_fast_math` tests (a skipped fold computes the
+// same VALUE, so only the surviving shape proves the gate fired).
+def private twin_bodies(t : T?; path : string) : table<string; string> {
+    var bodies : table<string; string>
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.version_2_syntax = true
+            compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                if (!ok) {
+                    t |> failure("compile failed: {path}\n{iss}")
+                    return
+                }
+                program_for_each_module(program) $(mod) {
+                    for_each_function(mod, "") $(func) {
+                        if (func.body != null && !func.flags.builtIn && func.name |> ends_with("_flat")) {
+                            bodies["{func.name}"] = "{describe(func.body)}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return <- bodies
 }
 
 [test]
@@ -89,6 +120,30 @@ def test_flatten_fold(t : T?) {
     t |> run("mad/lerp corpus fuses clean (test_flatten_mad.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_mad.das")
         t |> success(n >= 20, "expected >=20 twins, checked {n}")
+    }
+    t |> run("no-fast-math corpus: option-aware oracle clean") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_nofastmath.das")
+        t |> success(n >= 9, "expected >=9 twins, checked {n}")
+    }
+    t |> run("no-fast-math corpus: gated shapes survive (skip-proof)") @(t : T?) {
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_nofastmath.das")
+        let mul0 = bodies?["nf_mul0_flat"] ?? ""
+        t |> success(mul0 |> find("* 0f") >= 0, "x*0 must survive: {mul0}")
+        let vmul0 = bodies?["nf_vmul0_flat"] ?? ""
+        t |> success(vmul0 |> find("float3(0") >= 0, "v*vec0 must survive: {vmul0}")
+        let subself = bodies?["nf_subself_flat"] ?? ""
+        t |> success(subself |> find(" - ") >= 0, "x-x must survive: {subself}")
+        let reas = bodies?["nf_reassoc_flat"] ?? ""
+        t |> success(reas |> find("0.75") < 0 && reas |> find("0.25") >= 0, "float consts must stay scattered: {reas}")
+        let lrp = bodies?["nf_lerp0_flat"] ?? ""
+        t |> success(lrp |> find("lerp") >= 0, "lerp(a,b,0) must round-trip back to lerp: {lrp}")
+        let imul0 = bodies?["nf_imul0_flat"] ?? ""
+        t |> success(imul0 |> find("* 0") < 0, "int n*0 must STILL fold: {imul0}")
+        let ire = bodies?["nf_ireassoc_flat"] ?? ""
+        t |> success(ire |> find("2 +") < 0, "int consts must gather+fold: {ire}")
+        let pre = bodies?["nf_preshader_flat"] ?? ""
+        t |> success(pre |> find("_preshader_0") >= 0, "preshader extraction must still run: {pre}")
+        delete bodies
     }
     t |> run("every example shader folds clean (pixel_shader path)") @(t : T?) {
         let proj = "{root}/examples/flatten/flatten_shaders.das_project"

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -127,7 +127,13 @@ def test_flatten_fold(t : T?) {
     }
     t |> run("ctor lane algebra corpus rewrites clean (test_flatten_ctor.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_ctor.das")
-        t |> success(n >= 14, "expected >=14 twins, checked {n}")
+        t |> success(n >= 15, "expected >=15 twins, checked {n}")
+        // structural half for the uint kill — the oracle shares const_vec_zero_mask with the
+        // transform, so only the surviving shape proves the uint branches exist
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_ctor.das")
+        let zu = bodies?["z_uint_flat"] ?? ""
+        t |> success(zu |> find(" * ") < 0, "uint zero-lane kill must fold the whole product: {zu}")
+        delete bodies
     }
     t |> run("no-fast-math corpus: option-aware oracle clean") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_nofastmath.das")

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -125,9 +125,13 @@ def test_flatten_fold(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_rcp.das")
         t |> success(n >= 8, "expected >=8 twins, checked {n}")
     }
+    t |> run("ctor lane algebra corpus rewrites clean (test_flatten_ctor.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_ctor.das")
+        t |> success(n >= 14, "expected >=14 twins, checked {n}")
+    }
     t |> run("no-fast-math corpus: option-aware oracle clean") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_nofastmath.das")
-        t |> success(n >= 11, "expected >=11 twins, checked {n}")
+        t |> success(n >= 13, "expected >=13 twins, checked {n}")
     }
     t |> run("no-fast-math corpus: gated shapes survive (skip-proof)") @(t : T?) {
         var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_nofastmath.das")
@@ -151,6 +155,10 @@ def test_flatten_fold(t : T?) {
         t |> success(dv |> find("/ 3f") >= 0, "x / C must survive: {dv}")
         let udv = bodies?["nf_unidiv_flat"] ?? ""
         t |> success(udv |> find("/ G_NF") >= 0, "x / uniform must survive (no rcp): {udv}")
+        let zk = bodies?["nf_zkill_flat"] ?? ""
+        t |> success(zk |> find("sin") >= 0, "the zero-lane kill must be skipped (sin survives): {zk}")
+        let mj = bodies?["nf_mj_flat"] ?? ""
+        t |> success(mj |> find("* 12f") >= 0, "majority compensation must be skipped: {mj}")
         delete bodies
     }
     t |> run("every example shader folds clean (pixel_shader path)") @(t : T?) {

--- a/tests/flatten/test_flatten_ctor.das
+++ b/tests/flatten/test_flatten_ctor.das
@@ -36,6 +36,11 @@ def z_int(n : int) : int2 {
 }
 
 [flatten]
+def z_uint(n : uint) : uint2 {
+    return uint2(n * 7u, 5u) * uint2(0u, 3u)
+}
+
+[flatten]
 def sp_mul(v : float3; s : float) : float3 {
     return v * float3(s)
 }
@@ -139,6 +144,15 @@ def test_flatten_ctor(t : T?) {
         for (n in IGRID) {
             let r = z_int_flat(n)
             let o = z_int(n)
+            t |> equal(r.x, o.x)
+            t |> equal(r.y, o.y)
+        }
+    }
+    t |> run("uint zero-lane kill (exact, ungated)") @(t : T?) {
+        for (n in IGRID) {
+            let u = uint(n)
+            let r = z_uint_flat(u)
+            let o = z_uint(u)
             t |> equal(r.x, o.x)
             t |> equal(r.y, o.y)
         }

--- a/tests/flatten/test_flatten_ctor.das
+++ b/tests/flatten/test_flatten_ctor.das
@@ -1,0 +1,201 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Twin corpus for the ctor lane algebra. Fold phase: zero-lane kill (`floatN(e…) * constVec`
+//! zeroes the ctor lanes under a zero const lane — fast-math for floats, exact for ints) and
+//! splat collapse (`v ⊙ floatN(s) → v ⊙ s` for * and / — bit-exact). Fuse phase: lane
+//! re-vectorization (`floatN(v.x + c1, v.y + c2, …) → v + floatN(c…)` — bit-exact, the per-lane
+//! ops are the same IEEE ops), shared-factor extraction (`floatN(s*a, s*b, s*c) → floatN(a,b,c)
+//! * s` — bit-exact), and majority-const compensation (`float3(x*C1, y*C1, z*C2) → float3(x, y,
+//! z*(C2/C1)) * C1` — the odd-lane reciprocal rounds → fapprox + fast-math gate). All exact
+//! twins compare `equal`; only the compensation twin needs `fapprox`. Structural halves live in
+//! tests/flatten/no_aot/test_flatten_fold.das (option-aware oracles) and capability/cap_ctor.shader.
+
+var G_CTOR = 2.5
+
+// ----- fold phase: zero-lane kill + splat collapse -----
+
+[flatten]
+def z_kill(x : float) : float2 {
+    return float2(sin(x) * 12.0, 13.0) * float2(0.0, 123.0)
+}
+
+[flatten]
+def z_partial(x, y : float) : float3 {
+    return float3(sin(x), y * 2.0, 5.0) * float3(0.0, 2.0, 3.0)
+}
+
+[flatten]
+def z_int(n : int) : int2 {
+    return int2(n * 7, 5) * int2(0, 3)
+}
+
+[flatten]
+def sp_mul(v : float3; s : float) : float3 {
+    return v * float3(s)
+}
+
+[flatten]
+def sp_div(v : float3; s : float) : float3 {
+    return v / float3(s)
+}
+
+[flatten]
+def sp_rdiv(v : float3; s : float) : float3 {
+    return float3(s) / v
+}
+
+// ----- fuse phase: lane re-vectorization -----
+
+[flatten]
+def rv_add(v : float3) : float3 {
+    return sin(float3(v.x + 0.1, v.y + 0.2, v.z + 0.3))
+}
+
+[flatten]
+def rv_swiz(v : float4) : float3 {
+    return float3(v.z + 1.0, v.x + 2.0, v.y + 3.0)
+}
+
+[flatten]
+def rv_gather(v : float2; s1, s2 : float) : float2 {
+    return float2(v.x * s1, v.y * s2)
+}
+
+[flatten]
+def rv_eq_add(v : float3; s : float) : float3 {
+    return float3(s + v.x, s + v.y, s + v.z)
+}
+
+// ----- fuse phase: shared factor / majority compensation -----
+
+[flatten]
+def sf_var(x : float) : float3 {
+    let g = x * 0.5
+    return float3(g * 1.08, g * 0.86, g * 0.66)
+}
+
+[flatten]
+def sf_const(x, y, z : float) : float3 {
+    return float3(x * 13.0, y * 13.0, z * 13.0)
+}
+
+[flatten]
+def sf_div(x, y, z, s : float) : float3 {
+    return float3(x / s, y / s, z / s)
+}
+
+[flatten]
+def mj_comp(x, y, z : float) : float3 {
+    return float3(x * 13.0, y * 13.0, z * 12.0)
+}
+
+// ----- differential driver -----
+
+var GRID : array<float>
+var IGRID : array<int>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, -0.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+    IGRID <- [-100, -7, -1, 0, 1, 3, 42, 1000]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "ctor approx mismatch: {a} vs {b}")
+}
+
+def cmp2f(t : T?; a, b : float2) {
+    t |> equal(a.x, b.x); t |> equal(a.y, b.y)
+}
+
+def cmp3f(t : T?; a, b : float3) {
+    t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
+}
+
+def cmp3f_approx(t : T?; a, b : float3) {
+    fapprox(t, a.x, b.x); fapprox(t, a.y, b.y); fapprox(t, a.z, b.z)
+}
+
+[test]
+def test_flatten_ctor(t : T?) {
+    t |> run("zero-lane kill collapses the whole product (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp2f(t, z_kill_flat(v), z_kill(v))
+        }
+    }
+    t |> run("partial zero-lane kill (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, z_partial_flat(v, -v), z_partial(v, -v))
+        }
+    }
+    t |> run("int zero-lane kill (exact, ungated)") @(t : T?) {
+        for (n in IGRID) {
+            let r = z_int_flat(n)
+            let o = z_int(n)
+            t |> equal(r.x, o.x)
+            t |> equal(r.y, o.y)
+        }
+    }
+    t |> run("v * splat(s) -> v * s (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, sp_mul_flat(float3(v, -v, 1.0), 3.5), sp_mul(float3(v, -v, 1.0), 3.5))
+        }
+    }
+    t |> run("v / splat(s) -> v / s (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, sp_div_flat(float3(v, -v, 1.0), 3.5), sp_div(float3(v, -v, 1.0), 3.5))
+        }
+    }
+    t |> run("splat(s) / v -> s / v (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, sp_rdiv_flat(float3(v, -v, 1.0), 3.5), sp_rdiv(float3(v, -v, 1.0), 3.5))
+        }
+    }
+    t |> run("re-vectorize per-component adds (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, rv_add_flat(float3(v, -v, 1.0)), rv_add(float3(v, -v, 1.0)))
+        }
+    }
+    t |> run("re-vectorize through a permuted swizzle (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, rv_swiz_flat(float4(v, -v, 1.0, 2.0)), rv_swiz(float4(v, -v, 1.0, 2.0)))
+        }
+    }
+    t |> run("re-vectorize with a gathered varying side (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp2f(t, rv_gather_flat(float2(v, -v), 3.0, 5.0), rv_gather(float2(v, -v), 3.0, 5.0))
+        }
+    }
+    t |> run("re-vectorize with an equal-scalar splat side (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, rv_eq_add_flat(float3(v, -v, 1.0), 2.25), rv_eq_add(float3(v, -v, 1.0), 2.25))
+        }
+    }
+    t |> run("shared var factor -> const-vec * s (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, sf_var_flat(v), sf_var(v))
+        }
+    }
+    t |> run("shared const factor -> ctor * C (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, sf_const_flat(v, -v, 1.0), sf_const(v, -v, 1.0))
+        }
+    }
+    t |> run("shared divisor -> ctor / s (exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, sf_div_flat(v, -v, 1.0, 3.5), sf_div(v, -v, 1.0, 3.5))
+        }
+    }
+    t |> run("majority const factor compensates the odd lane (approx)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f_approx(t, mj_comp_flat(v, -v, 1.0), mj_comp(v, -v, 1.0))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_nofastmath.das
+++ b/tests/flatten/test_flatten_nofastmath.das
@@ -47,6 +47,16 @@ def nf_lerp0(a, b : float) : float {
     return lerp(a, b, 0.0)
 }
 
+[flatten]
+def nf_div(x : float) : float {
+    return x / 3.0
+}
+
+[flatten]
+def nf_unidiv(x : float) : float {
+    return x / G_NF
+}
+
 // ----- exact rewrites: still fire under the option -----
 
 [flatten]
@@ -110,6 +120,16 @@ def test_flatten_nofastmath(t : T?) {
     t |> run("lerp const-selector skipped — bit-exact") @(t : T?) {
         for (a in GRID) {
             t |> equal(nf_lerp0_flat(a, 7.5), nf_lerp0(a, 7.5))
+        }
+    }
+    t |> run("x / C NOT rewritten to *(1/C) — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_div_flat(v), nf_div(v))
+        }
+    }
+    t |> run("x / uniform NOT rcp'd — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_unidiv_flat(v), nf_unidiv(v))
         }
     }
     t |> run("int n * 0 still folds (exact)") @(t : T?) {

--- a/tests/flatten/test_flatten_nofastmath.das
+++ b/tests/flatten/test_flatten_nofastmath.das
@@ -57,6 +57,16 @@ def nf_unidiv(x : float) : float {
     return x / G_NF
 }
 
+[flatten]
+def nf_zkill(x : float) : float2 {
+    return float2(sin(x) * 12.0, 13.0) * float2(0.0, 123.0)
+}
+
+[flatten]
+def nf_mj(x, y, z : float) : float3 {
+    return float3(x * 13.0, y * 13.0, z * 12.0)
+}
+
 // ----- exact rewrites: still fire under the option -----
 
 [flatten]
@@ -130,6 +140,23 @@ def test_flatten_nofastmath(t : T?) {
     t |> run("x / uniform NOT rcp'd — bit-exact") @(t : T?) {
         for (v in GRID) {
             t |> equal(nf_unidiv_flat(v), nf_unidiv(v))
+        }
+    }
+    t |> run("float zero-lane kill skipped — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            let r = nf_zkill_flat(v)
+            let o = nf_zkill(v)
+            t |> equal(r.x, o.x)
+            t |> equal(r.y, o.y)
+        }
+    }
+    t |> run("majority-factor compensation skipped — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            let r = nf_mj_flat(v, -v, 1.0)
+            let o = nf_mj(v, -v, 1.0)
+            t |> equal(r.x, o.x)
+            t |> equal(r.y, o.y)
+            t |> equal(r.z, o.z)
         }
     }
     t |> run("int n * 0 still folds (exact)") @(t : T?) {

--- a/tests/flatten/test_flatten_nofastmath.das
+++ b/tests/flatten/test_flatten_nofastmath.das
@@ -1,0 +1,135 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+options _flatten_no_fast_math = true
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Twin corpus for `options _flatten_no_fast_math` — the user opt-out of flatten's
+//! value-changing rewrites. Under the option every gated rewrite (float `x*0`/`x-x`,
+//! float reassoc, lerp const-selectors) is SKIPPED, so each twin executes the same op
+//! sequence as its original and every differential below compares EXACT `equal` —
+//! including the reassoc shapes that need `fapprox` in the fast-math corpus. The
+//! bit-exact passes (flattening, predication, preshader extraction, CSE, mad fusion)
+//! must still run; the int twins prove the integer folds (exact) still fire. The
+//! structural FIRED/SKIPPED half lives in tests/flatten/no_aot/test_flatten_fold.das,
+//! which compiles this file as a unit and asserts the gated shapes SURVIVE in the
+//! twins while the option-aware oracle (`flatten_fold_residuals(func, false)`) stays clean.
+
+var G_NF = 2.5
+
+// ----- gated rewrites: skipped under the option, value bit-exact -----
+
+[flatten]
+def nf_mul0(x : float) : float {
+    return x * 0.0
+}
+
+[flatten]
+def nf_vmul0(v : float3) : float3 {
+    return v * float3(0.0, 0.0, 0.0)
+}
+
+[flatten]
+def nf_subself(x : float) : float {
+    return (x * 3.0) - (x * 3.0) // nolint:LINT007 — the x-x gate is exactly what's under test
+}
+
+[flatten]
+def nf_reassoc(x : float) : float {
+    return 0.25 + x + 0.5
+}
+
+[flatten]
+def nf_lerp0(a, b : float) : float {
+    return lerp(a, b, 0.0)
+}
+
+// ----- exact rewrites: still fire under the option -----
+
+[flatten]
+def nf_imul0(n : int) : int {
+    return n * 0
+}
+
+[flatten]
+def nf_ireassoc(n : int) : int {
+    return 2 + n + 3
+}
+
+[flatten]
+def nf_mad(x, y, z : float) : float {
+    return x * y + z
+}
+
+[flatten]
+def nf_preshader(x : float) : float {
+    let u = G_NF * 2.0 + 1.0
+    return x * u + u
+}
+
+// ----- differential driver -----
+
+var GRID : array<float>
+var IGRID : array<int>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, -0.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+    IGRID <- [-100, -7, -1, 0, 1, 3, 42, 1000]
+}
+
+def cmp3f(t : T?; a, b : float3) {
+    t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
+}
+
+[test]
+def test_flatten_nofastmath(t : T?) {
+    t |> run("x * 0.0 NOT folded — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_mul0_flat(v), nf_mul0(v))
+        }
+    }
+    t |> run("v * vec0 NOT folded — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, nf_vmul0_flat(float3(v, -v, 1.0)), nf_vmul0(float3(v, -v, 1.0)))
+        }
+    }
+    t |> run("x - x NOT folded — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_subself_flat(v), nf_subself(v))
+        }
+    }
+    t |> run("float reassoc skipped — EXACT equal (no fapprox needed)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_reassoc_flat(v), nf_reassoc(v))
+        }
+    }
+    t |> run("lerp const-selector skipped — bit-exact") @(t : T?) {
+        for (a in GRID) {
+            t |> equal(nf_lerp0_flat(a, 7.5), nf_lerp0(a, 7.5))
+        }
+    }
+    t |> run("int n * 0 still folds (exact)") @(t : T?) {
+        for (n in IGRID) {
+            t |> equal(nf_imul0_flat(n), nf_imul0(n))
+        }
+    }
+    t |> run("int reassoc still fires (exact)") @(t : T?) {
+        for (n in IGRID) {
+            t |> equal(nf_ireassoc_flat(n), nf_ireassoc(n))
+        }
+    }
+    t |> run("mad fusion still fires — das-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_mad_flat(v, 3.0, 1.5), nf_mad(v, 3.0, 1.5))
+        }
+    }
+    t |> run("preshader extraction still runs — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_preshader_flat(v), nf_preshader(v))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_rcp.das
+++ b/tests/flatten/test_flatten_rcp.das
@@ -1,0 +1,129 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Twin corpus for the fast-math division rewrites: `x / C → x * (1/C)` (fold arm) and
+//! `x / U → x * _preshader(1/U)` (extraction, U uniform). Exactness tiers: a power-of-two
+//! reciprocal is exact (`equal`); any other reciprocal rounds, so those twins compare
+//! `fapprox` — the rounding is the fast-math contract, `options _flatten_no_fast_math`
+//! turns it off (see test_flatten_nofastmath.das). A zero divisor keeps the division
+//! (no inf literal is minted); integer division is out of scope entirely. The structural
+//! FIRED half (no un-rcp'd const/uniform division residual) lives in
+//! tests/flatten/no_aot/test_flatten_fold.das via the option-aware oracles; the backend
+//! node proof is capability/cap_rcp.shader (one shared per-draw reciprocal).
+
+var G_RCP = 3.0
+
+[flatten]
+def r_pow2(x : float) : float {
+    return x / 4.0
+}
+
+[flatten]
+def r_npow2(x : float) : float {
+    return x / 3.0
+}
+
+[flatten]
+def r_vecdiv(v : float3) : float3 {
+    return v / 2.0
+}
+
+[flatten]
+def r_vconst(v : float3) : float3 {
+    return v / float3(2.0, 4.0, 8.0)
+}
+
+[flatten]
+def r_uni(x : float) : float {
+    return x / G_RCP
+}
+
+[flatten]
+def r_two(x, y : float) : float {
+    return (x / G_RCP) + (y / G_RCP)
+}
+
+[flatten]
+def r_zero(x : float) : float {
+    return x / 0.0 // nolint:LINT006 — the zero-divisor bail (no inf literal) is what's under test
+}
+
+[flatten]
+def i_div(n : int) : int {
+    return n / 3
+}
+
+// ----- differential driver -----
+
+var GRID : array<float>
+var NZGRID : array<float>
+var IGRID : array<int>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, -0.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+    NZGRID <- [-100.0, -3.5, -1.0, 1.0, 2.5, 7.0, 100.0]   // x/0 is inf (inf==inf) but 0/0 is NaN
+    IGRID <- [-100, -7, -1, 0, 1, 3, 42, 1000]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "rcp approx mismatch: {a} vs {b}")
+}
+
+def cmp3f(t : T?; a, b : float3) {
+    t |> equal(a.x, b.x); t |> equal(a.y, b.y); t |> equal(a.z, b.z)
+}
+
+def cmp3f_approx(t : T?; a, b : float3) {
+    fapprox(t, a.x, b.x); fapprox(t, a.y, b.y); fapprox(t, a.z, b.z)
+}
+
+[test]
+def test_flatten_rcp(t : T?) {
+    t |> run("x / 4.0 -> x * 0.25 (pow2 reciprocal, exact)") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(r_pow2_flat(v), r_pow2(v))
+        }
+    }
+    t |> run("x / 3.0 -> x * (1/3) (rounds, approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, r_npow2_flat(v), r_npow2(v))
+        }
+    }
+    t |> run("v / 2.0 -> v * 0.5 (vector by pow2 scalar, exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, r_vecdiv_flat(float3(v, -v, 1.0)), r_vecdiv(float3(v, -v, 1.0)))
+        }
+    }
+    t |> run("v / float3(2,4,8) -> v * float3(.5,.25,.125) (pow2 lanes, exact)") @(t : T?) {
+        for (v in GRID) {
+            cmp3f(t, r_vconst_flat(float3(v, -v, 1.0)), r_vconst(float3(v, -v, 1.0)))
+        }
+    }
+    t |> run("x / G -> x * _preshader(1/G) (uniform divisor, approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, r_uni_flat(v), r_uni(v))
+        }
+    }
+    t |> run("two / G share one reciprocal (approx)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, r_two_flat(v, -v), r_two(v, -v))
+        }
+    }
+    t |> run("x / 0.0 keeps the division (no inf literal)") @(t : T?) {
+        for (v in NZGRID) {
+            t |> equal(r_zero_flat(v), r_zero(v))
+        }
+    }
+    t |> run("int n / 3 untouched (exact)") @(t : T?) {
+        for (n in IGRID) {
+            t |> equal(i_div_flat(n), i_div(n))
+        }
+    }
+}


### PR DESCRIPTION
Optimization round 4 for `daslib/flatten`, in three pieces (one commit each + docs):

## 1. `options _flatten_no_fast_math` — the user opt-out

flatten's default contract is a shader compiler's: fast math. This adds the module-local user option that turns off exactly the **value-changing** rewrites — float `x*0` / `x-x` folds (inf/NaN propagation), float reassociation (both the const-gather and the canonical re-sort re-associate the chain), the lerp const-selector short-circuits (they drop an argument), and the new rewrites below. Everything bit-exact stays on: flattening, predication, unrolling, preshader extraction, CSE, alias elimination, the mad/lerp expand/re-fuse round trip, and every integer fold. Under the option a twin computes bit-identical results to its original — the test corpus proves it by comparing `equal` where the fast-math corpus needs `fapprox`.

The flag is threaded as `no_fast_math : bool = false` through the public passes (defaults are correct with nothing set); `flatten_no_fast_math()` reads the option from the compiling module — compile-time only, since `compiling_program()` returns a borrowed `smart_ptr_raw` and throws outside a compile. The residual oracles take the same flag, and the no_aot meta-test honors each unit's own option plus skip-proof asserts (a skipped fold computes the same value, so only the surviving shape proves the gate fired).

## 2. Division → reciprocal multiply (fast-math)

* fold: `x / C` → `x * (1/C)` — reciprocal computed at compile time; a zero lane keeps the division (no inf literals); pow2 reciprocals are exact.
* optimize: a varying `x / U` with a preshader-eligible scalar divisor → `x * _preshader_N` with `let _preshader_N = 1f / U` hoisted per draw, dedup'd by structural key.

raymarch's six smooth-min `/ smoothK` divides and its `/ marchDist` now ride two per-draw reciprocals — **zero per-pixel divisions** — and the rcp-muls mad-fuse downstream. cel_shading / toon / posterize / pixelate / gameboy all lose their per-pixel quantization divides the same way. `is_rcp_candidate` is shared verbatim by the rewrite and the new opt-residual arm; the fold oracle mirrors the const arm.

## 3. Ctor lane algebra

Per-lane scalar arithmetic wrapped in a vector constructor, re-packed from both ends:

* **Zero-lane kill** (fold, fast-math for floats / exact for ints): `floatN(e0, e1, ...) * constVec` with a zero const lane zeroes the matching ctor lanes in place — no distribution — so the dead lane's compute dies by DSE and a fully-const product embeds: `float2(sin(x)*12.0, 13.0) * float2(0.0, 123.0)` collapses to `float2(0f, 1599f)` and the `sin` never executes. No purity gate: flat lanes are pure by the verify contract, and macro-time `has_sideeffects` calls DSL stubs (`sin`, `tex2d`) impure — it would gut exactly this case.
* **Splat collapse** (fold, bit-exact): `v * floatN(s)`, `v / floatN(s)`, `floatN(s) / v` use das's native vector-scalar forms — the splat node disappears (triplanar's `an / float3(sumW)` → `an / sumW`).
* **Lane re-vectorization** (fuse, bit-exact) — the manual-vectorization shape the engine team reported: `sin(float3(c.x + 0.1, c.y + 0.2, c.z + 0.3))` → `sin(c + float3(0.1, 0.2, 0.3))`. Same-op lanes whose sides classify as a component pattern (any permutation of one base → swizzle; the natural full mask → the base itself), an equal scalar (broadcasts under `*`/`/`, splats under `+`/`-`), or a gather (a fresh ctor; a const literal when every lane is const — the fold phase is over, so a const ctor call would trip the fold oracle).
* **Shared-factor extraction** (fuse, bit-exact): `float3(g*1.08, g*0.86, g*0.66)` → `float3(1.08, 0.86, 0.66) * g` — 3 muls + ctor become one broadcast mul against an embedded const (sepia's grade is now exactly this).
* **Majority-factor compensation** (fuse, fast-math): `float3(x*13.0, y*13.0, z*12.0)` → `float3(x, y, z*(12.0/13.0)) * 13.0` — fires only when the per-pixel multiply count strictly drops.

The fuse-side matcher (`ctor_fuse_rewrite`) is clone-built so the residual oracle probes with it verbatim and non-destructively; the ctor walk runs first in `fuse_body` so its `ctor * s` output feeds the mad walk in the same round. The runtime residual entries now run under `ast_gc_guard` (the probe matchers clone).

## Validation

* tests/flatten 220/220 — new corpora: `test_flatten_rcp` (9), `test_flatten_ctor` (15), `test_flatten_nofastmath` (14, all-`equal`), plus option-aware oracle + skip-proof blocks in the no_aot meta-test
* full suites: interp 0 failed, JIT clean-cache 10400/0/0, AOT (CI form, rebuilt test_aot) 10163/0/0
* examples 69/0; capability 18/18 (new: cap_rcp — one shared reciprocal, zero per-pixel divs; cap_ctor — exactly 1 sin + 1 add)
* every example shader validates clean against the new residual arms; only 9 shaders' output changed, the other 60 are byte-identical
* flatten-fuzz int/bool/strict PASS; Sphinx 0 warnings; lint + dupe check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)