### PR TITLE
pages: stage tutorials/_assets into the published playground

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -167,6 +167,19 @@ jobs:
             # .wasm is reachable, so dropping the .wasm here permanently
             # disables the toggle in production.
             cp -r site/playground/samples _site/playground/samples 2>/dev/null || true
+            # Tutorial assets (mesh + PBR textures + HDRI) fetched at runtime by
+            # samples that ship a .das.assets.json manifest (the OpenGL
+            # deferred-shading rung). stage_site_playground staged them under
+            # site/playground/tutorials/_assets; the manifest names them at the
+            # repo-relative path tutorials/_assets/..., so preserve that layout.
+            # Without this the manifest 200s but every asset fetch 404s — so make
+            # a missing dir loud (warn) rather than silently shipping a broken
+            # rung; an actual copy failure fails the step under set -eo pipefail.
+            if [ -d site/playground/tutorials ]; then
+                cp -r site/playground/tutorials _site/playground/tutorials
+            else
+                echo "WARNING: site/playground/tutorials missing — manifest-driven samples (e.g. the OpenGL deferred rung) will 404 their assets."
+            fi
             # Our Forge-skinned playground/index.html + skin CSS + init shim take precedence.
             # CodeMirror bundle (codemirror.min.js/css, simple-mode.js, daslang-*.js,
             # cm-forge.css) is served from /files/cm/ — copied via `cp -r site/files`


### PR DESCRIPTION
## Problem

On the live playground (daslang.io), the OpenGL **deferred-shading** tutorial (`gl_10_deferred`) fails at startup:

```
asset preload failed: HTTP 404 fetching tutorials/_assets/cat/concrete_cat_statue.obj
EXCEPTION in init(): cat OBJ failed to load
 at main.das:433:8
```

That rung fetches its mesh + PBR textures + HDRI at runtime via a per-sample `.das.assets.json` manifest (`main.js` `preloadSampleAssets`). The manifest served `200` and the preloader read its 9 paths, but **every asset fetch 404'd** — so MEMFS stayed empty, `load_obj_mesh(CAT_OBJ)` returned empty, and `init()` panicked.

## Root cause — a deploy gap, not the tutorial/asset/manifest

`.github/workflows/pages.yml` assembles the published `_site/playground/` by copying:

- `web/examples/ui/src/*` → the IDE (incl. `main.js`)
- `site/playground/samples` → which **includes** the `.assets.json` manifest

…but it never copied **`site/playground/tutorials/_assets`** — the actual asset bytes. `stage_site_playground` (run in the `ninja` line) stages those onto the runner, but the deploy step dropped the `tutorials/` subtree on the floor. Hence: manifest `200`, asset bytes `404`.

## Fix

One copy step, after the samples copy, mirroring the existing pattern:

```bash
cp -r site/playground/tutorials _site/playground/tutorials 2>/dev/null || true
```

## Verification

- All **9** manifest assets are present under `site/playground/tutorials/_assets/` after `stage_site_playground` ✓
- `gl_10_deferred` is the **only** manifested sample, and **every** path is under `tutorials/`, so the single line fully covers it (and any future tutorials-asset sample) ✓
- The `.obj` is a plain 1.1 MB file, **not** git-LFS — no pointer/checkout complication ✓

CI-workflow-only change (no `.das`, docs, or tests); takes effect on the next Pages deploy from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)