### PR TITLE
flatten_opt: matcher refactor — qmatch arithmetic shapes, match dispatch ladders (+ ast_match synthesized-op fix)

### DIFF
--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -552,6 +552,14 @@ def private qm_skip_field(rtti_name : string; field_name : string) : bool {
     if (field_name == "func" || field_name == "atEnclosure" || field_name == "stackTop"
         || field_name == "doesNotNeedSp" || field_name == "cmresAlias"
         || field_name == "argumentsFailedToInfer") return true
+    // ExprOp* (and the ExprOp2-derived assignments) inherit ExprCallFunc's call
+    // machinery; their identity is `op` + children. The parser mirrors `op` into
+    // `name`, but macro-SYNTHESIZED nodes (`new ExprOp2(op := "-")`) leave `name`
+    // empty, so comparing it fails every qmatch against macro-built source.
+    if (rtti_name == "ExprOp1" || rtti_name == "ExprOp2" || rtti_name == "ExprOp3"
+            || rtti_name == "ExprCopy" || rtti_name == "ExprMove" || rtti_name == "ExprClone") {
+        if (field_name == "name" || field_name == "arguments") return true
+    }
     // ExprReturn
     return field_name == "returnInBlock"
 }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -14,8 +14,10 @@ module flatten_opt shared private
 
 require daslib/ast
 require daslib/ast_boost
+require daslib/ast_match
 require daslib/templates_boost
 require daslib/macro_boost
+require daslib/match
 require daslib/rtti
 require strings
 
@@ -536,93 +538,100 @@ class private FoldVisitor : AstVisitor {
         // Algebraic identities over the scalar + vector (float/int/uint) family, under fast-math.
         // `*1`/`*-1` return the non-const operand and gate on `same_base_type` (scalar*vector
         // broadcast must not mistype to scalar); `*0` returns a RESULT-typed zero via zero_const_of.
-        if (that.op == "*") {
-            if (is_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return that.left }
-            if (is_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return that.right }
-            if (is_neg_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return negate(that.left) }
-            if (is_neg_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return negate(that.right) }
-            // `*0` changes inf/NaN propagation — float forms are fast-math only (int exact)
-            if (is_zero_const_op(that.right) && !has_sideeffects(that.left) && (!noFastMath || !is_float_valued(that))) {
-                var z = zero_const_of(that._type, that.at)
-                if (z != null) { changed = true; return z }
-            }
-            if (is_zero_const_op(that.left) && !has_sideeffects(that.right) && (!noFastMath || !is_float_valued(that))) {
-                var z = zero_const_of(that._type, that.at)
-                if (z != null) { changed = true; return z }
-            }
-            // ctor-lane kill: a zero lane of a const vector factor zeroes the matching lane of a
-            // full-arity ctor factor IN PLACE — the lane compute dies (DSE) without distributing
-            // the multiply. Same inf/NaN class as scalar `*0` → float forms are fast-math only.
-            if (!noFastMath || !is_float_valued(that)) {
-                if (ctor_lane_kill(that.left, that.right) || ctor_lane_kill(that.right, that.left)) {
+        match (that.op) {
+            if ("*") {
+                if (is_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return that.left }
+                if (is_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return that.right }
+                if (is_neg_one_const_op(that.right) && same_base_type(that, that.left)) { changed = true; return negate(that.left) }
+                if (is_neg_one_const_op(that.left) && same_base_type(that, that.right)) { changed = true; return negate(that.right) }
+                // `*0` changes inf/NaN propagation — float forms are fast-math only (int exact)
+                if (is_zero_const_op(that.right) && !has_sideeffects(that.left) && (!noFastMath || !is_float_valued(that))) {
+                    var z = zero_const_of(that._type, that.at)
+                    if (z != null) { changed = true; return z }
+                }
+                if (is_zero_const_op(that.left) && !has_sideeffects(that.right) && (!noFastMath || !is_float_valued(that))) {
+                    var z = zero_const_of(that._type, that.at)
+                    if (z != null) { changed = true; return z }
+                }
+                // ctor-lane kill: a zero lane of a const vector factor zeroes the matching lane of a
+                // full-arity ctor factor IN PLACE — the lane compute dies (DSE) without distributing
+                // the multiply. Same inf/NaN class as scalar `*0` → float forms are fast-math only.
+                if (!noFastMath || !is_float_valued(that)) {
+                    if (ctor_lane_kill(that.left, that.right) || ctor_lane_kill(that.right, that.left)) {
+                        changed = true
+                        return that
+                    }
+                }
+                // splat collapse: `v * floatN(s) → v * s` (either side) — das vec×scalar is native, the
+                // splat ctor node disappears. Bit-exact (same per-lane product), so never gated.
+                var spm = splat_scalar_arg(that.right)
+                if (spm != null && is_float_vec(expr_bt(that.left))) {
                     changed = true
+                    that.right = spm
+                    return that
+                }
+                spm = splat_scalar_arg(that.left)
+                if (spm != null && is_float_vec(expr_bt(that.right))) {
+                    changed = true
+                    that.left = spm
                     return that
                 }
             }
-            // splat collapse: `v * floatN(s) → v * s` (either side) — das vec×scalar is native, the
-            // splat ctor node disappears. Bit-exact (same per-lane product), so never gated.
-            var spm = splat_scalar_arg(that.right)
-            if (spm != null && is_float_vec(expr_bt(that.left))) {
-                changed = true
-                that.right = spm
-                return that
+            if ("+") {
+                if (is_zero_const_op(that.right)) { changed = true; return that.left }
+                if (is_zero_const_op(that.left)) { changed = true; return that.right }
             }
-            spm = splat_scalar_arg(that.left)
-            if (spm != null && is_float_vec(expr_bt(that.right))) {
-                changed = true
-                that.left = spm
-                return that
-            }
-        } elif (that.op == "+") {
-            if (is_zero_const_op(that.right)) { changed = true; return that.left }
-            if (is_zero_const_op(that.left)) { changed = true; return that.right }
-        } elif (that.op == "-") {
-            if (is_zero_const_op(that.right)) { changed = true; return that.left }
-            if (is_zero_const_op(that.left)) { changed = true; return negate(that.right) }
-            // `x - x → 0` — purity-gated like `*0` (and like it, inf/NaN operands aside:
-            // fast-math charter). Identical describe ⇒ identical purity, so one check.
-            if (describe(that.left) == describe(that.right) && !has_sideeffects(that.left) &&
-                    (!noFastMath || !is_float_valued(that))) {
-                var z = zero_const_of(that._type, that.at)
-                if (z != null) { changed = true; return z }
-            }
-        } elif (that.op == "/") {
-            // `x / C → x * (1/C)` — a mul instead of a div; the reciprocal rounds (fast-math).
-            // Float-family only (int division has no reciprocal); zero lanes keep the div.
-            if (!noFastMath && is_float_valued(that)) {
-                var rec = recip_const(that.right)
-                if (rec != null) {
-                    changed = true
-                    return new ExprOp2(at = that.at, op := "*", left = that.left, right = rec)
+            if ("-") {
+                if (is_zero_const_op(that.right)) { changed = true; return that.left }
+                if (is_zero_const_op(that.left)) { changed = true; return negate(that.right) }
+                // `x - x → 0` — purity-gated like `*0` (and like it, inf/NaN operands aside:
+                // fast-math charter). Identical describe ⇒ identical purity, so one check.
+                if (describe(that.left) == describe(that.right) && !has_sideeffects(that.left) &&
+                        (!noFastMath || !is_float_valued(that))) {
+                    var z = zero_const_of(that._type, that.at)
+                    if (z != null) { changed = true; return z }
                 }
             }
-            // splat collapse for division: `v / floatN(s) → v / s`, `floatN(s) / v → s / v` —
-            // both vec÷scalar forms are native das. Bit-exact, never gated.
-            var spd = splat_scalar_arg(that.right)
-            if (spd != null && is_float_vec(expr_bt(that.left))) {
-                changed = true
-                that.right = spd
-                return that
+            if ("/") {
+                // `x / C → x * (1/C)` — a mul instead of a div; the reciprocal rounds (fast-math).
+                // Float-family only (int division has no reciprocal); zero lanes keep the div.
+                if (!noFastMath && is_float_valued(that)) {
+                    var rec = recip_const(that.right)
+                    if (rec != null) {
+                        changed = true
+                        return new ExprOp2(at = that.at, op := "*", left = that.left, right = rec)
+                    }
+                }
+                // splat collapse for division: `v / floatN(s) → v / s`, `floatN(s) / v → s / v` —
+                // both vec÷scalar forms are native das. Bit-exact, never gated.
+                var spd = splat_scalar_arg(that.right)
+                if (spd != null && is_float_vec(expr_bt(that.left))) {
+                    changed = true
+                    that.right = spd
+                    return that
+                }
+                spd = splat_scalar_arg(that.left)
+                if (spd != null && is_float_vec(expr_bt(that.right))) {
+                    changed = true
+                    that.left = spd
+                    return that
+                }
             }
-            spd = splat_scalar_arg(that.left)
-            if (spd != null && is_float_vec(expr_bt(that.right))) {
-                changed = true
-                that.left = spd
-                return that
+            if ("&&") {
+                // Short-circuit `&&`: `false && x` never evaluates x, so dropping x is
+                // safe; `x && false` DOES evaluate x, so that drop is gated on purity.
+                if (is_bool_val(that.left, true)) { changed = true; return that.right }
+                if (is_bool_val(that.right, true)) { changed = true; return that.left }
+                if (is_bool_val(that.left, false)) { changed = true; return that.left }
+                if (is_bool_val(that.right, false) && !has_sideeffects(that.left)) { changed = true; return that.right }
             }
-        } elif (that.op == "&&") {
-            // Short-circuit `&&`: `false && x` never evaluates x, so dropping x is
-            // safe; `x && false` DOES evaluate x, so that drop is gated on purity.
-            if (is_bool_val(that.left, true)) { changed = true; return that.right }
-            if (is_bool_val(that.right, true)) { changed = true; return that.left }
-            if (is_bool_val(that.left, false)) { changed = true; return that.left }
-            if (is_bool_val(that.right, false) && !has_sideeffects(that.left)) { changed = true; return that.right }
-        } elif (that.op == "||") {
-            // Mirror of `&&`: `true || x` never evaluates x; `x || true` does.
-            if (is_bool_val(that.left, false)) { changed = true; return that.right }
-            if (is_bool_val(that.right, false)) { changed = true; return that.left }
-            if (is_bool_val(that.left, true)) { changed = true; return that.left }
-            if (is_bool_val(that.right, true) && !has_sideeffects(that.left)) { changed = true; return that.right }
+            if ("||") {
+                // Mirror of `&&`: `true || x` never evaluates x; `x || true` does.
+                if (is_bool_val(that.left, false)) { changed = true; return that.right }
+                if (is_bool_val(that.right, false)) { changed = true; return that.left }
+                if (is_bool_val(that.left, true)) { changed = true; return that.left }
+                if (is_bool_val(that.right, true) && !has_sideeffects(that.left)) { changed = true; return that.right }
+            }
         }
         return that
     }
@@ -683,7 +692,7 @@ class private FoldVisitor : AstVisitor {
                 var aArg = that.arguments[0]
                 var bArg = that.arguments[1]
                 var tArg = that.arguments[2]
-                // const-selector short-circuits — no expand/refuse round trip. They DROP an
+                // const-selector short-circuits — no expand/re-fuse round trip. They DROP an
                 // argument (`(b-a)*0` would still propagate b's inf/NaN) → fast-math only.
                 if (!noFastMath) {
                     if (is_zero_const_op(tArg) && !has_sideeffects(bArg)) { changed = true; return aArg }
@@ -853,26 +862,27 @@ def private negate(var e : ExpressionPtr) : ExpressionPtr {
 // Keying on the result type lets both `v * 0.0` and `v * float3(0)` fold width-matched.
 def public zero_const_of(t : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
     if (t == null) return null
-    let bt = t.baseType
-    if (bt == Type.tInt) return new ExprConstInt(at = at, value = 0)
-    if (bt == Type.tInt8) return new ExprConstInt8(at = at, value = int8(0))
-    if (bt == Type.tInt16) return new ExprConstInt16(at = at, value = int16(0))
-    if (bt == Type.tInt64) return new ExprConstInt64(at = at, value = 0l)
-    if (bt == Type.tUInt) return new ExprConstUInt(at = at, value = 0u)
-    if (bt == Type.tUInt8) return new ExprConstUInt8(at = at, value = uint8(0))
-    if (bt == Type.tUInt16) return new ExprConstUInt16(at = at, value = uint16(0))
-    if (bt == Type.tUInt64) return new ExprConstUInt64(at = at, value = 0ul)
-    if (bt == Type.tFloat) return new ExprConstFloat(at = at, value = 0.0f)
-    if (bt == Type.tDouble) return new ExprConstDouble(at = at, value = 0.0lf)
-    if (bt == Type.tFloat2) return new ExprConstFloat2(at = at, value = float2(0.0))
-    if (bt == Type.tFloat3) return new ExprConstFloat3(at = at, value = float3(0.0))
-    if (bt == Type.tFloat4) return new ExprConstFloat4(at = at, value = float4(0.0))
-    if (bt == Type.tInt2) return new ExprConstInt2(at = at, value = int2(0))
-    if (bt == Type.tInt3) return new ExprConstInt3(at = at, value = int3(0))
-    if (bt == Type.tInt4) return new ExprConstInt4(at = at, value = int4(0))
-    if (bt == Type.tUInt2) return new ExprConstUInt2(at = at, value = uint2(0u))
-    if (bt == Type.tUInt3) return new ExprConstUInt3(at = at, value = uint3(0u))
-    if (bt == Type.tUInt4) return new ExprConstUInt4(at = at, value = uint4(0u))
+    match (t.baseType) {
+        if (Type.tInt) { return new ExprConstInt(at = at, value = 0) }
+        if (Type.tInt8) { return new ExprConstInt8(at = at, value = int8(0)) }
+        if (Type.tInt16) { return new ExprConstInt16(at = at, value = int16(0)) }
+        if (Type.tInt64) { return new ExprConstInt64(at = at, value = 0l) }
+        if (Type.tUInt) { return new ExprConstUInt(at = at, value = 0u) }
+        if (Type.tUInt8) { return new ExprConstUInt8(at = at, value = uint8(0)) }
+        if (Type.tUInt16) { return new ExprConstUInt16(at = at, value = uint16(0)) }
+        if (Type.tUInt64) { return new ExprConstUInt64(at = at, value = 0ul) }
+        if (Type.tFloat) { return new ExprConstFloat(at = at, value = 0.0f) }
+        if (Type.tDouble) { return new ExprConstDouble(at = at, value = 0.0lf) }
+        if (Type.tFloat2) { return new ExprConstFloat2(at = at, value = float2(0.0)) }
+        if (Type.tFloat3) { return new ExprConstFloat3(at = at, value = float3(0.0)) }
+        if (Type.tFloat4) { return new ExprConstFloat4(at = at, value = float4(0.0)) }
+        if (Type.tInt2) { return new ExprConstInt2(at = at, value = int2(0)) }
+        if (Type.tInt3) { return new ExprConstInt3(at = at, value = int3(0)) }
+        if (Type.tInt4) { return new ExprConstInt4(at = at, value = int4(0)) }
+        if (Type.tUInt2) { return new ExprConstUInt2(at = at, value = uint2(0u)) }
+        if (Type.tUInt3) { return new ExprConstUInt3(at = at, value = uint3(0u)) }
+        if (Type.tUInt4) { return new ExprConstUInt4(at = at, value = uint4(0u)) }
+    }
     return null
 }
 
@@ -2530,24 +2540,20 @@ def private fuse_callable(mod : Module?; fname : string) : bool {
 // residual; no purity gate — flat-body calls are pure by contract (and has_sideeffects is timing-dependent).
 def private match_mad(var that : ExprOp2?; var ma, mb, mc : ExpressionPtr&) : bool {
     if (that == null) return false
-    var mul : ExprOp2?
-    var other : ExpressionPtr
+    var fa, fb, other : ExpressionPtr
     var negOther = false        // `m - C`  → c = -C
     var negFactor = false       // `C - m`  → negate a const factor of m
-    if (that.op == "+" || that.op == "-") {
-        if (that.left is ExprOp2 && (that.left as ExprOp2).op == "*") {
-            mul = that.left as ExprOp2
-            other = that.right
-            negOther = that.op == "-"
-        } elif (that.right is ExprOp2 && (that.right as ExprOp2).op == "*") {
-            mul = that.right as ExprOp2
-            other = that.left
-            negFactor = that.op == "-"
-        }
+    if (qmatch(that, $e(fa) * $e(fb) + $e(other)).matched) {
+        pass
+    } elif (qmatch(that, $e(other) + $e(fa) * $e(fb)).matched) {
+        pass
+    } elif (qmatch(that, $e(fa) * $e(fb) - $e(other)).matched) {
+        negOther = true
+    } elif (qmatch(that, $e(other) - $e(fa) * $e(fb)).matched) {
+        negFactor = true
+    } else {
+        return false
     }
-    if (mul == null) return false
-    var fa = mul.left
-    var fb = mul.right
     // types captured BEFORE negation — a fresh negated literal is untyped until re-infer
     var bta = expr_bt(fa)
     var btb = expr_bt(fb)
@@ -2586,46 +2592,25 @@ def private match_mad(var that : ExprOp2?; var ma, mb, mc : ExpressionPtr&) : bo
 // the form (positives-first canonical order), so this catches the other producers — the `0 - x`
 // and `*-1` fold arms. Shared by fuser AND residual.
 def private match_neg_add(var that : ExprOp2?; var pos, neg : ExpressionPtr&) : bool {
-    if (that == null || that.op != "+" || !is_mad_elem(expr_bt(that))) return false
-    if (that.left is ExprOp1 && (that.left as ExprOp1).op == "-") {
-        pos = that.right
-        neg = (that.left as ExprOp1).subexpr
-        return true
-    }
-    if (that.right is ExprOp1 && (that.right as ExprOp1).op == "-") {
-        pos = that.left
-        neg = (that.right as ExprOp1).subexpr
-        return true
-    }
-    return false
+    if (that == null || !is_mad_elem(expr_bt(that))) return false
+    return (qmatch(that, -$e(neg) + $e(pos)).matched ||    // nolint:STYLE016 (qmatch macro expansion)
+        qmatch(that, $e(pos) + -$e(neg)).matched)           // nolint:STYLE016 (qmatch macro expansion)
 }
 
 // `mad(b - a, t, a)` → `lerp(a, b, t)`: the re-packed expansion shape, `a` matched by
 // describe-equality. The neg-add form is matched too (defense — reassoc no longer emits it).
 // Deliberately misses a CSE-shared `b - a` (behind a `_cse_` var — keeping the share IS the win).
 def private match_lerp(var cll : ExprCall?; var la, lb, lt : ExpressionPtr&) : bool {
-    if (cll == null || length(cll.arguments) != 3 ||
-        psh_simple_name("{cll.name}") != "mad" || !(cll.arguments[0] is ExprOp2)) return false
-    var diff = cll.arguments[0] as ExprOp2
-    var db : ExpressionPtr      // b — the minuend
-    var da : ExpressionPtr      // a — the subtrahend
-    if (diff.op == "-") {
-        db = diff.left
-        da = diff.right
-    } elif (diff.op == "+") {
-        if (diff.left is ExprOp1 && (diff.left as ExprOp1).op == "-") {
-            da = (diff.left as ExprOp1).subexpr
-            db = diff.right
-        } elif (diff.right is ExprOp1 && (diff.right as ExprOp1).op == "-") {
-            da = (diff.right as ExprOp1).subexpr
-            db = diff.left
-        }
-    }
-    if (da == null || describe(da) != describe(cll.arguments[2]) ||
-        !lerp_shape(expr_bt(da), expr_bt(db), expr_bt(cll.arguments[1]))) return false
-    la = cll.arguments[2]
+    if (cll == null) return false
+    var da, db, aa, tt : ExpressionPtr
+    if (!qmatch(cll, mad($e(db) - $e(da), $e(tt), $e(aa))).matched &&     // nolint:STYLE016 (qmatch macro expansion)
+        !qmatch(cll, mad(-$e(da) + $e(db), $e(tt), $e(aa))).matched &&    // nolint:STYLE016 (qmatch macro expansion)
+        !qmatch(cll, mad($e(db) + -$e(da), $e(tt), $e(aa))).matched) return false  // nolint:STYLE016 (qmatch macro expansion)
+    if (describe(da) != describe(aa) ||
+        !lerp_shape(expr_bt(da), expr_bt(db), expr_bt(tt))) return false
+    la = aa
     lb = db
-    lt = cll.arguments[1]
+    lt = tt
     return true
 }
 
@@ -2657,18 +2642,18 @@ def private component_read_of(var e : ExpressionPtr; var baseKey : string&; var 
     if (e is ExprRef2Value) return component_read_of((e as ExprRef2Value).subexpr, baseKey, base, comp)
     var v : ExpressionPtr
     var nm = ""
-    if (e is ExprSwizzle) {
-        var sw = e as ExprSwizzle
-        nm = "{sw.mask}"
-        v = sw.value
-    } elif (e is ExprField) {
-        var fl = e as ExprField
-        nm = "{fl.name}"
-        v = fl.value
-    } else {
-        return false
+    match (e) {
+        if (ExprSwizzle(mask = $v(swMask), value = $v(swValue))) {
+            nm = "{swMask}"
+            v = swValue
+        }
+        if (ExprField(name = $v(flName), value = $v(flValue))) {
+            nm = "{flName}"
+            v = flValue
+        }
     }
-    if ((nm != "x" && nm != "y" && nm != "z" && nm != "w") ||
+    if (v == null ||
+        (nm != "x" && nm != "y" && nm != "z" && nm != "w") ||
         !is_float_vec(expr_bt(v)) || expr_bt(e) != Type.tFloat) return false
     base = v
     baseKey = describe(v)

--- a/tests/ast_match/test_synthesized_op.das
+++ b/tests/ast_match/test_synthesized_op.das
@@ -1,0 +1,68 @@
+options gen2
+options indenting = 4
+options rtti
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_match
+require daslib/ast_boost
+require daslib/templates_boost
+require dastest/testing_boost public
+
+// ── macro-synthesized op nodes ──────────────────────────────────────────
+// ExprOp* inherit ExprCallFunc; the parser mirrors `op` into `name`, but a
+// macro-built node (`new ExprOp2(op := "-")`) leaves `name` empty. Matching
+// keys on `op` + children only — the call-machinery fields are skipped.
+
+[test]
+def test_synthesized_op2_matches(t : T?) {
+    ast_gc_guard() {
+        var e : ExpressionPtr = new ExprOp2(at = LineInfo(), op := "-", left = qmacro(p), right = qmacro(q))
+        var x, y : ExpressionPtr
+        let r = qmatch(e, $e(x) - $e(y))
+        t |> success(r.matched, "pattern must match a synthesized ExprOp2 (empty `name`)")
+        if (r.matched) {
+            t |> equal(describe(x), "p")
+            t |> equal(describe(y), "q")
+        }
+    }
+}
+
+[test]
+def test_synthesized_op2_wrong_op_fails(t : T?) {
+    ast_gc_guard() {
+        var e : ExpressionPtr = new ExprOp2(at = LineInfo(), op := "+", left = qmacro(p), right = qmacro(q))
+        var x, y : ExpressionPtr
+        let r = qmatch(e, $e(x) - $e(y))
+        t |> success(!r.matched, "`+` node must not match a `-` pattern")
+    }
+}
+
+[test]
+def test_synthesized_op1_matches(t : T?) {
+    ast_gc_guard() {
+        var e : ExpressionPtr = new ExprOp1(at = LineInfo(), op := "-", subexpr = qmacro(p))
+        var x : ExpressionPtr
+        let r = qmatch(e, -$e(x))
+        t |> success(r.matched, "pattern must match a synthesized ExprOp1 (empty `name`)")
+        if (r.matched) {
+            t |> equal(describe(x), "p")
+        }
+    }
+}
+
+[test]
+def test_synthesized_nested_matches(t : T?) {
+    ast_gc_guard() {
+        // the flatten re-fuse shape: synthesized mul under synthesized add
+        var mul : ExpressionPtr = new ExprOp2(at = LineInfo(), op := "*", left = qmacro(a), right = qmacro(b))
+        var e : ExpressionPtr = new ExprOp2(at = LineInfo(), op := "+", left = mul, right = qmacro(c))
+        var fa, fb, fc : ExpressionPtr
+        let r = qmatch(e, $e(fa) * $e(fb) + $e(fc))
+        t |> success(r.matched, "nested synthesized op2 shape must match")
+        if (r.matched) {
+            t |> equal(describe(fa), "a")
+            t |> equal(describe(fc), "c")
+        }
+    }
+}

--- a/tests/flatten/test_flatten_nofastmath.das
+++ b/tests/flatten/test_flatten_nofastmath.das
@@ -16,7 +16,8 @@ require math
 //! must still run; the int twins prove the integer folds (exact) still fire. The
 //! structural FIRED/SKIPPED half lives in tests/flatten/no_aot/test_flatten_fold.das,
 //! which compiles this file as a unit and asserts the gated shapes SURVIVE in the
-//! twins while the option-aware oracle (`flatten_fold_residuals(func, false)`) stays clean.
+//! twins while the option-aware oracle (`flatten_fold_residuals` called with the unit's
+//! detected `_flatten_no_fast_math` flag) stays clean.
 
 var G_NF = 2.5
 


### PR DESCRIPTION
Follow-up to #3082 — the flatten_opt matcher refactor those tool fixes unblocked, per the agreed division of labor: **qmatch** for surface-syntax arithmetic shapes, **match** for kind-dispatch ladders and construction-syntax structure, predicates stay plain functions.

## flatten_opt conversions

- `match_mad` / `match_neg_add` / `match_lerp` shape detection is now qmatch patterns (`$e(fa) * $e(fb) + $e(other)`, `-$e(neg) + $e(pos)`, `mad($e(db) - $e(da), $e(tt), $e(aa))` &amp; friends). The negation/vec-scalar-swap/type-gate logic is unchanged; only the hand-rolled `is ExprOp2 / as / .op ==` ladders became patterns. Captures are clones (qmatch semantics) — safe here because the fuse pass replaces the node and re-infers.
- `zero_const_of` Type-enum ladder and the FoldVisitor op dispatch are now `match (...)` (à la aot_cpp `das_to_cppString`); `component_read_of` uses match-on-AST patterns for `ExprSwizzle`/`ExprField` (the #3082 capability).
- Note: `match_lerp`'s name gate moved from `psh_simple_name` (backtick-mangle extraction) to qmatch's `qm_call_name_matches` — a strict superset (also matches module-qualified `mad`). Fuser and residual oracle share the matcher, so they stay in sync.
- Also folds in the two nits deferred from #3081: the nofastmath meta-test docstring now says the oracle gets the unit's detected `_flatten_no_fast_math` flag (not a hardcoded `false`), and the "expand/refuse" → "expand/re-fuse" typo.

## ast_match bug found by the refactor (fixed test-first)

`ExprOp1/2/3` (and the `ExprOp2`-derived assignments) inherit `ExprCallFunc` in C++, so qmatch's generic field walk compared their `name` field. The parser mirrors `op` into `name`, but **macro-synthesized nodes (`new ExprOp2(op := "-")`) leave `name` empty** — so every qmatch against macro-built AST silently failed. Both the fuser and the residual oracle share `match_mad`, so the fast-math corpus stayed green while broken; only the nofastmath positive round-trip assert (`lerp(a,b,0)` must come back as `lerp`) caught it. Fix: `qm_skip_field` skips `name`/`arguments` on the op rttis (identity of an op node is `op` + children). Regression tests in `tests/ast_match/test_synthesized_op.das` (verified failing without the fix: 3/4).

## Validation

- interp 10837/0, JIT clean-cache 10398/0, AOT 10161/0 with `test_aot` rebuilt through the modified macros
- **all 88 `examples/flatten` shader dumps byte-identical to master** (opcode graphs + flattened source); capability checks 18/18
- flatten-fuzz: 40 int batches (`--strict-fold`) + 40 bool batches all pass; strict residual counts identical to master on the same seeds
- MCP + CI-form lint clean; scoped detect-dupe clean

Compile-time: requiring `daslib/match` + `daslib/ast_match` adds ~110 ms to a cold `require daslib/flatten` (module compiles + expansions). Per-process one-time cost — both are `shared` modules, so in a multi-shader compile process everything past the first shader pays nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)