### PR TITLE
feat(math): horizontal reduce hmin/hmax/hadd for float{2,3,4}

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,6 +30,12 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 |---|---|
 | `test01.das` | Runtime heap `heap_collect` cost — mark-bound (20K live nodes), sweep-bound (400K-slot capacity, tiny live), and deep (500K-node chain, exercises the bounded-recursion mark path) |
 
+## core/math/
+
+| File | Description |
+|---|---|
+| `horizontal_reduce.das` | `hmin`/`hmax`/`hadd` over a hot float4 array — measures the JIT `llvm.vector.reduce.*` lowering vs the extern-call fallback (and interp); non-constant inputs + a global sink defeat const-fold / DCE |
+
 ## audio/
 
 | File | Description |

--- a/benchmarks/core/math/horizontal_reduce.das
+++ b/benchmarks/core/math/horizontal_reduce.das
@@ -1,0 +1,50 @@
+options gen2
+options persistent_heap
+
+require dastest/testing_boost
+require math
+
+// Horizontal reduce (hmin/hmax/hadd) over a hot array of float4. In JIT these lower
+// to a single llvm.vector.reduce.* op; without the intrinsic mapping they fall back to
+// an extern call across the JIT boundary (no inline, ABI marshalling) — this benchmark
+// measures that gap. Non-constant data + a global sink defeat const-fold / DCE.
+
+let N = 2048
+
+var g_sink = 0.0
+
+def make_data : array<float4> {
+    var data : array<float4>
+    data |> resize(N)
+    for (i in range(N)) {
+        let f = float(i)
+        data[i] = float4(f * 0.123 + 1.0, f * -0.7 + 3.0, f * 0.31 - 2.0, f * 0.05 + 0.5)
+    }
+    return <- data
+}
+
+[benchmark]
+def bench_horizontal_reduce(b : B?) {
+    let data <- make_data()
+    b |> run("hmin4/{N}", N) {
+        var acc = 0.0
+        for (v in data) {
+            acc += hmin(v)
+        }
+        g_sink += acc
+    }
+    b |> run("hmax4/{N}", N) {
+        var acc = 0.0
+        for (v in data) {
+            acc += hmax(v)
+        }
+        g_sink += acc
+    }
+    b |> run("hadd4/{N}", N) {
+        var acc = 0.0
+        for (v in data) {
+            acc += hadd(v)
+        }
+        g_sink += acc
+    }
+}

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -51,6 +51,7 @@ let private STD_WHITELIST : table<string> <- {
     "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sincos",
     "radians", "degrees",   // lowered to `x * K` by flatten_opt (no opcode needed)
     "dot", "cross", "length", "normalize", "distance", "reflect", "refract",
+    "hmin", "hmax", "hadd",   // horizontal reduces emitted by pack_map_reduce (flatten_opt_pack)
     "lerp", "mix", "step", "smooth_step", "rcp", "mad",
     "float2", "float3", "float4", "int2", "int3", "int4", "uint2", "uint3", "uint4"
 }

--- a/daslib/flatten_opt_pack.das
+++ b/daslib/flatten_opt_pack.das
@@ -14,7 +14,6 @@ require daslib/templates_boost
 require daslib/macro_boost
 require daslib/match
 require daslib/rtti
-require strings
 require daslib/flatten_opt_common
 
 
@@ -269,19 +268,14 @@ def private make_vec_let(vecName : string; var vecExpr : ExpressionPtr) : Expres
     return qmacro_expr(${ let $i(vecName) = $e(vecExpr); })
 }
 
-// Horizontal min/max over `vecName`'s W components: op(op(.x,.y),.z)... — W>=2.
+// Horizontal reduce over `vecName`'s W (2..4) components as a single hmin/hmax call.
 def private hreduce(vecName : string; width : int; op : string; at : LineInfo) : ExpressionPtr {
-    var acc : ExpressionPtr = new ExprField(at = at, value = new ExprVar(at = at, name := vecName),
-                                            name := slice("xyzw", 0, 1))
-    for (c in range(1, width)) {
-        var nextc = new ExprField(at = at, value = new ExprVar(at = at, name := vecName),
-                                  name := slice("xyzw", c, c + 1))
-        var call = new ExprCall(at = at, name := op)
-        call.arguments |> push(acc)
-        call.arguments |> push(nextc)
-        acc = call
-    }
-    return acc
+    // groups are width 2..4 (caller bails below M=3, plan_groups avoids width-1 tails),
+    // so one horizontal-reduce call (hmin/hmax) replaces the lane-extract + scalar tree.
+    assert(width >= 2 && width <= 4, "hreduce expects a packed group of width 2..4")
+    var call = new ExprCall(at = at, name := "h{op}")
+    call.arguments |> push(new ExprVar(at = at, name := vecName))
+    return call
 }
 
 def public pack_map_reduce(var func : FunctionPtr; no_fast_math : bool = false) : bool {

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -136,6 +136,7 @@ require spirv/spirv_reflect
 def document_module_math(_root : string) {
     var mod = get_module("math")
     var groups <- array<DocGroup>(
+        group_by_regex("Horizontal reduce (float2, float3, float4)", mod, %regex~(hmin|hmax|hadd)$%%),
         group_by_regex("all numerics (uint*, int*, float*, double)", mod, %regex~(min|max)$%%),
         group_by_regex("float* and double", mod, %regex~(sign|abs|acos|asin|safe_acos|safe_asin|atan|atan2|cos|sin|tan|sinh|cosh|tanh|asinh|acosh|atanh|exp|log|exp2|expm1|log2|log10|log1p|pow|sqrt|cbrt|hypot|fmod|remainder|trunc|rcp|ceil|floor|abs|saturate|sincos|is_finite|is_nan|radians|degrees|step|smoothstep)$%%),
         group_by_regex("float* only", mod, %regex~(atan_est|atan2_est|rcp_est|ceili|floori|roundi|trunci|round|rsqrt|rsqrt_est|fract|\-)$%%),

--- a/doc/source/stdlib/handmade/function-math-hadd-0xfed65a1480db07c6.rst
+++ b/doc/source/stdlib/handmade/function-math-hadd-0xfed65a1480db07c6.rst
@@ -1,0 +1,1 @@
+Horizontal sum: returns the sum of the vector's components. For example, ``hadd(float3(3,1,4))`` is ``8``.

--- a/doc/source/stdlib/handmade/function-math-hmax-0xf298bb1802b34bf7.rst
+++ b/doc/source/stdlib/handmade/function-math-hmax-0xf298bb1802b34bf7.rst
@@ -1,0 +1,1 @@
+Horizontal maximum: returns the largest of the vector's components. For example, ``hmax(float3(3,1,4))`` is ``4``. Results are unspecified if any component is NaN.

--- a/doc/source/stdlib/handmade/function-math-hmin-0xb278c4fc6659f82f.rst
+++ b/doc/source/stdlib/handmade/function-math-hmin-0xb278c4fc6659f82f.rst
@@ -1,0 +1,1 @@
+Horizontal minimum: returns the smallest of the vector's components. For example, ``hmin(float3(3,1,4))`` is ``1``. Results are unspecified if any component is NaN.

--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -78,6 +78,7 @@ let HINT_WHITELIST : table<string> <- {
     "abs", "min", "max", "clamp", "saturate", "frac", "floor", "ceil", "mad", "lerp",
     "sqrt", "pow", "sin", "cos", "atan2", "log", "exp", "sign", "radians", "degrees",
     "dot", "cross", "length", "normalize", "fresnel",
+    "hmin", "hmax", "hadd",
     "remap", "one_minus", "step", "smooth_step", "unpack_normal",
     "float", "int",
     "float2", "float3", "float4", "int2", "int3", "int4",

--- a/examples/flatten/backend/shader_dsl_primitives.das
+++ b/examples/flatten/backend/shader_dsl_primitives.das
@@ -138,6 +138,26 @@ def max(x : float3, y : float3) : float3 {}
 [stub, hint(max)]
 def max(x : float4, y : float4) : float4 {}
 
+// -- horizontal reduce (vector -> scalar) --
+[stub, hint(hmin)]
+def hmin(x : float2) : float {}
+[stub, hint(hmin)]
+def hmin(x : float3) : float {}
+[stub, hint(hmin)]
+def hmin(x : float4) : float {}
+[stub, hint(hmax)]
+def hmax(x : float2) : float {}
+[stub, hint(hmax)]
+def hmax(x : float3) : float {}
+[stub, hint(hmax)]
+def hmax(x : float4) : float {}
+[stub, hint(hadd)]
+def hadd(x : float2) : float {}
+[stub, hint(hadd)]
+def hadd(x : float3) : float {}
+[stub, hint(hadd)]
+def hadd(x : float4) : float {}
+
 // -- clamp (ternary) --
 [stub, hint(clamp)]
 def clamp(x : float | int, min : float | int, max : float | int) : float {}

--- a/include/daScript/simulate/aot_builtin_math.h
+++ b/include/daScript/simulate/aot_builtin_math.h
@@ -57,6 +57,18 @@ namespace das {
     __forceinline float dot3(vec4f a, vec4f b){return v_extract_x(v_dot3_x(a, b));}
     __forceinline float dot4(vec4f a, vec4f b){return v_extract_x(v_dot4_x(a, b));}
 
+    // horizontal reduce of a float vector to a scalar. hmin/hmax NaN behavior follows
+    // the underlying SIMD min/max (not daslang scalar min/max), so don't feed them NaN.
+    __forceinline float hmin2(vec4f a){return v_extract_x(v_min(a, v_rot_1(a)));}
+    __forceinline float hmin3(vec4f a){return v_extract_x(v_hmin3(a));}
+    __forceinline float hmin4(vec4f a){return v_extract_x(v_hmin(a));}
+    __forceinline float hmax2(vec4f a){return v_extract_x(v_max(a, v_rot_1(a)));}
+    __forceinline float hmax3(vec4f a){return v_extract_x(v_hmax3(a));}
+    __forceinline float hmax4(vec4f a){return v_extract_x(v_hmax(a));}
+    __forceinline float hadd2(vec4f a){return v_extract_x(v_add_x(a, v_rot_1(a)));}
+    __forceinline float hadd3(vec4f a){return v_extract_x(v_hadd3_x(a));}
+    __forceinline float hadd4(vec4f a){return v_extract_x(v_hadd4_x(a));}
+
     __forceinline vec4f normalize2(vec4f a){return v_norm2(a); }
     __forceinline vec4f normalize3(vec4f a){return v_norm3(a); }
     __forceinline vec4f normalize4(vec4f a){return v_norm4(a); }

--- a/include/vecmath/dag_vecMath_neon.h
+++ b/include/vecmath/dag_vecMath_neon.h
@@ -227,7 +227,7 @@ VECTORCALL VECMATH_FINLINE vec4i v_muli(vec4i a, vec4i b) { return vmulq_s32(a, 
 
 VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
 {
-  return v_set_x(vaddvq_s32(a));
+  return v_set_x(vaddvq_f32(a));
 }
 VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec4f a)
 {

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -107,6 +107,9 @@ let g_intrin_lookup <- {
     "math::pow" => @@intrinsic_op2,
     "math::min" => @@intrinsic_math_minmax,
     "math::max" => @@intrinsic_math_minmax,
+    "math::hmin" => @@intrinsic_math_hminmax,
+    "math::hmax" => @@intrinsic_math_hminmax,
+    "math::hadd" => @@intrinsic_math_hadd,
     "math::clamp" => @@intrinsic_math_clamp,
     "math::step" => @@intrinsic_math_step,
     "math::smoothstep" => @@intrinsic_math_smoothstep,
@@ -971,6 +974,31 @@ def intrinsic_math_dot(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array
     assert(opType.isVectorType)
     let v2 = LLVMBuildFMul(ctx.builder, arguments[0], arguments[1], "")
     return build_fadd(ctx, opType, v2, "dot")
+}
+
+// hmin/hmax: horizontal min/max via llvm.vector.reduce.fmin/fmax (one IR op, no extern call).
+def intrinsic_math_hminmax(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume opType = expr.arguments[0]._type
+    assert(opType.isVectorType)
+    let op = expr.name == "hmin" ? "fmin" : "fmax"
+    let iname = "llvm.vector.reduce.{op}.v{opType.vectorDim}f32"
+    var argTypes <- [ type_to_llvm_abi_type(opType)]
+    let id = LLVMLookupIntrinsicID(iname)
+    var decl = LLVMGetIntrinsicDeclaration(g_mod, id, argTypes)
+    if (decl == null) {
+        failed("missing intrinsic {iname}")
+        return null
+    }
+    var args <- [ arguments[0]]
+    var typ = LLVMFunctionType(ctx.types.t_float, [ type_to_llvm_abi_type(opType)])
+    return LLVMBuildCall2(ctx.builder, typ, decl, args, string(expr.name))
+}
+
+// hadd: horizontal sum via llvm.vector.reduce.fadd (shares build_fadd with dot/length).
+def intrinsic_math_hadd(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume opType = expr.arguments[0]._type
+    assert(opType.isVectorType)
+    return build_fadd(ctx, opType, arguments[0], "hadd")
 }
 
 def intrinsic_math_fast_normalize(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x28ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x29ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -684,6 +684,15 @@ namespace das {
             addExternEx<float(float2,float2),DAS_BIND_FUN(dot2)>(*this, lib, "dot", SideEffects::none, "dot2")->args({"x","y"});
             addExternEx<float(float3,float3),DAS_BIND_FUN(dot3)>(*this, lib, "dot", SideEffects::none, "dot3")->args({"x","y"});
             addExternEx<float(float4,float4),DAS_BIND_FUN(dot4)>(*this, lib, "dot", SideEffects::none, "dot4")->args({"x","y"});
+            addExternEx<float(float2),DAS_BIND_FUN(hmin2)>(*this, lib, "hmin", SideEffects::none, "hmin2")->arg("a");
+            addExternEx<float(float3),DAS_BIND_FUN(hmin3)>(*this, lib, "hmin", SideEffects::none, "hmin3")->arg("a");
+            addExternEx<float(float4),DAS_BIND_FUN(hmin4)>(*this, lib, "hmin", SideEffects::none, "hmin4")->arg("a");
+            addExternEx<float(float2),DAS_BIND_FUN(hmax2)>(*this, lib, "hmax", SideEffects::none, "hmax2")->arg("a");
+            addExternEx<float(float3),DAS_BIND_FUN(hmax3)>(*this, lib, "hmax", SideEffects::none, "hmax3")->arg("a");
+            addExternEx<float(float4),DAS_BIND_FUN(hmax4)>(*this, lib, "hmax", SideEffects::none, "hmax4")->arg("a");
+            addExternEx<float(float2),DAS_BIND_FUN(hadd2)>(*this, lib, "hadd", SideEffects::none, "hadd2")->arg("a");
+            addExternEx<float(float3),DAS_BIND_FUN(hadd3)>(*this, lib, "hadd", SideEffects::none, "hadd3")->arg("a");
+            addExternEx<float(float4),DAS_BIND_FUN(hadd4)>(*this, lib, "hadd", SideEffects::none, "hadd4")->arg("a");
             addExternEx<float3(float3,float3),DAS_BIND_FUN(cross3)>(*this, lib, "cross", SideEffects::none, "cross3")->args({"x","y"});
             addExternEx<float2(float2),DAS_BIND_FUN(normalize2)>(*this, lib, "fast_normalize", SideEffects::none, "normalize2")->arg("x");
             addExternEx<float3(float3),DAS_BIND_FUN(normalize3)>(*this, lib, "fast_normalize", SideEffects::none, "normalize3")->arg("x");

--- a/tests/language/horizontal_reduce.das
+++ b/tests/language/horizontal_reduce.das
@@ -1,0 +1,29 @@
+options gen2
+require dastest/testing_boost public
+require math
+
+// hmin / hmax / hadd horizontal reduce for float{2,3,4}. The values are read from heap
+// arrays, so the element reads are not const-folded and the calls exercise the real
+// interp / AOT / JIT codegen (the JIT lane thus covers the llvm.vector.reduce.* lowering).
+
+[test]
+def test_horizontal_reduce(t : T?) {
+    let v4 <- [float4(3.0, 1.0, 4.0, 1.5), float4(-2.0, 5.0, -7.0, 0.0)]
+    let v3 <- [float3(3.0, 1.0, 4.0)]
+    let v2 <- [float2(3.0, 1.0)]
+
+    t |> equal(hmin(v4[0]), 1.0)
+    t |> equal(hmax(v4[0]), 4.0)
+    t |> equal(hadd(v4[0]), 9.5)
+    t |> equal(hmin(v4[1]), -7.0)
+    t |> equal(hmax(v4[1]), 5.0)
+    t |> equal(hadd(v4[1]), -4.0)
+
+    t |> equal(hmin(v3[0]), 1.0)
+    t |> equal(hmax(v3[0]), 4.0)
+    t |> equal(hadd(v3[0]), 8.0)
+
+    t |> equal(hmin(v2[0]), 1.0)
+    t |> equal(hmax(v2[0]), 3.0)
+    t |> equal(hadd(v2[0]), 4.0)
+}


### PR DESCRIPTION
## What

Adds `hmin` / `hmax` / `hadd` — the smallest / largest / sum of a float vector's components — for `float2`, `float3`, `float4`, across all three execution tiers.

| | implementation |
|---|---|
| **interp + AOT** | one `__forceinline` wrapper per width in `aot_builtin_math.h` over the existing vecmath horizontal intrinsics (`v_hmin`/`v_hmax`/`v_hmin3`/`v_hmax3`/`v_hadd3_x`/`v_hadd4_x`), registered in module `math` next to `dot`/`length`. One C++ inline serves both tiers, exactly like `dot`. |
| **JIT** | `llvm.vector.reduce.fmin`/`fmax`/`fadd` lowering in `llvm_jit_intrin.das` (`hadd` reuses the `dot`/`length` `build_fadd` helper). Bumps `LLVM_JIT_CODEGEN_VERSION`. |

## Why the JIT intrinsic (not just the extern fallback)

An unmapped builtin is correct in JIT via an extern call, but that call is an optimization barrier (no inline, ABI marshalling). The intrinsic lowers to a single reduce op. Benchmark (`benchmarks/core/math/horizontal_reduce.das`, hot `float4` array, ns/op):

| op | interp | JIT-extern | JIT-intrinsic |
|---|---|---|---|
| hmin4 | 5.3 | 1.5 | 1.4 |
| hmax4 | 5.4 | 1.9 | **1.3** (−33%) |
| hadd4 | 7.0 | 1.9 | **1.0** (−47%, ~2×) |

## Flatten

`pack_map_reduce` now emits `hmin`/`hmax` for the packed min/max reduction spine instead of a lane-extract + scalar min-tree; the example shader backend gains the matching `[hint]` nodes. The packed reduction collapses to one node per group:

- **voronoi 171 → 159 nodes** (−12); no other shader in the 86-shader corpus changes (`pack_map_reduce` fires only on isomorphic min/max loop reductions).

## Tests

- `tests/language/horizontal_reduce.das` — heap-array inputs so the calls survive const-folding and exercise the real interp / AOT / JIT codegen.
- Doc: new builtins grouped under "Horizontal reduce" in `das2rst`; handmade descriptions added.

## Gates

Lint 0 issues · format verified · interp 10456 passed (0 fail/err) · AOT 9752 passed (0 fail/err) · JIT verified correct + benchmarked · 267 flatten tests pass · sphinx latex+html `-W` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)