### PR TITLE
blog: Drums. Drums. They are coming.

### DIFF
--- a/site/blog/_posts/mazarbul.md
+++ b/site/blog/_posts/mazarbul.md
@@ -1,0 +1,33 @@
+---
+title: Drums. Drums. They are coming.
+date: 2026-06-19 22:43:20
+tags:
+    daScript
+    strudel
+---
+
+It's all about the beat.
+
+<!-- more -->
+
+No. Not the LA pre-4th boom fest. The drums, man, the drums. In daStrudel.
+
+Ez. Load up SF2. Stolen is what Musyng does. Shtollen. That has a ring to it.
+
+One day I'll release my own SF2. Its gonna be tiny, but glorious. Or maybe I'll keep it in the family, and its gonna be bunch of code which generates it all. Just like drums.
+
+Good luck matching Stolen in its 1.1gb glory. I'm going to add SF2 surgeon for sure - smaller SF2 can be trimmed to shippable sizes. The issue remains though. Tiny demos are tiny. Generate everything. The-One-Ring.das. Not Also-The-Kick-Drum-Of-10mb-glory.wav. U can't ship Stolen anyway. The other one is also Kite-the-grey (area).
+
+My previous attempt at drums was okay. I called it beta (than nothing). This one is actually decent. All it took is the right tool. The other right tool that is; the A/B drum test has been under \examples\daStrudel\drum_compare and its fun.
+
+![Hit the drum](https://daslang.io/doc/_images/drum_compare.png)
+
+U kick the drums, switch versions, kick them again. You chat, tweak that code. And maybe get somewhere. Btw, if thats your thing - I'm game. Hit me with your drums.
+
+Now, here is something which will help. [SFX-lab](https://daslang.io/doc/reference/tutorials/daStrudel_18_sfx_lab.html) is different. Its useful.
+
+![Make the drum](https://daslang.io/doc/_images/workbench.png)
+
+Give it .wav and the code will fit the effect to it. Beats moving sliders. Then u play with til it hits u. When u done, save it and export it as code to The-Two-Ring.das. Check out my effect files - i've included all the drums.
+
+Does not have to be drum (duh). No loops yet. Its trivial, but no loops. U want loops - hit me. Hit me fast - or I find the need for loops before u. Hit me with your examples - I wants more examples. Hit me again, when it does not work. Keep the bit. Drums. Drums.


### PR DESCRIPTION
New blog post on daStrudel drums + the SFX-lab effect-fitting tool.

- First post to embed images (drum_compare.png + workbench.png, already live under `site/doc/_images/`).
- `.md`-only — `pages.yml` rebuilds the blog HTML from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)