### PR TITLE
lint: STYLE033 chain-receiver form + STYLE032/033 can_clone gate

### DIFF
--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -38,8 +38,8 @@ module style_lint shared private
 //!   STYLE029 — non-public 'require X' used only for ONE module X re-exports — require it directly and drop X (skipped when ≥2 re-exports are used: aggregation facade; or when X provides macros or [init])
 //!   STYLE030 — non-public 'require X' that is entirely unused — no symbol from X (or anything it re-exports) is referenced; drop it (skipped when X provides any macro or an [init], or only re-exports builtins used through it, or X or its public re-export closure exports a function matching an unresolved call inside an uninstanced generic body). Suppress a deliberate keep with '// nolint:STYLE030'
 //!   STYLE031 — table<K;V> (or table<K> set) var initialized via a run of insert / '[]=' statements; use a table (set) literal move-assign
-//!   STYLE032 — array<T> with empty default-init then a single 'push_from' / 'push_clone_from' from another array<T>; that is a clone — use 'var w := SRC' (clone-assign)
-//!   STYLE033 — run of >=2 'push_from' / 'push_clone_from' from arrays; into a fresh-empty array that is a concatenation (use 'var c <- concat(s1, s2, ...)', needs 'require daslib/linq'); into an existing array collapse to one variadic call of the same name ('dst |> push_from(...)' or 'dst |> push_clone_from(...)')
+//!   STYLE032 — array<T> with empty default-init then a single 'push_from' / 'push_clone_from' from another array<T>; that is a clone — use 'var w := SRC' (clone-assign). Cloneable elements only (a copyable-but-not-cloneable element such as a lambda stays silent — ':=' would not compile)
+//!   STYLE033 — run of >=2 'push_from' / 'push_clone_from' from arrays; into a fresh-empty array that is a concatenation (use 'var c <- concat(s1, s2, ...)', needs 'require daslib/linq'; cloneable elements only, as STYLE032); into an existing array — plain var or a pure chain like 'obj.arr' / 'bags[0].nums' — collapse to one variadic call of the same name ('dst |> push_from(...)' or 'dst |> push_clone_from(...)')
 
 require daslib/ast_boost
 require daslib/is_local
@@ -819,6 +819,7 @@ class StyleLintVisitor : AstVisitor {
         }
         check_style012_chain_runs(blk)
         check_style033_existing_runs(blk)
+        check_style033_existing_chain_runs(blk)
         let n = length(blk.list)
         for (i in range(n - 1)) {
             let cur = blk.list[i]
@@ -1474,10 +1475,13 @@ class StyleLintVisitor : AstVisitor {
         }
         if (idx < 0 || idx + 1 >= n) return
         for (v in elet.variables) {
-            // Only flag uninitialized array<T> locals from user code.
+            // Only flag uninitialized array<T> locals from user code, and only when the
+            // element is cloneable — `:=` / concat clone the source, so a lambda array
+            // (copyable but NOT cloneable) would not compile under either suggestion.
             if (v.init != null
                 || v.flags.generated || v.flags.inScope
-                || v._type == null || v._type.baseType != Type.tArray) continue
+                || v._type == null || v._type.baseType != Type.tArray
+                || v._type.firstType == null || !v._type.firstType.canClone) continue
             // Count the contiguous run of single-source bulk clone/copy-from-array
             // calls on v. 1 => clone (STYLE032 `:=`); >=2 => concat (STYLE033).
             var count = 0
@@ -1495,17 +1499,21 @@ class StyleLintVisitor : AstVisitor {
         }
     }
 
-    def bulk_src_matches_dest(src : Expression? const; dest : Variable? const) : bool {
+    def bulk_src_matches_elem(src : Expression? const; destElem : TypeDecl? const) : bool {
         //! A genuine bulk clone/copy: `src` is an `array<E>` whose element type E equals
-        //! `dest`'s element type. A *nested* source (`array<array<E>>` into a flat
-        //! `array<E>`, or any deeper mismatch) binds the recursive-flatten
-        //! push_from(Arr, src) overload (builtin.das) — that is a flatten, NOT a
-        //! `:=`/concat, so it must NOT match. A C-array source (tFixedArray) is not
-        //! tArray and has no clean array<T> rewrite either.
+        //! `destElem`. A *nested* source (`array<array<E>>` into a flat `array<E>`, or any
+        //! deeper mismatch) binds the recursive-flatten push_from(Arr, src) overload
+        //! (builtin.das) — that is a flatten, NOT a `:=`/concat/variadic-collapse, so it
+        //! must NOT match. A C-array source (tFixedArray) is not tArray and has no clean
+        //! array<T> rewrite either.
         if (src == null || src._type == null || src._type.baseType != Type.tArray
-            || src._type.firstType == null
-            || dest == null || dest._type == null || dest._type.firstType == null) return false
-        return describe(src._type.firstType) == describe(dest._type.firstType)
+            || src._type.firstType == null || destElem == null) return false
+        return describe(src._type.firstType) == describe(destElem)
+    }
+
+    def bulk_src_matches_dest(src : Expression? const; dest : Variable? const) : bool {
+        if (dest == null || dest._type == null) return false
+        return bulk_src_matches_elem(src, dest._type.firstType)
     }
 
     def is_array_clone_init_call(call : ExprCall?; target : Variable?) : bool {
@@ -1578,6 +1586,55 @@ class StyleLintVisitor : AstVisitor {
             if (count >= 2 && count <= MAX_VARIADIC_PUSH_ARITY
                 && !run_preceded_by_empty_array_decl(blk, i, target)) {
                 style_warning("STYLE033: run of {count} `{fname}` calls into '{target.name}' — collapse to one variadic call `{target.name} |> {fname}(s1, s2, ...)`", blk.list[i].at)
+            }
+            i += count
+        }
+    }
+
+    // --- STYLE033 (existing-array CHAIN form): run of >=2 into `obj.arr` / `fo[3].bar` ---
+
+    def bulk_from_chain_receiver(stmt : Expression const?; var fname : string&) : Expression const? {
+        //! Like bulk_from_call_target but for a pure-CHAIN destination (>=1 field/index link,
+        //! e.g. `obj.arr`): when stmt is `<chain> |> push_from/push_clone_from(SRC)` (2 args,
+        //! SRC an array<E> with E == chain element type — bulk append, not flatten), return the
+        //! receiver chain and set fname; else null. Plain ExprVar receivers (link_count 0) are
+        //! left to bulk_from_call_target's variable form, so the two never double-fire.
+        if (stmt == null || stmt.genFlags.generated || !(stmt is ExprCall)) return null
+        let call = stmt as ExprCall
+        if (call.func == null || call.func.fromGeneric == null
+            || length(call.arguments) != 2) return null
+        let isFrom = call.func.fromGeneric.name == "push_from"
+        let isCloneFrom = call.func.fromGeneric.name == "push_clone_from"
+        if (!isFrom && !isCloneFrom) return null
+        let recv = call.arguments[0]
+        if (recv == null || recv._type == null || recv._type.baseType != Type.tArray
+            || !is_pure_chain(recv) || chain_link_count(recv) < 1
+            || !bulk_src_matches_elem(call.arguments[1], recv._type.firstType)) return null
+        fname = isFrom ? "push_from" : "push_clone_from"
+        return recv
+    }
+
+    def check_style033_existing_chain_runs(blk : ExprBlock?) : void {
+        if (current_function != null && current_function.fromGeneric != null) return
+        let n = length(blk.list)
+        var i = 0
+        while (i < n) {
+            var fname = ""
+            let recv = bulk_from_chain_receiver(blk.list[i], fname)
+            if (recv == null) {
+                i++
+                continue
+            }
+            var count = 1
+            while (i + count < n) {
+                var fname2 = ""
+                let nrecv = bulk_from_chain_receiver(blk.list[i + count], fname2)
+                if (nrecv == null || fname2 != fname || !chain_equal(recv, nrecv)) break
+                count++
+            }
+            if (count >= 2 && count <= MAX_VARIADIC_PUSH_ARITY) {
+                let cd = chain_describe(recv)
+                style_warning("STYLE033: run of {count} `{fname}` calls into '{cd}' — collapse to one variadic call `{cd} |> {fname}(s1, s2, ...)`", blk.list[i].at)
             }
             i += count
         }

--- a/utils/lint/tests/style033_concat_run.das
+++ b/utils/lint/tests/style033_concat_run.das
@@ -7,18 +7,31 @@ options gen2
 //     (which handles the single-source case with `var c := SRC`).
 //   * into an EXISTING (already-live) array it collapses to a single variadic call
 //     of the same name — `dst |> push_from(...)` or `dst |> push_clone_from(...)`
-//     (the builtin fixed-arity overloads).
+//     (the builtin fixed-arity overloads). This works for a plain variable receiver
+//     (`dst`) AND a pure-chain receiver (`obj.arr`, `bags[0].nums`).
 //
 // Caps: concat tops out at 8 sources, the variadic push overloads at 4 — a run
 // longer than its target shape can express stays silent (no invalid suggestion).
 // A C-array (fixed-array) source has no clean array<T> rewrite, so it stays silent.
 // A nested source (array<array<E>> into a flat array<E>) binds the recursive-flatten
 // push_from overload — that is a flatten, not a clone/concat, so it stays silent too.
+//
+// `:=` / concat clone the source elements, so the FRESH-EMPTY suggestions are gated on
+// the element being cloneable: a lambda array is copyable (`push_from` works) but NOT
+// cloneable, so `var c := src` would not compile — STYLE032/033-concat stay silent for
+// it. The existing-array variadic collapse preserves the exact `push_from` op, so it is
+// NOT gated (a lambda existing-run still collapses).
 
-expect 31209:4
+expect 31209:7
 
 require daslib/style_lint
 require daslib/linq
+
+struct Bag {
+    nums : array<int>
+}
+
+typedef IntFn = lambda<(x : int) : int>
 
 // --- Bad: fresh-empty array filled by a run (>=2) — concat ---
 
@@ -37,7 +50,7 @@ def bad_fresh_concat_copy(a, b, c : array<int>) : array<int> {
     return <- d
 }
 
-// --- Bad: existing array filled by a run (>=2) — variadic collapse ---
+// --- Bad: existing array (plain var) filled by a run (>=2) — variadic collapse ---
 
 def bad_existing_variadic_clone(var dst : array<int>; a, b : array<int>) {
     dst |> push_clone_from(a)                 // STYLE033 — dst |> push_clone_from(a, b)
@@ -46,6 +59,25 @@ def bad_existing_variadic_clone(var dst : array<int>; a, b : array<int>) {
 
 def bad_existing_variadic_copy(var dst : array<int>; a, b : array<int>) {
     dst |> push_from(a)                       // STYLE033 — dst |> push_from(a, b)
+    dst |> push_from(b)
+}
+
+// --- Bad: existing array via a pure CHAIN receiver — variadic collapse ---
+
+def bad_chain_field_copy(var bag : Bag; a, b : array<int>) {
+    bag.nums |> push_from(a)                  // STYLE033 — bag.nums |> push_from(a, b)
+    bag.nums |> push_from(b)
+}
+
+def bad_chain_indexed_clone(var bags : array<Bag>; a, b : array<int>) {
+    bags[0].nums |> push_clone_from(a)        // STYLE033 — bags[0].nums |> push_clone_from(a, b)
+    bags[0].nums |> push_clone_from(b)
+}
+
+// --- Bad: lambda array is copyable, so the EXISTING variadic collapse still applies ---
+
+def bad_lambda_existing_variadic(var dst : array<IntFn>; a, b : array<IntFn>) {
+    dst |> push_from(a)                       // STYLE033 — dst |> push_from(a, b) (copy, no clone)
     dst |> push_from(b)
 }
 
@@ -102,4 +134,40 @@ def good_existing_flatten(var dst : array<int>; n1, n2 : array<array<int>>) {
     // Nested sources flatten into a flat dst — not a flat-array bulk append; stays silent.
     dst |> push_from(n1)
     dst |> push_from(n2)
+}
+
+// --- Good: chain receiver, out of scope (must NOT fire) ---
+
+def good_chain_single(var bag : Bag; a : array<int>) {
+    // A single chain push is not a run — no variadic collapse to suggest.
+    bag.nums |> push_from(a)
+}
+
+def good_chain_mixed_fname(var bag : Bag; a, b : array<int>) {
+    // push_from then push_clone_from cannot merge (different op) — each sub-run is 1.
+    bag.nums |> push_from(a)
+    bag.nums |> push_clone_from(b)
+}
+
+def good_chain_flatten(var bag : Bag; n1, n2 : array<array<int>>) {
+    // Nested sources flatten into the flat chain field — not a bulk append; stays silent.
+    bag.nums |> push_from(n1)
+    bag.nums |> push_from(n2)
+}
+
+// --- Good: lambda array fresh-empty — copyable but not cloneable, gate suppresses ---
+
+def good_lambda_fresh_single(src : array<IntFn>) : array<IntFn> {
+    // `var c := src` would not compile (lambda not cloneable) — STYLE032 must stay silent.
+    var c : array<IntFn>
+    c |> push_from(src)
+    return <- c
+}
+
+def good_lambda_fresh_run(a, b : array<IntFn>) : array<IntFn> {
+    // `concat(a, b)` clones — not valid for a lambda array. STYLE033-concat must stay silent.
+    var c : array<IntFn>
+    c |> push_from(a)
+    c |> push_from(b)
+    return <- c
 }


### PR DESCRIPTION
Follow-up to the "make concat better" arc (#3224 / #3230 / #3231), extending STYLE033 and tightening STYLE032/033.

## What

**1. Chain-receiver existing-run.** STYLE033's existing-array variadic-collapse now fires for a pure-chain receiver — `obj.arr`, `bags[0].nums` — not just a plain variable. Reuses the STYLE012 chain toolkit (`is_pure_chain` / `chain_equal` / `chain_describe`). The variable form requires an `ExprVar` root; the chain form requires ≥1 field/index link, so the two are disjoint and never double-fire.

**2. `can_clone` gate.** The fresh-empty STYLE032 (`var w := SRC`) and STYLE033 (`concat(...)`) suggestions now fire only when the destination element type is cloneable (`TypeDecl.canClone`). Both rewrites clone the source elements — a copyable-but-not-cloneable element (e.g. a **lambda array**: `push_from` compiles, but `:=` errors with `30914 can't be cloned`) would not compile under the suggestion. The existing-array *variadic collapse* preserves the exact `push_from`/`push_clone_from` op, so it is **not** gated (a lambda existing-run still collapses).

Together these address Copilot's valid edge-case note on #3231.

## Notes

- Both run scanners already detect the *maximal* contiguous run and emit one suggestion naming the full collapsed call, so applying a fix once is terminal — no fix-one-retrigger.
- Opt-in rule (only fires when `daslib/style_lint` is required / the linter runs) — no impact on normal compilation.

## Tests

`utils/lint/tests/style033_concat_run.das` extended with: chain bad cases (field + indexed), chain good cases (single / mixed-fname / flatten), lambda-array gate cases (fresh-empty suppressed), and a lambda *existing*-run that still fires (proving the gate is scoped to the clone-introducing path). **47/47 lint tests pass**, lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)