### PR TITLE
ast, parser, fio: fix six PVS-Studio findings

### DIFF
--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -3943,6 +3943,7 @@ namespace das {
                             if (!found->init) {
                                 error("bitfield constant '" + expr->name + "' of type " + describeType(alias) + " is not initialized", "", "",
                                       expr->at, CompilationError::missing_bitfield_init);
+                                return Visitor::visit(expr);
                             } else if (!found->init->type || !found->init->type->constant || !found->init->type->isBitfield()) {
                                 error("not a valid bitfield constant " + expr->name + " of type " + describeType(found->type), "", "",
                                       expr->at, CompilationError::invalid_bitfield);
@@ -4394,10 +4395,8 @@ namespace das {
                     error("can't access private variable '" + expr->name + "'", "not visible due to privacy:\n" + errs.str(), "",
                           expr->at, CompilationError::invalid_variable_private);
                 } else {
-                    if (verbose) {
-                        error("can't locate variable '" + expr->name + "'", "", "",
-                          expr->at, CompilationError::lookup_variable);
-                    }
+                    error("can't locate variable '" + expr->name + "'", "", "",
+                      expr->at, CompilationError::lookup_variable);
                 }
             } else {
                 error("can't locate variable '" + expr->name + "'", "", "",
@@ -4416,10 +4415,8 @@ namespace das {
                 error("too many matching variables '" + expr->name + "'", "candidates are:\n" + errs.str(), "",
                       expr->at, CompilationError::ambiguous_variable);
             } else {
-                if (verbose) {
-                    error("too many matching variables '" + expr->name + "'", "", "",
-                      expr->at, CompilationError::ambiguous_variable);
-                }
+                error("too many matching variables '" + expr->name + "'", "", "",
+                  expr->at, CompilationError::ambiguous_variable);
             }
         }
         return Visitor::visit(expr);

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -279,6 +279,7 @@ namespace das {
                     break;
                 }
                 if (totalAliases == aliases.size()) {
+                    program->updateAliasMapCallback = nullptr;
                     return false;
                 }
             }
@@ -1619,6 +1620,7 @@ namespace das {
                             error("unknown type of argument " + clone->arguments[ai]->name + "; can't instance " + describeFunction(oneGeneric), "",
                                   "provide argument type explicitly",
                                   expr->at, CompilationError::lookup_argument_type);
+                            program->updateAliasMapCallback = nullptr;
                             return nullptr;
                         }
                     }

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -2706,7 +2706,7 @@ namespace das
             }
         }
         if (firstType && !firstType->isFullySealed(all)) return false;
-        if (secondType && !firstType->isFullySealed(all)) return false;
+        if (secondType && !secondType->isFullySealed(all)) return false;
         for (auto & argT : argTypes) {
             if (argT && !argT->isFullySealed(all)) return false;
         }

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1366,8 +1366,8 @@ namespace das {
             if (static_cast<RegisterOnError>(on_error) != RegisterOnError::Quiet) {
                 auto err_msg = "dynamic module `" + string(mod_name) + "` — failed to load: " + actualPath
                     + (dlErr.empty() ? string("\n") : (" (" + dlErr + ")\n"));
-                context->to_err(at, err_msg.c_str());
-                if (static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
+                if (context) context->to_err(at, err_msg.c_str());
+                if (context && static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                     context->throw_error(err_msg.c_str());
                 }
             } else {

--- a/src/parser/ds2_lexer.cpp
+++ b/src/parser/ds2_lexer.cpp
@@ -1614,11 +1614,10 @@ case 1:
 YY_RULE_SETUP
 #line 81 "ds2_lexer.lpp"
 {
-    string txt = yytext;
     int lRow, lCol;
-    char lFile[256];
-    if ( sscanf ( yytext, "#%i,%i,\"%255s\"#", &lRow, &lCol, lFile )==3 ) {
-        lFile[strlen(lFile)-2] = 0;
+    if ( sscanf ( yytext, "#%i,%i,", &lRow, &lCol )==2 ) {
+        // file name is the quote-bounded span; sscanf %s would stop at whitespace inside it
+        string lFile ( strchr(yytext,'\"')+1, yytext+yyleng-2 );
         auto cfi = yyextra->g_FileAccessStack.back();
         string incFileName = yyextra->g_Access->getIncludeFileName(cfi->name,lFile);
         auto info = yyextra->g_Access->getFileInfo(incFileName);
@@ -1638,12 +1637,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 103 "ds2_lexer.lpp"
+#line 102 "ds2_lexer.lpp"
 das2_yyfatalerror(yylloc_param,yyscanner,"Unexpected */", CompilationError::invalid_line); return LEXER_ERROR;
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 104 "ds2_lexer.lpp"
+#line 103 "ds2_lexer.lpp"
 {
     BEGIN(c_comment);
     yyextra->das_c_style_depth = 1;
@@ -1655,7 +1654,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 112 "ds2_lexer.lpp"
+#line 111 "ds2_lexer.lpp"
 {
     BEGIN(cpp_comment);
     if ( !yyextra->g_CommentReaders.empty() ) {
@@ -1667,7 +1666,7 @@ YY_RULE_SETUP
 case 5:
 /* rule 5 can match eol */
 YY_RULE_SETUP
-#line 119 "ds2_lexer.lpp"
+#line 118 "ds2_lexer.lpp"
 {
     BEGIN(normal);
     unput('\n');
@@ -1678,12 +1677,12 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(cpp_comment):
-#line 127 "ds2_lexer.lpp"
+#line 126 "ds2_lexer.lpp"
 BEGIN(normal);
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 128 "ds2_lexer.lpp"
+#line 127 "ds2_lexer.lpp"
 {
     if ( !yyextra->g_CommentReaders.empty() ) {
         auto tak = tokAt(yyscanner,*yylloc_param);
@@ -1693,14 +1692,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 134 "ds2_lexer.lpp"
+#line 133 "ds2_lexer.lpp"
 {
     yyextra->das_c_style_depth ++;
 }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 137 "ds2_lexer.lpp"
+#line 136 "ds2_lexer.lpp"
 {
     yyextra->das_c_style_depth --;
     if ( yyextra->das_c_style_depth==0 ) {
@@ -1714,7 +1713,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 147 "ds2_lexer.lpp"
+#line 146 "ds2_lexer.lpp"
 {                      /* skipping comment body */
     if ( !yyextra->g_CommentReaders.empty() ) {
         auto tak = tokAt(yyscanner,*yylloc_param);
@@ -1725,7 +1724,7 @@ YY_RULE_SETUP
 case 10:
 /* rule 10 can match eol */
 YY_RULE_SETUP
-#line 153 "ds2_lexer.lpp"
+#line 152 "ds2_lexer.lpp"
 {                 /* skipping comment eol */
     if ( !yyextra->g_CommentReaders.empty() ) {
         auto tak = tokAt(yyscanner,*yylloc_param);
@@ -1734,14 +1733,14 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(c_comment):
-#line 159 "ds2_lexer.lpp"
+#line 158 "ds2_lexer.lpp"
 {
     das2_yyfatalerror(yylloc_param,yyscanner,"end of file encountered inside c-style comment", CompilationError::exceeds_file);
     BEGIN(normal);
 }
 	YY_BREAK
 case YY_STATE_EOF(reader):
-#line 163 "ds2_lexer.lpp"
+#line 162 "ds2_lexer.lpp"
 {
     das2_yyfatalerror(yylloc_param,yyscanner,"reader constant exceeds file", CompilationError::exceeds_file);
     BEGIN(normal);
@@ -1751,7 +1750,7 @@ case YY_STATE_EOF(reader):
 case 11:
 /* rule 11 can match eol */
 YY_RULE_SETUP
-#line 168 "ds2_lexer.lpp"
+#line 167 "ds2_lexer.lpp"
 {
     YY2NEWLINE(yyscanner);
     yylval_param->ch = yytext[0];
@@ -1760,7 +1759,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 173 "ds2_lexer.lpp"
+#line 172 "ds2_lexer.lpp"
 {
     yylval_param->ch = yytext[0];
     return STRING_CHARACTER;
@@ -1768,7 +1767,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 177 "ds2_lexer.lpp"
+#line 176 "ds2_lexer.lpp"
 {
     // assert(nested_sb==0);
     BEGIN(normal);
@@ -1777,7 +1776,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 182 "ds2_lexer.lpp"
+#line 181 "ds2_lexer.lpp"
 {
     if ( yyextra->das_nested_sb ) {
         das2_yyfatalerror(yylloc_param,yyscanner,"nested string constants are not allowed", CompilationError::invalid_string);
@@ -1790,7 +1789,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(strb):
-#line 192 "ds2_lexer.lpp"
+#line 191 "ds2_lexer.lpp"
 {
     das2_yyfatalerror(yylloc_param,yyscanner,"string constant exceeds file", CompilationError::exceeds_file);
     BEGIN(normal);
@@ -1799,14 +1798,14 @@ case YY_STATE_EOF(strb):
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 197 "ds2_lexer.lpp"
+#line 196 "ds2_lexer.lpp"
 {
     return STRING_CHARACTER_ESC;
 }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 200 "ds2_lexer.lpp"
+#line 199 "ds2_lexer.lpp"
 {
     yylval_param->ch = yytext[1];
     return STRING_CHARACTER;
@@ -1814,13 +1813,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 204 "ds2_lexer.lpp"
+#line 203 "ds2_lexer.lpp"
 /* do exactly nothing */
 	YY_BREAK
 case 18:
 /* rule 18 can match eol */
 YY_RULE_SETUP
-#line 205 "ds2_lexer.lpp"
+#line 204 "ds2_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     YY2NEWLINE(yyscanner);
@@ -1829,7 +1828,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 210 "ds2_lexer.lpp"
+#line 209 "ds2_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
@@ -1837,14 +1836,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 214 "ds2_lexer.lpp"
+#line 213 "ds2_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
 }
 	YY_BREAK
 case YY_STATE_EOF(strfmt):
-#line 218 "ds2_lexer.lpp"
+#line 217 "ds2_lexer.lpp"
 {
     das2_yyfatalerror(yylloc_param,yyscanner,"string format exceeds file", CompilationError::exceeds_file);
     BEGIN(normal);
@@ -1854,7 +1853,7 @@ case YY_STATE_EOF(strfmt):
 case 21:
 /* rule 21 can match eol */
 YY_RULE_SETUP
-#line 223 "ds2_lexer.lpp"
+#line 222 "ds2_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     YY2NEWLINE(yyscanner);
@@ -1863,7 +1862,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 228 "ds2_lexer.lpp"
+#line 227 "ds2_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
@@ -1871,7 +1870,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 232 "ds2_lexer.lpp"
+#line 231 "ds2_lexer.lpp"
 {
     BEGIN(normal);
     unput('}');
@@ -1879,7 +1878,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 236 "ds2_lexer.lpp"
+#line 235 "ds2_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
@@ -1887,12 +1886,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 240 "ds2_lexer.lpp"
+#line 239 "ds2_lexer.lpp"
 /* eat the whitespace */
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 241 "ds2_lexer.lpp"
+#line 240 "ds2_lexer.lpp"
 { /* got the include file name */
     auto cfi = yyextra->g_FileAccessStack.back();
     string incFileName = yyextra->g_Access->getIncludeFileName(cfi->name,yytext);
@@ -1919,78 +1918,78 @@ YY_RULE_SETUP
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 265 "ds2_lexer.lpp"
+#line 264 "ds2_lexer.lpp"
 BEGIN(include);
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 266 "ds2_lexer.lpp"
+#line 265 "ds2_lexer.lpp"
 return DAS_CAPTURE;
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 267 "ds2_lexer.lpp"
+#line 266 "ds2_lexer.lpp"
 return DAS_FOR;
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 268 "ds2_lexer.lpp"
+#line 267 "ds2_lexer.lpp"
 return DAS_WHILE;
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 269 "ds2_lexer.lpp"
+#line 268 "ds2_lexer.lpp"
 return DAS_IF;
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 270 "ds2_lexer.lpp"
+#line 269 "ds2_lexer.lpp"
 return DAS_STATIC_IF;
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 271 "ds2_lexer.lpp"
+#line 270 "ds2_lexer.lpp"
 return DAS_ELIF;
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 272 "ds2_lexer.lpp"
+#line 271 "ds2_lexer.lpp"
 return DAS_STATIC_ELIF;
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 273 "ds2_lexer.lpp"
+#line 272 "ds2_lexer.lpp"
 return DAS_ELSE;
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 274 "ds2_lexer.lpp"
+#line 273 "ds2_lexer.lpp"
 return DAS_FINALLY;
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 275 "ds2_lexer.lpp"
+#line 274 "ds2_lexer.lpp"
 return DAS_DEF;
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 276 "ds2_lexer.lpp"
+#line 275 "ds2_lexer.lpp"
 return DAS_WITH;
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 277 "ds2_lexer.lpp"
+#line 276 "ds2_lexer.lpp"
 return DAS_AKA;
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 278 "ds2_lexer.lpp"
+#line 277 "ds2_lexer.lpp"
 return DAS_ASSUME;
 	YY_BREAK
 case 41:
 /* rule 41 can match eol */
 YY_RULE_SETUP
-#line 279 "ds2_lexer.lpp"
+#line 278 "ds2_lexer.lpp"
 { // TODO: comment reader after let where?
     unput('\n');
     das_accept_cpp_comment(yyextra->g_CommentReaders, yyscanner, *yylloc_param, yytext);
@@ -1999,13 +1998,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 284 "ds2_lexer.lpp"
+#line 283 "ds2_lexer.lpp"
 return DAS_LET;
 	YY_BREAK
 case 43:
 /* rule 43 can match eol */
 YY_RULE_SETUP
-#line 285 "ds2_lexer.lpp"
+#line 284 "ds2_lexer.lpp"
 { // TODO: comment reader after var where?
     unput('\n');
     das_accept_cpp_comment(yyextra->g_CommentReaders, yyscanner, *yylloc_param, yytext);
@@ -2014,457 +2013,457 @@ YY_RULE_SETUP
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 290 "ds2_lexer.lpp"
+#line 289 "ds2_lexer.lpp"
 return DAS_UNINITIALIZED;
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 291 "ds2_lexer.lpp"
+#line 290 "ds2_lexer.lpp"
 return DAS_VAR;
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 292 "ds2_lexer.lpp"
+#line 291 "ds2_lexer.lpp"
 return DAS_STRUCT;
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 293 "ds2_lexer.lpp"
+#line 292 "ds2_lexer.lpp"
 return DAS_CLASS;
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 294 "ds2_lexer.lpp"
+#line 293 "ds2_lexer.lpp"
 return DAS_ENUM;
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 295 "ds2_lexer.lpp"
+#line 294 "ds2_lexer.lpp"
 return DAS_TRY;
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 296 "ds2_lexer.lpp"
+#line 295 "ds2_lexer.lpp"
 return DAS_CATCH;
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 297 "ds2_lexer.lpp"
+#line 296 "ds2_lexer.lpp"
 return DAS_TYPEDEF;
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 298 "ds2_lexer.lpp"
+#line 297 "ds2_lexer.lpp"
 return DAS_TYPEDECL;
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 299 "ds2_lexer.lpp"
+#line 298 "ds2_lexer.lpp"
 return DAS_LABEL;
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 300 "ds2_lexer.lpp"
+#line 299 "ds2_lexer.lpp"
 return DAS_GOTO;
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 301 "ds2_lexer.lpp"
+#line 300 "ds2_lexer.lpp"
 return DAS_MODULE;
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 302 "ds2_lexer.lpp"
+#line 301 "ds2_lexer.lpp"
 return DAS_PUBLIC;
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 303 "ds2_lexer.lpp"
+#line 302 "ds2_lexer.lpp"
 return DAS_OPTIONS;
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 304 "ds2_lexer.lpp"
+#line 303 "ds2_lexer.lpp"
 return DAS_OPERATOR;
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 305 "ds2_lexer.lpp"
+#line 304 "ds2_lexer.lpp"
 return DAS_REQUIRE;
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 306 "ds2_lexer.lpp"
+#line 305 "ds2_lexer.lpp"
 return DAS_TBLOCK;
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 307 "ds2_lexer.lpp"
+#line 306 "ds2_lexer.lpp"
 return DAS_TFUNCTION;
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 308 "ds2_lexer.lpp"
+#line 307 "ds2_lexer.lpp"
 return DAS_TLAMBDA;
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 309 "ds2_lexer.lpp"
+#line 308 "ds2_lexer.lpp"
 return DAS_GENERATOR;
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 310 "ds2_lexer.lpp"
+#line 309 "ds2_lexer.lpp"
 return DAS_TTUPLE;
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 311 "ds2_lexer.lpp"
+#line 310 "ds2_lexer.lpp"
 return DAS_TVARIANT;
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 312 "ds2_lexer.lpp"
+#line 311 "ds2_lexer.lpp"
 return DAS_CONST;
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 313 "ds2_lexer.lpp"
+#line 312 "ds2_lexer.lpp"
 return DAS_CONTINUE;
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 314 "ds2_lexer.lpp"
+#line 313 "ds2_lexer.lpp"
 return DAS_WHERE;
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 315 "ds2_lexer.lpp"
+#line 314 "ds2_lexer.lpp"
 return DAS_CAST;
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 316 "ds2_lexer.lpp"
+#line 315 "ds2_lexer.lpp"
 return DAS_UPCAST;
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 317 "ds2_lexer.lpp"
+#line 316 "ds2_lexer.lpp"
 return DAS_PASS;
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 318 "ds2_lexer.lpp"
+#line 317 "ds2_lexer.lpp"
 return DAS_REINTERPRET;
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 319 "ds2_lexer.lpp"
+#line 318 "ds2_lexer.lpp"
 return DAS_OVERRIDE;
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 320 "ds2_lexer.lpp"
+#line 319 "ds2_lexer.lpp"
 return DAS_SEALED;
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 321 "ds2_lexer.lpp"
+#line 320 "ds2_lexer.lpp"
 return DAS_TEMPLATE;
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 322 "ds2_lexer.lpp"
+#line 321 "ds2_lexer.lpp"
 return DAS_ABSTRACT;
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 323 "ds2_lexer.lpp"
+#line 322 "ds2_lexer.lpp"
 return DAS_EXPECT;
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 324 "ds2_lexer.lpp"
+#line 323 "ds2_lexer.lpp"
 return DAS_TABLE;
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 325 "ds2_lexer.lpp"
+#line 324 "ds2_lexer.lpp"
 return DAS_ARRAY;
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 326 "ds2_lexer.lpp"
+#line 325 "ds2_lexer.lpp"
 return DAS_FIXED_ARRAY;
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 327 "ds2_lexer.lpp"
+#line 326 "ds2_lexer.lpp"
 return DAS_DEFAULT;
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 328 "ds2_lexer.lpp"
+#line 327 "ds2_lexer.lpp"
 return DAS_ITERATOR;
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 329 "ds2_lexer.lpp"
+#line 328 "ds2_lexer.lpp"
 return DAS_IN;
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 330 "ds2_lexer.lpp"
+#line 329 "ds2_lexer.lpp"
 return DAS_IMPLICIT;
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 331 "ds2_lexer.lpp"
+#line 330 "ds2_lexer.lpp"
 return DAS_EXPLICIT;
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 332 "ds2_lexer.lpp"
+#line 331 "ds2_lexer.lpp"
 return DAS_SHARED;
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 333 "ds2_lexer.lpp"
+#line 332 "ds2_lexer.lpp"
 return DAS_PRIVATE;
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 334 "ds2_lexer.lpp"
+#line 333 "ds2_lexer.lpp"
 return DAS_SMART_PTR;
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 335 "ds2_lexer.lpp"
+#line 334 "ds2_lexer.lpp"
 return DAS_UNSAFE;
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 336 "ds2_lexer.lpp"
+#line 335 "ds2_lexer.lpp"
 return DAS_INSCOPE;
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 337 "ds2_lexer.lpp"
+#line 336 "ds2_lexer.lpp"
 return DAS_STATIC;
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 338 "ds2_lexer.lpp"
+#line 337 "ds2_lexer.lpp"
 return DAS_AS;
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 339 "ds2_lexer.lpp"
+#line 338 "ds2_lexer.lpp"
 return DAS_IS;
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 340 "ds2_lexer.lpp"
+#line 339 "ds2_lexer.lpp"
 return DAS_DEREF;
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 341 "ds2_lexer.lpp"
+#line 340 "ds2_lexer.lpp"
 return DAS_ADDR;
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 342 "ds2_lexer.lpp"
+#line 341 "ds2_lexer.lpp"
 return DAS_NULL;
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 343 "ds2_lexer.lpp"
+#line 342 "ds2_lexer.lpp"
 return DAS_RETURN;
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 344 "ds2_lexer.lpp"
+#line 343 "ds2_lexer.lpp"
 return DAS_YIELD;
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 345 "ds2_lexer.lpp"
+#line 344 "ds2_lexer.lpp"
 return DAS_BREAK;
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 346 "ds2_lexer.lpp"
+#line 345 "ds2_lexer.lpp"
 return DAS_TYPEINFO;
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 347 "ds2_lexer.lpp"
+#line 346 "ds2_lexer.lpp"
 return DAS_TYPE;
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 348 "ds2_lexer.lpp"
+#line 347 "ds2_lexer.lpp"
 return DAS_NEWT;
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 349 "ds2_lexer.lpp"
+#line 348 "ds2_lexer.lpp"
 return DAS_DELETE;
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 350 "ds2_lexer.lpp"
+#line 349 "ds2_lexer.lpp"
 return DAS_TRUE;
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 351 "ds2_lexer.lpp"
+#line 350 "ds2_lexer.lpp"
 return DAS_FALSE;
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 352 "ds2_lexer.lpp"
+#line 351 "ds2_lexer.lpp"
 return DAS_TAUTO;
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 353 "ds2_lexer.lpp"
+#line 352 "ds2_lexer.lpp"
 return DAS_TBOOL;
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 354 "ds2_lexer.lpp"
+#line 353 "ds2_lexer.lpp"
 return DAS_TVOID;
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 355 "ds2_lexer.lpp"
+#line 354 "ds2_lexer.lpp"
 return DAS_TSTRING;
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 356 "ds2_lexer.lpp"
+#line 355 "ds2_lexer.lpp"
 return DAS_TRANGE64;
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 357 "ds2_lexer.lpp"
+#line 356 "ds2_lexer.lpp"
 return DAS_TURANGE64;
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 358 "ds2_lexer.lpp"
+#line 357 "ds2_lexer.lpp"
 return DAS_TRANGE;
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 359 "ds2_lexer.lpp"
+#line 358 "ds2_lexer.lpp"
 return DAS_TURANGE;
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 360 "ds2_lexer.lpp"
+#line 359 "ds2_lexer.lpp"
 return DAS_TINT;
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 361 "ds2_lexer.lpp"
+#line 360 "ds2_lexer.lpp"
 return DAS_TINT8;
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 362 "ds2_lexer.lpp"
+#line 361 "ds2_lexer.lpp"
 return DAS_TINT16;
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 363 "ds2_lexer.lpp"
+#line 362 "ds2_lexer.lpp"
 return DAS_TINT64;
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 364 "ds2_lexer.lpp"
+#line 363 "ds2_lexer.lpp"
 return DAS_TINT2;
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 365 "ds2_lexer.lpp"
+#line 364 "ds2_lexer.lpp"
 return DAS_TINT3;
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 366 "ds2_lexer.lpp"
+#line 365 "ds2_lexer.lpp"
 return DAS_TINT4;
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 367 "ds2_lexer.lpp"
+#line 366 "ds2_lexer.lpp"
 return DAS_TUINT;
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 368 "ds2_lexer.lpp"
+#line 367 "ds2_lexer.lpp"
 return DAS_TBITFIELD;
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 369 "ds2_lexer.lpp"
+#line 368 "ds2_lexer.lpp"
 return DAS_TUINT8;
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 370 "ds2_lexer.lpp"
+#line 369 "ds2_lexer.lpp"
 return DAS_TUINT16;
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 371 "ds2_lexer.lpp"
+#line 370 "ds2_lexer.lpp"
 return DAS_TUINT64;
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 372 "ds2_lexer.lpp"
+#line 371 "ds2_lexer.lpp"
 return DAS_TUINT2;
 	YY_BREAK
 case 127:
 YY_RULE_SETUP
-#line 373 "ds2_lexer.lpp"
+#line 372 "ds2_lexer.lpp"
 return DAS_TUINT3;
 	YY_BREAK
 case 128:
 YY_RULE_SETUP
-#line 374 "ds2_lexer.lpp"
+#line 373 "ds2_lexer.lpp"
 return DAS_TUINT4;
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 375 "ds2_lexer.lpp"
+#line 374 "ds2_lexer.lpp"
 return DAS_TDOUBLE;
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 376 "ds2_lexer.lpp"
+#line 375 "ds2_lexer.lpp"
 return DAS_TFLOAT;
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 377 "ds2_lexer.lpp"
+#line 376 "ds2_lexer.lpp"
 return DAS_TFLOAT2;
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 378 "ds2_lexer.lpp"
+#line 377 "ds2_lexer.lpp"
 return DAS_TFLOAT3;
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 379 "ds2_lexer.lpp"
+#line 378 "ds2_lexer.lpp"
 return DAS_TFLOAT4;
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 380 "ds2_lexer.lpp"
+#line 379 "ds2_lexer.lpp"
 {
     yylval_param->s = new string(yytext);
     #if DAS_TRACK_ALLOC
@@ -2475,7 +2474,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 387 "ds2_lexer.lpp"
+#line 386 "ds2_lexer.lpp"
 {
         BEGIN(strb);
         return BEGIN_STRING;
@@ -2483,127 +2482,127 @@ YY_RULE_SETUP
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 391 "ds2_lexer.lpp"
+#line 390 "ds2_lexer.lpp"
 yylval_param->ui = 8; return UNSIGNED_INT8;
 	YY_BREAK
 case 137:
 YY_RULE_SETUP
-#line 392 "ds2_lexer.lpp"
+#line 391 "ds2_lexer.lpp"
 yylval_param->ui = 9; return UNSIGNED_INT8;
 	YY_BREAK
 case 138:
 YY_RULE_SETUP
-#line 393 "ds2_lexer.lpp"
+#line 392 "ds2_lexer.lpp"
 yylval_param->ui = 10; return UNSIGNED_INT8;
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 394 "ds2_lexer.lpp"
+#line 393 "ds2_lexer.lpp"
 yylval_param->ui = 12; return UNSIGNED_INT8;
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 395 "ds2_lexer.lpp"
+#line 394 "ds2_lexer.lpp"
 yylval_param->ui = 13; return UNSIGNED_INT8;
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 396 "ds2_lexer.lpp"
+#line 395 "ds2_lexer.lpp"
 yylval_param->ui = '\\'; return UNSIGNED_INT8;
 	YY_BREAK
 case 142:
 YY_RULE_SETUP
-#line 397 "ds2_lexer.lpp"
+#line 396 "ds2_lexer.lpp"
 yylval_param->ui = '\''; return UNSIGNED_INT8;
 	YY_BREAK
 case 143:
 YY_RULE_SETUP
-#line 398 "ds2_lexer.lpp"
+#line 397 "ds2_lexer.lpp"
 yylval_param->ui = uint32_t(yytext[1]); return UNSIGNED_INT8;
 	YY_BREAK
 case 144:
 YY_RULE_SETUP
-#line 400 "ds2_lexer.lpp"
+#line 399 "ds2_lexer.lpp"
 yylval_param->ui = 8; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 145:
 YY_RULE_SETUP
-#line 401 "ds2_lexer.lpp"
+#line 400 "ds2_lexer.lpp"
 yylval_param->ui = 9; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 146:
 YY_RULE_SETUP
-#line 402 "ds2_lexer.lpp"
+#line 401 "ds2_lexer.lpp"
 yylval_param->ui = 10; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 147:
 YY_RULE_SETUP
-#line 403 "ds2_lexer.lpp"
+#line 402 "ds2_lexer.lpp"
 yylval_param->ui = 12; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 148:
 YY_RULE_SETUP
-#line 404 "ds2_lexer.lpp"
+#line 403 "ds2_lexer.lpp"
 yylval_param->ui = 13; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 149:
 YY_RULE_SETUP
-#line 405 "ds2_lexer.lpp"
+#line 404 "ds2_lexer.lpp"
 yylval_param->ui = '\\'; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 406 "ds2_lexer.lpp"
+#line 405 "ds2_lexer.lpp"
 yylval_param->ui = '\''; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
-#line 407 "ds2_lexer.lpp"
+#line 406 "ds2_lexer.lpp"
 yylval_param->ui = uint32_t(yytext[1]); return UNSIGNED_INTEGER;
 	YY_BREAK
 case 152:
 YY_RULE_SETUP
-#line 409 "ds2_lexer.lpp"
+#line 408 "ds2_lexer.lpp"
 yylval_param->i = 8; return INTEGER;
 	YY_BREAK
 case 153:
 YY_RULE_SETUP
-#line 410 "ds2_lexer.lpp"
+#line 409 "ds2_lexer.lpp"
 yylval_param->i = 9; return INTEGER;
 	YY_BREAK
 case 154:
 YY_RULE_SETUP
-#line 411 "ds2_lexer.lpp"
+#line 410 "ds2_lexer.lpp"
 yylval_param->i = 10; return INTEGER;
 	YY_BREAK
 case 155:
 YY_RULE_SETUP
-#line 412 "ds2_lexer.lpp"
+#line 411 "ds2_lexer.lpp"
 yylval_param->i = 12; return INTEGER;
 	YY_BREAK
 case 156:
 YY_RULE_SETUP
-#line 413 "ds2_lexer.lpp"
+#line 412 "ds2_lexer.lpp"
 yylval_param->i = 13; return INTEGER;
 	YY_BREAK
 case 157:
 YY_RULE_SETUP
-#line 414 "ds2_lexer.lpp"
+#line 413 "ds2_lexer.lpp"
 yylval_param->i = '\\'; return INTEGER;
 	YY_BREAK
 case 158:
 YY_RULE_SETUP
-#line 415 "ds2_lexer.lpp"
+#line 414 "ds2_lexer.lpp"
 yylval_param->i = '\''; return INTEGER;
 	YY_BREAK
 case 159:
 YY_RULE_SETUP
-#line 417 "ds2_lexer.lpp"
+#line 416 "ds2_lexer.lpp"
 yylval_param->i = int32_t(yytext[1]); return INTEGER;
 	YY_BREAK
 case 160:
 YY_RULE_SETUP
-#line 418 "ds2_lexer.lpp"
+#line 417 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2618,7 +2617,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 161:
 YY_RULE_SETUP
-#line 429 "ds2_lexer.lpp"
+#line 428 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2633,7 +2632,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 162:
 YY_RULE_SETUP
-#line 440 "ds2_lexer.lpp"
+#line 439 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2650,7 +2649,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 163:
 YY_RULE_SETUP
-#line 453 "ds2_lexer.lpp"
+#line 452 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2665,7 +2664,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 164:
 YY_RULE_SETUP
-#line 464 "ds2_lexer.lpp"
+#line 463 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2684,7 +2683,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 165:
 YY_RULE_SETUP
-#line 479 "ds2_lexer.lpp"
+#line 478 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2699,7 +2698,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 166:
 YY_RULE_SETUP
-#line 490 "ds2_lexer.lpp"
+#line 489 "ds2_lexer.lpp"
 {
         char temptext[128];
         skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2714,7 +2713,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 167:
 YY_RULE_SETUP
-#line 501 "ds2_lexer.lpp"
+#line 500 "ds2_lexer.lpp"
 {
         char temptext[128];
         skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2729,7 +2728,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 168:
 YY_RULE_SETUP
-#line 512 "ds2_lexer.lpp"
+#line 511 "ds2_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2756,7 +2755,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 535 "ds2_lexer.lpp"
+#line 534 "ds2_lexer.lpp"
 {
         char temptext[128];
         skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2771,7 +2770,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 170:
 YY_RULE_SETUP
-#line 546 "ds2_lexer.lpp"
+#line 545 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2784,7 +2783,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 171:
 YY_RULE_SETUP
-#line 555 "ds2_lexer.lpp"
+#line 554 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2798,7 +2797,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 172:
 YY_RULE_SETUP
-#line 565 "ds2_lexer.lpp"
+#line 564 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2811,7 +2810,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 574 "ds2_lexer.lpp"
+#line 573 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2824,7 +2823,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 583 "ds2_lexer.lpp"
+#line 582 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2837,7 +2836,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 592 "ds2_lexer.lpp"
+#line 591 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2850,7 +2849,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 601 "ds2_lexer.lpp"
+#line 600 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2863,7 +2862,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 177:
 YY_RULE_SETUP
-#line 610 "ds2_lexer.lpp"
+#line 609 "ds2_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -2876,7 +2875,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 178:
 YY_RULE_SETUP
-#line 619 "ds2_lexer.lpp"
+#line 618 "ds2_lexer.lpp"
 {
     if ( !yyextra->das_nested_parentheses ) {
         das2_yyfatalerror(yylloc_param,yyscanner,"mismatching parentheses", CompilationError::mismatching_parens);
@@ -2888,7 +2887,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 627 "ds2_lexer.lpp"
+#line 626 "ds2_lexer.lpp"
 {
     yyextra->das_nested_parentheses ++;
     return '(';
@@ -2896,7 +2895,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 180:
 YY_RULE_SETUP
-#line 631 "ds2_lexer.lpp"
+#line 630 "ds2_lexer.lpp"
 {
     if ( !yyextra->das_nested_square_braces ) {
         das2_yyfatalerror(yylloc_param,yyscanner,"mismatching square braces", CompilationError::mismatching_parens);
@@ -2908,7 +2907,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 181:
 YY_RULE_SETUP
-#line 639 "ds2_lexer.lpp"
+#line 638 "ds2_lexer.lpp"
 {
     yyextra->das_nested_square_braces ++;
     return '[';
@@ -2916,7 +2915,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 182:
 YY_RULE_SETUP
-#line 643 "ds2_lexer.lpp"
+#line 642 "ds2_lexer.lpp"
 {
     if ( yyextra->das_nested_sb ) {
         yyextra->das_nested_sb --;
@@ -2957,7 +2956,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 183:
 YY_RULE_SETUP
-#line 680 "ds2_lexer.lpp"
+#line 679 "ds2_lexer.lpp"
 {
     if ( yyextra->das_nested_sb ) {
         yyextra->das_nested_sb ++;
@@ -2969,90 +2968,90 @@ YY_RULE_SETUP
 	YY_BREAK
 case 184:
 YY_RULE_SETUP
-#line 688 "ds2_lexer.lpp"
+#line 687 "ds2_lexer.lpp"
 return COLCOL;
 	YY_BREAK
 case 185:
 YY_RULE_SETUP
-#line 689 "ds2_lexer.lpp"
+#line 688 "ds2_lexer.lpp"
 return MTAG_DOTDOTDOT;
 	YY_BREAK
 case 186:
 YY_RULE_SETUP
-#line 690 "ds2_lexer.lpp"
+#line 689 "ds2_lexer.lpp"
 return DOTDOT;
 	YY_BREAK
 case 187:
 YY_RULE_SETUP
-#line 691 "ds2_lexer.lpp"
+#line 690 "ds2_lexer.lpp"
 return RPIPE;
 	YY_BREAK
 case 188:
 YY_RULE_SETUP
-#line 692 "ds2_lexer.lpp"
+#line 691 "ds2_lexer.lpp"
 return LPIPE;
 	YY_BREAK
 case 189:
 YY_RULE_SETUP
-#line 693 "ds2_lexer.lpp"
+#line 692 "ds2_lexer.lpp"
 return MTAG_E;
 	YY_BREAK
 case 190:
 /* rule 190 can match eol */
 YY_RULE_SETUP
-#line 694 "ds2_lexer.lpp"
+#line 693 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_E;
 	YY_BREAK
 case 191:
 /* rule 191 can match eol */
 YY_RULE_SETUP
-#line 695 "ds2_lexer.lpp"
+#line 694 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_I;
 	YY_BREAK
 case 192:
 /* rule 192 can match eol */
 YY_RULE_SETUP
-#line 696 "ds2_lexer.lpp"
+#line 695 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_V;
 	YY_BREAK
 case 193:
 /* rule 193 can match eol */
 YY_RULE_SETUP
-#line 697 "ds2_lexer.lpp"
+#line 696 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_B;
 	YY_BREAK
 case 194:
 /* rule 194 can match eol */
 YY_RULE_SETUP
-#line 698 "ds2_lexer.lpp"
+#line 697 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_A;
 	YY_BREAK
 case 195:
 /* rule 195 can match eol */
 YY_RULE_SETUP
-#line 699 "ds2_lexer.lpp"
+#line 698 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_T;
 	YY_BREAK
 case 196:
 /* rule 196 can match eol */
 YY_RULE_SETUP
-#line 700 "ds2_lexer.lpp"
+#line 699 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_C;
 	YY_BREAK
 case 197:
 /* rule 197 can match eol */
 YY_RULE_SETUP
-#line 701 "ds2_lexer.lpp"
+#line 700 "ds2_lexer.lpp"
 unput(yytext[yyleng-1]); return MTAG_F;
 	YY_BREAK
 case 198:
 YY_RULE_SETUP
-#line 702 "ds2_lexer.lpp"
+#line 701 "ds2_lexer.lpp"
 return QQ;
 	YY_BREAK
 case 199:
 YY_RULE_SETUP
-#line 703 "ds2_lexer.lpp"
+#line 702 "ds2_lexer.lpp"
 {
     yyextra->das_nested_square_braces ++;
     return QBRA;
@@ -3060,48 +3059,48 @@ YY_RULE_SETUP
 	YY_BREAK
 case 200:
 YY_RULE_SETUP
-#line 707 "ds2_lexer.lpp"
+#line 706 "ds2_lexer.lpp"
 return QDOT;
 	YY_BREAK
 case 201:
 YY_RULE_SETUP
-#line 708 "ds2_lexer.lpp"
+#line 707 "ds2_lexer.lpp"
 return CLONEEQU;
 	YY_BREAK
 case 202:
 YY_RULE_SETUP
-#line 709 "ds2_lexer.lpp"
+#line 708 "ds2_lexer.lpp"
 return RARROW;
 	YY_BREAK
 case 203:
 YY_RULE_SETUP
-#line 710 "ds2_lexer.lpp"
+#line 709 "ds2_lexer.lpp"
 return LARROW;
 	YY_BREAK
 case 204:
 YY_RULE_SETUP
-#line 711 "ds2_lexer.lpp"
+#line 710 "ds2_lexer.lpp"
 return ADDEQU;
 	YY_BREAK
 case 205:
 YY_RULE_SETUP
-#line 712 "ds2_lexer.lpp"
+#line 711 "ds2_lexer.lpp"
 return SUBEQU;
 	YY_BREAK
 case 206:
 YY_RULE_SETUP
-#line 713 "ds2_lexer.lpp"
+#line 712 "ds2_lexer.lpp"
 return DIVEQU;
 	YY_BREAK
 case 207:
 YY_RULE_SETUP
-#line 714 "ds2_lexer.lpp"
+#line 713 "ds2_lexer.lpp"
 return MULEQU;
 	YY_BREAK
 case 208:
 /* rule 208 can match eol */
 YY_RULE_SETUP
-#line 715 "ds2_lexer.lpp"
+#line 714 "ds2_lexer.lpp"
 {
     // inline (expression-level) reader macro:  %name! <body> %%
     // The whole construct is captured here (body = up to the first %%); the body is handed to the
@@ -3153,87 +3152,87 @@ YY_RULE_SETUP
 	YY_BREAK
 case 209:
 YY_RULE_SETUP
-#line 763 "ds2_lexer.lpp"
+#line 762 "ds2_lexer.lpp"
 return MODEQU;
 	YY_BREAK
 case 210:
 YY_RULE_SETUP
-#line 764 "ds2_lexer.lpp"
+#line 763 "ds2_lexer.lpp"
 return ANDANDEQU;
 	YY_BREAK
 case 211:
 YY_RULE_SETUP
-#line 765 "ds2_lexer.lpp"
+#line 764 "ds2_lexer.lpp"
 return OROREQU;
 	YY_BREAK
 case 212:
 YY_RULE_SETUP
-#line 766 "ds2_lexer.lpp"
+#line 765 "ds2_lexer.lpp"
 return XORXOREQU;
 	YY_BREAK
 case 213:
 YY_RULE_SETUP
-#line 767 "ds2_lexer.lpp"
+#line 766 "ds2_lexer.lpp"
 return ANDAND;
 	YY_BREAK
 case 214:
 YY_RULE_SETUP
-#line 768 "ds2_lexer.lpp"
+#line 767 "ds2_lexer.lpp"
 return OROR;
 	YY_BREAK
 case 215:
 YY_RULE_SETUP
-#line 769 "ds2_lexer.lpp"
+#line 768 "ds2_lexer.lpp"
 return XORXOR;
 	YY_BREAK
 case 216:
 YY_RULE_SETUP
-#line 770 "ds2_lexer.lpp"
+#line 769 "ds2_lexer.lpp"
 return ANDEQU;
 	YY_BREAK
 case 217:
 YY_RULE_SETUP
-#line 771 "ds2_lexer.lpp"
+#line 770 "ds2_lexer.lpp"
 return OREQU;
 	YY_BREAK
 case 218:
 YY_RULE_SETUP
-#line 772 "ds2_lexer.lpp"
+#line 771 "ds2_lexer.lpp"
 return XOREQU;
 	YY_BREAK
 case 219:
 YY_RULE_SETUP
-#line 773 "ds2_lexer.lpp"
+#line 772 "ds2_lexer.lpp"
 return ADDADD;
 	YY_BREAK
 case 220:
 YY_RULE_SETUP
-#line 774 "ds2_lexer.lpp"
+#line 773 "ds2_lexer.lpp"
 return SUBSUB;
 	YY_BREAK
 case 221:
 YY_RULE_SETUP
-#line 775 "ds2_lexer.lpp"
+#line 774 "ds2_lexer.lpp"
 return LEEQU;
 	YY_BREAK
 case 222:
 YY_RULE_SETUP
-#line 776 "ds2_lexer.lpp"
+#line 775 "ds2_lexer.lpp"
 return GREQU;
 	YY_BREAK
 case 223:
 YY_RULE_SETUP
-#line 777 "ds2_lexer.lpp"
+#line 776 "ds2_lexer.lpp"
 return EQUEQU;
 	YY_BREAK
 case 224:
 YY_RULE_SETUP
-#line 778 "ds2_lexer.lpp"
+#line 777 "ds2_lexer.lpp"
 return NOTEQU;
 	YY_BREAK
 case 225:
 YY_RULE_SETUP
-#line 779 "ds2_lexer.lpp"
+#line 778 "ds2_lexer.lpp"
 {
     if ( yyextra->das_arrow_depth ) {
         unput('>');
@@ -3247,7 +3246,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 226:
 YY_RULE_SETUP
-#line 789 "ds2_lexer.lpp"
+#line 788 "ds2_lexer.lpp"
 {
     if ( yyextra->das_arrow_depth ) {
         unput('>');
@@ -3260,48 +3259,48 @@ YY_RULE_SETUP
 	YY_BREAK
 case 227:
 YY_RULE_SETUP
-#line 798 "ds2_lexer.lpp"
+#line 797 "ds2_lexer.lpp"
 return ROTL;
 	YY_BREAK
 case 228:
 YY_RULE_SETUP
-#line 799 "ds2_lexer.lpp"
+#line 798 "ds2_lexer.lpp"
 return SHL;
 	YY_BREAK
 case 229:
 YY_RULE_SETUP
-#line 800 "ds2_lexer.lpp"
+#line 799 "ds2_lexer.lpp"
 return SHREQU;
 	YY_BREAK
 case 230:
 YY_RULE_SETUP
-#line 801 "ds2_lexer.lpp"
+#line 800 "ds2_lexer.lpp"
 return SHLEQU;
 	YY_BREAK
 case 231:
 YY_RULE_SETUP
-#line 802 "ds2_lexer.lpp"
+#line 801 "ds2_lexer.lpp"
 return ROTREQU;
 	YY_BREAK
 case 232:
 YY_RULE_SETUP
-#line 803 "ds2_lexer.lpp"
+#line 802 "ds2_lexer.lpp"
 return ROTLEQU;
 	YY_BREAK
 case 233:
 YY_RULE_SETUP
-#line 804 "ds2_lexer.lpp"
+#line 803 "ds2_lexer.lpp"
 return MAPTO;
 	YY_BREAK
 case 234:
 YY_RULE_SETUP
-#line 805 "ds2_lexer.lpp"
+#line 804 "ds2_lexer.lpp"
 /* skip white space */
 	YY_BREAK
 case 235:
 /* rule 235 can match eol */
 YY_RULE_SETUP
-#line 807 "ds2_lexer.lpp"
+#line 806 "ds2_lexer.lpp"
 {
     YYCOLUMN(yyextra->das_yycolumn = 0, "NEW LINE (with line break)");
 }
@@ -3309,7 +3308,7 @@ YY_RULE_SETUP
 case 236:
 /* rule 236 can match eol */
 YY_RULE_SETUP
-#line 810 "ds2_lexer.lpp"
+#line 809 "ds2_lexer.lpp"
 {
     YYCOLUMN(yyextra->das_yycolumn = 0, "NEW LINE (with tail end)");
     das_accept_cpp_comment(yyextra->g_CommentReaders, yyscanner, *yylloc_param, yytext);
@@ -3331,7 +3330,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(normal):
-#line 829 "ds2_lexer.lpp"
+#line 828 "ds2_lexer.lpp"
 {
     if ( yyextra->g_FileAccessStack.size()==1 ) {
         if ( !yyextra->das_keyword
@@ -3359,7 +3358,7 @@ case YY_STATE_EOF(normal):
 }
 	YY_BREAK
 case YY_STATE_EOF(eof_done):
-#line 854 "ds2_lexer.lpp"
+#line 853 "ds2_lexer.lpp"
 { YYCOLUMN(yyextra->das_yycolumn = 0,"EOF"); return 0; }
 	YY_BREAK
 /* '@@' (function pointer / local function) and '@name' (field annotation) are
@@ -3370,7 +3369,7 @@ case YY_STATE_EOF(eof_done):
        (the capture-clause keyword), so it must stay a lambda '@', not AT_FIELD. */
 case 237:
 YY_RULE_SETUP
-#line 861 "ds2_lexer.lpp"
+#line 860 "ds2_lexer.lpp"
 return DOUBLE_AT;
 	YY_BREAK
 case 238:
@@ -3380,7 +3379,7 @@ YY_LINENO_REWIND_TO(yy_bp + 1);
 yyg->yy_c_buf_p = yy_cp = yy_bp + 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 862 "ds2_lexer.lpp"
+#line 861 "ds2_lexer.lpp"
 return *yytext;
 	YY_BREAK
 case 239:
@@ -3388,20 +3387,20 @@ case 239:
 yyg->yy_c_buf_p = yy_cp = yy_bp + 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 863 "ds2_lexer.lpp"
+#line 862 "ds2_lexer.lpp"
 return AT_FIELD;
 	YY_BREAK
 case 240:
 YY_RULE_SETUP
-#line 864 "ds2_lexer.lpp"
+#line 863 "ds2_lexer.lpp"
 return *yytext;
 	YY_BREAK
 case 241:
 YY_RULE_SETUP
-#line 866 "ds2_lexer.lpp"
+#line 865 "ds2_lexer.lpp"
 ECHO;
 	YY_BREAK
-#line 3404 "ds2_lexer.cpp"
+#line 3403 "ds2_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(include):
 	yyterminate();
@@ -4595,7 +4594,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 866 "ds2_lexer.lpp"
+#line 865 "ds2_lexer.lpp"
 
 
 void das2_strfmt ( yyscan_t yyscanner ) {

--- a/src/parser/ds2_lexer.lpp
+++ b/src/parser/ds2_lexer.lpp
@@ -79,11 +79,10 @@ void das_accept_cpp_comment ( vector<CommentReader *> & crdi, yyscan_t scanner, 
 %%
 
 <normal>\#[0-9]+,[0-9]+,\"[^\"]+\"\# {
-    string txt = yytext;
     int lRow, lCol;
-    char lFile[256];
-    if ( sscanf ( yytext, "#%i,%i,\"%255s\"#", &lRow, &lCol, lFile )==3 ) {
-        lFile[strlen(lFile)-2] = 0;
+    if ( sscanf ( yytext, "#%i,%i,", &lRow, &lCol )==2 ) {
+        // file name is the quote-bounded span; sscanf %s would stop at whitespace inside it
+        string lFile ( strchr(yytext,'\"')+1, yytext+yyleng-2 );
         auto cfi = yyextra->g_FileAccessStack.back();
         string incFileName = yyextra->g_Access->getIncludeFileName(cfi->name,lFile);
         auto info = yyextra->g_Access->getFileInfo(incFileName);

--- a/src/parser/ds_lexer.cpp
+++ b/src/parser/ds_lexer.cpp
@@ -1687,11 +1687,10 @@ case 1:
 YY_RULE_SETUP
 #line 79 "ds_lexer.lpp"
 {
-    string txt = yytext;
     int lRow, lCol;
-    char lFile[256];
-    if ( sscanf ( yytext, "#%i,%i,\"%255s\"#", &lRow, &lCol, lFile )==3 ) {
-        lFile[strlen(lFile)-2] = 0;
+    if ( sscanf ( yytext, "#%i,%i,", &lRow, &lCol )==2 ) {
+        // file name is the quote-bounded span; sscanf %s would stop at whitespace inside it
+        string lFile ( strchr(yytext,'\"')+1, yytext+yyleng-2 );
         auto cfi = yyextra->g_FileAccessStack.back();
         string incFileName = yyextra->g_Access->getIncludeFileName(cfi->name,lFile);
         auto info = yyextra->g_Access->getFileInfo(incFileName);
@@ -1711,12 +1710,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 101 "ds_lexer.lpp"
+#line 100 "ds_lexer.lpp"
 das_yyfatalerror(yylloc_param,yyscanner,"Unexpected */", CompilationError::invalid_line); return LEXER_ERROR;
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 102 "ds_lexer.lpp"
+#line 101 "ds_lexer.lpp"
 {
     BEGIN(c_comment);
     yyextra->das_c_style_depth = 1;
@@ -1729,12 +1728,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 111 "ds_lexer.lpp"
+#line 110 "ds_lexer.lpp"
 das_yyfatalerror(yylloc_param,yyscanner,"Unexpected */", CompilationError::invalid_line); return LEXER_ERROR;
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 112 "ds_lexer.lpp"
+#line 111 "ds_lexer.lpp"
 {
     BEGIN(c_comment);
     yyextra->das_c_style_depth = 1;
@@ -1747,7 +1746,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 121 "ds_lexer.lpp"
+#line 120 "ds_lexer.lpp"
 {
     BEGIN(cpp_comment);
     if ( !yyextra->g_CommentReaders.empty() ) {
@@ -1758,7 +1757,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 128 "ds_lexer.lpp"
+#line 127 "ds_lexer.lpp"
 {
     yyextra->last_token_end = tokAt(yyscanner,*yylloc_param);
     BEGIN(cpp_comment);
@@ -1771,7 +1770,7 @@ YY_RULE_SETUP
 case 8:
 /* rule 8 can match eol */
 YY_RULE_SETUP
-#line 136 "ds_lexer.lpp"
+#line 135 "ds_lexer.lpp"
 {
     BEGIN(normal);
     unput('\n');
@@ -1782,12 +1781,12 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(cpp_comment):
-#line 144 "ds_lexer.lpp"
+#line 143 "ds_lexer.lpp"
 BEGIN(normal);
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 145 "ds_lexer.lpp"
+#line 144 "ds_lexer.lpp"
 {
     if ( !yyextra->g_CommentReaders.empty() ) {
         auto tak = tokAt(yyscanner,*yylloc_param);
@@ -1797,14 +1796,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 151 "ds_lexer.lpp"
+#line 150 "ds_lexer.lpp"
 {
     yyextra->das_c_style_depth ++;
 }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 154 "ds_lexer.lpp"
+#line 153 "ds_lexer.lpp"
 {
     yyextra->das_c_style_depth --;
     if ( yyextra->das_c_style_depth==0 ) {
@@ -1822,7 +1821,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 168 "ds_lexer.lpp"
+#line 167 "ds_lexer.lpp"
 {                      /* skipping comment body */
     if ( !yyextra->g_CommentReaders.empty() ) {
         auto tak = tokAt(yyscanner,*yylloc_param);
@@ -1833,7 +1832,7 @@ YY_RULE_SETUP
 case 13:
 /* rule 13 can match eol */
 YY_RULE_SETUP
-#line 174 "ds_lexer.lpp"
+#line 173 "ds_lexer.lpp"
 {                 /* skipping comment eol */
     YYNEWLINE(yyscanner);
     if ( !yyextra->g_CommentReaders.empty() ) {
@@ -1843,14 +1842,14 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(c_comment):
-#line 181 "ds_lexer.lpp"
+#line 180 "ds_lexer.lpp"
 {
     das_yyfatalerror(yylloc_param,yyscanner,"end of file encountered inside c-style comment", CompilationError::exceeds_file);
     BEGIN(normal);
 }
 	YY_BREAK
 case YY_STATE_EOF(reader):
-#line 185 "ds_lexer.lpp"
+#line 184 "ds_lexer.lpp"
 {
     das_yyfatalerror(yylloc_param,yyscanner,"reader constant exceeds file", CompilationError::exceeds_file);
     BEGIN(normal);
@@ -1860,7 +1859,7 @@ case YY_STATE_EOF(reader):
 case 14:
 /* rule 14 can match eol */
 YY_RULE_SETUP
-#line 190 "ds_lexer.lpp"
+#line 189 "ds_lexer.lpp"
 {
     YYNEWLINE(yyscanner);
     yylval_param->ch = yytext[0];
@@ -1869,7 +1868,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 195 "ds_lexer.lpp"
+#line 194 "ds_lexer.lpp"
 {
     yylval_param->ch = yytext[0];
     return STRING_CHARACTER;
@@ -1877,7 +1876,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 199 "ds_lexer.lpp"
+#line 198 "ds_lexer.lpp"
 {
     // assert(nested_sb==0);
     BEGIN(normal);
@@ -1886,7 +1885,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 204 "ds_lexer.lpp"
+#line 203 "ds_lexer.lpp"
 {
     if ( yyextra->das_nested_sb ) {
         das_yyfatalerror(yylloc_param,yyscanner,"nested string constants are not allowed", CompilationError::invalid_string);
@@ -1899,7 +1898,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(strb):
-#line 214 "ds_lexer.lpp"
+#line 213 "ds_lexer.lpp"
 {
     das_yyfatalerror(yylloc_param,yyscanner,"string constant exceeds file", CompilationError::exceeds_file);
     BEGIN(normal);
@@ -1908,14 +1907,14 @@ case YY_STATE_EOF(strb):
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 219 "ds_lexer.lpp"
+#line 218 "ds_lexer.lpp"
 {
     return STRING_CHARACTER_ESC;
 }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 222 "ds_lexer.lpp"
+#line 221 "ds_lexer.lpp"
 {
     yylval_param->ch = yytext[1];
     return STRING_CHARACTER;
@@ -1923,13 +1922,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 226 "ds_lexer.lpp"
+#line 225 "ds_lexer.lpp"
 /* do exactly nothing */
 	YY_BREAK
 case 21:
 /* rule 21 can match eol */
 YY_RULE_SETUP
-#line 227 "ds_lexer.lpp"
+#line 226 "ds_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     YYNEWLINE(yyscanner);
@@ -1938,7 +1937,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 232 "ds_lexer.lpp"
+#line 231 "ds_lexer.lpp"
 {
     YYTAB();
     yylval_param->ch = *yytext;
@@ -1947,14 +1946,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 237 "ds_lexer.lpp"
+#line 236 "ds_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
 }
 	YY_BREAK
 case YY_STATE_EOF(strfmt):
-#line 241 "ds_lexer.lpp"
+#line 240 "ds_lexer.lpp"
 {
     das_yyfatalerror(yylloc_param,yyscanner,"string format exceeds file", CompilationError::exceeds_file);
     BEGIN(normal);
@@ -1964,7 +1963,7 @@ case YY_STATE_EOF(strfmt):
 case 24:
 /* rule 24 can match eol */
 YY_RULE_SETUP
-#line 246 "ds_lexer.lpp"
+#line 245 "ds_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     YYNEWLINE(yyscanner);
@@ -1973,7 +1972,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 251 "ds_lexer.lpp"
+#line 250 "ds_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
@@ -1981,7 +1980,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 255 "ds_lexer.lpp"
+#line 254 "ds_lexer.lpp"
 {
     BEGIN(normal);
     unput('}');
@@ -1989,7 +1988,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 259 "ds_lexer.lpp"
+#line 258 "ds_lexer.lpp"
 {
     yylval_param->ch = *yytext;
     return STRING_CHARACTER;
@@ -1998,7 +1997,7 @@ YY_RULE_SETUP
 case 28:
 /* rule 28 can match eol */
 YY_RULE_SETUP
-#line 263 "ds_lexer.lpp"
+#line 262 "ds_lexer.lpp"
 /* skip empty line */ {
     yyextra->das_current_line_indent = 0;
     YYNEWLINE(yyscanner);
@@ -2006,7 +2005,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 267 "ds_lexer.lpp"
+#line 266 "ds_lexer.lpp"
 {
     yyextra->das_current_line_indent++;
     #ifdef FLEX_DEBUG
@@ -2016,7 +2015,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 273 "ds_lexer.lpp"
+#line 272 "ds_lexer.lpp"
 {
     yyextra->das_current_line_indent = (yyextra->das_current_line_indent + yyextra->das_tab_size) & ~(yyextra->das_tab_size-1);
     #ifdef FLEX_DEBUG
@@ -2028,7 +2027,7 @@ YY_RULE_SETUP
 case 31:
 /* rule 31 can match eol */
 YY_RULE_SETUP
-#line 280 "ds_lexer.lpp"
+#line 279 "ds_lexer.lpp"
 {
     yyextra->das_current_line_indent = 0;
     yyextra->das_need_oxford_comma = true;
@@ -2041,7 +2040,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 289 "ds_lexer.lpp"
+#line 288 "ds_lexer.lpp"
 {
     unput(*yytext);
     YYCOLUMN(yyextra->das_yycolumn--, "UNPUT");
@@ -2089,7 +2088,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(indent):
-#line 334 "ds_lexer.lpp"
+#line 333 "ds_lexer.lpp"
 {
     if ( yyextra->g_FileAccessStack.size()==1 ) {
         if ( yyextra->das_indent_level ) {
@@ -2114,19 +2113,19 @@ case YY_STATE_EOF(indent):
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 356 "ds_lexer.lpp"
+#line 355 "ds_lexer.lpp"
 /* eat the whitespace */
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 357 "ds_lexer.lpp"
+#line 356 "ds_lexer.lpp"
 {
     YYTAB();
 }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 360 "ds_lexer.lpp"
+#line 359 "ds_lexer.lpp"
 { /* got the include file name */
     auto cfi = yyextra->g_FileAccessStack.back();
     string incFileName = yyextra->g_Access->getIncludeFileName(cfi->name,yytext);
@@ -2152,78 +2151,78 @@ YY_RULE_SETUP
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 383 "ds_lexer.lpp"
+#line 382 "ds_lexer.lpp"
 BEGIN(include);
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 384 "ds_lexer.lpp"
+#line 383 "ds_lexer.lpp"
 return DAS_CAPTURE;
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 385 "ds_lexer.lpp"
+#line 384 "ds_lexer.lpp"
 /* yyextra->das_need_oxford_comma = false; */ return DAS_FOR;
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 386 "ds_lexer.lpp"
+#line 385 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_WHILE;
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 387 "ds_lexer.lpp"
+#line 386 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_IF;
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 388 "ds_lexer.lpp"
+#line 387 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_STATIC_IF;
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 389 "ds_lexer.lpp"
+#line 388 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_ELIF;
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 390 "ds_lexer.lpp"
+#line 389 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_STATIC_ELIF;
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 391 "ds_lexer.lpp"
+#line 390 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_ELSE;
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 392 "ds_lexer.lpp"
+#line 391 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_FINALLY;
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 393 "ds_lexer.lpp"
+#line 392 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_DEF;
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 394 "ds_lexer.lpp"
+#line 393 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_WITH;
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 395 "ds_lexer.lpp"
+#line 394 "ds_lexer.lpp"
 return DAS_AKA;
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 396 "ds_lexer.lpp"
+#line 395 "ds_lexer.lpp"
 return DAS_ASSUME;
 	YY_BREAK
 case 50:
 /* rule 50 can match eol */
 YY_RULE_SETUP
-#line 397 "ds_lexer.lpp"
+#line 396 "ds_lexer.lpp"
 {
     yyextra->das_need_oxford_comma = false;
     unput('\n');
@@ -2233,13 +2232,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 403 "ds_lexer.lpp"
+#line 402 "ds_lexer.lpp"
 return DAS_LET;
 	YY_BREAK
 case 52:
 /* rule 52 can match eol */
 YY_RULE_SETUP
-#line 404 "ds_lexer.lpp"
+#line 403 "ds_lexer.lpp"
 {
     yyextra->das_need_oxford_comma = false;
     unput('\n');
@@ -2249,232 +2248,232 @@ YY_RULE_SETUP
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 410 "ds_lexer.lpp"
+#line 409 "ds_lexer.lpp"
 return DAS_VAR;
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 411 "ds_lexer.lpp"
+#line 410 "ds_lexer.lpp"
 return DAS_UNINITIALIZED;
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 412 "ds_lexer.lpp"
+#line 411 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_STRUCT;
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 413 "ds_lexer.lpp"
+#line 412 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_CLASS;
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 414 "ds_lexer.lpp"
+#line 413 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_ENUM;
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 415 "ds_lexer.lpp"
+#line 414 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_TRY;
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 416 "ds_lexer.lpp"
+#line 415 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_CATCH;
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 417 "ds_lexer.lpp"
+#line 416 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_TYPEDEF;
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 418 "ds_lexer.lpp"
+#line 417 "ds_lexer.lpp"
 return DAS_TYPEDECL;
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 419 "ds_lexer.lpp"
+#line 418 "ds_lexer.lpp"
 return DAS_LABEL;
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 420 "ds_lexer.lpp"
+#line 419 "ds_lexer.lpp"
 return DAS_GOTO;
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 421 "ds_lexer.lpp"
+#line 420 "ds_lexer.lpp"
 return DAS_MODULE;
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 422 "ds_lexer.lpp"
+#line 421 "ds_lexer.lpp"
 return DAS_PUBLIC;
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 423 "ds_lexer.lpp"
+#line 422 "ds_lexer.lpp"
 return DAS_OPTIONS;
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 424 "ds_lexer.lpp"
+#line 423 "ds_lexer.lpp"
 return DAS_OPERATOR;
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 425 "ds_lexer.lpp"
+#line 424 "ds_lexer.lpp"
 return DAS_REQUIRE;
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 426 "ds_lexer.lpp"
+#line 425 "ds_lexer.lpp"
 return DAS_TBLOCK;
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 427 "ds_lexer.lpp"
+#line 426 "ds_lexer.lpp"
 return DAS_TFUNCTION;
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 428 "ds_lexer.lpp"
+#line 427 "ds_lexer.lpp"
 return DAS_TLAMBDA;
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 429 "ds_lexer.lpp"
+#line 428 "ds_lexer.lpp"
 return DAS_GENERATOR;
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 430 "ds_lexer.lpp"
+#line 429 "ds_lexer.lpp"
 return DAS_TTUPLE;
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 431 "ds_lexer.lpp"
+#line 430 "ds_lexer.lpp"
 return DAS_TVARIANT;
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 432 "ds_lexer.lpp"
+#line 431 "ds_lexer.lpp"
 return DAS_CONST;
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 433 "ds_lexer.lpp"
+#line 432 "ds_lexer.lpp"
 return DAS_CONTINUE;
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 434 "ds_lexer.lpp"
+#line 433 "ds_lexer.lpp"
 return DAS_WHERE;
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 435 "ds_lexer.lpp"
+#line 434 "ds_lexer.lpp"
 return DAS_CAST;
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 436 "ds_lexer.lpp"
+#line 435 "ds_lexer.lpp"
 return DAS_UPCAST;
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 437 "ds_lexer.lpp"
+#line 436 "ds_lexer.lpp"
 return DAS_PASS;
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 438 "ds_lexer.lpp"
+#line 437 "ds_lexer.lpp"
 return DAS_REINTERPRET;
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 439 "ds_lexer.lpp"
+#line 438 "ds_lexer.lpp"
 return DAS_OVERRIDE;
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 440 "ds_lexer.lpp"
+#line 439 "ds_lexer.lpp"
 return DAS_SEALED;
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 441 "ds_lexer.lpp"
+#line 440 "ds_lexer.lpp"
 return DAS_TEMPLATE;
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 442 "ds_lexer.lpp"
+#line 441 "ds_lexer.lpp"
 return DAS_ABSTRACT;
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 443 "ds_lexer.lpp"
+#line 442 "ds_lexer.lpp"
 return DAS_EXPECT;
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 444 "ds_lexer.lpp"
+#line 443 "ds_lexer.lpp"
 return DAS_TABLE;
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 445 "ds_lexer.lpp"
+#line 444 "ds_lexer.lpp"
 return DAS_ARRAY;
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 446 "ds_lexer.lpp"
+#line 445 "ds_lexer.lpp"
 return DAS_FIXED_ARRAY;
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 447 "ds_lexer.lpp"
+#line 446 "ds_lexer.lpp"
 return DAS_DEFAULT;
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 448 "ds_lexer.lpp"
+#line 447 "ds_lexer.lpp"
 return DAS_ITERATOR;
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 449 "ds_lexer.lpp"
+#line 448 "ds_lexer.lpp"
 return DAS_IN;
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 450 "ds_lexer.lpp"
+#line 449 "ds_lexer.lpp"
 return DAS_IMPLICIT;
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 451 "ds_lexer.lpp"
+#line 450 "ds_lexer.lpp"
 return DAS_EXPLICIT;
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 452 "ds_lexer.lpp"
+#line 451 "ds_lexer.lpp"
 return DAS_SHARED;
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 453 "ds_lexer.lpp"
+#line 452 "ds_lexer.lpp"
 return DAS_PRIVATE;
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 454 "ds_lexer.lpp"
+#line 453 "ds_lexer.lpp"
 return DAS_SMART_PTR;
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 455 "ds_lexer.lpp"
+#line 454 "ds_lexer.lpp"
 {
     unput('(');
     YYCOLUMN(yyextra->das_yycolumn--, "UNPUT (");
@@ -2483,232 +2482,232 @@ YY_RULE_SETUP
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 460 "ds_lexer.lpp"
+#line 459 "ds_lexer.lpp"
 yyextra->das_need_oxford_comma = false; return DAS_UNSAFE;
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 461 "ds_lexer.lpp"
+#line 460 "ds_lexer.lpp"
 return DAS_INSCOPE;
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 462 "ds_lexer.lpp"
+#line 461 "ds_lexer.lpp"
 return DAS_STATIC;
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 463 "ds_lexer.lpp"
+#line 462 "ds_lexer.lpp"
 return DAS_AS;
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 464 "ds_lexer.lpp"
+#line 463 "ds_lexer.lpp"
 return DAS_IS;
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 465 "ds_lexer.lpp"
+#line 464 "ds_lexer.lpp"
 return DAS_DEREF;
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 466 "ds_lexer.lpp"
+#line 465 "ds_lexer.lpp"
 return DAS_ADDR;
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 467 "ds_lexer.lpp"
+#line 466 "ds_lexer.lpp"
 return DAS_NULL;
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 468 "ds_lexer.lpp"
+#line 467 "ds_lexer.lpp"
 return DAS_RETURN;
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 469 "ds_lexer.lpp"
+#line 468 "ds_lexer.lpp"
 return DAS_YIELD;
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 470 "ds_lexer.lpp"
+#line 469 "ds_lexer.lpp"
 return DAS_BREAK;
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 471 "ds_lexer.lpp"
+#line 470 "ds_lexer.lpp"
 return DAS_TYPEINFO;
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 472 "ds_lexer.lpp"
+#line 471 "ds_lexer.lpp"
 return DAS_TYPE;
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 473 "ds_lexer.lpp"
+#line 472 "ds_lexer.lpp"
 return DAS_NEWT;
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 474 "ds_lexer.lpp"
+#line 473 "ds_lexer.lpp"
 return DAS_DELETE;
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 475 "ds_lexer.lpp"
+#line 474 "ds_lexer.lpp"
 return DAS_TRUE;
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 476 "ds_lexer.lpp"
+#line 475 "ds_lexer.lpp"
 return DAS_FALSE;
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 477 "ds_lexer.lpp"
+#line 476 "ds_lexer.lpp"
 return DAS_TAUTO;
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 478 "ds_lexer.lpp"
+#line 477 "ds_lexer.lpp"
 return DAS_TBOOL;
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 479 "ds_lexer.lpp"
+#line 478 "ds_lexer.lpp"
 return DAS_TVOID;
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 480 "ds_lexer.lpp"
+#line 479 "ds_lexer.lpp"
 return DAS_TSTRING;
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 481 "ds_lexer.lpp"
+#line 480 "ds_lexer.lpp"
 return DAS_TRANGE64;
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 482 "ds_lexer.lpp"
+#line 481 "ds_lexer.lpp"
 return DAS_TURANGE64;
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 483 "ds_lexer.lpp"
+#line 482 "ds_lexer.lpp"
 return DAS_TRANGE;
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 484 "ds_lexer.lpp"
+#line 483 "ds_lexer.lpp"
 return DAS_TURANGE;
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 485 "ds_lexer.lpp"
+#line 484 "ds_lexer.lpp"
 return DAS_TINT;
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 486 "ds_lexer.lpp"
+#line 485 "ds_lexer.lpp"
 return DAS_TINT8;
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 487 "ds_lexer.lpp"
+#line 486 "ds_lexer.lpp"
 return DAS_TINT16;
 	YY_BREAK
 case 127:
 YY_RULE_SETUP
-#line 488 "ds_lexer.lpp"
+#line 487 "ds_lexer.lpp"
 return DAS_TINT64;
 	YY_BREAK
 case 128:
 YY_RULE_SETUP
-#line 489 "ds_lexer.lpp"
+#line 488 "ds_lexer.lpp"
 return DAS_TINT2;
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 490 "ds_lexer.lpp"
+#line 489 "ds_lexer.lpp"
 return DAS_TINT3;
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 491 "ds_lexer.lpp"
+#line 490 "ds_lexer.lpp"
 return DAS_TINT4;
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 492 "ds_lexer.lpp"
+#line 491 "ds_lexer.lpp"
 return DAS_TUINT;
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 493 "ds_lexer.lpp"
+#line 492 "ds_lexer.lpp"
 return DAS_TBITFIELD;
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 494 "ds_lexer.lpp"
+#line 493 "ds_lexer.lpp"
 return DAS_TUINT8;
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 495 "ds_lexer.lpp"
+#line 494 "ds_lexer.lpp"
 return DAS_TUINT16;
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 496 "ds_lexer.lpp"
+#line 495 "ds_lexer.lpp"
 return DAS_TUINT64;
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 497 "ds_lexer.lpp"
+#line 496 "ds_lexer.lpp"
 return DAS_TUINT2;
 	YY_BREAK
 case 137:
 YY_RULE_SETUP
-#line 498 "ds_lexer.lpp"
+#line 497 "ds_lexer.lpp"
 return DAS_TUINT3;
 	YY_BREAK
 case 138:
 YY_RULE_SETUP
-#line 499 "ds_lexer.lpp"
+#line 498 "ds_lexer.lpp"
 return DAS_TUINT4;
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 500 "ds_lexer.lpp"
+#line 499 "ds_lexer.lpp"
 return DAS_TDOUBLE;
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 501 "ds_lexer.lpp"
+#line 500 "ds_lexer.lpp"
 return DAS_TFLOAT;
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 502 "ds_lexer.lpp"
+#line 501 "ds_lexer.lpp"
 return DAS_TFLOAT2;
 	YY_BREAK
 case 142:
 YY_RULE_SETUP
-#line 503 "ds_lexer.lpp"
+#line 502 "ds_lexer.lpp"
 return DAS_TFLOAT3;
 	YY_BREAK
 case 143:
 YY_RULE_SETUP
-#line 504 "ds_lexer.lpp"
+#line 503 "ds_lexer.lpp"
 return DAS_TFLOAT4;
 	YY_BREAK
 case 144:
 YY_RULE_SETUP
-#line 505 "ds_lexer.lpp"
+#line 504 "ds_lexer.lpp"
 {
     auto it = yyextra->das_keywords.find(yytext);
     if ( it != yyextra->das_keywords.end() ) {
@@ -2724,7 +2723,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 145:
 YY_RULE_SETUP
-#line 517 "ds_lexer.lpp"
+#line 516 "ds_lexer.lpp"
 {
         BEGIN(strb);
         return BEGIN_STRING;
@@ -2732,127 +2731,127 @@ YY_RULE_SETUP
 	YY_BREAK
 case 146:
 YY_RULE_SETUP
-#line 521 "ds_lexer.lpp"
+#line 520 "ds_lexer.lpp"
 yylval_param->ui = 8; return UNSIGNED_INT8;
 	YY_BREAK
 case 147:
 YY_RULE_SETUP
-#line 522 "ds_lexer.lpp"
+#line 521 "ds_lexer.lpp"
 yylval_param->ui = 9; return UNSIGNED_INT8;
 	YY_BREAK
 case 148:
 YY_RULE_SETUP
-#line 523 "ds_lexer.lpp"
+#line 522 "ds_lexer.lpp"
 yylval_param->ui = 10; return UNSIGNED_INT8;
 	YY_BREAK
 case 149:
 YY_RULE_SETUP
-#line 524 "ds_lexer.lpp"
+#line 523 "ds_lexer.lpp"
 yylval_param->ui = 12; return UNSIGNED_INT8;
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 525 "ds_lexer.lpp"
+#line 524 "ds_lexer.lpp"
 yylval_param->ui = 13; return UNSIGNED_INT8;
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
-#line 526 "ds_lexer.lpp"
+#line 525 "ds_lexer.lpp"
 yylval_param->ui = '\\'; return UNSIGNED_INT8;
 	YY_BREAK
 case 152:
 YY_RULE_SETUP
-#line 527 "ds_lexer.lpp"
+#line 526 "ds_lexer.lpp"
 yylval_param->ui = '\''; return UNSIGNED_INT8;
 	YY_BREAK
 case 153:
 YY_RULE_SETUP
-#line 528 "ds_lexer.lpp"
+#line 527 "ds_lexer.lpp"
 yylval_param->ui = uint32_t(yytext[1]); return UNSIGNED_INT8;
 	YY_BREAK
 case 154:
 YY_RULE_SETUP
-#line 530 "ds_lexer.lpp"
+#line 529 "ds_lexer.lpp"
 yylval_param->ui = 8; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 155:
 YY_RULE_SETUP
-#line 531 "ds_lexer.lpp"
+#line 530 "ds_lexer.lpp"
 yylval_param->ui = 9; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 156:
 YY_RULE_SETUP
-#line 532 "ds_lexer.lpp"
+#line 531 "ds_lexer.lpp"
 yylval_param->ui = 10; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 157:
 YY_RULE_SETUP
-#line 533 "ds_lexer.lpp"
+#line 532 "ds_lexer.lpp"
 yylval_param->ui = 12; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 158:
 YY_RULE_SETUP
-#line 534 "ds_lexer.lpp"
+#line 533 "ds_lexer.lpp"
 yylval_param->ui = 13; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 159:
 YY_RULE_SETUP
-#line 535 "ds_lexer.lpp"
+#line 534 "ds_lexer.lpp"
 yylval_param->ui = '\\'; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 160:
 YY_RULE_SETUP
-#line 536 "ds_lexer.lpp"
+#line 535 "ds_lexer.lpp"
 yylval_param->ui = '\''; return UNSIGNED_INTEGER;
 	YY_BREAK
 case 161:
 YY_RULE_SETUP
-#line 537 "ds_lexer.lpp"
+#line 536 "ds_lexer.lpp"
 yylval_param->ui = uint32_t(yytext[1]); return UNSIGNED_INTEGER;
 	YY_BREAK
 case 162:
 YY_RULE_SETUP
-#line 539 "ds_lexer.lpp"
+#line 538 "ds_lexer.lpp"
 yylval_param->i = 8; return INTEGER;
 	YY_BREAK
 case 163:
 YY_RULE_SETUP
-#line 540 "ds_lexer.lpp"
+#line 539 "ds_lexer.lpp"
 yylval_param->i = 9; return INTEGER;
 	YY_BREAK
 case 164:
 YY_RULE_SETUP
-#line 541 "ds_lexer.lpp"
+#line 540 "ds_lexer.lpp"
 yylval_param->i = 10; return INTEGER;
 	YY_BREAK
 case 165:
 YY_RULE_SETUP
-#line 542 "ds_lexer.lpp"
+#line 541 "ds_lexer.lpp"
 yylval_param->i = 12; return INTEGER;
 	YY_BREAK
 case 166:
 YY_RULE_SETUP
-#line 543 "ds_lexer.lpp"
+#line 542 "ds_lexer.lpp"
 yylval_param->i = 13; return INTEGER;
 	YY_BREAK
 case 167:
 YY_RULE_SETUP
-#line 544 "ds_lexer.lpp"
+#line 543 "ds_lexer.lpp"
 yylval_param->i = '\\'; return INTEGER;
 	YY_BREAK
 case 168:
 YY_RULE_SETUP
-#line 545 "ds_lexer.lpp"
+#line 544 "ds_lexer.lpp"
 yylval_param->i = '\''; return INTEGER;
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 547 "ds_lexer.lpp"
+#line 546 "ds_lexer.lpp"
 yylval_param->i = int32_t(yytext[1]); return INTEGER;
 	YY_BREAK
 case 170:
 YY_RULE_SETUP
-#line 548 "ds_lexer.lpp"
+#line 547 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2867,7 +2866,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 171:
 YY_RULE_SETUP
-#line 559 "ds_lexer.lpp"
+#line 558 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2882,7 +2881,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 172:
 YY_RULE_SETUP
-#line 570 "ds_lexer.lpp"
+#line 569 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2899,7 +2898,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 583 "ds_lexer.lpp"
+#line 582 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2914,7 +2913,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 594 "ds_lexer.lpp"
+#line 593 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2933,7 +2932,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 609 "ds_lexer.lpp"
+#line 608 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2948,7 +2947,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 620 "ds_lexer.lpp"
+#line 619 "ds_lexer.lpp"
 {
         char temptext[128];
         skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2963,7 +2962,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 177:
 YY_RULE_SETUP
-#line 631 "ds_lexer.lpp"
+#line 630 "ds_lexer.lpp"
 {
         char temptext[128];
         skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -2978,7 +2977,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 178:
 YY_RULE_SETUP
-#line 642 "ds_lexer.lpp"
+#line 641 "ds_lexer.lpp"
 {
         char temptext[128];
         int templength = skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -3005,7 +3004,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 665 "ds_lexer.lpp"
+#line 664 "ds_lexer.lpp"
 {
         char temptext[128];
         skip_underscode(yytext,temptext,temptext+sizeof(temptext));
@@ -3020,7 +3019,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 180:
 YY_RULE_SETUP
-#line 676 "ds_lexer.lpp"
+#line 675 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3033,7 +3032,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 181:
 YY_RULE_SETUP
-#line 685 "ds_lexer.lpp"
+#line 684 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3047,7 +3046,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 182:
 YY_RULE_SETUP
-#line 695 "ds_lexer.lpp"
+#line 694 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3060,7 +3059,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 183:
 YY_RULE_SETUP
-#line 704 "ds_lexer.lpp"
+#line 703 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->fd);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3073,7 +3072,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 184:
 YY_RULE_SETUP
-#line 713 "ds_lexer.lpp"
+#line 712 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3086,7 +3085,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 185:
 YY_RULE_SETUP
-#line 722 "ds_lexer.lpp"
+#line 721 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3099,7 +3098,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 186:
 YY_RULE_SETUP
-#line 731 "ds_lexer.lpp"
+#line 730 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3112,7 +3111,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 187:
 YY_RULE_SETUP
-#line 740 "ds_lexer.lpp"
+#line 739 "ds_lexer.lpp"
 {
     auto res = fast_float::from_chars(yytext, yytext+strlen(yytext), yylval_param->d);
     if ( res.ec == std::errc::result_out_of_range ) {
@@ -3125,7 +3124,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 188:
 YY_RULE_SETUP
-#line 749 "ds_lexer.lpp"
+#line 748 "ds_lexer.lpp"
 {
     if ( !yyextra->das_nested_parentheses ) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching parentheses", CompilationError::mismatching_parens);
@@ -3137,7 +3136,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 189:
 YY_RULE_SETUP
-#line 757 "ds_lexer.lpp"
+#line 756 "ds_lexer.lpp"
 {
     yyextra->das_nested_parentheses ++;
     return '(';
@@ -3145,7 +3144,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 190:
 YY_RULE_SETUP
-#line 761 "ds_lexer.lpp"
+#line 760 "ds_lexer.lpp"
 {
     if ( !yyextra->das_nested_square_braces ) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching square braces", CompilationError::mismatching_parens);
@@ -3157,7 +3156,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 191:
 YY_RULE_SETUP
-#line 769 "ds_lexer.lpp"
+#line 768 "ds_lexer.lpp"
 {
     yyextra->das_nested_square_braces ++;
     return '[';
@@ -3165,7 +3164,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 192:
 YY_RULE_SETUP
-#line 773 "ds_lexer.lpp"
+#line 772 "ds_lexer.lpp"
 {
     if ( yyextra->das_nested_sb ) {
         yyextra->das_nested_sb --;
@@ -3187,7 +3186,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 193:
 YY_RULE_SETUP
-#line 791 "ds_lexer.lpp"
+#line 790 "ds_lexer.lpp"
 {
     if ( yyextra->das_nested_sb ) {
         yyextra->das_nested_sb ++;
@@ -3199,28 +3198,28 @@ YY_RULE_SETUP
 	YY_BREAK
 case 194:
 YY_RULE_SETUP
-#line 799 "ds_lexer.lpp"
+#line 798 "ds_lexer.lpp"
 return COLCOL;
 	YY_BREAK
 case 195:
 YY_RULE_SETUP
-#line 800 "ds_lexer.lpp"
+#line 799 "ds_lexer.lpp"
 return MTAG_DOTDOTDOT;
 	YY_BREAK
 case 196:
 YY_RULE_SETUP
-#line 801 "ds_lexer.lpp"
+#line 800 "ds_lexer.lpp"
 return DOTDOT;
 	YY_BREAK
 case 197:
 YY_RULE_SETUP
-#line 802 "ds_lexer.lpp"
+#line 801 "ds_lexer.lpp"
 return RPIPE;
 	YY_BREAK
 case 198:
 /* rule 198 can match eol */
 YY_RULE_SETUP
-#line 803 "ds_lexer.lpp"
+#line 802 "ds_lexer.lpp"
 {
     yyextra->last_token_end = tokAt(yyscanner,*yylloc_param);
     yyextra->last_token_end.column += 2;
@@ -3233,7 +3232,7 @@ YY_RULE_SETUP
 case 199:
 /* rule 199 can match eol */
 YY_RULE_SETUP
-#line 812 "ds_lexer.lpp"
+#line 811 "ds_lexer.lpp"
 {
     yyextra->das_need_oxford_comma = false;
     unput('\n');
@@ -3245,7 +3244,7 @@ YY_RULE_SETUP
 case 200:
 /* rule 200 can match eol */
 YY_RULE_SETUP
-#line 820 "ds_lexer.lpp"
+#line 819 "ds_lexer.lpp"
 {
     yyextra->das_need_oxford_comma = false;
     unput('\n');
@@ -3257,7 +3256,7 @@ YY_RULE_SETUP
 case 201:
 /* rule 201 can match eol */
 YY_RULE_SETUP
-#line 827 "ds_lexer.lpp"
+#line 826 "ds_lexer.lpp"
 {
     yyextra->das_need_oxford_comma = false;
     unput('\n');
@@ -3267,7 +3266,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 202:
 YY_RULE_SETUP
-#line 833 "ds_lexer.lpp"
+#line 832 "ds_lexer.lpp"
 {
     unput('$');
     YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $");
@@ -3281,7 +3280,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 203:
 YY_RULE_SETUP
-#line 843 "ds_lexer.lpp"
+#line 842 "ds_lexer.lpp"
 {
     unput('@');
     YYCOLUMN(yyextra->das_yycolumn--, "UNPUT @");
@@ -3295,7 +3294,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 204:
 YY_RULE_SETUP
-#line 853 "ds_lexer.lpp"
+#line 852 "ds_lexer.lpp"
 {
     unput('@');
     unput('@');
@@ -3310,7 +3309,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 205:
 YY_RULE_SETUP
-#line 864 "ds_lexer.lpp"
+#line 863 "ds_lexer.lpp"
 {
     unput('@');
     YYCOLUMN(yyextra->das_yycolumn--, "UNPUT @");
@@ -3324,7 +3323,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 206:
 YY_RULE_SETUP
-#line 874 "ds_lexer.lpp"
+#line 873 "ds_lexer.lpp"
 {
     unput('$');
     YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $");
@@ -3338,70 +3337,70 @@ YY_RULE_SETUP
 	YY_BREAK
 case 207:
 YY_RULE_SETUP
-#line 884 "ds_lexer.lpp"
+#line 883 "ds_lexer.lpp"
 return LPIPE;
 	YY_BREAK
 case 208:
 YY_RULE_SETUP
-#line 885 "ds_lexer.lpp"
+#line 884 "ds_lexer.lpp"
 return MTAG_E;
 	YY_BREAK
 case 209:
 /* rule 209 can match eol */
 YY_RULE_SETUP
-#line 886 "ds_lexer.lpp"
+#line 885 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_E;
 	YY_BREAK
 case 210:
 /* rule 210 can match eol */
 YY_RULE_SETUP
-#line 887 "ds_lexer.lpp"
+#line 886 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_I;
 	YY_BREAK
 case 211:
 /* rule 211 can match eol */
 YY_RULE_SETUP
-#line 888 "ds_lexer.lpp"
+#line 887 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_V;
 	YY_BREAK
 case 212:
 /* rule 212 can match eol */
 YY_RULE_SETUP
-#line 889 "ds_lexer.lpp"
+#line 888 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_B;
 	YY_BREAK
 case 213:
 /* rule 213 can match eol */
 YY_RULE_SETUP
-#line 890 "ds_lexer.lpp"
+#line 889 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_A;
 	YY_BREAK
 case 214:
 /* rule 214 can match eol */
 YY_RULE_SETUP
-#line 891 "ds_lexer.lpp"
+#line 890 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_T;
 	YY_BREAK
 case 215:
 /* rule 215 can match eol */
 YY_RULE_SETUP
-#line 892 "ds_lexer.lpp"
+#line 891 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_C;
 	YY_BREAK
 case 216:
 /* rule 216 can match eol */
 YY_RULE_SETUP
-#line 893 "ds_lexer.lpp"
+#line 892 "ds_lexer.lpp"
 unput(yytext[yyleng-1]); YYCOLUMN(yyextra->das_yycolumn--, "UNPUT $"); return MTAG_F;
 	YY_BREAK
 case 217:
 YY_RULE_SETUP
-#line 894 "ds_lexer.lpp"
+#line 893 "ds_lexer.lpp"
 return QQ;
 	YY_BREAK
 case 218:
 YY_RULE_SETUP
-#line 895 "ds_lexer.lpp"
+#line 894 "ds_lexer.lpp"
 {
     yyextra->das_nested_square_braces ++;
     return QBRA;
@@ -3409,127 +3408,127 @@ YY_RULE_SETUP
 	YY_BREAK
 case 219:
 YY_RULE_SETUP
-#line 899 "ds_lexer.lpp"
+#line 898 "ds_lexer.lpp"
 return QDOT;
 	YY_BREAK
 case 220:
 YY_RULE_SETUP
-#line 900 "ds_lexer.lpp"
+#line 899 "ds_lexer.lpp"
 return CLONEEQU;
 	YY_BREAK
 case 221:
 YY_RULE_SETUP
-#line 901 "ds_lexer.lpp"
+#line 900 "ds_lexer.lpp"
 return RARROW;
 	YY_BREAK
 case 222:
 YY_RULE_SETUP
-#line 902 "ds_lexer.lpp"
+#line 901 "ds_lexer.lpp"
 return LARROW;
 	YY_BREAK
 case 223:
 YY_RULE_SETUP
-#line 903 "ds_lexer.lpp"
+#line 902 "ds_lexer.lpp"
 return ADDEQU;
 	YY_BREAK
 case 224:
 YY_RULE_SETUP
-#line 904 "ds_lexer.lpp"
+#line 903 "ds_lexer.lpp"
 return SUBEQU;
 	YY_BREAK
 case 225:
 YY_RULE_SETUP
-#line 905 "ds_lexer.lpp"
+#line 904 "ds_lexer.lpp"
 return DIVEQU;
 	YY_BREAK
 case 226:
 YY_RULE_SETUP
-#line 906 "ds_lexer.lpp"
+#line 905 "ds_lexer.lpp"
 return MULEQU;
 	YY_BREAK
 case 227:
 YY_RULE_SETUP
-#line 907 "ds_lexer.lpp"
+#line 906 "ds_lexer.lpp"
 return MODEQU;
 	YY_BREAK
 case 228:
 YY_RULE_SETUP
-#line 908 "ds_lexer.lpp"
+#line 907 "ds_lexer.lpp"
 return ANDANDEQU;
 	YY_BREAK
 case 229:
 YY_RULE_SETUP
-#line 909 "ds_lexer.lpp"
+#line 908 "ds_lexer.lpp"
 return OROREQU;
 	YY_BREAK
 case 230:
 YY_RULE_SETUP
-#line 910 "ds_lexer.lpp"
+#line 909 "ds_lexer.lpp"
 return XORXOREQU;
 	YY_BREAK
 case 231:
 YY_RULE_SETUP
-#line 911 "ds_lexer.lpp"
+#line 910 "ds_lexer.lpp"
 return ANDAND;
 	YY_BREAK
 case 232:
 YY_RULE_SETUP
-#line 912 "ds_lexer.lpp"
+#line 911 "ds_lexer.lpp"
 return OROR;
 	YY_BREAK
 case 233:
 YY_RULE_SETUP
-#line 913 "ds_lexer.lpp"
+#line 912 "ds_lexer.lpp"
 return XORXOR;
 	YY_BREAK
 case 234:
 YY_RULE_SETUP
-#line 914 "ds_lexer.lpp"
+#line 913 "ds_lexer.lpp"
 return ANDEQU;
 	YY_BREAK
 case 235:
 YY_RULE_SETUP
-#line 915 "ds_lexer.lpp"
+#line 914 "ds_lexer.lpp"
 return OREQU;
 	YY_BREAK
 case 236:
 YY_RULE_SETUP
-#line 916 "ds_lexer.lpp"
+#line 915 "ds_lexer.lpp"
 return XOREQU;
 	YY_BREAK
 case 237:
 YY_RULE_SETUP
-#line 917 "ds_lexer.lpp"
+#line 916 "ds_lexer.lpp"
 return ADDADD;
 	YY_BREAK
 case 238:
 YY_RULE_SETUP
-#line 918 "ds_lexer.lpp"
+#line 917 "ds_lexer.lpp"
 return SUBSUB;
 	YY_BREAK
 case 239:
 YY_RULE_SETUP
-#line 919 "ds_lexer.lpp"
+#line 918 "ds_lexer.lpp"
 return LEEQU;
 	YY_BREAK
 case 240:
 YY_RULE_SETUP
-#line 920 "ds_lexer.lpp"
+#line 919 "ds_lexer.lpp"
 return GREQU;
 	YY_BREAK
 case 241:
 YY_RULE_SETUP
-#line 921 "ds_lexer.lpp"
+#line 920 "ds_lexer.lpp"
 return EQUEQU;
 	YY_BREAK
 case 242:
 YY_RULE_SETUP
-#line 922 "ds_lexer.lpp"
+#line 921 "ds_lexer.lpp"
 return NOTEQU;
 	YY_BREAK
 case 243:
 YY_RULE_SETUP
-#line 923 "ds_lexer.lpp"
+#line 922 "ds_lexer.lpp"
 {
     if ( yyextra->das_arrow_depth ) {
         unput('>');
@@ -3543,7 +3542,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 244:
 YY_RULE_SETUP
-#line 933 "ds_lexer.lpp"
+#line 932 "ds_lexer.lpp"
 {
     if ( yyextra->das_arrow_depth ) {
         unput('>');
@@ -3556,42 +3555,42 @@ YY_RULE_SETUP
 	YY_BREAK
 case 245:
 YY_RULE_SETUP
-#line 942 "ds_lexer.lpp"
+#line 941 "ds_lexer.lpp"
 return ROTL;
 	YY_BREAK
 case 246:
 YY_RULE_SETUP
-#line 943 "ds_lexer.lpp"
+#line 942 "ds_lexer.lpp"
 return SHL;
 	YY_BREAK
 case 247:
 YY_RULE_SETUP
-#line 944 "ds_lexer.lpp"
+#line 943 "ds_lexer.lpp"
 return SHREQU;
 	YY_BREAK
 case 248:
 YY_RULE_SETUP
-#line 945 "ds_lexer.lpp"
+#line 944 "ds_lexer.lpp"
 return SHLEQU;
 	YY_BREAK
 case 249:
 YY_RULE_SETUP
-#line 946 "ds_lexer.lpp"
+#line 945 "ds_lexer.lpp"
 return ROTREQU;
 	YY_BREAK
 case 250:
 YY_RULE_SETUP
-#line 947 "ds_lexer.lpp"
+#line 946 "ds_lexer.lpp"
 return ROTLEQU;
 	YY_BREAK
 case 251:
 YY_RULE_SETUP
-#line 948 "ds_lexer.lpp"
+#line 947 "ds_lexer.lpp"
 return MAPTO;
 	YY_BREAK
 case 252:
 YY_RULE_SETUP
-#line 949 "ds_lexer.lpp"
+#line 948 "ds_lexer.lpp"
 {
         if ( yyextra->das_gen2_make_syntax ) {
             yyextra->das_nested_square_braces ++;
@@ -3606,7 +3605,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 253:
 YY_RULE_SETUP
-#line 960 "ds_lexer.lpp"
+#line 959 "ds_lexer.lpp"
 {
         if ( yyextra->das_gen2_make_syntax ) {
             yyextra->das_nested_square_braces ++;
@@ -3621,7 +3620,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 254:
 YY_RULE_SETUP
-#line 971 "ds_lexer.lpp"
+#line 970 "ds_lexer.lpp"
 {
         if ( yyextra->das_gen2_make_syntax ) {
             yyextra->das_nested_curly_braces ++;
@@ -3636,12 +3635,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 255:
 YY_RULE_SETUP
-#line 982 "ds_lexer.lpp"
+#line 981 "ds_lexer.lpp"
 /* skip white space */
 	YY_BREAK
 case 256:
 YY_RULE_SETUP
-#line 983 "ds_lexer.lpp"
+#line 982 "ds_lexer.lpp"
 {
     YYTAB();
 }
@@ -3649,7 +3648,7 @@ YY_RULE_SETUP
 case 257:
 /* rule 257 can match eol */
 YY_RULE_SETUP
-#line 987 "ds_lexer.lpp"
+#line 986 "ds_lexer.lpp"
 {
     if ( yyextra->das_nested_curly_braces < 2 ) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching curly braces", CompilationError::mismatching_curly_bracers);
@@ -3669,7 +3668,7 @@ YY_RULE_SETUP
 case 258:
 /* rule 258 can match eol */
 YY_RULE_SETUP
-#line 1003 "ds_lexer.lpp"
+#line 1002 "ds_lexer.lpp"
 {
     if ( !yyextra->das_nested_curly_braces ) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching curly braces", CompilationError::mismatching_curly_bracers);
@@ -3694,7 +3693,7 @@ YY_RULE_SETUP
 case 259:
 /* rule 259 can match eol */
 YY_RULE_SETUP
-#line 1024 "ds_lexer.lpp"
+#line 1023 "ds_lexer.lpp"
 {
     if ( !yyextra->das_nested_curly_braces ) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching curly braces", CompilationError::mismatching_curly_bracers);
@@ -3719,7 +3718,7 @@ YY_RULE_SETUP
 case 260:
 /* rule 260 can match eol */
 YY_RULE_SETUP
-#line 1045 "ds_lexer.lpp"
+#line 1044 "ds_lexer.lpp"
 {
     if ( yyextra->das_nested_square_braces < 2) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching square braces", CompilationError::mismatching_parens);
@@ -3740,7 +3739,7 @@ YY_RULE_SETUP
 case 261:
 /* rule 261 can match eol */
 YY_RULE_SETUP
-#line 1062 "ds_lexer.lpp"
+#line 1061 "ds_lexer.lpp"
 {
     if ( yyextra->das_nested_square_braces < 2) {
         das_yyfatalerror(yylloc_param,yyscanner,"mismatching square braces", CompilationError::mismatching_parens);
@@ -3760,7 +3759,7 @@ YY_RULE_SETUP
 case 262:
 /* rule 262 can match eol */
 YY_RULE_SETUP
-#line 1078 "ds_lexer.lpp"
+#line 1077 "ds_lexer.lpp"
 {
     YYCOLUMN(yyextra->das_yycolumn = 0, "NEW LINE");
 }
@@ -3768,7 +3767,7 @@ YY_RULE_SETUP
 case 263:
 /* rule 263 can match eol */
 YY_RULE_SETUP
-#line 1081 "ds_lexer.lpp"
+#line 1080 "ds_lexer.lpp"
 {
     if (yyextra->last_token_end.line != tokAt(yyscanner,*yylloc_param).line) {
         yyextra->last_token_end = tokAt(yyscanner,*yylloc_param);
@@ -3796,7 +3795,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(normal):
-#line 1106 "ds_lexer.lpp"
+#line 1105 "ds_lexer.lpp"
 {
     if ( yyextra->g_FileAccessStack.size()==1 ) {
         YYCOLUMN(yyextra->das_yycolumn = 0,"EOF");
@@ -3826,15 +3825,15 @@ case YY_STATE_EOF(normal):
 	YY_BREAK
 case 264:
 YY_RULE_SETUP
-#line 1132 "ds_lexer.lpp"
+#line 1131 "ds_lexer.lpp"
 return *yytext;
 	YY_BREAK
 case 265:
 YY_RULE_SETUP
-#line 1134 "ds_lexer.lpp"
+#line 1133 "ds_lexer.lpp"
 ECHO;
 	YY_BREAK
-#line 3837 "ds_lexer.cpp"
+#line 3836 "ds_lexer.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(include):
 	yyterminate();
@@ -5028,7 +5027,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 1134 "ds_lexer.lpp"
+#line 1133 "ds_lexer.lpp"
 
 
 void das_strfmt ( yyscan_t yyscanner ) {

--- a/src/parser/ds_lexer.lpp
+++ b/src/parser/ds_lexer.lpp
@@ -77,11 +77,10 @@ void das_accept_cpp_comment ( vector<CommentReader *> & crdi, yyscan_t scanner, 
 %%
 
 <indent,normal>\#[0-9]+,[0-9]+,\"[^\"]+\"\# {
-    string txt = yytext;
     int lRow, lCol;
-    char lFile[256];
-    if ( sscanf ( yytext, "#%i,%i,\"%255s\"#", &lRow, &lCol, lFile )==3 ) {
-        lFile[strlen(lFile)-2] = 0;
+    if ( sscanf ( yytext, "#%i,%i,", &lRow, &lCol )==2 ) {
+        // file name is the quote-bounded span; sscanf %s would stop at whitespace inside it
+        string lFile ( strchr(yytext,'\"')+1, yytext+yyleng-2 );
         auto cfi = yyextra->g_FileAccessStack.back();
         string incFileName = yyextra->g_Access->getIncludeFileName(cfi->name,lFile);
         auto info = yyextra->g_Access->getFileInfo(incFileName);

--- a/src/parser/lex.yy.h
+++ b/src/parser/lex.yy.h
@@ -720,7 +720,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 1134 "ds_lexer.lpp"
+#line 1133 "ds_lexer.lpp"
 
 
 #line 726 "lex.yy.h"

--- a/src/parser/lex2.yy.h
+++ b/src/parser/lex2.yy.h
@@ -720,7 +720,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 866 "ds2_lexer.lpp"
+#line 865 "ds2_lexer.lpp"
 
 
 #line 726 "lex2.yy.h"

--- a/tests-cpp/small/test_fully_sealed.cpp
+++ b/tests-cpp/small/test_fully_sealed.cpp
@@ -1,0 +1,29 @@
+// isFullySealed must test secondType where it checks secondType — the original
+// code re-tested firstType (copy-paste, flagged by PVS V522), so a sealed key
+// type masked an unsealed value type (e.g. table<int; auto>).
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include "daScript/ast/ast.h"
+using namespace das;
+
+TEST_CASE("isFullySealed checks secondType independently of firstType") {
+    gc_guard guard;
+    SUBCASE("sealed key, unsealed value") {
+        auto t = new TypeDecl(Type::tTable);
+        t->firstType = new TypeDecl(Type::tInt);
+        t->secondType = new TypeDecl(Type::autoinfer);
+        CHECK_FALSE(t->isFullySealed());
+    }
+    SUBCASE("unsealed key, sealed value") {
+        auto t = new TypeDecl(Type::tTable);
+        t->firstType = new TypeDecl(Type::autoinfer);
+        t->secondType = new TypeDecl(Type::tFloat);
+        CHECK_FALSE(t->isFullySealed());
+    }
+    SUBCASE("both sealed") {
+        auto t = new TypeDecl(Type::tTable);
+        t->firstType = new TypeDecl(Type::tInt);
+        t->secondType = new TypeDecl(Type::tFloat);
+        CHECK(t->isFullySealed());
+    }
+}


### PR DESCRIPTION
Triage of a PVS-Studio sweep over the vendored daScript copy: ~80 warnings, 6 real findings, all fixed here. Everything else classified as false positives (invariant-guarded derefs the parser guarantees, gc_node-tracked "leaks", deliberate hopeless-clear memsets, union aliasing PVS can't model, flex-generated boilerplate).

## Fixes

1. **`isFullySealed` copy-paste** (ast_typedecl.cpp) — null-checked `secondType` but re-tested `firstType`, so a sealed key type masked an unsealed value type (e.g. a table with sealed key and still-auto value), letting `typeinfo offsetof` fold prematurely. Pinned by a new doctest (`tests-cpp/small/test_fully_sealed.cpp`).
2. **Bitfield-constant null deref** (ast_infer_type.cpp) — the "bitfield constant ... is not initialized" error branch fell through to `found-&gt;init-&gt;clone()`. Added the missing return; only reachable via macro-side flag manipulation (the grammar always sets the initializer).
3. **Silent ambiguous-variable failure** (ast_infer_type.cpp) — `else { if (verbose) error(...) }` made the terse "too many matching variables" diagnostic dead code, so non-verbose compiles reported nothing for an ambiguous global. Also folded the mirror always-true `if (verbose)` on the "can't locate variable" path.
4. **Dangling `updateAliasMapCallback`** (ast_infer_type_function.cpp, 2 sites) — early returns left `program-&gt;updateAliasMapCallback` holding a lambda capturing dead stack frames by reference; a later das-side `update_alias_map` call (typeinfo macro) would write through them. The third site already cleared the callback before its early return — copied that pattern.
5. **Lexer line-directive OOB write** (ds_lexer.lpp + ds2_lexer.lpp) — the file name in `#row,col,"file"#` was parsed with `sscanf %s`, which stops at whitespace: a file name containing a space made `strlen(lFile)-2` underflow into a wild out-of-bounds write. Both lexers now take the quote-bounded span directly (also un-breaks paths with spaces and paths longer than 255 chars). Generated lexer sources regenerated.
6. **`context` guard asymmetry** (module_builtin_fio.cpp) — `register_dynamic_module` deref'd `context` unguarded on its first error path while both sibling error paths guard with `if (context)`; harmonized (a null context is passed internally today, Quiet-only).

## Validation

- preflight `--full`: 16 passed, 0 failed (lint skipped — no .das changes): cpp-syntax full sweep, das2rst + sphinx latex/html + pdflatex, tests-cpp, interp + JIT + AOT suites, sequence smoke
- full das suite: 11036 tests, 0 failed
- ctest: 64/64 incl. the new `isFullySealed` regression test
- lexer probed by hand: `#5,1,"probe b.das"#` (space in name) now lexes, resolves, and runs; plain directives unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)