### PR TITLE
Fix grammar rule for module name requirements

### DIFF
--- a/tree-sitter-daslang/grammar.js
+++ b/tree-sitter-daslang/grammar.js
@@ -176,6 +176,7 @@ module.exports = grammar({
 
     require_module_name: $ => seq(
       optional('%'),
+      optional(seq(choice('..', '.'), '/')),
       $.identifier,
       repeat(seq(choice('.', '/'), $.identifier)),
     ),

--- a/tree-sitter-daslang/grammar.js
+++ b/tree-sitter-daslang/grammar.js
@@ -176,7 +176,7 @@ module.exports = grammar({
 
     require_module_name: $ => seq(
       optional('%'),
-      optional(seq(choice('..', '.'), '/')),
+      repeat(seq(choice('..', '.'), '/')),
       $.identifier,
       repeat(seq(choice('.', '/'), $.identifier)),
     ),

--- a/tree-sitter-daslang/src/grammar.json
+++ b/tree-sitter-daslang/src/grammar.json
@@ -323,6 +323,31 @@
           ]
         },
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ".."
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "/"
+              }
+            ]
+          }
+        },
+        {
           "type": "SYMBOL",
           "name": "identifier"
         },

--- a/tree-sitter-daslang/test/corpus/declarations.txt
+++ b/tree-sitter-daslang/test/corpus/declarations.txt
@@ -399,3 +399,26 @@ require ?pugixml pugixml/linq_fold_xml public
     module: (require_module_name
       (identifier)
       (identifier))))
+
+================================================================================
+Require with relative path prefixes
+================================================================================
+
+require ./sibling
+require ../parent_mod
+require ../../foo/bar.das
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (require_declaration
+    module: (require_module_name
+      (identifier)))
+  (require_declaration
+    module: (require_module_name
+      (identifier)))
+  (require_declaration
+    module: (require_module_name
+      (identifier)
+      (identifier)
+      (identifier))))


### PR DESCRIPTION
Support relative path prefixes (./  and ../) in require declarations.