### PR TITLE
fix: guard Feature::setFrom shared_from_this against empty weak (standalone-exe)

### DIFF
--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -546,7 +546,12 @@ namespace das {
     void Feature::setFrom ( Context * c ) {
         from = c;
         if ( c && c->sharedPtrContext ) {
-            fromShared = c->shared_from_this();
+            // Standalone-AOT/exe contexts are member objects (not make_shared), so their
+            // weak_from_this() is empty and shared_from_this() throws bad_weak_ptr. Fall back
+            // to a null owner: such a context lives for the whole program, so the Feature never
+            // needs to keep it alive. Mirrors debugAgentContextOrNull in context.cpp.
+            auto wp = c->weak_from_this();
+            fromShared = wp.expired() ? nullptr : wp.lock();
         } else {
             fromShared.reset();
         }


### PR DESCRIPTION
## Problem

A standalone `-exe`/AOT context is constructed as a member object (see `daslib/aot_standalone.das::writeStandaloneCtor`), **not** via `make_shared`, so its `weak_from_this()` is empty and `enable_shared_from_this::shared_from_this()` throws `std::bad_weak_ptr`.

`Feature::setFrom` called `c->shared_from_this()` directly whenever `c->sharedPtrContext`:

```cpp
if ( c && c->sharedPtrContext ) {
    fromShared = c->shared_from_this();   // throws bad_weak_ptr on a standalone-exe context
} else {
    fromShared.reset();
}
```

So **any** jobque `Feature` (`LockBox` / `Channel` / `JobStatus` / `Stream`) created in a context whose `sharedPtrContext` is set aborts a standalone-exe program at the point of creation. Interpreter and JIT are unaffected because there the `Context` is owned by a `shared_ptr` (valid weak).

The codebase already documents this exact hazard and the fix pattern at `src/runtime/context.cpp` (`debugAgentContextOrNull`, which uses `weak_from_this().expired() ? nullptr : lock()`); `Feature::setFrom` simply missed the guard.

## Fix

Mirror that precedent in `Feature::setFrom`:

```cpp
if ( c && c->sharedPtrContext ) {
    auto wp = c->weak_from_this();
    fromShared = wp.expired() ? nullptr : wp.lock();
} else {
    fromShared.reset();
}
```

No-op for normal (`make_shared`) contexts: `wp.lock()` equals `shared_from_this()` when the weak ref is live. The only changed behavior is the standalone-exe case, which gets a null owner instead of an abort — safe, because such a context is a member object that lives for the whole program, so the `Feature` never needs to keep it alive.

## How it surfaced

The Physarum Lab wasm64 examples card (`daslang.io/examples.html?example=physarum_lab`) is a standalone `-exe`. It crashed at `init()` with an unhandled `std::bad_weak_ptr`. Symbolized stack from a local non-stripped build:

```
std::__throw_bad_weak_ptr()
das::Feature::Feature(void*, TypeInfo*, Context*)   // setFrom -> shared_from_this
das::LockBox::set(void*, TypeInfo*, Context*)
das::lockBoxSet(...)                                 // from strudel_create_channel()
init  ->  main
```

The card's audio path (`audio_system_create` clones the mixer context; the jobque/audio machinery sets `sharedPtrContext` on the main context) then `strudel_create_channel()` creates a `LockBox`, tripping the throw. The audio-less Path Tracer card survives because it never creates such a `Feature`. Verified: with this fix the card renders fully (slime network + live ImGui panel + threaded sim), zero exceptions; the local `tests/jobque` suite stays 175/175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)