### PR TITLE
mcp: add worktree bootstrap tool (setup.das)

### DIFF
--- a/skills/mcp_tools.md
+++ b/skills/mcp_tools.md
@@ -61,6 +61,8 @@ The daslang MCP server (`utils/mcp/main.das`) exposes compiler diagnostics, prog
 
 **Configuration.** Configure `.mcp.json` with `"command"` pointing at the daslang binary (`bin/Release/daslang.exe` on Windows MSVC, `build/daslang` on Linux/macOS, `bin/daslang` for the installed SDK), `"args": ["utils/mcp/main.das"]`. See `utils/mcp/README.md` for details and Claude Code permissions.
 
+**Fresh checkouts / worktrees.** `.mcp.json`, `sgconfig.yml`, `bin/`, and the tree-sitter grammar lib are all gitignored, so a new `git worktree add` (or clone) has no daslang MCP at all. Bootstrap it with `daslang utils/mcp/setup.das -- --root <worktree>` — it builds a worktree-local binary (+ grammar), copies the platform `sgconfig.yml`, and merges a `daslang` entry into `.mcp.json` (adds no new secrets; existing servers, including any secret env blocks, are preserved as-is). `--no-build` skips the build. Restart the session to pick it up.
+
 **`"defer_loading": false`.** The repo's `.mcp.json` sets this on the `daslang` server entry so tool schemas load at session start instead of being deferred (deferred = caller has to `ToolSearch select:<tool>` before each first call). When the harness honors the flag, this removes the per-call ToolSearch friction. When it doesn't (currently the upstream behavior — see [Issue #26844](https://github.com/anthropics/claude-code/issues/26844)), the flag is harmless and tools fall back to the deferred path; CLAUDE.md's "MCP-first search" rule documents that workflow.
 
 **Tests:** run `dastest/dastest.das -- --test utils/mcp/test_tools.das` through the daslang binary.

--- a/utils/mcp/README.md
+++ b/utils/mcp/README.md
@@ -108,6 +108,37 @@ claude mcp add daslang -- ./bin/daslang utils/mcp/main.das
 
 Claude Code starts and stops the server automatically with each session.
 
+### Fresh checkouts and worktrees
+
+A new `git worktree add` (or a fresh clone) does **not** carry the files the MCP
+server needs: `.mcp.json`, `sgconfig.yml`, a built `bin/` binary, and the
+tree-sitter grammar shared lib are all gitignored, so a Claude session opened in
+a worktree silently has zero daslang tools. Bootstrap one with:
+
+```bash
+# run from ANY existing daslang binary, pointed at the target worktree
+bin/Release/daslang.exe utils/mcp/setup.das -- --root <worktree-abs-path>   # Windows MSVC
+./bin/daslang           utils/mcp/setup.das -- --root <worktree-abs-path>   # Linux / macOS
+daslang                 utils/mcp/setup.das -- --root <worktree-abs-path>   # when daslang is on PATH
+```
+
+`setup.das` builds a worktree-local `daslang` (+ the `tree_sitter_daslang`
+grammar), copies the platform `sgconfig.yml` template, and writes/merges
+`.mcp.json` with the `daslang` server entry. It adds no new secrets, and
+preserves any existing server entries (e.g. `github`, including their env
+blocks) as-is. Pass `--no-build` to only wire the
+config to an already-built binary. On Windows it also points the build at a
+shared OpenSSL cache (`%LOCALAPPDATA%/daslang/openssl`; override with
+`--openssl-dir`) so OpenSSL is built once instead of ~15 min per worktree.
+Restart the session in the worktree afterward to pick up the server.
+
+> **`das_root` is derived from the binary, not the cwd** (`src/misc/sysos.cpp`):
+> daslang resolves its root (daslib, modules) from the directory above `bin/`.
+> `setup.das` therefore points `.mcp.json` at the **worktree-local** binary so
+> file resolution stays inside the worktree. If you ever wire a *shared* binary
+> from another checkout, pass `-dasroot <worktree>` in `args` or every tool will
+> read the wrong tree.
+
 ## Architecture
 
 - Each tool invocation runs in a **separate thread** (`new_thread`) with its own context/heap — when the thread ends, its memory is freed without GC

--- a/utils/mcp/setup.das
+++ b/utils/mcp/setup.das
@@ -1,0 +1,248 @@
+options gen2
+
+require daslib/clargs
+require daslib/fio
+require daslib/json_boost
+
+// daslang MCP worktree bootstrap.
+//
+// Run from ANY daslang binary against a target worktree root:
+//   daslang utils/mcp/setup.das -- --root <worktree-abs-path>
+//
+// A fresh `git worktree add` (or clone) carries none of the gitignored,
+// build-derived files the MCP server needs — `.mcp.json`, `sgconfig.yml`, a
+// built `bin/` binary, or the tree-sitter grammar shared lib — so a Claude
+// session there has zero daslang tools. This tool fixes that: it builds a
+// worktree-local daslang (+ tree-sitter grammar), copies the platform
+// `sgconfig.yml`, and writes/merges `.mcp.json` with the daslang server entry.
+//
+// It adds no NEW secrets; an existing .mcp.json is rewritten with any other
+// server entries (e.g. github, including their env blocks) preserved as-is.
+// Operates entirely on `--root` via filesystem + cmake, so it runs correctly
+// even when the worktree has no binary of its own yet.
+
+[CommandLineArgs]
+struct SetupArgs {
+    @clarg_doc = "Worktree root to set up (default: current directory)"
+    root : string = "."
+
+    @clarg_doc = "Skip building; only wire config to an already-built binary"
+    no_build : bool
+
+    @clarg_doc = "Shared OpenSSL cache dir (Windows/MSVC) so OpenSSL is built once, not per worktree. Default %LOCALAPPDATA%/daslang/openssl; pass '-' to disable (per-build-dir)."
+    openssl_dir : string = ""
+
+    @clarg_short = "?"
+    @clarg_name = "show-help"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+// Repo-root-relative binary candidates, most-specific first. Returns the first
+// that exists under `root` (the relative path is ready to drop into .mcp.json),
+// or "" when nothing is built yet.
+def locate_binary(root : string) : string {
+    let candidates = ["bin/Release/daslang.exe", "bin/daslang.exe", "bin/daslang", "build/daslang"]
+    for (rel in candidates) {
+        if (fexist(path_join(root, rel))) return rel
+    }
+    return ""
+}
+
+// Run a command with inherited stdio so cmake's progress streams live.
+def run_visible(cmd : string) : int {
+    return unsafe(system(cmd))
+}
+
+// Reject paths with characters that could break out of the double-quoted shell
+// commands we hand to cmake via system() — the quote itself, POSIX command
+// substitution (`$`, backtick), cmd.exe variable expansion (`%`), and newlines.
+// A build-dir / worktree path never legitimately contains these.
+def shell_unsafe(s : string) : bool {
+    return (find(s, "\"") >= 0 || find(s, "`") >= 0 || find(s, "$") >= 0 ||
+        find(s, "%") >= 0 || find(s, "\n") >= 0 || find(s, "\r") >= 0)
+}
+
+// Build the daslang target (required) plus tree_sitter_daslang (best-effort —
+// it powers the ast-grep tools). Configures build/ first if needed. A non-empty
+// `openssl_dir` is passed as -DOPENSSL_ROOT_DIR so dasHV reuses one OpenSSL build
+// across worktrees instead of rebuilding it per build dir (~15 min each). The
+// flag only takes effect on the INITIAL configure — a build/ that already has a
+// CMakeCache keeps its cached OPENSSL_ROOT_DIR (wipe build/ to change it). This
+// tool targets fresh worktrees, so that's the common case.
+def build_worktree(root, openssl_dir : string) : bool {
+    let build_dir = path_join(root, "build")
+    if (!fexist(path_join(build_dir, "CMakeCache.txt"))) {
+        print("Configuring CMake in {build_dir} ...\n")
+        var cfg_cmd = "cmake -S \"{root}\" -B \"{build_dir}\" -DCMAKE_BUILD_TYPE=Release"
+        if (!empty(openssl_dir)) {
+            cfg_cmd += " -DOPENSSL_ROOT_DIR=\"{to_generic_path(openssl_dir)}\""
+        }
+        let rc = run_visible(cfg_cmd)
+        if (rc != 0) {
+            print("ERROR: cmake configure failed (exit {rc})\n")
+            return false
+        }
+    }
+    print("Building daslang (this can take a while) ...\n")
+    let rc = run_visible("cmake --build \"{build_dir}\" --target daslang --config Release")
+    if (rc != 0) {
+        print("ERROR: building daslang failed (exit {rc})\n")
+        return false
+    }
+    // Grammar shared lib for ast-grep (grep_usage/outline/cpp_*). Optional —
+    // the compiler-backed tools work without it.
+    print("Building tree-sitter grammar ...\n")
+    let grc = run_visible("cmake --build \"{build_dir}\" --target tree_sitter_daslang --config Release")
+    if (grc != 0) {
+        print("WARNING: tree_sitter_daslang build failed (exit {grc}); ast-grep tools may be unavailable\n")
+    }
+    return true
+}
+
+// Copy the platform sgconfig.yml template if no sgconfig.yml exists yet.
+def ensure_sgconfig(root : string) {
+    let dst = path_join(root, "sgconfig.yml")
+    if (fexist(dst)) {
+        print("sgconfig.yml already present — left as is\n")
+        return
+    }
+    let plat = get_platform_name()
+    let tmpl_name = plat == "windows" ? "sgconfig.yml.windows" : (plat == "darwin" ? "sgconfig.yml.osx" : "sgconfig.yml.linux")
+    let src = path_join(root, tmpl_name)
+    if (!fexist(src)) {
+        print("WARNING: {tmpl_name} not found under root — cannot set up sgconfig.yml\n")
+        return
+    }
+    let cr = copy_file_result(src, dst, false)
+    if (cr is error) {
+        print("WARNING: failed to copy {tmpl_name}: {cr as error}\n")
+    } else {
+        print("Wrote sgconfig.yml (from {tmpl_name})\n")
+    }
+}
+
+// The daslang MCP server entry, as a JsonValue object.
+def daslang_server_entry(rel_binary : string) : JsonValue? {
+    var entry : table<string; JsonValue?>
+    entry["command"] = JV(rel_binary)
+    var args_arr : array<JsonValue?>
+    args_arr |> push(JV("utils/mcp/main.das"))
+    entry["args"] = JV(args_arr)
+    entry["defer_loading"] = JV(false)
+    return JV(entry)
+}
+
+// Write or merge .mcp.json: set/replace the `daslang` server entry while
+// preserving any other existing servers (e.g. github). Never writes secrets.
+def write_mcp_json(root, rel_binary : string) : bool {
+    let mcp_path = path_join(root, ".mcp.json")
+    var servers : table<string; JsonValue?>
+    if (fexist(mcp_path)) {
+        let txt = fread(mcp_path)
+        var err : string
+        var existing = read_json(txt, err)
+        if (existing == null) {
+            print("WARNING: existing .mcp.json did not parse ({err}) — rewriting from scratch\n")
+        } elif (existing is _object) {
+            // Navigate the parsed tree mutably (read_json data is mutable) so the
+            // preserved server values come back non-const and move into the output
+            // tree directly — no const-strip needed.
+            unsafe {
+                var root_obj & = existing.value as _object
+                if (key_exists(root_obj, "mcpServers")) {
+                    var srv & = root_obj["mcpServers"]
+                    if (srv != null && srv is _object) {
+                        var srv_obj & = srv.value as _object
+                        let ks <- [for (k in keys(srv_obj)); k]
+                        for (k in ks) {
+                            if (k != "daslang") {
+                                servers[k] = srv_obj?[k] ?? null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    servers["daslang"] = daslang_server_entry(rel_binary)
+    var root_obj : table<string; JsonValue?>
+    root_obj["mcpServers"] = JV(servers)
+    if (!fwrite(mcp_path, write_json(JV(root_obj)))) {
+        print("ERROR: failed to write {mcp_path}\n")
+        return false
+    }
+    print("Wrote .mcp.json (daslang -> {rel_binary})\n")
+    return true
+}
+
+[export]
+def main() : int {
+    let argv <- get_cli_arguments()
+    var r <- parse_args(type<SetupArgs>, argv)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<SetupArgs>), "mcp-setup")
+        return 1
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<SetupArgs>), "mcp-setup")
+        return 0
+    }
+    let root = get_full_file_name(cfg.root)
+    if (!fexist(path_join(root, "utils/mcp/main.das"))) {
+        print("ERROR: {root} does not look like a daslang checkout (no utils/mcp/main.das)\n")
+        return 1
+    }
+    print("Setting up daslang MCP in: {root}\n")
+
+    // Shared OpenSSL cache (Windows/MSVC): build OpenSSL once and reuse across
+    // worktrees instead of rebuilding it per build dir. Honored by dasHV's
+    // OPENSSL_ROOT_DIR override. "-" forces per-build-dir; otherwise empty
+    // defaults to %LOCALAPPDATA% on Windows (non-Windows stays per-build-dir).
+    var openssl_dir = cfg.openssl_dir
+    if (openssl_dir == "-") {
+        openssl_dir = ""  // explicit opt-out: per-build-dir OpenSSL
+    } elif (empty(openssl_dir) && get_platform_name() == "windows") {
+        let lad = get_env_variable("LOCALAPPDATA")
+        if (!empty(lad)) {
+            openssl_dir = path_join(lad, "daslang/openssl")
+        }
+    }
+
+    if (shell_unsafe(root)) {
+        print("ERROR: worktree root contains a shell-unsafe character: {root}\n")
+        return 1
+    }
+    if (!empty(openssl_dir) && shell_unsafe(openssl_dir)) {
+        print("ERROR: --openssl-dir contains a shell-unsafe character: {openssl_dir}\n")
+        return 1
+    }
+
+    var binary = locate_binary(root)
+    if (empty(binary) && !cfg.no_build) {
+        if (!empty(openssl_dir)) {
+            print("Using shared OpenSSL cache: {openssl_dir}\n")
+        }
+        if (!build_worktree(root, openssl_dir)) return 1
+        binary = locate_binary(root)
+    }
+    if (empty(binary)) {
+        if (cfg.no_build) {
+            print("ERROR: no daslang binary found under {root} and --no-build was set\n")
+        } else {
+            print("ERROR: build completed but no daslang binary was found\n")
+        }
+        return 1
+    }
+
+    ensure_sgconfig(root)
+    if (!write_mcp_json(root, binary)) {
+        return 1
+    }
+
+    print("\nDone. Restart the Claude Code session in {root} to pick up the MCP server.\n")
+    print("NOTE: the parse-aware tools (grep_usage/outline/cpp_*) also need the ast-grep `sg` CLI on PATH.\n")
+    return 0
+}


### PR DESCRIPTION
## Summary

A fresh `git worktree add` (or clone) carries none of the gitignored, build-derived files the daslang MCP server needs — `.mcp.json`, `sgconfig.yml`, a built `bin/` binary, the tree-sitter grammar lib — so a Claude Code session opened in a worktree silently has **zero daslang MCP tools**. This is a bootstrap gap, not an isolation bug (stdio already gives each session its own server process).

`utils/mcp/setup.das` fixes it. Run from any existing daslang binary against a target worktree:

```
daslang utils/mcp/setup.das -- --root <worktree>
```

It:
- builds a worktree-local `daslang` + the `tree_sitter_daslang` grammar (configures `build/` first if needed);
- copies the platform `sgconfig.yml` template;
- writes/**merges** a `daslang` entry into `.mcp.json` — **writing no secrets** and preserving existing server entries (e.g. `github`);
- `--no-build` wires config to an already-built binary.

`das_root` is derived from the binary's own path (not the cwd), so it points `.mcp.json` at the **worktree-local** binary; the `-dasroot` override for the shared-binary case is documented.

On Windows it also passes `-DOPENSSL_ROOT_DIR=%LOCALAPPDATA%/daslang/openssl` (`--openssl-dir` to override) so the worktree build reuses one shared OpenSSL — a harmless no-op until the dasHV `OPENSSL_ROOT_DIR` override ships (#3198).

## Verification

- **Fresh worktree, full build:** `git worktree add` → confirmed zero bootstrap files → `setup.das` built `daslang` + grammar and wrote `.mcp.json` → drove the worktree's own MCP server (`tools/list` = 38 tools) → functionally exercised `compile_check` (`"Compilation OK."`) and `grep_usage` (`"Found 2 matches"`), proving both the compiler tier and the ast-grep tier.
- **Isolated scratch checkout:** fresh write, merge preserving a nested `github` env block, idempotent re-run, and the no-binary / not-a-checkout error paths.
- `setup.das` compiles, formats clean, lints clean (0 issues).

## Files

- `utils/mcp/setup.das` (new)
- `utils/mcp/README.md` — "Fresh checkouts and worktrees" section
- `skills/mcp_tools.md` — worktree pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)