### PR TITLE
daspkg: --disable-module to keep native-only modules (dashv/libhv) out of the wasm cross-compile

### DIFF
--- a/include/daScript/ast/dyn_modules.h
+++ b/include/daScript/ast/dyn_modules.h
@@ -17,4 +17,16 @@ DAS_CC_API bool require_dynamic_modules(smart_ptr<FileAccess> file_access,
                                      const string &project_root,
                                      const vector<string> &load_modules,
                                      TextWriter &tout);
+
+// As above, plus `disabled_modules`: dynamic modules whose folder basename
+// matches (case-insensitive, every platform) are never loaded/registered.
+// Used to keep a native-only module (e.g. dashv/libhv) out of a wasm
+// cross-compile, so a guarded `require ?mod` resolves as absent instead of
+// dragging in a module whose target archive can't exist.
+DAS_CC_API bool require_dynamic_modules(smart_ptr<FileAccess> file_access,
+                                     const string &das_root,
+                                     const string &project_root,
+                                     const vector<string> &load_modules,
+                                     const vector<string> &disabled_modules,
+                                     TextWriter &tout);
 }

--- a/src/ast/dyn_modules.cpp
+++ b/src/ast/dyn_modules.cpp
@@ -108,6 +108,18 @@ static das::string normalize_module_name(const das::string &name) {
 #endif
 }
 
+// Always lowercase, on every platform — unlike normalize_module_name (which is
+// identity on case-sensitive Linux). The explicit `--disable-module` list is
+// user intent, not a filesystem-shadow concern, so `--disable-module dashv`
+// must match the on-disk folder `dasHV` everywhere, including CI's Linux.
+static das::string force_lower(const das::string &name) {
+    das::string out = name;
+    for (auto &c : out) {
+        c = (char)tolower((unsigned char)c);
+    }
+    return out;
+}
+
 // Collect directory names under path/modules/ without loading anything
 static das_hash_set<das::string> collect_module_names(const das::string &path) {
     das_hash_set<das::string> result;
@@ -146,7 +158,8 @@ static das_hash_set<das::string> collect_module_names(const das::string &path) {
 }
 
 static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, das::TextWriter &tout,
-                                    const das_hash_set<das::string> *skip_set = nullptr) {
+                                    const das_hash_set<das::string> *skip_set = nullptr,
+                                    const das_hash_set<das::string> *disabled_set = nullptr) {
     // FileAccess do not support iteratinf over directory.
 #if DAS_NO_FILEIO
     return false;
@@ -169,6 +182,9 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
                 fprintf(stderr, "Warning: local '%s' shadows global — using local\n", c_file.name);
                 continue;
             }
+            if (disabled_set && disabled_set->count(force_lower(das::string(c_file.name)))) {
+                continue;   // explicitly disabled (--disable-module) — never load/register
+            }
             all_good &= Result::OK == init_dyn_modules(fa, modules_path + c_file.name, tout, false);
         } while (_findnext(hFile, &c_file) == 0);
     }
@@ -186,6 +202,9 @@ static bool init_modules_for_folder(FileAccessPtr fa, const das::string &path, d
                 // dastest JSON / any stdout-parsing pipeline is a structured data channel a stray line corrupts.
                 fprintf(stderr, "Warning: local '%s' shadows global — using local\n", ent->d_name);
                 continue;
+            }
+            if (disabled_set && disabled_set->count(force_lower(das::string(ent->d_name)))) {
+                continue;   // explicitly disabled (--disable-module) — never load/register
             }
             all_good &= Result::OK == init_dyn_modules(fa, modules_path + ent->d_name, tout, false);
         }
@@ -217,7 +236,15 @@ bool require_dynamic_modules(FileAccessPtr file_access,
                              const das::string &das_root,
                              const das::string &project_root,
                              const das::vector<das::string> &load_modules,
+                             const das::vector<das::string> &disabled_modules,
                              das::TextWriter &tout) {
+    // Explicitly-disabled modules (case-insensitive on every platform) are never
+    // loaded/registered — keeps a native-only module out of a wasm cross-compile.
+    das_hash_set<das::string> disabled_set;
+    for (const auto &m : disabled_modules) {
+        disabled_set.insert(force_lower(m));
+    }
+    const das_hash_set<das::string> *disabled_ptr = disabled_set.empty() ? nullptr : &disabled_set;
     bool has_project = !project_root.empty() &&
         normalizeFileName(das_root.c_str()) !=
         normalizeFileName(project_root.c_str());
@@ -238,15 +265,18 @@ bool require_dynamic_modules(FileAccessPtr file_access,
         dasroot_skip.insert(name);
     }
     bool all_good = das::init_modules_for_folder(file_access, das_root, tout,
-        dasroot_skip.empty() ? nullptr : &dasroot_skip);
+        dasroot_skip.empty() ? nullptr : &dasroot_skip, disabled_ptr);
     if (has_project) {
         // Init for project_root, skipping anything an explicit -load_module
         // already covers (load_module wins over project_root/modules/<name>).
         all_good &= das::init_modules_for_folder(file_access, project_root, tout,
-            load_module_names.empty() ? nullptr : &load_module_names);
+            load_module_names.empty() ? nullptr : &load_module_names, disabled_ptr);
     }
-    // Finally, init each explicit -load_module path directly.
+    // Finally, init each explicit -load_module path directly (unless disabled).
     for (const auto &p : load_modules) {
+        if (disabled_ptr && disabled_ptr->count(force_lower(path_basename(p)))) {
+            continue;
+        }
         all_good &= (Result::OK == init_dyn_modules(file_access, p, tout));
     }
     // Module .so's may carry DT_NEEDED on sibling-module .so's (e.g. node-editor ->
@@ -256,6 +286,16 @@ bool require_dynamic_modules(FileAccessPtr file_access,
     // deferred. Retry the deferred set in fixed-point passes so order stops mattering.
     retry_pending_dynamic_modules();
     return all_good;
+}
+
+// Back-compat overload: the original 5-arg form, no disabled modules.
+bool require_dynamic_modules(FileAccessPtr file_access,
+                             const das::string &das_root,
+                             const das::string &project_root,
+                             const das::vector<das::string> &load_modules,
+                             das::TextWriter &tout) {
+    return require_dynamic_modules(file_access, das_root, project_root, load_modules,
+                                   das::vector<das::string>(), tout);
 }
 
 }

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -568,6 +568,7 @@ void print_help() {
         << "    -project <path.das_project> path to project file\n"
         << "    -project_root <path> root directory of the project (used for dyn modules)\n"
         << "    -load_module <path> directly load a single dynamic-module folder (the one containing .das_module); repeatable. Bypasses the project_root/modules/<name> scan and shadows same-basename entries from dasroot/project_root.\n"
+        << "    --disable-module <name> never load/register the named dynamic module (case-insensitive folder match); repeatable. Keeps a native-only module (e.g. dashv) out of a wasm cross-compile so a guarded `require ?name` resolves as absent.\n"
         << "    -run-fmt    <-i/-d> <-v2/-v1> {--semicolon} run formatter\n"
         << "    -log        output program code\n"
         << "    -pause      pause after errors and pause again before exiting program\n"
@@ -659,6 +660,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     bool dumpLeaks = true;
     string project_root;
     vector<string> load_modules;
+    vector<string> disabled_modules;
     optional<format::FormatOptions> formatter;
     for ( int i=1; i < argc; ++i ) {
         if ( argv[i][0]=='-' ) {
@@ -749,6 +751,14 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                     return -1;
                 }
                 load_modules.push_back(argv[i + 1]);
+                i++;
+            } else if ( cmd=="-disable-module" ) {
+                if ( i+1 >= argc ) {
+                    printf("--disable-module requires module-name argument\n");
+                    print_help();
+                    return -1;
+                }
+                disabled_modules.push_back(argv[i + 1]);
                 i++;
             } else if ( cmd=="run-fmt" ) {
                 formatter.emplace();
@@ -892,7 +902,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
         daScriptEnvironment::ensure();
         project_root = deduce_project_root(project_root, files.front());
         auto access = get_file_access((char*)(projectFile.empty() ? nullptr : projectFile.c_str()));
-        require_dynamic_modules(access, getDasRoot(), project_root, load_modules, tout);
+        require_dynamic_modules(access, getDasRoot(), project_root, load_modules, disabled_modules, tout);
     }
     #endif
     Module::Initialize();

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -2183,7 +2183,10 @@ def private release_one_wasm_app(root, out_dir, app_name, main_script : string;
 
     // 1. Cross-compile to a wasm64 object (link skipped via --jit-emit-object),
     //    with --list-shared-modules writing the referenced-module set.
-    let xc_cmd = "\"{daslang}\" -exe -output \"{obj_path}\" --list-shared-modules \"{deps_file}\" \"{main_path}\" -- --jit-target=wasm64-unknown-emscripten --jit-emit-object --jit-runtime-lib=\"{runtime_archive}\""
+    //    --disable-module dashv: libhv is native-only (no wasm archive), so keep it
+    //    unloaded on the cross-compile host — a guarded `require ?dashv` then resolves
+    //    as absent instead of pulling in a module whose wasm archive can't exist.
+    let xc_cmd = "\"{daslang}\" -exe -output \"{obj_path}\" --list-shared-modules \"{deps_file}\" --disable-module dashv \"{main_path}\" -- --jit-target=wasm64-unknown-emscripten --jit-emit-object --jit-runtime-lib=\"{runtime_archive}\""
     var xc_out : string
     let xc_rc = run_cmd(xc_cmd, xc_out)
     if (xc_rc != 0 || !fexist(obj_path)) {


### PR DESCRIPTION
Fixes the Pages deploy that went red after #3289 merged: `daspkg release wasm` fails building the `/examples` games on CI.

## The bug
The unified game mains (`examples/games/*/main.das`) do `require ?dashv live/live_api` (libhv-backed live-reload). The `?dashv` guard skips **iff dasModuleHV is not _registered_** (`ast_parse.cpp` uses `Module::requireEx`, a registration lookup — *not* `module_allowed`).

On a host where dasModuleHV is built — CI's Pages host configures `-DDAS_HV_DISABLED=OFF` — the guard fires, pulls `live_api` (→ dashv) into the program, dashv lands in `--list-shared-modules`, and `daspkg release wasm` then demands `liblibDasModuleHV.a`, which **can't exist** (libhv isn't emscripten-portable; `daspkg build --wasm` builds OpenGL/Glfw/StbImage/Audio/Minfft/LiveHost, not HV). It passed local only because HV wasn't built there, so `?dashv` resolved as absent.

## The fix
Because the guard keys on *registration*, gating the `require` (`module_allowed`) isn't enough — the module must simply not be loaded. Add **`--disable-module <name>`** to `daslang -exe`: `require_dynamic_modules` skips loading/registering any dynamic module whose folder basename matches.

- **Case-insensitive on every platform.** The on-disk folder is `dasHV` but the module is `dashv`; the existing shadow-skip normalization is identity on Linux, so a naïve compare would miss it on CI. A dedicated `force_lower` makes `--disable-module dashv` match `dasHV` everywhere.
- 5-arg `require_dynamic_modules` overload kept for the other in-tree callers (daScriptC, daslang-live, dasFormatter) — default behavior unchanged.
- daspkg's **wasm64** cross-compile passes `--disable-module dashv`; the **native** release path is untouched and keeps dashv for the live stack.

Scoped to the daspkg/libhv case for now; the same flag generalizes to any native-only dynamic module a wasm app pulls.

## Verification (local, with dasModuleHV built — reproducing CI exactly)
- arcanoid cross-compile `--list-shared-modules` deps: **`[dasHV, dasModuleHV, dashv]` → none** with the flag.
- Full `daspkg release wasm` **completes for both arcanoid and pacman** (18.1 MB / 17.9 MB wasm), passing the HV-archive check that was the failure.
- Full preflight clean (14 passed, 0 failed; interpreter + JIT suites green — the change is additive and gated on the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)