### PR TITLE
cmake: apply -fwrapv to clang-cl (fix Windows clang-cl AOT miscompile)

### DIFF
--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -131,12 +131,16 @@ MACRO(SETUP_COMPILER)
     # clangs (AppleClang 21+, mingw clang 22+, presumably newer linux clangs)
     # exploit it (e.g. the LCG step in daslib/random.das becomes miscompiled,
     # producing values that violate the trailing `& 0x7FFF` mask). -fwrapv
-    # makes the C++ output faithfully match daslang's semantics across every
-    # gcc / clang-driver build (excluding clang-cl, which uses MSVC-style
-    # flags and doesn't expose this option; MSVC defaults to wrap anyway).
+    # makes the C++ output faithfully match daslang's semantics.
+    #
+    # This MUST include clang-cl: it is clang underneath and exploits the very
+    # same UB, despite presenting an MSVC-style driver (only the real MSVC `cl`
+    # defaults to wrap). clang-cl accepts the plain `-fwrapv` clang flag. The
+    # earlier `FRONTEND_VARIANT != MSVC` exclusion regressed the Windows
+    # clang-cl AOT lane (tests/language/random_numbers — random_int escaped its
+    # `& 0x7FFF` mask), so the gate is now compiler-id based only.
     IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
-       ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
-        NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") OR
+       "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
        "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
         ADD_COMPILE_OPTIONS(-fwrapv)
     ENDIF()


### PR DESCRIPTION
## Symptom

The `build_windows_clangcl` **AOT sweep** started failing today across several PRs (e.g. #3218), all on the same test:

```
tests\language\random_numbers.das — 1 failed
  FAIL 'random_float is in [0,1)'   (test_random_float_range)
```

~48 of the 200 asserts in that test fail (≈ half the samples land outside `[0,1)`). Every other CI lane — including the Linux/macOS/gcc/clang AOT lanes — is green. The test itself is 4 months old and unchanged, so this is a fresh **codegen regression isolated to clang-cl**.

## Root cause

`random_int` in `daslib/random.das` is a classic LCG:

```
seed.x = seed.x * 214013 + 2531011      // overflows int32 — UB in C++
return (seed.x >> 16) & 0x7FFF          // [0, 32767]
```

daslang defines integer arithmetic to wrap, but the AOT lowers it to plain C++ `int * int`, which is **signed-overflow UB**. `CMakeCommon.txt` already adds `-fwrapv` for exactly this reason — its comment literally cites *"the LCG step in daslib/random.das ... violates the trailing `& 0x7FFF` mask"* — **but the gate excluded clang-cl**:

```cmake
("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
 NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")   # <-- skips clang-cl
```

…on the assumption clang-cl "behaves like MSVC `cl` (wraps anyway)". It does **not** — clang-cl is clang underneath and exploits the UB just like the GNU-driver clangs. Without `-fwrapv`, `random_int` escapes its `& 0x7FFF` mask and goes negative → `random_float < 0` → `f >= 0.0` fails. (The SIMD `random_float4` path passes, because `SimPolicy<int4>::Mul` lowers to SSE intrinsics that wrap — which pinpoints the scalar signed-overflow UB as the culprit.)

"Popped up today on several jobs" = the CI's clang-cl became aggressive enough to exploit it; the `-fwrapv` work (clang-22 / mingw era) simply forgot clang-cl.

## Fix

Widen the `-fwrapv` gate to **every Clang compiler id** (it already covered GNU / GNU-driver-clang / AppleClang). clang-cl accepts the plain `-fwrapv` flag. One-line condition change + an updated comment.

## Verification

Reproduced and verified locally with **clang-cl 22.1.5** (Ninja, AOT):

| | before fix | after fix |
|---|---|---|
| `tests/language/random_numbers.das` | 1 failed | **PASS** |
| full `tests/language` AOT sweep | — | **1063 / 1063 passed** |

`-fwrapv` only disables an overflow-assuming optimization (already the default on every other platform), so it cannot introduce new miscompiles — only remove this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)