### PR TITLE
dasHV: forward parent C/C++ + linker flags to the libhv ExternalProject (libc++ host fix)

### DIFF
--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -117,17 +117,28 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 		-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
 		-DOPENSSL_LIBRARIES="${OPENSSL_CRYPTO_LIBRARY};${OPENSSL_SSL_LIBRARY}"
 	)
+	# Forward the parent build's C/C++ + linker flags into the libhv sub-build so its
+	# stdlib/ABI matches daslang. Without this a libc++ host build (-stdlib=libc++, the
+	# wasm cross-compile host) leaves libhv on clang's default libstdc++, and the resulting
+	# dasModuleHV.shared_module carries undefined std::__cxx11 symbols that fail to dlopen
+	# under the libc++ daslang (surfaces as a misleading error[20605] missing prereq 'dashv').
+	SET(_HV_C_FLAGS "${CMAKE_C_FLAGS}")
+	SET(_HV_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 	IF(DAS_USE_SANITIZER STREQUAL "address" OR DAS_USE_SANITIZER STREQUAL "asan")
 		IF(MSVC)
 			SET(_HV_ASAN_FLAG "/fsanitize=address")
 		ELSE()
 			SET(_HV_ASAN_FLAG "-fsanitize=address")
 		ENDIF()
-		LIST(APPEND HV_CMAKE_FLAGS
-			"-DCMAKE_C_FLAGS=${_HV_ASAN_FLAG}"
-			"-DCMAKE_CXX_FLAGS=${_HV_ASAN_FLAG}"
-		)
+		SET(_HV_C_FLAGS "${_HV_C_FLAGS} ${_HV_ASAN_FLAG}")
+		SET(_HV_CXX_FLAGS "${_HV_CXX_FLAGS} ${_HV_ASAN_FLAG}")
 	ENDIF()
+	LIST(APPEND HV_CMAKE_FLAGS
+		"-DCMAKE_C_FLAGS:STRING=${_HV_C_FLAGS}"
+		"-DCMAKE_CXX_FLAGS:STRING=${_HV_CXX_FLAGS}"
+		"-DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}"
+		"-DCMAKE_SHARED_LINKER_FLAGS:STRING=${CMAKE_SHARED_LINKER_FLAGS}"
+	)
 	# libhv's ExternalProject picks its own CRT; if it disagrees with daslang's,
 	# hv_static.lib fails to link into dasModuleHV (LNK2038 RuntimeLibrary
 	# mismatch: MT_StaticRelease vs MD_DynamicRelease). daslang uses the dynamic


### PR DESCRIPTION
## Fixes the post-#3299 Pages-deploy failure (libc++ host → dasHV won't dlopen)

#3299 switched the wasm cross-compile host build to libc++ (`-stdlib=libc++`) for handled-type ABI parity with the emscripten target. The host build itself compiles + links fine, but the Pages deploy then failed at **`Run das2rst`** with the misleading `error[20605]: missing prerequisite 'dashv'; file not found`.

### Root cause
The `LIBHV` ExternalProject in `modules/dasHV/CMakeLists.txt` passed `-DCMAKE_CXX_COMPILER` but **not** the parent's `CMAKE_CXX_FLAGS`. So under a libc++ host build, libhv stayed on clang's **default libstdc++**, and the resulting `dasModuleHV.shared_module` carried **~30 undefined `std::__cxx11`** (libstdc++) symbols. Those fail to dlopen under the libc++ daslang — and daslang swallows the dlopen failure into the misleading 20605. das2rst reflects dasHV, so it tripped there.

### Fix
Forward `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS` (with the existing asan flag folded in — it previously *overwrote* these) plus `CMAKE_EXE_LINKER_FLAGS` / `CMAKE_SHARED_LINKER_FLAGS` into `HV_CMAKE_FLAGS`, so libhv matches daslang's stdlib/ABI.

### Verification
Reproduced + fixed in a WSL libc++ build (`clang++ -stdlib=libc++` + exceptions, the exact Pages host config):

| | before | after |
|---|---|---|
| `dasModuleHV` undefined `__cxx11` syms | 30 | **0** |
| `daslang doc/reflections/das2rst.das` | `error[20605]` | **exit 0, clean** |

Cross-platform (MSVC / gcc / macOS) builds of dasHV are exercised by the regular build matrix in this PR. The libc++-host path is master-only (Pages), so it validates on the next deploy after merge — but the WSL run above already proves it.

```
 modules/dasHV/CMakeLists.txt | 19 +++++++++++++++----
 1 file changed, 15 insertions(+), 4 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)