### PR TITLE
dasGLFW: native macOS fullscreen bindings

### DIFF
--- a/modules/dasGlfw/src/aot_dasGLFW.h
+++ b/modules/dasGlfw/src/aot_dasGLFW.h
@@ -16,6 +16,8 @@ namespace das {
     DAS_MOD_API void DasGlfw_Shutdown();
     DAS_MOD_API void DasGlfw_DestroyWindow ( GLFWwindow * window );
     DAS_MOD_API void * DAS_glfwGetNativeWindow ( GLFWwindow* window );
+    DAS_MOD_API bool DAS_glfwToggleNativeFullscreen ( GLFWwindow* window );
+    DAS_MOD_API int DAS_glfwIsNativeFullscreen ( GLFWwindow* window );
     DAS_MOD_API void DAS_glfwInitVulkanLoader ( void * loader );
     // chain + synthetic event API
     DAS_MOD_API void DasGlfw_ChainAddCursorPos ( GLFWwindow * window, TLambda<void,const GLFWwindow*,double,double> func, Context * ctx );

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -87,8 +87,9 @@ namespace das {
 
 // Native (Cocoa) fullscreen via NSWindow toggleFullScreen:, reached through the objc runtime so this
 // stays a plain .cpp (no ObjC++). A borderless window can't get a real macOS fullscreen Space — this is
-// the proper green-button / Ctrl-Cmd-F fullscreen. Returns whether it handled it; -1 from the query
-// means "not supported here" so callers fall back to a borderless window on Windows/Linux.
+// the proper green-button / Ctrl-Cmd-F fullscreen. Toggle returns whether it handled it; the query
+// returns -1 when there's no native fullscreen state to report (non-Apple platforms, or a null native
+// window) so callers fall back to a borderless window.
 #if defined(__APPLE__)
 #include <objc/message.h>
 #include <objc/runtime.h>
@@ -96,8 +97,10 @@ namespace das {
     bool DAS_glfwToggleNativeFullscreen ( GLFWwindow* window ) {
         void * win = glfwGetCocoaWindow(window);
         if ( !win ) return false;
-        // NSWindowCollectionBehaviorFullScreenPrimary (1<<7) — permit toggleFullScreen:
-        ((void(*)(void*,SEL,unsigned long))objc_msgSend)(win, sel_registerName("setCollectionBehavior:"), (unsigned long)(1ul<<7));
+        // OR-in NSWindowCollectionBehaviorFullScreenPrimary (1<<7) to permit toggleFullScreen: without
+        // clobbering the behavior flags GLFW already set
+        unsigned long cb = ((unsigned long(*)(void*,SEL))objc_msgSend)(win, sel_registerName("collectionBehavior"));
+        ((void(*)(void*,SEL,unsigned long))objc_msgSend)(win, sel_registerName("setCollectionBehavior:"), cb | (1ul<<7));
         ((void(*)(void*,SEL,void*))objc_msgSend)(win, sel_registerName("toggleFullScreen:"), nullptr);
         return true;
     }

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -85,6 +85,37 @@ namespace das {
     }
 }
 
+// Native (Cocoa) fullscreen via NSWindow toggleFullScreen:, reached through the objc runtime so this
+// stays a plain .cpp (no ObjC++). A borderless window can't get a real macOS fullscreen Space — this is
+// the proper green-button / Ctrl-Cmd-F fullscreen. Returns whether it handled it; -1 from the query
+// means "not supported here" so callers fall back to a borderless window on Windows/Linux.
+#if defined(__APPLE__)
+#include <objc/message.h>
+#include <objc/runtime.h>
+namespace das {
+    bool DAS_glfwToggleNativeFullscreen ( GLFWwindow* window ) {
+        void * win = glfwGetCocoaWindow(window);
+        if ( !win ) return false;
+        // NSWindowCollectionBehaviorFullScreenPrimary (1<<7) — permit toggleFullScreen:
+        ((void(*)(void*,SEL,unsigned long))objc_msgSend)(win, sel_registerName("setCollectionBehavior:"), (unsigned long)(1ul<<7));
+        ((void(*)(void*,SEL,void*))objc_msgSend)(win, sel_registerName("toggleFullScreen:"), nullptr);
+        return true;
+    }
+    int DAS_glfwIsNativeFullscreen ( GLFWwindow* window ) {
+        void * win = glfwGetCocoaWindow(window);
+        if ( !win ) return -1;
+        // NSWindowStyleMaskFullScreen (1<<14)
+        unsigned long mask = ((unsigned long(*)(void*,SEL))objc_msgSend)(win, sel_registerName("styleMask"));
+        return (mask & (1ul<<14)) ? 1 : 0;
+    }
+}
+#else
+namespace das {
+    bool DAS_glfwToggleNativeFullscreen ( GLFWwindow* ) { return false; }
+    int DAS_glfwIsNativeFullscreen ( GLFWwindow* ) { return -1; }
+}
+#endif
+
 
 namespace das {
 
@@ -444,6 +475,10 @@ namespace das {
         addExtern<DAS_BIND_FUN(DAS_glfwGetNativeWindow)>(*this, lib, "glfwGetNativeWindow",SideEffects::worstDefault, "DAS_glfwGetNativeWindow")
             ->args({"window"});
         addExtern<DAS_BIND_FUN(DAS_glfwGetNativeDisplay)>(*this, lib, "glfwGetNativeDisplay",SideEffects::worstDefault, "DAS_glfwGetNativeDisplay");
+        addExtern<DAS_BIND_FUN(DAS_glfwToggleNativeFullscreen)>(*this, lib, "glfwToggleNativeFullscreen",SideEffects::worstDefault, "DAS_glfwToggleNativeFullscreen")
+            ->args({"window"});
+        addExtern<DAS_BIND_FUN(DAS_glfwIsNativeFullscreen)>(*this, lib, "glfwIsNativeFullscreen",SideEffects::worstDefault, "DAS_glfwIsNativeFullscreen")
+            ->args({"window"});
         addExtern<DAS_BIND_FUN(DAS_glfwInitVulkanLoader)>(*this, lib, "glfwInitVulkanLoader",SideEffects::worstDefault, "DAS_glfwInitVulkanLoader")
             ->args({"loader"});
     }


### PR DESCRIPTION
## What

Adds two GLFW bindings for real fullscreen control:

- `glfwToggleNativeFullscreen(window) : bool`
- `glfwIsNativeFullscreen(window) : int`

## Why

On macOS a borderless window sized to the screen is **not** a real fullscreen Space — the menu bar/dock remain and the system offers "Enter Full Screen" in the Window menu. Getting a proper fullscreen Space requires `[NSWindow toggleFullScreen:]`.

## How

The dasGLFW module already bridges to the native `NSWindow` via `glfwGetCocoaWindow` (`DAS_glfwGetNativeWindow`). The new functions reach `toggleFullScreen:` and `styleMask` through the **objc runtime** (`objc_msgSend` / `sel_registerName`), so this stays a plain `.cpp` — no ObjC++/`.mm` file. All macOS code is gated by `#if __APPLE__`.

- `glfwToggleNativeFullscreen` sets `NSWindowCollectionBehaviorFullScreenPrimary` then toggles; returns whether it handled it (true on macOS).
- `glfwIsNativeFullscreen` returns 1/0 from the `NSWindowStyleMaskFullScreen` bit, or `-1` on non-Apple platforms so callers know to fall back to a borderless window.
- Non-Apple platforms get stubs (`false` / `-1`).
- Declared in `aot_dasGLFW.h` for AOT.

## Testing

Built Release locally on macOS (arm64) and verified the toggle enters/exits a real fullscreen Space and the query reflects the live window state. Non-Apple platforms compile via the stubs (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)