### PR TITLE
flatten_opt: rcp CSE'd/hoisted uniform divisors + examples/flatten client re-sync

### DIFF
--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -2261,6 +2261,17 @@ struct private PEX {
     noFastMath : bool                       // zero-init false = fast-math ON (the default)
 }
 
+// A ref to a hoisted / CSE'd let, carrying the replaced node's resolved type. The cse/alias loop runs
+// passes that read expr_bt BEFORE the macro re-infers (the rcp-rewrite's scalar-float gate is one) — an
+// un-typed ref reads as `none`, so those passes silently skip a freshly-hoisted divisor.
+def private hoisted_ref(refName : string; src : ExpressionPtr) : ExpressionPtr {
+    var v = new ExprVar(at = src.at, name := refName)
+    if (src._type != null) {
+        v._type = clone_type(src._type)
+    }
+    return v
+}
+
 // `x / U` rcp-candidate: a varying division by a preshader-eligible scalar-float NON-const
 // divisor — shared verbatim by the extraction rewrite and the opt residual oracle. A wholly-
 // uniform division hoists intact (maximal arm); a const divisor belongs to the fold arm.
@@ -2337,7 +2348,7 @@ def private pex_extract(var pe : PEX; barriers : table<string>; var e : Expressi
     if (psh_has_compute(e) && pex_eligible(pe, barriers, e)) {
         let nm = pex_hoist_name(pe, e)
         pe.changed = true
-        return new ExprVar(at = e.at, name := nm)
+        return hoisted_ref(nm, e)
     }
     if (e is ExprOp1) {
         var o = e as ExprOp1
@@ -2352,7 +2363,7 @@ def private pex_extract(var pe : PEX; barriers : table<string>; var e : Expressi
             pe.changed = true
             return new ExprOp2(at = o.at, op := "*",
                 left = pex_extract(pe, barriers, o.left),
-                right = new ExprVar(at = o.at, name := nm))
+                right = hoisted_ref(nm, o.right))   // 1/U shares U's (scalar-float) type
         }
         o.left = pex_extract(pe, barriers, o.left)
         o.right = pex_extract(pe, barriers, o.right)
@@ -2448,7 +2459,7 @@ def private extract_preshader(var func : FunctionPtr; var blk : ExprBlock?; barr
                 if (psh_has_compute(init)) {
                     // Whole uniform let: hoist its init, rename refs to the preshader temp, drop the decl.
                     let nm = pex_hoist_name(pe, init)
-                    pe.rename[vname] = new ExprVar(at = init.at, name := nm)
+                    pe.rename[vname] = hoisted_ref(nm, init)
                     pe.changed = true
                 } else {
                     // Trivial uniform alias (a bare global / member read): inline it at every use.
@@ -2624,7 +2635,7 @@ class private CseTally : AstVisitor {
 def private cse_replace_expr(var e : ExpressionPtr; key, refName : string) : ExpressionPtr {
     if (e == null) return null
     if (psh_has_compute(e) && "{describe(e)}" == key) {
-        return new ExprVar(at = e.at, name := refName)
+        return hoisted_ref(refName, e)
     }
     if (e is ExprOp1) {
         var o = e as ExprOp1

--- a/examples/flatten/backend/shader_dsl.das
+++ b/examples/flatten/backend/shader_dsl.das
@@ -6,3 +6,4 @@ module shader_dsl shared
 
 require engine.render.shader_dsl_primitives public
 require engine.render.shader_dsl_boost public
+

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -57,54 +57,31 @@ def clean_mangled_names(s : string) : string {
 let DEBUG_AT = false
 let PRIMITIVES_MODULE_NAME = "shader_dsl_primitives"
 
-// Bare function name from a (possibly mangled) symbol: an OR-type / generic instance is
-// named `__::<scope>`<name>`<hash>` (backtick == 96). A concrete builtin is already bare.
-[macro_function]
-def native_bare_name(fullname : string) : string {
-    let bt = 96  // '`'
-    let t1 = find(fullname, bt, 0)
-    if (t1 < 0) { return fullname }
-    let t2 = find(fullname, bt, t1 + 1)
-    return t2 < 0 ? slice(fullname, t1 + 1) : slice(fullname, t1 + 1, t2)
-}
-
 // Per-contract I/O struct names in PRIMITIVES_MODULE_NAME.
 // Add a row here when introducing a new contract.
 let CONTRACT_INPUT_STRUCTS : table<string; string> = {
-    "pbr"   => "PbrInput",
-    "unlit" => "UnlitInput"
+    "pbr"        => "PbrInput",
+    "unlit"      => "UnlitInput",
+    "posteffect" => "PostEffectInput"
 }
 let CONTRACT_OUTPUT_STRUCTS : table<string; string> = {
-    "pbr"   => "PbrOutput",
-    "unlit" => "UnlitOutput"
+    "pbr"        => "PbrOutput",
+    "unlit"      => "UnlitOutput",
+    "posteffect" => "PostEffectOutput"
 }
 
-// Leaf primitives flatten must KEEP (not inline). The native core math builtins
-// (mapped to opcodes via NATIVE_OPCODE) plus the engine-specific [hint] stubs and
-// the vector constructors the backend lowers directly. flatten matches by call name,
-// so list function names. `smooth_step` is absent — it is a native alias that flatten
-// INLINES to `smoothstep`. radians/degrees survive cycle 1 but carry no opcode:
-// flatten_opt lowers them to `x * K` (a `mul`) before the backend ever sees them.
+// Leaf primitives flatten must KEEP (not inline). These are the shader DSL's
+// [hint] primitives plus the vector constructors the backend lowers directly.
+// flatten matches by call name, so list function names (not the hint typeIds).
 let HINT_WHITELIST : table<string> <- {
     "tex2d", "noise",
     "abs", "min", "max", "clamp", "saturate", "frac", "floor", "ceil", "mad", "lerp",
-    "sqrt", "pow", "sin", "cos", "atan2", "log", "exp", "sign",
+    "sqrt", "pow", "sin", "cos", "atan2", "log", "exp", "sign", "radians", "degrees",
     "dot", "cross", "length", "normalize", "fresnel",
-    "remap", "one_minus", "step", "smoothstep", "radians", "degrees", "unpack_normal",
+    "remap", "one_minus", "step", "smooth_step", "unpack_normal",
     "float", "int",
-    "float2", "float3", "float4", "int2", "int3", "int4"
-}
-
-// Native core math builtins → shader-graph opcode. These carry no [hint] annotation
-// (they are daslang `math` builtins, not DSL stubs), so the validator maps them by
-// name. dot/length/normalize are width-dependent and resolved separately (below).
-let NATIVE_OPCODE : table<string; string> <- {
-    "abs" => "abs", "min" => "min", "max" => "max", "clamp" => "clamp", "saturate" => "sat",
-    "floor" => "floor", "ceil" => "ceil", "sign" => "sign",
-    "sqrt" => "sqrt", "pow" => "pow", "sin" => "sin", "cos" => "cos", "atan2" => "atan2",
-    "log" => "log", "exp" => "exp",
-    "lerp" => "lerp", "mad" => "mad", "step" => "step", "smoothstep" => "smoothStep",
-    "cross" => "cross_f3"
+    "float2", "float3", "float4", "int2", "int3", "int4",
+    "sample_scene_color", "sample_scene_depth"
 }
 
 // Surviving intrinsics that can't run in the per-draw preshader (texture sample / procedural
@@ -112,6 +89,7 @@ let NATIVE_OPCODE : table<string; string> <- {
 let SHADER_BARRIERS : table<string> <- {
     "tex2d", "noise"
 }
+
 
 let UV = "uv";
 let GTime = "gTime";
@@ -792,9 +770,9 @@ class ValidateShaderVisitor : AstVisitor {
             if (v._type.isPointer) {
                 errors.push(("shader code doesn't support pointer types", unsafe(addr(v.at))))
             }
-            if (v._type.baseType == Type.tFixedArray) {
-                errors.push(("shader code doesn't support vector literals; use float2/3/4 types instead", unsafe(addr(v.at))))
-            }
+            //if (v._type.baseType == Type.tFixedArray) {
+            //    errors.push(("shader code doesn't support vector literals; use float2/3/4 types instead", unsafe(addr(v.at))))
+            //}
             // A mutable `var` is an accumulator: it may be reassigned later via
             // `=` / `+=`. The init still emits a node normally; we just mark the
             // variable so reads/assignments are routed through accumCurPin.
@@ -887,36 +865,6 @@ class ValidateShaderVisitor : AstVisitor {
                 register_node(expr, irNode)
                 return
             }
-        }
-        // Native core math builtins (no [hint]): map the bare name to its opcode.
-        // dot/length/normalize resolve to a width-specific opcode from the operand.
-        let fn = native_bare_name("{expr.func.name}")
-        var nativeOp = NATIVE_OPCODE?[fn] ?? ""
-        if (nativeOp == "" && !empty(expr.arguments)) {
-            // dot/length/normalize: width-specific opcode, ONLY for an exact float2/3/4 operand
-            // (and arity). Any other type leaves nativeOp empty so an unrelated overload — e.g.
-            // length(string)/length(array) — falls through to the "unsupported function call"
-            // rejection rather than silently emitting len_f3 (fail-closed).
-            let w = expr.arguments[0]._type.baseType
-            let nargs = expr.arguments.length()
-            if (fn == "dot" && nargs == 2) {
-                nativeOp = w == Type.tFloat2 ? DotF2 : (w == Type.tFloat3 ? DotF3 : (w == Type.tFloat4 ? DotF4 : ""))
-            } elif (fn == "length" && nargs == 1) {
-                nativeOp = w == Type.tFloat2 ? LenF2 : (w == Type.tFloat3 ? LenF3 : (w == Type.tFloat4 ? LenF4 : ""))
-            } elif (fn == "normalize" && nargs == 1) {
-                nativeOp = w == Type.tFloat2 ? NormF2 : (w == Type.tFloat3 ? NormF3 : (w == Type.tFloat4 ? NormF4 : ""))
-            }
-        }
-        if (nativeOp != "") {
-            var irNode = begin_op(expr, nativeOp, kind)
-            for (arg in expr.arguments) {
-                add_arg(irNode, arg)
-            }
-            if (!expr.func.result.isVoid) {
-                irNode.outputs.push(add_pin(expr))
-            }
-            register_node(expr, irNode)
-            return
         }
         // Scalar `float(x)` cast — identity in the float-only shader graph. Useful
         // after loop unrolling, where an int loop index participates in float math
@@ -1082,9 +1030,9 @@ class ValidateShaderVisitor : AstVisitor {
             if (arg._type.isPointer) {
                 errors.push(("shader properties can't be pointers", unsafe(addr(arg.at))))
             }
-            if (arg._type.baseType == Type.tFixedArray) {
-                errors.push(("shader properties can't be vectors; use float2/3/4 types instead", unsafe(addr(arg.at))))
-            }
+            //if (arg._type.baseType == Type.tFixedArray) {
+            //    errors.push(("shader properties can't be vectors; use float2/3/4 types instead", unsafe(addr(arg.at))))
+            //}
             // if (!arg._type.isConst) {
             //     errors.push(("shader function arguments must be const", unsafe(addr(arg.at))))
             // }
@@ -1544,7 +1492,7 @@ def shader_build_ir(var func : FunctionPtr; var group : ModuleGroup; var errors 
             // macro transforms (loop unrolling, accumulator rewrites). Skipped on
             // normal asset builds so they never pay for the describe() build.
             if (sg_ir_want_ast_dump()) {
-                sg_ir_set_ast_dump("def {func.describe_function_short()}\n{func.body.describe()}".clean_mangled_names().replace("shader_dsl_primitives::", ""))
+                sg_ir_set_ast_dump(func.describe().clean_mangled_names().replace("shader_dsl_primitives::", ""))
             }
             for (prop in astVisitor.props) {
                 sg_ir_add_property(prop.name, int(prop._type), prop.defaultValue, prop.defaultTexture.name)

--- a/examples/flatten/backend/shader_dsl_primitives.das
+++ b/examples/flatten/backend/shader_dsl_primitives.das
@@ -4,13 +4,16 @@ options no_unused_function_arguments
 module shader_dsl_primitives shared public
 
 require daslib/stub
-require math public
 
 
-// Global engine inputs - not tied to any specific geometry contract.
+// Global engine inputs — not tied to any specific geometry contract.
 // Access these directly by name in any shader.
 var @alias = gTime g_Time : float
 var @alias = lightDir g_LightDirection : float3
+var @alias = cameraPos   g_CameraPosition : float3
+var @alias = cameraFwd   g_CameraForward  : float3
+var @alias = cameraRight g_CameraRight    : float3
+var @alias = cameraUp    g_CameraUp       : float3
 
 
 
@@ -29,6 +32,7 @@ struct PbrInput {
     @alias = viewDir     viewDir     : float3
     @alias = localPos    localPos    : float3
     @alias = localNormal localNormal : float3
+    @alias = screenPos   screenPos   : float2
 }
 
 struct PbrOutput {
@@ -50,6 +54,7 @@ struct UnlitInput {
     @alias = viewDir     viewDir     : float3
     @alias = localPos    localPos    : float3
     @alias = localNormal localNormal : float3
+    @alias = screenPos   screenPos   : float2
 }
 
 struct UnlitOutput {
@@ -58,20 +63,30 @@ struct UnlitOutput {
     @alias = out_alphaCutoff alphaCutoff : float  = 0.0
 }
 
+struct PostEffectInput {
+    @alias = screenPos screenPos : float2
+}
 
-// ---- Native core math --------------------------------------------------------
-// The component-wise math ops (abs/min/max/clamp/saturate/floor/ceil/sign/sqrt/pow/
-// sin/cos/atan2/log/exp/lerp/mad/step/smoothstep/radians/degrees/dot/cross/length/
-// normalize) are the daslang `math` builtins (re-exported above). The shader graph
-// backend recognises them by name (NATIVE_OPCODE in shader_dsl_boost.das) and maps
-// each to its opcode; radians/degrees carry no opcode — flatten_opt lowers them to a
-// multiply. Only the engine-specific leaves below remain DSL stubs.
+struct PostEffectOutput {
+    @alias = out_albedo out_color : float3 = float3(0)
+    @alias = out_alpha  alpha     : float  = 1.0
+}
+
+// struct VertexInput {}
+// struct VertexOutput {}
 
 
 // ---- Texture sampling -------------------------------------------------------
 
 [stub, hint(sampleTexture)]
 def tex2d(sampler : Sampler2D, uv : float2) : float4 {}
+
+[stub, hint(sampleSceneColor)]
+def sample_scene_color(uv : float2) : float3 {}
+
+// Returns eye depth (distance from camera in world units, reversed-Z corrected).
+[stub, hint(sampleSceneDepth)]
+def sample_scene_depth(uv : float2) : float {}
 
 
 // ---- Noise ------------------------------------------------------------------
@@ -83,8 +98,67 @@ def noise(pos : float2) : float {}
 def noise(pos : float3) : float {}
 
 
-// ---- Fractional part (no core builtin) --------------------------------------
+// ---- Generic (AnyFloat) component-wise operations ---------------------------
+// Overloaded per float width; the AST transformer maps them all to the same
+// shader graph node via the [hint] annotation.
 
+// add = + operator
+// sub = - operator
+// mul = * operator
+// div = / operator
+// neg = unary - operator
+
+// -- abs (unary) --
+[stub, hint(abs)]
+def abs(x : float) : float {}
+[stub, hint(abs)]
+def abs(x : float2) : float2 {}
+[stub, hint(abs)]
+def abs(x : float3) : float3 {}
+[stub, hint(abs)]
+def abs(x : float4) : float4 {}
+
+// -- min (binary) --
+[stub, hint(min)]
+def min(x : float | int, y : float | int) : float {}
+[stub, hint(min)]
+def min(x : float2, y : float2) : float2 {}
+[stub, hint(min)]
+def min(x : float3, y : float3) : float3 {}
+[stub, hint(min)]
+def min(x : float4, y : float4) : float4 {}
+
+// -- max (binary) --
+[stub, hint(max)]
+def max(x : float | int, y : float | int) : float {}
+[stub, hint(max)]
+def max(x : float2, y : float2) : float2 {}
+[stub, hint(max)]
+def max(x : float3, y : float3) : float3 {}
+[stub, hint(max)]
+def max(x : float4, y : float4) : float4 {}
+
+// -- clamp (ternary) --
+[stub, hint(clamp)]
+def clamp(x : float | int, min : float | int, max : float | int) : float {}
+[stub, hint(clamp)]
+def clamp(x : float2, min : float2, max : float2) : float2 {}
+[stub, hint(clamp)]
+def clamp(x : float3, min : float3, max : float3) : float3 {}
+[stub, hint(clamp)]
+def clamp(x : float4, min : float4, max : float4) : float4 {}
+
+// -- saturate (unary) --
+[stub, hint(sat)]
+def saturate(x : float | int) : float {}
+[stub, hint(sat)]
+def saturate(x : float2) : float2 {}
+[stub, hint(sat)]
+def saturate(x : float3) : float3 {}
+[stub, hint(sat)]
+def saturate(x : float4) : float4 {}
+
+// -- frac (unary) --
 [stub, hint(frac)]
 def frac(x : float | int) : float {}
 [stub, hint(frac)]
@@ -94,24 +168,205 @@ def frac(x : float3) : float3 {}
 [stub, hint(frac)]
 def frac(x : float4) : float4 {}
 
+// -- floor (unary) --
+[stub, hint(floor)]
+def floor(x : float | int) : float {}
+[stub, hint(floor)]
+def floor(x : float2) : float2 {}
+[stub, hint(floor)]
+def floor(x : float3) : float3 {}
+[stub, hint(floor)]
+def floor(x : float4) : float4 {}
 
-// ---- smoothstep: keep the engine `smooth_step` spelling as a native alias ----
-// The EdenSpark shaders spell it `smooth_step`; core spells it `smoothstep`. A thin
-// native alias (NOT a stub) keeps the shaders unedited — flatten inlines it to the
-// core call, which the backend maps to the SmoothStep opcode. The scalar form keeps the
-// old stub's `float | int` surface (auto-promote int edges to float) for the same reason
-// as the lerp compat overload below.
-def smooth_step(mn : float | int; mx : float | int; x : float | int) => smoothstep(float(mn), float(mx), float(x))
-def smooth_step(mn, mx, x : float2) => smoothstep(mn, mx, x)
-def smooth_step(mn, mx, x : float3) => smoothstep(mn, mx, x)
-def smooth_step(mn, mx, x : float4) => smoothstep(mn, mx, x)
+// -- ceil (unary) --
+[stub, hint(ceil)]
+def ceil(x : float | int) : float {}
+[stub, hint(ceil)]
+def ceil(x : float2) : float2 {}
+[stub, hint(ceil)]
+def ceil(x : float3) : float3 {}
+[stub, hint(ceil)]
+def ceil(x : float4) : float4 {}
+
+// -- mad (ternary: a * b + c) --
+[stub, hint(mad)]
+def mad(a : float | int, b : float | int, c : float | int) : float {}
+[stub, hint(mad)]
+def mad(a : float2, b : float2, c : float2) : float2 {}
+[stub, hint(mad)]
+def mad(a : float3, b : float3, c : float3) : float3 {}
+[stub, hint(mad)]
+def mad(a : float4, b : float4, c : float4) : float4 {}
+[stub, hint(mad)]
+def mad(a : float2, b : float, c : float2) : float2 {}
+[stub, hint(mad)]
+def mad(a : float3, b : float, c : float3) : float3 {}
+[stub, hint(mad)]
+def mad(a : float4, b : float, c : float4) : float4 {}
+
+// -- lerp (a, b: AnyFloat; t: float scalar) --
+[stub, hint(lerp)]
+def lerp(a : float | int, b : float | int, t : float) : float {}
+[stub, hint(lerp)]
+def lerp(a : float2, b : float2, t : float) : float2 {}
+[stub, hint(lerp)]
+def lerp(a : float3, b : float3, t : float) : float3 {}
+[stub, hint(lerp)]
+def lerp(a : float4, b : float4, t : float) : float4 {}
+
+// -- lerp with component-wise t (float2/3/4 weight per channel) --
+[stub, hint(lerp4)]
+def lerp(a : float2, b : float2, t : float2) : float2 {}
+[stub, hint(lerp4)]
+def lerp(a : float3, b : float3, t : float3) : float3 {}
+[stub, hint(lerp4)]
+def lerp(a : float4, b : float4, t : float4) : float4 {}
 
 
-// ---- Native-backed int-arg compat -------------------------------------------
-// The old DSL stubs accepted `float | int` and auto-promoted; core lerp is float-only.
-// A native-backed overload keeps `lerp(0.2, 10, daylight)` compiling unedited (the inner
-// all-float call binds to core lerp — concrete beats the OR-type, so no recursion).
-def lerp(a, b : float | int; t : float) => lerp(float(a), float(b), t)
+// ---- Transcendentals (AnyFloat, component-wise) -----------------------------
+
+// -- sqrt (unary) --
+[stub, hint(sqrt)]
+def sqrt(x : float | int) : float {}
+[stub, hint(sqrt)]
+def sqrt(x : float2) : float2 {}
+[stub, hint(sqrt)]
+def sqrt(x : float3) : float3 {}
+[stub, hint(sqrt)]
+def sqrt(x : float4) : float4 {}
+
+// -- pow (binary) --
+[stub, hint(pow)]
+def pow(x : float | int, y : float | int) : float {}
+[stub, hint(pow)]
+def pow(x : float2, y : float2) : float2 {}
+[stub, hint(pow)]
+def pow(x : float3, y : float3) : float3 {}
+[stub, hint(pow)]
+def pow(x : float4, y : float4) : float4 {}
+
+// -- sin (unary) --
+[stub, hint(sin)]
+def sin(x : float | int) : float {}
+[stub, hint(sin)]
+def sin(x : float2) : float2 {}
+[stub, hint(sin)]
+def sin(x : float3) : float3 {}
+[stub, hint(sin)]
+def sin(x : float4) : float4 {}
+
+// -- cos (unary) --
+[stub, hint(cos)]
+def cos(x : float | int) : float {}
+[stub, hint(cos)]
+def cos(x : float2) : float2 {}
+[stub, hint(cos)]
+def cos(x : float3) : float3 {}
+[stub, hint(cos)]
+def cos(x : float4) : float4 {}
+
+// -- atan2 (binary) --
+[stub, hint(atan2)]
+def atan2(x : float | int, y : float | int) : float {}
+[stub, hint(atan2)]
+def atan2(x : float2, y : float2) : float2 {}
+[stub, hint(atan2)]
+def atan2(x : float3, y : float3) : float3 {}
+[stub, hint(atan2)]
+def atan2(x : float4, y : float4) : float4 {}
+
+// -- log (unary) --
+[stub, hint(log)]
+def log(x : float | int) : float {}
+[stub, hint(log)]
+def log(x : float2) : float2 {}
+[stub, hint(log)]
+def log(x : float3) : float3 {}
+[stub, hint(log)]
+def log(x : float4) : float4 {}
+
+// -- exp (unary) --
+[stub, hint(exp)]
+def exp(x : float | int) : float {}
+[stub, hint(exp)]
+def exp(x : float2) : float2 {}
+[stub, hint(exp)]
+def exp(x : float3) : float3 {}
+[stub, hint(exp)]
+def exp(x : float4) : float4 {}
+
+// -- sign (unary) --
+[stub, hint(sign)]
+def sign(x : float | int) : float {}
+[stub, hint(sign)]
+def sign(x : float2) : float2 {}
+[stub, hint(sign)]
+def sign(x : float3) : float3 {}
+[stub, hint(sign)]
+def sign(x : float4) : float4 {}
+
+// -- radians / degrees (angle conversion; unary) --
+// Re-added locally (the client drop dropped them); flagged back to the client. flatten_opt
+// lowers each to a single `mul` (radians(x) -> x * K) when they resolve as math builtins.
+[stub, hint(radians)]
+def radians(x : float | int) : float {}
+[stub, hint(radians)]
+def radians(x : float2) : float2 {}
+[stub, hint(radians)]
+def radians(x : float3) : float3 {}
+[stub, hint(radians)]
+def radians(x : float4) : float4 {}
+
+[stub, hint(degrees)]
+def degrees(x : float | int) : float {}
+[stub, hint(degrees)]
+def degrees(x : float2) : float2 {}
+[stub, hint(degrees)]
+def degrees(x : float3) : float3 {}
+[stub, hint(degrees)]
+def degrees(x : float4) : float4 {}
+
+
+// ---- Dot product (dimension-specific, returns scalar) -----------------------
+
+[stub, hint(dot_f2)]
+def dot(x : float2, y : float2) : float {}
+
+[stub, hint(dot_f3)]
+def dot(x : float3, y : float3) : float {}
+
+[stub, hint(dot_f4)]
+def dot(x : float4, y : float4) : float {}
+
+
+// ---- Cross product ----------------------------------------------------------
+
+[stub, hint(cross_f3)]
+def cross(x : float3, y : float3) : float3 {}
+
+
+// ---- Length (dimension-specific, returns scalar) ----------------------------
+
+[stub, hint(len_f2)]
+def length(x : float2) : float {}
+
+[stub, hint(len_f3)]
+def length(x : float3) : float {}
+
+[stub, hint(len_f4)]
+def length(x : float4) : float {}
+
+
+// ---- Normalize (dimension-specific) -----------------------------------------
+
+[stub, hint(norm_f2)]
+def normalize(x : float2) : float2 {}
+
+[stub, hint(norm_f3)]
+def normalize(x : float3) : float3 {}
+
+[stub, hint(norm_f4)]
+def normalize(x : float4) : float4 {}
 
 
 // ---- Lighting / surface ops -------------------------------------------------
@@ -140,5 +395,63 @@ def one_minus(x : float3) : float3 {}
 [stub, hint(oneMinus)]
 def one_minus(x : float4) : float4 {}
 
+[stub, hint(step)]
+def step(x : float | int, y : float | int) : float {}
+[stub, hint(step)]
+def step(x : float2, y : float2) : float2 {}
+[stub, hint(step)]
+def step(x : float3, y : float3) : float3 {}
+[stub, hint(step)]
+def step(x : float4, y : float4) : float4 {}
+
+[stub, hint(smoothStep)]
+def smooth_step(min : float | int, max : float | int, x : float | int) : float {}
+[stub, hint(smoothStep)]
+def smooth_step(min : float2, max : float2, x : float2) : float2 {}
+[stub, hint(smoothStep)]
+def smooth_step(min : float3, max : float3, x : float3) : float3 {}
+[stub, hint(smoothStep)]
+def smooth_step(min : float4, max : float4, x : float4) : float4 {}
+
 [stub, hint(unpackNormal)]
 def unpack_normal(sample : float4) : float3 {}
+
+
+// ---- Swizzle / channel ops -------------------------------------------------
+
+// splatX == .x swizzle
+// splatY == .y swizzle
+// splatZ == .z swizzle
+// splatW == .w swizzle
+
+// [stub, hint(splatX)]
+// def splatX(v : float) : float {}
+// [stub, hint(splatX)]
+// def splatX(v : float2) : float {}
+// [stub, hint(splatX)]
+// def splatX(v : float3) : float {}
+// [stub, hint(splatX)]
+// def splatX(v : float4) : float {}
+
+// [stub, hint(splatY)]
+// def splatY(v : float2) : float {}
+// [stub, hint(splatY)]
+// def splatY(v : float3) : float {}
+// [stub, hint(splatY)]
+// def splatY(v : float4) : float {}
+
+// [stub, hint(splatZ)]
+// def splatZ(v : float3) : float {}
+// [stub, hint(splatZ)]
+// def splatZ(v : float4) : float {}
+
+// [stub, hint(splatW)]
+// def splatW(v : float4) : float {}
+
+// combineFloat2(x,y) = float2(x,y)
+// combineFloat3(x,y,z) = float3(x,y,z)
+// [stub, hint(combineFloat2)]
+// def combine_float2(x : float, y : float) : float2 {}
+
+// [stub, hint(combineFloat3)]
+// def combine_float3(x : float, y : float, z : float) : float3 {}

--- a/examples/flatten/capability/cap_rcp_shared.shader
+++ b/examples/flatten/capability/cap_rcp_shared.shader
@@ -1,0 +1,29 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    segments = 6.0
+}
+
+// A uniform divisor that is ALSO used as a multiplier in the same expression. The shared use
+// forces the divisor's value to be CSE'd / hoisted into a uniform `_preshader_` let; the
+// rcp-rewrite must still turn the per-pixel `x / slice` into `x * (1f / slice)`. Before the fix
+// the rewrite went blind to a freshly-hoisted (un-typed) divisor and left the per-pixel division
+// in — now both the reciprocal AND the multiplier ride one shared per-draw let, so the per-pixel
+// graph carries NO division by the uniform. (This is the kaleidoscope `frac(angle/slice)*slice`
+// shape, minimized.)
+[pixel_shader]
+def cap_rcp_shared(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let slice = 6.28318 / segments              // uniform
+    let folded = frac(c.x / slice) * slice      // divisor AND multiplier -> slice is CSE'd
+    let result = c * folded
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = 1.0,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -445,6 +445,23 @@ else
     fail=1
 fi
 
+echo "24. cap_rcp_shared.shader (uniform divisor also used as a multiplier -> still rcp'd)"
+out="$(FLATTEN_DUMP_DAS=1 compile "$here/cap_rcp_shared.shader")"
+rcps="$(echo "$out" | grep -c 'let _preshader_.*1f /')"
+divs="$(echo "$out" | grep -v 'let _preshader_' | grep -c '/ _preshader')"
+errs="$(echo "$out" | grep -ci error)"
+# `slice` is used as BOTH divisor and multiplier, so its value is CSE'd into a uniform _preshader_
+# let; the rcp-rewrite must still see through that freshly-hoisted (un-typed) divisor. With the fix
+# one shared `_preshader_N = 1f / slice` reciprocal exists and the per-pixel body has no `/ _preshader`
+# division — before it, the un-typed divisor read as `none` so the rcp gate skipped it (residual divide).
+if [[ "$errs" -eq 0 && "$rcps" -ge 1 && "$divs" -eq 0 ]]; then
+    echo "   ok — shared reciprocal preshader let; no per-pixel division by the CSE'd uniform"
+else
+    echo "   FAIL — errors=$errs rcp_lets=$rcps residual_divs=$divs (expected >=1 and 0)"
+    echo "$out" | grep -i error | head
+    fail=1
+fi
+
 echo
 if [[ "$fail" -eq 0 ]]; then echo "capability: all checks passed"; else echo "capability: FAILED"; fi
 exit $fail

--- a/examples/flatten/shaders/user_shaders/cells.shader
+++ b/examples/flatten/shaders/user_shaders/cells.shader
@@ -1,31 +1,43 @@
 require engine.render.shader_dsl
 
 var {
-    @color cellColor = float3(0.1, 0.4, 0.2)
-    @color edgeColor = float3(0.9, 1.0, 0.6)
-    @color deepColor = float3(0.0, 0.05, 0.0)
-    cellScale = 4.0
-    pulseSpeed = 0.5
+    @color cellColor  = float3(0.1, 0.4, 0.2)
+    @color edgeColor  = float3(0.9, 1.0, 0.6)
+    @color deepColor  = float3(0.0, 0.05, 0.0)
+    @color innerColor = float3(0.05, 0.25, 0.08)
+    cellScale         = 4.0
+    pulseSpeed        = 0.5
+}
+
+def cell_noise(p : float3; t : float; scale : float; drift : float3) : float {
+    return noise(p * scale + drift * t)
 }
 
 [pixel_shader]
 def cells(inp : PbrInput) {
-    let pulseT = g_Time * pulseSpeed
-    let uv = inp.worldPos * cellScale + float3(pulseT, 0, pulseT * 0.5)
-    let n = noise(uv)
+    let t = g_Time * pulseSpeed
 
-    let edgeMask = smooth_step(0.45, 0.55, n) - smooth_step(0.55, 0.65, n)
+    let n0 = cell_noise(inp.worldPos, t, cellScale,       float3(1.0, 0.0, 0.5))
+    let n1 = cell_noise(inp.worldPos, t, cellScale * 2.3, float3(-0.7, 0.0, 0.3))
+    let n2 = cell_noise(inp.worldPos, t, cellScale * 0.5, float3(0.2, 0.0, 0.8))
+
+    let n = n0 * 0.55 + n1 * 0.25 + n2 * 0.2
+
+    let edgeMask  = smooth_step(0.45, 0.55, n) - smooth_step(0.55, 0.65, n)
     let depthMask = smooth_step(0.6, 0.9, n)
+    let innerMask = smooth_step(0.35, 0.5, n) * (1.0 - depthMask)
 
-    let surface = lerp(cellColor, deepColor, depthMask)
+    let surface = lerp(lerp(cellColor, innerColor, innerMask), deepColor, depthMask)
+
+    let pulse = sin(t * 4.0) * 0.15 + 0.85
 
     let daylight = saturate(g_LightDirection.y)
     return PbrOutput(
         albedo = surface,
-        emission = edgeColor * edgeMask,
-        emissionStrength = edgeMask * lerp(0.1, 0.6, daylight),
+        emission = edgeColor * edgeMask * pulse,
+        emissionStrength = edgeMask * pulse * lerp(0.1, 0.6, daylight),
         metalness = 0.0,
-        roughness = 0.7,
+        roughness = lerp(0.4, 0.8, depthMask),
         ao = 1.0
     )
 }

--- a/examples/flatten/shaders/user_shaders/depth_fog_3d.shader
+++ b/examples/flatten/shaders/user_shaders/depth_fog_3d.shader
@@ -1,0 +1,42 @@
+require engine.render.shader_dsl
+
+// Demonstrates sample_scene_depth on a 3D object:
+// reads the depth behind the object's surface to compute
+// edge intersection thickness -- like soft particles / water foam.
+
+var {
+    @color shallowColor = float3(0.3, 0.7, 1.0)
+    @color deepColor    = float3(0.0, 0.2, 0.5)
+    @color edgeColor    = float3(0.8, 1.0, 1.0)
+    softDepth           = 1.5    // world-unit depth range for soft edge
+    edgeThreshold       = 0.25
+    opacity             = 0.7
+}
+
+def depth_thickness(screen_uv : float2; surface_depth : float) : float {
+    let scene_depth = sample_scene_depth(screen_uv)
+    return clamp((scene_depth - surface_depth) / softDepth, 0.0, 1.0)
+}
+
+[pixel_shader]
+def depth_fog_3d(inp : PbrInput) {
+    let surfaceDepth = length(inp.worldPos - g_CameraPosition)
+    let thickness    = depth_thickness(inp.screenPos, surfaceDepth)
+
+    let edgeMask = smooth_step(edgeThreshold, edgeThreshold + 0.15, thickness) * smooth_step(1.0, 0.7, thickness)
+
+    let bodyColor = lerp(shallowColor, deepColor, thickness)
+    let color     = lerp(bodyColor, edgeColor, edgeMask)
+
+    let f = fresnel(2.0, inp.worldNormal, inp.viewDir)
+
+    return PbrOutput(
+        albedo = color,
+        alpha  = lerp(0.05, opacity, thickness) + f * 0.2,
+        emission = edgeColor * edgeMask * 0.5,
+        emissionStrength = edgeMask * 0.8,
+        metalness = 0.0,
+        roughness = 0.1,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders/electric_3d.shader
+++ b/examples/flatten/shaders/user_shaders/electric_3d.shader
@@ -2,24 +2,39 @@ require engine.render.shader_dsl
 
 var {
     @color electricColor = float3(0.5, 0.8, 2.5)
-    @color coreColor = float3(1.5, 1.8, 2.5)
-    speed = 8.0
-    noiseScale = 6.0
+    @color coreColor     = float3(1.5, 1.8, 2.5)
+    @color arcColor      = float3(2.0, 2.5, 3.0)
+    speed                = 8.0
+    noiseScale           = 6.0
+    branchThreshold      = 0.72
+}
+
+def bolt_layer(p : float3; scale : float; t : float; dir : float3) : float {
+    let n1 = noise(p * scale      + dir * t)
+    let n2 = noise(p * scale * 2.0 - dir * t * 0.7)
+    return n1 * n2 * 2.0
 }
 
 [pixel_shader]
 def electric_3d(inp : PbrInput) {
     let t = g_Time * speed
-    let n1 = noise(inp.worldPos * noiseScale + float3(t, 0, 0))
-    let n2 = noise(inp.worldPos * noiseScale * 2.0 - float3(0, t, 0))
-    let bolt = step(0.75, n1 * n2 * 2.0)
-    let glow = smooth_step(0.5, 0.75, n1 * n2 * 2.0)
-    let flicker = sin(t * 3.0) * 0.5 + 0.5
+
+    let b0 = bolt_layer(inp.worldPos, noiseScale,        t, float3(1.0, 0.0, 0.0))
+    let b1 = bolt_layer(inp.worldPos, noiseScale * 1.5,  t, float3(0.0, 1.0, 0.3))
+    let b2 = bolt_layer(inp.worldPos, noiseScale * 0.7,  t, float3(-0.5, 0.0, 1.0))
+
+    let bolt = step(branchThreshold, max(b0, b1))
+    let arc  = step(branchThreshold + 0.08, b2) * (1.0 - bolt)
+    let glow = smooth_step(0.45, branchThreshold, b0 + b1 * 0.6)
+
+    let flicker  = sin(t * 3.0) * 0.5 + 0.5
+    let flicker2 = sin(t * 7.3 + 1.1) * 0.5 + 0.5
+
     let daylight = saturate(g_LightDirection.y)
     return PbrOutput(
         albedo = float3(0),
-        emission = coreColor * bolt * flicker + electricColor * glow,
-        emissionStrength = (bolt + glow * 0.5) * flicker * lerp(0.5, 2.5, daylight),
+        emission = coreColor * bolt * flicker + arcColor * arc * flicker2 + electricColor * glow,
+        emissionStrength = (bolt + arc * 0.7 + glow * 0.5) * flicker * lerp(0.5, 2.5, daylight),
         metalness = 0.0,
         roughness = 1.0,
         ao = 1.0

--- a/examples/flatten/shaders/user_shaders/iridescent.shader
+++ b/examples/flatten/shaders/user_shaders/iridescent.shader
@@ -1,30 +1,42 @@
 require engine.render.shader_dsl
 
 var {
-    @color baseTint = float3(0.05, 0.05, 0.1)
-    bandFreq = 8.0
-    bandPhaseR = 0.0
-    bandPhaseG = 2.1
-    bandPhaseB = 4.2
-    timeShift = 0.5
+    @color baseTint   = float3(0.05, 0.05, 0.1)
+    bandFreq          = 8.0
+    bandPhaseR        = 0.0
+    bandPhaseG        = 2.1
+    bandPhaseB        = 4.2
+    timeShift         = 0.5
+    microDetailScale  = 12.0
+    microDetailAmount = 0.3
+}
+
+def film_band(f : float; freq : float; phaseR : float; phaseG : float; phaseB : float; t : float) : float3 {
+    let phase = f * freq + t
+    return sin(float3(phase + phaseR, phase + phaseG, phase + phaseB)) * 0.5 + float3(0.5)
 }
 
 [pixel_shader]
 def iridescent(inp : PbrInput) {
     let f = fresnel(1.0, inp.worldNormal, inp.viewDir)
 
-    let phase = f * bandFreq + g_Time * timeShift
-    let phaseVec = float3(phase + bandPhaseR, phase + bandPhaseG, phase + bandPhaseB)
+    let macroFilm = film_band(f, bandFreq,        bandPhaseR, bandPhaseG, bandPhaseB, g_Time * timeShift)
+    let microFilm = film_band(f, bandFreq * 3.1,  bandPhaseB, bandPhaseR, bandPhaseG, g_Time * timeShift * 0.7)
 
-    let film = sin(phaseVec) * 0.5 + float3(0.5)
+    // Surface micro-variation via normal noise
+    let surfaceVar = noise(inp.worldNormal * microDetailScale) * microDetailAmount
+    let film = lerp(macroFilm, microFilm, surfaceVar)
+
     let intensity = pow(f, 1.5)
+    let viewAngle = saturate(dot(inp.worldNormal, inp.viewDir))
+    let grazeBoost = pow(1.0 - viewAngle, 3.0) * 0.4
 
     return PbrOutput(
         albedo = baseTint,
-        emission = film * intensity,
-        emissionStrength = intensity * 0.6,
+        emission = film * (intensity + grazeBoost),
+        emissionStrength = (intensity + grazeBoost) * 0.6,
         metalness = 1.0,
-        roughness = 0.15,
+        roughness = lerp(0.05, 0.25, surfaceVar),
         ao = 1.0
     )
 }

--- a/examples/flatten/shaders/user_shaders/scene_refraction.shader
+++ b/examples/flatten/shaders/user_shaders/scene_refraction.shader
@@ -1,0 +1,53 @@
+require engine.render.shader_dsl
+
+// Demonstrates both sample_scene_color and sample_scene_depth:
+// refracts the scene behind a glass-like surface using normal-based UV distortion,
+// and uses scene depth to tint deep regions with the glass color.
+
+var {
+    @color tintColor    = float3(0.15, 0.55, 0.9)
+    @color edgeColor    = float3(0.6, 0.9, 1.0)
+    refractStrength     = 0.04
+    tintDepth           = 4.0     // depth at which full tintColor is applied
+    fresnelPower        = 3.0
+    noiseScale          = 3.0
+    noiseSpeed          = 0.3
+}
+
+def refract_offset(normal : float3; right : float3; up : float3; strength : float; t : float; p : float3; scale : float) : float2 {
+    let ripple = noise(p * scale + float3(t, 0.0, t * 0.5)) * 0.5
+    let nx = dot(normal, right) + ripple * 0.3
+    let ny = dot(normal, up)    + ripple * 0.3
+    return float2(nx, ny) * strength
+}
+
+[pixel_shader]
+def scene_refraction(inp : PbrInput) {
+    let t = g_Time * noiseSpeed
+
+    let offset = refract_offset(
+        inp.worldNormal, g_CameraRight, g_CameraUp,
+        refractStrength, t, inp.worldPos, noiseScale)
+
+    let refractUV  = inp.screenPos + offset
+    let sceneColor = sample_scene_color(refractUV)
+
+    let surfaceDepth = length(inp.worldPos - g_CameraPosition)
+    let sceneDepth   = sample_scene_depth(inp.screenPos)
+    let depthBehind  = clamp((sceneDepth - surfaceDepth) / tintDepth, 0.0, 1.0)
+
+    let tinted = lerp(sceneColor, tintColor, depthBehind * 0.6)
+
+    let f    = fresnel(fresnelPower, inp.worldNormal, inp.viewDir)
+    let edge = lerp(tinted, edgeColor, pow(f, 2.0) * 0.5)
+
+    return PbrOutput(
+        albedo = edge,
+        alpha  = lerp(0.5, 0.95, f),
+        emission = edgeColor * pow(f, 4.0),
+        emissionStrength = 0.4,
+        metalness = 0.0,
+        roughness = 0.05,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders/water.shader
+++ b/examples/flatten/shaders/user_shaders/water.shader
@@ -1,34 +1,49 @@
 require engine.render.shader_dsl
 
 var {
-    @color deepColor = float3(0.0, 0.15, 0.35)
-    @color shallowColor = float3(0.2, 0.6, 0.8)
-    @color foamColor = float3(1.5, 1.6, 1.8)
-    waveSpeed = 0.6
-    waveScale = 5.0
-    foamThreshold = 0.55
+    @color deepColor      = float3(0.0, 0.15, 0.35)
+    @color shallowColor   = float3(0.2, 0.6, 0.8)
+    @color foamColor      = float3(1.5, 1.6, 1.8)
+    waveSpeed             = 0.6
+    waveScale             = 5.0
+    foamThreshold         = 0.55
+    normalStrength        = 0.6
+}
+
+def wave_octave(p : float3; speed : float; scale : float; t : float) : float {
+    return noise(p * scale + float3(t * speed, t * speed * 0.3, t * speed * 0.7))
+}
+
+def water_normal(p : float3; t : float; scale : float) : float3 {
+    let eps = 0.05
+    let c  = wave_octave(p, 0.6, scale, t)
+    let dx = wave_octave(p + float3(eps, 0.0, 0.0), 0.6, scale, t) - c
+    let dz = wave_octave(p + float3(0.0, 0.0, eps), 0.6, scale, t) - c
+    return normalize(float3(-dx * normalStrength, 1.0, -dz * normalStrength))
 }
 
 [pixel_shader]
 def water(inp : PbrInput) {
     let t = g_Time * waveSpeed
-    let uv1 = inp.worldPos * waveScale + float3(t, t * 0.3, t * 0.7)
-    let uv2 = inp.worldPos * (waveScale * 2.1) + float3(t * 1.6, 0, t * 0.5)
 
-    let n1 = noise(uv1)
-    let n2 = noise(uv2)
-    let n = n1 * 0.55 + n2 * 0.45
+    let n1 = wave_octave(inp.worldPos, 1.0,  waveScale,       t)
+    let n2 = wave_octave(inp.worldPos, 1.6,  waveScale * 2.1, t)
+    let n3 = wave_octave(inp.worldPos, 0.7,  waveScale * 0.5, t * 0.4)
+    let n = n1 * 0.5 + n2 * 0.3 + n3 * 0.2
 
     let depthMix = lerp(deepColor, shallowColor, n)
     let foamMask = smooth_step(foamThreshold, foamThreshold + 0.15, n)
-    let surface = lerp(depthMix, foamColor, foamMask)
+    let surface  = lerp(depthMix, foamColor, foamMask)
+
+    let nrm = water_normal(inp.worldPos, t, waveScale)
 
     return PbrOutput(
         albedo = surface,
         emission = foamColor * foamMask,
         emissionStrength = foamMask * 0.8,
+        normalMap = nrm,
         metalness = 0.0,
-        roughness = 0.2,
+        roughness = lerp(0.15, 0.4, foamMask),
         ao = 1.0
     )
 }

--- a/examples/flatten/shaders/user_shaders_2d/crt.shader
+++ b/examples/flatten/shaders/user_shaders_2d/crt.shader
@@ -1,0 +1,67 @@
+require engine.render.shader_dsl
+
+// CRT monitor simulation — barrel lens distortion, RGB scanlines,
+// phosphor glow (multi-tap), and flicker. Uses helper functions and loops.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    barrelStrength = 0.05
+    scanlineCount  = 120.0
+    scanlineDark   = 0.6
+    flickerSpeed   = 8.0
+    flickerAmt     = 0.04
+    glowSize       = 0.004
+}
+
+def barrel_uv(uv : float2; strength : float) : float2 {
+    let c = uv * 2.0 - float2(1.0, 1.0)
+    let r2 = dot(c, c)
+    let distort = 1.0 + r2 * strength
+    return (c * distort) * 0.5 + float2(0.5, 0.5)
+}
+
+def phosphor_glow(uv : float2; size : float) : float3 {
+    var acc = float3(0.0, 0.0, 0.0)
+    for (off in [float2(-1.0, 0.0), float2(0.0, 0.0), float2(1.0, 0.0),
+                 float2(0.0, -1.0), float2(0.0,  1.0)]) {
+        acc += tex2d(albedo_texture, uv + off * size).xyz
+    }
+    return acc * 0.2
+}
+
+[pixel_shader]
+def crt(inp : PbrInput) {
+    let distUV = barrel_uv(inp.uv, barrelStrength)
+
+    // vignette from barrel: kill pixels outside [0,1]
+    let inBounds = (step(0.0, distUV.x) * step(distUV.x, 1.0) * step(0.0, distUV.y) * step(distUV.y, 1.0))
+
+    let base = tex2d(albedo_texture, distUV).xyz
+
+    // RGB channel split — tiny lateral offset per channel
+    let r = tex2d(albedo_texture, distUV + float2( glowSize, 0.0)).x
+    let g = base.y
+    let b = tex2d(albedo_texture, distUV - float2( glowSize, 0.0)).z
+    let rgb = float3(r, g, b)
+
+    // Horizontal scanlines
+    let scanMask = lerp(scanlineDark, 1.0, step(0.5, frac(distUV.y * scanlineCount)))
+    let scanned = rgb * scanMask
+
+    // Phosphor glow
+    let glow = phosphor_glow(distUV, glowSize * 2.0)
+
+    // Flicker
+    let flicker = 1.0 - flickerAmt * (sin(g_Time * flickerSpeed) * 0.5 + 0.5)
+
+    let result = (scanned + glow * 0.3) * flicker * inBounds
+
+    return PbrOutput(
+        albedo = result,
+        emission = glow * 0.5 * inBounds,
+        emissionStrength = 0.8,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders_2d/damage.shader
+++ b/examples/flatten/shaders/user_shaders_2d/damage.shader
@@ -1,0 +1,27 @@
+require engine.render.shader_dsl
+
+var {
+    @color vignetteColor = float3(1.0, 0.05, 0.05)
+    shakeStrength        = 0.008
+    vignetteStrength     = 0.7
+    desaturation         = 0.5
+    pulseSpeed           = 3.5
+}
+
+[pixel_shader]
+def damage(inp : PostEffectInput) {
+    let uv    = inp.screenPos
+    let pulse = sin(g_Time * pulseSpeed) * 0.5 + 0.5
+
+    let shakeX = (noise(float2(g_Time * 12.0, 0.0)) - 0.5) * shakeStrength * pulse
+    let shakeY = (noise(float2(0.0, g_Time * 11.3)) - 0.5) * shakeStrength * pulse
+    let scene  = sample_scene_color(uv + float2(shakeX, shakeY))
+
+    let gray  = dot(scene, float3(0.299, 0.587, 0.114))
+    let desat = lerp(scene, float3(gray), desaturation * pulse)
+
+    let dist     = length(uv - float2(0.5)) * 1.41421
+    let vignette = smooth_step(0.4, 1.0, dist) * vignetteStrength * pulse
+
+    return PostEffectOutput(out_color = lerp(desat, vignetteColor, vignette))
+}

--- a/examples/flatten/shaders/user_shaders_2d/depth_outline.shader
+++ b/examples/flatten/shaders/user_shaders_2d/depth_outline.shader
@@ -1,0 +1,29 @@
+require engine.render.shader_dsl
+
+var {
+    @color outlineColor = float3(0.1, 0.8, 1.0)
+    outlineThickness    = 0.001
+    depthThreshold      = 0.5
+    maxDepth            = 80.0
+    darken              = 0.5
+}
+
+[pixel_shader]
+def depth_outline(inp : PostEffectInput) {
+    let uv    = inp.screenPos
+    let scene = sample_scene_color(uv)
+
+    let c = sample_scene_depth(uv)
+    let n = sample_scene_depth(uv + float2(0.0,  outlineThickness))
+    let s = sample_scene_depth(uv + float2(0.0, -outlineThickness))
+    let e = sample_scene_depth(uv + float2( outlineThickness, 0.0))
+    let w = sample_scene_depth(uv + float2(-outlineThickness, 0.0))
+    let maxDiff = max(max(abs(c - n), abs(c - s)), max(abs(c - e), abs(c - w)))
+    let edge    = smooth_step(depthThreshold, depthThreshold * 3.0, maxDiff)
+
+    let skyMask = step(maxDepth * 0.98, c)
+    let outline = outlineColor * edge * (1.0 - skyMask)
+    let dimmed  = lerp(scene * darken, scene, 1.0 - edge)
+
+    return PostEffectOutput(out_color = dimmed + outline)
+}

--- a/examples/flatten/shaders/user_shaders_2d/depth_vis.shader
+++ b/examples/flatten/shaders/user_shaders_2d/depth_vis.shader
@@ -1,0 +1,12 @@
+require engine.render.shader_dsl
+
+var {
+    max_depth = 50.0
+}
+
+[pixel_shader]
+def depth_vis(inp : PostEffectInput) {
+    let depth = sample_scene_depth(inp.screenPos)
+    let t = smooth_step(1.0, 0.0, depth / max_depth)
+    return PostEffectOutput(out_color = float3(t))
+}

--- a/examples/flatten/shaders/user_shaders_2d/dithering.shader
+++ b/examples/flatten/shaders/user_shaders_2d/dithering.shader
@@ -1,0 +1,48 @@
+require engine.render.shader_dsl
+
+// Ordered (Bayer) dithering — quantizes the image to `levels` shades using
+// a 4x4 Bayer threshold matrix encoded as a literal array.
+// The `?:` loop accumulator selects the threshold for the current pixel cell.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    levels         = 4.0
+    pixelSize      = 3.0
+    @color tint    = float3(1.0, 1.0, 1.0)
+}
+
+def bayer4(px : float2) : float {
+    // 4x4 Bayer matrix row-major, values / 16
+    let xi  = floor(frac(px.x * 0.25) * 4.0)
+    let yi  = floor(frac(px.y * 0.25) * 4.0)
+    let row = yi * 4.0 + xi
+
+    var threshold = 0.0
+    for (i, v in range(16),
+                 [0.0,  8.0,  2.0, 10.0,
+                  12.0, 4.0, 14.0,  6.0,
+                  3.0, 11.0,  1.0,  9.0,
+                  15.0, 7.0, 13.0,  5.0]) {
+        threshold = float(i) == row ? v * (1.0 / 16.0) : threshold
+    }
+    return threshold
+}
+
+[pixel_shader]
+def dithering(inp : PbrInput) {
+    let pixelUV   = floor(inp.uv * pixelSize * 128.0) / (pixelSize * 128.0)
+    let c         = tex2d(albedo_texture, pixelUV).xyz * tint
+    let gray      = dot(c, float3(0.299, 0.587, 0.114))
+    let thresh    = bayer4(inp.uv * pixelSize * 128.0)
+    let quantized = floor(gray * levels + thresh) / levels
+    let result    = c * (quantized / max(gray, 0.001))
+
+    return PbrOutput(
+        albedo           = result,
+        emission         = result * quantized * 0.3,
+        emissionStrength = 0.4,
+        metalness        = 0.0,
+        roughness        = 1.0,
+        ao               = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders_2d/frost.shader
+++ b/examples/flatten/shaders/user_shaders_2d/frost.shader
@@ -1,0 +1,42 @@
+require engine.render.shader_dsl
+
+var {
+    @color frostColor   = float3(0.75, 0.90, 1.0)
+    @color iceEdgeColor = float3(0.95, 0.98, 1.0)
+    @color deepIce      = float3(0.4,  0.65, 1.0)
+    freezeAmount        = 0.65
+    crystalScale        = 9.0
+}
+
+[pixel_shader]
+def frost(inp : PostEffectInput) {
+    let uv = inp.screenPos
+
+    // Edge-based mask: stronger at screen edges, zero in center
+    let dist    = length(uv - float2(0.5)) * 1.41421
+    let iceMask = smooth_step(1.0 - freezeAmount, 1.0, dist)
+
+    // Crystal structure: three overlapping noise layers at different scales/angles
+    // Using abs(noise - 0.5) * 2 sharpens each into a ridge pattern
+    let n1 = abs(noise(uv * crystalScale) - 0.5) * 2.0
+    let n2 = abs(noise(uv * crystalScale * 1.7 + float2(0.4, 0.9)) - 0.5) * 2.0
+    let n3 = abs(noise(uv * crystalScale * 0.6 + float2(1.3, 0.2)) - 0.5) * 2.0
+
+    // Crystal edges = where ridges from different layers intersect (minimum = tightest crossing)
+    let cellEdge = min(min(n1, n2), n3)
+    let edge     = smooth_step(0.15, 0.0, cellEdge) * iceMask  // sharp bright lines
+
+    // Fill: deeper ice color in cell interiors
+    let fill = smooth_step(0.5, 0.8, n1 * 0.5 + n2 * 0.5) * iceMask
+
+    // Scene: desaturate and blue-tint under ice, blur slightly
+    let offset = float2(n1 - 0.5, n2 - 0.5) * 0.003 * iceMask
+    let scene  = sample_scene_color(uv + offset)
+    let gray   = dot(scene, float3(0.299, 0.587, 0.114))
+    let frozen = lerp(scene, lerp(float3(gray) * frostColor, deepIce, fill), iceMask * 0.8)
+
+    // Overlay bright crystal edges on top
+    let result = frozen + iceEdgeColor * edge * 1.5
+
+    return PostEffectOutput(out_color = result)
+}

--- a/examples/flatten/shaders/user_shaders_2d/heal.shader
+++ b/examples/flatten/shaders/user_shaders_2d/heal.shader
@@ -1,0 +1,20 @@
+require engine.render.shader_dsl
+
+var {
+    @color vignetteColor  = float3(0.05, 0.9, 0.15)
+    vignetteStrength      = 0.7
+    pulseSpeed            = 1.2
+}
+
+[pixel_shader]
+def heal(inp : PostEffectInput) {
+    let uv    = inp.screenPos
+    let pulse = sin(g_Time * pulseSpeed) * 0.3 + 0.7
+
+    let scene = sample_scene_color(uv)
+
+    let dist     = length(uv - float2(0.5)) * 1.41421
+    let vignette = smooth_step(0.4, 1.0, dist) * vignetteStrength * pulse
+
+    return PostEffectOutput(out_color = lerp(scene, vignetteColor, vignette))
+}

--- a/examples/flatten/shaders/user_shaders_2d/heat_haze.shader
+++ b/examples/flatten/shaders/user_shaders_2d/heat_haze.shader
@@ -1,0 +1,25 @@
+require engine.render.shader_dsl
+
+var {
+    @color tintColor  = float3(1.05, 0.92, 0.75)
+    hazeStrength      = 0.012
+    hazeSpeed         = 1.2
+    hazeScale         = 6.0
+    heightFalloff     = 2.0
+}
+
+[pixel_shader]
+def heat_haze(inp : PostEffectInput) {
+    let uv = inp.screenPos
+    let t  = g_Time * hazeSpeed
+
+    let heatMask = pow(1.0 - uv.y, heightFalloff)
+    let n1 = noise(float2(uv.x * hazeScale,       uv.y * hazeScale * 0.5 + t))
+    let n2 = noise(float2(uv.x * hazeScale * 1.7, uv.y * hazeScale * 0.8 - t * 0.6))
+    let offset = float2(n1 - 0.5, n2 - 0.5) * hazeStrength * heatMask
+
+    let scene  = sample_scene_color(uv + offset)
+    let tinted = lerp(scene, scene * tintColor, heatMask * 0.4)
+
+    return PostEffectOutput(out_color = tinted)
+}

--- a/examples/flatten/shaders/user_shaders_2d/helmet.shader
+++ b/examples/flatten/shaders/user_shaders_2d/helmet.shader
@@ -1,0 +1,56 @@
+require engine.render.shader_dsl
+
+var {
+    @color visorColor = float3(0.3, 0.7, 1.0)
+    @color hudColor   = float3(0.2, 1.0, 0.5)
+    visorThickness    = 0.07   // thickness of the visor frame ring
+    lensDistort       = 0.04
+}
+
+[pixel_shader]
+def helmet(inp : PostEffectInput) {
+    let uv = inp.screenPos
+
+    // Oval visor shape: scale Y so the visor is wider than tall
+    let centered = uv - float2(0.5)
+    let oval     = float2(centered.x * 0.85, centered.y * 1.15)
+    let ovalDist = length(oval)
+
+    // Lens barrel distortion (only inside visor)
+    let r2     = dot(centered, centered)
+    let distUV = centered * (1.0 + lensDistort * r2) + float2(0.5)
+    let scene  = sample_scene_color(distUV)
+
+    // inside = 1 inside visor, 0 outside
+    let inside    = smooth_step(0.52, 0.50, ovalDist)
+    // innerEdge = 1 in visor interior (not the frame border)
+    let innerEdge = smooth_step(0.45, 0.43, ovalDist)
+    // frame = just the ring border
+    let frame     = inside * (1.0 - innerEdge)
+
+    // Outer darkness beyond visor
+    let outside = smooth_step(0.50, 0.58, ovalDist)
+
+    // Subtle reflection streak in upper-left of visor
+    let reflectUV = float2(centered.x + 0.15, centered.y + 0.2)
+    let reflectDist = length(float2(reflectUV.x * 2.5, reflectUV.y * 0.6))
+    let reflection = smooth_step(0.18, 0.0, reflectDist) * innerEdge * 0.35
+
+    // HUD: thin horizontal line at bottom third of visor
+    let hudLine = smooth_step(0.004, 0.0, abs(centered.y + 0.12)) * smooth_step(0.35, 0.30, abs(centered.x)) * innerEdge
+
+    // HUD: corner bracket marks
+    let bx = abs(centered.x) - 0.28
+    let by = abs(centered.y) - 0.18
+    let bracketX = smooth_step(0.003, 0.0, abs(bx)) * smooth_step(0.0, 0.04, by) * smooth_step(0.07, 0.03, by) * innerEdge
+    let bracketY = smooth_step(0.003, 0.0, abs(by)) * smooth_step(0.0, 0.04, bx) * smooth_step(0.07, 0.03, bx) * innerEdge
+    let brackets = saturate(bracketX + bracketY)
+
+    let pulse = sin(g_Time * 2.0) * 0.15 + 0.85
+
+    let base    = scene * (1.0 - outside * 0.97)
+    let withRim = base + visorColor * frame * 0.9 + float3(reflection)
+    let result  = withRim + hudColor * (hudLine + brackets) * pulse
+
+    return PostEffectOutput(out_color = result)
+}

--- a/examples/flatten/shaders/user_shaders_2d/kaleidoscope.shader
+++ b/examples/flatten/shaders/user_shaders_2d/kaleidoscope.shader
@@ -1,0 +1,43 @@
+require engine.render.shader_dsl
+
+// Kaleidoscope — maps UV into polar coordinates, folds the angle into one
+// of `segments` slices, then samples a texture through the mirrored UV.
+// Uses branches to handle the mirroring and quadrant mapping.
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    segments       = 6.0
+    zoom           = 0.4
+    speed          = 0.2
+    twist          = 0.5
+}
+
+def polar_fold(uv : float2; segs : float; t : float) : float2 {
+    let c  = uv - float2(0.5, 0.5)
+    let cx = c.x
+    let cy = c.y
+    let r  = length(c)
+    let angle = atan2(cy, cx) + t
+
+    let slice = 3.14159 * 2.0 / segs
+    let a = frac(angle / slice) * slice
+    let mirrored_a = a > slice * 0.5 ? slice - a : a
+
+    return float2(cos(mirrored_a), sin(mirrored_a)) * r * zoom + float2(0.5, 0.5)
+}
+
+[pixel_shader]
+def kaleidoscope(inp : PbrInput) {
+    let t = g_Time * speed
+    let folded = polar_fold(inp.uv, segments, t + length(inp.uv - float2(0.5, 0.5)) * twist)
+    let c = tex2d(albedo_texture, folded)
+
+    return PbrOutput(
+        albedo = c.xyz,
+        emission = c.xyz * 0.3,
+        emissionStrength = 0.5,
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders_2d/mandelbrot.shader
+++ b/examples/flatten/shaders/user_shaders_2d/mandelbrot.shader
@@ -1,0 +1,41 @@
+require engine.render.shader_dsl
+
+// Fractal Brownian Motion (fBm) — 6 octaves of noise, each at double frequency
+// and half amplitude. Written as explicit octave additions (no loop) so the
+// shader compiler can resolve every expression statically.
+// Domain-warping: UV is displaced by fBm itself before the final sample,
+// creating the characteristic "folded" fractal look.
+
+var {
+    @color colorA  = float3(0.05, 0.0, 0.15)
+    @color colorB  = float3(0.4, 0.1, 0.8)
+    @color colorC  = float3(1.0, 0.5, 0.1)
+    scale          = 3.0
+    speed          = 0.12
+    warpStrength   = 0.6
+}
+
+def fbm(p : float2) : float {
+    return noise(p) * 0.5 + noise(p * 2.1) * 0.25 + noise(p * 4.41) * 0.125 + noise(p * 9.261) * 0.0625 + noise(p * 19.448) * 0.03125 + noise(p * 40.841) * 0.015625
+}
+
+[pixel_shader]
+def mandelbrot(inp : PbrInput) {
+    let t  = g_Time * speed
+    let uv = inp.uv * scale + float2(t, t * 0.3)
+
+    let wx   = fbm(uv + float2(1.7, 9.2))
+    let wy   = fbm(uv + float2(8.3, 2.8))
+    let n    = fbm(uv + float2(wx, wy) * warpStrength)
+
+    let c = n < 0.5 ? lerp(colorA, colorB, n * 2.0) : lerp(colorB, colorC, (n - 0.5) * 2.0)
+
+    return PbrOutput(
+        albedo           = c,
+        emission         = c * n,
+        emissionStrength = n * 1.5,
+        metalness        = 0.0,
+        roughness        = 1.0,
+        ao               = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders_2d/scanner.shader
+++ b/examples/flatten/shaders/user_shaders_2d/scanner.shader
@@ -1,0 +1,30 @@
+require engine.render.shader_dsl
+
+var {
+    @color scan_color = float3(0.0, 1.0, 0.4)
+    speed     = 4.0    // wave travel speed in world units/sec
+    frequency = 0.4    // rings per world unit (lower = wider spacing)
+    sharpness = 10.0   // ring thinness (higher = narrower rings)
+    intensity = 3.0    // peak ring brightness
+    dim_scene = 0.15   // scene multiplier between rings (0 = pitch black, 1 = unaffected)
+}
+
+[pixel_shader]
+def scanner(inp : PostEffectInput) {
+    let uv    = inp.screenPos
+    let col   = sample_scene_color(uv)
+    let raw_depth = sample_scene_depth(uv)
+    let sky_mask  = step(100.0, raw_depth)   // 1 for sky / far background, 0 for scene
+    let depth     = min(raw_depth, 50.0)
+    let s = smooth_step(1.0, 0.0, depth / 50.0) // fade in effect from near to far
+
+    // Rings travel outward from the camera.
+    // sin(phase*pi) goes 0->1->0 each period; pow sharpens it to a thin spike.
+    let phase = depth * frequency - g_Time * speed
+    // Zero out the wave on sky pixels so they are never affected.
+    let wave  = pow(saturate(sin(phase * 3.14159265)), sharpness) * intensity * (1.0 - sky_mask) * s
+
+    // Scene pixels are dimmed; sky pixels keep their original brightness (sky_mask -> lerp to 1).
+    let scene_dim = lerp(dim_scene, 1.0, sky_mask)
+    return PostEffectOutput(out_color = col * scene_dim + scan_color * wave)
+}

--- a/examples/flatten/shaders/user_shaders_2d/vignette.shader
+++ b/examples/flatten/shaders/user_shaders_2d/vignette.shader
@@ -1,25 +1,20 @@
 require engine.render.shader_dsl
 
 var {
-    albedo_texture = Sampler2D("%builtin_package/logo.png")
-    radius = 0.45
-    softness = 0.55
+    @color vignetteColor = float3(0, 0, 0)
+    strength = 1.5
+    radius   = 0.6
+    softness = 0.4
 }
 
 [pixel_shader]
-def vignette(inp : PbrInput) {
-    let c = tex2d(albedo_texture, inp.uv).xyz
-    let uv = inp.uv - float2(0.5, 0.5)
-    let dist = length(uv) * 1.6
-    let vign = smooth_step(radius + softness, radius, dist)
-    let result = c * vign
-    let daylight = saturate(g_LightDirection.y)
-    return PbrOutput(
-        albedo = result,
-        emission = result,
-        emissionStrength = lerp(0.5, 2.0, daylight),
-        metalness = 0.0,
-        roughness = 1.0,
-        ao = 1.0
-    )
+def vignette(inp : PostEffectInput) {
+    let uv = inp.screenPos
+    let col = sample_scene_color(uv)
+
+    // Distance from center [0,1] -> vignette mask
+    let d = length(uv - float2(0.5, 0.5)) * strength
+    let mask = smooth_step(radius - softness, radius, d)
+
+    return PostEffectOutput(out_color = lerp(col, vignetteColor, mask))
 }

--- a/examples/flatten/shaders/user_shaders_2d/vignette_2d.shader
+++ b/examples/flatten/shaders/user_shaders_2d/vignette_2d.shader
@@ -1,0 +1,25 @@
+require engine.render.shader_dsl
+
+var {
+    albedo_texture = Sampler2D("%builtin_package/logo.png")
+    radius = 0.45
+    softness = 0.55
+}
+
+[pixel_shader]
+def vignette(inp : PbrInput) {
+    let c = tex2d(albedo_texture, inp.uv).xyz
+    let uv = inp.uv - float2(0.5, 0.5)
+    let dist = length(uv) * 1.6
+    let vign = smooth_step(radius + softness, radius, dist)
+    let result = c * vign
+    let daylight = saturate(g_LightDirection.y)
+    return PbrOutput(
+        albedo = result,
+        emission = result,
+        emissionStrength = lerp(0.5, 2.0, daylight),
+        metalness = 0.0,
+        roughness = 1.0,
+        ao = 1.0
+    )
+}

--- a/examples/flatten/shaders/user_shaders_2d/voronoi.shader
+++ b/examples/flatten/shaders/user_shaders_2d/voronoi.shader
@@ -1,0 +1,64 @@
+require engine.render.shader_dsl
+
+// Voronoi / cellular noise — nearest-point distance over a 3x3 grid neighbourhood.
+// Uses a nested loop with a ?:-based min accumulator.
+
+var {
+    @color edgeColor  = float3(1.0, 1.0, 1.0)
+    @color fillColor  = float3(0.05, 0.15, 0.4)
+    @color glowColor  = float3(0.2, 0.6, 1.0)
+    scale             = 5.0
+    speed             = 0.3
+    edgeWidth         = 0.08
+}
+
+def hash_x(cx : float; cy : float) : float {
+    return frac(sin(cx * 127.1 + cy * 311.7) * 43758.5)
+}
+def hash_y(cx : float; cy : float) : float {
+    return frac(sin(cx * 269.5 + cy * 183.3) * 43758.5)
+}
+
+def cell_dist(uvx : float; uvy : float; ncx : float; ncy : float; t : float) : float {
+    let hx  = hash_x(ncx, ncy)
+    let hy  = hash_y(ncx, ncy)
+    let ptx = ncx + hx * 0.5 + sin(t + hx * 6.28) * 0.3
+    let pty = ncy + hy * 0.5 + cos(t + hy * 6.28) * 0.3
+    let dx  = ptx - uvx
+    let dy  = pty - uvy
+    return sqrt(dx * dx + dy * dy)
+}
+
+[pixel_shader]
+def voronoi(inp : PbrInput) {
+    let t    = g_Time * speed
+    let uv   = inp.uv * scale
+    let uvx  = uv.x
+    let uvy  = uv.y
+    let cell = floor(uv)
+    let cx   = cell.x
+    let cy   = cell.y
+
+    var minDist = 10.0
+    for (dy in range(3)) {
+        for (dx in range(3)) {
+            let ncx = cx + float(dx - 1)
+            let ncy = cy + float(dy - 1)
+            let d   = cell_dist(uvx, uvy, ncx, ncy, t)
+            minDist = d < minDist ? d : minDist
+        }
+    }
+
+    let edge  = smooth_step(0.0, edgeWidth, minDist)
+    let glow  = smooth_step(edgeWidth * 3.0, edgeWidth, minDist)
+    let col   = lerp(edgeColor, fillColor, edge) + glowColor * glow * 0.5
+
+    return PbrOutput(
+        albedo           = col,
+        emission         = glowColor * glow,
+        emissionStrength = glow * 1.5,
+        metalness        = 0.0,
+        roughness        = 1.0,
+        ao               = 1.0
+    )
+}


### PR DESCRIPTION
Two commits, kept separate so the compiler fix stays bisectable under the content re-sync.

## 1. flatten_opt: rcp uniform divisors hoisted via CSE / preshader (`58900a6b4`)

A per-pixel `x / U` by a uniform `U` is rewritten to `x * (1/U)` (fast-math reciprocal, hoisted per-draw). When `U` is **also** used elsewhere, its value gets CSE'd / hoisted into a fresh `_preshader_`/`_cse_` let — and the synthesized ref to that let was **un-typed**, so `expr_bt` read it as `none` and the rcp gate's scalar-float test silently skipped the division. The preshade/cse fixpoint converges in that state, and the `optimized` flag then blocks any later cycle from re-checking once inference would have typed it — so the per-pixel division survived.

This is the `kaleidoscope` shape `frac(angle/slice)*slice`, and `(x/s)*s` generally: a uniform divisor that is *also* used as a multiplier (forcing its value to be CSE'd).

**Fix:** carry the matched/hoisted node's resolved type onto every synthesized ref — new `hoisted_ref` helper at the three `pex_extract` / `cse_replace` synthesis sites. The in-loop rcp gate then sees the uniform divisor and rewrites it.

> rcp is fast-math either way; whether `U` lands on CPU (preshader) or GPU is a hair-trigger of shader edits — so it should rcp everywhere it's allowed anywhere.

**Test:** `cap_rcp_shared.shader` + `check.sh` #24 — neutering the type propagation makes it fail with `residual_divs=1`, and `tests/flatten` `test_flatten_fold` fails on `kaleidoscope`; both genuinely guard the fix. `cap_rcp` and all other goldens unchanged.

## 2. examples/flatten: re-sync with the client drop (`60859e926`)

Overwrites the testing backend (`backend/shader_dsl*.das`) with the client's current shader-graph backend: adds the `PostEffectInput` / `PostEffectOutput` screen-space post-fx surface (`sample_scene_color` / `sample_scene_depth`) and declares all math ops as `[stub, hint(opcode)]`. Adds 16 new sample shaders and updates the changed ones (shaders whose only diff was line endings are left untouched).

`radians` / `degrees` were dropped from the client's primitives; re-added locally as `[stub, hint()]` + `HINT_WHITELIST` entries so `angle_spin` still resolves. **Note:** as `[stub]` (not `builtIn`) they emit `radians` / `degrees` **opcode** nodes rather than lowering to `mul` — correct output, flagged back to the client.

## Validation
- `tests/flatten`: 264/264
- capability tier: 24/24 (new #24 `cap_rcp_shared`)
- shader regression sweep: 86/86
- `flatten_opt.das`: lint PASS, format verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)