### PR TITLE
OpenGL/WebGL2: std140 UBO pack binder via a shared layout-walk (mat3 + composites)

### DIFF
--- a/daslib/shader_block_layout.das
+++ b/daslib/shader_block_layout.das
@@ -222,3 +222,28 @@ def public compute_block_layout(sname : string; st : Structure?; var fields : ar
     }
     return (ok = true, size = off, align = max_align)
 }
+
+//! True iff every field of the block packs into std140 with a single memcpy at its offset: a 32-bit
+//! scalar / vector / float4x4. False for float3x3 / float3x4 (std140 pads each column to vec4 ->
+//! per-column repack), fixed-arrays and nested structs (composite -> stride / recursion), and any block
+//! compute_block_layout rejects. A backend uses this to choose the std140 UBO pack path vs a loose
+//! by-name fallback for a given @uniform block, and the emitter + host binder MUST agree by both
+//! consulting it. (The simple-field restriction is the current GL UBO binder's scope, not a std140 law.)
+[macro_function]
+def public std140_block_is_simple(st : Structure?) : bool {
+    var fields : array<BlockField>
+    var errors : array<string>
+    let layout = compute_block_layout("", st, fields, errors)
+    var simple = layout.ok
+    if (simple) {
+        for (f in fields) {
+            if (f.is_composite || (f.is_matrix && f.matrix_width != 4)) {
+                simple = false
+                break
+            }
+        }
+    }
+    delete fields
+    delete errors
+    return simple
+}

--- a/daslib/shader_block_layout.das
+++ b/daslib/shader_block_layout.das
@@ -223,27 +223,78 @@ def public compute_block_layout(sname : string; st : Structure?; var fields : ar
     return (ok = true, size = off, align = max_align)
 }
 
-//! True iff every field of the block packs into std140 with a single memcpy at its offset: a 32-bit
-//! scalar / vector / float4x4. False for float3x3 / float3x4 (std140 pads each column to vec4 ->
-//! per-column repack), fixed-arrays and nested structs (composite -> stride / recursion), and any block
-//! compute_block_layout rejects. A backend uses this to choose the std140 UBO pack path vs a loose
-//! by-name fallback for a given @uniform block, and the emitter + host binder MUST agree by both
-//! consulting it. (The simple-field restriction is the current GL UBO binder's scope, not a std140 law.)
+//! True iff the block has a physical std140 layout — i.e. compute_block_layout succeeds. That covers
+//! every supported field shape: 32-bit scalar / vector / matrix (float4x4 flat, float3x3 / float3x4
+//! per-column), nested structs, and fixed-arrays of those. False only for blocks with a bool or other
+//! non-numeric field (no std140 layout). A backend uses this to choose the std140 UBO pack path vs a
+//! loose by-name fallback for a given @uniform block, and the emitter + host binder MUST agree by both
+//! consulting it.
 [macro_function]
-def public std140_block_is_simple(st : Structure?) : bool {
+def public std140_block_is_packable(st : Structure?) : bool {
     var fields : array<BlockField>
     var errors : array<string>
     let layout = compute_block_layout("", st, fields, errors)
-    var simple = layout.ok
-    if (simple) {
-        for (f in fields) {
-            if (f.is_composite || (f.is_matrix && f.matrix_width != 4)) {
-                simple = false
-                break
+    delete fields
+    delete errors
+    return layout.ok
+}
+
+//! One std140 leaf write produced by std140_block_writes: a scalar / vector value (a plain field, a
+//! matrix COLUMN, or an array ELEMENT) and its std140 byte offset within the block. A backend's bind
+//! macro emits one memcpy-style write per entry — GL std140_set, dasVulkan write_field — each copying
+//! sizeof(value) bytes. No backend needs matrix / array / nesting knowledge: the decomposition lives in
+//! std140_block_writes, so every rail packs the same bytes by construction.
+struct public Std140Write {
+    offset : int             //!< std140 byte offset of this leaf within the block
+    access : ExpressionPtr   //!< expression yielding the scalar/vector leaf value (field / column / element)
+}
+
+//! Decompose an interface block into a flat list of leaf writes (Std140Write) — the single shared
+//! std140 packing walk for every shader backend's host binder. float3x3 / float3x4 split into per-column
+//! writes (column c at offset + c*16; daslang stores width-wide packed columns, std140 pads each to a
+//! vec4, and the per-column memcpy gives that padding for free); float4x4 stays one whole-matrix write
+//! (its columns are already vec4-wide so a single memcpy is std140-correct); fixed-arrays split per
+//! element at the std140 stride; nested structs recurse; array-of-struct recurses per element. `access`
+//! is the accessor for the block instance (e.g. an ExprVar of the @uniform global), cloned per leaf;
+//! each emitted access node is moved by the caller into exactly one backend write call. Assumes the
+//! block is std140-packable (std140_block_is_packable) — array-of-matrix / bool fields are rejected
+//! upstream by compute_block_layout, so this never sees an unsupported shape.
+[macro_function]
+def public std140_block_writes(st : Structure?; access : ExpressionPtr; baseOffset : int; var out : array<Std140Write>) {
+    var fields : array<BlockField>
+    var errors : array<string>
+    compute_block_layout("", st, fields, errors)
+    for (i in range(length(fields))) {
+        let f = fields[i]
+        let ftype = st.fields[i]._type
+        let off = baseOffset + f.offset
+        var faccess = new ExprField(at = access.at, value <- clone_expression(access), name := st.fields[i].name)
+        if (f.is_matrix && f.matrix_width != 4) {
+            out |> reserve(length(out) + f.matrix_cols)
+            for (c in range(f.matrix_cols)) {
+                var col = new ExprAt(at = access.at, subexpr <- clone_expression(faccess),
+                    index <- new ExprConstInt(at = access.at, value = c))
+                out |> push(Std140Write(offset = off + c * 16, access = col))
             }
+        } elif (f.is_array && f.is_struct) {
+            for (e in range(f.array_count)) {
+                var el = new ExprAt(at = access.at, subexpr <- clone_expression(faccess),
+                    index <- new ExprConstInt(at = access.at, value = e))
+                std140_block_writes(ftype.firstType.structType, el, off + e * f.array_stride, out)
+            }
+        } elif (f.is_array) {
+            out |> reserve(length(out) + f.array_count)
+            for (e in range(f.array_count)) {
+                var el = new ExprAt(at = access.at, subexpr <- clone_expression(faccess),
+                    index <- new ExprConstInt(at = access.at, value = e))
+                out |> push(Std140Write(offset = off + e * f.array_stride, access = el))
+            }
+        } elif (f.is_struct) {
+            std140_block_writes(ftype.structType, faccess, off, out)
+        } else {
+            out |> push(Std140Write(offset = off, access = faccess))
         }
     }
     delete fields
     delete errors
-    return simple
 }

--- a/daslib/shader_block_layout.das
+++ b/daslib/shader_block_layout.das
@@ -1,0 +1,224 @@
+options gen2
+
+// std140 interface-block layout — the single source of truth shared by every shader backend's
+// uniform binder. compute_block_layout walks a daslang struct and yields per-field std140 byte
+// offsets / sizes / matrix + composite flags; the SPIR-V emitter (dasSpirv) lays out its interface
+// block from it, the OpenGL host binder (dasOpenGL) packs its UBO bytes from it, and dasVulkan's
+// host binder writes mapped memory from it — so all rails agree on the byte layout. Pure compile-time
+// AST logic (no backend types), which is why it lives in daslib and not in either emitter module.
+
+module shader_block_layout shared public
+
+require math
+require daslib/ast
+
+// daslang matrices are handled (tHandle) types named float<W>x<C> — W = column-vector width,
+// C = column count (MatrixAnnotation<floatW, C>, column-major: m[i] is column i). Returns the
+// dimensions so emit_type / the std140 layout / matrix arithmetic can treat them structurally.
+def public matrix_info(t : TypeDecl?) : tuple<ok : bool; width : int; cols : int> {
+    if (t == null || t.baseType != Type.tHandle || t.annotation == null) return (ok = false, width = 0, cols = 0)
+    let nm = "{t.annotation.name}"
+    if (nm == "float4x4") return (ok = true, width = 4, cols = 4)
+    if (nm == "float3x3") return (ok = true, width = 3, cols = 3)
+    if (nm == "float3x4") return (ok = true, width = 3, cols = 4)
+    return (ok = false, width = 0, cols = 0)
+}
+
+// Type -> scalar class: 0 signed int, 1 unsigned int, 2 float (scalars and their 2/3/4 vectors);
+// -1 for anything else. The supported interface-block leaf set is exactly these 32-bit numerics.
+def public scalar_class(bt : Type) : int {
+    if (bt == Type.tInt || bt == Type.tInt2 || bt == Type.tInt3 || bt == Type.tInt4) return 0
+    if (bt == Type.tUInt || bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4) return 1
+    if (bt == Type.tFloat || bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4) return 2
+    return -1
+}
+
+// Lane count of a scalar/vector Type: 1/2/3/4; 0 for non-scalar/vector types.
+def public component_count(bt : Type) : int {
+    if (bt == Type.tInt || bt == Type.tUInt || bt == Type.tFloat || bt == Type.tBool) return 1
+    if (bt == Type.tInt2 || bt == Type.tUInt2 || bt == Type.tFloat2) return 2
+    if (bt == Type.tInt3 || bt == Type.tUInt3 || bt == Type.tFloat3) return 3
+    if (bt == Type.tInt4 || bt == Type.tUInt4 || bt == Type.tFloat4) return 4
+    return 0
+}
+
+// ===== std140 layout for a UBO interface block =====
+// std140 base alignment: scalar -> 4, vec2 -> 8, vec3/vec4 -> 16. The base *size* of a vec3 is 12
+// (only its alignment is 16), so a scalar can pack into the trailing 4 bytes after a vec3.
+def public std140_align(bt : Type) : int {
+    let cc = component_count(bt)
+    if (cc == 1) return 4
+    if (cc == 2) return 8
+    return 16
+}
+
+def public std140_size(bt : Type) : int {
+    return component_count(bt) * 4
+}
+
+def public round_up(off, a : int) : int {
+    return ((off + a - 1) / a) * a
+}
+
+//! One std140-laid-out field of a @uniform / @push_constant interface block. Returned by
+//! compute_block_layout and consumed by host-side bind macros (e.g. dasVulkan's SpirvVulkanShader
+//! and dasOpenGL's GlslOpenGLShader) to emit one write per field at the right byte offset.
+//! `is_matrix` just means "this field IS a matrix" (and gets MatrixStride 16 in SPIR-V) — it does
+//! NOT by itself imply the daslang storage and std140 layout differ. For float4x4 the columns are
+//! already vec4-wide so a single memcpy works; for float3x3 / float3x4 the daslang storage is packed
+//! (3-wide columns) while std140 pads each column to vec4, so bind code must repack per-column.
+//! **Use `matrix_width` to choose**: `matrix_width == 4` → safe to memcpy the field; `matrix_width <
+//! 4` → repack per column.
+//!
+//! **Composite fields** (`is_array` / `is_struct`) carry the std140 layout of nested data but
+//! cannot be written by a single host-side `write_field(ptr, offset, value)` call. Host bind
+//! macros should detect `is_composite` and either recurse member-by-member using the published
+//! `offset` + `array_stride` / nested layout, or skip with a clear "manual bind required" message.
+struct public BlockField {
+    name              : string //!< field name as declared in the daslang struct
+    offset            : int    //!< std140 byte offset from the block base
+    size              : int    //!< std140 base size of the field (matrices: 16 * cols; composites: total laid-out bytes)
+    is_matrix         : bool   //!< true if this field is a matrix (MatrixStride 16 in SPIR-V); see struct docstring re: repack
+    matrix_width      : int    //!< matrix column-vector width — 4 for float4x4 (memcpy-safe); 3 for float3x3/3x4 (per-column repack)
+    matrix_cols       : int    //!< matrix column count (only valid when is_matrix); 0 otherwise
+    is_array          : bool   //!< true if this field is a fixed-array (scalar / vector / nested-struct elements)
+    array_count       : int    //!< number of array elements (only valid when is_array)
+    array_stride      : int    //!< per-element byte stride (std140 rounds each element up to 16); 0 otherwise
+    is_struct         : bool   //!< the struct-element marker. True when the field is a nested struct (`is_array=false`) OR a fixed-array whose elements are nested structs (`is_array=true` — disambiguate via is_array). Host bind macros that handle composites recurse into the inner Structure via compute_block_layout in either case.
+    is_composite      : bool   //!< convenience flag — true when is_array OR is_struct (host bind macros can't write this with a flat overload)
+}
+
+// std140 element stride for a fixed-array element type. Scalars/vectors round up to vec4 (16 bytes);
+// nested-struct elements take their std140 struct-size rounded up to the struct alignment (which is
+// already a multiple of 16 by std140's struct rule). Matrix elements and nested-array elements are
+// out of PR-G scope and rejected by the caller before reaching here.
+def private std140_array_element_stride(bt : Type) : int {
+    return round_up(std140_size(bt), 16)
+}
+
+//! Compute the std140 layout of one interface block. Pure: takes a Structure?, fills `fields` with
+//! per-field offsets / sizes / matrix and composite flags, returns the block total size and max
+//! member alignment. Used by build_block_struct (SPIR-V type emit), the OpenGL UBO pack binder, and
+//! dasVulkan's mapped-memory binder. Rejects bool and non-numeric fields fail-closed (no physical
+//! std140 layout). `sname` is only used in error messages. `fields` is cleared at entry so reuse
+//! across calls and partial-failure returns can't bleed. Supported field shapes (PR-G complete):
+//! 32-bit scalar / vector / matrix; nested struct (recursive); fixed-array of scalar / vector
+//! (std140 ArrayStride = element-size rounded to 16); fixed-array of nested struct (ArrayStride =
+//! laid-out struct size rounded to struct alignment). Out of scope (clean rejection): matrix-of-array,
+//! array-of-array, runtime arrays (use `@ssbo` for those).
+//! [macro_function]: callable from a backend's bind-gen macro at compile time, mirrors generate_spirv.
+[macro_function]
+def public compute_block_layout(sname : string; st : Structure?; var fields : array<BlockField>; var errors : array<string>) : tuple<ok : bool; size : int; align : int> {
+    fields |> clear
+    if (st == null || empty(st.fields)) {
+        errors |> push("interface block '{sname}' must be a struct with at least one field")
+        return (ok = false, size = 0, align = 0)
+    }
+    var off = 0
+    var max_align = 0
+    for (fld in st.fields) {
+        // matrix field (terminal)
+        let mi = matrix_info(fld._type)
+        if (mi.ok) {
+            off = round_up(off, 16)
+            fields |> emplace(BlockField(name := string(fld.name), offset = off, size = 16 * mi.cols,
+                is_matrix = true, matrix_width = mi.width, matrix_cols = mi.cols))
+            off += 16 * mi.cols
+            max_align = max(max_align, 16)
+            continue
+        }
+        // nested struct field (PR-G): recurse. Base alignment = round_up(inner_align, 16);
+        // size = round_up(inner_size, base_align). The inner field list isn't propagated up
+        // (host bind macros that recurse must re-invoke compute_block_layout on the nested
+        // Structure?). is_composite=true signals "no flat write_field overload exists".
+        if (fld._type != null && fld._type.baseType == Type.tStructure && fld._type.structType != null) {
+            var inner : array<BlockField>
+            let inner_layout = compute_block_layout("{sname}.{fld.name}", fld._type.structType, inner, errors)
+            delete inner
+            if (!inner_layout.ok) {
+                fields |> clear
+                return (ok = false, size = 0, align = 0)
+            }
+            let struct_align = round_up(inner_layout.align, 16)
+            off = round_up(off, struct_align)
+            let struct_size = round_up(inner_layout.size, struct_align)
+            fields |> emplace(BlockField(name := string(fld.name), offset = off, size = struct_size,
+                is_matrix = false, matrix_width = 0, matrix_cols = 0,
+                is_array = false, array_count = 0, array_stride = 0,
+                is_struct = true, is_composite = true))
+            off += struct_size
+            max_align = max(max_align, struct_align)
+            continue
+        }
+        // fixed-array field (PR-G): element kind decides stride. Scalar/vector elements stride by
+        // their size rounded up to 16 (the std140 array padding rule — every array slot is at
+        // least vec4-wide). Nested-struct elements stride by their laid-out struct size. Matrix
+        // elements and nested-array elements (array of array) are rejected; wrap in a struct.
+        if (fld._type != null && fld._type.baseType == Type.tFixedArray && fld._type.firstType != null) {
+            let et = fld._type.firstType
+            let nelem = fld._type.fixedDim
+            if (nelem <= 0) {
+                errors |> push("interface block '{sname}' field '{fld.name}': array must have positive count (got {nelem})")
+                fields |> clear
+                return (ok = false, size = 0, align = 0)
+            }
+            // scalar / vector element
+            if (et.baseType != Type.tStructure && et.baseType != Type.tFixedArray && !matrix_info(et).ok) {
+                let ebt = et.baseType
+                if (scalar_class(ebt) < 0) {
+                    errors |> push("interface block '{sname}' field '{fld.name}': array element type {ebt} is not supported (only 32-bit int/uint/float scalars, their vectors, or nested structs of those)")
+                    fields |> clear
+                    return (ok = false, size = 0, align = 0)
+                }
+                let stride = std140_array_element_stride(ebt)
+                off = round_up(off, 16)        // std140 array base alignment is 16
+                let total = stride * nelem
+                fields |> emplace(BlockField(name := string(fld.name), offset = off, size = total,
+                    is_matrix = false, matrix_width = 0, matrix_cols = 0,
+                    is_array = true, array_count = nelem, array_stride = stride,
+                    is_struct = false, is_composite = true))
+                off += total
+                max_align = max(max_align, 16)
+                continue
+            }
+            // array-of-struct element
+            if (et.baseType == Type.tStructure && et.structType != null) {
+                var inner : array<BlockField>
+                let inner_layout = compute_block_layout("{sname}.{fld.name}[]", et.structType, inner, errors)
+                delete inner
+                if (!inner_layout.ok) {
+                    fields |> clear
+                    return (ok = false, size = 0, align = 0)
+                }
+                let struct_align = round_up(inner_layout.align, 16)
+                let stride = round_up(inner_layout.size, struct_align)
+                off = round_up(off, struct_align)
+                let total = stride * nelem
+                fields |> emplace(BlockField(name := string(fld.name), offset = off, size = total,
+                    is_matrix = false, matrix_width = 0, matrix_cols = 0,
+                    is_array = true, array_count = nelem, array_stride = stride,
+                    is_struct = true, is_composite = true))
+                off += total
+                max_align = max(max_align, struct_align)
+                continue
+            }
+            errors |> push("interface block '{sname}' field '{fld.name}': array element type {et.baseType} is not supported (only scalar/vector or nested-struct elements; matrix-of-array and array-of-array are out of scope)")
+            fields |> clear
+            return (ok = false, size = 0, align = 0)
+        }
+        // terminal scalar / vector field
+        let fbt = fld._type.baseType
+        if (scalar_class(fbt) < 0) {
+            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported (only 32-bit int/uint/float scalars, their vectors, matrices, fixed-arrays of those, and nested structs of those; bool has no physical interface-block layout in Vulkan)")
+            fields |> clear
+            return (ok = false, size = 0, align = 0)
+        }
+        let falign = std140_align(fbt)
+        off = round_up(off, falign)
+        fields |> emplace(BlockField(name := string(fld.name), offset = off, size = std140_size(fbt),
+            is_matrix = false, matrix_width = 0, matrix_cols = 0))
+        off += std140_size(fbt)
+        max_align = max(max_align, falign)
+    }
+    return (ok = true, size = off, align = max_align)
+}

--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -999,11 +999,11 @@ class GlslExport : AstVisitor {
         let t = arg._type
         if (t.baseType != Type.tStructure || t.structType == null) return false
         // Skip the UBO path (fall through to the loose `uniform Struct name;` form + by-name binder) for
-        // sampler/image markers (they bind as textures, not UBOs) and for structs with a float3x3 /
-        // composite field that can't pack flat. The host bind macro consults the SAME predicate
-        // (std140_block_is_simple) so emitter and binder agree on which blocks pack.
+        // sampler/image markers (they bind as textures, not UBOs) and for blocks with no physical std140
+        // layout (a bool / non-numeric field). The host bind macro consults the SAME predicate
+        // (std140_block_is_packable) so emitter and binder agree on which blocks pack.
         let snm = "{t.structType.name}"
-        if (snm |> find("sampler") != -1 || snm |> find("image") != -1 || !std140_block_is_simple(t.structType)) return false
+        if (snm |> find("sampler") != -1 || snm |> find("image") != -1 || !std140_block_is_packable(t.structType)) return false
         // Block name = <instance>_ubo, NOT the struct type name: the struct type is still emitted as a
         // standalone GLSL `struct` (it may be used elsewhere), and a block sharing that name would
         // collide. Per-instance keeps two uniforms of the same struct type distinct, and keeps a global

--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -19,6 +19,7 @@ require daslib/ast_boost
 require daslib/templates_boost
 require daslib/strings_boost
 require daslib/ast_used
+require daslib/shader_block_layout
 
 let DEBUG_SHADER_TEXT = false
 let DEBUG_SHADER_BINDINGS = false
@@ -45,6 +46,7 @@ bitfield ShaderExportCaps {
     output_structure_initializers               // generate Foo_STRUCTURE_INITIALIZER instead of Foo() for HLSL compatibility
     allow_unitialized_local_arrays              // var a: float[9] can be local, and will not be initialized for HLSL (only if restrict_array_as_result)
     resolve_supported_semantics                 // resolve semantics from variable name (a_color0, v_position etc)
+    pack_std140_uniforms                        // emit a struct @uniform/@push_constant as a std140 interface block (UBO) instead of a free `uniform Struct name;`; the host binds it via glBindBufferRange (GL/WebGL2 portable floor)
 }
 
 class GlslShader : AstFunctionAnnotation {
@@ -64,6 +66,7 @@ class GlslShader : AstFunctionAnnotation {
     output_structure_initializers = false
     allow_unitialized_local_arrays = false
     resolve_supported_semantics = false
+    pack_std140_uniforms = false
     def get_glsl_prefix {
         return ""
     }
@@ -146,6 +149,9 @@ class GlslShader : AstFunctionAnnotation {
         }
         if (resolve_supported_semantics) {
             caps.resolve_supported_semantics = true
+        }
+        if (pack_std140_uniforms) {
+            caps.pack_std140_uniforms = true
         }
         return caps
     }
@@ -981,6 +987,40 @@ class GlslExport : AstVisitor {
         *writer |> write("{suffix}({arg.name},{format},{binding})")
         return true
     }
+    // std140 UBO pack: a struct @uniform / @push_constant (not a sampler/image marker) lowers to a
+    // `layout(std140) uniform <BlockType> { fields } <instance>;` interface block instead of a free
+    // `uniform Struct name;`. The host binds it as a UBO (glBindBufferRange). ES3.00 / WebGL2 allows no
+    // layout(binding=) on a block, so no binding qualifier is emitted — the host assigns the point at
+    // bind time. The shader body's `name.field` access is identical to the loose form. Returns false
+    // when packing is off (loose fallback) or the type isn't a packable struct. visitGlobalLetVariable
+    // appends the trailing ';'.
+    def outputStd140UboBlock(arg : VariablePtr) : bool {
+        if (!caps.pack_std140_uniforms) return false
+        let t = arg._type
+        if (t.baseType != Type.tStructure || t.structType == null) return false
+        // Skip the UBO path (fall through to the loose `uniform Struct name;` form + by-name binder) for
+        // sampler/image markers (they bind as textures, not UBOs) and for structs with a float3x3 /
+        // composite field that can't pack flat. The host bind macro consults the SAME predicate
+        // (std140_block_is_simple) so emitter and binder agree on which blocks pack.
+        let snm = "{t.structType.name}"
+        if (snm |> find("sampler") != -1 || snm |> find("image") != -1 || !std140_block_is_simple(t.structType)) return false
+        // Block name = <instance>_ubo, NOT the struct type name: the struct type is still emitted as a
+        // standalone GLSL `struct` (it may be used elsewhere), and a block sharing that name would
+        // collide. Per-instance keeps two uniforms of the same struct type distinct, and keeps a global
+        // shared by vertex+fragment one block (same name -> the linker merges it). Host binder matches.
+        *writer |> write("layout(std140) uniform {arg.name}_ubo")
+        newLine(1)
+        *writer |> write("\{")
+        newLine(1)
+        for (f in t.structType.fields) {
+            *writer |> write("    {describe_glsl_type_ex(f._type, false)} {f.name}")
+            write_dim_suffix(f._type)
+            *writer |> write(";")
+            newLine(1)
+        }
+        *writer |> write("\} {arg.name}")
+        return true
+    }
     def override preVisitGlobalLetVariable(arg : VariablePtr; lastArg : bool) {
         line(arg.at)
         if (caps.restrict_array_as_result) {
@@ -1021,7 +1061,7 @@ class GlslExport : AstVisitor {
             if (shaderType == ShaderType.vertex) {
                 if (isUniform) {
                     checkUniformType(arg._type)
-                    if (outputSamplerMacro(arg)) return
+                    if (outputSamplerMacro(arg) || outputStd140UboBlock(arg)) return
                     *writer |> write("uniform "); needInit = false
                 }
                 let argLoc = arg.annotation |> find_arg("location")
@@ -1039,7 +1079,7 @@ class GlslExport : AstVisitor {
             } elif (shaderType == ShaderType.fragment) {
                 if (isUniform) {
                     checkUniformType(arg._type)
-                    if (outputSamplerMacro(arg)) return
+                    if (outputSamplerMacro(arg) || outputStd140UboBlock(arg)) return
                     *writer |> write("uniform "); needInit = false
                 }
                 // GLSL ES 3.00 REQUIRES an explicit layout(location=N) on every fragment output when
@@ -1068,7 +1108,7 @@ class GlslExport : AstVisitor {
                 }
                 if (isUniform) {
                     checkUniformType(arg._type)
-                    if (outputSamplerMacro(arg) || outputImageMacro(arg)) return
+                    if (outputSamplerMacro(arg) || outputImageMacro(arg) || outputStd140UboBlock(arg)) return
                     *writer |> write("uniform "); needInit = false
                 }
                 if (arg.annotation |> find_arg("in") is tBool) {

--- a/modules/dasOpenGL/glsl/glsl_opengl.das
+++ b/modules/dasOpenGL/glsl/glsl_opengl.das
@@ -127,11 +127,23 @@ def private emit_loose_struct_bind(var blk : ExprBlock?; st : Structure?; namePr
     }
 }
 
-// Emit the std140 UBO bind for one struct @uniform / @push_constant block. The caller has already
-// confirmed std140_block_is_simple, so every field packs flat. Computes the shared std140 layout
-// (compute_block_layout — the same offsets the SPIR-V/Vulkan rails use), then emits a flat call
-// sequence into the bind function: std140_reset(prog, block, paddedSize); one std140_set(prog, block,
-// offset, vv.field) per field; std140_flush(prog, block, bindingPoint).
+// Emit a std140_set(_opengl_program, blockName, off, access) call into the bind block — a flat memcpy
+// of one scalar / vector / float4x4 / array-element / leaf field into the staging buffer at its offset.
+[macro_function]
+def private emit_std140_set(var blk : ExprBlock?; at : LineInfo; blockName : string; off : int; var access : ExpressionPtr) {
+    var c = new ExprCall(at = at, name := "std140_set")
+    c.arguments |> emplace_new() <| new ExprVar(at = at, name := "_opengl_program")
+    c.arguments |> emplace_new() <| new ExprConstString(at = at, value := blockName)
+    c.arguments |> emplace_new() <| new ExprConstUInt(at = at, value = uint(off))
+    c.arguments |> emplace(access)
+    blk.list |> emplace(c)
+}
+
+// Emit the std140 UBO bind for one struct @uniform / @push_constant block. The caller confirmed
+// std140_block_is_packable. The shared std140 walk (std140_block_writes) decomposes the block into leaf
+// scalar/vector writes — float3x3/float3x4 columns, array elements, nested-struct fields — at their
+// std140 offsets; we wrap them with std140_reset / per-leaf std140_set / std140_flush. The Vulkan rail
+// drives the SAME walk through write_field, so both pack byte-identically.
 [macro_function]
 def private emit_std140_ubo_bind(var blk : ExprBlock?; vv : VariablePtr; bindingPoint : int) {
     let st = vv._type.structType
@@ -142,7 +154,7 @@ def private emit_std140_ubo_bind(var blk : ExprBlock?; vv : VariablePtr; binding
     var errs : array<string>
     let layout = compute_block_layout(blockName, st, fields, errs)
     if (!layout.ok) {
-        // Defensive: std140_block_is_simple already rejected non-layoutable blocks to the loose path.
+        // Defensive: std140_block_is_packable already rejected non-layoutable blocks to the loose path.
         let msg = empty(errs) ? "(no diagnostic)" : errs[0]
         macro_error(compiling_program(), vv.at, "[opengl std140]: @uniform '{vv.name}' layout failed: {msg}")
         delete fields
@@ -155,18 +167,12 @@ def private emit_std140_ubo_bind(var blk : ExprBlock?; vv : VariablePtr; binding
     cll_reset.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := blockName)
     cll_reset.arguments |> emplace_new() <| new ExprConstInt(at = vv.at, value = padded)
     blk.list |> emplace(cll_reset)
-    for (f in fields) {
-        var cll_set = new ExprCall(at = vv.at, name := "std140_set")
-        cll_set.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
-        cll_set.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := blockName)
-        cll_set.arguments |> emplace_new() <| new ExprConstUInt(at = vv.at, value = uint(f.offset))
-        var fld_access = new ExprField(at = vv.at,
-            value <- new ExprVar(at = vv.at, name := vv.name),
-            name := f.name
-        )
-        cll_set.arguments |> emplace(fld_access)
-        blk.list |> emplace(cll_set)
+    var writes : array<Std140Write>
+    std140_block_writes(st, new ExprVar(at = vv.at, name := vv.name), 0, writes)
+    for (w in writes) {
+        emit_std140_set(blk, vv.at, blockName, w.offset, w.access)
     }
+    unsafe { delete writes; }
     var cll_flush = new ExprCall(at = vv.at, name := "std140_flush")
     cll_flush.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
     cll_flush.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := blockName)
@@ -255,20 +261,20 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr; pa
                 } elif (is_glsl_structure(vv, "sampler2DShadow")) {
                     emit_combined_sampler_bind(blk, vv, "texture2D", "bind_sampler_2d_shadow")
                 } elif (vv._type.baseType == Type.tStructure && vv._type.structType != null) {
-                    if (pack_std140 && std140_block_is_simple(vv._type.structType)) {
-                        // std140 UBO pack (default for blocks whose fields all pack flat): defer until
-                        // every block is collected, so binding points can be assigned in a stable order
-                        // that agrees across the vertex/fragment bind functions (both walk the same
-                        // module globals). The emitter consults the same predicate. Phase 2 / D5.
+                    if (pack_std140 && std140_block_is_packable(vv._type.structType)) {
+                        // std140 UBO pack (default): defer until every block is collected, so binding
+                        // points can be assigned in a stable order that agrees across the vertex/fragment
+                        // bind functions (both walk the same module globals). The emitter consults the
+                        // same predicate. Phase 2 / D5.
                         let nm = string(vv.name)
                         if (!key_exists(ubo_seen, nm)) {
                             ubo_seen |> insert(nm)
                             ubo_globals |> push(vv)
                         }
                     } else {
-                        // loose fallback (packing off, or a float3x3 / composite block the UBO binder
-                        // can't pack yet): a struct uniform lowers to `uniform StructType name;` and each
-                        // leaf field binds by flattened name (name.field, name.field.subfield, ...).
+                        // loose fallback (packing off, or a block with no std140 layout — e.g. a bool
+                        // field): a struct uniform lowers to `uniform StructType name;` and each leaf
+                        // field binds by flattened name (name.field, name.field.subfield, ...).
                         emit_loose_struct_bind(blk, vv._type.structType, string(vv.name),
                             new ExprVar(at = vv.at, name := vv.name))
                     }

--- a/modules/dasOpenGL/glsl/glsl_opengl.das
+++ b/modules/dasOpenGL/glsl/glsl_opengl.das
@@ -6,18 +6,24 @@ options strict_smart_pointers
 
 module glsl_opengl shared public
 
+require daslib/ast
 require daslib/ast_boost
 require daslib/strings_boost
+require daslib/shader_block_layout
 
 require glsl/glsl_internal
 require glsl/glsl_common public
 
 class GlslOpenGLShader : GlslShader {
+    // Pack struct @uniform / @push_constant blocks as std140 UBOs by default (the GL/WebGL2 portable
+    // floor, byte-for-byte with the Vulkan rail). Loose by-name binding stays the fallback for the
+    // scalar / vector / matrix / sampler uniforms that aren't interface blocks.
+    override pack_std140_uniforms = true
     def override generate_bind_uniform_dummy(var func : FunctionPtr) {
         glsl_opengl::generate_bind_uniform_dummy(func)
     }
     def override generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
-        glsl_opengl::generate_bind_uniform(fnMain, fn)
+        glsl_opengl::generate_bind_uniform(fnMain, fn, pack_std140_uniforms)
     }
 }
 
@@ -121,9 +127,60 @@ def private emit_loose_struct_bind(var blk : ExprBlock?; st : Structure?; namePr
     }
 }
 
+// Emit the std140 UBO bind for one struct @uniform / @push_constant block. The caller has already
+// confirmed std140_block_is_simple, so every field packs flat. Computes the shared std140 layout
+// (compute_block_layout — the same offsets the SPIR-V/Vulkan rails use), then emits a flat call
+// sequence into the bind function: std140_reset(prog, block, paddedSize); one std140_set(prog, block,
+// offset, vv.field) per field; std140_flush(prog, block, bindingPoint).
 [macro_function]
-def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
+def private emit_std140_ubo_bind(var blk : ExprBlock?; vv : VariablePtr; bindingPoint : int) {
+    let st = vv._type.structType
+    // Block name = <instance>_ubo — must match glsl_internal's outputStd140UboBlock (distinct from the
+    // struct type name, which is still emitted as a standalone GLSL struct).
+    let blockName = "{vv.name}_ubo"
+    var fields : array<BlockField>
+    var errs : array<string>
+    let layout = compute_block_layout(blockName, st, fields, errs)
+    if (!layout.ok) {
+        // Defensive: std140_block_is_simple already rejected non-layoutable blocks to the loose path.
+        let msg = empty(errs) ? "(no diagnostic)" : errs[0]
+        macro_error(compiling_program(), vv.at, "[opengl std140]: @uniform '{vv.name}' layout failed: {msg}")
+        delete fields
+        delete errs
+        return
+    }
+    let padded = round_up(layout.size, 16)
+    var cll_reset = new ExprCall(at = vv.at, name := "std140_reset")
+    cll_reset.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
+    cll_reset.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := blockName)
+    cll_reset.arguments |> emplace_new() <| new ExprConstInt(at = vv.at, value = padded)
+    blk.list |> emplace(cll_reset)
+    for (f in fields) {
+        var cll_set = new ExprCall(at = vv.at, name := "std140_set")
+        cll_set.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
+        cll_set.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := blockName)
+        cll_set.arguments |> emplace_new() <| new ExprConstUInt(at = vv.at, value = uint(f.offset))
+        var fld_access = new ExprField(at = vv.at,
+            value <- new ExprVar(at = vv.at, name := vv.name),
+            name := f.name
+        )
+        cll_set.arguments |> emplace(fld_access)
+        blk.list |> emplace(cll_set)
+    }
+    var cll_flush = new ExprCall(at = vv.at, name := "std140_flush")
+    cll_flush.arguments |> emplace_new() <| new ExprVar(at = vv.at, name := "_opengl_program")
+    cll_flush.arguments |> emplace_new() <| new ExprConstString(at = vv.at, value := blockName)
+    cll_flush.arguments |> emplace_new() <| new ExprConstInt(at = vv.at, value = bindingPoint)
+    blk.list |> emplace(cll_flush)
+    delete fields
+    delete errs
+}
+
+[macro_function]
+def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr; pack_std140 : bool) {
     var blk = new ExprBlock(at = fn.at)
+    var ubo_globals : array<VariablePtr>   // struct @uniform/@push_constant blocks to pack as std140 UBOs
+    var ubo_seen : table<string>           // dedup: a block reachable via >1 function is collected once
     collect_dependencies(fnMain) $(_vfun, vvar) {
         for (vv in vvar) {
             // @push_constant has no GL equivalent -> bind it like a @uniform (loose). Phase 2 / D4.
@@ -198,11 +255,23 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
                 } elif (is_glsl_structure(vv, "sampler2DShadow")) {
                     emit_combined_sampler_bind(blk, vv, "texture2D", "bind_sampler_2d_shadow")
                 } elif (vv._type.baseType == Type.tStructure && vv._type.structType != null) {
-                    // A struct @uniform / @push_constant lowers to a GLSL `uniform StructType name;`.
-                    // GL exposes each leaf field as its own by-name uniform location, so bind them
-                    // loose by flattened name (name.field, name.field.subfield, ...). Phase 2 / D5.
-                    emit_loose_struct_bind(blk, vv._type.structType, string(vv.name),
-                        new ExprVar(at = vv.at, name := vv.name))
+                    if (pack_std140 && std140_block_is_simple(vv._type.structType)) {
+                        // std140 UBO pack (default for blocks whose fields all pack flat): defer until
+                        // every block is collected, so binding points can be assigned in a stable order
+                        // that agrees across the vertex/fragment bind functions (both walk the same
+                        // module globals). The emitter consults the same predicate. Phase 2 / D5.
+                        let nm = string(vv.name)
+                        if (!key_exists(ubo_seen, nm)) {
+                            ubo_seen |> insert(nm)
+                            ubo_globals |> push(vv)
+                        }
+                    } else {
+                        // loose fallback (packing off, or a float3x3 / composite block the UBO binder
+                        // can't pack yet): a struct uniform lowers to `uniform StructType name;` and each
+                        // leaf field binds by flattened name (name.field, name.field.subfield, ...).
+                        emit_loose_struct_bind(blk, vv._type.structType, string(vv.name),
+                            new ExprVar(at = vv.at, name := vv.name))
+                    }
                 } else {
                     // scalar / vector / matrix uniform: glUniformAny(glGetUniformLocation("name"), name)
                     var cll_gul = new ExprCall(at = vv.at, name := "glGetUniformLocation")
@@ -216,6 +285,17 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr) {
             }
         }
     }
+    // std140 UBO binding points: assign by sorted block name so the same block gets the same point in
+    // every stage's bind function (the glBindBufferRange index must agree across vertex/fragment for a
+    // linked program). An explicit @binding wins; otherwise the name-sorted index is used.
+    ubo_globals |> sort() $(a, b) => string(a.name) < string(b.name)
+    for (i in range(length(ubo_globals))) {
+        let vv = ubo_globals[i]
+        let bp = vv.annotation |> find_arg("binding") ?as tInt ?? i
+        emit_std140_ubo_bind(blk, vv, bp)
+    }
+    unsafe { delete ubo_globals; }
+    delete ubo_seen
     fn.body := blk
     if (DEBUG_SHADER_BINDINGS) {
         print("{describe(fn)}\n")

--- a/modules/dasOpenGL/glsl/glsl_opengl.das
+++ b/modules/dasOpenGL/glsl/glsl_opengl.das
@@ -127,6 +127,18 @@ def private emit_loose_struct_bind(var blk : ExprBlock?; st : Structure?; namePr
     }
 }
 
+// True if a module global is a std140-packable @uniform / @push_constant UBO block (the exact set the
+// emitter packs: a non-sampler/image struct that lays out in std140). Used to build a program-stable
+// binding-point index across ALL of the module's UBO blocks, independent of which stage reaches them.
+[macro_function]
+def private is_packable_ubo(vv : VariablePtr) : bool {
+    if (!((vv.annotation |> find_arg("uniform") is tBool) || (vv.annotation |> find_arg("push_constant") is tBool)) ||
+        vv._type == null || vv._type.baseType != Type.tStructure || vv._type.structType == null) return false
+    let snm = "{vv._type.structType.name}"
+    if (snm |> find("sampler") != -1 || snm |> find("image") != -1) return false
+    return std140_block_is_packable(vv._type.structType)
+}
+
 // Emit a std140_set(_opengl_program, blockName, off, access) call into the bind block — a flat memcpy
 // of one scalar / vector / float4x4 / array-element / leaf field into the staging buffer at its offset.
 [macro_function]
@@ -261,7 +273,10 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr; pa
                 } elif (is_glsl_structure(vv, "sampler2DShadow")) {
                     emit_combined_sampler_bind(blk, vv, "texture2D", "bind_sampler_2d_shadow")
                 } elif (vv._type.baseType == Type.tStructure && vv._type.structType != null) {
-                    if (pack_std140 && std140_block_is_packable(vv._type.structType)) {
+                    // Same predicate the program-stable binding-point pass uses (is_packable_ubo), so a
+                    // block is collected iff it also gets a point — and it matches the emitter's pack
+                    // decision, so emitter and binder never disagree on a block.
+                    if (pack_std140 && is_packable_ubo(vv)) {
                         // std140 UBO pack (default): defer until every block is collected, so binding
                         // points can be assigned in a stable order that agrees across the vertex/fragment
                         // bind functions (both walk the same module globals). The emitter consults the
@@ -291,15 +306,62 @@ def private generate_bind_uniform(fnMain : FunctionPtr; var fn : FunctionPtr; pa
             }
         }
     }
-    // std140 UBO binding points: assign by sorted block name so the same block gets the same point in
-    // every stage's bind function (the glBindBufferRange index must agree across vertex/fragment for a
-    // linked program). An explicit @binding wins; otherwise the name-sorted index is used.
-    ubo_globals |> sort() $(a, b) => string(a.name) < string(b.name)
-    for (i in range(length(ubo_globals))) {
-        let vv = ubo_globals[i]
-        let bp = vv.annotation |> find_arg("binding") ?as tInt ?? i
-        emit_std140_ubo_bind(blk, vv, bp)
+    // std140 UBO binding points: a linked program needs a DISTINCT point per block, and a block shared
+    // across stages must get the SAME point in each stage's bind. The reachable set is per-stage, so an
+    // index over it is NOT program-stable — two distinct blocks split across the vertex/fragment stages
+    // could both land on 0 and stomp each other. So we assign points over ALL of the MODULE's packable
+    // UBO globals (every stage walks the same set, so the result is identical in each): an explicit
+    // @binding is reserved as-is (fail-closed on a negative or a duplicate), and every other block gets
+    // the lowest still-free point. The per-shader bind then just looks up its reachable blocks.
+    var ubo_explicit : table<string; int>   // module UBO block name -> explicit @binding (if any)
+    var ubo_names : array<string>           // all module UBO block names (sorted -> deterministic auto order)
+    for_each_global(compiling_module()) $(gv) {
+        if (is_packable_ubo(gv)) {
+            let gnm = string(gv.name)
+            ubo_names |> push(gnm)
+            let be = gv.annotation |> find_arg("binding")
+            if (be is tInt) {
+                ubo_explicit[gnm] = be as tInt
+            }
+        }
     }
+    ubo_names |> sort()
+    var reserved : table<int>                // points claimed by an explicit @binding
+    for (gnm in ubo_names) {
+        if (key_exists(ubo_explicit, gnm)) {
+            let be = ubo_explicit[gnm]
+            if (be < 0) {
+                macro_error(compiling_program(), fn.at,
+                    "[opengl std140]: @uniform block '{gnm}' has a negative @binding ({be}); binding points must be >= 0.")
+            } elif (key_exists(reserved, be)) {
+                macro_error(compiling_program(), fn.at,
+                    "[opengl std140]: two std140 UBO blocks both request @binding {be}; each block needs a distinct binding point.")
+            } else {
+                reserved |> insert(be)
+            }
+        }
+    }
+    var ubo_point : table<string; int>       // final program-stable point per block
+    var next_free = 0
+    for (gnm in ubo_names) {
+        if (key_exists(ubo_explicit, gnm)) {
+            ubo_point[gnm] = ubo_explicit[gnm]
+        } else {
+            while (key_exists(reserved, next_free)) {
+                next_free++
+            }
+            ubo_point[gnm] = next_free
+            reserved |> insert(next_free)
+            next_free++
+        }
+    }
+    for (vv in ubo_globals) {
+        emit_std140_ubo_bind(blk, vv, ubo_point?[string(vv.name)] ?? 0)
+    }
+    delete ubo_explicit
+    delete ubo_names
+    delete reserved
+    delete ubo_point
     unsafe { delete ubo_globals; }
     delete ubo_seen
     fn.body := blk

--- a/modules/dasOpenGL/opengl/opengl_boost.das
+++ b/modules/dasOpenGL/opengl/opengl_boost.das
@@ -181,6 +181,53 @@ def glBufferData(target : GLenum; arr; usage : GLenum) {
     }
 }
 
+// ===== std140 UBO runtime (the GL analogue of dasVulkan's write_field / with_mapped_memory) =====
+// A struct @uniform packed as a std140 interface block binds through these three helpers, emitted by
+// glsl_opengl's bind-uniform macro: std140_reset sizes a per-(program, block) CPU staging buffer,
+// std140_set writes each field at its compile-time std140 offset, std140_flush uploads the bytes to a
+// per-(program, block) GL uniform buffer and binds blockName -> bindingPoint -> buffer. Keeping all
+// state in these tables lets the generated bind body stay a flat list of calls (no local buffer).
+// GL/WebGL2 blocks carry no layout(binding=), so the binding point is assigned host-side at flush.
+var private g_std140_staging : table<string; array<uint8>>
+var private g_std140_ubos : table<string; uint>
+
+// Resize the staging buffer for (program, blockName) to `size` bytes (the std140 block size, padded to
+// 16). Unwritten bytes are std140 padding the shader never reads, so they need no zeroing.
+def std140_reset(program : uint; blockName : string; size : int) {
+    let key = "{program}/{blockName}"
+    g_std140_staging[key] |> resize(size)
+}
+
+// memcpy a 32-bit scalar / vector / float4x4 field into the staging buffer at its std140 byte offset.
+// Mirrors dasVulkan's write_field; float3x3 / composites are repacked/recursed by the bind macro.
+def std140_set(program : uint; blockName : string; offset : uint; var value : auto(TT) const) {
+    let key = "{program}/{blockName}"
+    unsafe {
+        let dst = reinterpret<void?>(addr(g_std140_staging[key][int(offset)]))
+        memcpy(dst, reinterpret<void?>(addr(value)), typeinfo sizeof(type<TT>))
+    }
+}
+
+// Upload the staging buffer to a per-(program, block) GL uniform buffer (lazily created) and bind the
+// block to `bindingPoint`. glUniformBlockBinding wires the program's block to the point; glBindBufferRange
+// binds the buffer there.
+def std140_flush(program : uint; blockName : string; bindingPoint : int) {
+    let key = "{program}/{blockName}"
+    var ubo = g_std140_ubos?[key] ?? 0u
+    if (ubo == 0u) {
+        glGenBuffers(1, safe_addr(ubo))
+        g_std140_ubos[key] = ubo
+    }
+    glBindBuffer(GL_UNIFORM_BUFFER, ubo)
+    glBufferData(GL_UNIFORM_BUFFER, g_std140_staging[key], GL_DYNAMIC_DRAW)
+    let blockIndex = glGetUniformBlockIndex(program, blockName)
+    if (blockIndex != GL_INVALID_INDEX) {
+        let nbytes = int64(length(g_std140_staging[key]))
+        glUniformBlockBinding(program, blockIndex, uint(bindingPoint))
+        glBindBufferRange(GL_UNIFORM_BUFFER, uint(bindingPoint), ubo, int64(0), nbytes)
+    }
+}
+
 def glVertexAttribPointer(index : uint; size : int; tp : GLenum; normalized : bool; stride : int; offset : int) {
     unsafe {
         glVertexAttribPointer(index, size, tp, normalized, stride, reinterpret<void?> offset)

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -12,10 +12,12 @@ require spirv_builder
 require spirv_types
 require spirv_grammar
 require spirv_reflect
-require math
 require daslib/ast
 require daslib/rtti
 require daslib/ast_boost
+// public: dasVulkan's host binder reaches compute_block_layout / BlockField through spirv_emit (its
+// existing spelling), so re-export the shared std140 module to keep that consumer compiling unchanged.
+require daslib/shader_block_layout public
 
 // The shader stage drives the entry-point execution model + execution mode and which builtins
 // are legal. Vertex needs no execution mode; Fragment needs OriginUpperLeft; Compute needs LocalSize.
@@ -191,186 +193,6 @@ def private stage_name(stage : ShaderStage) : string {
     if (stage == ShaderStage.Mesh) return "mesh"
     if (stage == ShaderStage.Task) return "task"
     return "compute"
-}
-
-// ===== std140 layout for a UBO interface block =====
-// std140 base alignment: scalar -> 4, vec2 -> 8, vec3/vec4 -> 16. The base *size* of a vec3 is 12
-// (only its alignment is 16), so a scalar can pack into the trailing 4 bytes after a vec3.
-def private std140_align(bt : Type) : int {
-    let cc = component_count(bt)
-    if (cc == 1) return 4
-    if (cc == 2) return 8
-    return 16
-}
-
-def private std140_size(bt : Type) : int {
-    return component_count(bt) * 4
-}
-
-def private round_up(off, a : int) : int {
-    return ((off + a - 1) / a) * a
-}
-
-//! One std140-laid-out field of a @uniform / @push_constant interface block. Returned by
-//! compute_block_layout and consumed by host-side bind macros (e.g. dasVulkan's SpirvVulkanShader)
-//! to emit one write per field at the right byte offset. `is_matrix` just means "this field IS a
-//! matrix" (and gets MatrixStride 16 in SPIR-V) — it does NOT by itself imply the daslang storage
-//! and std140 layout differ. For float4x4 the columns are already vec4-wide so a single memcpy
-//! works; for float3x3 / float3x4 the daslang storage is packed (3-wide columns) while std140 pads
-//! each column to vec4, so bind code must repack per-column. **Use `matrix_width` to choose**:
-//! `matrix_width == 4` → safe to memcpy the field; `matrix_width < 4` → repack per column.
-//!
-//! **Composite fields** (`is_array` / `is_struct`) carry the std140 layout of nested data but
-//! cannot be written by a single host-side `write_field(ptr, offset, value)` call. Host bind
-//! macros should detect `is_composite` and either recurse member-by-member using the published
-//! `offset` + `array_stride` / nested layout, or skip with a clear "manual bind required" message.
-struct public BlockField {
-    name              : string //!< field name as declared in the daslang struct
-    offset            : int    //!< std140 byte offset from the block base
-    size              : int    //!< std140 base size of the field (matrices: 16 * cols; composites: total laid-out bytes)
-    is_matrix         : bool   //!< true if this field is a matrix (MatrixStride 16 in SPIR-V); see struct docstring re: repack
-    matrix_width      : int    //!< matrix column-vector width — 4 for float4x4 (memcpy-safe); 3 for float3x3/3x4 (per-column repack)
-    matrix_cols       : int    //!< matrix column count (only valid when is_matrix); 0 otherwise
-    is_array          : bool   //!< true if this field is a fixed-array (scalar / vector / nested-struct elements)
-    array_count       : int    //!< number of array elements (only valid when is_array)
-    array_stride      : int    //!< per-element byte stride (std140 rounds each element up to 16); 0 otherwise
-    is_struct         : bool   //!< the struct-element marker. True when the field is a nested struct (`is_array=false`) OR a fixed-array whose elements are nested structs (`is_array=true` — disambiguate via is_array). Host bind macros that handle composites recurse into the inner Structure via compute_block_layout in either case.
-    is_composite      : bool   //!< convenience flag — true when is_array OR is_struct (host bind macros can't write this with a flat overload)
-}
-
-// std140 element stride for a fixed-array element type. Scalars/vectors round up to vec4 (16 bytes);
-// nested-struct elements take their std140 struct-size rounded up to the struct alignment (which is
-// already a multiple of 16 by std140's struct rule). Matrix elements and nested-array elements are
-// out of PR-G scope and rejected by the caller before reaching here.
-def private std140_array_element_stride(bt : Type) : int {
-    return round_up(std140_size(bt), 16)
-}
-
-//! Compute the std140 layout of one interface block. Pure: takes a Structure?, fills `fields` with
-//! per-field offsets / sizes / matrix and composite flags, returns the block total size and max
-//! member alignment. Used by build_block_struct (SPIR-V type emit) and by host-side bind macros.
-//! Rejects bool and non-numeric fields fail-closed (no physical std140 layout). `sname` is only used
-//! in error messages. `fields` is cleared at entry so reuse across calls and partial-failure returns
-//! can't bleed. Supported field shapes (PR-G complete): 32-bit scalar / vector / matrix; nested
-//! struct (recursive); fixed-array of scalar / vector (std140 ArrayStride = element-size rounded to
-//! 16); fixed-array of nested struct (ArrayStride = laid-out struct size rounded to struct
-//! alignment). Out of scope (clean rejection): matrix-of-array, array-of-array, runtime arrays
-//! (use `@ssbo` for those).
-//! [macro_function]: callable from a backend's bind-gen macro at compile time, mirrors generate_spirv.
-[macro_function]
-def public compute_block_layout(sname : string; st : Structure?; var fields : array<BlockField>; var errors : array<string>) : tuple<ok : bool; size : int; align : int> {
-    fields |> clear
-    if (st == null || empty(st.fields)) {
-        errors |> push("interface block '{sname}' must be a struct with at least one field")
-        return (ok = false, size = 0, align = 0)
-    }
-    var off = 0
-    var max_align = 0
-    for (fld in st.fields) {
-        // matrix field (terminal)
-        let mi = matrix_info(fld._type)
-        if (mi.ok) {
-            off = round_up(off, 16)
-            fields |> emplace(BlockField(name := string(fld.name), offset = off, size = 16 * mi.cols,
-                is_matrix = true, matrix_width = mi.width, matrix_cols = mi.cols))
-            off += 16 * mi.cols
-            max_align = max(max_align, 16)
-            continue
-        }
-        // nested struct field (PR-G): recurse. Base alignment = round_up(inner_align, 16);
-        // size = round_up(inner_size, base_align). The inner field list isn't propagated up
-        // (host bind macros that recurse must re-invoke compute_block_layout on the nested
-        // Structure?). is_composite=true signals "no flat write_field overload exists".
-        if (fld._type != null && fld._type.baseType == Type.tStructure && fld._type.structType != null) {
-            var inner : array<BlockField>
-            let inner_layout = compute_block_layout("{sname}.{fld.name}", fld._type.structType, inner, errors)
-            delete inner
-            if (!inner_layout.ok) {
-                fields |> clear
-                return (ok = false, size = 0, align = 0)
-            }
-            let struct_align = round_up(inner_layout.align, 16)
-            off = round_up(off, struct_align)
-            let struct_size = round_up(inner_layout.size, struct_align)
-            fields |> emplace(BlockField(name := string(fld.name), offset = off, size = struct_size,
-                is_matrix = false, matrix_width = 0, matrix_cols = 0,
-                is_array = false, array_count = 0, array_stride = 0,
-                is_struct = true, is_composite = true))
-            off += struct_size
-            max_align = max(max_align, struct_align)
-            continue
-        }
-        // fixed-array field (PR-G): element kind decides stride. Scalar/vector elements stride by
-        // their size rounded up to 16 (the std140 array padding rule — every array slot is at
-        // least vec4-wide). Nested-struct elements stride by their laid-out struct size. Matrix
-        // elements and nested-array elements (array of array) are rejected; wrap in a struct.
-        if (fld._type != null && fld._type.baseType == Type.tFixedArray && fld._type.firstType != null) {
-            let et = fld._type.firstType
-            let nelem = fld._type.fixedDim
-            if (nelem <= 0) {
-                errors |> push("interface block '{sname}' field '{fld.name}': array must have positive count (got {nelem})")
-                fields |> clear
-                return (ok = false, size = 0, align = 0)
-            }
-            // scalar / vector element
-            if (et.baseType != Type.tStructure && et.baseType != Type.tFixedArray && !matrix_info(et).ok) {
-                let ebt = et.baseType
-                if (scalar_class(ebt) < 0) {
-                    errors |> push("interface block '{sname}' field '{fld.name}': array element type {ebt} is not supported (only 32-bit int/uint/float scalars, their vectors, or nested structs of those)")
-                    fields |> clear
-                    return (ok = false, size = 0, align = 0)
-                }
-                let stride = std140_array_element_stride(ebt)
-                off = round_up(off, 16)        // std140 array base alignment is 16
-                let total = stride * nelem
-                fields |> emplace(BlockField(name := string(fld.name), offset = off, size = total,
-                    is_matrix = false, matrix_width = 0, matrix_cols = 0,
-                    is_array = true, array_count = nelem, array_stride = stride,
-                    is_struct = false, is_composite = true))
-                off += total
-                max_align = max(max_align, 16)
-                continue
-            }
-            // array-of-struct element
-            if (et.baseType == Type.tStructure && et.structType != null) {
-                var inner : array<BlockField>
-                let inner_layout = compute_block_layout("{sname}.{fld.name}[]", et.structType, inner, errors)
-                delete inner
-                if (!inner_layout.ok) {
-                    fields |> clear
-                    return (ok = false, size = 0, align = 0)
-                }
-                let struct_align = round_up(inner_layout.align, 16)
-                let stride = round_up(inner_layout.size, struct_align)
-                off = round_up(off, struct_align)
-                let total = stride * nelem
-                fields |> emplace(BlockField(name := string(fld.name), offset = off, size = total,
-                    is_matrix = false, matrix_width = 0, matrix_cols = 0,
-                    is_array = true, array_count = nelem, array_stride = stride,
-                    is_struct = true, is_composite = true))
-                off += total
-                max_align = max(max_align, struct_align)
-                continue
-            }
-            errors |> push("interface block '{sname}' field '{fld.name}': array element type {et.baseType} is not supported (only scalar/vector or nested-struct elements; matrix-of-array and array-of-array are out of scope)")
-            fields |> clear
-            return (ok = false, size = 0, align = 0)
-        }
-        // terminal scalar / vector field
-        let fbt = fld._type.baseType
-        if (scalar_class(fbt) < 0) {
-            errors |> push("interface block '{sname}' field '{fld.name}': type {fbt} is not supported (only 32-bit int/uint/float scalars, their vectors, matrices, fixed-arrays of those, and nested structs of those; bool has no physical interface-block layout in Vulkan)")
-            fields |> clear
-            return (ok = false, size = 0, align = 0)
-        }
-        let falign = std140_align(fbt)
-        off = round_up(off, falign)
-        fields |> emplace(BlockField(name := string(fld.name), offset = off, size = std140_size(fbt),
-            is_matrix = false, matrix_width = 0, matrix_cols = 0))
-        off += std140_size(fbt)
-        max_align = max(max_align, falign)
-    }
-    return (ok = true, size = off, align = max_align)
 }
 
 // Build a laid-out interface struct from a daslang struct's fields. Supported member shapes:
@@ -1151,14 +973,6 @@ def private atomic_info(name : string; cls : int) : tuple<ok : bool; op : SpvOp;
 }
 
 // ===== arithmetic opcode selection =====
-// 0 = signed int, 1 = unsigned int, 2 = float, -1 = other. Vectors classify by their lane kind
-// (IAdd/FAdd/… operate component-wise on vectors with the same opcode as the scalar).
-def private scalar_class(bt : Type) : int {
-    if (bt == Type.tInt || bt == Type.tInt2 || bt == Type.tInt3 || bt == Type.tInt4) return 0
-    if (bt == Type.tUInt || bt == Type.tUInt2 || bt == Type.tUInt3 || bt == Type.tUInt4) return 1
-    if (bt == Type.tFloat || bt == Type.tFloat2 || bt == Type.tFloat3 || bt == Type.tFloat4) return 2
-    return -1
-}
 
 // A scalar type-name used as a conversion call (float(x)/int(x)/uint(x)). Returns the destination
 // scalar class (0 signed / 1 unsigned / 2 float) or -1 if `name` is not a scalar type name. The
@@ -1251,15 +1065,6 @@ def private cmp_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> {
         if (cls == 1) return (ok = true, code = SpvOp.UGreaterThanEqual)
     }
     return (ok = false, code = SpvOp.Nop)
-}
-
-// number of scalar lanes in a type (scalar = 1, vecN = N, anything else = 0/unknown).
-def private component_count(bt : Type) : int {
-    if (bt == Type.tInt || bt == Type.tUInt || bt == Type.tFloat || bt == Type.tBool) return 1
-    if (bt == Type.tInt2 || bt == Type.tUInt2 || bt == Type.tFloat2) return 2
-    if (bt == Type.tInt3 || bt == Type.tUInt3 || bt == Type.tFloat3) return 3
-    if (bt == Type.tInt4 || bt == Type.tUInt4 || bt == Type.tFloat4) return 4
-    return 0
 }
 
 // vector constructor name (float2/3/4, int2/3/4, uint2/3/4) -> lane count + component class

--- a/modules/dasSpirv/spirv/spirv_types.das
+++ b/modules/dasSpirv/spirv/spirv_types.das
@@ -9,18 +9,7 @@ module spirv_types shared public
 
 require spirv_builder
 require daslib/ast
-
-// daslang matrices are handled (tHandle) types named float<W>x<C> — W = column-vector width,
-// C = column count (MatrixAnnotation<floatW, C>, column-major: m[i] is column i). Returns the
-// dimensions so emit_type / the std140 layout / matrix arithmetic can treat them structurally.
-def public matrix_info(t : TypeDecl?) : tuple<ok : bool; width : int; cols : int> {
-    if (t == null || t.baseType != Type.tHandle || t.annotation == null) return (ok = false, width = 0, cols = 0)
-    let nm = "{t.annotation.name}"
-    if (nm == "float4x4") return (ok = true, width = 4, cols = 4)
-    if (nm == "float3x3") return (ok = true, width = 3, cols = 3)
-    if (nm == "float3x4") return (ok = true, width = 3, cols = 4)
-    return (ok = false, width = 0, cols = 0)
-}
+require daslib/shader_block_layout
 
 def public emit_type(var m : SpirvModule; t : TypeDecl?) : uint {
     if (t == null) {

--- a/tests/glsl/test_lingua_franca_annotations.das
+++ b/tests/glsl/test_lingua_franca_annotations.das
@@ -2,26 +2,31 @@ options gen2
 options indenting = 4
 options no_unused_function_arguments = false
 
-// Emission gate for Phase 2 of the dasOpenGL <-> dasVulkan harmonization arc: the GL generator now
-// ACCEPTS the Vulkan-style @-annotations and maps them to GL semantics via the existing loose-uniform
-// binder. A shader authored exactly like a dasVulkan shader compiles + emits on the GL rail:
-//   - @uniform struct  -> `uniform StructType name;` (a GLSL struct uniform); fields bound loose
-//   - @push_constant   -> a GL uniform (GL has no push constants), NOT a dead zero-init global
+// Emission gate for Phase 2 of the dasOpenGL <-> dasVulkan harmonization arc: the GL generator ACCEPTS
+// the Vulkan-style @-annotations and maps them to GL semantics. A shader authored exactly like a
+// dasVulkan shader compiles + emits on the GL rail:
+//   - @uniform / @push_constant struct, fields all flat -> a std140 UBO block, `layout(std140) uniform
+//     <name>_ubo { ... } <name>;`, bound via std140_reset/set/flush (the GL/WebGL2 portable floor)
+//   - @uniform struct with a float3x3 / composite field -> graceful loose fallback `uniform Struct name;`
+//     (the std140 pack binder doesn't repack mat3 / recurse composites yet); fields bound by name
+//   - @push_constant   -> packed/loose like @uniform (GL has no push constants), NOT a dead global
 //   - @set             -> ignored (GL has one implicit descriptor set)
 //   - @binding         -> tolerated
 //   - @out @location in the vertex stage -> a real `out` varying
 //
 // Dummy host-bind stubs keep this suite free of opengl/opengl_boost (see test_lingua_franca_textures.das):
-// the struct uniform's generated bind flattens to glUniformAny(loc, name.field) per leaf field, so the
-// only stubs needed are glGetUniformLocation + the float4x4 glUniformAny. Asserts the emitted GLSL only.
+// the packed blocks' bind calls std140_reset/set/flush; the loose-fallback block flattens to
+// glUniformAny(loc, name.field) per leaf (float3x3 / float4 here). Asserts the emitted GLSL only.
 
 require dastest/testing_boost public
 require glsl/glsl_opengl
 require math
 require strings
 
+[unused_argument(program, blockName, size)] def std140_reset(program : uint; blockName : string; size : int) {}
+[unused_argument(program, blockName, offset, value)] def std140_set(program : uint; blockName : string; offset : uint; value) {}
+[unused_argument(program, blockName, bindingPoint)] def std140_flush(program : uint; blockName : string; bindingPoint : int) {}
 [unused_argument(program, name)] def glGetUniformLocation(program : uint; name : string) : int { return 0 }
-[unused_argument(location, value)] def glUniformAny(location : int; value : float4x4) {}
 [unused_argument(location, value)] def glUniformAny(location : int; value : float3x3) {}
 [unused_argument(location, value)] def glUniformAny(location : int; value : float4) {}
 
@@ -73,12 +78,12 @@ def private has(hay, needle : string) : bool => find(hay, needle) >= 0
 
 [test]
 def test_lingua_franca_annotations(t : T?) {
-    t |> run("@uniform struct lowers to a GLSL struct uniform") <| @(t : T?) {
-        t |> success(has(vk_ann_vs, "uniform VkCamera vk_cam"), "emits `uniform VkCamera vk_cam`")
+    t |> run("@uniform struct (all-flat fields) packs as a std140 UBO block") <| @(t : T?) {
+        t |> success(has(vk_ann_vs, "layout(std140) uniform vk_cam_ubo"), "emits `layout(std140) uniform vk_cam_ubo`")
     }
-    t |> run("@push_constant maps to a GL uniform, not a dead global") <| @(t : T?) {
-        t |> success(has(vk_ann_vs, "uniform VkModelPC vk_pc") && !has(vk_ann_vs, "VkModelPC vk_pc ="),
-            "emits `uniform VkModelPC vk_pc;` with no zero-initializer")
+    t |> run("@push_constant packs/binds like a UBO, not a dead global (GL has no push constants)") <| @(t : T?) {
+        t |> success(has(vk_ann_vs, "layout(std140) uniform vk_pc_ubo") && !has(vk_ann_vs, "vk_pc ="),
+            "emits `layout(std140) uniform vk_pc_ubo` with no zero-initializer")
     }
     t |> run("@out @location in the vertex stage emits a real out varying") <| @(t : T?) {
         t |> success(has(vk_ann_vs, "out vec3 vk_v_nrm"), "emits `out vec3 vk_v_nrm`")

--- a/tests/glsl/test_lingua_franca_annotations.das
+++ b/tests/glsl/test_lingua_franca_annotations.das
@@ -5,18 +5,17 @@ options no_unused_function_arguments = false
 // Emission gate for Phase 2 of the dasOpenGL <-> dasVulkan harmonization arc: the GL generator ACCEPTS
 // the Vulkan-style @-annotations and maps them to GL semantics. A shader authored exactly like a
 // dasVulkan shader compiles + emits on the GL rail:
-//   - @uniform / @push_constant struct, fields all flat -> a std140 UBO block, `layout(std140) uniform
-//     <name>_ubo { ... } <name>;`, bound via std140_reset/set/flush (the GL/WebGL2 portable floor)
-//   - @uniform struct with a float3x3 / composite field -> graceful loose fallback `uniform Struct name;`
-//     (the std140 pack binder doesn't repack mat3 / recurse composites yet); fields bound by name
-//   - @push_constant   -> packed/loose like @uniform (GL has no push constants), NOT a dead global
+//   - @uniform / @push_constant struct -> a std140 UBO block, `layout(std140) uniform <name>_ubo
+//     { ... } <name>;`, bound via std140_reset/set/flush (the GL/WebGL2 portable floor). float3x3 /
+//     fixed-arrays / nested structs / arrays-of-struct all pack -- the shared std140 walk
+//     (shader_block_layout) decomposes them into per-column / per-element / nested leaf writes.
+//   - @push_constant   -> packs like @uniform (GL has no push constants), NOT a dead global
 //   - @set             -> ignored (GL has one implicit descriptor set)
 //   - @binding         -> tolerated
 //   - @out @location in the vertex stage -> a real `out` varying
 //
 // Dummy host-bind stubs keep this suite free of opengl/opengl_boost (see test_lingua_franca_textures.das):
-// the packed blocks' bind calls std140_reset/set/flush; the loose-fallback block flattens to
-// glUniformAny(loc, name.field) per leaf (float3x3 / float4 here). Asserts the emitted GLSL only.
+// every packed block's bind calls std140_reset/set/flush by bare name. Asserts the emitted GLSL only.
 
 require dastest/testing_boost public
 require glsl/glsl_opengl
@@ -26,9 +25,6 @@ require strings
 [unused_argument(program, blockName, size)] def std140_reset(program : uint; blockName : string; size : int) {}
 [unused_argument(program, blockName, offset, value)] def std140_set(program : uint; blockName : string; offset : uint; value) {}
 [unused_argument(program, blockName, bindingPoint)] def std140_flush(program : uint; blockName : string; bindingPoint : int) {}
-[unused_argument(program, name)] def glGetUniformLocation(program : uint; name : string) : int { return 0 }
-[unused_argument(location, value)] def glUniformAny(location : int; value : float3x3) {}
-[unused_argument(location, value)] def glUniformAny(location : int; value : float4) {}
 
 struct VkCamera {
     view : float4x4
@@ -50,10 +46,9 @@ def vk_ann_vertex {
     vk_v_nrm = vk_a_pos
 }
 
-// The loose struct binder covers a nested struct + mat3 + array-of-struct (the deferred-tut UBO
-// shape): the generated bind flattens each leaf field by name -- vk_mat.normal_mat (mat3),
-// vk_mat.base_color, vk_mat.lights[0].pos/.color, vk_mat.lights[1].pos/.color -- so a shader using
-// such a uniform compiles (the bind resolves the float3x3 / float4 stubs above).
+// A nested struct + mat3 + array-of-struct (the deferred-tut UBO shape) ALSO packs std140: the shared
+// std140 walk emits per-column writes for normal_mat (float3x3) and per-element writes for lights[]
+// (array of struct), so it is a layout(std140) UBO block like the flat ones above.
 struct VkLight {
     pos   : float4
     color : float4
@@ -66,9 +61,10 @@ struct VkMaterial {
 var @uniform vk_mat : VkMaterial
 var @out @location = 0 vk_lit : float4
 
-// vk_mat is collected by USING any field; the bind then flattens EVERY field (incl normal_mat /
-// lights[]) -- so the mat3 + array-of-struct bind paths are exercised without the body needing a
-// matrix-column index (`normal_mat[0]` trips a no-opt bounds-check the GLSL emitter rejects).
+// vk_mat is collected by USING any field; the block then declares EVERY field (incl normal_mat /
+// lights[]) and the std140 walk packs them all. The body avoids a matrix-column index
+// (`normal_mat[0]` trips a no-opt bounds-check the GLSL emitter rejects) -- the mat3 is repacked
+// host-side per column, not read column-wise in the shader.
 [fragment_program(name="vk_mat_fs")]
 def vk_mat_fragment {
     vk_lit = vk_mat.base_color + vk_mat.lights[0].color + vk_mat.lights[1].color
@@ -91,11 +87,11 @@ def test_lingua_franca_annotations(t : T?) {
     t |> run("Vulkan @set / @binding are tolerated on the GL rail") <| @(t : T?) {
         t |> success(has(vk_ann_vs, "void main"), "the VK-annotated shader emitted a body")
     }
-    t |> run("loose binder: nested struct uniform with a mat3 field") <| @(t : T?) {
-        t |> success(has(vk_mat_fs, "uniform VkMaterial vk_mat") && has(vk_mat_fs, "mat3 normal_mat"),
-            "emits the VkMaterial struct uniform with a mat3 member (shader compiled => bind flattened)")
+    t |> run("std140 pack: a nested struct + mat3 block packs as a UBO") <| @(t : T?) {
+        t |> success(has(vk_mat_fs, "layout(std140) uniform vk_mat_ubo") && has(vk_mat_fs, "mat3 normal_mat"),
+            "emits `layout(std140) uniform vk_mat_ubo` with a mat3 member (per-column packed host-side)")
     }
-    t |> run("loose binder: array-of-struct uniform field flattens") <| @(t : T?) {
+    t |> run("std140 pack: an array-of-struct field stays in the block") <| @(t : T?) {
         t |> success(has(vk_mat_fs, "VkLight lights[2]"), "emits the VkLight lights[2] array member")
     }
 }

--- a/tests/glsl/test_std140_uniforms.das
+++ b/tests/glsl/test_std140_uniforms.das
@@ -1,0 +1,66 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+
+// Emission gate for std140 UBO packing (Phase 2 / D5 of the dasOpenGL <-> dasVulkan harmonization). A
+// struct @uniform / @push_constant packs as a `layout(std140) uniform <instance>_ubo { fields }
+// <instance>;` interface block (the GL/WebGL2 portable floor) instead of a free `uniform Struct name;`.
+// The generated <shader>_bind_uniform calls std140_reset / std140_set / std140_flush by BARE name
+// (resolved in the consumer's opengl_boost chain), so the local dummy stubs below keep this suite free
+// of opengl/opengl_boost and its GL-runtime AOT surface, exactly like the sampler test. The test
+// asserts only the emitted GLSL string (not the host bind), so the dummies are inert stand-ins.
+
+require dastest/testing_boost public
+require glsl/glsl_opengl
+require math
+require strings
+
+// Host-bind dummies (see header): the generated std140 bind body calls these by name.
+[unused_argument(program, blockName, size)] def std140_reset(program : uint; blockName : string; size : int) {}
+[unused_argument(program, blockName, offset, value)] def std140_set(program : uint; blockName : string; offset : uint; value) {}
+[unused_argument(program, blockName, bindingPoint)] def std140_flush(program : uint; blockName : string; bindingPoint : int) {}
+
+struct SceneUniforms {
+    model     : float4x4
+    tint      : float4
+    intensity : float
+}
+
+var @uniform u_scene : SceneUniforms
+var @in @location u_pos : float3
+var @out u_color : float4
+
+[vertex_program(name="ubo_vs_glsl")]
+def ubo_vertex {
+    gl_Position = u_scene.model * float4(u_pos, 1.0)
+}
+
+[fragment_program(name="ubo_fs_glsl")]
+def ubo_fragment {
+    u_color = u_scene.tint * u_scene.intensity
+}
+
+def private has(hay, needle : string) : bool => find(hay, needle) >= 0
+
+[test]
+def test_std140_uniforms(t : T?) {
+    t |> run("a struct @uniform packs as a std140 interface block") <| @(t : T?) {
+        t |> success(has(ubo_vs_glsl, "layout(std140) uniform"), "vertex emits a layout(std140) uniform block")
+    }
+    t |> run("the block name is <instance>_ubo, not the struct type name") <| @(t : T?) {
+        t |> success(has(ubo_vs_glsl, "uniform u_scene_ubo"), "block is named u_scene_ubo")
+    }
+    t |> run("the std140 block declares its fields inline") <| @(t : T?) {
+        t |> success(has(ubo_vs_glsl, "mat4 model") && has(ubo_vs_glsl, "vec4 tint") && has(ubo_vs_glsl, "float intensity"),
+            "block declares mat4 model / vec4 tint / float intensity")
+    }
+    t |> run("the block instance keeps the daslang global's name") <| @(t : T?) {
+        t |> success(has(ubo_vs_glsl, "} u_scene;"), "block instance is u_scene")
+    }
+    t |> run("the shader body reads fields through the instance") <| @(t : T?) {
+        t |> success(has(ubo_vs_glsl, "u_scene.model"), "body reads u_scene.model")
+    }
+    t |> run("the fragment stage shares the same block (the linker merges it)") <| @(t : T?) {
+        t |> success(has(ubo_fs_glsl, "layout(std140) uniform u_scene_ubo"), "fragment also declares u_scene_ubo")
+    }
+}


### PR DESCRIPTION
Phase 2 (D5) of the dasOpenGL ↔ dasVulkan shader harmonization: a struct `@uniform` / `@push_constant` on the GL rail now packs as a std140 UBO by default — the GL/WebGL2 portable floor, byte-for-byte with the Vulkan rail — instead of binding loose per-field via `glUniform`.

### Three commits

1. **`spirv`: extract std140 block layout to shared `daslib/shader_block_layout`** — `compute_block_layout` + `BlockField` + the `matrix_info` / `scalar_class` / `std140_*` helper cluster move out of dasSpirv into a new shared daslib module, so every shader backend's uniform binder computes byte offsets from one source of truth. `spirv_emit` re-exports it, so dasVulkan's host binder keeps compiling unchanged via its existing `require spirv/spirv_emit` spelling — additive, no externals-first ordering. Behavior-preserving: SPIR-V goldens byte-identical, tests/spirv 166/166, dasVulkan integration smoke 24/24.

2. **`opengl`: pack struct `@uniform` blocks as std140 UBOs** — a struct uniform lowers to `layout(std140) uniform <name>_ubo { … } <name>;` (no `layout(binding=)`, so it's ES3.00 / WebGL2-clean and bound host-side), with a per-instance block name distinct from the struct type. New `std140_reset` / `std140_set` / `std140_flush` in opengl_boost own a per-(program, block) staging buffer + GL uniform buffer and bind via `glUniformBlockBinding` + `glBindBufferRange` (the GL analogue of dasVulkan's `write_field` / `with_mapped_memory`). A shared `std140_block_is_packable` predicate is consulted by **both** the emitter and the binder so they always agree on which blocks pack.

3. **`opengl/spirv`: shared std140 layout-walk, pack mat3 + composites** — `std140_block_writes` decomposes a block into a flat list of leaf scalar/vector writes: `float3x3` / `float3x4` → per-column (column `c` at `offset + c*16`; daslang stores width-wide packed columns and std140 pads each to a vec4, so the per-column memcpy gives that padding for free), `float4x4` → one whole write, fixed-arrays → per-element, nested structs → recurse. Both rails drive the same walk, so a UBO packs byte-identically by construction with no per-backend matrix/array/nesting logic.

### Validation

The std140 pack renders the **identical pixel `(51,102,153)`** on **desktop GL, WebGL2 (Playwright), and Vulkan** — a fragment reading a mat3 column + an array element + a nested-struct field at non-trivial offsets, with decoy values elsewhere proving the offsets.

- tests/glsl **34/34** (`test_std140_uniforms` + a reworked `test_lingua_franca_annotations` whose `VkMaterial` — mat3 + array-of-struct — now asserts the pack form)
- tests/spirv 166/166 · SPIR-V goldens zero-drift · JIT smoke clean
- dasVulkan integration 24/24 + tutorials 15/15 (the shared-layout extraction is the only shared-surface change)
- lint 0 / format clean / das2rst regen zero-diff on all changed `.das`

### Companion + follow-ups

A companion dasVulkan change (branch `bbatkin/std140-shared-walk`) routes its host binder through the same walk, which **fixes a latent mat3/composite mis-pack** there (its old flat `write_field`-per-field memcpy'd a `float3x3` as 36 packed bytes into the 48-byte std140 slot; latent because every dasVulkan UBO test/tutorial used only flat scalar/vector/`float4x4`). It depends on this PR's walker, so it lands after this one.

Known follow-ups (not in this PR): the dasVulkan push-constants path raw-uploads the daslang struct (same daslang≠std140 class, needs its own std140 staging buffer); dogfooding a GL tutorial onto a UBO; suppressing the now-dead standalone UBO-struct GLSL decl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)