### PR TITLE
wasm: real threads + AudioWorklet audio thread (DAS_WASM_PTHREADS, gated)

### DIFF
--- a/modules/dasAudio/CMakeLists.txt
+++ b/modules/dasAudio/CMakeLists.txt
@@ -63,6 +63,18 @@ IF ((NOT DAS_AUDIO_INCLUDED) AND ((NOT ${DAS_AUDIO_DISABLED}) OR (NOT DEFINED DA
 	SETUP_AUDIO(libDasModuleAudio)
 	SETUP_AUDIO(dasModuleAudio)
 
+	# Threaded web build: drive miniaudio's emscripten backend via AudioWorklet
+	# (mixer callback on the dedicated audio rendering thread) instead of the
+	# main-thread ScriptProcessorNode. Needs the worklet emcc link flags
+	# (-sAUDIO_WORKLET=1 -sWASM_WORKERS=1, set in web/CMakeLists.txt) + the
+	# non-blocking ma_device_init patch (patches/miniaudio_memory64.cmake), so it
+	# works with -fwasm-exceptions (no -sASYNCIFY). Gated on DAS_WASM_PTHREADS.
+	IF(EMSCRIPTEN AND DAS_WASM_PTHREADS)
+		TARGET_COMPILE_DEFINITIONS(libDasModuleAudio PRIVATE MA_ENABLE_AUDIO_WORKLETS)
+		TARGET_COMPILE_DEFINITIONS(dasModuleAudio    PRIVATE MA_ENABLE_AUDIO_WORKLETS)
+		MESSAGE(STATUS "dasAudio: AudioWorklet backend enabled (threaded web build).")
+	ENDIF()
+
 	# HRTF FFT convolution — compile minfft.c directly (avoids cross-DLL static lib issues on Windows)
 	SET(DAS_MINFFT_INCLUDE ${PROJECT_SOURCE_DIR}/modules/dasMinfft/minfft)
 	TARGET_INCLUDE_DIRECTORIES(libDasModuleAudio PRIVATE ${DAS_MINFFT_INCLUDE})

--- a/modules/dasAudio/patches/miniaudio_memory64.cmake
+++ b/modules/dasAudio/patches/miniaudio_memory64.cmake
@@ -20,8 +20,13 @@ endif()
 
 file(READ "${MINIAUDIO_H}" _ma)
 
-# Idempotency guard: if the helper is already present, this copy is patched.
-string(FIND "${_ma}" "window.miniaudio.toPtr" _already)
+# Idempotency guard: key on the LAST-added patch marker (the worklet non-blocking
+# patch), not the first (toPtr). Otherwise a tree already patched by an older
+# version of this script (toPtr only) would early-return and never receive a
+# newly-added block. With this marker, a toPtr-only tree still runs the script;
+# the toPtr string(REPLACE)s are no-ops (targets already gone) and only the new
+# worklet block applies.
+string(FIND "${_ma}" "daslang non-blocking patch (see miniaudio_memory64.cmake)" _already)
 if(_already GREATER -1)
     message(STATUS "miniaudio_memory64.cmake: already patched, skipping ${MINIAUDIO_H}")
     return()
@@ -60,6 +65,67 @@ string(REPLACE
 string(REPLACE
 [==[                    _ma_device_process_pcm_frames_playback__webaudio(pDevice, bufferSize, pIntermediaryBuffer);]==]
 [==[                    _ma_device_process_pcm_frames_playback__webaudio(window.miniaudio.toPtr(pDevice), bufferSize, window.miniaudio.toPtr(pIntermediaryBuffer));]==]
+    _ma "${_ma}")
+
+# 6) AudioWorklet non-blocking init. miniaudio's worklet ma_device_init busy-waits
+# `while (initResult==MA_BUSY) emscripten_sleep(1);` for the async worklet to spin
+# up — the ONE thing that forces -sASYNCIFY, which is incompatible with our
+# -fwasm-exceptions build (binaryen's asyncify pass crashes on the memory64+EH
+# module). Replace the wait + BUSY error-check with a descriptor pre-fill from the
+# requested config so ma_device_init returns immediately; the worklet connects
+# asynchronously (the device callback isn't invoked until it does) and the
+# processor-created callback re-fills these descriptors with identical values.
+# Only compiled when MA_USE_AUDIO_WORKLETS (the threaded web build); inert
+# otherwise. Verified end-to-end: a 440Hz worklet tone plays in Chrome on
+# memory64+pthread+wasm-EH with no asyncify.
+string(REPLACE
+[==[        while (pDevice->webaudio.initResult == MA_BUSY) { emscripten_sleep(1); }    /* We must wait for initialization to complete. We're just spinning here. The emscripten_sleep() call is why we need to build with `-sASYNCIFY`. */
+
+        /* Initialization is now complete. Descriptors were updated when the worklet was initialized. */
+        if (pDevice->webaudio.initResult != MA_SUCCESS) {
+            ma_free(pStackBuffer, &pDevice->pContext->allocationCallbacks);
+            emscripten_destroy_audio_context(pDevice->webaudio.audioContext);
+            return pDevice->webaudio.initResult;
+        }]==]
+[==[        /* daslang non-blocking patch (see miniaudio_memory64.cmake): drop the
+           emscripten_sleep busy-wait that forces -sASYNCIFY. Pre-fill descriptors
+           from config; the worklet connects asynchronously. */
+        {
+            ma_uint32 awCh = (pDescriptorPlayback != NULL && pDescriptorPlayback->channels > 0) ? pDescriptorPlayback->channels : MA_DEFAULT_CHANNELS;
+            if (pDescriptorPlayback != NULL) {
+                pDescriptorPlayback->format             = ma_format_f32;
+                pDescriptorPlayback->channels           = awCh;
+                ma_channel_map_init_standard(ma_standard_channel_map_webaudio, pDescriptorPlayback->channelMap, ma_countof(pDescriptorPlayback->channelMap), pDescriptorPlayback->channels);
+                pDescriptorPlayback->periodSizeInFrames = 128;
+                pDescriptorPlayback->periodCount        = 1;
+            }
+            if (pDescriptorCapture != NULL) {
+                ma_uint32 awCapCh = (pDescriptorCapture->channels > 0) ? pDescriptorCapture->channels : MA_DEFAULT_CHANNELS;
+                pDescriptorCapture->format              = ma_format_f32;
+                pDescriptorCapture->channels            = awCapCh;
+                ma_channel_map_init_standard(ma_standard_channel_map_webaudio, pDescriptorCapture->channelMap, ma_countof(pDescriptorCapture->channelMap), pDescriptorCapture->channels);
+                pDescriptorCapture->periodSizeInFrames  = 128;
+                pDescriptorCapture->periodCount         = 1;
+            }
+            /* The descriptors are LOCALS of the generic ma_device_init and die when
+               it returns (right after this non-blocking init). The generic init has
+               already read back our pre-filled values above, so NULL the worklet
+               callback's copies (it null-guards them) to stop it writing through the
+               now-dangling pointers when it fires asynchronously. */
+            pInitParameters->pDescriptorPlayback = NULL;
+            pInitParameters->pDescriptorCapture  = NULL;
+        }]==]
+    _ma "${_ma}")
+
+# 7) AudioWorklet dangling-config fix. The processor-created callback runs long
+# after ma_device_init returns (non-blocking, block 6), so pConfig — a local of
+# the generic ma_device_init — is dead. Read the device type from the long-lived
+# pDevice instead, or the `if (deviceType == playback) connect(destination)` is
+# skipped (garbage type) and the worklet node is created but never connected ->
+# silent. string(REPLACE) hits all four reads in the callback.
+string(REPLACE
+[==[pParameters->pConfig->deviceType]==]
+[==[pParameters->pDevice->type]==]
     _ma "${_ma}")
 
 file(WRITE "${MINIAUDIO_H}" "${_ma}")

--- a/modules/dasLLVM/daslib/llvm_jit_cli.das
+++ b/modules/dasLLVM/daslib/llvm_jit_cli.das
@@ -42,6 +42,10 @@ struct public JitCliOptions {
     @clarg_doc = "JIT (-exe wasm cross-compile): emit the linkable object only and skip the emcc link, so the caller (e.g. daspkg release wasm) runs emcc with module archives + flags. Object is written to -output verbatim."
     emit_object : Option<bool>
 
+    @clarg_name = "jit-threads"
+    @clarg_doc = "JIT (-exe wasm cross-compile): emit a -pthread-compatible object (+atomics,+bulk-memory) for linking against the threaded runtime archives (web/output64mt). The emcc link must also pass -pthread."
+    threads : Option<bool>
+
     @clarg_name = "jit-linker-string"
     @clarg_doc = "JIT: extra args inserted verbatim into the host linker cmd (e.g. -fsanitize=undefined)"
     linker_string : Option<string>

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -381,6 +381,19 @@ var public g_handled_field_offset_globals : table<string; tuple<modName : string
 // wasm32-only miscompiles.
 var public g_target_is_wasm = false
 
+// Cross-compile a wasm object compatible with a -pthread (SharedArrayBuffer)
+// runtime: add +atomics,+bulk-memory to the target_features section so wasm-ld
+// links it into a --shared-memory build. Set from the --jit-threads CLI flag in
+// llvm_jit_run.das BEFORE codegen. MUST match the archives: a +atomics object
+// links only against -pthread archives (web/output64mt), and a non-threads
+// object only against non-pthread ones (web/output64) — same discipline as the
+// +simd128 vec4f-sret match documented in write_wasm.
+var public g_target_wasm_threads = false
+
+def private wasm_target_features() : string {
+    return g_target_wasm_threads ? "+simd128,+nontrapping-fptoint,+atomics,+bulk-memory" : "+simd128,+nontrapping-fptoint"
+}
+
 def public LLVMAddFunctionWithType(mod : LLVMModuleRef; name : string; typ : LLVMTypeRef) {
     var rv = LLVMAddFunction(mod, name, typ)
     g_fn_types[name] = typ
@@ -462,7 +475,7 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
         // so vec4f returns are v128-in-register on both sides; meaningless
         // (and potentially a target-machine-creation failure) on other
         // cross-compile triples, so keep features empty there.
-        let features = g_target_is_wasm ? "+simd128,+nontrapping-fptoint" : ""
+        let features = g_target_is_wasm ? wasm_target_features() : ""
         with_target_machine(target_triple, "", features, cg_opt_level) $(targetMachine : LLVMTargetMachineRef) {
             let dl = LLVMCreateTargetDataLayout(targetMachine)
             LLVMSetModuleDataLayout(g_mod, dl)
@@ -1010,8 +1023,9 @@ def public write_wasm(mod : LLVMOpaqueModule?; out_path : string; triple : strin
     // vec4f returns via sret while emcc returns them as native v128, causing
     // function-signature mismatches at wasm-ld link time and `unreachable`
     // traps at runtime on any helper that returns vec4f (jit_invoke_block_*,
-    // jit_call_*).
-    let features = "+simd128,+nontrapping-fptoint"
+    // jit_call_*). +atomics,+bulk-memory added for a -pthread runtime — see
+    // g_target_wasm_threads / wasm_target_features.
+    let features = wasm_target_features()
     with_target_machine(real_triple, "", features, 2u) $(targetMachine : LLVMTargetMachineRef) {
         // Pin the module's data layout + triple to the TARGET's so codegen sizes
         // pointers correctly (wasm64 → 8-byte). Without this the module inherits

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -186,6 +186,10 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
     // links it, e.g. daspkg release wasm). Sidesteps the link entirely, including
     // the Windows popen-quoting failure path in link_wasm.
     let emit_object = cli_opts.emit_object |> unwrap_or(false)
+    // --jit-threads: emit a -pthread-compatible wasm object (+atomics,+bulk-memory).
+    // Set the codegen global before any IR is built so both the data-layout machine
+    // and write_wasm's emission machine pick up the threaded feature set.
+    g_target_wasm_threads = cli_opts.threads |> unwrap_or(false)
     // Extra args appended verbatim to the host linker cmd. CLI > script option.
     let linker_string = cli_opts.linker_string |> unwrap_or((prog._options |> find_arg("jit_linker_string")) ?as tString ?? "")
 

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -47,6 +47,29 @@ if(DAS_WASM_MEMORY64)
     add_link_options(-sMEMORY64=1)
 endif()
 
+# Threads: build the runtime/modules with -pthread so std::thread (new_thread,
+# JobQue workers, parallel_for) map to real Web Workers backed by SharedArrayBuffer.
+# ABI-incompatible with a non-pthread build (TLS model, shared memory, +atomics),
+# so it MUST go to a separate DAS_WEB_OUTPUT_DIR (e.g. web/output64mt) and the
+# das→wasm cross-compile object must add +atomics,+bulk-memory to match
+# (llvm_jit_common.das write_wasm). The serving page must send COOP same-origin +
+# COEP require-corp for the SharedArrayBuffer to instantiate. Verified that
+# -sMEMORY64=1 -pthread -fwasm-exceptions all coexist in emsdk 5.0.7 (probe).
+option(DAS_WASM_PTHREADS "Build wasm output with -pthread (real worker threads, needs SharedArrayBuffer/COOP+COEP)" OFF)
+if(DAS_WASM_PTHREADS)
+    add_compile_options(-pthread)
+    # -sSHARED_MEMORY pins initial memory (no auto-grow at startup), so it must be
+    # large enough for daslang's static data + embedded daslib (~55MB). 128MB gives
+    # headroom; ALLOW_MEMORY_GROWTH still lets the heap grow past it at runtime.
+    add_link_options(-pthread -sPTHREAD_POOL_SIZE=8 -sINITIAL_MEMORY=134217728)
+    # AudioWorklet backend for dasAudio (mixer on the dedicated audio thread).
+    # WASM_WORKERS backs the worklet thread; AUDIO_WORKLET enables the API. No
+    # -sASYNCIFY (incompatible with -fwasm-exceptions) — the non-blocking
+    # ma_device_init patch removes the only code that needed it. Matched by
+    # MA_ENABLE_AUDIO_WORKLETS on libDasModuleAudio (modules/dasAudio/CMakeLists).
+    add_link_options(-sAUDIO_WORKLET=1 -sWASM_WORKERS=1)
+endif()
+
 # Modern wasm EH (try_table/exnref). DAS_ENABLE_EXCEPTIONS routes daslang
 # error paths through C++ throw instead of setjmp/longjmp.
 add_compile_options(-fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0)


### PR DESCRIPTION
Lands the foundation for **real worker threads + a dedicated AudioWorklet audio thread** on the wasm64 build. Everything is behind a new CMake option **`DAS_WASM_PTHREADS` (default OFF)**, so default builds are byte-unchanged.

## What this adds (all gated)

- **`web/CMakeLists.txt`** — `DAS_WASM_PTHREADS` option. When on, builds the runtime/modules with `-pthread` (real Web Workers + `SharedArrayBuffer`) and links with `-sPTHREAD_POOL_SIZE=8 -sINITIAL_MEMORY=… -sAUDIO_WORKLET=1 -sWASM_WORKERS=1`. The serving page must send COOP `same-origin` + COEP `require-corp` for SAB to instantiate. ABI-incompatible with a non-pthread build, so it goes to a separate output dir (e.g. `web/output64mt`).
- **`modules/dasAudio/CMakeLists.txt` + `patches/miniaudio_memory64.cmake`** — gated `MA_ENABLE_AUDIO_WORKLETS` so miniaudio's emscripten backend runs the mixer callback on the dedicated AudioWorklet thread (instead of the main-thread ScriptProcessorNode). Includes a **non-blocking `ma_device_init` patch** that removes the one `emscripten_sleep` busy-wait requiring `-sASYNCIFY` — asyncify is incompatible with `-fwasm-exceptions` (our build), so the patch lets the worklet path coexist with wasm-EH (no asyncify).
- **`modules/dasLLVM/daslib/llvm_jit_{cli,common,run}.das`** — a `--jit-threads` flag for the `-exe` wasm cross-compile. It adds `+atomics,+bulk-memory` to the emitted object's `target_features` so `wasm-ld` links it into a `--shared-memory` build, matched to the `-pthread` runtime archives (same discipline as the existing `+simd128` vec4f-sret match).

## Proven in-browser
Real `new_thread`/jobque on wasm64+pthread, COOP/COEP+SAB serving, and the dasAudio mixer running on a dedicated AudioWorklet thread — SFX sustained cleanly for 48s (the mixer's `data_callback` on the worklet thread, glfw input + render unaffected).

## Deliberately NOT enabled here
Threaded **strudel music** is *not* turned on. It hits a wasm64-only double-free in the pattern-query path (`array<Hap>` freed in a Pattern lambda on the producer thread) that's under separate investigation. Games stay single-threaded / SFX-only as today. This PR is purely the gated infrastructure so that work can land on top once the strudel issue is fixed.

## Notes
- Default behavior is unchanged (`DAS_WASM_PTHREADS` OFF).
- Local preflight: format/lint/dasgen/ci-das/docs/tests-cpp/tests-interp/**tests-jit** all green. `tests-aot`/`sequence` were skipped locally by the documented DLL-pin relink artifact; neither is affected by gated-CMake + JIT-flag changes, and CI's AOT lane covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)