### PR TITLE
infer: fold ref2value of a non-ref value (fixes flatten helper-swizzle)

### DIFF
--- a/examples/flatten/capability/cap_helper_swizzle.shader
+++ b/examples/flatten/capability/cap_helper_swizzle.shader
@@ -1,0 +1,29 @@
+require engine.render.shader_dsl
+
+// Capability: a HELPER that reads its by-value vector param through single-component swizzles
+// (p.x/p.y/p.z). flatten inlines the helper, and copy-prop substitutes the (value) call argument
+// into the swizzle base. Before the typer folded ref2value-of-a-value, this failed to compile with
+// error[30921] "can only dereference a reference". Distilled from the reported heal_3d/force_field
+// shaders, whose edited helper versions added exactly this shape.
+
+var {
+    @color tint = float3(0.2, 0.6, 1.0)
+    scale = 2.0
+}
+
+def axis_mix(p : float3) : float {
+    return p.x * 0.5 + p.y - p.z * 0.25
+}
+
+[pixel_shader]
+def cap_helper_swizzle(inp : PbrInput) {
+    let m = axis_mix(inp.worldPos * scale)
+    return PbrOutput(
+        albedo = tint * m,
+        emission = float3(0),
+        emissionStrength = saturate(m),
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -415,6 +415,21 @@ else
     fail=1
 fi
 
+echo "22. cap_helper_swizzle.shader (helper swizzles a by-value vector param -> inlined cleanly)"
+out="$(compile "$here/cap_helper_swizzle.shader")"
+nodes="$(echo "$out" | grep -c '^node ')"
+errs="$(echo "$out" | grep -ci error)"
+# the helper reads p.x/p.y/p.z; flatten inlines it and copy-prop substitutes the (value) argument
+# into the swizzle base. Before the typer folded ref2value-of-a-value this failed with error[30921]
+# "can only dereference a reference". A clean compile proves the swizzled-param helper inlined.
+if [[ "$errs" -eq 0 && "$nodes" -gt 0 ]]; then
+    echo "   ok — compiles ($nodes nodes); the swizzled-param helper inlined cleanly"
+else
+    echo "   FAIL — errors=$errs nodes=$nodes"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
 echo
 if [[ "$fail" -eq 0 ]]; then echo "capability: all checks passed"; else echo "capability: FAILED"; fi
 exit $fail

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1058,15 +1058,11 @@ namespace das {
         }
         // infer
         if (!expr->subexpr->type->isRef()) {
-            if (expr->subexpr->rtti_isConstant()) {
-                reportAstChanged();
-                return expr->subexpr;
-            } else {
-                TextWriter tw;
-                tw << *expr->subexpr;
-                error("can only dereference a reference", tw.str(), "",
-                      expr->at, CompilationError::cant_dereference);
-            }
+            // ref2value of a non-ref is a no-op load: the subexpr is already a value.
+            // Drops a stale R2V left by AST surgery — e.g. flatten's copy-prop substituting
+            // a value into a swizzle base that was a ref local before (else error[30921]).
+            reportAstChanged();
+            return expr->subexpr;
         } else if (!expr->subexpr->type->isSimpleType()) {
             error("can only dereference value types, not a " + describeType(expr->subexpr->type), "", "",
                   expr->at, CompilationError::cant_dereference);

--- a/tests/flatten/no_aot/test_flatten_inline_swizzle.das
+++ b/tests/flatten/no_aot/test_flatten_inline_swizzle.das
@@ -1,0 +1,74 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+
+//! Regression for the helper-inline swizzle bug. flatten inlines a helper that reads a by-value
+//! VECTOR parameter through a single-component swizzle (`p.x`). copy_prop then substitutes the call
+//! argument into the swizzle base. That argument is a VALUE — arithmetic, or the value-copy of a
+//! ref — so the swizzle becomes non-ref, while the `p.x`-of-a-ref-local read it replaced still
+//! carried an ExprRef2Value. Before the typer folded ref2value-of-a-value (ast_infer_type.cpp), the
+//! generated `_flat` twin failed to compile with error[30921] "can only dereference a reference".
+//! Reported as the shaders heal_3d / force_field (examples/flatten); these cover the same shapes in
+//! plain flatten. The file COMPILING proves the twins build; the equal() checks prove equivalence.
+
+// helper whose by-value vector param is read via single-component swizzles
+def axis_mix(p : float3) : float {
+    return p.x * 0.5 + p.y - p.z * 0.25
+}
+
+// value source: the call argument is arithmetic (force_field's `(scrolledPos * gridScale).x`)
+[flatten]
+def inl_swizzle_val(s : float) : float {
+    return axis_mix(float3(s, s * 2.0, s - 1.0) * 1.5)
+}
+
+// ref source: the argument is a (by-value) vector param; the `var __flat_arg = v` value-copy
+// still feeds a non-ref swizzle base after copy_prop (heal_3d's `inp.worldPos`)
+[flatten]
+def inl_swizzle_ref(v : float3) : float {
+    return axis_mix(v)
+}
+
+// loop-unroll + helper inline, accumulating swizzled reads (heal_3d's per-seed loop)
+def hatch(p : float3; k : float) : float {
+    return p.y * k + p.x
+}
+
+[flatten]
+def inl_swizzle_loop(base : float3) : float {
+    var acc = 0.0
+    for (i in range(3)) {
+        acc += hatch(base * float(i + 1), float(i) * 0.5)
+    }
+    return acc
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-7.0, -1.0, 0.0, 1.0, 2.5, 7.0]
+}
+
+[test]
+def test_flatten_inline_swizzle(t : T?) {
+    t |> run("helper swizzle of a value-source vector arg") @(t : T?) {
+        for (v in GRID) {
+            t |> equal(inl_swizzle_val_flat(v), inl_swizzle_val(v))
+        }
+    }
+    t |> run("helper swizzle of a ref-source vector arg") @(t : T?) {
+        for (v in GRID) {
+            let p = float3(v, -v, v * 0.5)
+            t |> equal(inl_swizzle_ref_flat(p), inl_swizzle_ref(p))
+        }
+    }
+    t |> run("helper swizzle inlined across an unrolled loop") @(t : T?) {
+        for (v in GRID) {
+            let p = float3(v, -v, v * 0.5)
+            t |> equal(inl_swizzle_loop_flat(p), inl_swizzle_loop(p))
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A `flatten` shader with a **helper that reads a by-value vector parameter via a single-component swizzle** (`p.x`) fails to compile:

```
error[30921]: can only dereference a reference
  heal_3d:     p.y  ->  inp.worldPos.y
  force_field: p.x  ->  (scrolledPos * gridScale).x
```

Reported against `examples/flatten` shaders. The original sample shaders compile only because they are hand-inlined; the moment a helper factors the math out and swizzles its param, the inliner trips.

## Root cause

In the helper, `p.x` lowers to `ExprRef2Value(ExprSwizzle(.x, ExprVar(p)))` — valid because the local `p` is a reference, so the swizzle is a reference. flatten's `copy_prop_pass` (`daslib/flatten_opt.das`) then substitutes the single-def `__flat_arg` temp into **every** use, including the swizzle base. The substituted source is a **value** (arithmetic, or the value-copy of a ref), so the swizzle becomes non-ref while the stale `ExprRef2Value` wrapper remains. `InferTypes::visit(ExprRef2Value)` then errors because the subexpr is neither a reference nor a constant.

The typer **already** folds `ref2value`-of-a-constant one branch up (`ast_infer_type.cpp`). It just didn't handle the non-const-value case.

## Fix

Extend that fold: `ref2value` over any non-ref value is a no-op load — drop it and return the subexpr (mirrors the existing constant case). The fix is operand-agnostic, so it covers swizzle / struct-field / array-index alike, not just the shader-reachable swizzle. It only ever fires on AST-surgery-produced stale `R2V` — normally-inferred code never has `R2V` over a value, so it is a no-op on all existing code.

## Validation

- All reported repros compile (heal_3d 122 nodes, force_field 109)
- flatten shader suite: 91/91; `dastest tests/flatten`: 261/261
- **Full `dastest --test tests`: 10437 passed, 0 failed, 0 errors** (6 skipped = missing `.sf2` asset)
- Audit: `ExprRef2Value` was the only gap. `ExprPtr2Ref` already folds its safe no-op; `ExprRef2Ptr` (addr) correctly errors on a non-ref (cannot address a value). const-folder / simulate / AOT run after the typer, so never see a stale `R2V`.

## Tests added

- `tests/flatten/no_aot/test_flatten_inline_swizzle.das` — differential regression (value-source, ref-source, loop-unroll helper-swizzle). In `no_aot/` so no checked-in AOT `.cpp` to maintain.
- `examples/flatten/capability/cap_helper_swizzle.shader` + `check.sh` entry #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)