### PR TITLE
dasSpirv Phase 10.3: fragment realism rails (discard/derivatives/textureSize/gl_FragDepth)

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -1283,3 +1283,34 @@ Fixture `gswizzle` (builtin-global multi-swizzle + @in-global contiguous/reorder
 component global + local-value swizzle regression) in `test_swizzle.das`; census wired
 (`phase10_2_emitter_opcodes` = Phase-8 set, unchanged). interp + JIT 90/90, spirv-val clean, lint + format
 clean.
+
+### Phase 10.3 — fragment realism LANDED (2026-06-15, branch `bbatkin/dasspirv-phase10-3-fragment`)
+
+Fragment-stage foundation rails — the realism toolkit a real fragment shader needs (alpha-test discard,
+edge-aware antialiasing via derivatives, mip selection / texel math via size queries, depth replacement).
+Five new census opcodes (`Kill`/`DPdx`/`DPdy`/`Fwidth`/`ImageQuerySizeLod`); each its own intrinsic in
+`spirv_builtins.das`, lowered in the emitter's call dispatch. interp + JIT 96/96, spirv-val clean,
+lint + format clean.
+
+- **`discard()` → `OpKill`.** A block terminator: sets `ctx.terminated`, so a statement following it on
+  the same path is rejected as unreachable (the existing dead-code guard) — matches glslang lowering
+  `discard` to `OpKill`. Fragment-only.
+- **`dFdx`/`dFdy`/`fwidth` → `OpDPdx`/`OpDPdy`/`OpFwidth`** (screen-space derivatives over the 2×2 quad).
+  Fragment-only; the basic forms need only the `Shader` capability (not the `DerivativeControl` the
+  `*Fine`/`*Coarse` variants would). Declared as **concrete per-width overloads** (float/float2/3/4),
+  NOT a generic — see finding 1.
+- **`textureSize(sampler, lod)` → `OpImage` (extract image) + `OpImageQuerySizeLod`**, lazily pulling in
+  the `ImageQuery` capability (deduped via a `ctx` flag, emitted into `SEC_CAPS`). int2 for 2D/Cube, int3
+  for 3D / 2D-array. Stage-agnostic.
+- **`gl_FragDepth` write → BuiltIn `FragDepth` Output + the `DepthReplacing` execution mode.** The exec
+  mode is emitted only when the builtin is referenced — `classify_global` sets `ctx.uses_frag_depth` and
+  `generate_spirv` reads it after dependency collection (which runs before the exec-mode section).
+
+**Findings (load-bearing):**
+1. **Generic builtins get mangled instance call-names** (`spirv_builtins`dFdx`5408…`), so the emitter's
+   `name == "dFdx"` dispatch can never match a `def dFdx(p : auto(TT))`. Every existing builtin is a
+   concrete overload for exactly this reason; the derivatives had to follow suit (4 widths × 3 functions).
+   The emitter dispatches by the DASLANG call name, which is clean only for non-generic functions.
+2. **`OpKill` is a terminator, so `discard()` composes with the existing terminated-block machinery for
+   free** — placed in an `if`-branch it skips the trailing `OpBranch merge`; followed by another statement
+   it trips the unreachable-code reject. No new control-flow plumbing.

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -22,6 +22,7 @@ var gl_InstanceIndex        : int       // BuiltIn InstanceIndex (Input)
 
 // fragment
 var gl_FragCoord            : float4    // BuiltIn FragCoord (Input)
+var gl_FragDepth            : float     // BuiltIn FragDepth (Output) — writing it forces DepthReplacing
 
 // ===== combined image samplers =====
 // sampler2D is an opaque marker type: a global of this type lowers to an OpTypeSampledImage in
@@ -100,3 +101,36 @@ def public imageStore(img : image2D; coord : int2; value : float4) : void {}
 def public imageLoad(img : image2D; coord : int2) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
+
+// ===== fragment realism =====
+// discard() abandons the current fragment (OpKill). It is a block terminator, so it must be the last
+// statement on its control-flow path (typically `if (cond) { discard() }`); fragment-only.
+def public discard() : void {}
+
+// Screen-space partial derivatives over the 2x2 fragment quad: dFdx/dFdy (OpDPdx/OpDPdy), and
+// fwidth = |dFdx| + |dFdy| (OpFwidth). Fragment-only. Concrete per-width overloads (NOT a generic):
+// the emitter dispatches by the call name, and a generic instance carries a mangled name the
+// name-match would miss. The stub bodies are never executed — only the call AST is lowered.
+[unused_argument(p)] def public dFdx(p : float) : float { return p }
+[unused_argument(p)] def public dFdx(p : float2) : float2 { return p }
+[unused_argument(p)] def public dFdx(p : float3) : float3 { return p }
+[unused_argument(p)] def public dFdx(p : float4) : float4 { return p }
+[unused_argument(p)] def public dFdy(p : float) : float { return p }
+[unused_argument(p)] def public dFdy(p : float2) : float2 { return p }
+[unused_argument(p)] def public dFdy(p : float3) : float3 { return p }
+[unused_argument(p)] def public dFdy(p : float4) : float4 { return p }
+[unused_argument(p)] def public fwidth(p : float) : float { return p }
+[unused_argument(p)] def public fwidth(p : float2) : float2 { return p }
+[unused_argument(p)] def public fwidth(p : float3) : float3 { return p }
+[unused_argument(p)] def public fwidth(p : float4) : float4 { return p }
+
+// textureSize(sampler, lod): the mip-level dimensions in texels (OpImageQuerySizeLod; needs the
+// ImageQuery capability). int2 for 2D/Cube, int3 for 3D / 2D-array (width,height,depth-or-layers).
+[unused_argument(s, lod)]
+def public textureSize(s : sampler2D; lod : int) : int2 { return int2(0, 0) }
+[unused_argument(s, lod)]
+def public textureSize(s : samplerCube; lod : int) : int2 { return int2(0, 0) }
+[unused_argument(s, lod)]
+def public textureSize(s : sampler3D; lod : int) : int3 { return int3(0, 0, 0) }
+[unused_argument(s, lod)]
+def public textureSize(s : sampler2DArray; lod : int) : int3 { return int3(0, 0, 0) }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -56,7 +56,7 @@ struct EmitCtx {
     terminated    : bool                        // current block already has a terminator
     glsl_ext      : uint                        // OpExtInstImport "GLSL.std.450" set id (0 = not imported yet)
     stage         : ShaderStage                 // the shader stage (texture() implicit-LOD sampling is fragment-only)
-    uses_frag_depth : bool                      // gl_FragDepth is written -> emit the DepthReplacing execution mode
+    uses_frag_depth : bool                      // gl_FragDepth referenced (Output-only, so = written) -> emit DepthReplacing
     image_query_cap : bool                      // OpCapability ImageQuery already emitted (textureSize)
 }
 
@@ -269,7 +269,8 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.BuiltIn), uint(bi.bi))
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = bi.storage, value_type = vt, is_ssbo = false))
         ctx.interface_ids |> push(vid)   // Input + Output builtins both list in the entry interface
-        // Writing gl_FragDepth replaces the fixed-function depth -> the shader must declare DepthReplacing.
+        // gl_FragDepth is Output-only, so any reference to it is a write -> the shader replaces the
+        // fixed-function depth and must declare DepthReplacing. Flagged here at classification.
         if (bi.bi == SpvBuiltIn.FragDepth) {
             ctx.uses_frag_depth = true
         }
@@ -2233,7 +2234,8 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; stage : ShaderS
         delete em
     } elif (stage == ShaderStage.Fragment) {
         emit(m, SEC_EXECMODE, SpvOp.ExecutionMode, id_main, uint(SpvExecutionMode.OriginUpperLeft))
-        // Writing gl_FragDepth (detected by classify_global above) replaces the fixed-function depth.
+        // gl_FragDepth referenced (detected by classify_global above; Output-only, so a reference is a
+        // write) -> the shader replaces the fixed-function depth.
         if (ctx.uses_frag_depth) {
             emit(m, SEC_EXECMODE, SpvOp.ExecutionMode, id_main, uint(SpvExecutionMode.DepthReplacing))
         }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -56,6 +56,8 @@ struct EmitCtx {
     terminated    : bool                        // current block already has a terminator
     glsl_ext      : uint                        // OpExtInstImport "GLSL.std.450" set id (0 = not imported yet)
     stage         : ShaderStage                 // the shader stage (texture() implicit-LOD sampling is fragment-only)
+    uses_frag_depth : bool                      // gl_FragDepth is written -> emit the DepthReplacing execution mode
+    image_query_cap : bool                      // OpCapability ImageQuery already emitted (textureSize)
 }
 
 // break -> branch to `merge`, continue -> branch to `cont`. Pushed per active loop.
@@ -106,6 +108,7 @@ def private builtin_info(name : string) : tuple<ok : bool; bi : SpvBuiltIn; stor
     if (name == "gl_InstanceIndex") return (ok = true, bi = SpvBuiltIn.InstanceIndex, storage = SpvStorageClass.Input, req = ShaderStage.Vertex)
     // fragment
     if (name == "gl_FragCoord") return (ok = true, bi = SpvBuiltIn.FragCoord, storage = SpvStorageClass.Input, req = ShaderStage.Fragment)
+    if (name == "gl_FragDepth") return (ok = true, bi = SpvBuiltIn.FragDepth, storage = SpvStorageClass.Output, req = ShaderStage.Fragment)
     return (ok = false, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
 }
 
@@ -266,6 +269,10 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.BuiltIn), uint(bi.bi))
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = bi.storage, value_type = vt, is_ssbo = false))
         ctx.interface_ids |> push(vid)   // Input + Output builtins both list in the entry interface
+        // Writing gl_FragDepth replaces the fixed-function depth -> the shader must declare DepthReplacing.
+        if (bi.bi == SpvBuiltIn.FragDepth) {
+            ctx.uses_frag_depth = true
+        }
         return
     }
     // stage I/O: @in / @out user variables carry an explicit @location. They become Input/Output
@@ -601,6 +608,14 @@ def private ensure_glsl_ext(var m : SpirvModule; var ctx : EmitCtx) : uint {
     delete ops
     ctx.glsl_ext = id
     return id
+}
+
+// OpImageQuerySizeLod (textureSize) requires the ImageQuery capability. Emit it once into SEC_CAPS
+// (which concatenates ahead of the body), deduped via the ctx flag.
+def private ensure_image_query(var m : SpirvModule; var ctx : EmitCtx) {
+    if (ctx.image_query_cap) return
+    emit(m, SEC_CAPS, SpvOp.Capability, uint(SpvCapability.ImageQuery))
+    ctx.image_query_cap = true
 }
 
 // daslang math builtin -> GLSL.std.450 ext-inst opcode. abs/min/max/clamp/sign pick the F/S/U
@@ -1410,6 +1425,74 @@ class SpirvEmit : AstVisitor {
         var bm & = unsafe(*m)
         let name = "{expr.name}"
         let k = intptr(expr)
+        // discard(): abandon the fragment -> OpKill. A block terminator (sets ctx.terminated), so any
+        // following statement on the same path is rejected as unreachable. Fragment-only.
+        if (name == "discard") {
+            if (ctx.stage != ShaderStage.Fragment) {
+                errs |> push("discard() is only valid in a fragment shader")
+                return expr
+            }
+            if (!empty(expr.arguments)) {
+                errs |> push("discard() takes no arguments")
+                return expr
+            }
+            emit(bm, SEC_FUNCS, SpvOp.Kill)
+            ctx.terminated = true
+            return expr
+        }
+        // dFdx/dFdy/fwidth: screen-space derivatives over the 2x2 quad (OpDPdx/OpDPdy/OpFwidth).
+        // Fragment-only; one float/floatN operand, same-typed result. No extra capability (the basic
+        // forms need only Shader; the *Fine/*Coarse variants would need DerivativeControl).
+        if (name == "dFdx" || name == "dFdy" || name == "fwidth") {
+            if (length(expr.arguments) != 1) {
+                errs |> push("{name} expects 1 argument")
+                return expr
+            }
+            if (ctx.stage != ShaderStage.Fragment) {
+                errs |> push("{name}: screen-space derivatives are only valid in a fragment shader")
+                return expr
+            }
+            let a = value_of(expr.arguments[0])
+            if (a == 0u) return expr
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            let op = (name == "dFdx" ? SpvOp.DPdx : (name == "dFdy" ? SpvOp.DPdy : SpvOp.Fwidth))
+            emit(bm, SEC_FUNCS, op, rt, res, a)
+            e2id[k] = res
+            return expr
+        }
+        // textureSize(sampler, lod): mip-level dimensions in texels (OpImageQuerySizeLod). Extract the
+        // image from the sampled image (OpImage), then query; needs the ImageQuery capability.
+        if (name == "textureSize") {
+            if (length(expr.arguments) != 2) {
+                errs |> push("textureSize expects (sampler, lod)")
+                return expr
+            }
+            let sg = global_var_of(expr.arguments[0])
+            if (sg == null) {
+                errs |> push("textureSize: first argument must be a sampler global")
+                return expr
+            }
+            let gi = ctx.globals?[intptr(sg)] ?? GlobalInfo()
+            if (!gi.is_sampler) {
+                errs |> push("textureSize: '{sg.name}' is not a sampler")
+                return expr
+            }
+            ensure_image_query(bm, *ctx)
+            let simg = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, simg, gi.var_id)
+            let si = sampler_info(sg._type)
+            let img_type = type_image(bm, type_float(bm, 32u), si.dim, si.arrayed)
+            let img = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.Image, img_type, img, simg)
+            let lod = value_of(expr.arguments[1])
+            if (lod == 0u) return expr
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.ImageQuerySizeLod, rt, res, img, lod)
+            e2id[k] = res
+            return expr
+        }
         // texture(sampler, uv): OpLoad the sampled image + OpImageSampleImplicitLod
         if (name == "texture") {
             if (length(expr.arguments) != 2) {
@@ -2150,6 +2233,10 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; stage : ShaderS
         delete em
     } elif (stage == ShaderStage.Fragment) {
         emit(m, SEC_EXECMODE, SpvOp.ExecutionMode, id_main, uint(SpvExecutionMode.OriginUpperLeft))
+        // Writing gl_FragDepth (detected by classify_global above) replaces the fixed-function depth.
+        if (ctx.uses_frag_depth) {
+            emit(m, SEC_EXECMODE, SpvOp.ExecutionMode, id_main, uint(SpvExecutionMode.DepthReplacing))
+        }
     }
 
     emit(m, SEC_FUNCS, SpvOp.Function, t_void, id_main, 0u, t_fn)

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -758,8 +758,10 @@ def public gswizzle_words : array<uint> {
 
 // ===== Phase-10.3 fragment realism: discard (OpKill), screen-space derivatives (OpDPdx/OpDPdy/
 // OpFwidth), textureSize (OpImageQuerySizeLod + the ImageQuery capability), and a gl_FragDepth write
-// (BuiltIn FragDepth Output -> the DepthReplacing execution mode). All fragment-only. discard() sits
-// in an if-branch (it is a block terminator); dFdx/dFdy take the whole float2 global, fwidth a scalar. =====
+// (BuiltIn FragDepth Output -> the DepthReplacing execution mode). discard/derivatives/gl_FragDepth are
+// fragment-only; textureSize is stage-agnostic (exercised here in a fragment shader for convenience).
+// discard() sits in an if-branch (it is a block terminator); dFdx/dFdy take the whole float2 global,
+// fwidth a scalar. =====
 var @binding = 0 fx_tex : sampler2D
 var @in @location = 0 fx_uv : float2
 var @out @location = 0 fx_color : float4

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -756,6 +756,32 @@ def public gswizzle_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-10.3 fragment realism: discard (OpKill), screen-space derivatives (OpDPdx/OpDPdy/
+// OpFwidth), textureSize (OpImageQuerySizeLod + the ImageQuery capability), and a gl_FragDepth write
+// (BuiltIn FragDepth Output -> the DepthReplacing execution mode). All fragment-only. discard() sits
+// in an if-branch (it is a block terminator); dFdx/dFdy take the whole float2 global, fwidth a scalar. =====
+var @binding = 0 fx_tex : sampler2D
+var @in @location = 0 fx_uv : float2
+var @out @location = 0 fx_color : float4
+[fragment_shader(name="fragx_spv"), marker(no_coverage)]
+def fragx {
+    if (fx_uv.x < 0.0f) {
+        discard()                       // OpKill (fragment-only terminator)
+    }
+    let dx = dFdx(fx_uv)                 // OpDPdx (float2)
+    let dy = dFdy(fx_uv)                 // OpDPdy (float2)
+    let w = fwidth(fx_uv.x)              // OpFwidth (scalar)
+    let sz = textureSize(fx_tex, 0)      // OpImageQuerySizeLod -> int2 (ImageQuery capability)
+    gl_FragDepth = fx_uv.x               // BuiltIn FragDepth write -> DepthReplacing execution mode
+    fx_color = float4(dx.x + dy.y + w, float(sz.x), float(sz.y), 1.0f)
+}
+
+def public fragx_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(fragx_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -991,4 +1017,20 @@ def public phase10_1_emitter_opcodes : table<uint> {
 // unchanged; the gswizzle fixture must still stay within it.
 def public phase10_2_emitter_opcodes : table<uint> {
     return <- phase10_1_emitter_opcodes()
+}
+
+// Phase-10.3 fragment realism adds five opcodes: OpKill (discard), OpDPdx/OpDPdy/OpFwidth (derivatives),
+// and OpImageQuerySizeLod (textureSize). gl_FragDepth reuses the existing builtin Variable/Decorate path
+// (DepthReplacing is an ExecutionMode operand, not an opcode), and OpImage was declared by Phase-7.2
+// texelFetch. Phase-10.2 set + these:
+def public phase10_3_emitter_opcodes : table<uint> {
+    var s <- phase10_2_emitter_opcodes()
+    for (op in [
+        SpvOp.Kill,                         // discard()
+        SpvOp.DPdx, SpvOp.DPdy, SpvOp.Fwidth,   // dFdx/dFdy/fwidth
+        SpvOp.ImageQuerySizeLod             // textureSize(s, lod)
+    ]) {
+        s |> insert(uint(op))
+    }
+    return <- s
 }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -61,7 +61,8 @@ def test_opcode_census(t : T?) {
         add_set(present, ssbovec_words())
         add_set(present, ssbostruct_words())
         add_set(present, gswizzle_words())
-        var declared <- phase10_2_emitter_opcodes()
+        add_set(present, fragx_words())
+        var declared <- phase10_3_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_fragment.das
+++ b/tests/spirv/test_fragment.das
@@ -1,0 +1,51 @@
+options gen2
+options indenting = 4
+
+// Phase-10.3 gate: fragment realism. discard() -> OpKill (a block terminator); screen-space
+// derivatives dFdx/dFdy/fwidth -> OpDPdx/OpDPdy/OpFwidth; textureSize -> OpImageQuerySizeLod (which
+// pulls in the ImageQuery capability); and a gl_FragDepth write -> BuiltIn FragDepth Output + the
+// DepthReplacing execution mode. Each opcode/decoration is asserted positionally, and the module is
+// spirv-val-clean -- the real check that OpKill terminates its block and the query/derivative results
+// are well-typed.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_fragment_realism(t : T?) {
+    t |> run("fragment realism: discard/derivatives/textureSize/gl_FragDepth") <| @(t : T?) {
+        var words <- fragx_words()
+        // a fragment entry point
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.Fragment),
+            "fragx: EntryPoint model is Fragment")
+        // discard() -> OpKill (the fragment-abandon terminator)
+        t |> success(has_op(words, SpvOp.Kill), "fragx: discard() -> OpKill")
+        // screen-space derivatives over the 2x2 quad
+        t |> success(has_op(words, SpvOp.DPdx), "fragx: dFdx -> OpDPdx")
+        t |> success(has_op(words, SpvOp.DPdy), "fragx: dFdy -> OpDPdy")
+        t |> success(has_op(words, SpvOp.Fwidth), "fragx: fwidth -> OpFwidth")
+        // textureSize -> OpImageQuerySizeLod + the ImageQuery capability it requires
+        t |> success(has_op(words, SpvOp.ImageQuerySizeLod), "fragx: textureSize -> OpImageQuerySizeLod")
+        t |> success(op_has_operand_at(words, SpvOp.Capability, 0, uint(SpvCapability.ImageQuery)),
+            "fragx: textureSize pulls in OpCapability ImageQuery")
+        // gl_FragDepth write -> BuiltIn FragDepth decoration + the DepthReplacing execution mode
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.FragDepth)),
+            "fragx: gl_FragDepth -> BuiltIn FragDepth")
+        t |> success(op_has_operand_at(words, SpvOp.ExecutionMode, 1, uint(SpvExecutionMode.DepthReplacing)),
+            "fragx: gl_FragDepth write -> DepthReplacing execution mode")
+        validate(t, words, "fragx")
+        delete words
+    }
+}


### PR DESCRIPTION
Phase 10.3 of the dasSpirv roadmap — the fragment-stage foundation rails a real fragment shader needs (alpha-test discard, edge-aware AA via derivatives, mip/texel math via size queries, depth replacement). Stacks on 10.1 (#3159) + 10.2 (#3160), both merged. Five new census opcodes; each rail is its own intrinsic in `spirv_builtins.das`, lowered in the emitter's call dispatch.

## Rails

- **`discard()` → `OpKill`** — a block terminator: sets `ctx.terminated`, so a statement following it on the same path is rejected as unreachable (the existing dead-code guard). Matches glslang lowering `discard` → `OpKill`. Fragment-only.
- **`dFdx`/`dFdy`/`fwidth` → `OpDPdx`/`OpDPdy`/`OpFwidth`** — screen-space derivatives over the 2×2 quad. Fragment-only; the basic forms need only the `Shader` capability. Concrete per-width overloads (float/float2/3/4), not a generic — see finding 1.
- **`textureSize(sampler, lod)` → `OpImage` + `OpImageQuerySizeLod`** — pulls in the `ImageQuery` capability lazily (deduped via a `ctx` flag). int2 for 2D/Cube, int3 for 3D / 2D-array. Stage-agnostic.
- **`gl_FragDepth` write → BuiltIn `FragDepth` Output + `DepthReplacing` execution mode** — the exec mode is emitted only when the builtin is referenced (`classify_global` sets `ctx.uses_frag_depth`, read after dependency collection).

## Findings

1. **Generic builtins get mangled instance call-names** (`spirv_builtins`dFdx`5408…`), so the emitter's `name == "dFdx"` dispatch can't match a `def dFdx(p : auto(TT))`. Every existing builtin is a concrete overload for exactly this reason; the derivatives follow suit (4 widths × 3 functions).
2. **`OpKill` is a terminator, so `discard()` reuses the existing terminated-block machinery for free** — no new control-flow plumbing.

## Testing

`fragx` fixture + `test_fragment` gate (each opcode/decoration asserted positionally + spirv-val). Census extended to `phase10_3_emitter_opcodes` (= 10.2 set + the 5 new opcodes), unioned over the new fixture. **interp + JIT 96/96**, spirv-val clean on every blob, lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)