### PR TITLE
fio: report broken dynamic-module artifacts when context is null

### DIFF
--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1320,7 +1320,7 @@ namespace das {
     }
 
     enum class RegisterOnError {
-        Quiet = 0,      // 'missing .shared_module' message is ignored
+        Quiet = 0,      // missing/unloadable .shared_module is silent (deferred for retry); broken artifacts still report
         ErrorMsg,       // error message is displayed
         Fail,           // error message is displayed and exception is thrown
     };
@@ -1344,7 +1344,10 @@ namespace das {
         return on;
     }
 
-    // Returns DLL handle.
+    // Returns DLL handle, nullptr on failure. on_error governs LOAD failures only:
+    // Quiet defers a failed dlopen to retry_pending_dynamic_modules() (sibling-dep
+    // ordering). A loadable-but-broken artifact (registrator missing, build-id
+    // mismatch) always reports — to the context if any, else LOG(error) (#2580).
     void *register_dynamic_module(const char *path, const char *mod_name, int on_error, Context * context, LineInfoArg * at ) {
         string actualPath(path);
 #ifndef NDEBUG
@@ -1367,6 +1370,7 @@ namespace das {
                 auto err_msg = "dynamic module `" + string(mod_name) + "` — failed to load: " + actualPath
                     + (dlErr.empty() ? string("\n") : (" (" + dlErr + ")\n"));
                 if (context) context->to_err(at, err_msg.c_str());
+                else LOG(LogLevel::error) << err_msg;
                 if (context && static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                     context->throw_error(err_msg.c_str());
                 }
@@ -1382,8 +1386,9 @@ namespace das {
         const auto regName = getDynModuleRegistratorName(mod_name);
         auto rawFn = getFunctionAddress(lib, regName.c_str());
         if (!rawFn) {
-            auto err_msg = "dynamic module `" + string(mod_name) + "` — function `" + regName + "` not found in `" + path + "`\n";
+            auto err_msg = "dynamic module `" + string(mod_name) + "` — function `" + regName + "` not found in `" + actualPath + "`\n";
             if (context) context->to_err(at, err_msg.c_str());
+            else LOG(LogLevel::error) << err_msg;
             if (context && static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                 context->throw_error(err_msg.c_str());
             }
@@ -1395,6 +1400,7 @@ namespace das {
         if (!mod) {
             auto err_msg = "dynamic module `" + string(mod_name) + "` — build-id mismatch (host " + to_string(DAS_BUILD_ID) + "); rebuild the module for current configuration\n";
             if (context) context->to_err(at, err_msg.c_str());
+            else LOG(LogLevel::error) << err_msg;
             if (context && static_cast<RegisterOnError>(on_error) == RegisterOnError::Fail) {
                 context->throw_error(err_msg.c_str());
             }

--- a/tests-cpp/small/test_register_dynamic_module.cpp
+++ b/tests-cpp/small/test_register_dynamic_module.cpp
@@ -1,0 +1,53 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+
+namespace das {
+    // forward declaration from module_builtin_fio.cpp (same as module_jit.cpp uses)
+    void * register_dynamic_module(const char *, const char *, int, Context *, LineInfoArg *);
+}
+
+namespace {
+
+// A library guaranteed loadable on each CI platform but which is NOT a das
+// module — drives register_dynamic_module into the registrator-missing branch.
+const char * loadable_non_das_library() {
+#if defined(_WIN32) || defined(_WIN64)
+    return "kernel32.dll";
+#elif defined(__APPLE__)
+    return "/usr/lib/libSystem.B.dylib";
+#else
+    return "libm.so.6";
+#endif
+}
+
+enum { Quiet = 0, ErrorMsg = 1, Fail = 2 }; // mirrors RegisterOnError in module_builtin_fio.cpp
+
+} // anon
+
+// Issue #2580: these calls used to segfault — the registrator-missing branch
+// called context->to_err unconditionally, and JIT/standalone callers pass
+// context=nullptr. The failure must now report via LOG(error) and return null.
+TEST_CASE("register_dynamic_module — registrator missing, nullptr context") {
+    SUBCASE("Quiet (the jit_register_dynamic_module signature)") {
+        CHECK(das::register_dynamic_module(loadable_non_das_library(),
+            "Module_DoesNotExist", Quiet, nullptr, nullptr) == nullptr);
+    }
+    SUBCASE("ErrorMsg") {
+        CHECK(das::register_dynamic_module(loadable_non_das_library(),
+            "Module_DoesNotExist", ErrorMsg, nullptr, nullptr) == nullptr);
+    }
+    SUBCASE("Fail must not throw without a context to throw through") {
+        void * result = &result; // poison — must come back null
+        CHECK_NOTHROW(result = das::register_dynamic_module(loadable_non_das_library(),
+            "Module_DoesNotExist", Fail, nullptr, nullptr));
+        CHECK(result == nullptr);
+    }
+}
+
+TEST_CASE("register_dynamic_module — dlopen failure, nullptr context, non-Quiet") {
+    // Quiet dlopen failures are deferred to the retry queue by design; non-Quiet
+    // ones with no context must report via LOG(error) and return null, not crash.
+    CHECK(das::register_dynamic_module("no/such/path.no_such_ext",
+        "Module_DoesNotExist", ErrorMsg, nullptr, nullptr) == nullptr);
+}

--- a/tests/exe-paths/CMakeLists.txt
+++ b/tests/exe-paths/CMakeLists.txt
@@ -19,6 +19,7 @@ add_test(
         -DDASLANG=$<TARGET_FILE:daslang>
         -DSRC_DAS=${CMAKE_CURRENT_SOURCE_DIR}/_uses_sqlite.das
         -DSQLITE_MOD=${_sqlite_mod_path}
+        "-DRUNTIME_DLLS=$<TARGET_FILE:libDaScriptDyn_runtime>$<SEMICOLON>$<TARGET_FILE:libDaScriptDyn>"
         -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}/wk
         -P ${CMAKE_CURRENT_SOURCE_DIR}/run_layouts.cmake
 )

--- a/tests/exe-paths/run_layouts.cmake
+++ b/tests/exe-paths/run_layouts.cmake
@@ -5,6 +5,7 @@
 #   DASLANG       — path to daslang binary
 #   SRC_DAS       — path to uses_sqlite.das (the test program)
 #   SQLITE_MOD    — path to dasModuleSQLITE(.shared_module|*_debug.shared_module)
+#   RUNTIME_DLLS  — list of daslang runtime shared libs the exe import-links
 #   WORKDIR       — temporary working directory (test-specific)
 #
 # The script compiles SRC_DAS to a standalone exe, then drives it through:
@@ -21,7 +22,7 @@
 # bundle" from "ok bundle" requires runtime override machinery that doesn't
 # exist yet. Each run uses a NEUTRAL cwd to isolate from cwd-relative fallbacks.
 
-if(NOT DASLANG OR NOT SRC_DAS OR NOT SQLITE_MOD OR NOT WORKDIR)
+if(NOT DASLANG OR NOT SRC_DAS OR NOT SQLITE_MOD OR NOT RUNTIME_DLLS OR NOT WORKDIR)
     message(FATAL_ERROR "run_layouts.cmake: missing required -D inputs")
 endif()
 if(NOT EXISTS "${DASLANG}")
@@ -53,6 +54,16 @@ if(NOT EXISTS "${EXE}")
     message(FATAL_ERROR "compile produced no output at ${EXE}")
 endif()
 
+# Helper — ship the daslang runtime shared libs next to the exe. The exe
+# import-links libDaScriptDyn_runtime, so every layout must carry it (this is
+# what `daspkg release` does for real bundles — without it the layout only
+# "works" by leaking the DLL from PATH).
+function(ship_runtime DEST)
+    foreach(_rt IN LISTS RUNTIME_DLLS)
+        file(COPY "${_rt}" DESTINATION "${DEST}")
+    endforeach()
+endfunction()
+
 # Helper — run the exe from CWD, capture output, verify "ok\n"
 function(run_layout SCENARIO EXE_PATH CWD)
     message(STATUS "[${SCENARIO}] exe=${EXE_PATH} cwd=${CWD}")
@@ -78,6 +89,7 @@ file(MAKE_DIRECTORY "${NEUTRAL}")
 set(BUNDLE "${WORKDIR}/bundle")
 file(MAKE_DIRECTORY "${BUNDLE}/modules/dasSQLITE")
 file(COPY "${EXE}" DESTINATION "${BUNDLE}")
+ship_runtime("${BUNDLE}")
 file(COPY "${SQLITE_MOD}" DESTINATION "${BUNDLE}/modules/dasSQLITE")
 get_filename_component(_exe_name "${EXE}" NAME)
 run_layout("bundle" "${BUNDLE}/${_exe_name}" "${NEUTRAL}")
@@ -87,12 +99,14 @@ run_layout("bundle" "${BUNDLE}/${_exe_name}" "${NEUTRAL}")
 set(INSTALL "${WORKDIR}/install")
 file(MAKE_DIRECTORY "${INSTALL}/bin" "${INSTALL}/modules/dasSQLITE")
 file(COPY "${EXE}" DESTINATION "${INSTALL}/bin")
+ship_runtime("${INSTALL}/bin")
 file(COPY "${SQLITE_MOD}" DESTINATION "${INSTALL}/modules/dasSQLITE")
 run_layout("sdk_install" "${INSTALL}/bin/${_exe_name}" "${NEUTRAL}")
 
 # Scenario 3 — local dev build sanity: run the exe from its build location.
 # (Compiled exe baked an absolute path to the SOURCE-tree dasSQLITE; that file
 # still exists, so tier-3 fallback wins. Verifies we don't break today.)
+ship_runtime("${WORKDIR}")
 run_layout("local_dev" "${EXE}" "${NEUTRAL}")
 
 message(STATUS "All exe-path layouts resolved successfully.")


### PR DESCRIPTION
## What

Closes #2580 — but not with the fix the issue suggests; the landscape changed since it was filed.

**The segfault as filed is already dead.** Both formerly-unconditional `context->to_err` sites got `if (context)` guards en passant: a03cb3977 (order-independent dyn-module loading) covered the registrator-missing and build-id-mismatch branches, 1b077a7d1 (PVS-Studio PR #3111) finished the dlopen branch.

**What remained is the inverse hole.** With `context == nullptr` (the issue's own reproducer — `jit_register_dynamic_module` / `jit_register_dynamic_module_resolve` from a standalone exe, plus `retry_pending_dynamic_modules`), a loadable-but-broken artifact now failed *completely silently*: the emitted exe discards the register call's return value, so a corrupt `.shared_module` or a build-id mismatch at exe startup produced no diagnostic anywhere (unless `DAS_TRACE_MODULE_LOAD=1`) and the symptom moved downstream to whatever broke first.

## How

- Every report site in `register_dynamic_module` falls back to `LOG(LogLevel::error)` when there is no context — same channel the function's `trace_module_load` already uses, TextPrinter-backed.
- **The issue's suggested fix (honor `Quiet` in the registrator-missing / build-id branches) is deliberately rejected.** `Quiet` governs *load* failures — expected during folder-scan enumeration, deferred for the fixed-point sibling-dep retry. A broken artifact is unfixable by retry, and silencing it would make a stale-build-id module vanish without a trace during the module scan (every `.das_module` descriptor calls the 2-arg silent overload) — recreating exactly the misleading-`error[20605]` class of swallowed diagnostics. The contract is now pinned in the function-head and enum comments.

## Tests

- `tests-cpp/small/test_register_dynamic_module.cpp` pins the no-crash + nullptr-return properties for all three `on_error` modes with a null context (the Quiet case is the historical segfault), plus the non-Quiet dlopen-failure path.

## Drive-by: exe_paths_module_resolve was passing via PATH leakage

While running the gates, `exe_paths_module_resolve` failed with `0xc0000135` (DLL not found). Root cause: the compiled exe import-links `libDaScriptDyn_runtime.dll`, but no test layout ever shipped it — the test only passed because a since-deleted SDK install on PATH happened to supply the DLL. `run_layouts.cmake` now ships the runtime DLLs next to the exe in every layout (mirroring `daspkg release` step 2.5, which does this for real bundles), so the test validates genuinely self-contained layouts. Note this test only registers when `DAS_LLVM_INCLUDED` is on, so standard CI lanes never caught it.

## Gates

- tests-cpp via ctest: 68/68 (new tests included; exe-paths now hermetic)
- full dastest sweep: 11081/11081
- AOT sweep: 10393/10393
- das2rst: exit 0, zero generated-doc drift
- lint/format/dupe: no `.das` files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)