### PR TITLE
docs: add dasVideo to external modules + announce it; de-dup two news titles

### DIFF
--- a/doc/source/external_modules/dasvideo.rst
+++ b/doc/source/external_modules/dasvideo.rst
@@ -1,0 +1,45 @@
+dasVideo
+========
+
+dasVideo is the daslang module for **video playback**: decode a clip to frames plus
+audio and hand them to your renderer, with A/V sync. Its design is "the player owns the
+decoded data, the consumer borrows it" — each frame's pixels and each audio batch are
+borrowed through RAII block accessors (no copy between the decoder and the GPU), and
+audio is the master clock the video paces to. ``video_open`` auto-detects the container
+from its magic bytes, so your code never names the codec; it plays from a file or from a
+borrowed in-memory buffer.
+
+Only royalty-free, permissively-licensed codecs are bound — both the code license and the
+codec patents have to be clear.
+
+Where to go
+-----------
+
+* **Documentation**: https://borisbat.github.io/dasVideo/
+* **Repository**: https://github.com/borisbat/dasVideo
+
+What's there
+------------
+
+* ``video`` — the playback surface: ``video_open`` / ``video_decode`` / ``video_rewind``,
+  stream info getters, and the borrow accessors — ``get_data`` (packed RGBA8 **or** the
+  decoder's native YUV420p planes, zero-copy) and ``get_audio_data`` (interleaved float
+  PCM). Audio is opt-in (``video_enable_audio``), and a ``video_open(data, size)``
+  overload plays from an in-memory buffer.
+* Codecs: **MPEG-1** video + MP2 audio (pl_mpeg, the always-on zero-dependency base), and
+  **AV1** video (dav1d) — as a raw ``.ivf`` elementary stream or inside a **WebM** container
+  (nestegg demux) alongside **Opus** audio (libopus). Each codec is vendor-and-compiled
+  from source under a single CMake flag, so a consumer needs only CMake + a C compiler.
+* Examples under ``examples/`` — windowed GL players (RGBA and a YUV→RGB shader path),
+  A/V-synced audio playback, and a video-textured spinning cube decoded straight from
+  memory. The decoded frames go to ``dasGlfw`` + ``dasOpenGL`` today; the borrow API is
+  ``dasImgui``-ready.
+* A seven-step tutorial ladder (open → decode → borrow → screen → GPU → sound → texture on
+  geometry) and headless decode tests that run in CI without a display.
+
+Licensing
+---------
+
+pl_mpeg is MIT, dav1d is BSD-2, nestegg is ISC, and libopus is BSD — all permissive, all
+royalty-free. FFmpeg, VP9, and Theora are deliberately **not** bound here; bind those
+yourself if you need them.

--- a/doc/source/external_modules/index.rst
+++ b/doc/source/external_modules/index.rst
@@ -12,3 +12,4 @@ module does and where its docs live.
    dasimguinodeeditor
    dasimguiimplot
    dasvulkan
+   dasvideo

--- a/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguiimplot.md
+++ b/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguiimplot.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-06
 tag: dasImguiImplot
-title: 0.6.3 is just around the corner. In the meantime, check out dasImguiImplot — immediate-mode plotting for daslang.
+title: dasImguiImplot adds immediate-mode plotting to daslang.
 link: https://borisbat.github.io/dasImguiImplot/
 ---

--- a/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguinodeeditor.md
+++ b/site/_news/2026-06-06-0-6-3-around-the-corner-check-out-dasimguinodeeditor.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-06
 tag: dasImguiNodeEditor
-title: 0.6.3 is just around the corner. In the meantime, check out dasImguiNodeEditor — node and graph editing on top of dasImgui.
+title: dasImguiNodeEditor brings node and graph editing on top of dasImgui.
 link: https://borisbat.github.io/dasImguiNodeEditor/
 ---

--- a/site/_news/2026-06-22-dasvideo-is-out-decode-webm-and-mpeg-1.md
+++ b/site/_news/2026-06-22-dasvideo-is-out-decode-webm-and-mpeg-1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-22
+tag: dasVideo
+title: dasVideo is out — decode WebM and MPEG-1 to a texture in daslang, with synced audio.
+link: https://borisbat.github.io/dasVideo/
+---


### PR DESCRIPTION
Final touch for the dasVideo work — surface it on the main docs + site.

## What's here

- **`doc/source/external_modules/dasvideo.rst`** — a new external-modules page (modeled on `dasvulkan.rst`): what dasVideo is (player-owns / consumer-borrows video playback with A/V sync), where its docs + repo live, the codecs (MPEG-1 + MP2 via pl_mpeg; AV1 via dav1d as raw `.ivf` or in **WebM** with **Opus** audio), the borrow API, and the permissive/royalty-free licensing. Added to the external-modules toctree.
- **`site/_news`** — a new entry announcing it: *"dasVideo is out — decode WebM and MPEG-1 to a texture in daslang, with synced audio."*
- **De-dup** the two 2026-06-06 news titles, which were copy-paste identical in the lead (*"0.6.3 is just around the corner. In the meantime, check out …"*). Reworded to timeless, distinct headlines with 0.6.3 dropped:
  - dasImguiNodeEditor → *"dasImguiNodeEditor brings node and graph editing on top of dasImgui."*
  - dasImguiImplot → *"dasImguiImplot adds immediate-mode plotting to daslang."*

  The published filename slugs are left unchanged (they're the post URLs).

## Verified

- Sphinx build generates `external_modules/dasvideo.html` and includes it in the toctree; no warnings reference the new page (the only build warnings are the pre-existing `stdlib/generated/*` autodoc stubs).
- All three news titles are now distinct, with no shared boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)