### PR TITLE
quote: revive aot_macros lowering — quote/qmacro now compile and run under AOT

### DIFF
--- a/QUOTE_LOWERING.md
+++ b/QUOTE_LOWERING.md
@@ -215,12 +215,18 @@ Findings from the first test_aot build of the lowered fixture's generated C++:
   semantically AND drops dead runtime work.
 
 - [x] Register tests/quote in tests/aot/CMakeLists.txt.
-- [x] test_aot: tests/quote 20/20 — with `fail_on_no_aot` active, so the lowered
-      reconstruction functions LINKED as AOT stubs and ran native (the unlowered
-      fixture's quote functions are noAot-exempt and interpret, as designed).
-      tests/aot regression 134/134.
-- [x] Full tests/ tree under test_aot: 10123 tests, 10117 passed, 0 failed, 6 skipped —
-      same skip set as the daslang baseline, +20 new quote tests.
+- [x] **Gate correction:** running `test_aot.exe dastest -- --test …` WITHOUT the
+      explicit `-use-aot … --use-aot` pair does NOT enable AOT linking for test files
+      (auto-detect didn't fire) — early "test_aot green" results were largely
+      interpreted. The CI-form invocation is the real gate and exposed:
+- [x] **Path-spelling hash divergence:** the lowered code bakes the source file path as
+      a string constant (FileInfoInitData.name). dasAot generation opened the file as
+      `D:/…` (forward slashes), runtime as `d:\…` → different constant → different
+      own-hash → error[50101] on every `` `quote`lowered`N ``. Fixed at the point the
+      constant enters the tree: `normalize_source_path` in quote.das (separators → `/`,
+      drive letter uppercased). Exactly the skill-documented mismatch class.
+- [x] CI-form full tree under test_aot after the fix: **9439 tests, 9433 passed,
+      0 failed, 0 errors, 6 skipped** — tests/quote linking and passing under real AOT.
 - [ ] Hash-mismatch fallback test: AOT objects built with `-aot-macros`, runtime without
       (and vice versa) must fall back to interpreter cleanly, not link garbage.
       (Deferred — exercise alongside the `-aot-macros` default-on decision; the noAot

--- a/QUOTE_LOWERING.md
+++ b/QUOTE_LOWERING.md
@@ -14,8 +14,8 @@ which is plain das code and compiles in all three tiers.
 - **Wiring = option (a):** static `require daslib/quote` from `daslib/templates_boost.das`.
   Activation stays cop-driven via the existing `policies.aot_macros` check
   (quote.das:410) — the pass is inert when the policy is off; `module quote shared` makes
-  the inert require near-free. (Rejected: root-level `addExtraModule` injection — extras l
-  and on the program root only, but QuotePass must fire inside each macro module's own
+  the inert require near-free. (Rejected: root-level `addExtraModule` injection — extras land
+  on the program root only, but QuotePass must fire inside each macro module's own
   compilation, where `[infer_macro]` visibility follows that module's require chain.)
 - **Tests are mandatory before anything ships.** Basic suite first; lifting `no_aot`/jit
   gates on existing tests is *extra* coverage afterwards, not a substitute.
@@ -225,6 +225,14 @@ Findings from the first test_aot build of the lowered fixture's generated C++:
       own-hash → error[50101] on every `` `quote`lowered`N ``. Fixed at the point the
       constant enters the tree: `normalize_source_path` in quote.das (separators → `/`,
       drive letter uppercased). Exactly the skill-documented mismatch class.
+- [x] **Second axis of the same class (review round 1):** dasAot generation gets the
+      file as a dasroot-ABSOLUTE path (CMake `${PROJECT_SOURCE_DIR}`), a runtime
+      `--test tests/...` compile gets it REPO-RELATIVE → same 50101. (The first local
+      "CI-form green" had masked it: hand-probe-generated stubs with relative spellings
+      survived the build's missing daslib-dep tracking.) Fix: `normalize_source_path`
+      now canonicalizes to **dasroot-relative** (`trim_prefix(get_das_root())` after the
+      spelling fix), absolute only outside dasroot. Side effect: baked constants — and
+      therefore stub hashes — are machine-independent (no `/home/runner` vs `D:/Work`).
 - [x] CI-form full tree under test_aot after the fix: **9439 tests, 9433 passed,
       0 failed, 0 errors, 6 skipped** — tests/quote linking and passing under real AOT.
 - [ ] Hash-mismatch fallback test: AOT objects built with `-aot-macros`, runtime without

--- a/QUOTE_LOWERING.md
+++ b/QUOTE_LOWERING.md
@@ -198,13 +198,33 @@ behavioral check that the spliced result still compiles/runs via `apply_template
 - negative: `-aot-macros` without lowering available → Phase 1 hard error fires;
   jit + unlowered quote → clean `unsupported` message (not "Internal jit error")
 
-## Phase 4 — AOT lane
+## Phase 4 — AOT lane (IN PROGRESS)
 
-- [ ] Wire `-aot-macros` into the tests/aot flow for `tests/quote/` (investigate how
-      per-directory dasAot invocation passes flags; register dir in tests/aot/CMakeLists).
-- [ ] test_aot run green on tests/quote.
+No `-aot-macros` harness wiring turned out to be needed: the per-module
+`options aot_macros` in the lowered fixture triggers lowering identically during dasAot
+generation and at test_aot runtime, so hashes line up by construction. Registered as
+test_aot_quote + test_aot_quote_modules (fixtures via DAS_AOT_LIB, linq/_common pattern).
+
+Findings from the first test_aot build of the lowered fixture's generated C++:
+
+- `module_find_enumeration` needed a `DAS_CC_API` declaration in
+  include/daScript/simulate/aot_builtin_ast.h (AOT emits direct calls by C++ name).
+- `ExprBlock.stackCleanVars` (vector<pair<uint32,uint32>>) reached the reconstruction:
+  post-infer allocateStack bookkeeping, always empty in quoted trees, and its type has
+  no AOT mapping (C2665 on das_arg<vector<TTuple<8,…>>>). Blacklisted — correct
+  semantically AND drops dead runtime work.
+
+- [x] Register tests/quote in tests/aot/CMakeLists.txt.
+- [x] test_aot: tests/quote 20/20 — with `fail_on_no_aot` active, so the lowered
+      reconstruction functions LINKED as AOT stubs and ran native (the unlowered
+      fixture's quote functions are noAot-exempt and interpret, as designed).
+      tests/aot regression 134/134.
+- [x] Full tests/ tree under test_aot: 10123 tests, 10117 passed, 0 failed, 6 skipped —
+      same skip set as the daslang baseline, +20 new quote tests.
 - [ ] Hash-mismatch fallback test: AOT objects built with `-aot-macros`, runtime without
       (and vice versa) must fall back to interpreter cleanly, not link garbage.
+      (Deferred — exercise alongside the `-aot-macros` default-on decision; the noAot
+      exemption side is already covered by the unlowered fixture under test_aot.)
 
 ## Phase 5 — JIT lane (FOLLOW-UP: starts only after Phase 4 is green)
 

--- a/QUOTE_LOWERING.md
+++ b/QUOTE_LOWERING.md
@@ -1,0 +1,204 @@
+# Quote lowering: AOT + JIT support for `quote` / `qmacro`
+
+**Goal:** `ExprQuote` (and therefore the whole qmacro family) compiles under AOT and JIT.
+Mechanism: revive the existing infer-time lowering in `daslib/quote.das` that replaces
+`quote(tree)` with generated AST-reconstruction code (`ExprMakeStruct`/`ExprAscend`/…),
+which is plain das code and compiles in all three tiers.
+
+## Decisions (settled)
+
+- **Revive, don't rewrite.** `d38cd728f` ("enable ast quote in aot", Jul 2025) is the right
+  design: reflection-driven converter walking the quoted tree via `BasicStructureAnnotation`
+  field enumeration + `walk_and_convert` for leaf data. No per-node emitter to maintain.
+- **Stays in `daslib/quote.das`.**
+- **Wiring = option (a):** static `require daslib/quote` from `daslib/templates_boost.das`.
+  Activation stays cop-driven via the existing `policies.aot_macros` check
+  (quote.das:410) — the pass is inert when the policy is off; `module quote shared` makes
+  the inert require near-free. (Rejected: root-level `addExtraModule` injection — extras l
+  and on the program root only, but QuotePass must fire inside each macro module's own
+  compilation, where `[infer_macro]` visibility follows that module's require chain.)
+- **Tests are mandatory before anything ships.** Basic suite first; lifting `no_aot`/jit
+  gates on existing tests is *extra* coverage afterwards, not a substitute.
+
+## Current-state map (verified 2026-06-11)
+
+- `ExprQuote` infers to `Expression?` handle; quoted subtree is never inferred
+  (`canVisitQuoteSubexpression` defaults false). Infer marks the enclosing function
+  `noAot` unless `policies.aot_macros` (src/ast/ast_infer_type.cpp:1440).
+- Interpreter: `SimNode_AstGetExpression` holds a raw `Expression*` and returns
+  `expr->clone()` per evaluation (src/ast/ast_simulate.cpp:1280).
+- qmacro expands to `apply_qmacro(quote(tree), rules-block)` (templates_boost.das:1179),
+  so lowering ExprQuote covers qmacro; the rules block is ordinary code.
+- `daslib/quote.das`: `QuotePass` (`[infer_macro]` AstPassMacro) + `QuoteConverter`
+  replaces each ExprQuote via `convert_quote_to_expression`. Managed entities resolve
+  by name at runtime (`get_module` / `module_find_annotation` / `find_call_macro` /
+  `find_unique_function_ptr` / `module_find_structure` / `clone_file_info`).
+  **Orphaned:** nothing requires it (docs tooling only), zero tests.
+- Lossiness blacklist (quote.das:151): `Function.annotations`, `EnumEntry.value/.at`,
+  `Enumeration.list`, `CaptureEntry.at`, `MakeFieldDecl.at`, `AnnotationArgument.at`;
+  `AnnotationArgumentInitData` carries only string/bool/int/float; FileInfo rebuilt by
+  name+tabSize (loses identity of `LineInfo.fileInfo`).
+- AOT: `daslib/aot_cpp.das` has **no** ExprQuote handling — with `-aot-macros` set but
+  the pass not required, codegen emits garbage with no diagnostic.
+- JIT: no `visitExprQuote` in `LlvmJitVisitor` → parent `getE` → `failed_E "unresolved
+  expression"` (llvm_jit.das:7017) → `g_errors` → `panic("Internal jit error…")`
+  (llvm_jit_run.das:295). Loud but misleading; all-or-nothing.
+- JIT of macro contexts is separately disabled: `jit_llvm` simulate-macro skips when
+  `is_compiling_macros()` (llvm_macro.das:49).
+- CLI: `daslang -aot … -aot-macros` sets `aot_macros` + `export_all` + 1MB stack
+  (utils/daScript/main.cpp:65).
+- Policy-option promotion precedent: `policies.threadlock_context |= options.getBoolOption(…)`
+  (src/ast/ast_parse.cpp:1416).
+- Blast radius: every in-tree quote user requires templates_boost (defer, decs_boost,
+  lpipe, static_let, typemacro_boost, interfaces, linq_fold_common, type_traits, …).
+  41 test files use quote/qmacro (ast_match suite, linq_fold, 13× dasPEG, flatten/no_aot,
+  dasSQLITE/test_07_macros, fake_numeric, …), heavily overlapping the `no_aot`-gated set.
+
+## Phase 0 — empirical baseline (in progress)
+
+Worktree build (fresh master; both existing binaries are skewed vs today's
+annotation-info merge), then:
+
+- [x] Interpreted probes: raw `quote`, `qmacro` incl. `$c` splice — green
+      (`SimNode_AstGetExpression` path intact).
+- [x] Lowered probes (`options aot_macros`, interpreted): green after the bitrot fixes
+      below — consts, op2, calls, strings, `$c` splice, `qmacro_block`, `qmacro_type`,
+      make-struct, lambda. Probes in `probe_quote/` (become `tests/quote/` in Phase 3).
+- [x] A/B: identical `describe_expression` output lowered vs unlowered (6 shapes).
+- [x] `daslang -aot -aot-macros`: emits real reconstruction C++
+      (`das_ascend_handle<ExprOp2*>::make`, `clone_line_info`/`clone_file_info`), exit 0.
+- [x] Reach probe: root-level `require daslib/quote` does NOT lower quotes inside a
+      required module (pass-macro visibility = the module's own require chain) — wiring
+      (b) rejected on evidence; with the templates_boost require the same module lowers.
+- [x] Regression smoke (unlowered path + new require wiring): ast_match 380/380,
+      template 10/10, linq 1971/1971.
+
+### Bitrot fixed during Phase 0
+
+1. **`apply_to_vec` gc_node spellings** (src/builtin/module_builtin_ast.cpp): dispatched
+   on smart_ptr-era `describe()` strings (`"ast::MakeStruct*"` — dead since the ast-module
+   removal). Fixed: one generic `tPointer` → `vector<void*>` branch (post-gc_node every
+   AST node vector is a plain raw-pointer vector); `"ast_core::MakeFieldDecl?"` keeps the
+   MakeStruct multiple-inheritance base-adjust special case.
+2. **`convert_vec_expr` retarget stomp** (daslib/quote.das): `dst_tp != src_tp` was a
+   POINTER compare — always true after `clone_type` — so for pointer-element vectors the
+   code reinterpreted an `ExprAscend` as `ExprMakeStruct` and wrote `makeType` through the
+   wrong layout (memory stomp → gc_collect AV; survived 2025 only by layout luck). Fixed:
+   semantic compare (`describe(dst) != describe(src)`) + `arg_expr is ExprMakeStruct` guard.
+3. **`cvt_to_mks` move_new** (daslib/quote.das): smart_ptr-era `move_new((*res)[i]) <| arg`
+   on what is now a raw-pointer slot. Fixed: plain assignment.
+
+## Phase 1 — plumbing + loud diagnostics (DONE 2026-06-11)
+
+- [x] `require daslib/quote public` in templates_boost (public: the generated
+      reconstruction calls — `cvt_to_mks`, `clone_line_info`, … — must resolve in the
+      qmacro-using module's scope).
+- [x] `options aot_macros` per-module trigger: the option name is already valid
+      (CodeOfPolicies fields are auto-registered option names via
+      `getCodeOfPolicyOptions()`). QuotePass gate reads
+      `policies.aot_macros || prog options aot_macros`; the infer-time noAot-skip
+      (ast_infer_type.cpp) got the identical option clause — no parseDaScript
+      promotion needed.
+- [x] QuotePass gate stays `aot_macros`-only (JIT extension deferred to Phase 5).
+- [x] `aot_cpp.das` diagnostics — NOT a panic: a panic inside a make_visitor-driven
+      visitor is swallowed by `runMacroFunction`/`runWithCatch` (verified — error filed
+      on a program nobody reads post-compile, tool exits 0). Instead: `NoAotMarker`
+      gets `preVisitExprQuote` → marks the function `noAot` + `to_log(LOG_ERROR, …)`
+      naming file:line, cause, and fix (silent when the function is already noAot, i.e.
+      the normal no-aot_macros flow). Function falls back to interpreter;
+      `fail_on_lack_of_aot_export` escalates for exports. CppAot keeps a backstop
+      `visitExprQuote` that writes `#error` into the generated C++ (deterministic,
+      unlike panic). Verified on a negative probe: clean LOG_ERROR, broken emission gone.
+- [x] `llvm_jit.das`: `preVisitExprQuote` → `unsupported(expr, "quote( ) is not jit-able
+      without aot_macros lowering (daslib/quote)")`, modeled on the try-catch case.
+      Lints clean; behavioral check needs an LLVM-enabled build (Phase 5).
+- [x] Formatter verified + lint clean on all four changed das files (llvm_jit.das lint
+      needs `lib/LLVM.dll` present — dasbind resolves `getDasRoot()/lib/<dll>`).
+
+## Phase 2 — make the lowering correct
+
+Driven by Phase 0 findings + a blacklist audit. Known suspects, each needs a verdict
+(legit-to-drop because infer rebuilds it, e.g. `ExprVar.pBlock` / `ExprReturn._block`
+backlinks — vs lossy-and-matters):
+
+- [ ] `ExprBlock` annotations + `blockFlags`, `finally` lists.
+- [ ] Capture lists (`CaptureEntryInitData` drops `at`).
+- [ ] `Enumeration.list` ("too huge in TypeDecl") — does `qmacro(MyEnum.Value)` survive?
+- [ ] `FileInfo`: replace per-call `clone_file_info` (fresh dummy per evaluation,
+      module_builtin_ast.cpp:1038) with a `resolve_file_info(name, tabSize)` builtin:
+      if compiling → look up `name` in the compiling program's `FileAccess` (which
+      caches FileInfo by name, so the dominant macro case returns the EXACT live
+      FileInfo — macro-module source is always parsed even under AOT; AOT only
+      carries the name string); else → per-name interned dummy (stable identity,
+      no source). Needs one small C++ binding; `Program.access` is not currently
+      exposed to das, and that's fine — resolve inside the builtin.
+- [ ] `AnnotationArgumentInitData`: missing double / multi-value coverage?
+- [ ] `Function.annotations` blacklist entry — reachable at all in quoted trees, or dead?
+- [ ] String escapes / non-ASCII round-trip through `ExprConstString` reconstruction.
+
+Acceptance bar: lowered tree ≡ `expr->clone()` for every construct the basic suite
+covers (modulo agreed-legit blacklist entries, each documented in quote.das).
+
+## Phase 3 — basic tests (`tests/quote/`)
+
+Self-contained via `options aot_macros` (Phase 1). For each category, A/B: expand the
+same qmacro with lowering on vs off, compare `describe_expression` output, plus a
+behavioral check that the spliced result still compiles/runs via `apply_template`:
+
+- consts (int/uint/float/double/string incl. escapes, enum refs, bitfields)
+- op1/op2/op3, field chains, index, calls incl. named args + pipe
+- blocks: statements, `finally`, block annotations, nested blocks
+- make-struct / make-array / make-tuple / make-variant (move/clone semantics flags)
+- lambdas + capture modes, generators, `qmacro_block` / `qmacro_expr` /
+  `qmacro_block_to_array`
+- `qmacro_type` / `ExprTypeDecl`, fixed-array types (post-FA-rework shapes)
+- tag splices: `$v $e $a $b $i $f $c $t` through the lowered path
+- LineInfo: `force_at` behavior, error-reporting fidelity from a lowered macro
+- negative: `-aot-macros` without lowering available → Phase 1 hard error fires;
+  jit + unlowered quote → clean `unsupported` message (not "Internal jit error")
+
+## Phase 4 — AOT lane
+
+- [ ] Wire `-aot-macros` into the tests/aot flow for `tests/quote/` (investigate how
+      per-directory dasAot invocation passes flags; register dir in tests/aot/CMakeLists).
+- [ ] test_aot run green on tests/quote.
+- [ ] Hash-mismatch fallback test: AOT objects built with `-aot-macros`, runtime without
+      (and vice versa) must fall back to interpreter cleanly, not link garbage.
+
+## Phase 5 — JIT lane (FOLLOW-UP: starts only after Phase 4 is green)
+
+Decision 2026-06-11: JIT is a follow-up effort, not part of the initial push. The only
+JIT work in scope before then is the Phase 1 diagnostic (clean `unsupported` message
+replacing the misleading "Internal jit error" panic). The QuotePass gate stays
+`aot_macros`-only until this phase; extending it to `jit_enabled` lands here.
+
+- [ ] Extend QuotePass gate to `jit_enabled`.
+- [ ] `tests/jit_tests/` coverage for quote under `options jit` (lowered path through
+      LlvmJitVisitor — make-struct of handled types, `to_array_move`, by-name lookups).
+- [ ] Decide + implement JIT-of-macro-contexts: lift the `is_compiling_macros()` skip in
+      llvm_macro.das behind a policy. This is the compile-time payoff twin of AOT'd
+      macro modules. Separate PR; needs its own bake time.
+- [ ] `LLVM_JIT_CODEGEN_VERSION` bump only if emitters change (diagnostic-only changes
+      don't).
+
+## Phase 6 — extra coverage + payoff measurement
+
+- [ ] Sweep: lift `options no_aot` from tests gated only because of quote/qmacro
+      (candidates from the 41-file list; case-by-case — some are no_aot for other
+      reasons). Same for jit exclusions (e.g. `failed_jit_abi`-style gates).
+- [ ] daslib sweep: any module carrying `no_aot` purely for quote.
+- [ ] Measure: imgui_demo compile profiling harness (D:\Work\daScript-profile playbook)
+      with AOT'd / jitted macro modules — this is the number that justifies the work.
+
+## Open questions
+
+1. ~~Gate predicate spelling~~ — RESOLVED: `aot_macros` only for the initial push;
+   `jit_enabled` extension lands in Phase 5.
+2. ~~JIT-of-macro-contexts scope~~ — RESOLVED 2026-06-11: JIT is a follow-up phase,
+   after the AOT lane is green.
+3. ~~FileInfo identity~~ — RESOLVED direction (2026-06-11): per-file interned dummy as
+   the floor (Boris), upgraded to the real live FileInfo when compiling — macro-module
+   source is parsed even under AOT, so the compiling program's FileAccess has the
+   actual FileInfo cached by name; AOT carries only the name string. See Phase 2.
+4. `-aot-macros` default: once tests are green, does `daslang -aot` flip it on by
+   default (with `noAot` fallback removed), or stay opt-in for a release cycle?

--- a/QUOTE_LOWERING.md
+++ b/QUOTE_LOWERING.md
@@ -115,11 +115,44 @@ annotation-info merge), then:
 - [x] Formatter verified + lint clean on all four changed das files (llvm_jit.das lint
       needs `lib/LLVM.dll` present — dasbind resolves `getDasRoot()/lib/<dll>`).
 
-## Phase 2 — make the lowering correct
+## Phase 2 — make the lowering correct (IN PROGRESS)
 
-Driven by Phase 0 findings + a blacklist audit. Known suspects, each needs a verdict
-(legit-to-drop because infer rebuilds it, e.g. `ExprVar.pBlock` / `ExprReturn._block`
-backlinks — vs lossy-and-matters):
+### Done so far (2026-06-11)
+
+- **Suite-wide forcing flags**: `daslang -aot-macros <script>` (normal run, main.cpp) and
+  `dastest --aot-macros` (dastest_clargs/suite.das → `cop.aot_macros`, + 1MB stack like
+  the `-aot -aot-macros` flow). These are the audit hammer.
+- **Function-per-quote**: QuoteConverter now wraps each lowered construction in a
+  generated `` `quote`lowered`<n> `` private function and replaces the quote with a call.
+  Without this, every lowered qmacro callsite inflates its CALLER's stack frame (sum of
+  construction temporaries), which is fatal in recursive macros — flatten's `lower_stmt`
+  overflowed any reasonable stack. With it, the big frame is a single non-recursive leaf.
+- **FULL tests/ tree, lowering forced: 10103 tests, 10097 passed, 0 failed, 6 skipped —
+  byte-identical verdict to the unlowered baseline.** (92.6s vs 57.7s wall — the forced
+  mode pays QuotePass + giant-tree inference; fine for a debug/audit mode.)
+- **resolve_file_info**: per-file interned dummy FileInfo (module-global table in quote.das,
+  per macro context) replaces a fresh allocation per LineInfo per evaluation. The
+  live-FileInfo upgrade is parked: AOT emits calls with null LineInfoArg and Program does
+  not retain its FileAccess, so there is no reliable runtime handle to the live file.
+- **Anonymous-module entities**: quoted `type<LocalEnum>` / `type<LocalStruct>` (entity
+  lives in the program's unnamed main module) generated `get_module("")` → null-deref at
+  reconstruction. Fixed: `Enumeration` joined the managed by-name set (new C++ builtin
+  `module_find_enumeration`), and TypeDecls referencing anonymous-module enums/structs
+  reconstruct as `make_alias_type_decl("<name>")` — the exact alias shape the parser
+  yields for unresolved names, so splice-site re-infer resolves them.
+
+### Phase 2 addendum (later same day)
+
+- Extended corpus (probe_quote/ab2_*): enum consts, escaped + non-ASCII strings,
+  `finally` blocks, capture-clause lambdas, table literals, tuple literals, generators,
+  double arithmetic — all A/B-identical; `daslang -aot-macros` (CLI) ==
+  `options aot_macros` (module) == unlowered reference.
+- Final full-tree lowered re-run after all Phase 2 changes: SUCCESS, identical verdict.
+
+### Blacklist audit — remaining suspects
+
+Known suspects, each needs a verdict (legit-to-drop because infer rebuilds it, e.g.
+`ExprVar.pBlock` / `ExprReturn._block` backlinks — vs lossy-and-matters):
 
 - [ ] `ExprBlock` annotations + `blockFlags`, `finally` lists.
 - [ ] Capture lists (`CaptureEntryInitData` drops `at`).
@@ -139,7 +172,15 @@ backlinks — vs lossy-and-matters):
 Acceptance bar: lowered tree ≡ `expr->clone()` for every construct the basic suite
 covers (modulo agreed-legit blacklist entries, each documented in quote.das).
 
-## Phase 3 — basic tests (`tests/quote/`)
+## Phase 3 — basic tests (`tests/quote/`) — LANDED 2026-06-11 (20/20)
+
+Implemented as twin fixture modules with identical bodies — `_quote_shapes.das`
+(SimNode path) vs `_quote_shapes_lowered.das` (`options aot_macros`) — plus shared
+entities in `_quote_entities.das` (one named module so describes are identically
+qualified). `test_quote_lowering.das` asserts per-shape describe equality;
+`test_quote_lowered_main.das` covers lowered quotes in the anonymous main module
+(alias fallback) and splice behavior. Registered in tests/aot/CMakeLists.txt
+(test_aot_quote + test_aot_quote_modules). Original checklist:
 
 Self-contained via `options aot_macros` (Phase 1). For each category, A/B: expand the
 same qmacro with lowering on vs off, compare `describe_expression` output, plus a

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -511,6 +511,15 @@ class NoAotMarker : AstVisitor {
             }
         }
     }
+    // quote that was not lowered. without aot_macros infer already made the function noAot
+    // (then this stays silent); with aot_macros set it means daslib/quote lowering did not
+    // run — the module with the quote is missing daslib/templates_boost (or daslib/quote)
+    def override preVisitExprQuote(expr : ExprQuote?) {
+        if (func != null && !func.flags.noAot) {
+            func.flags.noAot = true
+            to_log(LOG_ERROR, "{describe(expr.at)}: quote( ) survived to AOT with aot_macros enabled — daslib/quote lowering did not run; require daslib/templates_boost (or daslib/quote) in the module containing the quote. Function '{func.name}' excluded from AOT.\n")
+        }
+    }
 };
 
 class public PrologueMarker : AstVisitor {
@@ -1812,6 +1821,13 @@ class public CppAot : AstVisitor {
     }
     def override visitExprMove(var that : ExprMove?) : ExpressionPtr {
         write(*ss, ")");
+        return that;
+    }
+// quote
+    def override visitExprQuote(var that : ExprQuote?) : ExpressionPtr {
+        // unreachable: NoAotMarker excludes functions with surviving quotes. a panic here
+        // would be swallowed by runMacroFunction, so write a hard #error into the C++ instead
+        write(*ss, "\n#error quote( ) was not lowered (daslib/quote) at {describe(that.at)}\n")
         return that;
     }
 // op1

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -165,6 +165,7 @@ let blacklist = [
     ("ast_core::ExprVar", "pBlock"), // loop
     ("ast_core::EnumEntry", "value"), // loop
     ("ast_core::EnumEntry", "at"), // ignore it for now
+    ("ast_core::ExprBlock", "stackCleanVars"), // post-infer bookkeeping (allocateStack); always empty in quoted trees, and its vector<pair> type has no AOT mapping
     ("rtti_core::AnnotationArgument", "at"),
     ("ast_core::CaptureEntry", "at"), // ignore it for now
     ("ast_core::MakeFieldDecl", "at"), // ignore it for now

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -146,6 +146,17 @@ def public clone_file_info(b : FileInfoInitData) : FileInfo? {
     return clone_file_info(b.name, b.tabSize)
 }
 
+var private g_resolved_file_infos : table<string; FileInfo?>
+
+def public resolve_file_info(b : FileInfoInitData) : FileInfo? {
+    //! Stable FileInfo for reconstructed LineInfos: one interned dummy per file name
+    //! (per context), instead of a fresh allocation per evaluation.
+    if (!key_exists(g_resolved_file_infos, b.name)) {
+        g_resolved_file_infos[b.name] = clone_file_info(b.name, b.tabSize)
+    }
+    return g_resolved_file_infos[b.name]
+}
+
 let blacklist = [
     ("ast_core::Function", "inferStack"),
     ("ast_core::Function", "annotations"),
@@ -167,6 +178,7 @@ let managed_types = [
     "ast_core::Structure",
     "ast_core::CallMacro",
     "ast_core::Function",
+    "ast_core::Enumeration",
     "rtti_core::FileInfo",
     "ast_core::MakeStruct",
     "rtti_core::LineInfo",
@@ -316,15 +328,36 @@ def private convert_quote_structure(mod : Module?; data : uint8 const?;
     var mkStr = new ExprMakeStruct(makeType = get_dst_type(clone_type(info)), at = at)
     emplace(mkStr.structs, mkS1)
     mkStr.makeStructFlags |= ExprMakeStructFlags.useInitializer | ExprMakeStructFlags.canShadowBlock;
-    if (describe(info) == "rtti_core::FileInfo") return new ExprCall(at = at, name := "clone_file_info",
+    if (describe(info) == "rtti_core::FileInfo") return new ExprCall(at = at, name := "resolve_file_info",
                                arguments := array<Expression?>(mkStr))
     return mkStr;
+}
+
+def public make_alias_type_decl(name : string) : TypeDecl? {
+    //! Reconstruction helper: a by-name alias TypeDecl, resolved by re-infer at the splice site.
+    return new TypeDecl(baseType = Type.alias, alias := name)
 }
 
 def private convert_pointer_expr(mod; data; info; at) : Expression? {
     assume pdata = *unsafe(reinterpret<uint8 const ??> data);
     if (pdata == null) return new ExprConstPtr(at = at);
     assume first_tstr = describe(info.firstType);
+    if (first_tstr == "ast_core::TypeDecl") {
+        // a type that references an enum/struct from an anonymous module (the program's
+        // main module) can't be reconstructed by name — rebuild it as the alias the parser
+        // would have produced for an unresolved name; splice-site re-infer resolves it
+        assume td = unsafe(reinterpret<TypeDecl?>(pdata));
+        var aliasName = ""
+        if (td.enumType != null && (td.enumType._module == null || empty(td.enumType._module.name))) {
+            aliasName = string(td.enumType.name)
+        } elif (td.structType != null && (td.structType._module == null || empty(td.structType._module.name))) {
+            aliasName = string(td.structType.name)
+        }
+        if (!empty(aliasName)) {
+            return new ExprCall(at = at, name := "make_alias_type_decl",
+                arguments := array<Expression?>(create_string_expr(aliasName)));
+        }
+    }
     var final_type = clone_type(info.firstType);
     if (first_tstr == "ast_core::Expression") {
         assume annotation = mod |> module_find_type_annotation(unsafe(reinterpret<Expression?>(pdata)).__rtti);
@@ -366,6 +399,12 @@ def private convert_quote_expr(mod : Module?; var data : uint8 const?; info : Ty
     } elif (tstr == "ast_core::Function") {
          assume pdata = unsafe(reinterpret<Function?>(data));
          return get_find_in_module_expr("find_unique_function_ptr", pdata._module.name, pdata.name, at);
+    } elif (tstr == "ast_core::Enumeration") {
+         assume pdata = unsafe(reinterpret<Enumeration?>(data));
+         // anonymous module (e.g. the program's main module) can't be found by name at
+         // reconstruction time; the TypeDecl-level alias fallback covers that shape
+         if (pdata._module == null || empty(pdata._module.name)) return null
+         return get_find_in_module_expr("module_find_enumeration", pdata._module.name, pdata.name, at);
     } elif (tstr == "rtti_core::Module") {
          assume cur_mod = unsafe(reinterpret<Module?>(data));
          return find_module_expr(cur_mod.name, at);
@@ -397,9 +436,28 @@ def convert_quote_to_expression(var arg_expr : Expression?; at : LineInfo) : Exp
 class QuoteConverter : AstVisitor {
     //! AST visitor that converts quoted expressions to init data.
     astChanged : bool = false
+    mod : Module?
+    counter : int = 0
     def override visitExprQuote(var expr : ExprQuote?) : Expression? {
         astChanged = true
-        return convert_quote_to_expression(expr.arguments[0], expr.at)
+        var conv = convert_quote_to_expression(expr.arguments[0], expr.at)
+        // wrap the construction in a per-quote generated function and replace the quote with
+        // a call: the (large) construction expression then occupies one non-recursive leaf
+        // frame instead of inflating every caller's frame (fatal in recursive macros)
+        var fname = ""
+        while (true) {
+            fname = "`quote`lowered`{counter}"
+            counter++
+            break if (find_unique_function(mod, fname, true) == null)
+        }
+        var fn = new Function(at = expr.at, atDecl = expr.at, name := fname,
+            flags = FunctionFlags.generated | FunctionFlags.privateFunction)
+        fn.result = new TypeDecl(baseType = Type.autoinfer)
+        var blk = new ExprBlock(at = expr.at)
+        emplace_new(blk.list) <| new ExprReturn(at = expr.at, subexpr = conv)
+        fn.body = blk
+        mod |> add_function(fn)
+        return new ExprCall(at = expr.at, name := fname)
     }
 }
 
@@ -412,7 +470,7 @@ class QuotePass : AstPassMacro {
         // `options aot_macros` (self-contained tests, interpreted A/B).
         let lower = compiling_program().policies.aot_macros || (prog._options |> find_arg("aot_macros") ?as tBool ?? false)
         if (!lower) return false // nothing to do
-        var astVisitor = new QuoteConverter()
+        var astVisitor = new QuoteConverter(mod = compiling_module())
         make_visitor(*astVisitor) $(astVisitorAdapter) {
             visit(prog, astVisitorAdapter)
         }

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -130,9 +130,7 @@ def public cvt_to_mks(var args) : MakeStruct? {
     var res = new MakeStruct(uninitialized);
     *res |> resize(length(args))
     for (arg, i in args, count()) {
-        {
-            move_new((*res)[i]) <| arg;
-        }
+        (*res)[i] = arg;
     }
     return res;
 }
@@ -227,7 +225,10 @@ def private convert_vec_expr(mod : Module?; field_values : uint8 const?; xtype :
     for (idx in range(get_vector_length(field_values, src_tp))) {
         {
             var arg_expr = convert_quote_expr(mod, unsafe(reinterpret<uint8?>(get_vector_ptr_at_index(field_values, src_tp, idx))), src_tp, at);
-            if (dst_tp.baseType != Type.tString && dst_tp != src_tp) {
+            // retarget the element make-struct to the InitData wrapper type when get_dst_type
+            // substituted one; pointer compare (dst_tp != src_tp) is always true after clone_type,
+            // and writing makeType through a reinterpret of a non-ExprMakeStruct stomps the node
+            if (dst_tp.baseType != Type.tString && describe(dst_tp) != describe(src_tp) && arg_expr is ExprMakeStruct) {
                 var make_str = unsafe(reinterpret<ExprMakeStruct?>(arg_expr));
                 make_str.makeType = clone_type(dst_tp);
                 args |> emplace(make_str);
@@ -407,7 +408,10 @@ class QuotePass : AstPassMacro {
     //! Pass macro that processes quoted AST expressions.
     def override apply(prog : ProgramPtr; mod : Module?) : bool {
         // Unwrapping ExprQuote is slow and inefficient, do it only if necessary.
-        if (!compiling_program().policies.aot_macros) return false // nothing to do
+        // Triggered by the aot_macros policy (`daslang -aot -aot-macros`) or per-module
+        // `options aot_macros` (self-contained tests, interpreted A/B).
+        let lower = compiling_program().policies.aot_macros || (prog._options |> find_arg("aot_macros") ?as tBool ?? false)
+        if (!lower) return false // nothing to do
         var astVisitor = new QuoteConverter()
         make_visitor(*astVisitor) $(astVisitorAdapter) {
             visit(prog, astVisitorAdapter)

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -149,12 +149,13 @@ def public clone_file_info(b : FileInfoInitData) : FileInfo? {
 var private g_resolved_file_infos : table<string; FileInfo?>
 
 def public resolve_file_info(b : FileInfoInitData) : FileInfo? {
-    //! Stable FileInfo for reconstructed LineInfos: one interned dummy per file name
+    //! Stable FileInfo for reconstructed LineInfos: one interned dummy per (file name, tab size)
     //! (per context), instead of a fresh allocation per evaluation.
-    if (!key_exists(g_resolved_file_infos, b.name)) {
-        g_resolved_file_infos[b.name] = clone_file_info(b.name, b.tabSize)
+    let key = "{b.name}:{b.tabSize}"
+    if (!key_exists(g_resolved_file_infos, key)) {
+        g_resolved_file_infos[key] = clone_file_info(b.name, b.tabSize)
     }
-    return g_resolved_file_infos[b.name]
+    return g_resolved_file_infos[key]
 }
 
 let blacklist = [
@@ -209,10 +210,7 @@ def private create_string_expr(name) {
     return new ExprConstString(value := name);
 }
 
-def private normalize_source_path(p : string) : string {
-    // the same source file may be opened via different spellings at AOT-generation time
-    // and at runtime (slash form, drive-letter case); the path is baked into the lowered
-    // code as a string constant, so it must hash identically — normalize both axes
+def private fix_path_spelling(p : string) : string {
     var r = p |> replace("\\", "/")
     if (length(r) >= 2) {
         r = r |> modify_data() $(var arr) {
@@ -223,6 +221,18 @@ def private normalize_source_path(p : string) : string {
         }
     }
     return r
+}
+
+def private normalize_source_path(p : string) : string {
+    // the same source file may be opened via different spellings at AOT-generation time
+    // and at runtime (slash form, drive-letter case, dasroot-absolute vs repo-relative);
+    // the path is baked into the lowered code as a string constant, so it must hash
+    // identically — canonicalize to dasroot-relative (machine-independent), else absolute
+    var root = fix_path_spelling(get_das_root())
+    if (!(root |> ends_with("/"))) {
+        root += "/"
+    }
+    return fix_path_spelling(p) |> trim_prefix(root)
 }
 
 

--- a/daslib/quote.das
+++ b/daslib/quote.das
@@ -209,6 +209,22 @@ def private create_string_expr(name) {
     return new ExprConstString(value := name);
 }
 
+def private normalize_source_path(p : string) : string {
+    // the same source file may be opened via different spellings at AOT-generation time
+    // and at runtime (slash form, drive-letter case); the path is baked into the lowered
+    // code as a string constant, so it must hash identically — normalize both axes
+    var r = p |> replace("\\", "/")
+    if (length(r) >= 2) {
+        r = r |> modify_data() $(var arr) {
+            let c = uint(arr[0])
+            if (uint(arr[1]) == uint(':') && c >= uint('a') && c <= uint('z')) {
+                arr[0] = uint8(c - uint('a') + uint('A'))
+            }
+        }
+    }
+    return r
+}
+
 
 def private to_array_move_expr(var mkArr : ExprMakeArray?, at : LineInfo) {
     var mkToArrayMove = new ExprCall(at = at, name := "to_array_move")
@@ -311,6 +327,10 @@ def private convert_quote_struct_field(mod : Module?, data : uint8 const?,
         var prev = res_field;
         res_field = new ExprCall(at = parent_loc, name := "clone_line_info",
                                arguments := array<Expression?>(prev))
+    }
+    if (tstr == "rtti_core::FileInfo" && name == "name" && res_field is ExprConstString) {
+        var cs = unsafe(reinterpret<ExprConstString?>(res_field))
+        cs.value := normalize_source_path(string(cs.value))
     }
 
     return create_field_expr(name, clone(res_field), parent_loc, flags);

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -17,6 +17,9 @@ require daslib/ast
 require daslib/ast_boost
 require daslib/algorithm
 require daslib/strings_boost
+// quote lowering (QuotePass + runtime reconstruction helpers); public so the
+// reconstruction calls generated into qmacro-using modules resolve there
+require daslib/quote public
 
 struct Template {
     //! This structure contains collection of substitution rules for a template.

--- a/dastest/dastest_clargs.das
+++ b/dastest/dastest_clargs.das
@@ -77,6 +77,9 @@ struct DastestArgs {
     @clarg_doc = "Compile and run tests using AOT (ahead-of-time) compilation, failing if AOT is unavailable"
     use_aot : bool
 
+    @clarg_doc = "Force quote()/qmacro lowering (daslib/quote QuotePass) when compiling test files"
+    aot_macros : bool
+
     @clarg_doc = "Enable benchmark execution (all of them)"
     bench : bool
 

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -164,7 +164,7 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
             if (ctx.aot_macros) {
                 // a lowered quote evaluates one large make-struct construction frame
                 // (same bump the `daslang -aot -aot-macros` flow applies)
-                cop.stack = 1 * 1024 * 1024
+                cop.stack = 1024u * 1024u
             }
             cop.threadlock_context = true
             cop.jit_enabled = jit_enabled()

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -33,6 +33,7 @@ struct SuiteCtx {
     verbose : bool = false
     compile_only : bool = false
     use_aot : bool = false
+    aot_macros : bool = false
     cov_path : string = ""
     debugger : bool = false
     keep_alive : bool = false
@@ -86,6 +87,7 @@ def SuiteCtx(args : DastestArgs) : SuiteCtx {
     ctx.projectPath = args.test_project
     ctx.compile_only = args.compile_only
     ctx.use_aot = args.use_aot || is_in_aot()
+    ctx.aot_macros = args.aot_macros
     ctx.cov_path = args.cov_path
     ctx.testNames := args.test_names
     ctx.bench_names := args.bench_names
@@ -158,6 +160,12 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
             cop.aot_module = true
             cop.aot = ctx.use_aot
             cop.fail_on_no_aot = ctx.use_aot
+            cop.aot_macros = ctx.aot_macros
+            if (ctx.aot_macros) {
+                // a lowered quote evaluates one large make-struct construction frame
+                // (same bump the `daslang -aot -aot-macros` flow applies)
+                cop.stack = 1 * 1024 * 1024
+            }
             cop.threadlock_context = true
             cop.jit_enabled = jit_enabled()
             cop.debugger = ctx.debugger

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -356,7 +356,7 @@ def document_module_ast(_root : string) {
         group_by_regex("Removal", mod, %regex~(remove.*)%%),
         group_by_regex("Properties", mod, %regex~(is|has|get|can)_.*%%),
         group_by_regex("Infer", mod, %regex~(infer_generic_type|update_alias_map)$%%),
-        group_by_regex("Module queries", mod, %regex~(module_find_annotation|module_find_type_annotation|module_find_structure|module_has_comment_reader|not_inferred)$%%),
+        group_by_regex("Module queries", mod, %regex~(module_find_annotation|module_find_type_annotation|module_find_structure|module_find_enumeration|module_has_comment_reader|not_inferred)$%%),
         group_by_regex("Debug info helpers", mod, %regex~(debug_helper_.*)%%),
         group_by_regex("AOT support", mod, %regex~(aot_require|aot_type_ann_get_field_ptr|aot_need_type_info|aot_previsit_get_field_ptr|aot_previsit_get_field|aot_visit_get_field|write_aot_body|write_aot_suffix|write_aot_macro_suffix|write_aot_macro_prefix|macro_aot_infix|getInitSemanticHashWithDep|get_aot_hash_comment)$%%),
         group_by_regex("String builder writer", mod, %regex~(string_builder_str|string_builder_clear)$%%),
@@ -1269,8 +1269,8 @@ def document_module_coverage(_root : string) {
 def document_module_quote(_root : string) {
     var mod = find_module("quote")
     var groups <- array<DocGroup>(
-        group_by_regex("Clone operations", mod, %regex~(clone|clone_line_info|clone_file_info)$%%),
-        group_by_regex("Conversion", mod, %regex~(cvt_to_mks)$%%)
+        group_by_regex("Clone operations", mod, %regex~(clone|clone_line_info|clone_file_info|resolve_file_info)$%%),
+        group_by_regex("Conversion", mod, %regex~(cvt_to_mks|make_alias_type_decl)$%%)
     )
     document("AST quasiquoting infrastructure", mod, "quote.rst", groups)
 }

--- a/doc/source/stdlib/handmade/function-ast-module_find_enumeration-0xb93136d08d96a621.rst
+++ b/doc/source/stdlib/handmade/function-ast-module_find_enumeration-0xb93136d08d96a621.rst
@@ -1,0 +1,1 @@
+Finds an enumeration by name in the given module. Returns null when the module does not declare an enumeration with that name.

--- a/doc/source/stdlib/handmade/function-ast-module_find_enumeration-0xb93136d08d96a621.rst
+++ b/doc/source/stdlib/handmade/function-ast-module_find_enumeration-0xb93136d08d96a621.rst
@@ -1,1 +1,1 @@
-Finds an enumeration by name in the given module. Returns null when the module does not declare an enumeration with that name.
+Finds an enumeration by name in the given module. The module must not be null (panics otherwise); returns null when the module does not declare an enumeration with that name.

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -557,6 +557,7 @@ namespace das {
     DAS_CC_API Annotation * get_expression_annotation ( Expression * expr, Context * context, LineInfoArg * at );
     DAS_CC_API Structure * find_unique_structure ( smart_ptr_raw<Program> prog, const char * name, Context * context, LineInfoArg * at );
     DAS_CC_API Structure * module_find_structure ( const Module* module, const char * name, Context * context, LineInfoArg * at );
+    DAS_CC_API Enumeration * module_find_enumeration ( const Module* module, const char * name, Context * context, LineInfoArg * at );
     DAS_CC_API void get_use_global_variables ( Function * func, const TBlock<void,VariablePtr> & block, Context * context, LineInfoArg * at );
     DAS_CC_API void get_use_functions ( Function * func, const TBlock<void,FunctionPtr> & block, Context * context, LineInfoArg * at );
     DAS_CC_API Structure::FieldDeclaration * ast_findStructureField ( Structure * structType, const char * field, Context * context, LineInfoArg * at );

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -3389,6 +3389,11 @@ class public LlvmJitVisitor : AstVisitor {
         unsupported(expr, "try-catch")
     }
 
+// ExprQuote
+    def override preVisitExprQuote(expr : ExprQuote?) : void {
+        unsupported(expr, "quote( ) is not jit-able without aot_macros lowering (daslib/quote)")
+    }
+
 // ExprIfThenElse
     /*
     if_cond_at:

--- a/skills/aot_testing.md
+++ b/skills/aot_testing.md
@@ -274,6 +274,7 @@ Functions with `SideEffects::none` can be **constant-folded** at compile time. I
 | Dependency hash differs | A dependency function's SIM tree changed (different module state in batch) | Compare dep hashes in the hash comment; inspect the specific dependency |
 | AOT hash differs but own + all deps match | Dependency list differs (extra or missing deps) | Check if batch processing adds/removes function instantiations |
 | All hashes match but still fails | Stale generated C++ — `.cpp` file wasn't regenerated | Delete `_aot_generated/*.cpp` and rebuild |
+| Own hash differs after editing a quote-lowered file (`options aot_macros`) | ANY edit — even comment-only — shifts line numbers, and lowered code bakes LineInfos as integer constants | Purge that directory's `_aot_generated/` and rebuild `test_aot` (the custom commands don't track daslib deps either — same purge after `daslib/quote.das` edits) |
 
 ### Batch AOT processing
 

--- a/skills/writing_tests.md
+++ b/skills/writing_tests.md
@@ -15,6 +15,20 @@ comment + issue link on both. Glob exclusion alone is NOT enough — test_aot st
 the file and trips 50101 on its missing stubs; `options no_aot` is what makes the runtime
 skip AOT linking for it.
 
+## Per-folder sweep gating (`tests/.das_test`)
+
+`tests/.das_test` defines `can_visit_folder(folder_name, result)` — dastest consults it
+per subfolder during file collection (only for the `.das_test` at the `--test <root>`
+argument; directly naming a child folder bypasses it). It gates folders on module
+availability (`dasHV`, `dasSQLITE`, …) and on sweep mode by scanning argv for `-jit` /
+`--use-aot` (e.g. `ast`, `ast_match`, `no_aot`, `gc`, `quote` skip under `-jit` — runtime
+quote/qmacro the JIT can't codegen). Two traps: a whole-folder JIT/AOT failure usually
+means a missing entry here, NOT a per-file fix; and the `jit_cache_all_tests` prewarm
+target (utils/CMakeLists.txt) does NOT consult it — its `--exclude` list mirrors the
+`-jit` skips manually and must be updated in the same change. Per-function `[test, no_jit]`
+(tests/template/test_push_block_list.das) is the finer-grained alternative when only some
+tests in a kept folder can't JIT.
+
 ## Test file structure
 
 ```das

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1437,9 +1437,10 @@ namespace das {
         expr->type = new TypeDecl(Type::tPointer);
         expr->type->firstType = new TypeDecl(Type::tHandle);
         expr->type->firstType->annotation = (TypeAnnotation *)Module::require("ast_core")->findAnnotation("Expression");
-        // mark quote as noAot
+        // mark quote as noAot, unless daslib/quote lowering will replace it
+        // (aot_macros policy or per-module `options aot_macros` — same gate as QuotePass)
         if (func) {
-            if (!program->policies.aot_macros) {
+            if (!program->policies.aot_macros && !program->options.getBoolOption("aot_macros", false)) {
                 func->noAot = true;
             }
         }

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -813,7 +813,10 @@ namespace das {
             // subobject is not at offset 0, the cast chain performs the base adjustment.
             return apply(static_cast<vector<MakeFieldDeclPtr>*>((MakeStruct*)vec));
         }
-        if (type->baseType == Type::tPointer || tstr == "string") {
+        if (tstr == "string") {
+            return apply(static_cast<vector<const char *>*>(vec));
+        }
+        if (type->baseType == Type::tPointer) {
             // post-gc_node every AST node vector is a plain vector of raw pointers
             return apply(static_cast<vector<void*>*>(vec));
         }

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -743,6 +743,11 @@ namespace das {
         return module->findStructure(name);
     }
 
+    Enumeration * module_find_enumeration ( const Module* module, const char * name, Context * context, LineInfoArg * at ) {
+        if ( !module ) context->throw_error_at(at, "expecting module");
+        return module->findEnum(name);
+    }
+
     void * das_get_builtin_function_address ( Function * fn, Context * context, LineInfoArg * at ) {
         if ( !fn ) context->throw_error_at(at, "expecting function");
         if ( !fn->builtIn ) context->throw_error_at(at, "expecting built-in interop function");
@@ -1586,6 +1591,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(module_find_structure)>(*this, lib,  "module_find_structure",
             SideEffects::accessExternal, "module_find_structure")
                 ->args({"program","name","context","at"});
+        addExtern<DAS_BIND_FUN(module_find_enumeration)>(*this, lib,  "module_find_enumeration",
+            SideEffects::accessExternal, "module_find_enumeration")
+                ->args({"module","name","context","at"});
         // used variables and functions
         addExtern<DAS_BIND_FUN(get_use_global_variables)>(*this, lib,  "get_use_global_variables",
             SideEffects::invoke, "get_use_global_variables")

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -801,10 +801,18 @@ namespace das {
     }
 
     template <typename F>
-    static auto apply_to_vec(void* vec, string_view tstr, F apply) {
-        if (tstr == "string") {
-            return apply(static_cast<vector<const char *>*>(vec));
-        } else if (tstr == "$::das_string") {
+    static auto apply_to_vec(void* vec, TypeDecl * type, F apply) {
+        auto tstr = type->describe();
+        if (tstr == "ast_core::MakeFieldDecl?") {
+            // MakeStruct IS-A vector<MakeFieldDeclPtr> via multiple inheritance; the vector
+            // subobject is not at offset 0, the cast chain performs the base adjustment.
+            return apply(static_cast<vector<MakeFieldDeclPtr>*>((MakeStruct*)vec));
+        }
+        if (type->baseType == Type::tPointer || tstr == "string") {
+            // post-gc_node every AST node vector is a plain vector of raw pointers
+            return apply(static_cast<vector<void*>*>(vec));
+        }
+        if (tstr == "$::das_string") {
             return apply(static_cast<vector<string>*>(vec));
         } else if (tstr == "ast_core::CaptureEntry") {
             return apply(static_cast<vector<CaptureEntry>*>(vec));
@@ -818,11 +826,6 @@ namespace das {
             return apply(static_cast<vector<AnnotationArgument>*>(vec));
         } else if (tstr == "rtti_core::LineInfo") {
             return apply(static_cast<vector<LineInfo>*>(vec));
-        } else if (tstr == "ast::MakeStruct*") {
-            return apply(static_cast<vector<MakeStructPtr>*>(vec));
-        } else if (tstr == "ast::MakeFieldDecl*") {
-            auto vec2 = (MakeStruct*)(vec); // todo: hack, multiple inheritance breaks order in memory.
-            return apply(static_cast<vector<MakeFieldDeclPtr>*>(vec2));
         } else if (tstr == "ast_core::EnumEntry") {
             return apply(static_cast<vector<Enumeration::EnumEntry>*>(vec));
         }
@@ -831,18 +834,17 @@ namespace das {
     }
 
     void* getVectorPtrAtIndex(void* vec, TypeDecl *type, int idx, Context * /*context*/, LineInfoArg * /*at*/) {
-        auto tstr = type->describe();
         auto get_at = [idx](auto *vec) {
             return static_cast<void*>(&vec->at(idx));
         };
-        return apply_to_vec(vec, tstr, get_at);
+        return apply_to_vec(vec, type, get_at);
     }
 
     int32_t getVectorLength(void* vec, TypeDecl * type, Context * /*context*/, LineInfoArg * /*at*/) {
         auto get_size = [](auto *vec) {
             return vec->size();
         };
-        return (int) apply_to_vec(vec, type->describe(), get_size);
+        return (int) apply_to_vec(vec, type, get_size);
     }
 
     uint32_t getHandledTypeFieldOffset ( TypeAnnotationPtr annotation, char * name, Context * context, LineInfoArg * at ) {

--- a/tests/.das_test
+++ b/tests/.das_test
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 
 require daslib/rtti
-require strings
 
 [export, pinvoke]
 def can_visit_folder(folder_name : string; var result : bool?) {
@@ -61,6 +60,17 @@ def can_visit_folder(folder_name : string; var result : bool?) {
         }
     }
     if (folder_name == "gc") {
+        let args <- get_command_line_arguments()
+        for (arg in args) {
+            if (arg == "-jit") {
+                *result = false
+                return
+            }
+        }
+    }
+    // The A/B baseline fixture keeps raw quote( ) nodes LLVM JIT can't codegen.
+    // AOT stays on (the lowered twins are the point). Lift with the JIT lowering lane.
+    if (folder_name == "quote") {
         let args <- get_command_line_arguments()
         for (arg in args) {
             if (arg == "-jit") {

--- a/tests/README.md
+++ b/tests/README.md
@@ -842,6 +842,18 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | test_result.das | `Result<T, E>` — ok/err constructors, map/map_err/and_then/or_else, unwrap family, operators `??`/`==`, to_option/err_to_option bridges, if_ok/if_err, chaining | |
 | test_result_non_copyable.das | `Result<array<int>, string>` — every constructor/combinator/unwrap/operator with a non-copyable T, plus `move_ok` and `move_err` | |
 
+## quote/
+
+> A/B equivalence for the daslib/quote lowering (QuotePass, `aot_macros`): each shape is quoted through the interpreter SimNode path and the lowered reconstruction path, and the describe output must match.
+
+| File | Description | Expects errors |
+|---|---|---|
+| _quote_entities.das | Shared enum/struct in a named module so describes qualify identically on both sides *(helper)* | |
+| _quote_shapes.das | Reference fixture — quote/qmacro shapes through the SimNode path *(helper)* | |
+| _quote_shapes_lowered.das | Lowered twin — identical body + `options aot_macros` *(helper)* | |
+| test_quote_lowering.das | Per-shape describe equality: consts/escapes/non-ASCII, calls, splices, blocks+finally, make-struct, enum/struct/container types, table/tuple literals, capture lambdas, generators, block_to_array | |
+| test_quote_lowered_main.das | Lowered quotes in the anonymous main module — by-name alias fallback for local enum/struct types, splice substitution | |
+
 ## regex/
 
 | File | Description | Expects errors |

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -360,6 +360,18 @@ list(FILTER AOT_STRINGS_FILES EXCLUDE REGEX "failed_")
 # AOT for template test files
 FILE(GLOB AOT_TEMPLATE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/template/*.das")
 
+# AOT for quote lowering test files
+FILE(GLOB AOT_QUOTE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/quote/*.das")
+# Exclude fixture modules (compiled via DAS_AOT_LIB below)
+list(FILTER AOT_QUOTE_FILES EXCLUDE REGEX "/_")
+
+# Quote test module files (A/B fixtures required by the quote tests)
+SET(AOT_QUOTE_MODULE_FILES
+    tests/quote/_quote_entities.das
+    tests/quote/_quote_shapes.das
+    tests/quote/_quote_shapes_lowered.das
+)
+
 # AOT for type_traits test files
 FILE(GLOB AOT_TYPE_TRAITS_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/type_traits/*.das")
 
@@ -716,6 +728,14 @@ add_custom_target(test_aot_template)
 SET(TEMPLATE_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_TEMPLATE_FILES}" TEMPLATE_AOT_GENERATED_SRC test_aot_template daslang)
 
+add_custom_target(test_aot_quote)
+SET(QUOTE_AOT_GENERATED_SRC)
+DAS_AOT("${AOT_QUOTE_FILES}" QUOTE_AOT_GENERATED_SRC test_aot_quote daslang)
+
+add_custom_target(test_aot_quote_modules)
+SET(QUOTE_MODULES_AOT_GENERATED_SRC)
+DAS_AOT_LIB("${AOT_QUOTE_MODULE_FILES}" QUOTE_MODULES_AOT_GENERATED_SRC test_aot_quote_modules daslang)
+
 add_custom_target(test_aot_type_traits)
 SET(TYPE_TRAITS_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_TYPE_TRAITS_FILES}" TYPE_TRAITS_AOT_GENERATED_SRC test_aot_type_traits daslang)
@@ -825,6 +845,8 @@ SOURCE_GROUP_FILES("aot generated" SOA_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" SPOOF_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" STRINGS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" TEMPLATE_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" QUOTE_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" QUOTE_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" TYPE_TRAITS_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" URI_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LPIPE_AOT_GENERATED_SRC)
@@ -904,6 +926,8 @@ add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
     ${TABLE_PACKED_AOT_GENERATED_SRC}
     ${RTTI_AOT_GENERATED_SRC}
     ${TEMPLATE_AOT_GENERATED_SRC}
+    ${QUOTE_AOT_GENERATED_SRC}
+    ${QUOTE_MODULES_AOT_GENERATED_SRC}
     ${TYPE_TRAITS_AOT_GENERATED_SRC}
     ${URI_AOT_GENERATED_SRC}
     ${LPIPE_AOT_GENERATED_SRC}
@@ -952,7 +976,7 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_regex test_aot_reader_macro
     test_aot_delegate test_aot_safe_addr test_aot_soa test_aot_spoof test_aot_strings
     test_aot_lint test_aot_promote test_aot_table_packed test_aot_rtti
-    test_aot_template test_aot_type_traits test_aot_uri
+    test_aot_template test_aot_quote test_aot_quote_modules test_aot_type_traits test_aot_uri
     test_aot_lpipe
     test_aot_jit
     test_aot_loops

--- a/tests/quote/_quote_entities.das
+++ b/tests/quote/_quote_entities.das
@@ -1,0 +1,18 @@
+options gen2
+options indenting = 4
+
+// Shared entities for the quote-lowering A/B fixtures: declared in ONE named module so
+// describe output is module-qualified identically on both sides of the comparison.
+
+module _quote_entities shared
+
+enum public Color {
+    red
+    green
+    blue
+}
+
+struct public Pair {
+    a : int
+    b : string
+}

--- a/tests/quote/_quote_shapes.das
+++ b/tests/quote/_quote_shapes.das
@@ -12,7 +12,7 @@ module _quote_shapes shared
 require daslib/ast
 require daslib/templates_boost
 require daslib/strings_boost
-require _quote_entities
+require _quote_entities // nolint:STYLE030 referenced only inside quoted trees (parse-time type resolution), invisible to symbol-use
 
 def public shape_consts : string {
     var res = ""
@@ -163,10 +163,7 @@ def public shape_block_to_array : string {
             foo()
             bar(1, "x")
         }
-        var parts : array<string>
-        for (e in arr) {
-            parts |> push(describe_expression(e))
-        }
+        var parts <- [for (e in arr); describe_expression(e)]
         res = parts |> join(";")
         delete parts
     }

--- a/tests/quote/_quote_shapes.das
+++ b/tests/quote/_quote_shapes.das
@@ -2,10 +2,11 @@ options gen2
 options rtti
 options indenting = 4
 
-// Reference fixture for the quote-lowering A/B suite: quotes run through the
-// interpreter SimNode path (clone of the parsed tree). The lowered twin
-// (_quote_shapes_lowered.das) is IDENTICAL except for the module name and
-// `options aot_macros` — keep the bodies in sync.
+// Twin fixture for the quote-lowering A/B suite: _quote_shapes runs quotes through
+// the interpreter SimNode path (clone of the parsed tree), _quote_shapes_lowered
+// (`options aot_macros`) through the lowered reconstruction code. The two files are
+// IDENTICAL except for the module name and the `options aot_macros` line — keep
+// the bodies in sync.
 
 module _quote_shapes shared
 

--- a/tests/quote/_quote_shapes.das
+++ b/tests/quote/_quote_shapes.das
@@ -1,0 +1,174 @@
+options gen2
+options rtti
+options indenting = 4
+
+// Reference fixture for the quote-lowering A/B suite: quotes run through the
+// interpreter SimNode path (clone of the parsed tree). The lowered twin
+// (_quote_shapes_lowered.das) is IDENTICAL except for the module name and
+// `options aot_macros` — keep the bodies in sync.
+
+module _quote_shapes shared
+
+require daslib/ast
+require daslib/templates_boost
+require daslib/strings_boost
+require _quote_entities
+
+def public shape_consts : string {
+    var res = ""
+    ast_gc_guard() {
+        var e1 = quote("a\nb\t\"q\" — π λ")
+        var e2 = quote(13.5lf)
+        var e3 = quote(0xff)
+        res = "{describe_expression(e1)}|{describe_expression(e2)}|{describe_expression(e3)}"
+    }
+    return res
+}
+
+def public shape_call : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = quote(foo(1 + 2, "bar"))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_splices : string {
+    var res = ""
+    ast_gc_guard() {
+        let n = "spliced"
+        var e = qmacro($c(n)(true, 13.5, [1, 2, 3]))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_ident_splice : string {
+    var res = ""
+    ast_gc_guard() {
+        let nm = "counter"
+        var e = qmacro($i(nm) + 1)
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_block : string {
+    var res = ""
+    ast_gc_guard() {
+        var b = qmacro_block() {
+            var x = 5
+            for (i in range(x)) {
+                print("{i}\n")
+            }
+        }
+        res = describe_expression(b)
+    }
+    return res
+}
+
+def public shape_finally_block : string {
+    var res = ""
+    ast_gc_guard() {
+        var b = qmacro_block() {
+            var arr : array<int>
+            {
+                arr |> push(1)
+            } finally {
+                delete arr
+            }
+        }
+        res = describe_expression(b)
+    }
+    return res
+}
+
+def public shape_make_struct : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro(Foo(a = 1, b = "two"))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_named_enum_type : string {
+    var res = ""
+    ast_gc_guard() {
+        var t = qmacro_type(type<Color>)
+        res = describe(t)
+    }
+    return res
+}
+
+def public shape_named_struct_type : string {
+    var res = ""
+    ast_gc_guard() {
+        var t = qmacro_type(type<Pair>)
+        res = describe(t)
+    }
+    return res
+}
+
+def public shape_nested_type : string {
+    var res = ""
+    ast_gc_guard() {
+        var t = qmacro_type(type<table<string; array<int>>>)
+        res = describe(t)
+    }
+    return res
+}
+
+def public shape_table_literal : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro({ "k1" => 1, "k2" => 2 })
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_tuple_literal : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro((1, "a", 2.5))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_lambda_capture : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro(@ capture(:= y) (x : int) { return x + y; })
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_generator : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro($ { yield 1; yield 2; })
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_block_to_array : string {
+    var res = ""
+    ast_gc_guard() {
+        var arr <- qmacro_block_to_array() {
+            foo()
+            bar(1, "x")
+        }
+        var parts : array<string>
+        for (e in arr) {
+            parts |> push(describe_expression(e))
+        }
+        res = parts |> join(";")
+        delete parts
+    }
+    return res
+}

--- a/tests/quote/_quote_shapes_lowered.das
+++ b/tests/quote/_quote_shapes_lowered.das
@@ -3,10 +3,11 @@ options rtti
 options indenting = 4
 options aot_macros
 
-// Reference fixture for the quote-lowering A/B suite: quotes run through the
-// interpreter SimNode path (clone of the parsed tree). The lowered twin
-// (_quote_shapes_lowered.das) is IDENTICAL except for the module name and
-// `options aot_macros` — keep the bodies in sync.
+// Twin fixture for the quote-lowering A/B suite: _quote_shapes runs quotes through
+// the interpreter SimNode path (clone of the parsed tree), _quote_shapes_lowered
+// (`options aot_macros`) through the lowered reconstruction code. The two files are
+// IDENTICAL except for the module name and the `options aot_macros` line — keep
+// the bodies in sync.
 
 module _quote_shapes_lowered shared
 

--- a/tests/quote/_quote_shapes_lowered.das
+++ b/tests/quote/_quote_shapes_lowered.das
@@ -13,7 +13,7 @@ module _quote_shapes_lowered shared
 require daslib/ast
 require daslib/templates_boost
 require daslib/strings_boost
-require _quote_entities
+require _quote_entities // nolint:STYLE030 referenced only inside quoted trees (parse-time type resolution), invisible to symbol-use
 
 def public shape_consts : string {
     var res = ""
@@ -164,10 +164,7 @@ def public shape_block_to_array : string {
             foo()
             bar(1, "x")
         }
-        var parts : array<string>
-        for (e in arr) {
-            parts |> push(describe_expression(e))
-        }
+        var parts <- [for (e in arr); describe_expression(e)]
         res = parts |> join(";")
         delete parts
     }

--- a/tests/quote/_quote_shapes_lowered.das
+++ b/tests/quote/_quote_shapes_lowered.das
@@ -1,0 +1,175 @@
+options gen2
+options rtti
+options indenting = 4
+options aot_macros
+
+// Reference fixture for the quote-lowering A/B suite: quotes run through the
+// interpreter SimNode path (clone of the parsed tree). The lowered twin
+// (_quote_shapes_lowered.das) is IDENTICAL except for the module name and
+// `options aot_macros` — keep the bodies in sync.
+
+module _quote_shapes_lowered shared
+
+require daslib/ast
+require daslib/templates_boost
+require daslib/strings_boost
+require _quote_entities
+
+def public shape_consts : string {
+    var res = ""
+    ast_gc_guard() {
+        var e1 = quote("a\nb\t\"q\" — π λ")
+        var e2 = quote(13.5lf)
+        var e3 = quote(0xff)
+        res = "{describe_expression(e1)}|{describe_expression(e2)}|{describe_expression(e3)}"
+    }
+    return res
+}
+
+def public shape_call : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = quote(foo(1 + 2, "bar"))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_splices : string {
+    var res = ""
+    ast_gc_guard() {
+        let n = "spliced"
+        var e = qmacro($c(n)(true, 13.5, [1, 2, 3]))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_ident_splice : string {
+    var res = ""
+    ast_gc_guard() {
+        let nm = "counter"
+        var e = qmacro($i(nm) + 1)
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_block : string {
+    var res = ""
+    ast_gc_guard() {
+        var b = qmacro_block() {
+            var x = 5
+            for (i in range(x)) {
+                print("{i}\n")
+            }
+        }
+        res = describe_expression(b)
+    }
+    return res
+}
+
+def public shape_finally_block : string {
+    var res = ""
+    ast_gc_guard() {
+        var b = qmacro_block() {
+            var arr : array<int>
+            {
+                arr |> push(1)
+            } finally {
+                delete arr
+            }
+        }
+        res = describe_expression(b)
+    }
+    return res
+}
+
+def public shape_make_struct : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro(Foo(a = 1, b = "two"))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_named_enum_type : string {
+    var res = ""
+    ast_gc_guard() {
+        var t = qmacro_type(type<Color>)
+        res = describe(t)
+    }
+    return res
+}
+
+def public shape_named_struct_type : string {
+    var res = ""
+    ast_gc_guard() {
+        var t = qmacro_type(type<Pair>)
+        res = describe(t)
+    }
+    return res
+}
+
+def public shape_nested_type : string {
+    var res = ""
+    ast_gc_guard() {
+        var t = qmacro_type(type<table<string; array<int>>>)
+        res = describe(t)
+    }
+    return res
+}
+
+def public shape_table_literal : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro({ "k1" => 1, "k2" => 2 })
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_tuple_literal : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro((1, "a", 2.5))
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_lambda_capture : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro(@ capture(:= y) (x : int) { return x + y; })
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_generator : string {
+    var res = ""
+    ast_gc_guard() {
+        var e = qmacro($ { yield 1; yield 2; })
+        res = describe_expression(e)
+    }
+    return res
+}
+
+def public shape_block_to_array : string {
+    var res = ""
+    ast_gc_guard() {
+        var arr <- qmacro_block_to_array() {
+            foo()
+            bar(1, "x")
+        }
+        var parts : array<string>
+        for (e in arr) {
+            parts |> push(describe_expression(e))
+        }
+        res = parts |> join(";")
+        delete parts
+    }
+    return res
+}

--- a/tests/quote/test_quote_lowered_main.das
+++ b/tests/quote/test_quote_lowered_main.das
@@ -1,0 +1,45 @@
+options gen2
+options rtti
+options aot_macros
+options indenting = 4
+
+// Lowered quotes in the program's MAIN (anonymous) module: entities declared here can't
+// be reconstructed by module-name lookup, so TypeDecls referencing them must fall back
+// to the by-name alias shape (make_alias_type_decl) and resolve at splice-site re-infer.
+
+require dastest/testing_boost public
+require daslib/ast
+require daslib/templates_boost
+
+enum LocalColor {
+    red
+    green
+}
+
+struct LocalPair {
+    a : int
+    b : string
+}
+
+[test]
+def test_lowered_local_entities(t : T?) {
+    t |> run("local enum type reconstructs as by-name alias") @(t : T?) {
+        ast_gc_guard() {
+            var ty = qmacro_type(type<LocalColor>)
+            t |> equal(describe(ty), "LocalColor")
+        }
+    }
+    t |> run("local struct type reconstructs as by-name alias") @(t : T?) {
+        ast_gc_guard() {
+            var ty = qmacro_type(type<LocalPair>)
+            t |> equal(describe(ty), "LocalPair")
+        }
+    }
+    t |> run("lowered splice still substitutes") @(t : T?) {
+        ast_gc_guard() {
+            let nm = "renamed"
+            var e = qmacro($c(nm)(1 + 2))
+            t |> equal(describe_expression(e), "renamed(1 + 2)")
+        }
+    }
+}

--- a/tests/quote/test_quote_lowering.das
+++ b/tests/quote/test_quote_lowering.das
@@ -1,0 +1,61 @@
+options gen2
+options rtti
+options indenting = 4
+
+// A/B equivalence for the daslib/quote lowering (QuotePass, gated on aot_macros):
+// every shape is quoted twice — through the interpreter SimNode path (_quote_shapes)
+// and through the lowered reconstruction path (_quote_shapes_lowered) — and the
+// describe output must match exactly.
+
+require dastest/testing_boost public
+require _quote_shapes
+require _quote_shapes_lowered
+
+[test]
+def test_quote_lowering_ab(t : T?) {
+    t |> run("consts (escapes, non-ASCII, double, hex)") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_consts(), _quote_shapes::shape_consts())
+    }
+    t |> run("call") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_call(), _quote_shapes::shape_call())
+    }
+    t |> run("$c/$v splices + array literal") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_splices(), _quote_shapes::shape_splices())
+    }
+    t |> run("$i ident splice") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_ident_splice(), _quote_shapes::shape_ident_splice())
+    }
+    t |> run("block (var/for/print)") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_block(), _quote_shapes::shape_block())
+    }
+    t |> run("block with finally") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_finally_block(), _quote_shapes::shape_finally_block())
+    }
+    t |> run("make-struct named args") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_make_struct(), _quote_shapes::shape_make_struct())
+    }
+    t |> run("named-module enum type") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_named_enum_type(), _quote_shapes::shape_named_enum_type())
+    }
+    t |> run("named-module struct type") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_named_struct_type(), _quote_shapes::shape_named_struct_type())
+    }
+    t |> run("nested container type") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_nested_type(), _quote_shapes::shape_nested_type())
+    }
+    t |> run("table literal") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_table_literal(), _quote_shapes::shape_table_literal())
+    }
+    t |> run("tuple literal") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_tuple_literal(), _quote_shapes::shape_tuple_literal())
+    }
+    t |> run("lambda with capture clause") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_lambda_capture(), _quote_shapes::shape_lambda_capture())
+    }
+    t |> run("generator") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_generator(), _quote_shapes::shape_generator())
+    }
+    t |> run("qmacro_block_to_array") @(t : T?) {
+        t |> equal(_quote_shapes_lowered::shape_block_to_array(), _quote_shapes::shape_block_to_array())
+    }
+}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -105,12 +105,12 @@ endforeach()
 add_dependencies(all_utils_exe dastest_exe)
 
 # Prewarm the JIT dll cache for the whole test tree, except the folders dastest
-# also excludes under -jit (gc, ast_match, ast, no_aot — they use runtime quote/qmacro
+# also excludes under -jit (gc, ast_match, ast, no_aot, quote — they use runtime quote/qmacro
 # the JIT can't lower). Reuses the jit_exe target built by the foreach above (bin/jit.exe, built
 # with --jit-register-all-modules). Run explicitly:
 #   ninja jit_cache_all_tests
 add_custom_target(jit_cache_all_tests
-    COMMAND ${UTIL_BIN_DIR}/jit.exe ${PROJECT_SOURCE_DIR}/tests --parallel 0 $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3> --exclude gc --exclude dasHV --exclude dasPUGIXML --exclude dasSQLITE --exclude stbimage --exclude live_host --exclude audio --exclude strudel --exclude ast_match --exclude ast --exclude no_aot
+    COMMAND ${UTIL_BIN_DIR}/jit.exe ${PROJECT_SOURCE_DIR}/tests --parallel 0 $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3> --exclude gc --exclude dasHV --exclude dasPUGIXML --exclude dasSQLITE --exclude stbimage --exclude live_host --exclude audio --exclude strudel --exclude ast_match --exclude ast --exclude no_aot --exclude quote
     DEPENDS jit_exe
     WORKING_DIRECTORY ${UTIL_BIN_DIR}
     COMMENT "JIT-compiling tests/ into the .jitted_scripts cache"

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -285,6 +285,10 @@ int compile_and_run ( const string & fn, const string & mainFnName, bool outputP
         policies.fail_on_no_aot = false;
     }
     policies.fail_on_lack_of_aot_export = false;
+    policies.aot_macros = aotMacros;    // -aot-macros: force quote lowering (daslib/quote) in a normal run
+    if ( aotMacros ) {
+        policies.stack = 1 * 1024 * 1024;   // a lowered quote evaluates one large construction frame
+    }
     policies.version_2_syntax = version2syntax;
     policies.gen2_make_syntax = gen2MakeSyntax;
     policies.scoped_stack_allocator = scopedStackAllocator;
@@ -570,6 +574,8 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                 jitNoCache = true;
             } else if ( cmd=="use-aot") {
                 useAot = true;
+            } else if ( cmd=="aot-macros") {
+                aotMacros = true;   // force quote lowering (daslib/quote) in a normal run
             } else if ( cmd=="output") {
                 if ( i+1 > argc ) {
                     printf("output requires argument\n");


### PR DESCRIPTION
Revives `daslib/quote.das` (d38cd728f, orphaned since Jul 2025) so `quote(...)` — and therefore the whole qmacro family — lowers under `aot_macros` into plain AST-reconstruction code that compiles in all execution tiers. Plan/worklog: `QUOTE_LOWERING.md`.

## What was broken

- `apply_to_vec` (C++ reflection helper) still dispatched on smart_ptr-era `describe()` spellings (`"ast::MakeStruct*"`) — fatal on the very first `arguments` vector. Replaced with one generic `tPointer → vector<void*>` branch (post-gc_node every AST node vector is a raw-pointer vector); the `MakeFieldDecl?` multiple-inheritance base-adjust stays as the lone special case.
- `convert_vec_expr`'s `dst_tp != src_tp` was a pointer compare — always true after `clone_type` — so pointer-element vectors had an `ExprAscend` reinterpreted as `ExprMakeStruct` and `makeType` written through the wrong layout (gc_collect AV; survived 2025 only by layout luck). Now a semantic compare + `is ExprMakeStruct` guard.
- `cvt_to_mks` used smart_ptr-era `move_new` on a raw-pointer slot → plain assignment.

## Design changes

- **Function-per-quote**: each lowered construction becomes a generated `` `quote`lowered`N `` private function + a call. The inline form inflated every *caller's* frame by the sum of construction temporaries — fatal in recursive macros (flatten's `lower_stmt`). 1MB macro-context stack (the bump the `-aot -aot-macros` flow already used) then suffices everywhere.
- **Wiring**: `require daslib/quote public` in templates_boost — pass-macro visibility follows each module's own require chain (verified empirically; root-level injection does not reach macro-module compiles), and `public` lets the generated reconstruction calls resolve in qmacro-using modules.
- **Gate**: `policies.aot_macros` **or** per-module `options aot_macros` (CodeOfPolicies field names are auto-valid option names) — the latter enables self-contained interpreted A/B tests. Infer's noAot-skip uses the same condition.
- **Anonymous-module entities**: quoted `type<LocalEnum>` / `type<LocalStruct>` used to emit `get_module("")` → null deref. `Enumeration` joins the managed by-name set (new builtin `module_find_enumeration` + AOT decl), and TypeDecls referencing anonymous-module entities reconstruct as `make_alias_type_decl("<name>")` — the parser's unresolved-name shape, re-resolved at splice-site infer.
- **`resolve_file_info`**: per-file interned dummy FileInfo per context (was: fresh allocation per LineInfo per evaluation). Baked source paths are normalized (separators, drive-letter case) so dasAot-generation and runtime spellings of the same file hash identically — without this, every lowered function failed AOT linking (error 50101) under the CI invocation.
- **Diagnostics**: `NoAotMarker` excludes functions with surviving quotes + LOG_ERROR naming file/cause/fix (a panic inside make_visitor visitors is swallowed by `runMacroFunction`); CppAot writes `#error` into the generated C++ as a deterministic backstop; llvm_jit gets a clean `unsupported` message instead of the misleading "Internal jit error" panic.
- **Audit hammer**: `daslang -aot-macros <script>` and `dastest --aot-macros` force lowering program-wide for A/B validation.
- Blacklist addition: `ExprBlock.stackCleanVars` — post-infer allocateStack bookkeeping, always empty in quoted trees, no AOT type mapping.

## Tests

- `tests/quote/`: twin fixture modules with identical bodies (SimNode path vs lowered) compared shape-by-shape via describe output — consts/escapes/non-ASCII, calls, splices, blocks+finally, make-struct, enum/struct/container types, table/tuple literals, capture lambdas, generators, `qmacro_block_to_array` — plus anonymous-main-module alias coverage. Registered for AOT (`test_aot_quote` + `test_aot_quote_modules`).

## Validation

| Lane | Result |
|---|---|
| Full tests/ tree, interpreter, lowering **forced on everything** | identical verdict to unlowered baseline |
| tests/quote A/B | 20/20 |
| CI-form `test_aot -use-aot … --use-aot` full tree | 9439 tests, 9433 passed, 0 failed, 0 errors, 6 skipped — lowered functions link as AOT stubs and run native |
| das2rst / sphinx (latex+html) / formatter / lint / scoped detect-dupe | clean |

JIT support is deliberately out of scope (follow-up phase per `QUOTE_LOWERING.md`); the only JIT change here is the diagnostic. The `modules/dasLLVM/daslib/llvm_jit.das` edit is lint/compile-verified; no current CI JIT lane reaches a quote (functions containing them are noAot/interpreted until the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)