### PR TITLE
math: add step + smoothstep + Tier B dispatch sweep (shader breadth)

### DIFF
--- a/daslib/math_boost.das
+++ b/daslib/math_boost.das
@@ -36,16 +36,6 @@ struct Ray {
     origin : float3 //! origin
 }
 
-def degrees(f : float) {
-    //! convert radians to degrees
-    return f * 180. / PI
-}
-
-def radians(f : float) {
-    //! convert degrees to radians
-    return f * PI / 180.
-}
-
 def RGBA_TO_UCOLOR(x, y, z, w : float) {
     //! conversion from RGBA to ucolor. x,y,z,w are in [0,1] range
     return pack_float_to_byte(float4(x, y, z, w) * 255.)

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -137,7 +137,7 @@ def document_module_math(_root : string) {
     var mod = get_module("math")
     var groups <- array<DocGroup>(
         group_by_regex("all numerics (uint*, int*, float*, double)", mod, %regex~(min|max)$%%),
-        group_by_regex("float* and double", mod, %regex~(sign|abs|acos|asin|safe_acos|safe_asin|atan|atan2|cos|sin|tan|sinh|cosh|tanh|asinh|acosh|atanh|exp|log|exp2|expm1|log2|log10|log1p|pow|sqrt|cbrt|hypot|fmod|remainder|trunc|rcp|ceil|floor|abs|saturate|sincos|is_finite|is_nan)$%%),
+        group_by_regex("float* and double", mod, %regex~(sign|abs|acos|asin|safe_acos|safe_asin|atan|atan2|cos|sin|tan|sinh|cosh|tanh|asinh|acosh|atanh|exp|log|exp2|expm1|log2|log10|log1p|pow|sqrt|cbrt|hypot|fmod|remainder|trunc|rcp|ceil|floor|abs|saturate|sincos|is_finite|is_nan|radians|degrees|step|smoothstep)$%%),
         group_by_regex("float* only", mod, %regex~(atan_est|atan2_est|rcp_est|ceili|floori|roundi|trunci|round|rsqrt|rsqrt_est|fract|\-)$%%),
         group_by_regex("float3 only", mod, %regex~(cross|reflect|refract|distance|distance_sq|
 inv_distance|inv_distance_sq)$%%),

--- a/doc/source/stdlib/handmade/function-math-degrees-0xd470cb7d1ba8aa67.rst
+++ b/doc/source/stdlib/handmade/function-math-degrees-0xd470cb7d1ba8aa67.rst
@@ -1,0 +1,1 @@
+Converts the input from radians to degrees (multiplies by 180 / PI); computed component-wise for float2, float3, and float4 vector types.

--- a/doc/source/stdlib/handmade/function-math-radians-0x4f4aa468dabe2188.rst
+++ b/doc/source/stdlib/handmade/function-math-radians-0x4f4aa468dabe2188.rst
@@ -1,0 +1,1 @@
+Converts the input from degrees to radians (multiplies by PI / 180); computed component-wise for float2, float3, and float4 vector types.

--- a/doc/source/stdlib/handmade/function-math-smoothstep-0x1c9f109cb4ba616c.rst
+++ b/doc/source/stdlib/handmade/function-math-smoothstep-0x1c9f109cb4ba616c.rst
@@ -1,0 +1,1 @@
+Performs a smooth Hermite interpolation between 0 and 1 when x is between edge0 and edge1: returns 0 for x <= edge0, 1 for x >= edge1, and the smooth cubic t*t*(3 - 2*t) (where t = clamp((x - edge0) / (edge1 - edge0), 0, 1)) in between. Computed component-wise for float2, float3, and float4 vector types.

--- a/doc/source/stdlib/handmade/function-math-step-0x9b5214915b9085f7.rst
+++ b/doc/source/stdlib/handmade/function-math-step-0x9b5214915b9085f7.rst
@@ -1,0 +1,1 @@
+Returns 0.0 when x is strictly less than edge, otherwise 1.0; computed component-wise for float2, float3, and float4 vector types. Matches the GLSL step(edge, x) semantics: at the boundary (x == edge) the result is 1.0.

--- a/include/daScript/simulate/aot_builtin_math.h
+++ b/include/daScript/simulate/aot_builtin_math.h
@@ -68,6 +68,21 @@ namespace das {
 
     __forceinline vec4f lerp_vec_float(vec4f a, vec4f b, float t) { return v_madd(v_sub(b, a), v_splats(t), a); }
 
+    __forceinline float step_float(float edge, float x) { return x < edge ? 0.0f : 1.0f; }
+    __forceinline float smoothstep_float(float e0, float e1, float x) {
+        float t = (x - e0) / (e1 - e0);
+        t = t < 0.0f ? 0.0f : (t > 1.0f ? 1.0f : t);
+        return t * t * (3.0f - 2.0f * t);
+    }
+    __forceinline vec4f step_vec(vec4f edge, vec4f x) {
+        // GLSL: step(edge,x) = x<edge ? 0 : 1 (so x==edge yields 1). v_sel(a,b,mask) = mask?b:a.
+        return v_sel(v_splats(1.0f), v_zero(), v_cmp_lt(x, edge));
+    }
+    __forceinline vec4f smoothstep_vec(vec4f e0, vec4f e1, vec4f x) {
+        vec4f t = v_saturate(v_div(v_sub(x, e0), v_sub(e1, e0)));
+        return v_mul(v_mul(t, t), v_madd(v_splats(-2.0f), t, v_splats(3.0f)));
+    }
+
 #if defined(__GNUC__) || defined(__clang__)
 #if !defined(__clang__)
 #define DAS_FINITE_MATH __attribute__((optimize("no-finite-math-only")))

--- a/include/daScript/simulate/aot_builtin_math.h
+++ b/include/daScript/simulate/aot_builtin_math.h
@@ -83,6 +83,11 @@ namespace das {
         return v_mul(v_mul(t, t), v_madd(v_splats(-2.0f), t, v_splats(3.0f)));
     }
 
+    __forceinline float radians_float(float deg) { return deg * (3.14159265358979323846f / 180.0f); }
+    __forceinline float degrees_float(float rad) { return rad * (180.0f / 3.14159265358979323846f); }
+    __forceinline vec4f radians_vec(vec4f deg) { return v_mul(deg, v_splats(3.14159265358979323846f / 180.0f)); }
+    __forceinline vec4f degrees_vec(vec4f rad) { return v_mul(rad, v_splats(180.0f / 3.14159265358979323846f)); }
+
 #if defined(__GNUC__) || defined(__clang__)
 #if !defined(__clang__)
 #define DAS_FINITE_MATH __attribute__((optimize("no-finite-math-only")))

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -108,6 +108,8 @@ let g_intrin_lookup <- {
     "math::min" => @@intrinsic_math_minmax,
     "math::max" => @@intrinsic_math_minmax,
     "math::clamp" => @@intrinsic_math_clamp,
+    "math::step" => @@intrinsic_math_step,
+    "math::smoothstep" => @@intrinsic_math_smoothstep,
     "math::round" => @@intrinsic_math_float_op1,
     "math::floor" => @@intrinsic_math_float_op1,
     "math::ceil" => @@intrinsic_math_float_op1,
@@ -743,6 +745,46 @@ def intrinsic_math_lerp_op3(var ctx : JitCtx; expr : ExprCallFunc?; arguments : 
     var b_sub_a = LLVMBuildFSub(ctx.builder, b, a, "")
     var b_a_mul_t = LLVMBuildFMul(ctx.builder, b_sub_a, t, "")
     return LLVMBuildFAdd(ctx.builder, b_a_mul_t, a, "lerp")
+}
+
+def intrinsic_math_step(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume argType = expr.arguments[0]._type
+    if (argType.baseType == Type.tFloat || (argType.isVectorType && argType.vectorBaseType == Type.tFloat)) {
+        var zero = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 0.0lf))
+        var one = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 1.0lf))
+        // GLSL step(edge,x) = x<edge ? 0 : 1. fcmp OLT(x,edge) -> select(cmp, 0, 1).
+        var cmp = LLVMBuildFCmp(ctx.builder, LLVMRealPredicate.LLVMRealOLT, arguments[1], arguments[0], "")
+        return LLVMBuildSelect(ctx.builder, cmp, zero, one, "step")
+    } else {
+        failed_E(expr, "{expr.name}({describe(argType)}) is not supported (yet?)")
+        return null
+    }
+}
+
+def intrinsic_math_smoothstep(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume argType = expr.arguments[0]._type
+    if (argType.baseType == Type.tFloat || (argType.isVectorType && argType.vectorBaseType == Type.tFloat)) {
+        var zero = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 0.0lf))
+        var one = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 1.0lf))
+        var two = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 2.0lf))
+        var three = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 3.0lf))
+        // t = clamp((x-e0)/(e1-e0), 0, 1)
+        var x_minus_e0 = LLVMBuildFSub(ctx.builder, arguments[2], arguments[0], "")
+        var e1_minus_e0 = LLVMBuildFSub(ctx.builder, arguments[1], arguments[0], "")
+        var t_raw = LLVMBuildFDiv(ctx.builder, x_minus_e0, e1_minus_e0, "")
+        var cmp_lo = LLVMBuildFCmp(ctx.builder, LLVMRealPredicate.LLVMRealOGT, t_raw, zero, "")
+        var t_lo = LLVMBuildSelect(ctx.builder, cmp_lo, t_raw, zero, "")
+        var cmp_hi = LLVMBuildFCmp(ctx.builder, LLVMRealPredicate.LLVMRealOLT, t_lo, one, "")
+        var t = LLVMBuildSelect(ctx.builder, cmp_hi, t_lo, one, "")
+        // t*t*(3 - 2*t)
+        var two_t = LLVMBuildFMul(ctx.builder, two, t, "")
+        var three_minus_two_t = LLVMBuildFSub(ctx.builder, three, two_t, "")
+        var t_sq = LLVMBuildFMul(ctx.builder, t, t, "")
+        return LLVMBuildFMul(ctx.builder, t_sq, three_minus_two_t, "smoothstep")
+    } else {
+        failed_E(expr, "{expr.name}({describe(argType)}) is not supported (yet?)")
+        return null
+    }
 }
 
 def intrinsic_math_mad_op3(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -110,6 +110,12 @@ let g_intrin_lookup <- {
     "math::clamp" => @@intrinsic_math_clamp,
     "math::step" => @@intrinsic_math_step,
     "math::smoothstep" => @@intrinsic_math_smoothstep,
+    "math::radians" => @@intrinsic_math_radians,
+    "math::degrees" => @@intrinsic_math_degrees,
+    "math::fmod" => @@intrinsic_math_fmod,
+    "math::sinh" => @@intrinsic_math_sinh_cosh_tanh,
+    "math::cosh" => @@intrinsic_math_sinh_cosh_tanh,
+    "math::tanh" => @@intrinsic_math_sinh_cosh_tanh,
     "math::round" => @@intrinsic_math_float_op1,
     "math::floor" => @@intrinsic_math_float_op1,
     "math::ceil" => @@intrinsic_math_float_op1,
@@ -785,6 +791,42 @@ def intrinsic_math_smoothstep(var ctx : JitCtx; expr : ExprCallFunc?; arguments 
         failed_E(expr, "{expr.name}({describe(argType)}) is not supported (yet?)")
         return null
     }
+}
+
+def intrinsic_math_radians(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume argType = expr.arguments[0]._type
+    if (argType.baseType == Type.tFloat || (argType.isVectorType && argType.vectorBaseType == Type.tFloat)) {
+        let k = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 3.14159265358979323846lf / 180.0lf))
+        return LLVMBuildFMul(ctx.builder, arguments[0], k, "radians")
+    } else {
+        failed_E(expr, "{expr.name}({describe(argType)}) is not supported (yet?)")
+        return null
+    }
+}
+
+def intrinsic_math_degrees(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume argType = expr.arguments[0]._type
+    if (argType.baseType == Type.tFloat || (argType.isVectorType && argType.vectorBaseType == Type.tFloat)) {
+        let k = build_broadcast_vector(ctx.builder, argType, LLVMConstReal(ctx.types.t_float, 180.0lf / 3.14159265358979323846lf))
+        return LLVMBuildFMul(ctx.builder, arguments[0], k, "degrees")
+    } else {
+        failed_E(expr, "{expr.name}({describe(argType)}) is not supported (yet?)")
+        return null
+    }
+}
+
+def intrinsic_math_fmod(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume argType = expr.arguments[0]._type
+    if (argType.baseType == Type.tFloat || argType.baseType == Type.tDouble || (argType.isVectorType && argType.vectorBaseType == Type.tFloat)) {
+        return LLVMBuildFRem(ctx.builder, arguments[0], arguments[1], "fmod")
+    } else {
+        failed_E(expr, "{expr.name}({describe(argType)}) is not supported (yet?)")
+        return null
+    }
+}
+
+def intrinsic_math_sinh_cosh_tanh(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    return intrinsic_math_any_float_op1(string(expr.name), ctx.builder, expr, arguments)
 }
 
 def intrinsic_math_mad_op3(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -170,7 +170,7 @@ def public lookup_intinsic(g_ctx : LLVMContextRef; g_builder : LLVMOpaqueBuilder
 
 // intrinsics, $ aka builtin
 
-def intrinsic_builtin_variant_index(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_variant_index(var ctx : JitCtx; _expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     return LLVMBuildLoad2(ctx.builder, ctx.types.t_int32, arguments[0], "$::variant_index")
 }
 
@@ -178,7 +178,7 @@ def intrinsic_builtin_set_variant_index(var ctx : JitCtx; _expr : ExprCallFunc?;
     return LLVMBuildStore2(ctx.builder, ctx.types, ctx.types.t_int32, arguments[1], arguments[0])
 }
 
-def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     assume argType = expr.arguments[0]._type
     if (argType.isGoodArrayType) {
         var arr = LLVMBuildLoad2(ctx.builder, type_to_llvm_type(expr.arguments[0]._type), arguments[0], "arr")
@@ -193,7 +193,7 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
 
 // empty(array) / empty(table) -> size == 0. SIZE is field 1 in both the Array and Table LLVM
 // structs (Table inherits Array), so one body covers both. Returns i1 directly (no truncation).
-def intrinsic_builtin_empty(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_empty(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     assume argType = expr.arguments[0]._type
     if (argType.isGoodArrayType || argType.isGoodTableType) {
         var cont = LLVMBuildLoad2(ctx.builder, type_to_llvm_type(expr.arguments[0]._type), arguments[0], "cont")
@@ -204,7 +204,7 @@ def intrinsic_builtin_empty(var ctx : JitCtx; expr : ExprCallFunc?; arguments : 
     }
 }
 
-def intrinsic_is_standalone_exe(var ctx : JitCtx; _expr : ExprCallFunc?; _arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_is_standalone_exe(var ctx : JitCtx; _expr : ExprCallFunc?; _arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     return LLVMConstInt(ctx.types.t_int1, g_jit_exe_mode ? 1ul : 0ul, 0)
 }
 
@@ -342,7 +342,7 @@ def intrinsic_builtin_hash_string(var ctx : JitCtx; expr : ExprCallFunc?; argume
     return build_string_hash(ctx, arguments[0])
 }
 
-def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     let intType = base_type_to_llvm_type(expr._type.baseType)
     if (empty(arguments)) return LLVMConstInt(intType, 0ul, 0)
     assume argType = expr.arguments[0]._type
@@ -373,7 +373,7 @@ def intrinsic_builtin_int(var ctx : JitCtx; expr : ExprCallFunc?; arguments : ar
     }
 }
 
-def any2int(var ctx : JitCtx; val : LLVMOpaqueValue?; argType : Type; _outType : LLVMOpaqueType?; inbytes, outbytes : int; outSigned : bool) : LLVMOpaqueValue? {
+def any2int(var ctx : JitCtx; val : LLVMOpaqueValue?; argType : Type; _outType : LLVMOpaqueType?; inbytes, outbytes : int; outSigned : bool) : LLVMOpaqueValue? {   // nolint:LINT014 — private helper called from intrinsics that share the table signature
     var outType = _outType != null ? _outType : ctx.types.t_int32
     if (argType == Type.tFloat || argType == Type.tDouble) {
         if (outSigned) {
@@ -435,7 +435,7 @@ def intrinsic_builtin_int_vec(var ctx : JitCtx; expr : ExprCallFunc?; arguments 
     return vres
 }
 
-def any2float(var ctx : JitCtx; val : LLVMOpaqueValue?; argType : Type; _outType : LLVMOpaqueType? = null) {
+def any2float(var ctx : JitCtx; val : LLVMOpaqueValue?; argType : Type; _outType : LLVMOpaqueType? = null) {   // nolint:LINT014 — private helper called from intrinsics that share the table signature
     let outType = _outType != null ? _outType : ctx.types.t_float
     return val                                              if (argType == Type.tFloat)
     return LLVMBuildFPTrunc(ctx.builder, val, outType, "") if (argType == Type.tDouble)
@@ -477,7 +477,7 @@ def intrinsic_builtin_float_vec(var ctx : JitCtx; expr : ExprCallFunc?; argument
     return vres
 }
 
-def intrinsic_builtin_float(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_builtin_float(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     let floatType = base_type_to_llvm_type(expr._type.baseType)
     if (empty(arguments)) return LLVMConstReal(floatType, 0.0lf)
     assume argType = expr.arguments[0]._type
@@ -815,7 +815,7 @@ def intrinsic_math_degrees(var ctx : JitCtx; expr : ExprCallFunc?; arguments : a
     }
 }
 
-def intrinsic_math_fmod(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_math_fmod(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     assume argType = expr.arguments[0]._type
     if (argType.baseType == Type.tFloat || argType.baseType == Type.tDouble || (argType.isVectorType && argType.vectorBaseType == Type.tFloat)) {
         return LLVMBuildFRem(ctx.builder, arguments[0], arguments[1], "fmod")
@@ -945,7 +945,7 @@ def build_fsqrt(var ctx : JitCtx; v2 : LLVMOpaqueValue?; name : string) : LLVMOp
     return LLVMBuildCall2(ctx.builder, typ, decl_fsqrt, args_fsqrt, name)
 }
 
-def build_frcp(var ctx : JitCtx; v2 : LLVMOpaqueValue?; _name : string) : LLVMOpaqueValue? {
+def build_frcp(var ctx : JitCtx; v2 : LLVMOpaqueValue?; _name : string) : LLVMOpaqueValue? {   // nolint:LINT014 — private helper called from intrinsics that share the table signature
     var one = LLVMConstReal(ctx.types.t_float, 1.0lf)
     var fdiv = LLVMBuildFDiv(ctx.builder, one, v2, "")
     return fdiv
@@ -1101,13 +1101,13 @@ def intrinsic_das_ptr_sub(var ctx : JitCtx; expr : ExprCallFunc?; arguments : ar
     return intrinsic_das_ptr_add(ctx, expr, args)
 }
 
-def intrinsic_memset8(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+def intrinsic_memset8(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
     assume opType = expr.arguments[0]._type
     assert(opType.isPointer)
     return LLVMBuildMemSet(ctx.builder, arguments[0], arguments[1], arguments[2], 1u)
 }
 
-def build_cmove_nz(var ctx : JitCtx; val : LLVMOpaqueValue?; blk : block) {
+def build_cmove_nz(var ctx : JitCtx; val : LLVMOpaqueValue?; blk : block) {   // nolint:LINT014 — private helper called from intrinsics that share the table signature
     let cb = LLVMGetInsertBlock(ctx.builder)
     var write = LLVMInsertBasicBlockInContext(ctx.ctx, cb, "write")
     var skip = LLVMInsertBasicBlockInContext(ctx.ctx, cb, "skip")

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -744,7 +744,7 @@ def private ensure_image_query(var m : SpirvModule; var ctx : EmitCtx) {
 // GLSL.std.450 builtin (or wrong class) -> caller emits a clean error. NOTE: keyed on the DASLANG name,
 // which differs from the GLSL spelling for two: daslang `lerp` -> FMix, daslang `rsqrt` -> InverseSqrt.
 // Only dependency-free builtin `math` functions appear here (no dead branches). Excluded on purpose:
-// daslang has no mix/step/smoothstep; radians/degrees live in daslib/math_boost as das functions whose
+// daslang has no mix; radians/degrees live in daslib/math_boost as das functions whose
 // bodies reference a PI global the dependency walker can't lower (a shader writes the multiply inline).
 def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLstd450> {
     if (name == "abs") {
@@ -795,6 +795,8 @@ def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLst
     if (name == "round") return (ok = true, op = GLSLstd450.Round)
     if (name == "trunc") return (ok = true, op = GLSLstd450.Trunc)
     if (name == "fract") return (ok = true, op = GLSLstd450.Fract)
+    if (name == "step") return (ok = true, op = GLSLstd450.Step)
+    if (name == "smoothstep") return (ok = true, op = GLSLstd450.SmoothStep)
     if (name == "lerp") return (ok = true, op = GLSLstd450.FMix)            // daslang lerp == GLSL mix
     if (name == "length") return (ok = true, op = GLSLstd450.Length)
     if (name == "distance") return (ok = true, op = GLSLstd450.Distance)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -744,8 +744,7 @@ def private ensure_image_query(var m : SpirvModule; var ctx : EmitCtx) {
 // GLSL.std.450 builtin (or wrong class) -> caller emits a clean error. NOTE: keyed on the DASLANG name,
 // which differs from the GLSL spelling for two: daslang `lerp` -> FMix, daslang `rsqrt` -> InverseSqrt.
 // Only dependency-free builtin `math` functions appear here (no dead branches). Excluded on purpose:
-// daslang has no mix; radians/degrees live in daslib/math_boost as das functions whose
-// bodies reference a PI global the dependency walker can't lower (a shader writes the multiply inline).
+// daslang has no mix.
 def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLstd450> {
     if (name == "abs") {
         if (cls == 2) return (ok = true, op = GLSLstd450.FAbs)
@@ -785,6 +784,15 @@ def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLst
     if (name == "acos") return (ok = true, op = GLSLstd450.Acos)
     if (name == "atan") return (ok = true, op = GLSLstd450.Atan)
     if (name == "atan2") return (ok = true, op = GLSLstd450.Atan2)
+    if (name == "sinh") return (ok = true, op = GLSLstd450.Sinh)
+    if (name == "cosh") return (ok = true, op = GLSLstd450.Cosh)
+    if (name == "tanh") return (ok = true, op = GLSLstd450.Tanh)
+    if (name == "asinh") return (ok = true, op = GLSLstd450.Asinh)
+    if (name == "acosh") return (ok = true, op = GLSLstd450.Acosh)
+    if (name == "atanh") return (ok = true, op = GLSLstd450.Atanh)
+    if (name == "mad") return (ok = true, op = GLSLstd450.Fma)
+    if (name == "radians") return (ok = true, op = GLSLstd450.Radians)
+    if (name == "degrees") return (ok = true, op = GLSLstd450.Degrees)
     if (name == "pow") return (ok = true, op = GLSLstd450.Pow)
     if (name == "exp") return (ok = true, op = GLSLstd450.Exp)
     if (name == "log") return (ok = true, op = GLSLstd450.Log)
@@ -2123,6 +2131,21 @@ class SpirvEmit : AstVisitor {
             }
             emit_n(bm, SEC_FUNCS, SpvOp.CompositeConstruct, cons)
             delete cons
+            e2id[k] = res
+            return expr
+        }
+        // fmod: core OpFRem (C fmod semantics — sign-of-dividend). NOT a GLSL.std.450 ext-inst.
+        if (name == "fmod") {
+            if (length(expr.arguments) != 2) {
+                errs |> push("fmod expects 2 arguments")
+                return expr
+            }
+            let a = value_of(expr.arguments[0])
+            let b = value_of(expr.arguments[1])
+            if (a == 0u || b == 0u) return expr
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.FRem, rt, res, a, b)
             e2id[k] = res
             return expr
         }

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -719,21 +719,21 @@ namespace das {
             addExternEx<float3(float3,float3,float),DAS_BIND_FUN(lerp_vec_float)>(*this, lib, "lerp", SideEffects::none, "lerp_vec_float")->args({"a", "b", "t"});
             addExternEx<float4(float4,float4,float),DAS_BIND_FUN(lerp_vec_float)>(*this, lib, "lerp", SideEffects::none, "lerp_vec_float")->args({"a", "b", "t"});
             addExternEx<float(float,float),DAS_BIND_FUN(step_float)>(*this, lib, "step", SideEffects::none, "step_float")->args({"edge","x"});
-            addExternEx<float2(float2,float2),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec2")->args({"edge","x"});
-            addExternEx<float3(float3,float3),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec3")->args({"edge","x"});
-            addExternEx<float4(float4,float4),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec4")->args({"edge","x"});
+            addExternEx<float2(float2,float2),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec")->args({"edge","x"});
+            addExternEx<float3(float3,float3),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec")->args({"edge","x"});
+            addExternEx<float4(float4,float4),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec")->args({"edge","x"});
             addExternEx<float(float,float,float),DAS_BIND_FUN(smoothstep_float)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_float")->args({"edge0","edge1","x"});
-            addExternEx<float2(float2,float2,float2),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec2")->args({"edge0","edge1","x"});
-            addExternEx<float3(float3,float3,float3),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec3")->args({"edge0","edge1","x"});
-            addExternEx<float4(float4,float4,float4),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec4")->args({"edge0","edge1","x"});
+            addExternEx<float2(float2,float2,float2),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec")->args({"edge0","edge1","x"});
+            addExternEx<float3(float3,float3,float3),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec")->args({"edge0","edge1","x"});
+            addExternEx<float4(float4,float4,float4),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec")->args({"edge0","edge1","x"});
             addExternEx<float(float),DAS_BIND_FUN(radians_float)>(*this, lib, "radians", SideEffects::none, "radians_float")->arg("deg");
-            addExternEx<float2(float2),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec2")->arg("deg");
-            addExternEx<float3(float3),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec3")->arg("deg");
-            addExternEx<float4(float4),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec4")->arg("deg");
+            addExternEx<float2(float2),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec")->arg("deg");
+            addExternEx<float3(float3),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec")->arg("deg");
+            addExternEx<float4(float4),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec")->arg("deg");
             addExternEx<float(float),DAS_BIND_FUN(degrees_float)>(*this, lib, "degrees", SideEffects::none, "degrees_float")->arg("rad");
-            addExternEx<float2(float2),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec2")->arg("rad");
-            addExternEx<float3(float3),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec3")->arg("rad");
-            addExternEx<float4(float4),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec4")->arg("rad");
+            addExternEx<float2(float2),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec")->arg("rad");
+            addExternEx<float3(float3),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec")->arg("rad");
+            addExternEx<float4(float4),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec")->arg("rad");
 
             // unique float functions
             addExtern<DAS_BIND_FUN(fisnan)>(*this, lib, "is_nan", SideEffects::none, "fisnan")->arg("x");

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -726,6 +726,14 @@ namespace das {
             addExternEx<float2(float2,float2,float2),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec2")->args({"edge0","edge1","x"});
             addExternEx<float3(float3,float3,float3),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec3")->args({"edge0","edge1","x"});
             addExternEx<float4(float4,float4,float4),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec4")->args({"edge0","edge1","x"});
+            addExternEx<float(float),DAS_BIND_FUN(radians_float)>(*this, lib, "radians", SideEffects::none, "radians_float")->arg("deg");
+            addExternEx<float2(float2),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec2")->arg("deg");
+            addExternEx<float3(float3),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec3")->arg("deg");
+            addExternEx<float4(float4),DAS_BIND_FUN(radians_vec)>(*this, lib, "radians", SideEffects::none, "radians_vec4")->arg("deg");
+            addExternEx<float(float),DAS_BIND_FUN(degrees_float)>(*this, lib, "degrees", SideEffects::none, "degrees_float")->arg("rad");
+            addExternEx<float2(float2),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec2")->arg("rad");
+            addExternEx<float3(float3),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec3")->arg("rad");
+            addExternEx<float4(float4),DAS_BIND_FUN(degrees_vec)>(*this, lib, "degrees", SideEffects::none, "degrees_vec4")->arg("rad");
 
             // unique float functions
             addExtern<DAS_BIND_FUN(fisnan)>(*this, lib, "is_nan", SideEffects::none, "fisnan")->arg("x");

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -718,6 +718,14 @@ namespace das {
             addExternEx<float2(float2,float2,float),DAS_BIND_FUN(lerp_vec_float)>(*this, lib, "lerp", SideEffects::none, "lerp_vec_float")->args({"a", "b", "t"});
             addExternEx<float3(float3,float3,float),DAS_BIND_FUN(lerp_vec_float)>(*this, lib, "lerp", SideEffects::none, "lerp_vec_float")->args({"a", "b", "t"});
             addExternEx<float4(float4,float4,float),DAS_BIND_FUN(lerp_vec_float)>(*this, lib, "lerp", SideEffects::none, "lerp_vec_float")->args({"a", "b", "t"});
+            addExternEx<float(float,float),DAS_BIND_FUN(step_float)>(*this, lib, "step", SideEffects::none, "step_float")->args({"edge","x"});
+            addExternEx<float2(float2,float2),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec2")->args({"edge","x"});
+            addExternEx<float3(float3,float3),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec3")->args({"edge","x"});
+            addExternEx<float4(float4,float4),DAS_BIND_FUN(step_vec)>(*this, lib, "step", SideEffects::none, "step_vec4")->args({"edge","x"});
+            addExternEx<float(float,float,float),DAS_BIND_FUN(smoothstep_float)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_float")->args({"edge0","edge1","x"});
+            addExternEx<float2(float2,float2,float2),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec2")->args({"edge0","edge1","x"});
+            addExternEx<float3(float3,float3,float3),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec3")->args({"edge0","edge1","x"});
+            addExternEx<float4(float4,float4,float4),DAS_BIND_FUN(smoothstep_vec)>(*this, lib, "smoothstep", SideEffects::none, "smoothstep_vec4")->args({"edge0","edge1","x"});
 
             // unique float functions
             addExtern<DAS_BIND_FUN(fisnan)>(*this, lib, "is_nan", SideEffects::none, "fisnan")->arg("x");

--- a/tests/math/test_fmod_mad.das
+++ b/tests/math/test_fmod_mad.das
@@ -1,0 +1,46 @@
+options gen2
+require math
+require dastest/testing_boost public
+
+options optimize = false
+
+// Stage-2 math-shader-breadth: fmod + mad get dasSpirv + llvm_jit dispatch coverage. fmod maps to
+// GLSLstd450.FMod (FRem in LLVM); mad maps to GLSLstd450.Fma (= a*b + c per sim_policy). C++
+// bindings already exist for float scalar + float2/3/4; this test pins per-tier float correctness.
+
+[test]
+def test_fmod_scalar(t : T?) {
+    t |> equal(fmod(5.5f, 2.0f), 1.5f)
+    t |> equal(fmod(-5.5f, 2.0f), -1.5f)
+    t |> equal(fmod(5.5f, -2.0f), 1.5f)
+    t |> equal(fmod(0.0f, 1.0f), 0.0f)
+}
+
+[test]
+def test_fmod_vec(t : T?) {
+    let r2 = fmod(float2(5.5, -5.5), float2(2.0, 2.0))
+    t |> success(abs(r2.x - 1.5f) < 1.0e-5f && abs(r2.y + 1.5f) < 1.0e-5f, "fmod(float2) per-lane")
+    let r3 = fmod(float3(5.5, 0.0, 7.25), float3(2.0, 1.0, 2.5))
+    t |> success(abs(r3.x - 1.5f) < 1.0e-5f && abs(r3.y) < 1.0e-5f && abs(r3.z - 2.25f) < 1.0e-5f, "fmod(float3) per-lane")
+    let r4 = fmod(float4(5.5, 5.5, -5.5, 10.0), float4(2.0, -2.0, -2.0, 3.0))
+    t |> success(abs(r4.x - 1.5f) < 1.0e-5f && abs(r4.y - 1.5f) < 1.0e-5f && abs(r4.z + 1.5f) < 1.0e-5f && abs(r4.w - 1.0f) < 1.0e-5f, "fmod(float4) per-lane")
+}
+
+[test]
+def test_mad_scalar(t : T?) {
+    // mad(a, b, c) = a*b + c
+    t |> equal(mad(2.0f, 3.0f, 4.0f), 10.0f)
+    t |> equal(mad(0.0f, 0.0f, 5.0f), 5.0f)
+    t |> equal(mad(-1.0f, 2.0f, 3.0f), 1.0f)
+}
+
+[test]
+def test_mad_vec(t : T?) {
+    // float2 vec form: mad(a : float2, b : float, c : float2) = a*b + c
+    let r2 = mad(float2(1.0, 2.0), 3.0f, float2(4.0, 5.0))
+    t |> success(abs(r2.x - 7.0f) < 1.0e-5f && abs(r2.y - 11.0f) < 1.0e-5f, "mad(float2) lanes")
+    let r3 = mad(float3(1.0, 2.0, 3.0), 2.0f, float3(0.0, 1.0, -1.0))
+    t |> success(abs(r3.x - 2.0f) < 1.0e-5f && abs(r3.y - 5.0f) < 1.0e-5f && abs(r3.z - 5.0f) < 1.0e-5f, "mad(float3) lanes")
+    let r4 = mad(float4(1.0, 2.0, 3.0, 4.0), 1.5f, float4(0.5, 0.5, 0.5, 0.5))
+    t |> success(abs(r4.x - 2.0f) < 1.0e-5f && abs(r4.y - 3.5f) < 1.0e-5f && abs(r4.z - 5.0f) < 1.0e-5f && abs(r4.w - 6.5f) < 1.0e-5f, "mad(float4) lanes")
+}

--- a/tests/math/test_fmod_mad.das
+++ b/tests/math/test_fmod_mad.das
@@ -5,8 +5,9 @@ require dastest/testing_boost public
 options optimize = false
 
 // Stage-2 math-shader-breadth: fmod + mad get dasSpirv + llvm_jit dispatch coverage. fmod maps to
-// GLSLstd450.FMod (FRem in LLVM); mad maps to GLSLstd450.Fma (= a*b + c per sim_policy). C++
-// bindings already exist for float scalar + float2/3/4; this test pins per-tier float correctness.
+// SPIR-V core OpFRem (GLSL.std.450 has no FMod sub-opcode; OpFRem matches C fmod sign-of-dividend
+// semantics) / LLVM frem; mad maps to GLSLstd450.Fma (= a*b + c per sim_policy). C++ bindings
+// already exist for float scalar + float2/3/4; this test pins per-tier float correctness.
 
 [test]
 def test_fmod_scalar(t : T?) {

--- a/tests/math/test_hyperbolic.das
+++ b/tests/math/test_hyperbolic.das
@@ -1,0 +1,49 @@
+options gen2
+require math
+require dastest/testing_boost public
+
+options optimize = false
+
+// Stage-2 math-shader-breadth: hyperbolic trig family (sinh/cosh/tanh + inverses) gets dasSpirv +
+// llvm_jit dispatch coverage. C++ bindings already exist for float scalar + float2/3/4; this test
+// pins the float-side correctness (identity-at-zero + small-x round-trips) across the three tiers
+// under dastest --isolated-mode. Doubles already covered by tests/math/math_misc.das.
+
+[test]
+def test_hyperbolic_identity_at_zero(t : T?) {
+    t |> success(abs(sinh(0.0f)) < 1.0e-6f, "sinh(0)=0")
+    t |> success(abs(cosh(0.0f) - 1.0f) < 1.0e-6f, "cosh(0)=1")
+    t |> success(abs(tanh(0.0f)) < 1.0e-6f, "tanh(0)=0")
+    t |> success(abs(asinh(0.0f)) < 1.0e-6f, "asinh(0)=0")
+    t |> success(abs(acosh(1.0f)) < 1.0e-6f, "acosh(1)=0")
+    t |> success(abs(atanh(0.0f)) < 1.0e-6f, "atanh(0)=0")
+}
+
+[test]
+def test_inverse_roundtrip(t : T?) {
+    // asinh(sinh(x)) = x; tanh<->atanh and cosh<->acosh require |x|<1 / x>=1 domains.
+    let x = 0.5f
+    t |> success(abs(asinh(sinh(x)) - x) < 1.0e-5f, "asinh(sinh(0.5))=0.5")
+    t |> success(abs(atanh(tanh(x)) - x) < 1.0e-5f, "atanh(tanh(0.5))=0.5")
+    t |> success(abs(acosh(cosh(x)) - x) < 1.0e-5f, "acosh(cosh(0.5))=0.5")
+}
+
+[test]
+def test_hyperbolic_vec(t : T?) {
+    let s3 = sinh(float3(0.0, 0.0, 0.0))
+    t |> success(abs(s3.x) < 1.0e-6f && abs(s3.y) < 1.0e-6f && abs(s3.z) < 1.0e-6f, "sinh(float3(0)) lanes")
+    let c4 = cosh(float4(0.0, 0.0, 0.0, 0.0))
+    t |> success(abs(c4.x - 1.0f) < 1.0e-6f && abs(c4.y - 1.0f) < 1.0e-6f && abs(c4.z - 1.0f) < 1.0e-6f && abs(c4.w - 1.0f) < 1.0e-6f, "cosh(float4(0)) lanes")
+    let th2 = tanh(float2(0.0, 0.0))
+    t |> success(abs(th2.x) < 1.0e-6f && abs(th2.y) < 1.0e-6f, "tanh(float2(0)) lanes")
+}
+
+[test]
+def test_inverse_hyperbolic_vec(t : T?) {
+    let as3 = asinh(float3(0.0, 0.0, 0.0))
+    t |> success(abs(as3.x) < 1.0e-6f && abs(as3.y) < 1.0e-6f && abs(as3.z) < 1.0e-6f, "asinh(float3(0)) lanes")
+    let ac4 = acosh(float4(1.0, 1.0, 1.0, 1.0))
+    t |> success(abs(ac4.x) < 1.0e-5f && abs(ac4.y) < 1.0e-5f && abs(ac4.z) < 1.0e-5f && abs(ac4.w) < 1.0e-5f, "acosh(float4(1)) lanes")
+    let at2 = atanh(float2(0.0, 0.0))
+    t |> success(abs(at2.x) < 1.0e-6f && abs(at2.y) < 1.0e-6f, "atanh(float2(0)) lanes")
+}

--- a/tests/math/test_radians_degrees.das
+++ b/tests/math/test_radians_degrees.das
@@ -1,0 +1,46 @@
+options gen2
+require math
+require dastest/testing_boost public
+
+options optimize = false
+
+// Stage-2 math-shader-breadth: radians + degrees promoted from daslib/math_boost to the C++ math
+// module so dasSpirv can lower them in shaders. Scalar + float2/3/4 correctness across the three
+// execution tiers (interpreter / JIT / AOT) under dastest --isolated-mode.
+
+let PI_F = 3.14159265358979323846f
+
+[test]
+def test_radians_scalar(t : T?) {
+    t |> equal(radians(0.0f), 0.0f)
+    t |> success(abs(radians(180.0f) - PI_F) < 1.0e-5f, "radians(180) ~= pi")
+    t |> success(abs(radians(90.0f) - PI_F * 0.5f) < 1.0e-5f, "radians(90) ~= pi/2")
+    t |> success(abs(radians(-180.0f) + PI_F) < 1.0e-5f, "radians(-180) ~= -pi")
+}
+
+[test]
+def test_degrees_scalar(t : T?) {
+    t |> equal(degrees(0.0f), 0.0f)
+    t |> success(abs(degrees(PI_F) - 180.0f) < 1.0e-3f, "degrees(pi) ~= 180")
+    t |> success(abs(degrees(PI_F * 0.5f) - 90.0f) < 1.0e-3f, "degrees(pi/2) ~= 90")
+}
+
+[test]
+def test_radians_vec(t : T?) {
+    let r2 = radians(float2(0.0, 180.0))
+    t |> success(abs(r2.x) < 1.0e-5f && abs(r2.y - PI_F) < 1.0e-5f, "radians(float2) per-lane")
+    let r3 = radians(float3(0.0, 90.0, 180.0))
+    t |> success(abs(r3.x) < 1.0e-5f && abs(r3.y - PI_F * 0.5f) < 1.0e-5f && abs(r3.z - PI_F) < 1.0e-5f, "radians(float3) per-lane")
+    let r4 = radians(float4(0.0, 45.0, 90.0, 180.0))
+    t |> success(abs(r4.x) < 1.0e-5f && abs(r4.y - PI_F * 0.25f) < 1.0e-5f && abs(r4.z - PI_F * 0.5f) < 1.0e-5f && abs(r4.w - PI_F) < 1.0e-5f, "radians(float4) per-lane")
+}
+
+[test]
+def test_degrees_vec(t : T?) {
+    let d2 = degrees(float2(0.0, PI_F))
+    t |> success(abs(d2.x) < 1.0e-3f && abs(d2.y - 180.0f) < 1.0e-3f, "degrees(float2) per-lane")
+    let d3 = degrees(float3(0.0, PI_F * 0.5f, PI_F))
+    t |> success(abs(d3.x) < 1.0e-3f && abs(d3.y - 90.0f) < 1.0e-3f && abs(d3.z - 180.0f) < 1.0e-3f, "degrees(float3) per-lane")
+    let d4 = degrees(float4(0.0, PI_F * 0.25f, PI_F * 0.5f, PI_F))
+    t |> success(abs(d4.x) < 1.0e-3f && abs(d4.y - 45.0f) < 1.0e-3f && abs(d4.z - 90.0f) < 1.0e-3f && abs(d4.w - 180.0f) < 1.0e-3f, "degrees(float4) per-lane")
+}

--- a/tests/math/test_step_smoothstep.das
+++ b/tests/math/test_step_smoothstep.das
@@ -1,0 +1,50 @@
+options gen2
+require math
+require dastest/testing_boost public
+
+options optimize = false
+
+// Math correctness for step + smoothstep: scalar GLSL semantics plus float2/3/4 per-lane sanity.
+// dastest --isolated-mode exercises interpreter / JIT / AOT; one test file covers all three.
+
+[test]
+def test_step_scalar(t : T?) {
+    // GLSL: step(edge, x) = x < edge ? 0 : 1. At x == edge the result is 1.
+    t |> equal(step(0.5f, 0.3f), 0.0f)
+    t |> equal(step(0.5f, 0.7f), 1.0f)
+    t |> equal(step(0.5f, 0.5f), 1.0f)
+    t |> equal(step(0.0f, -0.1f), 0.0f)
+    t |> equal(step(0.0f, 0.0f), 1.0f)
+}
+
+[test]
+def test_step_vec(t : T?) {
+    t |> equal(step(float2(0.5, 0.5), float2(0.3, 0.7)), float2(0.0, 1.0))
+    t |> equal(step(float3(0.0, 1.0, -1.0), float3(0.5, 1.0, -2.0)), float3(1.0, 1.0, 0.0))
+    t |> equal(step(float4(0.0, 0.0, 0.0, 0.0), float4(-1.0, 0.0, 1.0, 2.0)), float4(0.0, 1.0, 1.0, 1.0))
+}
+
+[test]
+def test_smoothstep_scalar(t : T?) {
+    // t = clamp((x-e0)/(e1-e0), 0, 1); return t*t*(3-2t).
+    // smoothstep(0, 1, 0.5) -> t=0.5 -> 0.25 * (3-1) = 0.5
+    t |> equal(smoothstep(0.0f, 1.0f, 0.5f), 0.5f)
+    // Outside the band clamps: below e0 -> 0, above e1 -> 1.
+    t |> equal(smoothstep(0.0f, 1.0f, -1.0f), 0.0f)
+    t |> equal(smoothstep(0.0f, 1.0f, 2.0f), 1.0f)
+    // Endpoints: at e0 t=0 -> 0; at e1 t=1 -> 1*1*(3-2) = 1.
+    t |> equal(smoothstep(0.0f, 1.0f, 0.0f), 0.0f)
+    t |> equal(smoothstep(0.0f, 1.0f, 1.0f), 1.0f)
+    // Off-zero edge band: smoothstep(2,4,3) -> t=0.5 -> 0.5
+    t |> equal(smoothstep(2.0f, 4.0f, 3.0f), 0.5f)
+}
+
+[test]
+def test_smoothstep_vec(t : T?) {
+    let s2 = smoothstep(float2(0.0, 0.0), float2(1.0, 1.0), float2(0.5, -1.0))
+    t |> equal(s2, float2(0.5, 0.0))
+    let s3 = smoothstep(float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0), float3(0.5, 2.0, 1.0))
+    t |> equal(s3, float3(0.5, 1.0, 1.0))
+    let s4 = smoothstep(float4(0.0, 0.0, 0.0, 0.0), float4(1.0, 1.0, 1.0, 1.0), float4(0.5, 0.0, 1.0, -1.0))
+    t |> equal(s4, float4(0.5, 0.0, 1.0, 0.0))
+}

--- a/tests/spirv/_fail_closed/_fc_call.das
+++ b/tests/spirv/_fail_closed/_fc_call.das
@@ -1,5 +1,5 @@
-// Fail-closed fixture: calling a builtin/host function the emitter does not lower (here `tanh`, a
-// math builtin with no GLSL.std.450 mapping in the emitter) must be rejected cleanly — never a
+// Fail-closed fixture: calling a builtin/host function the emitter does not lower (here `safe_acos`,
+// a math builtin with no GLSL.std.450 mapping in the emitter) must be rejected cleanly — never a
 // silent blob. User-defined function calls ARE supported now (see test_functions.das); this guards
 // the "builtin not allowed" boundary. `expect 50501` makes lint skip the intentionally-failing shader.
 expect 50501
@@ -15,5 +15,5 @@ var @ssbo @binding = 0 data : array<float>
 [compute_shader(local_size_x=64, name="fc_call_spv")]
 def fc_call {
     let i = gl_GlobalInvocationID.x
-    data[i] = tanh(data[i])
+    data[i] = safe_acos(data[i])
 }

--- a/tests/spirv/test_fail_closed.das
+++ b/tests/spirv/test_fail_closed.das
@@ -44,7 +44,7 @@ def private check_rejects(t : T?; fixture, needle : string) {
 [test]
 def test_fail_closed_rejections(t : T?) {
     t |> run("emitter rejects shader-illegal constructs cleanly") <| @(t : T?) {
-        check_rejects(t, "_fc_call", "cannot call 'tanh'")
+        check_rejects(t, "_fc_call", "cannot call 'safe_acos'")
         check_rejects(t, "_fc_global", "unsupported global 'g_scale'")
         check_rejects(t, "_fc_localtype", "type tDouble is not supported")
         check_rejects(t, "_fc_stmt", "memzero is not supported in SPIR-V shaders")

--- a/tests/spirv/test_math_breadth.das
+++ b/tests/spirv/test_math_breadth.das
@@ -1,0 +1,73 @@
+options gen2
+options indenting = 4
+
+// Stage-2 math-shader-breadth: hyperbolic (sinh/cosh/tanh/asinh/acosh/atanh), fmod, mad,
+// radians, degrees all map to GLSL.std.450 ext-inst sub-opcodes. The dasSpirv emitter routes
+// each daslang name through glsl_ext_op; this test pins every Stage-2 sub-opcode by
+// (OpExtInst operand index 3 == GLSLstd450 instruction literal) and spirv-val's the blob.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_shader
+require spirv/spirv_builtins
+require spirv/spirv_dis
+require spirv/spirv_grammar
+require math
+
+// Dedicated fragment fixture: scalar + float3 inputs exercise both scalar and vec3 ext-inst variants.
+// spirv-val rejects mismatched ext-inst operand types.
+var @in @location = 0 mb_in : float4
+var @out @location = 0 mb_out : float4
+[fragment_shader(name="mathb_spv"), marker(no_coverage)]
+def mathb {
+    let x = mb_in.x
+    let y = mb_in.y
+    let v = float3(x, y, x)
+    let w = float3(y, x, y)
+    var r = 0.0f
+    r += sinh(x) + cosh(x) + tanh(x)
+    r += asinh(x) + acosh(x + 1.5f) + atanh(x * 0.5f)
+    r += fmod(x, y) + mad(x, y, x)
+    r += radians(x) + degrees(x)
+    let vh = sinh(v) + cosh(v) + tanh(v)
+    let vi = asinh(v) + acosh(v + float3(1.5f, 1.5f, 1.5f)) + atanh(v * 0.5f)
+    let vf = fmod(v, w) + mad(v, w, v)
+    let vr = radians(v) + degrees(v)
+    mb_out = float4(r + vh.x + vi.x + vf.x + vr.x, 0.0f, 0.0f, 1.0f)
+}
+
+def private mathb_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(mathb_spv)
+    return <- w
+}
+
+def private has_ext(words : array<uint>; op : GLSLstd450) : bool {
+    return op_has_operand_at(words, SpvOp.ExtInst, 3, uint(op))   // operand 3 = GLSLstd450 instruction literal
+}
+
+[test]
+def test_glsl_std450_breadth_stage2(t : T?) {
+    t |> run("GLSL.std.450: Stage-2 hyperbolic + fmod + mad + radians/degrees") <| @(t : T?) {
+        var words <- mathb_words()
+        t |> success(has_ext(words, GLSLstd450.Sinh), "sinh -> Sinh")
+        t |> success(has_ext(words, GLSLstd450.Cosh), "cosh -> Cosh")
+        t |> success(has_ext(words, GLSLstd450.Tanh), "tanh -> Tanh")
+        t |> success(has_ext(words, GLSLstd450.Asinh), "asinh -> Asinh")
+        t |> success(has_ext(words, GLSLstd450.Acosh), "acosh -> Acosh")
+        t |> success(has_ext(words, GLSLstd450.Atanh), "atanh -> Atanh")
+        // fmod uses the SPIR-V core OpFRem (C fmod semantics — sign-of-dividend),
+        // NOT a GLSL.std.450 ext-inst. GLSL.std.450 has no FMod sub-opcode.
+        t |> success(has_op(words, SpvOp.FRem), "fmod -> OpFRem")
+        t |> success(has_ext(words, GLSLstd450.Fma), "mad -> Fma")
+        t |> success(has_ext(words, GLSLstd450.Radians), "radians -> Radians")
+        t |> success(has_ext(words, GLSLstd450.Degrees), "degrees -> Degrees")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "mathb: spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}

--- a/tests/spirv/test_math_breadth.das
+++ b/tests/spirv/test_math_breadth.das
@@ -9,7 +9,6 @@ options indenting = 4
 require dastest/testing_boost public
 require _spirv_common
 require spirv/spirv_shader
-require spirv/spirv_builtins
 require spirv/spirv_dis
 require spirv/spirv_grammar
 require math

--- a/tests/spirv/test_math_step.das
+++ b/tests/spirv/test_math_step.das
@@ -1,0 +1,58 @@
+options gen2
+options indenting = 4
+
+// Stage-1 math-shader-breadth: step + smoothstep are GLSL.std.450 ext-inst opcodes 48/49. The dasSpirv
+// emitter maps the daslang `step`/`smoothstep` names through glsl_ext_op; this test pins each call by
+// its GLSLstd450 sub-opcode (OpExtInst operand index 3 = the instruction literal) and spirv-val's the
+// whole module so per-arg type-checking runs.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_shader
+require spirv/spirv_builtins
+require spirv/spirv_dis
+require spirv/spirv_grammar
+require math
+
+// Dedicated fragment fixture: scalar + float3 inputs feed step and smoothstep so both the float and
+// vec3 ext-inst variants are emitted. spirv-val rejects mismatched ext-inst operand types.
+var @in @location = 0 ss_in : float4
+var @out @location = 0 ss_out : float4
+[fragment_shader(name="stepfn_spv"), marker(no_coverage)]
+def stepfn {
+    let x = ss_in.x
+    let y = ss_in.y
+    let v = float3(x, y, x)
+    let w = float3(y, x, y)
+    let s_scalar = step(0.5f, x)
+    let s_vec = step(v, w)
+    let ss_scalar = smoothstep(0.0f, 1.0f, x)
+    let ss_vec = smoothstep(v, w, float3(0.5f, 0.5f, 0.5f))
+    ss_out = float4(s_scalar + ss_scalar + s_vec.x + ss_vec.x, 0.0f, 0.0f, 1.0f)
+}
+
+def private stepfn_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(stepfn_spv)
+    return <- w
+}
+
+def private has_ext(words : array<uint>; op : GLSLstd450) : bool {
+    return op_has_operand_at(words, SpvOp.ExtInst, 3, uint(op))   // operand 3 = GLSLstd450 instruction literal
+}
+
+[test]
+def test_glsl_std450_step(t : T?) {
+    t |> run("GLSL.std.450: step + smoothstep map to Step/SmoothStep") <| @(t : T?) {
+        var words <- stepfn_words()
+        t |> success(has_ext(words, GLSLstd450.Step), "step -> Step")
+        t |> success(has_ext(words, GLSLstd450.SmoothStep), "smoothstep -> SmoothStep")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "stepfn: spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}

--- a/tests/spirv/test_math_step.das
+++ b/tests/spirv/test_math_step.das
@@ -9,7 +9,6 @@ options indenting = 4
 require dastest/testing_boost public
 require _spirv_common
 require spirv/spirv_shader
-require spirv/spirv_builtins
 require spirv/spirv_dis
 require spirv/spirv_grammar
 require math


### PR DESCRIPTION
## Why

Authoring the SDF raymarch tutorial in [dasVulkan #15](https://github.com/borisbat/dasVulkan/pull/15) surfaced gaps in the math surface accessible from shaders. Audit across three surfaces (`math.cpp`, dasSpirv `glsl_ext_op`, llvm_jit `g_intrin_lookup`) found:

| Category | Names | Status before |
|---|---|---|
| **Genuinely missing in `math`** | `step`, `smoothstep` | No daslang signature anywhere → shader code couldn't even typecheck |
| **In daslang, missing dasSpirv dispatch** | `mad`, `fmod`, `sinh`/`cosh`/`tanh`/`asinh`/`acosh`/`atanh` | Slow `OpFunctionCall` (or broken — see `lerp_vec_float` note below) |
| **Daslib das-only, can't be lowered** | `radians`, `degrees` | Lived in `daslib/math_boost.das` referencing a PI global the dasSpirv dep walker can't lower → unusable in shaders |
| **Already done** | `mix → lerp → FMix`, `inversesqrt → rsqrt → InverseSqrt` | renames documented in `spirv_emit.das:744` |
| **Deferred to follow-up PR** | `saturate`/`rcp` composed-emit (FClamp(x,0,1) / FDiv); JIT-only fill for `acos`/`asin`/`atan`/`atan2`/`distance`/`reflect`/`refract` | Out of scope here — saturate/rcp work today via OpFunctionCall fallback; JIT trig works via extern dispatch |

## What changed (two commits, regression-bisect-friendly)

### Commit 1 — `math: add step + smoothstep`

Genuinely new functions. Same `addExternEx` binding shape as `lerp_vec_float` / `distance2/3/4`.

- `include/daScript/simulate/aot_builtin_math.h`: 4 inline helpers (`step_float`, `smoothstep_float`, `step_vec`, `smoothstep_vec`). Vec versions use `v_cmp_lt`/`v_sel`/`v_saturate`/`v_madd`.
- `src/builtin/module_builtin_math.cpp`: 8 `addExternEx` bindings (scalar + float2/3/4).
- `modules/dasSpirv/spirv/spirv_emit.das`: 2 entries in `glsl_ext_op` (`step → Step`, `smoothstep → SmoothStep`).
- `modules/dasLLVM/daslib/llvm_jit_intrin.das`: 2 dispatch entries + 2 impls (`intrinsic_math_step` is fcmp+select, `intrinsic_math_smoothstep` is `(x-e0)/(e1-e0)` → clamp → `t*t*(3-2t)`). Both broadcast 0/1/2/3 constants over the vector type.

### Commit 2 — `math: Tier B dispatch sweep`

- `modules/dasSpirv/spirv/spirv_emit.das`: 9 simple `glsl_ext_op` entries (`Sinh`/`Cosh`/`Tanh`/`Asinh`/`Acosh`/`Atanh`/`Fma`/`Radians`/`Degrees`) + **`fmod` takes a separate path emitting core `OpFRem`** — GLSL.std.450 has no `FMod` sub-opcode (my stage-2 brief had a stale claim; agent caught it). Exclusion comment trimmed.
- `modules/dasLLVM/daslib/llvm_jit_intrin.das`: 7 dispatch entries + 4 helpers (`intrinsic_math_radians`/`degrees` = broadcast PI/180 const + FMul; `intrinsic_math_fmod` = `LLVMBuildFRem`; `intrinsic_math_sinh_cosh_tanh` forwards to `llvm.{sinh,cosh,tanh}.f32/f64` via existing `intrinsic_math_any_float_op1`).
- `include/daScript/simulate/aot_builtin_math.h`: 4 inline helpers for `radians`/`degrees`.
- `src/builtin/module_builtin_math.cpp`: 8 `addExternEx` bindings (scalar + float2/3/4 for both names).
- `daslib/math_boost.das`: deleted `def radians`/`def degrees` (math_boost re-exports `require math public`; only known caller `examples/daslive/tank_game/main.das` picks up C++ versions transitively).
- `tests/spirv/_fail_closed/_fc_call.das` + `tests/spirv/test_fail_closed.das`: swapped `tanh` → `safe_acos` (tanh is now callable from shaders, so the negative test needed a different unsupported name).

## Tests

All new + regression green on Windows MSVC Release, interpreter + JIT + AOT via `--isolated-mode`. **128/128 `tests/math`** and **118/118 `tests/spirv`** total. Per file:

| File | Coverage |
|---|---|
| `tests/math/test_step_smoothstep.das` | scalar GLSL boundary (`step(0.5, 0.5) == 1.0`), vec2/3/4 per-lane |
| `tests/math/test_radians_degrees.das` | scalar + vec at 0/45/90/180 deg vs π multiples |
| `tests/math/test_hyperbolic.das` | identity-at-zero + inverse round-trips for all six + vec lanes |
| `tests/math/test_fmod_mad.das` | fmod sign-of-dividend, mad = a*b+c scalar+vec |
| `tests/spirv/test_math_step.das` | asserts `OpExtInst Step` + `OpExtInst SmoothStep` opcodes + spirv-val |
| `tests/spirv/test_math_breadth.das` | asserts every Stage-2 sub-opcode (`Radians`/`Degrees`/`Sinh`/`Cosh`/`Tanh`/`Asinh`/`Acosh`/`Atanh`/`Fma`) **and** `has_op(SpvOp.FRem)` for fmod + spirv-val |
| `tests/spirv/test_census.das` | regression — `ExtInst` already in census, sub-opcodes aren't tracked there (verified no census update needed) |

## Out-of-scope, recorded for follow-up

- **`saturate` / `rcp` composed-emit in dasSpirv** — both work today through OpFunctionCall fallback. Composed-emit (FClamp(x,0,1) + FDiv) would route through ext-inst with composed-constant operands; emit path is different from the simple table dispatch (needs to build constants + compose ids before emitting). Separate PR.
- **JIT-only fill** — `acos`/`asin`/`atan`/`atan2`/`distance`/`reflect`/`refract` exist in `math.cpp` and dasSpirv but aren't in `g_intrin_lookup`. Function-call fallback works; intrinsic JIT would tighten codegen. Separate PR.
- **`asinh`/`acosh`/`atanh` JIT inlining** — LLVM has no direct `llvm.{asinh,acosh,atanh}` intrinsics; the existing extern dispatch (binding to `fasinh`/`facosh`/`fatanh`) works correctly. Adding `LLVMBuildCall2` to `libcm` symbols would need fresh `LLVMAddFunctionWithType` plumbing. Left for the broader JIT-fill PR if it's worth doing.
- **Stale JIT-cache hash gap** — surfaced during dev: `g_intrin_lookup` table changes don't invalidate cached `.jitted_scripts/*.dll` because the cache hash folds AOT hashes per function but not the table itself. Recovery is one-time (clear cache); doesn't affect users on fresh checkouts but worth a follow-up tightening.
- **dasSpirv `lerp_vec_float` scalar-broadcast bug** — surfaced in dasVulkan #15: when you call `lerp(vec, vec, float)` (the scalar-t overload at `module_builtin_math.cpp:718`), the dasSpirv emitter passes scalar `t` to FMix without broadcasting → invalid SPIR-V, crashes pipeline creation. The vec-vec-vec form `lerp(vec, vec, vec)` works. Two fixes possible (broadcast at emit / reject the overload); separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)