### PR TITLE
src/hal: serialize wasm malloc/free across the AudioWorklet thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,6 +999,7 @@ src/hal/crash_handler.cpp
 src/hal/project_specific.cpp
 src/hal/project_specific_file_info.cpp
 src/hal/project_specific_crash_handler.cpp
+src/hal/wasm_thread_malloc.cpp
 include/daScript/misc/crash_handler.h
 include/daScript/misc/network.h
 src/misc/network.cpp

--- a/src/hal/wasm_thread_malloc.cpp
+++ b/src/hal/wasm_thread_malloc.cpp
@@ -1,0 +1,58 @@
+// Global serialization of heap allocation on threaded WebAssembly builds.
+//
+// emscripten's dlmalloc lock only serializes pthreads. The AudioWorklet audio thread runs as a
+// Wasm Worker (-sWASM_WORKERS, required by -sAUDIO_WORKLET) and bypasses that lock, so its
+// malloc/free races against the pthreads on the shared dlmalloc arena -> arena corruption (a later
+// posix_memalign aborts in dispose_chunk; or a contended lock busy-spins forever, since the audio
+// thread cannot Atomics.wait). We wrap every allocation entry point in one process-wide spinlock
+// (which the Wasm Worker DOES honor) and delegate to the real allocator (emscripten_builtin_*), so
+// das, C++ new and miniaudio allocations are mutually exclusive across the pthreads and the worklet.
+//
+// No-op except on threaded wasm; native and single-threaded wasm compile this to an empty unit.
+
+#if defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_SHARED_MEMORY__)
+
+#include <stddef.h>
+#include <atomic>
+
+extern "C" {
+    void  *emscripten_builtin_malloc(size_t);
+    void   emscripten_builtin_free(void *);
+    void  *emscripten_builtin_calloc(size_t, size_t);
+    void  *emscripten_builtin_realloc(void *, size_t);
+    void  *emscripten_builtin_memalign(size_t, size_t);
+}
+
+static std::atomic_flag g_das_wasm_malloc_lock = ATOMIC_FLAG_INIT;
+static inline void das_wasm_malloc_acquire() { while (g_das_wasm_malloc_lock.test_and_set(std::memory_order_acquire)) {} }
+static inline void das_wasm_malloc_release() { g_das_wasm_malloc_lock.clear(std::memory_order_release); }
+
+extern "C" {
+
+void *malloc(size_t n) {
+    das_wasm_malloc_acquire(); void *p = emscripten_builtin_malloc(n); das_wasm_malloc_release(); return p;
+}
+void free(void *p) {
+    if (!p) return; das_wasm_malloc_acquire(); emscripten_builtin_free(p); das_wasm_malloc_release();
+}
+void *calloc(size_t a, size_t b) {
+    das_wasm_malloc_acquire(); void *p = emscripten_builtin_calloc(a, b); das_wasm_malloc_release(); return p;
+}
+void *realloc(void *p, size_t n) {
+    das_wasm_malloc_acquire(); void *r = emscripten_builtin_realloc(p, n); das_wasm_malloc_release(); return r;
+}
+void *memalign(size_t al, size_t n) {
+    das_wasm_malloc_acquire(); void *p = emscripten_builtin_memalign(al, n); das_wasm_malloc_release(); return p;
+}
+void *aligned_alloc(size_t al, size_t n) {
+    das_wasm_malloc_acquire(); void *p = emscripten_builtin_memalign(al, n); das_wasm_malloc_release(); return p;
+}
+int posix_memalign(void **out, size_t al, size_t n) {
+    das_wasm_malloc_acquire(); void *p = emscripten_builtin_memalign(al, n); das_wasm_malloc_release();
+    if (!p) return 12 /*ENOMEM*/;
+    *out = p; return 0;
+}
+
+}  // extern "C"
+
+#endif


### PR DESCRIPTION
## Problem

On threaded WebAssembly, the dasAudio mixer runs on the **AudioWorklet** audio thread. emscripten's dlmalloc lock only serializes **pthreads** — but the AudioWorklet thread runs as a **Wasm Worker** (`-sWASM_WORKERS`, required by `-sAUDIO_WORKLET`), which **bypasses that lock**. So the worklet's `malloc`/`free` races against the pthreads (the strudel producer + main) on the shared dlmalloc arena.

The arena gets corrupted, which surfaces two ways (same root):
- a later `posix_memalign` aborts inside dlmalloc's `dispose_chunk` → **crash** (`RuntimeError: unreachable` on a Pthread), or
- a contended lock busy-spins forever (the audio thread can't `Atomics.wait`) → **stall** (music stops after a few seconds).

This is the long-standing wasm strudel "music stops after a few seconds / random Pthread abort" failure that parked the games-with-music milestone.

## Diagnosis

Reproduced in an isolated pure-strudel AudioWorklet harness (no GL/decs). A process-wide spinlock around **only** the dlmalloc entry points (`das_aligned_alloc16`/`free16`), leaving the per-context allocator map unguarded, took the isolated repro from **4/6 crash → 0/6** — proving it is literally two threads concurrently inside dlmalloc, and that emscripten's own malloc lock does not cover the Wasm-Worker audio thread. (A das-only lock isn't enough — the mixer also does C++ `new`/miniaudio `malloc`, so the fix has to cover every allocation entry point.)

## Fix

`src/hal/wasm_thread_malloc.cpp` wraps every allocation entry point (`malloc`/`free`/`calloc`/`realloc`/`memalign`/`aligned_alloc`/`posix_memalign`) in one process-wide `atomic_flag` spinlock — which the Wasm Worker **does** honor — delegating to the real allocator (`emscripten_builtin_*`). das, C++ `new` and miniaudio allocations are now mutually exclusive across the pthreads and the worklet.

- Gated `#if defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_SHARED_MEMORY__)` → **empty translation unit on native and single-threaded wasm** (no behavior change off threaded-wasm).
- Added to `SIMULATE_SRC`, so it compiles into the runtime and the override is picked up by every cross-compiled threaded-wasm module — no per-link flag needed.
- Spinlock holds are a single `posix_memalign`/`free` (µs), so there's no priority-inversion freeze even when the main thread is CPU-bound.

## Verification

- **Native (libc++):** builds clean (empty TU), daslang links.
- **Isolated strudel ambient (wasm64 threaded):** 4/6 crash → **0 crashes**, sustains under a 12 ms/frame main-thread busy-spin (models a heavy game frame).
- **arcanoid (wasm64 threaded, with music), fix from the runtime archive:** baseline ~2 s-then-stall → **full-duration continuous music** across runs (1 residual early-stall is the pre-existing worklet-startup flake, ~20% even on clean builds, unrelated to this corruption).

## Notes

- Native, single-thread wasm, and all non-emscripten targets are unaffected (gated out).
- Minor perf: dlmalloc already globally-locked the pthreads, so the only *added* serialization is worklet↔pthreads (necessary for correctness); the double-lock overhead is µs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)