### PR TITLE
flatten: keep lerp whole by default; expansion becomes opt-in _flatten_expand_lerp

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -742,11 +742,19 @@ def public flatten_no_fast_math : bool {
 }
 
 [macro_function]
-def public flatten_fold(var func : FunctionPtr; no_fast_math : bool = false) : bool {
+def public flatten_expand_lerp : bool {
+    //! True when the COMPILING module sets `options _flatten_expand_lerp = true` — opt-in lerp
+    //! disassembly for backends WITHOUT a native lerp instruction (a native-lerp ISA only loses
+    //! nodes to it). COMPILE-TIME ONLY: patch code reads it once, runtime tools pass their flag.
+    return compiling_program()._options |> find_arg("_flatten_expand_lerp") ?as tBool ?? false
+}
+
+[macro_function]
+def public flatten_fold(var func : FunctionPtr; no_fast_math : bool = false; expand_lerp : bool = false) : bool {
     //! Post-infer fold pass (delegates to `fold_body`): collapse `const ? a : b`, fold identities,
     //! drop pure self-assigns. Run AFTER re-inference; returns true if anything changed. Compile-time
-    //! callers pass `flatten_no_fast_math()` to honor the module option; the default is fast-math ON.
-    return fold_body(func, no_fast_math)
+    //! callers pass `flatten_no_fast_math()` / `flatten_expand_lerp()` to honor the module options.
+    return fold_body(func, no_fast_math, expand_lerp)
 }
 
 [macro_function]
@@ -924,7 +932,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // Cycle 2+: fold the inferred twin (const selects, algebraic identities, pure self-
             // assigns), re-infer if anything changed. Iterate to a fixpoint — fold and the typer's
             // re-infer const-fold are mutually-enabling, so one pass isn't enough.
-            let folded = flatten_fold(twin, flatten_no_fast_math())
+            let folded = flatten_fold(twin, flatten_no_fast_math(), flatten_expand_lerp())
             set_flatten_phase(func, PHASE_FOLDED)
             if (folded) {
                 astChanged = true

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -527,6 +527,7 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
 class private FoldVisitor : AstVisitor {
     changed : bool
     noFastMath : bool
+    expandLerp : bool
     def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
         // A fully-constant ExprOp2 the typer left unfolded — it folds scalar const arithmetic but
         // leaves vector const (`float3(2)+float3(3)`), what reassoc's gathered groups become. Fold
@@ -680,9 +681,9 @@ class private FoldVisitor : AstVisitor {
                 return folded
             }
         }
-        // DISASSEMBLE lerp/mad into raw arithmetic so the identity/const folds, reassoc and CSE
-        // see through them; the PHASE_FUSED finishing pass re-packs survivors. Type-gated to the
-        // das math overload set — a loose DSL-stub instantiation must not expand into ill-typed ops.
+        // DISASSEMBLE mad (and, under `expandLerp`, lerp) into raw arithmetic so the folds,
+        // reassoc and CSE see through them; PHASE_FUSED re-packs survivors. Type-gated to the
+        // das math overload set — a loose DSL-stub instantiation must not expand ill-typed.
         if (that.func != null && length(that.arguments) == 3) {
             let fname = psh_simple_name("{that.func.name}")
             let ta = expr_bt(that.arguments[0])
@@ -702,6 +703,7 @@ class private FoldVisitor : AstVisitor {
                         return aArg
                     }
                 }
+                if (!expandLerp) return that
                 changed = true
                 var sub = new ExprOp2(at = that.at, op := "-", left = bArg, right = clone_expression(aArg))
                 var mul = new ExprOp2(at = that.at, op := "*", left = sub, right = tArg)
@@ -1448,10 +1450,10 @@ class private ReassocVisitor : AstVisitor {
     }
 }
 
-def public fold_body(var func : FunctionPtr; no_fast_math : bool = false) : bool {
-    //! Post-infer fold over a flattened body: const-propagate single-def locals, reassociate
-    //! scattered consts, collapse `const ? a : b`, fold identities/const ctors, drop pure self-assigns.
-    //! SINGLE pass (caller re-infers and loops); `no_fast_math = true` skips the value-changing arms.
+def public fold_body(var func : FunctionPtr; no_fast_math : bool = false; expand_lerp : bool = false) : bool {
+    //! Post-infer fold over a flattened body: const-propagate single-def locals, reassociate scattered
+    //! consts, collapse `const ? a : b`, fold identities/const ctors, drop pure self-assigns. SINGLE pass
+    //! (caller loops); `no_fast_math` skips value-changing arms, `expand_lerp` disassembles `lerp` calls.
     if (!(func.body is ExprBlock)) return false
     let nfm = no_fast_math
     var changed = const_prop_locals(func.body as ExprBlock)
@@ -1469,8 +1471,7 @@ def public fold_body(var func : FunctionPtr; no_fast_math : bool = false) : bool
     unsafe {
         delete rv
     }
-    var v = new FoldVisitor()
-    v.noFastMath = nfm
+    var v = new FoldVisitor(noFastMath = nfm, expandLerp = expand_lerp)
     make_visitor(*v) $(adapter) {
         visit(func.body, adapter)
     }

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -186,28 +186,52 @@ passes exclude any subtree that reads a **reassigned** variable
 (a live/loop mask, a written global, or the base of an indexed store — ``G[i] = v``
 makes every ``G[...]`` read unstable), whose value is not stable across the body.
 
-**mad / lerp: disassemble early, re-fuse late.** ``lerp`` and ``mad`` are pure
-arithmetic wearing a call: the fold phase **expands** them in place —
-``mad(a, b, c) → a*b + c``, ``lerp(a, b, t) → (b - a)*t + a`` — so every
-downstream pass sees through them: the existing identity arms collapse the
-constant selectors (``lerp(a, b, 0) → a``, ``lerp(a, b, 1) → b``,
-``lerp(a, a, t) → a``, ``mad(a, 1, c) → a + c``, ``lerp(1.0, d, 1.0) → d``)
-with **no per-builtin identity table**, reassociation canonicalises the exposed
-operands, CSE shares a repeated ``b - a`` across lerps, and preshader extraction
-hoists a uniform ``b - a`` even when ``t`` is varying. Once the optimize pass
-converges, a finishing **fuse** pass (``PHASE_FUSED``) re-packs what survived:
-``a*b + c`` / ``c + a*b`` (and the const-negatable ``a*b - C`` / ``C - a*b``)
-become one ``mad(a, b, c)`` node — including the vector·scalar broadcast form —
-and a mad still carrying the lerp shape, ``mad(b - a, t, a)``, becomes one
-``lerp(a, b, t)`` node. Hand-written ``(b - a)*t + a`` arithmetic that never
-spelled ``lerp`` canonicalises into the lerp node the same way. A leftover
+**mad: disassemble early, re-fuse late. lerp: keep whole.** ``mad`` is pure
+arithmetic wearing a call: the fold phase **expands** it in place —
+``mad(a, b, c) → a*b + c`` — so every downstream pass sees through it (the
+identity arms collapse ``mad(a, 1, c) → a + c`` with **no per-builtin identity
+table**, reassociation canonicalises the exposed operands, CSE and preshader
+extraction work on the pieces). Once the optimize pass converges, a finishing
+**fuse** pass (``PHASE_FUSED``) re-packs what survived: ``a*b + c`` /
+``c + a*b`` (and the const-negatable ``a*b - C`` / ``C - a*b``) become one
+``mad(a, b, c)`` node — including the vector·scalar broadcast form. A leftover
 ``(-a) + b`` (the ``0 - x`` / ``*-1`` folds produce bare negates) re-packs into
-``b - a``. Type gates keep
-the rewrites inside the das ``math`` overload set (float / int / uint, scalar +
-vector; lerp with scalar ``t``), and fusion only runs when a 3-argument
-``mad`` / ``lerp`` is visible from the twin's module (``math`` or a backend DSL).
-Fusion is value-exact at the das level (das ``mad`` computes ``a*b + c``); the
-*backend* may contract it to a single-rounding FMA — that is its call.
+``b - a``.
+
+``lerp`` is **not** expanded by default. A shader-graph backend computes
+``(b - a)*t + a`` in one native lerp instruction with constant operands free,
+so disassembly can at best break even (a full re-fuse) and loses 1–2
+instructions whenever reassociation or mad fusion merges a lerp piece with a
+*neighbor* term into a shape re-fusion cannot recover — the smooth-min idiom
+``lerp(d, ds, h) + k*h*(h - 1.0)`` loses its lerp six times over in the
+raymarch example shader. The
+constant-selector identities fire directly on the call instead
+(``lerp(a, b, 0) → a``, ``lerp(a, b, 1) → b``, ``lerp(a, a, t) → a``; fast-math
+gated — they drop an argument), the surviving call is one pure node for CSE,
+and a fully-uniform lerp hoists whole into the preshader. The fuse pass still
+canonicalises hand-written ``(b - a)*t + a`` arithmetic (via the
+``mad(b - a, t, a)`` shape) *into* one ``lerp(a, b, t)`` node, so organic
+lerp-shaped math reaches the backend as the native instruction too.
+
+A backend **without** a native lerp opts back into the disassembly with an
+integration setting in the modules that carry its shaders:
+
+.. code-block:: das
+
+    options _flatten_expand_lerp = true
+
+(or by passing ``expand_lerp = true`` when driving ``flatten_fold`` directly).
+Under the option ``lerp(a, b, t) → (b - a)*t + a`` exactly as mad: the folds
+see through it, CSE shares a repeated ``b - a`` across lerps, preshader
+extraction hoists a uniform ``b - a`` even when ``t`` is varying, and the fuse
+pass re-packs an unfolded survivor back into the single ``lerp`` node.
+
+Type gates keep the rewrites inside the das ``math`` overload set (float / int /
+uint, scalar + vector; lerp with scalar ``t``), and fusion only runs when a
+3-argument ``mad`` / ``lerp`` is visible from the twin's module (``math`` or a
+backend DSL). Fusion is value-exact at the das level (das ``mad`` computes
+``a*b + c``); the *backend* may contract it to a single-rounding FMA — that is
+its call.
 
 **Division becomes a reciprocal multiply.** A divide is the most expensive
 arithmetic node a shader carries, and most divisors never change per pixel. The
@@ -268,9 +292,10 @@ with a user option:
 The option is module-local (it applies to the shaders/twins *written in* that
 module) and turns off exactly the value-changing set; everything bit-exact —
 flattening, predication, unrolling, preshader extraction, CSE, alias
-elimination, the mad/lerp expand/re-fuse round trip, splat collapse, lane
-re-vectorization, shared-factor extraction, and every *integer* fold — stays
-on. Under the option a twin computes bit-identical results to its original.
+elimination, the mad expand/re-fuse round trip (and the lerp one, when
+``_flatten_expand_lerp`` enables it), splat collapse, lane re-vectorization,
+shared-factor extraction, and every *integer* fold — stays on. Under the
+option a twin computes bit-identical results to its original.
 The residual oracles take the same flag, so a unit compiled under the option
 validates clean without flagging the deliberately-skipped rewrites.
 
@@ -366,7 +391,13 @@ Public API
     threads the bool into the passes below); a runtime tool driving the passes
     directly passes its own flag instead.
 
-``flatten_fold(var func, no_fast_math = false) : bool``
+``flatten_expand_lerp : bool``
+    True when the *compiling* module sets ``options _flatten_expand_lerp = true`` —
+    the opt-in lerp disassembly for backends *without* a native lerp instruction
+    (see the mad/lerp section above). Same compile-time-only contract as
+    ``flatten_no_fast_math``.
+
+``flatten_fold(var func, no_fast_math = false, expand_lerp = false) : bool``
     The post-inference fold pass: collapse ``const ? a : b`` selects, drop the
     pure ``lhs = lhs`` self-assigns, strip redundant zero initializers. Run it
     *after* re-inference (the constant conditions must already be folded to

--- a/examples/flatten/backend/shader_graph_ir_builder.das
+++ b/examples/flatten/backend/shader_graph_ir_builder.das
@@ -14,6 +14,7 @@ module shader_graph_ir_builder shared public
 //! `finish` hook), so compiling a shader against this module dumps its opcodes.
 
 require daslib/fio
+require strings
 
 // ShaderNodeKind { Input, Output, Op, Const, Var }
 def private kind_name(k : int) : string {
@@ -40,21 +41,45 @@ def private type_name(t : int) : string {
 // flattened daslang stands alone — the node/pin/link plumbing is noise when you
 // just want to read flatten's output. The default `run.sh <shader>` view (and the
 // regression / capability checks that parse `node ` lines) is unaffected.
+//
+// SGIR mode (FLATTEN_DUMP_SGIR) wins over both: it serializes the graph in the
+// machine line format a native `sg_compile` driver can parse — same fields as
+// the engine IR-builder calls, one line per call, full float precision.
+
+def sg_ir_want_sgir_dump() : bool {
+    return has_env_variable("FLATTEN_DUMP_SGIR")
+}
+
+def private f4_fields(v : float4) : string {
+    return build_string() $(var writer) {
+        writer |> fmt(":.9g", v.x) |> write(" ") |> fmt(":.9g", v.y) |> write(" ")
+        writer |> fmt(":.9g", v.z) |> write(" ") |> fmt(":.9g", v.w)
+    }
+}
 
 def sg_ir_reset() {
     //! Begin a fresh shader graph.
-    return if (sg_ir_want_ast_dump())
+    return if (sg_ir_want_sgir_dump() || sg_ir_want_ast_dump())
     print(";; ---- begin shader graph ----\n")
 }
 
 def sg_ir_set_contract(stage : string; contract : string) {
     //! Record the shader stage + I/O contract.
+    if (sg_ir_want_sgir_dump()) {
+        print("contract {stage} {contract}\n")
+        return
+    }
     return if (sg_ir_want_ast_dump())
     print(";; contract: stage={stage} type={contract}\n")
 }
 
 def sg_ir_add_property(name : string; ptype : int; defaultValue : float4; defaultTexture : string) {
     //! A material property (from a `var { ... }` block / shader argument).
+    if (sg_ir_want_sgir_dump()) {
+        let tex = empty(defaultTexture) ? "-" : defaultTexture
+        print("property {name} {ptype} {f4_fields(defaultValue)} {tex}\n")
+        return
+    }
     return if (sg_ir_want_ast_dump())
     if (empty(defaultTexture)) {
         print(";; property {name} : {type_name(ptype)} = {defaultValue}\n")
@@ -65,6 +90,10 @@ def sg_ir_add_property(name : string; ptype : int; defaultValue : float4; defaul
 
 def sg_ir_begin_node(id : int; typeId : string; kind : int; constValue : float4; propertyIndex : int) {
     //! Open a graph node. Its pins follow via sg_ir_add_*_pin.
+    if (sg_ir_want_sgir_dump()) {
+        print("node {id} {typeId} {kind} {f4_fields(constValue)} {propertyIndex}\n")
+        return
+    }
     return if (sg_ir_want_ast_dump())
     var extra = ""
     if (kind == 3) {   // Const
@@ -76,16 +105,28 @@ def sg_ir_begin_node(id : int; typeId : string; kind : int; constValue : float4;
 }
 
 def sg_ir_add_input_pin(id : int; ptype : int) {
+    if (sg_ir_want_sgir_dump()) {
+        print("in {id} {ptype}\n")
+        return
+    }
     return if (sg_ir_want_ast_dump())
     print("    in   pin {id} : {type_name(ptype)}\n")
 }
 
 def sg_ir_add_output_pin(id : int; ptype : int) {
+    if (sg_ir_want_sgir_dump()) {
+        print("out {id} {ptype}\n")
+        return
+    }
     return if (sg_ir_want_ast_dump())
     print("    out  pin {id} : {type_name(ptype)}\n")
 }
 
 def sg_ir_add_link(fromPin : int; toPin : int) {
+    if (sg_ir_want_sgir_dump()) {
+        print("link {fromPin} {toPin}\n")
+        return
+    }
     return if (sg_ir_want_ast_dump())
     print("link  pin {fromPin} -> pin {toPin}\n")
 }

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -120,6 +120,29 @@ def test_flatten_fold(t : T?) {
     t |> run("mad/lerp corpus fuses clean (test_flatten_mad.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_mad.das")
         t |> success(n >= 20, "expected >=20 twins, checked {n}")
+        // default mode: a plain lerp survives as the call (no expansion), and organic
+        // (b-a)*t + a arithmetic still canonicalizes INTO the lerp node via the fuser
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_mad.das")
+        let lr = bodies?["l_round_flat"] ?? ""
+        t |> success(lr |> find("lerp") >= 0, "plain lerp must survive whole by default: {lr}")
+        let lm = bodies?["l_manual_flat"] ?? ""
+        t |> success(lm |> find("lerp") >= 0, "organic (b-a)*t+a must still re-fuse to lerp: {lm}")
+        delete bodies
+    }
+    t |> run("expand-lerp corpus folds clean (test_flatten_lerp_expand.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_lerp_expand.das")
+        t |> success(n >= 6, "expected >=6 twins, checked {n}")
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_lerp_expand.das")
+        // the expand -> re-fuse round trip must come back (the symmetric-oracle guard:
+        // fuser and residual oracle share match_lerp, so only a POSITIVE assert catches
+        // a matcher break blinding both)
+        let rt = bodies?["le_round_flat"] ?? ""
+        t |> success(rt |> find("lerp") >= 0, "lerp must round-trip under _flatten_expand_lerp: {rt}")
+        // uniform bounds preshade ONLY when expansion exposes G_B - G_A — the FIRED proof
+        // (kept whole, the bounds ride as plain operands and nothing extracts)
+        let pre = bodies?["le_preshader_flat"] ?? ""
+        t |> success(pre |> find("_preshader_") >= 0, "expanded uniform bounds must preshade: {pre}")
+        delete bodies
     }
     t |> run("rcp corpus rewrites clean (test_flatten_rcp.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_rcp.das")
@@ -150,7 +173,7 @@ def test_flatten_fold(t : T?) {
         let reas = bodies?["nf_reassoc_flat"] ?? ""
         t |> success(reas |> find("0.75") < 0 && reas |> find("0.25") >= 0, "float consts must stay scattered: {reas}")
         let lrp = bodies?["nf_lerp0_flat"] ?? ""
-        t |> success(lrp |> find("lerp") >= 0, "lerp(a,b,0) must round-trip back to lerp: {lrp}")
+        t |> success(lrp |> find("lerp") >= 0, "lerp(a,b,0) must survive as lerp (selector is fast-math gated): {lrp}")
         let imul0 = bodies?["nf_imul0_flat"] ?? ""
         t |> success(imul0 |> find("* 0") < 0, "int n*0 must STILL fold: {imul0}")
         let ire = bodies?["nf_ireassoc_flat"] ?? ""

--- a/tests/flatten/test_flatten_lerp_expand.das
+++ b/tests/flatten/test_flatten_lerp_expand.das
@@ -1,0 +1,101 @@
+options gen2
+options indenting = 4
+options _flatten_expand_lerp = true
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Twin corpus for `options _flatten_expand_lerp` — the opt-in lerp disassembly for backends
+//! WITHOUT a native lerp instruction. Under the option the fold expands `lerp(a,b,t)` into
+//! `(b-a)*t + a` so reassoc/CSE/preshader see through it, and PHASE_FUSED re-packs the
+//! surviving `mad(b-a, t, a)` shape back into one `lerp` call — the expand → re-fuse round
+//! trip that is OFF by default. Float differentials compare approx (the das lerp builtin is
+//! FMA-contracted, the expanded form is raw interp ops — same contract as test_flatten_mad.das).
+//! The structural half (round trip survives, the merge shape proves expansion FIRED, uniform
+//! bounds split into a preshader mad) lives in no_aot/test_flatten_fold.das.
+
+var G_A = 0.25
+var G_B = 4.0
+
+// ----- round trip: expand -> nothing folds -> re-fuse to the same call -----
+[flatten]
+def le_round(a : float; b : float; t : float) : float {
+    return lerp(a, b, t)
+}
+
+[flatten]
+def le_vec(a : float3; b : float3; t : float) : float3 {
+    return lerp(a, b, t)
+}
+
+// ----- const selectors: fire on the call before any expansion -----
+[flatten]
+def le_t0(a : float; b : float) : float {
+    return lerp(a, b, 0.0)
+}
+
+[flatten]
+def le_t1(a : float; b : float) : float {
+    return lerp(a, b, 1.0)
+}
+
+// ----- the smin shape: expansion hands the pieces to reassoc/mad fusion; whether the lerp
+// ----- re-fuses depends on the canonical term order, so this twin is differential-only
+[flatten]
+def le_merge(d : float; ds : float; h : float; k : float) : float {
+    return lerp(d, ds, h) + k * h * (h - 1.0)
+}
+
+// ----- uniform bounds: expansion exposes `G_B - G_A` to the preshader split -----
+[flatten]
+def le_preshader(x : float) : float {
+    return lerp(G_A, G_B, x)
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "expanded-lerp approx mismatch: {a} vs {b}")
+}
+
+def cmp3f_approx(t : T?; a, b : float3) {
+    fapprox(t, a.x, b.x); fapprox(t, a.y, b.y); fapprox(t, a.z, b.z)
+}
+
+[test]
+def test_flatten_lerp_expand(t : T?) {
+    t |> run("round trip — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, le_round_flat(v, 7.5, 0.3), le_round(v, 7.5, 0.3))
+        }
+    }
+    t |> run("vector round trip — value approx") @(t : T?) {
+        for (v in GRID) {
+            cmp3f_approx(t, le_vec_flat(float3(v, -v, 1.0), float3(2.0, 3.0, 4.0), 0.3),
+                le_vec(float3(v, -v, 1.0), float3(2.0, 3.0, 4.0), 0.3))
+        }
+    }
+    t |> run("const selectors still collapse") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(le_t0_flat(v, 7.5), le_t0(v, 7.5))
+            t |> equal(le_t1_flat(v, 7.5), le_t1(v, 7.5))
+        }
+    }
+    t |> run("merge shape — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, le_merge_flat(2.0, v, 0.4, 0.22), le_merge(2.0, v, 0.4, 0.22))
+        }
+    }
+    t |> run("uniform-bound lerp — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, le_preshader_flat(v), le_preshader(v))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_mad.das
+++ b/tests/flatten/test_flatten_mad.das
@@ -5,10 +5,13 @@ require dastest/testing_boost public
 require daslib/flatten
 require math
 
-//! Differential net for the mad/lerp DISASSEMBLE → re-fuse arc. The fold expands `lerp`/`mad`
-//! calls into raw arithmetic (const selectors then collapse through the existing identity arms,
-//! and reassoc/CSE see through the operators); the PHASE_FUSED finishing pass re-packs surviving
-//! `a*b ± c` into `mad(a,b,c)` and the lerp shape `mad(b-a, t, a)` back into `lerp(a,b,t)`.
+//! Differential net for the mad disassemble → re-fuse arc and the DEFAULT lerp handling. The
+//! fold expands `mad` calls into raw arithmetic (reassoc/CSE see through the operators); the
+//! PHASE_FUSED finishing pass re-packs surviving `a*b ± c` into `mad(a,b,c)` and the lerp shape
+//! `mad(b-a, t, a)` back into `lerp(a,b,t)`. `lerp` calls are KEPT WHOLE by default (a native-lerp
+//! backend computes `(b-a)*t+a` in one instruction); the const-selector identities (`t=0`/`t=1`/
+//! `a==b`) fire directly on the call. The opt-in expansion path (`options _flatten_expand_lerp`)
+//! has its own corpus in test_flatten_lerp_expand.das.
 //! Exactness per twin: int twins and same-builtin-both-sides round trips compare exact; ANY
 //! float twin comparing raw interp ops against a `mad`/`lerp` builtin compares approx — the
 //! vector builtins are hardware-fused (NEON FMLA / x86 FMADD), and even the scalar C++ impls
@@ -99,13 +102,13 @@ def l_same(a : float; t : float) : float {
     return lerp(a, a, t)
 }
 
-// ----- lerp where expansion exposes a full fold: lerp(1, d, 1) -> d -----
+// ----- lerp with a const selector hitting the t=1 arm directly on the call -----
 [flatten]
 def l_const1(d : float) : float {
     return lerp(1.0, d, 1.0)
 }
 
-// ----- lerp round trip: expand -> nothing folds -> refuse to the same call -----
+// ----- plain lerp: survives as the same call (no expansion by default) -----
 [flatten]
 def l_round(a : float; b : float; t : float) : float {
     return lerp(a, b, t)
@@ -127,7 +130,7 @@ def l_vec_manual(a : float3; b : float3; t : float) : float3 {
     return (b - a) * t + a
 }
 
-// ----- uniform lerp bounds: the preshader split beats the lerp node (mad(_preshader_, x, G_A)) -----
+// ----- uniform lerp bounds: the call survives whole, bounds ride as const operands -----
 [flatten]
 def p_lerp(x : float) : float {
     return lerp(G_A, G_B, x)

--- a/utils/flatten-fuzz/main.das
+++ b/utils/flatten-fuzz/main.das
@@ -117,7 +117,7 @@ def gen_expr(var g : Gen&; scope : array<Var>; depth : int) : string {
         let e = gen_expr(g, scope, depth - 1)
         return "({op} {e})"   // space: avoid `--`/`-~` token glue on negative literals
     } elif (k < 90) {
-        // exercises the lerp/mad disassemble -> re-fuse arc (int mad is exact, so the
+        // exercises the mad disassemble -> re-fuse arc (int mad is exact, so the
         // differential oracle rides free; strict mode checks the fusion residual arms)
         let a = gen_expr(g, scope, depth - 1)
         let b = gen_expr(g, scope, depth - 1)


### PR DESCRIPTION
## What

`lerp` calls are no longer disassembled by the flatten fold. The const-selector identities (`t=0` / `t=1` / `a==b`, fast-math gated) fire directly on the call; `mad` expansion is unchanged; the fuse pass still canonicalizes organic `(b-a)*t + a` arithmetic *into* the `lerp` node (covered by a new default-mode structural assert on `l_manual`).

The disassembly stays available as an **integration setting, off by default** — for backends without a native lerp instruction, where breaking the call open lets the folds/CSE shave scalar ops:

- `options _flatten_expand_lerp = true` (module option, mirrors `_flatten_no_fast_math` plumbing), or
- `expand_lerp = true` on `flatten_fold` / `fold_body` for backends driving the passes directly.

## Why

A shader-graph backend computes `(b-a)*t + a` in one native lerp instruction with constant operands free, so expansion can at best break even (a full re-fuse) and loses 1–2 instructions whenever reassoc/mad fusion merges a lerp piece with a *neighbor* term into a shape re-fusion cannot recover. The smooth-min idiom `lerp(d, ds, h) + k*h*(h-1.0)` in the raymarch example shader lost its lerp 6 times over.

Measured on the engine's real shader-graph bytecode compiler across all 88 example shaders: raymarch **103 → 91 GPU instructions** (depth 86 → 74); aggregate gpu −13, cpu −18, depth −12, peak-register sum −16; **no shader got worse** (const slots +3 total — lerp keeps both endpoints as slots where mad had dedup'd one).

## Coverage

- New `tests/flatten/test_flatten_lerp_expand.das` (`options _flatten_expand_lerp = true`): differentials for the expansion path + meta-test structural arms — the expand→re-fuse round-trip guard (`le_round` must come back as `lerp`; the symmetric-oracle protection) and the expansion-FIRED proof (`le_preshader`: uniform bounds split into a `_preshader_` mad only under expansion).
- Default-mode asserts added to the mad-corpus arm: plain `lerp` survives whole; organic `(b-a)*t+a` still re-fuses to `lerp`.
- One finding while writing the corpus: the smin merge under expansion is canonical-order-dependent — the simple twin actually re-fuses (`mad((h-1)*h, k, lerp(d,ds,h))`), it is the real raymarch loop-carried form that loses it — so `le_merge` is differential-only and the RST claim says "not always recoverable".
- `doc/source/reference/flatten.rst`: mad/lerp section reworked (mad: disassemble early, re-fuse late; lerp: keep whole + the opt-in), new `flatten_expand_lerp` API entry; Sphinx clean.

Also rides along: `FLATTEN_DUMP_SGIR` machine-export mode in the example harness's `shader_graph_ir_builder.das` (serializes the `sg_ir_*` call stream so an external native `sg_compile` driver can rebuild the engine IR and report real instruction counts — this is how the numbers above were measured). Default and `--das` output modes unchanged.

## Validation

interp full-tree 10852/0 (post-rebase) · JIT full-tree clean-cache 10412/0 · AOT full-tree 10175/0 (test_aot rebuilt through the macros) · flatten-fuzz int/strict/bool 20+20+20 batches, strict residual count identical to master (44=44, seed 7) · examples/flatten run.sh 69/69 + capability 18/18 · CI-form lint 0 issues · Sphinx 0 warnings · scoped detect-dupe: only the deliberate option-reader mirror and intentional corpus-twin fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)