### PR TITLE
sprint_json: skip class methods, keep function/lambda fields valid JSON

### DIFF
--- a/doc/source/stdlib/handmade/typedef-rtti-TypeInfoFlags.rst
+++ b/doc/source/stdlib/handmade/typedef-rtti-TypeInfoFlags.rst
@@ -16,3 +16,4 @@ indicates that the type needs marking by the garbage collector.
 indicates that the type needs marking of strings by the garbage collector.
 indicates that the type needs lock checking.
 indicates that the type is private.
+indicates that the struct field is a class method.

--- a/include/daScript/simulate/debug_info.h
+++ b/include/daScript/simulate/debug_info.h
@@ -373,6 +373,7 @@ namespace das
             flag_heapGC = 1<<13,
             flag_stringHeapGC = 1<<14,
             flag_private = 1<<15,
+            flag_classMethod = 1<<16,   // struct field is a class method (set on the field VarInfo)
         };
         union {
             StructInfo *                structType;

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -209,6 +209,9 @@ namespace das {
             if (var.privateField) {
                 vi->flags |= TypeInfo::flag_private;
             }
+            if (var.classMethod) {
+                vi->flags |= TypeInfo::flag_classMethod;
+            }
             sti->fields[i] = vi;
         }
         sti->firstGcField = sti->count;

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -811,7 +811,7 @@ namespace das {
         ft->alias = "TypeInfoFlags";
         ft->argNames = { "ref", "refType", "canCopy", "isPod", "isRawPod", "isConst", "isTemp", "isImplicit",
             "refValue", "hasInitValue", "isSmartPtr", "isSmartPtrNative", "isHandled",
-            "heapGC", "stringHeapGC", "isPrivate" };
+            "heapGC", "stringHeapGC", "isPrivate", "classMethod" };
         return ft;
     }
 

--- a/src/simulate/json_print.cpp
+++ b/src/simulate/json_print.cpp
@@ -56,7 +56,9 @@ namespace das {
             }
             bool ignoreNextField = false;
             if ( si->flags & StructInfo::flag_class ) {
-                if (name == "__rtti" || name == "__finalize") {
+                // A class carries its methods as function-pointer fields. They aren't data —
+                // skip them entirely (rather than emit "kek":null) along with the class plumbing.
+                if (name == "__rtti" || name == "__finalize" || (vi->flags & TypeInfo::flag_classMethod)) {
                     ignoreNextField = true;
                 }
             }
@@ -339,6 +341,18 @@ namespace das {
             // uint64_t-backed values with the top bit set will compare bit-for-bit equal because the
             // stored value already round-tripped through int64_t at EnumValueInfo build time.
             Enum(value,info);
+        }
+        // A function pointer / block isn't JSON data. Emit `null` rather than nothing so the output
+        // stays valid JSON. Class methods are dropped earlier (flag_classMethod); this still guards
+        // the __lambda/__finalize fields inside a lambda's capture struct and any function-typed
+        // field, which otherwise left a dangling `:` and produced invalid JSON.
+        virtual void WalkFunction ( Func * ) override {
+            if ( !ignoreNextFields.empty() && ignoreNextFields.back() ) return;
+            ss << "null";
+        }
+        virtual void WalkBlock ( Block * ) override {
+            if ( !ignoreNextFields.empty() && ignoreNextFields.back() ) return;
+            ss << "null";
         }
 
         virtual bool revisitStructure ( char * /*ps*/, StructInfo * /*si*/ ) override {

--- a/tests/json/test_sprint_json.das
+++ b/tests/json/test_sprint_json.das
@@ -60,7 +60,7 @@ def test_sprint_containers(t : T?) {
         t |> equal(js != null, true)
     }
     t |> run("empty array") @(t : T?) {
-        var a : array<int>
+        let a : array<int>
         let json = sprint_json(a, false)
         var error : string
         var js = read_json(json, error)
@@ -68,7 +68,7 @@ def test_sprint_containers(t : T?) {
         t |> equal(js != null, true)
     }
     t |> run("table") @(t : T?) {
-        var tab <- { "x" => 1 }
+        let tab <- { "x" => 1 }
         let json = sprint_json(tab, false)
         var error : string
         var js = read_json(json, error)
@@ -76,7 +76,7 @@ def test_sprint_containers(t : T?) {
         t |> equal(js?.x ?? -1, 1)
     }
     t |> run("empty table") @(t : T?) {
-        var tab : table<string; int>
+        let tab : table<string; int>
         let json = sprint_json(tab, false)
         var error : string
         var js = read_json(json, error)
@@ -102,7 +102,7 @@ struct SimpleStruct {
 [test]
 def test_sprint_struct(t : T?) {
     t |> run("basic struct") @(t : T?) {
-        var s = SimpleStruct(x = 42, name = "hello")
+        let s = SimpleStruct(x = 42, name = "hello")
         let json = sprint_json(s, false)
         // verify fields are present
         var error : string
@@ -183,6 +183,56 @@ def test_sprint_class(t : T?) {
 }
 
 // ============================================================
+//  sprint_json: callables (class methods, lambdas)
+//  regression: a class method / lambda field is a function pointer with no
+//  JSON value, and JsonWriter emitted "name": with nothing after it, producing
+//  invalid JSON that read_json rejected and that dropped the whole object.
+//  Now function/block values serialize to null.
+// ============================================================
+
+class MethodClass {
+    hp : int
+    def heal() {}
+}
+
+struct LambdaFieldStruct {
+    x : int
+    fn : lambda<(a : int) : int>
+}
+
+[test]
+def test_sprint_callables(t : T?) {
+    t |> run("class method field is skipped, json stays valid") @(t : T?) {
+        var a = new MethodClass(hp = 7)
+        let json = sprint_json(a, false)        // pointer form, as reported
+        var error : string
+        var js = read_json(json, error)
+        t |> equal(error, "")                   // was "{\"hp\":7,\"heal\":}" — invalid
+        t |> equal(js?.hp ?? 0, 7)              // sibling data field survives
+        t |> equal(find(json, "heal") < 0, true) // method omitted entirely, not "heal":null
+        unsafe { delete a; }
+    }
+    t |> run("struct with initialized lambda field is valid json") @(t : T?) {
+        var b = LambdaFieldStruct(x = 3)
+        b.fn <- @(a : int) : int => a + 1
+        let json = sprint_json(b, false)
+        var error : string
+        var js = read_json(json, error)
+        t |> equal(error, "")
+        t |> equal(js?.x ?? 0, 3)
+        unsafe { delete b.fn; }
+    }
+    t |> run("standalone lambda is valid json") @(t : T?) {
+        var lam <- @(a : int) : int => a * 2
+        let json = sprint_json(lam, false)
+        var error : string
+        var js = read_json(json, error)
+        t |> equal(error, "")                   // {"__lambda":null,"__finalize":null}
+        unsafe { delete lam; }
+    }
+}
+
+// ============================================================
 //  sprint_json: null pointer
 // ============================================================
 
@@ -202,13 +252,13 @@ def test_sprint_null(t : T?) {
 def test_sprint_pretty(t : T?) {
     if (jit_enabled()) return ;
     t |> run("pretty has newlines") @(t : T?) {
-        var s = SimpleStruct(x = 1, name = "a")
+        let s = SimpleStruct(x = 1, name = "a")
         let json = sprint_json(s, true)
         // human-readable format has newlines
         t |> equal(find(json, "\n") >= 0, true)
     }
     t |> run("compact has no newlines") @(t : T?) {
-        var s = SimpleStruct(x = 1, name = "a")
+        let s = SimpleStruct(x = 1, name = "a")
         let json = sprint_json(s, false)
         // NOTE: Under JIT, sprint_json(struct, false) may produce pretty-printed
         // output for certain struct layouts.  SimpleStruct appears unaffected,
@@ -236,7 +286,7 @@ struct OptionalFields {
 [test]
 def test_annotation_optional(t : T?) {
     t |> run("default values are omitted") @(t : T?) {
-        var s <- OptionalFields(uninitialized name = "test")
+        let s <- OptionalFields(uninitialized name = "test")
         let json = sprint_json(s, false)
         var error : string
         var js = read_json(json, error)
@@ -253,7 +303,7 @@ def test_annotation_optional(t : T?) {
         t |> equal(find(json, "opt_ptr") < 0, true)
     }
     t |> run("non-default values are present") @(t : T?) {
-        var s <- OptionalFields(uninitialized
+        let s <- OptionalFields(uninitialized
             name = "test",
             opt_bool = true,
             opt_int = 42,
@@ -285,7 +335,7 @@ struct EnumFields {
 [test]
 def test_annotation_enum_as_int(t : T?) {
     t |> run("normal enum is string") @(t : T?) {
-        var s = EnumFields(normal = Color.green, as_int = Color.blue)
+        let s = EnumFields(normal = Color.green, as_int = Color.blue)
         let json = sprint_json(s, false)
         var error : string
         var js = read_json(json, error)
@@ -293,7 +343,7 @@ def test_annotation_enum_as_int(t : T?) {
         t |> equal(js?.normal ?? "", "green")
     }
     t |> run("enum_as_int is integer") @(t : T?) {
-        var s = EnumFields(normal = Color.red, as_int = Color.blue)
+        let s = EnumFields(normal = Color.red, as_int = Color.blue)
         let json = sprint_json(s, false)
         var error : string
         var js = read_json(json, error)
@@ -301,7 +351,7 @@ def test_annotation_enum_as_int(t : T?) {
         t |> equal(js?.as_int ?? -1, 2)     // blue = 2
     }
     t |> run("enum_as_int zero") @(t : T?) {
-        var s = EnumFields(normal = Color.red, as_int = Color.red)
+        let s = EnumFields(normal = Color.red, as_int = Color.red)
         let json = sprint_json(s, false)
         var error : string
         var js = read_json(json, error)
@@ -327,7 +377,7 @@ def test_annotation_embed(t : T?) {
     // pretty-printed output with newlines instead of compact JSON.
     // See test_sprint_jit_compact_bug below.
     t |> run("embedded array") @(t : T?) {
-        var s = EmbedFields(name = "test", data = "[1,2,3]")
+        let s = EmbedFields(name = "test", data = "[1,2,3]")
         let json = sprint_json(s, false)
         // data should be embedded as raw JSON, not quoted
         var error : string
@@ -337,7 +387,7 @@ def test_annotation_embed(t : T?) {
         t |> equal(js?.data is _array, true)
     }
     t |> run("embedded object") @(t : T?) {
-        var s = EmbedFields(name = "test", data = "\{\"x\":1\}")
+        let s = EmbedFields(name = "test", data = "\{\"x\":1\}")
         let json = sprint_json(s, false)
         var error : string
         var js = read_json(json, error)
@@ -346,7 +396,7 @@ def test_annotation_embed(t : T?) {
         t |> equal(js?.data?.x ?? -1, 1)
     }
     t |> run("embedded string is reparsed") @(t : T?) {
-        var s = EmbedFields(name = "test", data = "[1,2,3]")
+        let s = EmbedFields(name = "test", data = "[1,2,3]")
         let json = sprint_json(s, false)
         // the entire output should be valid JSON
         var error : string
@@ -368,13 +418,13 @@ struct UnescapeFields {
 [test]
 def test_annotation_unescape(t : T?) {
     t |> run("normal string escapes backslash") @(t : T?) {
-        var s = UnescapeFields(normal = "C:\\Users\\test", raw = "C:\\Users\\test")
+        let s = UnescapeFields(normal = "C:\\Users\\test", raw = "C:\\Users\\test")
         let json = sprint_json(s, false)
         // normal field should have escaped backslashes: C:\\Users\\test
         t |> equal(find(json, "C:\\\\Users\\\\test") >= 0, true)
     }
     t |> run("unescape preserves raw") @(t : T?) {
-        var s = UnescapeFields(normal = "hello", raw = "C:\\Users\\test")
+        let s = UnescapeFields(normal = "hello", raw = "C:\\Users\\test")
         let json = sprint_json(s, false)
         // raw field should NOT have double backslashes — just single: C:\Users\test
         // Note: @unescape produces non-standard JSON (unescaped backslashes), so
@@ -397,7 +447,7 @@ struct RenameFields {
 [test]
 def test_annotation_rename(t : T?) {
     t |> run("renamed fields in sprint_json") @(t : T?) {
-        var s = RenameFields(_type = "widget", _class = 5, normal = true)
+        let s = RenameFields(_type = "widget", _class = 5, normal = true)
         let json = sprint_json(s, false)
         var error : string
         var js = read_json(json, error)
@@ -424,7 +474,7 @@ def test_annotation_rename(t : T?) {
         var error : string
         var js = read_json("\{ \"type\": \"item\", \"class\": 7, \"normal\": true \}", error)
         t |> equal(error, "")
-        var s = from_JV(js, type<RenameFields>)
+        let s = from_JV(js, type<RenameFields>)
         t |> equal(s._type, "item")
         t |> equal(s._class, 7)
         t |> equal(s.normal, true)
@@ -443,7 +493,7 @@ struct BareRenameFields {
 [test]
 def test_annotation_rename_bare(t : T?) {
     t |> run("bare @rename strips underscore in sprint_json") @(t : T?) {
-        var s = BareRenameFields(_bare = 42, normal = "ok")
+        let s = BareRenameFields(_bare = 42, normal = "ok")
         let json = sprint_json(s, false)
         // Validate via parsed JSON — bare @rename strips leading underscore
         var error : string
@@ -461,7 +511,7 @@ def test_annotation_rename_bare(t : T?) {
         var error : string
         var js = read_json("\{ \"bare\": 7, \"normal\": \"yes\" \}", error)
         t |> equal(error, "")
-        var s = from_JV(js, type<BareRenameFields>)
+        let s = from_JV(js, type<BareRenameFields>)
         t |> equal(s._bare, 7)
         t |> equal(s.normal, "yes")
     }
@@ -489,7 +539,7 @@ def test_combined_annotations(t : T?) {
     // NOTE: @embed assertion uses parsed JSON instead of substring match
     // due to JIT bug with sprint_json compact mode — see test_sprint_jit_compact_bug.
     t |> run("all annotations together") @(t : T?) {
-        var s = CombinedAnnotations(
+        let s = CombinedAnnotations(
             _label = "test",
             pri = TestLevel.high,
             payload = "[1,2]",
@@ -507,7 +557,7 @@ def test_combined_annotations(t : T?) {
         t |> equal(js?.payload is _array, true)
     }
     t |> run("optional on enum does not skip (enum type not checked)") @(t : T?) {
-        var s = CombinedAnnotations(
+        let s = CombinedAnnotations(
             _label = "test",
             pri = TestLevel.low,        // low = 0
             payload = "[]",
@@ -523,7 +573,7 @@ def test_combined_annotations(t : T?) {
 [test]
 def test_sprint_jit_compact_bug(t : T?) {
     t |> run("compact mode should not contain newlines") @(t : T?) {
-        var s = CombinedAnnotations(
+        let s = CombinedAnnotations(
             _label = "test",
             pri = TestLevel.high,
             payload = "[1,2]",


### PR DESCRIPTION
## Bug

`sprint_json` on a class instance produced **invalid JSON** — reported via the playground:

```das
class Foo {
    lol : int = 10
    def kek() {}
}
print("{sprint_json(new Foo(), true)}\n")
```

emitted `{"lol":10,"kek":}` — a dangling colon after the method field, which `read_json` rejects and which drops the whole object. The same gap hit the `__lambda`/`__finalize` function-pointer fields inside every lambda's capture struct (a bare lambda serialized to `{"__lambda":,"__finalize":}`).

## Root cause

`JsonWriter` (a `DataWalker` in `src/simulate/json_print.cpp`) overrides a handler for every scalar/struct/array/enum type, but **none for function or block values**. A class method field is a `tFunction`; a lambda expands to a capture struct whose `__lambda`/`__finalize` fields are `tFunction`. With no `WalkFunction`/`WalkBlock` override, these emitted nothing after their `"name":`. Same class of bug the enum-fallback comment in this file already documents.

## Fix

- **Skip class-method fields entirely** (they aren't data). New `TypeInfo::flag_classMethod`, propagated from the existing `FieldDeclaration::classMethod` in `makeStructureDebugInfo` — same post-hoc pattern as `flag_private`, set on the field `VarInfo` after debug-info generation, so no semantic-hash / ABI impact and it's regenerated after deserialization. Flows into AOT typeinfo for free via the emitter's `reinterpret<int>(flags)`; named in the RTTI `TypeInfoFlags` bitfield (+ its handmade doc line).
- **Emit `null` for any remaining function/block value** (standalone lambdas, function-typed fields) so the output is always valid JSON.

Result: `{"lol":10}` for the class; `{"__lambda":null,"__finalize":null}` for a bare lambda.

## Tests

Adds `test_sprint_callables` to `tests/json/test_sprint_json.das`:
- class-with-method → method omitted, JSON parses, sibling data field survives
- struct with an initialized lambda field → valid JSON
- standalone lambda → valid JSON

## Verification

- **Interpreter**: playground repro → `{"lol":10}`; `tests/json/test_sprint_json` 61/61, `tests/rtti` 4/4; lint + format clean.
- **AOT generation**: inspected generated C++ — the method field bakes `flags = 65548` (`(1<<16) | canCopy | isPod`), i.e. `flag_classMethod` set; the AOT *runtime* uses the same `JsonWriter`, so it skips identically.
- **Docs**: `das2rst` runs clean; the handmade `TypeInfoFlags` doc gets the 17th member line (generated `rtti.rst` is gitignored / CI-regenerated).

Note: local full `test_aot` build and the clang-cl syntax gate couldn't run on this box (pre-existing VS2026-preview MSVC teardown crash blocks AOT-gen link; clang-cl STL mismatch) — both env-only, exercised properly in CI. That's why this was pushed without a local preflight token; CI is the first full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)