### PR TITLE
Fix gcc -Werror breaks that leak to downstream package builds

### DIFF
--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -283,7 +283,7 @@ MACRO(DAS_APPLY_STRICT_WARNINGS _target)
                 $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual;-Wno-unqualified-std-cast-call>)
         ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
             target_compile_options(${_target} PRIVATE
-                $<$<COMPILE_LANGUAGE:CXX>:-Wno-overloaded-virtual;-Wno-array-bounds;-Wno-clobbered;-Wno-maybe-uninitialized>)
+                $<$<COMPILE_LANGUAGE:CXX>:-Wno-overloaded-virtual;-Wno-array-bounds;-Wno-clobbered;-Wno-maybe-uninitialized;-Wno-stringop-overflow>)
         ENDIF()
     ENDIF()
 ENDMACRO()

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -700,6 +700,7 @@ static HANDLE g_singleInstanceMutex = nullptr;
 #else
 #include <sys/file.h>
 #include <unistd.h>
+#include <cerrno>
 static int g_lockFd = -1;
 #endif
 
@@ -859,16 +860,21 @@ int main(int argc, char * argv[]) {
     if (changeCwd && !scriptFile.empty()) {
         auto slash = scriptFile.find_last_of("\\/");
         if (slash != string::npos) {
-            string dir = scriptFile.substr(0, slash);
+            // Keep the separator for root-level paths so the directory stays valid:
+            // POSIX "/foo.das" -> "/", Windows drive root "C:\foo.das" -> "C:\".
+            size_t cut = (slash == 0 || (slash == 2 && scriptFile[1] == ':')) ? slash + 1 : slash;
+            string dir = scriptFile.substr(0, cut);
             scriptFile = scriptFile.substr(slash + 1);
 #ifdef _WIN32
             if (!SetCurrentDirectoryA(dir.c_str())) {
-                fprintf(stderr, "ERROR: -cwd failed to change directory to %s\n", dir.c_str());
+                fprintf(stderr, "ERROR: -cwd failed to change directory to %s (error %lu)\n",
+                        dir.c_str(), (unsigned long)GetLastError());
                 return 1;
             }
 #else
             if (chdir(dir.c_str()) != 0) {
-                fprintf(stderr, "ERROR: -cwd failed to change directory to %s\n", dir.c_str());
+                fprintf(stderr, "ERROR: -cwd failed to change directory to %s: %s\n",
+                        dir.c_str(), strerror(errno));
                 return 1;
             }
 #endif

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -862,9 +862,15 @@ int main(int argc, char * argv[]) {
             string dir = scriptFile.substr(0, slash);
             scriptFile = scriptFile.substr(slash + 1);
 #ifdef _WIN32
-            SetCurrentDirectoryA(dir.c_str());
+            if (!SetCurrentDirectoryA(dir.c_str())) {
+                fprintf(stderr, "ERROR: -cwd failed to change directory to %s\n", dir.c_str());
+                return 1;
+            }
 #else
-            chdir(dir.c_str());
+            if (chdir(dir.c_str()) != 0) {
+                fprintf(stderr, "ERROR: -cwd failed to change directory to %s\n", dir.c_str());
+                return 1;
+            }
 #endif
         }
     }


### PR DESCRIPTION
## What

daslang's own CI is **clang-only on every Linux lane** (`CC=clang CXX=clang++`; no gcc anywhere). gcc is exercised only by downstream package CIs (e.g. dasImgui's `integration (ubuntu-latest)` job uses the default `g++`). So gcc-specific `-Werror` warnings — surfaced now that #3155 enabled `-Werror` across core + module targets — are invisible to daslang's own CI and leak straight to packages.

A full `g++ 13.3 -Werror` build of the whole tree (core + all in-tree modules) found exactly **two** such breaks. Both fixed here:

### 1. `daslang-live` — bare `chdir` / `SetCurrentDirectoryA`

The `-cwd` block ignored the return value. On glibc/gcc `chdir()` carries `warn_unused_result`, so:

```
utils/daslang-live/main.cpp:867:18: error: ignoring return value of 'int chdir(const char*)'
  declared with attribute 'warn_unused_result' [-Werror=unused-result]
```

clang doesn't apply `__wur` to `chdir`, which is why core CI (clang) stayed green while downstream gcc builds broke — [dasImgui #202](https://github.com/borisbat/dasImgui/pull/202)'s ubuntu job died here before reaching its own modules. Now both branches check the result and exit non-zero on failure (a failed `-cwd` would otherwise silently leave relative `require`s resolving against the wrong directory). Per review: root-level paths keep their separator (`"/foo.das" → "/"`, `"C:\foo.das" → "C:\"`), and the failure message prints the OS error reason (`GetLastError` / `strerror(errno)`).

### 2. `src/ast/ast_infer_type.cpp` — `-Wstringop-overflow` false positive

gcc-13 `-Wstringop-overflow` fires on a `std::vector<Function*>` copy under `-O3` (`InferTypes::visit(ExprNamedCall*)`). This is the same gcc-O3 false-positive family already suppressed right beside it (`-Wno-array-bounds` / `-Wno-clobbered` / `-Wno-maybe-uninitialized`); added `-Wno-stringop-overflow` to the GNU branch of `DAS_APPLY_STRICT_WARNINGS`.

## Verification

Full tree builds clean under `g++ 13.3 -Werror -k 0` after both fixes — these were the only two gcc-only breaks in the entire tree.

## Follow-up

External package bindings (dasImgui/NodeEditor/Implot/Profile/Vulkan) build via raw `add_library`, **not** daslang's strict module macros, so #3155's flags never reach them — no per-package source changes needed; they recover on next CI once this lands. A separate PR will add a permanent gcc Linux CI lane so this class of break is caught upstream rather than downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)