### PR TITLE
aot: bump emitter stack + fail closed on codegen exception (#3065)

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -15,6 +15,11 @@ require daslib/aot_constants
 
 options strict_smart_pointers = false
 options unsafe_table_lookup = false
+// describeCppTypeEx recurses once per nesting level of a type; a deeply nested
+// function/lambda/tuple type (the fuzzer's, #3065) needs far more than the default
+// ~16KB macro-context stack. Bump it so realistic depths emit; pathological depths
+// still overflow and are caught fail-closed (see fail_on_aot_emit_error).
+options stack = 1_048_576
 
 def aotFieldName(name : string) : string {
     var result = replace(name, "`", "__");
@@ -4171,6 +4176,27 @@ def public compile_and_simulate(input : string, var access; var mg : ModuleGroup
 }
 
 
+def public fail_on_aot_emit_error(program : ProgramPtr) {
+    // Fail-closed (#3065). A macro/codegen exception during the emit visit -- e.g. an
+    // unbounded type recursion overflowing the stack -- is caught and recorded by the
+    // visitor adapter (sets macroException/failToCompile, appends to errors), but the
+    // visit is NOT aborted: it leaves the C++ output partial (a struct missing a field,
+    // a dangling offsetof, ...). Never write such broken C++ -- surface the recorded
+    // errors and abort so the build fails loudly instead of silently emitting code that
+    // does not compile.
+    if (!program.flags.macroException && !program.flags.failToCompile) {
+        return
+    }
+    for (err in program.errors) {
+        var detail = ""
+        if (!empty(err.extra)) {
+            detail = " -- {err.extra}"
+        }
+        to_log(LOG_ERROR, "{describe(err.at)}: {err.what}{detail}\n")
+    }
+    panic("AOT codegen failed: {length(program.errors)} codegen error(s) during emission (see log)")
+}
+
 [export]
 def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) : string {
     //! Generates the complete AOT C++ source code string for a compiled and simulated program.
@@ -4236,12 +4262,15 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
                     dumpDependencies(program, cpp_aot);
                     visit(program, cpp_aot.adapter, true)
                 }
-                write(writer, "{cpp_aot.str()}");
+                if (!program.flags.macroException && !program.flags.failToCompile) {
+                    write(writer, "{cpp_aot.str()}");
+                }
                 unsafe {
                     delete cpp_aot.helper.helper
                     delete cpp_aot.collector
                     delete cpp_aot
                 }
+                fail_on_aot_emit_error(program)
             }
             registerAotCpp(unsafe(addr(writer)), program, *pctx, cop.cross_platform, false);
             write(writer, "\n");
@@ -4317,6 +4346,7 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
                 delete cpp_aot.collector
                 delete cpp_aot
             }
+            fail_on_aot_emit_error(program)
             // extract between markers
             let begin_pos = find(full_output, AOT_FUNC_BEGIN)
             if (begin_pos >= 0) {

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -4191,11 +4191,14 @@ def public fail_on_aot_emit_error(program : ProgramPtr) {
         return
     }
     for (err in program.errors) {
-        var detail = ""
+        var msg = "{describe(err.at)}: error[{int(err.cerr)}]: {err.what}"
         if (!empty(err.extra)) {
-            detail = " -- {err.extra}"
+            msg += " -- {err.extra}"
         }
-        to_log(LOG_ERROR, "{describe(err.at)}: {err.what}{detail}\n")
+        if (!empty(err.fixme)) {
+            msg += " -- {err.fixme}"
+        }
+        to_log(LOG_ERROR, "{msg}\n")
     }
     panic("AOT codegen failed: {length(program.errors)} codegen error(s) during emission (see log)")
 }

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -4346,7 +4346,12 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
                 dumpDependencies(program, cpp_aot);
                 visit(program, cpp_aot.adapter, true)
             }
-            let full_output = cpp_aot.str()
+            // Don't materialize the (partial) output on the fail-closed path -- mirrors
+            // run_aot. fail_on_aot_emit_error panics below; cleanup still runs first.
+            var full_output = ""
+            if (!program.flags.macroException && !program.flags.failToCompile) {
+                full_output = cpp_aot.str()
+            }
             unsafe {
                 delete cpp_aot.helper.helper
                 delete cpp_aot.collector

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -15,9 +15,12 @@ require daslib/aot_constants
 
 options strict_smart_pointers = false
 options unsafe_table_lookup = false
-// describeCppTypeEx recurses once per nesting level of a type; a deeply nested
-// function/lambda/tuple type (the fuzzer's, #3065) needs far more than the default
-// ~16KB macro-context stack. Bump it so realistic depths emit; pathological depths
+// describeCppTypeEx recurses once per type-nesting level; a deeply nested
+// function/lambda/tuple type (the fuzzer's, #3065) overflows the default ~16KB stack.
+// This bump only governs when aot_cpp is the ROOT program -- the direct `daslang -aot`
+// C++ driver compiles it as root (utils/daScript/main.cpp::aot_compile). The CMake/CI
+// driver utils/aot/main.das only REQUIRES this module, so getContextStackSize() reads
+// the driver's options there; it carries a matching twin bump. Pathological depths
 // still overflow and are caught fail-closed (see fail_on_aot_emit_error).
 options stack = 1_048_576
 

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -354,6 +354,9 @@ def genStandaloneSrc(var program : ProgramPtr;
             }
         }
     }
+    // Fail-closed (#3065): never assemble standalone C++ from a partial emit -- abort if
+    // a macro/codegen exception was recorded during the visits above.
+    fail_on_aot_emit_error(program)
 
     write(source, "namespace {program.thisNamespace} \{\n");
     write(source, "{ctx_generated}");

--- a/tests/aot/test_deep_nested_type_aot.das
+++ b/tests/aot/test_deep_nested_type_aot.das
@@ -1,4 +1,4 @@
-﻿options gen2
+options gen2
 require dastest/testing_boost public
 
 // Regression for #3065 / PR #3145 (AOT emitter stack bump). describeCppTypeEx recurses

--- a/tests/aot/test_deep_nested_type_aot.das
+++ b/tests/aot/test_deep_nested_type_aot.das
@@ -1,0 +1,25 @@
+﻿options gen2
+require dastest/testing_boost public
+
+// Regression for #3065 / PR #3145 (AOT emitter stack bump). describeCppTypeEx recurses
+// once per nesting level when emitting a type, so a deeply-nested function type overflows
+// the emitter's default ~16KB macro-context stack (overflow threshold ~13 levels). That
+// used to silently drop the field and emit uncompilable C++ (a Func deep; with an
+// unbalanced DAS_COMMENT, plus a dangling offsetof). With options stack bumped in
+// daslib/aot_cpp.das the ~40-level field below emits a complete, balanced field; the
+// tests/aot harness compiles the emitted C++, so removing the bump would fail this AOT
+// build. 40 is ~3x the overflow threshold yet well within the 1MB bump -- the daslang
+// context stack is a platform-independent managed buffer, so depth behaves identically
+// across CI targets.
+
+struct Holder {
+    deep : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : function<(a : int) : int>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+}
+
+[test]
+def test_deep_nested_type_aot(t : T?) {
+    t |> run("deeply-nested function type AOT-emits a complete field") @(t : T?) {
+        let h = Holder()
+        t |> equal(h.deep == null, true)
+    }
+}

--- a/utils/aot/main.das
+++ b/utils/aot/main.das
@@ -1,4 +1,11 @@
 options gen2
+// The AOT emitter (daslib/aot_cpp::describeCppTypeEx) recurses once per type-nesting
+// level and runs in THIS driver's context, so its depth is bounded by
+// getContextStackSize() here -- NOT by aot_cpp's own `options stack` (that governs only
+// the direct `daslang -aot` C++ driver, where aot_cpp is the root program). A deeply
+// nested type (#3065) overflows the default ~16KB stack; bump so realistic depths emit.
+// Pathological depths still fail-closed (aot_cpp::fail_on_aot_emit_error).
+options stack = 1_048_576
 require daslib/aot_cpp
 require daslib/aot_standalone
 


### PR DESCRIPTION
### Problem

The fuzzer (#3065) found a deeply-nested type (`function < function < … < lambda<…> > … >`,
~65 levels) that made the AOT emitter produce **broken C++ at exit 0**:

```c++
struct _lambda_vate_9_2 {
                                                       // <- __lambda field DROPPED (empty)
    Func DAS_COMMENT((void,…*)) __finalize;
};
static_assert(offsetof(_lambda_vate_9_2,__lambda)==0,…);  // references a field that isn't there
```

Two compounding causes:

1. **`describeCppTypeEx` recurses once per nesting level** of a type. The default
   ~16 KB macro-context stack of the AOT emitter overflows on such a type, and daslang
   raises a (catchable) stack-overflow panic mid-type.
2. **The panic is swallowed.** The visitor adapter's `runMacroFunction` catches the
   panic, records it (`macroException` / `failToCompile` / appends to `program.errors`),
   then **clears it and continues the visit** — so the field's type comes back empty and
   emission proceeds, yielding the broken struct above. Nothing downstream checked the
   recorded failure, so the AOT wrote the file and exited 0.

### Fix — both, per the "any codegen error must fail the build" rule

1. **Bump the emitter stack** (`options stack = 1_048_576` in `aot_cpp.das`) so
   realistic nesting depths emit completely. The #3065 repro now produces full, valid
   C++ (60 KB → 160 KB, balanced `__lambda` field).
2. **Fail closed** (`fail_on_aot_emit_error`, wired into all three emit entry points —
   `run_aot`, `run_aot_function`, `aot_standalone`): after each emit visit, check
   `macroException` / `failToCompile`; if set, surface the recorded errors via `to_log`
   and `panic` so the AOT **aborts with no output written** rather than emitting partial
   C++. The driver's `evalWithCatch` turns that into a clean non-zero exit.

Together: realistic-depth types emit; anything past the (now much higher) ceiling fails
the build loudly instead of silently writing uncompilable code.

### Verification

- The #3065 repro now AOT-emits **complete, valid C++** (exit 0) — was silently broken.
- With the bump removed (to force the overflow), the AOT **aborts cleanly**: exit
  non-zero, **no output file**, no GC leak, surfacing the real diagnostic
  `stack overflow while calling @aot_cpp::describeCppTypeEx` at the exact site.
- `options stack` is a no-op on output; `fail_on_aot_emit_error` is a no-op when no
  exception was recorded — so normal AOT output (and semantic hashes) is unchanged.

### Out of scope (filed separately)

A *pathologically* deep type (≥~2000 levels) crashes the **compiler itself**
(`EXCEPTION_STACK_OVERFLOW` in parse/infer, before AOT) — pre-existing, independent of
the emitter and of this change. Filed as #3144.

Part of #3065 (fuzzer bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)