### PR TITLE
ci: explicit-trigger heavy workflows (auto on PR open, manual after)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,13 @@ defaults:
     shell: bash
 
 concurrency:
-  # Key off the branch name (head_ref on PRs, ref_name on push/workflow_dispatch)
-  # so a manual dispatch and the PR-open run for the same branch share a group
-  # and cancel-in-progress dedupes them (the explicit-trigger model makes manual
-  # dispatch the common re-run path).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # Key off head-repo + branch. head_ref/ref_name dedupes a manual dispatch
+  # against the PR-open run for the same branch (the explicit-trigger re-run
+  # path); head.repo.full_name (falling back to the base repo for dispatch/push)
+  # keeps fork PRs that share a branch name (e.g. two forks' `main`) from
+  # colliding and cancelling each other. Dispatch only targets base-repo
+  # branches, so same-repo PR-open and dispatch still share a group.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,24 @@ name: build
 on:
   push:
     branches: [master]
+  # Explicit-trigger model: auto-run only on the PR open/reopen/ready events,
+  # NOT on every subsequent push (no `synchronize`). Re-run manually via
+  # the Actions "Run workflow" button (`workflow_dispatch`) on your PR branch,
+  # or `gh workflow run build.yml --ref <branch>`. Copilot review (ruleset)
+  # still runs free on every push, so iterate there without burning runners.
   pull_request:
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 defaults:
   run:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Key off the branch name (head_ref on PRs, ref_name on push/workflow_dispatch)
+  # so a manual dispatch and the PR-open run for the same branch share a group
+  # and cancel-in-progress dedupes them (the explicit-trigger model makes manual
+  # dispatch the common re-run path).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -13,9 +13,9 @@ defaults:
     shell: bash
 
 concurrency:
-  # Branch-name key so PR-open and manual workflow_dispatch runs share a group
-  # and cancel-in-progress dedupes them. See build.yml.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # head-repo + branch key: dedupes dispatch vs PR-open for the same branch,
+  # fork-collision-safe (shared branch names across forks). See build.yml.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -3,14 +3,19 @@ name: extended checks
 on:
   push:
     branches: [master]
+  # Explicit-trigger: auto only on PR open/reopen/ready; manual re-run via
+  # workflow_dispatch (Actions "Run workflow" / `gh workflow run`). See build.yml.
   pull_request:
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 defaults:
   run:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Branch-name key so PR-open and manual workflow_dispatch runs share a group
+  # and cancel-in-progress dedupes them. See build.yml.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Branch-name key so PR-open and manual workflow_dispatch runs share a group
-  # and cancel-in-progress dedupes them. See build.yml.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # head-repo + branch key: dedupes dispatch vs PR-open for the same branch,
+  # fork-collision-safe (shared branch names across forks). See build.yml.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -3,11 +3,16 @@ name: wasm_build
 on:
   push:
     branches: [master]
+  # Explicit-trigger: auto only on PR open/reopen/ready; manual re-run via
+  # workflow_dispatch (Actions "Run workflow" / `gh workflow run`). See build.yml.
   pull_request:
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Branch-name key so PR-open and manual workflow_dispatch runs share a group
+  # and cancel-in-progress dedupes them. See build.yml.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,15 @@ Full reference (per-platform generator commands, build flags, AOT debugging, exi
 - **Use GitHub MCP tools** (`mcp__github__*`) for all GitHub operations (creating PRs, listing issues, reading PRs, etc.) — they avoid shell escaping issues entirely
 - **Fallback:** If MCP tools are unavailable, use `gh` CLI with `--body-file` for any text containing backticks (they're shell escape characters in every supported shell)
 
+### CI runs on EXPLICIT trigger (not every push)
+
+The heavy CI workflows (`build`, `extended_checks`, `wasm_build`) auto-run on a PR **only when it opens** (`pull_request: types:[opened, reopened, ready_for_review]`) — **not on subsequent pushes** (no `synchronize`). This is deliberate cost control (see `skills/make_pr.md` and [[project_ci_cost_runners]]):
+
+- **Iterate for free on Copilot.** Copilot review is a ruleset check, not a runner job — it re-runs on every push at no runner cost. Push fixes, get Copilot's read, repeat, all free.
+- **Re-run the heavy CI manually when converged:** Actions → the workflow → "Run workflow" on your PR branch, or `gh workflow run build.yml --ref <branch>` (also `extended_checks.yml`, `wasm_build.yml`). A `/ci` PR-comment dispatcher is planned (needs a `CI_DISPATCH_TOKEN` PAT — `GITHUB_TOKEN` can't fire `workflow_dispatch`).
+- **Green is per-SHA.** A passing run counts only for the commit it ran on; push a new commit and the heavy checks are absent again until you re-dispatch. So **dispatch on your final commit before merging**, and merge only when that run is green. (master is not hard-gated on these checks — it's maintainer discipline; don't merge on a stale-SHA green.)
+- `doc`/`codeql` are `paths`-gated (run only when relevant files change); `msvc` is `workflow_dispatch`-only. The post-merge `push:[master]` run still validates master after each merge.
+
 ## MCP-first search
 
 Before reaching for `Bash`/`Grep`/`Read` to find a symbol or trace usages in this repo, ToolSearch the daslang MCP tool that answers the question and call it. The tools are deferred (schemas not in turn-start context) so the workflow is two calls: `ToolSearch select:mcp__daslang__<tool>` → invoke. (`defer_loading: false` in `.mcp.json` is the documented knob to flip this, but [it's currently broken upstream](https://github.com/anthropics/claude-code/issues/26844) — set it anyway, then operate as if deferred.)

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -306,6 +306,15 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 
 **Squash-from-multi-commit pattern (`git reset --soft master`)**: only safe AFTER step 0 has rebased onto `origin/master`. Otherwise the soft reset collapses the gap between local `master` and origin's into your one commit. If you forgot step 0 and already pushed a leaky PR, the fix is `git fetch origin master && git rebase origin/master && git push --force-with-lease` — git's 3-way merge drops files where your "modification" matches the already-merged content on origin/master.
 
+## 7. Trigger the heavy CI on your FINAL commit before merge
+
+The heavy workflows (`build`, `extended_checks`, `wasm_build`) **only auto-run when the PR opens** — not on later pushes (explicit-trigger model; see `CLAUDE.md` → "CI runs on EXPLICIT trigger"). So:
+
+- **While iterating** (Copilot rounds, fixes): just push. Copilot review re-runs free every push (it's a ruleset check, not a runner). Do NOT expect the build matrix to re-run on its own — and that's the point (it saves the per-iteration runner cost).
+- **When the PR is final** (Copilot dry, fixes in): **manually dispatch** the heavy CI on the latest commit — Actions → each workflow → "Run workflow" on your PR branch, or `gh workflow run build.yml --ref <branch>` (also `extended_checks.yml`, `wasm_build.yml`). They run on the branch tip and report on that SHA.
+- **Merge only when the dispatched run is green on the HEAD commit.** Green is per-SHA: a run that passed on an earlier commit does NOT vouch for new commits. If you push after dispatching, re-dispatch. master isn't hard-gated on these checks (maintainer discipline) — so the discipline is: *don't merge on a stale-SHA green.*
+- A `/ci` PR-comment dispatcher is planned (needs a `CI_DISPATCH_TOKEN` PAT; `GITHUB_TOKEN` can't fire `workflow_dispatch`). Until then, use the Actions button / `gh workflow run`.
+
 ## Quick reference
 
 | Step | Tool/Command | Fix policy |
@@ -323,4 +332,5 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | Wrap-up curation | `skills/task_wrap_up.md` | Optional. Add answers for cache misses, edit cached answers this PR invalidated |
 | `.md` stop | `git diff --name-only origin/master..HEAD \| grep '\.md$'` | If any match: STOP, list changes, ask user to review BEFORE push |
 | PR | GitHub MCP `create_pull_request` or `gh pr create` | — |
+| Trigger CI | `gh workflow run build.yml --ref <branch>` (+ `extended_checks.yml`, `wasm_build.yml`) on the FINAL commit | Heavy CI auto-runs only on PR open; dispatch manually after iterating. Merge only on a per-SHA green of HEAD |
 | Review iter | Follow `skills/pr_review_iteration.md` | One round per Copilot pass; convergence in 1-3 rounds is normal |

--- a/skills/pr_review_iteration.md
+++ b/skills/pr_review_iteration.md
@@ -2,6 +2,8 @@
 
 Use this skill after the pull request already exists. It covers the post-open loop: watching CI, triaging Copilot/human review comments, discussing verdicts with the user, applying fixes, replying, resolving threads, and re-requesting review.
 
+> **Explicit-trigger CI (important for this loop).** The heavy workflows (`build`, `extended_checks`, `wasm_build`) auto-run **only when the PR opens** — they do **NOT** re-run on later pushes (see `CLAUDE.md` → "CI runs on EXPLICIT trigger"). Consequence for iteration: **iterate on Copilot for free** (it re-runs on every push, it's a ruleset check not a runner) — push fixes, read Copilot, repeat, burning zero runner minutes. Only when the PR is converged, **manually dispatch** the heavy CI on the final commit (`gh workflow run build.yml --ref <branch>`, also `extended_checks.yml` / `wasm_build.yml`) and merge on that per-SHA green. So below, "CI re-runs on push" applies to Copilot only; the matrix is yours to fire deliberately at the end.
+
 ## 1. Watching the PR
 
 Pick a cadence — either ping the user when something interesting happens, or use `/loop` (without an interval, dynamic mode) to self-pace polls. On each tick:
@@ -25,7 +27,7 @@ If a check goes red:
 1. Identify the failing job: `gh pr checks <PR>` shows the URL; `gh run view <runID> --log-failed` fetches the log.
 2. Apply the same fix policy as Step 2 in `skills/make_pr.md`: own change → fix it; obvious pre-existing → fix it; non-obvious pre-existing → ask the user.
 3. After the fix, **re-run the gates from Step 1-5 in `skills/make_pr.md`** (lint + interpreted + AOT + Sphinx if `//!` or RST touched + format) — don't trust spot-checks. CI failures often come bundled (a missing format triggers a lint, a removed function triggers an AOT hash mismatch).
-4. Amend the squashed commit + force-push. CI re-runs automatically on push. No need to re-request review for a CI-only fix unless the diff is large.
+4. Amend the squashed commit + force-push. **Note (explicit-trigger model):** the heavy matrix does NOT re-run automatically on push — only Copilot does. To re-validate the fix you must **dispatch** the affected workflow on the new HEAD (`gh workflow run <wf> --ref <branch>`). No need to re-request review for a CI-only fix unless the diff is large.
 
 ## 3. Triaging review comments — discuss BEFORE acting
 

--- a/skills/preflight.md
+++ b/skills/preflight.md
@@ -23,16 +23,19 @@ without `EXECUTABLE_OUTPUT_PATH`). Commands are platform-neutral unless marked.
 "WSL" means the verbatim-CI recipe in `skills/wsl_ci_repro.md` — fresh clone at
 the CI ref, never a working-tree copy.
 
-## What runs on every PR
+## What runs on a PR
+
+**Explicit-trigger model (see `CLAUDE.md`):** the heavy lanes auto-run **once, when the PR opens** (`pull_request: types:[opened, reopened, ready_for_review]`) — NOT on every subsequent push. Re-run them on the final commit with `gh workflow run <wf> --ref <branch>` (or the Actions "Run workflow" button). Copilot review re-runs free on every push.
 
 | Workflow | Trigger | Jobs |
 |---|---|---|
-| `build.yml` | every PR | `build` matrix (5 targets × Debug/Release/RelWithDebInfo × sanitizers), `bundle_smoke`, `build_windows_mingw`, `build_windows_clangcl` |
-| `extended_checks.yml` | every PR | linux + darwin15-arm64 + windows, ALL release modules ON |
-| `wasm_build.yml` | every PR | emscripten build of `web/` on 3 OSes + `wasm_cross` |
+| `build.yml` | PR open (+ manual dispatch) | `build` matrix (5 targets × Debug/Release/RelWithDebInfo × sanitizers), `bundle_smoke`, `build_windows_mingw`, `build_windows_clangcl` |
+| `extended_checks.yml` | PR open (+ manual dispatch) | linux + darwin15-arm64 + windows, ALL release modules ON |
+| `wasm_build.yml` | PR open (+ manual dispatch) | emscripten build of `web/` on 3 OSes + `wasm_cross` |
 | `build_eastl.yml` | every PR | EASTL shadow-config build + no-fileio build (linux clang) |
-| `doc.yml` | only if `doc/**`, `daslib/**`, or `src/builtin/**` changed | seven doc gates |
+| `doc.yml` | `paths`-gated (`doc/**` / `daslib/**` / `src/builtin/**`) — runs on every such push, NOT converted to open-only in this pass | seven doc gates |
 | `playground-e2e.yml` | only if `site/**` / `web/examples/ui/**` changed | Playwright on the web playground |
+| `msvc.yml` | `workflow_dispatch` only | MSVC code-analysis |
 
 ## build.yml — the build matrix
 


### PR DESCRIPTION
## What

The heavy CI workflows — `build`, `extended_checks`, `wasm_build` — now auto-run **only when a PR opens** (`pull_request: types: [opened, reopened, ready_for_review]`), **not on every subsequent push** (dropped the implicit `synchronize`). Re-run them on demand:
- Actions → workflow → **Run workflow** on your PR branch, or
- `gh workflow run build.yml --ref <branch>` (also `extended_checks.yml`, `wasm_build.yml`).

`doc`/`codeql` stay `paths`-gated; `msvc` is already `workflow_dispatch`-only; the post-merge `push: [master]` run still validates master after each merge.

## Why

Cost control. **Copilot review is a ruleset check, not a runner job** — it re-runs free on every push. So the iteration loop becomes: push → free Copilot read → fix → repeat (zero runner minutes), then **deliberately fire the matrix once** on the final commit instead of on every intermediate push. During the recent spending-limit incident, a single PR's Copilot rounds would otherwise have burned ~5 full matrices; this makes it 1.

**Green is per-SHA**, so a passing run vouches only for the commit it ran on — push a new commit and the heavy checks are absent on the new HEAD until you re-dispatch. That gives "green only on the latest commit" for free (no required-status-checks needed). master is **not** hard-gated on these checks (maintainer discipline) — the discipline is: dispatch on your final commit, merge only on its green.

## Follow-up (not in this PR)

A `/ci` PR-comment dispatcher (ChatOps) would be more ergonomic than the Actions button, but the default `GITHUB_TOKEN` **can't** fire `workflow_dispatch` (GitHub recursion-prevention), so it needs a stored `CI_DISPATCH_TOKEN` PAT (scope: actions:write). Deferred until that secret exists.

## Docs

- `CLAUDE.md` → GitHub Operations → new "CI runs on EXPLICIT trigger" section
- `skills/make_pr.md` → new step 7 ("trigger the heavy CI on your final commit before merge") + quick-ref row
- `skills/pr_review_iteration.md` → explicit-trigger callout + corrected "CI re-runs on push" (now Copilot-only)
- `skills/preflight.md` → "What runs on a PR" table updated

## Self-validating

This PR's own CI exercises the new triggers — the matrix should auto-run once now (on `opened`); after that, pushes won't re-trigger it and I'll dispatch manually. If you see the build matrix run here, the change works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)