### PR TITLE
shared modules: match a promoted module by canonical require identity

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1131,7 +1131,7 @@ namespace das
     class DAS_API Module {
     public:
         Module ( const string & n = "" );
-        void promoteToBuiltin(const FileAccessPtr & access);
+        void promoteToBuiltin(const FileAccessPtr & access, const string & requireName = string());
         virtual ~Module();
         virtual void addPrerequisits ( ModuleLibrary & ) const {}
         virtual ModuleAotType aotRequire ( TextWriter & ) const { return ModuleAotType::no_aot; }
@@ -1174,7 +1174,7 @@ namespace das
         }
         friend DAS_CC_API bool compileBuiltinModule ( Module * module, const string & name, const unsigned char * const str, unsigned int str_len );
         static Module * require ( const string & name );
-        static Module * requireEx ( const string & name, bool allowPromoted, const string & expectedFileName = string() );
+        static Module * requireEx ( const string & name, bool allowPromoted, const string & requireName = string() );
         static void Initialize();
         static void CollectFileInfo(das::vector<FileInfoPtr> &accesses);
         static void Shutdown( bool dumpHandleLeaks = true );
@@ -1259,6 +1259,7 @@ namespace das
         string                                      cppClassName;       // C++ class name (e.g. "Module_Math"), set by REGISTER_MODULE
         uint64_t                                    nameHash = 0;
         string                                      fileName;           // where the module was found, if not built-in
+        string                                      promotedRequire;    // canonical require string a shared module was promoted with (e.g. "daslib/fio"); identity-matched in requireEx so a cross-directory `require` resolves it, while a mis-qualified one (bare `require fio`) does not
         union {
             struct {
                 bool    builtIn : 1;

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -221,7 +221,7 @@ namespace das {
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
         static constexpr uint32_t getVersion () { 
-            return 93;   // 93: ExprMakeArray::makeArrayOnHeap added
+            return 94;   // 94: Module::promotedRequire (shared-module canonical require identity) added
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -196,6 +196,7 @@ namespace das
         string  fileName;
         string  importName;
         bool extraDepModule = false;
+        string  requireName;    // the require string that produced this info (e.g. "daslib/fio"); carried so a promoted shared module records its canonical, directory-independent require identity
     };
 
     struct BaseRequireRecord {

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -290,16 +290,20 @@ namespace das {
         return nullptr;
     }
 
-    Module * Module::requireEx ( const string & name, bool allowPromoted, const string & expectedFileName ) {
+    Module * Module::requireEx ( const string & name, bool allowPromoted, const string & requireName ) {
         if ( !daScriptEnvironment::getBound() ) return nullptr;
         for ( auto m = daScriptEnvironment::getBound()->modules; m != nullptr; m = m->next ) {
             if ( allowPromoted || !m->promoted ) {
                 if ( m->name == name ) {
-                    // We key by module name only.
-                    // If someone required daslib/fio earlier (fio is shared),
-                    // and now we write require fio it will be found, although
-                    // it's an error.
-                    if ( m->promoted && !expectedFileName.empty() && m->fileName != expectedFileName ) {
+                    // A shared module is identity-matched by the canonical require
+                    // string it was promoted with, NOT by a directory-relative file
+                    // path. This lets `require component_macro` resolve the promoted
+                    // module from any directory, while a mis-qualified require -- bare
+                    // `require fio` for a module promoted as `daslib/fio` -- still fails.
+                    // An empty stored identity (older serialized data, extra-dependency
+                    // promotion) falls back to name-only matching.
+                    if ( m->promoted && !requireName.empty() && !m->promotedRequire.empty()
+                            && m->promotedRequire != requireName ) {
                         continue;
                     }
                     return m;
@@ -354,13 +358,14 @@ namespace das {
         isPublic = true;
     }
 
-    void Module::promoteToBuiltin(const FileAccessPtr & access) {
+    void Module::promoteToBuiltin(const FileAccessPtr & access, const string & requireName) {
         DAS_ASSERTF(!builtIn, "failed to promote. already builtin");
         next = daScriptEnvironment::getBound()->modules;
         daScriptEnvironment::getBound()->modules = this;
         builtIn = true;
         promoted = true;
         promotedAccess = access;
+        promotedRequire = requireName;
     }
 
     Module::~Module() {

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -380,7 +380,7 @@ namespace das {
                     return false;
                 }
                 auto info = access->getModuleInfo(mod, fileName);
-                auto module = Module::requireEx(mod, allowPromoted, info.fileName);
+                auto module = Module::requireEx(mod, allowPromoted, modRec.name);
                 if ( !module ) {
                     if ( !info.moduleName.empty() ) {
                         mod = info.moduleName;
@@ -388,7 +388,7 @@ namespace das {
                             *log << string(tab,'\t') << " resolved as " << mod << "\n";
                         }
                     }
-                    module = Module::requireEx(mod, allowPromoted, info.fileName); // try native with that name AGAIN (promoted?)
+                    module = Module::requireEx(mod, allowPromoted, modRec.name); // try native with that name AGAIN (promoted?)
                     if ( !module ) {
                         auto it_r = find_if(req.begin(), req.end(), [&] ( const ModuleInfo & reqM ) {
                             return reqM.moduleName == mod;
@@ -450,6 +450,7 @@ namespace das {
                                 *log << string(tab,'\t') << "from " << fileName << " require " << mod
                                     << " - ok, new module " << info.moduleName << " at " << info.fileName << "\n";
                             }
+                            info.requireName = modRec.name;
                             req.push_back(info);
                         } else {
                             if ( !access->isSameFileName(it_r->fileName, info.fileName) ) {
@@ -1467,7 +1468,7 @@ namespace das {
                 program->thisModule->fromExtraDependency = mod.extraDepModule;
                 if ( program->promoteToBuiltin ) {
                     if ( canShareModule(program) ) {
-                        program->thisModule->promoteToBuiltin(access);
+                        program->thisModule->promoteToBuiltin(access, mod.requireName);
                     } else {
                         return program;
                     }

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2755,7 +2755,7 @@ namespace das {
             for ( auto & m : modules ) {
                 bool builtin = m->builtIn, promoted = m->promoted;
                 ser << builtin << promoted;
-                ser << m->name << m->fileName;
+                ser << m->name << m->fileName << m->promotedRequire;
 
                 if ( m->builtIn && m->promoted ) {
                     bool isNew = ser.writingReadyModules.count(m) == 0;
@@ -2789,8 +2789,8 @@ namespace das {
         uint64_t size = 0; ser << size;
         for ( uint64_t i = 0; i < size; i++ ) {
             bool builtin = false, promoted = false;
-            string name, fileName;
-            ser << builtin << promoted << name << fileName;
+            string name, fileName, promotedRequire;
+            ser << builtin << promoted << name << fileName << promotedRequire;
             if ( builtin && !promoted ) {
                 // pass
             } else if ( builtin && promoted ) {
@@ -2809,7 +2809,7 @@ namespace das {
                         library.addModule(mod);
                         ser.serializeModule(*mod, /*already_exists*/false);
                         mod->builtIn = false; // suppress assert
-                        mod->promoteToBuiltin(nullptr);
+                        mod->promoteToBuiltin(nullptr, promotedRequire);
                     }
                 } else {
                     Module * m = Module::require(name);

--- a/tests-cpp/small/test_shared_module_crossdir.cpp
+++ b/tests-cpp/small/test_shared_module_crossdir.cpp
@@ -1,0 +1,75 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+
+using namespace das;
+
+// A `shared` module is promoted to the global module registry when first
+// compiled as a dependency, so a later `require` finds it "no file needed" --
+// even from a script in a different directory (see tutorials/integration/c/
+// 13_shared_module.c). The match is by the module's canonical require STRING,
+// not a directory-relative file path, so:
+//   * `require my_xmod` resolves the promoted module from ANY directory, and
+//   * a mis-qualified bare `require fio` (canonical `daslib/fio`) still fails.
+
+namespace {
+
+static ProgramPtr compileNamed(const char * name, const char * src, ModuleGroup & lib) {
+    TextPrinter tout;
+    auto fAccess = make_smart<FsFileAccess>();
+    fAccess->setFileInfo(name, make_unique<TextFileInfo>(src, uint32_t(strlen(src)), /*own*/false));
+    return compileDaScript(name, fAccess, tout, lib);
+}
+
+static const char * SHARED_MOD =
+    "options gen2\n"
+    "module my_xmod shared\n"
+    "[export] def x_double(a : int) : int { return a * 2 }\n";
+
+} // namespace
+
+TEST_CASE("shared module resolves across directories via the promoted registry") {
+    // 1) Promote my_xmod by compiling a loader that requires it. The loader and
+    //    the module file both live at the root, and share ONE FileAccess.
+    {
+        ModuleGroup lib;
+        TextPrinter tout;
+        auto fAccess = make_smart<FsFileAccess>();
+        fAccess->setFileInfo("my_xmod.das", make_unique<TextFileInfo>(SHARED_MOD, uint32_t(strlen(SHARED_MOD)), false));
+        const char * loader = "options gen2\nrequire my_xmod\n";
+        fAccess->setFileInfo("loader.das", make_unique<TextFileInfo>(loader, uint32_t(strlen(loader)), false));
+        auto p = compileDaScript("loader.das", fAccess, tout, lib);
+        REQUIRE(p);
+        CHECK_FALSE(p->failed());
+    }
+
+    // 2) A requirer in a SUBDIRECTORY, with a FRESH FileAccess that does NOT
+    //    carry my_xmod.das. It can only resolve via the promoted registry.
+    //    Before the fix this failed with error[20605] file not found, because
+    //    resolution recomputed a directory-relative "scripts/bug/my_xmod.das".
+    {
+        ModuleGroup lib;
+        auto p = compileNamed("scripts/bug/bug.das", "options gen2\nrequire my_xmod\n", lib);
+        REQUIRE(p);
+        CHECK_FALSE(p->failed());
+    }
+}
+
+TEST_CASE("bare `require fio` fails every time -- promoted daslib/fio is not name-matched") {
+    // Promote daslib/fio (module fio, canonical require "daslib/fio").
+    {
+        ModuleGroup lib;
+        auto p = compileNamed("load_fio.das", "options gen2\nrequire daslib/fio\n", lib);
+        REQUIRE(p);
+        CHECK_FALSE(p->failed());
+    }
+    // A bare `require fio` must NOT resolve the promoted module -- the canonical
+    // require identity "daslib/fio" != "fio", so it falls through to a file
+    // lookup that fails. Order-independent: holds whether or not fio was loaded.
+    {
+        ModuleGroup lib;
+        auto p = compileNamed("bare_fio.das", "options gen2\nrequire fio\n", lib);
+        REQUIRE(p);
+        CHECK(p->failed());
+    }
+}

--- a/tutorials/integration/c/13_shared_module.c
+++ b/tutorials/integration/c/13_shared_module.c
@@ -256,6 +256,39 @@ static void part2_solution(void) {
         das_modulegroup_release(libgrp);
         das_text_release(tout);
     }
+
+    // --- 2c: Requirer in a SUBDIRECTORY — still resolves ---
+    //
+    // The promoted module is matched by its canonical require string
+    // ("my_helpers"), NOT by a file path recomputed relative to the requiring
+    // script's directory. So a `require my_helpers` from a script that lives in
+    // a subdirectory resolves to the same promoted module — no module file
+    // needed, exactly as at the root.
+    {
+        das_text_writer  * tout    = das_text_make_printer();
+        das_module_group * libgrp  = das_modulegroup_make();
+        das_file_access  * fa      = das_fileaccess_make_default();
+
+        // Requirer lives under scripts/app/ — a different directory than the
+        // root loader that promoted my_helpers in Part 2a.
+        das_fileaccess_introduce_file(fa, "scripts/app/consumer.das", USER_SCRIPT, 0);
+
+        das_program * program = das_program_compile("scripts/app/consumer.das", fa, tout, libgrp);
+        int err_count = das_program_err_count(program);
+        printf("Part 2c: requirer in a subdirectory -- compilation %s\n",
+               err_count ? "FAILED (unexpected)" : "succeeded!");
+        for (int i = 0; i < err_count; i++) {
+            das_error * error = das_program_get_error(program, i);
+            char buf[1024];
+            das_error_report(error, buf, sizeof(buf));
+            printf("  error %d: %s\n", i, buf);
+        }
+
+        das_program_release(program);
+        das_fileaccess_release(fa);
+        das_modulegroup_release(libgrp);
+        das_text_release(tout);
+    }
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A `module X shared` module is promoted to the global module registry when first compiled as a dependency, so a later `require X` resolves it even when the module file isn't present in that compilation — the mechanism documented in `tutorials/integration/c/13_shared_module.c`.

But `require X` from a script in a **different directory** than the one that first promoted it failed:

```
error[20605]: missing prerequisite 'X'; file not found
        from scripts/bug/bug
```

`Module::requireEx` matched a promoted module by comparing `m->fileName` against `info.fileName` — a path `getModuleInfo` / `getIncludeFileName` recomputes **relative to the requiring file's directory**. The same shared module therefore produced a different path string from a different directory (`component_macro.das` vs `scripts/bug/component_macro.das`), so the guard rejected the promoted module and fell through to a disk lookup that failed.

Tutorial 13 documents this feature but only ever requires from the root, so the cross-directory case — the whole point of shared modules — was never exercised.

Reported at https://codeberg.org/Pukeko/BugRepro.

## Fix

Match a promoted module by the **canonical require string it was promoted with** (`Module::promotedRequire`), carried through `ModuleInfo::requireName` from the require site to the promotion site. The require string (`component_macro`, `daslib/fio`) is directory-independent, so:

- `require component_macro` resolves the promoted module from **any** directory, and
- a mis-qualified require — bare `require fio` for a module whose canonical require is `daslib/fio` — **still fails, every time**, regardless of load order (the invariant the previous path-compare enforced only by accident).

An empty stored identity (older serialized data, extra-dependency promotion) falls back to name-only matching.

## Notes

- `promotedRequire` round-trips through AST serialization; serializer version bumped 93 → 94.
- No positional `ModuleInfo` construction exists in-tree, so the added field is source-compatible.

## Testing

- **`tests-cpp/small/test_shared_module_crossdir.cpp`** (new): shared module resolves from a subdirectory via the promoted registry; bare `require fio` fails after `daslib/fio` is promoted. `ctest -L small`: 71/71 pass, leak guard clean.
- **`13_shared_module.c`**: new Part 2c requires the shared module from a subdirectory.
- Interpreter + ser/deser sweeps green (744 programs serialized, deserialize round-trips), AOT green (10054/10060, 0 failed), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)