### PR TITLE
alloc_tracker: allow opting out of the lexer NAME-token leak dump

### DIFF
--- a/src/misc/alloc_tracker.cpp
+++ b/src/misc/alloc_tracker.cpp
@@ -514,7 +514,11 @@ static void dump_alloc_leaks_atexit() {
         return;
     }
     uint64_t leaked = dump_alloc_leaks(stderr);
+    // The lexer's per-NAME-token strings are a bounded compile-time
+    // retention, not a runtime leak; let embedders opt out of this dump.
+#if !defined(DAS_DONT_REPORT_LEXER_LEAKS)
     dump_lexer_string_leaks(stderr);
+#endif
     if (leaked > 0) {
         // Surface leaks as non-zero exit so CI / scripts can detect.
         // _Exit skips remaining atexit handlers (already dumped what we need).


### PR DESCRIPTION
At shutdown `dump_lexer_string_leaks()` reports the lexer's
per-NAME-token `std::string`s that are still live. These are a bounded
compile-time retention (one per identifier token), not a runtime leak,
and are not part of the general heap-leak count or its non-zero exit.

Embedders that gate CI on a clean shutdown get this sub-dump as noise
with no way to silence it separately. This guards the call behind
`DAS_DONT_REPORT_LEXER_LEAKS`; the real heap-leak report is untouched.
Undefined by default, so reporting is unchanged.
