### PR TITLE
site/news: dasImgui + companions updated to Dear ImGui 1.92.6

### DIFF
--- a/site/_news/2026-06-26-dasimgui-updated-to-dear-imgui-1-92-6.md
+++ b/site/_news/2026-06-26-dasimgui-updated-to-dear-imgui-1-92-6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-26
+tag: dasImgui
+title: dasImgui and related modules (dasImguiNodeEditor, dasImguiImplot) updated to Dear ImGui 1.92.6.
+link: https://borisbat.github.io/dasImgui/
+---


### PR DESCRIPTION
Adds a `site/_news` entry announcing that **dasImgui** and its related modules (**dasImguiNodeEditor**, **dasImguiImplot**) now track **Dear ImGui 1.92.6**.

The entry follows the established `_news/*.md` frontmatter format (`date` / `tag` / `title` / `link`). `site/blog/build_blog.py` globs the directory and sorts by date descending, so the new file lands at the top of the news rail with no index edit required.

Verified locally: `build_blog.py` renders 39 news entries (was 38) with the new entry first in `files/news.json`, no warnings.

This is the news-first, separate PR. The actual module-update verification (build dasImgui + dasImguiNodeEditor latest, confirm `/examples/daStrudel/sfx-lab` still runs) follows on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)