### PR TITLE
standalone game loop: GC support + per-frame get_dt

### DIFF
--- a/doc/source/stdlib/handmade/function-builtin-heap_total_allocated-0x83b34cf36450f448.rst
+++ b/doc/source/stdlib/handmade/function-builtin-heap_total_allocated-0x83b34cf36450f448.rst
@@ -1,0 +1,1 @@
+Total bytes the context's value heap has reserved from the OS (aligned), including currently-free space. Pair with heap_bytes_allocated (the live bytes in use) to gauge how full the heap is — e.g. to decide whether a collection would reclaim much.

--- a/doc/source/stdlib/handmade/function-builtin-string_heap_total_allocated-0x7cb9ab66ff86158e.rst
+++ b/doc/source/stdlib/handmade/function-builtin-string_heap_total_allocated-0x7cb9ab66ff86158e.rst
@@ -1,0 +1,1 @@
+Total bytes the context's string heap has reserved from the OS (aligned), including currently-free space. Pair with string_heap_bytes_allocated (the live bytes in use) to gauge how full the string heap is — e.g. to decide whether a collection would reclaim much.

--- a/examples/games/arcanoid/main.das
+++ b/examples/games/arcanoid/main.das
@@ -1,5 +1,6 @@
 options gen2
 options persistent_heap
+options gc
 // arcanoid live
 require glfw/glfw_boost
 require live/glfw_live
@@ -9,13 +10,13 @@ require opengl/opengl_cache
 require daslib/defer
 require daslib/safe_addr
 require daslib/decs_boost
-require live/decs_live
-require live/opengl_live
+require live/decs_live    // nolint:STYLE030 — load-bearing for decs entity serialization across live reloads
+require live/opengl_live  // nolint:STYLE030 — load-bearing for OpenGL resource live-reload
 require live/live_commands
 require live/live_api
-require live/live_watch_boost
+require live/live_watch_boost // nolint:STYLE030 — load-bearing for live file-watch side-effects
 require live/live_vars
-require live/audio_live
+require live/audio_live   // nolint:STYLE030 — load-bearing for audio buffer persistence across reloads
 require daslib/json
 require daslib/json_boost
 require daslib/math_boost
@@ -24,7 +25,7 @@ require opengl/opengl_ttf
 require audio/audio_boost
 require strudel/strudel
 require strudel/strudel_player
-require strudel/strudel_live
+require strudel/strudel_live // nolint:STYLE030 — load-bearing for strudel audio live-reload side-effects
 require daslib/strings_boost
 require live_host
 
@@ -386,12 +387,12 @@ def gen_rounded_cube(bevel : float; sectors : int = 16; stacks : int = 8) {
         let k2 = k1 + sectors + 1
         for (j in range(sectors)) {
             if (i != 0) {
-                frag.indices |> push(k1 + j)
+                frag.indices |> push(k1 + j) // nolint:STYLE012 — conditional appends inside loop; literal move-assign would change behavior
                 frag.indices |> push(k1 + j + 1)
                 frag.indices |> push(k2 + j)
             }
             if (i != stacks - 1) {
-                frag.indices |> push(k1 + j + 1)
+                frag.indices |> push(k1 + j + 1) // nolint:STYLE012 — conditional appends inside loop; literal move-assign would change behavior
                 frag.indices |> push(k2 + j + 1)
                 frag.indices |> push(k2 + j)
             }
@@ -496,7 +497,7 @@ def draw_walls() {
 def draw_shield() {
     if (shield_timer > 0.0) {
         let alpha = min(shield_timer / 2.0, 1.0)  // fade out in last 2 seconds
-        let pulse = 0.7 + 0.3 * sin(float(get_uptime()) * 6.0)
+        let pulse = 0.7 + 0.3 * sin(get_uptime() * 6.0)
         let color = BONUS_COLORS[int(BonusType.shield)] * pulse
         draw_box(
             float3(0.0, WALL_HEIGHT * 0.25, SHIELD_Z),
@@ -721,10 +722,10 @@ def reset_powerups() {
 var @live paddle_x = 0.0
 
 def update_paddle(dt : float) {
-    if (glfwGetKey(live_window, int(GLFW_KEY_LEFT)) == int(GLFW_PRESS)) {
+    if (glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS) {
         paddle_x += PADDLE_SPEED * dt
     }
-    if (glfwGetKey(live_window, int(GLFW_KEY_RIGHT)) == int(GLFW_PRESS)) {
+    if (glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS) {
         paddle_x -= PADDLE_SPEED * dt
     }
     let pw = current_paddle_w()
@@ -878,7 +879,7 @@ def spawn_bricks() {
     let total_w = float(BRICK_COLS) * (BRICK_W + BRICK_GAP) - BRICK_GAP
     let x_offset = -total_w * 0.5 + BRICK_W * 0.5
     let total = BRICK_ROWS * BRICK_COLS
-    create_entities`Brick(total) $(eid : EntityId; i : int; var b : Brick) {
+    create_entities`Brick(total) $(_eid : EntityId; i : int; var b : Brick) {
         let row = i / BRICK_COLS
         let col = i % BRICK_COLS
         b.pos = float3(x_offset + float(col) * (BRICK_W + BRICK_GAP), BRICK_H * 0.5, BRICK_START_Z + float(row) * (BRICK_D + BRICK_GAP))
@@ -914,7 +915,7 @@ def draw_bricks(br : Brick) {
 def update_bonuses(eid : EntityId; var bn : Bonus) {
     bn.pos.z -= BONUS_FALL_SPEED * tick_dt
     // Rotate Y for visual flair
-    bn.pos.y = BONUS_SIZE * 0.5 + sin(float(get_uptime()) * 4.0) * 0.1
+    bn.pos.y = BONUS_SIZE * 0.5 + sin(get_uptime() * 4.0) * 0.1
     // Check paddle collection
     let pw = current_paddle_w()
     let px_min = paddle_x - pw * 0.5 - BONUS_SIZE * 0.5
@@ -936,7 +937,7 @@ def update_bonuses(eid : EntityId; var bn : Bonus) {
 [decs(stage=draw)]
 def draw_bonuses(bn : Bonus) {
     // Draw as small rotating cube
-    let angle = float(get_uptime()) * 3.0
+    let angle = get_uptime() * 3.0
     v_model = compose(bn.pos, float4(0.0, sin(angle * 0.5), 0.0, cos(angle * 0.5)), float3(BONUS_SIZE * 0.5))
     f_Color = float4(bn.color, 1.0)
     vs_arcanoid_bind_uniform(program)
@@ -1029,8 +1030,8 @@ def spawn_trail_dots() {
     query() $(b : Ball) {
         ball_positions |> push(b.pos)
     }
-    if (length(ball_positions) > 0) {
-        create_entities`Trail(length(ball_positions)) $(eid : EntityId; i : int; var tr : Trail) {
+    if (!empty(ball_positions)) {
+        create_entities`Trail(length(ball_positions)) $(_eid : EntityId; i : int; var tr : Trail) {
             tr.pos = ball_positions[i]
             tr.lifetime = 0.15
         }
@@ -1077,7 +1078,7 @@ def draw_shadow_scene() {
         draw_box(br.pos, float3(BRICK_W, BRICK_H, BRICK_D), SHADOW_COLOR)
     }
     // Bonuses (with rotation matching the main draw)
-    let angle = float(get_uptime()) * 3.0
+    let angle = get_uptime() * 3.0
     query() $(bn : Bonus) {
         v_model = compose(bn.pos, float4(0.0, sin(angle * 0.5), 0.0, cos(angle * 0.5)), float3(BONUS_SIZE * 0.5))
         f_Color = float4(SHADOW_COLOR, 0.5)
@@ -1134,7 +1135,7 @@ struct GameStatusResult {
 }
 
 [live_command(description="Show score, lives, ball/brick counts")]
-def cmd_game_status(input : JsonValue?) : JsonValue? {
+def cmd_game_status(_input : JsonValue?) : JsonValue? {
     var result = GameStatusResult()
     query() $(b : Ball) { result.balls++; }
     query() $(br : Brick) { result.bricks++; }
@@ -1148,7 +1149,7 @@ def cmd_game_status(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Spawn a new set of bricks")]
-def cmd_spawn_bricks(input : JsonValue?) : JsonValue? {
+def cmd_spawn_bricks(_input : JsonValue?) : JsonValue? {
     spawn_bricks()
     return JV(true)
 }
@@ -1172,7 +1173,7 @@ def cmd_spawn_bonus(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Dump DECS archetypes, entities, and queries")]
-def cmd_decs_dump(input : JsonValue?) : JsonValue? {
+def cmd_decs_dump(_input : JsonValue?) : JsonValue? {
     return JV(debug_dump_string())
 }
 
@@ -1198,7 +1199,7 @@ def cmd_powerup(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Reset game to initial state")]
-def cmd_reset_game(input : JsonValue?) : JsonValue? {
+def cmd_reset_game(_input : JsonValue?) : JsonValue? {
     decs::restart()
     spawn_bricks()
     commit()
@@ -1222,7 +1223,7 @@ def cmd_set_lives(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Toggle god mode (ball bounces back instead of falling)")]
-def cmd_god_mode(input : JsonValue?) : JsonValue? {
+def cmd_god_mode(_input : JsonValue?) : JsonValue? {
     god_mode = !god_mode
     return JV(god_mode)
 }
@@ -1270,7 +1271,7 @@ def draw_text_centered(text : string; cx, y : int; tint : float3 = float3(1.0)) 
 }
 
 def pulse_tint(base : float3) : float3 {
-    let pulse = 0.5 + 0.5 * sin(float(get_uptime()) * 4.5)
+    let pulse = 0.5 + 0.5 * sin(get_uptime() * 4.5)
     return lerp(base * 0.86, base * 1.06, pulse)
 }
 
@@ -1359,10 +1360,10 @@ def update() {
 
     let dt = get_dt()
     tick_dt = min(dt, 1.0 / 30.0) * game_speed
-    let space_pressed = glfwGetKey(live_window, int(GLFW_KEY_SPACE)) == int(GLFW_PRESS)
+    let space_pressed = glfwGetKey(live_window, GLFW_KEY_SPACE) == GLFW_PRESS
     let space_just = space_pressed && !space_was_pressed
     space_was_pressed = space_pressed
-    let esc_pressed = glfwGetKey(live_window, int(GLFW_KEY_ESCAPE)) == int(GLFW_PRESS)
+    let esc_pressed = glfwGetKey(live_window, GLFW_KEY_ESCAPE) == GLFW_PRESS
     let esc_just = esc_pressed && !esc_was_pressed
     esc_was_pressed = esc_pressed
     // Menu → start
@@ -1516,6 +1517,7 @@ def main() {
     var frame_count = 0
     while (!exit_requested()) {
         update()
+        maybe_collect_gc()
         frame_count ++
         if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
             break

--- a/examples/games/arcanoid/main.das
+++ b/examples/games/arcanoid/main.das
@@ -17,7 +17,6 @@ require live/live_api
 require live/live_watch_boost // nolint:STYLE030 — load-bearing for live file-watch side-effects
 require live/live_vars
 require live/audio_live   // nolint:STYLE030 — load-bearing for audio buffer persistence across reloads
-require daslib/json
 require daslib/json_boost
 require daslib/math_boost
 require daslib/archive

--- a/examples/games/asteroids/main.das
+++ b/examples/games/asteroids/main.das
@@ -18,7 +18,6 @@ require strudel/strudel
 require strudel/strudel_player
 require strudel/strudel_live // nolint:STYLE030 — side-effect registration for live-reload
 require daslib/math_boost
-require daslib/json // nolint:STYLE030 — side-effect registration for live-reload
 require daslib/json_boost
 require daslib/strings_boost
 require daslib/safe_addr

--- a/examples/games/asteroids/main.das
+++ b/examples/games/asteroids/main.das
@@ -1,23 +1,24 @@
 options gen2
 options persistent_heap
+options gc
 
 require glfw/glfw_boost
 require live/glfw_live
 require opengl/opengl_boost
 require opengl/opengl_gen
 require opengl/opengl_cache
-require live/opengl_live
+require live/opengl_live // nolint:STYLE030 — side-effect registration for live-reload
 require live/live_commands
 require live/live_api
-require live/live_watch_boost
+require live/live_watch_boost // nolint:STYLE030 — side-effect registration for live-reload
 require live/live_vars
-require live/audio_live
+require live/audio_live // nolint:STYLE030 — side-effect registration for live-reload
 require audio/audio_boost
 require strudel/strudel
 require strudel/strudel_player
-require strudel/strudel_live
+require strudel/strudel_live // nolint:STYLE030 — side-effect registration for live-reload
 require daslib/math_boost
-require daslib/json
+require daslib/json // nolint:STYLE030 — side-effect registration for live-reload
 require daslib/json_boost
 require daslib/strings_boost
 require daslib/safe_addr
@@ -477,25 +478,14 @@ def create_gl_objects() {
 }
 
 def gen_ship_triangle() {
-    var frag : GeometryFragment
-    frag.vertices |> push(GeometryPreviewVertex(
-        xyz = float3(0.0, 1.2, 0.0),
-        normal = float3(0.0, 0.0, 1.0),
-        uv = float2(0.5, 1.0)
-    ))
-    frag.vertices |> push(GeometryPreviewVertex(
-        xyz = float3(-0.75, -0.8, 0.0),
-        normal = float3(0.0, 0.0, 1.0),
-        uv = float2(0.0, 0.0)
-    ))
-    frag.vertices |> push(GeometryPreviewVertex(
-        xyz = float3(0.75, -0.8, 0.0),
-        normal = float3(0.0, 0.0, 1.0),
-        uv = float2(1.0, 0.0)
-    ))
-    frag.indices |> push(0)
-    frag.indices |> push(1)
-    frag.indices |> push(2)
+    var frag <- GeometryFragment(
+        vertices <- [
+            GeometryPreviewVertex(xyz = float3(0.0, 1.2, 0.0),  normal = float3(0.0, 0.0, 1.0), uv = float2(0.5, 1.0)),
+            GeometryPreviewVertex(xyz = float3(-0.75, -0.8, 0.0), normal = float3(0.0, 0.0, 1.0), uv = float2(0.0, 0.0)),
+            GeometryPreviewVertex(xyz = float3(0.75, -0.8, 0.0),  normal = float3(0.0, 0.0, 1.0), uv = float2(1.0, 0.0))
+        ]
+    )
+    frag.indices <- [0, 1, 2]
     frag.prim = GeometryFragmentType.triangles
     gen_bbox(frag)
     return <- frag
@@ -568,7 +558,7 @@ def spawn_asteroid(pos : float3; size, speed_mult : float = 1.0) {
 }
 
 def spawn_particles(origin, color : float3; count : int) {
-    create_entities`Particle(count) $(eid : EntityId; i : int; var p : Particle) {
+    create_entities`Particle(count) $(_eid : EntityId; _i : int; var p : Particle) {
         let angle = random_f() * 2.0 * PI
         let speed = 50.0 + random_f() * 100.0
         p.pos = origin
@@ -624,7 +614,7 @@ def apply_powerup(kind : PowerupType) {
         rapid_fire_timer = max(rapid_fire_timer, POWERUP_RAPID_FIRE_TIME)
         spawn_particles(ship_pos, powerup_color(kind), 8)
     } elif (kind == PowerupType.extra_life) {
-        lives += 1
+        lives++
         spawn_particles(ship_pos, powerup_color(kind), 10)
     } else {
         invuln_powerup_timer = max(invuln_powerup_timer, POWERUP_INVULN_TIME)
@@ -643,7 +633,7 @@ def spawn_wave(wave : int) {
         var tries = 0
         while (tries < 8 && wrapped_distance_sq(pos, ship_pos) < 180.0 * 180.0) {
             pos = float3(random_range(0.0, FIELD_W), random_range(0.0, FIELD_H), 0.0)
-            tries += 1
+            tries++
         }
         spawn_asteroid(pos, random_range(ASTEROID_MIN_SIZE, max_size), speed_mult)
     }
@@ -679,20 +669,16 @@ def reset_game() {
 }
 
 def update_ship() {
-    if (game_state != GameState.playing) {
+    if (game_state != GameState.playing || ship_respawn_timer > DEATH_BLINK_TIME) {
         return
     }
 
-    if (ship_respawn_timer > DEATH_BLINK_TIME) {
-        return
-    }
+    let up = glfwGetKey(live_window, GLFW_KEY_W) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_UP) == GLFW_PRESS
+    let down = glfwGetKey(live_window, GLFW_KEY_S) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_DOWN) == GLFW_PRESS
+    let left = glfwGetKey(live_window, GLFW_KEY_A) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS
+    let right = glfwGetKey(live_window, GLFW_KEY_D) == GLFW_PRESS || glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS
 
-    let up = glfwGetKey(live_window, int(GLFW_KEY_W)) == int(GLFW_PRESS) || glfwGetKey(live_window, int(GLFW_KEY_UP)) == int(GLFW_PRESS)
-    let down = glfwGetKey(live_window, int(GLFW_KEY_S)) == int(GLFW_PRESS) || glfwGetKey(live_window, int(GLFW_KEY_DOWN)) == int(GLFW_PRESS)
-    let left = glfwGetKey(live_window, int(GLFW_KEY_A)) == int(GLFW_PRESS) || glfwGetKey(live_window, int(GLFW_KEY_LEFT)) == int(GLFW_PRESS)
-    let right = glfwGetKey(live_window, int(GLFW_KEY_D)) == int(GLFW_PRESS) || glfwGetKey(live_window, int(GLFW_KEY_RIGHT)) == int(GLFW_PRESS)
-
-    let mouse_aim_active = mouse_aim_enabled && glfwGetMouseButton(live_window, int(GLFW_MOUSE_BUTTON_2)) == int(GLFW_PRESS)
+    let mouse_aim_active = mouse_aim_enabled && glfwGetMouseButton(live_window, GLFW_MOUSE_BUTTON_2) == GLFW_PRESS
     if (mouse_aim_active) {
         let d = mouse_world - ship_pos
         if (length_sq(d) > 1.0) {
@@ -716,8 +702,8 @@ def update_ship() {
         ship_vel -= ship_forward(ship_rotation) * force
     }
 
-    let fire_kb = glfwGetKey(live_window, int(GLFW_KEY_SPACE)) == int(GLFW_PRESS)
-    let fire_mouse = mouse_fire_enabled && glfwGetMouseButton(live_window, int(GLFW_MOUSE_BUTTON_1)) == int(GLFW_PRESS)
+    let fire_kb = glfwGetKey(live_window, GLFW_KEY_SPACE) == GLFW_PRESS
+    let fire_mouse = mouse_fire_enabled && glfwGetMouseButton(live_window, GLFW_MOUSE_BUTTON_1) == GLFW_PRESS
     let fire_cooldown = (rapid_fire_timer > 0.0 ? FIRE_COOLDOWN * 0.5 : FIRE_COOLDOWN)
     let now = get_uptime()
     if (ship_respawn_timer <= 0.0 && (fire_kb || fire_mouse) && now - last_shot_time > fire_cooldown) {
@@ -868,7 +854,7 @@ def process_collisions() {
             }
         }
         if (ship_hit) {
-            lives -= 1
+            lives--
             spawn_particles(ship_pos, float3(1.0, 0.4, 0.3), 16)
             ship_pos = float3(FIELD_W * 0.5, FIELD_H * 0.5, 0.0)
             ship_vel = float3(0.0)
@@ -931,7 +917,7 @@ def update() {
     update_mouse_world()
 
     if (game_state == GameState.game_over_state || game_state == GameState.win_state) {
-        if (glfwGetKey(live_window, int(GLFW_KEY_SPACE)) == int(GLFW_PRESS)) {
+        if (glfwGetKey(live_window, GLFW_KEY_SPACE) == GLFW_PRESS) {
             reset_game()
         }
     }
@@ -958,8 +944,8 @@ def update() {
             game_state = GameState.win_state
             wave_banner_timer = 0.0
         } else {
-            wave_number += 1
-            lives += 1
+            wave_number++
+            lives++
             wave_banner_timer = WAVE_BANNER_DURATION
             var inscope to_delete : array<EntityId>
             query() $(eid : EntityId; b : Bullet) {
@@ -1100,7 +1086,8 @@ def main() {
     var frame_count = 0
     while (!exit_requested()) {
         update()
-        frame_count += 1
+        maybe_collect_gc()
+        frame_count++
         if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
             break
         }

--- a/examples/games/pacman/main.das
+++ b/examples/games/pacman/main.das
@@ -17,7 +17,6 @@ require live/live_api
 require live/live_watch_boost // nolint:STYLE030 — load-bearing: registers live-watch hooks
 require live/live_vars
 require live/audio_live       // nolint:STYLE030 — load-bearing: registers audio live-reload hooks
-require daslib/json           // nolint:STYLE030 — load-bearing: required by json_boost transitive usage
 require daslib/json_boost
 require daslib/math_boost
 require daslib/archive

--- a/examples/games/pacman/main.das
+++ b/examples/games/pacman/main.das
@@ -1,5 +1,6 @@
 options gen2
 options persistent_heap
+options gc
 
 require glfw/glfw_boost
 require live/glfw_live
@@ -9,14 +10,14 @@ require opengl/opengl_cache
 require daslib/defer
 require daslib/safe_addr
 require daslib/decs_boost
-require live/decs_live
-require live/opengl_live
+require live/decs_live    // nolint:STYLE030 — load-bearing: registers decs live-reload hooks
+require live/opengl_live  // nolint:STYLE030 — load-bearing: registers opengl live-reload hooks
 require live/live_commands
 require live/live_api
-require live/live_watch_boost
+require live/live_watch_boost // nolint:STYLE030 — load-bearing: registers live-watch hooks
 require live/live_vars
-require live/audio_live
-require daslib/json
+require live/audio_live       // nolint:STYLE030 — load-bearing: registers audio live-reload hooks
+require daslib/json           // nolint:STYLE030 — load-bearing: required by json_boost transitive usage
 require daslib/json_boost
 require daslib/math_boost
 require daslib/archive
@@ -24,7 +25,7 @@ require opengl/opengl_ttf
 require audio/audio_boost
 require strudel/strudel
 require strudel/strudel_player
-require strudel/strudel_live
+require strudel/strudel_live  // nolint:STYLE030 — load-bearing: registers strudel live-reload hooks
 require daslib/strings_boost
 require live_host
 
@@ -330,12 +331,12 @@ def gen_pac_sphere(sectorCount, stackCount : int; mouth_half_angle : float) {
             let a   = mid > PI ? mid - 2.0 * PI : mid
             if (abs(a) >= mouth_half_angle) {
                 if (i != 0) {
-                    frag.indices |> push(k1)
+                    frag.indices |> push(k1) // nolint:STYLE012 — conditional per-iteration pushes; not a bulk literal assignment
                     frag.indices |> push(k2)
                     frag.indices |> push(k1 + 1)
                 }
                 if (i != (stackCount - 1)) {
-                    frag.indices |> push(k1 + 1)
+                    frag.indices |> push(k1 + 1) // nolint:STYLE012 — conditional per-iteration pushes; not a bulk literal assignment
                     frag.indices |> push(k2)
                     frag.indices |> push(k2 + 1)
                 }
@@ -661,7 +662,7 @@ def draw_pellets(prog : uint) {
                 let wpos = cell_to_world(col, row)
                 draw_sphere_obj(float3(wpos.x, wpos.y, 0.08), 0.1, PELLET_COLOR, prog)
             } elif (power_pills[idx]) {
-                let t = float(get_uptime())
+                let t = get_uptime()
                 let pulse = 0.15 + 0.05 * sin(t * 4.0)
                 let wpos = cell_to_world(col, row)
                 draw_sphere_obj(float3(wpos.x, wpos.y, 0.12), pulse, POWER_COLOR, prog)
@@ -692,7 +693,7 @@ def draw_hud() {
     let cy = display_h / 2
     if (game_state == GameState.menu) {
         draw_text_centered("PAC-MAN", cx, cy - 60, float3(1.0, 0.9, 0.1))
-        let pulse = 0.5 + 0.5 * sin(float(get_uptime()) * 3.0)
+        let pulse = 0.5 + 0.5 * sin(get_uptime() * 3.0)
         draw_text_centered("PRESS SPACE TO START", cx, cy + 10, float3(pulse, pulse, pulse))
         draw_text_centered("ARROW KEYS TO MOVE", cx, cy + 45, float3(0.6, 0.6, 0.6))
         return
@@ -704,7 +705,7 @@ def draw_hud() {
         draw_text("POWER!", display_w - 130, 35, float3(1.0, 0.5, 0.0))
     }
     if (game_state == GameState.ready) {
-        let pulse = 0.5 + 0.5 * sin(float(get_uptime()) * 6.0)
+        let pulse = 0.5 + 0.5 * sin(get_uptime() * 6.0)
         draw_text_centered("READY!", cx, cy, float3(1.0, 1.0, 0.2) * pulse)
     } elif (game_state == GameState.game_over_state) {
         draw_text_centered("GAME OVER", cx, cy - 20, float3(1.0, 0.2, 0.2))
@@ -777,17 +778,17 @@ def update_pac(dt : float) {
     if (pac_dead || game_state != GameState.playing) { return ; }
 
     // Read input → queue next direction
-    if (glfwGetKey(live_window, int(GLFW_KEY_RIGHT)) == int(GLFW_PRESS)) { pac_next = int2(1, 0); }
-    if (glfwGetKey(live_window, int(GLFW_KEY_LEFT))  == int(GLFW_PRESS)) { pac_next = int2(-1, 0); }
-    if (glfwGetKey(live_window, int(GLFW_KEY_UP))    == int(GLFW_PRESS)) { pac_next = int2(0, 1); }
-    if (glfwGetKey(live_window, int(GLFW_KEY_DOWN))  == int(GLFW_PRESS)) { pac_next = int2(0, -1); }
+    if (glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS) { pac_next = int2(1, 0); }
+    if (glfwGetKey(live_window, GLFW_KEY_LEFT)  == GLFW_PRESS) { pac_next = int2(-1, 0); }
+    if (glfwGetKey(live_window, GLFW_KEY_UP)    == GLFW_PRESS) { pac_next = int2(0, 1); }
+    if (glfwGetKey(live_window, GLFW_KEY_DOWN)  == GLFW_PRESS) { pac_next = int2(0, -1); }
 
     pac_anim += dt
     pac_move_acc += eff_pac_speed() * dt
 
     // Move by whole cells
     while (pac_move_acc >= 1.0) {
-        pac_move_acc -= 1.0
+        --pac_move_acc
         let cell = world_to_cell(pac_pos.x, pac_pos.y)
         let col  = cell.x
         let row  = cell.y
@@ -815,14 +816,14 @@ def update_pac(dt : float) {
         if (pellets[pi]) {
             pellets[pi] = false
             score += PELLET_SCORE
-            pellets_eaten_total += 1
-            dot_counter += 1
+            ++pellets_eaten_total
+            ++dot_counter
             play_sfx(snd_eat_pellet)
             // Bonus fruit trigger
             if (next_fruit_idx < 2 && pellets_eaten_total >= FRUIT_TRIGGER[next_fruit_idx] && !fruit.active) {
                 let fw = cell_to_world(10, 12)
                 fruit = Fruit(active = true, kind = next_fruit_idx, timer = 9.0, world_pos = fw)
-                next_fruit_idx += 1
+                ++next_fruit_idx
             }
             if (!has_pellets() && !power_pills_any()) {
                 game_state = GameState.win_state
@@ -885,7 +886,7 @@ def update_fruit(dt : float) {
 
 def draw_fruit(prog : uint) {
     if (!fruit.active) { return ; }
-    let pulse = 0.18 + 0.04 * sin(float(get_uptime()) * 5.0)
+    let pulse = 0.18 + 0.04 * sin(get_uptime() * 5.0)
     draw_sphere_obj(float3(fruit.world_pos.x, fruit.world_pos.y, 0.25), pulse, FRUIT_COLOR[fruit.kind], prog)
 }
 
@@ -1022,7 +1023,7 @@ def draw_ghost_ent(g : Ghost) {
     let rt = float2(fd.y, -fd.x)
 
     // Flee blink in last 2 seconds
-    let blink_active = g.flee && power_timer < 2.0 && (sin(float(get_uptime()) * 14.0) > 0.0)
+    let blink_active = g.flee && power_timer < 2.0 && (sin(get_uptime() * 14.0) > 0.0)
     let flee_visible = g.flee && !blink_active
 
     if (!g.eaten) {
@@ -1124,8 +1125,8 @@ def update() {
     // Screen shake
     var shake_off = float2(0.0)
     if (shake_timer > 0.0) {
-        shake_timer -= min(float(get_dt()), 1.0 / 30.0)
-        let t = float(get_uptime())
+        shake_timer -= min(get_dt(), 1.0 / 30.0)
+        let t = get_uptime()
         let decay = saturate(shake_timer / max(shake_mag * 3.0, 0.01))
         shake_off = float2(sin(t * 97.0), cos(t * 71.0)) * shake_mag * decay
     }
@@ -1136,12 +1137,12 @@ def update() {
         float3(0.0, 1.0, 0.0)
     )
 
-    let raw_dt = min(float(get_dt()), 1.0 / 30.0)
+    let raw_dt = min(get_dt(), 1.0 / 30.0)
     // Slow motion during death animation only (not on game over screen)
     let dt = (pac_dead && lives > 0) ? raw_dt * 0.2 : raw_dt
 
     // Input
-    let space_pressed = glfwGetKey(live_window, int(GLFW_KEY_SPACE)) == int(GLFW_PRESS)
+    let space_pressed = glfwGetKey(live_window, GLFW_KEY_SPACE) == GLFW_PRESS
     let space_just = space_pressed && !space_was_pressed
     space_was_pressed = space_pressed
 
@@ -1212,7 +1213,7 @@ def update() {
         if (score_popups[spi].timer <= 0.0) {
             erase(score_popups, spi)
         }
-        spi -= 1
+        --spi
     }
 
     // Render
@@ -1245,6 +1246,7 @@ def main() {
     init()
     while (!exit_requested()) {
         update()
+        maybe_collect_gc()
     }
     shutdown()
 }

--- a/examples/games/river_run/main.das
+++ b/examples/games/river_run/main.das
@@ -1,5 +1,6 @@
 options gen2
 options persistent_heap
+options gc
 
 require rr_globals public
 require rr_audio
@@ -41,7 +42,7 @@ def update_camera() {
     let pitch_deg = CAM_PITCH_SLOW_DEG + (CAM_PITCH_FAST_DEG - CAM_PITCH_SLOW_DEG) * speed_t
     let cam_height = (CAM_BACK + CAM_LOOK_AHEAD) * tan(pitch_deg * PI / 180.0)
 
-    let t = float(get_uptime())
+    let t = get_uptime()
     let shake = float3(sin(t * 47.0), sin(t * 53.0), sin(t * 61.0)) * screen_shake_amount
 
     let eye = float3(cam_x, player_pos.y - CAM_BACK, cam_height) + shake
@@ -56,7 +57,7 @@ var prev_esc_pressed = false
 var prev_space_pressed = false
 
 def handle_menu_input() {
-    let space = glfwGetKey(live_window, int(GLFW_KEY_SPACE)) == int(GLFW_PRESS)
+    let space = glfwGetKey(live_window, GLFW_KEY_SPACE) == GLFW_PRESS
     let space_just = space && !prev_space_pressed
     prev_space_pressed = space
 
@@ -69,7 +70,7 @@ def handle_menu_input() {
 }
 
 def handle_pause_input() {
-    let esc = glfwGetKey(live_window, int(GLFW_KEY_ESCAPE)) == int(GLFW_PRESS)
+    let esc = glfwGetKey(live_window, GLFW_KEY_ESCAPE) == GLFW_PRESS
     let esc_just = esc && !prev_esc_pressed
     prev_esc_pressed = esc
 
@@ -145,7 +146,7 @@ def update() {
         restart_input_lock -= tick_dt
     }
 
-    let game_time = float(get_uptime())
+    let game_time = get_uptime()
 
     handle_menu_input()
     handle_pause_input()
@@ -212,7 +213,8 @@ def main() {
     var frame_count = 0
     while (!exit_requested()) {
         update()
-        frame_count += 1
+        maybe_collect_gc()
+        frame_count++
         if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
             break
         }

--- a/examples/games/sequence/main.das
+++ b/examples/games/sequence/main.das
@@ -1,5 +1,6 @@
 options gen2
 options persistent_heap
+options gc
 
 require live/glfw_live
 require live/opengl_live
@@ -1553,6 +1554,7 @@ def main() {
     var frame_count = 0
     while (!exit_requested()) {
         update()
+        maybe_collect_gc()
         frame_count ++
         if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
             break

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -56,8 +56,10 @@ namespace das {
     DAS_API urange64 string_heap_allocation_stats ( Context * context );
     DAS_API uint64_t string_heap_allocation_count ( Context * context );
     DAS_API uint64_t heap_bytes_allocated ( Context * context );
+    DAS_API uint64_t heap_total_allocated ( Context * context );
     DAS_API int32_t heap_depth ( Context * context );
     DAS_API uint64_t string_heap_bytes_allocated ( Context * context );
+    DAS_API uint64_t string_heap_total_allocated ( Context * context );
     DAS_API int32_t string_heap_depth ( Context * context );
     DAS_API void string_heap_report ( Context * context, LineInfoArg * info );
     DAS_API bool is_intern_strings ( Context * context );

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -101,6 +101,7 @@ def public live_begin_frame() : bool {
         request_exit()
         return false
     }
+    advance_frame_clock()   // standalone: compute this frame's dt once so get_dt() is stable all frame (no-op under the live host)
     return true
 }
 
@@ -108,6 +109,26 @@ def public live_end_frame() {
     //! Swaps buffers. Call after rendering.
     if (live_window != null) {
         glfwSwapBuffers(live_window)
+    }
+}
+
+def public maybe_collect_gc() {
+    //! Standalone-loop GC. Call once per frame after your update/render: the daslang-live host
+    //! collects the heap for you, but a standalone `def main` loop must do it itself. Collects a heap
+    //! only when it is mostly FREE (cheap compaction — little live data to walk), so it is fine to
+    //! call every frame. The string heap fills faster, so it gets the lower threshold and is checked
+    //! first. Requires `options gc` + `options persistent_heap` on the program (heap_collect throws
+    //! otherwise).
+    let s_used = string_heap_bytes_allocated()
+    let s_total = string_heap_total_allocated()
+    if (s_total > 0ul && s_used * 3ul < s_total * 2ul) {        // string heap > 1/3 unused
+        unsafe(heap_collect(true, false))
+        return
+    }
+    let h_used = heap_bytes_allocated()
+    let h_total = heap_total_allocated()
+    if (h_total > 0ul && h_used * 3ul < h_total) {              // heap > 2/3 unused
+        unsafe(heap_collect(true, false))
     }
 }
 
@@ -403,7 +424,7 @@ def mouse_play(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Stop synthetic playback and clear the timeline.")]
-def mouse_stop(input : JsonValue?) : JsonValue? {
+def mouse_stop(_input : JsonValue?) : JsonValue? {
     let was_playing = playing
     let released    = length(synth_held_buttons)
     release_held_buttons()
@@ -423,7 +444,7 @@ struct MouseStatusResult {
 }
 
 [live_command(description="Synthetic-mouse playback status.")]
-def mouse_status(input : JsonValue?) : JsonValue? {
+def mouse_status(_input : JsonValue?) : JsonValue? {
     let elapsed = playing ? int((get_uptime() - play_start_t) * 1000.0) : 0
     return JV(MouseStatusResult(
         playing       = playing,
@@ -636,49 +657,49 @@ def private mod_name_to_bit(name : string) : int {
 // event with `keycode == 0` (text-input widgets still receive it via
 // CharCallback).
 def private needs_shift_ascii(c : int) : bool {
-    if (c >= int('A') && c <= int('Z')) return true   // nolint:PERF014 (uppercase-only, is_alpha would also match lowercase)
+    if (c >= 'A' && c <= 'Z') return true   // nolint:PERF014 (uppercase-only, is_alpha would also match lowercase)
     // shifted punctuation on a US layout. Listed as char literals (not a single
     // string) so the parser doesn't treat `{` / `}` as interpolation delimiters.
-    return (c == int('~') || c == int('!') || c == int('@') || c == int('#')
-         || c == int('$') || c == int('%') || c == int('^') || c == int('&')
-         || c == int('*') || c == int('(') || c == int(')') || c == int('_')
-         || c == int('+') || c == int('{') || c == int('}') || c == int('|')
-         || c == int(':') || c == int('"') || c == int('<') || c == int('>')
-         || c == int('?'))
+    return (c == '~' || c == '!' || c == '@' || c == '#'
+         || c == '$' || c == '%' || c == '^' || c == '&'
+         || c == '*' || c == '(' || c == ')' || c == '_'
+         || c == '+' || c == '{' || c == '}' || c == '|'
+         || c == ':' || c == '"' || c == '<' || c == '>'
+         || c == '?')
 }
 
 def private base_keycode_ascii(c : int) : int {
     // letters — distinguishing case to compute the right keycode offset
-    if (c >= int('A') && c <= int('Z')) return GLFW_KEY_A + (c - int('A'))   // nolint:PERF014 (need uppercase-only offset)
-    if (c >= int('a') && c <= int('z')) return GLFW_KEY_A + (c - int('a'))   // nolint:PERF014 (need lowercase-only offset)
+    if (c >= 'A' && c <= 'Z') return GLFW_KEY_A + (c - 'A')   // nolint:PERF014 (need uppercase-only offset)
+    if (c >= 'a' && c <= 'z') return GLFW_KEY_A + (c - 'a')   // nolint:PERF014 (need lowercase-only offset)
     // digits 0-9 → GLFW_KEY_0..9
-    if (c >= int('0') && c <= int('9')) return GLFW_KEY_0 + (c - int('0'))   // nolint:PERF014 (need digit-only offset)
+    if (c >= '0' && c <= '9') return GLFW_KEY_0 + (c - '0')   // nolint:PERF014 (need digit-only offset)
     // shifted digit row: ! @ # $ % ^ & * ( )  → keys 1 2 3 4 5 6 7 8 9 0
-    if (c == int('!')) return GLFW_KEY_1
-    if (c == int('@')) return GLFW_KEY_2
-    if (c == int('#')) return GLFW_KEY_3
-    if (c == int('$')) return GLFW_KEY_4
-    if (c == int('%')) return GLFW_KEY_5
-    if (c == int('^')) return GLFW_KEY_6
-    if (c == int('&')) return GLFW_KEY_7
-    if (c == int('*')) return GLFW_KEY_8
-    if (c == int('(')) return GLFW_KEY_9
-    if (c == int(')')) return GLFW_KEY_0
+    if (c == '!') return GLFW_KEY_1
+    if (c == '@') return GLFW_KEY_2
+    if (c == '#') return GLFW_KEY_3
+    if (c == '$') return GLFW_KEY_4
+    if (c == '%') return GLFW_KEY_5
+    if (c == '^') return GLFW_KEY_6
+    if (c == '&') return GLFW_KEY_7
+    if (c == '*') return GLFW_KEY_8
+    if (c == '(') return GLFW_KEY_9
+    if (c == ')') return GLFW_KEY_0
     // punctuation
-    if (c == int(' ')) return GLFW_KEY_SPACE
-    if (c == int('\n')) return GLFW_KEY_ENTER
-    if (c == int('\t')) return GLFW_KEY_TAB
-    if (c == int(',') || c == int('<')) return GLFW_KEY_COMMA
-    if (c == int('.') || c == int('>')) return GLFW_KEY_PERIOD
-    if (c == int('/') || c == int('?')) return GLFW_KEY_SLASH
-    if (c == int(';') || c == int(':')) return GLFW_KEY_SEMICOLON
-    if (c == int('\'') || c == int('"')) return GLFW_KEY_APOSTROPHE
-    if (c == int('-') || c == int('_')) return GLFW_KEY_MINUS
-    if (c == int('=') || c == int('+')) return GLFW_KEY_EQUAL
-    if (c == int('[') || c == int('{')) return GLFW_KEY_LEFT_BRACKET
-    if (c == int(']') || c == int('}')) return GLFW_KEY_RIGHT_BRACKET
-    if (c == int('\\') || c == int('|')) return GLFW_KEY_BACKSLASH
-    if (c == int('`') || c == int('~')) return GLFW_KEY_GRAVE_ACCENT
+    if (c == ' ') return GLFW_KEY_SPACE
+    if (c == '\n') return GLFW_KEY_ENTER
+    if (c == '\t') return GLFW_KEY_TAB
+    if (c == ',' || c == '<') return GLFW_KEY_COMMA
+    if (c == '.' || c == '>') return GLFW_KEY_PERIOD
+    if (c == '/' || c == '?') return GLFW_KEY_SLASH
+    if (c == ';' || c == ':') return GLFW_KEY_SEMICOLON
+    if (c == '\'' || c == '"') return GLFW_KEY_APOSTROPHE
+    if (c == '-' || c == '_') return GLFW_KEY_MINUS
+    if (c == '=' || c == '+') return GLFW_KEY_EQUAL
+    if (c == '[' || c == '{') return GLFW_KEY_LEFT_BRACKET
+    if (c == ']' || c == '}') return GLFW_KEY_RIGHT_BRACKET
+    if (c == '\\' || c == '|') return GLFW_KEY_BACKSLASH
+    if (c == '`' || c == '~') return GLFW_KEY_GRAVE_ACCENT
     return 0
 }
 
@@ -749,7 +770,7 @@ def key_chord(input : JsonValue?) : JsonValue? {
     // resolve target keycode: prefer a single ASCII char (uppercase letter / digit / symbol).
     var target_kc = 0
     if (length(args.key) == 1) {
-        target_kc = base_keycode_ascii(int(first_character(args.key)))
+        target_kc = base_keycode_ascii(first_character(args.key))
     }
     return JV((error = "unsupported chord key", key = args.key)) if (target_kc == 0)
     var mod_bits = 0
@@ -834,7 +855,7 @@ def key_play(input : JsonValue?) : JsonValue? {
 }
 
 [live_command(description="Stop synthetic key playback and clear the timeline. Releases any keys still synth-held (e.g. modifiers from an interrupted key_chord) so ImGui doesn't inherit stuck modifier state.")]
-def key_stop(input : JsonValue?) : JsonValue? {
+def key_stop(_input : JsonValue?) : JsonValue? {
     let was_playing = key_playing
     let released    = length(synth_held_keys)
     release_held_keys()
@@ -853,7 +874,7 @@ struct KeyStatusResult {
 }
 
 [live_command(description="Synthetic-keyboard playback status.")]
-def key_status(input : JsonValue?) : JsonValue? {
+def key_status(_input : JsonValue?) : JsonValue? {
     let elapsed = key_playing ? int((get_uptime() - key_play_start_t) * 1000.0) : 0
     return JV(KeyStatusResult(
         playing        = key_playing,

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -129,7 +129,7 @@ def public maybe_collect_gc() {
     let h_used = heap_bytes_allocated()
     let h_total = heap_total_allocated()
     if (h_total > 0ul && h_used * 3ul < h_total) {              // heap > 2/3 unused
-        unsafe(heap_collect(false, false))                     // value heap only — string heap was just checked, not mostly free
+        unsafe(heap_collect(true, false))                      // both heaps — the GC walk is shared, so reclaiming the string heap too is near-free
     }
 }
 

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -119,6 +119,7 @@ def public maybe_collect_gc() {
     //! call every frame. The string heap fills faster, so it gets the lower threshold and is checked
     //! first. Requires `options gc` + `options persistent_heap` on the program (heap_collect throws
     //! otherwise).
+    return if (is_live_mode())       // host already collects each frame — only a standalone loop needs this
     let s_used = string_heap_bytes_allocated()
     let s_total = string_heap_total_allocated()
     if (s_total > 0ul && s_used * 3ul < s_total * 2ul) {        // string heap > 1/3 unused

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -129,7 +129,7 @@ def public maybe_collect_gc() {
     let h_used = heap_bytes_allocated()
     let h_total = heap_total_allocated()
     if (h_total > 0ul && h_used * 3ul < h_total) {              // heap > 2/3 unused
-        unsafe(heap_collect(true, false))
+        unsafe(heap_collect(false, false))                     // value heap only — string heap was just checked, not mostly free
     }
 }
 

--- a/modules/dasLiveHost/src/dasLiveHost.cpp
+++ b/modules/dasLiveHost/src/dasLiveHost.cpp
@@ -159,15 +159,9 @@ bool live_is_reload() {
     return g_state.is_reload;
 }
 
-// Standalone: compute THIS frame's dt once and cache it in g_state.dt. Call once per frame (from
-// live_begin_frame). Under the live host the host owns the clock, so this is a no-op. Caching makes
-// get_dt() idempotent within a frame — every get_dt() call in one frame returns the same value
-// (matching live-host behavior). Before this, standalone get_dt() recomputed a wall-clock delta on
-// EVERY call, so a frame's dt was split across however many times the frame called get_dt(): the sim
-// accumulator (first call) got the big slice and was fine, but later callers (e.g. the render pass's
-// pulse/crossfade/camera) got a near-zero sliver, freezing time-based effects.
-void live_advance_frame_clock() {
-    if (g_state.live_mode) return;
+// Measure the wall-clock delta since the last call and cache it into g_state.dt (+ uptime).
+// Shared by the frame-driven path (live_advance_frame_clock) and the undriven get_dt() fallback.
+static void measure_wall_clock_dt() {
     auto now = std::chrono::steady_clock::now();
     if (!g_state.time_initialized) {
         g_state.last_time = now;
@@ -182,7 +176,26 @@ void live_advance_frame_clock() {
     g_state.uptime = float(g_state.uptime_accum);
 }
 
+// Standalone: compute THIS frame's dt once and cache it in g_state.dt. Call once per frame (from
+// live_begin_frame). Under the live host the host owns the clock, so this is a no-op. Caching makes
+// get_dt() idempotent within a frame — every get_dt() call in one frame returns the same value
+// (matching live-host behavior). Before this, standalone get_dt() recomputed a wall-clock delta on
+// EVERY call, so a frame's dt was split across however many times the frame called get_dt(): the sim
+// accumulator (first call) got the big slice and was fine, but later callers (e.g. the render pass's
+// pulse/crossfade/camera) got a near-zero sliver, freezing time-based effects.
+void live_advance_frame_clock() {
+    if (g_state.live_mode) return;
+    g_state.frame_clock_driven = true;     // a frame driver owns the clock now → get_dt() returns the cache
+    measure_wall_clock_dt();
+}
+
 float live_get_dt() {
+    // Undriven standalone caller (no frame loop calling advance_frame_clock, not under the host):
+    // self-advance per call so direct live_host users keep the legacy "get_dt computes time" contract.
+    // Once a frame driver has called advance_frame_clock, return the stable per-frame cache instead.
+    if (!g_state.live_mode && !g_state.frame_clock_driven) {
+        measure_wall_clock_dt();
+    }
     return g_state.dt;   // per-frame cache: set by live_advance_frame_clock (standalone) or by the host
 }
 

--- a/modules/dasLiveHost/src/dasLiveHost.cpp
+++ b/modules/dasLiveHost/src/dasLiveHost.cpp
@@ -159,22 +159,31 @@ bool live_is_reload() {
     return g_state.is_reload;
 }
 
-float live_get_dt() {
-    if (!g_state.live_mode) {
-        // Standalone mode: compute dt from elapsed time
-        auto now = std::chrono::steady_clock::now();
-        if (!g_state.time_initialized) {
-            g_state.last_time = now;
-            g_state.time_initialized = true;
-            return 0.0f;
-        }
-        float dt = std::chrono::duration<float>(now - g_state.last_time).count();
+// Standalone: compute THIS frame's dt once and cache it in g_state.dt. Call once per frame (from
+// live_begin_frame). Under the live host the host owns the clock, so this is a no-op. Caching makes
+// get_dt() idempotent within a frame — every get_dt() call in one frame returns the same value
+// (matching live-host behavior). Before this, standalone get_dt() recomputed a wall-clock delta on
+// EVERY call, so a frame's dt was split across however many times the frame called get_dt(): the sim
+// accumulator (first call) got the big slice and was fine, but later callers (e.g. the render pass's
+// pulse/crossfade/camera) got a near-zero sliver, freezing time-based effects.
+void live_advance_frame_clock() {
+    if (g_state.live_mode) return;
+    auto now = std::chrono::steady_clock::now();
+    if (!g_state.time_initialized) {
         g_state.last_time = now;
-        g_state.dt = dt;
-        g_state.uptime_accum += dt;            // double accumulator — drift-free over long sessions
-        g_state.uptime = float(g_state.uptime_accum);
+        g_state.time_initialized = true;
+        g_state.dt = 0.0f;
+        return;
     }
-    return g_state.dt;
+    float dt = std::chrono::duration<float>(now - g_state.last_time).count();
+    g_state.last_time = now;
+    g_state.dt = dt;
+    g_state.uptime_accum += dt;            // double accumulator — drift-free over long sessions
+    g_state.uptime = float(g_state.uptime_accum);
+}
+
+float live_get_dt() {
+    return g_state.dt;   // per-frame cache: set by live_advance_frame_clock (standalone) or by the host
 }
 
 float live_get_uptime() {
@@ -417,6 +426,8 @@ public:
         // Timing
         addExtern<DAS_BIND_FUN(live_get_dt)>(*this, lib, "get_dt",
             SideEffects::accessGlobal, "das::live_get_dt");
+        addExtern<DAS_BIND_FUN(live_advance_frame_clock)>(*this, lib, "advance_frame_clock",
+            SideEffects::modifyExternal, "das::live_advance_frame_clock");
         addExtern<DAS_BIND_FUN(live_get_uptime)>(*this, lib, "get_uptime",
             SideEffects::accessGlobal, "das::live_get_uptime");
         addExtern<DAS_BIND_FUN(live_get_fps)>(*this, lib, "get_fps",

--- a/modules/dasLiveHost/src/dasLiveHost.h
+++ b/modules/dasLiveHost/src/dasLiveHost.h
@@ -74,6 +74,7 @@ namespace das {
     void live_request_reset();
     uint64_t live_get_reload_generation();
     bool live_is_reload();
+    void live_advance_frame_clock();
     float live_get_dt();
     float live_get_uptime();
     float live_get_fps();

--- a/modules/dasLiveHost/src/dasLiveHost.h
+++ b/modules/dasLiveHost/src/dasLiveHost.h
@@ -33,6 +33,10 @@ namespace das {
         float fps = 0.0f;
         std::chrono::steady_clock::time_point last_time;
         bool time_initialized = false;
+        // True once a frame driver (live_begin_frame → advance_frame_clock) owns the clock; then
+        // get_dt() returns the per-frame cache. Until then a direct live_host user's get_dt()
+        // self-advances per call (legacy standalone contract).
+        bool frame_clock_driven = false;
         // Lockstep recording: 0 = wall-clock (normal), > 0 = fixed dt per frame.
         // When set, the host advances the clock by exactly fixed_dt each frame
         // instead of measured wall time, so capture cadence, animation, and the

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -891,12 +891,20 @@ namespace das
         return context->heap->bytesAllocated();
     }
 
+    uint64_t heap_total_allocated ( Context * context ) {
+        return context->heap->totalAlignedMemoryAllocated();
+    }
+
     int32_t heap_depth ( Context * context ) {
         return (int32_t) context->heap->depth();
     }
 
     uint64_t string_heap_bytes_allocated ( Context * context ) {
         return context->stringHeap->bytesAllocated();
+    }
+
+    uint64_t string_heap_total_allocated ( Context * context ) {
+        return context->stringHeap->totalAlignedMemoryAllocated();
     }
 
     int32_t string_heap_depth ( Context * context ) {
@@ -2055,11 +2063,17 @@ namespace das
         addExtern<DAS_BIND_FUN(heap_bytes_allocated)>(*this, lib, "heap_bytes_allocated",
             SideEffects::modifyExternal, "heap_bytes_allocated")
                 ->arg("context");
+        addExtern<DAS_BIND_FUN(heap_total_allocated)>(*this, lib, "heap_total_allocated",
+            SideEffects::modifyExternal, "heap_total_allocated")
+                ->arg("context");
         addExtern<DAS_BIND_FUN(heap_depth)>(*this, lib, "heap_depth",
             SideEffects::modifyExternal, "heap_depth")
                 ->arg("context");
         addExtern<DAS_BIND_FUN(string_heap_bytes_allocated)>(*this, lib, "string_heap_bytes_allocated",
             SideEffects::modifyExternal, "string_heap_bytes_allocated")
+                ->arg("context");
+        addExtern<DAS_BIND_FUN(string_heap_total_allocated)>(*this, lib, "string_heap_total_allocated",
+            SideEffects::modifyExternal, "string_heap_total_allocated")
                 ->arg("context");
         addExtern<DAS_BIND_FUN(string_heap_depth)>(*this, lib, "string_heap_depth",
             SideEffects::modifyExternal, "string_heap_depth")

--- a/tests/gc/test_heap_total_allocated.das
+++ b/tests/gc/test_heap_total_allocated.das
@@ -1,0 +1,35 @@
+// Regression coverage for the heap_total_allocated / string_heap_total_allocated bindings:
+// total reserved capacity must stay >= live bytes, be non-zero, and never shrink across an
+// allocation. Catches a mis-wired binding / wrong return type / ABI drift. AOT-eligible (no
+// options no_aot) so the AOT codegen path for these builtins is exercised too.
+options gen2
+
+require dastest/testing_boost public
+
+// global → the allocation escapes to the heap (escape analysis won't stack-allocate it)
+var g_sink : array<int>
+
+[test]
+def test_heap_total_allocated(t : T?) {
+    t |> run("total reserved >= live bytes (both heaps)") @(t : T?) {
+        t |> success(heap_total_allocated() >= heap_bytes_allocated(),
+            "value heap: total reserved must be >= live bytes")
+        t |> success(string_heap_total_allocated() >= string_heap_bytes_allocated(),
+            "string heap: total reserved must be >= live bytes")
+    }
+    t |> run("totals are sane and non-decreasing after a large allocation") @(t : T?) {
+        let t0 = heap_total_allocated()
+        let b0 = heap_bytes_allocated()
+        g_sink |> resize(1048576)          // ~4 MB on the value heap
+        for (i in range(length(g_sink))) {
+            g_sink[i] = i
+        }
+        let t1 = heap_total_allocated()
+        let b1 = heap_bytes_allocated()
+        t |> success(b1 > b0, "live bytes must grow after the allocation")
+        t |> success(t1 >= b1, "total reserved must still be >= live bytes")
+        t |> success(t1 >= t0, "total reserved must not shrink across an allocation")
+        t |> success(t1 > 0ul, "total reserved must be non-zero")
+        g_sink |> resize(0)
+    }
+}

--- a/tests/live_host/test_lifecycle.das
+++ b/tests/live_host/test_lifecycle.das
@@ -24,6 +24,14 @@ def test_timing(t : T?) {
         let fps = get_fps()
         t |> success(fps >= 0.0f, "fps should be >= 0")
     }
+    // Must come last: advance_frame_clock latches the frame-driven clock for the rest of the process,
+    // after which get_dt() returns the stable per-frame cache (the standalone-loop fix).
+    t |> run("advance_frame_clock makes get_dt idempotent within a frame") @(t : T?) {
+        advance_frame_clock()
+        let a = get_dt()
+        let b = get_dt()
+        t |> success(a == b, "every get_dt() in one frame must return the same value")
+    }
 }
 
 [test]


### PR DESCRIPTION
A standalone `daslang game.das` runs its own `def main` loop, where the daslang-live host's clock and garbage collection are absent. Two gaps surface only there:

### `get_dt()` was a per-call stopwatch

It recomputed the delta on every call, so calling it twice in one frame split that frame's delta across the two calls (the second sees ~0). Now the frame delta is computed **once per frame** in `live_begin_frame` (`live_advance_frame_clock`) and cached; `get_dt()` returns that stable value for the rest of the frame. Under the live host this is a no-op — the host still owns the clock.

### the heap is never collected standalone

Added `maybe_collect_gc()` to `glfw_live`. It collects a heap only when it is **mostly free** (cheap compaction — little live data to walk), so it is safe to call every frame after update/render. The string heap fills faster, so it gets the lower threshold and is checked first. Ported from the daslang-live host's C++ collector. Requires `options gc` + `options persistent_heap`.

To drive the collector's "how full is the heap?" decision, expose the reserved-capacity counters alongside the existing live-byte ones:

- `heap_total_allocated()` / `string_heap_total_allocated()` — bytes the context heap / string heap have reserved from the OS (`totalAlignedMemoryAllocated`), including currently-free space
- pair with the existing `heap_bytes_allocated()` / `string_heap_bytes_allocated()` (live bytes in use)

### example games

All five example games (arcanoid, asteroids, pacman, river_run, sequence) now declare `options gc` and call `maybe_collect_gc()` in their standalone loop, so they reclaim memory instead of growing unbounded. Verified each runs standalone with the heap reclaiming (e.g. asteroids peak ~120 MB to ~17 MB live).

### lint

Also clears the pre-existing lint warnings across every touched file — mostly redundant `int(...)` casts on already-`int` arguments (GLFW key/button constants, character literals), plus a few `+= 1` to `++`, guard merges, and unused-arg renames. Requires that were flagged as unused are load-bearing side-effect registrations and are `nolint`'d with reasons.

Preflight (full tier) green: format, lint, cpp-syntax, dasgen, ci-das, docs (das2rst + sphinx latex/html + pdflatex), tests-cpp/interp/jit/aot, sequence smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)