### PR TITLE
jit: join the completion status before leaving run_parallel

### DIFF
--- a/utils/jit/main.das
+++ b/utils/jit/main.das
@@ -235,6 +235,9 @@ def run_parallel(files : array<string>; tool : JitToolArgs; jit : JitCliOptions)
                         rc = 1
                     }
                 }
+                // the drain loop only proves all results were pushed; without this join
+                // a straggler worker races the guard ("deleted while being used (ref=1)")
+                completion |> join()
             }
         }
     }


### PR DESCRIPTION
One-line race fix in jit.exe's parallel dispatcher, root cause of the `synch primitive deleted while being used (ref=1)` trap (exit 133) seen on the linux Release "Prewarm JIT cache" step of #3122 (a doc-only PR).

`run_parallel` was modeled on dastest's isolated-mode worker pool but dropped the final `completion |> join()` (dastest.das:743). Without it, draining the output channel is the only synchronization main has: the last worker's final `outputChannel |> notify()` lets main exit the `with_job_status` block while that worker is still between the notify and its `completion |> notify_and_release()` — the `AddReleaseGuard` then throws with ref=1 and the process traps. The window is a few instructions wide, hence the flaky look.

The join is sufficient: `NotifyAndRelease` drops the worker's ref before waking the waiter under one mutex, and each worker releases both channels before notifying completion, so the outer `with_channel` guards are covered too. Every other `with_job_status` dispatcher in the tree already joins (dastest, parallel_workers, dasfmt, `with_wait_group`, pathTracer); jit was the lone outlier.

Validated by rebuilding jit.exe and running the parallel path on tests/algorithm (3 workers) and tests/json (14 workers) — clean exits, no guard throw. Lint and formatter verify clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)