### PR TITLE
opengl: std140 UBO buffer release + dogfood the UBO pack in 04_cube

### DIFF
--- a/doc/source/tutorials/opengl/04_cube.rst
+++ b/doc/source/tutorials/opengl/04_cube.rst
@@ -5,8 +5,9 @@ The first **3D-geometry** rung. After three fullscreen-fragment tutorials, this
 one draws an actual mesh: a textured, lit, breathing cube spinning while the
 camera orbits it. It introduces everything 01-03 skipped -- a real vertex buffer
 with per-vertex ``(pos, normal, uv)``, the model / view / projection matrix chain
-(``mat4`` uniforms built host-side with ``daslib/math_boost``), depth testing +
-back-face culling, and a texture sampled in the fragment shader.
+(built host-side with ``daslib/math_boost`` and packed into a **std140 uniform
+block**), depth testing + back-face culling, and a texture sampled in the fragment
+shader.
 
 It is a faithful port of the dasVulkan rung, with the same look: the cube wears a
 procedural **synthwave horizon** texture -- a deep-purple-to-magenta sky with a
@@ -28,10 +29,35 @@ wires the interleaved ``(pos, normal, uv)`` layout to the three ``@in @location`
 attributes by declaration order. The vertex shader transforms the position by
 ``proj * view * model`` and writes the world-space position and normal as
 varyings; ``update()`` rebuilds the three matrices every frame with
-``look_at_rh`` / ``perspective_rh_opengl`` / a quaternion ``compose``, uploaded as
-``float4x4`` uniforms. ``glEnable(GL_DEPTH_TEST)`` plus a ``GL_DEPTH_BUFFER_BIT``
-clear keep the back faces hidden (the default clear-depth of 1.0 needs no explicit
-``glClearDepth`` -- which is desktop-only anyway; GLES uses ``glClearDepthf``).
+``look_at_rh`` / ``perspective_rh_opengl`` / a quaternion ``compose``.
+``glEnable(GL_DEPTH_TEST)`` plus a ``GL_DEPTH_BUFFER_BIT`` clear keep the back
+faces hidden (the default clear-depth of 1.0 needs no explicit ``glClearDepth`` --
+which is desktop-only anyway; GLES uses ``glClearDepthf``).
+
+The camera uniform block
+------------------------
+
+The matrices and lighting constants are not separate uniforms -- they live in one
+``struct Camera`` declared ``@uniform``::
+
+    struct Camera {
+        model   : float4x4
+        view    : float4x4
+        proj    : float4x4
+        cam_pos : float3
+        time    : float
+    }
+    var @uniform u_cam : Camera
+
+dasGlsl lowers that to a ``layout(std140) uniform u_cam_ubo { ... } u_cam;``
+interface block and the host bind uploads it through a single **uniform buffer**,
+the GL/WebGL2-portable way to feed a shader a block of constants -- and the same
+std140 path the dasVulkan rail uses, so the byte layout matches across both
+backends. ``std140`` is a fixed cross-vendor packing rule, which is why
+``cam_pos`` (a ``float3``) sitting right before ``time`` (a ``float``) lands at the
+correct offsets even though their natural alignments differ; the host and shader
+agree on the layout because they derive it from the same struct. The sampler
+``u_tex`` stays a plain ``uniform sampler2D`` -- opaque types can't live in a UBO.
 
 The texture
 -----------
@@ -40,16 +66,19 @@ The texture
 ``array<uint8>`` -- pure arithmetic per pixel, no asset -- and
 ``load_image_from_bytes`` uploads it via ``glTexImage2D``. On the web this is the
 first texture to cross into WebGL2: the CPU-generated pixels upload through the
-same generated gl-call wrappers, and the ``mat4`` uniforms through
-``glUniformMatrix4fv``, with no special-casing.
+same generated gl-call wrappers, and the camera block through the WebGL2
+uniform-buffer calls (``glBindBufferRange`` / ``glUniformBlockBinding``), with no
+special-casing.
 
 The fragment lighting
 ---------------------
 
 ``fs_main`` normalizes the interpolated world normal, computes a warm key light
 with an ambient floor and a cool-cyan rim term from the view direction, scrolls
-the UV by ``u_time``, samples the texture, and combines. The camera world
-position (for the rim) and the time (for the scroll) are plain uniforms.
+the UV by ``u_cam.time``, samples the texture, and combines. The camera world
+position (for the rim) and the time (for the scroll) are read as fields of the
+same ``u_cam`` block the vertex stage uses -- the linker merges the two stages'
+declarations into one buffer binding.
 
 Run it
 ------

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -145,6 +145,15 @@ def public live_get_framebuffer_size(var width, height : int&) {
 
 // --- Window preservation across reloads ---
 
+// Free std140 UBO buffers before the render context is torn down for a reload. opengl_boost tracks
+// them in render-context tables holding raw GL handles the GC can't see; the reload frees the tables
+// but not the buffers, so each reload would otherwise orphan one buffer set per (program, block). The
+// preserved GL context is still current here, so glDeleteBuffers is valid.
+[before_reload]
+def release_std140_ubos() {
+    std140_release_all()
+}
+
 [before_reload]
 def save_glfw_window() {
     if (live_window != null) {

--- a/modules/dasOpenGL/opengl/opengl_boost.das
+++ b/modules/dasOpenGL/opengl/opengl_boost.das
@@ -10,6 +10,7 @@ require opengl/opengl public
 require daslib/safe_addr
 require daslib/contracts
 require daslib/array_boost
+require daslib/strings_boost
 
 require glsl/glsl_opengl public
 
@@ -226,6 +227,39 @@ def std140_flush(program : uint; blockName : string; bindingPoint : int) {
         glUniformBlockBinding(program, blockIndex, uint(bindingPoint))
         glBindBufferRange(GL_UNIFORM_BUFFER, uint(bindingPoint), ubo, int64(0), nbytes)
     }
+}
+
+// Delete the GL uniform buffer + CPU staging entry for every std140 block owned by `program`. Call
+// when a program is deleted (e.g. an app that recompiles shaders at runtime) so its per-(program,
+// block) UBO buffers don't leak. g_std140_* hold raw GL handles the GC can't see, so they must be
+// released explicitly, and from the SAME context that ran the bind (these tables are render-context
+// state, not the opengl_cache agent context). Block keys are "program/block", so an exact "program/"
+// prefix selects this program's entries without matching e.g. "12/" for program 1.
+def std140_release(program : uint) {
+    let prefix = "{program}/"
+    var stale <- [for (key in keys(g_std140_staging)); key; where key |> starts_with(prefix)]
+    for (key in stale) {
+        var ubo = g_std140_ubos?[key] ?? 0u
+        if (ubo != 0u) {
+            glDeleteBuffers(1, safe_addr(ubo))
+        }
+        g_std140_ubos |> erase(key)
+        g_std140_staging |> erase(key)
+    }
+    delete stale
+}
+
+// Delete ALL std140 UBO buffers + staging entries in the current context. Call on teardown or before
+// a live reload (glfw_live does, via [before_reload]): the render context is about to be destroyed,
+// which frees these tables but NOT the GL buffers they reference, so without this every reload
+// orphans one buffer set per (program, block). Safe to call when nothing was allocated (no-op).
+def std140_release_all() {
+    for (ubo in values(g_std140_ubos)) {
+        var b = ubo
+        glDeleteBuffers(1, safe_addr(b))
+    }
+    delete g_std140_ubos
+    delete g_std140_staging
 }
 
 def glVertexAttribPointer(index : uint; size : int; tp : GLenum; normalized : bool; stride : int; offset : int) {

--- a/tutorials/opengl/04_cube/04_cube.das
+++ b/tutorials/opengl/04_cube/04_cube.das
@@ -10,9 +10,14 @@ require daslib/safe_addr
 // The first 3D-geometry rung. A textured, lit, breathing cube spins while the
 // camera orbits it. This introduces the pieces the fullscreen-fragment rungs
 // (01-03) skipped: a real vertex buffer with per-vertex (pos, normal, uv), the
-// model / view / projection matrix chain (mat4 uniforms built host-side with
-// daslib/math_boost), depth testing + back-face culling, and a texture sampled
-// in the fragment shader.
+// model / view / projection matrix chain (mat4s built host-side with
+// daslib/math_boost and packed into a std140 uniform block), depth testing +
+// back-face culling, and a texture sampled in the fragment shader.
+//
+// The matrices + lighting params live in one `struct Camera` declared `@uniform`:
+// dasGlsl lowers it to a `layout(std140) uniform` interface block and the host
+// uploads it through a single uniform buffer, the GL/WebGL2-portable way to feed
+// a shader a block of constants (and the same std140 path the dasVulkan rail uses).
 //
 // A faithful port of the dasVulkan rung (same look): the cube wears a procedural
 // "synthwave horizon" texture -- deep-purple-to-magenta sky with a banded neon
@@ -27,11 +32,20 @@ require daslib/safe_addr
 var @in @location a_pos : float3
 var @in @location a_normal : float3
 var @in @location a_uv : float2
-var @uniform u_model : float4x4
-var @uniform u_view : float4x4
-var @uniform u_proj : float4x4
-var @uniform u_cam_pos : float3
-var @uniform u_time : float
+
+// The camera's per-frame transform + lighting params, packed into one std140 UBO. A struct @uniform
+// emits a `layout(std140) uniform u_cam_ubo { ... } u_cam;` interface block (the GL/WebGL2 portable
+// floor) and the host bind uploads it through a single uniform-buffer, instead of one glUniform* call
+// per field. cam_pos (float3) sits right before time (float) on purpose: that float3-then-scalar pair
+// is the case naive packing gets wrong, and exercises the std140 layout walk's per-field offsets.
+struct Camera {
+    model   : float4x4
+    view    : float4x4
+    proj    : float4x4
+    cam_pos : float3
+    time    : float
+}
+var @uniform u_cam : Camera
 var @uniform u_tex : sampler2D
 var @inout w_pos : float3
 var @inout w_normal : float3
@@ -40,24 +54,24 @@ var @out f_FragColor : float4
 
 [vertex_program]
 def vs_main {
-    let world = u_model * float4(a_pos, 1.0)
-    gl_Position = u_proj * u_view * world
+    let world = u_cam.model * float4(a_pos, 1.0)
+    gl_Position = u_cam.proj * u_cam.view * world
     w_pos = world.xyz
     // model is rotation + uniform scale only, so a (normal, 0) multiply transforms
     // the normal correctly without an inverse-transpose.
-    w_normal = (u_model * float4(a_normal, 0.0)).xyz
+    w_normal = (u_cam.model * float4(a_normal, 0.0)).xyz
     w_uv = a_uv
 }
 
 [fragment_program]
 def fs_main {
     let n = normalize(w_normal)
-    let v = normalize(u_cam_pos - w_pos)
+    let v = normalize(u_cam.cam_pos - w_pos)
     let l = normalize(float3(0.5, 1.0, 0.3))            // warm key light from above-front
     let key = max(dot(n, l), 0.0) * 0.7 + 0.3            // ambient floor 0.3
     let rim = pow(1.0 - max(dot(n, v), 0.0), 2.0)        // silhouette glow
     let rim_color = float3(0.4, 0.6, 1.0)                // cool cyan
-    let scrolled = float2(w_uv.x, w_uv.y + u_time * 0.05)
+    let scrolled = float2(w_uv.x, w_uv.y + u_cam.time * 0.05)
     let albedo = texture(u_tex, scrolled).xyz
     let lit = albedo * key + rim_color * rim
     f_FragColor = float4(lit, 1.0)
@@ -231,11 +245,11 @@ def update : bool {
     // breathing scale + tumble about a tilted axis
     let breathe = 1.0 + 0.05 * sin(t * 2.0)
     let rot = quat_from_unit_vec_ang(normalize(float3(1.0, 1.0, 0.0)), t * 0.6)
-    u_model = compose(float3(0, 0, 0), rot, float3(breathe))
-    u_view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 50.0)
-    u_cam_pos = cam_pos
-    u_time = t
+    u_cam.model = compose(float3(0, 0, 0), rot, float3(breathe))
+    u_cam.view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
+    u_cam.proj = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 50.0)
+    u_cam.cam_pos = cam_pos
+    u_cam.time = t
 
     glViewport(0, 0, display_w, display_h)
     glClearColor(0.02, 0.01, 0.05, 1.0)


### PR DESCRIPTION
Two follow-ups to the std140 UBO pack binder (#3273).

## 1. Release std140 UBO buffers on teardown / live-reload
The pack binder tracks a per-`(program, block)` GL uniform buffer + CPU staging entry in `opengl_boost`'s render-context tables, but nothing ever deleted the GL buffers — so repeated program creation / live-reload leaked one buffer set per `(program, block)`.

- Add `std140_release(program)` (free one program's blocks) and `std140_release_all()` (free everything) to `opengl_boost`, operating on the current/render context.
- Hook `std140_release_all()` into a new `glfw_live` `[before_reload]` handler: the reload frees the daslang tables but not the GL buffers they reference, and the preserved GL context is still current there.

`reset_opengl_cache` is **not** the right hook despite being the program-delete path — it runs in the `opengl_cache` *agent* context (`apply_in_context`) while the std140 tables live in the *render* context, so it would operate on empty tables and free nothing.

Validated with a headless-GL smoke (hidden GLFW window) exercising create / prefix-selective release / re-flush / release-all / idempotent.

## 2. Dogfood the std140 UBO pack in 04_cube
Convert 04_cube's `u_model` / `u_view` / `u_proj` / `u_cam_pos` / `u_time` uniforms into a single `struct Camera` declared `@uniform`, which dasGlsl packs as a `layout(std140) uniform` block (`u_tex` stays a separate sampler — opaque types can't live in a UBO). `cam_pos:float3` sits right before `time:float` on purpose: that float3-then-scalar pair is the case naive packing gets wrong, so the tutorial now exercises the std140 layout walk's per-field offsets.

Render is byte-identical to the prior loose-uniform version (verified with an A/B FBO readback: 0 differing bytes across the frame). RST prose updated to teach the camera UBO.

Lint + format clean; Sphinx builds with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)