### PR TITLE
infer: reject template structure used without instantiation (#3065)

### DIFF
--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -111,7 +111,7 @@ namespace das {
         string describeFunction(const Function *fun) const;
 
     protected:
-        void verifyType(const TypeDeclPtr &decl, bool allowExplicit = false, bool classMethod = false) const;
+        void verifyType(const TypeDeclPtr &decl, bool allowExplicit = false, bool classMethod = false, bool allowTemplate = false) const;
 
         bool jitEnabled() const;
 

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -2152,7 +2152,7 @@ namespace das {
                   expr->at, CompilationError::not_resolved_yet_type);
             return Visitor::visit(expr);
         }
-        verifyType(expr->typeexpr, true);
+        verifyType(expr->typeexpr, true, false, /*allowTemplate*/ true);  // type<> introspects; template is fine here
         TypeDecl::clone(expr->type, expr->typeexpr);
         return Visitor::visit(expr);
     }
@@ -2204,7 +2204,7 @@ namespace das {
                       expr->at, CompilationError::not_resolved_yet_typeinfo);
                 return Visitor::visit(expr);
             }
-            verifyType(expr->typeexpr, true);
+            verifyType(expr->typeexpr, true, false, /*allowTemplate*/ true);  // typeinfo introspects; template is fine here
         }
         if (nErrors == program->errors.size()) {
             if (expr->trait == "sizeof") {

--- a/src/ast/ast_infer_type_helper.cpp
+++ b/src/ast/ast_infer_type_helper.cpp
@@ -79,7 +79,7 @@ namespace das {
     string InferTypes::describeFunction(const Function *fun) const {
         return verbose ? fun->describe() : "";
     }
-    void InferTypes::verifyType(const TypeDeclPtr &decl, bool allowExplicit, bool classMethod) const {
+    void InferTypes::verifyType(const TypeDeclPtr &decl, bool allowExplicit, bool classMethod, bool allowTemplate) const {
         // TODO: enable and cleanup
         if (decl->isExplicit && !allowExplicit) {
             /*
@@ -118,7 +118,7 @@ namespace das {
                               ptrType->at, CompilationError::invalid_annotation_type);
                     }
                 }
-                verifyType(ptrType);
+                verifyType(ptrType, false, false, allowTemplate);
             } else {
                 if (decl->smartPtr) {
                     error("can't declare a void smart pointer", "", "",
@@ -127,7 +127,7 @@ namespace das {
             }
         } else if (decl->baseType == Type::tIterator) {
             if (auto ptrType = decl->firstType) {
-                verifyType(ptrType);
+                verifyType(ptrType, false, false, allowTemplate);
             }
         } else if (decl->baseType == Type::tFixedArray) {
             if (decl->fixedDim <= 0) {
@@ -155,7 +155,7 @@ namespace das {
                     error("can't declare an array of void: '" + describeType(decl) + "'", "", "",
                           decl->at, CompilationError::invalid_array);
                 }
-                verifyType(elemType);
+                verifyType(elemType, false, false, allowTemplate);
             }
         } else if (decl->baseType == Type::tArray) {
             if (auto arrayType = decl->firstType) {
@@ -175,7 +175,7 @@ namespace das {
                     error("can't have array of non-trivial type: '" + describeType(arrayType) + "'", "", "",
                           arrayType->at, CompilationError::invalid_array_type);
                 }
-                verifyType(arrayType);
+                verifyType(arrayType, false, false, allowTemplate);
             }
         } else if (decl->baseType == Type::tTable) {
             if (auto keyType = decl->firstType) {
@@ -191,7 +191,7 @@ namespace das {
                     error("table key has to be declared as a basic 'hashable' type: '" + describeType(keyType) + "'", "", "",
                           keyType->at, CompilationError::invalid_table_type);
                 }
-                verifyType(keyType);
+                verifyType(keyType, false, false, allowTemplate);
             }
             if (auto valueType = decl->secondType) {
                 if (valueType->isAutoOrAlias()) {
@@ -206,7 +206,7 @@ namespace das {
                     error("can't have table value of non-trivial type: '" + describeType(valueType) + "'", "", "",
                           valueType->at, CompilationError::invalid_table_type);
                 }
-                verifyType(valueType);
+                verifyType(valueType, false, false, allowTemplate);
             }
         } else if (decl->baseType == Type::tBlock || decl->baseType == Type::tFunction || decl->baseType == Type::tLambda) {
             if (auto resultType = decl->firstType) {
@@ -214,14 +214,14 @@ namespace das {
                     error("not a valid return type: '" + describeType(resultType) + "'", "", "",
                           resultType->at, CompilationError::invalid_result_type);
                 }
-                verifyType(resultType);
+                verifyType(resultType, false, false, allowTemplate);
             }
             for (auto &argType : decl->argTypes) {
                 if (!classMethod && (argType->ref && argType->isRefType())) {
                     error("can't pass a boxed type by a reference: '" + describeType(argType) + "'", "", "",
                           argType->at, CompilationError::invalid_argument_type);
                 }
-                verifyType(argType, true);
+                verifyType(argType, true, false, allowTemplate);
             }
         } else if (decl->baseType == Type::tTuple) {
             for (auto &argType : decl->argTypes) {
@@ -237,7 +237,7 @@ namespace das {
                     error("invalid tuple element type: '" + describeType(argType) + "'", "", "",
                           argType->at, CompilationError::invalid_tuple_type);
                 }
-                verifyType(argType);
+                verifyType(argType, false, false, allowTemplate);
             }
         } else if (decl->baseType == Type::tVariant) {
             for (auto &argType : decl->argTypes) {
@@ -253,7 +253,16 @@ namespace das {
                     error("invalid variant element type: '" + describeType(argType) + "'", "", "",
                           argType->at, CompilationError::invalid_variant_type);
                 }
-                verifyType(argType);
+                verifyType(argType, false, false, allowTemplate);
+            }
+        } else if (decl->baseType == Type::tStructure) {
+            // A template structure has no concrete layout, so it can't be used where
+            // a real value would live (parameter, variable, field, result). It IS legal
+            // inside type<>/typeinfo introspection, which is how the typemacro machinery
+            // reads a template's fields to instantiate it -- those sites pass allowTemplate.
+            if (!allowTemplate && decl->structType && decl->structType->isTemplate) {
+                error("can't use template structure " + decl->structType->name + " without instantiation", "", "",
+                        decl->at, CompilationError::invalid_structure_template);
             }
         }
     }

--- a/tests/typer_errors/failed_template_without_instantiation.das
+++ b/tests/typer_errors/failed_template_without_instantiation.das
@@ -1,0 +1,14 @@
+// Regression test for issue #3065 (fuzzer): a `struct template` used directly
+// as a type (here a function parameter) without going through its typemacro
+// instantiation slipped past infer and tripped the DAS_VERIFYF in
+// makeStructureDebugInfo ("cannot make debug info for template structure").
+// verifyType now rejects it cleanly with invalid_structure_template (30241).
+options gen2
+expect 30241
+
+struct template Foo {
+    x : int
+}
+
+[export]
+def use_template(r : Foo) {}


### PR DESCRIPTION
## Problem

One of the fuzzer repros in #3065:

```
require UnitTest
struct template var0;[export]def v(r:var0){}[export]def y{}
```

A `struct template` used directly as a **value type** (function parameter, variable, field, or result) slipped past type inference and only failed at **simulate** time, tripping the debug-info assertion:

```
verify failed: !st.isTemplate, src/ast/ast_debug_info_helper.cpp:188
cannot make debug info for template structure ...
```

## Root cause

A template structure has no concrete layout. The `MakeStruct` path already rejected initializing a template (`invalid_structure_template`), but the **type-declaration** path (parameter / variable / field / result) had no such check, so a raw template `tStructure` reached `makeStructureDebugInfo` and hit the `DAS_VERIFYF`.

## Fix

`verifyType` now rejects a template `tStructure` with the same clean `invalid_structure_template` (30241) error the `MakeStruct` guard uses.

The check is narrowed so it does **not** break legitimate template use:

- `type<>` / `typeinfo` introspection is exempted via a new `allowTemplate` flag — that is exactly how the typemacro machinery (`daslib/typemacro_boost`) reads a template's fields in order to instantiate it. Without the exemption, **all** `[template_tuple]` / `[template_structure]` instantiation (Result, Option, flat/cuckoo hash tables, delegate) breaks. (Confirmed: the unguarded first cut did break them.)
- Template structures and template functions are never visited by the inferer (`canVisitStructure` / `canVisitFunction` both return `!isTemplate`), so only non-template positions are affected — and any code with a template in such a position would already have hit the assert pre-fix.

## Validation

- New compile-fail test `tests/typer_errors/failed_template_without_instantiation.das` (`expect 30241`).
- Preflight `--full`: 14 gates pass — lint, formatter, 159-file clang-cl header sweep, dasgen, ci-das, all 6 doc gates, tests-cpp, full interp suite, full JIT suite.
- AOT sweep over `tests/`: **10398 / 10398** pass.
- Template regression dirs (`option` / `hash_map` / `delegate`) all green, including `template_tuple` and `template_structure` instantiation paths.

Part of #3065 (fuzzer bugs) — first of several; the remaining repros (folding, type inference, AOT codegen) will follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)