### PR TITLE
dasLLAMA: x64 AVX kernel matrix picks up dispatch-lane chunk sizing

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_math_default.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_default.das
@@ -5,7 +5,7 @@ module dasllama_math_default shared public
 require dasllama/dasllama_math       // KernelBackend + register_kernel_backend + g_matmul_par_threshold + repack_q8q8_identity
 require dasllama/dasllama_tune       // [tuned]: reconstitute dot_q8q8 from its template with per-box loop hints
 require daslib/jobque_boost public   // parallel_for / notify_and_release (the kernels expand parallel_for)
-require dasllama/dasllama_par        // maybe_parallel_for / get_total_hw_jobs
+require dasllama/dasllama_par        // maybe_parallel_for
 require math
 
 // The PORTABLE Q8·Q8 kernel backend — auto-vectorized dot_q8q8, no repack (row-major weights). It is
@@ -224,7 +224,7 @@ def mx4q8_batch_kernel(var yp : float?; wn : uint8 const?; we : uint8 const?; xq
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+        maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let wrow = wn + int64(i) * (n / 2l)
@@ -247,7 +247,7 @@ def mx4q8_batch_groupn_kernel(var yp : float?; wn : uint8 const?; we : uint8 con
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+        maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let ii = int64(i)

--- a/modules/dasLLAMA/dasllama/dasllama_math_x64_avx.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_x64_avx.das
@@ -483,8 +483,8 @@ def private q8q8_batch_kernel_x64_grp4(var yp : float?; wp : int8 const?; sp : f
     // @32 workers ntok=512: kv ng=128 x1 456 > x2 447 > x4 425 GMAC/s (floor binds -> x1); qo
     // ng=512 x4 473 > x1 430 (floor doesn't bind -> full oversplit).
     let TB = effective_token_block(g_q8_token_block, n)
-    let hw = get_dispatch_lanes()
-    let njobs = clamp(int(ng / 4l), hw, hw * get_q8_batch_chunks_per_job())
+    let lanes = get_dispatch_lanes()
+    let njobs = clamp(int(ng / 4l), lanes, lanes * get_q8_batch_chunks_per_job())
     maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(ng), njobs) $(rb, re) {
         unsafe {
             var tb = 0l
@@ -636,7 +636,7 @@ def private mx4q8_kernel_x64(var yp : float?; wn : uint8 const?; we : uint8 cons
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+        maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     myp[i] = dot_mx4q8_x64(lutp, wn + int64(i) * (n / 2l), we + int64(i) * nb, xqp, xsp, n)
@@ -654,7 +654,7 @@ def private mx4q8_kernel_x64(var yp : float?; wn : uint8 const?; we : uint8 cons
 def private q8q8_groupn_kernel_x64(var yp : float?; wp : int8 const?; sp : float const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let ii = int64(i)
@@ -678,7 +678,7 @@ def private q8q8_groupn_kernel_x64_grp4(var yp : float?; wp : int8 const?; sp : 
     let nb = n / 32l
     let ng = d / 4l
     var myp = yp
-    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * ng), get_total_hw_jobs()) $(gb, ge) {
+    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * ng), get_dispatch_lanes()) $(gb, ge) {
         unsafe {
             for (gi in range(gb, ge)) {
                 let gg = int64(gi)
@@ -721,7 +721,7 @@ def private mx4q8_groupn_kernel_x64(var yp : float?; wn : uint8 const?; we : uin
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+        maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let ii = int64(i)
@@ -803,7 +803,7 @@ def mx4_dequant_grp4_x64(lut : int8 const?; wn : uint8 const?; we : uint8 const?
 // dot4x4 (same bytes, same dot, rows independent).
 def private mx4q8_batch_kernel_x64(var yp : float?; wn : uint8 const?; we : uint8 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
-    let nchunks = min(get_total_hw_jobs(), int(d))
+    let nchunks = min(get_dispatch_lanes(), int(d))
     mx4b_reserve(int64(nchunks) * n, int64(nchunks) * nb)
     var myp = yp
     var lut : int8[16]
@@ -839,8 +839,8 @@ def private mx4q8_batch_kernel_x64_grp4(var yp : float?; wn : uint8 const?; we :
     let nb = n / 32l
     let ng = d / 4l
     let TB = effective_token_block(g_q8_token_block, n)
-    let hw = get_total_hw_jobs()
-    let nchunks = clamp(int(ng / 4l), hw, hw * get_q8_batch_chunks_per_job())
+    let lanes = get_dispatch_lanes()
+    let nchunks = clamp(int(ng / 4l), lanes, lanes * get_q8_batch_chunks_per_job())
     mx4b_reserve(max(int64(nchunks) * 4l * n, n), max(int64(nchunks) * 4l * nb, nb))
     var myp = yp
     var lut : int8[16]
@@ -903,7 +903,7 @@ def private mx4q8_batch_kernel_x64_grp4(var yp : float?; wn : uint8 const?; we :
 def private mx4q8_batch_groupn_kernel_x64(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     let items = nregions * d
-    let nchunks = min(get_total_hw_jobs(), int(items))
+    let nchunks = min(get_dispatch_lanes(), int(items))
     mx4b_reserve(int64(nchunks) * n, int64(nchunks) * nb)
     var myp = yp
     var lut : int8[16]
@@ -951,9 +951,9 @@ def private mx4q8_batch_groupn_kernel_x64(var yp : float?; wn : uint8 const?; we
 def private mx4q8_batch_groupn_kernel_x64_grp4(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     let ng = d / 4l
-    let hw = get_total_hw_jobs()
+    let lanes = get_dispatch_lanes()
     let items = nregions * ng
-    let nchunks = clamp(int(items / 4l), hw, hw * get_q8_batch_chunks_per_job())
+    let nchunks = clamp(int(items / 4l), lanes, lanes * get_q8_batch_chunks_per_job())
     mx4b_reserve(max(int64(nchunks) * 4l * n, n), max(int64(nchunks) * 4l * nb, nb))
     var myp = yp
     var lut : int8[16]
@@ -1345,7 +1345,7 @@ def mx4_dequant_row_x64z(lut : int8 const?; wn : uint8 const?; we : uint8 const?
 def private q8q8_kernel_x64_vnni(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 myp[i] = dot_q8q8_x64vnni(wp + int64(i) * n, sp + int64(i) * nb, xqp, xsp, n)
@@ -1357,7 +1357,7 @@ def private q8q8_kernel_x64_vnni(var yp : float?; wp : int8 const?; sp : float c
 def private q8q8_batch_kernel_x64_vnni(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -1377,7 +1377,7 @@ def private q8q8_group3_kernel_x64_vnni(var y0p : float?; var y1p : float?; var 
     var w0 = y0p
     var w1 = y1p
     var w2 = y2p
-    parallel_for(0, int(dtot), get_total_hw_jobs()) $(rb, re, wg) {
+    parallel_for(0, int(dtot), get_dispatch_lanes()) $(rb, re, wg) {
         unsafe {
             for (gi in range(rb, re)) {
                 let g = int64(gi)
@@ -1399,7 +1399,7 @@ def private q8q8_group3_kernel_x64_vnni(var y0p : float?; var y1p : float?; var 
 def private q8q8_groupn_kernel_x64_vnni(var yp : float?; wp : int8 const?; sp : float const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let ii = int64(i)
@@ -1424,7 +1424,7 @@ def private mx4q8_kernel_x64_vnni(var yp : float?; wn : uint8 const?; we : uint8
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+        maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     myp[i] = dot_mx4q8_x64vnni(lutp, wn + int64(i) * (n / 2l), we + int64(i) * nb, xqp, xsp, n)
@@ -1441,7 +1441,7 @@ def private mx4q8_groupn_kernel_x64_vnni(var yp : float?; wn : uint8 const?; we 
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+        maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let ii = int64(i)
@@ -1463,7 +1463,7 @@ def private mx4q8_groupn_kernel_x64_vnni(var yp : float?; wn : uint8 const?; we 
 
 def private mx4q8_batch_kernel_x64_vnni(var yp : float?; wn : uint8 const?; we : uint8 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
-    let nchunks = min(get_total_hw_jobs(), int(d))
+    let nchunks = min(get_dispatch_lanes(), int(d))
     mx4b_reserve(int64(nchunks) * n, int64(nchunks) * nb)
     var myp = yp
     var lut : int8[16]
@@ -1493,7 +1493,7 @@ def private mx4q8_batch_kernel_x64_vnni(var yp : float?; wn : uint8 const?; we :
 def private mx4q8_batch_groupn_kernel_x64_vnni(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     let items = nregions * d
-    let nchunks = min(get_total_hw_jobs(), int(items))
+    let nchunks = min(get_dispatch_lanes(), int(items))
     mx4b_reserve(int64(nchunks) * n, int64(nchunks) * nb)
     var myp = yp
     var lut : int8[16]
@@ -1539,7 +1539,7 @@ def private mx4q8_batch_groupn_kernel_x64_vnni(var yp : float?; wn : uint8 const
 def private q8q8_kernel_x64_acc8vnni(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 myp[i] = dot_q8q8_x64acc8vnni(wp + int64(i) * n, sp + int64(i) * nb, xqp, xsp, n)
@@ -1552,7 +1552,7 @@ def private q8q8_batch_kernel_x64_acc8vnni(var yp : float?; wp : int8 const?; sp
     let nb = n / 32l
     var myp = yp
     // OVERSPLIT: mirrors the acc8 batch kernel (idle workers steal a late-woken worker's chunks)
-    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs() * get_q8_batch_chunks_per_job()) $(rb, re) {
+    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes() * get_q8_batch_chunks_per_job()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -1572,7 +1572,7 @@ def private q8q8_group3_kernel_x64_acc8vnni(var y0p : float?; var y1p : float?; 
     var w0 = y0p
     var w1 = y1p
     var w2 = y2p
-    parallel_for(0, int(dtot), get_total_hw_jobs()) $(rb, re, wg) {
+    parallel_for(0, int(dtot), get_dispatch_lanes()) $(rb, re, wg) {
         unsafe {
             for (gi in range(rb, re)) {
                 let g = int64(gi)
@@ -1597,7 +1597,7 @@ def private q8q8_kernel_x64_grp4vnni(var yp : float?; wp : int8 const?; sp : flo
     let nb = n / 32l
     let ng = d / 4l
     var myp = yp
-    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(ng), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(ng), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (gi in range(rb, re)) {
                 let g = int64(gi)
@@ -1622,8 +1622,8 @@ def private q8q8_batch_kernel_x64_grp4vnni(var yp : float?; wp : int8 const?; sp
     var myp = yp
     // Token-blocked + oversplit floored at 4 groups/chunk — mirrors the grp4 batch kernel
     let TB = effective_token_block(g_q8_token_block, n)
-    let hw = get_total_hw_jobs()
-    let njobs = clamp(int(ng / 4l), hw, hw * get_q8_batch_chunks_per_job())
+    let lanes = get_dispatch_lanes()
+    let njobs = clamp(int(ng / 4l), lanes, lanes * get_q8_batch_chunks_per_job())
     maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(ng), njobs) $(rb, re) {
         unsafe {
             var tb = 0l
@@ -1673,7 +1673,7 @@ def private q8q8_group3_kernel_x64_grp4vnni(var y0p : float?; var y1p : float?; 
     var w0 = y0p
     var w1 = y1p
     var w2 = y2p
-    parallel_for(0, int(ngtot), get_total_hw_jobs()) $(rb, re, wg) {
+    parallel_for(0, int(ngtot), get_dispatch_lanes()) $(rb, re, wg) {
         unsafe {
             for (gi in range(rb, re)) {
                 let g = int64(gi)
@@ -1719,7 +1719,7 @@ def private q8q8_groupn_kernel_x64_grp4vnni(var yp : float?; wp : int8 const?; s
     let nb = n / 32l
     let ng = d / 4l
     var myp = yp
-    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * ng), get_total_hw_jobs()) $(gb, ge) {
+    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * ng), get_dispatch_lanes()) $(gb, ge) {
         unsafe {
             for (gi in range(gb, ge)) {
                 let gg = int64(gi)
@@ -1759,8 +1759,8 @@ def private mx4q8_batch_kernel_x64_grp4vnni(var yp : float?; wn : uint8 const?; 
     let nb = n / 32l
     let ng = d / 4l
     let TB = effective_token_block(g_q8_token_block, n)
-    let hw = get_total_hw_jobs()
-    let nchunks = clamp(int(ng / 4l), hw, hw * get_q8_batch_chunks_per_job())
+    let lanes = get_dispatch_lanes()
+    let nchunks = clamp(int(ng / 4l), lanes, lanes * get_q8_batch_chunks_per_job())
     mx4b_reserve(max(int64(nchunks) * 4l * n, n), max(int64(nchunks) * 4l * nb, nb))
     var myp = yp
     var lut : int8[16]
@@ -1819,9 +1819,9 @@ def private mx4q8_batch_kernel_x64_grp4vnni(var yp : float?; wn : uint8 const?; 
 def private mx4q8_batch_groupn_kernel_x64_grp4vnni(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     let ng = d / 4l
-    let hw = get_total_hw_jobs()
+    let lanes = get_dispatch_lanes()
     let items = nregions * ng
-    let nchunks = clamp(int(items / 4l), hw, hw * get_q8_batch_chunks_per_job())
+    let nchunks = clamp(int(items / 4l), lanes, lanes * get_q8_batch_chunks_per_job())
     mx4b_reserve(max(int64(nchunks) * 4l * n, n), max(int64(nchunks) * 4l * nb, nb))
     var myp = yp
     var lut : int8[16]
@@ -1905,7 +1905,7 @@ def private mx4q8_batch_groupn_kernel_x64_grp4vnni(var yp : float?; wn : uint8 c
 def private q8q8_kernel_x64_z16(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 myp[i] = dot_q8q8_x64z16(wp + int64(i) * n, sp + int64(i) * nb, xqp, xsp, n)
@@ -1918,7 +1918,7 @@ def private q8q8_batch_kernel_x64_z16(var yp : float?; wp : int8 const?; sp : fl
     let nb = n / 32l
     var myp = yp
     // OVERSPLIT: mirrors the acc8 batch kernel (idle workers steal a late-woken worker's chunks)
-    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs() * get_q8_batch_chunks_per_job()) $(rb, re) {
+    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes() * get_q8_batch_chunks_per_job()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -1938,7 +1938,7 @@ def private q8q8_group3_kernel_x64_z16(var y0p : float?; var y1p : float?; var y
     var w0 = y0p
     var w1 = y1p
     var w2 = y2p
-    parallel_for(0, int(dtot), get_total_hw_jobs()) $(rb, re, wg) {
+    parallel_for(0, int(dtot), get_dispatch_lanes()) $(rb, re, wg) {
         unsafe {
             for (gi in range(rb, re)) {
                 let g = int64(gi)
@@ -1960,7 +1960,7 @@ def private q8q8_group3_kernel_x64_z16(var y0p : float?; var y1p : float?; var y
 def private q8q8_groupn_kernel_x64_z16(var yp : float?; wp : int8 const?; sp : float const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let ii = int64(i)
@@ -1981,7 +1981,7 @@ def private q8q8_groupn_kernel_x64_z16(var yp : float?; wp : int8 const?; sp : f
 def private q8q8_kernel_x64_z16vnni(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 myp[i] = dot_q8q8_x64z16vnni(wp + int64(i) * n, sp + int64(i) * nb, xqp, xsp, n)
@@ -1994,7 +1994,7 @@ def private q8q8_batch_kernel_x64_z16vnni(var yp : float?; wp : int8 const?; sp 
     let nb = n / 32l
     var myp = yp
     // OVERSPLIT: mirrors the acc8 batch kernel (idle workers steal a late-woken worker's chunks)
-    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_total_hw_jobs() * get_q8_batch_chunks_per_job()) $(rb, re) {
+    maybe_parallel_for(n * d * ntok >= g_matmul_par_threshold, 0, int(d), get_dispatch_lanes() * get_q8_batch_chunks_per_job()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -2014,7 +2014,7 @@ def private q8q8_group3_kernel_x64_z16vnni(var y0p : float?; var y1p : float?; v
     var w0 = y0p
     var w1 = y1p
     var w2 = y2p
-    parallel_for(0, int(dtot), get_total_hw_jobs()) $(rb, re, wg) {
+    parallel_for(0, int(dtot), get_dispatch_lanes()) $(rb, re, wg) {
         unsafe {
             for (gi in range(rb, re)) {
                 let g = int64(gi)
@@ -2036,7 +2036,7 @@ def private q8q8_group3_kernel_x64_z16vnni(var y0p : float?; var y1p : float?; v
 def private q8q8_groupn_kernel_x64_z16vnni(var yp : float?; wp : int8 const?; sp : float const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_total_hw_jobs()) $(rb, re) {
+    maybe_parallel_for(n * d * nregions >= g_matmul_par_threshold, 0, int(nregions * d), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let ii = int64(i)
@@ -2056,7 +2056,7 @@ def private q8q8_groupn_kernel_x64_z16vnni(var yp : float?; wp : int8 const?; sp
 
 def private mx4q8_batch_kernel_x64_z16vnni(var yp : float?; wn : uint8 const?; we : uint8 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
-    let nchunks = min(get_total_hw_jobs(), int(d))
+    let nchunks = min(get_dispatch_lanes(), int(d))
     mx4b_reserve(int64(nchunks) * n, int64(nchunks) * nb)
     var myp = yp
     var lut : int8[16]
@@ -2086,7 +2086,7 @@ def private mx4q8_batch_kernel_x64_z16vnni(var yp : float?; wn : uint8 const?; w
 def private mx4q8_batch_groupn_kernel_x64_z16vnni(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
     let nb = n / 32l
     let items = nregions * d
-    let nchunks = min(get_total_hw_jobs(), int(items))
+    let nchunks = min(get_dispatch_lanes(), int(items))
     mx4b_reserve(int64(nchunks) * n, int64(nchunks) * nb)
     var myp = yp
     var lut : int8[16]


### PR DESCRIPTION
The mxfp4-x64 branch (#3369) predated the dispatch-lanes change (#3368), so its new kernels merged sizing chunks to `get_total_hw_jobs()` — the workers-only count whose last wave runs short of the lanes actually serving (workers + caller). On arm64 that misalignment measured as the entire decode-GEMV "kernel gap" (109 → 118-120 GB/s when fixed).

Converts all 35 `dasllama_math_x64_avx.das` sites (mx4 batch/groupn kernels across base/VNNI/z16 tiers) + the 2 new portable groupn/batch sites in `dasllama_math_default.das` to `get_dispatch_lanes()`:

- each site's multipliers (`* get_q8_batch_chunks_per_job()`) and clamps preserved — mirrors the neon file's converted patterns exactly
- the `nchunks`-coupled `mx4b_reserve` scratch sizing stays coupled (the same local feeds reserve and dispatch)
- `let hw` locals that now hold lanes renamed to `lanes`
- harness/bench uses of `get_total_hw_jobs()` deliberately untouched (reporting labels; `bench_gemv_decode` A/Bs the alignment on purpose)

arm64 box: compile-gated only — 171/171 dasLLAMA tests under `-jit`, lint clean. The utilization delta gets measured on real x64 hardware (expected ~+14% theoretical on tail-wave-bound ops at 8 threads, ~2-3% at 32+ workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)