### PR TITLE
Prefill 4.2×: thread attention/requant/norm + size jobque to Apple Silicon performance cores

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -48,6 +48,27 @@ def vaxpy(d : float const?; s : float const?; scale : float; n : int64) {
     }
 }
 
+//! d[j] += s[j], width-8 vectorized (the residual-stream update). The plain `for k; a[k]+=b[k]`
+//! over bounds-checked arrays does NOT vectorize under the JIT — this pointer form is ~5x faster.
+[hint(unsafe_range_check, noalias = d, noalias = s)]
+def add_inplace(var d : float?; s : float const?; n : int64) {
+    for [vectorize, vectorize_width = 8, unroll_count = 2] (j in range64(n)) {
+        unsafe {
+            d[j] += s[j]
+        }
+    }
+}
+
+//! d[j] *= s[j], width-8 vectorized — the SwiGLU/GeGLU gate multiply (act(W1·x) * (W3·x)).
+[hint(unsafe_range_check, noalias = d, noalias = s)]
+def mul_inplace(var d : float?; s : float const?; n : int64) {
+    for [vectorize, vectorize_width = 8, unroll_count = 2] (j in range64(n)) {
+        unsafe {
+            d[j] *= s[j]
+        }
+    }
+}
+
 // n*d above this -> split the output rows across worker threads. Below it, the per-call
 // job-dispatch overhead (~90us) dwarfs the gain, so stay single-thread. (Measured on M1 Max:
 // classifier 32000x288 = 9.2M threads to ~2x; ffn 768x288 = 0.22M would be ~5x slower.)
@@ -495,17 +516,20 @@ def rmsnorm(var o : array<float> | #; x : array<float> | #; weight : array<float
 def softmax(xc : float const?; size : int64) {
     unsafe {
         var x = reinterpret<float?>(xc)
+        // max is exact + idempotent, so the vectorized reduce (any order, x[0] folded in twice) is bit-exact
         var maxv = x[0]
-        for (i in range64(1l, size)) {
+        for [vectorize, vectorize_width = 8, unroll_count = 2] (i in range64(size)) {
             maxv = max(maxv, x[i])
         }
         var sum = 0.0
-        for (i in range64(size)) {
-            x[i] = exp(x[i] - maxv)
-            sum += x[i]
+        for [vectorize, vectorize_width = 8, unroll_count = 2] (i in range64(size)) {
+            let e = exp(x[i] - maxv)
+            x[i] = e
+            sum += e
         }
-        for (i in range64(size)) {
-            x[i] /= sum
+        let inv_sum = 1.0 / sum   // scale by the reciprocal (matches ggml_vec_scale_f32), not a per-element /=
+        for [vectorize, vectorize_width = 8, unroll_count = 2] (i in range64(size)) {
+            x[i] *= inv_sum
         }
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -34,6 +34,20 @@ def axpy(var d : float?; s : float const?; scale : float; n : int64) {
     }
 }
 
+//! Fork-callable AXPY for the threaded prefill attention. Same width-8 kernel as axpy, but takes
+//! `d` as `const?` so a capture-const fork pointer binds (add-const is allowed) — un-consts inside
+//! to write. NO `noalias` hint on purpose: `const?`+reinterpret under noalias miscompiles. Output
+//! and the value-cache source never overlap, so the vectorizer's runtime alias check always passes.
+[hint(unsafe_range_check)]
+def vaxpy(d : float const?; s : float const?; scale : float; n : int64) {
+    unsafe {
+        var dm = reinterpret<float?>(d)
+        for [vectorize, vectorize_width = 8, unroll_count = 2] (j in range64(n)) {
+            dm[j] += scale * s[j]
+        }
+    }
+}
+
 // n*d above this -> split the output rows across worker threads. Below it, the per-call
 // job-dispatch overhead (~90us) dwarfs the gain, so stay single-thread. (Measured on M1 Max:
 // classifier 32000x288 = 9.2M threads to ~2x; ffn 768x288 = 0.22M would be ~5x slower.)
@@ -475,19 +489,28 @@ def rmsnorm(var o : array<float> | #; x : array<float> | #; weight : array<float
 //! softmax — turns a score vector into a probability distribution (sums to 1).
 //! In place over the first `size` elements. Subtracts the max first so exp() can't
 //! overflow (exp(x-max)/sum(exp(x-max)) is identical math, numerically safe).
+//! Pointer core — the threaded prefill attention runs in fork contexts and can only touch raw
+//! addresses; the array overload forwards here, so both are bit-identical. Takes `const?` so a
+//! capture-const fork pointer binds (add-const is allowed); un-consts internally to write in place.
+def softmax(xc : float const?; size : int64) {
+    unsafe {
+        var x = reinterpret<float?>(xc)
+        var maxv = x[0]
+        for (i in range64(1l, size)) {
+            maxv = max(maxv, x[i])
+        }
+        var sum = 0.0
+        for (i in range64(size)) {
+            x[i] = exp(x[i] - maxv)
+            sum += x[i]
+        }
+        for (i in range64(size)) {
+            x[i] /= sum
+        }
+    }
+}
 def softmax(var x : array<float> | #; size : int64) {
-    var maxv = x[0]
-    for (i in range64(1l, size)) {
-        maxv = max(maxv, x[i])
-    }
-    var sum = 0.0
-    for (i in range64(size)) {
-        x[i] = exp(x[i] - maxv)
-        sum += x[i]
-    }
-    for (i in range64(size)) {
-        x[i] /= sum
-    }
+    softmax(unsafe(addr(x[0])), size)
 }
 
 //! SiLU (a.k.a. swish) activation: silu(x) = x * sigmoid(x) = x / (1 + exp(-x)).
@@ -515,11 +538,18 @@ def gelu(var x : array<float> | #; size : int64) {
 //! Logit soft-capping (Gemma2): x = cap * tanh(x / cap), elementwise over the first `size`.
 //! Smoothly bounds values to (-cap, cap). Applied to attention scores (cap 50) after the
 //! 1/sqrt(head_size) scale and before softmax, and to the final classifier logits (cap 30).
-def softcap(var x : array<float> | #; size : int64; cap : float) {
+//! Pointer core (see softmax) — threaded prefill attention calls this on raw fork addresses.
+def softcap(xc : float const?; size : int64; cap : float) {
     let inv = 1.0 / cap
-    for (i in range64(size)) {
-        x[i] = cap * tanh(x[i] * inv)
+    unsafe {
+        var x = reinterpret<float?>(xc)
+        for (i in range64(size)) {
+            x[i] = cap * tanh(x[i] * inv)
+        }
     }
+}
+def softcap(var x : array<float> | #; size : int64; cap : float) {
+    softcap(unsafe(addr(x[0])), size, cap)
 }
 
 //! RoPE — rotary position embedding. Rotates each adjacent coordinate pair (2j, 2j+1)

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -494,16 +494,28 @@ def matmul_q4(var y : array<float>; wq : array<uint8> | #; ws : array<float> | #
 //! RMSNorm — root-mean-square normalization (no mean subtraction, no bias).
 //! o[i] = weight[i] * x[i] / sqrt(mean(x^2) + eps). eps defaults to 1e-5 (Llama-2/3);
 //! Qwen2 / Gemma2 pass 1e-6 from the model's metadata.
-def rmsnorm(var o : array<float> | #; x : array<float> | #; weight : array<float> | #; size : int64; eps : float = 1.0e-5) {
-    var ss = 0.0
-    for (j in range64(size)) {
-        ss += x[j] * x[j]
+//! Pointer core — the batched prefill norm threads over positions in fork contexts (raw addresses
+//! only). `o`/`x` may alias (in-place post-norms): the sum over x completes before any write to o.
+def rmsnorm(o : float const?; x : float const?; weight : float const?; size : int64; eps : float = 1.0e-5) {
+    unsafe {
+        var oo = reinterpret<float?>(o)
+        var ss = 0.0
+        for (j in range64(size)) {
+            ss += x[j] * x[j]
+        }
+        ss /= float(size)
+        ss += eps
+        ss = 1.0 / sqrt(ss)
+        for (j in range64(size)) {
+            oo[j] = weight[j] * (x[j] * ss)
+        }
     }
-    ss /= float(size)
-    ss += eps
-    ss = 1.0 / sqrt(ss)
-    for (j in range64(size)) {
-        o[j] = weight[j] * (x[j] * ss)
+}
+def rmsnorm(var o : array<float> | #; x : array<float> | #; weight : array<float> | #; size : int64; eps : float = 1.0e-5) {
+    // reinterpret strips the temporary (#) qualifier — rms_at passes array_view (#) slices
+    unsafe {
+        rmsnorm(reinterpret<float const?>(addr(o[0])), reinterpret<float const?>(addr(x[0])),
+            reinterpret<float const?>(addr(weight[0])), size, eps)
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_quant.das
+++ b/modules/dasLLAMA/dasllama/dasllama_quant.das
@@ -52,18 +52,30 @@ def quantize_q8_0(src : array<float> | #; n : int64) : Q8Tensor {
 //! quantize one tensor at a time into the model's shared qblob/qscales. n must be a multiple of 32.
 def quantize_q8_0_into(src : array<float> | #; n : int64; var qdst : array<int8>; var sdst : array<float>; qoff, soff : int64) {
     assert(n % QK8 == 0l, "quantize_q8_0_into requires n to be a multiple of 32")
+    quantize_q8_0_into_ptr(unsafe(addr(src[0])), n, unsafe(addr(qdst[0])), unsafe(addr(sdst[0])), qoff, soff)
+}
+
+//! Pointer core of quantize_q8_0_into — the batched prefill requant threads over positions in fork
+//! contexts, which can only touch raw addresses. Takes the destinations as `const?` so capture-const
+//! fork pointers bind (add-const is allowed); un-consts internally to write. Bit-identical to the
+//! array overload, which forwards here.
+def quantize_q8_0_into_ptr(src : float const?; n : int64; qdst : int8 const?; sdst : float const?; qoff, soff : int64) {
     let nblocks = n / QK8
-    for (b in range64(nblocks)) {
-        let base = b * QK8
-        var amax = 0.0
-        for (i in range64(QK8)) {
-            amax = max(amax, abs(src[base + i]))
-        }
-        let d = amax / 127.0
-        let id = d != 0.0 ? 1.0 / d : 0.0
-        sdst[soff + b] = d
-        for (i in range64(QK8)) {
-            qdst[qoff + base + i] = int8(round(src[base + i] * id))
+    unsafe {
+        var q = reinterpret<int8?>(qdst)
+        var s = reinterpret<float?>(sdst)
+        for (b in range64(nblocks)) {
+            let base = b * QK8
+            var amax = 0.0
+            for (i in range64(QK8)) {
+                amax = max(amax, abs(src[base + i]))
+            }
+            let d = amax / 127.0
+            let id = d != 0.0 ? 1.0 / d : 0.0
+            s[soff + b] = d
+            for (i in range64(QK8)) {
+                q[qoff + base + i] = int8(round(src[base + i] * id))
+            }
         }
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -990,9 +990,7 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
                 }
             }
         }
-        for (k in range64(npos * dim)) {
-            s.x_b[k] += s.xb2_b[k]
-        }
+        add_inplace(unsafe(addr(s.x_b[0])), unsafe(addr(s.xb2_b[0])), npos * dim)
         prof_add("act_resid", ts_resid0)
         // ffn rmsnorm, per position
         let ts_norm1 = ref_time_ticks()
@@ -1015,9 +1013,7 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         } else {
             silu(s.hb_b, npos * hidden)
         }
-        for (k in range64(npos * hidden)) {
-            s.hb_b[k] *= s.hb2_b[k]
-        }
+        mul_inplace(unsafe(addr(s.hb_b[0])), unsafe(addr(s.hb2_b[0])), npos * hidden)
         prof_add("act_resid", ts_act)
         // down projection (batched) + optional post-FFN norm + residual
         let ts_ffn2 = ref_time_ticks()
@@ -1031,9 +1027,7 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
                 }
             }
         }
-        for (k in range64(npos * dim)) {
-            s.x_b[k] += s.xb_b[k]
-        }
+        add_inplace(unsafe(addr(s.x_b[0])), unsafe(addr(s.xb_b[0])), npos * dim)
         prof_add("act_resid", ts_resid1)
     }
 

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -658,9 +658,21 @@ def private mm_b(var y : array<float>; t : Transformer; woff : int64; x : array<
     if (t.quant == QuantMode.q8) {
         let nb = n / 32l
         let ts_rq = ref_time_ticks()
-        for (p in range64(npos)) {
-            array_view(x, p * n, n) $(col : array<float>#) {
-                quantize_q8_0_into(col, n, xqb, xsb, p * n, p * nb)
+        // quantize each of the npos activation columns into xqb/xsb — independent per position, so
+        // thread it (it was the largest serial bucket once attention + GEMM threaded). Fork workers
+        // touch raw addresses only; quantize_q8_0_into_ptr un-consts the captured destinations.
+        unsafe {
+            let xp = reinterpret<float const?>(addr(x[0]))
+            var qp = addr(xqb[0])
+            var sp = addr(xsb[0])
+            let rq_par = n * npos >= REQUANT_PAR_THRESHOLD
+            maybe_parallel_for(rq_par, 0, int(npos), get_total_hw_jobs()) $(rb, re) {
+                unsafe {
+                    for (p in range(rb, re)) {
+                        let pp = int64(p)
+                        quantize_q8_0_into_ptr(xp + pp * n, n, qp, sp, pp * n, pp * nb)
+                    }
+                }
             }
         }
         prof_add("mm_requant", ts_rq)
@@ -802,6 +814,8 @@ def forward(t : Transformer; var s : RunState; token, pos : int64) {
 // Thread the prefill attention over heads once the work proxy (npos × max-cnt × n_heads) clears this;
 // below it the per-job dispatch overhead isn't worth it and we run the head loop inline.
 let ATTN_PAR_THRESHOLD = 100_000l
+// Thread the per-position activation requant (mm_b) once n × npos clears this.
+let REQUANT_PAR_THRESHOLD = 256_000l
 
 var g_prefill_prof_acc : table<string; int64>
 

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -8,6 +8,7 @@ require dasllama/dasllama_math
 require dasllama/dasllama_math_aarch64_neon  // registers the arm64 SDOT Q8·Q8 backend at [init]; no-op off-ARM
 require dasllama/dasllama_quant
 require dasllama/dasllama_gguf
+require dasllama/dasllama_par  // maybe_parallel_for (+ get_total_hw_jobs): thread the prefill attention over heads
 require math
 
 // dasLLAMA inference engine. A model is split into two regions by role: a small fp32 aux blob
@@ -516,7 +517,9 @@ struct RunState {
     q : array<float>          // query (dim)
     k : array<float>          // key, this position (kv_dim)
     v : array<float>          // value, this position (kv_dim)
-    att : array<float>        // attention scores for one head (seq_len)
+    att : array<float>        // attention scores for one head (seq_len) — the per-token forward() path
+    att_b : array<float>      // batched prefill attention scores, one (start_pos+npos)-wide row PER HEAD
+                              // so the head loop threads with no shared scratch (sized in forward_prefill)
     logits : array<float>     // output logits (vocab_size)
     xq : array<int8>          // activation quantized to Q8 (sized max(dim, hidden_dim)) for the Q8·Q8 kernel
     xs : array<float>         // per-block activation scales (sized max(dim, hidden_dim) / 32)
@@ -796,6 +799,10 @@ def forward(t : Transformer; var s : RunState; token, pos : int64) {
 // Measurement is UNCONDITIONAL: a handful of ref_time_ticks() + table adds per prefill, negligible
 // against the matmuls, so it always accumulates. Output is on-demand — reset() to start a window,
 // report() to dump it. (We measure a lot; never gate the measurement, only the printing.)
+// Thread the prefill attention over heads once the work proxy (npos × max-cnt × n_heads) clears this;
+// below it the per-job dispatch overhead isn't worth it and we run the head loop inline.
+let ATTN_PAR_THRESHOLD = 100_000l
+
 var g_prefill_prof_acc : table<string; int64>
 
 //! Start a fresh measurement window (zero the per-section accumulators).
@@ -856,6 +863,9 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
     s.hb2_b |> resize(npos * hidden)
     s.xqb |> resize(npos * maxn)
     s.xsb |> resize(npos * maxn / 32l)
+    // per-head attention scratch: each head gets its own (start_pos+npos)-wide score row (= max cnt),
+    // so the head loop threads with no shared `att` row to contend on
+    s.att_b |> resize(n_heads * (start_pos + npos))
 
     // token embeddings -> residual stream x_b [npos x dim]
     let ts_embed = ref_time_ticks()
@@ -921,28 +931,49 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         // per-position causal attention into xb_b (position ap attends to cached keys kstart..ap;
         // kstart = 0 unless a Gemma2 sliding-window layer past the window). The attention output for
         // position p is written at xb_b[p*qd..] (qd-strided), feeding the wo projection below.
+        // THREADED OVER HEADS: every head does the same causal triangle (perfect load balance) and
+        // writes a disjoint output slice [p*qd + h*head_size ..]; each head owns its own att_b row, so
+        // there is no shared scratch to contend on. Workers run in fork contexts → raw pointers only.
         let ts_attn = ref_time_ticks()
-        for (p in range64(npos)) {
-            let ap = start_pos + p
-            let kstart = (is_sliding && ap + 1l > c.sliding_window) ? (ap + 1l - c.sliding_window) : 0l
-            let cnt = ap + 1l - kstart
-            for (h in range64(n_heads)) {
-                let qoff = h * head_size
-                let kvhoff = (h / kv_mul) * head_size
-                for (j in range64(cnt)) {
-                    let koff = loff + (kstart + j) * kv_dim + kvhoff
-                    s.att[j] = dot(unsafe(addr(s.q_b[p * qd + qoff])), unsafe(addr(s.key_cache[koff])), head_size) * scale
-                }
-                if (c.attn_logit_softcap > 0.0) {  // Gemma2: soft-cap scores before softmax
-                    softcap(s.att, cnt, c.attn_logit_softcap)
-                }
-                softmax(s.att, cnt)
-                for (i in range64(head_size)) {
-                    s.xb_b[p * qd + qoff + i] = 0.0
-                }
-                for (j in range64(cnt)) {
-                    let voff = loff + (kstart + j) * kv_dim + kvhoff
-                    axpy(unsafe(addr(s.xb_b[p * qd + qoff])), unsafe(addr(s.value_cache[voff])), s.att[j], head_size)
+        let maxctx = start_pos + npos          // per-head att row width (= max cnt over this call)
+        let sliding_window = c.sliding_window  // hoisted: scalars captured by the worker, not the struct
+        let attn_softcap = c.attn_logit_softcap
+        unsafe {
+            let qp = reinterpret<float const?>(addr(s.q_b[0]))
+            let kcp = reinterpret<float const?>(addr(s.key_cache[0]))
+            let vcp = reinterpret<float const?>(addr(s.value_cache[0]))
+            var xbp = addr(s.xb_b[0])
+            var attp = addr(s.att_b[0])
+            let attn_par = npos * maxctx * n_heads >= ATTN_PAR_THRESHOLD
+            maybe_parallel_for(attn_par, 0, int(n_heads), get_total_hw_jobs()) $(rb, re) {
+                unsafe {
+                    for (h in range(rb, re)) {
+                        let hh = int64(h)
+                        let qoff = hh * head_size
+                        let kvhoff = (hh / kv_mul) * head_size
+                        let abase = hh * maxctx                // this head's private score row
+                        for (p in range64(npos)) {
+                            let ap = start_pos + p
+                            let kstart = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
+                            let cnt = ap + 1l - kstart
+                            let qbase = p * qd + qoff           // q row == output row (both qd-strided)
+                            for (j in range64(cnt)) {
+                                let koff = loff + (kstart + j) * kv_dim + kvhoff
+                                attp[abase + j] = dot(qp + qbase, kcp + koff, head_size) * scale
+                            }
+                            if (attn_softcap > 0.0) {  // Gemma2: soft-cap scores before softmax
+                                softcap(attp + abase, cnt, attn_softcap)
+                            }
+                            softmax(attp + abase, cnt)
+                            for (i in range64(head_size)) {
+                                xbp[qbase + i] = 0.0
+                            }
+                            for (j in range64(cnt)) {   // output += Σ att[j]·V[j]
+                                let voff = loff + (kstart + j) * kv_dim + kvhoff
+                                vaxpy(xbp + qbase, vcp + voff, attp[abase + j], head_size)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -584,6 +584,25 @@ def private rms_at(var o : array<float> | #; t : Transformer; woff : int64; x : 
     }
 }
 
+// Threaded per-position rmsnorm: out[p*dim..] = rmsnorm(src[p*dim..]) with the layer weight at fblob+woff.
+// `out` and `src` may be the same array (Gemma post-norms run in place). Fork workers touch raw addresses.
+def private rms_batch(var out : array<float>; src : array<float>; t : Transformer; woff : int64; dim, npos : int64) {
+    let eps = t.config.norm_eps
+    unsafe {
+        var op = addr(out[0])
+        let ip = reinterpret<float const?>(addr(src[0]))
+        let wp = reinterpret<float const?>(addr(t.fblob[woff]))
+        maybe_parallel_for(dim * npos >= NORM_PAR_THRESHOLD, 0, int(npos), get_total_hw_jobs()) $(rb, re) {
+            unsafe {
+                for (p in range(rb, re)) {
+                    let off = int64(p) * dim
+                    rmsnorm(op + off, ip + off, wp, dim, eps)
+                }
+            }
+        }
+    }
+}
+
 // Add a projection bias (Qwen2): y[yoff + i] += b[boff + i]. yoff is 0 for the single-token forward,
 // p*stride for the batched prefill; boff is the per-layer slice into bq/bk/bv.
 def private add_bias(var y : array<float>; yoff : int64; b : array<float>; boff, n : int64) {
@@ -816,6 +835,8 @@ def forward(t : Transformer; var s : RunState; token, pos : int64) {
 let ATTN_PAR_THRESHOLD = 100_000l
 // Thread the per-position activation requant (mm_b) once n × npos clears this.
 let REQUANT_PAR_THRESHOLD = 256_000l
+// Thread the per-position rmsnorm once dim × npos clears this.
+let NORM_PAR_THRESHOLD = 256_000l
 
 var g_prefill_prof_acc : table<string; int64>
 
@@ -904,13 +925,7 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         let is_sliding = c.sliding_window > 0l && (l % 2l == 0l)
         // attention rmsnorm, per position
         let ts_norm0 = ref_time_ticks()
-        for (p in range64(npos)) {
-            array_view(s.xb_b, p * dim, dim) $(var ov : array<float>#) {
-                array_view(s.x_b, p * dim, dim) $(var xv : array<float>#) {
-                    rms_at(ov, t, t.rms_att_off + l * dim, xv, dim)
-                }
-            }
-        }
+        rms_batch(s.xb_b, s.x_b, t, t.rms_att_off + l * dim, dim, npos)
         prof_add("norm", ts_norm0)
         // batched q/k/v projections (each re-quantizes xb_b — cheap vs the matmul)
         let ts_qkv = ref_time_ticks()
@@ -998,23 +1013,13 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         prof_add("mm_wo", ts_wo)
         let ts_resid0 = ref_time_ticks()
         if (c.pre_post_norm) {  // Gemma2: post-attention RMSNorm per position before residual
-            for (p in range64(npos)) {
-                array_view(s.xb2_b, p * dim, dim) $(var ov : array<float>#) {
-                    rms_at(ov, t, t.rms_post_att_off + l * dim, ov, dim)
-                }
-            }
+            rms_batch(s.xb2_b, s.xb2_b, t, t.rms_post_att_off + l * dim, dim, npos)
         }
         add_inplace(unsafe(addr(s.x_b[0])), unsafe(addr(s.xb2_b[0])), npos * dim)
         prof_add("act_resid", ts_resid0)
         // ffn rmsnorm, per position
         let ts_norm1 = ref_time_ticks()
-        for (p in range64(npos)) {
-            array_view(s.xb_b, p * dim, dim) $(var ov : array<float>#) {
-                array_view(s.x_b, p * dim, dim) $(var xv : array<float>#) {
-                    rms_at(ov, t, t.rms_ffn_off + l * dim, xv, dim)
-                }
-            }
-        }
+        rms_batch(s.xb_b, s.x_b, t, t.rms_ffn_off + l * dim, dim, npos)
         prof_add("norm", ts_norm1)
         // gated FFN (batched): hb = act(W1·xb) * (W3·xb) — act/mul elementwise, so batch-flat
         let ts_ffn = ref_time_ticks()
@@ -1035,11 +1040,7 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         prof_add("mm_ffn", ts_ffn2)
         let ts_resid1 = ref_time_ticks()
         if (c.pre_post_norm) {  // Gemma2: post-FFN RMSNorm per position before residual
-            for (p in range64(npos)) {
-                array_view(s.xb_b, p * dim, dim) $(var ov : array<float>#) {
-                    rms_at(ov, t, t.rms_post_ffn_off + l * dim, ov, dim)
-                }
-            }
+            rms_batch(s.xb_b, s.xb_b, t, t.rms_post_ffn_off + l * dim, dim, npos)
         }
         add_inplace(unsafe(addr(s.x_b[0])), unsafe(addr(s.xb_b[0])), npos * dim)
         prof_add("act_resid", ts_resid1)

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -5,24 +5,43 @@
 #include "daScript/simulate/aot_builtin_jobque.h"
 #include "daScript/misc/string_writer.h"
 
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
 // Feature tracking statics
 das::Feature *  das::Feature::sTrackHead = nullptr;
 das::mutex      das::Feature::sTrackMutex;
 
 namespace das {
 
-    // Worker count = logical cores - 1, capped at DAS_MAX_HW_JOBS. parallel_for has the CALLING (main)
-    // thread run one chunk too and then wait, so it occupies a core for the bulk of the call; spawning a
-    // worker per core therefore oversubscribes (N workers + main = N+1 threads on N cores), and the
-    // surplus worker can't get a core until another yields — measured as workers "trickling in" over the
-    // first ~37% of every matmul on a 10-core machine. cores-1 workers + the main thread == cores, which
-    // removes that oversubscription at no throughput cost. DAS_MAX_HW_JOBS (default 4; raise via
-    // -DDAS_MAX_HW_JOBS=N) is the hard upper bound — it keeps a wasm/web build from spawning one Web
-    // Worker per logical core, and on a desktop build with the cap raised the cores-1 rule then applies.
-    // DAS_JOBQUE_THREADS is an explicit override that bypasses both (0/unset = the default).
+#if defined(__APPLE__)
+    // Performance ("good") core count on heterogeneous Apple Silicon (P-cores). Returns 0 on homogeneous
+    // Macs (Intel) and wherever the keys are missing, so the caller falls back to the generic rule.
+    static int apple_perf_core_count() {
+        int nperf = 0; size_t len = sizeof(nperf);
+        if ( sysctlbyname("hw.nperflevels", &nperf, &len, nullptr, 0) != 0 || nperf < 2 ) return 0;
+        int good = 0; len = sizeof(good);
+        if ( sysctlbyname("hw.perflevel0.logicalcpu", &good, &len, nullptr, 0) != 0 ) return 0;
+        return good;
+    }
+#endif
+
+    // Worker count. Generic rule: logical cores - 1, capped at DAS_MAX_HW_JOBS — parallel_for has the
+    // CALLING (main) thread run a chunk and then wait, so it occupies a core; cores-1 workers + main ==
+    // cores avoids the oversubscription that otherwise makes the surplus worker "trickle in" over the
+    // first ~37% of every matmul. DAS_MAX_HW_JOBS (default 4; raise via -DDAS_MAX_HW_JOBS=N) keeps a
+    // wasm build from spawning one Web Worker per logical core. On heterogeneous Apple Silicon we
+    // instead run one worker per PERFORMANCE core (no -1, no cap): the efficiency cores absorb the main
+    // thread + OS, whereas cores-1 (logical) spills a worker onto a slow E-core that stalls every
+    // parallel_for on the straggler — measured ~1.6x slower on an M-series 8P+2E prefill. DAS_JOBQUE_THREADS
+    // is an explicit override that bypasses everything (0/unset = the default).
     static int jobque_thread_count(int hw) {
         static int forced = []{ const char * e = getenv("DAS_JOBQUE_THREADS"); return e ? atoi(e) : 0; }();
         if ( forced > 0 ) return forced;
+#if defined(__APPLE__)
+        if ( int good = apple_perf_core_count() ) return good;
+#endif
         return max(1, min(DAS_MAX_HW_JOBS, hw - 1));
     }
 

--- a/tests/dasLLAMA/test_prefill.das
+++ b/tests/dasLLAMA/test_prefill.das
@@ -78,6 +78,9 @@ def test_prefill_fp32(t : T?) {
         let prompt <- encode(tk, "Once upon a time, there was a little girl", true, false)
         check_prefill(t, tr, prompt)
         check_continuation(t, tr, prompt, 4l)
+        // a long prompt trips ATTN_PAR_THRESHOLD, so this covers the THREADED attention arm
+        let long_prompt <- [for (i in range64(200l)); int64(i % 200l + 1l)]
+        check_prefill(t, tr, long_prompt)
     }
 }
 
@@ -94,5 +97,8 @@ def test_prefill_q8(t : T?) {
         let prompt <- encode(tk, "Once upon a time, there was a little girl", true, false)
         check_prefill(t, tr, prompt)
         check_continuation(t, tr, prompt, 4l)
+        // a long prompt trips ATTN_PAR_THRESHOLD, so this covers the THREADED attention arm
+        let long_prompt <- [for (i in range64(200l)); int64(i % 200l + 1l)]
+        check_prefill(t, tr, long_prompt)
     }
 }


### PR DESCRIPTION
## Prefill 4.2× — thread the serial work + size the jobque to Apple Silicon performance cores

Once the Q8 GEMM reached llama.cpp parity (PR #3297/#3304), the dasLLAMA prefill ceiling was the **serial, single-threaded** non-GEMM work — attention (the only O(npos²) term), the activation requant, and the per-position rmsnorm. This branch threads all of it and fixes the worker-pool sizing that was silently starving it.

### Results — Llama-3.2-1B Q8, JIT, M-series (8 P-cores + 2 E-cores)

Prefill throughput (tok/s), vs the same model on the NEON-only llama.cpp CPU build at 8 threads:

| context | before | **after** | total | llama.cpp | ours/llama |
|--------:|-------:|----------:|:-----:|----------:|:----------:|
| 128 | 235 | **503** | 2.1× | 827 | 61% |
| 512 | 170 | **481** | 2.8× | 821 | 59% |
| 1024 | 121 | **416** | 3.4× | 765 | 54% |
| 2048 | 76 | **322** | **4.2×** | 670 | 48% |

The gap to llama.cpp closes from ~6× to ~2×. What remains widens with context — that's attention: llama.cpp uses flash-attention, ours is threaded-but-classic, so it pulls ahead as the sequence grows (a separate, future effort).

### What changed

1. **Thread the prefill attention over heads.** Every head runs the identical causal triangle (perfect load balance) and writes a disjoint output slice, so there's no shared scratch — each head gets its own score row. `softmax`/`softcap` gain fork-callable pointer cores (fork workers can only touch raw addresses, not main-context array objects); the array overloads forward to them, bit-identical.

2. **Vectorize the flat per-element loops.** The residual adds and the SwiGLU/GeGLU gate multiply were plain bounds-checked array loops the JIT does not auto-vectorize (an isolated bench shows the pointer + `[vectorize]` form is 5.3× faster). softmax now scales by the reciprocal (matching ggml's `ggml_vec_scale_f32`) and carries vectorize hints.

3. **Thread the activation requant and the rmsnorm** over positions (both independent per position) — `quantize_q8_0_into` and `rmsnorm` get fork-callable pointer cores. requant 9.1×, norm 11× on their buckets.

4. **Size the jobque worker pool to the performance cores on Apple Silicon** (`src/misc/job_que.cpp`). The pool used logical-cores-1 everywhere; on a P+E chip that spills a worker onto a slow efficiency core that becomes the straggler every `parallel_for` waits on, and the wasm-guard `DAS_MAX_HW_JOBS` default (4) caps a native build far below the real core count besides. It now queries `sysctl hw.perflevel0.logicalcpu` (gated on `hw.nperflevels >= 2`) and runs one worker per P-core — no -1 (the E-cores absorb the main thread + OS) and no cap. **Intel Macs and every other platform keep the existing cores-1 rule unchanged**; `DAS_JOBQUE_THREADS` still overrides. This is a general daslang runtime improvement for all `parallel_for` users on Apple Silicon, not dasLLAMA-specific.

### Correctness

Every step is verified bit-exact against running `forward()` once per position, and token-for-token against llama.cpp greedy decode (Llama-3.2-1B 40/40). `test_prefill` gains a 200-token case to cover the threaded attention arm. Full suites: 59/59 dasLLAMA, 175/175 jobque. Full local preflight green (17/17 gates: interp/JIT/AOT sweeps, docs, sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)