### PR TITLE
ci: harden Windows Defender exclusion across all Windows jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,12 +225,11 @@ jobs:
       # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
-        $ErrorActionPreference = 'SilentlyContinue'
-        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
         foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-          Add-MpPreference -ExclusionProcess $p
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
         }
-        Set-MpPreference -DisableRealtimeMonitoring $true
+        Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
         Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
@@ -624,12 +623,11 @@ jobs:
       # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
-        $ErrorActionPreference = 'SilentlyContinue'
-        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
         foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-          Add-MpPreference -ExclusionProcess $p
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
         }
-        Set-MpPreference -DisableRealtimeMonitoring $true
+        Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
         Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
@@ -742,12 +740,11 @@ jobs:
       # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
-        $ErrorActionPreference = 'SilentlyContinue'
-        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
         foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-          Add-MpPreference -ExclusionProcess $p
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
         }
-        Set-MpPreference -DisableRealtimeMonitoring $true
+        Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
         Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,13 +218,21 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       continue-on-error: true
-      # Real-time Defender scans every .obj/.exe/.dll the build writes and every
-      # test process/DLL load; excluding the workspace cuts Windows CI wall-time.
+      # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+      # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+      # race). Exclude the workspace + toolchain writers and try to disable RTP;
+      # the status dump records whether the runner image actually honored it
+      # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
+        $ErrorActionPreference = 'SilentlyContinue'
         Add-MpPreference -ExclusionPath "${{ github.workspace }}"
-        Add-MpPreference -ExclusionProcess "daslang.exe"
-        Add-MpPreference -ExclusionProcess "test_aot.exe"
+        foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+          Add-MpPreference -ExclusionProcess $p
+        }
+        Set-MpPreference -DisableRealtimeMonitoring $true
+        Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+        Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
     - name: "Install CMake and Ninja"
       uses: lukka/get-cmake@latest
@@ -605,6 +613,26 @@ jobs:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
 
+    - name: "Exclude workspace from Windows Defender"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      continue-on-error: true
+      # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+      # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+      # race). Exclude the workspace + toolchain writers and try to disable RTP;
+      # the status dump records whether the runner image actually honored it
+      # (managed Defender / Tamper Protection may silently no-op).
+      # continue-on-error: a managed-Defender runner must not fail the job.
+      run: |
+        $ErrorActionPreference = 'SilentlyContinue'
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+          Add-MpPreference -ExclusionProcess $p
+        }
+        Set-MpPreference -DisableRealtimeMonitoring $true
+        Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+        Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+
     - name: "Install MSYS2 + clang-mingw64 toolchain"
       uses: msys2/setup-msys2@v2
       with:
@@ -703,13 +731,25 @@ jobs:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
 
-    - name: "Exclude workspace from Defender"
+    - name: "Exclude workspace from Windows Defender"
+      if: runner.os == 'Windows'
       shell: pwsh
       continue-on-error: true
+      # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+      # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+      # race). Exclude the workspace + toolchain writers and try to disable RTP;
+      # the status dump records whether the runner image actually honored it
+      # (managed Defender / Tamper Protection may silently no-op).
+      # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
+        $ErrorActionPreference = 'SilentlyContinue'
         Add-MpPreference -ExclusionPath "${{ github.workspace }}"
-        Add-MpPreference -ExclusionProcess "daslang.exe"
-        Add-MpPreference -ExclusionProcess "test_aot.exe"
+        foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+          Add-MpPreference -ExclusionProcess $p
+        }
+        Set-MpPreference -DisableRealtimeMonitoring $true
+        Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+        Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
     - name: "Install nasm (OpenSSL asm)"
       uses: ilammy/setup-nasm@v1

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -82,13 +82,21 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       continue-on-error: true
-      # Real-time Defender scans every .obj/.exe/.dll the build writes and every
-      # process + DLL load at test time; excluding the workspace cuts Windows CI
-      # wall-time. continue-on-error: a managed-Defender runner must not fail CI.
+      # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+      # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+      # race). Exclude the workspace + toolchain writers and try to disable RTP;
+      # the status dump records whether the runner image actually honored it
+      # (managed Defender / Tamper Protection may silently no-op).
+      # continue-on-error: a managed-Defender runner must not fail CI.
       run: |
+        $ErrorActionPreference = 'SilentlyContinue'
         Add-MpPreference -ExclusionPath "${{ github.workspace }}"
-        Add-MpPreference -ExclusionProcess "daslang.exe"
-        Add-MpPreference -ExclusionProcess "daslang_static.exe"
+        foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+          Add-MpPreference -ExclusionProcess $p
+        }
+        Set-MpPreference -DisableRealtimeMonitoring $true
+        Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+        Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
     - name: "Install CMake and Ninja"
       uses: lukka/get-cmake@latest

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -89,12 +89,11 @@ jobs:
       # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail CI.
       run: |
-        $ErrorActionPreference = 'SilentlyContinue'
-        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
         foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-          Add-MpPreference -ExclusionProcess $p
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
         }
-        Set-MpPreference -DisableRealtimeMonitoring $true
+        Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
         Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 

--- a/.github/workflows/llvm_release.yml
+++ b/.github/workflows/llvm_release.yml
@@ -61,12 +61,11 @@ jobs:
         # (managed Defender / Tamper Protection may silently no-op).
         # continue-on-error: a managed-Defender runner must not fail the job.
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
           foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-            Add-MpPreference -ExclusionProcess $p
+            Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
           }
-          Set-MpPreference -DisableRealtimeMonitoring $true
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
           Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
           Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 

--- a/.github/workflows/llvm_release.yml
+++ b/.github/workflows/llvm_release.yml
@@ -50,6 +50,26 @@ jobs:
           - name: win64
             os: windows-2022
     steps:
+      - name: "Exclude workspace from Windows Defender"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+        # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+        # race). Exclude the workspace + toolchain writers and try to disable RTP;
+        # the status dump records whether the runner image actually honored it
+        # (managed Defender / Tamper Protection may silently no-op).
+        # continue-on-error: a managed-Defender runner must not fail the job.
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+            Add-MpPreference -ExclusionProcess $p
+          }
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+          Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+
       # git clone, not the source tarball: tar on Windows fails to extract
       # symlinks under clang/test and llvm/utils/mlgo-utils; git stores them
       # as plain files when core.symlinks=false

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -26,6 +26,26 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: "Exclude workspace from Windows Defender"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      continue-on-error: true
+      # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+      # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+      # race). Exclude the workspace + toolchain writers and try to disable RTP;
+      # the status dump records whether the runner image actually honored it
+      # (managed Defender / Tamper Protection may silently no-op).
+      # continue-on-error: a managed-Defender runner must not fail the job.
+      run: |
+        $ErrorActionPreference = 'SilentlyContinue'
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+          Add-MpPreference -ExclusionProcess $p
+        }
+        Set-MpPreference -DisableRealtimeMonitoring $true
+        Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+        Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+
     - name: Configure CMake
       run: cmake -B ${{ env.CONFIG_DIR }} -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_configuration }} -G "Visual Studio 17 2022"
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -37,12 +37,11 @@ jobs:
       # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
-        $ErrorActionPreference = 'SilentlyContinue'
-        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
         foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-          Add-MpPreference -ExclusionProcess $p
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
         }
-        Set-MpPreference -DisableRealtimeMonitoring $true
+        Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
         Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,11 @@ jobs:
         # (managed Defender / Tamper Protection may silently no-op).
         # continue-on-error: a managed-Defender runner must not fail the job.
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
           foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-            Add-MpPreference -ExclusionProcess $p
+            Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
           }
-          Set-MpPreference -DisableRealtimeMonitoring $true
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
           Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
           Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,13 +142,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         continue-on-error: true
-        # Real-time Defender scans every .obj/.exe/.dll the build writes;
-        # excluding the workspace cuts Windows CI wall-time. continue-on-error:
-        # a managed-Defender runner must not fail the job.
+        # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+        # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+        # race). Exclude the workspace + toolchain writers and try to disable RTP;
+        # the status dump records whether the runner image actually honored it
+        # (managed Defender / Tamper Protection may silently no-op).
+        # continue-on-error: a managed-Defender runner must not fail the job.
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           Add-MpPreference -ExclusionPath "${{ github.workspace }}"
-          Add-MpPreference -ExclusionProcess "daslang.exe"
-          Add-MpPreference -ExclusionProcess "test_aot.exe"
+          foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+            Add-MpPreference -ExclusionProcess $p
+          }
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+          Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
       - name: "Install CMake and Ninja"
         uses: lukka/get-cmake@latest

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -64,6 +64,26 @@ jobs:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
 
+    - name: "Exclude workspace from Windows Defender"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      continue-on-error: true
+      # Defender real-time scan of freshly-written .obj/.exe/.dll slows the build
+      # and can momentarily lock a just-linked exe (the "Access is denied" deploy
+      # race). Exclude the workspace + toolchain writers and try to disable RTP;
+      # the status dump records whether the runner image actually honored it
+      # (managed Defender / Tamper Protection may silently no-op).
+      # continue-on-error: a managed-Defender runner must not fail the job.
+      run: |
+        $ErrorActionPreference = 'SilentlyContinue'
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
+          Add-MpPreference -ExclusionProcess $p
+        }
+        Set-MpPreference -DisableRealtimeMonitoring $true
+        Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
+        Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+
     - uses: lukka/get-cmake@latest
 
     - name: Setup Python 3.10

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -75,12 +75,11 @@ jobs:
       # (managed Defender / Tamper Protection may silently no-op).
       # continue-on-error: a managed-Defender runner must not fail the job.
       run: |
-        $ErrorActionPreference = 'SilentlyContinue'
-        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}" -ErrorAction SilentlyContinue
         foreach ($p in 'daslang.exe','daslang_static.exe','test_aot.exe','cl.exe','link.exe','lld-link.exe','mt.exe','vctip.exe','mspdbsrv.exe','vcpkg.exe') {
-          Add-MpPreference -ExclusionProcess $p
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
         }
-        Set-MpPreference -DisableRealtimeMonitoring $true
+        Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
         Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 


### PR DESCRIPTION
## Why

Windows lanes intermittently fail at **link/deploy time** with `Access is denied` on a freshly-linked exe (most recently `integration_c_08.exe` on the `windows, 32, Release` lane). The just-written PE is momentarily locked — Defender real-time scan is the prime suspect, but a managed-runner image can silently ignore our exclusion, and it could also be the `vcpkg z-applocal` / `mt.exe` handle race.

The existing step only did `Add-MpPreference -ExclusionPath $workspace`, which *should* already cover `bin\*.exe` — yet the flake persists. This PR strengthens the knob **and instruments it** so the next runs tell us whether Defender is even the culprit.

## What

The `Exclude workspace from Windows Defender` step now also:

- adds the toolchain writers to `-ExclusionProcess`: `cl.exe`, `link.exe`, `lld-link.exe`, `mt.exe`, `vctip.exe`, `mspdbsrv.exe`, `vcpkg.exe` (+ `daslang_static.exe`)
- attempts `Set-MpPreference -DisableRealtimeMonitoring $true` — **may silently no-op under Tamper Protection** on managed runners; that's expected
- dumps `Get-MpComputerStatus` (`RealTimeProtectionEnabled`, `IsTamperProtected`) and the effective `ExclusionPath`, so the log shows whether the runner image actually honored any of it

`$ErrorActionPreference = 'SilentlyContinue'` keeps the status dump running even when a mutation is blocked; the step stays `continue-on-error: true`.

## Coverage

Applied to **every Windows job across all workflows**:

| Workflow | Job(s) |
|---|---|
| `build.yml` | `build` matrix, `build_windows_mingw`, `build_windows_clangcl` |
| `extended_checks.yml` | `extended_checks` matrix |
| `wasm_build.yml` | `wasm_build` matrix |
| `release.yml` | `build` matrix |
| `msvc.yml` | `analyze` |
| `llvm_release.yml` | `build` matrix (win64) |

(`mingw`, `wasm`, `msvc`, `llvm_release` had no Defender step before.)

## Expectations

This is a "see-the-fallout" change. On the PR run, watch `build` / `extended_checks` / `wasm_build` Windows lanes:
- the new status dump tells us whether RTP-disable sticks or Tamper Protection blocks it;
- if the `Access is denied` flake survives a confirmed-excluded run, the lock isn't Defender — it's the `mt.exe` / `vcpkg z-applocal` handle race, and the follow-up is a retry around the deploy step.

`msvc.yml`, `release.yml`, `llvm_release.yml` are `workflow_dispatch`/release-triggered, so they won't exercise here — included for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)