### PR TITLE
dasSpirv: const arrays + dynamic indexing

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -624,3 +624,32 @@ Test robustness: added a positional `op_has_operand_at(words, op, idx, value)` t
 the three position-sensitive asserts to it (OpVariable storage class at index 2 in `test_raster` +
 `test_control`; OpExecutionMode mode at index 1) — a bare `op_has_operand` value match can false-positive
 against the result-type/id operands when the enum value is a small number.
+
+### Const arrays + dynamic indexing LANDED (2026-06-14, branch `bbatkin/dasspirv-const-arrays`)
+
+Prereq for the dasVulkan triangle gate: the canonical hardcoded triangle is `positions[gl_VertexIndex]`
+over a shader-local constant array, which the emitter couldn't lower. Added const arrays + dynamic
+indexing. All three tiers green (interp/JIT/AOT 38/38), spirv-val clean, external `spirv-dis` confirms
+textbook OpTypeArray/OpConstantComposite/OpAccessChain, lint + format clean.
+
+- **`OpTypeArray` + `OpConstantComposite`** builders in `spirv_builder` (deduped). `OpTypeArray`'s length
+  operand is the id of a uint `OpConstant` (not a literal), emitted first for define-before-use.
+- **`emit_type` handles `tFixedArray`** (`float2[3]`): element from `firstType`, length from the scalar
+  `fixedDim`; recurses for multi-dim.
+- **`emit_const`** — a constant-only lowering path: scalar consts, **folded vector constants**
+  (`ExprConstFloat2/3/4`, `ExprConstInt/UInt2/3/4` read via `.value`), **unfolded** all-const vector
+  *constructors* (`ExprCall` → `OpConstantComposite`), **unary-minus-of-constant** (`ExprOp1("-", const)`),
+  and `ExprMakeArray` → array `OpConstantComposite`. ok=false on any non-constant → clean error.
+- **Array-typed locals are memory-backed.** `collect_locals` declares a `tFixedArray` `let` (not just
+  `var`) as a Function-storage `OpVariable`; the `ExprLet` store writes the array constant into it.
+  `emit_ptr` handles `ExprAt` on a local array → `OpAccessChain` by the (dynamic) index.
+- **Tests:** `tests/spirv/test_const_arrays.das` — the gl_VertexIndex triangle vertex shader; asserts
+  TypeArray/ConstantComposite/AccessChain, the length-3 `OpConstant`, a Function-storage array variable,
+  and the VertexIndex/Position builtins + spirv-val. Census extended to `const_array_emitter_opcodes`
+  (Phase-3 set + `TypeArray`/`ConstantComposite`), unioned over the new `catri` fixture.
+
+**Finding (load-bearing):** `float2(0.0, -0.6)` arrives **fold-state-dependent** — as a folded
+`ExprConstFloat2` in the dastest compile, but as an `ExprCall float2(...)` with an `ExprOp1("-", 0.6)`
+argument in the lint/macro-patch compile. `emit_const` must handle BOTH (and the unary-minus fold), or
+the shader compiles in one context and errors in another. Both shapes produce the identical
+`OpConstantComposite`, so the census stays stable across tiers.

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -214,6 +214,43 @@ def public type_runtime_array(var m : SpirvModule; elem : uint; stride : int) : 
     return id
 }
 
+// A fixed-size array type. OpTypeArray's length operand is the id of a uint OpConstant (not a
+// literal), so the length constant is emitted first (define-before-use within SEC_TYPES). Deduped
+// by element + length.
+def public type_array(var m : SpirvModule; elem : uint; len : int) : uint {
+    if (len <= 0) {
+        panic("type_array: length must be positive, got {len}")
+    }
+    let key = "arr{elem}_n{len}"
+    let ex = m.type_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let len_id = const_uint(m, uint(len))
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, SpvOp.TypeArray, id, elem, len_id)
+    m.type_pool |> insert(key, id)
+    return id
+}
+
+// A composite (vector / array / struct) constant from already-emitted constituent constant ids.
+// Deduped by type + constituents — two identical composites collapse to one OpConstantComposite.
+def public const_composite(var m : SpirvModule; type_id : uint; parts : array<uint>) : uint {
+    let key = build_string() $(var wr) {
+        wr |> write("cc{type_id}")
+        for (p in parts) {
+            wr |> write("_{p}")
+        }
+    }
+    let ex = m.const_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let id = alloc_id(m)
+    var ops <- [type_id, id]
+    ops |> push_from(parts)
+    emit_n(m, SEC_TYPES, SpvOp.ConstantComposite, ops)
+    delete ops
+    m.const_pool |> insert(key, id)
+    return id
+}
+
 // A block-decorated struct (UBO/SSBO interface). Members + their byte offsets are supplied by
 // the caller (it owns layout). Two structs with identical member ids + offsets dedup to one.
 def public type_struct_block(var m : SpirvModule; members : array<uint>; offsets : array<int>) : uint {

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -186,9 +186,25 @@ def private global_var_of(e : ExpressionPtr) : Variable const? {
 def emit_ptr(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) : tuple<id : uint; pointee : uint> {
     let at = e ?as ExprAt
     if (at != null) {
+        // local fixed-array indexing: positions[i] -> OpAccessChain into the Function-storage var
+        let lev = at.subexpr ?as ExprVar
+        if (lev != null && (lev.varFlags.local || lev.varFlags.argument || lev.varFlags._block)) {
+            let lv = ctx.local_vars?[intptr(lev.variable)] ?? LocalVar()
+            if (lv.ptr_id != 0u) {
+                let idx = emit_value(m, ctx, at.index, errors)
+                if (idx == 0u) return (id = 0u, pointee = 0u)
+                let pointee = emit_type(m, e._type)
+                let ptr_t = type_pointer(m, SpvStorageClass.Function, pointee)
+                let res = alloc_id(m)
+                emit(m, SEC_FUNCS, SpvOp.AccessChain, ptr_t, res, lv.ptr_id, idx)
+                return (id = res, pointee = pointee)
+            }
+            errors |> push("indexing local '{lev.name}': only fixed-array `var`/`let` locals are indexable")
+            return (id = 0u, pointee = 0u)
+        }
         let bv = global_var_of(at.subexpr)
         if (bv == null) {
-            errors |> push("indexing is only supported on a global ssbo array for now")
+            errors |> push("indexing is only supported on a global ssbo array or a local fixed array for now")
             return (id = 0u, pointee = 0u)
         }
         let gi = ctx.globals?[intptr(bv)] ?? GlobalInfo()
@@ -531,6 +547,132 @@ def private emit_call(var m : SpirvModule; var ctx : EmitCtx; call : ExprCall?; 
     return 0u
 }
 
+// ===== compile-time constants: scalars, all-const vector constructors, const arrays =====
+// Produces a deduped OpConstant / OpConstantComposite for a fully-constant expression. Used for
+// array literals (which must be constant initializers for now) and their constituents. ok=false =>
+// not a compile-time constant (the caller emits a clean error).
+def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : array<string>) : tuple<ok : bool; id : uint> {
+    let r2v = e ?as ExprRef2Value
+    if (r2v != null) return emit_const(m, r2v.subexpr, errors)
+    let cu = e ?as ExprConstUInt
+    if (cu != null) return (ok = true, id = const_uint(m, cu.value))
+    let ci = e ?as ExprConstInt
+    if (ci != null) return (ok = true, id = const_int(m, ci.value))
+    let cf = e ?as ExprConstFloat
+    if (cf != null) return (ok = true, id = const_float(m, cf.value))
+    // unary minus on a constant: depending on fold state `-0.6` can arrive as ExprOp1("-", const)
+    // rather than a folded negative literal. Fold it here so both shapes produce the same constant.
+    let neg = e ?as ExprOp1
+    if (neg != null && "{neg.op}" == "-") {
+        let inner = neg.subexpr ?as ExprRef2Value
+        let sub = inner != null ? inner.subexpr : neg.subexpr
+        let ncf = sub ?as ExprConstFloat
+        if (ncf != null) return (ok = true, id = const_float(m, -ncf.value))
+        let nci = sub ?as ExprConstInt
+        if (nci != null) return (ok = true, id = const_int(m, -nci.value))
+        return (ok = false, id = 0u)
+    }
+    // folded vector constants (float2(0.,−.6) etc. fold to ExprConstFloatN at patch time) ->
+    // OpConstantComposite of per-lane scalar constants.
+    let cf2 = e ?as ExprConstFloat2
+    if (cf2 != null) {
+        let v = cf2.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_float(m, v.x), const_float(m, v.y)]))
+    }
+    let cf3 = e ?as ExprConstFloat3
+    if (cf3 != null) {
+        let v = cf3.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_float(m, v.x), const_float(m, v.y), const_float(m, v.z)]))
+    }
+    let cf4 = e ?as ExprConstFloat4
+    if (cf4 != null) {
+        let v = cf4.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_float(m, v.x), const_float(m, v.y), const_float(m, v.z), const_float(m, v.w)]))
+    }
+    let ci2 = e ?as ExprConstInt2
+    if (ci2 != null) {
+        let v = ci2.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_int(m, v.x), const_int(m, v.y)]))
+    }
+    let ci3 = e ?as ExprConstInt3
+    if (ci3 != null) {
+        let v = ci3.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_int(m, v.x), const_int(m, v.y), const_int(m, v.z)]))
+    }
+    let ci4 = e ?as ExprConstInt4
+    if (ci4 != null) {
+        let v = ci4.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_int(m, v.x), const_int(m, v.y), const_int(m, v.z), const_int(m, v.w)]))
+    }
+    let cu2 = e ?as ExprConstUInt2
+    if (cu2 != null) {
+        let v = cu2.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_uint(m, v.x), const_uint(m, v.y)]))
+    }
+    let cu3 = e ?as ExprConstUInt3
+    if (cu3 != null) {
+        let v = cu3.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_uint(m, v.x), const_uint(m, v.y), const_uint(m, v.z)]))
+    }
+    let cu4 = e ?as ExprConstUInt4
+    if (cu4 != null) {
+        let v = cu4.value
+        return (ok = true, id = const_composite(m, emit_type(m, e._type), [const_uint(m, v.x), const_uint(m, v.y), const_uint(m, v.z), const_uint(m, v.w)]))
+    }
+    // all-constant vector constructor -> OpConstantComposite
+    let call = e ?as ExprCall
+    if (call != null) {
+        let vc = vector_ctor("{call.name}")
+        if (!vc.ok) return (ok = false, id = 0u)
+        var total = 0
+        var parts : array<uint>
+        parts |> reserve(length(call.arguments))
+        for (a in call.arguments) {
+            let cc = component_count(a._type.baseType)
+            if (cc == 0 || scalar_class(a._type.baseType) != vc.cls) {
+                errors |> push("{call.name}: constant constructor constituent of type {a._type.baseType} has the wrong component kind")
+                delete parts
+                return (ok = false, id = 0u)
+            }
+            total += cc
+            let pr = emit_const(m, a, errors)
+            if (!pr.ok) {
+                errors |> push("{call.name}: constructor argument is not a compile-time constant")
+                delete parts
+                return (ok = false, id = 0u)
+            }
+            parts |> push(pr.id)
+        }
+        if (total != vc.n) {
+            errors |> push("{call.name}: constant constituent lanes sum to {total}, expected {vc.n}")
+            delete parts
+            return (ok = false, id = 0u)
+        }
+        let cid = const_composite(m, emit_type(m, e._type), parts)
+        delete parts
+        return (ok = true, id = cid)
+    }
+    // const array literal -> OpConstantComposite of element constants
+    let mk = e ?as ExprMakeArray
+    if (mk != null) {
+        var parts : array<uint>
+        parts |> reserve(length(mk.values))
+        for (v in mk.values) {
+            let pr = emit_const(m, v, errors)
+            if (!pr.ok) {
+                errors |> push("array literal element is not a compile-time constant")
+                delete parts
+                return (ok = false, id = 0u)
+            }
+            parts |> push(pr.id)
+        }
+        let cid = const_composite(m, emit_type(m, e._type), parts)
+        delete parts
+        return (ok = true, id = cid)
+    }
+    return (ok = false, id = 0u)
+}
+
 // ===== rvalue: produce an SSA result-id =====
 def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) : uint {
     // ExprRef2Value wraps a ref lvalue to read its value; running in `patch` (pre-fold) the AST
@@ -602,6 +744,15 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     }
     let call = e ?as ExprCall
     if (call != null) return emit_call(m, ctx, call, e, errors)
+    let mk = e ?as ExprMakeArray
+    if (mk != null) {
+        let r = emit_const(m, e, errors)
+        if (!r.ok) {
+            errors |> push("array literal must be a compile-time constant for now")
+            return 0u
+        }
+        return r.id
+    }
     let ev = e ?as ExprVar
     if (ev != null && (ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block)) {
         let lv = ctx.local_vars?[intptr(ev.variable)] ?? LocalVar()
@@ -635,9 +786,9 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
 def private declare_local_var(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; var errors : array<string>) {
     if (key_exists(ctx.local_vars, intptr(v))) return
     let bt = v._type.baseType
-    if (scalar_class(bt) < 0 && bt != Type.tBool) {
+    if (scalar_class(bt) < 0 && bt != Type.tBool && bt != Type.tFixedArray) {
         // emit_type would panic on an unsupported base type; reject with a clean error instead.
-        errors |> push("local '{v.name}': type {bt} is not supported yet (only 32-bit int/uint/float scalars+vectors and bool)")
+        errors |> push("local '{v.name}': type {bt} is not supported yet (only 32-bit int/uint/float scalars+vectors, bool, and fixed arrays)")
         return
     }
     let vt = emit_type(m, v._type)
@@ -659,7 +810,11 @@ def private collect_locals(var m : SpirvModule; var ctx : EmitCtx; e : Expressio
     let lt = e ?as ExprLet
     if (lt != null) {
         for (v in lt.variables) {
-            if (!v._type.flags.constant) declare_local_var(m, ctx, v, errors)   // `var` -> memory; `let` -> SSA
+            // `var` -> memory; scalar/vector `let` -> SSA; but a fixed-array `let` needs memory too
+            // (dynamic indexing requires an addressable OpVariable + OpAccessChain).
+            if (!v._type.flags.constant || v._type.baseType == Type.tFixedArray) {
+                declare_local_var(m, ctx, v, errors)
+            }
         }
         return
     }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -655,6 +655,12 @@ def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : arra
     // const array literal -> OpConstantComposite of element constants
     let mk = e ?as ExprMakeArray
     if (mk != null) {
+        // a dynamic array<T> literal is ALSO an ExprMakeArray; emit_type would panic on tArray.
+        // Only fixed-array literals lower to a constant composite — reject the rest cleanly.
+        if (e._type == null || e._type.baseType != Type.tFixedArray) {
+            errors |> push("only fixed-array literals are supported (dynamic array<T> literals are not)")
+            return (ok = false, id = 0u)
+        }
         var parts : array<uint>
         parts |> reserve(length(mk.values))
         for (v in mk.values) {
@@ -746,12 +752,8 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
     if (call != null) return emit_call(m, ctx, call, e, errors)
     let mk = e ?as ExprMakeArray
     if (mk != null) {
-        let r = emit_const(m, e, errors)
-        if (!r.ok) {
-            errors |> push("array literal must be a compile-time constant for now")
-            return 0u
-        }
-        return r.id
+        let r = emit_const(m, e, errors)   // emit_const reports the specific reason on failure
+        return r.ok ? r.id : 0u
     }
     let ev = e ?as ExprVar
     if (ev != null && (ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block)) {

--- a/modules/dasSpirv/spirv/spirv_types.das
+++ b/modules/dasSpirv/spirv/spirv_types.das
@@ -29,6 +29,11 @@ def public emit_type(var m : SpirvModule; t : TypeDecl?) : uint {
     if (bt == Type.tFloat2) return type_vector(m, type_float(m, 32u), 2)
     if (bt == Type.tFloat3) return type_vector(m, type_float(m, 32u), 3)
     if (bt == Type.tFloat4) return type_vector(m, type_float(m, 32u), 4)
+    // fixed array: float2[3] -> OpTypeArray(element, length). Outermost dim is fixedDim; the
+    // element (firstType) may itself be a fixed array for multi-dim, so recurse.
+    if (bt == Type.tFixedArray && t.firstType != null) {
+        return type_array(m, emit_type(m, t.firstType), t.fixedDim)
+    }
     panic("emit_type: unsupported baseType {bt}")
     return 0u
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -287,6 +287,24 @@ def public raster_math_words : array<uint> {
     return <- w
 }
 
+// ===== const arrays + dynamic indexing: the gl_VertexIndex hardcoded-triangle vertex shader.
+// Exercises OpTypeArray, OpConstantComposite (vec + array constants), a Function-storage array
+// OpVariable initialized from the constant, and OpAccessChain indexing by gl_VertexIndex. =====
+var @out @location = 0 cv_color : float3
+[vertex_shader(name="catri_spv"), marker(no_coverage)]
+def catri {
+    let positions = fixed_array(float2(0.0, -0.6), float2(0.6, 0.6), float2(-0.6, 0.6))
+    let colors = fixed_array(float3(1.0, 0.0, 0.0), float3(0.0, 1.0, 0.0), float3(0.0, 0.0, 1.0))
+    gl_Position = float4(positions[gl_VertexIndex], 0.0, 1.0)   // OpAccessChain + CompositeConstruct
+    cv_color = colors[gl_VertexIndex]
+}
+
+def public catri_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(catri_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -400,6 +418,16 @@ def public phase3_emitter_opcodes : table<uint> {
         SpvOp.Dot,                          // dot(a, b)
         SpvOp.ExtInstImport, SpvOp.ExtInst  // GLSL.std.450 math (sqrt/clamp/...)
     ]) {
+        s |> insert(uint(op))
+    }
+    return <- s
+}
+
+// Const arrays + dynamic indexing add OpTypeArray + OpConstantComposite (the array/vector constants).
+// Phase-3 set + these:
+def public const_array_emitter_opcodes : table<uint> {
+    var s <- phase3_emitter_opcodes()
+    for (op in [SpvOp.TypeArray, SpvOp.ConstantComposite]) {
         s |> insert(uint(op))
     }
     return <- s

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -26,7 +26,7 @@ def private add_set(var dst : table<uint>; var words : array<uint>) {
 
 [test]
 def test_opcode_census(t : T?) {
-    t |> run("emitter opcode census == declared Phase-3 set (all fixtures)") <| @(t : T?) {
+    t |> run("emitter opcode census == declared set (all fixtures)") <| @(t : T?) {
         var present : table<uint>
         add_set(present, square_words())
         add_set(present, uarith_words())
@@ -41,7 +41,8 @@ def test_opcode_census(t : T?) {
         add_set(present, tri_frag_words())
         add_set(present, vindex_words())
         add_set(present, raster_math_words())
-        var declared <- phase3_emitter_opcodes()
+        add_set(present, catri_words())
+        var declared <- const_array_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_const_arrays.das
+++ b/tests/spirv/test_const_arrays.das
@@ -1,0 +1,49 @@
+options gen2
+options indenting = 4
+
+// Const arrays + dynamic indexing gate: the gl_VertexIndex hardcoded-triangle vertex shader lowers
+// fixed-array `let`s to OpTypeArray + OpConstantComposite (vec + array constants), a Function-storage
+// array OpVariable initialized via OpStore, and OpAccessChain indexing by gl_VertexIndex. The emitted
+// module passes spirv-val (the real define-before-use / type oracle).
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private check_ops(t : T?; words : array<uint>; lbl : string; ops : array<SpvOp>) {
+    for (op in ops) {
+        t |> success(has_op(words, op), "{lbl}: emits {op}")
+    }
+}
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_const_array_triangle(t : T?) {
+    t |> run("const arrays: positions[gl_VertexIndex] -> TypeArray + ConstantComposite + AccessChain") <| @(t : T?) {
+        var words <- catri_words()
+        // array type + composite constants + dynamic index + the vec4 build
+        check_ops(t, words, "catri", [SpvOp.TypeArray, SpvOp.ConstantComposite,
+            SpvOp.AccessChain, SpvOp.Load, SpvOp.Store, SpvOp.CompositeConstruct])
+        // the length-3 array constant: an OpConstant uint with value 3 (operand index 2)
+        t |> success(op_has_operand_at(words, SpvOp.Constant, 2, 3u), "catri: has the uint 3 length constant")
+        // a Function-storage OpVariable for the array (storage class at operand index 2)
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Function)),
+            "catri: array lives in a Function-storage OpVariable")
+        // rasterizer builtins driving it
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.VertexIndex)),
+            "catri: reads gl_VertexIndex")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.Position)),
+            "catri: writes gl_Position")
+        validate(t, words, "catri")
+        delete words
+    }
+}


### PR DESCRIPTION
Adds shader-local **constant arrays** and **dynamic indexing** to the dasSpirv emitter. This is the prerequisite for the dasVulkan triangle GPU gate (Phase 3's cross-repo closer): the canonical hardcoded triangle is `positions[gl_VertexIndex]` over a shader-local constant array, which the emitter couldn't lower until now.

## What lands

**Builder (`spirv_builder.das`)**
- `type_array` → `OpTypeArray` (length operand is the id of a uint `OpConstant`, emitted first for define-before-use), deduped.
- `const_composite` → `OpConstantComposite` (vector + array constants), deduped.

**Types (`spirv_types.das`)**
- `emit_type` handles `tFixedArray` (`float2[3]`): element from `firstType`, length from the scalar `fixedDim`; recurses for multi-dim.

**Emit (`spirv_emit.das`)**
- A constant-only `emit_const` path: scalar consts, **folded** vector constants (`ExprConstFloat/Int/UInt {2,3,4}` via `.value`), **unfolded** all-const vector constructors (`ExprCall`), **unary-minus-of-constant** (`ExprOp1("-", const)`), and `ExprMakeArray` → array `OpConstantComposite`. Any non-constant → clean error (fail-closed).
- Array-typed locals are memory-backed: `collect_locals` declares a `tFixedArray` `let` (not just `var`) as a Function-storage `OpVariable`; the `ExprLet` store writes the array constant; `emit_ptr` lowers `ExprAt` on a local array to `OpAccessChain` by the dynamic index.

## Fold-state finding
`float2(0.0, -0.6)` arrives **fold-state-dependent** — a folded `ExprConstFloat2` in the dastest compile, but an `ExprCall float2(...)` with an `ExprOp1("-", 0.6)` argument in the lint/macro-patch compile. `emit_const` handles both shapes (identical `OpConstantComposite` output), so the shader can't compile in one context and error in another.

## Tests / gates
- `tests/spirv/test_const_arrays.das`: the gl_VertexIndex hardcoded-triangle vertex shader — asserts `OpTypeArray`/`OpConstantComposite`/`OpAccessChain`, the length-3 `OpConstant`, a Function-storage array variable, the VertexIndex/Position builtins, + spirv-val. External `spirv-dis` confirms textbook structure.
- Census extended to `const_array_emitter_opcodes` (Phase-3 set + `TypeArray`/`ConstantComposite`), unioned over the new `catri` fixture.
- **All three tiers green (interpreter / JIT / AOT, 38/38)**, spirv-val clean, lint + format clean.

## Follow-on
Next: the dasVulkan triangle PR — port `triangle.vert`/`.frag` to `[vertex_shader]`/`[fragment_shader]`, delete the committed `.spv`, regress the triangle on lavapipe + local GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)