### PR TITLE
docs(CLAUDE): unsafe(expr) does not cover a nested addr in a call argument

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 ### Unsafe
 
 - **`unsafe(expr)`** — narrow-scope unsafe, preferred over `unsafe { block }`. Limits unsafe to the exact expression that needs it. Lint backs this: STYLE024 flags `unsafe` wraps with no descendant needing unsafe; STYLE025 flags blocks where exactly one statement needs unsafe (narrow to expression form); STYLE026 flags nested `unsafe { ... }`
+  - **The expression form does NOT propagate into nested call arguments.** `unsafe(f(addr(x)))` still fails with `error[31000] address of reference requires unsafe` at the inner `addr` — the wrap only authorizes the unsafe op at the *top* of `expr`, not a sub-expression buried in an argument. Wrap the exact unsafe op instead: `f(unsafe(addr(x)))`. The block form `unsafe { f(addr(x)) }` *does* cover the nested op (whole scope), so it's the fallback when several nested ops need it.
 - **Local reference binding is unsafe:** `let blk & = expr` requires `unsafe` whenever it creates a local reference to a non-local expression — `let blk & = unsafe(expr)`
 - **Variant `as` read access is safe:** `(v as _field).member` works without `unsafe` after an `is` check
 - **Variant field assignment is always unsafe:** `v._field = value` and `set_variant_index(v, N)` require `unsafe`


### PR DESCRIPTION
## What

One-line addition to the **Unsafe** section of `CLAUDE.md` documenting a non-obvious failure mode.

The expression-form `unsafe(...)` only authorizes the unsafe operation at the *top* of the wrapped expression — it does **not** reach a sub-expression buried in a call argument:

```das
let rc = unsafe(f(addr(x)))      // error[31000]: address of reference requires unsafe (at the inner addr)
let rc = f(unsafe(addr(x)))      // OK — wrap the exact unsafe op
unsafe { rc = f(addr(x)) }       // OK — block form covers the whole scope
```

## Why

The existing guidance ("limit `unsafe` to the exact expression that needs it") implies the right shape but reads as if a broader wrap is merely a style nit — when in fact `unsafe(f(addr(x)))` is a hard **compile error**, not just wide. Hit this in practice (it broke a compile until narrowed to `f(unsafe(addr(x)))`). Verified by probe with the current binary.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)