### PR TITLE
web: embed dasStbImage fonts so the interpreter can run TTF apps

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -112,6 +112,13 @@ add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasO
 add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasGlsl/glsl@modules/dasGlsl/glsl")
 #   stbimage, stbimage/stbimage_boost, stbimage/stbimage_ttf -> modules/dasStbImage/stbimage
 add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasStbImage/stbimage@modules/dasStbImage/stbimage")
+# Embed the HUD font so cache_font("{get_das_root()}/modules/dasStbImage/fonts/
+# droidsansmono.ttf") resolves in the interpreter. opengl_ttf asserts a non-empty
+# font bitmap, so a missing .ttf kills the script in init() — that is why the
+# arcanoid/pac-man playground samples (and any TTF-using example) showed a black
+# canvas. Mounted at /modules/dasStbImage/fonts: get_das_root() is "." on wasm and
+# the MEMFS cwd is "/", so the loader's "./modules/..." resolves to the embed.
+add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasStbImage/fonts@modules/dasStbImage/fonts")
 
 # Embed the dasAudio .das source trees (the matching halves of the statically
 # linked libDasModuleAudio). The native fs resolver looks for


### PR DESCRIPTION
## Problem

Running the **arcanoid** / **pac-man** samples in the web playground (and any TTF-using example) shows a **black canvas**. The interpreter aborts in `init()`:

```
error: assert failed, font bitmap is not valid
  ./modules/dasOpenGL/opengl/opengl_ttf.das:50
  assert(int(font.bitmap.width) > 0, "font bitmap is not valid")
  CALL STACK: cache_font → upload_font_texture → ...
EXCEPTION in init(): assert failed
```

`daslang_static.wasm` (the interpreter the playground/`_interp.html` runs) embeds the dasStbImage **`.das` source tree** (`modules/dasStbImage/stbimage`) but **not** its `fonts/` directory. So `cache_font("{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf")` opens a non-existent file, the TTF loader bakes an empty bitmap, and `opengl_ttf` asserts on it — killing the script before anything renders.

## Fix

One line in `web/CMakeLists.txt`, alongside the existing module embeds:

```cmake
add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasStbImage/fonts@modules/dasStbImage/fonts")
```

Mounted at the path the loader builds from `get_das_root()` (`""` on wasm → `/modules/...`).

## Verification

Built `daslang_static` with the embed and ran both samples in the playground (Chromium):

- **arcanoid** and **pac-man** render (3D board/maze, decs entities, HUD).
- Text is correct — `PRESS SPACE TO START`, `PAC-MAN`.
- Audio device initializes without crashing (`HRTF` log). Audio *playback* on the single-threaded interpreter is a separate, known item and is out of scope here.

## Notes

- **No CI size regression.** A clean checkout has no `daslib/_aot_generated` scratch, so the embedded FS is unchanged apart from the ~117KB font; the deployed `daslang_static.wasm` stays ~24MB. (Locally the artifact balloons because the existing `--embed-file ../daslib@daslib` sweeps in a 30MB `_aot_generated` dir that exists only after local AOT test runs — a pre-existing embed-hygiene nit, not touched here.)
- No `.das`, test, or doc changes — the lint/test/AOT/docs/format gates have nothing to check for this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)