### PR TITLE
audio_wav: 16/24/32-bit PCM read; SFX Lab trimmer + fit-length fix

### DIFF
--- a/examples/daStrudel/sfx_lab/main.das
+++ b/examples/daStrudel/sfx_lab/main.das
@@ -43,6 +43,8 @@ var g_ref_wave : array<float>
 var g_ref_spec : array<float>
 var g_ref_name = "(no reference loaded)"
 var g_ref_path = ""              // full path of the loaded reference (saved as mimic_target)
+var g_trim_init = false          // one-time init of the trim-gate slider value
+var g_trim_info = ""             // last trim result (ms trimmed off each end), shown under the ref name
 var g_show_ref = true            // overlay the reference on the mix plots
 var g_fit : FitScore             // current reference-vs-mix fit (valid when g_have_fit)
 var g_ref_feat : SfxFeatures
@@ -316,6 +318,16 @@ def private load_to_mono44k(src : array<float>; src_rate, src_ch : int) : array<
     return <- out
 }
 
+//! Recompute the reference's derived data (waveform, spectrum, spectrogram, fit, levels) after the
+//! samples in g_ref change — shared by load_reference and trim_reference.
+def private refresh_reference() {
+    downsample(g_ref, g_ref_wave, 2000)
+    compute_spectrum(g_ref, g_ref_spec)
+    g_ref_spectro <- spectrogram(g_ref, SR, SPEC_FRAMES, SPEC_BINS, SPEC_FMAX)
+    recompute_fit()
+    update_levels()   // match the audition + export levels to the reference
+}
+
 def load_reference(path : string) {
     var samples : array<float>
     var sr = SR
@@ -327,15 +339,45 @@ def load_reference(path : string) {
     }
     g_ref <- load_to_mono44k(samples, sr, ch)
     delete samples
-    downsample(g_ref, g_ref_wave, 2000)
-    compute_spectrum(g_ref, g_ref_spec)
-    g_ref_spectro <- spectrogram(g_ref, SR, SPEC_FRAMES, SPEC_BINS, SPEC_FMAX)
     g_ref_name = "{base_name(path)}  ({sr} Hz, {ch} ch)"
     g_ref_path = path
+    g_trim_info = ""
     g_show_ref = true
     REF_SHOW.value = true
-    recompute_fit()
-    update_levels()   // match the audition + export levels to the freshly-loaded reference
+    refresh_reference()
+}
+
+//! Trim leading + trailing near-silence from the loaded reference (button-triggered, both ends).
+//! The gate is TRIM_DB dB below peak; raise it to cut a soft attack/whoosh, lower it to keep more.
+//! Reports the ms cut off each end in g_trim_info. Re-trimming at the same gate is a no-op.
+def trim_reference() {
+    let n = length(g_ref)
+    return if (n == 0)
+    var pk = 0.0
+    for (s in g_ref) {
+        pk = max(pk, abs(s))
+    }
+    return if (pk <= 0.0)
+    let thr = pk * pow(10.0, TRIM_DB.value / 20.0)
+    var lo = 0
+    while (lo < n && abs(g_ref[lo]) < thr) {
+        lo++
+    }
+    var hi = n - 1
+    while (hi > lo && abs(g_ref[hi]) < thr) {
+        hi--
+    }
+    return if (lo >= hi || (lo == 0 && hi == n - 1))   // all below the gate, or nothing to trim
+    var trimmed : array<float>
+    trimmed |> reserve(hi - lo + 1)
+    for (i in range(lo, hi + 1)) {
+        trimmed |> push(g_ref[i])
+    }
+    g_ref <- trimmed
+    refresh_reference()
+    let lead_ms = int(double(lo) / double(SR) * 1000.0lf)
+    let tail_ms = int(double(n - 1 - hi) / double(SR) * 1000.0lf)
+    g_trim_info = "trimmed -{lead_ms}ms lead / -{tail_ms}ms tail  (gate {int(TRIM_DB.value)} dB)"
 }
 
 def do_save_sound(path : string) {
@@ -382,7 +424,7 @@ def do_export_das(path : string) {
     if (length(leaf) > 4 && leaf |> ends_with(".das")) {
         leaf = slice(leaf, 0, length(leaf) - 4)
     }
-    var doc <- current_sound()
+    let doc <- current_sound()
     fwrite(path, emit_das(doc, leaf, false))
 }
 
@@ -1387,10 +1429,23 @@ def reference_panel() {
     if (icon_button(REFPLAY, (glyph = "play", tip = "Play the reference"))) {
         play_buf_copy(g_ref)
     }
+    same_line()
+    if (button(REFTRIM, (text = "trim silence"))) {
+        trim_reference()
+    }
     same_line(REF_SL2)
     checkbox(REF_SHOW, (text = "overlay on mix"))
     g_show_ref = REF_SHOW.value
     text(REF_NAME, (text = g_ref_name))
+    if (!g_trim_init) {
+        TRIM_DB.value = -24.0
+        g_trim_init = true
+    }
+    TRIM_DB.bounds = (-60.0f, -6.0f)
+    slider_float(TRIM_DB, (text = "trim gate (dB below peak)"))
+    if (!empty(g_trim_info)) {
+        text(REF_TRIMINFO, (text = g_trim_info))
+    }
     plot(REF_WAVE, (title = "reference waveform", size = float2(-1.0f, 120.0f), flags = ImPlotFlags.None)) {
         setup_axes("sample", "amp", ImPlotAxisFlags.AutoFit, ImPlotAxisFlags.AutoFit)
         setup_legend(ImPlotLocation.NorthEast)
@@ -1865,7 +1920,7 @@ struct ExportDasArgs {
 def sfx_export_das(input : JsonValue?) : JsonValue? {
     let args = from_JV(input, type<ExportDasArgs>)
     if (empty(args.path)) return JV("pass a path arg")
-    var doc <- current_sound()
+    let doc <- current_sound()
     let src = emit_das(doc, args.name, args.pitched)
     if (!fwrite(args.path, src)) return JV("write failed: {args.path}")
     return JV("exported {args.name} ({length(g_layers)} layers) to {args.path}")

--- a/examples/daStrudel/sfx_lab/sfx_analysis.das
+++ b/examples/daStrudel/sfx_lab/sfx_analysis.das
@@ -336,7 +336,8 @@ def private norm_db(var s : array<float>) {
 // blind spots of the single-window linear-cosine spectral_fit.
 def public spectral_evo_fit(a, b : array<float>; rate : int) : float {
     if (empty(a) || empty(b)) return 0.0
-    let L = min(min(length(a), length(b)), rate)   // shared absolute window, up to ~1 s
+    let longer = max(length(a), length(b))           // shared absolute window: span the LONGER, zero-pad the shorter
+    let L = min(longer, rate)                          // up to ~1 s
     let NF = 32
     let NB = 40
     let FMAX = 12000.0
@@ -614,7 +615,8 @@ def public spectral_dist(a, b : array<float>; rate : int) : float {
     if (empty(a) || empty(b)) return 1.0
     var na <- peak_normalized(a)
     var nb <- peak_normalized(b)
-    let L = min(min(length(na), length(nb)), rate)
+    let longer = max(length(na), length(nb))         // span the LONGER (zero-pad the shorter's tail) so a duration mismatch is penalized, not truncated away
+    let L = min(longer, rate)                          // capped at ~1 s
     let NF = 32
     let NB = 40
     let FMAX = 12000.0

--- a/modules/dasAudio/audio/audio_wav.das
+++ b/modules/dasAudio/audio/audio_wav.das
@@ -41,7 +41,7 @@ def public read_wav(fname : string; var samples : array<float>&; var sample_rate
             cursor += 4
             cursor += 2
             fmt_bits = read_wav_u16(raw, cursor)
-            cursor += int(chunk_size) - 16
+            cursor += max(int(chunk_size) - 16, 0)   // never move the cursor backwards on a malformed (< 16) fmt chunk
         } elif (chunk_id == "data") {
             data_offset = cursor
             data_size = int(chunk_size)
@@ -53,12 +53,17 @@ def public read_wav(fname : string; var samples : array<float>&; var sample_rate
             cursor ++
         }
     }
-    // integer PCM only — format 1, or extensible (0xFFFE) which is PCM in practice. Float (format 3) is not supported yet.
-    return false if (data_offset == 0 || (fmt_format != 1 && fmt_format != int(0xFFFE)))
+    // integer PCM only (format 1). Extensible (0xFFFE) and float (format 3) are rejected: we don't parse the
+    // extensible sub-format GUID, so accepting 0xFFFE could silently mis-decode an extensible-float WAV as int.
+    return false if (data_offset == 0 || fmt_format != 1)
     let bytes_per = fmt_bits / 8
     return false if (bytes_per != 2 && bytes_per != 3 && bytes_per != 4)   // 16 / 24 / 32-bit PCM
     sample_rate = fmt_rate
     channels = fmt_channels
+    let avail = length(raw) - data_offset
+    if (data_size > avail) {
+        data_size = avail   // a truncated / over-claimed data chunk must not read past the buffer
+    }
     let num_samples = data_size / bytes_per
     samples |> resize(num_samples)
     var c = data_offset

--- a/modules/dasAudio/audio/audio_wav.das
+++ b/modules/dasAudio/audio/audio_wav.das
@@ -2,7 +2,7 @@ options gen2
 options indenting = 4
 
 module audio_wav shared private
-//! WAV file reading and writing (16-bit PCM format).
+//! WAV file reading (16/24/32-bit integer PCM) and writing (16-bit PCM).
 
 require daslib/fio
 require math
@@ -28,13 +28,14 @@ def public read_wav(fname : string; var samples : array<float>&; var sample_rate
     var fmt_channels = 0
     var fmt_rate = 0
     var fmt_bits = 0
+    var fmt_format = 1
     var data_offset = 0
     var data_size = 0
     while (cursor < length(raw) - 8) {
         let chunk_id = read_wav_tag(raw, cursor)
         let chunk_size = read_wav_u32(raw, cursor)
         if (chunk_id == "fmt ") {
-            cursor += 2
+            fmt_format = read_wav_u16(raw, cursor)
             fmt_channels = read_wav_u16(raw, cursor)
             fmt_rate = int(read_wav_u32(raw, cursor))
             cursor += 4
@@ -52,21 +53,34 @@ def public read_wav(fname : string; var samples : array<float>&; var sample_rate
             cursor ++
         }
     }
-    if (data_offset == 0 || fmt_bits != 16) return false
+    // integer PCM only — format 1, or extensible (0xFFFE) which is PCM in practice. Float (format 3) is not supported yet.
+    return false if (data_offset == 0 || (fmt_format != 1 && fmt_format != int(0xFFFE)))
+    let bytes_per = fmt_bits / 8
+    return false if (bytes_per != 2 && bytes_per != 3 && bytes_per != 4)   // 16 / 24 / 32-bit PCM
     sample_rate = fmt_rate
     channels = fmt_channels
-    let num_samples = data_size / 2
+    let num_samples = data_size / bytes_per
     samples |> resize(num_samples)
     var c = data_offset
     for (i in range(num_samples)) {
-        let lo = int(raw[c])
-        let hi = int(raw[c + 1])
-        var v = lo | (hi << 8)
-        if (v >= int(0x8000)) {
-            v -= int(0x10000)
+        if (bytes_per == 2) {
+            var v = int(raw[c]) | (int(raw[c + 1]) << 8)
+            if (v >= int(0x8000)) {
+                v -= int(0x10000)
+            }
+            samples[i] = float(v) / 32768.0
+        } elif (bytes_per == 3) {
+            var v = int(raw[c]) | (int(raw[c + 1]) << 8) | (int(raw[c + 2]) << 16)
+            if (v >= int(0x800000)) {
+                v -= int(0x1000000)
+            }
+            samples[i] = float(v) / 8388608.0
+        } else {
+            // 32-bit: pack as unsigned then reinterpret to signed via int(), avoiding shift overflow on the sign bit
+            let u = uint(raw[c]) | (uint(raw[c + 1]) << 8u) | (uint(raw[c + 2]) << 16u) | (uint(raw[c + 3]) << 24u)
+            samples[i] = float(int(u)) / 2147483648.0
         }
-        samples[i] = float(v) / 32768.0
-        c += 2
+        c += bytes_per
     }
     return true
 }

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -210,6 +210,7 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_modal.das
         tests/strudel/test_sfx.das
         tests/audio/test_hrtf_budget.das
+        tests/audio/test_wav.das
     )
 ENDIF()
 

--- a/tests/audio/test_wav.das
+++ b/tests/audio/test_wav.das
@@ -67,7 +67,12 @@ def test_read_wav_bit_depths(t : T?) {
         let sr = 44100
         let want = [0.0, 0.5, -0.5, 0.25, 0.999, -0.999]
         for (bits in [16, 24, 32]) {
-            let path = "das_read_wav_test_{bits}.wav"   // cwd-relative + removed after (matches tests/fio)
+            let tmp = create_temp_file_result("das_read_wav_test", ".wav")   // unique writable path (no cwd assumptions / collisions)
+            if (!(tmp is value)) {
+                t |> success(false, "temp file created ({bits}-bit)")
+                continue
+            }
+            let path = tmp as value
             let bytes <- build_wav(bits, want, sr)
             var wrote = false
             fopen(path, "wb") $(f) {

--- a/tests/audio/test_wav.das
+++ b/tests/audio/test_wav.das
@@ -1,0 +1,95 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require audio/audio_wav
+require daslib/fio
+require strings
+require math
+
+// Exercises read_wav's integer-PCM decode paths (16 / 24 / 32-bit). write_wav only
+// emits 16-bit, so the wider depths can't round-trip through the module — instead we
+// hand-build a minimal mono RIFF/fmt/data WAV in memory at each depth (no binary
+// fixtures committed) and assert read_wav reconstructs the samples, rate, and channels.
+
+def private push_le(var a : array<uint8>; v, nbytes : int) {
+    for (i in range(nbytes)) {
+        a |> push(uint8((v >> (i * 8)) & 0xFF))   // nolint: PERF006 — 2..4 bytes, reserve is noise
+    }
+}
+
+def private push_tag(var a : array<uint8>; s : string) {
+    peek_data(s) $(bytes) {
+        for (b in bytes) {
+            a |> push(b)   // nolint: PERF022 — peek_data yields a temp (const#); push_from rejects it
+        }
+    }
+}
+
+// Encode `samples` (-1..1) as signed little-endian PCM at `bits` depth, wrapped in a
+// canonical mono WAV container.
+def private build_wav(bits : int; samples : array<float>; sr : int) : array<uint8> {
+    let bytes_per = bits / 8
+    var data : array<uint8>
+    for (s in samples) {
+        var v = 0
+        if (bits == 16) {
+            v = clamp(int(s * 32768.0), -32768, 32767)
+        } elif (bits == 24) {
+            v = clamp(int(s * 8388608.0), -8388608, 8388607)
+        } else {
+            v = int(s * 2147483647.0)
+        }
+        push_le(data, v, bytes_per)
+    }
+    let data_size = length(data)
+    var w : array<uint8>
+    push_tag(w, "RIFF")
+    push_le(w, 36 + data_size, 4)
+    push_tag(w, "WAVE")
+    push_tag(w, "fmt ")
+    push_le(w, 16, 4)                // fmt chunk size
+    push_le(w, 1, 2)                 // format = integer PCM
+    push_le(w, 1, 2)                 // channels = mono
+    push_le(w, sr, 4)
+    push_le(w, sr * bytes_per, 4)    // byte rate (mono)
+    push_le(w, bytes_per, 2)         // block align (mono)
+    push_le(w, bits, 2)
+    push_tag(w, "data")
+    push_le(w, data_size, 4)
+    w |> push_from(data)
+    return <- w
+}
+
+[test]
+def test_read_wav_bit_depths(t : T?) {
+    t |> run("read_wav decodes 16 / 24 / 32-bit integer PCM (mono)") @(t : T?) {
+        let sr = 44100
+        let want = [0.0, 0.5, -0.5, 0.25, 0.999, -0.999]
+        for (bits in [16, 24, 32]) {
+            let path = "das_read_wav_test_{bits}.wav"   // cwd-relative + removed after (matches tests/fio)
+            let bytes <- build_wav(bits, want, sr)
+            var wrote = false
+            fopen(path, "wb") $(f) {
+                if (f != null) {
+                    fwrite(f, bytes)
+                    wrote = true
+                }
+            }
+            t |> success(wrote, "wrote {bits}-bit wav")
+            var got : array<float>
+            var gsr = 0
+            var gch = 0
+            let ok = read_wav(path, got, gsr, gch)
+            t |> success(ok, "read_wav ok ({bits}-bit)")
+            t |> success(gsr == sr, "rate preserved ({bits}-bit)")
+            t |> success(gch == 1, "mono ({bits}-bit)")
+            t |> success(length(got) == length(want), "sample count ({bits}-bit)")
+            let tol = bits == 16 ? 0.0001 : 0.000002   // 1 quantum at the depth + truncation slack
+            for (i in range(min(length(got), length(want)))) {
+                t |> success(abs(got[i] - want[i]) < tol, "sample {i} within tol ({bits}-bit)")
+            }
+            remove(path)
+        }
+    }
+}


### PR DESCRIPTION
Three small SFX-Lab / audio improvements (tail of the SFX Lab arc).

## audio_wav: 16/24/32-bit integer PCM read

`read_wav` rejected anything but 16-bit, so 24-bit reference clips (common for hi-res audio) failed to load. It now captures the `fmt` format code and decodes 16/24/32-bit signed integer PCM (mono or stereo, interleaved); float (format 3) is still rejected. `write_wav` stays 16-bit.

Adds `tests/audio/test_wav.das`: hand-builds a minimal mono WAV at each depth in memory, writes it, and asserts `read_wav` reconstructs the samples / rate / channels (write_wav only emits 16-bit, so the wider depths can't round-trip through the module). Interp green; registered for AOT in `tests/aot/CMakeLists.txt`.

## SFX Lab: silence trimmer

A `trim silence` button in the reference panel cuts leading + trailing silence from the loaded clip, gated by a `trim gate (dB below peak)` slider (default -24 dB). Button-triggered (not on load), and reports the ms trimmed off each end.

## sfx_analysis: fit spans the longer duration (zero-pad), not the shorter

The spectral fit / evo windows used `min(len_a, len_b)` — truncating the comparison to the shorter clip. So trimming the reference shrank the fit window, and a generated sound longer than the reference had its extra tail ignored rather than penalized. Switched to the longer duration with the shorter zero-padded (matching `envelope_fit`'s existing design; `log_spectro` already zero-pads past the buffer end). A duration mismatch now costs fit instead of hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)