### PR TITLE
dasSpirv Phase 2: control flow + arithmetic breadth

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -474,3 +474,54 @@ First Phase-2 slice: full scalar binary + unary arithmetic. `emit_value`'s `Expr
   (mutable locals as `Function` `OpVariable`, `OpSelectionMerge`/`OpLoopMerge`) are the next slices.
 
 **Reserved word:** `label` is a daslang keyword — a parameter named `label` is `error[30151]`. Use `lbl`.
+
+### Phase 2 — control flow LANDED (2026-06-14, branch `bbatkin/dasspirv-phase2`)
+
+Second Phase-2 slice: mutable locals + comparisons + logical ops + the full structured-CFG set
+(if/else, while, range-for, break/continue). All three tiers green (interp/JIT/AOT 26/26),
+spirv-val clean, external `spirv-dis` confirms textbook structured CFG, lint + format clean.
+
+- **Mutable locals as Function `OpVariable`s.** A pre-scan (`collect_locals`) walks the WHOLE body
+  once before any body code and declares an `OpVariable` (Function storage) for every mutable local
+  (`var`) and loop-induction variable — SPIR-V requires all Function-storage OpVariables to lead the
+  entry block. Reads → `OpLoad`, writes → `OpStore`; the driver mem2reg's them (NO hand-rolled
+  `OpPhi`). Immutable value-lets (`let`) stay pure SSA ids (the Phase-1 path) — so the square's
+  `let i` is unchanged and the census/exact-count asserts still hold. Discriminator (probed):
+  `var._type.flags.constant` — `false` for `var` (→ memory), `true` for `let` and loop-iter vars.
+- **Compound assignment** (`+= -= *= /= %=`, void-typed `ExprOp2`) and **`++`/`--`** (statement-level
+  `ExprOp1`) → load-modify-store via `emit_load_op_store`.
+- **Comparisons** (`== != < > <= >=`, `ExprOp2` → bool): `cmp_code` table picks I/S/U/FOrd opcode by
+  operand class. Equality is sign-agnostic (`IEqual`/`INotEqual`); ordering splits signed/unsigned/
+  float; floats use the **ordered** (non-NaN) forms.
+- **Logical** `&&`/`||` (`ExprOp2` → bool) → `OpLogicalAnd`/`OpLogicalOr`; `!` (`ExprOp1`) →
+  `OpLogicalNot`. **Eager, NOT short-circuit** — valid because shader condition operands are
+  side-effect free (documented in-code); true short-circuit would need extra control flow.
+- **if/else** → `OpSelectionMerge` + `OpBranchConditional`, then/else/merge blocks. Early-`return`
+  in a branch is handled by the per-block `terminated` flag (skip the trailing `OpBranch merge`).
+- **while + range-for** → the canonical 4-block `OpLoopMerge` shape: header (LoopMerge → branch to
+  cond) / cond (`OpBranchConditional body merge`) / body / continue (→ header), + merge. **break →
+  `OpBranch merge`, continue → `OpBranch continue`** off a `loop_stack`. range-for's `i < hi` test
+  and `i += 1` update are synthesized directly against the induction `OpVariable` (no daslang AST
+  node exists for them); bounds are evaluated ONCE in the pre-header (range captures at entry).
+- **Tests:** `tests/spirv/test_control.das` (uint/int/float fixtures — every comparison flavor +
+  logical + if/else) and `test_loops.das` (while+break, range-for+continue, both `range(n)` and
+  `range(lo,hi)`). Per-op opcode-shape asserts + spirv-val on every blob.
+
+**Findings (load-bearing):**
+
+1. **Constant-bound `range()` folds to `ExprConstRange`, NOT an `ExprCall`.** `range(10)` / `range(2,8)`
+   with literal bounds arrive as `ExprConstRange` (a half-open `[from,to)` value); only
+   *runtime*-bound ranges stay an `ExprCall` to `range`/`urange`. The emitter handles both. Read the
+   const bounds via `unsafe(reinterpret<int2>(cr.value))` → `(from, to)` (daslang `range` is a
+   vector-like pair; `.from`/`.to` parse as swizzle masks and fail — `reinterpret` is the way).
+2. **`continue if (cond)` desugars to a plain `if (cond) { continue }`** — no special postfix handling
+   needed; `ExprBreak`/`ExprContinue` are leaf statements.
+3. **At patch (pre-fold) stage, mutable-local reads are `ExprVar : T&` (non-const ref) wrapped in
+   `ExprRef2Value`; value-let / loop-var reads are `T const&`.** The const flag on the *variable's*
+   `_type` (not the read site) is the stable mutable-vs-SSA discriminator at the `ExprLet` site.
+
+**Deferred (not blocking Phase 2):** the aggregate opcode census (gate B) still validates only the
+square fixture; the Phase-2 opcodes are covered by per-op presence asserts in test_arith/control/
+loops. Extending the census to aggregate across all fixtures is a cheap follow-up.
+
+**Phase 2 COMPLETE** — arithmetic (commit 1) + control flow (commit 2). Ready to PR.

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -437,3 +437,40 @@ runs (exit 0) with `VULKAN_SDK` set. Registered in `tests/aot/CMakeLists.txt` (5
 **NEXT:** dasVulkan `run_compute_spirv` GPU gate (`out[i]==i*i` on local real GPU + lavapipe CI) —
 the cross-repo Phase-1 piece. Then Phase 2 (control flow + arithmetic). Dev binary: the worktree's
 LLVM-enabled `bin/Release/daslang.exe`.
+
+## Phase 1 — CROSS-REPO GPU GATE GREEN, milestone fully closed (2026-06-14)
+
+daslang #3133 merged to master (`6caf9bf59`). The dasVulkan side ([borisbat/dasVulkan#3](https://github.com/borisbat/dasVulkan/pull/3))
+replaces the committed `square.comp(.spv)` with a daslang `[compute_shader]` lowered by dasSpirv:
+
+- New `create_shader_module(device, code : array<uint>)` overload (SPIR-V words; `codeSize = 4·len`).
+- The `[compute_shader] square` fixture emits the public `square_spv : array<uint>` global; the raw
+  (`run_compute`) and boost (`run_compute_spirv`/`run_compute_boost`) descriptor paths feed it.
+- `examples/compute.das` authors its own inline `[compute_shader]`.
+
+**Result:** `out[i]==i*i` green on the **local real GPU** (integration suite 5/5) AND **lavapipe CI**
+(PR #3 `build`+`integration` pass). dasVulkan CI builds daslang from `master`, which compiles dasSpirv
+in unconditionally (top-level CMake auto-includes every `modules/*/CMakeLists.txt`); the macro runs
+interpreted, so the `-DDAS_LLVM_DISABLED=ON` CI build is unaffected. Pure daslang→SPIR-V on a real GPU,
+no GLSL/glslang/committed `.spv` anywhere.
+
+### Phase 2 — arithmetic breadth (in progress, branch `bbatkin/dasspirv-phase2`)
+
+First Phase-2 slice: full scalar binary + unary arithmetic. `emit_value`'s `ExprOp2` went from
+`*`-only to a `binop_code(op, scalar_class)` table; added an `ExprOp1` handler via `unop_code`.
+
+- **Binary** (`+ - * / %`): `IAdd`/`ISub`/`IMul` (sign-agnostic), `SDiv`/`UDiv`/`FDiv`, `SRem`/`UMod`/`FRem`.
+- **Unary** (`- ~`): `SNegate`/`FNegate`, `Not`.
+- **Op-semantics probe (load-bearing):** daslang `/` truncates toward zero (`-7/3 == -2`) and `%`
+  takes the **dividend's** sign (`-7%3 == -1`, `7%-3 == 1`) — C semantics. So int `%` → `OpSRem`
+  (dividend's sign), NOT `OpSMod` (divisor's sign); int `/` → `OpSDiv` (truncating). uint → `UDiv`/`UMod`;
+  float → `FDiv`/`FRem`.
+- **Node shapes (probed):** `+ - * / %` are all `ExprOp2`; unary `-`/`~` are `ExprOp1` (`{op, subexpr}`).
+  No `ExprCall` lowering for these on builtin scalars.
+- **Tests:** `tests/spirv/test_arith.das` — uint/int/float fixtures in `_spirv_common.das` (operands are
+  loaded SSBO values + the uint index, so no constants/conversions needed yet), per-op opcode-shape
+  asserts + spirv-val clean. Interp + JIT green (16/16); `marker(no_coverage)` on the new fixtures.
+  Constants (`const_int`/`const_float`/`const_bool`), comparisons (bool result), and control flow
+  (mutable locals as `Function` `OpVariable`, `OpSelectionMerge`/`OpLoopMerge`) are the next slices.
+
+**Reserved word:** `label` is a daslang keyword — a parameter named `label` is `error[30151]`. Use `lbl`.

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -520,8 +520,13 @@ spirv-val clean, external `spirv-dis` confirms textbook structured CFG, lint + f
    `ExprRef2Value`; value-let / loop-var reads are `T const&`.** The const flag on the *variable's*
    `_type` (not the read site) is the stable mutable-vs-SSA discriminator at the `ExprLet` site.
 
-**Deferred (not blocking Phase 2):** the aggregate opcode census (gate B) still validates only the
-square fixture; the Phase-2 opcodes are covered by per-op presence asserts in test_arith/control/
-loops. Extending the census to aggregate across all fixtures is a cheap follow-up.
+**Census gate (B) now aggregates across ALL fixtures.** `test_census.das` unions `opcode_set` over
+every fixture (square + arith + control + loops) and asserts it equals the declared
+`phase2_emitter_opcodes()` set in both directions (failures resolve the numeric opcode to its OpName).
+This caught a real gap: float `%` (FRem) was reachable in the emitter but no fixture exercised it, so
+a `fdata[i] % 2.0f` line was added to `farith` (daslang float `%` is fmod) — test-per-instruction
+restored. The declared set lists only the comparison flavors the fixtures actually emit (e.g. no
+unsigned `>=`/`<=`), so the both-directions check stays exact.
 
-**Phase 2 COMPLETE** — arithmetic (commit 1) + control flow (commit 2). Ready to PR.
+**Phase 2 COMPLETE** — arithmetic (commit 1) + control flow (commit 2) + aggregate census (commit 3).
+All three tiers 26/26, spirv-val clean, lint + format clean.

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -529,4 +529,15 @@ restored. The declared set lists only the comparison flavors the fixtures actual
 unsigned `>=`/`<=`), so the both-directions check stays exact.
 
 **Phase 2 COMPLETE** — arithmetic (commit 1) + control flow (commit 2) + aggregate census (commit 3).
-All three tiers 26/26, spirv-val clean, lint + format clean.
+All three tiers 28/28, spirv-val clean, lint + format clean.
+
+**Review hardening (#3137).** Copilot review surfaced an "unvalidated scalar class → silently emits an
+invalid op" class of latent bug. Fixed across the dispatch surface and audited for completeness:
+`const_float` keys by raw IEEE-754 bits (not stringified — `-0.0`/`0.0`/NaN payloads stay distinct;
+regression test added); `binop_code`/`unop_code` reject `cls < 0` (and `~` is gated to int/uint) so an
+unsupported operand type becomes a clean error instead of a masquerading integer op; `emit_for` guards
+the induction class; `declare_local_var` rejects unsupported local types (e.g. `var d : double`) with a
+clean error instead of letting `emit_type` panic. Net rule for the emitter: **every type/opcode
+dispatch validates its input and produces a clean `error[...]`, never a silent bad blob or a panic.**
+The remaining `emit_type`/`emit_component_type` panics are now unreachable for valid daslang (all
+callers pre-validate); they stand as internal invariants.

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -271,12 +271,16 @@ def public const_int(var m : SpirvModule; v : int) : uint {
 }
 
 def public const_float(var m : SpirvModule; v : float) : uint {
-    let key = "cf_{v}"
+    // Key by the raw IEEE-754 bits, NOT the stringified float: stringifying would collapse distinct
+    // bit patterns (-0.0 vs 0.0, NaN payloads, rounding-equal values) into one pool entry and reuse
+    // the wrong constant id. The bits are also the literal word, so compute once.
+    let bits = unsafe(reinterpret<uint>(v))
+    let key = "cf_{bits}"
     let ex = m.const_pool?[key] ?? 0u
     return ex if (ex != 0u)
     let ft = type_float(m, 32u)
     let id = alloc_id(m)
-    emit(m, SEC_TYPES, SpvOp.Constant, ft, id, unsafe(reinterpret<uint>(v)))
+    emit(m, SEC_TYPES, SpvOp.Constant, ft, id, bits)
     m.const_pool |> insert(key, id)
     return id
 }

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -256,6 +256,31 @@ def public const_uint(var m : SpirvModule; v : uint) : uint {
     return id
 }
 
+// Signed-int and float OpConstants. The literal word is the raw 32-bit pattern: uint(v) carries an
+// int's two's-complement bits; reinterpret carries a float's IEEE-754 bits. Keyed separately from
+// const_uint so int 2 and uint 2 (distinct types) don't collide in the pool.
+def public const_int(var m : SpirvModule; v : int) : uint {
+    let key = "ci_{v}"
+    let ex = m.const_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let it = type_int(m, 32u, 1u)
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, SpvOp.Constant, it, id, uint(v))
+    m.const_pool |> insert(key, id)
+    return id
+}
+
+def public const_float(var m : SpirvModule; v : float) : uint {
+    let key = "cf_{v}"
+    let ex = m.const_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let ft = type_float(m, 32u)
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, SpvOp.Constant, ft, id, unsafe(reinterpret<uint>(v)))
+    m.const_pool |> insert(key, id)
+    return id
+}
+
 // ===== finalize: header (5 words) ++ sections in layout order =====
 def public module_words(m : SpirvModule) : array<uint> {
     // header: magic, version, generator, id-bound (all result-ids < next_id), schema (0)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -24,17 +24,35 @@ struct GlobalInfo {
     is_ssbo    : bool               // wrapped in a Block-decorated struct (member 0 = the array)
 }
 
+// A memory-backed local: an OpVariable in Function storage. Mutable locals (`var x`) and loop
+// induction variables get one; reads become OpLoad, writes OpStore. The driver mem2reg's them,
+// so we never hand-roll OpPhi. Immutable value-lets (`let x`) stay pure SSA ids (ctx.locals).
+struct LocalVar {
+    ptr_id     : uint    // OpVariable result-id (Function storage)
+    value_type : uint    // SPIR-V type-id of the pointee
+}
+
 struct EmitCtx {
     globals       : table<uint64; GlobalInfo>   // intptr(Variable) -> classification
     locals        : table<uint64; uint>         // intptr(Variable) -> SSA result-id (value lets)
+    local_vars    : table<uint64; LocalVar>     // intptr(Variable) -> memory-backed local (var / loop var)
     interface_ids : array<uint>                 // EntryPoint interface (Input/Output vars, SPIR-V <= 1.3)
+    loop_stack    : array<LoopTargets>          // innermost loop's {merge, continue} for break/continue
     terminated    : bool                        // current block already has a terminator
+}
+
+// break -> branch to `merge`, continue -> branch to `cont`. Pushed per active loop.
+struct LoopTargets {
+    merge : uint
+    cont  : uint
 }
 
 def finalize(var c : EmitCtx) {
     delete c.globals
     delete c.locals
+    delete c.local_vars
     delete c.interface_ids
+    delete c.loop_stack
 }
 
 // ===== builtin name -> SpvBuiltIn (compute subset; extended in later phases) =====
@@ -147,6 +165,15 @@ def emit_ptr(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var erro
         emit(m, SEC_FUNCS, SpvOp.AccessChain, ptr_t, res, gi.var_id, const_uint(m, uint(sw.fields[0])))
         return (id = res, pointee = pointee)
     }
+    let lev = e ?as ExprVar
+    if (lev != null && (lev.varFlags.local || lev.varFlags.argument || lev.varFlags._block)) {
+        let lv = ctx.local_vars?[intptr(lev.variable)] ?? LocalVar()
+        if (lv.ptr_id != 0u) {
+            return (id = lv.ptr_id, pointee = lv.value_type)
+        }
+        errors |> push("cannot take a pointer to immutable local '{lev.name}' (only `var` locals are addressable)")
+        return (id = 0u, pointee = 0u)
+    }
     let gv = global_var_of(e)
     if (gv != null) {
         let gi = ctx.globals?[intptr(gv)] ?? GlobalInfo()
@@ -198,6 +225,42 @@ def private unop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
     return (ok = false, code = SpvOp.Nop)
 }
 
+// daslang comparison op -> SPIR-V opcode. Result is always bool. Equality (==/!=) is two's-complement
+// sign-agnostic on integers (IEqual/INotEqual). Ordering splits signed/unsigned/float. `F*` uses the
+// ordered (non-NaN) forms — matching daslang's total order on finite shader values.
+def private cmp_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
+    let is_int = cls == 0 || cls == 1
+    if (op == "==") {
+        if (cls == 2) return (ok = true, code = SpvOp.FOrdEqual)
+        if (is_int) return (ok = true, code = SpvOp.IEqual)
+    }
+    if (op == "!=") {
+        if (cls == 2) return (ok = true, code = SpvOp.FOrdNotEqual)
+        if (is_int) return (ok = true, code = SpvOp.INotEqual)
+    }
+    if (op == "<") {
+        if (cls == 2) return (ok = true, code = SpvOp.FOrdLessThan)
+        if (cls == 0) return (ok = true, code = SpvOp.SLessThan)
+        if (cls == 1) return (ok = true, code = SpvOp.ULessThan)
+    }
+    if (op == ">") {
+        if (cls == 2) return (ok = true, code = SpvOp.FOrdGreaterThan)
+        if (cls == 0) return (ok = true, code = SpvOp.SGreaterThan)
+        if (cls == 1) return (ok = true, code = SpvOp.UGreaterThan)
+    }
+    if (op == "<=") {
+        if (cls == 2) return (ok = true, code = SpvOp.FOrdLessThanEqual)
+        if (cls == 0) return (ok = true, code = SpvOp.SLessThanEqual)
+        if (cls == 1) return (ok = true, code = SpvOp.ULessThanEqual)
+    }
+    if (op == ">=") {
+        if (cls == 2) return (ok = true, code = SpvOp.FOrdGreaterThanEqual)
+        if (cls == 0) return (ok = true, code = SpvOp.SGreaterThanEqual)
+        if (cls == 1) return (ok = true, code = SpvOp.UGreaterThanEqual)
+    }
+    return (ok = false, code = SpvOp.Nop)
+}
+
 // ===== rvalue: produce an SSA result-id =====
 def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) : uint {
     // ExprRef2Value wraps a ref lvalue to read its value; running in `patch` (pre-fold) the AST
@@ -213,12 +276,30 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     if (cf != null) return const_float(m, cf.value)
     let op2 = e ?as ExprOp2
     if (op2 != null) {
+        let ops = "{op2.op}"
+        // operand type drives the signed/unsigned/float opcode choice for every op family.
+        let cls = scalar_class(op2.left._type.baseType)
         let l = emit_value(m, ctx, op2.left, errors)
         let r = emit_value(m, ctx, op2.right, errors)
         if (l == 0u || r == 0u) return 0u   // operand error already reported; don't emit with id 0
-        // operand type drives the signed/unsigned/float opcode choice; result type is the same for
-        // arithmetic (comparisons, whose result is bool, arrive in a later phase).
-        let bo = binop_code("{op2.op}", scalar_class(op2.left._type.baseType))
+        // comparison -> bool result (operands keep their scalar class)
+        let cc = cmp_code(ops, cls)
+        if (cc.ok) {
+            let bt = type_bool(m)
+            let res = alloc_id(m)
+            emit(m, SEC_FUNCS, cc.code, bt, res, l, r)
+            return res
+        }
+        // logical and/or -> bool. daslang `&&`/`||` short-circuit, but shader condition operands are
+        // side-effect free, so eager OpLogicalAnd/Or is equivalent (no extra control flow needed).
+        if (ops == "&&" || ops == "||") {
+            let bt = type_bool(m)
+            let res = alloc_id(m)
+            emit(m, SEC_FUNCS, ops == "&&" ? SpvOp.LogicalAnd : SpvOp.LogicalOr, bt, res, l, r)
+            return res
+        }
+        // arithmetic -> same type as operands
+        let bo = binop_code(ops, cls)
         if (!bo.ok) {
             errors |> push("unsupported binary op '{op2.op}' on {op2.left._type.baseType}")
             return 0u   // no instruction emitted: don't return an undefined result id
@@ -230,9 +311,16 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     }
     let op1 = e ?as ExprOp1
     if (op1 != null) {
+        let ops = "{op1.op}"
         let v = emit_value(m, ctx, op1.subexpr, errors)
         if (v == 0u) return 0u
-        let uo = unop_code("{op1.op}", scalar_class(op1.subexpr._type.baseType))
+        if (ops == "!") {       // logical not -> bool
+            let bt = type_bool(m)
+            let res = alloc_id(m)
+            emit(m, SEC_FUNCS, SpvOp.LogicalNot, bt, res, v)
+            return res
+        }
+        let uo = unop_code(ops, scalar_class(op1.subexpr._type.baseType))
         if (!uo.ok) {
             errors |> push("unsupported unary op '{op1.op}' on {op1.subexpr._type.baseType}")
             return 0u
@@ -244,6 +332,12 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     }
     let ev = e ?as ExprVar
     if (ev != null && (ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block)) {
+        let lv = ctx.local_vars?[intptr(ev.variable)] ?? LocalVar()
+        if (lv.ptr_id != 0u) {      // memory-backed local: read through OpLoad
+            let res = alloc_id(m)
+            emit(m, SEC_FUNCS, SpvOp.Load, lv.value_type, res, lv.ptr_id)
+            return res
+        }
         let lid = ctx.locals?[intptr(ev.variable)] ?? 0u
         if (lid == 0u) {
             errors |> push("local '{ev.name}' used before it was assigned an SSA id")
@@ -261,8 +355,290 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     return 0u
 }
 
+// ===== local variable declaration (Function-storage OpVariable) =====
+// SPIR-V requires every Function-storage OpVariable to be among the first instructions of the
+// function's first block. So we pre-scan the whole body (one walk, all scopes — SPIR-V locals are
+// function-scoped, not block-scoped) BEFORE emitting any body code, declaring an OpVariable for each
+// mutable local (`var`) and loop-induction variable. Reads/writes then resolve to OpLoad/OpStore.
+def private declare_local_var(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr) {
+    if (key_exists(ctx.local_vars, intptr(v))) return
+    let vt = emit_type(m, v._type)
+    let pt = type_pointer(m, SpvStorageClass.Function, vt)
+    let pid = alloc_id(m)
+    emit(m, SEC_FUNCS, SpvOp.Variable, pt, pid, uint(SpvStorageClass.Function))
+    ctx.local_vars |> insert(intptr(v), LocalVar(ptr_id = pid, value_type = vt))
+}
+
+def private collect_locals(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) {
+    if (e == null) return
+    let blk = e ?as ExprBlock
+    if (blk != null) {
+        for (s in blk.list) {
+            collect_locals(m, ctx, s, errors)
+        }
+        return
+    }
+    let lt = e ?as ExprLet
+    if (lt != null) {
+        for (v in lt.variables) {
+            if (!v._type.flags.constant) declare_local_var(m, ctx, v)   // `var` -> memory; `let` -> SSA
+        }
+        return
+    }
+    let ite = e ?as ExprIfThenElse
+    if (ite != null) {
+        collect_locals(m, ctx, ite.if_true, errors)
+        collect_locals(m, ctx, ite.if_false, errors)
+        return
+    }
+    let wh = e ?as ExprWhile
+    if (wh != null) {
+        collect_locals(m, ctx, wh.body, errors)
+        return
+    }
+    let fr = e ?as ExprFor
+    if (fr != null) {
+        for (fv in fr.iteratorVariables) {
+            declare_local_var(m, ctx, fv)
+        }
+        collect_locals(m, ctx, fr.body, errors)
+        return
+    }
+}
+
+// ===== compound assignment + increment/decrement =====
+def private compound_base(op : string) : string {
+    if (op == "+=") return "+"
+    if (op == "-=") return "-"
+    if (op == "*=") return "*"
+    if (op == "/=") return "/"
+    if (op == "%=") return "%"
+    return ""
+}
+
+def private const_one(var m : SpirvModule; cls : int) : uint {
+    if (cls == 2) return const_float(m, 1.0f)
+    if (cls == 1) return const_uint(m, 1u)
+    return const_int(m, 1)
+}
+
+def private const_zero(var m : SpirvModule; cls : int) : uint {
+    if (cls == 2) return const_float(m, 0.0f)
+    if (cls == 1) return const_uint(m, 0u)
+    return const_int(m, 0)
+}
+
+// An integer-valued constant for a loop bound (range bounds are always int or uint, never float).
+def private const_int_for(var m : SpirvModule; cls : int; v : int) : uint {
+    if (cls == 1) return const_uint(m, uint(v))
+    return const_int(m, v)
+}
+
+// load-modify-store against an lvalue: `dst <op>= rhs` and `dst++`/`dst--`.
+def private emit_load_op_store(var m : SpirvModule; var ctx : EmitCtx; lhs : ExpressionPtr; code : SpvOp; rhs : uint; var errors : array<string>) {
+    if (rhs == 0u) return
+    let p = emit_ptr(m, ctx, lhs, errors)
+    if (p.id == 0u) return
+    let cur = alloc_id(m)
+    emit(m, SEC_FUNCS, SpvOp.Load, p.pointee, cur, p.id)
+    let res = alloc_id(m)
+    emit(m, SEC_FUNCS, code, p.pointee, res, cur, rhs)
+    emit(m, SEC_FUNCS, SpvOp.Store, p.id, res)
+}
+
+// ===== if / else (OpSelectionMerge + OpBranchConditional) =====
+def private emit_if(var m : SpirvModule; var ctx : EmitCtx; ite : ExprIfThenElse?; var errors : array<string>) {
+    let cond = emit_value(m, ctx, ite.cond, errors)
+    if (cond == 0u) return
+    let merge = alloc_id(m)
+    let then_l = alloc_id(m)
+    let else_l = ite.if_false != null ? alloc_id(m) : merge
+    // the header block selects the merge target, then branches on the condition
+    emit(m, SEC_FUNCS, SpvOp.SelectionMerge, merge, uint(SpvSelectionControl.None))
+    emit(m, SEC_FUNCS, SpvOp.BranchConditional, cond, then_l, else_l)
+    ctx.terminated = true
+    emit(m, SEC_FUNCS, SpvOp.Label, then_l)
+    ctx.terminated = false
+    emit_stmt(m, ctx, ite.if_true, errors)
+    if (!ctx.terminated) {
+        emit(m, SEC_FUNCS, SpvOp.Branch, merge)
+        ctx.terminated = true
+    }
+    if (ite.if_false != null) {
+        emit(m, SEC_FUNCS, SpvOp.Label, else_l)
+        ctx.terminated = false
+        emit_stmt(m, ctx, ite.if_false, errors)
+        if (!ctx.terminated) {
+            emit(m, SEC_FUNCS, SpvOp.Branch, merge)
+            ctx.terminated = true
+        }
+    }
+    emit(m, SEC_FUNCS, SpvOp.Label, merge)
+    ctx.terminated = false
+}
+
+// ===== loops (OpLoopMerge, 4-block: header / cond / body / continue + merge) =====
+// Canonical structured-loop shape (matches glslang): the header carries OpLoopMerge then branches to
+// the condition block; the condition block does OpBranchConditional body/merge; the body branches to
+// the continue block; the continue block branches back to the header. break -> merge, continue -> cont.
+// The shared header/cond/continue/merge skeleton. The caller supplies the condition result-id (via
+// `eval_cond`, emitted into the cond block) and the body; `emit_continue` runs in the continue block
+// (range-for's `i += 1`; while passes nothing). Returns nothing — terminator state is left on a fresh
+// merge block.
+def private emit_while(var m : SpirvModule; var ctx : EmitCtx; wh : ExprWhile?; var errors : array<string>) {
+    let header = alloc_id(m)
+    let cond_l = alloc_id(m)
+    let body_l = alloc_id(m)
+    let cont_l = alloc_id(m)
+    let merge = alloc_id(m)
+    emit(m, SEC_FUNCS, SpvOp.Branch, header)
+    emit(m, SEC_FUNCS, SpvOp.Label, header)
+    ctx.terminated = false
+    emit(m, SEC_FUNCS, SpvOp.LoopMerge, merge, cont_l, uint(SpvLoopControl.None))
+    emit(m, SEC_FUNCS, SpvOp.Branch, cond_l)
+    emit(m, SEC_FUNCS, SpvOp.Label, cond_l)
+    ctx.terminated = false
+    let c = emit_value(m, ctx, wh.cond, errors)
+    if (c == 0u) return
+    emit(m, SEC_FUNCS, SpvOp.BranchConditional, c, body_l, merge)
+    emit(m, SEC_FUNCS, SpvOp.Label, body_l)
+    ctx.terminated = false
+    ctx.loop_stack |> push(LoopTargets(merge = merge, cont = cont_l))
+    emit_stmt(m, ctx, wh.body, errors)
+    pop(ctx.loop_stack)
+    if (!ctx.terminated) emit(m, SEC_FUNCS, SpvOp.Branch, cont_l)
+    emit(m, SEC_FUNCS, SpvOp.Label, cont_l)
+    ctx.terminated = false
+    emit(m, SEC_FUNCS, SpvOp.Branch, header)
+    emit(m, SEC_FUNCS, SpvOp.Label, merge)
+    ctx.terminated = false
+}
+
+// `for (i in range(lo, hi))` -> init i = lo; loop while i < hi; continue-block does i += 1. The
+// condition (`i < hi`) and update (`i += 1`) are synthesized directly against the induction
+// OpVariable — there is no daslang AST node for them.
+def private emit_for(var m : SpirvModule; var ctx : EmitCtx; fr : ExprFor?; var errors : array<string>) {
+    if (length(fr.iteratorVariables) != 1 || length(fr.sources) != 1) {
+        errors |> push("for: only a single `i in range(...)` iterator is supported for now")
+        return
+    }
+    let iv = fr.iteratorVariables[0]
+    let lvr = ctx.local_vars?[intptr(iv)] ?? LocalVar()
+    if (lvr.ptr_id == 0u) {
+        errors |> push("for: induction variable '{iv.name}' was not declared")
+        return
+    }
+    let cls = scalar_class(iv._type.baseType)
+    // bounds (lo inclusive, hi exclusive) evaluated ONCE in the pre-header — range captures them at
+    // loop entry. Constant-bound range() folds to ExprConstRange (a half-open [from,to) value);
+    // runtime bounds stay an ExprCall to range()/urange().
+    var lo = 0u
+    var hi = 0u
+    let cr = fr.sources[0] ?as ExprConstRange
+    if (cr != null) {
+        let fromto = unsafe(reinterpret<int2>(cr.value))   // range == { from : int; to : int }
+        lo = const_int_for(m, cls, fromto.x)
+        hi = const_int_for(m, cls, fromto.y)
+    } else {
+        let src = fr.sources[0] ?as ExprCall
+        if (src == null) {
+            errors |> push("for: source is {fr.sources[0].__rtti}, expected range()/urange()")
+            return
+        }
+        if ("{src.name}" != "range" && "{src.name}" != "urange") {
+            errors |> push("for: source call is '{src.name}', expected range()/urange()")
+            return
+        }
+        let na = length(src.arguments)
+        if (na != 1 && na != 2) {
+            errors |> push("for: only range(n) and range(lo, hi) are supported for now (no step)")
+            return
+        }
+        lo = na == 2 ? emit_value(m, ctx, src.arguments[0], errors) : const_zero(m, cls)
+        hi = emit_value(m, ctx, src.arguments[na - 1], errors)
+    }
+    if (lo == 0u || hi == 0u) return
+    emit(m, SEC_FUNCS, SpvOp.Store, lvr.ptr_id, lo)
+    let header = alloc_id(m)
+    let cond_l = alloc_id(m)
+    let body_l = alloc_id(m)
+    let cont_l = alloc_id(m)
+    let merge = alloc_id(m)
+    emit(m, SEC_FUNCS, SpvOp.Branch, header)
+    emit(m, SEC_FUNCS, SpvOp.Label, header)
+    ctx.terminated = false
+    emit(m, SEC_FUNCS, SpvOp.LoopMerge, merge, cont_l, uint(SpvLoopControl.None))
+    emit(m, SEC_FUNCS, SpvOp.Branch, cond_l)
+    emit(m, SEC_FUNCS, SpvOp.Label, cond_l)
+    ctx.terminated = false
+    let cur = alloc_id(m)
+    emit(m, SEC_FUNCS, SpvOp.Load, lvr.value_type, cur, lvr.ptr_id)
+    let cc = cmp_code("<", cls)
+    let cres = alloc_id(m)
+    emit(m, SEC_FUNCS, cc.code, type_bool(m), cres, cur, hi)
+    emit(m, SEC_FUNCS, SpvOp.BranchConditional, cres, body_l, merge)
+    emit(m, SEC_FUNCS, SpvOp.Label, body_l)
+    ctx.terminated = false
+    ctx.loop_stack |> push(LoopTargets(merge = merge, cont = cont_l))
+    emit_stmt(m, ctx, fr.body, errors)
+    pop(ctx.loop_stack)
+    if (!ctx.terminated) emit(m, SEC_FUNCS, SpvOp.Branch, cont_l)
+    emit(m, SEC_FUNCS, SpvOp.Label, cont_l)
+    ctx.terminated = false
+    let cur2 = alloc_id(m)
+    emit(m, SEC_FUNCS, SpvOp.Load, lvr.value_type, cur2, lvr.ptr_id)
+    let nxt = alloc_id(m)
+    emit(m, SEC_FUNCS, binop_code("+", cls).code, lvr.value_type, nxt, cur2, const_one(m, cls))
+    emit(m, SEC_FUNCS, SpvOp.Store, lvr.ptr_id, nxt)
+    emit(m, SEC_FUNCS, SpvOp.Branch, header)
+    emit(m, SEC_FUNCS, SpvOp.Label, merge)
+    ctx.terminated = false
+}
+
 // ===== statement =====
 def private emit_stmt(var m : SpirvModule; var ctx : EmitCtx; s : ExpressionPtr; var errors : array<string>) {
+    // nested lexical block -> inline its statements (locals are function-scoped, already pre-declared)
+    let blk = s ?as ExprBlock
+    if (blk != null) {
+        for (st in blk.list) {
+            emit_stmt(m, ctx, st, errors)
+            break if (ctx.terminated)   // SPIR-V forbids instructions after a block terminator
+        }
+        return
+    }
+    let ite = s ?as ExprIfThenElse
+    if (ite != null) {
+        emit_if(m, ctx, ite, errors)
+        return
+    }
+    let wh = s ?as ExprWhile
+    if (wh != null) {
+        emit_while(m, ctx, wh, errors)
+        return
+    }
+    let fr = s ?as ExprFor
+    if (fr != null) {
+        emit_for(m, ctx, fr, errors)
+        return
+    }
+    if (s is ExprBreak) {
+        if (empty(ctx.loop_stack)) {
+            errors |> push("break outside of a loop")
+            return
+        }
+        emit(m, SEC_FUNCS, SpvOp.Branch, ctx.loop_stack[length(ctx.loop_stack) - 1].merge)
+        ctx.terminated = true
+        return
+    }
+    if (s is ExprContinue) {
+        if (empty(ctx.loop_stack)) {
+            errors |> push("continue outside of a loop")
+            return
+        }
+        emit(m, SEC_FUNCS, SpvOp.Branch, ctx.loop_stack[length(ctx.loop_stack) - 1].cont)
+        ctx.terminated = true
+        return
+    }
     let cp = s ?as ExprCopy
     if (cp != null) {
         let p = emit_ptr(m, ctx, cp.left, errors)
@@ -271,13 +647,43 @@ def private emit_stmt(var m : SpirvModule; var ctx : EmitCtx; s : ExpressionPtr;
         emit(m, SEC_FUNCS, SpvOp.Store, p.id, val)
         return
     }
+    // compound assignment `dst <op>= rhs` arrives as a void-typed ExprOp2
+    let cop2 = s ?as ExprOp2
+    if (cop2 != null && cop2._type.baseType == Type.tVoid) {
+        let base = compound_base("{cop2.op}")
+        let bo = binop_code(base, scalar_class(cop2.left._type.baseType))
+        if (!bo.ok) {
+            errors |> push("unsupported compound assignment '{cop2.op}'")
+            return
+        }
+        emit_load_op_store(m, ctx, cop2.left, bo.code, emit_value(m, ctx, cop2.right, errors), errors)
+        return
+    }
+    // `dst++` / `dst--` arrive as a statement-level ExprOp1
+    let iop1 = s ?as ExprOp1
+    if (iop1 != null && ("{iop1.op}" == "++" || "{iop1.op}" == "--")) {
+        let cls = scalar_class(iop1.subexpr._type.baseType)
+        let bo = binop_code("{iop1.op}" == "++" ? "+" : "-", cls)
+        if (!bo.ok) {
+            errors |> push("unsupported {iop1.op} on {iop1.subexpr._type.baseType}")
+            return
+        }
+        emit_load_op_store(m, ctx, iop1.subexpr, bo.code, const_one(m, cls), errors)
+        return
+    }
     let lt = s ?as ExprLet
     if (lt != null) {
         for (v in lt.variables) {
-            if (v.init != null) {
-                ctx.locals |> insert(intptr(v), emit_value(m, ctx, v.init, errors))
-            } else {
+            if (v.init == null) {
                 errors |> push("uninitialized let '{v.name}' not supported")
+                continue
+            }
+            let lv = ctx.local_vars?[intptr(v)] ?? LocalVar()
+            if (lv.ptr_id != 0u) {                  // mutable: OpVariable pre-declared -> store init
+                let val = emit_value(m, ctx, v.init, errors)
+                if (val != 0u) emit(m, SEC_FUNCS, SpvOp.Store, lv.ptr_id, val)
+            } else {                                // immutable value-let -> bind SSA id
+                ctx.locals |> insert(intptr(v), emit_value(m, ctx, v.init, errors))
             }
         }
         return
@@ -343,6 +749,8 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; local_size : in
     emit(m, SEC_FUNCS, SpvOp.Label, id_label)
     ctx.terminated = false
 
+    // Function-storage OpVariables must lead the entry block, before any body code.
+    collect_locals(m, ctx, fn.body, errors)
     emit_body(m, ctx, fn.body, errors)
 
     if (!ctx.terminated) {

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -160,6 +160,44 @@ def emit_ptr(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var erro
     return (id = 0u, pointee = 0u)
 }
 
+// ===== arithmetic opcode selection =====
+// 0 = signed int, 1 = unsigned int, 2 = float, -1 = other. Vectors classify by their lane kind
+// (IAdd/FAdd/… operate component-wise on vectors with the same opcode as the scalar).
+def private scalar_class(bt : Type) : int {
+    if (bt == Type.tInt || bt == Type.tInt2 || bt == Type.tInt3 || bt == Type.tInt4) return 0
+    if (bt == Type.tUInt || bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4) return 1
+    if (bt == Type.tFloat || bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4) return 2
+    return -1
+}
+
+// daslang binary op -> SPIR-V opcode. Add/Sub/Mul are two's-complement sign-agnostic (IAdd for
+// both int kinds). Div/Rem split by kind. daslang `/` truncates toward zero and `%` takes the
+// dividend's sign (probed) -> SDiv/SRem (not the floored SMod); unsigned -> UDiv/UMod; float ->
+// FDiv/FRem (fmod, dividend's sign).
+def private binop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
+    if (op == "+") return (ok = true, code = cls == 2 ? SpvOp.FAdd : SpvOp.IAdd)
+    if (op == "-") return (ok = true, code = cls == 2 ? SpvOp.FSub : SpvOp.ISub)
+    if (op == "*") return (ok = true, code = cls == 2 ? SpvOp.FMul : SpvOp.IMul)
+    if (op == "/") {
+        if (cls == 2) return (ok = true, code = SpvOp.FDiv)
+        if (cls == 0) return (ok = true, code = SpvOp.SDiv)
+        if (cls == 1) return (ok = true, code = SpvOp.UDiv)
+    }
+    if (op == "%") {
+        if (cls == 2) return (ok = true, code = SpvOp.FRem)
+        if (cls == 0) return (ok = true, code = SpvOp.SRem)
+        if (cls == 1) return (ok = true, code = SpvOp.UMod)
+    }
+    return (ok = false, code = SpvOp.Nop)
+}
+
+// daslang unary op -> SPIR-V opcode. `-` negates (FNegate/SNegate); `~` is bitwise Not (int/uint).
+def private unop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
+    if (op == "-") return (ok = true, code = cls == 2 ? SpvOp.FNegate : SpvOp.SNegate)
+    if (op == "~") return (ok = true, code = SpvOp.Not)
+    return (ok = false, code = SpvOp.Nop)
+}
+
 // ===== rvalue: produce an SSA result-id =====
 def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) : uint {
     // ExprRef2Value wraps a ref lvalue to read its value; running in `patch` (pre-fold) the AST
@@ -169,18 +207,40 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     if (r2v != null) return emit_value(m, ctx, r2v.subexpr, errors)
     let cu = e ?as ExprConstUInt
     if (cu != null) return const_uint(m, cu.value)
+    let ci = e ?as ExprConstInt
+    if (ci != null) return const_int(m, ci.value)
+    let cf = e ?as ExprConstFloat
+    if (cf != null) return const_float(m, cf.value)
     let op2 = e ?as ExprOp2
     if (op2 != null) {
         let l = emit_value(m, ctx, op2.left, errors)
         let r = emit_value(m, ctx, op2.right, errors)
-        if (op2.op == "*" && e._type.isInteger) {
-            let rt = emit_type(m, e._type)
-            let res = alloc_id(m)
-            emit(m, SEC_FUNCS, SpvOp.IMul, rt, res, l, r)
-            return res
+        if (l == 0u || r == 0u) return 0u   // operand error already reported; don't emit with id 0
+        // operand type drives the signed/unsigned/float opcode choice; result type is the same for
+        // arithmetic (comparisons, whose result is bool, arrive in a later phase).
+        let bo = binop_code("{op2.op}", scalar_class(op2.left._type.baseType))
+        if (!bo.ok) {
+            errors |> push("unsupported binary op '{op2.op}' on {op2.left._type.baseType}")
+            return 0u   // no instruction emitted: don't return an undefined result id
         }
-        errors |> push("unsupported binary op '{op2.op}' on {e._type.baseType}")
-        return 0u   // no instruction emitted: don't return an undefined result id
+        let rt = emit_type(m, e._type)
+        let res = alloc_id(m)
+        emit(m, SEC_FUNCS, bo.code, rt, res, l, r)
+        return res
+    }
+    let op1 = e ?as ExprOp1
+    if (op1 != null) {
+        let v = emit_value(m, ctx, op1.subexpr, errors)
+        if (v == 0u) return 0u
+        let uo = unop_code("{op1.op}", scalar_class(op1.subexpr._type.baseType))
+        if (!uo.ok) {
+            errors |> push("unsupported unary op '{op1.op}' on {op1.subexpr._type.baseType}")
+            return 0u
+        }
+        let rt = emit_type(m, e._type)
+        let res = alloc_id(m)
+        emit(m, SEC_FUNCS, uo.code, rt, res, v)
+        return res
     }
     let ev = e ?as ExprVar
     if (ev != null && (ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block)) {

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -171,7 +171,7 @@ def emit_ptr(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var erro
         if (lv.ptr_id != 0u) {
             return (id = lv.ptr_id, pointee = lv.value_type)
         }
-        errors |> push("cannot take a pointer to immutable local '{lev.name}' (only `var` locals are addressable)")
+        errors |> push("cannot take the address of '{lev.name}': only `var` locals are addressable (Function-storage OpVariables); `let` values and arguments are not")
         return (id = 0u, pointee = 0u)
     }
     let gv = global_var_of(e)
@@ -202,6 +202,7 @@ def private scalar_class(bt : Type) : int {
 // dividend's sign (probed) -> SDiv/SRem (not the floored SMod); unsigned -> UDiv/UMod; float ->
 // FDiv/FRem (fmod, dividend's sign).
 def private binop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
+    if (cls < 0) return (ok = false, code = SpvOp.Nop)   // unsupported scalar class: don't masquerade as int
     if (op == "+") return (ok = true, code = cls == 2 ? SpvOp.FAdd : SpvOp.IAdd)
     if (op == "-") return (ok = true, code = cls == 2 ? SpvOp.FSub : SpvOp.ISub)
     if (op == "*") return (ok = true, code = cls == 2 ? SpvOp.FMul : SpvOp.IMul)
@@ -220,8 +221,9 @@ def private binop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> 
 
 // daslang unary op -> SPIR-V opcode. `-` negates (FNegate/SNegate); `~` is bitwise Not (int/uint).
 def private unop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
+    if (cls < 0) return (ok = false, code = SpvOp.Nop)   // unsupported scalar class
     if (op == "-") return (ok = true, code = cls == 2 ? SpvOp.FNegate : SpvOp.SNegate)
-    if (op == "~") return (ok = true, code = SpvOp.Not)
+    if (op == "~" && (cls == 0 || cls == 1)) return (ok = true, code = SpvOp.Not)   // bitwise: int/uint only
     return (ok = false, code = SpvOp.Nop)
 }
 
@@ -360,8 +362,14 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
 // function's first block. So we pre-scan the whole body (one walk, all scopes — SPIR-V locals are
 // function-scoped, not block-scoped) BEFORE emitting any body code, declaring an OpVariable for each
 // mutable local (`var`) and loop-induction variable. Reads/writes then resolve to OpLoad/OpStore.
-def private declare_local_var(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr) {
+def private declare_local_var(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; var errors : array<string>) {
     if (key_exists(ctx.local_vars, intptr(v))) return
+    let bt = v._type.baseType
+    if (scalar_class(bt) < 0 && bt != Type.tBool) {
+        // emit_type would panic on an unsupported base type; reject with a clean error instead.
+        errors |> push("local '{v.name}': type {bt} is not supported yet (only 32-bit int/uint/float scalars+vectors and bool)")
+        return
+    }
     let vt = emit_type(m, v._type)
     let pt = type_pointer(m, SpvStorageClass.Function, vt)
     let pid = alloc_id(m)
@@ -381,7 +389,7 @@ def private collect_locals(var m : SpirvModule; var ctx : EmitCtx; e : Expressio
     let lt = e ?as ExprLet
     if (lt != null) {
         for (v in lt.variables) {
-            if (!v._type.flags.constant) declare_local_var(m, ctx, v)   // `var` -> memory; `let` -> SSA
+            if (!v._type.flags.constant) declare_local_var(m, ctx, v, errors)   // `var` -> memory; `let` -> SSA
         }
         return
     }
@@ -399,7 +407,7 @@ def private collect_locals(var m : SpirvModule; var ctx : EmitCtx; e : Expressio
     let fr = e ?as ExprFor
     if (fr != null) {
         for (fv in fr.iteratorVariables) {
-            declare_local_var(m, ctx, fv)
+            declare_local_var(m, ctx, fv, errors)
         }
         collect_locals(m, ctx, fr.body, errors)
         return

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -529,6 +529,12 @@ def private emit_for(var m : SpirvModule; var ctx : EmitCtx; fr : ExprFor?; var 
         return
     }
     let cls = scalar_class(iv._type.baseType)
+    if (cls != 0 && cls != 1) {
+        // induction must be a 32-bit int/uint; otherwise the synthesized `i < hi` / `i += 1` would
+        // pick a Nop opcode (cmp_code/binop_code return ok=false) and emit invalid SPIR-V silently.
+        errors |> push("for: induction variable '{iv.name}' must be int or uint (got {iv._type.baseType})")
+        return
+    }
     // bounds (lo inclusive, hi exclusive) evaluated ONCE in the pre-header — range captures them at
     // loop entry. Constant-bound range() folds to ExprConstRange (a half-open [from,to) value);
     // runtime bounds stay an ExprCall to range()/urange().

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -87,6 +87,131 @@ def public farith_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-2 control-flow fixtures: mutable locals (Function OpVariables), compound assignment,
+// ++/--, comparisons (signed/unsigned/float), logical &&/||/!, and if/else (OpSelectionMerge +
+// OpBranchConditional). One fixture per scalar class so every comparison-opcode flavor is covered. =====
+[compute_shader(local_size_x=64, name="uctrl_spv"), marker(no_coverage)]
+def uctrl {
+    let i = gl_GlobalInvocationID.x
+    var acc = data[i]           // mutable local -> Function OpVariable + Store
+    var k = 0u
+    k++                         // ++ -> Load/IAdd/Store
+    acc += i                    // += -> IAdd
+    acc -= k                    // -= -> ISub
+    acc *= 2u                   // *= -> IMul
+    if (acc > 100u) {           // UGreaterThan + if/else (SelectionMerge, BranchConditional)
+        acc = acc / 3u
+    } else {
+        acc = acc + 1u
+    }
+    if (acc < i && i != 0u) {   // ULessThan, INotEqual, LogicalAnd, single-branch if
+        acc = 0u
+    }
+    if (!(acc == 7u)) {         // IEqual + LogicalNot
+        acc -= 2u
+    }
+    data[i] = acc
+}
+
+[compute_shader(local_size_x=64, name="ictrl_spv"), marker(no_coverage)]
+def ictrl {
+    let i = gl_GlobalInvocationID.x
+    var acc = idata[i]
+    if (acc >= 0) {             // SGreaterThanEqual
+        acc += 2
+    }
+    if (acc <= 10) {            // SLessThanEqual
+        acc -= 3
+    }
+    if (acc > 0 && acc < 100) { // SGreaterThan, SLessThan, LogicalAnd
+        acc = acc / 2
+    }
+    idata[i] = acc
+}
+
+[compute_shader(local_size_x=64, name="fctrl_spv"), marker(no_coverage)]
+def fctrl {
+    let i = gl_GlobalInvocationID.x
+    var acc = fdata[i]
+    if (acc > 1.0f) {                       // FOrdGreaterThan
+        acc *= 0.5f
+    }
+    if (acc < 0.0f || acc != 2.0f) {        // FOrdLessThan, FOrdNotEqual, LogicalOr
+        acc += 3.0f
+    }
+    if (acc == 0.0f) {                      // FOrdEqual
+        acc = 1.0f
+    }
+    if (acc >= 5.0f && acc <= 9.0f) {       // FOrdGreaterThanEqual, FOrdLessThanEqual
+        acc -= 2.0f
+    }
+    fdata[i] = acc
+}
+
+def public uctrl_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(uctrl_spv)
+    return <- w
+}
+
+def public ictrl_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(ictrl_spv)
+    return <- w
+}
+
+def public fctrl_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(fctrl_spv)
+    return <- w
+}
+
+// ===== Phase-2 loop fixtures: while + range-for (OpLoopMerge 4-block) with break/continue. The
+// structured CFG these produce is the real spirv-val workout — a misrouted break/continue or a
+// missing block terminator fails validation. =====
+[compute_shader(local_size_x=64, name="wloop_spv"), marker(no_coverage)]
+def wloop {
+    let i = gl_GlobalInvocationID.x
+    var acc = 0u
+    var k = data[i]
+    while (k > 0u) {                // OpLoopMerge + UGreaterThan
+        acc += k
+        k--                        // -- decrement (ExprOp1) -> Load/ISub/Store
+        if (acc > 1000u) {
+            break                  // break -> Branch loop merge
+        }
+    }
+    data[i] = acc
+}
+
+[compute_shader(local_size_x=64, name="floop_spv"), marker(no_coverage)]
+def floop {
+    let gi = gl_GlobalInvocationID.x
+    var acc = 0
+    for (j in range(10)) {          // range(n): init 0, SLessThan, IAdd update
+        if (j == 5) {
+            continue               // continue -> Branch loop continue block
+        }
+        acc += j
+    }
+    for (j in range(2, 8)) {        // range(lo, hi): init lo
+        acc -= j
+    }
+    idata[gi] = acc
+}
+
+def public wloop_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(wloop_spv)
+    return <- w
+}
+
+def public floop_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(floop_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -34,6 +34,59 @@ def public square_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-2 arithmetic fixtures: exercise every binary/unary scalar op the emitter supports.
+// Operands are loaded SSBO values (+ the uint index), so no constants/conversions are needed yet —
+// the opcode-shape + spirv-val gates only require each instruction to be emitted and valid. =====
+var @ssbo @binding = 0 idata : array<int>
+var @ssbo @binding = 0 fdata : array<float>
+
+[compute_shader(local_size_x=64, name="uarith_spv"), marker(no_coverage)]
+def uarith {
+    let i = gl_GlobalInvocationID.x
+    data[i] = data[i] + i       // IAdd
+    data[i] = data[i] - i       // ISub
+    data[i] = data[i] * i       // IMul
+    data[i] = data[i] / i       // UDiv
+    data[i] = data[i] % i       // UMod
+}
+
+[compute_shader(local_size_x=64, name="iarith_spv"), marker(no_coverage)]
+def iarith {
+    let i = gl_GlobalInvocationID.x
+    idata[i] = idata[i] / 2     // SDiv  (signed int OpConstant 2)
+    idata[i] = idata[i] % 3     // SRem  (OpConstant 3)
+    idata[i] = -idata[i]        // SNegate
+    idata[i] = ~idata[i]        // Not
+}
+
+[compute_shader(local_size_x=64, name="farith_spv"), marker(no_coverage)]
+def farith {
+    let i = gl_GlobalInvocationID.x
+    fdata[i] = fdata[i] + 1.0f  // FAdd  (float OpConstant 1.0)
+    fdata[i] = fdata[i] - 1.0f  // FSub
+    fdata[i] = fdata[i] * 2.0f  // FMul  (OpConstant 2.0)
+    fdata[i] = fdata[i] / 2.0f  // FDiv
+    fdata[i] = -fdata[i]        // FNegate
+}
+
+def public uarith_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(uarith_spv)
+    return <- w
+}
+
+def public iarith_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(iarith_spv)
+    return <- w
+}
+
+def public farith_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(farith_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -66,6 +66,7 @@ def farith {
     fdata[i] = fdata[i] - 1.0f  // FSub
     fdata[i] = fdata[i] * 2.0f  // FMul  (OpConstant 2.0)
     fdata[i] = fdata[i] / 2.0f  // FDiv
+    fdata[i] = fdata[i] % 2.0f  // FRem  (fmod, dividend's sign)
     fdata[i] = -fdata[i]        // FNegate
 }
 
@@ -282,6 +283,33 @@ def public phase1_emitter_opcodes : table<uint> {
         SpvOp.Constant, SpvOp.Variable,
         SpvOp.Function, SpvOp.Label, SpvOp.AccessChain, SpvOp.Load, SpvOp.IMul, SpvOp.Store,
         SpvOp.Return, SpvOp.FunctionEnd
+    ]) {
+        s |> insert(uint(op))
+    }
+    return <- s
+}
+
+// The EXACT set generate_spirv emits across ALL Phase-2 fixtures (square + arith + control + loops).
+// The census meta-test unions opcode_set over every fixture and asserts equality with this set in
+// BOTH directions — so a newly-emitted-but-unasserted opcode, or a declared opcode that stopped
+// firing, fails the gate. Phase-1 set + the Phase-2 additions:
+def public phase2_emitter_opcodes : table<uint> {
+    var s <- phase1_emitter_opcodes()
+    for (op in [
+        // types newly needed by Phase 2
+        SpvOp.TypeBool, SpvOp.TypeFloat,
+        // arithmetic breadth
+        SpvOp.IAdd, SpvOp.ISub, SpvOp.UDiv, SpvOp.UMod, SpvOp.SDiv, SpvOp.SRem, SpvOp.SNegate, SpvOp.Not,
+        SpvOp.FAdd, SpvOp.FSub, SpvOp.FMul, SpvOp.FDiv, SpvOp.FRem, SpvOp.FNegate,
+        // comparisons (only the flavors the fixtures actually exercise)
+        SpvOp.IEqual, SpvOp.INotEqual, SpvOp.UGreaterThan, SpvOp.ULessThan,
+        SpvOp.SGreaterThan, SpvOp.SLessThan, SpvOp.SGreaterThanEqual, SpvOp.SLessThanEqual,
+        SpvOp.FOrdEqual, SpvOp.FOrdNotEqual, SpvOp.FOrdGreaterThan, SpvOp.FOrdLessThan,
+        SpvOp.FOrdGreaterThanEqual, SpvOp.FOrdLessThanEqual,
+        // logical
+        SpvOp.LogicalAnd, SpvOp.LogicalOr, SpvOp.LogicalNot,
+        // structured control flow
+        SpvOp.SelectionMerge, SpvOp.BranchConditional, SpvOp.Branch, SpvOp.LoopMerge
     ]) {
         s |> insert(uint(op))
     }

--- a/tests/spirv/test_arith.das
+++ b/tests/spirv/test_arith.das
@@ -48,9 +48,9 @@ def test_int_arith(t : T?) {
 
 [test]
 def test_float_arith(t : T?) {
-    t |> run("float arithmetic: FAdd/FSub/FMul/FDiv/FNegate") <| @(t : T?) {
+    t |> run("float arithmetic: FAdd/FSub/FMul/FDiv/FRem/FNegate") <| @(t : T?) {
         var words <- farith_words()
-        check_ops(t, words, "farith", [SpvOp.FAdd, SpvOp.FSub, SpvOp.FMul, SpvOp.FDiv, SpvOp.FNegate])
+        check_ops(t, words, "farith", [SpvOp.FAdd, SpvOp.FSub, SpvOp.FMul, SpvOp.FDiv, SpvOp.FRem, SpvOp.FNegate])
         validate(t, words, "farith")
         delete words
     }

--- a/tests/spirv/test_arith.das
+++ b/tests/spirv/test_arith.das
@@ -1,0 +1,57 @@
+options gen2
+options indenting = 4
+
+// Phase-2 arithmetic gate: every binary/unary scalar op the emitter supports is present in the
+// emitted blob (opcode-shape), and each whole module passes spirv-val. Operands are loaded SSBO
+// values, so these isolate the arithmetic opcode selection (signed/unsigned/float) from constants
+// and conversions (which arrive with control flow).
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private check_ops(t : T?; words : array<uint>; lbl : string; ops : array<SpvOp>) {
+    for (op in ops) {
+        t |> success(has_op(words, op), "{lbl}: emits {op}")
+    }
+}
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_uint_arith(t : T?) {
+    t |> run("uint arithmetic: IAdd/ISub/IMul/UDiv/UMod") <| @(t : T?) {
+        var words <- uarith_words()
+        check_ops(t, words, "uarith", [SpvOp.IAdd, SpvOp.ISub, SpvOp.IMul, SpvOp.UDiv, SpvOp.UMod])
+        validate(t, words, "uarith")
+        delete words
+    }
+}
+
+[test]
+def test_int_arith(t : T?) {
+    t |> run("int arithmetic: SDiv/SRem/SNegate/Not") <| @(t : T?) {
+        var words <- iarith_words()
+        check_ops(t, words, "iarith", [SpvOp.SDiv, SpvOp.SRem, SpvOp.SNegate, SpvOp.Not])
+        validate(t, words, "iarith")
+        delete words
+    }
+}
+
+[test]
+def test_float_arith(t : T?) {
+    t |> run("float arithmetic: FAdd/FSub/FMul/FDiv/FNegate") <| @(t : T?) {
+        var words <- farith_words()
+        check_ops(t, words, "farith", [SpvOp.FAdd, SpvOp.FSub, SpvOp.FMul, SpvOp.FDiv, SpvOp.FNegate])
+        validate(t, words, "farith")
+        delete words
+    }
+}

--- a/tests/spirv/test_builder.das
+++ b/tests/spirv/test_builder.das
@@ -106,3 +106,24 @@ def test_builder_dedup_and_validate(t : T?) {
         delete words
     }
 }
+
+// Regression: const_float must key by raw IEEE-754 bits, not the stringified value. -0.0 and 0.0
+// stringify identically but are distinct bit patterns (0x80000000 vs 0x0) and distinct SPIR-V
+// constants — a stringified key would alias them to one id.
+[test]
+def test_const_float_bitkey(t : T?) {
+    t |> run("builder: const_float keys by bits (0.0 != -0.0), dedup intact") <| @(t : T?) {
+        var m = make_module()
+        let zero = 0.0f
+        let negzero = -zero                 // -0.0 (sign-preserving negate, distinct bit pattern)
+        let id_pos = const_float(m, zero)
+        let id_neg = const_float(m, negzero)
+        t |> success(id_pos != id_neg, "0.0 and -0.0 get distinct constant ids")
+        t |> equal(const_float(m, zero), id_pos)     // dedup still holds per bit pattern
+        t |> equal(const_float(m, negzero), id_neg)
+        var words <- module_words(m)
+        delete m
+        t |> equal(count_op(words, SpvOp.Constant), 2)   // two distinct OpConstant, not collapsed
+        delete words
+    }
+}

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -1,28 +1,50 @@
 options gen2
 options indenting = 4
 
-// Census gate (gate B): the set of opcodes the emitter actually produces for the square must
-// equal the declared Phase-1 set, in both directions. Stronger than line coverage — it catches
-// an opcode whose emit line ran but was never asserted, and a declared opcode that stopped firing.
+// Census gate (gate B): the union of opcodes the emitter produces across EVERY fixture must equal
+// the declared supported set, in both directions. Stronger than line coverage — it catches an
+// opcode whose emit line ran but was never asserted by any test, and a declared opcode that stopped
+// firing. Failure messages resolve the numeric opcode to its OpName for readability.
 
 require dastest/testing_boost public
 require _spirv_common
 require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private op_name(op : uint) : string {
+    return SPV_OP_NAMES?[op] ?? "op#{op}"
+}
+
+def private add_set(var dst : table<uint>; var words : array<uint>) {
+    var s <- opcode_set(words)
+    for (op in keys(s)) {
+        dst |> insert(op)
+    }
+    delete s
+    delete words
+}
 
 [test]
 def test_opcode_census(t : T?) {
-    t |> run("emitter opcode census == declared Phase-1 set") <| @(t : T?) {
-        var words <- square_words()
-        var present <- opcode_set(words)
-        var declared <- phase1_emitter_opcodes()
+    t |> run("emitter opcode census == declared Phase-2 set (all fixtures)") <| @(t : T?) {
+        var present : table<uint>
+        add_set(present, square_words())
+        add_set(present, uarith_words())
+        add_set(present, iarith_words())
+        add_set(present, farith_words())
+        add_set(present, uctrl_words())
+        add_set(present, ictrl_words())
+        add_set(present, fctrl_words())
+        add_set(present, wloop_words())
+        add_set(present, floop_words())
+        var declared <- phase2_emitter_opcodes()
         for (op in keys(present)) {
-            t |> success(key_exists(declared, op), "emitted opcode {op} is in the declared set")
+            t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }
         for (op in keys(declared)) {
-            t |> success(key_exists(present, op), "declared opcode {op} is actually emitted")
+            t |> success(key_exists(present, op), "declared {op_name(op)} is actually emitted")
         }
         delete present
         delete declared
-        delete words
     }
 }

--- a/tests/spirv/test_control.das
+++ b/tests/spirv/test_control.das
@@ -1,0 +1,71 @@
+options gen2
+options indenting = 4
+
+// Phase-2 control-flow gate: mutable locals (Function OpVariable + Load/Store), compound assignment,
+// ++/--, comparisons (signed/unsigned/float), logical &&/||/!, and if/else (OpSelectionMerge +
+// OpBranchConditional + Branch). One fixture per scalar class so every comparison flavor is asserted;
+// every emitted module passes spirv-val (the structured-CFG / define-before-use oracle).
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private check_ops(t : T?; words : array<uint>; lbl : string; ops : array<SpvOp>) {
+    for (op in ops) {
+        t |> success(has_op(words, op), "{lbl}: emits {op}")
+    }
+}
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_uint_control(t : T?) {
+    t |> run("uint control flow: var/compound/++/cmp/logical/if-else") <| @(t : T?) {
+        var words <- uctrl_words()
+        // mutable local + if/else structure
+        check_ops(t, words, "uctrl", [SpvOp.Variable, SpvOp.Load, SpvOp.Store,
+            SpvOp.SelectionMerge, SpvOp.BranchConditional, SpvOp.Branch])
+        // compound assignment arithmetic + ++ (IAdd)
+        check_ops(t, words, "uctrl", [SpvOp.IAdd, SpvOp.ISub, SpvOp.IMul, SpvOp.UDiv])
+        // unsigned comparisons + equality + logical
+        check_ops(t, words, "uctrl", [SpvOp.UGreaterThan, SpvOp.ULessThan, SpvOp.IEqual,
+            SpvOp.INotEqual, SpvOp.LogicalAnd, SpvOp.LogicalNot])
+        // a Function-storage OpVariable was declared for the mutable locals
+        t |> success(op_has_operand(words, SpvOp.Variable, uint(SpvStorageClass.Function)),
+            "uctrl: has a Function-storage OpVariable")
+        validate(t, words, "uctrl")
+        delete words
+    }
+}
+
+[test]
+def test_int_control(t : T?) {
+    t |> run("int control flow: signed comparisons") <| @(t : T?) {
+        var words <- ictrl_words()
+        check_ops(t, words, "ictrl", [SpvOp.SGreaterThanEqual, SpvOp.SLessThanEqual,
+            SpvOp.SGreaterThan, SpvOp.SLessThan, SpvOp.LogicalAnd,
+            SpvOp.SelectionMerge, SpvOp.BranchConditional])
+        validate(t, words, "ictrl")
+        delete words
+    }
+}
+
+[test]
+def test_float_control(t : T?) {
+    t |> run("float control flow: ordered comparisons") <| @(t : T?) {
+        var words <- fctrl_words()
+        check_ops(t, words, "fctrl", [SpvOp.FOrdGreaterThan, SpvOp.FOrdLessThan,
+            SpvOp.FOrdNotEqual, SpvOp.FOrdEqual, SpvOp.FOrdGreaterThanEqual,
+            SpvOp.FOrdLessThanEqual, SpvOp.LogicalOr])
+        validate(t, words, "fctrl")
+        delete words
+    }
+}

--- a/tests/spirv/test_loops.das
+++ b/tests/spirv/test_loops.das
@@ -1,0 +1,49 @@
+options gen2
+options indenting = 4
+
+// Phase-2 loop gate: while + range-for lowered to the structured 4-block OpLoopMerge shape, with
+// break (-> loop merge) and continue (-> loop continue block). Opcode-shape asserts plus spirv-val,
+// which is the real oracle here: an invalid loop CFG (bad merge/continue targets, a block without a
+// terminator, code after a terminator) fails validation even when every opcode is "present".
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private check_ops(t : T?; words : array<uint>; lbl : string; ops : array<SpvOp>) {
+    for (op in ops) {
+        t |> success(has_op(words, op), "{lbl}: emits {op}")
+    }
+}
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_while_loop(t : T?) {
+    t |> run("while loop with break: OpLoopMerge structured CFG") <| @(t : T?) {
+        var words <- wloop_words()
+        check_ops(t, words, "wloop", [SpvOp.LoopMerge, SpvOp.BranchConditional, SpvOp.Branch,
+            SpvOp.Label, SpvOp.UGreaterThan, SpvOp.IAdd, SpvOp.ISub])
+        validate(t, words, "wloop")
+        delete words
+    }
+}
+
+[test]
+def test_range_for(t : T?) {
+    t |> run("range-for with continue: range(n) + range(lo,hi)") <| @(t : T?) {
+        var words <- floop_words()
+        check_ops(t, words, "floop", [SpvOp.LoopMerge, SpvOp.BranchConditional, SpvOp.Branch,
+            SpvOp.SLessThan, SpvOp.IEqual, SpvOp.IAdd, SpvOp.ISub])
+        validate(t, words, "floop")
+        delete words
+    }
+}


### PR DESCRIPTION
Phase 2 of the pure-daslang daslang→SPIR-V shader backend (`modules/dasSpirv`), building on the Phase-1 compute-square milestone (#3133). The emitter goes from "square only" to a real scalar shader language: full arithmetic, comparisons, logical ops, and the complete structured-control-flow set.

### What's new in `spirv_emit.das`

**Arithmetic breadth** (`+ - * / %`, unary `- ~`)
- `IAdd`/`ISub`/`IMul` (two's-complement sign-agnostic), `SDiv`/`UDiv`/`FDiv`, `SRem`/`UMod`/`FRem`, `SNegate`/`FNegate`, `Not`.
- Op-semantics probed against daslang: `/` truncates toward zero and `%` takes the **dividend's** sign (C semantics) → int `%` is `OpSRem` (not floored `OpSMod`), int `/` is `OpSDiv`; uint → `UDiv`/`UMod`; float → `FDiv`/`FRem` (fmod).

**Control flow**
- **Mutable locals** (`var`) and loop-induction variables become Function-storage `OpVariable`s — a one-pass pre-scan declares them leading the entry block (SPIR-V requires it), reads/writes lower to `OpLoad`/`OpStore`, and the driver mem2reg's them (no hand-rolled `OpPhi`). Immutable value-lets (`let`) stay pure SSA, so the Phase-1 square emission and its exact-count/census asserts are unchanged.
- **Compound assignment** (`+= -= *= /= %=`) and **`++`/`--`** via load-modify-store.
- **Comparisons** (`== != < > <= >=`) → bool, with signed/unsigned/float opcode chosen by operand class (`IEqual`/`INotEqual` sign-agnostic; ordering split; floats use the ordered `FOrd*` forms).
- **Logical** `&&`/`||` → `OpLogicalAnd`/`OpLogicalOr`, `!` → `OpLogicalNot`. Eager (not short-circuit) — valid because shader condition operands are side-effect free.
- **if/else** → `OpSelectionMerge` + `OpBranchConditional`. **while** + **range-for** → the canonical 4-block `OpLoopMerge` shape. **break/continue** → `OpBranch` to merge/continue off a loop-stack. range-for handles both the constant-folded `ExprConstRange` and the runtime `ExprCall range()/urange()` forms; the `i < hi` test and `i += 1` update are synthesized directly against the induction `OpVariable`.

### Tests / gates

- `tests/spirv/test_arith.das`, `test_control.das`, `test_loops.das` — per-op opcode-shape asserts (uint/int/float fixtures so every comparison + arithmetic flavor is exercised) + `spirv-val` on every blob.
- **Census gate (B) now aggregates across ALL fixtures** — `test_census.das` unions the emitted opcode set over square + arith + control + loops and asserts equality with the declared set in both directions (resolving opcodes to their `OpName` on failure). This caught a real gap: float `%` (`FRem`) was reachable but unexercised, so a `fdata[i] % 2.0f` line was added — test-per-instruction restored.

### Verification

All three tiers green — **interpreter / JIT / AOT 26/26** — every emitted blob `spirv-val`-clean, external `spirv-dis` confirms textbook structured CFG, lint + format clean. Implementation log + the load-bearing AST findings are recorded in `modules/dasSpirv/MASTERPLAN.md`.

Three commits: arithmetic breadth → control flow → aggregate census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)