### PR TITLE
flatten: migrate examples/flatten backend to native core math + radians/degrees fold

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -50,6 +50,7 @@ let private STD_WHITELIST : table<string> <- {
     "min", "max", "abs", "clamp", "saturate", "sign", "floor", "ceil", "round", "trunc", "frac",
     "sqrt", "rsqrt", "pow", "exp", "exp2", "log", "log2",
     "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sincos",
+    "radians", "degrees",   // lowered to `x * K` by flatten_opt (no opcode needed)
     "dot", "cross", "length", "normalize", "distance", "reflect", "refract",
     "lerp", "mix", "step", "smooth_step", "rcp", "mad",
     "float2", "float3", "float4", "int2", "int3", "int4", "uint2", "uint3", "uint4"

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -595,6 +595,12 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
     delete current
 }
 
+// radians/degrees are each exactly one float32 multiply by these conversion constants —
+// the bit pattern the C++ helpers (aot_builtin_math.h radians_float/degrees_float) fold to,
+// verified bit-identical to evaluating the builtin at 1.0 (0x3c8efa35 / 0x42652ee0).
+let private DEG_TO_RAD = 0.017453292f
+let private RAD_TO_DEG = 57.295776f
+
 class private FoldVisitor : AstVisitor {
     changed : bool
     noFastMath : bool
@@ -755,6 +761,21 @@ class private FoldVisitor : AstVisitor {
             if (!(folded is ExprCall)) {   // eval_to_const returns the call unchanged on failure
                 changed = true
                 return folded
+            }
+        }
+        // Lower radians/degrees to their defining multiply (`x * K`) so an adjacent const
+        // factor merges (`degrees(x) * C → x * (K*C)`, via reassoc) and a backend needs no
+        // radians/degrees opcode — only `mul`. Bit-exact (K = the builtin at 1.0); a const
+        // arg already folded to a literal above. `x * scalarK` covers float and float-vector
+        // (vec*scalar is native, matching the C++ v_mul-by-splat form).
+        if (that.func != null && that.func.flags.builtIn && length(that.arguments) == 1
+                && is_float_family(expr_bt(that.arguments[0]))) {
+            let nm = psh_simple_name("{that.func.name}")
+            if (nm == "radians" || nm == "degrees") {
+                changed = true
+                let k = nm == "radians" ? DEG_TO_RAD : RAD_TO_DEG
+                return new ExprOp2(at = that.at, op := "*", left = that.arguments[0],
+                    right = new ExprConstFloat(at = that.at, value = k))
             }
         }
         // DISASSEMBLE mad (and, under `expandLerp`, lerp) into raw arithmetic so the folds,

--- a/examples/flatten/README.md
+++ b/examples/flatten/README.md
@@ -22,8 +22,8 @@ call-free code.
 | Path | What |
 |---|---|
 | `shaders/user_shaders/`, `shaders/user_shaders_2d/` | The real EdenSpark sample shaders (3D + 2D post-fx), **unedited**. |
-| `shaders/features/` | Loop-unroll feature fixtures (array-literal / parallel multi-iterator / `urange` sources). The backend bans `ExprFor`, so these compile **only** because flatten unrolls them — flatten is load-bearing, not transparent. |
-| `backend/shader_dsl_primitives.das` | The `[hint]`/`[stub]` leaf primitives + I/O contract structs (`PbrInput`/`PbrOutput`). |
+| `shaders/features/` | Feature fixtures: loop-unroll source forms (array-literal / parallel multi-iterator / `urange`) that compile **only** because flatten unrolls them, plus `angle_spin.shader` exercising the native `radians`/`degrees` → `mul` lowering. flatten is load-bearing, not transparent. |
+| `backend/shader_dsl_primitives.das` | I/O contract structs (`PbrInput`/`PbrOutput`) + the leaf primitives. The component-wise math ops are the native daslang `math` builtins (`require math public`); only the engine-specific leaves (`tex2d`/`noise`/`frac`/`remap`/`one_minus`/`fresnel`/`unpack_normal`) remain `[hint]` stubs. |
 | `backend/shader_dsl_boost.das` | The validator + graph IR builder + the `[pixel_shader]` annotation. **This is where flatten is wired in.** |
 | `backend/shader_graph_ir_builder.das` | Print-only stand-in for the engine's native `sg_ir_*` graph sink — dumps human-readable opcodes. |
 | `backend/shader_dsl.das` | Re-exporter: `require engine.render.shader_dsl` pulls in the two modules above. |
@@ -32,10 +32,13 @@ call-free code.
 ## How flatten plugs in
 
 The `[pixel_shader]` annotation's `patch` hook calls `flatten_function(func, HINT_WHITELIST)`
-*before* validation (`backend/shader_dsl_boost.das`). `HINT_WHITELIST` is the set of
-backend primitive names — flatten keeps those calls as leaves and inlines/lowers
-everything else. The backend then walks the branchless result. For the capability
-tier the backend also maps `ExprOp3 → Select` (and comparison ops → mask nodes) to
+*before* validation (`backend/shader_dsl_boost.das`). `HINT_WHITELIST` is the set of leaf
+primitive names — flatten keeps those calls as leaves and inlines/lowers everything else.
+The leaves are the native `math` builtins (mapped to opcodes by name via `NATIVE_OPCODE`)
+plus the engine-specific `[hint]` stubs. `radians`/`degrees` carry no opcode: `flatten_opt`
+lowers each to a `mul` (`radians(x) → x * K`), and an adjacent const factor merges
+(`degrees(x) * C → x * (K*C)`). The backend then walks the branchless result. For the
+capability tier it also maps `ExprOp3 → Select` (and comparison ops → mask nodes) to
 consume flatten's `?:` output.
 
 ## Two tiers

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -892,13 +892,18 @@ class ValidateShaderVisitor : AstVisitor {
         let fn = native_bare_name("{expr.func.name}")
         var nativeOp = NATIVE_OPCODE?[fn] ?? ""
         if (nativeOp == "" && !empty(expr.arguments)) {
+            // dot/length/normalize: width-specific opcode, ONLY for an exact float2/3/4 operand
+            // (and arity). Any other type leaves nativeOp empty so an unrelated overload — e.g.
+            // length(string)/length(array) — falls through to the "unsupported function call"
+            // rejection rather than silently emitting len_f3 (fail-closed).
             let w = expr.arguments[0]._type.baseType
-            if (fn == "dot") {
-                nativeOp = w == Type.tFloat2 ? DotF2 : (w == Type.tFloat4 ? DotF4 : DotF3)
-            } elif (fn == "length") {
-                nativeOp = w == Type.tFloat2 ? LenF2 : (w == Type.tFloat4 ? LenF4 : LenF3)
-            } elif (fn == "normalize") {
-                nativeOp = w == Type.tFloat2 ? NormF2 : (w == Type.tFloat4 ? NormF4 : NormF3)
+            let nargs = expr.arguments.length()
+            if (fn == "dot" && nargs == 2) {
+                nativeOp = w == Type.tFloat2 ? DotF2 : (w == Type.tFloat3 ? DotF3 : (w == Type.tFloat4 ? DotF4 : ""))
+            } elif (fn == "length" && nargs == 1) {
+                nativeOp = w == Type.tFloat2 ? LenF2 : (w == Type.tFloat3 ? LenF3 : (w == Type.tFloat4 ? LenF4 : ""))
+            } elif (fn == "normalize" && nargs == 1) {
+                nativeOp = w == Type.tFloat2 ? NormF2 : (w == Type.tFloat3 ? NormF3 : (w == Type.tFloat4 ? NormF4 : ""))
             }
         }
         if (nativeOp != "") {

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -61,9 +61,10 @@ let PRIMITIVES_MODULE_NAME = "shader_dsl_primitives"
 // named `__::<scope>`<name>`<hash>` (backtick == 96). A concrete builtin is already bare.
 [macro_function]
 def native_bare_name(fullname : string) : string {
-    let t1 = find(fullname, 96, 0)
+    let bt = 96  // '`'
+    let t1 = find(fullname, bt, 0)
     if (t1 < 0) { return fullname }
-    let t2 = find(fullname, 96, t1 + 1)
+    let t2 = find(fullname, bt, t1 + 1)
     return t2 < 0 ? slice(fullname, t1 + 1) : slice(fullname, t1 + 1, t2)
 }
 

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -57,6 +57,16 @@ def clean_mangled_names(s : string) : string {
 let DEBUG_AT = false
 let PRIMITIVES_MODULE_NAME = "shader_dsl_primitives"
 
+// Bare function name from a (possibly mangled) symbol: an OR-type / generic instance is
+// named `__::<scope>`<name>`<hash>` (backtick == 96). A concrete builtin is already bare.
+[macro_function]
+def native_bare_name(fullname : string) : string {
+    let t1 = find(fullname, 96, 0)
+    if (t1 < 0) { return fullname }
+    let t2 = find(fullname, 96, t1 + 1)
+    return t2 < 0 ? slice(fullname, t1 + 1) : slice(fullname, t1 + 1, t2)
+}
+
 // Per-contract I/O struct names in PRIMITIVES_MODULE_NAME.
 // Add a row here when introducing a new contract.
 let CONTRACT_INPUT_STRUCTS : table<string; string> = {
@@ -68,17 +78,32 @@ let CONTRACT_OUTPUT_STRUCTS : table<string; string> = {
     "unlit" => "UnlitOutput"
 }
 
-// Leaf primitives flatten must KEEP (not inline). These are the shader DSL's
-// [hint] primitives plus the vector constructors the backend lowers directly.
-// flatten matches by call name, so list function names (not the hint typeIds).
+// Leaf primitives flatten must KEEP (not inline). The native core math builtins
+// (mapped to opcodes via NATIVE_OPCODE) plus the engine-specific [hint] stubs and
+// the vector constructors the backend lowers directly. flatten matches by call name,
+// so list function names. `smooth_step` is absent — it is a native alias that flatten
+// INLINES to `smoothstep`. radians/degrees survive cycle 1 but carry no opcode:
+// flatten_opt lowers them to `x * K` (a `mul`) before the backend ever sees them.
 let HINT_WHITELIST : table<string> <- {
     "tex2d", "noise",
     "abs", "min", "max", "clamp", "saturate", "frac", "floor", "ceil", "mad", "lerp",
     "sqrt", "pow", "sin", "cos", "atan2", "log", "exp", "sign",
     "dot", "cross", "length", "normalize", "fresnel",
-    "remap", "one_minus", "step", "smooth_step", "unpack_normal",
+    "remap", "one_minus", "step", "smoothstep", "radians", "degrees", "unpack_normal",
     "float", "int",
     "float2", "float3", "float4", "int2", "int3", "int4"
+}
+
+// Native core math builtins → shader-graph opcode. These carry no [hint] annotation
+// (they are daslang `math` builtins, not DSL stubs), so the validator maps them by
+// name. dot/length/normalize are width-dependent and resolved separately (below).
+let NATIVE_OPCODE : table<string; string> <- {
+    "abs" => "abs", "min" => "min", "max" => "max", "clamp" => "clamp", "saturate" => "sat",
+    "floor" => "floor", "ceil" => "ceil", "sign" => "sign",
+    "sqrt" => "sqrt", "pow" => "pow", "sin" => "sin", "cos" => "cos", "atan2" => "atan2",
+    "log" => "log", "exp" => "exp",
+    "lerp" => "lerp", "mad" => "mad", "step" => "step", "smoothstep" => "smoothStep",
+    "cross" => "cross_f3"
 }
 
 // Surviving intrinsics that can't run in the per-draw preshader (texture sample / procedural
@@ -861,6 +886,31 @@ class ValidateShaderVisitor : AstVisitor {
                 register_node(expr, irNode)
                 return
             }
+        }
+        // Native core math builtins (no [hint]): map the bare name to its opcode.
+        // dot/length/normalize resolve to a width-specific opcode from the operand.
+        let fn = native_bare_name("{expr.func.name}")
+        var nativeOp = NATIVE_OPCODE?[fn] ?? ""
+        if (nativeOp == "" && !empty(expr.arguments)) {
+            let w = expr.arguments[0]._type.baseType
+            if (fn == "dot") {
+                nativeOp = w == Type.tFloat2 ? DotF2 : (w == Type.tFloat4 ? DotF4 : DotF3)
+            } elif (fn == "length") {
+                nativeOp = w == Type.tFloat2 ? LenF2 : (w == Type.tFloat4 ? LenF4 : LenF3)
+            } elif (fn == "normalize") {
+                nativeOp = w == Type.tFloat2 ? NormF2 : (w == Type.tFloat4 ? NormF4 : NormF3)
+            }
+        }
+        if (nativeOp != "") {
+            var irNode = begin_op(expr, nativeOp, kind)
+            for (arg in expr.arguments) {
+                add_arg(irNode, arg)
+            }
+            if (!expr.func.result.isVoid) {
+                irNode.outputs.push(add_pin(expr))
+            }
+            register_node(expr, irNode)
+            return
         }
         // Scalar `float(x)` cast — identity in the float-only shader graph. Useful
         // after loop unrolling, where an int loop index participates in float math

--- a/examples/flatten/backend/shader_dsl_primitives.das
+++ b/examples/flatten/backend/shader_dsl_primitives.das
@@ -100,7 +100,7 @@ def frac(x : float4) : float4 {}
 // native alias (NOT a stub) keeps the shaders unedited — flatten inlines it to the
 // core call, which the backend maps to the SmoothStep opcode. The scalar form keeps the
 // old stub's `float | int` surface (auto-promote int edges to float) for the same reason
-// as the lerp compat overload above.
+// as the lerp compat overload below.
 def smooth_step(mn : float | int; mx : float | int; x : float | int) => smoothstep(float(mn), float(mx), float(x))
 def smooth_step(mn, mx, x : float2) => smoothstep(mn, mx, x)
 def smooth_step(mn, mx, x : float3) => smoothstep(mn, mx, x)

--- a/examples/flatten/backend/shader_dsl_primitives.das
+++ b/examples/flatten/backend/shader_dsl_primitives.das
@@ -98,8 +98,10 @@ def frac(x : float4) : float4 {}
 // ---- smoothstep: keep the engine `smooth_step` spelling as a native alias ----
 // The EdenSpark shaders spell it `smooth_step`; core spells it `smoothstep`. A thin
 // native alias (NOT a stub) keeps the shaders unedited — flatten inlines it to the
-// core call, which the backend maps to the SmoothStep opcode.
-def smooth_step(mn, mx, x : float)  => smoothstep(mn, mx, x)
+// core call, which the backend maps to the SmoothStep opcode. The scalar form keeps the
+// old stub's `float | int` surface (auto-promote int edges to float) for the same reason
+// as the lerp compat overload above.
+def smooth_step(mn : float | int; mx : float | int; x : float | int) => smoothstep(float(mn), float(mx), float(x))
 def smooth_step(mn, mx, x : float2) => smoothstep(mn, mx, x)
 def smooth_step(mn, mx, x : float3) => smoothstep(mn, mx, x)
 def smooth_step(mn, mx, x : float4) => smoothstep(mn, mx, x)

--- a/examples/flatten/backend/shader_dsl_primitives.das
+++ b/examples/flatten/backend/shader_dsl_primitives.das
@@ -4,6 +4,7 @@ options no_unused_function_arguments
 module shader_dsl_primitives shared public
 
 require daslib/stub
+require math public
 
 
 // Global engine inputs - not tied to any specific geometry contract.
@@ -58,6 +59,15 @@ struct UnlitOutput {
 }
 
 
+// ---- Native core math --------------------------------------------------------
+// The component-wise math ops (abs/min/max/clamp/saturate/floor/ceil/sign/sqrt/pow/
+// sin/cos/atan2/log/exp/lerp/mad/step/smoothstep/radians/degrees/dot/cross/length/
+// normalize) are the daslang `math` builtins (re-exported above). The shader graph
+// backend recognises them by name (NATIVE_OPCODE in shader_dsl_boost.das) and maps
+// each to its opcode; radians/degrees carry no opcode — flatten_opt lowers them to a
+// multiply. Only the engine-specific leaves below remain DSL stubs.
+
+
 // ---- Texture sampling -------------------------------------------------------
 
 [stub, hint(sampleTexture)]
@@ -73,57 +83,7 @@ def noise(pos : float2) : float {}
 def noise(pos : float3) : float {}
 
 
-// ---- Generic (AnyFloat) component-wise operations ---------------------------
-// Overloaded per float width; the AST transformer maps them all to the same
-// shader graph node via the [hint] annotation.
-//
-// add = + operator, sub = - operator, mul = * operator, div = / operator,
-// neg = unary - operator.
-
-[stub, hint(abs)]
-def abs(x : float) : float {}
-[stub, hint(abs)]
-def abs(x : float2) : float2 {}
-[stub, hint(abs)]
-def abs(x : float3) : float3 {}
-[stub, hint(abs)]
-def abs(x : float4) : float4 {}
-
-[stub, hint(min)]
-def min(x : float | int, y : float | int) : float {}
-[stub, hint(min)]
-def min(x : float2, y : float2) : float2 {}
-[stub, hint(min)]
-def min(x : float3, y : float3) : float3 {}
-[stub, hint(min)]
-def min(x : float4, y : float4) : float4 {}
-
-[stub, hint(max)]
-def max(x : float | int, y : float | int) : float {}
-[stub, hint(max)]
-def max(x : float2, y : float2) : float2 {}
-[stub, hint(max)]
-def max(x : float3, y : float3) : float3 {}
-[stub, hint(max)]
-def max(x : float4, y : float4) : float4 {}
-
-[stub, hint(clamp)]
-def clamp(x : float | int, min : float | int, max : float | int) : float {}
-[stub, hint(clamp)]
-def clamp(x : float2, min : float2, max : float2) : float2 {}
-[stub, hint(clamp)]
-def clamp(x : float3, min : float3, max : float3) : float3 {}
-[stub, hint(clamp)]
-def clamp(x : float4, min : float4, max : float4) : float4 {}
-
-[stub, hint(sat)]
-def saturate(x : float | int) : float {}
-[stub, hint(sat)]
-def saturate(x : float2) : float2 {}
-[stub, hint(sat)]
-def saturate(x : float3) : float3 {}
-[stub, hint(sat)]
-def saturate(x : float4) : float4 {}
+// ---- Fractional part (no core builtin) --------------------------------------
 
 [stub, hint(frac)]
 def frac(x : float | int) : float {}
@@ -134,166 +94,22 @@ def frac(x : float3) : float3 {}
 [stub, hint(frac)]
 def frac(x : float4) : float4 {}
 
-[stub, hint(floor)]
-def floor(x : float | int) : float {}
-[stub, hint(floor)]
-def floor(x : float2) : float2 {}
-[stub, hint(floor)]
-def floor(x : float3) : float3 {}
-[stub, hint(floor)]
-def floor(x : float4) : float4 {}
 
-[stub, hint(ceil)]
-def ceil(x : float | int) : float {}
-[stub, hint(ceil)]
-def ceil(x : float2) : float2 {}
-[stub, hint(ceil)]
-def ceil(x : float3) : float3 {}
-[stub, hint(ceil)]
-def ceil(x : float4) : float4 {}
-
-// mad: a * b + c (b may be a scalar broadcast)
-[stub, hint(mad)]
-def mad(a : float | int, b : float | int, c : float | int) : float {}
-[stub, hint(mad)]
-def mad(a : float2, b : float2, c : float2) : float2 {}
-[stub, hint(mad)]
-def mad(a : float3, b : float3, c : float3) : float3 {}
-[stub, hint(mad)]
-def mad(a : float4, b : float4, c : float4) : float4 {}
-[stub, hint(mad)]
-def mad(a : float2, b : float, c : float2) : float2 {}
-[stub, hint(mad)]
-def mad(a : float3, b : float, c : float3) : float3 {}
-[stub, hint(mad)]
-def mad(a : float4, b : float, c : float4) : float4 {}
-
-// lerp: a, b are AnyFloat; t is a float scalar
-[stub, hint(lerp)]
-def lerp(a : float | int, b : float | int, t : float) : float {}
-[stub, hint(lerp)]
-def lerp(a : float2, b : float2, t : float) : float2 {}
-[stub, hint(lerp)]
-def lerp(a : float3, b : float3, t : float) : float3 {}
-[stub, hint(lerp)]
-def lerp(a : float4, b : float4, t : float) : float4 {}
+// ---- smoothstep: keep the engine `smooth_step` spelling as a native alias ----
+// The EdenSpark shaders spell it `smooth_step`; core spells it `smoothstep`. A thin
+// native alias (NOT a stub) keeps the shaders unedited — flatten inlines it to the
+// core call, which the backend maps to the SmoothStep opcode.
+def smooth_step(mn, mx, x : float)  => smoothstep(mn, mx, x)
+def smooth_step(mn, mx, x : float2) => smoothstep(mn, mx, x)
+def smooth_step(mn, mx, x : float3) => smoothstep(mn, mx, x)
+def smooth_step(mn, mx, x : float4) => smoothstep(mn, mx, x)
 
 
-// ---- Transcendentals (AnyFloat, component-wise) -----------------------------
-
-[stub, hint(sqrt)]
-def sqrt(x : float | int) : float {}
-[stub, hint(sqrt)]
-def sqrt(x : float2) : float2 {}
-[stub, hint(sqrt)]
-def sqrt(x : float3) : float3 {}
-[stub, hint(sqrt)]
-def sqrt(x : float4) : float4 {}
-
-[stub, hint(pow)]
-def pow(x : float | int, y : float | int) : float {}
-[stub, hint(pow)]
-def pow(x : float2, y : float2) : float2 {}
-[stub, hint(pow)]
-def pow(x : float3, y : float3) : float3 {}
-[stub, hint(pow)]
-def pow(x : float4, y : float4) : float4 {}
-
-[stub, hint(sin)]
-def sin(x : float | int) : float {}
-[stub, hint(sin)]
-def sin(x : float2) : float2 {}
-[stub, hint(sin)]
-def sin(x : float3) : float3 {}
-[stub, hint(sin)]
-def sin(x : float4) : float4 {}
-
-[stub, hint(cos)]
-def cos(x : float | int) : float {}
-[stub, hint(cos)]
-def cos(x : float2) : float2 {}
-[stub, hint(cos)]
-def cos(x : float3) : float3 {}
-[stub, hint(cos)]
-def cos(x : float4) : float4 {}
-
-[stub, hint(atan2)]
-def atan2(x : float | int, y : float | int) : float {}
-[stub, hint(atan2)]
-def atan2(x : float2, y : float2) : float2 {}
-[stub, hint(atan2)]
-def atan2(x : float3, y : float3) : float3 {}
-[stub, hint(atan2)]
-def atan2(x : float4, y : float4) : float4 {}
-
-[stub, hint(log)]
-def log(x : float | int) : float {}
-[stub, hint(log)]
-def log(x : float2) : float2 {}
-[stub, hint(log)]
-def log(x : float3) : float3 {}
-[stub, hint(log)]
-def log(x : float4) : float4 {}
-
-[stub, hint(exp)]
-def exp(x : float | int) : float {}
-[stub, hint(exp)]
-def exp(x : float2) : float2 {}
-[stub, hint(exp)]
-def exp(x : float3) : float3 {}
-[stub, hint(exp)]
-def exp(x : float4) : float4 {}
-
-[stub, hint(sign)]
-def sign(x : float | int) : float {}
-[stub, hint(sign)]
-def sign(x : float2) : float2 {}
-[stub, hint(sign)]
-def sign(x : float3) : float3 {}
-[stub, hint(sign)]
-def sign(x : float4) : float4 {}
-
-
-// ---- Dot product (dimension-specific, returns scalar) -----------------------
-
-[stub, hint(dot_f2)]
-def dot(x : float2, y : float2) : float {}
-
-[stub, hint(dot_f3)]
-def dot(x : float3, y : float3) : float {}
-
-[stub, hint(dot_f4)]
-def dot(x : float4, y : float4) : float {}
-
-
-// ---- Cross product ----------------------------------------------------------
-
-[stub, hint(cross_f3)]
-def cross(x : float3, y : float3) : float3 {}
-
-
-// ---- Length (dimension-specific, returns scalar) ----------------------------
-
-[stub, hint(len_f2)]
-def length(x : float2) : float {}
-
-[stub, hint(len_f3)]
-def length(x : float3) : float {}
-
-[stub, hint(len_f4)]
-def length(x : float4) : float {}
-
-
-// ---- Normalize (dimension-specific) -----------------------------------------
-
-[stub, hint(norm_f2)]
-def normalize(x : float2) : float2 {}
-
-[stub, hint(norm_f3)]
-def normalize(x : float3) : float3 {}
-
-[stub, hint(norm_f4)]
-def normalize(x : float4) : float4 {}
+// ---- Native-backed int-arg compat -------------------------------------------
+// The old DSL stubs accepted `float | int` and auto-promoted; core lerp is float-only.
+// A native-backed overload keeps `lerp(0.2, 10, daylight)` compiling unedited (the inner
+// all-float call binds to core lerp — concrete beats the OR-type, so no recursion).
+def lerp(a, b : float | int; t : float) => lerp(float(a), float(b), t)
 
 
 // ---- Lighting / surface ops -------------------------------------------------
@@ -321,24 +137,6 @@ def one_minus(x : float2) : float2 {}
 def one_minus(x : float3) : float3 {}
 [stub, hint(oneMinus)]
 def one_minus(x : float4) : float4 {}
-
-[stub, hint(step)]
-def step(x : float | int, y : float | int) : float {}
-[stub, hint(step)]
-def step(x : float2, y : float2) : float2 {}
-[stub, hint(step)]
-def step(x : float3, y : float3) : float3 {}
-[stub, hint(step)]
-def step(x : float4, y : float4) : float4 {}
-
-[stub, hint(smoothStep)]
-def smooth_step(min : float | int, max : float | int, x : float | int) : float {}
-[stub, hint(smoothStep)]
-def smooth_step(min : float2, max : float2, x : float2) : float2 {}
-[stub, hint(smoothStep)]
-def smooth_step(min : float3, max : float3, x : float3) : float3 {}
-[stub, hint(smoothStep)]
-def smooth_step(min : float4, max : float4, x : float4) : float4 {}
 
 [stub, hint(unpackNormal)]
 def unpack_normal(sample : float4) : float3 {}

--- a/examples/flatten/shaders/features/angle_spin.shader
+++ b/examples/flatten/shaders/features/angle_spin.shader
@@ -1,0 +1,24 @@
+require engine.render.shader_dsl
+
+// Feature fixture: native radians/degrees on the shader-graph backend. Neither has a
+// graph opcode — flatten_opt lowers each to a single `mul` (`radians(x) → x * K`), and an
+// adjacent const factor merges (`degrees(x) * C → x * (K*C)`). So angle math authored in
+// degrees costs the backend only the multiplies it would have hand-written.
+var {
+    spinDegPerSec = 90.0
+}
+
+[pixel_shader]
+def angle_spin(inp : PbrInput) {
+    let ang = radians(g_Time * spinDegPerSec)
+    let c = cos(ang)
+    let s = sin(ang)
+    let p = inp.uv - float2(0.5)
+    let rp = float2(p.x * c - p.y * s, p.x * s + p.y * c)
+    // degrees(worldNormal.y) * 0.01 → worldNormal.y * (57.29578 * 0.01) = one multiply
+    let shade = degrees(inp.worldNormal.y) * 0.01
+    return PbrOutput(
+        albedo = float3(rp.x + 0.5, rp.y + 0.5, shade),
+        roughness = 0.5
+    )
+}


### PR DESCRIPTION
## What

The `examples/flatten` shader-graph backend carried ~24 `[stub, hint]` math primitives because, pre-#3181, daslang core had no `step`/`smoothstep`/`radians`/`degrees`. Now that those — and the rest of the component-wise math — are native `math` builtins, the backend uses them directly instead of hand-rolled stubs.

## Backend migration (`examples/flatten/backend/`)

- `shader_dsl_primitives.das`: `require math public`; **dropped the ~24 math stubs** (`abs`/`min`/`max`/`clamp`/`saturate`/`floor`/`ceil`/`sign`/`sqrt`/`pow`/`sin`/`cos`/`atan2`/`log`/`exp`/`lerp`/`mad`/`step`/`dot`/`cross`/`length`/`normalize`). Kept the genuinely engine-specific leaves that have no core equivalent: `tex2d`/`noise`/`frac`/`remap`/`one_minus`/`fresnel`/`unpack_normal`.
- `shader_dsl_boost.das`: `NATIVE_OPCODE` name→opcode map + native recognition in `preVisitExprCall` (width-resolved for `dot`/`length`/`normalize`, with a bare-name strip for OR-type instances). `HINT_WHITELIST` updated.
- The EdenSpark sample shaders stay **unedited**: `smooth_step` (engine spelling) and the int-arg `lerp(0.2, 10, …)` form are kept as thin **native-backed aliases** (flatten inlines them to the core call).

## Fold growth (`daslib/flatten_opt.das`, `daslib/flatten.das`)

`radians`/`degrees` have no graph opcode but are exactly `x * K`. `flatten_opt` now lowers each to a multiply with the bit-exact constant (`radians(1.0)`/`degrees(1.0)` — `0x3c8efa35`/`0x42652ee0`), so an adjacent const factor merges via the existing reassoc/const-fold:

```
radians(g_Time * spinDegPerSec)   → (g_Time * spinDegPerSec) * 0.017453292f   // no radians opcode
degrees(inp.worldNormal.y) * 0.01 → inp.worldNormal.y * 0.57295775f           // degrees(x)*C → x*(K·C)
```

New feature fixture `shaders/features/angle_spin.shader` demonstrates it.

## Verification

- All **69** user shaders + **21** capability shaders + the new `angle_spin` compile clean on the native backend.
- `test_flatten_fold` **14/14** (residual-clean, incl. "every example shader folds clean (pixel_shader path)").
- `tests/flatten` **257/257**; lint clean; format OK.
- Width opcodes confirmed correct (`dot_f3`/`len_f3`/`norm_f3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)