### PR TITLE
infer: clean error instead of assert on mismatched default argument (#3065)

### DIFF
--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -1471,7 +1471,11 @@ namespace das {
                                 return nullptr;
                             }
                             auto retT = TypeDecl::inferGenericType(mkStruct->type, funcC->arguments[iF]->type, true, true, nullptr);
-                            DAS_ASSERTF(retT, "how? it matched during findMatchingFunctions the same way");
+                            if ( !retT ) {
+                                error("default arguments don't match the function signature of '" + funcC->name + "'", "", "",
+                                    expr->at, CompilationError::mismatching_function_argument);
+                                return nullptr;
+                            }
                             TypeDecl::applyAutoContracts(mkStruct->type, funcC->arguments[iF]->type);
                             mkStruct->makeType = retT;
                             reportAstChanged();

--- a/tests/typer_errors/failed_default_argument_mismatch.das
+++ b/tests/typer_errors/failed_default_argument_mismatch.das
@@ -1,0 +1,19 @@
+// Regression test for issue #3065 (fuzzer): a generic function whose tuple-typed
+// parameter defaults to an empty make-struct `<- {}` (parsed as table<auto;auto>)
+// drove inferGenericType to return null in ExprCall's forward-type loop, where a
+// DAS_ASSERTF assumed it never could ("how? it matched during findMatchingFunctions
+// the same way"). In release that fell through to a null makeType and crashed in
+// ExprMakeStruct::visit. The guard now returns cleanly, so the bad default surfaces
+// as ordinary compile errors instead of a crash.
+options gen2
+expect 30161, 30254, 30341
+
+tuple var0 {}
+
+def var0(v; r : var0 <- {}) {
+}
+
+[export]
+def n {
+    var0(0)
+}


### PR DESCRIPTION
Third fix in the #3065 fuzzer-bug sweep (after #3134, #3136).

## Bug

When a generic function is instantiated and one of its arguments is an auto-typed make-struct (e.g. an empty `{}` standing in for an array / table / tuple parameter), `ExprCall`'s forward-type inference calls `TypeDecl::inferGenericType` to resolve the make-struct's concrete type. A

```cpp
DAS_ASSERTF(retT, "how? it matched during findMatchingFunctions the same way");
```

assumed this could never fail — but a fuzzer payload whose default doesn't match the parameter signature makes it return `null`. In debug the assert fires; in release the null `retT` flows into `mkStruct->makeType` and crashes in `ExprMakeStruct::visit` (`EXCEPTION_ACCESS_VIOLATION`):

```
optimizationFinal → visitModule → Function::visit → ExprCall::visit → ExprMakeStruct::visit
```

## Fix

Replace the assert with the same `mismatching_function_argument` guard the block/lambda branch just above already uses — report cleanly and bail:

```cpp
auto retT = TypeDecl::inferGenericType(mkStruct->type, funcC->arguments[iF]->type, true, true, nullptr);
if ( !retT ) {
    error("default arguments don't match the function signature of '" + funcC->name + "'", "", "",
        expr->at, CompilationError::mismatching_function_argument);
    return nullptr;
}
```

The early `return nullptr` is the load-bearing change (it prevents the null `makeType`). For this particular payload the 30404 message itself is redundant and gets filtered downstream, so the bad default surfaces as the ordinary default-value / no-matching-call diagnostics — a clean compile failure instead of a crash.

## Test

`tests/typer_errors/failed_default_argument_mismatch.das` — a tuple-typed parameter defaulting to `<- {}`, called so the default is used (reduced from the #3065 fuzzer payload):

```das
tuple var0 {}
def var0(v; r : var0 <- {}) {}
[export]
def n {
    var0(0)
}
```

- **Crashes** the unfixed compiler (`0xC0000005` in `ExprMakeStruct::visit`).
- **Compiles to clean errors** with the fix: `expect 30161, 30254, 30341`.

## Validation

- preflight `--full`: 14/14 gates green (format, lint, cpp-syntax, dasgen, ci-das, docs ×6, tests-cpp, interp, JIT).
- AOT not separately swept: the guard only fires on the error path (for any valid program `retT` is non-null and codegen is byte-identical to master — the replaced `DAS_ASSERTF` was already a no-op in release), and the test is `failed_`-prefixed → AOT-excluded. CI's AOT lane covers it.

Part of #3065 (fuzzer bugs).