### PR TITLE
tutorials: teach PEG negative lookahead (!rule) in PEG-02; fix dasPEG debug-codegen bug

### DIFF
--- a/doc/source/reference/tutorials/dasPEG_02_calculator.rst
+++ b/doc/source/reference/tutorials/dasPEG_02_calculator.rst
@@ -134,7 +134,10 @@ Negative Lookahead (``!``)
 
 ``!rule`` is the mirror of ``PEEK``: it also consumes **no input**, but the
 match succeeds only when ``rule`` *fails* at this position.  The classic use is
-keyword guarding --- accept an identifier unless it spells a reserved word:
+keyword guarding --- accept an identifier unless it is a reserved word.  Negate
+a ``keyword`` rule that matches a *whole* keyword (the literal up to ``EOF``),
+so the exact words are rejected but identifiers that merely *start* with them
+(``"ifx"``) are still accepted:
 
 .. code-block:: das
 
@@ -142,8 +145,16 @@ keyword guarding --- accept an identifier unless it spells a reserved word:
                   blk : block<(val : string; err : array<ParsingError>) : void>) {
        parse(input) {
            var ident : string
-           rule(!"if", !"then", "{+alpha}" as word, EOF) {
+           rule(!keyword, "{+alpha}" as word, EOF) {
                return word
+           }
+           // a reserved keyword is the whole word: the literal then EOF
+           var keyword : void?
+           rule("if", EOF) {
+               return null
+           }
+           rule("then", EOF) {
+               return null
            }
            var alpha : void?
            rule(set('a'..'z', 'A'..'Z')) {
@@ -152,11 +163,12 @@ keyword guarding --- accept an identifier unless it spells a reserved word:
        }
    }
 
-``!"if"`` and ``!"then"`` reject those keywords before the identifier rule runs,
-so ``"hello"`` parses as an identifier while ``"if"`` and ``"then"`` are
-rejected.  Unlike ``not_set()`` (an inverted character *class* that advances by
-one character --- see :ref:`tutorial_dasPEG_csv_parser`), ``!rule`` is a
-zero-width assertion that can negate *any* rule, not just a character set.
+``!keyword`` rejects ``"if"`` and ``"then"`` while still accepting ``"ifx"`` ---
+``keyword`` only matches a literal *immediately followed by* ``EOF``, so a
+prefix match alone does not trigger it.  Note ``!rule`` negates *any* rule, not
+just a character set: unlike ``not_set()`` (an inverted character *class* that
+advances by one character --- see :ref:`tutorial_dasPEG_csv_parser`), it is a
+zero-width assertion.
 
 Examples
 ========

--- a/doc/source/reference/tutorials/dasPEG_02_calculator.rst
+++ b/doc/source/reference/tutorials/dasPEG_02_calculator.rst
@@ -16,7 +16,7 @@ precedence, parentheses, and unary negation.  You will learn:
 
 - Encoding operator precedence via grammar layering
 - The ``number`` built-in terminal
-- ``PEEK`` for lookahead
+- ``PEEK`` for positive lookahead, ``!`` for negative lookahead
 - ``commit`` (cut) for error reporting
 - Recursive rules
 
@@ -128,6 +128,35 @@ character is a digit before committing to the ``number`` terminal:
 
 This prevents the parser from committing to the number alternative when
 the input does not start with a digit.
+
+Negative Lookahead (``!``)
+==========================
+
+``!rule`` is the mirror of ``PEEK``: it also consumes **no input**, but the
+match succeeds only when ``rule`` *fails* at this position.  The classic use is
+keyword guarding --- accept an identifier unless it spells a reserved word:
+
+.. code-block:: das
+
+   def identifier(input : string;
+                  blk : block<(val : string; err : array<ParsingError>) : void>) {
+       parse(input) {
+           var ident : string
+           rule(!"if", !"then", "{+alpha}" as word, EOF) {
+               return word
+           }
+           var alpha : void?
+           rule(set('a'..'z', 'A'..'Z')) {
+               return null
+           }
+       }
+   }
+
+``!"if"`` and ``!"then"`` reject those keywords before the identifier rule runs,
+so ``"hello"`` parses as an identifier while ``"if"`` and ``"then"`` are
+rejected.  Unlike ``not_set()`` (an inverted character *class* that advances by
+one character --- see :ref:`tutorial_dasPEG_csv_parser`), ``!rule`` is a
+zero-width assertion that can negate *any* rule, not just a character set.
 
 Examples
 ========

--- a/doc/source/reference/tutorials/dasPEG_03_csv_parser.rst
+++ b/doc/source/reference/tutorials/dasPEG_03_csv_parser.rst
@@ -152,7 +152,7 @@ anything except a specific character":
 
 ``not_set()`` accepts the same range and single-character arguments as
 ``set()``.  Unlike ``!rule`` (negative lookahead, covered in
-:ref:`tutorial_dasPEG_basic_interpreter`), ``not_set()`` is a
+:ref:`tutorial_dasPEG_calculator`), ``not_set()`` is a
 *terminal* --- it always advances the parser by exactly one character
 when it matches.
 

--- a/modules/dasPEG/peg/parser_generator.das
+++ b/modules/dasPEG/peg/parser_generator.das
@@ -13,7 +13,6 @@ require daslib/ast
 require daslib/rtti
 require daslib/math
 require daslib/ast_boost
-require daslib/utf8_utils
 require daslib/macro_boost
 require daslib/templates_boost
 
@@ -375,7 +374,7 @@ def generate(var gen : ParserGenerator; var def_ : Definition) {
 
 def generate_grammar(var gen : ParserGenerator; var gram : array<Definition>; name : string) {
     for (rule in gram) {
-        gen |> set_rule_type(rule.name |> string(), rule.type_)
+        gen |> set_rule_type(rule.name, rule.type_)
     }
 
     gen |> generate_result_types
@@ -488,10 +487,7 @@ def get_action_block(var alternative : Alternative) : ExpressionPtr {
 
 // Contract: block is managed externally and will clean up its own memory
 def flatten_block(var blk : ExprBlock?) {
-    var result : array<ExpressionPtr>
-    for (e in blk.list) {
-        result |> push(e |> clone_expression)
-    }
+    var result <- [for (e in blk.list); e |> clone_expression]
     return <- result
 }
 
@@ -567,23 +563,14 @@ def generate(var gen : ParserGenerator; var rule_ : Rule) : array<ExpressionPtr>
 
         if (Rule(seq = $v(rules))) {
             var result : array<ExpressionPtr>
-
             for (rule in rules) {
-                for (expr in gen |> generate(rule.rule)) {
-                    result |> push(expr)  // nolint:PERF006 — nested generator loop; total size unknown until exhausted
-                }
+                result |> push_from(gen |> generate(rule.rule))
             }
-
             return <- result
         }
 
         if (Rule(alt = $v(alts))) {
-            var results : array<ExpressionPtr>
-
-            for (alt, i in alts, iota()) {
-                results |> push <| generate_one_alternative(gen, alt, i, alts |> length == 1)
-            }
-
+            var results <- [for (alt, i in alts, iota()); generate_one_alternative(gen, alt, i, alts |> length == 1)]
             return <- results
         }
 
@@ -1044,14 +1031,14 @@ def generate_one_alternative(var gen : ParserGenerator; var alt : Alternative; i
                 parser |> log_success <| "Alternative {$v(i)} successful"
             }
             if ($v(gen.debug) && !$v(only)) {
-                parser |> log_plain <|  "State: index: {parser.index}, current: {parser.current}"
+                parser |> log_plain <|  "State: index: {parser.index}, current: {get_current_char(parser)}"
             }
             return <- $i(result)
         }
         parser.tabs--
 
         if ($v(gen.debug) && !$v(only)) {
-            parser |> log_plain <| "Resetting index to {parse_pos}, current: {parser.current}"
+            parser |> log_plain <| "Resetting index to {parse_pos}, current: {get_current_char(parser)}"
         }
 
         parser.index = parse_pos

--- a/tutorials/dasPEG/02_calculator.das
+++ b/tutorials/dasPEG/02_calculator.das
@@ -109,14 +109,25 @@ def eval_and_print(input : string) {
 //
 // `!rule` is the mirror image of PEEK: it consumes nothing, but the match
 // succeeds only when `rule` FAILS at this position. The classic use is keyword
-// guarding — accept an identifier UNLESS it spells a reserved word. Here `!"if"`
-// and `!"then"` reject those keywords before the identifier rule even runs.
+// guarding — accept an identifier UNLESS it is a reserved word. We negate a
+// `keyword` rule that matches a WHOLE keyword (the literal up to EOF), so "if"
+// and "then" are rejected but identifiers that merely start with them ("ifx")
+// are still accepted. (Negating the bare literal `!"if"` would wrongly reject
+// "ifx" too, since the literal matches a prefix.)
 
 def identifier(input : string; blk : block<(val : string; err : array<ParsingError>) : void>) {
     parse(input) {
         var ident : string
-        rule(!"if", !"then", "{+alpha}" as word, EOF) {
+        rule(!keyword, "{+alpha}" as word, EOF) {
             return word
+        }
+        // A reserved keyword is the whole word: the literal then EOF.
+        var keyword : void?
+        rule("if", EOF) {
+            return null
+        }
+        rule("then", EOF) {
+            return null
         }
         var alpha : void?
         rule(set('a'..'z', 'A'..'Z')) {
@@ -126,6 +137,9 @@ def identifier(input : string; blk : block<(val : string; err : array<ParsingErr
 }
 
 def try_identifier(input : string) {
+    // A keyword-rejected parse captures no word, so `val` stays empty. (`err` is
+    // empty on a bare lookahead failure — there is no `commit` — so the captured
+    // value, not the error list, is what distinguishes accept from reject here.)
     identifier(input) $(val; _err) {
         if (!empty(val)) {
             print("  {input} -> identifier \"{val}\"\n")
@@ -167,6 +181,7 @@ def main {
     try_identifier("hello")     // accepted — not a keyword
     try_identifier("if")        // rejected — reserved
     try_identifier("then")      // rejected — reserved
+    try_identifier("ifx")       // accepted — only the exact keyword is reserved
 }
 
 // Expected output:
@@ -197,3 +212,4 @@ def main {
 //   hello -> identifier "hello"
 //   if -> rejected (reserved keyword)
 //   then -> rejected (reserved keyword)
+//   ifx -> identifier "ifx"

--- a/tutorials/dasPEG/02_calculator.das
+++ b/tutorials/dasPEG/02_calculator.das
@@ -3,7 +3,7 @@
 // This tutorial covers:
 //   - Operator precedence via grammar layering
 //   - The `number` built-in terminal
-//   - PEEK for lookahead
+//   - PEEK for positive lookahead, ! for negative lookahead
 //   - commit (cut operator) for error reporting
 //   - WS for whitespace handling
 //   - Recursive rules (parenthesized expressions)
@@ -103,6 +103,39 @@ def eval_and_print(input : string) {
 }
 
 
+// ──────────────────────────────────────────────────────────────────────────
+// Negative lookahead — guard an identifier against reserved keywords
+// ──────────────────────────────────────────────────────────────────────────
+//
+// `!rule` is the mirror image of PEEK: it consumes nothing, but the match
+// succeeds only when `rule` FAILS at this position. The classic use is keyword
+// guarding — accept an identifier UNLESS it spells a reserved word. Here `!"if"`
+// and `!"then"` reject those keywords before the identifier rule even runs.
+
+def identifier(input : string; blk : block<(val : string; err : array<ParsingError>) : void>) {
+    parse(input) {
+        var ident : string
+        rule(!"if", !"then", "{+alpha}" as word, EOF) {
+            return word
+        }
+        var alpha : void?
+        rule(set('a'..'z', 'A'..'Z')) {
+            return null
+        }
+    }
+}
+
+def try_identifier(input : string) {
+    identifier(input) $(val; _err) {
+        if (!empty(val)) {
+            print("  {input} -> identifier \"{val}\"\n")
+        } else {
+            print("  {input} -> rejected (reserved keyword)\n")
+        }
+    }
+}
+
+
 [export]
 def main {
     print("=== Basic arithmetic ===\n")
@@ -129,6 +162,11 @@ def main {
     eval_and_print("2 +")
     eval_and_print("(2 + 3")
     eval_and_print("* 3")
+
+    print("\n=== Negative lookahead (keyword guard) ===\n")
+    try_identifier("hello")     // accepted — not a keyword
+    try_identifier("if")        // rejected — reserved
+    try_identifier("then")      // rejected — reserved
 }
 
 // Expected output:
@@ -154,3 +192,8 @@ def main {
 //
 // === Error cases ===
 //   (error messages for invalid expressions)
+//
+// === Negative lookahead (keyword guard) ===
+//   hello -> identifier "hello"
+//   if -> rejected (reserved keyword)
+//   then -> rejected (reserved keyword)

--- a/tutorials/dasPEG/07_basic.das
+++ b/tutorials/dasPEG/07_basic.das
@@ -119,7 +119,7 @@ def eval_expr_parse(input : string;
 def eval_expr(input : string; vars : table<string; double>) : double {
     eval_vars := vars
     var result = 0.0lf
-    eval_expr_parse(input) $(val; err) {
+    eval_expr_parse(input) $(val; _err) {
         result = val
     }
     return result
@@ -144,7 +144,7 @@ def eval_string_parse(input : string;
 
 def eval_string(input : string) : string {
     var result = ""
-    eval_string_parse(input) $(val; err) {
+    eval_string_parse(input) $(val; _err) {
         result = val
     }
     return result


### PR DESCRIPTION
## What

Tier-B follow-up to the tutorial gap audit (#3125). After verifying the audit's Tier-B list against source, **almost all of it was already covered** (json `sscan_json`/annotations/`$variant`, async `async_timeout`/`async_race`, SOA `from_array`/`to_array`/`swap`, SQL `_each_sql`/`insert_or_ignore`/`insert_or_replace` — all already taught). The one genuine gap: **negative lookahead (`!rule`)** was only ever *used* (PEG-07) and forward-referenced from PEG-03 ("see PEG-07"), never actually taught.

### Tutorial (the gap)
- **PEG-02 `.das`** — standalone keyword-guard demo: accept an identifier unless it spells a reserved word (`!"if"`, `!"then"`), plus a `main` section. Runs with correct output.
- **PEG-02 `.rst`** — new "Negative Lookahead (`!`)" section beside the existing PEEK section, contrasting `!rule` (zero-width assertion, negates any rule) with `not_set()` (one-char terminal).
- **PEG-03 `.rst`** — forward-reference repointed from PEG-07 to PEG-02 (the concept now has an earlier home).

### Module bug (surfaced by the above)
Adding the first `!rule` grammar to a **linted** file exposed a latent dasPEG codegen bug: `parser_generator.das`'s debug-trace branch references `parser.current`, a field removed when `get_current_char()` replaced it. The branch is dead (`gen.debug` is never set true) so a normal compile const-folds it away — but the lint tool type-checks it and fails. This silently blocked **every** `!rule` grammar under lint (incl. `tests/dasPEG/test_lookahead.das` and `07_basic.das`); it slipped through because CI runs/dry-runs PEG files rather than linting them, and the pre-push hook only lints *changed* files. Fixed both debug lines to use `get_current_char(parser)`.

### Lint cleanups (module was in the changed-set → gate enforces them)
- **STYLE030**: drop unused `require daslib/utf8_utils`
- **PERF020**: drop redundant `string()` cast on an already-`string` rule name
- **STYLE027 ×2 / PERF022**: `flatten_block` + the `seq`/`alt` result assembly now use a comprehension / `push_from`. The **emitted parser AST is byte-identical**, so no behavior change and no AOT-hash desync.
- **07_basic.das**: 2 LINT013 unused-block-arg (`err` → `_err`), newly visible because the module fix makes 07 lint-compilable for the first time.

## Verification
- All **7 dasPEG tutorials** run clean (exit 0) with correct output — they exercise `seq`/`alt`/`flatten_block`/PEEK/`!rule`/`not_set`/recursion, i.e. the exact generator paths touched.
- `lint` clean (exit 0) on all changed `.das`; `format_file` clean.
- `preflight --only format,lint,docs` green — both Sphinx builders (`-W`); pdflatex skipped locally (no TeX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)