### PR TITLE
Add '\0' to buffers in das_get_root and das_error_report

### DIFF
--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -233,6 +233,8 @@ int das_fileaccess_is_locked ( das_file_access * access ) {
 void das_get_root ( char * root, int maxbuf ) {
     auto r = getDasRoot();
     strncpy ( root, r.c_str(), maxbuf );
+    if (maxbuf > 0)
+        root[maxbuf - 1] = 0;
 }
 
 das_program * das_program_compile ( char * program_file, das_file_access * access, das_text_writer * tout, das_module_group * libgroup ) {
@@ -436,6 +438,8 @@ void das_error_report ( das_error * error, char * text, int maxLength ) {
     auto err = (Error *) error;
     auto str = reportError(err->at, err->what, err->extra, err->fixme, err->cerr );
     strncpy(text, str.c_str(), maxLength);
+    if (maxLength > 0)
+        text[maxLength - 1] = 0;
 }
 
 das_module * das_module_create ( char * name ) {


### PR DESCRIPTION
Ensure null termination for root and error text buffers in C-binding