### PR TITLE
fix(stack): keep finally-block locals in distinct slots (no reuse)

### DIFF
--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -454,6 +454,12 @@ namespace das {
             block->stackVarTop = allocateStack(0);
             block->stackCleanVars.clear();
             if ( inStruct ) return;
+            // A block with a `finally` section runs that section on EVERY exit, including
+            // an early return that precedes a later variable's declaration. Disable stack
+            // reuse for the whole block so its locals keep distinct slots and the
+            // block-entry memzero (SimulateVisitor::visit(ExprBlock*)) stays valid when
+            // the finally fires before a variable's initializer ran.
+            if ( block->finalList.size() ) doNotOptimize++;
             if ( block->isClosure ) {
                 blocks.push_back(block);
             }
@@ -470,6 +476,7 @@ namespace das {
             pushSp();
         }
         virtual ExpressionPtr visit ( ExprBlock * block ) override {
+            if ( !inStruct && block->finalList.size() ) doNotOptimize--;
             auto top = inStruct ? stackTop : popSp().maxStack;
             block->stackVarBottom = top;
 

--- a/tests/bare_block/finally_stack_reuse.das
+++ b/tests/bare_block/finally_stack_reuse.das
@@ -1,0 +1,37 @@
+// Regression: a `finally` (here via daslib/defer) runs on EVERY block exit, including
+// an early `return` that lexically precedes a later variable's declaration. The
+// interpreter zeroes such locals at block entry, but the stack-reuse optimization
+// could hand a finally-referenced local's slot to an earlier sub-scope and clobber
+// the zero -- so the finally saw garbage (and crashed when it dereferenced a pointer
+// local). The stack allocator now disables slot reuse for blocks that have a `finally`,
+// so those locals keep distinct, zeroed slots when the finally fires before their
+// initializer ran.
+options gen2
+require dastest/testing_boost public
+require daslib/defer
+
+var g_seen_int = -1
+
+def private trigger_int(early : bool) {
+    if (early) {
+        // sub-scope locals occupying the slot `x` would otherwise reuse on this path
+        var junk : int[16]
+        for (i in range(16)) {
+            junk[i] = 0x40000000 + i
+        }
+        return
+    }
+    var x = 12345 // nolint:LINT003 - must stay a slot-backed local; let would const-fold it
+    defer() {
+        g_seen_int = x   // on the early path x is never initialized; must read as 0, not garbage
+    }
+}
+
+[test]
+def test_finally_local_zeroed_on_early_exit(t : T?) {
+    t |> run("finally sees a zeroed local on an early exit before its declaration") @(t : T?) {
+        g_seen_int = -1
+        trigger_int(true)
+        t |> equal(g_seen_int, 0)
+    }
+}


### PR DESCRIPTION
## Symptom

A `defer`'d cleanup crashes when a function takes an early `return` *before* the deferred resource is declared. Minimal shape:

```das
def main : int {
    if (cfg.help) { print_help(...); return 0 }   // early exit
    var p = open_something()                        // not reached on --help
    defer() { close_something(p) }                  // runs anyway -> p is garbage -> crash
}
```

`defer` lowers to the block's `finally`, which runs on **every** block exit — including the early `return` above, which precedes `p`'s declaration.

## Root cause

The interpreter already zeroes a finally-block's locals at block entry (the memzero in `SimulateVisitor::visit(ExprBlock*)`, gated on `finalList`, with the comment *"bad scenario we fight is ( in scope X ; return ; in scope Y )"*). **But the stack-reuse optimization defeats it:** `popSp()` restores `stackTop` on sub-scope exit, so a later finally-referenced local can reuse a slot that an *earlier* sub-scope on the early-return path writes into — clobbering the zero. The finally then reads garbage (and dereferences it for a pointer local → access violation).

AOT never hits this: its `finallyBeforeBody` path pre-declares every block variable as distinct, `memset`-zeroed storage.

## Fix

`ast_allocate_stack.cpp`: bump the existing `doNotOptimize` counter while inside a block that has a `finalList` (balanced across `preVisit`/`visit` of `ExprBlock`). That block's locals then keep **distinct** slots, so the block-entry memzero stays valid when the finally fires before a local's initializer ran. It's the interpreter analog of AOT's distinct-storage approach. No effect on blocks without a `finally`.

## Tests

- `tests/bare_block/finally_stack_reuse.das` — a `finally` referencing a local declared after an early `return`; asserts the local reads as `0` (not clobbered garbage). Fails before the fix, passes after.
- Full suite green: **10405 passed, 0 failed, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)