### PR TITLE
dasSpirv: broadcast scalar operands to vector result in GLSL.std.450 ops (+ regression test)

### DIFF
--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -1418,6 +1418,19 @@ def private glsl_ext_op(name : string; cls : int) : tuple<ok : bool; op : GLSLst
     return (ok = false, op = GLSLstd450.Round)
 }
 
+//! GLSL.std.450 ops where a scalar operand is allowed against a vector result and the SPIR-V spec
+//! requires it to match the result type — mix/clamp/min/max/step/smoothstep. SPIR-V has no implicit
+//! scalar broadcast, so the emitter must splat such a scalar to the result width (e.g. daslang
+//! lerp(vec, vec, float) -> FMix wants a vector t). Ops NOT here (pow, atan2, distance, …) require
+//! their operands to match exactly and must not be touched.
+def private ext_op_broadcasts_scalar(op : GLSLstd450) : bool {
+    return (op == GLSLstd450.FMix
+        || op == GLSLstd450.FClamp || op == GLSLstd450.SClamp || op == GLSLstd450.UClamp
+        || op == GLSLstd450.FMin   || op == GLSLstd450.SMin   || op == GLSLstd450.UMin
+        || op == GLSLstd450.FMax   || op == GLSLstd450.SMax   || op == GLSLstd450.UMax
+        || op == GLSLstd450.Step   || op == GLSLstd450.SmoothStep)
+}
+
 // ===== compile-time constants: scalars, all-const vector constructors, const arrays =====
 // Produces a deduped OpConstant / OpConstantComposite for a fully-constant expression. Used for
 // array literals (which must be constant initializers for now) and their constituents. ok=false =>
@@ -3020,11 +3033,28 @@ class SpirvEmit : AstVisitor {
             let rt = emit_type(bm, expr._type)
             let res = alloc_id(bm)
             var ops <- [rt, res, set, uint(ge.op)]
+            // SPIR-V has no implicit scalar->vector broadcast. For the ops that allow a scalar operand
+            // against a vector result (mix/clamp/min/max/step/smoothstep), splat any scalar operand to
+            // the result width via OpCompositeConstruct so the OpExtInst is valid. This is what makes
+            // daslang lerp(vec, vec, float) emit correctly instead of an invalid (scalar-t) FMix.
+            let result_n = component_count(expr._type.baseType)
+            let broadcast = result_n > 1 && ext_op_broadcasts_scalar(ge.op)
             for (a in expr.arguments) {
-                let aid = value_of(a)
+                var aid = value_of(a)
                 if (aid == 0u) {
                     delete ops
                     return expr
+                }
+                if (broadcast && component_count(a._type.baseType) == 1) {
+                    let sres = alloc_id(bm)
+                    var cons <- [rt, sres]
+                    cons |> reserve(2 + result_n)
+                    for (_l in range(result_n)) {
+                        cons |> push(aid)
+                    }
+                    emit_n(bm, SEC_FUNCS, SpvOp.CompositeConstruct, cons)
+                    delete cons
+                    aid = sres
                 }
                 ops |> push(aid)
             }

--- a/tests/spirv/test_ext_broadcast.das
+++ b/tests/spirv/test_ext_broadcast.das
@@ -1,0 +1,59 @@
+options gen2
+options indenting = 4
+
+// Ext-op scalar-broadcast gate (regression for the FMix-scalar-t crash).
+//
+// `lerp(vecN, vecN, scalar)` lowers to OpExtInst FMix, but SPIR-V FMix requires ALL three operands to
+// match the result type — there is no implicit scalar->vector broadcast. So the emitter MUST splat the
+// scalar t to the vector width (OpCompositeConstruct) before the OpExtInst. Before that fix, the scalar
+// went straight into FMix: the blob still EMITTED (so a bytes-only check passed) but was INVALID SPIR-V
+// and blew up as a driver access-violation at vkCreateGraphicsPipelines. The real oracle is spirv-val.
+//
+// Each lerp result is written straight to its own @out (NO float4(...) constructors), so the only
+// OpCompositeConstruct instructions in the module are the three scalar->vector splats — the counts are
+// then exact + attributable even when spirv-val soft-skips locally (a missing splat would drop the
+// CompositeConstruct count to 0). `lerp` is the only GLSL.std.450 op daslang exposes with a vec+scalar
+// overload, so it is the only reachable broadcast case; the emitter's ext_op_broadcasts_scalar also
+// covers FClamp/FMin/FMax/Step/SmoothStep defensively (no daslang overload reaches them yet).
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require spirv/spirv_shader         // [fragment_shader] annotation
+require spirv/spirv_dis            // count_op / count_op_operand_at
+require spirv/spirv_grammar        // SpvOp, GLSLstd450
+require math                       // lerp(vec,vec,scalar)
+
+var @in @location = 0 eb_a : float4
+var @in @location = 1 eb_b : float4
+var @in @location = 2 eb_s : float
+var @out @location = 0 eb_out2 : float2
+var @out @location = 1 eb_out3 : float3
+var @out @location = 2 eb_out4 : float4
+[fragment_shader(name="extbcast_spv"), marker(no_coverage)]
+def extbcast {
+    eb_out2 = lerp(eb_a.xy, eb_b.xy, eb_s)      // FMix float2,float2,scalar -> splat t to float2
+    eb_out3 = lerp(eb_a.xyz, eb_b.xyz, eb_s)    // FMix float3,float3,scalar -> splat t to float3
+    eb_out4 = lerp(eb_a, eb_b, eb_s)            // FMix float4,float4,scalar -> splat t to float4
+}
+
+[test]
+def test_ext_broadcast(t : T?) {
+    t |> run("lerp(vec,vec,scalar) -> FMix splats the scalar t to vec width; spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(extbcast_spv)
+        // Exactly the three lerps lower to OpExtInst FMix. GLSLstd450.FMix is operand #3 of OpExtInst
+        // (result-type, result-id, set, instruction, args...), so this rejects a non-FMix ext-inst.
+        t |> success(count_op_operand_at(words, SpvOp.ExtInst, 3, uint(GLSLstd450.FMix)) == 3,
+            "three OpExtInst FMix (lerp lowered to FMix at widths 2/3/4)")
+        // The only OpCompositeConstruct in the module are the three scalar->vector splats; if the
+        // broadcast were missing, the scalar would go straight into FMix and this count would be 0.
+        t |> success(count_op(words, SpvOp.CompositeConstruct) == 3,
+            "three OpCompositeConstruct == the scalar->vec splats, and nothing else")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}


### PR DESCRIPTION
## Problem

`lerp(vecN, vecN, scalar)` lowers to `OpExtInst FMix`, but SPIR-V `FMix` requires **all three operands to match the result type** — there is no implicit scalar→vector broadcast. The emitter passed the scalar `t` straight into `FMix`, producing **invalid SPIR-V**. It passed emission (a bytes-only check would not catch it) and only surfaced as a **driver access-violation at `vkCreateGraphicsPipelines`**. `spirv-val` flags it cleanly:

```
FMix: expected types of all operands to be equal to Result Type
```

Surfaced by tutorial 10's deferred shaders in the [dasVulkan](https://github.com/borisbat/dasVulkan) ladder (heavy `lerp`/IBL use).

## Fix (`spirv_emit.das`)

`ext_op_broadcasts_scalar(op)` gates the GLSL.std.450 ops that allow a scalar operand against a vector result — `FMix` / `FClamp` / `FMin` / `FMax` / `Step` / `SmoothStep`. In the generic `OpExtInst` branch, any scalar operand (`component_count == 1`) of one of those ops is splatted to the result width via `OpCompositeConstruct` before the instruction. Ops that require exact-match operands (`pow`, `atan2`, `distance`, …) are untouched, and vector-operand / scalar-result calls are left as-is.

## Test (`tests/spirv/test_ext_broadcast.das`)

The fix originally shipped without a regression test; this adds one. It asserts `lerp(vecN, vecN, scalar)` for **N = 2/3/4** emits `OpExtInst` (FMix) + `OpCompositeConstruct` (the splat) and **passes `spirv-val`** — the real oracle that catches the original invalid blob. Self-contained inline-shader fixture (same pattern as `test_math_breadth` / `test_math_step`); auto-discovered by the `tests/spirv/*.das` AOT glob.

## Note (dispatch audit)

`lerp` is the **only** GLSL.std.450 op daslang currently exposes with a vec+scalar overload, so it is the only *reachable* broadcast case. The other five `ext_op_broadcasts_scalar` entries are **defensive** — daslang's `math` has only same-type overloads for `min`/`max`/`clamp`/`step`/`smoothstep`, so they never reach the emitter today, but the helper is ready if those overloads are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)