### PR TITLE
ci: nightly daspkg-index sweep — every index package vs daslang master (coverage-gap stage 4)

### DIFF
--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -9,6 +9,11 @@ name: nightly daspkg index
 #
 # Linux-only by design: the recorded incident class (external module compiled
 # against changed daslang headers) is a compile error, platform-independent.
+#
+# The scheduled run always sweeps master (GitHub runs cron from the default
+# branch). workflow_dispatch from a non-default branch deliberately sweeps
+# THAT branch — an on-demand externals check for ABI-touching PRs (see
+# skills/abi_break_sweep.md); the step summary names the ref it swept.
 
 on:
   schedule:
@@ -120,7 +125,8 @@ jobs:
           fi
           echo "::endgroup::"
         done < <(jq -r '.[] | [.name, .url] | @tsv' /tmp/packages.json)
-        printf '## daspkg-index nightly sweep\n\n| package | status |\n|---|---|\n' >> "$GITHUB_STEP_SUMMARY"
+        printf '## daspkg-index sweep — %s @ %s\n\n| package | status |\n|---|---|\n' \
+          "$GITHUB_REF_NAME" "$(git rev-parse --short HEAD)" >> "$GITHUB_STEP_SUMMARY"
         printf '%b' "$summary" >> "$GITHUB_STEP_SUMMARY"
         if [ ${#failed[@]} -gt 0 ]; then
           echo "FAILED: ${failed[*]}"

--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -1,0 +1,128 @@
+name: nightly daspkg index
+
+# Builds daslang master, then daspkg-installs every package listed in the
+# daspkg-index (borisbat/daspkg-index packages.json) at its default-branch
+# HEAD. The list is fetched at RUN time, so newly published packages are
+# picked up automatically — no workflow edit needed. External ABI breakage
+# surfaces here as a nightly signal instead of inside an unrelated PR's
+# extended_checks run. COVERAGE_GAP.md stage 4.
+#
+# Linux-only by design: the recorded incident class (external module compiled
+# against changed daslang headers) is a compile error, platform-independent.
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  index_sweep:
+    runs-on: ubuntu-latest-fat
+    timeout-minutes: 90
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - name: "Install CMake and Ninja"
+      uses: lukka/get-cmake@latest
+
+    - name: "Install: Required Dev Packages"
+      # mirrors extended_checks' linux lane: apt.llvm.org for llvm-22-dev
+      # (release_modules.txt flips DAS_LLVM_DISABLED=OFF), mesa/glfw/x11 for
+      # the dasImgui-family native package builds
+      run: |
+        set -eux
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
+        echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' \
+          | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update -y
+        sudo apt-get install --no-install-recommends -y \
+          mesa-common-dev \
+          libglu1-mesa-dev \
+          libgl1-mesa-dev \
+          libglfw3-dev \
+          libx11-dev \
+          libxrandr-dev \
+          libxcursor-dev \
+          libxinerama-dev \
+          libxi-dev \
+          llvm-22-dev \
+          jq
+
+    # sccache with local-disk backend, RESTORE-ONLY from extended_checks'
+    # master-seeded slot — this workflow never saves, so it cannot clobber
+    # the per-PR cache slots. A cold slot just means a slower build.
+    - uses: mozilla-actions/sccache-action@v0.0.10
+    - run: |
+        echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
+        echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+        echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+    - name: "Restore sccache objects (read-only)"
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/sccache
+        key: sccache-extended-linux-64
+
+    - name: "Build: Daslang (Release)"
+      # mirrors extended_checks' linux build (clang + Ninja + release
+      # modules; dasClangBind OFF for the same libclang/dasLLVM collision)
+      run: |
+        set -eux
+        ACTIVE_MODULES=$(grep -v "^#" ci/release_modules.txt | cut -d':' -f2 | sed 's|^|-D|' | xargs)
+        CC=clang CXX=clang++ cmake --no-warn-unused-cli -B./build \
+          -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DDAS_CLANG_BIND_DISABLED=ON \
+          -G Ninja $ACTIVE_MODULES
+        cmake --build ./build --config Release --target daslang
+
+    - name: "Sweep: install every index package at default-branch HEAD"
+      # default-branch HEAD (not release-tag resolution): release tags lag
+      # legitimately after an ABI sweep until externals re-release; branch
+      # HEAD is the externals-merge-first invariant this nightly monitors.
+      # Index order puts dasImgui before its dependents, so dependency
+      # installs reuse the branch-HEAD copy instead of re-resolving.
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -eux
+        curl -fsSL https://raw.githubusercontent.com/borisbat/daspkg-index/main/packages.json -o /tmp/packages.json
+        failed=()
+        summary=""
+        while IFS=$'\t' read -r name url; do
+          url="${url%$'\r'}"   # jq emits CRLF on some hosts
+          repo="${url#github.com/}"
+          def=$(gh api "repos/$repo" --jq .default_branch) || def=""
+          if [ -z "$def" ]; then
+            echo "::error::$name: cannot resolve default branch for $repo"
+            failed+=("$name")
+            summary+="| $name | :x: default-branch resolve failed |\n"
+            continue
+          fi
+          echo "::group::install $name ($repo @ $def)"
+          if ./bin/daslang utils/daspkg/main.das -- install "$name" --branch "$def"; then
+            summary+="| $name | :white_check_mark: $def |\n"
+          else
+            failed+=("$name")
+            summary+="| $name | :x: install failed ($def) |\n"
+          fi
+          echo "::endgroup::"
+        done < <(jq -r '.[] | [.name, .url] | @tsv' /tmp/packages.json)
+        printf '## daspkg-index nightly sweep\n\n| package | status |\n|---|---|\n' >> "$GITHUB_STEP_SUMMARY"
+        printf '%b' "$summary" >> "$GITHUB_STEP_SUMMARY"
+        if [ ${#failed[@]} -gt 0 ]; then
+          echo "FAILED: ${failed[*]}"
+          exit 1
+        fi

--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -99,8 +99,9 @@ jobs:
       # HEAD is the externals-merge-first invariant this nightly monitors.
       # Index order puts dasImgui before its dependents, so dependency
       # installs reuse the branch-HEAD copy instead of re-resolving.
-      env:
-        GH_TOKEN: ${{ github.token }}
+      # Resolution goes over the git protocol (ls-remote --symref), not the
+      # GitHub API: anonymous, no rate limits on shared runner IPs, and the
+      # same transport the install's clone uses anyway.
       run: |
         set -eux
         curl -fsSL https://raw.githubusercontent.com/borisbat/daspkg-index/main/packages.json -o /tmp/packages.json
@@ -109,7 +110,7 @@ jobs:
         while IFS=$'\t' read -r name url; do
           url="${url%$'\r'}"   # jq emits CRLF on some hosts
           repo="${url#github.com/}"
-          def=$(gh api "repos/$repo" --jq .default_branch) || def=""
+          def=$(git ls-remote --symref "https://$url" HEAD | awk '/^ref:/ {sub("refs/heads/","",$2); print $2}') || def=""
           if [ -z "$def" ]; then
             echo "::error::$name: cannot resolve default branch for $repo"
             failed+=("$name")

--- a/COVERAGE_GAP.md
+++ b/COVERAGE_GAP.md
@@ -102,8 +102,9 @@ THIS repo — fat runners, in-tree `utils/daspkg`, signal lands where daslang
 devs look. Builds daslang master (extended_checks' linux recipe, sccache
 restore-only), then daspkg-installs every package in
 `borisbat/daspkg-index/packages.json` at its **default-branch HEAD**
-(resolved per repo via `gh api` — 5 of 9 use `main`, not `master`; release
-tags deliberately NOT used, they lag legitimately after an ABI sweep).
+(resolved per repo via anonymous `git ls-remote --symref` — 5 of 9 use
+`main`, not `master`; release tags deliberately NOT used, they lag
+legitimately after an ABI sweep).
 The list is fetched at run time, so new packages need no workflow edit; the
 one future-edit case is a native package needing a system lib outside the
 extended_checks apt set — v2 answer is an optional `"apt"` field in

--- a/COVERAGE_GAP.md
+++ b/COVERAGE_GAP.md
@@ -95,11 +95,20 @@ src+tests-cpp TUs = 5-7 s warm, ~30 s cold):
   `_debug.shared_module` coexist with Release by design). Recipes, not
   standing gates.
 
-## Stage 4 — CI
+## Stage 4 — CI (shipped 2026-06-12)
 
-- Nightly cron on daspkg-index building every index package against daslang
-  master — external ABI breakage surfaces as a nightly signal instead of
-  inside an unrelated PR's extended_checks.
+`.github/workflows/nightly_daspkg_index.yml`: nightly cron (+ dispatch) in
+THIS repo — fat runners, in-tree `utils/daspkg`, signal lands where daslang
+devs look. Builds daslang master (extended_checks' linux recipe, sccache
+restore-only), then daspkg-installs every package in
+`borisbat/daspkg-index/packages.json` at its **default-branch HEAD**
+(resolved per repo via `gh api` — 5 of 9 use `main`, not `master`; release
+tags deliberately NOT used, they lag legitimately after an ABI sweep).
+The list is fetched at run time, so new packages need no workflow edit; the
+one future-edit case is a native package needing a system lib outside the
+extended_checks apt set — v2 answer is an optional `"apt"` field in
+packages.json. Other v2 follow-up: per-package smoke/require-probe metadata
+so the sweep loads what it installs, not just builds it.
 
 ## Stage 2 follow-ups (found while building utils/preflight, 2026-06-11)
 


### PR DESCRIPTION
Final stage of `COVERAGE_GAP.md`. External ABI breakage currently surfaces inside an unrelated PR's extended_checks `dasImgui install` step; this makes it a named nightly signal instead — and covers all 9 index packages, not just dasImgui.

## What it does

`.github/workflows/nightly_daspkg_index.yml` — nightly cron (`30 2 * * *`) + `workflow_dispatch`, one linux fat-runner job:

1. Build daslang master mirroring extended_checks' linux recipe (clang + Ninja + `ci/release_modules.txt`, `DAS_CLANG_BIND_DISABLED=ON` for the same libclang/dasLLVM collision). sccache is **restore-only** from the extended slot — this workflow never saves, so it cannot clobber the master-seeded PR caches; a cold slot just means a slower build.
2. Fetch `borisbat/daspkg-index/packages.json` **at run time** — newly published packages are swept automatically, no workflow edit needed.
3. For each package: resolve its **default-branch HEAD** via `gh api` and `daspkg install <name> --branch <that>`. Per-package continue-on-error.
4. Step-summary table (package → ✅/❌); job fails at the end listing the broken packages → nightly notification.

## Design notes

- **Default-branch HEAD, not release-tag resolution**: a bare `daspkg install` resolves to the latest release tag, which lags legitimately after an ABI sweep until externals re-release — that would be a standing false red. Branch HEAD is the externals-merge-first invariant this nightly actually monitors.
- **Per-repo branch resolution matters**: dry-run against all 9 index repos shows 5 use `main` and 4 use `master` — a uniform `--branch master` would break 5 of 9.
- **Linux-only by design**: the recorded incident class (`no member named 'dim'` against changed headers) is a compile error, platform-independent.
- Index order puts dasImgui before its dependents (implot, node-editor), so dependency installs reuse the branch-HEAD copy.
- The one case that ever needs a workflow edit: a new native package requiring a system lib outside the extended_checks apt set. Recorded v2 answer in COVERAGE_GAP.md: an optional `"apt"` field in packages.json. Also recorded for v2: per-package smoke/require-probe metadata so the sweep loads what it installs.

## Verification

- YAML parses clean.
- The resolve loop (jq TSV → `gh api` default branch) dry-run locally against all 9 index repos — all resolve (plus a CRLF guard: Windows jq emits CRLF; harmless on linux, free insurance).
- The install command is verbatim the proven extended_checks step (`daslang utils/daspkg/main.das -- install <pkg> --branch <b>`).
- Suggest a `workflow_dispatch` run after merge as the first live sweep (schedule triggers only run from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)