### PR TITLE
optimizer: fast_math policy + algebraic identity folding; fix isNop and RunFolding round bugs

### DIFF
--- a/doc/source/reference/language/options.rst
+++ b/doc/source/reference/language/options.rst
@@ -150,6 +150,15 @@ Optimization
      - bool
      - false
      - Disables all optimizations unconditionally. Overrides all other optimization settings.
+   * - ``fast_math``
+     - bool
+     - false
+     - Allows float optimizations that change results in a major way for inf/NaN inputs or rounding
+       (``x*0`` and ``x-x`` to ``0``, division by a constant via reciprocal multiply, ``!(a<b)`` to
+       ``a>=b``, constant reassociation), and lets the JIT stamp fast-math flags on all FP
+       instructions. ``double`` stays bit-exact unless this is on; ``float`` identities with only
+       sign-of-zero differences (``x+0.0``) fold regardless, since float32 is not bit-exact across
+       execution tiers. Also available as ``CodeOfPolicies::fast_math``.
    * - ``fusion``
      - bool
      - true

--- a/doc/source/stdlib/handmade/structure_annotation-rtti-CodeOfPolicies.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-rtti-CodeOfPolicies.rst
@@ -62,6 +62,7 @@ Report invisible functions.
 Report private functions.
 Enables strict property checks.
 Disables all optimizations.
+Allows float optimizations with major bit differences (x*0, x-x, reciprocal division, NaN-compare flips, reassociation); also stamps JIT fast-math flags. Doubles stay bit-exact unless enabled.
 Disables infer-time constant folding.
 Fails compilation if AOT is not available.
 Fails compilation if AOT export is not available.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1591,6 +1591,7 @@ namespace das
         /*option*/ bool no_writing_to_nameless = true;             // if true, then writing to nameless variables (intermediate on the stack) is not allowed
     // environment
         /*option*/ bool no_optimizations = false;                  // disable optimizations, regardless of settings
+        /*option*/ bool fast_math = false;                         // allow float optimizations with major bit differences (x*0, x-x, rcp division, NaN-compare flips, reassociation); doubles stay bit-exact unless this is on
         /*option*/ bool no_infer_time_folding = false;             // disable infer-time constant folding
         bool fail_on_no_aot = true;                     // AOT link failure is error
         bool fail_on_lack_of_aot_export = false;        // remove_unused_symbols = false is missing in the module, which is passed to AOT

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -220,8 +220,8 @@ namespace das {
         AstSerializer & operator << ( Module & module );
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
-        static constexpr uint32_t getVersion () { 
-            return 94;   // 94: Module::promotedRequire (shared-module canonical require identity) added
+        static constexpr uint32_t getVersion () {
+            return 95;   // 95: CodeOfPolicies::fast_math added
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -690,7 +690,8 @@ typedef enum das_bool_policy {
     DAS_POLICY_STRICT_SMART_POINTERS,            // Strict smart pointer rules (var inscope, etc.)
     DAS_POLICY_RTTI,                             // Generate extended RTTI
     DAS_POLICY_NO_OPTIMIZATIONS,                 // Disable all optimizations
-    DAS_POLICY_NO_INFER_TIME_FOLDING             // Disable infer-time constant folding
+    DAS_POLICY_NO_INFER_TIME_FOLDING,            // Disable infer-time constant folding
+    DAS_POLICY_FAST_MATH                         // Allow float optimizations with major bit differences (x*0, x-x, rcp division, reassociation)
 } das_bool_policy;
 
 // Integer policy fields (stack size, heap limits).

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -37,7 +37,8 @@ let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x37ul   // x64_avx AVX kernel-matrix ti
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
-// `options _jit_fast_math = true` stamps every FP instruction with all fast-math flags before opt — lets
+// `options fast_math = true` (or policies.fast_math; `_jit_fast_math` is a legacy alias) stamps every FP
+// instruction with all fast-math flags before opt — lets
 // reductions reassociate/vectorize and FP contract everywhere. NON-bit-exact, but this is the same FP
 // laxity llama.cpp/ggml already runs with (hand-coded FMA + ~2ulp poly exp + reassociated SIMD reductions;
 // ggml CPU is just -O3, no -ffast-math flag — it hand-writes the equivalent). Measured greedy-STABLE on
@@ -308,7 +309,8 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
 
     // Set global options
     LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS = prog._options |> find_arg("jit_vec3_ldu") ?as tBool ?? LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS_DEFAULT
-    g_jit_fast_math = prog._options |> find_arg("_jit_fast_math") ?as tBool ?? false
+    // `options fast_math` (or policies.fast_math) is the one knob; `_jit_fast_math` kept as a legacy alias
+    g_jit_fast_math = (prog._options |> find_arg("fast_math") ?as tBool ?? prog.policies.fast_math) || (prog._options |> find_arg("_jit_fast_math") ?as tBool ?? false)
 
     make_visitor(*disableJitVisitor) $(disableJitVisitorAdapter) {
         prog |> for_each_module() $(mod) {

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -6,11 +6,6 @@
 #include "daScript/ast/ast_simulate.h"
 #include "daScript/simulate/debug_print.h"
 
-/*
-TODO:
-    Fold vector constructors
-*/
-
 namespace das {
 
     void PassVisitor::preVisitProgram ( Program * prog ) {
@@ -39,10 +34,10 @@ namespace das {
         if (func) {
             // Mark the function as dirty for the current and
             // upcoming optimization pass.
-            // Non-optimizer passes that derive from PassVisitor
-            // have round always set to 0, so this assignment
-            // wouldn't affect anything
-            func->optimizationRound = round;
+            // max() so a pass constructed with a lower round (or a
+            // non-optimizer pass with round 0) can never downgrade a
+            // dirty marker another pass already stamped this round.
+            func->optimizationRound = das::max(func->optimizationRound, round);
         }
     }
 
@@ -500,6 +495,123 @@ namespace das {
         }
     }
 
+    // ===== algebraic identity folding helpers =====
+
+    static bool isFloat32Family ( Type bt ) {
+        return bt==Type::tFloat || bt==Type::tFloat2 || bt==Type::tFloat3 || bt==Type::tFloat4;
+    }
+
+    static bool isFPFamily ( Type bt ) {
+        return isFloat32Family(bt) || bt==Type::tDouble;
+    }
+
+    static bool isSignedNumericFamily ( Type bt ) {
+        switch ( bt ) {
+        case Type::tInt: case Type::tInt8: case Type::tInt16: case Type::tInt64:
+        case Type::tInt2: case Type::tInt3: case Type::tInt4:
+        case Type::tFloat: case Type::tFloat2: case Type::tFloat3: case Type::tFloat4:
+        case Type::tDouble:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    static bool isIntegerFamily ( Type bt ) {
+        switch ( bt ) {
+        case Type::tInt: case Type::tInt8: case Type::tInt16: case Type::tInt64:
+        case Type::tUInt: case Type::tUInt8: case Type::tUInt16: case Type::tUInt64:
+        case Type::tInt2: case Type::tInt3: case Type::tInt4:
+        case Type::tUInt2: case Type::tUInt3: case Type::tUInt4:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    static bool isNumericFamily ( Type bt ) {
+        return isIntegerFamily(bt) || isFPFamily(bt);
+    }
+
+    // every lane of a numeric constant equals `v` (v is small and exactly representable in every type tested)
+    static bool constEquals ( Expression * e, double v ) {
+        if ( !e || !e->rtti_isConstant() || !e->type || e->type->ref ) return false;
+        auto c = static_cast<ExprConst *>(e);
+        switch ( e->type->baseType ) {
+        case Type::tInt:     return cast<int32_t>::to(c->value)==int32_t(v);
+        case Type::tInt8:    return cast<int8_t>::to(c->value)==int8_t(v);
+        case Type::tInt16:   return cast<int16_t>::to(c->value)==int16_t(v);
+        case Type::tInt64:   return cast<int64_t>::to(c->value)==int64_t(v);
+        case Type::tUInt:    return v>=0 && cast<uint32_t>::to(c->value)==uint32_t(v);
+        case Type::tUInt8:   return v>=0 && cast<uint8_t>::to(c->value)==uint8_t(v);
+        case Type::tUInt16:  return v>=0 && cast<uint16_t>::to(c->value)==uint16_t(v);
+        case Type::tUInt64:  return v>=0 && cast<uint64_t>::to(c->value)==uint64_t(v);
+        case Type::tFloat:   return cast<float>::to(c->value)==float(v);
+        case Type::tDouble:  return cast<double>::to(c->value)==double(v);
+        case Type::tInt2:    { auto t = cast<int2>::to(c->value);   return t.x==int32_t(v) && t.y==int32_t(v); }
+        case Type::tInt3:    { auto t = cast<int3>::to(c->value);   return t.x==int32_t(v) && t.y==int32_t(v) && t.z==int32_t(v); }
+        case Type::tInt4:    { auto t = cast<int4>::to(c->value);   return t.x==int32_t(v) && t.y==int32_t(v) && t.z==int32_t(v) && t.w==int32_t(v); }
+        case Type::tUInt2:   { if ( v<0 ) return false; auto t = cast<uint2>::to(c->value);  return t.x==uint32_t(v) && t.y==uint32_t(v); }
+        case Type::tUInt3:   { if ( v<0 ) return false; auto t = cast<uint3>::to(c->value);  return t.x==uint32_t(v) && t.y==uint32_t(v) && t.z==uint32_t(v); }
+        case Type::tUInt4:   { if ( v<0 ) return false; auto t = cast<uint4>::to(c->value);  return t.x==uint32_t(v) && t.y==uint32_t(v) && t.z==uint32_t(v) && t.w==uint32_t(v); }
+        case Type::tFloat2:  { auto t = cast<float2>::to(c->value); return t.x==float(v) && t.y==float(v); }
+        case Type::tFloat3:  { auto t = cast<float3>::to(c->value); return t.x==float(v) && t.y==float(v) && t.z==float(v); }
+        case Type::tFloat4:  { auto t = cast<float4>::to(c->value); return t.x==float(v) && t.y==float(v) && t.z==float(v) && t.w==float(v); }
+        default: return false;
+        }
+    }
+
+    static bool isPosZeroBits ( float f )  { uint32_t u; memcpy(&u,&f,sizeof(u)); return u==0u; }
+    static bool isPosZeroBits ( double d ) { uint64_t u; memcpy(&u,&d,sizeof(u)); return u==0ul; }
+    static bool isNegZeroBits ( float f )  { uint32_t u; memcpy(&u,&f,sizeof(u)); return u==0x80000000u; }
+    static bool isNegZeroBits ( double d ) { uint64_t u; memcpy(&u,&d,sizeof(u)); return u==0x8000000000000000ul; }
+
+    // every lane is +0.0 exactly (integer zero also qualifies)
+    static bool constAllPosZero ( Expression * e ) {
+        if ( !constEquals(e, 0) ) return false;
+        auto c = static_cast<ExprConst *>(e);
+        switch ( e->type->baseType ) {
+        case Type::tFloat:   return isPosZeroBits(cast<float>::to(c->value));
+        case Type::tDouble:  return isPosZeroBits(cast<double>::to(c->value));
+        case Type::tFloat2:  { auto t = cast<float2>::to(c->value); return isPosZeroBits(t.x) && isPosZeroBits(t.y); }
+        case Type::tFloat3:  { auto t = cast<float3>::to(c->value); return isPosZeroBits(t.x) && isPosZeroBits(t.y) && isPosZeroBits(t.z); }
+        case Type::tFloat4:  { auto t = cast<float4>::to(c->value); return isPosZeroBits(t.x) && isPosZeroBits(t.y) && isPosZeroBits(t.z) && isPosZeroBits(t.w); }
+        default: return true;
+        }
+    }
+
+    // every lane is -0.0 exactly (never true for integers)
+    static bool constAllNegZero ( Expression * e ) {
+        if ( !constEquals(e, 0) ) return false;
+        auto c = static_cast<ExprConst *>(e);
+        switch ( e->type->baseType ) {
+        case Type::tFloat:   return isNegZeroBits(cast<float>::to(c->value));
+        case Type::tDouble:  return isNegZeroBits(cast<double>::to(c->value));
+        case Type::tFloat2:  { auto t = cast<float2>::to(c->value); return isNegZeroBits(t.x) && isNegZeroBits(t.y); }
+        case Type::tFloat3:  { auto t = cast<float3>::to(c->value); return isNegZeroBits(t.x) && isNegZeroBits(t.y) && isNegZeroBits(t.z); }
+        case Type::tFloat4:  { auto t = cast<float4>::to(c->value); return isNegZeroBits(t.x) && isNegZeroBits(t.y) && isNegZeroBits(t.z) && isNegZeroBits(t.w); }
+        default: return false;
+        }
+    }
+
+    static bool isConstBoolValue ( Expression * e, bool v ) {
+        if ( !e || !e->rtti_isConstant() || !e->type || e->type->baseType!=Type::tBool ) return false;
+        return static_cast<ExprConstBool *>(e)->getValue()==v;
+    }
+
+    // both expressions read the same variable (cheap structural equality; a full
+    // Expression::sameAs comparator is a planned follow-up)
+    static bool sameVariableRead ( Expression * a, Expression * b ) {
+        if ( !a || !b || !a->rtti_isVar() || !b->rtti_isVar() ) return false;
+        auto va = static_cast<ExprVar *>(a);
+        auto vb = static_cast<ExprVar *>(b);
+        return va->variable && va->variable==vb->variable && !va->write && !vb->write && va->r2v==vb->r2v;
+    }
+
+    // inf-safe finiteness check without <cmath>: inf-inf and NaN-NaN are NaN
+    static bool finiteFP ( float f )  { return f-f==0.0f; }
+    static bool finiteFP ( double d ) { return d-d==0.0; }
+
     /*
         op1 constexpr = op1(constexpr)
         op2 constexpr,constexpr = op2(constexpr,constexpr)
@@ -520,22 +632,131 @@ namespace das {
     class ConstFolding : public FoldingVisitor {
     public:
         using PassVisitor::visit;
-        ConstFolding( const ProgramPtr & prog, int32_t round ) : FoldingVisitor(prog, round) {}
+        ConstFolding( const ProgramPtr & prog, int32_t round ) : FoldingVisitor(prog, round) {
+            fastMath = prog->options.getBoolOption("fast_math", prog->policies.fast_math);
+        }
     public:
         vector<Function *> needRun;
     protected:
+        bool fastMath = false;
+        // sign-of-zero-only bit differences (x+0, 0-x): float32 is not bit-exact across das
+        // tiers so they are always fair game; double IS bit-exact and needs fast_math; int is exact
+        bool zeroSignLaxOk ( Type bt ) const {
+            return bt==Type::tDouble ? fastMath : true;
+        }
+        // folds that change values for inf/NaN inputs (x*0, x-x): fast_math only for FP
+        bool valueChangeOk ( Type bt ) const {
+            return isFPFamily(bt) ? fastMath : true;
+        }
+        // builtin, side-effect-free operator with these exact argument types (t1 null → unary)
+        Function * findBuiltinOperator ( const char * opName, TypeDecl * t0, TypeDecl * t1 = nullptr ) {
+            if ( !t0 ) return nullptr;
+            Function * result = nullptr;
+            uint64_t hName = hash64z(opName);
+            size_t nArgs = t1 ? 2 : 1;
+            program->library.foreach([&](Module * mod) -> bool {
+                if ( auto kv = mod->functionsByName.find(hName) ) {
+                    for ( auto fn : kv->second ) {
+                        if ( !fn->builtIn || fn->sideEffectFlags || fn->isTemplate ) continue;
+                        if ( fn->arguments.size()!=nArgs ) continue;
+                        if ( !fn->arguments[0]->type->isSameType(*t0, RefMatters::no, ConstMatters::no, TemporaryMatters::no) ) continue;
+                        if ( t1 && !fn->arguments[1]->type->isSameType(*t1, RefMatters::no, ConstMatters::no, TemporaryMatters::no) ) continue;
+                        result = fn;
+                        return false;
+                    }
+                }
+                return true;
+            }, "*");
+            return result;
+        }
+        ExpressionPtr makeZeroConst ( Expression * expr ) {
+            auto sim = Program::makeConst(expr->at, expr->type, v_zero());
+            if ( !sim ) return nullptr;
+            sim->type = new TypeDecl(*expr->type);
+            sim->type->ref = false;
+            sim->constexpression = true;
+            ((ExprConst *)sim)->foldedNonConst = !expr->type->constant;
+            return sim;
+        }
+        ExpressionPtr makeNegate ( Expression * host, Expression * sub ) {
+            auto negFn = findBuiltinOperator("-", sub->type);
+            if ( !negFn ) return nullptr;
+            auto neg = new ExprOp1(host->at, "-", sub);
+            neg->func = negFn;
+            neg->type = new TypeDecl(*host->type);
+            neg->type->ref = false;
+            neg->type->constant = false;
+            return neg;
+        }
+        // 1/C for an FP constant; null when any lane is zero or the reciprocal is not finite
+        ExpressionPtr makeReciprocalConst ( Expression * c ) {
+            auto cc = static_cast<ExprConst *>(c);
+            vec4f rv = v_zero();
+            switch ( c->type->baseType ) {
+            case Type::tFloat: {
+                float f = cast<float>::to(cc->value);
+                float r = 1.0f / f;
+                if ( f==0.0f || !finiteFP(r) ) return nullptr;
+                rv = cast<float>::from(r);
+                break;
+            }
+            case Type::tDouble: {
+                double d = cast<double>::to(cc->value);
+                double r = 1.0 / d;
+                if ( d==0.0 || !finiteFP(r) ) return nullptr;
+                rv = cast<double>::from(r);
+                break;
+            }
+            case Type::tFloat2: {
+                auto t = cast<float2>::to(cc->value);
+                if ( t.x==0.0f || t.y==0.0f ) return nullptr;
+                float2 r; r.x = 1.0f/t.x; r.y = 1.0f/t.y;
+                if ( !finiteFP(r.x) || !finiteFP(r.y) ) return nullptr;
+                rv = cast<float2>::from(r);
+                break;
+            }
+            case Type::tFloat3: {
+                auto t = cast<float3>::to(cc->value);
+                if ( t.x==0.0f || t.y==0.0f || t.z==0.0f ) return nullptr;
+                float3 r; r.x = 1.0f/t.x; r.y = 1.0f/t.y; r.z = 1.0f/t.z;
+                if ( !finiteFP(r.x) || !finiteFP(r.y) || !finiteFP(r.z) ) return nullptr;
+                rv = cast<float3>::from(r);
+                break;
+            }
+            case Type::tFloat4: {
+                auto t = cast<float4>::to(cc->value);
+                if ( t.x==0.0f || t.y==0.0f || t.z==0.0f || t.w==0.0f ) return nullptr;
+                float4 r; r.x = 1.0f/t.x; r.y = 1.0f/t.y; r.z = 1.0f/t.z; r.w = 1.0f/t.w;
+                if ( !finiteFP(r.x) || !finiteFP(r.y) || !finiteFP(r.z) || !finiteFP(r.w) ) return nullptr;
+                rv = cast<float4>::from(r);
+                break;
+            }
+            default: return nullptr;
+            }
+            auto sim = Program::makeConst(c->at, c->type, rv);
+            if ( !sim ) return nullptr;
+            sim->type = new TypeDecl(*c->type);
+            sim->type->ref = false;
+            sim->constexpression = true;
+            return sim;
+        }
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate && funcIsDirty(fun);    // we don't do a thing with templates
         }
         virtual bool canVisitStructure ( Structure * st ) override {
             return !st->isTemplate;    // we don't do a thing with templates
         }
-        // function which is fully a nop
+        // function which is fully a nop. finalizers count as content — a body
+        // that is nothing but finalList (e.g. a lone `defer { ... }`) still runs
+        // observable code, so deleting the call would miscompile. declared side
+        // effects count too: emission stubs (glsl `_discard()` etc) have empty
+        // das bodies on purpose and the call itself is the payload
         bool isNop ( const FunctionPtr & func ) {
             if ( func->builtIn ) return false;
+            if ( func->sideEffectFlags ) return false;
             if ( func->body->rtti_isBlock() ) {
                 auto block = static_cast<ExprBlock*>(func->body);
-                if ( block->list.size()==0 && block->finalList.size() ) {
+                if ( block->list.size()==0 && block->finalList.size()==0 ) {
                     return true;
                 }
             }
@@ -614,6 +835,41 @@ namespace das {
                     return evalAndFold(expr);
                 }
             }
+            if ( expr->func->builtIn ) {
+                // !!x → x ; -(-x) → x (bit-exact for FP too: negate is a sign flip)
+                if ( (expr->op=="!" || expr->op=="-") && expr->subexpr->rtti_isOp1() ) {
+                    auto inner = static_cast<ExprOp1 *>(expr->subexpr);
+                    if ( inner->op==expr->op && inner->func && inner->func->builtIn && !inner->func->sideEffectFlags ) {
+                        reportFolding();
+                        return inner->subexpr;
+                    }
+                }
+                // !(a<b) → a>=b etc. FP compares change NaN behavior → fast_math
+                if ( expr->op=="!" && expr->subexpr->rtti_isOp2() ) {
+                    auto cmp = static_cast<ExprOp2 *>(expr->subexpr);
+                    if ( cmp->func && cmp->func->builtIn && !cmp->func->sideEffectFlags && cmp->type && cmp->type->isSimpleType(Type::tBool) ) {
+                        const char * flip = nullptr;
+                        if ( cmp->op=="==" ) flip = "!=";
+                        else if ( cmp->op=="!=" ) flip = "==";
+                        else if ( cmp->op=="<" )  flip = ">=";
+                        else if ( cmp->op==">=" ) flip = "<";
+                        else if ( cmp->op==">" )  flip = "<=";
+                        else if ( cmp->op=="<=" ) flip = ">";
+                        if ( flip ) {
+                            bool fpCompare = ( cmp->left->type && isFPFamily(cmp->left->type->baseType) )
+                                || ( cmp->right->type && isFPFamily(cmp->right->type->baseType) );
+                            if ( !fpCompare || fastMath ) {
+                                if ( auto flipFn = findBuiltinOperator(flip, cmp->left->type, cmp->right->type) ) {
+                                    cmp->op = flip;
+                                    cmp->func = flipFn;
+                                    reportFolding();
+                                    return cmp;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             return Visitor::visit(expr);
         }
     // op2
@@ -664,6 +920,167 @@ namespace das {
                     }
                 }
             }
+            // algebraic identities. only for the builtin operators on basic types; laxity per fold:
+            //   exact           - always on (bit-identical for every input)
+            //   zeroSignLaxOk   - sign-of-zero-only difference (float32 always, double under fast_math)
+            //   valueChangeOk   - inf/NaN results change (FP under fast_math only)
+            if ( expr->func->builtIn && expr->type && !expr->type->ref ) {
+                const auto bt = expr->type->baseType;
+                auto L = expr->left;
+                auto R = expr->right;
+                const auto lbt = L->type ? L->type->baseType : Type::none;
+                const auto rbt = R->type ? R->type->baseType : Type::none;
+                if ( expr->op=="*" && isNumericFamily(bt) ) {
+                    if ( constEquals(R,1) && lbt==bt ) { reportFolding(); return L; }
+                    if ( constEquals(L,1) && rbt==bt ) { reportFolding(); return R; }
+                    if ( constEquals(R,-1) && lbt==bt && isSignedNumericFamily(bt) ) {
+                        if ( auto neg = makeNegate(expr, L) ) { reportFolding(); return neg; }
+                    }
+                    if ( constEquals(L,-1) && rbt==bt && isSignedNumericFamily(bt) ) {
+                        if ( auto neg = makeNegate(expr, R) ) { reportFolding(); return neg; }
+                    }
+                    if ( ( (constEquals(R,0) && L->noSideEffects) || (constEquals(L,0) && R->noSideEffects) ) && valueChangeOk(bt) ) {
+                        if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
+                    }
+                } else if ( expr->op=="+" && isNumericFamily(bt) ) {
+                    // x + (-0.0) and integer x + 0 are exact; x + (+0.0) flips a -0.0 input's sign
+                    if ( lbt==bt && constEquals(R,0) && ( constAllNegZero(R) || zeroSignLaxOk(bt) ) ) { reportFolding(); return L; }
+                    if ( rbt==bt && constEquals(L,0) && ( constAllNegZero(L) || zeroSignLaxOk(bt) ) ) { reportFolding(); return R; }
+                } else if ( expr->op=="-" && isNumericFamily(bt) ) {
+                    // x - (+0.0) and integer x - 0 are exact; x - (-0.0) flips a -0.0 input's sign
+                    if ( lbt==bt && constEquals(R,0) && ( constAllPosZero(R) || zeroSignLaxOk(bt) ) ) { reportFolding(); return L; }
+                    // 0 - x → -x: exact when the zero is -0.0, sign-of-zero lax when +0.0
+                    if ( rbt==bt && constEquals(L,0) && isSignedNumericFamily(bt) && ( constAllNegZero(L) || zeroSignLaxOk(bt) ) ) {
+                        if ( auto neg = makeNegate(expr, R) ) { reportFolding(); return neg; }
+                    }
+                    // x - x → 0: changes inf/NaN results → fast_math for FP
+                    if ( sameVariableRead(L, R) && valueChangeOk(bt) ) {
+                        if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
+                    }
+                } else if ( expr->op=="/" && isNumericFamily(bt) ) {
+                    if ( lbt==bt && constEquals(R,1) ) { reportFolding(); return L; }
+                    // x / C → x * (1/C): the reciprocal rounds → fast_math, FP only
+                    if ( fastMath && isFPFamily(bt) && R->rtti_isConstant() ) {
+                        if ( auto rec = makeReciprocalConst(R) ) {
+                            if ( auto mulFn = findBuiltinOperator("*", L->type, rec->type) ) {
+                                expr->op = "*";
+                                expr->func = mulFn;
+                                expr->right = rec;
+                                reportFolding();
+                                return Visitor::visit(expr);
+                            }
+                        }
+                    }
+                } else if ( ( expr->op=="&" || expr->op=="|" || expr->op=="^" ) && isIntegerFamily(bt) ) {
+                    const bool zr = constEquals(R,0);
+                    const bool zl = constEquals(L,0);
+                    if ( expr->op=="&" ) {
+                        if ( (zr && L->noSideEffects) || (zl && R->noSideEffects) ) {
+                            if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
+                        }
+                        if ( sameVariableRead(L,R) ) { reportFolding(); return L; }
+                    } else if ( expr->op=="|" ) {
+                        if ( zr && lbt==bt ) { reportFolding(); return L; }
+                        if ( zl && rbt==bt ) { reportFolding(); return R; }
+                        if ( sameVariableRead(L,R) ) { reportFolding(); return L; }
+                    } else {
+                        if ( zr && lbt==bt ) { reportFolding(); return L; }
+                        if ( zl && rbt==bt ) { reportFolding(); return R; }
+                        if ( sameVariableRead(L,R) ) {
+                            if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
+                        }
+                    }
+                } else if ( ( expr->op=="<<" || expr->op==">>" || expr->op=="<<<" || expr->op==">>>" ) && isIntegerFamily(bt) ) {
+                    if ( constEquals(R,0) && lbt==bt ) { reportFolding(); return L; }
+                } else if ( expr->op=="%" && isIntegerFamily(bt) ) {
+                    if ( constEquals(R,1) && L->noSideEffects ) {
+                        if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
+                    }
+                } else if ( expr->op=="&&" && bt==Type::tBool ) {
+                    // short-circuit: a const-false LEFT never evaluates the right, so those drops
+                    // are unconditional; dropping an evaluated left needs purity
+                    if ( isConstBoolValue(L,true) ) { reportFolding(); return R; }
+                    if ( isConstBoolValue(L,false) ) { reportFolding(); return L; }
+                    if ( isConstBoolValue(R,true) ) { reportFolding(); return L; }
+                    if ( isConstBoolValue(R,false) && L->noSideEffects ) { reportFolding(); return R; }
+                } else if ( expr->op=="||" && bt==Type::tBool ) {
+                    if ( isConstBoolValue(L,false) ) { reportFolding(); return R; }
+                    if ( isConstBoolValue(L,true) ) { reportFolding(); return L; }
+                    if ( isConstBoolValue(R,false) ) { reportFolding(); return L; }
+                    if ( isConstBoolValue(R,true) && L->noSideEffects ) { reportFolding(); return R; }
+                }
+                // v * floatN(s) → v * s ; v / floatN(s) → v / s (splat collapse, per-lane bit-identical)
+                if ( ( expr->op=="*" || expr->op=="/" ) && isFloat32Family(bt) && bt!=Type::tFloat ) {
+                    auto trySplat = [&]( Expression * e ) -> Expression * {
+                        if ( !e || !e->rtti_isCall() ) return nullptr;
+                        auto call = static_cast<ExprCall *>(e);
+                        if ( !call->func || !call->func->builtIn || call->func->sideEffectFlags ) return nullptr;
+                        if ( call->arguments.size()!=1 ) return nullptr;
+                        auto & a0 = call->arguments[0];
+                        if ( !a0->type || a0->type->baseType!=Type::tFloat || a0->type->ref ) return nullptr;
+                        if ( call->func->name!=das_to_string(bt) ) return nullptr;
+                        return a0;
+                    };
+                    if ( auto s = trySplat(expr->right) ) {
+                        if ( auto fn = findBuiltinOperator(expr->op.c_str(), L->type, s->type) ) {
+                            expr->right = s;
+                            expr->func = fn;
+                            reportFolding();
+                            return Visitor::visit(expr);
+                        }
+                    }
+                    if ( expr->op=="*" ) {
+                        if ( auto s = trySplat(expr->left) ) {
+                            if ( auto fn = findBuiltinOperator("*", R->type, s->type) ) {
+                                expr->left = R;
+                                expr->right = s;
+                                expr->func = fn;
+                                reportFolding();
+                                return Visitor::visit(expr);
+                            }
+                        }
+                    }
+                }
+                // (x ∘ C1) ∘ C2 → x ∘ (C1 ∘ C2) — reassociation rounds differently → fast_math only,
+                // uniform-baseType chains only (mixed vec/scalar chains would retype the operator)
+                if ( fastMath && ( expr->op=="+" || expr->op=="*" ) && isNumericFamily(bt) ) {
+                    ExprOp2 * inner = nullptr;
+                    Expression * c2 = nullptr;
+                    if ( expr->right->rtti_isConstant() && expr->left->rtti_isOp2() ) {
+                        inner = static_cast<ExprOp2 *>(expr->left); c2 = expr->right;
+                    } else if ( expr->left->rtti_isConstant() && expr->right->rtti_isOp2() ) {
+                        inner = static_cast<ExprOp2 *>(expr->right); c2 = expr->left;
+                    }
+                    if ( inner && inner->op==expr->op && inner->func && inner->func->builtIn && !inner->func->sideEffectFlags
+                        && inner->type && inner->type->baseType==bt && c2->type && c2->type->baseType==bt
+                        && inner->left->type && inner->left->type->baseType==bt
+                        && inner->right->type && inner->right->type->baseType==bt ) {
+                        Expression * x = nullptr;
+                        Expression * c1 = nullptr;
+                        bool constOnRight = false;
+                        if ( inner->right->rtti_isConstant() && !inner->left->rtti_isConstant() ) {
+                            x = inner->left; c1 = inner->right; constOnRight = true;
+                        } else if ( inner->left->rtti_isConstant() && !inner->right->rtti_isConstant() ) {
+                            x = inner->right; c1 = inner->left;
+                        }
+                        if ( x ) {
+                            inner->left = c1;
+                            inner->right = c2;
+                            auto k = evalAndFold(inner);
+                            if ( k->rtti_isConstant() ) {
+                                expr->left = x;
+                                expr->right = k;
+                                reportFolding();
+                                return Visitor::visit(expr);
+                            } else {
+                                // restore the original tree exactly
+                                if ( constOnRight ) { inner->left = x; inner->right = c1; }
+                                else { inner->left = c1; inner->right = x; }
+                            }
+                        }
+                    }
+                }
+            }
             return Visitor::visit(expr);
         }
     // op3
@@ -688,6 +1105,27 @@ namespace das {
                 bool res = cast<bool>::to(resB);
                 reportFolding();
                 return res ? expr->left : expr->right;
+            }
+            // c ? true : false → c ; c ? false : true → !c
+            if ( expr->type && expr->type->isSimpleType(Type::tBool) ) {
+                if ( isConstBoolValue(expr->left,true) && isConstBoolValue(expr->right,false) ) {
+                    reportFolding();
+                    return expr->subexpr;
+                }
+                if ( isConstBoolValue(expr->left,false) && isConstBoolValue(expr->right,true) ) {
+                    if ( auto notFn = findBuiltinOperator("!", expr->subexpr->type) ) {
+                        auto notE = new ExprOp1(expr->at, "!", expr->subexpr);
+                        notE->func = notFn;
+                        notE->type = new TypeDecl(Type::tBool);
+                        reportFolding();
+                        return notE;
+                    }
+                }
+            }
+            // c ? a : a → a for same-variable arms (cheap structural equality)
+            if ( expr->subexpr->noSideEffects && sameVariableRead(expr->left, expr->right) ) {
+                reportFolding();
+                return expr->left;
             }
             return Visitor::visit(expr);
         }
@@ -738,7 +1176,35 @@ namespace das {
             }
             return Visitor::visitBlockExpression(block, expr);
         }
+        virtual ExpressionPtr visit ( ExprWhile * expr ) override {
+            // while(false) never runs and a constexpr condition is pure — drop the loop
+            if ( expr->cond->constexpression ) {
+                bool failed;
+                vec4f resB = eval(expr->cond, failed);
+                if ( !failed && !cast<bool>::to(resB) ) {
+                    reportFolding();
+                    return nullptr;
+                }
+            }
+            return Visitor::visit(expr);
+        }
         virtual ExpressionPtr visit ( ExprFor * expr ) override {
+            // a loop over a constant empty range never runs the body
+            if ( expr->sources.size()==1 && expr->sources[0]->rtti_isConstant() && expr->sources[0]->type ) {
+                auto src = static_cast<ExprConst *>(expr->sources[0]);
+                bool emptyRange = false;
+                switch ( src->type->baseType ) {
+                case Type::tRange:    { auto rv = cast<range>::to(src->value);    emptyRange = rv.from >= rv.to; break; }
+                case Type::tURange:   { auto rv = cast<urange>::to(src->value);   emptyRange = rv.from >= rv.to; break; }
+                case Type::tRange64:  { auto rv = cast<range64>::to(src->value);  emptyRange = rv.from >= rv.to; break; }
+                case Type::tURange64: { auto rv = cast<urange64>::to(src->value); emptyRange = rv.from >= rv.to; break; }
+                default: break;
+                }
+                if ( emptyRange ) {
+                    reportFolding();
+                    return nullptr;
+                }
+            }
             if ( expr->body->rtti_isBlock()) {
                 auto block = static_cast<ExprBlock*>(expr->body);
                 if ( !block->list.size() && !block->finalList.size() ) {
@@ -799,6 +1265,17 @@ namespace das {
         }
     // ExprCall
         virtual ExpressionPtr visit ( ExprCall * expr ) override {
+            // same-type workhorse cast is a no-op: int(x) where x is already int, float(x:float), ...
+            if ( expr->func->builtIn && expr->arguments.size()==1 ) {
+                auto arg = expr->arguments[0];
+                if ( expr->type && arg->type && !expr->type->ref && !arg->type->ref
+                    && expr->type->baseType==arg->type->baseType
+                    && ( isNumericFamily(expr->type->baseType) || expr->type->baseType==Type::tString )
+                    && expr->func->name==das_to_string(expr->type->baseType) ) {
+                    reportFolding();
+                    return arg;
+                }
+            }
             bool allNoSideEffects = true;
             for ( auto & arg : expr->arguments ) {
                 if ( arg->type->baseType!=Type::fakeContext && arg->type->baseType!=Type::fakeLineInfo ) {
@@ -935,7 +1412,7 @@ namespace das {
     class RunFolding : public FoldingVisitor {
     public:
         using PassVisitor::visit;
-        RunFolding( const ProgramPtr & prog, vector<Function *> & _needRun ) : FoldingVisitor(prog),
+        RunFolding( const ProgramPtr & prog, vector<Function *> & _needRun, int32_t round ) : FoldingVisitor(prog, round),
             runProgram(prog.get()), needRun(_needRun) {
         }
     protected:
@@ -1011,7 +1488,7 @@ namespace das {
         bool any = cfe.didAnything();
         if ( !cfe.needRun.empty() ) {
             if ( !options.getBoolOption("disable_run",false) ) {
-                RunFolding rfe(this,cfe.needRun);
+                RunFolding rfe(this,cfe.needRun,round);
                 visit(rfe);
                 any |= rfe.didAnything();
             }

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -562,9 +562,9 @@ namespace das {
     }
 
     static bool isPosZeroBits ( float f )  { uint32_t u; memcpy(&u,&f,sizeof(u)); return u==0u; }
-    static bool isPosZeroBits ( double d ) { uint64_t u; memcpy(&u,&d,sizeof(u)); return u==0ul; }
+    static bool isPosZeroBits ( double d ) { uint64_t u; memcpy(&u,&d,sizeof(u)); return u==0ull; }
     static bool isNegZeroBits ( float f )  { uint32_t u; memcpy(&u,&f,sizeof(u)); return u==0x80000000u; }
-    static bool isNegZeroBits ( double d ) { uint64_t u; memcpy(&u,&d,sizeof(u)); return u==0x8000000000000000ul; }
+    static bool isNegZeroBits ( double d ) { uint64_t u; memcpy(&u,&d,sizeof(u)); return u==0x8000000000000000ull; }
 
     // every lane is +0.0 exactly (integer zero also qualifies)
     static bool constAllPosZero ( Expression * e ) {
@@ -1266,11 +1266,13 @@ namespace das {
     // ExprCall
         virtual ExpressionPtr visit ( ExprCall * expr ) override {
             // same-type workhorse cast is a no-op: int(x) where x is already int, float(x:float), ...
+            // numeric families only — a string "cast" can be lifetime-relevant (temporary-ness),
+            // and qualifiers don't matter for numeric value types
             if ( expr->func->builtIn && expr->arguments.size()==1 ) {
                 auto arg = expr->arguments[0];
                 if ( expr->type && arg->type && !expr->type->ref && !arg->type->ref
                     && expr->type->baseType==arg->type->baseType
-                    && ( isNumericFamily(expr->type->baseType) || expr->type->baseType==Type::tString )
+                    && isNumericFamily(expr->type->baseType)
                     && expr->func->name==das_to_string(expr->type->baseType) ) {
                     reportFolding();
                     return arg;

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2563,6 +2563,7 @@ namespace das {
               << value.strict_properties
               << value.no_writing_to_nameless
               << value.no_optimizations
+              << value.fast_math
               << value.no_infer_time_folding
               << value.fail_on_no_aot
               << value.fail_on_lack_of_aot_export

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -990,6 +990,7 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(strict_properties)>("strict_properties");
         // environment
             addField<DAS_BIND_MANAGED_FIELD(no_optimizations)>("no_optimizations");
+            addField<DAS_BIND_MANAGED_FIELD(fast_math)>("fast_math");
             addField<DAS_BIND_MANAGED_FIELD(no_infer_time_folding)>("no_infer_time_folding");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_no_aot)>("fail_on_no_aot");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_lack_of_aot_export)>("fail_on_lack_of_aot_export");

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -609,6 +609,7 @@ int das_policies_set_bool ( das_policies * policies, das_bool_policy flag, int v
         case DAS_POLICY_RTTI:                   p->rtti = v; break;
         case DAS_POLICY_NO_OPTIMIZATIONS:       p->no_optimizations = v; break;
         case DAS_POLICY_NO_INFER_TIME_FOLDING:  p->no_infer_time_folding = v; break;
+        case DAS_POLICY_FAST_MATH:              p->fast_math = v; break;
         default: return 0;
     }
     return 1;

--- a/tests/language/optimization_fast_math.das
+++ b/tests/language/optimization_fast_math.das
@@ -1,0 +1,66 @@
+options gen2
+options fast_math = true
+
+require dastest/testing_boost public
+require math
+
+// behavioral coverage for the fast_math-gated folds: x*0 / x-x for FP, x/C → x*(1/C),
+// NaN-compare flips, reassociation. values here are chosen so the transforms stay exact
+// (or are compared with a tolerance where the reciprocal legitimately rounds).
+
+var g_f = 3.5
+var g_d = 2.25lf
+var g_v = float3(1.0, 2.0, 4.0)
+var g_calls = 0
+
+def side_f : float {
+    g_calls++
+    return g_f
+}
+
+[test]
+def test_fp_zero_folds(t : T?) {
+    t |> equal(g_f * 0.0, 0.0)
+    t |> equal(0.0 * g_f, 0.0)
+    t |> equal(g_d * 0.0lf, 0.0lf)
+    t |> equal(g_f - g_f, 0.0) // nolint:LINT007 -- deliberate: exercises the fast_math x-x fold
+    t |> equal(g_d - g_d, 0.0lf) // nolint:LINT007
+    g_calls = 0
+    t |> equal(side_f() * 0.0, 0.0)
+    t |> equal(g_calls, 1)    // impure operand must still run
+}
+
+[test]
+def test_double_zero_sign_folds(t : T?) {
+    // double x+0 / 0-x folds are fast_math-gated; values are identical for normal inputs
+    t |> equal(g_d + 0.0lf, 2.25lf)
+    t |> equal(g_d - 0.0lf, 2.25lf)
+    t |> equal(0.0lf - g_d, -2.25lf)
+}
+
+[test]
+def test_reciprocal_division(t : T?) {
+    // powers of two: the reciprocal is exact
+    t |> equal(g_f / 2.0, 1.75)
+    t |> equal(g_f / 4.0, 0.875)
+    t |> equal(g_d / 2.0lf, 1.125lf)
+    t |> equal(g_v / 2.0, float3(0.5, 1.0, 2.0))
+    // non-power-of-two: the reciprocal rounds — compare with tolerance
+    t |> success(abs(g_f / 3.0 - 1.1666666) < 1e-5, "x/3 via reciprocal stays close")
+}
+
+[test]
+def test_fp_compare_flip(t : T?) {
+    t |> equal(!(g_f < 4.0), g_f >= 4.0)
+    t |> equal(!(g_f == 3.5), false)
+}
+
+[test]
+def test_reassociation(t : T?) {
+    // (x ∘ C1) ∘ C2 → x ∘ K; constants chosen exactly representable
+    t |> equal((g_f + 1.0) + 2.0, 6.5)
+    t |> equal((g_f * 2.0) * 4.0, 28.0)
+    t |> equal(2.0 * (g_f * 4.0), 28.0)
+    t |> equal((2.0 + g_f) + 1.0, 6.5)
+    t |> equal((g_d + 1.0lf) + 2.0lf, 5.25lf)
+}

--- a/tests/language/optimization_fold_shape.das
+++ b/tests/language/optimization_fold_shape.das
@@ -1,0 +1,182 @@
+options gen2
+options rtti
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_boost
+require dastest/testing_boost public
+require strings
+
+// structural FIRED proof for the ConstFolding algebraic identities: inspects the
+// post-optimize AST of the target functions below and asserts the rewrite actually
+// happened. the behavioral half (value preservation, purity gates) lives in
+// optimization_folding.das — a silently disabled fold passes there but fails here.
+
+[export]
+def target_mul_one(x : int) : int {
+    return x * 1
+}
+
+[export]
+def target_add_zero(f : float) : float {
+    return f + 0.0
+}
+
+[export]
+def target_mul_zero(x : int) : int {
+    return x * 0
+}
+
+[export]
+def target_compare_flip(x : int) : bool {
+    return !(x < 5)
+}
+
+[export]
+def target_cast(x : int) : int {
+    return int(x) // nolint:PERF020 -- deliberate: the fold under test
+}
+
+[export]
+def target_not_not(b : bool) : bool {
+    return !!b
+}
+
+[export]
+def target_tern_bool(x : int) : bool {
+    return x > 3 ? true : false
+}
+
+[export]
+def target_dead_while(x : int) : int {
+    var acc = x
+    while (false) {
+        acc ++
+    }
+    return acc
+}
+
+[export]
+def target_dead_for(x : int) : int {
+    var acc = x
+    for (_i in range(3, 3)) {
+        acc ++
+    }
+    return acc
+}
+
+[export]
+def target_splat(v : float3; s : float) : float3 {
+    return v * float3(s)
+}
+
+[export]
+def target_div_one(f : float) : float {
+    return f / 1.0
+}
+
+[export]
+def target_shift_zero(u : uint) : uint {
+    return u << 0u
+}
+
+[export]
+def target_xor_self(u : uint) : uint {
+    return u ^ u // nolint:LINT007 -- deliberate: the fold under test
+}
+
+[export]
+def target_and_false(b : bool) : bool {
+    return b && false
+}
+
+[export]
+def target_reassoc(f : float) : float {
+    return (f + 1.0) + 2.0
+}
+
+def has(s, sub : string) : bool {
+    return find(s, sub, 0) >= 0
+}
+
+def body_of(t : T?; nm : string) : string {
+    var body = ""
+    compiling_module() |> for_each_function("{nm}") $(func) {
+        if (empty(body)) {
+            body = "{describe(func.body)}"
+        }
+    }
+    t |> success(!empty(body), "target function found")
+    return body
+}
+
+[test]
+def test_identity_folds_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("x*1 leaves no multiply") @(t : T?) {
+            let b = body_of(t, "target_mul_one")
+            t |> success(!has(b, "*"), "no `*` survives: {b}")
+            t |> success(has(b, "return x"), "operand returned directly: {b}")
+        }
+        t |> run("x+0.0 leaves no add") @(t : T?) {
+            let b = body_of(t, "target_add_zero")
+            t |> success(!has(b, "+"), "no `+` survives: {b}")
+        }
+        t |> run("x*0 becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_mul_zero")
+            t |> success(!has(b, "*"), "no `*` survives: {b}")
+            t |> success(has(b, "return 0"), "constant zero returned: {b}")
+        }
+        t |> run("!(a<b) becomes the flipped compare") @(t : T?) {
+            let b = body_of(t, "target_compare_flip")
+            t |> success(!has(b, "!"), "no `!` survives: {b}")
+            t |> success(has(b, ">="), "flipped compare present: {b}")
+        }
+        t |> run("same-type cast is erased") @(t : T?) {
+            let b = body_of(t, "target_cast")
+            t |> success(!has(b, "int("), "no cast call survives: {b}")
+        }
+        t |> run("!!x is erased") @(t : T?) {
+            let b = body_of(t, "target_not_not")
+            t |> success(!has(b, "!"), "no `!` survives: {b}")
+        }
+        t |> run("c ? true : false becomes c") @(t : T?) {
+            let b = body_of(t, "target_tern_bool")
+            t |> success(!has(b, "?"), "no ternary survives: {b}")
+        }
+        t |> run("while(false) is removed") @(t : T?) {
+            let b = body_of(t, "target_dead_while")
+            t |> success(!has(b, "while"), "no while survives: {b}")
+        }
+        t |> run("for over const empty range is removed") @(t : T?) {
+            let b = body_of(t, "target_dead_for")
+            t |> success(!has(b, "for"), "no for survives: {b}")
+        }
+        t |> run("v*float3(s) collapses the splat") @(t : T?) {
+            let b = body_of(t, "target_splat")
+            t |> success(!has(b, "float3("), "no splat ctor survives: {b}")
+            t |> success(has(b, "v * s"), "vec*scalar form present: {b}")
+        }
+        t |> run("x/1.0 leaves no divide") @(t : T?) {
+            let b = body_of(t, "target_div_one")
+            t |> success(!has(b, "/"), "no `/` survives: {b}")
+        }
+        t |> run("x<<0 leaves no shift") @(t : T?) {
+            let b = body_of(t, "target_shift_zero")
+            t |> success(!has(b, "<<"), "no `<<` survives: {b}")
+        }
+        t |> run("x^x becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_xor_self")
+            t |> success(!has(b, "^"), "no `^` survives: {b}")
+        }
+        t |> run("x && false becomes false") @(t : T?) {
+            let b = body_of(t, "target_and_false")
+            t |> success(!has(b, "&&"), "no `&&` survives: {b}")
+            t |> success(has(b, "return false"), "constant false returned: {b}")
+        }
+        t |> run("reassociation stays OFF without fast_math") @(t : T?) {
+            let b = body_of(t, "target_reassoc")
+            t |> success(has(b, "1f") && has(b, "2f"), "chain not regrouped: {b}")
+        }
+    }
+}

--- a/tests/language/optimization_fold_shape.das
+++ b/tests/language/optimization_fold_shape.das
@@ -6,6 +6,7 @@ require daslib/rtti
 require daslib/ast_boost
 require dastest/testing_boost public
 require strings
+require daslib/strings_boost
 
 // structural FIRED proof for the ConstFolding algebraic identities: inspects the
 // post-optimize AST of the target functions below and asserts the rewrite actually
@@ -107,7 +108,11 @@ def body_of(t : T?; nm : string) : string {
         }
     }
     t |> success(!empty(body), "target function found")
-    return body
+    // the coverage lane (dastest --cov-path) injects add_func_coverage/add_line_coverage
+    // statements whose arguments collide with the substrings asserted here (paths carry
+    // `/`, "target_dead_while" carries "while", hex line args can carry "2f") — drop them
+    let clean <- [for (ln in split(body, "\n")); ln; where !(ln |> has("coverage("))]
+    return join(clean, "\n")
 }
 
 [test]

--- a/tests/language/optimization_fold_shape_fast_math.das
+++ b/tests/language/optimization_fold_shape_fast_math.das
@@ -7,6 +7,7 @@ require daslib/rtti
 require daslib/ast_boost
 require dastest/testing_boost public
 require strings
+require daslib/strings_boost
 
 // structural FIRED proof for the fast_math-gated folds (x*0 / x-x on FP, reciprocal
 // division, NaN-compare flips, reassociation). the behavioral half lives in
@@ -49,7 +50,11 @@ def body_of(t : T?; nm : string) : string {
         }
     }
     t |> success(!empty(body), "target function found")
-    return body
+    // the coverage lane (dastest --cov-path) injects add_func_coverage/add_line_coverage
+    // statements whose arguments collide with the substrings asserted here (paths carry
+    // `/`, hex line args can carry "2f") — drop them
+    let clean <- [for (ln in split(body, "\n")); ln; where !(ln |> has("coverage("))]
+    return join(clean, "\n")
 }
 
 [test]

--- a/tests/language/optimization_fold_shape_fast_math.das
+++ b/tests/language/optimization_fold_shape_fast_math.das
@@ -1,0 +1,83 @@
+options gen2
+options rtti
+options fast_math = true
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_boost
+require dastest/testing_boost public
+require strings
+
+// structural FIRED proof for the fast_math-gated folds (x*0 / x-x on FP, reciprocal
+// division, NaN-compare flips, reassociation). the behavioral half lives in
+// optimization_fast_math.das.
+
+[export]
+def target_mul_zero_f(f : float) : float {
+    return f * 0.0
+}
+
+[export]
+def target_sub_self_f(f : float) : float {
+    return f - f // nolint:LINT007 -- deliberate: the fold under test
+}
+
+[export]
+def target_rcp(f : float) : float {
+    return f / 4.0
+}
+
+[export]
+def target_flip_f(f : float) : bool {
+    return !(f < 4.0)
+}
+
+[export]
+def target_reassoc_f(f : float) : float {
+    return (f + 1.0) + 2.0
+}
+
+def has(s, sub : string) : bool {
+    return find(s, sub, 0) >= 0
+}
+
+def body_of(t : T?; nm : string) : string {
+    var body = ""
+    compiling_module() |> for_each_function("{nm}") $(func) {
+        if (empty(body)) {
+            body = "{describe(func.body)}"
+        }
+    }
+    t |> success(!empty(body), "target function found")
+    return body
+}
+
+[test]
+def test_fast_math_folds_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("f*0.0 becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_mul_zero_f")
+            t |> success(!has(b, "*"), "no `*` survives: {b}")
+            t |> success(has(b, "return 0f"), "constant zero returned: {b}")
+        }
+        t |> run("f-f becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_sub_self_f")
+            t |> success(!has(b, "-"), "no `-` survives: {b}")
+        }
+        t |> run("f/4.0 becomes multiply by reciprocal") @(t : T?) {
+            let b = body_of(t, "target_rcp")
+            t |> success(!has(b, "/"), "no `/` survives: {b}")
+            t |> success(has(b, "*"), "reciprocal multiply present: {b}")
+        }
+        t |> run("!(f<4.0) becomes the flipped compare") @(t : T?) {
+            let b = body_of(t, "target_flip_f")
+            t |> success(!has(b, "!"), "no `!` survives: {b}")
+            t |> success(has(b, ">="), "flipped compare present: {b}")
+        }
+        t |> run("(f+1)+2 regroups to f+3") @(t : T?) {
+            let b = body_of(t, "target_reassoc_f")
+            t |> success(has(b, "3f"), "merged constant present: {b}")
+            t |> success(!has(b, "2f"), "original tail constant gone: {b}")
+        }
+    }
+}

--- a/tests/language/optimization_folding.das
+++ b/tests/language/optimization_folding.das
@@ -1,0 +1,191 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/defer
+
+// behavioral coverage for the ConstFolding algebraic identities: every fold must be
+// value-preserving, and purity gates must keep impure operands evaluated. folding
+// QUALITY (that the rewrite actually fired) is asserted by hand via `options log`.
+
+var g_i = 7
+var g_u = 0xDEADu
+var g_i64 = 9000000000l
+var g_f = 3.5
+var g_d = 2.25lf
+var g_v = float3(1.0, 2.0, 4.0)
+var g_b = true
+var g_calls = 0
+
+def side_i : int {
+    g_calls++
+    return g_i
+}
+
+def side_b : bool {
+    g_calls++
+    return g_b
+}
+
+def only_finally {
+    defer() {
+        g_calls++
+    }
+}
+
+[test]
+def test_mul_identities(t : T?) {
+    t |> run("x*1 and 1*x") @(t : T?) {
+        t |> equal(g_i * 1, 7)
+        t |> equal(1 * g_i, 7)
+        t |> equal(g_f * 1.0, 3.5)
+        t |> equal(1.0 * g_f, 3.5)
+        t |> equal(g_d * 1.0lf, 2.25lf)
+        t |> equal(g_v * 1.0, float3(1.0, 2.0, 4.0))
+    }
+    t |> run("x*-1") @(t : T?) {
+        t |> equal(g_i * -1, -7)
+        t |> equal(g_f * -1.0, -3.5)
+    }
+    t |> run("x*0 folds for int, keeps impure operands") @(t : T?) {
+        t |> equal(g_i * 0, 0)
+        t |> equal(0 * g_i, 0)
+        g_calls = 0
+        t |> equal(side_i() * 0, 0)
+        t |> equal(g_calls, 1)    // impure operand must still run
+    }
+}
+
+[test]
+def test_add_sub_identities(t : T?) {
+    t |> run("x+0 and x-0") @(t : T?) {
+        t |> equal(g_i + 0, 7)
+        t |> equal(0 + g_i, 7)
+        t |> equal(g_i - 0, 7)
+        t |> equal(g_f + 0.0, 3.5)
+        t |> equal(g_f - 0.0, 3.5)
+        t |> equal(g_d + 0.0lf, 2.25lf)
+        t |> equal(g_v + float3(0.0), float3(1.0, 2.0, 4.0))
+    }
+    t |> run("0-x negates") @(t : T?) {
+        t |> equal(0 - g_i, -7)
+        t |> equal(0.0 - g_f, -3.5)
+    }
+    t |> run("x-x is zero for ints") @(t : T?) {
+        t |> equal(g_i - g_i, 0)
+        t |> equal(g_i64 - g_i64, 0l)
+    }
+}
+
+[test]
+def test_div_mod_identities(t : T?) {
+    t |> equal(g_i / 1, 7)
+    t |> equal(g_f / 1.0, 3.5)
+    t |> equal(g_v / 1.0, float3(1.0, 2.0, 4.0))
+    t |> equal(g_i % 1, 0)
+    g_calls = 0
+    t |> equal(side_i() % 1, 0)
+    t |> equal(g_calls, 1)
+}
+
+[test]
+def test_bitwise_identities(t : T?) {
+    t |> equal(g_u & 0u, 0u)
+    t |> equal(g_u | 0u, 0xDEADu)
+    t |> equal(g_u ^ 0u, 0xDEADu)
+    t |> equal(g_u ^ g_u, 0u) // nolint:LINT007 -- deliberate: exercises the x^x fold
+    t |> equal(g_u & g_u, 0xDEADu) // nolint:LINT007 -- deliberate: exercises the x&x fold
+    t |> equal(g_u | g_u, 0xDEADu) // nolint:LINT007 -- deliberate: exercises the x|x fold
+    t |> equal(g_u << 0u, 0xDEADu)
+    t |> equal(g_u >> 0u, 0xDEADu)
+    t |> equal(g_i << 0, 7)
+}
+
+[test]
+def test_bool_identities(t : T?) {
+    t |> run("const arms fold") @(t : T?) {
+        t |> equal(g_b && true, true)
+        t |> equal(g_b && false, false)
+        t |> equal(g_b || false, true)
+        t |> equal(g_b || true, true)
+        t |> equal(true && g_b, true)
+        t |> equal(false || g_b, true)
+    }
+    t |> run("short-circuit never evaluates right of const-false") @(t : T?) {
+        g_calls = 0
+        t |> equal(false && side_b(), false)
+        t |> equal(true || side_b(), true)
+        t |> equal(g_calls, 0)
+    }
+    t |> run("purity gate keeps impure left evaluated") @(t : T?) {
+        g_calls = 0
+        t |> equal(side_b() && false, false)
+        t |> equal(g_calls, 1)
+        t |> equal(side_b() || true, true)
+        t |> equal(g_calls, 2)
+    }
+    t |> run("double negation and compare flip") @(t : T?) {
+        t |> equal(!!g_b, true)
+        t |> equal(!(g_i < 5), g_i >= 5)
+        t |> equal(!(g_i == 7), false)
+        t |> equal(-(-g_i), 7)
+    }
+}
+
+[test]
+def test_ternary_identities(t : T?) {
+    t |> equal(g_i > 3 ? true : false, true)
+    t |> equal(g_i > 3 ? false : true, false)
+    t |> equal(g_i < 3 ? g_f : g_f, 3.5) // nolint:LINT008 -- deliberate: exercises the c?a:a fold
+}
+
+[test]
+def test_same_type_casts(t : T?) {
+    t |> equal(int(g_i), 7) // nolint:PERF020 -- deliberate: this whole test exercises the same-type cast fold
+    t |> equal(uint(g_u), 0xDEADu) // nolint:PERF020
+    t |> equal(int64(g_i64), 9000000000l) // nolint:PERF020
+    t |> equal(float(g_f), 3.5) // nolint:PERF020
+    t |> equal(double(g_d), 2.25lf) // nolint:PERF020
+    t |> equal(float3(g_v), float3(1.0, 2.0, 4.0))
+}
+
+[test]
+def test_splat_collapse(t : T?) {
+    t |> equal(g_v * float3(g_f), float3(1.0 * g_f, 2.0 * g_f, 4.0 * g_f))
+    t |> equal(g_v / float3(g_f), float3(1.0 / g_f, 2.0 / g_f, 4.0 / g_f))
+    t |> equal(float3(g_f) * g_v, float3(g_f * 1.0, g_f * 2.0, g_f * 4.0))
+}
+
+[test]
+def test_dead_loops(t : T?) {
+    g_calls = 0
+    while (false) {
+        g_calls++
+    }
+    for (_i in range(0, 0)) {
+        g_calls++
+    }
+    for (_i in range(3, 3)) {
+        g_calls++
+    }
+    for (_i in urange(5u, 5u)) {
+        g_calls++
+    }
+    t |> equal(g_calls, 0)
+}
+
+[test]
+def test_finalizer_only_function_still_runs(t : T?) {
+    // regression: isNop used to treat a finalizer-only body as a nop and delete the
+    // call, silently dropping the defer's side effect under optimization
+    g_calls = 0
+    only_finally()
+    t |> equal(g_calls, 1)
+}
+
+[test]
+def test_reassociation_off_by_default(t : T?) {
+    // without fast_math the chain is NOT regrouped; values are exact here either way
+    t |> equal((g_f + 1.0) + 2.0, 6.5)
+    t |> equal((g_f * 2.0) * 4.0, 28.0)
+    t |> equal(2.0 * (g_f * 4.0), 28.0)
+}

--- a/tests/language/optimization_folding.das
+++ b/tests/language/optimization_folding.das
@@ -103,12 +103,22 @@ def test_bitwise_identities(t : T?) {
 [test]
 def test_bool_identities(t : T?) {
     t |> run("const arms fold") @(t : T?) {
+        // both values of g_b — with only g_b==true, a fold that wrongly rewrote
+        // `b && true` to constant `true` would pass undetected
         t |> equal(g_b && true, true)
         t |> equal(g_b && false, false)
         t |> equal(g_b || false, true)
         t |> equal(g_b || true, true)
         t |> equal(true && g_b, true)
         t |> equal(false || g_b, true)
+        g_b = false
+        t |> equal(g_b && true, false)
+        t |> equal(g_b && false, false)
+        t |> equal(g_b || false, false)
+        t |> equal(g_b || true, true)
+        t |> equal(true && g_b, false)
+        t |> equal(false || g_b, false)
+        g_b = true
     }
     t |> run("short-circuit never evaluates right of const-false") @(t : T?) {
         g_calls = 0

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -1839,8 +1839,10 @@ def test_all_loop_shape(t : T?) {
             return $e(body_expr)
         }
         t |> success(r.matched && body_expr is ExprInvoke, "expected invoke wrapper")
-        // all emits `if (!pred) return false` — at least one ExprOp1 with op `!`.
-        t |> success(count_op1(body_expr, "!") >= 1, "all: at least one `!` for predicate negation")
+        // all emits `if (!pred) return false`; the optimizer's compare flip folds
+        // `!(_ > 0)` into `_ <= 0`, so accept either shape.
+        t |> success(count_op1(body_expr, "!") >= 1 || count_op2(body_expr, "<=") >= 1,
+            "all: negated predicate present (as `!` or as the flipped compare)")
         t |> equal(1, count_inner_for_loops(body_expr), "all: one for-loop")
     }
 }


### PR DESCRIPTION
Audit + first upgrade round for the C++ optimizer pipeline (`optimizeProgram`: RefFolding → Unused → ConstFolding/RunFolding → CondFolding → BlockFolding). One PR per the plan: two probe-confirmed bug fixes, the `fast_math` policy, and the algebraic folding repertoire ported from `daslib/flatten_opt_fold.das` to the C++ side where every program benefits.

## Bug fixes (both probe-confirmed miscompiles/regressions)

- **`isNop` deleted calls to finalizer-only functions.** `list.size()==0 && finalList.size()` treated a body that is *nothing but* finalizers (e.g. a lone `defer { print(...) }`) as a nop and removed the call — the finalizer's observable effect silently vanished under optimization (ran fine with `options optimize=false`). `isNop` now requires the finalList to be empty **and** the callee's declared side-effect flags to be zero — the flags gate also protects empty-bodied emission stubs (`_discard()` in daslib/glsl declares side effects precisely so the call survives to the emitter).
- **`RunFolding` dropped the optimization round.** It was constructed with round 0, so when compile-time function execution folded a call, `reportFolding()` *downgraded* the enclosing function's dirty marker; `funcIsDirty` then skipped the function in every later round, freezing all post-CTFE residue (`10f*1f`, `(1==1)&&false`, dangling empty `let`s). RunFolding now carries the round, and `reportFolding` uses `max()` so no pass can downgrade a dirty marker. A probe that previously left all that residue now folds `main` down to a single constant `print`.
- Removed the stale `TODO: Fold vector constructors` — they fold fine today (probe-verified).

## `fast_math` (CodeOfPolicies + `options fast_math`)

New `/*option*/ bool fast_math = false` in CodeOfPolicies, readable per module via `options fast_math`. Consumers:

- **AST optimizer** — gates the value-changing float folds below.
- **JIT** — `llvm_jit_run.das` now reads `fast_math` (option or policy); the experimental `_jit_fast_math` remains as a legacy alias. The DLL cache key already carries the flag.
- **AOT** — not wired yet; per-function/file pragma emission is on the follow-up list.

Gating model (per the "floats are not bit-exact in das, doubles are" charter):

| Fold class | int | float32 (incl. vec) | double |
|---|---|---|---|
| Bit-exact for every input (`x*1`, `x/1`, `x-(+0)`, `x+(-0)`, bitwise/shift identities, `&&`/`\|\|` table, `!!x`, `-(-x)`, casts, splat collapse) | always | always | always |
| Sign-of-zero-only difference (`x+0`, `0-x`) | always (exact) | always | `fast_math` |
| Value-changing for inf/NaN or rounding (`x*0`, `x-x`, `x/C → x*(1/C)`, `!(a<b) → a>=b`, reassociation) | always (exact, purity-gated) | `fast_math` | `fast_math` |

## New folds in ConstFolding

- `x*1`, `1*x`, `x*-1` (→ negate), `x+0`, `x-0`, `0-x` (→ negate), `x/1`, `x*0`, `x-x`, scalar + vector
- `x&0`, `x|0`, `x^0`, `x&x`, `x|x`, `x^x`, shifts by 0, `x%1`
- `&&`/`||` with a constant arm — short-circuit-correct: a const-false/true **left** folds unconditionally; dropping an evaluated **left** requires purity (`noSideEffects`)
- `!!x`, `-(-x)`, `!(a<b)` → `a>=b` (all six compares; FP gated)
- `c ? true : false` → `c`, `c ? false : true` → `!c`, `c ? a : a` → `a` (same-variable arms; a full `Expression::sameAs` is follow-up)
- same-type workhorse cast elimination: `int(x)` where `x:int`, `float(x:float)`, … (the shapes PERF020 lints)
- vector splat collapse: `v * floatN(s)` → `v * s`, `v / floatN(s)` → `v / s` (bit-exact per lane)
- `while(false)` removal; `for` over a constant empty `range`/`urange`/`range64`/`urange64` removal
- reassociation `(x∘C1)∘C2` → `x∘K` for `+`/`*`, uniform-baseType chains, both orientations — `fast_math` only (including int, conservatively)

New builtin-operator lookup helper (`functionsByName` scan with exact type match) lets the pass synthesize negate/flip/mul nodes with resolved `func`, fail-closed when no operator matches.

Serializer version 94 → 95 (CodeOfPolicies layout changed). rtti binding + handmade doc + options.rst updated.

## Validation

- Full interpreted test sweep green (the sweep caught two AST-shape consumers: the glsl `_discard` emission stub — fixed at the root via the side-effect gate in `isNop` — and a linq fold-shape assertion that expected `!pred`, updated to also accept the flipped compare the optimizer now produces).
- Full AOT sweep (`test_aot -use-aot ... --use-aot --test tests`): 10171/10171 green.
- JIT smoke (array + decs bulk-create): no verifier errors.
- New behavior tests: `tests/language/optimization_folding.das` (21 tests: every identity, purity gates via side-effect counters, short-circuit semantics, dead loops, the finalizer-call regression) and `tests/language/optimization_fast_math.das` (FP zero folds, reciprocal division incl. rounding tolerance, compare flips, reassociation both orientations).
- das2rst clean; Sphinx latex + html clean (`-W`).
- Probes with `options log` confirm each rewrite actually fires (identities, splat collapse, rcp, reassoc, loop removal, CTFE cascade).

## Follow-up roadmap (planned, in order)

1. **DSE** — dead store elimination on locals; `flatten_opt_straightline.das` (`dse_pass`) is the das-side prototype, `ast_cfg.cpp` the flow substrate. Next big pass.
2. **`Expression::sameAs`** — real structural equality (replaces the same-variable-only gate for `x-x`, `c?a:a`, and enables `a==a`-class folds). Tricky by design — separate PR.
3. **CSE** on pure subexpressions (needs sameAs + expression hashing).
4. **AOT fast_math** — per-function `float_control`/`clang fp`/GCC-attribute emission in `describeCppFunc`.
5. Widen reassociation to mixed `-`/`+` chains and consider unconditional int reassociation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)