### PR TITLE
daspkg: update-index last-updated date via --date=short --format=%cd

### DIFF
--- a/utils/daspkg/index.das
+++ b/utils/daspkg/index.das
@@ -980,9 +980,10 @@ def cmd_update_index(root : string) : int {
                 index[name].latest_version = strip(tag_output)
             }
 
-            // get last commit date
+            // get last commit date; --date=short --format=%cd, NOT %cs — pre-2.25 git
+            // has no %cs and passes unknown placeholders through LITERALLY
             var date_output : string
-            let date_exit = run_cmd("git -C \"{tmp_dir}\" log -1 --format=%cs", date_output)
+            let date_exit = run_cmd("git -C \"{tmp_dir}\" log -1 --date=short --format=%cd", date_output)
             if (date_exit == 0 && !empty(strip(date_output))) {
                 index[name].last_updated = strip(date_output)
             }


### PR DESCRIPTION
One-liner found while introducing dasPostgreSQL to the index: `update-index` read the last-commit date with `git log -1 --format=%cs`, but pre-2.25 git has no `%cs` and passes unknown placeholders through **literally** — so the regenerated index README grew `**Updated:** %cs` lines (daspkg-index#28, closed). `--date=short --format=%cd` produces the same `YYYY-MM-DD` on every git version.

Verified: rerunning `update-index` with the fix produced real dates for all 14 packages (daspkg-index#29, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)