### PR TITLE
the little wasm boy: imgui family built from source into the wasm playground + CI lane

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -178,38 +178,40 @@ jobs:
                 ./bin/daslang utils/daspkg/main.das -- install "$@"
         }
 
-        # 0. dasImgui for the playground showcases (furier, path_tracer_lab). The threaded
-        #    daslang_static interpreter binds it so those samples run in the playground itself —
-        #    not only as the wasm64 examples-card builds. daspkg installs dasImgui from the package
-        #    index into the path_tracer_lab package; build its threaded wasm32 archives (-pthread,
-        #    no memory64 -> _wasm32mt) so the ABI matches the threaded daslang_static. If any of
-        #    this fails (e.g. the dasImgui wasm release isn't in the index yet), fall back to a
-        #    plain single-thread daslang_static so the rest of the playground still deploys; only
-        #    the two imgui samples are unavailable that deploy (same non-fatal stance as the cards).
-        IMGUI_DIR="$REPO/examples/graphics/path_tracer_lab/modules/dasImgui"
-        PLAYGROUND_IMGUI=""
-        if das_install --root examples/graphics/path_tracer_lab \
-           && ( cd "$IMGUI_DIR" \
-                && emcmake cmake -S . -B _wasm_build32mt -G Ninja -DCMAKE_BUILD_TYPE=Release \
-                     -DDASLANG_DIR="$REPO" -DDAS_IMGUI_WASM_MEMORY64=OFF -DDAS_IMGUI_WASM_PTHREADS=ON \
-                && cmake --build _wasm_build32mt --target dasModuleImgui imguiApp imguiAppHeadless ); then
-            PLAYGROUND_IMGUI="-DDAS_WASM_PTHREADS=ON -DDAS_WEB_IMGUI_DIR=$IMGUI_DIR"
-            echo "playground: threaded daslang_static + dasImgui bound (furier + path_tracer_lab enabled)"
-        else
-            echo "WARNING: dasImgui wasm32mt archives unavailable — building plain daslang_static; the furier + path_tracer_lab playground samples will not run this deploy."
-        fi
+        # 0. The imgui family for the playground showcases (furier, path_tracer_lab):
+        #    clone dasImgui + dasImguiImplot + dasImguiNodeEditor into modules/ — the
+        #    root modules glob absorbs their both-worlds CMakeLists (the superbuild-
+        #    emscripten arm), so the playground build below compiles + statically links
+        #    them from source into the threaded daslang_static and embeds their .das
+        #    halves (web/CMakeLists EXISTS gates). No daspkg index or prebuilt archives
+        #    involved; the wasmboy CI lane gates this exact wiring on every PR. The
+        #    clones are REMOVED right after the playground build — the wasm64 daspkg
+        #    release flow (steps 2+) uses the externals' STANDALONE emscripten branches
+        #    via the package index and must not absorb the clones into web/build64.
+        git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImgui.git          modules/dasImgui
+        git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiImplot.git    modules/dasImguiImplot
+        git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiNodeEditor.git modules/dasImguiNodeEditor
 
         # 1. wasm32 interpreter playground (daslang_static) + vendored UI + the example .das
-        #    sources staged into site/playground. When the dasImgui archives built above, this is
-        #    the THREADED build (-pthread + dasImgui), so new_thread / JobQue map to Web Workers and
-        #    every playground sample runs cross-origin-isolated (coi-serviceworker drops the
-        #    memory64 gate for /playground). stage_site_playground also generates the furier +
-        #    path_tracer_lab samples from the canonical examples/graphics sources.
-        #    (stage_site_playground_wasm is gone — compute samples are wasm64 now, built below;
-        #    it is gated off under non-memory64 in web/CMakeLists.)
-        ( cd web && mkdir -p build && cd build \
-            && emcmake cmake -DCMAKE_BUILD_TYPE=Release -G Ninja $PLAYGROUND_IMGUI .. \
-            && ninja daslang_static stage_site_playground )
+        #    sources staged into site/playground. THREADED build (-pthread + the imgui family),
+        #    so new_thread / JobQue map to Web Workers and every playground sample runs
+        #    cross-origin-isolated (coi-serviceworker drops the memory64 gate for /playground).
+        #    stage_site_playground also generates the furier + path_tracer_lab samples from the
+        #    canonical examples/graphics sources. If the imgui-family build breaks (an external's
+        #    master regressed), degrade rather than blocking every deploy: drop the clones and
+        #    rebuild plain — only the imgui playground samples are unavailable that deploy (the
+        #    same non-fatal stance as the example cards).
+        build_playground() {
+            ( cd web && mkdir -p build && cd build \
+                && emcmake cmake -DCMAKE_BUILD_TYPE=Release -G Ninja -DDAS_WASM_PTHREADS=ON .. \
+                && ninja daslang_static stage_site_playground )
+        }
+        if ! build_playground; then
+            echo "WARNING: imgui-family playground build failed — rebuilding plain threaded daslang_static; the furier + path_tracer_lab playground samples will not run this deploy."
+            rm -rf modules/dasImgui modules/dasImguiImplot modules/dasImguiNodeEditor web/build
+            build_playground
+        fi
+        rm -rf modules/dasImgui modules/dasImguiImplot modules/dasImguiNodeEditor
 
         # 2. wasm64 archives + compute samples + games. Configure web/build64 with
         #    the prebuilt host (so the compute foreach reuses it instead of

--- a/.github/workflows/wasmboy.yml
+++ b/.github/workflows/wasmboy.yml
@@ -1,0 +1,64 @@
+# The little wasm boy: the fat man's web-side sibling. Clones the imgui family
+# (dasImgui, dasImguiImplot, dasImguiNodeEditor — the externals the playground
+# interpreter binds; no dasVulkan on wasm) into modules/ and builds the threaded
+# interpreter-in-wasm (daslang_static) with them compiled + statically linked from
+# source — the emscripten arm of the externals' superbuild CMakeLists, which
+# pages.yml deploys but no other CI exercises (each module's own CI covers the
+# standalone .shared_module / standalone-wasm halves). Runs the require-smoke
+# under node: registration + boost-path resolution (the --embed-file mounts) +
+# the static wasm link, no browser, no GPU.
+name: wasmboy
+
+on:
+  pull_request:
+    paths:
+      - 'CMakeLists.txt'
+      - 'web/**'
+      - 'examples/fatman/**'
+      - '.github/workflows/wasmboy.yml'
+      - 'include/**'
+      - 'src/**'
+  workflow_dispatch:
+
+concurrency:
+  group: wasmboy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasmboy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: "Install CMake and Ninja"
+        uses: lukka/get-cmake@latest
+
+      - name: Setup Emscripten
+        uses: emscripten-core/setup-emsdk@v11
+        with:
+          # Same pin as pages.yml (the deploy this lane gates) — see the emsdk
+          # version archaeology there before bumping.
+          version: '5.0.7'
+
+      - name: "Clone the imgui family into modules/ (master; no .daspkg_standalone marker => the modules glob includes their both-worlds CMakeLists)"
+        run: |
+          set -eux
+          git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImgui.git          modules/dasImgui
+          git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiImplot.git    modules/dasImguiImplot
+          git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiNodeEditor.git modules/dasImguiNodeEditor
+
+      - name: "Configure + build the threaded playground interpreter (daslang_static; the same config pages.yml deploys)"
+        run: |
+          set -eux
+          emcmake cmake -S web -B web/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDAS_WASM_PTHREADS=ON
+          cmake --build web/build --target daslang_static -j $(nproc)
+
+      - name: "Run the little wasm boy under node"
+        run: |
+          set -eux
+          # emsdk-bundled Node: deterministic version that supports the modern wasm
+          # EH proposal flag (try_table/exnref — gated in Node 22, default-on 24+).
+          "$EMSDK_NODE" --experimental-wasm-exnref web/test/wasmboy_node.js . web/output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,43 +598,6 @@ FOREACH(_module ${_modules})
     ENDIF()
 ENDFOREACH()
 
-# ===== External dasImgui -> wasm interpreter (daslang_static) =====
-# The /examples furier + path_tracer_lab playground cards run their .das in the
-# interpreter-in-wasm. dasImgui is an EXTERNAL module (not under modules/), so bind it
-# here when DAS_WEB_IMGUI_DIR points at a built dasImgui (its _wasm32 archives + the
-# widgets/ .das tree). Replicate the module's .das_module register_native_path list as
-# static NATIVE_MODULE entries -- the dynamic register path is gated behind
-# das_is_dll_build(), which is false in the static wasm monolith. The archive link +
-# the .das/font embeds live in web/CMakeLists.txt; this block only registers names so the
-# generated external_*.inc pick them up. Inert for every non-web build (var unset).
-IF(EMSCRIPTEN AND DAS_WEB_IMGUI_DIR)
-    MESSAGE(STATUS "daslang_static: binding external dasImgui (${DAS_WEB_IMGUI_DIR})")
-    # require imgui/<name> -> modules/dasImgui/imgui/<name>.das (the embedded widgets tree).
-    SET(_module dasImgui)
-    FILE(GLOB _imgui_das_files "${DAS_WEB_IMGUI_DIR}/widgets/*.das")
-    FOREACH(_f ${_imgui_das_files})
-        GET_FILENAME_COMPONENT(_n "${_f}" NAME_WE)
-        # imgui_boost is the v1 module name, intentionally non-compileable during the
-        # v2 refactor; the FILE widgets/imgui_boost.das actually holds module
-        # imgui_boost_v2 (registered explicitly below, name != file stem). Skip the stem.
-        IF(NOT "${_n}" STREQUAL "imgui_boost")
-            ADD_MODULE_DAS(imgui imgui ${_n})
-        ENDIF()
-    ENDFOREACH()
-    # Pre-rename dasImgui kept module imgui_boost_v2 in widgets/imgui_boost.das (the web
-    # embed mounts it under the module name); post-rename (dasImgui #218) the glob above
-    # already registered it. Tolerate both layouts.
-    IF(NOT EXISTS "${DAS_WEB_IMGUI_DIR}/widgets/imgui_boost_v2.das")
-        ADD_MODULE_DAS(imgui imgui imgui_boost_v2)
-    ENDIF()
-    UNSET(_module)
-    # C++ binding modules: register_Module_dasIMGUI / _imgui_app / _imgui_app_headless,
-    # pulled from the prebuilt wasm32 archives linked in web/CMakeLists.txt.
-    ADD_MODULE_CPP(dasIMGUI)
-    ADD_MODULE_CPP(imgui_app)
-    ADD_MODULE_CPP(imgui_app_headless)
-ENDIF()
-
 # Clean stale .shared_module files. When a module is disabled, its .shared_module
 # from a previous build may remain and cause crashes at startup (the dynamic module
 # loader tries to load them even though the module code is no longer linked).

--- a/examples/fatman/wasmboy.das
+++ b/examples/fatman/wasmboy.das
@@ -1,0 +1,31 @@
+options gen2
+options indenting = 4
+
+// The little wasm boy: the fat man's web-side sibling. Statically links the imgui
+// family (dasImgui + dasImguiImplot + dasImguiNodeEditor — the externals the
+// playground interpreter binds; no dasVulkan on wasm) into daslang_static and
+// requires them all under node. Exists purely to CI-gate the emscripten arm of the
+// externals' both-worlds CMakeLists + the web/CMakeLists .das embeds — the wiring
+// the playground's furier/path_tracer_lab cards run on. Build recipe: clone the
+// three externals into modules/ of a daslang checkout, emcmake-configure web/,
+// build daslang_static, run this file via web/test/wasmboy_node.js. A `require`
+// proves registration + boost-path resolution (the --embed-file mounts) + the
+// static wasm link; nothing here opens a canvas, so it runs under plain node.
+
+// C++ binding modules (require-to-link is the whole test, hence the nolints)
+require imgui                       // nolint:STYLE030
+require imgui_app                   // nolint:STYLE030
+require imgui_app_headless          // nolint:STYLE030
+require implot                      // nolint:STYLE030
+require imgui_node_editor           // nolint:STYLE030
+
+// one boost path per external — proves the ADD_MODULE_DAS registrations + embeds resolve
+require imgui/imgui_boost_v2
+require imgui/imgui_theme_daslang   // nolint:STYLE030
+require imgui/imgui_implot_boost_v2
+require imgui/imgui_node_editor_boost_v2
+
+[export]
+def main {
+    print("the little wasm boy stands: imgui + imgui_app(+headless) + implot + node_editor statically linked in wasm\n")
+}

--- a/skills/build_and_debug.md
+++ b/skills/build_and_debug.md
@@ -57,7 +57,7 @@ Optional modules are controlled by CMake flags (`DAS_*_DISABLED`). The active co
 Key flags (defaults are MIXED — see CMakeLists.txt:28-43):
 - Default `OFF` (module ENABLED by default): `DAS_HV_DISABLED` (dasHV — HTTP/WebSocket via libhv), `DAS_GLFW_DISABLED` (GLFW/OpenGL windowing), `DAS_PUGIXML_DISABLED` (XML), `DAS_AUDIO_DISABLED`, `DAS_STBIMAGE_DISABLED`, `DAS_STDDLG_DISABLED`
 - Default `ON` (module DISABLED by default): `DAS_LLVM_DISABLED` (LLVM JIT), `DAS_CLANG_BIND_DISABLED` (Clang bindings), `DAS_SQLITE_DISABLED`
-- dasImgui has no `_DISABLED` toggle — it's wired via `DAS_WEB_IMGUI_DIR`
+- dasImgui has no `_DISABLED` toggle — it's an EXTERNAL module: cloned/junctioned into `modules/` (the modules glob absorbs its both-worlds CMakeLists; a `.daspkg_standalone` marker in the dir makes the glob skip it) or loaded at runtime as a `.shared_module` by the DLL-flavor host. The wasm playground binds it the same clone-into-modules way (see `.github/workflows/wasmboy.yml`)
 
 **To change modules:** edit the active `cmake.configureSettings` in `.vscode/settings.json`, then reconfigure. Or pass `-DFLAG=VALUE` to your `cmake -B build ...` command. VSCode CMake Tools will pick up settings changes automatically.
 

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -156,23 +156,32 @@ add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasS
 add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasAudio/audio@modules/dasAudio/audio")
 add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasAudio/strudel@modules/dasAudio/strudel")
 
-# External dasImgui bound into the interpreter (the /examples furier + path_tracer_lab
-# playground cards). DAS_WEB_IMGUI_DIR points at a built dasImgui; CMakeLists.txt (root)
-# registers the imgui/* NATIVE_MODULE names when it is set, here we embed the matching
-# .das sources + font and link the wasm32 archives. The imgui harness also requires the
-# dasLiveHost live/* halves (registered as NATIVE_MODULE but never embedded before, since
-# no interpreter sample required them) and the JetBrainsMono font it loads at init.
-IF(DAS_WEB_IMGUI_DIR)
-    MESSAGE(STATUS "web: embedding dasImgui (${DAS_WEB_IMGUI_DIR}) into daslang_static")
-    add_link_options("SHELL:--embed-file ${DAS_WEB_IMGUI_DIR}/widgets@modules/dasImgui/imgui")
-    # Pre-rename dasImgui kept module imgui_boost_v2 in the file widgets/imgui_boost.das;
-    # post-rename (dasImgui #218) the file carries the module's own name and the widgets/
-    # embed above already covers it. Tolerate both layouts.
-    IF(NOT EXISTS "${DAS_WEB_IMGUI_DIR}/widgets/imgui_boost_v2.das")
-        add_link_options("SHELL:--embed-file ${DAS_WEB_IMGUI_DIR}/widgets/imgui_boost.das@modules/dasImgui/imgui/imgui_boost_v2.das")
-    ENDIF()
-    add_link_options("SHELL:--embed-file ${DAS_WEB_IMGUI_DIR}/font/JetBrainsMono-Regular.ttf@modules/dasImgui/font/JetBrainsMono-Regular.ttf")
-    add_link_options("SHELL:--embed-file ${CMAKE_CURRENT_SOURCE_DIR}/../modules/dasLiveHost/live@modules/dasLiveHost/live")
+# The imgui family (EXTERNAL modules) bound into the interpreter — the furier +
+# path_tracer_lab playground cards run their .das in the interpreter-in-wasm. Clone
+# dasImgui / dasImguiImplot / dasImguiNodeEditor into modules/ (fresh clone = no
+# .daspkg_standalone marker) and the root modules glob absorbs their both-worlds
+# CMakeLists: the superbuild branch registers the C++ modules + `imgui/<name>` boost
+# paths and builds the static archives from source in-build (linked into
+# daslang_static via DAS_MODULES_LIBS — no prebuilt-archive wiring). Here we embed
+# the matching .das halves at the paths the superbuild registrations resolve
+# (modules/<dir>/<subfolder>/<name>.das), plus the harness font and the dasLiveHost
+# live/* halves the imgui harness requires (in-tree, registered but not embedded
+# otherwise). Each gate mirrors the root glob's marker check so a daspkg-installed
+# (standalone-built) checkout is not half-embedded.
+SET(_ext_modules_dir "${CMAKE_CURRENT_SOURCE_DIR}/../modules")
+IF(EXISTS "${_ext_modules_dir}/dasImgui" AND NOT EXISTS "${_ext_modules_dir}/dasImgui/.daspkg_standalone")
+    MESSAGE(STATUS "web: embedding dasImgui widgets + font into daslang_static")
+    add_link_options("SHELL:--embed-file ${_ext_modules_dir}/dasImgui/widgets@modules/dasImgui/widgets")
+    add_link_options("SHELL:--embed-file ${_ext_modules_dir}/dasImgui/font/JetBrainsMono-Regular.ttf@modules/dasImgui/font/JetBrainsMono-Regular.ttf")
+    add_link_options("SHELL:--embed-file ${_ext_modules_dir}/dasLiveHost/live@modules/dasLiveHost/live")
+ENDIF()
+IF(EXISTS "${_ext_modules_dir}/dasImguiImplot" AND NOT EXISTS "${_ext_modules_dir}/dasImguiImplot/.daspkg_standalone")
+    MESSAGE(STATUS "web: embedding dasImguiImplot daslib into daslang_static")
+    add_link_options("SHELL:--embed-file ${_ext_modules_dir}/dasImguiImplot/daslib@modules/dasImguiImplot/daslib")
+ENDIF()
+IF(EXISTS "${_ext_modules_dir}/dasImguiNodeEditor" AND NOT EXISTS "${_ext_modules_dir}/dasImguiNodeEditor/.daspkg_standalone")
+    MESSAGE(STATUS "web: embedding dasImguiNodeEditor daslib into daslang_static")
+    add_link_options("SHELL:--embed-file ${_ext_modules_dir}/dasImguiNodeEditor/daslib@modules/dasImguiNodeEditor/daslib")
 ENDIF()
 
 IF(DEFINED DAS_CONFIG_INCLUDE_DIR)
@@ -189,30 +198,6 @@ add_subdirectory(.. ${CMAKE_BINARY_DIR}/daslang_src EXCLUDE_FROM_ALL)
 set_target_properties(daslang_static PROPERTIES
     EXCLUDE_FROM_ALL FALSE
     RUNTIME_OUTPUT_DIRECTORY ${DAS_WEB_OUTPUT_DIR})
-
-# Link the prebuilt dasImgui wasm32 archives into daslang_static. The root CMake's
-# ADD_MODULE_CPP(dasIMGUI/imgui_app/imgui_app_headless) put register_Module_* references
-# into the interpreter's main; these archives supply them (+ imgui itself). App/headless
-# reference the imgui core, so list core last (wasm-ld resolves archives iteratively, but
-# keep the natural order). GLFW symbols come from -sUSE_GLFW=3 at this final link.
-IF(DAS_WEB_IMGUI_DIR)
-    # Match the dasImgui archive ABI to this build: threaded daslang_static (-pthread,
-    # DAS_WASM_PTHREADS=ON, so new_thread/JobQue run on real Web Workers in the playground)
-    # links the _wasm32mt archives; a single-thread build links _wasm32.
-    IF(DAS_WASM_PTHREADS)
-        SET(_imgui_archive_dir "${DAS_WEB_IMGUI_DIR}/_wasm32mt")
-    ELSE()
-        SET(_imgui_archive_dir "${DAS_WEB_IMGUI_DIR}/_wasm32")
-    ENDIF()
-    target_link_libraries(daslang_static
-        "${_imgui_archive_dir}/liblibImguiApp.a"
-        "${_imgui_archive_dir}/liblibImguiAppHeadless.a"
-        "${_imgui_archive_dir}/liblibDasModuleImgui.a")
-    # imguiApp's glfw backend re-instantiates daslang's typeFactory<GLFWwindow> (also in
-    # dasGlfw); the instantiations are identical, so let the linker take the first. This is
-    # the same flag the cross-compiled examples-card apps use for the same imgui+glfw stack.
-    target_link_options(daslang_static PRIVATE "-Wl,--allow-multiple-definition")
-ENDIF()
 
 # Pin the wasm32 runtime archive into web/output/lib so it doesn't collide
 # with the host build's lib/ (root CMakeLists.txt:317 resets
@@ -256,7 +241,7 @@ add_custom_target(stage_site_playground ALL
     # The dasImgui showcase samples (furier, path_tracer_lab) are generated from the canonical
     # examples/graphics sources — no committed copies. Must run AFTER the samples copy_directory
     # above (which would otherwise overwrite them). data.json lists them; they only run in the
-    # threaded daslang_static interpreter (DAS_WEB_IMGUI_DIR + DAS_WASM_PTHREADS build).
+    # threaded daslang_static interpreter (imgui family cloned into modules/ + DAS_WASM_PTHREADS).
     COMMAND ${CMAKE_COMMAND}
         -DREPO=${CMAKE_CURRENT_SOURCE_DIR}/..
         -DDEST=${SITE_PLAYGROUND_DIR}/samples/examples

--- a/web/test/wasmboy_node.js
+++ b/web/test/wasmboy_node.js
@@ -1,0 +1,35 @@
+// Run the little wasm boy (examples/fatman/wasmboy.das) inside the WASM build by
+// mounting the host repo via NODEFS — the require-smoke for the imgui family
+// statically linked into daslang_static (see .github/workflows/wasmboy.yml).
+// Usage: node wasmboy_node.js <repo-root> <output-dir>
+//   repo-root  — path to daslang repo root (contains examples/, daslib/)
+//   output-dir — path containing daslang_static.js + daslang_static.wasm
+const path = require('path');
+
+const repoRoot  = path.resolve(process.argv[2]);
+const outputDir = path.resolve(process.argv[3]);
+
+if (!repoRoot || !outputDir) {
+    console.error('usage: node wasmboy_node.js <repo-root> <output-dir>');
+    process.exit(1);
+}
+
+// Emscripten implements exit() by throwing ExitStatus, which propagates as an
+// unhandled promise rejection. Intercept it to forward the exit code correctly.
+process.on('unhandledRejection', (reason) => {
+    if (reason && reason.name === 'ExitStatus') {
+        process.exit(reason.status);
+    }
+    console.error('WASM error:', reason);
+    process.exit(1);
+});
+
+const Module = require(outputDir + '/daslang_static.js');
+Module.onRuntimeInitialized = function() {
+    Module.FS.mkdir('/repo');
+    Module.FS.mount(Module.FS.filesystems.NODEFS, { root: repoRoot }, '/repo');
+
+    // daslib + the imgui-family .das halves are embedded by --embed-file at build
+    // time; only the smoke script itself comes from the host repo mount.
+    Module.callMain(['/repo/examples/fatman/wasmboy.das']);
+};


### PR DESCRIPTION
## The little wasm boy

The fat man's (#3351) web-side sibling. The playground interpreter (`daslang_static`) now gets the imgui family (dasImgui + dasImguiImplot + dasImguiNodeEditor) by **cloning them into `modules/`** — the modules glob absorbs their both-worlds CMakeLists (the superbuild-emscripten arm), which registers the C++ modules + `imgui/<name>` boost paths and compiles + statically links the archives **from source, in-build**. The entire `DAS_WEB_IMGUI_DIR` prebuilt-archive hand-wiring is deleted.

### Deleted
- root `CMakeLists.txt`: the `EMSCRIPTEN AND DAS_WEB_IMGUI_DIR` NATIVE_MODULE/ADD_MODULE_CPP block, incl. the `imgui_boost_v2` tolerance shim (dead since dasImgui #218)
- `web/CMakeLists.txt`: the prebuilt `liblib*.a` link block **and its `-Wl,--allow-multiple-definition`** — dasImgui #219's `DAS_IMGUI_APP_EXTERN_GLFW_TYPE_FACTORY` guard (set by the superbuild arm) kills the `GLFWwindow` typeFactory dupe at source; verified the final wasm link is clean without the flag
- `pages.yml`: step 0 (daspkg install + standalone `_wasm_build32mt` archive build + the `DAS_WEB_IMGUI_DIR`/`PLAYGROUND_IMGUI` flags)

### Added
- `web/CMakeLists.txt`: `--embed-file` mounts EXISTS-gated on the cloned modules, at the paths the superbuild registrations resolve (`modules/dasImgui/widgets` — note: `widgets`, not the old `/imgui` mount — + font + dasLiveHost `live/*`, implot + node-editor `daslib/`); each gate mirrors the root glob's `.daspkg_standalone` marker check. Implot + node-editor are NEW in the playground interpreter (the old wiring bound dasImgui only).
- `examples/fatman/wasmboy.das` — the imgui-family require-smoke (registration + boost-path resolution via the embeds + the static wasm link; no canvas, runs under plain node), driven by `web/test/wasmboy_node.js` (NODEFS mount + callMain, modeled on `dastest_wasm.js`)
- `.github/workflows/wasmboy.yml` — fatman.yml's web sibling: clone the 3 externals → emcmake-build the threaded `daslang_static` (`-DDAS_WASM_PTHREADS=ON`, the exact config pages.yml deploys, emsdk pinned 5.0.7 like pages.yml) → run the smoke under node. This is the only CI exercising the externals' superbuild-emscripten arm.
- `pages.yml`: clone → threaded playground build → **rm the clones before the wasm64 steps** (the daspkg release flow keeps using the externals' STANDALONE emscripten branches via the package index — `web/build64` must not absorb the clones); non-fatal fallback rebuilds plain if an external's master regressed, so a broken external can't block docs deploys.
- `skills/build_and_debug.md`: one-line factual fix (the "dasImgui is wired via DAS_WEB_IMGUI_DIR" claim is now wrong).

### Verified
- **Windows** (emsdk 5.0.7, externals junctioned into `modules/`): configure absorbs all three, 280/280 build, `daslang_static` links **without** `--allow-multiple-definition`, node smoke exit 0.
- **WSL Ubuntu 24.04 verbatim-CI run** (fresh clones, emsdk 5.0.7, the exact wasmboy.yml steps): build green under Linux emscripten clang `-Werror` (all vendored imgui/implot/node-editor sources warning-clean), node smoke prints `the little wasm boy stands: ...`, exit 0.
- **Playground card end-to-end in a real browser** against the WSL-staged `site/playground` served COOP/COEP: Path Tracer Lab compiles + runs in the interpreter — ImGui panel renders, click interaction switches render mode, **CPU-threads mode traces at 1.0M rays/s vs 0.3M single-thread** (real Web-Worker pthreads), 0 console errors.
- CI-mirror lint on the changed `.das` set: `0 issue(s), 0 error(s)` (the require-smoke SKIPs prerequisite resolution on hosts without the externals, same as `fatman/main.das`).
- Preflight `--full`: 13 passed, 0 failed, 4 skipped (no-C++-changed, latexmk-absent, and the two documented DLL-flavor relink skips on a diff with zero AOT/GLFW-das surface — interp + JIT suites passed).

### Ordering
Requires borisbat/dasImgui#220 (gl3w excluded from the emscripten superbuild — **merged**, `b2d5413`) — the wasmboy lane clones dasImgui@master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)