### PR TITLE
builtin: variadic + recursive-flatten push_from / push_clone_from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,14 @@ Full migration table (when reading older docs that say `var inscope` or `<-` for
 - **Unqualified** `foo(x)`: resolves in the **defining** module — caller’s overloads NOT visible.
 - This is why `:=` and `delete` emit `_::clone` / `_::finalize`
 
+### Recursive flatten / variadic generics (untyped param)
+
+A generic that should accept `array<T>`, `array<array<T>>`, … (any nesting) — e.g. a flattening `push_from(dest, src)` — uses an **untyped** source param (`def f(var dest : array<auto(T)>; src)`, NOT `array<auto(TT)>`) plus `static_if (typeinfo is_array(src)) { for (x in src) f(dest, x) } else { <base> }`. **ADD it alongside** the concrete single-level overload (`array<numT>`); the concrete one out-specializes a bare untyped param, so flat sources take the fast/bulk path and the recursive form fires only for deeper nesting — zero change/risk to the existing overload. (Live example: variadic `push_from`/`push_clone_from` in `daslib/builtin.das`.)
+
+- **`array<numT>` and `array<auto(TT)>` are EQUALLY specialized** → two such same-name overloads are *ambiguous* (`error[30341] too many matching functions`). A bare untyped `src` is *less* specialized than `array<numT>`, so the concrete one wins — that's why the recursive param is untyped, not `array<auto(TT)>`. (Whether an alias should out-specialize a non-alias is an open compiler question.)
+- **Compile-time type equality:** there is **no** `typeinfo is_same_type(A, B)` (typeinfo traits take one arg). Use `typeinfo stripped_typename(x) == typeinfo stripped_typename(y)` (pattern from `daslib/algorithm.das`).
+- **`-#` / `==const` on ≥2 same-`numT` array params breaks matching** (rejects a plain `array<int>&`) — use plain `array<numT>` for fixed-arity multi-source params (`f(dest; a : array<numT>; b : array<numT>)`).
+
 ### Dot as pseudo-pipe
 
 `a.foo(b)` is sugar for `foo(a, b)` — but **only when `a` is a struct/class value** (chains: `a.foo().bar(x)` ≡ `bar(foo(a), x)`).

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -412,6 +412,46 @@ def push_from(var Arr : array<auto(numT)>; varr : numT[] -#) {
     }
 }
 
+//! Append a *nested* source: an `array<array<...numT>>` flattened into `Arr`,
+//! one array level per recursion (any depth). The single-level overloads above
+//! out-specialize this untyped form, so a flat `array<numT>` (and the
+//! numT-is-array base) take the bulk path; this fires only for deeper nesting.
+[unused_argument(Arr, src)]
+def push_from(var Arr : array<auto(numT)>; src) {
+    static_if (typeinfo is_array(src)) {
+        for (x in src) {
+            Arr |> push_from(x)
+        }
+    } else {
+        concept_assert(false, "push_from: source is not an array (or nested array) of the element type")
+    }
+}
+
+//! Append several flat source arrays in one call — one combined `reserve(Σ)`
+//! up front, then unrolls to the single-source overload per arg. A *nested*
+//! source (`array<array<...>>`) goes through the recursive `push_from(Arr, src)`
+//! overload above, not this fixed-arity form (its params are `array<numT>`).
+def push_from(var Arr : array<auto(numT)>; a : array<numT>; b : array<numT>) {
+    Arr |> reserve(long_length(Arr) + long_length(a) + long_length(b))
+    Arr |> push_from(a)
+    Arr |> push_from(b)
+}
+
+def push_from(var Arr : array<auto(numT)>; a : array<numT>; b : array<numT>; c : array<numT>) {
+    Arr |> reserve(long_length(Arr) + long_length(a) + long_length(b) + long_length(c))
+    Arr |> push_from(a)
+    Arr |> push_from(b)
+    Arr |> push_from(c)
+}
+
+def push_from(var Arr : array<auto(numT)>; a : array<numT>; b : array<numT>; c : array<numT>; d : array<numT>) {
+    Arr |> reserve(long_length(Arr) + long_length(a) + long_length(b) + long_length(c) + long_length(d))
+    Arr |> push_from(a)
+    Arr |> push_from(b)
+    Arr |> push_from(c)
+    Arr |> push_from(d)
+}
+
 //! Append every element of source array `varr` to `Arr` via clone (`:=`).
 //! Reserves the combined length up front. Each slot is zero-initialized
 //! before clone (matches single-element ``push_clone`` semantics).
@@ -474,6 +514,45 @@ def push_clone_from(var Arr : array<auto(numT)>; var varr : numT[] ==const) {
     } else {
         concept_assert(false, "can't push_clone value, which can't be cloned")
     }
+}
+
+//! Append a *nested* source via clone — `array<array<...numT>>` flattened into
+//! `Arr`, one array level per recursion (any depth). Single-level overloads
+//! out-specialize this untyped form; fires only for deeper nesting.
+[unused_argument(Arr, src)]
+def push_clone_from(var Arr : array<auto(numT)>; src) {
+    static_if (typeinfo is_array(src)) {
+        for (x in src) {
+            Arr |> push_clone_from(x)
+        }
+    } else {
+        concept_assert(false, "push_clone_from: source is not an array (or nested array) of the element type")
+    }
+}
+
+//! Append several flat source arrays in one call via clone — one combined
+//! `reserve(Σ)` up front, then unrolls to the single-source overload per arg.
+//! Nested sources go through the recursive `push_clone_from(Arr, src)` overload
+//! above, not this fixed-arity form.
+def push_clone_from(var Arr : array<auto(numT)>; a : array<numT>; b : array<numT>) {
+    Arr |> reserve(long_length(Arr) + long_length(a) + long_length(b))
+    Arr |> push_clone_from(a)
+    Arr |> push_clone_from(b)
+}
+
+def push_clone_from(var Arr : array<auto(numT)>; a : array<numT>; b : array<numT>; c : array<numT>) {
+    Arr |> reserve(long_length(Arr) + long_length(a) + long_length(b) + long_length(c))
+    Arr |> push_clone_from(a)
+    Arr |> push_clone_from(b)
+    Arr |> push_clone_from(c)
+}
+
+def push_clone_from(var Arr : array<auto(numT)>; a : array<numT>; b : array<numT>; c : array<numT>; d : array<numT>) {
+    Arr |> reserve(long_length(Arr) + long_length(a) + long_length(b) + long_length(c) + long_length(d))
+    Arr |> push_clone_from(a)
+    Arr |> push_clone_from(b)
+    Arr |> push_clone_from(c)
+    Arr |> push_clone_from(d)
 }
 
 //! Move every element of source array `varr` into `Arr` (`<-`).

--- a/doc/source/stdlib/handmade/function-builtin-push_clone_from-0x9054931c609c8774.rst
+++ b/doc/source/stdlib/handmade/function-builtin-push_clone_from-0x9054931c609c8774.rst
@@ -1,0 +1,1 @@
+Bulk-appends two source arrays ``a`` and ``b`` to ``Arr`` via clone in one call, reserving the combined length up front. Companion overloads take three or four sources; a nested ``array<array<...>>`` source is flattened by the recursive ``push_clone_from(Arr, src)`` overload instead.

--- a/doc/source/stdlib/handmade/function-builtin-push_from-0x2de6b1f15204b003.rst
+++ b/doc/source/stdlib/handmade/function-builtin-push_from-0x2de6b1f15204b003.rst
@@ -1,0 +1,1 @@
+Bulk-appends two source arrays ``a`` and ``b`` to ``Arr`` via copy in one call, reserving the combined length up front so the whole append makes a single allocation. Companion overloads take three or four sources; a nested ``array<array<...>>`` source is flattened by the recursive ``push_from(Arr, src)`` overload instead.

--- a/tests/language/array_push_from_variadic.das
+++ b/tests/language/array_push_from_variadic.das
@@ -1,0 +1,89 @@
+options gen2
+
+require dastest/testing_boost public
+
+// Variadic + nested push_from / push_clone_from (builtin.das). The binary
+// single-source forms are covered by tests/language/array.das; this file
+// exercises the fixed-arity multi-source overloads and the recursive
+// arbitrary-depth flatten. Single-source-into-fresh-array lines carry
+// nolint:STYLE032 — they deliberately test push_from, which STYLE032 would
+// otherwise suggest rewriting to `:= src`.
+
+[test]
+def test_variadic_push_from(t : T?) {
+    // fixed-arity push_from (>=2 sources -> not STYLE032; one combined reserve)
+    var b2 : array<int>
+    push_from(b2, [1, 2], [3, 4])
+    t |> equal(length(b2), 4)
+    t |> equal(b2[0], 1)
+    t |> equal(b2[3], 4)
+
+    var b3 : array<int>
+    push_from(b3, [1, 2], [3], [4, 5, 6])
+    t |> equal(length(b3), 6)
+    t |> equal(b3[0], 1)
+    t |> equal(b3[5], 6)
+
+    var b4 : array<int>
+    push_from(b4, [1], [2], [3], [4])
+    t |> equal(length(b4), 4)
+    t |> equal(b4[3], 4)
+
+    // fixed-arity push_clone_from across all arities (2/3/4 sources)
+    var dc2 : array<int>
+    push_clone_from(dc2, [10, 20], [30])
+    t |> equal(length(dc2), 3)
+    t |> equal(dc2[2], 30)
+
+    var dc3 : array<int>
+    push_clone_from(dc3, [10], [20, 30], [40])
+    t |> equal(length(dc3), 4)
+    t |> equal(dc3[3], 40)
+
+    var dc4 : array<int>
+    push_clone_from(dc4, [1], [2], [3], [4])
+    t |> equal(length(dc4), 4)
+    t |> equal(dc4[3], 4)
+}
+
+[test]
+def test_nested_push_from(t : T?) {
+    // recursive nested flatten: array<array<int>> -> array<int>
+    let nested <- [[100, 200], [300]]
+    var fl : array<int>                            // nolint:STYLE032 (deliberately testing push_from)
+    push_from(fl, nested)
+    t |> equal(length(fl), 3)
+    t |> equal(fl[0], 100)
+    t |> equal(fl[2], 300)
+
+    // recursive deep flatten (any depth)
+    let deep <- [[[7, 8], [9]]]
+    var fld : array<int>                           // nolint:STYLE032 (deliberately testing push_from)
+    push_from(fld, deep)
+    t |> equal(length(fld), 3)
+    t |> equal(fld[0], 7)
+    t |> equal(fld[2], 9)
+
+    // recursive flatten via the CLONE variant: array<array<int>> -> array<int>
+    let cnested <- [[11, 22], [33]]
+    var cfl : array<int>                           // nolint:STYLE032 (deliberately testing push_clone_from)
+    push_clone_from(cfl, cnested)
+    t |> equal(length(cfl), 3)
+    t |> equal(cfl[0], 11)
+    t |> equal(cfl[2], 33)
+
+    let cdeep <- [[[5, 6], [7]]]
+    var cfld : array<int>                          // nolint:STYLE032 (deliberately testing push_clone_from)
+    push_clone_from(cfld, cdeep)
+    t |> equal(length(cfld), 3)
+    t |> equal(cfld[0], 5)
+    t |> equal(cfld[2], 7)
+
+    // numT is itself an array: clone-append sub-arrays as elements (base, NOT flattened)
+    let src <- [[1, 2], [3]]
+    var aoa : array<array<int>>                    // nolint:STYLE032 (deliberately testing push_clone_from)
+    push_clone_from(aoa, src)
+    t |> equal(length(aoa), 2)
+    t |> equal(aoa[0][1], 2)
+    t |> equal(aoa[1][0], 3)
+}


### PR DESCRIPTION
## What

Two new shapes for `push_from` / `push_clone_from` in `daslib/builtin.das`. The existing binary single-level overloads are **untouched** — zero behavior change for current callers; this only adds capability where there was previously no matching overload.

```das
// fixed-arity multi-source (separate vars)
push_from(dst, a, b)
push_from(dst, a, b, c, d)
// recursive flatten (any nesting depth)
push_from(dst, arrayOfArrays)          // array<array<...numT>> -> flattened into dst
push_clone_from(dst, x, y)             // clone twin of both shapes
```

Second of the "make concat better" arc (follows #3224 concat). Closes the gap that arc opened: the `push_from`/`push_clone_from` multi-source rail.

## Design

- **Fixed-arity multi-source** — `push_from(dst, a, b[, c, d])`: one combined `reserve(Σ)` up front, then unrolls to the binary per source (the per-source reserves become no-ops, so it's a single allocation). Plain `array<numT>` params.
- **Recursive flatten** — `push_from(dst, src)` with an **untyped** `src`: `static_if (typeinfo is_array(src)) { for (x in src) push_from(dst, x) } else { … }`. Flattens `array<array<…>>` one level per recursion down to the binary base, any depth. The concrete single-level overload out-specializes the untyped form, so flat sources keep the bulk path and this fires only for deeper nesting. Stops at the destination element type, so an `array<array<X>>` destination appends sub-arrays *as elements* (no over-flatten).

The untyped `src` is the key: it sidesteps an overload ambiguity. `array<numT>` and `array<auto(TT)>` are *equally specialized* (so two such same-name overloads are ambiguous — `error[30341]`), but a bare untyped param is *less* specialized than `array<numT>`, so the concrete one wins cleanly. Pattern + its gotchas documented in `CLAUDE.md` (Generic function dispatch), incl. the `stripped_typename` compile-time type-equality idiom and the `-#`/`==const`-breaks-multi-param-matching note.

## Tests

`tests/language/array_push_from_variadic.das` — fixed-arity 2/3/4, recursive nested + deep, and the numT-is-array (append sub-arrays, no flatten) case, across copy and clone variants. (Binary single-source forms keep their coverage in `tests/language/array.das`.)

Suites: `tests/language` 1065/1065 interpreted **and** `-use-aot`; `linq` 2007/2007; `algorithm` 162/162.

Notes: fixed-arity is capped at 4 (the lint-collapse target + common runs) — extendable if wanted; the recursive form covers larger N via a nested source. Follow-up PR3 will add the STYLE lint rule suggesting `concat(…)` / `push_clone_from(…)` for `push_clone` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)