### PR TITLE
tutorials: Tier-A binding-module tutorials (dasStbImage TTF+HDR, dasHV TLS, dasAudio status+global)

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -233,6 +233,7 @@ Run any tutorial from the project root::
    tutorials/dasHV_05_cookies_and_forms.rst
    tutorials/dasHV_06_websockets.rst
    tutorials/dasHV_07_sse_and_streaming.rst
+   tutorials/dasHV_08_https_wss.rst
 
 .. _tutorials_dasopenai:
 
@@ -306,6 +307,8 @@ Run any tutorial from the project root::
    tutorials/dasStbImage_03_transforms.rst
    tutorials/dasStbImage_04_pixel_access_and_conversion.rst
    tutorials/dasStbImage_05_drawing_and_blending.rst
+   tutorials/dasStbImage_06_truetype_fonts.rst
+   tutorials/dasStbImage_07_hdr.rst
 
 .. _tutorials_sql:
 
@@ -393,6 +396,8 @@ Run any tutorial from the project root::
    tutorials/dasAudio_06_streaming.rst
    tutorials/dasAudio_07_wav_io.rst
    tutorials/dasAudio_08_midi.rst
+   tutorials/dasAudio_09_playback_status.rst
+   tutorials/dasAudio_10_global_controls.rst
 
 .. _tutorials_dastrudel:
 

--- a/doc/source/reference/tutorials/dasAudio_08_midi.rst
+++ b/doc/source/reference/tutorials/dasAudio_08_midi.rst
@@ -136,3 +136,5 @@ direction over 3 seconds.
    Full source: :download:`tutorials/dasAudio/08_midi.das <../../../../tutorials/dasAudio/08_midi.das>`
 
    Audio module reference: :ref:`stdlib_audio`
+
+   Next tutorial: :ref:`tutorial_dasAudio_playback_status`

--- a/doc/source/reference/tutorials/dasAudio_09_playback_status.rst
+++ b/doc/source/reference/tutorials/dasAudio_09_playback_status.rst
@@ -1,0 +1,85 @@
+.. _tutorial_dasAudio_playback_status:
+
+==================================
+AUDIO-09 — Playback Status
+==================================
+
+.. index::
+    single: Tutorial; Playback Status
+    single: Tutorial; AudioChannelStatus
+    single: Tutorial; set_status_update
+    single: Tutorial; dasAudio
+
+This tutorial covers monitoring a playing sound. Audio runs on its own thread,
+so status is published through a ``LockBox``: the audio thread writes a snapshot
+each mix, and the main thread reads it on demand. This is how you detect when a
+one-shot sound has finished, or how full a streaming queue is.
+
+Registering a Status Box
+========================
+
+Create a ``LockBox`` with ``lock_box_create`` and attach it to a sound with
+``set_status_update``. The call seeds the box with state ``starting``; the audio
+thread updates it from then on:
+
+.. code-block:: das
+
+   require audio/audio_boost
+   require daslib/jobque_boost
+
+   let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
+   var status_box <- lock_box_create()
+   set_status_update(sid, status_box)
+
+Reading the Snapshot
+====================
+
+Read the current ``AudioChannelStatus`` with ``box |> get()`` — a read-only peek
+that keeps the box alive across reads (do not use ``grab``, which is a one-shot
+consume). The snapshot carries the playback state, frame positions, and the
+streaming queue depth:
+
+.. code-block:: das
+
+   status_box |> get() $(s : AudioChannelStatus#) {
+       // s.state              : AudioChannelState
+       // s.playback_position  : frames played
+       // s.consumed_position  : frames of real audio consumed
+       // s.stream_que_length  : pending PCM chunks (for streaming sounds)
+   }
+
+``AudioChannelState`` is ``starting`` → ``playing`` → ``stopped`` (with
+``stopping`` during a fade-out and ``paused`` while paused). Polling the box lets
+you watch a one-shot sound run to completion:
+
+.. code-block:: das
+
+   var done = false
+   for (i in range(100)) {
+       status_box |> get() $(s : AudioChannelStatus#) {
+           done = s.state == AudioChannelState.stopped
+       }
+       break if (done)
+       sleep(20u)
+   }
+
+Releasing the Box
+=================
+
+Order matters — stop the updates, clear the stored value, join, then remove the
+box, or the ``LockBox`` leaks:
+
+.. code-block:: das
+
+   unset_status_update(sid)
+   clear_status(status_box)
+   status_box |> join()
+   unsafe(lock_box_remove(status_box))
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasAudio/09_playback_status.das <../../../../tutorials/dasAudio/09_playback_status.das>`
+
+   Previous tutorial: :ref:`tutorial_dasAudio_midi`
+
+   Next tutorial: :ref:`tutorial_dasAudio_global_controls`

--- a/doc/source/reference/tutorials/dasAudio_10_global_controls.rst
+++ b/doc/source/reference/tutorials/dasAudio_10_global_controls.rst
@@ -1,0 +1,64 @@
+.. _tutorial_dasAudio_global_controls:
+
+==================================
+AUDIO-10 — Global Controls
+==================================
+
+.. index::
+    single: Tutorial; Global Volume
+    single: Tutorial; set_global_volume
+    single: Tutorial; set_global_pause
+    single: Tutorial; dasAudio
+
+This tutorial covers the master controls that affect **every** playing sound at
+once, rather than a single channel. They are independent of each sound's own
+``set_volume`` / ``set_pitch`` / ``set_pause`` (see :ref:`tutorial_dasAudio_sound_control`).
+
+Master Volume
+=============
+
+``set_global_volume`` multiplies the final mix — it scales all sounds together.
+Reach for it on focus loss to duck the whole game without touching individual
+channels:
+
+.. code-block:: das
+
+   set_global_volume(0.3)   // everything quieter
+   set_global_volume(1.0)   // restored
+
+Master Pitch
+============
+
+``set_global_pitch`` multiplies the playback rate of every sound — a one-call
+slow-motion (``0.5``) or fast-forward (``2.0``) effect:
+
+.. code-block:: das
+
+   set_global_pitch(0.5)    // an octave down, slow motion
+   set_global_pitch(1.0)    // normal
+
+Master Pause
+============
+
+``set_global_pause(true)`` freezes the entire mixer; ``(false)`` resumes it, and
+each sound continues exactly where it left off — ideal for a pause menu:
+
+.. code-block:: das
+
+   set_global_pause(true)   // silence
+   set_global_pause(false)  // resume
+
+Because these act on the whole mixer, two looping tones started together both
+respond to a single global call — no need to enumerate channels.
+
+.. note::
+
+   ``set_ignore_global_volume(sid, true)`` exempts one channel from the master
+   volume — useful for an editor preview that should stay audible while the
+   game's master volume is muted.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasAudio/10_global_controls.das <../../../../tutorials/dasAudio/10_global_controls.das>`
+
+   Previous tutorial: :ref:`tutorial_dasAudio_playback_status`

--- a/doc/source/reference/tutorials/dasHV_07_sse_and_streaming.rst
+++ b/doc/source/reference/tutorials/dasHV_07_sse_and_streaming.rst
@@ -241,3 +241,5 @@ Quick Reference
    Full source: :download:`tutorials/dasHV/07_sse_and_streaming.das <../../../../tutorials/dasHV/07_sse_and_streaming.das>`
 
    Previous tutorial: :ref:`tutorial_dasHV_websockets`
+
+   Next tutorial: :ref:`tutorial_dasHV_https_wss`

--- a/doc/source/reference/tutorials/dasHV_08_https_wss.rst
+++ b/doc/source/reference/tutorials/dasHV_08_https_wss.rst
@@ -1,0 +1,83 @@
+.. _tutorial_dasHV_https_wss:
+
+=================================
+HV-08 — HTTPS and WSS (TLS)
+=================================
+
+.. index::
+    single: Tutorial; HTTPS
+    single: Tutorial; TLS
+    single: Tutorial; WSS
+    single: Tutorial; init_wss
+    single: Tutorial; dasHV
+
+This tutorial covers serving over TLS. A server created with ``init_wss``
+listens on both a plain HTTP port and an HTTPS port, using a certificate and
+private key on disk. The same route handlers serve both.
+
+Prerequisites: :ref:`tutorial_dasHV_http_server`.
+
+Starting a TLS Server
+=====================
+
+Where a plain server calls ``init(port)``, a TLS server calls
+``init_wss(port, httpsPort)``. The server then accepts plain HTTP on ``port``
+and TLS on ``httpsPort``; the route API is unchanged:
+
+.. code-block:: das
+
+   class TutorialTlsServer : HvWebServer {
+       def override onInit {
+           GET("/secure") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+               return resp |> TEXT_PLAIN("secure hello over TLS")
+           }
+       }
+   }
+
+   var server = new TutorialTlsServer()
+   server->init_wss(18091, 18443)   // HTTP on 18091, HTTPS on 18443
+   server->start()
+
+The Certificate
+===============
+
+``init_wss`` takes an optional third argument — the directory holding
+``server.crt`` and ``server.key``. When omitted it defaults to
+``modules/dasHV/cert``, a self-signed pair that ships with dasHV:
+
+.. code-block:: das
+
+   server->init_wss(18091, 18443)                 // default cert dir
+   server->init_wss(18091, 18443, "/path/certs")  // your own crt/key
+
+TLS requires that dasHV was built with OpenSSL (the build enables it by
+default). If the certificate files cannot be loaded, ``init_wss`` reports an
+error naming the expected ``server.crt`` / ``server.key`` paths.
+
+Making an HTTPS Request
+=======================
+
+The client follows the ``https://`` scheme and negotiates TLS automatically.
+The bundled certificate is self-signed, which the local client accepts:
+
+.. code-block:: das
+
+   GET("https://127.0.0.1:18443/secure") $(resp) {
+       assert(resp.status_code == http_status.OK)
+       // resp.body == "secure hello over TLS"
+   }
+
+The same threaded server-lifecycle helper from :ref:`tutorial_dasHV_http_server`
+works unchanged — only ``init`` becomes ``init_wss`` and the client URL becomes
+``https://``.
+
+.. note::
+
+   ``init_wss`` also enables secure WebSockets (``wss://``) on the TLS port for
+   any WebSocket routes the server registers (see :ref:`tutorial_dasHV_websockets`).
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasHV/08_https_wss.das <../../../../tutorials/dasHV/08_https_wss.das>`
+
+   Previous tutorial: :ref:`tutorial_dasHV_sse_and_streaming`

--- a/doc/source/reference/tutorials/dasStbImage_05_drawing_and_blending.rst
+++ b/doc/source/reference/tutorials/dasStbImage_05_drawing_and_blending.rst
@@ -108,3 +108,5 @@ is a common pattern in UI rendering:
    Full source: :download:`tutorials/dasStbImage/05_drawing_and_blending.das <../../../../tutorials/dasStbImage/05_drawing_and_blending.das>`
 
    Previous tutorial: :ref:`tutorial_dasStbImage_pixel_access`
+
+   Next tutorial: :ref:`tutorial_dasStbImage_truetype_fonts`

--- a/doc/source/reference/tutorials/dasStbImage_06_truetype_fonts.rst
+++ b/doc/source/reference/tutorials/dasStbImage_06_truetype_fonts.rst
@@ -1,0 +1,107 @@
+.. _tutorial_dasStbImage_truetype_fonts:
+
+==================================
+STBIMAGE-06 — TrueType Fonts
+==================================
+
+.. index::
+    single: Tutorial; TrueType
+    single: Tutorial; load_ttf
+    single: Tutorial; render_text
+    single: Tutorial; dasStbImage
+
+This tutorial covers the ``stbimage_ttf`` module — loading a TrueType
+(``.ttf``) font, querying metrics, rasterizing glyphs, and rendering text
+onto an image with software alpha blending.
+
+Loading a Font
+==============
+
+``load_ttf`` reads a ``.ttf`` file and packs a range of glyphs (by default
+ASCII 32..127) into a 1-channel atlas bitmap stored on the returned ``Font``.
+The ``DroidSansMono`` font ships with dasStbImage; resolve its path through
+``get_das_root()`` so the tutorial runs from any working directory:
+
+.. code-block:: das
+
+   require stbimage/stbimage_boost
+   require stbimage/stbimage_ttf
+
+   let font_file = "{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf"
+   var font <- load_ttf(font_file, [pixel_height = 32.0])
+   assert(is_valid(font))
+   // font.bitmap is the packed atlas; font.char_range is (first_char, num_chars)
+
+Use ``load_font`` instead when you only need metrics or glyph shapes and no
+atlas.
+
+Font Metrics
+============
+
+``font_metrics`` returns ascent, descent, and line height in **pixels** at the
+font's loaded ``pixel_height``. ``font_vmetrics`` returns the same values in raw
+**font units** (before scaling):
+
+.. code-block:: das
+
+   let m = font_metrics(font)
+   // m.ascent, m.descent (negative), m.line_height  — all in pixels
+
+   let vm = font_vmetrics(font)
+   // vm.ascent, vm.descent, vm.line_gap  — in font units
+
+Per-Glyph Metrics and Measuring Text
+====================================
+
+``codepoint_hmetrics`` gives one glyph's advance width and left side bearing
+(in font units). ``measure_text`` sums advances to return a pixel width:
+
+.. code-block:: das
+
+   let hm = codepoint_hmetrics(font, 'A')
+   // hm.advance_width, hm.left_side_bearing
+
+   let width = measure_text(font, "Hello", 32.0)   // pixels
+
+Rasterizing a Single Glyph
+==========================
+
+``codepoint_bitmap`` renders one glyph to a 1-channel (alpha) ``Image`` at a
+scale computed from the desired pixel height, together with a pixel offset from
+the origin:
+
+.. code-block:: das
+
+   let scale = scale_for_pixel_height(font, 32.0)
+   var bm = codepoint_bitmap(font, 'A', scale, scale)
+   // bm.image is 1-channel uint8; bm.offset is the int2 pixel offset
+   bm.image |> with_pixels() $(var px : array<uint8>#) {
+       // px[i] is the coverage/alpha of pixel i
+   }
+
+Rendering Text onto a Canvas
+============================
+
+``render_text`` blits the packed atlas glyphs onto a 4-channel RGBA ``Image``
+at a baseline origin, in the given ``(r, g, b)`` color. Coordinates are clipped
+to the destination bounds automatically:
+
+.. code-block:: das
+
+   var canvas = make_image(256, 64, 4)
+   canvas.fill_rect(0, 0, 256, 64, 0xFFFFFFFFu)      // white background
+   let m = font_metrics(font)
+   render_text(canvas, font, "Hello, daslang!", 8, int(m.ascent) + 8, 0, 0, 0)
+   let (ok, err) = canvas.save("text.png")
+
+``render_text`` is built on ``blit_alpha`` (see
+:ref:`tutorial_dasStbImage_drawing_and_blending`): the font atlas is a 1-channel
+coverage image, and each glyph is alpha-blended onto the canvas.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasStbImage/06_truetype_fonts.das <../../../../tutorials/dasStbImage/06_truetype_fonts.das>`
+
+   Previous tutorial: :ref:`tutorial_dasStbImage_drawing_and_blending`
+
+   Next tutorial: :ref:`tutorial_dasStbImage_hdr`

--- a/doc/source/reference/tutorials/dasStbImage_07_hdr.rst
+++ b/doc/source/reference/tutorials/dasStbImage_07_hdr.rst
@@ -1,0 +1,79 @@
+.. _tutorial_dasStbImage_hdr:
+
+==================================
+STBIMAGE-07 — HDR Images
+==================================
+
+.. index::
+    single: Tutorial; HDR
+    single: Tutorial; load_hdr
+    single: Tutorial; float pixels
+    single: Tutorial; dasStbImage
+
+This tutorial covers high-dynamic-range images: float pixel buffers whose
+values are not clamped to ``[0, 1]``, saved and loaded through the Radiance
+``.hdr`` format.
+
+Creating a Float Image
+======================
+
+HDR images store float pixels (``bpc = 4``), so a channel can be brighter than
+full white. ``make_image(w, h, channels, 4)`` allocates the float buffer; the
+float overload of ``with_pixels`` exposes it as ``array<float>#``:
+
+.. code-block:: das
+
+   require stbimage/stbimage_boost
+
+   var img = make_image(32, 32, 3, 4)
+   img |> with_pixels() $(var px : array<float>#) {
+       for (i in range(32 * 32)) {
+           px[i * 3 + 0] = 2.5        // red brighter than full white
+           px[i * 3 + 1] = 1.0
+           px[i * 3 + 2] = 0.5
+       }
+   }
+
+Saving and Loading
+==================
+
+``save()`` selects the encoder from the file extension; ``.hdr`` writes
+Radiance RGBE. ``load_hdr()`` reads it back as float and sets ``bpc = 4``.
+``is_hdr()`` reports whether a file on disk is HDR:
+
+.. code-block:: das
+
+   let (ok, err) = img.save("out.hdr")
+   let detected = is_hdr("out.hdr")        // true
+
+   var reloaded : Image
+   let (ok2, err2) = reloaded.load_hdr("out.hdr")
+   // reloaded.bpc == 4, reloaded.channels == 3
+
+Round-Trip Accuracy
+===================
+
+Radiance ``.hdr`` is RGBE: an 8-bit mantissa per channel plus one **shared**
+exponent. It is therefore slightly lossy — per-channel precision is about
+``max_channel / 256`` — but HDR magnitudes (values above ``1.0``) survive:
+
+.. code-block:: das
+
+   var maxerr = 0.0
+   img |> with_pixels() $(var a : array<float>#) {
+       reloaded |> with_pixels() $(var b : array<float>#) {
+           for (i in range(length(a))) {
+               maxerr = max(maxerr, abs(a[i] - b[i]))
+           }
+       }
+   }
+   // maxerr stays within the RGBE tolerance
+
+Values that are exact multiples of a power of two (like the ``2.5 / 1.0 / 0.5``
+above) reconstruct exactly; arbitrary values pick up a small RGBE rounding error.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasStbImage/07_hdr.das <../../../../tutorials/dasStbImage/07_hdr.das>`
+
+   Previous tutorial: :ref:`tutorial_dasStbImage_truetype_fonts`

--- a/site/algolia/crawler-config.js
+++ b/site/algolia/crawler-config.js
@@ -7,9 +7,28 @@
 // person isn't reverse-engineering it. See README.md in this directory for the
 // reasoning behind the two-action design and the RTD-specific selectors.
 //
+// NOTE: the dashboard editor evaluates a single `new Crawler({...})` expression
+// and rejects comments + sibling top-level declarations (it errors with a JSON
+// parse failure). So this commented mirror is reference-only — when you paste
+// into the dashboard, strip the comments, and do NOT factor logic into a helper
+// function outside the Crawler object (inline it inside the extractor instead).
+//
 // The appId below is the public search ID (also shipped in site/files/docsearch.js).
 // The crawler's admin/write API key is configured separately in the dashboard and
 // is intentionally NOT part of this object.
+//
+// Ranking: pageRank is the FIRST customRanking key (see initialIndexSettings),
+// but docsearch defaults it to 0 on every record, which made desc(weight.pageRank)
+// a dead tiebreaker — ties fell through to level/position and an arbitrary numbered
+// section out-ranked the canonical page (e.g. searching "table" surfaced a tutorial
+// section above the language-reference "Table" page). Action 1's extractor assigns
+// it by URL so the authoritative reference wins textual TIES:
+//   /doc/reference/language/  → 3   canonical concept pages (Array, Table, Structs, …)
+//   …/stdlib/generated/builtin.html → 2   runtime function reference (push, get, length, …)
+//   everything else           → 0   (unchanged default)
+// ast.html (Action 1b) matches no tier (always 0), so it is left untouched.
+// pageRank only reorders results that are otherwise textually tied; it does not
+// override the words/attribute/exact criteria that run before `custom`.
 
 new Crawler({
   appId: "Z88JBBPHHH",
@@ -36,6 +55,7 @@ new Crawler({
     // (empty <dd>) searchable. content is p/li only — never dt (the signatures
     // render as hundreds of syntax-highlight <span>s; pulling that markup into
     // content is what ballooned a 58KB-of-text page into a 349KB record).
+    // The pageRank block at the end assigns the tiers documented in the header.
     {
       indexName: "daslang.io crawler",
       // ast.html is handled by its own signatures-only action below (it has 546
@@ -44,13 +64,13 @@ new Crawler({
         "https://daslang.io/doc/**",
         "!https://daslang.io/doc/stdlib/generated/ast.html",
       ],
-      recordExtractor: ({ helpers, $ }) => {
+      recordExtractor: ({ helpers, $, url }) => {
         // Drop blocks das2rst marked `.. container:: nosearch` (e.g. rtti's
         // 580-value CompilationError enum, which alone blew the per-record size
         // cap): the symbol <dt> + its description stay indexed, only the oversized
         // value/field table is removed. Toggle by symbol name in das2rst.das.
         $(".nosearch").remove();
-        return helpers.docsearch({
+        const records = helpers.docsearch({
           recordProps: {
             lvl0: {
               selectors: ".wy-breadcrumbs li.active",
@@ -76,6 +96,20 @@ new Crawler({
           aggregateContent: true,
           recordVersion: "v3",
         });
+        // pageRank tiers (see header) — canonical pages win textual ties.
+        const p = url.pathname;
+        const pr = p.startsWith("/doc/reference/language/")
+          ? 3
+          : p.endsWith("/stdlib/generated/builtin.html")
+            ? 2
+            : 0;
+        if (pr) {
+          records.forEach((r) => {
+            r.weight = r.weight || {};
+            r.weight.pageRank = pr;
+          });
+        }
+        return records;
       },
     },
     // Action 1b — ast.html ONLY. The AST module exposes 546 public symbols;
@@ -124,7 +158,8 @@ new Crawler({
     // "p, li" catch-all is needed because the landing/downloads/daspkg pages
     // have no <article>/<main>; blog posts use <article>. /doc/** is negated
     // out so doc pages aren't double-processed (a URL matching multiple actions
-    // produces a record from EACH — Algolia crawler semantics).
+    // produces a record from EACH — Algolia crawler semantics). No pageRank tier
+    // matches these URLs.
     {
       indexName: "daslang.io crawler",
       pathsToMatch: ["https://daslang.io/**", "!https://daslang.io/doc/**"],

--- a/tutorials/dasAudio/09_playback_status.das
+++ b/tutorials/dasAudio/09_playback_status.das
@@ -68,6 +68,9 @@ def main() {
 
         assert(saw_read, "status box never produced a reading")
         print("  final observed state: {last_state}\n")
+        // The whole point of the status box is detecting completion — so confirm
+        // the one-shot tone actually ran through to `stopped` (0.3s tone, ~2s window).
+        assert(reached_stopped, "sound never reached the stopped state within the poll window")
 
         // ──────────────────────────────────────────────────────────────────
         // Release the status box. Order matters: stop the updates, clear the

--- a/tutorials/dasAudio/09_playback_status.das
+++ b/tutorials/dasAudio/09_playback_status.das
@@ -1,0 +1,83 @@
+// Tutorial AUDIO-09: Playback Status
+//
+// This tutorial covers:
+//   - Registering a status LockBox with set_status_update
+//   - Reading the AudioChannelStatus snapshot (state, position, queue depth)
+//   - Watching a sound advance through its AudioChannelState lifecycle
+//   - Releasing the status box cleanly (unset_status_update + lock_box_remove)
+//
+// The audio thread publishes a snapshot into a LockBox once per mix; the main
+// thread reads it on demand with `box |> get()`. This is how you detect when a
+// one-shot sound has finished, or how full a streaming queue is.
+//
+// Run: daslang.exe tutorials/dasAudio/09_playback_status.das
+
+options gen2
+options persistent_heap
+options indenting = 4
+
+require audio/audio_boost
+require daslib/jobque_boost
+require daslib/fio
+require math
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helper — a short (non-looping) tone so the sound finishes on its own
+// ──────────────────────────────────────────────────────────────────────────
+
+def generate_short_tone(seconds : float) : array<float> {
+    let n = int(float(MA_SAMPLE_RATE) * seconds)
+    return <- [for (x in range(n)); sin(2.0 * PI * 440.0 * float(x) / float(MA_SAMPLE_RATE))]
+}
+
+[export]
+def main() {
+    print("AUDIO-09: Playback Status\n\n")
+    with_audio_system() {
+        var tone <- generate_short_tone(0.3)
+        let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
+        assert(sid != INVALID_SID, "failed to start sound")
+        print("Playing a 0.3s tone, SID = {sid}\n")
+
+        // ──────────────────────────────────────────────────────────────────
+        // Register a status box. set_status_update seeds it with state
+        // `starting`; the audio thread then updates it as the sound plays.
+        // ──────────────────────────────────────────────────────────────────
+        var status_box <- lock_box_create()
+        set_status_update(sid, status_box)
+
+        // Poll until the sound reports `stopped` (or we time out after ~2s),
+        // printing each state transition we observe.
+        var last_state = AudioChannelState.starting
+        var saw_read = false
+        var reached_stopped = false
+        for (_i in range(100)) {
+            status_box |> get() $(s : AudioChannelStatus#) {
+                saw_read = true
+                if (s.state != last_state) {
+                    print("  state: {s.state}  (position={int(s.playback_position)} frames, queue={s.stream_que_length})\n")
+                    last_state = s.state
+                }
+                if (s.state == AudioChannelState.stopped) {
+                    reached_stopped = true
+                }
+            }
+            break if (reached_stopped)
+            sleep(20u)
+        }
+
+        assert(saw_read, "status box never produced a reading")
+        print("  final observed state: {last_state}\n")
+
+        // ──────────────────────────────────────────────────────────────────
+        // Release the status box. Order matters: stop the updates, clear the
+        // stored value, join, then remove — otherwise the LockBox leaks.
+        // ──────────────────────────────────────────────────────────────────
+        unset_status_update(sid)
+        clear_status(status_box)
+        status_box |> join()
+        unsafe(lock_box_remove(status_box))
+
+        print("\nDone!\n")
+    }
+}

--- a/tutorials/dasAudio/10_global_controls.das
+++ b/tutorials/dasAudio/10_global_controls.das
@@ -1,0 +1,92 @@
+// Tutorial AUDIO-10: Global Controls
+//
+// This tutorial covers the master controls that affect every playing sound at
+// once, rather than a single channel:
+//   - set_global_volume — master volume multiplier
+//   - set_global_pitch  — master playback-rate multiplier
+//   - set_global_pause  — pause/resume the whole mixer
+//
+// These are the controls you reach for on focus loss (duck the master volume),
+// slow-motion effects (global pitch), or a pause menu (global pause) — without
+// touching each sound individually.
+//
+// Run: daslang.exe tutorials/dasAudio/10_global_controls.das
+
+options gen2
+options persistent_heap
+options indenting = 4
+
+require audio/audio_boost
+require daslib/fio
+require math
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helper — a 1-second looping tone at a given frequency
+// ──────────────────────────────────────────────────────────────────────────
+
+def generate_tone(freq : float) : array<float> {
+    return <- [for (x in range(MA_SAMPLE_RATE)); sin(2.0 * PI * freq * float(x) / float(MA_SAMPLE_RATE))]
+}
+
+[export]
+def main() {
+    print("AUDIO-10: Global Controls\n\n")
+    with_audio_system() {
+        // Two looping tones so the GLOBAL effect on every sound is audible.
+        var tone_a <- generate_tone(440.0)
+        var tone_b <- generate_tone(660.0)
+        let sid_a = play_sound_loop_from_pcm(MA_SAMPLE_RATE, 1, tone_a)
+        let sid_b = play_sound_loop_from_pcm(MA_SAMPLE_RATE, 1, tone_b)
+        assert(sid_a != INVALID_SID && sid_b != INVALID_SID, "failed to start tones")
+        print("Two looping tones playing (440 Hz + 660 Hz)\n")
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 1 — Master volume
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // set_global_volume multiplies the final mix. It scales every sound at
+        // once and is independent of each sound's own set_volume.
+
+        print("\n=== Section 1: Global volume ===\n")
+        set_global_volume(0.3)
+        print("  master volume 0.3 (both tones quieter)\n")
+        sleep(1000u)
+        set_global_volume(1.0)
+        print("  master volume 1.0 (restored)\n")
+        sleep(1000u)
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 2 — Master pitch
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // set_global_pitch multiplies playback rate for every sound — useful
+        // for slow-motion (0.5) or fast-forward (2.0) effects.
+
+        print("\n=== Section 2: Global pitch ===\n")
+        set_global_pitch(0.5)
+        print("  global pitch 0.5 (an octave down, slow motion)\n")
+        sleep(1000u)
+        set_global_pitch(1.0)
+        print("  global pitch 1.0 (normal)\n")
+        sleep(1000u)
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 3 — Master pause / resume
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // set_global_pause(true) freezes the whole mixer; (false) resumes it.
+        // Each sound picks up exactly where it left off — ideal for a pause menu.
+
+        print("\n=== Section 3: Global pause ===\n")
+        set_global_pause(true)
+        print("  paused (silence)\n")
+        sleep(1000u)
+        set_global_pause(false)
+        print("  resumed\n")
+        sleep(1000u)
+
+        stop(sid_a)
+        stop(sid_b)
+        print("\nDone!\n")
+    }
+}

--- a/tutorials/dasHV/08_https_wss.das
+++ b/tutorials/dasHV/08_https_wss.das
@@ -107,9 +107,13 @@ def main() {
             print("GET {https_url}/api/info -> {resp.status_code}: {resp.body}\n")
             var err : string
             var parsed = read_json(string(resp.body), err)
-            ok_json = parsed != null
+            // Don't settle for "it's valid JSON" — an error body parses too. Check
+            // the status and the actual fields the /api/info route promises.
+            let scheme = parsed?["scheme"] ?? ""
+            let tls = parsed?["tls"] ?? false
+            ok_json = resp.status_code == http_status.OK && scheme == "https" && tls
         }
-        assert(ok_json, "HTTPS GET /api/info did not return valid JSON")
+        assert(ok_json, "HTTPS GET /api/info did not return the expected scheme=https, tls=true payload")
     }
     print("\nDone.\n")
 }

--- a/tutorials/dasHV/08_https_wss.das
+++ b/tutorials/dasHV/08_https_wss.das
@@ -1,0 +1,115 @@
+// Tutorial HV-08: HTTPS / WSS server with TLS
+//
+// This tutorial covers:
+//   - Starting a TLS server with init_wss(port, httpsPort) instead of init(port)
+//   - The bundled self-signed certificate under modules/dasHV/cert
+//   - Serving the same routes over HTTPS
+//   - Making an HTTPS request from the client
+//
+// Prerequisites: Tutorial HV-03 (HTTP server basics)
+//
+// init_wss starts the server on BOTH a plain HTTP port and a TLS port. The
+// certificate/key default to modules/dasHV/cert (server.crt / server.key),
+// which ship with dasHV — pass a directory to init_wss to use your own.
+//
+// Run: daslang.exe tutorials/dasHV/08_https_wss.das
+
+options gen2
+options persistent_heap
+options gc
+
+require dashv/dashv_boost public
+require daslib/jobque_boost
+require daslib/json_boost
+require daslib/fio
+
+let SERVER_PORT = 18091         // plain HTTP
+let SERVER_HTTPS_PORT = 18443   // TLS
+
+// ──────────────────────────────────────────────────────────────────────────
+// A minimal TLS server — same route API as a plain HvWebServer
+// ──────────────────────────────────────────────────────────────────────────
+
+class TutorialTlsServer : HvWebServer {
+    def override onInit {
+        GET("/secure") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> TEXT_PLAIN("secure hello over TLS")
+        }
+        GET("/api/info") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            let payload = (scheme = "https", tls = true)
+            return resp |> JSON(write_json(JV(payload)))
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Server lifecycle helper — identical to HV-03's, but init_wss for TLS
+// ──────────────────────────────────────────────────────────────────────────
+
+def with_wss_server(port, https_port : int; blk : block<(https_url : string) : void>) {
+    with_job_status(1) $(started) {
+        with_job_status(1) $(finished) {
+            with_atomic32() $(stop_flag) {
+                new_thread() @() {
+                    var server = new TutorialTlsServer()
+                    server->init_wss(port, https_port)   // default cert dir: modules/dasHV/cert
+                    server->start()
+                    started |> notify_and_release
+                    while (stop_flag |> get == 0) {
+                        server->tick()
+                        sleep(10u)
+                    }
+                    server->stop()
+                    server->cleanup()
+                    unsafe {
+                        delete server
+                    }
+                    finished |> notify_and_release
+                }
+                started |> join
+                let https_url = "https://127.0.0.1:{https_port}"
+                invoke(blk, https_url)
+                stop_flag |> set(1)
+                finished |> join
+            }
+        }
+    }
+}
+
+[export]
+def main() {
+    print("HV-08: HTTPS / WSS server with TLS\n\n")
+    with_wss_server(SERVER_PORT, SERVER_HTTPS_PORT) $(https_url) {
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 1 — An HTTPS GET
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // The client follows the https:// scheme and negotiates TLS. The
+        // bundled certificate is self-signed, which the client accepts for
+        // this local test.
+
+        print("=== Section 1: HTTPS GET ===\n")
+        var ok_secure = false
+        GET("{https_url}/secure") $(resp) {
+            print("GET {https_url}/secure -> {resp.status_code}: {resp.body}\n")
+            ok_secure = resp.status_code == http_status.OK && resp.body == "secure hello over TLS"
+        }
+        assert(ok_secure, "HTTPS GET /secure did not return the expected response")
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 2 — A JSON route over HTTPS
+        // ──────────────────────────────────────────────────────────────────
+
+        print("\n=== Section 2: JSON over HTTPS ===\n")
+        var ok_json = false
+        GET("{https_url}/api/info") $(resp) {
+            print("GET {https_url}/api/info -> {resp.status_code}: {resp.body}\n")
+            var err : string
+            var parsed = read_json(string(resp.body), err)
+            ok_json = parsed != null
+        }
+        assert(ok_json, "HTTPS GET /api/info did not return valid JSON")
+    }
+    print("\nDone.\n")
+}

--- a/tutorials/dasStbImage/06_truetype_fonts.das
+++ b/tutorials/dasStbImage/06_truetype_fonts.das
@@ -1,0 +1,150 @@
+// Tutorial STBIMAGE-06: TrueType Fonts
+//
+// This tutorial covers:
+//   - Loading a TrueType (.ttf) font and packing a glyph atlas (load_ttf)
+//   - Querying font metrics (ascent, descent, line height) and per-glyph metrics
+//   - Measuring rendered text width
+//   - Rasterizing a single glyph to a 1-channel bitmap (codepoint_bitmap)
+//   - Rendering text onto an RGBA canvas (render_text) and saving it
+//
+// Run: daslang.exe tutorials/dasStbImage/06_truetype_fonts.das
+
+options gen2
+options indenting = 4
+
+require daslib/fio
+require stbimage/stbimage_boost
+require stbimage/stbimage_ttf
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helper — load the DroidSansMono font bundled with dasStbImage
+// ──────────────────────────────────────────────────────────────────────────
+//
+// load_ttf reads the .ttf and packs a range of glyphs (default ASCII 32..127)
+// into a 1-channel atlas bitmap kept on the Font. Resolve the bundled font via
+// get_das_root() so the tutorial runs from any working directory.
+
+def load_bundled_font(pixel_height : float) : Font {
+    let font_file = "{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf"
+    return <- load_ttf(font_file, [pixel_height = pixel_height])
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Font metrics
+// ──────────────────────────────────────────────────────────────────────────
+//
+// font_metrics returns ascent/descent/line_height in PIXELS at the font's
+// loaded pixel_height. font_vmetrics returns the same in raw font units.
+
+def section_metrics(font : Font) {
+    let m = font_metrics(font)
+    assert(m.ascent > 0.0 && m.line_height > 0.0, "degenerate font metrics")
+    print("  pixels:     ascent={m.ascent}, descent={m.descent}, line_height={m.line_height}\n")
+    let vm = font_vmetrics(font)
+    print("  font units: ascent={vm.ascent}, descent={vm.descent}, line_gap={vm.line_gap}\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Per-glyph metrics and text measurement
+// ──────────────────────────────────────────────────────────────────────────
+//
+// codepoint_hmetrics gives the advance width / left side bearing of one glyph
+// (in font units). measure_text sums advances to get a pixel width.
+
+def section_glyph_metrics(font : Font) {
+    let hm = codepoint_hmetrics(font, 'A')
+    assert(hm.advance_width > 0, "glyph 'A' has no advance")
+    print("  'A': advance_width={hm.advance_width}, left_side_bearing={hm.left_side_bearing} (font units)\n")
+    let width = measure_text(font, "Hello", 32.0)
+    assert(width > 0.0, "measured zero width")
+    print("  measure_text(\"Hello\", 32px) = {width} px\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Rasterizing a single glyph
+// ──────────────────────────────────────────────────────────────────────────
+//
+// codepoint_bitmap renders one glyph to a 1-channel (alpha) Image at a scale
+// computed from the desired pixel height, plus a pixel offset from the origin.
+
+def section_glyph_bitmap(font : Font) {
+    let scale = scale_for_pixel_height(font, 32.0)
+    var bm = codepoint_bitmap(font, 'A', scale, scale)
+    assert(bm.image.channels == 1 && bm.image.bpc == 1, "glyph bitmap should be 1-channel uint8")
+    assert(bm.image.width > 0 && bm.image.height > 0, "glyph bitmap is empty")
+    var inked = 0
+    bm.image |> with_pixels() $(var px : array<uint8>#) {
+        for (p in px) {
+            if (p != uint8(0)) {
+                inked++
+            }
+        }
+    }
+    assert(inked > 0, "glyph 'A' rasterized with no ink")
+    print("  glyph 'A': {bm.image.width}x{bm.image.height} px, offset ({bm.offset.x},{bm.offset.y}), {inked} inked pixels\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — Rendering text onto an RGBA canvas
+// ──────────────────────────────────────────────────────────────────────────
+//
+// render_text blits the packed atlas glyphs onto a 4-channel RGBA Image at a
+// baseline origin, in the given color. We draw black text on a white canvas,
+// confirm some pixels were inked, then save + reload to prove the round-trip.
+
+def section_render_text(font : Font) {
+    let W = 256
+    let H = 64
+    var canvas = make_image(W, H, 4)
+    canvas.fill_rect(0, 0, W, H, 0xFFFFFFFFu)        // white background
+    let m = font_metrics(font)
+    render_text(canvas, font, "Hello, daslang!", 8, int(m.ascent) + 8, 0, 0, 0)
+    var inked = 0
+    canvas |> with_pixels() $(var px : array<uint8>#) {
+        for (i in range(W * H)) {
+            if (px[i * 4] != uint8(255)) {            // R channel no longer white
+                inked++
+            }
+        }
+    }
+    assert(inked > 0, "no text pixels were drawn")
+    print("  rendered text, {inked} inked pixels on a {W}x{H} canvas\n")
+
+    let path = "_tutorial_text.png"
+    let (ok, err) = canvas.save(path)
+    if (!ok) {
+        print("  save error: {err}\n")
+    }
+    assert(ok, "save failed")
+    var inscope reloaded : Image
+    let (ok2, err2) = reloaded.load(path)
+    if (!ok2) {
+        print("  reload error: {err2}\n")
+    }
+    assert(ok2, "reload failed")
+    assert(reloaded.width == W && reloaded.height == H, "round-trip changed dimensions")
+    print("  saved + reloaded {reloaded.width}x{reloaded.height}\n")
+    remove(path)
+}
+
+[export]
+def main() {
+    print("=== Section 0: Loading a font ===\n")
+    let font <- load_bundled_font(32.0)
+    assert(is_valid(font), "failed to load bundled DroidSansMono font")
+    print("  atlas {font.bitmap.width}x{font.bitmap.height}, packed range [{font.char_range.x}..{font.char_range.x + font.char_range.y})\n")
+
+    print("\n=== Section 1: Font metrics ===\n")
+    section_metrics(font)
+
+    print("\n=== Section 2: Per-glyph metrics ===\n")
+    section_glyph_metrics(font)
+
+    print("\n=== Section 3: Rasterizing a glyph ===\n")
+    section_glyph_bitmap(font)
+
+    print("\n=== Section 4: Rendering text ===\n")
+    section_render_text(font)
+
+    print("\nDone.\n")
+}

--- a/tutorials/dasStbImage/07_hdr.das
+++ b/tutorials/dasStbImage/07_hdr.das
@@ -1,0 +1,105 @@
+// Tutorial STBIMAGE-07: HDR Images (float pixels, Radiance .hdr round-trip)
+//
+// This tutorial covers:
+//   - Creating a float-pixel (bpc = 4) image for high dynamic range
+//   - Writing pixel values above 1.0 via the float with_pixels overload
+//   - Saving to Radiance .hdr and reloading with load_hdr
+//   - Detecting HDR files (is_hdr) and verifying the round-trip
+//
+// Run: daslang.exe tutorials/dasStbImage/07_hdr.das
+
+options gen2
+options indenting = 4
+
+require daslib/fio
+require stbimage/stbimage_boost
+require math
+
+[export]
+def main() {
+    let W = 32
+    let H = 32
+    let path = "_tutorial_out.hdr"
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Section 1 — Create a float HDR image
+    // ──────────────────────────────────────────────────────────────────────
+    //
+    // HDR images store float pixels (bpc = 4), so values are not clamped to
+    // [0, 1]: a channel can be brighter than full white. make_image(w, h, ch, 4)
+    // allocates a float buffer; the float overload of with_pixels exposes it.
+
+    print("=== Section 1: Create a float HDR image ===\n")
+    var img = make_image(W, H, 3, 4)
+    img |> with_pixels() $(var px : array<float>#) {
+        for (i in range(W * H)) {
+            px[i * 3 + 0] = 2.5            // red brighter than full white
+            px[i * 3 + 1] = 1.0
+            px[i * 3 + 2] = 0.5
+        }
+        px[0] = 10.0                       // one very bright pixel
+        px[1] = 0.25
+        px[2] = 0.0
+    }
+    print("  created {W}x{H} float image, bpc={img.bpc}, channels={img.channels}\n")
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Section 2 — Save as .hdr and reload
+    // ──────────────────────────────────────────────────────────────────────
+    //
+    // save() picks the encoder from the extension; .hdr writes Radiance RGBE.
+    // load_hdr() reads it back as float and sets bpc = 4.
+
+    print("\n=== Section 2: Save + reload ===\n")
+    let (ok, err) = img.save(path)
+    if (!ok) {
+        print("  save error: {err}\n")
+    }
+    assert(ok, "save .hdr failed")
+    let detected_hdr = is_hdr(path)
+    assert(detected_hdr, "saved file not detected as HDR")
+    var inscope reloaded : Image
+    let (ok2, err2) = reloaded.load_hdr(path)
+    if (!ok2) {
+        print("  load error: {err2}\n")
+    }
+    assert(ok2, "load_hdr failed")
+    assert(reloaded.bpc == 4 && reloaded.channels == 3, "reloaded image is not float RGB")
+    assert(reloaded.width == W && reloaded.height == H, "round-trip changed dimensions")
+    print("  reloaded {reloaded.width}x{reloaded.height}, bpc={reloaded.bpc}, channels={reloaded.channels}\n")
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Section 3 — Verify the round-trip
+    // ──────────────────────────────────────────────────────────────────────
+    //
+    // Radiance .hdr is RGBE: an 8-bit mantissa per channel plus one shared
+    // exponent, so it is slightly lossy — precision is about max_channel / 256.
+    // The reconstructed pixels match within that tolerance, and HDR magnitudes
+    // (values > 1.0) survive.
+
+    print("\n=== Section 3: Round-trip accuracy ===\n")
+    var maxerr = 0.0
+    img |> with_pixels() $(var a : array<float>#) {
+        reloaded |> with_pixels() $(var b : array<float>#) {
+            for (i in range(length(a))) {
+                let e = abs(a[i] - b[i])
+                if (e > maxerr) {
+                    maxerr = e
+                }
+            }
+        }
+    }
+    print("  max per-channel round-trip error: {maxerr}\n")
+    assert(maxerr < 0.05, "round-trip error larger than RGBE tolerance")
+
+    // confirm the bright pixel kept its high dynamic range
+    var bright_r = 0.0
+    reloaded |> with_pixels() $(var b : array<float>#) {
+        bright_r = b[0]
+    }
+    print("  bright pixel red channel after round-trip: {bright_r}\n")
+    assert(bright_r > 1.0, "HDR magnitude was clamped")
+
+    remove(path)
+    print("\nDone.\n")
+}


### PR DESCRIPTION
Five new tutorials closing flagship-feature gaps found in the tutorial gap audit (#3125). Each is self-verifying (assert-based) and runs offline; all five compile-and-run clean locally, and the docs gate (both Sphinx builders with `-W`) is green.

## Tutorials

| File | Covers |
|---|---|
| `dasStbImage/06_truetype_fonts.das` | `load_ttf`, font/glyph metrics, `codepoint_bitmap`, `render_text` onto an RGBA canvas (bundled DroidSansMono) |
| `dasStbImage/07_hdr.das` | float (`bpc=4`) images, `save` `.hdr` / `load_hdr`, RGBE round-trip accuracy |
| `dasHV/08_https_wss.das` | `init_wss` with the bundled self-signed cert + an HTTPS client request |
| `dasAudio/09_playback_status.das` | `set_status_update` + `AudioChannelStatus` via a `LockBox`, state-lifecycle polling, clean release |
| `dasAudio/10_global_controls.das` | `set_global_volume` / `set_global_pitch` / `set_global_pause` |

Each ships a paired RST page under `doc/source/reference/tutorials/`, is added to the toctree in `tutorials.rst`, and chains prev/next links (so HV-07, AUDIO-08, and STBIMAGE-05 each gained a "Next" link).

## Notes

- **dasHV 08** issues a single HTTPS request on purpose — avoids the open Windows 16-POST stall. The client accepts the self-signed cert (libhv `requests` does not verify the peer by default).
- **dasAudio** tutorials can't assert on audible output (no device in CI; tutorials are dry-run-only in CI anyway), so they verify SID validity + observable channel-status transitions.
- Also folds in the version-controlled Algolia `site/algolia/crawler-config.js` mirror — the pageRank ranking tiers were already applied in the dashboard; this keeps the in-repo mirror matching live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)