### PR TITLE
dasSpirv Phase 10.5: compute tier (shared memory + barriers + atomics)

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -1350,3 +1350,42 @@ already works (sample a depth texture as a plain `sampler2D`, compare with a ter
    explicit `compare : float` is clearer, keeps the result type scalar (vs `texture()`'s float4), and
    fail-closes by construction — the type system prevents the wrong sampler/op pairing without an emitter
    check.
+
+### Phase 10.5 — compute tier (shared memory + barriers + atomics) LANDED (2026-06-15, branch `bbatkin/dasspirv-phase10-5-compute`)
+
+The cross-thread-compute differentiator: workgroup-shared memory, the barrier sync primitives, and the
+atomic read-modify-write family. Twelve new census opcodes (`OpControlBarrier`/`OpMemoryBarrier` + the
+ten atomics). interp + JIT 104/104, spirv-val clean, external `spirv-dis` confirms textbook lowering,
+lint + format clean.
+
+- **`@workgroup` shared memory → Workgroup storage (GLSL `shared`).** A `@workgroup` global lowers to a
+  Workgroup-class `OpVariable` (scalar, vector, or fixed array). Not a descriptor and not in the entry
+  interface (Workgroup is neither Input nor Output, SPIR-V ≤ 1.3), so no set/binding and nothing
+  reflected; compute-only. A shared fixed-array indexes through `visitExprAt`'s new Workgroup branch — a
+  **bare** array (single-index `OpAccessChain`), with NO member-0 indirection (unlike an SSBO, whose array
+  is wrapped in a Block struct).
+- **`barrier()` → `OpControlBarrier`, `memoryBarrierShared()` → `OpMemoryBarrier`.** Both at Workgroup
+  scope with `WorkgroupMemory | AcquireRelease` (= 264) semantics, matching glslang. `barrier()` is the
+  execution + shared-memory rendezvous (the tiled-reduction sync point); `memoryBarrierShared()` is the
+  memory-only ordering. Compute-only; neither is a block terminator. No extra capability (base `Shader`).
+- **Atomics → `OpAtomic*`.** `atomicAdd`/`Min`/`Max`/`And`/`Or`/`Xor`/`Exchange`/`CompSwap` on a
+  `@workgroup` or `@ssbo` int/uint lvalue, returning the OLD value. `atomicMin`/`Max` pick the signed
+  (`SMin`/`SMax`) or unsigned (`UMin`/`UMax`) opcode by the operand's signedness; `atomicCompSwap` is the
+  `OpAtomicCompareExchange` CAS. Memory scope = Workgroup for shared targets, Device for buffer targets
+  (read off the target's root-global storage class); Relaxed (0) semantics, the glslang default. No extra
+  capability for 32-bit integer atomics (lavapipe-safe).
+
+**Findings (load-bearing):**
+1. **`@shared` is a reserved keyword → the annotation is `@workgroup`.** `var @shared x` is a parse error
+   ("unexpected shared"), same class as the `block` keyword collision in Phase 10.1. `@workgroup` (the
+   SPIR-V storage-class name) parses cleanly and reads well. The shared-memory authoring spelling is
+   `var @workgroup tile : float[64]`.
+2. **The atomic target is a reference parameter (`mem : T&`), NOT by-value.** A by-value `mem : T`
+   workhorse param makes daslang insert an `ExprRef2Value` (a load) around the lvalue arg — a wasted
+   `OpLoad` whose result the atomic ignores. A `T&` ref param keeps the arg an lvalue, so the visitor
+   seeds its `e2ptr` pointer and the emitter recovers it directly (no spurious load). LINT014 then forces
+   dropping `var` (the body only reads `mem`): `mem : int&`, not `var mem : int&`. The emitter still peels
+   a defensive `ExprRef2Value` in case one appears, and `root_global_of` walks the lvalue chain
+   (`ExprAt`/`ExprField`/`ExprSwizzle`/`ExprRef2Value` → root `ExprVar`) to read the storage class for the
+   memory scope. External `spirv-dis` verified: shared scalar atomics at `%uint_2` (Workgroup) scope, the
+   SSBO `atomicAdd` at `%uint_1` (Device).

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -147,3 +147,38 @@ def public textureSize(s : samplerCube; lod : int) : int2 { return int2(0, 0) }
 def public textureSize(s : sampler3D; lod : int) : int3 { return int3(0, 0, 0) }
 [unused_argument(s, lod)]
 def public textureSize(s : sampler2DArray; lod : int) : int3 { return int3(0, 0, 0) }
+
+// ===== compute synchronization =====
+// barrier() is a control + shared-memory barrier (OpControlBarrier at Workgroup scope): every
+// invocation in the workgroup waits here, and writes to @workgroup memory before the barrier are
+// visible to all after it. The must-have sync point for shared-memory compute (the tiled-reduction
+// pattern). memoryBarrierShared() is the memory-only variant (OpMemoryBarrier) -- it orders shared
+// writes without the execution rendezvous. Both compute-only; the stub bodies never run.
+def public barrier() : void {}
+def public memoryBarrierShared() : void {}
+
+// ===== atomics =====
+// Atomic read-modify-write on a @workgroup or @ssbo lvalue, returning the OLD value (GLSL/SPIR-V
+// semantics). The target is the first argument, passed by reference so the emitter recovers its
+// pointer; int and uint overloads cover signed/unsigned ops (atomicMin/Max pick SMin/UMin /
+// SMax/UMax by the operand's signedness). Lowered to OpAtomicIAdd/SMin/.../Exchange/CompareExchange
+// at Workgroup scope (shared) or Device scope (buffer). The stub bodies never run -- only the call
+// AST is read. Use as `let old = atomicAdd(counter, 1)`.
+[unused_argument(value)] def public atomicAdd(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicAdd(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value)] def public atomicMin(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicMin(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value)] def public atomicMax(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicMax(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value)] def public atomicAnd(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicAnd(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value)] def public atomicOr(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicOr(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value)] def public atomicXor(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicXor(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value)] def public atomicExchange(mem : int &; value : int) : int { return mem }
+[unused_argument(value)] def public atomicExchange(mem : uint &; value : uint) : uint { return mem }
+// atomicCompSwap(mem, compare, value): if mem == compare, store value; returns the OLD value either
+// way (OpAtomicCompareExchange). The lock-free CAS primitive.
+[unused_argument(compare, value)] def public atomicCompSwap(mem : int &; compare, value : int) : int { return mem }
+[unused_argument(compare, value)] def public atomicCompSwap(mem : uint &; compare, value : uint) : uint { return mem }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -256,6 +256,17 @@ def private storage_image_info(t : TypeDecl?) : tuple<ok : bool; dim : SpvDim> {
     return (ok = false, dim = SpvDim._2D)
 }
 
+// Exactly the type set emit_type lowers without panicking: a scalar/vector (scalar_class >= 0), bool,
+// a matrix, or a fixed array of those. Lets the @workgroup path reject an unsupported shared type with
+// a clean diagnostic instead of crashing in emit_type (struct/handle/dynamic-array shared vars).
+def private is_emittable_value_type(t : TypeDecl?) : bool {
+    if (t == null) return false
+    if (matrix_info(t).ok) return true
+    let bt = t.baseType
+    if (bt == Type.tFixedArray && t.firstType != null) return is_emittable_value_type(t.firstType)
+    return scalar_class(bt) >= 0 || bt == Type.tBool
+}
+
 // ===== global variable classification + emission =====
 def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : VariablePtr; stage : ShaderStage; var reflection : SpirvReflection; var errors : array<string>) {
     let vname = "{v.name}"
@@ -460,6 +471,10 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
     if (v.annotation |> find_arg("workgroup") is tBool) {
         if (stage != ShaderStage.Compute) {
             errors |> push("shared variable '{vname}': @workgroup memory is only valid in a compute shader")
+            return
+        }
+        if (!is_emittable_value_type(v._type)) {
+            errors |> push("shared variable '{vname}': @workgroup type must be a scalar, vector, matrix, or fixed array of those")
             return
         }
         let vt = emit_type(m, v._type)
@@ -1567,6 +1582,13 @@ class SpirvEmit : AstVisitor {
                 return expr
             }
             let rgi = ctx.globals?[intptr(rg)] ?? GlobalInfo()
+            // only @workgroup (Workgroup) and @ssbo (StorageBuffer) are writable atomic targets; a
+            // @uniform/@push_constant/builtin lvalue is read-only storage -> reject cleanly rather than
+            // emit an OpAtomic* on an invalid storage class (fail-closed, not spirv-val-only).
+            if (rgi.storage != SpvStorageClass.Workgroup && rgi.storage != SpvStorageClass.StorageBuffer) {
+                errs |> push("{name}: atomic target must live in @workgroup or @ssbo memory")
+                return expr
+            }
             let scope = rgi.storage == SpvStorageClass.Workgroup ? SpvScope.Workgroup : SpvScope.Device
             let sc_id = const_uint(bm, uint(scope))
             let sem_id = const_uint(bm, uint(SpvMemorySemantics.Relaxed))

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -452,7 +452,24 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         reflection.push_constants |> push(SpirvPushConstantRange(offset = 0, size = bs.size, stages = stage_flag(stage)))
         return
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, or a sampler type e.g. sampler2D)")
+    // workgroup shared memory: @workgroup global -> Workgroup storage (GLSL `shared`). Not a
+    // descriptor and not in the entry interface (Workgroup is not Input/Output, SPIR-V <= 1.3), so no
+    // set/binding and nothing reflected. Compute-only. Read/written via OpLoad/OpStore; a fixed-array
+    // shared global is indexed by visitExprAt's Workgroup branch. (`shared` is a reserved keyword, so
+    // the annotation is spelled @workgroup, matching the SPIR-V storage class.)
+    if (v.annotation |> find_arg("workgroup") is tBool) {
+        if (stage != ShaderStage.Compute) {
+            errors |> push("shared variable '{vname}': @workgroup memory is only valid in a compute shader")
+            return
+        }
+        let vt = emit_type(m, v._type)
+        let pt = type_pointer(m, SpvStorageClass.Workgroup, vt)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.Workgroup))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.Workgroup, value_type = vt, is_ssbo = false))
+        return
+    }
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, or a sampler type e.g. sampler2D)")
 }
 
 // ===== member index of a struct field by name =====
@@ -473,6 +490,44 @@ def private global_var_of(e : ExpressionPtr) : Variable const? {
     let ev = e ?as ExprVar
     if (ev == null || ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block) return null
     return ev.variable
+}
+
+// ===== root global of an lvalue chain (for an atomic target's memory scope) =====
+// Peels ExprAt/ExprField/ExprSwizzle/ExprRef2Value down to the underlying ExprVar and returns its
+// global Variable (or null if the chain doesn't root in a global). Lets the atomic handler read the
+// target's storage class to pick Workgroup vs Device memory scope.
+def private root_global_of(e : ExpressionPtr) : Variable const? {
+    if (e == null) return null
+    let ev = e ?as ExprVar
+    if (ev != null) {
+        if (ev.varFlags.local || ev.varFlags.argument || ev.varFlags._block) return null
+        return ev.variable
+    }
+    let at = e ?as ExprAt
+    if (at != null) return root_global_of(at.subexpr)
+    let fld = e ?as ExprField
+    if (fld != null) return root_global_of(fld.value)
+    let sw = e ?as ExprSwizzle
+    if (sw != null) return root_global_of(sw.value)
+    let r2v = e ?as ExprRef2Value
+    if (r2v != null) return root_global_of(r2v.subexpr)
+    return null
+}
+
+// ===== atomic call name + operand class -> SPIR-V opcode =====
+// cls: 0 = signed int, 1 = unsigned int. atomicMin/Max pick the signed (SMin/SMax) or unsigned
+// (UMin/UMax) opcode by the operand's signedness; the rest are sign-agnostic. compswap flags the
+// OpAtomicCompareExchange shape (an extra comparator operand + a second semantics id).
+def private atomic_info(name : string; cls : int) : tuple<ok : bool; op : SpvOp; compswap : bool> {
+    if (name == "atomicAdd") return (ok = true, op = SpvOp.AtomicIAdd, compswap = false)
+    if (name == "atomicMin") return (ok = true, op = cls == 1 ? SpvOp.AtomicUMin : SpvOp.AtomicSMin, compswap = false)
+    if (name == "atomicMax") return (ok = true, op = cls == 1 ? SpvOp.AtomicUMax : SpvOp.AtomicSMax, compswap = false)
+    if (name == "atomicAnd") return (ok = true, op = SpvOp.AtomicAnd, compswap = false)
+    if (name == "atomicOr") return (ok = true, op = SpvOp.AtomicOr, compswap = false)
+    if (name == "atomicXor") return (ok = true, op = SpvOp.AtomicXor, compswap = false)
+    if (name == "atomicExchange") return (ok = true, op = SpvOp.AtomicExchange, compswap = false)
+    if (name == "atomicCompSwap") return (ok = true, op = SpvOp.AtomicCompareExchange, compswap = true)
+    return (ok = false, op = SpvOp.AtomicIAdd, compswap = false)
 }
 
 // ===== arithmetic opcode selection =====
@@ -1163,8 +1218,21 @@ class SpirvEmit : AstVisitor {
             return expr
         }
         let gi = ctx.globals?[intptr(bv)] ?? GlobalInfo()
+        // @workgroup shared fixed-array: a BARE array global (not wrapped in a Block struct), so the
+        // access chain is a single index off the variable -- no member-0 indirection like an SSBO.
+        if (gi.storage == SpvStorageClass.Workgroup) {
+            let idx = value_of(expr.index)
+            if (idx == 0u) return expr   // index failed to lower (error already pushed)
+            let pointee = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            let ptr_t = type_pointer(bm, SpvStorageClass.Workgroup, pointee)
+            emit(bm, SEC_FUNCS, SpvOp.AccessChain, ptr_t, res, gi.var_id, idx)
+            e2ptr[k] = res
+            e2pty[k] = pointee
+            return expr
+        }
         if (!gi.is_ssbo) {
-            errs |> push("only ssbo array indexing is supported for now")
+            errs |> push("only ssbo or @workgroup array indexing is supported for now")
             return expr
         }
         let idx = value_of(expr.index)
@@ -1445,6 +1513,81 @@ class SpirvEmit : AstVisitor {
             }
             emit(bm, SEC_FUNCS, SpvOp.Kill)
             ctx.terminated = true
+            return expr
+        }
+        // barrier(): control + shared-memory barrier (OpControlBarrier at Workgroup execution+memory
+        // scope, WorkgroupMemory|AcquireRelease semantics). memoryBarrierShared(): the memory-only
+        // variant (OpMemoryBarrier, same scope/semantics). Both compute-only; not block terminators.
+        if (name == "barrier" || name == "memoryBarrierShared") {
+            if (ctx.stage != ShaderStage.Compute) {
+                errs |> push("{name}() is only valid in a compute shader")
+                return expr
+            }
+            if (!empty(expr.arguments)) {
+                errs |> push("{name}() takes no arguments")
+                return expr
+            }
+            let scope = const_uint(bm, uint(SpvScope.Workgroup))
+            let sem = const_uint(bm, uint(SpvMemorySemantics.WorkgroupMemory) | uint(SpvMemorySemantics.AcquireRelease))
+            if (name == "barrier") {
+                emit(bm, SEC_FUNCS, SpvOp.ControlBarrier, scope, scope, sem)
+            } else {
+                emit(bm, SEC_FUNCS, SpvOp.MemoryBarrier, scope, sem)
+            }
+            return expr
+        }
+        // atomics: atomicAdd/Min/Max/And/Or/Xor/Exchange/CompSwap on a @workgroup or @ssbo lvalue,
+        // returning the OLD value. The mem param is a reference (T&), so the first arg stays an lvalue
+        // and ptr_of recovers its pointer (peel a defensive ExprRef2Value in case daslang loaded it).
+        // Scope = Workgroup for shared memory, Device for buffer memory; Relaxed semantics (glslang's
+        // default for GLSL atomics). 6-operand shape -> emit_n; CompSwap adds a comparator + neq-sem.
+        let acls = empty(expr.arguments) ? -1 : scalar_class(expr.arguments[0]._type.baseType)
+        let ainfo = atomic_info(name, acls)
+        if (ainfo.ok) {
+            let nargs = ainfo.compswap ? 3 : 2
+            if (length(expr.arguments) != nargs) {
+                errs |> push("{name} expects {nargs} arguments")
+                return expr
+            }
+            if (acls != 0 && acls != 1) {
+                errs |> push("{name}: atomic target must be int or uint")
+                return expr
+            }
+            let arg0 = expr.arguments[0]
+            let r2v = arg0 ?as ExprRef2Value
+            let lvexpr = r2v != null ? r2v.subexpr : arg0
+            let rg = root_global_of(lvexpr)
+            if (rg == null) {
+                errs |> push("{name}: target must be a @workgroup or @ssbo global lvalue")
+                return expr
+            }
+            let p = ptr_of(lvexpr)
+            if (p.id == 0u) {
+                errs |> push("{name}: target is not an addressable lvalue")
+                return expr
+            }
+            let rgi = ctx.globals?[intptr(rg)] ?? GlobalInfo()
+            let scope = rgi.storage == SpvStorageClass.Workgroup ? SpvScope.Workgroup : SpvScope.Device
+            let sc_id = const_uint(bm, uint(scope))
+            let sem_id = const_uint(bm, uint(SpvMemorySemantics.Relaxed))
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            if (ainfo.compswap) {
+                let val = value_of(expr.arguments[2])
+                let cmp = value_of(expr.arguments[1])
+                if (val == 0u || cmp == 0u) return expr
+                // OpAtomicCompareExchange: rt res ptr scope eq-sem neq-sem value comparator
+                var ops <- [rt, res, p.id, sc_id, sem_id, sem_id, val, cmp]
+                emit_n(bm, SEC_FUNCS, SpvOp.AtomicCompareExchange, ops)
+                delete ops
+            } else {
+                let val = value_of(expr.arguments[1])
+                if (val == 0u) return expr
+                var ops <- [rt, res, p.id, sc_id, sem_id, val]
+                emit_n(bm, SEC_FUNCS, ainfo.op, ops)
+                delete ops
+            }
+            e2id[k] = res
             return expr
         }
         // dFdx/dFdy/fwidth: screen-space derivatives over the 2x2 quad (OpDPdx/OpDPdy/OpFwidth).

--- a/tests/spirv/_fail_closed/_fc_atomicmem.das
+++ b/tests/spirv/_fail_closed/_fc_atomicmem.das
@@ -1,0 +1,21 @@
+// Fail-closed fixture (Phase 10.5): an atomic on a NON-writable storage class (a @uniform member;
+// only @workgroup and @ssbo memory are valid atomic targets) must be rejected cleanly by the atomic
+// handler -- never emit an OpAtomic* on read-only Uniform storage and lean on spirv-val to catch it.
+// `_`-prefix + `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+struct Ubo { scale : int }
+var @uniform @binding = 0 ubo : Ubo
+var @ssbo @binding = 1 data : array<int>
+
+[compute_shader(local_size_x=64, name="fc_atomicmem_spv")]
+def fc_atomicmem {
+    let i = gl_GlobalInvocationID.x
+    let o = atomicAdd(ubo.scale, 1)
+    data[i] = o
+}

--- a/tests/spirv/_fail_closed/_fc_wgtype.das
+++ b/tests/spirv/_fail_closed/_fc_wgtype.das
@@ -1,0 +1,20 @@
+// Fail-closed fixture (Phase 10.5): an unsupported @workgroup shared TYPE (a struct; only scalars,
+// vectors, matrices, and fixed arrays of those are emittable in Workgroup storage) must be rejected
+// cleanly by classify_global -- never reach emit_type's panic. `_`-prefix + `expect 50501` keep
+// dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @ssbo @binding = 0 data : array<uint>
+struct Foo { a : int; b : int }
+var @workgroup wgfoo : Foo
+
+[compute_shader(local_size_x=64, name="fc_wgtype_spv")]
+def fc_wgtype {
+    let i = gl_GlobalInvocationID.x
+    data[i] = uint(wgfoo.a)
+}

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -805,6 +805,62 @@ def public fragshadow_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-10.5 compute-tier fixtures: shared memory + barriers + atomics =====
+// cshared: a workgroup-shared scratch array (`@workgroup`, GLSL `shared` -> Workgroup OpVariable),
+// the control + shared-memory sync (barrier() -> OpControlBarrier, memoryBarrierShared() ->
+// OpMemoryBarrier), and an atomicAdd onto an SSBO element (OpAtomicIAdd at Device scope, since the
+// target lives in buffer memory). The canonical tiled-reduction skeleton.
+var @ssbo @binding = 0 rin : array<uint>
+var @ssbo @binding = 1 rout : array<uint>
+var @workgroup rtile : uint[64]
+
+[compute_shader(local_size_x=64, name="cshared_spv"), marker(no_coverage)]
+def cshared {
+    let lid = gl_LocalInvocationID.x
+    let gid = gl_GlobalInvocationID.x
+    rtile[lid] = rin[gid]       // store into shared memory (Workgroup OpAccessChain + OpStore)
+    barrier()                   // OpControlBarrier (execution + shared-memory rendezvous)
+    memoryBarrierShared()       // OpMemoryBarrier (shared-memory ordering)
+    let _o = atomicAdd(rout[0], rtile[lid])   // OpAtomicIAdd onto an SSBO element (Device scope)
+}
+
+// catomics: the rest of the atomic family on @workgroup int + uint scalar counters (Workgroup
+// scope). Both signednesses are present so atomicMin/Max emit BOTH the signed (SMin/SMax) and
+// unsigned (UMin/UMax) opcodes; atomicCompSwap is the OpAtomicCompareExchange CAS. The results feed
+// an SSBO write so they stay live.
+var @workgroup acnt_i : int
+var @workgroup acnt_u : uint
+var @ssbo @binding = 0 aout : array<int>
+
+[compute_shader(local_size_x=64, name="catomics_spv"), marker(no_coverage)]
+def catomics {
+    let gid = gl_GlobalInvocationID.x
+    let v = int(gid)
+    let u = gid
+    let a = atomicMin(acnt_i, v)            // OpAtomicSMin
+    let b = atomicMax(acnt_i, v)            // OpAtomicSMax
+    let c = atomicMin(acnt_u, u)            // OpAtomicUMin
+    let d = atomicMax(acnt_u, u)            // OpAtomicUMax
+    let e = atomicAnd(acnt_i, v)            // OpAtomicAnd
+    let f = atomicOr(acnt_i, v)             // OpAtomicOr
+    let g = atomicXor(acnt_i, v)            // OpAtomicXor
+    let h = atomicExchange(acnt_i, v)       // OpAtomicExchange
+    let kk = atomicCompSwap(acnt_i, 0, v)   // OpAtomicCompareExchange
+    aout[gid] = a + b + e + f + g + h + kk + int(c) + int(d)
+}
+
+def public cshared_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(cshared_spv)
+    return <- w
+}
+
+def public catomics_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(catomics_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -1064,5 +1120,24 @@ def public phase10_3_emitter_opcodes : table<uint> {
 def public phase10_4_emitter_opcodes : table<uint> {
     var s <- phase10_3_emitter_opcodes()
     s |> insert(uint(SpvOp.ImageSampleDrefImplicitLod))
+    return <- s
+}
+
+// Phase-10.5 compute tier adds twelve opcodes: the two barriers (OpControlBarrier / OpMemoryBarrier)
+// and the atomic family (IAdd, signed+unsigned Min/Max, And/Or/Xor, Exchange, CompareExchange). The
+// @workgroup shared global reuses the existing OpVariable / OpTypeArray / OpAccessChain path (a
+// Workgroup storage class, not a new opcode). Phase-10.4 set + these:
+def public phase10_5_emitter_opcodes : table<uint> {
+    var s <- phase10_4_emitter_opcodes()
+    for (op in [
+        SpvOp.ControlBarrier, SpvOp.MemoryBarrier,                  // barrier() / memoryBarrierShared()
+        SpvOp.AtomicIAdd,                                           // atomicAdd
+        SpvOp.AtomicSMin, SpvOp.AtomicUMin,                         // atomicMin (int / uint)
+        SpvOp.AtomicSMax, SpvOp.AtomicUMax,                         // atomicMax (int / uint)
+        SpvOp.AtomicAnd, SpvOp.AtomicOr, SpvOp.AtomicXor,           // atomicAnd / atomicOr / atomicXor
+        SpvOp.AtomicExchange, SpvOp.AtomicCompareExchange           // atomicExchange / atomicCompSwap
+    ]) {
+        s |> insert(uint(op))
+    }
     return <- s
 }

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -63,7 +63,9 @@ def test_opcode_census(t : T?) {
         add_set(present, gswizzle_words())
         add_set(present, fragx_words())
         add_set(present, fragshadow_words())
-        var declared <- phase10_4_emitter_opcodes()
+        add_set(present, cshared_words())
+        add_set(present, catomics_words())
+        var declared <- phase10_5_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_compute.das
+++ b/tests/spirv/test_compute.das
@@ -1,0 +1,68 @@
+options gen2
+options indenting = 4
+
+// Phase-10.5 gate: the compute tier -- shared memory, barriers, and atomics.
+//   cshared:  a @workgroup shared array (Workgroup OpVariable), barrier() -> OpControlBarrier,
+//             memoryBarrierShared() -> OpMemoryBarrier, atomicAdd onto an SSBO -> OpAtomicIAdd.
+//   catomics: the rest of the atomic family on shared int/uint counters -> OpAtomicSMin/UMin/SMax/
+//             UMax/And/Or/Xor/Exchange/CompareExchange (both signednesses present).
+// Opcode presence is asserted directly; the barrier scope/semantics operands are constant <id>s
+// (not literals), so their well-formedness is left to spirv-val -- the structural oracle for the
+// barrier-scope and atomic-pointer-storage-class rules.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_shared_and_barriers(t : T?) {
+    t |> run("compute: @workgroup shared memory + barrier() + memoryBarrierShared() + atomicAdd") <| @(t : T?) {
+        var words <- cshared_words()
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.GLCompute),
+            "cshared: EntryPoint model is GLCompute")
+        // @workgroup global -> a Workgroup-storage OpVariable. OpVariable operands:
+        // result-type(0), result-id(1), storage-class(2).
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Workgroup)),
+            "cshared: shared global is a Workgroup OpVariable")
+        t |> success(has_op(words, SpvOp.ControlBarrier), "cshared: barrier() -> OpControlBarrier")
+        t |> success(has_op(words, SpvOp.MemoryBarrier), "cshared: memoryBarrierShared() -> OpMemoryBarrier")
+        t |> success(has_op(words, SpvOp.AtomicIAdd), "cshared: atomicAdd -> OpAtomicIAdd")
+        validate(t, words, "cshared")
+        delete words
+    }
+}
+
+[test]
+def test_atomic_family(t : T?) {
+    t |> run("compute: atomic family on shared int/uint counters") <| @(t : T?) {
+        var words <- catomics_words()
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.GLCompute),
+            "catomics: EntryPoint model is GLCompute")
+        t |> success(op_has_operand_at(words, SpvOp.Variable, 2, uint(SpvStorageClass.Workgroup)),
+            "catomics: shared counters are Workgroup OpVariables")
+        // atomicMin/Max emit the signed (S) opcode for int and the unsigned (U) opcode for uint.
+        t |> success(has_op(words, SpvOp.AtomicSMin), "catomics: atomicMin(int) -> OpAtomicSMin")
+        t |> success(has_op(words, SpvOp.AtomicUMin), "catomics: atomicMin(uint) -> OpAtomicUMin")
+        t |> success(has_op(words, SpvOp.AtomicSMax), "catomics: atomicMax(int) -> OpAtomicSMax")
+        t |> success(has_op(words, SpvOp.AtomicUMax), "catomics: atomicMax(uint) -> OpAtomicUMax")
+        t |> success(has_op(words, SpvOp.AtomicAnd), "catomics: atomicAnd -> OpAtomicAnd")
+        t |> success(has_op(words, SpvOp.AtomicOr), "catomics: atomicOr -> OpAtomicOr")
+        t |> success(has_op(words, SpvOp.AtomicXor), "catomics: atomicXor -> OpAtomicXor")
+        t |> success(has_op(words, SpvOp.AtomicExchange), "catomics: atomicExchange -> OpAtomicExchange")
+        t |> success(has_op(words, SpvOp.AtomicCompareExchange), "catomics: atomicCompSwap -> OpAtomicCompareExchange")
+        validate(t, words, "catomics")
+        delete words
+    }
+}

--- a/tests/spirv/test_fail_closed.das
+++ b/tests/spirv/test_fail_closed.das
@@ -50,5 +50,7 @@ def test_fail_closed_rejections(t : T?) {
         check_rejects(t, "_fc_stmt", "memzero is not supported in SPIR-V shaders")
         check_rejects(t, "_fc_deadcode", "unreachable code after a block terminator")
         check_rejects(t, "_fc_wswz", "cannot assign through a swizzle")
+        check_rejects(t, "_fc_wgtype", "@workgroup type must be a scalar, vector, matrix, or fixed array")
+        check_rejects(t, "_fc_atomicmem", "atomic target must live in @workgroup or @ssbo memory")
     }
 }


### PR DESCRIPTION
The cross-thread-compute differentiator for the pure-daslang→SPIR-V backend (`modules/dasSpirv`). Adds the three pieces a real compute shader needs beyond per-invocation arithmetic: **workgroup-shared memory**, the **barrier** sync primitives, and the **atomic** read-modify-write family.

### What landed

- **`@workgroup` shared memory → Workgroup-storage `OpVariable`** (GLSL `shared`). Scalar, vector, or fixed-array globals. Not a descriptor and not in the entry interface (Workgroup is neither Input nor Output, SPIR-V ≤ 1.3), so no set/binding and nothing reflected; compute-only. A shared fixed-array indexes through `visitExprAt`'s new Workgroup branch — a **bare** array (single-index `OpAccessChain`), with no member-0 indirection like an SSBO's Block-wrapped array.
- **`barrier()` → `OpControlBarrier`, `memoryBarrierShared()` → `OpMemoryBarrier`**, both at Workgroup scope with `WorkgroupMemory | AcquireRelease` (= 264) semantics, matching glslang. `barrier()` is the execution + shared-memory rendezvous (the tiled-reduction sync point); `memoryBarrierShared()` is the memory-only ordering. Compute-only; neither is a block terminator. No extra capability (base `Shader`).
- **Atomics → `OpAtomic*`.** `atomicAdd` / `atomicMin` / `atomicMax` / `atomicAnd` / `atomicOr` / `atomicXor` / `atomicExchange` / `atomicCompSwap` on a `@workgroup` or `@ssbo` int/uint lvalue, returning the OLD value. `atomicMin`/`Max` pick the signed (`SMin`/`SMax`) or unsigned (`UMin`/`UMax`) opcode by operand signedness; `atomicCompSwap` is the `OpAtomicCompareExchange` CAS. Memory scope = Workgroup for shared targets, Device for buffer targets (read off the target's root-global storage class); Relaxed semantics (the glslang default). No extra capability for 32-bit integer atomics (lavapipe-safe).

### Design notes (load-bearing)

1. **`@shared` is a reserved keyword** (`var @shared x` is a parse error, same class as the `block` collision in 10.1) → the annotation is spelled **`@workgroup`** (the SPIR-V storage-class name).
2. **The atomic target is a reference parameter (`mem : T&`), not by-value.** A by-value workhorse param makes daslang insert an `ExprRef2Value` load around the lvalue arg — a wasted `OpLoad`. A `T&` ref keeps the arg an lvalue, so the emitter recovers its pointer directly. `root_global_of` walks the lvalue chain (`ExprAt`/`ExprField`/`ExprSwizzle`/`ExprRef2Value` → root `ExprVar`) to read the storage class for the memory scope.

### Tests / gates

- Twelve new census opcodes (`OpControlBarrier`/`OpMemoryBarrier` + the ten atomics); census bumped to `phase10_5_emitter_opcodes`.
- Two fixtures: `cshared` (shared array + both barriers + `atomicAdd` onto an SSBO) and `catomics` (the rest of the family on int+uint shared counters, both signednesses present). New `test_compute.das` gate.
- **interp + JIT 104/104**, spirv-val clean (vulkan1.1) on every blob, external `spirv-dis` confirms textbook lowering (shared scalar atomics at Workgroup scope, the SSBO `atomicAdd` at Device scope), lint + format clean.

Durable record appended to `modules/dasSpirv/MASTERPLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)