### PR TITLE
Path Tracer Lab: decouple Threads slider from detected core count (cap 16)

### DIFF
--- a/examples/graphics/path_tracer_lab_opengl_imgui_example.das
+++ b/examples/graphics/path_tracer_lab_opengl_imgui_example.das
@@ -39,6 +39,12 @@ let {
     TRACE_H = 256    // 4-thread cap means a 512^2 single-thread pass is ~6 s; 256^2 is a snappy ~1.6 s)
     WIN_W = 512      // display window — CSS-scales to the examples-page card; 2x NEAREST upscale of the trace
     WIN_H = 512
+    // Threads-mode band ceiling. Decoupled from get_total_hw_threads() on purpose: the lab lets you
+    // oversubscribe the real cores to watch starved threads. 16 == the wasm64 build's PTHREAD_POOL_SIZE
+    // (daspkg), so the bands map 1:1 onto pre-spawned Web Workers — going higher trips emscripten's
+    // pool-exhausted warning. Privacy browsers (Vivaldi clamps navigator.hardwareConcurrency to 2) can
+    // still reach 16 here even though their detected count is 1.
+    MAX_BANDS = 16
 }
 
 enum Mode {
@@ -60,7 +66,7 @@ var g_render_epoch = -1               // epoch the render state machine is synce
 var g_pass = -1                       // completed accumulation passes (frameCount-1)
 var g_last_rays = 0                   // rays of the last completed full-image pass (stats)
 var g_last_pass_us = 0                // microseconds of the last completed pass (stats)
-var g_max_threads = 1                 // Threads-mode band count (slider; set to hw count in init)
+var g_max_threads = 1                 // Threads-mode band count (slider 1..MAX_BANDS; default set in init)
 
 var backbuffer : array<float3>        // TRACE_W*TRACE_H accumulation surface (linear color)
 var upload_rgba : array<float4>       // RGBA staging for the CPU->texture upload (WebGL2 requires RGBA/FLOAT for an RGBA32F texture, not RGB)
@@ -273,7 +279,7 @@ def advance_render {
     if (mode == int(Mode.SingleThread)) {
         start_threads_pass(g_pass + 1, 1)        // one background band-thread; UI stays free (no main-thread crawl)
     } elif (mode == int(Mode.Threads)) {
-        start_threads_pass(g_pass + 1, clamp(g_max_threads, 1, get_total_hw_threads()))
+        start_threads_pass(g_pass + 1, clamp(g_max_threads, 1, MAX_BANDS))
     }
 }
 
@@ -356,7 +362,7 @@ def build_ui {
 
     // per-mode control (the slider value doubles as the parallelism readout)
     if (g_mode == int(Mode.Threads)) {
-        SliderInt("max threads", safe_addr(g_max_threads), 1, get_total_hw_threads())
+        SliderInt("max threads", safe_addr(g_max_threads), 1, MAX_BANDS)
     } else {
         Text("{mode_label(g_mode)}")
     }
@@ -431,7 +437,10 @@ def init() {
     create_gl_objects()
     backbuffer |> resize(TRACE_W * TRACE_H)
     upload_rgba |> resize(TRACE_W * TRACE_H)
-    g_max_threads = get_total_hw_threads()
+    // Open at the detected core count, floored to 4 so it never looks single-threaded on a browser
+    // that clamps navigator.hardwareConcurrency (e.g. Vivaldi -> 2 -> get_total_hw_threads() == 1),
+    // and capped at the MAX_BANDS ceiling. Drag the slider up to MAX_BANDS to oversubscribe.
+    g_max_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
 }
 
 [export]

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -61,7 +61,7 @@ if(DAS_WASM_PTHREADS)
     # -sSHARED_MEMORY pins initial memory (no auto-grow at startup), so it must be
     # large enough for daslang's static data + embedded daslib (~55MB). 128MB gives
     # headroom; ALLOW_MEMORY_GROWTH still lets the heap grow past it at runtime.
-    add_link_options(-pthread -sPTHREAD_POOL_SIZE=8 -sINITIAL_MEMORY=134217728)
+    add_link_options(-pthread -sPTHREAD_POOL_SIZE=16 -sINITIAL_MEMORY=134217728)
     # AudioWorklet backend for dasAudio (mixer on the dedicated audio thread).
     # WASM_WORKERS backs the worklet thread; AUDIO_WORKLET enables the API. No
     # -sASYNCIFY (incompatible with -fwasm-exceptions) — the non-blocking


### PR DESCRIPTION
## What

The Path Tracer Lab's **Threads** mode slider now ranges `1..16` instead of `1..get_total_hw_threads()`, and opens at `clamp(get_total_hw_threads(), 4, 16)`.

## Why

The slider max and the dispatch clamp were both tied to:

```
get_total_hw_threads() = max(1, min(DAS_MAX_HW_JOBS=4, hw-1))
```

So a browser that under-reports `navigator.hardwareConcurrency` collapsed the slider to **1**. Concretely: **Vivaldi clamps `navigator.hardwareConcurrency` to 2** (fingerprint protection, same as Brave), giving `min(4, 2-1) = 1` — even though the machine has many cores and the threaded wasm build runs fine (verified `crossOriginIsolated=true`, `SharedArrayBuffer` present). Chrome on the same box reports the real count and capped at 4.

Key point: the clamp is **cosmetic / JS-visible only** — it does not limit how many physical cores the workers actually use. And the lab spawns **raw `new_thread()` bands, not the jobque pool**, so band count was never bounded by `DAS_MAX_HW_JOBS` — only the slider was. So decoupling the slider is the right fix; no change to `get_total_hw_threads()` semantics.

## Changes

- **`examples/graphics/path_tracer_lab_opengl_imgui_example.das`** — add `MAX_BANDS = 16`; slider range and dispatch clamp use it; default `clamp(get_total_hw_threads(), 4, 16)` (opens at a sane parallel value everywhere, never looks single-threaded under a clamped count, drag up to 16 to oversubscribe and watch starved threads — the point of the "lab").
- **`web/CMakeLists.txt`** — `PTHREAD_POOL_SIZE` 8 → 16, so the wasm32 (playground) build path can service 16 bands without emscripten's pool-exhausted warning. The wasm64 (daspkg) path was already 16, so `MAX_BANDS = 16` maps 1:1 onto pre-spawned Web Workers.

## Verification

- Lint clean (`mcp__daslang__lint`), formatter clean, compiles with dasImgui loaded.
- Rebuilt the wasm64 (threaded) lab locally and ran it cross-origin-isolated; confirmed in **Vivaldi** the slider now reaches 16 and uses 16 real cores (previously capped at 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)