### PR TITLE
core: read real core count via emscripten_num_logical_cores on emscripten

### DIFF
--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -5,6 +5,10 @@
 #include "daScript/simulate/aot_builtin_jobque.h"
 #include "daScript/misc/string_writer.h"
 
+#if defined(__EMSCRIPTEN__)
+#include <emscripten/threading.h>   // emscripten_num_logical_cores
+#endif
+
 // Feature tracking statics
 das::Feature *  das::Feature::sTrackHead = nullptr;
 das::mutex      das::Feature::sTrackMutex;
@@ -40,7 +44,16 @@ namespace das {
 #else
 
     int JobQue::get_num_threads() {
-        return jobque_thread_count(max(1,static_cast<int>(thread::hardware_concurrency())));
+#if defined(__EMSCRIPTEN__)
+        // emscripten's std::thread::hardware_concurrency() does NOT reflect
+        // navigator.hardwareConcurrency in the wasm64/memory64 build (it returns a
+        // low default ~2); emscripten_num_logical_cores() reads it directly and is
+        // correct on both wasm32/64.
+        int hw = emscripten_num_logical_cores();
+#else
+        int hw = static_cast<int>(thread::hardware_concurrency());
+#endif
+        return jobque_thread_count(max(1, hw));
     }
 
 #endif


### PR DESCRIPTION
On the **wasm64/memory64** build, `std::thread::hardware_concurrency()` returns a low default (~2) instead of `navigator.hardwareConcurrency`, so `JobQue::get_num_threads` (and therefore `get_total_hw_threads`) caps the worker pool / thread count far below the real core count.

Symptom: the shipped Path Tracer Lab card's **Threads** slider maxed at **2** on a 64-core box. Verified against the live site — the iframe context is cross-origin-isolated and reports `navigator.hardwareConcurrency = 64`, and the **wasm32** playground reads it correctly (`get_total_hw_threads()` → 4, the `DAS_MAX_HW_JOBS` cap). Only the wasm64 card under-reports.

`emscripten_num_logical_cores()` reads `navigator.hardwareConcurrency` directly and is correct on both wasm32 and wasm64. This routes `get_num_threads` through it on emscripten (keeping the existing `jobque_thread_count` cores-1 / `DAS_MAX_HW_JOBS` logic). Desktop/native paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)