### PR TITLE
build: disable vcpkg per-target applocal deploy (fix flaky win32 link race)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,27 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(EXECUTABLE_OUTPUT_PATH  ${PROJECT_SOURCE_DIR}/bin/)
 
+# Disable vcpkg's per-target applocal deploy project-wide.
+#
+# When built through the vcpkg toolchain on Windows, VCPKG_APPLOCAL_DEPS
+# defaults to ON, which appends a POST_BUILD "vcpkg z-applocal" step to every
+# executable / shared library. Since all of our binaries emit into the single
+# shared bin/, that means dozens of targets (the ~40 integration tutorials, the
+# test exes, the modules) each concurrently re-copy the same runtime DLLs into
+# bin/. Under Ninja's parallel link those copies collide on Windows with
+# "The process cannot access the file because it is being used by another
+# process" — a flaky build failure (observed on win32 Release).
+#
+# That deploy is pure redundant work for this project: our own DLLs
+# (libDaScriptDyn*.dll, ...) build directly into bin/, and every module that
+# needs a third-party DLL deploys it itself with an idempotent, single-target
+# copy_if_different (openssl via dasHV, glfw3.dll via dasGlfw). openssl is the
+# only vcpkg-installed package in any workflow, and it is covered by dasHV — so
+# nothing relies on vcpkg's applocal pass. Turning it off removes the race for
+# all targets and loses no deployed dependency. No-op on non-Windows / non-vcpkg
+# builds, where the variable is unused.
+set(VCPKG_APPLOCAL_DEPS OFF)
+
 SET(LINUX_UUID FALSE)
 
 IF(NOT DAS_FLEX_BISON_DISABLED)


### PR DESCRIPTION
## Problem

The `build (windows, 32, Release, none)` job intermittently fails during **Build: Daslang** at the link phase, e.g.:

```
[472/574] Linking CXX executable ...\bin\integration_cpp_07.exe
FAILED: .../bin/integration_cpp_07.exe
  ... link.exe ... && vcpkg.exe z-applocal --target-binary=...integration_cpp_07.exe ...
The process cannot access the file because it is being used by another process.
ninja: build stopped: subcommand failed.
```

It's flaky and not always the same target — all compiles come from sccache (414 hits / 0 misses), so nothing fails to *compile*; the failure is in the post-link deploy step.

## Root cause

Built through the vcpkg toolchain on Windows, `VCPKG_APPLOCAL_DEPS` defaults to **ON**, which appends a `POST_BUILD` "`vcpkg z-applocal`" step to every executable / shared library. All of our binaries emit into the single shared `bin/`, so dozens of targets (the ~40 integration tutorials, test exes, modules) each concurrently **re-copy the same runtime DLLs** into `bin/`. Under Ninja's parallel link those copies collide → sharing violation → ninja stops the whole build.

## Why disabling it is safe

The applocal pass is pure redundant work for this project:

- Our own DLLs (`libDaScriptDyn*.dll`, …) build **directly into** `bin/` — no copy needed.
- Every module that needs a third-party DLL deploys it **itself** with an idempotent, single-target `copy_if_different`: **openssl** via `dasHV`, **glfw3.dll** via `dasGlfw`.
- **openssl is the only vcpkg-installed package** in any workflow (build / release / extended_checks), and it's covered by `dasHV`.

So nothing relies on vcpkg's applocal pass. Turning it off project-wide removes the race for **all** targets and loses no deployed dependency. No-op on non-Windows / non-vcpkg builds.

## Change

One line (plus an explanatory comment) in the root `CMakeLists.txt`:

```cmake
set(VCPKG_APPLOCAL_DEPS OFF)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)