### PR TITLE
daspkg: fix wasm release archive-name case (Linux Pages deploy)

### DIFF
--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -2133,6 +2133,11 @@ def private wasm_archive_name(rel : string) : string {
     if (base |> ends_with(suffix)) {
         base = slice(base, 0, length(base) - length(suffix))
     }
+    // CMake emits the archive after its target case (libDasModule*); the file is
+    // lowercase dasModule*. Capitalize so the lookup hits on case-sensitive FS (Linux CI).
+    if (!empty(base)) {
+        base = "{to_upper(slice(base, 0, 1))}{slice(base, 1)}"
+    }
     return "liblib{base}.a"
 }
 


### PR DESCRIPTION
## Problem

The **Deploy to GitHub Pages** workflow on `master` is red ([run 28298023967](https://github.com/GaijinEntertainment/daScript/actions/runs/28298023967)), failing in *Build WASM (Emscripten): playground + wasm64 examples*:

```
release wasm: missing module archive .../web/output64/lib/liblibdasModuleGlfw.a
(module `glfw`); run `daspkg build --wasm`
```

Note the lowercase `liblibdasModuleGlfw.a`.

## Root cause

`daspkg release wasm` derived each per-module archive name from the lowercase `.shared_module` basename (`dasModuleGlfw`), but the `web/` build emits the archive named after its **CMake target case** — `libDasModuleGlfw` → `liblibDasModuleGlfw.a` (capital `D`). `wasm_archive_name()`'s own header comment already documents the intended output as `liblibDasModuleGlfw.a`, but the implementation (`"liblib{base}.a"`) never applied the case change.

The two names match on **case-insensitive** filesystems (Windows/macOS — where `release wasm` was originally validated), so this slipped through. On Linux (case-sensitive) the lookup misses and the deploy fails. All five linked modules (Glfw/OpenGL/StbImage/Audio/Minfft) differ from their `.shared_module` basename by exactly this leading `d`→`D`.

## Fix

Capitalize the leading character in `wasm_archive_name()` so it produces the documented target-case name, matching the on-disk archive on case-sensitive filesystems. (The runtime archive `liblibDaScript_runtime.a` was already hardcoded correctly — only the per-module names were derived.)

## Validation

- `liblib{to_upper(...)}…` evaluates to `liblibDasModuleGlfw.a` / `liblibDasModuleOpenGL.a`, byte-identical to the actual on-disk archives (`ls web/output64/lib`).
- daspkg program compiles; lint `0 issue(s)`; formatter `Verified!`.
- The Pages `wasm_build` lane re-running green is the end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvWu2izV1ebb2LgHwHaWjp