### PR TITLE
match/ast_match: AST-pointer pattern fixes + qualified call names

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -244,7 +244,7 @@ def aotSuffixNameEx(funcName : string; suffix : string) {
                     if ('.') { t_ch = "Dot"; }
                     if ('`') { t_ch = "Tick"; }
                     if (',') { t_ch = "Comma"; }
-                    if (_) {   // nolint:STYLE010 — match macro expands wildcard to `if (true)`
+                    if (_) {
                         let repr = build_string() $(ss) {
                             ss |> write_char(hex_char(ch >> 4))
                             ss |> write_char(hex_char(ch));
@@ -1912,7 +1912,7 @@ class public CppAot : AstVisitor {
                     if ("&") { op = "&&"; }
                     if ("|") { op = "||"; }
                     if ("^" || "^^") { op = "!="; }
-                    if (_) { op = that_op; }  // nolint:STYLE010 — match macro expands wildcard to `if (true)`
+                    if (_) { op = that_op; }
                 }
                 write(*ss, " {op} ");
             } else {
@@ -2687,7 +2687,7 @@ class public CppAot : AstVisitor {
                 if (1) { write(*ss, "y"); }
                 if (2) { write(*ss, "z"); }
                 if (3) { write(*ss, "w"); }
-                if (_) { write(*ss, "?"); }  // nolint:STYLE010 — match macro expands wildcard to `if (true)`
+                if (_) { write(*ss, "?"); }
             }
         }
         write(*ss, "*/");

--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -302,13 +302,15 @@ def qm_extract_stmts(var blk_expr : Expression?; from_pos : int; to_pos : int; v
 }
 
 def qm_call_name_matches(call : ExprCall?; expected_name : string) : bool {
-    //! Check if a call's name matches, accounting for generic instantiation.
-    //! When a generic function is instantiated, the call name is mangled
-    //! (e.g. ``generic_add`123456``). This checks the mangled name first,
-    //! then falls back to the ``fromGeneric`` original name.
-    if (call.name == expected_name) return true
-    if (call.func != null && call.func.fromGeneric != null) return call.func.fromGeneric.name == expected_name
-    return false
+    //! Check if a call's name matches, accounting for generic instantiation
+    //! and module qualification. When a generic function is instantiated, the
+    //! call name is mangled (e.g. ``generic_add`123456``) — the ``fromGeneric``
+    //! original name is checked as a fallback. A resolved call may also carry a
+    //! module-qualified name (``math::mad``); an unqualified pattern name
+    //! matches its last ``::`` segment.
+    return (call.name == expected_name ||
+        (call.func != null && call.func.fromGeneric != null && call.func.fromGeneric.name == expected_name) ||
+        (find(expected_name, "::") < 0 && "{call.name}" |> ends_with("::{expected_name}")))
 }
 
 def qm_extract_call_name(var expr : Expression?) : string {

--- a/daslib/match.das
+++ b/daslib/match.das
@@ -443,6 +443,7 @@ def match_or(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var to : 
         return false
     }
     var toR : MatchTo
+    toR.declarations := to.declarations
     if (!match_any(what, wth.right, access, toR)) {
         to.errors |> push_from(toR.errors)
         to.failed ||= toR.failed
@@ -462,8 +463,10 @@ def match_or(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var to : 
             return false
         }
     }
-    unsafe {
-        to.declarations <- toL.declarations // because its a superset
+    // merge the branch's new captures (toL post-erase holds only those) — the old wholesale
+    // move dropped captures made earlier in the same pattern
+    for (k, v in keys(toL.declarations), values(toL.declarations)) {
+        to.declarations[k] = v
     }
     var lcond = join_conditions(toL.conditions, wth.left.at)
     var rcond = join_conditions(toR.conditions, wth.right.at)

--- a/daslib/match.das
+++ b/daslib/match.das
@@ -60,6 +60,13 @@ enum MatchType {
 }
 
 [macro_function]
+def is_string_like(typ : TypeDeclPtr) : bool {
+    if (typ == null) return false
+    if (typ.baseType == Type.tString) return true
+    return typ.baseType == Type.tHandle && typ.annotation != null && typ.annotation.name == "das_string"
+}
+
+[macro_function]
 def get_match_type(typ : TypeDeclPtr) {
     if (!typ.isStructure || typ.structType == null) return MatchType.none
     for (ann in typ.structType.annotations) {
@@ -107,7 +114,13 @@ def match_copy(what : TypeDeclPtr; wths : Expression?; makeType : TypeDeclPtr; a
 def match_struct(what : TypeDeclPtr; wths : ExprMakeStruct?; access : Expression?; var to : MatchTo) {
     // if its a pointer to ast::Expression or such, we need to 'as' cast first
     if (wths.makeType.isHandle && isExpression(wths.makeType)
-            && what.isPointer && what.firstType != null && isExpression(what.firstType)) return match_as_is(what, wths, wths.makeType,  wths.makeType.annotation.name, access, to)
+            && what.isPointer && what.firstType != null && isExpression(what.firstType)) {
+        // `is` on a null AST pointer panics — guard like the pointer-to-structure path below
+        var cond_nz = qmacro($e(access) != null)
+        cond_nz |> force_at(wths.at)
+        to.conditions |> emplace(cond_nz)
+        return match_as_is(what, wths, wths.makeType, wths.makeType.annotation.name, access, to)
+    }
     // if its pointer to structure, automatically dereference it
     if (what.baseType == Type.tPointer && what.firstType != null && (what.firstType.isStructure || what.firstType.isHandle)) {
         var cond_nz = qmacro($e(access) != null)
@@ -423,9 +436,18 @@ def match_guards(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var t
 def match_or(what : TypeDeclPtr; wth : ExprOp2?; access : Expression?; var to : MatchTo) {
     var toL : MatchTo
     toL.declarations := to.declarations
-    if (!match_any(what, wth.left, access, toL)) return false
+    if (!match_any(what, wth.left, access, toL)) {
+        // propagate the branch's diagnostics — a silent false here surfaces as "unspecified match error"
+        to.errors |> push_from(toL.errors)
+        to.failed ||= toL.failed
+        return false
+    }
     var toR : MatchTo
-    if (!match_any(what, wth.right, access, toR)) return false
+    if (!match_any(what, wth.right, access, toR)) {
+        to.errors |> push_from(toR.errors)
+        to.failed ||= toR.failed
+        return false
+    }
     for (k in keys(to.declarations)) {
         toL.declarations |> erase(k)
         toR.declarations |> erase(k)
@@ -552,6 +574,8 @@ def match_any(what : TypeDeclPtr; wth : Expression?; access : Expression?; var t
         }
         if (wth.__rtti == "ExprConstPtr" && what.isPointer) {
             pass
+        } elif (is_string_like(what) && is_string_like(wth._type)) {
+            pass    // das_string == string is a language-level compare
         } elif (!is_same_type(what, wth._type, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) {
             to.errors |> match_error("condition type mismatch {describe(what)} vs {describe(wth._type)}", wth.at)
             return false
@@ -562,7 +586,8 @@ def match_any(what : TypeDeclPtr; wth : Expression?; access : Expression?; var t
         cond |> force_at(wth.at)
         to.conditions |> emplace(cond)
         return true
-    } elif (wth._type != null && is_same_type(what, wth._type, RefMatters.no, ConstMatters.no, TemporaryMatters.no)) {
+    } elif (wth._type != null && (is_same_type(what, wth._type, RefMatters.no, ConstMatters.no, TemporaryMatters.no) ||
+            (is_string_like(what) && is_string_like(wth._type)))) {
         log_m("\tadd condition {describe(access)} == {describe(wth)}\n")
         var ee = unsafe(reinterpret<Expression?> copy_to_local(wth))
         var cond = qmacro($e(access) == $e(ee))
@@ -640,7 +665,7 @@ class MatchMacro : AstCallMacro {
             }
         }
         var access = clone_expression(what)
-        var iff : ExprIfThenElse?
+        var iff : Expression?
         var iffb : array<ExprIfThenElse?>
         let eli = length(eblk.list)
         var any_errors = false
@@ -651,7 +676,6 @@ class MatchMacro : AstCallMacro {
                 var to : MatchTo
                 if (match_any(what._type, eto.cond, access, to)) {
                     log_m("match_any ok\n\n")
-                    var new_iff = new ExprIfThenElse(at = eto.at, cond = join_conditions(to.conditions, eto.at))
                     var nblk = new ExprBlock(at = eto.at)
                     for (l in (eto.if_true as ExprBlock).list) {
                         nblk.list |> emplace_new <| clone_expression(l)
@@ -665,12 +689,19 @@ class MatchMacro : AstCallMacro {
                         }
                         rules |> replaceVarTag("_") <| clone_expression(access)
                     }
-                    new_iff.if_true = nblk
-                    if (multi_match) {
-                        iffb |> emplace(new_iff)
+                    if (!multi_match && iff == null && empty(to.conditions)) {
+                        // unconditional tail arm (`_` wildcard): splice the body directly — an
+                        // `if (true)` tail defeats all-paths-return analysis and trips STYLE010
+                        iff = nblk
                     } else {
-                        new_iff.if_false = iff
-                        iff = new_iff
+                        var new_iff = new ExprIfThenElse(at = eto.at, cond = join_conditions(to.conditions, eto.at))
+                        new_iff.if_true = nblk
+                        if (multi_match) {
+                            iffb |> emplace(new_iff)
+                        } else {
+                            new_iff.if_false = iff
+                            iff = new_iff
+                        }
                     }
                 } elif (report_match_errors || to.failed) {
                     log_m("match_any failed\n\n")
@@ -680,7 +711,7 @@ class MatchMacro : AstCallMacro {
                             macro_error(prog, *e.at, e.msg)
                         }
                     } else {
-                        macro_error(prog, eto.at, "unspecified match error")
+                        macro_error(prog, eto.at, "pattern `{describe(eto.cond)}` does not match `{describe(what._type)}`")
                     }
                     break
                 }

--- a/doc/source/reference/language/ast_matching.rst
+++ b/doc/source/reference/language/ast_matching.rst
@@ -366,6 +366,11 @@ so patterns like ``generic_add(a, b)`` match transparently.
 
 ``$c(name)`` on a generic call also returns the original (unmangled) name.
 
+A parsed or resolved call may also carry a module-qualified name (``math::sin``). An
+unqualified pattern name matches its last ``::`` segment — ``sin($e(x))`` matches
+``math::sin(1.0)``. The match is segment-aligned (``sin`` does not match ``foosin``),
+and a qualified pattern name still requires an exact match.
+
 -----------
 Result type
 -----------

--- a/doc/source/reference/language/pattern_matching.rst
+++ b/doc/source/reference/language/pattern_matching.rst
@@ -392,6 +392,37 @@ Usage is identical to regular struct matching:
         }
     }
 
+Matching AST Nodes
+------------------
+
+``match`` decomposes compiler AST nodes (``ExpressionPtr``, ``TypeDeclPtr``, and other
+handled-type pointers) directly: the pattern names the node type, fields compare or
+capture, and nested node patterns recurse:
+
+.. code-block:: das
+
+    def classify ( e : ExpressionPtr ) {
+        match ( e ) {
+            if ( ExprOp2(op="+", left=ExprOp2(op="*", left=$v(a), right=$v(b)), right=$v(c)) ) {
+                return "mad shape"
+            }
+            if ( ExprOp2(op="+" || "-") ) {
+                return "additive"
+            }
+            if ( ExprSwizzle(mask="xy", value=$v(v)) ) {
+                return "xy swizzle"
+            }
+            if ( _ ) {
+                return "other"
+            }
+        }
+    }
+
+A null pointer fails node patterns cleanly, so no explicit ``if ( null )`` arm is
+required (one may still be used to handle null specifically). ``das_string`` fields
+(operator names, identifiers, swizzle masks) compare directly against string literals.
+Node-type checks are exact — ``ExprField`` does not match ``ExprSafeField``.
+
 Static Matching
 ---------------
 

--- a/tests/ast_match/test_call_qualified.das
+++ b/tests/ast_match/test_call_qualified.das
@@ -1,0 +1,68 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ── module-qualified call names ─────────────────────────────────────────
+// A resolved/parsed call may carry a qualified name (`math::sin`); an
+// unqualified pattern name matches its last `::` segment via
+// qm_call_name_matches. The suffix must be segment-aligned.
+
+[test]
+def test_unqualified_pattern_vs_qualified_call(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(math::sin(1.0))
+        var arg : ExpressionPtr
+        let r = qmatch(expr, sin($e(arg)))
+        t |> success(r.matched, "bare `sin` should match `math::sin`")
+        if (r.matched) {
+            t |> equal("{arg.__rtti}", "ExprConstFloat")
+        }
+    }
+}
+
+[test]
+def test_qualified_pattern_vs_qualified_call(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(math::sin(1.0))
+        var arg : ExpressionPtr
+        let r = qmatch(expr, math::sin($e(arg)))
+        t |> success(r.matched, "exact qualified name should still match")
+    }
+}
+
+[test]
+def test_wrong_name_fails(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(math::sin(1.0))
+        var arg : ExpressionPtr
+        let r = qmatch(expr, cos($e(arg)))
+        t |> success(!r.matched, "`cos` must not match `math::sin`")
+    }
+}
+
+[test]
+def test_suffix_is_segment_aligned(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(foosin(1.0))
+        var arg : ExpressionPtr
+        let r = qmatch(expr, sin($e(arg)))
+        t |> success(!r.matched, "`sin` must not match `foosin` (not a `::` segment)")
+    }
+}
+
+[test]
+def test_qualified_pattern_requires_exact(t : T?) {
+    ast_gc_guard() {
+        var expr = qmacro(sin(1.0))
+        var arg : ExpressionPtr
+        let r = qmatch(expr, math::sin($e(arg)))
+        t |> success(!r.matched, "qualified pattern must not match a bare call")
+    }
+}

--- a/tests/match/all_matches.das
+++ b/tests/match/all_matches.das
@@ -202,7 +202,7 @@ def dynamic_array_match(A : array<int>) {
 [sideeffects]
 def ascending_array_match(A : int[3]) {
     match (A) {
-        if (fixed_array<int>($v(x), match_expr(x + 1), match_expr(x + 2))) {
+        if (fixed_array<int>($v(x), match_expr(x + 1), match_expr(x + 2))) {  // nolint:STYLE017 (match macro expansion)
             return true
         }
         if (_) {
@@ -235,7 +235,7 @@ def tuple_match(A : tuple<int; float; string>) {
 [sideeffects]
 def or_match(i : int) {
     match (i) {
-        if (1 || 2) {
+        if (1 || 2) {  // nolint:STYLE017 (match macro expansion)
             return true
         }
         if (_) {
@@ -300,6 +300,39 @@ def match_ast_expr_ptr(E : ExpressionPtr) {
         }
         if (_) {
             return "anything"
+        }
+    }
+}
+
+[sideeffects]
+def match_ast_op2_shape(E : ExpressionPtr) {
+    match (E) {
+        if (ExprOp2(op = "+", left = ExprOp2(op = "*", left = $v(a), right = $v(b)), right = $v(c))) {
+            return "mad {a.__rtti} {b.__rtti} {c.__rtti}"
+        }
+        if (ExprOp2(op = "+" || "-", left = $v(l))) {
+            return "addsub {l.__rtti}"
+        }
+        if (ExprSwizzle(mask = "xy", value = $v(v))) {
+            return "swizzle-xy {v.__rtti}"
+        }
+        if (_) {
+            return "other"
+        }
+    }
+}
+
+[sideeffects]
+def match_op_string(o : das_string) {
+    match (o) {
+        if ("+") {
+            return "plus"
+        }
+        if ("-") {
+            return "minus"
+        }
+        if (_) {
+            return "other"
         }
     }
 }
@@ -536,6 +569,44 @@ def test_all_match(t : T?) {
             t |> equal("int 13", match_ast_expr_ptr(ep))
             var fp <- new ExprConstFloat(value = 13.0)
             t |> equal("anything", match_ast_expr_ptr(fp))
+        }
+    }
+    t |> run("match ast op2 shapes") @@(t : T?) {
+        ast_gc_guard() {
+            var a <- new ExprConstInt(value = 1)
+            var b <- new ExprConstInt(value = 2)
+            var mul <- new ExprOp2(op := "*", left = a, right = b)
+            var c <- new ExprConstInt(value = 3)
+            var mad <- new ExprOp2(op := "+", left = mul, right = c)
+            t |> equal("mad ExprConstInt ExprConstInt ExprConstInt", match_ast_op2_shape(mad))
+            var x <- new ExprConstInt(value = 4)
+            var y <- new ExprConstInt(value = 5)
+            var sub <- new ExprOp2(op := "-", left = x, right = y)
+            t |> equal("addsub ExprConstInt", match_ast_op2_shape(sub))
+            var dx <- new ExprConstInt(value = 6)
+            var dy <- new ExprConstInt(value = 7)
+            var dv <- new ExprOp2(op := "/", left = dx, right = dy)
+            t |> equal("other", match_ast_op2_shape(dv))
+            var sv <- new ExprVar(name := "v")
+            var sw <- new ExprSwizzle(value = sv, mask := "xy")
+            t |> equal("swizzle-xy ExprVar", match_ast_op2_shape(sw))
+            var sv2 <- new ExprVar(name := "w")
+            var sw2 <- new ExprSwizzle(value = sv2, mask := "zw")
+            t |> equal("other", match_ast_op2_shape(sw2))
+            // null guard: node arms must fail cleanly on null without an `if (null)` arm
+            t |> equal("other", match_ast_op2_shape(default<ExpressionPtr>))
+        }
+    }
+    t |> run("match das_string scrutinee against string literals") @@(t : T?) {
+        ast_gc_guard() {
+            var l <- new ExprConstInt(value = 1)
+            var r <- new ExprConstInt(value = 2)
+            var plus <- new ExprOp2(op := "+", left = l, right = r)
+            t |> equal("plus", match_op_string(plus.op))
+            var l2 <- new ExprConstInt(value = 3)
+            var r2 <- new ExprConstInt(value = 4)
+            var dv <- new ExprOp2(op := "/", left = l2, right = r2)
+            t |> equal("other", match_op_string(dv.op))
         }
     }
     t |> run("match as is") @@(t : T?) {

--- a/tests/match/all_matches.das
+++ b/tests/match/all_matches.das
@@ -257,6 +257,30 @@ def or_match_v(B : Bar) {
 }
 
 [sideeffects]
+def or_match_prior_capture(ab : AB) {
+    match (ab) {
+        if (AB(a = $v(a), b = 1 || 2)) {
+            return a
+        }
+        if (_) {
+            return -1
+        }
+    }
+}
+
+[sideeffects]
+def or_capture_both_branches(ab : AB) {
+    match (ab) {
+        if (AB(a = $v(a), b = ($v(b) && (b > 5)) || ($v(b) && (b < 5)))) {
+            return a * 100 + b
+        }
+        if (_) {
+            return -1
+        }
+    }
+}
+
+[sideeffects]
 def struct_ptr_match(f : Foo?) {
     match (f) {
         if (null) {
@@ -547,6 +571,13 @@ def test_all_match(t : T?) {
         t |> equal(1., or_match_v(Bar(a = 1, b = 1.)))
         t |> equal(1., or_match_v(Bar(a = 2, b = 1.)))
         t |> equal(0., or_match_v(Bar(a = 3, b = 1.)))
+    }
+    t |> run("or match keeps captures made before it") @@(t : T?) {
+        t |> equal(7, or_match_prior_capture(AB(a = 7, b = 2)))
+        t |> equal(-1, or_match_prior_capture(AB(a = 7, b = 3)))
+        t |> equal(304, or_capture_both_branches(AB(a = 3, b = 4)))
+        t |> equal(309, or_capture_both_branches(AB(a = 3, b = 9)))
+        t |> equal(-1, or_capture_both_branches(AB(a = 3, b = 5)))
     }
     t |> run("struct ptr match") @@(t : T?) {
         t |> equal(-1, struct_ptr_match(null))


### PR DESCRIPTION
Tool fixes ahead of the flatten_opt matcher refactor — `match` already decomposes AST handled-type pointers (`ExprConstInt(value = $v(v))` routes through `match_as_is` via the `isExpression` check), but four gaps made it impractical on real compiler AST, and `qmatch` could not name a resolved call. One commit per module.

## `daslib/match.das` — AST-pointer patterns

* **das_string fields compare against string literals.** `ExprOp2(op = "+")` failed `condition type mismatch $::das_string& vs string const` — both compare arms gated on `is_same_type` before emitting a condition the language compiles fine (`das_string == string` is native). Relaxed via `is_string_like` on both arms. This also unblocks field-position alternation: `ExprOp2(op = "+" || "-")` now works.
* **Null guard on the AST route.** `is` on a null AST pointer panics (`dereferencing null pointer`), and the pointer-to-Expression path emitted no guard — unlike the pointer-to-structure path right below it. Matching a null `ExpressionPtr` against node patterns now fails cleanly to the next arm; an explicit `if (null)` arm is no longer load-bearing.
* **Unconditional tail arm splices directly.** The `_` wildcard expanded to `if (true) { ... }`, which defeats all-paths-return analysis under a fold-free compile (every match-returning function in `tests/match/all_matches.das` failed lint with `error[30310]`) and tripped STYLE010. An unconditional last arm now splices its body as a bare block; aot_cpp's three `// nolint:STYLE010` workarounds drop out.
* **`||` branch diagnostics propagate.** A failing pattern inside `||` returned silent `false`, surfacing as `unspecified match error` at the wrong location (cost three probe iterations to localize a das_string mismatch two levels deep). `match_or` now propagates its branches' error lists, and the no-error fallback names the pattern and scrutinee type.

With these, the construction-syntax form covers real matcher shapes — nested two levels, captures, guards, including nodes `qmatch` patterns cannot spell:

```das
match (e) {
    if (ExprOp2(op = "+", left = ExprOp2(op = "*", left = $v(a), right = $v(b)), right = $v(c))) { ... }
    if (ExprOp2(op = "+" || "-", left = $v(l))) { ... }
    if (ExprSwizzle(mask = "xy", value = $v(v))) { ... }
    if (_) { ... }
}
```

## `daslib/ast_match.das` — qualified call names

A parsed/resolved call carries a module-qualified name (`math::sin`), so a bare pattern name like `sin($e(x))` never matched on inferred AST. `qm_call_name_matches` now also matches an unqualified expected name against the call name's last `::` segment — segment-aligned (`sin` does not match `foosin`), and a qualified pattern name still requires an exact match.

## Tests & docs

* `tests/match/all_matches.das` — nested op2 shapes, das_string field compares + field-position `||`, swizzle mask compare with negative case, null-without-null-arm safety, direct das_string scrutinee.
* `tests/ast_match/test_call_qualified.das` — the four qualified-name behaviors.
* `pattern_matching.rst` gains a "Matching AST Nodes" section (the capability was undocumented); `ast_matching.rst` documents qualified-name matching.

## Validation

* full suites: interp 10838/0 failed, JIT clean-cache 10403/0, AOT (CI form, test_aot rebuilt **through** the modified macro — every test's AOT C++ regenerated via aot_cpp's match blocks) 10166/0
* tests/match 53/53, tests/ast_match 376/376 (ast_match is interp-only by design — runtime qmacro)
* lint (MCP + CI form) 0 issues; aot_cpp lints clean with the stale nolints removed; Sphinx 0 warnings; das2rst clean; dupe check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)