### PR TITLE
fix: web examples — correct fullscreen mouse coords on HiDPI imgui cards

### DIFF
--- a/site/files/examples.js
+++ b/site/files/examples.js
@@ -199,11 +199,10 @@
     }
 
     // The "⤢ fullscreen" button fullscreens the parent viewport element, which
-    // (a) leaves keyboard focus on the parent so the game — whose input listener
+    // (a) leaves keyboard focus on the parent so a game — whose input listener
     // lives inside the iframe — goes deaf, and (b) doesn't resize the iframe's
-    // fixed-backing-store canvas (max-width/height can only shrink it, so in a
-    // big fullscreen box it stays tiny). Reaching into the same-origin game frame
-    // fixes both: refocus it, and let the canvas fill the box letterboxed.
+    // fixed-backing-store canvas. Reaching into the same-origin game frame fixes
+    // both: refocus it, and let a game canvas fill the box letterboxed.
     function onFsChange() {
         var frame = document.getElementById('ex-frame');
         var vp = document.getElementById('ex-viewport');
@@ -213,13 +212,31 @@
             var idoc = frame.contentDocument;
             var canvas = idoc && idoc.getElementById('canvas');
             if (canvas) {
-                // object-fit:contain scales the fixed backing store up to fill while
-                // preserving the game aspect (no squish); reverted to the letterbox
-                // default on exit.
-                canvas.style.width = entering ? '100%' : '';
-                canvas.style.height = entering ? '100%' : '';
-                canvas.style.objectFit = entering ? 'contain' : '';
-                if (entering && canvas.focus) canvas.focus();
+                if (entering) {
+                    // Fill ONLY a fixed-backing (game) canvas — object-fit:contain scales
+                    // it up preserving aspect (no squish). A canvas whose size emscripten
+                    // manages itself (GLFW_SCALE_TO_MONITOR imgui cards set an inline
+                    // width/height + a HiDPI backing store) must be left alone: overriding
+                    // it desyncs emscripten's device-pixel cursor mapping, so on a HiDPI
+                    // display clicks land in the wrong place. Those cards fill via their
+                    // own in-app F11 (which routes through emscripten's real fullscreen).
+                    if (!canvas.style.width && !canvas.style.height) {
+                        canvas.style.width = '100%';
+                        canvas.style.height = '100%';
+                        canvas.style.objectFit = 'contain';
+                    }
+                    if (canvas.focus) canvas.focus();
+                } else if (canvas.style.width === '100%' && canvas.style.objectFit === 'contain') {
+                    // Revert only the fill WE applied, matched by its exact inline signature
+                    // (100% + contain — a value we alone set; games start with no inline size,
+                    // imgui cards carry emscripten's px). Stateless, so a cross-session
+                    // fullscreenchange race (exitFullscreen is async; opening another card
+                    // re-attaches this listener before the pending event lands) can never
+                    // clear a different card's inline sizing.
+                    canvas.style.width = '';
+                    canvas.style.height = '';
+                    canvas.style.objectFit = '';
+                }
             }
         } catch (e) {}
         if (entering && frame.contentWindow) { try { frame.contentWindow.focus(); } catch (e) {} }


### PR DESCRIPTION
Follow-up regression fix for #3337.

## The bug
On a HiDPI display, clicking/dragging an **imgui card in fullscreen** (Physarum's field seed, imgui widgets) lands in the wrong place.

## Root cause
#3337's fullscreen fill CSS-scaled **every** card's canvas (`width/height:100%; object-fit:contain`). That is correct for a fixed-backing **game** canvas (pacman/arcanoid — verified, and they don't use the mouse anyway), but it breaks the `GLFW_SCALE_TO_MONITOR` imgui cards (Fourier / Path Tracer / Physarum):

- Those cards let emscripten manage the canvas size and a **HiDPI backing store** (backing = CSS×DPR; measured 556px style / 1112 backing at DPR 2). Overriding the canvas style with `width:100%` changes the *display* size but emscripten does **not** observe the CSS-only resize, so its device-pixel cursor mapping and ImGui `DisplaySize` desync from the new display size → clicks map to the wrong point. Only bites DPR > 1 (all the imgui cards are square, so there's no letterbox — it's purely the SCALE_TO_MONITOR/device-pixel desync, which is why it's HiDPI-only).

## Fix
Only CSS-scale a **fixed-backing (game) canvas**, detected by the absence of an emscripten-forced inline `width`/`height`. A managed (imgui) canvas is left exactly as emscripten sizes it — its pre-#3337 fullscreen state, where the mouse was correct. Also, the exit path now only reverts the canvas we actually scaled (the old code unconditionally cleared the style on exit, which would wipe emscripten's managed inline size on imgui cards).

imgui cards still get a crisp, correct-mouse fullscreen via their **in-app F11** (which routes through emscripten's real fullscreen — that path resizes backing + `DisplaySize` + cursor together, so it stays consistent). Games keep filling via the ⤢ button.

## Verified (Playwright)
- **Game canvas**: still fills the fullscreen box letterboxed (660×558 → 1066×900), corners map to (0,0)/(900,760). ✅
- **imgui detection**: a loaded imgui card carries an inline canvas `width` (556px at DPR 1; backing 1112 at DPR 2), so the guard skips it → emscripten's sizing left intact = the known-good pre-#3337 mapping. ✅
- Physarum's exact HiDPI field mapping is best confirmed **on-device** (I can't fully reproduce the physarum sim's seed math in browser automation).

## Tradeoff / possible follow-up
imgui cards' **⤢ button** no longer force-fills their canvas (they fill via F11 instead). If we want ⤢ to *also* crisp-fill the imgui cards, the follow-up is to route ⤢ through the card's own fullscreen path (or fullscreen the iframe so emscripten resizes it) — I'd validate that on Physarum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)