### PR TITLE
dasSpirv: subpass input attachments (subpassInput + subpassLoad)

### DIFF
--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -125,6 +125,24 @@ def public imageSize(img : image2D) : int2 {
     return int2(0, 0)
 }
 
+// ===== subpass input attachments (Vulkan deferred-rendering rail) =====
+// subpassInput is an opaque marker for a Vulkan subpass input attachment: a per-fragment read of a
+// previous subpass's color or depth attachment, sampled at the SAME fragment coordinate (no UV).
+// Lowers to OpTypeImage with Dim=SubpassData (Sampled=2, format=Unknown) + an InputAttachmentIndex
+// decoration. The host binds it as VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT. Requires the
+// InputAttachment capability. The shader declares it with `@input_attachment_index = N` alongside
+// the usual `@set` / `@binding` slots:
+//     var @set = 0 @binding = 0 @input_attachment_index = 0 subpass_color : subpassInput
+// subpassLoad samples it at the current fragment (no coord operand on the daslang side; the int2
+// (0,0) is emitted internally as the OpImageRead coordinate). Returns float4 even for depth inputs
+// -- the depth value lands in .x.
+struct subpassInput {}
+
+[unused_argument(i), sideeffects]
+def public subpassLoad(i : subpassInput) : float4 {
+    return float4(0.0, 0.0, 0.0, 0.0)
+}
+
 // ===== fragment realism =====
 // discard() abandons the current fragment (OpKill). It is a block terminator, so it must be the last
 // statement on its control-flow path (typically `if (cond) { discard() }`); fragment-only.

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -36,6 +36,7 @@ struct GlobalInfo {
     is_storage_image : bool         // a read-write storage image (UniformConstant OpTypeImage); used via imageLoad/imageStore
     is_separate_image : bool        // a standalone sampled image (texture2D, OpTypeImage); combined at the call via OpSampledImage
     is_separate_sampler : bool      // a standalone sampler (OpTypeSampler)
+    is_subpass_input : bool         // a subpass-input attachment (UniformConstant OpTypeImage Dim=SubpassData); used via subpassLoad
     elem_type  : uint               // SSBO runtime-array element type-id (vec/struct elements can't go through emit_type)
     is_constant : bool              // a module-scope `let X = <const>` folded to an OpConstant; references resolve to const_id directly (no OpVariable / OpLoad)
     const_id   : uint               // the OpConstant result-id (when is_constant)
@@ -60,6 +61,7 @@ struct EmitCtx {
     stage         : ShaderStage                 // the shader stage (texture() implicit-LOD sampling is fragment-only)
     uses_frag_depth : bool                      // gl_FragDepth referenced (Output-only, so = written) -> emit DepthReplacing
     image_query_cap : bool                      // OpCapability ImageQuery already emitted (textureSize)
+    input_attachment_cap : bool                 // OpCapability InputAttachment already emitted (subpassLoad)
     user_funcs    : table<uint64; UserFunc>     // intptr(Function) -> emittable user-defined shader function
     user_order    : array<uint64>               // user_funcs keys in stable emission order (collect_dependencies order)
     call_temps    : table<uint64; CallTemp>     // intptr(ref-arg Expression) -> its copy-in/out Function-storage temp
@@ -322,6 +324,15 @@ def private storage_image_info(t : TypeDecl?) : tuple<ok : bool; dim : SpvDim> {
     return (ok = false, dim = SpvDim._2D)
 }
 
+// subpassInput is the opaque marker for a Vulkan subpass input attachment. Same recognition pattern
+// as sampler/image globals -- a tStructure named "subpassInput" -> Dim=SubpassData OpTypeImage in
+// UniformConstant storage (sampled=2, no format), decorated with InputAttachmentIndex, sampled via
+// subpassLoad -> OpImageRead with an int2(0,0) coord.
+def private is_subpass_input_type(t : TypeDecl?) : bool {
+    if (t == null || t.baseType != Type.tStructure || t.structType == null) return false
+    return "{t.structType.name}" == "subpassInput"
+}
+
 // Exactly the type set emit_type lowers without panicking: a scalar/vector (scalar_class >= 0), bool,
 // a matrix, or a fixed array of those. Lets the @workgroup path reject an unsupported shared type with
 // a clean diagnostic instead of crashing in emit_type (struct/handle/dynamic-array shared vars).
@@ -429,6 +440,38 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.UniformConstant, value_type = img, is_storage_image = true))
         reflection.bindings |> push(SpirvDescriptorBinding(set = set, binding = binding,
             kind = SpirvDescriptorKind.storage_image, count = 1, stages = stage_flag(stage)))
+        return
+    }
+    // subpass input attachment: a global of the opaque subpassInput type. OpTypeImage with Dim=
+    // SubpassData (Sampled=2, no format), UniformConstant storage, decorated with both Descriptor-
+    // Set/Binding (like any other descriptor) AND InputAttachmentIndex (from @input_attachment_index).
+    // Sampled only via subpassLoad() -- which emits OpImageRead with an internal int2(0,0) coord.
+    // Requires the InputAttachment capability (emitted once via ensure_input_attachment). Used by
+    // Vulkan deferred-rendering subpasses to read the previous subpass's color/depth at the same
+    // fragment coordinate (the int2(0,0) is an OFFSET relative to gl_FragCoord, not an absolute pos).
+    if (is_subpass_input_type(v._type)) {
+        let img = type_image(m, type_float(m, 32u), SpvDim.SubpassData, 0u, 2u, SpvImageFormat.Unknown)
+        let pt = type_pointer(m, SpvStorageClass.UniformConstant, img)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.UniformConstant))
+        let set = v.annotation |> find_arg("set") ?as tInt ?? 0
+        let binding = v.annotation |> find_arg("binding") ?as tInt ?? 0
+        let iax = v.annotation |> find_arg("input_attachment_index") ?as tInt ?? -1
+        if (set < 0 || binding < 0) {
+            errors |> push("subpassInput '{vname}' set/binding must be non-negative (got set={set}, binding={binding})")
+            return
+        }
+        if (iax < 0) {
+            errors |> push("subpassInput '{vname}' must specify @input_attachment_index = N (non-negative)")
+            return
+        }
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.DescriptorSet), uint(set))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Binding), uint(binding))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.InputAttachmentIndex), uint(iax))
+        ensure_input_attachment(m, ctx)
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.UniformConstant, value_type = img, is_subpass_input = true))
+        reflection.bindings |> push(SpirvDescriptorBinding(set = set, binding = binding,
+            kind = SpirvDescriptorKind.input_attachment, count = 1, stages = stage_flag(stage)))
         return
     }
     // separate image + sampler (Vulkan's split model): a texture2D is a standalone sampled OpTypeImage,
@@ -564,7 +607,7 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
             return
         }
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, a constant `let`, or a sampler type e.g. sampler2D)")
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, a constant `let`, or an opaque type e.g. sampler2D / image2D / subpassInput)")
 }
 
 // ===== member index of a struct field by name =====
@@ -773,6 +816,14 @@ def private ensure_image_query(var m : SpirvModule; var ctx : EmitCtx) {
     if (ctx.image_query_cap) return
     emit(m, SEC_CAPS, SpvOp.Capability, uint(SpvCapability.ImageQuery))
     ctx.image_query_cap = true
+}
+
+// Subpass-input attachments (OpTypeImage Dim=SubpassData) require the InputAttachment capability.
+// Same emit-once + ctx-flag dedupe pattern as ensure_image_query.
+def private ensure_input_attachment(var m : SpirvModule; var ctx : EmitCtx) {
+    if (ctx.input_attachment_cap) return
+    emit(m, SEC_CAPS, SpvOp.Capability, uint(SpvCapability.InputAttachment))
+    ctx.input_attachment_cap = true
 }
 
 // daslang math builtin -> GLSL.std.450 ext-inst opcode. abs/min/max/clamp/sign pick the F/S/U
@@ -2046,6 +2097,37 @@ class SpirvEmit : AstVisitor {
             emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, imgval, gi.var_id)
             let coord = value_of(expr.arguments[1])
             if (coord == 0u) return expr
+            let rt = emit_type(bm, expr._type)
+            let res = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.ImageRead, rt, res, imgval, coord)
+            e2id[k] = res
+            return expr
+        }
+        // subpassLoad(input) : float4: OpLoad the SubpassData image + OpImageRead at int2(0, 0). For a
+        // SubpassData image the coordinate is an OFFSET from gl_FragCoord (not absolute), so (0,0) is
+        // "this fragment" -- which is the only useful subpass-input sampling pattern (subpasses share
+        // pixel locality with the previous pass).
+        if (name == "subpassLoad") {
+            if (length(expr.arguments) != 1) {
+                errs |> push("subpassLoad expects (input)")
+                return expr
+            }
+            let ig = global_var_of(expr.arguments[0])
+            if (ig == null) {
+                errs |> push("subpassLoad: argument must be a subpassInput global")
+                return expr
+            }
+            let gi = ctx.globals?[intptr(ig)] ?? GlobalInfo()
+            if (!gi.is_subpass_input) {
+                errs |> push("subpassLoad: '{ig.name}' is not a subpassInput")
+                return expr
+            }
+            let imgval = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.Load, gi.value_type, imgval, gi.var_id)
+            let it = type_int(bm, 32u, 1u)
+            let ivec = type_vector(bm, it, 2)
+            let zero = const_int(bm, 0)
+            let coord = const_composite(bm, ivec, [zero, zero])
             let rt = emit_type(bm, expr._type)
             let res = alloc_id(bm)
             emit(bm, SEC_FUNCS, SpvOp.ImageRead, rt, res, imgval, coord)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -450,6 +450,13 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
     // Vulkan deferred-rendering subpasses to read the previous subpass's color/depth at the same
     // fragment coordinate (the int2(0,0) is an OFFSET relative to gl_FragCoord, not an absolute pos).
     if (is_subpass_input_type(v._type)) {
+        // SubpassData images + the InputAttachment capability are fragment-only per the Vulkan
+        // spec; reject the global at emit time with a clean message rather than letting spirv-val
+        // surface it as a structural error.
+        if (stage != ShaderStage.Fragment) {
+            errors |> push("subpassInput '{vname}' is fragment-only (Vulkan subpass-input attachments)")
+            return
+        }
         let img = type_image(m, type_float(m, 32u), SpvDim.SubpassData, 0u, 2u, SpvImageFormat.Unknown)
         let pt = type_pointer(m, SpvStorageClass.UniformConstant, img)
         let vid = alloc_id(m)
@@ -2108,6 +2115,10 @@ class SpirvEmit : AstVisitor {
         // "this fragment" -- which is the only useful subpass-input sampling pattern (subpasses share
         // pixel locality with the previous pass).
         if (name == "subpassLoad") {
+            if (ctx.stage != ShaderStage.Fragment) {
+                errs |> push("subpassLoad is fragment-only (Vulkan subpass-input attachments)")
+                return expr
+            }
             if (length(expr.arguments) != 1) {
                 errs |> push("subpassLoad expects (input)")
                 return expr

--- a/modules/dasSpirv/spirv/spirv_reflect.das
+++ b/modules/dasSpirv/spirv/spirv_reflect.das
@@ -20,6 +20,7 @@ enum SpirvDescriptorKind {
     sampled_image           //!< a standalone `texture2D` (separate-image model)
     sampler                 //!< a standalone `sampler` (separate-sampler model)
     comparison_sampler      //!< a `sampler2DShadow` (depth-compare combined sampler, sampled via textureCompare)
+    input_attachment        //!< a `subpassInput` (Vulkan subpass-input attachment, sampled via subpassLoad)
 }
 
 //! Stages a binding / push range is used in (the host maps to e.g. VkShaderStageFlags). A single
@@ -55,11 +56,12 @@ struct SpirvReflection {
     push_constants : array<SpirvPushConstantRange>  //!< push-constant ranges
 }
 
-// 'RFL3' — wire-format magic + version. Bump on any layout OR descriptor-kind change to encode/
+// 'RFL4' — wire-format magic + version. Bump on any layout OR descriptor-kind change to encode/
 // decode_reflection, so an older consumer rejects a newer stream loudly instead of mis-mapping an
 // unknown SpirvDescriptorKind (kind_from_int falls back to uniform_buffer). RFL2 = Phase 7
-// (storage_image / sampled_image / sampler); RFL3 = Phase 10.4 (comparison_sampler).
-let REFLECTION_MAGIC = 0x52464C33u
+// (storage_image / sampled_image / sampler); RFL3 = Phase 10.4 (comparison_sampler);
+// RFL4 = input_attachment (subpassInput, this commit).
+let REFLECTION_MAGIC = 0x52464C34u
 
 def finalize(var r : SpirvReflection) {
     delete r.bindings
@@ -97,6 +99,7 @@ def private kind_from_int(k : int) : SpirvDescriptorKind {
     if (k == int(SpirvDescriptorKind.sampled_image)) return SpirvDescriptorKind.sampled_image
     if (k == int(SpirvDescriptorKind.sampler)) return SpirvDescriptorKind.sampler
     if (k == int(SpirvDescriptorKind.comparison_sampler)) return SpirvDescriptorKind.comparison_sampler
+    if (k == int(SpirvDescriptorKind.input_attachment)) return SpirvDescriptorKind.input_attachment
     return SpirvDescriptorKind.uniform_buffer
 }
 

--- a/tests/spirv/_fail_closed/_fc_subpass_stage.das
+++ b/tests/spirv/_fail_closed/_fc_subpass_stage.das
@@ -1,0 +1,20 @@
+// Fail-closed fixture: a subpassInput global in a non-fragment shader must be rejected cleanly.
+// SubpassData images + the InputAttachment capability are fragment-only per the Vulkan spec, and
+// spirv-val would flag a compute/vertex-stage usage; we surface the error at emit time with a
+// clean message instead. The `_`-prefix + `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @set = 0 @binding = 0 @input_attachment_index = 0 fc_subpass : subpassInput
+var @ssbo @binding = 1 out_data : array<float>
+
+[compute_shader(local_size_x=64, name="fc_subpass_spv")]
+def fc_subpass {
+    let i = gl_GlobalInvocationID.x
+    let sample = subpassLoad(fc_subpass)        // would compile if this were a fragment shader
+    out_data[i] = sample.x
+}

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -859,6 +859,25 @@ def public mrt_words : array<uint> {
     return <- w
 }
 
+// ===== Subpass input attachment: a Vulkan deferred-rendering rail (tutorial 10 lighting subpass).
+// Reads a previous subpass's color/depth at the SAME fragment coordinate via subpassLoad. The
+// opaque type subpassInput lowers to OpTypeImage Dim=SubpassData (Sampled=2, no format) decorated
+// with InputAttachmentIndex (from @input_attachment_index); subpassLoad emits OpImageRead with an
+// internal int2(0,0) coord. Requires the InputAttachment capability. =====
+var @set = 0 @binding = 0 @input_attachment_index = 0 sp_color : subpassInput
+var @out @location = 0 sp_out : float4
+[fragment_shader(name="subpass_spv"), marker(no_coverage)]
+def subpass_load_frag {
+    let sample = subpassLoad(sp_color)         // OpImageRead -> read color from prev subpass
+    sp_out = float4(sample.x, sample.y, sample.z, 1.0f)
+}
+
+def public subpass_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(subpass_spv)
+    return <- w
+}
+
 // ===== Phase-10.5 compute-tier fixtures: shared memory + barriers + atomics =====
 // cshared: a workgroup-shared scratch array (`@workgroup`, GLSL `shared` -> Workgroup OpVariable),
 // the control + shared-memory sync (barrier() -> OpControlBarrier, memoryBarrierShared() ->

--- a/tests/spirv/test_fail_closed.das
+++ b/tests/spirv/test_fail_closed.das
@@ -57,5 +57,7 @@ def test_fail_closed_rejections(t : T?) {
         check_rejects(t, "_fc_mutual", "recursion is not supported")
         check_rejects(t, "_fc_badparam", "is not supported (only 32-bit scalar/vector/matrix parameters")
         check_rejects(t, "_fc_badret", "return type tDouble is not supported")
+        // subpass input attachments + subpassLoad are fragment-only
+        check_rejects(t, "_fc_subpass_stage", "subpassInput 'fc_subpass' is fragment-only")
     }
 }

--- a/tests/spirv/test_subpass_input.das
+++ b/tests/spirv/test_subpass_input.das
@@ -1,0 +1,65 @@
+options gen2
+options indenting = 4
+
+// Subpass input attachment: a Vulkan deferred-rendering rail (tutorial 10 lighting subpass). A
+// shader declares `var @set @binding @input_attachment_index = N x : subpassInput` and reads it
+// via `subpassLoad(x)`. The emitter lowers this to:
+//   * OpTypeImage Dim=SubpassData (Sampled=2, no format), UniformConstant storage class
+//   * Decorate DescriptorSet, Binding, InputAttachmentIndex
+//   * OpCapability InputAttachment
+//   * Reflection: SpirvDescriptorKind.input_attachment
+//   * subpassLoad -> OpLoad + OpImageRead at int2(0, 0)
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+require spirv/spirv_reflect
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_subpass_input(t : T?) {
+    t |> run("subpass input: subpassInput global + subpassLoad -> OpImageRead") <| @(t : T?) {
+        var words <- subpass_words()
+        // Fragment shader (subpassLoad is fragment-only in practice -- the OpImageRead at
+        // current-fragment offset only makes sense per fragment).
+        let model = op_first_operand(words, SpvOp.EntryPoint)
+        t |> success(model.ok && model.value == uint(SpvExecutionModel.Fragment),
+            "subpass: EntryPoint model is Fragment")
+        // InputAttachment capability declared (required for Dim=SubpassData).
+        t |> success(op_has_operand(words, SpvOp.Capability, uint(SpvCapability.InputAttachment)),
+            "subpass: OpCapability InputAttachment emitted")
+        // InputAttachmentIndex decoration on the global (idx 1 in OpDecorate after the target id).
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.InputAttachmentIndex)),
+            "subpass: InputAttachmentIndex decoration emitted")
+        // DescriptorSet + Binding decorations (set=0, binding=0 per the fixture).
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.DescriptorSet)),
+            "subpass: DescriptorSet decoration emitted")
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Binding)),
+            "subpass: Binding decoration emitted")
+        // OpImageRead is the read instruction (vs OpImageSample* for textures).
+        t |> success(has_op(words, SpvOp.ImageRead), "subpass: subpassLoad -> OpImageRead")
+        // Reflection: the binding is registered as input_attachment (the host needs to bind it as
+        // VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, distinct from combined_image_sampler / storage_image).
+        let refl = decode_reflection(subpass_spv_reflect)
+        t |> success(length(refl.bindings) >= 1, "subpass: at least one descriptor binding reflected")
+        if (length(refl.bindings) >= 1) {
+            let b = refl.bindings[0]
+            t |> success(b.kind == SpirvDescriptorKind.input_attachment,
+                "subpass: binding kind is input_attachment (got {b.kind})")
+            t |> success(b.set == 0 && b.binding == 0,
+                "subpass: binding at (set=0, binding=0), got (set={b.set}, binding={b.binding})")
+        }
+        // spirv-val (CI gate) checks the structural CFG + Sampled=2 + Dim=SubpassData semantics.
+        validate(t, words, "subpass")
+        delete words
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Vulkan deferred-rendering rail to the dasSpirv emitter: a fragment shader can declare a subpass-input attachment and sample it at the current fragment position. Pedagogically the last piece an upcoming deferred-shading tutorial in dasVulkan (tutorial 10) needs from the emitter side — combined with #3195's MRT lock-in, the dasSpirv surface for G-buffer write (MRT) + G-buffer read (`subpassLoad`) is complete.

## Surface

```das
var @set = 0 @binding = 0 @input_attachment_index = 0 colorIn : subpassInput

[vulkan_fragment_shader(name="lighting_spv")]
def lighting {
    let sample = subpassLoad(colorIn)
    ...
}
```

Lowers to:
- `OpTypeImage Dim=SubpassData Sampled=2` (no format), `UniformConstant` storage
- `OpDecorate` `DescriptorSet` / `Binding` / `InputAttachmentIndex`
- `OpCapability InputAttachment` (emitted once, deduped)
- `subpassLoad` → `OpLoad` + `OpImageRead` at `int2(0, 0)` (offset from `gl_FragCoord`)
- Reflection: `SpirvDescriptorKind.input_attachment` (new variant)

## Wire format

Bumped from `RFL3` to `RFL4` because the descriptor-kind enum gained a new value — older consumers reject loudly via the magic check instead of mis-mapping. No checked-in pre-RFL4 reflection bytes anywhere; consumers recompile clean.

## Implementation

- `modules/dasSpirv/spirv/spirv_builtins.das` — opaque `struct subpassInput {}` + `subpassLoad` stub
- `modules/dasSpirv/spirv/spirv_reflect.das` — `input_attachment` `SpirvDescriptorKind` + `RFL3`→`RFL4` + `kind_from_int` case
- `modules/dasSpirv/spirv/spirv_emit.das` — `is_subpass_input` GlobalInfo field, `input_attachment_cap` EmitCtx flag, `is_subpass_input_type` helper, `ensure_input_attachment` capability helper, `classify_global` branch (parses `@input_attachment_index` + `DescriptorSet`/`Binding` + decorations + reflection entry), `subpassLoad` call dispatch (validates the global is subpass-input, emits `OpLoad` + `OpImageRead` with internal `int2(0,0)` coord)
- `tests/spirv/_spirv_common.das` — new `subpass_words()` fixture
- `tests/spirv/test_subpass_input.das` — 9 asserts (EntryPoint=Fragment, `InputAttachment` capability, `InputAttachmentIndex`+`DescriptorSet`+`Binding` decorations, `OpImageRead` present, reflection binding is `input_attachment` at `(set=0, binding=0)`) + `spirv-val`

## Test plan

- [x] `test_subpass_input` passes locally (worktree build)
- [x] Full spirv suite: **126 tests pass** (124 prior baseline + 2 from this PR) → no regressions
- [x] `spirv-val` clean
- [ ] CI lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)