### PR TITLE
ci(pages): pin TeX Live 2025 on the PDF compile steps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -136,6 +136,9 @@ jobs:
     - name: "Compile PDF: daslangstdlib.tex"
       uses: xu-cheng/latex-action@v4
       with:
+        # Pinned: the rolling texlive-alpine:latest flipped to TL 2026 (2026-07-01) whose kernel
+        # dies with "TeX capacity exceeded [input stack size]" on the generated stdlib PDF.
+        texlive_version: "2025"
         root_file: daslangstdlib.tex
         working_directory: build/latex
         continue_on_error: true
@@ -143,6 +146,7 @@ jobs:
     - name: "Compile PDF: daslang.tex"
       uses: xu-cheng/latex-action@v4
       with:
+        texlive_version: "2025"
         root_file: daslang.tex
         working_directory: build/latex
         continue_on_error: true


### PR DESCRIPTION
Same break as doc.yml (ed8164e41, landed via #3340): the rolling `texlive-alpine:latest` flipped to TL 2026 on 2026-07-01, whose kernel dies with `TeX capacity exceeded [input stack size=10000]` at a `\sphinxmidrule` in the generated stdlib PDF. This took down the master Pages deploy (run [28558501455](https://github.com/GaijinEntertainment/daScript/actions/runs/28558501455)).

Fix: pin `texlive_version: "2025"` on both `xu-cheng/latex-action@v4` steps in `pages.yml`, mirroring the doc.yml fix. These are the only remaining unpinned latex-action uses in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)