### PR TITLE
site/news: daslang 0.6.3 officially released

### DIFF
--- a/site/_news/2026-06-26-daslang-0-6-3-released.md
+++ b/site/_news/2026-06-26-daslang-0-6-3-released.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-26
+tag: 0.6.3
+title: Daslang 0.6.3 released.
+link: https://github.com/GaijinEntertainment/daScript/releases/tag/v0.6.3-RC3
+---


### PR DESCRIPTION
Adds a `/site/_news` entry announcing that **daslang 0.6.3** is officially released — `v0.6.3-RC3` has been promoted to the final release.

Matches the format of the prior official-release post (0.6.2): `tag: 0.6.3`, `title: Daslang 0.6.3 released.`, linking to the promoted release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)