### PR TITLE
jit: unwind tables on emitted functions when the host uses C++ exceptions

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -182,7 +182,7 @@ get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_defau
         group_by_regex("Binary serializer", mod, %regex~(binary_load|binary_save)$%%),
         group_by_regex("Path and command line", mod, %regex~(get_command_line_arguments|with_argv)$%%),
         group_by_regex("Time and date", mod, %regex~(get_time_usec|ref_time_ticks|get_clock|get_time_nsec|mktime|iso8601_now|format_time)$%%),
-        group_by_regex("Platform queries", mod, %regex~(get_context_share_counter|das_is_dll_build|is_standalone_exe|get_platform_name|get_running_platform_name|get_cross_platform_name|get_architecture_name)$%%),
+        group_by_regex("Platform queries", mod, %regex~(get_context_share_counter|das_is_dll_build|das_is_exceptions_enabled|is_standalone_exe|get_platform_name|get_running_platform_name|get_cross_platform_name|get_architecture_name)$%%),
         group_by_regex("String formatting", mod, %regex~(fmt)$%%),
         group_by_regex("Argument consumption", mod, %regex~(consume_argument)$%%),
         group_by_regex("Lock checking", mod, %regex~(lock_count)$%%),

--- a/doc/source/stdlib/handmade/function-builtin-das_is_exceptions_enabled-0x27ce9197920821b5.rst
+++ b/doc/source/stdlib/handmade/function-builtin-das_is_exceptions_enabled-0x27ce9197920821b5.rst
@@ -1,0 +1,1 @@
+Reports whether the runtime was built with DAS_ENABLE_EXCEPTIONS=1, i.e. panics propagate as C++ exceptions rather than longjmp. The JIT consults this to decide whether emitted functions need unwind tables.

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -4,6 +4,7 @@
 
 namespace das {
     DAS_API bool das_is_dll_build();
+    DAS_API bool das_is_exceptions_enabled();
     DAS_API bool is_in_aot();
     DAS_API void set_aot();
     DAS_API void reset_aot();

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -412,6 +412,14 @@ def private wasm_target_features() : string {
 def public LLVMAddFunctionWithType(mod : LLVMModuleRef; name : string; typ : LLVMTypeRef) {
     var rv = LLVMAddFunction(mod, name, typ)
     g_fn_types[name] = typ
+    // uwtable(async): -O3 function-attrs infers `nounwind` through the runtime-helper
+    // attributes, and Win64 codegen then omits .pdata for provably-nounwind functions —
+    // a C++-EH panic (DAS_ENABLE_EXCEPTIONS=1 host) crossing such a frame kills the
+    // process. uwtable forces the tables regardless; ignored on declarations. Skipped
+    // on longjmp hosts (tables dead weight there); folded into the DLL cache key.
+    if (das_is_exceptions_enabled()) {
+        rv |> LLVMAddAttributeToFunction(LLVMCreateEnumAttribute(g_ctx, LLVMGetEnumAttributeKindForName("uwtable"), 2ul))
+    }
     return rv
 }
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x2eul   // exp(floatN) → inline ggml_v_expf polynomial
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x2ful   // uwtable on all emitted functions (EH through JIT frames)
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
@@ -127,6 +127,9 @@ def jit_dll_basename(funcs : array<FunctionPtr>; opt_level : int; size_level : i
     h = (h ^ (emit_prologue ? 1ul : 0ul)) * JIT_FNV_PRIME
     h = (h ^ (debug_info ? 1ul : 0ul)) * JIT_FNV_PRIME
     h = (h ^ (g_jit_fast_math ? 1ul : 0ul)) * JIT_FNV_PRIME   // fast-math changes codegen → distinct cache
+    // EH hosts get uwtable on every function, longjmp hosts don't — a table-less DLL
+    // cached by a longjmp host must never cache-hit on an EH host (panic would crash).
+    h = (h ^ (das_is_exceptions_enabled() ? 1ul : 0ul)) * JIT_FNV_PRIME
     return "{h}"
 }
 

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1669,6 +1669,14 @@ namespace das
         #endif
     }
 
+    bool das_is_exceptions_enabled() {
+        #if DAS_ENABLE_EXCEPTIONS
+        return true;
+        #else
+        return false;
+        #endif
+    }
+
     bool is_in_aot ( ) {
         return daScriptEnvironment::getBound() ? daScriptEnvironment::getBound()->g_isInAot : false;
     }
@@ -2406,6 +2414,8 @@ namespace das
         // migrate data
         addExtern<DAS_BIND_FUN(das_is_dll_build)>(*this, lib, "das_is_dll_build",
             SideEffects::worstDefault, "das_is_dll_build");
+        addExtern<DAS_BIND_FUN(das_is_exceptions_enabled)>(*this, lib, "das_is_exceptions_enabled",
+            SideEffects::worstDefault, "das_is_exceptions_enabled");
         addExtern<DAS_BIND_FUN(is_in_aot)>(*this, lib, "is_in_aot",
             SideEffects::worstDefault, "is_in_aot");
         addExtern<DAS_BIND_FUN(set_aot)>(*this, lib, "set_aot",


### PR DESCRIPTION
## Problem

On a host built with `DAS_ENABLE_EXCEPTIONS=1`, a panic thrown from a JIT runtime helper under `try/recover` kills the process with unhandled `0xE06D7363` instead of being recovered. Canonical repro: insert into a locked table inside a `get` block — `tests/language/table_operations.das` "table lock panic" under `-jit` (dies with no dastest summary).

## Root cause

At `--jit-opt-level=3`, LLVM's function-attrs pass infers `nounwind` for jitted functions whose calls are all marked `nounwind` (the emitter stamps runtime-helper declarations and call sites that way — including table helpers that do panic). Win64 codegen then **omits `.pdata`/`.xdata` for provably-nounwind functions**.

Proof from `llvm-readobj --unwind` on the cached DLL for the repro: the jitted `insert` instance, `to_table_move`, and the `get`-block had **no RuntimeFunction entries**, while `main` / `get` / the try-block kept theirs (they contain indirect calls — `builtin_try_recover` glob, block pointers — which block the inference). During C++ exception dispatch the unwinder hits the table-less jitted frame, its leaf-frame fallback lands on a garbage "return address", no handler is ever found → unhandled. At `--jit-opt-level=0` (no inference) the identical probe passes — mechanism confirmed.

Why CI never sees it: EH-flavor Windows hosts are the `DAS_LLVM_DISABLED=ON` builds (CMakeLists.txt:78-83) — which still JIT, because dasLLVM is a dynamically-loaded module. All CI JIT lanes are longjmp-flavor (`DAS_ENABLE_EXCEPTIONS=0`), where `longjmp` skips unwinding entirely and missing tables never matter.

## Fix

- New builtin `das_is_exceptions_enabled()` (beside `das_is_dll_build`) reports the runtime's `DAS_ENABLE_EXCEPTIONS` flavor.
- When true, `LLVMAddFunctionWithType` — the single choke point all JIT function creation goes through — stamps `uwtable`(async) on every function. `uwtable` is orthogonal to `nounwind`: the inference keeps its optimization value, codegen just always emits the tables. Also restores Win64 ABI conformance and makes debugger/profiler stack walks work through JIT frames. Harmless no-op on declarations.
- longjmp hosts skip the tables entirely (dead weight there), so their codegen is byte-identical to before this PR.
- The flag folds into the JIT DLL cache key (beside `g_jit_fast_math`) — a table-less DLL cached by a longjmp host can never cache-hit on an EH host. `LLVM_JIT_CODEGEN_VERSION` bumped.

## Performance

Zero runtime cost: unwind tables are cold metadata consulted only when something walks the stack; no instructions are added to function bodies, and the optimization pipeline is unchanged (`nounwind` retained). Measured on the repro DLL: total size byte-identical, object +264 bytes (~2%) of pure `.pdata`/`.xdata`.

## Validation (on an EH-flavor host — the config that crashes)

- Minimal probe: crash before → `failed=true` exit 0 after; DLL unwind coverage complete (true leaves legitimately carry no entry, per ABI).
- `tests/language/table_operations.das` under `-jit`: 8/8 including "table lock panic".
- Full JIT sweep: **10650 tests, 10650 passed, 0 failed, 0 errors** — first fully-green `-jit` sweep this configuration has ever produced (it previously died mid-sweep).
- Full preflight: 13 passed, 0 failed (tests-jit gate green); AOT suite green (10028/10028).

## Note

The `CMakeLists.txt` WIN32 gate comment ("FOR NOW DISABLE EXCEPTIONS AND USE SETJMP/LONGJUMP, IF JIT IS ENABLED") is now stale in spirit — EH+JIT is a working combination after this fix. Left untouched here; whether to revisit the default EH flavor is a separate policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)