### PR TITLE
flatten_opt: boolean-inversion folds (comparison negation + De Morgan)

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -863,6 +863,8 @@ class private FoldResidualVisitor : AstVisitor {
     def override preVisitExprOp1(expr : ExprOp1?) : void {
         if (expr.op == "!" && expr.subexpr is ExprConstBool) {
             found |> push("an unfolded constant '!'")
+        } elif (expr.op == "!" && can_negate_bool(expr.subexpr, noFastMath)) {
+            found |> push("an unfolded boolean inversion ('!' over a comparison / '!' / && / ||)")
         }
     }
     def override preVisitExprSwizzle(var expr : ExprSwizzle?) : void {

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -637,11 +637,16 @@ class private FoldVisitor : AstVisitor {
         return that
     }
     def override visitExprOp1(var that : ExprOp1?) : ExpressionPtr {
-        // `!true → false`, `!false → true` — const operand only (already folded
-        // post-order). Double-negation `!!x → x` is intentionally out of scope.
+        // `!true → false`, `!false → true` (const operand). Then push `!` into its operand
+        // where it eliminates — flip a comparison (`!(a > b) → a <= b`), drop a double `!`,
+        // De-Morgan through `&&` / `||` — via negate_bool; it returns null (leave the `!`)
+        // when a residual `!` would remain. The select-fold above emits `c ? false : true → !c`,
+        // so this is what collapses the resulting `!comparison`.
         if (that.op == "!") {
             if (is_bool_val(that.subexpr, true)) { changed = true; return new ExprConstBool(at = that.at, value = false) }
             if (is_bool_val(that.subexpr, false)) { changed = true; return new ExprConstBool(at = that.at, value = true) }
+            var neg = negate_bool(that.subexpr, noFastMath)
+            if (neg != null) { changed = true; return neg }
         }
         return that
     }
@@ -865,6 +870,66 @@ def private same_base_type(a, b : ExpressionPtr) : bool {
 
 def private negate(var e : ExpressionPtr) : ExpressionPtr {
     return new ExprOp1(at = e.at, op := "-", subexpr = e)
+}
+
+// Negate a boolean expression by pushing `!` down to negatable leaves — flip a comparison
+// (`!(a > b) → a <= b`), drop a double `!`, De-Morgan through `&&` / `||` — and return the
+// residual-`!`-free result. Returns null when that can't be done (a leaf would still need a
+// wrapping `!`), so the caller keeps the original `!` rather than churn for no win. NaN charter:
+// an ordered float/double comparison flips only under fast-math; equality flips are always exact.
+def private negate_bool(var e : ExpressionPtr; noFastMath : bool) : ExpressionPtr {
+    if (e is ExprConstBool) {
+        return new ExprConstBool(at = e.at, value = !((e as ExprConstBool).value))
+    }
+    if (e is ExprOp1 && (e as ExprOp1).op == "!") {
+        return (e as ExprOp1).subexpr               // !!x → x
+    }
+    if (e is ExprOp2) {
+        var o = e as ExprOp2
+        if (o.op == ">" || o.op == "<" || o.op == ">=" || o.op == "<=" || o.op == "==" || o.op == "!=") {
+            // don't flip when: (a) a user / non-built-in operator — daslang doesn't auto-generate
+            // its complement (`<=` from `<`, `!=` from `==`), so flipping could call a missing op or
+            // change semantics; or (b) an ordered float/double comparison under no-fast-math, which
+            // is NaN-unsafe (`!(a>b) ≠ a<=b` for NaN)
+            if (o.func == null || !o.func.flags.builtIn ||
+                    ((o.op == ">" || o.op == "<" || o.op == ">=" || o.op == "<=") && noFastMath && is_float_valued(o.left))) {
+                return null
+            }
+            if (o.op == ">") return new ExprOp2(at = e.at, op := "<=", left = o.left, right = o.right)
+            if (o.op == "<") return new ExprOp2(at = e.at, op := ">=", left = o.left, right = o.right)
+            if (o.op == ">=") return new ExprOp2(at = e.at, op := "<",  left = o.left, right = o.right)
+            if (o.op == "<=") return new ExprOp2(at = e.at, op := ">",  left = o.left, right = o.right)
+            if (o.op == "==") return new ExprOp2(at = e.at, op := "!=", left = o.left, right = o.right)
+            if (o.op == "!=") return new ExprOp2(at = e.at, op := "==", left = o.left, right = o.right)
+        }
+        if (o.op == "&&" || o.op == "||") {        // De Morgan, only if both sides negate clean
+            var nl = negate_bool(o.left, noFastMath)
+            if (nl == null) return null
+            var nr = negate_bool(o.right, noFastMath)
+            if (nr == null) return null
+            if (o.op == "&&") return new ExprOp2(at = e.at, op := "||", left = nl, right = nr)
+            return new ExprOp2(at = e.at, op := "&&", left = nl, right = nr)
+        }
+    }
+    return null
+}
+
+// Read-only twin of negate_bool: would a wrapping `!` over `e` fold away? Used by the residual
+// oracle (which must NOT call negate_bool — it reuses `e`'s children and would alias the live
+// tree). Keep the foldability rules here in lockstep with negate_bool above.
+def public can_negate_bool(e : ExpressionPtr; noFastMath : bool) : bool {
+    if (e is ExprConstBool || (e is ExprOp1 && (e as ExprOp1).op == "!")) return true   // const / !!x
+    if (e is ExprOp2) {
+        let o = e as ExprOp2
+        if (o.op == "==" || o.op == "!=") return o.func != null && o.func.flags.builtIn
+        if (o.op == ">" || o.op == "<" || o.op == ">=" || o.op == "<=") {
+            return o.func != null && o.func.flags.builtIn && !(noFastMath && is_float_valued(o.left))
+        }
+        if (o.op == "&&" || o.op == "||") {
+            return can_negate_bool(o.left, noFastMath) && can_negate_bool(o.right, noFastMath)
+        }
+    }
+    return false
 }
 
 // A fresh zero literal of `t` (the RESULT type of `X * 0`; also the lowering's materialized

--- a/tests/flatten/no_aot/_fold_fixtures.das
+++ b/tests/flatten/no_aot/_fold_fixtures.das
@@ -63,3 +63,33 @@ def fx_scalar(v : float; s : float) : float {
     }
     return acc
 }
+
+// Bool-inversion fold: `break if (cond)` updates the loop-active mask as `m = m && !(s > 0.9)`
+// (the motivating case). The comparison-negation fold flips it to `m && (s <= 0.9)`, so no
+// `!comparison` residual survives.
+[flatten]
+def fx_loop_break(uv : float2; s : float) : float3 {
+    var acc = float3(0.0, 0.0, 0.0)
+    for (_i in range(3)) {
+        acc += float3(length(uv) * s)
+        if (s > 0.9) {
+            break
+        }
+    }
+    return acc
+}
+
+// De Morgan: `break if (compound)` updates the loop mask as `m = m && !((a > 0) && (b < 1))`;
+// the fold pushes the `!` through the `&&` to the leaves → `m && ((a <= 0) || (b >= 1))`,
+// leaving no residual `!`.
+[flatten]
+def fx_demorgan(a, b : float) : float {
+    var acc = 0.0
+    for (_i in range(3)) {
+        acc += a + b
+        if ((a > 0.0) && (b < 1.0)) {
+            break
+        }
+    }
+    return acc
+}

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -231,6 +231,10 @@ def test_flatten_fold(t : T?) {
         t |> success(zk |> find("sin") >= 0, "the zero-lane kill must be skipped (sin survives): {zk}")
         let mj = bodies?["nf_mj_flat"] ?? ""
         t |> success(mj |> find("* 12f") >= 0, "majority compensation must be skipped: {mj}")
+        let oinv = bodies?["nf_ordered_inv_flat"] ?? ""
+        t |> success(oinv |> find("!(") >= 0, "ordered float `!(s>0.9)` flip is NaN-unsafe — must survive no-fast-math: {oinv}")
+        let einv = bodies?["nf_eq_inv_flat"] ?? ""
+        t |> success(einv |> find("!(") < 0, "equality `!(s==0.9)` flip is NaN-exact — must still fold (to `!=`): {einv}")
         delete bodies
     }
     t |> run("every example shader folds clean (pixel_shader path)") @(t : T?) {

--- a/tests/flatten/test_flatten_nofastmath.das
+++ b/tests/flatten/test_flatten_nofastmath.das
@@ -91,6 +91,35 @@ def nf_preshader(x : float) : float {
     return x * u + u
 }
 
+// ----- bool-inversion gate -----
+
+// `break if (s > 0.9)` → `m = m && !(s > 0.9)`. The ordered FLOAT flip is NaN-unsafe, so under
+// no-fast-math it is SKIPPED — the `!comparison` survives.
+[flatten]
+def nf_ordered_inv(s : float) : float {
+    var acc = 0.0
+    for (_i in range(3)) {
+        acc += s
+        if (s > 0.9) {
+            break
+        }
+    }
+    return acc
+}
+
+// Equality is NaN-exact (`!(a == b) ≡ a != b`), so the flip still fires under no-fast-math.
+[flatten]
+def nf_eq_inv(s : float) : float {
+    var acc = 0.0
+    for (_i in range(3)) {
+        acc += s
+        if (s == 0.9) {
+            break
+        }
+    }
+    return acc
+}
+
 // ----- differential driver -----
 
 var GRID : array<float>
@@ -131,6 +160,12 @@ def test_flatten_nofastmath(t : T?) {
     t |> run("lerp const-selector skipped — bit-exact") @(t : T?) {
         for (a in GRID) {
             t |> equal(nf_lerp0_flat(a, 7.5), nf_lerp0(a, 7.5))
+        }
+    }
+    t |> run("bool-inversion gate (ordered skipped, equality folds) — bit-exact") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(nf_ordered_inv_flat(v), nf_ordered_inv(v))
+            t |> equal(nf_eq_inv_flat(v), nf_eq_inv(v))
         }
     }
     t |> run("x / C NOT rewritten to *(1/C) — bit-exact") @(t : T?) {


### PR DESCRIPTION
## The missing fold

flatten output like `__flat_loop_0 = __flat_loop_0 && !((s.x > 0.9f))` kept a redundant `!` over a comparison. The source is flatten_opt's *own* select-fold (`c ? false : true → !c`, `visitExprOp3`): when `c` is a comparison (a loop-break / else mask), it manufactures `!comparison` — and nothing folded it, because `visitExprOp1` only handled `!const`.

## The fold

A recursive `negate_bool` pushes `!` down to negatable leaves and returns the residual-`!`-free result, or `null` (keep the `!`) when it can't:

- **comparison negation** — `!(a > b) → a <= b` (all 6 ops)
- **double negation** — `!!x → x`
- **De Morgan** — `!(a && b) → !a || !b`, `!(a || b) → !a && !b`, **only when both sides negate clean** (the leaf-eliminability guard — so it never turns one `!` into two)

**NaN charter** (gated like the existing `*0` / `x-x` float folds): an *ordered* float/double comparison flips only under fast-math (`!(a>b) ≠ a<=b` for NaN); *equality* flips are always exact (`!(a==b) ≡ a!=b` even for NaN); integer comparisons are always safe.

## Verification

- `FoldResidualVisitor` (`daslib/flatten`) gains a read-only `can_negate_bool` twin so the fold-completeness oracle flags a *missed* inversion (regression guard).
- `_fold_fixtures.das`: `fx_loop_break` (the motivating `m && !(s>0.9)`) + `fx_demorgan` — both **A/B-proven to fire** (fold disabled → oracle flags them; enabled → fold clean).
- `test_flatten_nofastmath.das`: `nf_ordered_inv` (ordered float `!(s>0.9)` **survives** under no-fast-math) + `nf_eq_inv` (equality `!(s==0.9)` **folds** to `!=` regardless) — structural + bit-exact differential.
- Flatten differential fuzzer: exhaustive `--bool` truth-table (50 batches) + numeric (40 batches), all pass. Flatten dir (246) + full suite (10292) green; lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)