### PR TITLE
flatten: SSA-rename inlined-helper accumulators (+ JIT ref2value guard)

### DIFF
--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -25,6 +25,14 @@ def private is_flat_temp(name : das_string) : bool {
     return name |> starts_with("__flat_")
 }
 
+// Inlined-helper locals are uniquified to `__flat_loc_N` (inline_call). Unlike the loop/live
+// MASKS (`__flat_live`/`__flat_loop`/`__flat_iter`), an inlined `var` accumulator must be
+// SSA-renamed like a user accumulator — else it stays a self-referential `var` whose live init
+// a later DSE strips, leaving a null-init self-ref the shader backend rejects.
+def private is_flat_inlined_local(name : das_string) : bool {
+    return name |> starts_with("__flat_loc_")
+}
+
 // ===== Dead-store elimination =====
 // Straight-line body → liveness is one backward scan. Touches only `__flat_*` locals (never
 // user locals/globals); drops a store whose target is dead afterward and whose RHS is pure.
@@ -543,7 +551,8 @@ def public ssa_rename_pass(var out : array<ExpressionPtr>) {
     for (s in out) {
         if (s is ExprLet && length((s as ExprLet).variables) == 1) {
             let v = (s as ExprLet).variables[0]
-            if (!is_flat_temp(v.name) && v.init != null) declaredInit |> insert(hash(v.name))
+            // User locals, plus inline-renamed `__flat_loc_` accumulators (NOT the masks).
+            if ((!is_flat_temp(v.name) || is_flat_inlined_local(v.name)) && v.init != null) declaredInit |> insert(hash(v.name))
         }
     }
     if (empty(declaredInit)) {

--- a/examples/flatten/capability/cap_inline_accumulator.shader
+++ b/examples/flatten/capability/cap_inline_accumulator.shader
@@ -1,0 +1,28 @@
+require engine.render.shader_dsl
+
+// Capability: a `var` accumulator declared inside a HELPER and reassigned in a parallel loop.
+// flatten inlines the helper, uniquifying the accumulator to `__flat_loc_N`, and must SSA-rename
+// it like a user accumulator — else it stays a self-referential `var` whose live init a later DSE
+// strips, and the backend rejects the null-init self-ref (error[50503] undefined __flat_loc_N).
+// Distilled from the reported `dithering` shader (its 4x4 Bayer threshold accumulator).
+
+var { levels = 4.0 }
+
+def pick_threshold(cell : float) : float {
+    var threshold = 0.0
+    for (i, v in range(4), [0.0, 8.0, 4.0, 12.0]) {
+        threshold = float(i) == cell ? v * (1.0 / 16.0) : threshold
+    }
+    return threshold
+}
+
+[pixel_shader]
+def cap_inline_accumulator(inp : PbrInput) {
+    let cell = floor(frac(inp.uv.x) * 4.0)
+    let t    = pick_threshold(cell)
+    let q    = floor(inp.uv.y * levels + t) / levels
+    return PbrOutput(
+        albedo = float3(q, q, q), emission = float3(0), emissionStrength = 0.0,
+        metalness = 0.0, roughness = 1.0, ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -430,6 +430,21 @@ else
     fail=1
 fi
 
+echo "23. cap_inline_accumulator.shader (var accumulator in an inlined helper + parallel loop)"
+out="$(compile "$here/cap_inline_accumulator.shader")"
+nodes="$(echo "$out" | grep -c '^node ')"
+errs="$(echo "$out" | grep -ci error)"
+# the helper's `var threshold` accumulator is uniquified to __flat_loc_N when inlined; ssa_rename
+# must SSA-rename it like a user accumulator. Before that, it stayed a self-referential var whose
+# live init a later DSE stripped -> error[50503] undefined __flat_loc_N. (The dithering shader.)
+if [[ "$errs" -eq 0 && "$nodes" -gt 0 ]]; then
+    echo "   ok — compiles ($nodes nodes); the inlined-helper accumulator was SSA-renamed"
+else
+    echo "   FAIL — errors=$errs nodes=$nodes"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
 echo
 if [[ "$fail" -eq 0 ]]; then echo "capability: all checks passed"; else echo "capability: FAILED"; fi
 exit $fail

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -4510,8 +4510,14 @@ class public LlvmJitVisitor : AstVisitor {
 
 // ExprRef2Value
     def override visitExprRef2Value(expr : ExprRef2Value?) : ExpressionPtr {
-        setE(expr) <| LLVMBuildLoadData2Aligned(g_builder,
-            type_to_llvm_type(expr.subexpr._type), getE(expr.subexpr), expr._type.alignOf, "r2v")
+        // Mirror GetR2V (ast_simulate.cpp): a by-ref result type (struct/array/tuple/...) is held
+        // by reference — R2V is a no-op, keep the address; only a workhorse value actually loads.
+        if (expr._type.isRefType) {
+            setE(expr) <| getE(expr.subexpr)
+        } else {
+            setE(expr) <| LLVMBuildLoadData2Aligned(g_builder,
+                type_to_llvm_type(expr.subexpr._type), getE(expr.subexpr), expr._type.alignOf, "r2v")
+        }
         return expr
     }
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x27ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x28ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/tests/flatten/no_aot/test_flatten_inline_accumulator.das
+++ b/tests/flatten/no_aot/test_flatten_inline_accumulator.das
@@ -1,0 +1,72 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require daslib/ast
+require daslib/ast_boost
+require daslib/rtti
+require strings
+
+//! Regression for the inlined-accumulator SSA bug (reported as the `dithering` flatten shader).
+//! A `var` accumulator declared inside an INLINED helper and reassigned in a (parallel) loop is
+//! uniquified to `__flat_loc_N` by inline_call. ssa_rename_pass must SSA-rename it like a user
+//! accumulator — else it stays a self-referential `var __flat_loc_N` whose live `= init` a later
+//! DSE strips, leaving a null-init self-ref the shader backend rejects (error[50503] undefined
+//! __flat_loc_N). Plain flatten ACCEPTS the self-ref var (it is valid daslang), so a value check
+//! alone can't gate this — the structural half asserts the inlined accumulator was SSA-renamed
+//! (`__ssa___flat_loc_`), which is present iff ssa_rename processed it.
+
+// `acc` lives in the inlined helper; after inlining it is a `__flat_loc_` accumulator reassigned
+// across the unrolled loop. The equality-select mirrors the dithering Bayer accumulator; runtime
+// `sel` keeps the selects from const-folding away.
+def acc_pick(sel : float) : float {
+    var acc = 0.0
+    for (i, v in range(4), [0.0, 8.0, 4.0, 12.0]) {
+        acc = float(i) == sel ? v : acc
+    }
+    return acc
+}
+
+[flatten]
+def inline_acc(sel : float) : float {
+    return acc_pick(sel)
+}
+
+[test]
+def test_flatten_inline_accumulator(t : T?) {
+    t |> run("inlined-helper accumulator: flattened twin matches original") @(t : T?) {
+        // exact: the accumulator selects a constant per iteration, so no float reordering
+        for (sel in [0.0, 1.0, 2.0, 3.0, 9.0]) {
+            t |> equal(inline_acc_flat(sel), inline_acc(sel))
+        }
+    }
+    t |> run("inlined accumulator is SSA-renamed (not left a self-ref __flat_loc var)") @(t : T?) {
+        let root = get_das_root()
+        let path = "{root}/tests/flatten/no_aot/test_flatten_inline_accumulator.das"
+        var inscope access <- make_file_access("")
+        using() $(var mg : ModuleGroup) {
+            using() $(var cop : CodeOfPolicies) {
+                cop.threadlock_context = true
+                cop.version_2_syntax = true
+                compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                    t |> success(ok, "compile failed: {iss}")
+                    if (!ok) {
+                        return
+                    }
+                    var body = ""
+                    program_for_each_module(program) $(mod) {
+                        for_each_function(mod, "") $(func) {
+                            if (func.body != null && !func.flags.builtIn && func.name == "inline_acc_flat") {
+                                body = "{describe(func.body)}"
+                            }
+                        }
+                    }
+                    t |> success(!empty(body), "inline_acc_flat twin must be produced")
+                    t |> success(body |> find("__ssa___flat_loc") >= 0,
+                        "inlined accumulator must be SSA-renamed (ssa_rename_pass): {body}")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two related fixes for flatten/codegen, bundled per review.

## 1. flatten: inlined-helper accumulator SSA (fixes the `dithering` shader)

A `flatten` shader with a **`var` accumulator declared inside a helper and reassigned in a loop** fails to compile:

```
error[50503]: undefined variable __flat_loc_N (local|write|under_clone) referenced in shader code
error[50503]: shader variables must be initialized with a constant expression
```

Reported as the `dithering` shader (its 4×4 Bayer threshold accumulator lives inside a helper). Accumulators in the entry function compile fine; moving one into a helper trips flatten.

**Root cause — a 4-hop propagation (no single pass is wrong):**
1. **inline** — `inline_call` uniquifies the helper's `var threshold` to `__flat_loc_N`.
2. **ssa_rename skips it** — `ssa_rename_pass` guarded on `!is_flat_temp(v.name)`, so it SSA-converts *user* accumulators but skips the now-`__flat_`-named one → it stays a self-referential multi-def `var`.
3. **DSE strips the live init** — a later dead-store pass drops the `= 0.0` init as "dead", missing that the first unrolled select reads it (`… : __flat_loc_N`).
4. **backend rejects** — the shader validator gets a null-init, self-referential `__flat_loc_N`.

Confirmed pass-by-pass with `options log_infer_passes`: `var __flat_loc_2 = 0f` → (later) `var __flat_loc_2:float;`.

**Fix:** relax the skip so inline-renamed `__flat_loc_` accumulators are SSA-renamed like user accumulators, while still excluding the loop/live **masks** (`__flat_live`/`__flat_loop`/`__flat_iter`). `ssaNames` already only collects *reassigned* decls, so scoping to the `__flat_loc_` prefix leaves the masks untouched.

**Validation:** dithering + the full client shader set **78/78 compile**; `dastest tests/flatten` **264/264** (incl. break/continue/loop **mask** tests); in-repo + capability sweep **92/92**; value-identical to no-fix (within flatten's normal float-reorder ULPs).

**Tests:** `tests/flatten/no_aot/test_flatten_inline_accumulator.das` (differential + a **structural** `__ssa___flat_loc_` gate — the real gate, since plain flatten accepts the self-ref var and only the shader backend rejects it) + `examples/flatten/capability/cap_inline_accumulator.shader` + `check.sh` #23.

## 2. jit: mirror `GetR2V`'s by-ref-type no-op

The interpreter's `GetR2V` (`ast_simulate.cpp`) treats `ref2value` over a by-ref result type (struct/array/tuple/table/…) as a **no-op** — it keeps the address and only loads workhorse values. The dasLLVM JIT's `visitExprRef2Value` emitted a load **unconditionally**, diverging from the interpreter for by-ref types. Mirror the guard so JIT ref2value handling matches the interpreter exactly. Bumps `LLVM_JIT_CODEGEN_VERSION` (emitter change → invalidate cached `.dll`s).

**Validation:** struct `ref2value` parity (interpreter == JIT) + `tests/flatten` under JIT **264/264**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)