### PR TITLE
ci(pages): build wasm64 game/module archives -pthread + make game builds non-fatal

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,7 +77,10 @@ jobs:
           web/output64
           site/playground/samples
           site/playground/tutorials
-        key: wasm-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'web/CMakeLists.txt', 'web/stage_playground_imgui_samples.cmake', 'src/**', 'include/**', 'modules/**', 'daslib/**', 'utils/daspkg/**', 'examples/games/**', 'examples/graphics/**', 'examples/pathTracer/**', 'web/examples/ui/samples/**', 'tutorials/**', 'dastest/**') }}
+        # The workflow file itself is a build input (it carries the configure flags
+        # for web/build64 below), so hash it too — a change to the build steps must
+        # miss a stale cache rather than skip the rebuild and reuse old archives.
+        key: wasm-${{ runner.os }}-${{ hashFiles('.github/workflows/pages.yml', 'CMakeLists.txt', 'web/CMakeLists.txt', 'web/stage_playground_imgui_samples.cmake', 'src/**', 'include/**', 'modules/**', 'daslib/**', 'utils/daspkg/**', 'examples/games/**', 'examples/graphics/**', 'examples/pathTracer/**', 'web/examples/ui/samples/**', 'tutorials/**', 'dastest/**') }}
 
     # Host daslang — one games-capable build (dasLLVM for cross-compile + dasGlfw
     # + dasOpenGL shared modules for the games) that serves BOTH das2rst and the
@@ -193,10 +196,17 @@ jobs:
         #    the prebuilt host (so the compute foreach reuses it instead of
         #    rebuilding daslang) + memory64; daspkg build --wasm then populates the
         #    runtime/module archives into it.
+        #    DAS_WASM_PTHREADS=ON: daspkg `release wasm` now ALWAYS links -pthread
+        #    (--shared-memory), so the module archives it links (dasGlfw/dasOpenGL/...)
+        #    MUST be compiled with +atomics,+bulk-memory or wasm-ld rejects the link
+        #    ("--shared-memory is disallowed by dasGLFW.cpp.o"). cmd_build_wasm only
+        #    self-configures threads when build64 has no cache yet, but we pre-create
+        #    the cache here (for the host override), so set the flag explicitly.
         emcmake cmake -S web -B web/build64 -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DDAS_WEB_OUTPUT_DIR="$REPO/web/output64" \
           -DDAS_WASM_MEMORY64=ON \
+          -DDAS_WASM_PTHREADS=ON \
           -DCMAKE_CXX_FLAGS=-sMEMORY64=1 -DCMAKE_C_FLAGS=-sMEMORY64=1 \
           -DDAS_HOST_DASLANG_OVERRIDE="$REPO/bin/daslang"
         ./bin/daslang utils/daspkg/main.das -- build --wasm
@@ -204,10 +214,17 @@ jobs:
         # 3. compute playground samples → wasm64 (web/output64/samples/examples)
         cmake --build web/build64 --target all_wasm
 
-        # 4. /examples games → standalone wasm64 web apps (web/output64/examples/<g>/)
+        # 4. /examples games → standalone wasm64 web apps (web/output64/examples/<g>/).
+        #    Non-fatal per game: a game's wasm build must never red the whole deploy
+        #    (which would take the playground + the other example cards down with it).
+        #    The staging step degrades a missing game wasm to its interpreted fallback.
         for g in arcanoid pacman; do
-            ./bin/daslang utils/daspkg/main.das -- \
-                release wasm --root "examples/games/$g" --out "$REPO/web/output64/examples"
+            if ./bin/daslang utils/daspkg/main.das -- \
+                 release wasm --root "examples/games/$g" --out "$REPO/web/output64/examples"; then
+                echo "$g wasm build OK"
+            else
+                echo "WARNING: $g wasm build failed — its card falls back to interpreted this deploy."
+            fi
         done
 
         # 5. /examples furier — the ImGui-in-wasm showcase. Unlike the games (all


### PR DESCRIPTION
Fixes the post-merge Pages deploy, which failed linking `arcanoid`:

```
wasm-ld: error: --shared-memory is disallowed by dasGLFW.cpp.o because it was
         not compiled with 'atomics' or 'bulk-memory' features.
```

### Root cause
The Path Tracer Lab PR (#3302) made daspkg `release wasm` **always** link `-pthread`
(`--shared-memory`). But `pages.yml` step 2 pre-configures `web/build64` *without*
`-DDAS_WASM_PTHREADS`, and `cmd_build_wasm` only self-enables threads when `build64`
has **no cache yet** — the pre-configure already created one. So the module archives
(`dasGlfw`/`dasOpenGL`/…) were compiled non-threaded while the link demanded shared
memory. The games were the first link to hit it, and that step was **fatal**, so it
took the whole deploy down (playground + the other example cards with it).

### Fix (pages.yml only)
1. **`-DDAS_WASM_PTHREADS=ON`** on the `web/build64` configure → the module archives
   are compiled with `+atomics,+bulk-memory`, matching daspkg's threaded link. *The
   actual fix.*
2. **Non-fatal games** — wrap step 4's per-game `release wasm` in `if/else`. A game's
   wasm build must never red the whole deploy; the staging step already degrades a
   missing game wasm to its interpreted fallback.
3. **Cache key hashes `pages.yml`** — the workflow file carries the configure flags,
   so a change to the build steps must miss any stale (partial, non-threaded) cache
   the failed run may have saved under the same key, rather than skip the rebuild.

### Notes
- This makes the games + compute samples threaded wasm (served cross-origin-isolated
  under `/examples` + `/playground` by the coi-serviceworker, already in place). The
  games' music gate flips on, but the wasm-audio crash is fixed upstream — worst case
  is the known "music stops" behavior, not a crash.
- Deploy-workflow-only change: it can't be exercised by PR CI (the Pages deploy runs
  on master push), so it's validated by the post-merge deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)