### PR TITLE
pages.yml: fix shell line-continuation broken by interior comment in host build (#3299 follow-up)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -98,13 +98,13 @@ jobs:
         # + exceptions makes host==target layout (verified: zero handled-type
         # divergence on every runtime-live type; only the compiler-only Program
         # residual remains).
+        # /usr/bin/clang (absolute): setup-emsdk prepends its LLVM snapshot to PATH, so a
+        # bare `clang` resolves to emsdk's (flaky on ds_parser.cpp, see version note above).
+        # /usr/bin/clang is the runner-image clang every other Linux clang job uses
+        # (build.yml, extended_checks.yml), paired with the apt libc++ installed above.
+        # NB: a `#` comment inside the `\`-continued cmake call below terminates it (exit 127).
         cmake --no-warn-unused-cli -B./build \
           -DCMAKE_BUILD_TYPE:STRING=Release \
-          # Absolute path: setup-emsdk prepends its LLVM snapshot to PATH, so a bare
-          # `clang` would resolve to emsdk's (flaky on ds_parser.cpp, see version note
-          # above). /usr/bin/clang is the runner image's clang — same one every other
-          # Linux clang job uses (build.yml, extended_checks.yml) — paired with the
-          # apt libc++ installed above.
           -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
           -DCMAKE_C_FLAGS="-DDAS_ENABLE_EXCEPTIONS=1" \
           -DCMAKE_CXX_FLAGS="-stdlib=libc++ -DDAS_ENABLE_EXCEPTIONS=1 -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS" \


### PR DESCRIPTION
## Fix-forward for the post-merge Pages deploy failure

PR #3299 added a `#` comment **inside** the `cmake ... \` line-continuation of the wasm cross-compile host build step. In bash the `\`-continued line runs into the comment, the cmake command terminates early, and the next line (`-DCMAKE_C_COMPILER=/usr/bin/clang ...`) is parsed as a *command* → `No such file or directory`, **exit 127**.

This step is **master-only** (`pages.yml` triggers on push to master, not on PRs), so it never ran in #3299's CI and only surfaced on the post-merge Pages deploy ([run on merge commit `763c2f0b0`](https://github.com/GaijinEntertainment/daScript/actions/runs/28380298957)). The prior successful deploy stayed live, so there was **no user-facing breakage** — master's latest simply didn't redeploy.

### Fix
Move the `/usr/bin/clang` rationale comment to **above** the `cmake` invocation. No change to the build flags themselves. This unblocks the configure so the libc++/exceptions host build (the actual point of #3299's CI change) can finally run — that build is validated for the first time by *this* PR's deploy.

```
 1 file changed, 5 insertions(+), 5 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)