### PR TITLE
CI: revive CodeQL — v3 action, build-mode none, wired to PRs + weekly cron

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,9 @@ on:
 jobs:
   analyze:
     name: analyze (c-cpp)
+    # fork PRs get a read-only GITHUB_TOKEN, so the SARIF upload would fail —
+    # skip them; the post-merge master push scans their code anyway
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest-fat
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,70 +1,61 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
+# CodeQL static analysis over the C++ surface (src, include, modules,
+# tests-cpp). build-mode none — no traced build, so a run costs minutes, not a
+# full build per PR; switch to a built mode only if finding quality ever
+# warrants it. PR checks flag NEW alerts only; the pre-existing backlog lives
+# in the Security tab and does not gate PRs. .das files are invisible to
+# CodeQL — that surface is covered by the in-tree lint.
+
 on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'modules/**'
+      - 'tests-cpp/**'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'modules/**'
+      - 'tests-cpp/**'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    # weekly full refresh keeps the master baseline current even when no
+    # C++-touching push happens (PR alert diffing compares against it)
+    - cron: '20 3 * * 1'
   workflow_dispatch:
 
 jobs:
   analyze:
-    name: Analyze
+    name: analyze (c-cpp)
     runs-on: ubuntu-latest-fat
+    timeout-minutes: 90
     permissions:
       actions: read
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'cpp', 'javascript', 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+        languages: c-cpp
+        build-mode: none
+        # vendored code — findings there are not actionable here
+        config: |
+          paths-ignore:
+            - 3rdparty
+            - tests-cpp/3rdparty
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:c-cpp"


### PR DESCRIPTION
## What

Rewrites the dormant `.github/workflows/codeql.yml`. The existing file was the stock GitHub template parked on `workflow_dispatch`-only — it never triggered automatically, and it sits on `codeql-action@v2`, which GitHub has since sunset, so even a manual dispatch fails today.

## Design

- **`languages: c-cpp` only.** `.das` is invisible to CodeQL (covered by the in-tree lint, which is stricter anyway); the template's javascript/python lanes scanned a handful of scripts for the price of two extra jobs per run.
- **`build-mode: none`** instead of Autobuild — no traced build, so a run costs minutes rather than a full build per PR. Can be upgraded to a built mode later if finding quality warrants the precision.
- **Vendored code excluded** from analysis (`3rdparty/`, `tests-cpp/3rdparty/`) — findings in fmt/uriparser/doctest aren't actionable here. Modules pull externals via FetchContent, so nothing else is in-tree.
- **Triggers:** PRs and master pushes path-filtered to the C++ surface (`src/`, `include/`, `modules/`, `tests-cpp/`), a weekly cron to keep the master baseline fresh (PR alert diffing compares against it), and `workflow_dispatch` kept for manual runs. Org `ubuntu-latest-fat` runner label kept per 9f7d8d0ca.

## Adoption note

PR checks flag only alerts **new in the diff**. The first scan of the codebase will land a backlog of findings in the Security tab — that backlog does not gate PRs and can be triaged (or ignored) independently.

Companion to the local-vs-CI coverage-gap work (#3102): Copilot review covers diff-scoped judgment, CodeQL adds whole-program dataflow on the C++ surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)