### PR TITLE
gc_node: survive panic inside ast_gc_guard / ast_gc_collect_scope

### DIFF
--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -396,8 +396,14 @@ namespace das {
     }
 
     void ast_gc_guard ( const TBlock<void> & block, Context * context, LineInfoArg * at ) {
-        gc_guard scope;
-        das_invoke<void>::invoke(context,at,block);
+        bool ok;
+        {
+            gc_guard scope;
+            ok = context->runWithCatch([&]() {
+                das_invoke<void>::invoke(context,at,block);
+            });
+        }
+        if ( !ok ) context->rethrow();
     }
 
     // Build fn->body inside `block` on a fresh scoped gc root; on exit, promote the body's
@@ -407,11 +413,17 @@ namespace das {
     // at fn->body, not fn: fn already lives on the enclosing root, so fn->gc_collect would hit
     // the gc_owner==target early-out and collect nothing.
     void ast_gc_collect_scope ( FunctionPtr fn, const TBlock<void> & block, Context * context, LineInfoArg * at ) {
-        gc_guard scope;
-        das_invoke<void>::invoke(context,at,block);
-        if ( fn && fn->body ) {
-            fn->body->gc_collect(scope.saved_thread_root, &scope.guard_root);
+        bool ok;
+        {
+            gc_guard scope;
+            ok = context->runWithCatch([&]() {
+                das_invoke<void>::invoke(context,at,block);
+            });
+            if ( fn && fn->body ) {
+                fn->body->gc_collect(scope.saved_thread_root, &scope.guard_root);
+            }
         }
+        if ( !ok ) context->rethrow();
     }
 
     // Free a SINGLE orphaned AST expression node mid-compile, instead of waiting for the

--- a/tests/gc/test_gc_guard.das
+++ b/tests/gc/test_gc_guard.das
@@ -21,6 +21,27 @@ def test_ast_gc_guard_basic(t : T?) {
 }
 
 [test]
+def test_ast_gc_guard_panic_recover(t : T?) {
+    var recovered = false
+    try {
+        ast_gc_guard() {
+            var tmp = qmacro(type<int>)
+            panic("boom")
+        }
+    } recover {
+        recovered = true
+    }
+    t |> success(recovered, "panic should propagate out of ast_gc_guard")
+    // pre-fix the panic longjmp'd past the guard destructor, leaving the active gc
+    // root pointing at a dead stack frame — new nodes then miss the thread root
+    let before = gc_thread_root_count()
+    var probe = qmacro(gc_guard_probe)
+    let after = gc_thread_root_count()
+    t |> success(after > before, "allocations must land on the restored thread root (before={before}, after={after})")
+    unsafe(delete_expression(probe))
+}
+
+[test]
 def test_ast_gc_guard_sweeps(t : T?) {
     let before = gc_thread_root_count()
     ast_gc_guard() {


### PR DESCRIPTION
Fixes #3349.

## Problem

A `panic` inside `ast_gc_guard() { ... }` (or `ast_gc_collect_scope`) crashes the compiler with SIGSEGV in `gc_node::gc_node()` on the next AST allocation.

In the default build (`DAS_ENABLE_EXCEPTIONS=0`) panic unwinds via `longjmp`, jumping straight to the enclosing `setjmp`. The extern's C++ frame is skipped, so `gc_guard::~gc_guard()` never runs:

- the active gc root is left pointing at `guard_root` on a dead stack frame;
- the saved previous root is never restored;
- nodes allocated inside the guard are never swept.

The next `gc_node` allocation links into the dangling root → SIGSEGV.

## Fix

Invoke the block through `Context::runWithCatch` so a panic is caught at the guard boundary, let `~gc_guard` run via normal scope exit (root restored + sweep), then `Context::rethrow()` to propagate the panic to the outer handler. Same treatment for `ast_gc_collect_scope`, which additionally promotes `fn->body` even on panic so it never dangles into the sweep.

Works identically in the longjmp and `DAS_ENABLE_EXCEPTIONS=1` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
