### PR TITLE
dasSpirv: 4 emitter fixes + the one-source path tracer showcase (examples/vulkan)

### DIFF
--- a/examples/vulkan/one_source_path_tracer/.das_package
+++ b/examples/vulkan/one_source_path_tracer/.das_package
@@ -1,0 +1,24 @@
+options gen2
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("one-source-path-tracer")
+    package_description("One source, four engines: the same daslang path tracer on CPU interp, CPU JIT + threads, dasSpirv compute, and hardware ray tracing")
+    package_author("borisbat")
+    package_license("MIT")
+    package_tag("graphics")
+    package_tag("vulkan")
+    package_tag("raytracing")
+}
+
+[export]
+def dependencies(version : string) {
+    require_package("dasVulkan")
+    require_package("dasImgui")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/examples/vulkan/one_source_path_tracer/README.md
+++ b/examples/vulkan/one_source_path_tracer/README.md
@@ -1,0 +1,65 @@
+# One source, four engines — a daslang path tracer
+
+The same daslang functions — scene, camera, RNG, materials, the NEE integrator — run on four
+execution tiers, live-switchable from an ImGui panel:
+
+| Engine | What runs | 512², measured on an RTX 3060 Ti box |
+|---|---|---|
+| CPU — 1 thread | `pt_core` in the interpreter (or JIT with `-jit`) | ~0.03 / ~0.4 Mpaths/s |
+| CPU — band threads | the same rows split across `new_thread` bands | ~0.1 / ~1.6 Mpaths/s |
+| GPU — dasSpirv compute | the same functions lowered to a SPIR-V compute kernel | ~110 Mpaths/s |
+| GPU — hardware ray tracing | raygen/miss/closest-hit, also lowered by dasSpirv; hardware traversal replaces the software intersector | ~330 Mpaths/s |
+
+No GLSL anywhere. The scene lives in `@ssbo` globals the CPU fills and reads directly while the GPU
+binds them as storage buffers, and the hardware-RT BLAS is built from the same arrays. The CPU and
+compute engines produce pixel-identical images (same PCG RNG streams); hardware RT differs only at
+watertight-traversal edges.
+
+## Files
+
+- `pt_core.das` — the shared core: Cornell scene, Möller–Trumbore intersector, PCG RNG, NEE + mirror
+  integrator, tonemap. Written to the dasSpirv lowering rules (vector params, no recursion) so every
+  function runs on all four tiers verbatim.
+- `pt_shaders.das` — the GPU entry points: the compute megakernel, the RT stages (payload carries
+  t + primitive id; all shading stays in raygen, reusing the shared functions), and the display quad.
+- `main.das` — the app: vulkan_imgui_app harness, the band-thread state machine, the engine stacks,
+  and the imgui_boost_v2 panel.
+- `pt_reference.das` — headless CPU renderer, writes `pt_reference.png` (the pixel-parity oracle).
+
+## Running
+
+The example depends on [dasVulkan](https://github.com/borisbat/dasVulkan) and
+[dasImgui](https://github.com/borisbat/dasImgui), declared in `.das_package`. Install once:
+
+```
+cd examples/vulkan/one_source_path_tracer
+daslang ../../../utils/daspkg/main.das -- install
+```
+
+Then:
+
+```
+daslang -project_root . main.das          # interpreter CPU tiers
+daslang -jit -project_root . main.das     # JIT CPU tiers
+```
+
+Click the engine radios; watch the samples counter and Mpaths/s. **P** saves a screenshot. Flags:
+`--engine=<Single|Threads|Compute|RayTrace>`, `--max-frames=N` (renders N frames, writes
+`one_source_path_tracer_proof.png`, exits — for smoke runs and screenshots). Hardware RT needs
+`VK_KHR_ray_tracing_pipeline`; without it the radio reports unavailable and the other three run.
+
+## Live control
+
+The UI is imgui_boost_v2, so under daslang-live every widget is drivable:
+
+```
+daslang-live -project_root . main.das
+curl -X POST -d '{"name":"imgui_force_set","args":{"target":"PT_WIN/ENGINE","value":3}}' localhost:9090/command
+curl -X POST -d '{"name":"imgui_click","args":{"target":"PT_WIN/ENGINE#1"}}' localhost:9090/command
+curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command
+curl -X POST -d '{"name":"screenshot","args":{"file":"shot.png"}}' localhost:9090/command
+```
+
+`ENGINE` values: 0 = 1 thread, 1 = band threads, 2 = compute, 3 = hardware RT; the threads slider is
+`PT_WIN/THREADS`. Editing `pt_core.das` and reloading re-lowers the shaders — CPU and GPU pick up the
+change together.

--- a/examples/vulkan/one_source_path_tracer/main.das
+++ b/examples/vulkan/one_source_path_tracer/main.das
@@ -1,0 +1,685 @@
+options gen2
+options indenting = 4
+options solid_context
+
+// One source, four engines. The SAME pt_core path tracer — scene, camera, RNG, materials,
+// integrator — runs on four execution tiers, live-switchable from an imgui_boost_v2 panel rendered
+// by the 100%-daslang Vulkan backend:
+//
+//   CPU 1 thread   one background band thread (interpreter, or JIT when launched with -jit)
+//   CPU N threads  band threads over the same rows (path_tracer_lab pattern)
+//   GPU compute    the same functions lowered to a SPIR-V compute kernel by dasSpirv
+//   GPU ray trace  hardware RT pipeline (VK_KHR_ray_tracing_pipeline): raygen/miss/closest-hit
+//                  also lowered by dasSpirv; hardware traversal replaces the software intersector,
+//                  the shading/NEE/RNG code is shared verbatim (harness_rt_supported-gated)
+//
+// The vulkan_imgui_app harness owns the window/device/swapchain and wires the live stack, so the
+// app is fully drivable under daslang-live: `imgui_snapshot` dumps the widget state,
+// `imgui_force_set {"target":"PT_WIN/ENGINE","value":3}` switches to hardware RT,
+// `imgui_force_set {"target":"PT_WIN/THREADS","value":16}` moves the thread slider, and
+// `screenshot {"file":"..."}` captures the frame.
+//
+// Run (after `daslang ../../../utils/daspkg/main.das -- install` in this directory):
+//   daslang -project_root . main.das            # interpreter CPU tiers
+//   daslang -jit -project_root . main.das       # JIT CPU tiers
+// Live:
+//   daslang-live -project_root . main.das
+// Keys: P = screenshot. Flags: --engine=<Single|Threads|Compute|RayTrace>, --max-frames=N (writes
+// one_source_path_tracer_proof.png before exiting; for CI-less smoke and the README shots).
+
+require vulkan/vulkan_imgui_app
+require vulkan/vulkan_reflect
+require daslib/safe_addr
+require daslib/jobque_boost
+require daslib/clargs
+require math
+require strings
+
+require pt_shaders
+
+let {
+    TRACE_W = 512
+    TRACE_H = 512
+    WIN_W = 960
+    WIN_H = 640
+    MAX_BANDS = 16
+}
+
+enum Engine {
+    Single
+    Threads
+    Compute
+    RayTrace
+}
+
+[CommandLineArgs]
+struct Args {
+    @clarg_doc = "Starting engine"
+    engine : Engine
+    @clarg_doc = "Exit after N presented frames, writing one_source_path_tracer_proof.png (0 = run until closed)"
+    max_frames : int
+    @clarg_short = "?"
+    @clarg_name = "show-help"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+// ===== CPU engines: band threads over the shared core (path_tracer_lab state machine) =====
+
+var g_mode = int(Engine.Single)
+var g_epoch = 0
+var g_render_epoch = -1
+var g_pass = -1                          // last completed pass (accumulated sample count - 1)
+var g_max_threads = 4
+var g_accum : array<float3>              // CPU radiance accumulation
+var g_pixels : array<uint8>              // CPU tonemapped RGBA (upload source)
+var g_cpu_dirty = false                  // a completed CPU pass awaits upload
+var g_threads_status : JobStatus?
+var g_threads_epoch = 0
+var g_threads_t0 = 0l
+var g_last_pass_us = 0
+var g_smooth_pps = 0.0lf                 // smoothed Mpaths/s
+
+// One band: trace rows [ymin, ymax) for pass `my_pass`, tonemap them into the shared pixel buffer,
+// bail per-row if the epoch moves (engine switch). Runs in its own context — own pt_core globals.
+def cpu_band(var pacc : array<float3>?; var ppix : array<uint8>?; var pepoch : int?;
+             my_epoch, my_pass, ymin, ymax : int) {
+    pt_init_scene()
+    let inv = 1.0 / float(my_pass + 1)
+    for (y in range(ymin, ymax)) {
+        if (*pepoch != my_epoch) {
+            break
+        }
+        unsafe {
+            pt_render_rows(my_pass, TRACE_W, TRACE_H, y, y + 1, *pacc)
+        }
+        for (x in range(TRACE_W)) {
+            let i = y * TRACE_W + x
+            let c = pt_tonemap(unsafe((*pacc)[i]) * inv)
+            unsafe {
+                (*ppix)[i * 4 + 0] = uint8(int(clamp(c.x, 0.0, 1.0) * 255.0 + 0.5))
+                (*ppix)[i * 4 + 1] = uint8(int(clamp(c.y, 0.0, 1.0) * 255.0 + 0.5))
+                (*ppix)[i * 4 + 2] = uint8(int(clamp(c.z, 0.0, 1.0) * 255.0 + 0.5))
+                (*ppix)[i * 4 + 3] = uint8(255)
+            }
+        }
+    }
+}
+
+def start_cpu_pass(my_pass, bands : int) {
+    var pacc : array<float3>?
+    var ppix : array<uint8>?
+    var pepoch : int?
+    unsafe {
+        pacc = addr(g_accum)
+        ppix = addr(g_pixels)
+        pepoch = addr(g_epoch)
+    }
+    g_threads_t0 = ref_time_ticks()
+    g_threads_epoch = g_epoch
+    var status = job_status_create()
+    status |> append(bands)
+    g_threads_status = status
+    let chunk = (TRACE_H + bands - 1) / bands
+    let my_epoch = g_epoch
+    for (c in range(bands)) {
+        let ymin = c * chunk
+        let ymax = min((c + 1) * chunk, TRACE_H)
+        var st = status
+        new_thread() <| @capture(= pacc, = ppix, = pepoch, = my_epoch, = my_pass, = ymin, = ymax, = st) {
+            cpu_band(pacc, ppix, pepoch, my_epoch, my_pass, ymin, ymax)
+            st |> notify_and_release
+        }
+    }
+}
+
+def note_pass_done {
+    g_last_pass_us = get_time_usec(g_threads_t0)
+    let inst = double(TRACE_W * TRACE_H) / double(max(g_last_pass_us, 1))   // paths/us == Mpaths/s
+    g_smooth_pps = g_smooth_pps == 0.0lf ? inst : g_smooth_pps * 0.85lf + inst * 0.15lf
+}
+
+// Drain an in-flight CPU pass and apply the epoch reset. Returns false while a pass from a dead
+// epoch is still winding down — no engine may dispatch until the reset has actually happened.
+def advance_ready : bool {
+    if (g_threads_status != null) {
+        if (!g_threads_status.isReady) {
+            return false
+        }
+        if (g_threads_epoch == g_epoch) {
+            g_pass++
+            g_cpu_dirty = true
+            note_pass_done()
+        }
+        var st = g_threads_status
+        unsafe {
+            job_status_remove(st)
+        }
+        g_threads_status = null
+    }
+    if (g_render_epoch != g_epoch) {
+        g_render_epoch = g_epoch
+        g_pass = -1
+        for (i in range(TRACE_W * TRACE_H)) {
+            g_accum[i] = float3(0.0)
+        }
+    }
+    return true
+}
+
+// ===== GPU resources (globals — daslang-live reloads keep them; shutdown() deletes them) =====
+
+struct PtImage {
+    image : Image
+    memory : DeviceMemory
+    view : ImageView
+}
+
+def finalize(var pi : PtImage) {
+    delete pi.view
+    delete pi.image
+    delete pi.memory
+}
+
+def make_storage_image(device : Device; phys : VkPhysicalDevice; w, h : int; fmt : VkFormat;
+                       sampled, transfer_dst : bool) : PtImage {
+    let dev = boost_value_to_vk(device)
+    var ici = ImageCreateInfo(imageType = VkImageType._2D, format = fmt, mipLevels = 1u,
+        arrayLayers = 1u, tiling = VkImageTiling.OPTIMAL, initialLayout = VkImageLayout.UNDEFINED)
+    ici.extent.width = uint(w)
+    ici.extent.height = uint(h)
+    ici.extent.depth = 1u
+    ici.samples._1 = true
+    ici.usage.storage = true
+    ici.usage.sampled = sampled
+    ici.usage.transfer_dst = transfer_dst
+    var inscope image <- create_image(device, ici)
+    var ireq : VkMemoryRequirements
+    vkGetImageMemoryRequirements(dev, boost_value_to_vk(image), ireq)
+    var iwant : VkMemoryPropertyFlags
+    iwant.device_local = true
+    let imai = MemoryAllocateInfo(allocationSize = ireq.size,
+        memoryTypeIndex = find_memory_type(phys, ireq.memoryTypeBits, iwant))
+    var inscope imem <- allocate_memory(device, imai)
+    vk_check(vkBindImageMemory(dev, boost_value_to_vk(image), boost_value_to_vk(imem), 0ul), null)
+    var vci = ImageViewCreateInfo(image = weak_copy(image), viewType = VkImageViewType._2D, format = fmt)
+    vci.subresourceRange.aspectMask.color = true
+    vci.subresourceRange.levelCount = 1u
+    vci.subresourceRange.layerCount = 1u
+    var inscope view <- create_image_view(device, vci)
+    return <- PtImage(image <- image, memory <- imem, view <- view)
+}
+
+//! layouts + pool + set + pipeline for one engine stack (compute or RT — same descriptor surface,
+//! the RT stack adds the TLAS at binding 4 and builds its pipeline/SBT separately)
+struct EngineStack {
+    set_layouts : array<DescriptorSetLayout>
+    pipe_layout : PipelineLayout
+    desc_pool : DescriptorPool
+    dsets : array<DescriptorSet>
+    pipeline : Pipeline
+}
+
+def finalize(var s : EngineStack) {
+    delete s.pipeline
+    delete s.desc_pool
+    delete s.pipe_layout
+    delete s.set_layouts
+    delete s.dsets
+}
+
+def write_common_bindings(device : Device; dset : DescriptorSet; accum, disp : PtImage;
+                          vbuf, tbuf : HostBuffer) {
+    var writes : array<WriteDescriptorSet>
+    var w0 = WriteDescriptorSet(dstSet = weak_copy(dset), dstBinding = 0u,
+        descriptorType = VkDescriptorType.STORAGE_IMAGE, descriptorCount = 1u)
+    w0.pImageInfo |> push(DescriptorImageInfo(imageView = weak_copy(accum.view), imageLayout = VkImageLayout.GENERAL))
+    writes |> emplace(w0)
+    var w1 = WriteDescriptorSet(dstSet = weak_copy(dset), dstBinding = 1u,
+        descriptorType = VkDescriptorType.STORAGE_IMAGE, descriptorCount = 1u)
+    w1.pImageInfo |> push(DescriptorImageInfo(imageView = weak_copy(disp.view), imageLayout = VkImageLayout.GENERAL))
+    writes |> emplace(w1)
+    var w2 = WriteDescriptorSet(dstSet = weak_copy(dset), dstBinding = 2u,
+        descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+    w2.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(vbuf.buffer), range_ = vbuf.size))
+    writes |> emplace(w2)
+    var w3 = WriteDescriptorSet(dstSet = weak_copy(dset), dstBinding = 3u,
+        descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+    w3.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(tbuf.buffer), range_ = tbuf.size))
+    writes |> emplace(w3)
+    let no_copies : array<CopyDescriptorSet>
+    update_descriptor_sets(device, writes, no_copies)
+}
+
+// ===== fullscreen display quad (letterboxed, samples the display image) =====
+
+def build_quad_pipeline(device : Device; render_pass : RenderPass; layout : PipelineLayout;
+                        vert, frag : ShaderModule) : Pipeline {
+    var stages : array<VkPipelineShaderStageCreateInfo>
+    stages |> resize(2)
+    stages[0] = VkPipelineShaderStageCreateInfo()
+    stages[0].stage.vertex = true
+    stages[0].module_ = boost_value_to_vk(vert)
+    stages[0].pName = "main"
+    stages[1] = VkPipelineShaderStageCreateInfo()
+    stages[1].stage.fragment = true
+    stages[1].module_ = boost_value_to_vk(frag)
+    stages[1].pName = "main"
+
+    var vinput = VkPipelineVertexInputStateCreateInfo()   // no vertex input: gl_VertexIndex drives it
+    var iasm = VkPipelineInputAssemblyStateCreateInfo()
+    iasm.topology = VkPrimitiveTopology.TRIANGLE_LIST
+    var vpstate = VkPipelineViewportStateCreateInfo()
+    vpstate.viewportCount = 1u
+    vpstate.scissorCount = 1u
+    var raster = VkPipelineRasterizationStateCreateInfo()
+    raster.polygonMode = VkPolygonMode.FILL
+    raster.frontFace = VkFrontFace.COUNTER_CLOCKWISE
+    raster.lineWidth = 1.0f
+    var msaa = VkPipelineMultisampleStateCreateInfo()
+    msaa.rasterizationSamples._1 = true
+    var blend_att : VkPipelineColorBlendAttachmentState
+    blend_att.colorWriteMask.r = true
+    blend_att.colorWriteMask.g = true
+    blend_att.colorWriteMask.b = true
+    blend_att.colorWriteMask.a = true
+    var blend = VkPipelineColorBlendStateCreateInfo()
+    blend.attachmentCount = 1u
+    var dyn_states : array<VkDynamicState>
+    dyn_states |> push(VkDynamicState.VIEWPORT)
+    dyn_states |> push(VkDynamicState.SCISSOR)
+    var dynstate = VkPipelineDynamicStateCreateInfo()
+    dynstate.dynamicStateCount = 2u
+
+    var gp = VkGraphicsPipelineCreateInfo()
+    gp.stageCount = 2u
+    gp.layout = boost_value_to_vk(layout)
+    gp.renderPass = boost_value_to_vk(render_pass)
+    var h : VkPipeline
+    unsafe {
+        dynstate.pDynamicStates = addr(dyn_states[0])
+        gp.pDynamicState = addr(dynstate)
+        blend.pAttachments = addr(blend_att)
+        gp.pStages = addr(stages[0])
+        gp.pVertexInputState = addr(vinput)
+        gp.pInputAssemblyState = addr(iasm)
+        gp.pViewportState = addr(vpstate)
+        gp.pRasterizationState = addr(raster)
+        gp.pMultisampleState = addr(msaa)
+        gp.pColorBlendState = addr(blend)
+        vk_check(vkCreateGraphicsPipelines(boost_value_to_vk(device), null, 1u, addr(gp), null, addr(h)), null)
+    }
+    delete dyn_states
+    delete stages
+    var b = vk_value_to_boost(h)
+    b._needs_delete = true
+    b._device = unsafe(reinterpret<uint64>(boost_value_to_vk(device)))
+    return <- b
+}
+
+// ===== app state (globals so daslang-live reloads keep them) =====
+
+var g_rt_ok = false
+var g_max_frames = 0
+var g_vbuf : HostBuffer
+var g_tbuf : HostBuffer
+var g_staging : HostBuffer
+var g_accum_img : PtImage
+var g_disp_img : PtImage
+var g_comp : EngineStack
+var g_rt : EngineStack
+var g_blas : AccelStructure
+var g_tlas : AccelStructure
+var g_sbt : ShaderBindingTable
+var g_sampler : Sampler
+var g_quad : EngineStack
+
+[export]
+def init() {
+    var args_r <- parse_args(type<Args>)
+    if (args_r |> is_err) {
+        print("error: {args_r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Args>), "one_source_path_tracer")
+        request_exit()
+        return
+    }
+    let args <- args_r |> move_unwrap
+    if (args.help) {
+        print_help(get_command_info(type<Args>), "one_source_path_tracer")
+        request_exit()
+        return
+    }
+    g_mode = int(args.engine)
+    g_max_frames = args.max_frames
+
+    harness_init("one source, four engines — daslang path tracer", WIN_W, WIN_H, true)
+    let device = harness_device()
+    let phys = harness_phys()
+    let queue = harness_queue()
+    let pool = harness_pool()
+    g_rt_ok = harness_rt_supported()
+    if (!g_rt_ok && g_mode == int(Engine.RayTrace)) {
+        g_mode = int(Engine.Compute)
+    }
+    ENGINE.value = g_mode
+
+    // ----- shared scene + images: CPU fills the globals, GPU binds the same arrays -----
+    pt_init_scene()
+    g_accum |> resize(TRACE_W * TRACE_H)
+    g_pixels |> resize(TRACE_W * TRACE_H * 4)
+    var buf_usage : VkBufferUsageFlags
+    buf_usage.storage_buffer = true
+    g_vbuf <- create_host_buffer_from_bytes(device, phys, buf_usage, pt_verts)
+    g_tbuf <- create_host_buffer_from_bytes(device, phys, buf_usage, pt_tris)
+    var stage_usage : VkBufferUsageFlags
+    stage_usage.transfer_src = true
+    g_staging <- create_host_buffer(device, phys, uint64(TRACE_W * TRACE_H * 4), stage_usage)
+    g_accum_img <- make_storage_image(device, phys, TRACE_W, TRACE_H, VkFormat.R32G32B32A32_SFLOAT, false, false)
+    g_disp_img <- make_storage_image(device, phys, TRACE_W, TRACE_H, VkFormat.R8G8B8A8_UNORM, true, true)
+
+    // both storage images live in GENERAL forever: written by compute/RT, copied into from the CPU
+    // staging buffer, sampled by the display quad — every engine submit is queue-synchronous
+    run_cmd_sync(device, pool, queue) $(cmd) {
+        let none : VkAccessFlags
+        var shader_rw : VkAccessFlags
+        shader_rw.shader_read = true
+        shader_rw.shader_write = true
+        var top : VkPipelineStageFlags
+        top.top_of_pipe = true
+        var comp_stage : VkPipelineStageFlags
+        comp_stage.compute_shader = true
+        transition_image(cmd, g_accum_img.image, VkImageLayout.UNDEFINED, VkImageLayout.GENERAL, none, shader_rw, top, comp_stage)
+        transition_image(cmd, g_disp_img.image, VkImageLayout.UNDEFINED, VkImageLayout.GENERAL, none, shader_rw, top, comp_stage)
+    }
+
+    // ----- compute engine stack -----
+    {
+        var reflections <- [decode_reflection(pt_compute_spv_reflect)]
+        g_comp.set_layouts <- build_descriptor_set_layouts(device, reflections)
+        g_comp.pipe_layout <- build_pipeline_layout(device, g_comp.set_layouts, reflections)
+        delete reflections
+        var dpci = DescriptorPoolCreateInfo(maxSets = 1u,
+            pPoolSizes <- [
+                DescriptorPoolSize(type_ = VkDescriptorType.STORAGE_IMAGE, descriptorCount = 2u),
+                DescriptorPoolSize(type_ = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 2u)
+            ])
+        g_comp.desc_pool <- create_descriptor_pool(device, dpci)
+        var dsai : DescriptorSetAllocateInfo
+        dsai.descriptorPool = weak_copy(g_comp.desc_pool)
+        dsai.pSetLayouts |> push(weak_copy(g_comp.set_layouts[0]))
+        g_comp.dsets <- allocate_descriptor_sets(device, dsai)
+        write_common_bindings(device, g_comp.dsets[0], g_accum_img, g_disp_img, g_vbuf, g_tbuf)
+        var inscope shader <- create_shader_module(device, pt_compute_spv)
+        g_comp.pipeline <- create_compute_pipeline(device, g_comp.pipe_layout, shader)
+    }
+
+    // ----- hardware RT engine stack (only when the device has the pipeline) -----
+    if (g_rt_ok) {
+        var bverts : array<float3>
+        for (pv in pt_verts) {
+            bverts |> push(pv.xyz)
+        }
+        var bidx : array<uint>
+        for (tr in pt_tris) {
+            bidx |> push(tr.x)
+            bidx |> push(tr.y)
+            bidx |> push(tr.z)
+        }
+        g_blas <- build_blas(device, phys, pool, queue, bverts, bidx)
+        delete bverts
+        delete bidx
+        var insts <- [make_accel_instance(g_blas.address)]
+        g_tlas <- build_tlas(device, phys, pool, queue, insts)
+        delete insts
+        var reflections <- [decode_reflection(pt_rgen_spv_reflect),
+            decode_reflection(pt_miss_spv_reflect),
+            decode_reflection(pt_shadow_miss_spv_reflect),
+            decode_reflection(pt_chit_spv_reflect)]
+        g_rt.set_layouts <- build_descriptor_set_layouts(device, reflections)
+        g_rt.pipe_layout <- build_pipeline_layout(device, g_rt.set_layouts, reflections)
+        delete reflections
+        var dpci = DescriptorPoolCreateInfo(maxSets = 1u,
+            pPoolSizes <- [
+                DescriptorPoolSize(type_ = VkDescriptorType.STORAGE_IMAGE, descriptorCount = 2u),
+                DescriptorPoolSize(type_ = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 2u),
+                DescriptorPoolSize(type_ = VkDescriptorType.ACCELERATION_STRUCTURE_KHR, descriptorCount = 1u)
+            ])
+        g_rt.desc_pool <- create_descriptor_pool(device, dpci)
+        var dsai : DescriptorSetAllocateInfo
+        dsai.descriptorPool = weak_copy(g_rt.desc_pool)
+        dsai.pSetLayouts |> push(weak_copy(g_rt.set_layouts[0]))
+        g_rt.dsets <- allocate_descriptor_sets(device, dsai)
+        write_common_bindings(device, g_rt.dsets[0], g_accum_img, g_disp_img, g_vbuf, g_tbuf)
+        write_descriptor_acceleration_structure(device, g_rt.dsets[0], 4u, g_tlas)
+        var inscope rgen <- create_shader_module(device, pt_rgen_spv)
+        var inscope miss <- create_shader_module(device, pt_miss_spv)
+        var inscope shadow_miss <- create_shader_module(device, pt_shadow_miss_spv)
+        var inscope chit <- create_shader_module(device, pt_chit_spv)
+        var miss_list <- [weak_copy(miss), weak_copy(shadow_miss)]
+        g_rt.pipeline <- create_ray_tracing_pipeline(device, g_rt.pipe_layout, rgen, miss_list, chit, 1u)
+        delete miss_list
+        g_sbt <- build_shader_binding_table(device, phys, g_rt.pipeline, 2u, 1u)
+    }
+
+    // ----- display quad stack -----
+    let sci = SamplerCreateInfo(
+        magFilter = VkFilter.LINEAR,
+        minFilter = VkFilter.LINEAR,
+        mipmapMode = VkSamplerMipmapMode.LINEAR,
+        addressModeU = VkSamplerAddressMode.CLAMP_TO_EDGE,
+        addressModeV = VkSamplerAddressMode.CLAMP_TO_EDGE,
+        addressModeW = VkSamplerAddressMode.CLAMP_TO_EDGE,
+        maxLod = 1.0f)
+    g_sampler <- create_sampler(device, sci)
+    {
+        var reflections <- [decode_reflection(pt_quad_vert_spv_reflect), decode_reflection(pt_quad_frag_spv_reflect)]
+        g_quad.set_layouts <- build_descriptor_set_layouts(device, reflections)
+        g_quad.pipe_layout <- build_pipeline_layout(device, g_quad.set_layouts, reflections)
+        delete reflections
+        var dpci = DescriptorPoolCreateInfo(maxSets = 1u,
+            pPoolSizes <- [DescriptorPoolSize(type_ = VkDescriptorType.COMBINED_IMAGE_SAMPLER, descriptorCount = 1u)])
+        g_quad.desc_pool <- create_descriptor_pool(device, dpci)
+        var dsai : DescriptorSetAllocateInfo
+        dsai.descriptorPool = weak_copy(g_quad.desc_pool)
+        dsai.pSetLayouts |> push(weak_copy(g_quad.set_layouts[0]))
+        g_quad.dsets <- allocate_descriptor_sets(device, dsai)
+        var write = WriteDescriptorSet(dstSet = weak_copy(g_quad.dsets[0]), dstBinding = 0u,
+            descriptorType = VkDescriptorType.COMBINED_IMAGE_SAMPLER, descriptorCount = 1u)
+        write.pImageInfo |> push(DescriptorImageInfo(sampler = weak_copy(g_sampler),
+            imageView = weak_copy(g_disp_img.view), imageLayout = VkImageLayout.GENERAL))
+        var writes : array<WriteDescriptorSet>
+        writes |> emplace(write)
+        let no_copies : array<CopyDescriptorSet>
+        update_descriptor_sets(device, writes, no_copies)
+        var inscope qvert <- create_shader_module(device, pt_quad_vert_spv)
+        var inscope qfrag <- create_shader_module(device, pt_quad_frag_spv)
+        g_quad.pipeline <- build_quad_pipeline(device, harness_render_pass(), g_quad.pipe_layout, qvert, qfrag)
+    }
+
+    g_max_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
+    g_cpu_dirty = true   // first frame uploads the zeroed pixel buffer = a black display image
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) {
+        return
+    }
+    harness_new_frame()
+    let device = harness_device()
+    let queue = harness_queue()
+    let pool = harness_pool()
+
+    // ----- advance the active engine -----
+    if (advance_ready()) {
+        if (g_mode == int(Engine.Single)) {
+            start_cpu_pass(g_pass + 1, 1)
+        } elif (g_mode == int(Engine.Threads)) {
+            start_cpu_pass(g_pass + 1, clamp(g_max_threads, 1, MAX_BANDS))
+        } else {
+            let f = g_pass + 1
+            let t0 = ref_time_ticks()
+            run_cmd_sync(device, pool, queue) $(cmd) {
+                var shader_rw : VkAccessFlags
+                shader_rw.shader_read = true
+                shader_rw.shader_write = true
+                var frag_read : VkAccessFlags
+                frag_read.shader_read = true
+                var comp_stage : VkPipelineStageFlags
+                comp_stage.compute_shader = true
+                var rt_stage : VkPipelineStageFlags
+                rt_stage.ray_tracing_shader_khr = true
+                var frag_stage : VkPipelineStageFlags
+                frag_stage.fragment_shader = true
+                var no_dyn : array<uint>
+                pt_push.frame = uint(f)
+                if (g_mode == int(Engine.Compute)) {
+                    cmd_bind_pipeline(cmd, g_comp.pipeline, VkPipelineBindPoint.COMPUTE)
+                    cmd_bind_descriptor_sets(cmd, VkPipelineBindPoint.COMPUTE, g_comp.pipe_layout, 0u, g_comp.dsets, no_dyn)
+                    pt_compute_push_constants(cmd, g_comp.pipe_layout)
+                    cmd_dispatch(cmd, uint(TRACE_W / 8), uint(TRACE_H / 8), 1u)
+                    transition_image(cmd, g_disp_img.image, VkImageLayout.GENERAL, VkImageLayout.GENERAL,
+                        shader_rw, frag_read, comp_stage, frag_stage)
+                } else {
+                    cmd_bind_pipeline(cmd, g_rt.pipeline, VkPipelineBindPoint.RAY_TRACING_KHR)
+                    cmd_bind_descriptor_sets(cmd, VkPipelineBindPoint.RAY_TRACING_KHR, g_rt.pipe_layout, 0u, g_rt.dsets, no_dyn)
+                    pt_rgen_push_constants(cmd, g_rt.pipe_layout)
+                    cmd_trace_rays(cmd, g_sbt, uint(TRACE_W), uint(TRACE_H))
+                    transition_image(cmd, g_disp_img.image, VkImageLayout.GENERAL, VkImageLayout.GENERAL,
+                        shader_rw, frag_read, rt_stage, frag_stage)
+                }
+            }
+            g_pass = f
+            g_threads_t0 = t0
+            note_pass_done()
+        }
+    }
+
+    // a completed CPU pass: copy its tonemapped pixels into the display image
+    if (g_cpu_dirty) {
+        g_cpu_dirty = false
+        g_staging |> upload_bytes(device, g_pixels)
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            let none : VkAccessFlags
+            var to_dst : VkAccessFlags
+            to_dst.transfer_write = true
+            var frag_read : VkAccessFlags
+            frag_read.shader_read = true
+            var top : VkPipelineStageFlags
+            top.top_of_pipe = true
+            var xfer : VkPipelineStageFlags
+            xfer.transfer = true
+            var frag_stage : VkPipelineStageFlags
+            frag_stage.fragment_shader = true
+            transition_image(cmd, g_disp_img.image, VkImageLayout.GENERAL, VkImageLayout.TRANSFER_DST_OPTIMAL,
+                none, to_dst, top, xfer)
+            var region : BufferImageCopy
+            region.imageSubresource.aspectMask.color = true
+            region.imageSubresource.layerCount = 1u
+            region.imageExtent.width = uint(TRACE_W)
+            region.imageExtent.height = uint(TRACE_H)
+            region.imageExtent.depth = 1u
+            var regions : array<BufferImageCopy>
+            regions |> emplace(region)
+            cmd_copy_buffer_to_image(cmd, g_staging.buffer, g_disp_img.image, VkImageLayout.TRANSFER_DST_OPTIMAL, regions)
+            transition_image(cmd, g_disp_img.image, VkImageLayout.TRANSFER_DST_OPTIMAL, VkImageLayout.GENERAL,
+                to_dst, frag_read, xfer, frag_stage)
+        }
+    }
+
+    // ----- panel (imgui_boost_v2: every widget live-drivable at PT_WIN/<id>) -----
+    window(PT_WIN, (text = "One source, four engines", closable = false,
+                    flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+        text("The same daslang functions on every engine.")
+        radio_button_int(ENGINE, (text = "CPU - 1 thread", v_button = int(Engine.Single)))
+        radio_button_int(ENGINE, (text = "CPU - band threads", v_button = int(Engine.Threads)))
+        radio_button_int(ENGINE, (text = "GPU - dasSpirv compute", v_button = int(Engine.Compute)))
+        if (g_rt_ok) {
+            radio_button_int(ENGINE, (text = "GPU - hardware ray tracing", v_button = int(Engine.RayTrace)))
+        } else {
+            text("GPU - hardware ray tracing: not supported here")
+        }
+        if (ENGINE.value != g_mode) {
+            g_mode = ENGINE.value
+            g_epoch++
+            g_smooth_pps = 0.0lf
+        }
+        if (g_mode == int(Engine.Threads)) {
+            edit_slider_int(safe_addr(g_max_threads), (id = "THREADS", text = "threads",
+                                                       v_min = 1, v_max = MAX_BANDS))
+        }
+        separator(PT_SEP)
+        text(STATS_SAMPLES, (text = "samples: {max(g_pass + 1, 0)}"))
+        text(STATS_PPS, (text = "throughput: {fmt(":.2f", g_smooth_pps)} Mpaths/s"))
+    }
+
+    // ----- present: letterboxed quad + UI -----
+    let sz = harness_size()
+    let a = float(sz.x) / float(max(sz.y, 1))
+    pt_qpush.scale = a > 1.0 ? float2(1.0 / a, 1.0) : float2(1.0, a)
+    harness_end_frame() $(cmd : CommandBuffer) {
+        cmd_bind_pipeline(cmd, g_quad.pipeline)
+        var no_dyn : array<uint>
+        cmd_bind_descriptor_sets(cmd, VkPipelineBindPoint.GRAPHICS, g_quad.pipe_layout, 0u, g_quad.dsets, no_dyn)
+        pt_quad_vs_push_constants(cmd, g_quad.pipe_layout)
+        // scissor to the letterboxed quad so the fullscreen triangle's hypotenuse can't smear
+        // clamped edge texels outside it (imgui sets its own scissors after this)
+        var sc : Rect2D
+        sc.offset.x = int((1.0 - pt_qpush.scale.x) * 0.5 * float(sz.x))
+        sc.offset.y = int((1.0 - pt_qpush.scale.y) * 0.5 * float(sz.y))
+        sc.extent.width = uint(pt_qpush.scale.x * float(sz.x) + 0.5)
+        sc.extent.height = uint(pt_qpush.scale.y * float(sz.y) + 0.5)
+        var scis : array<Rect2D>
+        scis |> push(sc)
+        cmd_set_scissor(cmd, 0u, scis)
+        delete scis
+        cmd_draw(cmd, 3u, 1u)
+    }
+
+    if (g_max_frames > 0) {
+        let fc = harness_frame_count()
+        if (fc == g_max_frames - 1) {
+            vk_live_save_screenshot("one_source_path_tracer_proof.png")
+            print("saved one_source_path_tracer_proof.png\n")
+        }
+        if (fc >= g_max_frames) {
+            request_exit()
+        }
+    }
+}
+
+[export]
+def shutdown() {
+    // wind down any in-flight CPU pass before the Vulkan objects go away
+    g_epoch++
+    if (g_threads_status != null) {
+        g_threads_status |> join()
+        var st = g_threads_status
+        unsafe {
+            job_status_remove(st)
+        }
+        g_threads_status = null
+    }
+    delete g_quad
+    delete g_sampler
+    delete g_sbt
+    delete g_rt
+    delete g_tlas
+    delete g_blas
+    delete g_comp
+    delete g_disp_img
+    delete g_accum_img
+    delete g_staging
+    delete g_tbuf
+    delete g_vbuf
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/vulkan/one_source_path_tracer/pt_core.das
+++ b/examples/vulkan/one_source_path_tracer/pt_core.das
@@ -1,0 +1,318 @@
+options gen2
+options indenting = 4
+
+// One-source path tracer core. The SAME functions below run on the CPU (interpreter or JIT,
+// single- or multi-threaded) and lower to SPIR-V (compute and ray-tracing stages) via dasSpirv.
+// GPU-lowerable authoring rules observed throughout: 32-bit scalar/vector params only (no
+// struct/array params), no recursion, stateless PCG RNG threaded by ref, scene data in @ssbo
+// globals that the CPU fills and reads directly while the GPU binds them as storage buffers.
+
+module pt_core public
+
+options solid_context
+
+require math
+
+// ===== scene data — one source: CPU fills + reads these, GPU binds them as SSBOs =====
+
+var @ssbo @binding = 2 pt_verts : array<float4>     // xyz = position (float4 => std430 stride matches CPU)
+var @ssbo @binding = 3 pt_tris : array<uint4>       // xyz = vertex indices, w = material id
+
+let PT_TRI_COUNT = 32                               // 6 quads + 2 boxes * 5 faces; verified by pt_init_scene
+
+let {
+    PT_MIN_T = 0.001
+    PT_MAX_T = 1.0e7
+    PT_MAX_BOUNCES = 5
+}
+
+let {
+    PT_MAT_WHITE = 0u
+    PT_MAT_RED = 1u
+    PT_MAT_GREEN = 2u
+    PT_MAT_LIGHT = 3u
+    PT_MAT_MIRROR = 4u
+}
+
+// ceiling light quad: x in [-0.35,0.35], z in [0.75,1.45] at y=1.995, normal (0,-1,0)
+let {
+    PT_LIGHT_Y = 1.995
+    PT_LIGHT_X0 = -0.35
+    PT_LIGHT_X1 = 0.35
+    PT_LIGHT_Z0 = 0.75
+    PT_LIGHT_Z1 = 1.45
+    PT_LIGHT_AREA = 0.49
+}
+
+// ===== materials as code — shared by every engine, no material buffer to marshal =====
+
+def pt_mat_albedo(m : uint) : float3 {
+    if (m == PT_MAT_RED) {
+        return float3(0.63, 0.065, 0.05)
+    }
+    if (m == PT_MAT_GREEN) {
+        return float3(0.14, 0.45, 0.091)
+    }
+    if (m == PT_MAT_MIRROR) {
+        return float3(0.95, 0.95, 0.95)
+    }
+    return float3(0.73, 0.73, 0.73)
+}
+
+def pt_mat_emission(m : uint) : float3 {
+    if (m == PT_MAT_LIGHT) {
+        return float3(17.0, 12.0, 6.0)
+    }
+    return float3(0.0)
+}
+
+def pt_mat_is_mirror(m : uint) : bool => m == PT_MAT_MIRROR
+
+// ===== stateless PCG RNG — identical streams on CPU and GPU =====
+
+def pt_rng_uint(var state : uint&) : uint {
+    state = state * 747796405u + 2891336453u
+    let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u
+    return (word >> 22u) ^ word
+}
+
+def pt_rng(var state : uint&) : float {
+    return float(pt_rng_uint(state) >> 8u) * (1.0 / 16777216.0)
+}
+
+def pt_seed(x, y, frame : int) : uint {
+    var state = (uint(x) * 1973u + uint(y) * 9277u + uint(frame) * 26699u) | 1u
+    return pt_rng_uint(state) | 1u
+}
+
+// ===== pinhole camera looking down +Z into the box front opening (square aspect) =====
+
+def pt_camera_ray(u, v : float; var ro : float3&; var rd : float3&) {
+    ro = float3(0.0, 1.0, -3.0)
+    rd = normalize(float3((u * 2.0 - 1.0) * 0.35, (1.0 - v * 2.0) * 0.35, 1.0))
+}
+
+// ===== intersection — Moller-Trumbore over the shared triangle list =====
+
+def pt_hit_tri(ro, rd : float3; v0, v1, v2 : float3; tmax : float; var t : float&) : bool {
+    let e1 = v1 - v0
+    let e2 = v2 - v0
+    let pv = cross(rd, e2)
+    let det = dot(e1, pv)
+    if (abs(det) < 1e-8) {
+        return false
+    }
+    let inv = 1.0 / det
+    let tv = ro - v0
+    let u = dot(tv, pv) * inv
+    if (u < 0.0 || u > 1.0) {
+        return false
+    }
+    let qv = cross(tv, e1)
+    let v = dot(rd, qv) * inv
+    if (v < 0.0 || u + v > 1.0) {
+        return false
+    }
+    let tt = dot(e2, qv) * inv
+    if (tt < PT_MIN_T || tt > tmax) {
+        return false
+    }
+    t = tt
+    return true
+}
+
+def pt_intersect(ro, rd : float3; var t : float&; var prim : int&) : bool {
+    t = PT_MAX_T
+    prim = -1
+    for (i in range(PT_TRI_COUNT)) {
+        let tri = pt_tris[i]
+        let v0 = pt_verts[int(tri.x)].xyz
+        let v1 = pt_verts[int(tri.y)].xyz
+        let v2 = pt_verts[int(tri.z)].xyz
+        var tt = 0.0
+        if (pt_hit_tri(ro, rd, v0, v1, v2, t, tt)) {
+            t = tt
+            prim = i
+        }
+    }
+    return prim >= 0
+}
+
+def pt_tri_normal(prim : int; rd : float3) : float3 {
+    let tri = pt_tris[prim]
+    let v0 = pt_verts[int(tri.x)].xyz
+    let v1 = pt_verts[int(tri.y)].xyz
+    let v2 = pt_verts[int(tri.z)].xyz
+    var n = normalize(cross(v1 - v0, v2 - v0))
+    if (dot(n, rd) > 0.0) {
+        n = -n
+    }
+    return n
+}
+
+// ===== sampling =====
+
+def pt_sphere_dir(var rng : uint&) : float3 {
+    let z = 1.0 - 2.0 * pt_rng(rng)
+    let phi = 6.2831853 * pt_rng(rng)
+    let r = sqrt(max(0.0, 1.0 - z * z))
+    return float3(r * cos(phi), r * sin(phi), z)
+}
+
+def pt_cosine_dir(n : float3; var rng : uint&) : float3 {
+    let d = n + pt_sphere_dir(rng)
+    if (dot(d, d) < 1e-6) {
+        return n
+    }
+    return normalize(d)
+}
+
+// ===== next-event estimation — shared light sampling; only the occlusion query is per-engine =====
+
+def pt_light_sample(var rng : uint&) : float3 {
+    let lx = lerp(PT_LIGHT_X0, PT_LIGHT_X1, pt_rng(rng))
+    let lz = lerp(PT_LIGHT_Z0, PT_LIGHT_Z1, pt_rng(rng))
+    return float3(lx, PT_LIGHT_Y, lz)
+}
+
+//! Unshadowed direct-light term for a lambert surface at hitp with normal n toward light point lp:
+//! Le * cos_surf * cos_light * area / (pi * d^2). Multiply by albedo * visibility at the call site.
+def pt_light_term(hitp, n, lp : float3) : float3 {
+    let ld = lp - hitp
+    let d2 = dot(ld, ld)
+    let ldir = ld * rsqrt(d2)
+    let cosS = dot(n, ldir)
+    let cosL = ldir.y   // light normal is (0,-1,0); incoming dir at light is -ldir
+    if (cosS <= 0.0 || cosL <= 0.0) {
+        return float3(0.0)
+    }
+    return pt_mat_emission(PT_MAT_LIGHT) * (cosS * cosL * PT_LIGHT_AREA / (PI * d2))
+}
+
+// ===== integrator — iterative, mirror + lambert, NEE + emissive on specular paths =====
+
+def pt_trace_path(ro0, rd0 : float3; var rng : uint&) : float3 {
+    var ro = ro0
+    var rd = rd0
+    var throughput = float3(1.0)
+    var radiance = float3(0.0)
+    var specular = true
+    for (_bounce in range(PT_MAX_BOUNCES)) {
+        var t = 0.0
+        var prim = -1
+        if (!pt_intersect(ro, rd, t, prim)) {
+            break
+        }
+        let mat = pt_tris[prim].w
+        if (mat == PT_MAT_LIGHT) {
+            if (specular) {
+                radiance += throughput * pt_mat_emission(mat)
+            }
+            break
+        }
+        let hitp = ro + rd * t
+        let n = pt_tri_normal(prim, rd)
+        if (pt_mat_is_mirror(mat)) {
+            rd = reflect(rd, n)
+            ro = hitp + n * 0.001
+            specular = true
+            continue
+        }
+        let albedo = pt_mat_albedo(mat)
+        // next-event estimation: sample the light, shadow-test with the shared intersector
+        let lp = pt_light_sample(rng)
+        let direct = pt_light_term(hitp, n, lp)
+        if (direct.x > 0.0 || direct.y > 0.0) {
+            var st = 0.0
+            var sprim = -1
+            if (pt_intersect(hitp + n * 0.001, normalize(lp - hitp), st, sprim)) {
+                if (pt_tris[sprim].w == PT_MAT_LIGHT) {
+                    radiance += throughput * albedo * direct
+                }
+            }
+        }
+        throughput *= albedo
+        rd = pt_cosine_dir(n, rng)
+        ro = hitp + n * 0.001
+        specular = false
+    }
+    return radiance
+}
+
+// ===== per-pixel entry — 1 sample; every engine accumulates these =====
+
+def pt_render_pixel(x, y, frame, width, height : int) : float3 {
+    var rng = pt_seed(x, y, frame)
+    let u = (float(x) + pt_rng(rng)) / float(width)
+    let v = (float(y) + pt_rng(rng)) / float(height)
+    var ro = float3(0.0)
+    var rd = float3(0.0)
+    pt_camera_ray(u, v, ro, rd)
+    return pt_trace_path(ro, rd, rng)
+}
+
+def pt_tonemap(c : float3) : float3 {
+    let m = c / (c + float3(1.0))
+    return pow(m, float3(1.0 / 2.2))
+}
+
+// ===== scene construction — host/CPU only (never lowered; shaders read the arrays it fills) =====
+
+def private pt_push_quad(a, b, c, d : float3; mat : uint) {
+    let base = uint(length(pt_verts))
+    pt_verts |> push(float4(a, 0.0))
+    pt_verts |> push(float4(b, 0.0))
+    pt_verts |> push(float4(c, 0.0))
+    pt_verts |> push(float4(d, 0.0))
+    pt_tris |> push(uint4(base, base + 1u, base + 2u, mat))
+    pt_tris |> push(uint4(base, base + 2u, base + 3u, mat))
+}
+
+def private pt_push_box(cx, cz : float; hx, height, hz : float; angle : float; mat : uint) {
+    let ca = cos(angle)
+    let sa = sin(angle)
+    let lx = fixed_array(-hx, hx, hx, -hx)
+    let lz = fixed_array(-hz, -hz, hz, hz)
+    var b : float3[4]
+    var tp : float3[4]
+    for (i in range(4)) {
+        let wx = cx + lx[i] * ca - lz[i] * sa
+        let wz = cz + lx[i] * sa + lz[i] * ca
+        b[i] = float3(wx, 0.0, wz)
+        tp[i] = float3(wx, height, wz)
+    }
+    for (i in range(4)) {
+        let j = (i + 1) & 3
+        pt_push_quad(b[i], b[j], tp[j], tp[i], mat)
+    }
+    pt_push_quad(tp[0], tp[1], tp[2], tp[3], mat)
+}
+
+//! Builds the Cornell scene into pt_verts/pt_tris. Idempotent per context — every worker thread
+//! (own context, own globals) calls it before tracing; the host also uploads these arrays to the
+//! GPU engines and feeds them to the BLAS build.
+def pt_init_scene {
+    if (!empty(pt_tris)) {
+        return
+    }
+    // interior: x in [-1,1], y in [0,2], z in [0,2]; camera looks in from z < 0
+    pt_push_quad(float3(-1.0, 0.0, 0.0), float3(1.0, 0.0, 0.0), float3(1.0, 0.0, 2.0), float3(-1.0, 0.0, 2.0), PT_MAT_WHITE)            // floor
+    pt_push_quad(float3(-1.0, 2.0, 0.0), float3(1.0, 2.0, 0.0), float3(1.0, 2.0, 2.0), float3(-1.0, 2.0, 2.0), PT_MAT_WHITE)            // ceiling
+    pt_push_quad(float3(-1.0, 0.0, 2.0), float3(1.0, 0.0, 2.0), float3(1.0, 2.0, 2.0), float3(-1.0, 2.0, 2.0), PT_MAT_WHITE)            // back wall
+    pt_push_quad(float3(-1.0, 0.0, 0.0), float3(-1.0, 0.0, 2.0), float3(-1.0, 2.0, 2.0), float3(-1.0, 2.0, 0.0), PT_MAT_RED)            // left wall
+    pt_push_quad(float3(1.0, 0.0, 0.0), float3(1.0, 0.0, 2.0), float3(1.0, 2.0, 2.0), float3(1.0, 2.0, 0.0), PT_MAT_GREEN)              // right wall
+    pt_push_quad(float3(-0.35, 1.995, 0.75), float3(0.35, 1.995, 0.75), float3(0.35, 1.995, 1.45), float3(-0.35, 1.995, 1.45), PT_MAT_LIGHT)
+    pt_push_box(-0.38, 1.3, 0.28, 1.15, 0.28, 0.65, PT_MAT_MIRROR)  // tall mirror box, ~37 deg so it reflects the room
+    pt_push_box(0.4, 0.68, 0.28, 0.55, 0.28, -0.3, PT_MAT_WHITE)    // short white box, ~-17 deg
+    verify(length(pt_tris) == PT_TRI_COUNT)
+}
+
+// ===== CPU band renderer — host only =====
+
+def pt_render_rows(frame, width, height, ymin, ymax : int; var accum : array<float3>) {
+    for (y in range(ymin, ymax)) {
+        for (x in range(width)) {
+            accum[y * width + x] += pt_render_pixel(x, y, frame, width, height)
+        }
+    }
+}

--- a/examples/vulkan/one_source_path_tracer/pt_reference.das
+++ b/examples/vulkan/one_source_path_tracer/pt_reference.das
@@ -1,0 +1,63 @@
+options gen2
+options indenting = 4
+options solid_context
+
+// CPU reference renderer: traces the shared pt_core scene on host threads and writes
+// pt_reference.png to the current directory. Run under `daslang -jit ...` for the fast-CPU tier;
+// the GPU engines in main.das lower the very same functions to SPIR-V.
+
+require math
+require stbimage
+require daslib/jobque_boost
+
+require pt_core
+
+let {
+    WIDTH = 512
+    HEIGHT = 512
+    SPP = 16
+}
+
+[export]
+def main {
+    var accum : array<float3>
+    accum |> resize(WIDTH * HEIGHT)
+    let nThreads = get_total_hw_threads()
+    let t0 = ref_time_ticks()
+    var pbb : array<float3>?
+    unsafe {
+        pbb = addr(accum)
+    }
+    with_job_status(nThreads) $(status) {
+        let chunk = (HEIGHT + nThreads - 1) / nThreads
+        for (c in range(nThreads)) {
+            let ymin = c * chunk
+            let ymax = min((c + 1) * chunk, HEIGHT)
+            new_thread <| @ {
+                pt_init_scene()
+                for (sample in range(SPP)) {
+                    pt_render_rows(sample, WIDTH, HEIGHT, ymin, ymax, *pbb)
+                }
+                status |> notify_and_release
+            }
+        }
+        status |> join
+    }
+    let usec = get_time_usec(t0)
+    let paths = double(WIDTH * HEIGHT) * double(SPP)
+    print("{WIDTH}x{HEIGHT} @ {SPP}spp on {nThreads} threads: {double(usec) / 1000000.0lf} sec, {fmt(":.3f", paths / double(usec))} Mpaths/s\n")
+    var pixels : array<uint>
+    pixels |> reserve(WIDTH * HEIGHT)
+    let inv = 1.0 / float(SPP)
+    for (i in range(WIDTH * HEIGHT)) {
+        let srgb = pt_tonemap(accum[i] * inv)
+        let r = uint(clamp(srgb.x, 0.0, 1.0) * 255.0 + 0.5)
+        let g = uint(clamp(srgb.y, 0.0, 1.0) * 255.0 + 0.5)
+        let b = uint(clamp(srgb.z, 0.0, 1.0) * 255.0 + 0.5)
+        pixels |> push(r | (g << 8u) | (b << 16u) | 0xFF000000)
+    }
+    unsafe {
+        stbi_write_png("pt_reference.png", WIDTH, HEIGHT, 4, addr(pixels[0]), WIDTH * 4)
+    }
+    print("wrote pt_reference.png\n")
+}

--- a/examples/vulkan/one_source_path_tracer/pt_shaders.das
+++ b/examples/vulkan/one_source_path_tracer/pt_shaders.das
@@ -1,0 +1,170 @@
+options gen2
+options indenting = 4
+
+// GPU entry points for the one-source path tracer. The kernels call the SAME pt_core functions the
+// CPU engines run; dasSpirv lowers them (shared helpers included) to SPIR-V at compile time.
+
+module pt_shaders public
+
+require math
+require vulkan/vulkan_boost public
+require vulkan/spirv_vulkan_shader public
+require spirv/spirv_builtins public
+
+require pt_core public
+
+// set 0: binding 0 = rgba32f accumulation, binding 1 = rgba8 display; pt_core's scene SSBOs sit at
+// bindings 2 (verts) and 3 (tris)
+var @binding = 0 @format = "rgba32f" pt_accum : image2D
+var @binding = 1 pt_display : image2D
+
+struct PtPush {
+    frame : uint
+}
+var @push_constant pt_push : PtPush
+
+[vulkan_compute_shader(local_size_x=8, local_size_y=8, name="pt_compute_spv")]
+def pt_compute {
+    let px = int2(gl_GlobalInvocationID.xy)
+    let dim = imageSize(pt_display)
+    if (px.x >= dim.x || px.y >= dim.y) {
+        return
+    }
+    let frame = int(pt_push.frame)
+    let c = pt_render_pixel(px.x, px.y, frame, dim.x, dim.y)
+    var acc = imageLoad(pt_accum, px).xyz
+    if (frame == 0) {
+        acc = float3(0.0)
+    }
+    acc += c
+    imageStore(pt_accum, px, float4(acc, 1.0))
+    imageStore(pt_display, px, float4(pt_tonemap(acc / float(frame + 1)), 1.0))
+}
+
+// ===== hardware ray tracing: traversal replaces pt_intersect, everything else is the same code =====
+//
+// The raygen mirrors pt_trace_path bounce-for-bounce — camera, RNG, NEE light sampling, materials,
+// normals, accumulation all come from pt_core — but each intersection is a traceRayEXT into the
+// TLAS built from the same pt_verts/pt_tris the software intersector loops over. The closest-hit
+// and miss shaders are minimal reporters (t + primitive id in the payload); the shadow ray uses
+// terminate-on-first-hit + skip-closest-hit with miss_index 1, so only the shadow miss can flip
+// its payload to "lit" (tutorial-15 pattern, recursion-free at max_recursion = 1).
+
+var @binding = 4 pt_tlas : accelerationStructureEXT
+
+var @ray_payload pt_hit : float4                    // x = t, y = primitive id, z = hit flag
+var @ray_payload @location = 1 pt_shadow : float3   // x = lit flag (0 until the shadow miss runs)
+
+[vulkan_raygen_shader(name="pt_rgen_spv")]
+def pt_rgen {
+    let gid = gl_LaunchIDEXT
+    let dim = gl_LaunchSizeEXT
+    let px = int2(gid.xy)
+    let frame = int(pt_push.frame)
+    var rng = pt_seed(px.x, px.y, frame)
+    let u = (float(px.x) + pt_rng(rng)) / float(dim.x)
+    let v = (float(px.y) + pt_rng(rng)) / float(dim.y)
+    var ro = float3(0.0)
+    var rd = float3(0.0)
+    pt_camera_ray(u, v, ro, rd)
+    var throughput = float3(1.0)
+    var radiance = float3(0.0)
+    var specular = true
+    for (bounce in range(PT_MAX_BOUNCES)) {
+        pt_hit = float4(0.0)
+        traceRayEXT(pt_tlas, 0x01u, 0xFFu, 0u, 0u, 0u, ro, PT_MIN_T, rd, PT_MAX_T, pt_hit)
+        if (pt_hit.z == 0.0) {
+            break
+        }
+        let t = pt_hit.x
+        let prim = int(pt_hit.y)
+        let mat = pt_tris[prim].w
+        if (mat == PT_MAT_LIGHT) {
+            if (specular) {
+                radiance += throughput * pt_mat_emission(mat)
+            }
+            break
+        }
+        let hitp = ro + rd * t
+        let n = pt_tri_normal(prim, rd)
+        if (pt_mat_is_mirror(mat)) {
+            rd = reflect(rd, n)
+            ro = hitp + n * 0.001
+            specular = true
+            continue
+        }
+        let albedo = pt_mat_albedo(mat)
+        let lp = pt_light_sample(rng)
+        let direct = pt_light_term(hitp, n, lp)
+        if (direct.x > 0.0 || direct.y > 0.0) {
+            let ld = lp - hitp
+            let dist = length(ld)
+            pt_shadow = float3(0.0)
+            // opaque + terminate-on-first-hit + skip-closest-hit; tmax stops just short of the
+            // light quad, so any hit is an occluder and only the shadow miss can set lit
+            traceRayEXT(pt_tlas, 0x0Du, 0xFFu, 0u, 0u, 1u, hitp + n * 0.001, 0.001, ld / dist, dist - 0.01, pt_shadow)
+            if (pt_shadow.x > 0.5) {
+                radiance += throughput * albedo * direct
+            }
+        }
+        throughput *= albedo
+        rd = pt_cosine_dir(n, rng)
+        ro = hitp + n * 0.001
+        specular = false
+    }
+    var acc = imageLoad(pt_accum, px).xyz
+    if (frame == 0) {
+        acc = float3(0.0)
+    }
+    acc += radiance
+    imageStore(pt_accum, px, float4(acc, 1.0))
+    imageStore(pt_display, px, float4(pt_tonemap(acc / float(frame + 1)), 1.0))
+}
+
+var @incoming_ray_payload pt_miss_in : float4
+
+[vulkan_miss_shader(name="pt_miss_spv")]
+def pt_miss {
+    pt_miss_in = float4(0.0)    // z = 0: no hit
+}
+
+var @incoming_ray_payload pt_shadow_in : float3
+
+[vulkan_miss_shader(name="pt_shadow_miss_spv")]
+def pt_shadow_miss {
+    pt_shadow_in = float3(1.0)  // the shadow ray reached the light: lit
+}
+
+var @incoming_ray_payload pt_chit_in : float4
+
+[vulkan_closest_hit_shader(name="pt_chit_spv")]
+def pt_chit {
+    pt_chit_in = float4(gl_HitTEXT, float(gl_PrimitiveID), 1.0, 0.0)
+}
+
+// ===== display: fullscreen triangle sampling the display image (letterboxed by `scale`) =====
+
+struct PtQuadPush {
+    scale : float2
+}
+var @push_constant pt_qpush : PtQuadPush
+
+var @out @location = 0 pt_quad_uv : float2
+
+[vulkan_vertex_shader(name="pt_quad_vert_spv")]
+def pt_quad_vs {
+    let vi = gl_VertexIndex
+    let u = float((vi << 1) & 2)
+    let v = float(vi & 2)
+    pt_quad_uv = float2(u, v)
+    gl_Position = float4((u * 2.0 - 1.0) * pt_qpush.scale.x, (v * 2.0 - 1.0) * pt_qpush.scale.y, 0.0, 1.0)
+}
+
+var @in @location = 0 pt_quad_uv_in : float2
+var @out @location = 0 pt_quad_color : float4
+var @binding = 0 pt_tex : sampler2D
+
+[vulkan_fragment_shader(name="pt_quad_frag_spv")]
+def pt_quad_fs {
+    pt_quad_color = texture(pt_tex, pt_quad_uv_in)
+}

--- a/examples/vulkan_imgui_cube/README.md
+++ b/examples/vulkan_imgui_cube/README.md
@@ -24,9 +24,9 @@ Two opt-in modules ship with [dasVulkan](https://github.com/borisbat/dasVulkan):
 
 ## Files
 
-- `main.das` — the app: GLFW (no-API) window + Vulkan swapchain, the cube, and the ImGui panel; cube
-  and UI share one swapchain render pass (the cube is back-face culled, so a convex mesh needs no
-  depth buffer). It registers the swapchain with `vulkan_live` and draws through `vk_live_draw_frame`.
+- `main.das` — the app: the `vulkan/vulkan_imgui_app` harness owns the window/device/swapchain and
+  wires the live stack; the cube draws in the `harness_end_frame` scene block (back-face culled, so a
+  convex mesh needs no depth buffer), and the panel is imgui_boost_v2 (`CUBE_WIN/SPEED`).
 - `cube_shaders.das` — the cube's lit shaders (dasSpirv), push-constant-only.
 
 ## Running
@@ -41,8 +41,19 @@ daslang ../../utils/daspkg/main.das -- install
 ```
 
 Then run it — drag the slider to change the spin speed, press **P** to save a screenshot
-(`vulkan_imgui_cube.png`, captured by `vulkan_live`), close the window to exit:
+(`screenshot.png`, captured by `vulkan_live`), close the window to exit:
 
 ```
 daslang -project_root . main.das
+```
+
+## Live control
+
+The UI is imgui_boost_v2, so under daslang-live every widget is drivable:
+
+```
+daslang-live -project_root . main.das
+curl -X POST -d '{"name":"imgui_force_set","args":{"target":"CUBE_WIN/SPEED","value":4.0}}' localhost:9090/command
+curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command
+curl -X POST -d '{"name":"screenshot","args":{"file":"shot.png"}}' localhost:9090/command
 ```

--- a/examples/vulkan_imgui_cube/main.das
+++ b/examples/vulkan_imgui_cube/main.das
@@ -2,25 +2,23 @@ options gen2
 options indenting = 4
 
 // Spinning cube rendered with dasVulkan, with a Dear ImGui control panel whose slider drives the
-// rotation speed -- and the ImGui UI is rasterized by a renderer backend written entirely in
-// daslang (vulkan/vulkan_imgui_driver). Cube and UI share one swapchain render pass: the cube draws first
-// (back-face culled, so no depth buffer is needed for a convex mesh), then the UI blends on top.
+// rotation speed -- UI built with the imgui_boost_v2 widget DSL and rasterized by a renderer backend
+// written entirely in daslang (vulkan/vulkan_imgui_driver). The vulkan_imgui_app harness owns the
+// window/device/swapchain and wires the live stack, so the app is fully drivable under daslang-live:
+// `imgui_snapshot` dumps the widget state, `imgui_force_set {"target":"CUBE_WIN/SPEED","value":4.0}`
+// spins the cube faster, `screenshot {"file":"..."}` captures the frame. Cube and UI share one
+// swapchain render pass (the cube draws in the harness_end_frame scene block).
 //
 // Run (from the repo root):
 //   daslang -project_root examples/vulkan_imgui_cube examples/vulkan_imgui_cube/main.das
-// Close the window to exit.
+// Live:
+//   daslang-live -project_root examples/vulkan_imgui_cube examples/vulkan_imgui_cube/main.das
+// Close the window to exit; P saves screenshot.png.
 
-require glfw/glfw_boost
-require vulkan
-require vulkan/vulkan_boost
-require vulkan/vulkan_window
-require vulkan/vulkan_live
+require vulkan/vulkan_imgui_app
 require vulkan/vulkan_reflect
 require cube_shaders
-require vulkan/vulkan_imgui_driver
-require imgui
-require imgui/imgui_theme_daslang
-require daslib/defer
+require daslib/safe_addr
 require math
 
 let WIN_W = 1100
@@ -187,178 +185,96 @@ def build_cube_pipeline(device : Device; render_pass : RenderPass; layout : Pipe
     return <- b
 }
 
+// ===== app state (globals so daslang-live reloads keep them) =====
+
+var g_speed = 1.0f
+var g_angle = 0.0f
+var g_cube_vb : HostBuffer
+var g_cube_ib : HostBuffer
+var g_cube_set_layouts : array<DescriptorSetLayout>
+var g_cube_pipe_layout : PipelineLayout
+var g_cube_pipeline : Pipeline
+
 [export]
-def main {
-    if (volkInitialize() != 0) {
-        panic("no vulkan loader")
-    }
-    glfwInitVulkanLoader(vk_get_instance_proc_addr())
-    if (glfwInit() == 0) {
-        panic("can't init glfw")
-    }
-    defer() { glfwTerminate() }
-    if (glfwVulkanSupported() == 0) {
-        panic("glfw reports no vulkan support")
-    }
-    glfwWindowHint(int(GLFW_CLIENT_API), GLFW_NO_API)
-    glfwWindowHint(int(GLFW_RESIZABLE), GLFW_TRUE)
-    var window = glfwCreateWindow(WIN_W, WIN_H, "dasVulkan cube + daslang ImGui backend", null, null)
-    if (window == null) {
-        panic("can't create window")
-    }
-    defer() { glfwDestroyWindow(window) }
+def init() {
+    harness_init("dasVulkan cube + daslang ImGui backend", WIN_W, WIN_H)
+    let device = harness_device()
+    let phys = harness_phys()
 
-    // ----- instance / surface / device / queue / pool -----
-    var ext_count = 0u
-    let glfw_exts = glfwGetRequiredInstanceExtensions(unsafe(addr(ext_count)))
-    var inst_exts : array<string>
-    for (i in range(int(ext_count))) {
-        unsafe {
-            inst_exts |> push(glfw_exts[i])
-        }
-    }
-    var inscope instance <- create_instance("vulkan_imgui_cube", make_api_version(1u, 3u, 0u), inst_exts)
-    volkLoadInstance(boost_value_to_vk(instance))
-    var inscope surface <- create_surface(instance, glfwGetNativeWindow(window), glfwGetNativeDisplay())
-    let phys = select_physical_device(instance)
-    let gfx = select_graphics_queue_family(phys)
-    if (!queue_family_supports_present(phys, gfx, surface)) {
-        panic("graphics queue family does not support presentation")
-    }
-    var inscope device <- create_device(phys, gfx, ["VK_KHR_swapchain"])
-    volkLoadDevice(boost_value_to_vk(device))
-    let queue = get_device_queue(device, gfx, 0u)
-    var poolci : CommandPoolCreateInfo
-    poolci.queueFamilyIndex = gfx
-    var inscope pool <- create_command_pool(device, poolci)
-
-    // ----- swapchain + color-only render pass (present) + framebuffers -----
-    // UNORM (pass-through) swapchain: the cube + ImGui both output already-sRGB colors, so we must NOT
-    // let the GPU sRGB-encode them again. Matches how the GL tools render (GL_FRAMEBUFFER_SRGB off).
-    var inscope swap <- create_swapchain(device, phys, surface, WIN_W, WIN_H, VkFormat.B8G8R8A8_UNORM)
-    var inscope render_pass <- create_render_pass_single_color(device, swap.format, VkImageLayout.PRESENT_SRC_KHR)
-    build_swapchain_framebuffers(device, swap, render_pass)
-    var inscope sync <- create_frame_sync(device)
-
-    // hand vulkan_live the objects its screenshot / recording commands read (it owns none of them)
-    vk_live_set_target(device, phys, queue, pool, swap)
-
-    // ----- cube resources -----
     var vb_usage : VkBufferUsageFlags
     vb_usage.vertex_buffer = true
     var verts_copy := cube_vertices
-    var inscope cube_vb <- create_host_buffer_from_bytes(device, phys, vb_usage, verts_copy)
+    g_cube_vb <- create_host_buffer_from_bytes(device, phys, vb_usage, verts_copy)
     delete verts_copy
     var ib_usage : VkBufferUsageFlags
     ib_usage.index_buffer = true
     var indices_copy := cube_indices
-    var inscope cube_ib <- create_host_buffer_from_bytes(device, phys, ib_usage, indices_copy)
+    g_cube_ib <- create_host_buffer_from_bytes(device, phys, ib_usage, indices_copy)
     delete indices_copy
 
     var cube_refl <- [decode_reflection(cube_vert_spv_reflect), decode_reflection(cube_frag_spv_reflect)]
-    var inscope cube_set_layouts <- build_descriptor_set_layouts(device, cube_refl)
-    var inscope cube_pipe_layout <- build_pipeline_layout(device, cube_set_layouts, cube_refl)
+    g_cube_set_layouts <- build_descriptor_set_layouts(device, cube_refl)
+    g_cube_pipe_layout <- build_pipeline_layout(device, g_cube_set_layouts, cube_refl)
     delete cube_refl
     var inscope cube_vert <- create_shader_module(device, cube_vert_spv)
     var inscope cube_frag <- create_shader_module(device, cube_frag_spv)
-    var inscope cube_pipeline <- build_cube_pipeline(device, render_pass, cube_pipe_layout, cube_vert, cube_frag)
+    g_cube_pipeline <- build_cube_pipeline(device, harness_render_pass(), g_cube_pipe_layout, cube_vert, cube_frag)
+}
 
-    // ----- ImGui context + the 100%-daslang Vulkan renderer backend -----
-    let ctx = CreateContext(null)
-    load_daslang_font()       // daslang.io look (JetBrains Mono + amber theme), like the other tools
-    apply_daslang_theme()
-    var io & = unsafe(GetIO())
-    io.BackendFlags |= ImGuiBackendFlags.RendererHasTextures      // we drain the texture queue ourselves
-    io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset
-    var inscope igvk <- imgui_vk_create(device, render_pass)
-
-    var speed = 1.0f
-    var angle = 0.0f
-    var last_t = float(glfwGetTime())
-    var shot_key_was_down = false   // edge-detect the screenshot key (P)
-
-    while (glfwWindowShouldClose(window) == 0) {
-        glfwPollEvents()
-        var fbw = 0
-        var fbh = 0
-        glfwGetFramebufferSize(window, fbw, fbh)
-        if (fbw == 0 || fbh == 0) {
-            glfwWaitEvents()
-            continue
-        }
-        if (fbw != swap.width || fbh != swap.height) {
-            vkDeviceWaitIdle(boost_value_to_vk(device))
-            recreate_swapchain(swap, device, phys, surface, render_pass, fbw, fbh)
-        }
-
-        let t = float(glfwGetTime())
-        let dt = max(t - last_t, 0.0001f)
-        last_t = t
-        angle += speed * dt
-
-        // ----- feed ImGui input (mouse + display) and build the UI -----
-        io.DisplaySize = float2(float(fbw), float(fbh))
-        io.DeltaTime = dt
-        // cursor pos is in window points but DisplaySize is framebuffer pixels -- scale to match on HiDPI
-        var winw = 0
-        var winh = 0
-        glfwGetWindowSize(window, unsafe(addr(winw)), unsafe(addr(winh)))
-        let csx = winw > 0 ? float(fbw) / float(winw) : 1.0f
-        let csy = winh > 0 ? float(fbh) / float(winh) : 1.0f
-        let mpos = glfwGetCursorPos(window)
-        io |> AddMousePosEvent(mpos.x * csx, mpos.y * csy)
-        io |> AddMouseButtonEvent(0, glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_1) == GLFW_PRESS)   // ImGui button 0 = left
-
-        var win_flags : ImGuiWindowFlags
-        var slider_flags : ImGuiSliderFlags
-        NewFrame()
-        if (Begin("Controls", null, win_flags)) {
-            Text("Cube: dasVulkan. UI: a 100% daslang ImGui->Vulkan backend.")
-            Text("Drag the slider to change the spin speed.")
-            SliderFloat("Rotation speed", unsafe(addr(speed)), 0.0f, 6.0f, "%.2f", slider_flags)
-        }
-        End()
-        Render()
-
-        // upload any textures ImGui requested (the font atlas on the first frame)
-        imgui_vk_update_textures(igvk, device, phys, queue, pool)
-
-        // ----- per-frame matrices -----
-        let aspect = float(swap.width) / float(swap.height)
-        let proj = perspective_vk(45.0f * PI / 180.0f, aspect, 0.1f, 100.0f)
-        let view = look_at_rh(float3(0.0f, 1.1f, 3.2f), float3(0.0f, 0.0f, 0.0f), float3(0.0f, 1.0f, 0.0f))
-        let model = rotate_y(angle)
-        let mvp = proj * view * model
-
-        let ok = vk_live_draw_frame(render_pass, sync,
-                            clear_color(0.10f, 0.11f, 0.14f, 1.0f), true) $(cmd) {
-            // cube
-            cmd_bind_pipeline(cmd, cube_pipeline)
-            cpc.mvp = mvp
-            cpc.model = model
-            cube_vs_push_constants(cmd, cube_pipe_layout)
-            let vbufs <- [weak_copy(cube_vb.buffer)]
-            var voffs : array<uint64>
-            voffs |> push(0ul)
-            cmd_bind_vertex_buffers(cmd, 0u, vbufs, voffs)
-            cmd_bind_index_buffer(cmd, weak_copy(cube_ib.buffer), 0ul, VkIndexType.UINT16)
-            cmd_draw_indexed(cmd, 36u, 1u, 0u, 0, 0u)
-            // UI on top, via the daslang backend
-            imgui_vk_render(igvk, device, phys, cmd)
-        }
-        if (!ok) {
-            vkDeviceWaitIdle(boost_value_to_vk(device))
-            recreate_swapchain(swap, device, phys, surface, render_pass, fbw, fbh)
-        }
-        // press P to capture the current frame via vulkan_live (swapchain readback -> PNG)
-        let shot_key_down = glfwGetKey(window, GLFW_KEY_P) == GLFW_PRESS
-        if (shot_key_down && !shot_key_was_down) {
-            if (vk_live_save_screenshot("vulkan_imgui_cube.png")) {
-                print("saved vulkan_imgui_cube.png\n")
-            }
-        }
-        shot_key_was_down = shot_key_down
+[export]
+def update() {
+    if (!harness_begin_frame()) {
+        return
     }
-    vkDeviceWaitIdle(boost_value_to_vk(device))
-    DestroyContext(ctx)
+    harness_new_frame()
+
+    var io & = unsafe(GetIO())
+    g_angle += g_speed * io.DeltaTime
+
+    window(CUBE_WIN, (text = "Controls", closable = false,
+                      flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+        text("Cube: dasVulkan. UI: a 100% daslang ImGui->Vulkan backend.")
+        text("Drag the slider to change the spin speed.")
+        edit_slider_float(safe_addr(g_speed), (id = "SPEED", text = "Rotation speed",
+                                               v_min = 0.0f, v_max = 6.0f))
+    }
+
+    let sz = harness_size()
+    let aspect = float(sz.x) / float(max(sz.y, 1))
+    let proj = perspective_vk(45.0f * PI / 180.0f, aspect, 0.1f, 100.0f)
+    let view = look_at_rh(float3(0.0f, 1.1f, 3.2f), float3(0.0f, 0.0f, 0.0f), float3(0.0f, 1.0f, 0.0f))
+    let model = rotate_y(g_angle)
+    let mvp = proj * view * model
+
+    harness_end_frame() $(cmd : CommandBuffer) {
+        cmd_bind_pipeline(cmd, g_cube_pipeline)
+        cpc.mvp = mvp
+        cpc.model = model
+        cube_vs_push_constants(cmd, g_cube_pipe_layout)
+        let vbufs <- [weak_copy(g_cube_vb.buffer)]
+        var voffs : array<uint64>
+        voffs |> push(0ul)
+        cmd_bind_vertex_buffers(cmd, 0u, vbufs, voffs)
+        cmd_bind_index_buffer(cmd, weak_copy(g_cube_ib.buffer), 0ul, VkIndexType.UINT16)
+        cmd_draw_indexed(cmd, 36u, 1u, 0u, 0, 0u)
+    }
+}
+
+[export]
+def shutdown() {
+    delete g_cube_pipeline
+    delete g_cube_pipe_layout
+    delete g_cube_set_layouts
+    delete g_cube_ib
+    delete g_cube_vb
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
 }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -140,9 +140,10 @@ struct LoopTargets {
 // ===== per-control-flow-node label ids (visitor side-maps; allocated to match the hand-walker's
 // linear id order so the emitted blob stays byte-identical) =====
 struct IteIds {
-    merge   : uint
-    then_l  : uint
-    else_l  : uint   // == merge when there is no else branch (no separate else label emitted)
+    merge     : uint
+    then_l    : uint
+    else_l    : uint   // == merge when there is no else branch (no separate else label emitted)
+    then_term : bool   // then-branch ended terminated (recorded when the else block opens)
 }
 
 struct LoopIds {
@@ -1163,6 +1164,16 @@ def private binop_code(op : string; cls : int) : tuple<ok : bool; code : SpvOp> 
         if (cls == 0) return (ok = true, code = SpvOp.SRem)
         if (cls == 1) return (ok = true, code = SpvOp.UMod)
     }
+    // bitwise family: int/uint only; `>>` splits arithmetic/logical by signedness (daslang C semantics)
+    let is_int = cls == 0 || cls == 1
+    if (op == "&" && is_int) return (ok = true, code = SpvOp.BitwiseAnd)
+    if (op == "|" && is_int) return (ok = true, code = SpvOp.BitwiseOr)
+    if (op == "^" && is_int) return (ok = true, code = SpvOp.BitwiseXor)
+    if (op == "<<" && is_int) return (ok = true, code = SpvOp.ShiftLeftLogical)
+    if (op == ">>") {
+        if (cls == 0) return (ok = true, code = SpvOp.ShiftRightArithmetic)
+        if (cls == 1) return (ok = true, code = SpvOp.ShiftRightLogical)
+    }
     return (ok = false, code = SpvOp.Nop)
 }
 
@@ -2119,8 +2130,14 @@ class SpirvEmit : AstVisitor {
                         errs |> push("unsupported compound assignment '{expr.op}'")
                         return expr
                     }
+                    // vector <op>= scalar: splat the scalar rhs (SPIR-V arithmetic operands must match)
+                    var rhs2 = rhs
+                    let dn = component_count(expr.left._type.baseType)
+                    if (dn > 1 && component_count(expr.right._type.baseType) == 1) {
+                        rhs2 = splat_to_vec(bm, p.pty, rhs, dn)
+                    }
                     res = alloc_id(bm)
-                    emit(bm, SEC_FUNCS, bo.code, p.pty, res, cur, rhs)
+                    emit(bm, SEC_FUNCS, bo.code, p.pty, res, cur, rhs2)
                 }
                 emit(bm, SEC_FUNCS, SpvOp.Store, p.id, res)
             }
@@ -2160,8 +2177,21 @@ class SpirvEmit : AstVisitor {
             return expr
         }
         let rt = emit_type(bm, expr._type)
+        // SPIR-V arithmetic operands must match the result type: splat a scalar operand against a
+        // vector one (daslang broadcasts vec <op> scalar; `*` already went through emit_mul above)
+        var lid = l
+        var rid = r
+        let rn = component_count(expr._type.baseType)
+        if (rn > 1) {
+            if (component_count(expr.left._type.baseType) == 1) {
+                lid = splat_to_vec(bm, rt, l, rn)
+            }
+            if (component_count(expr.right._type.baseType) == 1) {
+                rid = splat_to_vec(bm, rt, r, rn)
+            }
+        }
         let res = alloc_id(bm)
-        emit(bm, SEC_FUNCS, bo.code, rt, res, l, r)
+        emit(bm, SEC_FUNCS, bo.code, rt, res, lid, rid)
         e2id[intptr(expr)] = res
         return expr
     }
@@ -3030,6 +3060,20 @@ class SpirvEmit : AstVisitor {
                 let a0 = expr.arguments[0]
                 let cc = component_count(a0._type.baseType)
                 if (scalar_class(a0._type.baseType) != vc.cls) {
+                    // same-width component-kind conversion: float2(uint2) -> OpConvertUToF,
+                    // int2(uint2) -> OpBitcast, ... (OpConvert*/OpBitcast are vector-valid)
+                    let src_cls = scalar_class(a0._type.baseType)
+                    if (cc == vc.n && src_cls >= 0) {
+                        let cv = convert_op(src_cls, vc.cls)
+                        if (cv.ok) {
+                            let aid = value_of(a0)
+                            if (aid == 0u) return expr
+                            let res = alloc_id(bm)
+                            emit(bm, SEC_FUNCS, cv.code, rt, res, aid)
+                            e2id[k] = res
+                            return expr
+                        }
+                    }
                     errs |> push("{name}: component-kind conversion from {a0._type.baseType} is not supported yet")
                     return expr
                 }
@@ -3210,6 +3254,9 @@ class SpirvEmit : AstVisitor {
     def override preVisitExprIfThenElseElseBlock(var expr : ExprIfThenElse?; elseBlock : ExpressionPtr) : void {
         let ids = ite_ids?[intptr(expr)] ?? IteIds()
         var bm & = unsafe(*m)
+        if (key_exists(ite_ids, intptr(expr))) {
+            ite_ids[intptr(expr)].then_term = ctx.terminated
+        }
         if (!ctx.terminated) emit(bm, SEC_FUNCS, SpvOp.Branch, ids.merge)
         emit(bm, SEC_FUNCS, SpvOp.Label, ids.else_l)
         ctx.terminated = false
@@ -3218,9 +3265,18 @@ class SpirvEmit : AstVisitor {
     def override visitExprIfThenElse(var expr : ExprIfThenElse?) : ExpressionPtr {
         let ids = ite_ids?[intptr(expr)] ?? IteIds()
         var bm & = unsafe(*m)
+        let last_term = ctx.terminated      // else-branch termination (or then's, when there is no else)
         if (!ctx.terminated) emit(bm, SEC_FUNCS, SpvOp.Branch, ids.merge)
         emit(bm, SEC_FUNCS, SpvOp.Label, ids.merge)
-        ctx.terminated = false
+        if (expr.if_false != null && ids.then_term && last_term) {
+            // both branches terminate (the optimizer folds trailing code into `else`, so a body can
+            // END on such an if) — the merge block is unreachable: close it and stay terminated so
+            // the function-end check doesn't misread this as a missing return
+            emit(bm, SEC_FUNCS, SpvOp.Unreachable)
+            ctx.terminated = true
+        } else {
+            ctx.terminated = false
+        }
         return expr
     }
 

--- a/tests/spirv/_spirv_xmod.das
+++ b/tests/spirv/_spirv_xmod.das
@@ -1,0 +1,28 @@
+options gen2
+options indenting = 4
+options no_aot     // the fixture exists to pin the optimizer-folded REQUIRED-module shape; the same
+                   // root-vs-required fold asymmetry makes its AOT semantic hash unstable (50101)
+
+// Cross-module shader-helper fixture for test_return_paths. Functions in a REQUIRED module reach
+// the emitter OPTIMIZED (required modules finish optimization before the requiring module's macros
+// run), and the optimizer folds trailing code after a returning `if` into an `else` — producing
+// if/else bodies where BOTH branches return. Keep these shapes verbatim: they pin the real-world
+// path (a shared CPU/GPU core module) that same-file fixtures can't reach.
+
+module _spirv_xmod public
+
+
+def xm_clip(x : float; var out_v : float&) : bool {
+    if (x < 0.0) {
+        return false
+    }
+    out_v = x * 2.0
+    return true
+}
+
+def xm_sign_mag(x : float) : float {
+    if (x < 0.0) {
+        return -x
+    }
+    return x + 1.0
+}

--- a/tests/spirv/test_bitwise.das
+++ b/tests/spirv/test_bitwise.das
@@ -1,0 +1,56 @@
+options gen2
+options indenting = 4
+
+// Bitwise/shift binary ops gate (found by the one-source path tracer's PCG RNG).
+//
+// binop_code previously covered only +,-,*,/,% — every bitwise binary op (&, |, ^, <<, >>) failed
+// "unsupported binary op". They lower to BitwiseAnd/Or/Xor + ShiftLeftLogical, and `>>` splits by
+// signedness: uint -> ShiftRightLogical, int -> ShiftRightArithmetic (daslang C semantics). The
+// fixture is the PCG hash step — the canonical stateless shader RNG — plus an int arithmetic-shift
+// arm. spirv-val'd.
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require spirv/spirv_shader         // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis            // has_op
+require spirv/spirv_grammar        // SpvOp
+
+var @ssbo @binding = 0 bw_data : array<uint>
+var @ssbo @binding = 1 bw_idata : array<int>
+
+def private bw_pcg_hash(x : uint) : uint {
+    let state = x * 747796405u + 2891336453u
+    let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u
+    return (word >> 22u) ^ word
+}
+
+[compute_shader(local_size_x=64, name="bw_spv"), marker(no_coverage)]
+def bw {
+    let i = gl_GlobalInvocationID.x
+    var h = bw_pcg_hash(bw_data[i])
+    h = (h & 0xFFu) | (h << 8u)
+    bw_data[i] = h
+    let s = bw_idata[i]
+    bw_idata[i] = (s >> 2) & 15
+}
+
+[test]
+def test_bitwise(t : T?) {
+    t |> run("bitwise &,|,^,<<,>> -> BitwiseAnd/Or/Xor + shifts (>> splits by signedness); spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(bw_spv)
+        t |> success(has_op(words, SpvOp.BitwiseAnd), "& -> OpBitwiseAnd")
+        t |> success(has_op(words, SpvOp.BitwiseOr), "| -> OpBitwiseOr")
+        t |> success(has_op(words, SpvOp.BitwiseXor), "^ -> OpBitwiseXor")
+        t |> success(has_op(words, SpvOp.ShiftLeftLogical), "<< -> OpShiftLeftLogical")
+        t |> success(has_op(words, SpvOp.ShiftRightLogical), "uint >> -> OpShiftRightLogical")
+        t |> success(has_op(words, SpvOp.ShiftRightArithmetic), "int >> -> OpShiftRightArithmetic")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}

--- a/tests/spirv/test_return_paths.das
+++ b/tests/spirv/test_return_paths.das
@@ -1,0 +1,56 @@
+options gen2
+options indenting = 4
+options no_aot     // requires the no_aot _spirv_xmod fixture (optimizer-folded shape; AOT hash unstable)
+
+// Both-branches-return if/else (found lowering the one-source path tracer's shared core module).
+//
+// When BOTH branches of an if/else terminate (return), the selection-merge block is unreachable.
+// The emitter used to unconditionally reset terminated=false after the merge label, so a function
+// BODY ending on such an if was misread as "not every control-flow path returns a value". Now the
+// merge block is closed with OpUnreachable and the function stays terminated. Two sources of the
+// shape: explicit if/else-both-return in the same file, and a REQUIRED module (see _spirv_xmod.das)
+// whose optimizer-folded functions arrive with trailing code folded into `else`. spirv-val'd.
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require _spirv_xmod                // optimized cross-module helpers
+require spirv/spirv_shader         // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis            // has_op / count_op
+require spirv/spirv_grammar        // SpvOp
+
+var @ssbo @binding = 0 rp_data : array<float>
+
+// explicit both-return if/else as the WHOLE body (same-file, unoptimized AST)
+def private rp_pick(x : float) : float {
+    if (x < 0.0) {
+        return 0.0
+    } else {
+        return x * 2.0
+    }
+}
+
+[compute_shader(local_size_x=64, name="rp_spv"), marker(no_coverage)]
+def rp {
+    let i = int(gl_GlobalInvocationID.x)
+    var v = 0.0
+    if (xm_clip(rp_data[i], v)) {
+        rp_data[i] = rp_pick(v) + xm_sign_mag(v)
+    }
+}
+
+[test]
+def test_return_paths(t : T?) {
+    t |> run("if/else with both branches returning: merge closes with OpUnreachable; spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(rp_spv)
+        t |> success(length(words) > 0, "shader with both-return if/else bodies lowers")
+        t |> success(has_op(words, SpvOp.Unreachable), "unreachable merge block closed with OpUnreachable")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}

--- a/tests/spirv/test_vec_convert.das
+++ b/tests/spirv/test_vec_convert.das
@@ -1,0 +1,50 @@
+options gen2
+options indenting = 4
+
+// Same-width vector component-kind conversions (found writing the tutorial-15 raygen; the natural
+// idiom `int2(gl_GlobalInvocationID.xy)` used to fail "component-kind conversion ... not supported").
+//
+// A single-argument vecN constructor whose argument is a vecN of a DIFFERENT component kind is a
+// plain conversion: OpConvertSToF/UToF/FToS/FToU for value conversions, OpBitcast for int<->uint —
+// all vector-valid in SPIR-V (result type = the vector type). Cross-width cross-kind stays rejected.
+// spirv-val'd.
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require spirv/spirv_shader         // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis            // has_op
+require spirv/spirv_grammar        // SpvOp
+
+var @ssbo @binding = 0 vc_out : array<float4>
+
+[compute_shader(local_size_x=64, name="vc_spv"), marker(no_coverage)]
+def vc {
+    let gid = gl_GlobalInvocationID.xy      // uint2
+    let f = float2(gid)                     // uint2 -> float2 : OpConvertUToF
+    let si = int2(gid)                      // uint2 -> int2   : OpBitcast
+    let f3 = float3(int3(si.x, si.y, 3))    // int3 -> float3  : OpConvertSToF
+    let u2 = uint2(f * 4.0)                 // float2 -> uint2 : OpConvertFToU
+    let i2 = int2(f)                        // float2 -> int2  : OpConvertFToS
+    let i = int(gl_GlobalInvocationID.x)
+    vc_out[i] = float4(f.x + f3.x, float(si.y), float(u2.x), float(i2.y))
+}
+
+[test]
+def test_vec_convert(t : T?) {
+    t |> run("same-width vector kind conversions -> OpConvert*/OpBitcast on vectors; spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(vc_spv)
+        t |> success(has_op(words, SpvOp.ConvertUToF), "float2(uint2) -> OpConvertUToF")
+        t |> success(has_op(words, SpvOp.ConvertSToF), "float3(int3) -> OpConvertSToF")
+        t |> success(has_op(words, SpvOp.ConvertFToU), "uint2(float2) -> OpConvertFToU")
+        t |> success(has_op(words, SpvOp.ConvertFToS), "int2(float2) -> OpConvertFToS")
+        t |> success(has_op(words, SpvOp.Bitcast), "int2(uint2) -> OpBitcast")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}

--- a/tests/spirv/test_vec_scalar_arith.das
+++ b/tests/spirv/test_vec_scalar_arith.das
@@ -1,0 +1,51 @@
+options gen2
+options indenting = 4
+
+// Vector / scalar arithmetic broadcast (found by spirv-val on the one-source path tracer:
+// `acc / float(frame + 1)` emitted a shape-mismatched OpFDiv).
+//
+// SPIR-V arithmetic requires both operands to match the result type. Of daslang's binops only
+// * and / broadcast vec <op> scalar (+/- are typer-rejected); `*` was already routed through
+// OpVectorTimesScalar (test_vecarith), so `/` — plain and compound — is the exposed path. The
+// emitter now splats the scalar operand to the vector width via OpCompositeConstruct. spirv-val'd.
+
+require dastest/testing_boost public
+require _spirv_common              // validate_spirv
+require spirv/spirv_shader         // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis            // has_op
+require spirv/spirv_grammar        // SpvOp
+
+var @ssbo @binding = 0 vsa_out : array<float4>
+var @ssbo @binding = 1 vsa_iout : array<int4>
+
+[compute_shader(local_size_x=64, name="vsa_spv"), marker(no_coverage)]
+def vsa {
+    let i = int(gl_GlobalInvocationID.x)
+    let n = float(i + 1)
+    var v = vsa_out[i].xyz
+    v = v / n                       // FDiv: scalar rhs splat
+    var acc = vsa_out[i]
+    acc /= n                        // compound /= with scalar rhs (float4)
+    vsa_out[i] = float4(v, 0.0) + acc
+    var iv = vsa_iout[i].xyz
+    iv = iv / (i + 2)               // SDiv: int vector / int scalar splat
+    vsa_iout[i] = int4(iv, 0)
+}
+
+[test]
+def test_vec_scalar_arith(t : T?) {
+    t |> run("vec / scalar splats the scalar operand (FDiv/SDiv, plain + compound); spirv-val clean") <| @(t : T?) {
+        var words <- clone_to_move(vsa_spv)
+        t |> success(has_op(words, SpvOp.FDiv), "v / s -> OpFDiv (splat rhs)")
+        t |> success(has_op(words, SpvOp.SDiv), "ivec / int -> OpSDiv (splat rhs)")
+        t |> success(has_op(words, SpvOp.CompositeConstruct), "scalar operands splatted via OpCompositeConstruct")
+        let r = validate_spirv(words)
+        if (r.ran) {
+            t |> success(r.ok, "spirv-val: {r.msg}")
+        } else {
+            feint("spirv-val not found locally; skipping (CI enforces)\n")
+        }
+        delete words
+    }
+}


### PR DESCRIPTION
## Emitter fixes (each found by lowering the showcase's real shared core; each pinned by a `tests/spirv` regression test)

1. **Bitwise/shift binops** `& | ^ << >>` on int/uint — `binop_code` covered only `+ - * / %`; the PCG shader RNG needs the bitwise family. `>>` splits `ShiftRightArithmetic` / `ShiftRightLogical` by signedness (daslang C semantics). → `test_bitwise`
2. **Same-width vector component-kind conversions** — `float2(uint2)` → `OpConvertUToF`, `int2(uint2)` → `OpBitcast`, etc., via the existing `convert_op` in the single-arg vector constructor (`OpConvert*`/`OpBitcast` are vector-valid). The natural `int2(gl_GlobalInvocationID.xy)` idiom used to fail. → `test_vec_convert`
3. **if/else where both branches return** — required modules reach the emitter *optimizer-folded* (trailing code after a returning `if` folds into `else`), and the selection-merge label unconditionally reset `terminated`, misreporting "not every control-flow path returns a value". The unreachable merge block now closes with `OpUnreachable` and stays terminated. Same-file shaders never see optimized ASTs, which is why no tutorial ever hit this — it is load-bearing for any shared CPU/GPU core module. → `test_return_paths` + the `_spirv_xmod` cross-module fixture (`no_aot`: the same root-vs-required fold asymmetry makes its AOT semantic hash unstable)
4. **`vec / scalar` arithmetic** emitted a shape-mismatched `OpFDiv` (caught by spirv-val); scalar operands now splat to the vector width in the binop and compound-assignment paths. Of daslang's binops only `*` (already routed via `OpVectorTimesScalar`) and `/` broadcast. → `test_vec_scalar_arith`

## `examples/vulkan/one_source_path_tracer` — one source, four engines

The same `pt_core` functions — Cornell scene in `@ssbo` globals, PCG RNG, NEE + mirror integrator — run on four execution tiers, live-switchable from an imgui_boost_v2 panel:

| Engine | 512², RTX 3060 Ti |
|---|---|
| CPU interp / JIT, 1 thread | ~0.03 / ~0.4 Mpaths/s |
| CPU band threads | ~0.1 / ~1.6 Mpaths/s |
| dasSpirv compute | ~110 Mpaths/s |
| hardware ray tracing (dasVulkan #62 rails; BLAS/TLAS from the same arrays, shading stays in raygen reusing the shared functions) | ~330 Mpaths/s |

No GLSL anywhere. CPU-vs-compute pixel parity: mean-abs-diff 0.028/255, zero pixels off by more than 8 (identical RNG streams); hardware RT differs only at watertight-traversal edges (0.01% of pixels, tutorial-15 budget). Depends on dasVulkan + dasImgui via daspkg (`.das_package`), like `examples/vulkan_imgui_cube` — not built by root CMake or CI.

`examples/vulkan_imgui_cube` is ported to the `vulkan_imgui_app` harness + the imgui_boost_v2 widget DSL (borisbat/dasVulkan#63, merged), so **both Vulkan examples run under daslang-live and answer `imgui_snapshot` / `imgui_click` / `imgui_force_set`** — verified live: engine switch via force_set and a real synthesized click, slider set, screenshot capture, hot reload.

## Validation

- lint 0 issues on the changed set; whole spirv suite 180/180 (golden + census gates untouched)
- full preflight green (interp + JIT suites, docs, format); AOT suite run manually from a plain shell (preflight's DLL-flavor host can't relink): **10044 tests, 0 failed, 0 errors**
- both examples validated under `VK_LAYER_KHRONOS_validation` on the GPU engines (two pre-existing `vulkan_live` findings noted for a dasVulkan follow-up: screenshot transitions a non-acquired presentable image; `g_readback` never freed at exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)