### PR TITLE
sql_boost: register the external dasDuckDB provider (+ dasClangBind CRT save/restore, rst trailing-underscore escape)

### DIFF
--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -378,7 +378,13 @@ def rst_describe_function_short(func : FunctionPtr) {
         }
     }
 
-    var res = "{function_name(func)} ({join(args,"; ")})"
+    // a trailing-underscore name (delete_, where_) parses as an RST reference in the
+    // emitted plain-text def line — escape the underscore (`delete\_ (`)
+    var fname = function_name(func)
+    if (fname |> ends_with("_")) {
+        fname = slice(fname, 0, -1) + "\\_"
+    }
+    var res = "{fname} ({join(args,"; ")})"
     if (func.result != null && func.result.baseType != Type.tVoid) {
         res = "{res} : {describe_type_short(func.result)}"
     }

--- a/daslib/sql_boost.das
+++ b/daslib/sql_boost.das
@@ -24,6 +24,7 @@ require daslib/json_boost public    // [sql_table] @sql_json adapter codegen cal
 require daslib/archive public       // [sql_table] @sql_blob adapter codegen calls mem_archive_save / mem_archive_load
 
 require ?sqlite sqlite/sqlite_provider    // in-tree provider registration shim -- loaded only when sqlite is linked
+require ?duckdb duckdb/duckdb_provider    // external provider (github.com/borisbat/dasDuckDB) -- loaded only when duckdb is linked
 
 //! Provider-neutral SQL macro layer: ``[sql_table]`` / ``[sql_view]`` / ``[sql_index]``,
 //! the typed ALTER macros (``add_column`` / ``create_index``), and the ``sql_bind`` /
@@ -39,6 +40,9 @@ def public sql_register_present_providers {
     if (sql_register_present_providers_done()) return
     static_if (typeinfo builtin_module_exists(sqlite)) {
         register_sqlite_provider()
+    }
+    static_if (typeinfo builtin_module_exists(duckdb)) {
+        register_duckdb_provider()
     }
 }
 

--- a/modules/dasClangBind/CMakeLists.txt
+++ b/modules/dasClangBind/CMakeLists.txt
@@ -2,7 +2,14 @@ IF (NOT DEFINED PATH_TO_LIBCLANG)
 	SET(PATH_TO_LIBCLANG "${PROJECT_SOURCE_DIR}/../libclang")
 ENDIF()
 IF ((NOT ${DAS_CLANG_BIND_DISABLED}) OR (NOT DEFINED DAS_CLANG_BIND_DISABLED))
+	# The official LLVM SDK's LLVMConfig.cmake does set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
+	# at OUR scope, silently flipping every daslang target to the static CRT (/MT) and breaking
+	# any module whose vendored lib is /MD (dasHV's hv_static.lib -> LNK2038/OLDNAMES). libclang
+	# is consumed as a DLL through its C API, so daslang's CRT never has to match LLVM's — save
+	# and restore the knob around the find_package.
+	SET(_das_saved_msvc_runtime_library "${CMAKE_MSVC_RUNTIME_LIBRARY}")
 	find_package(Clang 22.1 PATHS "${PATH_TO_LIBCLANG}")
+	SET(CMAKE_MSVC_RUNTIME_LIBRARY "${_das_saved_msvc_runtime_library}")
 ENDIF()
 IF ((NOT DAS_CLANG_BIND_INCLUDED) AND (${Clang_FOUND}) AND ((NOT ${DAS_CLANG_BIND_DISABLED}) OR (NOT DEFINED DAS_CLANG_BIND_DISABLED)))
     SET(DAS_CLANG_BIND_INCLUDED TRUE)


### PR DESCRIPTION
Three riders for [dasDuckDB](https://github.com/borisbat/dasDuckDB) — the first **external** consumer of [PROVIDER_CONTRACT.md](https://github.com/GaijinEntertainment/daScript/blob/master/modules/dasSQLITE/PROVIDER_CONTRACT.md), passing the shared `tests/sql_conformance` suite 64/64 (fts5 file dropped per the capability-skip policy; everything else including `[sql_function]` UDFs green).

### `daslib/sql_boost.das` — provider registration hookup

`require ?duckdb duckdb/duckdb_provider` + the `register_duckdb_provider()` `static_if` branch in `sql_register_present_providers`. Exactly the two-line extension point the contract documents. **Inert when the module is absent** — `builtin_module_exists(duckdb)` compiles the branch out, so in-tree CI never sees it. Verified: `tests/sql_conformance` 66/66 and `tests/dasSQLITE` 904/904 with the edit in place.

### `modules/dasClangBind/CMakeLists.txt` — LLVM SDK stomps the CRT

The official LLVM SDK's `LLVMConfig.cmake` does `set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)` **at the caller's scope**, so enabling clang-bind (`find_package(Clang)`) silently flips every daslang target to the static CRT. The breakage surfaces later and looks unrelated: dasHV's next relink fails with `LNK2038 RuntimeLibrary mismatch` + OLDNAMES `__imp__access`-style unresolved externals against its `/MD` `hv_static.lib`. libclang is consumed as a DLL through its C API, so daslang's CRT never has to match LLVM's — save/restore the variable around the `find_package`. (Found by `cmake --trace-expand | grep 'set(CMAKE_MSVC_RUNTIME_LIBRARY'`.)

### `daslib/rst.das` — trailing-underscore names break strict Sphinx

The generated plain-text def line for a trailing-underscore function (`delete_`, `try_delete_`) parses as an RST *reference* (`delete_ (…)` → target `delete`) and fails `-W` builds with `ERROR: Unknown target name`. Escape the underscore (`delete\_`). Hit by dasDuckDB's docs pipeline, which builds strict; applies to any module documenting the `delete_` CRUD parity name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)