### PR TITLE
jit: --jit-check-abi handled-type size/offset validation + libc++ wasm cross-compile host

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,10 +36,12 @@ jobs:
     # The host daslang now builds with dasGlfw/dasOpenGL ON so it can drive the
     # /examples game cross-compile (daspkg release wasm). dasGlfw's
     # find_package(OpenGL REQUIRED) needs the GL + X11 dev headers.
-    - name: "Install OpenGL dev libraries"
+    - name: "Install OpenGL + libc++ dev libraries"
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev xorg-dev
+        # libc++ so the wasm cross-compile host can be built with the SAME C++
+        # stdlib as the emscripten target (see the host build step below).
+        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev xorg-dev libc++-dev libc++abi-dev
 
     - name: Setup Emscripten
       uses: emscripten-core/setup-emsdk@v11
@@ -86,8 +88,28 @@ jobs:
       run: |
         set -eux
         mkdir -p build
+        # This is the wasm CROSS-COMPILE host: `daspkg build --wasm` below runs it
+        # to JIT-codegen the .das games/samples to wasm64, baking C++ handled-type
+        # layouts (Context, jobque, std::string-bearing structs) from the HOST's
+        # ABI. The emscripten target is libc++ + C++ exceptions (-fwasm-exceptions
+        # + DAS_ENABLE_EXCEPTIONS, see web/CMakeLists.txt); a default libstdc++ +
+        # setjmp host bakes the WRONG offsets/sizes (std::string 32 vs 24, mutex 80
+        # vs 40, exception state) -> wasm heap corruption. Building the host libc++
+        # + exceptions makes host==target layout (verified: zero handled-type
+        # divergence on every runtime-live type; only the compiler-only Program
+        # residual remains).
         cmake --no-warn-unused-cli -B./build \
           -DCMAKE_BUILD_TYPE:STRING=Release \
+          # Absolute path: setup-emsdk prepends its LLVM snapshot to PATH, so a bare
+          # `clang` would resolve to emsdk's (flaky on ds_parser.cpp, see version note
+          # above). /usr/bin/clang is the runner image's clang — same one every other
+          # Linux clang job uses (build.yml, extended_checks.yml) — paired with the
+          # apt libc++ installed above.
+          -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+          -DCMAKE_C_FLAGS="-DDAS_ENABLE_EXCEPTIONS=1" \
+          -DCMAKE_CXX_FLAGS="-stdlib=libc++ -DDAS_ENABLE_EXCEPTIONS=1 -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS" \
+          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" \
+          -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++" \
           -DDAS_HV_DISABLED=OFF \
           -DDAS_PUGIXML_DISABLED=OFF \
           -DDAS_LLVM_DISABLED=OFF \

--- a/doc/source/stdlib/handmade/function-ast-get_handled_type_size-0xd6f17ac49de8b42d.rst
+++ b/doc/source/stdlib/handmade/function-ast-get_handled_type_size-0xd6f17ac49de8b42d.rst
@@ -1,0 +1,1 @@
+Returns the size in bytes (sizeof) of a handled (C++) type from its annotation. Mirrors get_handled_type_field_offset for whole-type size; used by the JIT to validate that a cross-compile target's handled-type layout matches the host-baked one.

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -659,12 +659,60 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
             LLVMBuildStore(ib, off_val, glob)
         }
     }
+    // --jit-check-abi: sweep every handled-type the program uses and emit
+    // host-vs-target size + field-offset checks, then a report/kaboom call.
+    if (g_jit_check_handled_abi) {
+        emit_handled_abi_check(ib, prog)
+    }
     LLVMBuildRetVoid(ib)
     LLVMDisposeBuilder(ib)
     extern_resolver.uid = null
     extern_resolver.types = null
     unsafe { delete extern_resolver; }
     return (any_unimplemented = any_unimp, needs_whole_lib = whole_lib)
+}
+
+// --jit-check-abi: emit, into initialize_modules(), a host-vs-target layout
+// safe-check for every handled type the program references. For each handled
+// (BasicStructure) annotation across all program modules we bake the HOST size +
+// each field's HOST offset into a check call; at runtime those resolve the TARGET
+// runtime annotation and record every divergence, then jit_handled_abi_check_report()
+// dumps them all and aborts. The whole magnitude of the layout disaster in one run.
+def private emit_handled_abi_check(ib : LLVMBuilderRef; prog : Program?) {
+    let size_fn = LLVMGetNamedFunction(g_mod, FN_JIT_CHECK_HANDLED_TYPE_SIZE)
+    let size_type = g_fn_types[FN_JIT_CHECK_HANDLED_TYPE_SIZE]
+    let off_fn = LLVMGetNamedFunction(g_mod, FN_JIT_CHECK_HANDLED_FIELD_OFFSET)
+    let off_type = g_fn_types[FN_JIT_CHECK_HANDLED_FIELD_OFFSET]
+    var seen : table<string; bool>
+    var n_types = 0
+    var n_fields = 0
+    prog |> for_each_module() $(m) {
+        module_for_each_annotation(m) $(value) {
+            if (!value.isBasicStructureAnnotation) return
+            let modName = string(m.name)
+            let typeName = string(value.name)
+            let key = "{modName}`{typeName}"
+            if (key_exists(seen, key)) return
+            seen[key] = true
+            let host_size = int(get_handled_type_size(unsafe(reinterpret<TypeAnnotation?>(value))))
+            let mod_str = get_string_constant_ptr(ib, modName)
+            let type_str = get_string_constant_ptr(ib, typeName)
+            LLVMBuildCall2(ib, size_type, size_fn,
+                fixed_array(mod_str, type_str, g_prim_t.ConstI32(uint64(host_size))), "")
+            n_types ++
+            for_each_field(*unsafe(reinterpret<BasicStructureAnnotation?>(value))) $(name, _cppName, _xtype, offset) {
+                if (offset == -1u) return
+                let field_str = get_string_constant_ptr(ib, name)
+                LLVMBuildCall2(ib, off_type, off_fn,
+                    fixed_array(mod_str, type_str, field_str, g_prim_t.ConstI32(uint64(offset))), "")
+                n_fields ++
+            }
+        }
+    }
+    to_log(LOG_INFO, "ABI-CHECK sweep emitted: {n_types} handled types, {n_fields} fields\n")
+    let rep_fn = LLVMGetNamedFunction(g_mod, FN_JIT_HANDLED_ABI_CHECK_REPORT)
+    let rep_type = g_fn_types[FN_JIT_HANDLED_ABI_CHECK_REPORT]
+    LLVMBuildCall2(ib, rep_type, rep_fn, array<LLVMValueRef>(), "")
 }
 
 // Suffix from the last "modules/" segment onwards; "" → caller falls back to abs path.

--- a/modules/dasLLVM/daslib/llvm_jit_cli.das
+++ b/modules/dasLLVM/daslib/llvm_jit_cli.das
@@ -46,6 +46,10 @@ struct public JitCliOptions {
     @clarg_doc = "JIT (-exe wasm cross-compile): emit a -pthread-compatible object (+atomics,+bulk-memory) for linking against the threaded runtime archives (web/output64mt). The emcc link must also pass -pthread."
     threads : Option<bool>
 
+    @clarg_name = "jit-check-abi"
+    @clarg_doc = "JIT (-exe): emit a startup safe-check that compares every used handled-type's HOST-baked size + field offsets against the TARGET runtime annotation and aborts — reporting ALL divergences — on any mismatch. Diagnostic for the cross-compile C++ ABI layout class (wasm). Off by default."
+    check_abi : Option<bool>
+
     @clarg_name = "jit-linker-string"
     @clarg_doc = "JIT: extra args inserted verbatim into the host linker cmd (e.g. -fsanitize=undefined)"
     linker_string : Option<string>

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -52,6 +52,9 @@ let public FN_JIT_GET_SHARED_MNH    = "jit_get_shared_mnh"
 // runtime's annotation registry (the host's offsetof is wrong when the target C++
 // ABI lays the struct out differently; see handled_field_offset_value in llvm_jit.das).
 let public FN_JIT_GET_HANDLED_FIELD_OFFSET = "jit_get_handled_field_offset"
+let public FN_JIT_CHECK_HANDLED_TYPE_SIZE = "jit_check_handled_type_size"
+let public FN_JIT_CHECK_HANDLED_FIELD_OFFSET = "jit_check_handled_field_offset"
+let public FN_JIT_HANDLED_ABI_CHECK_REPORT = "jit_handled_abi_check_report"
 let public FN_JIT_ALLOC_HEAP        = "jit_alloc_heap"
 let public FN_JIT_ALLOC_PERSISTENT  = "jit_alloc_persistent"
 let public FN_JIT_FREE_HEAP         = "jit_free_heap"
@@ -390,6 +393,13 @@ var public g_target_is_wasm = false
 // +simd128 vec4f-sret match documented in write_wasm.
 var public g_target_wasm_threads = false
 
+// --jit-check-abi: emit a startup sweep that compares every used handled-type's
+// HOST-baked size + field offsets against the TARGET runtime annotation and
+// kabooms — reporting ALL divergences — on any mismatch. Diagnostic for the
+// MSVC-host vs wasm/clang-target C++ ABI layout class (vptr/base ordering or
+// #ifdef WIN32/EMSCRIPTEN-conditional members). Opt-in; off by default.
+var public g_jit_check_handled_abi = false
+
 def private wasm_target_features() : string {
     return g_target_wasm_threads ? "+simd128,+nontrapping-fptoint,+atomics,+bulk-memory" : "+simd128,+nontrapping-fptoint"
 }
@@ -577,6 +587,29 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
             fixed_array<LLVMTypeRef>(g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType())))
     LLVMAddGlobalMapping(g_engine, jit_get_handled_field_offset, get_jit_get_handled_field_offset())
     LLVMAddAttributesToFunction(jit_get_handled_field_offset, fixed_array(nounwind, willreturn))
+    // --jit-check-abi safe-check trio (declared unconditionally; only called from the
+    // init function when g_jit_check_handled_abi). The host bakes its layout into the
+    // call args; these resolve the TARGET annotation and record/abort on mismatch.
+    // void jit_check_handled_type_size ( const char * module, const char * type, uint32_t hostSize )
+    var jit_check_handled_type_size = LLVMAddFunctionWithType(g_mod, FN_JIT_CHECK_HANDLED_TYPE_SIZE,
+        LLVMFunctionType(g_prim_t.t_void,
+            fixed_array<LLVMTypeRef>(g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType(), g_prim_t.t_int32)))
+    LLVMAddGlobalMapping(g_engine, jit_check_handled_type_size, get_jit_check_handled_type_size())
+    LLVMAddAttributesToFunction(jit_check_handled_type_size, fixed_array(nounwind, willreturn))
+    // void jit_check_handled_field_offset ( const char * module, const char * type, const char * field, uint32_t hostOffset )
+    var jit_check_handled_field_offset = LLVMAddFunctionWithType(g_mod, FN_JIT_CHECK_HANDLED_FIELD_OFFSET,
+        LLVMFunctionType(g_prim_t.t_void,
+            fixed_array<LLVMTypeRef>(g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType(), g_prim_t.LLVMVoidPtrType(), g_prim_t.t_int32)))
+    LLVMAddGlobalMapping(g_engine, jit_check_handled_field_offset, get_jit_check_handled_field_offset())
+    LLVMAddAttributesToFunction(jit_check_handled_field_offset, fixed_array(nounwind, willreturn))
+    // void jit_handled_abi_check_report ()
+    // NO willreturn: this aborts (DAS_FATAL_ERROR) on any mismatch, so it may not
+    // return normally — willreturn would be UB. (The two check fns above DO always
+    // return, so they keep willreturn.)
+    var jit_handled_abi_check_report = LLVMAddFunctionWithType(g_mod, FN_JIT_HANDLED_ABI_CHECK_REPORT,
+        LLVMFunctionType(g_prim_t.t_void, array<LLVMTypeRef>()))
+    LLVMAddGlobalMapping(g_engine, jit_handled_abi_check_report, get_jit_handled_abi_check_report())
+    LLVMAddAttributesToFunction(jit_handled_abi_check_report, fixed_array(nounwind))
     // jit_alloc_heap ( uint64_t mnh, context * )
     var jit_alloc_heap = LLVMAddFunctionWithType(g_mod, FN_JIT_ALLOC_HEAP,
         LLVMFunctionType(g_prim_t.LLVMVoidPtrType(),

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x29ul
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x2Aul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
@@ -190,6 +190,9 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
     // Set the codegen global before any IR is built so both the data-layout machine
     // and write_wasm's emission machine pick up the threaded feature set.
     g_target_wasm_threads = cli_opts.threads |> unwrap_or(false)
+    // --jit-check-abi: emit the handled-type host-vs-target layout safe-check into
+    // initialize_modules(). Set before codegen so llvm_exe's sweep sees the flag.
+    g_jit_check_handled_abi = cli_opts.check_abi |> unwrap_or(false)
     // Extra args appended verbatim to the host linker cmd. CLI > script option.
     let linker_string = cli_opts.linker_string |> unwrap_or((prog._options |> find_arg("jit_linker_string")) ?as tString ?? "")
 

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -877,6 +877,11 @@ namespace das {
         return annotation->getFieldOffset(name);
     }
 
+    uint32_t getHandledTypeSize ( TypeAnnotationPtr annotation, Context * context, LineInfoArg * at ) {
+        if ( !annotation ) context->throw_error_at(at, "expecting type annotation");
+        return uint32_t(annotation->getSizeOf());
+    }
+
     bool addModuleRequire ( Module * module, Module * reqModule, bool publ ) {
         auto it = module->requireModule.find(reqModule);
         if ( it != module->requireModule.end() ) {
@@ -1480,6 +1485,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(getHandledTypeFieldOffset)>(*this, lib,  "get_handled_type_field_offset",
             SideEffects::none, "getHandledTypeFieldOffset")
                 ->args({"type","field","context","line"});
+        addExtern<DAS_BIND_FUN(getHandledTypeSize)>(*this, lib,  "get_handled_type_size",
+            SideEffects::none, "getHandledTypeSize")
+                ->args({"type","context","line"});
         addExtern<DAS_BIND_FUN(getHandledTypeFieldType)>(*this, lib,  "get_handled_type_field_type",
             SideEffects::none, "getHandledTypeFieldType")
                 ->args({"type","field","context","line"});

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -446,7 +446,9 @@ extern "C" {
         Module::foreach([&](Module * module) -> bool {
             if ( module->name != moduleName ) return true;
             auto ann = module->findAnnotation(typeName);
-            if ( ann && (ann->rtti_isHandledTypeAnnotation() || ann->rtti_isStructureAnnotation()) ) {
+            // handled-type annotations only — StructureAnnotation isn't a TypeAnnotation (see note in
+            // jit_find_handled_annotation); the JIT only resolves offsets for handled-type fields.
+            if ( ann && ann->rtti_isHandledTypeAnnotation() ) {
                 offset = ((TypeAnnotation *)ann)->getFieldOffset(fieldName);
                 return false; // stop iterating
             }
@@ -459,6 +461,85 @@ extern "C" {
                 moduleName, typeName, fieldName);
         }
         return offset;
+    }
+
+    // ---- ABI safe-check (opt-in via --jit-check-abi) ------------------------
+    // Cross-compiling from an MSVC host to a wasm/clang target can bake a wrong
+    // handled-type (C++ struct) SIZE or field OFFSET when the two C++ ABIs lay the
+    // struct out differently (vptr/base ordering, or #ifdef WIN32/EMSCRIPTEN-
+    // conditional members). The codegen emits, at startup, one check call per used
+    // handled type (size) and per field (offset) carrying the HOST-baked value;
+    // each compares against the TARGET runtime annotation and records every
+    // divergence. jit_handled_abi_check_report() dumps them all at once and aborts,
+    // so a single run reveals the full magnitude of the layout disaster.
+    static string g_abi_check_report;
+    static int    g_abi_check_count = 0;        // mismatches
+    static int    g_abi_types_checked = 0;      // type-size checks where the target annotation was found
+    static int    g_abi_types_skipped = 0;      // ... not registered on target (module not linked here)
+    static int    g_abi_fields_checked = 0;
+    static int    g_abi_fields_skipped = 0;
+
+    static TypeAnnotation * jit_find_handled_annotation ( const char * moduleName, const char * typeName ) {
+        TypeAnnotation * found = nullptr;
+        Module::foreach([&](Module * module) -> bool {
+            if ( module->name != moduleName ) return true;
+            auto ann = module->findAnnotation(typeName);
+            // handled-type annotations only: StructureAnnotation derives from Annotation (not
+            // TypeAnnotation), so casting one to TypeAnnotation* would be UB. The ABI sweep only
+            // emits checks for handled (BasicStructureAnnotation) types, so this is also exact.
+            if ( ann && ann->rtti_isHandledTypeAnnotation() ) {
+                found = (TypeAnnotation *) ann;
+                return false; // stop iterating
+            }
+            return true;
+        });
+        return found;
+    }
+
+    DAS_API void jit_check_handled_type_size ( const char * moduleName, const char * typeName, uint32_t hostSize ) {
+        auto ann = jit_find_handled_annotation(moduleName, typeName);
+        if ( !ann ) { g_abi_types_skipped ++; return; } // not registered on target -> module not linked here
+        g_abi_types_checked ++;
+        uint32_t targetSize = uint32_t(ann->getSizeOf());
+        if ( targetSize != hostSize ) {
+            char buf[256];
+            snprintf(buf, sizeof(buf), "  size   %s::%s  host=%u target=%u\n",
+                moduleName, typeName, hostSize, targetSize);
+            g_abi_check_report += buf;
+            g_abi_check_count ++;
+        }
+    }
+
+    DAS_API void jit_check_handled_field_offset ( const char * moduleName, const char * typeName,
+                                                  const char * fieldName, uint32_t hostOffset ) {
+        auto ann = jit_find_handled_annotation(moduleName, typeName);
+        if ( !ann ) { g_abi_fields_skipped ++; return; }
+        g_abi_fields_checked ++;
+        uint32_t targetOffset = ann->getFieldOffset(fieldName);
+        if ( targetOffset != hostOffset ) {
+            char buf[256];
+            if ( targetOffset == (uint32_t)-1 ) // field absent on the target annotation
+                snprintf(buf, sizeof(buf), "  offset %s::%s.%s  host=%u target=MISSING\n",
+                    moduleName, typeName, fieldName, hostOffset);
+            else
+                snprintf(buf, sizeof(buf), "  offset %s::%s.%s  host=%u target=%u\n",
+                    moduleName, typeName, fieldName, hostOffset, targetOffset);
+            g_abi_check_report += buf;
+            g_abi_check_count ++;
+        }
+    }
+
+    DAS_API void jit_handled_abi_check_report () {
+        DAS_FATAL_LOG("JIT ABI CHECK: types %d checked / %d skipped, fields %d checked / %d skipped, %d mismatch(es)\n",
+            g_abi_types_checked, g_abi_types_skipped, g_abi_fields_checked, g_abi_fields_skipped, g_abi_check_count);
+        if ( g_abi_check_count==0 ) {
+            // reset so a subsequent sweep in the same process reports only its own results
+            g_abi_types_checked = g_abi_types_skipped = g_abi_fields_checked = g_abi_fields_skipped = 0;
+            g_abi_check_report.clear();
+            return;
+        }
+        DAS_FATAL_ERROR("JIT ABI CHECK: %d handled-type layout mismatch(es) (host-baked vs target runtime):\n%s",
+            g_abi_check_count, g_abi_check_report.c_str());
     }
 
     DAS_API void * jit_alloc_heap ( uint32_t bytes, Context * context ) {
@@ -653,6 +734,9 @@ extern "C" {
     void *das_get_jit_get_global_mnh() { return (void *)&jit_get_global_mnh; }
     void *das_get_jit_get_shared_mnh() { return (void *)&jit_get_shared_mnh; }
     void *das_get_jit_get_handled_field_offset() { return (void *)&jit_get_handled_field_offset; }
+    void *das_get_jit_check_handled_type_size() { return (void *)&jit_check_handled_type_size; }
+    void *das_get_jit_check_handled_field_offset() { return (void *)&jit_check_handled_field_offset; }
+    void *das_get_jit_handled_abi_check_report() { return (void *)&jit_handled_abi_check_report; }
     void *das_get_jit_alloc_heap() { return (void *)&jit_alloc_heap; }
     void *das_get_jit_alloc_persistent() { return (void *)&jit_alloc_persistent; }
     void *das_get_jit_free_heap() { return (void *)&jit_free_heap; }
@@ -1208,6 +1292,12 @@ extern "C" {
                 SideEffects::none, "das_get_jit_get_shared_mnh");
             addExtern<DAS_BIND_FUN(das_get_jit_get_handled_field_offset)>(*this, lib, "get_jit_get_handled_field_offset",
                 SideEffects::none, "das_get_jit_get_handled_field_offset");
+            addExtern<DAS_BIND_FUN(das_get_jit_check_handled_type_size)>(*this, lib, "get_jit_check_handled_type_size",
+                SideEffects::none, "das_get_jit_check_handled_type_size");
+            addExtern<DAS_BIND_FUN(das_get_jit_check_handled_field_offset)>(*this, lib, "get_jit_check_handled_field_offset",
+                SideEffects::none, "das_get_jit_check_handled_field_offset");
+            addExtern<DAS_BIND_FUN(das_get_jit_handled_abi_check_report)>(*this, lib, "get_jit_handled_abi_check_report",
+                SideEffects::none, "das_get_jit_handled_abi_check_report");
             addExtern<DAS_BIND_FUN(das_get_jit_alloc_heap)>(*this, lib, "get_jit_alloc_heap",
                 SideEffects::none, "das_get_jit_alloc_heap");
             addExtern<DAS_BIND_FUN(das_get_jit_alloc_persistent)>(*this, lib, "get_jit_alloc_persistent",

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -240,10 +240,35 @@ else()
     find_program(DAS_HOST_CC  NAMES clang gcc   REQUIRED)
     find_program(DAS_HOST_CXX NAMES clang++ g++ REQUIRED)
     set(_host_compiler_args)
+    set(_host_abi_args)
     if(NOT CMAKE_HOST_WIN32)
         set(_host_compiler_args
             -DCMAKE_C_COMPILER:FILEPATH=${DAS_HOST_CC}
             -DCMAKE_CXX_COMPILER:FILEPATH=${DAS_HOST_CXX})
+        # Match the wasm TARGET's C++ ABI so cross-compiled handled-type layouts
+        # (Context, jobque, std::string-bearing structs) bake identically. The
+        # emscripten target is libc++ + C++ exceptions (-fwasm-exceptions +
+        # DAS_ENABLE_EXCEPTIONS, top of this file); the default Linux host is
+        # libstdc++ + setjmp, whose std::string (32 vs 24) / std::mutex (80 vs 40)
+        # / exception layouts diverge -> the JIT bakes wrong handled-type offsets
+        # and sizes. Building the cross-compile host libc++ + DAS_ENABLE_EXCEPTIONS
+        # makes host==target layout (verified: drops handled-type divergence to
+        # zero on every runtime-live type; only the compiler-only Program residual
+        # remains). _LIBCPP_DISABLE_DEPRECATION_WARNINGS keeps -Werror happy with
+        # libc++ deprecations (codecvt_utf8 in dasUnitTest).
+        # -stdlib=libc++ requires clang; the find_program above prefers clang but
+        # can fall back to gcc, which rejects -stdlib=libc++. Only apply the libc++
+        # ABI args when the host compiler is clang; otherwise warn that the layouts
+        # may diverge (degraded but builds) rather than hard-failing the sub-build.
+        if(DAS_HOST_CXX MATCHES "clang")
+            set(_host_abi_args
+                "-DCMAKE_CXX_FLAGS:STRING=-stdlib=libc++ -DDAS_ENABLE_EXCEPTIONS=1 -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS"
+                "-DCMAKE_C_FLAGS:STRING=-DDAS_ENABLE_EXCEPTIONS=1"
+                "-DCMAKE_EXE_LINKER_FLAGS:STRING=-stdlib=libc++"
+                "-DCMAKE_SHARED_LINKER_FLAGS:STRING=-stdlib=libc++")
+        else()
+            message(WARNING "host_daslang: clang not found (using ${DAS_HOST_CXX}); building the wasm cross-compile host with the default stdlib + setjmp — handled-type layouts may diverge from the libc++ emscripten target. Install clang for ABI parity.")
+        endif()
     endif()
     ExternalProject_Add(host_daslang
         EXCLUDE_FROM_ALL TRUE
@@ -253,6 +278,7 @@ else()
         STEP_TARGETS     build
         CMAKE_CACHE_ARGS -DCMAKE_TOOLCHAIN_FILE:STRING=
                          ${_host_compiler_args}
+                         ${_host_abi_args}
                          -DCMAKE_BUILD_TYPE:STRING=Release
                          -DDAS_LLVM_DISABLED:BOOL=OFF
                          -DDAS_PUGIXML_DISABLED:BOOL=OFF


### PR DESCRIPTION
# JIT handled-type ABI validation + libc++/exceptions wasm cross-compile host

Two related pieces of technical-debt cleanup around the wasm64 cross-compile, born from chasing why threaded-strudel games corrupt the heap on wasm.

## 1. `--jit-check-abi` — handled-type size/offset validation (opt-in diagnostic)

A new opt-in JIT mode that, at exe startup, sweeps every used handled (C++) type and compares the **host-baked** `sizeof` + field offsets against the **target runtime** annotation, reporting *all* divergences then aborting. One run reveals the full magnitude of any host↔target C++ ABI mismatch in a cross-compile.

- New flag `--jit-check-abi` (off by default; native host==target → 0 mismatches).
- C++: `jit_check_handled_type_size` / `jit_check_handled_field_offset` / `jit_handled_abi_check_report` (`module_jit.cpp`) + `get_handled_type_size` (`module_builtin_ast.cpp`).
- Codegen: `emit_handled_abi_check` sweep emitted into `initialize_modules()` (`llvm_exe.das`), gated on the flag; declarations in `llvm_jit_common.das`; flag wired in `llvm_jit_cli/run.das`. `LLVM_JIT_CODEGEN_VERSION` bumped.

This is the instrument that diagnosed the wasm divergence: from an MSVC host the report showed `std::string` (32 vs 24), `std::mutex`/jobque (80 vs 40), and `Context` field-offset divergences vs the emscripten target.

## 2. CI: build the wasm cross-compile host with libc++ + exceptions

The fix the diagnostic pointed to. The emscripten wasm **target** is libc++ + C++ exceptions (`-fwasm-exceptions` + `DAS_ENABLE_EXCEPTIONS`, `web/CMakeLists.txt`), but the wasm cross-compile **host** was built default libstdc++ + setjmp — so the JIT baked wrong handled-type layouts (the source of the wasm heap corruption).

- `pages.yml` — the cross-compile host build (`daspkg build --wasm` driver) now builds **clang + libc++ + `DAS_ENABLE_EXCEPTIONS=1`**; runner installs `libc++-dev libc++abi-dev`.
- `web/CMakeLists.txt` — the `host_daslang` ExternalProject (override fallback) gets the same args, gated non-Windows.

Verified locally (WSL): the full games-host (daslang + HV + glfw + opengl) builds clean with libc++ + exceptions, and the `--jit-check-abi` report drops to **zero handled-type divergence on every runtime-live type** (Context, jobque, all `std::string`-bearing structs); only the compiler-only `Program` struct retains a residual, which never goes runtime-live in a game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)