### PR TITLE
doc: local block variables are allowed (fix self-contradiction in blocks.rst)

### DIFF
--- a/doc/source/reference/language/blocks.rst
+++ b/doc/source/reference/language/blocks.rst
@@ -23,9 +23,9 @@ The ``->`` operator can be used instead of ``:`` for the return type:
 If no type signature is specified, ``block`` alone represents a block that takes no
 arguments and returns nothing.
 
-Blocks capture the current stack, so blocks can be passed, but never returned.
-Block variables can only be passed as arguments.
-Global or local block variables are prohibited; returning the block type is also prohibited:
+Blocks capture the current stack, so blocks can be passed and stored in local
+variables, but never returned. Global block variables are prohibited, and returning
+the block type is also prohibited:
 
 .. code-block:: das
 


### PR DESCRIPTION
## Summary

[blocks.rst](doc/source/reference/language/blocks.rst) contradicted itself: the intro paragraph claimed *"Global or local block variables are prohibited"*, while a later section — **"Local block variables are allowed"** — shows a working example (`var blk = $(a, b : int) { return a + b }`). The reported page is https://daslang.io/doc/reference/language/blocks.html.

Local block variables are in fact allowed; only **global** block variables and **returning** a block type are prohibited.

## Verification

Probed against the current compiler:

| Construct | Behavior |
|---|---|
| Local block variable (`var blk = $(...) {...}`) | compiles OK |
| Global block variable | `error[30179]` can't have a global variable of type `block<...>` |
| Returning a block type | `error[30167]` / `error[30221]` this type can't be returned |

## Change

Reworded the intro paragraph to drop the false claim and stay consistent with the existing "Local block variables are allowed" example below:

> Blocks capture the current stack, so blocks can be passed and stored in local variables, but never returned. Global block variables are prohibited, and returning the block type is also prohibited:

Docs-only change. Sphinx `-W` builds (latex + html) pass clean with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)