### PR TITLE
site/news: announce 0.6.3-RC3 release

### DIFF
--- a/site/_news/2026-06-22-0-6-3-rc3-is-out-see-you-all-soon.md
+++ b/site/_news/2026-06-22-0-6-3-rc3-is-out-see-you-all-soon.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-22
+tag: 0.6.3-rc3
+title: 0.6.3-RC3 is out! See you all soon.
+link: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC3
+---


### PR DESCRIPTION
Adds a short news entry for the [v0.6.3-RC3 prerelease](https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC3).

Follows the RC1/RC2 one-liner pattern — tagline folded into the title, no body:

```yaml
---
date: 2026-06-22
tag: 0.6.3-rc3
title: 0.6.3-RC3 is out! See you all soon.
link: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC3
---
```

Built locally with `site/blog/build_blog.py`: the entry lands at the top of the landing news feed (`files/news.json`) and as the first row of `/changelist.html`, linking to the release. Only the `.md` is tracked — all generated HTML/JSON stays gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)