### PR TITLE
flatten: swizzle lane fold — resolve lane provenance, re-emit the cheapest form

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -865,6 +865,11 @@ class private FoldResidualVisitor : AstVisitor {
             found |> push("an unfolded constant '!'")
         }
     }
+    def override preVisitExprSwizzle(var expr : ExprSwizzle?) : void {
+        if (is_unfolded_swizzle_lanes(expr)) {
+            found |> push("an un-folded swizzle over decomposable lanes ('ctor(…).mask' should re-pack)")
+        }
+    }
 }
 
 def public flatten_fold_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -717,6 +717,14 @@ class private FoldVisitor : AstVisitor {
         }
         return that
     }
+    def override visitExprSwizzle(var that : ExprSwizzle?) : ExpressionPtr {
+        var r = swizzle_fold_rewrite(that)
+        if (r != null) {
+            changed = true
+            return r
+        }
+        return that
+    }
 }
 
 // A scalar zero/default literal (int 0, float 0.0, bool false, …). A `var x = <this>` init is
@@ -1517,6 +1525,324 @@ def public fold_body(var func : FunctionPtr; no_fast_math : bool = false; expand
         }
     }
     return changed
+}
+
+// ===== Swizzle lane fold =====
+// `ctor(args…).mask` pays a combine + an extract for separable lanes: resolve each output lane's
+// provenance, re-emit the cheapest form (base / swizzle / scalar / splat / narrower ctor).
+
+struct private LaneSrc {
+    lane : int          // -1: e itself is the lane; >= 0: lane of e
+    e : ExpressionPtr   // scalar expr when lane < 0, else the (opaque) float-vector base
+}
+
+def private lane_letter(i : int) : string {
+    if (i == 0) return "x"
+    if (i == 1) return "y"
+    if (i == 2) return "z"
+    return "w"
+}
+
+// float2/3/4 ctor call of ANY arity (full per-lane, mixed vector+scalar, splat); null otherwise.
+def private float_ctor_of(e : ExpressionPtr) : ExprCall? {
+    if (e == null || !(e is ExprCall)) return null
+    var c = e as ExprCall
+    let nm = psh_simple_name("{c.name}")
+    if (nm != "float2" && nm != "float3" && nm != "float4") return null
+    return c
+}
+
+def private r2v_unwrap(var e : ExpressionPtr) : ExpressionPtr {
+    return e is ExprRef2Value ? (e as ExprRef2Value).subexpr : e
+}
+
+// The fold arm's firing gate (and the residual oracle's): a value resolve_lanes can see through.
+def private swizzle_decomposable(e : ExpressionPtr) : bool {
+    if (e == null) return false
+    if (e is ExprRef2Value) return swizzle_decomposable((e as ExprRef2Value).subexpr)
+    if (e is ExprConstFloat2 || e is ExprConstFloat3 || e is ExprConstFloat4) return true
+    if (e is ExprSwizzle) return float_vec_dim(expr_bt((e as ExprSwizzle).value)) > 0
+    return float_ctor_of(e) != null
+}
+
+// Per-output-lane provenance of a float-vector expr. Sees through float ctors of any arity,
+// vector const literals, nested swizzles, component-read scalar args and Ref2Value wraps; an
+// opaque vector contributes (e, 0..d-1). False only when something isn't a typed float vector.
+def private resolve_lanes(var e : ExpressionPtr; var out : array<LaneSrc>) : bool {
+    if (e == null) return false
+    if (e is ExprRef2Value) return resolve_lanes((e as ExprRef2Value).subexpr, out)
+    let d = float_vec_dim(expr_bt(e))
+    if (d == 0) return false
+    if (e is ExprConstFloat2) {
+        let v = (e as ExprConstFloat2).value
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.x)))
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.y)))
+        return true
+    }
+    if (e is ExprConstFloat3) {
+        let v = (e as ExprConstFloat3).value
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.x)))
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.y)))
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.z)))
+        return true
+    }
+    if (e is ExprConstFloat4) {
+        let v = (e as ExprConstFloat4).value
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.x)))
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.y)))
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.z)))
+        out |> push(LaneSrc(lane = -1, e = new ExprConstFloat(at = e.at, value = v.w)))
+        return true
+    }
+    if (e is ExprSwizzle) {
+        var sw = e as ExprSwizzle
+        var inner : array<LaneSrc>
+        var ok = resolve_lanes(sw.value, inner)
+        if (ok) {
+            for (f in sw.fields) {
+                if (int(f) >= length(inner)) {
+                    ok = false
+                } else {
+                    out |> push(inner[int(f)])
+                }
+            }
+        }
+        unsafe {
+            delete inner
+        }
+        return ok && length(sw.fields) == d
+    }
+    var c = float_ctor_of(e)
+    if (c != null) {
+        // splat: the one scalar arg fills every lane (emitters clone the duplicate references)
+        if (length(c.arguments) == 1 && expr_bt(c.arguments[0]) == Type.tFloat) {
+            for (_i in range(d)) {
+                out |> push(LaneSrc(lane = -1, e = c.arguments[0]))
+            }
+            return true
+        }
+        var total = 0
+        for (i in range(length(c.arguments))) {
+            var a = c.arguments[i]
+            let abt = expr_bt(a)
+            if (abt == Type.tFloat) {
+                var bk = ""
+                var base : ExpressionPtr
+                var comp = ""
+                if (component_read_of(a, bk, base, comp)) {
+                    out |> push(LaneSrc(lane = lane_index(comp), e = base))
+                } else {
+                    out |> push(LaneSrc(lane = -1, e = a))
+                }
+                total ++
+            } elif (float_vec_dim(abt) > 0) {
+                if (!resolve_lanes(a, out)) return false
+                total += float_vec_dim(abt)
+            } else {
+                return false
+            }
+        }
+        return total == d
+    }
+    // opaque float vector — contributes its own lanes
+    for (i in range(d)) {
+        out |> push(LaneSrc(lane = i, e = e))
+    }
+    return true
+}
+
+let private SWF_NONE = 0
+let private SWF_VALUE = 1      // identity selection — drop the swizzle, keep the value
+let private SWF_BASE = 2       // single base, full in-order width — the base itself
+let private SWF_SWIZZLE = 3    // single base — one re-masked swizzle
+let private SWF_SCALAR = 4     // one scalar lane — the scalar expr
+let private SWF_SPLAT = 5      // every lane the same non-const scalar — splat ctor
+let private SWF_CTOR = 6       // re-pack whole bases + scalars into a narrower/permuted ctor
+
+// Maximal consecutive same-base groups of a selection ((start, len) each); scalar lanes are
+// singleton runs. Shared by classify (validity) and the rewrite (emission) so they cannot drift.
+def private swizzle_sel_runs(sel : array<LaneSrc>; var runs : array<int2>) {
+    var i = 0
+    while (i < length(sel)) {
+        if (sel[i].lane < 0) {
+            runs |> push(int2(i, 1))
+            i ++
+        } else {
+            let bk = describe(sel[i].e)
+            var j = i + 1
+            while (j < length(sel) && sel[j].lane >= 0 && describe(sel[j].e) == bk) {
+                j ++
+            }
+            runs |> push(int2(i, j - i))
+            i = j
+        }
+    }
+}
+
+// Decide which rewrite a swizzle's resolved selection admits and fill `sel` for the builder.
+// Shared by the fold arm and the residual oracle — ONE gate, so a survivor is always a fold miss.
+def private swizzle_fold_classify(var that : ExprSwizzle?; var sel : array<LaneSrc>) : int {
+    if (that == null || that.fieldFlags.write) return SWF_NONE
+    let nOut = length(that.fields)
+    if (nOut < 1 || nOut > 4 || !swizzle_decomposable(that.value)) return SWF_NONE
+    var lanes : array<LaneSrc>
+    var ok = resolve_lanes(that.value, lanes)
+    let nLanes = length(lanes)
+    if (ok) {
+        for (f in that.fields) {
+            if (int(f) >= nLanes) {
+                ok = false
+            }
+        }
+    }
+    if (ok) {
+        for (f in that.fields) {
+            sel |> push(lanes[int(f)])
+        }
+    }
+    unsafe {
+        delete lanes
+    }
+    if (!ok) return SWF_NONE
+    var nScalar = 0
+    for (s in sel) {
+        if (s.lane < 0) {
+            nScalar ++
+        }
+    }
+    // single-base arms: every lane a component of one (describe-equal) base
+    if (nScalar == 0) {
+        let k0 = describe(sel[0].e)
+        var same = true
+        for (s in sel) {
+            if (describe(s.e) != k0) {
+                same = false
+            }
+        }
+        if (same) {
+            var ident = nOut == float_vec_dim(expr_bt(sel[0].e))
+            for (i in range(nOut)) {
+                if (sel[i].lane != i) {
+                    ident = false
+                }
+            }
+            return ident ? SWF_BASE : SWF_SWIZZLE
+        }
+    }
+    if (nOut == 1) return SWF_SCALAR    // the single component-lane case returned above
+    // identity selection over the whole value — just drop the swizzle node
+    var ident = nOut == nLanes
+    if (ident) {
+        for (i in range(nOut)) {
+            if (int(that.fields[i]) != i) {
+                ident = false
+            }
+        }
+    }
+    if (ident) return SWF_VALUE
+    // every lane the same non-const scalar — splat (all-const packs to a literal via SWF_CTOR)
+    if (nScalar == nOut) {
+        let k0 = describe(sel[0].e)
+        var same = true
+        for (s in sel) {
+            if (describe(s.e) != k0) {
+                same = false
+            }
+        }
+        var cv = 0.0
+        if (same && !scalar_float_const(sel[0].e, cv)) return SWF_SPLAT
+    }
+    // ctor re-pack: only whole in-order bases ride free (a partial run would pay fresh extracts)
+    if (nOut > nLanes) return SWF_NONE
+    var runs : array<int2>
+    swizzle_sel_runs(sel, runs)
+    var bad = false
+    for (r in runs) {
+        if (sel[r.x].lane >= 0) {
+            if (r.y != float_vec_dim(expr_bt(sel[r.x].e))) {
+                bad = true
+            } else {
+                for (k in range(r.y)) {
+                    if (sel[r.x + k].lane != k) {
+                        bad = true
+                    }
+                }
+            }
+        }
+    }
+    // rebuilding the value's own arg list is churn, not a fold (e.g. `float2(a, a).yx`)
+    if (!bad) {
+        var vc = float_ctor_of(r2v_unwrap(that.value))
+        if (vc != null && length(vc.arguments) == length(runs)) {
+            var same = true
+            for (idx in range(length(runs))) {
+                if (describe(sel[runs[idx].x].e) != describe(vc.arguments[idx])) {
+                    same = false
+                }
+            }
+            bad = same
+        }
+    }
+    delete runs
+    return bad ? SWF_NONE : SWF_CTOR
+}
+
+// Oracle mirror for the swizzle fold arm (FoldResidualVisitor in flatten.das).
+def public is_unfolded_swizzle_lanes(var e : ExprSwizzle?) : bool {
+    var sel : array<LaneSrc>
+    let k = swizzle_fold_classify(e, sel)
+    unsafe {
+        delete sel
+    }
+    return k != SWF_NONE
+}
+
+// Build the replacement classify picked. Source nodes are reused (the old tree is discarded
+// whole); only a source landing in a second output lane gets cloned.
+def private swizzle_fold_rewrite(var that : ExprSwizzle?) : ExpressionPtr {
+    var sel : array<LaneSrc>
+    let kind = swizzle_fold_classify(that, sel)
+    var res : ExpressionPtr
+    if (kind == SWF_VALUE) {
+        res = that.value
+    } elif (kind == SWF_BASE || kind == SWF_SCALAR) {
+        res = sel[0].e
+    } elif (kind == SWF_SWIZZLE) {
+        var mask = ""
+        for (s in sel) {
+            mask += lane_letter(s.lane)     // nolint:PERF001 (a mask is at most 4 letters)
+        }
+        res = new ExprSwizzle(at = that.at, value = sel[0].e, mask := mask)
+    } elif (kind == SWF_SPLAT) {
+        var sc = sel[0].e
+        res = make_float_splat(length(sel), that.at, sc)
+    } elif (kind == SWF_CTOR) {
+        var runs : array<int2>
+        swizzle_sel_runs(sel, runs)
+        var args : array<ExpressionPtr>
+        args |> reserve(length(runs))
+        var seen : table<string>
+        for (r in runs) {
+            var a = sel[r.x].e
+            let k = describe(a)
+            if (key_exists(seen, k)) {
+                a = clone_expression(a)
+            } else {
+                seen |> insert(k)
+            }
+            args |> push(a)
+        }
+        res = make_float_ctor(length(sel), that.at, args)
+        delete runs
+        delete seen
+        unsafe {
+            delete args
+        }
+    }
+    unsafe {
+        delete sel
+    }
+    return res
 }
 
 // ===== Preshader extraction + CSE =====
@@ -2854,7 +3180,8 @@ def private make_float_ctor(d : int; at : LineInfo; var lanes : array<Expression
     var c1 = 0.0
     var c2 = 0.0
     var c3 = 0.0
-    if (scalar_float_const(lanes[0], c0) && scalar_float_const(lanes[1], c1) &&
+    // const-collapse needs one scalar arg per lane — the swizzle re-pack passes mixed-arity lists
+    if (length(lanes) == d && scalar_float_const(lanes[0], c0) && scalar_float_const(lanes[1], c1) &&
             (d < 3 || scalar_float_const(lanes[2], c2)) && (d < 4 || scalar_float_const(lanes[3], c3))) {
         if (d == 2) return new ExprConstFloat2(at = at, value = float2(c0, c1))
         if (d == 3) return new ExprConstFloat3(at = at, value = float3(c0, c1, c2))

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -144,6 +144,21 @@ constant *arithmetic* but not constant *constructors*, and never a runtime-opera
 or reassociation), done here under a shader's fast-math assumption (``x*0 → 0`` fires by
 default; ``options _flatten_no_fast_math`` turns the float forms off — see below).
 
+**Swizzle lane fold.** A swizzle over a value whose lanes are separable — a float
+constructor of any arity, a vector const literal, or another swizzle — resolves every
+output lane to its provenance and re-emits the cheapest equivalent form. A selection
+covering one whole base hands back the base itself (``float4(v, 1f).xyz → v`` — the
+endemic *helper-returns-float4-with-alpha* shape; the constructor, the extract and the
+dropped lanes' compute all die), or one composed swizzle (``float4(v.zyx, 1f).xz → v.zx``,
+``v.zyx.xz → v.zx``); a single lane hands back the scalar argument
+(``float3(a, b, c).y → b``); the rest re-pack as a narrower constructor, splat, or const
+literal (``float4(sin(x), x, 3f, cos(x)).yz → float2(x, 3f)`` — the ``sin``/``cos`` die).
+Component-read scalar arguments decompose too, so ``float3(v.x, v.y, v.z).xyz``
+re-vectorizes to ``v``. Pure lane selection is bit-exact, so the fold is never
+fast-math gated. The one cost gate: a *partial* run of a base inside a re-pack
+(``float3(v2, s).yz`` would need a ``v2.y`` extract the original didn't pay for) is left
+alone — lane reads are full instructions on the target ISA.
+
 The fold and the typer's const-fold are *mutually-enabling*, so the fold phase
 **iterates to a fixpoint**. Flattening folds the runtime-operand identities the
 typer will not (``0*b → 0``); the re-infer between passes then const-folds the
@@ -448,8 +463,8 @@ Public API
     Test-framework / fuzzer introspection: walks a compiled twin's final body
     and returns a description for each const-foldable residual a complete fold
     should have collapsed — an unconditional algebraic identity (``x*1``,
-    ``x+0``, …), an all-const foldable call, a const-condition select, or
-    ``!const``. Empty means clean. It runs over the *compiled* output (not at
+    ``x+0``, …), an all-const foldable call, a const-condition select,
+    ``!const``, or a swizzle over decomposable lanes. Empty means clean. It runs over the *compiled* output (not at
     transform time), so it covers backend paths such as ``[pixel_shader]`` and
     is the fold-completeness oracle for both ``tests/flatten/test_flatten_fold.das``
     (the ``[flatten]`` + const-identity corpus and every example shader) and the

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -81,6 +81,9 @@
 #  20. cap_regroup.shader (a `1 - mask` feeding two outputs) -> one shared sub. Reassoc's
 #      canonical sum order splits the alpha copy apart; the regroup re-pairs it toward the
 #      albedo's grouped twin so CSE shares the node: exactly 1 sub in the graph.
+#
+#  21. cap_swizzle.shader (`float4(rgb, 1f).xyz` after inlining) -> the swizzle lane fold
+#      collapses the combine + extract + dead alpha const back to the float3: 0 combine nodes.
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -393,6 +396,21 @@ if [[ "$errs" -eq 0 && "$subs" -eq 1 ]]; then
     echo "   ok — 1 shared sub node (the regrouped '1 - mask')"
 else
     echo "   FAIL — errors=$errs subs=$subs (expected 1)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
+echo "21. cap_swizzle.shader (float4(rgb, 1f).xyz -> the float3 itself, combine + extract die)"
+out="$(compile "$here/cap_swizzle.shader")"
+combines="$(echo "$out" | grep '^node ' | grep -c 'combine')"
+dots="$(echo "$out" | grep '^node ' | grep -cw 'dot_f3')"
+errs="$(echo "$out" | grep -ci error)"
+# the inlined helper returns float4(baseColor * d, 1f); the caller's .xyz selects the whole
+# leading float3 arg, so the lane fold hands back `baseColor * d` — no combine survives
+if [[ "$errs" -eq 0 && "$combines" -eq 0 && "$dots" -eq 1 ]]; then
+    echo "   ok — 0 combine nodes (the swizzled ctor collapsed to its float3 arg)"
+else
+    echo "   FAIL — errors=$errs combines=$combines dots=$dots (expected 0 and 1)"
     echo "$out" | grep -i error | head
     fail=1
 fi

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -142,6 +142,24 @@ def test_flatten_fold(t : T?) {
         t |> success(wn |> find("float3(2f,3f,-4f)") >= 0, "weighted/negated lanes must land in the mask: {wn}")
         delete bodies
     }
+    t |> run("swizzle corpus folds clean (test_flatten_swizzle.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_swizzle.das")
+        t |> success(n >= 14, "expected >=14 twins, checked {n}")
+        // the FIRED proof (symmetric-oracle guard: fold arm and residual share
+        // swizzle_fold_classify, so only a POSITIVE assert catches a matcher break blinding both)
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_swizzle.das")
+        let c3 = bodies?["s_ctor3_flat"] ?? ""
+        t |> success(c3 |> find("float4") < 0, "float4(v,1f).xyz must collapse to v: {c3}")
+        let nx = bodies?["s_nestedxz_flat"] ?? ""
+        t |> success(nx |> find("v.zx") >= 0, "float4(v.zyx,1f).xz must compose to v.zx: {nx}")
+        let dd = bodies?["s_dropdead_flat"] ?? ""
+        t |> success(dd |> find("sin") < 0 && dd |> find("float2(x,3f)") >= 0,
+            "dropped lanes' compute must die with the re-pack: {dd}")
+        // the cost-gate control: a partial base run must survive UN-folded (and un-flagged)
+        let pt = bodies?["s_partial_flat"] ?? ""
+        t |> success(pt |> find(".yz") >= 0, "a partial base run must stay put: {pt}")
+        delete bodies
+    }
     t |> run("mad/lerp corpus fuses clean (test_flatten_mad.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_mad.das")
         t |> success(n >= 20, "expected >=20 twins, checked {n}")

--- a/tests/flatten/test_flatten_swizzle.das
+++ b/tests/flatten/test_flatten_swizzle.das
@@ -1,0 +1,152 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Differential net for the swizzle lane fold: `ctor(args…).mask` resolves every output lane to
+//! its provenance (scalar arg / lane of an opaque vector / const) and re-emits the cheapest
+//! equivalent — the base itself, one swizzle, a scalar, a splat, or a narrower ctor. Pure lane
+//! selection is bit-exact, so every compare here is EXACT equal. The structural FIRED half lives
+//! in no_aot/test_flatten_fold.das.
+
+// ----- full leading vector arg selected whole: the ctor and the 1f die -----
+[flatten]
+def s_ctor3(v : float3) : float3 {
+    return float4(v, 1.0).xyz
+}
+
+// ----- nested swizzle composes through the ctor: float4(v.zyx, 1).xz -> v.zx -----
+[flatten]
+def s_nestedxz(v : float3) : float2 {
+    return float4(v.zyx, 1.0).xz
+}
+
+// ----- single lane kills the whole ctor -----
+[flatten]
+def s_lane(a : float; b : float; c : float) : float {
+    return float3(a, b, c).y
+}
+
+// ----- swizzle-of-swizzle composes to one mask -----
+[flatten]
+def s_swsw(v : float4) : float2 {
+    return v.zyx.xz
+}
+
+// ----- mixed ctor: selected scalar + const re-pack narrower -----
+[flatten]
+def s_mixed(v : float2; s : float) : float2 {
+    return float4(v, s, 2.0).zw
+}
+
+// ----- dropped lanes' compute dies with them -----
+[flatten]
+def s_dropdead(x : float) : float2 {
+    return float4(sin(x), x, 3.0, cos(x)).yz
+}
+
+// ----- splat ctor narrows to a splat -----
+[flatten]
+def s_splat(s : float) : float2 {
+    return float4(s).xy
+}
+
+// ----- identity selection just drops the swizzle node -----
+[flatten]
+def s_identity(v : float2; s : float) : float3 {
+    return float3(v, s).xyz
+}
+
+// ----- all-const lanes collapse to a vector literal -----
+[flatten]
+def s_const(x : float) : float2 {
+    return float4(1.0, 2.0, 3.0, 4.0).wy + float2(x)
+}
+
+// ----- component-read args re-vectorize to the base itself -----
+[flatten]
+def s_revec(v : float3) : float3 {
+    return float3(v.x, v.y, v.z).xyz
+}
+
+// ----- permutation re-pack: the extract dies, args reorder -----
+[flatten]
+def s_perm(a : float; b : float; c : float) : float3 {
+    return float3(a, b, c).zyx
+}
+
+// ----- whole-base run + scalar ride into a narrower ctor -----
+[flatten]
+def s_widen(v : float2; s : float) : float3 {
+    return float4(v, s, 4.0).xyz
+}
+
+// ----- repeated source lane: the duplicate clones -----
+[flatten]
+def s_repeat(a : float; b : float; c : float; d : float) : float3 {
+    return float4(a, b, c, d).xyx
+}
+
+// ----- partial base run stays: re-packing would pay extracts the original didn't -----
+[flatten]
+def s_partial(v : float2; s : float) : float2 {
+    return float3(v, s).yz
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def eq2(t : T?; a, b : float2) {
+    t |> equal(a.x, b.x)
+    t |> equal(a.y, b.y)
+}
+
+def eq3(t : T?; a, b : float3) {
+    t |> equal(a.x, b.x)
+    t |> equal(a.y, b.y)
+    t |> equal(a.z, b.z)
+}
+
+[test]
+def test_flatten_swizzle(t : T?) {
+    t |> run("whole-base / nested / swizzle-of-swizzle — exact") @(t : T?) {
+        for (v in GRID) {
+            eq3(t, s_ctor3_flat(float3(v, -v, 2.5)), s_ctor3(float3(v, -v, 2.5)))
+            eq2(t, s_nestedxz_flat(float3(v, -v, 2.5)), s_nestedxz(float3(v, -v, 2.5)))
+            eq2(t, s_swsw_flat(float4(v, -v, 2.5, 0.125)), s_swsw(float4(v, -v, 2.5, 0.125)))
+        }
+    }
+    t |> run("single lane / mixed re-pack / dead lanes — exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(s_lane_flat(v, -v, 2.5), s_lane(v, -v, 2.5))
+            eq2(t, s_mixed_flat(float2(v, -v), v * 0.5), s_mixed(float2(v, -v), v * 0.5))
+            eq2(t, s_dropdead_flat(v), s_dropdead(v))
+        }
+    }
+    t |> run("splat / identity / const literal — exact") @(t : T?) {
+        for (v in GRID) {
+            eq2(t, s_splat_flat(v), s_splat(v))
+            eq3(t, s_identity_flat(float2(v, -v), v * 0.5), s_identity(float2(v, -v), v * 0.5))
+            eq2(t, s_const_flat(v), s_const(v))
+        }
+    }
+    t |> run("re-vectorize / permutation / narrower ctor / repeat — exact") @(t : T?) {
+        for (v in GRID) {
+            eq3(t, s_revec_flat(float3(v, -v, 2.5)), s_revec(float3(v, -v, 2.5)))
+            eq3(t, s_perm_flat(v, -v, 2.5), s_perm(v, -v, 2.5))
+            eq3(t, s_widen_flat(float2(v, -v), v * 0.5), s_widen(float2(v, -v), v * 0.5))
+            eq3(t, s_repeat_flat(v, -v, 2.5, 0.125), s_repeat(v, -v, 2.5, 0.125))
+        }
+    }
+    t |> run("partial base run stays put — exact") @(t : T?) {
+        for (v in GRID) {
+            eq2(t, s_partial_flat(float2(v, -v), v * 0.5), s_partial(float2(v, -v), v * 0.5))
+        }
+    }
+}


### PR DESCRIPTION
## What

A new fold arm: a swizzle over a value whose lanes are separable — a float ctor of **any arity** (full per-lane, mixed vector+scalar, splat), a vector const literal, or another swizzle — resolves every output lane to its provenance and re-emits the cheapest equivalent form. One recursive resolver (`resolve_lanes`) instead of per-shape pattern arms, so nested compositions fall out for free.

| input | output | arm |
|---|---|---|
| `float4(v, 1f).xyz` | `v` | whole base — ctor, extract, dead alpha const all die |
| `float4(v.zyx, 1f).xz` | `v.zx` | nested swizzle composes through the ctor |
| `v.zyx.xz` | `v.zx` | swizzle-of-swizzle |
| `float3(a, b, c).y` | `b` | single lane kills the ctor |
| `float4(sin(x), x, 3f, cos(x)).yz` | `float2(x, 3f)` | narrower re-pack; `sin`/`cos` die |
| `float4(s).xy` | `float2(s)` | splat narrows |
| `float3(v.x, v.y, v.z).xyz` | `v` | component-read args re-vectorize |
| `float4(1f, 2f, 3f, 4f).wy` | `float2(4f, 2f)` | const literal |
| `float3(v2, s).yz` | *(unchanged)* | partial base run — re-packing would pay a `v2.y` extract the original didn't |

Pure lane selection is **bit-exact**, so the arm is never fast-math gated and every differential twin compares exact. Cost gates: a partial base run inside a re-pack is left alone (lane reads are full instructions on the target ISA), expansion never re-packs (only the splat arm wins there), and rebuilding the value's own arg list is rejected as churn (termination).

The motivating shape is `cap_swizzle.shader`'s inlined `lighting()` helper — `float4(baseColor * d, 1f).xyz` used to carry a dead `combineFloat4F3F1` + extract + dead `1f` into the graph; it now collapses to the `float3` mul (capability case 21, real-backend gpu 6→5).

## Symmetric oracle

`FoldResidualVisitor` gains a `preVisitExprSwizzle` arm via the public `is_unfolded_swizzle_lanes`, which shares `swizzle_fold_classify` with the fold arm — one gate, so a surviving foldable swizzle is always a fold miss. The meta-test carries POSITIVE structural asserts (collapse to `v`, compose to `v.zx`, dead-`sin` re-pack) plus the partial-run negative control.

Also fixes a latent OOB in `make_float_ctor`: its const-collapse indexed `lanes[0..d-1]`, which the new mixed-arity re-pack (`float3(v2, s)` — 2 args, d=3) would walk off; now gated on `length(lanes) == d` (existing dot/fuse callers always pass exactly d).

## Validation

- `tests/flatten` 251/251 interp; new `test_flatten_swizzle.das` (14 twins, exact equal) passes interp + JIT (clean cache) + AOT
- full tree: interp 10870/0, JIT 10427/0, AOT 10190/0
- flatten-fuzz: int 20 batches, bool 20, strict-fold 20 — all PASS; strict residuals 41 = 41 vs master (same seeds, pre-existing run-ordering class; the new oracle adds zero)
- `examples/flatten/run.sh` 69/69; `capability/check.sh` 21/21 (new case 21)
- real-backend sweep (90 shaders): `cap_swizzle` gpu 6→5, everything else count-identical
- MCP + CI lint 0 issues; Sphinx 0 warnings; dupe scan: only the intentional `lane_letter`/`lane_index` mirror pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)