### PR TITLE
dasLLAMA: cache-block the Q8 GEMM token dimension (+unroll) — CPU prefill now beats llama.cpp

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_math_aarch64_neon.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_aarch64_neon.das
@@ -6,6 +6,7 @@ require dasllama/dasllama_math
 require llvm/daslib/aarch64_neon  // sdot4: JIT-emitted ARM SDOT, scalar fallback elsewhere
 require daslib/jobque_boost public  // kernels expand parallel_for; consumers need its symbols
 require dasllama/dasllama_par  // maybe_parallel_for
+require math  // min/max in the token-block bounds
 
 // arm64 SDOT backend for the Q8·Q8 matmuls. dasllama_math owns the public matmul wrappers + the
 // portable kernels (the default); this module supplies the NEON kernels and, on an arm64 JIT host,
@@ -18,6 +19,16 @@ require dasllama/dasllama_par  // maybe_parallel_for
 // The kernels mirror the portable ones in dasllama_math (same raw-pointer signatures = the
 // MatmulQ8Q8*Fn typedefs, same 1N threading) and differ only in the inner dot. They are free to
 // diverge in threading/tiling per-platform since dispatch is at the whole-matmul level.
+
+// Batched-GEMM token-block width: the laneq batch kernel tiles tokens into TB-sized blocks (outer),
+// looping weight groups inside, so a TB×n activation slice stays L2-resident and is reused across a
+// thread's groups instead of re-streaming the whole activation per group. 128 is the tuned default
+// (Llama-3.2-1B, M1 Max — pipeline best-of-5 @2048); exposed as a runtime knob for per-model tuning
+// (larger n wants a smaller TB to stay in L2). Clamped to >= 1: the kernel advances `tb += TB`, so a
+// non-positive block width would never make progress (infinite loop).
+var g_q8_token_block = 128l
+def public set_q8_token_block(tb : int64) { g_q8_token_block = max(tb, 1l) }
+def public get_q8_token_block() : int64 { return g_q8_token_block }
 
 //! ARM SDOT dot: 4 blocks/iter, 4 independent int4 accumulators (each block = 2 sdot4 of 16 int8),
 //! hsum + dual-scale flushed per block into 4 separate float accumulators. Bit-for-bit close to
@@ -178,7 +189,7 @@ def dot_q8q8_laneq4x4(var yp : float?; wg : int8 const?; sg : float const?; xqp 
         let xs1 = xsp + (t0 + 1l) * nb
         let xs2 = xsp + (t0 + 2l) * nb
         let xs3 = xsp + (t0 + 3l) * nb
-        for (bi in range64(nb)) {
+        for [unroll_count = 2] (bi in range64(nb)) {
             let wb = bi * 128l
             let xb = bi * 32l
             var a0 = int4(0, 0, 0, 0)
@@ -295,27 +306,36 @@ def private q8q8_kernel_neon_laneq(var yp : float?; wp : int8 const?; sp : float
 def private q8q8_batch_kernel_neon_laneq(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
     let ng = d / 4l
-    let nt4 = (ntok / 4l) * 4l   // tokens covered by full 4-token tiles
     var myp = yp
+    // Token-blocked: TB tokens outer, groups inner — the TB×n activation slice stays L2-resident and is
+    // reused across this thread's groups, instead of re-streaming the whole activation once per group
+    // (which goes DRAM-bound at large ntok, e.g. the FFN-down n=8192, ntok=2048 = 16MB restreamed d/4×).
+    let TB = g_q8_token_block
     maybe_parallel_for(n * d * ntok >= MATMUL_PAR_THRESHOLD, 0, int(ng), get_total_hw_jobs()) $(rb, re) {
         unsafe {
-            for (gi in range(rb, re)) {
-                let g = int64(gi)
-                let wgp = wp + g * 4l * n
-                let sgp = sp + g * 4l * nb
-                var tk = 0l
-                while (tk < nt4) {     // 4-row × 4-token tiles (the throughput path)
-                    dot_q8q8_laneq4x4(myp, wgp, sgp, xqp, xsp, n, d, g, tk)
-                    tk += 4l
+            var tb = 0l
+            while (tb < ntok) {
+                let tbe = min(tb + TB, ntok)
+                let tb4 = tb + ((tbe - tb) / 4l) * 4l
+                for (gi in range(rb, re)) {
+                    let g = int64(gi)
+                    let wgp = wp + g * 4l * n
+                    let sgp = sp + g * 4l * nb
+                    var tk = tb
+                    while (tk < tb4) {     // 4-row × 4-token tiles (the throughput path)
+                        dot_q8q8_laneq4x4(myp, wgp, sgp, xqp, xsp, n, d, g, tk)
+                        tk += 4l
+                    }
+                    while (tk < tbe) {    // token tail within this block: one token at a time
+                        let f = dot_q8q8_laneq4(wgp, sgp, xqp + tk * n, xsp + tk * nb, n)
+                        myp[tk * d + g * 4l + 0l] = f.x
+                        myp[tk * d + g * 4l + 1l] = f.y
+                        myp[tk * d + g * 4l + 2l] = f.z
+                        myp[tk * d + g * 4l + 3l] = f.w
+                        tk++
+                    }
                 }
-                while (tk < ntok) {    // token tail (ntok % 4): one token at a time
-                    let f = dot_q8q8_laneq4(wgp, sgp, xqp + tk * n, xsp + tk * nb, n)
-                    myp[tk * d + g * 4l + 0l] = f.x
-                    myp[tk * d + g * 4l + 1l] = f.y
-                    myp[tk * d + g * 4l + 2l] = f.z
-                    myp[tk * d + g * 4l + 3l] = f.w
-                    tk++
-                }
+                tb += TB
             }
         }
     }


### PR DESCRIPTION
Follow-up to #3322 (flash-attention mask-pass) — the last non-GEMM lever. With #3322 we were already ahead of llama.cpp on attention; this closes the projection-GEMM gap and puts CPU prefill over the top.

## The gap

A per-op profile of llama.cpp at pp2048 (ggml compute loop instrumented) showed it spends **71% in MUL_MAT** (projections) and **27% in FLASH_ATTN_EXT** (attention). Measuring the same sections on our side: our projection GEMM was **~18% slower** in-pipeline than llama's MUL_MAT, while our flash attention was **~31% faster** than FLASH_ATTN_EXT. So the whole remaining gap was the **projection GEMM** — and not the kernel instruction (this is an M1 Max: no i8mm, both sides use SDOT), but the loop structure.

## The fix (both bit-exact)

1. **Token-blocking (the win).** The laneq Q8 batch kernel looped `for weight-group: for all ntok tokens`, so the full activation (ntok*n) was re-streamed once per weight group (d/4 times) — DRAM-bound at large ntok (the FFN-down, n=8192, ntok=2048 = 16MB re-streamed ~512x). Restructured to `for token-block(TB): for weight-group: for tokens-in-block`, so a TB*n activation slice stays L2-resident and is reused across a thread's groups.
2. **`[unroll_count=2]`** on the laneq4x4 block loop — disassembly against llama.cpp showed LLVM had left ours at 1 block/iteration while llama's hand-written kernel is heavily unrolled.

TB is a runtime knob (`set_q8_token_block` / `get_q8_token_block`, default **128** = the M1 Max pipeline optimum; larger n wants a smaller TB to stay in L2).

## Numbers (M1 Max, 8 P-cores, Parsec off, interleaved measurement)

- Isolated FFN-down GEMM at ntok=2048: **675 -> 981 GMAC/s (+45%)**.
- End-to-end (Llama-3.2-1B Q8): projection GEMM **2586 -> 2156ms** — now beats llama.cpp's MUL_MAT (2190ms).
- Prefill vs llama.cpp, interleaved 5-round mean @512/1024/2048: **806 / 781 / 714 tok/s (ours)** vs **804 / 759 / 661 (llama)** = **100% / 103% / 108%**. Every round ahead at N>=1024 (no distribution overlap — our worst round beats their best); parity at 512.

## Correctness

Bit-exact: token-blocking only reorders independent output writes; unroll preserves accumulation order. Llama-3.2-1B **40/40 flash oracle** + dasLLAMA suite unchanged. Full preflight green (16 passed / 0 failed / 1 skip cpp-syntax).

🤖 Generated with [Claude Code](https://claude.com/claude-code)