### PR TITLE
optimizer: dead-store elimination + Expression::sameAs same-shape folds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1204,6 +1204,7 @@ SET(LIBDASCRIPT_COMPILER_SRC
     src/ast/ast_inscope_pod.cpp
     src/ast/ast_escape_analysis.cpp
     src/ast/ast_cfg.cpp
+    src/ast/ast_dse.cpp
     src/ast/ast_validate.cpp
 
     src/builtin/module_builtin_ast.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,6 +835,7 @@ src/ast/ast_typedecl.cpp
 src/ast/ast_match.cpp
 src/ast/ast_module.cpp
 src/ast/ast_print.cpp
+src/ast/ast_same.cpp
 src/ast/ast_program.cpp
 src/ast/ast_allocate_stack.cpp
 src/ast/ast_gc_collect.cpp

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -644,6 +644,11 @@ namespace das
         Expression() { gc_magic = GC_MAGIC_EXPRESSION; }
         Expression(const LineInfo & a) : at(a) { gc_magic = GC_MAGIC_EXPRESSION; }
         string describe() const;
+        // structural equality over value expressions (same computation over the same
+        // operands). NOT value equality by itself: folding `E op E` additionally
+        // requires E->noSideEffects at the call site. Unrecognized node classes
+        // conservatively compare unequal. Implemented in ast_same.cpp.
+        bool sameAs ( const Expression * other ) const;
         virtual ~Expression() {}
         friend DAS_API StringWriter& operator<< (StringWriter& stream, const Expression & func);
         virtual ExpressionPtr visit(Visitor & /*vis*/ )  { DAS_ASSERT(0); return this; };

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1714,6 +1714,7 @@ namespace das
         bool optimizationBlockFolding(int32_t round);
         bool optimizationCondFolding(int32_t round);
         bool optimizationUnused(TextWriter & logs, int32_t round);
+        bool optimizationDeadStores(int32_t round);
         void buildAccessFlags(TextWriter & logs);
         bool verifyAndFoldContracts();
         void validateAst();

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -599,13 +599,11 @@ namespace das {
         return static_cast<ExprConstBool *>(e)->getValue()==v;
     }
 
-    // both expressions read the same variable (cheap structural equality; a full
-    // Expression::sameAs comparator is a planned follow-up)
-    static bool sameVariableRead ( Expression * a, Expression * b ) {
-        if ( !a || !b || !a->rtti_isVar() || !b->rtti_isVar() ) return false;
-        auto va = static_cast<ExprVar *>(a);
-        auto vb = static_cast<ExprVar *>(b);
-        return va->variable && va->variable==vb->variable && !va->write && !vb->write && va->r2v==vb->r2v;
+    // both subtrees are the same pure computation: structural equality
+    // (Expression::sameAs) plus side-effect freedom, so dropping or deduplicating an
+    // evaluation cannot lose observable work. `E op E` folds route through here.
+    static bool samePureValue ( Expression * a, Expression * b ) {
+        return a && b && a->noSideEffects && a->sameAs(b);
     }
 
     // inf-safe finiteness check without <cmath>: inf-inf and NaN-NaN are NaN
@@ -954,7 +952,7 @@ namespace das {
                         if ( auto neg = makeNegate(expr, R) ) { reportFolding(); return neg; }
                     }
                     // x - x → 0: changes inf/NaN results → fast_math for FP
-                    if ( sameVariableRead(L, R) && valueChangeOk(bt) ) {
+                    if ( samePureValue(L, R) && valueChangeOk(bt) ) {
                         if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
                     }
                 } else if ( expr->op=="/" && isNumericFamily(bt) ) {
@@ -978,15 +976,15 @@ namespace das {
                         if ( (zr && L->noSideEffects) || (zl && R->noSideEffects) ) {
                             if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
                         }
-                        if ( sameVariableRead(L,R) ) { reportFolding(); return L; }
+                        if ( samePureValue(L,R) ) { reportFolding(); return L; }
                     } else if ( expr->op=="|" ) {
                         if ( zr && lbt==bt ) { reportFolding(); return L; }
                         if ( zl && rbt==bt ) { reportFolding(); return R; }
-                        if ( sameVariableRead(L,R) ) { reportFolding(); return L; }
+                        if ( samePureValue(L,R) ) { reportFolding(); return L; }
                     } else {
                         if ( zr && lbt==bt ) { reportFolding(); return L; }
                         if ( zl && rbt==bt ) { reportFolding(); return R; }
-                        if ( sameVariableRead(L,R) ) {
+                        if ( samePureValue(L,R) ) {
                             if ( auto z = makeZeroConst(expr) ) { reportFolding(); return z; }
                         }
                     }
@@ -1122,8 +1120,9 @@ namespace das {
                     }
                 }
             }
-            // c ? a : a → a for same-variable arms (cheap structural equality)
-            if ( expr->subexpr->noSideEffects && sameVariableRead(expr->left, expr->right) ) {
+            // c ? a : a → a for same-shape arms. Arm purity is NOT required — exactly one
+            // arm evaluates before and after the fold; only the dropped condition must be pure
+            if ( expr->subexpr->noSideEffects && expr->left->sameAs(expr->right) ) {
                 reportFolding();
                 return expr->left;
             }

--- a/src/ast/ast_dse.cpp
+++ b/src/ast/ast_dse.cpp
@@ -1,0 +1,244 @@
+#include "daScript/misc/platform.h"
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_visitor.h"
+#include "daScript/ast/ast_expressions.h"
+#include "daScript/ast/ast_cfg.h"
+
+namespace das {
+
+    // ===== Dead-store elimination =====
+    // Removes a statement-level `x = <rhs>` when x is a plain by-value local with no
+    // aliasing uses, the rhs is pure, and no path from the store reaches a read of x
+    // before the next full overwrite. Liveness runs backward over the statement-level
+    // CFG (ast_cfg.h).
+    //
+    // Soundness model (deliberately narrow):
+    //  * candidates are ExprLet locals of non-ref, non-refType types (the pass-by-value
+    //    world: workhorse scalars, pointers, enums, bitfields, ranges, vectors, string) -
+    //    ExprCopy on them is a plain value write with no copy hooks;
+    //  * every occurrence of a candidate must be a value read (r2v) or the left side of a
+    //    statement-level ExprCopy. Anything else (addr(), by-ref pass, field/index/swizzle
+    //    access, op-assign, ref binding, clone/move target) disqualifies the variable -
+    //    this is what rules out invisible aliases;
+    //  * a store inside an opaque statement (make-block body, unsafe block) is never a
+    //    removal candidate or a kill - any candidate mention inside an opaque statement
+    //    makes the variable live there (over-approximation, sound);
+    //  * functions carrying control flow the CFG does not model are skipped whole:
+    //    goto/label (also covers lowered generators), try/recover, and non-empty finally
+    //    (it also runs on an early return the CFG routes straight to exit).
+    // Local stores are unobservable after a panic (locals die with the frame; finally is
+    // skipped on panic by design), so removal needs no panic-path modeling.
+
+    namespace {
+
+        // one walk: (a) bail on constructs the CFG does not model, (b) collect candidate
+        // locals, (c) disqualify any variable with a use that is not a plain value read
+        // and not the lvalue of a statement-level assignment
+        class DsePrescan : public Visitor {
+        public:
+            bool eligible = true;
+            vector<Variable *> locals;                  // ExprLet locals of by-value type, in order
+            das_hash_set<Variable *> disq;              // variables with an aliasing-capable use
+            das_hash_set<Variable *> storedVars;        // variables with at least one statement-level store
+        protected:
+            das_hash_set<Expression *> storeLefts;      // lvalue ExprVar nodes of statement-level copies
+            Expression * curStmt = nullptr;
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisit ( ExprBlock * blk ) override {
+                Visitor::preVisit(blk);
+                if ( !blk->finalList.empty() ) eligible = false;
+            }
+            virtual void preVisit ( ExprTryCatch * expr ) override {
+                Visitor::preVisit(expr);
+                eligible = false;
+            }
+            virtual void preVisit ( ExprGoto * expr ) override {
+                Visitor::preVisit(expr);
+                eligible = false;
+            }
+            virtual void preVisit ( ExprLabel * expr ) override {
+                Visitor::preVisit(expr);
+                eligible = false;
+            }
+            virtual void preVisit ( ExprYield * expr ) override {
+                Visitor::preVisit(expr);
+                eligible = false;
+            }
+            virtual void preVisitBlockExpression ( ExprBlock * block, Expression * expr ) override {
+                Visitor::preVisitBlockExpression(block, expr);
+                curStmt = expr;
+            }
+            virtual void preVisit ( ExprCopy * expr ) override {
+                Visitor::preVisit(expr);
+                if ( expr==curStmt && expr->left->rtti_isVar() ) {
+                    storeLefts.insert(expr->left);
+                    storedVars.insert(((ExprVar *)expr->left)->variable);
+                }
+            }
+            virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
+                Visitor::preVisitLet(let, var, last);
+                if ( var->type && !var->type->ref && !var->type->isRefType() ) {
+                    locals.push_back(var);
+                }
+            }
+            virtual void preVisit ( ExprVar * expr ) override {
+                Visitor::preVisit(expr);
+                if ( !expr->r2v && storeLefts.find(expr)==storeLefts.end() ) {
+                    disq.insert(expr->variable);
+                }
+            }
+        };
+
+        // collect candidate-variable mentions (any occurrence) in a subtree
+        class DseMentions : public Visitor {
+        public:
+            DseMentions ( const das_hash_map<Variable *,int> & idx, vector<int> & out )
+                : index(idx), uses(out) {}
+        protected:
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisit ( ExprVar * expr ) override {
+                Visitor::preVisit(expr);
+                auto it = index.find(expr->variable);
+                if ( it!=index.end() ) uses.push_back(it->second);
+            }
+        protected:
+            const das_hash_map<Variable *,int> & index;
+            vector<int> & uses;
+        };
+
+        struct DseStmt {
+            int killVar = -1;       // candidate index fully overwritten by this statement
+            bool rhsPure = false;   // store rhs carries no side effects (safe to not evaluate)
+            vector<int> uses;       // candidate mentions (store: rhs only; otherwise whole subtree)
+        };
+
+        void analyzeDeadStores ( Function * fn, das_hash_set<Expression *> & dead ) {
+            DsePrescan scan;
+            fn->body->visit(scan);
+            if ( !scan.eligible ) return;
+            das_hash_map<Variable *,int> index;
+            for ( auto v : scan.locals ) {
+                if ( scan.disq.find(v)!=scan.disq.end() ) continue;
+                if ( scan.storedVars.find(v)==scan.storedVars.end() ) continue;  // nothing to remove
+                int idx = int(index.size());
+                index[v] = idx;
+            }
+            if ( index.empty() ) return;
+            Cfg cfg = buildCfg(fn);
+            size_t nw = (index.size() + 63) / 64;
+            struct BlockInfo {
+                vector<DseStmt>  stmts;
+                vector<uint64_t> liveIn, liveOut;
+            };
+            vector<BlockInfo> binfo(cfg.blocks.size());
+            for ( size_t bi=0, bis=cfg.blocks.size(); bi!=bis; ++bi ) {
+                auto b = cfg.blocks[bi];
+                auto & BI = binfo[bi];
+                BI.liveIn.resize(nw, 0);
+                BI.liveOut.resize(nw, 0);
+                BI.stmts.resize(b->stmts.size());
+                for ( size_t si=0, sis=b->stmts.size(); si!=sis; ++si ) {
+                    auto stmt = b->stmts[si];
+                    auto & SI = BI.stmts[si];
+                    if ( stmt->rtti_isCopy() ) {
+                        auto cp = (ExprCopy *) stmt;
+                        if ( cp->left->rtti_isVar() ) {
+                            auto it = index.find(((ExprVar *)cp->left)->variable);
+                            if ( it!=index.end() ) {
+                                SI.killVar = it->second;
+                                SI.rhsPure = cp->right->noSideEffects;
+                                DseMentions m(index, SI.uses);
+                                cp->right->visit(m);
+                                continue;
+                            }
+                        }
+                    }
+                    DseMentions m(index, SI.uses);
+                    stmt->visit(m);
+                }
+            }
+            // backward liveness to fixpoint. blocks are numbered in creation order, so
+            // reverse order approximates reverse topological order and converges fast
+            vector<uint64_t> live(nw);
+            bool changed = true;
+            while ( changed ) {
+                changed = false;
+                for ( size_t bi=cfg.blocks.size(); bi-->0; ) {
+                    auto b = cfg.blocks[bi];
+                    auto & BI = binfo[bi];
+                    for ( auto & w : BI.liveOut ) w = 0;
+                    for ( auto s : b->succ ) {
+                        auto & sin = binfo[s->id].liveIn;
+                        for ( size_t w=0; w!=nw; ++w ) BI.liveOut[w] |= sin[w];
+                    }
+                    live = BI.liveOut;
+                    for ( size_t si=BI.stmts.size(); si-->0; ) {
+                        auto & SI = BI.stmts[si];
+                        if ( SI.killVar>=0 ) live[SI.killVar>>6] &= ~(1ull<<(SI.killVar&63));
+                        for ( int u : SI.uses ) live[u>>6] |= 1ull<<(u&63);
+                    }
+                    if ( live != BI.liveIn ) { BI.liveIn = live; changed = true; }
+                }
+            }
+            // final scan: a store whose target is dead after it and whose rhs is pure is
+            // removed - it neither kills (target already dead) nor gens (rhs not evaluated),
+            // which lets a chain of dead stores fall in a single pass
+            for ( size_t bi=0, bis=cfg.blocks.size(); bi!=bis; ++bi ) {
+                auto b = cfg.blocks[bi];
+                auto & BI = binfo[bi];
+                live = BI.liveOut;
+                for ( size_t si=BI.stmts.size(); si-->0; ) {
+                    auto & SI = BI.stmts[si];
+                    if ( SI.killVar>=0 ) {
+                        bool isLive = ((live[SI.killVar>>6] >> (SI.killVar&63)) & 1) != 0;
+                        if ( !isLive && SI.rhsPure ) {
+                            dead.insert(b->stmts[si]);
+                            continue;
+                        }
+                        live[SI.killVar>>6] &= ~(1ull<<(SI.killVar&63));
+                    }
+                    for ( int u : SI.uses ) live[u>>6] |= 1ull<<(u&63);
+                }
+            }
+        }
+
+        class EliminateDeadStores : public PassVisitor {
+        public:
+            using PassVisitor::PassVisitor;
+            using PassVisitor::visit;
+        protected:
+            das_hash_set<Expression *> dead;
+            virtual bool canVisitFunction ( Function * fun ) override {
+                if ( fun->stub || fun->isTemplate || !funcIsDirty(fun) ) return false;
+                if ( !fun->body || !fun->body->rtti_isBlock() ) return false;
+                dead.clear();
+                analyzeDeadStores(fun, dead);
+                return !dead.empty();
+            }
+            virtual bool canVisitStructure ( Structure * ) override { return false; }
+            virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
+            virtual bool canVisitArgumentInit ( Function *, const VariablePtr &, Expression * ) override { return false; }
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual bool canVisitGlobalVariable ( Variable * ) override { return false; }
+            virtual bool canVisitEnumeration ( Enumeration * ) override { return false; }
+            virtual ExpressionPtr visitBlockExpression ( ExprBlock * block, Expression * expr ) override {
+                if ( dead.find(expr)!=dead.end() ) {
+                    reportFolding();
+                    return nullptr;
+                }
+                return Visitor::visitBlockExpression(block, expr);
+            }
+        };
+    }
+
+    // program
+
+    bool Program::optimizationDeadStores(int32_t round) {
+        if ( options.getBoolOption("disable_dse", false) ) return false;
+        checkSideEffects();
+        EliminateDeadStores pass(round);
+        visit(pass);
+        return pass.didAnything();
+    }
+}

--- a/src/ast/ast_optimize.cpp
+++ b/src/ast/ast_optimize.cpp
@@ -34,6 +34,9 @@ namespace das {
             last = program->optimizationBlockFolding(optimizationRound);  if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "BLOCK FOLDING:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
+            last = program->optimizationDeadStores(optimizationRound);  if ( program->failed() ) break;  any |= last;
+            if ( log ) logs << "DEAD STORES:" << (last ? "optimized" : "nothing") << "\n";
+            if ( logPass ) logs << *program;
             // this is here again for a reason
             last = program->optimizationUnused(logs, optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REMOVE UNUSED:" << (last ? "optimized" : "nothing") << "\n";

--- a/src/ast/ast_same.cpp
+++ b/src/ast/ast_same.cpp
@@ -1,0 +1,112 @@
+#include "daScript/misc/platform.h"
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_expressions.h"
+
+namespace das {
+
+    // ===== Expression::sameAs =====
+    // Structural equality over VALUE expressions: true means the two subtrees are the
+    // same computation over the same operands - same variables (by Variable pointer),
+    // fields, indices, constants (bit-exact), and the same resolved functions. It does
+    // NOT by itself mean two evaluations yield the same value; a caller folding
+    // `E op E` must additionally require E->noSideEffects. Write-flagged occurrences
+    // (lvalues) never compare equal, and any node class not explicitly handled below
+    // conservatively compares unequal.
+
+    static bool sameExpr ( const Expression * a, const Expression * b ) {
+        if ( a==b ) return a!=nullptr;
+        if ( !a || !b ) return false;
+        // exact-class gate: __rtti is stamped per concrete class in every constructor,
+        // so subclasses (ExprCopy under ExprOp2, ExprSafeAt under ExprAt, ...) can never
+        // be conflated with their base or with each other
+        if ( !a->__rtti || !b->__rtti || strcmp(a->__rtti,b->__rtti)!=0 ) return false;
+        if ( a->rtti_isCopy() || a->rtti_isClone() || a->rtti_isSequence() ) return false;   // statements, not values
+        if ( a->rtti_isConstant() ) {
+            auto ca = static_cast<const ExprConst *>(a);
+            auto cb = static_cast<const ExprConst *>(b);
+            if ( ca->baseType != cb->baseType ) return false;
+            if ( a->rtti_isStringConstant() ) {
+                return static_cast<const ExprConstString *>(a)->text == static_cast<const ExprConstString *>(b)->text;
+            }
+            if ( ca->baseType==Type::tEnumeration ) {
+                auto ea = static_cast<const ExprConstEnumeration *>(a);
+                auto eb = static_cast<const ExprConstEnumeration *>(b);
+                return ea->enumType==eb->enumType && ea->text==eb->text;
+            }
+            return memcmp(&ca->value,&cb->value,sizeof(vec4f))==0;   // bit-exact, incl. FP
+        } else if ( a->rtti_isVar() ) {
+            auto va = static_cast<const ExprVar *>(a);
+            auto vb = static_cast<const ExprVar *>(b);
+            return va->variable && va->variable==vb->variable
+                && !va->write && !vb->write && va->r2v==vb->r2v;
+        } else if ( a->rtti_isField() || a->rtti_isSafeField()
+                 || a->rtti_isIsVariant() || a->rtti_isAsVariant() || a->rtti_isSafeAsVariant() ) {
+            auto fa = static_cast<const ExprField *>(a);
+            auto fb = static_cast<const ExprField *>(b);
+            return !fa->write && !fb->write && fa->r2v==fb->r2v
+                && fa->name==fb->name && sameExpr(fa->value, fb->value);
+        } else if ( a->rtti_isSwizzle() ) {
+            auto sa = static_cast<const ExprSwizzle *>(a);
+            auto sb = static_cast<const ExprSwizzle *>(b);
+            return !sa->write && !sb->write && sa->r2v==sb->r2v
+                && sa->fields==sb->fields && sameExpr(sa->value, sb->value);
+        } else if ( a->rtti_isAt() || a->rtti_isSafeAt() ) {
+            auto aa = static_cast<const ExprAt *>(a);
+            auto ab = static_cast<const ExprAt *>(b);
+            return !aa->write && !ab->write && aa->r2v==ab->r2v
+                && sameExpr(aa->subexpr, ab->subexpr) && sameExpr(aa->index, ab->index);
+        } else if ( a->rtti_isNullCoalescing() ) {   // before isPtr2Ref: subclass keeps the base rtti
+            auto na = static_cast<const ExprNullCoalescing *>(a);
+            auto nb = static_cast<const ExprNullCoalescing *>(b);
+            return sameExpr(na->subexpr, nb->subexpr) && sameExpr(na->defaultValue, nb->defaultValue);
+        } else if ( a->rtti_isR2V() ) {
+            return sameExpr(static_cast<const ExprRef2Value *>(a)->subexpr,
+                            static_cast<const ExprRef2Value *>(b)->subexpr);
+        } else if ( a->rtti_isRef2Ptr() ) {
+            return sameExpr(static_cast<const ExprRef2Ptr *>(a)->subexpr,
+                            static_cast<const ExprRef2Ptr *>(b)->subexpr);
+        } else if ( a->rtti_isPtr2Ref() ) {
+            return sameExpr(static_cast<const ExprPtr2Ref *>(a)->subexpr,
+                            static_cast<const ExprPtr2Ref *>(b)->subexpr);
+        } else if ( a->rtti_isCast() ) {
+            auto ca = static_cast<const ExprCast *>(a);
+            auto cb = static_cast<const ExprCast *>(b);
+            return ca->castFlags==cb->castFlags
+                && ca->castType && cb->castType && ca->castType->isSameExactType(*cb->castType)
+                && sameExpr(ca->subexpr, cb->subexpr);
+        } else if ( a->rtti_isOp1() ) {
+            auto oa = static_cast<const ExprOp1 *>(a);
+            auto ob = static_cast<const ExprOp1 *>(b);
+            return oa->op==ob->op && oa->func==ob->func && sameExpr(oa->subexpr, ob->subexpr);
+        } else if ( a->rtti_isOp2() ) {
+            auto oa = static_cast<const ExprOp2 *>(a);
+            auto ob = static_cast<const ExprOp2 *>(b);
+            return oa->op==ob->op && oa->func==ob->func
+                && sameExpr(oa->left, ob->left) && sameExpr(oa->right, ob->right);
+        } else if ( a->rtti_isOp3() ) {
+            auto oa = static_cast<const ExprOp3 *>(a);
+            auto ob = static_cast<const ExprOp3 *>(b);
+            return oa->op==ob->op && oa->func==ob->func && sameExpr(oa->subexpr, ob->subexpr)
+                && sameExpr(oa->left, ob->left) && sameExpr(oa->right, ob->right);
+        } else if ( a->rtti_isCall() ) {
+            auto ca = static_cast<const ExprCall *>(a);
+            auto cb = static_cast<const ExprCall *>(b);
+            if ( !ca->func || ca->func!=cb->func ) return false;
+            if ( ca->arguments.size()!=cb->arguments.size() ) return false;
+            for ( size_t i=0, is=ca->arguments.size(); i!=is; ++i ) {
+                if ( !sameExpr(ca->arguments[i], cb->arguments[i]) ) return false;
+            }
+            return true;
+        } else if ( a->rtti_isAddr() ) {
+            return static_cast<const ExprAddr *>(a)->func
+                && static_cast<const ExprAddr *>(a)->func==static_cast<const ExprAddr *>(b)->func;
+        }
+        return false;   // unrecognized class - conservatively unequal
+    }
+
+    bool Expression::sameAs ( const Expression * other ) const {
+        return sameExpr(this, other);
+    }
+
+}

--- a/tests/language/optimization_dead_stores.das
+++ b/tests/language/optimization_dead_stores.das
@@ -1,0 +1,267 @@
+options gen2
+options rtti
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_boost
+require dastest/testing_boost public
+require strings
+require daslib/strings_boost
+
+// structural FIRED proof + behavioral safety net for the dead-store-elimination pass
+// (src/ast/ast_dse.cpp): a store to a plain local is removed when nothing reads it
+// before the next full overwrite AND the rhs is pure. The behavioral tests pin the
+// safety gates: impure rhs kept, aliased/by-ref/op-assign locals untouched, functions
+// with finally skipped whole.
+
+var g_count = 0
+var g_obs = 0
+
+def bump() : int {
+    g_count ++
+    return g_count
+}
+
+def call_it(blk : block) {
+    invoke(blk)
+}
+
+[export]
+def target_overwrite(x : int) : int {
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    t = x * 5 // nolint:LINT010 -- dead: overwritten below before any read
+    t = x + 7
+    return t
+}
+
+[export]
+def target_trailing(x : int) : int {
+    var t = x + 1
+    let r = t * 2
+    t = x * 9 // nolint:LINT010 -- dead: t never read again
+    return r
+}
+
+[export]
+def target_branch_dead(x : int; c : bool) : int {
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    t = x * 11 // dead: overwritten on both arms before any read
+    if (c) {
+        t = x + 1
+    } else {
+        t = x + 2
+    }
+    return t
+}
+
+[export]
+def target_branch_live(x : int; c : bool) : int {
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    t = x + 3 // LIVE: read on the then-path
+    if (c) {
+        return t
+    }
+    return x
+}
+
+[export]
+def target_loop_live(x : int) : int {
+    var acc = 0
+    var i = 0
+    while (i < x) {
+        acc = acc + i // LIVE: read next iteration and after the loop
+        i = i + 1     // LIVE: read by the condition
+    }
+    return acc
+}
+
+[export]
+def target_chain(x : int) : int {
+    var a = 0 // nolint:LINT010 -- deliberate dead init
+    var b = 0 // nolint:LINT010 -- deliberate dead init
+    a = x + 13 // nolint:LINT010 -- dead: only read by the dead store below
+    b = a * 2 // nolint:LINT010 -- dead: b never read
+    return x
+}
+
+[export]
+def target_impure(x : int) : int {
+    var t = 0
+    t = bump() // target is dead but the rhs has side effects — statement must stay
+    return x
+}
+
+[export]
+def target_alias(x : int) : int {
+    var t = 0
+    t = x + 5
+    var p = unsafe(addr(t))
+    t = x * 6 // looks dead by direct uses, but p aliases t — addr() disqualifies t
+    return *p
+}
+
+[export]
+def target_string() : string {
+    var s = "" // nolint:LINT010 -- deliberate dead init
+    s = "deadbeef" // nolint:LINT010 -- dead: overwritten before any read
+    s = "live"
+    return s
+}
+
+[export]
+def target_ptr(a, b : int const?) : int const? {
+    var p : int const?
+    p = a // nolint:LINT010,STYLE011 -- dead: overwritten before any read; decl-then-assign is the shape under test
+    p = b
+    return p
+}
+
+[export]
+def target_capture(x : int) : int {
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    var r = 0
+    t = x + 40 // LIVE: read inside the block below
+    call_it() $ {
+        r = t + 2
+    }
+    return r
+}
+
+[export]
+def target_finally(x : int) : int {
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    {
+        t = x + 21 // LIVE: the finally reads it on the early-return path the CFG does not model
+        return x
+    } finally {
+        g_obs = t
+    }
+    return 0
+}
+
+[export]
+def target_opassign(x : int) : int {
+    var t = x
+    t += 1 // nolint:PERF013 -- op-assign disqualifies t; the `+=` shape is the point
+    return x
+}
+
+def has(s, sub : string) : bool {
+    return find(s, sub, 0) >= 0
+}
+
+def body_of(t : T?; nm : string) : string {
+    var body = ""
+    compiling_module() |> for_each_function("{nm}") $(func) {
+        if (empty(body)) {
+            body = "{describe(func.body)}"
+        }
+    }
+    t |> success(!empty(body), "target function found")
+    // the coverage lane (dastest --cov-path) injects add_func_coverage/add_line_coverage
+    // statements whose arguments collide with the substrings asserted here — drop them
+    let clean <- [for (ln in split(body, "\n")); ln; where !(ln |> has("coverage("))]
+    return join(clean, "\n")
+}
+
+[test]
+def test_dead_stores_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("overwritten store is removed") @(t : T?) {
+            let b = body_of(t, "target_overwrite")
+            t |> success(!has(b, "* 5"), "dead store gone: {b}")
+            t |> success(has(b, "+ 7"), "live store kept: {b}")
+        }
+        t |> run("store after the last read is removed") @(t : T?) {
+            let b = body_of(t, "target_trailing")
+            t |> success(!has(b, "* 9"), "trailing dead store gone: {b}")
+            t |> success(has(b, "* 2"), "live read kept: {b}")
+        }
+        t |> run("store killed on both branch arms is removed") @(t : T?) {
+            let b = body_of(t, "target_branch_dead")
+            t |> success(!has(b, "* 11"), "pre-branch dead store gone: {b}")
+            t |> success(has(b, "+ 1") && has(b, "+ 2"), "arm stores kept: {b}")
+        }
+        t |> run("store live on one path only is kept") @(t : T?) {
+            let b = body_of(t, "target_branch_live")
+            t |> success(has(b, "+ 3"), "partially-live store kept: {b}")
+        }
+        t |> run("loop-carried stores are kept") @(t : T?) {
+            let b = body_of(t, "target_loop_live")
+            t |> success(has(b, "+ i"), "accumulator kept: {b}")
+            t |> success(has(b, "+ 1"), "counter kept: {b}")
+        }
+        t |> run("dead-store chain falls in one pass") @(t : T?) {
+            let b = body_of(t, "target_chain")
+            t |> success(!has(b, "+ 13") && !has(b, "* 2"), "whole chain gone: {b}")
+        }
+        t |> run("impure rhs keeps the statement") @(t : T?) {
+            let b = body_of(t, "target_impure")
+            t |> success(has(b, "bump"), "side-effecting store kept: {b}")
+        }
+        t |> run("addr() disqualifies the variable") @(t : T?) {
+            let b = body_of(t, "target_alias")
+            t |> success(has(b, "* 6"), "aliased store kept: {b}")
+        }
+        t |> run("dead string store is removed") @(t : T?) {
+            let b = body_of(t, "target_string")
+            t |> success(!has(b, "deadbeef"), "dead string store gone: {b}")
+            t |> success(has(b, "live"), "live string store kept: {b}")
+        }
+        t |> run("dead pointer store is removed") @(t : T?) {
+            let b = body_of(t, "target_ptr")
+            t |> success(!has(b, "p = a"), "dead pointer store gone: {b}")
+            t |> success(has(b, "p = b"), "live pointer store kept: {b}")
+        }
+        t |> run("store read inside a block capture is kept") @(t : T?) {
+            let b = body_of(t, "target_capture")
+            t |> success(has(b, "+ 40"), "block-read store kept: {b}")
+        }
+        t |> run("function with finally is skipped whole") @(t : T?) {
+            let b = body_of(t, "target_finally")
+            t |> success(has(b, "+ 21"), "store read by finally kept: {b}")
+        }
+        t |> run("op-assign disqualifies the variable") @(t : T?) {
+            let b = body_of(t, "target_opassign")
+            t |> success(has(b, "+="), "op-assign statement kept: {b}")
+        }
+    }
+}
+
+[test]
+def test_dead_stores_behavior(t : T?) {
+    t |> run("values preserved") @(t : T?) {
+        t |> equal(target_overwrite(3), 10)
+        t |> equal(target_trailing(4), 10)
+        t |> equal(target_branch_dead(5, true), 6)
+        t |> equal(target_branch_dead(5, false), 7)
+        t |> equal(target_branch_live(2, true), 5)
+        t |> equal(target_branch_live(2, false), 2)
+        t |> equal(target_loop_live(4), 6)
+        t |> equal(target_chain(15), 15)
+        t |> equal(target_string(), "live")
+        t |> equal(target_capture(1), 43)
+        t |> equal(target_opassign(5), 5)
+    }
+    t |> run("side effects of a dead target's rhs still happen") @(t : T?) {
+        g_count = 0
+        t |> equal(target_impure(1), 1)
+        t |> equal(g_count, 1)
+        t |> equal(target_impure(2), 2)
+        t |> equal(g_count, 2)
+    }
+    t |> run("aliased store still lands") @(t : T?) {
+        t |> equal(target_alias(7), 42)
+    }
+    t |> run("finally observes the store on the early-return path") @(t : T?) {
+        g_obs = 0
+        t |> equal(target_finally(9), 9)
+        t |> equal(g_obs, 30)
+    }
+    t |> run("pointer store chain") @(t : T?) {
+        var va = 1
+        var vb = 2
+        let res = target_ptr(unsafe(addr(va)), unsafe(addr(vb)))
+        t |> equal(*res, 2)
+    }
+}

--- a/tests/language/optimization_fold_shape.das
+++ b/tests/language/optimization_fold_shape.das
@@ -96,6 +96,50 @@ def target_reassoc(f : float) : float {
     return (f + 1.0) + 2.0
 }
 
+// ===== Expression::sameAs powered folds (same-shape operands beyond bare vars) =====
+
+struct SamePair {
+    a : int
+    b : int
+}
+
+var g_side = 0
+
+def bump_side() : int {
+    g_side ++
+    return g_side
+}
+
+[export]
+def target_xor_self_field(s : SamePair) : int {
+    return s.a ^ s.a // nolint:LINT007 -- deliberate: the fold under test
+}
+
+[export]
+def target_sub_self_swizzle(v : int2) : int {
+    return v.x - v.x // nolint:LINT007 -- deliberate: the fold under test
+}
+
+[export]
+def target_and_self_at(arr : int[4]; i : int) : int {
+    return arr[i] & arr[i] // nolint:LINT007 -- deliberate: the fold under test
+}
+
+[export]
+def target_tern_same_arms(c : bool; s : SamePair) : int {
+    return c ? s.b : s.b // nolint:LINT008 -- deliberate: the fold under test
+}
+
+[export]
+def target_sub_self_impure() : int {
+    return bump_side() - bump_side() // nolint:LINT007 -- deliberate: impure operands must NOT fold
+}
+
+[export]
+def target_sub_self_float(f : float) : float {
+    return f - f // nolint:LINT007 -- deliberate: stays without fast_math (inf/NaN)
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -183,5 +227,56 @@ def test_identity_folds_fired(t : T?) {
             let b = body_of(t, "target_reassoc")
             t |> success(has(b, "1f") && has(b, "2f"), "chain not regrouped: {b}")
         }
+    }
+}
+
+[test]
+def test_same_as_folds_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("s.a ^ s.a becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_xor_self_field")
+            t |> success(!has(b, "^"), "no `^` survives: {b}")
+            t |> success(has(b, "return 0"), "constant zero returned: {b}")
+        }
+        t |> run("v.x - v.x becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_sub_self_swizzle")
+            t |> success(!has(b, "-"), "no `-` survives: {b}")
+            t |> success(has(b, "return 0"), "constant zero returned: {b}")
+        }
+        t |> run("arr[i] & arr[i] keeps a single read") @(t : T?) {
+            let b = body_of(t, "target_and_self_at")
+            t |> success(!has(b, "&"), "no `&` survives: {b}")
+            t |> success(has(b, "arr[i]"), "single indexed read kept: {b}")
+        }
+        t |> run("c ? s.b : s.b collapses to the arm") @(t : T?) {
+            let b = body_of(t, "target_tern_same_arms")
+            t |> success(!has(b, "?"), "no ternary survives: {b}")
+            t |> success(has(b, "s.b"), "arm kept: {b}")
+        }
+        t |> run("impure same-shape operands do NOT fold") @(t : T?) {
+            let b = body_of(t, "target_sub_self_impure")
+            t |> success(has(b, "bump_side"), "calls kept: {b}")
+            t |> success(has(b, "-"), "subtract kept: {b}")
+        }
+        t |> run("f - f stays OFF without fast_math") @(t : T?) {
+            let b = body_of(t, "target_sub_self_float")
+            t |> success(has(b, "f - f"), "float self-sub not folded: {b}")
+        }
+    }
+}
+
+[test]
+def test_same_as_folds_behavior(t : T?) {
+    t |> run("values preserved") @(t : T?) {
+        t |> equal(target_xor_self_field(SamePair(a = 77, b = 5)), 0)
+        t |> equal(target_sub_self_swizzle(int2(9, 4)), 0)
+        t |> equal(target_and_self_at(fixed_array(3, 5, 7, 9), 2), 7)
+        t |> equal(target_tern_same_arms(true, SamePair(a = 1, b = 42)), 42)
+        t |> equal(target_tern_same_arms(false, SamePair(a = 1, b = 42)), 42)
+    }
+    t |> run("impure operands evaluate exactly twice") @(t : T?) {
+        g_side = 0
+        t |> equal(target_sub_self_impure(), -1)
+        t |> equal(g_side, 2)
     }
 }

--- a/tests/language/optimization_fold_shape_fast_math.das
+++ b/tests/language/optimization_fold_shape_fast_math.das
@@ -24,6 +24,11 @@ def target_sub_self_f(f : float) : float {
 }
 
 [export]
+def target_sub_self_swizzle_f(v : float2) : float {
+    return v.x - v.x // nolint:LINT007 -- deliberate: sameAs-shape fold under fast_math
+}
+
+[export]
 def target_rcp(f : float) : float {
     return f / 4.0
 }
@@ -67,6 +72,10 @@ def test_fast_math_folds_fired(t : T?) {
         }
         t |> run("f-f becomes the zero constant") @(t : T?) {
             let b = body_of(t, "target_sub_self_f")
+            t |> success(!has(b, "-"), "no `-` survives: {b}")
+        }
+        t |> run("v.x-v.x becomes the zero constant") @(t : T?) {
+            let b = body_of(t, "target_sub_self_swizzle_f")
             t |> success(!has(b, "-"), "no `-` survives: {b}")
         }
         t |> run("f/4.0 becomes multiply by reciprocal") @(t : T?) {


### PR DESCRIPTION
Next step of the optimizer-audit roadmap (#3384 follow-up), two roadmap items batched into one CI cycle: **dead-store elimination** in the C++ AST optimizer, plus **`Expression::sameAs`** replacing the bare-variable equality at the `E op E` fold sites.

# Dead-store elimination

Backward liveness over the existing statement-level CFG (`ast_cfg.h`, the escape-analysis substrate). The das-side prototype is `flatten_opt_straightline.das`'s `dse_pass`; this is the general-control-flow port.

## What it does

Removes a statement-level `x = <rhs>` when

- `x` is a **by-value local** (non-ref, non-refType: workhorse scalars, pointers, enums, bitfields, ranges, vectors, string) — `ExprCopy` on these is a plain value write with no copy hooks,
- the **rhs is pure** (`noSideEffects`, refreshed via `checkSideEffects()` at pass start — CondFolding/BlockFolding create nodes after ConstFolding's pass computed the flags), and
- **no path from the store reaches a read** of `x` before the next full overwrite (backward liveness bitsets to fixpoint over the CFG).

New pass slot: after BLOCK FOLDING, before the second REMOVE UNUSED — so a variable whose last store falls becomes write-free and the existing Unused pass deletes its declaration in the same fixpoint loop. Escape hatch: `options disable_dse` (precedent: `disable_run`).

## Soundness model (deliberately narrow v1)

- **Aliasing:** every occurrence of a candidate must be an r2v value read or the lvalue of a statement-level `ExprCopy`. Anything else — `addr()`, by-ref pass, field/index/swizzle access, op-assign, ref binding, clone/move target — disqualifies the variable outright. This rules out invisible aliases without needing escape analysis.
- **Opaque statements** (make-block bodies, `unsafe { }` blocks): any candidate mention inside one makes the variable live there (gen-only over-approximation); stores inside them are never removal candidates or kills.
- **Whole-function bail-outs** where the CFG doesn't model the edges: `goto`/`label` (also covers lowered generators), `try`/`recover`, and non-empty `finally` (the CFG models `finalList` on the fall-through path only; an early `return` also runs it — removing a store the finally reads would miscompile; there is a test pinning exactly this shape).
- **Panic paths need no modeling:** locals die with the frame and `finally` is skipped on panic by design, so a removed local store is unobservable after a panic.

## Test coverage (each safety gate has a FIRED/NOT-FIRED pin)

Removed: plain overwrite, trailing dead store, both-arms-killed pre-branch store, dead-store chain (single pass), dead string store, dead pointer store. Kept: partially-live branch store, loop-carried stores, impure rhs (side effect observed behaviorally), `addr()`-aliased store (behavioral proof through the pointer), store read inside a block capture, store read by `finally` on the early-return path, op-assign shapes.

## Known v1 conservatisms (follow-up surface)

1. decl-inits are never removed (only `ExprCopy` statements) — `var x = pure(); x = 5` keeps the init;
2. op-assign disqualifies the whole variable (could be modeled as a gen-only use);
3. a dead store with impure rhs keeps the whole statement (could rewrite `t = bump()` → `bump()`);
4. struct/refType locals excluded (partial writes would need modeling as use+def).

# Expression::sameAs (second commit)

The structural comparator planned in #3384 ("cheap structural equality; a full Expression::sameAs comparator is a planned follow-up") replaces `sameVariableRead` at all five `E op E` fold sites.

**Contract** (`src/ast/ast_same.cpp`, method on `Expression`): structural equality over value expressions — same computation over the same operands (variables by `Variable*`, fields by name, constants bit-exact, calls by resolved `Function*`). It is deliberately NOT value equality: folding `E op E` additionally requires `E->noSideEffects`, wrapped as `samePureValue()` at the fold sites. Exact-class identity is gated on `__rtti`, so `ExprCopy` can never be conflated with `ExprOp2`, `ExprSafeAt` with `ExprAt`, etc. Write-flagged occurrences (lvalues) never compare equal; unrecognized node classes conservatively compare unequal.

**Widened folds** (previously bare-variable-only):
- `s.a ^ s.a` → 0, `v.x - v.x` → 0 (swizzle), `arr[i] & arr[i]` → single read — any pure same-shape operand;
- `c ? E : E` → `E` now requires only structural arm equality — arm *purity* is not needed (exactly one arm evaluates before and after; only the dropped condition must stay pure);
- `x - x` keeps its FP fast_math gate (inf/NaN); the swizzle form is pinned in the fast_math shape suite.

**Implementation note:** `ast_same.cpp` sits in `AST_SRC` (the runtime source list, next to `ast_print.cpp`'s `describe()`), not the compiler list — `Expression` is a `DAS_API` class, so a member defined only in the compiler lib would leave `libDaScriptDyn_runtime`'s export table unresolved.

New shape pins: field/swizzle/index/ternary FIRED + two negatives (impure operands stay — with a behavioral exactly-twice-evaluated proof; `f - f` stays without fast_math). This is the substrate CSE will build on (next PR).

# Validation (both commits, local)

| Lane | Result |
|---|---|
| New tests: `optimization_dead_stores.das` 20/20, `optimization_fold_shape.das` 26/26, `_fast_math` 7/7, `optimization_folding.das` 21/21 | all pass |
| `tests/glsl` (shape-sensitive `_discard()` consumer) | 38/38 |
| `tests/linq` (fold-shape assertions) | 2007/2007 |
| full `tests/` sweep | 10936/10936 |
| JIT lane (`-jit` on `tests/jit_tests`) | 296/296, no verifier errors; cached DLLs correctly self-invalidated via AST-hash change |
| AOT emission | DSE'd store absent from emitted C++; finally-bail store present; `arr[i] & arr[i]` emits a single read |

The strudel end-of-sweep "potential memory leak" log lines were A/B'd against a master-built binary over the identical full sweep — byte-identical on both, pre-existing diagnostic noise, not this PR.

Roadmap after this: CSE (on the sameAs substrate), AOT fast_math pragma emission in `describeCppFunc`, wider reassociation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)