### PR TITLE
build: reuse one OpenSSL across build dirs/worktrees (shared cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ benchdata.db
 
 # build artifacts
 build/
+build-ninja/
 build-track/
 build-rwdi/
 build-asan/

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -12,9 +12,20 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 		# Both are MSVC-only — perl invokes OpenSSL's MSVC-flavored config and
 		# nmake is the MSVC make tool. clang-mingw / gcc-mingw take the ELSE
 		# branch below and pick up the system OpenSSL from the mingw sysroot.
-		set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/openssl")
-		find_package(OpenSSL QUIET PATHS ${OPENSSL_ROOT_DIR})
+		# OPENSSL_ROOT_DIR defaults to a build-dir-local openssl/, but honors an
+		# override (env DASLANG_OPENSSL_DIR, or -DOPENSSL_ROOT_DIR) so OpenSSL can
+		# be built once into a shared per-machine cache and reused across build
+		# dirs / worktrees instead of rebuilt per build dir. CI sets neither, so
+		# its per-build-dir path (and the build-clangcl/openssl cache) is unchanged.
+		if(NOT OPENSSL_ROOT_DIR AND DEFINED ENV{DASLANG_OPENSSL_DIR})
+			set(OPENSSL_ROOT_DIR "$ENV{DASLANG_OPENSSL_DIR}")
+		endif()
+		if(NOT OPENSSL_ROOT_DIR)
+			set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/openssl")
+		endif()
+		find_package(OpenSSL QUIET PATHS "${OPENSSL_ROOT_DIR}")
 		IF(NOT OpenSSL_FOUND)
+			MESSAGE(STATUS "dasHV: OpenSSL not found at ${OPENSSL_ROOT_DIR} - building 3.5.1 from source (one-time per OPENSSL_ROOT_DIR)")
 			# Build openssl from sources
 			if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
 				set(OPENSSL_ARCH "VC-WIN64A")
@@ -53,6 +64,7 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 			list(APPEND OPENSSL_LIBRARIES_FILES Crypt32.lib)
 			SET(OPENSSL_FROM_SOURCES TRUE)
 		ELSE()
+			MESSAGE(STATUS "dasHV: using prebuilt OpenSSL ${OPENSSL_VERSION} (include: ${OPENSSL_INCLUDE_DIR}) - skipping source build")
 			SET(OPENSSL_LIBRARIES_FILES OpenSSL::Crypto OpenSSL::SSL)
 		ENDIF()
 

--- a/skills/build_and_debug.md
+++ b/skills/build_and_debug.md
@@ -31,6 +31,16 @@ This skill uses `bin/Release/daslang.exe` in examples below (the dominant local-
 - For incremental builds after editing a single `.cpp` file, expect ~2-5 minutes. For changes touching headers, expect longer
 - **MSVC `C1001` / `LNK1000` during "Generating code"** (Windows) — link-time codegen (LTCG) choking on a **stale incremental database** (`.ipdb`/`.iobj`) in a long-lived `build/`, *not* a code bug. The line `"no usable IPDB/IOBJ from previous compilation … fall back to full compilation"` on a clean retry confirms it. Fix: clean-rebuild just the offending target — `cmake --build build --target <name> --clean-first` — rather than nuking `build/`. Commonly triggered when a config change (e.g. flipping a `DAS_*_DISABLED` flag) forces a recompile of an object whose stale LTCG state no longer matches.
 
+### Shared OpenSSL cache (Windows/MSVC) — the big first-build lever
+
+On **Windows/MSVC**, the dominant cost of a *fresh* build dir is **dasHV building OpenSSL 3.5.1 from source** (~15 min of the clean build): `modules/dasHV/CMakeLists.txt` defaults `OPENSSL_ROOT_DIR` to `${CMAKE_BINARY_DIR}/openssl` (per build dir), so every new `build*/` and every worktree rebuilds it. The configure prints which path it took — `dasHV: … building 3.5.1 from source` vs `dasHV: using prebuilt OpenSSL <version> (include: <dir>) - skipping source build`.
+
+To build OpenSSL **once and reuse it everywhere**, point it at a shared cache (it's an `IF(NOT OpenSSL_FOUND)` gate — first build populates the dir, all later builds `find_package` → skip):
+- **Env (covers CLI + VS Code):** set `DASLANG_OPENSSL_DIR=%LOCALAPPDATA%/daslang/openssl` once in your environment.
+- **Per-configure:** `cmake … -DOPENSSL_ROOT_DIR=<shared-dir>`.
+
+The default (no env, no flag) stays per-build-dir, so **CI is unchanged** — its lanes use vcpkg (`vcpkg install openssl` + the vcpkg toolchain) or a cached from-source `build-clangcl/openssl` for the same effect. Linux/macOS use the system OpenSSL (brew/apt/mingw sysroot), so this is MSVC-only.
+
 ## Debugging runtime crashes
 
 - **Always check the exit code** after running `daslang` — a crash may produce no output, looking like a silent success


### PR DESCRIPTION
## Summary

On Windows/MSVC, dasHV builds OpenSSL 3.5.1 from source into `${CMAKE_BINARY_DIR}/openssl` — **per build dir** — so every fresh build dir and every worktree rebuilds it (~15 min, the dominant clean-build cost).

This makes `OPENSSL_ROOT_DIR` honor an **opt-in override** so OpenSSL can be built once and reused everywhere:
- `DASLANG_OPENSSL_DIR` env var, or `-DOPENSSL_ROOT_DIR=<dir>`;
- defaults to the current per-build-dir path when neither is set;
- pointed at a shared dir, the first build populates it and all later builds `find_package` → **skip the source build** (the existing `IF(NOT OpenSSL_FOUND)` gate);
- a `MESSAGE(STATUS ...)` now shows which path was taken (`building 3.5.1 from source` vs `using prebuilt OpenSSL … skipping source build`).

## CI impact

**No behavioral change.** CI sets neither override, so every lane keeps its current per-build-dir path (and the `build-clangcl/openssl` cache). The only effect is a **one-time clang-cl cache-key bust** — that lane's OpenSSL cache key hashes `modules/dasHV/CMakeLists.txt`, so it rebuilds OpenSSL once and re-caches under the new key. Other lanes (MSVC-vcpkg, macOS-brew, mingw, Linux) are untouched.

## Files

- `modules/dasHV/CMakeLists.txt` — override + status messages
- `skills/build_and_debug.md` — "Shared OpenSSL cache" section (env var, flag, CI/vcpkg context)
- `.gitignore` — `build-ninja/`

## Local usage

Set `DASLANG_OPENSSL_DIR=%LOCALAPPDATA%/daslang/openssl` once → every build dir / worktree skips the OpenSSL rebuild. Verified locally: a build dir pointed at a prebuilt scheduled **0** `openssl_build` rules (vs **375** for a cold dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)