### PR TITLE
site: news entry for 0.6.3-RC2

### DIFF
--- a/site/_news/2026-06-17-0-6-3-rc2-is-out-almost-there.md
+++ b/site/_news/2026-06-17-0-6-3-rc2-is-out-almost-there.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-17
+tag: 0.6.3-rc2
+title: 0.6.3-RC2 is out! Almost there.
+link: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC2-take-2
+---


### PR DESCRIPTION
Adds a site news entry announcing the **0.6.3-RC2** pre-release.

- `site/_news/2026-06-17-0-6-3-rc2-is-out-almost-there.md`
- Links to the release: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC2-take-2

Front-matter-only entry, matching the existing RC1 / RC2 news format (LF, no body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)