### PR TITLE
ci: guard scheduled workflows to the canonical repo (stop fork nightly spam)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -613,7 +613,10 @@ jobs:
     # gate on pre_job.should_skip — a nightly run must fire even when master is
     # unchanged (skip-duplicate-actions would otherwise skip it and we'd never
     # catch a toolchain/runner regression on an idle day).
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # scheduled cron runs the toolchains only on the canonical repo, so forks
+    # don't run (and fail) the nightly — that would email every fork owner.
+    # Manual workflow_dispatch still runs them anywhere.
+    if: (github.event_name == 'schedule' && github.repository == 'GaijinEntertainment/daScript') || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     defaults:
       run:
@@ -771,7 +774,10 @@ jobs:
     needs: pre_job
     # NIGHTLY ONLY (+ manual dispatch): off per-PR/push CI. Does NOT gate on
     # pre_job.should_skip — a nightly run must fire even when master is unchanged.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # scheduled cron runs the toolchains only on the canonical repo, so forks
+    # don't run (and fail) the nightly — that would email every fork owner.
+    # Manual workflow_dispatch still runs them anywhere.
+    if: (github.event_name == 'schedule' && github.repository == 'GaijinEntertainment/daScript') || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     steps:
     - name: "SCM Checkout"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,8 +34,10 @@ jobs:
   analyze:
     name: analyze (c-cpp)
     # fork PRs get a read-only GITHUB_TOKEN, so the SARIF upload would fail —
-    # skip them; the post-merge master push scans their code anyway
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # skip them; the post-merge master push scans their code anyway. The weekly
+    # schedule only runs on the canonical repo so forks don't run the cron
+    # (push/PR-triggered scans on a fork still work).
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -33,6 +33,10 @@ permissions:
 
 jobs:
   index_sweep:
+    # the nightly cron only sweeps on the canonical repo — forks don't run it
+    # (the sweep exit-1s on any package failure, which would email every fork
+    # owner). Manual workflow_dispatch still works anywhere (branch ABI sweeps).
+    if: github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
Forkers reported getting spammed with nightly CI failure emails. Cause: GitHub runs a repo's **scheduled (cron) workflows on forks too**, and emails the fork owner when a scheduled run fails — so every active fork gets nightly failure mail for crons they never opted into.

Three workflows had unguarded schedules (two added in the last few weeks, which is why it started "now"):

| Workflow | Cron | Why it spams forks |
|---|---|---|
| `build.yml` | `0 8 * * *` | the nightly Windows toolchain jobs (`build_windows_mingw` / `build_windows_clangcl`) fire on `schedule` in forks and fail without the parent's setup |
| `nightly_daspkg_index.yml` | `30 2 * * *` | sweeps the daspkg-index and `exit 1`s on any package failure → a **guaranteed** failure mail in every fork |
| `codeql.yml` | `20 3 * * 1` | weekly baseline refresh burns fork minutes |

## Fix
Guard the scheduled jobs so the cron only fires on the canonical repo:

```yaml
# build.yml toolchains
if: (github.event_name == 'schedule' && github.repository == 'GaijinEntertainment/daScript') || github.event_name == 'workflow_dispatch'
# nightly_daspkg_index.yml index_sweep
if: github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript'
# codeql.yml analyze (composed into the existing fork-PR guard)
if: (…existing fork-PR guard…) && (github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript')
```

In a fork's cron these jobs simply skip → the run is green → no failure email. **Push/PR CI and manual `workflow_dispatch` are unchanged**, on the canonical repo *and* forks (a forker can still dispatch a build or an ABI sweep on their own fork). All three files validated (YAML parses; expressions match the existing guard style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)