### PR TITLE
linq: concat for 3..8 sources (mirrors the zip arity convention)

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -273,6 +273,393 @@ def concat_inplace(var a : array<auto(TT)>, b : array<auto(TT)>) {
     }
 }
 
+// ===== concat — 3 sources =====
+
+[unused_argument(tt)]
+def private concat3_impl(var a; var b; var c; tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    var r : array<TT -const -&>
+    if (reserveSize > 0) {
+        r.reserve(reserveSize)
+    }
+    for (it in a) { r.push_clone(it) } // nolint:PERF022
+    for (it in b) { r.push_clone(it) } // nolint:PERF022
+    for (it in c) { r.push_clone(it) } // nolint:PERF022
+    return <- r
+}
+
+[unused_argument(tt)]
+def private concat3_impl_const(a : auto(ARGA); b : auto(ARGB); c : auto(ARGC); tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    return <- concat3_impl(unsafe(reinterpret<ARGA -const>(a)), unsafe(reinterpret<ARGB -const>(b)), unsafe(reinterpret<ARGC -const>(c)), type<TT -const -&>, reserveSize)
+}
+
+def concat(a, b, c : array<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates three arrays
+    return <- concat3_impl_const(a, b, c, type<TT -const -&>, length(a) + length(b) + length(c))
+}
+
+def concat_to_array(var a, b, c : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates three iterators and returns an array
+    return <- concat3_impl(a, b, c, type<TT -const -&>, 0)
+}
+
+def concat(var a, b, c : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Concatenates three iterators
+    return generator<TT -const -&> capture(<- a, <- b, <- c) {
+        for (itA in a) {
+            static_if (typeinfo can_copy(itA)) { yield itA } else { yield <- clone_to_move(itA) }
+        }
+        for (itB in b) {
+            static_if (typeinfo can_copy(itB)) { yield itB } else { yield <- clone_to_move(itB) }
+        }
+        for (itC in c) {
+            static_if (typeinfo can_copy(itC)) { yield itC } else { yield <- clone_to_move(itC) }
+        }
+        return false
+    }
+}
+
+def concat_inplace(var a : array<auto(TT)>, b, c : array<auto(TT)>) {
+    //! Concatenates three arrays in place
+    a.reserve(length(a) + length(b) + length(c))
+    a |> push_clone_from(b)
+    a |> push_clone_from(c)
+}
+
+// ===== concat — 4 sources =====
+
+[unused_argument(tt)]
+def private concat4_impl(var a; var b; var c; var d; tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    var r : array<TT -const -&>
+    if (reserveSize > 0) {
+        r.reserve(reserveSize)
+    }
+    for (it in a) { r.push_clone(it) } // nolint:PERF022
+    for (it in b) { r.push_clone(it) } // nolint:PERF022
+    for (it in c) { r.push_clone(it) } // nolint:PERF022
+    for (it in d) { r.push_clone(it) } // nolint:PERF022
+    return <- r
+}
+
+[unused_argument(tt)]
+def private concat4_impl_const(a : auto(ARGA); b : auto(ARGB); c : auto(ARGC); d : auto(ARGD); tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    return <- concat4_impl(unsafe(reinterpret<ARGA -const>(a)), unsafe(reinterpret<ARGB -const>(b)), unsafe(reinterpret<ARGC -const>(c)), unsafe(reinterpret<ARGD -const>(d)), type<TT -const -&>, reserveSize)
+}
+
+def concat(a, b, c, d : array<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates four arrays
+    return <- concat4_impl_const(a, b, c, d, type<TT -const -&>, length(a) + length(b) + length(c) + length(d))
+}
+
+def concat_to_array(var a, b, c, d : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates four iterators and returns an array
+    return <- concat4_impl(a, b, c, d, type<TT -const -&>, 0)
+}
+
+def concat(var a, b, c, d : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Concatenates four iterators
+    return generator<TT -const -&> capture(<- a, <- b, <- c, <- d) {
+        for (itA in a) {
+            static_if (typeinfo can_copy(itA)) { yield itA } else { yield <- clone_to_move(itA) }
+        }
+        for (itB in b) {
+            static_if (typeinfo can_copy(itB)) { yield itB } else { yield <- clone_to_move(itB) }
+        }
+        for (itC in c) {
+            static_if (typeinfo can_copy(itC)) { yield itC } else { yield <- clone_to_move(itC) }
+        }
+        for (itD in d) {
+            static_if (typeinfo can_copy(itD)) { yield itD } else { yield <- clone_to_move(itD) }
+        }
+        return false
+    }
+}
+
+def concat_inplace(var a : array<auto(TT)>, b, c, d : array<auto(TT)>) {
+    //! Concatenates four arrays in place
+    a.reserve(length(a) + length(b) + length(c) + length(d))
+    a |> push_clone_from(b)
+    a |> push_clone_from(c)
+    a |> push_clone_from(d)
+}
+
+// ===== concat — 5 sources =====
+
+[unused_argument(tt)]
+def private concat5_impl(var a; var b; var c; var d; var e; tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    var r : array<TT -const -&>
+    if (reserveSize > 0) {
+        r.reserve(reserveSize)
+    }
+    for (it in a) { r.push_clone(it) } // nolint:PERF022
+    for (it in b) { r.push_clone(it) } // nolint:PERF022
+    for (it in c) { r.push_clone(it) } // nolint:PERF022
+    for (it in d) { r.push_clone(it) } // nolint:PERF022
+    for (it in e) { r.push_clone(it) } // nolint:PERF022
+    return <- r
+}
+
+[unused_argument(tt)]
+def private concat5_impl_const(a : auto(ARGA); b : auto(ARGB); c : auto(ARGC); d : auto(ARGD); e : auto(ARGE); tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    return <- concat5_impl(unsafe(reinterpret<ARGA -const>(a)), unsafe(reinterpret<ARGB -const>(b)), unsafe(reinterpret<ARGC -const>(c)), unsafe(reinterpret<ARGD -const>(d)), unsafe(reinterpret<ARGE -const>(e)), type<TT -const -&>, reserveSize)
+}
+
+def concat(a, b, c, d, e : array<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates five arrays
+    return <- concat5_impl_const(a, b, c, d, e, type<TT -const -&>, length(a) + length(b) + length(c) + length(d) + length(e))
+}
+
+def concat_to_array(var a, b, c, d, e : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates five iterators and returns an array
+    return <- concat5_impl(a, b, c, d, e, type<TT -const -&>, 0)
+}
+
+def concat(var a, b, c, d, e : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Concatenates five iterators
+    return generator<TT -const -&> capture(<- a, <- b, <- c, <- d, <- e) {
+        for (itA in a) {
+            static_if (typeinfo can_copy(itA)) { yield itA } else { yield <- clone_to_move(itA) }
+        }
+        for (itB in b) {
+            static_if (typeinfo can_copy(itB)) { yield itB } else { yield <- clone_to_move(itB) }
+        }
+        for (itC in c) {
+            static_if (typeinfo can_copy(itC)) { yield itC } else { yield <- clone_to_move(itC) }
+        }
+        for (itD in d) {
+            static_if (typeinfo can_copy(itD)) { yield itD } else { yield <- clone_to_move(itD) }
+        }
+        for (itE in e) {
+            static_if (typeinfo can_copy(itE)) { yield itE } else { yield <- clone_to_move(itE) }
+        }
+        return false
+    }
+}
+
+def concat_inplace(var a : array<auto(TT)>, b, c, d, e : array<auto(TT)>) {
+    //! Concatenates five arrays in place
+    a.reserve(length(a) + length(b) + length(c) + length(d) + length(e))
+    a |> push_clone_from(b)
+    a |> push_clone_from(c)
+    a |> push_clone_from(d)
+    a |> push_clone_from(e)
+}
+
+// ===== concat — 6 sources =====
+
+[unused_argument(tt)]
+def private concat6_impl(var a; var b; var c; var d; var e; var f; tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    var r : array<TT -const -&>
+    if (reserveSize > 0) {
+        r.reserve(reserveSize)
+    }
+    for (it in a) { r.push_clone(it) } // nolint:PERF022
+    for (it in b) { r.push_clone(it) } // nolint:PERF022
+    for (it in c) { r.push_clone(it) } // nolint:PERF022
+    for (it in d) { r.push_clone(it) } // nolint:PERF022
+    for (it in e) { r.push_clone(it) } // nolint:PERF022
+    for (it in f) { r.push_clone(it) } // nolint:PERF022
+    return <- r
+}
+
+[unused_argument(tt)]
+def private concat6_impl_const(a : auto(ARGA); b : auto(ARGB); c : auto(ARGC); d : auto(ARGD); e : auto(ARGE); f : auto(ARGF); tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    return <- concat6_impl(unsafe(reinterpret<ARGA -const>(a)), unsafe(reinterpret<ARGB -const>(b)), unsafe(reinterpret<ARGC -const>(c)), unsafe(reinterpret<ARGD -const>(d)), unsafe(reinterpret<ARGE -const>(e)), unsafe(reinterpret<ARGF -const>(f)), type<TT -const -&>, reserveSize)
+}
+
+def concat(a, b, c, d, e, f : array<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates six arrays
+    return <- concat6_impl_const(a, b, c, d, e, f, type<TT -const -&>, length(a) + length(b) + length(c) + length(d) + length(e) + length(f))
+}
+
+def concat_to_array(var a, b, c, d, e, f : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates six iterators and returns an array
+    return <- concat6_impl(a, b, c, d, e, f, type<TT -const -&>, 0)
+}
+
+def concat(var a, b, c, d, e, f : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Concatenates six iterators
+    return generator<TT -const -&> capture(<- a, <- b, <- c, <- d, <- e, <- f) {
+        for (itA in a) {
+            static_if (typeinfo can_copy(itA)) { yield itA } else { yield <- clone_to_move(itA) }
+        }
+        for (itB in b) {
+            static_if (typeinfo can_copy(itB)) { yield itB } else { yield <- clone_to_move(itB) }
+        }
+        for (itC in c) {
+            static_if (typeinfo can_copy(itC)) { yield itC } else { yield <- clone_to_move(itC) }
+        }
+        for (itD in d) {
+            static_if (typeinfo can_copy(itD)) { yield itD } else { yield <- clone_to_move(itD) }
+        }
+        for (itE in e) {
+            static_if (typeinfo can_copy(itE)) { yield itE } else { yield <- clone_to_move(itE) }
+        }
+        for (itF in f) {
+            static_if (typeinfo can_copy(itF)) { yield itF } else { yield <- clone_to_move(itF) }
+        }
+        return false
+    }
+}
+
+def concat_inplace(var a : array<auto(TT)>, b, c, d, e, f : array<auto(TT)>) {
+    //! Concatenates six arrays in place
+    a.reserve(length(a) + length(b) + length(c) + length(d) + length(e) + length(f))
+    a |> push_clone_from(b)
+    a |> push_clone_from(c)
+    a |> push_clone_from(d)
+    a |> push_clone_from(e)
+    a |> push_clone_from(f)
+}
+
+// ===== concat — 7 sources =====
+
+[unused_argument(tt)]
+def private concat7_impl(var a; var b; var c; var d; var e; var f; var g; tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    var r : array<TT -const -&>
+    if (reserveSize > 0) {
+        r.reserve(reserveSize)
+    }
+    for (it in a) { r.push_clone(it) } // nolint:PERF022
+    for (it in b) { r.push_clone(it) } // nolint:PERF022
+    for (it in c) { r.push_clone(it) } // nolint:PERF022
+    for (it in d) { r.push_clone(it) } // nolint:PERF022
+    for (it in e) { r.push_clone(it) } // nolint:PERF022
+    for (it in f) { r.push_clone(it) } // nolint:PERF022
+    for (it in g) { r.push_clone(it) } // nolint:PERF022
+    return <- r
+}
+
+[unused_argument(tt)]
+def private concat7_impl_const(a : auto(ARGA); b : auto(ARGB); c : auto(ARGC); d : auto(ARGD); e : auto(ARGE); f : auto(ARGF); g : auto(ARGG); tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    return <- concat7_impl(unsafe(reinterpret<ARGA -const>(a)), unsafe(reinterpret<ARGB -const>(b)), unsafe(reinterpret<ARGC -const>(c)), unsafe(reinterpret<ARGD -const>(d)), unsafe(reinterpret<ARGE -const>(e)), unsafe(reinterpret<ARGF -const>(f)), unsafe(reinterpret<ARGG -const>(g)), type<TT -const -&>, reserveSize)
+}
+
+def concat(a, b, c, d, e, f, g : array<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates seven arrays
+    return <- concat7_impl_const(a, b, c, d, e, f, g, type<TT -const -&>, length(a) + length(b) + length(c) + length(d) + length(e) + length(f) + length(g))
+}
+
+def concat_to_array(var a, b, c, d, e, f, g : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates seven iterators and returns an array
+    return <- concat7_impl(a, b, c, d, e, f, g, type<TT -const -&>, 0)
+}
+
+def concat(var a, b, c, d, e, f, g : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Concatenates seven iterators
+    return generator<TT -const -&> capture(<- a, <- b, <- c, <- d, <- e, <- f, <- g) {
+        for (itA in a) {
+            static_if (typeinfo can_copy(itA)) { yield itA } else { yield <- clone_to_move(itA) }
+        }
+        for (itB in b) {
+            static_if (typeinfo can_copy(itB)) { yield itB } else { yield <- clone_to_move(itB) }
+        }
+        for (itC in c) {
+            static_if (typeinfo can_copy(itC)) { yield itC } else { yield <- clone_to_move(itC) }
+        }
+        for (itD in d) {
+            static_if (typeinfo can_copy(itD)) { yield itD } else { yield <- clone_to_move(itD) }
+        }
+        for (itE in e) {
+            static_if (typeinfo can_copy(itE)) { yield itE } else { yield <- clone_to_move(itE) }
+        }
+        for (itF in f) {
+            static_if (typeinfo can_copy(itF)) { yield itF } else { yield <- clone_to_move(itF) }
+        }
+        for (itG in g) {
+            static_if (typeinfo can_copy(itG)) { yield itG } else { yield <- clone_to_move(itG) }
+        }
+        return false
+    }
+}
+
+def concat_inplace(var a : array<auto(TT)>, b, c, d, e, f, g : array<auto(TT)>) {
+    //! Concatenates seven arrays in place
+    a.reserve(length(a) + length(b) + length(c) + length(d) + length(e) + length(f) + length(g))
+    a |> push_clone_from(b)
+    a |> push_clone_from(c)
+    a |> push_clone_from(d)
+    a |> push_clone_from(e)
+    a |> push_clone_from(f)
+    a |> push_clone_from(g)
+}
+
+// ===== concat — 8 sources =====
+
+[unused_argument(tt)]
+def private concat8_impl(var a; var b; var c; var d; var e; var f; var g; var h; tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    var r : array<TT -const -&>
+    if (reserveSize > 0) {
+        r.reserve(reserveSize)
+    }
+    for (it in a) { r.push_clone(it) } // nolint:PERF022
+    for (it in b) { r.push_clone(it) } // nolint:PERF022
+    for (it in c) { r.push_clone(it) } // nolint:PERF022
+    for (it in d) { r.push_clone(it) } // nolint:PERF022
+    for (it in e) { r.push_clone(it) } // nolint:PERF022
+    for (it in f) { r.push_clone(it) } // nolint:PERF022
+    for (it in g) { r.push_clone(it) } // nolint:PERF022
+    for (it in h) { r.push_clone(it) } // nolint:PERF022
+    return <- r
+}
+
+[unused_argument(tt)]
+def private concat8_impl_const(a : auto(ARGA); b : auto(ARGB); c : auto(ARGC); d : auto(ARGD); e : auto(ARGE); f : auto(ARGF); g : auto(ARGG); h : auto(ARGH); tt : auto(TT); reserveSize : int) : array<TT -const -&> {
+    return <- concat8_impl(unsafe(reinterpret<ARGA -const>(a)), unsafe(reinterpret<ARGB -const>(b)), unsafe(reinterpret<ARGC -const>(c)), unsafe(reinterpret<ARGD -const>(d)), unsafe(reinterpret<ARGE -const>(e)), unsafe(reinterpret<ARGF -const>(f)), unsafe(reinterpret<ARGG -const>(g)), unsafe(reinterpret<ARGH -const>(h)), type<TT -const -&>, reserveSize)
+}
+
+def concat(a, b, c, d, e, f, g, h : array<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates eight arrays
+    return <- concat8_impl_const(a, b, c, d, e, f, g, h, type<TT -const -&>, length(a) + length(b) + length(c) + length(d) + length(e) + length(f) + length(g) + length(h))
+}
+
+def concat_to_array(var a, b, c, d, e, f, g, h : iterator<auto(TT)>) : array<TT -const -&> {
+    //! Concatenates eight iterators and returns an array
+    return <- concat8_impl(a, b, c, d, e, f, g, h, type<TT -const -&>, 0)
+}
+
+def concat(var a, b, c, d, e, f, g, h : iterator<auto(TT)>) : iterator<TT -const -&> {
+    //! Concatenates eight iterators
+    return generator<TT -const -&> capture(<- a, <- b, <- c, <- d, <- e, <- f, <- g, <- h) {
+        for (itA in a) {
+            static_if (typeinfo can_copy(itA)) { yield itA } else { yield <- clone_to_move(itA) }
+        }
+        for (itB in b) {
+            static_if (typeinfo can_copy(itB)) { yield itB } else { yield <- clone_to_move(itB) }
+        }
+        for (itC in c) {
+            static_if (typeinfo can_copy(itC)) { yield itC } else { yield <- clone_to_move(itC) }
+        }
+        for (itD in d) {
+            static_if (typeinfo can_copy(itD)) { yield itD } else { yield <- clone_to_move(itD) }
+        }
+        for (itE in e) {
+            static_if (typeinfo can_copy(itE)) { yield itE } else { yield <- clone_to_move(itE) }
+        }
+        for (itF in f) {
+            static_if (typeinfo can_copy(itF)) { yield itF } else { yield <- clone_to_move(itF) }
+        }
+        for (itG in g) {
+            static_if (typeinfo can_copy(itG)) { yield itG } else { yield <- clone_to_move(itG) }
+        }
+        for (itH in h) {
+            static_if (typeinfo can_copy(itH)) { yield itH } else { yield <- clone_to_move(itH) }
+        }
+        return false
+    }
+}
+
+def concat_inplace(var a : array<auto(TT)>, b, c, d, e, f, g, h : array<auto(TT)>) {
+    //! Concatenates eight arrays in place
+    a.reserve(length(a) + length(b) + length(c) + length(d) + length(e) + length(f) + length(g) + length(h))
+    a |> push_clone_from(b)
+    a |> push_clone_from(c)
+    a |> push_clone_from(d)
+    a |> push_clone_from(e)
+    a |> push_clone_from(f)
+    a |> push_clone_from(g)
+    a |> push_clone_from(h)
+}
+
 def reverse_inplace(var buffer : array<auto(TT)>) {
     //! Reverses an array in place
     let l = length(buffer)

--- a/daslib/linq_fold_common.das
+++ b/daslib/linq_fold_common.das
@@ -700,8 +700,10 @@ var linqCalls = {
     "chunk" => LinqCall(name = "chunk"),
     "chunk_to_array" => LinqCall(name = "chunk"),
 // concatenation operations
-    "concat" => LinqCall(name = "concat", recursive = [1], inplace = true),
-    "concat_to_array" => LinqCall(name = "concat", recursive = [1], inplace = true),
+    // recursive covers every appended source (args 1..7 — N-ary concat goes to 8);
+    // the walker's `i < arg count` guard makes the extra indices safe at low arity.
+    "concat" => LinqCall(name = "concat", recursive = [1, 2, 3, 4, 5, 6, 7], inplace = true),
+    "concat_to_array" => LinqCall(name = "concat", recursive = [1, 2, 3, 4, 5, 6, 7], inplace = true),
     "prepend" => LinqCall(name = "prepend", inplace = true),
     "prepend_to_array" => LinqCall(name = "prepend", inplace = true),
     "append" => LinqCall(name = "append", inplace = true),
@@ -1619,8 +1621,7 @@ def emit_accumulator_lane(
     let isDoubleAccType = accType != null && accType.baseType == Type.tDouble
     var spec = build_accumulator_spec(opName, accName, cntName, firstName, accType, at)
     if (spec.returnExpr == null) return null
-    var perElementStmts : array<Expression?>
-    perElementStmts |> push_from <| build_accumulator_perelement_stmts(opName, accName, valBindName, firstName, cntName, valueExpr, workhorse, isDoubleAccType)
+    var perElementStmts <- build_accumulator_perelement_stmts(opName, accName, valBindName, firstName, cntName, valueExpr, workhorse, isDoubleAccType)
     var tailStmts : array<Expression?>
     tailStmts |> push <| qmacro_expr() {
         return $e(spec.returnExpr)
@@ -2945,8 +2946,7 @@ def emit_streaming_min(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Exp
             var dLess = (oc.orderName == "order_by_descending"
                 ? qmacro(_::less($i(bestKeyName), $i(xkeyName)))
                 : qmacro(_::less($i(xkeyName), $i(bestKeyName))))
-            var dPerElement : array<Expression?>
-            dPerElement |> push_from <| qmacro_block_to_array() {
+            var dPerElement <- qmacro_block_to_array() {
                 let $i(xkeyName) = $e(keyBody)
                 if (!$i(seenName)) {
                     $i(bestKeyName) = $i(xkeyName)
@@ -3105,8 +3105,7 @@ def private build_surrogate_materialize_loop(var ctx : EmitCtx; bufName, outBufN
         : qmacro($i(matItName)))
     var matHandle = (handleIsTuple ? qmacro($i(surrName)._1) : qmacro($i(surrName)))
     var matStmt = ctx.src->materialize_handle(matHandle, matItName, at)
-    var stmts : array<Expression?>
-    stmts |> push_from <| qmacro_block_to_array() {
+    var stmts <- qmacro_block_to_array() {
         $i(outBufName) |> reserve(length($i(bufName)))
         for ($i(surrName) in $i(bufName)) {
             var $i(matItName) = default<$t(rowType)>
@@ -3903,8 +3902,7 @@ def emit_reverse_distinct_forward_keeplast(var c : Captures; var ctx : EmitCtx; 
     }
     // Tail: collect survivors, sort by descending seq, materialize (deferred) or emit the stored element.
     var seqDescCmp = build_surrogate_cmp(true, at)
-    var tail : array<Expression?>
-    tail |> push_from <| qmacro_block_to_array() {
+    var tail <- qmacro_block_to_array() {
         var $i(pairsName) : array<$t(surrType)>
         $i(pairsName) |> reserve(length($i(tabName)))
         for ($i(svName) in values($i(tabName))) {
@@ -6184,8 +6182,7 @@ def emit_array_join(var c : Captures; var ctx : EmitCtx; at : LineInfo) : Expres
         pieces = build_join_standalone_pieces(joinCall, whereLam, selectLam, leadWhereLam, countOnly, keyaBody, tupAName, hashName, tupBType, isGroupJoin, "ajoin", at)
     }
     if (pieces == null) return null
-    var allStmts : array<Expression?>
-    allStmts |> push_from(pieces.preludeStmts)
+    var allStmts := pieces.preludeStmts
     if (!probeMode) {
         allStmts |> push <| qmacro_expr() {
             var $i(hashName) : table<$t(keyType); array<$t(tupBType)>>

--- a/tests/linq/test_linq_concat_nary.das
+++ b/tests/linq/test_linq_concat_nary.das
@@ -1,0 +1,119 @@
+options gen2
+require daslib/linq
+require daslib/linq_boost
+require dastest/testing_boost public
+
+require _common
+
+
+// N-ary concat (3..8 sources). The binary forms live in test_linq_concat.das;
+// this file exercises only the multi-source overloads and their fold fusion.
+
+[test]
+def test_concat3(t : T?) {
+    t |> run("3 iterators -> iterator") @(t : T?) {
+        var query = concat(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 3..6); x],
+            [iterator for(x in 6..9); x]
+        )
+        for (c, i in query, 0..9) {
+            t |> equal(c, i)
+        }
+    }
+    t |> run("3 iterators -> array") @(t : T?) {
+        let qarray = concat_to_array(
+            [iterator for(x in 0..3); x],
+            [iterator for(x in 3..6); x],
+            [iterator for(x in 6..9); x]
+        )
+        t |> success(qarray.Equal([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+    }
+    t |> run("3 arrays -> array") @(t : T?) {
+        let a = [for (x in 0..3); x]
+        let b = [for (x in 3..6); x]
+        let c = [for (x in 6..9); x]
+        let result = concat(a, b, c)
+        t |> success(result.Equal([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+    }
+    t |> run("3 complex iterators") @(t : T?) {
+        var qcomplex = concat(
+            [iterator for(x in 0..3); ComplexType(a = [x, x * 10])],
+            [iterator for(x in 3..6); ComplexType(a = [x, x * 10])],
+            [iterator for(x in 6..9); ComplexType(a = [x, x * 10])]
+        )
+        for (c, i in qcomplex, 0..9) {
+            t |> success(c.a.Equal([i, i * 10]))
+        }
+    }
+    t |> run("concat_inplace 3 arrays") @(t : T?) {
+        var a = [for (x in 0..3); x]
+        concat_inplace(a, [for (x in 3..6); x], [for (x in 6..9); x])
+        t |> success(a.Equal([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+    }
+}
+
+[test]
+def test_concat_high_arity(t : T?) {
+    t |> run("5 arrays -> array") @(t : T?) {
+        let result = concat(
+            [for (x in 0..2); x], [for (x in 2..4); x], [for (x in 4..6); x],
+            [for (x in 6..8); x], [for (x in 8..10); x]
+        )
+        t |> success(result.Equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+    }
+    t |> run("5 iterators -> iterator") @(t : T?) {
+        var query = concat(
+            [iterator for(x in 0..2); x], [iterator for(x in 2..4); x], [iterator for(x in 4..6); x],
+            [iterator for(x in 6..8); x], [iterator for(x in 8..10); x]
+        )
+        for (c, i in query, 0..10) {
+            t |> equal(c, i)
+        }
+    }
+    t |> run("8 arrays -> array") @(t : T?) {
+        let result = concat(
+            [for (x in 0..1); x], [for (x in 1..2); x], [for (x in 2..3); x], [for (x in 3..4); x],
+            [for (x in 4..5); x], [for (x in 5..6); x], [for (x in 6..7); x], [for (x in 7..8); x]
+        )
+        t |> success(result.Equal([0, 1, 2, 3, 4, 5, 6, 7]))
+    }
+    t |> run("8 iterators -> array") @(t : T?) {
+        let result = concat_to_array(
+            [iterator for(x in 0..1); x], [iterator for(x in 1..2); x], [iterator for(x in 2..3); x], [iterator for(x in 3..4); x],
+            [iterator for(x in 4..5); x], [iterator for(x in 5..6); x], [iterator for(x in 6..7); x], [iterator for(x in 7..8); x]
+        )
+        t |> success(result.Equal([0, 1, 2, 3, 4, 5, 6, 7]))
+    }
+    t |> run("concat_inplace 8 arrays") @(t : T?) {
+        var a = [for (x in 0..1); x]
+        concat_inplace(a,
+            [for (x in 1..2); x], [for (x in 2..3); x], [for (x in 3..4); x],
+            [for (x in 4..5); x], [for (x in 5..6); x], [for (x in 6..7); x], [for (x in 7..8); x]
+        )
+        t |> success(a.Equal([0, 1, 2, 3, 4, 5, 6, 7]))
+    }
+}
+
+[test]
+def test_concat3_fold(t : T?) {
+    t |> run("3-source concat fold") @(t : T?) {
+        // Each source is its own sub-pipeline — exercises recursive folding of args 0, 1, 2.
+        var q <- (
+            concat(
+                [1, 2, 3, 4, 5]._where(_ <= 2)._select(_ * 2)
+            ,
+                [6, 7, 8]._where(_ >= 7)
+            ,
+                [10, 20, 30]._select(_ + 1)
+            )
+            ._fold()
+        )
+        t |> equal(typeinfo typename(q), "array<int>")
+        t |> equal(length(q), 7)
+        let expected = [2, 4, 7, 8, 11, 21, 31]    // nolint:LINT003
+        for (i, v in 0..7, q) {
+            t |> equal(expected[i], v)
+        }
+    }
+}


### PR DESCRIPTION
## What

Expands the existing binary `concat` in `daslib/linq.das` to **N sources (3 through 8)**, replicating the `zip` arity convention already in that file.

```das
concat(a, b, c, d)                    // arrays  -> array
concat(itA, itB, itC)                 // iterators -> iterator (lazy)
concat_to_array(itA, itB, itC, itD)   // iterators -> array
concat_inplace(dst, b, c, d)          // append N into dst
```

**SQL framing:** `concat` is `UNION ALL`; it pairs with the existing linq `union` (= `UNION`, which dedups via a seen-table). So this is "the union family minus the dedup," generalized to N.

## Design (mirrors `zip`)

- Per-arity private impls `concatN_impl` / `concatN_impl_const` (clone-based, one combined `reserve(Σ lengths)`).
- Public `concat(arr…) : array`, `concat(it…) : iterator` (a **lazy generator**, matching concat's own binary `it+it` form — not zip's eager-materialize), and `concat_to_array(it…) : array`.
- `concat_inplace(dst, b, c, …)` — needed because a chained N-ary concat lowers to `concat_inplace` in the fold engine. Array-only, so each source goes through the bulk `push_clone_from` helper (combined up-front reserve → single realloc).
- **Pure forms only at arity 3+** — mixed array/iterator stays binary-only, the same rule `zip` follows ("mixed only up to two").
- **No `result_selector`** — concat appends, it doesn't transform.

## Fold

Extended concat's dispatch `recursive` list in `linq_fold_common.das` from `[1]` to `[1, 2, 3, 4, 5, 6, 7]` so **every** appended source sub-folds, not just the second (the walker's `i < arg-count` guard keeps the extra indices safe at low arity). A 3-source fusion test (`concat(p1, p2, p3)._fold()`, each source its own sub-pipeline) is added.

While touching `linq_fold_common.das`, fixed 5 pre-existing **STYLE032** clone-init sites it surfaced (4× `<-` move from a fresh temp, 1× `:=` clone from a field read).

## Tests

New file **`tests/linq/test_linq_concat_nary.das`** (the binary forms keep their existing coverage in `test_linq_concat.das`):
- `test_concat3` — 3-source array / iterator / `to_array` / `inplace` + complex element type.
- `test_concat_high_arity` — arity 5 & 8 across the same forms.
- `test_concat3_fold` — 3-source `concat(...)._fold()` fusion (each source a sub-pipeline).

Full `tests/linq`: **2007/2007** interpreted; concat + fold AOT codegen verified locally. Lint-clean on the exact changed-set, formatter clean, das2rst clean (overloads land in the existing "Concatenation operations" group).

First of a small "make concat better" arc; follow-ups: variadic `push_from`/`push_clone_from` in builtin.das, and a lint rule suggesting `concat(…)` for `push_clone` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)