### PR TITLE
dasLLAMA + JIT: vectorized exp/softmax, threaded FFN activation, opt-in fast-math

### DIFF
--- a/examples/dasLLAMA/chat.das
+++ b/examples/dasLLAMA/chat.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_tokenizer

--- a/examples/dasLLAMA/gemma_chat.das
+++ b/examples/dasLLAMA/gemma_chat.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_tokenizer

--- a/examples/dasLLAMA/gguf_run.das
+++ b/examples/dasLLAMA/gguf_run.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_tokenizer

--- a/examples/dasLLAMA/llama3_chat.das
+++ b/examples/dasLLAMA/llama3_chat.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_bpe

--- a/examples/dasLLAMA/llama3_run.das
+++ b/examples/dasLLAMA/llama3_run.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_bpe

--- a/examples/dasLLAMA/phi_chat.das
+++ b/examples/dasLLAMA/phi_chat.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_tokenizer

--- a/examples/dasLLAMA/qwen_chat.das
+++ b/examples/dasLLAMA/qwen_chat.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_bpe

--- a/examples/dasLLAMA/run.das
+++ b/examples/dasLLAMA/run.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_tokenizer

--- a/modules/dasLLAMA/benchmarks/gguf_perf.das
+++ b/modules/dasLLAMA/benchmarks/gguf_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require dasllama/dasllama_tokenizer

--- a/modules/dasLLAMA/benchmarks/llama3_perf.das
+++ b/modules/dasLLAMA/benchmarks/llama3_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require daslib/jobque_boost

--- a/modules/dasLLAMA/benchmarks/perf.das
+++ b/modules/dasLLAMA/benchmarks/perf.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require daslib/jobque_boost

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer
 require daslib/jobque_boost

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -657,6 +657,11 @@ def softmax(var x : array<float> | #; size : int64) {
 //! no vector libm on Darwin-ARM, so exp(float4) scalarizes). FAST PATH ONLY (no |n|>126 guard):
 //! valid for x in ~[-87, 88]; outside that it returns garbage, so callers must clamp. The flash
 //! softmax fold clamps masked/underflow entries to -87 (exp -> ~0) before calling.
+//! NOTE: the JIT now also emits this same ggml_v_expf as the lowering for exp(floatN) directly
+//! (build_vector_expf in modules/dasLLVM/daslib/llvm_jit_intrin.das) — but full-range (always pays the
+//! |n|>126 guard, ~2.9x) and gated to aarch64 pending x64 hardware validation. This local exp4 is kept
+//! separate because it's the cheaper fast-path-only form. Once x64 is verified, add a fast-path branch
+//! to the intrinsic and replace this with exp(float4); until then they coexist deliberately.
 def exp4(x : float4) : float4 {
     let z = mad(x, float4(1.4426950216293335), float4(12582912.0))   // x*log2e + 1.5*2^23
     let n = z - float4(12582912.0)                                   // round(x*log2e)

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -651,6 +651,26 @@ def softmax(var x : array<float> | #; size : int64) {
     softmax(unsafe(addr(x[0])), size)
 }
 
+//! Vectorized expf, 4 lanes — ggml_v_expf (ARM optimized-routines): a degree-4 poly on the
+//! ln2-reduced argument times the 2^n exponent rebuilt by the round-to-int magic-number trick.
+//! Max rel err ~2 ulp vs libm, ~7x faster than scalar exp() (which the JIT lowers to libm expf —
+//! no vector libm on Darwin-ARM, so exp(float4) scalarizes). FAST PATH ONLY (no |n|>126 guard):
+//! valid for x in ~[-87, 88]; outside that it returns garbage, so callers must clamp. The flash
+//! softmax fold clamps masked/underflow entries to -87 (exp -> ~0) before calling.
+def exp4(x : float4) : float4 {
+    let z = mad(x, float4(1.4426950216293335), float4(12582912.0))   // x*log2e + 1.5*2^23
+    let n = z - float4(12582912.0)                                   // round(x*log2e)
+    let b = mad(n, float4(-1.428606765330187e-06), mad(n, float4(-0.693145751953125), x))  // x - n*ln2
+    let u = b * b
+    let p = mad(mad(mad(float4(0.008247390389442444), b, float4(0.04189976677298546)), u,
+        mad(float4(0.16668395698070526), b, float4(0.4999912679195404))), u, float4(0.9999994039535522) * b)
+    unsafe {
+        let zbits = reinterpret<uint4>(z)
+        let k = reinterpret<float4>((zbits << 23) + uint4(0x3f800000u, 0x3f800000u, 0x3f800000u, 0x3f800000u))
+        return mad(p, k, k)                                          // 2^n * (1 + poly(b))
+    }
+}
+
 //! SiLU (a.k.a. swish) activation: silu(x) = x * sigmoid(x) = x / (1 + exp(-x)).
 //! In place over the first `size` elements. The nonlinearity in the SwiGLU FFN gate;
 //! smooth, ~identity for large x, dips slightly negative just below zero.

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -618,9 +618,10 @@ def softmax(var x : float?; size : int64) {
     unsafe {
         // Hand-vectorized max reduction (replaces a [vectorize] hint that LLVM ignored): max() lowers to
         // fcmp+select, which LLVM won't auto-vectorize as a reduction without nnan/nsz fast-math (we don't
-        // emit it — bit-exactness). max IS associative+exact, so two float4 lane accumulators (width-8, the
-        // original hint's intent — 2 accs hide the fmax latency, ~9x over scalar) + a horizontal max is
-        // bit-identical to the scalar fold. The broadcast seed folds x[0] in (idempotent) and never reads
+        // emit it — bit-exactness). On NaN-free inputs (softmax scores are always finite) max is
+        // associative+exact, so two float4 lane accumulators (width-8, the original hint's intent — 2 accs
+        // hide the fmax latency, ~9x over scalar) + a horizontal max is bit-identical to the scalar fold
+        // (fcmp+select is order-dependent only when a NaN is present). The broadcast seed folds x[0] in (idempotent) and never reads
         // past the buffer, so it stays safe for size < 8 (early decode).
         let pf4 = reinterpret<float4 const?>(x)
         let n8 = size / 8l

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -654,25 +654,35 @@ def softmax(var x : array<float> | #; size : int64) {
 //! SiLU (a.k.a. swish) activation: silu(x) = x * sigmoid(x) = x / (1 + exp(-x)).
 //! In place over the first `size` elements. The nonlinearity in the SwiGLU FFN gate;
 //! smooth, ~identity for large x, dips slightly negative just below zero.
-[hint(unsafe_range_check)]
-def silu(var x : array<float> | #; size : int64) {
-    for (i in range64(size)) {
-        let v = x[i]
-        x[i] = v / (1.0 + exp(-v))
+//! Pointer core (see softmax) — the threaded prefill FFN runs act_batch in fork contexts on raw addresses.
+def silu(var x : float?; size : int64) {
+    unsafe {
+        for (i in range64(size)) {
+            let v = x[i]
+            x[i] = v / (1.0 + exp(-v))
+        }
     }
+}
+def silu(var x : array<float> | #; size : int64) {
+    silu(unsafe(addr(x[0])), size)
 }
 
 //! GELU, tanh approximation (HF's gelu_pytorch_tanh): the GeGLU gate nonlinearity (Gemma2).
 //! gelu(x) = 0.5x(1 + tanh(sqrt(2/pi)(x + 0.044715 x^3))). In place over the first `size`
 //! elements. ggml's LLM_FFN_GELU approximates this same form via an fp16 lookup table; we
 //! compute it directly (more accurate — near-ties against the LUT are expected, not bugs).
-[hint(unsafe_range_check)]
-def gelu(var x : array<float> | #; size : int64) {
+//! Pointer core (see softmax) — threaded prefill act_batch calls this on raw fork addresses.
+def gelu(var x : float?; size : int64) {
     let k = 0.7978845608028654  // sqrt(2/pi)
-    for (i in range64(size)) {
-        let v = x[i]
-        x[i] = 0.5 * v * (1.0 + tanh(k * (v + 0.044715 * v * v * v)))
+    unsafe {
+        for (i in range64(size)) {
+            let v = x[i]
+            x[i] = 0.5 * v * (1.0 + tanh(k * (v + 0.044715 * v * v * v)))
+        }
     }
+}
+def gelu(var x : array<float> | #; size : int64) {
+    gelu(unsafe(addr(x[0])), size)
 }
 
 //! Logit soft-capping (Gemma2): x = cap * tanh(x / cap), elementwise over the first `size`.

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -615,6 +615,7 @@ def rmsnorm(var o : array<float> | #; x : array<float> | #; weight : array<float
 //! addresses; the array overload forwards here, so both are bit-identical. Output `x` is a `var
 //! float?` written in place (a hoisted/captured fork pointer binds directly — no const-strip).
 def softmax(var x : float?; size : int64) {
+    if (size <= 0) return   // seeds the reduction with x[0]; size<=0 must be a no-op (same contract as the array overload)
     unsafe {
         // Hand-vectorized max reduction (replaces a [vectorize] hint that LLVM ignored): max() lowers to
         // fcmp+select, which LLVM won't auto-vectorize as a reduction without nnan/nsz fast-math (we don't

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -649,6 +649,7 @@ def softmax(var x : float?; size : int64) {
     }
 }
 def softmax(var x : array<float> | #; size : int64) {
+    if (size <= 0) return   // empty array: addr(x[0]) would index out of range; old loop form no-op'd
     softmax(unsafe(addr(x[0])), size)
 }
 
@@ -690,6 +691,7 @@ def silu(var x : float?; size : int64) {
     }
 }
 def silu(var x : array<float> | #; size : int64) {
+    if (size <= 0) return   // empty array: addr(x[0]) would index out of range; old loop form no-op'd
     silu(unsafe(addr(x[0])), size)
 }
 
@@ -708,6 +710,7 @@ def gelu(var x : float?; size : int64) {
     }
 }
 def gelu(var x : array<float> | #; size : int64) {
+    if (size <= 0) return   // empty array: addr(x[0]) would index out of range; old loop form no-op'd
     gelu(unsafe(addr(x[0])), size)
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -656,7 +656,7 @@ def softmax(var x : array<float> | #; size : int64) {
 //! Max rel err ~2 ulp vs libm, ~7x faster than scalar exp() (which the JIT lowers to libm expf —
 //! no vector libm on Darwin-ARM, so exp(float4) scalarizes). FAST PATH ONLY (no |n|>126 guard):
 //! valid for x in ~[-87, 88]; outside that it returns garbage, so callers must clamp. The flash
-//! softmax fold clamps masked/underflow entries to -87 (exp -> ~0) before calling.
+//! softmax fold clamps masked/underflow entries to -80 (exp -> ~0) before calling.
 //! NOTE: the JIT now also emits this same ggml_v_expf as the lowering for exp(floatN) directly
 //! (build_vector_expf in modules/dasLLVM/daslib/llvm_jit_intrin.das) — but full-range (always pays the
 //! |n|>126 guard, ~2.9x) and gated to aarch64 pending x64 hardware validation. This local exp4 is kept

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -616,9 +616,23 @@ def rmsnorm(var o : array<float> | #; x : array<float> | #; weight : array<float
 //! float?` written in place (a hoisted/captured fork pointer binds directly — no const-strip).
 def softmax(var x : float?; size : int64) {
     unsafe {
-        // max is exact + idempotent, so the vectorized reduce (any order, x[0] folded in twice) is bit-exact
-        var maxv = x[0]
-        for [vectorize, vectorize_width = 8, unroll_count = 2] (i in range64(size)) {
+        // Hand-vectorized max reduction (replaces a [vectorize] hint that LLVM ignored): max() lowers to
+        // fcmp+select, which LLVM won't auto-vectorize as a reduction without nnan/nsz fast-math (we don't
+        // emit it — bit-exactness). max IS associative+exact, so two float4 lane accumulators (width-8, the
+        // original hint's intent — 2 accs hide the fmax latency, ~9x over scalar) + a horizontal max is
+        // bit-identical to the scalar fold. The broadcast seed folds x[0] in (idempotent) and never reads
+        // past the buffer, so it stays safe for size < 8 (early decode).
+        let pf4 = reinterpret<float4 const?>(x)
+        let n8 = size / 8l
+        var acc0 = float4(x[0], x[0], x[0], x[0])
+        var acc1 = acc0
+        for (k in 0l..n8) {
+            acc0 = max(acc0, pf4[2l * k])
+            acc1 = max(acc1, pf4[2l * k + 1l])
+        }
+        let acc = max(acc0, acc1)
+        var maxv = max(max(acc.x, acc.y), max(acc.z, acc.w))
+        for (i in n8 * 8l .. size) {
             maxv = max(maxv, x[i])
         }
         var sum = 0.0

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -1170,11 +1170,19 @@ def private attn_head_flash(qp, kcp, vcp : float const?; var xbp : float?;
                         srun[int(qt)] *= ms
                     }
                     mrun[int(qt)] = mnew
-                    for (kt in range64(KV)) {          // kq row becomes the (un-normalized) prob row
-                        let pe = kqp[row + kt] <= -1.0e29 ? 0.0 : exp(kqp[row + kt] - mnew)
-                        kqp[row + kt] = pe
-                        srun[int(qt)] += pe
+                    // kq row becomes the (un-normalized) prob row — vectorized exp4 over KV (mult of 4).
+                    // Masked entries (-1e30) clamp to -80 so exp4's fast path stays in range and yields ~0
+                    // (1.8e-35, negligible vs the real probs); flash is already non-bit-exact (online reorder).
+                    let mnew4 = float4(mnew, mnew, mnew, mnew)
+                    let floor4 = float4(-80.0, -80.0, -80.0, -80.0)
+                    var sum4 = float4(0.0, 0.0, 0.0, 0.0)
+                    var prow = reinterpret<float4?>(kqp + row)
+                    for (kc in range64(KV / 4l)) {
+                        let pe4 = exp4(max(prow[kc] - mnew4, floor4))
+                        prow[kc] = pe4
+                        sum4 += pe4
                     }
+                    srun[int(qt)] += sum4.x + sum4.y + sum4.z + sum4.w
                 }
                 // accumulate output: vkq[tile_rows × head_size] += P[tile_rows × KV] · V[KV × head_size]
                 gemm_f32(vkqp, kqp, vpk, tile_rows, KV, head_size)

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -1476,7 +1476,7 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         prof_add("act", ts_act)
         let ts_gate = ref_time_ticks()
         mul_inplace(unsafe(addr(s.hb_b[0])), unsafe(addr(s.hb2_b[0])), npos * hidden)
-        prof_add("act_resid", ts_gate)
+        prof_add("gate", ts_gate)   // SwiGLU/GeGLU gate multiply — own bucket (act_resid is residual-adds)
         // down projection (batched) + optional post-FFN norm + residual
         let ts_ffn2 = ref_time_ticks()
         mm_b(s.xb_b, t, t.w2_off + l * hidden * dim, s.hb_b, s.xqb, s.xsb, hidden, dim, npos)

--- a/modules/dasLLAMA/dasllama/dasllama_transformer.das
+++ b/modules/dasLLAMA/dasllama/dasllama_transformer.das
@@ -757,6 +757,29 @@ def private kv_store_batch(var key_cache : array<float>; var value_cache : array
     }
 }
 
+// Threaded per-position FFN activation: act(hb[p*hidden..]) in place for every position. Each element's
+// silu/gelu is independent (no cross-position reduce), so threading is bit-exact — the reorder risk is only
+// in VECTORIZING the transcendental, never in splitting positions across workers. Fork workers touch the
+// raw base pointer; self-gates on ACT_PAR_THRESHOLD so small prompts run inline.
+def private act_batch(var hb : array<float>; act : FfnAct; hidden, npos : int64) {
+    let is_gelu = act == FfnAct.gelu
+    unsafe {
+        var hp = addr(hb[0])
+        maybe_parallel_for(hidden * npos >= ACT_PAR_THRESHOLD, 0, int(npos), get_total_hw_jobs()) $(rb, re) {
+            unsafe {
+                for (p in range(rb, re)) {
+                    let off = int64(p) * hidden
+                    if (is_gelu) {
+                        gelu(hp + off, hidden)
+                    } else {
+                        silu(hp + off, hidden)
+                    }
+                }
+            }
+        }
+    }
+}
+
 // Add a projection bias (Qwen2): y[yoff + i] += b[boff + i]. yoff is 0 for the single-token forward,
 // p*stride for the batched prefill; boff is the per-layer slice into bq/bk/bv.
 [hint(unsafe_range_check)]
@@ -988,6 +1011,9 @@ let NORM_PAR_THRESHOLD = 256_000l
 let ROPE_PAR_THRESHOLD = 100_000l
 // Thread the KV-cache store once kv_dim × npos clears this (it's a memory-bound contiguous copy).
 let KV_STORE_PAR_THRESHOLD = 256_000l
+// Thread the per-position FFN activation (silu/gelu) once hidden × npos clears this. Lower than the
+// memory-bound passes — each element pays a transcendental (exp/tanh), so the compute justifies threading sooner.
+let ACT_PAR_THRESHOLD = 100_000l
 // Query-block width for the blocked prefill attention (each K/V tile is reused across this many queries).
 let ATTN_BLOCK_Q = 8l
 // Tile dims for the flash prefill attention (Q rows × KV cols processed per GEMM tile). The flash
@@ -1438,13 +1464,11 @@ def forward_prefill(t : Transformer; var s : RunState; tokens : array<int64>; np
         mm_b(s.hb2_b, t, t.w3_off + l * dim * hidden, s.xb_b, s.xqb, s.xsb, dim, hidden, npos)
         prof_add("mm_ffn", ts_ffn)
         let ts_act = ref_time_ticks()
-        if (c.ffn_act == FfnAct.gelu) {
-            gelu(s.hb_b, npos * hidden)
-        } else {
-            silu(s.hb_b, npos * hidden)
-        }
+        act_batch(s.hb_b, c.ffn_act, hidden, npos)
+        prof_add("act", ts_act)
+        let ts_gate = ref_time_ticks()
         mul_inplace(unsafe(addr(s.hb_b[0])), unsafe(addr(s.hb2_b[0])), npos * hidden)
-        prof_add("act_resid", ts_act)
+        prof_add("act_resid", ts_gate)
         // down projection (batched) + optional post-FFN norm + residual
         let ts_ffn2 = ref_time_ticks()
         mm_b(s.xb_b, t, t.w2_off + l * hidden * dim, s.hb_b, s.xqb, s.xsb, hidden, dim, npos)

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -878,6 +878,10 @@ def private vexpf_fsplat(ctx : JitCtx; opType : TypeDeclPtr; v : double) : LLVMO
 // The default lowering (@llvm.exp.vNf32) scalarizes to N libm expf calls on targets without a vector
 // libm (Darwin-ARM, most others) — ~7x slower. The |n|>126 overflow/underflow path is a branchless
 // select tree (correct inf/0), so this is a full-range drop-in: callers need no clamp.
+// The always-computed guard costs ~2.4x of the throughput (~2.9x vs scalar here, vs ~7x for a fast-path-
+// only form like dasLLAMA's exp4). TODO (post-x64): add ggml's fast-path branch — reduce-OR the |n|>126
+// mask, cond-br past the slow path when no lane overflows — to recover ~7x on the common case, then
+// dasLLAMA's exp4 can be retired in favor of plain exp(float4).
 def private build_vector_expf(ctx : JitCtx; opType : TypeDeclPtr; x : LLVMOpaqueValue?) : LLVMOpaqueValue? {
     let bld = ctx.builder
     let dim = opType.vectorDim

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -94,7 +94,7 @@ let g_intrin_lookup <- {
     "math::lerp" => @@intrinsic_math_lerp_op3,
     "math::rcp" => @@intrinsic_math_rcp,
     "math::rcp_est" => @@intrinsic_math_rcp,
-    "math::exp" => @@intrinsic_math_float_op1,
+    "math::exp" => @@intrinsic_math_exp,
     "math::log" => @@intrinsic_math_float_op1,
     "math::exp2" => @@intrinsic_math_float_op1,
     "math::log2" => @@intrinsic_math_float_op1,
@@ -851,6 +851,80 @@ def intrinsic_math_fmod(var ctx : JitCtx; expr : ExprCallFunc?; arguments : arra
 
 def intrinsic_math_sinh_cosh_tanh(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
     return intrinsic_math_any_float_op1(string(expr.name), ctx.builder, expr, arguments)
+}
+
+def private vexpf_fma(builder : LLVMOpaqueBuilder?; decl : LLVMOpaqueValue?; fty : LLVMOpaqueType?;
+                      a, b, c : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    if (decl != null) {
+        return LLVMBuildCall2(builder, fty, decl, [ a, b, c], "")   // @llvm.fmuladd: a*b+c
+    }
+    return LLVMBuildFAdd(builder, LLVMBuildFMul(builder, a, b, ""), c, "")
+}
+
+def private vexpf_isplat(ctx : JitCtx; dim : int; v : uint64) : LLVMOpaqueValue? {
+    var res = LLVMGetUndef(LLVMVectorType(ctx.types.t_int32, uint(dim)))
+    let cv = LLVMConstInt(ctx.types.t_int32, v, 0)
+    for (d in range(dim)) {
+        res = LLVMBuildInsertElement(ctx.builder, res, cv, LLVMConstInt(ctx.types.t_int32, uint64(d), 0), "")
+    }
+    return res
+}
+
+def private vexpf_fsplat(ctx : JitCtx; opType : TypeDeclPtr; v : double) : LLVMOpaqueValue? {
+    return build_broadcast_vector(ctx.builder, opType, LLVMConstReal(ctx.types.t_float, v))
+}
+
+// Vectorized expf emitted as inline IR — ggml_v_expf (ARM optimized-routines), max rel err ~2 ulp.
+// The default lowering (@llvm.exp.vNf32) scalarizes to N libm expf calls on targets without a vector
+// libm (Darwin-ARM, most others) — ~7x slower. The |n|>126 overflow/underflow path is a branchless
+// select tree (correct inf/0), so this is a full-range drop-in: callers need no clamp.
+def private build_vector_expf(ctx : JitCtx; opType : TypeDeclPtr; x : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    let bld = ctx.builder
+    let dim = opType.vectorDim
+    let lt = type_to_llvm_type(opType)
+    let fty = LLVMFunctionType(lt, [ lt, lt, lt])
+    let fid = LLVMLookupIntrinsicID(build_op_name("fmuladd", opType))
+    let fma_decl = fid != 0u ? LLVMGetIntrinsicDeclaration(g_mod, fid, [ lt]) : null
+    let R = vexpf_fsplat(ctx, opType, 12582912.0lf); let LE = vexpf_fsplat(ctx, opType, 1.4426950216293335lf)
+    let NH = vexpf_fsplat(ctx, opType, -0.693145751953125lf); let NL = vexpf_fsplat(ctx, opType, -1.428606765330187e-06lf)
+    let C0 = vexpf_fsplat(ctx, opType, 0.9999994039535522lf); let C1 = vexpf_fsplat(ctx, opType, 0.4999912679195404lf)
+    let C2 = vexpf_fsplat(ctx, opType, 0.16668395698070526lf); let C3 = vexpf_fsplat(ctx, opType, 0.04189976677298546lf)
+    let C4 = vexpf_fsplat(ctx, opType, 0.008247390389442444lf)
+    let z = vexpf_fma(bld, fma_decl, fty, x, LE, R)                          // x*log2e + magic
+    let n = LLVMBuildFSub(bld, z, R, "")                                     // round(x*log2e)
+    let bred = vexpf_fma(bld, fma_decl, fty, n, NL, vexpf_fma(bld, fma_decl, fty, n, NH, x))  // x - n*ln2
+    let u = LLVMBuildFMul(bld, bred, bred, "")
+    let inner = vexpf_fma(bld, fma_decl, fty, vexpf_fma(bld, fma_decl, fty, C4, bred, C3), u,
+        vexpf_fma(bld, fma_decl, fty, C2, bred, C1))
+    let poly = vexpf_fma(bld, fma_decl, fty, inner, u, LLVMBuildFMul(bld, C0, bred, ""))
+    let e = LLVMBuildShl(bld, LLVMBuildBitCast(bld, z, LLVMVectorType(ctx.types.t_int32, uint(dim)), ""),
+        vexpf_isplat(ctx, dim, 23ul), "")                                   // exponent field of 2^n
+    let k = LLVMBuildBitCast(bld, LLVMBuildAdd(bld, e, vexpf_isplat(ctx, dim, 0x3f800000ul), ""), lt, "")
+    let fast = vexpf_fma(bld, fma_decl, fty, poly, k, k)                     // k*(1+poly), normal range
+    let fabs_decl = LLVMGetIntrinsicDeclaration(g_mod, LLVMLookupIntrinsicID(build_op_name("fabs", opType)), [ lt])
+    let nabs = LLVMBuildCall2(bld, LLVMFunctionType(lt, [ lt]), fabs_decl, [ n], "")
+    let c126 = LLVMBuildFCmp(bld, LLVMRealPredicate.LLVMRealOGT, nabs, vexpf_fsplat(ctx, opType, 126.0lf), "")
+    let c192 = LLVMBuildFCmp(bld, LLVMRealPredicate.LLVMRealOGT, nabs, vexpf_fsplat(ctx, opType, 192.0lf), "")
+    let nlez = LLVMBuildFCmp(bld, LLVMRealPredicate.LLVMRealOLE, n, vexpf_fsplat(ctx, opType, 0.0lf), "")
+    let d = LLVMBuildSelect(bld, nlez, vexpf_isplat(ctx, dim, 0x82000000ul), vexpf_isplat(ctx, dim, 0ul), "")
+    let s1 = LLVMBuildBitCast(bld, LLVMBuildAdd(bld, d, vexpf_isplat(ctx, dim, 0x7f000000ul), ""), lt, "")
+    let s2 = LLVMBuildBitCast(bld, LLVMBuildSub(bld, e, d, ""), lt, "")
+    let mid = LLVMBuildFMul(bld, vexpf_fma(bld, fma_decl, fty, s2, poly, s2), s1, "")  // |n|>126 underflow/overflow
+    let big = LLVMBuildFMul(bld, s1, s1, "")                                 // |n|>192 saturates to inf/0
+    return LLVMBuildSelect(bld, c192, big, LLVMBuildSelect(bld, c126, mid, fast, ""), "")
+}
+
+// exp: on aarch64, vector-float gets the inline polynomial (the default @llvm.exp.vNf32 scalarizes to
+// libm). The IR is generic vector ops, so it lowers fine on x64 too (verified via llc: SSE2/AVX2/AVX-512
+// all vectorize, zero scalarization) — but it's GATED to aarch64 pending validation on real x64 hardware;
+// flip g_target_is_aarch64 to drop the gate. Scalar float/double, and all non-aarch64 vector exp, keep
+// @llvm.exp (libm, correctly rounded — a single scalar call carries no scalarization penalty).
+def intrinsic_math_exp(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    assume opType = expr.arguments[0]._type
+    if (g_target_is_aarch64 && opType.isVectorType && opType.vectorBaseType == Type.tFloat) {
+        return build_vector_expf(ctx, opType, arguments[0])
+    }
+    return intrinsic_math_any_float_op1("exp", ctx.builder, expr, arguments)
 }
 
 def intrinsic_math_mad_op3(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -37,6 +37,33 @@ let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x2eul   // exp(floatN) → inline ggml_
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
+// `options _jit_fast_math = true` stamps every FP instruction with all fast-math flags before opt — lets
+// reductions reassociate/vectorize and FP contract everywhere. NON-bit-exact, but this is the same FP
+// laxity llama.cpp/ggml already runs with (hand-coded FMA + ~2ulp poly exp + reassociated SIMD reductions;
+// ggml CPU is just -O3, no -ffast-math flag — it hand-writes the equivalent). Measured greedy-STABLE on
+// Llama-3.2-1B prefill (identical next token @512/1024/2048, ~1% logit drift) for +8-10% end-to-end.
+// Default off (bit-exact). The magic-number exp survives reassoc — LLVM keeps `z` (its bits feed the
+// exponent bitcast), so it does NOT fold `(x*log2e + M) - M` away.
+var g_jit_fast_math = false
+
+def private apply_fast_math_to_module(m : LLVMOpaqueModule?) {
+    var fn = LLVMGetFirstFunction(m)
+    while (fn != null) {
+        var bb = LLVMGetFirstBasicBlock(fn)
+        while (bb != null) {
+            var inst = LLVMGetFirstInstruction(bb)
+            while (inst != null) {
+                if (LLVMCanValueUseFastMathFlags(inst) != 0) {
+                    LLVMSetFastMathFlags(inst, 0x7fu)   // reassoc|nnan|ninf|nsz|arcp|contract|afn
+                }
+                inst = LLVMGetNextInstruction(inst)
+            }
+            bb = LLVMGetNextBasicBlock(bb)
+        }
+        fn = LLVMGetNextFunction(fn)
+    }
+}
+
 def jit_dll_basename(funcs : array<FunctionPtr>; opt_level : int; size_level : int;
                      emit_prologue : bool; debug_info : bool) : string {
     var h = LLVM_JIT_CODEGEN_VERSION
@@ -47,6 +74,7 @@ def jit_dll_basename(funcs : array<FunctionPtr>; opt_level : int; size_level : i
     h = (h ^ uint64(size_level)) * JIT_FNV_PRIME
     h = (h ^ (emit_prologue ? 1ul : 0ul)) * JIT_FNV_PRIME
     h = (h ^ (debug_info ? 1ul : 0ul)) * JIT_FNV_PRIME
+    h = (h ^ (g_jit_fast_math ? 1ul : 0ul)) * JIT_FNV_PRIME   // fast-math changes codegen → distinct cache
     return "{h}"
 }
 
@@ -198,6 +226,7 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
 
     // Set global options
     LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS = prog._options |> find_arg("jit_vec3_ldu") ?as tBool ?? LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS_DEFAULT
+    g_jit_fast_math = prog._options |> find_arg("_jit_fast_math") ?as tBool ?? false
 
     make_visitor(*disableJitVisitor) $(disableJitVisitorAdapter) {
         prog |> for_each_module() $(mod) {
@@ -309,6 +338,9 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
                 panic("Internal jit error. Failed to get IR for functions {fn_names}.\n")
             }
             generate_global_ctors_dtors(g_prim_t, !(use_dll || gen_exe))
+            if (g_jit_fast_math) {
+                apply_fast_math_to_module(g_mod)   // EXPERIMENT: stamp all FP ops fast (non-bit-exact ceiling)
+            }
             optimize_llvm_module(opt_level |> uint(), size_level |> uint(), LLVM_INLINE_THRESHOLD, !gen_exe)
             if (dump_ir) {
                 // Let's remove unused attributes before we print IR.

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x2dul   // mad → @llvm.fmuladd (fused multiply-add)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x2eul   // exp(floatN) → inline ggml_v_expf polynomial
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/tests/dasLLAMA/test_silu.das
+++ b/tests/dasLLAMA/test_silu.das
@@ -23,4 +23,16 @@ def test_silu(t : T?) {
         t |> success(abs(x[0] - 20.0) < 1e-4)
         t |> success(abs(x[1]) < 1e-4)
     }
+    // Regression: the array overload forwards via addr(x[0]), which index-faults on an empty
+    // array. size <= 0 must be a safe no-op (both silu and gelu).
+    t |> run("empty / zero size is a no-op") @(t : T?) {
+        var e : array<float>
+        silu(e, 0l)
+        gelu(e, 0l)
+        var x <- [1.0, 2.0, 3.0]
+        silu(x, 0l)
+        gelu(x, 0l)
+        t |> success(abs(x[0] - 1.0) < 1e-6)   // untouched by the zero-count calls
+        t |> success(true)                      // reached here ⇒ no index-fault
+    }
 }

--- a/tests/dasLLAMA/test_softmax.das
+++ b/tests/dasLLAMA/test_softmax.das
@@ -40,4 +40,14 @@ def test_softmax(t : T?) {
         }
         t |> success(abs(sum - 1.0) < 1e-5)  // would be NaN without the max-subtract
     }
+    // Regression: the array overload forwards via addr(x[0]), which index-faults on an empty
+    // array; size <= 0 must be a safe no-op.
+    t |> run("empty / zero size is a no-op") @(t : T?) {
+        var e : array<float>
+        softmax(e, 0l)
+        var x <- [1.0, 2.0, 3.0]
+        softmax(x, 0l)
+        t |> success(abs(x[0] - 1.0) < 1e-6)   // untouched
+        t |> success(true)                      // reached here ⇒ no index-fault
+    }
 }


### PR DESCRIPTION
Follow-up to #3316 (dasLLAMA JIT cleanup). Squeezes more out of the flash-attention prefill path: a vectorized `expf`, a hand-vectorized softmax max reduction, threaded FFN activation, and an opt-in JIT fast-math switch. All perf numbers are aarch64 (Apple Silicon) under `-jit`.

### JIT emitter (`modules/dasLLVM`)

- **`exp(floatN)` → inline `ggml_v_expf` polynomial** (aarch64-gated). The default lowering is `@llvm.exp.vNf32`, which scalarizes to N libm `expf` calls on targets without a vector libm (Darwin-ARM and most others) — ~7x slower. The new emitter inlines the ggml ARM-optimized-routines polynomial (degree-4 on the ln2-reduced argument, ~2 ulp), with a branchless overflow/underflow select tree so it's a full-range drop-in. The IR is generic vector ops (llc-verified to vectorize on SSE2/AVX2/AVX-512 with zero scalarization), but **gated to aarch64 pending validation on real x64 hardware** — flip `g_target_is_aarch64` to drop the gate. Scalar `float`/`double` exp stays on `@llvm.exp` (one libm call, no scalarization penalty).
- **`options _jit_fast_math`** — stamps every FP instruction with all fast-math flags before opt, letting reductions reassociate/vectorize and FP contract everywhere. **Non-bit-exact, default off.** This is the same FP laxity llama.cpp/ggml already runs with (hand-coded FMA + ~2 ulp poly exp + reassociated SIMD reductions). Measured greedy-stable on Llama-3.2-1B prefill (identical next token @512/1024/2048, ~1% logit drift) for +8–10% end-to-end. `LLVM_JIT_CODEGEN_VERSION` bumped 0x2d→0x2e and the flag folds into the JIT DLL cache key (distinct cache).

### dasLLAMA kernels (`modules/dasLLAMA`)

- **Softmax max reduction, hand-vectorized** (float4 ×2 + horizontal). Replaces a `[vectorize]` hint LLVM ignored — `max()` lowers to fcmp+select, which LLVM won't auto-vectorize as a reduction without nnan/nsz fast-math (we don't emit it, for bit-exactness). `max` is associative+exact, so two lane accumulators + a horizontal max are **bit-identical** to the scalar fold (~9x over scalar). The broadcast seed never reads past the buffer (safe for size &lt; 8).
- **`exp4`** — fast-path-only vectorized `expf` (no overflow guard, valid for x in ~[-87, 88]) for the flash softmax fold, which clamps masked/underflow entries first. ~1.4x on the attention bucket. Kept separate from the JIT intrinsic above (which is full-range and gated) deliberately; once x64 is verified the intrinsic gets a fast-path branch and this can be retired for plain `exp(float4)`.
- **Threaded per-position FFN activation** (`act_batch`). silu/gelu split into a `var float?` pointer core + array wrapper (the established softmax idiom — no const-strip), then threaded over positions via `maybe_parallel_for`. Each element's activation is independent (no cross-position reduce), so threading is bit-exact. 7.2x on the activation bucket; self-gates on `ACT_PAR_THRESHOLD` so small prompts run inline.

### Runners + benchmarks

- `options _jit_fast_math` enabled on the example runners/chat demos and the perf benchmarks (the +8–10% above).

### Bit-exactness note

The non-bit-exact pieces (`_jit_fast_math`, `exp4`, the flash exp4 fold) are opt-in or live only on the already-non-bit-exact flash path. The token-for-token parity fixture pins **classic** attention (bit-exact), so parity is unaffected.

### Validation

`utils/preflight/main.das -- --full` — 16 passed, 0 failed (format, lint, dasgen, ci-das, docs ×7, tests-cpp, tests-interp, tests-jit, tests-aot, sequence). tests-jit ran cold (codegen-version bump invalidated the DLL cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)