### PR TITLE
utils/mcp: stdio supervisor that auto-respawns the daslang MCP child

### DIFF
--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -194,8 +194,11 @@ class DaslangChild:
 
 def handle(child: DaslangChild, msg: dict) -> str | None:
     """Return a response line for a request, or None for a notification.
-    initialize/ping are answered locally; tools/* are forwarded (spawning the
-    child on first use)."""
+    initialize/ping/notifications are answered locally; only tools/* is
+    forwarded (spawning the child on first use). Any other id-bearing method
+    gets a local method-not-found — the daslang server answers those the same
+    way, so we avoid spawning the child (and re-locking DLLs mid-build) for
+    stray resources/*/prompts/* probes."""
     method = msg.get("method")
     has_id = "id" in msg
     mid = msg.get("id")
@@ -212,7 +215,10 @@ def handle(child: DaslangChild, msg: dict) -> str | None:
     if not has_id:
         child.notify(msg)
         return None
-    return child.request(msg)   # tools/list, tools/call, anything else
+    if method is not None and method.startswith("tools/"):
+        return child.request(msg)   # the only methods that need the compiler
+    return json.dumps({"jsonrpc": "2.0", "id": mid,
+                       "error": {"code": -32601, "message": f"method not found: {method}"}})
 
 
 def _default_launcher() -> list[str]:

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -124,17 +124,21 @@ class DaslangChild:
 
     # ---- forwarding -----------------------------------------------------
     def request(self, msg: dict) -> str:
-        """Forward a request (has id) and return the daslang response line."""
+        """Forward a request (has id) and return the daslang response line.
+        The retry covers a child that's dead / dies *before* the request is
+        delivered (the build-guard case). Once the write succeeds we do NOT
+        re-send on a later failure — a retry could double-execute a
+        side-effecting tool (run_test, live_*, format_file); a child that dies
+        while we read the response surfaces as an error instead."""
         with self.lock:
             line = json.dumps(msg, separators=(",", ":"))
             try:
                 self._ensure_alive()
                 self._write_line(line)
-                return self._read_line()
             except ChildDead:
-                self._spawn_and_replay()        # died mid-exchange -> respawn + retry once
+                self._spawn_and_replay()        # not yet delivered -> respawn + resend once
                 self._write_line(line)
-                return self._read_line()
+            return self._read_line()            # ChildDead here propagates (no re-send)
 
     def notify(self, msg: dict):
         """Forward a notification (no id) to a live child; skip if dead (state
@@ -188,8 +192,9 @@ def handle(child: DaslangChild, msg: dict) -> str | None:
 def _default_launcher() -> list[str]:
     if IS_WINDOWS:
         return ["cmd", "/c", os.path.join(SCRIPT_DIR, "daslang-mcp-msvc.cmd")]
-    # POSIX: run the built binary directly. Mirror setup.das locate_binary's
-    # candidate order — single/multi-config generators land it in bin/ or build/.
+    # POSIX: run the built binary directly, trying the usual single/multi-config
+    # output locations (bin/ and build/, cf. setup.das locate_binary) — first
+    # existing wins.
     main_das = os.path.join(SCRIPT_DIR, "main.das")
     for rel in ("bin/Release/daslang", "bin/daslang", "build/daslang", "build/bin/daslang"):
         cand = os.path.join(REPO_ROOT, rel)
@@ -213,7 +218,13 @@ def write_mcp_json(repo_root: str) -> str:
         if not isinstance(data, dict):
             print(f"  WARNING: {path} is not a JSON object; leaving it untouched", flush=True)
             return path
-    servers = data.setdefault("mcpServers", {})
+    servers = data.get("mcpServers")
+    if servers is None:
+        servers = {}
+        data["mcpServers"] = servers
+    elif not isinstance(servers, dict):
+        print(f"  WARNING: {path} has a non-object 'mcpServers'; leaving it untouched", flush=True)
+        return path
     prev = servers.get("daslang", {})
     entry = {"command": "python", "args": ["utils/mcp/mcp_supervisor.py"]}
     if isinstance(prev, dict) and "defer_loading" in prev:

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -84,7 +84,33 @@ class DaslangChild:
             self.initialized_seen = True
 
     # ---- lifecycle ------------------------------------------------------
+    def _kill_proc(self):
+        """Terminate (if alive), reap, and close the pipes of the current child.
+        Run before every respawn and on stop() so a long kill-rebuild session
+        never orphans a live daslang or leaks its pipe fds."""
+        p = self.proc
+        self.proc = None
+        if p is None:
+            return
+        try:
+            if p.poll() is None:
+                if IS_WINDOWS:
+                    subprocess.run(["taskkill", "/F", "/T", "/PID", str(p.pid)],
+                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                else:
+                    p.terminate()
+                p.wait(timeout=10)
+        except Exception:
+            pass
+        for pipe in (p.stdin, p.stdout):
+            try:
+                if pipe is not None:
+                    pipe.close()
+            except Exception:
+                pass
+
     def _spawn_and_replay(self):
+        self._kill_proc()   # clean up any prior child before respawning
         if self._stderr_fh is None:
             self._stderr_fh = open(self.stderr_log, "ab", buffering=0)
         self.proc = subprocess.Popen(
@@ -153,17 +179,7 @@ class DaslangChild:
 
     def stop(self):
         with self.lock:
-            if self.proc is not None and self.proc.poll() is None:
-                try:
-                    if IS_WINDOWS:
-                        subprocess.run(["taskkill", "/F", "/T", "/PID", str(self.proc.pid)],
-                                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                    else:
-                        self.proc.terminate()
-                    self.proc.wait(timeout=10)
-                except Exception:
-                    pass
-            self.proc = None
+            self._kill_proc()
             if self._stderr_fh is not None:
                 try:
                     self._stderr_fh.close()
@@ -294,7 +310,8 @@ def main():
     if args.emit_config:
         if write_mcp_json(repo_root):
             print(f"wrote {os.path.join(repo_root, '.mcp.json')}: daslang -> stdio supervisor (utils/mcp/mcp_supervisor.py)")
-        return
+            return
+        sys.exit(1)   # left an existing malformed .mcp.json untouched -> fail so callers surface it
     serve(repo_root, args.stderr_log)
 
 

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -188,7 +188,14 @@ def handle(child: DaslangChild, msg: dict) -> str | None:
 def _default_launcher() -> list[str]:
     if IS_WINDOWS:
         return ["cmd", "/c", os.path.join(SCRIPT_DIR, "daslang-mcp-msvc.cmd")]
-    return [os.path.join(REPO_ROOT, "bin", "daslang"), os.path.join(SCRIPT_DIR, "main.das")]
+    # POSIX: run the built binary directly. Mirror setup.das locate_binary's
+    # candidate order — single/multi-config generators land it in bin/ or build/.
+    main_das = os.path.join(SCRIPT_DIR, "main.das")
+    for rel in ("bin/Release/daslang", "bin/daslang", "build/daslang", "build/bin/daslang"):
+        cand = os.path.join(REPO_ROOT, rel)
+        if os.path.exists(cand):
+            return [cand, main_das]
+    return [os.path.join(REPO_ROOT, "bin", "daslang"), main_das]  # best-guess fallback
 
 
 def write_mcp_json(repo_root: str) -> str:
@@ -202,6 +209,9 @@ def write_mcp_json(repo_root: str) -> str:
                 data = json.load(f)
         except Exception as e:
             print(f"  WARNING: {path} did not parse ({e}); leaving it untouched", flush=True)
+            return path
+        if not isinstance(data, dict):
+            print(f"  WARNING: {path} is not a JSON object; leaving it untouched", flush=True)
             return path
     servers = data.setdefault("mcpServers", {})
     prev = servers.get("daslang", {})

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -203,9 +203,10 @@ def _default_launcher() -> list[str]:
     return [os.path.join(REPO_ROOT, "bin", "daslang"), main_das]  # best-guess fallback
 
 
-def write_mcp_json(repo_root: str) -> str:
+def write_mcp_json(repo_root: str) -> bool:
     """Set mcpServers.daslang to spawn this supervisor over stdio, preserving
-    every other server (github, …). Atomic; never clobbers an unparseable file."""
+    every other server (github, …). Atomic; never clobbers an unparseable file.
+    Returns True if the file was (re)written, False if left untouched."""
     path = os.path.join(repo_root, ".mcp.json")
     data = {"mcpServers": {}}
     if os.path.exists(path):
@@ -214,17 +215,17 @@ def write_mcp_json(repo_root: str) -> str:
                 data = json.load(f)
         except Exception as e:
             print(f"  WARNING: {path} did not parse ({e}); leaving it untouched", flush=True)
-            return path
+            return False
         if not isinstance(data, dict):
             print(f"  WARNING: {path} is not a JSON object; leaving it untouched", flush=True)
-            return path
+            return False
     servers = data.get("mcpServers")
     if servers is None:
         servers = {}
         data["mcpServers"] = servers
     elif not isinstance(servers, dict):
         print(f"  WARNING: {path} has a non-object 'mcpServers'; leaving it untouched", flush=True)
-        return path
+        return False
     prev = servers.get("daslang", {})
     entry = {"command": "python", "args": ["utils/mcp/mcp_supervisor.py"]}
     if isinstance(prev, dict) and "defer_loading" in prev:
@@ -235,7 +236,7 @@ def write_mcp_json(repo_root: str) -> str:
         json.dump(data, f, indent=2)
         f.write("\n")
     os.replace(tmp, path)
-    return path
+    return True
 
 
 def serve(repo_root: str, stderr_log: str):
@@ -283,8 +284,8 @@ def main():
     repo_root = os.path.abspath(args.repo_root)
 
     if args.emit_config:
-        path = write_mcp_json(repo_root)
-        print(f"wrote {path}: daslang -> stdio supervisor (utils/mcp/mcp_supervisor.py)")
+        if write_mcp_json(repo_root):
+            print(f"wrote {os.path.join(repo_root, '.mcp.json')}: daslang -> stdio supervisor (utils/mcp/mcp_supervisor.py)")
         return
     serve(repo_root, args.stderr_log)
 

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""daslang MCP stdio supervisor.
+
+Claude Code spawns THIS over stdio (so CC's HTTP-transport OAuth probe never
+happens — see anthropics/claude-code#46879). It forwards MCP JSON-RPC to a
+daslang child (spawned via daslang-mcp-msvc.cmd, which sets up vcvars), and
+respawns that child on death/rebuild, replaying the MCP `initialize` handshake.
+
+Result: daslang can be killed (e.g. to release DLL locks before a rebuild) or
+crash, and CC never sees a disconnect — CC's pipe is to this supervisor, which
+does not die when the child does. The supervisor answers `initialize` and
+`ping` itself and spawns the daslang child lazily on the first real `tools/*`
+call, so idle keepalives during a build don't respawn a deliberately-killed
+child and re-lock the DLLs.
+
+Per-worktree / per-session isolation is automatic: every CC session spawns its
+own supervisor, which spawns that worktree's own daslang. No ports, no config.
+
+.mcp.json (written by --emit-config / setup.das):
+    "daslang": { "command": "python", "args": ["utils/mcp/mcp_supervisor.py"] }
+
+Pre-build guard: kill the daslang child (a `daslang.exe` running mcp\\main.das)
+to release its DLL locks; build; the next tool call respawns the fresh binary.
+The supervisor stays up throughout, so CC never disconnects.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+
+IS_WINDOWS = os.name == "nt"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(SCRIPT_DIR))  # utils/mcp -> utils -> repo
+
+# The daslang MCP server's InitializeResult is a fixed constant
+# (utils/mcp/protocol_core.das: handle_initialize). Answering it here lets CC
+# connect instantly while the daslang child stays unspawned until first use.
+INIT_RESULT = {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {"tools": {}},
+    "serverInfo": {"name": "daslang", "version": "0.1.0"},
+}
+
+SUPERVISOR_LOG = os.path.join(tempfile.gettempdir(), "daslang_mcp_supervisor.log")
+
+
+def _log(msg: str):
+    try:
+        with open(SUPERVISOR_LOG, "a", encoding="utf-8") as f:
+            f.write(msg + "\n")
+    except Exception:
+        pass
+
+
+class ChildDead(Exception):
+    """The daslang child exited / its pipe broke mid-exchange."""
+
+
+class DaslangChild:
+    """Supervises the stdio daslang MCP child: lazy spawn, transparent respawn
+    with handshake replay, serialized forwarding."""
+
+    def __init__(self, launcher: list[str], stderr_log: str, cwd: str):
+        self.launcher = launcher
+        self.stderr_log = stderr_log
+        self.cwd = cwd
+        self.proc: subprocess.Popen | None = None
+        self.init_request: dict | None = None   # cached client `initialize`, replayed on spawn
+        self.initialized_seen = False
+        self.lock = threading.RLock()
+        self._stderr_fh = None
+
+    def cache_init(self, msg: dict):
+        with self.lock:
+            self.init_request = msg
+
+    def mark_initialized(self):
+        with self.lock:
+            self.initialized_seen = True
+
+    # ---- lifecycle ------------------------------------------------------
+    def _spawn_and_replay(self):
+        if self._stderr_fh is None:
+            self._stderr_fh = open(self.stderr_log, "ab", buffering=0)
+        self.proc = subprocess.Popen(
+            self.launcher,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=self._stderr_fh,
+            cwd=self.cwd, text=True, encoding="utf-8", errors="replace", bufsize=1,
+        )
+        _log(f"spawned daslang child pid={self.proc.pid}")
+        if self.init_request is not None:
+            self._write_line(json.dumps(self.init_request, separators=(",", ":")))
+            self._read_line()  # consume & discard the replayed initialize result
+            if self.initialized_seen:
+                self._write_line('{"jsonrpc":"2.0","method":"notifications/initialized"}')
+
+    def _ensure_alive(self):
+        if self.proc is None or self.proc.poll() is not None:
+            self._spawn_and_replay()
+
+    def _write_line(self, line: str):
+        try:
+            self.proc.stdin.write(line + "\n")
+            self.proc.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            raise ChildDead(str(e))
+
+    def _read_line(self) -> str:
+        while True:
+            try:
+                line = self.proc.stdout.readline()
+            except (OSError, ValueError) as e:
+                raise ChildDead(str(e))
+            if line == "":
+                raise ChildDead("eof")
+            line = line.strip()
+            if line:
+                return line
+
+    # ---- forwarding -----------------------------------------------------
+    def request(self, msg: dict) -> str:
+        """Forward a request (has id) and return the daslang response line."""
+        with self.lock:
+            line = json.dumps(msg, separators=(",", ":"))
+            try:
+                self._ensure_alive()
+                self._write_line(line)
+                return self._read_line()
+            except ChildDead:
+                self._spawn_and_replay()        # died mid-exchange -> respawn + retry once
+                self._write_line(line)
+                return self._read_line()
+
+    def notify(self, msg: dict):
+        """Forward a notification (no id) to a live child; skip if dead (state
+        is re-established via handshake replay on the next spawn)."""
+        with self.lock:
+            if self.proc is None or self.proc.poll() is not None:
+                return
+            try:
+                self._write_line(json.dumps(msg, separators=(",", ":")))
+            except ChildDead:
+                pass
+
+    def stop(self):
+        with self.lock:
+            if self.proc is not None and self.proc.poll() is None:
+                try:
+                    if IS_WINDOWS:
+                        subprocess.run(["taskkill", "/F", "/T", "/PID", str(self.proc.pid)],
+                                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    else:
+                        self.proc.terminate()
+                    self.proc.wait(timeout=10)
+                except Exception:
+                    pass
+            self.proc = None
+
+
+def handle(child: DaslangChild, msg: dict) -> str | None:
+    """Return a response line for a request, or None for a notification.
+    initialize/ping are answered locally; tools/* are forwarded (spawning the
+    child on first use)."""
+    method = msg.get("method")
+    has_id = "id" in msg
+    mid = msg.get("id")
+
+    if method == "initialize":
+        child.cache_init(msg)   # replayed to the child when it first spawns
+        return json.dumps({"jsonrpc": "2.0", "id": mid, "result": INIT_RESULT})
+    if method in ("notifications/initialized", "initialized"):
+        child.mark_initialized()
+        child.notify(msg)
+        return None
+    if method == "ping" and has_id:
+        return json.dumps({"jsonrpc": "2.0", "id": mid, "result": {}})
+    if not has_id:
+        child.notify(msg)
+        return None
+    return child.request(msg)   # tools/list, tools/call, anything else
+
+
+def _default_launcher() -> list[str]:
+    if IS_WINDOWS:
+        return ["cmd", "/c", os.path.join(SCRIPT_DIR, "daslang-mcp-msvc.cmd")]
+    return [os.path.join(REPO_ROOT, "bin", "daslang"), os.path.join(SCRIPT_DIR, "main.das")]
+
+
+def write_mcp_json(repo_root: str) -> str:
+    """Set mcpServers.daslang to spawn this supervisor over stdio, preserving
+    every other server (github, …). Atomic; never clobbers an unparseable file."""
+    path = os.path.join(repo_root, ".mcp.json")
+    data = {"mcpServers": {}}
+    if os.path.exists(path):
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception as e:
+            print(f"  WARNING: {path} did not parse ({e}); leaving it untouched", flush=True)
+            return path
+    servers = data.setdefault("mcpServers", {})
+    prev = servers.get("daslang", {})
+    entry = {"command": "python", "args": ["utils/mcp/mcp_supervisor.py"]}
+    if isinstance(prev, dict) and "defer_loading" in prev:
+        entry["defer_loading"] = prev["defer_loading"]
+    servers["daslang"] = entry
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+    return path
+
+
+def serve(repo_root: str, stderr_log: str):
+    child = DaslangChild(_default_launcher(), stderr_log, cwd=repo_root)
+    _log(f"supervisor up (repo={repo_root})")
+    out = sys.stdout.buffer            # binary: avoid Windows \r\n translation on the JSON-RPC pipe
+    try:
+        for raw in sys.stdin.buffer:   # newline-delimited JSON-RPC from Claude Code
+            text = raw.decode("utf-8", "replace").strip()
+            if not text:
+                continue
+            try:
+                msg = json.loads(text)
+            except Exception as e:
+                _log(f"parse error: {e}: {text[:200]}")
+                continue
+            if not isinstance(msg, dict):   # MCP 2025-06-18 removed JSON-RPC batching
+                _log(f"ignoring non-object message: {text[:120]}")
+                continue
+            try:
+                resp = handle(child, msg)
+            except Exception as e:
+                _log(f"handle error: {e}")
+                mid = msg.get("id")
+                resp = (json.dumps({"jsonrpc": "2.0", "id": mid,
+                        "error": {"code": -32000, "message": f"supervisor error: {e}"}})
+                        if mid is not None else None)
+            if resp is not None:
+                out.write(resp.encode("utf-8") + b"\n")
+                out.flush()
+    finally:
+        child.stop()
+        _log("supervisor down (stdin closed)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="daslang MCP stdio supervisor with auto-respawn")
+    ap.add_argument("--repo-root", default=REPO_ROOT)
+    ap.add_argument("--stderr-log", default=os.environ.get(
+        "DASLANG_MCP_CHILD_LOG",
+        os.path.join(tempfile.gettempdir(), "daslang_mcp_child_stderr.log")))
+    ap.add_argument("--emit-config", action="store_true",
+                    help="write the worktree's .mcp.json daslang entry and exit")
+    args = ap.parse_args()
+    repo_root = os.path.abspath(args.repo_root)
+
+    if args.emit_config:
+        path = write_mcp_json(repo_root)
+        print(f"wrote {path}: daslang -> stdio supervisor (utils/mcp/mcp_supervisor.py)")
+        return
+    serve(repo_root, args.stderr_log)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -164,6 +164,12 @@ class DaslangChild:
                 except Exception:
                     pass
             self.proc = None
+            if self._stderr_fh is not None:
+                try:
+                    self._stderr_fh.close()
+                except Exception:
+                    pass
+                self._stderr_fh = None   # reopened on the next spawn
 
 
 def handle(child: DaslangChild, msg: dict) -> str | None:
@@ -260,10 +266,12 @@ def serve(repo_root: str, stderr_log: str):
                 resp = handle(child, msg)
             except Exception as e:
                 _log(f"handle error: {e}")
-                mid = msg.get("id")
-                resp = (json.dumps({"jsonrpc": "2.0", "id": mid,
+                # Respond whenever the request carried an `id` field (same test
+                # handle() uses to tell requests from notifications) — including
+                # an explicit null id — so the client isn't left hanging.
+                resp = (json.dumps({"jsonrpc": "2.0", "id": msg.get("id"),
                         "error": {"code": -32000, "message": f"supervisor error: {e}"}})
-                        if mid is not None else None)
+                        if "id" in msg else None)
             if resp is not None:
                 out.write(resp.encode("utf-8") + b"\n")
                 out.flush()

--- a/utils/mcp/mcp_supervisor.py
+++ b/utils/mcp/mcp_supervisor.py
@@ -99,7 +99,11 @@ class DaslangChild:
                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 else:
                     p.terminate()
-                p.wait(timeout=10)
+                try:
+                    p.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    p.kill()            # graceful terminate ignored -> force (POSIX SIGKILL)
+                    p.wait(timeout=10)
         except Exception:
             pass
         for pipe in (p.stdin, p.stdout):

--- a/utils/mcp/setup.das
+++ b/utils/mcp/setup.das
@@ -2,7 +2,6 @@ options gen2
 
 require daslib/clargs
 require daslib/fio
-require daslib/json_boost
 
 // daslang MCP worktree bootstrap.
 //
@@ -14,7 +13,9 @@ require daslib/json_boost
 // built `bin/` binary, or the tree-sitter grammar shared lib — so a Claude
 // session there has zero daslang tools. This tool fixes that: it builds a
 // worktree-local daslang (+ tree-sitter grammar), copies the platform
-// `sgconfig.yml`, and writes/merges `.mcp.json` with the daslang server entry.
+// `sgconfig.yml`, and points `.mcp.json` at the stdio supervisor
+// (mcp_supervisor.py, via `--emit-config`) — Claude Code spawns the supervisor,
+// which forwards to a daslang child and respawns it on death/rebuild.
 //
 // It adds no NEW secrets; an existing .mcp.json is rewritten with any other
 // server entries (e.g. github, including their env blocks) preserved as-is.
@@ -122,57 +123,21 @@ def ensure_sgconfig(root : string) {
     }
 }
 
-// The daslang MCP server entry, as a JsonValue object.
-def daslang_server_entry(rel_binary : string) : JsonValue? {
-    var entry : table<string; JsonValue?>
-    entry["command"] = JV(rel_binary)
-    var args_arr : array<JsonValue?>
-    args_arr |> push(JV("utils/mcp/main.das"))
-    entry["args"] = JV(args_arr)
-    entry["defer_loading"] = JV(false)
-    return JV(entry)
-}
-
-// Write or merge .mcp.json: set/replace the `daslang` server entry while
-// preserving any other existing servers (e.g. github). Never writes secrets.
-def write_mcp_json(root, rel_binary : string) : bool {
-    let mcp_path = path_join(root, ".mcp.json")
-    var servers : table<string; JsonValue?>
-    if (fexist(mcp_path)) {
-        let txt = fread(mcp_path)
-        var err : string
-        var existing = read_json(txt, err)
-        if (existing == null) {
-            print("WARNING: existing .mcp.json did not parse ({err}) — rewriting from scratch\n")
-        } elif (existing is _object) {
-            // Navigate the parsed tree mutably (read_json data is mutable) so the
-            // preserved server values come back non-const and move into the output
-            // tree directly — no const-strip needed.
-            unsafe {
-                var root_obj & = existing.value as _object
-                if (key_exists(root_obj, "mcpServers")) {
-                    var srv & = root_obj["mcpServers"]
-                    if (srv != null && srv is _object) {
-                        var srv_obj & = srv.value as _object
-                        let ks <- [for (k in keys(srv_obj)); k]
-                        for (k in ks) {
-                            if (k != "daslang") {
-                                servers[k] = srv_obj?[k] ?? null
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    servers["daslang"] = daslang_server_entry(rel_binary)
-    var root_obj : table<string; JsonValue?>
-    root_obj["mcpServers"] = JV(servers)
-    if (!fwrite(mcp_path, write_json(JV(root_obj)))) {
-        print("ERROR: failed to write {mcp_path}\n")
+// Point .mcp.json at the stdio supervisor (mcp_supervisor.py). The supervisor
+// owns the .mcp.json merge (preserving other servers like github), so setup
+// just invokes it. Requires python on PATH — Claude Code spawns the supervisor
+// as `python utils/mcp/mcp_supervisor.py`.
+def emit_mcp_config(root : string) : bool {
+    let script = path_join(root, "utils/mcp/mcp_supervisor.py")
+    if (!fexist(script)) {
+        print("ERROR: {script} not found\n")
         return false
     }
-    print("Wrote .mcp.json (daslang -> {rel_binary})\n")
+    let rc = run_visible("python \"{script}\" --emit-config --repo-root \"{root}\"")
+    if (rc != 0) {
+        print("ERROR: emit-config failed (exit {rc}); is python on PATH?\n")
+        return false
+    }
     return true
 }
 
@@ -238,11 +203,12 @@ def main() : int {
     }
 
     ensure_sgconfig(root)
-    if (!write_mcp_json(root, binary)) {
+    if (!emit_mcp_config(root)) {
         return 1
     }
 
-    print("\nDone. Restart the Claude Code session in {root} to pick up the MCP server.\n")
+    print("\nDone. Restart the Claude Code session in {root} to pick up the daslang MCP server.\n")
+    print("Claude Code spawns the stdio supervisor (utils/mcp/mcp_supervisor.py); no persistent process to keep running.\n")
     print("NOTE: the parse-aware tools (grep_usage/outline/cpp_*) also need the ast-grep `sg` CLI on PATH.\n")
     return 0
 }


### PR DESCRIPTION
## Problem

Claude Code never auto-restarts a **stdio** MCP server once it dies ([anthropics/claude-code#43177](https://github.com/anthropics/claude-code/issues/43177), closed "not planned"). So whenever the daslang MCP child was killed to release DLL locks before a rebuild, crashed, or was rebuilt, the daslang tools stayed "disconnected" until a manual `/mcp`.

## Solution

`utils/mcp/mcp_supervisor.py` — a stdlib-only Python **stdio** proxy that Claude Code spawns in place of daslang. It forwards MCP JSON-RPC to a daslang child (spawned via the existing `daslang-mcp-msvc.cmd`, so vcvars still reaches `cpp_compile_check`) and **respawns that child on death/rebuild, replaying the `initialize` handshake**. CC's pipe is to the supervisor, which doesn't die when the child does — so daslang can be killed/rebuilt and CC never sees a disconnect.

- `initialize`/`ping`/notifications are answered by the supervisor itself, and the daslang child spawns **lazily on the first `tools/*` call**. So a deliberately-killed child (to drop DLL locks before a build) isn't respawned by idle keepalive pings and can't re-lock mid-link.
- Per-worktree / per-session isolation is automatic — each CC session spawns its own supervisor, which spawns that worktree's own daslang. No ports, no shared state.

`setup.das` now points `.mcp.json` at the supervisor via a new `--emit-config` mode (was: a direct stdio entry for the binary), preserving any other servers (e.g. github) in the merge.

## Why stdio and not HTTP

The first cut was an HTTP bridge (HTTP MCP servers *do* auto-reconnect in CC). Dead end: CC's HTTP transport eagerly runs an OAuth flow — it probes `/.well-known/oauth-*` and POSTs OAuth Dynamic Client Registration, then hard-fails on a no-auth local server, with no config flag to disable it ([#46879](https://github.com/anthropics/claude-code/issues/46879), [#46640](https://github.com/anthropics/claude-code/issues/46640), [#2831](https://github.com/anthropics/claude-code/issues/2831)). Stdio sidesteps that entirely, CC manages the supervisor's lifecycle (no persistent process to babysit), and it still delivers the "stable thing in front of daslang" that fixes the reconnect problem.

## Verification

Driven exactly as CC drives it (newline-delimited JSON-RPC over stdin/stdout): `initialize`/`ping` answered locally, child stays unspawned until the first `tools/list`, then killing the child leaves the supervisor alive and transparently respawns it (new pid) with all 43 tools intact — no disconnect. `setup.das` compiles, lints clean, and is already formatted (checked through the supervisor itself).

## Notes

- `mcp_supervisor.py` is a utility script (not built/tested by CI); `setup.das` is lint-clean and formatted. No runtime/daslib/C++/test surface is touched.
- `.mcp.json` is gitignored and per-worktree, so wiring is local (via `setup.das --emit-config` or the supervisor's `--emit-config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)