### PR TITLE
ast: 64-bit loop counters in any_array_foreach / any_table_foreach

### DIFF
--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -355,7 +355,8 @@ namespace das {
         if ( !tab->data ) return;
         char * values = tab->data;
         char * keys = tab->keys;
-        for ( uint32_t index=0, indexs=tab->capacity; index!=indexs; index++, keys+=keyStride, values+=valueStride ) {
+        // counters must be 64-bit: Table::capacity is uint64_t (a 32-bit index truncates past 4G slots)
+        for ( uint64_t index=0, indexs=tab->capacity; index!=indexs; index++, keys+=keyStride, values+=valueStride ) {
             if ( tableLiveSlot(*tab, index) ) {
                 das_invoke<void>::invoke<void *,void *>(context,at,blk,(void*)keys,(void*)values);
             }
@@ -366,7 +367,8 @@ namespace das {
         auto arr = (Array *) _arr;
         if ( !arr->data ) return;
         char * values = arr->data;
-        for ( uint32_t index=0, indexs=arr->size; index!=indexs; index++, values+=stride ) {
+        // counters must be 64-bit: Array::size is uint64_t (a 32-bit index truncates past 4G elements)
+        for ( uint64_t index=0, indexs=arr->size; index!=indexs; index++, values+=stride ) {
             das_invoke<void>::invoke<void *>(context,at,blk,(void*)values);
         }
     }


### PR DESCRIPTION
## Problem

`Array::size` / `Table::capacity` are `uint64_t` (`include/daScript/misc/arraytype.h`), but the two AST-conversion iterators in `src/builtin/module_builtin_ast.cpp` walked them with `uint32_t` loop counters:

```cpp
for ( uint32_t index=0, indexs=tab->capacity; ... )   // any_table_foreach
for ( uint32_t index=0, indexs=arr->size;     ... )   // any_array_foreach
```

Past 4G slots/elements the bound truncates and the loop visits the wrong count. These back `convert_to_expression` (array/table value → AST literal) in `daslib/ast_boost.das`, used by `templates_boost` / `json_boost` / `regex_boost`.

## Fix

Widen both loop counters to `uint64_t`, matching the canonical `table_for_each` helper (`runtime_table.h`) and `tableLiveSlot(const Table&, uint64_t)`. No signature change; behavior is identical for every array under 4G.

These are "category 2" under the 64-bit API policy — they take `(array, strides, block)` with no count in the signature, so widening the internal counters makes them just work; no new API, no panic needed.

## Testing

A true reproduction needs >4G elements (the *fixed* loop must iterate the full count), which isn't CI-feasible — so no unit test is added. Verified the normal path is intact: `convert_to_expression` of a 5-element array and a 3-entry table produce `ExprMakeArray` nodes with 5 / 3 values respectively, and the full interpreter suite passes (`10286 tests, 0 failed, 0 errors`).

These are `addExtern` C++ functions — interpreter, AOT, and JIT all emit a plain call to the same compiled host function, so no tier generates a distinct loop body and the change can't alter AOT/JIT codegen.

## Followups (separate PRs, each discussed individually)

- `any_array_size` / `any_table_size` return `int32_t` — add a 64-bit `long_` counterpart and panic the 32-bit version on overflow.
- Heap-sort array path (`module_builtin_runtime_sort.cpp:365-373`) passes `arr.size` straight through, missing the `sort_array_size_or_panic` guard the `sort` path above it already has.
- `fio` popen (`:956`, `:1140`) and `jobque` stream (`:427-431`) `uint32_t` loops over daslang arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)