### PR TITLE
lint: LINT015 — flag free-floating unary +/- statements (silently dropped terms)

### DIFF
--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -164,10 +164,11 @@ class LintVisitor : AstVisitor {
         }
         // LINT015: a free-floating unary +/- subexpression used as a statement — a
         // continuation line that lost its wrapping parens (`let x = a` ⏎ `+ b`,
-        // which re-parses as a unary `+b`, is pure, and the optimizer silently drops
-        // it). Only `+`/`-` qualify: they are the only operators that are both binary
-        // and unary, so a split binary `a + b` orphans as a valid unary statement
-        // (`~`/`!` aren't binary, `*`/`|>`/etc. can't start a statement → loud error).
+        // which re-parses as a unary `+b` whose value is discarded; if the operand
+        // is pure the optimizer drops the whole statement silently). Only `+`/`-`
+        // qualify: they are the only operators that are both binary and unary, so a
+        // split binary `a + b` orphans as a valid unary statement (`~`/`!` aren't
+        // binary, `*`/`|>`/etc. can't start a statement → loud error).
         if (!noLint && genericDepth == 0 && expr is ExprOp1 && !expr.genFlags.generated) {
             let op1 = expr as ExprOp1
             if (op1.op == "+" || op1.op == "-") {

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -62,6 +62,7 @@ class LintVisitor : AstVisitor {
     //!   - LINT012: unused function argument (class-method and [extern] args skipped — signature is dictated externally)
     //!   - LINT013: unused block argument
     //!   - LINT014: mutable (var) function argument is never written — drop the var
+    //!   - LINT015: free-floating unary +/- expression statement — value discarded; a continuation line missing its parens
     astVisitorAdapter : VisitorAdapter?
     exprForTerminator : array<uint64>
     compile_time_errors : bool
@@ -160,6 +161,18 @@ class LintVisitor : AstVisitor {
         let lb = exprForTerminator |> back()
         if (lb != 0ul) {
             lint_error("LINT001: unreachable code", expr.at)
+        }
+        // LINT015: a free-floating unary +/- subexpression used as a statement — a
+        // continuation line that lost its wrapping parens (`let x = a` ⏎ `+ b`,
+        // which re-parses as a unary `+b`, is pure, and the optimizer silently drops
+        // it). Only `+`/`-` qualify: they are the only operators that are both binary
+        // and unary, so a split binary `a + b` orphans as a valid unary statement
+        // (`~`/`!` aren't binary, `*`/`|>`/etc. can't start a statement → loud error).
+        if (!noLint && genericDepth == 0 && expr is ExprOp1 && !expr.genFlags.generated) {
+            let op1 = expr as ExprOp1
+            if (op1.op == "+" || op1.op == "-") {
+                lint_error("LINT015: free-floating unary '{op1.op}' expression as a statement — its value is silently discarded; this is almost always a continuation line missing its parens, wrap the multi-line RHS in (...)", expr.at)
+            }
         }
         // Mark this block as terminated only when `expr` IS a direct-child terminator.
         // Tracking from preVisitExprReturn/preVisitExprCall(panic) was incorrect: it

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -527,6 +527,35 @@ the next lint run exposes the caller.
     on the specific parameter's line; on a single-line ``def foo(a, b, c)`` a
     trailing ``// nolint:LINT012`` suppresses the whole line.
 
+LINT015 — free-floating unary ``+``/``-`` statement
+============================================================
+
+At statement level daslang is one statement per line, so a multi-line
+arithmetic RHS without wrapping parentheses splits each continuation into its
+own statement. A line beginning with ``+`` or ``-`` re-parses as a unary
+expression (``+b`` / ``-b``), which is pure — so the optimizer **silently drops
+it**: terms vanish, the result is wrong, and nothing is reported.
+
+Only ``+`` and ``-`` qualify — they are the only operators that are both binary
+and unary, so a split binary ``a + b`` orphans as a valid unary statement.
+``~`` / ``!`` are not binary (they cannot be a split continuation), ``++`` /
+``--`` mutate (real statements), and an operator that cannot begin a statement
+(``*``, ``|>``, …) raises a loud parse error instead.
+
+.. code-block:: das
+
+    // Bad — `+ b` and `+ c` become separate `+b` / `+c` statements, dropped
+    let x = a
+        + b                                 // LINT015
+        + c                                 // LINT015
+
+    // Good — the newlines now fall inside the parentheses
+    let x = (a
+        + b
+        + c)
+
+Wrap any multi-line arithmetic RHS in ``(...)``.
+
 .. _perf_lint:
 
 -----------------

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -533,8 +533,11 @@ LINT015 — free-floating unary ``+``/``-`` statement
 At statement level daslang is one statement per line, so a multi-line
 arithmetic RHS without wrapping parentheses splits each continuation into its
 own statement. A line beginning with ``+`` or ``-`` re-parses as a unary
-expression (``+b`` / ``-b``), which is pure — so the optimizer **silently drops
-it**: terms vanish, the result is wrong, and nothing is reported.
+expression (``+b`` / ``-b``) whose value is discarded — the term no longer
+contributes. When the operand is pure the optimizer removes the whole statement
+**silently**: terms vanish, the result is wrong, and nothing is reported. (If
+the operand has side effects those still run, but the leading ``+``/``-`` is
+meaningless either way — the rule fires regardless.)
 
 Only ``+`` and ``-`` qualify — they are the only operators that are both binary
 and unary, so a split binary ``a + b`` orphans as a valid unary statement.

--- a/utils/lint/tests/lint015_free_floating_unary.das
+++ b/utils/lint/tests/lint015_free_floating_unary.das
@@ -1,0 +1,73 @@
+options gen2
+// LINT015: free-floating unary +/- expression as a statement
+//
+// Problem:
+//   At statement level daslang is one-statement-per-line. A multi-line
+//   arithmetic RHS without wrapping parens splits each continuation into its
+//   own statement: `+ b` re-parses as unary `+b` (pure), and the optimizer
+//   SILENTLY drops it — terms vanish, wrong result, no diagnostic.
+//
+// Bad pattern:
+//   let x = a
+//       + b          // becomes a separate `+b` statement, dropped
+//       + c
+//
+// Good pattern:
+//   let x = (a
+//       + b
+//       + c)
+//
+// Only `+`/`-` qualify — they are the only operators that are both binary and
+// unary. `~`/`!` aren't binary (can't be a split continuation); `++`/`--` mutate
+// (real statements); `*`/`|>`/etc. can't start a statement (loud parse error).
+
+expect 50503:3
+
+require daslib/lint
+
+// --- Bad: orphaned continuation lines ---
+
+def bad_plus_continuation(a, b, c : int) : int {
+    let x = a
+        + b                                          // LINT015
+        + c                                          // LINT015
+    return x
+}
+
+def bad_minus_continuation(a, b : int) : int {
+    let x = a
+        - b                                          // LINT015
+    return x
+}
+
+// --- Good: wrapped RHS (newlines fall inside the parens) ---
+
+def good_wrapped(a, b, c : int) : int {
+    let x = (a
+        + b
+        + c)
+    return x
+}
+
+// --- Good: single-line arithmetic ---
+
+def good_single_line(a, b, c : int) : int {
+    let x = a + b + c
+    return x
+}
+
+// --- Good: unary in expression context (not a statement) ---
+
+def good_unary_in_expr(a : int) : int {
+    let y = -a
+    return y
+}
+
+// --- Good: increment / decrement are real (mutating) statements ---
+
+def good_inc_dec(start : int) : int {
+    var i = start
+    ++ i
+    i ++
+    return i
+}


### PR DESCRIPTION
## What

New `daslib/lint` rule **LINT015** catching a free-floating unary `+`/`-` expression used as a statement — the silent-wrong-result footgun documented by the CLAUDE.md multi-line note.

## Why

At statement level daslang is one-statement-per-line, so a multi-line arithmetic RHS without wrapping parens splits each continuation into its own statement:

```das
let x = a
    + b        // re-parses as a separate unary `+b` statement
    + c
```

`+ b` / `+ c` are pure unary expressions whose value is discarded, so the optimizer **silently drops them** — terms vanish, the result is wrong, and nothing is reported. There is no warning channel in the compiler and `ast_unused` removes these without a word, so a lint rule is the right home. daslib lint runs **pre-optimize**, so it still sees the orphaned statement.

## Scope — only `+` and `-`

They are the only operators that are *both binary and unary*, so a split binary `a + b` orphans as a *valid* unary statement. The others can't produce this footgun:
- `~` / `!` aren't binary — there's no `a ~ b` to split.
- `++` / `--` mutate — real statements.
- `*` / `|>` / `&` etc. can't begin a statement → loud parse error (caught already).

## Implementation

In `LintVisitor.visitExprBlockExpression` (the per-block-statement hook, same place LINT001 works): flag a statement that `is ExprOp1` with `op == "+"` or `op == "-"`. Generated subtrees and generic instances are skipped by the existing visitor guards.

## Verified

- Fires **exactly 3×** on the test fixture (`expect 50503:3`, dastest green).
- **Zero hits** sweeping `daslib/` + `utils/` + `tests/` (~1500 files) — no false positives, and no latent bugs surfaced.
- `daslib/lint.das` is lint-clean and format-clean; full preflight green (docs gate included — das2rst regen + Sphinx ×2 on the new `lint.rst` section).
- Test fixture is auto-discovered by `dastest --test utils/lint` and auto-skipped by the changed-files linter (its `expect` directive marks it intentional), so it doesn't trip CI's own lint step.

Docs: handwritten `doc/source/reference/language/lint.rst` section + the `//!` rule list in `lint.das` (regenerates the LintVisitor detail RST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)