### PR TITLE
fixed arrays: accept int64/uint64 indexes across all execution tiers

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -972,6 +972,22 @@ namespace das {
             if ( idx>=uint32_t(size) ) __context__->throw_error_ex("index out of range, %u of %d", idx, size);
             return data[idx];
         }
+        __forceinline TT & operator () ( int64_t index, Context * __context__ ) {
+            if ( index<0 || uint64_t(index)>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %lld of %d", (long long)index, size);
+            return data[index];
+        }
+        __forceinline const TT & operator () ( int64_t index, Context * __context__ ) const {
+            if ( index<0 || uint64_t(index)>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %lld of %d", (long long)index, size);
+            return data[index];
+        }
+        __forceinline TT & operator () ( uint64_t idx, Context * __context__ ) {
+            if ( idx>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %llu of %d", (unsigned long long)idx, size);
+            return data[idx];
+        }
+        __forceinline const TT & operator () ( uint64_t idx, Context * __context__ ) const {
+            if ( idx>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %llu of %d", (unsigned long long)idx, size);
+            return data[idx];
+        }
     // safe index
         static __forceinline TT * safe_index ( THIS_TYPE * that, int32_t index, Context * ) {
             if (!that) return nullptr;
@@ -991,6 +1007,26 @@ namespace das {
         static __forceinline const TT * safe_index ( const THIS_TYPE * that, uint32_t idx, Context * ) {
             if (!that) return nullptr;
             if ( idx>=uint32_t(size) ) return nullptr;
+            return that->data + idx;
+        }
+        static __forceinline TT * safe_index ( THIS_TYPE * that, int64_t index, Context * ) {
+            if (!that) return nullptr;
+            if ( index<0 || uint64_t(index)>=uint64_t(size) ) return nullptr;
+            return that->data + index;
+        }
+        static __forceinline const TT * safe_index ( const THIS_TYPE * that, int64_t index, Context * ) {
+            if (!that) return nullptr;
+            if ( index<0 || uint64_t(index)>=uint64_t(size) ) return nullptr;
+            return that->data + index;
+        }
+        static __forceinline TT * safe_index ( THIS_TYPE * that, uint64_t idx, Context * ) {
+            if (!that) return nullptr;
+            if ( idx>=uint64_t(size) ) return nullptr;
+            return that->data + idx;
+        }
+        static __forceinline const TT * safe_index ( const THIS_TYPE * that, uint64_t idx, Context * ) {
+            if (!that) return nullptr;
+            if ( idx>=uint64_t(size) ) return nullptr;
             return that->data + idx;
         }
     };

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -881,6 +881,106 @@ namespace das {
 #undef EVAL_NODE
     };
 
+    // AT (INDEX) - int64 index
+    struct DAS_API SimNode_At_I64 : SimNode_WithErrorMessage {
+        DAS_PTR_NODE;
+        SimNode_At_I64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng, const char * msg )
+            : SimNode_WithErrorMessage(at,msg), value(rv), index(idx), stride(strd), offset(o), range(rng) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute (Context & context) {
+            DAS_PROFILE_NODE
+            auto pValue = value->evalPtr(context);
+            int64_t idx = index->evalInt64(context);
+            if (idx<0 || uint64_t(idx) >= uint64_t(range)) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)idx, range, errorMessage);
+            return pValue + uint32_t(idx)*stride + offset;
+        }
+        SimNode * value, * index;
+        uint32_t  stride, offset, range;
+    };
+
+    // AT (INDEX) - uint64 index
+    struct DAS_API SimNode_At_U64 : SimNode_WithErrorMessage {
+        DAS_PTR_NODE;
+        SimNode_At_U64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng, const char * msg )
+            : SimNode_WithErrorMessage(at,msg), value(rv), index(idx), stride(strd), offset(o), range(rng) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute (Context & context) {
+            DAS_PROFILE_NODE
+            auto pValue = value->evalPtr(context);
+            uint64_t idx = index->evalUInt64(context);
+            if (idx >= uint64_t(range)) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)idx, range, errorMessage);
+            return pValue + uint32_t(idx)*stride + offset;
+        }
+        SimNode * value, * index;
+        uint32_t  stride, offset, range;
+    };
+
+    // SAFE AT (INDEX) - int64 index
+    struct DAS_API SimNode_SafeAt_I64 : SimNode_At_I64 {
+        DAS_PTR_NODE;
+        SimNode_SafeAt_I64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng )
+            : SimNode_At_I64(at,rv,idx,strd,o,rng,"") {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute (Context & context) {
+            DAS_PROFILE_NODE
+            auto pValue = value->evalPtr(context);
+            if (!pValue) return nullptr;
+            int64_t idx = index->evalInt64(context);
+            if (idx<0 || uint64_t(idx) >= uint64_t(range)) return nullptr;
+            return pValue + uint32_t(idx)*stride + offset;
+        }
+    };
+
+    // SAFE AT (INDEX) - uint64 index
+    struct DAS_API SimNode_SafeAt_U64 : SimNode_At_U64 {
+        DAS_PTR_NODE;
+        SimNode_SafeAt_U64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng )
+            : SimNode_At_U64(at,rv,idx,strd,o,rng,"") {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        __forceinline char * compute (Context & context) {
+            DAS_PROFILE_NODE
+            auto pValue = value->evalPtr(context);
+            if (!pValue) return nullptr;
+            uint64_t idx = index->evalUInt64(context);
+            if (idx >= uint64_t(range)) return nullptr;
+            return pValue + uint32_t(idx)*stride + offset;
+        }
+    };
+
+    template <typename TT>
+    struct SimNode_AtR2V_I64 : SimNode_At_I64 {
+        SimNode_AtR2V_I64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng, const char * msg )
+            : SimNode_At_I64(at,rv,idx,strd,o,rng,msg) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+            TT * pR = (TT *) compute(context);
+            return cast<TT>::from(*pR);
+        }
+#define EVAL_NODE(TYPE,CTYPE)                                       \
+        virtual CTYPE eval##TYPE ( Context & context ) override {   \
+            return *(CTYPE *)compute(context);                      \
+        }
+        DAS_EVAL_NODE
+#undef EVAL_NODE
+    };
+
+    template <typename TT>
+    struct SimNode_AtR2V_U64 : SimNode_At_U64 {
+        SimNode_AtR2V_U64 ( const LineInfo & at, SimNode * rv, SimNode * idx, uint32_t strd, uint32_t o, uint32_t rng, const char * msg )
+            : SimNode_At_U64(at,rv,idx,strd,o,rng,msg) {}
+        virtual SimNode * visit ( SimVisitor & vis ) override;
+        DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
+            TT * pR = (TT *) compute(context);
+            return cast<TT>::from(*pR);
+        }
+#define EVAL_NODE(TYPE,CTYPE)                                       \
+        virtual CTYPE eval##TYPE ( Context & context ) override {   \
+            return *(CTYPE *)compute(context);                      \
+        }
+        DAS_EVAL_NODE
+#undef EVAL_NODE
+    };
+
     // AT (INDEX)
     template <typename TT>
     struct SimNode_PtrAt : SimNode {

--- a/include/daScript/simulate/simulate_visit.h
+++ b/include/daScript/simulate/simulate_visit.h
@@ -141,6 +141,30 @@ namespace das {
     }
 
     template <typename TT>
+    SimNode * SimNode_AtR2V_I64<TT>::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP_TT(AtR2V_I64);
+        V_SUB(value);
+        V_SUB(index);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_ARG(range);
+        V_END();
+    }
+
+    template <typename TT>
+    SimNode * SimNode_AtR2V_U64<TT>::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP_TT(AtR2V_U64);
+        V_SUB(value);
+        V_SUB(index);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_ARG(range);
+        V_END();
+    }
+
+    template <typename TT>
     SimNode * SimNode_PtrAt<TT>::visit ( SimVisitor & vis ) {
         V_BEGIN();
         V_OP_TT(PtrAt);

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -3314,6 +3314,21 @@ namespace das {
                 TypeDecl::clone(expr->type, seT->firstType);
                 expr->type->ref = true;
                 expr->type->constant |= seT->constant;
+            } else if (seT->baseType == Type::tFixedArray) {
+                if (!ixT->isIndexExt()) {
+                    expr->type = nullptr;
+                    error("index type must be 'int', 'int64', 'uint', or 'uint64', not '" + describeType(ixT) + "'", "", "",
+                          expr->index->at, CompilationError::invalid_index_type);
+                    return Visitor::visit(expr);
+                } else if (!seT->isAutoArrayResolved()) {
+                    error("type dimensions are not resolved yet: '" + describeType(seT) + "'", "", "",
+                          expr->subexpr->at, CompilationError::not_resolved_yet_array_dimension);
+                    return Visitor::visit(expr);
+                }
+                // peel one level - same element-access pattern as tArray
+                TypeDecl::clone(expr->type, seT->firstType);
+                expr->type->ref = true;
+                expr->type->constant |= seT->constant;
             } else if (!ixT->isIndex()) {
                 expr->type = nullptr;
                 error("index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
@@ -3323,19 +3338,10 @@ namespace das {
                 expr->type = new TypeDecl(seT->getVectorBaseType());
                 expr->type->ref = seT->ref;
                 expr->type->constant = seT->constant;
-            } else if (seT->baseType != Type::tFixedArray) {
+            } else {
                 error("type can't be indexed: '" + describeType(seT) + "'", "", "",
                       expr->subexpr->at, CompilationError::cant_index);
                 return Visitor::visit(expr);
-            } else if (!seT->isAutoArrayResolved()) {
-                error("type dimensions are not resolved yet: '" + describeType(seT) + "'", "", "",
-                      expr->subexpr->at, CompilationError::not_resolved_yet_array_dimension);
-                return Visitor::visit(expr);
-            } else {
-                // peel one level - same element-access pattern as tArray
-                TypeDecl::clone(expr->type, seT->firstType);
-                expr->type->ref = true;
-                expr->type->constant |= seT->constant;
             }
         }
         propagateTempType(expr->subexpr->type, expr->type); // foo#[a] = a#
@@ -3390,10 +3396,11 @@ namespace das {
                 // expr->type = seT->annotation->makeIndexType(expr->subexpr, expr->index);
                 // expr->type->constant |= seT->constant;
             } else if (seT->isVectorType() || seT->isGoodArrayType() || seT->baseType==Type::tFixedArray) {
-                // arrays accept int/int64/uint/uint64; vector and fixed_array — int/uint only
-                if (seT->isGoodArrayType() ? !ixT->isIndexExt() : !ixT->isIndex()) {
+                // arrays and fixed arrays accept int/int64/uint/uint64; vector — int/uint only
+                bool indexExt = seT->isGoodArrayType() || seT->baseType==Type::tFixedArray;
+                if (indexExt ? !ixT->isIndexExt() : !ixT->isIndex()) {
                     expr->type = nullptr;
-                    error(seT->isGoodArrayType()
+                    error(indexExt
                           ? "index type must be 'int', 'int64', 'uint', or 'uint64', not '" + describeType(ixT) + "'"
                           : "index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
                           expr->index->at, CompilationError::invalid_index_type);
@@ -3475,8 +3482,8 @@ namespace das {
                 error("safe-index of fixed_array<> must be inside the 'unsafe' block", "", "",
                       expr->at, CompilationError::unsafe_fixed_array_safe_index);
             }
-            if (!ixT->isIndex()) {
-                error("index type must be 'int' or 'uint', not '" + describeType(ixT) + "'", "", "",
+            if (!ixT->isIndexExt()) {
+                error("index type must be 'int', 'int64', 'uint', or 'uint64', not '" + describeType(ixT) + "'", "", "",
                       expr->index->at, CompilationError::invalid_index_type);
                 return Visitor::visit(expr);
             }

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -1882,9 +1882,17 @@ namespace das
             auto pidx = simulateExpression(expr->index);
             auto errorMessage = context.code->allocateName(", "+expr->describe());
             if ( r2vType->baseType!=Type::none ) {
-                return context.code->makeValueNode<SimNode_AtR2V>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset, range, errorMessage);
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  return context.code->makeValueNode<SimNode_AtR2V_I64>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset, range, errorMessage);
+                case Type::tUInt64: return context.code->makeValueNode<SimNode_AtR2V_U64>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset, range, errorMessage);
+                default:            return context.code->makeValueNode<SimNode_AtR2V>(r2vType->getR2VType(), at, prv, pidx, stride, extraOffset, range, errorMessage);
+                }
             } else {
-                return context.code->makeNode<SimNode_At>(at, prv, pidx, stride, extraOffset, range, errorMessage);
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  return context.code->makeNode<SimNode_At_I64>(at, prv, pidx, stride, extraOffset, range, errorMessage);
+                case Type::tUInt64: return context.code->makeNode<SimNode_At_U64>(at, prv, pidx, stride, extraOffset, range, errorMessage);
+                default:            return context.code->makeNode<SimNode_At>(at, prv, pidx, stride, extraOffset, range, errorMessage);
+                }
             }
         }
     }
@@ -1993,7 +2001,11 @@ namespace das
                 uint32_t stride = seT->getStride();
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);
-                setE(expr, context.code->makeNode<SimNode_SafeAt>(at, prv, pidx, stride, 0, range));
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  setE(expr, context.code->makeNode<SimNode_SafeAt_I64>(at, prv, pidx, stride, 0, range)); break;
+                case Type::tUInt64: setE(expr, context.code->makeNode<SimNode_SafeAt_U64>(at, prv, pidx, stride, 0, range)); break;
+                default:            setE(expr, context.code->makeNode<SimNode_SafeAt>(at, prv, pidx, stride, 0, range)); break;
+                }
             } else if ( seT->isVectorType() ) {
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);
@@ -2049,7 +2061,11 @@ namespace das
                 uint32_t stride = seT->getStride();
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);
-                setE(expr, context.code->makeNode<SimNode_SafeAt>(at, prv, pidx, stride, 0, range));
+                switch ( expr->index->type->baseType ) {
+                case Type::tInt64:  setE(expr, context.code->makeNode<SimNode_SafeAt_I64>(at, prv, pidx, stride, 0, range)); break;
+                case Type::tUInt64: setE(expr, context.code->makeNode<SimNode_SafeAt_U64>(at, prv, pidx, stride, 0, range)); break;
+                default:            setE(expr, context.code->makeNode<SimNode_SafeAt>(at, prv, pidx, stride, 0, range)); break;
+                }
             } else if ( seT->isVectorType() && seT->ref ) {
                 auto prv = getE(expr->subexpr);
                 auto pidx = getE(expr->index);

--- a/src/simulate/simulate_fusion_at.cpp
+++ b/src/simulate/simulate_fusion_at.cpp
@@ -156,11 +156,274 @@ namespace das {
     IMPLEMENT_ANY_SETOP(__forceinline, At, Ptr, StringPtr, StringPtr);
     IMPLEMENT_ANY_SETOP(__forceinline, At, Ptr, VoidPtr, StringPtr);
 
+    struct SimNode_Op2At_I64 : SimNode_Op2At {};
+    struct SimNode_Op2At_U64 : SimNode_Op2At {};
+
+/* AtR2V_I64 SCALAR */
+
+#undef IMPLEMENT_OP2_SET_NODE_ANY
+#define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At_I64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            int64_t rr = r.subexpr->evalInt64(context); \
+            if ( rr<0 || uint64_t(rr) >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)rr, range, errorMessage); \
+            return *((CTYPE *)(pl + uint32_t(rr)*stride + offset)); \
+        } \
+        DAS_NODE(TYPE,CTYPE); \
+    };
+
+#undef IMPLEMENT_OP2_SET_NODE
+#define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At_I64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            int64_t rr = *((int64_t *)r.compute##COMPUTER(context)); \
+            if ( rr<0 || uint64_t(rr) >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)rr, range, errorMessage); \
+            return *((CTYPE *)(pl + uint32_t(rr)*stride + offset)); \
+        } \
+        DAS_NODE(TYPE,CTYPE); \
+    };
+
+#undef IMPLEMENT_OP2_SET_SETUP_NODE
+#define IMPLEMENT_OP2_SET_SETUP_NODE(result,node) \
+    auto rn = (SimNode_Op2At_I64 *)result; \
+    auto sn = (SimNode_At_I64 *)node; \
+    rn->errorMessage = sn->errorMessage; \
+    rn->stride = sn->stride; \
+    rn->offset = sn->offset; \
+    rn->range = sn->range;
+
+#undef FUSION_OP2_SUBEXPR_LEFT
+#undef FUSION_OP2_SUBEXPR_RIGHT
+#define FUSION_OP2_SUBEXPR_LEFT(CTYPE,node)     ((static_cast<SimNode_At_I64 *>(node))->value)
+#define FUSION_OP2_SUBEXPR_RIGHT(CTYPE,node)    ((static_cast<SimNode_At_I64 *>(node))->index)
+
+#include "daScript/simulate/simulate_fusion_op2_set_impl.h"
+#include "daScript/simulate/simulate_fusion_op2_set_perm.h"
+
+    IMPLEMENT_SETOP_SCALAR(AtR2V_I64);
+
+/* AtR2V_I64 VECTOR */
+
+#undef IMPLEMENT_OP2_SET_NODE_ANY
+#define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At_I64 { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            int64_t rr = r.subexpr->evalInt64(context); \
+            if ( rr<0 || uint64_t(rr) >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)rr, range, errorMessage); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl + uint32_t(rr)*stride + offset, CTYPE); \
+            return __r; \
+        } \
+    };
+
+#undef IMPLEMENT_OP2_SET_NODE
+#define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At_I64 { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            int64_t rr = *((int64_t *)r.compute##COMPUTER(context)); \
+            if ( rr<0 || uint64_t(rr) >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)rr, range, errorMessage); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl + uint32_t(rr)*stride + offset, CTYPE); \
+            return __r; \
+        } \
+    };
+
+#include "daScript/simulate/simulate_fusion_op2_set_impl.h"
+#include "daScript/simulate/simulate_fusion_op2_set_perm.h"
+
+    IMPLEMENT_SETOP_NUMERIC_VEC(AtR2V_I64);
+
+/* At_I64 */
+
+#undef IMPLEMENT_OP2_SET_NODE_ANY
+#define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At_I64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            int64_t rr = r.subexpr->evalInt64(context); \
+            if ( rr<0 || uint64_t(rr) >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)rr, range, errorMessage); \
+            return pl + uint32_t(rr)*stride + offset; \
+        } \
+        DAS_PTR_NODE; \
+    };
+
+#undef IMPLEMENT_OP2_SET_NODE
+#define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At_I64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            int64_t rr = *((int64_t *)r.compute##COMPUTER(context)); \
+            if ( rr<0 || uint64_t(rr) >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %lld of %u%s", (long long)rr, range, errorMessage); \
+            return pl + uint32_t(rr)*stride + offset; \
+        } \
+        DAS_PTR_NODE; \
+    };
+
+#undef IMPLEMENT_OP2_SET_SETUP_NODE
+#define IMPLEMENT_OP2_SET_SETUP_NODE(result,node) \
+    auto rn = (SimNode_Op2At_I64 *)result; \
+    auto sn = (SimNode_At_I64 *)node; \
+    rn->errorMessage = sn->errorMessage; \
+    rn->stride = sn->stride; \
+    rn->offset = sn->offset; \
+    rn->range = sn->range; \
+    rn->baseType = Type::none;
+
+#include "daScript/simulate/simulate_fusion_op2_set_impl.h"
+#include "daScript/simulate/simulate_fusion_op2_set_perm.h"
+
+    IMPLEMENT_ANY_SETOP(__forceinline, At_I64, Ptr, StringPtr, StringPtr);
+    IMPLEMENT_ANY_SETOP(__forceinline, At_I64, Ptr, VoidPtr, StringPtr);
+
+/* AtR2V_U64 SCALAR */
+
+#undef IMPLEMENT_OP2_SET_NODE_ANY
+#define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At_U64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            uint64_t rr = r.subexpr->evalUInt64(context); \
+            if ( rr >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)rr, range, errorMessage); \
+            return *((CTYPE *)(pl + uint32_t(rr)*stride + offset)); \
+        } \
+        DAS_NODE(TYPE,CTYPE); \
+    };
+
+#undef IMPLEMENT_OP2_SET_NODE
+#define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At_U64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            uint64_t rr = *((uint64_t *)r.compute##COMPUTER(context)); \
+            if ( rr >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)rr, range, errorMessage); \
+            return *((CTYPE *)(pl + uint32_t(rr)*stride + offset)); \
+        } \
+        DAS_NODE(TYPE,CTYPE); \
+    };
+
+#undef IMPLEMENT_OP2_SET_SETUP_NODE
+#define IMPLEMENT_OP2_SET_SETUP_NODE(result,node) \
+    auto rn = (SimNode_Op2At_U64 *)result; \
+    auto sn = (SimNode_At_U64 *)node; \
+    rn->errorMessage = sn->errorMessage; \
+    rn->stride = sn->stride; \
+    rn->offset = sn->offset; \
+    rn->range = sn->range;
+
+#undef FUSION_OP2_SUBEXPR_LEFT
+#undef FUSION_OP2_SUBEXPR_RIGHT
+#define FUSION_OP2_SUBEXPR_LEFT(CTYPE,node)     ((static_cast<SimNode_At_U64 *>(node))->value)
+#define FUSION_OP2_SUBEXPR_RIGHT(CTYPE,node)    ((static_cast<SimNode_At_U64 *>(node))->index)
+
+#include "daScript/simulate/simulate_fusion_op2_set_impl.h"
+#include "daScript/simulate/simulate_fusion_op2_set_perm.h"
+
+    IMPLEMENT_SETOP_SCALAR(AtR2V_U64);
+
+/* AtR2V_U64 VECTOR */
+
+#undef IMPLEMENT_OP2_SET_NODE_ANY
+#define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At_U64 { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            uint64_t rr = r.subexpr->evalUInt64(context); \
+            if ( rr >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)rr, range, errorMessage); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl + uint32_t(rr)*stride + offset, CTYPE); \
+            return __r; \
+        } \
+    };
+
+#undef IMPLEMENT_OP2_SET_NODE
+#define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At_U64 { \
+         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            uint64_t rr = *((uint64_t *)r.compute##COMPUTER(context)); \
+            if ( rr >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)rr, range, errorMessage); \
+            vec4f __r; \
+            DAS_LDU_WORKHORSE(__r, pl + uint32_t(rr)*stride + offset, CTYPE); \
+            return __r; \
+        } \
+    };
+
+#include "daScript/simulate/simulate_fusion_op2_set_impl.h"
+#include "daScript/simulate/simulate_fusion_op2_set_perm.h"
+
+    IMPLEMENT_SETOP_NUMERIC_VEC(AtR2V_U64);
+
+/* At_U64 */
+
+#undef IMPLEMENT_OP2_SET_NODE_ANY
+#define IMPLEMENT_OP2_SET_NODE_ANY(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_Any : SimNode_Op2At_U64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            uint64_t rr = r.subexpr->evalUInt64(context); \
+            if ( rr >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)rr, range, errorMessage); \
+            return pl + uint32_t(rr)*stride + offset; \
+        } \
+        DAS_PTR_NODE; \
+    };
+
+#undef IMPLEMENT_OP2_SET_NODE
+#define IMPLEMENT_OP2_SET_NODE(INLINE,OPNAME,TYPE,CTYPE,COMPUTEL,COMPUTER) \
+    struct SimNode_##OPNAME##_##COMPUTEL##_##COMPUTER : SimNode_Op2At_U64 { \
+        INLINE auto compute ( Context & context ) { \
+            DAS_PROFILE_NODE \
+            auto pl = l.compute##COMPUTEL(context); \
+            uint64_t rr = *((uint64_t *)r.compute##COMPUTER(context)); \
+            if ( rr >= uint64_t(range) ) context.throw_error_at(debugInfo,"index out of range, %llu of %u%s", (unsigned long long)rr, range, errorMessage); \
+            return pl + uint32_t(rr)*stride + offset; \
+        } \
+        DAS_PTR_NODE; \
+    };
+
+#undef IMPLEMENT_OP2_SET_SETUP_NODE
+#define IMPLEMENT_OP2_SET_SETUP_NODE(result,node) \
+    auto rn = (SimNode_Op2At_U64 *)result; \
+    auto sn = (SimNode_At_U64 *)node; \
+    rn->errorMessage = sn->errorMessage; \
+    rn->stride = sn->stride; \
+    rn->offset = sn->offset; \
+    rn->range = sn->range; \
+    rn->baseType = Type::none;
+
+#include "daScript/simulate/simulate_fusion_op2_set_impl.h"
+#include "daScript/simulate/simulate_fusion_op2_set_perm.h"
+
+    IMPLEMENT_ANY_SETOP(__forceinline, At_U64, Ptr, StringPtr, StringPtr);
+    IMPLEMENT_ANY_SETOP(__forceinline, At_U64, Ptr, VoidPtr, StringPtr);
+
     void createFusionEngine_at() {
         REGISTER_SETOP_SCALAR(AtR2V);
         REGISTER_SETOP_NUMERIC_VEC(AtR2V);
         (*getFusionEngine())["At"].emplace_back(new FusionPoint_Set_At_StringPtr());
         (*getFusionEngine())["At"].emplace_back(new FusionPoint_Set_At_VoidPtr());
+        REGISTER_SETOP_SCALAR(AtR2V_I64);
+        REGISTER_SETOP_NUMERIC_VEC(AtR2V_I64);
+        (*getFusionEngine())["At_I64"].emplace_back(new FusionPoint_Set_At_I64_StringPtr());
+        (*getFusionEngine())["At_I64"].emplace_back(new FusionPoint_Set_At_I64_VoidPtr());
+        REGISTER_SETOP_SCALAR(AtR2V_U64);
+        REGISTER_SETOP_NUMERIC_VEC(AtR2V_U64);
+        (*getFusionEngine())["At_U64"].emplace_back(new FusionPoint_Set_At_U64_StringPtr());
+        (*getFusionEngine())["At_U64"].emplace_back(new FusionPoint_Set_At_U64_VoidPtr());
     }
 }
 

--- a/src/simulate/simulate_visit.cpp
+++ b/src/simulate/simulate_visit.cpp
@@ -368,6 +368,50 @@ namespace das {
         V_END();
     }
 
+    SimNode * SimNode_At_I64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(At_I64);
+        V_SUB(value);
+        V_SUB(index);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_ARG(range);
+        V_END();
+    }
+
+    SimNode * SimNode_At_U64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(At_U64);
+        V_SUB(value);
+        V_SUB(index);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_ARG(range);
+        V_END();
+    }
+
+    SimNode * SimNode_SafeAt_I64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(SafeAt_I64);
+        V_SUB(value);
+        V_SUB(index);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_ARG(range);
+        V_END();
+    }
+
+    SimNode * SimNode_SafeAt_U64::visit ( SimVisitor & vis ) {
+        V_BEGIN();
+        V_OP(SafeAt_U64);
+        V_SUB(value);
+        V_SUB(index);
+        V_ARG(stride);
+        V_ARG(offset);
+        V_ARG(range);
+        V_END();
+    }
+
     SimNode * SimNode_StringBuilder::visit ( SimVisitor & vis ) {
         V_BEGIN();
         V_OP(StringBuilder);

--- a/tests/language/index_types.das
+++ b/tests/language/index_types.das
@@ -41,40 +41,60 @@ def test_pointer_index(t : T?) {
 [test]
 def test_array_index(t : T?) {
     t |> run("array index int") @(t : T?) {
-        var ar <- [10, 20, 30]
+        let ar <- [10, 20, 30]
         t |> equal(ar[0], 10)
         t |> equal(ar[2], 30)
     }
     t |> run("array index uint") @(t : T?) {
-        var ar <- [10, 20, 30]
+        let ar <- [10, 20, 30]
         t |> equal(ar[0u], 10)
         t |> equal(ar[2u], 30)
+    }
+    t |> run("array index int64") @(t : T?) {
+        let ar <- [10, 20, 30]
+        t |> equal(ar[0l], 10)
+        t |> equal(ar[2l], 30)
+    }
+    t |> run("array index uint64") @(t : T?) {
+        let ar <- [10, 20, 30]
+        t |> equal(ar[0ul], 10)
+        t |> equal(ar[2ul], 30)
     }
 }
 
 [test]
 def test_fixed_array_index(t : T?) {
     t |> run("fixed array index int") @(t : T?) {
-        var di = fixed_array(10, 20, 30)
+        let di = fixed_array(10, 20, 30)
         t |> equal(di[0], 10)
         t |> equal(di[2], 30)
     }
     t |> run("fixed array index uint") @(t : T?) {
-        var di = fixed_array(10, 20, 30)
+        let di = fixed_array(10, 20, 30)
         t |> equal(di[0u], 10)
         t |> equal(di[2u], 30)
+    }
+    t |> run("fixed array index int64") @(t : T?) {
+        let di = fixed_array(10, 20, 30)
+        t |> equal(di[0l], 10)
+        t |> equal(di[2l], 30)
+    }
+    t |> run("fixed array index uint64") @(t : T?) {
+        let di = fixed_array(10, 20, 30)
+        t |> equal(di[0ul], 10)
+        t |> equal(di[2ul], 30)
     }
 }
 
 [test]
 def test_vector_index(t : T?) {
     t |> run("vector index int") @(t : T?) {
-        var vec = int3(10, 20, 30)
+        let vec = int3(10, 20, 30)
         t |> equal(vec[0], 10)
         t |> equal(vec[2], 30)
     }
     t |> run("vector index uint") @(t : T?) {
-        var vec = int3(10, 20, 30)
+        let vec = int3(10, 20, 30)
         t |> equal(vec[0u], 10)
         t |> equal(vec[2u], 30)
     }
@@ -99,7 +119,7 @@ def test_struct_pointer_index(t : T?) {
     t |> run("struct pointer index") @(t : T?) {
         var ar = fixed_array(int2(1, 2), int2(3, 4), int2(5, 6))
         var p : int2? = unsafe(addr(ar[0]))
-        var val = unsafe(p[1])
+        let val = unsafe(p[1])
         t |> equal(val.x, 3)
         t |> equal(val.y, 4)
     }

--- a/tests/language/invalid_index_type.das
+++ b/tests/language/invalid_index_type.das
@@ -6,10 +6,10 @@ expect 30184:2, 30251, 30934    // invalid_index_type
 
 def test {
     let a : int[10]
-    a["blah"]   // index is int or uint
+    a["blah"]   // index is int, int64, uint, or uint64
     a[0]        // this one ok
     let b : array<string>
-    b["blah"]   // index is int or uint
+    b["blah"]   // index is int, int64, uint, or uint64
     b[0]        // this one ok
     let c : table<string; int>
     c["blah"]   // 30106: can't index in the constant table, use find instead

--- a/tests/long_array_table/test_dim_int64_indexing.das
+++ b/tests/long_array_table/test_dim_int64_indexing.das
@@ -1,0 +1,171 @@
+options gen2
+require dastest/testing_boost public
+
+// 64-bit index types (int64/uint64) on fixed arrays (T[N]) — mirrors
+// test_arr_int64_indexing.das / test_fusion_arr_i64.das for array<T>.
+// Covers const-literal indices (compile-time fold), variable indices
+// (SimNode_At_I64/U64 + fused variants), r2v reads, writes, argument
+// passing, and safe-at.
+
+[test]
+def test_dim_i64_index_read(t : T?) {
+    var arr : int[5]
+    for (i in range(5)) {
+        arr[i] = i * 10
+    }
+    let i64_idx : int64 = 2_l
+    t |> equal(arr[i64_idx], 20)
+}
+
+[test]
+def test_dim_u64_index_read(t : T?) {
+    var arr : int[5]
+    for (i in range(5)) {
+        arr[i] = i * 10
+    }
+    let u64_idx : uint64 = 3_ul
+    t |> equal(arr[u64_idx], 30)
+}
+
+[test]
+def test_dim_i64_index_write(t : T?) {
+    var arr : int[3]
+    let i64_idx : int64 = 1_l
+    arr[i64_idx] = 42
+    t |> equal(arr[1], 42)
+}
+
+[test]
+def test_dim_mixed_width_indexing(t : T?) {
+    var arr : int[4]
+    arr[0] = 10
+    arr[1_l] = 20
+    arr[2_ul] = 30
+    arr[uint(3)] = 40
+    t |> equal(arr[0] + arr[int64(1)] + arr[uint64(2)] + arr[uint(3)], 100)
+}
+
+[test]
+def test_dim_i64_const_idx(t : T?) {
+    // const literal 64-bit indices fold at compile time (sv_trySimulate const path)
+    var arr : int[10]
+    for (i in range(10)) {
+        arr[i] = i * 7
+    }
+    t |> equal(arr[0_l], 0)
+    t |> equal(arr[3_l], 21)
+    t |> equal(arr[9_l], 63)
+    t |> equal(arr[0_ul], 0)
+    t |> equal(arr[4_ul], 28)
+    t |> equal(arr[9_ul], 63)
+}
+
+[test]
+def test_dim_i64_via_argument(t : T?) {
+    var arr : int[8]
+    for (i in range(8)) {
+        arr[i] = i + 1000
+    }
+    t |> equal(read_at(arr, 0_l), 1000)
+    t |> equal(read_at(arr, 5_l), 1005)
+    t |> equal(read_at(arr, 7_l), 1007)
+    t |> equal(read_at_u(arr, 6_ul), 1006)
+}
+
+def read_at(arr : int[8]; idx : int64) : int {
+    return arr[idx]
+}
+
+def read_at_u(arr : int[8]; idx : uint64) : int {
+    return arr[idx]
+}
+
+[test]
+def test_dim_i64_float_value_type(t : T?) {
+    // float element exercises the AtR2V_I64 value-node path
+    var arr : float[4]
+    arr[0_l] = 1.5f
+    arr[1_l] = 2.5f
+    arr[2_l] = 3.5f
+    arr[3_l] = 4.5f
+    t |> equal(arr[0_l], 1.5f)
+    t |> equal(arr[3_l], 4.5f)
+}
+
+[test]
+def test_dim_u64_lvalue_write(t : T?) {
+    var arr : float[3]
+    arr[0_ul] = 1.0f
+    arr[1_ul] = 2.0f
+    arr[2_ul] = 3.0f
+    t |> equal(arr[0_ul] + arr[1_ul] + arr[2_ul], 6.0f)
+}
+
+[test]
+def test_dim_i64_multi_dim(t : T?) {
+    // one-peel rule: each [] peels one fixed-array level; 64-bit index at both levels
+    var arr : int[2][3]
+    for (i in range(2)) {
+        for (j in range(3)) {
+            arr[i][j] = i * 100 + j
+        }
+    }
+    let ii : int64 = 1_l
+    let jj : uint64 = 2_ul
+    t |> equal(arr[ii][jj], 102)
+    t |> equal(arr[1_l][0], 100)
+    t |> equal(arr[0][2_ul], 2)
+}
+
+[test]
+def test_dim_i64_int64_value_type(t : T?) {
+    // 64-bit element type + 64-bit index
+    var arr : int64[4]
+    let idx : int64 = 2_l
+    arr[idx] = 5_000_000_000_l
+    t |> equal(arr[2], 5_000_000_000_l)
+    t |> equal(arr[idx], 5_000_000_000_l)
+}
+
+[test]
+def test_dim_i64_safe_at(t : T?) {
+    var arr : int[5]
+    for (i in range(5)) {
+        arr[i] = i * 10
+    }
+    let good : int64 = 3_l
+    let bad : int64 = 99_l
+    let neg : int64 = -1_l
+    var val : int
+    unsafe {
+        val = arr?[good] ?? -1
+    }
+    t |> equal(val, 30)
+    unsafe {
+        val = arr?[bad] ?? -1
+    }
+    t |> equal(val, -1)
+    unsafe {
+        val = arr?[neg] ?? -1
+    }
+    t |> equal(val, -1)
+}
+
+[test]
+def test_dim_u64_safe_at(t : T?) {
+    var arr : int[5]
+    for (i in range(5)) {
+        arr[i] = i * 10
+    }
+    let good : uint64 = 4_ul
+    let bad : uint64 = 100_ul
+    var val : int
+    unsafe {
+        val = arr?[good] ?? -1
+    }
+    t |> equal(val, 40)
+    unsafe {
+        val = arr?[bad] ?? -1
+    }
+    t |> equal(val, -1)
+}


### PR DESCRIPTION
`T[N]` indexing was gated to `int`/`uint` (`error[30184]`) while `array<T>` already accepts the full `int`/`int64`/`uint`/`uint64` set — generic code indexing with 64-bit loop variables had to cast at every fixed-array site. This closes the gap, mirroring the dynamic-array `ArrayAt_I64/U64` sweep.

## Changes per tier

- **Typer** (`ast_infer_type.cpp`): the `ExprAt` fixed-array branch moves ahead of the shared `isIndex()` gate and widens to `isIndexExt()`; both `ExprSafeAt` fixed-array gates (direct and through-pointer) widen the same way. Vectors deliberately stay `int`/`uint`, and diagnostics for all other types are unchanged (`invalid_index_type.das` expect-test passes as-is).
- **Interpreter** (`simulate_nodes.h`, `simulate_visit.h/.cpp`, `ast_simulate.cpp`): new `SimNode_At_I64/U64`, `SimNode_SafeAt_I64/U64`, `SimNode_AtR2V_I64/U64<TT>` nodes plus index-type dispatch. The constant-index fold path was already 64-bit-aware.
- **Fusion** (`simulate_fusion_at.cpp`): full `At_I64/U64` + `AtR2V_I64/U64` fused permutation sets (scalar, numeric-vec, StringPtr/VoidPtr set-ops), exact mirror of the `ArrayAt_I64/U64` pattern in `simulate_fusion_at_array.cpp`.
- **AOT** (`aot.h`): `TDim` gains `int64_t`/`uint64_t` `operator()` and `safe_index` overloads. The emitter is index-type-agnostic — no `aot_cpp.das` change.
- **JIT**: no emitter change needed — `check_range` sign/zero-extends by index width and `build_array_index` GEPs at the index's width, so the existing codegen already handles 64-bit indexes once the typer admits them. No `LLVM_JIT_CODEGEN_VERSION` bump.

## Tests

- New `tests/long_array_table/test_dim_int64_indexing.das` (12 cases): read/write, compile-time const-fold (incl. `uint64` literals), argument passing, `float`/`int64` element types, multi-dim one-peel with mixed 64-bit indexes, safe-at in-range / out-of-range / negative for both `int64` and `uint64`.
- `tests/language/index_types.das`: 64-bit subtests added for both dynamic and fixed arrays (plus LINT003 `var`→`let` cleanup in the file).

## Validation

- Interp: full suite green (incl. fixed_array 114/114, language 1080/1080, long_array_table 77/77).
- AOT: `test_aot` full sweep — **10024/10024 green**.
- JIT: new test file green under `-jit --jit-opt-level=3`; jit_tests 296/296.
- Lint zero-warning on changed files, formatter clean.

Local-only note: the full JIT sweep can't complete on my box due to a **pre-existing** environment crash (0xE06D7363 when a lock-panic thrown from a runtime helper unwinds through jitted frames, e.g. `table_operations.das` "table lock panic"). A/B-verified pre-existing: pristine master `ac014be8e` built in the same build dir crashes identically. CI's JIT lanes are the oracle here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)