### PR TITLE
dasSpirv: ray-tracing pipeline stages (raygen / miss / closest-hit)

### DIFF
--- a/modules/dasSpirv/spirv/spirv_builder.das
+++ b/modules/dasSpirv/spirv/spirv_builder.das
@@ -224,6 +224,18 @@ def public type_sampler(var m : SpirvModule) : uint {
     return id
 }
 
+// OpTypeAccelerationStructureKHR — the opaque top-level acceleration structure descriptor type
+// (SPV_KHR_ray_tracing). Deduped (no operands).
+def public type_acceleration_structure(var m : SpirvModule) : uint {
+    let key = "accel"
+    let ex = m.type_pool?[key] ?? 0u
+    return ex if (ex != 0u)
+    let id = alloc_id(m)
+    emit(m, SEC_TYPES, SpvOp.TypeAccelerationStructureKHR, id)
+    m.type_pool |> insert(key, id)
+    return id
+}
+
 // OpTypeSampledImage wrapping an image type — the type of a combined image+sampler descriptor.
 def public type_sampled_image(var m : SpirvModule; image_type : uint) : uint {
     let key = "simg{image_type}"

--- a/modules/dasSpirv/spirv/spirv_builtins.das
+++ b/modules/dasSpirv/spirv/spirv_builtins.das
@@ -175,3 +175,33 @@ struct gl_MeshPerPrimitiveEXT {
     gl_PrimitiveID : int
 }
 var gl_MeshPrimitivesEXT : array<gl_MeshPerPrimitiveEXT>
+
+// ===== ray tracing (VK_KHR_ray_tracing_pipeline) =====
+// The RT-pipeline minimum surface: the launch grid + world-ray + hit-state builtins, the opaque
+// top-level acceleration structure descriptor, and traceRayEXT. Stage legality (which builtin is
+// visible in raygen / miss / closest-hit) is enforced at classification in spirv_emit; a payload is
+// declared as a `@ray_payload` (traced FROM this stage) or `@incoming_ray_payload` (what THIS stage
+// was invoked with) global, a triangle hit attribute as `@hit_attribute barycentrics : float2`.
+// AnyHit / Intersection / Callable stages (and their builtins) land with their first consumer.
+var gl_LaunchIDEXT             : uint3      // BuiltIn LaunchIdKHR (Input) — this invocation's cell in the vkCmdTraceRaysKHR launch grid
+var gl_LaunchSizeEXT           : uint3      // BuiltIn LaunchSizeKHR (Input) — the launch grid dimensions
+var gl_WorldRayOriginEXT       : float3     // BuiltIn WorldRayOriginKHR (Input, miss / closest-hit) — the current ray's world-space origin
+var gl_WorldRayDirectionEXT    : float3     // BuiltIn WorldRayDirectionKHR (Input, miss / closest-hit) — the current ray's world-space direction
+var gl_HitTEXT                 : float      // BuiltIn RayTmaxKHR (Input, closest-hit) — the hit distance t along the ray
+var gl_InstanceCustomIndexEXT  : int        // BuiltIn InstanceCustomIndexKHR (Input, closest-hit) — the TLAS instance's 24-bit custom index
+
+// The opaque top-level acceleration structure descriptor (VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR
+// on the host side). Declared with the usual `@set` / `@binding` slots:
+//     var @set = 0 @binding = 0 tlas : accelerationStructureEXT
+struct accelerationStructureEXT {}
+
+// traceRayEXT: OpTraceRayKHR. Traces one ray against `accel`; the closest-hit / miss shader selected
+// through the SBT (sbt_offset / sbt_stride / miss_index) writes its result into `payload`, which MUST
+// be a @ray_payload / @incoming_ray_payload global (the SPIR-V operand names the payload variable).
+// ray_flags: SPIR-V RayFlags bits (0x01 opaque, 0x04 terminate-on-first-hit, 0x08 skip-closest-hit, ...).
+// The stub body never runs -- only the call AST is read.
+[unused_argument(accel, ray_flags, cull_mask, sbt_offset, sbt_stride, miss_index, origin, tmin, direction, tmax, payload), sideeffects]
+def public traceRayEXT(accel : accelerationStructureEXT; ray_flags : uint; cull_mask : uint;
+                       sbt_offset : uint; sbt_stride : uint; miss_index : uint;
+                       origin : float3; tmin : float; direction : float3; tmax : float;
+                       var payload : auto(TT)&) : void {}

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -24,12 +24,18 @@ require daslib/shader_block_layout public
 // Mesh + Task (VK_EXT_mesh_shader) pull in the MeshShadingEXT capability + SPV_EXT_mesh_shader
 // extension; both need LocalSize and Mesh additionally needs OutputVertices + OutputPrimitivesEXT
 // + an output-topology mode (triangles / lines / points), all configurable via the [mesh_shader] args.
+// RayGen + Miss + ClosestHit (VK_KHR_ray_tracing_pipeline) pull in the RayTracingKHR capability +
+// SPV_KHR_ray_tracing extension (SPIR-V >= 1.4); none needs an execution mode. (AnyHit / Intersection /
+// Callable follow the same rail and land with their first consumer.)
 enum public ShaderStage {
     Compute
     Vertex
     Fragment
     Mesh
     Task
+    RayGen
+    Miss
+    ClosestHit
 }
 
 // Mesh-shader output configuration, parsed from the [mesh_shader] annotation args
@@ -67,6 +73,8 @@ struct GlobalInfo {
     elem_type  : uint               // SSBO runtime-array element type-id (vec/struct elements can't go through emit_type) OR descriptor-array element type-id (sampled-image / image / sampler)
     is_constant : bool              // a module-scope `let X = <const>` folded to an OpConstant; references resolve to const_id directly (no OpVariable / OpLoad)
     const_id   : uint               // the OpConstant result-id (when is_constant)
+    is_accel   : bool               // an accelerationStructureEXT descriptor (UniformConstant OpTypeAccelerationStructureKHR); consumed by traceRayEXT
+    is_ray_payload : bool           // a @ray_payload / @incoming_ray_payload variable; traceRayEXT's payload operand names its var_id
 }
 
 // A memory-backed local: an OpVariable in Function storage. Mutable locals (`var x`) and loop
@@ -93,6 +101,7 @@ struct EmitCtx {
     descriptor_indexing_cap : bool              // OpCapability ShaderNonUniform + OpExtension "SPV_EXT_descriptor_indexing" already emitted (nonuniformEXT, descriptor arrays)
     sampled_image_nu_cap : bool                 // OpCapability SampledImageArrayNonUniformIndexing already emitted (NonUniform-indexed sampler descriptor array)
     mesh_shading_cap : bool                     // OpCapability MeshShadingEXT + OpExtension "SPV_EXT_mesh_shader" already emitted (mesh / task stages)
+    ray_tracing_cap : bool                      // OpCapability RayTracingKHR + OpExtension "SPV_KHR_ray_tracing" already emitted (raygen / miss / closest-hit stages)
     mesh_max_vertices : int                     // mesh-output array sizing (from MeshOutputConfig): gl_MeshVerticesEXT length
     mesh_max_primitives : int                   // mesh-output array sizing: gl_PrimitiveTriangleIndicesEXT length
     mesh_topology : MeshOutputTopology          // declared output topology; the index-array builtin must match it (triangles -> gl_PrimitiveTriangleIndicesEXT)
@@ -182,9 +191,38 @@ def private builtin_info(name : string) : tuple<ok : bool; bi : SpvBuiltIn; stor
     if (name == "gl_PointCoord") return (ok = true, bi = SpvBuiltIn.PointCoord, storage = SpvStorageClass.Input, req = ShaderStage.Fragment)
     // gl_PrimitiveID: fragment Input (the per-primitive id a mesh shader wrote via gl_MeshPrimitivesEXT).
     // In a mesh pipeline it is NOT fixed-function-generated, so reading it pulls in the MeshShadingEXT
-    // capability on the fragment module (handled at classification).
+    // capability on the fragment module (handled at classification). ALSO valid in a closest-hit shader
+    // (the hit triangle's index within its geometry) -- rt_builtin_stage_ok widens the check there.
     if (name == "gl_PrimitiveID") return (ok = true, bi = SpvBuiltIn.PrimitiveId, storage = SpvStorageClass.Input, req = ShaderStage.Fragment)
+    // ray tracing (VK_KHR_ray_tracing_pipeline). `req` lists the PRIMARY stage; several are legal in
+    // more than one RT stage -- rt_builtin_stage_ok encodes the full per-name stage sets.
+    if (name == "gl_LaunchIDEXT") return (ok = true, bi = SpvBuiltIn.LaunchIdKHR, storage = SpvStorageClass.Input, req = ShaderStage.RayGen)
+    if (name == "gl_LaunchSizeEXT") return (ok = true, bi = SpvBuiltIn.LaunchSizeKHR, storage = SpvStorageClass.Input, req = ShaderStage.RayGen)
+    if (name == "gl_WorldRayOriginEXT") return (ok = true, bi = SpvBuiltIn.WorldRayOriginKHR, storage = SpvStorageClass.Input, req = ShaderStage.ClosestHit)
+    if (name == "gl_WorldRayDirectionEXT") return (ok = true, bi = SpvBuiltIn.WorldRayDirectionKHR, storage = SpvStorageClass.Input, req = ShaderStage.ClosestHit)
+    if (name == "gl_HitTEXT") return (ok = true, bi = SpvBuiltIn.RayTmaxKHR, storage = SpvStorageClass.Input, req = ShaderStage.ClosestHit)
+    if (name == "gl_InstanceCustomIndexEXT") return (ok = true, bi = SpvBuiltIn.InstanceCustomIndexKHR, storage = SpvStorageClass.Input, req = ShaderStage.ClosestHit)
     return (ok = false, bi = SpvBuiltIn.Position, storage = SpvStorageClass.Input, req = ShaderStage.Compute)
+}
+
+// The multi-stage validity sets for the ray-tracing builtins (and gl_PrimitiveID's closest-hit reuse).
+// Returns ok=true when `name` is one of the multi-stage names AND `stage` is in its set; a name not
+// listed here falls back to classify_global's exact `req == stage` check.
+def private rt_builtin_stage_ok(name : string; stage : ShaderStage) : bool {
+    // the launch grid: every ray-pipeline stage sees it
+    if (name == "gl_LaunchIDEXT" || name == "gl_LaunchSizeEXT") {
+        return is_rt_stage(stage)
+    }
+    // the world-space ray: miss + closest-hit (raygen has no current ray)
+    if (name == "gl_WorldRayOriginEXT" || name == "gl_WorldRayDirectionEXT") {
+        return stage == ShaderStage.Miss || stage == ShaderStage.ClosestHit
+    }
+    // hit-only state; gl_PrimitiveID doubles as the closest-hit triangle index (its fragment role
+    // stays on the req == stage path)
+    if (name == "gl_HitTEXT" || name == "gl_InstanceCustomIndexEXT" || name == "gl_PrimitiveID") {
+        return stage == ShaderStage.ClosestHit
+    }
+    return false
 }
 
 def private stage_name(stage : ShaderStage) : string {
@@ -192,7 +230,14 @@ def private stage_name(stage : ShaderStage) : string {
     if (stage == ShaderStage.Fragment) return "fragment"
     if (stage == ShaderStage.Mesh) return "mesh"
     if (stage == ShaderStage.Task) return "task"
+    if (stage == ShaderStage.RayGen) return "raygen"
+    if (stage == ShaderStage.Miss) return "miss"
+    if (stage == ShaderStage.ClosestHit) return "closest-hit"
     return "compute"
+}
+
+def private is_rt_stage(stage : ShaderStage) : bool {
+    return stage == ShaderStage.RayGen || stage == ShaderStage.Miss || stage == ShaderStage.ClosestHit
 }
 
 // Build a laid-out interface struct from a daslang struct's fields. Supported member shapes:
@@ -302,6 +347,9 @@ def private stage_flag(stage : ShaderStage) : SpirvStageFlags {
     if (stage == ShaderStage.Fragment) return SpirvStageFlags.fragment
     if (stage == ShaderStage.Mesh) return SpirvStageFlags.mesh
     if (stage == ShaderStage.Task) return SpirvStageFlags.task
+    if (stage == ShaderStage.RayGen) return SpirvStageFlags.raygen
+    if (stage == ShaderStage.Miss) return SpirvStageFlags.miss
+    if (stage == ShaderStage.ClosestHit) return SpirvStageFlags.closest_hit
     return SpirvStageFlags.compute
 }
 
@@ -487,11 +535,13 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         // gl_NumWorkGroups / gl_LocalInvocationIndex, all req=Compute in builtin_info) are equally valid
         // in MESH and TASK shaders -- those stages are workgroup-dispatched (LocalSize) too, and a real
         // mesh/task shader needs them to index its slice of the work (e.g. the payload survivor-list).
+        // The ray-tracing builtins are legal in per-name SETS of RT stages (rt_builtin_stage_ok).
         let workgroup_builtin = bi.req == ShaderStage.Compute
         let stage_ok = (bi.req == stage ||
-            (workgroup_builtin && (stage == ShaderStage.Mesh || stage == ShaderStage.Task)))
+            (workgroup_builtin && (stage == ShaderStage.Mesh || stage == ShaderStage.Task)) ||
+            rt_builtin_stage_ok(vname, stage))
         if (!stage_ok) {
-            errors |> push("builtin '{vname}' is only available in the {stage_name(bi.req)} stage, not {stage_name(stage)}")
+            errors |> push("builtin '{vname}' is not available in the {stage_name(stage)} stage")
             return
         }
         let vt = emit_type(m, v._type)
@@ -514,7 +564,10 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         // gl_PrimitiveID in a fragment of a mesh pipeline: the id is not fixed-function-generated, so
         // reading it pulls in MeshShadingEXT + SPV_EXT_mesh_shader (→ SPIR-V 1.4), same as the mesh stage.
         // It is an integer fragment Input, so it MUST be Flat (no interpolation for ints; VUID-…-Flat-04744).
-        if (bi.bi == SpvBuiltIn.PrimitiveId) {
+        // In a CLOSEST-HIT shader the same builtin is the hit triangle's index: no interpolation happens
+        // there (Flat is fragment-interface-only) and the capability is RayTracingKHR, already enabled
+        // by the stage itself -- so the fragment-side extras are fragment-gated.
+        if (bi.bi == SpvBuiltIn.PrimitiveId && stage == ShaderStage.Fragment) {
             ensure_per_primitive(m, ctx)
             emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Flat))
         }
@@ -757,6 +810,33 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
     // a sampler is a standalone OpTypeSampler -- each its own UniformConstant descriptor. sampleTexture()
     // combines them at the call site (OpSampledImage).
     let stn = v._type != null && v._type.baseType == Type.tStructure && v._type.structType != null ? "{v._type.structType.name}" : ""
+    // top-level acceleration structure (VK_KHR_ray_tracing_pipeline): the opaque accelerationStructureEXT
+    // marker -> a UniformConstant OpTypeAccelerationStructureKHR descriptor, traced via traceRayEXT.
+    // RT-pipeline stages only (ray QUERY from compute/fragment is a different extension and a separate
+    // slice -- fail closed here rather than emit a blob spirv-val rejects).
+    if (stn == "accelerationStructureEXT") {
+        if (!is_rt_stage(stage)) {
+            errors |> push("accelerationStructureEXT '{vname}' is only valid in a raygen / miss / closest-hit shader (ray queries from other stages are not supported yet)")
+            return
+        }
+        let set = v.annotation |> find_arg("set") ?as tInt ?? 0
+        let binding = v.annotation |> find_arg("binding") ?as tInt ?? 0
+        if (set < 0 || binding < 0) {
+            errors |> push("accelerationStructureEXT '{vname}' set/binding must be non-negative (got set={set}, binding={binding})")
+            return
+        }
+        let vt = type_acceleration_structure(m)
+        let pt = type_pointer(m, SpvStorageClass.UniformConstant, vt)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(SpvStorageClass.UniformConstant))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.DescriptorSet), uint(set))
+        emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Binding), uint(binding))
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = SpvStorageClass.UniformConstant,
+            value_type = vt, is_accel = true))
+        reflection.bindings |> push(SpirvDescriptorBinding(set = set, binding = binding,
+            kind = SpirvDescriptorKind.acceleration_structure, count = 1, stages = stage_flag(stage)))
+        return
+    }
     if (stn == "texture2D" || stn == "sampler") {
         let set = v.annotation |> find_arg("set") ?as tInt ?? 0
         let binding = v.annotation |> find_arg("binding") ?as tInt ?? 0
@@ -897,6 +977,69 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         ctx.task_payload_id = vid
         return
     }
+    // ray payloads + hit attributes (VK_KHR_ray_tracing_pipeline) -- three logical storage classes,
+    // all plain-laid-out like @task_payload:
+    //   @ray_payload           RayPayloadKHR          the OUTGOING payload a stage passes to traceRayEXT
+    //                                                 (raygen; also miss / closest-hit for recursive rays)
+    //   @incoming_ray_payload  IncomingRayPayloadKHR  the payload THIS stage was invoked with
+    //                                                 (miss / closest-hit; they write the result here)
+    //   @hit_attribute         HitAttributeKHR        the triangle barycentrics (float2 on the fixed-function
+    //                                                 triangle path), closest-hit read-only
+    // Payloads carry a Location decoration (@location, default 0) like glslang's rayPayloadEXT lowering;
+    // hit attributes carry none. Struct payloads lay out plainly (build_plain_struct, member access via
+    // the is_block path); scalar / vector / matrix payloads emit directly and load/store whole.
+    let is_ray_payload = v.annotation |> find_arg("ray_payload") is tBool
+    let is_incoming_payload = v.annotation |> find_arg("incoming_ray_payload") is tBool
+    let is_hit_attribute = v.annotation |> find_arg("hit_attribute") is tBool
+    if (is_ray_payload || is_incoming_payload || is_hit_attribute) {
+        let ann_name = is_ray_payload ? "@ray_payload" : (is_incoming_payload ? "@incoming_ray_payload" : "@hit_attribute")
+        if (is_ray_payload && !is_rt_stage(stage)) {
+            errors |> push("{ann_name} '{vname}' is only valid in a raygen / miss / closest-hit shader")
+            return
+        }
+        if (is_incoming_payload && stage != ShaderStage.Miss && stage != ShaderStage.ClosestHit) {
+            errors |> push("{ann_name} '{vname}' is only valid in a miss or closest-hit shader")
+            return
+        }
+        if (is_hit_attribute && stage != ShaderStage.ClosestHit) {
+            errors |> push("{ann_name} '{vname}' is only valid in a closest-hit shader")
+            return
+        }
+        var storage = SpvStorageClass.RayPayloadKHR
+        if (is_incoming_payload) {
+            storage = SpvStorageClass.IncomingRayPayloadKHR
+        } elif (is_hit_attribute) {
+            storage = SpvStorageClass.HitAttributeKHR
+        }
+        var vt : uint
+        var as_block = false
+        if (v._type.baseType == Type.tStructure && v._type.structType != null) {
+            vt = build_plain_struct(m, vname, v._type.structType, errors)
+            if (vt == 0u) return
+            as_block = true
+        } elif (is_emittable_value_type(v._type)) {
+            vt = emit_type(m, v._type)
+        } else {
+            errors |> push("{ann_name} '{vname}' must be a struct or a scalar / vector / matrix / fixed array of those")
+            return
+        }
+        let pt = type_pointer(m, storage, vt)
+        let vid = alloc_id(m)
+        emit(m, SEC_TYPES, SpvOp.Variable, pt, vid, uint(storage))
+        if (!is_hit_attribute) {
+            let loc = v.annotation |> find_arg("location") ?as tInt ?? 0
+            if (loc < 0) {
+                errors |> push("{ann_name} '{vname}' @location must be non-negative (got {loc})")
+                return
+            }
+            emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Location), uint(loc))
+        }
+        ctx.globals |> insert(intptr(v), GlobalInfo(var_id = vid, storage = storage, value_type = vt,
+            is_block = as_block, is_ray_payload = !is_hit_attribute))
+        // not pushed into interface_ids here: RT modules are SPIR-V 1.4, whose every-referenced-global
+        // interface pass appends these (they are not Input/Output, so the <= 1.3 rule never applies)
+        return
+    }
     // module-scope constant: an immutable `let X = <const-expr>` referenced by the shader body. Fold the
     // initializer to an OpConstant and resolve references straight to it (no OpVariable / OpLoad), so a
     // shader can hoist view rectangles, iteration counts, etc. to module scope and share them with the
@@ -911,7 +1054,7 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
             return
         }
     }
-    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, a constant `let`, or an opaque type e.g. sampler2D / image2D / subpassInput)")
+    errors |> push("unsupported global '{vname}' (expected gl_* builtin, @ssbo, @uniform, @push_constant, @workgroup, @ray_payload / @incoming_ray_payload / @hit_attribute, a constant `let`, or an opaque type e.g. sampler2D / image2D / subpassInput / accelerationStructureEXT)")
 }
 
 // ===== member index of a struct field by name =====
@@ -1163,6 +1306,19 @@ def private ensure_mesh_shading(var m : SpirvModule; var ctx : EmitCtx) {
 def private ensure_per_primitive(var m : SpirvModule; var ctx : EmitCtx) {
     ensure_mesh_shading(m, ctx)
     m.version = SPV_VERSION_1_4
+}
+
+// Ray-tracing stages (VK_KHR_ray_tracing_pipeline): OpCapability RayTracingKHR + OpExtension
+// "SPV_KHR_ray_tracing". Emit-once + ctx-flag dedupe; the cap gates the RayGenerationKHR / MissKHR /
+// ClosestHitKHR execution models, the RT storage classes, OpTypeAccelerationStructureKHR, and
+// OpTraceRayKHR. SPV_KHR_ray_tracing requires SPIR-V >= 1.4 (set by the caller alongside this).
+def private ensure_ray_tracing(var m : SpirvModule; var ctx : EmitCtx) {
+    if (ctx.ray_tracing_cap) return
+    emit(m, SEC_CAPS, SpvOp.Capability, uint(SpvCapability.RayTracingKHR))
+    var nm <- string_words("SPV_KHR_ray_tracing")
+    emit_n(m, SEC_EXT, SpvOp.Extension, nm)
+    delete nm
+    ctx.ray_tracing_cap = true
 }
 
 // daslang math builtin -> GLSL.std.450 ext-inst opcode. abs/min/max/clamp/sign pick the F/S/U
@@ -2381,6 +2537,63 @@ class SpirvEmit : AstVisitor {
             ctx.terminated = true
             return expr
         }
+        // traceRayEXT(accel, ray_flags, cull_mask, sbt_offset, sbt_stride, miss_index, origin, tmin,
+        // direction, tmax, payload): OpTraceRayKHR. The accel operand is an OpLoad of the
+        // accelerationStructureEXT descriptor; the payload operand names the @ray_payload /
+        // @incoming_ray_payload VARIABLE itself (a pointer, per SPV_KHR_ray_tracing), so the last
+        // argument must be a payload global, not an arbitrary expression. RT-pipeline stages only.
+        // The stub is GENERIC over the payload type, so the resolved call carries the mangled
+        // instance name — match on the ORIGIN generic's name instead of the ExprCall name.
+        var origin_name = name
+        if (expr.func != null) {
+            var co = expr.func
+            while (co.fromGeneric != null) {
+                co = co.fromGeneric
+            }
+            origin_name = "{co.name}"
+        }
+        if (origin_name == "traceRayEXT") {
+            if (!is_rt_stage(ctx.stage)) {
+                errs |> push("traceRayEXT is only valid in a raygen / miss / closest-hit shader")
+                return expr
+            }
+            if (length(expr.arguments) != 11) {
+                errs |> push("traceRayEXT expects (accel, ray_flags, cull_mask, sbt_offset, sbt_stride, miss_index, origin, tmin, direction, tmax, payload)")
+                return expr
+            }
+            let accel_g = global_var_of(expr.arguments[0])
+            let agi = accel_g != null ? (ctx.globals?[intptr(accel_g)] ?? GlobalInfo()) : GlobalInfo()
+            if (accel_g == null || !agi.is_accel) {
+                errs |> push("traceRayEXT: the first argument must be an accelerationStructureEXT global")
+                return expr
+            }
+            let payload_g = global_var_of(expr.arguments[10])
+            let pgi = payload_g != null ? (ctx.globals?[intptr(payload_g)] ?? GlobalInfo()) : GlobalInfo()
+            if (payload_g == null || !pgi.is_ray_payload) {
+                errs |> push("traceRayEXT: the payload argument must be a @ray_payload / @incoming_ray_payload global")
+                return expr
+            }
+            var vals : array<uint>
+            vals |> reserve(9)
+            for (ai in range(1, 10)) {
+                let vv = value_of(expr.arguments[ai])
+                if (vv == 0u) {
+                    errs |> push("traceRayEXT: could not evaluate operand {ai}")
+                    delete vals
+                    return expr
+                }
+                vals |> push(vv)
+            }
+            let accel_id = alloc_id(bm)
+            emit(bm, SEC_FUNCS, SpvOp.Load, agi.value_type, accel_id, agi.var_id)
+            var ops <- [accel_id]
+            ops |> push_from(vals)
+            ops |> push(pgi.var_id)
+            emit_n(bm, SEC_FUNCS, SpvOp.TraceRayKHR, ops)
+            delete ops
+            delete vals
+            return expr
+        }
         // barrier(): control + shared-memory barrier (OpControlBarrier at Workgroup execution+memory
         // scope, WorkgroupMemory|AcquireRelease semantics). memoryBarrierShared(): the memory-only
         // variant (OpMemoryBarrier, same scope/semantics). Both compute-only; not block terminators.
@@ -3344,8 +3557,14 @@ def private is_user_shader_func(f : Function const?; entry : FunctionPtr) : bool
     // module "" is the user's own root module (a shader written without an explicit `module` line) —
     // a valid place for helper functions. Host/extern builtins are already excluded by flags.builtIn
     // above; the named modules below have their calls intercepted by name (math -> GLSL.std.450,
-    // spirv_builtins -> texture/imageStore/...), so they must never be emitted as OpFunctions.
-    let mn = "{f._module.name}"
+    // spirv_builtins -> texture/imageStore/traceRayEXT/...), so they must never be emitted as
+    // OpFunctions. A GENERIC intrinsic stub (traceRayEXT) instantiates into the caller's module, so
+    // classify by the ORIGIN generic's module, not the instance's.
+    var forigin = f
+    while (forigin.fromGeneric != null) {
+        forigin = forigin.fromGeneric
+    }
+    let mn = "{forigin._module.name}"
     return !(mn == "builtin" || mn == "math" || mn == "math_bits" || mn == "spirv_builtins" || mn == "shader_lingua_franca")
 }
 
@@ -3547,6 +3766,9 @@ def private execution_model(stage : ShaderStage) : SpvExecutionModel {
     if (stage == ShaderStage.Fragment) return SpvExecutionModel.Fragment
     if (stage == ShaderStage.Mesh) return SpvExecutionModel.MeshEXT
     if (stage == ShaderStage.Task) return SpvExecutionModel.TaskEXT
+    if (stage == ShaderStage.RayGen) return SpvExecutionModel.RayGenerationKHR
+    if (stage == ShaderStage.Miss) return SpvExecutionModel.MissKHR
+    if (stage == ShaderStage.ClosestHit) return SpvExecutionModel.ClosestHitKHR
     return SpvExecutionModel.GLCompute
 }
 
@@ -3577,6 +3799,12 @@ def generate_spirv(fn : FunctionPtr; var errors : array<string>; stage : ShaderS
     if (stage == ShaderStage.Mesh || stage == ShaderStage.Task) {
         m.version = SPV_VERSION_1_4
         ensure_mesh_shading(m, ctx)
+    }
+    // Ray-tracing stages pull in the RayTracingKHR capability + SPV_KHR_ray_tracing, which likewise
+    // requires SPIR-V >= 1.4 (the every-referenced-global interface rule below then applies).
+    if (is_rt_stage(stage)) {
+        m.version = SPV_VERSION_1_4
+        ensure_ray_tracing(m, ctx)
     }
     // Mesh per-vertex / per-primitive Output arrays (gl_MeshVerticesEXT, gl_PrimitiveTriangleIndicesEXT)
     // are sized from the [mesh_shader] output config; classify_global reads these off ctx when it

--- a/modules/dasSpirv/spirv/spirv_reflect.das
+++ b/modules/dasSpirv/spirv/spirv_reflect.das
@@ -21,6 +21,7 @@ enum SpirvDescriptorKind {
     sampler                 //!< a standalone `sampler` (separate-sampler model)
     comparison_sampler      //!< a `sampler2DShadow` (depth-compare combined sampler, sampled via textureCompare)
     input_attachment        //!< a `subpassInput` (Vulkan subpass-input attachment, sampled via subpassLoad)
+    acceleration_structure  //!< an `accelerationStructureEXT` (VK_KHR_ray_tracing top-level AS, traced via traceRayEXT)
 }
 
 //! Stages a binding / push range is used in (the host maps to e.g. VkShaderStageFlags). A single
@@ -31,6 +32,9 @@ bitfield SpirvStageFlags {
     compute     //!< used in the compute stage
     mesh        //!< used in the mesh stage (VK_EXT_mesh_shader)
     task        //!< used in the task / amplification stage (VK_EXT_mesh_shader)
+    raygen      //!< used in the ray-generation stage (VK_KHR_ray_tracing_pipeline)
+    miss        //!< used in the miss stage (VK_KHR_ray_tracing_pipeline)
+    closest_hit //!< used in the closest-hit stage (VK_KHR_ray_tracing_pipeline)
 }
 
 //! One descriptor binding (a UBO / SSBO / combined image sampler) at a (set, binding) slot.
@@ -58,12 +62,13 @@ struct SpirvReflection {
     push_constants : array<SpirvPushConstantRange>  //!< push-constant ranges
 }
 
-// 'RFL5' — wire-format magic + version. Bump on any layout OR descriptor-kind change to encode/
+// 'RFL6' — wire-format magic + version. Bump on any layout OR descriptor-kind change to encode/
 // decode_reflection, so an older consumer rejects a newer stream loudly instead of mis-mapping an
 // unknown SpirvDescriptorKind (kind_from_int falls back to uniform_buffer). RFL2 = Phase 7
 // (storage_image / sampled_image / sampler); RFL3 = Phase 10.4 (comparison_sampler);
-// RFL4 = input_attachment (subpassInput); RFL5 = mesh / task stage bits (this commit).
-let REFLECTION_MAGIC = 0x52464C35u
+// RFL4 = input_attachment (subpassInput); RFL5 = mesh / task stage bits;
+// RFL6 = ray-tracing stage bits + acceleration_structure kind (this commit).
+let REFLECTION_MAGIC = 0x52464C36u
 
 def finalize(var r : SpirvReflection) {
     delete r.bindings
@@ -102,6 +107,7 @@ def private kind_from_int(k : int) : SpirvDescriptorKind {
     if (k == int(SpirvDescriptorKind.sampler)) return SpirvDescriptorKind.sampler
     if (k == int(SpirvDescriptorKind.comparison_sampler)) return SpirvDescriptorKind.comparison_sampler
     if (k == int(SpirvDescriptorKind.input_attachment)) return SpirvDescriptorKind.input_attachment
+    if (k == int(SpirvDescriptorKind.acceleration_structure)) return SpirvDescriptorKind.acceleration_structure
     return SpirvDescriptorKind.uniform_buffer
 }
 

--- a/modules/dasSpirv/spirv/spirv_shader.das
+++ b/modules/dasSpirv/spirv/spirv_shader.das
@@ -195,3 +195,23 @@ class SpirvMeshShader : SpirvShader {
 class SpirvTaskShader : SpirvShader {
     def override shader_stage() : ShaderStage => ShaderStage.Task
 }
+
+// [raygen_shader] / [miss_shader] / [closest_hit_shader] (VK_KHR_ray_tracing_pipeline). Execution
+// model + RayTracingKHR capability + SPV_KHR_ray_tracing extension (SPIR-V 1.4); no execution modes.
+// Payloads / hit attributes are @ray_payload / @incoming_ray_payload / @hit_attribute globals; the
+// acceleration structure is an accelerationStructureEXT descriptor; rays are traced via traceRayEXT.
+// AnyHit / Intersection / Callable stages land with their first consumer.
+[function_macro(name="raygen_shader")]
+class SpirvRayGenShader : SpirvShader {
+    def override shader_stage() : ShaderStage => ShaderStage.RayGen
+}
+
+[function_macro(name="miss_shader")]
+class SpirvMissShader : SpirvShader {
+    def override shader_stage() : ShaderStage => ShaderStage.Miss
+}
+
+[function_macro(name="closest_hit_shader")]
+class SpirvClosestHitShader : SpirvShader {
+    def override shader_stage() : ShaderStage => ShaderStage.ClosestHit
+}

--- a/tests/spirv/_fail_closed/_fc_rt_accel_stage.das
+++ b/tests/spirv/_fail_closed/_fc_rt_accel_stage.das
@@ -1,0 +1,20 @@
+// Fail-closed fixture (RT): an accelerationStructureEXT descriptor is RT-pipeline-only (ray queries
+// from other stages are a different extension, not yet supported); referencing one from a fragment
+// shader must be rejected cleanly by classify_global. `_`-prefix + `expect 50501` keep dastest/lint
+// off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @set = 0 @binding = 0 fc_rta_tlas : accelerationStructureEXT
+var @ray_payload fc_rta_payload : float3
+var @out @location = 0 fc_rta_out : float4
+[fragment_shader(name="fc_rt_accel_spv")]
+def fc_rt_accel {
+    traceRayEXT(fc_rta_tlas, 0x01u, 0xFFu, 0u, 0u, 0u,
+        float3(0.0, 0.0, -1.0), 0.001, float3(0.0, 0.0, 1.0), 100.0, fc_rta_payload)
+    fc_rta_out = float4(1.0, 0.0, 0.0, 1.0)
+}

--- a/tests/spirv/_fail_closed/_fc_rt_builtin_stage.das
+++ b/tests/spirv/_fail_closed/_fc_rt_builtin_stage.das
@@ -1,0 +1,15 @@
+// Fail-closed fixture (RT): gl_LaunchIDEXT is an RT-pipeline builtin (raygen / miss / closest-hit);
+// reading it in a compute shader must be rejected cleanly by the builtin stage check. `_`-prefix +
+// `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @ssbo @binding = 0 fc_rtb_out : array<uint>
+[compute_shader(local_size_x=64, name="fc_rt_builtin_spv")]
+def fc_rt_builtin {
+    fc_rtb_out[0] = gl_LaunchIDEXT.x
+}

--- a/tests/spirv/_fail_closed/_fc_rt_hitattr_stage.das
+++ b/tests/spirv/_fail_closed/_fc_rt_hitattr_stage.das
@@ -1,0 +1,16 @@
+// Fail-closed fixture (RT): @hit_attribute (triangle barycentrics) only exists in a closest-hit
+// shader; declaring + referencing one from a raygen shader must be rejected cleanly by
+// classify_global. `_`-prefix + `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @hit_attribute fc_rth_bary : float2
+var @ray_payload fc_rth_payload : float3
+[raygen_shader(name="fc_rt_hitattr_spv")]
+def fc_rt_hitattr {
+    fc_rth_payload = float3(fc_rth_bary, 0.0)
+}

--- a/tests/spirv/_fail_closed/_fc_rt_incoming_stage.das
+++ b/tests/spirv/_fail_closed/_fc_rt_incoming_stage.das
@@ -1,0 +1,15 @@
+// Fail-closed fixture (RT): @incoming_ray_payload only exists where a payload arrives (miss /
+// closest-hit); declaring + referencing one from a raygen shader must be rejected cleanly by
+// classify_global. `_`-prefix + `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @incoming_ray_payload fc_rti_prd : float3
+[raygen_shader(name="fc_rt_incoming_spv")]
+def fc_rt_incoming {
+    fc_rti_prd = float3(0.0, 0.0, 0.0)
+}

--- a/tests/spirv/_fail_closed/_fc_rt_payload_stage.das
+++ b/tests/spirv/_fail_closed/_fc_rt_payload_stage.das
@@ -1,0 +1,16 @@
+// Fail-closed fixture (RT): @ray_payload is an RT-pipeline storage class (RayPayloadKHR); declaring +
+// referencing one from a vertex shader must be rejected cleanly by classify_global. `_`-prefix +
+// `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @ray_payload fc_rtp_payload : float3
+[vertex_shader(name="fc_rt_payload_spv")]
+def fc_rt_payload {
+    fc_rtp_payload = float3(0.0, 0.0, 0.0)
+    gl_Position = float4(fc_rtp_payload, 1.0)
+}

--- a/tests/spirv/_fail_closed/_fc_rt_trace_payload.das
+++ b/tests/spirv/_fail_closed/_fc_rt_trace_payload.das
@@ -1,0 +1,18 @@
+// Fail-closed fixture (RT): OpTraceRayKHR's payload operand must name a @ray_payload /
+// @incoming_ray_payload VARIABLE (SPIR-V takes the pointer, not a value); handing traceRayEXT a
+// plain local must be rejected cleanly by the intrinsic's payload resolution. `_`-prefix +
+// `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @set = 0 @binding = 0 fc_rtl_tlas : accelerationStructureEXT
+[raygen_shader(name="fc_rt_trace_payload_spv")]
+def fc_rt_trace_payload {
+    var local_payload = float3(0.0, 0.0, 0.0)
+    traceRayEXT(fc_rtl_tlas, 0x01u, 0xFFu, 0u, 0u, 0u,
+        float3(0.0, 0.0, -1.0), 0.001, float3(0.0, 0.0, 1.0), 100.0, local_payload)
+}

--- a/tests/spirv/_fail_closed/_fc_rt_trace_stage.das
+++ b/tests/spirv/_fail_closed/_fc_rt_trace_stage.das
@@ -1,0 +1,18 @@
+// Fail-closed fixture (RT): traceRayEXT is an RT-pipeline intrinsic; calling it from a compute
+// shader must be rejected cleanly by the intrinsic's stage gate (which fires before argument
+// resolution, so the message names the stage, not a missing accel/payload). `_`-prefix +
+// `expect 50501` keep dastest/lint off the failing shader.
+expect 50501
+
+options gen2
+
+require spirv/spirv_shader
+require spirv/spirv_builtins
+
+var @set = 0 @binding = 0 fc_rtt_tlas : accelerationStructureEXT
+var @ray_payload fc_rtt_payload : float3
+[compute_shader(local_size_x=64, name="fc_rt_trace_spv")]
+def fc_rt_trace {
+    traceRayEXT(fc_rtt_tlas, 0x01u, 0xFFu, 0u, 0u, 0u,
+        float3(0.0, 0.0, -1.0), 0.001, float3(0.0, 0.0, 1.0), 100.0, fc_rtt_payload)
+}

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -1682,3 +1682,74 @@ def public mesh_stage_emitter_opcodes : table<uint> {
     }
     return <- s
 }
+
+// ===== ray-tracing stage fixtures (VK_KHR_ray_tracing_pipeline) =====
+// The RT-pipeline minimum: raygen traces a ray into the TLAS carrying a @ray_payload; miss writes the
+// @incoming_ray_payload from the world-ray direction; closest-hit reads the triangle @hit_attribute +
+// the hit-state builtins, traces a second (shadow-style) ray with its OWN @ray_payload at @location=1
+// -- the multi-payload case that forces the payload-by-argument traceRayEXT surface -- and writes the
+// incoming payload. All three share the rt_tlas descriptor (classified independently per blob).
+
+var @set = 0 @binding = 0 rt_tlas : accelerationStructureEXT
+var @ray_payload rt_payload : float3
+
+[raygen_shader(name="rt_raygen_spv"), marker(no_coverage)]
+def rt_raygen {
+    let px = float(gl_LaunchIDEXT.x)
+    let sx = float(gl_LaunchSizeEXT.x)
+    rt_payload = float3(0.0, 0.0, 0.0)
+    traceRayEXT(rt_tlas, 0x01u, 0xFFu, 0u, 0u, 0u,
+        float3(px / sx, 0.0, -1.0), 0.001, float3(0.0, 0.0, 1.0), 100.0, rt_payload)
+}
+
+var @incoming_ray_payload rt_miss_prd : float3
+
+[miss_shader(name="rt_miss_spv"), marker(no_coverage)]
+def rt_miss {
+    rt_miss_prd = float3(0.2, 0.3, 0.7) * (0.5 + 0.5 * gl_WorldRayDirectionEXT.y)
+}
+
+var @incoming_ray_payload rt_chit_prd : float3
+var @hit_attribute rt_bary : float2
+var @ray_payload @location = 1 rt_shadow : float3
+
+[closest_hit_shader(name="rt_chit_spv"), marker(no_coverage)]
+def rt_chit {
+    let w = 1.0 - rt_bary.x - rt_bary.y
+    // shadow-style secondary ray from the hit point: terminate-on-first-hit + skip-closest-hit
+    // (0x04 | 0x08 + opaque 0x01), miss index 1; the miss shader flips the "lit" payload
+    rt_shadow = float3(0.0, 0.0, 0.0)
+    traceRayEXT(rt_tlas, 0x0Du, 0xFFu, 0u, 0u, 1u,
+        gl_WorldRayOriginEXT + gl_WorldRayDirectionEXT * gl_HitTEXT, 0.001,
+        float3(0.0, 1.0, 0.0), 100.0, rt_shadow)
+    let ids = float(gl_PrimitiveID + gl_InstanceCustomIndexEXT)
+    rt_chit_prd = float3(w, rt_bary.x, rt_bary.y) * (rt_shadow.x + ids * 0.0)
+}
+
+def public rt_raygen_words : array<uint> {
+    return clone_to_move(rt_raygen_spv)
+}
+
+def public rt_miss_words : array<uint> {
+    return clone_to_move(rt_miss_spv)
+}
+
+def public rt_chit_words : array<uint> {
+    return clone_to_move(rt_chit_spv)
+}
+
+def public rt_raygen_reflect_words : array<uint> {
+    return clone_to_move(rt_raygen_spv_reflect)
+}
+
+// The RT stages add two opcodes: OpTypeAccelerationStructureKHR (the TLAS descriptor type) and
+// OpTraceRayKHR. The RayTracingKHR capability + the SPV_KHR_ray_tracing extension ride on the
+// already-declared OpCapability / OpExtension; the RT storage classes ride on OpTypePointer /
+// OpVariable operands.
+def public rt_stage_emitter_opcodes : table<uint> {
+    var s <- mesh_stage_emitter_opcodes()
+    for (op in [SpvOp.TypeAccelerationStructureKHR, SpvOp.TraceRayKHR]) {
+        s |> insert(uint(op))
+    }
+    return <- s
+}

--- a/tests/spirv/test_census.das
+++ b/tests/spirv/test_census.das
@@ -90,7 +90,10 @@ def test_opcode_census(t : T?) {
         add_set(present, pp_frag_words())
         add_set(present, task_payload_words())
         add_set(present, mesh_payload_words())
-        var declared <- mesh_stage_emitter_opcodes()
+        add_set(present, rt_raygen_words())
+        add_set(present, rt_miss_words())
+        add_set(present, rt_chit_words())
+        var declared <- rt_stage_emitter_opcodes()
         for (op in keys(present)) {
             t |> success(key_exists(declared, op), "emitted {op_name(op)} is in the declared set")
         }

--- a/tests/spirv/test_fail_closed.das
+++ b/tests/spirv/test_fail_closed.das
@@ -68,12 +68,21 @@ def test_fail_closed_rejections(t : T?) {
         // index array under a non-triangle output topology
         check_rejects(t, "_fc_mesh_vertices_stage", "is only available in a mesh shader")
         check_rejects(t, "_fc_mesh_indices_topology", "requires output_topology")
-        // gl_PrimitiveID is a fragment-only Input builtin (reading it in a vertex shader is rejected)
-        check_rejects(t, "_fc_primid_stage", "is only available in the fragment stage")
+        // gl_PrimitiveID is a fragment Input builtin (+ closest-hit); reading it in a vertex shader is rejected
+        check_rejects(t, "_fc_primid_stage", "is not available in the vertex stage")
         // a mesh @out array<T> with an unsupported element type (double) fails closed, not crash emit_type
         check_rejects(t, "_fc_mesh_out_badtype", "not a supported varying type")
         // @task_payload outside a task/mesh stage, and a payload with a nested-struct field
         check_rejects(t, "_fc_payload_stage", "is only valid in a task or mesh shader")
         check_rejects(t, "_fc_payload_nested", "nested-struct payload fields are not yet supported")
+        // ray tracing: builtins / the traceRayEXT intrinsic / the TLAS descriptor / the RT storage
+        // classes are all RT-pipeline-stage-gated, and the trace payload must be a payload GLOBAL
+        check_rejects(t, "_fc_rt_builtin_stage", "is not available in the compute stage")
+        check_rejects(t, "_fc_rt_trace_stage", "traceRayEXT is only valid in a raygen / miss / closest-hit shader")
+        check_rejects(t, "_fc_rt_accel_stage", "accelerationStructureEXT 'fc_rta_tlas' is only valid in a raygen / miss / closest-hit shader")
+        check_rejects(t, "_fc_rt_payload_stage", "@ray_payload 'fc_rtp_payload' is only valid in a raygen / miss / closest-hit shader")
+        check_rejects(t, "_fc_rt_incoming_stage", "@incoming_ray_payload 'fc_rti_prd' is only valid in a miss or closest-hit shader")
+        check_rejects(t, "_fc_rt_hitattr_stage", "@hit_attribute 'fc_rth_bary' is only valid in a closest-hit shader")
+        check_rejects(t, "_fc_rt_trace_payload", "the payload argument must be a @ray_payload / @incoming_ray_payload global")
     }
 }

--- a/tests/spirv/test_raytracing.das
+++ b/tests/spirv/test_raytracing.das
@@ -1,0 +1,219 @@
+options gen2
+options indenting = 4
+
+// Ray-tracing stage scaffolding (VK_KHR_ray_tracing_pipeline). Each fixture asserts:
+//   * the right execution model (RayGenerationKHR 5313 / MissKHR 5317 / ClosestHitKHR 5316)
+//   * OpCapability RayTracingKHR (4479) + OpExtension "SPV_KHR_ray_tracing", each exactly once
+//   * the SPIR-V 1.4 header (SPV_KHR_ray_tracing requires >= 1.4) and NO execution modes (none of
+//     the three stages takes one)
+//   * the RT storage classes on the payload / hit-attribute OpVariables + payload Location decorations
+//   * OpTypeAccelerationStructureKHR + DescriptorSet/Binding on the TLAS descriptor
+//   * OpTraceRayKHR's payload operand == the matching @ray_payload variable id (raygen payload at
+//     Location 0; the closest-hit shadow payload at Location 1 -- the multi-payload case)
+//   * the reflected acceleration_structure binding + raygen stage flag
+//   * spirv-val against vulkan1.2 (the first env with SPV_KHR_ray_tracing promoted extensions).
+// AnyHit / Intersection / Callable stages land with their first consumer.
+
+require dastest/testing_boost public
+require _spirv_common
+require spirv/spirv_dis
+require spirv/spirv_grammar
+require spirv/spirv_reflect
+require daslib/strings_boost
+
+def private validate(t : T?; words : array<uint>; lbl : string) {
+    let r = validate_spirv(words, "vulkan1.2")
+    if (r.ran) {
+        t |> success(r.ok, "{lbl}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+// OpExtension's operand words encode the extension-name string (LSB-first bytes, NUL-terminated,
+// zero-padded). Reassemble bytes across each OpExtension and substring-search the requested name.
+def private has_extension(words : array<uint>; want : string) : bool {
+    var found = false
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (found || opcode != uint(SpvOp.Extension)) return
+        let name = build_string() $(var wr) {
+            for (k in range(n)) {
+                let wd = w[s + k]
+                for (i in range(4)) {
+                    let b = uint8((wd >> uint(i * 8)) & 0xFFu)
+                    if (b == 0u8) return
+                    wr |> write_char(int(b))
+                }
+            }
+        }
+        if (find(name, want) >= 0) {
+            found = true
+        }
+    }
+    return found
+}
+
+// Result id (operand 1) of the FIRST OpVariable whose storage class (operand 2) is `sc`.
+def private variable_id_with_storage(words : array<uint>; sc : SpvStorageClass) : tuple<ok : bool; value : uint> {
+    var res = (ok = false, value = 0u)
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (res.ok || opcode != uint(SpvOp.Variable)) return
+        if (n > 2 && w[s + 2] == uint(sc)) {
+            res = (ok = true, value = w[s + 1])
+        }
+    }
+    return res
+}
+
+// The payload operand (the 11th operand, index 10) of the FIRST OpTraceRayKHR.
+def private trace_ray_payload_id(words : array<uint>) : tuple<ok : bool; value : uint> {
+    var res = (ok = false, value = 0u)
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (res.ok || opcode != uint(SpvOp.TraceRayKHR)) return
+        if (n > 10) {
+            res = (ok = true, value = w[s + 10])
+        }
+    }
+    return res
+}
+
+// The id decorated `Location = loc` (Decorate <id> Location loc), or ok=false.
+def private id_with_location(words : array<uint>; loc : uint) : tuple<ok : bool; value : uint> {
+    var res = (ok = false, value = 0u)
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (res.ok || opcode != uint(SpvOp.Decorate)) return
+        if (n > 2 && w[s + 1] == uint(SpvDecoration.Location) && w[s + 2] == loc) {
+            res = (ok = true, value = w[s + 0])
+        }
+    }
+    return res
+}
+
+def private assert_rt_module_shape(t : T?; words : array<uint>; lbl : string; model : SpvExecutionModel) {
+    t |> success(words[1] == SPV_VERSION_1_4, "{lbl}: SPIR-V header version is 1.4")
+    t |> success(op_has_operand_at(words, SpvOp.Capability, 0, uint(SpvCapability.RayTracingKHR)),
+        "{lbl}: OpCapability RayTracingKHR")
+    let ncap = count_op_operand_at(words, SpvOp.Capability, 0, uint(SpvCapability.RayTracingKHR))
+    t |> success(ncap == 1, "{lbl}: exactly one RayTracingKHR cap (got {ncap})")
+    t |> success(has_extension(words, "SPV_KHR_ray_tracing"), "{lbl}: OpExtension SPV_KHR_ray_tracing")
+    t |> success(count_op(words, SpvOp.Extension) == 1,
+        "{lbl}: exactly one OpExtension (got {count_op(words, SpvOp.Extension)})")
+    t |> success(op_has_operand_at(words, SpvOp.EntryPoint, 0, uint(model)),
+        "{lbl}: OpEntryPoint execution model")
+    // none of the three RT stages takes an execution mode (no LocalSize / OriginUpperLeft / ...)
+    t |> success(count_op(words, SpvOp.ExecutionMode) == 0,
+        "{lbl}: no execution modes (got {count_op(words, SpvOp.ExecutionMode)})")
+}
+
+[test]
+def test_raygen_stage(t : T?) {
+    t |> run("[raygen_shader]: model + cap + ext + payload + TLAS + OpTraceRayKHR payload operand") <| @(t : T?) {
+        var words <- rt_raygen_words()
+        assert_rt_module_shape(t, words, "rt_raygen", SpvExecutionModel.RayGenerationKHR)
+        // the launch-grid builtins
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.LaunchIdKHR)),
+            "rt_raygen: gl_LaunchIDEXT -> BuiltIn LaunchIdKHR")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.LaunchSizeKHR)),
+            "rt_raygen: gl_LaunchSizeEXT -> BuiltIn LaunchSizeKHR")
+        // @ray_payload -> a RayPayloadKHR OpVariable, Location 0
+        let pvar = variable_id_with_storage(words, SpvStorageClass.RayPayloadKHR)
+        t |> success(pvar.ok, "rt_raygen: @ray_payload -> RayPayloadKHR OpVariable")
+        let ploc = id_with_location(words, 0u)
+        t |> success(ploc.ok && ploc.value == pvar.value,
+            "rt_raygen: the payload variable carries Location 0 (loc-id={ploc.value} var={pvar.value})")
+        // the TLAS descriptor: OpTypeAccelerationStructureKHR + set/binding decorations
+        t |> success(has_op(words, SpvOp.TypeAccelerationStructureKHR),
+            "rt_raygen: OpTypeAccelerationStructureKHR")
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.DescriptorSet)),
+            "rt_raygen: TLAS has a DescriptorSet decoration")
+        t |> success(op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Binding)),
+            "rt_raygen: TLAS has a Binding decoration")
+        // OpTraceRayKHR: present once, its payload operand names the @ray_payload variable
+        t |> success(count_op(words, SpvOp.TraceRayKHR) == 1,
+            "rt_raygen: exactly one OpTraceRayKHR (got {count_op(words, SpvOp.TraceRayKHR)})")
+        let tpay = trace_ray_payload_id(words)
+        t |> success(tpay.ok && tpay.value == pvar.value,
+            "rt_raygen: OpTraceRayKHR payload operand == the payload variable id (op={tpay.value} var={pvar.value})")
+        validate(t, words, "rt_raygen")
+        delete words
+        // reflection: the TLAS binding surfaces as acceleration_structure with the raygen stage flag
+        var rwords <- rt_raygen_reflect_words()
+        var refl <- decode_reflection(rwords)
+        t |> success(refl.stage.raygen, "rt_raygen: reflection stage flag is raygen")
+        var accel_found = false
+        for (b in refl.bindings) {
+            if (b.kind == SpirvDescriptorKind.acceleration_structure) {
+                accel_found = true
+                t |> equal(b.set, 0)
+                t |> equal(b.binding, 0)
+                t |> success(b.stages.raygen, "rt_raygen: the TLAS binding carries the raygen stage bit")
+            }
+        }
+        t |> success(accel_found, "rt_raygen: reflection carries an acceleration_structure binding")
+        finalize(refl)
+        delete rwords
+    }
+}
+
+[test]
+def test_miss_stage(t : T?) {
+    t |> run("[miss_shader]: model + incoming payload + world-ray builtin") <| @(t : T?) {
+        var words <- rt_miss_words()
+        assert_rt_module_shape(t, words, "rt_miss", SpvExecutionModel.MissKHR)
+        // @incoming_ray_payload -> an IncomingRayPayloadKHR OpVariable, Location 0
+        let pvar = variable_id_with_storage(words, SpvStorageClass.IncomingRayPayloadKHR)
+        t |> success(pvar.ok, "rt_miss: @incoming_ray_payload -> IncomingRayPayloadKHR OpVariable")
+        let ploc = id_with_location(words, 0u)
+        t |> success(ploc.ok && ploc.value == pvar.value,
+            "rt_miss: the incoming payload carries Location 0")
+        // the world-ray builtin read by the sky gradient
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.WorldRayDirectionKHR)),
+            "rt_miss: gl_WorldRayDirectionEXT -> BuiltIn WorldRayDirectionKHR")
+        // a miss shader that doesn't trace has no OpTraceRayKHR
+        t |> success(count_op(words, SpvOp.TraceRayKHR) == 0, "rt_miss: no OpTraceRayKHR")
+        validate(t, words, "rt_miss")
+        delete words
+    }
+}
+
+[test]
+def test_closest_hit_stage(t : T?) {
+    t |> run("[closest_hit_shader]: hit attribute + hit builtins + second payload + shadow trace") <| @(t : T?) {
+        var words <- rt_chit_words()
+        assert_rt_module_shape(t, words, "rt_chit", SpvExecutionModel.ClosestHitKHR)
+        // @hit_attribute -> a HitAttributeKHR OpVariable (NO Location decoration on it)
+        let hvar = variable_id_with_storage(words, SpvStorageClass.HitAttributeKHR)
+        t |> success(hvar.ok, "rt_chit: @hit_attribute -> HitAttributeKHR OpVariable")
+        // both payloads: the incoming one (written result) + the chit's OWN outgoing shadow payload
+        let ivar = variable_id_with_storage(words, SpvStorageClass.IncomingRayPayloadKHR)
+        t |> success(ivar.ok, "rt_chit: @incoming_ray_payload -> IncomingRayPayloadKHR OpVariable")
+        let svar = variable_id_with_storage(words, SpvStorageClass.RayPayloadKHR)
+        t |> success(svar.ok, "rt_chit: the shadow @ray_payload -> RayPayloadKHR OpVariable")
+        let sloc = id_with_location(words, 1u)
+        t |> success(sloc.ok && sloc.value == svar.value,
+            "rt_chit: the shadow payload carries @location = 1")
+        // the hit-state builtins
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.RayTmaxKHR)),
+            "rt_chit: gl_HitTEXT -> BuiltIn RayTmaxKHR")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.WorldRayOriginKHR)),
+            "rt_chit: gl_WorldRayOriginEXT -> BuiltIn WorldRayOriginKHR")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.InstanceCustomIndexKHR)),
+            "rt_chit: gl_InstanceCustomIndexEXT -> BuiltIn InstanceCustomIndexKHR")
+        t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.BuiltIn), uint(SpvBuiltIn.PrimitiveId)),
+            "rt_chit: gl_PrimitiveID -> BuiltIn PrimitiveId")
+        // gl_PrimitiveID must NOT be Flat here (that's the fragment-interface rule, not closest-hit)
+        t |> success(!op_has_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Flat)),
+            "rt_chit: no Flat decoration (fragment-only rule)")
+        // ... and no MeshShadingEXT capability leaked in via the gl_PrimitiveID path
+        t |> success(!op_has_operand_at(words, SpvOp.Capability, 0, uint(SpvCapability.MeshShadingEXT)),
+            "rt_chit: no MeshShadingEXT capability")
+        // the shadow trace: OpTraceRayKHR whose payload operand is the SHADOW payload (Location 1)
+        t |> success(count_op(words, SpvOp.TraceRayKHR) == 1,
+            "rt_chit: exactly one OpTraceRayKHR (got {count_op(words, SpvOp.TraceRayKHR)})")
+        let tpay = trace_ray_payload_id(words)
+        t |> success(tpay.ok && tpay.value == svar.value,
+            "rt_chit: OpTraceRayKHR payload operand == the shadow payload id (op={tpay.value} var={svar.value})")
+        validate(t, words, "rt_chit")
+        delete words
+    }
+}

--- a/utils/preflight/main.das
+++ b/utils/preflight/main.das
@@ -23,6 +23,7 @@ require daslib/fio
 require daslib/strings_boost
 require strings
 require ../common/parallel_workers.das
+require ../common/git_signature.das
 
 
 [CommandLineArgs]
@@ -167,17 +168,40 @@ def find_daslang(cli_path : string) : string {
     if (!empty(cli_path)) {
         return fexist(cli_path) ? cli_path : ""
     }
-    if (has_env_variable("DASLANG")) {
-        let env = get_env_variable("DASLANG")
-        if (fexist(env)) return env
-    }
+    // Repo-local binaries FIRST. daslang derives its module root from the executable's location,
+    // so a DASLANG env var pointing at ANOTHER checkout silently resolves in-tree modules
+    // (spirv/, ...) against THAT tree — any PR changing them then fails child gates with
+    // phantom errors (the worktree trap). The env var is only a fallback for treeless setups.
+    // Among the local candidates the NEWEST wins: a tree often carries several flavors (the MSVC
+    // bin/Release binary next to an MCP-setup bin/daslang stub), and a stale stub paired with
+    // newer-relinked runtime DLLs fails the try/recover-heavy suites with phantom errors.
     let candidates = [
         "bin/daslang", "bin/daslang.exe",
         "bin/Release/daslang.exe", "bin/RelWithDebInfo/daslang.exe", "bin/Debug/daslang.exe",
         "build/daslang", "build/bin/daslang"
     ]
+    var best = ""
+    var best_mtime = 0l
     for (c in candidates) {
-        if (fexist(c)) return c
+        if (fexist(c)) {
+            let mt = stat_mtime_or_zero(c)
+            if (mt > best_mtime) {
+                best_mtime = mt
+                best = c
+            }
+        }
+    }
+    if (!empty(best)) {
+        // absolutize: child gates spawn this via popen_argv, whose CreateProcess does not
+        // resolve a bare relative exe path the way a shell does
+        return get_full_file_name(best)
+    }
+    if (has_env_variable("DASLANG")) {
+        let env = get_env_variable("DASLANG")
+        if (fexist(env)) {
+            to_log(LOG_WARNING, "preflight: no repo-local daslang found; falling back to DASLANG={env} — a binary from another checkout resolves in-tree modules against THAT tree\n")
+            return env
+        }
     }
     return ""
 }


### PR DESCRIPTION
## What

VK_KHR_ray_tracing_pipeline support in the SPIR-V emitter — Phase 1 of the Vulkan HW ray-tracing arc, with the mesh-shader slice as the template. All three stages are authored in daslang and lowered by dasSpirv; no GLSL anywhere.

- **Stages:** `[raygen_shader]` / `[miss_shader]` / `[closest_hit_shader]` → RayGenerationKHR / MissKHR / ClosestHitKHR execution models; RayTracingKHR capability + `OpExtension "SPV_KHR_ray_tracing"`; SPIR-V 1.4 floor (the mesh slice's every-referenced-global entry-interface pass applies as-is). None of the three takes an execution mode. AnyHit / Intersection / Callable follow the same rail and land with their first consumer.
- **Storage classes:** `@ray_payload` → RayPayloadKHR, `@incoming_ray_payload` → IncomingRayPayloadKHR (both Location-decorated, `@location` default 0), `@hit_attribute` → HitAttributeKHR. Struct payloads lay out plainly like `@task_payload`; scalar/vector payloads emit directly.
- **TLAS descriptor:** the `accelerationStructureEXT` marker → UniformConstant `OpTypeAccelerationStructureKHR` with set/binding decorations, reflected as the new `SpirvDescriptorKind.acceleration_structure` (reflection wire bumped to RFL6 with raygen/miss/closest_hit stage bits; the sole decoder lives in-tree, so producer and consumer move together).
- **Builtins:** `gl_LaunchIDEXT` / `gl_LaunchSizeEXT` (all RT stages), `gl_WorldRayOriginEXT` / `gl_WorldRayDirectionEXT` (miss + chit), `gl_HitTEXT` (RayTmaxKHR) / `gl_InstanceCustomIndexEXT` / `gl_PrimitiveID` (chit). Multi-stage validity goes through `rt_builtin_stage_ok`; `gl_PrimitiveID`'s closest-hit reuse keeps the Flat decoration + MeshShadingEXT capability strictly fragment-gated.
- **`traceRayEXT(accel, flags, cull_mask, sbt_offset, sbt_stride, miss_index, origin, tmin, direction, tmax, payload)`** → `OpTraceRayKHR`. The payload argument must be a payload **global** (SPIR-V names the variable) — payload-by-argument rather than an implicit module global, because a closest-hit shader tracing shadow rays needs its own second payload (the chit fixture exercises exactly that, `@location = 1`). The stub is generic over the payload type, which surfaced a real emitter gap: intercepted-call matching and the user-shader-func exclusion now resolve generic instances to their **origin** generic's name/module.

Also folded in (own commit): **preflight fix** — `find_daslang` preferred the `DASLANG` env var over repo-local binaries, so in a worktree every das child gate ran a binary whose module root is another checkout; a PR changing an in-tree module (this one) failed lint/tests with phantom "annotation not found" errors. Repo-local candidates now win (newest mtime among flavors), the path is absolutized for `popen_argv`, and the env var is a warned fallback.

## Tests

- `tests/spirv/test_raytracing.das` — per stage: execution model, cap + extension exactly once, 1.4 header, **zero** execution modes, RT storage classes on the OpVariables, payload Location identity, TLAS decorations, `OpTraceRayKHR` payload-operand == the payload variable id, reflection roundtrip (acceleration_structure binding + raygen stage bit), spirv-val vulkan1.2
- 7 fail-closed fixtures: every RT builtin / the intrinsic / the descriptor / both payload kinds / the hit attribute from a wrong stage rejects with a clean compile error; a non-global trace payload rejects
- census extended with the two new opcodes (OpTraceRayKHR, OpTypeAccelerationStructureKHR)

## Verification

- tests/spirv **172/172** green; spirv-val (SDK 1.4.350) clean on all three fixture blobs
- full preflight: **13 passed, 0 failed** (token minted); AOT suite run separately: **9940/9946 passed, 0 failed** (6 environmental skips)
- lint 17 files clean, formatted, docs gates clean (das2rst silent, no Uncategorized, generated/ untracked)

Part of VULKAN_RT_ARC.md; dasVulkan-side rails (SBT builder, `rt_supported`, BLAS/TLAS helpers, `[vulkan_*_shader]` mirrors) and tutorial 15 follow in the external repo once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)