### PR TITLE
cmake: fix bison/flex parallel race between libDaScript / libDaScriptDyn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,6 +734,16 @@ src/parser/ds2_lexer.cpp
 src/parser/lex2.yy.h
 )
 
+# Funnel the bison/flex generation through ONE custom target. libDaScript
+# AND libDaScriptDyn both list PARSER_GENERATED_SRC, so with MSBuild's per-
+# vcxproj parallelism each library independently triggers the custom commands
+# and they race on the shared output files (ds_parser.hpp / ds_lexer.cpp /
+# ds2_*) -- "Device or resource busy" from bison and C1083 "Permission
+# denied" from cl on the same file. A single parser_generated target both
+# libraries depend on serialises the generation once before either library
+# compiles, while the libraries themselves still compile in parallel.
+add_custom_target(parser_generated DEPENDS ${PARSER_GENERATED_SRC})
+
 SET(PARSER_SRC
 src/parser/ds_parser.ypp
 src/parser/ds_lexer.lpp
@@ -1169,6 +1179,16 @@ SETUP_LIBDASCRIPT(libDaScriptDyn_runtime ON ON LIBDASCRIPT_RUNTIME_SRC DAS_EXPOR
 
 SETUP_LIBDASCRIPT(libDaScript OFF OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
 SETUP_LIBDASCRIPT(libDaScriptDyn ON OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
+
+# Make both compiler libraries wait for the single parser_generated target so
+# the bison/flex custom commands run exactly once per build (see definition
+# above PARSER_GENERATED_SRC). Without this both vcxprojs race over the
+# shared ds_parser.hpp / ds_lexer.cpp / ds2_* outputs under MSBuild's
+# per-project parallelism, intermittently failing with "Device or resource
+# busy" (bison can't open the .hpp the other proc is writing) and C1083
+# "Permission denied" (cl can't open the .cpp bison's still writing).
+add_dependencies(libDaScript parser_generated)
+add_dependencies(libDaScriptDyn parser_generated)
 
 # Heap leak tracking: permanently enabled in RelWithDebInfo only.
 # DAS_FREE_LIST=0 forces the reuse cache off so every aligned allocation reaches


### PR DESCRIPTION
## Summary

`libDaScript` and `libDaScriptDyn` both list `${PARSER_GENERATED_SRC}` in their source set (they share `LIBDASCRIPT_COMPILER_SRC`). With MSBuild's per-vcxproj parallelism each library independently triggers the `ADD_CUSTOM_COMMAND(OUTPUT ds_parser.cpp ds_parser.hpp ds_lexer.cpp ds2_*)` rule that runs bison + flex. With both libraries scheduled at once the two custom-command invocations race on the same shared output files:

```
/usr/bin/bison: ds2_parser.hpp: cannot open: Device or resource busy
…
ds_lexer.cpp(1,1): error C1083: Cannot open source file:
    'D:\Work\daScript\src\parser\ds_lexer.cpp': Permission denied
```

This intermittently fails clean Windows MSVC builds; a rerun usually wins because the first invocation's output is on disk by then. The Ninja generator isn't affected — its single-DAG dependency resolution sees the shared command and runs it exactly once.

Hit while reconfiguring the local toolchain to VS 2026; the symptom showed up on the first `cmake --build` after a clean `cmake -B build`, with `-j 64`. Rerunning the same command succeeded.

## Fix

Funnel parser generation through a single `parser_generated` custom target and have both compiler libraries `add_dependencies` on it. The bison/flex commands run exactly once; `libDaScript` and `libDaScriptDyn` still compile in parallel afterwards.

```diff
 SET(PARSER_GENERATED_SRC
 # 1st parser
 src/parser/ds_parser.hpp
 …
 src/parser/lex2.yy.h
 )

+add_custom_target(parser_generated DEPENDS ${PARSER_GENERATED_SRC})

 …
 SETUP_LIBDASCRIPT(libDaScript OFF OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)
 SETUP_LIBDASCRIPT(libDaScriptDyn ON OFF LIBDASCRIPT_COMPILER_SRC DAS_CC_EXPORTS)

+add_dependencies(libDaScript parser_generated)
+add_dependencies(libDaScriptDyn parser_generated)
```

The `utils/dasFormatter/ds_parser.ypp` flex/bison invocation isn't affected — its generated `utils/dasFormatter/ds_parser.cpp` is consumed only by `das-fmt`, no parallel consumer.

## Test plan

- [x] Local Windows MSVC clean build (`cmake -B build -G "Visual Studio 18 2026" -A x64` + `cmake --build build --config Release -j 64`) — pre-fix: intermittent fail with the "Device or resource busy" / C1083 above; post-fix: clean.
- [ ] Linux + macOS CI lanes (Ninja: no behavior change; just an extra always-up-to-date target).
- [ ] Windows CI lanes (MSBuild + clang-cl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)