### PR TITLE
unitTest: define testFoo inline so AOT callers can use it (#3065)

### DIFF
--- a/modules/dasUnitTest/test_handles.cpp
+++ b/modules/dasUnitTest/test_handles.cpp
@@ -125,10 +125,6 @@ struct TestObjectBarAnnotation : ManagedStructureAnnotation <TestObjectBar> {
     }
 };
 
-void testFoo ( TestObjectFoo & foo ) {
-    foo.fooData = 1234;
-}
-
 void testAdd ( int & a, int b ) {
     a += b;
 }

--- a/modules/dasUnitTest/unitTest.h
+++ b/modules/dasUnitTest/unitTest.h
@@ -168,6 +168,11 @@ typedef das::vector<TestObjectFoo> FooArray;
 
 DAS_MOD_API void testFooArray(const das::TBlock<void, FooArray> & blk, das::Context * context, das::LineInfoArg * lineinfo);
 
+// testFoo is defined inline here (the makeDummy pattern) so AOT-emitted callers that include this
+// header see it and addExtern still gets a constant &testFoo. It used to live only in test_handles.cpp,
+// so AOT callers hit `use of undeclared identifier 'testFoo'` (#3065 fuzzer).
+DAS_MOD_API __forceinline void testFoo ( TestObjectFoo & foo ) { foo.fooData = 1234; }
+
 DAS_MOD_API __forceinline void set_foo_data (TestObjectFoo * obj, int32_t data ) { obj->fooData = data; }
 
 struct DAS_MOD_API TestObjectSmart : public das::ptr_ref_count {

--- a/tests/aot/test_call_namespaced_extern.das
+++ b/tests/aot/test_call_namespaced_extern.das
@@ -1,0 +1,20 @@
+options gen2
+require dastest/testing_boost public
+require UnitTest
+
+// Regression for issue #3065 (fuzzer, AOT): a call to the UnitTest module function
+// `testFoo`, which is defined inside `namespace das` but was declared nowhere in the
+// module's AOT header. AOT-emitted callers `#include "unitTest.h"` then emit a bare
+// `testFoo(...)` -> `error: use of undeclared identifier 'testFoo'`. Fixed by declaring
+// testFoo in unitTest.h (inside namespace das, so AOT callers link). makeDummy sets
+// fooData=1; testFoo sets it to 1234 -- so the side effect proves the call really runs.
+
+[test]
+def test_call_namespaced_extern(t : T?) {
+    t |> run("aot call to namespace-das module extern testFoo") @(t : T?) {
+        var foo = makeDummy()
+        t |> equal(foo.fooData, 1)
+        testFoo(foo)
+        t |> equal(foo.fooData, 1234)
+    }
+}


### PR DESCRIPTION
First of the four #3065 "AOT" fuzzer bugs (after the assertion/folding/inference fixes in #3134/#3136/#3138).

## Bug

The fuzzer payload `testFoo(makeDummy())` compiles in daslang but its AOT-emitted C++ fails:

```
/tmp/v.cpp:80:5: error: use of undeclared identifier 'testFoo'
```

`testFoo` is a `UnitTest` module function defined only in `test_handles.cpp` (inside `namespace das`) and registered via `addExtern` — but it was **declared nowhere** in the module's AOT header `unitTest.h`. AOT-emitted callers `#include "unitTest.h"` and then emit a bare `testFoo(...)` call, so it's undeclared. (`makeDummy` works — it's `__forceinline` in the header. `testFooArray` works only by luck: its `das::TBlock` argument lets ADL find `das::testFooArray`.)

This is a **bindings bug**, not an emitter bug — the AOT design relies on every `addExtern`'d function being declared in its module's AOT header, and `testFoo` violated that.

## Fix

Define `testFoo` inline in `unitTest.h`, mirroring `makeDummy`, and drop the `test_handles.cpp` definition:

```cpp
DAS_MOD_API __forceinline void testFoo ( TestObjectFoo & foo ) { foo.fooData = 1234; }
```

A header-inline body is visible to AOT callers **and** keeps `&testFoo` a compile-time constant for the module's own `addExtern<DAS_BIND_FUN(testFoo)>` (which expands to `decltype(&testFoo), testFoo`). A non-inline header *declaration* doesn't work either way:
- in `namespace das` it breaks that `addExtern` (`&testFoo` becomes non-constant / ambiguous);
- in the global namespace AOT callers can't link it, since `testFoo`'s global argument type defeats the ADL that rescues `testFooArray`.

## Test

`tests/aot/test_call_namespaced_extern.das` calls `testFoo` through AOT and checks the side effect (`makeDummy` sets `fooData=1`, `testFoo` sets it to `1234`), so the binding gap can't regress silently.

## Validation

- Built `test_aot` and ran the new test **under AOT**: passes (compiles, links, runs).
- preflight `--full`: 13/13 gates green (format, lint, dasgen, ci-das, docs ×6, tests-cpp, interp, JIT). `cpp-syntax` skipped locally (module-dir C++) but compiled clean via the `test_aot` build; `tests-aot` verified manually as above.

Part of #3065 (fuzzer bugs).