### PR TITLE
aot: error when requiring a module-less .das file from an AOT'd file

### DIFF
--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -1101,10 +1101,10 @@ namespace das {
         return true;
     }
 
-    bool aotModuleHasName ( ProgramPtr program, const ModuleInfo & mod ) {
+    bool aotModuleHasModuleDecl ( ProgramPtr program, const ModuleInfo & mod ) {
         if ( bool no_aot = program->options.getBoolOption("no_aot",false); no_aot )
             return true;
-        if ( !program->thisModule->name.empty() )
+        if ( program->thisModule->isModule )
             return true;
         program->error("Module " + mod.moduleName + " is not setup correctly for AOT",
             "module " + mod.moduleName + " is required", "", LineInfo(),
@@ -1417,7 +1417,7 @@ namespace das {
                 if ( program->failed() ) {
                     return program;
                 }
-                if ( policies.fail_on_lack_of_aot_export && !aotModuleHasName(program, mod) ) {
+                if ( policies.fail_on_lack_of_aot_export && !aotModuleHasModuleDecl(program, mod) ) {
                     return program;
                 }
                 if ( program->thisModule->name.empty() ) {

--- a/tests/daslib/aot_module_check_test.das
+++ b/tests/daslib/aot_module_check_test.das
@@ -1,0 +1,54 @@
+options gen2
+options no_aot
+
+require dastest/testing_boost public
+require daslib/ast_boost
+require daslib/rtti
+require daslib/fio
+require strings
+
+def write_fixtures(dir : string) {
+    fwrite(path_join(dir, "helper.das"),
+        "options gen2\ndef helper_add(a, b : int) : int \{\n    return a + b\n\}\n")
+    fwrite(path_join(dir, "main.das"),
+        "options gen2\nrequire helper\n[export]\ndef do_add(a, b : int) : int \{\n    return helper_add(a, b)\n\}\n")
+}
+
+def compile_main_for_aot(dir : string; fail_on_lack_of_aot_export : bool; var ok : bool&; var issues : string&) {
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.aot = false
+            cop.aot_module = true
+            cop.fail_on_lack_of_aot_export = fail_on_lack_of_aot_export
+            cop.ignore_shared_modules = false
+            compile_file(path_join(dir, "main.das"), access, unsafe(addr(mg)), cop) $(cok; _program; cissues) {
+                ok = cok
+                issues := cissues
+            }
+        }
+    }
+}
+
+[test]
+def test_require_module_less_file_fails_aot(t : T?) {
+    t |> run("AOT compile errors when a required file is not a module") <| @(t2 : T?) {
+        var error : string
+        let dir = create_temp_directory("das_aot_modcheck", error)
+        write_fixtures(dir)
+
+        var ok = true
+        var issues = ""
+        compile_main_for_aot(dir, true, ok, issues)
+        t2 |> success(!ok, "compile fails for a module-less required file")
+        t2 |> success(find(issues, "not setup correctly for AOT") >= 0,
+            "diagnostic mentions AOT setup: {issues}")
+
+        var ok2 = false
+        var issues2 = ""
+        compile_main_for_aot(dir, false, ok2, issues2)
+        t2 |> success(ok2, "same file compiles when fail_on_lack_of_aot_export is off: {issues2}")
+
+        rmdir_rec_result(dir)
+    }
+}


### PR DESCRIPTION
## Problem

When AOT-compiling a `.das` file that `require`s another `.das` file which is **not declared as a module** (`module foo`), the dependency's functions were silently left out of AOT codegen — no error, no warning. At runtime those calls fell back to the interpreter forever.

### Reproduction

`helper.das` — no `module` declaration:

```das
options gen2
require strings

def helper_add(a : int; b : int) : int {
    var sum = a + b
    print("helper computes {sum}\n")
    return sum
}
```

`main.das` — requires it:

```das
options gen2
require helper
require strings

[export]
def main() {
    var x = length("hello")
    print("{helper_add(x, 3)}\n")
}
```

```
daslang utils/aot/main.das -- -aot main.das main.das.cpp
```

**Before:** exits 0, generates `main.das.cpp` with no stub for `helper_add`; the call site degrades to `fnByMangledName` interpreter dispatch.

**After:** fails loudly:

```
error[20201]: Module helper is not setup correctly for AOT
module helper is required
```

Adding `module helper` to `helper.das` (so it gets its own `-aotlib` pass) — or `options no_aot` — compiles cleanly as before.

## Root cause

The guard already existed: `aotModuleHasName` (gated behind `cop.fail_on_lack_of_aot_export`, which the AOT tool sets). It tested `!thisModule->name.empty()`.

Commit `f200a9c65` ("instantly set module name (before macroses)") began pre-filling `thisModule->name` from the require name **before** parsing, so the name is never empty for a dependency. The check became dead code and never fired.

## Fix

Test `thisModule->isModule` — set **only** by an explicit `module` directive in the parser (`ds2_parser.cpp`) — instead of the name. Renamed `aotModuleHasName` → `aotModuleHasModuleDecl` to match the new semantics.

## Verification

Rebuilt `daslang`, all four cases behave correctly:

| Case | Result |
|---|---|
| Required helper, no `module` decl | `error[20201]` — exit 255 |
| Required helper, `module helper` | AOT succeeds |
| Required helper, `options no_aot` | escape hatch honored |
| Nameless helper, normal (non-AOT) run | unaffected (guard gated behind `fail_on_lack_of_aot_export`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
