### PR TITLE
preflight: header change escalates cpp-syntax to a full frontend sweep (coverage-gap stage 3, downscoped)

### DIFF
--- a/COVERAGE_GAP.md
+++ b/COVERAGE_GAP.md
@@ -67,12 +67,33 @@ Process: per-stage plan → implement → review, same as FIXED_ARRAY_REWORK.md.
 - CI-only das surface list (dasOpenGL, sequence, release tooling …) compiled
   via `compile_check` with proper mounts.
 
-## Stage 3 — local build matrix
+## Stage 3 — local build matrix (downscoped by decision, 2026-06-11)
 
-- clang-cl CMake preset in a gitignored alt build dir, wired into
-  `preflight --full` (compile-focused; full builds affordable but rarely needed).
-- mingw preset: deferred unless a mingw-specific failure class appears.
-- Debug-config build target for the fused-path divergence family.
+No local clang-cl/mingw build dirs. The preset idea died on two facts:
+(a) the only recorded incident in this family (the doctest bit-field) is
+frontend-level — the Stage 2 syntax pass catches it; the residual classes
+(link divergence, codegen-only issues) are rare and arrive batched in one
+cheap-to-iterate CI log; (b) all build dirs of one source tree share `bin/`,
+`lib/`, and `modules/<X>/*.shared_module` outputs (only Debug gets a
+`_debug` suffix), so a local clang-cl Release build clobbers the primary
+MSVC artifacts — isolating it would need a root-CMakeLists output knob,
+upstream complexity for speculative benefit.
+
+What shipped instead (measured: full `/Zs` frontend sweep of all 157
+src+tests-cpp TUs = 5-7 s warm, ~30 s cold):
+
+- `cpp-syntax` escalates to the full src+tests-cpp sweep whenever a core
+  header (`.h`/`.hpp`/`.inc`) changed — closes the header-ripple /
+  template-instantiation gap, the one real class a full clang build would
+  have added over the syntax pass.
+- `-I{build_dir}/include` added to the gate — latent false-FAIL for TUs
+  including configure-generated `modules/external_*.inc`
+  (e.g. `src/simulate/fs_file_info.cpp`).
+- skills/preflight.md: the verbatim clang-cl mirror is marked
+  separate-clone-only (the clobber); the Debug-config recipe for the
+  fused-path family is documented as safe in-checkout (`bin/Debug/`,
+  `_debug.shared_module` coexist with Release by design). Recipes, not
+  standing gates.
 
 ## Stage 4 — CI
 

--- a/skills/preflight.md
+++ b/skills/preflight.md
@@ -7,7 +7,8 @@ not a wrong change. This file maps every PR-triggered lane to its exact local
 mirror, or says honestly that there isn't one.
 
 **`utils/preflight` automates these gates.** `daslang utils/preflight/main.das`
-runs the fast tier (format + lint + clang syntax pass on changed C++, seconds);
+runs the fast tier (format + lint + clang frontend pass on changed C++ —
+escalating to a full src+tests-cpp sweep when a header changed; seconds);
 `-- --full` adds dasgen freshness, the CI-only-das compile sweep, the six doc
 gates, ctest, the interp/JIT/AOT suites, and the sequence smoke. `--list-gates`
 shows the menu; `--only <names>` / `--skip <names>` select subsets. Gates whose
@@ -44,7 +45,7 @@ Per-lane steps: build → JIT prewarm → JIT test sweep → interpreter sweep �
 | JIT sweep | `<daslang> dastest/dastest.das -jit -- --jit-opt-level=3 --color --failures-only --timeout 900 --test tests` | Windows-local `clang-cl` link failures are env noise — the catchable class is LLVM verifier errors; full end-to-end JIT needs WSL/mac. See `skills/make_pr.md` §2.5 for the 2-test smoke version |
 | Small C++ tests | `ctest --test-dir build --build-config Release -L small --output-on-failure` | drop `--build-config` on single-config generators. **Run this after touching `tests-cpp/`** — and remember MSVC tolerates C++ that clang/gcc reject (the doctest bit-field incident); see `skills/writing_cpp_tests.md` |
 | AOT sweep | `cmake --build build --config Release --target test_aot`, then `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 900 --test tests` | Release lanes only in CI |
-| Debug lanes | same suite against a **Debug build** | Debug bypasses the fused interpreter permutations — a fix that lands only in the fused path passes Release everywhere and trips Debug; conversely fused-path bugs need Release. If you touched `src/simulate/simulate_fusion_*`, run both configs |
+| Debug lanes | `cmake --build build --config Debug --target daslang`, then the sweep against `bin/Debug/daslang.exe` — safe in-checkout: Debug coexists with Release by design (`bin/Debug/`, `_debug.shared_module` suffix) | Debug bypasses the fused interpreter permutations — a fix that lands only in the fused path passes Release everywhere and trips Debug; conversely fused-path bugs need Release. If you touched `src/simulate/simulate_fusion_*`, run both configs |
 | Sanitizer lanes (linux Release asan/tsan/ubsan) | WSL: `CC=clang CXX=clang++ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDAS_USE_SANITIZER=<asan\|tsan\|ubsan>`, then the JIT sweep on `tests/language` | not mirrorable on Windows/mac. CI applies LSan suppressions (`format_error`, `uriParseSingleUriA`, `uriMakeOwner`) — see the workflow's Test step |
 | linux_arm / darwin lanes | mac: same commands as linux. From Windows: not mirrorable | ARM-specific reds (LLVM SelectionDAG, alignment) are CI-only signals |
 
@@ -67,22 +68,36 @@ dasClangBind bindings, run the self-binder locally per `skills/clang_bind_build.
 
 ## build.yml — build_windows_clangcl
 
-Fully mirrorable on a Windows dev box, in a separate (gitignored) build dir:
+The preflight `cpp-syntax` gate mirrors this lane's frontend: a clang-cl `/Zs`
+pass (parse + semantic analysis + template instantiation — no codegen) on your
+changed C++, escalating to ALL ~160 src+tests-cpp TUs (~15-30 s) when any core
+header changed, since a header edit can break template instantiation in TUs
+the diff never touched. What it cannot catch — link-stage divergence and
+codegen-only issues — is rare, arrives batched in one CI log, and is cheap to
+fix post-CI.
+
+A full local mirror is possible but **destructive in the main checkout**: all
+build dirs of one source tree share `bin/`, `lib/`, and the
+`modules/<X>/*.shared_module` outputs (only Debug gets a `_debug` suffix), so
+CI's verbatim configure+build below overwrites your MSVC Release binaries and
+Release shared modules. Run it in a separate clone or worktree only:
 
 ```powershell
+# SEPARATE clone/worktree only — clobbers bin/Release + Release .shared_modules otherwise
 cmake -B build-clangcl -G "Visual Studio 17 2022" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release
 cmake --build build-clangcl --config Release --parallel
 ```
 
-The cheap tier — seconds, catches most MSVC-vs-clang diagnostics without a
-full build — is a syntax-only pass on just the files you changed:
+Manual single-file check (what the gate automates):
 
 ```powershell
-# from a VS dev prompt (clang-cl on PATH); add -I flags for daScript includes
-clang-cl /Zs /std:c++17 -Iinclude -I3rdparty/fmt-10.1.0/include <changed>.cpp
+# from a VS dev prompt (clang-cl on PATH)
+clang-cl /Zs /EHsc /std:c++17 -Iinclude -I3rdparty/fmt/include -I3rdparty/uriparser/include -Itests-cpp/3rdparty -Ibuild/include <changed>.cpp
 ```
 
-(mac/WSL equivalent: `clang -fsyntax-only -std=c++17 -Iinclude ... <changed>.cpp`.)
+(mac/WSL equivalent: `clang -fsyntax-only -std=c++17 ...`.) `-Ibuild/include`
+matters — the configure-generated `modules/external_*.inc` headers live there,
+and TUs like `src/simulate/fs_file_info.cpp` include them.
 
 ## extended_checks.yml
 

--- a/utils/preflight/README.md
+++ b/utils/preflight/README.md
@@ -5,7 +5,8 @@ manual commands this tool automates live in
 [skills/preflight.md](https://github.com/GaijinEntertainment/daScript/blob/master/skills/preflight.md).
 
 ```bash
-# fast tier (seconds): format --verify, lint changed .das, clang syntax pass on changed C++
+# fast tier (seconds): format --verify, lint changed .das, clang frontend pass
+# on changed C++ (full src+tests-cpp sweep when a header changed)
 daslang utils/preflight/main.das
 
 # full tier: adds dasgen freshness, CI-only-das compile sweep, the six doc
@@ -20,9 +21,11 @@ daslang utils/preflight/main.das -- --skip tests-aot --full
 
 Cross-platform (Windows / macOS / Linux+WSL): subprocesses go through
 `popen_argv` (no shell) — except the sequence gate, which by design runs CI's
-own smoke scripts under pwsh/bash. The C++ syntax pass uses `clang-cl /Zs` on
+own smoke scripts under pwsh/bash. The C++ pass uses `clang-cl /Zs` on
 Windows (preferring the VS-bundled clang — the same binary CI's ClangCL
-toolset uses) and `clang -fsyntax-only` elsewhere, and a gate whose host tool
+toolset uses) and `clang -fsyntax-only` elsewhere; both are frontend-only
+(parse + semantic analysis + template instantiation, no codegen), which keeps
+even the full ~160-TU header-change sweep at ~15-30 s. A gate whose host tool
 or module is missing reports `SKIP` with an install/rebuild hint instead of
 passing silently. Exit code is non-zero when any gate fails.
 

--- a/utils/preflight/main.das
+++ b/utils/preflight/main.das
@@ -6,9 +6,11 @@ options persistent_heap
 // and the manual commands this tool automates: skills/preflight.md.
 //
 // Fast tier (default): format --verify, lint on changed .das, clang
-// syntax-only pass on changed C++. --full adds dasgen freshness, the
-// CI-only-das compile sweep, the six doc gates, tests-cpp (ctest -L small),
-// interpreter/JIT/AOT suites, and the sequence smoke.
+// frontend (syntax-only) pass on changed C++ — escalates to a full
+// src+tests-cpp sweep when a header changed, since a header edit can break
+// template instantiation in TUs the diff never touched. --full adds dasgen
+// freshness, the CI-only-das compile sweep, the six doc gates, tests-cpp
+// (ctest -L small), interpreter/JIT/AOT suites, and the sequence smoke.
 //
 // Cross-platform: Windows / macOS / Linux+WSL. Subprocesses go through
 // popen_argv (no shell, no quoting trap), with one exception: the sequence
@@ -241,6 +243,14 @@ def find_clang(cli_path, build_dir : string) : tuple<exe : string; is_cl : bool>
     return (exe = "", is_cl = false)
 }
 
+// TUs the clang frontend pass can compile standalone: core + tests-cpp.
+// Module/util TUs need external or build-generated headers; CI's clang-cl
+// lane covers those.
+def in_core_scope(path : string) : bool {
+    let g = to_generic_path(path)
+    return starts_with(g, "src/") || starts_with(g, "include/") || starts_with(g, "tests-cpp/")
+}
+
 def collect_changed_files(base : string; var das_files, cpp_files : array<string>&; var hdr_count : int&) {
     var seen : table<string>
     let probe = run_argv(["git", "rev-parse", "--verify", "--quiet", base])
@@ -263,8 +273,13 @@ def collect_changed_files(base : string; var das_files, cpp_files : array<string
                 das_files |> push(f)
             } elif (ext == ".cpp" || ext == ".cc") {
                 cpp_files |> push(f)
-            } elif (ext == ".h" || ext == ".hpp") {
-                hdr_count ++
+            } elif (ext == ".h" || ext == ".hpp" || ext == ".inc") {
+                // core-scope only — the sole consumer is the cpp-syntax
+                // full-sweep trigger, and module headers don't ripple into
+                // core TUs (modules depend on core, not the other way)
+                if (in_core_scope(f)) {
+                    hdr_count ++
+                }
             }
         }
     }
@@ -312,25 +327,44 @@ def gate_lint(ctx : PreflightCtx) : GateResult {
 
 def gate_cpp_syntax(ctx : PreflightCtx) : GateResult {
     let t0 = ref_time_ticks()
-    if (empty(ctx.changed_cpp)) {
-        let note = ctx.changed_hdr > 0 ? " — {ctx.changed_hdr} changed header(s) NOT validated by this gate; compile their includers (cmake --build) or rely on CI's clang lanes" : ""
+    if (empty(ctx.changed_cpp) && ctx.changed_hdr == 0) {
         return GateResult(name = "cpp-syntax", status = GateStatus.Skip, seconds = seconds_since(t0),
-            detail = "no .cpp files changed vs {ctx.base}{note}")
+            detail = "no C++ changed vs {ctx.base}")
     }
     if (empty(ctx.clang)) {
         return GateResult(name = "cpp-syntax", status = GateStatus.Skip, seconds = seconds_since(t0),
             detail = "clang not found — install LLVM (clang-cl/clang on PATH) or pass --clang <path>")
     }
-    // in-scope TUs: core + tests-cpp. Module/util TUs need external or
-    // build-generated headers; CI's clang-cl lane covers those.
     var in_scope : array<string>
     var skipped : array<string>
-    for (f in ctx.changed_cpp) {
-        let g = to_generic_path(f)
-        if (starts_with(g, "src/") || starts_with(g, "include/") || starts_with(g, "tests-cpp/")) {
+    var sweep_note = ""
+    if (ctx.changed_hdr > 0) {
+        // a changed header can break template instantiation in any TU that
+        // includes it — frontend-sweep ALL core TUs instead of just the
+        // changed ones (no codegen, so the full sweep stays in seconds)
+        let ls = run_argv(["git", "ls-files", "--", "src", "tests-cpp"])
+        if (ls.rc != 0) {
+            return GateResult(name = "cpp-syntax", status = GateStatus.Fail, seconds = seconds_since(t0),
+                detail = "git ls-files failed (rc={ls.rc}) — cannot enumerate TUs for the header-change sweep", output = ls.out)
+        }
+        for (f in non_empty_lines(ls.out)) {
+            let ext = extension(f)
+            continue if ((ext != ".cpp" && ext != ".cc") || starts_with(f, "tests-cpp/3rdparty/"))
             in_scope |> push(f)
-        } else {
-            skipped |> push(f)
+        }
+        sweep_note = "{ctx.changed_hdr} changed header(s) → full sweep: "
+        for (f in ctx.changed_cpp) {
+            if (!in_core_scope(f)) {
+                skipped |> push(f)
+            }
+        }
+    } else {
+        for (f in ctx.changed_cpp) {
+            if (in_core_scope(f)) {
+                in_scope |> push(f)
+            } else {
+                skipped |> push(f)
+            }
         }
     }
     if (empty(in_scope)) {
@@ -343,7 +377,12 @@ def gate_cpp_syntax(ctx : PreflightCtx) : GateResult {
     } else {
         flags <- ["-fsyntax-only", "-std=c++17", "-w"]
     }
-    let includes = ["include", "3rdparty/fmt/include", "3rdparty/uriparser/include", "tests-cpp/3rdparty"]
+    var includes <- ["include", "3rdparty/fmt/include", "3rdparty/uriparser/include", "tests-cpp/3rdparty"]
+    if (!empty(ctx.build_dir)) {
+        // configure-time generated headers (modules/external_*.inc) — without
+        // this root, TUs like src/simulate/fs_file_info.cpp false-fail
+        includes |> push(path_join(ctx.build_dir, "include"))
+    }
     let workers = compute_worker_count(length(in_scope), ctx.jobs)
     let chunks <- chunk_files(in_scope, workers)
     var argvs : array<array<string>>
@@ -374,7 +413,7 @@ def gate_cpp_syntax(ctx : PreflightCtx) : GateResult {
             }
         }
     }
-    var detail = "{length(in_scope)} file(s) via {ctx.clang}"
+    var detail = "{sweep_note}{length(in_scope)} file(s) via {ctx.clang}"
     if (!empty(skipped)) {
         detail = "{detail}; out of scope: {join(skipped, ", ")}"
     }
@@ -721,7 +760,7 @@ def gate_table() : array<GateInfo> {
     return <- [
         GateInfo(name = "format", full_only = false, doc = "formatter --verify on tracked .das (mirrors pre-push + CI)"),
         GateInfo(name = "lint", full_only = false, doc = "lint changed .das, zero warnings"),
-        GateInfo(name = "cpp-syntax", full_only = false, doc = "clang syntax-only pass on changed C++ (MSVC-vs-clang 80/20)"),
+        GateInfo(name = "cpp-syntax", full_only = false, doc = "clang frontend pass on changed C++; header change → full src+tests-cpp sweep"),
         GateInfo(name = "dasgen", full_only = true, doc = "gen_bind.das freshness vs include/daScript/builtin/"),
         GateInfo(name = "ci-das", full_only = true, doc = "compile-only sweep of CI-only das surface (ci_only_das.txt)"),
         GateInfo(name = "docs", full_only = true, doc = "the six doc.yml gates (das2rst, stubs, uncategorized, untracked, sphinx ×2)"),


### PR DESCRIPTION
Stage 3 of `COVERAGE_GAP.md`, **downscoped by decision**: no local clang-cl / mingw build dirs.

## Why the downscope

- The only recorded incident in the MSVC-vs-clang family (the doctest bit-field, 15 lanes red) is **frontend-level** — the Stage 2 syntax pass catches it in seconds. The residual classes a full local clang build would add (link-stage divergence, codegen-only issues) are rare and arrive batched in one cheap-to-iterate CI log.
- All build dirs of one source tree share `bin/`, `lib/`, and `modules/<X>/*.shared_module` outputs (only Debug gets a `_debug` suffix) — a local clang-cl Release build **clobbers the primary MSVC artifacts**. Isolating it would need a root-CMakeLists output knob: upstream complexity for speculative benefit.

## What ships instead

- **`cpp-syntax` gate escalation**: when any core header (`.h`/`.hpp`/`.inc` under `src`/`include`/`tests-cpp`) changed, the gate frontend-sweeps **all** core TUs (`clang-cl /Zs` — parse + semantic analysis + template instantiation, no codegen) instead of just the changed `.cpp`. A header edit can break template instantiation in TUs the diff never touched; this was the one real class a full clang build would have added. Measured: **157 TUs in 5-7 s warm, ~30 s cold**.
- **Latent false-FAIL fix**: `-I{build_dir}/include` added — TUs including configure-generated `modules/external_*.inc` (e.g. `src/simulate/fs_file_info.cpp`) failed the gate with the old include set.
- **skills/preflight.md**: the verbatim `build_windows_clangcl` mirror is now marked separate-clone-only (the clobber warning); the Debug-config recipe for the fused-path divergence family is documented as safe in-checkout (`bin/Debug/`, `_debug.shared_module` coexist with Release by design). Also fixed a stale `3rdparty/fmt-10.1.0` include path in the manual command.
- **COVERAGE_GAP.md**: Stage 3 decision recorded.

## Verification

- Positive: `--base` spanning the annotation-rework header changes → 7 changed headers detected, full sweep of 157 TUs, PASS in 6.9 s.
- Negative: `#error` poison appended to `ast.h` (uncommitted, 0 `.cpp` changed) → sweep triggered, FAILED with every includer TU named, exit code 1, in 5.2 s.
- Skip path: branch with no C++ changes → `SKIP — no C++ changed`.
- lint clean, formatter clean, preflight fast tier green on the branch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)