### PR TITLE
ci: bump msvc.yml to VS2026 generator (match migrated runner)

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -46,7 +46,11 @@ jobs:
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
     - name: Configure CMake
-      run: cmake -B ${{ env.CONFIG_DIR }} -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_configuration }} -G "Visual Studio 17 2022"
+      # Generator pinned to the VS major on the windows-latest-fat image. GitHub
+      # migrated it from VS2022 (v17) to VS2026 (v18); bump in lockstep (see
+      # build.yml's build_windows_clangcl). On a mismatch, configure dies at
+      # project() with "could not find any instance of Visual Studio".
+      run: cmake -B ${{ env.CONFIG_DIR }} -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake_configuration }} -G "Visual Studio 18 2026"
 
     - name: Build CMake
       run: cmake --build ${{ env.CONFIG_DIR }} --config ${{ matrix.cmake_configuration }}


### PR DESCRIPTION
Follow-up to #3205. `msvc.yml` runs on the same `windows-latest-fat` runner (now on the VS2026 image) and still pinned the VS generator to `"Visual Studio 17 2022"`, so it would fail at `project()` with `could not find any instance of Visual Studio` the moment it's dispatched.

It's `workflow_dispatch`-only and not in the PR gate, so this was a **latent trap** rather than an active break — fixing it now so the next manual run doesn't rediscover the same issue.

```diff
- -G "Visual Studio 17 2022"
+ -G "Visual Studio 18 2026"
```

Generator approach validated by #3205 (clang-cl job, full green on the VS2026 image). Note: this workflow being dispatch-only, PR CI here won't exercise the changed line — but it's the identical one-line generator bump already proven in #3205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)