### PR TITLE
das_source_formatter: recognize $name<types>(args) type-macro form

### DIFF
--- a/benchmarks/core/hash/test02.das
+++ b/benchmarks/core/hash/test02.das
@@ -11,11 +11,11 @@ require dastest/testing_boost
 require daslib/flat_hash_table
 require daslib/cuckoo_hash_table
 
-typedef CuckooHashMap_test = $TCuckooHashTable < int; int >
-typedef CuckooHashMap_test_inline = $TCuckooHashTable < int; int > (@@hash0, @@hash_inline)
-typedef FlatHashMap_test = $TFlatHashTable < int; int >
-typedef FlatHashMap_test_inline = $TFlatHashTable < int; int > (@@hash_inline)
-typedef FlatHashMap_test0 = $TFlatHashTable < int; int > (@@hash0)
+typedef CuckooHashMap_test = $TCuckooHashTable<int; int>
+typedef CuckooHashMap_test_inline = $TCuckooHashTable<int; int>(@@hash0, @@hash_inline)
+typedef FlatHashMap_test = $TFlatHashTable<int; int>
+typedef FlatHashMap_test_inline = $TFlatHashTable<int; int>(@@hash_inline)
+typedef FlatHashMap_test0 = $TFlatHashTable<int; int>(@@hash0)
 
 [sideeffects]
 def read_map(b : B?; hmap : auto(HashMapType)) {

--- a/benchmarks/core/hash/test11.das
+++ b/benchmarks/core/hash/test11.das
@@ -14,16 +14,16 @@ require daslib/flat_hash_table
 require daslib/cuckoo_hash_table
 require _slot_map
 
-typedef CuckooHashMap_uint64_int = $TCuckooHashTable < uint64, int >
-typedef FlatHashMap_uint64_int = $TFlatHashTable < uint64, int >
-typedef FlatHashMap0_uint64_int = $TFlatHashTable < uint64, int > (@@hash0)
+typedef CuckooHashMap_uint64_int = $TCuckooHashTable<uint64, int>
+typedef FlatHashMap_uint64_int = $TFlatHashTable<uint64, int>
+typedef FlatHashMap0_uint64_int = $TFlatHashTable<uint64, int>(@@hash0)
 
 typedef SlotTable = table<uint64; int>
 
-typedef SlotMapAdapter_Table = $SlotMap < SlotTable >
-typedef SlotMapAdapter_CuckooHashMap = $SlotMap < CuckooHashMap_uint64_int >
-typedef SlotMapAdapter_FlatHashMap = $SlotMap < FlatHashMap_uint64_int >
-typedef SlotMapAdapter_FlatHashMap0 = $SlotMap < FlatHashMap0_uint64_int >
+typedef SlotMapAdapter_Table = $SlotMap<SlotTable>
+typedef SlotMapAdapter_CuckooHashMap = $SlotMap<CuckooHashMap_uint64_int>
+typedef SlotMapAdapter_FlatHashMap = $SlotMap<FlatHashMap_uint64_int>
+typedef SlotMapAdapter_FlatHashMap0 = $SlotMap<FlatHashMap0_uint64_int>
 
 [sideeffects]
 def fill_slotmap(smap : auto(SlotMapType); randomNumbers : array<int>) {

--- a/benchmarks/core/hash/test12.das
+++ b/benchmarks/core/hash/test12.das
@@ -16,9 +16,9 @@ require _common
 require daslib/flat_hash_table
 require daslib/cuckoo_hash_table
 
-typedef CuckooHashMap_test = $TCuckooHashTable < int; int >
-typedef FlatHashMap_test = $TFlatHashTable < int; int >
-typedef PathalogicalFlatHashMap_test = $TFlatHashTable < int; int > (@@pathalogical)
+typedef CuckooHashMap_test = $TCuckooHashTable<int; int>
+typedef FlatHashMap_test = $TFlatHashTable<int; int>
+typedef PathalogicalFlatHashMap_test = $TFlatHashTable<int; int>(@@pathalogical)
 
 let PATHO_TOTAL = 100000
 let PATHO_SEQUENTIAL = 8192

--- a/daslib/cuckoo_hash_table.das
+++ b/daslib/cuckoo_hash_table.das
@@ -20,7 +20,7 @@ require strings public
 
 def public hash0(data) {
     //! this hash function converts and workhorse key to a 64 bit hash
-    let k64 = uint64(data)
+    let k64 = uint64(data)  // nolint:PERF020 — generic over key types; cast is identity only for uint64 keys
     return k64 <= 2ul ? 0x9e3779b97f4a7c15ul : k64
 }
 
@@ -131,7 +131,7 @@ struct template TCuckooHashTable {
         let firstHash = $c(hashFunction0Name)(key)
         var index = int(firstHash) & mask
         if (khv[index].hash == firstHash && khv[index].key == key) return index
-        var secondHash = $c(hashFunction1Name)(key)
+        let secondHash = $c(hashFunction1Name)(key)
         index = int(secondHash) & mask
         if (khv[index].hash == secondHash && khv[index].key == key) return index
         return -1
@@ -246,9 +246,9 @@ struct template TCuckooHashTable {
         var key := _key
         var value := _value
         while (true) {
-            for (i in range(length(khv) / 2)) {
-                var firstHash = $c(hashFunction0Name)(key)
-                var firstIndex = int(firstHash) & mask
+            for (_i in range(length(khv) / 2)) {
+                let firstHash = $c(hashFunction0Name)(key)
+                let firstIndex = int(firstHash) & mask
                 if (khv[firstIndex].hash == 0ul) {
                     khv[firstIndex].hash = firstHash
                     khv[firstIndex].key <- key
@@ -256,8 +256,8 @@ struct template TCuckooHashTable {
                     data_length ++
                     return
                 }
-                var secondHash = $c(hashFunction1Name)(key)
-                var secondIndex = int(secondHash) & mask
+                let secondHash = $c(hashFunction1Name)(key)
+                let secondIndex = int(secondHash) & mask
                 if (khv[secondIndex].hash == 0ul) {
                     khv[secondIndex].hash = secondHash
                     khv[secondIndex].key <- key
@@ -302,15 +302,15 @@ struct template TCuckooHashTable {
             self |> grow()
         }
         // if its already there
-        var firstHash = $c(hashFunction0Name)(key)
-        var firstIndex = int(firstHash) & mask
+        let firstHash = $c(hashFunction0Name)(key)
+        let firstIndex = int(firstHash) & mask
         if (khv[firstIndex].hash == firstHash && khv[firstIndex].key == key) {
             unsafe {
                 return khv[firstIndex].value
             }
         }
-        var secondHash = $c(hashFunction1Name)(key)
-        var secondIndex = int(secondHash) & mask
+        let secondHash = $c(hashFunction1Name)(key)
+        let secondIndex = int(secondHash) & mask
         if (khv[secondIndex].hash == secondHash && khv[secondIndex].key == key) {
             unsafe {
                 return khv[secondIndex].value

--- a/daslib/das_source_formatter.das
+++ b/daslib/das_source_formatter.das
@@ -477,6 +477,10 @@ def mark_tokens_as_type(var ctx : FormatterCtx; i : int) {
             pos++;
         }
     } else {
+        // '$' prefix of the $name(args) / $name<types>(args) type-macro form
+        if (ctx |> eq(pos, "$") && pos + 1 < length(ctx.tokens) && ctx.tokens[pos + 1].tokenType == TokenType.KEYWORD_OR_IDENTIFIER) {
+            pos++
+        }
         // 'ident :: ident ...'
         while (pos < length(ctx.tokens)) {
             if (ctx |> new_line_before(pos)) break;

--- a/daslib/option.das
+++ b/daslib/option.das
@@ -37,7 +37,7 @@ struct template Option {
 //! For non-copyable ``T`` the payload is cloned; if you want to move out of a
 //! mutable source, use ``move_some`` instead.
 def some(v : auto(TT)) {
-    typedef OT = $Option < TT - const >
+    typedef OT = $Option<TT -const>
     var o = default<OT>
     o._has_value = true
     static_if (typeinfo can_copy(o._value)) {
@@ -67,17 +67,17 @@ def none(t : auto(TT)) {
 }
 
 //! ``true`` iff the option carries a value.
-def is_some(o : $Option < auto(TT) >) : bool {
+def is_some(o : $Option<auto(TT)>) : bool {
     return o._has_value
 }
 
 //! ``true`` iff the option is empty.
-def is_none(o : $Option < auto(TT) >) : bool {
+def is_none(o : $Option<auto(TT)>) : bool {
     return !o._has_value
 }
 
 //! Apply ``f`` to the payload, producing ``Option<U>``. ``none`` stays ``none``.
-def map(o : $Option < auto(TT) >; f : block<(v : TT) : auto(UU)>) {
+def map(o : $Option<auto(TT)>; f : block<(v : TT) : auto(UU)>) {
     var r = default<$Option<UU -const> >
     if (o._has_value) {
         r._has_value = true
@@ -91,13 +91,13 @@ def map(o : $Option < auto(TT) >; f : block<(v : TT) : auto(UU)>) {
 }
 
 //! Monadic bind — ``f`` returns the next ``Option``; chains only when ``some``.
-def and_then(o : $Option < auto(TT) >; f : block<(v : TT) : $Option<auto(UU)> >) {
+def and_then(o : $Option<auto(TT)>; f : block<(v : TT) : $Option<auto(UU)> >) {
     if (o._has_value) return invoke(f, o._value)
     return default<$Option<UU -const> >
 }
 
 //! Keep the payload only if ``p`` holds; otherwise turn ``some`` into ``none``.
-def filter(o : $Option < auto(TT) >; p : block<(v : TT) : bool>) {
+def filter(o : $Option<auto(TT)>; p : block<(v : TT) : bool>) {
     if (o._has_value && invoke(p, o._value)) {
         static_if (typeinfo can_copy(o._value)) {
             return o
@@ -109,7 +109,7 @@ def filter(o : $Option < auto(TT) >; p : block<(v : TT) : bool>) {
 }
 
 //! Fallback to ``f()`` when ``none``; ``some`` passes through unchanged.
-def or_else(o : $Option < auto(TT) >; f : block<() : $Option<TT> >) {
+def or_else(o : $Option<auto(TT)>; f : block<() : $Option<TT> >) {
     if (o._has_value) {
         static_if (typeinfo can_copy(o._value)) {
             return o
@@ -121,7 +121,7 @@ def or_else(o : $Option < auto(TT) >; f : block<() : $Option<TT> >) {
 }
 
 //! Fallback to eager ``v`` when ``none``; ``some`` passes through unchanged.
-def or_value(o : $Option < auto(TT) >; v : TT) {
+def or_value(o : $Option<auto(TT)>; v : TT) {
     if (o._has_value) {
         static_if (typeinfo can_copy(o._value)) {
             return o
@@ -133,7 +133,7 @@ def or_value(o : $Option < auto(TT) >; v : TT) {
 }
 
 //! Extract the payload or panic when ``none``.
-def unwrap(o : $Option < auto(TT) >) : TT {
+def unwrap(o : $Option<auto(TT)>) : TT {
     if (!o._has_value) {
         panic("unwrap called on none")
     }
@@ -149,7 +149,7 @@ def unwrap(o : $Option < auto(TT) >) : TT {
 //! non-copyable (``array<T>``, ``table<K;V>``, lambdas) and you no longer need
 //! ``o`` — it avoids the deep clone that ``unwrap`` would otherwise perform.
 //! Panics when ``none``.
-def move_unwrap(var o : $Option < auto(TT) >) : TT {
+def move_unwrap(var o : $Option<auto(TT)>) : TT {
     if (!o._has_value) {
         panic("move_unwrap called on none")
     }
@@ -158,7 +158,7 @@ def move_unwrap(var o : $Option < auto(TT) >) : TT {
 }
 
 //! Extract the payload or return ``d`` when ``none``.
-def unwrap_or(o : $Option < auto(TT) >; d : TT) : TT {
+def unwrap_or(o : $Option<auto(TT)>; d : TT) : TT {
     static_if (typeinfo can_copy(o._value)) {
         return o._has_value ? o._value : d
     } else {
@@ -167,7 +167,7 @@ def unwrap_or(o : $Option < auto(TT) >; d : TT) : TT {
 }
 
 //! Extract the payload or compute a fallback via ``f`` when ``none``.
-def unwrap_or_else(o : $Option < auto(TT) >; f : block<() : TT>) : TT {
+def unwrap_or_else(o : $Option<auto(TT)>; f : block<() : TT>) : TT {
     static_if (typeinfo can_copy(o._value)) {
         return o._has_value ? o._value : invoke(f)
     } else {
@@ -176,7 +176,7 @@ def unwrap_or_else(o : $Option < auto(TT) >; f : block<() : TT>) : TT {
 }
 
 //! Extract the payload or return ``default<T>`` when ``none``.
-def unwrap_or_default(o : $Option < auto(TT) >) : TT {
+def unwrap_or_default(o : $Option<auto(TT)>) : TT {
     static_if (typeinfo can_copy(o._value)) {
         return o._has_value ? o._value : default<TT>
     } else {
@@ -186,7 +186,7 @@ def unwrap_or_default(o : $Option < auto(TT) >) : TT {
 
 //! Extract the payload or panic with ``msg`` when ``none``. ``expect_value``
 //! rather than ``expect`` because ``expect`` is a reserved keyword in daslang.
-def expect_value(o : $Option < auto(TT) >; msg : string) : TT {
+def expect_value(o : $Option<auto(TT)>; msg : string) : TT {
     if (!o._has_value) {
         panic(msg)
     }
@@ -198,21 +198,21 @@ def expect_value(o : $Option < auto(TT) >; msg : string) : TT {
 }
 
 //! Invoke ``f`` with the payload when ``some``; no-op when ``none``.
-def if_some(o : $Option < auto(TT) >; f : block<(v : TT) : void>) : void {
+def if_some(o : $Option<auto(TT)>; f : block<(v : TT) : void>) : void {
     if (o._has_value) {
         invoke(f, o._value)
     }
 }
 
 //! Invoke ``f`` when ``none``; no-op when ``some``.
-def if_none(o : $Option < auto(TT) >; f : block<() : void>) : void {
+def if_none(o : $Option<auto(TT)>; f : block<() : void>) : void {
     if (!o._has_value) {
         invoke(f)
     }
 }
 
 //! Pair two options; ``some`` iff both are ``some``.
-def zip(a : $Option < auto(TT) >; b : $Option < auto(UU) >) {
+def zip(a : $Option<auto(TT)>; b : $Option<auto(UU)>) {
     var r = default<$Option<tuple<TT -const; UU -const> > >
     if (a._has_value && b._has_value) {
         r._has_value = true
@@ -231,7 +231,7 @@ def zip(a : $Option < auto(TT) >; b : $Option < auto(UU) >) {
 }
 
 //! Unwrap or default. Mirrors ``T? ?? default`` for value types.
-def operator ??(o : $Option < auto(TT) >; d : TT) : TT {
+def operator ??(o : $Option<auto(TT)>; d : TT) : TT {
     static_if (typeinfo can_copy(o._value)) {
         return o._has_value ? o._value : d
     } else {
@@ -240,24 +240,24 @@ def operator ??(o : $Option < auto(TT) >; d : TT) : TT {
 }
 
 //! Structural equality: same tag, and when ``some``, equal payloads.
-def operator ==(a, b : $Option < auto(TT) > implicit) : bool {
+def operator ==(a, b : $Option<auto(TT)> implicit) : bool {
     if (a._has_value != b._has_value) return false
     return !a._has_value || a._value == b._value
 }
 
 //! Equality against payload value: ``some(v) == v``, ``none != v``.
-def operator ==(o : $Option < auto(TT) >; v : TT) : bool {
+def operator ==(o : $Option<auto(TT)>; v : TT) : bool {
     return o._has_value && o._value == v
 }
 
-def operator ==(v : auto(TT); o : $Option < TT >) : bool {
+def operator ==(v : auto(TT); o : $Option<TT>) : bool {
     return o._has_value && o._value == v
 }
 
-def operator !=(o : $Option < auto(TT) >; v : TT) : bool {
+def operator !=(o : $Option<auto(TT)>; v : TT) : bool {
     return !(o == v)
 }
 
-def operator !=(v : auto(TT); o : $Option < TT >) : bool {
+def operator !=(v : auto(TT); o : $Option<TT>) : bool {
     return !(o == v)
 }

--- a/daslib/result.das
+++ b/daslib/result.das
@@ -46,7 +46,7 @@ struct template Result {
 //! mutable source, use ``move_ok`` instead.
 [template(etype)]
 def ok(v : auto(TT); etype : auto(EE)) {
-    typedef RT = $Result < TT - const; EE - const >
+    typedef RT = $Result<TT -const; EE -const>
     var r = default<RT>
     r._is_ok = true
     static_if (typeinfo can_copy(r._value)) {
@@ -74,7 +74,7 @@ def move_ok(var v : auto(TT); etype : auto(EE)) {
 //! mutable source, use ``move_err`` instead.
 [template(ttype)]
 def err(e : auto(EE); ttype : auto(TT)) {
-    typedef RT = $Result < TT - const; EE - const >
+    typedef RT = $Result<TT -const; EE -const>
     var r = default<RT>
     r._is_ok = false
     static_if (typeinfo can_copy(r._error)) {
@@ -95,17 +95,17 @@ def move_err(var e : auto(EE); ttype : auto(TT)) {
 }
 
 //! ``true`` iff the result is a successful ``ok``.
-def is_ok(r : $Result < auto(TT); auto(EE) >) : bool {
+def is_ok(r : $Result<auto(TT); auto(EE)>) : bool {
     return r._is_ok
 }
 
 //! ``true`` iff the result is a failed ``err``.
-def is_err(r : $Result < auto(TT); auto(EE) >) : bool {
+def is_err(r : $Result<auto(TT); auto(EE)>) : bool {
     return !r._is_ok
 }
 
 //! Apply ``f`` to the ok payload. ``err`` stays ``err`` (same ``E``).
-def map(r : $Result < auto(TT); auto(EE) >; f : block<(v : TT) : auto(UU)>) {
+def map(r : $Result<auto(TT); auto(EE)>; f : block<(v : TT) : auto(UU)>) {
     var out = default<$Result<UU -const; EE -const> >
     if (r._is_ok) {
         out._is_ok = true
@@ -125,7 +125,7 @@ def map(r : $Result < auto(TT); auto(EE) >; f : block<(v : TT) : auto(UU)>) {
 }
 
 //! Apply ``f`` to the err payload. ``ok`` stays ``ok`` (same ``T``).
-def map_err(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : auto(FF)>) {
+def map_err(r : $Result<auto(TT); auto(EE)>; f : block<(e : EE) : auto(FF)>) {
     var out = default<$Result<TT -const; FF -const> >
     if (r._is_ok) {
         out._is_ok = true
@@ -145,7 +145,7 @@ def map_err(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : auto(FF)>) 
 }
 
 //! Monadic bind on the ok side — ``f`` returns the next ``Result``.
-def and_then(r : $Result < auto(TT); auto(EE) >; f : block<(v : TT) : $Result<auto(UU); EE> >) {
+def and_then(r : $Result<auto(TT); auto(EE)>; f : block<(v : TT) : $Result<auto(UU); EE> >) {
     if (r._is_ok) return <- invoke(f, r._value)
     var out = default<$Result<UU -const; EE -const> >
     static_if (typeinfo can_copy(out._error)) {
@@ -157,7 +157,7 @@ def and_then(r : $Result < auto(TT); auto(EE) >; f : block<(v : TT) : $Result<au
 }
 
 //! Monadic bind on the err side — ``f`` can recover or re-map the error.
-def or_else(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : $Result<TT; auto(FF)> >) {
+def or_else(r : $Result<auto(TT); auto(EE)>; f : block<(e : EE) : $Result<TT; auto(FF)> >) {
     if (!r._is_ok) return <- invoke(f, r._error)
     var out = default<$Result<TT -const; FF -const> >
     out._is_ok = true
@@ -170,7 +170,7 @@ def or_else(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : $Result<TT;
 }
 
 //! Extract the ok payload or panic when ``err``.
-def unwrap(r : $Result < auto(TT); auto(EE) >) : TT {
+def unwrap(r : $Result<auto(TT); auto(EE)>) : TT {
     if (!r._is_ok) {
         panic("unwrap called on err")
     }
@@ -186,7 +186,7 @@ def unwrap(r : $Result < auto(TT); auto(EE) >) : TT {
 //! this instead of ``unwrap`` when ``T`` is non-copyable and you no longer need
 //! ``r`` — it avoids the deep clone that ``unwrap`` would otherwise perform.
 //! Panics when ``err``.
-def move_unwrap(var r : $Result < auto(TT); auto(EE) >) : TT {
+def move_unwrap(var r : $Result<auto(TT); auto(EE)>) : TT {
     if (!r._is_ok) {
         panic("move_unwrap called on err")
     }
@@ -195,7 +195,7 @@ def move_unwrap(var r : $Result < auto(TT); auto(EE) >) : TT {
 }
 
 //! Extract the ok payload or return ``d`` when ``err``.
-def unwrap_or(r : $Result < auto(TT); auto(EE) >; d : TT) : TT {
+def unwrap_or(r : $Result<auto(TT); auto(EE)>; d : TT) : TT {
     static_if (typeinfo can_copy(r._value)) {
         return r._is_ok ? r._value : d
     } else {
@@ -204,7 +204,7 @@ def unwrap_or(r : $Result < auto(TT); auto(EE) >; d : TT) : TT {
 }
 
 //! Extract the ok payload or compute a fallback from the error via ``f``.
-def unwrap_or_else(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : TT>) : TT {
+def unwrap_or_else(r : $Result<auto(TT); auto(EE)>; f : block<(e : EE) : TT>) : TT {
     static_if (typeinfo can_copy(r._value)) {
         return r._is_ok ? r._value : invoke(f, r._error)
     } else {
@@ -213,7 +213,7 @@ def unwrap_or_else(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : TT>)
 }
 
 //! Extract the ok payload or return ``default<T>`` when ``err``.
-def unwrap_or_default(r : $Result < auto(TT); auto(EE) >) : TT {
+def unwrap_or_default(r : $Result<auto(TT); auto(EE)>) : TT {
     static_if (typeinfo can_copy(r._value)) {
         return r._is_ok ? r._value : default<TT>
     } else {
@@ -222,7 +222,7 @@ def unwrap_or_default(r : $Result < auto(TT); auto(EE) >) : TT {
 }
 
 //! Extract the err payload or panic when ``ok``.
-def unwrap_err(r : $Result < auto(TT); auto(EE) >) : EE {
+def unwrap_err(r : $Result<auto(TT); auto(EE)>) : EE {
     if (r._is_ok) {
         panic("unwrap_err called on ok")
     }
@@ -236,7 +236,7 @@ def unwrap_err(r : $Result < auto(TT); auto(EE) >) : EE {
 //! Destructively extract the err payload, leaving ``r`` in the ok state with
 //! the ok side defaulted. Mirrors ``move_err`` on the construction side.
 //! Panics when ``ok``.
-def move_unwrap_err(var r : $Result < auto(TT); auto(EE) >) : EE {
+def move_unwrap_err(var r : $Result<auto(TT); auto(EE)>) : EE {
     if (r._is_ok) {
         panic("move_unwrap_err called on ok")
     }
@@ -246,7 +246,7 @@ def move_unwrap_err(var r : $Result < auto(TT); auto(EE) >) : EE {
 
 //! Extract the ok payload or panic with ``msg`` when ``err``. ``expect_value``
 //! rather than ``expect`` because ``expect`` is a reserved keyword.
-def expect_value(r : $Result < auto(TT); auto(EE) >; msg : string) : TT {
+def expect_value(r : $Result<auto(TT); auto(EE)>; msg : string) : TT {
     if (!r._is_ok) {
         panic(msg)
     }
@@ -258,7 +258,7 @@ def expect_value(r : $Result < auto(TT); auto(EE) >; msg : string) : TT {
 }
 
 //! Extract the err payload or panic with ``msg`` when ``ok``.
-def expect_err(r : $Result < auto(TT); auto(EE) >; msg : string) : EE {
+def expect_err(r : $Result<auto(TT); auto(EE)>; msg : string) : EE {
     if (r._is_ok) {
         panic(msg)
     }
@@ -270,21 +270,21 @@ def expect_err(r : $Result < auto(TT); auto(EE) >; msg : string) : EE {
 }
 
 //! Invoke ``f`` with the ok payload when ``ok``; no-op when ``err``.
-def if_ok(r : $Result < auto(TT); auto(EE) >; f : block<(v : TT) : void>) : void {
+def if_ok(r : $Result<auto(TT); auto(EE)>; f : block<(v : TT) : void>) : void {
     if (r._is_ok) {
         invoke(f, r._value)
     }
 }
 
 //! Invoke ``f`` with the err payload when ``err``; no-op when ``ok``.
-def if_err(r : $Result < auto(TT); auto(EE) >; f : block<(e : EE) : void>) : void {
+def if_err(r : $Result<auto(TT); auto(EE)>; f : block<(e : EE) : void>) : void {
     if (!r._is_ok) {
         invoke(f, r._error)
     }
 }
 
 //! Drop the err side; ``ok`` becomes ``some``, ``err`` becomes ``none``.
-def to_option(r : $Result < auto(TT); auto(EE) >) {
+def to_option(r : $Result<auto(TT); auto(EE)>) {
     var o = default<$Option<TT -const> >
     if (r._is_ok) {
         o._has_value = true
@@ -298,7 +298,7 @@ def to_option(r : $Result < auto(TT); auto(EE) >) {
 }
 
 //! Drop the ok side; ``err`` becomes ``some``, ``ok`` becomes ``none``.
-def err_to_option(r : $Result < auto(TT); auto(EE) >) {
+def err_to_option(r : $Result<auto(TT); auto(EE)>) {
     var o = default<$Option<EE -const> >
     if (!r._is_ok) {
         o._has_value = true
@@ -312,7 +312,7 @@ def err_to_option(r : $Result < auto(TT); auto(EE) >) {
 }
 
 //! Unwrap or default. Mirrors ``T? ?? default`` for value types.
-def operator ??(r : $Result < auto(TT); auto(EE) >; d : TT) : TT {
+def operator ??(r : $Result<auto(TT); auto(EE)>; d : TT) : TT {
     static_if (typeinfo can_copy(r._value)) {
         return r._is_ok ? r._value : d
     } else {
@@ -321,24 +321,24 @@ def operator ??(r : $Result < auto(TT); auto(EE) >; d : TT) : TT {
 }
 
 //! Structural equality: same tag, and the active payload compares equal.
-def operator ==(a, b : $Result < auto(TT); auto(EE) > implicit) : bool {
+def operator ==(a, b : $Result<auto(TT); auto(EE)> implicit) : bool {
     if (a._is_ok != b._is_ok) return false
     return a._is_ok ? a._value == b._value : a._error == b._error
 }
 
 //! Equality against ok payload: ``ok(v) == v``, ``err(...) != v``.
-def operator ==(r : $Result < auto(TT); auto(EE) >; v : TT) : bool {
+def operator ==(r : $Result<auto(TT); auto(EE)>; v : TT) : bool {
     return r._is_ok && r._value == v
 }
 
-def operator ==(v : auto(TT); r : $Result < TT; auto(EE) >) : bool {
+def operator ==(v : auto(TT); r : $Result<TT; auto(EE)>) : bool {
     return r._is_ok && r._value == v
 }
 
-def operator !=(r : $Result < auto(TT); auto(EE) >; v : TT) : bool {
+def operator !=(r : $Result<auto(TT); auto(EE)>; v : TT) : bool {
     return !(r == v)
 }
 
-def operator !=(v : auto(TT); r : $Result < TT; auto(EE) >) : bool {
+def operator !=(v : auto(TT); r : $Result<TT; auto(EE)>) : bool {
     return !(r == v)
 }

--- a/tests/hash_map/all_hash_table.das
+++ b/tests/hash_map/all_hash_table.das
@@ -11,12 +11,12 @@ struct Foo {
 }
 
 [sideeffects]
-def take_any_hash_table(a : $TFlatHashTable < auto(TT); auto(QQ) >) {
+def take_any_hash_table(a : $TFlatHashTable<auto(TT); auto(QQ)>) {
     return "any_flat"
 }
 
 [sideeffects]
-def take_any_hash_map(a : $TFlatHashTable < string; auto(QQ) >) {
+def take_any_hash_map(a : $TFlatHashTable<string; auto(QQ)>) {
     return "string;any"
 }
 
@@ -25,20 +25,20 @@ def take_any_hash_map(a) {
     return "nothing"
 }
 [sideeffects]
-def take_dict_map(a : $TFlatHashTable < auto(TT); auto(TT) > (@@hash_string)) {
+def take_dict_map(a : $TFlatHashTable<auto(TT); auto(TT)>(@@hash_string)) {
     return "dict_map"
 }
 
 [sideeffects]
-def take_any_hash_table(a : $TCuckooHashTable < auto(TT); auto(QQ) >) {
+def take_any_hash_table(a : $TCuckooHashTable<auto(TT); auto(QQ)>) {
     return "any_cuckoo"
 }
 
-typedef FlatHashMap_int_Foo = $TFlatHashTable < int; Foo >
-typedef FlatHashMap_string_int = $TFlatHashTable < string; int >
-typedef DictMap = $TFlatHashTable < string; int > (@@hash_string)   // vs @@hash
+typedef FlatHashMap_int_Foo = $TFlatHashTable<int; Foo>
+typedef FlatHashMap_string_int = $TFlatHashTable<string; int>
+typedef DictMap = $TFlatHashTable<string; int>(@@hash_string)    // vs @@hash
 
-typedef CuckooHashMap_int_Foo = $TCuckooHashTable < int; Foo >
+typedef CuckooHashMap_int_Foo = $TCuckooHashTable<int; Foo>
 
 def hash_string(s : string) : uint64 {
     var h : uint64 = 14695981039346656037ul
@@ -51,11 +51,11 @@ def hash_string(s : string) : uint64 {
 
 [test]
 def specialization(t : T?) {
-    var map1 <- FlatHashMap_int_Foo()
-    var map2 <- FlatHashMap_string_int()
-    var map3 : table<string; int>
-    var map4 <- DictMap()
-    var map5 <- CuckooHashMap_int_Foo()
+    let map1 <- FlatHashMap_int_Foo()
+    let map2 <- FlatHashMap_string_int()
+    let map3 : table<string; int>
+    let map4 <- DictMap()
+    let map5 <- CuckooHashMap_int_Foo()
     t |> equal("any_flat", take_any_hash_table(map1))
     t |> equal("string;any", take_any_hash_map(map2))
     t |> equal("nothing", take_any_hash_map(map3))
@@ -100,15 +100,15 @@ def table_ops(t : T?; var a : auto(AnyTable_int_to_Foo); var e : Foo; var et : F
     for (v in a.values()) {
         t |> equal(1, v.a)
     }
-    var found = a.get(0) <| $(v) {
+    var found = a.get(0) $(v) {
         t |> equal(1, v.a)
     }
     t |> success(found)
-    found = a.get(1) <| $(v) {
+    found = a.get(1) $(v) {
         t |> equal(1, v.a)
     }
     t |> success(found)
-    found = a.get(2) <| $(v) {
+    found = a.get(2) $(v) {
         t |> failure("we should not be here\n")
     }
     t |> success(!found)

--- a/tests/typemacro/test_basic.das
+++ b/tests/typemacro/test_basic.das
@@ -25,7 +25,7 @@ def test_grammar_forms(t : T?) {
         t |> equal(typeinfo typename(_a), "float[4]")
     }
     t |> run("$name<types>(args) form") @(t : T?) {
-        var _a : $tm_make < float > (4, true, "arr")
+        var _a : $tm_make<float>(4, true, "arr")
         t |> equal(typeinfo typename(_a), "float[4]")
     }
 }


### PR DESCRIPTION
Fixes #3074.

The source formatter did not recognize the `$`-prefixed type-macro-with-type-arguments grammar form (`'$' name_in_namespace '<' type_declaration_no_options_list '>' optional_expr_list_in_braces`), so it treated the `<` / `>` as comparison operators and inserted spaces:

```das
var a : $tm_make<float>(4, true, "arr")     // input
var a : $tm_make < float > (4, true, "arr") // old formatter output
```

**Fix:** `mark_tokens_as_type` now consumes the leading `$` when it is followed by an identifier, so the rest of the form goes through the exact same marking path as the non-`$` sibling (`name<types>(args)`, which already formatted correctly): the angle-bracketed type list gets `isInType`, no spaces are inserted, and `>` glues to `(`.

**Mangled-file cleanup:** the old behavior had already reformatted several in-tree files into the spaced form. This PR re-tightens them to the intended rendering: `daslib/option.das`, `daslib/result.das` (`$Option<auto(TT)>`, `$Result<TT -const; EE -const>`, …), `tests/hash_map/all_hash_table.das`, `tests/typemacro/test_basic.das` (the issue's repro), and `benchmarks/core/hash/test02/11/12.das`.

**Lint cleanup (fix-at-source policy):** touching those consumer files surfaced pre-existing warnings, fixed here: `var`→`let` + unused loop index in `daslib/cuckoo_hash_table.das` template methods, a `// nolint:PERF020` on generic `hash0` (the `uint64(data)` cast is identity only for `uint64` keys), and `var`→`let` / STYLE001 trailing-block fixes in `tests/hash_map/all_hash_table.das`.

**Validation:**
- `das-fmt --path ./ --verify` clean over the whole tree (2174 files) with the new formatter
- lint clean on all 9 changed files (`0 issue(s), 0 error(s)`)
- `tests/typemacro`, `tests/option`, `tests/hash_map` all pass (230 tests)
- full `tests/` run: failure set byte-identical to master baseline (pre-existing local-environment failures only — missing C++ test modules, jit link, audio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)