### PR TITLE
dasSpirv: integer vector*scalar (splat + IMul) + bool constants (OpConstantTrue/False)

### DIFF
--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -456,6 +456,19 @@ def public const_float(var m : SpirvModule; v : float) : uint {
     return id
 }
 
+// Boolean OpConstant: OpConstantTrue / OpConstantFalse carry NO literal word (the opcode IS the
+// value), so this is type + result-id only. Keyed separately so it never collides with const_int 0/1.
+def public const_bool(var m : SpirvModule; v : bool) : uint {
+    let key = "cb_{v}"
+    let ex = m.const_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let bt = type_bool(m)
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, v ? SpvOp.ConstantTrue : SpvOp.ConstantFalse, bt, id)
+    m.const_pool |> insert(key, id)
+    return id
+}
+
 // ===== finalize: header (5 words) ++ sections in layout order =====
 def public module_words(m : SpirvModule) : array<uint> {
     // header: magic, version, generator, id-bound (all result-ids < next_id), schema (0)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -1444,6 +1444,8 @@ def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : arra
     if (ci != null) return (ok = true, id = const_int(m, ci.value))
     let cf = e ?as ExprConstFloat
     if (cf != null) return (ok = true, id = const_float(m, cf.value))
+    let cb = e ?as ExprConstBool
+    if (cb != null) return (ok = true, id = const_bool(m, cb.value))
     // unary minus on a constant: depending on fold state `-0.6` can arrive as ExprOp1("-", const)
     // rather than a folded negative literal. Fold it here so both shapes produce the same constant.
     let neg = e ?as ExprOp1
@@ -1563,14 +1565,30 @@ def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : arra
     return (ok = false, id = 0u)
 }
 
+// Splat a scalar id to a vector of `n` lanes (OpCompositeConstruct of n copies of the scalar) ->
+// the splatted vector id. SPIR-V has no implicit scalar->vector broadcast, so an integer vec*scalar
+// must build the vector explicitly before the component-wise OpIMul.
+def private splat_to_vec(var m : SpirvModule; vec_type : uint; scalar_id : uint; n : int) : uint {
+    let res = alloc_id(m)
+    var cons <- [vec_type, res]
+    cons |> reserve(2 + n)
+    for (_k in range(n)) {
+        cons |> push(scalar_id)
+    }
+    emit_n(m, SEC_FUNCS, SpvOp.CompositeConstruct, cons)
+    delete cons
+    return res
+}
+
 // ===== `*` over matrices / vectors / scalars =====
 // SPIR-V splits multiplication by operand shape: OpMatrixTimesMatrix / OpMatrixTimesVector /
 // OpVectorTimesScalar. Plain component-wise FMul/IMul (the scalar binop path) only works when both
 // operands have the SAME shape, so the mixed cases are routed here first. Returns handled=false for
 // same-shape operands (let binop_code emit FMul/IMul); handled=true with id=0 on an unsupported mix
-// (error already pushed). Operands l/r are pre-emitted result-ids. Only the daslang-defined matrix
-// operators are handled (matrix*matrix, matrix*vector, and float vector*scalar either order);
-// daslang has no matrix*scalar or vector*matrix operator, so those SPIR-V ops are intentionally absent.
+// (error already pushed). Operands l/r are pre-emitted result-ids. Handled: matrix*matrix,
+// matrix*vector, float vector*scalar (OpVectorTimesScalar, either order), and integer vector*scalar
+// (splat + OpIMul, either order). daslang has no matrix*scalar or vector*matrix operator, so those
+// SPIR-V ops are intentionally absent.
 def private emit_mul(var m : SpirvModule; op2 : ExprOp2?; e : ExpressionPtr; l, r : uint; var errors : array<string>) : tuple<handled : bool; id : uint> {
     let lmat = matrix_info(op2.left._type)
     let rmat = matrix_info(op2.right._type)
@@ -1590,8 +1608,14 @@ def private emit_mul(var m : SpirvModule; op2 : ExprOp2?; e : ExpressionPtr; l, 
         emit(m, SEC_FUNCS, SpvOp.VectorTimesScalar, rt, res, l, r)
     } elif (rcc > 1 && lcc == 1 && lcls == 2 && rcls == 2) {
         emit(m, SEC_FUNCS, SpvOp.VectorTimesScalar, rt, res, r, l)   // SPIR-V wants the vector first
+    } elif (lcc > 1 && rcc == 1 && lcls == rcls && lcls >= 0 && lcls != 2) {
+        // integer vector * integer scalar: there is no OpVectorTimesScalar for ints, so splat the
+        // scalar to the vec width and do a component-wise OpIMul (sign-agnostic, valid for int + uint).
+        emit(m, SEC_FUNCS, SpvOp.IMul, rt, res, l, splat_to_vec(m, rt, r, lcc))
+    } elif (rcc > 1 && lcc == 1 && lcls == rcls && lcls >= 0 && lcls != 2) {
+        emit(m, SEC_FUNCS, SpvOp.IMul, rt, res, splat_to_vec(m, rt, l, rcc), r)
     } else {
-        errors |> push("unsupported '*' between {op2.left._type.baseType} and {op2.right._type.baseType} (integer vector/scalar mixes need a splat)")
+        errors |> push("unsupported '*' between {op2.left._type.baseType} and {op2.right._type.baseType}")
         return (handled = true, id = 0u)
     }
     return (handled = true, id = res)
@@ -1817,6 +1841,11 @@ class SpirvEmit : AstVisitor {
     def override visitExprConstFloat(var expr : ExprConstFloat?) : ExpressionPtr {
         var bm & = unsafe(*m)
         e2id[intptr(expr)] = const_float(bm, expr.value)
+        return expr
+    }
+    def override visitExprConstBool(var expr : ExprConstBool?) : ExpressionPtr {
+        var bm & = unsafe(*m)
+        e2id[intptr(expr)] = const_bool(bm, expr.value)
         return expr
     }
 

--- a/tests/spirv/test_bool_const.das
+++ b/tests/spirv/test_bool_const.das
@@ -1,0 +1,47 @@
+options gen2
+options indenting = 4
+
+// Bool constants gate.
+//
+// `false` / `true` literals (ExprConstBool) lower to OpConstantFalse / OpConstantTrue — these carry NO
+// literal word (the opcode IS the value), so they are type + result-id only. Before the fix the emitter
+// had no rvalue path for ExprConstBool and failed the annotation patch with "no rvalue available for
+// ExprConstBool". (Bool locals, comparisons, &&/||/!, and bool `if` conditions already worked — only
+// the bool literals were missing.) Asserts OpTypeBool + both bool constants are emitted, spirv-val clean.
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require spirv/spirv_shader         // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis            // has_op
+require spirv/spirv_grammar        // SpvOp
+
+var @ssbo @binding = 0 bc_data : array<uint>
+[compute_shader(local_size_x=64, name="bc_spv"), marker(no_coverage)]
+def bc {
+    let i = gl_GlobalInvocationID.x
+    var hit = false                 // ExprConstBool false -> OpConstantFalse
+    if (bc_data[i] > 5u) {
+        hit = true                  // ExprConstBool true -> OpConstantTrue
+    }
+    if (!hit) {                     // bool local read + LogicalNot
+        bc_data[i] = 0u
+    }
+}
+
+[test]
+def test_bool_const(t : T?) {
+    t |> run("false/true -> OpConstantFalse/OpConstantTrue (+ OpTypeBool); spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(bc_spv)
+        t |> success(has_op(words, SpvOp.TypeBool), "emits OpTypeBool")
+        t |> success(has_op(words, SpvOp.ConstantTrue), "emits OpConstantTrue (the `true` literal)")
+        t |> success(has_op(words, SpvOp.ConstantFalse), "emits OpConstantFalse (the `false` literal)")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}

--- a/tests/spirv/test_int_vec_scalar.das
+++ b/tests/spirv/test_int_vec_scalar.das
@@ -1,0 +1,52 @@
+options gen2
+options indenting = 4
+
+// Integer vector * scalar gate.
+//
+// SPIR-V has no OpVectorTimesScalar for integers (that op is float-only), so `ivecN * int` must splat
+// the scalar to the vector width (OpCompositeConstruct) and then do a component-wise OpIMul. Before the
+// fix the emitter rejected this with "integer vector/scalar mixes need a splat" (fail-closed, but a
+// missing feature). Both operand orders (vec*scalar, scalar*vec) and both int + uint are exercised.
+//
+// The vectors are loaded from SSBO array<ivec> elements (NOT constructed), so the only
+// OpCompositeConstruct instructions are the three scalar->vector splats — the counts are exact and
+// attributable even when spirv-val soft-skips locally.
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require spirv/spirv_shader         // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis            // count_op
+require spirv/spirv_grammar        // SpvOp
+
+var @ssbo @binding = 0 ivs_iv : array<int3>
+var @ssbo @binding = 1 ivs_uv : array<uint3>
+var @ssbo @binding = 2 ivs_is : array<int>
+var @ssbo @binding = 3 ivs_us : array<uint>
+[compute_shader(local_size_x=64, name="ivs_spv"), marker(no_coverage)]
+def ivs {
+    let i = gl_GlobalInvocationID.x
+    ivs_iv[i] = ivs_iv[i] * ivs_is[i]       // int3 * int   -> splat + OpIMul
+    ivs_iv[i] = ivs_is[i] * ivs_iv[i]       // int * int3   -> splat + OpIMul (reverse order)
+    ivs_uv[i] = ivs_uv[i] * ivs_us[i]       // uint3 * uint -> splat + OpIMul
+}
+
+[test]
+def test_int_vec_scalar(t : T?) {
+    t |> run("ivecN * int -> splat (OpCompositeConstruct) + OpIMul; spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(ivs_spv)
+        // Three integer vector*scalar multiplies -> three OpIMul.
+        t |> success(count_op(words, SpvOp.IMul) == 3, "three OpIMul (component-wise integer multiply)")
+        // The only OpCompositeConstruct are the three scalar->vec splats (vectors are loaded, not built).
+        t |> success(count_op(words, SpvOp.CompositeConstruct) == 3, "three OpCompositeConstruct == the splats")
+        // Integers must NOT route through OpVectorTimesScalar (that op is float-only).
+        t |> success(!has_op(words, SpvOp.VectorTimesScalar), "no OpVectorTimesScalar (ints use IMul)")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}


### PR DESCRIPTION
Two dasSpirv emitter gaps surfaced by the GLSL.std.450 / arithmetic dispatch audit (the [dasVulkan](https://github.com/borisbat/dasVulkan) tutorial ladder is the forcing function). Both were fail-closed/missing, not silent-invalid.

## 1. Integer `ivecN * int` → splat + `OpIMul`

`ivecN * int` was rejected with *"integer vector/scalar mixes need a splat"* — a missing feature, since SPIR-V has no `OpVectorTimesScalar` for integers (that op is float-only). `emit_mul` now splats the scalar to the vector width via `OpCompositeConstruct` (new `splat_to_vec` helper) and does a component-wise `OpIMul`, for both operand orders (`vec*scalar` and `scalar*vec`) and both `int` + `uint`. Mirrors the existing float `OpVectorTimesScalar` path and the FMix scalar-broadcast.

## 2. Bool constants → `OpConstantFalse` / `OpConstantTrue`

`false` / `true` literals (`ExprConstBool`) had no rvalue path and failed the annotation patch with *"no rvalue available for ExprConstBool"*. They now lower to `OpConstantFalse` / `OpConstantTrue` (new `const_bool` builder helper — these carry no literal word, the opcode is the value) via a `visitExprConstBool` override + an `emit_const` case. Bool **locals**, comparisons, `&&`/`||`/`!`, and bool `if` conditions already worked — only the literal constants were missing.

## Tests

- `tests/spirv/test_int_vec_scalar.das` — loads the vectors from SSBO `array<ivec>` elements (not constructed), so the only `OpCompositeConstruct` are the three splats: asserts exactly 3 `OpIMul` + 3 `OpCompositeConstruct`, **no** `OpVectorTimesScalar` (ints don't use it), and spirv-val clean.
- `tests/spirv/test_bool_const.das` — asserts `OpTypeBool` + both bool constants, spirv-val clean.

160 `tests/spirv` pass; lint-clean. Self-contained inline-shader fixtures (the established `test_math_*` / `test_ext_broadcast` pattern); auto-discovered by the `tests/spirv/*.das` AOT glob, so `test_aot_spirv` exercises both through the AOT path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)