### PR TITLE
flatten: horizontal-add → dot fuse arm + const-minus regroup-to-share + _flatten_log_cse cache dump

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -758,25 +758,33 @@ def public flatten_fold(var func : FunctionPtr; no_fast_math : bool = false; exp
 }
 
 [macro_function]
-def public flatten_optimize(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false) : bool {
+def public flatten_log_cse : bool {
+    //! True when the COMPILING module sets `options _flatten_log_cse = true` — dump each twin's
+    //! final CSE value-number cache (pure-subtree tally + const-minus shapes) after the optimize
+    //! fixpoint. COMPILE-TIME ONLY: patch code reads it once, runtime tools pass their flag.
+    return compiling_program()._options |> find_arg("_flatten_log_cse") ?as tBool ?? false
+}
+
+[macro_function]
+def public flatten_optimize(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false; log_cse : bool = false) : bool {
     //! Post-fold optimize pass (delegates to `flatten_preshade_cse`): hoist uniform subtrees to
-    //! per-draw `_preshader_` lets + CSE-dedup + rcp-rewrite divisions by a uniform (fast-math).
-    //! Run after the `flatten_fold` fixpoint; `barriers` = the backend's sampler/intrinsic names.
-    return flatten_preshade_cse(func, barriers, no_fast_math)
+    //! per-draw `_preshader_` lets + regroup const-minus sums toward live `C - x` twins + CSE-dedup
+    //! + rcp-rewrite uniform divisions. After the `flatten_fold` fixpoint; `barriers` = sampler names.
+    return flatten_preshade_cse(func, barriers, no_fast_math, log_cse)
 }
 
 [macro_function]
 def public flatten_fuse(var func : FunctionPtr; no_fast_math : bool = false) : bool {
-    //! PHASE_FUSED finishing pass (delegates to `fuse_body`): re-pack ctor lane patterns, `a*b ± c`
-    //! into `mad(a,b,c)`, and the expanded lerp shape back into `lerp(a,b,t)`. Call on the optimized,
-    //! re-inferred body and repeat across re-inference until it returns false.
+    //! PHASE_FUSED finishing pass (delegates to `fuse_body`): collapse same-vector lane sums into
+    //! `dot(v, mask)`, re-pack ctor lane patterns, `a*b ± c` into mad, and the expanded lerp shape
+    //! back into lerp. Call on the optimized, re-inferred body; repeat until it returns false.
     return fuse_body(func, no_fast_math)
 }
 
 def public flatten_opt_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {
     //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin
     //! has no un-extracted uniform subtree, no un-CSE'd repeat, no un-rcp'd uniform division,
-    //! no un-packed ctor lane pattern.
+    //! no un-packed ctor lane pattern, no un-fused lane sum, no regroup-to-share miss.
     var res : array<string>
     ast_gc_guard() {
         res <- opt_residuals(func, FLATTEN_BARRIERS, no_fast_math)
@@ -942,7 +950,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // subtrees to top-of-body `_preshader_` lets, CSE-dedup repeated subtrees. Re-infer to
             // type the new lets, then fuse next cycle.
             set_flatten_phase(func, PHASE_OPTIMIZED)
-            if (flatten_optimize(twin, FLATTEN_BARRIERS, flatten_no_fast_math())) {
+            if (flatten_optimize(twin, FLATTEN_BARRIERS, flatten_no_fast_math(), flatten_log_cse())) {
                 astChanged = true
                 return true
             }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -2141,6 +2141,153 @@ def private cse_body(var blk : ExprBlock?; var counter : int&) : bool {
     return anyChange
 }
 
+// ===== Regroup-to-share (const-minus) =====
+// Reassoc's canonical sum order splits a `C - x` idiom out of a sum another expression carries whole
+// (`1 - mask` × two outputs), killing the describe-match CSE needs; re-emit as `(C - x) + rest`.
+
+def private cm_key(l, r : ExpressionPtr) : string {
+    return "{describe(l)}\t-\t{describe(r)}"
+}
+
+class private CmTally : AstVisitor {
+    counts : table<string; int>
+    mutableVars : table<string>
+    def override preVisitExprOp2(var expr : ExprOp2?) : void {
+        if (expr.op == "-" && is_all_const(expr.left) && !is_all_const(expr.right) &&
+                !reads_mutable(expr.right, mutableVars)) {
+            let k = cm_key(expr.left, expr.right)
+            counts[k] = (counts?[k] ?? 0) + 1
+        }
+    }
+}
+
+// A grouped `C - x` node already on the chain's spine — collect_add re-splits it into {+C, -x},
+// so without this check a regrouped chain would re-fire (and spin the fixpoint) forever.
+def private chain_has_grouped(e : ExpressionPtr; key : string) : bool {
+    if (e == null) return false
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        if (o.op == "+" || o.op == "-") {
+            if (o.op == "-" && is_all_const(o.left) && !is_all_const(o.right) && cm_key(o.left, o.right) == key) {
+                return true
+            }
+            return chain_has_grouped(o.left, key) || chain_has_grouped(o.right, key)
+        }
+    } elif (e is ExprOp1) {
+        let o = e as ExprOp1
+        if (o.op == "-") return chain_has_grouped(o.subexpr, key)
+    }
+    return false
+}
+
+// Fill `terms` + the (const, negated-var) indices to regroup, gated on a live `C - x` twin in
+// `cm`. ONE gate for the pass and the residual oracle. A ≥2-const chain is reassoc's business
+// (gather pending), and a mutable-reading x can't CSE-share, so neither is a candidate.
+def private regroup_candidate(var that : ExprOp2?; cm : table<string; int>; mutableVars : table<string>;
+                              no_fast_math : bool; var terms : array<ReTerm>; var ci : int&; var xi : int&) : bool {
+    if (that == null || !(that.op == "+" || that.op == "-") || (no_fast_math && is_float_valued(that))) {
+        return false
+    }
+    collect_add(that, false, terms)
+    ci = -1
+    for (i in range(length(terms))) {
+        if (is_all_const(terms[i].e)) {
+            if (ci >= 0) return false
+            ci = i
+        }
+    }
+    if (ci < 0 || terms[ci].neg) return false
+    for (i in range(length(terms))) {
+        if (i == ci || !terms[i].neg || reads_mutable(terms[i].e, mutableVars)) {
+            continue
+        }
+        let k = cm_key(terms[ci].e, terms[i].e)
+        if ((cm?[k] ?? 0) >= 1 && !chain_has_grouped(that, k)) {
+            xi = i
+            return true
+        }
+    }
+    return false
+}
+
+class private RegroupShareVisitor : AstVisitor {
+    changed : bool
+    noFastMath : bool
+    cm : table<string; int>
+    mutableVars : table<string>
+    def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
+        var terms : array<ReTerm>
+        var ci = -1
+        var xi = -1
+        if (!regroup_candidate(that, cm, mutableVars, noFastMath, terms, ci, xi)) {
+            unsafe {
+                delete terms
+            }
+            return that
+        }
+        var newTerms : array<ReTerm>
+        newTerms |> push(ReTerm(neg = false,
+            e = new ExprOp2(at = that.at, op := "-", left = terms[ci].e, right = terms[xi].e)))
+        for (i in range(length(terms))) {
+            if (i != ci && i != xi) {
+                newTerms |> push(terms[i])
+            }
+        }
+        changed = true
+        var r = build_chain(newTerms, that.at, "+", "-")
+        unsafe {
+            delete terms
+            delete newTerms
+        }
+        return r
+    }
+}
+
+class private RegroupResidualVisitor : AstVisitor {
+    found : bool
+    noFastMath : bool
+    cm : table<string; int>
+    mutableVars : table<string>
+    def override preVisitExprOp2(var expr : ExprOp2?) : void {
+        var terms : array<ReTerm>
+        var ci = -1
+        var xi = -1
+        if (regroup_candidate(expr, cm, mutableVars, noFastMath, terms, ci, xi)) {
+            found = true
+        }
+        unsafe {
+            delete terms
+        }
+    }
+}
+
+def private regroup_to_share(var blk : ExprBlock?; no_fast_math : bool) : bool {
+    var mutableVars <- collect_mutable(blk)
+    var ct = new CmTally()
+    ct.mutableVars := mutableVars
+    make_visitor(*ct) $(a) {
+        visit(blk, a)
+    }
+    var ch = false
+    if (!empty(ct.counts)) {
+        var rv = new RegroupShareVisitor(noFastMath = no_fast_math)
+        rv.cm := ct.counts
+        rv.mutableVars := mutableVars
+        make_visitor(*rv) $(a) {
+            visit(blk, a)
+        }
+        ch = rv.changed
+        unsafe {
+            delete rv
+        }
+    }
+    unsafe {
+        delete ct
+    }
+    delete mutableVars
+    return ch
+}
+
 // ===== Pure-alias elimination =====
 // Collapse `let X = <bare var V>` copies (V not reassigned) into direct refs to V and drop the let —
 // clears CSE's `_cse_a = _cse_b` leftovers and unroll/fold's `p_0 = ro`. General, not CSE-specific.
@@ -2372,6 +2519,30 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
             break
         }
     }
+    // Regroup residual: a sum still splitting {+C, -x} apart while a grouped `C - x` twin lives
+    // elsewhere in the body — regroup_to_share should have re-paired it for the CSE.
+    var cmt = new CmTally()
+    cmt.mutableVars := pe.mutableVars
+    make_visitor(*cmt) $(a) {
+        visit(blk, a)
+    }
+    if (!empty(cmt.counts)) {
+        var rr = new RegroupResidualVisitor(noFastMath = no_fast_math)
+        rr.cm := cmt.counts
+        rr.mutableVars := pe.mutableVars
+        make_visitor(*rr) $(a) {
+            visit(blk, a)
+        }
+        if (rr.found) {
+            res |> push("a sum splitting a 'C - x' apart from its grouped twin (regroup-to-share miss)")
+        }
+        unsafe {
+            delete rr
+        }
+    }
+    unsafe {
+        delete cmt
+    }
     // Alias residual: a pure single-def `let X = <bare var V>` copy (neither X nor V reassigned)
     // the cleanup should collapse. A reassigned X (`var X = V` reused across copies) is a real var.
     for (s in blk.list) {
@@ -2389,7 +2560,8 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
     // `mad` (or a mad still carrying the lerp shape) — gated on the same module visibility —
     // plus an un-packed ctor lane pattern (re-vectorize / shared factor), which needs no callable.
     let cm = fuse_callable(func._module, "mad")
-    var fr = new FuseResidualVisitor(checkMad = cm, checkLerp = cm && fuse_callable(func._module, "lerp"), noFastMath = no_fast_math)
+    var fr = new FuseResidualVisitor(checkMad = cm, checkLerp = cm && fuse_callable(func._module, "lerp"),
+        checkDot = !no_fast_math && fuse_callable(func._module, "dot", 2), noFastMath = no_fast_math)
     make_visitor(*fr) $(a) {
         visit(func.body, a)
     }
@@ -2405,6 +2577,9 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
     if (fr.foundCtor) {
         res |> push("an un-packed ctor lane pattern (should re-vectorize / extract the shared factor)")
     }
+    if (fr.foundDot) {
+        res |> push("an un-fused lane sum ('v.x + v.y + …' should be dot(v, mask))")
+    }
     unsafe {
         delete fr
     }
@@ -2415,15 +2590,66 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
     return <- res
 }
 
-def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false) : bool {
+// The CSE value-number cache (per-region pure-subtree tally, count ≥1) plus the const-minus shape
+// table — the raw material for grouping/variation decisions, dumped under `_flatten_log_cse`.
+def private log_cse_cache(func : FunctionPtr; var blk : ExprBlock?) {
+    var mutableVars <- collect_mutable(blk)
+    var counts : table<string; int>
+    for (i in range(length(blk.list))) {
+        var ct = new CseTally()
+        ct.mutableVars := mutableVars
+        make_visitor(*ct) $(a) {
+            cse_tally_stmt(blk.list[i], a)
+        }
+        for (k in keys(ct.counts)) {
+            counts[k] = (counts?[k] ?? 0) + (ct.counts?[k] ?? 0)
+        }
+        unsafe {
+            delete ct
+        }
+    }
+    var cm = new CmTally()
+    cm.mutableVars := mutableVars
+    make_visitor(*cm) $(a) {
+        visit(blk, a)
+    }
+    var ks <- [for (k in keys(counts)); k]
+    sort(ks) $(a, b : string) : bool {
+        let ca = counts?[a] ?? 0
+        let cb = counts?[b] ?? 0
+        if (ca != cb) {
+            return ca > cb
+        }
+        return a < b
+    }
+    to_log(LOG_INFO, "flatten cse cache [{func.name}]: {length(ks)} pure subtrees\n")
+    for (k in ks) {
+        to_log(LOG_INFO, "    {counts?[k] ?? 0}x  {k}\n")
+    }
+    var cks <- [for (k in keys(cm.counts)); k]
+    sort(cks)
+    to_log(LOG_INFO, "  const-minus shapes: {length(cks)}\n")
+    for (k in cks) {
+        to_log(LOG_INFO, "    {cm.counts?[k] ?? 0}x  {k}\n")
+    }
+    unsafe {
+        delete cm
+    }
+    delete counts
+    delete ks
+    delete cks
+    delete mutableVars
+}
+
+def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false; log_cse : bool = false) : bool {
     //! Post-fold optimize pass: hoist uniform (globals+literals) subtrees to top-of-body
-    //! `_preshader_N` lets, CSE-dedup repeats, collapse pure aliases — a joint fixpoint.
-    //! `barriers` = sampler/noise names that stay per-pixel. Post-fold, once; caller re-infers.
+    //! `_preshader_N` lets, regroup const-minus sums toward live `C - x` twins, CSE-dedup repeats,
+    //! collapse pure aliases — a joint fixpoint. `log_cse` dumps the final value-number cache.
     if (!(func.body is ExprBlock)) return false
     var blk = func.body as ExprBlock
-    // The passes enable each other — an alias subst / CSE share can re-expose uniform compute in
-    // the varying region (`!_preshader_0`) that only re-extraction hoists, so iterate the triple
-    // to a fixpoint. An exhausted guard means an oscillation regression — warn, never hang.
+    // The passes enable each other — an alias subst / CSE share can re-expose uniform compute only
+    // re-extraction hoists, and a regroup creates the very dup CSE shares, so iterate the set to a
+    // fixpoint. An exhausted guard means an oscillation regression — warn, never hang.
     var changed = false
     var guard = 0
     var cseCounter = 0
@@ -2432,6 +2658,9 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
         guard ++
         var round = false
         if (extract_preshader(func, blk, barriers, preCounter, no_fast_math)) {
+            round = true
+        }
+        if (regroup_to_share(blk, no_fast_math)) {
             round = true
         }
         if (cse_body(blk, cseCounter)) {
@@ -2447,6 +2676,9 @@ def public flatten_preshade_cse(var func : FunctionPtr; barriers : table<string>
     }
     if (guard >= 16) {
         to_log(LOG_WARNING, "flatten: cse/alias loop guard exhausted in {func.name} (oscillation?)\n")
+    }
+    if (log_cse) {
+        log_cse_cache(func, blk)
     }
     return changed
 }
@@ -2509,27 +2741,27 @@ def private negate_const(e : ExpressionPtr) : ExpressionPtr {
     return null
 }
 
-def private has_3arg_named(mod : Module?; fname : string) : bool {
+def private has_arity_named(mod : Module?; fname : string; argc : int) : bool {
     var found = false
     for_each_function(mod, fname) $(fn) {
-        if (length(fn.arguments) == 3) {
+        if (length(fn.arguments) == argc) {
             found = true
         }
     }
     for_each_generic(mod, fname) $(fn) {
-        if (length(fn.arguments) == 3) {
+        if (length(fn.arguments) == argc) {
             found = true
         }
     }
     return found
 }
 
-def private fuse_callable(mod : Module?; fname : string) : bool {
+def private fuse_callable(mod : Module?; fname : string; argc : int = 3) : bool {
     if (mod == null) return false
-    if (has_3arg_named(mod, fname)) return true
+    if (has_arity_named(mod, fname, argc)) return true
     var found = false
     module_for_each_dependency(mod) $(dep, _isPub) {
-        if (!found && has_3arg_named(dep, fname)) {
+        if (!found && has_arity_named(dep, fname, argc)) {
             found = true
         }
     }
@@ -2924,6 +3156,251 @@ def private ctor_fuse_rewrite(var that : ExprCall?; no_fast_math : bool) : Expre
     return new ExprOp2(at = that.at, op := "*", left = nc, right = new ExprConstFloat(at = that.at, value = bestC))
 }
 
+// ===== horizontal add → dot re-pack =====
+// `v.x + v.y (+ v.z + v.w)` — and weighted/negated lanes `v.x * c` — collapse into `dot(v, mask)`: one
+// node where every lane read is an instruction. Fast-math (reorders adds, ×0 a dead-lane inf/NaN).
+
+def private float_vec_dim(bt : Type) : int {
+    if (bt == Type.tFloat2) return 2
+    if (bt == Type.tFloat3) return 3
+    if (bt == Type.tFloat4) return 4
+    return 0
+}
+
+def private lane_index(comp : string) : int {
+    if (comp == "x") return 0
+    if (comp == "y") return 1
+    if (comp == "z") return 2
+    return 3
+}
+
+struct private DotGroup {
+    base : ExpressionPtr        // first lane's base node, reused as the dot's vector arg
+    dim : int
+    weights : float4
+    nterms : int
+}
+
+// One additive term as a (possibly const-weighted) lane read: `v.x`, `v.x * c`, `c * v.x`.
+def private dot_term_lane(var e : ExpressionPtr; var baseKey : string&; var base : ExpressionPtr&;
+                          var lane : int&; var w : float&) : bool {
+    var comp = ""
+    if (component_read_of(e, baseKey, base, comp)) {
+        lane = lane_index(comp)
+        w = 1.0
+        return true
+    }
+    var l, r : ExpressionPtr
+    if (!qmatch(e, $e(l) * $e(r)).matched) return false    // nolint:STYLE016 (qmatch macro expansion)
+    var c = 0.0
+    if (scalar_float_const(r, c) && component_read_of(l, baseKey, base, comp)) {
+        lane = lane_index(comp)
+        w = c
+        return true
+    }
+    if (scalar_float_const(l, c) && component_read_of(r, baseKey, base, comp)) {
+        lane = lane_index(comp)
+        w = c
+        return true
+    }
+    return false
+}
+
+// Bucket a chain's terms into per-base lane groups; `tKey[i]` carries term i's group key ("" for
+// a non-lane term). Shared by the fuser and the residual oracle — ONE gate, so a survivor is
+// always a fuser miss.
+def private dot_chain_groups(var terms : array<ReTerm>; var groups : table<string; DotGroup>;
+                             var tKey : array<string>) : bool {
+    tKey |> resize(length(terms))
+    for (i in range(length(terms))) {
+        var baseKey = ""
+        var base : ExpressionPtr
+        var lane = 0
+        var w = 0.0
+        if (!dot_term_lane(terms[i].e, baseKey, base, lane, w)) {
+            continue
+        }
+        tKey[i] = baseKey
+        if (terms[i].neg) {
+            w = -w
+        }
+        if (!key_exists(groups, baseKey)) {
+            groups[baseKey] = DotGroup(base = base, dim = float_vec_dim(expr_bt(base)))
+        }
+        groups[baseKey].weights[lane] += w
+        groups[baseKey].nterms ++
+    }
+    var any = false
+    for (g in values(groups)) {
+        if (g.nterms >= 2) {
+            any = true
+        }
+    }
+    return any
+}
+
+def private has_unfused_lane_dot(var that : ExprOp2?) : bool {
+    if (that == null || !(that.op == "+" || that.op == "-") || expr_bt(that) != Type.tFloat) return false
+    var terms : array<ReTerm>
+    collect_add(that, false, terms)
+    var groups : table<string; DotGroup>
+    var tKey : array<string>
+    let any = dot_chain_groups(terms, groups, tKey)
+    unsafe {
+        delete terms
+        delete groups
+    }
+    delete tKey
+    return any
+}
+
+// Rebuild the chain with every ≥2-lane group collapsed to `dot(base, mask)` — emitted at the
+// group's first term, term order otherwise preserved; null when no group qualifies. Operand
+// nodes are reused (each lands in one slot); the fused lane reads just drop.
+def private dot_fold_chain(var that : ExpressionPtr; var terms : array<ReTerm>) : ExpressionPtr {
+    var groups : table<string; DotGroup>
+    var tKey : array<string>
+    if (!dot_chain_groups(terms, groups, tKey)) {
+        unsafe {
+            delete groups
+        }
+        delete tKey
+        return null
+    }
+    var emitted : table<string>
+    var newTerms : array<ReTerm>
+    for (i in range(length(terms))) {
+        let k = tKey[i]
+        if (k == "") {
+            newTerms |> push(terms[i])
+            continue
+        }
+        var g = groups?[k] ?? default<DotGroup>
+        if (g.nterms < 2) {
+            newTerms |> push(terms[i])
+            continue
+        }
+        if (key_exists(emitted, k)) {
+            continue
+        }
+        emitted |> insert(k)
+        var lanes : array<ExpressionPtr>
+        lanes |> reserve(g.dim)
+        for (li in range(g.dim)) {
+            lanes |> push(new ExprConstFloat(at = that.at, value = g.weights[li]))
+        }
+        var cll = new ExprCall(at = that.at, name := "dot")
+        emplace(cll.arguments, g.base)
+        var mask = make_float_ctor(g.dim, that.at, lanes)
+        emplace(cll.arguments, mask)
+        newTerms |> push(ReTerm(neg = false, e = cll))
+        unsafe {
+            delete lanes
+        }
+    }
+    var r = build_chain(newTerms, that.at, "+", "-")
+    unsafe {
+        delete groups
+        delete newTerms
+    }
+    delete tKey
+    delete emitted
+    return r
+}
+
+// Top-down rewrite over the closed post-flatten node set: fold each maximal `+`/`-` chain once
+// (a bottom-up visitor would fold a sub-chain first and strand the outer lanes), recursing into
+// chain leaves and every other child slot.
+def private dot_fold_expr(var e : ExpressionPtr; var changed : bool&) : ExpressionPtr {
+    if (e == null) return null
+    if (e is ExprOp2) {
+        var o = e as ExprOp2
+        if ((o.op == "+" || o.op == "-") && expr_bt(o) == Type.tFloat) {
+            var terms : array<ReTerm>
+            collect_add(e, false, terms)
+            for (t in terms) {
+                // a chain leaf is never itself a chain, so the result is always `t.e` back
+                dot_fold_expr(t.e, changed)
+            }
+            var r = dot_fold_chain(e, terms)
+            unsafe {
+                delete terms
+            }
+            if (r != null) {
+                changed = true
+                return r
+            }
+            return e
+        }
+        o.left = dot_fold_expr(o.left, changed)
+        o.right = dot_fold_expr(o.right, changed)
+    } elif (e is ExprOp1) {
+        var o = e as ExprOp1
+        o.subexpr = dot_fold_expr(o.subexpr, changed)
+    } elif (e is ExprOp3) {
+        var o = e as ExprOp3
+        o.subexpr = dot_fold_expr(o.subexpr, changed)
+        o.left = dot_fold_expr(o.left, changed)
+        o.right = dot_fold_expr(o.right, changed)
+    } elif (e is ExprCall) {
+        var c = e as ExprCall
+        for (i in range(length(c.arguments))) {
+            c.arguments[i] = dot_fold_expr(c.arguments[i], changed)
+        }
+    } elif (e is ExprField) {
+        var o = e as ExprField
+        o.value = dot_fold_expr(o.value, changed)
+    } elif (e is ExprSwizzle) {
+        var o = e as ExprSwizzle
+        o.value = dot_fold_expr(o.value, changed)
+    } elif (e is ExprRef2Value) {
+        var o = e as ExprRef2Value
+        o.subexpr = dot_fold_expr(o.subexpr, changed)
+    } elif (e is ExprCast) {
+        var o = e as ExprCast
+        o.subexpr = dot_fold_expr(o.subexpr, changed)
+    } elif (e is ExprPtr2Ref) {
+        var o = e as ExprPtr2Ref
+        o.subexpr = dot_fold_expr(o.subexpr, changed)
+    } elif (e is ExprAt) {
+        var o = e as ExprAt
+        o.subexpr = dot_fold_expr(o.subexpr, changed)
+        o.index = dot_fold_expr(o.index, changed)
+    } elif (e is ExprMakeTuple) {
+        var o = e as ExprMakeTuple
+        for (vi in range(length(o.values))) {
+            o.values[vi] = dot_fold_expr(o.values[vi], changed)
+        }
+    } elif (e is ExprMakeStruct) {
+        var ms = e as ExprMakeStruct
+        for (si in range(length(ms.structs))) {
+            for (fld in *(ms.structs[si])) {
+                fld.value = dot_fold_expr(fld.value, changed)
+            }
+        }
+    }
+    return e
+}
+
+def private dot_fold_stmt(var s : ExpressionPtr; var changed : bool&) {
+    if (s is ExprLet) {
+        var lc = s as ExprLet
+        for (lv in lc.variables) {
+            if (lv.init != null) {
+                lv.init = dot_fold_expr(lv.init, changed)
+            }
+        }
+    } elif (s is ExprCopy) {
+        var cp = s as ExprCopy
+        cp.right = dot_fold_expr(cp.right, changed)
+    } elif (s is ExprReturn) {
+        var rt = s as ExprReturn
+        if (rt.subexpr != null) {
+            rt.subexpr = dot_fold_expr(rt.subexpr, changed)
+        }
+    }
+}
+
 class private CtorFuseVisitor : AstVisitor {
     changed : bool
     noFastMath : bool
@@ -2984,12 +3461,17 @@ class private LerpFuseVisitor : AstVisitor {
 class private FuseResidualVisitor : AstVisitor {
     checkMad : bool
     checkLerp : bool
+    checkDot : bool
     noFastMath : bool
     foundMad : bool
     foundLerp : bool
     foundNegAdd : bool
     foundCtor : bool
+    foundDot : bool
     def override preVisitExprOp2(var expr : ExprOp2?) : void {
+        if (checkDot && has_unfused_lane_dot(expr)) {
+            foundDot = true
+        }
         if (!checkMad) {
             return
         }
@@ -3021,12 +3503,23 @@ class private FuseResidualVisitor : AstVisitor {
 }
 
 def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool {
-    //! PHASE_FUSED finishing pass: re-pack ctor lane patterns (re-vectorize / shared factor),
-    //! `a*b ± c` into `mad(a,b,c)`, and the expanded lerp shape `mad(b - a, t, a)` back into
-    //! `lerp(a, b, t)` over the optimized, re-inferred body. Caller re-infers after each round.
+    //! PHASE_FUSED finishing pass: collapse same-vector lane sums into `dot(v, mask)`, re-pack
+    //! ctor lane patterns (re-vectorize / shared factor), `a*b ± c` into `mad(a,b,c)`, and the
+    //! expanded lerp shape back into `lerp(a, b, t)`. Caller re-infers after each round.
     if (!(func.body is ExprBlock)) return false
     var changed = false
-    // ctor re-pack first — its `ctor * s` / vector-op output feeds the mad walk this same round
+    // hadd → dot first — the mad walk would otherwise steal a weighted lane (`v.x * w + rest`)
+    if (!no_fast_math && fuse_callable(func._module, "dot", 2)) {
+        var blk = func.body as ExprBlock
+        var dchanged = false
+        for (s in blk.list) {
+            dot_fold_stmt(s, dchanged)
+        }
+        if (dchanged) {
+            changed = true
+        }
+    }
+    // ctor re-pack next — its `ctor * s` / vector-op output feeds the mad walk this same round
     var cv = new CtorFuseVisitor()
     cv.noFastMath = no_fast_math
     make_visitor(*cv) $(adapter) {

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -164,6 +164,15 @@ common-subexpression elimination (``flatten_optimize``):
   per pixel runs once per draw. Sampler / procedural intrinsics (``tex2d``, ``noise``)
   are *barriers* — they cannot run in a preshader, so a subtree containing one stays
   per-pixel even when its inputs are uniform.
+* **Regroup-to-share** repairs a sharing loss the reassociation pass can cause:
+  its canonical sum order (variables first, constants last) rewrites
+  ``1.0 - mask + edge`` into ``(edge - mask) + 1.0``, splitting the ``1.0 - mask``
+  another expression still carries whole — the shapes stop matching and the share
+  dies (burn's alpha cost one extra instruction exactly this way). A sum holding
+  ``{+C, -x, …}`` whose grouped ``C - x`` twin is live elsewhere in the body
+  re-emits as ``(C - x) + rest``, so the next CSE round shares the node. Gated on
+  the live twin (regrouping is count-neutral standalone, so it can never lose);
+  re-pairing moves the float association → **fast-math gated**.
 * **CSE** value-numbers the (now-canonical) body by structural key and shares any
   pure subtree computed twice or more into one ``let`` before its first use, so the
   backend emits one graph node and *N* links instead of *N* recomputations. The
@@ -181,8 +190,9 @@ common-subexpression elimination (``flatten_optimize``):
   re-extraction hoists to the per-draw group.
 
 Hoisting and sharing are **value-exact** — existing subtrees move, nothing regroups or
-rounds (the one exception is the fast-math division→reciprocal rewrite below) — and both
-passes exclude any subtree that reads a **reassigned** variable
+rounds (the exceptions are the fast-math regroup-to-share above and the
+division→reciprocal rewrite below) — and the passes exclude any subtree that reads a
+**reassigned** variable
 (a live/loop mask, a written global, or the base of an indexed store — ``G[i] = v``
 makes every ``G[...]`` read unstable), whose value is not stable across the body.
 
@@ -233,6 +243,22 @@ backend DSL). Fusion is value-exact at the das level (das ``mad`` computes
 ``a*b + c``); the *backend* may contract it to a single-rounding FMA — that is
 its call.
 
+**Horizontal adds become dots.** On a shader-graph ISA every lane read is a
+full instruction (a splat node), so ``c.x + c.y + c.z`` costs three splats and
+two adds — and ``dot(c, float3(1, 1, 1))`` costs **one**, the mask riding free
+as a constant operand. The fuse pass collects each maximal ``+``/``-`` chain's
+terms that are lane reads of one vector — bare ``v.x``, const-weighted
+``v.x * 0.299``, negated, repeated — and collapses every ≥2-lane group into a
+single ``dot(v, mask)``: missing lanes mask as ``0``, weights land in the mask
+(the luma idiom ``c.x*0.299 + c.y*0.587 + c.z*0.114`` becomes one dot against
+``float3(0.299, 0.587, 0.114)``), repeated lanes accumulate, and non-lane
+terms stay in the sum (``v.x + v.y + b → dot(v, float2(1, 1)) + b``). Worst
+case — every splat already shared elsewhere — a 2-lane fold trades one add for
+one dot (neutral); everything else strictly drops nodes (triplanar's weight
+normalize ``an.x + an.y + an.z`` drops 4 instructions). The fold reorders the
+float adds and multiplies skipped lanes by 0, so it is **fast-math gated**, and
+it runs only when a 2-argument ``dot`` is visible from the twin's module.
+
 **Division becomes a reciprocal multiply.** A divide is the most expensive
 arithmetic node a shader carries, and most divisors never change per pixel. The
 fold rewrites ``x / C`` (const ``C``, float family) into ``x * (1/C)`` with the
@@ -279,9 +305,10 @@ The fast-math opt-out
 
 flatten's default contract is a shader compiler's: fast math. Every
 value-changing rewrite — the float ``x*0 → 0`` / ``x - x → 0`` folds (inf/NaN
-propagation), float reassociation (association order), the ``lerp``
-const-selector short-circuits (they drop an argument), division→reciprocal,
-the float zero-lane kill, and majority-factor compensation — assumes finite
+propagation), float reassociation (association order), regroup-to-share (same),
+the ``lerp`` const-selector short-circuits (they drop an argument),
+division→reciprocal, the float zero-lane kill, the horizontal-add→dot re-pack,
+and majority-factor compensation — assumes finite
 inputs and tolerates ~1-ulp drift. A module that cannot accept that opts out
 with a user option:
 
@@ -397,6 +424,13 @@ Public API
     (see the mad/lerp section above). Same compile-time-only contract as
     ``flatten_no_fast_math``.
 
+``flatten_log_cse : bool``
+    True when the *compiling* module sets ``options _flatten_log_cse = true`` —
+    a debug dump of each twin's final CSE value-number cache (every pure-subtree
+    key with its occurrence count, plus the grouped ``C - x`` shape table) after
+    the optimize fixpoint, via ``to_log``. Same compile-time-only contract as
+    ``flatten_no_fast_math``.
+
 ``flatten_fold(var func, no_fast_math = false, expand_lerp = false) : bool``
     The post-inference fold pass: collapse ``const ? a : b`` selects, drop the
     pure ``lhs = lhs`` self-assigns, strip redundant zero initializers. Run it
@@ -423,19 +457,22 @@ Public API
     check — there is no compile-time flag; a missed fold is suboptimal, not an
     error, so it is validated by tests rather than gated in the macro.
 
-``flatten_optimize(var func, barriers : table<string>, no_fast_math = false) : bool``
+``flatten_optimize(var func, barriers : table<string>, no_fast_math = false, log_cse = false) : bool``
     The post-fold optimize pass: hoist maximal uniform subtrees to per-draw
     ``_preshader_`` lets, rewrite divisions by a uniform into per-draw
-    reciprocal multiplies (fast-math), CSE-dedup repeated subtrees, then
+    reciprocal multiplies (fast-math), regroup const-minus sums toward live
+    ``C - x`` twins (fast-math), CSE-dedup repeated subtrees, then
     collapse pure-alias ``let`` copies — iterating to a joint fixpoint. Run it **once** after
     the ``flatten_fold`` fixpoint converges (and *not* before — reassociation runs
     in the fold and would reorder a hoisted reference back into a fresh uniform
     subtree). ``barriers`` is the backend's sampler / intrinsic call-name set
-    (``{ "tex2d", "noise" }``) — those stay per-pixel. ``[flatten]`` runs it
+    (``{ "tex2d", "noise" }``) — those stay per-pixel. ``log_cse`` dumps the final
+    value-number cache. ``[flatten]`` runs it
     automatically; the ``[pixel_shader]`` backend runs it after its fold fixpoint.
 
 ``flatten_fuse(var func, no_fast_math = false) : bool``
-    The finishing fuse pass: re-pack ctor lane patterns (re-vectorization,
+    The finishing fuse pass: collapse same-vector lane sums into
+    ``dot(v, mask)`` (fast-math), re-pack ctor lane patterns (re-vectorization,
     shared-factor extraction, majority compensation), ``a*b ± c`` into
     ``mad(a, b, c)``, and the expanded lerp shape ``mad(b - a, t, a)`` back
     into ``lerp(a, b, t)``. Run it
@@ -449,8 +486,10 @@ Public API
     walks a compiled twin and returns a description for each missed optimization —
     a maximal uniform subtree still inline in the varying body, an un-rewritten
     division by a uniform, a pure subtree computed twice or more left un-shared,
+    a sum still splitting a ``C - x`` apart from its grouped twin,
     a pure-alias ``let`` copy left uncollapsed, a fusable mul-add left un-packed,
-    a mad still carrying the lerp shape, or an un-packed ctor lane pattern.
+    a mad still carrying the lerp shape, an un-fused same-vector lane sum, or an
+    un-packed ctor lane pattern.
     Empty means complete. Drives the same
     ``tests/flatten/test_flatten_fold.das`` corpus and the ``flatten-fuzz``
     strict mode.

--- a/examples/flatten/capability/cap_dot.shader
+++ b/examples/flatten/capability/cap_dot.shader
@@ -1,0 +1,25 @@
+require engine.render.shader_dsl
+
+// Capability demo: horizontal-add → dot re-fusion. Each lane read is a full graph node (a
+// splat), so `c.x + c.y + c.z` costs 3 splats + 2 adds; the finishing pass collapses it — and
+// the weighted `c.x*0.299 + c.y*0.587 + c.z*0.114` luma spelling — into ONE dot node each,
+// with the lane weights riding as a free const mask.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+[pixel_shader]
+def cap_dot(inp : PbrInput) : PbrOutput {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let lum = c.x * 0.299 + c.y * 0.587 + c.z * 0.114
+    let sum = c.x + c.y + c.z
+    return PbrOutput(
+        albedo = float3(lum, sum * 0.333, lum),
+        emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/cap_regroup.shader
+++ b/examples/flatten/capability/cap_regroup.shader
@@ -1,0 +1,26 @@
+require engine.render.shader_dsl
+
+// Capability demo: regroup-to-share. Reassoc canonicalizes the alpha sum `1 - mask + edge` to
+// `(edge - mask) + 1`, splitting the `1 - mask` the albedo line still carries whole — two sub
+// nodes where the source shares one. The regroup re-pairs the sum toward the live `1 - mask`
+// twin, CSE shares it, and the backend gets ONE sub node feeding both consumers.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+}
+
+[pixel_shader]
+def cap_regroup(inp : PbrInput) : PbrOutput {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let mask = saturate(inp.uv.y * 2.0 - 0.3)
+    let edge = saturate(inp.uv.x)
+    return PbrOutput(
+        albedo = c * (1.0 - mask),
+        emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0,
+        alpha = 1.0 - mask + edge
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -73,6 +73,14 @@
 #  18. cap_ctor.shader (ctor lane algebra) -> the zero-lane product collapses to an embedded
 #      constant (its sin lane dies) and the per-component adds re-vectorize into one vector
 #      add feeding one sin: exactly 1 sin + 1 add node in the whole graph.
+#
+#  19. cap_dot.shader (horizontal adds) -> dot nodes. Each lane read is a full splat node, so
+#      `c.x+c.y+c.z` costs 5 nodes; the finishing pass folds it (and the weighted luma form)
+#      into ONE dot each, the lane weights riding as a free const mask: 2 dots, 0 splats.
+#
+#  20. cap_regroup.shader (a `1 - mask` feeding two outputs) -> one shared sub. Reassoc's
+#      canonical sum order splits the alpha copy apart; the regroup re-pairs it toward the
+#      albedo's grouped twin so CSE shares the node: exactly 1 sub in the graph.
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -356,6 +364,35 @@ if [[ "$errs" -eq 0 && "$sins" -eq 1 && "$adds" -eq 1 ]]; then
     echo "   ok — 1 sin + 1 add (zero-lane product folded; adds re-vectorized)"
 else
     echo "   FAIL — errors=$errs sins=$sins adds=$adds (expected 1 and 1)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "19. cap_dot.shader (horizontal adds -> dot nodes, no splat chains)"
+out="$(compile "$here/cap_dot.shader")"
+dots="$(echo "$out" | grep '^node ' | grep -cw 'dot_f3')"
+splats="$(echo "$out" | grep '^node ' | grep -c 'splat')"
+errs="$(echo "$out" | grep -ci error)"
+# `c.x+c.y+c.z` and the weighted luma spelling each fuse into ONE dot with a const mask;
+# un-fused each costs 3 splat nodes + 2 adds (lane reads are full graph nodes).
+if [[ "$errs" -eq 0 && "$dots" -eq 2 && "$splats" -eq 0 ]]; then
+    echo "   ok — 2 dot nodes, 0 splats (lane sums fused)"
+else
+    echo "   FAIL — errors=$errs dots=$dots splats=$splats (expected 2 and 0)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "20. cap_regroup.shader (alpha sum re-paired toward the albedo's '1 - mask' -> one sub)"
+out="$(compile "$here/cap_regroup.shader")"
+subs="$(echo "$out" | grep '^node ' | grep -cw 'sub')"
+errs="$(echo "$out" | grep -ci error)"
+# reassoc canonicalizes alpha to `(edge - mask) + 1` (a second sub); the regroup re-pairs it as
+# `(1 - mask) + edge` so CSE shares the albedo's sub node — exactly ONE sub in the graph.
+if [[ "$errs" -eq 0 && "$subs" -eq 1 ]]; then
+    echo "   ok — 1 shared sub node (the regrouped '1 - mask')"
+else
+    echo "   FAIL — errors=$errs subs=$subs (expected 1)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -127,7 +127,8 @@ def test_flatten_fold(t : T?) {
     }
     t |> run("dot corpus fuses clean (test_flatten_dot.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_dot.das")
-        t |> success(n >= 11, "expected >=11 twins, checked {n}")
+        t |> success(n >= 12, "expected >=12 twins, checked {n}")
+        // weighted + negated lanes in one chain land in the mask: dot(a, (2, 3, -4))
         // the hadd must come back as a dot call (symmetric-oracle guard: fuser and residual
         // share dot_chain_groups, so only a POSITIVE assert catches a matcher break blinding both)
         var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_dot.das")
@@ -137,6 +138,8 @@ def test_flatten_fold(t : T?) {
         t |> success(lu |> find("dot(") >= 0, "weighted lanes must fuse to dot: {lu}")
         let ne = bodies?["d_nested_flat"] ?? ""
         t |> success(ne |> find("dot(") >= 0, "lane sum inside a call arg must fuse: {ne}")
+        let wn = bodies?["d_wneg_flat"] ?? ""
+        t |> success(wn |> find("float3(2f,3f,-4f)") >= 0, "weighted/negated lanes must land in the mask: {wn}")
         delete bodies
     }
     t |> run("mad/lerp corpus fuses clean (test_flatten_mad.das twins)") @(t : T?) {

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -115,7 +115,29 @@ def test_flatten_fold(t : T?) {
     }
     t |> run("optimize corpus folds clean (test_flatten_opt.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_opt.das")
-        t |> success(n >= 7, "expected >=7 twins, checked {n}")
+        t |> success(n >= 14, "expected >=14 twins, checked {n}")
+        // regroup-to-share FIRED proof: reassoc canonicalizes alpha to `(e - b) + 1f`, so a
+        // shared `_cse_` let only appears when the regroup re-paired `1f - b` for the CSE
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_opt.das")
+        let rg = bodies?["r_oneminus_flat"] ?? ""
+        t |> success(rg |> find("_cse_") >= 0, "regrouped '1 - b' must CSE-share with the albedo use: {rg}")
+        let ra = bodies?["r_anyconst_flat"] ?? ""
+        t |> success(ra |> find("_cse_") >= 0, "regrouped '0.5 - b' must CSE-share: {ra}")
+        delete bodies
+    }
+    t |> run("dot corpus fuses clean (test_flatten_dot.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_dot.das")
+        t |> success(n >= 11, "expected >=11 twins, checked {n}")
+        // the hadd must come back as a dot call (symmetric-oracle guard: fuser and residual
+        // share dot_chain_groups, so only a POSITIVE assert catches a matcher break blinding both)
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_dot.das")
+        let h4 = bodies?["d_hadd4_flat"] ?? ""
+        t |> success(h4 |> find("dot(") >= 0, "v.x+v.y+v.z+v.w must fuse to dot: {h4}")
+        let lu = bodies?["d_luma_flat"] ?? ""
+        t |> success(lu |> find("dot(") >= 0, "weighted lanes must fuse to dot: {lu}")
+        let ne = bodies?["d_nested_flat"] ?? ""
+        t |> success(ne |> find("dot(") >= 0, "lane sum inside a call arg must fuse: {ne}")
+        delete bodies
     }
     t |> run("mad/lerp corpus fuses clean (test_flatten_mad.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_mad.das")

--- a/tests/flatten/test_flatten_dot.das
+++ b/tests/flatten/test_flatten_dot.das
@@ -57,6 +57,12 @@ def d_dup(v : float2) : float {
     return v.x + v.x + v.y
 }
 
+// ----- weighted AND negated lanes in one chain -> dot(a, (2, 3, -4)) -----
+[flatten]
+def d_wneg(a : float3) : float {
+    return 2.0 * a.x + 3.0 * a.y - 4.0 * a.z
+}
+
 // ----- two base vectors in one sum -> two independent dots -----
 [flatten]
 def d_two(a : float2; b : float2) : float {
@@ -106,11 +112,12 @@ def test_flatten_dot(t : T?) {
             fapprox(t, d_luma_flat(float3(v, v * 0.5, -v)), d_luma(float3(v, v * 0.5, -v)))
         }
     }
-    t |> run("negated / mixed / repeated lanes — value approx") @(t : T?) {
+    t |> run("negated / mixed / repeated / weighted-negated lanes — value approx") @(t : T?) {
         for (v in GRID) {
             fapprox(t, d_neg_flat(float3(v, 7.5, 1.0)), d_neg(float3(v, 7.5, 1.0)))
             fapprox(t, d_mixed_flat(float3(v, -v, 1.0), v * 0.25), d_mixed(float3(v, -v, 1.0), v * 0.25))
             fapprox(t, d_dup_flat(float2(v, 7.5)), d_dup(float2(v, 7.5)))
+            fapprox(t, d_wneg_flat(float3(v, -v, 2.5)), d_wneg(float3(v, -v, 2.5)))
         }
     }
     t |> run("two base vectors — value approx") @(t : T?) {

--- a/tests/flatten/test_flatten_dot.das
+++ b/tests/flatten/test_flatten_dot.das
@@ -1,0 +1,131 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Differential net for the PHASE_FUSED horizontal-add → dot re-pack: a sum of same-vector lane
+//! reads — bare `v.x`, const-weighted `v.x * c`, negated, repeated — collapses into `dot(v, mask)`
+//! with missing lanes masked by 0. The dot reorders the adds and runs hardware-dotted, so floats
+//! compare approx (same contract as the mad corpus). The structural FIRED half (a `dot(` call in
+//! the twin) lives in no_aot/test_flatten_fold.das.
+
+// ----- bare horizontal adds, every width -----
+[flatten]
+def d_hadd2(v : float2) : float {
+    return v.x + v.y
+}
+
+[flatten]
+def d_hadd3(v : float3) : float {
+    return v.x + v.y + v.z
+}
+
+[flatten]
+def d_hadd4(v : float4) : float {
+    return v.x + v.y + v.z + v.w
+}
+
+// ----- partial lanes of a wider vector: the skipped lane rides as mask 0 -----
+[flatten]
+def d_partial4(v : float4) : float {
+    return v.x + v.y + v.z
+}
+
+// ----- const-weighted lanes (the luma idiom) -----
+[flatten]
+def d_luma(c : float3) : float {
+    return c.x * 0.299 + c.y * 0.587 + c.z * 0.114
+}
+
+// ----- negated lane -> negative mask weight -----
+[flatten]
+def d_neg(v : float3) : float {
+    return v.x - v.y
+}
+
+// ----- non-lane leftover term + negated lanes -----
+[flatten]
+def d_mixed(v : float3; e : float) : float {
+    return e - v.x - v.y
+}
+
+// ----- repeated lane accumulates its weight: (2, 1) -----
+[flatten]
+def d_dup(v : float2) : float {
+    return v.x + v.x + v.y
+}
+
+// ----- two base vectors in one sum -> two independent dots -----
+[flatten]
+def d_two(a : float2; b : float2) : float {
+    return a.x + a.y + b.x + b.y
+}
+
+// ----- lane sum buried inside a call argument -----
+[flatten]
+def d_nested(v : float2) : float {
+    return sin(v.x + v.y)
+}
+
+// ----- variable weight is NOT a lane term: one lane left -> no dot, mad fuses instead -----
+[flatten]
+def d_varweight(v : float2; w : float) : float {
+    return v.x * w + v.y
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "dot-fused approx mismatch: {a} vs {b}")
+}
+
+[test]
+def test_flatten_dot(t : T?) {
+    t |> run("bare horizontal adds — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_hadd2_flat(float2(v, 7.5)), d_hadd2(float2(v, 7.5)))
+            fapprox(t, d_hadd3_flat(float3(v, -v, 2.5)), d_hadd3(float3(v, -v, 2.5)))
+            fapprox(t, d_hadd4_flat(float4(v, -v, 2.5, 0.125)), d_hadd4(float4(v, -v, 2.5, 0.125)))
+        }
+    }
+    t |> run("partial lanes — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_partial4_flat(float4(v, -v, 2.5, 1.0e9)), d_partial4(float4(v, -v, 2.5, 1.0e9)))
+        }
+    }
+    t |> run("weighted lanes (luma) — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_luma_flat(float3(v, v * 0.5, -v)), d_luma(float3(v, v * 0.5, -v)))
+        }
+    }
+    t |> run("negated / mixed / repeated lanes — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_neg_flat(float3(v, 7.5, 1.0)), d_neg(float3(v, 7.5, 1.0)))
+            fapprox(t, d_mixed_flat(float3(v, -v, 1.0), v * 0.25), d_mixed(float3(v, -v, 1.0), v * 0.25))
+            fapprox(t, d_dup_flat(float2(v, 7.5)), d_dup(float2(v, 7.5)))
+        }
+    }
+    t |> run("two base vectors — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_two_flat(float2(v, 2.0), float2(-v, 3.0)), d_two(float2(v, 2.0), float2(-v, 3.0)))
+        }
+    }
+    t |> run("lane sum inside a call arg — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_nested_flat(float2(v, 0.75)), d_nested(float2(v, 0.75)))
+        }
+    }
+    t |> run("variable weight stays out — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, d_varweight_flat(float2(v, 7.5), v * 0.5), d_varweight(float2(v, 7.5), v * 0.5))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_opt.das
+++ b/tests/flatten/test_flatten_opt.das
@@ -6,15 +6,15 @@ require dastest/testing_boost public
 require daslib/flatten
 require math
 
-//! Differential net for the flatten OPTIMIZE arc (preshader extraction + CSE).
-//! Both passes are VALUE-EXACT — they only hoist and dedup pure subtrees, never
-//! regroup or round — so twins compare with exact `equal` (unlike the reassoc
-//! arc). ONE carve-out: PHASE_FUSED re-packs a vector mul-add into `mad`, which
-//! runs hardware-fused (FMA, single rounding), so a vector twin where that fires
-//! (p_vec) compares approx. The FIRED proof (a `_preshader_` let on top, a shared
-//! `_cse_` let) lives in `no_aot/test_flatten_fold.das` (empty
-//! `flatten_opt_residuals`) and the cap_preshader / cap_cse node-count shaders;
-//! here we only assert the optimization preserved the result.
+//! Differential net for the flatten OPTIMIZE arc (preshader extraction + CSE +
+//! regroup-to-share). Hoist/dedup passes are VALUE-EXACT, so their twins compare
+//! with exact `equal` (unlike the reassoc arc). Carve-outs compare approx: a twin
+//! where PHASE_FUSED packs a mul-add into hardware-fused `mad` (p_vec, the r_*
+//! returns), and the regroup twins themselves (re-pairing `C - x` moves the float
+//! association). The FIRED proof (a `_preshader_` let on top, a shared `_cse_`
+//! let) lives in `no_aot/test_flatten_fold.das` (empty `flatten_opt_residuals`)
+//! and the cap_preshader / cap_cse node-count shaders; here we only assert the
+//! optimization preserved the result.
 
 // Module globals are UNIFORM (preshader-eligible); function params are VARYING.
 var G_GAIN = 2.5
@@ -122,6 +122,29 @@ def c_store(a : int; b : int) : int {
     return G_BUF[(a * 3 + b) & 7]
 }
 
+// ----- regroup-to-share: reassoc canonicalizes `1 - b + e` to `(e - b) + 1` which splits the
+// `1 - b` the albedo line carries whole; the regroup re-pairs it so CSE shares ONE node -----
+[flatten]
+def r_oneminus(b : float; e : float; c : float) : float {
+    let albedo = c * (1.0 - b)
+    let alpha = 1.0 - b + e
+    return albedo + alpha * 2.0
+}
+
+// ----- regroup is keyed on the exact const, not just 1.0 -----
+[flatten]
+def r_anyconst(b : float; e : float; c : float) : float {
+    let p = c * (0.5 - b)
+    let q = 0.5 - b + e
+    return p + q * 2.0
+}
+
+// ----- no grouped twin anywhere -> no regroup, canonical order stands (differential guard) -----
+[flatten]
+def r_notwin(b : float; e : float) : float {
+    return 1.0 - b + e
+}
+
 var GRID : array<float>
 
 [init]
@@ -195,6 +218,14 @@ def test_flatten_opt(t : T?) {
         for (v in GRID) {
             let n = int(v)
             t |> equal(c_at_flat(n, n + 1), c_at(n, n + 1))
+        }
+    }
+    t |> run("regroup-to-share: const-minus re-pairs toward the grouped twin (approx — fused mad)") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, r_oneminus_flat(v, v * 0.5, -v), r_oneminus(v, v * 0.5, -v))
+            fapprox(t, r_anyconst_flat(v, v * 0.5, -v), r_anyconst(v, v * 0.5, -v))
+            // no twin -> reassoc's canonical `(e - b) + 1` stands (approx: the association moved)
+            fapprox(t, r_notwin_flat(v, v * 0.5), r_notwin(v, v * 0.5))
         }
     }
     t |> run("CSE: indexed-store base is mutable (no read shared across stores)") @(t : T?) {


### PR DESCRIPTION
Follow-up to #3088, implementing the engine authors' horizontal-add feedback plus the burn `1 - burnMask` fix.

## Horizontal add → dot (PHASE_FUSED)

On the shader-graph ISA every lane read is a full instruction (a splat node), so `c.x + c.y + c.z` costs 5 nodes while `dot(c, float3(1,1,1))` costs **one** — the const mask rides free as an operand. The fuse pass now collects each maximal `+`/`-` chain's terms that are lane reads of one vector — bare `v.x`, const-weighted `v.x * 0.299`, negated, repeated — and collapses every ≥2-lane group into a single `dot(v, mask)`:

- missing lanes mask as `0`, weights land in the mask (the luma idiom `c.x*0.299 + c.y*0.587 + c.z*0.114` becomes one dot), repeated lanes accumulate, non-lane terms stay in the sum
- maximal-chain only: the rewrite recurses top-down from statement roots — a bottom-up visitor would fold the inner `a.x + a.y` first and strand `+ a.z`
- runs **first** in `fuse_body` (the mad walk would otherwise steal `v.x*w + rest`), fast-math gated, and only when a 2-argument `dot` is visible from the twin's module

## Regroup-to-share (optimize fixpoint)

Reassoc's canonical sum order (vars first, const last) rewrites burn's alpha `1.0 - burnMask + edgeMask` into `(edgeMask - burnMask) + 1.0`, splitting the `1.0 - burnMask` the albedo line still carries whole — the shapes stop describe-matching and the share dies (+1 instruction). A sum holding `{+C, -x, …}` whose grouped `C - x` twin is live elsewhere in the body now re-emits as `(C - x) + rest`, so the next CSE round shares the node. Gated on the live twin (regrouping is count-neutral standalone, so it can never lose); a spine check on the already-grouped form is the termination guard.

## `options _flatten_log_cse`

Debug dump of each twin's final CSE value-number cache (every pure-subtree key with its count, plus the grouped `C - x` shape table) after the optimize fixpoint — raw material for share-policy decisions.

## Real-ISA results (88-shader engine sweep, vs current master)

| shader | gpu | depth | peak_reg |
|---|---|---|---|
| triplanar | 24 → 20 | 22 → 18 | 7 → 6 |
| burn | 25 → 24 | — | — |
| shiny | 13 → 11 | — | — |
| plasma | flat | — | 7 → 6 |

Zero shaders worse; consts +2 slots. triplanar is the engine authors' exact example (`an.x + an.y + an.z` weight normalize); burn is exactly the predicted regroup fix (one shared sub feeding both outputs); plasma is the modeled neutral case (2 lanes whose splats were already CSE-shared).

## Completeness

Both arms ride the shared-matcher discipline: `dot_chain_groups` / `regroup_candidate` are the ONE gate for the fuser/pass **and** the residual oracle, and `flatten_opt_residuals` gained both checks (validated over every corpus + every example shader by the no_aot meta-test).

## Tests

- `tests/flatten/test_flatten_dot.das` — 11 differential twins (widths, partial lanes, luma weights, negated/mixed/repeated lanes, two base vectors, chain inside a call arg, variable-weight non-fire)
- regroup twins (`r_oneminus`, `r_anyconst`, `r_notwin`) in the optimize corpus
- meta-test structural arms: `d_hadd4`/`d_luma`/`d_nested` must contain `dot(`; `r_oneminus`/`r_anyconst` must contain `_cse_` (the symmetric-oracle guard — only a positive assert catches a matcher break blinding fuser and oracle together)
- capability tier: `cap_dot.shader` (2 dot nodes, 0 splats) + `cap_regroup.shader` (exactly 1 sub node)

## Validation

interp full-tree 10862/0 · JIT full-tree clean-cache 10421/0 · AOT full-tree 10184/0 (rebuilt `test_aot`) · flatten suite 238/238 · fuzz int/strict/bool (strict residuals 3=3 vs master, seed 7) · examples 69/69 + capability 20/20 · MCP + CI lint 0 issues · Sphinx 0 warnings · scoped detect-dupe: only the deliberate option-reader mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)