### PR TITLE
jobque: 64-bit Stream byte-buffer API (push / pushBatch / pop)

### DIFF
--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -142,8 +142,8 @@ namespace das {
         Stream() { mTrackMagic = TRACK_STREAM; }
         Stream( int count ) { mTrackMagic = TRACK_STREAM; mRemaining = count; }
         virtual ~Stream();
-        void push ( const uint8_t * data, uint32_t size );
-        void pushBatch ( const uint8_t * const * data, const uint32_t * sizes, int count );
+        void push ( const uint8_t * data, uint64_t size );
+        void pushBatch ( const uint8_t * const * data, const uint64_t * sizes, int64_t count );
         void pop ( const TBlock<void, TTemporary<TArray<uint8_t> const>> & blk, Context * context, LineInfoArg * at );
         bool tryPop ( const TBlock<void, TTemporary<TArray<uint8_t> const>> & blk, Context * context, LineInfoArg * at );
         bool popWithTimeout ( int timeoutMs, const TBlock<void, TTemporary<TArray<uint8_t> const>> & blk, Context * context, LineInfoArg * at );
@@ -155,7 +155,7 @@ namespace das {
             lock_guard<mutex> guard(mCompleteMutex);
             for ( auto & v : pipe ) {
                 Array arr;
-                array_mark_locked(arr, (void *)v.data(), (uint32_t)v.size());
+                array_mark_locked(arr, (void *)v.data(), v.size());
                 tt(&arr);
             }
         }
@@ -164,7 +164,7 @@ namespace das {
             lock_guard<mutex> guard(mCompleteMutex);
             for ( auto & v : pipe ) {
                 Array arr;
-                array_mark_locked(arr, (void *)v.data(), (uint32_t)v.size());
+                array_mark_locked(arr, (void *)v.data(), v.size());
                 tt(&arr);
             }
             pipe.clear();

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -292,7 +292,7 @@ namespace das {
         DAS_ASSERT(mRef==0);
     }
 
-    void Stream::push ( const uint8_t * data, uint32_t size ) {
+    void Stream::push ( const uint8_t * data, uint64_t size ) {
         lock_guard<mutex> guard(mCompleteMutex);
         pipe.emplace_back();
         auto & v = pipe.back();
@@ -301,9 +301,9 @@ namespace das {
         mCond.notify_all();
     }
 
-    void Stream::pushBatch ( const uint8_t * const * data, const uint32_t * sizes, int count ) {
+    void Stream::pushBatch ( const uint8_t * const * data, const uint64_t * sizes, int64_t count ) {
         lock_guard<mutex> guard(mCompleteMutex);
-        for ( int i=0; i!=count; ++i ) {
+        for ( int64_t i=0; i<count; ++i ) {
             pipe.emplace_back();
             auto & v = pipe.back();
             v.resize(sizes[i]);
@@ -313,7 +313,7 @@ namespace das {
     }
 
     static void invoke_stream_block ( const TBlock<void, TTemporary<TArray<uint8_t> const>> & blk,
-                                      const uint8_t * data, uint32_t size,
+                                      const uint8_t * data, uint64_t size,
                                       Context * context, LineInfoArg * at ) {
         Array arr;
         array_mark_locked(arr, (void *)data, size);
@@ -342,7 +342,7 @@ namespace das {
                 pipe.pop_front();
             }
         }
-        invoke_stream_block(blk, item.data(), (uint32_t)item.size(), context, at);
+        invoke_stream_block(blk, item.data(), item.size(), context, at);
     }
 
     bool Stream::tryPop ( const TBlock<void, TTemporary<TArray<uint8_t> const>> & blk, Context * context, LineInfoArg * at ) {
@@ -353,7 +353,7 @@ namespace das {
             item = das::move(pipe.front());
             pipe.pop_front();
         }
-        invoke_stream_block(blk, item.data(), (uint32_t)item.size(), context, at);
+        invoke_stream_block(blk, item.data(), item.size(), context, at);
         return true;
     }
 
@@ -370,7 +370,7 @@ namespace das {
             item = das::move(pipe.front());
             pipe.pop_front();
         }
-        invoke_stream_block(blk, item.data(), (uint32_t)item.size(), context, at);
+        invoke_stream_block(blk, item.data(), item.size(), context, at);
         return true;
     }
 
@@ -420,15 +420,15 @@ namespace das {
         if ( !ch ) context->throw_error_at(at, "streamPushBatch: stream is null");
         if ( data.size == 0 ) return;
         vector<const uint8_t *> ptrs;
-        vector<uint32_t> sizes;
+        vector<uint64_t> sizes;
         ptrs.reserve(data.size);
         sizes.reserve(data.size);
         auto items = (const TArray<uint8_t> *)data.data;
-        for ( uint32_t i=0; i!=data.size; ++i ) {
+        for ( uint64_t i=0; i!=data.size; ++i ) {
             ptrs.push_back((const uint8_t *)items[i].data);
             sizes.push_back(items[i].size);
         }
-        ch->pushBatch(ptrs.data(), sizes.data(), (int)data.size);
+        ch->pushBatch(ptrs.data(), sizes.data(), int64_t(data.size));
     }
 
     void streamPop ( Stream * ch, const TBlock<void, TTemporary<TArray<uint8_t> const>> & blk, Context * context, LineInfoArg * at ) {


### PR DESCRIPTION
Followup to #3175 — final item of the 64-bit container sweep.

## Problem

The byte-buffer `Stream` API truncated 64-bit sizes/counts at the boundary, even though the pipe internals (`deque<vector<uint8_t>>`) are already `size_t`:
- `Stream::push(const uint8_t*, uint32_t size)` — a single buffer > 4 GB truncates.
- `Stream::pushBatch(const uint8_t* const*, const uint32_t* sizes, int count)` — a per-item size > 4 GB truncates; > INT_MAX items truncates.
- `streamPushBatch` built a `vector<uint32_t> sizes` and passed `(int)data.size`.
- `invoke_stream_block(..., uint32_t size, ...)` (pop side) + the 3 `(uint32_t)item.size()` casts.

## Fix (widen the Stream API to 64-bit)

- `Stream::push` size → `uint64_t`.
- `Stream::pushBatch` sizes → `const uint64_t*`, count → `int64_t` (loop counter `int64_t`).
- `invoke_stream_block` size → `uint64_t`; dropped the `(uint32_t)` casts on `item.size()` (`size_t` → `uint64_t`).
- `streamPushBatch`: `vector<uint64_t> sizes`, `uint64_t` loop counter, `int64_t(data.size)`.
- `aot_builtin_jobque.h` `Stream` declarations updated to match.

The das-bound functions (`streamPush` / `streamPushBatch` / `streamPop`) are **unchanged** — they take `TArray` and call the internal `Stream` methods — so there's no das-API or AOT-prototype change (das2rst produced no doc churn).

## Test

A true >4 GB-buffer / >2 G-batch repro isn't CI-feasible, so no new test (same as the foreach/fio PRs). Validated normal behavior: `tests/jobque/test_jobque_stream.das` (20/20), `test_jobque_channels.das` (19/19), and the full suite (10291, 0 failed).

## Scope notes (follow-ups)

Two adjacent int-bounded jobque APIs left out (separate decisions):
- `Stream::total()` returns `(int)pipe.size()` — a das-facing queue-depth count accessor (category-1).
- `Channel::push` / `Channel::pushBatch` — the typed-message path, takes `int count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)