### PR TITLE
physarum: fix field-click position under HiDPI (map through DisplaySize, not framebuffer)

### DIFF
--- a/examples/graphics/physarum_lab_opengl_imgui_example.das
+++ b/examples/graphics/physarum_lab_opengl_imgui_example.das
@@ -379,13 +379,15 @@ def apply_mouse_seed {
         return
     }
     let mp = GetMousePos()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    if (w <= 0 || h <= 0) {
+    // GetMousePos is in ImGui DisplaySize (logical) coordinates, so normalise by DisplaySize -- NOT the
+    // framebuffer size. Under HiDPI (SCALE_TO_MONITOR) the framebuffer is DisplaySize x devicePixelRatio,
+    // so dividing by it would land the seed at 1/DPR of the cursor (half the click on a 2x display).
+    let ds = GetIO().DisplaySize
+    if (ds.x <= 0.0f || ds.y <= 0.0f) {
         return
     }
-    let cx = wrap_i(int(mp.x / float(w) * float(TW)), TW)
-    let cy = wrap_i(int((1.0f - mp.y / float(h)) * float(TH)), TH)   // flip Y: GL origin is bottom-left
+    let cx = wrap_i(int(mp.x / ds.x * float(TW)), TW)
+    let cy = wrap_i(int((1.0f - mp.y / ds.y) * float(TH)), TH)   // flip Y: GL origin is bottom-left
     let off = read_off()
     let R = 9
     for (dy in range(-R, R + 1)) {


### PR DESCRIPTION
On a HiDPI display, clicking the physarum field painted the attractant at the wrong spot — a click at 300 landed the seed where 150 should be (a clean ÷2 on a 2× display). The ImGui UI was unaffected.

## Cause
`apply_mouse_seed` takes the ImGui cursor via `GetMousePos()` — which is in **ImGui `DisplaySize` (logical) coordinates** — but normalised it by `live_get_framebuffer_size`. Since the HiDPI canvas work (`GLFW_SCALE_TO_MONITOR`), the framebuffer/backing store is `DisplaySize × devicePixelRatio`, so dividing a logical cursor by the framebuffer yields `1/DPR` of the correct position.

```
- live_get_framebuffer_size(w, h)                 // = DisplaySize × DPR
- let cx = wrap_i(int(mp.x / float(w) * float(TW)), TW)
+ let ds = GetIO().DisplaySize                     // the space GetMousePos lives in
+ let cx = wrap_i(int(mp.x / ds.x * float(TW)), TW)
```

## Verification
Empirically confirmed the coordinate model by emulating DPR=2 in-browser (path-tracer card): the GLFW logical size is 900 while `live_get_framebuffer_size` reports 1800 — exactly the 2× that halved the click. The fix normalises by `DisplaySize` (logical), matching `GetMousePos`'s space, so the seed lands under the cursor at any DPR. At DPR=1 the two sizes are equal, so this is a no-op there (no regression — which is why it never surfaced on non-HiDPI setups or CI).

Physarum is the only card with this mismatch: `sequence` and `asteroids` already normalise the cursor and window in the same space; the other `live_get_framebuffer_size` calls are for `glViewport`/screenshot (correctly framebuffer-space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)