### PR TITLE
dasSQLITE: provider seam — sql_provider registry, typed-splice emitters, generic row helpers, dialect render hooks

### DIFF
--- a/modules/dasSQLITE/.das_module
+++ b/modules/dasSQLITE/.das_module
@@ -6,7 +6,7 @@ def initialize(project_path : string) {
     if (das_is_dll_build()) {
         register_dynamic_module("{project_path}/dasModuleSQLITE.shared_module", "Module_dasSQLITE")
     }
-    let sqlite_paths = ["sqlite_boost", "sqlite_linq", "sqlite_migrate", "linq_fold_sql"]
+    let sqlite_paths = ["sql_provider", "sqlite_boost", "sqlite_linq", "sqlite_migrate", "linq_fold_sql"]
     for (path in sqlite_paths) {
         register_native_path("sqlite", "{path}", "{project_path}/daslib/{path}.das")
     }

--- a/modules/dasSQLITE/PROVIDER_CONTRACT.md
+++ b/modules/dasSQLITE/PROVIDER_CONTRACT.md
@@ -4,7 +4,8 @@ What a database provider implements to plug into the `_sql` LINQ-to-SQL machiner
 (`sqlite_linq.das`, migrating to `daslib/sql_linq` in a follow-up). SQLite
 (`sqlite_boost.das`) is the reference implementation; DuckDB and PostgreSQL are the
 planned consumers. This document is the contract; the registry in
-`daslib/sql_provider.das` is its executable form.
+`modules/dasSQLITE/daslib/sql_provider.das` (required as `sqlite/sql_provider`;
+moves to root `daslib/` with the sql_linq promotion) is its executable form.
 
 ## Architecture in one paragraph
 
@@ -55,14 +56,15 @@ overload-resolve against whichever provider's stmt type instantiated them.
 
 ### 3. Registry entry (compile-time)
 
-Registered in `daslib/sql_provider.das` (the provider's registration code must be
-in the `require` closure of the macro module — consumer-requires-contributor; see
-skills/das_macros.md "Macro modules each compile into their own context"):
+Registered via `sqlite/sql_provider`'s `register_sql_provider` (the provider's
+registration code must be in the `require` closure of the macro module —
+consumer-requires-contributor; see skills/das_macros.md "Macro modules each
+compile into their own context"):
 
 | Field | SQLite value | Consulted by |
 |---|---|---|
 | `name` | `"sqlite"` | diagnostics |
-| `runnerTypeName` | `SqlRunner` (qualified) | registry lookup from `q.dbExpr._type` |
+| `runnerModule` + `runnerStruct` | `"sqlite_boost"` + `"SqlRunner"` | registry lookup key, matched against `q.dbExpr._type`'s struct + owning module |
 | `makeStmtType` | `qmacro_type(type<sqlite3_stmt?>)` | bind-block parameter splices (mutable flavor) |
 | `makeStmtTypeConst` | `qmacro_type(type<sqlite3_stmt? const>)` | row-reader block/lambda parameter splices — qualifiers are spelled in the type expression; `$t` substitution replaces the placeholder type wholesale, so the parser's const-append on non-`var` params does not apply to spliced types |
 | `renderPlaceholder(ordinal)` | `"?"` | `fold_to_builder` — the single render point for bind frags (`?` inside `build_sql_string` output is internal IR that `sql_to_frags` re-splits). Ordinal is 1-based among macro-enumerated binds; upsert row-binds are emitted as literal `?` text (bound by the generated `_sql_bind_row`, not enumerated), so a numbered-placeholder provider must also handle row-binder placeholders at port time |
@@ -73,14 +75,17 @@ skills/das_macros.md "Macro modules each compile into their own context"):
 | `identityDdl` | `PRIMARY KEY` (INTEGER PK aliases rowid) | registered, NOT yet routed — same story as `sqlTypeFor` |
 | capability flags | see below | macro_error gates |
 
-### 4. Capability flags
+### 4. Capability flags — `SqlProviderCaps` bitfield + `pkReport`
 
-| Flag | SQLite | Gate |
+| Field | SQLite | Gate |
 |---|---|---|
-| `has_fts5` | yes | `[sql_fts5]` / `text_match` → compile error when absent |
-| `has_client_udfs` | yes | `[sql_function]` → compile error when absent (PG has no client-side UDFs) |
-| `returning_style` | `RETURNING` | `_sql_*_returning` |
-| `insert_pk_report` | `last_insert_rowid` | `insert(...) : id` — RETURNING-pk contract for providers without rowid |
+| `caps.fts5` | set | `[sql_fts5]` / `text_match` → compile error when absent |
+| `caps.client_udfs` | set | `[sql_function]` → compile error when absent (PG has no client-side UDFs) |
+| `caps.returning` | set | `_sql_*_returning` |
+| `pkReport : SqlPkReport` | `LastInsertRowid` | `insert(...) : id` — `ReturningPk` for providers without rowid |
+
+The gates wire up as the second provider lands; in this PR the flags are
+registered data only.
 
 A missing capability is a **compile-time** `macro_error` naming the provider and the
 feature — never a runtime failure.

--- a/modules/dasSQLITE/PROVIDER_CONTRACT.md
+++ b/modules/dasSQLITE/PROVIDER_CONTRACT.md
@@ -1,0 +1,99 @@
+# SQL provider contract
+
+What a database provider implements to plug into the `_sql` LINQ-to-SQL machinery
+(`sqlite_linq.das`, migrating to `daslib/sql_linq` in a follow-up). SQLite
+(`sqlite_boost.das`) is the reference implementation; DuckDB and PostgreSQL are the
+planned consumers. This document is the contract; the registry in
+`daslib/sql_provider.das` is its executable form.
+
+## Architecture in one paragraph
+
+`_sql(...)` and its siblings analyze a LINQ-shaped chain at **compile time** and emit
+(a) a SQL string with positional placeholders, (b) a bind block, (c) a row-reader
+block/lambda, all passed to a **runtime runner helper** (`run_select`,
+`run_each_select`, ...). Nothing provider-specific survives to runtime except the
+helper call — dispatch is by ordinary overload resolution on the provider's runner
+type. The macro learns which provider it is emitting for from the **provider
+registry**: a compile-time (macro-context) table keyed by the runner's type name,
+carrying the provider's statement type, dialect hooks, and capability flags.
+
+## What a provider ships
+
+### 1. Runtime types
+
+| Piece | SQLite reference | Notes |
+|---|---|---|
+| Runner struct | `SqlRunner { sqlite_handle, schema_name }` | The value user code threads through every call. Must be a struct (registry keys on its type name) |
+| Statement handle | `sqlite3_stmt?` | Spliced by the macro into emitted bind/reader blocks; opaque to the analyzer |
+| `finalize(var db)` | closes the connection | enables `var inscope db` RAII |
+| `with_<provider>(path) <\| $(db)` | `with_sqlite` | scoped open/close |
+| open family | `open_sqlite` / `try_open_sqlite` | strict + `try_` forms |
+
+### 2. Runtime runner helpers (overloads on the runner type)
+
+The macro emits calls to these **unqualified** names; overload resolution on the
+first argument picks the provider. Signatures are generic over the row type
+(`auto(TT)`) and take the provider's concrete stmt type in block/lambda positions:
+
+| Helper | Shape | Used by |
+|---|---|---|
+| `run_select` | `(db, sql, bind_blk, row_blk) : array<TT>` | `_sql` (default terminal) |
+| `run_select_one` | `... : TT` (panics on empty) | `_sql(... \|> _first())` |
+| `run_select_one_opt` | `... : Option<TT>` | `_first_opt()` |
+| `try_run_select` / `_one` / `_one_opt` | `... : Result<..., string>` | `_try_sql` |
+| `run_each_select` | `(db, sql, bind_blk, row_lam) : iterator<TT>` | `_each_sql`; finalize in generator `finally` |
+| `run_exec_binds` | `(db, sql, bind_blk) : int` (rows affected) | `_sql_update` / `_sql_delete` |
+| `run_returning` variants | rows-after-write | `_sql_*_returning` |
+| `sql_bind_to_stmt` | `(var stmt, idx, v)` per storage class + adapter fallthrough | emitted bind blocks; generated `_sql_bind_row` |
+| `sql_read_witness` / `read_via_adapter` | `(stmt, col, ...)` per storage class | row readers; generated `_sql_read_row` |
+| `exec` / `query*` raw-SQL family | see skills/sql.md | not macro-emitted; provider-specific surface |
+
+The generated per-table helpers (`_sql_bind_row`, `_sql_read_row`, from
+`[sql_table]`) are **generic over the stmt parameter** — they monomorphize per
+provider, and their interior `sql_bind_to_stmt` / `read_via_adapter` calls
+overload-resolve against whichever provider's stmt type instantiated them.
+
+### 3. Registry entry (compile-time)
+
+Registered in `daslib/sql_provider.das` (the provider's registration code must be
+in the `require` closure of the macro module — consumer-requires-contributor; see
+skills/das_macros.md "Macro modules each compile into their own context"):
+
+| Field | SQLite value | Consulted by |
+|---|---|---|
+| `name` | `"sqlite"` | diagnostics |
+| `runnerTypeName` | `SqlRunner` (qualified) | registry lookup from `q.dbExpr._type` |
+| `makeStmtType` | `qmacro_type(type<sqlite3_stmt?>)` | bind-block parameter splices (mutable flavor) |
+| `makeStmtTypeConst` | `qmacro_type(type<sqlite3_stmt? const>)` | row-reader block/lambda parameter splices — qualifiers are spelled in the type expression; `$t` substitution replaces the placeholder type wholesale, so the parser's const-append on non-`var` params does not apply to spliced types |
+| `renderPlaceholder(ordinal)` | `"?"` | `fold_to_builder` — the single render point for bind frags (`?` inside `build_sql_string` output is internal IR that `sql_to_frags` re-splits). Ordinal is 1-based among macro-enumerated binds; upsert row-binds are emitted as literal `?` text (bound by the generated `_sql_bind_row`, not enumerated), so a numbered-placeholder provider must also handle row-binder placeholders at port time |
+| `noLimitSpelling` | `"LIMIT -1"` | OFFSET-without-LIMIT rendering in `build_sql_string` |
+| `renderJsonExtract(target, path)` | `json_extract({target}, '$....')` | `@sql_json` column descent (`render_json_extract`) |
+| `quoteId(name)` | `"name"` (double quotes) | registered, NOT yet routed — double-quote identifier quoting is portable across SQLite/DuckDB/PostgreSQL; the renderers keep inline quoting until a diverging provider (e.g. MySQL backticks) forces the sweep |
+| `sqlTypeFor(SqlType)` | `sqlite_sql_type` | registered, NOT yet routed — `[sql_table]` DDL emission is provider-agnostic at struct declaration time; routing lands with the neutral `[sql_table]` (per-provider DDL selected by the runner at the `create_table` call site) |
+| `identityDdl` | `PRIMARY KEY` (INTEGER PK aliases rowid) | registered, NOT yet routed — same story as `sqlTypeFor` |
+| capability flags | see below | macro_error gates |
+
+### 4. Capability flags
+
+| Flag | SQLite | Gate |
+|---|---|---|
+| `has_fts5` | yes | `[sql_fts5]` / `text_match` → compile error when absent |
+| `has_client_udfs` | yes | `[sql_function]` → compile error when absent (PG has no client-side UDFs) |
+| `returning_style` | `RETURNING` | `_sql_*_returning` |
+| `insert_pk_report` | `last_insert_rowid` | `insert(...) : id` — RETURNING-pk contract for providers without rowid |
+
+A missing capability is a **compile-time** `macro_error` naming the provider and the
+feature — never a runtime failure.
+
+## Dialect notes (what is already portable)
+
+`ON CONFLICT` upsert, `RETURNING`, double-quote identifier quoting, and
+`LIKE ... ESCAPE '\'` are portable across SQLite / DuckDB / PostgreSQL. DuckDB even
+shares the `json_extract` spelling. The known divergence points are exactly the
+registry hooks above plus placeholder style (`?` vs `$n`).
+
+## Conformance
+
+A provider passes the shared conformance suite (`tests/sql_conformance/`, follow-up
+PR) by shipping a `conformance_provider.das` shim exposing its runner + capability
+flags for self-skip of unsupported groups.

--- a/modules/dasSQLITE/daslib/sql_provider.das
+++ b/modules/dasSQLITE/daslib/sql_provider.das
@@ -27,8 +27,8 @@ enum public SqlPkReport {
 }
 
 bitfield public SqlProviderCaps {
-    //! Feature gates consulted by the macros; a missing capability is a
-    //! compile-time `macro_error` naming the provider and the feature.
+    //! Feature gates for the macros' capability checks (wired as providers land);
+    //! a missing capability is a compile-time `macro_error` naming the provider.
     fts5
     client_udfs
     returning

--- a/modules/dasSQLITE/daslib/sql_provider.das
+++ b/modules/dasSQLITE/daslib/sql_provider.das
@@ -1,0 +1,98 @@
+options gen2
+options indenting = 4
+options no_unused_function_arguments = false
+options strict_smart_pointers
+
+module sql_provider shared public
+
+require daslib/ast public
+require daslib/sql public
+require strings
+
+//! Compile-time SQL provider registry. The `_sql` chain analyzer and the
+//! `[sql_table]` structure macro are provider-neutral; everything dialect- or
+//! handle-specific routes through a `SqlProviderInfo` entry registered here.
+//! Providers register from their own module's `[init]` (the registration must be
+//! in the `require` closure of every macro module that consults the registry —
+//! consumer-requires-contributor; see skills/das_macros.md). SQLite registers
+//! from `sqlite/sqlite_boost`. Contract: modules/dasSQLITE/PROVIDER_CONTRACT.md.
+
+enum public SqlPkReport {
+    //! How `insert(row)` learns the new row's primary key.
+    LastInsertRowid
+    ReturningPk
+}
+
+bitfield public SqlProviderCaps {
+    //! Feature gates consulted by the macros; a missing capability is a
+    //! compile-time `macro_error` naming the provider and the feature.
+    fts5
+    client_udfs
+    returning
+}
+
+struct public SqlProviderInfo {
+    //! One registered provider: identity, statement type factory, dialect hooks,
+    //! capability flags. Hook fields are plain function pointers — macro code
+    //! cannot overload-dispatch across providers, so dispatch is data-driven.
+    name : string                                                //! diagnostics: "sqlite"
+    runnerModule : string                                        //! registry key: module of the runner struct, e.g. "sqlite_boost"
+    runnerStruct : string                                        //! registry key: runner struct name, e.g. "SqlRunner"
+    makeStmtType : function<() : TypeDeclPtr>                    //! fresh stmt TypeDecl per splice — bind-block (mutable) parameter flavor
+    makeStmtTypeConst : function<() : TypeDeclPtr>               //! const flavor for row-reader block/lambda parameters (spell the qualifier in the type: `type<stmt? const>`)
+    renderPlaceholder : function<(ordinal : int) : string>       //! bind placeholder; ordinal is 1-based ("?" ignores it, "$n" styles use it)
+    noLimitSpelling : string                                     //! LIMIT clause when only OFFSET is present (sqlite: "LIMIT -1")
+    renderJsonExtract : function<(target : string; jsonPath : string) : string>  //! @sql_json descent; jsonPath is the quoted '$.a.b' literal
+    quoteId : function<(id : string) : string>                   //! identifier quoting
+    sqlTypeFor : function<(t : SqlType) : string>                //! DDL column type spelling
+    identityDdl : string                                         //! DDL for the auto-assigned integer primary key column
+    caps : SqlProviderCaps
+    pkReport : SqlPkReport
+}
+
+var private g_sql_providers : array<SqlProviderInfo>
+
+def public register_sql_provider(var info : SqlProviderInfo) {
+    //! Appends a provider entry. Call from the provider module's `[init]`.
+    //! Duplicate (runnerModule, runnerStruct) keys panic at registration time.
+    for (p in g_sql_providers) {
+        if (p.runnerModule == info.runnerModule && p.runnerStruct == info.runnerStruct) {
+            panic("register_sql_provider: duplicate runner key {info.runnerModule}::{info.runnerStruct} ({p.name} vs {info.name})")
+        }
+    }
+    g_sql_providers |> emplace(info)
+}
+
+def public find_sql_provider_by_runner(runnerT : TypeDeclPtr) : int {
+    //! Registry index for the provider whose runner struct matches `runnerT`
+    //! (the inferred type of the chain's db expression), or -1.
+    if (runnerT == null || runnerT.structType == null) return -1
+    let st = runnerT.structType
+    if (st._module == null) return -1
+    for (i in range(length(g_sql_providers))) {
+        if (g_sql_providers[i].runnerStruct == st.name && g_sql_providers[i].runnerModule == st._module.name) {
+            return i
+        }
+    }
+    return -1
+}
+
+def public sql_provider_at(idx : int) : SqlProviderInfo {
+    //! Copy of the registered entry (hook fields are pointers; the copy is cheap).
+    assert(idx >= 0 && idx < length(g_sql_providers), "sql_provider_at: index out of range")
+    return g_sql_providers[idx]
+}
+
+def public sql_provider_count() : int => length(g_sql_providers)
+
+def public sql_provider_names() : string {
+    //! Comma-separated registered provider names, for macro_error diagnostics.
+    return build_string() $(var w) {
+        for (i in range(length(g_sql_providers))) {
+            if (i > 0) {
+                w |> write(", ")
+            }
+            w |> write(g_sql_providers[i].name)
+        }
+    }
+}

--- a/modules/dasSQLITE/daslib/sql_provider.das
+++ b/modules/dasSQLITE/daslib/sql_provider.das
@@ -12,10 +12,13 @@ require strings
 //! Compile-time SQL provider registry. The `_sql` chain analyzer and the
 //! `[sql_table]` structure macro are provider-neutral; everything dialect- or
 //! handle-specific routes through a `SqlProviderInfo` entry registered here.
-//! Providers register from their own module's `[init]` (the registration must be
-//! in the `require` closure of every macro module that consults the registry —
-//! consumer-requires-contributor; see skills/das_macros.md). SQLite registers
-//! from `sqlite/sqlite_boost`. Contract: modules/dasSQLITE/PROVIDER_CONTRACT.md.
+//! Registration happens at macro-build time: each module whose macros consult the
+//! registry calls the provider's registration function from its own `[_macro]`
+//! (only a module's own `[_macro]`s run at its macro build — `[init]`/globals-init
+//! never reach a consumer's macro context; consumer-requires-contributor, see
+//! skills/das_macros.md). SQLite registers via the `[_macro]` wrappers in
+//! `sqlite/sqlite_boost` and `sqlite/sqlite_linq`. Contract:
+//! modules/dasSQLITE/PROVIDER_CONTRACT.md.
 
 enum public SqlPkReport {
     //! How `insert(row)` learns the new row's primary key.
@@ -53,7 +56,8 @@ struct public SqlProviderInfo {
 var private g_sql_providers : array<SqlProviderInfo>
 
 def public register_sql_provider(var info : SqlProviderInfo) {
-    //! Appends a provider entry. Call from the provider module's `[init]`.
+    //! Appends a provider entry. Call from a `[_macro]` function in each macro
+    //! module that consults the registry (`[init]` does not reach macro contexts).
     //! Duplicate (runnerModule, runnerStruct) keys panic at registration time.
     for (p in g_sql_providers) {
         if (p.runnerModule == info.runnerModule && p.runnerStruct == info.runnerStruct) {

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -10,6 +10,7 @@ options _comment_hygiene = true
 module sqlite_boost shared public
 
 require sqlite public
+require sqlite/sql_provider public
 
 require strings public
 require daslib/fio                  // [sql_table(schema_from=...)] uses is_absolute / path_join at macro time
@@ -102,6 +103,46 @@ struct SqlRunner {
 }
 
 typedef SqlError = Option<string>
+
+// ===== SQL provider registration (see modules/dasSQLITE/PROVIDER_CONTRACT.md) =====
+
+def private _sqlite_make_stmt_type() : TypeDeclPtr => qmacro_type(type<sqlite3_stmt?>)
+
+def private _sqlite_make_stmt_type_const() : TypeDeclPtr => qmacro_type(type<sqlite3_stmt? const>)
+
+[unused_argument(ordinal)]
+def private _sqlite_render_placeholder(ordinal : int) : string => "?"
+
+def private _sqlite_render_json_extract(target : string; jsonPath : string) : string => "json_extract({target}, {jsonPath})"
+
+def private _sqlite_quote_id(id : string) : string => sql_quote_id(id)
+
+def register_sqlite_provider {
+    //! Registers the sqlite `SqlProviderInfo` entry in the CURRENT macro context. Only a
+    //! module's own `[_macro]`s run at its macro build (linq_fold.das:123 pattern), so each
+    //! consulting module calls this from its own `[_macro]` — here and in sqlite_linq.das.
+    var info = SqlProviderInfo(
+        name = "sqlite",
+        runnerModule = "sqlite_boost",
+        runnerStruct = "SqlRunner",
+        makeStmtType = @@_sqlite_make_stmt_type,
+        makeStmtTypeConst = @@_sqlite_make_stmt_type_const,
+        renderPlaceholder = @@_sqlite_render_placeholder,
+        noLimitSpelling = "LIMIT -1",
+        renderJsonExtract = @@_sqlite_render_json_extract,
+        quoteId = @@_sqlite_quote_id,
+        sqlTypeFor = @@sqlite_sql_type,
+        identityDdl = "PRIMARY KEY",
+        caps = SqlProviderCaps.fts5 | SqlProviderCaps.client_udfs | SqlProviderCaps.returning,
+        pkReport = SqlPkReport.LastInsertRowid)
+    register_sql_provider(info)
+}
+
+[_macro]
+def private _boost_register_sqlite_provider {
+    if (!is_compiling_macros_in_module("sqlite_boost")) return
+    register_sqlite_provider()
+}
 
 def finalize(var db : SqlRunner) {
     //! Closes the underlying SQLite connection. Triggered automatically by `var inscope db`.
@@ -2537,7 +2578,7 @@ class SqlTableMacro : AstStructureAnnotation {
         var fn_select_all = make_select_all_sql_fn(st, table_name, fields)
         compiling_module() |> add_function(fn_select_all)
         var fn_read = make_read_row_fn(st, fields)
-        compiling_module() |> add_function(fn_read)
+        compiling_module() |> add_generic(fn_read)
         var fn_col_info = make_column_info_fn(st, fields)
         compiling_module() |> add_function(fn_col_info)
 
@@ -2565,7 +2606,7 @@ class SqlTableMacro : AstStructureAnnotation {
             var fn_pk_unset = make_pk_is_unset_fn(st, fields)
             compiling_module() |> add_function(fn_pk_unset)
             var fn_bind = make_bind_row_fn(st, fields)
-            compiling_module() |> add_function(fn_bind)
+            compiling_module() |> add_generic(fn_bind)
             var fn_upd_pk_named = make_update_by_pk_sql_named_fn(st, fields)
             compiling_module() |> add_function(fn_upd_pk_named)
             var fn_upd_pk = make_update_by_pk_sql_fn(st, table_name, fields)
@@ -2975,7 +3016,9 @@ class SqlTableMacro : AstStructureAnnotation {
             }))
         }
 
-        var fn = qmacro_function("_sql_bind_row") $(var stmt : sqlite3_stmt?; row : $t(st); include_pk : bool) : void {
+        // stmt is untyped (generic): monomorphizes per provider stmt type; the interior
+        // sql_bind_to_stmt overloads dispatch on whichever concrete stmt instantiated it.
+        var fn = qmacro_function("_sql_bind_row") $(var stmt; row : $t(st); include_pk : bool) : void {
             if (include_pk) {
                 $b(with_pk_exprs)
             } else {
@@ -3037,7 +3080,8 @@ class SqlTableMacro : AstStructureAnnotation {
         }
 
         // Explicit default<>: Option<T> fields don't satisfy strict_smart_pointers' uninit check otherwise.
-        var fn = qmacro_function("_sql_read_row") $(stmt : sqlite3_stmt?; typ : $t(st)) : $t(st) {
+        // stmt untyped (generic over provider stmt type) — same rationale as make_bind_row_fn.
+        var fn = qmacro_function("_sql_read_row") $(stmt; typ : $t(st)) : $t(st) {
             var row = default<$t(st)>
             $b(assign_exprs)
             return <- row
@@ -3459,7 +3503,7 @@ class private SqlViewMacro : AstStructureAnnotation {
         var fn_select_all = make_view_select_all_sql_fn(st, view_name, fields)
         compiling_module() |> add_function(fn_select_all)
         var fn_read = make_read_row_helper_fn(st, fields)
-        compiling_module() |> add_function(fn_read)
+        compiling_module() |> add_generic(fn_read)
         var fn_col_info = make_view_column_info_fn(st, fields)
         compiling_module() |> add_function(fn_col_info)
         // ---- mutation stubs (panic at runtime with a clear message) ----
@@ -3580,7 +3624,8 @@ def private make_read_row_helper_fn(var st : StructurePtr; fields : array<FieldI
             }
         }))
     }
-    var fn = qmacro_function("_sql_read_row") $(stmt : sqlite3_stmt?; typ : $t(st)) : $t(st) {
+    // stmt untyped (generic over provider stmt type) — same rationale as make_read_row_fn.
+    var fn = qmacro_function("_sql_read_row") $(stmt; typ : $t(st)) : $t(st) {
         var row = default<$t(st)>
         $b(assign_exprs)
         return <- row
@@ -3810,7 +3855,7 @@ class private SqlFts5Macro : AstStructureAnnotation {
         var fn_select_all = make_const_string_helper_fn(st, "_sql_select_all_sql", select_all_sql)
         compiling_module() |> add_function(fn_select_all)
         var fn_read = make_read_row_helper_fn(st, fields)
-        compiling_module() |> add_function(fn_read)
+        compiling_module() |> add_generic(fn_read)
         // FTS5 has no daslang-side PK; both insert helper variants emit the same SQL.
         var fn_ins_pk = make_const_string_helper_fn(st, "_sql_insert_with_pk_sql", insert_sql)
         compiling_module() |> add_function(fn_ins_pk)

--- a/modules/dasSQLITE/daslib/sqlite_linq.das
+++ b/modules/dasSQLITE/daslib/sqlite_linq.das
@@ -13,6 +13,7 @@ options _comment_hygiene = true
 module sqlite_linq shared public
 
 require sqlite/sqlite_boost public
+require sqlite/sql_provider
 require daslib/sql public
 require daslib/linq_boost public
 
@@ -25,6 +26,14 @@ require daslib/macro_boost
 require daslib/rtti
 require strings public
 require daslib/strings_convert
+
+// Twin of sqlite_boost's [_macro] wrapper — this module's chain emitters consult the
+// provider registry, and only a module's own [_macro] functions run at its macro build.
+[_macro]
+def private _linq_register_sqlite_provider {
+    if (!is_compiling_macros_in_module("sqlite_linq")) return
+    register_sqlite_provider()
+}
 
 [unused_argument(arr)]
 def _to_array(var arr : array<auto(TT)>) : array<TT -const -#> {
@@ -207,6 +216,7 @@ struct private SqlQuery {
     argSourceIdx : array<int>
     dbExpr      : ExpressionPtr
     upsertMode  : bool
+    providerIdx : int = -1              // sql_provider registry index; set where dbExpr binds (chain root / subquery propagation)
     inView      : bool
     hadError    : bool
     lastError   : string
@@ -302,9 +312,10 @@ def private fold_to_string(var frags : array<SqlFrag>; var hadError : bool&; pro
 }
 
 [macro_function]
-def private fold_to_builder(var frags : array<SqlFrag>; at : LineInfo;
+def private fold_to_builder(var frags : array<SqlFrag>; providerIdx : int; at : LineInfo;
                             var sqlExpr : ExpressionPtr&;
                             var bindExprs : array<ExpressionPtr>) {
+    let prov = sql_provider_at(providerIdx)
     var sb = new ExprStringBuilder(at = at)
     var pending = ""
     // macro-function: short-burst string accumulation, flushed into ExprConstString nodes
@@ -312,7 +323,7 @@ def private fold_to_builder(var frags : array<SqlFrag>; at : LineInfo;
         if (f is text) {
             pending += f as text // nolint:PERF001
         } elif (f is bind) {
-            pending += "?" // nolint:PERF001
+            pending += invoke(prov.renderPlaceholder, length(bindExprs) + 1) // nolint:PERF001
             var be : ExpressionPtr = f as bind
             bindExprs |> push(be)
         } elif (f is inline_id) {
@@ -453,7 +464,7 @@ def private is_fts_rank_field(rootT : TypeDeclPtr; fieldName : string) : bool {
 }
 
 [macro_function]
-def private render_json_extract(rootT : TypeDeclPtr; alias : string; col : string; path : array<string>) : string {
+def private render_json_extract(providerIdx : int; rootT : TypeDeclPtr; alias : string; col : string; path : array<string>) : string {
     let p = build_string() $(var w) {
         w |> write("'$")
         for (s in path) {
@@ -463,7 +474,7 @@ def private render_json_extract(rootT : TypeDeclPtr; alias : string; col : strin
         w |> write("'")
     }
     let target = column_sql_for_alias(alias, rootT, col)
-    return "json_extract({target}, {p})"
+    return invoke(sql_provider_at(providerIdx).renderJsonExtract, target, p)
 }
 
 [macro_function]
@@ -600,7 +611,7 @@ def private is_nullable_column_ref(var node : ExpressionPtr; var q : SqlQuery&) 
 
 // nolint:STYLE015 Shared subquery-wrap: SQLite's bare-aggregate optimization — `SELECT *, MIN/MAX(pk) FROM t GROUP BY K` picks the row with the min (useMax=false) or max (useMax=true) pk per K, preserving all `*` columns at those values. MIN matches linq `_distinct_by`'s "first row per K" semantics; MAX matches `reverse() |> _distinct_by(K)` "last row per K" — both when pk is monotonic with insertion order.
 [macro_function]
-def private build_distinct_by_inner_subquery(var q : SqlQuery&; pkField : string; useMax : bool) : string {
+def private build_distinct_by_inner_subquery(q : SqlQuery; pkField : string; useMax : bool) : string {
     let sqlK = field_to_column_name(q.rootType, q.distinctByCol)
     let pkCol = field_to_column_name(q.rootType, pkField)
     let aggOp = useMax ? "MAX" : "MIN"
@@ -1433,7 +1444,7 @@ def private collect_query_binds(var q : SqlQuery&; var out : array<ExpressionPtr
     for (j in q.joins) {
         out |> push_from(j.rightOnBindExprs)
     }
-    out |> push_from(q.bindExprs)
+    out |> push_from(q.bindExprs)   // nolint:STYLE033 — variadic push_from forwards ==const; array<Expression?> sources fail 31400
     out |> push_from(q.havingBindExprs)
     out |> push_from(q.setOpRhsBinds)
     let forced_one_row = ((q.matr == Materializer.One || q.matr == Materializer.OneOpt)
@@ -1560,6 +1571,7 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
     }
     if (q.dbExpr == null) {
         q.dbExpr = subQ.dbExpr
+        q.providerIdx = subQ.providerIdx
     }
     if (subQ.proj == ProjectionShape.FullRow) {
         // FullRow inner: outer treats wrapped subquery as the original table; v1 path — unchanged.
@@ -2095,6 +2107,11 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
         if (qmatch(node, select_from($e(dbE), type<$t(rootT)>)).matched) {
             q.dbExpr = dbE
             q.rootType = rootT
+            q.providerIdx = find_sql_provider_by_runner(dbE._type)
+            if (q.providerIdx < 0) {
+                macro_error(prog, at, "_sql: no SQL provider registered for runner type {describe(dbE._type)} (registered: {sql_provider_names()})")
+                return false
+            }
             // Default projection if no _select was seen above
             if (!q.seenSelect && q.proj != ProjectionShape.Aggregate) {
                 fill_default_columns(q, rootT, prog, at)
@@ -2203,7 +2220,7 @@ def private try_recognize_json_path_proj(val : ExpressionPtr; var q : SqlQuery&;
         macro_error(prog, at, "_sql: JSON path on @sql_json column '{colName}' walks into a field that isn't a struct/tuple member at depth {length(jsonPath)}")
         return -1
     }
-    outFrag = render_json_extract(srcType, source_alias_for_idx(q, srcIdx), colName, jsonPath)
+    outFrag = render_json_extract(q.providerIdx, srcType, source_alias_for_idx(q, srcIdx), colName, jsonPath)
     outLeafType = leaf
     return 1
 }
@@ -3198,7 +3215,7 @@ def private pred_to_sql(var node : ExpressionPtr; var q : SqlQuery&; prog : Prog
                         // Validate every path segment — the typer never sees `_where`'s lambda body so silent NULL-on-typo is the failure mode.
                         let leaf = resolve_nested_field_type(srcType, colName, jsonPath)
                         if (leaf == null) return pred_fail(q, prog, at, "_sql: JSON path on @sql_json column '{colName}' walks into a field that isn't a struct/tuple member at depth {length(jsonPath)}")
-                        return render_json_extract(srcType, source_alias_for_idx(q, srcIdx), colName, jsonPath)
+                        return render_json_extract(q.providerIdx, srcType, source_alias_for_idx(q, srcIdx), colName, jsonPath)
                     }
                 }
             }
@@ -4061,7 +4078,7 @@ def private build_sql_select(var q : SqlQuery&; force_aliases : bool = false) : 
         } elif (q.limitBindExpr != null) {
             w |> write(" LIMIT ?")
         } elif (q.offsetBindExpr != null) {
-            w |> write(" LIMIT -1")
+            w |> write(" {sql_provider_at(q.providerIdx).noLimitSpelling}")
         }
         if (!forced_one_row && q.offsetBindExpr != null) {
             w |> write(" OFFSET ?")
@@ -4086,7 +4103,7 @@ class private SqlTextMacro : AstCallMacro {
         sql_to_frags_ex(sql, noBinds, q.orderByInlineExprs, frags)
         var sqlExpr : ExpressionPtr
         var bindExprs : array<ExpressionPtr>
-        fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+        fold_to_builder(frags, q.providerIdx, call.at, sqlExpr, bindExprs)
         sqlExpr.force_at(call.at)
         return sqlExpr
     }
@@ -4283,9 +4300,14 @@ def private emit_pragma_or_vacuum(prog : ProgramPtr; var call : ExprCallMacro?;
         frags |> push_text("VACUUM INTO ")
         frags |> push_inline_lit(call.arguments[1])
     }
+    let provIdx = find_sql_provider_by_runner(call.arguments[0]._type)
+    if (provIdx < 0) {
+        macro_error(prog, call.at, "{macroName}: no SQL provider registered for runner type {describe(call.arguments[0]._type)} (registered: {sql_provider_names()})")
+        return null
+    }
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    fold_to_builder(frags, provIdx, call.at, sqlExpr, bindExprs)
     var res = qmacro(_::try_exec($e(call.arguments[0]), $e(sqlExpr)))
     res.force_at(call.at)
     return res
@@ -4604,7 +4626,7 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     sql_to_frags_ex(sql, allBinds, q.orderByInlineExprs, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    fold_to_builder(frags, q.providerIdx, call.at, sqlExpr, bindExprs)
     // Build bind statements: sql_bind_to_stmt(stmt, i+1, $e(boundExpr))
     var bind_stmts : array<ExpressionPtr>
     bind_stmts |> reserve(length(bindExprs))
@@ -4618,14 +4640,17 @@ def private emit_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro?; is
     var rowBuilder = build_row_builder(q, prog, call.at)
     if (rowBuilder == null) return null
     var dbExpr = q.dbExpr
+    let prov = sql_provider_at(q.providerIdx)
+    var stmtT = invoke(prov.makeStmtType)
+    var stmtTC = invoke(prov.makeStmtTypeConst)
     let suffix = (q.matr == Materializer.One ? "_one"
                   : (q.matr == Materializer.OneOpt ? "_one_opt" : ""))
     let fname = (isTry ? "try_run_select" : "run_select") + suffix
     var res = qmacro($c(fname)($e(dbExpr), $e(sqlExpr),
-        $(var _sql_stmt : sqlite3_stmt?) {
+        $(var _sql_stmt : $t(stmtT)) {
             $b(bind_stmts)
         },
-        $(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        $(_sql_stmt : $t(stmtTC)) => $e(rowBuilder)))
     res.force_at(call.at)
     return res
 }
@@ -4677,7 +4702,7 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
     sql_to_frags_ex(sql, allBinds, q.orderByInlineExprs, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    fold_to_builder(frags, q.providerIdx, call.at, sqlExpr, bindExprs)
     var bind_stmts : array<ExpressionPtr>
     bind_stmts |> reserve(length(bindExprs))
     for (i in range(length(bindExprs))) {
@@ -4690,12 +4715,15 @@ def private emit_each_sql_macro_body(prog : ProgramPtr; var call : ExprCallMacro
     var rowBuilder = build_row_builder(q, prog, call.at)
     if (rowBuilder == null) return null
     var dbExpr = q.dbExpr
+    let prov = sql_provider_at(q.providerIdx)
+    var stmtT = invoke(prov.makeStmtType)
+    var stmtTC = invoke(prov.makeStmtTypeConst)
     // bind_blk = block (one-shot, before the generator); row_blk = capturing lambda (outlives run_each_select).
     var res = qmacro(_::run_each_select($e(dbExpr), $e(sqlExpr),
-        $(var _sql_stmt : sqlite3_stmt?) {
+        $(var _sql_stmt : $t(stmtT)) {
             $b(bind_stmts)
         },
-        @(_sql_stmt : sqlite3_stmt?) => $e(rowBuilder)))
+        @(_sql_stmt : $t(stmtTC)) => $e(rowBuilder)))
     res.force_at(call.at)
     return res
 }
@@ -4783,6 +4811,7 @@ def private analyze_set_clause(var setExpr : ExpressionPtr; var q : SqlQuery&;
     var setQ = SqlQuery(
         rootType = q.rootType,
         tableName = q.tableName,
+        providerIdx = q.providerIdx,
         argNames <- ["_"],
         argSourceIdx <- [0]
     )
@@ -4823,14 +4852,17 @@ def private build_returning_clause(rootT : TypeDeclPtr) : string {
 def private emit_dml_call(var dbE : ExpressionPtr; var sqlExpr : ExpressionPtr;
                           var bindStmts : array<ExpressionPtr>;
                           isTry : bool; isReturning : bool;
-                          rootT : TypeDeclPtr; at : LineInfo) : ExpressionPtr {
-    var bindLambda = qmacro($(var _sql_stmt : sqlite3_stmt?) {
+                          rootT : TypeDeclPtr; provIdx : int; at : LineInfo) : ExpressionPtr {
+    let prov = sql_provider_at(provIdx)
+    var stmtT = invoke(prov.makeStmtType)
+    var bindLambda = qmacro($(var _sql_stmt : $t(stmtT)) {
         $b(bindStmts)
     })
     var res : ExpressionPtr
     if (isReturning) {
         var rootClone = clone_type(rootT)
-        var readerLambda = qmacro($(_sql_stmt : sqlite3_stmt?) => _::_sql_read_row(_sql_stmt, type<$t(rootClone)>))
+        var stmtTC = invoke(prov.makeStmtTypeConst)
+        var readerLambda = qmacro($(_sql_stmt : $t(stmtTC)) => _::_sql_read_row(_sql_stmt, type<$t(rootClone)>))
         let fname = (isTry ? "try_run_dml_returning" : "run_dml_returning")
         res = qmacro($c(fname)($e(dbE), $e(sqlExpr), $e(bindLambda), $e(readerLambda)))
     } else {
@@ -4859,6 +4891,11 @@ def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
         argNames <- ["_"],
         argSourceIdx <- [0]
     )
+    q.providerIdx = find_sql_provider_by_runner(dbE._type)
+    if (q.providerIdx < 0) {
+        macro_error(prog, call.at, "_sql_update: no SQL provider registered for runner type {describe(dbE._type)} (registered: {sql_provider_names()})")
+        return null
+    }
     // Translate WHERE — raw AST. pred_to_sql emitted macro_error, OR returned "" without setting hadError.
     let whereSql = pred_to_sql(whereE, q, prog, call.at)
     if (q.hadError || empty(whereSql)) return null
@@ -4886,13 +4923,13 @@ def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
     // Combine binds: SET first, then WHERE.
     var allBinds : array<ExpressionPtr>
     allBinds |> reserve(length(setBindExprs) + length(q.bindExprs))
-    allBinds |> push_from(setBindExprs)
+    allBinds |> push_from(setBindExprs)   // nolint:STYLE033 — same 31400 as collect_query_binds
     allBinds |> push_from(q.bindExprs)
     var frags : array<SqlFrag>
     sql_to_frags(sql, allBinds, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    fold_to_builder(frags, q.providerIdx, call.at, sqlExpr, bindExprs)
     var bindStmts : array<ExpressionPtr>
     bindStmts |> reserve(length(bindExprs))
     for (i in range(length(bindExprs))) {
@@ -4902,7 +4939,7 @@ def private emit_update_body(prog : ProgramPtr; var call : ExprCallMacro?;
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, call.at)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, q.providerIdx, call.at)
 }
 
 [macro_function]
@@ -4922,6 +4959,11 @@ def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
         argNames <- ["_"],
         argSourceIdx <- [0]
     )
+    q.providerIdx = find_sql_provider_by_runner(dbE._type)
+    if (q.providerIdx < 0) {
+        macro_error(prog, call.at, "_sql_delete: no SQL provider registered for runner type {describe(dbE._type)} (registered: {sql_provider_names()})")
+        return null
+    }
     // pred_to_sql emitted macro_error, OR returned "" without setting hadError.
     let whereSql = pred_to_sql(whereE, q, prog, call.at)
     if (q.hadError || empty(whereSql)) return null
@@ -4933,7 +4975,7 @@ def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
     sql_to_frags(sql, q.bindExprs, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
+    fold_to_builder(frags, q.providerIdx, call.at, sqlExpr, bindExprs)
     var bindStmts : array<ExpressionPtr>
     bindStmts |> reserve(length(bindExprs))
     for (i in range(length(bindExprs))) {
@@ -4943,7 +4985,7 @@ def private emit_delete_body(prog : ProgramPtr; var call : ExprCallMacro?;
             sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
         })
     }
-    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, call.at)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, q.providerIdx, call.at)
 }
 
 // ----------------------------------------------------------------------------
@@ -5165,6 +5207,7 @@ def private validate_conflict_cols(rootT : TypeDeclPtr; conflictCols : array<str
 
 [macro_function]
 def private analyze_upsert_set_clause(var setExpr : ExpressionPtr; var rootT : TypeDeclPtr; tableName : string;
+                                      providerIdx : int;
                                       var setSqlClauses : array<string>&;
                                       var setBindExprs : array<ExpressionPtr>&;
                                       prog : ProgramPtr; at : LineInfo) : bool {
@@ -5235,6 +5278,7 @@ def private analyze_upsert_set_clause(var setExpr : ExpressionPtr; var rootT : T
     var setQ = SqlQuery(
         rootType = rootT,
         tableName = tableName,
+        providerIdx = providerIdx,
         argNames <- ["_"],
         argSourceIdx <- [0],
         upsertMode = true
@@ -5267,13 +5311,18 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
     var conflictE = call.arguments[2]
     var doUpdateE = call.arguments[3]
     let tableName = sql_table_name_from_type(rootT)
+    let provIdx = find_sql_provider_by_runner(dbE._type)
+    if (provIdx < 0) {
+        macro_error(prog, call.at, "_sql_upsert: no SQL provider registered for runner type {describe(dbE._type)} (registered: {sql_provider_names()})")
+        return null
+    }
     // 1) on_conflict columns
     var conflictCols : array<string>
     if (!analyze_upsert_conflict_inner(conflictE, rootT, conflictCols, prog, call.at)) return null
     // 2) do_update SET clauses (with upsertMode=true so `_excluded.Col` resolves)
     var setSqlClauses : array<string>
     var setBindExprs : array<ExpressionPtr>
-    if (!analyze_upsert_set_clause(doUpdateE, rootT, tableName, setSqlClauses, setBindExprs, prog, call.at)) return null
+    if (!analyze_upsert_set_clause(doUpdateE, rootT, tableName, provIdx, setSqlClauses, setBindExprs, prog, call.at)) return null
     // 3) INSERT column list (non-computed only) — SQL-side names, positional bind indices.
     var nonComputedCols : array<string>
     var nRowBinds = 0
@@ -5336,8 +5385,8 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
     sql_to_frags(sql, noBinds, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, call.at, sqlExpr, bindExprs)
-    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, call.at)
+    fold_to_builder(frags, provIdx, call.at, sqlExpr, bindExprs)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, provIdx, call.at)
 }
 
 [call_macro(name="_sql_upsert")]


### PR DESCRIPTION
## What

Behavior-preserving provider seam in dasSQLITE so a second SQL provider (DuckDB, then PostgreSQL — the planned `borisbat/dasDuckDB` / `borisbat/dasPostgreSQL` external modules) can plug into the `_sql` LINQ-to-SQL machinery without touching the analyzer. First rung of the provider ladder: seam (this PR) → neutral `daslib/sql_linq` move → shared conformance suite → DuckDB → PostgreSQL.

- **`daslib/sql_provider.das` (new)** — neutral compile-time provider registry keyed by runner type: stmt-type factories (mutable + const flavors, qualifiers spelled in the type expression — `$t` substitution replaces placeholder types wholesale, including the parser's const-append on non-`var` params), dialect hooks as function pointers (macros can't overload-dispatch across providers), capability flags, PK-report style. Registered via the `[_macro]` + `is_compiling_macros_in_module` pattern (linq_fold.das:123) from **both** consulting modules — only a module's own `[_macro]` functions run when its macro context is built.
- **`sqlite_linq.das`** — all six emitted bind/reader block/lambda sites splice the stmt type from the registry instead of spelling `sqlite3_stmt?`; `providerIdx` threads through `SqlQuery` (chain root, subquery propagation, DML/upsert/pragma manual constructions); an unknown runner type is a compile-time `macro_error` naming the registered providers. Dialect points routed through the entry: bind placeholder (single render point in `fold_to_builder`), OFFSET-without-LIMIT spelling, `json_extract` rendering.
- **`sqlite_boost.das`** — the `[sql_table]` / `[sql_view]` / `[sql_fts5]` row binder/reader factories emit stmt-**generic** helpers (`add_generic`); they monomorphize per provider stmt type and their interior `sql_bind_to_stmt` / `read_via_adapter` calls overload-resolve against whichever provider instantiated them.
- **`PROVIDER_CONTRACT.md` (new)** — the runtime helper contract (~15 overloads on the runner type), registry entry shape, capability semantics, and which hooks stay registered-but-unrouted for now (`quoteId` — double-quote quoting is portable across SQLite/DuckDB/PG; `sqlTypeFor`/`identityDdl` — DDL routing lands with the neutral `[sql_table]`).

## Gate (behavior-preserving)

- All 45 `tutorials/sql` goldens **byte-identical** before/after (only known timestamp noise in `41-triggers`, present across any two runs).
- `tests/dasSQLITE`: 904/904. Full interp suite: 11741 tests, 0 failed, 0 errors. Full AOT suite (`test_aot` with CI flags): 11029 tests, 0 failed, 0 errors.
- Lint 0 issues on the changed set, formatter clean, dupe scan clean, full preflight token minted.

## Notes for reviewers

- Registration uses `[_macro]` wrappers in both `sqlite_boost` and `sqlite_linq` because globals-init and `[init]` do **not** reach a consumer's macro context (`ast_export.cpp` `markUsedFunctions` roots only the macro module's own `macroInit` functions). Future providers will be invoked from the consulting module's own `[_macro]` (consumer-requires-contributor, optional-require-guarded) — same as linq_fold source adapters.
- Two pre-existing issues found while here, deliberately not fixed in this PR: **STYLE033** suggests a variadic `push_from(s1, s2, ...)` collapse that does not compile for `array<Expression?>` sources (the variadic overload forwards `==const` and trips 31400 "can't push value which can't be cloned from const") — the two sites in `sqlite_linq.das` carry `// nolint:STYLE033` with the reason; and `fold_to_string` in `sqlite_linq.das` is dead code (zero callers) — cleanup rides the `daslib/sql_linq` move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)