### PR TITLE
tutorials: convert 5 verbatim code blocks to literalinclude (drift-proofing)

### DIFF
--- a/doc/source/reference/tutorials/32_operator_overloading.rst
+++ b/doc/source/reference/tutorials/32_operator_overloading.rst
@@ -24,32 +24,9 @@ Overload ``+``, ``-``, ``*``, ``/``, ``%`` to give your types arithmetic
 behaviour. Each operator is a binary function that takes two values and returns
 a result:
 
-.. code-block:: das
-
-    struct Vec2 {
-        x : float
-        y : float
-    }
-
-    def operator +(a, b : Vec2) : Vec2 {
-        return Vec2(x = a.x + b.x, y = a.y + b.y)
-    }
-
-    def operator -(a, b : Vec2) : Vec2 {
-        return Vec2(x = a.x - b.x, y = a.y - b.y)
-    }
-
-    def operator *(a : Vec2; s : float) : Vec2 {
-        return Vec2(x = a.x * s, y = a.y * s)
-    }
-
-    def operator *(s : float; a : Vec2) : Vec2 {
-        return a * s
-    }
-
-    def operator /(a : Vec2; s : float) : Vec2 {
-        return Vec2(x = a.x / s, y = a.y / s)
-    }
+.. literalinclude:: ../../../../tutorials/language/32_operator_overloading.das
+   :language: das
+   :lines: 27-50
 
 Usage::
 
@@ -122,22 +99,9 @@ Overload ``+=``, ``-=``, ``*=``, ``/=``, ``%=``, ``&=``, ``|=``, ``^=``,
 ``<<=``, ``>>=`` and others for in-place modification. The first argument must
 be ``var ... &`` (mutable reference):
 
-.. code-block:: das
-
-    def operator +=(var a : Vec2&; b : Vec2) {
-        a.x += b.x
-        a.y += b.y
-    }
-
-    def operator -=(var a : Vec2&; b : Vec2) {
-        a.x -= b.x
-        a.y -= b.y
-    }
-
-    def operator *=(var a : Vec2&; s : float) {
-        a.x *= s
-        a.y *= s
-    }
+.. literalinclude:: ../../../../tutorials/language/32_operator_overloading.das
+   :language: das
+   :lines: 145-158
 
 Usage::
 

--- a/doc/source/reference/tutorials/47_data_walker.rst
+++ b/doc/source/reference/tutorials/47_data_walker.rst
@@ -35,22 +35,9 @@ A ``DapiDataWalker`` subclass overrides only the callbacks you need.
 All 87 methods default to no-ops, so a minimal walker that prints
 integers, floats, strings, and booleans is very small:
 
-.. code-block:: das
-
-    class ScalarPrinter : DapiDataWalker {
-        def override Int(var value : int&) : void {
-            print("  int: {value}\n")
-        }
-        def override Float(var value : float&) : void {
-            print("  float: {value}\n")
-        }
-        def override String(var value : string&) : void {
-            print("  string: \"{value}\"\n")
-        }
-        def override Bool(var value : bool&) : void {
-            print("  bool: {value}\n")
-        }
-    }
+.. literalinclude:: ../../../../tutorials/language/47_data_walker.das
+   :language: das
+   :lines: 41-54
 
 To walk a value, create the walker, wrap it with ``make_data_walker``,
 then call ``walk_data`` with a pointer and ``TypeInfo``:
@@ -375,21 +362,9 @@ Mutating data in-place
 Scalar callbacks receive ``var value : T&`` — a mutable reference.
 This means the walker can modify data during traversal:
 
-.. code-block:: das
-
-    class FloatClamper : DapiDataWalker {
-        lo : float = 0.0
-        hi : float = 1.0
-
-        def override Float(var value : float&) : void {
-            if (value < lo) {
-                value = lo
-            }
-            if (value > hi) {
-                value = hi
-            }
-        }
-    }
+.. literalinclude:: ../../../../tutorials/language/47_data_walker.das
+   :language: das
+   :lines: 767-779
 
 Walking a ``Particle`` with out-of-range floats clamps them to
 ``[0..1]``:

--- a/doc/source/reference/tutorials/macros/19_add_module_option.rst
+++ b/doc/source/reference/tutorials/macros/19_add_module_option.rst
@@ -89,22 +89,9 @@ The usage file
 
 Full source: :download:`19_add_module_option.das <../../../../../tutorials/macros/19_add_module_option.das>`
 
-.. code-block:: das
-
-    require add_module_option_mod
-    options trace_compile = true
-
-    def greet(name : string) {
-        print("Hello, {name}!\n")
-    }
-
-    def add(a, b : int) : int => a + b
-
-    [export]
-    def main() {
-        greet("world")
-        print("2 + 3 = {add(2, 3)}\n")
-    }
+.. literalinclude:: ../../../../../tutorials/macros/19_add_module_option.das
+   :language: das
+   :lines: 23-36
 
 The ``options trace_compile = true`` line is accepted only because
 ``add_module_option_mod`` registered the name — without the ``require``, the


### PR DESCRIPTION
High-value-only `literalinclude` sweep — followup to the tutorial gap audit (#3125, #3126).

## What this is

Hand-copied RST code blocks were the root cause of nearly every factual bug #3125 fixed (fabricated APIs, wrong fields, stale outputs). The fix for *that* class of bug is `literalinclude`, which auto-syncs a block from its source so it can't drift.

A fan-out pass examined **all ~214 tutorial RST files** against their paired `.das`/`.cpp`/`.c` sources, looking for blocks that are byte-verbatim copies of a contiguous source region (≥10 lines) — the only kind that can be safely auto-synced.

## The finding

**Only 5 blocks across 3 files qualified.** Tutorial RST code is almost universally *curated*, not copied — cleaner formatting, fewer comments, simplified bodies, `<|` block style vs the source's trailing-block form, or aggregating non-contiguous functions. Those are deliberate pedagogy and must stay hand-copied (per the agreed scope). So the broad anti-drift win isn't available via `literalinclude` — the recurring fix for tutorial drift is periodic audits like #3125, not includes.

## The 5 conversions (all verified byte-equal to source)

| File | Block | Source `:lines:` |
|---|---|---|
| `32_operator_overloading.rst` | `Vec2` + arithmetic operators | 27-50 |
| `32_operator_overloading.rst` | compound-assignment operators | 145-158 |
| `47_data_walker.rst` | `ScalarPrinter` walker | 41-54 |
| `47_data_walker.rst` | `FloatClamper` walker | 767-779 |
| `macros/19_add_module_option.rst` | usage file | 23-36 |

These are large, genuinely-verbatim blocks → future-proofed against drift.

## Verification

`preflight --only docs` — **6 passed, 0 failed** (both `sphinx-html` and `sphinx-latex` with `-W`; `pdflatex` skipped — no local TeX). Each `:lines:` range re-read and confirmed byte-equal to the block it replaced. RST-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)