### PR TITLE
dasHV: build the libhv sub-build with /EHsc (fix clang-cl nightly lane)

### DIFF
--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -124,6 +124,17 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 	# under the libc++ daslang (surfaces as a misleading error[20605] missing prereq 'dashv').
 	SET(_HV_C_FLAGS "${CMAKE_C_FLAGS}")
 	SET(_HV_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+	# libhv's parse_json() (http/http_content.cpp) wraps nlohmann::json::parse in
+	# try/catch, so libhv MUST build with C++ exceptions. daslang strips /EHsc from
+	# CMAKE_CXX_FLAGS (CMakeCommon.txt) and re-adds /EHa only to the per-config flag
+	# vars, which are NOT forwarded here — so the sub-build inherits no /EH at all.
+	# Plain cl only warns (C4530); clang-cl (the ClangCL-toolset nightly lane) makes
+	# it a hard error ("cannot use 'try' with exceptions disabled"). Re-add /EHsc for
+	# the MSVC drivers (cl + clang-cl); non-MSVC (emscripten host, gcc/clang) is
+	# untouched — those keep exceptions on by default.
+	IF(MSVC)
+		SET(_HV_CXX_FLAGS "${_HV_CXX_FLAGS} /EHsc")
+	ENDIF()
 	IF(DAS_USE_SANITIZER STREQUAL "address" OR DAS_USE_SANITIZER STREQUAL "asan")
 		IF(MSVC)
 			SET(_HV_ASAN_FLAG "/fsanitize=address")


### PR DESCRIPTION
## Problem

The nightly `build_windows_clangcl` lane broke ([run 28513873052](https://github.com/GaijinEntertainment/daScript/actions/runs/28513873052/job/84520606167)) — but the failure is in the **libhv** dependency, not daslang:

```
libhv\http\http_content.cpp(243,5): error : cannot use 'try' with exceptions disabled
```

libhv's `parse_json()` wraps `nlohmann::json::parse` in `try`/`catch`, so libhv must compile with C++ exceptions. daslang strips `/EHsc` from `CMAKE_CXX_FLAGS` (`CMakeCommon.txt`) and re-adds `/EHa` only to the **per-config** flag vars — which `modules/dasHV/CMakeLists.txt` never forwards to the libhv `ExternalProject`. The sub-build therefore inherited **no `/EH` flag at all**:

- plain `cl` only warns (C4530) → the MSVC + mingw lanes stayed green;
- **clang-cl** makes it a hard error → only the ClangCL-toolset nightly lane went red.

Follow-up to #3301 (the flag-forwarding block this extends).

## Fix

Re-add `/EHsc` to the forwarded C++ flags for the MSVC drivers (`cl` + clang-cl). Non-MSVC hosts (emscripten cross-compile, gcc/clang) keep exceptions on by default and are untouched.

## Verification

Reproduced against the real toolchain (VS ClangCL component isn't installed locally, so this exercises the failing TU directly with standalone clang-cl — the error is a clang frontend behavior identical across clang-cl builds):

1. Downloaded libhv at the exact pinned commit `5da5fc22` — **SHA256 matches** the manifest (`b4f774936ccd…`), i.e. the identical source CI builds.
2. Configured with clang-cl and pulled CMake's own compile command for `http_content.cpp`, then recompiled it two ways:
   - **without `/EH`** (matching daslang's forwarded flags): reproduced the CI error verbatim — `http_content.cpp(243,5): error: cannot use 'try' with exceptions disabled`, exit 1;
   - **with `/EHsc`** (this patch): compiled clean, exit 0, `.obj` produced.

Full local preflight (`--full`) is green (12 passed, 0 failed, env-SKIPs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)