### PR TITLE
dasSpirv: imageSize() + module-scope shader constants

### DIFF
--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -1412,3 +1412,13 @@ the core" pass. One new census opcode (`OpImageQuerySize`); 108/108, spirv-val c
    wrong (it is memory the shader can write). Gating on the const-qualified type keeps `var` globals on
    the fail-closed `unsupported global` path (the `_fc_global` fixture in test_fail_closed.das proves the
    rejection), while `let` globals fold. Compilation succeeding at all is the positive fold proof.
+2. **All `spirv_builtins.das` stubs are now `[sideeffects]` — the macro runs POST-infer, so a folded
+   stub call would lower wrong.** `generate_spirv` is called from the annotation's `patch` override (the
+   `patchAnnotations` pass), which runs *after* inference. The stubs have empty/constant bodies +
+   `[unused_argument]`, so the analyzer would see them as pure — a pure constant-returning call
+   (`imageSize` → `int2(0,0)`) or a pure void call (`discard`/`barrier`) is exactly what const-fold /
+   dead-code-elimination target. They survived only because daslang infer doesn't inline-and-fold
+   arbitrary calls and the optimize passes run after patch — pass-ordering luck, not a guarantee.
+   `[sideeffects]` sets `Function::sideEffectFlags`, so `ast_const_folding.cpp` marks every such call
+   `noSideEffects=false` and no pass folds/elides/CSEs it. The declarations are now honest: these stubs
+   model GPU side-effecting operations. (Boris's catch on the imageSize stub in the PR.)

--- a/modules/dasSpirv/MASTERPLAN.md
+++ b/modules/dasSpirv/MASTERPLAN.md
@@ -1389,3 +1389,26 @@ lint + format clean.
    (`ExprAt`/`ExprField`/`ExprSwizzle`/`ExprRef2Value` → root `ExprVar`) to read the storage class for the
    memory scope. External `spirv-dis` verified: shared scalar atomics at `%uint_2` (Workgroup) scope, the
    SSBO `atomicAdd` at `%uint_1` (Device).
+
+### Phase 10.6 — imageSize + module-scope shader constants LANDED (2026-06-15, branch `bbatkin/dasspirv-shader-const-imagesize`)
+
+Two small emitter rails surfaced by the Mandelbrot tutorial (Phase 11) — the "gaps show up, we fix at
+the core" pass. One new census opcode (`OpImageQuerySize`); 108/108, spirv-val clean.
+
+- **`imageSize(image2D)` → `OpImageQuerySize`.** The storage image's dimensions in texels, NO LOD — a
+  storage image is `Sampled=2`, so the no-LOD query is legal (unlike `textureSize`, which needs a LOD
+  operand and emits `OpImageQuerySizeLod` on a `Sampled=1` image). Loads the UniformConstant image, then
+  queries; pulls in the `ImageQuery` capability via the shared `ensure_image_query` guard. Lets a compute
+  shader size its pixel↔coordinate mapping off the bound image instead of a hardcoded extent.
+- **Module-scope `let` constants.** An immutable `let X = <const-expr>` at module scope folds (via
+  `emit_const`) to an `OpConstant` / `OpConstantComposite` and references resolve straight to the id (no
+  `OpVariable` / `OpLoad`) — so a shader can hoist iteration counts, view rectangles, etc. to module scope
+  and share them with the host. `GlobalInfo` carries `is_constant` + `const_id`; `visitExprVar`'s global
+  else-branch resolves a constant global to its folded id.
+
+**Findings (load-bearing):**
+1. **The fold gate is `v._type.flags.constant` (an immutable `let`), NOT just "has a const-foldable
+   init".** A mutable `var g : uint = 2u` global has a const initializer too, but folding it would be
+   wrong (it is memory the shader can write). Gating on the const-qualified type keeps `var` globals on
+   the fail-closed `unsupported global` path (the `_fc_global` fixture in test_fail_closed.das proves the
+   rejection), while `let` globals fold. Compilation succeeding at all is the positive fold proof.

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -115,6 +115,14 @@ def public imageLoad(img : image2D; coord : int2) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
 
+// imageSize is a stub too: it lowers to OpImageQuerySize (the storage image's dimensions in texels,
+// no LOD). Lets a compute shader size its pixel<->coordinate mapping off the bound image instead of a
+// hardcoded constant.
+[unused_argument(img)]
+def public imageSize(img : image2D) : int2 {
+    return int2(0, 0)
+}
+
 // ===== fragment realism =====
 // discard() abandons the current fragment (OpKill). It is a block terminator, so it must be the last
 // statement on its control-flow path (typically `if (cond) { discard() }`); fragment-only.

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -31,21 +31,21 @@ var gl_FragDepth            : float     // BuiltIn FragDepth (Output) — writin
 // stub: its body is never executed (only the AST is read), and the call lowers to OpImageSampleImplicitLod.
 struct sampler2D {}
 
-[unused_argument(s, uv)]
+[unused_argument(s, uv), sideeffects]
 def public texture(s : sampler2D; uv : float2) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
 
 // textureLod samples with an EXPLICIT level-of-detail (OpImageSampleExplicitLod): no screen-space
 // derivatives, so unlike texture() it is valid in any stage (vertex/compute), not fragment-only.
-[unused_argument(s, uv, lod)]
+[unused_argument(s, uv, lod), sideeffects]
 def public textureLod(s : sampler2D; uv : float2; lod : float) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
 
 // texelFetch reads a single texel by integer coordinate + mip level, unfiltered (OpImage to extract the
 // image from the sampled image, then OpImageFetch). Stage-agnostic (no derivatives).
-[unused_argument(s, coord, lod)]
+[unused_argument(s, coord, lod), sideeffects]
 def public texelFetch(s : sampler2D; coord : int2; lod : int) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
@@ -59,17 +59,17 @@ struct sampler3D {}
 struct samplerCube {}
 struct sampler2DArray {}
 
-[unused_argument(s, uv)]
+[unused_argument(s, uv), sideeffects]
 def public texture(s : sampler3D; uv : float3) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
 
-[unused_argument(s, uv)]
+[unused_argument(s, uv), sideeffects]
 def public texture(s : samplerCube; uv : float3) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
 
-[unused_argument(s, uv)]
+[unused_argument(s, uv), sideeffects]
 def public texture(s : sampler2DArray; uv : float3) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
@@ -82,7 +82,7 @@ def public texture(s : sampler2DArray; uv : float3) : float4 {
 // fragment-only. The stub body never runs — only the call AST is lowered.
 struct sampler2DShadow {}
 
-[unused_argument(s, uv, compare)]
+[unused_argument(s, uv, compare), sideeffects]
 def public textureCompare(s : sampler2DShadow; uv : float2; compare : float) : float {
     return 0.0
 }
@@ -95,7 +95,7 @@ def public textureCompare(s : sampler2DShadow; uv : float2; compare : float) : f
 struct texture2D {}
 struct sampler {}
 
-[unused_argument(tex, smp, uv)]
+[unused_argument(tex, smp, uv), sideeffects]
 def public sampleTexture(tex : texture2D; smp : sampler; uv : float2) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
@@ -107,10 +107,10 @@ def public sampleTexture(tex : texture2D; smp : sampler; uv : float2) : float4 {
 // format means no StorageImageRead/WriteWithoutFormat capability is required (lavapipe-safe).
 struct image2D {}
 
-[unused_argument(img, coord, value)]
+[unused_argument(img, coord, value), sideeffects]
 def public imageStore(img : image2D; coord : int2; value : float4) : void {}
 
-[unused_argument(img, coord)]
+[unused_argument(img, coord), sideeffects]
 def public imageLoad(img : image2D; coord : int2) : float4 {
     return float4(0.0, 0.0, 0.0, 0.0)
 }
@@ -118,7 +118,7 @@ def public imageLoad(img : image2D; coord : int2) : float4 {
 // imageSize is a stub too: it lowers to OpImageQuerySize (the storage image's dimensions in texels,
 // no LOD). Lets a compute shader size its pixel<->coordinate mapping off the bound image instead of a
 // hardcoded constant.
-[unused_argument(img)]
+[unused_argument(img), sideeffects]
 def public imageSize(img : image2D) : int2 {
     return int2(0, 0)
 }
@@ -126,34 +126,35 @@ def public imageSize(img : image2D) : int2 {
 // ===== fragment realism =====
 // discard() abandons the current fragment (OpKill). It is a block terminator, so it must be the last
 // statement on its control-flow path (typically `if (cond) { discard() }`); fragment-only.
+[sideeffects]
 def public discard() : void {}
 
 // Screen-space partial derivatives over the 2x2 fragment quad: dFdx/dFdy (OpDPdx/OpDPdy), and
 // fwidth = |dFdx| + |dFdy| (OpFwidth). Fragment-only. Concrete per-width overloads (NOT a generic):
 // the emitter dispatches by the call name, and a generic instance carries a mangled name the
 // name-match would miss. The stub bodies are never executed — only the call AST is lowered.
-[unused_argument(p)] def public dFdx(p : float) : float { return p }
-[unused_argument(p)] def public dFdx(p : float2) : float2 { return p }
-[unused_argument(p)] def public dFdx(p : float3) : float3 { return p }
-[unused_argument(p)] def public dFdx(p : float4) : float4 { return p }
-[unused_argument(p)] def public dFdy(p : float) : float { return p }
-[unused_argument(p)] def public dFdy(p : float2) : float2 { return p }
-[unused_argument(p)] def public dFdy(p : float3) : float3 { return p }
-[unused_argument(p)] def public dFdy(p : float4) : float4 { return p }
-[unused_argument(p)] def public fwidth(p : float) : float { return p }
-[unused_argument(p)] def public fwidth(p : float2) : float2 { return p }
-[unused_argument(p)] def public fwidth(p : float3) : float3 { return p }
-[unused_argument(p)] def public fwidth(p : float4) : float4 { return p }
+[unused_argument(p), sideeffects] def public dFdx(p : float) : float { return p }
+[unused_argument(p), sideeffects] def public dFdx(p : float2) : float2 { return p }
+[unused_argument(p), sideeffects] def public dFdx(p : float3) : float3 { return p }
+[unused_argument(p), sideeffects] def public dFdx(p : float4) : float4 { return p }
+[unused_argument(p), sideeffects] def public dFdy(p : float) : float { return p }
+[unused_argument(p), sideeffects] def public dFdy(p : float2) : float2 { return p }
+[unused_argument(p), sideeffects] def public dFdy(p : float3) : float3 { return p }
+[unused_argument(p), sideeffects] def public dFdy(p : float4) : float4 { return p }
+[unused_argument(p), sideeffects] def public fwidth(p : float) : float { return p }
+[unused_argument(p), sideeffects] def public fwidth(p : float2) : float2 { return p }
+[unused_argument(p), sideeffects] def public fwidth(p : float3) : float3 { return p }
+[unused_argument(p), sideeffects] def public fwidth(p : float4) : float4 { return p }
 
 // textureSize(sampler, lod): the mip-level dimensions in texels (OpImageQuerySizeLod; needs the
 // ImageQuery capability). int2 for 2D/Cube, int3 for 3D / 2D-array (width,height,depth-or-layers).
-[unused_argument(s, lod)]
+[unused_argument(s, lod), sideeffects]
 def public textureSize(s : sampler2D; lod : int) : int2 { return int2(0, 0) }
-[unused_argument(s, lod)]
+[unused_argument(s, lod), sideeffects]
 def public textureSize(s : samplerCube; lod : int) : int2 { return int2(0, 0) }
-[unused_argument(s, lod)]
+[unused_argument(s, lod), sideeffects]
 def public textureSize(s : sampler3D; lod : int) : int3 { return int3(0, 0, 0) }
-[unused_argument(s, lod)]
+[unused_argument(s, lod), sideeffects]
 def public textureSize(s : sampler2DArray; lod : int) : int3 { return int3(0, 0, 0) }
 
 // ===== compute synchronization =====
@@ -162,7 +163,9 @@ def public textureSize(s : sampler2DArray; lod : int) : int3 { return int3(0, 0,
 // visible to all after it. The must-have sync point for shared-memory compute (the tiled-reduction
 // pattern). memoryBarrierShared() is the memory-only variant (OpMemoryBarrier) -- it orders shared
 // writes without the execution rendezvous. Both compute-only; the stub bodies never run.
+[sideeffects]
 def public barrier() : void {}
+[sideeffects]
 def public memoryBarrierShared() : void {}
 
 // ===== atomics =====
@@ -172,21 +175,21 @@ def public memoryBarrierShared() : void {}
 // SMax/UMax by the operand's signedness). Lowered to OpAtomicIAdd/SMin/.../Exchange/CompareExchange
 // at Workgroup scope (shared) or Device scope (buffer). The stub bodies never run -- only the call
 // AST is read. Use as `let old = atomicAdd(counter, 1)`.
-[unused_argument(value)] def public atomicAdd(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicAdd(mem : uint &; value : uint) : uint { return mem }
-[unused_argument(value)] def public atomicMin(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicMin(mem : uint &; value : uint) : uint { return mem }
-[unused_argument(value)] def public atomicMax(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicMax(mem : uint &; value : uint) : uint { return mem }
-[unused_argument(value)] def public atomicAnd(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicAnd(mem : uint &; value : uint) : uint { return mem }
-[unused_argument(value)] def public atomicOr(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicOr(mem : uint &; value : uint) : uint { return mem }
-[unused_argument(value)] def public atomicXor(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicXor(mem : uint &; value : uint) : uint { return mem }
-[unused_argument(value)] def public atomicExchange(mem : int &; value : int) : int { return mem }
-[unused_argument(value)] def public atomicExchange(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicAdd(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicAdd(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicMin(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicMin(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicMax(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicMax(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicAnd(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicAnd(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicOr(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicOr(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicXor(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicXor(mem : uint &; value : uint) : uint { return mem }
+[unused_argument(value), sideeffects] def public atomicExchange(mem : int &; value : int) : int { return mem }
+[unused_argument(value), sideeffects] def public atomicExchange(mem : uint &; value : uint) : uint { return mem }
 // atomicCompSwap(mem, compare, value): if mem == compare, store value; returns the OLD value either
 // way (OpAtomicCompareExchange). The lock-free CAS primitive.
-[unused_argument(compare, value)] def public atomicCompSwap(mem : int &; compare, value : int) : int { return mem }
-[unused_argument(compare, value)] def public atomicCompSwap(mem : uint &; compare, value : uint) : uint { return mem }
+[unused_argument(compare, value), sideeffects] def public atomicCompSwap(mem : int &; compare, value : int) : int { return mem }
+[unused_argument(compare, value), sideeffects] def public atomicCompSwap(mem : uint &; compare, value : uint) : uint { return mem }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -37,6 +37,8 @@ struct GlobalInfo {
     is_separate_image : bool        // a standalone sampled image (texture2D, OpTypeImage); combined at the call via OpSampledImage
     is_separate_sampler : bool      // a standalone sampler (OpTypeSampler)
     elem_type  : uint               // SSBO runtime-array element type-id (vec/struct elements can't go through emit_type)
+    is_constant : bool              // a module-scope `let X = <const>` folded to an OpConstant; references resolve to const_id directly (no OpVariable / OpLoad)
+    const_id   : uint               // the OpConstant result-id (when is_constant)
 }
 
 // A memory-backed local: an OpVariable in Function storage. Mutable locals (`var x`) and loop
@@ -484,7 +486,21 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.Workgroup, value_type = vt, is_ssbo = false))
         return
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, or a sampler type e.g. sampler2D)")
+    // module-scope constant: an immutable `let X = <const-expr>` referenced by the shader body. Fold the
+    // initializer to an OpConstant and resolve references straight to it (no OpVariable / OpLoad), so a
+    // shader can hoist view rectangles, iteration counts, etc. to module scope and share them with the
+    // host. Gated on a const-qualified type (a `let`, not a `var`) AND a const-foldable initializer;
+    // a mutable `var` global, or a non-const initializer, falls through to the error below.
+    if (v.init != null && v._type != null && v._type.flags.constant) {
+        var probe : array<string>
+        let cc = emit_const(m, v.init, probe)
+        delete probe
+        if (cc.ok) {
+            ctx.globals |> insert(intptr(v), GlobalInfo(value_type = emit_type(m, v._type), is_constant = true, const_id = cc.id))
+            return
+        }
+    }
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, a constant `let`, or a sampler type e.g. sampler2D)")
 }
 
 // ===== member index of a struct field by name =====
@@ -1155,11 +1171,15 @@ class SpirvEmit : AstVisitor {
             }
         } else {
             let gi = ctx.globals?[intptr(expr.variable)] ?? GlobalInfo()
-            if (gi.var_id == 0u) {   // referenced global was not classified (unsupported / not collected)
-                errs |> push("global '{expr.name}' is not classified")
+            if (gi.is_constant) {   // module-scope constant let -> the folded OpConstant id directly (no pointer/load)
+                e2id[k] = gi.const_id
+            } else {
+                if (gi.var_id == 0u) {   // referenced global was not classified (unsupported / not collected)
+                    errs |> push("global '{expr.name}' is not classified")
+                }
+                e2ptr[k] = gi.var_id
+                e2pty[k] = gi.value_type
             }
-            e2ptr[k] = gi.var_id
-            e2pty[k] = gi.value_type
         }
         return expr
     }
@@ -1889,6 +1909,32 @@ class SpirvEmit : AstVisitor {
             let rt = emit_type(bm, expr._type)
             let res = alloc_id(bm)
             emit(bm, SEC_FUNCS, SpvOp.ImageRead, rt, res, imgval, coord)
+            e2id[k] = res
+            return expr
+        }
+        // imageSize(image) : int2: the storage image's dimensions in texels (OpImageQuerySize, no LOD --
+        // a storage image is Sampled=2, so the no-LOD query is legal). Needs the ImageQuery capability.
+        if (name == "imageSize") {
+            if (length(expr.arguments) != 1) {
+                errs |> push("imageSize expects (image)")
+                return expr
+            }
+            let ig = global_var_of(expr.arguments[0])
+            if (ig == null) {
+                errs |> push("imageSize: argument must be a storage-image global")
+                return expr
+            }
+            let gi = ctx.globals?[intptr(ig)] ?? GlobalInfo()
+            if (!gi.is_storage_image) {
+                errs |> push("imageSize: '{ig.name}' is not a storage image")
+                return expr
+            }
+            ensure_image_query(bm, *ctx)
+            let imgval = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, imgval, gi.var_id)
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.ImageQuerySize, rt, res, imgval)
             e2id[k] = res
             return expr
         }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -861,6 +861,54 @@ def public catomics_words : array<uint> {
     return <- w
 }
 
+// ===== Phase-10.6 storage-image size query + module-scope shader constants =====
+// imgquery: imageSize(img) -> OpImageQuerySize (the storage image's dimensions in texels, NO LOD --
+// a storage image is Sampled=2 so the no-LOD query is legal, unlike textureSize which needs a LOD).
+// Pulls in the ImageQuery capability. Lets a compute shader size its pixel<->coordinate mapping off
+// the bound image instead of a hardcoded extent (the Mandelbrot-tutorial rail).
+var @binding = 0 qimg : image2D
+[compute_shader(local_size_x=8, local_size_y=8, name="imgquery_spv"), marker(no_coverage)]
+def imgquery {
+    let gid = gl_GlobalInvocationID
+    let dim = imageSize(qimg)                            // OpImageQuerySize -> int2
+    let coord = int2(int(gid.x), int(gid.y))
+    let u = float(gid.x) / float(dim.x)                  // the queried size feeds the mapping
+    let v = float(gid.y) / float(dim.y)
+    imageStore(qimg, coord, float4(u, v, 0.0f, 1.0f))
+}
+
+// modconst: module-scope shader constants. An immutable `let X = <const-expr>` at module scope folds to
+// an OpConstant and references resolve straight to it (no OpVariable / OpLoad) -- so a shader can hoist
+// iteration counts, view rectangles, etc. to module scope and share them with the host. Scalar (float +
+// int) and a folded const-vector module const are all exercised. Counterpart fail-closed case (a mutable
+// `var` global must still be rejected) lives in test_fail_closed.das.
+let MC_LO = -2.0f
+let MC_HI = 1.0f
+let MC_ITER = 16
+let MC_BASE = float2(0.5, 0.5)
+[compute_shader(local_size_x=64, name="modconst_spv"), marker(no_coverage)]
+def modconst {
+    let i = gl_GlobalInvocationID.x
+    var acc = MC_LO + float(MC_ITER)        // module-scope float + int consts as rvalues
+    for (k in range(MC_ITER)) {             // int const as a loop bound
+        acc += MC_HI
+    }
+    let b = MC_BASE                          // folded const-vector module const
+    fdata[i] = acc + b.x
+}
+
+def public imgquery_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(imgquery_spv)
+    return <- w
+}
+
+def public modconst_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(modconst_spv)
+    return <- w
+}
+
 // ===== spirv-val gate =====
 struct SpirvValResult {
     ran : bool      // false => tool not found (soft-skip locally; CI provides it)
@@ -1139,5 +1187,14 @@ def public phase10_5_emitter_opcodes : table<uint> {
     ]) {
         s |> insert(uint(op))
     }
+    return <- s
+}
+
+// Phase-10.6 adds the storage-image size query (imageSize -> OpImageQuerySize, the no-LOD sibling of
+// Phase-10.3's OpImageQuerySizeLod). Module-scope shader constants add NO new opcodes: a folded `let`
+// global resolves straight to its already-declared OpConstant/OpConstantComposite. Phase-10.5 set + this:
+def public phase10_6_emitter_opcodes : table<uint> {
+    var s <- phase10_5_emitter_opcodes()
+    s |> insert(uint(SpvOp.ImageQuerySize))     // imageSize(img)
     return <- s
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -890,7 +890,7 @@ let MC_BASE = float2(0.5, 0.5)
 def modconst {
     let i = gl_GlobalInvocationID.x
     var acc = MC_LO + float(MC_ITER)        // module-scope float + int consts as rvalues
-    for (k in range(MC_ITER)) {             // int const as a loop bound
+    for (_k in range(MC_ITER)) {            // int const as a loop bound (counter unused)
         acc += MC_HI
     }
     let b = MC_BASE                          // folded const-vector module const

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -65,7 +65,9 @@ def test_opcode_census(t : T?) {
         add_set(present, fragshadow_words())
         add_set(present, cshared_words())
         add_set(present, catomics_words())
-        var declared <- phase10_5_emitter_opcodes()
+        add_set(present, imgquery_words())
+        add_set(present, modconst_words())
+        var declared <- phase10_6_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_storage_image.das
+++ b/tests/spirv/test_storage_image.das
@@ -46,3 +46,37 @@ def test_storage_image_compute(t : T?) {
         delete words
     }
 }
+
+[test]
+def test_image_size_query(t : T?) {
+    t |> run("imageSize(storage image) -> OpImageQuerySize + ImageQuery capability") <| @(t : T?) {
+        var words <- imgquery_words()
+        t |> success(has_op(words, SpvOp.ImageQuerySize), "imgquery: imageSize -> OpImageQuerySize")
+        // the no-LOD query: must NOT emit the LOD variant (that one is textureSize's, Sampled=1 images)
+        t |> success(!has_op(words, SpvOp.ImageQuerySizeLod),
+            "imgquery: storage-image query is the no-LOD OpImageQuerySize, not OpImageQuerySizeLod")
+        // OpImageQuerySize takes (result_type, result_id, image) -- the image operand is the loaded
+        // storage image, so an OpLoad of the UniformConstant image must precede it
+        t |> success(has_op(words, SpvOp.Load), "imgquery: loads the storage image before the query")
+        t |> success(op_has_operand_at(words, SpvOp.Capability, 0, uint(SpvCapability.ImageQuery)),
+            "imgquery: imageSize pulls in OpCapability ImageQuery")
+        validate(t, words, "imgquery")
+        delete words
+    }
+}
+
+[test]
+def test_module_scope_const(t : T?) {
+    t |> run("module-scope `let` constants fold to OpConstant / OpConstantComposite") <| @(t : T?) {
+        var words <- modconst_words()
+        // Compilation succeeding at all is the fold proof: a non-folded module-scope const falls through
+        // to the fail-closed `unsupported global` error (see test_fail_closed.das for the `var` rejection).
+        // Here we pin the positive structure -- the folded scalar consts become OpConstant, the const-
+        // vector becomes OpConstantComposite, referenced straight by id (no OpVariable / OpLoad).
+        t |> success(has_op(words, SpvOp.Constant), "modconst: scalar module consts -> OpConstant")
+        t |> success(has_op(words, SpvOp.ConstantComposite),
+            "modconst: const-vector module const -> OpConstantComposite")
+        validate(t, words, "modconst")
+        delete words
+    }
+}


### PR DESCRIPTION
Two small dasSpirv emitter rails surfaced by the Mandelbrot tutorial (the upcoming dasVulkan tutorial 02) — the "gaps show up, we fix at the core" pass rather than working around them in the tutorial — plus a const-fold hardening pass on the shader builtin stubs.

## `imageSize(image2D)` → `OpImageQuerySize`

A storage image's dimensions in texels, **no LOD** — a storage image is `Sampled=2`, so the no-LOD query is legal (unlike `textureSize`, which needs a LOD operand and emits `OpImageQuerySizeLod` on a `Sampled=1` image). The handler loads the UniformConstant image, then queries; the `ImageQuery` capability is pulled in via the existing `ensure_image_query` guard. This lets a compute shader size its pixel↔coordinate mapping off the bound image instead of a hardcoded extent.

`spirv_builtins.das` gains the `imageSize` stub (mirrors `imageLoad`/`imageStore`).

## Module-scope `let` constants

An immutable `let X = <const-expr>` at module scope now folds (via `emit_const`) to an `OpConstant` / `OpConstantComposite`, and references resolve straight to the id (no `OpVariable` / `OpLoad`) — so a shader can hoist iteration counts, view rectangles, etc. to module scope and share them with the host. `GlobalInfo` carries `is_constant` + `const_id`; `visitExprVar`'s global else-branch resolves a constant global to its folded id.

**Fail-closed gate:** the fold is gated on `v._type.flags.constant` (an immutable `let`), **not** merely "has a const-foldable init". A mutable `var g : uint = 2u` global has a const initializer too, but folding it would be wrong (it is memory the shader can write), so `var` globals stay on the `unsupported global` error path — the existing `_fc_global` fixture in `test_fail_closed.das` proves that rejection still fires.

## Const-fold hardening: all builtin stubs marked `[sideeffects]`

`generate_spirv` runs in the annotation's `patch` override (the `patchAnnotations` pass), which runs **after inference** — the macro reads a body inference has already walked. The `spirv_builtins.das` stubs have empty/constant bodies + `[unused_argument]`, so the analyzer sees them as *pure*: a pure constant-returning call (`imageSize` → `int2(0,0)`) or a pure void call (`discard`/`barrier`) is exactly what const-fold / dead-code-elimination target. They survived today only because daslang infer doesn't inline-and-fold arbitrary calls and the optimize passes run *after* patch — pass-ordering luck, not a guarantee.

`[sideeffects]` sets `Function::sideEffectFlags`, so `ast_const_folding.cpp` marks every such call `noSideEffects=false` and no pass folds/elides/CSEs it. The declarations now honestly model GPU side-effecting operations. (Thanks @borisbat for catching this on the `imageSize` stub.)

## Tests

- **`imgquery` fixture** — opcode-shape test asserts `OpImageQuerySize` present, the LOD variant absent, the image loaded first, the `ImageQuery` capability pulled in, and the blob spirv-val clean.
- **`modconst` fixture** — float/int scalar + a folded const-vector module constant referenced from a shader body; asserts the folded `OpConstant`/`OpConstantComposite` are emitted and the blob validates (compilation succeeding at all is the fold proof).
- New `phase10_6_emitter_opcodes` census adds `OpImageQuerySize`; both fixtures join the census union.

Full dasSpirv suite **108/108**, spirv-val-clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)