### PR TITLE
opengl_boost: fix glBufferData over fixed arrays — require array_boost for empty()

### DIFF
--- a/modules/dasOpenGL/opengl/opengl_boost.das
+++ b/modules/dasOpenGL/opengl/opengl_boost.das
@@ -9,6 +9,7 @@ require opengl/opengl public
 
 require daslib/safe_addr
 require daslib/contracts
+require daslib/array_boost
 
 require glsl/glsl_opengl public
 
@@ -40,7 +41,7 @@ def write_ssbo(ssbo : uint; data : auto(TT)) {
     if (p_mat == null) {
         panic("can't map ssbo")
     }
-    unsafe {
+    unsafe { // nolint:STYLE025 — expression-form unsafe loses the reinterpret in generic instances (31004)
         *(reinterpret<TT -const?> p_mat) = data
     }
     glUnmapBuffer(GL_SHADER_STORAGE_BUFFER)
@@ -50,7 +51,10 @@ def write_ssbo(ssbo : uint; data : auto(TT)) {
 def read_ssbo(ssbo : uint; var data : auto(TT)) {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo)
     var p_mat = glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY)
-    unsafe {
+    if (p_mat == null) {
+        panic("can't map ssbo")
+    }
+    unsafe { // nolint:STYLE025 — expression-form unsafe loses the reinterpret in generic instances (31004)
         data = *(reinterpret<TT?> p_mat)
     }
     glUnmapBuffer(GL_SHADER_STORAGE_BUFFER)


### PR DESCRIPTION
## What

`glBufferData(target, arr, usage)` — the `[expect_any_array]` template in `opengl_boost` — fails to compile when `arr` is a **fixed array** (`Vertex[3]`-style), with `error[30341]: no matching functions or generics: empty(...)`. This has been breaking `examples/daslive/triangle` (and any external consumer passing fixed arrays, which is the canonical VBO-init pattern) on master.

## Why

The PERF017 lint sweep (5ab38face, 2026-05-15) rewrote `assert(length(arr) > 0)` to `assert(!empty(arr))`. For dynamic arrays the builtin `empty()` resolves; for fixed arrays `empty()` comes from `daslib/array_boost` — which `opengl_boost` never required. Unqualified calls resolve in the defining module, so the fixed-array instantiation can't see it. Only fixed-array call sites instantiate that path, and no pre-merge lane compiles them — the sequence smoke passes dynamic arrays — so the break was invisible to CI.

## Fix

Add `require daslib/array_boost` — restores resolution for every any-array generic in the module and keeps the PERF017-idiomatic `empty()` form (reverting to `length(arr) != 0` would just re-trip the lint).

Also brings the touched file to lint-zero: two pre-existing STYLE025 warnings (`write_ssbo`/`read_ssbo`) stay as block-form `unsafe` with `nolint` — the rule's suggested expression form drops the `reinterpret` from unsafe coverage once the generic instantiates (`error[31004]: cast requires unsafe`). That unsafe-propagation quirk in generic instances may deserve its own issue; out of scope here.

## Gates

- `tests/` interp suite: 11056 tests, 0 failed, 0 errors, 6 skipped
- `examples/opengl/*.das`: 8/8 compile (incl. `05_hello_compute`, which exercises both ssbo helpers)
- `examples/daslive/triangle/main.das`: compiles again
- sequence `ci_smoke_test.sh`: PASS (daspkg release bundle builds and launches)
- lint + format: clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)