### PR TITLE
fix: propagate write through pointer-offset args in side-effect inference (#3321)

### DIFF
--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -258,7 +258,12 @@ namespace das {
                 propagateWrite(rr->subexpr);
             } else if ( expr->rtti_isCallFunc() ) {
                 auto call = (ExprCallFunc *) expr;
-                if ( call->func && (call->func->propertyFunction || call->func->isCustomProperty) ) {
+                // firstArgReturnType (pointer arithmetic: i_das_ptr_add/sub/etc) returns a
+                // pointer aliasing arguments[0]'s pointee, so a write through the result is a
+                // write through arguments[0]. Without this the write is lost across an
+                // offset-pointer helper call and the caller is wrongly judged pure (issue #3321)
+                if ( call->func && (call->func->propertyFunction || call->func->isCustomProperty
+                                    || call->func->firstArgReturnType) ) {
                     propagateWrite(call->arguments[0]);
                 }
             }
@@ -312,7 +317,8 @@ namespace das {
             } else if ( expr->rtti_isCallFunc() ) {
                 auto call = (ExprCallFunc *) expr;
                 call->write = true;
-                if ( call->func && (call->func->propertyFunction || call->func->isCustomProperty) ) {
+                if ( call->func && (call->func->propertyFunction || call->func->isCustomProperty
+                                    || call->func->firstArgReturnType) ) {
                     propagateWriteViaCopyOrMove(call->arguments[0]);
                 }
             }
@@ -351,7 +357,8 @@ namespace das {
                 propagatePassMutable(((ExprRef2Value *) expr)->subexpr);
             } else if ( expr->rtti_isCallFunc() ) {
                 auto call = (ExprCallFunc *) expr;
-                if ( call->func && (call->func->propertyFunction || call->func->isCustomProperty) ) {
+                if ( call->func && (call->func->propertyFunction || call->func->isCustomProperty
+                                    || call->func->firstArgReturnType) ) {
                     propagatePassMutable(call->arguments[0]);
                 }
             }

--- a/tests/language/offset_pointer_write_through_helper.das
+++ b/tests/language/offset_pointer_write_through_helper.das
@@ -1,0 +1,65 @@
+options gen2
+options no_unused_function_arguments = false
+require dastest/testing_boost public
+
+// Regression for issue #3321: a callee that writes its output pointer ONLY through a
+// helper call, passing the pointer OFFSET (`cpy(d + k*2, ...)`) inside a loop, must still
+// be inferred [modify_argument]. The offset desugars to `i_das_ptr_add(d, ...)` — a
+// firstArgReturnType builtin whose result aliases the base pointer's pointee. Before the
+// fix the side-effect analyzer did not recurse through that builtin, so the forwarded write
+// never reached `d`, `pk` collapsed to [nosideeffects], and the whole call was
+// dead-code-eliminated — silently dropping the write in interp, JIT and AOT alike.
+
+// leaf helper: writes every element of its (mutable) output pointer
+def cpy2(var d : float?; s : float const?; n : int64) {
+    for (j in range64(n)) { unsafe { d[j] = s[j] + 100.0 } }
+}
+
+// the #3321 surface: writes d ONLY via the helper, passing d offset by the loop var
+def pk(var d : float?; s : float const?) {
+    unsafe { for (k in range64(2l)) { cpy2(d + k * 2l, s + k * 2l, 2l) } }
+}
+
+// control: writes d directly (no helper) — the write was never lost
+def pk_direct(var d : float?; s : float const?) {
+    unsafe { for (k in range64(4l)) { d[k] = s[k] + 100.0 } }
+}
+
+// control: helper called with the pointer UNOFFSET — plain ExprVar arg, always propagated
+def pk_unoffset(var d : float?; s : float const?) {
+    unsafe { cpy2(d, s, 4l) }
+}
+
+def fill(var a : float[4]; base : float) {
+    for (i in range(4)) { a[i] = base + float(i) }
+}
+
+[test]
+def test_offset_pointer_write_through_helper(t : T?) {
+    // (1) the bug: offset-pointer helper call in a loop — a stayed -9 before the fix
+    t |> run("offset-pointer helper write") @(t : T?) {
+        var a : float[4]; fill(a, -9.0)
+        var b : float[4]; fill(b, 0.0)
+        unsafe { pk(addr(a[0]), addr(b[0])) }
+        t |> equal(a[0], 100.0)
+        t |> equal(a[1], 101.0)
+        t |> equal(a[2], 102.0)
+        t |> equal(a[3], 103.0)
+    }
+    // (2) control: direct write, no helper — always worked
+    t |> run("direct write control") @(t : T?) {
+        var a : float[4]; fill(a, -9.0)
+        var b : float[4]; fill(b, 0.0)
+        unsafe { pk_direct(addr(a[0]), addr(b[0])) }
+        t |> equal(a[0], 100.0)
+        t |> equal(a[3], 103.0)
+    }
+    // (3) control: unoffset helper call — plain ExprVar argument, always worked
+    t |> run("unoffset helper control") @(t : T?) {
+        var a : float[4]; fill(a, -9.0)
+        var b : float[4]; fill(b, 0.0)
+        unsafe { pk_unoffset(addr(a[0]), addr(b[0])) }
+        t |> equal(a[0], 100.0)
+        t |> equal(a[3], 103.0)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3321 — the front-end silently dead-code-eliminated a call whose only write to an output pointer flowed through a helper that received the pointer **offset** (`cpy(d + k*2, ...)`).

## Root cause

`d + offset` desugars to `i_das_ptr_add(d, offset, stride)` — an `ExprCall` to a pointer-arithmetic builtin flagged `firstArgReturnType` (its result aliases `arguments[0]`'s pointee). In `src/ast/ast_unused.cpp`, the side-effect analyzer's write-propagation helpers (`propagateWrite`, `propagateWriteViaCopyOrMove`, `propagatePassMutable`) only recursed into `arguments[0]` for **property functions**. So when a `[modify_argument]` callee (`cpy`) received an offset pointer, the forwarded write never reached the base pointer `d`, the caller `pk` collapsed to `[nosideeffects]`, and the whole call was DCE'd — silently, under interpreter, JIT **and** AOT.

Direct `d[k] = …` or an **unoffset** `cpy(d, …)` worked because those reach `d` as a plain `ExprVar`; only the pointer-arith `ExprCall` broke the write-propagation chain.

## Fix

Extend the `ExprCallFunc` branch in all three helpers to also recurse into `arguments[0]` when `firstArgReturnType` is set. That flag is set **only** by `PointerOp` (the six pointer-arith builtins: add / sub / set_add / set_sub / inc / dec), so the match is precise; the direction is conservative — it can only keep a call, never drop one, so it can never introduce a miscompile.

## Test

`tests/language/offset_pointer_write_through_helper.das` — the exact #3321 surface plus direct-write and unoffset-helper controls (sibling to #3311's `const_strip_write_through_passthrough.das`).

Test-first verified: on the unpatched compiler the offset write is lost; patched, all four elements are written. Full `tests/` suite green (10658 tests) in the interpreter; the new test is green under interpreter / JIT / AOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)