### PR TITLE
blog: fix tags - dashes in mazarbul frontmatter + render all tags in …

### DIFF
--- a/site/blog/_posts/mazarbul.md
+++ b/site/blog/_posts/mazarbul.md
@@ -2,8 +2,8 @@
 title: Drums. Drums. They are coming.
 date: 2026-06-19 22:43:20
 tags:
-    daScript
-    strudel
+    - daScript
+    - strudel
 ---
 
 It's all about the beat.

--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -321,10 +321,10 @@ def render_index(posts: list[Entry], md) -> str:
     for p in posts:
         md.reset()
         excerpt_html = md.convert(p.excerpt_md) if p.excerpt_md else ''
-        tag = p.tags[0] if p.tags else p.tag
+        tags_html = '<br>'.join(html.escape(t) for t in p.tags) if p.tags else html.escape(p.tag)
         items.append(f"""        <div class="forge-blog-item">
             <div class="forge-blog-item__date">{html.escape(p.date)}</div>
-            <div class="forge-blog-item__tag">{html.escape(tag)}</div>
+            <div class="forge-blog-item__tag">{tags_html}</div>
             <div>
                 <div class="forge-blog-item__title"><a href="{p.slug}.html">{html.escape(p.title)}</a></div>
                 <div class="forge-blog-item__excerpt">{excerpt_html}</div>


### PR DESCRIPTION
…index

The frontmatter parser only recognizes "- item" list entries, so the dashless tags block in mazarbul.md was silently dropped (blank tag pill). Add the dashes to match every other post.

Also: render_index showed p.tags[0] only - multi-tag posts lost all but the first tag in the TOC. Join all tags with <br> so they stack vertically in the pill (no horizontal clipping in the 90px column).