### PR TITLE
dasSpirv: lock in MRT (multiple @location fragment outputs) via test

### DIFF
--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -837,6 +837,28 @@ def public fragshadow_words : array<uint> {
     return <- w
 }
 
+// ===== MRT: multiple @location outputs in a fragment shader (G-buffer prep for tutorial 10's
+// deferred rendering). Each `var @out @location = N` global is its own Output OpVariable with a
+// distinct Location decoration; the entry-point interface lists all of them. This locks in the
+// per-global Location model so a future MRT-breaking change in spirv_emit.das gets caught here
+// instead of in a downstream tutorial. =====
+var @in @location = 0 mrt_uv : float2
+var @out @location = 0 mrt_position : float4
+var @out @location = 1 mrt_normal   : float4
+var @out @location = 2 mrt_albedo   : float4
+[fragment_shader(name="mrt_spv"), marker(no_coverage)]
+def mrt {
+    mrt_position = float4(mrt_uv.x, mrt_uv.y, 0.0f, 1.0f)   // OpStore -> mrt_position (location 0)
+    mrt_normal   = float4(0.0f, 1.0f, 0.0f, 0.0f)            // OpStore -> mrt_normal   (location 1)
+    mrt_albedo   = float4(0.8f, 0.2f, 0.4f, 1.0f)            // OpStore -> mrt_albedo   (location 2)
+}
+
+def public mrt_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(mrt_spv)
+    return <- w
+}
+
 // ===== Phase-10.5 compute-tier fixtures: shared memory + barriers + atomics =====
 // cshared: a workgroup-shared scratch array (`@workgroup`, GLSL `shared` -> Workgroup OpVariable),
 // the control + shared-memory sync (barrier() -> OpControlBarrier, memoryBarrierShared() ->

--- a/tests/spirv/test_mrt.das
+++ b/tests/spirv/test_mrt.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+
+// Multiple Render Targets: lock in that the dasSpirv emitter accepts multiple `@out @location = N`
+// globals in a fragment shader and emits each as its own Output OpVariable with a distinct Location
+// decoration. This is the G-buffer shape tutorial 10 (deferred shading) will use; the per-global
+// Location model is already what the emitter does, so this test exists to *guard* the behavior
+// against a future regression -- not to add new functionality.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_mrt_three_outputs(t : T?) {
+    t |> run("MRT: fragment shader with 3 @location outputs") <| @(t : T?) {
+        var words <- mrt_words()
+        // Entry point is a fragment shader.
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.Fragment),
+            "mrt: EntryPoint model is Fragment")
+        // Exactly 4 Location decorations: 1 @in (mrt_uv at 0) + 3 @out (position/normal/albedo at 0/1/2).
+        let n_loc = count_op_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Location))
+        t |> success(n_loc == 4, "mrt: 4 Location decorations (1 input + 3 outputs), got {n_loc}")
+        // Each of locations 0, 1, 2 is emitted. (Location 0 is emitted twice -- input + output -- and
+        // op_has_operand_pair only checks for presence, not count.)
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Location), 0u),
+            "mrt: Location 0 decoration present")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Location), 1u),
+            "mrt: Location 1 decoration present")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Location), 2u),
+            "mrt: Location 2 decoration present")
+        // At least 4 OpVariable (1 in + 3 out -- there may be more for builtins / internals).
+        let n_var = count_op(words, SpvOp.Variable)
+        t |> success(n_var >= 4, "mrt: at least 4 OpVariable (1 input + 3 outputs), got {n_var}")
+        // At least 3 OpStore -- one write per output global. The shader body has exactly 3 stores.
+        let n_store = count_op(words, SpvOp.Store)
+        t |> success(n_store >= 3, "mrt: at least 3 OpStore writes, got {n_store}")
+        // spirv-val (CI gate) catches structural CFG / type errors the opcode-counting asserts can't.
+        validate(t, words, "mrt")
+        delete words
+    }
+}


### PR DESCRIPTION
## Summary

Test-only PR guarding the emitter's already-working multi-output fragment shader path. This is the G-buffer shape an upcoming deferred-shading tutorial in dasVulkan (tutorial 10) will use; verifying the support exists *now* (and pinning it against regressions) saves a tutorial-time surprise later.

## What works (no emitter change)

Declaring multiple `@out @location = N` globals in a fragment shader:

```das
var @out @location = 0 g_position : float4
var @out @location = 1 g_normal   : float4
var @out @location = 2 g_albedo   : float4

[fragment_shader(name="...")]
def shader { g_position = ...; g_normal = ...; g_albedo = ...; }
```

compiles to a 171-word SPIR-V module spirv-val-clean with:
- 3 Output `OpVariable` of pointer-to-vec4
- 3 distinct `OpDecorate Location {0, 1, 2}`
- All 3 in the `OpEntryPoint` interface list
- 3 `OpStore` (the three writes)

`spirv_emit.das:372-385` already does the right thing — one `Location` per `@out` global, multiple `@out` globals → multiple `Location` decorations. The per-global Location model *is* the right design for MRT; what was missing was test coverage.

## Diff

- `tests/spirv/_spirv_common.das` — new `mrt_words()` fixture + the 3-output fragment shader
- `tests/spirv/test_mrt.das` — 6 asserts (EntryPoint model = Fragment, 4 total Location decorations, Locations 0/1/2 present, OpVariable ≥ 4, OpStore ≥ 3) + `spirv-val` clean

## Test plan

- [x] New `test_mrt_three_outputs` passes locally (worktree build)
- [x] Full spirv suite: 124 tests pass (123 existing + 1 new MRT) → no regressions
- [x] `spirv-val` clean on the emitted MRT module
- [ ] CI lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)