### PR TITLE
dasGlfw: bind glfwInitVulkanLoader

### DIFF
--- a/modules/dasGlfw/src/aot_dasGLFW.h
+++ b/modules/dasGlfw/src/aot_dasGLFW.h
@@ -16,6 +16,7 @@ namespace das {
     DAS_MOD_API void DasGlfw_Shutdown();
     DAS_MOD_API void DasGlfw_DestroyWindow ( GLFWwindow * window );
     DAS_MOD_API void * DAS_glfwGetNativeWindow ( GLFWwindow* window );
+    DAS_MOD_API void DAS_glfwInitVulkanLoader ( void * loader );
     // chain + synthetic event API
     DAS_MOD_API void DasGlfw_ChainAddCursorPos ( GLFWwindow * window, TLambda<void,const GLFWwindow*,double,double> func, Context * ctx );
     DAS_MOD_API void DasGlfw_ChainAddMouseButton ( GLFWwindow * window, TLambda<void,const GLFWwindow*,int,int,int> func, Context * ctx );

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -69,6 +69,22 @@ namespace das {
 
 #endif
 
+// glfwInitVulkanLoader hands GLFW the Vulkan loader's vkGetInstanceProcAddr so GLFW
+// does not have to discover the loader itself — needed on macOS where the Homebrew
+// loader is off GLFW's default dlopen search path. glfw3.h guards its prototype
+// behind VK_VERSION_1_0 (i.e. needs vulkan.h, which this module does not include),
+// so forward-declare it with an ABI-compatible loader type and bind a void* shim.
+extern "C" {
+    typedef void * (* DAS_vkGetInstanceProcAddr)(void * instance, const char * name);
+    GLFWAPI void glfwInitVulkanLoader(DAS_vkGetInstanceProcAddr loader);
+}
+
+namespace das {
+    void DAS_glfwInitVulkanLoader(void * loader) {
+        glfwInitVulkanLoader((DAS_vkGetInstanceProcAddr) loader);
+    }
+}
+
 
 namespace das {
 
@@ -428,6 +444,8 @@ namespace das {
         addExtern<DAS_BIND_FUN(DAS_glfwGetNativeWindow)>(*this, lib, "glfwGetNativeWindow",SideEffects::worstDefault, "DAS_glfwGetNativeWindow")
             ->args({"window"});
         addExtern<DAS_BIND_FUN(DAS_glfwGetNativeDisplay)>(*this, lib, "glfwGetNativeDisplay",SideEffects::worstDefault, "DAS_glfwGetNativeDisplay");
+        addExtern<DAS_BIND_FUN(DAS_glfwInitVulkanLoader)>(*this, lib, "glfwInitVulkanLoader",SideEffects::worstDefault, "DAS_glfwInitVulkanLoader")
+            ->args({"loader"});
     }
 
 	ModuleAotType Module_dasGLFW::aotRequire ( TextWriter & tw ) const {


### PR DESCRIPTION
## What

Binds GLFW 3.4's `glfwInitVulkanLoader` so a daslang app can hand GLFW the Vulkan loader's `vkGetInstanceProcAddr`, instead of relying on GLFW to discover the loader itself.

## Why

On macOS the Homebrew Vulkan loader (`/opt/homebrew/lib`) sits **off** GLFW's default `dlopen` search path, so `glfwVulkanSupported()` / `glfwGetRequiredInstanceExtensions()` fail even when a loader is installed. With this binding a Vulkan app does:

```das
volkInitialize()                                  // finds + loads the loader
glfwInitVulkanLoader(vk_get_instance_proc_addr()) // hand GLFW the same loader
glfwInit()                                        // GLFW reuses it; no own discovery
```

This is the prerequisite for upcoming **dasVulkan macOS support** (its windowed examples call this). The binding is generally useful on any platform/setup where GLFW's loader discovery and the app's diverge.

## How

`glfwInitVulkanLoader`'s `glfw3.h` prototype is guarded behind `VK_VERSION_1_0` (i.e. needs `vulkan.h`, which dasGlfw does not include). Rather than add a Vulkan dependency to dasGlfw, it's forward-declared with an ABI-compatible loader type and bound through a `void*` shim (`DAS_glfwInitVulkanLoader`), mirroring the existing hand-bound `glfwGetNativeWindow` pattern. AOT decl added for parity.

## Test

- `dasModuleGlfw` rebuilds clean (AppleClang).
- `tests/dasglfw` 6/6 pass.
- Verified callable from daslang and exercised end-to-end by the dasVulkan windowed examples (Metal surface present loop) on an Apple M1 Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)