### PR TITLE
dasSpirv: abstract bind-gen hooks + public std140 layout helper

### DIFF
--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -165,6 +165,64 @@ def private round_up(off, a : int) : int {
     return ((off + a - 1) / a) * a
 }
 
+//! One std140-laid-out field of a @uniform / @push_constant interface block. Returned by
+//! compute_block_layout and consumed by host-side bind macros (e.g. dasVulkan's SpirvVulkanShader)
+//! to emit one write per field at the right byte offset. `is_matrix` just means "this field IS a
+//! matrix" (and gets MatrixStride 16 in SPIR-V) — it does NOT by itself imply the daslang storage
+//! and std140 layout differ. For float4x4 the columns are already vec4-wide so a single memcpy
+//! works; for float3x3 / float3x4 the daslang storage is packed (3-wide columns) while std140 pads
+//! each column to vec4, so bind code must repack per-column. **Use `matrix_width` to choose**:
+//! `matrix_width == 4` → safe to memcpy the field; `matrix_width < 4` → repack per column.
+struct public BlockField {
+    name         : string //!< field name as declared in the daslang struct
+    offset       : int    //!< std140 byte offset from the block base
+    size         : int    //!< std140 base size of the field (matrices: 16 * cols)
+    is_matrix    : bool   //!< true if this field is a matrix (MatrixStride 16 in SPIR-V); see struct docstring re: repack
+    matrix_width : int    //!< matrix column-vector width — 4 for float4x4 (memcpy-safe); 3 for float3x3/3x4 (per-column repack)
+    matrix_cols  : int    //!< matrix column count (only valid when is_matrix); 0 otherwise
+}
+
+//! Compute the std140 layout of one interface block. Pure: takes a Structure?, fills `fields` with
+//! per-field offsets / sizes / matrix flags, returns the block total size and max member alignment.
+//! Used by build_block_struct (SPIR-V type emit) and by host-side bind macros. Rejects bool and
+//! non-numeric fields fail-closed (no physical std140 layout). `sname` is only used in error messages.
+//! `fields` is cleared at entry so reuse across calls and partial-failure returns can't bleed.
+//! [macro_function]: callable from a backend's bind-gen macro at compile time, mirrors generate_spirv.
+[macro_function]
+def public compute_block_layout(sname : string; st : Structure?; var fields : array<BlockField>; var errors : array<string>) : tuple<ok : bool; size : int; align : int> {
+    fields |> clear
+    if (st == null || empty(st.fields)) {
+        errors |> push("interface block '{sname}' must be a struct with at least one field")
+        return (ok = false, size = 0, align = 0)
+    }
+    var off = 0
+    var max_align = 0
+    for (fld in st.fields) {
+        let mi = matrix_info(fld._type)
+        if (mi.ok) {
+            off = round_up(off, 16)
+            fields |> emplace(BlockField(name := string(fld.name), offset = off, size = 16 * mi.cols,
+                is_matrix = true, matrix_width = mi.width, matrix_cols = mi.cols))
+            off += 16 * mi.cols
+            max_align = max(max_align, 16)
+            continue
+        }
+        let fbt = fld._type.baseType
+        if (scalar_class(fbt) < 0) {
+            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported (only 32-bit int/uint/float scalars, their vectors, and matrices; bool has no physical interface-block layout in Vulkan)")
+            fields |> clear
+            return (ok = false, size = 0, align = 0)
+        }
+        let falign = std140_align(fbt)
+        off = round_up(off, falign)
+        fields |> emplace(BlockField(name := string(fld.name), offset = off, size = std140_size(fbt),
+            is_matrix = false, matrix_width = 0, matrix_cols = 0))
+        off += std140_size(fbt)
+        max_align = max(max_align, falign)
+    }
+    return (ok = true, size = off, align = max_align)
+}
+
 // Build a laid-out interface struct from a daslang struct's fields. 32-bit scalar/vector/matrix
 // members are supported; nested structs and arrays are not yet. `as_block` toggles the Block decoration
 // (true for @uniform/@push_constant blocks, false for an SSBO runtime-array element struct).
@@ -174,54 +232,31 @@ def private round_up(off, a : int) : int {
 // past the last member (the push-constant range size); `align` lets the SSBO caller round it up to
 // the std430 array stride.
 def private build_block_struct(var m : SpirvModule; sname : string; st : Structure?; as_block : bool; var errors : array<string>) : tuple<ok : bool; type_id : uint; size : int; align : int> {
-    if (st == null || empty(st.fields)) {
-        errors |> push("interface block '{sname}' must be a struct with at least one field")
+    var fields : array<BlockField>
+    let layout = compute_block_layout(sname, st, fields, errors)
+    if (!layout.ok) {
+        delete fields
         return (ok = false, type_id = 0u, size = 0, align = 0)
     }
     var members : array<uint>
     var offsets : array<int>
     var mat_strides : array<int>
-    var off = 0
-    var max_align = 0
+    var fi = 0
     for (fld in st.fields) {
-        let mi = matrix_info(fld._type)
-        if (mi.ok) {
-            // std140/std430 matrix: ColMajor, each column padded to vec4 (MatrixStride 16), align 16,
-            // size = 16 * cols. (daslang float3x3 stores packed columns, so its bytes need
-            // repacking host-side before upload; float4x4 columns are already vec4 -> direct.)
-            off = round_up(off, 16)
-            members |> push(emit_type(m, fld._type))
-            offsets |> push(off)
-            mat_strides |> push(16)
-            off += 16 * mi.cols
-            max_align = max(max_align, 16)
-            continue
-        }
-        let fbt = fld._type.baseType
-        // only 32-bit int/uint/float scalars + their vectors. scalar_class rejects bool (and any
-        // non-numeric): OpTypeBool has no physical size in a std140/std430 interface block, so a
-        // bool member would emit an invalid layout — reject it fail-closed rather than emit it.
-        if (scalar_class(fbt) < 0) {
-            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported (only 32-bit int/uint/float scalars, their vectors, and matrices; bool has no physical interface-block layout in Vulkan)")
-            delete members
-            delete offsets
-            delete mat_strides
-            return (ok = false, type_id = 0u, size = 0, align = 0)
-        }
-        let falign = std140_align(fbt)
-        off = round_up(off, falign)
+        let f = fields[fi]
         members |> push(emit_type(m, fld._type))
-        offsets |> push(off)
-        mat_strides |> push(0)
-        off += std140_size(fbt)
-        max_align = max(max_align, falign)
+        offsets |> push(f.offset)
+        // std140 matrix: ColMajor, each column padded to vec4 (MatrixStride 16) — see BlockField docs.
+        mat_strides |> push(f.is_matrix ? 16 : 0)
+        fi++
     }
     let id = (as_block ? type_struct_block(m, members, offsets, mat_strides)
                        : type_struct_layout(m, members, offsets, mat_strides))
     delete members
     delete offsets
     delete mat_strides
-    return (ok = true, type_id = id, size = off, align = max_align)
+    delete fields
+    return (ok = true, type_id = id, size = layout.size, align = layout.align)
 }
 
 // std430 layout of an SSBO runtime-array element. Returns the element SPIR-V type-id + the

--- a/modules/dasSpirv/spirv/spirv_shader.das
+++ b/modules/dasSpirv/spirv/spirv_shader.das
@@ -36,9 +36,39 @@ def private build_uint_array_literal(words : array<uint>; at : LineInfo) : Expre
     return toMove
 }
 
+// Per-shader auxiliary function names. The dasGlsl/dasOpenGL split puts the body fill in a backend
+// subclass; we mirror that. {shader}_bind_uniform writes @uniform-tagged module globals into mapped
+// UBO memory; {shader}_push_constants pushes @push_constant-tagged globals via the backend's push API.
+// [macro_function]: both helpers are called from the backend subclass during patch/apply (macro
+// context), mirroring glsl_internal::bind_uniform_function_name.
+[macro_function]
+def bind_uniform_function_name(fnMain : FunctionPtr) {
+    return "{fnMain.name}_bind_uniform"
+}
+[macro_function]
+def push_constants_function_name(fnMain : FunctionPtr) {
+    return "{fnMain.name}_push_constants"
+}
+
 class SpirvShader : AstFunctionAnnotation {
     // overridden per stage; drives the entry-point execution model + execution mode in generate_spirv
     def shader_stage() : ShaderStage => ShaderStage.Compute
+    // Backend-specific hooks. Base = no-op (keeps dasSpirv usable without a host backend). A backend
+    // subclass (e.g. dasVulkan's SpirvVulkanShader) overrides all four: the _dummy form reserves an
+    // empty function during apply() so consumer code references resolve in the first inference pass;
+    // the non-dummy form fills the body during patch() after generate_spirv has succeeded.
+    def generate_bind_uniform_dummy(var func : FunctionPtr) {
+        pass
+    }
+    def generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
+        pass
+    }
+    def generate_push_constants_dummy(var func : FunctionPtr) {
+        pass
+    }
+    def generate_push_constants(fnMain : FunctionPtr; var fn : FunctionPtr) {
+        pass
+    }
     def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         func.flags.exports = true   // temporary: keeps the function alive through dependency collection
         let argName = args |> find_arg("name") ?as tString ?? "{func.name}`spirv"
@@ -56,6 +86,8 @@ class SpirvShader : AstFunctionAnnotation {
             errors := "can't add global variable {argName}_reflect"
             return false
         }
+        generate_bind_uniform_dummy(func)
+        generate_push_constants_dummy(func)
         return true
     }
     def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool {
@@ -89,6 +121,23 @@ class SpirvShader : AstFunctionAnnotation {
         if (!(err |> empty())) {
             errors := join(err, "\n")
             return false
+        }
+        // Backend body-fill: the dummy bind_uniform / push_constants functions were reserved in apply();
+        // their bodies stay empty (still `exports = true`) until the backend's generate_* override
+        // populates them here. astChanged on the first fill triggers re-infer so the bodies resolve.
+        for_each_function(compiling_module(), bind_uniform_function_name(func)) $(bfun) {
+            if (bfun.flags.exports) {
+                bfun.flags.exports = false
+                generate_bind_uniform(func, bfun)
+                astChanged = true
+            }
+        }
+        for_each_function(compiling_module(), push_constants_function_name(func)) $(bfun) {
+            if (bfun.flags.exports) {
+                bfun.flags.exports = false
+                generate_push_constants(func, bfun)
+                astChanged = true
+            }
         }
         return true
     }


### PR DESCRIPTION
## Summary

Two prep changes that turn the dasSpirv shader annotation into a backend-extensible substrate. They ship empty on the daslang side and only become useful when a host backend (dasVulkan's `SpirvVulkanShader`) provides overrides; **no behaviour change for the existing main-tree test suite** (all 118 `tests/spirv` tests stay green).

This is the daslang-side half of a paired change. Companion: [borisbat/dasVulkan#TBD](https://github.com/borisbat/dasVulkan) — `dasVulkan: [vulkan_*_shader] + bind_uniform + push_constants macros`. Merge **this** first; the dasVulkan PR consumes the new virtuals + helper.

### 1. `modules/dasSpirv/spirv/spirv_shader.das`

Add four virtual methods on `SpirvShader`, each defaulting to `pass`:

```daslang
def generate_bind_uniform_dummy(var func : FunctionPtr) { pass }
def generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) { pass }
def generate_push_constants_dummy(var func : FunctionPtr) { pass }
def generate_push_constants(fnMain : FunctionPtr; var fn : FunctionPtr) { pass }
```

The base `[vertex_shader]` / `[fragment_shader]` / `[compute_shader]` annotations continue to do exactly what they did before — the no-op defaults keep main-tree tests that need only the SPIR-V blob unchanged.

`apply()` now calls the two `*_dummy` methods after declaring the SPIR-V blob global. `patch()` now follows the same body-fill pattern dasGlsl / dasOpenGL uses: after `generate_spirv` succeeds, walk every function in the module matching `bind_uniform_function_name(func)` / `push_constants_function_name(func)`, clear the `exports`-flag-as-still-dummy marker, fire the override to fill the body, and set `astChanged` so the new body resolves in re-infer.

Public name helpers `bind_uniform_function_name` / `push_constants_function_name` pin the naming convention used by both the placeholder reserve and the consumer-side lookup (`<shader>_bind_uniform`, `<shader>_push_constants`).

### 2. `modules/dasSpirv/spirv/spirv_emit.das`

Extract a public `BlockField` struct + `compute_block_layout` function from the previously-private `build_block_struct`. Same std140 logic — matrix columns padded to vec4 (MatrixStride 16), vec3 keeps its trailing-scalar slot, fail-closed on bool/non-numeric fields — but now usable by a host-side bind macro at compile time:

```daslang
struct BlockField {
    name : string; offset : int; size : int
    is_matrix : bool; matrix_width : int; matrix_cols : int
}

def public compute_block_layout(sname : string; st : Structure?;
        var fields : array<BlockField>; var errors : array<string>)
    : tuple<ok : bool; size : int; align : int>
```

`build_block_struct` now calls `compute_block_layout` first, then iterates the laid-out fields to emit `OpTypeStruct` — single source of truth for std140 across the SPIR-V emitter and any host-side bind generator. Output-array param for `fields` (cleanest array-ownership shape for this signature).

## Test plan

- [x] `tests/spirv` — full suite green (118 / 118)
- [x] `utils/preflight` fast tier — format + lint clean (`2 file(s) clean`, 5.6s)
- [x] Companion dasVulkan branch (`bbatkin/shader-bind-macros`) consumes both additions:
  - `SpirvVulkanShader : SpirvShader` overrides all four virtuals
  - `generate_bind_uniform` calls `compute_block_layout(struct)` to drive per-field `write_field(ptr, offset, varName.fieldName)` emission
  - All 4 dasVulkan tutorial pixel oracles (triangle / mandelbrot / sdf / cube) green on lavapipe + real GPU after migrating to the new annotations
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)