### PR TITLE
ast: add any_array_long_size / any_table_long_size; panic 32-bit size accessors past INT_MAX

### DIFF
--- a/doc/source/stdlib/handmade/function-ast-any_array_long_size-0xdad4ddc50b040997.rst
+++ b/doc/source/stdlib/handmade/function-ast-any_array_long_size-0xdad4ddc50b040997.rst
@@ -1,0 +1,1 @@
+Returns the 64-bit size of an array from a pointer to an `array<>` object.

--- a/doc/source/stdlib/handmade/function-ast-any_array_size-0x80bb6b450798a7d4.rst
+++ b/doc/source/stdlib/handmade/function-ast-any_array_size-0x80bb6b450798a7d4.rst
@@ -1,1 +1,0 @@
-Returns the size of an array from a pointer to an `array<>` object.

--- a/doc/source/stdlib/handmade/function-ast-any_array_size-0xf0c6adda9a970aca.rst
+++ b/doc/source/stdlib/handmade/function-ast-any_array_size-0xf0c6adda9a970aca.rst
@@ -1,0 +1,1 @@
+Returns the size of an array from a pointer to an `array<>` object. Panics if the size exceeds INT_MAX; use `any_array_long_size` for larger arrays.

--- a/doc/source/stdlib/handmade/function-ast-any_table_long_size-0xa9b71092cc5c67e6.rst
+++ b/doc/source/stdlib/handmade/function-ast-any_table_long_size-0xa9b71092cc5c67e6.rst
@@ -1,0 +1,1 @@
+Returns the 64-bit size of a table from a pointer to a `table<>` object.

--- a/doc/source/stdlib/handmade/function-ast-any_table_size-0x4d61d962d217a025.rst
+++ b/doc/source/stdlib/handmade/function-ast-any_table_size-0x4d61d962d217a025.rst
@@ -1,1 +1,0 @@
-Returns the size of a table from a pointer to a `table<>` object.

--- a/doc/source/stdlib/handmade/function-ast-any_table_size-0xa81e274ba432f1a1.rst
+++ b/doc/source/stdlib/handmade/function-ast-any_table_size-0xa81e274ba432f1a1.rst
@@ -1,0 +1,1 @@
+Returns the size of a table from a pointer to a `table<>` object. Panics if the size exceeds INT_MAX; use `any_table_long_size` for larger tables.

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -16,8 +16,10 @@ namespace das {
     DAS_CC_API int64_t ast_find_enum_value ( EnumerationPtr enu, const char * value );
     DAS_CC_API int64_t ast_find_enum_value_ex ( Enumeration * enu, const char * value );
 
-    DAS_CC_API int32_t any_array_size ( void * _arr );
-    DAS_CC_API int32_t any_table_size ( void * _tab );
+    DAS_CC_API int32_t any_array_size ( void * _arr, Context * context, LineInfoArg * at );
+    DAS_CC_API int32_t any_table_size ( void * _tab, Context * context, LineInfoArg * at );
+    DAS_CC_API int64_t any_array_long_size ( void * _arr );
+    DAS_CC_API int64_t any_table_long_size ( void * _tab );
     DAS_CC_API void any_array_foreach ( void * _arr, int stride, const TBlock<void,void *> & blk, Context * context, LineInfoArg * at );
     DAS_CC_API void any_table_foreach ( void * _tab, int keyStride, int valueStride, const TBlock<void,void *,void *> & blk, Context * context, LineInfoArg * at );
 

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -373,12 +373,26 @@ namespace das {
         }
     }
 
-    int32_t any_array_size ( void * _arr ) {
-        return int32_t(((Array *) _arr)->size);
+    // Array::size / Table::size are uint64_t. The 32-bit accessors panic past INT_MAX instead of
+    // silently truncating; callers that can handle 4G+ elements use the long_ counterparts below.
+    int32_t any_array_size ( void * _arr, Context * context, LineInfoArg * at ) {
+        uint64_t sz = ((Array *) _arr)->size;
+        if ( sz > uint64_t(INT32_MAX) ) context->throw_error_at(at, "any_array_size: array size %llu exceeds INT_MAX; use any_array_long_size", (unsigned long long)sz);
+        return int32_t(sz);
     }
 
-    int32_t any_table_size ( void * _tab ) {
-        return int32_t(((Table *) _tab)->size);
+    int32_t any_table_size ( void * _tab, Context * context, LineInfoArg * at ) {
+        uint64_t sz = ((Table *) _tab)->size;
+        if ( sz > uint64_t(INT32_MAX) ) context->throw_error_at(at, "any_table_size: table size %llu exceeds INT_MAX; use any_table_long_size", (unsigned long long)sz);
+        return int32_t(sz);
+    }
+
+    int64_t any_array_long_size ( void * _arr ) {
+        return int64_t(((Array *) _arr)->size);
+    }
+
+    int64_t any_table_long_size ( void * _tab ) {
+        return int64_t(((Table *) _tab)->size);
     }
 
     void ast_gc_guard ( const TBlock<void> & block, Context * context, LineInfoArg * at ) {
@@ -1450,9 +1464,15 @@ namespace das {
                 ->args({"array","stride","block","context","line"});
         addExtern<DAS_BIND_FUN(any_array_size)>(*this, lib,  "any_array_size",
             SideEffects::none, "any_array_size")
-                ->arg("array");
+                ->args({"array","context","line"});
         addExtern<DAS_BIND_FUN(any_table_size)>(*this, lib,  "any_table_size",
             SideEffects::none, "any_table_size")
+                ->args({"table","context","line"});
+        addExtern<DAS_BIND_FUN(any_array_long_size)>(*this, lib,  "any_array_long_size",
+            SideEffects::none, "any_array_long_size")
+                ->arg("array");
+        addExtern<DAS_BIND_FUN(any_table_long_size)>(*this, lib,  "any_table_long_size",
+            SideEffects::none, "any_table_long_size")
                 ->arg("table");
         addExtern<DAS_BIND_FUN(getUnderlyingValueType)>(*this, lib,  "get_underlying_value_type",
             SideEffects::none, "getUnderlyingValueType")

--- a/tests-cpp/small/test_any_size_64bit.cpp
+++ b/tests-cpp/small/test_any_size_64bit.cpp
@@ -1,0 +1,74 @@
+// 64-bit size accessors for the AST value->literal conversion path.
+// Array::size / Table::size are uint64_t. The 32-bit accessors (any_array_size /
+// any_table_size) panic past INT_MAX instead of silently truncating; the long_
+// counterparts (any_array_long_size / any_table_long_size) carry the full count.
+//
+// We can exercise the >INT_MAX path without a multi-GB allocation: the accessors
+// only read the `size` field, so a fabricated Array/Table with `size` set (and a
+// null `data`) is enough.
+
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/simulate/aot.h"
+#include "daScript/simulate/aot_builtin_ast.h"
+
+#include <cstring>
+
+using namespace das;
+
+#define SCRIPT_PATH "/tests-cpp/small/test_any_size_64bit.das"
+
+TEST_CASE("any_array/table size — 64-bit accessors + overflow panic") {
+    TextPrinter tout;
+    ModuleGroup dummyLibGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+    auto program = compileDaScript(getDasRoot() + SCRIPT_PATH,
+                                   fAccess, tout, dummyLibGroup);
+    REQUIRE_FALSE(program->failed());
+
+    Context ctx(program->getContextStackSize());
+    REQUIRE(program->simulate(ctx, tout));
+
+    LineInfoArg at;
+    const uint64_t big = uint64_t(INT32_MAX) + 100u; // > INT_MAX; as int32_t it wraps negative (INT32_MIN + 99), not a valid count
+
+    SUBCASE("array: under INT_MAX returns exact size; long matches") {
+        Array arr; memset(&arr, 0, sizeof(arr));
+        arr.size = 5;
+        int32_t v = -1;
+        bool ok = ctx.runWithCatchAndClear([&](){ v = any_array_size(&arr, &ctx, &at); });
+        CHECK_MESSAGE(ok, "small array size must not panic");
+        CHECK(v == 5);
+        CHECK(any_array_long_size(&arr) == 5);
+    }
+
+    SUBCASE("array: past INT_MAX panics; long carries the full count") {
+        Array arr; memset(&arr, 0, sizeof(arr));
+        arr.size = big;
+        // the bug the 32-bit accessor used to hide: long_ returns the full value
+        CHECK(any_array_long_size(&arr) == int64_t(big));
+        // 32-bit accessor panics instead of returning a wrapped-negative count
+        bool ok = ctx.runWithCatchAndClear([&](){ (void) any_array_size(&arr, &ctx, &at); });
+        CHECK_FALSE_MESSAGE(ok, "oversized array size must panic");
+        CHECK(ctx.getException() == nullptr); // AndClear scrubbed it
+    }
+
+    SUBCASE("table: under INT_MAX returns exact size; long matches") {
+        Table tab; memset(&tab, 0, sizeof(tab));
+        tab.size = 3;
+        int32_t v = -1;
+        bool ok = ctx.runWithCatchAndClear([&](){ v = any_table_size(&tab, &ctx, &at); });
+        CHECK_MESSAGE(ok, "small table size must not panic");
+        CHECK(v == 3);
+        CHECK(any_table_long_size(&tab) == 3);
+    }
+
+    SUBCASE("table: past INT_MAX panics; long carries the full count") {
+        Table tab; memset(&tab, 0, sizeof(tab));
+        tab.size = big;
+        CHECK(any_table_long_size(&tab) == int64_t(big));
+        bool ok = ctx.runWithCatchAndClear([&](){ (void) any_table_size(&tab, &ctx, &at); });
+        CHECK_FALSE_MESSAGE(ok, "oversized table size must panic");
+    }
+}

--- a/tests-cpp/small/test_any_size_64bit.das
+++ b/tests-cpp/small/test_any_size_64bit.das
@@ -1,0 +1,6 @@
+options gen2
+
+[export]
+def dummy() {
+    return
+}

--- a/tests/ast/test_any_long_size.das
+++ b/tests/ast/test_any_long_size.das
@@ -1,0 +1,26 @@
+options gen2
+
+require daslib/ast
+require dastest/testing_boost public
+
+// Consumer test for the 64-bit size accessors: validates the any_*_long_size
+// bindings end-to-end from daslang. The accessors take a pointer to the
+// array/table header (same idiom as convert_to_expression in ast_boost).
+
+[test]
+def test_any_array_long_size(t : T?) {
+    var arr <- [10, 20, 30, 40, 50]
+    unsafe {
+        let p = reinterpret<uint8 const?>(addr(arr))
+        t |> equal(any_array_long_size(p), int64(5))
+    }
+}
+
+[test]
+def test_any_table_long_size(t : T?) {
+    var tab <- {1 => 100, 2 => 200, 3 => 300}
+    unsafe {
+        let p = reinterpret<uint8 const?>(addr(tab))
+        t |> equal(any_table_long_size(p), int64(3))
+    }
+}


### PR DESCRIPTION
Followup to #3175 — item 2 of the 64-bit container API sweep.

## Problem

`Array::size` / `Table::size` are `uint64_t`, but `any_array_size` / `any_table_size` (`module_builtin_ast.cpp`) returned `int32_t(size)` — a silent truncation past INT_MAX. They back `convert_to_expression` (array/table value → AST literal) in `daslib/ast_boost`.

## Fix (64-bit API policy, category 1)

- Add 64-bit counterparts `any_array_long_size` / `any_table_long_size` (return `int64_t`) carrying the full count.
- Make the 32-bit `any_array_size` / `any_table_size` **panic** past INT_MAX instead of truncating. They gain a `Context` / `LineInfoArg` (auto-supplied — das call sites unchanged). Mirrors the fail-closed `sort_array_size_or_panic` precedent in the sort builtins.

The existing daslib caller (`walk_and_convert`) keeps the 32-bit accessor: it feeds `make_fixed_array_type` / `TypeDecl.fixedDim`, both `int`, so a >2G array literal can't be represented as a fixed-array AST node regardless — panic is the correct floor there.

## Tests

- `tests-cpp/small/test_any_size_64bit.cpp` — fabricates an `Array`/`Table` with `size > INT_MAX` (no allocation; the accessors only read `.size`) and checks: under INT_MAX returns the exact size; the `long_` accessors return the full 64-bit value (the bug the 32-bit ones used to hide); the 32-bit accessors panic past INT_MAX (via `runWithCatchAndClear`). Genuinely fail-before/pass-after.
- `tests/ast/test_any_long_size.das` — exercises the `long_` accessors from daslang, validating the bindings end-to-end (so the new API has an in-tree consumer).

## Gates

Interpreter suite (10282), C++ doctest (19 assertions), AOT suite (9598), lint, format, das2rst + Sphinx (latex + html, `-W`) all clean. Rebased onto post-#3175 master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)