### PR TITLE
feat(flatten): pack horizontal scalar sums into hadd

### DIFF
--- a/daslib/flatten_opt_fuse.das
+++ b/daslib/flatten_opt_fuse.das
@@ -617,21 +617,122 @@ class private LerpFuseVisitor : AstVisitor {
     }
 }
 
+// A horizontal-sum lane for the hadd pack: a positive, non-const term that is neither a `*`
+// (mad-fusable — `mad(a, b, acc)` folds the multiply AND the add into one node per term, beating a
+// combine + hadd on a weighted sum like an fBm octave chain) nor an already-emitted `hadd` (re-packing
+// one as a lane would nest hadds; excluding it makes a >4 chain pack into PARALLEL hadds instead). The
+// fuser packs ≥4 of these per chain; the residual oracle counts the same predicate, so it mirrors it.
+def private is_hadd_term(t : ReTerm) : bool {
+    return !(t.neg || is_all_const(t.e) ||
+             (t.e is ExprOp2 && (t.e as ExprOp2).op == "*") ||
+             (t.e is ExprCall && simple_name("{(t.e as ExprCall).name}") == "hadd"))
+}
+
+// Pack a horizontal sum of >=4 independent scalars into `hadd(float4(...))`. The dot fold above only
+// reaches lanes of ONE vector (`v.x + v.y + …`); unrelated scalars (plasma's `v1 + v2 + v3 + v4`)
+// have no shared base, so a combine + hadd is the collapse. ONLY full groups of four are emitted:
+// 4 adds -> one combine + one hadd is a strict -1 node, while widths 2-3 are node-neutral/negative
+// on this backend, so a remainder of 1-3 stays as scalar adds. Fast-math (reassociates the sum),
+// so it rides the same no_fast_math gate as the dot fold.
+class private HaddFuseVisitor : AstVisitor {
+    changed : bool
+    def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
+        if (!(that.op == "+" || that.op == "-") || expr_bt(that) != Type.tFloat) return that
+        var terms : array<ReTerm>
+        collect_add(that, false, terms)
+        // gather the hadd lanes (see is_hadd_term); excluding an already-emitted hadd makes this
+        // bottom-up visitor pack a >4 chain into PARALLEL hadds rather than nesting one in the next,
+        // matching a top-down maximal-chain walk — same node count, lower dependency depth
+        var cand <- [for (i in range(length(terms))); i; where is_hadd_term(terms[i])]
+        let ng = length(cand) / 4   // nolint:PERF015 — full groups of four only; remainder stays scalar
+        if (ng == 0) {
+            delete cand
+            unsafe {
+                delete terms
+            }
+            return that
+        }
+        // group head term i -> hadd(float4(...)) over its 4 lanes; the other 3 lanes drop
+        var headBase : table<int; int>
+        var dropped : table<int>
+        for (gi in range(ng)) {
+            headBase |> insert(cand[gi * 4], gi * 4)
+            for (li in range(1, 4)) {
+                dropped |> insert(cand[gi * 4 + li])
+            }
+        }
+        var newTerms : array<ReTerm>
+        for (i in range(length(terms))) {
+            if (key_exists(dropped, i)) continue
+            if (key_exists(headBase, i)) {
+                let base = headBase[i]
+                var lanes : array<ExpressionPtr>
+                lanes |> reserve(4)
+                for (li in range(4)) {
+                    lanes |> push(terms[cand[base + li]].e)   // reuse the leaf node (each used once)
+                }
+                var ctor = make_float_ctor(4, that.at, lanes)
+                var cll = new ExprCall(at = that.at, name := "hadd")
+                emplace(cll.arguments, ctor)
+                newTerms |> push(ReTerm(neg = false, e = cll))
+                unsafe {
+                    delete lanes
+                }
+            } else {
+                newTerms |> push(terms[i])
+            }
+        }
+        var r = build_chain(newTerms, that.at, "+", "-")
+        changed = true
+        delete cand
+        delete headBase
+        delete dropped
+        unsafe {
+            delete terms
+            delete newTerms
+        }
+        return r
+    }
+}
+
+// A maximal `+`/`-` chain still carrying ≥4 hadd lanes the fuser should have packed — the residual
+// twin of HaddFuseVisitor, sharing is_hadd_term so the oracle's gate is the fuser's gate exactly.
+def private has_unfused_hadd(var that : ExprOp2?) : bool {
+    if (that == null || !(that.op == "+" || that.op == "-") || expr_bt(that) != Type.tFloat) return false
+    var terms : array<ReTerm>
+    collect_add(that, false, terms)
+    var n = 0
+    for (t in terms) {
+        if (is_hadd_term(t)) {
+            n ++
+        }
+    }
+    unsafe {
+        delete terms
+    }
+    return n >= 4
+}
+
 // Fusion residuals — mirrors the fuser's matchers EXACTLY (same gates, same shapes), so a
 // survivor means the PHASE_FUSED pass missed, never that the gate was narrower here.
 class public FuseResidualVisitor : AstVisitor {
     checkMad : bool
     checkLerp : bool
     checkDot : bool
+    checkHadd : bool
     noFastMath : bool
     foundMad : bool
     foundLerp : bool
     foundNegAdd : bool
     foundCtor : bool
     foundDot : bool
+    foundHadd : bool
     def override preVisitExprOp2(var expr : ExprOp2?) : void {
         if (checkDot && has_unfused_lane_dot(expr)) {
             foundDot = true
+        }
+        if (checkHadd && has_unfused_hadd(expr)) {
+            foundHadd = true
         }
         if (!checkMad) {
             return
@@ -664,12 +765,13 @@ class public FuseResidualVisitor : AstVisitor {
 }
 
 def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool {
-    //! PHASE_FUSED finishing pass: collapse same-vector lane sums into `dot(v, mask)`, re-pack
-    //! ctor lane patterns (re-vectorize / shared factor), `a*b ± c` into `mad(a,b,c)`, and the
-    //! expanded lerp shape back into `lerp(a, b, t)`. Caller re-infers after each round.
+    //! PHASE_FUSED finishing pass: collapse same-vector lane sums into `dot(v, mask)` and
+    //! independent >=4-term scalar sums into `hadd(float4(...))`, re-pack ctor lane patterns
+    //! (re-vectorize / shared factor), `a*b ± c` into `mad(a,b,c)`, and the expanded lerp shape
+    //! back into `lerp(a, b, t)`. Caller re-infers after each round.
     if (!(func.body is ExprBlock)) return false
     var changed = false
-    // hadd → dot first — the mad walk would otherwise steal a weighted lane (`v.x * w + rest`)
+    // lane-dot fold first — the mad walk would otherwise steal a weighted lane (`v.x * w + rest`)
     if (!no_fast_math && fuse_callable(func._module, "dot", 2)) {
         var blk = func.body as ExprBlock
         var dchanged = false
@@ -678,6 +780,20 @@ def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool
         }
         if (dchanged) {
             changed = true
+        }
+    }
+    // then horizontal sum: pack >=4 unrelated positive scalars into hadd(float4(...)). Before the
+    // mad walk so a folded `hadd(...) * c + d` still re-fuses into mad on this same round.
+    if (!no_fast_math && fuse_callable(func._module, "hadd", 1)) {
+        var hv = new HaddFuseVisitor()
+        make_visitor(*hv) $(adapter) {
+            visit(func.body, adapter)
+        }
+        if (hv.changed) {
+            changed = true
+        }
+        unsafe {
+            delete hv
         }
     }
     // ctor re-pack next — its `ctor * s` / vector-op output feeds the mad walk this same round

--- a/daslib/flatten_opt_preshade.das
+++ b/daslib/flatten_opt_preshade.das
@@ -797,7 +797,8 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
     // plus an un-packed ctor lane pattern (re-vectorize / shared factor), which needs no callable.
     let cm = fuse_callable(func._module, "mad")
     var fr = new FuseResidualVisitor(checkMad = cm, checkLerp = cm && fuse_callable(func._module, "lerp"),
-        checkDot = !no_fast_math && fuse_callable(func._module, "dot", 2), noFastMath = no_fast_math)
+        checkDot = !no_fast_math && fuse_callable(func._module, "dot", 2),
+        checkHadd = !no_fast_math && fuse_callable(func._module, "hadd", 1), noFastMath = no_fast_math)
     make_visitor(*fr) $(a) {
         visit(func.body, a)
     }
@@ -815,6 +816,9 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
     }
     if (fr.foundDot) {
         res |> push("an un-fused lane sum ('v.x + v.y + …' should be dot(v, mask))")
+    }
+    if (fr.foundHadd) {
+        res |> push("an un-fused scalar sum ('a + b + c + d' should be hadd(float4(...)))")
     }
     unsafe {
         delete fr

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -274,6 +274,27 @@ normalize ``an.x + an.y + an.z`` drops 4 instructions). The fold reorders the
 float adds and multiplies skipped lanes by 0, so it is **fast-math gated**, and
 it runs only when a 2-argument ``dot`` is visible from the twin's module.
 
+**Independent horizontal sums become hadds.** The dot re-pack reaches a sum only
+when its terms are lane reads of *one* vector; a sum of **unrelated** scalars —
+four separate accumulators with no shared base — has no vector to ride. The fuse
+pass collapses ≥4 **positive** such terms of any maximal ``+``/``-`` chain into
+``hadd(float4(…))``: one *combine* node gathers the lanes, one *hadd* node reduces
+them, replacing the ≥3 add nodes the serial chain spent (``hadd`` takes one
+``floatN`` argument, so a width-4 group is ``hadd(float4(a, b, c, d))``; a
+subtracted term is not packed — ``a + b + c + d - e → hadd(float4(a, b, c, d)) - e``). Only full groups of four
+are emitted — four adds for one combine + one hadd is a strict one-node drop,
+while a width-2 or width-3 group only breaks even against its combine, so a
+remainder of one to three terms stays a scalar add. Two exclusions keep it from
+fighting the neighbouring fusions: a ``*``-weighted term is left for the mad walk
+(``mad(a, b, acc)`` folds the multiply *and* the add into one node per term, which
+beats a combine + hadd on a weighted sum such as an fBm octave chain
+``n0*w0 + n1*w1 + …``), and an already-emitted ``hadd`` is never re-packed as a
+lane, so a chain longer than four packs into *parallel* hadds
+(``hadd(float4(a, b, c, d)) + hadd(float4(e, f, g, h))``) rather than nesting one
+inside the next — same node count, lower dependency depth. The fold reorders the adds, so it is **fast-math
+gated**, and it runs only when a 1-argument ``hadd`` is visible from the twin's
+module.
+
 **Division becomes a reciprocal multiply.** A divide is the most expensive
 arithmetic node a shader carries, and most divisors never change per pixel. The
 fold rewrites ``x / C`` (const ``C``, float family) into ``x * (1/C)`` with the
@@ -322,8 +343,8 @@ flatten's default contract is a shader compiler's: fast math. Every
 value-changing rewrite — the float ``x*0 → 0`` / ``x - x → 0`` folds (inf/NaN
 propagation), float reassociation (association order), regroup-to-share (same),
 the ``lerp`` const-selector short-circuits (they drop an argument),
-division→reciprocal, the float zero-lane kill, the horizontal-add→dot re-pack,
-and majority-factor compensation — assumes finite
+division→reciprocal, the float zero-lane kill, the horizontal-add→dot and
+horizontal-sum→hadd re-packs, and majority-factor compensation — assumes finite
 inputs and tolerates ~1-ulp drift. A module that cannot accept that opts out
 with a user option:
 
@@ -487,10 +508,11 @@ Public API
 
 ``flatten_fuse(var func, no_fast_math = false) : bool``
     The finishing fuse pass: collapse same-vector lane sums into
-    ``dot(v, mask)`` (fast-math), re-pack ctor lane patterns (re-vectorization,
-    shared-factor extraction, majority compensation), ``a*b ± c`` into
-    ``mad(a, b, c)``, and the expanded lerp shape ``mad(b - a, t, a)`` back
-    into ``lerp(a, b, t)``. Run it
+    ``dot(v, mask)`` and independent ≥4-term scalar sums into
+    ``hadd(float4(…))`` (both fast-math), re-pack ctor lane patterns
+    (re-vectorization, shared-factor extraction, majority compensation),
+    ``a*b ± c`` into ``mad(a, b, c)``, and the expanded lerp shape
+    ``mad(b - a, t, a)`` back into ``lerp(a, b, t)``. Run it
     after ``flatten_optimize``'s re-infer (the type gates need settled types) and
     **iterate across re-inference while it reports change**, exactly like the
     fold — each round strictly drops a ``+``/``-`` node, so it converges.

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -189,6 +189,30 @@ def test_flatten_fold(t : T?) {
         t |> success(wn |> find("float3(2f,3f,-4f)") >= 0, "weighted/negated lanes must land in the mask: {wn}")
         delete bodies
     }
+    t |> run("hadd corpus fuses clean (test_flatten_hadd.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_hadd.das")
+        t |> success(n >= 9, "expected >=9 twins, checked {n}")
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_hadd.das")
+        // FIRED proof: four independent scalars with no shared base collapse to hadd(float4(...))
+        let h4 = bodies?["h_four_flat"] ?? ""
+        t |> success(!empty(h4), "h_four_flat twin must be produced")
+        t |> success(h4 |> find("hadd(") >= 0, "a+b+c+d must fuse to hadd: {h4}")
+        // 8-way packs into TWO PARALLEL hadds, not a nested one — an existing hadd is never a lane,
+        // so `hadd(float4(...` never contains an inner `hadd(` (guards the bottom-up nesting trap)
+        let h8 = bodies?["h_eight_flat"] ?? ""
+        t |> success(!empty(h8), "h_eight_flat twin must be produced")
+        t |> equal(count_sub(h8, "hadd("), 2, "8-way must pack into two hadds: {h8}")
+        t |> success(h8 |> find("float4(hadd(") < 0, "the two hadds must be parallel, not nested: {h8}")
+        // below the four-lane threshold: a 3-term sum stays a scalar add chain (no combine+hadd cost)
+        let h3 = bodies?["h_three_flat"] ?? ""
+        t |> success(!empty(h3), "h_three_flat twin must be produced")
+        t |> success(h3 |> find("hadd(") < 0, "a+b+c must NOT fuse (below four-lane threshold): {h3}")
+        // the mandelbrot guard: `*`-weighted terms are mad-fusable, so mad must win — no hadd
+        let hp = bodies?["h_products_flat"] ?? ""
+        t |> success(!empty(hp), "h_products_flat twin must be produced")
+        t |> success(hp |> find("hadd(") < 0, "weighted products must stay for mad, not hadd: {hp}")
+        delete bodies
+    }
     t |> run("swizzle corpus folds clean (test_flatten_swizzle.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_swizzle.das")
         t |> success(n >= 14, "expected >=14 twins, checked {n}")

--- a/tests/flatten/test_flatten_hadd.das
+++ b/tests/flatten/test_flatten_hadd.das
@@ -1,0 +1,106 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! Differential net for the PHASE_FUSED horizontal-sum re-pack: a sum of >=4 independent scalars
+//! (no shared vector base, so the dot fold above can't reach them) collapses into `hadd(float4(...))`
+//! — one combine + one hadd where the chain had >=3 adds. Only full groups of four pack (a strict
+//! node win); a remainder of 1-3 and any `*`-weighted term (mad fuses those better) stay scalar. The
+//! hadd reorders the adds, so floats compare approx (same contract as the dot/mad corpus). The
+//! structural FIRED half (a `hadd(` call in the twin, and its absence on the guarded shapes) lives
+//! in no_aot/test_flatten_fold.das.
+
+// ----- pure 4-way sum -> hadd(float4(...)) -----
+[flatten]
+def h_four(a, b, c, d : float) : float {
+    return a + b + c + d
+}
+
+// ----- 5 terms: one group of four, the fifth rides as a scalar add -----
+[flatten]
+def h_five(a, b, c, d, e : float) : float {
+    return a + b + c + d + e
+}
+
+// ----- 8 terms: two groups of four -----
+[flatten]
+def h_eight(a, b, c, d, e, f, g, h : float) : float {
+    return a + b + c + d + e + f + g + h
+}
+
+// ----- 3 terms: below the four-lane threshold, stays a scalar add chain -----
+[flatten]
+def h_three(a, b, c : float) : float {
+    return a + b + c
+}
+
+// ----- negated tail: four positives pack, the `- e` stays -----
+[flatten]
+def h_neg(a, b, c, d, e : float) : float {
+    return a + b + c + d - e
+}
+
+// ----- const term stays out of the ctor (it folds), four vars pack -----
+[flatten]
+def h_const(a, b, c, d : float) : float {
+    return a + b + c + d + 0.5
+}
+
+// ----- horizontal sum buried inside a call argument -----
+[flatten]
+def h_buried(a, b, c, d : float) : float {
+    return sin(a + b + c + d)
+}
+
+// ----- the plasma shape: `(sum) * s + k` -> mad(hadd(...), s, k) -----
+[flatten]
+def h_mad(a, b, c, d : float) : float {
+    return (a + b + c + d) * 2.0 + 1.0
+}
+
+// ----- weighted products must NOT pack: `n*w` is mad-fusable, mad beats hadd (mandelbrot fBm) -----
+[flatten]
+def h_products(a, b, c, d : float) : float {
+    return a * 2.0 + b * 3.0 + c * 4.0 + d * 5.0
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "hadd-fused approx mismatch: {a} vs {b}")
+}
+
+[test]
+def test_flatten_hadd(t : T?) {
+    t |> run("four / five / eight scalar sums — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, h_four_flat(v, 1.5, -v, 2.5), h_four(v, 1.5, -v, 2.5))
+            fapprox(t, h_five_flat(v, 1.5, -v, 2.5, 0.125), h_five(v, 1.5, -v, 2.5, 0.125))
+            fapprox(t, h_eight_flat(v, 1.5, -v, 2.5, 0.125, -0.5, v * 0.25, 3.0),
+                       h_eight(v, 1.5, -v, 2.5, 0.125, -0.5, v * 0.25, 3.0))
+        }
+    }
+    t |> run("below-threshold / negated / const tail — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, h_three_flat(v, 1.5, -v), h_three(v, 1.5, -v))
+            fapprox(t, h_neg_flat(v, 1.5, -v, 2.5, 0.75), h_neg(v, 1.5, -v, 2.5, 0.75))
+            fapprox(t, h_const_flat(v, 1.5, -v, 2.5), h_const(v, 1.5, -v, 2.5))
+        }
+    }
+    t |> run("buried sum / mad shape / weighted products — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, h_buried_flat(v, 1.5, -v, 2.5), h_buried(v, 1.5, -v, 2.5))
+            fapprox(t, h_mad_flat(v, 1.5, -v, 2.5), h_mad(v, 1.5, -v, 2.5))
+            fapprox(t, h_products_flat(v, 1.5, -v, 2.5), h_products(v, 1.5, -v, 2.5))
+        }
+    }
+}


### PR DESCRIPTION
## What

The PHASE_FUSED dot fold collapses lane reads of one vector (`v.x + v.y + …`) into `dot(v, mask)`. This adds the complementary **`HaddFuseVisitor`**: a sum of **≥4 independent scalars with no shared base** (e.g. plasma's `v1 + v2 + v3 + v4`) collapses into `hadd(float4(...))` — one combine + one hadd where the chain had ≥3 adds.

This completes reduction recognition in the flatten layer: min/max already re-roll via `pack_map_reduce` (#3258), and now plain sum chains emit the `hadd` primitive shipped in #3261.

```
// plasma, before:  let v = ((((v1 + v2) + v3) + v4) * 0.125) + 0.5
// plasma, after:   let v = mad(hadd(float4(v1,v2,v3,v4)), 0.125, 0.5)
```

## Design

- **Width-4-only.** A full group of four is a strict −1 node (4 adds → one combine + one hadd); widths 2–3 are node-neutral/negative on this backend, so a remainder of 1–3 stays as scalar adds.
- **`*`-weighted terms are excluded.** They are mad-fusable, and `mad(a, b, acc)` (one node per term) beats hadd's combine+hadd on a weighted sum — e.g. an fBm octave chain `n0*w0 + n1*w1 + …`. This was caught as a real **+6 regression on `mandelbrot`** in the corpus sweep before the exclusion was added.
- **Already-emitted `hadd` excluded.** So a chain longer than four packs into *parallel* hadds (`hadd(a..d) + hadd(e..h)`) rather than nesting one inside the next — same node count, lower dependency depth (from Copilot review round 1).
- **Ordering.** Runs right after the dot fold, before the mad walk, so a folded `hadd(...) * c + d` still re-fuses into `mad`.
- **Gating.** `!no_fast_math` (it reassociates the sum) + `hadd` callable in the module — same contract as the dot fold. Backends without `hadd` are unaffected.

## Verification

- **Corpus:** `plasma` 57→56, **zero regressions / zero errors across all 86 example shaders**.
- **Tests:** new `tests/flatten/test_flatten_hadd.das` — differential value twins (4/5/8-way sums, below-threshold, negated tail, const tail, buried-in-call, plasma mad-shape, mad-fusable-products guard). Structural FIRED proof in `no_aot/test_flatten_fold.das` (`h_four` packs; `h_three`/`h_products` do not; `h_eight` packs into two parallel hadds, not nested).
- **AOT:** auto-globbed via `tests/flatten/*.das`; codegen emits `hadd4(float4(...))` (shipped in #3261), no nesting.

Daslib + tests + the flatten reference doc (the horizontal-sum→hadd section, the `flatten_fuse` API entry, and the fast-math opt-out list). No backend change — the `hadd` stub/whitelist already shipped in #3261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)