### PR TITLE
tutorials: dasOPENAI vision, image generation, moderations, completions

### DIFF
--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -260,6 +260,10 @@ Run any tutorial from the project root::
    tutorials/dasOPENAI_05_embeddings_and_models.rst
    tutorials/dasOPENAI_06_audio.rst
    tutorials/dasOPENAI_07_streaming_chat.rst
+   tutorials/dasOPENAI_08_vision.rst
+   tutorials/dasOPENAI_09_image_generation.rst
+   tutorials/dasOPENAI_10_moderations.rst
+   tutorials/dasOPENAI_11_completions.rst
 
 .. _tutorials_daspugixml:
 

--- a/doc/source/reference/tutorials/dasOPENAI_07_streaming_chat.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_07_streaming_chat.rst
@@ -97,3 +97,5 @@ Quick Reference
    Full source: :download:`tutorials/dasOPENAI/07_streaming_chat.das <../../../../tutorials/dasOPENAI/07_streaming_chat.das>`
 
    For the SSE protocol and ``request_cb`` see :ref:`tutorial_dasHV_sse_and_streaming`.
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_vision`

--- a/doc/source/reference/tutorials/dasOPENAI_08_vision.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_08_vision.rst
@@ -1,0 +1,66 @@
+.. _tutorial_dasOPENAI_vision:
+
+=====================================
+OPENAI-08 — Vision (Image Input)
+=====================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Vision
+    single: Tutorial; Multimodal
+
+This tutorial covers multimodal chat — sending an image alongside text. As with
+every dasOPENAI script, the consumer root needs ``options rtti``.
+
+chat_vision
+===========
+
+``chat_vision`` sends one user turn (text + a single image) and returns the
+normal ``ChatResult`` — the assistant's text is in
+``choices[0].message.content``. The image can be an ``http(s)`` URL or a
+``data:`` URL (base64-inlined bytes):
+
+.. code-block:: das
+
+   require openai/openai_vision
+
+   let client = openai_client(base_url)
+   let res = chat_vision(client, "gpt-4o", "What is in this image?",
+       "https://example.com/cat.png", [max_tokens = 100])
+   if (res.ok) {
+       print("{res.response.choices[0].message.content}\n")
+   }
+
+The Multimodal Request Shape
+============================
+
+A vision message can't use the plain ``content : string`` shape — its content is
+an **array of parts** (a text part and an ``image_url`` part). ``vision_request_body``
+builds that JSON, so you can see the wire format or post it yourself:
+
+.. code-block:: das
+
+   let body = vision_request_body("gpt-4o", "Describe this", "https://example.com/cat.png")
+   // {
+   //   "model": "gpt-4o",
+   //   "messages": [{ "role": "user", "content": [
+   //       { "type": "text", "text": "Describe this" },
+   //       { "type": "image_url", "image_url": { "url": "https://example.com/cat.png" } }
+   //   ]}],
+   //   "max_tokens": 300
+   // }
+
+.. note::
+
+   To run against a real vision backend, point ``base_url`` at it. Ollama with a
+   vision model (``ollama run llava``) serves the same ``/chat/completions``
+   shape, so the only change is the URL.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/08_vision.das <../../../../tutorials/dasOPENAI/08_vision.das>`
+
+   Previous tutorial: :ref:`tutorial_dasOPENAI_streaming`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_image_generation`

--- a/doc/source/reference/tutorials/dasOPENAI_09_image_generation.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_09_image_generation.rst
@@ -1,0 +1,61 @@
+.. _tutorial_dasOPENAI_image_generation:
+
+=====================================
+OPENAI-09 — Image Generation
+=====================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Image Generation
+
+This tutorial covers generating images from a text prompt. As with every
+dasOPENAI script, the consumer root needs ``options rtti``.
+
+Building the Request
+====================
+
+Only ``prompt`` is required on ``ImageRequest``; the rest are optional and are
+omitted from the wire payload when unset (``options rtti`` honors ``@optional``):
+
+.. code-block:: das
+
+   require openai/openai_images
+
+   let req = ImageRequest(prompt = "a serene mountain lake at dawn",
+       size = "1024x1024", n = 1, response_format = "url")
+   let res = generate_image(client, req)
+
+Reading the Result
+==================
+
+``generate_image`` returns an ``ImageResult``; when ``ok`` is true,
+``response.data`` holds the generated images. With ``response_format`` ``"url"``
+the bytes live at ``url``; with ``"b64_json"`` they arrive base64-encoded in
+``b64_json``. ``revised_prompt`` is the prompt the model actually used, if it
+rewrote yours:
+
+.. code-block:: das
+
+   if (res.ok) {
+       for (img in res.response.data) {
+           print("url:            {img.url}\n")
+           print("revised prompt: {img.revised_prompt}\n")
+       }
+   } else {
+       print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+   }
+
+.. note::
+
+   The bundled mock returns a canned URL so the tutorial runs offline. To
+   generate real images, point ``base_url`` at a backend whose
+   ``/images/generations`` endpoint is OpenAI-compatible (OpenAI, OpenRouter).
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/09_image_generation.das <../../../../tutorials/dasOPENAI/09_image_generation.das>`
+
+   Previous tutorial: :ref:`tutorial_dasOPENAI_vision`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_moderations`

--- a/doc/source/reference/tutorials/dasOPENAI_10_moderations.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_10_moderations.rst
@@ -1,0 +1,57 @@
+.. _tutorial_dasOPENAI_moderations:
+
+=====================================
+OPENAI-10 — Moderations
+=====================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Moderation
+
+This tutorial covers the content-moderation endpoint — classifying text for
+policy violations. As with every dasOPENAI script, the consumer root needs
+``options rtti``.
+
+Classifying Text
+================
+
+``ModerationRequest`` takes a model and an array of input strings;
+``moderations`` returns one verdict per input in ``response.results``:
+
+.. code-block:: das
+
+   require openai/openai_moderations
+
+   let req = ModerationRequest(model = "text-moderation-latest",
+       input <- ["some text to classify"])
+   let res = moderations(client, req)
+
+Reading the Verdict
+===================
+
+Each ``ModerationCategoryResult`` carries a ``flagged`` boolean plus two tables
+keyed by **category name** (``"violence"``, ``"hate"``, ``"self-harm"``, …) —
+``categories`` (booleans) and ``category_scores`` (confidence in ``[0, 1]``).
+Because they are tables, use safe lookup rather than assuming a key exists:
+
+.. code-block:: das
+
+   for (verdict in res.response.results) {
+       let violence = verdict.category_scores?["violence"] ?? 0.0lf
+       print("flagged={verdict.flagged}, violence score={violence}\n")
+   }
+
+.. note::
+
+   The bundled mock flags any input containing the sentinel ``"flagged-example"``
+   so both outcomes are demonstrable offline; a real backend decides per its
+   model.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/10_moderations.das <../../../../tutorials/dasOPENAI/10_moderations.das>`
+
+   Previous tutorial: :ref:`tutorial_dasOPENAI_image_generation`
+
+   Next tutorial: :ref:`tutorial_dasOPENAI_completions`

--- a/doc/source/reference/tutorials/dasOPENAI_11_completions.rst
+++ b/doc/source/reference/tutorials/dasOPENAI_11_completions.rst
@@ -1,0 +1,48 @@
+.. _tutorial_dasOPENAI_completions:
+
+=====================================
+OPENAI-11 — Legacy Completions
+=====================================
+
+.. index::
+    single: Tutorial; OpenAI
+    single: Tutorial; dasOPENAI
+    single: Tutorial; Completions
+
+This tutorial covers the older (pre-chat) text-completion endpoint. Prefer chat
+(:ref:`tutorial_dasOPENAI_first_chat`) for new code; ``/completions`` exists for
+older models and OpenAI-compatible backends that only expose it. As with every
+dasOPENAI script, the consumer root needs ``options rtti``.
+
+The completions() Call
+======================
+
+``completions`` takes a ``CompletionRequest`` and returns a ``CompletionResult``.
+On success, ``response.choices`` holds the generated text and ``finish_reason``,
+and ``response.usage`` the token accounting:
+
+.. code-block:: das
+
+   require openai/openai_completions
+
+   let req = CompletionRequest(model = "gpt-3.5-turbo-instruct",
+       prompt = "The capital of France is", max_tokens = 16)
+   let res = completions(client, req)
+   if (res.ok) {
+       print("{res.response.choices[0].text}\n")
+   }
+
+The complete() Wrapper
+======================
+
+``complete`` is the one-liner: prompt in, text out (empty string on error):
+
+.. code-block:: das
+
+   let text = complete(client, "gpt-3.5-turbo-instruct", "Once upon a time")
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasOPENAI/11_completions.das <../../../../tutorials/dasOPENAI/11_completions.das>`
+
+   Previous tutorial: :ref:`tutorial_dasOPENAI_moderations`

--- a/tutorials/dasOPENAI/08_vision.das
+++ b/tutorials/dasOPENAI/08_vision.das
@@ -23,7 +23,7 @@ options gc
 require openai/openai_vision
 require tutorial_openai_server
 
-let SERVER_PORT = 18191
+let SERVER_PORT = 18197
 
 // ──────────────────────────────────────────────────────────────────────────
 // Section 1 — chat_vision

--- a/tutorials/dasOPENAI/08_vision.das
+++ b/tutorials/dasOPENAI/08_vision.das
@@ -1,0 +1,66 @@
+// Tutorial OPENAI-08: Vision (image input)
+//
+// This tutorial covers multimodal chat — sending an image alongside text:
+//   - chat_vision: one user turn with text + an image URL
+//   - The multimodal request body (an array of text / image_url parts)
+//   - Reading the assistant's reply (same ChatResult shape as a text chat)
+//
+// Prerequisites: OPENAI-01 (chat basics)
+//
+// Every dasOPENAI script needs `options rtti` — see OPENAI-01.
+//
+// The image can be an http(s) URL or a `data:` URL (base64-inlined bytes). To
+// run against a real vision-capable backend, point base_url at it; Ollama with a
+// vision model (e.g. `ollama run llava`) serves the same /chat/completions shape.
+//
+// Run: daslang.exe tutorials/dasOPENAI/08_vision.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_vision
+require tutorial_openai_server
+
+let SERVER_PORT = 18191
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — chat_vision
+// ──────────────────────────────────────────────────────────────────────────
+//
+// chat_vision sends a single user turn (text + one image) and returns the
+// normal ChatResult — the assistant's text is in choices[0].message.content.
+
+def example_vision(base_url : string) {
+    let client = openai_client(base_url)
+    let res = chat_vision(client, "mock-model", "What is in this image?",
+        "https://example.com/cat.png", [max_tokens = 100])
+    assert(res.ok, "vision request failed")
+    assert(!empty(res.response.choices), "no choices returned")
+    print("vision reply: {res.response.choices[0].message.content}\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — The multimodal request shape
+// ──────────────────────────────────────────────────────────────────────────
+//
+// A vision message can't use the plain `content : string` shape — its content
+// is an ARRAY of parts (a text part and an image_url part). vision_request_body
+// builds that JSON; printing it shows the wire format.
+
+def example_request_shape() {
+    let body = vision_request_body("gpt-4o", "Describe this", "https://example.com/cat.png")
+    print("request body:\n{body}\n")
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        print("=== Section 1: chat_vision ===\n")
+        example_vision(base_url)
+
+        print("\n=== Section 2: request shape ===\n")
+        example_request_shape()
+    }
+}

--- a/tutorials/dasOPENAI/09_image_generation.das
+++ b/tutorials/dasOPENAI/09_image_generation.das
@@ -21,7 +21,7 @@ options gc
 require openai/openai_images
 require tutorial_openai_server
 
-let SERVER_PORT = 18192
+let SERVER_PORT = 18198
 
 [export]
 def main() {

--- a/tutorials/dasOPENAI/09_image_generation.das
+++ b/tutorials/dasOPENAI/09_image_generation.das
@@ -1,0 +1,57 @@
+// Tutorial OPENAI-09: Image Generation
+//
+// This tutorial covers generating images from a text prompt:
+//   - Building an ImageRequest (prompt, size, count, response_format)
+//   - generate_image and the ImageResult / ImageResponse shape
+//   - Reading the returned url / revised_prompt
+//
+// Prerequisites: OPENAI-01 (client + result handling)
+//
+// Every dasOPENAI script needs `options rtti` — see OPENAI-01. To generate real
+// images, point base_url at a backend whose /images/generations endpoint is
+// OpenAI-compatible (e.g. OpenAI or OpenRouter with a key).
+//
+// Run: daslang.exe tutorials/dasOPENAI/09_image_generation.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_images
+require tutorial_openai_server
+
+let SERVER_PORT = 18192
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        let client = openai_client(base_url)
+
+        // ──────────────────────────────────────────────────────────────────
+        // Build the request. Only `prompt` is required; the rest are optional
+        // and are omitted from the wire payload when left unset (thanks to
+        // `options rtti` honoring @optional).
+        // ──────────────────────────────────────────────────────────────────
+        let req = ImageRequest(prompt = "a serene mountain lake at dawn",
+            size = "1024x1024", n = 1, response_format = "url")
+        let res = generate_image(client, req)
+        if (!res.ok) {
+            print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+        }
+        assert(res.ok, "image generation failed")
+        assert(!empty(res.response.data), "no images returned")
+
+        // ──────────────────────────────────────────────────────────────────
+        // Read each generated image. With response_format "url" the bytes live
+        // at `url`; with "b64_json" they arrive base64-encoded in `b64_json`.
+        // `revised_prompt` is the prompt the model actually used, if it rewrote
+        // yours.
+        // ──────────────────────────────────────────────────────────────────
+        for (img in res.response.data) {
+            print("url:            {img.url}\n")
+            print("revised prompt: {img.revised_prompt}\n")
+            assert(!empty(img.url), "image url is empty")
+        }
+    }
+}

--- a/tutorials/dasOPENAI/10_moderations.das
+++ b/tutorials/dasOPENAI/10_moderations.das
@@ -21,7 +21,7 @@ options gc
 require openai/openai_moderations
 require tutorial_openai_server
 
-let SERVER_PORT = 18193
+let SERVER_PORT = 18199
 
 // Classify one string and return whether it was flagged.
 def classify(client : OpenAIClient; text : string) : bool {

--- a/tutorials/dasOPENAI/10_moderations.das
+++ b/tutorials/dasOPENAI/10_moderations.das
@@ -1,0 +1,53 @@
+// Tutorial OPENAI-10: Moderations
+//
+// This tutorial covers the content-moderation endpoint:
+//   - Building a ModerationRequest (model + an array of input strings)
+//   - moderations and the ModerationResult / per-input verdicts
+//   - Reading the `flagged` boolean and the per-category score tables
+//
+// Prerequisites: OPENAI-01 (client + result handling)
+//
+// Every dasOPENAI script needs `options rtti` — see OPENAI-01. The mock flags any
+// input containing the sentinel phrase "flagged-example" so this runs offline;
+// against a real backend the model decides.
+//
+// Run: daslang.exe tutorials/dasOPENAI/10_moderations.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_moderations
+require tutorial_openai_server
+
+let SERVER_PORT = 18193
+
+// Classify one string and return whether it was flagged.
+def classify(client : OpenAIClient; text : string) : bool {
+    let req = ModerationRequest(model = "text-moderation-latest", input <- [text])
+    let res = moderations(client, req)
+    assert(res.ok, "moderation request failed")
+    assert(!empty(res.response.results), "no results returned")
+    // `categories` / `category_scores` are tables keyed by category name, so use
+    // safe lookup (?[] ?? default) rather than assuming a key is present.
+    var flagged = false
+    for (verdict in res.response.results) {
+        flagged = verdict.flagged
+        let violence = verdict.category_scores?["violence"] ?? 0.0lf
+        print("  \"{text}\"\n    flagged={verdict.flagged}, violence score={violence}\n")
+    }
+    return flagged
+}
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        let client = openai_client(base_url)
+        print("=== Moderations ===\n")
+        let clean_flagged = classify(client, "I love sunny days at the park.")
+        let bad_flagged = classify(client, "flagged-example: a violent threat")
+        assert(!clean_flagged, "benign text should not be flagged")
+        assert(bad_flagged, "sentinel text should be flagged")
+    }
+}

--- a/tutorials/dasOPENAI/11_completions.das
+++ b/tutorials/dasOPENAI/11_completions.das
@@ -1,0 +1,63 @@
+// Tutorial OPENAI-11: Legacy Completions
+//
+// This tutorial covers the older (pre-chat) text-completion endpoint:
+//   - Building a CompletionRequest (model + prompt + sampling options)
+//   - completions and the CompletionResult / CompletionResponse shape
+//   - The complete() convenience wrapper (prompt in, text out)
+//
+// Prefer chat (OPENAI-01) for new code; this endpoint exists for older models
+// and OpenAI-compatible backends that only expose /completions.
+//
+// Prerequisites: OPENAI-01 (client + result handling)
+//
+// Every dasOPENAI script needs `options rtti` — see OPENAI-01.
+//
+// Run: daslang.exe tutorials/dasOPENAI/11_completions.das
+
+options gen2
+options rtti
+options persistent_heap
+options gc
+
+require openai/openai_completions
+require tutorial_openai_server
+
+let SERVER_PORT = 18194
+
+[export]
+def main() {
+    with_openai_server(SERVER_PORT) $(base_url) {
+        let client = openai_client(base_url)
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 1 — The full completions() call
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // completions() takes a CompletionRequest and returns a CompletionResult.
+        // On success, response.choices holds the generated text and finish_reason.
+
+        print("=== Section 1: completions ===\n")
+        let req = CompletionRequest(model = "mock-model",
+            prompt = "The capital of France is", max_tokens = 16)
+        let res = completions(client, req)
+        if (!res.ok) {
+            print("error [{res.error.kind}/{res.error.status}]: {res.error.message}\n")
+        }
+        assert(res.ok, "completion failed")
+        assert(!empty(res.response.choices), "no choices returned")
+        print("text:          {res.response.choices[0].text}\n")
+        print("finish_reason: {res.response.choices[0].finish_reason}\n")
+        print("tokens:        {res.response.usage.total_tokens}\n")
+
+        // ──────────────────────────────────────────────────────────────────
+        // Section 2 — The complete() convenience wrapper
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // complete() is a one-liner: prompt in, text out (empty string on error).
+
+        print("\n=== Section 2: complete() ===\n")
+        let text = complete(client, "mock-model", "Once upon a time")
+        print("complete(): {text}\n")
+        assert(!empty(text), "complete() returned empty text")
+    }
+}

--- a/tutorials/dasOPENAI/11_completions.das
+++ b/tutorials/dasOPENAI/11_completions.das
@@ -22,7 +22,7 @@ options gc
 require openai/openai_completions
 require tutorial_openai_server
 
-let SERVER_PORT = 18194
+let SERVER_PORT = 18200
 
 [export]
 def main() {

--- a/tutorials/dasOPENAI/tutorial_openai_server.das
+++ b/tutorials/dasOPENAI/tutorial_openai_server.das
@@ -41,6 +41,8 @@ require openai/openai_chat public
 require openai/openai_embeddings public
 require openai/openai_models public
 require openai/openai_completions public
+require openai/openai_images public
+require openai/openai_moderations public
 
 // ──────────────────────────────────────────────────────────────────────────
 // Canned response builders
@@ -159,6 +161,24 @@ def private mock_completion_json() : string {
     return sprint_json(r, false)
 }
 
+def private mock_image_json() : string {
+    let r = ImageResponse(created = 0,
+        data <- [ImageData(url = "https://mock.local/generated_image.png",
+            revised_prompt = "a serene mountain lake at dawn (mock revised prompt)")])
+    return sprint_json(r, false)
+}
+
+// `flagged` lets the tutorial demonstrate both a clean and a flagged verdict by
+// varying the request text (see the /v1/moderations handler below).
+def private mock_moderation_json(flagged : bool) : string {
+    let violence_score = flagged ? 0.92lf : 0.0008lf
+    let r = ModerationResponse(id = "modr-mock", model = "mock-moderation",
+        results <- [ModerationCategoryResult(flagged = flagged,
+            categories <- {"violence" => flagged, "hate" => false, "self-harm" => false},
+            category_scores <- {"violence" => violence_score, "hate" => 0.0002lf, "self-harm" => 0.0001lf})])
+    return sprint_json(r, false)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Server
 // ──────────────────────────────────────────────────────────────────────────
@@ -201,6 +221,14 @@ class MockOpenAIServer : HvWebServer {
         }
         POST("/v1/completions") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return resp |> JSON(mock_completion_json())
+        }
+        POST("/v1/images/generations") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> JSON(mock_image_json())
+        }
+        POST("/v1/moderations") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            // Flag the verdict when the request text contains a sentinel phrase.
+            let flagged = find(string(req.body), "flagged-example") >= 0
+            return resp |> JSON(mock_moderation_json(flagged))
         }
     }
 }


### PR DESCRIPTION
Four new dasOPENAI tutorials closing flagship-endpoint gaps from the tutorial gap audit (#3125), plus two handlers added to the shared mock server so they self-verify offline. All four compile-and-run clean; docs / format / lint gates green.

## Tutorials

| File | Covers |
|---|---|
| `dasOPENAI/08_vision.das` | `chat_vision` (text + image URL) + the multimodal array-of-parts request shape via `vision_request_body` |
| `dasOPENAI/09_image_generation.das` | `ImageRequest` / `generate_image`, reading `url` / `revised_prompt` |
| `dasOPENAI/10_moderations.das` | `ModerationRequest` / `moderations`, the `flagged` verdict + category-name-keyed score tables (safe `?[]` lookup) |
| `dasOPENAI/11_completions.das` | legacy `/completions` + the `complete()` one-liner |

Each ships a paired RST page, is added to the dasOPENAI toctree, and chains prev/next (OPENAI-07 gained a "Next" link).

## Mock server

`tutorial_openai_server.das` gains `POST /v1/images/generations` and `POST /v1/moderations`, built from the typed `ImageResponse` / `ModerationResponse` structs via `sprint_json` (same wire shape as the real API). The moderation mock flags a sentinel phrase so the tutorial can show **both** a clean and a flagged verdict offline.

Vision and completions reuse the already-mocked `/chat/completions` and `/completions` endpoints, so no new live backend is needed. Each tutorial notes how to point `base_url` at a real backend (e.g. Ollama + `llava` for vision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)