### PR TITLE
Allocate arrays instantly on heap

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -75,6 +75,12 @@ Small-table regime micro-benchmarks (N from 1 to 64) — the load profile the la
 | `test01.das` | emplace, emplace_grow, move, and reserve on arrays of locked vs unlocked struct elements |
 | `test02.das` | push vs push_clone — int and struct with string field (10K elements, pre-reserved) |
 
+## core/array_literal/
+
+| File | Description |
+|---|---|
+| `build.das` | array/table literal build cost — `[..]` / `array<T>(..)` / `{..}` built directly on the heap (no stack `T[N]` + memcpy), for ints, structs, and tables |
+
 ## core/array_lock/
 
 | File | Description |

--- a/benchmarks/core/array_literal/build.das
+++ b/benchmarks/core/array_literal/build.das
@@ -1,0 +1,31 @@
+// array/table literal build benchmark. A gen2 literal feeding to_array_move/to_table_move
+// (`[..]`, `array<T>(..)`, `{..}`) builds the array<T> directly on the heap — no stack T[N]
+// + memcpy. Each iteration move-assigns a fresh literal into a global: the move finalizes the
+// previous value (no leak) and the store keeps the build live (not dead-code-eliminated).
+options gen2
+options persistent_heap
+options no_aot
+
+require dastest/testing_boost
+
+struct Vec {
+    x, y, z, w : float
+}
+
+var gInts : array<int>
+var gVecs : array<Vec>
+var gTab : table<int; int>
+
+[benchmark]
+def bench_array_literal(b : B?) {
+    b |> run("array_literal/ints_12") {
+        gInts <- [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]
+    }
+    b |> run("array_literal/vecs_8") {
+        gVecs <- [Vec(x = 1.0), Vec(y = 2.0), Vec(z = 3.0), Vec(w = 4.0),
+                  Vec(x = 5.0), Vec(y = 6.0), Vec(z = 7.0), Vec(w = 8.0)]
+    }
+    b |> run("array_literal/table_8") {
+        gTab <- {1 => 10, 2 => 20, 3 => 30, 4 => 40, 5 => 50, 6 => 60, 7 => 70, 8 => 80}
+    }
+}

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -3292,8 +3292,14 @@ class public CppAot : AstVisitor {
         if (!needTempSrc(expr)) {
             write(*ss, "{tabs()}{describeCppType(expr._type,DescribeConfig(skip_ref=true,cross_platform=cross_platform))} {mkaName(expr)};\n");
         }
-        if (!expr.makeFlags.initAllFields) {
+        if (!expr.makeFlags.initAllFields || expr.makeArrayOnHeap) {
             write(*ss, "{tabs()}das_zero({mkaName(expr)});\n");
+        }
+        if (expr.makeArrayOnHeap) {
+            // build the dynamic array<T> on the heap directly (mirrors interp SimNode_MakeArrayHeap):
+            // size it once, then the per-element writes below land straight into the heap buffer.
+            let elem_str = describeCppType(expr.recordType, DescribeConfig(skip_ref = true, skip_const = true, cross_platform = cross_platform));
+            write(*ss, "{tabs()}builtin_array_resize({mkaName(expr)},{length(expr.values)},sizeof({elem_str}),__context__,nullptr);\n");
         }
     }
     def override preVisitExprMakeArrayIndex(expr : ExprMakeArray?; index : int; init : ExpressionPtr; last : bool) {

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -1403,6 +1403,13 @@ def to_array(var arr : array<auto(TT)>) : array<TT -const -#> {
     return <- arr
 }
 
+def to_array_move(var a : array<auto(TT)>) : array<TT -const> {
+    //! Already an `array` — move it through unchanged. Chosen at compile time over the fixed-array
+    //! overload for gen2 literals the inferer built directly on the heap (makeArrayOnHeap), so
+    //! `[..]` / `array<T>(..)` skip the stack `T[N]` + bulk copy.
+    return <- a
+}
+
 def to_array_move(var a : auto(TT)[]) : array<TT -const> {
     unsafe {
         var arr : array<TT -const>

--- a/doc/source/stdlib/handmade/structure_annotation-ast-ExprMakeArray.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-ast-ExprMakeArray.rst
@@ -12,4 +12,5 @@ Flags specific to make-local expressions
 Type of the array elements
 Array of expressions for the elements
 If gen2 syntax is used (i.e. `[...]` instead of `[[...]]`)
+Whether the array is built directly on the heap (set by the inferer for gen2 literals feeding to_array_move/to_table_move)
 

--- a/doc/source/stdlib/handmade/structure_annotation-ast-ExprMakeTuple.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-ast-ExprMakeTuple.rst
@@ -12,5 +12,6 @@ Flags specific to make-local expressions
 Type of the array elements
 Array of expressions for the elements
 If gen2 syntax is used (i.e. `[...]` instead of `[[...]]`)
+Whether the array is built directly on the heap (set by the inferer for gen2 literals feeding to_array_move/to_table_move)
 If key-value syntax is used (i.e. `[key=>val; key2=>val2]`)
 Field names, when key-value record syntax is used

--- a/include/daScript/ast/ast_expressions.h
+++ b/include/daScript/ast/ast_expressions.h
@@ -1480,6 +1480,7 @@ namespace das
         TypeDeclPtr                 recordType = nullptr;
         vector<ExpressionPtr>       values;
         bool                        gen2 = false;
+        bool                        makeArrayOnHeap = false; // set by inferer when this gen2 literal feeds to_array_move/to_table_move: build a heap array<T> directly (no stack T[N] + copy)
     };
 
     struct DAS_API ExprMakeTuple : ExprMakeArray {

--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -64,6 +64,7 @@ namespace das {
         bool savedFoldingForStaticIf = true;    // preVisit(ExprIfThenElse) / visit(ExprIfThenElse) save-restore (block hooks skipped for static_if)
         bool savedFoldingForStaticAssert = true; // preVisit(ExprStaticAssert) / visit(ExprStaticAssert) save-restore
         bool disableAot = false;
+        bool noHeapArrayLiterals = false;       // options no_heap_array_literals: disable building gen2 [..]/{..} literals directly on the heap
         bool multiContext = false;
         bool standaloneContext = false;
         Expression *lastEnuValue = nullptr;

--- a/include/daScript/simulate/aot_builtin_jit.h
+++ b/include/daScript/simulate/aot_builtin_jit.h
@@ -37,6 +37,7 @@ namespace das {
     void * das_get_jit_array_unlock ();
     void * das_get_jit_table_lock ();
     void * das_get_jit_table_unlock ();
+    void * das_get_jit_array_resize ();
     void * das_get_jit_table_at ( int32_t baseType, Context * context, LineInfoArg * at );
     void * das_get_jit_table_erase ( int32_t baseType, Context * context, LineInfoArg * at );
     void * das_get_jit_table_find ( int32_t baseType, Context * context, LineInfoArg * at );

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -3056,6 +3056,34 @@ SIM_NODE_AT_VECTOR(Float, float)
         }
     };
 
+    // Heap array literal: build an array<T> directly on the heap. The result slot (stackTop) holds
+    // the Array value; we reserve the buffer, point abiCMRES at it so the CMRES element-write
+    // children fill it in place (no stack T[N] + copy), then publish size. Used for flagged
+    // gen2 array literals feeding to_array_move / to_table_move (see makeArrayOnHeap).
+    struct SimNode_MakeArrayHeap : SimNode_Block {
+        DAS_PTR_NODE;
+        SimNode_MakeArrayHeap ( const LineInfo & at, uint32_t sp, uint32_t count, uint32_t str )
+            : SimNode_Block(at), stackTop(sp), arrayCount(count), stride(str) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute ( Context & context ) {
+            DAS_PROFILE_NODE
+            Array * arr = (Array *)(context.stack.sp() + stackTop);
+            memset(arr, 0, sizeof(Array));
+            array_resize(context, *arr, arrayCount, stride, true, &debugInfo);
+            void * saveCMRES = context.abiCMRES;
+            context.abiCMRES = arr->data;
+            SimNode ** __restrict tail = list + total;
+            SimNode ** __restrict body = list;
+            for (; body!=tail; ++body) {
+                (*body)->eval(context);
+                if (context.stopFlags) break;
+            }
+            context.abiCMRES = saveCMRES;
+            return (char *) arr;
+        }
+        uint32_t stackTop, arrayCount, stride;
+    };
+
     struct SimNode_ReturnLocalCMRes : SimNode_Block {
         SimNode_ReturnLocalCMRes ( const LineInfo & at )
             : SimNode_Block(at) {}

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -244,6 +244,11 @@ struct TableWalkState {
 class public LlvmJitVisitor : AstVisitor {
     adapter : VisitorAdapter?
     e2v : table<Expression?; LLVMOpaqueValue?>
+    // makeArrayOnHeap literals: stack of arr.data buffer bases for heap make-arrays currently being
+    // built. getE(expr) holds the Array struct (the expression result); the top of this stack is where
+    // element make-local cmres writes go, mirroring interp's abiCMRES redirect in SimNode_MakeArrayHeap.
+    // LIFO matches visitor recursion, so nested `[[..],[..]]` just push/pop (no per-expr bookkeeping).
+    heapMkaData : array<LLVMOpaqueValue?>
     v2v : table<Variable?; LLVMOpaqueValue?>
     v2t : table<LLVMOpaqueValue?; LLVMOpaqueType?>
     call2cmres : table<Expression?; LLVMOpaqueValue?>
@@ -3481,6 +3486,18 @@ class public LlvmJitVisitor : AstVisitor {
         LLVMBuildCall2(g_builder, typ, LLVMGetNamedFunction(g_mod, FN_JIT_ARRAY_UNLOCK), params, "")
     }
 
+    def build_array_resize(array_ptr : LLVMOpaqueValue?; count : int; stride : int; at : LineInfo) {
+        var params = fixed_array(
+            array_ptr,                                                               // array (already voidptr)
+            types.ConstI32(uint64(count)),                                           // newSize
+            types.ConstI32(uint64(stride)),                                          // stride
+            get_context_param(),                                                     // context
+            LLVMConstPointerNull(types.LLVMVoidPtrType())                            // at
+        )
+        var typ = g_fn_types[FN_JIT_ARRAY_RESIZE]
+        LLVMBuildCall2(g_builder, typ, LLVMGetNamedFunction(g_mod, FN_JIT_ARRAY_RESIZE), params, "")
+    }
+
     def build_iter_first(at : LineInfo; iter_ptr, data_ptr : LLVMOpaqueValue?) {
         let vdata_ptr = LLVMBuildPointerCast(g_builder, data_ptr, types.LLVMVoidPtrType(), "")
         var params = fixed_array(
@@ -4261,7 +4278,10 @@ class public LlvmJitVisitor : AstVisitor {
 // ExprMakeArray
     def override preVisitExprMakeArray(expr : ExprMakeArray?) : void {
         var mks_ptr : LLVMOpaqueValue?
-        if (return_by_cmres(expr)) {
+        // makeArrayOnHeap: the Array struct lives in the make-array's own stack slot (interp's
+        // SimNode_MakeArrayHeap returns stackTop, not the function cmres). The cmres flag set in
+        // allocate_stack only directs element writes — handled here via heapMkaData. So always alloca.
+        if (return_by_cmres(expr) && !expr.makeArrayOnHeap) {
             mks_ptr = get_cmres_param()
             mks_ptr = LLVMBuildPointerCast(g_builder, mks_ptr, LLVMPointerType(types.t_int8, 0u), "")
             if (expr.extraOffset != 0u) {
@@ -4282,6 +4302,17 @@ class public LlvmJitVisitor : AstVisitor {
                 mks_ptr = LLVMBuildGEP2(g_builder, types.t_int8, mks_ptr, types.ConstI32(uint64(expr.extraOffset)), "mka_local_sp_{expr.stackTop}_eo_{expr.extraOffset}_at_{int(expr.at.line)}_")
             }
         }
+        if (expr.makeArrayOnHeap) {
+            // build the dynamic array<T> on the heap directly (mirrors interp SimNode_MakeArrayHeap):
+            // zero the Array header, size it once, then point the per-element stores at arr.data so they
+            // land straight in the heap buffer (no stack T[N] + copy).
+            LLVMBuildMemSet(g_builder, mks_ptr, 0ul, uint64(expr._type.sizeOf), uint(expr._type.alignOf))
+            build_array_resize(mks_ptr, expr.values |> length, expr.makeType.stride, expr.at)
+            var dataPtr = LLVMBuildLoad2(g_builder, types.LLVMVoidPtrType(), mks_ptr, "mka_heap_data_{expr.at.line}")
+            setE(expr, mks_ptr)
+            heapMkaData |> push(dataPtr)
+            return
+        }
         let stride = expr.makeType.stride
         if (!expr.makeFlags.doesNotNeedInit && !expr.makeFlags.initAllFields && stride != 0) {
             let total = expr.values |> length
@@ -4295,12 +4326,17 @@ class public LlvmJitVisitor : AstVisitor {
     def override preVisitExprMakeArrayIndex(expr : ExprMakeArray?; index : int; init : ExpressionPtr; last : bool) : void {
         let stride = expr.makeType.stride
         let offset =  index * stride
+        // heap literals fill arr.data (top of heapMkaData), not the Array struct held in getE(expr)
         var v_ptr = getE(expr)
+        if (expr.makeArrayOnHeap) { v_ptr = heapMkaData |> back() }
         verify(v_ptr != null && LLVMIsUndef(v_ptr) == 0, "make array index, but no pointer")
         let record_ptr = LLVMBuildGEP2(g_builder, types.t_int8, v_ptr, types.ConstI32(uint64(offset)), "ema_ind_{index}_{expr.at.line}")
         if (init |> isMakeLocal) {
             var val = unsafe(reinterpret<ExprMakeLocal?> init)
-            if (!expr.makeFlags.useCMRES) {
+            // heap literals set useCMRES (allocate_stack) but, like interp's per-element
+            // extraLocalOffset, the element make-local must write at arr.data+offset — so use the
+            // same extraOffset+setE placement the non-CMRES path uses instead of a cmres redirect.
+            if (!expr.makeFlags.useCMRES || expr.makeArrayOnHeap) {
                 val.extraOffset = uint(offset) // + expr.extraOffset
                 setE(init, v_ptr)
             }
@@ -4313,6 +4349,7 @@ class public LlvmJitVisitor : AstVisitor {
         let stride = expr.makeType.stride
         let offset =  index * stride
         var v_ptr = getE(expr)
+        if (expr.makeArrayOnHeap) { v_ptr = heapMkaData |> back() }
         v_ptr = LLVMBuildGEP2(g_builder, types.t_int8, v_ptr, types.ConstI32(uint64(offset)), "[{index}]")
         v_ptr = LLVMBuildPointerCast(g_builder, v_ptr, get_type_pointer(expr.recordType), "")
         if (init |> isMakeLocal) {
@@ -4330,6 +4367,9 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def override visitExprMakeArray(expr : ExprMakeArray?) : ExpressionPtr {
+        if (expr.makeArrayOnHeap) {
+            heapMkaData |> pop() // children done; parent heap literal (if any) resumes on top
+        }
         var v_ptr = getE(expr)
         setE(expr, LLVMBuildPointerCast(g_builder, v_ptr, get_type_pointer(expr._type), ""))
         return expr
@@ -6835,6 +6875,8 @@ class public LlvmJitVisitor : AstVisitor {
     // (e.g. a register-sized handled value type) — then there is no cmres param to write into.
     def return_by_cmres(expr : ExprMakeLocal?) : bool {
         if (!expr.makeFlags.useCMRES) return false
+        if (!(heapMkaData |> empty)) return true
+
         if (thisBlock != null) {
             return isCMRESType(thisBlock.returnType)
         } elif (thisFunc != null) {
@@ -6844,6 +6886,11 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def get_cmres_param : LLVMOpaqueValue ? {
+        // While building a heap array literal (makeArrayOnHeap), cmres-based element make-locals must
+        // target arr.data (top of heapMkaData), not the enclosing function's cmres param.
+        if (!(heapMkaData |> empty)) {
+            return heapMkaData |> back()
+        }
         if (thisBlock != null) {
             return LLVMGetParam(ffunc, uint(thisBlock.arguments |> length + 2))
         } elif (thisFunc != null) {

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -60,6 +60,7 @@ let public FN_JIT_ARRAY_LOCK        = "jit_array_lock"
 let public FN_JIT_ARRAY_UNLOCK      = "jit_array_unlock"
 let public FN_JIT_TABLE_LOCK        = "jit_table_lock"
 let public FN_JIT_TABLE_UNLOCK      = "jit_table_unlock"
+let public FN_JIT_ARRAY_RESIZE      = "jit_array_resize"
 let public FN_JIT_STR_CMP           = "jit_str_cmp"
 let public FN_JIT_STR_CAT           = "jit_str_cat"
 let public FN_JIT_PROLOGUE          = "jit_prologue"
@@ -613,6 +614,20 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
     LLVMAddGlobalMapping(g_engine, jit_array_unlock, get_jit_array_unlock())
     LLVMAddAttributesToFunction(jit_array_unlock, fixed_array(nounwind, willreturn))
     LLVMAddAttributeToFunctionArgumentRange(jit_array_unlock, urange(0, 2), nocapture)
+    // void builtin_array_resize ( Array & array, int newSize, int stride, Context * context, LineInfoArg * at )
+    var jit_array_resize = LLVMAddFunctionWithType(g_mod, FN_JIT_ARRAY_RESIZE,
+        LLVMFunctionType(g_prim_t.t_void,
+            fixed_array<LLVMTypeRef>(
+                g_prim_t.LLVMVoidPtrType(), // arr
+                g_prim_t.t_int32,           // newSize
+                g_prim_t.t_int32,           // stride
+                g_prim_t.LLVMVoidPtrType(), // ctx
+                g_prim_t.LLVMVoidPtrType(), // lineInfo
+            )
+        ))
+    LLVMAddGlobalMapping(g_engine, jit_array_resize, get_jit_array_resize())
+    LLVMAddAttributesToFunction(jit_array_resize, fixed_array(nounwind, willreturn))
+    LLVMAddAttributeToFunctionArgumentRange(jit_array_resize, urange(0, 1), nocapture)
 
     // void jit_table_lock ( Table & tab, Context * context, LineInfoArg * at )
     var jit_table_lock = LLVMAddFunctionWithType(g_mod, FN_JIT_TABLE_LOCK,

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x26ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x27ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -2883,6 +2883,7 @@ namespace das {
             cexpr->recordType = new TypeDecl(*recordType);
         }
         cexpr->gen2 = gen2;
+        cexpr->makeArrayOnHeap = makeArrayOnHeap;
         return cexpr;
     }
 

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -806,7 +806,9 @@ namespace das {
                     logs << "\t" << cStackTop << "\t" << sz
                     << "\t[[" << expr->type->describe() << "]], line " << expr->at.line << "\n";
                 }
-                applySetRefSp(expr, false, false, cStackTop, 0);
+                // heap array literal: slot holds the array<T> value (sizeof Array); element writes
+                // go into the heap buffer via cmres (set to arr.data by SimNode_MakeArrayHeap).
+                applySetRefSp(expr, false, expr->makeArrayOnHeap, cStackTop, 0);
                 expr->doesNotNeedSp = false;
                 expr->doesNotNeedInit = false;
             }

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -228,8 +228,22 @@ namespace das {
     // call
         virtual ExpressionPtr visit ( ExprCall * expr ) override {
             if ( !expr->func ) { reportNullFunc(expr, "call"); return Visitor::visit(expr); }
-            expr->noSideEffects = (expr->func->sideEffectFlags==0);
-            expr->noNativeSideEffects = (expr->func->sideEffectFlags & uint32_t(SideEffects::inferredSideEffects))==0;
+            uint32_t sef = expr->func->sideEffectFlags;
+            expr->noSideEffects = (sef==0);
+            // A call whose ONLY effect is modifyArgument, and whose every argument is a freshly-built
+            // make-local rvalue, is side-effect-free at this site: the writes land on temporaries the
+            // expression itself constructs and nothing else can observe. The function keeps its
+            // modifyArgument flag for callers that pass real lvalues. This is what makes move-through
+            // wrappers over array/table literals (to_array_move / to_table_move) pure.
+            if ( !expr->noSideEffects && !expr->arguments.empty()
+                    && (sef & ~uint32_t(SideEffects::modifyArgument))==0 ) {
+                bool allTemp = true;
+                for ( auto & a : expr->arguments ) {
+                    if ( !a->rtti_isMakeLocal() ) { allTemp = false; break; }
+                }
+                expr->noSideEffects = allTemp;
+            }
+            expr->noNativeSideEffects = (sef & uint32_t(SideEffects::inferredSideEffects))==0;
             if ( expr->noSideEffects ) {
                 for ( auto & arg : expr->arguments ) {
                     expr->noSideEffects &= arg->noSideEffects;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -96,6 +96,7 @@ namespace das {
         debugInferFlag = prog->options.getBoolOption("debug_infer_flag", prog->policies.debug_infer_flag);
         enableInferTimeFolding = prog->options.getBoolOption("infer_time_folding", !prog->policies.no_infer_time_folding);
         disableAot = prog->options.getBoolOption("no_aot", false);
+        noHeapArrayLiterals = prog->options.getBoolOption("no_heap_array_literals", false);
         multiContext = prog->options.getBoolOption("multiple_contexts", prog->policies.multiple_contexts);
         standaloneContext = prog->options.getBoolOption("standalone_context", prog->policies.standalone_context);
         checkNoGlobalVariablesAtAll = prog->options.getBoolOption("no_global_variables_at_all", prog->policies.no_global_variables_at_all);
@@ -5701,7 +5702,19 @@ namespace das {
                   "use let _ = " + call->name + "(...)", "",
                   call->at, CompilationError::invalid_function_result_discarded);
         }
-        // super() constructor rewrite is done in visit(ExprCall*), once argument types are inferred
+        // Array/table literal: `[..]` / `array<T>(..)` parse to to_array_move(ExprMakeArray), and
+        // `{..}` table literals to to_table_move(ExprMakeArray of tuples). Flag the gen2 make_array
+        // (here, in preVisit, BEFORE the child is type-inferred) so it builds a heap `array<T>`
+        // directly instead of a stack `T[N]` that to_array_move/to_table_move then copies. The
+        // type carries the decision: to_array_move/to_table_move resolve their `array<T>` overload
+        // at compile time (no runtime check). Only the gen2 literal shape is flagged.
+        if ((call->name == "to_array_move" || call->name == "to_table_move")
+                && call->arguments.size() == 1 && call->arguments[0]->rtti_isMakeArray()) {
+            auto mka = static_cast<ExprMakeArray*>(call->arguments[0]);
+            if (mka->gen2 && !noHeapArrayLiterals) {
+                mka->makeArrayOnHeap = true;
+            }
+        }
     }
     void InferTypes::preVisitCallArg(ExprCall *call, Expression *arg, bool last) {
         Visitor::preVisitCallArg(call, arg, last);

--- a/src/ast/ast_infer_type_make.cpp
+++ b/src/ast/ast_infer_type_make.cpp
@@ -1468,7 +1468,17 @@ namespace das {
         }
         uint32_t resDim = uint32_t(expr->values.size());
         TypeDeclPtr resT = nullptr;
-        if (expr->gen2) {
+        if (expr->gen2 && expr->makeArrayOnHeap) {
+            // heap array literal: type directly as array<T> (not the stack fixed array); codegen
+            // builds it on the heap, and to_array_move/to_table_move resolve their array<T> overload.
+            resT = new TypeDecl(Type::tArray);
+            resT->at = expr->at;
+            resT->constant = false;
+            resT->removeConstant = true;
+            resT->firstType = new TypeDecl(*expr->recordType);
+            resT->firstType->ref = false;
+            resT->firstType->constant = false;
+        } else if (expr->gen2) {
             // wrap outermost - element count is the outer dimension (old dim.push_back was inner-first, latent order bug)
             resT = makeFixedArrayTypeDecl(int32_t(resDim), new TypeDecl(*expr->makeType));
         } else if (resDim != 1 || expr->makeType->baseType==Type::tFixedArray) {

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -1244,6 +1244,8 @@ namespace das {
     // aot
         "no_aot",                       Type::tBool,
         "aot_prologue",                 Type::tBool,
+    // codegen
+        "no_heap_array_literals",       Type::tBool,
     // logging
         "log",                          Type::tBool,
         "log_optimization_passes",      Type::tBool,

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -903,7 +903,7 @@ namespace das
                 auto & fields = mks->structs[index];
                 // adjust var for index
                 if ( mks->useCMRES ) {
-                    fakeVariable->stackTop = mks->extraOffset + index*stride;
+                    fakeVariable->extraLocalOffset = mks->extraOffset + index*stride;
                 } else if ( mks->useStackRef ) {
                     if ( total > 1 ) {
                         indexExpr->value = cast<int32_t>::from(index);
@@ -946,6 +946,7 @@ namespace das
             fakeVariable->type = new TypeDecl(*mks->type);
             if ( mks->useCMRES ) {
                 fakeVariable->aliasCMRES = true;
+                fakeVariable->extraLocalOffset = mks->extraOffset;
             } else if ( mks->useStackRef ) {
                 fakeVariable->stackTop = mks->stackTop + mks->extraOffset;
                 fakeVariable->type->ref = true;
@@ -1050,7 +1051,13 @@ namespace das
     ExpressionPtr SimulateVisitor::visit(ExprMakeArray * expr) {
         const auto &at = expr->at;
         SimNode_Block * block;
-        if ( expr->useCMRES ) {
+        if ( expr->makeArrayOnHeap ) {
+            // build array<T> on the heap; CMRES-style children fill arr.data in place (allocate_stack
+            // set useCMRES so sv_simulateLocal below emits the CMRES element writes).
+            uint32_t stride = expr->recordType->getSizeOf();
+            uint32_t count = uint32_t(expr->values.size());
+            block = context.code->makeNode<SimNode_MakeArrayHeap>(at, expr->stackTop, count, stride);
+        } else if ( expr->useCMRES ) {
             block = context.code->makeNode<SimNode_MakeLocalCMRes>(at);
         } else {
             block = context.code->makeNode<SimNode_MakeLocal>(at, expr->stackTop);
@@ -2424,6 +2431,8 @@ namespace das
                                                     expr->variable->stackTop, extraOffset + expr->variable->extraLocalOffset);
                 }
             } else if ( expr->variable->aliasCMRES ) {
+                // extraOffset already includes the var's extraLocalOffset (passed by the caller),
+                // which for fake CMRES-alias vars carries the make-struct element slot offset.
                 if ( r2vType->baseType!=Type::none ) {
                     return context.code->makeValueNode<SimNode_GetCMResOfsR2V>(r2vType->getR2VType(), at, extraOffset);
                 } else {

--- a/src/builtin/module_builtin_ast.h
+++ b/src/builtin/module_builtin_ast.h
@@ -299,6 +299,7 @@ namespace das {
             this->template addField<DAS_BIND_MANAGED_FIELD(recordType)>("recordType");
             this->template addField<DAS_BIND_MANAGED_FIELD(values)>("values");
             this->template addField<DAS_BIND_MANAGED_FIELD(gen2)>("gen2");
+            this->template addField<DAS_BIND_MANAGED_FIELD(makeArrayOnHeap)>("makeArrayOnHeap");
         }
     };
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -1562,7 +1562,7 @@ namespace das {
 
     void SerializeVisitor::serializeMakeArray ( ExprMakeArray * expr ) {
         serializeMakeLocal(expr);
-        ser << expr->recordType << expr->values << expr->gen2;
+        ser << expr->recordType << expr->values << expr->gen2 << expr->makeArrayOnHeap;
     }
 
     void SerializeVisitor::preVisitExpression ( Expression * expr ) {
@@ -2705,7 +2705,7 @@ namespace das {
     }
 
     uint32_t AstSerializer::getVersion () {
-        static constexpr uint32_t currentVersion = 92;   // 92: Variable::access_info added (issue #3090)
+        static constexpr uint32_t currentVersion = 93;   // 93: ExprMakeArray::makeArrayOnHeap added
         return currentVersion;
     }
 

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -454,6 +454,10 @@ extern "C" {
         builtin_table_unlock(tab, context, at);
     }
 
+    DAS_API void jit_array_resize ( Array & arr, int newSize, int stride, Context * context, LineInfoArg * at ) {
+        builtin_array_resize(arr, newSize, stride, context, at);
+    }
+
     DAS_API int32_t jit_str_cmp ( char * a, char * b ) {
         return strcmp(a ? a : "",b ? b : "");
     }
@@ -618,6 +622,7 @@ extern "C" {
     void *das_get_jit_array_unlock() { return (void *)&builtin_array_unlock; }
     void *das_get_jit_table_lock() { return (void *)&builtin_table_lock; }
     void *das_get_jit_table_unlock() { return (void *)&builtin_table_unlock; }
+    void *das_get_jit_array_resize() { return (void *)&builtin_array_resize; }
     void *das_get_jit_str_cmp() { return (void *)&jit_str_cmp; }
     void *das_get_jit_prologue() { return (void *)&jit_prologue; }
     void *das_get_jit_epilogue() { return (void *)&jit_epilogue; }
@@ -1159,6 +1164,8 @@ extern "C" {
                 SideEffects::none, "das_get_jit_table_lock");
             addExtern<DAS_BIND_FUN(das_get_jit_table_unlock)>(*this, lib, "get_jit_table_unlock",
                 SideEffects::none, "das_get_jit_table_unlock");
+            addExtern<DAS_BIND_FUN(das_get_jit_array_resize)>(*this, lib, "get_jit_array_resize",
+                SideEffects::none, "das_get_jit_array_resize");
             addExtern<DAS_BIND_FUN(das_get_jit_table_at)>(*this, lib, "get_jit_table_at",
                 SideEffects::none, "das_get_jit_table_at");
             addExtern<DAS_BIND_FUN(das_get_jit_table_erase)>(*this, lib, "get_jit_table_erase",

--- a/src/simulate/simulate_visit.cpp
+++ b/src/simulate/simulate_visit.cpp
@@ -878,6 +878,17 @@ namespace das {
         V_END();
     }
 
+    SimNode * SimNode_MakeArrayHeap::visit ( SimVisitor & vis ) {
+        V_BEGIN_CR();
+        V_OP(MakeArrayHeap);
+        V_SP(stackTop);
+        V_ARG(arrayCount);
+        V_ARG(stride);
+        V_BLOCK();
+        V_FINAL();
+        V_END();
+    }
+
     SimNode * SimNode_ReturnLocalCMRes::visit ( SimVisitor & vis ) {
         V_BEGIN_CR();
         V_OP(ReturnLocalCMRes);

--- a/tests/assert_once/test_assert_over_temporary.das
+++ b/tests/assert_once/test_assert_over_temporary.das
@@ -1,0 +1,29 @@
+// assert over an expression whose only effect is modifyArgument on a freshly-built temporary.
+// Modifying a temporary the expression itself constructs is unobservable, so the side-effect
+// analysis treats such a call as side-effect-free and assert must accept it.
+//
+// Before the side-effect fix this file failed to COMPILE with error[30151] "assert expressions
+// can't have side-effects": the move-through to_array_move / to_table_move over an array/table
+// literal, and a `var` parameter that mutates a make-local argument, all carried modifyArgument.
+// assert is used deliberately here — these statements ARE the thing under test (that assert
+// accepts them), not test assertions; the dastest API checks come after.
+options gen2
+require dastest/testing_boost public
+
+struct A {
+    x : int
+}
+
+def modify_temp(var a : A) : bool {
+    a.x = 5            // mutates the argument -> the function carries modifyArgument
+    return a.x == 5
+}
+
+[test]
+def test_assert_over_temporary(t : T?) {
+    assert(modify_temp(A(x = 1)))               // make-local temp, directly modified
+    assert(length([10, 20, 30]) == 3)           // array literal (to_array_move), operator-wrapped
+    assert(length({1 => 10, 2 => 20}) == 2)     // table literal (to_table_move)
+    assert(([1, 2, 3] |> length) == 3)          // array literal, pipe form
+    t |> success(true, "asserts over temporary-modifying expressions compiled")
+}

--- a/tests/fixed_array/test_array_literal_heap.das
+++ b/tests/fixed_array/test_array_literal_heap.das
@@ -1,0 +1,55 @@
+// Heap-built array/table literals: a gen2 literal feeding to_array_move/to_table_move builds the
+// array<T> directly on the heap (SimNode_MakeArrayHeap) instead of a stack T[N] + memcpy. Verifies
+// the new codegen path returns the right size and element values, for copyable and move-only elements.
+options gen2
+require dastest/testing_boost public
+
+struct Bag {
+    items : array<int>
+}
+
+[test]
+def test_int_literal(t : T?) {
+    var a <- [10, 20, 30, 40, 50]
+    t |> equal(a |> length, 5)
+    t |> equal(a[0], 10)
+    t |> equal(a[4], 50)
+    delete a
+}
+
+[test]
+def test_move_only_literal(t : T?) {
+    // element type carries an array<int> -> non-copyable, exercises the emplace fill path
+    var a <- [Bag(items <- [1, 2]), Bag(items <- [3, 4, 5])]
+    t |> equal(a |> length, 2)
+    t |> equal(a[0].items |> length, 2)
+    t |> equal(a[1].items[2], 5)
+    delete a
+}
+
+[test]
+def test_table_literal(t : T?) {
+    var m <- {1 => 100, 2 => 200, 3 => 300}
+    t |> equal(m |> length, 3)
+    t |> equal(m?[2] ?? -1, 200)
+    t |> equal(m?[3] ?? -1, 300)
+    delete m
+}
+
+struct Cell {
+    data : int[2048]   // 8 KB per element
+}
+
+[test]
+def test_large_literal_no_stack_overflow(t : T?) {
+    // Building directly on the heap has no stack-size limit. The old stack T[N] + copy path first
+    // materializes the whole literal (128 KB here) on the stack, so a regression back to stack-build
+    // would stack-overflow instead of failing this assert. The per-element finalize on delete still
+    // fits the stack, so only the whole-literal build is the failure point.
+    var a <- [Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(),
+              Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell()]
+    t |> equal(a |> length, 16)
+    a[9].data[100] = 12345
+    t |> equal(a[9].data[100], 12345)
+    delete a
+}


### PR DESCRIPTION
Avoid extra copy when possible