### PR TITLE
mcp: ship cpp-mcp as a standalone AOT binary + bundle/release CI

### DIFF
--- a/.github/workflows/cpp_mcp_release.yml
+++ b/.github/workflows/cpp_mcp_release.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - 'utils/mcp/**'
       - 'utils/common/**'
+      - 'tree-sitter-daslang/*.yml'   # ast-grep rule files the bundle ships
       - 'ci/make_cpp_mcp_bundle.sh'
       - 'ci/smoke_test_cpp_mcp.sh'
       - '.github/workflows/cpp_mcp_release.yml'

--- a/.github/workflows/cpp_mcp_release.yml
+++ b/.github/workflows/cpp_mcp_release.yml
@@ -1,0 +1,124 @@
+name: cpp-mcp release
+
+# Builds the standalone C++-only MCP server (cpp-mcp) as a self-contained AOT
+# bundle per platform and, on a release, uploads each as a release asset.
+#
+# Triggers:
+#   * pull_request (only when the cpp-mcp surface changes) — builds + smoke-tests
+#     on linux only, NO upload. Catches breakage at PR time (the cpp-mcp target
+#     is OFF in the normal build matrix, so nothing else compiles it).
+#   * workflow_dispatch — full matrix build + smoke, NO upload. Manual validation.
+#   * release: prereleased — full matrix, uploads cpp-mcp-<os>-<arch>.<ext>
+#     alongside the daslang SDK bundles.
+#
+# The build is intentionally lean: cpp_main.das requires only daslib + builtin
+# modules, so every external module (dasHV/OpenSSL, GLFW, Audio, ...) is disabled
+# — no vcpkg/openssl/apt module deps, and a ~360-step build instead of 2000+.
+on:
+  pull_request:
+    paths:
+      - 'utils/mcp/**'
+      - 'utils/common/**'
+      - 'ci/make_cpp_mcp_bundle.sh'
+      - 'ci/smoke_test_cpp_mcp.sh'
+      - '.github/workflows/cpp_mcp_release.yml'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+  release:
+    types: [prereleased]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    # On a PR, only the linux cell runs (cheap cross-platform-agnostic gate);
+    # dispatch/release run the full matrix.
+    if: github.event_name != 'pull_request' || matrix.name == 'linux-x86_64'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            runner: ubuntu-latest
+            asset: cpp-mcp-linux-x86_64
+            ext: tar.gz
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+            asset: cpp-mcp-linux-arm64
+            ext: tar.gz
+          - name: darwin-arm64
+            runner: macos-14
+            asset: cpp-mcp-darwin-arm64
+            ext: tar.gz
+          - name: windows-x64
+            runner: windows-latest
+            asset: cpp-mcp-windows-x64
+            ext: zip
+
+    steps:
+      - name: SCM Checkout
+        uses: actions/checkout@v4
+
+      - name: Install CMake and Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Set up MSVC environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure + build cpp-mcp
+        run: |
+          set -eux
+          # cpp_main.das needs no external module -> disable them all (no OpenSSL,
+          # no GLFW/X11 deps) and skip tests/tutorials/aot-examples + flex/bison
+          # (the committed parser is used).
+          MODULES_OFF="-DDAS_HV_DISABLED=ON -DDAS_LLVM_DISABLED=ON -DDAS_AUDIO_DISABLED=ON"
+          MODULES_OFF="$MODULES_OFF -DDAS_GLFW_DISABLED=ON -DDAS_PUGIXML_DISABLED=ON -DDAS_SQLITE_DISABLED=ON"
+          MODULES_OFF="$MODULES_OFF -DDAS_STBIMAGE_DISABLED=ON -DDAS_STDDLG_DISABLED=ON -DDAS_CLANG_BIND_DISABLED=ON"
+          MODULES_OFF="$MODULES_OFF -DDAS_TREE_SITTER_DISABLED=ON"
+          LEAN="-DDAS_TESTS_DISABLED=ON -DDAS_TUTORIAL_DISABLED=ON -DDAS_AOT_EXAMPLES_DISABLED=ON -DDAS_FLEX_BISON_DISABLED=ON"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # Match release.yml: clang avoids GCC's -Wchanges-meaning on
+            # AOT-generated structs being treated as an error.
+            export CC=clang CXX=clang++
+          fi
+          cmake --no-warn-unused-cli -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DDAS_BUILD_CPP_MCP=ON $MODULES_OFF $LEAN
+          cmake --build build --target cpp-mcp --parallel
+
+      - name: Assemble bundle
+        run: bash ci/make_cpp_mcp_bundle.sh dist/cpp-mcp
+
+      - name: Smoke-test bundle
+        run: bash ci/smoke_test_cpp_mcp.sh dist/cpp-mcp
+
+      - name: Package (zip)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir -p artifacts
+          7z a "artifacts/${{ matrix.asset }}.zip" ./dist/cpp-mcp
+
+      - name: Package (tar.gz)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p artifacts
+          tar -czf "artifacts/${{ matrix.asset }}.${{ matrix.ext }}" -C dist cpp-mcp
+
+      - name: Upload workflow artifact (dispatch / PR inspection)
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: artifacts/${{ matrix.asset }}.${{ matrix.ext }}
+          if-no-files-found: error
+
+      - name: Upload release asset
+        if: github.event_name == 'release' && github.event.action == 'prereleased'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "artifacts/${{ matrix.asset }}.${{ matrix.ext }}" --clobber

--- a/.github/workflows/cpp_mcp_release.yml
+++ b/.github/workflows/cpp_mcp_release.yml
@@ -86,7 +86,9 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           mkdir -p artifacts
-          7z a "artifacts/${{ matrix.asset }}.zip" ./dist/cpp-mcp
+          # Package from inside dist/ so the zip root is `cpp-mcp/` (matching the
+          # tarball's `-C dist cpp-mcp`), not `dist/cpp-mcp/`.
+          cd dist && 7z a "../artifacts/${{ matrix.asset }}.zip" cpp-mcp
 
       - name: Package (tar.gz)
         if: runner.os != 'Windows'

--- a/.github/workflows/cpp_mcp_release.yml
+++ b/.github/workflows/cpp_mcp_release.yml
@@ -33,30 +33,15 @@ defaults:
 
 jobs:
   build:
-    # On a PR, only the linux cell runs (cheap cross-platform-agnostic gate);
-    # dispatch/release run the full matrix.
-    if: github.event_name != 'pull_request' || matrix.name == 'linux-x86_64'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      # Vary the matrix by event: a PR builds only linux (a cheap, cross-platform-
+      # agnostic gate); dispatch/release build all four. The selection lives here
+      # because the `matrix` context is NOT available in a job-level `if` (only
+      # github/needs/vars/inputs are), whereas `github` IS available in strategy.
       matrix:
-        include:
-          - name: linux-x86_64
-            runner: ubuntu-latest
-            asset: cpp-mcp-linux-x86_64
-            ext: tar.gz
-          - name: linux-arm64
-            runner: ubuntu-24.04-arm
-            asset: cpp-mcp-linux-arm64
-            ext: tar.gz
-          - name: darwin-arm64
-            runner: macos-14
-            asset: cpp-mcp-darwin-arm64
-            ext: tar.gz
-          - name: windows-x64
-            runner: windows-latest
-            asset: cpp-mcp-windows-x64
-            ext: zip
+        include: ${{ fromJSON( github.event_name == 'pull_request' && '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"}]' || '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"},{"name":"linux-arm64","runner":"ubuntu-24.04-arm","asset":"cpp-mcp-linux-arm64","ext":"tar.gz"},{"name":"darwin-arm64","runner":"macos-14","asset":"cpp-mcp-darwin-arm64","ext":"tar.gz"},{"name":"windows-x64","runner":"windows-latest","asset":"cpp-mcp-windows-x64","ext":"zip"}]' ) }}
 
     steps:
       - name: SCM Checkout

--- a/.github/workflows/cpp_mcp_release.yml
+++ b/.github/workflows/cpp_mcp_release.yml
@@ -41,7 +41,7 @@ jobs:
       # because the `matrix` context is NOT available in a job-level `if` (only
       # github/needs/vars/inputs are), whereas `github` IS available in strategy.
       matrix:
-        include: ${{ fromJSON( github.event_name == 'pull_request' && '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"}]' || '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"},{"name":"linux-arm64","runner":"ubuntu-24.04-arm","asset":"cpp-mcp-linux-arm64","ext":"tar.gz"},{"name":"darwin-arm64","runner":"macos-14","asset":"cpp-mcp-darwin-arm64","ext":"tar.gz"},{"name":"windows-x64","runner":"windows-latest","asset":"cpp-mcp-windows-x64","ext":"zip"}]' ) }}
+        include: ${{ fromJSON( github.event_name == 'pull_request' && '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"}]' || '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"},{"name":"linux-arm64","runner":"ubuntu-24.04-arm-fat","asset":"cpp-mcp-linux-arm64","ext":"tar.gz"},{"name":"darwin-arm64","runner":"macos-14","asset":"cpp-mcp-darwin-arm64","ext":"tar.gz"},{"name":"windows-x64","runner":"windows-latest","asset":"cpp-mcp-windows-x64","ext":"zip"}]' ) }}
 
     steps:
       - name: SCM Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1324,13 +1324,19 @@ if (NOT ${DAS_TOOLS_DISABLED})
         # Feed the graph in via DAS_AOT_EXTRA_DEPENDS BEFORE the DAS_AOT call so it
         # lands in the generated command's DEPENDS list (clean builds unaffected;
         # this only fixes local incremental iteration). Scoped: unset right after.
-        # GLOB (not GLOB_RECURSE) over only the dirs cpp_main can require -- top-level
-        # utils/mcp + tools/ + utils/common -- so the tests/ fixtures and other
-        # nested files don't needlessly re-trigger the expensive AOT codegen.
+        # cpp_main's require graph = its (stable) top-level server files, listed
+        # explicitly so the full-server / test / setup peers (main.das,
+        # registry_das.das, test_tools.das, setup.das) don't re-trigger the AOT;
+        # plus the tool modules (GLOB, so a new cpp tool tracks automatically) and
+        # utils/common. NOT GLOB_RECURSE -> tests/ fixtures stay out.
         file(GLOB CPP_MCP_DAS_DEPS CONFIGURE_DEPENDS
-            ${PROJECT_SOURCE_DIR}/utils/mcp/*.das
             ${PROJECT_SOURCE_DIR}/utils/mcp/tools/*.das
             ${PROJECT_SOURCE_DIR}/utils/common/*.das)
+        list(APPEND CPP_MCP_DAS_DEPS
+            ${PROJECT_SOURCE_DIR}/utils/mcp/cpp_main.das
+            ${PROJECT_SOURCE_DIR}/utils/mcp/protocol_core.das
+            ${PROJECT_SOURCE_DIR}/utils/mcp/registry_cpp.das
+            ${PROJECT_SOURCE_DIR}/utils/mcp/cpp_search_config.das)
         set(DAS_AOT_EXTRA_DEPENDS ${CPP_MCP_DAS_DEPS})
         DAS_AOT("utils/mcp/cpp_main.das" CPP_MCP_AOT_GENERATED_SRC cpp_mcp_dasAotStub daslang)
         unset(DAS_AOT_EXTRA_DEPENDS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1324,8 +1324,12 @@ if (NOT ${DAS_TOOLS_DISABLED})
         # Feed the graph in via DAS_AOT_EXTRA_DEPENDS BEFORE the DAS_AOT call so it
         # lands in the generated command's DEPENDS list (clean builds unaffected;
         # this only fixes local incremental iteration). Scoped: unset right after.
-        file(GLOB_RECURSE CPP_MCP_DAS_DEPS CONFIGURE_DEPENDS
+        # GLOB (not GLOB_RECURSE) over only the dirs cpp_main can require -- top-level
+        # utils/mcp + tools/ + utils/common -- so the tests/ fixtures and other
+        # nested files don't needlessly re-trigger the expensive AOT codegen.
+        file(GLOB CPP_MCP_DAS_DEPS CONFIGURE_DEPENDS
             ${PROJECT_SOURCE_DIR}/utils/mcp/*.das
+            ${PROJECT_SOURCE_DIR}/utils/mcp/tools/*.das
             ${PROJECT_SOURCE_DIR}/utils/common/*.das)
         set(DAS_AOT_EXTRA_DEPENDS ${CPP_MCP_DAS_DEPS})
         DAS_AOT("utils/mcp/cpp_main.das" CPP_MCP_AOT_GENERATED_SRC cpp_mcp_dasAotStub daslang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,9 @@ find_package(Threads REQUIRED)
 FILE(GLOB DAS_AOT_DASLIB_DEPENDS CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/daslib/*.das")
 
 MACRO(DAS_AOT_EXT input_files genList mainTarget dasAotTool dasAotToolArg)
-    set(all_depends ${dasAotTool} ${PROJECT_SOURCE_DIR}/utils/aot/main.das ${DAS_AOT_DASLIB_DEPENDS})
+    # DAS_AOT_EXTRA_DEPENDS lets a caller add inputs (e.g. the entry file's own
+    # require graph) that this macro can't discover; empty for normal callers.
+    set(all_depends ${dasAotTool} ${PROJECT_SOURCE_DIR}/utils/aot/main.das ${DAS_AOT_DASLIB_DEPENDS} ${DAS_AOT_EXTRA_DEPENDS})
     set(all_outputs "")
     # Per-batch arg buffer; chunked to keep each invocation under Windows'
     # 32K command-line limit when worktree paths are long.
@@ -1316,17 +1318,18 @@ if (NOT ${DAS_TOOLS_DISABLED})
     if(DAS_BUILD_CPP_MCP)
         SET(CPP_MCP_AOT_GENERATED_SRC)
         add_custom_target(cpp_mcp_dasAotStub)
-        DAS_AOT("utils/mcp/cpp_main.das" CPP_MCP_AOT_GENERATED_SRC cpp_mcp_dasAotStub daslang)
         # DAS_AOT only tracks cpp_main.das + daslib/*.das as inputs; cpp_main's own
         # require graph (protocol_core / registry_cpp / tools/*.das / utils/common)
         # is invisible to it, so edits there would NOT regenerate the AOT C++.
-        # Append the graph as explicit deps of the generated output (clean builds
-        # are unaffected; this only fixes local incremental iteration).
+        # Feed the graph in via DAS_AOT_EXTRA_DEPENDS BEFORE the DAS_AOT call so it
+        # lands in the generated command's DEPENDS list (clean builds unaffected;
+        # this only fixes local incremental iteration). Scoped: unset right after.
         file(GLOB_RECURSE CPP_MCP_DAS_DEPS CONFIGURE_DEPENDS
             ${PROJECT_SOURCE_DIR}/utils/mcp/*.das
             ${PROJECT_SOURCE_DIR}/utils/common/*.das)
-        add_custom_command(OUTPUT ${CPP_MCP_AOT_GENERATED_SRC} APPEND
-            DEPENDS ${CPP_MCP_DAS_DEPS})
+        set(DAS_AOT_EXTRA_DEPENDS ${CPP_MCP_DAS_DEPS})
+        DAS_AOT("utils/mcp/cpp_main.das" CPP_MCP_AOT_GENERATED_SRC cpp_mcp_dasAotStub daslang)
+        unset(DAS_AOT_EXTRA_DEPENDS)
         add_executable(cpp-mcp
             ${PROJECT_SOURCE_DIR}/utils/mcp/cpp_mcp_main.cpp
             ${CPP_MCP_AOT_GENERATED_SRC}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1307,6 +1307,50 @@ if (NOT ${DAS_TOOLS_DISABLED})
         RUNTIME DESTINATION ${DAS_INSTALL_BINDIR}
     )
 
+    # cpp-mcp: standalone AOT C++-only MCP server (gated, OFF by default).
+    # Statically links libDaScript + the AOT-compiled cpp_main.das into one
+    # self-contained binary (no shared modules). The cpp tools still shell out
+    # to ast-grep / cl at runtime (environmental); the ast-grep rules YAML is
+    # read from the SDK tree via getDasRoot(), so the binary lands in bin/.
+    option(DAS_BUILD_CPP_MCP "Build the standalone AOT cpp-only MCP server (cpp-mcp)" OFF)
+    if(DAS_BUILD_CPP_MCP)
+        SET(CPP_MCP_AOT_GENERATED_SRC)
+        add_custom_target(cpp_mcp_dasAotStub)
+        DAS_AOT("utils/mcp/cpp_main.das" CPP_MCP_AOT_GENERATED_SRC cpp_mcp_dasAotStub daslang)
+        # DAS_AOT only tracks cpp_main.das + daslib/*.das as inputs; cpp_main's own
+        # require graph (protocol_core / registry_cpp / tools/*.das / utils/common)
+        # is invisible to it, so edits there would NOT regenerate the AOT C++.
+        # Append the graph as explicit deps of the generated output (clean builds
+        # are unaffected; this only fixes local incremental iteration).
+        file(GLOB_RECURSE CPP_MCP_DAS_DEPS CONFIGURE_DEPENDS
+            ${PROJECT_SOURCE_DIR}/utils/mcp/*.das
+            ${PROJECT_SOURCE_DIR}/utils/common/*.das)
+        add_custom_command(OUTPUT ${CPP_MCP_AOT_GENERATED_SRC} APPEND
+            DEPENDS ${CPP_MCP_DAS_DEPS})
+        add_executable(cpp-mcp
+            ${PROJECT_SOURCE_DIR}/utils/mcp/cpp_mcp_main.cpp
+            ${CPP_MCP_AOT_GENERATED_SRC}
+        )
+        target_sources(cpp-mcp PRIVATE src/misc/alloc_tracker_overrides.cpp)
+        # cpp_main.das requires only daslib + builtin modules (jobque / json /
+        # fio / logger / strings), all of which live in libDaScript. It pulls NO
+        # external module (dasHV / SQLITE / GLFW / ...), so they are deliberately
+        # NOT linked -> a lean, dependency-light binary. For a cpp-mcp-only build,
+        # also pass -DDAS_HV_DISABLED=ON (and friends) so they are never built.
+        TARGET_LINK_LIBRARIES(cpp-mcp libDaScript ${SRC_LIBRARIES})
+        ADD_DEPENDENCIES(cpp-mcp libDaScript daslang cpp_mcp_dasAotStub)
+        target_include_directories(cpp-mcp PRIVATE ${NEED_MODULES_PATH})
+        SETUP_CPP11(cpp-mcp)
+        SETUP_BIN_RPATH(cpp-mcp)
+        SET_TARGET_PROPERTIES(cpp-mcp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
+        # Strip the shipped binary (Linux/macOS); on MSVC symbols live in a side PDB.
+        if(NOT MSVC AND CMAKE_BUILD_TYPE STREQUAL "Release")
+            add_custom_command(TARGET cpp-mcp POST_BUILD
+                COMMAND ${CMAKE_STRIP} $<TARGET_FILE:cpp-mcp>
+                COMMENT "Stripping cpp-mcp")
+        endif()
+    endif()
+
     # daslang-live: live-reloading application host
     SET(DAS_LIVE_MAIN_SRC
         ${PROJECT_SOURCE_DIR}/utils/daslang-live/main.cpp

--- a/ci/make_cpp_mcp_bundle.sh
+++ b/ci/make_cpp_mcp_bundle.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Assemble a standalone cpp-mcp bundle from a built daslang tree.
+#
+# The AOT cpp-mcp binary still compiles cpp_main.das (+ daslib) at startup
+# (AOT only swaps interpreter SimNodes for the linked native code), so the
+# bundle ships the .das sources alongside the binary. getDasRoot() derives the
+# root from the exe path, so the binary MUST live at <bundle>/bin/ — the rest of
+# the layout mirrors the source tree (utils/mcp, utils/common, daslib).
+#
+# Usage:  bash ci/make_cpp_mcp_bundle.sh <out-bundle-dir>
+# Run from anywhere; paths resolve relative to the repo root. The cpp-mcp target
+# must already be built (bin/cpp-mcp[.exe] present).
+
+set -eu
+
+OUT="${1:?usage: $0 <out-bundle-dir>}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$ROOT"
+
+if [[ -f bin/cpp-mcp.exe ]]; then
+    BIN=bin/cpp-mcp.exe
+elif [[ -f bin/cpp-mcp ]]; then
+    BIN=bin/cpp-mcp
+else
+    echo "ERROR: bin/cpp-mcp[.exe] not found — build the cpp-mcp target first" >&2
+    exit 2
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT/bin" "$OUT/utils/mcp/tools" "$OUT/utils/common"
+
+cp "$BIN"                              "$OUT/bin/"
+cp utils/mcp/*.das                     "$OUT/utils/mcp/"
+cp utils/mcp/tools/*.das               "$OUT/utils/mcp/tools/"
+cp utils/common/git_signature.das      "$OUT/utils/common/"
+cp -r daslib                           "$OUT/daslib"
+# Windows vcvars launcher (no-op on Linux/macOS — clang/gcc find system headers)
+cp utils/mcp/daslang-mcp-msvc.cmd      "$OUT/utils/mcp/" 2>/dev/null || true
+# Setup guide -> bundle README
+cp utils/mcp/cpp-mcp-setup.md          "$OUT/README.md" 2>/dev/null || true
+
+echo "cpp-mcp bundle assembled at: $OUT"
+du -sh "$OUT" 2>/dev/null || true

--- a/ci/make_cpp_mcp_bundle.sh
+++ b/ci/make_cpp_mcp_bundle.sh
@@ -34,6 +34,12 @@ cp utils/mcp/*.das                     "$OUT/utils/mcp/"
 cp utils/mcp/tools/*.das               "$OUT/utils/mcp/tools/"
 cp utils/common/git_signature.das      "$OUT/utils/common/"
 cp -r daslib                           "$OUT/daslib"
+# ast-grep rule files: the outline / cpp_* tools load these at runtime via
+# get_das_root() (tools/outline.das, tools/cpp_common.das), so the bundle needs
+# them for those tools to work once `sg` is installed. (The daslang grammar lib
+# + sgconfig.yml are a separate optional ast-grep setup — see the README.)
+mkdir -p "$OUT/tree-sitter-daslang"
+cp tree-sitter-daslang/*.yml           "$OUT/tree-sitter-daslang/" 2>/dev/null || true
 # Windows vcvars launcher (no-op on Linux/macOS — clang/gcc find system headers)
 cp utils/mcp/daslang-mcp-msvc.cmd      "$OUT/utils/mcp/" 2>/dev/null || true
 # Setup guide -> bundle README

--- a/ci/smoke_test_cpp_mcp.sh
+++ b/ci/smoke_test_cpp_mcp.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Smoke-test a standalone cpp-mcp bundle: it starts, advertises the cpp tool
+# subset, and cpp_status returns a report — all with a clean exit. Run from a
+# neutral cwd so getDasRoot() MUST resolve from the exe path (proving the bundle
+# is self-contained, not leaning on a sibling daslang tree).
+#
+# Usage:  bash ci/smoke_test_cpp_mcp.sh <bundle-dir>
+# Exit 0 on pass, non-zero with a diagnostic otherwise.
+
+set -u
+
+B="$(cd "${1:?usage: $0 <bundle-dir>}" 2>/dev/null && pwd -P)" \
+    || { echo "ERROR: bundle dir not found: ${1:-}" >&2; exit 2; }
+
+if [[ -f "$B/bin/cpp-mcp.exe" ]]; then
+    BIN="$B/bin/cpp-mcp.exe"
+elif [[ -f "$B/bin/cpp-mcp" ]]; then
+    BIN="$B/bin/cpp-mcp"
+else
+    echo "ERROR: cpp-mcp binary not found in $B/bin/" >&2
+    exit 2
+fi
+
+REQ="$(mktemp)"; OUT="$(mktemp)"; ERR="$(mktemp)"
+trap 'rm -f "$REQ" "$OUT" "$ERR"' EXIT
+
+cat > "$REQ" <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"1.0"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"cpp_status","arguments":{}}}
+EOF
+
+echo "==================================================================="
+echo "cpp-mcp bundle smoke test"
+echo "  bundle : $B"
+echo "  binary : $BIN"
+echo "==================================================================="
+
+# Neutral cwd: the binary must find its .das sources via getDasRoot() (the
+# bundle), not via the current directory.
+( cd / && "$BIN" < "$REQ" ) > "$OUT" 2> "$ERR"
+rc=$?
+
+tools=$(grep -oE '"name":"(cpp_[a-z_]+|grep_usage|outline|shutdown)"' "$OUT" | sort -u | wc -l | tr -d ' ')
+echo "exit code        : $rc"
+echo "tools advertised : $tools"
+
+fail=0
+[[ $rc -eq 0 ]]                                  || { echo "FAIL: non-zero exit ($rc)"; fail=1; }
+grep -q '"name":"cpp_status"' "$OUT"             || { echo "FAIL: cpp_status not advertised"; fail=1; }
+grep -q '"name":"cpp_compile_check"' "$OUT"      || { echo "FAIL: cpp_compile_check not advertised"; fail=1; }
+grep -q 'cpp-mcp server status' "$OUT"           || { echo "FAIL: cpp_status call returned no report"; fail=1; }
+# The compile-DB / status tools are always on; ast-grep tools are env-gated.
+[[ ${tools:-0} -ge 4 ]]                          || { echo "FAIL: too few tools ($tools, expected >= 4)"; fail=1; }
+
+if [[ $fail -ne 0 ]]; then
+    echo "--- server stderr ---"; tail -20 "$ERR"
+    echo "--- first response bytes ---"; head -c 400 "$OUT"; echo
+    echo "RESULT: FAIL"
+    exit 1
+fi
+
+echo "RESULT: PASS"

--- a/utils/common/git_signature.das
+++ b/utils/common/git_signature.das
@@ -7,6 +7,8 @@
 
 options gen2
 
+module git_signature
+
 require strings public
 require daslib/fio public
 require daslib/strings_boost public

--- a/utils/mcp/cpp-mcp-setup.md
+++ b/utils/mcp/cpp-mcp-setup.md
@@ -15,7 +15,7 @@ cpp-mcp/
   bin/cpp-mcp[.exe]            # the server (statically linked; AOT-compiled hot paths)
   utils/mcp/*.das              # server sources (compiled at startup)
   utils/mcp/tools/*.das
-  utils/common/*.das
+  utils/common/git_signature.das
   utils/mcp/daslang-mcp-msvc.cmd   # Windows vcvars launcher
   tree-sitter-daslang/*.yml    # ast-grep rule files (loaded at runtime)
   daslib/                      # daslang standard library (sources)

--- a/utils/mcp/cpp-mcp-setup.md
+++ b/utils/mcp/cpp-mcp-setup.md
@@ -63,7 +63,9 @@ bundled `utils/` and `daslib/`** (or pass `--root <bundle-dir>`).
    ```
 
 3. Restart your MCP client and call **`cpp_status`** — it reports exactly which
-   dependencies are present and which tools that enables.
+   dependencies are present and which tools that enables. When checking the
+   compile DB for an external project, pass `build_dir` (your project's build
+   directory); without it, `cpp_status` probes the bundle root, not your project.
 
 ## Tools
 

--- a/utils/mcp/cpp-mcp-setup.md
+++ b/utils/mcp/cpp-mcp-setup.md
@@ -17,6 +17,7 @@ cpp-mcp/
   utils/mcp/tools/*.das
   utils/common/*.das
   utils/mcp/daslang-mcp-msvc.cmd   # Windows vcvars launcher
+  tree-sitter-daslang/*.yml    # ast-grep rule files (loaded at runtime)
   daslib/                      # daslang standard library (sources)
   README.md                    # this file
 ```
@@ -82,9 +83,11 @@ gracefully when it isn't.
 ### Optional: enable the ast-grep tools
 
 Install [ast-grep](https://ast-grep.github.io/guide/quick-start.html) and ensure
-`sg` is on PATH. For `.das` search you also need the tree-sitter-daslang grammar
-+ an `sgconfig.yml`; for plain C/C++ search the stock ast-grep cpp grammar
-suffices.
+`sg` is on PATH. The bundle already ships the rule files
+(`tree-sitter-daslang/*.yml`), so the **C/C++** ast-grep tools (`cpp_grep_usage`,
+`cpp_find_symbol`, `cpp_outline`, `cpp_goto_definition`) work with just `sg`
+installed. The `.das` tools (`grep_usage`, `outline`) additionally need the
+tree-sitter-daslang grammar + an `sgconfig.yml`.
 
 ## Notes
 

--- a/utils/mcp/cpp-mcp-setup.md
+++ b/utils/mcp/cpp-mcp-setup.md
@@ -1,0 +1,94 @@
+# cpp-mcp — C++ source-intelligence MCP server (setup)
+
+`cpp-mcp` is a standalone [MCP](https://modelcontextprotocol.io) server exposing
+daslang's **C++ source tooling** — parse-aware search/outline (via ast-grep) and
+compile-DB-driven syntax checks — without pulling in the full daslang toolchain.
+It's the curated cpp/agnostic subset of the daslang MCP server, shipped as a
+self-contained AOT binary.
+
+It is **language/project agnostic**: point it at any C/C++ codebase.
+
+## What's in the bundle
+
+```
+cpp-mcp/
+  bin/cpp-mcp[.exe]            # the server (statically linked; AOT-compiled hot paths)
+  utils/mcp/*.das              # server sources (compiled at startup)
+  utils/mcp/tools/*.das
+  utils/common/*.das
+  utils/mcp/daslang-mcp-msvc.cmd   # Windows vcvars launcher
+  daslib/                      # daslang standard library (sources)
+  README.md                    # this file
+```
+
+The binary recompiles `cpp_main.das` (+ `daslib`) at startup — AOT swaps in the
+native code, but the sources must be present. `getDasRoot()` derives the source
+root from the executable's path, so **keep `cpp-mcp` in `bin/` next to the
+bundled `utils/` and `daslib/`** (or pass `--root <bundle-dir>`).
+
+## Install
+
+1. Download the bundle for your platform from the
+   [releases page](https://github.com/GaijinEntertainment/daScript/releases) and
+   extract it anywhere (e.g. `~/tools/cpp-mcp`).
+2. Add a server entry to your MCP client's `.mcp.json`:
+
+   **Linux / macOS** — point straight at the binary (clang/gcc find system
+   headers on their own):
+   ```json
+   {
+     "mcpServers": {
+       "cpp-mcp": {
+         "command": "/abs/path/to/cpp-mcp/bin/cpp-mcp",
+         "defer_loading": false
+       }
+     }
+   }
+   ```
+
+   **Windows (MSVC)** — launch through the bundled `.cmd` so `cl.exe` finds the
+   system headers (`compile_commands.json` omits them on MSVC; the compiler reads
+   them from the `INCLUDE` env that vcvars sets):
+   ```json
+   {
+     "mcpServers": {
+       "cpp-mcp": {
+         "command": "cmd",
+         "args": ["/c", "C:\\abs\\path\\to\\cpp-mcp\\utils\\mcp\\daslang-mcp-msvc.cmd", "cpp-mcp.exe"],
+         "defer_loading": false
+       }
+     }
+   }
+   ```
+
+3. Restart your MCP client and call **`cpp_status`** — it reports exactly which
+   dependencies are present and which tools that enables.
+
+## Tools
+
+| Tool | Needs |
+|---|---|
+| `cpp_status` | nothing — self-diagnosis of the items below |
+| `cpp_compile_check` | a `compile_commands.json` (CMake `CMAKE_EXPORT_COMPILE_COMMANDS=ON`); on MSVC, a vcvars env |
+| `cpp_build_info` | a `compile_commands.json` |
+| `cpp_format_file` | `clang-format` on PATH + a `.clang-format` in the project |
+| `cpp_grep_usage`, `cpp_find_symbol`, `cpp_outline`, `cpp_goto_definition` | [ast-grep](https://ast-grep.github.io) (`sg`) on PATH |
+| `grep_usage`, `outline` | ast-grep — for `.das` files |
+
+The compile-DB and status tools work out of the box. The six ast-grep tools are
+**enabled only if `sg` is on PATH** (run `cpp_status` to confirm); they degrade
+gracefully when it isn't.
+
+### Optional: enable the ast-grep tools
+
+Install [ast-grep](https://ast-grep.github.io/guide/quick-start.html) and ensure
+`sg` is on PATH. For `.das` search you also need the tree-sitter-daslang grammar
++ an `sgconfig.yml`; for plain C/C++ search the stock ast-grep cpp grammar
+suffices.
+
+## Notes
+
+- `--root <dir>` overrides source-root autodetection (use when running the
+  binary from outside its bundle layout).
+- The server speaks JSON-RPC over stdio; all diagnostics go to a log file, never
+  stdout (which is the protocol pipe).

--- a/utils/mcp/cpp_mcp_main.cpp
+++ b/utils/mcp/cpp_mcp_main.cpp
@@ -1,0 +1,120 @@
+// Standalone AOT entry point for the C++-only MCP server (cpp-mcp).
+//
+// Compiles utils/mcp/cpp_main.das with AOT linking enabled and runs its
+// main() — the stdio JSON-RPC loop. The AOT-generated C++ for cpp_main.das
+// (and everything it requires) is linked into this binary and self-registers
+// via AotListBase; with CodeOfPolicies::aot = true, simulate() swaps the
+// interpreter nodes for the native functions.
+//
+// stdout IS the JSON-RPC framing pipe. On a clean compile (the shipped state)
+// nothing is written to it before main() takes over, and cpp_main's own
+// logger_install_hook keeps the server's diagnostics off stdout. Compile /
+// simulate diagnostics (only on a broken build) go to the global TextPrinter.
+//
+// Teardown mirrors the daslang tool's main (utils/daScript/main.cpp): the
+// context is a heap ContextPtr destroyed *before* Module::Shutdown, which
+// drains the jobque worker threads. Matching that order is what keeps the
+// jobque + persistent_heap teardown crash-free.
+//
+// Built only when -DDAS_BUILD_CPP_MCP=ON; see CMakeLists.txt.
+
+#include "daScript/daScript.h"
+#include "daScript/daScriptModule.h"
+#include "daScript/misc/das_common.h"     // SimulateWithErrReport
+#include "daScript/misc/crash_handler.h"  // install_das_crash_handler
+
+#include <cstdio>
+#include <cstring>
+#if defined(_WIN32)
+#include <direct.h>
+#define das_getcwd _getcwd
+#else
+#include <unistd.h>
+#define das_getcwd getcwd
+#endif
+
+using namespace das;
+
+static bool cpp_mcp_file_exists(const string & p) {
+    FILE * f = fopen(p.c_str(), "rb");
+    if ( f ) { fclose(f); return true; }
+    return false;
+}
+
+// Resolve where the bundled .das sources live. The AOT binary still compiles
+// cpp_main.das (+ daslib) at startup (AOT only swaps SimNodes for native code),
+// so the sources must be findable. Order: an explicit --root / -dasroot <dir>;
+// else getDasRoot() derived from the exe path (the bundle layout <root>/bin/);
+// else the cwd, if it happens to carry the sources (exe moved / run in place).
+static void cpp_mcp_resolve_root(int argc, char * argv[]) {
+    for ( int i = 1; i + 1 < argc; ++i ) {
+        if ( strcmp(argv[i], "--root") == 0 || strcmp(argv[i], "-dasroot") == 0 ) {
+            setDasRoot(argv[i + 1]);
+            return;
+        }
+    }
+    if ( cpp_mcp_file_exists(getDasRoot() + "/utils/mcp/cpp_main.das") ) return;
+    char cwd[4096];
+    if ( das_getcwd(cwd, sizeof(cwd)) ) {
+        string c = cwd;
+        if ( cpp_mcp_file_exists(c + "/utils/mcp/cpp_main.das") ) setDasRoot(c);
+    }
+}
+
+int main(int argc, char * argv[]) {
+    install_das_crash_handler();
+    setCommandLineArguments(argc, argv);
+    cpp_mcp_resolve_root(argc, argv);
+
+    // Full builtin module set — same as the daslang tool. Notably this
+    // includes jobque (new_thread / channels), which NEED_ALL_DEFAULT_MODULES
+    // omits and which cpp_main's per-tool-call worker threads rely on.
+    register_builtin_modules();
+    Module::Initialize();
+
+    int rc = 1;
+    // Everything that owns module references — TextPrinter, file access, the
+    // ModuleGroup, the program and its context — lives in this scope and is
+    // destroyed at its close, BEFORE Module::Shutdown. ~ModuleGroup touches the
+    // global module registry, so it must run while that registry is still
+    // alive; destroying it after Module::Shutdown is an access violation
+    // (matches the daslang tool / 13_aot.cpp ordering).
+    {
+        TextPrinter tout;
+        auto access = make_smart<FsFileAccess>();
+        ModuleGroup dummyGroup;
+
+        CodeOfPolicies policies;
+        policies.aot = true;                        // link AOT functions during simulate
+        policies.fail_on_no_aot = false;            // any non-AOT function falls back to interpreter
+        policies.fail_on_lack_of_aot_export = false;
+
+        auto program = compileDaScript(getDasRoot() + "/utils/mcp/cpp_main.das",
+                                       access, tout, dummyGroup, policies);
+        if (program && !program->failed()) {
+            // Heap context owned by a smart pointer — destroyed at the end of
+            // this scope, before Module::Shutdown (matches the daslang tool).
+            auto pctx = SimulateWithErrReport(program, tout);
+            if (pctx) {
+                if (auto fnMain = pctx->findFunction("main")) {
+                    pctx->restart();
+                    pctx->evalWithCatch(fnMain, nullptr);
+                    if (auto ex = pctx->getException()) {
+                        tout << "EXCEPTION: " << ex << "\n";
+                    } else {
+                        rc = 0;
+                    }
+                } else {
+                    tout << "cpp_main.das: main() not found\n";
+                }
+            }
+        } else if (program) {
+            for (auto & err : program->errors) {
+                tout << reportError(err.at, err.what, err.extra, err.fixme, err.cerr);
+            }
+        }
+    }
+
+    Module::Shutdown(false);
+    return rc;
+}

--- a/utils/mcp/cpp_mcp_main.cpp
+++ b/utils/mcp/cpp_mcp_main.cpp
@@ -9,7 +9,8 @@
 // stdout IS the JSON-RPC framing pipe. On a clean compile (the shipped state)
 // nothing is written to it before main() takes over, and cpp_main's own
 // logger_install_hook keeps the server's diagnostics off stdout. Compile /
-// simulate diagnostics (only on a broken build) go to the global TextPrinter.
+// simulate diagnostics (only on a broken build) are buffered and flushed to
+// stderr — never stdout.
 //
 // Teardown mirrors the daslang tool's main (utils/daScript/main.cpp): the
 // context is a heap ContextPtr destroyed *before* Module::Shutdown, which
@@ -80,7 +81,11 @@ int main(int argc, char * argv[]) {
     // alive; destroying it after Module::Shutdown is an access violation
     // (matches the daslang tool / 13_aot.cpp ordering).
     {
-        TextPrinter tout;
+        // A buffer, NOT TextPrinter: TextPrinter writes to stdout, which IS the
+        // JSON-RPC framing pipe (corrupting it). Compile/simulate diagnostics
+        // accumulate here and flush to stderr at the end of this scope (only a
+        // broken build produces any).
+        TextWriter tout;
         auto access = make_smart<FsFileAccess>();
         ModuleGroup dummyGroup;
 
@@ -112,6 +117,11 @@ int main(int argc, char * argv[]) {
             for (auto & err : program->errors) {
                 tout << reportError(err.at, err.what, err.extra, err.fixme, err.cerr);
             }
+        }
+        // Flush any buffered diagnostics to stderr — never stdout (the pipe).
+        if (!tout.empty()) {
+            fputs(tout.c_str(), stderr);
+            fflush(stderr);
         }
     }
 

--- a/utils/mcp/cpp_search_config.das
+++ b/utils/mcp/cpp_search_config.das
@@ -17,6 +17,8 @@
 
 options gen2
 
+module cpp_search_config
+
 // Folders to scan, recursively. `sg scan` walks each tree, so listing
 // `modules` covers all `modules/*/...` subdirectories automatically.
 let CPP_SEARCH_DIRS <- [

--- a/utils/mcp/daslang-mcp-msvc.cmd
+++ b/utils/mcp/daslang-mcp-msvc.cmd
@@ -49,13 +49,26 @@ rem Prefer the single-config (Ninja) binary, fall back to the MSVC Release layou
 set "DASLANG=%MCPDIR%..\..\bin\daslang.exe"
 if not exist "%DASLANG%" set "DASLANG=%MCPDIR%..\..\bin\Release\daslang.exe"
 
-rem First arg selects the server script (main.das full / cpp_main.das cpp-only);
-rem any further args are forwarded to the server script.
+rem First arg selects the server. A *.exe selects a prebuilt server binary in
+rem bin/ (the AOT cpp-mcp) run directly; otherwise it's an interpreted .das
+rem script handed to daslang.exe. Defaults to main.das (the full server).
+rem Any further args are forwarded to the chosen server.
 set "MCPSCRIPT=%~1"
 if not defined MCPSCRIPT (
     "%DASLANG%" "%MCPDIR%main.das"
     exit /b %ERRORLEVEL%
 )
+rem Goto (not a parenthesized block) so MCPBIN's set + use are sequential
+rem statements -- this script has no EnableDelayedExpansion, so %MCPBIN%
+rem read inside an `if ( ... )` block would expand stale (pre-set).
+if /i "%MCPSCRIPT:~-4%"==".exe" goto runexe
 shift
 "%DASLANG%" "%MCPDIR%%MCPSCRIPT%" %1 %2 %3 %4 %5 %6 %7 %8
+exit /b %ERRORLEVEL%
+
+:runexe
+set "MCPBIN=%MCPDIR%..\..\bin\%MCPSCRIPT%"
+if not exist "%MCPBIN%" set "MCPBIN=%MCPDIR%..\..\bin\Release\%MCPSCRIPT%"
+shift
+"%MCPBIN%" %1 %2 %3 %4 %5 %6 %7 %8
 exit /b %ERRORLEVEL%

--- a/utils/mcp/daslang-mcp-msvc.cmd
+++ b/utils/mcp/daslang-mcp-msvc.cmd
@@ -67,8 +67,15 @@ shift
 exit /b %ERRORLEVEL%
 
 :runexe
-set "MCPBIN=%MCPDIR%..\..\bin\%MCPSCRIPT%"
-if not exist "%MCPBIN%" set "MCPBIN=%MCPDIR%..\..\bin\Release\%MCPSCRIPT%"
+rem Use the basename only (%~nx1) so a path-y arg can't corrupt the bin\ prefix
+rem (e.g. a full path would otherwise yield ...\bin\C:\foo\cpp-mcp.exe).
+set "MCPEXE=%~nx1"
+set "MCPBIN=%MCPDIR%..\..\bin\%MCPEXE%"
+if not exist "%MCPBIN%" set "MCPBIN=%MCPDIR%..\..\bin\Release\%MCPEXE%"
+if not exist "%MCPBIN%" (
+    echo cpp-mcp launcher: binary "%MCPEXE%" not found under "%MCPDIR%..\..\bin\" 1>&2
+    exit /b 1
+)
 shift
 "%MCPBIN%" %1 %2 %3 %4 %5 %6 %7 %8
 exit /b %ERRORLEVEL%

--- a/utils/mcp/protocol_core.das
+++ b/utils/mcp/protocol_core.das
@@ -11,6 +11,8 @@
 options gen2
 options rtti
 
+module protocol_core
+
 require tools/common public
 require daslib/json
 require daslib/json_boost public
@@ -95,10 +97,15 @@ def handle_initialize(id_json : string) : string {
     return jsonrpc::response(id_json, sprint_json(result, false))
 }
 
-struct MakeFileTool {
-    name : string
+// Declared dependency-first (PropertySchema -> InputSchema -> MakeFileTool):
+// the AOT C++ emitter writes structs in declaration order, and a by-value
+// member needs its type complete first, so MakeFileTool (which holds an
+// InputSchema by value) must come after InputSchema, which must come after
+// PropertySchema (held by value inside its `properties` table).
+struct PropertySchema {
+    @rename = "type" _type : string
     description : string
-    inputSchema : InputSchema
+    @optional items : PropertySchema?
 }
 
 struct InputSchema {
@@ -107,10 +114,10 @@ struct InputSchema {
     required : array<string>
 }
 
-struct PropertySchema {
-    @rename = "type" _type : string
+struct MakeFileTool {
+    name : string
     description : string
-    @optional items : PropertySchema?
+    inputSchema : InputSchema
 }
 
 let PROJECT_PROP = PropertySchema(_type = "string", description = "Path to a .das_project file for custom module resolution")

--- a/utils/mcp/registry_cpp.das
+++ b/utils/mcp/registry_cpp.das
@@ -1,6 +1,8 @@
 options gen2
 options rtti
 
+module registry_cpp
+
 require protocol_core public
 require tools/grep_usage public
 require tools/outline public
@@ -10,6 +12,7 @@ require tools/cpp_outline public
 require tools/cpp_goto_definition public
 require tools/cpp_compile_check public
 require tools/cpp_format_file public
+require tools/cpp_status public
 
 // The cpp/agnostic subset shared by main.das and cpp_main.das: ast-grep-backed
 // .das + .cpp search/outline plus the compile-DB-driven C++ build tools. None
@@ -137,4 +140,14 @@ def build_cpp_tools(var reg : array<ToolDef>) {
         required <- ["file"],
         arg_names <- ["file"],
         handler = @@(arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string; load_modules : array<string>) => do_cpp_format_file(arg1)))
+    reg |> emplace(ToolDef(
+        tool <- make_tool(
+            "cpp_status",
+            "Report which external dependencies the cpp/agnostic tools need (ast-grep, a compile_commands.json, clang-format, and the MSVC vcvars INCLUDE env) and whether each is present — so a freshly-installed bundle can self-diagnose why a tool is missing or failing. No compilation, no side effects.",
+            {
+                "json" => PropertySchema(_type = "string", description = "If 'true', return structured JSON instead of the text report")
+            },
+            []),
+        main_thread = true,
+        handler = @@(arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string; load_modules : array<string>) => do_cpp_status(arg1 == "true")))
 }

--- a/utils/mcp/registry_cpp.das
+++ b/utils/mcp/registry_cpp.das
@@ -148,6 +148,7 @@ def build_cpp_tools(var reg : array<ToolDef>) {
                 "json" => PropertySchema(_type = "string", description = "If 'true', return structured JSON instead of the text report")
             },
             []),
+        arg_names <- ["json"],
         main_thread = true,
         handler = @@(arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string; load_modules : array<string>) => do_cpp_status(arg1 == "true")))
 }

--- a/utils/mcp/registry_cpp.das
+++ b/utils/mcp/registry_cpp.das
@@ -145,10 +145,11 @@ def build_cpp_tools(var reg : array<ToolDef>) {
             "cpp_status",
             "Report which external dependencies the cpp/agnostic tools need (ast-grep, a compile_commands.json, clang-format, and the MSVC vcvars INCLUDE env) and whether each is present — so a freshly-installed bundle can self-diagnose why a tool is missing or failing. No compilation, no side effects.",
             {
+                "build_dir" => PropertySchema(_type = "string", description = "Build directory (or a path to compile_commands.json) to check. Empty -> probe the server root's build/, build-ninja/, build*/. Pass your project's build dir when running cpp-mcp as a standalone bundle against an external project, or the compile DB check reports the server root, not your project."),
                 "json" => PropertySchema(_type = "string", description = "If 'true', return structured JSON instead of the text report")
             },
             []),
-        arg_names <- ["json"],
+        arg_names <- ["build_dir", "json"],
         main_thread = true,
-        handler = @@(arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string; load_modules : array<string>) => do_cpp_status(arg1 == "true")))
+        handler = @@(arg1, arg2, arg3, arg4, arg5, arg6, project, project_root : string; load_modules : array<string>) => do_cpp_status(arg1, arg2 == "true")))
 }

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -32,6 +32,7 @@ require tools/cpp_outline public
 require tools/cpp_goto_definition public
 require tools/cpp_compile_check public
 require tools/cpp_format_file public
+require tools/cpp_status public
 require tools/aot public
 require tools/lint_tool public
 require tools/program_log public
@@ -2496,6 +2497,30 @@ def test_cpp_format_file(t : T?) {
         parse_result(do_cpp_format_file("src/zzz_nonexistent_xyz.cpp"), text, is_error)
         t |> success(is_error, "missing file -> error -- text={text}")
         t |> success(find(text, "file not found") >= 0, "reports file not found -- text={text}")
+    }
+}
+
+[test]
+def test_cpp_status(t : T?) {
+    // Pure env detection — no compilation, no external deps required. Whatever the
+    // environment, the report (or JSON) is produced and is not an error.
+    t |> run("text report names each diagnosed dependency") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_cpp_status(false), text, is_error)
+        t |> success(!is_error, "status is not an error -- text={text}")
+        t |> success(find(text, "cpp-mcp server status") >= 0, "has report header -- text={text}")
+        t |> success(find(text, "ast-grep") >= 0, "reports ast-grep -- text={text}")
+        t |> success(find(text, "compile DB") >= 0, "reports compile DB -- text={text}")
+        t |> success(find(text, "clang-format") >= 0, "reports clang-format -- text={text}")
+    }
+    t |> run("json mode returns structured fields") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_cpp_status(true), text, is_error)
+        t |> success(!is_error, "json status is not an error -- text={text}")
+        t |> success(find(text, "das_root") >= 0, "json has das_root -- text={text}")
+        t |> success(find(text, "ast_grep_available") >= 0, "json has ast_grep_available -- text={text}")
     }
 }
 

--- a/utils/mcp/test_tools.das
+++ b/utils/mcp/test_tools.das
@@ -2507,7 +2507,7 @@ def test_cpp_status(t : T?) {
     t |> run("text report names each diagnosed dependency") <| @(t : T?) {
         var text : string
         var is_error = false
-        parse_result(do_cpp_status(false), text, is_error)
+        parse_result(do_cpp_status("", false), text, is_error)
         t |> success(!is_error, "status is not an error -- text={text}")
         t |> success(find(text, "cpp-mcp server status") >= 0, "has report header -- text={text}")
         t |> success(find(text, "ast-grep") >= 0, "reports ast-grep -- text={text}")
@@ -2517,10 +2517,17 @@ def test_cpp_status(t : T?) {
     t |> run("json mode returns structured fields") <| @(t : T?) {
         var text : string
         var is_error = false
-        parse_result(do_cpp_status(true), text, is_error)
+        parse_result(do_cpp_status("", true), text, is_error)
         t |> success(!is_error, "json status is not an error -- text={text}")
         t |> success(find(text, "das_root") >= 0, "json has das_root -- text={text}")
         t |> success(find(text, "ast_grep_available") >= 0, "json has ast_grep_available -- text={text}")
+    }
+    t |> run("explicit build_dir is honored for the compile-DB probe") <| @(t : T?) {
+        var text : string
+        var is_error = false
+        parse_result(do_cpp_status("build-ninja", true), text, is_error)
+        t |> success(!is_error, "build_dir status is not an error -- text={text}")
+        t |> success(find(text, "compile_db") >= 0, "json reports compile_db field -- text={text}")
     }
 }
 

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -1,6 +1,8 @@
 options gen2
 options rtti
 
+module common
+
 require daslib/json_boost public
 require daslib/strings_boost public
 require daslib/ast public

--- a/utils/mcp/tools/cpp_common.das
+++ b/utils/mcp/tools/cpp_common.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_common
+
 require common public
 require grep_usage public
 require outline public

--- a/utils/mcp/tools/cpp_compile_check.das
+++ b/utils/mcp/tools/cpp_compile_check.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_compile_check
+
 require common public
 require daslib/json
 require daslib/json_boost

--- a/utils/mcp/tools/cpp_find_symbol.das
+++ b/utils/mcp/tools/cpp_find_symbol.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_find_symbol
+
 require cpp_common public
 require daslib/strings_boost public
 require strings public

--- a/utils/mcp/tools/cpp_format_file.das
+++ b/utils/mcp/tools/cpp_format_file.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_format_file
+
 require common public
 require daslib/json_boost
 

--- a/utils/mcp/tools/cpp_goto_definition.das
+++ b/utils/mcp/tools/cpp_goto_definition.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_goto_definition
+
 require cpp_common public
 require daslib/strings_boost public
 require daslib/fio public

--- a/utils/mcp/tools/cpp_grep_usage.das
+++ b/utils/mcp/tools/cpp_grep_usage.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_grep_usage
+
 require cpp_common public
 require daslib/strings_boost public
 require strings public

--- a/utils/mcp/tools/cpp_outline.das
+++ b/utils/mcp/tools/cpp_outline.das
@@ -1,5 +1,7 @@
 options gen2
 
+module cpp_outline
+
 require cpp_common public
 require daslib/strings_boost public
 require strings public

--- a/utils/mcp/tools/cpp_status.das
+++ b/utils/mcp/tools/cpp_status.das
@@ -52,10 +52,11 @@ def do_cpp_status(as_json : bool) : string {
         w |> write("  das root:      {root}\n")
         if (!empty(sg)) {
             w |> write("  ast-grep:      {sg}\n")
-            w |> write("                 -> grep_usage / outline / cpp_grep_usage / cpp_find_symbol / cpp_outline / cpp_goto_definition ENABLED\n")
+            w |> write("                 -> C++ tools ENABLED: cpp_grep_usage / cpp_find_symbol / cpp_outline / cpp_goto_definition (the bundle ships their rule YAMLs)\n")
+            w |> write("                 -> .das tools (grep_usage / outline) ALSO need the tree-sitter-daslang grammar + an sgconfig.yml\n")
         } else {
             w |> write("  ast-grep:      NOT FOUND\n")
-            w |> write("                 -> those 6 tools are disabled; install ast-grep (sg) on PATH and restart\n")
+            w |> write("                 -> grep_usage / outline / cpp_grep_usage / cpp_find_symbol / cpp_outline / cpp_goto_definition disabled; install ast-grep (sg) on PATH and restart\n")
         }
         if (!empty(db)) {
             w |> write("  compile DB:    {db}\n")

--- a/utils/mcp/tools/cpp_status.das
+++ b/utils/mcp/tools/cpp_status.das
@@ -1,0 +1,70 @@
+options gen2
+options rtti
+
+module cpp_status
+
+require common public
+require grep_usage
+require cpp_compile_check
+require cpp_format_file
+require daslib/fio
+require daslib/json
+require daslib/json_boost
+require strings
+
+// Self-diagnosis for a freshly-installed bundle: report which external
+// dependencies the cpp/agnostic tools need (ast-grep, a compile_commands.json,
+// clang-format, and the MSVC vcvars INCLUDE env) and whether each is present,
+// so it's obvious why a tool is missing or failing. Pure detection — no
+// compilation, no side effects.
+def do_cpp_status(as_json : bool) : string {
+    let root = get_das_root()
+    let sg = detect_ast_grep()
+    let db = cpp_locate_compile_db("")
+    let cf = detect_clang_format()
+    let has_include = has_env_variable("INCLUDE")   // MSVC: cpp_compile_check needs vcvars' INCLUDE
+
+    if (as_json) {
+        return make_tool_result(sprint_json(JV((
+            das_root = root,
+            ast_grep = sg,
+            ast_grep_available = !empty(sg),
+            compile_db = db,
+            compile_db_found = !empty(db),
+            clang_format = cf,
+            clang_format_available = !empty(cf),
+            msvc_include_env = has_include
+        )), false))
+    }
+
+    let report = build_string() $(var w) {
+        w |> write("cpp-mcp server status (cpp/agnostic tool surface)\n\n")
+        w |> write("  das root:      {root}\n")
+        if (!empty(sg)) {
+            w |> write("  ast-grep:      {sg}\n")
+            w |> write("                 -> grep_usage / outline / cpp_grep_usage / cpp_find_symbol / cpp_outline / cpp_goto_definition ENABLED\n")
+        } else {
+            w |> write("  ast-grep:      NOT FOUND\n")
+            w |> write("                 -> those 6 tools are disabled; install ast-grep (sg) on PATH and restart\n")
+        }
+        if (!empty(db)) {
+            w |> write("  compile DB:    {db}\n")
+            w |> write("                 -> cpp_compile_check / cpp_build_info ready\n")
+        } else {
+            w |> write("  compile DB:    NOT FOUND in build/ build-ninja/ build*/\n")
+            w |> write("                 -> configure CMake with CMAKE_EXPORT_COMPILE_COMMANDS=ON; the VS generator does not emit it -- use a Ninja build dir\n")
+        }
+        if (!empty(cf)) {
+            w |> write("  clang-format:  {cf}\n")
+            w |> write("                 -> cpp_format_file ready (formats only where a .clang-format is present)\n")
+        } else {
+            w |> write("  clang-format:  NOT FOUND  -> cpp_format_file will no-op\n")
+        }
+        if (has_include) {
+            w |> write("  MSVC INCLUDE:  set  -> cpp_compile_check can spawn cl and find system headers\n")
+        } else {
+            w |> write("  MSVC INCLUDE:  not set  -> on Windows+MSVC, launch via the vcvars wrapper or cpp_compile_check fails on <vcruntime.h>; ignored for clang/gcc\n")
+        }
+    }
+    return make_tool_result(report)
+}

--- a/utils/mcp/tools/cpp_status.das
+++ b/utils/mcp/tools/cpp_status.das
@@ -8,9 +8,20 @@ require grep_usage
 require cpp_compile_check
 require cpp_format_file
 require daslib/fio
-require daslib/json
-require daslib/json_boost
 require strings
+
+// Serialization shape for the `json=true` mode. sprint_json reflects a plain
+// struct into clean JSON (unlike a JsonValue, whose internals it would reflect).
+struct private CppStatusResult {
+    das_root : string
+    ast_grep : string
+    ast_grep_available : bool
+    compile_db : string
+    compile_db_found : bool
+    clang_format : string
+    clang_format_available : bool
+    msvc_include_env : bool
+}
 
 // Self-diagnosis for a freshly-installed bundle: report which external
 // dependencies the cpp/agnostic tools need (ast-grep, a compile_commands.json,
@@ -25,7 +36,7 @@ def do_cpp_status(as_json : bool) : string {
     let has_include = has_env_variable("INCLUDE")   // MSVC: cpp_compile_check needs vcvars' INCLUDE
 
     if (as_json) {
-        return make_tool_result(sprint_json(JV((
+        return make_tool_result(sprint_json(CppStatusResult(
             das_root = root,
             ast_grep = sg,
             ast_grep_available = !empty(sg),
@@ -33,8 +44,7 @@ def do_cpp_status(as_json : bool) : string {
             compile_db_found = !empty(db),
             clang_format = cf,
             clang_format_available = !empty(cf),
-            msvc_include_env = has_include
-        )), false))
+            msvc_include_env = has_include), false))
     }
 
     let report = build_string() $(var w) {

--- a/utils/mcp/tools/cpp_status.das
+++ b/utils/mcp/tools/cpp_status.das
@@ -28,10 +28,13 @@ struct private CppStatusResult {
 // clang-format, and the MSVC vcvars INCLUDE env) and whether each is present,
 // so it's obvious why a tool is missing or failing. Pure detection — no
 // compilation, no side effects.
-def do_cpp_status(as_json : bool) : string {
+def do_cpp_status(build_dir : string; as_json : bool) : string {
     let root = get_das_root()
     let sg = detect_ast_grep()
-    let db = cpp_locate_compile_db("")
+    // Empty build_dir probes the server root's build dirs (get_das_root) -- which
+    // in a standalone bundle is the bundle, NOT the user's project. Callers serving
+    // an external project should pass their build_dir so this reflects it.
+    let db = cpp_locate_compile_db(build_dir)
     let cf = detect_clang_format()
     let has_include = has_env_variable("INCLUDE")   // MSVC: cpp_compile_check needs vcvars' INCLUDE
 
@@ -64,6 +67,7 @@ def do_cpp_status(as_json : bool) : string {
         } else {
             w |> write("  compile DB:    NOT FOUND in build/ build-ninja/ build*/\n")
             w |> write("                 -> configure CMake with CMAKE_EXPORT_COMPILE_COMMANDS=ON; the VS generator does not emit it -- use a Ninja build dir\n")
+            w |> write("                 -> probes the server root by default; pass build_dir to point at your project's build dir\n")
         }
         if (!empty(cf)) {
             w |> write("  clang-format:  {cf}\n")

--- a/utils/mcp/tools/grep_usage.das
+++ b/utils/mcp/tools/grep_usage.das
@@ -1,5 +1,7 @@
 options gen2
 
+module grep_usage
+
 require common public
 require daslib/json
 require daslib/json_boost

--- a/utils/mcp/tools/outline.das
+++ b/utils/mcp/tools/outline.das
@@ -1,5 +1,7 @@
 options gen2
 
+module outline
+
 require common public
 require grep_usage public
 require daslib/json


### PR DESCRIPTION
## What

Ship the C++-only MCP server (`utils/mcp/cpp_main.das`) as a **self-contained AOT binary** people can download and install for C/C++ source intelligence — without pulling in the full daslang toolchain. This is the final phase of the MCP server enhancement (worktree bootstrap #3199, C++ syntax-check #3204, registry das/cpp split #3210).

## Contents

**Binary (`cpp-mcp`)**
- CMake target gated behind `DAS_BUILD_CPP_MCP` (OFF by default): `DAS_AOT` of `cpp_main.das` linked into a small harness (`utils/mcp/cpp_mcp_main.cpp`).
- Links **`libDaScript` only** — `cpp_main` requires no external module (jobque/json/fio/logger/strings are all builtin), so dasHV/OpenSSL/GLFW/Audio/… are never linked.
- **Strips** the Linux/macOS binary; tracks `cpp_main`'s full `require` graph so local edits regenerate the AOT C++ (DAS_AOT otherwise only tracks the entry file + daslib).
- Source root resolves from the exe path (`getDasRoot`), with a `--root` override and a cwd fallback.

**`cpp_status` tool** — self-diagnoses which external deps are present (ast-grep, `compile_commands.json`, clang-format, MSVC `INCLUDE`) and which tools that enables. Lands in both the cpp server and the full server (via `build_cpp_tools`).

**Release CI (`.github/workflows/cpp_mcp_release.yml`)**
- PR-time: builds + smoke-tests on Linux (the `cpp-mcp` target is OFF in the normal matrix, so nothing else compiles it).
- `workflow_dispatch`: full matrix (linux x86_64/arm64, darwin arm64, windows x64), no upload.
- `release: prereleased`: full matrix → uploads `cpp-mcp-<os>-<arch>.{tar.gz,zip}`.
- Lean build (all heavy modules disabled → ~360 steps, no vcpkg/OpenSSL/apt deps).
- `ci/make_cpp_mcp_bundle.sh` assembles the bundle (binary + `.das` sources + daslib + Windows launcher); `ci/smoke_test_cpp_mcp.sh` verifies it starts, advertises the cpp subset, and `cpp_status` reports.

**Supporting changes**
- Named `module` declarations on the cpp/agnostic tool modules (required for AOT).
- Dependency-first reorder of `protocol_core`'s schema structs — the AOT C++ emitter writes struct definitions in declaration order, so a by-value field of a later-declared struct fails to compile (filed as #3212; this is the workaround).
- Windows launcher gains an `.exe` route so a prebuilt binary runs under the vcvars env `cpp_compile_check` needs.
- `utils/mcp/cpp-mcp-setup.md` — install guide (shipped as the bundle README).

## Verification

- **Windows + WSL** bundles built and run from a clean directory outside any daslang tree. A controlled-break test (rename a required `daslib` file → server fails; restore → recovers) proves the binary reads its sources from the bundle, not a sibling build tree.
- `cpp_build_info` + `cpp_compile_check` work from the bundle against an external project; `cpp_status` reports the env correctly on both OSes.
- Linux binary 70 MB → **45 MB stripped**.
- Full `daslang` server unaffected — gains `cpp_status` (42 tools), clean startup.
- Lint clean (17 files), `cpp_status.das` formatter-clean.

## Notes for review

- The `cpp-mcp` target is OFF by default; regular CI is unchanged. The release workflow validates on PR (linux cell only).
- `-aot` (not standalone-context) is intentional: the binary recompiles `cpp_main.das` + daslib at startup (AOT swaps in native code), so the bundle ships the sources. That's why `getDasRoot` / the bundle layout matter.

Related: #3212 (AOT emitter struct ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)