### PR TITLE
das-fmt: load daslib/builtin in the converter's verify-compile (#3094)

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -133,6 +133,16 @@ FOREACH(_das ${DAS_UTILS_TO_TEST})
         DEPENDS das-fmt tree_sitter_daslang
     )
 ENDFOREACH()
+
+# das-fmt (utils/dasFormatter, the gen1->gen2 syntax converter) carries its own
+# --tests self-check suite. It's a C++ target (not a daslang -exe util), so invoke
+# the binary directly rather than through dastest. Previously uncovered by CI, which
+# let the make-literal verify-compile tests rot unnoticed. (issue #3094)
+LIST(APPEND _run_utils_tests
+    COMMAND ${CMAKE_COMMAND} -E echo "Running tests das-fmt dasFormatter --tests"
+    COMMAND $<TARGET_FILE:das-fmt> --tests
+    DEPENDS das-fmt
+)
 ADD_CUSTOM_TARGET(run_utils_tests
     ${_run_utils_tests}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/utils/dasFormatter/fmt.cpp
+++ b/utils/dasFormatter/fmt.cpp
@@ -147,28 +147,50 @@ Result transform_syntax(const string &filename, const string content, format::Fo
     string moduleName;
     das_hash_map<string, NamelessModuleReq> namelessReq;
     vector<NamelessMismatch> namelessMismatches;
-    if (getPrerequisits(filename, access, moduleName, req, missing, circular, notAllowed, chain,
-                        dependencies, namelessReq, namelessMismatches, libGroup, nullptr, 1, !policies.ignore_shared_modules)) {
-        for (auto &mod: req) {
-            if (libGroup.findModule(mod.moduleName)) {
-                continue;
-            }
-            auto program = parseDaScript(mod.fileName, mod.moduleName, access, tout, libGroup, true, true,
-                                         policies);
-            policies.threadlock_context |= program->options.getBoolOption("threadlock_context", false);
-            if (program->failed()) {
-                for (const auto& err: program->errors) {
-                    tp << err.what << " " << err.at.describe() << '\n';
-                }
-                // return {}; // still try to compile
-            }
-            if (program->thisModule->name.empty()) {
-                program->thisModule->name = mod.moduleName;
-                program->thisModule->wasParsedNameless = true;
-            }
-            program->thisModule->fileName = mod.fileName;
-            addNewModules(libGroup, program);
+
+    // daslib/builtin defines to_array_move / to_table_move and the comprehension push that the
+    // gen2 make-literal lowering ([1,2,3], {k=>v}, [for ...]) emits. compileDaScript pulls it in
+    // automatically (addExtraDependency); this hand-rolled parse must do the same, or the
+    // verify-compile of converted make-literals fails generic resolution. (issue #3094)
+    {
+        const string builtinPath = getDasRoot() + "/daslib/builtin.das";
+        string builtinModName;
+        if (getPrerequisits(builtinPath, access, builtinModName, req, missing, circular, notAllowed, chain,
+                            dependencies, namelessReq, namelessMismatches, libGroup, nullptr, 1, !policies.ignore_shared_modules)) {
+            ModuleInfo info;
+            auto finfo = access->getFileInfo(builtinPath);
+            info.fileName = finfo ? finfo->name : builtinPath;
+            info.importName = "";
+            info.moduleName = "builtin";
+            info.extraDepModule = true;
+            req.push_back(info);
         }
+    }
+
+    // The input filename may be synthetic (e.g. the --tests harness, where the content is
+    // supplied directly and no such file exists on disk), so don't gate module loading on
+    // getPrerequisits resolving it — builtin (added above) must load either way.
+    getPrerequisits(filename, access, moduleName, req, missing, circular, notAllowed, chain,
+                    dependencies, namelessReq, namelessMismatches, libGroup, nullptr, 1, !policies.ignore_shared_modules);
+    for (auto &mod: req) {
+        if (libGroup.findModule(mod.moduleName)) {
+            continue;
+        }
+        auto program = parseDaScript(mod.fileName, mod.moduleName, access, tout, libGroup, true, true,
+                                     policies);
+        policies.threadlock_context |= program->options.getBoolOption("threadlock_context", false);
+        if (program->failed()) {
+            for (const auto& err: program->errors) {
+                tp << err.what << " " << err.at.describe() << '\n';
+            }
+            // return {}; // still try to compile
+        }
+        if (program->thisModule->name.empty()) {
+            program->thisModule->name = mod.moduleName;
+            program->thisModule->wasParsedNameless = true;
+        }
+        program->thisModule->fileName = mod.fileName;
+        addNewModules(libGroup, program);
     }
 
     int iter = 0;


### PR DESCRIPTION
Fixes #3094 — the 8 failing `das-fmt --tests` self-checks (the `utils/dasFormatter` gen1→gen2 syntax converter).

## Root cause

`transform_syntax` ([fmt.cpp](https://github.com/GaijinEntertainment/daScript/blob/master/utils/dasFormatter/fmt.cpp)) verify-compiles the converted output through a **hand-rolled** `parseDaScript` whose module group was built only from the input file's `require`s. It never loaded **`daslib/builtin`** — unlike the real `compileDaScript`, which pulls it in automatically via `addExtraDependency` (`ast_parse.cpp`).

The 8 failing cases all convert a global `var var1 = …` to a gen2 make-literal (`[1,2,3]`, `{k=>v}`, `[for …]`). The parser lowers those to `to_array_move` / `to_table_move` / comprehension `push` — all defined in `daslib/builtin.das`. With builtin absent from the verify libGroup, generic resolution failed on otherwise-correct output:

```
no matching functions or generics: to_array_move(int[4])
no matching functions or generics: to_table_move(tuple<int;string>[4])
no matching functions or generics: push(array<int>& -const, int const)
...
```

The converted text itself is correct and compiles fine through `daslang.exe` directly — the failure was specific to the converter's verify environment.

A secondary trap: the module-load loop was gated on `getPrerequisits(filename)` succeeding, but the `--tests` harness passes a synthetic `test.das` that doesn't exist on disk → `getPrerequisits` returns false → the loop (and thus all module loading) was skipped entirely.

## Fix

- **`utils/dasFormatter/fmt.cpp`** — load `daslib/builtin.das` into the libGroup before parsing (mirroring `compileDaScript`'s `addExtraDependency`), and run the module-load loop unconditionally so it isn't skipped for the synthetic filename.
- **`utils/CMakeLists.txt`** — wire `das-fmt --tests` into `run_utils_tests` (runs in `extended_checks` on all 3 OSes). The issue flagged that `--tests` had **zero CI coverage**: the converter binary's name collides with the AOT-compiled `dasfmt.das` formatter (extended_checks overwrites `./bin/das-fmt` before the `--verify` step), so the converter suite never ran. A direct `$<TARGET_FILE:das-fmt>` invocation sidesteps the collision.

## Verification

- `das-fmt --tests`: **8 failures → exit 0** (all pass); no regression in the other ~30 brace/tuple tests.
- Real single-file and multi-file `-i` conversions (incl. a file with `require math`) convert correctly and verify-compile clean — no cross-call module collision from re-parsing builtin per file.
- CMake reconfigures cleanly; the generated `run_utils_tests` rule contains `das-fmt --tests` with the binary as a build dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)