### PR TITLE
dasAudio: microphone capture (recording)

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -117,6 +117,7 @@ require stbimage/stbimage_boost
 require stbimage/stbimage_ttf
 require audio/audio_boost
 require audio/audio_wav
+require audio/audio_record
 require strudel/strudel_event
 require strudel/strudel_time
 require strudel/strudel_live
@@ -1470,6 +1471,7 @@ def document_module_audio(_root : string) {
     var mod = get_module("audio")
     var groups <- array<DocGroup>(
         group_by_regex("Audio device", mod, %regex~(sound_initalize|sound_finalize|mixer_context|sound_set_null_device|audio_is_single_threaded)$%%),
+        group_by_regex("Capture", mod, %regex~(sound_record|sound_is_recording)%%),
         group_by_regex("Decoder", mod, %regex~ma_decoder%%),
         group_by_regex("Resampler", mod, %regex~ma_resampler%%),
         group_by_regex("Channel converter", mod, %regex~ma_channel_converter%%),
@@ -1515,6 +1517,14 @@ def document_module_audio_wav(_root : string) {
         group_by_regex("WAV I/O", mod, %regex~(read_wav|write_wav)$%%)
     )
     document("WAV file reading and writing", mod, "audio_wav.rst", groups)
+}
+
+def document_module_audio_record(_root : string) {
+    var mod = find_module("audio_record")
+    var groups <- array<DocGroup>(
+        group_by_regex("Recording", mod, %regex~(sound_record_list_devices|record_to_wav)$%%)
+    )
+    document("Microphone capture and record-to-WAV", mod, "audio_record.rst", groups)
 }
 
 def document_module_strudel_event(_root : string) {
@@ -1726,6 +1736,7 @@ def main {
     // document dasAudio daScript modules
     document_module_audio_boost(root)
     document_module_audio_wav(root)
+    document_module_audio_record(root)
     // document strudel modules
     document_module_strudel_event(root)
     document_module_strudel_time(root)

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -430,6 +430,7 @@ Run any tutorial from the project root::
    tutorials/dasAudio_08_midi.rst
    tutorials/dasAudio_09_playback_status.rst
    tutorials/dasAudio_10_global_controls.rst
+   tutorials/dasAudio_11_recording.rst
 
 .. _tutorials_dasminfft:
 

--- a/doc/source/reference/tutorials/dasAudio_10_global_controls.rst
+++ b/doc/source/reference/tutorials/dasAudio_10_global_controls.rst
@@ -62,3 +62,5 @@ respond to a single global call — no need to enumerate channels.
    Full source: :download:`tutorials/dasAudio/10_global_controls.das <../../../../tutorials/dasAudio/10_global_controls.das>`
 
    Previous tutorial: :ref:`tutorial_dasAudio_playback_status`
+
+   Next tutorial: :ref:`tutorial_dasAudio_recording`

--- a/doc/source/reference/tutorials/dasAudio_11_recording.rst
+++ b/doc/source/reference/tutorials/dasAudio_11_recording.rst
@@ -1,0 +1,121 @@
+.. _tutorial_dasAudio_recording:
+
+==========================================
+AUDIO-11 — Recording from the Microphone
+==========================================
+
+.. index::
+    single: Tutorial; Recording
+    single: Tutorial; Microphone
+    single: Tutorial; Capture
+    single: Tutorial; Audio
+
+This tutorial covers capturing audio from a microphone with the
+``audio/audio_record`` module: enumerating input devices, recording to a WAV
+file, and driving the low-level capture loop yourself for live processing.
+
+Capture is independent of playback — you do **not** need ``with_audio_system``.
+A dedicated capture device runs on the audio thread and fills a lock-free ring
+buffer; your script drains it on the main thread. Samples are interleaved 32-bit
+float at the sample rate and channel count you request.
+
+Enumerating Capture Devices
+===========================
+
+``sound_record_list_devices`` returns the available microphones. Each
+``AudioDeviceInfo`` has a display ``name``, an ``is_default`` flag, and an
+``index`` you pass to the recording calls as ``device_index`` (``-1`` means the
+system default):
+
+.. code-block:: das
+
+    require audio/audio_record
+
+    for (d in sound_record_list_devices()) {
+        let tag = d.is_default ? " (default)" : ""
+        print("[{d.index}] {d.name}{tag}\n")
+    }
+
+Listing devices does not open the microphone, so it works before any capture
+permission prompt.
+
+Recording to a WAV File
+=======================
+
+``record_to_wav`` is the one-call path: it opens the default capture device,
+records for the requested duration, writes a 16-bit PCM WAV, and returns
+``false`` if the device could not be opened (no microphone, or the OS denied
+access). Pass a ``device_index`` to target a specific input:
+
+.. code-block:: das
+
+    // fname, seconds, rate = 44100, channels = 1, device_index = -1
+    if (record_to_wav("recording.wav", 2.0, 44100, 1)) {
+        print("wrote recording.wav\n")
+    }
+
+The Manual Capture Loop
+=======================
+
+For live processing you drive the loop yourself. ``sound_record_start`` opens
+the device; ``sound_record_read`` drains as many buffered frames as fit in your
+scratch array, returning the frame count; ``sound_record_stop`` closes the
+device. The ``rb_frames`` argument sizes the ring buffer (a sample rate's worth
+is about one second of headroom):
+
+.. code-block:: das
+
+    require audio/audio_record
+    require audio
+    require math
+
+    if (sound_record_start(44100, 1, 44100, -1)) {
+        var scratch : array<float>
+        scratch |> resize(44100)
+        var frames = 0
+        var peak = 0.0
+        while (frames < 44100) {          // ~1 second
+            let n = sound_record_read(scratch)
+            if (n > 0) {
+                for (i in range(n)) {
+                    peak = max(peak, abs(scratch[i]))
+                }
+                frames += n
+            } else {
+                sleep(5u)
+            }
+        }
+        sound_record_stop()
+        print("peak {peak}, dropped {sound_record_overflow_frames()} frames\n")
+    }
+
+``sound_record_overflow_frames`` reports frames the audio thread had to drop
+because the ring filled up — a non-zero value means your drain loop fell behind.
+``sound_record_available`` reports how many frames are currently buffered, and
+``sound_is_recording`` reports whether a capture device is open.
+
+The samples are at the native rate you requested; resample to another rate (for
+example 16 kHz mono for speech models) with the ``ma_resampler_*`` bindings.
+
+Running the Tutorial
+====================
+
+Run from the project root::
+
+   daslang.exe tutorials/dasAudio/11_recording.das
+
+The tutorial lists the capture devices, records two seconds to ``recording.wav``,
+reads the file back to confirm the round-trip, then runs the manual loop for one
+second and reports the peak amplitude.
+
+.. note::
+
+   On macOS the microphone is gated by the system privacy settings — the process
+   (or the terminal that launched it) must be granted microphone access, or
+   capture returns silence. Enumeration is unaffected.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasAudio/11_recording.das <../../../../tutorials/dasAudio/11_recording.das>`
+
+   Previous tutorial: :ref:`tutorial_dasAudio_global_controls`

--- a/doc/source/stdlib/handmade/function-audio-sound_is_recording-0x13254772bb55c5a5.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_is_recording-0x13254772bb55c5a5.rst
@@ -1,0 +1,1 @@
+True while a capture device is open and recording.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_available-0xa60cec4c8688fce7.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_available-0xa60cec4c8688fce7.rst
@@ -1,0 +1,1 @@
+Number of captured frames currently buffered and waiting to be read.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_device_count-0x21fff6cfb6ef1db2.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_device_count-0x21fff6cfb6ef1db2.rst
@@ -1,0 +1,1 @@
+Enumerate the available capture (microphone) devices and return how many there are. Names and default flags for each index are read with sound_record_device_name and sound_record_device_is_default.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_device_is_default-0x7e7a6b73c44301d7.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_device_is_default-0x7e7a6b73c44301d7.rst
@@ -1,0 +1,1 @@
+True if the capture device at the given index is the system default input device.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_device_name-0xc6ffa0fa1d9dba02.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_device_name-0xc6ffa0fa1d9dba02.rst
@@ -1,0 +1,1 @@
+Human-readable name of the capture device at the given index, from the most recent sound_record_device_count enumeration.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_overflow_frames-0x412c97ae5b2e81ee.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_overflow_frames-0x412c97ae5b2e81ee.rst
@@ -1,0 +1,1 @@
+Number of frames the audio thread dropped because the ring buffer was full (the read loop fell behind). Reset to 0 at each sound_record_start.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_read-0xdb6576e71f2f5ec6.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_read-0xdb6576e71f2f5ec6.rst
@@ -1,0 +1,1 @@
+Drain buffered capture frames into the given array, up to its length, and return the number of frames read. Returns 0 when not recording or nothing is buffered. Samples are interleaved 32-bit float.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_start-0x67618b6873307678.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_start-0x67618b6873307678.rst
@@ -1,1 +1,1 @@
-Open the capture (microphone) device and begin recording interleaved float samples into a ring buffer. rb_frames sizes the ring buffer; device_index selects an input (-1 = system default). Returns false if the device cannot be opened.
+Open the capture (microphone) device and begin recording interleaved float samples into a ring buffer. rb_frames sizes the ring buffer; device_index selects an input (-1 = system default). Returns false if the device cannot be opened. Panics if called while already recording, or if rate or channels are not positive.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_start-0x67618b6873307678.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_start-0x67618b6873307678.rst
@@ -1,0 +1,1 @@
+Open the capture (microphone) device and begin recording interleaved float samples into a ring buffer. rb_frames sizes the ring buffer; device_index selects an input (-1 = system default). Returns false if the device cannot be opened.

--- a/doc/source/stdlib/handmade/function-audio-sound_record_stop-0x146d5491df854727.rst
+++ b/doc/source/stdlib/handmade/function-audio-sound_record_stop-0x146d5491df854727.rst
@@ -1,0 +1,1 @@
+Stop recording and close the capture device.

--- a/doc/source/stdlib/handmade/module-audio_record.rst
+++ b/doc/source/stdlib/handmade/module-audio_record.rst
@@ -1,0 +1,1 @@
+Module audio_record

--- a/doc/source/stdlib/introduction.rst
+++ b/doc/source/stdlib/introduction.rst
@@ -196,6 +196,7 @@ Audio
 * :doc:`audio <generated/audio>` — audio playback, mixing, 3D spatial audio, effects (C++ module, based on miniaudio)
 * :doc:`audio_boost <generated/audio_boost>` — audio convenience helpers: sound loading, bus routing, effect chains
 * :doc:`audio_wav <generated/audio_wav>` — WAV file reading and writing
+* :doc:`audio_record <generated/audio_record>` — microphone capture and record-to-WAV
 * :doc:`strudel_midi <generated/strudel_midi>` — MIDI file parsing and playback
 * :doc:`strudel_sf2 <generated/strudel_sf2>` — SoundFont 2 file parser for sample-based synthesis
 

--- a/doc/source/stdlib/sec_audio.rst
+++ b/doc/source/stdlib/sec_audio.rst
@@ -11,3 +11,4 @@ Audio playback, 3D spatial audio, effects, WAV file I/O, MIDI parsing, and SF2 s
    generated/audio.rst
    generated/audio_boost.rst
    generated/audio_wav.rst
+   generated/audio_record.rst

--- a/modules/dasAudio/.das_module
+++ b/modules/dasAudio/.das_module
@@ -7,6 +7,7 @@ def initialize(project_path : string) {
         register_dynamic_module("{project_path}/dasModuleAudio.shared_module", "Module_Audio")
     }
     register_native_path("audio", "audio_wav", "{project_path}/audio/audio_wav.das")
+    register_native_path("audio", "audio_record", "{project_path}/audio/audio_record.das")
     register_native_path("live", "audio_live", "{project_path}/audio/audio_live.das")
     register_native_path("strudel", "strudel", "{project_path}/strudel/strudel.das")
     register_native_path("strudel", "strudel_event", "{project_path}/strudel/strudel_event.das")

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -12,6 +12,7 @@ module audio_record shared private
 require audio public
 require audio/audio_wav public
 require daslib/fio
+require math
 
 struct public AudioDeviceInfo {
     //! A capture (microphone) device, as returned by `sound_record_list_devices`.
@@ -31,7 +32,7 @@ def public sound_record_list_devices() : array<AudioDeviceInfo> {
 
 def public record_to_wav(fname : string; seconds : float; rate : int = 44100; channels : int = 1; device_index : int = -1) : bool {
     //! Record `seconds` of audio from the microphone into a 16-bit PCM WAV file. Blocks until done.
-    //! Returns false if the capture device fails to open or produces no audio.
+    //! Returns false (and writes nothing) if the device fails to open, produces no audio, or stalls mid-capture.
     if (!sound_record_start(rate, channels, rate, device_index)) {
         return false
     }
@@ -41,24 +42,30 @@ def public record_to_wav(fname : string; seconds : float; rate : int = 44100; ch
     let total_frames = int(float(rate) * seconds)
     var got_frames = 0
     var stall_ms = 0
+    var completed = true
     while (got_frames < total_frames) {
         let n = sound_record_read(scratch)
         if (n > 0) {
+            let take = min(n, total_frames - got_frames)   // cap to remaining — never overshoot `seconds`
             let base = length(samples)
-            samples |> resize(base + n * channels)
-            for (i in range(n * channels)) {
+            samples |> resize(base + take * channels)
+            for (i in range(take * channels)) {
                 samples[base + i] = scratch[i]
             }
-            got_frames += n
+            got_frames += take
             stall_ms = 0
         } else {
             sleep(5u)
             stall_ms += 5
-            break if (stall_ms > 2000)   // device produced nothing for ~2s — bail rather than hang
+            if (stall_ms > 2000) {   // device produced nothing for ~2s — treat as a mid-capture failure, don't hang
+                completed = false
+                break
+            }
         }
     }
     sound_record_stop()
-    return false if (got_frames == 0)   // device opened but produced nothing — don't leave an empty WAV behind
+    // don't leave a partial/empty WAV: stalled mid-capture, or the device produced nothing
+    return false if (!completed || got_frames == 0)
     write_wav(fname, samples, uint(rate), channels)
     return true
 }

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -32,10 +32,10 @@ def public sound_record_list_devices() : array<AudioDeviceInfo> {
 
 def public record_to_wav(fname : string; seconds : float; rate : int = 44100; channels : int = 1; device_index : int = -1) : bool {
     //! Record `seconds` of audio from the microphone into a 16-bit PCM WAV file. Blocks until done.
-    //! Returns false (and writes nothing) if the device fails to open, produces no audio, or stalls mid-capture.
-    if (!sound_record_start(rate, channels, rate, device_index)) {
-        return false
-    }
+    //! Returns false (and writes nothing) on invalid arguments, or if the device fails to open,
+    //! produces no audio, or stalls mid-capture.
+    // invalid args (short-circuit before the device call), or the device fails to open — return false, never panic
+    return false if (seconds <= 0.0 || rate <= 0 || channels <= 0 || !sound_record_start(rate, channels, rate, device_index))
     var samples : array<float>
     var scratch : array<float>
     scratch |> resize(rate * channels)   // ~1s drain buffer

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -10,7 +10,7 @@ module audio_record shared private
 //! separately (e.g. via the `ma_resampler_*` bindings) if you need a different format.
 
 require audio public
-require audio_wav public
+require audio/audio_wav public
 require daslib/fio
 
 struct public AudioDeviceInfo {
@@ -58,6 +58,7 @@ def public record_to_wav(fname : string; seconds : float; rate : int = 44100; ch
         }
     }
     sound_record_stop()
+    return false if (got_frames == 0)   // device opened but produced nothing — don't leave an empty WAV behind
     write_wav(fname, samples, uint(rate), channels)
-    return got_frames > 0
+    return true
 }

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -32,8 +32,8 @@ def public sound_record_list_devices() : array<AudioDeviceInfo> {
 
 def public record_to_wav(fname : string; seconds : float; rate : int = 44100; channels : int = 1; device_index : int = -1) : bool {
     //! Record `seconds` of audio from the microphone into a 16-bit PCM WAV file. Blocks until done.
-    //! Returns false (and writes nothing) on invalid arguments, if a recording is already active, or
-    //! if the device fails to open, produces no audio, or stalls mid-capture.
+    //! Returns false (and writes nothing) on invalid arguments, if a recording is already active, if
+    //! the device fails to open, produces no audio, or stalls mid-capture, or if the WAV cannot be written.
     // invalid args or an already-active recording short-circuit before sound_record_start, so this never panics
     return false if (seconds <= 0.0 || rate <= 0 || channels <= 0 || sound_is_recording() || !sound_record_start(rate, channels, rate, device_index))
     var samples : array<float>
@@ -67,6 +67,5 @@ def public record_to_wav(fname : string; seconds : float; rate : int = 44100; ch
     sound_record_stop()
     // don't leave a partial/empty WAV: stalled mid-capture, or the device produced nothing
     return false if (!completed || got_frames == 0)
-    write_wav(fname, samples, uint(rate), channels)
-    return true
+    return write_wav(fname, samples, uint(rate), channels)   // false if the output path is unwritable
 }

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -40,6 +40,7 @@ def public record_to_wav(fname : string; seconds : float; rate : int = 44100; ch
     var scratch : array<float>
     scratch |> resize(rate * channels)   // ~1s drain buffer
     let total_frames = int(float(rate) * seconds)
+    samples |> reserve(total_frames * channels)   // final size is known up front — reserve once, no intermediate reallocs
     var got_frames = 0
     var stall_ms = 0
     var completed = true

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -1,0 +1,63 @@
+options gen2
+options indenting = 4
+
+module audio_record shared private
+//! Microphone capture: enumerate input devices, start/stop recording, drain samples, record-to-WAV.
+//!
+//! Capture runs on its own device, independent of playback. The audio-thread callback fills a
+//! lock-free ring; scripts drain it on the main thread with `sound_record_read`. Samples are
+//! interleaved 32-bit float at the native rate/channels you request — resample or downmix
+//! separately (e.g. via the `ma_resampler_*` bindings) if you need a different format.
+
+require audio public
+require audio_wav public
+require daslib/fio
+
+struct public AudioDeviceInfo {
+    //! A capture (microphone) device, as returned by `sound_record_list_devices`.
+    name : string           //!< Human-readable device name.
+    is_default : bool       //!< True if this is the system default input device.
+    index : int             //!< Index to pass as `device_index` to `sound_record_start` / `record_to_wav`.
+}
+
+def public sound_record_list_devices() : array<AudioDeviceInfo> {
+    //! Enumerate available capture (microphone) devices. Pass an entry's `index` to
+    //! `sound_record_start` / `record_to_wav` as `device_index`, or -1 for the system default.
+    let n = sound_record_device_count()
+    return <- [for (i in range(n));
+        AudioDeviceInfo(name = sound_record_device_name(i),
+            is_default = sound_record_device_is_default(i), index = i)]
+}
+
+def public record_to_wav(fname : string; seconds : float; rate : int = 44100; channels : int = 1; device_index : int = -1) : bool {
+    //! Record `seconds` of audio from the microphone into a 16-bit PCM WAV file. Blocks until done.
+    //! Returns false if the capture device fails to open or produces no audio.
+    if (!sound_record_start(rate, channels, rate, device_index)) {
+        return false
+    }
+    var samples : array<float>
+    var scratch : array<float>
+    scratch |> resize(rate * channels)   // ~1s drain buffer
+    let total_frames = int(float(rate) * seconds)
+    var got_frames = 0
+    var stall_ms = 0
+    while (got_frames < total_frames) {
+        let n = sound_record_read(scratch)
+        if (n > 0) {
+            let base = length(samples)
+            samples |> resize(base + n * channels)
+            for (i in range(n * channels)) {
+                samples[base + i] = scratch[i]
+            }
+            got_frames += n
+            stall_ms = 0
+        } else {
+            sleep(5u)
+            stall_ms += 5
+            break if (stall_ms > 2000)   // device produced nothing for ~2s — bail rather than hang
+        }
+    }
+    sound_record_stop()
+    write_wav(fname, samples, uint(rate), channels)
+    return got_frames > 0
+}

--- a/modules/dasAudio/audio/audio_record.das
+++ b/modules/dasAudio/audio/audio_record.das
@@ -32,10 +32,10 @@ def public sound_record_list_devices() : array<AudioDeviceInfo> {
 
 def public record_to_wav(fname : string; seconds : float; rate : int = 44100; channels : int = 1; device_index : int = -1) : bool {
     //! Record `seconds` of audio from the microphone into a 16-bit PCM WAV file. Blocks until done.
-    //! Returns false (and writes nothing) on invalid arguments, or if the device fails to open,
-    //! produces no audio, or stalls mid-capture.
-    // invalid args (short-circuit before the device call), or the device fails to open — return false, never panic
-    return false if (seconds <= 0.0 || rate <= 0 || channels <= 0 || !sound_record_start(rate, channels, rate, device_index))
+    //! Returns false (and writes nothing) on invalid arguments, if a recording is already active, or
+    //! if the device fails to open, produces no audio, or stalls mid-capture.
+    // invalid args or an already-active recording short-circuit before sound_record_start, so this never panics
+    return false if (seconds <= 0.0 || rate <= 0 || channels <= 0 || sound_is_recording() || !sound_record_start(rate, channels, rate, device_index))
     var samples : array<float>
     var scratch : array<float>
     scratch |> resize(rate * channels)   // ~1s drain buffer

--- a/modules/dasAudio/audio/audio_wav.das
+++ b/modules/dasAudio/audio/audio_wav.das
@@ -110,7 +110,10 @@ def read_wav_u32(data : array<uint8>; var cursor : int&) : uint {
 }
 
 def public write_wav(fname : string; samples : array<float>; sample_rate : uint = 44100u; channels : int = 2) : bool {
-    //! Write float samples as a 16-bit PCM WAV file. Returns false if the output file could not be opened for writing.
+    //! Write float samples as a 16-bit PCM WAV file. Returns false on invalid input (channels <= 0, or a
+    //! sample count that isn't a whole number of frames) or if the output file could not be opened for writing.
+    // reject non-positive channels (avoids /0) and ragged input (header dataSize must match the samples written)
+    return false if (channels <= 0 || length(samples) % channels != 0)
     var wrote = false
     fopen(fname, "wb") $(f) {
         if (f != null) {

--- a/modules/dasAudio/audio/audio_wav.das
+++ b/modules/dasAudio/audio/audio_wav.das
@@ -109,27 +109,31 @@ def read_wav_u32(data : array<uint8>; var cursor : int&) : uint {
     return v
 }
 
-def public write_wav(fname : string; samples : array<float>; sample_rate : uint = 44100u; channels : int = 2) {
-    //! Write float samples as a 16-bit PCM WAV file.
+def public write_wav(fname : string; samples : array<float>; sample_rate : uint = 44100u; channels : int = 2) : bool {
+    //! Write float samples as a 16-bit PCM WAV file. Returns false if the output file could not be opened for writing.
+    var wrote = false
     fopen(fname, "wb") $(f) {
-        if (f == null) return
-        let numFrames = length(samples) / channels
-        let dataSize = uint(numFrames * channels * 2)
-        fwrite(f, "RIFF")
-        fwrite(f, 36u + dataSize)
-        fwrite(f, "WAVE")
-        fwrite(f, "fmt ")
-        fwrite(f, 16u)
-        fwrite(f, uint16(1))
-        fwrite(f, uint16(channels))
-        fwrite(f, sample_rate)
-        fwrite(f, sample_rate * uint(channels) * 2u)
-        fwrite(f, uint16(channels * 2))
-        fwrite(f, uint16(16))
-        fwrite(f, "data")
-        fwrite(f, dataSize)
-        for (s in samples) {
-            fwrite(f, int16(clamp(s, -1.0, 1.0) * 32767.0))
+        if (f != null) {
+            wrote = true
+            let numFrames = length(samples) / channels
+            let dataSize = uint(numFrames * channels * 2)
+            fwrite(f, "RIFF")
+            fwrite(f, 36u + dataSize)
+            fwrite(f, "WAVE")
+            fwrite(f, "fmt ")
+            fwrite(f, 16u)
+            fwrite(f, uint16(1))
+            fwrite(f, uint16(channels))
+            fwrite(f, sample_rate)
+            fwrite(f, sample_rate * uint(channels) * 2u)
+            fwrite(f, uint16(channels * 2))
+            fwrite(f, uint16(16))
+            fwrite(f, "data")
+            fwrite(f, dataSize)
+            for (s in samples) {
+                fwrite(f, int16(clamp(s, -1.0, 1.0) * 32767.0))
+            }
         }
     }
+    return wrote
 }

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -282,7 +282,6 @@ static bool g_capture_context_inited = false;
 static ma_device g_capture_device;
 static ma_pcm_rb g_capture_rb;
 static bool g_capture_initialized = false;
-static int g_capture_rate = 0;
 static int g_capture_channels = 0;
 // Frames dropped because the ring was full when the callback tried to write (drain loop too slow).
 // Written on the audio thread, read on the main thread — atomic to stay data-race-clean under TSAN.
@@ -292,7 +291,16 @@ static std::atomic<uint64_t> g_capture_overflow_frames { 0 };
 static vector<ma_device_info> g_capture_device_cache;
 
 void dasAudio_set_null_device ( bool enabled ) {
+    if ( enabled == g_force_null_backend ) return;
     g_force_null_backend = enabled;
+    // The persistent capture context was built for the old backend; drop it while idle so the next
+    // enumeration/record rebuilds it on the newly-selected backend. Skip if actively recording (the
+    // live device sits on this context) — toggling the backend mid-capture is a no-op until stop.
+    if ( g_capture_context_inited && !g_capture_initialized ) {
+        ma_context_uninit(&g_capture_context);
+        g_capture_context_inited = false;
+        g_capture_device_cache.clear();
+    }
 }
 
 bool dasAudio_is_single_threaded () {
@@ -481,7 +489,6 @@ bool dasAudio_record_start ( int32_t rate, int32_t channels, int32_t rb_frames, 
         ma_pcm_rb_uninit(&g_capture_rb);
         return false;
     }
-    g_capture_rate = rate;
     g_capture_channels = channels;
     g_capture_initialized = true;   // set before start: the callback may fire immediately
     if ( ma_device_start(&g_capture_device) != MA_SUCCESS ) {

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -536,6 +536,7 @@ int64_t dasAudio_record_overflow_frames ( void ) {
 }
 
 int32_t dasAudio_record_device_count ( Context *, LineInfoArg * ) {
+    g_capture_device_cache.clear();   // a failed enumeration must not leave stale devices readable by name/is_default
     if ( !ensure_capture_context() ) return 0;
     ma_device_info * pCapture = nullptr;
     ma_uint32 captureCount = 0;

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -279,6 +279,7 @@ static bool g_audio_single_threaded = false;
 // captured data cross into a context safely (see the threading notes in the module docs).
 static ma_context g_capture_context;
 static bool g_capture_context_inited = false;
+static bool g_capture_context_is_null = false;   // which backend g_capture_context was built with (tracks g_force_null_backend)
 static ma_device g_capture_device;
 static ma_pcm_rb g_capture_rb;
 static bool g_capture_initialized = false;
@@ -291,16 +292,9 @@ static std::atomic<uint64_t> g_capture_overflow_frames { 0 };
 static vector<ma_device_info> g_capture_device_cache;
 
 void dasAudio_set_null_device ( bool enabled ) {
-    if ( enabled == g_force_null_backend ) return;
     g_force_null_backend = enabled;
-    // The persistent capture context was built for the old backend; drop it while idle so the next
-    // enumeration/record rebuilds it on the newly-selected backend. Skip if actively recording (the
-    // live device sits on this context) — toggling the backend mid-capture is a no-op until stop.
-    if ( g_capture_context_inited && !g_capture_initialized ) {
-        ma_context_uninit(&g_capture_context);
-        g_capture_context_inited = false;
-        g_capture_device_cache.clear();
-    }
+    // The capture context is rebuilt lazily in ensure_capture_context when its backend no longer
+    // matches this flag — so a toggle here (even mid-capture) takes effect on the next idle use.
 }
 
 bool dasAudio_is_single_threaded () {
@@ -393,6 +387,14 @@ bool dasAudio_init ( TFunc<void,TTemporary<TArray<float>>,int32_t,int32_t,float>
 // around rather than the transient (pContext==nullptr) form the playback path uses. Honors the
 // null-backend override so headless/CI runs enumerate+capture without real hardware.
 static bool ensure_capture_context () {
+    // If the cached context was built for a different backend than currently requested (e.g.
+    // sound_set_null_device was toggled since), drop it and rebuild — but only while idle; a live
+    // capture device holds this context, so a mismatch during recording waits until the next use.
+    if ( g_capture_context_inited && g_capture_context_is_null != g_force_null_backend && !g_capture_initialized ) {
+        ma_context_uninit(&g_capture_context);
+        g_capture_context_inited = false;
+        g_capture_device_cache.clear();
+    }
     if ( g_capture_context_inited ) return true;
     ma_result r;
     if ( g_force_null_backend ) {
@@ -406,6 +408,7 @@ static bool ensure_capture_context () {
         return false;
     }
     g_capture_context_inited = true;
+    g_capture_context_is_null = g_force_null_backend;
     return true;
 }
 

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -6,6 +6,8 @@
 #include "daScript/ast/ast_handle.h"
 #include "daScript/simulate/bind_enum.h"
 
+#include <atomic>
+
 // include vorbis extras before miniaudio
 #define STB_VORBIS_HEADER_ONLY
 #ifdef __forceinline
@@ -269,6 +271,26 @@ static bool g_null_context_inited = false;
 // initialized" rather than "what platform is this".
 static bool g_audio_single_threaded = false;
 
+// ---- capture (microphone) ----
+// A capture device independent of the playback device above: recording has its own lifecycle, so
+// it does not share g_device / g_mixer_context. The RT capture callback writes interleaved f32 into
+// g_capture_rb (a lock-free single-producer/single-consumer ring); scripts drain it on the main
+// thread via dasAudio_record_read. No daScript code runs on the audio thread — that is what lets
+// captured data cross into a context safely (see the threading notes in the module docs).
+static ma_context g_capture_context;
+static bool g_capture_context_inited = false;
+static ma_device g_capture_device;
+static ma_pcm_rb g_capture_rb;
+static bool g_capture_initialized = false;
+static int g_capture_rate = 0;
+static int g_capture_channels = 0;
+// Frames dropped because the ring was full when the callback tried to write (drain loop too slow).
+// Written on the audio thread, read on the main thread — atomic to stay data-race-clean under TSAN.
+static std::atomic<uint64_t> g_capture_overflow_frames { 0 };
+// Value-copies of the last capture enumeration, so device names/ids survive past the context-internal
+// buffer that ma_context_get_devices returns. Populated by dasAudio_record_device_count (main thread).
+static vector<ma_device_info> g_capture_device_cache;
+
 void dasAudio_set_null_device ( bool enabled ) {
     g_force_null_backend = enabled;
 }
@@ -358,16 +380,179 @@ bool dasAudio_init ( TFunc<void,TTemporary<TArray<float>>,int32_t,int32_t,float>
     return true;
 }
 
+// Bring up a persistent context for capture: enumeration hands back an opaque, context-owned
+// ma_device_id, and the device we later open on it must outlive that context — so we keep one
+// around rather than the transient (pContext==nullptr) form the playback path uses. Honors the
+// null-backend override so headless/CI runs enumerate+capture without real hardware.
+static bool ensure_capture_context () {
+    if ( g_capture_context_inited ) return true;
+    ma_result r;
+    if ( g_force_null_backend ) {
+        ma_backend nullBackend = ma_backend_null;
+        r = ma_context_init(&nullBackend, 1, nullptr, &g_capture_context);
+    } else {
+        r = ma_context_init(nullptr, 0, nullptr, &g_capture_context);
+    }
+    if ( r != MA_SUCCESS ) {
+        LOG(LogLevel::error) << "failed to init capture context.\n";
+        return false;
+    }
+    g_capture_context_inited = true;
+    return true;
+}
+
 void dasAudio_finalize ( void ) {
     if ( g_mixer_initialized ) {
         ma_device_uninit(&g_device);
         g_mixer_context.reset();
         g_mixer_initialized = false;
     }
+    // capture teardown, in case a script never called sound_record_stop
+    if ( g_capture_initialized ) {
+        ma_device_uninit(&g_capture_device);
+        g_capture_initialized = false;
+        ma_pcm_rb_uninit(&g_capture_rb);
+    }
+    if ( g_capture_context_inited ) {
+        ma_context_uninit(&g_capture_context);
+        g_capture_context_inited = false;
+    }
+    g_capture_device_cache.clear();
     if ( g_null_context_inited ) {
         ma_context_uninit(&g_null_context);
         g_null_context_inited = false;
     }
+}
+
+// RT-thread capture callback: append the just-captured interleaved f32 frames to the ring. Pure
+// C++ — no daScript, no allocation, no lock. On overflow (drain loop fell behind) the excess is
+// dropped and counted; recording never blocks the audio thread.
+void capture_callback ( ma_device *, void *, const void * pInput, ma_uint32 frameCount ) {
+    if ( !g_capture_initialized || pInput == nullptr ) return;
+    const float * src = (const float *) pInput;
+    ma_uint32 channels = (ma_uint32) g_capture_channels;
+    ma_uint32 framesLeft = frameCount;
+    ma_uint32 srcFrame = 0;
+    while ( framesLeft > 0 ) {
+        ma_uint32 chunk = framesLeft;
+        void * pWrite = nullptr;
+        if ( ma_pcm_rb_acquire_write(&g_capture_rb, &chunk, &pWrite) != MA_SUCCESS ) break;
+        if ( chunk == 0 ) {
+            ma_pcm_rb_commit_write(&g_capture_rb, 0);
+            g_capture_overflow_frames.fetch_add(framesLeft, std::memory_order_relaxed);
+            break;
+        }
+        memcpy(pWrite, src + (size_t)srcFrame * channels, (size_t)chunk * channels * sizeof(float));
+        ma_pcm_rb_commit_write(&g_capture_rb, chunk);
+        srcFrame += chunk;
+        framesLeft -= chunk;
+    }
+}
+
+bool dasAudio_record_start ( int32_t rate, int32_t channels, int32_t rb_frames, int32_t device_index, Context * context, LineInfoArg * at ) {
+    if ( g_capture_initialized ) context->throw_error_at(at, "already recording; call sound_record_stop first");
+    if ( rate <= 0 || channels <= 0 ) context->throw_error_at(at, "record rate and channels must be positive");
+    if ( rb_frames <= 0 ) rb_frames = rate;   // ~1s ring by default
+    if ( !ensure_capture_context() ) return false;
+    if ( ma_pcm_rb_init(ma_format_f32, (ma_uint32)channels, (ma_uint32)rb_frames, nullptr, nullptr, &g_capture_rb) != MA_SUCCESS ) {
+        LOG(LogLevel::error) << "failed to init capture ring buffer.\n";
+        return false;
+    }
+    ma_device_config cfg = ma_device_config_init(ma_device_type_capture);
+    cfg.capture.format   = ma_format_f32;
+    cfg.capture.channels = (ma_uint32)channels;
+    cfg.sampleRate       = (ma_uint32)rate;
+    cfg.dataCallback     = capture_callback;
+    cfg.pUserData        = nullptr;
+    if ( device_index >= 0 ) {
+        // Re-enumerate for a fresh, valid id; the pointer only needs to survive until ma_device_init copies it.
+        ma_device_info * pCapture = nullptr;
+        ma_uint32 captureCount = 0;
+        if ( ma_context_get_devices(&g_capture_context, nullptr, nullptr, &pCapture, &captureCount) == MA_SUCCESS
+             && device_index < (int32_t)captureCount ) {
+            cfg.capture.pDeviceID = &pCapture[device_index].id;
+        } else {
+            LOG(LogLevel::error) << "capture device index out of range; falling back to default device.\n";
+        }
+    }
+    g_capture_overflow_frames.store(0, std::memory_order_relaxed);
+    if ( ma_device_init(&g_capture_context, &cfg, &g_capture_device) != MA_SUCCESS ) {
+        LOG(LogLevel::error) << "failed to open capture device.\n";
+        ma_pcm_rb_uninit(&g_capture_rb);
+        return false;
+    }
+    g_capture_rate = rate;
+    g_capture_channels = channels;
+    g_capture_initialized = true;   // set before start: the callback may fire immediately
+    if ( ma_device_start(&g_capture_device) != MA_SUCCESS ) {
+        LOG(LogLevel::error) << "failed to start capture device.\n";
+        g_capture_initialized = false;
+        ma_device_uninit(&g_capture_device);
+        ma_pcm_rb_uninit(&g_capture_rb);
+        return false;
+    }
+    return true;
+}
+
+void dasAudio_record_stop ( void ) {
+    if ( !g_capture_initialized ) return;
+    ma_device_uninit(&g_capture_device);   // stops the device and joins the audio thread
+    g_capture_initialized = false;
+    ma_pcm_rb_uninit(&g_capture_rb);
+}
+
+// Drain up to out's length of interleaved f32 from the ring into out; returns FRAMES read
+// (0 if not recording or nothing buffered). out is caller-sized; frames = out.size / channels.
+int32_t dasAudio_record_read ( TArray<float> & out, Context *, LineInfoArg * ) {
+    if ( !g_capture_initialized ) return 0;
+    ma_uint32 channels = (ma_uint32) g_capture_channels;
+    if ( channels == 0 || out.size == 0 ) return 0;
+    ma_uint32 wantFrames = (ma_uint32)(out.size / channels);
+    float * dst = (float *) out.data;
+    ma_uint32 framesRead = 0;
+    while ( framesRead < wantFrames ) {
+        ma_uint32 chunk = wantFrames - framesRead;
+        void * pRead = nullptr;
+        if ( ma_pcm_rb_acquire_read(&g_capture_rb, &chunk, &pRead) != MA_SUCCESS ) break;
+        if ( chunk == 0 ) { ma_pcm_rb_commit_read(&g_capture_rb, 0); break; }
+        memcpy(dst + (size_t)framesRead * channels, pRead, (size_t)chunk * channels * sizeof(float));
+        ma_pcm_rb_commit_read(&g_capture_rb, chunk);
+        framesRead += chunk;
+    }
+    return (int32_t) framesRead;
+}
+
+int32_t dasAudio_record_available ( void ) {
+    if ( !g_capture_initialized ) return 0;
+    return (int32_t) ma_pcm_rb_available_read(&g_capture_rb);
+}
+
+bool dasAudio_is_recording ( void ) {
+    return g_capture_initialized;
+}
+
+int64_t dasAudio_record_overflow_frames ( void ) {
+    return (int64_t) g_capture_overflow_frames.load(std::memory_order_relaxed);
+}
+
+int32_t dasAudio_record_device_count ( Context *, LineInfoArg * ) {
+    if ( !ensure_capture_context() ) return 0;
+    ma_device_info * pCapture = nullptr;
+    ma_uint32 captureCount = 0;
+    if ( ma_context_get_devices(&g_capture_context, nullptr, nullptr, &pCapture, &captureCount) != MA_SUCCESS ) return 0;
+    g_capture_device_cache.assign(pCapture, pCapture + captureCount);   // value-copy; ids survive next enumeration
+    return (int32_t) captureCount;
+}
+
+char * dasAudio_record_device_name ( int32_t index, Context * context, LineInfoArg * at ) {
+    if ( index < 0 || index >= (int32_t) g_capture_device_cache.size() ) return nullptr;
+    const char * name = g_capture_device_cache[index].name;
+    return context->allocateString(name, (uint64_t) strlen(name), at);
+}
+
+bool dasAudio_record_device_is_default ( int32_t index ) {
+    if ( index < 0 || index >= (int32_t) g_capture_device_cache.size() ) return false;
+    return g_capture_device_cache[index].isDefault != 0;
 }
 
 MA_API ma_result dasAudio_ma_resampler_init(const ma_resampler_config* pConfig, ma_resampler* pResampler) {
@@ -1034,6 +1219,25 @@ public:
             SideEffects::modifyExternal, "dasAudio_set_null_device")->args({"enabled"});
         addExtern<DAS_BIND_FUN(dasAudio_is_single_threaded)>(*this, lib, "audio_is_single_threaded",
             SideEffects::accessExternal, "dasAudio_is_single_threaded");
+        // ---- capture (microphone) ----
+        addExtern<DAS_BIND_FUN(dasAudio_record_start)>(*this, lib, "sound_record_start",
+            SideEffects::modifyExternal, "dasAudio_record_start")->args({"rate", "channels", "rb_frames", "device_index", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_record_stop)>(*this, lib, "sound_record_stop",
+            SideEffects::modifyExternal, "dasAudio_record_stop");
+        addExtern<DAS_BIND_FUN(dasAudio_record_read)>(*this, lib, "sound_record_read",
+            SideEffects::modifyArgumentAndExternal, "dasAudio_record_read")->args({"out", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_record_available)>(*this, lib, "sound_record_available",
+            SideEffects::accessExternal, "dasAudio_record_available");
+        addExtern<DAS_BIND_FUN(dasAudio_is_recording)>(*this, lib, "sound_is_recording",
+            SideEffects::accessExternal, "dasAudio_is_recording");
+        addExtern<DAS_BIND_FUN(dasAudio_record_overflow_frames)>(*this, lib, "sound_record_overflow_frames",
+            SideEffects::accessExternal, "dasAudio_record_overflow_frames");
+        addExtern<DAS_BIND_FUN(dasAudio_record_device_count)>(*this, lib, "sound_record_device_count",
+            SideEffects::modifyExternal, "dasAudio_record_device_count")->args({"context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_record_device_name)>(*this, lib, "sound_record_device_name",
+            SideEffects::modifyExternal, "dasAudio_record_device_name")->args({"index", "context", "at"});
+        addExtern<DAS_BIND_FUN(dasAudio_record_device_is_default)>(*this, lib, "sound_record_device_is_default",
+            SideEffects::accessExternal, "dasAudio_record_device_is_default")->args({"index"});
         addExtern<DAS_BIND_FUN(dasAudio_mixerContext),SimNode_ExtFuncCallRef>(*this, lib, "mixer_context",
             SideEffects::modifyExternal, "dasAudio_mixerContext");
         // enums

--- a/modules/dasAudio/src/dasAudio.cpp
+++ b/modules/dasAudio/src/dasAudio.cpp
@@ -438,7 +438,7 @@ void dasAudio_finalize ( void ) {
 // RT-thread capture callback: append the just-captured interleaved f32 frames to the ring. Pure
 // C++ — no daScript, no allocation, no lock. On overflow (drain loop fell behind) the excess is
 // dropped and counted; recording never blocks the audio thread.
-void capture_callback ( ma_device *, void *, const void * pInput, ma_uint32 frameCount ) {
+static void capture_callback ( ma_device *, void *, const void * pInput, ma_uint32 frameCount ) {
     if ( !g_capture_initialized || pInput == nullptr ) return;
     const float * src = (const float *) pInput;
     ma_uint32 channels = (ma_uint32) g_capture_channels;

--- a/modules/dasAudio/src/dasAudio.h
+++ b/modules/dasAudio/src/dasAudio.h
@@ -48,6 +48,19 @@ namespace das {
     void dasAudio_finalize ( void );
     void dasAudio_set_null_device ( bool enabled );
     bool dasAudio_is_single_threaded ();
+
+    // ---- capture (microphone) ----
+    // Separate capture device + a lock-free ring (ma_pcm_rb): the RT callback only writes C++-owned
+    // memory (no daScript context on the audio thread); scripts drain on the main thread via record_read.
+    bool dasAudio_record_start ( int32_t rate, int32_t channels, int32_t rb_frames, int32_t device_index, Context * context, LineInfoArg * at );
+    void dasAudio_record_stop ( void );
+    int32_t dasAudio_record_read ( TArray<float> & out, Context * context, LineInfoArg * at );
+    int32_t dasAudio_record_available ( void );
+    bool dasAudio_is_recording ( void );
+    int64_t dasAudio_record_overflow_frames ( void );
+    int32_t dasAudio_record_device_count ( Context * context, LineInfoArg * at );
+    char * dasAudio_record_device_name ( int32_t index, Context * context, LineInfoArg * at );
+    bool dasAudio_record_device_is_default ( int32_t index );
     MA_API ma_result dasAudio_ma_resampler_init(const ma_resampler_config* pConfig, ma_resampler* pResampler);
     MA_API void dasAudio_ma_resampler_uninit(ma_resampler* pResampler);
     MA_API ma_result dasAudio_ma_channel_converter_init(const ma_channel_converter_config* pConfig, ma_channel_converter* pConverter);

--- a/modules/dasAudio/src/dasAudio.h
+++ b/modules/dasAudio/src/dasAudio.h
@@ -51,7 +51,7 @@ namespace das {
 
     // ---- capture (microphone) ----
     // Separate capture device + a lock-free ring (ma_pcm_rb): the RT callback only writes C++-owned
-    // memory (no daScript context on the audio thread); scripts drain on the main thread via record_read.
+    // memory (no daScript context on the audio thread); scripts drain on the main thread via sound_record_read.
     bool dasAudio_record_start ( int32_t rate, int32_t channels, int32_t rb_frames, int32_t device_index, Context * context, LineInfoArg * at );
     void dasAudio_record_stop ( void );
     int32_t dasAudio_record_read ( TArray<float> & out, Context * context, LineInfoArg * at );

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -187,12 +187,14 @@ IF(NOT DAS_SQLITE_DISABLED)
     list(FILTER AOT_SQL_CONFORMANCE_FILES EXCLUDE REGEX "/_")
 ENDIF()
 
-# AOT for strudel/audio module library files (required by strudel tests)
+# AOT for strudel/audio module library files (required by strudel tests;
+# audio_record is here for AOT-compile coverage of the capture module)
 SET(AOT_STRUDEL_MODULE_FILES)
 IF(NOT DAS_AUDIO_DISABLED)
     SET(AOT_STRUDEL_MODULE_FILES
         modules/dasAudio/audio/audio_boost.das
         modules/dasAudio/audio/audio_wav.das
+        modules/dasAudio/audio/audio_record.das
         modules/dasAudio/strudel/strudel_event.das
         modules/dasAudio/strudel/strudel_time.das
         modules/dasAudio/strudel/strudel_pattern.das

--- a/tests/audio/test_wav.das
+++ b/tests/audio/test_wav.das
@@ -98,3 +98,20 @@ def test_read_wav_bit_depths(t : T?) {
         }
     }
 }
+
+[test]
+def test_write_wav_guards(t : T?) {
+    t |> run("write_wav rejects invalid input and reports open failure") @(t : T?) {
+        let tmp = create_temp_file_result("das_write_wav_guard", ".wav")
+        if (!(tmp is value)) {
+            t |> failure("could not create a temp file")
+            return
+        }
+        let path = tmp as value
+        t |> success(!write_wav(path, [0.0, 0.5, -0.5], 44100u, 0), "rejects channels <= 0 (would divide by zero)")
+        t |> success(!write_wav(path, [0.0, 0.5, -0.5], 44100u, 2), "rejects a non-frame-aligned sample count")
+        t |> success(write_wav(path, [0.0, 0.5, -0.5, 0.25], 44100u, 2), "writes valid frame-aligned input")
+        t |> success(!write_wav("/nonexistent_dir_xyzzy_das/x.wav", [0.0], 44100u, 1), "returns false on an unwritable path")
+        remove(path)
+    }
+}

--- a/tests/strudel_device/test_record_capture.das
+++ b/tests/strudel_device/test_record_capture.das
@@ -1,0 +1,65 @@
+options gen2
+options indenting = 4
+options persistent_heap
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost
+require daslib/defer
+require audio/audio_record
+require audio
+require jobque
+require daslib/fio
+
+// Headless microphone-capture smoke test on miniaudio's NULL backend: the null device
+// feeds timer-paced silent frames, so start -> drain -> stop runs in CI with no real
+// hardware. Lives in this interpreter-only directory (gated off under --use-aot in
+// tests/.das_test) alongside the playback device tests — no capture device is AOT-driven,
+// matching the established "no device test is AOT'd" rule. Unlike playback, capture never
+// touches the mixer context (the RT callback only writes a lock-free C++ ring), so there is
+// no context race here; it is kept interp-only for consistency, not because of a known bug.
+
+[test]
+def test_record_capture_smoke(t : T?) {
+    t |> run("null-backend capture: start, drain silent frames, clean stop") @(t : T?) {
+        sound_set_null_device(true)
+        // reset the global null-backend flag on exit, so a later audio test in this process isn't forced onto it
+        defer() {
+            sound_set_null_device(false)
+        }
+        let before = count_jobque_leaks()
+        t |> success(sound_record_start(16000, 1, 16000, -1), "capture device should start on the null backend")
+        t |> success(sound_is_recording(), "should be recording after start")
+        var scratch : array<float>
+        scratch |> resize(16000)
+        var total = 0
+        for (_iter in range(30)) {   // ~600ms wall; the null device paces silent frames by run time
+            sleep(20u)
+            let n = sound_record_read(scratch)
+            t |> success(n >= 0, "record_read must never return a negative frame count")
+            total += n
+        }
+        t |> success(total > 0, "null backend should have produced capture frames")
+        t |> equal(sound_record_overflow_frames(), 0l)   // 1s ring drained every 20ms -> no overflow
+        sound_record_stop()
+        t |> success(!sound_is_recording(), "should not be recording after stop")
+        t |> equal(sound_record_available(), 0)          // device torn down -> nothing buffered
+        let after = count_jobque_leaks()
+        t |> equal(after, before)                        // capture allocates no jobque objects
+    }
+}
+
+[test]
+def test_record_device_enumeration(t : T?) {
+    t |> run("null-backend capture device enumeration") @(t : T?) {
+        sound_set_null_device(true)
+        defer() {
+            sound_set_null_device(false)
+        }
+        let devs <- sound_record_list_devices()
+        t |> equal(length(devs), sound_record_device_count())
+        for (d in devs) {
+            t |> success(d.index >= 0, "device index is non-negative")
+        }
+    }
+}

--- a/tests/strudel_device/test_record_capture.das
+++ b/tests/strudel_device/test_record_capture.das
@@ -88,5 +88,8 @@ def test_record_to_wav_roundtrip(t : T?) {
         t |> equal(got_channels, 1)
         t |> equal(length(samples), int(float(rate) * seconds))   // exact-length capping: 0.2s * 16000 = 3200 frames
         remove(path)
+        // a write failure must propagate: an unwritable output path returns false (not a silent success)
+        t |> success(!record_to_wav("/nonexistent_dir_xyzzy_das/rec.wav", 0.05, rate, 1),
+            "record_to_wav returns false when the WAV cannot be written")
     }
 }

--- a/tests/strudel_device/test_record_capture.das
+++ b/tests/strudel_device/test_record_capture.das
@@ -63,3 +63,30 @@ def test_record_device_enumeration(t : T?) {
         }
     }
 }
+
+[test]
+def test_record_to_wav_roundtrip(t : T?) {
+    t |> run("null-backend record_to_wav writes a readable WAV of exactly the requested length") @(t : T?) {
+        sound_set_null_device(true)
+        defer() {
+            sound_set_null_device(false)
+        }
+        let tmp = create_temp_file_result("das_record_to_wav_test", ".wav")   // unique writable path, no cwd assumptions
+        if (!(tmp is value)) {
+            t |> failure("could not create a temp file")
+            return
+        }
+        let path = tmp as value
+        let rate = 16000
+        let seconds = 0.2
+        t |> success(record_to_wav(path, seconds, rate, 1), "record_to_wav should succeed on the null backend")
+        var samples : array<float>
+        var got_rate = 0
+        var got_channels = 0
+        t |> success(read_wav(path, samples, got_rate, got_channels), "the written WAV should be readable back")
+        t |> equal(got_rate, rate)
+        t |> equal(got_channels, 1)
+        t |> equal(length(samples), int(float(rate) * seconds))   // exact-length capping: 0.2s * 16000 = 3200 frames
+        remove(path)
+    }
+}

--- a/tutorials/dasAudio/11_recording.das
+++ b/tutorials/dasAudio/11_recording.das
@@ -1,0 +1,135 @@
+// Tutorial AUDIO-11: Recording from the Microphone
+//
+// This tutorial covers:
+//   - Enumerating capture (input) devices with sound_record_list_devices
+//   - Recording to a WAV file with record_to_wav
+//   - The low-level capture loop: sound_record_start / sound_record_read / sound_record_stop
+//   - Reading the recording back with read_wav to confirm the round-trip
+//
+// Capture is independent of playback — you do NOT need with_audio_system here. The audio
+// thread fills a lock-free ring buffer; your script drains it on the main thread. Samples are
+// interleaved 32-bit float at the rate/channels you ask for.
+//
+// Run: daslang.exe tutorials/dasAudio/11_recording.das
+
+options gen2
+options persistent_heap
+options indenting = 4
+
+require audio/audio_record
+require audio
+require audio/audio_wav
+require daslib/fio
+require math
+
+let SAMPLE_RATE = 44100
+let CHANNELS = 1
+let OUT_FILE = "recording.wav"
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1 — Enumerate capture (microphone) devices
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Each AudioDeviceInfo carries a display name, whether it is the system default,
+// and an index. Pass that index to record_to_wav / sound_record_start as
+// device_index to target a specific microphone; -1 always means "system default".
+
+def list_devices() {
+    print("=== Section 1: Capture devices ===\n")
+    let devices <- sound_record_list_devices()
+    if (empty(devices)) {
+        print("  no capture devices found\n")
+        return
+    }
+    for (d in devices) {
+        let tag = d.is_default ? " (default)" : ""
+        print("  [{d.index}] {d.name}{tag}\n")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2 — Record two seconds to a WAV file (the easy way)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// record_to_wav opens the default capture device, records for the requested
+// duration, writes a 16-bit PCM WAV, and returns false if the device could not
+// be opened (e.g. no microphone, or the OS denied access). Pass a device_index
+// as the last argument to record from a specific device instead of the default.
+
+def record_clip() : bool {
+    print("\n=== Section 2: Record {2.0} seconds to {OUT_FILE} ===\n")
+    print("  speak into the microphone...\n")
+    let ok = record_to_wav(OUT_FILE, 2.0, SAMPLE_RATE, CHANNELS)
+    if (!ok) {
+        print("  recording failed (no microphone, or access denied)\n")
+        return false
+    }
+    print("  wrote {OUT_FILE}\n")
+    return true
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 4 — The manual capture loop (what record_to_wav does inside)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// For live processing you drive the loop yourself: start the device, then poll
+// sound_record_read into a scratch buffer as fast as you consume it. Here we run
+// for ~1 second and report the peak amplitude and any dropped frames (overflow
+// means your drain loop fell behind the audio thread and the ring filled up).
+
+def manual_capture() {
+    print("\n=== Section 4: Manual capture loop (~1s) ===\n")
+    if (!sound_record_start(SAMPLE_RATE, CHANNELS, SAMPLE_RATE, -1)) {
+        print("  could not open capture device\n")
+        return
+    }
+    var scratch : array<float>
+    scratch |> resize(SAMPLE_RATE * CHANNELS)
+    var frames = 0
+    var peak = 0.0
+    while (frames < SAMPLE_RATE) {
+        let n = sound_record_read(scratch)
+        if (n > 0) {
+            for (i in range(n * CHANNELS)) {
+                peak = max(peak, abs(scratch[i]))
+            }
+            frames += n
+        } else {
+            sleep(5u)
+        }
+    }
+    sound_record_stop()
+    print("  captured {frames} frames, peak amplitude {peak}, dropped {sound_record_overflow_frames()} frames\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Read the recording back
+// ──────────────────────────────────────────────────────────────────────────
+//
+// read_wav (from audio/audio_wav) decodes the file we just wrote, so we can
+// confirm the round-trip: same channel count, and a sample count that matches
+// the duration we asked for.
+
+def verify_clip() {
+    print("\n=== Section 3: Read {OUT_FILE} back ===\n")
+    var samples : array<float>
+    var rate = 0
+    var channels = 0
+    if (!read_wav(OUT_FILE, samples, rate, channels)) {
+        print("  could not read {OUT_FILE} (was it recorded?)\n")
+        return
+    }
+    let seconds = float(length(samples) / channels) / float(rate)
+    print("  {length(samples)} samples, {channels}ch @ {rate}Hz = {seconds} seconds\n")
+}
+
+[export]
+def main() {
+    print("AUDIO-11: Recording from the Microphone\n\n")
+    list_devices()
+    if (record_clip()) {
+        verify_clip()
+    }
+    manual_capture()
+    print("\nDone!\n")
+}

--- a/tutorials/dasAudio/11_recording.das
+++ b/tutorials/dasAudio/11_recording.das
@@ -69,6 +69,27 @@ def record_clip() : bool {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Section 3 — Read the recording back
+// ──────────────────────────────────────────────────────────────────────────
+//
+// read_wav (from audio/audio_wav) decodes the file we just wrote, so we can
+// confirm the round-trip: same channel count, and a sample count that matches
+// the duration we asked for.
+
+def verify_clip() {
+    print("\n=== Section 3: Read {OUT_FILE} back ===\n")
+    var samples : array<float>
+    var rate = 0
+    var channels = 0
+    if (!read_wav(OUT_FILE, samples, rate, channels)) {
+        print("  could not read {OUT_FILE} (was it recorded?)\n")
+        return
+    }
+    let seconds = float(length(samples) / channels) / float(rate)
+    print("  {length(samples)} samples, {channels}ch @ {rate}Hz = {seconds} seconds\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Section 4 — The manual capture loop (what record_to_wav does inside)
 // ──────────────────────────────────────────────────────────────────────────
 //
@@ -100,27 +121,6 @@ def manual_capture() {
     }
     sound_record_stop()
     print("  captured {frames} frames, peak amplitude {peak}, dropped {sound_record_overflow_frames()} frames\n")
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// Section 3 — Read the recording back
-// ──────────────────────────────────────────────────────────────────────────
-//
-// read_wav (from audio/audio_wav) decodes the file we just wrote, so we can
-// confirm the round-trip: same channel count, and a sample count that matches
-// the duration we asked for.
-
-def verify_clip() {
-    print("\n=== Section 3: Read {OUT_FILE} back ===\n")
-    var samples : array<float>
-    var rate = 0
-    var channels = 0
-    if (!read_wav(OUT_FILE, samples, rate, channels)) {
-        print("  could not read {OUT_FILE} (was it recorded?)\n")
-        return
-    }
-    let seconds = float(length(samples) / channels) / float(rate)
-    print("  {length(samples)} samples, {channels}ch @ {rate}Hz = {seconds} seconds\n")
 }
 
 [export]


### PR DESCRIPTION
## Summary

Adds microphone **capture** to dasAudio, which was playback-only. A dedicated `ma_device_type_capture` device (independent of playback) feeds a lock-free `ma_pcm_rb` from the RT callback; scripts drain it on the main thread via `sound_record_read` — no daScript context ever runs on the audio thread, which is what lets captured data cross into a context safely.

## API

**C++ module `audio`** (`modules/dasAudio/src/dasAudio.cpp`):
- `sound_record_start(rate, channels, rb_frames, device_index) : bool` · `sound_record_stop()` · `sound_record_read(var buf : array<float>) : int`
- `sound_record_available() : int` · `sound_is_recording() : bool` · `sound_record_overflow_frames() : int64`
- Device enumeration: `sound_record_device_count` / `sound_record_device_name` / `sound_record_device_is_default`
- Capture teardown folded into `sound_finalize`; honors the existing null-backend flag for headless CI.

**das module `audio/audio_record.das`**:
- `AudioDeviceInfo`, `sound_record_list_devices() : array<AudioDeviceInfo>`
- `record_to_wav(fname, seconds, rate, channels, device_index) : bool` (layered over `write_wav`)

Native-rate interleaved f32; resample separately via the `ma_resampler_*` bindings for another format (e.g. 16 kHz mono for speech models).

## Design

- **Pull model** (ring buffer + main-thread drain), not a push callback — fits daslang's context-isolation rule (the RT thread only writes C++-owned memory).
- **Separate capture device**, not duplex — recording has its own lifecycle, independent of playback.
- **Index-based device selection** via a persistent capture context (miniaudio's opaque `ma_device_id` must outlive enumeration and stay valid for the device's lifetime).

## Tests &amp; docs

- `tests/strudel_device/test_record_capture.das` — null-backend smoke (start → drain silent frames → clean stop, no jobque leak) + device enumeration. Interpreter-only, matching the established "no device test is AOT'd" convention (the null device feeds timer-paced silent frames, so it runs headless).
- AOT-compile coverage: `audio_record.das` added to `AOT_STRUDEL_MODULE_FILES` so `test_aot` AOT-compiles the capture module.
- Tutorial `tutorials/dasAudio/11_recording.das` + RST (toctree + prev/next chain); stdlib doc entries for the new `audio_record` module and the 9 new `sound_record_*` functions.

## Verification

- **Real mic on macOS**: non-zero captured signal — no Info.plist / entitlement needed (the controlling terminal's mic-access grant covers the child `daslang` process; enumeration never needs permission).
- **Null backend** end-to-end; clean device teardown.
- **Lint** clean on all changed `.das`; **formatter `--verify`** clean; **HTML + LaTeX Sphinx `-W`** both `build succeeded` (0 warnings).
- **AOT**: `test_aot` builds + links; strudel AOT sweep 637/637, audio AOT 12/12; capture module AOT-compiles.
- **Full interpreted `tests/` sweep**: 10979 tests, 10973 passed, 0 failed, 0 errors, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)