### PR TITLE
ci: bump clang-cl job to VS2026 generator (fix runner-image migration)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -806,8 +806,12 @@ jobs:
 
     - name: "Build: Daslang (clang-cl / VS ClangCL toolset)"
       shell: pwsh
+      # Generator is pinned to the VS major on the runner image. GitHub migrated
+      # the windows-2025 / "latest" image from VS2022 (v17) to VS2026 (v18); on a
+      # VS2026 image "Visual Studio 17 2022" finds no instance and configure dies
+      # at project(). Bump this in lockstep with the image's VS major.
       run: |
-        cmake -B build-clangcl -G "Visual Studio 17 2022" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release
+        cmake -B build-clangcl -G "Visual Studio 18 2026" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release
         if ($LASTEXITCODE -ne 0) { exit 1 }
         cmake --build build-clangcl --config Release --parallel
         if ($LASTEXITCODE -ne 0) { exit 1 }


### PR DESCRIPTION
## Problem

`build_windows_clangcl` is failing on master and every PR at **configure time**:

```
CMake Error at CMakeLists.txt:2 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

GitHub migrated the `windows-2025` / "latest" runner image (used by the `dascriptrunners` `windows-latest-fat` larger runner) from **VS2022 (v17)** to **VS2026 (v18)**:

| | Image | VS |
|---|---|---|
| last green (today 11:27) | `windows-2025` (`win25/20260607.161`) | 2022 ✅ |
| failing (today 14:54+) | `windows-2025-vs2026` (`win25-vs2026/20260608.135`) | 2026 ❌ |

The job uses CMake's **VS generator** (required for the `-T ClangCL` toolset), pinned to `"Visual Studio 17 2022"`. On a VS2026 image there is no VS2022 instance to discover, so configure dies at `project()`. There is **no VS2022-on-2025 image to revert to** — custom runner images are disabled by enterprise policy, and the only remaining VS2022 image (`windows-2022`) is itself on GitHub's deprecation path.

## Change

Move the generator forward to match the image:

```diff
- cmake -B build-clangcl -G "Visual Studio 17 2022" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release
+ cmake -B build-clangcl -G "Visual Studio 18 2026" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=Release
```

Plus a comment noting the generator must track the image's VS major.

## Validation

This is verified by the clang-cl job in this PR's own CI run — it executes on the current (VS2026) runner.

## Note

`.github/workflows/msvc.yml` also pins `"Visual Studio 17 2022"`, but it is `workflow_dispatch`-only and not part of the PR gate, so it's left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)