### PR TITLE
release CI: give -jit test run a 900s budget + isolated-mode fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,8 @@ jobs:
             TEST_PATH="../tests"
             EXEC=""
           fi
-          ./daslang${EXEC} _dasroot_/dastest/dastest.das -jit -- --color --failures-only --test "$TEST_PATH"
+          ./daslang${EXEC} _dasroot_/dastest/dastest.das -jit -- --color --failures-only --timeout 900 --test "$TEST_PATH" \
+            || ./daslang${EXEC} _dasroot_/dastest/dastest.das -jit -- --color --failures-only --isolated-mode --timeout 3600 --test "$TEST_PATH"
 
       - name: "Install binaries"
         if: matrix.cmake_preset == 'Release'


### PR DESCRIPTION
## Problem

The v0.6.3-RC2 release run ([#27675988686](https://github.com/GaijinEntertainment/daScript/actions/runs/27675988686)) failed on `linux`, `linux_arm`, and `windows` — but **with 0 actual test failures**. Each platform tripped `dastest`'s wall-clock timeout:

| Job | Result | Wall time |
|---|---|---|
| linux | 9553/9560 pass, 0 failed, **1 error = timeout** | 600.65s |
| windows | 7863/7864 pass, 0 failed, **1 error = timeout** | 612.82s |
| linux_arm | 10612/10619 pass, 0 failed, **1 error = timeout** | 603.11s |
| darwin26 | ✓ passed (faster runner, finished < 600s) | — |

## Root cause

`release.yml`'s "Run tests" step ran the full `-jit` suite under `dastest`'s **default 600s** budget with **no fallback**:

```bash
./daslang${EXEC} _dasroot_/dastest/dastest.das -jit -- --color --failures-only --test "$TEST_PATH"
```

`build.yml` runs the same suite with `--timeout 900` **plus** an `|| --isolated-mode --timeout 3600` retry. On the slower release runners the JIT suite legitimately takes ~600–613s — a fresh CI checkout has an empty `.jitted_scripts/` cache, so every script is a DLL codegen miss (1–6s each) on top of the AOT compile phase — so it sat right on the 600s line and panicked.

Nothing in the RC tag is broken; this is purely a release-CI budget gap (`release.yml` drifting from `build.yml`).

## Fix

Match `build.yml`: bump to `--timeout 900` and add the isolated-mode 3600s fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)