### PR TITLE
dasSpirv Phase 4: resource breadth (UBOs, matrices, push constants, samplers)

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -566,6 +566,12 @@ class UseTypeMarker : AstVisitor {
     def override preVisitExprBlockArgument(expr_blk : ExprBlock?; variable : VariablePtr; lastArg : bool) {
         mark(variable._type);
     }
+    def override preVisitGlobalLetVariable(variable : Variable?; lastArg : bool) {
+        // a global's type must be marked even if its fields are never accessed: das_global[_zero]
+        // needs the complete C++ type (sizeof), so a struct used ONLY as a global's type would
+        // otherwise be dropped to a forward declaration and fail to compile.
+        mark(variable._type);
+    }
     def mark(decl : TypeDeclPtr) {
         if (decl == null) return ;
         if (decl.baseType == Type.tStructure) {

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -653,3 +653,33 @@ textbook OpTypeArray/OpConstantComposite/OpAccessChain, lint + format clean.
 argument in the lint/macro-patch compile. `emit_const` must handle BOTH (and the unary-minus fold), or
 the shader compiles in one context and errors in another. Both shapes produce the identical
 `OpConstantComposite`, so the census stays stable across tiers.
+
+### Phase 4a — UBO struct foundation LANDED (2026-06-14, branch `bbatkin/dasspirv-phase4`)
+
+First Phase-4 (resource breadth) slice: uniform buffer objects. A `@uniform` struct global lowers to a
+Uniform-storage, Block-decorated `OpTypeStruct` with std140 member offsets, read through member access
+(`ubo.field` → `OpAccessChain` by field index → `OpLoad`). All three tiers green (interp/JIT/AOT 40/40),
+spirv-val clean, external `spirv-dis` confirms textbook std140 layout, lint + format clean.
+
+- **std140 layout** (`std140_align`/`std140_size`/`round_up`/`build_block_struct` in `spirv_emit`): scalar
+  align 4, vec2 align 8, vec3/vec4 align 16; the vec3 base *size* is 12 (not 16), so a scalar packs into a
+  vec3's (or vec2's) trailing slot. The fixture struct exercises both packing edge cases — `flags@24` after
+  a vec2, `bias@44` after a vec3. Members + offsets feed the existing `type_struct_block` builder (it already
+  emits `Block` + per-member `Offset` decorations). Scalar/vector members only for now (matrices/nested
+  structs/arrays → 4b+, rejected with a clean error).
+- **`@uniform` classify_global branch** — mirrors the `@ssbo` branch: `Uniform` storage pointer + the
+  Block struct + `DescriptorSet`/`Binding` decorations (defaults 0/0, non-negative-checked). `GlobalInfo`
+  gained `is_block` (set for both ssbo and ubo) so member access knows the global is an AccessChain target.
+- **`ExprField` member access** in `emit_ptr` — `OpAccessChain(var, const(memberIndex))`, pointee =
+  `emit_type(field._type)`, storage from the global's class; `emit_value`'s ref path then `OpLoad`s it.
+- **Tests:** `tests/spirv/test_ubo.das` — a `[fragment_shader]` reading every member of a 6-field UBO;
+  asserts the Uniform OpVariable, DescriptorSet/Binding, Block, and EVERY std140 offset (0/16/24/28/32/44)
+  + AccessChain/Load/CompositeConstruct + spirv-val. The `Uniforms`/`ubo_frag` fixture lives in
+  `_spirv_common`; census unions it under `phase4a_emitter_opcodes` (= const-array set; UBOs add NO new
+  opcodes — Uniform storage + DescriptorSet/Binding are operands, not opcodes).
+
+**Finding (load-bearing):** `ExprField.fieldIndex` is **still -1 at the annotation's patch (pre-fold)
+stage** (member-access resolution hasn't run yet), so the member index must be resolved by **name** from
+the struct type (`field_index_by_name` over `bv._type.structType.fields`), not read off the node. Same
+fold-state class as the Phase-1 `ExprRef2Value` and const-array `float2` findings: the patch-stage AST is
+less resolved than the fixup-stage one.

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -683,3 +683,42 @@ stage** (member-access resolution hasn't run yet), so the member index must be r
 the struct type (`field_index_by_name` over `bv._type.structType.fields`), not read off the node. Same
 fold-state class as the Phase-1 `ExprRef2Value` and const-array `float2` findings: the patch-stage AST is
 less resolved than the fixup-stage one.
+
+### Phase 4b — matrices + matrix/vector arithmetic + local swizzle LANDED (2026-06-14, branch `bbatkin/dasspirv-phase4`)
+
+Second Phase-4 slice: matrices (the MVP transform) + the linear-algebra products + local-value swizzles.
+All three tiers green (interp/JIT/AOT 42/42), spirv-val clean, external `spirv-dis` confirms a textbook
+MVP vertex shader, lint + format clean.
+
+- **Matrices are `tHandle` types** (`MatrixAnnotation<floatW, C>`, named `float4x4`/`float3x3`/`float3x4`),
+  NOT a distinct `Type` enum member. `matrix_info(t)` reads `t.annotation.name` → (width, cols);
+  `emit_type` lowers to `type_matrix` = `OpTypeMatrix(vector(float, W), C)`.
+- **Column-major maps directly — no transpose.** daslang stores matrices column-major (`m[i]` is column
+  `i`: `float3x3_mul` builds `va.col0 = a.m[0]`; `float4x4_mul_vec4` is `v_mat44_mul_vec4`, standard
+  M·v), which is SPIR-V's **default** `ColMajor`. So daslang `M * v` → `OpMatrixTimesVector`, `M * N` →
+  `OpMatrixTimesMatrix`, with the matrix uploaded as-is. (Caveat: `float4x4` columns are vec4 = std140's
+  MatrixStride 16, so it uploads byte-for-byte; `float3x3` stores packed 12-byte columns and would need
+  host repacking before a std140 upload — emitter SPIR-V is correct either way.)
+- **std140 matrix layout** (in `build_block_struct`): a matrix member gets align 16, size `16*cols`,
+  ColMajor + `MatrixStride 16` member decorations. `type_struct_block` gained a 3rd `mat_strides` arg
+  (folded into the dedup key) so the matrix decorations are part of the one deduped type emission; the
+  2-arg form delegates with zeros.
+- **`emit_mul`** routes `*` by operand shape BEFORE the scalar binop path (component-wise FMul only works
+  for same-shape operands): `OpMatrixTimesMatrix`, `OpMatrixTimesVector`, `OpVectorTimesScalar` (either
+  order). Only the daslang-defined operators are handled — daslang has **no** `matrix*scalar` or
+  `vector*matrix` operator, so those SPIR-V ops are intentionally absent (no dead, untestable emit path);
+  an unsupported mix (e.g. integer vector×scalar) is a clean error.
+- **Local-value swizzle** in `emit_value`: a swizzle of a local/computed VALUE (`clip.xy`, `clip.w` on a
+  `let`) → `OpVectorShuffle` (multi-component) / `OpCompositeExtract` (single). A swizzle of a *global*
+  lvalue stays the Phase-1 emit_ptr + `OpAccessChain` path (guarded by `global_var_of(sw.value) == null`),
+  closing the Phase-3 "local swizzles not supported" gap.
+- **Tests:** `tests/spirv/test_matrix.das` — a `[vertex_shader]` MVP (`cam.proj * cam.view`,
+  `mvp * float4(in_pos,1)`, `clip * 0.5`, `clip.xy` / `clip.w`); asserts TypeMatrix + the three products +
+  both swizzle ops + ColMajor/MatrixStride/std140 offsets (proj@0, view@64) + spirv-val. Census extended
+  to `phase4b_emitter_opcodes` (= 4a set + TypeMatrix/MatrixTimesMatrix/MatrixTimesVector/VectorTimesScalar/
+  VectorShuffle/CompositeExtract), unioned over the `mvp_vert` fixture.
+
+**Finding:** `float4 * float` (vector×scalar) and `M * v` both arrive as **`ExprOp2`** (not `ExprCall`) —
+`ExprOp2 : ExprOp : ExprCallFunc`, so the operator resolves to a `.func` but the node stays `ExprOp2` with
+`.left`/`.right`. So matrix/vector `*` is intercepted in the emitter's existing `ExprOp2` path, before the
+scalar-class `binop_code` (which returns ok=false on the `tHandle`/mismatched-shape operands).

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -722,3 +722,22 @@ MVP vertex shader, lint + format clean.
 `ExprOp2 : ExprOp : ExprCallFunc`, so the operator resolves to a `.func` but the node stays `ExprOp2` with
 `.left`/`.right`. So matrix/vector `*` is intercepted in the emitter's existing `ExprOp2` path, before the
 scalar-class `binop_code` (which returns ok=false on the `tHandle`/mismatched-shape operands).
+
+### Phase 4c — push constants LANDED (2026-06-14, branch `bbatkin/dasspirv-phase4`)
+
+Third Phase-4 slice: push constants. A `@push_constant` struct global lowers to a PushConstant-storage,
+Block-decorated `OpTypeStruct` — the same struct machinery as a UBO (`build_block_struct` layout +
+`ExprField` member access), but with **no DescriptorSet/Binding** (push constants are not descriptors)
+and not listed in the entry interface (SPIR-V ≤ 1.3). All three tiers green (interp/JIT/AOT 44/44),
+spirv-val clean, external `spirv-dis` confirms PushConstant storage with no descriptor decorations,
+lint + format clean.
+
+- **`@push_constant` classify_global branch** — mirrors `@uniform` minus the descriptor decorations:
+  `PushConstant` storage pointer + the Block struct, `GlobalInfo.is_block = true` so member access reuses
+  the `ExprField` → `OpAccessChain` path verbatim. Layout reuses `build_block_struct` (std140 == std430
+  for the scalar/vector/matrix members we support — they differ only on arrays/nested-struct alignment).
+- **Tests:** `tests/spirv/test_push_constant.das` — a `[fragment_shader]` reading a `@push_constant`
+  block (`pc.tint * pc.gamma`); asserts the PushConstant OpVariable, Block + offsets (tint@0, gamma@16),
+  the **absence** of DescriptorSet/Binding, AccessChain + VectorTimesScalar, + spirv-val. Census set is
+  unchanged (`phase4c_emitter_opcodes` = 4b set — PushConstant is a storage-class operand, not an opcode);
+  the `pc_frag` fixture is unioned in and must stay within the declared set.

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -741,3 +741,39 @@ lint + format clean.
   the **absence** of DescriptorSet/Binding, AccessChain + VectorTimesScalar, + spirv-val. Census set is
   unchanged (`phase4c_emitter_opcodes` = 4b set — PushConstant is a storage-class operand, not an opcode);
   the `pc_frag` fixture is unioned in and must stay within the declared set.
+
+### Phase 4d — combined image samplers LANDED (2026-06-14, branch `bbatkin/dasspirv-phase4`)
+
+Fourth (final) Phase-4 slice: combined image samplers — the last resource kind. A `sampler2D` global
+lowers to an `OpTypeImage` + `OpTypeSampledImage` in UniformConstant storage with DescriptorSet/Binding;
+`texture(tex, uv)` lowers to `OpLoad` (the sampled image) + `OpImageSampleImplicitLod`. All three tiers
+green (interp/JIT/AOT 46/46), spirv-val clean, external `spirv-dis` confirms a textbook textured fragment
+shader, lint + format clean.
+
+- **Sampler authoring surface (no native daslang type).** daslang has no sampler type, so `spirv_builtins`
+  declares an **opaque marker struct `sampler2D {}`** + a stub `texture(s : sampler2D; uv : float2) : float4`
+  (body never runs — only the AST is read). Shaders write `var @binding = 0 tex : sampler2D` and
+  `texture(tex, uv)`; the emitter recognizes both by name.
+- **`type_image` / `type_sampled_image`** builders. For a sampled 2D float texture:
+  `OpTypeImage %float 2D 0 0 0 1 Unknown` then `OpTypeSampledImage`.
+- **classify_global sampler branch** (detected by the `sampler2D` struct name, not an annotation):
+  UniformConstant pointer + OpVariable + DescriptorSet/Binding, `GlobalInfo.is_sampler`. Not in the entry
+  interface (UniformConstant excluded for SPIR-V ≤ 1.3).
+- **`texture()` in emit_call**: `OpLoad` the sampled image (via the global's var-id) + `OpImageSampleImplicitLod`.
+  Implicit-LOD uses screen-space derivatives, so it is **fragment-only** — `ctx` gained a `stage` field
+  (set in `generate_spirv`) and a non-fragment `texture()` is a clean error (fail-closed).
+- **AOT emitter fix (`daslib/aot_cpp.das`).** A struct used **only as a global variable's type** (never
+  field-accessed) was dropped by `UseTypeMarker` to a forward declaration, so `das_global_zero<sampler2D>`
+  failed with C2027 "use of undefined type" (needs `sizeof`). `UseTypeMarker` now overrides
+  `preVisitGlobalLetVariable` to `mark(variable._type)` — a strictly emit-MORE direction (can only add a
+  struct definition, never remove one), so it cannot regress existing AOT. This is a general AOT codegen
+  correctness fix surfaced by the empty-marker-struct global, not dasSpirv-specific.
+- **Tests:** `tests/spirv/test_sampler.das` — a textured `[fragment_shader]` (`texture(tex, ti_uv)`);
+  asserts OpTypeImage/OpTypeSampledImage, the UniformConstant OpVariable, DescriptorSet/Binding, OpLoad +
+  OpImageSampleImplicitLod, + spirv-val. Census extended to `phase4d_emitter_opcodes` (= 4c set +
+  TypeImage/TypeSampledImage/ImageSampleImplicitLod), unioned over the `tex_frag` fixture.
+
+**Phase 4 (resource breadth) COMPLETE** — UBOs (4a) + matrices (4b) + push constants (4c) + combined image
+samplers (4d). The emitter now covers the full descriptor model. The cross-repo GPU gate (a dasVulkan
+UBO/MVP and/or textured example, regressed on lavapipe + the local GPU — the real-hardware proof of the
+column-major matrix mapping) is the follow-on dasVulkan PR, mirroring the Phase-1/Phase-3 GPU gates.

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -178,6 +178,21 @@ def public type_vector(var m : SpirvModule; comp_id : uint; n : int) : uint {
     return id
 }
 
+// A matrix type: `cols` columns, each of type `col_type` (a vector type-id). daslang stores matrices
+// column-major (m[i] is column i), matching SPIR-V's default — so float4x4 -> OpTypeMatrix(v4float, 4).
+def public type_matrix(var m : SpirvModule; col_type : uint; cols : int) : uint {
+    if (cols <= 0) {
+        panic("type_matrix: column count must be positive, got {cols}")
+    }
+    let key = "mat{col_type}_c{cols}"
+    let ex = m.type_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, SpvOp.TypeMatrix, id, col_type, uint(cols))
+    m.type_pool |> insert(key, id)
+    return id
+}
+
 def public type_pointer(var m : SpirvModule; sc : SpvStorageClass; pointee : uint) : uint {
     let key = "p{uint(sc)}_{pointee}"
     let ex = m.type_pool?[key] ?? 0u
@@ -254,8 +269,19 @@ def public const_composite(var m : SpirvModule; type_id : uint; parts : array<ui
 // A block-decorated struct (UBO/SSBO interface). Members + their byte offsets are supplied by
 // the caller (it owns layout). Two structs with identical member ids + offsets dedup to one.
 def public type_struct_block(var m : SpirvModule; members : array<uint>; offsets : array<int>) : uint {
-    if (empty(members) || length(members) != length(offsets)) {
-        panic("type_struct_block: members and offsets must be non-empty and equal length (members={length(members)}, offsets={length(offsets)})")
+    var no_mats : array<int>   // no matrix members
+    no_mats |> resize(length(members))
+    let id = type_struct_block(m, members, offsets, no_mats)
+    delete no_mats
+    return id
+}
+
+// As above, plus per-member matrix strides: mat_strides[k] > 0 marks member k as a matrix needing
+// ColMajor + MatrixStride decorations (daslang matrices are column-major, so ColMajor matches). The
+// stride is part of the dedup key so the decorations stay tied to a single deduped type emission.
+def public type_struct_block(var m : SpirvModule; members : array<uint>; offsets : array<int>; mat_strides : array<int>) : uint {
+    if (empty(members) || length(members) != length(offsets) || length(members) != length(mat_strides)) {
+        panic("type_struct_block: members/offsets/mat_strides must be non-empty and equal length (members={length(members)}, offsets={length(offsets)}, mat_strides={length(mat_strides)})")
     }
     let key = build_string() $(var wr) {
         wr |> write("struct_b")
@@ -264,6 +290,9 @@ def public type_struct_block(var m : SpirvModule; members : array<uint>; offsets
         }
         for (off in offsets) {
             wr |> write("@{off}")
+        }
+        for (ms in mat_strides) {
+            wr |> write("m{ms}")
         }
     }
     let ex = m.type_pool?[key] ?? 0u
@@ -277,6 +306,11 @@ def public type_struct_block(var m : SpirvModule; members : array<uint>; offsets
     emit(m, SEC_DECOR, SpvOp.Decorate, id, uint(SpvDecoration.Block))
     for (k in range(length(offsets))) {
         emit(m, SEC_DECOR, SpvOp.MemberDecorate, id, uint(k), uint(SpvDecoration.Offset), uint(offsets[k]))
+        if (mat_strides[k] > 0) {
+            // a matrix member: column-major (daslang's layout) + the per-column byte stride
+            emit(m, SEC_DECOR, SpvOp.MemberDecorate, id, uint(k), uint(SpvDecoration.ColMajor))
+            emit(m, SEC_DECOR, SpvOp.MemberDecorate, id, uint(k), uint(SpvDecoration.MatrixStride), uint(mat_strides[k]))
+        }
     }
     m.type_pool |> insert(key, id)
     return id

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -193,6 +193,32 @@ def public type_matrix(var m : SpirvModule; col_type : uint; cols : int) : uint 
     return id
 }
 
+// OpTypeImage for a standard sampled (non-storage) texture: depth=0, arrayed=0, ms=0, sampled=1
+// (used with a sampler), format=Unknown. `sampled_type` is the texel component scalar (float).
+def public type_image(var m : SpirvModule; sampled_type : uint; dim : SpvDim) : uint {
+    let key = "img{sampled_type}_d{uint(dim)}"
+    let ex = m.type_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let id = alloc_id(m)
+    // operands: Sampled Type, Dim, Depth, Arrayed, MS, Sampled, Image Format
+    var ops <- [id, sampled_type, uint(dim), 0u, 0u, 0u, 1u, uint(SpvImageFormat.Unknown)]
+    emit_n(m, SEC_TYPES, SpvOp.TypeImage, ops)
+    delete ops
+    m.type_pool |> insert(key, id)
+    return id
+}
+
+// OpTypeSampledImage wrapping an image type — the type of a combined image+sampler descriptor.
+def public type_sampled_image(var m : SpirvModule; image_type : uint) : uint {
+    let key = "simg{image_type}"
+    let ex = m.type_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, SpvOp.TypeSampledImage, id, image_type)
+    m.type_pool |> insert(key, id)
+    return id
+}
+
 def public type_pointer(var m : SpirvModule; sc : SpvStorageClass; pointee : uint) : uint {
     let key = "p{uint(sc)}_{pointee}"
     let ex = m.type_pool?[key] ?? 0u

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -22,3 +22,15 @@ var gl_InstanceIndex        : int       // BuiltIn InstanceIndex (Input)
 
 // fragment
 var gl_FragCoord            : float4    // BuiltIn FragCoord (Input)
+
+// ===== combined image samplers =====
+// sampler2D is an opaque marker type: a global of this type lowers to an OpTypeSampledImage in
+// UniformConstant storage (the emitter recognizes it by name in classify_global). The struct has no
+// fields — shader code never reads it directly, only passes it to texture(). texture() is likewise a
+// stub: its body is never executed (only the AST is read), and the call lowers to OpImageSampleImplicitLod.
+struct sampler2D {}
+
+[unused_argument(s, uv)]
+def public texture(s : sampler2D; uv : float2) : float4 {
+    return float4(0.0, 0.0, 0.0, 0.0)
+}

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -31,6 +31,7 @@ struct GlobalInfo {
     value_type : uint               // SPIR-V type-id of the whole variable's value
     is_ssbo    : bool               // wrapped in a Block-decorated struct (member 0 = the array)
     is_block   : bool               // a Block-decorated struct (ssbo OR ubo); member access -> OpAccessChain by field index
+    is_sampler : bool               // a combined image sampler (UniformConstant OpTypeSampledImage); used via texture()
 }
 
 // A memory-backed local: an OpVariable in Function storage. Mutable locals (`var x`) and loop
@@ -49,6 +50,7 @@ struct EmitCtx {
     loop_stack    : array<LoopTargets>          // innermost loop's {merge, continue} for break/continue
     terminated    : bool                        // current block already has a terminator
     glsl_ext      : uint                        // OpExtInstImport "GLSL.std.450" set id (0 = not imported yet)
+    stage         : ShaderStage                 // the shader stage (texture() implicit-LOD sampling is fragment-only)
 }
 
 // break -> branch to `merge`, continue -> branch to `cont`. Pushed per active loop.
@@ -156,6 +158,15 @@ def private build_block_struct(var m : SpirvModule; sname : string; st : Structu
     return (ok = true, type_id = id)
 }
 
+// ===== combined image sampler detection =====
+// sampler globals are recognized by their opaque marker struct name (sampler2D, ...). Returns the
+// SPIR-V image dimensionality so classify_global can build the OpTypeImage / OpTypeSampledImage.
+def private sampler_info(t : TypeDecl?) : tuple<ok : bool; dim : SpvDim> {
+    if (t == null || t.baseType != Type.tStructure || t.structType == null) return (ok = false, dim = SpvDim._2D)
+    if ("{t.structType.name}" == "sampler2D") return (ok = true, dim = SpvDim._2D)
+    return (ok = false, dim = SpvDim._2D)
+}
+
 // ===== global variable classification + emission =====
 def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; stage : ShaderStage; var errors : array<string>) {
     let vname = "{v.name}"
@@ -200,6 +211,26 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Location), uint(loc))
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = storage, value_type = vt, is_ssbo = false))
         ctx.interface_ids |> push(vid)
+        return
+    }
+    // combined image sampler: a global of an opaque sampler type (sampler2D) -> UniformConstant
+    // OpTypeSampledImage + DescriptorSet/Binding. Used only via texture(); not in the entry interface.
+    let si = sampler_info(v._type)
+    if (si.ok) {
+        let img = type_image(m, type_float(m, 32u), si.dim)
+        let simg = type_sampled_image(m, img)
+        let pt = type_pointer(m, SpvStorageClass.UniformConstant, simg)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.UniformConstant))
+        let set = v.annotation |> find_arg("set") ?as tInt ?? 0
+        let binding = v.annotation |> find_arg("binding") ?as tInt ?? 0
+        if (set < 0 || binding < 0) {
+            errors |> push("sampler '{vname}' set/binding must be non-negative (got set={set}, binding={binding})")
+            return
+        }
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.DescriptorSet), uint(set))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Binding), uint(binding))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.UniformConstant, value_type = simg, is_sampler = true))
         return
     }
     if (v.annotation |> find_arg("ssbo") is tBool) {
@@ -586,6 +617,36 @@ def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLst
 // ===== ExprCall: vector constructors, dot (core OpDot), GLSL.std.450 math (OpExtInst) =====
 def private emit_call(var m : SpirvModule; var ctx : EmitCtx; call : ExprCall?; e : ExpressionPtr; var errors : array<string>) : uint {
     let name = "{call.name}"
+    // ----- texture(sampler, uv): OpLoad the sampled image + OpImageSampleImplicitLod -----
+    if (name == "texture") {
+        if (length(call.arguments) != 2) {
+            errors |> push("texture expects (sampler, uv)")
+            return 0u
+        }
+        // implicit-LOD sampling uses screen-space derivatives -> fragment stage only (fail-closed)
+        if (ctx.stage != ShaderStage.Fragment) {
+            errors |> push("texture() implicit-LOD sampling is only valid in a fragment shader")
+            return 0u
+        }
+        let sg = global_var_of(call.arguments[0])
+        if (sg == null) {
+            errors |> push("texture: first argument must be a sampler global")
+            return 0u
+        }
+        let gi = ctx.globals?[intptr(sg)] ?? GlobalInfo()
+        if (!gi.is_sampler) {
+            errors |> push("texture: '{sg.name}' is not a sampler")
+            return 0u
+        }
+        let simg = alloc_id(m)
+        emit(m, SEC_FUNCS, SpvOp.Load, gi.value_type, simg, gi.var_id)
+        let uv = emit_value(m, ctx, call.arguments[1], errors)
+        if (uv == 0u) return 0u
+        let rt = emit_type(m, e._type)
+        let res = alloc_id(m)
+        emit(m, SEC_FUNCS, SpvOp.ImageSampleImplicitLod, rt, res, simg, uv)
+        return res
+    }
     // ----- vector constructor: OpCompositeConstruct (or splat / identity for one arg) -----
     let vc = vector_ctor(name)
     if (vc.ok) {
@@ -1364,6 +1425,7 @@ def private execution_model(stage : ShaderStage) : SpvExecutionModel {
 def generate_spirv(fn : FunctionPtr; var errors : array<string>; stage : ShaderStage; local_size : int3) : array<uint> {
     var m = make_module()
     var ctx : EmitCtx
+    ctx.stage = stage
 
     emit(m, SEC_CAPS, SpvOp.Capability, uint(SpvCapability.Shader))
     emit(m, SEC_MEMMODEL, SpvOp.MemoryModel, uint(SpvAddressingModel.Logical), uint(SpvMemoryModel.GLSL450))

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -112,12 +112,13 @@ def private round_up(off, a : int) : int {
     return ((off + a - 1) / a) * a
 }
 
-// Build a Block-decorated interface struct from a daslang struct's fields, laid out std140.
-// Scalar/vector members only for now (matrices/nested structs/arrays -> 4b+). Returns the struct
-// type-id; the caller wraps it in the right storage-class pointer + descriptor decorations.
+// Build a Block-decorated interface struct from a daslang struct's fields, laid out std140. Shared
+// by @uniform and @push_constant blocks. 32-bit scalar/vector/matrix members are supported; nested
+// structs and arrays are not yet. Returns the struct type-id; the caller wraps it in the right
+// storage-class pointer + descriptor decorations.
 def private build_block_struct(var m : SpirvModule; sname : string; st : Structure?; var errors : array<string>) : tuple<ok : bool; type_id : uint> {
     if (st == null || empty(st.fields)) {
-        errors |> push("uniform '{sname}' must be a struct with at least one field")
+        errors |> push("interface block '{sname}' must be a struct with at least one field")
         return (ok = false, type_id = 0u)
     }
     var members : array<uint>
@@ -139,7 +140,7 @@ def private build_block_struct(var m : SpirvModule; sname : string; st : Structu
         }
         let fbt = fld._type.baseType
         if (component_count(fbt) == 0) {
-            errors |> push("uniform '{sname}' field '{fld.name}': type {fbt} is not supported yet (only 32-bit scalar/vector/matrix members for now)")
+            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported yet (only 32-bit scalar/vector/matrix members for now)")
             delete members
             delete offsets
             delete mat_strides
@@ -307,7 +308,7 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.PushConstant, value_type = bs.type_id, is_ssbo = false, is_block = true))
         return
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, or @push_constant)")
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, or a sampler type e.g. sampler2D)")
 }
 
 // ===== member index of a struct field by name =====
@@ -374,12 +375,12 @@ def emit_ptr(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var erro
     if (fld != null) {
         let bv = global_var_of(fld.value)
         if (bv == null) {
-            errors |> push("member access '.{fld.name}' is only supported on a @uniform/@ssbo block global for now")
+            errors |> push("member access '.{fld.name}' is only supported on a @uniform/@ssbo/@push_constant block global for now")
             return (id = 0u, pointee = 0u)
         }
         let gi = ctx.globals?[intptr(bv)] ?? GlobalInfo()
         if (!gi.is_block) {
-            errors |> push("member access '.{fld.name}': '{bv.name}' is not a block (uniform/ssbo) global")
+            errors |> push("member access '.{fld.name}': '{bv.name}' is not a block (uniform/ssbo/push_constant) global")
             return (id = 0u, pointee = 0u)
         }
         let midx = field_index_by_name(bv._type.structType, "{fld.name}")

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -120,23 +120,39 @@ def private build_block_struct(var m : SpirvModule; sname : string; st : Structu
     }
     var members : array<uint>
     var offsets : array<int>
+    var mat_strides : array<int>
     var off = 0
     for (fld in st.fields) {
+        let mi = matrix_info(fld._type)
+        if (mi.ok) {
+            // std140 matrix: ColMajor, each column padded to vec4 (MatrixStride 16), align 16,
+            // size = 16 * cols. (daslang float3x3 stores packed columns, so its bytes need
+            // repacking host-side before upload; float4x4 columns are already vec4 -> direct.)
+            off = round_up(off, 16)
+            members |> push(emit_type(m, fld._type))
+            offsets |> push(off)
+            mat_strides |> push(16)
+            off += 16 * mi.cols
+            continue
+        }
         let fbt = fld._type.baseType
         if (component_count(fbt) == 0) {
-            errors |> push("uniform '{sname}' field '{fld.name}': type {fbt} is not supported yet (only 32-bit scalar/vector members for now)")
+            errors |> push("uniform '{sname}' field '{fld.name}': type {fbt} is not supported yet (only 32-bit scalar/vector/matrix members for now)")
             delete members
             delete offsets
+            delete mat_strides
             return (ok = false, type_id = 0u)
         }
         off = round_up(off, std140_align(fbt))
         members |> push(emit_type(m, fld._type))
         offsets |> push(off)
+        mat_strides |> push(0)
         off += std140_size(fbt)
     }
-    let id = type_struct_block(m, members, offsets)
+    let id = type_struct_block(m, members, offsets, mat_strides)
     delete members
     delete offsets
+    delete mat_strides
     return (ok = true, type_id = id)
 }
 
@@ -788,6 +804,40 @@ def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : arra
     return (ok = false, id = 0u)
 }
 
+// ===== `*` over matrices / vectors / scalars =====
+// SPIR-V splits multiplication by operand shape: OpMatrixTimesMatrix / OpMatrixTimesVector /
+// OpVectorTimesScalar. Plain component-wise FMul/IMul (the scalar binop path) only works when both
+// operands have the SAME shape, so the mixed cases are routed here first. Returns handled=false for
+// same-shape operands (let binop_code emit FMul/IMul); handled=true with id=0 on an unsupported mix
+// (error already pushed). Operands l/r are pre-emitted result-ids. Only the daslang-defined matrix
+// operators are handled (matrix*matrix, matrix*vector, and float vector*scalar either order);
+// daslang has no matrix*scalar or vector*matrix operator, so those SPIR-V ops are intentionally absent.
+def private emit_mul(var m : SpirvModule; op2 : ExprOp2?; e : ExpressionPtr; l, r : uint; var errors : array<string>) : tuple<handled : bool; id : uint> {
+    let lmat = matrix_info(op2.left._type)
+    let rmat = matrix_info(op2.right._type)
+    let lcc = component_count(op2.left._type.baseType)
+    let rcc = component_count(op2.right._type.baseType)
+    let lcls = scalar_class(op2.left._type.baseType)
+    let rcls = scalar_class(op2.right._type.baseType)
+    // same-shape (scalar*scalar or equal-width vector*vector): component-wise, defer to binop_code
+    if (!lmat.ok && !rmat.ok && lcc == rcc) return (handled = false, id = 0u)
+    let rt = emit_type(m, e._type)
+    let res = alloc_id(m)
+    if (lmat.ok && rmat.ok) {
+        emit(m, SEC_FUNCS, SpvOp.MatrixTimesMatrix, rt, res, l, r)
+    } elif (lmat.ok && rcc > 1) {
+        emit(m, SEC_FUNCS, SpvOp.MatrixTimesVector, rt, res, l, r)
+    } elif (lcc > 1 && rcc == 1 && lcls == 2 && rcls == 2) {
+        emit(m, SEC_FUNCS, SpvOp.VectorTimesScalar, rt, res, l, r)
+    } elif (rcc > 1 && lcc == 1 && lcls == 2 && rcls == 2) {
+        emit(m, SEC_FUNCS, SpvOp.VectorTimesScalar, rt, res, r, l)   // SPIR-V wants the vector first
+    } else {
+        errors |> push("unsupported '*' between {op2.left._type.baseType} and {op2.right._type.baseType} (integer vector/scalar mixes need a splat)")
+        return (handled = true, id = 0u)
+    }
+    return (handled = true, id = res)
+}
+
 // ===== rvalue: produce an SSA result-id =====
 def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var errors : array<string>) : uint {
     // ExprRef2Value wraps a ref lvalue to read its value; running in `patch` (pre-fold) the AST
@@ -809,6 +859,12 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
         let l = emit_value(m, ctx, op2.left, errors)
         let r = emit_value(m, ctx, op2.right, errors)
         if (l == 0u || r == 0u) return 0u   // operand error already reported; don't emit with id 0
+        // matrix / vector-scalar `*`: SPIR-V has dedicated linear-algebra ops (operand types differ,
+        // so the plain component-wise FMul path would be invalid). Handled before the scalar binop.
+        if (ops == "*") {
+            let mr = emit_mul(m, op2, e, l, r, errors)
+            if (mr.handled) return mr.id
+        }
         // comparison -> bool result (operands keep their scalar class)
         let cc = cmp_code(ops, cls)
         if (cc.ok) {
@@ -877,6 +933,27 @@ def emit_value(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var er
             errors |> push("local '{ev.name}' used before it was assigned an SSA id")
         }
         return lid
+    }
+    // swizzle of a local/computed VALUE (p.x / p.xy on a let or expression result). A swizzle of a
+    // global lvalue is a ref and goes through emit_ptr below; this handles the value case via
+    // OpCompositeExtract (single component) / OpVectorShuffle (multiple).
+    let sw = e ?as ExprSwizzle
+    if (sw != null && global_var_of(sw.value) == null) {
+        let base = emit_value(m, ctx, sw.value, errors)
+        if (base == 0u) return 0u
+        let rt = emit_type(m, e._type)
+        let res = alloc_id(m)
+        if (length(sw.fields) == 1) {
+            emit(m, SEC_FUNCS, SpvOp.CompositeExtract, rt, res, base, uint(sw.fields[0]))
+        } else {
+            var ops <- [rt, res, base, base]   // shuffle from a single source: vec1==vec2==base
+            for (f in sw.fields) {
+                ops |> push(uint(f))
+            }
+            emit_n(m, SEC_FUNCS, SpvOp.VectorShuffle, ops)
+            delete ops
+        }
+        return res
     }
     if (e._type.flags.ref) {
         let p = emit_ptr(m, ctx, e, errors)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -30,6 +30,7 @@ struct GlobalInfo {
     storage    : SpvStorageClass
     value_type : uint               // SPIR-V type-id of the whole variable's value
     is_ssbo    : bool               // wrapped in a Block-decorated struct (member 0 = the array)
+    is_block   : bool               // a Block-decorated struct (ssbo OR ubo); member access -> OpAccessChain by field index
 }
 
 // A memory-backed local: an OpVariable in Function storage. Mutable locals (`var x`) and loop
@@ -89,6 +90,54 @@ def private stage_name(stage : ShaderStage) : string {
     if (stage == ShaderStage.Vertex) return "vertex"
     if (stage == ShaderStage.Fragment) return "fragment"
     return "compute"
+}
+
+// ===== std140 layout for a UBO interface block =====
+// std140 base alignment: scalar -> 4, vec2 -> 8, vec3/vec4 -> 16. The base *size* of a vec3 is 12
+// (only its alignment is 16), so a scalar can pack into the trailing 4 bytes after a vec3.
+def private std140_align(bt : Type) : int {
+    let cc = component_count(bt)
+    if (cc == 1) return 4
+    if (cc == 2) return 8
+    return 16
+}
+
+def private std140_size(bt : Type) : int {
+    return component_count(bt) * 4
+}
+
+def private round_up(off, a : int) : int {
+    return ((off + a - 1) / a) * a
+}
+
+// Build a Block-decorated interface struct from a daslang struct's fields, laid out std140.
+// Scalar/vector members only for now (matrices/nested structs/arrays -> 4b+). Returns the struct
+// type-id; the caller wraps it in the right storage-class pointer + descriptor decorations.
+def private build_block_struct(var m : SpirvModule; sname : string; st : Structure?; var errors : array<string>) : tuple<ok : bool; type_id : uint> {
+    if (st == null || empty(st.fields)) {
+        errors |> push("uniform '{sname}' must be a struct with at least one field")
+        return (ok = false, type_id = 0u)
+    }
+    var members : array<uint>
+    var offsets : array<int>
+    var off = 0
+    for (fld in st.fields) {
+        let fbt = fld._type.baseType
+        if (component_count(fbt) == 0) {
+            errors |> push("uniform '{sname}' field '{fld.name}': type {fbt} is not supported yet (only 32-bit scalar/vector members for now)")
+            delete members
+            delete offsets
+            return (ok = false, type_id = 0u)
+        }
+        off = round_up(off, std140_align(fbt))
+        members |> push(emit_type(m, fld._type))
+        offsets |> push(off)
+        off += std140_size(fbt)
+    }
+    let id = type_struct_block(m, members, offsets)
+    delete members
+    delete offsets
+    return (ok = true, type_id = id)
 }
 
 // ===== global variable classification + emission =====
@@ -169,10 +218,46 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         }
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.DescriptorSet), uint(set))
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Binding), uint(binding))
-        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.StorageBuffer, value_type = st, is_ssbo = true))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.StorageBuffer, value_type = st, is_ssbo = true, is_block = true))
         return
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin or @ssbo)")
+    // uniform buffer: @uniform struct -> Uniform storage + Block-decorated struct (std140) +
+    // DescriptorSet/Binding. Member reads go through ExprField -> OpAccessChain by field index.
+    if (v.annotation |> find_arg("uniform") is tBool) {
+        if (v._type.baseType != Type.tStructure || v._type.structType == null) {
+            errors |> push("uniform '{vname}' must be a struct")
+            return
+        }
+        let bs = build_block_struct(m, vname, v._type.structType, errors)
+        if (!bs.ok) return
+        let pt = type_pointer(m, SpvStorageClass.Uniform, bs.type_id)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.Uniform))
+        let set = v.annotation |> find_arg("set") ?as tInt ?? 0
+        let binding = v.annotation |> find_arg("binding") ?as tInt ?? 0
+        if (set < 0 || binding < 0) {
+            errors |> push("uniform '{vname}' set/binding must be non-negative (got set={set}, binding={binding})")
+            return
+        }
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.DescriptorSet), uint(set))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Binding), uint(binding))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.Uniform, value_type = bs.type_id, is_ssbo = false, is_block = true))
+        return
+    }
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, or @uniform)")
+}
+
+// ===== member index of a struct field by name =====
+// ExprField.fieldIndex is still -1 at the annotation's patch (pre-fold) stage, so resolve the
+// member position by name from the (fully-known) struct type instead.
+def private field_index_by_name(st : Structure?; name : string) : int {
+    if (st == null) return -1
+    var i = 0
+    for (fld in st.fields) {
+        if ("{fld.name}" == name) return i
+        i++
+    }
+    return -1
 }
 
 // ===== emit a global ExprVar's Variable (or null) =====
@@ -219,6 +304,30 @@ def emit_ptr(var m : SpirvModule; var ctx : EmitCtx; e : ExpressionPtr; var erro
         var ops <- [ptr_t, res, gi.var_id, const_uint(m, 0u), idx]
         emit_n(m, SEC_FUNCS, SpvOp.AccessChain, ops)
         delete ops
+        return (id = res, pointee = pointee)
+    }
+    // member of a Block global (ubo.color) -> OpAccessChain by field index into the Uniform/SSBO struct
+    let fld = e ?as ExprField
+    if (fld != null) {
+        let bv = global_var_of(fld.value)
+        if (bv == null) {
+            errors |> push("member access '.{fld.name}' is only supported on a @uniform/@ssbo block global for now")
+            return (id = 0u, pointee = 0u)
+        }
+        let gi = ctx.globals?[intptr(bv)] ?? GlobalInfo()
+        if (!gi.is_block) {
+            errors |> push("member access '.{fld.name}': '{bv.name}' is not a block (uniform/ssbo) global")
+            return (id = 0u, pointee = 0u)
+        }
+        let midx = field_index_by_name(bv._type.structType, "{fld.name}")
+        if (midx < 0) {
+            errors |> push("member access '.{fld.name}': no such field on '{bv.name}'")
+            return (id = 0u, pointee = 0u)
+        }
+        let pointee = emit_type(m, e._type)
+        let ptr_t = type_pointer(m, gi.storage, pointee)
+        let res = alloc_id(m)
+        emit(m, SEC_FUNCS, SpvOp.AccessChain, ptr_t, res, gi.var_id, const_uint(m, uint(midx)))
         return (id = res, pointee = pointee)
     }
     let sw = e ?as ExprSwizzle

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -139,8 +139,11 @@ def private build_block_struct(var m : SpirvModule; sname : string; st : Structu
             continue
         }
         let fbt = fld._type.baseType
-        if (component_count(fbt) == 0) {
-            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported yet (only 32-bit scalar/vector/matrix members for now)")
+        // only 32-bit int/uint/float scalars + their vectors. scalar_class rejects bool (and any
+        // non-numeric): OpTypeBool has no physical size in a std140/std430 interface block, so a
+        // bool member would emit an invalid layout — reject it fail-closed rather than emit it.
+        if (scalar_class(fbt) < 0) {
+            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported (only 32-bit int/uint/float scalars, their vectors, and matrices; bool has no physical interface-block layout in Vulkan)")
             delete members
             delete offsets
             delete mat_strides

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -260,7 +260,23 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.Uniform, value_type = bs.type_id, is_ssbo = false, is_block = true))
         return
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, or @uniform)")
+    // push constants: @push_constant struct -> PushConstant storage + Block-decorated struct. Same
+    // std140-style member layout + ExprField access as a UBO, but NO descriptor set/binding (push
+    // constants are not descriptors) and not listed in the entry interface (SPIR-V <= 1.3).
+    if (v.annotation |> find_arg("push_constant") is tBool) {
+        if (v._type.baseType != Type.tStructure || v._type.structType == null) {
+            errors |> push("push_constant '{vname}' must be a struct")
+            return
+        }
+        let bs = build_block_struct(m, vname, v._type.structType, errors)
+        if (!bs.ok) return
+        let pt = type_pointer(m, SpvStorageClass.PushConstant, bs.type_id)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.PushConstant))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.PushConstant, value_type = bs.type_id, is_ssbo = false, is_block = true))
+        return
+    }
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, or @push_constant)")
 }
 
 // ===== member index of a struct field by name =====

--- a/modules/dasSpirv/spirv/spirv_types.das
+++ b/modules/dasSpirv/spirv/spirv_types.das
@@ -10,9 +10,25 @@ module spirv_types shared public
 require spirv_builder
 require daslib/ast
 
+// daslang matrices are handled (tHandle) types named float<W>x<C> — W = column-vector width,
+// C = column count (MatrixAnnotation<floatW, C>, column-major: m[i] is column i). Returns the
+// dimensions so emit_type / the std140 layout / matrix arithmetic can treat them structurally.
+def public matrix_info(t : TypeDecl?) : tuple<ok : bool; width : int; cols : int> {
+    if (t == null || t.baseType != Type.tHandle || t.annotation == null) return (ok = false, width = 0, cols = 0)
+    let nm = "{t.annotation.name}"
+    if (nm == "float4x4") return (ok = true, width = 4, cols = 4)
+    if (nm == "float3x3") return (ok = true, width = 3, cols = 3)
+    if (nm == "float3x4") return (ok = true, width = 3, cols = 4)
+    return (ok = false, width = 0, cols = 0)
+}
+
 def public emit_type(var m : SpirvModule; t : TypeDecl?) : uint {
     if (t == null) {
         panic("emit_type: null TypeDecl")
+    }
+    let mi = matrix_info(t)
+    if (mi.ok) {
+        return type_matrix(m, type_vector(m, type_float(m, 32u), mi.width), mi.cols)
     }
     let bt = t.baseType
     if (bt == Type.tVoid) return type_void(m)

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -392,6 +392,23 @@ def public pc_frag_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-4d combined image sampler fixture: a sampler2D global -> OpTypeImage +
+// OpTypeSampledImage in UniformConstant storage + DescriptorSet/Binding; texture(tex, uv) ->
+// OpLoad the sampled image + OpImageSampleImplicitLod (fragment-only, uses derivatives). =====
+var @binding = 0 tex : sampler2D
+var @in @location = 0 ti_uv : float2
+var @out @location = 0 tex_out : float4
+[fragment_shader(name="tex_frag_spv"), marker(no_coverage)]
+def tex_frag {
+    tex_out = texture(tex, ti_uv)       // OpLoad sampler + OpImageSampleImplicitLod
+}
+
+def public tex_frag_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(tex_frag_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -546,4 +563,16 @@ def public phase4b_emitter_opcodes : table<uint> {
 // that is an operand, not an opcode. The declared set is unchanged.
 def public phase4c_emitter_opcodes : table<uint> {
     return <- phase4b_emitter_opcodes()
+}
+
+// Phase-4d combined image samplers add the image type pair + the sample op. Phase-4c set + these:
+def public phase4d_emitter_opcodes : table<uint> {
+    var s <- phase4c_emitter_opcodes()
+    for (op in [
+        SpvOp.TypeImage, SpvOp.TypeSampledImage,    // sampler2D -> OpTypeImage + OpTypeSampledImage
+        SpvOp.ImageSampleImplicitLod                // texture(tex, uv)
+    ]) {
+        s |> insert(uint(op))
+    }
+    return <- s
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -343,6 +343,35 @@ def public ubo_frag_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-4b matrix fixture: a UBO with two float4x4 -> MVP transform. Matrices are tHandle
+// types lowered to OpTypeMatrix (4 float4 columns); daslang stores them column-major (m[i] is
+// column i) so they map to SPIR-V's default ColMajor (+ MatrixStride 16 in std140). Exercises
+// OpMatrixTimesMatrix, OpMatrixTimesVector, OpVectorTimesScalar, and local-value swizzles
+// (OpVectorShuffle for .xy, OpCompositeExtract for .w). =====
+struct Camera {
+    proj : float4x4     // std140 offset 0  (ColMajor, MatrixStride 16, size 64)
+    view : float4x4     // std140 offset 64
+}
+var @uniform @binding = 0 cam : Camera
+var @in @location = 0 in_pos : float3
+var @out @location = 0 mv_color : float4
+[vertex_shader(name="mvp_vert_spv"), marker(no_coverage)]
+def mvp_vert {
+    let mvp = cam.proj * cam.view           // OpMatrixTimesMatrix
+    let world = float4(in_pos, 1.0f)        // OpCompositeConstruct
+    let clip = mvp * world                  // OpMatrixTimesVector
+    gl_Position = clip * 0.5f               // OpVectorTimesScalar (float4 * float)
+    let xy = clip.xy                        // OpVectorShuffle (float2 from a local float4)
+    let w = clip.w                          // OpCompositeExtract (float from a local float4)
+    mv_color = float4(xy, w, 1.0f)          // OpCompositeConstruct from the swizzles
+}
+
+def public mvp_vert_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(mvp_vert_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -476,4 +505,18 @@ def public const_array_emitter_opcodes : table<uint> {
 // operands, not opcodes). The declared set is unchanged — the UBO fixture must still stay within it.
 def public phase4a_emitter_opcodes : table<uint> {
     return <- const_array_emitter_opcodes()
+}
+
+// Phase-4b adds matrices + matrix/vector arithmetic + local-value swizzles. Phase-4a set + these:
+def public phase4b_emitter_opcodes : table<uint> {
+    var s <- phase4a_emitter_opcodes()
+    for (op in [
+        SpvOp.TypeMatrix,                                   // float4x4 -> OpTypeMatrix
+        SpvOp.MatrixTimesMatrix, SpvOp.MatrixTimesVector,   // proj*view, mvp*world
+        SpvOp.VectorTimesScalar,                            // clip * 0.5
+        SpvOp.VectorShuffle, SpvOp.CompositeExtract         // clip.xy / clip.w (local swizzle)
+    ]) {
+        s |> insert(uint(op))
+    }
+    return <- s
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -305,6 +305,44 @@ def public catri_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-4a UBO fixture: a @uniform struct read through OpAccessChain by field index. The
+// struct's std140 layout exercises both packing edge cases — a scalar packing after a vec2
+// (uv@16,flags@24,scale@28) and after a vec3 (dir@32,bias@44). Every field is read; member loads
+// feed CompositeConstruct + scalar arithmetic + an int compare. No NEW opcodes vs const-arrays
+// (member access is AccessChain/Load over a Block struct) — it broadens the resource surface. =====
+struct Uniforms {
+    color : float4      // std140 offset 0
+    uv    : float2      // offset 16
+    flags : int         // offset 24 (vec2 size 8 -> 24; int aligns to 4)
+    scale : float       // offset 28
+    dir   : float3      // offset 32 (vec3 aligns to 16)
+    bias  : float       // offset 44 (packs into the vec3's trailing slot: vec3 size 12 -> 44)
+}
+var @uniform @binding = 0 ubo : Uniforms
+var @out @location = 0 u_out : float4
+[fragment_shader(name="ubo_frag_spv"), marker(no_coverage)]
+def ubo_frag {
+    var a = ubo.scale + ubo.bias            // FAdd: two scalar members (off 28 + 44)
+    if (ubo.flags > 0) {                    // int member load + SGreaterThan
+        a = a + 1.0f
+    }
+    let dir4 = float4(ubo.dir, a)           // CompositeConstruct: vec3 member + scalar
+    let uv4 = float4(ubo.uv, a, a)          // CompositeConstruct: vec2 member + 2 scalars
+    u_out = ubo.color                       // vec4 member load
+    if (a > 0.0f) {
+        u_out = dir4
+    }
+    if (a > 1.0f) {
+        u_out = uv4
+    }
+}
+
+def public ubo_frag_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(ubo_frag_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -431,4 +469,11 @@ def public const_array_emitter_opcodes : table<uint> {
         s |> insert(uint(op))
     }
     return <- s
+}
+
+// Phase-4a UBOs add NO new opcodes: @uniform member access is OpAccessChain/OpLoad over a Block-
+// decorated OpTypeStruct, all already in the set (Uniform storage + DescriptorSet/Binding are
+// operands, not opcodes). The declared set is unchanged — the UBO fixture must still stay within it.
+def public phase4a_emitter_opcodes : table<uint> {
+    return <- const_array_emitter_opcodes()
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -372,6 +372,26 @@ def public mvp_vert_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-4c push-constant fixture: a @push_constant struct -> PushConstant storage + Block,
+// laid out like a UBO (std140 offsets) but with NO DescriptorSet/Binding (push constants are not
+// descriptors) and not in the entry interface. Member access is the same OpAccessChain/OpLoad. =====
+struct PushData {
+    tint  : float4      // offset 0
+    gamma : float       // offset 16
+}
+var @push_constant pc : PushData
+var @out @location = 0 pc_out : float4
+[fragment_shader(name="pc_frag_spv"), marker(no_coverage)]
+def pc_frag {
+    pc_out = pc.tint * pc.gamma     // PushConstant member loads -> VectorTimesScalar
+}
+
+def public pc_frag_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(pc_frag_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -519,4 +539,11 @@ def public phase4b_emitter_opcodes : table<uint> {
         s |> insert(uint(op))
     }
     return <- s
+}
+
+// Phase-4c push constants add NO new opcodes: a @push_constant block is the same Block-decorated
+// OpTypeStruct read via OpAccessChain/OpLoad — only the storage class (PushConstant) differs, and
+// that is an operand, not an opcode. The declared set is unchanged.
+def public phase4c_emitter_opcodes : table<uint> {
+    return <- phase4b_emitter_opcodes()
 }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -42,7 +42,8 @@ def test_opcode_census(t : T?) {
         add_set(present, vindex_words())
         add_set(present, raster_math_words())
         add_set(present, catri_words())
-        var declared <- const_array_emitter_opcodes()
+        add_set(present, ubo_frag_words())
+        var declared <- phase4a_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -45,7 +45,8 @@ def test_opcode_census(t : T?) {
         add_set(present, ubo_frag_words())
         add_set(present, mvp_vert_words())
         add_set(present, pc_frag_words())
-        var declared <- phase4c_emitter_opcodes()
+        add_set(present, tex_frag_words())
+        var declared <- phase4d_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -44,7 +44,8 @@ def test_opcode_census(t : T?) {
         add_set(present, catri_words())
         add_set(present, ubo_frag_words())
         add_set(present, mvp_vert_words())
-        var declared <- phase4b_emitter_opcodes()
+        add_set(present, pc_frag_words())
+        var declared <- phase4c_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -43,7 +43,8 @@ def test_opcode_census(t : T?) {
         add_set(present, raster_math_words())
         add_set(present, catri_words())
         add_set(present, ubo_frag_words())
-        var declared <- phase4a_emitter_opcodes()
+        add_set(present, mvp_vert_words())
+        var declared <- phase4b_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_matrix.das
+++ b/tests/spirv/test_matrix.das
@@ -1,0 +1,60 @@
+options gen2
+options indenting = 4
+
+// Phase-4b matrix gate: matrices (OpTypeMatrix) carried in a UBO with std140 ColMajor + MatrixStride
+// decorations, the linear-algebra products (OpMatrixTimesMatrix / OpMatrixTimesVector /
+// OpVectorTimesScalar), and local-value swizzles (OpVectorShuffle / OpCompositeExtract). daslang
+// matrices are column-major (m[i] is column i), matching SPIR-V's default — verified clean by spirv-val.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private check_ops(t : T?; words : array<uint>; lbl : string; ops : array<SpvOp>) {
+    for (op in ops) {
+        t |> success(has_op(words, op), "{lbl}: emits {op}")
+    }
+}
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_mvp_vertex(t : T?) {
+    t |> run("vertex: UBO mat4x4 MVP -> MatrixTimesMatrix/Vector + VectorTimesScalar + local swizzle") <| @(t : T?) {
+        var words <- mvp_vert_words()
+        // a vertex entry point feeding gl_Position
+        let vmodel = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(vmodel.ok && vmodel.value == uint(SpvExecutionModel.Vertex),
+            "mvp_vert: EntryPoint model is Vertex")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.Position)),
+            "mvp_vert: gl_Position -> BuiltIn Position")
+        // the UBO carrying the two matrices: Uniform OpVariable + Block + descriptor + std140
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Uniform)),
+            "mvp_vert: Uniform-storage OpVariable (the camera UBO)")
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Block)),
+            "mvp_vert: camera struct is Block-decorated")
+        // matrix std140: proj@0, view@64 (each mat4 is 16*4 = 64 bytes)
+        t |> success(op_has_operand_pair(words, SpvOp.MemberDecorate, uint(SpvDecoration.Offset), 0u),
+            "mvp_vert: proj @ std140 offset 0")
+        t |> success(op_has_operand_pair(words, SpvOp.MemberDecorate, uint(SpvDecoration.Offset), 64u),
+            "mvp_vert: view @ std140 offset 64")
+        // matrix members carry ColMajor + MatrixStride 16 (daslang column-major storage)
+        t |> success(op_has_operand_at(words, SpvOp.MemberDecorate, 2, uint(SpvDecoration.ColMajor)),
+            "mvp_vert: matrix member is ColMajor")
+        t |> success(op_has_operand_pair(words, SpvOp.MemberDecorate, uint(SpvDecoration.MatrixStride), 16u),
+            "mvp_vert: matrix member has MatrixStride 16")
+        // the matrix type itself + the linear-algebra products + local swizzles
+        check_ops(t, words, "mvp_vert", [SpvOp.TypeMatrix, SpvOp.MatrixTimesMatrix, SpvOp.MatrixTimesVector,
+            SpvOp.VectorTimesScalar, SpvOp.VectorShuffle, SpvOp.CompositeExtract, SpvOp.CompositeConstruct])
+        validate(t, words, "mvp_vert")
+        delete words
+    }
+}

--- a/tests/spirv/test_push_constant.das
+++ b/tests/spirv/test_push_constant.das
@@ -1,0 +1,51 @@
+options gen2
+options indenting = 4
+
+// Phase-4c push-constant gate: a @push_constant struct lowers to a PushConstant-storage,
+// Block-decorated OpTypeStruct with std140 member offsets, read via OpAccessChain — and crucially
+// with NO DescriptorSet/Binding decorations (push constants are not descriptors). Every blob is
+// spirv-val'd.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_push_constant_fragment(t : T?) {
+    t |> run("push_constant: @push_constant struct -> PushConstant/Block, no descriptor, member reads") <| @(t : T?) {
+        var words <- pc_frag_words()
+        let fmodel = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(fmodel.ok && fmodel.value == uint(SpvExecutionModel.Fragment),
+            "pc_frag: EntryPoint model is Fragment")
+        // a PushConstant-storage OpVariable (storage class at operand index 2)
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.PushConstant)),
+            "pc_frag: has a PushConstant-storage OpVariable")
+        // Block-decorated, with std140 offsets (tint@0, gamma@16)
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Block)),
+            "pc_frag: struct is Block-decorated")
+        t |> success(op_has_operand_pair(words, SpvOp.MemberDecorate, uint(SpvDecoration.Offset), 0u),
+            "pc_frag: tint @ offset 0")
+        t |> success(op_has_operand_pair(words, SpvOp.MemberDecorate, uint(SpvDecoration.Offset), 16u),
+            "pc_frag: gamma @ offset 16")
+        // push constants are NOT descriptors: no DescriptorSet / Binding decoration anywhere
+        t |> success(!op_has_operand(words, SpvOp.Decorate, uint(SpvDecoration.DescriptorSet)),
+            "pc_frag: no DescriptorSet decoration")
+        t |> success(!op_has_operand(words, SpvOp.Decorate, uint(SpvDecoration.Binding)),
+            "pc_frag: no Binding decoration")
+        // member access + the scalar-broadcast multiply
+        t |> success(has_op(words, SpvOp.AccessChain), "pc_frag: member access via OpAccessChain")
+        t |> success(has_op(words, SpvOp.VectorTimesScalar), "pc_frag: tint * gamma -> VectorTimesScalar")
+        validate(t, words, "pc_frag")
+        delete words
+    }
+}

--- a/tests/spirv/test_sampler.das
+++ b/tests/spirv/test_sampler.das
@@ -1,0 +1,46 @@
+options gen2
+options indenting = 4
+
+// Phase-4d combined image sampler gate: a sampler2D global lowers to OpTypeImage + OpTypeSampledImage
+// in UniformConstant storage with DescriptorSet/Binding; texture(tex, uv) lowers to OpLoad (the
+// sampled image) + OpImageSampleImplicitLod. The blob is spirv-val'd.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_sampler_fragment(t : T?) {
+    t |> run("sampler: sampler2D -> OpTypeImage/SampledImage (UniformConstant) + texture() sample") <| @(t : T?) {
+        var words <- tex_frag_words()
+        let fmodel = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(fmodel.ok && fmodel.value == uint(SpvExecutionModel.Fragment),
+            "tex_frag: EntryPoint model is Fragment")
+        // the image type pair
+        t |> success(has_op(words, SpvOp.TypeImage), "tex_frag: emits OpTypeImage")
+        t |> success(has_op(words, SpvOp.TypeSampledImage), "tex_frag: emits OpTypeSampledImage")
+        // a UniformConstant-storage OpVariable (the sampler descriptor) at operand index 2
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.UniformConstant)),
+            "tex_frag: has a UniformConstant-storage OpVariable")
+        // descriptor decorations
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.DescriptorSet), 0u),
+            "tex_frag: DescriptorSet 0")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Binding), 0u),
+            "tex_frag: Binding 0")
+        // the sample: OpLoad the sampled image + OpImageSampleImplicitLod
+        t |> success(has_op(words, SpvOp.Load), "tex_frag: OpLoad the sampled image")
+        t |> success(has_op(words, SpvOp.ImageSampleImplicitLod), "tex_frag: texture() -> OpImageSampleImplicitLod")
+        validate(t, words, "tex_frag")
+        delete words
+    }
+}

--- a/tests/spirv/test_ubo.das
+++ b/tests/spirv/test_ubo.das
@@ -1,0 +1,63 @@
+options gen2
+options indenting = 4
+
+// Phase-4a UBO gate: a @uniform struct lowered to a Uniform-storage, Block-decorated OpTypeStruct
+// with std140 member offsets, read through OpAccessChain by field index. Asserts the descriptor
+// decorations (DescriptorSet/Binding), the Block decoration, and EVERY std140 member offset (the
+// two packing edge cases — scalar after vec2, scalar after vec3 — are the whole point). Every
+// emitted module passes spirv-val.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+// MemberDecorate operands are [struct_id, member, decoration, value]; Offset is at idx 2 with the
+// byte offset adjacent at idx 3, so op_has_operand_pair(Offset, off) is an exact layout assertion.
+def private has_member_offset(words : array<uint>; off : uint) : bool {
+    return op_has_operand_pair(words, SpvOp.MemberDecorate, uint(SpvDecoration.Offset), off)
+}
+
+[test]
+def test_ubo_fragment(t : T?) {
+    t |> run("uniform: @uniform struct -> Uniform/Block + std140 offsets + OpAccessChain member reads") <| @(t : T?) {
+        var words <- ubo_frag_words()
+        // a fragment entry point
+        let fmodel = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(fmodel.ok && fmodel.value == uint(SpvExecutionModel.Fragment),
+            "ubo_frag: EntryPoint model is Fragment")
+        // a Uniform-storage OpVariable (storage class at operand index 2)
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Uniform)),
+            "ubo_frag: has a Uniform-storage OpVariable")
+        // descriptor decorations (decoration adjacent to its value)
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.DescriptorSet), 0u),
+            "ubo_frag: DescriptorSet 0")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Binding), 0u),
+            "ubo_frag: Binding 0")
+        // Block decoration on the interface struct (decoration at operand index 1: [target, Block])
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Block)),
+            "ubo_frag: struct is Block-decorated")
+        // the FULL std140 layout: color@0, uv@16, flags@24, scale@28, dir@32, bias@44
+        t |> success(has_member_offset(words, 0u), "ubo_frag: color @ std140 offset 0")
+        t |> success(has_member_offset(words, 16u), "ubo_frag: uv @ std140 offset 16")
+        t |> success(has_member_offset(words, 24u), "ubo_frag: flags @ std140 offset 24 (packs after vec2)")
+        t |> success(has_member_offset(words, 28u), "ubo_frag: scale @ std140 offset 28")
+        t |> success(has_member_offset(words, 32u), "ubo_frag: dir @ std140 offset 32 (vec3 aligns to 16)")
+        t |> success(has_member_offset(words, 44u), "ubo_frag: bias @ std140 offset 44 (packs after vec3)")
+        // member reads: OpAccessChain into the block + OpLoad, feeding CompositeConstruct
+        t |> success(has_op(words, SpvOp.AccessChain), "ubo_frag: member access via OpAccessChain")
+        t |> success(has_op(words, SpvOp.Load), "ubo_frag: member load via OpLoad")
+        t |> success(has_op(words, SpvOp.CompositeConstruct), "ubo_frag: float4(member, ...) -> CompositeConstruct")
+        validate(t, words, "ubo_frag")
+        delete words
+    }
+}


### PR DESCRIPTION
Phase 4 of the pure-daslang daslang→SPIR-V shader backend (`modules/dasSpirv`): the full descriptor/resource surface. Builds on Phase 3 (vertex/fragment) + const arrays. Masterplan + per-slice implementation log live in-repo at `modules/dasSpirv/MASTERPLAN.md`.

Four independently-verified slices (one commit each):

### 4a — UBO struct foundation (`@uniform`)
A `@uniform` struct global → Uniform-storage, `Block`-decorated `OpTypeStruct` with **std140** member offsets, read via `ubo.field` → `OpAccessChain` by field index → `OpLoad`. std140 layout helper (align 4/8/16; vec3 base size 12 so a scalar packs into the trailing slot — both packing edge cases covered). `GlobalInfo` gains `is_block` (shared by ssbo + ubo); `ExprField` member access added to `emit_ptr`.
- *Load-bearing:* `ExprField.fieldIndex` is `-1` at the annotation patch (pre-fold) stage, so the member index is resolved **by name** from the struct type.

### 4b — matrices + matrix/vector arithmetic + local swizzle
Matrices (`tHandle` `MatrixAnnotation` types) → `OpTypeMatrix`. daslang stores them **column-major** (`m[i]` is column `i`), matching SPIR-V's default `ColMajor`, so `M*v` / `M*N` map directly with **no transpose**. std140 matrix members get `ColMajor` + `MatrixStride 16`. `emit_mul` routes `*` by operand shape (`OpMatrixTimesMatrix` / `OpMatrixTimesVector` / `OpVectorTimesScalar`) before the component-wise path — only the daslang-defined operators (no dead `matrix*scalar` / `vector*matrix`). Local-value swizzles (`clip.xy` → `OpVectorShuffle`, `clip.w` → `OpCompositeExtract`) close the Phase-3 gap.

### 4c — push constants (`@push_constant`)
`@push_constant` struct → `PushConstant` storage + `Block` struct, reusing the 4a layout + `ExprField` machinery, but with **no DescriptorSet/Binding** (push constants aren't descriptors) and excluded from the entry interface.

### 4d — combined image samplers
`sampler2D` (an opaque marker struct in `spirv_builtins`) → `OpTypeImage` + `OpTypeSampledImage` in `UniformConstant` storage + descriptors; `texture(tex, uv)` → `OpLoad` + `OpImageSampleImplicitLod` (fragment-only — implicit LOD needs derivatives, fail-closed via a `ctx.stage`).

**AOT codegen fix (`daslib/aot_cpp.das`), surfaced by 4d:** `UseTypeMarker` did not mark a struct used **only as a global variable's type** (never field-accessed), so the empty `sampler2D` global dropped to a forward declaration and failed `das_global_zero`'s `sizeof` (C2027). `UseTypeMarker` now marks global-var types via `preVisitGlobalLetVariable` — a strictly *emit-more* direction that can only add a struct definition, never remove one, so it cannot regress existing AOT. This is a general AOT correctness fix, not dasSpirv-specific.

### Verification
- **All three tiers green: interpreter / JIT / AOT 46/46.**
- Every emitted blob passes `spirv-val --target-env vulkan1.1`; external `spirv-dis` confirms textbook UBO/MVP/push-constant/textured output for each slice.
- Opcode **census gate** extended per slice (`phase4a..d_emitter_opcodes`), union over all fixtures == declared set, both directions.
- Lint + format clean on all changed `.das`.
- Fail-closed throughout: unsupported member/operand types, cross-stage `texture()`, negative set/binding → clean `error[...]`, never a bad blob.

### Notes for review
- The `aot_cpp.das` change touches the shared AOT emitter (used by the whole CI AOT matrix) — verified locally via a clean `test_aot` rebuild; the full matrix runs in CI. It only adds emission.
- Follow-on (separate dasVulkan PR, mirroring the Phase-1/3 GPU gates): a UBO/MVP and/or textured example regressed on lavapipe + a real GPU — the real-hardware proof of the column-major matrix mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)