### PR TITLE
docs: rename pr_review_iteration skill to babysit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/preflight.md` | Pushing a non-trivial branch or reproducing a red CI lane — maps every PR-triggered CI lane to its exact local mirror command (or an honest "not mirrorable") |
 | `skills/abi_break_sweep.md` | Changing public C++ API, AST node layout, or daslib generic signatures that external module repos compile against — both-worlds spellings, externals-merge-first ordering, daspkg-index scope |
 | `skills/wsl_ci_repro.md` | Reproducing a Linux-only CI failure (sanitizers, POSIX divergence, headless timing) in the WSL CI-mirror distro — verbatim-CI recipe and its traps |
-| `skills/pr_review_iteration.md` | Working an open PR through CI failures and Copilot/human review feedback after the PR is created |
+| `skills/babysit.md` | Babysitting an open PR through CI failures and Copilot/human review feedback after the PR is created (the post-open loop) |
 | `skills/strudel_port.md` | Porting strudel.cc patterns into daslang |
 | `skills/clargs_usage.md` | Writing or editing any tool that parses command-line flags — declarative argv parsing via `daslib/clargs`, plus migration discipline for legacy `get_command_line_arguments()` callers |
 | `skills/json.md` | Reading/writing JSON in `.das` code (`sprint_json`/`sscan_json`, `JV`, manual `JsonValue?`) |

--- a/skills/babysit.md
+++ b/skills/babysit.md
@@ -1,6 +1,6 @@
-# PR Review Iteration
+# Babysit (PR review iteration)
 
-Use this skill after the pull request already exists. It covers the post-open loop: watching CI, triaging Copilot/human review comments, discussing verdicts with the user, applying fixes, replying, resolving threads, and re-requesting review.
+**Babysit** an open pull request through to merge. Use this skill after the PR already exists; it covers the post-open loop: watching CI, triaging Copilot/human review comments, discussing verdicts with the user, applying fixes, replying, resolving threads, and re-requesting review.
 
 ## 1. Watching the PR — the loop
 

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -323,4 +323,4 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | Wrap-up curation | `skills/task_wrap_up.md` | Optional. Add answers for cache misses, edit cached answers this PR invalidated |
 | `.md` stop | `git diff --name-only origin/master..HEAD \| grep '\.md$'` | If any match: STOP, list changes, ask user to review BEFORE push |
 | PR | GitHub MCP `create_pull_request` or `gh pr create` | — |
-| Review iter | Follow `skills/pr_review_iteration.md` | One round per Copilot pass; convergence in 1-3 rounds is normal |
+| Babysit | Follow `skills/babysit.md` | One round per Copilot pass; convergence in 1-3 rounds is normal |


### PR DESCRIPTION
Renames the post-open PR-loop skill to match what we call it — **babysit**.

- `skills/pr_review_iteration.md` → `skills/babysit.md` (git rename, history preserved; retitled, intro leads with the "babysit" term)
- `CLAUDE.md` skill-table row updated
- `skills/make_pr.md` quick-ref row updated (`Review iter` → `Babysit`)

Docs-only; no other references exist (`git grep pr_review_iteration` is now empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)