### PR TITLE
dasSpirv Phase 10.4: depth-compare (shadow) sampling (Dref)

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -1314,3 +1314,39 @@ lint + format clean.
 2. **`OpKill` is a terminator, so `discard()` composes with the existing terminated-block machinery for
    free** — placed in an `if`-branch it skips the trailing `OpBranch merge`; followed by another statement
    it trips the unreachable-code reject. No new control-flow plumbing.
+
+### Phase 10.4 — depth-compare (shadow) sampling LANDED (2026-06-15, branch `bbatkin/dasspirv-phase10-4-dref`)
+
+The hardware-PCF shadow rail — `sampler2DShadow` sampled via `textureCompare` lowers to
+`OpImageSampleDrefImplicitLod`, the depth-compare sample. One new census opcode
+(`ImageSampleDrefImplicitLod`); the Depth=1 image flag and the `comparison_sampler` reflection kind are
+operand/reflection-only, not opcodes. This is the quality upgrade over the manual-compare shadow that
+already works (sample a depth texture as a plain `sampler2D`, compare with a ternary). interp + JIT
+100/100, spirv-val clean, external `spirv-dis` confirms textbook structure, lint + format clean.
+
+- **`sampler2DShadow` marker + `textureCompare(s, uv, compare) : float`.** A new opaque sampler type;
+  `sampler_info` maps it to a 2D image with the **Depth=1** flag (the operand that distinguishes a
+  comparison sampler from an ordinary one). `textureCompare` is its only sample path (the daslang type
+  system blocks passing it to `texture()`/`textureLod`/… since those overloads don't accept it).
+- **`OpImageSampleDrefImplicitLod`.** Loads the combined comparison sampler, then samples with the
+  reference value as the **Dref** operand; the scalar `float` result is the comparison (1 = lit, 0 =
+  shadowed; a filtered sampler returns the PCF average). Implicit LOD → fragment-only (same stage gate as
+  `texture()`). Emitted via `emit_n` (5 operands: resultType, result, sampledImage, coord, dref).
+- **`type_image` gained a `depth` parameter** (default 0), threaded into both the OpTypeImage Depth
+  operand (index 3) **and the dedup key** — without the key change a `sampler2DShadow` and a `sampler2D`
+  (same dim/arrayed/sampled/format) would collide on one type id.
+- **`comparison_sampler` reflection kind.** `classify_global` picks it (vs `combined_image_sampler`) when
+  the sampler's depth flag is set, so the host binds a `VkSampler` with `compareEnable`. Wire-format magic
+  bumped RFL2 → RFL3 (a descriptor-kind change), with the `kind_from_int` mapping extended.
+
+**Findings (load-bearing):**
+1. **The Depth flag lives on the OpTypeImage, not the sample op.** `OpImageSampleDrefImplicitLod` is the
+   same regardless of image type; what makes a sampler a *comparison* sampler is the `Depth=1` operand on
+   its `OpTypeImage`. So the dedup key MUST include depth (else the shadow sampler aliases a plain one and
+   spirv-val rejects the Dref sample against a non-depth image). External `spirv-dis` verified:
+   `OpTypeImage %float 2D 1 0 0 1 Unknown` + `OpImageSampleDrefImplicitLod %float %img %uv %ref`.
+2. **A dedicated `textureCompare` intrinsic beats overloading `texture()`.** GLSL packs the compare ref
+   into a third coordinate component (`texture(sampler2DShadow, vec3)`); a separate intrinsic with an
+   explicit `compare : float` is clearer, keeps the result type scalar (vs `texture()`'s float4), and
+   fail-closes by construction — the type system prevents the wrong sampler/op pairing without an emitter
+   check.

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -198,13 +198,14 @@ def public type_matrix(var m : SpirvModule; col_type : uint; cols : int) : uint 
 // e.g. Rgba8, so no StorageImageRead/WriteWithoutFormat capability is needed). depth=0, ms=0; the
 // arrayed flag distinguishes a 2D/2DArray (etc.) image. Deduped on the full operand tuple.
 def public type_image(var m : SpirvModule; sampled_type : uint; dim : SpvDim;
-                      arrayed : uint = 0u; sampled : uint = 1u; format : SpvImageFormat = SpvImageFormat.Unknown) : uint {
-    let key = "img{sampled_type}_d{uint(dim)}_a{arrayed}_s{sampled}_f{uint(format)}"
+                      arrayed : uint = 0u; sampled : uint = 1u; format : SpvImageFormat = SpvImageFormat.Unknown;
+                      depth : uint = 0u) : uint {
+    let key = "img{sampled_type}_d{uint(dim)}_a{arrayed}_s{sampled}_f{uint(format)}_z{depth}"
     let ex = m.type_pool?[key] ?? 0u
     return ex if (ex != 0u)
     let id = alloc_id(m)
     // operands: Sampled Type, Dim, Depth, Arrayed, MS, Sampled, Image Format
-    var ops <- [id, sampled_type, uint(dim), 0u, arrayed, 0u, sampled, uint(format)]
+    var ops <- [id, sampled_type, uint(dim), depth, arrayed, 0u, sampled, uint(format)]
     emit_n(m, SEC_TYPES, SpvOp.TypeImage, ops)
     delete ops
     m.type_pool |> insert(key, id)

--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -195,8 +195,9 @@ def public type_matrix(var m : SpirvModule; col_type : uint; cols : int) : uint 
 
 // OpTypeImage. `sampled_type` is the texel component scalar. `sampled` = 1 for a sampled texture
 // (used with a sampler, format usually Unknown), 2 for a read-write storage image (a KNOWN format
-// e.g. Rgba8, so no StorageImageRead/WriteWithoutFormat capability is needed). depth=0, ms=0; the
-// arrayed flag distinguishes a 2D/2DArray (etc.) image. Deduped on the full operand tuple.
+// e.g. Rgba8, so no StorageImageRead/WriteWithoutFormat capability is needed). `depth` = 1 marks a
+// depth-comparison image (sampler2DShadow, sampled via Dref), else 0; ms is always 0; the arrayed flag
+// distinguishes a 2D/2DArray (etc.) image. Deduped on the full operand tuple (depth included).
 def public type_image(var m : SpirvModule; sampled_type : uint; dim : SpvDim;
                       arrayed : uint = 0u; sampled : uint = 1u; format : SpvImageFormat = SpvImageFormat.Unknown;
                       depth : uint = 0u) : uint {

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -74,6 +74,19 @@ def public texture(s : sampler2DArray; uv : float3) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
 
+// ===== depth-compare (shadow) sampling =====
+// sampler2DShadow is an opaque marker for a DEPTH-comparison combined sampler: its OpTypeImage carries
+// the Depth=1 flag and the descriptor is a comparison sampler. textureCompare samples it with a
+// reference value (OpImageSampleDrefImplicitLod) and returns the scalar comparison result in [0,1]
+// (1 = fully lit, 0 = fully shadowed; a filtered sampler returns the PCF average). Implicit LOD ->
+// fragment-only. The stub body never runs — only the call AST is lowered.
+struct sampler2DShadow {}
+
+[unused_argument(s, uv, compare)]
+def public textureCompare(s : sampler2DShadow; uv : float2; compare : float) : float {
+    return 0.0
+}
+
 // ===== separate image + sampler =====
 // texture2D is a standalone sampled image (OpTypeImage, no sampler) and sampler is a standalone
 // OpTypeSampler -- two independent descriptors with their own @binding. sampleTexture combines them at

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -234,7 +234,8 @@ def private stage_flag(stage : ShaderStage) : SpirvStageFlags {
 
 // ===== combined image sampler detection =====
 // sampler globals are recognized by their opaque marker struct name (sampler2D, ...). Returns the
-// SPIR-V image dimensionality so classify_global can build the OpTypeImage / OpTypeSampledImage.
+// OpTypeImage operands classify_global needs: dimensionality (dim), the Arrayed flag (arrayed), and
+// the Depth flag (depth, 1 for a sampler2DShadow comparison sampler, else 0).
 def private sampler_info(t : TypeDecl?) : tuple<ok : bool; dim : SpvDim; arrayed : uint; depth : uint> {
     if (t == null || t.baseType != Type.tStructure || t.structType == null) return (ok = false, dim = SpvDim._2D, arrayed = 0u, depth = 0u)
     let n = "{t.structType.name}"
@@ -1488,7 +1489,9 @@ class SpirvEmit : AstVisitor {
             let simg = alloc_id(bm)
             emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, simg, gi.var_id)
             let si = sampler_info(sg._type)
-            let img_type = type_image(bm, type_float(bm, 32u), si.dim, si.arrayed)
+            // reconstruct the SAME image type classify_global built for this sampler so OpImage's
+            // result type matches the sampled image's image type -- depth included (type_image dedups on it)
+            let img_type = type_image(bm, type_float(bm, 32u), si.dim, si.arrayed, 1u, SpvImageFormat.Unknown, si.depth)
             let img = alloc_id(bm)
             emit(bm, SEC_FUNCS, SpvOp.Image, img_type, img, simg)
             let lod = value_of(expr.arguments[1])
@@ -1616,7 +1619,9 @@ class SpirvEmit : AstVisitor {
             emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, simg, gi.var_id)
             // extract the underlying image (same dedup key classify_global used for the sampler)
             let si = sampler_info(sg._type)
-            let img_type = type_image(bm, type_float(bm, 32u), si.dim, si.arrayed)
+            // reconstruct the SAME image type classify_global built for this sampler so OpImage's
+            // result type matches the sampled image's image type -- depth included (type_image dedups on it)
+            let img_type = type_image(bm, type_float(bm, 32u), si.dim, si.arrayed, 1u, SpvImageFormat.Unknown, si.depth)
             let img = alloc_id(bm)
             emit(bm, SEC_FUNCS, SpvOp.Image, img_type, img, simg)
             let coord = value_of(expr.arguments[1])

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -235,14 +235,16 @@ def private stage_flag(stage : ShaderStage) : SpirvStageFlags {
 // ===== combined image sampler detection =====
 // sampler globals are recognized by their opaque marker struct name (sampler2D, ...). Returns the
 // SPIR-V image dimensionality so classify_global can build the OpTypeImage / OpTypeSampledImage.
-def private sampler_info(t : TypeDecl?) : tuple<ok : bool; dim : SpvDim; arrayed : uint> {
-    if (t == null || t.baseType != Type.tStructure || t.structType == null) return (ok = false, dim = SpvDim._2D, arrayed = 0u)
+def private sampler_info(t : TypeDecl?) : tuple<ok : bool; dim : SpvDim; arrayed : uint; depth : uint> {
+    if (t == null || t.baseType != Type.tStructure || t.structType == null) return (ok = false, dim = SpvDim._2D, arrayed = 0u, depth = 0u)
     let n = "{t.structType.name}"
-    if (n == "sampler2D") return (ok = true, dim = SpvDim._2D, arrayed = 0u)
-    if (n == "sampler3D") return (ok = true, dim = SpvDim._3D, arrayed = 0u)
-    if (n == "samplerCube") return (ok = true, dim = SpvDim.Cube, arrayed = 0u)
-    if (n == "sampler2DArray") return (ok = true, dim = SpvDim._2D, arrayed = 1u)
-    return (ok = false, dim = SpvDim._2D, arrayed = 0u)
+    if (n == "sampler2D") return (ok = true, dim = SpvDim._2D, arrayed = 0u, depth = 0u)
+    if (n == "sampler3D") return (ok = true, dim = SpvDim._3D, arrayed = 0u, depth = 0u)
+    if (n == "samplerCube") return (ok = true, dim = SpvDim.Cube, arrayed = 0u, depth = 0u)
+    if (n == "sampler2DArray") return (ok = true, dim = SpvDim._2D, arrayed = 1u, depth = 0u)
+    // sampler2DShadow: a 2D DEPTH-comparison sampler (Depth=1). Sampled only via textureCompare (Dref).
+    if (n == "sampler2DShadow") return (ok = true, dim = SpvDim._2D, arrayed = 0u, depth = 1u)
+    return (ok = false, dim = SpvDim._2D, arrayed = 0u, depth = 0u)
 }
 
 // Storage-image globals are recognized by their opaque marker struct name (image2D, ...). Returns the
@@ -308,7 +310,7 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
     // OpTypeSampledImage + DescriptorSet/Binding. Used only via texture(); not in the entry interface.
     let si = sampler_info(v._type)
     if (si.ok) {
-        let img = type_image(m, type_float(m, 32u), si.dim, si.arrayed)
+        let img = type_image(m, type_float(m, 32u), si.dim, si.arrayed, 1u, SpvImageFormat.Unknown, si.depth)
         let simg = type_sampled_image(m, img)
         let pt = type_pointer(m, SpvStorageClass.UniformConstant, simg)
         let vid = alloc_id(m)
@@ -322,8 +324,11 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.DescriptorSet), uint(set))
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Binding), uint(binding))
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.UniformConstant, value_type = simg, is_sampler = true))
+        // a Depth=1 sampler is a comparison sampler (sampled via textureCompare/Dref); the host binds a
+        // VkSampler created with compareEnable. Otherwise an ordinary combined image sampler.
+        let kind = si.depth != 0u ? SpirvDescriptorKind.comparison_sampler : SpirvDescriptorKind.combined_image_sampler
         reflection.bindings |> push(SpirvDescriptorBinding(set = set, binding = binding,
-            kind = SpirvDescriptorKind.combined_image_sampler, count = 1, stages = stage_flag(stage)))
+            kind = kind, count = 1, stages = stage_flag(stage)))
         return
     }
     // storage image: a global of an opaque image type (image2D) -> UniformConstant OpTypeImage with a
@@ -1491,6 +1496,42 @@ class SpirvEmit : AstVisitor {
             let rt = emit_type(bm, expr._type)
             let res = alloc_id(bm)
             emit(bm, SEC_FUNCS, SpvOp.ImageQuerySizeLod, rt, res, img, lod)
+            e2id[k] = res
+            return expr
+        }
+        // textureCompare(sampler2DShadow, uv, compare): depth-compare sampling. OpLoad the comparison
+        // sampler + OpImageSampleDrefImplicitLod with the reference value as the Dref operand; the
+        // scalar result is the comparison (1 = lit, 0 = shadowed; filtered -> PCF average). Implicit
+        // LOD -> fragment-only.
+        if (name == "textureCompare") {
+            if (length(expr.arguments) != 3) {
+                errs |> push("textureCompare expects (sampler2DShadow, uv, compare)")
+                return expr
+            }
+            if (ctx.stage != ShaderStage.Fragment) {
+                errs |> push("textureCompare: implicit-LOD depth-compare sampling is only valid in a fragment shader")
+                return expr
+            }
+            let sg = global_var_of(expr.arguments[0])
+            if (sg == null) {
+                errs |> push("textureCompare: first argument must be a sampler2DShadow global")
+                return expr
+            }
+            let gi = ctx.globals?[intptr(sg)] ?? GlobalInfo()
+            if (!gi.is_sampler || sampler_info(sg._type).depth == 0u) {
+                errs |> push("textureCompare: '{sg.name}' is not a sampler2DShadow (depth-compare sampler)")
+                return expr
+            }
+            let simg = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, simg, gi.var_id)
+            let uv = value_of(expr.arguments[1])
+            let dref = value_of(expr.arguments[2])
+            if (uv == 0u || dref == 0u) return expr
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            var ops <- [rt, res, simg, uv, dref]
+            emit_n(bm, SEC_FUNCS, SpvOp.ImageSampleDrefImplicitLod, ops)
+            delete ops
             e2id[k] = res
             return expr
         }

--- a/modules/dasSpirv/spirv/spirv_reflect.das
+++ b/modules/dasSpirv/spirv/spirv_reflect.das
@@ -19,6 +19,7 @@ enum SpirvDescriptorKind {
     storage_image           //!< an `image2D` (read-write storage image)
     sampled_image           //!< a standalone `texture2D` (separate-image model)
     sampler                 //!< a standalone `sampler` (separate-sampler model)
+    comparison_sampler      //!< a `sampler2DShadow` (depth-compare combined sampler, sampled via textureCompare)
 }
 
 //! Stages a binding / push range is used in (the host maps to e.g. VkShaderStageFlags). A single
@@ -54,11 +55,11 @@ struct SpirvReflection {
     push_constants : array<SpirvPushConstantRange>  //!< push-constant ranges
 }
 
-// 'RFL2' — wire-format magic + version. Bump on any layout OR descriptor-kind change to encode/
+// 'RFL3' — wire-format magic + version. Bump on any layout OR descriptor-kind change to encode/
 // decode_reflection, so an older consumer rejects a newer stream loudly instead of mis-mapping an
-// unknown SpirvDescriptorKind (kind_from_int falls back to uniform_buffer). Bumped to RFL2 in Phase 7
-// (added storage_image / sampled_image / sampler kinds).
-let REFLECTION_MAGIC = 0x52464C32u
+// unknown SpirvDescriptorKind (kind_from_int falls back to uniform_buffer). RFL2 = Phase 7
+// (storage_image / sampled_image / sampler); RFL3 = Phase 10.4 (comparison_sampler).
+let REFLECTION_MAGIC = 0x52464C33u
 
 def finalize(var r : SpirvReflection) {
     delete r.bindings
@@ -95,6 +96,7 @@ def private kind_from_int(k : int) : SpirvDescriptorKind {
     if (k == int(SpirvDescriptorKind.storage_image)) return SpirvDescriptorKind.storage_image
     if (k == int(SpirvDescriptorKind.sampled_image)) return SpirvDescriptorKind.sampled_image
     if (k == int(SpirvDescriptorKind.sampler)) return SpirvDescriptorKind.sampler
+    if (k == int(SpirvDescriptorKind.comparison_sampler)) return SpirvDescriptorKind.comparison_sampler
     return SpirvDescriptorKind.uniform_buffer
 }
 

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -784,6 +784,27 @@ def public fragx_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-10.4 depth-compare (shadow) sampling: a sampler2DShadow sampled via textureCompare
+// (OpImageSampleDrefImplicitLod). The sampler's OpTypeImage carries Depth=1 and the descriptor reflects
+// as a comparison_sampler (not a plain combined_image_sampler). The reference value is the fragment's
+// light-space depth (a runtime @in); the scalar result is the comparison (1 = lit, 0 = shadowed).
+// Implicit LOD -> fragment-only. =====
+var @binding = 0 sh_shadow : sampler2DShadow
+var @in @location = 0 sh_uv : float2
+var @in @location = 1 sh_ref : float
+var @out @location = 0 sh_color : float4
+[fragment_shader(name="fragshadow_spv"), marker(no_coverage)]
+def fragshadow {
+    let lit = textureCompare(sh_shadow, sh_uv, sh_ref)   // OpImageSampleDrefImplicitLod -> scalar in [0,1]
+    sh_color = float4(lit, lit, lit, 1.0f)
+}
+
+def public fragshadow_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(fragshadow_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -1034,5 +1055,14 @@ def public phase10_3_emitter_opcodes : table<uint> {
     ]) {
         s |> insert(uint(op))
     }
+    return <- s
+}
+
+// Phase-10.4 depth-compare sampling adds one opcode: OpImageSampleDrefImplicitLod (textureCompare on a
+// sampler2DShadow). The Depth=1 image flag is an OpTypeImage operand and the comparison_sampler kind is
+// reflection-only — neither is a new opcode. Phase-10.3 set + this:
+def public phase10_4_emitter_opcodes : table<uint> {
+    var s <- phase10_3_emitter_opcodes()
+    s |> insert(uint(SpvOp.ImageSampleDrefImplicitLod))
     return <- s
 }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -62,7 +62,8 @@ def test_opcode_census(t : T?) {
         add_set(present, ssbostruct_words())
         add_set(present, gswizzle_words())
         add_set(present, fragx_words())
-        var declared <- phase10_3_emitter_opcodes()
+        add_set(present, fragshadow_words())
+        var declared <- phase10_4_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_reflect.das
+++ b/tests/spirv/test_reflect.das
@@ -91,6 +91,21 @@ def test_reflect_sampler(t : T?) {
 }
 
 [test]
+def test_reflect_comparison_sampler(t : T?) {
+    t |> run("reflect: fragshadow -> one comparison_sampler @ (0,0), fragment stage") <| @(t : T?) {
+        var r = decode_reflection(fragshadow_spv_reflect)
+        t |> success(length(r.bindings) == 1, "fragshadow: one binding")
+        if (length(r.bindings) == 1) {
+            let b = r.bindings[0]
+            t |> success(b.set == 0 && b.binding == 0, "fragshadow: binding @ (0,0)")
+            t |> success(b.kind == SpirvDescriptorKind.comparison_sampler, "fragshadow: comparison_sampler kind")
+            t |> success(b.stages.fragment, "fragshadow: stages = fragment")
+        }
+        finalize(r)
+    }
+}
+
+[test]
 def test_reflect_malformed(t : T?) {
     t |> run("reflect: malformed streams decode to empty (no over-read / over-alloc / panic)") <| @(t : T?) {
         // empty stream

--- a/tests/spirv/test_shadow.das
+++ b/tests/spirv/test_shadow.das
@@ -1,0 +1,44 @@
+options gen2
+options indenting = 4
+
+// Phase-10.4 gate: depth-compare (shadow) sampling. textureCompare(sampler2DShadow, uv, ref) lowers to
+// OpImageSampleDrefImplicitLod (the reference value as the Dref operand, a scalar result). The sampler's
+// OpTypeImage carries the Depth=1 flag that distinguishes a comparison sampler from an ordinary one.
+// Each is asserted positionally, and the module is spirv-val-clean -- the real check that the Dref
+// operand count and the Depth-flagged image type are well-formed.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_depth_compare(t : T?) {
+    t |> run("depth-compare sampling: sampler2DShadow + textureCompare -> OpImageSampleDrefImplicitLod") <| @(t : T?) {
+        var words <- fragshadow_words()
+        // a fragment entry point (implicit-LOD Dref sampling is fragment-only)
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.Fragment),
+            "fragshadow: EntryPoint model is Fragment")
+        // textureCompare -> the depth-compare sample op
+        t |> success(has_op(words, SpvOp.ImageSampleDrefImplicitLod),
+            "fragshadow: textureCompare -> OpImageSampleDrefImplicitLod")
+        // the sampler's OpTypeImage marks Depth=1 (comparison) and Dim=2D. OpTypeImage operands:
+        // result-id(0), Sampled Type(1), Dim(2), Depth(3), Arrayed(4), MS(5), Sampled(6), Format(7).
+        t |> success(op_has_operand_at(words, SpvOp.TypeImage, 3, 1u),
+            "fragshadow: sampler2DShadow OpTypeImage has Depth=1")
+        t |> success(op_has_operand_at(words, SpvOp.TypeImage, 2, uint(SpvDim._2D)),
+            "fragshadow: sampler2DShadow OpTypeImage Dim=2D")
+        validate(t, words, "fragshadow")
+        delete words
+    }
+}


### PR DESCRIPTION
Phase 10.4 of the dasSpirv roadmap — the hardware-PCF shadow rail. A `sampler2DShadow` sampled via `textureCompare` lowers to `OpImageSampleDrefImplicitLod`, the depth-compare sample. This is the quality upgrade over the manual-compare shadow that already works (sample a depth texture as a plain `sampler2D` and compare with a ternary). Stacks on 10.3 (#3161). One new census opcode; the Depth=1 image flag and the `comparison_sampler` reflection kind are operand/reflection-only.

## Rail

- **`sampler2DShadow` marker + `textureCompare(s, uv, compare) : float`.** A new opaque sampler type; `sampler_info` maps it to a 2D image with the **Depth=1** flag — the OpTypeImage operand that distinguishes a comparison sampler from an ordinary one. `textureCompare` is its only sample path: the daslang type system blocks passing it to `texture()`/`textureLod`/… since those overloads don't accept it (fail-closed by construction).
- **`OpImageSampleDrefImplicitLod`.** Loads the combined comparison sampler, then samples with the reference value as the **Dref** operand; the scalar `float` result is the comparison (1 = lit, 0 = shadowed; a filtered sampler returns the PCF average). Implicit LOD → fragment-only (same stage gate as `texture()`).
- **`type_image` gained a `depth` parameter** — threaded into both the OpTypeImage Depth operand (index 3) **and the dedup key**. Without the key change a `sampler2DShadow` and a `sampler2D` (same dim/arrayed/sampled/format) collide on one type id.
- **`comparison_sampler` reflection kind.** `classify_global` picks it (vs `combined_image_sampler`) when the depth flag is set, so the host binds a `VkSampler` with `compareEnable`. Wire-format magic bumped RFL2 → RFL3.

## Findings

1. **The Depth flag lives on the OpTypeImage, not the sample op.** `OpImageSampleDrefImplicitLod` is identical regardless of image type; what makes a sampler a *comparison* sampler is the `Depth=1` operand on its `OpTypeImage`. So the dedup key MUST include depth, else the shadow sampler aliases a plain one and spirv-val rejects the Dref sample against a non-depth image. External `spirv-dis` verified: `OpTypeImage %float 2D 1 0 0 1 Unknown` + `OpImageSampleDrefImplicitLod %float %img %uv %ref`.
2. **A dedicated `textureCompare` intrinsic beats overloading `texture()`.** GLSL packs the compare ref into a third coordinate component (`texture(sampler2DShadow, vec3)`); a separate intrinsic with an explicit `compare : float` is clearer, keeps the result type scalar (vs `texture()`'s float4), and fail-closes by construction.

## Testing

`fragshadow` fixture + `test_shadow` gate (Dref opcode + `Depth=1` image flag asserted positionally + spirv-val) + a `comparison_sampler` reflection assert in `test_reflect`. Census extended to `phase10_4_emitter_opcodes` (= 10.3 set + `ImageSampleDrefImplicitLod`), unioned over the new fixture. **interp + JIT 100/100**, spirv-val clean on every blob, external `spirv-dis` confirms textbook structure, lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)