### PR TITLE
flatten: scalar-packing map-reduce loop re-roll (−51% on voronoi)

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -777,6 +777,14 @@ def public flatten_optimize(var func : FunctionPtr; barriers : table<string>; no
 }
 
 [macro_function]
+def public flatten_pack(var func : FunctionPtr; no_fast_math : bool = false) : bool {
+    //! Scalar-packing map-reduce re-roll (delegates to `pack_map_reduce`): recognize an unrolled
+    //! min/max reduction's N isomorphic scalar lanes and pack them into width-W vector ops + one
+    //! horizontal reduce. Run PRE-fold (before `flatten_fold`); re-infer after. no_fast_math skips it.
+    return pack_map_reduce(func, no_fast_math)
+}
+
+[macro_function]
 def public flatten_fuse(var func : FunctionPtr; no_fast_math : bool = false) : bool {
     //! PHASE_FUSED finishing pass (delegates to `fuse_body`): collapse same-vector lane sums into
     //! `dot(v, mask)`, re-pack ctor lane patterns, `a*b ± c` into mad, and the expanded lerp shape

--- a/daslib/flatten_opt.das
+++ b/daslib/flatten_opt.das
@@ -4256,3 +4256,512 @@ def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool
     }
     return changed
 }
+
+// ===== Scalar packing — map-reduce loop re-roll (Phase 1) =====
+// Re-rolls an unrolled min/max reduction's N isomorphic scalar lanes into width-W vector ops + a
+// horizontal reduce (backend emits one width-W node, not N). Pre-fold. Design: scalar_packing/PLAN.md.
+
+struct private LinkInfo {
+    ok      : bool
+    defName : string   // var this link declares (acc_{k+1})
+    dName   : string   // per-lane operand (ternary true arm)
+    accRef  : string   // running accumulator (ternary false arm)
+    op      : string   // "min" / "max"
+}
+
+// A reduction link `var acc' = (d cmp acc) ? d : acc` — true arm replaces the accumulator with the
+// per-lane operand. Classifies the min/max direction. Fail-closed: both comparison operands must be
+// exactly the lane operand and the accumulator var, so a threshold-select (`(d < K) ? d : acc`) or a
+// shifted compare (`d < acc + eps`) does NOT classify and is left untouched rather than mis-packed.
+def private classify_link(s : ExpressionPtr) : LinkInfo {
+    var r : LinkInfo
+    if (!(s is ExprLet)) return r
+    let lc = s as ExprLet
+    if (length(lc.variables) != 1) return r
+    let t = sel3(lc.variables[0].init)
+    if (t == null || !(t.subexpr is ExprOp2)) return r
+    let cond = t.subexpr as ExprOp2
+    let isLess = cond.op == "<" || cond.op == "<="
+    let isGreater = cond.op == ">" || cond.op == ">="
+    if (!isLess && !isGreater) return r
+    let ta = ref_var_name(t.left)
+    let fa = ref_var_name(t.right)
+    if (ta == "" || fa == "" || ta == fa) return r
+    let cl = ref_var_name(cond.left)
+    let cr = ref_var_name(cond.right)
+    var condLeftIsNew = false
+    if (cl == ta && cr == fa) {
+        condLeftIsNew = true
+    } elif (cr == ta && cl == fa) {
+        condLeftIsNew = false
+    } else {
+        return r
+    }
+    r.op = (isLess == condLeftIsNew) ? "min" : "max"
+    r.defName = "{lc.variables[0].name}"
+    r.dName = ta
+    r.accRef = fa
+    r.ok = true
+    return r
+}
+
+// Name-HASHES of every var read in `e` (independence check). Hashes, not strings: `hash(expr.name)`
+// reads the das_string directly (no per-ExprVar temp alloc — the FlatVarRef rule, lines ~195). A
+// 64-bit collision among one function's locals is effectively impossible; were one to occur it would
+// at worst skip a valid pack (false bail) or — far less likely — miss a cross-lane dependency. Treat
+// as practically safe, not provably so.
+class private VarNames : AstVisitor {
+    found : table<uint64>
+    def override preVisitExprVar(expr : ExprVar?) : void {
+        found |> insert(hash(expr.name))
+    }
+}
+
+def private collect_var_hashes(e : ExpressionPtr) : table<uint64> {
+    var res : table<uint64>
+    var v = new VarNames()
+    make_visitor(*v) $(adapter) {
+        visit(e, adapter)
+    }
+    res <- v.found
+    unsafe {
+        delete v
+    }
+    return <- res
+}
+
+// Vectorize N parallel scalar exprs into one width-N (2..4) vector expr (CLONE-built): invariants
+// splat to floatN, differing float consts → a floatN const, lane-local vars → the role-vector
+// temp, op/call nodes rebuild over vectorized children. null on any unpackable shape (bails clean).
+def private vectorize(exprs : array<ExpressionPtr>; nameToRole : table<string; int>;
+                      roleVecName : array<string>; at : LineInfo) : ExpressionPtr {
+    let N = length(exprs)
+    let key0 = describe(exprs[0])
+    var allEq = true
+    for (i in range(1, N)) {
+        if (describe(exprs[i]) != key0) {
+            allEq = false
+            break
+        }
+    }
+    // invariant subtree → splat to floatN (daslang has no scalar→vector broadcast for +/-/call-args)
+    if (allEq) return make_float_splat(N, at, clone_expression(exprs[0]))
+    if (exprs[0] is ExprRef2Value) {
+        var inner : array<ExpressionPtr>
+        inner |> reserve(N)
+        var okk = true
+        for (e in exprs) {
+            if (!(e is ExprRef2Value)) {
+                okk = false
+                break
+            }
+            inner |> push((e as ExprRef2Value).subexpr)
+        }
+        var res : ExpressionPtr = null
+        if (okk) {
+            res = vectorize(inner, nameToRole, roleVecName, at)
+        }
+        unsafe {
+            delete inner
+        }
+        return res
+    }
+    if (exprs[0] is ExprConstFloat) {
+        var lanes : array<ExpressionPtr>
+        lanes |> reserve(N)
+        var okk = true
+        for (e in exprs) {
+            if (!(e is ExprConstFloat)) {
+                okk = false
+                break
+            }
+            lanes |> push(clone_expression(e))
+        }
+        var res : ExpressionPtr = null
+        if (okk) {
+            res = make_float_ctor(N, at, lanes)
+        }
+        unsafe {
+            delete lanes
+        }
+        return res
+    }
+    if (exprs[0] is ExprVar) {
+        var role = -1
+        for (e in exprs) {
+            if (!(e is ExprVar)) return null
+            let nm = "{(e as ExprVar).name}"
+            let rr = nameToRole?[nm] ?? -1
+            if (rr < 0) return null
+            if (role < 0) {
+                role = rr
+            } elif (role != rr) {
+                return null
+            }
+        }
+        return new ExprVar(at = at, name := roleVecName[role])
+    }
+    if (exprs[0] is ExprOp2) {
+        let l0 = exprs[0] as ExprOp2
+        let op0 = "{l0.op}"
+        var lefts : array<ExpressionPtr>
+        var rights : array<ExpressionPtr>
+        lefts |> reserve(N)
+        rights |> reserve(N)
+        var okk = true
+        for (e in exprs) {
+            if (!(e is ExprOp2) || "{(e as ExprOp2).op}" != op0) {
+                okk = false
+                break
+            }
+            lefts |> push((e as ExprOp2).left)
+            rights |> push((e as ExprOp2).right)
+        }
+        var res : ExpressionPtr = null
+        if (okk) {
+            var vl = vectorize(lefts, nameToRole, roleVecName, at)
+            var vr : ExpressionPtr = null
+            if (vl != null) {
+                vr = vectorize(rights, nameToRole, roleVecName, at)
+            }
+            if (vl != null && vr != null) {
+                res = new ExprOp2(at = at, atEnclosure = l0.atEnclosure, genFlags = l0.genFlags,
+                                  op := op0, left = vl, right = vr)
+            }
+        }
+        unsafe {
+            delete lefts
+            delete rights
+        }
+        return res
+    }
+    if (exprs[0] is ExprOp1) {
+        let l0 = exprs[0] as ExprOp1
+        let op0 = "{l0.op}"
+        var subs : array<ExpressionPtr>
+        subs |> reserve(N)
+        var okk = true
+        for (e in exprs) {
+            if (!(e is ExprOp1) || "{(e as ExprOp1).op}" != op0) {
+                okk = false
+                break
+            }
+            subs |> push((e as ExprOp1).subexpr)
+        }
+        var res : ExpressionPtr = null
+        if (okk) {
+            var vs = vectorize(subs, nameToRole, roleVecName, at)
+            if (vs != null) {
+                res = new ExprOp1(at = at, atEnclosure = l0.atEnclosure, genFlags = l0.genFlags,
+                                  op := op0, subexpr = vs)
+            }
+        }
+        unsafe {
+            delete subs
+        }
+        return res
+    }
+    if (exprs[0] is ExprCall) {
+        let l0 = exprs[0] as ExprCall
+        // simple name (post-infer .name is the mangled scalar overload) so re-infer picks by arg width
+        let nm0 = psh_simple_name("{l0.name}")
+        let argc = length(l0.arguments)
+        for (e in exprs) {
+            if (!(e is ExprCall) || psh_simple_name("{(e as ExprCall).name}") != nm0 ||
+                    length((e as ExprCall).arguments) != argc) {
+                return null
+            }
+        }
+        var c = new ExprCall(at = at, atEnclosure = l0.atEnclosure, genFlags = l0.genFlags, name := nm0)
+        for (ai in range(argc)) {
+            var col : array<ExpressionPtr>
+            col |> reserve(N)
+            for (e in exprs) {
+                col |> push((e as ExprCall).arguments[ai])
+            }
+            var v = vectorize(col, nameToRole, roleVecName, at)
+            unsafe {
+                delete col
+            }
+            if (v == null) return null
+            c.arguments |> push(v)
+        }
+        return c
+    }
+    return null
+}
+
+// Partition M lanes into width<=4 groups, never leaving a width-1 remainder (so every group packs).
+def private plan_groups(M : int) : array<int> {
+    var g : array<int>
+    g |> reserve((M + 3) / 4)
+    var rem = M
+    while (rem > 0) {
+        var take = rem >= 4 ? 4 : rem   // nolint:PERF015 — math.min not required in this module
+        if (rem - take == 1) {
+            take = take - 1
+        }
+        g |> push(take)
+        rem = rem - take
+    }
+    return <- g
+}
+
+def private make_vec_let(vecName : string; var vecExpr : ExpressionPtr) : ExpressionPtr {
+    return qmacro_expr(${ let $i(vecName) = $e(vecExpr); })
+}
+
+// Horizontal min/max over `vecName`'s W components: op(op(.x,.y),.z)... — W>=2.
+def private hreduce(vecName : string; width : int; op : string; at : LineInfo) : ExpressionPtr {
+    var acc : ExpressionPtr = new ExprField(at = at, value = new ExprVar(at = at, name := vecName),
+                                            name := slice("xyzw", 0, 1))
+    for (c in range(1, width)) {
+        var nextc = new ExprField(at = at, value = new ExprVar(at = at, name := vecName),
+                                  name := slice("xyzw", c, c + 1))
+        var call = new ExprCall(at = at, name := op)
+        call.arguments |> push(acc)
+        call.arguments |> push(nextc)
+        acc = call
+    }
+    return acc
+}
+
+def public pack_map_reduce(var func : FunctionPtr; no_fast_math : bool = false) : bool {
+    //! Map-reduce loop re-roll: pack an unrolled min/max reduction's N isomorphic scalar lanes into
+    //! width-W vector ops + a horizontal reduce. Returns true if it rewrote a chain. Run PRE-fold;
+    //! caller re-infers after. Skipped under no_fast_math (the reduce-tree reassociation opt-out).
+    if (no_fast_math || !(func.body is ExprBlock)) return false
+    var blk = func.body as ExprBlock
+    let n = length(blk.list)
+    if (n < 6) return false   // init + >=3 lanes (each >=1 let + link) is the smallest worth packing
+    var links : array<LinkInfo>
+    links |> reserve(n)
+    for (i in range(n)) {
+        links |> push(classify_link(blk.list[i]))
+    }
+    var accRefToIdx : table<string; int>
+    var isDef : table<string>
+    for (i in range(n)) {
+        if (links[i].ok) {
+            if (!key_exists(accRefToIdx, links[i].accRef)) {
+                accRefToIdx |> insert(links[i].accRef, i)
+            }
+            isDef |> insert(links[i].defName)
+        }
+    }
+    var ub = new FlatUsesBuilder()
+    make_visitor(*ub) $(adapter) {
+        for (j in range(n)) {
+            ub.j = j
+            clear(ub.seen)
+            visit(blk.list[j], adapter)
+        }
+    }
+    var did = false
+    for (h in range(n)) {
+        if (did) break
+        if (!links[h].ok || key_exists(isDef, links[h].accRef)) continue   // not a chain head
+        // head accumulator must be a const-init let, used only by this head link
+        var initIdx = -1
+        for (j in range(h)) {
+            if (!(blk.list[j] is ExprLet)) continue
+            let lc = blk.list[j] as ExprLet
+            if (length(lc.variables) == 1 && "{lc.variables[0].name}" == links[h].accRef &&
+                    lc.variables[0].init != null && is_all_const(lc.variables[0].init)) {
+                initIdx = j
+                break
+            }
+        }
+        if (initIdx < 0 ||
+                (key_exists(ub.nameUses, hash(links[h].accRef)) &&
+                 length(ub.nameUses[hash(links[h].accRef)]) != 1)) continue   // init absent or escapes
+        // follow the chain; each intermediate accumulator must be single-use (its successor link)
+        let op = links[h].op
+        var chainIdx : array<int>
+        var dNames : array<string>
+        chainIdx |> reserve(n)
+        dNames |> reserve(n)
+        var cur = h
+        var bail = false
+        while (true) {
+            chainIdx |> push(cur)
+            dNames |> push(links[cur].dName)
+            let dn = links[cur].defName
+            // stop: no successor link consumes dn (chain end), or dn escapes (multi-use accumulator)
+            if (!key_exists(accRefToIdx, dn) ||
+                    !key_exists(ub.nameUses, hash(dn)) || length(ub.nameUses[hash(dn)]) != 1) break
+            let nx = accRefToIdx[dn]
+            if (nx <= cur || !links[nx].ok || links[nx].op != op) break
+            cur = nx
+        }
+        let M = length(chainIdx)
+        let lastLinkIdx = chainIdx[M - 1]
+        // R = lane-lets between each pair of consecutive links (and after the init); must be uniform
+        let R = chainIdx[0] - initIdx - 1
+        if (M < 3 || R < 1) {
+            delete chainIdx
+            delete dNames
+            continue
+        }
+        for (k in range(1, M)) {
+            if (chainIdx[k] - chainIdx[k - 1] - 1 != R) {
+                bail = true
+                break
+            }
+        }
+        // collect per-lane let inits (role order) + own-name sets; last let must define d_k
+        var laneInit : array<array<ExpressionPtr>>
+        var laneNames : array<array<string>>
+        var laneOwnHash : array<table<uint64>>   // per-lane owned name-hashes (independence check)
+        var nameToRole : table<string; int>
+        var roleHash : table<uint64>             // all lane-local name-hashes (the role-name set)
+        laneInit |> reserve(M)
+        laneNames |> reserve(M)
+        laneOwnHash |> reserve(M)
+        if (!bail) {
+            for (k in range(M)) {
+                let prev = k == 0 ? initIdx : chainIdx[k - 1]
+                var inits : array<ExpressionPtr>
+                var names : array<string>
+                var own : table<uint64>
+                inits |> reserve(R)
+                names |> reserve(R)
+                for (idx in range(prev + 1, chainIdx[k])) {
+                    if (!(blk.list[idx] is ExprLet) || length((blk.list[idx] as ExprLet).variables) != 1) {
+                        bail = true
+                        break
+                    }
+                    var lc = blk.list[idx] as ExprLet
+                    inits |> push(lc.variables[0].init)
+                    let nm = "{lc.variables[0].name}"
+                    names |> push(nm)
+                    own |> insert(hash(nm))
+                    nameToRole |> insert(nm, length(names) - 1)
+                    roleHash |> insert(hash(nm))
+                }
+                if (!bail && (empty(names) || names[length(names) - 1] != dNames[k])) {
+                    bail = true
+                }
+                laneInit |> emplace(inits)
+                laneNames |> emplace(names)
+                laneOwnHash |> emplace(own)
+                if (bail) break
+            }
+        }
+        // independence: no lane let may read a spine accumulator or another lane's temp
+        if (!bail) {
+            var spineHash : table<uint64>
+            spineHash |> insert(hash(links[h].accRef))
+            for (ci in chainIdx) {
+                spineHash |> insert(hash(links[ci].defName))
+            }
+            for (k in range(M)) {
+                if (bail) break
+                for (r in range(R)) {
+                    var refs <- collect_var_hashes(laneInit[k][r])
+                    for (rh in keys(refs)) {
+                        if (key_exists(spineHash, rh) ||
+                                (key_exists(roleHash, rh) && !key_exists(laneOwnHash[k], rh))) {
+                            bail = true
+                        }
+                    }
+                    delete refs
+                    if (bail) break
+                }
+            }
+            delete spineHash
+        }
+        if (bail) {
+            delete chainIdx; delete dNames; delete laneNames; delete laneOwnHash; delete nameToRole; delete roleHash
+            unsafe {
+                delete laneInit
+            }
+            continue
+        }
+        // build the packed lets + per-group d-vector names
+        var groups <- plan_groups(M)
+        var newLets : array<ExpressionPtr>
+        var groupDName : array<string>
+        var groupWidth : array<int>
+        newLets |> reserve(length(groups) * R)
+        groupDName |> reserve(length(groups))
+        groupWidth |> reserve(length(groups))
+        var laneBase = 0
+        for (gid in range(length(groups))) {
+            let w = groups[gid]
+            var roleVecName : array<string>
+            roleVecName |> reserve(R)
+            for (r in range(R)) {
+                roleVecName |> push("_pk{h}_{gid}_{r}")
+            }
+            for (r in range(R)) {
+                var col : array<ExpressionPtr>
+                col |> reserve(w)
+                for (li in range(w)) {
+                    col |> push(laneInit[laneBase + li][r])
+                }
+                var v = vectorize(col, nameToRole, roleVecName, blk.at)
+                unsafe {
+                    delete col
+                }
+                if (v == null) {
+                    bail = true
+                    break
+                }
+                newLets |> push(make_vec_let(roleVecName[r], v))
+            }
+            groupDName |> push(roleVecName[R - 1])
+            groupWidth |> push(w)
+            delete roleVecName
+            laneBase += w
+            if (bail) break
+        }
+        if (bail) {
+            delete chainIdx; delete dNames; delete laneNames
+            delete laneOwnHash; delete nameToRole; delete roleHash; delete groups
+            delete groupDName; delete groupWidth
+            unsafe {
+                delete laneInit
+                delete newLets
+            }
+            continue
+        }
+        // reduce: op(init, op(g0, op(g1, ...))) — preserves the original reduction's value set
+        var acc = clone_expression((blk.list[initIdx] as ExprLet).variables[0].init)
+        for (gid in range(length(groups))) {
+            var hm = hreduce(groupDName[gid], groupWidth[gid], op, blk.at)
+            var call = new ExprCall(at = blk.at, name := op)
+            call.arguments |> push(acc)
+            call.arguments |> push(hm)
+            acc = call
+        }
+        let finalAcc = "{links[lastLinkIdx].defName}"
+        var finalStmt = qmacro_expr(${ var $i(finalAcc) = $e(acc); })
+        // splice: list is a dasvector — rebuild a fresh block (preamble drop-init, packed lets,
+        // final reduce, tail), moving the surviving original statements across.
+        var newBody = new ExprBlock(at = blk.at)
+        for (i in range(initIdx)) {   // nolint:PERF018 — preamble is a [0,initIdx) sub-range
+            newBody.list |> emplace(blk.list[i])
+        }
+        for (s in newLets) {
+            newBody.list |> emplace(s)
+        }
+        newBody.list |> emplace(finalStmt)
+        for (i in range(lastLinkIdx + 1, n)) {   // nolint:PERF018 — tail is a (lastLinkIdx,n) sub-range
+            newBody.list |> emplace(blk.list[i])
+        }
+        func.body = newBody
+        did = true
+        delete chainIdx; delete dNames; delete laneNames
+        delete laneOwnHash; delete nameToRole; delete roleHash; delete groups
+        delete groupDName; delete groupWidth
+        unsafe {
+            delete laneInit
+            delete newLets
+        }
+    }
+    unsafe {
+        delete ub
+    }
+    return did
+}

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1600,15 +1600,22 @@ class PixelShaderMacro : AstFunctionAnnotation {
     def override patch(var func : FunctionPtr; var group : ModuleGroup;
                        args, progArgs : AnnotationArgumentList; var errors : das_string;
                        var astChanged : bool&) : bool {
-        // Skip during lint (the twin is irrelevant to linting source).
-        if (is_in_lint_check() || shader_annotation_arg(func, "folded")) {
-            return true
-        }
-        // flatten=off: skip ALL passes; finish() builds IR on the source verbatim (must be flat).
-        if (flatten_is_off(func)) {
+        // Skip during lint (the twin is irrelevant to linting source); flatten=off also skips ALL
+        // passes — finish() then builds IR on the source verbatim (which must already be flat).
+        if (is_in_lint_check() || shader_annotation_arg(func, "folded") || flatten_is_off(func)) {
             return true
         }
         if (shader_annotation_arg(func, "flattened")) {
+            // Scalar packing runs FIRST (pre-fold): the unrolled lane bodies are still isomorphic
+            // and un-CSE'd, so a min/max reduction re-rolls cleanly into width-W vector ops; the
+            // fold/optimize/fuse stages below then clean the boundary combine/splat glue.
+            if (!shader_annotation_arg(func, "packed")) {
+                set_shader_annotation_flag(func, "packed")
+                if (flatten_pack(func, flatten_no_fast_math())) {
+                    astChanged = true
+                    return true
+                }
+            }
             // Cycle 2+ (re-inferred after flattening): collapse const-condition selects
             // and drop the resulting pure self-assigns (`acc = acc`) — without this a
             // loop-var-gated accumulate leaves a self-referential accumulator the IR

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1544,6 +1544,23 @@ def private shader_annotation_arg(func : FunctionPtr; argName : string) : bool {
     return false
 }
 
+// `[pixel_shader(flatten=false)]` -> emit IR for the source VERBATIM: no inline / fold / optimize /
+// fuse. The source must already be flat (the backend bans if/else, loops, helper calls). Lets us
+// A/B a hand-vectorized shader against its scalar twin with the backend producing exactly what is
+// written. Presence-aware (a missing `flatten` arg means flatten stays ON).
+def private flatten_is_off(func : FunctionPtr) : bool {
+    for (ann in func.annotations) {
+        if (ann.annotation.name == "pixel_shader") {
+            for (a in ann.arguments) {
+                if ("{a.name}" == "flatten" && a.basicType == Type.tBool) {
+                    return !a.bValue
+                }
+            }
+        }
+    }
+    return false
+}
+
 [macro_function]
 def private set_shader_annotation_flag(var func : FunctionPtr; argName : string) {
     for (ann in func.annotations) {
@@ -1585,6 +1602,10 @@ class PixelShaderMacro : AstFunctionAnnotation {
                        var astChanged : bool&) : bool {
         // Skip during lint (the twin is irrelevant to linting source).
         if (is_in_lint_check() || shader_annotation_arg(func, "folded")) {
+            return true
+        }
+        // flatten=off: skip ALL passes; finish() builds IR on the source verbatim (must be flat).
+        if (flatten_is_off(func)) {
             return true
         }
         if (shader_annotation_arg(func, "flattened")) {

--- a/examples/flatten/scalar_packing/FINDINGS.md
+++ b/examples/flatten/scalar_packing/FINDINGS.md
@@ -1,0 +1,76 @@
+# Scalar Packing — Findings
+
+Empirical study: does packing independent scalars into vector (float2/3/4) ops reduce
+node count in the EdenSpark shader-graph backend (`examples/flatten/backend/`)? Run with
+the daslang binary + the `flatten_shaders.das_project`.
+
+## Backend cost model (the *why*)
+
+The backend lowers a flattened shader to a node graph. An op-node carries an op name and
+a **width (1–4); the width is free** — a `mul` node costs the same whether its pins are
+`Float` or `Float4` (`ShaderPinType` is polymorphic, "widest input wins",
+`shader_dsl_boost.das:223`). `splatX/Y/Z/W` (lane extract) and `combineFloatN` (pack
+scalars → vector) are *pure overhead* nodes. So **node count is the cost, and packing N
+scalar ops into one width-N vector op is N→1** — as long as the pack/unpack glue at the
+boundaries doesn't exceed the saving.
+
+## Method
+
+`[pixel_shader(flatten=false)]` (a backend mode added for this study) emits IR for the
+source **verbatim** — no inline / fold / optimize / fuse — so a hand-vectorized shader can
+be A/B'd against its scalar twin with the backend producing exactly what's written. Node
+count = `… | grep -c '^node '`.
+
+Two configs:
+- **flatten=off** — raw, counts every hand-written splat. *Understates* the vec win.
+- **optimize on** (drop `(flatten=false)`) — the backend folds redundant splat/combine
+  chains. This is the **shipping config and the fair one** to judge by.
+
+## Results (optimize on)
+
+| pattern | width | live-range | scalar | packed | **win** |
+|---|---|---|---|---|---|
+| within-cell x/y (voronoi, 1 cell) | float2 | ~10 ops | 59 | 44 | **−25%** |
+| across-cell (voronoi, 2×2 block)  | float4 | ~20 ops | 169 | 72 | **−57%** |
+| within-vector multi-sin (plasma)  | float4 | 1 op    | 43 | 40 | **−7%** |
+
+`flatten=off` understated all three (61→53, 185→74, 45→**47** — plasma even looked like a
++2 *loss* before folding).
+
+## Key insights
+
+1. **Every case is net-positive optimize-on.** The pass is low-risk.
+2. **Win scales with width × live-range** — the number of vector ops the packed value
+   flows through before it is unpacked/reduced. plasma packs 4 sins but sums them
+   immediately (1-op live-range) → tiny win; voronoi cells flow through ~20 vector ops
+   before the min → huge win.
+3. **The backend's splat/combine folding is the enabler.** It's what flips plasma from
+   loss to win (folds 8 boundary splats → 2). Our packed output relies on it — hence judge
+   the pass *post-optimize*, not at `flatten=off`.
+4. **Transcendentals drive the big wins** — sin/cos/frac/sqrt go exactly width× (voronoi
+   4-cell: `sin` 12→3, `cos` 4→1, `frac` 8→2, `sqrt` 4→1). They can't be CSE'd across
+   lanes (different args), so that saving is real regardless of CSE.
+5. **False friends** (look like candidates, aren't):
+   - `raymarch_spheres` (10 trig) — the trig is **uniform** (depends only on `g_Time` →
+     preshaded, per-draw), and both loops are **sequential** (the march accumulates depth;
+     the inner loop is a sequential smooth-union fold) — not data-parallel.
+   - `blur` / `loop_multi` — data-parallel but **texture-bound** (each tap is a `tex2d`,
+     already float3, no scalar arithmetic to pack).
+
+## Backend suggestion (EdenSpark's call)
+
+A **horizontal-reduce node** `reduce(b, c, CONST) = Σ bᵢ·cᵢ·CONSTᵢ` (a generalized dot —
+sum / weighted-sum / dot all fall out of it) collapses every unpack-at-a-reduction
+(voronoi's min, plasma's sum) from `W splats + (W−1) ops` to **one node**, lowering the
+break-even for packing. We suggest it; the backend is EdenSpark's.
+
+## Reproduce
+
+A/B shader pairs live in this dir. With the binary built and the project wired:
+
+```
+daslang -compile-only -project ../flatten_shaders.das_project <shader> | grep -c '^node '
+```
+
+Drop `(flatten=false)` from the `[pixel_shader]` annotation for the optimize-on number
+(`sed 's/(flatten=false)//'`).

--- a/examples/flatten/scalar_packing/FINDINGS.md
+++ b/examples/flatten/scalar_packing/FINDINGS.md
@@ -57,6 +57,35 @@ Two configs:
    - `blur` / `loop_multi` — data-parallel but **texture-bound** (each tap is a `tex2d`,
      already float3, no scalar arithmetic to pack).
 
+## Phase 2 (general SLP) — evaluated, not pursued
+
+After Phase 1 shipped (map-reduce loop re-roll), a corpus survey settled whether a general
+SLP pass — packing isomorphic scalar trees *not* from a loop reduction — was worth building.
+**It is not, on this corpus.** The reasoning is structural, not just sample-size:
+
+1. **Phase 1 already harvests every high-live-range opportunity.** The win scales with
+   width × live-range, and the long-live-range parallelism in these shaders lives in the
+   data-parallel loop reductions Phase 1 re-rolls. Dumping post-Phase-1 voronoi
+   (`FLATTEN_DUMP_DAS=1`) confirms the within-cell x/y chains are *absorbed*: the per-cell
+   `dx`/`dy` become two float4 lets (`_pk*_4` = x across 4 cells, `_pk*_5` = y), and
+   `sqrt(dx*dx + dy*dy)` is already component-wise float4 math — exactly the hand-written
+   `cell_vec` form, generalized across cells. There is no residual within-cell SLP left.
+
+2. **What general SLP would add is only the *low*-live-range cases:**
+   - **Fan into a common builtin** (plasma: 4 independent `sin`s → immediate sum). Live-range
+     ≈ 1, so structurally marginal — measured **−7%**. Exactly **one** corpus instance.
+   - **Standalone isomorphic destructured chains** (a hand-split distance/normal over long
+     chains, then recombined) — this *would* be high-live-range, but there are **zero**
+     standalone instances in the corpus. The only candidates (mandelbrot's `wx`/`wy` fBm,
+     electric_3d's `b0/b1/b2`) are blocked: their dominant op is `noise()` / `tex2d()`,
+     engine leaves that take a vector and return a scalar and **cannot vectorize across
+     lanes** (there is no "noise of N points" primitive). Same false-friend class as #5.
+
+**Conclusion: Phase 1 is the win.** A general SLP pass would add code + risk for at most a
+−7% improvement on a single shader. (The standalone-isomorphic-chain shape could still pay
+off on *client* shaders we feed verbatim and can't see here — if such a shader surfaces with
+a long-live-range destructured computation, revisit then, with that shader as the proof point.)
+
 ## Backend suggestion (EdenSpark's call)
 
 A **horizontal-reduce node** `reduce(b, c, CONST) = Σ bᵢ·cᵢ·CONSTᵢ` (a generalized dot —

--- a/examples/flatten/scalar_packing/PLAN.md
+++ b/examples/flatten/scalar_packing/PLAN.md
@@ -1,0 +1,66 @@
+# Scalar Packing — Plan
+
+A scalar-packing (**SLP / loop re-roll**) pass in our flatten layer. `flatten` unrolls
+data-parallel loops into N scalar copies; this pass packs structurally-identical scalar
+groups into width-W vector ops (SoA lanes), so the EdenSpark backend emits one width-W
+node where it currently emits N scalar nodes. We produce the vectorized *demand*; their
+backend's folding (+ a future horizontal-reduce node) finishes it.
+
+See `FINDINGS.md` for the empirical justification (−7% / −25% / −57%, always positive
+optimize-on, scales with width × live-range).
+
+## Where it slots
+
+A new pass in `daslib/flatten_opt.das`, run **after `flatten_function`** (post-unroll /
+inline, so data-parallel iterations are visible as isomorphic scalar groups) and **inside
+the optimize cycle**, so the existing splat/combine fold cleans our boundary glue — that
+fold is what makes packing net-positive (FINDINGS #3).
+
+## What it detects
+
+A **lane group**: N scalar values produced by structurally-identical expression trees
+whose leaf inputs differ only by the lane index or a known per-lane constant. Two sources:
+
+- **Loop-unroll groups** (Phase 1) — the N copies `flatten` emitted from `for (i in range(N))`.
+- **Hand-destructured components** (Phase 2) — independent same-shape scalar chains within
+  one iteration (the x/y of a 2D quantity the source pulled apart, e.g. voronoi's `uvx`/`uvy`).
+
+## How it packs
+
+1. Identify the lane group + its width W (2/3/4; split N>4 into ⌈N/4⌉ groups).
+2. SoA-ify: create vector vars holding the W lanes; rewrite each scalar op as the
+   corresponding vector op.
+3. Pack inputs at the sources (`combineFloatW`); reduce/unpack at the sinks.
+4. Reductions (min/sum) → horizontal op: splat + scalar-reduce for now (folds fine), swap
+   to EdenSpark's `reduce(b,c,CONST)` node when it ships.
+
+## Phasing
+
+- **Phase 1 — map-reduce loop re-roll (the −57% case, lowest risk).** Recognize an unrolled
+  loop that is a *map-reduce*: an independent per-iteration value + an associative reduction
+  (voronoi's `minDist = min(minDist, d)`, written as `d < minDist ? d : minDist`). Emit a
+  vector-map across W lanes + one horizontal reduce. Prove on **voronoi** (348 → target ~150).
+- **Phase 2 — general SLP.** Pack isomorphic scalar trees not from a loop (the within-vector
+  −25% case).
+
+## Heuristic
+
+Permissive (worst case still +7%), gated on **body size**: pack only when the live-range
+(vector ops between pack and reduce) ≥ K. Prefer width 4. Skip **uniform/preshaded** groups
+and **texture-bound** taps — no per-pixel arithmetic to save (the raymarch / blur false
+friends in FINDINGS #5).
+
+## Risks / open questions
+
+- Reduction recognition: associativity, and the `?:`-mask form vs an explicit `min()`.
+- Isomorphism-detection cost on the flat AST (the bounded post-flatten node set helps).
+- Ordering vs CSE/fold: run packing *before* them, let fold clean the boundaries.
+- Per-lane constants must pack into a const-vector (`float4Const`).
+- Width padding: 9 cells → 2×float4 + 1, or 3×float3 — which wastes fewer lanes/nodes.
+
+## Status
+
+- [x] Backend cost model understood; `flatten=off` A/B mode added.
+- [x] Empirical bracket measured (FINDINGS.md).
+- [ ] Phase 1 — map-reduce re-roll, proven on voronoi.
+- [ ] Phase 2 — general SLP.

--- a/examples/flatten/scalar_packing/PLAN.md
+++ b/examples/flatten/scalar_packing/PLAN.md
@@ -41,7 +41,7 @@ whose leaf inputs differ only by the lane index or a known per-lane constant. Tw
   (voronoi's `minDist = min(minDist, d)`, written as `d < minDist ? d : minDist`). Emit a
   vector-map across W lanes + one horizontal reduce. Prove on **voronoi** (348 → target ~150).
 - **Phase 2 — general SLP.** Pack isomorphic scalar trees not from a loop (the within-vector
-  −25% case).
+  −25% case). **Evaluated and declined** — see Status below and `FINDINGS.md`.
 
 ## Heuristic
 
@@ -62,5 +62,34 @@ friends in FINDINGS #5).
 
 - [x] Backend cost model understood; `flatten=off` A/B mode added.
 - [x] Empirical bracket measured (FINDINGS.md).
-- [ ] Phase 1 — map-reduce re-roll, proven on voronoi.
-- [ ] Phase 2 — general SLP.
+- [x] **Phase 1 — map-reduce re-roll, proven on voronoi: 348 → 171 nodes (−51%).**
+- [x] **Phase 2 — general SLP: evaluated, NOT pursued.** Corpus survey showed Phase 1 already
+  absorbs every high-live-range opportunity (the within-cell x/y chains are subsumed into the
+  across-cell float4 component math — `FLATTEN_DUMP_DAS=1` confirmed). General SLP would add
+  only the low-live-range cases: fan-into-a-common-builtin (plasma, **−7%**, one corpus
+  instance) and standalone isomorphic chains (**zero** corpus instances — the candidates are
+  blocked by non-vectorizable `noise`/`tex2d` leaves). Not worth the code + risk for −7% on one
+  shader. Revisit only if a *client* shader surfaces a long-live-range destructured computation.
+  Full reasoning in `FINDINGS.md` § "Phase 2 (general SLP) — evaluated, not pursued".
+
+### Phase 1 — landed (`pack_map_reduce` in `daslib/flatten_opt.das`)
+
+Pass `flatten_pack` (wrapper in flatten.das), wired as a gated `packed` stage in the backend's
+cycle-2 **before** fold (`shader_dsl_boost.das`). Recognizes a min/max SSA reduction spine
+(`var acc' = (d cmp acc) ? d : acc`) over N isomorphic, independent lane bodies, packs into
+width-≤4 SoA groups (`plan_groups` avoids width-1 tails: 9 → [4,3,2]), and replaces the spine
+with a horizontal reduce `min(init, hmin(g0), …)`.
+
+- **Result:** voronoi 348 → 171 (−51%). Full regression 86/86 compile; A/B diff confirms **only
+  voronoi changed** — zero collateral (raymarch/blur/plasma untouched). Output verified
+  semantically (all 9 cells map once; reduction = `min(10, all d)`).
+- **Key finding:** daslang has **no scalar→vector broadcast** for `+`/`-`/call-args (only
+  `vec * scalar`). So invariants are splatted to `floatN(x)` and the downstream splat-fold
+  collapses the collapsible ones — this is exactly FINDINGS #3's "fold-cleans-the-glue" pipeline.
+- **Gated** on `!no_fast_math` (reduction-tree reassociation), `M ≥ 3` lanes, uniform lane layout,
+  per-lane independence (no lane reads a spine accumulator or another lane's temp) — bails clean
+  (no mutation) on any mismatch.
+
+**Open tuning (not blocking):** [3,3,3] vs [4,3,2] grouping (≈equal node count); the boundary
+const-vec literals (`float4(127.1,…)`) survive mad-fusion (width is free, so each is 1 node) — a
+horizontal-reduce backend node (FINDINGS suggestion) would shave the unpack-at-reduction further.

--- a/examples/flatten/scalar_packing/cell_scalar.shader
+++ b/examples/flatten/scalar_packing/cell_scalar.shader
@@ -1,0 +1,17 @@
+require engine.render.shader_dsl
+
+// One voronoi cell, scalar — matches flatten's per-cell output form (mads already fused).
+[pixel_shader(flatten=false)]
+def cell_scalar(inp : PbrInput) {
+    let uv  = inp.uv * 5.0
+    let t   = g_Time * 0.3
+    let ncx = floor(uv.x)
+    let ncy = floor(uv.y)
+    let hx  = frac(sin(ncx * 127.1 + ncy * 311.7) * 43758.5)
+    let hy  = frac(sin(ncx * 269.5 + ncy * 183.3) * 43758.5)
+    let dx  = mad(sin(mad(hx, 6.28, t)), 0.3, mad(hx, 0.5, ncx)) - uv.x
+    let dy  = mad(cos(mad(hy, 6.28, t)), 0.3, mad(hy, 0.5, ncy)) - uv.y
+    let d   = sqrt(mad(dx, dx, dy * dy))
+    return PbrOutput(albedo = float3(d, d, d), emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 0.0, metalness = 0.0, roughness = 1.0, ao = 1.0)
+}

--- a/examples/flatten/scalar_packing/cell_vec.shader
+++ b/examples/flatten/scalar_packing/cell_vec.shader
@@ -1,0 +1,16 @@
+require engine.render.shader_dsl
+
+// Same cell, hand-vectorized: pack the x/y scalars into float2 vars. The trig stays per-lane
+// (sin vs cos differ), everything else goes float2.
+[pixel_shader(flatten=false)]
+def cell_vec(inp : PbrInput) {
+    let uv   = inp.uv * 5.0
+    let t    = g_Time * 0.3
+    let nc   = floor(uv)
+    let h    = frac(sin(float2(nc.x * 127.1 + nc.y * 311.7, nc.x * 269.5 + nc.y * 183.3)) * 43758.5)
+    let trig = float2(sin(mad(h.x, 6.28, t)), cos(mad(h.y, 6.28, t)))
+    let dvec = mad(trig, 0.3, mad(h, 0.5, nc)) - uv
+    let d    = length(dvec)
+    return PbrOutput(albedo = float3(d, d, d), emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 0.0, metalness = 0.0, roughness = 1.0, ao = 1.0)
+}

--- a/examples/flatten/scalar_packing/cells4_scalar.shader
+++ b/examples/flatten/scalar_packing/cells4_scalar.shader
@@ -1,0 +1,40 @@
+require engine.render.shader_dsl
+
+// 4 voronoi cells (2x2 block), scalar — four independent distance computations + min.
+[pixel_shader(flatten=false)]
+def cells4_scalar(inp : PbrInput) {
+    let uv  = inp.uv * 5.0
+    let t   = g_Time * 0.3
+    let cx  = floor(uv.x)
+    let cy  = floor(uv.y)
+    let cx1 = cx + 1.0
+    let cy1 = cy + 1.0
+    // cell 0 (cx,cy)
+    let hx0 = frac(sin(cx * 127.1 + cy * 311.7) * 43758.5)
+    let hy0 = frac(sin(cx * 269.5 + cy * 183.3) * 43758.5)
+    let dx0 = mad(sin(mad(hx0, 6.28, t)), 0.3, mad(hx0, 0.5, cx)) - uv.x
+    let dy0 = mad(cos(mad(hy0, 6.28, t)), 0.3, mad(hy0, 0.5, cy)) - uv.y
+    let d0  = sqrt(mad(dx0, dx0, dy0 * dy0))
+    // cell 1 (cx1,cy)
+    let hx1 = frac(sin(cx1 * 127.1 + cy * 311.7) * 43758.5)
+    let hy1 = frac(sin(cx1 * 269.5 + cy * 183.3) * 43758.5)
+    let dx1 = mad(sin(mad(hx1, 6.28, t)), 0.3, mad(hx1, 0.5, cx1)) - uv.x
+    let dy1 = mad(cos(mad(hy1, 6.28, t)), 0.3, mad(hy1, 0.5, cy)) - uv.y
+    let d1  = sqrt(mad(dx1, dx1, dy1 * dy1))
+    // cell 2 (cx,cy1)
+    let hx2 = frac(sin(cx * 127.1 + cy1 * 311.7) * 43758.5)
+    let hy2 = frac(sin(cx * 269.5 + cy1 * 183.3) * 43758.5)
+    let dx2 = mad(sin(mad(hx2, 6.28, t)), 0.3, mad(hx2, 0.5, cx)) - uv.x
+    let dy2 = mad(cos(mad(hy2, 6.28, t)), 0.3, mad(hy2, 0.5, cy1)) - uv.y
+    let d2  = sqrt(mad(dx2, dx2, dy2 * dy2))
+    // cell 3 (cx1,cy1)
+    let hx3 = frac(sin(cx1 * 127.1 + cy1 * 311.7) * 43758.5)
+    let hy3 = frac(sin(cx1 * 269.5 + cy1 * 183.3) * 43758.5)
+    let dx3 = mad(sin(mad(hx3, 6.28, t)), 0.3, mad(hx3, 0.5, cx1)) - uv.x
+    let dy3 = mad(cos(mad(hy3, 6.28, t)), 0.3, mad(hy3, 0.5, cy1)) - uv.y
+    let d3  = sqrt(mad(dx3, dx3, dy3 * dy3))
+
+    let m = min(min(d0, d1), min(d2, d3))
+    return PbrOutput(albedo = float3(m, m, m), emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 0.0, metalness = 0.0, roughness = 1.0, ao = 1.0)
+}

--- a/examples/flatten/scalar_packing/cells4_vec.shader
+++ b/examples/flatten/scalar_packing/cells4_vec.shader
@@ -1,0 +1,27 @@
+require engine.render.shader_dsl
+
+// Same 4 cells, packed across cells into ONE float4 lane-set. Each lane is a full independent
+// cell, so the body has no within-vector lane-crossing (sin is sin in all 4 lanes, etc.).
+// mad() needs matching widths, so scalar args are broadcast (operators broadcast on their own).
+[pixel_shader(flatten=false)]
+def cells4_vec(inp : PbrInput) {
+    let uv  = inp.uv * 5.0
+    let t   = g_Time * 0.3
+    let cx  = floor(uv.x)
+    let cy  = floor(uv.y)
+    let cx1 = cx + 1.0
+    let cy1 = cy + 1.0
+    let ncx = float4(cx, cx1, cx, cx1)
+    let ncy = float4(cy, cy, cy1, cy1)
+    let t4  = float4(t)
+    let uvx4 = float4(uv.x)
+    let uvy4 = float4(uv.y)
+    let hx  = frac(sin(ncx * 127.1 + ncy * 311.7) * 43758.5)
+    let hy  = frac(sin(ncx * 269.5 + ncy * 183.3) * 43758.5)
+    let dx  = mad(sin(mad(hx, float4(6.28), t4)), float4(0.3), mad(hx, float4(0.5), ncx)) - uvx4
+    let dy  = mad(cos(mad(hy, float4(6.28), t4)), float4(0.3), mad(hy, float4(0.5), ncy)) - uvy4
+    let d   = sqrt(mad(dx, dx, dy * dy))
+    let m   = min(min(d.x, d.y), min(d.z, d.w))
+    return PbrOutput(albedo = float3(m, m, m), emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 0.0, metalness = 0.0, roughness = 1.0, ao = 1.0)
+}

--- a/examples/flatten/scalar_packing/plasma_scalar.shader
+++ b/examples/flatten/scalar_packing/plasma_scalar.shader
@@ -1,0 +1,13 @@
+require engine.render.shader_dsl
+[pixel_shader(flatten=false)]
+def plasma_scalar(inp : PbrInput) {
+    let t  = g_Time * 1.5
+    let uv = inp.uv * 4.0
+    let v1 = sin(uv.x + t)
+    let v2 = sin(uv.y + t * 0.7)
+    let v3 = sin(uv.x + uv.y + t * 0.5)
+    let v4 = sin(length(uv - float2(2.0, 2.0)) - t)
+    let v  = (v1 + v2 + v3 + v4) * 0.125 + 0.5
+    return PbrOutput(albedo = float3(v, v, v), emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 0.0, metalness = 0.0, roughness = 1.0, ao = 1.0)
+}

--- a/examples/flatten/scalar_packing/plasma_vec.shader
+++ b/examples/flatten/scalar_packing/plasma_vec.shader
@@ -1,0 +1,11 @@
+require engine.render.shader_dsl
+[pixel_shader(flatten=false)]
+def plasma_vec(inp : PbrInput) {
+    let t    = g_Time * 1.5
+    let uv   = inp.uv * 4.0
+    let args = float4(uv.x + t, uv.y + t * 0.7, uv.x + uv.y + t * 0.5, length(uv - float2(2.0, 2.0)) - t)
+    let s    = sin(args)
+    let v    = (s.x + s.y + s.z + s.w) * 0.125 + 0.5
+    return PbrOutput(albedo = float3(v, v, v), emission = float3(0.0, 0.0, 0.0),
+        emissionStrength = 0.0, metalness = 0.0, roughness = 1.0, ao = 1.0)
+}

--- a/tests/flatten/no_aot/_pack_fixtures.das
+++ b/tests/flatten/no_aot/_pack_fixtures.das
@@ -1,0 +1,50 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+
+require flat_pack_macro
+require math
+
+//! Fixtures for the scalar-packing pass (`pack_map_reduce` via `flatten_pack`). Each `[flat_pack]`
+//! function produces a `*_packflat` twin (flattened → packed → folded). test_flatten_pack.das
+//! compiles this file and asserts the min/max reduction re-rolls into `_pk*` vector vars, while
+//! the fail-closed shapes (a const-threshold select, a lane that reads the accumulator) do NOT.
+
+// PACKS: a min reduction over 4 independent, isomorphic scalar lanes (each lane = sin/mul chain
+// of `seed` + a per-lane const). The unrolled `?:` min spine re-rolls into width-4 vector ops.
+[flat_pack]
+def pk_min4(seed : float) : float {
+    var acc = 100.0
+    for (i in range(4)) {
+        let x = sin(seed + float(i) * 1.3) * 7.0
+        let d = x * x
+        acc = d < acc ? d : acc   // nolint:PERF015 — ternary-min spine is the exact shape the pass recognizes
+    }
+    return acc
+}
+
+// BAILS (classification, fail-closed): the select compares `d` against a CONST threshold, not the
+// accumulator — `acc = (d < 5) ? d : acc` is NOT a min reduction. classify_link must reject it.
+[flat_pack]
+def pk_thresh(seed : float) : float {
+    var acc = 100.0
+    for (i in range(4)) {
+        let x = sin(seed + float(i) * 1.3) * 7.0
+        let d = x * x
+        acc = d < 5.0 ? d : acc
+    }
+    return acc
+}
+
+// BAILS (independence, fail-closed): each lane reads the running accumulator (`sin(acc + ...)`),
+// so the iterations are genuinely sequential — the per-lane independence check must reject it.
+[flat_pack]
+def pk_dep(seed : float) : float {
+    var acc = 100.0
+    for (i in range(4)) {
+        let x = sin(acc + seed + float(i) * 1.3) * 7.0
+        let d = x * x
+        acc = d < acc ? d : acc   // nolint:PERF015 — ternary-min spine is the exact shape the pass recognizes
+    }
+    return acc
+}

--- a/tests/flatten/no_aot/flat_pack_macro.das
+++ b/tests/flatten/no_aot/flat_pack_macro.das
@@ -1,0 +1,96 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+
+module flat_pack_macro shared private
+
+//! A stand-in "backend" annotation that exercises the PUBLIC `flatten_pack` entry the way the
+//! example shader backend does: clone a twin, `flatten_function` it (cycle 1), then on the
+//! re-inferred body run `flatten_pack` (scalar-packing map-reduce re-roll) PRE-fold, then
+//! `flatten_fold`. Lives in its own module — the consuming test compiles a fixture that
+//! `require`s it. The `*_packflat` twin is the real flattened+packed body, so a test can
+//! introspect it (does a min/max reduction re-roll into `_pk*` vector vars, or bail clean?).
+
+require daslib/flatten
+require daslib/ast
+require daslib/ast_boost
+require daslib/rtti
+
+let private PACK_PRIMS : table<string> <- { "sin", "cos", "sqrt", "min", "max" }
+
+def private pack_phase(func : FunctionPtr) : int {
+    for (ann in func.annotations) {
+        if (ann.annotation.name == "flat_pack") {
+            let pv = find_arg(ann.arguments, "phase")
+            if (pv is tInt) return pv as tInt
+        }
+    }
+    return -1
+}
+
+def private set_pack_phase(var func : FunctionPtr; ph : int) {
+    for (ann in func.annotations) {
+        if (ann.annotation.name != "flat_pack") continue
+        var found = false
+        for (a in ann.arguments) {
+            if ("{a.name}" == "phase") {
+                a.iValue = ph
+                found = true
+            }
+        }
+        if (!found) ann.arguments |> add_annotation_argument("phase", ph)
+    }
+}
+
+[function_macro(name="flat_pack")]
+class FlatPackMacro : AstFunctionAnnotation {
+    def override apply(var func : FunctionPtr; var group : ModuleGroup;
+                       args : AnnotationArgumentList; var errors : das_string) : bool {
+        let tn = "{func.name}_packflat"
+        if (find_unique_function(compiling_module(), tn, true) == null) {
+            var fn = clone_function(func)
+            fn.name := tn
+            fn.flags |= FunctionFlags.generated | FunctionFlags.exports
+            while (fn.annotations |> length != 0) {
+                fn.annotations |> erase(0)
+            }
+            compiling_module() |> add_function(fn)
+        }
+        return true
+    }
+    def override patch(var func : FunctionPtr; var group : ModuleGroup;
+                       args, progArgs : AnnotationArgumentList; var errors : das_string;
+                       var astChanged : bool&) : bool {
+        // Skip under lint (the twin is irrelevant to linting source); mirrors [flatten] / the backend.
+        if (is_in_lint_check()) return true
+        let ph = pack_phase(func)
+        if (ph >= 3) return true
+        var twin = find_unique_function(compiling_module(), "{func.name}_packflat", true)
+        if (twin == null) {
+            errors := "flat_pack: twin not declared"
+            return false
+        }
+        if (ph == 2) {
+            // Cycle 2 finish: fold the packed body the way the backend does after packing.
+            flatten_fold(twin)
+            set_pack_phase(func, 3)
+            astChanged = true
+            return true
+        }
+        if (ph == 1) {
+            // Re-inferred after flattening: run the PUBLIC pack entry PRE-fold (backend order).
+            flatten_pack(twin, false)
+            set_pack_phase(func, 2)
+            astChanged = true
+            return true
+        }
+        let ctx = flatten_function(twin, PACK_PRIMS)
+        if (!ctx.ok) {
+            errors := ctx.err
+            return false
+        }
+        set_pack_phase(func, 1)
+        astChanged = true
+        return true
+    }
+}

--- a/tests/flatten/no_aot/test_flatten_pack.das
+++ b/tests/flatten/no_aot/test_flatten_pack.das
@@ -1,0 +1,67 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require daslib/ast
+require daslib/ast_boost
+require daslib/rtti
+require strings
+
+//! Targeted test for the scalar-packing pass (`pack_map_reduce`, exposed as `flatten_pack`). It
+//! compiles _pack_fixtures.das — whose `[flat_pack]` annotation flattens a twin, runs the PUBLIC
+//! `flatten_pack` entry, then folds — and asserts the post-pack body structurally:
+//!   • a real min reduction re-rolls into `_pk*` vector vars (the pass FIRED);
+//!   • a const-threshold select and an accumulator-dependent lane do NOT (the fail-closed bailout).
+//! Structural (not value) so it is tier-independent; the `_pk*` marker also regression-guards the
+//! classify_link fail-closed gate — if it ever re-accepts a threshold, `_pk` reappears and this reds.
+//!
+//! Lives in no_aot/ (compiles daslib/flatten at runtime, pulling macro_boost instantiations that
+//! don't AOT-link in the full-tree batch — same reason as test_flatten_fold.das).
+
+// describe() of each `*_packflat` twin produced by compiling `path`, keyed by twin name.
+def private pack_twins(t : T?; path : string) : table<string; string> {
+    var bodies : table<string; string>
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.version_2_syntax = true
+            compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                if (!ok) {
+                    t |> failure("compile failed: {path}\n{iss}")
+                    return
+                }
+                program_for_each_module(program) $(mod) {
+                    for_each_function(mod, "") $(func) {
+                        if (func.body != null && !func.flags.builtIn && func.name |> ends_with("_packflat")) {
+                            bodies["{func.name}"] = "{describe(func.body)}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return <- bodies
+}
+
+[test]
+def test_flatten_pack(t : T?) {
+    let root = get_das_root()
+    t |> run("min reduction packs; fail-closed shapes bail clean") @(t : T?) {
+        var bodies <- pack_twins(t, "{root}/tests/flatten/no_aot/_pack_fixtures.das")
+        // FIRED: the unrolled min spine re-rolls into width-4 vector vars (`_pk*`).
+        let mn = bodies?["pk_min4_packflat"] ?? ""
+        t |> success(!empty(mn), "pk_min4_packflat twin must be produced")
+        t |> success(mn |> find("_pk") >= 0, "min reduction must re-roll into _pk* vector vars: {mn}")
+        // BAILED (classification): a const-threshold select is not a min/max reduction.
+        let th = bodies?["pk_thresh_packflat"] ?? ""
+        t |> success(!empty(th), "pk_thresh_packflat twin must be produced")
+        t |> success(th |> find("_pk") < 0, "const-threshold select must NOT pack (fail-closed): {th}")
+        // BAILED (independence): a lane reading the accumulator is sequential, not data-parallel.
+        let dp = bodies?["pk_dep_packflat"] ?? ""
+        t |> success(!empty(dp), "pk_dep_packflat twin must be produced")
+        t |> success(dp |> find("_pk") < 0, "accumulator-dependent lane must NOT pack (fail-closed): {dp}")
+        delete bodies
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **scalar-packing (SLP / loop re-roll)** pass to the flatten shader-backend optimizer. `flatten` unrolls a data-parallel loop into N scalar copies; this pass recognizes an unrolled **min/max reduction** whose N lane bodies are isomorphic and independent, and re-rolls them into width-≤4 vector ops + one horizontal reduce — so the shader-graph backend emits **one width-W node where it previously emitted N scalar nodes**.

The pass produces the vectorized *demand*; the backend's existing splat/combine fold cleans the boundary glue (which is what makes packing net-positive).

## What's in it (3 commits)

1. **`flatten=off` backend mode** — `[pixel_shader(flatten=false)]` emits IR for the source verbatim (no inline/fold/optimize/fuse), so a hand-vectorized shader can be A/B'd against its scalar twin. Used purely for the study below.
2. **Scalar-packing study** (`examples/flatten/scalar_packing/`) — `FINDINGS.md` + `PLAN.md` + 6 A/B shader pairs establishing the empirical bracket.
3. **Phase 1 pass** — `pack_map_reduce` (`daslib/flatten_opt.das`) + `flatten_pack` public wrapper (`daslib/flatten.das`) + a gated `packed` cycle-2 stage wired into the example backend (`shader_dsl_boost.das`), running **pre-fold**.

## Result

| Scope | nodes (pass off → on) | Δ |
|---|---|---|
| **voronoi** | 348 → 171 | **−51%** |
| whole corpus (86 shaders) | 4387 → 4210 | −177 (= voronoi alone) |

voronoi is the **only** corpus shader with the target shape (a data-parallel min/max reduction loop). On the other 85 the pass is a clean no-op — zero collateral, confirmed by A/B diff.

## Design notes

- Recognizes the SSA min/max reduction spine `var acc' = (d cmp acc) ? d : acc` over N isomorphic, independent lane bodies; SoA-packs each role across W lanes; `plan_groups` splits into width-≤4 groups avoiding width-1 tails (9 → [4,3,2]); replaces the spine with `min(init, hmin(g0), …)`.
- **Gated** on `!no_fast_math` (reduction-tree reassociation), ≥3 lanes, uniform lane layout, and per-lane independence (no lane reads a spine accumulator or another lane's temp). Bails clean (no mutation) on any mismatch.
- daslang has no scalar→vector broadcast for `+`/`-`/call-args (only `vec * scalar`), so invariants are splatted to `floatN(x)` and the downstream splat-fold collapses the collapsible ones.

## Phase 2 (general SLP) — evaluated and declined

A corpus survey settled whether a general SLP pass (packing isomorphic scalar trees *not* from a loop) was worth building. It isn't, on this corpus, for a structural reason: **Phase 1 already harvests every high-live-range opportunity** (the win scales with width × live-range, and that lives in the loop reductions Phase 1 re-rolls — e.g. voronoi's within-cell x/y chains are *absorbed* into across-cell float4 component math). General SLP would add only the low-live-range cases: fan-into-a-builtin (plasma, −7%, one corpus instance) and standalone isomorphic chains (zero corpus instances — the candidates are blocked by non-vectorizable `noise`/`tex2d` leaves). Full reasoning + the revisit trigger are in `FINDINGS.md`.

## Testing

- `tests/flatten` — 264/264 pass.
- flatten-fuzz (differential oracle on the core optimizer) — numeric `-b 40` and `--bool -b 40` both all-pass.
- Lint: 0 issues on changed `.das`. Formatter `--verify`: clean (2357 files).
- `examples/flatten` is not in CI ctest; the guard is `test_flatten_fold` + the manual node-count repro in `FINDINGS.md`.

Note: the pass is **opt-in** — only the example backend calls `flatten_pack`; the core `flatten_function`/`flatten_optimize` pipeline is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvWu2izV1ebb2LgHwHaWjp