### PR TITLE
get_stackwalk — capture the stack walk as a string (builtin + debugapi)

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -177,7 +177,7 @@ get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_defau
         group_by_regex("Smart ptr infrastructure", mod, %regex~(add_ptr_ref|smart_ptr|get_const_ptr|move|move_new|get_ptr$)%%),
         group_by_regex("Macro infrastructure", mod, %regex~(is_folding|is_compiling|is_in_completion|is_in_lint_check|is_reporting_compilation_errors)%%),
         group_by_regex("Profiler", mod, %regex~(profile|reset_profiler|dump_profile_info|collect_profile_info)$%%),
-        group_by_regex("System infrastructure", mod, %regex~(panic|print|feint|sprint|sprint_json|sscan_json|to_log|to_compiler_log|error|terminate|breakpoint|stackwalk|get_das_root|get_das_version|is_in_aot|aot_enabled|is_intern_strings|is_safe_hash|eval_main_loop|shared_module_extension)$%%),
+        group_by_regex("System infrastructure", mod, %regex~(panic|print|feint|sprint|sprint_json|sscan_json|to_log|to_compiler_log|error|terminate|breakpoint|stackwalk|get_stackwalk|get_das_root|get_das_version|is_in_aot|aot_enabled|is_intern_strings|is_safe_hash|eval_main_loop|shared_module_extension)$%%),
         group_by_regex("Memory manipulation", mod, %regex~(intptr|memcmp|variant_index|set_variant_index|hash|memcpy|lock_data|map_to_array|map_to_ro_array)$%%),
         group_by_regex("Binary serializer", mod, %regex~(binary_load|binary_save)$%%),
         group_by_regex("Path and command line", mod, %regex~(get_command_line_arguments|with_argv)$%%),
@@ -288,7 +288,7 @@ def document_module_debugapi(_root : string) {
         group_by_regex("Agent construction", mod, %regex~(make_debug_agent|make_data_walker|make_stack_walker)$%%),
         group_by_regex("Agent tick and state collection", mod, %regex~(tick_debug_agent|collect_debug_agent_state|on_breakpoints_reset|report_context_state|debug_agent_command|debugger_stop_requested)$%%),
         group_by_regex("Instrumentation", mod, %regex~(instrument_node|instrument_function|instrument_all_functions|instrument_all_functions_thread_local|instrument_context_allocations|clear_instruments|set_single_step)$%%),
-        group_by_regex("Data and stack walking", mod, %regex~(walk_data|walk_stack|stackwalk|stack_depth)$%%),
+        group_by_regex("Data and stack walking", mod, %regex~(walk_data|walk_stack|stackwalk|get_stackwalk|stack_depth)$%%),
         group_by_regex("Context inspection", mod, %regex~(get_context_global_variable|has_function|get_heap_stats)$%%),
         group_by_regex("Breakpoints", mod, %regex~(set_hw_breakpoint|clear_hw_breakpoint)$%%),
         group_by_regex("Memory", mod, %regex~(free_temp_string|temp_string_size|break_on_free|track_insane_pointer)$%%)

--- a/doc/source/stdlib/handmade/function-builtin-get_stackwalk-0x9606fc7db19f88e3.rst
+++ b/doc/source/stdlib/handmade/function-builtin-get_stackwalk-0x9606fc7db19f88e3.rst
@@ -1,0 +1,1 @@
+Returns the current call stack as a string — the same report `stackwalk` prints, captured instead of logged. `args` and `vars` include function arguments and local variable values, `out_of_scope` includes out-of-scope locals, and `top_only` limits the walk to the topmost frame.

--- a/doc/source/stdlib/handmade/function-debugapi-get_stackwalk-0x657a5282da1ca432.rst
+++ b/doc/source/stdlib/handmade/function-debugapi-get_stackwalk-0x657a5282da1ca432.rst
@@ -1,0 +1,1 @@
+Returns a human-readable stack trace of the given context as a string — the same report `stackwalk` prints, captured instead of logged. `args` and `vars` include function arguments and local variable values, `out_of_scope` includes out-of-scope locals, and `top_only` limits the walk to the topmost frame.

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -42,6 +42,7 @@ namespace das {
     DAS_API Func builtin_SimFunction_by_MNH ( Context & context, uint64_t MNH );
     DAS_API vec4f builtin_breakpoint ( Context & context, SimNode_CallBase * call, vec4f * );
     DAS_API void builtin_stackwalk ( bool args, bool vars, Context * context, LineInfoArg * lineInfo );
+    DAS_API char * builtin_get_stackwalk ( bool args, bool vars, bool outOfScope, bool topOnly, Context * context, LineInfoArg * lineInfo );
     DAS_API void builtin_terminate ( Context * context, LineInfoArg * lineInfo );
     DAS_API int builtin_table_size ( const Table & arr );
     DAS_API bool builtin_table_empty ( const Table & arr );

--- a/include/daScript/simulate/aot_builtin_debugger.h
+++ b/include/daScript/simulate/aot_builtin_debugger.h
@@ -4,6 +4,8 @@ namespace das {
 
     DAS_API DebugAgentPtr makeDebugAgent ( const void * pClass, const StructInfo * info, Context * context );
     DAS_API void debuggerStackWalk ( Context & context, const LineInfo & lineInfo );
+    DAS_API char * debuggerGetStackWalk ( Context & context, const LineInfo & lineInfo,
+        bool args, bool vars, bool outOfScope, bool topOnly, Context * toContext, LineInfoArg * at );
     DAS_API void debuggerSetContextSingleStep ( Context & context, bool step );
 
     DAS_API void makeDataWalker ( const void * pClass, const StructInfo * info,

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -819,6 +819,12 @@ namespace debugger {
         context.stackWalk(&lineInfo, true, true);
     }
 
+    char * debuggerGetStackWalk ( Context & context, const LineInfo & lineInfo,
+            bool args, bool vars, bool outOfScope, bool topOnly, Context * toContext, LineInfoArg * at ) {
+        // allocate in the calling context's heap - the walked context may be a different one
+        return toContext->allocateString(context.getStackWalk(&lineInfo, args, vars, outOfScope, topOnly), at);
+    }
+
     void makeDataWalker ( const void * pClass, const StructInfo * info,
             const TBlock<void, DataWalker *> & blk, Context * context, LineInfoArg * at ) {
         auto adapter = new DataWalkerAdapter((char *)pClass,info,context);
@@ -1364,6 +1370,13 @@ namespace debugger {
             addExtern<DAS_BIND_FUN(debuggerStackWalk)>(*this, lib, "stackwalk",
                 SideEffects::modifyExternal, "debuggerStackWalk")
                     ->args({"context","line"});
+            auto fngsw = addExtern<DAS_BIND_FUN(debuggerGetStackWalk)>(*this, lib, "get_stackwalk",
+                SideEffects::accessExternal, "debuggerGetStackWalk")
+                    ->args({"context","line","args","vars","out_of_scope","top_only","context","at"});
+            fngsw->arguments[2]->init = new ExprConstBool(true);
+            fngsw->arguments[3]->init = new ExprConstBool(true);
+            fngsw->arguments[4]->init = new ExprConstBool(false);
+            fngsw->arguments[5]->init = new ExprConstBool(false);
             addExtern<DAS_BIND_FUN(dapiReportContextState)>(*this, lib, "report_context_state",
                 SideEffects::modifyExternal, "dapiReportContextState")
                     ->args({"context","category","name","info","data"});

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -805,6 +805,10 @@ namespace das
         context->stackWalk(lineInfo, args, vars);
     }
 
+    char * builtin_get_stackwalk ( bool args, bool vars, bool outOfScope, bool topOnly, Context * context, LineInfoArg * lineInfo ) {
+        return context->allocateString(context->getStackWalk(lineInfo, args, vars, outOfScope, topOnly), lineInfo);
+    }
+
     void builtin_terminate ( Context * context, LineInfoArg * at ) {
         context->throw_error_at(at, "terminate");
     }
@@ -2058,6 +2062,13 @@ namespace das
                 ->args({"args","vars","context","lineinfo"});
         fnsw->arguments[0]->init = new ExprConstBool(true);
         fnsw->arguments[1]->init = new ExprConstBool(true);
+        auto fngsw = addExtern<DAS_BIND_FUN(builtin_get_stackwalk)>(*this, lib, "get_stackwalk",
+            SideEffects::accessExternal, "builtin_get_stackwalk")
+                ->args({"args","vars","out_of_scope","top_only","context","lineinfo"});
+        fngsw->arguments[0]->init = new ExprConstBool(true);
+        fngsw->arguments[1]->init = new ExprConstBool(true);
+        fngsw->arguments[2]->init = new ExprConstBool(false);
+        fngsw->arguments[3]->init = new ExprConstBool(false);
         // profiler
         addExtern<DAS_BIND_FUN(resetProfiler)>(*this, lib, "reset_profiler",
             SideEffects::modifyExternal, "resetProfiler")

--- a/tests/debug/test_get_stackwalk.das
+++ b/tests/debug/test_get_stackwalk.das
@@ -1,0 +1,28 @@
+// Test: get_stackwalk - stack walk captured as a string instead of printed
+options gen2
+
+require dastest/testing_boost public
+require strings
+require daslib/rtti
+require debugapi
+
+def private capture_own_stack() : string => get_stackwalk()
+
+[test]
+def test_get_stackwalk(t : T?) {
+    t |> run("builtin returns the stack as a string") @(t : T?) {
+        let s = capture_own_stack()
+        t |> success(!empty(s))
+        t |> success(find(s, "CALL STACK") != -1)
+    }
+    t |> run("all four bools accepted") @(t : T?) {
+        let s = get_stackwalk(false, false, false, true)
+        t |> success(!empty(s))
+        t |> success(find(s, "CALL STACK") != -1)
+    }
+    t |> run("debugapi variant walks a given context") @(t : T?) {
+        let s = get_stackwalk(this_context(), get_line_info())
+        t |> success(!empty(s))
+        t |> success(find(s, "CALL STACK") != -1)
+    }
+}


### PR DESCRIPTION
## What

Expose `Context::getStackWalk` to script — the stack walk as a *string*, alongside the existing print-only `stackwalk()`. Requested by game teams that want the call stack in their own crash reports / telemetry.

- `builtin::get_stackwalk(args = true, vars = true, out_of_scope = false, top_only = false) : string` — the current context's call stack, the exact report `stackwalk()` prints, captured instead of logged.
- `debugapi::get_stackwalk(context : Context; line : LineInfo; args = true, vars = true, out_of_scope = false, top_only = false) : string` — walks a given context (debug-agent shape). The result string is allocated in the **calling** context's heap, since the walked context may be a different one.

Both mirror their print-variant neighbors (`builtin_stackwalk` / `debuggerStackWalk`) and additionally expose `getStackWalk`'s `showOutOfScope` / `stackTopOnly` knobs as defaulted bools (`top_only` is handy for compact one-line telemetry).

## Testing

- New `tests/debug/test_get_stackwalk.das` — passes under interpreter, `-jit`, and `test_aot` (directory already AOT-registered; the `CONFIGURE_DEPENDS` glob picks the file up with no CMake change).
- Full local preflight `--full` green, 17/17 gates: format, lint, clang syntax sweep over all 163 src+tests-cpp TUs (both AOT headers changed), all seven doc gates including both PDFs, ctest, and the complete interp/JIT/AOT test sweeps + sequence smoke.

## Docs

- Handmade descriptions for both functions; `das2rst.das` group regexes updated ("System infrastructure" / "Data and stack walking" — the patterns are start-anchored, so `get_stackwalk` needs its own alternative). No `// stub`, no `Uncategorized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)