### PR TITLE
mcp/lsp: cross-tree guard — warn when a file is queried against the wrong worktree's binder

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -339,6 +339,13 @@ jobs:
       run: |
         set -eux
         $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/mcp/test_tools.das
+        $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/mcp/test_crosstree_guard.das
+
+    - name: "Test LSP cross-tree guard (python)"
+      if: matrix.target == 'linux'
+      run: |
+        set -eux
+        python3 utils/lsp/test_crosstree_guard.py
 
     # Self-binders for dasClangBind + dasLLVM bindings live on the mingw
     # worker (build.yml build_windows_mingw) — see comment on the linux

--- a/utils/lsp/lsp_supervisor.py
+++ b/utils/lsp/lsp_supervisor.py
@@ -84,6 +84,22 @@ def find_compiler(init_options: dict) -> str | None:
     return shutil.which("daslang")
 
 
+def git_tree_root(start_dir: str | None) -> str | None:
+    """Nearest ancestor of start_dir holding a `.git` entry — a directory in the main tree,
+    a file in a linked worktree; os.path.exists catches both. None if none is found."""
+    if not start_dir:
+        return None
+    d = os.path.abspath(start_dir)
+    for _ in range(64):
+        if os.path.exists(os.path.join(d, ".git")):
+            return d
+        up = os.path.dirname(d)
+        if up == d:
+            return None
+        d = up
+    return None
+
+
 class Server:
     def __init__(self):
         self.docs: dict[str, str] = {}
@@ -194,6 +210,11 @@ class Server:
         except Exception:
             tail = (err.decode("utf-8", "replace").strip() or text)[-400:]
             diags = [self.tool_diagnostic(f"daslang validate crashed: {tail}")]
+        # Flag cross-tree files: a clean compile in the WRONG worktree's binder is the most
+        # misleading case, so this is prepended even when diags is empty.
+        xt = self.crosstree_diagnostic(path)
+        if xt:
+            diags = [xt] + diags
         self.publish_if_current(uri, my_gen, diags)
 
     def publish_if_current(self, uri: str, my_gen: int, diags: list) -> None:
@@ -208,6 +229,41 @@ class Server:
         return {"range": {"start": {"line": 0, "character": 0},
                           "end": {"line": 0, "character": 1}},
                 "severity": 1, "source": "daslang-lsp", "message": message}
+
+    def crosstree_diagnostic(self, path: str) -> dict | None:
+        """Warning when `path` lives in a different git worktree than the daslang binary serving
+        it — that binary's compiled-in C++ bindings AND its module resolution come from its own
+        tree, so diagnostics here may be stale/wrong (missing symbols, outdated signatures).
+        Suppressed when -project_root is set and the file is under it (deliberate external-module
+        scoping)."""
+        binary_root = git_tree_root(os.path.dirname(self.compiler)) if self.compiler else None
+        file_root = git_tree_root(os.path.dirname(path))
+        if not binary_root or not file_root or binary_root == file_root:
+            return None
+        pr = self.init_options.get("project_root")
+        if pr:
+            # commonpath (normcased for Windows) handles the drive-root / trailing-separator / component-
+            # boundary edges a startswith(pr + sep) prefix check gets wrong; cross-drive -> ValueError.
+            try:
+                pr_abs = os.path.normcase(os.path.abspath(pr))
+                if os.path.commonpath([os.path.normcase(os.path.abspath(path)), pr_abs]) == pr_abs:
+                    return None
+            except ValueError:
+                pass
+        has = lambda rel: os.path.exists(os.path.join(file_root, rel))
+        if has("bin/daslang") or has("bin/daslang.exe"):
+            hint = (f"that worktree is bootstrapped — open a session rooted in {file_root}"
+                    if has(".mcp.json") else
+                    f"that worktree has a binary but no MCP config — run "
+                    f"`daslang utils/mcp/setup.das -- --root {file_root} --no-build`")
+        else:
+            hint = f"that worktree isn't bootstrapped — run `daslang utils/mcp/setup.das -- --root {file_root}`"
+        d = self.tool_diagnostic(
+            f"CROSS-TREE: this file is in a different git worktree ({file_root}) than the daslang "
+            f"binder serving it ({binary_root}). Diagnostics use that tree's module sources and its "
+            f"binary's compiled-in C++ bindings, so they may be STALE or wrong here. {hint}.")
+        d["severity"] = 2  # warning, not error
+        return d
 
     def write_overlay(self, uri: str | None) -> str | None:
         """Document-shadow text -> temp file for the subtool's --overlay flag.

--- a/utils/lsp/test_crosstree_guard.py
+++ b/utils/lsp/test_crosstree_guard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Standalone regression test for the LSP cross-tree guard (lsp_supervisor.crosstree_diagnostic).
+
+Builds two throwaway git-style trees under a tempdir and checks: a file in a different tree than
+the binary warns (severity 2, with the right bootstrap hint); a file in the binary's own tree is
+silent; and an explicit -project_root that scopes the file suppresses the warning.
+
+Run:  python3 utils/lsp/test_crosstree_guard.py   (exit 0 = pass)
+"""
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lsp_supervisor as L
+
+
+def make_tree(base, name, *, with_bin=False, with_mcp=False):
+    root = os.path.join(base, name)
+    os.makedirs(os.path.join(root, "sub"), exist_ok=True)
+    open(os.path.join(root, ".git"), "w").close()  # worktree-style .git file (a dir also works)
+    if with_bin:
+        os.makedirs(os.path.join(root, "bin"), exist_ok=True)
+        open(os.path.join(root, "bin", "daslang"), "w").close()
+    if with_mcp:
+        open(os.path.join(root, ".mcp.json"), "w").close()
+    return root
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="lsp_crosstree_")
+    try:
+        binroot = make_tree(tmp, "binder", with_bin=True)
+        wt_bin = make_tree(tmp, "worktree-bin", with_bin=True)              # binary, no mcp
+        wt_boot = make_tree(tmp, "worktree-boot", with_bin=True, with_mcp=True)  # bootstrapped
+        wt_bare = make_tree(tmp, "worktree-bare")                           # nothing
+
+        s = L.Server()
+        s.compiler = os.path.join(binroot, "bin", "daslang")
+        s.init_options = {}
+
+        # git_tree_root basics
+        assert L.git_tree_root(os.path.join(wt_bin, "sub")) == wt_bin, "git_tree_root walks up to .git"
+
+        # cross-tree, binary-but-no-mcp -> warn with the --no-build hint
+        d = s.crosstree_diagnostic(os.path.join(wt_bin, "sub", "x.das"))
+        assert d and d["severity"] == 2 and "CROSS-TREE" in d["message"], "cross-tree must warn"
+        assert "no MCP config" in d["message"] and "--no-build" in d["message"], "bin-but-no-mcp hint"
+
+        # cross-tree, bootstrapped -> "start a session rooted"
+        d2 = s.crosstree_diagnostic(os.path.join(wt_boot, "sub", "x.das"))
+        assert d2 and "bootstrapped" in d2["message"] and "session rooted" in d2["message"], "bootstrapped hint"
+
+        # cross-tree, bare -> "isn't bootstrapped"
+        d3 = s.crosstree_diagnostic(os.path.join(wt_bare, "sub", "x.das"))
+        assert d3 and "isn't bootstrapped" in d3["message"], "not-bootstrapped hint"
+
+        # same tree as the binary -> silent
+        assert s.crosstree_diagnostic(os.path.join(binroot, "sub", "y.das")) is None, "same-tree silent"
+
+        # -project_root scoping the file -> suppressed
+        s.init_options = {"project_root": wt_bin}
+        assert s.crosstree_diagnostic(os.path.join(wt_bin, "sub", "x.das")) is None, "project_root-scoped silent"
+
+        print("OK: LSP cross-tree guard (5 cases)")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mcp/protocol_core.das
+++ b/utils/mcp/protocol_core.das
@@ -325,7 +325,10 @@ def handle_tools_call(reg : array<ToolDef>; id_json : string; params : JsonValue
     let project = get_string_arg(args, "project")
     let project_root = get_string_arg(args, "project_root")
     var load_modules <- get_string_array_arg(args, "load_modules")
-    return jsonrpc::response(id_json, run_tool(handler, name, main_thread, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root, load_modules))
+    let tool_result = run_tool(handler, name, main_thread, arg1, arg2, arg3, arg4, arg5, arg6, project, project_root, load_modules)
+    // Flag cross-tree file queries: if `file` is an absolute path outside this server's root, the
+    // result was produced against the wrong tree's modules + compiled bindings and may be stale.
+    return jsonrpc::response(id_json, guard_crosstree(tool_result, get_string_arg(args, "file"), project_root))
 }
 
 // ── JSON-RPC dispatcher ──────────────────────────────────────────────

--- a/utils/mcp/test_crosstree_guard.das
+++ b/utils/mcp/test_crosstree_guard.das
@@ -1,0 +1,84 @@
+options gen2
+
+require dastest/testing_boost public
+require tools/common
+require daslib/fio
+require strings
+
+// Unit tests for the MCP cross-tree guard (tools/common.das): a file whose absolute path is
+// outside the server root must warn; in-tree absolute + relative + empty must stay silent.
+// Portable — the root is getcwd(), the cross-tree path is a synthetic sibling outside it.
+
+[test]
+def test_crosstree_guard(t : T?) {
+    let root = getcwd()
+
+    t |> run("in-tree absolute path → silent") @(t : T?) {
+        let w = crosstree_warning(path_join(root, "utils/mcp/main.das"), root)
+        t |> success(empty(w), "no warning for a file under the server root")
+    }
+
+    t |> run("cross-tree absolute path → warns") @(t : T?) {
+        // a sibling of the root that isn't under it → relative() yields a leading ".."
+        let outside = path_join(dir_name(root), "some-other-worktree/x.das")
+        let w = crosstree_warning(outside, root)
+        t |> success(!empty(w), "warns for a file outside the server root")
+        t |> success(find(w, "CROSS-TREE WARNING") >= 0, "warning is labelled")
+    }
+
+    t |> run("relative path → silent") @(t : T?) {
+        let w = crosstree_warning("utils/mcp/main.das", root)
+        t |> success(empty(w), "relative paths resolve against the server cwd (in-tree)")
+    }
+
+    t |> run("empty file arg → silent") @(t : T?) {
+        t |> success(empty(crosstree_warning("", root)), "no file, no warning")
+    }
+
+    t |> run("a dir named \"..foo\" under the root → silent (not an escape)") @(t : T?) {
+        let w = crosstree_warning(path_join(root, "..foo/x.das"), root)
+        t |> success(empty(w), "a first segment merely beginning with .. stays in-tree")
+    }
+
+    t |> run("relative project_root is resolved to absolute → cross-tree still detected") @(t : T?) {
+        let outside = path_join(dir_name(root), "some-other-worktree/x.das")
+        // project_root "." resolves to the cwd; the outside file still escapes it (regression: a
+        // relative root used to make relative_result error and silence the warning)
+        t |> success(!empty(crosstree_warning(outside, ".")), "relative root resolved, still warns")
+    }
+
+    t |> run("comma list with a cross-tree first entry → warns") @(t : T?) {
+        let outside = path_join(dir_name(root), "some-other-worktree/a.das")
+        let w = crosstree_warning("{outside},{path_join(root, "b.das")}", root)
+        t |> success(!empty(w), "checks the first path of a comma list")
+    }
+
+    t |> run("multi-path parsing: whitespace / non-first / newline entries all checked") @(t : T?) {
+        let outside = path_join(dir_name(root), "some-other-worktree/x.das")
+        let intree = path_join(root, "a.das")
+        t |> success(!empty(crosstree_warning(" {outside}", root)), "leading whitespace is stripped")
+        t |> success(!empty(crosstree_warning("{intree},{outside}", root)), "a cross-tree entry that isn't first still warns")
+        t |> success(!empty(crosstree_warning("{intree}\n{outside}", root)), "newline-separated lists are split")
+    }
+
+    t |> run("guard_crosstree splices a leading content block for cross-tree") @(t : T?) {
+        let outside = path_join(dir_name(root), "some-other-worktree/x.das")
+        let base = make_tool_result("original output")
+        let guarded = guard_crosstree(base, outside, root)
+        t |> success(guarded != base, "result changed")
+        t |> success(find(guarded, "CROSS-TREE WARNING") >= 0, "warning present")
+        t |> success(find(guarded, "original output") >= 0, "original text preserved")
+        // in-tree → unchanged
+        let g2 = guard_crosstree(base, path_join(root, "x.das"), root)
+        t |> success(g2 == base, "in-tree result untouched")
+    }
+
+    t |> run("guard_crosstree keeps JSON valid for an empty content array") @(t : T?) {
+        let outside = path_join(dir_name(root), "some-other-worktree/x.das")
+        let guarded = guard_crosstree("\{\"content\":[],\"isError\":false}", outside, root)
+        t |> success(find(guarded, "CROSS-TREE WARNING") >= 0, "warning inserted")
+        t |> success(find(guarded, ",]") < 0, "no trailing comma before the array close")
+        var err : string
+        t |> success(read_json(guarded, err) != null, "result still parses as JSON")
+    }
+}

--- a/utils/mcp/tools/common.das
+++ b/utils/mcp/tools/common.das
@@ -52,6 +52,109 @@ def make_tool_result(text : string; is_error : bool = false) : string {
     return sprint_json(result, false)
 }
 
+// ── Cross-tree guard ─────────────────────────────────────────────────
+// When a tool is asked about a file that lives OUTSIDE this server's root (a different git
+// worktree), the answer is produced against THIS root's module sources and THIS binary's
+// compiled-in C++ bindings — so it can be stale/wrong for that file (missing symbols, outdated
+// signatures). Detect it and prepend a warning so the caller knows the result is suspect.
+
+// Walk up from `start_dir` to the nearest ancestor holding a `.git` entry — a directory in the
+// main tree, a file in a linked worktree; `fexist` catches both. "" if none within a bounded walk.
+def private git_tree_root(start_dir : string) : string {
+    var d = normalize(start_dir)
+    for (_ in range(64)) {
+        if (fexist(path_join(d, ".git"))) {
+            return d
+        }
+        let up = dir_name(d)
+        if (empty(up) || up == d) {
+            break
+        }
+        d = up
+    }
+    return ""
+}
+
+// How to make a cross-tree worktree queryable: depends on whether it's been bootstrapped.
+def private bootstrap_hint(tree : string) : string {
+    if (empty(tree)) {
+        return "couldn't locate its git root"
+    }
+    let has_bin = fexist(path_join(tree, "bin/daslang")) || fexist(path_join(tree, "bin/daslang.exe"))
+    let has_mcp = fexist(path_join(tree, ".mcp.json"))
+    if (has_bin && has_mcp) {
+        return "that worktree is bootstrapped — start a session rooted in {tree} to query it correctly"
+    }
+    if (has_bin) {
+        return "that worktree has a binary but no MCP config — run `daslang utils/mcp/setup.das -- --root {tree} --no-build`, then query from a session rooted there"
+    }
+    return "that worktree isn't bootstrapped — run `daslang utils/mcp/setup.das -- --root {tree}`, then query from a session rooted there"
+}
+
+// A `relative()` result escapes its base only when its first segment is `..` — exactly ".." or a
+// "../" prefix. A segment that merely begins with ".." (a dir named "..foo") stays inside the base.
+def private escapes_root(rel : string) : bool {
+    return rel == ".." || starts_with(rel, "../")
+}
+
+//! The cross-tree warning for a `file` argument — "" when every path it names is relative
+//! (server-cwd-relative, so in-tree) or under the server's root (`project_root` if given, else the
+//! process cwd). Parses the arg the way the tools do (`parse_file_list`: comma/newline split,
+//! whitespace-stripped, empties skipped, globs expanded), so the guard sees the same files, and
+//! warns on the FIRST cross-tree path. Public so it can be unit-tested directly.
+def crosstree_warning(file_arg, project_root : string) : string {
+    if (empty(file_arg)) {
+        return ""
+    }
+    // resolve the effective root to an ABSOLUTE path — a relative project_root would otherwise make
+    // relative_result fail for every file and silence the guard entirely
+    let raw_root = empty(project_root) ? getcwd() : project_root
+    let root = is_absolute(raw_root) ? normalize(raw_root) : normalize(path_join(getcwd(), raw_root))
+    var paths : array<string>
+    parse_file_list(file_arg, paths)
+    for (p in paths) {
+        // relative paths resolve against the server's own cwd, so they are in-tree by construction
+        if (!is_absolute(p)) {
+            continue
+        }
+        let fileabs = normalize(p)
+        let rr = relative_result(fileabs, root)
+        // in-tree when the relative path computes AND doesn't escape upward; a compute error means
+        // different root names / volumes (Windows cross-drive) — that IS outside the root, so warn.
+        if (!(rr is error) && !escapes_root(to_generic_path(rr as value))) {
+            continue
+        }
+        let tree = git_tree_root(dir_name(fileabs))
+        return ("CROSS-TREE WARNING — this file is in a different worktree than this MCP server.\n" +
+                "  file:   {p}\n" +
+                "  server: {root}\n" +
+                "This server resolves modules AND its binary's compiled-in C++ bindings from its own root, " +
+                "so results for this file may be STALE or wrong (missing symbols, outdated signatures). " +
+                "{bootstrap_hint(tree)}.")
+    }
+    return ""
+}
+
+//! Prepend the cross-tree warning (if any) as a leading content block of a tool-result JSON.
+//! No-op (returns the input unchanged) when the file is in-tree, so the common path pays nothing
+//! beyond one path comparison.
+def guard_crosstree(result_json, file_arg, project_root : string) : string {
+    let warn = crosstree_warning(file_arg, project_root)
+    if (empty(warn)) {
+        return result_json
+    }
+    let item = sprint_json(ContentItem(_type = "text", text = warn), false)
+    let marker = "\"content\":["
+    let pos = find(result_json, marker)
+    if (pos < 0) {
+        return result_json
+    }
+    let cut = pos + length(marker)
+    // an empty content array ("content":[]) must not get a trailing comma — [item,] is invalid JSON
+    let sep = (cut < length(result_json) && slice(result_json, cut, cut + 1) == "]") ? "" : ","
+    return slice(result_json, 0, cut) + item + sep + slice(result_json, cut, length(result_json))
+}
+
 // Validate the `project` argument shared across MCP subtools. Empty is fine
 // (means "no project, default file access"). Non-empty must point at an
 // existing regular `.das_project` file. Returns empty on success, otherwise


### PR DESCRIPTION
## Problem

A Claude Code (or any LSP/MCP) session binds its daslang binder to the session's **workspace** tree — the binary is found relative to `CLAUDE_PROJECT_DIR`, and modules resolve from that root. When you edit files that live in a **different git worktree** than the session's, the diagnostics are produced against the *wrong* tree's module sources **and that binary's compiled-in C++ bindings**. The result: phantom errors (missing symbols, outdated signatures) — or, worse, a **clean compile that hides real problems**, because the file was checked against a tree it doesn't belong to.

The deciding factor is the **binary** — its compiled-in C++ can't be fixed by repointing `-project_root` — so correct diagnostics require a session rooted in the file's own worktree. Today nothing tells you when you've drifted; you just get silently wrong answers.

## Fix — a detector on both surfaces

When a queried file lives outside the binder's tree, warn. Never block; just surface that the result is suspect and how to fix it.

### MCP (`utils/mcp/tools/common.das` + `protocol_core.das`)

`guard_crosstree()` checks the `file` argument against the server's effective root (`project_root`, else `getcwd()`). An **absolute path outside** it gets a leading `CROSS-TREE WARNING` content block that names both roots plus a bootstrap hint — it walks up to the file's `.git` root and stats `bin/daslang` + `.mcp.json` to say either "bootstrapped, re-root your session" or "run `setup.das`". Relative and in-tree paths cost one `relative_result` comparison and nothing else. Wired once, in `handle_tools_call`. 7 unit tests in `utils/mcp/test_crosstree_guard.das`.

### LSP (`utils/lsp/lsp_supervisor.py`)

`crosstree_diagnostic()` compares the file's git-tree-root to the **binary's** tree; if they differ it prepends a **severity-2 warning diagnostic** — emitted **even when the compile is clean**, since a clean compile in the wrong tree is the most misleading case. Suppressed when `-project_root` deliberately scopes the file (the external-module junction workflow). 5 portable tests (throwaway git-style trees) in `utils/lsp/test_crosstree_guard.py`.

### Example warning

```
CROSS-TREE: this file is in a different git worktree (…/daScript-server) than the daslang
binder serving it (…/daScript). Diagnostics use that tree's module sources and its binary's
compiled-in C++ bindings, so they may be STALE or wrong here. that worktree has a binary but
no MCP config — run `daslang utils/mcp/setup.das -- --root …/daScript-server --no-build`.
```

## Notes

- A `.git` entry is a **directory** in the main tree and a **file** in a linked worktree — `fexist` / `os.path.exists` catches both, so the detection works uniformly.
- The MCP side uses `fio.relative_result` (outside-base ⇒ leading `..`) rather than manual prefix-stripping, per the filesystem-skill rule.
- Independent of any feature branch — cuts straight from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)