### PR TITLE
glsl: map atan2 to GLSL atan in the function rename table

### DIFF
--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -258,6 +258,7 @@ let private glsl_functions <- {
     "uint4"    =>  "uvec4",
     "floori"    =>  "floor",
     "lerp"      =>  "mix",
+    "atan2"     =>  "atan",
     "fast_normalize" => "normalize",
     "saturate"  =>  "SATURATE",
     "int_bits_to_float" => "intBitsToFloat",


### PR DESCRIPTION
das math's `atan2(y, x)` is spelled `atan(y, x)` in GLSL (same argument order and semantics); without the mapping, a transpiled shader calling `atan2` emits the name verbatim and fails GLSL compilation at runtime (`Use of undeclared identifier 'atan2'`). One more entry in `glsl_functions`, same class as `floori`→`floor` and `lerp`→`mix`.

Hit in practice by a fragment shader computing a polar angle from a 2D vector; verified live (shader compiles and renders correctly with the mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)