### PR TITLE
dasSpirv Phase 10.2: composite/global swizzle

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -1214,3 +1214,24 @@ two already partly done:
 
 **This closes the emitter language surface.** Phases 9 (docs/tutorial), 10 (examples/vulkan), 11
 (vulkan_lint) are docs/demos/lint on top of a feature-complete emitter — not plumbing.
+
+### Phase 10.2 — composite/global swizzle LANDED (2026-06-15, branch `bbatkin/dasspirv-phase10-2-swizzle`)
+
+Foundation rail closing the Phase-8 out-of-scope swizzle note. **Multi-component swizzle of a bare
+global** (`gl_FragCoord.xy`, `a_pos.xyz`, `fin.yx`) now lowers; previously only single-component global
+swizzle + swizzle-of-a-loaded-value existed (the latter already covered `ubo.color.xy` /
+`texture(...).rgb`, since those bases aren't bare globals). No new census opcodes.
+
+**The actual gap (grounded finding):** `visitExprSwizzle` rejected `length(fields) != 1` *only* on the
+bare-global branch. A single-component global swizzle takes the pointer path (`OpAccessChain` to the
+component — keeps it an lvalue, `g.x = …`); a multi-component swizzle can't form one pointer, so it must
+go through the value path (load the whole global `OpVariable` → `OpVectorShuffle`). `visitExprVar` already
+seeds `e2ptr`/`e2pty` for a global, so `value_of(expr.value)` loads the full composite — the fix is a
+one-line guard change (`gv != null && length(fields) == 1` for the pointer path; everything else falls
+through to the existing extract/shuffle value path). `gl_FragCoord.xy` (a common fragment screen-space
+idiom) was the headline previously-broken case.
+
+Fixture `gswizzle` (builtin-global multi-swizzle + @in-global contiguous/reordered swizzle + single-
+component global + local-value swizzle regression) in `test_swizzle.das`; census wired
+(`phase10_2_emitter_opcodes` = Phase-8 set, unchanged). interp + JIT 90/90, spirv-val clean, lint + format
+clean.

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -1031,16 +1031,15 @@ class SpirvEmit : AstVisitor {
         return expr
     }
 
-    // ----- swizzle: global single-component -> pointer (AccessChain); value -> extract/shuffle -----
+    // ----- swizzle: single-component global -> pointer (AccessChain, an lvalue); everything else
+    // (multi-component, or a swizzle of any loaded value: local, UBO/SSBO member, sampler result) ->
+    // value path: load the whole source composite, then CompositeExtract (1) / VectorShuffle (many) -----
     def override visitExprSwizzle(var expr : ExprSwizzle?) : ExpressionPtr {
         var bm & = unsafe(*m)
         let k = intptr(expr)
         let gv = global_var_of(expr.value)
-        if (gv != null) {
-            if (length(expr.fields) != 1) {
-                errs |> push("only single-component swizzle of a global is supported for now")
-                return expr
-            }
+        // single-component global -> AccessChain to that one component (keeps it an lvalue: g.x = …)
+        if (gv != null && length(expr.fields) == 1) {
             let gi = ctx.globals?[intptr(gv)] ?? GlobalInfo()
             if (gi.var_id == 0u) {   // global not classified -> never AccessChain through a 0 base
                 errs |> push("swizzle target global '{gv.name}' is not classified")
@@ -1052,23 +1051,25 @@ class SpirvEmit : AstVisitor {
             emit(bm, SEC_FUNCS, SpvOp.AccessChain, ptr_t, res, gi.var_id, const_uint(bm, uint(expr.fields[0])))
             e2ptr[k] = res
             e2pty[k] = pointee
-        } else {
-            let base = value_of(expr.value)
-            if (base == 0u) return expr   // operand failed to lower (error already pushed) — no 0-operand extract/shuffle
-            let rt = emit_type(bm, expr._type)
-            let res = alloc_id(bm)
-            if (length(expr.fields) == 1) {
-                emit(bm, SEC_FUNCS, SpvOp.CompositeExtract, rt, res, base, uint(expr.fields[0]))
-            } else {
-                var ops <- [rt, res, base, base]
-                for (f in expr.fields) {
-                    ops |> push(uint(f))
-                }
-                emit_n(bm, SEC_FUNCS, SpvOp.VectorShuffle, ops)
-                delete ops
-            }
-            e2id[k] = res
+            return expr
         }
+        // value path. value_of loads the whole composite (a bare global loads its OpVariable -> the
+        // full vector; gl_FragCoord.xy, a_pos.xyz, … all reach here now), then extract / shuffle.
+        let base = value_of(expr.value)
+        if (base == 0u) return expr   // operand failed to lower (error already pushed) — no 0-operand extract/shuffle
+        let rt = emit_type(bm, expr._type)
+        let res = alloc_id(bm)
+        if (length(expr.fields) == 1) {
+            emit(bm, SEC_FUNCS, SpvOp.CompositeExtract, rt, res, base, uint(expr.fields[0]))
+        } else {
+            var ops <- [rt, res, base, base]
+            for (f in expr.fields) {
+                ops |> push(uint(f))
+            }
+            emit_n(bm, SEC_FUNCS, SpvOp.VectorShuffle, ops)
+            delete ops
+        }
+        e2id[k] = res
         return expr
     }
 

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -936,6 +936,13 @@ class SpirvEmit : AstVisitor {
     def ptr_of(e : ExpressionPtr) : tuple<id : uint; pty : uint> {
         let k = intptr(e)
         if (key_exists(e2ptr, k)) return (id = e2ptr?[k] ?? 0u, pty = e2pty?[k] ?? 0u)
+        // a swizzle that produced a value (not a pointer) used as a write target: a multi-component
+        // swizzle (`v.xy = …`) or a single-component swizzle of a value. Fail-closed with a clear
+        // message rather than the generic "internal: not an lvalue".
+        if (e is ExprSwizzle) {
+            errs |> push("cannot assign through a swizzle — write-swizzle (e.g. `v.xy = …`) is not supported; assign the whole vector instead")
+            return (id = 0u, pty = 0u)
+        }
         errs |> push("internal: {e.__rtti} is not an lvalue")
         return (id = 0u, pty = 0u)
     }

--- a/tests/spirv/_fail_closed/_fc_wswz.das
+++ b/tests/spirv/_fail_closed/_fc_wswz.das
@@ -1,0 +1,18 @@
+// Fail-closed fixture (Phase 10.2): a multi-component swizzle used as an assignment target
+// (`v.xy = …`) is not supported. The typer accepts it, so the emitter must reject it with a CLEAN
+// message at ptr_of rather than the generic "internal: not an lvalue". `_`-prefix + `expect 50501`
+// keep dastest/lint off.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @out @location = 0 fc_wswz_out : float4
+
+[fragment_shader(name="fc_wswz_spv")]
+def fc_wswz {
+    fc_wswz_out.xy = float2(1.0, 0.0)   // write-swizzle -> clean fail-closed rejection
+    fc_wswz_out = float4(0.0, 0.0, 0.0, 1.0)
+}

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -657,8 +657,8 @@ def public vecarith_words : array<uint> {
 
 // ===== Phase-8.3 GLSL.std.450 math breadth: exercise every reachable ext-inst the emitter maps beyond
 // Phase 3's dot/sqrt/clamp. Keyed on the DASLANG name (lerp -> FMix, rsqrt -> InverseSqrt). Vectors are
-// built from scalar swizzles (multi-component swizzle of a global is a separate, unrelated gap). Each
-// ext-inst is spirv-val'd + asserted by sub-opcode. =====
+// built from scalar swizzles (multi-component swizzle of a global is its own gap, closed in Phase 10.2).
+// Each ext-inst is spirv-val'd + asserted by sub-opcode. =====
 var @in @location = 0 mx_in : float4
 var @out @location = 0 mx_out : float4
 [fragment_shader(name="mathx_spv"), marker(no_coverage)]
@@ -686,6 +686,29 @@ def mathx {
 def public mathx_words : array<uint> {
     var w : array<uint>
     w |> push_from(mathx_spv)
+    return <- w
+}
+
+// ===== Phase-10.2 composite/global swizzle: multi-component swizzle of a bare global (the Phase-8
+// out-of-scope note). A single-component global swizzle stays an lvalue (AccessChain); a multi-component
+// one loads the whole global and OpVectorShuffle's it. Covers a builtin global (gl_FragCoord.xy), an @in
+// global (contiguous .xyz + reordered .yx), single-component global (.w, still the pointer path), and a
+// swizzle of a local value (regression). No new opcodes vs Phase 4b (VectorShuffle/CompositeExtract). =====
+var @in @location = 0 sw_in : float4
+var @out @location = 0 sw_out : float4
+[fragment_shader(name="gswizzle_spv"), marker(no_coverage)]
+def gswizzle {
+    let fc = gl_FragCoord.xy         // multi-component swizzle of a builtin global -> OpVectorShuffle
+    let rgb = sw_in.xyz              // multi-component swizzle of an @in global -> OpVectorShuffle
+    let yx = sw_in.yx                // reordered multi-component swizzle -> OpVectorShuffle
+    let a = sw_in.w                  // single-component global -> AccessChain (pointer), loaded here
+    let lx = rgb.xy                  // swizzle of a LOCAL value (regression) -> OpVectorShuffle
+    sw_out = float4(rgb, fc.x + yx.x + a + lx.y)
+}
+
+def public gswizzle_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(gswizzle_spv)
     return <- w
 }
 
@@ -909,4 +932,11 @@ def public phase8_emitter_opcodes : table<uint> {
     var s <- phase7d_emitter_opcodes()
     s |> insert(uint(SpvOp.Select))     // cond ? a : b
     return <- s
+}
+
+// Phase-10.2 multi-component global swizzle adds NO new opcodes: it routes a bare global through the
+// existing load + OpVectorShuffle / OpCompositeExtract path (both declared by Phase 4b). The set is
+// unchanged; the gswizzle fixture must still stay within it.
+def public phase10_2_emitter_opcodes : table<uint> {
+    return <- phase8_emitter_opcodes()
 }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -58,7 +58,8 @@ def test_opcode_census(t : T?) {
         add_set(present, tern_words())
         add_set(present, vecarith_words())
         add_set(present, mathx_words())
-        var declared <- phase8_emitter_opcodes()
+        add_set(present, gswizzle_words())
+        var declared <- phase10_2_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_fail_closed.das
+++ b/tests/spirv/test_fail_closed.das
@@ -49,5 +49,6 @@ def test_fail_closed_rejections(t : T?) {
         check_rejects(t, "_fc_localtype", "type tDouble is not supported")
         check_rejects(t, "_fc_stmt", "memzero is not supported in SPIR-V shaders")
         check_rejects(t, "_fc_deadcode", "unreachable code after a block terminator")
+        check_rejects(t, "_fc_wswz", "cannot assign through a swizzle")
     }
 }

--- a/tests/spirv/test_swizzle.das
+++ b/tests/spirv/test_swizzle.das
@@ -1,0 +1,41 @@
+options gen2
+options indenting = 4
+
+// Phase-10.2 gate: multi-component swizzle of a bare global (the Phase-8 out-of-scope note). A
+// single-component global swizzle stays an lvalue (OpAccessChain to the component); a multi-component
+// one loads the whole global and OpVectorShuffle's the lanes. Asserts both opcodes are present (shuffle
+// for .xy/.xyz/.yx, access-chain for the single-component .w) and that the module is spirv-val-clean --
+// the real check that the loaded-then-shuffled lanes form a valid vector result.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_global_swizzle(t : T?) {
+    t |> run("swizzle: multi-component global -> load + OpVectorShuffle; single-component -> OpAccessChain") <| @(t : T?) {
+        var words <- gswizzle_words()
+        // a fragment entry point
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.Fragment),
+            "gswizzle: EntryPoint model is Fragment")
+        // multi-component global swizzles (gl_FragCoord.xy, sw_in.xyz, sw_in.yx) -> OpVectorShuffle
+        t |> success(has_op(words, SpvOp.VectorShuffle), "gswizzle: multi-component swizzle -> OpVectorShuffle")
+        // the single-component global swizzle (sw_in.w) -> OpAccessChain to the component
+        t |> success(has_op(words, SpvOp.AccessChain), "gswizzle: single-component global swizzle -> OpAccessChain")
+        // and the loaded lanes feed a float4 constructor
+        t |> success(has_op(words, SpvOp.CompositeConstruct), "gswizzle: result via OpCompositeConstruct")
+        validate(t, words, "gswizzle")
+        delete words
+    }
+}


### PR DESCRIPTION
Foundation rail closing the **Phase-8 out-of-scope swizzle note**. **Multi-component swizzle of a bare global** — `gl_FragCoord.xy`, `a_pos.xyz`, `fin.yx` — now lowers. Previously only single-component global swizzle + swizzle-of-a-loaded-value existed (the latter already covered `ubo.color.xy` / `texture(...).rgb`, whose bases aren't bare globals). No new census opcodes.

### The gap (grounded finding)
`visitExprSwizzle` rejected `length(fields) != 1` **only on the bare-global branch**. A single-component global swizzle takes the pointer path (`OpAccessChain` to the component — keeps it an lvalue, `g.x = …`); a multi-component swizzle can't form one pointer, so it must go through the value path (load the whole global `OpVariable` → `OpVectorShuffle`). `visitExprVar` already seeds `e2ptr`/`e2pty` for a global, so `value_of(expr.value)` loads the full composite — the fix is a one-line guard change (`gv != null && length(fields) == 1` for the pointer path; everything else falls through to the existing extract/shuffle value path). **`gl_FragCoord.xy`** (a common fragment screen-space idiom) was the headline previously-broken case.

### Tests
`tests/spirv/test_swizzle.das`: `gswizzle` fixture exercising a builtin-global multi-swizzle (`gl_FragCoord.xy`), an `@in`-global contiguous + reordered swizzle (`.xyz` / `.yx`), a single-component global (`.w`, still the pointer path), and a swizzle of a local value (regression). Census wired (`phase10_2_emitter_opcodes` = Phase-8 set, unchanged). **interp + JIT 90/90**, spirv-val clean, lint + format clean.

> Independent of #3159 (Phase 10.1 SSBO std430). Both touch `_spirv_common.das` / `test_census.das` / `MASTERPLAN.md` at the append points — a trivial both-additions merge whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)