### PR TITLE
tutorials: stale-comment + panic-model fixes (audit followup)

### DIFF
--- a/doc/source/reference/tutorials/21_error_handling.rst
+++ b/doc/source/reference/tutorials/21_error_handling.rst
@@ -38,6 +38,15 @@ general exception handling — only panics are caught::
       print("recovered from panic\n")
   }
 
+.. note::
+
+   Execution resumes after the ``try``/``recover`` block, but a panic means
+   the program reached a broken state. Use ``recover`` to capture the failure
+   (log it, report it) before deciding to stop — **not** as resumable
+   exception handling and not for soft, expected errors. For those, return a
+   status value instead — see :ref:`tutorial_option_and_result`. (Consistent
+   with this, a ``finally`` block is skipped when its body panics.)
+
 assert and verify
 =================
 

--- a/tutorials/dasStbImage/03_transforms.das
+++ b/tutorials/dasStbImage/03_transforms.das
@@ -57,7 +57,8 @@ def print_img(lbl : string; img : Image) {
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Image.resize(new_w, new_h) returns a new resized Image using the
-// default filter (Catmull-Rom). You can also specify a filter explicitly.
+// default filter (Catmull-Rom when upscaling, Mitchell when downscaling).
+// You can also specify a filter explicitly.
 
 def example_resize() {
     var inscope img <- make_gradient(64, 64)

--- a/tutorials/integration/c/03_binding_types.c
+++ b/tutorials/integration/c/03_binding_types.c
@@ -85,8 +85,8 @@ das_module * register_module_tutorial_c_03(void) {
     das_module_bind_alias(mod, lib, "IntArray", "1<i>A");
 
     // --- Enumeration ---
-    // The third argument to das_enumeration_make is the underlying int type:
-    //   0 = int8, 1 = int (32-bit), 2 = int16.
+    // The third argument ('ext') is a boolean: non-zero = int64 underlying
+    // storage, zero = int.  We pass 1 here, so Color is int64-backed.
     das_enumeration * en = das_enumeration_make("Color", "Color", 1);
     das_enumeration_add_value(en, "red",   "Color_red",   Color_red);
     das_enumeration_add_value(en, "green", "Color_green", Color_green);

--- a/tutorials/language/30_json.das
+++ b/tutorials/language/30_json.das
@@ -341,7 +341,7 @@ def tuples_and_variants() {
     let s = Shape(circle = 5.0)
     var js_s = JV(s)
     print("variant: {write_json(js_s)}\n")
-    // output: variant: {"circle":5}
+    // output: variant: {"$variant":0,"circle":5}   ($variant is the active-field index)
 }
 
 // === Vector types ===


### PR DESCRIPTION
Tier-C quick-win followup to the tutorial gap audit (#3125): four small, low-risk fixes that the audit flagged but were out of scope for the main PR (source-file comments and one doc note). Each claim was verified against source before editing.

## Changes

| File | Fix | Verified against |
|---|---|---|
| `tutorials/language/30_json.das` | Variant output comment was missing the `$variant` discriminator — actual output is `{"$variant":0,"circle":5}` | ran the tutorial |
| `tutorials/dasStbImage/03_transforms.das` | Default resize filter is **Catmull-Rom only when upscaling, Mitchell when downscaling** (the tutorial's `resize(16,16)` downsamples a 64×64, so it actually uses Mitchell) | `stb_image_resize2.h` 846-852 + filter resolution at 6578 |
| `tutorials/integration/c/03_binding_types.c` | `das_enumeration_make`'s third arg is the boolean `ext` (non-zero = `int64` storage), **not** a `0=int8/1=int32/2=int16` selector | `include/daScript/daScriptC.h:382` |
| `doc/source/reference/tutorials/21_error_handling.rst` | Added a note: `try`/`recover` resumes mechanically, but a panic means a broken program — `recover` is for diagnostics-before-exit, not soft-error recovery; soft errors → `Option`/`Result` | CLAUDE.md panic model; probe-confirmed control flow |

## Not changed (audit over-flag)

The audit also flagged `09_aot.c`'s `daslang.exe -aot script.das script.das.cpp` line as wrong. It isn't — that direct form is valid (`utils/daScript/main.cpp:510-515` routes `argv[1] == "-aot"` to `das_aot_main`). The RST shows the alternate `utils/aot/main.das -- -aot ...` form; both work. Left as-is.

## Verification

`preflight --only format,lint,docs` — **8 passed, 0 failed** (both `sphinx-html` and `sphinx-latex` with `-W`; only `pdflatex` skipped — no local TeX). The two `.das` edits are comment-only; the `.c` edit is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)