### PR TITLE
dasSpirv Phase 3: vertex/fragment shaders

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -605,3 +605,12 @@ vertex/fragment structure, lint + format clean.
 (commit 2) + tests/census/masterplan (commit 3). The cross-repo triangle-on-GPU gate (dasVulkan: port
 `triangle.vert`/`.frag` to `[vertex_shader]`/`[fragment_shader]`, delete the committed `.spv`, regress
 the triangle PPM on lavapipe + local GPU) is the follow-on dasVulkan PR, mirroring Phase 1's GPU gate.
+
+**Review hardening (#3139).** Copilot review surfaced a stage-legality gap in the fail-closed surface:
+`classify_global` recognized vertex/fragment builtins but didn't check they were legal for the *current*
+stage, so a vertex shader referencing `gl_FragCoord` would silently emit a blob that only spirv-val
+would reject. Fixed: `builtin_info` now records the single stage each builtin is valid in (`req`),
+`classify_global` takes the `ShaderStage` and rejects a cross-stage builtin (and `@in`/`@out` Location
+I/O in a compute shader) with a clean `error[...]` — restoring "stage drives which builtins are legal."
+Also tightened the two `op_first_operand` entry-model asserts in `test_raster.das` to check `.ok` (an
+empty/truncated module's default `value` 0 collides with `SpvExecutionModel.Vertex`).

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -614,3 +614,13 @@ would reject. Fixed: `builtin_info` now records the single stage each builtin is
 I/O in a compute shader) with a clean `error[...]` — restoring "stage drives which builtins are legal."
 Also tightened the two `op_first_operand` entry-model asserts in `test_raster.das` to check `.ok` (an
 empty/truncated module's default `value` 0 collides with `SpvExecutionModel.Vertex`).
+
+Round 2 (same fail-closed family): the vector constructor only checked lane *count*, not component
+*kind* — `int4(float4(...))`/`int4(float2(...), ...)` would alias the wrong-typed id or mix kinds and
+emit invalid SPIR-V. `vector_ctor` now carries the component class; both the single-arg (identity/splat)
+and multi-arg paths reject a constituent whose `scalar_class` differs from the constructor's class with a
+clean "component-kind conversion not supported yet" error (real conversions need `OpConvert*`, deferred).
+Test robustness: added a positional `op_has_operand_at(words, op, idx, value)` to `spirv_dis` and moved
+the three position-sensitive asserts to it (OpVariable storage class at index 2 in `test_raster` +
+`test_control`; OpExecutionMode mode at index 1) — a bare `op_has_operand` value match can false-positive
+against the result-type/id operands when the enum value is a small number.

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -541,3 +541,67 @@ clean error instead of letting `emit_type` panic. Net rule for the emitter: **ev
 dispatch validates its input and produces a clean `error[...]`, never a silent bad blob or a panic.**
 The remaining `emit_type`/`emit_component_type` panics are now unreachable for valid daslang (all
 callers pre-validate); they stand as internal invariants.
+
+### Phase 3 — vertex/fragment shaders LANDED (2026-06-14, branch `bbatkin/dasspirv-phase3`)
+
+The emitter goes from compute-only to all three rasterization-relevant stages. All three tiers green
+(interp/JIT/AOT 36/36), every emitted blob spirv-val clean, external `spirv-dis` confirms textbook
+vertex/fragment structure, lint + format clean.
+
+- **Stage parameterization.** `generate_spirv` gained a `stage : ShaderStage` (Compute/Vertex/Fragment)
+  argument driving the entry-point execution model (`GLCompute`/`Vertex`/`Fragment`) and execution mode:
+  Compute → `LocalSize`, Fragment → `OriginUpperLeft`, Vertex → none. The annotation classes carry the
+  stage via a virtual `shader_stage()` method — `SpirvComputeShader`/`SpirvVertexShader`/
+  `SpirvFragmentShader` are now all `[function_macro]` subclasses of `SpirvShader` (the base defaults to
+  Compute, vertex/fragment override). New annotations: `[vertex_shader]`, `[fragment_shader]`.
+- **Stage I/O (`@in`/`@out` + `@location`).** `classify_global` now recognizes `@in`/`@out` user
+  variables: Input/Output `OpVariable` + a `Location` decoration, listed in the entry-point interface.
+  `@location` is **required and must be non-negative** (fail-closed: a missing/negative location is a
+  clean error, not a silent collide-at-0). `@in`+`@out` together is rejected.
+- **Rasterizer builtins.** `builtin_info` extends the compute builtin table with `gl_Position` (Output,
+  BuiltIn Position), `gl_VertexIndex` / `gl_InstanceIndex` (Input, int) and `gl_FragCoord` (Input,
+  float4). The storage class is now part of the builtin record (compute IDs + the indices/FragCoord are
+  Input; only `gl_Position` is Output) — `classify_global` emits the right pointer storage + lists both
+  Input and Output builtins in the interface. **`gl_Position` is a standalone Output decorated `BuiltIn
+  Position`** (no `gl_PerVertex` block) — spirv-val `--target-env vulkan1.1` accepts it; the GLSL ABI
+  block is not a SPIR-V requirement.
+- **Entry-point interface (SPIR-V ≤ 1.3).** The interface lists exactly the Input/Output vars (stage I/O
+  + Input/Output builtins); SSBO StorageBuffer globals are correctly excluded (the ≤1.3 rule).
+- **Vector constructors → `OpCompositeConstruct`.** `float2/3/4`, `int2/3/4`, `uint2/3/4` arrive as
+  `ExprCall`. One scalar arg → splat (repeat the lane N times); one same-width vector arg → identity
+  (pass through); multiple args → CompositeConstruct of the constituents, each contributing its lanes
+  (a `vec2` contributes 2, so `float4(vec2, s, s)` works). **Lane count is validated** (constituent
+  lanes must sum to N) — a malformed constructor is a clean error.
+- **`dot` → core `OpDot`.** Not an ext-inst — the core op (vector·vector → scalar).
+- **GLSL.std.450 math → `OpExtInst`.** `OpExtInstImport "GLSL.std.450"` is emitted lazily (once, cached
+  in `ctx.glsl_ext`) the first time a math builtin is used. `glsl_ext_op` maps daslang math names to the
+  ext-inst opcode, **class-aware** for `abs`/`min`/`max`/`clamp`/`sign` (F/S/U variant by operand class)
+  with the rest float-only; an unsupported name or wrong class is a clean error (fail-closed).
+- **Tests:** `tests/spirv/test_raster.das` — vertex passthrough (`@in`/`@out` + Location, `gl_Position`,
+  `float4(vec2, s, s)`), fragment passthrough (`OriginUpperLeft`, `float4(vec3, s)`), vertex
+  builtins (`gl_VertexIndex`/`gl_InstanceIndex`), fragment math (`gl_FragCoord` + dot/sqrt/clamp). The
+  EntryPoint execution model is asserted via a new `op_first_operand` helper in `spirv_dis` (positional —
+  `op_has_operand` is unreliable because `Vertex == 0` collides with the name's NUL word). Census gate
+  extended to `phase3_emitter_opcodes` = Phase-2 set + `CompositeConstruct`/`Dot`/`ExtInstImport`/
+  `ExtInst`, unioned over the four new fixtures.
+
+**Findings (load-bearing):**
+
+1. **`dot`/`sqrt`/`clamp`/etc. need `require math` in the fixture file.** They're `math` builtins; without
+   the require they fail typecheck (`module math is not visible directly`) before the emitter ever runs.
+2. **Class virtual method call: drop `self->`.** `self->shader_stage()` trips STYLE028 — call
+   `shader_stage()` unqualified inside the method; the compiler auto-promotes to the same virtual invoke.
+3. **`gl_Position` standalone Output works** (no `gl_PerVertex` block needed for Vulkan ≤1.3) — confirmed
+   by spirv-val. Keeps the emitter simple; the block wrapper can come later only if a stage needs
+   `gl_PointSize`/`gl_ClipDistance`.
+4. **Local-value swizzles (`p.x` on a `let`) are NOT yet supported** — only single-component swizzle of a
+   *global* (via OpAccessChain). Reading a component of a local SSA value needs `OpCompositeExtract`;
+   deferred. The Phase-3 fixtures avoid it (they swizzle only globals, e.g. `gl_GlobalInvocationID.x`).
+5. **Vector·scalar ops (`vec * float`) are NOT yet supported** — would need `OpVectorTimesScalar` (the
+   plain `ExprOp2` path emits `OpFMul`, which requires matching operand types). Deferred to a later slice;
+   the fixtures avoid it.
+
+**Phase 3 COMPLETE** — stages + I/O + builtins + interface (commit 1) + constructors/dot/ext-inst
+(commit 2) + tests/census/masterplan (commit 3). The cross-repo triangle-on-GPU gate (dasVulkan: port
+`triangle.vert`/`.frag` to `[vertex_shader]`/`[fragment_shader]`, delete the committed `.spv`, regress
+the triangle PPM on lavapipe + local GPU) is the follow-on dasVulkan PR, mirroring Phase 1's GPU gate.

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -3,7 +3,8 @@ options gen2
 // Shader builtin globals, recognized by name in the emitter (mirrors dasGlsl's glsl_common
 // gl_* declarations). They exist only so authored shader code typechecks; the shader body is
 // never executed in daslang — only its AST is read and lowered to SPIR-V. Each maps to a
-// BuiltIn-decorated Input variable in spirv_emit.das.
+// BuiltIn-decorated variable in spirv_emit.das — Input for read-only builtins (the compute IDs,
+// gl_VertexIndex/gl_InstanceIndex, gl_FragCoord), Output for gl_Position (the one written builtin).
 
 module spirv_builtins shared public
 

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -13,3 +13,11 @@ var gl_WorkGroupID          : uint3     // WorkgroupId
 var gl_LocalInvocationID    : uint3     // LocalInvocationId
 var gl_GlobalInvocationID   : uint3     // GlobalInvocationId
 var gl_LocalInvocationIndex : uint      // LocalInvocationIndex
+
+// vertex (gl_Position is the one Output builtin; the indices are Inputs)
+var gl_Position             : float4    // BuiltIn Position (Output)
+var gl_VertexIndex          : int       // BuiltIn VertexIndex (Input)
+var gl_InstanceIndex        : int       // BuiltIn InstanceIndex (Input)
+
+// fragment
+var gl_FragCoord            : float4    // BuiltIn FragCoord (Input)

--- a/modules/dasSpirv/spirv/spirv_dis.das
+++ b/modules/dasSpirv/spirv/spirv_dis.das
@@ -88,6 +88,21 @@ def public op_has_operand_pair(words : array<uint>; op : SpvOp; first : uint; se
     return found
 }
 
+// First operand of the first instruction with `op` (e.g. OpEntryPoint's execution model). Use this
+// instead of op_has_operand when the operand's POSITION matters: an EntryPoint's model value can
+// collide with a later operand (Vertex == 0 matches the name's NUL-terminator word, ids, etc.).
+def public op_first_operand(words : array<uint>; op : SpvOp) : tuple<ok : bool; value : uint> {
+    var ok = false
+    var value = 0u
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (opcode == uint(op) && n > 0 && !ok) {
+            ok = true
+            value = w[s]
+        }
+    }
+    return (ok = ok, value = value)
+}
+
 // Symbolic dump for eyeballing / diffing against external spirv-dis. Operands are printed as
 // raw decimal words (a result-id-aware pretty printer is a later refinement).
 def public dump(words : array<uint>) : string {

--- a/modules/dasSpirv/spirv/spirv_dis.das
+++ b/modules/dasSpirv/spirv/spirv_dis.das
@@ -103,6 +103,20 @@ def public op_first_operand(words : array<uint>; op : SpvOp) : tuple<ok : bool; 
     return (ok = ok, value = value)
 }
 
+// Does any instruction with `op` carry `value` at operand index `idx` (0-based, after word0)?
+// Positional — use this when the operand's POSITION matters and a bare value would false-positive
+// (e.g. OpVariable's storage class at index 2: op_has_operand would also match the result-type/id
+// operands, and small storage-class values like Output collide with ordinary ids).
+def public op_has_operand_at(words : array<uint>; op : SpvOp; idx : int; value : uint) : bool {
+    var found = false
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (opcode == uint(op) && idx < n && w[s + idx] == value) {
+            found = true
+        }
+    }
+    return found
+}
+
 // Symbolic dump for eyeballing / diffing against external spirv-dis. Operands are printed as
 // raw decimal words (a result-id-aware pretty printer is a later refinement).
 def public dump(words : array<uint>) : string {

--- a/modules/dasSpirv/spirv/spirv_dis.das
+++ b/modules/dasSpirv/spirv/spirv_dis.das
@@ -110,7 +110,7 @@ def public op_first_operand(words : array<uint>; op : SpvOp) : tuple<ok : bool; 
 def public op_has_operand_at(words : array<uint>; op : SpvOp; idx : int; value : uint) : bool {
     var found = false
     foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
-        if (opcode == uint(op) && idx < n && w[s + idx] == value) {
+        if (opcode == uint(op) && idx >= 0 && idx < n && w[s + idx] == value) {
             found = true
         }
     }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -64,30 +64,42 @@ def finalize(var c : EmitCtx) {
     delete c.loop_stack
 }
 
-// ===== builtin name -> SpvBuiltIn + storage class (compute + vertex/fragment) =====
-// Most builtins are read-only Inputs; gl_Position is the one written Output. The storage class is
-// what decides whether the variable's pointer type is Input or Output and how it is written.
-def private builtin_info(name : string) : tuple<ok : bool; bi : SpvBuiltIn; storage : SpvStorageClass> {
+// ===== builtin name -> SpvBuiltIn + storage class + the stage it's legal in =====
+// Most builtins are read-only Inputs; gl_Position is the one written Output. The storage class
+// decides Input vs Output pointer type; `req` is the single stage the builtin is valid in, so
+// classify_global can reject a cross-stage reference (e.g. gl_FragCoord in a vertex shader) with a
+// clean error instead of emitting a blob that only spirv-val would catch.
+def private builtin_info(name : string) : tuple<ok : bool; bi : SpvBuiltIn; storage : SpvStorageClass; req : ShaderStage> {
     // compute
-    if (name == "gl_GlobalInvocationID") return (ok = true, bi = SpvBuiltIn.GlobalInvocationId, storage = SpvStorageClass.Input)
-    if (name == "gl_LocalInvocationID") return (ok = true, bi = SpvBuiltIn.LocalInvocationId, storage = SpvStorageClass.Input)
-    if (name == "gl_WorkGroupID") return (ok = true, bi = SpvBuiltIn.WorkgroupId, storage = SpvStorageClass.Input)
-    if (name == "gl_NumWorkGroups") return (ok = true, bi = SpvBuiltIn.NumWorkgroups, storage = SpvStorageClass.Input)
-    if (name == "gl_LocalInvocationIndex") return (ok = true, bi = SpvBuiltIn.LocalInvocationIndex, storage = SpvStorageClass.Input)
+    if (name == "gl_GlobalInvocationID") return (ok = true, bi = SpvBuiltIn.GlobalInvocationId, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
+    if (name == "gl_LocalInvocationID") return (ok = true, bi = SpvBuiltIn.LocalInvocationId, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
+    if (name == "gl_WorkGroupID") return (ok = true, bi = SpvBuiltIn.WorkgroupId, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
+    if (name == "gl_NumWorkGroups") return (ok = true, bi = SpvBuiltIn.NumWorkgroups, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
+    if (name == "gl_LocalInvocationIndex") return (ok = true, bi = SpvBuiltIn.LocalInvocationIndex, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
     // vertex
-    if (name == "gl_Position") return (ok = true, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Output)
-    if (name == "gl_VertexIndex") return (ok = true, bi = SpvBuiltIn.VertexIndex, storage = SpvStorageClass.Input)
-    if (name == "gl_InstanceIndex") return (ok = true, bi = SpvBuiltIn.InstanceIndex, storage = SpvStorageClass.Input)
+    if (name == "gl_Position") return (ok = true, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Output, req = ShaderStage.Vertex)
+    if (name == "gl_VertexIndex") return (ok = true, bi = SpvBuiltIn.VertexIndex, storage = SpvStorageClass.Input, req = ShaderStage.Vertex)
+    if (name == "gl_InstanceIndex") return (ok = true, bi = SpvBuiltIn.InstanceIndex, storage = SpvStorageClass.Input, req = ShaderStage.Vertex)
     // fragment
-    if (name == "gl_FragCoord") return (ok = true, bi = SpvBuiltIn.FragCoord, storage = SpvStorageClass.Input)
-    return (ok = false, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Input)
+    if (name == "gl_FragCoord") return (ok = true, bi = SpvBuiltIn.FragCoord, storage = SpvStorageClass.Input, req = ShaderStage.Fragment)
+    return (ok = false, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
+}
+
+def private stage_name(stage : ShaderStage) : string {
+    if (stage == ShaderStage.Vertex) return "vertex"
+    if (stage == ShaderStage.Fragment) return "fragment"
+    return "compute"
 }
 
 // ===== global variable classification + emission =====
-def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; var errors : array<string>) {
+def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; stage : ShaderStage; var errors : array<string>) {
     let vname = "{v.name}"
     let bi = builtin_info(vname)
     if (bi.ok) {
+        if (bi.req != stage) {
+            errors |> push("builtin '{vname}' is only available in the {stage_name(bi.req)} stage, not {stage_name(stage)}")
+            return
+        }
         let vt = emit_type(m, v._type)
         let pt = type_pointer(m, bi.storage, vt)
         let vid = alloc_id(m)
@@ -102,6 +114,10 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
     let is_in = v.annotation |> find_arg("in") is tBool
     let is_out = v.annotation |> find_arg("out") is tBool
     if (is_in || is_out) {
+        if (stage == ShaderStage.Compute) {
+            errors |> push("stage variable '{vname}': @in/@out Location I/O is not valid in a compute shader")
+            return
+        }
         if (is_in && is_out) {
             errors |> push("stage variable '{vname}' cannot be both @in and @out")
             return
@@ -975,7 +991,7 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; stage : ShaderS
 
     collect_dependencies(fn) $(_vfun, vvar) {
         for (v in vvar) {
-            classify_global(m, ctx, v, errors)
+            classify_global(m, ctx, v, stage, errors)
         }
     }
 

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -16,6 +16,14 @@ require daslib/ast
 require daslib/rtti
 require daslib/ast_boost
 
+// The shader stage drives the entry-point execution model + execution mode and which builtins
+// are legal. Vertex needs no execution mode; Fragment needs OriginUpperLeft; Compute needs LocalSize.
+enum public ShaderStage {
+    Compute
+    Vertex
+    Fragment
+}
+
 // ===== per-global classification =====
 struct GlobalInfo {
     var_id     : uint
@@ -39,6 +47,7 @@ struct EmitCtx {
     interface_ids : array<uint>                 // EntryPoint interface (Input/Output vars, SPIR-V <= 1.3)
     loop_stack    : array<LoopTargets>          // innermost loop's {merge, continue} for break/continue
     terminated    : bool                        // current block already has a terminator
+    glsl_ext      : uint                        // OpExtInstImport "GLSL.std.450" set id (0 = not imported yet)
 }
 
 // break -> branch to `merge`, continue -> branch to `cont`. Pushed per active loop.
@@ -55,27 +64,60 @@ def finalize(var c : EmitCtx) {
     delete c.loop_stack
 }
 
-// ===== builtin name -> SpvBuiltIn (compute subset; extended in later phases) =====
-def private builtin_for_name(name : string) : tuple<ok : bool; bi : SpvBuiltIn> {
-    if (name == "gl_GlobalInvocationID") return (ok = true, bi = SpvBuiltIn.GlobalInvocationId)
-    if (name == "gl_LocalInvocationID") return (ok = true, bi = SpvBuiltIn.LocalInvocationId)
-    if (name == "gl_WorkGroupID") return (ok = true, bi = SpvBuiltIn.WorkgroupId)
-    if (name == "gl_NumWorkGroups") return (ok = true, bi = SpvBuiltIn.NumWorkgroups)
-    if (name == "gl_LocalInvocationIndex") return (ok = true, bi = SpvBuiltIn.LocalInvocationIndex)
-    return (ok = false, bi = SpvBuiltIn.GlobalInvocationId)
+// ===== builtin name -> SpvBuiltIn + storage class (compute + vertex/fragment) =====
+// Most builtins are read-only Inputs; gl_Position is the one written Output. The storage class is
+// what decides whether the variable's pointer type is Input or Output and how it is written.
+def private builtin_info(name : string) : tuple<ok : bool; bi : SpvBuiltIn; storage : SpvStorageClass> {
+    // compute
+    if (name == "gl_GlobalInvocationID") return (ok = true, bi = SpvBuiltIn.GlobalInvocationId, storage = SpvStorageClass.Input)
+    if (name == "gl_LocalInvocationID") return (ok = true, bi = SpvBuiltIn.LocalInvocationId, storage = SpvStorageClass.Input)
+    if (name == "gl_WorkGroupID") return (ok = true, bi = SpvBuiltIn.WorkgroupId, storage = SpvStorageClass.Input)
+    if (name == "gl_NumWorkGroups") return (ok = true, bi = SpvBuiltIn.NumWorkgroups, storage = SpvStorageClass.Input)
+    if (name == "gl_LocalInvocationIndex") return (ok = true, bi = SpvBuiltIn.LocalInvocationIndex, storage = SpvStorageClass.Input)
+    // vertex
+    if (name == "gl_Position") return (ok = true, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Output)
+    if (name == "gl_VertexIndex") return (ok = true, bi = SpvBuiltIn.VertexIndex, storage = SpvStorageClass.Input)
+    if (name == "gl_InstanceIndex") return (ok = true, bi = SpvBuiltIn.InstanceIndex, storage = SpvStorageClass.Input)
+    // fragment
+    if (name == "gl_FragCoord") return (ok = true, bi = SpvBuiltIn.FragCoord, storage = SpvStorageClass.Input)
+    return (ok = false, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Input)
 }
 
 // ===== global variable classification + emission =====
 def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; var errors : array<string>) {
     let vname = "{v.name}"
-    let bi = builtin_for_name(vname)
+    let bi = builtin_info(vname)
     if (bi.ok) {
         let vt = emit_type(m, v._type)
-        let pt = type_pointer(m, SpvStorageClass.Input, vt)
+        let pt = type_pointer(m, bi.storage, vt)
         let vid = alloc_id(m)
-        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.Input))
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(bi.storage))
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.BuiltIn), uint(bi.bi))
-        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.Input, value_type = vt, is_ssbo = false))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = bi.storage, value_type = vt, is_ssbo = false))
+        ctx.interface_ids |> push(vid)   // Input + Output builtins both list in the entry interface
+        return
+    }
+    // stage I/O: @in / @out user variables carry an explicit @location. They become Input/Output
+    // OpVariables with a Location decoration and list in the entry-point interface.
+    let is_in = v.annotation |> find_arg("in") is tBool
+    let is_out = v.annotation |> find_arg("out") is tBool
+    if (is_in || is_out) {
+        if (is_in && is_out) {
+            errors |> push("stage variable '{vname}' cannot be both @in and @out")
+            return
+        }
+        let loc = v.annotation |> find_arg("location") ?as tInt ?? -1
+        if (loc < 0) {
+            errors |> push("stage variable '{vname}' must specify a non-negative @location (e.g. @in @location = 0)")
+            return
+        }
+        let storage = is_in ? SpvStorageClass.Input : SpvStorageClass.Output
+        let vt = emit_type(m, v._type)
+        let pt = type_pointer(m, storage, vt)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(storage))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Location), uint(loc))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = storage, value_type = vt, is_ssbo = false))
         ctx.interface_ids |> push(vid)
         return
     }
@@ -263,6 +305,196 @@ def private cmp_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
     return (ok = false, code = SpvOp.Nop)
 }
 
+// number of scalar lanes in a type (scalar = 1, vecN = N, anything else = 0/unknown).
+def private component_count(bt : Type) : int {
+    if (bt == Type.tInt || bt == Type.tUInt || bt == Type.tFloat || bt == Type.tBool) return 1
+    if (bt == Type.tInt2 || bt == Type.tUInt2 || bt == Type.tFloat2) return 2
+    if (bt == Type.tInt3 || bt == Type.tUInt3 || bt == Type.tFloat3) return 3
+    if (bt == Type.tInt4 || bt == Type.tUInt4 || bt == Type.tFloat4) return 4
+    return 0
+}
+
+// vector constructor name (float2/3/4, int2/3/4, uint2/3/4) -> lane count, else ok=false.
+def private vector_ctor(name : string) : tuple<ok : bool; n : int> {
+    if (name == "float2" || name == "int2" || name == "uint2") return (ok = true, n = 2)
+    if (name == "float3" || name == "int3" || name == "uint3") return (ok = true, n = 3)
+    if (name == "float4" || name == "int4" || name == "uint4") return (ok = true, n = 4)
+    return (ok = false, n = 0)
+}
+
+// OpExtInstImport "GLSL.std.450" once per module; returns the cached set id.
+def private ensure_glsl_ext(var m : SpirvModule; var ctx : EmitCtx) : uint {
+    if (ctx.glsl_ext != 0u) return ctx.glsl_ext
+    let id = alloc_id(m)
+    var ops <- [id]
+    var nm <- string_words("GLSL.std.450")
+    ops |> push_from(nm)
+    delete nm
+    emit_n(m, SEC_EXTIMPORT, SpvOp.ExtInstImport, ops)
+    delete ops
+    ctx.glsl_ext = id
+    return id
+}
+
+// daslang math builtin -> GLSL.std.450 ext-inst opcode. abs/min/max/clamp/sign pick the F/S/U
+// variant by operand class; the rest are float-only. Operand class comes from arg 0 (vectors
+// classify by lane kind, so length/normalize/cross/etc. read as float-class). ok=false => not a
+// GLSL.std.450 builtin (or wrong class) -> caller emits a clean error.
+def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLstd450> {
+    if (name == "abs") {
+        if (cls == 2) return (ok = true, op = GLSLstd450.FAbs)
+        if (cls == 0) return (ok = true, op = GLSLstd450.SAbs)
+        return (ok = false, op = GLSLstd450.Round)
+    }
+    if (name == "min") {
+        if (cls == 2) return (ok = true, op = GLSLstd450.FMin)
+        if (cls == 0) return (ok = true, op = GLSLstd450.SMin)
+        if (cls == 1) return (ok = true, op = GLSLstd450.UMin)
+        return (ok = false, op = GLSLstd450.Round)
+    }
+    if (name == "max") {
+        if (cls == 2) return (ok = true, op = GLSLstd450.FMax)
+        if (cls == 0) return (ok = true, op = GLSLstd450.SMax)
+        if (cls == 1) return (ok = true, op = GLSLstd450.UMax)
+        return (ok = false, op = GLSLstd450.Round)
+    }
+    if (name == "clamp") {
+        if (cls == 2) return (ok = true, op = GLSLstd450.FClamp)
+        if (cls == 0) return (ok = true, op = GLSLstd450.SClamp)
+        if (cls == 1) return (ok = true, op = GLSLstd450.UClamp)
+        return (ok = false, op = GLSLstd450.Round)
+    }
+    if (name == "sign") {
+        if (cls == 2) return (ok = true, op = GLSLstd450.FSign)
+        if (cls == 0) return (ok = true, op = GLSLstd450.SSign)
+        return (ok = false, op = GLSLstd450.Round)
+    }
+    if (cls != 2) return (ok = false, op = GLSLstd450.Round)   // the rest are float-only
+    if (name == "sqrt") return (ok = true, op = GLSLstd450.Sqrt)
+    if (name == "inversesqrt") return (ok = true, op = GLSLstd450.InverseSqrt)
+    if (name == "sin") return (ok = true, op = GLSLstd450.Sin)
+    if (name == "cos") return (ok = true, op = GLSLstd450.Cos)
+    if (name == "tan") return (ok = true, op = GLSLstd450.Tan)
+    if (name == "asin") return (ok = true, op = GLSLstd450.Asin)
+    if (name == "acos") return (ok = true, op = GLSLstd450.Acos)
+    if (name == "atan") return (ok = true, op = GLSLstd450.Atan)
+    if (name == "atan2") return (ok = true, op = GLSLstd450.Atan2)
+    if (name == "pow") return (ok = true, op = GLSLstd450.Pow)
+    if (name == "exp") return (ok = true, op = GLSLstd450.Exp)
+    if (name == "log") return (ok = true, op = GLSLstd450.Log)
+    if (name == "exp2") return (ok = true, op = GLSLstd450.Exp2)
+    if (name == "log2") return (ok = true, op = GLSLstd450.Log2)
+    if (name == "floor") return (ok = true, op = GLSLstd450.Floor)
+    if (name == "ceil") return (ok = true, op = GLSLstd450.Ceil)
+    if (name == "round") return (ok = true, op = GLSLstd450.Round)
+    if (name == "trunc") return (ok = true, op = GLSLstd450.Trunc)
+    if (name == "fract") return (ok = true, op = GLSLstd450.Fract)
+    if (name == "radians") return (ok = true, op = GLSLstd450.Radians)
+    if (name == "degrees") return (ok = true, op = GLSLstd450.Degrees)
+    if (name == "mix") return (ok = true, op = GLSLstd450.FMix)
+    if (name == "step") return (ok = true, op = GLSLstd450.Step)
+    if (name == "smoothstep") return (ok = true, op = GLSLstd450.SmoothStep)
+    if (name == "length") return (ok = true, op = GLSLstd450.Length)
+    if (name == "distance") return (ok = true, op = GLSLstd450.Distance)
+    if (name == "cross") return (ok = true, op = GLSLstd450.Cross)
+    if (name == "normalize") return (ok = true, op = GLSLstd450.Normalize)
+    if (name == "reflect") return (ok = true, op = GLSLstd450.Reflect)
+    return (ok = false, op = GLSLstd450.Round)
+}
+
+// ===== ExprCall: vector constructors, dot (core OpDot), GLSL.std.450 math (OpExtInst) =====
+def private emit_call(var m : SpirvModule; var ctx : EmitCtx; call : ExprCall?; e : ExpressionPtr; var errors : array<string>) : uint {
+    let name = "{call.name}"
+    // ----- vector constructor: OpCompositeConstruct (or splat / identity for one arg) -----
+    let vc = vector_ctor(name)
+    if (vc.ok) {
+        let rt = emit_type(m, e._type)
+        if (length(call.arguments) == 1) {
+            let cc = component_count(call.arguments[0]._type.baseType)
+            let aid = emit_value(m, ctx, call.arguments[0], errors)
+            if (aid == 0u) return 0u
+            if (cc == vc.n) return aid                  // identity: float4(someFloat4)
+            if (cc == 1) {                              // splat: float4(scalar) -> repeat N lanes
+                let res = alloc_id(m)
+                var cons <- [rt, res]
+                cons |> reserve(2 + vc.n)
+                for (_l in range(vc.n)) {
+                    cons |> push(aid)
+                }
+                emit_n(m, SEC_FUNCS, SpvOp.CompositeConstruct, cons)
+                delete cons
+                return res
+            }
+            errors |> push("cannot construct {name} from a single {call.arguments[0]._type.baseType}")
+            return 0u
+        }
+        // multi-arg: each constituent contributes its lanes; total must equal n
+        var total = 0
+        let res = alloc_id(m)
+        var cons <- [rt, res]
+        cons |> reserve(2 + length(call.arguments))
+        for (a in call.arguments) {
+            let cc = component_count(a._type.baseType)
+            if (cc == 0) {
+                errors |> push("{name}: argument of type {a._type.baseType} is not a scalar/vector")
+                delete cons
+                return 0u
+            }
+            total += cc
+            let aid = emit_value(m, ctx, a, errors)
+            if (aid == 0u) {
+                delete cons
+                return 0u
+            }
+            cons |> push(aid)
+        }
+        if (total != vc.n) {
+            errors |> push("{name}: constituent lanes sum to {total}, expected {vc.n}")
+            delete cons
+            return 0u
+        }
+        emit_n(m, SEC_FUNCS, SpvOp.CompositeConstruct, cons)
+        delete cons
+        return res
+    }
+    // ----- dot: core OpDot (vector . vector -> scalar) -----
+    if (name == "dot") {
+        if (length(call.arguments) != 2) {
+            errors |> push("dot expects 2 arguments")
+            return 0u
+        }
+        let a = emit_value(m, ctx, call.arguments[0], errors)
+        let b = emit_value(m, ctx, call.arguments[1], errors)
+        if (a == 0u || b == 0u) return 0u
+        let rt = emit_type(m, e._type)
+        let res = alloc_id(m)
+        emit(m, SEC_FUNCS, SpvOp.Dot, rt, res, a, b)
+        return res
+    }
+    // ----- GLSL.std.450 math: OpExtInst -----
+    let cls = empty(call.arguments) ? -1 : scalar_class(call.arguments[0]._type.baseType)
+    let ge = glsl_ext_op(name, cls)
+    if (ge.ok) {
+        let set = ensure_glsl_ext(m, ctx)
+        let rt = emit_type(m, e._type)
+        let res = alloc_id(m)
+        var ops <- [rt, res, set, uint(ge.op)]
+        for (a in call.arguments) {
+            let aid = emit_value(m, ctx, a, errors)
+            if (aid == 0u) {
+                delete ops
+                return 0u
+            }
+            ops |> push(aid)
+        }
+        emit_n(m, SEC_FUNCS, SpvOp.ExtInst, ops)
+        delete ops
+        return res
+    }
+    errors |> push("unsupported call '{name}' (not a vector constructor, dot, or GLSL.std.450 math builtin)")
+    return 0u
+}
+
 // ===== rvalue: produce an SSA result-id =====
 def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) : uint {
     // ExprRef2Value wraps a ref lvalue to read its value; running in `patch` (pre-fold) the AST
@@ -332,6 +564,8 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
         emit(m, SEC_FUNCS, uo.code, rt, res, v)
         return res
     }
+    let call = e ?as ExprCall
+    if (call != null) return emit_call(m, ctx, call, e, errors)
     let ev = e ?as ExprVar
     if (ev != null && (ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block)) {
         let lv = ctx.local_vars?[intptr(ev.variable)] ?? LocalVar()
@@ -689,7 +923,7 @@ def private emit_stmt(var m : SpirvModule; var ctx : EmitCtx; s : ExpressionPtr;
     if (lt != null) {
         for (v in lt.variables) {
             if (v.init == null) {
-                errors |> push("uninitialized let '{v.name}' not supported")
+                errors |> push("uninitialized local '{v.name}' is not supported (every let/var must have an initializer)")
                 continue
             }
             let lv = ctx.local_vars?[intptr(v)] ?? LocalVar()
@@ -725,8 +959,14 @@ def private emit_body(var m : SpirvModule; var ctx : EmitCtx; body : ExpressionP
 }
 
 // ===== entry =====
+def private execution_model(stage : ShaderStage) : SpvExecutionModel {
+    if (stage == ShaderStage.Vertex) return SpvExecutionModel.Vertex
+    if (stage == ShaderStage.Fragment) return SpvExecutionModel.Fragment
+    return SpvExecutionModel.GLCompute
+}
+
 [macro_function]
-def generate_spirv(fn : FunctionPtr; var errors : array<string>; local_size : int3) : array<uint> {
+def generate_spirv(fn : FunctionPtr; var errors : array<string>; stage : ShaderStage; local_size : int3) : array<uint> {
     var m = make_module()
     var ctx : EmitCtx
 
@@ -743,7 +983,7 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; local_size : in
     let t_fn = type_function_void(m, t_void)
     let id_main = alloc_id(m)
 
-    var ep <- [uint(SpvExecutionModel.GLCompute), id_main]
+    var ep <- [uint(execution_model(stage)), id_main]
     var nm <- string_words("main")
     ep |> push_from(nm)
     delete nm
@@ -751,12 +991,17 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; local_size : in
     emit_n(m, SEC_ENTRY, SpvOp.EntryPoint, ep)
     delete ep
 
-    let lx = local_size.x > 0 ? uint(local_size.x) : 1u
-    let ly = local_size.y > 0 ? uint(local_size.y) : 1u
-    let lz = local_size.z > 0 ? uint(local_size.z) : 1u
-    var em <- [id_main, uint(SpvExecutionMode.LocalSize), lx, ly, lz]
-    emit_n(m, SEC_EXECMODE, SpvOp.ExecutionMode, em)
-    delete em
+    // Compute pins the workgroup size; Fragment fixes the framebuffer origin; Vertex needs none.
+    if (stage == ShaderStage.Compute) {
+        let lx = local_size.x > 0 ? uint(local_size.x) : 1u
+        let ly = local_size.y > 0 ? uint(local_size.y) : 1u
+        let lz = local_size.z > 0 ? uint(local_size.z) : 1u
+        var em <- [id_main, uint(SpvExecutionMode.LocalSize), lx, ly, lz]
+        emit_n(m, SEC_EXECMODE, SpvOp.ExecutionMode, em)
+        delete em
+    } elif (stage == ShaderStage.Fragment) {
+        emit(m, SEC_EXECMODE, SpvOp.ExecutionMode, id_main, uint(SpvExecutionMode.OriginUpperLeft))
+    }
 
     emit(m, SEC_FUNCS, SpvOp.Function, t_void, id_main, 0u, t_fn)
     let id_label = alloc_id(m)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -330,12 +330,20 @@ def private component_count(bt : Type) : int {
     return 0
 }
 
-// vector constructor name (float2/3/4, int2/3/4, uint2/3/4) -> lane count, else ok=false.
-def private vector_ctor(name : string) : tuple<ok : bool; n : int> {
-    if (name == "float2" || name == "int2" || name == "uint2") return (ok = true, n = 2)
-    if (name == "float3" || name == "int3" || name == "uint3") return (ok = true, n = 3)
-    if (name == "float4" || name == "int4" || name == "uint4") return (ok = true, n = 4)
-    return (ok = false, n = 0)
+// vector constructor name (float2/3/4, int2/3/4, uint2/3/4) -> lane count + component class
+// (0 signed, 1 unsigned, 2 float), else ok=false. The class lets the constructor reject
+// component-kind conversions (e.g. int4(float4(...))), which need conversion ops we don't emit yet.
+def private vector_ctor(name : string) : tuple<ok : bool; n : int; cls : int> {
+    if (name == "float2") return (ok = true, n = 2, cls = 2)
+    if (name == "float3") return (ok = true, n = 3, cls = 2)
+    if (name == "float4") return (ok = true, n = 4, cls = 2)
+    if (name == "int2") return (ok = true, n = 2, cls = 0)
+    if (name == "int3") return (ok = true, n = 3, cls = 0)
+    if (name == "int4") return (ok = true, n = 4, cls = 0)
+    if (name == "uint2") return (ok = true, n = 2, cls = 1)
+    if (name == "uint3") return (ok = true, n = 3, cls = 1)
+    if (name == "uint4") return (ok = true, n = 4, cls = 1)
+    return (ok = false, n = 0, cls = -1)
 }
 
 // OpExtInstImport "GLSL.std.450" once per module; returns the cached set id.
@@ -426,10 +434,17 @@ def private emit_call(var m : SpirvModule; var ctx : EmitCtx; call : ExprCall?; 
     if (vc.ok) {
         let rt = emit_type(m, e._type)
         if (length(call.arguments) == 1) {
-            let cc = component_count(call.arguments[0]._type.baseType)
-            let aid = emit_value(m, ctx, call.arguments[0], errors)
+            let a0 = call.arguments[0]
+            let cc = component_count(a0._type.baseType)
+            // a different component kind is a conversion (int4(float4(...)), float4(int(...))),
+            // which needs OpConvert* we don't emit yet — reject rather than alias the wrong type.
+            if (scalar_class(a0._type.baseType) != vc.cls) {
+                errors |> push("{name}: component-kind conversion from {a0._type.baseType} is not supported yet")
+                return 0u
+            }
+            let aid = emit_value(m, ctx, a0, errors)
             if (aid == 0u) return 0u
-            if (cc == vc.n) return aid                  // identity: float4(someFloat4)
+            if (cc == vc.n) return aid                  // identity: float4(someFloat4), same kind
             if (cc == 1) {                              // splat: float4(scalar) -> repeat N lanes
                 let res = alloc_id(m)
                 var cons <- [rt, res]
@@ -441,10 +456,10 @@ def private emit_call(var m : SpirvModule; var ctx : EmitCtx; call : ExprCall?; 
                 delete cons
                 return res
             }
-            errors |> push("cannot construct {name} from a single {call.arguments[0]._type.baseType}")
+            errors |> push("cannot construct {name} from a single {a0._type.baseType}")
             return 0u
         }
-        // multi-arg: each constituent contributes its lanes; total must equal n
+        // multi-arg: each constituent contributes its lanes; kinds must match and lanes sum to n
         var total = 0
         let res = alloc_id(m)
         var cons <- [rt, res]
@@ -453,6 +468,11 @@ def private emit_call(var m : SpirvModule; var ctx : EmitCtx; call : ExprCall?; 
             let cc = component_count(a._type.baseType)
             if (cc == 0) {
                 errors |> push("{name}: argument of type {a._type.baseType} is not a scalar/vector")
+                delete cons
+                return 0u
+            }
+            if (scalar_class(a._type.baseType) != vc.cls) {
+                errors |> push("{name}: constituent of type {a._type.baseType} has a different component kind (conversion not supported yet)")
                 delete cons
                 return 0u
             }

--- a/modules/dasSpirv/spirv/spirv_shader.das
+++ b/modules/dasSpirv/spirv/spirv_shader.das
@@ -36,6 +36,8 @@ def private build_uint_array_literal(words : array<uint>; at : LineInfo) : Expre
 }
 
 class SpirvShader : AstFunctionAnnotation {
+    // overridden per stage; drives the entry-point execution model + execution mode in generate_spirv
+    def shader_stage() : ShaderStage => ShaderStage.Compute
     def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         func.flags.exports = true   // temporary: keeps the function alive through dependency collection
         let argName = args |> find_arg("name") ?as tString ?? "{func.name}`spirv"
@@ -56,7 +58,7 @@ class SpirvShader : AstFunctionAnnotation {
         var err : array<string>
         var glob <- find_variable(compiling_module(), argName)
         if (glob != null && glob.init == null && glob.name == argName) {
-            var words <- generate_spirv(func, err, local_size)
+            var words <- generate_spirv(func, err, shader_stage(), local_size)
             if (err |> empty()) {
                 glob.init = build_uint_array_literal(words, func.at)
                 astChanged = true
@@ -74,4 +76,14 @@ class SpirvShader : AstFunctionAnnotation {
 
 [function_macro(name="compute_shader")]
 class SpirvComputeShader : SpirvShader {
+}
+
+[function_macro(name="vertex_shader")]
+class SpirvVertexShader : SpirvShader {
+    def override shader_stage() : ShaderStage => ShaderStage.Vertex
+}
+
+[function_macro(name="fragment_shader")]
+class SpirvFragmentShader : SpirvShader {
+    def override shader_stage() : ShaderStage => ShaderStage.Fragment
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -14,6 +14,7 @@ require spirv/spirv_shader
 require spirv/spirv_grammar
 require spirv/spirv_builtins public
 require daslib/fio
+require math
 
 // ===== Phase-1 fixture: data[i] = i*i, captured into the `square_spv : array<uint>` global =====
 var @ssbo @binding = 0 data : array<uint>
@@ -213,6 +214,79 @@ def public floop_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-3 vertex/fragment fixtures: stage I/O (@in/@out + Location), rasterizer builtins
+// (gl_Position/gl_VertexIndex/gl_InstanceIndex/gl_FragCoord), vector constructors
+// (OpCompositeConstruct), dot (OpDot), and GLSL.std.450 math (OpExtInst). Each emitted blob is
+// spirv-val'd; together they add the Phase-3 opcodes to the census. =====
+
+// vertex: vertex-attribute -> clip position + a passthrough varying
+var @in @location = 0 a_pos : float2
+var @in @location = 1 a_color : float3
+var @out @location = 0 v_color : float3
+[vertex_shader(name="tri_vert_spv"), marker(no_coverage)]
+def tri_vert {
+    gl_Position = float4(a_pos, 0.0f, 1.0f)     // CompositeConstruct: vec2 + 2 scalars -> vec4
+    v_color = a_color                            // varying passthrough (vec3 in -> vec3 out)
+}
+
+// fragment: varying -> framebuffer color (OriginUpperLeft execution mode)
+var @in @location = 0 fi_color : float3
+var @out @location = 0 frag_color : float4
+[fragment_shader(name="tri_frag_spv"), marker(no_coverage)]
+def tri_frag {
+    frag_color = float4(fi_color, 1.0f)          // CompositeConstruct: vec3 + scalar -> vec4
+}
+
+// vertex: gl_VertexIndex / gl_InstanceIndex builtins driving a procedural position
+var @out @location = 0 vi_col : float4
+[vertex_shader(name="vindex_spv"), marker(no_coverage)]
+def vindex {
+    var x = 0.0f
+    if (gl_VertexIndex == 0) {                    // VertexIndex (int Input builtin) + IEqual
+        x = 1.0f
+    }
+    if (gl_InstanceIndex > 0) {                   // InstanceIndex (int Input builtin) + SGreaterThan
+        x = x + 0.5f
+    }
+    gl_Position = float4(x, 0.0f, 0.0f, 1.0f)     // CompositeConstruct: 4 scalars
+    vi_col = float4(x, x, x, 1.0f)
+}
+
+// fragment: gl_FragCoord builtin + GLSL.std.450 math (dot/sqrt/clamp) -> grayscale
+var @out @location = 0 m_out : float4
+[fragment_shader(name="raster_math_spv"), marker(no_coverage)]
+def raster_math {
+    let p = gl_FragCoord                          // FragCoord (float4 Input builtin)
+    let d = dot(p, p)                             // OpDot -> float
+    let s = sqrt(d)                               // OpExtInst Sqrt (imports GLSL.std.450)
+    let c = clamp(s, 0.0f, 1.0f)                  // OpExtInst FClamp
+    m_out = float4(c, c, c, 1.0f)                 // CompositeConstruct
+}
+
+def public tri_vert_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(tri_vert_spv)
+    return <- w
+}
+
+def public tri_frag_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(tri_frag_spv)
+    return <- w
+}
+
+def public vindex_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(vindex_spv)
+    return <- w
+}
+
+def public raster_math_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(raster_math_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -310,6 +384,21 @@ def public phase2_emitter_opcodes : table<uint> {
         SpvOp.LogicalAnd, SpvOp.LogicalOr, SpvOp.LogicalNot,
         // structured control flow
         SpvOp.SelectionMerge, SpvOp.BranchConditional, SpvOp.Branch, SpvOp.LoopMerge
+    ]) {
+        s |> insert(uint(op))
+    }
+    return <- s
+}
+
+// Phase-3 adds vertex/fragment: stage I/O + rasterizer builtins reuse Decorate/Variable/EntryPoint/
+// ExecutionMode (already declared), so the only NEW opcodes are vector construction, dot, and the
+// GLSL.std.450 ext-inst pair. Phase-2 set + these:
+def public phase3_emitter_opcodes : table<uint> {
+    var s <- phase2_emitter_opcodes()
+    for (op in [
+        SpvOp.CompositeConstruct,           // vector constructors float4(...)/float3(...)
+        SpvOp.Dot,                          // dot(a, b)
+        SpvOp.ExtInstImport, SpvOp.ExtInst  // GLSL.std.450 math (sqrt/clamp/...)
     ]) {
         s |> insert(uint(op))
     }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -26,7 +26,7 @@ def private add_set(var dst : table<uint>; var words : array<uint>) {
 
 [test]
 def test_opcode_census(t : T?) {
-    t |> run("emitter opcode census == declared Phase-2 set (all fixtures)") <| @(t : T?) {
+    t |> run("emitter opcode census == declared Phase-3 set (all fixtures)") <| @(t : T?) {
         var present : table<uint>
         add_set(present, square_words())
         add_set(present, uarith_words())
@@ -37,7 +37,11 @@ def test_opcode_census(t : T?) {
         add_set(present, fctrl_words())
         add_set(present, wloop_words())
         add_set(present, floop_words())
-        var declared <- phase2_emitter_opcodes()
+        add_set(present, tri_vert_words())
+        add_set(present, tri_frag_words())
+        add_set(present, vindex_words())
+        add_set(present, raster_math_words())
+        var declared <- phase3_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_control.das
+++ b/tests/spirv/test_control.das
@@ -38,8 +38,10 @@ def test_uint_control(t : T?) {
         // unsigned comparisons + equality + logical
         check_ops(t, words, "uctrl", [SpvOp.UGreaterThan, SpvOp.ULessThan, SpvOp.IEqual,
             SpvOp.INotEqual, SpvOp.LogicalAnd, SpvOp.LogicalNot])
-        // a Function-storage OpVariable was declared for the mutable locals
-        t |> success(op_has_operand(words, SpvOp.Variable, uint(SpvStorageClass.Function)),
+        // a Function-storage OpVariable was declared for the mutable locals. OpVariable operands are
+        // [result_type, result_id, storage_class, init?]; check the storage class positionally (index 2)
+        // so the small Function value can't false-match the result-type/id operands.
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Function)),
             "uctrl: has a Function-storage OpVariable")
         validate(t, words, "uctrl")
         delete words

--- a/tests/spirv/test_raster.das
+++ b/tests/spirv/test_raster.das
@@ -38,8 +38,10 @@ def private has_location(words : array<uint>; loc : uint) : bool {
 def test_vertex_passthrough(t : T?) {
     t |> run("vertex: @in/@out + Location, gl_Position, float4(...) -> CompositeConstruct") <| @(t : T?) {
         var words <- tri_vert_words()
-        // entry point is a Vertex shader with no execution mode
-        t |> success(op_first_operand(words, SpvOp.EntryPoint).value == uint(SpvExecutionModel.Vertex),
+        // entry point is a Vertex shader with no execution mode (assert .ok so an empty/truncated
+        // module can't pass via the default value 0, which collides with SpvExecutionModel.Vertex)
+        let vmodel = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(vmodel.ok && vmodel.value == uint(SpvExecutionModel.Vertex),
             "tri_vert: EntryPoint model is Vertex")
         t |> success(count_op(words, SpvOp.ExecutionMode) == 0, "tri_vert: vertex has no ExecutionMode")
         // stage I/O Locations (a_pos=0, a_color=1, v_color=0) + the Position builtin
@@ -59,7 +61,8 @@ def test_vertex_passthrough(t : T?) {
 def test_fragment_passthrough(t : T?) {
     t |> run("fragment: OriginUpperLeft, float4(vec3, 1.0) -> CompositeConstruct") <| @(t : T?) {
         var words <- tri_frag_words()
-        t |> success(op_first_operand(words, SpvOp.EntryPoint).value == uint(SpvExecutionModel.Fragment),
+        let fmodel = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(fmodel.ok && fmodel.value == uint(SpvExecutionModel.Fragment),
             "tri_frag: EntryPoint model is Fragment")
         t |> success(op_has_operand(words, SpvOp.ExecutionMode, uint(SpvExecutionMode.OriginUpperLeft)),
             "tri_frag: ExecutionMode OriginUpperLeft")

--- a/tests/spirv/test_raster.das
+++ b/tests/spirv/test_raster.das
@@ -48,8 +48,10 @@ def test_vertex_passthrough(t : T?) {
         t |> success(has_location(words, 0u), "tri_vert: has a Location 0 decoration")
         t |> success(has_location(words, 1u), "tri_vert: has a Location 1 decoration")
         t |> success(has_builtin(words, SpvBuiltIn.Position), "tri_vert: gl_Position -> BuiltIn Position")
-        // an Output-storage variable (gl_Position + v_color)
-        t |> success(op_has_operand(words, SpvOp.Variable, uint(SpvStorageClass.Output)),
+        // an Output-storage variable (gl_Position + v_color). OpVariable operands are
+        // [result_type, result_id, storage_class, init?] — check the storage class positionally
+        // (index 2), since a bare value match would also hit the small result-type/id operands.
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Output)),
             "tri_vert: has an Output-storage OpVariable")
         check_ops(t, words, "tri_vert", [SpvOp.CompositeConstruct, SpvOp.Load, SpvOp.Store])
         validate(t, words, "tri_vert")
@@ -64,7 +66,9 @@ def test_fragment_passthrough(t : T?) {
         let fmodel = op_first_operand(words, SpvOp.EntryPoint)
         t |> success(fmodel.ok && fmodel.value == uint(SpvExecutionModel.Fragment),
             "tri_frag: EntryPoint model is Fragment")
-        t |> success(op_has_operand(words, SpvOp.ExecutionMode, uint(SpvExecutionMode.OriginUpperLeft)),
+        // ExecutionMode operands are [entry_id, mode, ...]; check the mode positionally (index 1)
+        // so a small mode value can't false-match the entry-id operand.
+        t |> success(op_has_operand_at(words, SpvOp.ExecutionMode, 1, uint(SpvExecutionMode.OriginUpperLeft)),
             "tri_frag: ExecutionMode OriginUpperLeft")
         t |> success(has_location(words, 0u), "tri_frag: has a Location 0 decoration")
         check_ops(t, words, "tri_frag", [SpvOp.CompositeConstruct, SpvOp.Load, SpvOp.Store])

--- a/tests/spirv/test_raster.das
+++ b/tests/spirv/test_raster.das
@@ -1,0 +1,96 @@
+options gen2
+options indenting = 4
+
+// Phase-3 vertex/fragment gate: stage I/O (@in/@out -> Input/Output + Location), rasterizer builtins
+// (gl_Position/gl_VertexIndex/gl_InstanceIndex/gl_FragCoord), vector constructors (OpCompositeConstruct),
+// dot (OpDot), and GLSL.std.450 math (OpExtInstImport + OpExtInst). The entry-point execution model
+// + interface + decorations are asserted by shape; every emitted module passes spirv-val.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private check_ops(t : T?; words : array<uint>; lbl : string; ops : array<SpvOp>) {
+    for (op in ops) {
+        t |> success(has_op(words, op), "{lbl}: emits {op}")
+    }
+}
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+def private has_builtin(words : array<uint>; bi : SpvBuiltIn) : bool {
+    return op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(bi))
+}
+
+def private has_location(words : array<uint>; loc : uint) : bool {
+    return op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Location), loc)
+}
+
+[test]
+def test_vertex_passthrough(t : T?) {
+    t |> run("vertex: @in/@out + Location, gl_Position, float4(...) -> CompositeConstruct") <| @(t : T?) {
+        var words <- tri_vert_words()
+        // entry point is a Vertex shader with no execution mode
+        t |> success(op_first_operand(words, SpvOp.EntryPoint).value == uint(SpvExecutionModel.Vertex),
+            "tri_vert: EntryPoint model is Vertex")
+        t |> success(count_op(words, SpvOp.ExecutionMode) == 0, "tri_vert: vertex has no ExecutionMode")
+        // stage I/O Locations (a_pos=0, a_color=1, v_color=0) + the Position builtin
+        t |> success(has_location(words, 0u), "tri_vert: has a Location 0 decoration")
+        t |> success(has_location(words, 1u), "tri_vert: has a Location 1 decoration")
+        t |> success(has_builtin(words, SpvBuiltIn.Position), "tri_vert: gl_Position -> BuiltIn Position")
+        // an Output-storage variable (gl_Position + v_color)
+        t |> success(op_has_operand(words, SpvOp.Variable, uint(SpvStorageClass.Output)),
+            "tri_vert: has an Output-storage OpVariable")
+        check_ops(t, words, "tri_vert", [SpvOp.CompositeConstruct, SpvOp.Load, SpvOp.Store])
+        validate(t, words, "tri_vert")
+        delete words
+    }
+}
+
+[test]
+def test_fragment_passthrough(t : T?) {
+    t |> run("fragment: OriginUpperLeft, float4(vec3, 1.0) -> CompositeConstruct") <| @(t : T?) {
+        var words <- tri_frag_words()
+        t |> success(op_first_operand(words, SpvOp.EntryPoint).value == uint(SpvExecutionModel.Fragment),
+            "tri_frag: EntryPoint model is Fragment")
+        t |> success(op_has_operand(words, SpvOp.ExecutionMode, uint(SpvExecutionMode.OriginUpperLeft)),
+            "tri_frag: ExecutionMode OriginUpperLeft")
+        t |> success(has_location(words, 0u), "tri_frag: has a Location 0 decoration")
+        check_ops(t, words, "tri_frag", [SpvOp.CompositeConstruct, SpvOp.Load, SpvOp.Store])
+        validate(t, words, "tri_frag")
+        delete words
+    }
+}
+
+[test]
+def test_vertex_index_builtins(t : T?) {
+    t |> run("vertex: gl_VertexIndex / gl_InstanceIndex builtins drive a procedural position") <| @(t : T?) {
+        var words <- vindex_words()
+        t |> success(has_builtin(words, SpvBuiltIn.VertexIndex), "vindex: BuiltIn VertexIndex")
+        t |> success(has_builtin(words, SpvBuiltIn.InstanceIndex), "vindex: BuiltIn InstanceIndex")
+        t |> success(has_builtin(words, SpvBuiltIn.Position), "vindex: BuiltIn Position")
+        check_ops(t, words, "vindex", [SpvOp.IEqual, SpvOp.SGreaterThan, SpvOp.CompositeConstruct])
+        validate(t, words, "vindex")
+        delete words
+    }
+}
+
+[test]
+def test_fragment_math(t : T?) {
+    t |> run("fragment: gl_FragCoord + GLSL.std.450 math (dot/sqrt/clamp)") <| @(t : T?) {
+        var words <- raster_math_words()
+        t |> success(has_builtin(words, SpvBuiltIn.FragCoord), "raster_math: BuiltIn FragCoord")
+        check_ops(t, words, "raster_math", [SpvOp.Dot, SpvOp.ExtInstImport, SpvOp.ExtInst,
+            SpvOp.CompositeConstruct])
+        validate(t, words, "raster_math")
+        delete words
+    }
+}


### PR DESCRIPTION
Extends the pure-daslang daslang→SPIR-V backend (`modules/dasSpirv`) from compute-only to **vertex and fragment** shaders. Builds on Phase 2 (#3137).

## What lands

**Stages & entry points**
- `ShaderStage` enum; `generate_spirv` takes a stage that drives the execution model (`Vertex`/`Fragment`/`GLCompute`) and execution mode (Fragment → `OriginUpperLeft`, Compute → `LocalSize`, Vertex → none).
- New `[vertex_shader]` / `[fragment_shader]` annotations — `SpirvShader` subclasses with a virtual `shader_stage()`.

**Stage I/O & builtins**
- `@in` / `@out` user variables → Input/Output `OpVariable` + `Location` decoration, listed in the entry-point interface. `@location` is required and non-negative (fail-closed); `@in`+`@out` is rejected.
- Rasterizer builtins: `gl_Position` (Output, BuiltIn Position), `gl_VertexIndex` / `gl_InstanceIndex` (Input int), `gl_FragCoord` (Input float4). `gl_Position` is a standalone Output (no `gl_PerVertex` block) — spirv-val accepts it under vulkan1.1.
- Entry-point interface lists exactly the Input/Output vars (SSBO StorageBuffer excluded, per the ≤1.3 rule).

**Expressions**
- Vector constructors `floatN`/`intN`/`uintN` → `OpCompositeConstruct` (splat / identity / multi-arg, lane-sum validated).
- `dot` → core `OpDot`.
- GLSL.std.450 math → `OpExtInst` with a lazily-imported `OpExtInstImport` set; class-aware for `abs`/`min`/`max`/`clamp`/`sign`, the rest float-only. Unsupported name/class is a clean error.

Net rule held from Phase 2: **every type/opcode dispatch validates its input and produces a clean `error[...]`, never a silent bad blob or a panic.**

## Tests / gates
- `tests/spirv/test_raster.das`: vertex passthrough, fragment passthrough, vertex index builtins, fragment math (gl_FragCoord + dot/sqrt/clamp). EntryPoint model asserted via a new `op_first_operand` disassembler helper; decorations via `op_has_operand_pair`; **every emitted blob spirv-val'd**.
- Census (gate B) extended to `phase3_emitter_opcodes` = Phase-2 set + `CompositeConstruct`/`Dot`/`ExtInstImport`/`ExtInst`, unioned over the four new fixtures.
- **All three tiers green (interpreter / JIT / AOT, 36/36)**, spirv-val clean, lint + format clean. External `spirv-dis` confirms textbook vertex/fragment structure.

Masterplan log appended (`modules/dasSpirv/MASTERPLAN.md`), including the deferred items (local-value swizzle, vector·scalar ops).

## Follow-on (separate dasVulkan PR)
The cross-repo triangle-on-GPU gate — port `triangle.vert`/`.frag` to `[vertex_shader]`/`[fragment_shader]`, delete the committed `.spv`, regress the triangle on lavapipe + local GPU — mirrors Phase 1's GPU gate and ships in dasVulkan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)