### PR TITLE
ast: describe() output no longer depends on print history

### DIFF
--- a/src/ast/ast_print.cpp
+++ b/src/ast/ast_print.cpp
@@ -11,9 +11,11 @@
 namespace das {
 
     // print flags are sticky node bits; without a wipe the output of a subtree print depends on
-    // what larger trees the node was printed inside before (describe() must be pure — CSE keys on it)
+    // what larger trees the node was printed inside before (describe() must be pure — CSE keys on it).
+    // opts into quote AND assume interiors — everything the Printer below descends into.
     class ClearPrinterFlags : public Visitor {
         virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return true; }
+        virtual bool canVisitWithAliasSubexpression ( ExprAssume * ) override { return true; }
         virtual void preVisitExpression ( Expression * expr ) override {
             Visitor::preVisitExpression(expr);
             expr->printFlags = 0;

--- a/src/ast/ast_print.cpp
+++ b/src/ast/ast_print.cpp
@@ -10,6 +10,16 @@
 
 namespace das {
 
+    // print flags are sticky node bits; without a wipe the output of a subtree print depends on
+    // what larger trees the node was printed inside before (describe() must be pure — CSE keys on it)
+    class ClearPrinterFlags : public Visitor {
+        virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return true; }
+        virtual void preVisitExpression ( Expression * expr ) override {
+            Visitor::preVisitExpression(expr);
+            expr->printFlags = 0;
+        }
+    };
+
     class SetPrinterFlags : public Visitor {
     // ExprBlock
         virtual void preVisitBlockExpression ( ExprBlock * block, Expression * expr ) override {
@@ -1451,6 +1461,8 @@ namespace das {
         ast_print::Standalone ctx;
         ctx.setFlags(this);
 #else
+        ClearPrinterFlags cflags;
+        visit(cflags);
         SetPrinterFlags pflags;
         visit(pflags);
 #endif
@@ -1458,6 +1470,8 @@ namespace das {
 
     template <typename TT>
     __forceinline StringWriter&  print ( StringWriter& stream, const TT & value ) {
+        ClearPrinterFlags cflags;
+        const_cast<TT&>(value).visit(cflags);
         SetPrinterFlags flags;
         const_cast<TT&>(value).visit(flags);
         Printer log(nullptr);
@@ -1477,6 +1491,8 @@ namespace das {
         }, "*");
         if (any) stream << "\n";
         bool logGenerics = program.options.getBoolOption("log_generics");
+        ClearPrinterFlags cflags;
+        const_cast<Program&>(program).visit(cflags, logGenerics);
         SetPrinterFlags flags;
         const_cast<Program&>(program).visit(flags, logGenerics);
         Printer log(&program);

--- a/tests/.das_test
+++ b/tests/.das_test
@@ -51,7 +51,7 @@ def can_visit_folder(folder_name : string; var result : bool?) {
             }
         }
     }
-    if (folder_name == "ast_match") {
+    if (folder_name == "ast_match" || folder_name == "ast") {
         let args <- get_command_line_arguments()
         for (arg in args) {
             if (arg == "--use-aot" || arg == "-jit") {

--- a/tests/ast/test_describe_purity.das
+++ b/tests/ast/test_describe_purity.das
@@ -1,0 +1,34 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/ast
+require daslib/ast_boost
+require daslib/templates_boost
+
+//! describe() must be a pure function of node structure. The printer marks sticky per-node
+//! print flags (argLevel / topLevel / bottomLevel); without the pre-print wipe a node once
+//! printed as a call argument keeps argLevel forever and describes WITHOUT outer parens,
+//! while an identical fresh node describes with them. CSE value-numbering keys on describe,
+//! so the unstable key silently loses shares (glitch_2d spelled `_cse_2 + _cse_1` twice and
+//! shared it zero times).
+
+[test]
+def test_describe_purity(t : T?) {
+    ast_gc_guard() {
+        var fresh = qmacro(1f - x)
+        let d0 = "{describe(fresh)}"
+        // print an identical sum in a CALL-ARG position — this used to stamp argLevel on it
+        // for good, so its next standalone describe dropped the outer parens
+        var wrapped = qmacro(sin(1f - x))
+        let _whole = "{describe(wrapped)}"
+        if (wrapped is ExprCall) {
+            var inner = (wrapped as ExprCall).arguments[0]
+            t |> equal("{describe(inner)}", d0, "print history must not change a subtree's describe")
+        } else {
+            t |> failure("expected qmacro(sin(…)) to parse as ExprCall, got {wrapped.__rtti}")
+        }
+        // the fresh node's own describe must not drift across repeated prints either
+        t |> equal("{describe(fresh)}", d0, "repeated describe of the same node must be stable")
+    }
+}

--- a/tests/ast/test_describe_purity.das
+++ b/tests/ast/test_describe_purity.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options rtti
 
 require dastest/testing_boost public
 require daslib/ast

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -105,12 +105,12 @@ endforeach()
 add_dependencies(all_utils_exe dastest_exe)
 
 # Prewarm the JIT dll cache for the whole test tree, except the folders dastest
-# also excludes under -jit (gc, ast_match, no_aot — they use runtime quote/qmacro
+# also excludes under -jit (gc, ast_match, ast, no_aot — they use runtime quote/qmacro
 # the JIT can't lower). Reuses the jit_exe target built by the foreach above (bin/jit.exe, built
 # with --jit-register-all-modules). Run explicitly:
 #   ninja jit_cache_all_tests
 add_custom_target(jit_cache_all_tests
-    COMMAND ${UTIL_BIN_DIR}/jit.exe ${PROJECT_SOURCE_DIR}/tests --parallel 0 $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3> --exclude gc --exclude dasHV --exclude dasPUGIXML --exclude dasSQLITE --exclude stbimage --exclude live_host --exclude audio --exclude strudel --exclude ast_match --exclude no_aot
+    COMMAND ${UTIL_BIN_DIR}/jit.exe ${PROJECT_SOURCE_DIR}/tests --parallel 0 $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3> --exclude gc --exclude dasHV --exclude dasPUGIXML --exclude dasSQLITE --exclude stbimage --exclude live_host --exclude audio --exclude strudel --exclude ast_match --exclude ast --exclude no_aot
     DEPENDS jit_exe
     WORKING_DIRECTORY ${UTIL_BIN_DIR}
     COMMENT "JIT-compiling tests/ into the .jitted_scripts cache"


### PR DESCRIPTION
`SetPrinterFlags` marks sticky per-node print bits (`topLevel`/`argLevel`/`bottomLevel`) and nothing ever cleared them — so a node once printed as a call argument kept `argLevel` forever and described **without** outer parens, while a structurally identical fresh node described with them. `describe()` was a function of print *history*, not structure.

Anything keying on describe pays for that — flatten's CSE value numbering first of all: glitch_2d's flattened body spelled `_cse_2 + _cse_1` twice (once keying `(_cse_2 + _cse_1)`, once bare) and shared it **zero** times. A corpus tally over all 69 example shaders found this exact class as the only CSE-variation miss.

**Fix:** wipe the subtree's print flags (`ClearPrinterFlags`) before `SetPrinterFlags` in every print entry point — the Expression/Function `print()` template, `Program operator<<`, and `Program::setPrintFlags()`. describe becomes a pure function of structure (one extra O(n) walk per print).

**Effect:** with stable keys glitch_2d's repeated sum now CSEs into one node and mad-fuses (`mad(glitchColorB, b.z, glitchColorA*r.x)` shared by tint and emission); the corpus tally drops to zero paren-key misses. The real-engine 88-shader sweep is **count-flat** (its own structural CSE had recovered the identical trees); CSE-less backends drop the duplicate outright, and flatten's cache counts — which drive `bestKey` selection and the ≥2 residual oracle — are truthful again.

**Regression test:** `tests/ast/test_describe_purity.das` — prints an identical sum in a call-arg position (which used to stamp `argLevel` for good) and asserts the subtree's standalone describe matches a fresh node's; gated interp-only in `tests/.das_test` (runtime daslib/ast, same as ast_match).

**Validation:** interp full-tree 10853/0 · JIT clean-cache 10412/0 · AOT 10175/0 (`test_aot` host) · flatten suite 228/228 · examples 69/69 + capability all green · fuzz int/strict (residuals 3=3 vs baseline, seed 7) · engine sweep counts match baseline · CI lint 0.

Composes with #3089: once both land, the regrouped burn alpha and the float3-lane `1 - b` all converge on one shared `_cse_` (the demo there shares 3-way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)