### PR TITLE
class finalizers chain through inheritance like constructors

### DIFF
--- a/doc/source/reference/language/classes.rst
+++ b/doc/source/reference/language/classes.rst
@@ -197,31 +197,49 @@ user-defined ctors on every control-flow path, so the user-ctor path always runs
 parent's invariants. ``new Class()`` (no args) on such a class continues to call the
 field-init synth — it does not run the user ctor.
 
-Inside a derived class's finalizer (``operator delete``), ``delete super.self`` runs the
-parent's finalizer on the current object:
+Finalizers chain through the inheritance hierarchy under the same rules as
+constructors. Inside a derived class's finalizer (``operator delete``),
+``delete super.self`` runs the parent's finalizer on the current object:
 
 .. code-block:: das
 
     class Derived : Base {
         def operator delete {
-            delete super.self       // calls Base's finalizer on self
-            // additional cleanup
+            // derived cleanup first — dtor order, base state still visible
+            delete super.self       // then Base's finalizer on self
         }
     }
 
-The compiler rewrites ``delete super.self`` into ``delete cast<T>(self)``, where ``T``
-is the closest ancestor whose ``finalize`` lookup resolves to a user-defined finalizer.
-For class hierarchies that means walking past intermediate classes that do not define
-their own ``def operator delete``. For struct hierarchies, ``finalize`` resolution honors
-inheritance substitution (a derived struct can be passed where its base is expected), so
-``T`` may be the immediate parent even when only an ancestor defines ``operator delete``.
-``delete super.self`` is only valid inside an ``operator delete`` (or equivalently
-``def finalize``) of a class that has a base with a finalizer; other uses are rejected
-at compile time. The same form also works for struct finalizers declared as free
-functions — see :ref:`Structs <structs>`.
+For classes, the compiler rewrites ``delete super.self`` into ``delete cast<T>(self)``
+where ``T`` is the *immediate* parent. If the parent has no finalizer of its own, the
+compiler generates one that finalizes the parent's own fields and chains up in turn —
+so every level of the hierarchy finalizes its own slice of the object exactly once.
+A user-defined finalizer takes over that slice responsibility for its class: it must
+clean up its class's own fields itself (the generated per-field cleanup is replaced,
+exactly as for non-derived classes).
 
-Base-class finalization is explicit, not automatic: a derived finalizer that omits
-``delete super.self`` will not run any ancestor finalizer.
+When an ancestor has a user-defined finalizer, a derived class finalizer must call
+``delete super.self`` exactly once on every control-flow path. The lint mirrors the
+``super(...)`` constructor rules:
+
+* zero ``delete super.self`` calls on any reachable path → error;
+* two or more calls on any path → error;
+* a call inside a loop body → error (call count is not bounded to one);
+* a hand-written ``delete cast<Ancestor> self`` that skips the immediate parent does
+  NOT count — it would bypass the parent's field-slice cleanup.
+
+A derived class with *no* finalizer of its own inherits finalization automatically:
+its generated finalizer cleans the derived slice and chains to the parent, so deleting
+a ``Derived`` always runs the ancestor's finalizer — no boilerplate forwarding needed.
+
+``delete super.self`` is only valid inside an ``operator delete`` (or equivalently
+``def finalize``) of a class that has a base with a finalizer somewhere in its
+ancestry; other uses are rejected at compile time. The same form also works for struct
+finalizers declared as free functions — see :ref:`Structs <structs>`. For struct
+hierarchies, ``finalize`` resolution honors inheritance substitution (a derived struct
+can be passed where its base is expected), so ``delete super.self`` resolves to the
+closest ancestor with a user-defined finalizer; structs do not chain field slices the
+way classes do.
 
 Alternatively, the parent's method can be called directly using the backtick syntax:
 

--- a/doc/source/reference/language/finalizers.rst
+++ b/doc/source/reference/language/finalizers.rst
@@ -62,6 +62,11 @@ Finalizers obey the following rules:
 
 If a custom ``finalize`` is available, it is called instead of default one.
 
+For derived classes, finalizers chain through the inheritance hierarchy — each level
+finalizes its own fields and runs the parent's finalizer via ``delete super.self``
+(written explicitly in user finalizers, generated automatically otherwise). See
+:ref:`Classes <classes>`.
+
 Pointer finalizers expand to calling ``finalize`` on the dereferenced pointer,
 and then calling the native memory finalizer on the result:
 

--- a/doc/source/reference/language/structs.rst
+++ b/doc/source/reference/language/structs.rst
@@ -240,9 +240,12 @@ the closest ancestor struct whose ``finalize`` lookup resolves to a user-defined
 Because struct ``finalize`` resolution honors inheritance substitution (a derived struct
 can be passed where its base is expected), ``T`` is typically the immediate parent — even
 when only a more distant ancestor defines ``operator delete``. See :ref:`Classes <classes>`
-for the full description of the ``super`` sugar; the behavior is the same except that
-classes lack this substitution and instead skip past empty intermediate classes that
-don't define their own ``operator delete``.
+for the full description of the ``super`` sugar. Classes go further: they chain through
+the immediate parent level by level, finalize each level's own field slice, inherit
+finalizers automatically when a derived class declares none, and lint-enforce the
+``delete super.self`` call in user-defined derived finalizers. None of that applies to
+structs — a struct finalizer that omits ``delete super.self`` silently skips its
+ancestors' finalizers.
 
 .. _structs_alignment:
 

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -290,6 +290,7 @@ namespace das
         bool hasAnyInitializers() const;
         bool hasUserConstructor() const;
         bool hasUserDefaultConstructor() const;
+        bool hasUserFinalizer() const;
         void serialize( AstSerializer & ser );
         void gc_collect ( gc_root * target, gc_root * from );
         uint64_t getOwnSemanticHash(HashBuilder & hb,das_set<Structure *> & dep, das_set<Annotation *> & adep) const;

--- a/include/daScript/ast/ast_generate.h
+++ b/include/daScript/ast/ast_generate.h
@@ -91,6 +91,12 @@ namespace das {
     // user ctor.
     DAS_API Structure * findChainCtorAncestor ( Structure * cls );
 
+    // Finalizer twin of findChainCtorAncestor: closest ancestor with a user-defined
+    // finalizer ("finalize" class method, not generated). Used by the generated
+    // structure finalizer (chain to the parent's finalize) and by the lint
+    // (derived user finalizer must `delete super.self` when this returns non-null).
+    DAS_API Structure * findChainFinalizerAncestor ( Structure * cls );
+
     /*
      def clone(var a:STRUCT_NAME; b:STRUCT_NAME)
         a.f1 := b.f1

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -642,14 +642,6 @@ class AudioSourceDecoderLoop : AudioSourceDecoder {
         ma_decoder_get_cursor_in_pcm_frames(decoder, unsafe(addr(cursor)))
         return cursor
     }
-    def finalize {
-        if (isReady) {
-            ma_decoder_uninit(decoder)
-        }
-        unsafe {
-            delete decoder
-        }
-    }
 }
 
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -342,6 +342,26 @@ namespace das {
         return false;
     }
 
+    // True if this class has a non-generated finalizer method. Class finalizers keep
+    // the plain name "finalize" (parser: ast_structVarDef), so the registry lookup is
+    // by that name with the classParent identity check filtering out other classes'
+    // finalizers and free-function struct finalizers.
+    bool Structure::hasUserFinalizer() const {
+        if ( !module ) return false;
+        uint64_t hName = hash64z("finalize");
+        if ( auto kv = module->functionsByName.find(hName) ) {
+            for ( auto * fn : kv->second ) {
+                if ( !fn->generated && fn->classParent == this ) return true;
+            }
+        }
+        if ( auto kv = module->genericsByName.find(hName) ) {
+            for ( auto * fn : kv->second ) {
+                if ( !fn->generated && fn->classParent == this ) return true;
+            }
+        }
+        return false;
+    }
+
     bool Structure::canCopy(bool tempMatters) const {
         if ( circularGuard ) return true;
         circularGuard = true;

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -300,6 +300,14 @@ namespace das {
         return nullptr;
     }
 
+    Structure * findChainFinalizerAncestor ( Structure * cls ) {
+        if ( !cls || !cls->isClass || !cls->parent ) return nullptr;
+        for ( auto * anc = cls->parent; anc; anc = anc->parent ) {
+            if ( anc->hasUserFinalizer() ) return anc;
+        }
+        return nullptr;
+    }
+
     // return [[t()]] -- or, for a class derived from a parent with a user ctor,
     // emit the let-self / call Parent`Parent(self) / return self chain body.
     FunctionPtr makeConstructor ( Structure * str, bool isPrivate ) {
@@ -529,11 +537,19 @@ namespace das {
         if ( ls->macroInterface ) pFunc->macroFunction = true;
         auto fb = new ExprBlock();
         fb->at = ls->at;
+        // For a class whose ancestry has a user finalizer, chain to the immediate
+        // parent: this finalizer owns only its own slice of the fields (everything
+        // past the parent prefix), then `delete cast<Parent>(__this)` runs the
+        // parent's finalize — the user one, or a generated chain finalizer that
+        // recurses the same way. Derived slice first, parent second (dtor order).
+        Structure * chainParent = ( ls->isClass && findChainFinalizerAncestor(ls) ) ? ls->parent : nullptr;
+        size_t firstOwnField = chainParent ? chainParent->fields.size() : 0;
         // now finalize
         bool needUnsafe = false;
         for ( int stage=0; stage!=2; ++stage ) {
             // stage 0 is iterators, stage 1 is everything else
-            for ( const auto & fl : ls->fields ) {
+            for ( size_t fi=firstOwnField, fis=ls->fields.size(); fi!=fis; ++fi ) {
+                const auto & fl = ls->fields[fi];
                 if ( !fl.type->constant && !fl.capturedConstant && fl.type->needDelete() ) {
                     if ( !fl.doNotDelete && !fl.capturedRef ) {
                         if ( stage==0 && !fl.type->isIterator() ) continue;
@@ -552,6 +568,13 @@ namespace das {
                     }
                 }
             }
+        }
+        if ( chainParent ) {
+            auto chthis = new ExprVar(ls->at, "__this");
+            auto chcast = new ExprCast(ls->at, chthis, new TypeDecl(chainParent));
+            auto chdel = new ExprDelete(ls->at, chcast);
+            chdel->alwaysSafe = true;
+            fb->list.push_back(chdel);
         }
         auto mz = new ExprMemZero(ls->at, "memzero");
         auto lvar = new ExprVar(ls->at, "__this");

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2724,11 +2724,31 @@ namespace das {
                               "", "", expr->at, CompilationError::lookup_super_class);
                         return Visitor::visit(expr);
                     }
-                    // Walk up the inheritance chain to the nearest ancestor with a user-defined
-                    // finalizer (mirrors the super() / super.method() walk-ups). For structs, finalize
-                    // substitution via base type matches at the immediate parent even when only an
-                    // ancestor defines `def operator delete`. For classes there's no such substitution,
-                    // so we must skip empty intermediates and cast to the actual finalizer's class.
+                    // Classes chain through the IMMEDIATE parent: `delete cast<Parent>(self)`
+                    // resolves to the parent's user finalizer, or to a generated chain finalizer
+                    // (generateStructureFinalizer) that cleans the parent's own field slice and
+                    // recurses up — so every level's slice is finalized exactly once. We still
+                    // require SOME ancestor user finalizer; otherwise the chain is dead weight.
+                    if (selfStruct->isClass) {
+                        if (!findChainFinalizerAncestor(selfStruct)) {
+                            error("delete super.self in " + func->name + ": no ancestor of " + selfStruct->name + " defines a finalizer",
+                                  "", "", expr->at, CompilationError::lookup_super_finalizer);
+                            return Visitor::visit(expr);
+                        }
+                        reportAstChanged();
+                        auto selfVar = new ExprVar(expr->at, "self");
+                        auto castT = new TypeDecl(baseStruct);
+                        auto castExpr = new ExprCast(expr->at, selfVar, castT);
+                        auto newDel = new ExprDelete(expr->at, castExpr);
+                        newDel->alwaysSafe = true;
+                        newDel->native = expr->native;
+                        if (expr->sizeexpr)
+                            newDel->sizeexpr = expr->sizeexpr->clone();
+                        return newDel;
+                    }
+                    // Structs: walk up to the nearest ancestor with a user-defined finalizer.
+                    // Struct finalize substitution via base type matches at the immediate parent
+                    // even when only an ancestor defines `def operator delete`.
                     while (baseStruct) {
                         auto baseType = new TypeDecl(Type::tStructure);
                         baseType->structType = baseStruct;

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -133,6 +133,32 @@ namespace das {
     // Closures (ExprMakeBlock) are NOT descended into — a super() inside a defer/lambda
     // is asynchronous and isn't the chain call we're enforcing.
     static const int kSuperUnbounded = INT_MAX;
+    // Matcher for the chain call the CFG count is looking for.
+    // Ctor mode (mangled non-empty): super(...) post-infer is a direct call to
+    // Parent`Parent, possibly _::-qualified.
+    // Finalizer mode (finalizeParent set): `delete super.self` post-infer is
+    // `_::finalize(cast<Parent>(self))` — match the resolved finalize call whose
+    // single argument casts `self` to the immediate parent. A hand-written
+    // `delete cast<Parent>(self)` lowers to the identical AST and counts the same;
+    // a cast to a deeper ancestor does NOT count (it would skip the parent's field
+    // slice now that generated finalizers chain level by level).
+    struct SuperChainMatch {
+        string      mangled;
+        Structure * finalizeParent = nullptr;
+        bool operator() ( ExprCall * call ) const {
+            if ( !mangled.empty() ) {
+                return call->name == mangled || call->name == ("_::" + mangled);
+            }
+            if ( !call->func || call->func->name != "finalize" ) return false;
+            if ( call->arguments.size() != 1 ) return false;
+            auto arg = call->arguments[0];
+            if ( !arg || !arg->rtti_isCast() ) return false;
+            auto cast = static_cast<ExprCast*>(arg);
+            if ( !cast->castType || cast->castType->structType != finalizeParent ) return false;
+            auto sub = cast->subexpr;
+            return sub && sub->rtti_isVar() && static_cast<ExprVar*>(sub)->name == "self";
+        }
+    };
     struct SuperCount {
         bool    fallsThrough;
         int     fallLo, fallHi;
@@ -159,48 +185,48 @@ namespace das {
     // via break/continue/goto (those terminate dead() and erase prefix super counts on
     // the way out, so e.g. `if(x){ super(); break }` would otherwise look super-free).
     // Closures are still skipped (super inside defer/lambda isn't the chain call).
-    bool subtreeHasSuperCall ( const ExpressionPtr & expr, const string & parentMangled ) {
+    bool subtreeHasSuperCall ( const ExpressionPtr & expr, const SuperChainMatch & chainCall ) {
         if ( !expr ) return false;
         if ( expr->rtti_isCall() ) {
             auto call = static_cast<ExprCall*>(expr);
-            if ( call->name == parentMangled || call->name == ("_::" + parentMangled) ) return true;
+            if ( chainCall(call) ) return true;
             if ( call->func && call->func->module && call->func->module->name == "$"
                 && call->func->name == "builtin_try_recover"
                 && call->arguments.size() >= 2
                 && call->arguments[0]->rtti_isMakeBlock() ) {
                 auto mb = static_cast<ExprMakeBlock*>(call->arguments[0]);
-                return subtreeHasSuperCall(mb->block, parentMangled);
+                return subtreeHasSuperCall(mb->block, chainCall);
             }
             return false;
         }
         if ( expr->rtti_isBlock() ) {
             for ( auto & be : static_cast<ExprBlock*>(expr)->list ) {
-                if ( subtreeHasSuperCall(be, parentMangled) ) return true;
+                if ( subtreeHasSuperCall(be, chainCall) ) return true;
             }
             return false;
         }
         if ( expr->rtti_isIfThenElse() ) {
             auto ite = static_cast<ExprIfThenElse*>(expr);
-            return subtreeHasSuperCall(ite->if_true, parentMangled)
-                || subtreeHasSuperCall(ite->if_false, parentMangled);
+            return subtreeHasSuperCall(ite->if_true, chainCall)
+                || subtreeHasSuperCall(ite->if_false, chainCall);
         }
-        if ( expr->rtti_isWith() )   return subtreeHasSuperCall(static_cast<ExprWith*>(expr)->body, parentMangled);
-        if ( expr->rtti_isUnsafe() ) return subtreeHasSuperCall(static_cast<ExprUnsafe*>(expr)->body, parentMangled);
-        if ( expr->rtti_isWhile() )  return subtreeHasSuperCall(static_cast<ExprWhile*>(expr)->body, parentMangled);
-        if ( expr->rtti_isFor() )    return subtreeHasSuperCall(static_cast<ExprFor*>(expr)->body, parentMangled);
+        if ( expr->rtti_isWith() )   return subtreeHasSuperCall(static_cast<ExprWith*>(expr)->body, chainCall);
+        if ( expr->rtti_isUnsafe() ) return subtreeHasSuperCall(static_cast<ExprUnsafe*>(expr)->body, chainCall);
+        if ( expr->rtti_isWhile() )  return subtreeHasSuperCall(static_cast<ExprWhile*>(expr)->body, chainCall);
+        if ( expr->rtti_isFor() )    return subtreeHasSuperCall(static_cast<ExprFor*>(expr)->body, chainCall);
         if ( expr->__rtti && strcmp(expr->__rtti, "ExprTryCatch") == 0 ) {
             // Mirror countSuperCalls: only the try block contributes to chain semantics.
             // The recover block's super (if any) is irrelevant to the chain check.
             auto tc = static_cast<ExprTryCatch*>(expr);
-            return subtreeHasSuperCall(tc->try_block, parentMangled);
+            return subtreeHasSuperCall(tc->try_block, chainCall);
         }
         return false;
     }
-    SuperCount countSuperCalls ( const ExpressionPtr & expr, const string & parentMangled ) {
+    SuperCount countSuperCalls ( const ExpressionPtr & expr, const SuperChainMatch & chainCall ) {
         if ( !expr ) return SuperCount::onlyFall(0, 0);
         if ( expr->rtti_isCall() ) {
             auto call = static_cast<ExprCall*>(expr);
-            if ( call->name == parentMangled || call->name == ("_::" + parentMangled) ) {
+            if ( chainCall(call) ) {
                 return SuperCount::onlyFall(1, 1);
             }
             // JIT-mode rewrite of try/recover: ast_infer_type_op.cpp:1015 emits
@@ -214,7 +240,7 @@ namespace das {
                 && call->arguments.size() >= 2
                 && call->arguments[0]->rtti_isMakeBlock() ) {
                 auto mb = static_cast<ExprMakeBlock*>(call->arguments[0]);
-                return countSuperCalls(mb->block, parentMangled);
+                return countSuperCalls(mb->block, chainCall);
             }
             return SuperCount::onlyFall(0, 0);
         }
@@ -235,7 +261,7 @@ namespace das {
             out.hasExits = false;
             bool fallenThrough = true;
             for ( auto & be : blk->list ) {
-                auto sub = countSuperCalls(be, parentMangled);
+                auto sub = countSuperCalls(be, chainCall);
                 if ( sub.hasExits ) {
                     mergeExit(out, safeAdd(prefix_lo, sub.exitLo), safeAdd(prefix_hi, sub.exitHi));
                 }
@@ -253,9 +279,9 @@ namespace das {
         }
         if ( expr->rtti_isIfThenElse() ) {
             auto ite = static_cast<ExprIfThenElse*>(expr);
-            auto t = countSuperCalls(ite->if_true, parentMangled);
+            auto t = countSuperCalls(ite->if_true, chainCall);
             // Treat absent else as an empty fall-through branch with 0 super calls.
-            SuperCount e = ite->if_false ? countSuperCalls(ite->if_false, parentMangled)
+            SuperCount e = ite->if_false ? countSuperCalls(ite->if_false, chainCall)
                                          : SuperCount::onlyFall(0, 0);
             SuperCount out = SuperCount::dead();
             if ( t.hasExits ) mergeExit(out, t.exitLo, t.exitHi);
@@ -273,23 +299,23 @@ namespace das {
         }
         if ( expr->rtti_isWith() ) {
             auto wth = static_cast<ExprWith*>(expr);
-            return countSuperCalls(wth->body, parentMangled);
+            return countSuperCalls(wth->body, chainCall);
         }
         if ( expr->rtti_isUnsafe() ) {
             auto us = static_cast<ExprUnsafe*>(expr);
-            return countSuperCalls(us->body, parentMangled);
+            return countSuperCalls(us->body, chainCall);
         }
         if ( expr->rtti_isWhile() || expr->rtti_isFor() ) {
             ExpressionPtr body = expr->rtti_isWhile()
                 ? static_cast<ExprWhile*>(expr)->body
                 : static_cast<ExprFor*>(expr)->body;
-            auto inner = countSuperCalls(body, parentMangled);
+            auto inner = countSuperCalls(body, chainCall);
             // Conservatively: loop iterates 0..N times. If body contains ANY super anywhere
             // (including paths that terminate via break/continue, which countSuperCalls
             // collapses to dead()), the loop's fall-through count is unbounded. Inner exits
             // (return) still propagate as function-level exit paths.
             SuperCount out = SuperCount::onlyFall(0, 0);
-            if ( subtreeHasSuperCall(body, parentMangled) ) {
+            if ( subtreeHasSuperCall(body, chainCall) ) {
                 out.fallLo = 0; out.fallHi = kSuperUnbounded;
             }
             if ( inner.hasExits ) mergeExit(out, inner.exitLo, inner.exitHi);
@@ -301,7 +327,7 @@ namespace das {
         // it. ExprTryCatch has no rtti_is* — dispatch via __rtti.
         if ( expr->__rtti && strcmp(expr->__rtti, "ExprTryCatch") == 0 ) {
             auto tc = static_cast<ExprTryCatch*>(expr);
-            return countSuperCalls(tc->try_block, parentMangled);
+            return countSuperCalls(tc->try_block, chainCall);
         }
         return SuperCount::onlyFall(0, 0);
     }
@@ -1044,8 +1070,9 @@ namespace das {
                 && fn->name == fn->classParent->name + "`" + fn->classParent->name ) {
                 Structure * chainAncestor = findChainCtorAncestor(fn->classParent);
                 if ( chainAncestor ) {
-                    string chainMangled = chainAncestor->name + "`" + chainAncestor->name;
-                    auto count = reduceSuperCount(countSuperCalls(fn->body, chainMangled));
+                    SuperChainMatch match;
+                    match.mangled = chainAncestor->name + "`" + chainAncestor->name;
+                    auto count = reduceSuperCount(countSuperCalls(fn->body, match));
                     if ( count.lo == 0 ) {
                         program->error("class constructor " + fn->name + " does not call super(...) on every control-flow path",
                             "", "call super(...) (or super." + chainAncestor->name + "(...)) exactly once per path",
@@ -1055,6 +1082,27 @@ namespace das {
                             "", "super(...) must be called exactly once per control-flow path",
                             fn->at, CompilationError::missing_function_body);
                     }
+                }
+            }
+            // Derived class finalizer: when ANY ancestor has a user-defined finalizer,
+            // every CFG path must `delete super.self` exactly once — same chain
+            // invariant as ctors. An empty intermediate parent is fine: the chain
+            // call resolves to its generated finalizer, which chains up in turn.
+            if ( fn->isClassMethod && fn->classParent && fn->classParent->parent
+                && !fn->generated
+                && fn->name == "finalize"
+                && findChainFinalizerAncestor(fn->classParent) ) {
+                SuperChainMatch match;
+                match.finalizeParent = fn->classParent->parent;
+                auto count = reduceSuperCount(countSuperCalls(fn->body, match));
+                if ( count.lo == 0 ) {
+                    program->error("class finalizer of " + fn->classParent->name + " does not call delete super.self on every control-flow path",
+                        "", "delete super.self exactly once per path",
+                        fn->at, CompilationError::missing_function_body);
+                } else if ( count.hi != count.lo || count.hi > 1 ) {
+                    program->error("class finalizer of " + fn->classParent->name + " calls delete super.self more than once on some path",
+                        "", "delete super.self must be called exactly once per control-flow path",
+                        fn->at, CompilationError::missing_function_body);
                 }
             }
             func = nullptr;

--- a/tests/language/failed_finalize_no_super.das
+++ b/tests/language/failed_finalize_no_super.das
@@ -1,0 +1,24 @@
+// Derived finalizer must call `delete super.self` when an ancestor has a finalizer.
+options gen2
+expect 30308
+
+class Base {
+    def operator delete {
+        feint("base finalizer\n")
+    }
+}
+
+class Derived : Base {
+    def operator delete {
+        // 30308: class finalizer does not call delete super.self on every control-flow path
+        feint("derived finalizer\n")
+    }
+}
+
+[export]
+def main {
+    var d = new Derived()
+    unsafe {
+        delete d
+    }
+}

--- a/tests/language/failed_finalize_super_on_branch.das
+++ b/tests/language/failed_finalize_super_on_branch.das
@@ -1,0 +1,27 @@
+// Derived finalizer must `delete super.self` on every path — one if-branch is not enough.
+options gen2
+expect 30308
+
+class Base {
+    def operator delete {
+        feint("base finalizer\n")
+    }
+}
+
+class Derived : Base {
+    flag : bool = true
+    def operator delete {
+        // 30308: false-branch path has zero delete super.self calls
+        if (flag) {
+            delete super.self
+        }
+    }
+}
+
+[export]
+def main {
+    var d = new Derived()
+    unsafe {
+        delete d
+    }
+}

--- a/tests/language/failed_finalize_super_skips_parent.das
+++ b/tests/language/failed_finalize_super_skips_parent.das
@@ -1,0 +1,29 @@
+// A hand-written delete cast<Ancestor>(self) that SKIPS the immediate parent does not
+// satisfy the chain lint: it would bypass the parent's field-slice cleanup now that
+// generated finalizers chain level by level. Only the immediate parent counts.
+options gen2
+expect 30308
+
+class GrandBase {
+    def operator delete {
+        feint("grand base finalizer\n")
+    }
+}
+
+class MidBase : GrandBase {
+}
+
+class Leaf : MidBase {
+    def operator delete {
+        // 30308: cast skips MidBase — not the chain call
+        delete cast<GrandBase> self
+    }
+}
+
+[export]
+def main {
+    var l = new Leaf()
+    unsafe {
+        delete l
+    }
+}

--- a/tests/language/failed_finalize_super_twice.das
+++ b/tests/language/failed_finalize_super_twice.das
@@ -1,0 +1,25 @@
+// Derived finalizer must `delete super.self` exactly once — duplicate is rejected.
+options gen2
+expect 30308
+
+class Base {
+    def operator delete {
+        feint("base finalizer\n")
+    }
+}
+
+class Derived : Base {
+    def operator delete {
+        // 30308: delete super.self called twice on the single path
+        delete super.self
+        delete super.self
+    }
+}
+
+[export]
+def main {
+    var d = new Derived()
+    unsafe {
+        delete d
+    }
+}

--- a/tests/language/super_finalize.das
+++ b/tests/language/super_finalize.das
@@ -49,6 +49,7 @@ struct StructBase {
     a : int
 }
 
+[unused_argument(self)]
 def operator delete(var self : StructBase) {
     struct_del_base ++
 }
@@ -135,6 +136,58 @@ class MidLeaf : MidEmpty {
     }
 }
 
+// Finalizer inheritance: a derived class with NO finalizer of its own chains to the
+// ancestor's automatically — the generated finalizer cleans the derived slice and
+// runs `delete super.self` on the immediate parent, recursing past empty levels.
+var inh_base = 0
+
+class InhBase {
+    def operator delete {
+        inh_base ++
+    }
+}
+
+class InhDerived : InhBase {
+}
+
+class InhMid : InhBase {
+}
+
+class InhLeaf : InhMid {
+}
+
+// Slice cleanup + ordering: TrB has no finalizer, but its generated chain finalizer
+// still finalizes TrB's own fields (Tracer observes it), in dtor order — derived
+// body first, then each slice on the way up, base finalizer last.
+var fin_order = ""
+
+struct Tracer {
+    id : int
+}
+
+def operator delete(var self : Tracer) {
+    fin_order += "tracer{self.id};"
+}
+
+class TrA {
+    def operator delete {
+        fin_order += "A;"
+    }
+}
+
+class TrB : TrA {
+    tr_b : Tracer = Tracer(id = 2)
+}
+
+class TrC : TrB {
+    tr_c : Tracer = Tracer(id = 3)
+    def operator delete {
+        fin_order += "C;"
+        delete tr_c
+        delete super.self
+    }
+}
+
 // Struct skip-level: SkipStructMid has no finalizer (struct case relies on
 // substitution at the immediate parent — we still verify it works).
 var skip_struct_base = 0
@@ -144,6 +197,7 @@ struct SkipStructBase {
     a : int
 }
 
+[unused_argument(self)]
 def operator delete(var self : SkipStructBase) {
     skip_struct_base ++
 }
@@ -237,5 +291,35 @@ def test_delete_super_self(t : T?) {
         }
         t |> equal(skip_struct_base, 1)
         t |> equal(skip_struct_leaf, 1)
+    }
+}
+
+[test]
+def test_finalizer_inheritance(t : T?) {
+    t |> run("derived class without finalizer inherits the base finalizer") @(t : T?) {
+        inh_base = 0
+        var d = new InhDerived()
+        unsafe {
+            delete d
+        }
+        t |> equal(inh_base, 1)
+    }
+    t |> run("finalizer inheritance chains past an empty intermediate class") @(t : T?) {
+        inh_base = 0
+        var l = new InhLeaf()
+        unsafe {
+            delete l
+        }
+        t |> equal(inh_base, 1)
+    }
+    t |> run("generated chain finalizer cleans the intermediate slice in dtor order") @(t : T?) {
+        fin_order = ""
+        var c = new TrC()
+        unsafe {
+            delete c
+        }
+        // TrC body (logs C, deletes its own tracer), then TrB's generated chain
+        // finalizer (deletes TrB's tracer), then TrA's finalizer.
+        t |> equal(fin_order, "C;tracer3;tracer2;A;")
     }
 }


### PR DESCRIPTION
## Problem

Deleting a derived class instance whose ancestor defines a finalizer never ran that finalizer ([playground repro](https://daslang.io/playground/index.html#z=N4IgZglgNgpgziAXKAtgQwgOwHQBM0KIgDGUBcABAIIXAA6mdALmhYhVkxQLwUCMABgYURFXDDAVImNFAgAvGAAoAlLWGjmrXgFo+GkQF8GxxplLkKAITbVaphgG0YADwAOAewBOTALoNxSXQsVXVGJgA3NC8KACMeCkwYAHdrVQMxGFiAVwBzJViVDOzMODQwGDDRCmZxWCZlQozTavEc-KbMQxBDABoQNGImCAiYJBBgnHwEQyA)):

```das
class A {
    a : int = 10
    def finalize() { a = -1 }
}
class B : A {}
// delete (new B()) — A's finalizer never runs
```

Root cause: every class gets a generated virtual finalizer (`Klass'__finalize`) whose body is `delete self`. For a derived class with no finalizer of its own, that `delete` finds no matching `finalize` (class function matching has no base-type substitution, unlike structs) and falls back to a flat field-cleanup finalizer that never chains to the ancestor.

## Fix — finalizers follow the same chain rules as `super(...)` constructors

- **`generateStructureFinalizer`**: for a class whose ancestry has a user finalizer, the generated finalizer cleans only the class's **own field slice** (past the parent prefix), then runs `delete cast&lt;Parent&gt;(__this)` — derived slice first, parent second (dtor order, parity with other languages). Empty intermediate levels get their own generated chain finalizer lazily, so every level's slice is finalized exactly once.
- **`delete super.self`** in a class finalizer now rewrites to the **immediate parent** instead of walking up to the nearest user finalizer — the walk-up skipped intermediate classes' field slices (`C : B : A` with finalizers on `C`+`A` left `B`'s fields cleaned by nobody). Struct behavior is unchanged (substitution-based resolution, no slice chaining).
- **Lint**: a derived class finalizer must call `delete super.self` **exactly once on every control-flow path** when an ancestor has a user finalizer — mirroring the ctor `super(...)` lint (error 30308), reusing the same CFG machinery via a generalized `SuperChainMatch` matcher. A hand-written `delete cast&lt;DeeperAncestor&gt; self` does **not** count, since it would skip the parent's slice.
- **A derived class with no finalizer inherits finalization automatically** — no boilerplate forwarding.
- New helpers `Structure::hasUserFinalizer()` and `findChainFinalizerAncestor()` mirror their ctor-side twins.

A user-defined finalizer keeps full responsibility for its own class's field slice (the generated per-field cleanup is replaced for that slice — same rule as before for non-derived classes).

## dasAudio fallout (real bug caught by the new lint)

`AudioSourceDecoderLoop` carried a byte-for-byte **copy of its parent's finalizer** — the manual workaround for exactly this missing inheritance. Chaining it now would double-free the `ma_decoder`. Removed; the parent's finalizer now runs via the chain.

## Docs

`classes.rst` (the "explicit, not automatic" paragraph replaced with the chain rules), `structs.rst`, `finalizers.rst`.

## Tests

- `tests/language/super_finalize.das`: +3 tests — inheritance (direct + skip-level), and a slice/ordering observation (`"C;tracer3;tracer2;A;"` — derived body, derived slice, intermediate slice, base finalizer).
- `tests/language/failed_finalize_{no_super,super_on_branch,super_twice,super_skips_parent}.das` — lint fixtures (expect 30308), mirroring the ctor `failed_super_*` set.

## Verification

- Full `tests/` sweep green in **interp** and **AOT** (all 73 registered directories via `test_aot`).
- Lint (`utils/lint`) zero warnings on changed files; `das-fmt --verify` clean; Sphinx clean build, 0 warnings.
- **JIT rides CI** — no LLVM SDK in the local environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)