### PR TITLE
dasSpirv: emit Flat decoration on integer varyings (Vulkan spec mandate)

### DIFF
--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -391,6 +391,18 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         let vid = alloc_id(m)
         emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(storage))
         emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Location), uint(loc))
+        // Flat decoration. Vulkan mandates Flat on any integer/uint varying (no valid interpolation
+        // mode exists for integers — the driver returns garbage without it), so emit it automatically
+        // for those. Floats default to perspective-correct smooth interpolation; honour an explicit
+        // @flat annotation when the user wants flat-shaded floats (low-poly stylised look, provoking-
+        // vertex picks per primitive). Reflection bit not added — Flat is purely a SPIR-V decoration,
+        // it doesn't change the descriptor or pipeline layout.
+        let bt = v._type.baseType
+        let is_int_kind = scalar_class(bt) >= 0 && scalar_class(bt) <= 1
+        let want_flat = is_int_kind || (v.annotation |> find_arg("flat") is tBool)
+        if (want_flat) {
+            emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Flat))
+        }
         ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = storage, value_type = vt, is_ssbo = false))
         ctx.interface_ids |> push(vid)
         return

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -392,6 +392,33 @@ def raster_math {
     m_out = float4(c, c, c, 1.0f)                 // CompositeConstruct
 }
 
+// vertex / fragment Flat-decoration fixtures: integer varyings auto-Flat (Vulkan spec mandate —
+// the driver can't interpolate ints, so the emitter MUST decorate them), and an explicit @flat on a
+// float varying forces flat-shading (a stylised-look knob). flat_vert/flat_frag cover both: an int
+// passthrough (`mat_id`) which should emit Flat without the user asking, and a float passthrough
+// (`flat_val`) carrying @flat which should also emit Flat. The plain float `smooth_val` carries no
+// @flat and must NOT pick up the decoration — that's the negative control.
+var @out @location = 0 mat_id : int                   // int Output -> auto-Flat
+var @flat @out @location = 1 flat_val : float          // float Output + @flat -> Flat
+var @out @location = 2 smooth_val : float              // float Output, no @flat -> no Flat
+[vertex_shader(name="flat_vert_spv"), marker(no_coverage)]
+def flat_vert {
+    mat_id = gl_VertexIndex
+    flat_val = float(gl_VertexIndex) * 0.5f
+    smooth_val = float(gl_VertexIndex) * 0.25f
+    gl_Position = float4(0.0f, 0.0f, 0.0f, 1.0f)
+}
+
+var @in @location = 0 fi_mat_id : int                  // int Input -> auto-Flat
+var @flat @in @location = 1 fi_flat_val : float        // float Input + @flat -> Flat
+var @in @location = 2 fi_smooth_val : float            // float Input, no @flat -> no Flat
+var @out @location = 0 flat_color : float4
+[fragment_shader(name="flat_frag_spv"), marker(no_coverage)]
+def flat_frag {
+    let m = float(fi_mat_id)
+    flat_color = float4(m, fi_flat_val, fi_smooth_val, 1.0f)
+}
+
 def public tri_vert_words : array<uint> {
     var w : array<uint>
     w |> push_from(tri_vert_spv)
@@ -425,6 +452,18 @@ def public vindex_words : array<uint> {
 def public raster_math_words : array<uint> {
     var w : array<uint>
     w |> push_from(raster_math_spv)
+    return <- w
+}
+
+def public flat_vert_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(flat_vert_spv)
+    return <- w
+}
+
+def public flat_frag_words : array<uint> {
+    var w : array<uint>
+    w |> push_from(flat_frag_spv)
     return <- w
 }
 

--- a/tests/spirv/test_raster.das
+++ b/tests/spirv/test_raster.das
@@ -140,3 +140,34 @@ def test_fragment_math(t : T?) {
         delete words
     }
 }
+
+// Flat decoration: Vulkan mandates Flat on any integer / uint varying — int can't interpolate, so
+// without it the driver returns garbage. The emitter auto-applies Flat to int/uint @in/@out, and
+// honours an explicit `@flat` on float varyings (low-poly stylised look). The negative control is a
+// plain float varying with no @flat — it must NOT pick up Flat.
+[test]
+def test_vertex_flat(t : T?) {
+    t |> run("vertex: int @out is auto-Flat; @flat float @out is Flat; plain float @out is not") <| @(t : T?) {
+        var words <- flat_vert_words()
+        // exactly two Flat decorations (mat_id + flat_val); plain smooth_val stays unflagged
+        let nflat = count_op_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Flat))
+        t |> success(nflat == 2, "flat_vert: 2 Flat decorations (got {nflat})")
+        // each Location is still present (Flat decoration sits alongside, not in place of, Location)
+        t |> success(has_location(words, 0u), "flat_vert: Location 0 (mat_id) still present")
+        t |> success(has_location(words, 1u), "flat_vert: Location 1 (flat_val) still present")
+        t |> success(has_location(words, 2u), "flat_vert: Location 2 (smooth_val) still present")
+        validate(t, words, "flat_vert")
+        delete words
+    }
+}
+
+[test]
+def test_fragment_flat(t : T?) {
+    t |> run("fragment: int @in is auto-Flat; @flat float @in is Flat; plain float @in is not") <| @(t : T?) {
+        var words <- flat_frag_words()
+        let nflat = count_op_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Flat))
+        t |> success(nflat == 2, "flat_frag: 2 Flat decorations (got {nflat})")
+        validate(t, words, "flat_frag")
+        delete words
+    }
+}


### PR DESCRIPTION
## Summary

Vulkan requires `OpDecorate %vid Flat` on any `@in`/`@out` integer varying — int can't interpolate, so without it the driver returns garbage (lavapipe + real HW both observed). spirv-val flags it explicitly:

> `VUID-StandaloneSpirv-Flat-04744`: Fragment OpEntryPoint operand %vid with Input interfaces with integer or float type must have a Flat decoration

The emitter now:

- **Auto-emits Flat on any `@in`/`@out` whose value type is `int` / `uint` / `int{2,3,4}` / `uint{2,3,4}`** (scalar_class 0 or 1). GLSL infers it the same way, and there is no other valid choice for integers.
- **Honors an explicit `@flat` on float varyings** — the stylised-look knob for low-poly / provoking-vertex shading.

The negative control (plain float without `@flat`) stays smooth-interpolated as before.

## Tests

`flat_vert` + `flat_frag` fixtures in `tests/spirv/_spirv_common.das` each declare three `@out`/`@in` varyings — int (auto-Flat), float + `@flat` (Flat), float (no Flat). New `test_raster.das` tests assert exactly 2 Flat decorations per shader (positive control: `count == 2` catches both missing emission and spurious-Flat-on-plain-float regressions) and that Location decorations are still present alongside.

The 28 pre-existing fragment / vertex fixtures have no integer varyings, so existing goldens are unchanged. Full `tests/spirv` suite still 130/130 green.

## Context

Surfaced by dasVulkan tutorial 10 (deferred shading): the gbuffer vertex shader routes `op.material : int` as `@flat @out` to the fragment shader and the value always read as zero. Once this lands the tutorial switches the material branch from positional `f_world_pos.y < 0.5` back to the natural push-constant `f_material == 1`.

## Test plan

- [x] `tests/spirv` — full suite green (130 / 130)
- [x] Lint clean on the 3 modified files
- [x] spirv-val confirms the fix (the new Flat assertions now pass; pre-fix `VUID-StandaloneSpirv-Flat-04744` was observed)
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
