### PR TITLE
flatten: fold the loop/iter mask `true && X` residue (mask const-prop)

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -719,6 +719,8 @@ def public flatten_function(var func : FunctionPtr; whitelist : table<string>; m
             dse_pass(out)          // drop dead mask-kills (`__flat_live = false`) first…
             copy_prop_pass(out)    // inline single-def temps AND const-fold the masks they expose
                                    // (`__flat_live=true` → `true ? a:b` → a; `__flat_ret=c; return __flat_ret` → `return c`)
+            mask_const_prop_pass(out)  // flow-sensitive const-prop of the multi-def loop/iter masks:
+                                   // first unrolled iter unconditional (`true ? a:b → a`), `m = m && X → m = X`
             dse_pass(out)          // remove anything left dead (collapsed mask decls, folded temps)
             ssa_rename_pass(out)   // single-def-ify reassigned user locals → fold_body const-props the chain
         }

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -447,6 +447,77 @@ def public dse_pass(var out : array<ExpressionPtr>) {
     delete dead
 }
 
+// ===== Flow-sensitive const-bool propagation of loop/iter masks =====
+// The break/continue masks (`__flat_loop_*`, `__flat_iter_*`) are multi-def — a `var M = true`
+// decl plus `M = M && !(term)` narrows — so copy_prop (single-def only) leaves them. But the body
+// is straight-line, so a forward scan carries each mask's known const-bool value to its next use:
+// the decl seeds `true`; every use before the first narrow folds (`true && X → X`, `true ? a : b →
+// a`, so the first unrolled iteration is unconditional); the first narrow itself (`M = M && X`, M
+// known true → `M = X`) drops the dead `&& true` AND — when M is read nowhere else (a continue
+// mask whose sole consumer was its own narrow) — leaves the whole decl+store dead for the
+// following dse_pass. A non-const narrow clears the mask (subsequent uses are genuine reads).
+
+// True if `e` reads any flat-mask currently in `known` (fills `reads`, cleared first). Cheap
+// O(size) scan gating the cloning fold_const so mask-free statements are skipped.
+def private reads_known(var e : ExpressionPtr; known : table<uint64; bool>; var reads : table<uint64>) : bool {
+    clear(reads)
+    var risky = false
+    scan_flat(e, reads, risky)
+    for (h in keys(reads)) {
+        if (key_exists(known, h)) return true
+    }
+    return false
+}
+
+def public mask_const_prop_pass(var out : array<ExpressionPtr>) {
+    var known : table<uint64; bool>   // flat-mask name-hash -> currently-known const bool value
+    var reads : table<uint64>         // scratch, cleared per statement
+    let n = length(out)
+    for (i in range(n)) {
+        var s = out[i]
+        // (1) flat-mask decl `var M = <init>`: fold init under known masks, then (re)seed M.
+        if (s is ExprLet && length((s as ExprLet).variables) == 1 && is_flat_temp((s as ExprLet).variables[0].name)) {
+            var lc = s as ExprLet
+            let h = hash(lc.variables[0].name)
+            if (lc.variables[0].init != null) {
+                if (!empty(known) && reads_known(lc.variables[0].init, known, reads)) {
+                    lc.variables[0].init = fold_const(lc.variables[0].init, known)
+                }
+                var bv = false
+                if (const_bool(lc.variables[0].init, bv)) {
+                    known[h] = bv
+                } else {
+                    known |> erase(h)
+                }
+            } else {
+                known |> erase(h)
+            }
+            continue
+        }
+        // (2) flat-mask store `M = <rhs>`: fold rhs (the `M = M && X` collapse), then update M.
+        if (s is ExprCopy && (s as ExprCopy).left is ExprVar && is_flat_temp(((s as ExprCopy).left as ExprVar).name)) {
+            var cp = s as ExprCopy
+            let h = hash((cp.left as ExprVar).name)
+            if (!empty(known) && reads_known(cp.right, known, reads)) {
+                cp.right = fold_const(cp.right, known)
+            }
+            var bv = false
+            if (const_bool(cp.right, bv)) {
+                known[h] = bv
+            } else {
+                known |> erase(h)
+            }
+            continue
+        }
+        // (3) any other statement: fold its mask reads (select predicates) under known masks.
+        if (!empty(known) && reads_known(s, known, reads)) {
+            out[i] = fold_stmt(s, known)
+        }
+    }
+    delete known
+    delete reads
+}
+
 // ===== SSA-rename of reassigned user locals =====
 // Straight-line body → a reassigned local is a linear def-chain (no phi); renaming each write to a
 // fresh single-def `__ssa_` version lets post-infer const-prop fold the chain (declared-with-init only).

--- a/tests/flatten/no_aot/_fold_fixtures.das
+++ b/tests/flatten/no_aot/_fold_fixtures.das
@@ -64,9 +64,11 @@ def fx_scalar(v : float; s : float) : float {
     return acc
 }
 
-// Bool-inversion fold: `break if (cond)` updates the loop-active mask as `m = m && !(s > 0.9)`
-// (the motivating case). The comparison-negation fold flips it to `m && (s <= 0.9)`, so no
-// `!comparison` residual survives.
+// Two folds in one twin. (1) Bool-inversion: `break if (cond)` updates the loop-active mask as
+// `m = m && !(s > 0.9)`; the comparison-negation fold flips it to `m && (s <= 0.9)`, so no
+// `!comparison` residual survives. (2) Mask const-prop: the loop mask is statically `true` for
+// the first unrolled iteration, so that iteration's predicated `acc = (m ? new : acc-init)` folds
+// unconditional and the `float3(0,0,0)` acc-init is consumed (asserted absent in test_flatten_fold).
 [flatten]
 def fx_loop_break(uv : float2; s : float) : float3 {
     var acc = float3(0.0, 0.0, 0.0)

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -108,6 +108,15 @@ def test_flatten_fold(t : T?) {
     t |> run("[flatten] reveal-cascade corpus folds clean") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/no_aot/_fold_fixtures.das")
         t |> success(n >= 3, "expected >=3 twins, checked {n}")
+        // mask const-prop FIRED proof: a break loop's first unrolled iteration is unconditional
+        // (the loop mask is statically `true` there), so the acc zero-init is consumed — no
+        // `(mask ? new : float3(0,0,0))` first-iter select survives. Without the fold the
+        // predicated first iteration keeps the `float3(0f,0f,0f)` init as its false arm.
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/no_aot/_fold_fixtures.das")
+        let lb = bodies?["fx_loop_break_flat"] ?? ""
+        t |> success(lb |> find("float3(0f,0f,0f)") < 0,
+            "loop-break first iter must fold unconditional (mask const-prop): {lb}")
+        delete bodies
     }
     t |> run("const-identity corpus folds clean (test_flatten_const.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_const.das")

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -114,6 +114,9 @@ def test_flatten_fold(t : T?) {
         // predicated first iteration keeps the `float3(0f,0f,0f)` init as its false arm.
         var bodies <- twin_bodies(t, "{root}/tests/flatten/no_aot/_fold_fixtures.das")
         let lb = bodies?["fx_loop_break_flat"] ?? ""
+        // existence guard: a missing twin leaves lb == "" and the negative find below would pass
+        // vacuously (false positive). Assert the twin was produced before checking its shape.
+        t |> success(!empty(lb), "fx_loop_break_flat twin must be produced")
         t |> success(lb |> find("float3(0f,0f,0f)") < 0,
             "loop-break first iter must fold unconditional (mask const-prop): {lb}")
         delete bodies


### PR DESCRIPTION
## What

The break/continue masks in flatten's lowered output (`__flat_loop_*`, `__flat_iter_*`) are **multi-def** — a `var M = true` decl plus one or more `M = M && !(term)` narrows. `copy_prop_pass` only handles single-def temps, so it leaves these masks untouched, and the FoldVisitor's `&&` arm only fires on *literal* const operands — but `M` is a var, not a literal, so `M = M && cond` and the first-iteration `M ? a : b` selects survive all the way to the backend.

The flattened body is straight-line (no control flow), though, so a single forward scan can carry each mask's known const-bool value to its next use. `mask_const_prop_pass` does exactly that, hooked into `flatten_function` right after `copy_prop_pass`:

- the decl seeds `true`;
- every use before the first narrow folds — `true && X → X`, `true ? a : b → a` — so **the first unrolled iteration becomes unconditional** (its `acc = (M ? new : acc-init)` collapses to `acc = new`, consuming the accumulator's zero-init);
- the first narrow itself (`M = M && X` with `M` known `true`) folds to `M = X`, dropping the dead `&& true`;
- a non-const narrow clears the mask, so later uses stay genuine reads.

The backend does **not** fold `true && X` — this surfaced on actual shaders — so the win is real, not cosmetic.

### Before / after (a `for ... { acc += ...; if (s > 0.9) break }` twin)

```
// before
var __ssa_acc_2 = (__flat_loop_0 ? _cse_0 : float3(0f,0f,0f));   // first iter predicated on a known-true mask
__flat_loop_0 = __flat_loop_0 && _cse_1;                          // `true && X`

// after
__flat_loop_0 = _cse_1;                                           // `true && X` -> X
var __ssa_acc_3 = (__flat_loop_0 ? (_cse_0 + _cse_0) : _cse_0);   // first iter folded in, unconditional
```

This is item **#1** from the flatten_opt missing-optimization audit. (#3 — same-mask select-accumulation fusion — is a separate follow-up.)

## Verification

- **246/246 flatten tests pass** — value preserved (differential `*_flat`-vs-original over input grids), residual oracle clean, `_flatten_no_fast_math` gates intact.
- **New FIRED proof** in `test_flatten_fold` (break-loop first iter unconditional → `float3(0,0,0)` acc-init absent) **A/B-fails** with the pass disabled, passes with it enabled.
- **flatten-fuzz differential clean**: `--bool` 40 batches (exhaustive 2³ truth table, the strongest oracle for mask folds) + numeric 30 batches.

## Notes

- Pure daslib change (`daslib/flatten*.das`) — no engine rebuild needed.
- New pass is `O(size)` forward, with a cheap mask-read guard so mask-free statements skip the (cloning) `fold_const`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)