### PR TITLE
fio: 64-bit loop counters for popen_argv argv handling

### DIFF
--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -827,9 +827,9 @@ namespace das {
         return out;
     }
 
-    static string winBuildCommandLine ( char ** argv, uint32_t argc ) {
+    static string winBuildCommandLine ( char ** argv, uint64_t argc ) {
         string s;
-        for ( uint32_t i = 0; i < argc; ++i ) {
+        for ( uint64_t i = 0; i < argc; ++i ) {
             if ( i ) s += ' ';
             s += winArgvEscape(argv[i]);
         }
@@ -953,7 +953,7 @@ namespace das {
         // trailing NULL element.
         vector<char *> cargv;
         cargv.reserve(args_arr.size + 1);
-        for ( uint32_t i = 0; i < args_arr.size; ++i ) {
+        for ( uint64_t i = 0; i < args_arr.size; ++i ) {
             cargv.push_back(argv[i] ? argv[i] : (char *)"");
         }
         cargv.push_back(nullptr);
@@ -1137,7 +1137,7 @@ namespace das {
         }
         vector<char *> cargv;
         cargv.reserve(args_arr.size + 1);
-        for ( uint32_t i = 0; i < args_arr.size; ++i ) {
+        for ( uint64_t i = 0; i < args_arr.size; ++i ) {
             cargv.push_back(argv[i] ? argv[i] : (char *)"");
         }
         cargv.push_back(nullptr);


### PR DESCRIPTION
Followup to #3175 — 64-bit container sweep.

## Problem

`popen_argv` / `popen_argv_pipe` build the child argv from `args_arr.size` (uint64) with `uint32_t` loop counters:
- the POSIX `execvp` argv-copy loops (`for (uint32_t i = 0; i < args_arr.size; ++i)`), and
- the Windows `winBuildCommandLine(char** argv, uint32_t argc)` + its loop.

Both truncate past 4G args.

## Fix

Widen the counters / `argc` to `uint64_t`. Clean category-2 widen — `cargv.reserve(args_arr.size + 1)` already takes `size_t`, and argv handling is pointer-based. No behavior change for normal argv.

## Test

A true >4G-argv repro isn't feasible, so no new test (same as the foreach PR). Validated `winBuildCommandLine` end-to-end on Windows via `tests/fio/popen_argv.das` (14/14 — `popen_argv` launches subprocesses through `CreateProcessA` + `winBuildCommandLine`). The POSIX loops are `#ifdef`'d out on Windows; Linux CI compiles them.

## Note

This is the `fio` half of the audit's "fio + jobque" item. `jobque`'s `streamPushBatch` is a separate, deeper fork (the `Stream::pushBatch` API is int/uint32-bound: `int count`, `const uint32_t* sizes`) — handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)