### PR TITLE
ci: give the mingw lane a compiler cache (sccache)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -645,8 +645,28 @@ jobs:
           mingw-w64-clang-x86_64-ninja
           mingw-w64-clang-x86_64-openssl
           mingw-w64-clang-x86_64-glfw
+          mingw-w64-clang-x86_64-sccache
           bison
           git
+
+    # sccache (compiler cache) for the mingw lane. mingw builds on Ninja, which
+    # honors CMAKE_<LANG>_COMPILER_LAUNCHER (the VS-generator clang-cl lane can't,
+    # which is why only this lane gets it). Use the msys2-NATIVE sccache (installed
+    # above), not the hostedtoolcache one: a native-Windows sccache fails to
+    # CreateProcess msys2's clang.exe (the compiler's runtime DLLs aren't on
+    # sccache's PATH). Local-disk backend in one actions/cache slot, same approach
+    # as the build matrix. Fixed key (single config); PRs restore read-only, master
+    # refreshes the slot after Build.
+    - name: "Configure sccache (local-disk backend)"
+      shell: bash
+      run: |
+        echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
+    - name: "Restore sccache objects"
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/sccache
+        key: sccache-mingw-clang64-release
 
     - name: "Build: Daslang (clang-mingw64)"
       run: |
@@ -656,9 +676,27 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
           -DDAS_CLANG_BIND_DISABLED=OFF \
           -DDAS_LLVM_DISABLED=OFF
         cmake --build ./build-mingw --parallel
+        sccache --show-stats || true
+
+    # On master, overwrite the fixed cache slot with fresh objects (GHA caches
+    # are immutable, so delete then save). PRs are read-only.
+    - name: "Refresh sccache slot"
+      if: github.ref == 'refs/heads/master'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh cache delete "sccache-mingw-clang64-release" -R ${{ github.repository }} || true
+    - name: "Save sccache objects"
+      if: github.ref == 'refs/heads/master'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/sccache
+        key: sccache-mingw-clang64-release
 
     - name: "Test: interpreter sweep"
       run: |


### PR DESCRIPTION
## Summary

`build_windows_mingw` is the long pole of PR CI (~25 min) — the **only Windows lane with no compiler cache**, so it recompiles the whole C++ tree from scratch every run. (It's also the only Windows lane building `dasClangBind` + LLVM, and it runs interpreter + JIT + AOT sweeps — but the missing *compiler cache* is the fixable part.)

Unlike clang-cl — which *must* use the VS generator and therefore can't use `CMAKE_<LANG>_COMPILER_LAUNCHER` (documented in its own job) — **mingw builds on Ninja**, so it can use sccache exactly like the `build` matrix:
- `sccache-action` + local-disk backend (`SCCACHE_GHA_ENABLED=false`);
- one `actions/cache` slot (`sccache-mingw-clang64-release`), restored read-only on PRs, refreshed on master after Build;
- launcher passed as `-D` on daslang's own configure (scoped, not leaked into the GLFW/libhv sub-builds).

## Rollout

The first **master** run after merge populates the slot (still a cold build); subsequent runs — **including PRs** — hit the cache. So this PR's own mingw run is still cold (the slot doesn't exist yet); it validates the wiring (`sccache --show-stats` at the end of Build), and the speedup lands once master seeds the cache.

## Files

- `.github/workflows/build.yml` — sccache wiring in the `build_windows_mingw` job only; no other lane touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)