### PR TITLE
msvc analysis: suppress C26819/C28251 advisories, bump EOL actions

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -44,13 +44,13 @@ jobs:
 
     # Upload SARIF file to GitHub Code Scanning Alerts
     - name: Upload SARIF to GitHub
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.run-analysis.outputs.sarif }}
 
     # Upload SARIF file as an Artifact to download and view
     - name: Upload SARIF as an Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sarif-file
         path: ${{ steps.run-analysis.outputs.sarif }}

--- a/CustomRules.ruleset
+++ b/CustomRules.ruleset
@@ -9,5 +9,7 @@
     <Rule Id="C26439" Action="None" /> <!-- Exclude: This kind of function should not throw. Declare it 'noexcept' (f.6). -->
     <Rule Id="C26813" Action="None" /> <!-- Exclude: Use 'bitwise and' to check if a flag is set. -->
     <Rule Id="C6255" Action="None" /> <!-- _alloca indicates failure by raising a stack overflow exception. Consider using _malloca instead. -->
+    <Rule Id="C26819" Action="None" /> <!-- Exclude: Unannotated fallthrough between switch labels (es.78). Advisory; our fallthroughs are intentional and we don't annotate with [[fallthrough]]. -->
+    <Rule Id="C28251" Action="None" /> <!-- Exclude: Inconsistent SAL annotation for operator new/new[]. Our global allocators (free_list) intentionally carry no SAL annotations. -->
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Follow-up to the CodeQL cleanup (#3112). The PREfast / MSVC `/analyze` workflow had left 16 alerts in the Security tab — all pure style/advisory, none memory-safety:

- **14× C26819** (es.78, unannotated switch fallthrough) — ours are intentional and we don't annotate with `[[fallthrough]]`; several are last-label-before-brace misfires (e.g. `default: DAS_ASSERT(0); break;`, which isn't even a fallthrough). 5 of these are in vendored stb single-file headers.
- **2× C28251** (inconsistent SAL annotation on `free_list`'s global `operator new` / `new[]`) — our allocators intentionally carry no SAL annotations; nothing relies on the contract.

All 16 were dismissed (won't-fix) in the Security tab. This suppresses both rules at the ruleset source (`CustomRules.ruleset`, alongside the existing `C26451`/`C26495`/`C26439`/`C26813`/`C6255` exclusions) so a future manual run stays clean rather than re-raising them as new alerts (the workflow is `workflow_dispatch`-only, so this only fires on a manual trigger anyway).

Also bumps the two EOL actions in this workflow to the repo standard used by the other workflows: `codeql-action/upload-sarif` v2→v3, `actions/upload-artifact` v3→v4. `microsoft/msvc-code-analysis-action` stays at v0.1.1 — no newer release exists.

Can't be CI-validated pre-merge (the workflow is manual-dispatch and Windows-only), but the changes are a ruleset rule-list addition + two action version pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)