### PR TITLE
jobque: pushBatch comments say what the code does — one notify + wake propagation

### DIFF
--- a/include/daScript/misc/job_que.h
+++ b/include/daScript/misc/job_que.h
@@ -88,7 +88,7 @@ namespace das {
         int getNumberOfQueuedJobs();
         int getTotalHwJobs();
         void push(Job && job, JobCategory category, JobPriority priority);
-        void pushBatch(vector<Job> && jobs, JobCategory category, JobPriority priority);   // one lock hold + one notify_all for the whole batch
+        void pushBatch(vector<Job> && jobs, JobCategory category, JobPriority priority);   // one lock hold + one notify for the whole batch (workers wake-propagate, see JobQue::job)
         void parallel_for ( JobStatus & status, int from, int to, const JobChunk & chunk, JobCategory category, JobPriority priority, int chunk_count = -1, int step = 1 );
         void parallel_for ( int from, int to, const JobChunk & chunk, JobCategory category, JobPriority priority, int chunk_count = -1, int step = 1 );
         void parallel_for_with_consume (int from, int to, const JobChunk & chunk, const JobChunk & consume, JobCategory category, JobPriority priority, int chunk_count = -1, int step = 1);

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -634,7 +634,8 @@ namespace das {
     }
 
     // Batched fork-job dispatch (opt-in, per DISPATCHING thread): new_job keeps the finished job
-    // closures locally and join() publishes the whole batch under ONE fifo lock + one notify_all.
+    // closures locally and join() publishes the whole batch under ONE fifo lock + one notify —
+    // the woken worker wake-propagates to the rest (JobQue::job), so the fan-out is log-depth.
     // Removes the per-job push/wake interleaving that stalls a fork/join dispatch loop: every
     // notify_one to a parked worker costs the dispatcher an OS thread-wake (~3-4.5us) serially, and
     // with spinning workers the per-push lock acquisition contends with every consumer's pop.


### PR DESCRIPTION
The followup for Copilot's two comments on #3361 (merged before the round): the `pushBatch` API comment and the batch-dispatch preamble both said "notify_all" while the implementation does `notify_one` and relies on `JobQue::job`'s wake propagation for the log-depth fan-out. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)