### PR TITLE
const-fold: skip template structures (#3065)

### DIFF
--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -930,6 +930,9 @@ namespace das {
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
+        virtual bool canVisitStructure ( Structure * str ) override {
+            return !str->isTemplate;    // we don't do a thing with template structures
+        }
         // ExprCall
         virtual ExpressionPtr visit ( ExprCall * expr ) override {
             if ( expr->func->result->isFoldable() && (expr->func->sideEffectFlags==0) && !expr->func->builtIn ) {

--- a/tests/language/template_struct_const_folding.das
+++ b/tests/language/template_struct_const_folding.das
@@ -1,0 +1,26 @@
+// Regression for issue #3065 (fuzzer crash). Const folding used to descend into a
+// `struct template`'s field initializer; the unresolved call in v2's init folded to
+// a null `func`, crashing RunFolding::visit(ExprCall) in ast_const_folding.cpp
+// (read access violation on expr->func->result). Fixed by giving RunFolding a
+// canVisitStructure that returns !isTemplate, mirroring canVisitFunction.
+//
+// Must-not-crash test: with the fix the template is skipped during folding so the
+// program compiles & runs; without it the compiler crashes (process dies). The
+// foldable float4(...) in `ma` is what engages the folder, which then walked into
+// v2's init. v2 is reduced from the #3065 fuzzer payload -- gnarly on purpose.
+options gen2
+
+class v {}
+
+struct template v2{r = i((3 ? reinterpret<bitfield<>>(([],) < (0 > t)) as r * ([{for((v) in @@o[[]] > (2) > 5, (v)); (0[((3 > (k()) > new<a<v>>() - 0)) as  t8 ]) % (9) % (99) % o }
+].) ?[ (T)] .. 2 : [  ]), (3));
+}
+
+[export]
+def ma{
+ return float4(uint(), 2, -9, 3);
+}
+
+[export]
+def main {
+}


### PR DESCRIPTION
Second fix in the #3065 fuzzer-bug sweep (after #3134).

## Bug

Const folding's `RunFolding` visitor descended into a `struct template`'s field initializer and tried to fold the unresolved calls there. A template structure is never instantiated on its own, so its field-init calls have no resolved overload — `expr->func` is `null` — and `RunFolding::visit(ExprCall)` crashed dereferencing `expr->func->result->isFoldable()` (`EXCEPTION_ACCESS_VIOLATION`, read at `0x80`).

Stack at the crash:
```
optimizationConstFolding → visitModule → visitStructure → … (template field init) → RunFolding::visit(ExprCall)
```

## Fix

Give `RunFolding` a `canVisitStructure` that returns `!isTemplate`, mirroring the existing `canVisitFunction`. A template structure carries no concrete layout and is only folded through its concrete instantiations, so visiting its init expressions is both meaningless and unsafe.

```cpp
virtual bool canVisitStructure ( Structure * str ) override {
    return !str->isTemplate;    // we don't do a thing with template structures
}
```

## Test

`tests/language/template_struct_const_folding.das` — a `struct template` whose field initializer is an unresolved call, plus a foldable `float4(...)` to engage the folder. Reduced from the #3065 fuzzer payload (a degenerate same-name `class v` + `enum v` was dropped — orthogonal to the crash, and the only thing that broke AOT C++ codegen of the reduced case).

- **Crashes** the unfixed compiler (`0xC0000005` in `optimizationConstFolding`).
- **Compiles + runs clean** with the fix, across interpreter, JIT, and AOT.

## Validation

- preflight `--full`: 14/14 gates green (format, lint, cpp-syntax, dasgen, ci-das, docs ×6, tests-cpp, interp, JIT)
- AOT sweep: 10408/10408 passed

Part of #3065 (fuzzer bugs).