### PR TITLE
ci: switch all runners to standard free runners (temporary, unblock spending limit)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   pre_job:
   ###########################################################
     # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -64,7 +64,7 @@ jobs:
           - target: linux
             release_target: linux
             release_arch: x86_64
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
             archive_ext: tar.gz
             sanitizers: none
 
@@ -73,7 +73,7 @@ jobs:
           # was prohibitive for production CI. See issue #2530.
           - target: linux
             architecture: 64
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
             cmake_preset: Release
             sanitizers: asan
             build_name: linux_asan
@@ -82,7 +82,7 @@ jobs:
 
           - target: linux
             architecture: 64
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
             cmake_preset: Release
             sanitizers: tsan
             build_name: linux_tsan
@@ -91,7 +91,7 @@ jobs:
 
           - target: linux
             architecture: 64
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
             cmake_preset: Release
             sanitizers: ubsan
             build_name: linux_ubsan
@@ -101,26 +101,26 @@ jobs:
           - target: linux_arm
             release_target: linux
             release_arch: arm64
-            runner: ubuntu-24.04-arm-fat
+            runner: ubuntu-24.04-arm
             archive_ext: tar.gz
 
           - target: darwin15
             architecture: arm64
             release_target: darwin15
             release_arch: arm64
-            runner: macos-15-xlarge # Apple Silicon arm64, M2
+            runner: macos-15 # Apple Silicon arm64, M2
             architecture_string: arm64
             archive_ext: tar.gz
 
           - target: darwin26
             release_target: darwin26
             release_arch: arm64
-            runner: macos-26-xlarge # Apple Silicon arm64, M2
+            runner: macos-26 # Apple Silicon arm64, M2
             architecture_string: arm64
             archive_ext: tar.gz
 
           - target: windows
-            runner: windows-latest-fat
+            runner: windows-latest
             archive_ext: zip
 
           - target: windows
@@ -164,7 +164,7 @@ jobs:
             architecture: 64
             cmake_preset: RelWithDebInfo
             sanitizers: none
-            runner: windows-latest-fat
+            runner: windows-latest
             archive_ext: zip
             build_system: cmake
             cmake_generator: Ninja
@@ -540,7 +540,7 @@ jobs:
   ###########################################################
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
@@ -595,7 +595,7 @@ jobs:
   # and src/builtin/module_jit.cpp (PR #2838). Without this job, a Windows-touching
   # change that compiles under MSVC but breaks mingw would only surface when a
   # maintainer rebuilds locally. Same runner pool as the MSVC matrix
-  # (windows-latest-fat), separate top-level job so mingw churn doesn't risk
+  # (windows-latest), separate top-level job so mingw churn doesn't risk
   # the much-larger MSVC entries.
   #
   # dasClangBind is enabled here — find_package(Clang 22.1) matches msys2's
@@ -604,7 +604,7 @@ jobs:
   ###########################################################
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: windows-latest-fat
+    runs-on: windows-latest
     defaults:
       run:
         shell: msys2 {0}
@@ -762,7 +762,7 @@ jobs:
   ###########################################################
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: windows-latest-fat
+    runs-on: windows-latest
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
@@ -855,7 +855,7 @@ jobs:
   ###########################################################
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
     # fork PRs get a read-only GITHUB_TOKEN, so the SARIF upload would fail —
     # skip them; the post-merge master push scans their code anyway
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
       actions: read

--- a/.github/workflows/cpp_mcp_release.yml
+++ b/.github/workflows/cpp_mcp_release.yml
@@ -42,7 +42,7 @@ jobs:
       # because the `matrix` context is NOT available in a job-level `if` (only
       # github/needs/vars/inputs are), whereas `github` IS available in strategy.
       matrix:
-        include: ${{ fromJSON( github.event_name == 'pull_request' && '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"}]' || '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"},{"name":"linux-arm64","runner":"ubuntu-24.04-arm-fat","asset":"cpp-mcp-linux-arm64","ext":"tar.gz"},{"name":"darwin-arm64","runner":"macos-14","asset":"cpp-mcp-darwin-arm64","ext":"tar.gz"},{"name":"windows-x64","runner":"windows-latest","asset":"cpp-mcp-windows-x64","ext":"zip"}]' ) }}
+        include: ${{ fromJSON( github.event_name == 'pull_request' && '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"}]' || '[{"name":"linux-x86_64","runner":"ubuntu-latest","asset":"cpp-mcp-linux-x86_64","ext":"tar.gz"},{"name":"linux-arm64","runner":"ubuntu-24.04-arm","asset":"cpp-mcp-linux-arm64","ext":"tar.gz"},{"name":"darwin-arm64","runner":"macos-14","asset":"cpp-mcp-darwin-arm64","ext":"tar.gz"},{"name":"windows-x64","runner":"windows-latest","asset":"cpp-mcp-windows-x64","ext":"zip"}]' ) }}
 
     steps:
       - name: SCM Checkout

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -18,7 +18,7 @@ jobs:
   ###########################################################
   pre_job:
   ###########################################################
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -46,19 +46,19 @@ jobs:
 
         include:
           - target: linux
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
             build_system: cmake
             cmake_generator: Ninja
 
           - target: darwin15
             architecture: arm64
-            runner: macos-15-xlarge
+            runner: macos-15
             architecture_string: arm64
             build_system: cmake
             cmake_generator: Ninja
 
           - target: windows
-            runner: windows-latest-fat
+            runner: windows-latest
             build_system: cmake
             cmake_generator: Ninja
             architecture_string: x64

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ windows-latest-fat ]
+        target: [ windows-latest ]
         cmake_configuration: [ Debug, Release ]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
         Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
 
     - name: Configure CMake
-      # Generator pinned to the VS major on the windows-latest-fat image. GitHub
+      # Generator pinned to the VS major on the windows-latest image. GitHub
       # migrated it from VS2022 (v17) to VS2026 (v18); bump in lockstep (see
       # build.yml's build_windows_clangcl). On a mismatch, configure dies at
       # project() with "could not find any instance of Visual Studio".

--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   index_sweep:
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
     - name: "SCM Checkout"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   pre_job:
     ###########################################################
     # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -61,24 +61,24 @@ jobs:
           - target: linux
             release_target: linux
             release_arch: x86_64
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
             archive_ext: tar.gz
 
           - target: linux_arm
             release_target: linux
             release_arch: arm64
-            runner: ubuntu-24.04-arm-fat
+            runner: ubuntu-24.04-arm
             archive_ext: tar.gz
 
           - target: darwin26
             release_target: darwin26
             release_arch: arm64
-            runner: macos-26-xlarge # Apple Silicon arm64
+            runner: macos-26 # Apple Silicon arm64
             architecture_string: arm64
             archive_ext: tar.gz
 
           - target: windows
-            runner: windows-latest-fat
+            runner: windows-latest
             archive_ext: zip
 
           - target: windows
@@ -123,7 +123,7 @@ jobs:
           # (release_arch: arm64 via the include overlay at L53-57, which applies
           # to all linux_arm cells regardless of architecture). Lifting this
           # exclude would make the ×arm64 cell build the same bundle name on the
-          # same ARM64 hardware (ubuntu-24.04-arm-fat) and clobber via the
+          # same ARM64 hardware (ubuntu-24.04-arm) and clobber via the
           # `--clobber` flag in the upload step. Wasted CI for no extra artifact.
           - target: linux_arm
             architecture: arm64

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -20,7 +20,7 @@ jobs:
   pre_job:
   ###########################################################
     # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -48,13 +48,13 @@ jobs:
 
         include:
           - target: linux
-            runner: ubuntu-latest-fat
+            runner: ubuntu-latest
 
           - target: darwin
-            runner: macos-latest-xlarge
+            runner: macos-latest
 
           - target: windows
-            runner: windows-latest-fat
+            runner: windows-latest
 
           - target: windows
             architecture: 64
@@ -173,7 +173,7 @@ jobs:
     # end-to-end (see modules/dasLLVM/README.md "Cross-compilation").
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest-fat
+    runs-on: ubuntu-latest
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4


### PR DESCRIPTION
## Why

The org Actions **spending limit was hit**, which stops the `dascriptrunners` larger-runner group — every `-fat` / `-xlarge` lane sits `queued` indefinitely (this is what's been blocking #3231 and everything else).

daScript is a **public repo**, so standard GitHub-hosted runners are **free / unlimited**; only the larger `-fat` / `-xlarge` runners are billed (the docs are explicit: *"Larger runners are always charged for, even when used by public repositories or when you have quota available"*). Swapping every workflow to the standard equivalents unblocks CI at **zero cost** while billing is sorted.

## What

Label swaps across all workflows (`llvm_release.yml` already used standard runners — untouched):

| from | to |
|---|---|
| `ubuntu-latest-fat` | `ubuntu-latest` |
| `windows-latest-fat` | `windows-latest` |
| `ubuntu-24.04-arm-fat` | `ubuntu-24.04-arm` |
| `macos-15-xlarge` | `macos-15` |
| `macos-26-xlarge` | `macos-26` |
| `macos-latest-xlarge` | `macos-latest` |

10 files, 37/37 line swaps (string-only; no structural changes).

## Speed impact: ~none

Measured win32 build, bigger vs smaller runner: **Debug long-pole 16.3m vs 16.2m** (identical — Debug is link/IO-bound, not core-bound). Release was faster on the bigger runner but runs parallel to Debug, so no wall-clock win. So this switch is speed-neutral on the critical path while cutting cost 4–7× and freeing capacity.

## Caveats (this is temporary)

- **Resources differ**: standard runners have less disk/RAM than the `-fat`/`-xlarge` ones. Heavy lanes (LLVM, vcpkg/openssl, AOT) *may* hit disk/memory limits — that's part of "see how it goes." If a lane fails on resources, we either trim its disk usage or keep that one lane on a paid runner.
- **`macos-26`**: assumed the standard (non-xlarge) label exists alongside `macos-26-xlarge`. If not, that lane will error on "no matching runner" and we'll map it to `macos-latest`.
- **Revert plan**: switch back to the larger runners once the payment/spending limit is resolved.

This PR's own CI exercises the new standard runners (pull_request uses the changed workflow files), so it's self-validating — if it goes green, free runners work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)