### PR TITLE
ci: add gcc -Werror Linux build lane

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -758,3 +758,40 @@ jobs:
         ctest --build-config Release -L small --output-on-failure
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
+  build_linux_gcc:
+  ###########################################################
+  # Catches gcc-only -Werror breaks at PR time. Every Linux lane in this
+  # workflow builds with CC=clang CXX=clang++, so warnings that only gcc emits
+  # (glibc warn_unused_result on chdir/etc., -Wstringop-overflow / -Warray-bounds
+  # / -Wmaybe-uninitialized false positives under -O3) are invisible to our own
+  # CI and only ever surface downstream, where external module repos build
+  # daslang from source with the default system g++ (e.g. dasImgui's
+  # ubuntu-latest job). This job closes that gap. Compile-only: the clang lanes
+  # already run the test sweeps; the point here is the strict-warning gate.
+  #
+  # Config mirrors the linux_arm lane (GLFW off, HV+SQLITE on); LLVM is left off
+  # to keep this fast — its module also goes through DAS_APPLY_STRICT_WARNINGS,
+  # but the LLVM build dominates walltime and the bulk of strict-compiled code
+  # (core + HV/SQLITE/Audio/PUGIXML/UnitTest modules) is covered without it.
+  ###########################################################
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest-fat
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - name: "Install toolchain"
+      run: sudo apt-get update && sudo apt-get install -y ninja-build bison
+
+    - name: "Build: Daslang (gcc -Werror)"
+      run: |
+        set -eux
+        CC=gcc CXX=g++ cmake --no-warn-unused-cli -B./build-gcc -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DDAS_GLFW_DISABLED=ON \
+          -DDAS_HV_DISABLED=OFF \
+          -DDAS_SQLITE_DISABLED=OFF \
+          -DDAS_LLVM_DISABLED=ON
+        cmake --build ./build-gcc --parallel
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -781,8 +781,10 @@ jobs:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
 
-    - name: "Install toolchain"
-      run: sudo apt-get update && sudo apt-get install -y ninja-build bison
+    # Pinned CMake + Ninja, matching the other Linux jobs (bison is preinstalled
+    # on the ubuntu runners — the matrix linux64 job relies on it the same way).
+    - name: "Get CMake + Ninja"
+      uses: lukka/get-cmake@latest
 
     - name: "Build: Daslang (gcc -Werror)"
       run: |


### PR DESCRIPTION
## What

Adds a standalone `build_linux_gcc` job to `build.yml` — a compile-only gcc `-Werror` build of daslang core + in-tree modules.

## Why

Every Linux lane in this workflow builds with `CC=clang CXX=clang++` (the matrix `linux64`/`linux_arm` cases, the sanitizer lanes, `extended_checks`, `wasm` — all clang). **There is no gcc lane anywhere.** So warnings only gcc emits are invisible to our own CI and only ever surface *downstream*, where external module repos build daslang from source with the default system `g++` (e.g. dasImgui's `integration (ubuntu-latest)` job).

That's exactly how [#3162](https://github.com/GaijinEntertainment/daScript/pull/3162) happened: #3155 enabled `-Werror`, and two gcc-only breaks — `chdir`'s glibc `warn_unused_result`, and a `-Wstringop-overflow` `-O3` false positive in `ast_infer_type.cpp` — passed our clang CI green but broke every downstream gcc build. This lane closes the gap so the class is caught at PR time here instead.

## Scope

- **Compile-only.** The clang lanes already run the dastest/JIT/AOT sweeps; the point of this job is the strict-warning gate, nothing more.
- **Config** mirrors the `linux_arm` lane (`GLFW off`, `HV+SQLITE on`). LLVM is left **off** to keep walltime down — its module also goes through `DAS_APPLY_STRICT_WARNINGS`, but the LLVM build dominates walltime and the bulk of strict-compiled code (core + HV/SQLITE/Audio/PUGIXML/UnitTest modules) is covered without it. Easy to flip on later if we want dasLLVM bindings under the gate too.

Verified locally: this exact config builds clean under `g++ 13.3 -Werror -k0` against current master (post-#3162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)