### PR TITLE
infer: reject local reference to a temporary value (#3065)

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1689,7 +1689,7 @@ class public CppAot : AstVisitor {
         } elif (variable.flags.init_via_move) {
             let vname = collector.getVarName(variable);
             var cvname = vname;
-            if (variable._type.flags.constant && variable._type.isRefType) {
+            if (variable._type.flags.constant && variable._type.isRefType && !variable._type.flags.ref) {
                 cvname += "_ConstRef";
             }
             write(*ss, "; das_zero({cvname}); das_move({cvname}, ");

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -5211,8 +5211,22 @@ namespace das {
         if (var->type->ref && !var->init)
             error("local reference has to be initialized", "", "",
                   var->at, CompilationError::missing_local_reference_init);
-        if (var->type->ref && var->init && !(var->init->alwaysSafe || isLocalOrGlobal(var->init)) && !safeExpression(expr) && !(var->init->type && var->init->type->temporary)) {
-            if (program->policies.local_ref_is_unsafe) {
+        // A reference can only bind to addressable storage. Split the non-local case in two:
+        //  - a freshly-materialized temporary - a *value* (type->ref==false) that is not a cast/view:
+        //    a make-local literal, or a value-returning call. It needs its own temp-stack slot and has
+        //    no storage to point at, so the reference would dangle. Never valid: a hard error,
+        //    regardless of `unsafe`. (`[1]` etc. is lowered to a value-returning call by this point, so
+        //    rtti_isMakeLocal no longer holds - hence the type->ref + !rtti_isCast test.)
+        //  - an addressable non-local - a deref, or an upcast/reinterpret view of real storage: merely
+        //    unsafe (the existing policy-gated diagnostic).
+        if (var->type->ref && var->init && !(var->init->alwaysSafe || isLocalOrGlobal(var->init))
+                && var->init->type && !var->init->type->temporary) {
+            if (!var->init->type->ref && !var->init->rtti_isCast()) {
+                error("local reference to a temporary value is not allowed",
+                      "a reference must bind to addressable storage (a variable, a field, or a function "
+                      "returning a reference); a freshly-built temporary has none", "",
+                      var->at, CompilationError::unsafe_local_reference);
+            } else if (!safeExpression(expr) && program->policies.local_ref_is_unsafe) {
                 error("local reference to non-local expression is unsafe", "", "",
                       var->at, CompilationError::unsafe_local_reference);
             }

--- a/tests/typer_errors/failed_local_reference_to_temporary.das
+++ b/tests/typer_errors/failed_local_reference_to_temporary.das
@@ -1,0 +1,15 @@
+// Regression for issue #3065 (fuzzer, AOT): binding a local reference to a temporary
+// value -- here a freshly-built array `[1]` -- has no addressable storage to point at,
+// so the reference would dangle. The front-end used to let this through under `unsafe`
+// (in the fuzzer it was the finally of an unsafe block that suppressed the check), after
+// which it crashed the interpreter at runtime and emitted ill-formed C++ (`&temporary`)
+// under AOT. It is now a hard compile error regardless of `unsafe`.
+options gen2
+expect 31019
+
+[export]
+def main {
+    unsafe {
+        let r & := [1]
+    }
+}


### PR DESCRIPTION
### Problem

A local reference can only bind to addressable storage. The fuzzer (#3065) found

```
unsafe {
    let r & := [1]
}
```

— a reference bound to a freshly-built value (an array/struct/tuple literal, or a
value-returning call) that lives only on the temp stack. The reference dangles
immediately.

The front-end let this through under `unsafe`: the unsafe-gated *"local reference
to non-local expression is unsafe"* check in `visitLet` was skipped inside
`unsafe`, and never distinguished a **temporary** from an **addressable
non-local**. The bad binding then crashed the interpreter at runtime and, under
AOT, emitted ill-formed C++ — `das_move(ptr, &(<temp>))`, taking the address of a
temporary (this is one of the "AOT" entries in #3065).

### Fix

`visitLet` now splits the non-local-reference case in two:

- a **value** init that is not a cast/view (`type->ref == false && !rtti_isCast`)
  — a materialized temporary — is **rejected unconditionally, ignoring `unsafe`**,
  since it can never be valid. (`[1]` is lowered to a value-returning call by this
  point, so `rtti_isMakeLocal` no longer holds — hence the type-based test.)
- an **addressable non-local** (a deref, or an upcast/`reinterpret` view of real
  storage) keeps the existing unsafe-gated diagnostic.

So the two long-standing valid forms still compile:

```
var g = 13
let r & = g                 // local ref to a global — fine

def foo : int& { ... }
let r & = foo()             // ref to a function returning a reference — fine
```

The error reuses `unsafe_local_reference` (31019) but the message now says the
binding is **not allowed at all**, rather than merely unsafe.

### Also

Keeps a latent-asymmetry fix in the AOT emitter (`daslib/aot_cpp.das`): the
move-init use-site appended `_ConstRef` for a `flags.ref` binding while the three
declaration sites do not (they gate on `!flags.ref`), producing an undeclared
`_ConstRef`. The typer now rejects the input that exercised it, but the emitter
guard is correct on its own and is kept as a tripwire.

### Test

`tests/typer_errors/failed_local_reference_to_temporary.das` (`expect 31019`).

Validated: full interpreter suite (11116/11116), JIT suite, and the AOT sweep over
`tests/` all green; the two cast-view cases (`override_field.das` upcast,
`reflection.das` `reinterpret<T&>`) still compile.

Part of #3065 (fuzzer bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)