### PR TITLE
feat(flatten): hadd remainder widths, width-2 pack option, producer-vectorization

### DIFF
--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -750,6 +750,15 @@ def public flatten_expand_lerp : bool {
 }
 
 [macro_function]
+def public flatten_hadd_pack_pairs : bool {
+    //! True when the COMPILING module sets `options _flatten_hadd_pack_pairs = true` — pack width-2
+    //! horizontal sums (`a + b`) into `hadd2` too. The default packs width >=3 only: a width-2 pack is
+    //! +1 node on a node-graph backend (a `combine2` with no offsetting add saved), but a win in cycles
+    //! on a SIMD CPU backend. COMPILE-TIME ONLY: patch code reads it once, runtime tools pass their flag.
+    return compiling_program()._options |> find_arg("_flatten_hadd_pack_pairs") ?as tBool ?? false
+}
+
+[macro_function]
 def public flatten_fold(var func : FunctionPtr; no_fast_math : bool = false; expand_lerp : bool = false) : bool {
     //! Post-infer fold pass (delegates to `fold_body`): collapse `const ? a : b`, fold identities,
     //! drop pure self-assigns. Run AFTER re-inference; returns true if anything changed. Compile-time
@@ -782,11 +791,12 @@ def public flatten_pack(var func : FunctionPtr; no_fast_math : bool = false) : b
 }
 
 [macro_function]
-def public flatten_fuse(var func : FunctionPtr; no_fast_math : bool = false) : bool {
+def public flatten_fuse(var func : FunctionPtr; no_fast_math : bool = false; hadd_min_width : int = 3) : bool {
     //! PHASE_FUSED finishing pass (delegates to `fuse_body`): collapse same-vector lane sums into
-    //! `dot(v, mask)`, re-pack ctor lane patterns, `a*b ± c` into mad, and the expanded lerp shape
-    //! back into lerp. Call on the optimized, re-inferred body; repeat until it returns false.
-    return fuse_body(func, no_fast_math)
+    //! `dot(v, mask)`, independent scalar sums into `hadd` (groups of width [hadd_min_width..4]),
+    //! re-pack ctor lane patterns, `a*b ± c` into mad, and the expanded lerp shape back into lerp.
+    //! Call on the optimized, re-inferred body; repeat until it returns false.
+    return fuse_body(func, no_fast_math, hadd_min_width)
 }
 
 def public flatten_opt_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {
@@ -980,7 +990,7 @@ class FlattenAnnotation : AstFunctionAnnotation {
             // `lerp`, re-inferring to resolve the new calls; iterates (each round strictly
             // drops a `+`/`-`, so it converges), a clean round falls through to the shape check.
             set_flatten_phase(func, PHASE_FUSED)
-            if (flatten_fuse(twin, flatten_no_fast_math())) {
+            if (flatten_fuse(twin, flatten_no_fast_math(), flatten_hadd_pack_pairs() ? 2 : 3)) {
                 astChanged = true
                 return true
             }

--- a/daslib/flatten_opt_common.das
+++ b/daslib/flatten_opt_common.das
@@ -862,3 +862,26 @@ def public lane_index(comp : string) : int {
     if (comp == "z") return 2
     return 3
 }
+
+// Partition M lanes into groups of width [minWidth..4]. A tail smaller than minWidth is NOT grouped
+// (the caller leaves those lanes unpacked) — so sum(result) may be < M. A too-small tail is rebalanced
+// by shrinking the previous take when that keeps both groups >= minWidth (so M=5,minWidth=2 -> [3,2],
+// not [4]+1). Shared by the min/max reduction pack (minWidth=2) and the hadd fold (minWidth 2 or 3).
+// minWidth=2: 5 -> [3,2], 6 -> [4,2], 9 -> [4,3,2] (covers all, M>=2). minWidth=3: 5 -> [4] (+1 left),
+// 6 -> [3,3], 9 -> [4,4] (+1 left).
+def public plan_groups(M : int; minWidth : int = 2) : array<int> {
+    assert(minWidth >= 2 && minWidth <= 4, "plan_groups expects minWidth in [2..4]")   // minWidth<=0 would divide by zero below / never terminate
+    var g : array<int>
+    g |> reserve((M + minWidth - 1) / minWidth)
+    var rem = M
+    while (rem >= minWidth) {
+        var take = rem >= 4 ? 4 : rem   // nolint:PERF015 — math.min not required in this module
+        let tail = rem - take
+        if (tail > 0 && tail < minWidth && take - (minWidth - tail) >= minWidth) {
+            take = take - (minWidth - tail)
+        }
+        g |> push(take)
+        rem = rem - take
+    }
+    return <- g
+}

--- a/daslib/flatten_opt_fuse.das
+++ b/daslib/flatten_opt_fuse.das
@@ -617,86 +617,232 @@ class private LerpFuseVisitor : AstVisitor {
     }
 }
 
-// A horizontal-sum lane for the hadd pack: a positive, non-const term that is neither a `*`
-// (mad-fusable — `mad(a, b, acc)` folds the multiply AND the add into one node per term, beating a
-// combine + hadd on a weighted sum like an fBm octave chain) nor an already-emitted `hadd` (re-packing
-// one as a lane would nest hadds; excluding it makes a >4 chain pack into PARALLEL hadds instead). The
-// fuser packs ≥4 of these per chain; the residual oracle counts the same predicate, so it mirrors it.
+// A horizontal-sum lane for the hadd pack: a positive, non-const term that no better fuser already
+// claims. Excluded: a `*` (mad folds the multiply AND the add into one node per term, beating a combine
+// + hadd on a weighted sum like an fBm octave chain) and a call to a fuse-pass output (`mad`/`dot`/
+// `lerp`/`hadd` — already optimally fused, so wrapping it in a hadd is a node loss; and re-claiming a
+// `mad`/`hadd` across re-infer rounds would make the pass non-idempotent — the round-N output becomes
+// a round-N+1 lane). The fuser packs these into groups of width >=3 by default (width-2 is +1 node on
+// a node-graph backend — pure combine overhead — so a bare pair stays scalar; `options
+// _flatten_hadd_pack_pairs = true` lowers the floor to 2 for a SIMD CPU backend). The residual oracle
+// counts the same predicate, so it mirrors it.
 def private is_hadd_term(t : ReTerm) : bool {
-    return !(t.neg || is_all_const(t.e) ||
-             (t.e is ExprOp2 && (t.e as ExprOp2).op == "*") ||
-             (t.e is ExprCall && simple_name("{(t.e as ExprCall).name}") == "hadd"))
+    if (t.neg || is_all_const(t.e) || (t.e is ExprOp2 && (t.e as ExprOp2).op == "*")) return false
+    if (t.e is ExprCall) {
+        let nm = simple_name("{(t.e as ExprCall).name}")
+        if (nm == "hadd" || nm == "mad" || nm == "dot" || nm == "lerp") return false
+    }
+    return true
 }
 
-// Pack a horizontal sum of >=4 independent scalars into `hadd(float4(...))`. The dot fold above only
-// reaches lanes of ONE vector (`v.x + v.y + …`); unrelated scalars (plasma's `v1 + v2 + v3 + v4`)
-// have no shared base, so a combine + hadd is the collapse. ONLY full groups of four are emitted:
-// 4 adds -> one combine + one hadd is a strict -1 node, while widths 2-3 are node-neutral/negative
-// on this backend, so a remainder of 1-3 stays as scalar adds. Fast-math (reassociates the sum),
-// so it rides the same no_fast_math gate as the dot fold.
-class private HaddFuseVisitor : AstVisitor {
-    changed : bool
-    def override visitExprOp2(var that : ExprOp2?) : ExpressionPtr {
-        if (!(that.op == "+" || that.op == "-") || expr_bt(that) != Type.tFloat) return that
-        var terms : array<ReTerm>
-        collect_add(that, false, terms)
-        // gather the hadd lanes (see is_hadd_term); excluding an already-emitted hadd makes this
-        // bottom-up visitor pack a >4 chain into PARALLEL hadds rather than nesting one in the next,
-        // matching a top-down maximal-chain walk — same node count, lower dependency depth
-        var cand <- [for (i in range(length(terms))); i; where is_hadd_term(terms[i])]
-        let ng = length(cand) / 4   // nolint:PERF015 — full groups of four only; remainder stays scalar
-        if (ng == 0) {
-            delete cand
+// ===== producer-vectorization for hadd groups =====
+// When every lane of a hadd group is `g(scalar)` for the same componentwise unary `g`, pull `g` out
+// over the packed args: `sin(a)+sin(b)+sin(c)` -> `hadd(sin(float3(a,b,c)))` (exact, since g is per-lane).
+// That collapses N g-nodes to ONE width-free `g(floatN)` — turning the otherwise node-neutral width-3
+// hadd into a win (−2 nodes), and a bigger win at width-4.
+
+// Componentwise unary float->float builtins (their floatN overload is per-lane). NOT length/normalize/
+// dot/cross (vector->scalar or cross-lane) — vectorizing those would change the value.
+let private ELEMENTWISE_UNARY : table<string> <- {
+    "sin", "cos", "sqrt", "exp", "log", "abs", "frac", "floor", "ceil",
+    "sign", "saturate", "radians", "degrees", "one_minus"
+}
+
+// If every lane is `g(scalarFloat)` for the SAME whitelisted elementwise-unary g, return g; else "".
+// A module-qualified call (`math::sin`) is skipped: the rewrite re-emits the unqualified simple name,
+// which could resolve to a different overload — or be ambiguous — in a module that relies on the
+// qualifier, so it would not be semantics-preserving (leaf-pack instead, never breaking compiling code).
+def private shared_elementwise_unary(lanes : array<ExpressionPtr>) : string {
+    var g = ""
+    for (e in lanes) {
+        if (!(e is ExprCall)) return ""
+        let c = e as ExprCall
+        if (length(c.arguments) != 1 || expr_bt(c.arguments[0]) != Type.tFloat) return ""
+        let fullname = "{c.name}"
+        if (find(fullname, 58, 0) >= 0) return ""   // 58 = ':' — a module qualifier (math::sin); see above
+        let nm = simple_name(fullname)
+        if (!key_exists(ELEMENTWISE_UNARY, nm)) return ""
+        if (g == "") {
+            g = nm
+        } elif (g != nm) {
+            return ""
+        }
+    }
+    return g
+}
+
+def private mod_has_unary_vec(mod : Module?; fname : string; want : Type) : bool {
+    var found = false
+    for_each_function(mod, fname) $(fn) {
+        if (length(fn.arguments) == 1 && fn.arguments[0]._type != null && fn.arguments[0]._type.baseType == want) {
+            found = true
+        }
+    }
+    return found
+}
+
+// True if `fname` has a single-arg overload taking exactly `want` (a floatN) in `mod` or its deps —
+// the gate that keeps producer-vectorization from emitting an unresolvable `g(floatN)` on a backend
+// whose `g` is scalar-only (it falls back to leaf-packing rather than breaking a shader that compiled).
+def private has_unary_vec_overload(mod : Module?; fname : string; want : Type) : bool {
+    if (mod == null) return false
+    if (mod_has_unary_vec(mod, fname, want)) return true
+    var found = false
+    module_for_each_dependency(mod) $(dep, _isPub) {
+        if (!found && mod_has_unary_vec(dep, fname, want)) {
+            found = true
+        }
+    }
+    return found
+}
+
+def private float_vec_type(dim : int) : Type {
+    return dim == 2 ? Type.tFloat2 : (dim == 3 ? Type.tFloat3 : Type.tFloat4)
+}
+
+// Build a hadd group's argument: the producer-vectorized `g(floatN(args))` when all `lanes` share an
+// elementwise-unary `g` with a floatN overload, else the plain `floatN(lanes)` leaf pack.
+def private make_hadd_arg(var lanes : array<ExpressionPtr>; w : int; at : LineInfo; mod : Module?) : ExpressionPtr {
+    let g = shared_elementwise_unary(lanes)
+    if (g == "" || !has_unary_vec_overload(mod, g, float_vec_type(w))) {
+        return make_float_ctor(w, at, lanes)
+    }
+    var args : array<ExpressionPtr>
+    args |> reserve(w)
+    for (ln in lanes) {
+        args |> push(clone_expression((ln as ExprCall).arguments[0]))   // clone: the g-call wrapper drops
+    }
+    var argCtor = make_float_ctor(w, at, args)
+    var gcall = new ExprCall(at = at, name := g)
+    emplace(gcall.arguments, argCtor)
+    unsafe {
+        delete args
+    }
+    return gcall
+}
+
+// Pack the independent-scalar lanes of a maximal `+`/`-` chain into `hadd(floatW(...))` groups via
+// plan_groups(minWidth..4); null when no group reaches minWidth (see is_hadd_term). The dot fold above
+// only reaches lanes of ONE vector (`v.x + v.y + …`); unrelated scalars (plasma's `v1 + v2 + v3 + v4`)
+// have no shared base, so a combine + hadd is the collapse. The first sum(groups) lanes (source order)
+// form the groups — each group's first term emits the hadd, the rest drop; any sub-minWidth tail of
+// lanes stays scalar. Operand nodes are reused. A wide sum becomes PARALLEL hadds (9 lanes -> [4,4] +
+// a scalar tail by default, [4,3,2] = hadd4+hadd3+hadd2 under the pack-pairs option).
+def private hadd_fold_chain(var that : ExpressionPtr; var terms : array<ReTerm>; minWidth : int; mod : Module?) : ExpressionPtr {
+    var cand <- [for (i in range(length(terms))); i; where is_hadd_term(terms[i])]
+    var groups <- plan_groups(length(cand), minWidth)
+    var covered = 0
+    for (w in groups) {
+        covered += w
+    }
+    if (covered == 0) {     // no group reached minWidth — the lanes (if any) stay scalar
+        delete cand
+        delete groups
+        return null
+    }
+    // head term idx -> its group index in `groups`; groupOff[gi] = that group's first candidate slot
+    var headGroup : table<int; int>
+    var groupOff : array<int>
+    groupOff |> reserve(length(groups))
+    var dropped : table<int>
+    var off = 0
+    for (gi in range(length(groups))) {
+        let w = groups[gi]
+        headGroup |> insert(cand[off], gi)
+        groupOff |> push(off)
+        for (li in range(1, w)) {
+            dropped |> insert(cand[off + li])
+        }
+        off += w
+    }
+    var newTerms : array<ReTerm>
+    for (i in range(length(terms))) {
+        if (key_exists(dropped, i)) continue
+        if (key_exists(headGroup, i)) {
+            let gi = headGroup[i]
+            let w = groups[gi]
+            let o = groupOff[gi]
+            var lanes : array<ExpressionPtr>
+            lanes |> reserve(w)
+            for (li in range(w)) {
+                lanes |> push(terms[cand[o + li]].e)   // reuse the leaf node (each used once)
+            }
+            var ctor = make_hadd_arg(lanes, w, that.at, mod)   // producer-vectorizes a shared unary
+            var cll = new ExprCall(at = that.at, name := "hadd")
+            emplace(cll.arguments, ctor)
+            newTerms |> push(ReTerm(neg = false, e = cll))
+            unsafe {
+                delete lanes
+            }
+        } else {
+            newTerms |> push(terms[i])
+        }
+    }
+    var r = build_chain(newTerms, that.at, "+", "-")
+    delete cand
+    delete groups
+    delete headGroup
+    delete groupOff
+    delete dropped
+    unsafe {
+        delete newTerms
+    }
+    return r
+}
+
+// Top-down rewrite mirroring dot_fold_expr: pack each maximal `+`/`-` chain once. A bottom-up visitor
+// would pack an inner sub-chain into a narrow hadd and strand the outer lanes into a second one (e.g.
+// `((a+b)+c)+d` -> hadd2(a,b) + hadd2(c,d) instead of one hadd4), so the walk is top-down — recurse
+// into chain leaves and every other child slot, then fold the maximal chain at this node.
+def private hadd_fold_expr(var e : ExpressionPtr; var changed : bool&; minWidth : int; mod : Module?) : ExpressionPtr {
+    if (e == null) return null
+    if (e is ExprOp2) {
+        var o = e as ExprOp2
+        if ((o.op == "+" || o.op == "-") && expr_bt(o) == Type.tFloat) {
+            var terms : array<ReTerm>
+            collect_add(e, false, terms)
+            for (t in terms) {
+                // a chain leaf is never itself a chain, so it mutates in place and returns `t.e`
+                hadd_fold_expr(t.e, changed, minWidth, mod)
+            }
+            var r = hadd_fold_chain(e, terms, minWidth, mod)
             unsafe {
                 delete terms
             }
-            return that
+            if (r != null) {
+                changed = true
+                return r
+            }
+            return e
         }
-        // group head term i -> hadd(float4(...)) over its 4 lanes; the other 3 lanes drop
-        var headBase : table<int; int>
-        var dropped : table<int>
-        for (gi in range(ng)) {
-            headBase |> insert(cand[gi * 4], gi * 4)
-            for (li in range(1, 4)) {
-                dropped |> insert(cand[gi * 4 + li])
+    }
+    rewrite_children(e) $(var c : ExpressionPtr) { return hadd_fold_expr(c, changed, minWidth, mod) }
+    return e
+}
+
+def private hadd_fold_stmt(var s : ExpressionPtr; var changed : bool&; minWidth : int; mod : Module?) {
+    if (s is ExprLet) {
+        var lc = s as ExprLet
+        for (lv in lc.variables) {
+            if (lv.init != null) {
+                lv.init = hadd_fold_expr(lv.init, changed, minWidth, mod)
             }
         }
-        var newTerms : array<ReTerm>
-        for (i in range(length(terms))) {
-            if (key_exists(dropped, i)) continue
-            if (key_exists(headBase, i)) {
-                let base = headBase[i]
-                var lanes : array<ExpressionPtr>
-                lanes |> reserve(4)
-                for (li in range(4)) {
-                    lanes |> push(terms[cand[base + li]].e)   // reuse the leaf node (each used once)
-                }
-                var ctor = make_float_ctor(4, that.at, lanes)
-                var cll = new ExprCall(at = that.at, name := "hadd")
-                emplace(cll.arguments, ctor)
-                newTerms |> push(ReTerm(neg = false, e = cll))
-                unsafe {
-                    delete lanes
-                }
-            } else {
-                newTerms |> push(terms[i])
-            }
+    } elif (s is ExprCopy) {
+        var cp = s as ExprCopy
+        cp.right = hadd_fold_expr(cp.right, changed, minWidth, mod)
+    } elif (s is ExprReturn) {
+        var rt = s as ExprReturn
+        if (rt.subexpr != null) {
+            rt.subexpr = hadd_fold_expr(rt.subexpr, changed, minWidth, mod)
         }
-        var r = build_chain(newTerms, that.at, "+", "-")
-        changed = true
-        delete cand
-        delete headBase
-        delete dropped
-        unsafe {
-            delete terms
-            delete newTerms
-        }
-        return r
     }
 }
 
-// A maximal `+`/`-` chain still carrying ≥4 hadd lanes the fuser should have packed — the residual
-// twin of HaddFuseVisitor, sharing is_hadd_term so the oracle's gate is the fuser's gate exactly.
+// A maximal `+`/`-` chain still carrying ≥3 hadd lanes the fuser should have packed — the residual
+// twin of the hadd fold, sharing is_hadd_term. The >=3 gate is mode-agnostic on purpose: the fuser
+// packs width>=3 in BOTH modes (the pack-pairs option only LOWERS the floor to 2), so a >=3-lane
+// survivor is a real miss under either, while a 2-lane chain left scalar by the default is not flagged.
 def private has_unfused_hadd(var that : ExprOp2?) : bool {
     if (that == null || !(that.op == "+" || that.op == "-") || expr_bt(that) != Type.tFloat) return false
     var terms : array<ReTerm>
@@ -710,7 +856,7 @@ def private has_unfused_hadd(var that : ExprOp2?) : bool {
     unsafe {
         delete terms
     }
-    return n >= 4
+    return n >= 3
 }
 
 // Fusion residuals — mirrors the fuser's matchers EXACTLY (same gates, same shapes), so a
@@ -764,11 +910,12 @@ class public FuseResidualVisitor : AstVisitor {
     }
 }
 
-def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool {
-    //! PHASE_FUSED finishing pass: collapse same-vector lane sums into `dot(v, mask)` and
-    //! independent >=4-term scalar sums into `hadd(float4(...))`, re-pack ctor lane patterns
-    //! (re-vectorize / shared factor), `a*b ± c` into `mad(a,b,c)`, and the expanded lerp shape
-    //! back into `lerp(a, b, t)`. Caller re-infers after each round.
+def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false; hadd_min_width : int = 3) : bool {
+    //! PHASE_FUSED finishing pass: collapse same-vector lane sums into `dot(v, mask)` and independent
+    //! scalar sums into `hadd(floatN(...))` (groups of width [hadd_min_width..4] via plan_groups — the
+    //! default 3 keeps a bare pair scalar, 2 packs pairs too), re-pack ctor lane patterns (re-vectorize
+    //! / shared factor), `a*b ± c` into `mad(a,b,c)`, and the expanded lerp shape back into `lerp(a, b,
+    //! t)`. Caller re-infers after each round.
     if (!(func.body is ExprBlock)) return false
     var changed = false
     // lane-dot fold first — the mad walk would otherwise steal a weighted lane (`v.x * w + rest`)
@@ -782,21 +929,9 @@ def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool
             changed = true
         }
     }
-    // then horizontal sum: pack >=4 unrelated positive scalars into hadd(float4(...)). Before the
-    // mad walk so a folded `hadd(...) * c + d` still re-fuses into mad on this same round.
-    if (!no_fast_math && fuse_callable(func._module, "hadd", 1)) {
-        var hv = new HaddFuseVisitor()
-        make_visitor(*hv) $(adapter) {
-            visit(func.body, adapter)
-        }
-        if (hv.changed) {
-            changed = true
-        }
-        unsafe {
-            delete hv
-        }
-    }
-    // ctor re-pack next — its `ctor * s` / vector-op output feeds the mad walk this same round
+    // ctor re-pack next — it claims same-op ctor lanes (`floatN(x+a, x+b, …)` → `splat(x) + floatN(a,b,…)`)
+    // BEFORE the hadd fold, so a hadd at width 2 can't pre-empt that vectorization by turning a lane into
+    // a `hadd(...)` call; its `ctor * s` / vector-op output also feeds the mad walk this same round.
     var cv = new CtorFuseVisitor()
     cv.noFastMath = no_fast_math
     make_visitor(*cv) $(adapter) {
@@ -807,6 +942,19 @@ def public fuse_body(var func : FunctionPtr; no_fast_math : bool = false) : bool
     }
     unsafe {
         delete cv
+    }
+    // then horizontal sum: pack unrelated positive scalars into hadd(floatN(...)) groups (width
+    // [hadd_min_width..4]) via plan_groups. A top-down stmt walk (like the dot fold) so each maximal
+    // chain packs once. Before the mad walk so a folded `hadd(...) * c + d` still re-fuses into mad.
+    if (!no_fast_math && fuse_callable(func._module, "hadd", 1)) {
+        var blk = func.body as ExprBlock
+        var hchanged = false
+        for (s in blk.list) {
+            hadd_fold_stmt(s, hchanged, hadd_min_width, func._module)
+        }
+        if (hchanged) {
+            changed = true
+        }
     }
     if (!fuse_callable(func._module, "mad")) return changed
     var v = new MadFuseVisitor()

--- a/daslib/flatten_opt_pack.das
+++ b/daslib/flatten_opt_pack.das
@@ -248,22 +248,6 @@ def private vectorize(exprs : array<ExpressionPtr>; nameToRole : table<string; i
     return null
 }
 
-// Partition M lanes into width<=4 groups, never leaving a width-1 remainder (so every group packs).
-def private plan_groups(M : int) : array<int> {
-    var g : array<int>
-    g |> reserve((M + 3) / 4)
-    var rem = M
-    while (rem > 0) {
-        var take = rem >= 4 ? 4 : rem   // nolint:PERF015 — math.min not required in this module
-        if (rem - take == 1) {
-            take = take - 1
-        }
-        g |> push(take)
-        rem = rem - take
-    }
-    return <- g
-}
-
 def private make_vec_let(vecName : string; var vecExpr : ExpressionPtr) : ExpressionPtr {
     return qmacro_expr(${ let $i(vecName) = $e(vecExpr); })
 }

--- a/examples/flatten/shaders/features/interference.shader
+++ b/examples/flatten/shaders/features/interference.shader
@@ -1,0 +1,37 @@
+require engine.render.shader_dsl
+
+// Demonstrates the flatten producer-vectorizer: three sine waves at different
+// frequencies/directions are summed INLINE (no temp vars), so the lanes reach the
+// hadd fold as direct `sin(...)` calls. The fold pulls the shared `sin` out over the
+// packed args — `sin(a)+sin(b)+sin(c)` becomes `hadd(sin(float3(a,b,c)))` — collapsing
+// three `sin` nodes into one width-free `sin(float3)` (a width-3 hadd that would
+// otherwise be node-neutral turns into a -2 win).
+
+var {
+    freqA = 12.0
+    freqB = 18.0
+    freqC = 7.0
+    speed = 1.5
+    tint = float3(0.2, 0.5, 0.9)
+}
+
+[pixel_shader]
+def interference(inp : PbrInput) {
+    let t = g_Time * speed
+    let uv = inp.uv
+    // parens keep the multi-line sum a single expression (a bare multi-line `let` whose
+    // continuation lines start with `+` would parse as separate dropped statements)
+    let wave = (sin(uv.x * freqA + t)
+              + sin(uv.y * freqB - t)
+              + sin((uv.x + uv.y) * freqC + t * 0.5))
+    let h = wave * 0.1666667 + 0.5
+    let col = tint * h
+    return PbrOutput(
+        albedo = col,
+        emission = col * 0.3,
+        emissionStrength = 0.4,
+        metalness = 0.0,
+        roughness = 0.8,
+        ao = 1.0
+    )
+}

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -189,28 +189,72 @@ def test_flatten_fold(t : T?) {
         t |> success(wn |> find("float3(2f,3f,-4f)") >= 0, "weighted/negated lanes must land in the mask: {wn}")
         delete bodies
     }
-    t |> run("hadd corpus fuses clean (test_flatten_hadd.das twins)") @(t : T?) {
+    t |> run("hadd corpus fuses clean — DEFAULT width>=3 (test_flatten_hadd.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_hadd.das")
-        t |> success(n >= 9, "expected >=9 twins, checked {n}")
+        t |> success(n >= 15, "expected >=15 twins, checked {n}")
         var bodies <- twin_bodies(t, "{root}/tests/flatten/test_flatten_hadd.das")
-        // FIRED proof: four independent scalars with no shared base collapse to hadd(float4(...))
+        // FIRED proof: width-3/4 sums pack (each width emits its own hadd ctor); a bare pair stays scalar
+        let h3 = bodies?["h_three_flat"] ?? ""
+        t |> success(!empty(h3), "h_three_flat twin must be produced")
+        t |> success(h3 |> find("hadd(float3(") >= 0, "a+b+c must fuse to hadd3: {h3}")
         let h4 = bodies?["h_four_flat"] ?? ""
         t |> success(!empty(h4), "h_four_flat twin must be produced")
-        t |> success(h4 |> find("hadd(") >= 0, "a+b+c+d must fuse to hadd: {h4}")
+        t |> success(h4 |> find("hadd(float4(") >= 0, "a+b+c+d must fuse to hadd4: {h4}")
+        // 2-way is below the default width-3 floor: stays a scalar add, no combine overhead
+        let h2 = bodies?["h_two_flat"] ?? ""
+        t |> success(!empty(h2), "h_two_flat twin must be produced")
+        t |> success(h2 |> find("hadd(") < 0, "a+b must NOT fuse by default (width-2 below the floor): {h2}")
+        // 5-way -> plan_groups(5,3) = [4] + 1 scalar tail: one hadd4, the 5th lane stays a scalar add
+        let h5 = bodies?["h_five_flat"] ?? ""
+        t |> success(!empty(h5), "h_five_flat twin must be produced")
+        t |> success(h5 |> find("hadd(float4(") >= 0, "5-way must pack a hadd4: {h5}")
+        t |> equal(count_sub(h5, "hadd("), 1, "5-way is hadd4 + a scalar tail, not two hadds: {h5}")
+        // 7-way -> [4,3]: hadd4 + hadd3 (the width-3 remainder packs under the default)
+        let h7 = bodies?["h_seven_flat"] ?? ""
+        t |> success(!empty(h7), "h_seven_flat twin must be produced")
+        t |> success(h7 |> find("hadd(float4(") >= 0 && h7 |> find("hadd(float3(") >= 0,
+                     "7-way must split into hadd4 + hadd3: {h7}")
         // 8-way packs into TWO PARALLEL hadds, not a nested one — an existing hadd is never a lane,
         // so `hadd(float4(...` never contains an inner `hadd(` (guards the bottom-up nesting trap)
         let h8 = bodies?["h_eight_flat"] ?? ""
         t |> success(!empty(h8), "h_eight_flat twin must be produced")
         t |> equal(count_sub(h8, "hadd("), 2, "8-way must pack into two hadds: {h8}")
         t |> success(h8 |> find("float4(hadd(") < 0, "the two hadds must be parallel, not nested: {h8}")
-        // below the four-lane threshold: a 3-term sum stays a scalar add chain (no combine+hadd cost)
-        let h3 = bodies?["h_three_flat"] ?? ""
-        t |> success(!empty(h3), "h_three_flat twin must be produced")
-        t |> success(h3 |> find("hadd(") < 0, "a+b+c must NOT fuse (below four-lane threshold): {h3}")
+        // a single hadd lane (the rest `*`-products) never reaches a group — no hadd
+        let h1 = bodies?["h_one_lane_flat"] ?? ""
+        t |> success(!empty(h1), "h_one_lane_flat twin must be produced")
+        t |> success(h1 |> find("hadd(") < 0, "a single lane must NOT fuse: {h1}")
         // the mandelbrot guard: `*`-weighted terms are mad-fusable, so mad must win — no hadd
         let hp = bodies?["h_products_flat"] ?? ""
         t |> success(!empty(hp), "h_products_flat twin must be produced")
         t |> success(hp |> find("hadd(") < 0, "weighted products must stay for mad, not hadd: {hp}")
+        // producer-vectorization: shared elementwise-unary lanes collapse the producer into one call
+        let ht = bodies?["h_trig_flat"] ?? ""
+        t |> success(!empty(ht), "h_trig_flat twin must be produced")
+        t |> success(ht |> find("hadd(sin(float3(") >= 0, "sin(a)+sin(b)+sin(c) must collapse to hadd(sin(float3(...))): {ht}")
+        let ht4 = bodies?["h_trig4_flat"] ?? ""
+        t |> success(!empty(ht4), "h_trig4_flat twin must be produced")
+        t |> success(ht4 |> find("hadd(cos(float4(") >= 0, "four cos lanes must collapse to hadd(cos(float4(...))): {ht4}")
+        // mixed producers (sin/cos/sin) do NOT vectorize — leaf-pack keeps the per-lane calls
+        let hmx = bodies?["h_mixed_flat"] ?? ""
+        t |> success(!empty(hmx), "h_mixed_flat twin must be produced")
+        t |> success(hmx |> find("hadd(float3(") >= 0 && hmx |> find("hadd(sin(") < 0,
+                     "mixed sin/cos/sin must leaf-pack, not vectorize the producer: {hmx}")
+        delete bodies
+    }
+    t |> run("hadd width-2 path — OPTION _flatten_hadd_pack_pairs (test_flatten_hadd_pairs.das twins)") @(t : T?) {
+        let n = check_unit(t, "", "{root}/tests/flatten/no_aot/test_flatten_hadd_pairs.das")
+        t |> success(n >= 2, "expected >=2 twins, checked {n}")
+        var bodies <- twin_bodies(t, "{root}/tests/flatten/no_aot/test_flatten_hadd_pairs.das")
+        // with the floor lowered to 2, a bare pair packs into hadd2 ...
+        let p2 = bodies?["hp_two_flat"] ?? ""
+        t |> success(!empty(p2), "hp_two_flat twin must be produced")
+        t |> success(p2 |> find("hadd(float2(") >= 0, "a+b must fuse to hadd2 under the option: {p2}")
+        // ... and plan_groups(5,2) = [3,2] emits the width-2 remainder alongside the hadd3
+        let p5 = bodies?["hp_five_flat"] ?? ""
+        t |> success(!empty(p5), "hp_five_flat twin must be produced")
+        t |> success(p5 |> find("hadd(float3(") >= 0 && p5 |> find("hadd(float2(") >= 0,
+                     "5-way must split into hadd3 + hadd2 under the option: {p5}")
         delete bodies
     }
     t |> run("swizzle corpus folds clean (test_flatten_swizzle.das twins)") @(t : T?) {

--- a/tests/flatten/no_aot/test_flatten_hadd_pairs.das
+++ b/tests/flatten/no_aot/test_flatten_hadd_pairs.das
@@ -1,0 +1,47 @@
+options gen2
+options indenting = 4
+options _flatten_hadd_pack_pairs = true
+
+require dastest/testing_boost public
+require daslib/flatten
+require math
+
+//! The width-2 hadd path, opt-in via `options _flatten_hadd_pack_pairs = true`: with the floor lowered
+//! to 2, a bare pair packs into `hadd2` and plan_groups emits width-2 remainders (5 -> [3,2]). This is
+//! +1 node on a node-graph backend but a win in cycles on a SIMD CPU backend — hence opt-in, default
+//! width>=3 (see test_flatten_hadd.das). Value approx (the hadd reorders the adds); the structural
+//! FIRED proof (`hadd(float2(` / `hadd(float3(` emission) lives in test_flatten_fold.das.
+
+// ----- 2-way sum -> hadd(float2(...)) (the opt-in pays for the combine here) -----
+[flatten]
+def hp_two(a, b : float) : float {
+    return a + b
+}
+
+// ----- 5 terms: plan_groups(5,2) = [3,2] -> hadd3 + hadd2 (the width-2 remainder emits) -----
+[flatten]
+def hp_five(a, b, c, d, e : float) : float {
+    return a + b + c + d + e
+}
+
+var GRID : array<float>
+
+[init]
+def fill_grid {
+    GRID <- [-100.0, -3.5, -1.0, 0.0, 1.0, 2.5, 7.0, 100.0]
+}
+
+def fapprox(t : T?; a, b : float) {
+    let m = max(max(abs(a), abs(b)), 1.0)
+    t |> success(abs(a - b) <= 1.0e-4 * m, "hadd-pairs approx mismatch: {a} vs {b}")
+}
+
+[test]
+def test_flatten_hadd_pairs(t : T?) {
+    t |> run("width-2 pack + [3,2] split — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, hp_two_flat(v, 1.5), hp_two(v, 1.5))
+            fapprox(t, hp_five_flat(v, 1.5, -v, 2.5, 0.125), hp_five(v, 1.5, -v, 2.5, 0.125))
+        }
+    }
+}

--- a/tests/flatten/test_flatten_hadd.das
+++ b/tests/flatten/test_flatten_hadd.das
@@ -5,13 +5,24 @@ require dastest/testing_boost public
 require daslib/flatten
 require math
 
-//! Differential net for the PHASE_FUSED horizontal-sum re-pack: a sum of >=4 independent scalars
-//! (no shared vector base, so the dot fold above can't reach them) collapses into `hadd(float4(...))`
-//! — one combine + one hadd where the chain had >=3 adds. Only full groups of four pack (a strict
-//! node win); a remainder of 1-3 and any `*`-weighted term (mad fuses those better) stay scalar. The
-//! hadd reorders the adds, so floats compare approx (same contract as the dot/mad corpus). The
-//! structural FIRED half (a `hadd(` call in the twin, and its absence on the guarded shapes) lives
-//! in no_aot/test_flatten_fold.das.
+//! Differential net for the PHASE_FUSED horizontal-sum re-pack (DEFAULT width>=3 policy): a sum of
+//! independent scalars (no shared vector base, so the dot fold above can't reach them) collapses into
+//! `hadd(floatN(...))` groups of width 3..4 via plan_groups; a width-2 tail stays scalar (a bare pair
+//! is +1 node on a node-graph backend). The width-2 path is exercised under the option in
+//! no_aot/test_flatten_hadd_pairs.das. The hadd reorders the adds, so floats compare approx (same
+//! contract as the dot/mad corpus). The structural FIRED half lives in no_aot/test_flatten_fold.das.
+
+// ----- 2-way sum: below the default width-3 floor -> stays a scalar add -----
+[flatten]
+def h_two(a, b : float) : float {
+    return a + b
+}
+
+// ----- 3-way sum -> hadd(float3(...)) -----
+[flatten]
+def h_three(a, b, c : float) : float {
+    return a + b + c
+}
 
 // ----- pure 4-way sum -> hadd(float4(...)) -----
 [flatten]
@@ -19,22 +30,28 @@ def h_four(a, b, c, d : float) : float {
     return a + b + c + d
 }
 
-// ----- 5 terms: one group of four, the fifth rides as a scalar add -----
+// ----- 5 terms: plan_groups(5,3) = [4] -> hadd4, the 5th lane stays a scalar add (sub-width-3 tail) -----
 [flatten]
 def h_five(a, b, c, d, e : float) : float {
     return a + b + c + d + e
 }
 
-// ----- 8 terms: two groups of four -----
+// ----- 7 terms: plan_groups splits [4,3] -> hadd4 + hadd3 -----
+[flatten]
+def h_seven(a, b, c, d, e, f, g : float) : float {
+    return a + b + c + d + e + f + g
+}
+
+// ----- 8 terms: two groups of four -> two PARALLEL hadd4 (never a nested hadd) -----
 [flatten]
 def h_eight(a, b, c, d, e, f, g, h : float) : float {
     return a + b + c + d + e + f + g + h
 }
 
-// ----- 3 terms: below the four-lane threshold, stays a scalar add chain -----
+// ----- one lane only: `a` is the sole hadd term, the rest are `*`-products (mad-fusable) -> no hadd -----
 [flatten]
-def h_three(a, b, c : float) : float {
-    return a + b + c
+def h_one_lane(a, b, c : float) : float {
+    return a + b * 2.0 + c * 3.0
 }
 
 // ----- negated tail: four positives pack, the `- e` stays -----
@@ -67,6 +84,24 @@ def h_products(a, b, c, d : float) : float {
     return a * 2.0 + b * 3.0 + c * 4.0 + d * 5.0
 }
 
+// ----- producer-vectorization: same elementwise-unary lanes collapse the producer -> hadd(sin(float3(...))) -----
+[flatten]
+def h_trig(a, b, c : float) : float {
+    return sin(a) + sin(b) + sin(c)
+}
+
+// ----- producer-vectorization at width 4 -> hadd(cos(float4(...))) -----
+[flatten]
+def h_trig4(a, b, c, d : float) : float {
+    return cos(a) + cos(b) + cos(c) + cos(d)
+}
+
+// ----- mixed producers (sin / cos / sin) do NOT vectorize: leaf-pack hadd(float3(sin,cos,sin)) -----
+[flatten]
+def h_mixed(a, b, c : float) : float {
+    return sin(a) + cos(b) + sin(c)
+}
+
 var GRID : array<float>
 
 [init]
@@ -81,17 +116,25 @@ def fapprox(t : T?; a, b : float) {
 
 [test]
 def test_flatten_hadd(t : T?) {
-    t |> run("four / five / eight scalar sums — value approx") @(t : T?) {
+    t |> run("two / three / four scalar sums — value approx") @(t : T?) {
         for (v in GRID) {
+            fapprox(t, h_two_flat(v, 1.5), h_two(v, 1.5))
+            fapprox(t, h_three_flat(v, 1.5, -v), h_three(v, 1.5, -v))
             fapprox(t, h_four_flat(v, 1.5, -v, 2.5), h_four(v, 1.5, -v, 2.5))
+        }
+    }
+    t |> run("five / seven / eight scalar sums — multi-group + scalar tail, value approx") @(t : T?) {
+        for (v in GRID) {
             fapprox(t, h_five_flat(v, 1.5, -v, 2.5, 0.125), h_five(v, 1.5, -v, 2.5, 0.125))
+            fapprox(t, h_seven_flat(v, 1.5, -v, 2.5, 0.125, -0.5, v * 0.25),
+                       h_seven(v, 1.5, -v, 2.5, 0.125, -0.5, v * 0.25))
             fapprox(t, h_eight_flat(v, 1.5, -v, 2.5, 0.125, -0.5, v * 0.25, 3.0),
                        h_eight(v, 1.5, -v, 2.5, 0.125, -0.5, v * 0.25, 3.0))
         }
     }
-    t |> run("below-threshold / negated / const tail — value approx") @(t : T?) {
+    t |> run("one-lane / negated / const tail — value approx") @(t : T?) {
         for (v in GRID) {
-            fapprox(t, h_three_flat(v, 1.5, -v), h_three(v, 1.5, -v))
+            fapprox(t, h_one_lane_flat(v, 1.5, -v), h_one_lane(v, 1.5, -v))
             fapprox(t, h_neg_flat(v, 1.5, -v, 2.5, 0.75), h_neg(v, 1.5, -v, 2.5, 0.75))
             fapprox(t, h_const_flat(v, 1.5, -v, 2.5), h_const(v, 1.5, -v, 2.5))
         }
@@ -101,6 +144,13 @@ def test_flatten_hadd(t : T?) {
             fapprox(t, h_buried_flat(v, 1.5, -v, 2.5), h_buried(v, 1.5, -v, 2.5))
             fapprox(t, h_mad_flat(v, 1.5, -v, 2.5), h_mad(v, 1.5, -v, 2.5))
             fapprox(t, h_products_flat(v, 1.5, -v, 2.5), h_products(v, 1.5, -v, 2.5))
+        }
+    }
+    t |> run("producer-vectorization: shared / mixed elementwise unary — value approx") @(t : T?) {
+        for (v in GRID) {
+            fapprox(t, h_trig_flat(v, 1.5, -v), h_trig(v, 1.5, -v))
+            fapprox(t, h_trig4_flat(v, 1.5, -v, 2.5), h_trig4(v, 1.5, -v, 2.5))
+            fapprox(t, h_mixed_flat(v, 1.5, -v), h_mixed(v, 1.5, -v))
         }
     }
 }


### PR DESCRIPTION
Follow-up to #3264. Extends the PHASE_FUSED horizontal-sum fold (`daslib/flatten_opt_fuse.das`) so it emits the remainder widths and vectorizes a shared producer, with the node-graph-vs-SIMD tradeoff behind an option.

## What changed

### 1. Remainder widths via `plan_groups`
The hadd fold now packs into groups of width `[3..4]` by default (the `plan_groups` partitioner, lifted from `flatten_opt_pack` into `flatten_opt_common` and generalized with a `minWidth` param), so **`hadd2`/`hadd3` are reachable from a flatten input** instead of dead node-emission in the example backend.

The bottom-up `HaddFuseVisitor` is converted to a **top-down maximal-chain walk** (mirroring the dot fold). A bottom-up visitor strands outer lanes once the pack floor drops below 4 — e.g. `((a+b)+c)+d` would pack `a+b`→hadd2 first and leave `c+d` as a second hadd2 instead of one hadd4.

### 2. `_flatten_hadd_pack_pairs` option (default off ⇒ width ≥ 3)
The backend `hadd` node is width-polymorphic; the only cost of packing is the `combineFloatN` glue. So per lane width:

| width | packed | scalar | Δ |
|---|---|---|---|
| 2 | combine2 + hadd | 1 add | **+1** |
| 3 | combine3 + hadd | 2 adds | **0** |
| 4 | combine4 + hadd | 3 adds | **−1** |

A bare pair is a node loss on a node-graph backend, so it **stays scalar by default** — the corpus is unchanged (`4197`, every shader). The option lowers the floor to 2 for a SIMD CPU backend, where `combine2 + hadd` is cheaper in cycles than two scalar ops.

### 3. Producer-vectorization
When every lane of a hadd group is the same componentwise unary `g(scalar)`, `g` is pulled out over the packed args:

```
sin(a) + sin(b) + sin(c)   →   hadd(sin(float3(a,b,c)))
```

collapsing N `g`-nodes into one width-free `g(floatN)` — turning the otherwise node-neutral width-3 hadd into a **−2 win**. Gated on the `g(floatN)` overload existing (falls back to leaf-packing, so it never breaks a shader that compiled). The whitelist is componentwise unaries only (`sin/cos/sqrt/exp/log/abs/frac/floor/ceil/sign/saturate/radians/degrees/one_minus` — never `length`/`normalize`/`dot`).

Also: `is_hadd_term` now excludes `mad`/`dot`/`lerp` calls (a fuse-pass output is never a lane — keeps the pass idempotent across re-infer rounds).

## Corpus note
There are zero direct producer-vectorization examples in today's 86-shader corpus — the only hadd is plasma's, whose four `sin` lanes are single-use `let`s (var-bound), so the fold can't see them (plasma is one copy-prop inline away from qualifying). Per discussion, shipped with artificial fixtures + a real demo shader `examples/flatten/shaders/features/interference.shader` (three inline sines, −2); it'll light up as more shaders land.

## Verification
- **Interp:** full suite `10472/10478` (0 failed, 0 errors; 6 unrelated env skips), `tests/flatten` `277/277`.
- **AOT:** `tests/flatten` `277/277` under `--isolated-mode` (CI path); producer-vec survives — `hadd3(SimPolicy<float3>::Sin(float3(...)))`, mixed `sin/cos/sin` correctly leaf-packs.
- **Corpus:** 86 existing shaders unchanged (default width ≥ 3); demo `interference.shader` added (−2 from the collapsed sines).
- **Lint** 7 `.das` files, 0 issues. **Format** verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)