### PR TITLE
compiler: automatic block inlining + invoke devirtualization; CSE/DSE v2 field chains

### DIFF
--- a/doc/source/stdlib/handmade/structure_annotation-rtti-CodeOfPolicies.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-rtti-CodeOfPolicies.rst
@@ -66,13 +66,18 @@ Allows float optimizations with major bit differences (x*0, x-x, reciprocal divi
 Disables the dead-store-elimination optimizer pass. Host-side counterpart of ``options disable_dse`` (the option overrides the policy).
 Disables the common-subexpression-elimination optimizer pass. Host-side counterpart of ``options disable_cse`` (the option overrides the policy).
 Disables ``[inline]`` splicing - annotated calls stay regular calls. The declaration-level contract checks (body shape, recursion through the inline graph, taking the address) still run; call-site splice checks do not apply, since nothing splices. Host-side counterpart of ``options disable_inline`` (the option overrides the policy).
+Disables automatic inlining: block-literal call sites stay regular calls and invoke-of-literal sites stay invokes. ``[inline]`` splicing is unaffected. Host-side counterpart of ``options disable_auto_inline`` (the option overrides the policy).
+Disables compile-time function evaluation (RunFolding of pure calls over constant arguments). Host-side counterpart of ``options disable_run`` (the option overrides the policy).
 Disables infer-time constant folding.
 Fails compilation if AOT is not available.
 Fails compilation if AOT export is not available.
 Log compile time.
 Log total compile time.
 Log detailed per-module compile-time breakdown. Each required module emits its own block with parse / infer (with pass count) / optimize / macro (in infer) / macro mods times plus function count. Also enables a separate ``simulate (...) took X, modName (fileName)`` line for every ``Program::simulate`` call and the top-level aggregate summary at the end of compilation. Wired to the daslang CLI flag ``-log-compile-time``.
+Log optimizer rewrites: per-pass fired/nothing lines plus inline/devirtualization sites and declines. Host-side counterpart of ``options log_optimization`` (the option overrides the policy).
+Log the AST after every optimizer pass (verbose). Host-side counterpart of ``options log_optimization_passes`` (the option overrides the policy).
 Disables fast call optimization.
+Fuses interpreter nodes into wider superinstructions at simulate time (on by default). Host-side counterpart of ``options fusion`` (the option overrides the policy).
 Reuse stack memory after variables go out of scope.
 Force in-scope for POD-like types.
 Log in-scope for POD-like types.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1600,13 +1600,18 @@ namespace das
         /*option*/ bool disable_dse = false;                       // disable the dead-store-elimination pass
         /*option*/ bool disable_cse = false;                       // disable the common-subexpression-elimination pass
         /*option*/ bool disable_inline = false;                    // disable the [inline] function inliner (calls stay regular calls; declaration-level contract checks - shape, recursion, @@ - still lint)
+        /*option*/ bool disable_auto_inline = false;               // disable automatic inlining of block-literal call sites and invoke-of-literal devirtualization ([inline] splicing is unaffected)
+        /*option*/ bool disable_run = false;                       // disable compile-time function evaluation (RunFolding of pure calls over constants)
         /*option*/ bool no_infer_time_folding = false;             // disable infer-time constant folding
         bool fail_on_no_aot = true;                     // AOT link failure is error
         bool fail_on_lack_of_aot_export = false;        // remove_unused_symbols = false is missing in the module, which is passed to AOT
         /*option*/ bool log_compile_time = false;                  // if true, then compile time will be printed at the end of the compilation
         /*option*/ bool log_total_compile_time = false;            // if true, then detailed compile time will be printed at the end of the compilation
         /*option*/ bool log_module_compile_time = false;           // if true, every required module logs its own parse / infer (with pass count) / optimize / macro (in infer) / macro mods breakdown + function count; also enables per-context simulate timing and the top-level aggregate summary (CLI: -log-compile-time)
+        /*option*/ bool log_optimization = false;                  // log optimizer rewrites (per-pass fired/nothing lines, inline/devirt sites and declines)
+        /*option*/ bool log_optimization_passes = false;           // log the AST after every optimizer pass (verbose)
         /*option*/ bool no_fast_call = false;                      // disable fastcall
+        /*option*/ bool fusion = true;                             // fuse interpreter nodes into wider superinstructions at simulate time
         /*option*/ bool scoped_stack_allocator = true;             // reuse stack memory after variables out of scope
         /*option*/ bool force_inscope_pod = false;                 // force in-scope for POD-like types
         /*option*/ bool log_inscope_pod = false;                   // log in-scope for POD-like types

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -221,7 +221,7 @@ namespace das {
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
         static constexpr uint32_t getVersion () {
-            return 97;   // 97: Function::mustInline flag / CodeOfPolicies::disable_inline added
+            return 98;   // 98: CodeOfPolicies disable_auto_inline / disable_run / fusion added
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -694,7 +694,12 @@ typedef enum das_bool_policy {
     DAS_POLICY_FAST_MATH,                        // Allow float optimizations with major bit differences (x*0, x-x, rcp division, reassociation)
     DAS_POLICY_DISABLE_DSE,                      // Disable the dead-store-elimination pass
     DAS_POLICY_DISABLE_CSE,                      // Disable the common-subexpression-elimination pass
-    DAS_POLICY_DISABLE_INLINE                    // Disable [inline] splicing (calls stay regular calls; declaration-level contract checks - shape, recursion, @@ - still lint, call-site splice checks do not apply)
+    DAS_POLICY_DISABLE_INLINE,                   // Disable [inline] splicing (calls stay regular calls; declaration-level contract checks - shape, recursion, @@ - still lint, call-site splice checks do not apply)
+    DAS_POLICY_DISABLE_AUTO_INLINE,              // Disable automatic inlining of block-literal call sites and invoke-of-literal devirtualization ([inline] splicing is unaffected)
+    DAS_POLICY_DISABLE_RUN,                      // Disable compile-time function evaluation (RunFolding of pure calls over constant arguments)
+    DAS_POLICY_LOG_OPTIMIZATION,                 // Log optimizer rewrites (per-pass fired/nothing lines, inline/devirt sites and declines)
+    DAS_POLICY_LOG_OPTIMIZATION_PASSES,          // Log the AST after every optimizer pass (verbose)
+    DAS_POLICY_FUSION                            // Fuse interpreter nodes into wider superinstructions at simulate time (default: on)
 } das_bool_policy;
 
 // Integer policy fields (stack size, heap limits).

--- a/src/ast/ast_alias.h
+++ b/src/ast/ast_alias.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_expressions.h"
+
+namespace das {
+
+    // ===== shared alias model for the CSE / DSE passes =====
+    // A tracked CHAIN is a Field/At/Swizzle access path over a plain (non-ref) variable
+    // base: struct/tuple/bitfield fields and array/fixed-array/vector indexing only.
+    // Pointer or handled-type links, variant access, and table indexing (which inserts on
+    // read) fall outside the model. Soundness rests on the access flags stamped by
+    // buildAccessFlags/TrackVariableFlags (ast_unused.cpp), which run at the top of every
+    // optimization round (optimizationUnused precedes CSE/DSE in ast_optimize.cpp):
+    //  * every write stamps `write` on the full access chain, including the base ExprVar -
+    //    statement stores, op-assign, addr-of, move sources, non-const for sources, and
+    //    call sites of argument-modifying callees (propagateModifiedArguments) alike;
+    //  * every read-through stamps `r2cr`, so `r2v | (r2cr && !write)` identifies an
+    //    occurrence that cannot modify the variable.
+    // A pass can therefore KILL facts about a base at statements that visibly store
+    // through it, and treat any other write-flagged chain root (pointer paths, globals,
+    // loop variables, block arguments) as OPAQUE - discarding every memory-derived fact.
+
+    struct AliasChain {
+        Variable *              base = nullptr;
+        ExprVar *               baseVar = nullptr;
+        vector<const char *>    path;       // field names, base-side first; nullptr marks an At/Swizzle link
+        vector<Expression *>    indices;    // At index subtrees (not part of the spine)
+        bool                    exact = true;       // no At/Swizzle links anywhere in the chain
+        bool                    anyWrite = false;   // some link carries a write flag
+    };
+
+    // peel Field/At/Swizzle/R2V links down to a variable base. returns false when a link
+    // is outside the model; `spine` (when given) collects every node consumed by the walk
+    // so a top-down scanner can avoid re-classifying interior links
+    inline bool aliasChainOf ( Expression * e, AliasChain & out, das_hash_set<Expression *> * spine = nullptr ) {
+        vector<const char *> rpath;         // outermost first, reversed at the end
+        vector<Expression *> seen;
+        for ( ;; ) {
+            seen.push_back(e);
+            if ( e->rtti_isR2V() ) {
+                e = static_cast<ExprRef2Value *>(e)->subexpr;
+            } else if ( e->rtti_isField() ) {   // exact class: safe-field and variant forms excluded
+                auto f = static_cast<ExprField *>(e);
+                if ( f->annotation ) return false;      // handled-type field or property
+                auto & vt = f->value->type;
+                if ( !vt || vt->isPointer() ) return false;
+                if ( !(vt->baseType==Type::tStructure || vt->baseType==Type::tTuple
+                    || vt->baseType==Type::tBitfield) ) return false;
+                out.anyWrite |= f->write;
+                rpath.push_back(f->name.c_str());
+                e = f->value;
+            } else if ( e->rtti_isAt() ) {      // exact class: safe-at excluded
+                auto a = static_cast<ExprAt *>(e);
+                auto & vt = a->subexpr->type;
+                if ( !vt ) return false;
+                if ( !(vt->baseType==Type::tArray || vt->baseType==Type::tFixedArray
+                    || vt->isVectorType()) ) return false;
+                out.anyWrite |= a->write;
+                out.exact = false;
+                out.indices.push_back(a->index);
+                rpath.push_back(nullptr);
+                e = a->subexpr;
+            } else if ( e->rtti_isSwizzle() ) {
+                auto s = static_cast<ExprSwizzle *>(e);
+                out.anyWrite |= s->write;
+                out.exact = false;
+                rpath.push_back(nullptr);
+                e = s->value;
+            } else if ( e->rtti_isVar() ) {
+                auto v = static_cast<ExprVar *>(e);
+                if ( !v->variable ) return false;
+                if ( v->variable->type && v->variable->type->ref ) return false;    // ref local: aliases elsewhere
+                out.anyWrite |= v->write;
+                out.baseVar = v;
+                out.base = v->variable;
+                out.path.assign(rpath.rbegin(), rpath.rend());
+                if ( spine ) for ( auto n : seen ) spine->insert(n);
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    // base-side prefix length known exactly (stops at the first At/Swizzle link)
+    inline size_t aliasChainExactLen ( const vector<const char *> & path ) {
+        for ( size_t i=0, is=path.size(); i!=is; ++i ) {
+            if ( !path[i] ) return i;
+        }
+        return path.size();
+    }
+
+    // paths agree on their first n links (caller keeps n within both exact prefixes)
+    inline bool aliasPathAgree ( const vector<const char *> & a, const vector<const char *> & b, size_t n ) {
+        for ( size_t i=0; i!=n; ++i ) {
+            if ( strcmp(a[i],b[i])!=0 ) return false;
+        }
+        return true;
+    }
+}

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -1488,7 +1488,7 @@ namespace das {
         visit(cfe);
         bool any = cfe.didAnything();
         if ( !cfe.needRun.empty() ) {
-            if ( !options.getBoolOption("disable_run",false) ) {
+            if ( !options.getBoolOption("disable_run", policies.disable_run) ) {
                 RunFolding rfe(this,cfe.needRun,round);
                 visit(rfe);
                 any |= rfe.didAnything();

--- a/src/ast/ast_cse.cpp
+++ b/src/ast/ast_cse.cpp
@@ -6,6 +6,8 @@
 #include "daScript/ast/ast_cfg.h"
 #include "daScript/misc/anyhash.h"
 
+#include "ast_alias.h"
+
 namespace das {
 
     // ===== Common-subexpression elimination (value reuse) =====
@@ -13,55 +15,77 @@ namespace das {
     // `let t = E` / `t = E` is available on every path to the occurrence (forward
     // availability over the statement-level CFG, ast_cfg.h) and t's declaration is
     // lexically visible there. No temps are created and no statements are inserted -
-    // v1 only reuses values the program already named, so every rewrite strictly
+    // the pass only reuses values the program already named, so every rewrite strictly
     // removes work. Reuse is bit-exact (the reused value came from the same pure
     // computation over unchanged inputs), so there is no fast_math gate.
     //
-    // Soundness model (deliberately narrow):
-    //  * leaves are ExprLet locals and function arguments of by-value types (non-ref,
-    //    non-refType) where every occurrence is a value read (r2v) or the left side
-    //    of a statement-level ExprCopy - anything else (addr(), by-ref pass,
-    //    field/index/swizzle access, op-assign, ref binding, clone/move target)
-    //    disqualifies the variable, which rules out invisible writes;
+    // Soundness model - two leaf disciplines (shared chain model in ast_alias.h):
+    //  * VALUE leaves are ExprLet locals and function arguments of by-value types where
+    //    every occurrence provably cannot modify the variable: a value read (r2v), a
+    //    read-through (r2cr without write - const-ref passes, read chains), or the base
+    //    of a statement-level ExprCopy store (a visible kill). Any other occurrence -
+    //    addr(), mutable-ref pass, op-assign, move/clone target - disqualifies the
+    //    variable. Pairs over value leaves die only on visible stores to their leaves;
+    //  * MEMORY leaves are Field/At/Swizzle chains (ast_alias.h) rooted at any non-ref
+    //    local or argument. They are never disqualified; instead a pair that reads
+    //    memory is killed by any visible store through its base, by any store through
+    //    an untracked target (pointer paths, block arguments - the statement goes
+    //    OPAQUE), and by any call that may write memory the pass cannot see (anything
+    //    beyond modifyArgument, whose writes stamp the argument chains at the call
+    //    site). Writes through loop variables kill the loop source's base; stores
+    //    through global or argument bases kill all argument-rooted pairs (an argument
+    //    may alias a global or another argument, but never a local);
     //  * candidate expressions are side-effect-free trees of Op1/Op2/Op3/Call/Cast/
-    //    Swizzle over leaves and constants - no memory reads (field/at/deref), so a
-    //    candidate's value can only change through a visible store to a leaf;
-    //  * pointer/handle-returning calls are excluded even when flagged pure: a
-    //    factory like clone_type returns a fresh, uniquely-owned node per
-    //    evaluation - value-equal is not identity-equal (found live in
-    //    daslib/linq_fold_common, where merging two clone_type calls aliased one
-    //    TypeDecl into two owners);
-    //  * pairs (E -> t) come from `let t = E` and statement-level `t = E` where t is
-    //    itself a clean local; a store to any leaf mentioned by E (or to t) kills the
-    //    pair; make-block interiors neither generate pairs nor get rewritten;
-    //  * a rewrite additionally requires t's declaration to be lexically visible at
-    //    the occurrence - dataflow availability alone is not enough: a pair born in a
-    //    closed `{ }` scope may still be "available" after it, while t's stack slot
-    //    is already reused by a sibling scope;
+    //    Swizzle/Field/At over leaves and constants;
+    //  * pointer/handle-returning calls are excluded even when flagged pure: a factory
+    //    like clone_type returns a fresh, uniquely-owned node per evaluation - value-
+    //    equal is not identity-equal (found live in daslib/linq_fold_common);
+    //  * pairs (E -> t) come from `let t = E` and statement-level `t = E` where t is a
+    //    clean VALUE leaf; make-block interiors neither generate pairs nor get
+    //    rewritten (their execution count is unknown), but their stores and calls do
+    //    contribute kills to the statement that owns the literal;
+    //  * a rewrite additionally requires t's declaration to be lexically visible at the
+    //    occurrence - dataflow availability alone is not enough: a pair born in a
+    //    closed `{ }` scope may still be "available" after it, while t's stack slot is
+    //    already reused by a sibling scope;
     //  * functions carrying control flow the CFG does not model are skipped whole:
     //    goto/label (also covers lowered generators), try/recover, and non-empty
     //    finally - same rule as DSE (ast_dse.cpp).
 
     namespace {
 
+        // call-side effects that may write memory invisibly at the call site.
+        // modifyArgument is visible (argument chains are write-stamped at the call by
+        // propagateModifiedArguments); unsafe alone writes nothing; captureString
+        // retains string data but writes no tracked memory. accessExternal shares the
+        // modifyExternal bit, so pointer READS pay the conservative price
+        constexpr uint32_t CSE_OPAQUE_CALL_EFFECTS =
+              uint32_t(SideEffects::modifyExternal)
+            | uint32_t(SideEffects::accessGlobal)
+            | uint32_t(SideEffects::invoke)
+            | uint32_t(SideEffects::userScenario);
+
+        bool cseIsMove ( const Expression * e ) {
+            return e->__rtti && strcmp(e->__rtti,"ExprMove")==0;
+        }
+
         struct CseAnchor {
             ExprBlock * block = nullptr;
             int         index = -1;     // statement index within the block
         };
 
-        // one walk: (a) bail on constructs the CFG does not model, (b) collect
-        // candidate leaves and their declaration anchors, (c) disqualify any variable
-        // with a use that is not a plain value read and not the lvalue of a
-        // statement-level assignment, (d) record the lexical anchor of every
+        // one walk: (a) bail on constructs the CFG does not model, (b) collect candidate
+        // leaves and their declaration anchors, (c) disqualify any VALUE variable with
+        // an occurrence that can modify it, (d) record the lexical anchor of every
         // expression the CFG carries as a statement (block statements, if/while
         // conditions, for sources, with subjects) for the scope-visibility check
         class CsePrescan : public Visitor {
         public:
             bool eligible = true;
             vector<Variable *> locals;                      // ExprLet locals of by-value type, in order
-            das_hash_set<Variable *> disq;                  // variables with an aliasing-capable use
-            das_hash_set<Expression *> storeLefts;          // lvalue ExprVar nodes of statement-level copies
-            das_hash_set<Expression *> swizzleReads;        // ExprVar nodes under a value-read swizzle
+            vector<Variable *> allLocals;                   // every non-ref ExprLet local (chain bases)
+            das_hash_set<Variable *> disq;                  // VALUE variables with a modifying-capable use
+            das_hash_set<Expression *> storeBaseVars;       // base ExprVar nodes of statement-level store chains
             das_hash_map<Variable *, CseAnchor> declAt;     // where each local's ExprLet sits
             das_hash_map<Expression *, CseAnchor> anchorOf; // lexical anchor of potential CFG statements
             das_hash_map<ExprBlock *, CseAnchor> blockParent;
@@ -106,29 +130,23 @@ namespace das {
             }
             virtual void preVisit ( ExprCopy * expr ) override {
                 Visitor::preVisit(expr);
-                if ( expr==curStmt && expr->left->rtti_isVar() ) {
-                    storeLefts.insert(expr->left);
+                if ( expr==curStmt ) {
+                    AliasChain ch;
+                    if ( aliasChainOf(expr->left, ch) ) storeBaseVars.insert(ch.baseVar);
                 }
             }
             virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
                 Visitor::preVisitLet(let, var, last);
-                if ( var->type && !var->type->ref && !var->type->isRefType() ) {
-                    locals.push_back(var);
+                if ( var->type && !var->type->ref ) {
+                    allLocals.push_back(var);
                     declAt[var] = curAnchor();
-                }
-            }
-            virtual void preVisit ( ExprSwizzle * expr ) override {
-                Visitor::preVisit(expr);
-                // a value-read swizzle over a by-value local (v.x with r2v) cannot
-                // write or alias the variable - keep it a clean use
-                if ( expr->r2v && !expr->write && expr->value->rtti_isVar() ) {
-                    swizzleReads.insert(expr->value);
+                    if ( !var->type->isRefType() ) locals.push_back(var);
                 }
             }
             virtual void preVisit ( ExprVar * expr ) override {
                 Visitor::preVisit(expr);
-                if ( !expr->r2v && storeLefts.find(expr)==storeLefts.end()
-                    && swizzleReads.find(expr)==swizzleReads.end() ) {
+                bool readOnly = expr->r2v || (expr->r2cr && !expr->write);
+                if ( !readOnly && storeBaseVars.find(expr)==storeBaseVars.end() ) {
                     disq.insert(expr->variable);
                 }
             }
@@ -150,6 +168,12 @@ namespace das {
             }
         };
 
+        struct CseUniverse {
+            das_hash_set<Variable *> valueLeaves;   // v1 discipline: every occurrence read-only or visible store
+            das_hash_set<Variable *> memBases;      // chain bases: non-ref locals and arguments
+            das_hash_set<Variable *> argVars;       // function arguments (may alias each other and globals)
+        };
+
         // a side-effect-free call returning a pointer/handle may still be a FACTORY
         // (clone_type & co return a fresh node each evaluation): results are
         // value-equal but not identity-equal, and reuse would alias something the
@@ -162,55 +186,87 @@ namespace das {
             return func && !func->builtIn;
         }
 
-        // whitelisted pure value tree over clean leaves and constants (no memory
-        // reads); collects the leaf variables the tree mentions
-        bool cseAllowedTree ( Expression * e, const das_hash_set<Variable *> & leaves, vector<Variable *> & mentions ) {
+        struct CseTreeInfo {
+            vector<Variable *>  mentions;           // leaf variables and chain bases the tree reads
+            bool                readsMemory = false;
+            bool                argRooted = false;
+        };
+
+        bool cseAllowedTree ( Expression * e, const CseUniverse & U, CseTreeInfo & info );
+
+        // a read chain over a tracked base is a MEMORY leaf: its value is stable until
+        // a store through the base or an opaque statement (both kill the pair)
+        bool cseChainLeaf ( Expression * e, const CseUniverse & U, CseTreeInfo & info ) {
+            AliasChain ch;
+            if ( !aliasChainOf(e, ch) ) return false;
+            if ( ch.anyWrite ) return false;
+            if ( U.memBases.find(ch.base)==U.memBases.end() ) return false;
+            for ( auto idx : ch.indices ) {
+                if ( !cseAllowedTree(idx, U, info) ) return false;
+            }
+            info.mentions.push_back(ch.base);
+            info.readsMemory = true;
+            if ( U.argVars.find(ch.base)!=U.argVars.end() ) info.argRooted = true;
+            return true;
+        }
+
+        // whitelisted pure value tree over clean leaves, read chains, and constants;
+        // collects the variables the tree mentions
+        bool cseAllowedTree ( Expression * e, const CseUniverse & U, CseTreeInfo & info ) {
             if ( !e ) return false;
             if ( e->rtti_isConstant() ) return true;
             if ( e->rtti_isVar() ) {
                 auto v = static_cast<ExprVar *>(e);
                 if ( v->write || !v->variable ) return false;
-                if ( leaves.find(v->variable)==leaves.end() ) return false;
-                mentions.push_back(v->variable);
+                if ( U.valueLeaves.find(v->variable)==U.valueLeaves.end() ) return false;
+                info.mentions.push_back(v->variable);
                 return true;
             }
             if ( e->rtti_isR2V() ) {
-                return cseAllowedTree(static_cast<ExprRef2Value *>(e)->subexpr, leaves, mentions);
+                return cseAllowedTree(static_cast<ExprRef2Value *>(e)->subexpr, U, info);
             }
             if ( e->rtti_isCopy() || e->rtti_isClone() || e->rtti_isSequence() ) return false;
+            if ( e->rtti_isField() || e->rtti_isAt() ) {
+                return cseChainLeaf(e, U, info);
+            }
             if ( e->rtti_isOp3() ) {
                 auto op = static_cast<ExprOp3 *>(e);
                 if ( cseIdentityProducing(e, op->func) ) return false;
-                return cseAllowedTree(op->subexpr, leaves, mentions)
-                    && cseAllowedTree(op->left, leaves, mentions)
-                    && cseAllowedTree(op->right, leaves, mentions);
+                return cseAllowedTree(op->subexpr, U, info)
+                    && cseAllowedTree(op->left, U, info)
+                    && cseAllowedTree(op->right, U, info);
             }
             if ( e->rtti_isOp2() ) {    // ExprMove's write-flagged left is caught by the ExprVar rule
                 auto op = static_cast<ExprOp2 *>(e);
                 if ( cseIdentityProducing(e, op->func) ) return false;
-                return cseAllowedTree(op->left, leaves, mentions)
-                    && cseAllowedTree(op->right, leaves, mentions);
+                return cseAllowedTree(op->left, U, info)
+                    && cseAllowedTree(op->right, U, info);
             }
             if ( e->rtti_isOp1() ) {
                 auto op = static_cast<ExprOp1 *>(e);
                 if ( cseIdentityProducing(e, op->func) ) return false;
-                return cseAllowedTree(op->subexpr, leaves, mentions);
+                return cseAllowedTree(op->subexpr, U, info);
             }
             if ( e->rtti_isCall() ) {
                 auto c = static_cast<ExprCall *>(e);
                 if ( !c->func ) return false;
                 if ( cseIdentityProducing(e, c->func) ) return false;
                 for ( auto & arg : c->arguments ) {
-                    if ( !cseAllowedTree(arg, leaves, mentions) ) return false;
+                    if ( cseAllowedTree(arg, U, info) ) continue;
+                    // a read chain passed by reference to a pure callee (length(s.arr))
+                    if ( cseChainLeaf(arg, U, info) ) continue;
+                    return false;
                 }
                 return true;
             }
             if ( e->rtti_isCast() ) {
-                return cseAllowedTree(static_cast<ExprCast *>(e)->subexpr, leaves, mentions);
+                return cseAllowedTree(static_cast<ExprCast *>(e)->subexpr, U, info);
             }
             if ( e->rtti_isSwizzle() ) {
                 auto s = static_cast<ExprSwizzle *>(e);
-                return !s->write && cseAllowedTree(s->value, leaves, mentions);
+                if ( s->write ) return false;
+                if ( cseAllowedTree(s->value, U, info) ) return true;   // swizzle over a value tree
+                return cseChainLeaf(e, U, info);                        // swizzle link over a chain
             }
             return false;   // unrecognized class - conservatively out
         }
@@ -220,7 +276,8 @@ namespace das {
             if ( !e || !e->type ) return false;
             if ( !e->noSideEffects ) return false;
             if ( !(e->rtti_isOp1() || e->rtti_isOp2() || e->rtti_isOp3()
-                || e->rtti_isCall() || e->rtti_isCast() || e->rtti_isSwizzle()) ) return false;
+                || e->rtti_isCall() || e->rtti_isCast() || e->rtti_isSwizzle()
+                || e->rtti_isField() || e->rtti_isAt()) ) return false;
             if ( e->rtti_isCopy() || e->rtti_isClone() || e->rtti_isSequence() ) return false;
             if ( e->type->ref || e->type->isRefType() ) return false;
             if ( e->type->baseType==Type::tVoid ) return false;
@@ -245,6 +302,14 @@ namespace das {
                 mix(uint64_t(uintptr_t(static_cast<ExprVar *>(e)->variable)));
             } else if ( e->rtti_isR2V() ) {
                 mix(cseHash(static_cast<ExprRef2Value *>(e)->subexpr));
+            } else if ( e->rtti_isField() ) {
+                auto f = static_cast<ExprField *>(e);
+                mix(hash_blockz64((const uint8_t *) f->name.c_str()));
+                mix(cseHash(f->value));
+            } else if ( e->rtti_isAt() ) {
+                auto a = static_cast<ExprAt *>(e);
+                mix(cseHash(a->subexpr));
+                mix(cseHash(a->index));
             } else if ( e->rtti_isOp3() ) {
                 auto op = static_cast<ExprOp3 *>(e);
                 mix(hash_blockz64((const uint8_t *) op->op.c_str()));
@@ -283,27 +348,112 @@ namespace das {
             Expression *        expr = nullptr;    // canonical E
             Variable *          var = nullptr;     // clean local holding E's value
             uint64_t            hash = 0;
-            vector<Variable *>  mentions;           // leaf variables E reads
+            vector<Variable *>  mentions;           // leaf variables and chain bases E reads
+            bool                readsMemory = false;
+            bool                argRooted = false;
         };
 
         struct CseStmtInfo {
             vector<int>         gen;                // pairs this statement (re)establishes
             vector<Variable *>  declVars;           // let-declared here (kill, before gen)
-            vector<Variable *>  storeVars;          // stored-to leaves in subtree (kill, before gen)
+            vector<Variable *>  storeVars;          // visibly stored-through bases in subtree (kill, before gen)
+            bool                opaque = false;     // may write memory invisibly: kill every memory pair
+            bool                killArgs = false;   // store through a global/argument base: kill argument-rooted pairs
         };
 
-        // stores to candidate leaves anywhere in a statement's subtree, including
-        // make-block interiors (a block argument body runs during the statement)
-        class CseWrites : public Visitor {
+        // per-statement effect collection, including make-block interiors (a block
+        // argument body runs - zero or more times - during the statement that owns the
+        // literal, and invoke-carrying calls at other statements are opaque anyway)
+        class CseEffects : public Visitor {
         public:
-            CseWrites ( const das_hash_set<Expression *> & sl ) : storeLefts(sl) {}
-            vector<Variable *> writes;
+            CseEffects ( const CseUniverse & u ) : U(u) {}
+            vector<Variable *> kills;
+            bool opaque = false;
+            bool killArgs = false;
         protected:
-            const das_hash_set<Expression *> & storeLefts;
+            const CseUniverse & U;
+            das_hash_set<Expression *> spine;   // chain links already classified from their top
+            void killBase ( Variable * v ) {
+                kills.push_back(v);
+                if ( U.argVars.find(v)!=U.argVars.end() ) killArgs = true;
+            }
+            bool tracked ( Variable * v ) const {
+                return U.memBases.find(v)!=U.memBases.end()
+                    || U.valueLeaves.find(v)!=U.valueLeaves.end();
+            }
+            // a store target: visible store through a tracked base is a kill; a loop
+            // variable forwards to its source's base; a global (which an argument may
+            // alias, but a local cannot) kills argument-rooted pairs; anything else -
+            // pointer paths, block arguments - makes the statement opaque
+            void classifyWrite ( Expression * e ) {
+                AliasChain ch;
+                if ( !aliasChainOf(e, ch, &spine) ) { opaque = true; return; }
+                if ( tracked(ch.base) ) {
+                    killBase(ch.base);
+                } else if ( ch.base->loop_source ) {
+                    classifyWrite(ch.base->loop_source);
+                } else if ( ch.baseVar->isGlobalVariable() ) {
+                    killArgs = true;
+                } else {
+                    opaque = true;
+                }
+            }
+            void writeRoot ( Expression * expr, bool w ) {
+                if ( !w ) return;
+                if ( spine.find(expr)!=spine.end() ) return;
+                classifyWrite(expr);
+            }
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisit ( ExprCopy * expr ) override {
+                Visitor::preVisit(expr);
+                classifyWrite(expr->left);
+            }
+            virtual void preVisit ( ExprMove * expr ) override {
+                Visitor::preVisit(expr);
+                classifyWrite(expr->left);  // the zeroed source arrives via its write flags
+            }
+            virtual void preVisit ( ExprClone * expr ) override {
+                Visitor::preVisit(expr);    // deep clones lower to calls during infer; a surviving
+                classifyWrite(expr->left);  // ExprClone is a flat builtin copy
+            }
+            virtual void preVisit ( ExprDelete * expr ) override {
+                Visitor::preVisit(expr);    // finalize zeroes the target (write flags may not cover it)
+                classifyWrite(expr->subexpr);
+            }
+            virtual void preVisit ( ExprRef2Ptr * expr ) override {
+                Visitor::preVisit(expr);
+                // taking the address writes nothing by itself; later writes through the
+                // escaped pointer arrive as pointer-path stores or impure calls (opaque)
+                AliasChain ch;
+                if ( aliasChainOf(expr->subexpr, ch, &spine) ) {
+                    if ( tracked(ch.base) ) killBase(ch.base);
+                }
+            }
             virtual void preVisit ( ExprVar * expr ) override {
                 Visitor::preVisit(expr);
-                if ( storeLefts.find(expr)!=storeLefts.end() ) writes.push_back(expr->variable);
+                writeRoot(expr, expr->write);
+            }
+            virtual void preVisit ( ExprField * expr ) override {
+                Visitor::preVisit(expr);
+                writeRoot(expr, expr->write);
+            }
+            virtual void preVisit ( ExprSwizzle * expr ) override {
+                Visitor::preVisit(expr);
+                writeRoot(expr, expr->write);
+            }
+            virtual void preVisit ( ExprAt * expr ) override {
+                Visitor::preVisit(expr);
+                writeRoot(expr, expr->write);
+            }
+            virtual void preVisitExpression ( Expression * expr ) override {
+                Visitor::preVisitExpression(expr);
+                if ( !expr->rtti_isCallLikeExpr() || expr->noSideEffects ) return;
+                if ( expr->rtti_isCopy() || expr->rtti_isClone() || cseIsMove(expr) ) return;  // classified above
+                if ( expr->rtti_isCallFunc() ) {
+                    auto func = static_cast<ExprCallFunc *>(expr)->func;
+                    if ( func && !(func->sideEffectFlags & CSE_OPAQUE_CALL_EFFECTS) ) return;
+                }
+                opaque = true;  // invoke, unresolved, or a callee that may write unseen memory
             }
         };
 
@@ -319,9 +469,13 @@ namespace das {
                 anchored = anch.block!=nullptr;
                 anchor = anch;
                 touched.clear();
+                stmtOpaque = false;
+                stmtKillArgs = false;
                 if ( si ) {
                     for ( auto v : si->declVars ) touched.insert(v);
                     for ( auto v : si->storeVars ) touched.insert(v);
+                    stmtOpaque = si->opaque;
+                    stmtKillArgs = si->killArgs;
                 }
                 suppress = 0;
             }
@@ -334,6 +488,8 @@ namespace das {
             das_hash_set<Variable *> touched;   // vars this statement declares or stores to
             CseAnchor anchor;
             bool anchored = false;
+            bool stmtOpaque = false;
+            bool stmtKillArgs = false;
             int suppress = 0;
             bool scopeValid ( Variable * v ) const {
                 auto dit = scan.declAt.find(v);
@@ -357,6 +513,8 @@ namespace das {
                     auto & P = pairs[pi];
                     // no reuse across a statement that writes P's inputs or holder -
                     // intra-statement evaluation order is not modeled
+                    if ( P.readsMemory && stmtOpaque ) continue;
+                    if ( P.argRooted && stmtKillArgs ) continue;
                     if ( touched.find(P.var)!=touched.end() ) continue;
                     bool touchedMention = false;
                     for ( auto m : P.mentions ) {
@@ -391,62 +549,76 @@ namespace das {
             CsePrescan scan;
             fn->body->visit(scan);
             if ( !scan.eligible ) return;
-            // leaf universe: clean by-value locals and arguments
-            das_hash_set<Variable *> leaves;
+            CseUniverse U;
+            // value leaves: clean by-value locals and arguments
             for ( auto v : scan.locals ) {
-                if ( scan.disq.find(v)==scan.disq.end() ) leaves.insert(v);
+                if ( scan.disq.find(v)==scan.disq.end() ) U.valueLeaves.insert(v);
             }
             for ( auto & arg : fn->arguments ) {
+                U.argVars.insert(arg);
                 if ( arg->type && !arg->type->ref && !arg->type->isRefType()
-                    && scan.disq.find(arg)==scan.disq.end() ) leaves.insert(arg);
+                    && scan.disq.find(arg)==scan.disq.end() ) U.valueLeaves.insert(arg);
             }
-            if ( leaves.empty() ) return;
+            // chain bases: every non-ref local and argument
+            for ( auto v : scan.allLocals ) U.memBases.insert(v);
+            for ( auto & arg : fn->arguments ) {
+                if ( arg->type && !arg->type->ref ) U.memBases.insert(arg);
+            }
+            if ( U.valueLeaves.empty() && U.memBases.empty() ) return;
             Cfg cfg = buildCfg(fn);
             // pair and per-statement gen/kill collection
             vector<CsePair> pairs;
             das_hash_map<uint64_t, vector<int>> byHash;
             das_hash_map<Expression *, CseStmtInfo> stmtInfo;
-            auto addPair = [&]( Expression * stmt, Expression * E, Variable * v ) {
+            das_hash_set<Variable *> stmtKills;
+            auto addPair = [&]( Expression * stmt, CseStmtInfo & SI, Expression * E, Variable * v ) {
                 if ( !E || !cseCandidateRoot(E) ) return;
-                vector<Variable *> mentions;
-                if ( !cseAllowedTree(E, leaves, mentions) ) return;
-                for ( auto m : mentions ) {
+                CseTreeInfo info;
+                if ( !cseAllowedTree(E, U, info) ) return;
+                if ( SI.opaque && info.readsMemory ) return;
+                if ( SI.killArgs && info.argRooted ) return;
+                for ( auto m : info.mentions ) {
                     if ( m==v ) return;     // t = f(t): stale the moment the store lands
+                    if ( stmtKills.find(m)!=stmtKills.end() ) return;   // input stored this statement
                 }
                 uint64_t h = cseHash(E);
                 auto & bucket = byHash[h];
                 for ( int pi : bucket ) {
                     if ( pairs[pi].var==v && pairs[pi].expr->sameAs(E) ) {
-                        stmtInfo[stmt].gen.push_back(pi);
+                        SI.gen.push_back(pi);
                         return;
                     }
                 }
                 int idx = int(pairs.size());
-                pairs.push_back(CsePair{E, v, h, mentions});
+                pairs.push_back(CsePair{E, v, h, info.mentions, info.readsMemory, info.argRooted});
                 bucket.push_back(idx);
-                stmtInfo[stmt].gen.push_back(idx);
+                SI.gen.push_back(idx);
             };
             for ( auto b : cfg.blocks ) {
                 for ( auto stmt : b->stmts ) {
                     auto & SI = stmtInfo[stmt];
-                    CseWrites w(scan.storeLefts);
-                    stmt->visit(w);
-                    SI.storeVars = w.writes;
+                    CseEffects fx(U);
+                    stmt->visit(fx);
+                    SI.storeVars = fx.kills;
+                    SI.opaque = fx.opaque;
+                    SI.killArgs = fx.killArgs;
+                    stmtKills.clear();
+                    for ( auto v : SI.storeVars ) stmtKills.insert(v);
                     if ( stmt->rtti_isLet() ) {
                         auto let = static_cast<ExprLet *>(stmt);
                         for ( auto & pv : let->variables ) {
                             SI.declVars.push_back(pv);
-                            if ( leaves.find(pv)==leaves.end() ) continue;
+                            if ( U.valueLeaves.find(pv)==U.valueLeaves.end() ) continue;
                             if ( pv->init_via_move || pv->init_via_clone ) continue;
-                            addPair(stmt, pv->init, pv);
+                            addPair(stmt, SI, pv->init, pv);
                         }
                     } else if ( stmt->rtti_isCopy() ) {
                         auto cp = static_cast<ExprCopy *>(stmt);
                         if ( cp->left->rtti_isVar() ) {
                             auto v = static_cast<ExprVar *>(cp->left)->variable;
-                            if ( leaves.find(v)!=leaves.end()
+                            if ( U.valueLeaves.find(v)!=U.valueLeaves.end()
                                 && scan.declAt.find(v)!=scan.declAt.end() ) {
-                                addPair(stmt, cp->right, v);
+                                addPair(stmt, SI, cp->right, v);
                             }
                         }
                     }
@@ -461,17 +633,25 @@ namespace das {
             size_t np = pairs.size();
             size_t nw = (np + 63) / 64;
             size_t nb = cfg.blocks.size();
+            vector<uint64_t> memMask(nw, 0), argMask(nw, 0);
+            for ( int i=0, is=int(pairs.size()); i!=is; ++i ) {
+                if ( pairs[i].readsMemory ) memMask[i>>6] |= 1ull<<(i&63);
+                if ( pairs[i].argRooted ) argMask[i>>6] |= 1ull<<(i&63);
+            }
             auto killVar = [&]( Variable * v, vector<uint64_t> & avail ) {
                 auto it = pairsTouchingVar.find(v);
                 if ( it==pairsTouchingVar.end() ) return;
                 for ( int pi : it->second ) avail[pi>>6] &= ~(1ull<<(pi&63));
             };
             // kills first, then gen: a store's rhs was computed before the store
-            // landed, and self-referencing pairs were rejected at creation
+            // landed, and pairs whose inputs die in their own statement were
+            // rejected at creation
             auto applyStmt = [&]( Expression * stmt, vector<uint64_t> & avail ) {
                 auto it = stmtInfo.find(stmt);
                 if ( it==stmtInfo.end() ) return;
                 auto & SI = it->second;
+                if ( SI.opaque ) for ( size_t w=0; w!=nw; ++w ) avail[w] &= ~memMask[w];
+                if ( SI.killArgs ) for ( size_t w=0; w!=nw; ++w ) avail[w] &= ~argMask[w];
                 for ( auto v : SI.declVars ) killVar(v, avail);
                 for ( auto v : SI.storeVars ) killVar(v, avail);
                 for ( int g : SI.gen ) avail[g>>6] |= 1ull<<(g&63);

--- a/src/ast/ast_dse.cpp
+++ b/src/ast/ast_dse.cpp
@@ -5,44 +5,57 @@
 #include "daScript/ast/ast_expressions.h"
 #include "daScript/ast/ast_cfg.h"
 
+#include "ast_alias.h"
+
 namespace das {
 
     // ===== Dead-store elimination =====
-    // Removes a statement-level `x = <rhs>` when x is a plain by-value local with no
-    // aliasing uses, the rhs is pure, and no path from the store reaches a read of x
-    // before the next full overwrite. Liveness runs backward over the statement-level
-    // CFG (ast_cfg.h).
+    // Removes a statement-level `x = <rhs>` / `x.field.path = <rhs>` when the target is
+    // a chain (ast_alias.h) over a plain ExprLet local, the rhs is pure, and no path
+    // from the store reaches a read overlapping the chain before the next full
+    // overwrite. Also strips a dead pure declaration init (`var x = <rhs>` where every
+    // path overwrites x before reading it) down to the plain zero-init declaration.
+    // Liveness runs backward over the statement-level CFG (ast_cfg.h), one bit per
+    // stored chain.
     //
     // Soundness model (deliberately narrow):
-    //  * candidates are ExprLet locals of non-ref, non-refType types (the pass-by-value
-    //    world: workhorse scalars, pointers, enums, bitfields, ranges, vectors, string) -
-    //    ExprCopy on them is a plain value write with no copy hooks;
-    //  * every occurrence of a candidate must be a value read (r2v) or the left side of a
-    //    statement-level ExprCopy. Anything else (addr(), by-ref pass, field/index/swizzle
-    //    access, op-assign, ref binding, clone/move target) disqualifies the variable -
-    //    this is what rules out invisible aliases;
-    //  * a store inside an opaque statement (make-block body, unsafe block) is never a
-    //    removal candidate or a kill - any candidate mention inside an opaque statement
-    //    makes the variable live there (over-approximation, sound);
+    //  * bases are ExprLet locals (never arguments - argument writes are the caller's
+    //    to observe). Every occurrence of a base must be a value read (r2v), a
+    //    read-through (r2cr without write - const-ref passes, read chains), or on the
+    //    spine of a statement-level ExprCopy store; anything else (addr(), mutable-ref
+    //    pass, op-assign, move/clone, delete) disqualifies the variable. A local whose
+    //    every use is classified cannot escape, so no call can read it behind the
+    //    pass's back;
+    //  * removal candidates are stores through EXACT chains (fields only, no index or
+    //    swizzle links) whose target type is by-value - such an ExprCopy is a plain
+    //    value write with no copy hooks. A store through an inexact chain
+    //    (s.arr[i] = v) kills nothing and reads its exact prefix; a store to a chain
+    //    keeps every strict-prefix store alive (partial overwrite observes the rest);
+    //  * chain identity is the field-name path; two chains overlap when one path is a
+    //    prefix of the other (an inexact link truncates the known path, widening the
+    //    overlap conservatively);
+    //  * a store inside a make-block body is never a removal candidate or a kill - any
+    //    occurrence inside the owning statement makes the overlapped chains live there
+    //    (the body runs zero or more times during that statement, and blocks cannot
+    //    escape it);
     //  * functions carrying control flow the CFG does not model are skipped whole:
-    //    goto/label (also covers lowered generators), try/recover, and non-empty finally
-    //    (it also runs on an early return the CFG routes straight to exit).
-    // Local stores are unobservable after a panic (locals die with the frame; finally is
-    // skipped on panic by design), so removal needs no panic-path modeling.
+    //    goto/label (also covers lowered generators), try/recover, and non-empty
+    //    finally (it also runs on an early return the CFG routes straight to exit).
+    // Local stores are unobservable after a panic (locals die with the frame; finally
+    // is skipped on panic by design), so removal needs no panic-path modeling.
 
     namespace {
 
-        // one walk: (a) bail on constructs the CFG does not model, (b) collect candidate
-        // locals, (c) disqualify any variable with a use that is not a plain value read
-        // and not the lvalue of a statement-level assignment
+        // one walk: (a) bail on constructs the CFG does not model, (b) collect locals,
+        // (c) disqualify any variable with an occurrence that is neither a read nor on
+        // the spine of a statement-level store
         class DsePrescan : public Visitor {
         public:
             bool eligible = true;
-            vector<Variable *> locals;                  // ExprLet locals of by-value type, in order
-            das_hash_set<Variable *> disq;              // variables with an aliasing-capable use
-            das_hash_set<Variable *> storedVars;        // variables with at least one statement-level store
+            vector<Variable *> locals;                  // every non-ref ExprLet local, in order
+            das_hash_set<Variable *> disq;              // variables with an unclassified occurrence
+            das_hash_set<Expression *> storeSpines;     // nodes on statement-level ExprCopy store-left chains
         protected:
-            das_hash_set<Expression *> storeLefts;      // lvalue ExprVar nodes of statement-level copies
             Expression * curStmt = nullptr;
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
             virtual void preVisit ( ExprBlock * blk ) override {
@@ -71,62 +84,134 @@ namespace das {
             }
             virtual void preVisit ( ExprCopy * expr ) override {
                 Visitor::preVisit(expr);
-                if ( expr==curStmt && expr->left->rtti_isVar() ) {
-                    storeLefts.insert(expr->left);
-                    storedVars.insert(((ExprVar *)expr->left)->variable);
+                if ( expr==curStmt ) {
+                    AliasChain ch;
+                    aliasChainOf(expr->left, ch, &storeSpines);
                 }
             }
             virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
                 Visitor::preVisitLet(let, var, last);
-                if ( var->type && !var->type->ref && !var->type->isRefType() ) {
+                if ( var->type && !var->type->ref ) {
                     locals.push_back(var);
                 }
             }
             virtual void preVisit ( ExprVar * expr ) override {
                 Visitor::preVisit(expr);
-                if ( !expr->r2v && storeLefts.find(expr)==storeLefts.end() ) {
+                bool readOnly = expr->r2v || (expr->r2cr && !expr->write);
+                if ( !readOnly && storeSpines.find(expr)==storeSpines.end() ) {
                     disq.insert(expr->variable);
                 }
             }
         };
 
-        // collect candidate-variable mentions (any occurrence) in a subtree
-        class DseMentions : public Visitor {
+        struct DseChain {
+            Variable *              base = nullptr;
+            vector<const char *>    path;               // exact field path (candidates only)
+        };
+
+        // resolve chain occurrences in a subtree to candidate uses: every maximal chain
+        // rooted at a tracked base - reads and interior-block stores alike - touches
+        // the candidates its known prefix overlaps
+        class DseReads : public Visitor {
         public:
-            DseMentions ( const das_hash_map<Variable *,int> & idx, vector<int> & out )
-                : index(idx), uses(out) {}
+            DseReads ( const das_hash_map<Variable *, vector<int>> & bb, const vector<DseChain> & cs,
+                       vector<int> & out, const das_hash_set<Expression *> * skip )
+                : byBase(bb), chains(cs), uses(out), skipSpine(skip) {}
         protected:
-            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
-            virtual void preVisit ( ExprVar * expr ) override {
-                Visitor::preVisit(expr);
-                auto it = index.find(expr->variable);
-                if ( it!=index.end() ) uses.push_back(it->second);
-            }
-        protected:
-            const das_hash_map<Variable *,int> & index;
+            const das_hash_map<Variable *, vector<int>> & byBase;
+            const vector<DseChain> & chains;
             vector<int> & uses;
+            const das_hash_set<Expression *> * skipSpine;
+            das_hash_set<Expression *> seen;
+            void chainRoot ( Expression * expr ) {
+                if ( seen.find(expr)!=seen.end() ) return;
+                if ( skipSpine && skipSpine->find(expr)!=skipSpine->end() ) return;
+                AliasChain ch;
+                if ( !aliasChainOf(expr, ch, &seen) ) return;
+                auto bit = byBase.find(ch.base);
+                if ( bit==byBase.end() ) return;
+                size_t rlen = aliasChainExactLen(ch.path);
+                for ( int ci : bit->second ) {
+                    auto & C = chains[ci];
+                    size_t n = das::min(rlen, C.path.size());
+                    if ( aliasPathAgree(ch.path, C.path, n) ) uses.push_back(ci);
+                }
+            }
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisit ( ExprVar * expr ) override     { Visitor::preVisit(expr); chainRoot(expr); }
+            virtual void preVisit ( ExprField * expr ) override   { Visitor::preVisit(expr); chainRoot(expr); }
+            virtual void preVisit ( ExprSwizzle * expr ) override { Visitor::preVisit(expr); chainRoot(expr); }
+            virtual void preVisit ( ExprAt * expr ) override      { Visitor::preVisit(expr); chainRoot(expr); }
+        };
+
+        struct DseLetInit {
+            int         cand = -1;
+            Variable *  var = nullptr;
         };
 
         struct DseStmt {
-            int killVar = -1;       // candidate index fully overwritten by this statement
-            bool rhsPure = false;   // store rhs carries no side effects (safe to not evaluate)
-            vector<int> uses;       // candidate mentions (store: rhs only; otherwise whole subtree)
+            vector<int> kills;          // candidates fully overwritten by this statement
+            vector<int> uses;           // candidates whose chains this statement touches
+            int         removeIdx = -1; // candidate this store establishes (removable when dead)
+            bool        rhsPure = false;
+            vector<DseLetInit> letInits;    // strippable declaration inits (removable when dead)
         };
 
-        void analyzeDeadStores ( Function * fn, das_hash_set<Expression *> & dead ) {
+        void analyzeDeadStores ( Function * fn, das_hash_set<Expression *> & dead,
+                                 das_hash_set<Variable *> & deadInits ) {
             DsePrescan scan;
             fn->body->visit(scan);
             if ( !scan.eligible ) return;
-            das_hash_map<Variable *,int> index;
+            das_hash_set<Variable *> bases;
             for ( auto v : scan.locals ) {
-                if ( scan.disq.find(v)!=scan.disq.end() ) continue;
-                if ( scan.storedVars.find(v)==scan.storedVars.end() ) continue;  // nothing to remove
-                int idx = int(index.size());
-                index[v] = idx;
+                if ( scan.disq.find(v)==scan.disq.end() ) bases.insert(v);
             }
-            if ( index.empty() ) return;
+            if ( bases.empty() ) return;
             Cfg cfg = buildCfg(fn);
-            size_t nw = (index.size() + 63) / 64;
+            // candidate enumeration: exact by-value chain stores, then strippable
+            // declaration inits of bases that carry at least one store
+            vector<DseChain> chains;
+            das_hash_map<Variable *, vector<int>> byBase;
+            auto findChain = [&]( Variable * base, const vector<const char *> & path ) -> int {
+                for ( int ci : byBase[base] ) {
+                    if ( chains[ci].path.size()==path.size()
+                        && aliasPathAgree(chains[ci].path, path, path.size()) ) return ci;
+                }
+                return -1;
+            };
+            auto storeTarget = [&]( Expression * stmt, AliasChain & ch, das_hash_set<Expression *> * spine ) -> bool {
+                if ( !stmt->rtti_isCopy() ) return false;
+                auto cp = static_cast<ExprCopy *>(stmt);
+                if ( !aliasChainOf(cp->left, ch, spine) ) return false;
+                return bases.find(ch.base)!=bases.end();
+            };
+            for ( auto b : cfg.blocks ) {
+                for ( auto stmt : b->stmts ) {
+                    AliasChain ch;
+                    if ( !storeTarget(stmt, ch, nullptr) ) continue;
+                    if ( !ch.exact ) continue;
+                    auto cp = static_cast<ExprCopy *>(stmt);
+                    if ( !cp->left->type || cp->left->type->isRefType() ) continue;
+                    if ( findChain(ch.base, ch.path)>=0 ) continue;
+                    int idx = int(chains.size());
+                    chains.push_back(DseChain{ch.base, ch.path});
+                    byBase[ch.base].push_back(idx);
+                }
+            }
+            if ( chains.empty() ) return;
+            vector<const char *> emptyPath;
+            for ( auto v : scan.locals ) {
+                if ( byBase.find(v)==byBase.end() ) continue;   // no stores: unused-var territory
+                if ( !v->init || v->init_via_move || v->init_via_clone ) continue;
+                if ( v->type->isRefType() ) continue;
+                if ( !v->init->noSideEffects ) continue;
+                if ( findChain(v, emptyPath)>=0 ) continue;
+                int idx = int(chains.size());
+                chains.push_back(DseChain{v, emptyPath});
+                byBase[v].push_back(idx);
+            }
+            // per-statement gen/kill resolution
+            size_t nw = (chains.size() + 63) / 64;
             struct BlockInfo {
                 vector<DseStmt>  stmts;
                 vector<uint64_t> liveIn, liveOut;
@@ -141,26 +226,57 @@ namespace das {
                 for ( size_t si=0, sis=b->stmts.size(); si!=sis; ++si ) {
                     auto stmt = b->stmts[si];
                     auto & SI = BI.stmts[si];
-                    if ( stmt->rtti_isCopy() ) {
-                        auto cp = (ExprCopy *) stmt;
-                        if ( cp->left->rtti_isVar() ) {
-                            auto it = index.find(((ExprVar *)cp->left)->variable);
-                            if ( it!=index.end() ) {
-                                SI.killVar = it->second;
-                                SI.rhsPure = cp->right->noSideEffects;
-                                DseMentions m(index, SI.uses);
-                                cp->right->visit(m);
-                                continue;
+                    das_hash_set<Expression *> spine;
+                    AliasChain ch;
+                    if ( storeTarget(stmt, ch, &spine) ) {
+                        size_t known = aliasChainExactLen(ch.path);
+                        for ( int ci : byBase[ch.base] ) {
+                            auto & C = chains[ci];
+                            if ( ch.exact ) {
+                                // full overwrite of every extension; a strict-prefix
+                                // store stays observable through the untouched rest
+                                if ( C.path.size()>=ch.path.size()
+                                    && aliasPathAgree(C.path, ch.path, ch.path.size()) ) {
+                                    SI.kills.push_back(ci);
+                                    if ( C.path.size()==ch.path.size() ) SI.removeIdx = ci;
+                                } else if ( C.path.size()<ch.path.size()
+                                    && aliasPathAgree(C.path, ch.path, C.path.size()) ) {
+                                    SI.uses.push_back(ci);
+                                }
+                            } else {
+                                // partial write through an unknown element: touches
+                                // everything its known prefix overlaps, kills nothing
+                                size_t n = das::min(known, C.path.size());
+                                if ( aliasPathAgree(ch.path, C.path, n) ) SI.uses.push_back(ci);
+                            }
+                        }
+                        SI.rhsPure = static_cast<ExprCopy *>(stmt)->right->noSideEffects;
+                    } else if ( stmt->rtti_isLet() ) {
+                        auto let = static_cast<ExprLet *>(stmt);
+                        for ( auto & pv : let->variables ) {
+                            auto bit = byBase.find(pv);
+                            if ( bit==byBase.end() ) continue;
+                            for ( int ci : bit->second ) {
+                                SI.kills.push_back(ci); // nothing before the declaration observes it
+                                if ( chains[ci].path.empty() && pv->init
+                                    && !pv->init_via_move && !pv->init_via_clone
+                                    && pv->init->noSideEffects ) {
+                                    SI.letInits.push_back(DseLetInit{ci, pv});
+                                }
                             }
                         }
                     }
-                    DseMentions m(index, SI.uses);
-                    stmt->visit(m);
+                    DseReads reads(byBase, chains, SI.uses, spine.empty() ? nullptr : &spine);
+                    stmt->visit(reads);
                 }
             }
             // backward liveness to fixpoint. blocks are numbered in creation order, so
             // reverse order approximates reverse topological order and converges fast
             vector<uint64_t> live(nw);
+            auto applyBackward = [&]( DseStmt & SI, vector<uint64_t> & lv ) {
+                for ( int k : SI.kills ) lv[k>>6] &= ~(1ull<<(k&63));
+                for ( int u : SI.uses ) lv[u>>6] |= 1ull<<(u&63);
+            };
             bool changed = true;
             while ( changed ) {
                 changed = false;
@@ -173,32 +289,38 @@ namespace das {
                         for ( size_t w=0; w!=nw; ++w ) BI.liveOut[w] |= sin[w];
                     }
                     live = BI.liveOut;
-                    for ( size_t si=BI.stmts.size(); si-->0; ) {
-                        auto & SI = BI.stmts[si];
-                        if ( SI.killVar>=0 ) live[SI.killVar>>6] &= ~(1ull<<(SI.killVar&63));
-                        for ( int u : SI.uses ) live[u>>6] |= 1ull<<(u&63);
-                    }
+                    for ( size_t si=BI.stmts.size(); si-->0; ) applyBackward(BI.stmts[si], live);
                     if ( live != BI.liveIn ) { BI.liveIn = live; changed = true; }
                 }
             }
-            // final scan: a store whose target is dead after it and whose rhs is pure is
-            // removed - it neither kills (target already dead) nor gens (rhs not evaluated),
-            // which lets a chain of dead stores fall in a single pass
+            // final scan: a store whose chain is dead after it and whose rhs is pure is
+            // removed - it neither kills (already dead) nor gens (rhs not evaluated),
+            // which lets a chain of dead stores fall in a single pass. a dead pure
+            // declaration init is stripped to the plain zero-init declaration
+            auto isDead = [&]( const vector<uint64_t> & lv, int ci ) {
+                return ((lv[ci>>6] >> (ci&63)) & 1)==0;
+            };
+            vector<uint64_t> liveInit(nw);
             for ( size_t bi=0, bis=cfg.blocks.size(); bi!=bis; ++bi ) {
                 auto b = cfg.blocks[bi];
                 auto & BI = binfo[bi];
                 live = BI.liveOut;
                 for ( size_t si=BI.stmts.size(); si-->0; ) {
                     auto & SI = BI.stmts[si];
-                    if ( SI.killVar>=0 ) {
-                        bool isLive = ((live[SI.killVar>>6] >> (SI.killVar&63)) & 1) != 0;
-                        if ( !isLive && SI.rhsPure ) {
-                            dead.insert(b->stmts[si]);
-                            continue;
-                        }
-                        live[SI.killVar>>6] &= ~(1ull<<(SI.killVar&63));
+                    if ( SI.removeIdx>=0 && SI.rhsPure && isDead(live, SI.removeIdx) ) {
+                        dead.insert(b->stmts[si]);
+                        continue;   // the statement vanishes whole: no kills, no uses
                     }
-                    for ( int u : SI.uses ) live[u>>6] |= 1ull<<(u&63);
+                    if ( !SI.letInits.empty() ) {
+                        // a later init in the same `let` may read an earlier variable -
+                        // judge deadness with the statement's own uses folded in
+                        liveInit = live;
+                        for ( int u : SI.uses ) liveInit[u>>6] |= 1ull<<(u&63);
+                        for ( auto & li : SI.letInits ) {
+                            if ( isDead(liveInit, li.cand) ) deadInits.insert(li.var);
+                        }
+                    }
+                    applyBackward(SI, live);
                 }
             }
         }
@@ -209,12 +331,14 @@ namespace das {
             using PassVisitor::visit;
         protected:
             das_hash_set<Expression *> dead;
+            das_hash_set<Variable *> deadInits;
             virtual bool canVisitFunction ( Function * fun ) override {
                 if ( fun->stub || fun->isTemplate || !funcIsDirty(fun) ) return false;
                 if ( !fun->body || !fun->body->rtti_isBlock() ) return false;
                 dead.clear();
-                analyzeDeadStores(fun, dead);
-                return !dead.empty();
+                deadInits.clear();
+                analyzeDeadStores(fun, dead, deadInits);
+                return !dead.empty() || !deadInits.empty();
             }
             virtual bool canVisitStructure ( Structure * ) override { return false; }
             virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
@@ -228,6 +352,15 @@ namespace das {
                     return nullptr;
                 }
                 return Visitor::visitBlockExpression(block, expr);
+            }
+            virtual ExpressionPtr visit ( ExprLet * let ) override {
+                for ( auto & pv : let->variables ) {
+                    if ( deadInits.find(pv)!=deadInits.end() ) {
+                        pv->init = nullptr;
+                        reportFolding();
+                    }
+                }
+                return Visitor::visit(let);
             }
         };
     }

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -186,6 +186,11 @@ namespace das {
             void checkFunc ( Function * fn ) {
                 if ( !fn || !privateSymbol.empty() ) return;
                 auto origin = fn->fromGeneric ? fn->fromGeneric : fn;
+                // instances are stamped private by instantiation, which keeps this gate
+                // deliberately conservative: a body calling ANY generic instance stays
+                // un-spliced across modules. Loosening it to origin-privateness re-fires
+                // hundreds of linq_fold_common splices and destabilizes the fold macro's
+                // shape assumptions - measure before widening
                 if ( fn->privateFunction || origin->privateFunction ) {
                     if ( fn->module==mod || origin->module==mod ) {
                         privateSymbol = origin->name;

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -6,18 +6,33 @@
 
 namespace das {
 
-    // ===== [inline] splicing =====
+    // ===== [inline] splicing, automatic block inlining, invoke devirtualization =====
     // Runs in the patch slot (Program::patchAnnotations -> patchInline), after infer and
     // buildAccessFlags, before lint and optimize. Splices are syntax-level: cloned callee
     // statements land in the caller, the pass reports astChanged, and the compiler restarts
     // infer, which re-resolves every ExprVar by name and legalizes types/r2v/temporaries.
     //
-    // The contract is fail-closed: [inline] is a promise, not a hint. A callee shape the
-    // inliner can't splice is a compile error (annotation lint hook -> checkInlineShape,
-    // pointing at the declaration); a call site it can't host is a compile error reported
-    // here at the site. The pass has no size budgets and no decline paths. When a callee
-    // shape is bad the patch pass skips it SILENTLY and the lint hook reports it - both
-    // run on every compile, so a skip is never silent overall.
+    // Three site kinds, two contracts:
+    //  * [inline] calls (MUST): fail-closed. A callee shape the inliner can't splice is a
+    //    compile error (annotation lint hook -> checkInlineShape, pointing at the
+    //    declaration); a call site it can't host is a compile error reported here at the
+    //    site. No size budgets, no decline paths. When a callee shape is bad the patch
+    //    pass skips it SILENTLY and the lint hook reports it - both run on every compile,
+    //    so a skip is never silent overall.
+    //  * calls passing a block LITERAL argument (AUTO, optimized builds only): best-effort.
+    //    The literal is the user's signal; nobody promised anything, so every gate -
+    //    callee shape, unsafe in the body, recursion through the splice graph, private
+    //    symbols, call position - declines SILENTLY (counted, logged under
+    //    log_optimization). `options disable_auto_inline` (or the policy) turns it off.
+    //  * invoke of a block literal (DEVIRT, same best-effort contract): an invoke whose
+    //    block resolves to a same-function literal - directly or through a move-initialized,
+    //    never-rewritten local (which is what an auto-spliced callee leaves behind) -
+    //    splices the block body in place. Same-frame semantics make this a pure win: the
+    //    body already reads the caller's locals directly.
+    // The two halves converge over patch rounds: an auto splice moves the callee's invoke
+    // next to the literal, the next round devirtualizes it, and any block-literal calls
+    // inside the spliced body trigger further waves. Recursion through the combined graph
+    // is declined up front, so the rounds terminate.
     //
     // Argument substitution is three-tier:
     //  (A) leaf args (constants; variable reads) substitute textually, no temp. A by-value
@@ -64,22 +79,54 @@ namespace das {
 
         class InlineShapeScan : public Visitor {
         public:
+            InlineShapeScan ( bool blockLiteral = false ) : forBlockLiteral(blockLiteral) {}
             string reason;
             int returnCount = 0;
             Expression * lastTopLevelStmt = nullptr;
             Expression * misplacedReturn = nullptr;
             bool bad = false;
         protected:
+            bool forBlockLiteral;
+            int makeBlockDepth = 0;
+            int loopDepth = 0;
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
             void flag ( const char * why ) { if ( !bad ) { bad = true; reason = why; } }
             virtual void preVisit ( ExprGoto * expr ) override { Visitor::preVisit(expr); flag("body contains goto"); }
             virtual void preVisit ( ExprLabel * expr ) override { Visitor::preVisit(expr); flag("body contains a label"); }
             virtual void preVisit ( ExprTryCatch * expr ) override { Visitor::preVisit(expr); flag("body contains try/recover"); }
             virtual void preVisit ( ExprYield * expr ) override { Visitor::preVisit(expr); flag("body contains yield"); }
-            virtual void preVisit ( ExprMakeBlock * expr ) override { Visitor::preVisit(expr); flag("body contains a block, lambda, or generator literal"); }
+            virtual void preVisit ( ExprFor * expr ) override { Visitor::preVisit(expr); loopDepth ++; }
+            virtual ExpressionPtr visit ( ExprFor * expr ) override { loopDepth --; return Visitor::visit(expr); }
+            virtual void preVisit ( ExprWhile * expr ) override { Visitor::preVisit(expr); loopDepth ++; }
+            virtual ExpressionPtr visit ( ExprWhile * expr ) override { loopDepth --; return Visitor::visit(expr); }
+            // splicing a block body inline dissolves the block boundary; a break/continue
+            // not bound to a loop inside the body would re-bind to the invoke site's loop
+            virtual void preVisit ( ExprBreak * expr ) override {
+                Visitor::preVisit(expr);
+                if ( forBlockLiteral && !makeBlockDepth && !loopDepth ) flag("body breaks out of the block");
+            }
+            virtual void preVisit ( ExprContinue * expr ) override {
+                Visitor::preVisit(expr);
+                if ( forBlockLiteral && !makeBlockDepth && !loopDepth ) flag("body continues out of the block");
+            }
+            virtual void preVisit ( ExprMakeBlock * expr ) override {
+                Visitor::preVisit(expr);
+                // a plain block literal stays in-frame and clones safely with the body;
+                // lambda and local-function literals lower to generated functions during
+                // infer, and cloning those post-infer is not safe
+                if ( expr->isLambda || expr->isLocalFunction || !expr->capture.empty() ) {
+                    flag("body contains a lambda literal");
+                }
+                makeBlockDepth ++;
+            }
+            virtual ExpressionPtr visit ( ExprMakeBlock * expr ) override {
+                makeBlockDepth --;
+                return Visitor::visit(expr);
+            }
             virtual void preVisit ( ExprMakeGenerator * expr ) override { Visitor::preVisit(expr); flag("body contains a generator"); }
             virtual void preVisit ( ExprReturn * expr ) override {
                 Visitor::preVisit(expr);
+                if ( makeBlockDepth ) return;   // a return inside a block literal exits the block
                 returnCount ++;
                 if ( expr != lastTopLevelStmt ) misplacedReturn = expr;
             }
@@ -99,8 +146,8 @@ namespace das {
 
         class ParamReadScan : public Visitor {
         public:
-            ParamReadScan ( Function * fn, ParamReadStats & st ) : stats(st) {
-                for ( auto & arg : fn->arguments ) params.insert(arg);
+            ParamReadScan ( const vector<VariablePtr> & paramVars, ParamReadStats & st ) : stats(st) {
+                for ( auto & arg : paramVars ) params.insert(arg);
             }
         protected:
             das_hash_set<Variable *> params;
@@ -111,6 +158,9 @@ namespace das {
             virtual ExpressionPtr visit ( ExprFor * expr ) override { loopDepth --; return Visitor::visit(expr); }
             virtual void preVisit ( ExprWhile * expr ) override { Visitor::preVisit(expr); loopDepth ++; }
             virtual ExpressionPtr visit ( ExprWhile * expr ) override { loopDepth --; return Visitor::visit(expr); }
+            // a block literal's body may run any number of times - reads inside count as under-loop
+            virtual void preVisit ( ExprMakeBlock * expr ) override { Visitor::preVisit(expr); loopDepth ++; }
+            virtual ExpressionPtr visit ( ExprMakeBlock * expr ) override { loopDepth --; return Visitor::visit(expr); }
             virtual void preVisit ( ExprVar * expr ) override {
                 Visitor::preVisit(expr);
                 if ( expr->variable && params.find(expr->variable)!=params.end() ) {
@@ -120,24 +170,60 @@ namespace das {
             }
         };
 
-        // ----- private-symbol scan (cross-module splice gate) -----
+        // ----- cross-module reference scan (splice gate) -----
+        // a spliced body re-resolves its calls and globals in the DESTINATION module:
+        // everything it references must be public and visible from there. generic
+        // instances are judged by their origin (instances do not carry the private flag)
 
         class PrivateUseScan : public Visitor {
         public:
-            PrivateUseScan ( Module * calleeModule ) : mod(calleeModule) {}
+            PrivateUseScan ( Module * calleeModule, Module * destModule )
+                : mod(calleeModule), dest(destModule) {}
             string privateSymbol;
         protected:
             Module * mod;
+            Module * dest;
+            void checkFunc ( Function * fn ) {
+                if ( !fn || !privateSymbol.empty() ) return;
+                auto origin = fn->fromGeneric ? fn->fromGeneric : fn;
+                if ( fn->privateFunction || origin->privateFunction ) {
+                    if ( fn->module==mod || origin->module==mod ) {
+                        privateSymbol = origin->name;
+                        return;
+                    }
+                }
+                if ( dest && origin->module && !dest->isVisibleDirectly(origin->module) ) {
+                    privateSymbol = origin->name;
+                }
+            }
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
             virtual void preVisit ( ExprCall * expr ) override {
                 Visitor::preVisit(expr);
-                if ( expr->func && expr->func->privateFunction && expr->func->module==mod && privateSymbol.empty() ) {
-                    privateSymbol = expr->func->name;
-                }
+                checkFunc(expr->func);
+            }
+            virtual void preVisit ( ExprOp1 * expr ) override {
+                Visitor::preVisit(expr);
+                checkFunc(expr->func);
+            }
+            virtual void preVisit ( ExprOp2 * expr ) override {
+                Visitor::preVisit(expr);
+                checkFunc(expr->func);
+            }
+            virtual void preVisit ( ExprOp3 * expr ) override {
+                Visitor::preVisit(expr);
+                checkFunc(expr->func);
+            }
+            virtual void preVisit ( ExprAddr * expr ) override {
+                Visitor::preVisit(expr);
+                checkFunc(expr->func);
             }
             virtual void preVisit ( ExprVar * expr ) override {
                 Visitor::preVisit(expr);
-                if ( expr->variable && expr->variable->private_variable && privateSymbol.empty() ) {
+                if ( !expr->variable || !privateSymbol.empty() ) return;
+                if ( expr->variable->private_variable ) {
+                    privateSymbol = expr->variable->name;
+                } else if ( dest && expr->isGlobalVariable() && expr->variable->module
+                    && !dest->isVisibleDirectly(expr->variable->module) ) {
                     privateSymbol = expr->variable->name;
                 }
             }
@@ -169,6 +255,12 @@ namespace das {
             virtual void preVisit ( ExprFor * expr ) override {
                 Visitor::preVisit(expr);
                 for ( auto & var : expr->iteratorVariables ) renameVar(var->name, var->aka);
+            }
+            // block-literal arguments rename too: after the splice they sit in the caller's
+            // scope chain, and an unrenamed argument could shadow a caller local (an error)
+            virtual void preVisitBlockArgument ( ExprBlock * block, const VariablePtr & var, bool lastArg ) override {
+                Visitor::preVisitBlockArgument(block, var, lastArg);
+                renameVar(var->name, var->aka);
             }
         };
 
@@ -238,6 +330,15 @@ namespace das {
                     if ( rit != rename->end() ) var->name = rit->second;
                 }
             }
+            virtual void preVisitBlockArgument ( ExprBlock * block, const VariablePtr & var, bool lastArg ) override {
+                Visitor::preVisitBlockArgument(block, var, lastArg);
+                auto rit = rename->find(var->name);
+                if ( rit != rename->end() ) var->name = rit->second;
+                if ( !var->aka.empty() ) {
+                    auto ait = rename->find(var->aka);
+                    if ( ait != rename->end() ) var->aka = ait->second;
+                }
+            }
         };
 
         // replace one specific node (by identity) inside a statement
@@ -260,20 +361,51 @@ namespace das {
             int         index = -1;
         };
 
-        struct PlannedSite {
-            ExprCall *  call = nullptr;
-            Expression * stmt = nullptr;
-            StmtAnchor  anchor;
+        enum class SiteKind {
+            MustCall,   // call to an [inline] function: fail-closed contract, errors
+            AutoCall,   // call with a block-literal argument: best-effort, silent declines
+            Devirt      // invoke of a block literal (direct or let-bound): best-effort
         };
 
+        struct PlannedSite {
+            Expression * callLike = nullptr;    // ExprCall or ExprInvoke
+            Expression * stmt = nullptr;
+            StmtAnchor  anchor;
+            SiteKind    kind = SiteKind::MustCall;
+        };
+
+        // annotations other than inert markers may carry call-site semantics (verifyCall,
+        // transform, per-call codegen) that splicing the call away would bypass
+        bool annotatedCallee ( Function * fn, string & why ) {
+            for ( auto & ann : fn->annotations ) {
+                if ( !ann->annotation ) continue;
+                auto & nm = ann->annotation->name;
+                if ( nm=="export" || nm=="unused_argument" ) continue;
+                why = "annotated function [" + nm + "]";
+                return true;
+            }
+            return false;
+        }
+
+        bool autoEligibleCall ( ExprCall * call ) {
+            if ( !call->func || call->func->mustInline || call->func->builtIn ) return false;
+            if ( !call->func->body || call->func->isTemplate ) return false;
+            for ( auto & a : call->arguments ) {
+                if ( a->rtti_isMakeBlock() ) return true;
+            }
+            return false;
+        }
+
         // one walk per function: for every statement its (block, index) anchor, and
-        // every mustInline call site tagged with the statement that anchors it. a call
-        // in a while/elif condition is tagged with the while/if statement itself; the
+        // every splice site tagged with the statement that anchors it. a call in a
+        // while/elif condition is tagged with the while/if statement itself; the
         // splice step lowers those constructs first when statements are needed.
         class InlineCollect : public Visitor {
         public:
+            InlineCollect ( bool autoOn ) : autoEnabled(autoOn) {}
             vector<PlannedSite> sites;      // in visit order: within a block, increasing index
         protected:
+            bool autoEnabled;
             vector<StmtAnchor> blockStack;
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
             virtual void preVisit ( ExprBlock * blk ) override {
@@ -288,21 +420,67 @@ namespace das {
                 Visitor::preVisitBlockExpression(block, expr);
                 if ( !blockStack.empty() && blockStack.back().block==block ) blockStack.back().index++;
             }
+            void plan ( Expression * expr, SiteKind kind ) {
+                // the anchoring statement is the innermost open block's CURRENT
+                // statement - not the last statement any nested block visited
+                // (an elif condition visits after the outer if's then-block)
+                PlannedSite site;
+                site.callLike = expr;
+                site.kind = kind;
+                if ( !blockStack.empty() && blockStack.back().index >= 0
+                    && blockStack.back().index < int(blockStack.back().block->list.size()) ) {
+                    site.anchor = blockStack.back();
+                    site.stmt = site.anchor.block->list[site.anchor.index];
+                }
+                sites.push_back(site);
+            }
             virtual void preVisit ( ExprCall * expr ) override {
                 Visitor::preVisit(expr);
                 if ( expr->func && expr->func->mustInline ) {
-                    // the anchoring statement is the innermost open block's CURRENT
-                    // statement - not the last statement any nested block visited
-                    // (an elif condition visits after the outer if's then-block)
-                    PlannedSite site;
-                    site.call = expr;
-                    if ( !blockStack.empty() && blockStack.back().index >= 0
-                        && blockStack.back().index < int(blockStack.back().block->list.size()) ) {
-                        site.anchor = blockStack.back();
-                        site.stmt = site.anchor.block->list[site.anchor.index];
-                    }
-                    sites.push_back(site);
+                    plan(expr, SiteKind::MustCall);
+                } else if ( autoEnabled && autoEligibleCall(expr) ) {
+                    plan(expr, SiteKind::AutoCall);
                 }
+            }
+            virtual void preVisit ( ExprInvoke * expr ) override {
+                Visitor::preVisit(expr);
+                if ( !autoEnabled || expr->isInvokeMethod || expr->arguments.empty() ) return;
+                Expression * a0 = expr->arguments[0];
+                if ( a0->rtti_isR2V() ) a0 = static_cast<ExprRef2Value *>(a0)->subexpr;
+                if ( a0->rtti_isMakeBlock() || a0->rtti_isVar() ) plan(expr, SiteKind::Devirt);
+            }
+        };
+
+        // let-bound block literals: a variable move-initialized from a block literal and
+        // never REBOUND still holds that literal at every invoke. write flags are fresh
+        // at patch time (buildAccessFlags runs right before patchAnnotations); an invoke
+        // stamps a write on its non-const block argument, but invoking cannot rebind the
+        // holder to a different literal, so arg0 occurrences stay clean for this purpose
+        class BlockBindingScan : public Visitor {
+        public:
+            das_hash_map<Variable *, ExprMakeBlock *> binding;
+            das_hash_set<Variable *> disq;
+        protected:
+            das_hash_set<Expression *> invokeArg0;
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
+                Visitor::preVisitLet(let, var, last);
+                if ( var->init && var->init->rtti_isMakeBlock() ) {
+                    if ( binding.find(var)!=binding.end() ) disq.insert(var);  // paranoia: one binding only
+                    binding[var] = static_cast<ExprMakeBlock *>(var->init);
+                }
+            }
+            virtual void preVisit ( ExprInvoke * expr ) override {
+                Visitor::preVisit(expr);
+                if ( expr->arguments.empty() ) return;
+                Expression * a0 = expr->arguments[0];
+                if ( a0->rtti_isR2V() ) a0 = static_cast<ExprRef2Value *>(a0)->subexpr;
+                if ( a0->rtti_isVar() ) invokeArg0.insert(a0);
+            }
+            virtual void preVisit ( ExprVar * expr ) override {
+                Visitor::preVisit(expr);
+                if ( expr->variable && expr->write
+                    && invokeArg0.find(expr)==invokeArg0.end() ) disq.insert(expr->variable);
             }
         };
 
@@ -371,6 +549,8 @@ namespace das {
                 out.emplace_back(at->index, 0);
             } else if ( e->rtti_isCast() ) {
                 out.emplace_back(static_cast<ExprCast *>(e)->subexpr, 0);
+            } else if ( e->rtti_isUnsafe() ) {
+                out.emplace_back(static_cast<ExprUnsafe *>(e)->body, 0);
             }
         }
 
@@ -384,6 +564,10 @@ namespace das {
         bool inlinePure ( Expression * e ) {
             if ( !e ) return true;
             if ( e->rtti_isConstant() ) return true;
+            if ( e->rtti_isMakeBlock() ) return true;   // making a block writes nothing (and
+                                                        // hoisting one would copy a non-copyable)
+            if ( e->rtti_isTypeDecl() ) return true;    // type<...> witness: a compile-time tag
+            if ( e->rtti_isUnsafe() ) return inlinePure(static_cast<ExprUnsafe *>(e)->body);
             if ( e->rtti_isVar() ) return !static_cast<ExprVar *>(e)->isGlobalVariable();
             if ( e->rtti_isR2V() ) return inlinePure(static_cast<ExprRef2Value *>(e)->subexpr);
             if ( e->rtti_isField() ) return inlinePure(static_cast<ExprField *>(e)->value);
@@ -450,12 +634,23 @@ namespace das {
             return (fn->sideEffectFlags & writeMask)==0;
         }
 
+        // the arguments and parameters of one splice site: a direct call binds the whole
+        // argument list, an invoke binds arguments[1..] against the block's parameters
+        struct SiteArgs {
+            const vector<ExpressionPtr> *  args = nullptr;
+            size_t                         ofs = 0;
+            const vector<VariablePtr> *    params = nullptr;
+            size_t count () const { return params->size(); }
+            Expression * arg ( size_t i ) const { return (*args)[ofs+i]; }
+            const VariablePtr & param ( size_t i ) const { return (*params)[i]; }
+        };
+
         // for a callee that DOES write: a substituted argument may only read storage
         // the spliced body provably cannot touch - plain local by-value variables that
         // are not passed by mutable reference in this very call and whose address was
         // never taken. no field / index / deref reads at all (they may reach heap or
         // aliased storage). constants and operations over such leaves are fine
-        bool argReadsOnlyPrivateLocals ( Expression * e, ExprCall * call, Function * callee ) {
+        bool argReadsOnlyPrivateLocals ( Expression * e, const SiteArgs & sa ) {
             if ( !e ) return true;
             if ( e->rtti_isConstant() ) return true;
             if ( e->rtti_isVar() ) {
@@ -465,34 +660,34 @@ namespace das {
                 if ( v->variable->access_ref ) return false;    // address taken somewhere
                 auto vt = v->variable->type;
                 if ( vt && (vt->ref || vt->isRefType()) ) return false;
-                for ( size_t oi=0, ois=call->arguments.size(); oi!=ois; ++oi ) {
-                    auto & OP = callee->arguments[oi];
+                for ( size_t oi=0, ois=sa.count(); oi!=ois; ++oi ) {
+                    auto & OP = sa.param(oi);
                     bool oRef = OP->type->ref || OP->type->isRefType();
                     if ( !oRef || OP->type->constant ) continue;
-                    Expression * oleaf = call->arguments[oi];
+                    Expression * oleaf = sa.arg(oi);
                     if ( oleaf->rtti_isR2V() ) oleaf = static_cast<ExprRef2Value *>(oleaf)->subexpr;
                     if ( oleaf->rtti_isVar() && static_cast<ExprVar *>(oleaf)->variable==v->variable ) return false;
                 }
                 return true;
             }
-            if ( e->rtti_isR2V() ) return argReadsOnlyPrivateLocals(static_cast<ExprRef2Value *>(e)->subexpr, call, callee);
-            if ( e->rtti_isCast() ) return argReadsOnlyPrivateLocals(static_cast<ExprCast *>(e)->subexpr, call, callee);
-            if ( e->rtti_isOp1() ) return argReadsOnlyPrivateLocals(static_cast<ExprOp1 *>(e)->subexpr, call, callee);
+            if ( e->rtti_isR2V() ) return argReadsOnlyPrivateLocals(static_cast<ExprRef2Value *>(e)->subexpr, sa);
+            if ( e->rtti_isCast() ) return argReadsOnlyPrivateLocals(static_cast<ExprCast *>(e)->subexpr, sa);
+            if ( e->rtti_isOp1() ) return argReadsOnlyPrivateLocals(static_cast<ExprOp1 *>(e)->subexpr, sa);
             if ( e->rtti_isOp2() ) {
                 auto op = static_cast<ExprOp2 *>(e);
-                return argReadsOnlyPrivateLocals(op->left, call, callee)
-                    && argReadsOnlyPrivateLocals(op->right, call, callee);
+                return argReadsOnlyPrivateLocals(op->left, sa)
+                    && argReadsOnlyPrivateLocals(op->right, sa);
             }
             if ( e->rtti_isOp3() ) {
                 auto op = static_cast<ExprOp3 *>(e);
-                return argReadsOnlyPrivateLocals(op->subexpr, call, callee)
-                    && argReadsOnlyPrivateLocals(op->left, call, callee)
-                    && argReadsOnlyPrivateLocals(op->right, call, callee);
+                return argReadsOnlyPrivateLocals(op->subexpr, sa)
+                    && argReadsOnlyPrivateLocals(op->left, sa)
+                    && argReadsOnlyPrivateLocals(op->right, sa);
             }
             if ( e->rtti_isCall() ) {
                 auto c = static_cast<ExprCall *>(e);
                 for ( auto & a : c->arguments ) {
-                    if ( !argReadsOnlyPrivateLocals(a, call, callee) ) return false;
+                    if ( !argReadsOnlyPrivateLocals(a, sa) ) return false;
                 }
                 return true;
             }
@@ -515,7 +710,7 @@ namespace das {
             vector<Expression *> lazyOps;   // lazy ops on the path, outermost LAST (pushed on unwind)
         };
 
-        SitePosition findPath ( Expression * root, ExprCall * call, PathScan & scan ) {
+        SitePosition findPath ( Expression * root, Expression * call, PathScan & scan ) {
             if ( root==call ) return SitePosition::Eager;
             vector<pair<Expression *,int>> kids;
             childrenInEvalOrder(root, kids);
@@ -537,7 +732,7 @@ namespace das {
         // maximal impure subexpressions evaluated strictly before `call` within `root`,
         // in evaluation order. hoisting them (whole, internal laziness intact) keeps the
         // spliced arg temps from jumping ahead of earlier side effects
-        void collectImpurePrefix ( Expression * root, ExprCall * call, vector<Expression *> & prefix ) {
+        void collectImpurePrefix ( Expression * root, Expression * call, vector<Expression *> & prefix ) {
             if ( root==call ) return;
             vector<pair<Expression *,int>> kids;
             childrenInEvalOrder(root, kids);
@@ -560,6 +755,9 @@ namespace das {
             var->generated = true;
             var->type = new TypeDecl(Type::autoinfer);
             var->type->constant = isConst;
+            // autoinfer inherits constness from the init; a mutable temp initialized
+            // from a constant must strip it (the `-const` operator) or writes fail
+            var->type->removeConstant = !isConst;
             var->type->ref = isRef;
             var->init = init;
             var->init_via_move = viaMove;
@@ -612,7 +810,11 @@ namespace das {
             if ( !arg->type ) continue;
             if ( arg->type->temporary ) { err = "[inline] does not support temporary (#) parameter '" + arg->name + "'"; return false; }
             if ( arg->type->implicit ) { err = "[inline] does not support implicit parameter '" + arg->name + "'"; return false; }
+            // a smart-pointer argument temp would need inscope/move discipline the
+            // splicer does not manufacture (strict_smart_pointers rejects the copy)
+            if ( arg->type->smartPtr ) { err = "[inline] does not support smart-pointer parameter '" + arg->name + "'"; return false; }
         }
+        if ( fn->result && fn->result->smartPtr ) { err = "[inline] does not support a smart-pointer result"; return false; }
         auto body = static_cast<ExprBlock *>(fn->body);
         InlineShapeScan scan;
         scan.lastTopLevelStmt = body->list.empty() ? nullptr : body->list.back();
@@ -657,6 +859,58 @@ namespace das {
         return true;
     }
 
+    // ----- best-effort shape gates (auto inlining and devirtualization decline, never error) -----
+
+    namespace {
+
+        // a block literal the devirtualizer can splice in place: a plain in-frame block
+        // with a single-exit body and a by-value (or void) result. splicing dissolves the
+        // block boundary, so a break/continue not bound to a loop inside the body is out
+        bool checkDevirtShape ( ExprMakeBlock * mkb, string & why ) {
+            if ( mkb->isLambda || mkb->isLocalFunction || !mkb->capture.empty() ) { why = "lambda literal"; return false; }
+            if ( !mkb->block || !mkb->block->rtti_isBlock() ) { why = "no block body"; return false; }
+            auto blk = static_cast<ExprBlock *>(mkb->block);
+            bool isVoid = !blk->returnType || blk->returnType->isVoid();
+            if ( !isVoid && (blk->returnType->ref || blk->returnType->isRefType()) ) {
+                why = "result is not by-value";
+                return false;
+            }
+            for ( auto & arg : blk->arguments ) {
+                if ( !arg->type ) { why = "unresolved parameter"; return false; }
+                if ( arg->type->temporary ) { why = "temporary (#) parameter"; return false; }
+                if ( arg->type->implicit ) { why = "implicit parameter"; return false; }
+                if ( arg->type->smartPtr ) { why = "smart-pointer parameter"; return false; }
+            }
+            if ( blk->returnType && blk->returnType->smartPtr ) { why = "smart-pointer result"; return false; }
+            InlineShapeScan scan(true);
+            scan.lastTopLevelStmt = blk->list.empty() ? nullptr : blk->list.back();
+            blk->visit(scan);
+            if ( scan.bad ) { why = scan.reason; return false; }
+            if ( scan.misplacedReturn ) { why = "multiple exits"; return false; }
+            if ( !isVoid && scan.returnCount!=1 ) { why = "multiple exits"; return false; }
+            return true;
+        }
+
+        // recursion over the whole splice graph - [inline] calls and auto-eligible
+        // block-literal calls alike - would re-manufacture eligible sites every round
+        bool spliceGraphReaches ( Function * target, Function * cur, das_hash_set<Function *> & visited ) {
+            if ( !cur->body ) return false;
+            bool found = false;
+            lookupExpressions(cur->body, [&](Expression * expr) {
+                if ( found || !expr->rtti_isCall() ) return;
+                auto call = static_cast<ExprCall *>(expr);
+                if ( !call->func ) return;
+                if ( !call->func->mustInline && !autoEligibleCall(call) ) return;
+                if ( call->func==target ) { found = true; return; }
+                if ( visited.insert(call->func).second ) {
+                    if ( spliceGraphReaches(target, call->func, visited) ) found = true;
+                }
+            });
+            return found;
+        }
+
+    } // anonymous namespace
+
     // ----- the patch pass -----
 
     namespace {
@@ -665,10 +919,17 @@ namespace das {
             Program * program = nullptr;
             TextWriter * logs = nullptr;
             bool logOpt = false;
+            bool mustEnabled = true;
+            bool autoEnabled = false;
             bool changed = false;
-            int inlined = 0;
-            das_hash_map<Function *, ParamReadStats> statsCache;
+            int inlined = 0;        // [inline] sites
+            int inlinedAuto = 0;    // auto block-literal call sites
+            int devirted = 0;       // invoke-of-literal sites
+            int declined = 0;       // best-effort sites the pass passed on
+            das_hash_map<ExprBlock *, ParamReadStats> statsCache;
             das_hash_map<Function *, bool> shapeCache;
+            das_hash_map<Function *, pair<bool,string>> autoOkCache;
+            das_hash_map<ExprMakeBlock *, pair<bool,string>> devirtShapeCache;
             das_hash_map<Function *, string> privateUseCache;
 
             bool calleeShapeOk ( Function * fn ) {
@@ -680,19 +941,68 @@ namespace das {
                 return ok;
             }
 
-            const ParamReadStats & paramStats ( Function * fn ) {
-                auto it = statsCache.find(fn);
+            // best-effort callee gate: [inline]'s shape contract, plus no unsafe in the
+            // body (a spliced unsafe re-checks against the CALLER module's permissions),
+            // plus no recursion through the combined splice graph
+            bool autoCalleeOk ( Function * fn, string & why ) {
+                auto it = autoOkCache.find(fn);
+                if ( it != autoOkCache.end() ) { why = it->second.second; return it->second.first; }
+                bool ok = true;
+                if ( !checkInlineShape(fn, why) ) {
+                    ok = false;
+                } else if ( fn->unsafeOperation || fn->unsafeDeref || fn->hasUnsafe ) {
+                    // hasUnsafe is stamped by infer and survives foldUnsafe: a spliced
+                    // unsafe body would re-check against the caller's module, wrapper-less
+                    ok = false;
+                    why = "unsafe operation";
+                } else if ( annotatedCallee(fn, why) ) {
+                    ok = false;     // an annotation may carry call-site semantics
+                                    // (verifyCall & co) that a splice would bypass
+                } else {
+                    // a type<...> witness naming the generic's own alias (type<TT>) stays
+                    // symbolic in the instance body and cannot re-resolve after a splice
+                    bool aliasWitness = false;
+                    lookupExpressions(fn->body, [&](Expression * expr) {
+                        if ( aliasWitness || !expr->rtti_isTypeDecl() ) return;
+                        auto td = static_cast<ExprTypeDecl *>(expr);
+                        if ( td->typeexpr && td->typeexpr->isAutoOrAlias() ) aliasWitness = true;
+                    });
+                    if ( aliasWitness ) {
+                        ok = false;
+                        why = "body carries a generic type witness";
+                    } else {
+                        das_hash_set<Function *> visited;
+                        if ( spliceGraphReaches(fn, fn, visited) ) {
+                            ok = false;
+                            why = "recursive through the inline graph";
+                        }
+                    }
+                }
+                autoOkCache[fn] = pair<bool,string>(ok, why);
+                return ok;
+            }
+
+            bool devirtShapeOk ( ExprMakeBlock * mkb, string & why ) {
+                auto it = devirtShapeCache.find(mkb);
+                if ( it != devirtShapeCache.end() ) { why = it->second.second; return it->second.first; }
+                bool ok = checkDevirtShape(mkb, why);
+                devirtShapeCache[mkb] = pair<bool,string>(ok, why);
+                return ok;
+            }
+
+            const ParamReadStats & paramStats ( ExprBlock * body, const vector<VariablePtr> & params ) {
+                auto it = statsCache.find(body);
                 if ( it != statsCache.end() ) return it->second;
-                auto & st = statsCache[fn];
-                ParamReadScan scan(fn, st);
-                fn->body->visit(scan);
+                auto & st = statsCache[body];
+                ParamReadScan scan(params, st);
+                body->visit(scan);
                 return st;
             }
 
-            const string & privateUse ( Function * fn ) {
+            const string & privateUse ( Function * fn, Module * originModule ) {
                 auto it = privateUseCache.find(fn);
                 if ( it != privateUseCache.end() ) return it->second;
-                PrivateUseScan scan(fn->module);
+                PrivateUseScan scan(originModule, program->thisModule.get());
                 fn->body->visit(scan);
                 return privateUseCache[fn] = scan.privateSymbol;
             }
@@ -723,28 +1033,86 @@ namespace das {
                 program->error(what, "", "", at, CompilationError::invalid_annotation);
             }
 
-            void logSite ( Function * caller, ExprCall * call ) {
-                if ( logOpt && logs ) {
-                    *logs << "INLINE " << call->func->getMangledName() << " into "
-                          << caller->getMangledName() << " at " << call->at.describe() << "\n";
+            // a MUST site that can't splice fails the compile; a best-effort site
+            // declines silently (counted, logged under log_optimization)
+            void siteFail ( const PlannedSite & site, const string & what, const LineInfo & at ) {
+                if ( site.kind==SiteKind::MustCall ) {
+                    error(what, at);
+                } else {
+                    decline(site, what, at);
                 }
+            }
+
+            void decline ( const PlannedSite & site, const string & why, const LineInfo & at ) {
+                declined ++;
+                if ( logOpt && logs ) {
+                    *logs << (site.kind==SiteKind::Devirt ? "DEVIRT DECLINED at " : "AUTO-INLINE DECLINED at ")
+                          << at.describe() << ": " << why << "\n";
+                }
+            }
+
+            void completeSite ( const PlannedSite & site, Function * caller, const string & subjName ) {
+                switch ( site.kind ) {
+                    case SiteKind::MustCall: inlined ++; break;
+                    case SiteKind::AutoCall: inlinedAuto ++; break;
+                    case SiteKind::Devirt:   devirted ++; break;
+                }
+                if ( logOpt && logs ) {
+                    const char * verb = site.kind==SiteKind::MustCall ? "INLINE "
+                        : site.kind==SiteKind::AutoCall ? "AUTO-INLINE " : "DEVIRT ";
+                    *logs << verb << subjName << " into " << caller->getMangledName()
+                          << " at " << site.callLike->at.describe() << "\n";
+                }
+                changed = true;
             }
 
             void processFunction ( Function * fn );
         };
 
         void InlinePatch::processFunction ( Function * fn ) {
-            InlineCollect collect;
+            InlineCollect collect(autoEnabled);
             fn->body->visit(collect);
             if ( collect.sites.empty() ) return;
+            // let-bound block literals this function's invokes may resolve to
+            das_hash_map<Variable *, ExprMakeBlock *> bindings;
+            if ( autoEnabled ) {
+                BlockBindingScan bscan;
+                fn->body->visit(bscan);
+                for ( auto & kv : bscan.binding ) {
+                    if ( bscan.disq.find(kv.first)==bscan.disq.end() ) bindings[kv.first] = kv.second;
+                }
+            }
             int inlineId = nextInlineId(fn);
             // a splice shifts the indices of later statements in the same block
             das_hash_map<ExprBlock *, int> indexShift;
             for ( auto & site : collect.sites ) {
-                auto call = site.call;
-                auto callee = call->func;
+                auto callLike = site.callLike;
+                if ( site.kind==SiteKind::MustCall && !mustEnabled ) continue;
+                // ----- resolve the splice subject -----
+                Function * calleeFn = nullptr;          // MustCall / AutoCall
+                ExprMakeBlock * literal = nullptr;      // Devirt
+                string subjName;
+                if ( site.kind==SiteKind::Devirt ) {
+                    auto inv = static_cast<ExprInvoke *>(callLike);
+                    Expression * a0 = inv->arguments[0];
+                    if ( a0->rtti_isR2V() ) a0 = static_cast<ExprRef2Value *>(a0)->subexpr;
+                    if ( a0->rtti_isMakeBlock() ) {
+                        literal = static_cast<ExprMakeBlock *>(a0);
+                    } else if ( a0->rtti_isVar() ) {
+                        auto v = static_cast<ExprVar *>(a0);
+                        if ( v->variable ) {
+                            auto bit = bindings.find(v->variable);
+                            if ( bit!=bindings.end() ) literal = bit->second;
+                        }
+                    }
+                    if ( !literal ) continue;   // not a traceable block literal
+                    subjName = "block";
+                } else {
+                    calleeFn = static_cast<ExprCall *>(callLike)->func;
+                    subjName = calleeFn->name;
+                }
                 if ( !site.stmt || !site.anchor.block ) {
-                    error("can't inline " + callee->name + " here: the call is outside a function statement", call->at);
+                    siteFail(site, "can't inline " + subjName + " here: the call is outside a function statement", callLike->at);
                     continue;
                 }
                 int anchorIndex = site.anchor.index + indexShift[site.anchor.block];
@@ -759,38 +1127,66 @@ namespace das {
                     || site.anchor.block->list[anchorIndex] != site.stmt ) {
                     continue;
                 }
-                bool siteLive = exprContains(site.stmt, call);
+                bool siteLive = exprContains(site.stmt, callLike);
                 if ( !siteLive && site.stmt->rtti_isWhile() ) {
-                    siteLive = exprContains(static_cast<ExprWhile *>(site.stmt)->cond, call);
+                    siteLive = exprContains(static_cast<ExprWhile *>(site.stmt)->cond, callLike);
                 }
                 if ( !siteLive && site.stmt->rtti_isIfThenElse() ) {
                     auto lite = static_cast<ExprIfThenElse *>(site.stmt);
                     while ( lite->if_false && lite->if_false->rtti_isIfThenElse() ) {
                         auto inner = static_cast<ExprIfThenElse *>(lite->if_false);
-                        if ( exprContains(inner->cond, call) ) { siteLive = true; break; }
+                        if ( exprContains(inner->cond, callLike) ) { siteLive = true; break; }
                         lite = inner;
                     }
                 }
                 if ( !siteLive ) continue;
-                if ( !calleeShapeOk(callee) ) continue;             // lint reports at the declaration
-                if ( call->arguments.size() != callee->arguments.size() ) continue; // not fully inferred - defensive
-                if ( callee->module != program->thisModule.get() ) {
-                    auto & priv = privateUse(callee);
-                    if ( !priv.empty() ) {
-                        error("can't inline " + callee->name + " across modules: body uses private symbol '" + priv + "'", call->at);
-                        continue;
+                // ----- subject shape gates -----
+                ExprBlock * body = nullptr;
+                TypeDecl * subjResult = nullptr;    // null = void result
+                SiteArgs sa;
+                if ( site.kind==SiteKind::Devirt ) {
+                    string why;
+                    if ( !devirtShapeOk(literal, why) ) { decline(site, why, callLike->at); continue; }
+                    auto blk = static_cast<ExprBlock *>(literal->block);
+                    auto inv = static_cast<ExprInvoke *>(callLike);
+                    if ( inv->arguments.size() != blk->arguments.size()+1 ) { decline(site, "argument count mismatch", callLike->at); continue; }
+                    body = blk;
+                    if ( blk->returnType && !blk->returnType->isVoid() ) subjResult = blk->returnType;
+                    sa.args = &inv->arguments; sa.ofs = 1; sa.params = &blk->arguments;
+                } else {
+                    auto call = static_cast<ExprCall *>(callLike);
+                    if ( site.kind==SiteKind::MustCall ) {
+                        if ( !calleeShapeOk(calleeFn) ) continue;   // lint reports at the declaration
+                    } else {
+                        string why;
+                        if ( !autoCalleeOk(calleeFn, why) ) { decline(site, subjName + ": " + why, callLike->at); continue; }
                     }
+                    if ( call->arguments.size() != calleeFn->arguments.size() ) continue; // not fully inferred - defensive
+                    // a generic instance lives in the CALLER's module - judge its home
+                    // (and the reachability of its references) by the generic's origin
+                    Module * originModule = calleeFn->fromGeneric
+                        ? calleeFn->fromGeneric->module : calleeFn->module;
+                    if ( originModule != program->thisModule.get() ) {
+                        auto & priv = privateUse(calleeFn, originModule);
+                        if ( !priv.empty() ) {
+                            siteFail(site, "can't inline " + subjName + " across modules: body uses private symbol '" + priv + "'", callLike->at);
+                            continue;
+                        }
+                    }
+                    body = static_cast<ExprBlock *>(calleeFn->body);
+                    if ( calleeFn->result && !calleeFn->result->isVoid() ) subjResult = calleeFn->result;
+                    sa.args = &call->arguments; sa.ofs = 0; sa.params = &calleeFn->arguments;
                 }
                 // ----- classify arguments -----
-                auto & stats = paramStats(callee);
-                auto body = static_cast<ExprBlock *>(callee->body);
-                bool isVoid = !callee->result || callee->result->isVoid();
+                auto & stats = paramStats(body, *sa.params);
+                bool isVoid = subjResult==nullptr;
                 bool exprBody = body->list.size()==1 && body->list.back()->rtti_isReturn();
+                bool writeFree = calleeFn ? calleeWriteFree(calleeFn) : false;  // a block body is judged unknown
                 das_hash_map<Variable *, ArgSub> paramSub;
                 vector<ExpressionPtr> temps;
-                for ( size_t ai=0, ais=call->arguments.size(); ai!=ais; ++ai ) {
-                    auto & A = call->arguments[ai];
-                    auto & P = callee->arguments[ai];
+                for ( size_t ai=0, ais=sa.count(); ai!=ais; ++ai ) {
+                    Expression * A = sa.arg(ai);
+                    auto & P = sa.param(ai);
                     ArgSub sub;
                     bool byRefParam = P->type->ref || P->type->isRefType();
                     bool varParam = !P->type->constant;
@@ -800,21 +1196,46 @@ namespace das {
                     bool leafVar = leafA->rtti_isVar();
                     auto makeArgTemp = [&]( Expression * init, bool cnst, bool ref, bool viaMove ) {
                         string tname = "__inl" + to_string(inlineId) + "_arg_" + P->name;
-                        temps.push_back(makeTemp(call->at, tname, init, cnst, ref, viaMove));
+                        temps.push_back(makeTemp(callLike->at, tname, init, cnst, ref, viaMove));
                         sub.tempName = tname;
                     };
+                    if ( leafA->rtti_isTypeDecl() ) {
+                        // type<...> witness: a compile-time tag - a temp would "use" it
+                        sub.substitute = leafA;
+                        paramSub[P] = sub;
+                        continue;
+                    }
                     if ( byRefParam ) {
                         if ( leafVar ) {
                             sub.substitute = leafA;             // same aliasing as the call itself
+                        } else if ( leafA->rtti_isMakeBlock() ) {
+                            // a block literal read once outside loops substitutes textually,
+                            // keeping shapes a holder can't reproduce (temporary-typed block
+                            // parameters do not survive a `var <-` binding). multi-read and
+                            // under-loop literals bind a holder; devirtualization takes over
+                            int reads = 0;
+                            auto rit = stats.readCount.find(P);
+                            if ( rit != stats.readCount.end() ) reads = rit->second;
+                            bool underLoop = stats.readUnderLoop.find(P)!=stats.readUnderLoop.end();
+                            if ( reads<=1 && !underLoop ) {
+                                sub.substitute = leafA;
+                            } else {
+                                makeArgTemp(A->clone(), false, false, true);
+                            }
                         } else if ( A->type && A->type->ref ) {
                             // lvalue chain (field/index): bind a reference once, like the call did
                             auto init = A->clone();
                             init->alwaysSafe = true;            // generated binding to real storage
                             makeArgTemp(init, !varParam, true, false);
                         } else {
-                            // rvalue into a const-ref param: materialize the value
+                            // rvalue into a ref param: materialize the value. constness
+                            // follows the param (a var-ref param - e.g. a consumed iterator -
+                            // needs a mutable holder), and a block always binds `var`: a const
+                            // holder const-propagates into the invoke, rejecting the block's
+                            // own var parameters
                             bool nonCopyable = A->type && !A->type->canCopy();
-                            makeArgTemp(A->clone(), true, false, nonCopyable);
+                            bool blockValue = A->type && A->type->baseType==Type::tBlock;
+                            makeArgTemp(A->clone(), !varParam && !blockValue, false, nonCopyable);
                         }
                     } else if ( varParam ) {
                         // a mutable by-value param IS a local copy
@@ -829,10 +1250,10 @@ namespace das {
                         if ( av->variable ) {
                             for ( size_t oi=0; oi!=ais; ++oi ) {
                                 if ( oi==ai ) continue;
-                                auto & OP = callee->arguments[oi];
+                                auto & OP = sa.param(oi);
                                 bool oRef = OP->type->ref || OP->type->isRefType();
                                 if ( !oRef || OP->type->constant ) continue;
-                                Expression * oleaf = call->arguments[oi];
+                                Expression * oleaf = sa.arg(oi);
                                 if ( oleaf->rtti_isR2V() ) oleaf = static_cast<ExprRef2Value *>(oleaf)->subexpr;
                                 if ( oleaf->rtti_isVar() && static_cast<ExprVar *>(oleaf)->variable==av->variable ) {
                                     hazard = true;
@@ -842,7 +1263,7 @@ namespace das {
                             if ( !hazard && (av->isGlobalVariable() || av->variable->access_ref) ) {
                                 // a global, or a local whose address escaped: the spliced
                                 // body's writes could reach it, breaking snapshot semantics
-                                hazard = !calleeWriteFree(callee);
+                                hazard = !writeFree;
                             }
                         }
                         if ( hazard ) {
@@ -856,7 +1277,7 @@ namespace das {
                         auto rit = stats.readCount.find(P);
                         if ( rit != stats.readCount.end() ) reads = rit->second;
                         bool underLoop = stats.readUnderLoop.find(P)!=stats.readUnderLoop.end();
-                        bool orderSafe = calleeWriteFree(callee) || argReadsOnlyPrivateLocals(A, call, callee);
+                        bool orderSafe = writeFree || argReadsOnlyPrivateLocals(A, sa);
                         if ( reads<=1 && !underLoop && inlinePure(A) && orderSafe ) {
                             sub.substitute = A;
                         } else {
@@ -872,13 +1293,13 @@ namespace das {
                     InlineBodyRewriter rewriter;
                     rewriter.paramSub = &paramSub;
                     rewriter.rename = &rename;
-                    rewriter.tempAt = call->at;
+                    rewriter.tempAt = callLike->at;
                     auto ret = static_cast<ExprReturn *>(body->list.back());
                     ExpressionPtr callReplacement = nullptr;
                     if ( ret->subexpr ) {
                         callReplacement = ret->subexpr->clone()->visit(rewriter);
                     }
-                    if ( site.stmt==call ) {
+                    if ( site.stmt==callLike ) {
                         auto & list = site.anchor.block->list;
                         if ( callReplacement ) {
                             list[anchorIndex] = callReplacement;
@@ -888,29 +1309,27 @@ namespace das {
                         }
                     } else {
                         ReplaceNode rn;
-                        rn.what = call;
+                        rn.what = callLike;
                         rn.with = callReplacement;
                         if ( !callReplacement ) {
-                            error("can't inline void " + callee->name + " here: the call is not a statement", call->at);
+                            siteFail(site, "can't inline void " + subjName + " here: the call is not a statement", callLike->at);
                             continue;
                         }
                         auto & slot = site.anchor.block->list[anchorIndex];
                         slot = slot->visit(rn);
                         if ( !rn.done ) {
-                            error("internal error: inlined call not found in its statement", call->at);
+                            error("internal error: inlined call not found in its statement", callLike->at);
                             continue;
                         }
                     }
-                    logSite(fn, call);
-                    inlined ++;
+                    completeSite(site, fn, subjName);
                     inlineId ++;
-                    changed = true;
                     continue;
                 }
                 // ----- statements needed: check the position, lower if necessary -----
                 if ( site.stmt->rtti_isWhile() ) {
                     auto wh = static_cast<ExprWhile *>(site.stmt);
-                    if ( exprContains(wh->cond, call) && wh->body->rtti_isBlock() ) {
+                    if ( exprContains(wh->cond, callLike) && wh->body->rtti_isBlock() ) {
                         // while(C) -> while(true) { if (!(C)) break; ... } - the condition
                         // becomes a statement-anchored expression, next round splices there
                         auto brkBlock = new ExprBlock();
@@ -932,7 +1351,7 @@ namespace das {
                     bool lowered = false;
                     while ( ite->if_false && ite->if_false->rtti_isIfThenElse() ) {
                         auto inner = static_cast<ExprIfThenElse *>(ite->if_false);
-                        if ( exprContains(inner->cond, call) || exprContains(ite->if_false, call) ) {
+                        if ( exprContains(inner->cond, callLike) || exprContains(ite->if_false, callLike) ) {
                             auto blk = new ExprBlock();
                             blk->at = inner->at;
                             blk->list.push_back(ite->if_false);
@@ -948,13 +1367,13 @@ namespace das {
                     }
                 }
                 PathScan path;
-                auto pos = findPath(site.stmt, call, path);
+                auto pos = findPath(site.stmt, callLike, path);
                 if ( pos==SitePosition::NotFound ) {
-                    error("can't inline " + callee->name + " here: unsupported call position", call->at);
+                    siteFail(site, "can't inline " + subjName + " here: unsupported call position", callLike->at);
                     continue;
                 }
                 if ( pos==SitePosition::Unsupported ) {
-                    error("can't inline " + callee->name + " inside ?? or a safe-navigation suffix - hoist the call into its own statement", call->at);
+                    siteFail(site, "can't inline " + subjName + " inside ?? or a safe-navigation suffix - hoist the call into its own statement", callLike->at);
                     continue;
                 }
                 if ( pos==SitePosition::Lazy ) {
@@ -976,13 +1395,15 @@ namespace das {
                     if ( !rootVar ) {
                         string tname = "__inl" + to_string(inlineId) + "_low";
                         inlineId ++;
-                        auto hoist = makeTemp(call->at, tname, lazy, true, false, false);
+                        // a non-const temp: a `var p = <temp>` consumer of pointer type
+                        // rejects initialization from a const reference
+                        auto hoist = makeTemp(callLike->at, tname, lazy, false, false, false);
                         ReplaceNode rn;
                         rn.what = lazy;
-                        rn.with = new ExprVar(call->at, tname);
+                        rn.with = new ExprVar(callLike->at, tname);
                         list[anchorIndex] = list[anchorIndex]->visit(rn);
                         if ( !rn.done ) {
-                            error("internal error: lazy operator not found in its statement", call->at);
+                            error("internal error: lazy operator not found in its statement", callLike->at);
                             continue;
                         }
                         list.insert(list.begin()+anchorIndex, hoist);
@@ -991,7 +1412,7 @@ namespace das {
                         continue;
                     }
                     if ( !lazy->type ) {
-                        error("can't inline " + callee->name + " here: missing type on the lazy operator", call->at);
+                        siteFail(site, "can't inline " + subjName + " here: missing type on the lazy operator", callLike->at);
                         continue;
                     }
                     vector<ExpressionPtr> replacement;
@@ -1016,7 +1437,7 @@ namespace das {
                         if ( op2->op=="||" ) cond = new ExprOp1(op2->at, "!", cond);
                         replacement.push_back(new ExprIfThenElse(op2->at, cond, thenBlk, nullptr));
                     } else {
-                        error("can't inline " + callee->name + " here: unsupported lazy operator", call->at);
+                        siteFail(site, "can't inline " + subjName + " here: unsupported lazy operator", callLike->at);
                         continue;
                     }
                     list.erase(list.begin()+anchorIndex);
@@ -1027,26 +1448,38 @@ namespace das {
                 }
                 // ----- eager position: hoist the impure prefix, splice temps and body -----
                 vector<Expression *> prefix;
-                collectImpurePrefix(site.stmt, call, prefix);
+                collectImpurePrefix(site.stmt, callLike, prefix);
                 vector<ExpressionPtr> splice;
                 bool prefixFailed = false;
                 int preIdx = 0;
                 for ( auto pe : prefix ) {
                     if ( pe->type && pe->type->isVoid() ) {
                         // a void expression can only BE the statement, and then it has no prefix
-                        error("can't inline " + callee->name + " here: void expression in the evaluation prefix", call->at);
+                        siteFail(site, "can't inline " + subjName + " here: void expression in the evaluation prefix", callLike->at);
                         prefixFailed = true;
                         break;
                     }
                     string tname = "__inl" + to_string(inlineId) + "_pre" + to_string(preIdx++);
-                    splice.push_back(makeTemp(pe->at, tname, pe, true, false, false));
+                    // non-const temps throughout: the hoisted expression was a non-const
+                    // rvalue (or keeps its lvalue constness via the reference binding), and
+                    // a const temp read would no longer match var pointer params downstream
+                    if ( pe->type && pe->type->ref ) {
+                        // lvalue: bind a reference once - evaluation order and identity
+                        // both survive (writes through the temp land in the original place)
+                        pe->alwaysSafe = true;          // generated binding to real storage
+                        splice.push_back(makeTemp(pe->at, tname, pe, pe->type->constant, true, false));
+                    } else if ( pe->type && !pe->type->canCopy() ) {
+                        splice.push_back(makeTemp(pe->at, tname, pe, false, false, true));  // move the rvalue
+                    } else {
+                        splice.push_back(makeTemp(pe->at, tname, pe, false, false, false));
+                    }
                     ReplaceNode rn;
                     rn.what = pe;
                     rn.with = new ExprVar(pe->at, tname);
                     auto & slot = site.anchor.block->list[anchorIndex];
                     slot = slot->visit(rn);
                     if ( !rn.done ) {
-                        error("internal error: prefix expression not found in its statement", call->at);
+                        error("internal error: prefix expression not found in its statement", callLike->at);
                         prefixFailed = true;
                         break;
                     }
@@ -1057,12 +1490,15 @@ namespace das {
                 das_hash_map<string, string> rename;
                 LocalNameCollect names;
                 names.rename = &rename;
-                names.prefix = "__inl" + to_string(inlineId) + "_";
-                callee->body->visit(names);
+                // renamed locals live in the _l_ sub-namespace so a callee local named
+                // `res` (or `arg_x`, `pre0`, `low`) can never collide with the
+                // manufactured _res/_arg_*/_pre*/_low temps of the same site
+                names.prefix = "__inl" + to_string(inlineId) + "_l_";
+                body->visit(names);
                 InlineBodyRewriter rewriter;
                 rewriter.paramSub = &paramSub;
                 rewriter.rename = &rename;
-                rewriter.tempAt = call->at;
+                rewriter.tempAt = callLike->at;
                 ExpressionPtr callReplacement = nullptr;
                 if ( exprBody ) {
                     auto ret = static_cast<ExprReturn *>(body->list.back());
@@ -1070,7 +1506,19 @@ namespace das {
                         callReplacement = ret->subexpr->clone()->visit(rewriter);
                     }
                 } else {
-                    auto bodyClone = static_cast<ExprBlock *>(callee->body->clone());
+                    auto bodyClone = static_cast<ExprBlock *>(body->clone());
+                    if ( site.kind==SiteKind::Devirt ) {
+                        // the literal's parameters became substitutions and its result
+                        // becomes the result temp: the spliced copy is a plain scope block
+                        bodyClone->arguments.clear();
+                        bodyClone->annotations.clear();
+                        bodyClone->returnType = nullptr;
+                        bodyClone->isClosure = false;
+                        bodyClone->isLambdaBlock = false;
+                        bodyClone->hasReturn = false;
+                        bodyClone->copyOnReturn = false;
+                        bodyClone->moveOnReturn = false;
+                    }
                     ExpressionPtr trailing = nullptr;
                     if ( !bodyClone->list.empty() && bodyClone->list.back()->rtti_isReturn() ) {
                         trailing = bodyClone->list.back();
@@ -1078,11 +1526,11 @@ namespace das {
                     }
                     if ( !isVoid ) {
                         string resName = "__inl" + to_string(inlineId) + "_res";
-                        splice.push_back(makeUninitDecl(call->at, resName, callee->result));
+                        splice.push_back(makeUninitDecl(callLike->at, resName, subjResult));
                         auto ret = static_cast<ExprReturn *>(trailing);
                         bodyClone->list.push_back(new ExprCopy(ret->at,
                             new ExprVar(ret->at, resName), ret->subexpr));
-                        callReplacement = new ExprVar(call->at, resName);
+                        callReplacement = new ExprVar(callLike->at, resName);
                     }
                     splice.push_back(bodyClone->visit(rewriter));
                 }
@@ -1090,7 +1538,7 @@ namespace das {
                 list.insert(list.begin()+anchorIndex, splice.begin(), splice.end());
                 indexShift[site.anchor.block] += int(splice.size());
                 int stmtIndex = anchorIndex + int(splice.size());
-                if ( list[stmtIndex]==call ) {
+                if ( list[stmtIndex]==callLike ) {
                     // the call IS the statement
                     if ( callReplacement ) {
                         list[stmtIndex] = callReplacement;
@@ -1100,24 +1548,22 @@ namespace das {
                     }
                 } else {
                     ReplaceNode rn;
-                    rn.what = call;
+                    rn.what = callLike;
                     rn.with = callReplacement;
                     list[stmtIndex] = list[stmtIndex]->visit(rn);
                     if ( !rn.done ) {
-                        error("internal error: inlined call not found in its statement", call->at);
+                        error("internal error: inlined call not found in its statement", callLike->at);
                         continue;
                     }
                 }
-                logSite(fn, call);
-                inlined ++;
+                completeSite(site, fn, subjName);
                 inlineId ++;
-                changed = true;
             }
         }
 
-        // DFS postorder over the inline graph inside this module, [inline] functions
+        // DFS postorder over the splice graph inside this module, [inline] functions
         // first: a chain f -> g -> h splices already-inlined bodies in a single round
-        void orderInlineFunctions ( Module * thisMod, Function * fn,
+        void orderInlineFunctions ( Module * thisMod, Function * fn, bool autoOn,
                 vector<Function *> & order, das_hash_set<Function *> & seen ) {
             if ( !fn->body || fn->isTemplate || fn->stub ) return;
             if ( fn->module != thisMod ) return;
@@ -1125,8 +1571,9 @@ namespace das {
             lookupExpressions(fn->body, [&](Expression * expr) {
                 if ( expr->rtti_isCall() ) {
                     auto call = static_cast<ExprCall *>(expr);
-                    if ( call->func && call->func->mustInline ) {
-                        orderInlineFunctions(thisMod, call->func, order, seen);
+                    if ( !call->func ) return;
+                    if ( call->func->mustInline || (autoOn && autoEligibleCall(call)) ) {
+                        orderInlineFunctions(thisMod, call->func, autoOn, order, seen);
                     }
                 }
             });
@@ -1136,37 +1583,47 @@ namespace das {
     } // anonymous namespace
 
     bool Program::patchInline() {
-        if ( options.getBoolOption("disable_inline", policies.disable_inline) ) return false;
+        bool mustEnabled = !options.getBoolOption("disable_inline", policies.disable_inline);
+        // best-effort inlining is an optimization: it stays out of unoptimized builds
+        bool autoEnabled = getOptimize()
+            && !options.getBoolOption("disable_auto_inline", policies.disable_auto_inline);
         // cheap gate: any [inline] function visible at all?
         bool anyInline = false;
-        library.foreach([&](Module * mod) -> bool {
-            if ( !anyInline ) {
-                mod->functions.find_first([&](auto fn) {
-                    if ( fn->mustInline ) { anyInline = true; return true; }
-                    return false;
-                });
-            }
-            return true;
-        }, "*");
-        if ( !anyInline ) return false;
+        if ( mustEnabled ) {
+            library.foreach([&](Module * mod) -> bool {
+                if ( !anyInline ) {
+                    mod->functions.find_first([&](auto fn) {
+                        if ( fn->mustInline ) { anyInline = true; return true; }
+                        return false;
+                    });
+                }
+                return true;
+            }, "*");
+        }
+        if ( !anyInline && !autoEnabled ) return false;
         InlinePatch patch;
         patch.program = this;
         patch.logs = daScriptEnvironment::getBound()->g_compilerLog;
-        patch.logOpt = options.getBoolOption("log_optimization", false);
+        patch.logOpt = options.getBoolOption("log_optimization", policies.log_optimization);
+        patch.mustEnabled = mustEnabled && anyInline;
+        patch.autoEnabled = autoEnabled;
         vector<Function *> order;
         das_hash_set<Function *> seen;
         thisModule->functions.foreach([&](auto fn) {
-            if ( fn->mustInline ) orderInlineFunctions(thisModule.get(), fn, order, seen);
+            if ( fn->mustInline ) orderInlineFunctions(thisModule.get(), fn, autoEnabled, order, seen);
         });
         thisModule->functions.foreach([&](auto fn) {
-            orderInlineFunctions(thisModule.get(), fn, order, seen);
+            orderInlineFunctions(thisModule.get(), fn, autoEnabled, order, seen);
         });
         for ( auto fn : order ) {
             patch.processFunction(fn);
             if ( failed() ) break;
         }
-        if ( patch.logOpt && patch.logs && patch.inlined ) {
-            *patch.logs << "INLINE: " << patch.inlined << " call site(s) in module " << thisModule->name << "\n";
+        if ( patch.logOpt && patch.logs
+            && (patch.inlined || patch.inlinedAuto || patch.devirted || patch.declined) ) {
+            *patch.logs << "INLINE: " << patch.inlined << " must + " << patch.inlinedAuto
+                        << " auto + " << patch.devirted << " devirt site(s), "
+                        << patch.declined << " declined in module " << thisModule->name << "\n";
         }
         return patch.changed;
     }

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -1289,8 +1289,7 @@ namespace das {
         "no_heap_array_literals",       Type::tBool,
     // logging
         "log",                          Type::tBool,
-        "log_optimization_passes",      Type::tBool,
-        "log_optimization",             Type::tBool,
+        // log_optimization / log_optimization_passes registered via CodeOfPolicies fields
         "log_stack",                    Type::tBool,
         "log_init",                     Type::tBool,
         "log_symbol_use",               Type::tBool,
@@ -1314,12 +1313,12 @@ namespace das {
     // optimization
         "optimize",                     Type::tBool,
         "no_optimization",              Type::tBool,
-        "fusion",                       Type::tBool,
+        // fusion registered via its CodeOfPolicies field
         "remove_unused_symbols",        Type::tBool,
     // language
         "always_export_initializer",    Type::tBool,
         "infer_time_folding",           Type::tBool,
-        "disable_run",                  Type::tBool,
+        // disable_run registered via its CodeOfPolicies field
         "indenting",                    Type::tInt,
         "no_unsafe_uninitialized_structures", Type::tBool,
     // version_2_syntax

--- a/src/ast/ast_optimize.cpp
+++ b/src/ast/ast_optimize.cpp
@@ -7,8 +7,8 @@
 namespace das {
 
     void optimizeProgram(Program * program, TextWriter & logs, ModuleGroup & libGroup) {
-        bool logOpt = program->options.getBoolOption("log_optimization",false);
-        bool logPass = program->options.getBoolOption("log_optimization_passes",false);
+        bool logOpt = program->options.getBoolOption("log_optimization", program->policies.log_optimization);
+        bool logPass = program->options.getBoolOption("log_optimization_passes", program->policies.log_optimization_passes);
         bool log = logOpt || logPass;
         bool any, last;
         int optimizationRound = 1;

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3821,7 +3821,7 @@ namespace das
 #if DAS_FUSION
         if ( !folding ) {               // note: only run fusion when not folding
             DAS_ASSERTF(g_fusionContextFn, "fusion library not loaded, add call to NEED_FUSION macro.");
-            g_fusionContextFn(context, logs, options.getBoolOption("fusion",true));
+            g_fusionContextFn(context, logs, options.getBoolOption("fusion", policies.fusion));
             context.relocateCode(true); // this to get better estimate on relocated size. its fust enough
         }
 #else

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2567,10 +2567,13 @@ namespace das {
               << value.disable_dse
               << value.disable_cse
               << value.disable_inline
+              << value.disable_auto_inline
+              << value.disable_run
               << value.no_infer_time_folding
               << value.fail_on_no_aot
               << value.fail_on_lack_of_aot_export
               << value.no_fast_call
+              << value.fusion
               << value.scoped_stack_allocator
               << value.force_inscope_pod
               << value.log_inscope_pod

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -994,13 +994,18 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(disable_dse)>("disable_dse");
             addField<DAS_BIND_MANAGED_FIELD(disable_cse)>("disable_cse");
             addField<DAS_BIND_MANAGED_FIELD(disable_inline)>("disable_inline");
+            addField<DAS_BIND_MANAGED_FIELD(disable_auto_inline)>("disable_auto_inline");
+            addField<DAS_BIND_MANAGED_FIELD(disable_run)>("disable_run");
             addField<DAS_BIND_MANAGED_FIELD(no_infer_time_folding)>("no_infer_time_folding");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_no_aot)>("fail_on_no_aot");
             addField<DAS_BIND_MANAGED_FIELD(fail_on_lack_of_aot_export)>("fail_on_lack_of_aot_export");
             addField<DAS_BIND_MANAGED_FIELD(log_compile_time)>("log_compile_time");
             addField<DAS_BIND_MANAGED_FIELD(log_total_compile_time)>("log_total_compile_time");
             addField<DAS_BIND_MANAGED_FIELD(log_module_compile_time)>("log_module_compile_time");
+            addField<DAS_BIND_MANAGED_FIELD(log_optimization)>("log_optimization");
+            addField<DAS_BIND_MANAGED_FIELD(log_optimization_passes)>("log_optimization_passes");
             addField<DAS_BIND_MANAGED_FIELD(no_fast_call)>("no_fast_call");
+            addField<DAS_BIND_MANAGED_FIELD(fusion)>("fusion");
             addField<DAS_BIND_MANAGED_FIELD(scoped_stack_allocator)>("scoped_stack_allocator");
             addField<DAS_BIND_MANAGED_FIELD(force_inscope_pod)>("force_inscope_pod");
             addField<DAS_BIND_MANAGED_FIELD(log_inscope_pod)>("log_inscope_pod");

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -613,6 +613,11 @@ int das_policies_set_bool ( das_policies * policies, das_bool_policy flag, int v
         case DAS_POLICY_DISABLE_DSE:            p->disable_dse = v; break;
         case DAS_POLICY_DISABLE_CSE:            p->disable_cse = v; break;
         case DAS_POLICY_DISABLE_INLINE:         p->disable_inline = v; break;
+        case DAS_POLICY_DISABLE_AUTO_INLINE:    p->disable_auto_inline = v; break;
+        case DAS_POLICY_DISABLE_RUN:            p->disable_run = v; break;
+        case DAS_POLICY_LOG_OPTIMIZATION:       p->log_optimization = v; break;
+        case DAS_POLICY_LOG_OPTIMIZATION_PASSES: p->log_optimization_passes = v; break;
+        case DAS_POLICY_FUSION:                 p->fusion = v; break;
         default: return 0;
     }
     return 1;

--- a/tests/language/invalid_types.das
+++ b/tests/language/invalid_types.das
@@ -1,4 +1,5 @@
 options gen2
+options disable_auto_inline    // this test pins lint diagnostics; splicing would reshape them
 expect 30500:3, 30508, 30510, 30512:2, 30513
 
 require dastest/testing_boost public

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -1,0 +1,158 @@
+options gen2
+options rtti
+options no_coverage
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_boost
+require dastest/testing_boost public
+require strings
+require daslib/strings_boost
+
+// structural FIRED proof + behavioral safety net for automatic block inlining and
+// invoke-of-literal devirtualization (src/ast/ast_inline.cpp): a direct call passing a
+// block LITERAL argument splices the callee body (best-effort MAY contract - silent
+// declines, never errors), and an invoke whose block resolves to a same-function
+// literal splices the block body in place. The negative tests pin the decline gates:
+// forwarded (non-literal) blocks, multi-exit callees, and recursion stay regular calls.
+
+var g_log : string = ""
+
+def side(tag : string; v : int) : int {
+    g_log += tag
+    return v
+}
+
+def for_each_val(src : array<int>; blk : block<(v : int) : void>) {
+    for (v in src) {
+        invoke(blk, v)
+    }
+}
+
+def transform_sum(src : array<int>; blk : block<(v : int) : int>) : int {
+    var total = 0
+    for (v in src) {
+        total += invoke(blk, v)
+    }
+    return total
+}
+
+def chain_sum(src : array<int>; k : int; blk : block<(v : int) : int>) : int {
+    // forwards the block down: the inner call inlines through on a later wave
+    return transform_sum(src, blk) + k
+}
+
+def multi_exit(src : array<int>; blk : block<(v : int) : int>) : int {
+    // two returns: single-exit gate declines this callee
+    if (length(src) == 0) {
+        return -1
+    }
+    return invoke(blk, src[0])
+}
+
+def recursive_taker(n : int; blk : block<(v : int) : int>) : int {
+    if (n <= 0) {
+        return invoke(blk, 0)
+    }
+    return recursive_taker(n - 1, blk) + 1  // nolint:LINT010
+}
+
+[export]
+def target_auto(src : array<int>) : int {
+    return src |> transform_sum() $(v) => v * v
+}
+
+[export]
+def target_void_auto(src : array<int>) : int {
+    var sum = 0
+    src |> for_each_val() $(v) {
+        sum += v
+    }
+    return sum
+}
+
+[export]
+def target_chain(src : array<int>) : int {
+    return src |> chain_sum(100) $(v) => v + 1
+}
+
+[export]
+def target_multi_exit(src : array<int>) : int {
+    return src |> multi_exit() $(v) => v * 3
+}
+
+[export]
+def target_recursive(src : array<int>) : int {
+    return recursive_taker(length(src)) $(v) => v + 7
+}
+
+[export]
+def target_impure_args(a, b : int) : int {
+    // call-order evaluation of impure arguments must survive the splice
+    return transform_sum([side("a", a), side("b", b)]) $(v) => v * 2
+}
+
+def has(s, sub : string) : bool {
+    return find(s, sub, 0) >= 0
+}
+
+def body_of(t : T?; nm : string) : string {
+    var body = ""
+    compiling_module() |> for_each_function("{nm}") $(func) {
+        if (empty(body)) {
+            body = "{describe(func.body)}"
+        }
+    }
+    t |> success(!empty(body), "target function found")
+    let clean <- [for (ln in split(body, "\n")); ln; where !(ln |> has("coverage("))]
+    return join(clean, "\n")
+}
+
+[test]
+def test_auto_inline_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("block-literal call splices and devirtualizes") @(t : T?) {
+            let b = body_of(t, "target_auto")
+            t |> success(!has(b, "transform_sum("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("void block-literal call splices") @(t : T?) {
+            let b = body_of(t, "target_void_auto")
+            t |> success(!has(b, "for_each_val("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("forwarded block inlines through on later waves") @(t : T?) {
+            let b = body_of(t, "target_chain")
+            t |> success(!has(b, "chain_sum("), "outer call is gone: {b}")
+            t |> success(!has(b, "transform_sum("), "forwarded call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("multi-exit callee declines") @(t : T?) {
+            let b = body_of(t, "target_multi_exit")
+            t |> success(has(b, "multi_exit("), "call stays regular: {b}")
+        }
+        t |> run("recursive callee declines") @(t : T?) {
+            let b = body_of(t, "target_recursive")
+            t |> success(has(b, "recursive_taker("), "call stays regular: {b}")
+        }
+    }
+}
+
+[test]
+def test_auto_inline_behavior(t : T?) {
+    t |> run("values preserved") @(t : T?) {
+        var src <- [1, 2, 3, 4]
+        t |> equal(target_auto(src), 30)
+        t |> equal(target_void_auto(src), 10)
+        t |> equal(target_chain(src), 114)
+        t |> equal(target_multi_exit(src), 3)
+        var none : array<int>
+        t |> equal(target_multi_exit(none), -1)
+        t |> equal(target_recursive(src), 11)
+    }
+    t |> run("impure arguments evaluate once in call order") @(t : T?) {
+        g_log = ""
+        t |> equal(target_impure_args(3, 4), 14)
+        t |> equal(g_log, "ab")
+    }
+}

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -44,7 +44,7 @@ def chain_sum(src : array<int>; k : int; blk : block<(v : int) : int>) : int {
 
 def multi_exit(src : array<int>; blk : block<(v : int) : int>) : int {
     // two returns: single-exit gate declines this callee
-    if (length(src) == 0) {
+    if (empty(src)) {
         return -1
     }
     return invoke(blk, src[0])
@@ -141,12 +141,12 @@ def test_auto_inline_fired(t : T?) {
 [test]
 def test_auto_inline_behavior(t : T?) {
     t |> run("values preserved") @(t : T?) {
-        var src <- [1, 2, 3, 4]
+        let src <- [1, 2, 3, 4]
         t |> equal(target_auto(src), 30)
         t |> equal(target_void_auto(src), 10)
         t |> equal(target_chain(src), 114)
         t |> equal(target_multi_exit(src), 3)
-        var none : array<int>
+        let none : array<int>
         t |> equal(target_multi_exit(none), -1)
         t |> equal(target_recursive(src), 11)
     }

--- a/tests/language/optimization_cse.das
+++ b/tests/language/optimization_cse.das
@@ -1,6 +1,7 @@
 options gen2
 options rtti
 options no_coverage
+options disable_auto_inline    // this file pins CSE shapes; auto-splicing would dissolve them
 
 require daslib/ast
 require daslib/rtti
@@ -169,6 +170,77 @@ def target_blockarg(x : int) : int {
     return r + a
 }
 
+// ----- v2: field/index chains rooted at locals and arguments (ast_alias.h) -----
+
+struct CsePoint {
+    x : int
+    y : int
+}
+
+struct CseBody {
+    pos : CsePoint
+    id : int
+}
+
+def touch(var b : CseBody) {
+    b.pos.x += 1
+}
+
+[export]
+def target_field_reuse(b : CseBody) : int {
+    let a = b.pos.x * 19
+    return b.pos.x * 19 + a // chain reused: becomes a + a
+}
+
+[export]
+def target_field_kill(var b : CseBody) : int {
+    let a = b.pos.x * 23
+    b.pos.x = 9   // visible store through the base kills the pair
+    return b.pos.x * 23 + a
+}
+
+[export]
+def target_field_opaque(var b : CseBody) : int {
+    let a = b.pos.x * 29
+    touch(b)      // impure call: kills every memory pair
+    return b.pos.x * 29 + a
+}
+
+[export]
+def target_index_reuse(arr : array<int>; i : int) : int {
+    let a = arr[i] * 31
+    return arr[i] * 31 + a // index chain reused: becomes a + a
+}
+
+[export]
+def target_index_kill(var arr : array<int>; i : int) : int {
+    let a = arr[i] * 37
+    arr |> push(1) // argument-writing call kills chains rooted at arr
+    return arr[i] * 37 + a
+}
+
+[export]
+def target_local_precision(x : int) : int {
+    var s1 = CseBody(pos = CsePoint(x = x, y = 0), id = 0)
+    var s2 = CseBody(pos = CsePoint(x = x + 1, y = 0), id = 0)
+    let a = s1.pos.x * 41
+    s2.pos.x = 7  // a store through ANOTHER local cannot alias s1: the pair survives
+    return s1.pos.x * 41 + a + s2.pos.x
+}
+
+[export]
+def target_arg_aliasing(var a : CseBody; b : CseBody) : int {
+    let t = b.pos.x * 43
+    a.pos.x = 5   // arguments may alias each other: kills argument-rooted pairs
+    return b.pos.x * 43 + t
+}
+
+[export]
+def target_pure_ref_read(arr : array<int>) : int {
+    let n = length(arr) * 47
+    return length(arr) * 47 + n // pure by-ref read of a chain base reused
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -270,6 +342,38 @@ def test_cse_fired(t : T?) {
             var td = new TypeDecl(baseType = Type.tInt)
             t |> success(target_ptr_factory(td), "fresh clones are distinct")
         }
+        t |> run("field chain is reused") @(t : T?) {
+            let b = body_of(t, "target_field_reuse")
+            t |> equal(count_of(b, "* 19"), 1)
+        }
+        t |> run("store through the base kills the chain pair") @(t : T?) {
+            let b = body_of(t, "target_field_kill")
+            t |> equal(count_of(b, "* 23"), 2)
+        }
+        t |> run("impure call kills memory pairs") @(t : T?) {
+            let b = body_of(t, "target_field_opaque")
+            t |> equal(count_of(b, "* 29"), 2)
+        }
+        t |> run("index chain is reused") @(t : T?) {
+            let b = body_of(t, "target_index_reuse")
+            t |> equal(count_of(b, "* 31"), 1)
+        }
+        t |> run("argument-writing call kills the array chain") @(t : T?) {
+            let b = body_of(t, "target_index_kill")
+            t |> equal(count_of(b, "* 37"), 2)
+        }
+        t |> run("store through another local keeps the pair") @(t : T?) {
+            let b = body_of(t, "target_local_precision")
+            t |> equal(count_of(b, "* 41"), 1)
+        }
+        t |> run("store through one argument kills pairs on another") @(t : T?) {
+            let b = body_of(t, "target_arg_aliasing")
+            t |> equal(count_of(b, "* 43"), 2)
+        }
+        t |> run("pure by-ref read is reused") @(t : T?) {
+            let b = body_of(t, "target_pure_ref_read")
+            t |> equal(count_of(b, "* 47"), 1)
+        }
     }
 }
 
@@ -301,5 +405,24 @@ def test_cse_behavior(t : T?) {
     }
     t |> run("aliased leaf still recomputes") @(t : T?) {
         t |> equal(target_alias(5), 42)
+    }
+    t |> run("chain values preserved") @(t : T?) {
+        var b = CseBody(pos = CsePoint(x = 3, y = 0), id = 0)
+        t |> equal(target_field_reuse(b), 114)
+        t |> equal(target_field_kill(b), 276)
+        b.pos.x = 3
+        t |> equal(target_field_opaque(b), 203)
+        var arr <- [2, 5, 8]
+        t |> equal(target_index_reuse(arr, 0), 124)
+        t |> equal(target_index_kill(arr, 0), 148)
+        t |> equal(target_local_precision(2), 171)
+        t |> equal(target_pure_ref_read(arr), 376)  // push above grew it to 4
+    }
+    t |> run("same struct passed to both parameters reads the store") @(t : T?) {
+        var s = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
+        t |> equal(target_arg_aliasing(s, s), 301)  // 5*43 + 2*43: the recompute observes the write
+        var s2 = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
+        var s3 = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
+        t |> equal(target_arg_aliasing(s2, s3), 172)
     }
 }

--- a/tests/language/optimization_cse.das
+++ b/tests/language/optimization_cse.das
@@ -183,7 +183,7 @@ struct CseBody {
 }
 
 def touch(var b : CseBody) {
-    b.pos.x += 1
+    b.pos.x ++
 }
 
 [export]
@@ -221,7 +221,7 @@ def target_index_kill(var arr : array<int>; i : int) : int {
 
 [export]
 def target_local_precision(x : int) : int {
-    var s1 = CseBody(pos = CsePoint(x = x, y = 0), id = 0)
+    let s1 = CseBody(pos = CsePoint(x = x, y = 0), id = 0)
     var s2 = CseBody(pos = CsePoint(x = x + 1, y = 0), id = 0)
     let a = s1.pos.x * 41
     s2.pos.x = 7  // a store through ANOTHER local cannot alias s1: the pair survives
@@ -422,7 +422,7 @@ def test_cse_behavior(t : T?) {
         var s = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
         t |> equal(target_arg_aliasing(s, s), 301)  // 5*43 + 2*43: the recompute observes the write
         var s2 = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
-        var s3 = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
+        let s3 = CseBody(pos = CsePoint(x = 2, y = 0), id = 0)
         t |> equal(target_arg_aliasing(s2, s3), 172)
     }
 }

--- a/tests/language/optimization_dead_stores.das
+++ b/tests/language/optimization_dead_stores.das
@@ -1,5 +1,6 @@
 options gen2
 options rtti
+options disable_auto_inline    // this file pins DSE shapes; auto-splicing would dissolve them
 
 require daslib/ast
 require daslib/rtti
@@ -146,6 +147,76 @@ def target_opassign(x : int) : int {
     return x
 }
 
+// ----- v2: field-chain stores and declaration inits (ast_alias.h) -----
+
+struct DsePoint {
+    x : int
+    y : int
+}
+
+struct DseBody {
+    pos : DsePoint
+    id : int
+}
+
+def observe_field(s : DseBody) : int => s.pos.x
+
+[export]
+def target_field_overwrite(x : int) : int {
+    var s : DseBody
+    s.pos.x = x * 51 // dead: overwritten below before any read
+    s.pos.x = x + 53
+    return s.pos.x
+}
+
+[export]
+def target_field_disjoint(x : int) : int {
+    var s : DseBody
+    s.pos.x = x + 57 // LIVE: disjoint fields never kill each other
+    s.pos.y = x + 59
+    return s.pos.x + s.pos.y
+}
+
+[export]
+def target_field_partial(x : int) : int {
+    var s : DseBody
+    s.pos = DsePoint(x = x + 61, y = x + 67) // LIVE: its y survives the partial overwrite below
+    s.pos.x = x + 71
+    return s.pos.x + s.pos.y
+}
+
+[export]
+def target_whole_read(x : int) : int {
+    var s : DseBody
+    s.pos.x = x + 73 // LIVE: the whole-struct read below observes it
+    return observe_field(s)
+}
+
+[export]
+def target_arg_store(var s : DseBody; x : int) {
+    s.pos.x = x + 79 // LIVE: argument writes are the caller's to observe
+}
+
+[export]
+def target_init_strip(x : int) : int {
+    var t = x * 83 // dead init: overwritten on every path before any read
+    if (x > 0) {
+        t = x + 1
+    } else {
+        t = x + 2
+    }
+    return t
+}
+
+[export]
+def target_init_live(x : int) : int {
+    var t = x * 89 // LIVE init: read on the else path
+    if (x > 0) {
+        t = x + 3
+    }
+    return t
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -225,6 +296,37 @@ def test_dead_stores_fired(t : T?) {
             let b = body_of(t, "target_opassign")
             t |> success(has(b, "+="), "op-assign statement kept: {b}")
         }
+        t |> run("overwritten field store is removed") @(t : T?) {
+            let b = body_of(t, "target_field_overwrite")
+            t |> success(!has(b, "* 51"), "dead field store gone: {b}")
+            t |> success(has(b, "+ 53"), "live field store kept: {b}")
+        }
+        t |> run("disjoint fields never kill each other") @(t : T?) {
+            let b = body_of(t, "target_field_disjoint")
+            t |> success(has(b, "+ 57") && has(b, "+ 59"), "both field stores kept: {b}")
+        }
+        t |> run("partial overwrite keeps the whole-chain store") @(t : T?) {
+            let b = body_of(t, "target_field_partial")
+            t |> success(has(b, "+ 67"), "prefix store kept for its y: {b}")
+            t |> success(has(b, "+ 71"), "partial store kept: {b}")
+        }
+        t |> run("whole-struct read keeps the field store") @(t : T?) {
+            let b = body_of(t, "target_whole_read")
+            t |> success(has(b, "+ 73"), "field store kept: {b}")
+        }
+        t |> run("argument stores are never candidates") @(t : T?) {
+            let b = body_of(t, "target_arg_store")
+            t |> success(has(b, "+ 79"), "argument store kept: {b}")
+        }
+        t |> run("dead declaration init is stripped") @(t : T?) {
+            let b = body_of(t, "target_init_strip")
+            t |> success(!has(b, "* 83"), "dead init gone: {b}")
+            t |> success(has(b, "+ 1") && has(b, "+ 2"), "arm stores kept: {b}")
+        }
+        t |> run("init read on one path is kept") @(t : T?) {
+            let b = body_of(t, "target_init_live")
+            t |> success(has(b, "* 89"), "live init kept: {b}")
+        }
     }
 }
 
@@ -263,5 +365,20 @@ def test_dead_stores_behavior(t : T?) {
         var vb = 2
         let res = target_ptr(unsafe(addr(va)), unsafe(addr(vb)))
         t |> equal(*res, 2)
+    }
+    t |> run("chain values preserved") @(t : T?) {
+        t |> equal(target_field_overwrite(2), 55)
+        t |> equal(target_field_disjoint(1), 118)
+        t |> equal(target_field_partial(1), 140)
+        t |> equal(target_whole_read(1), 74)
+        t |> equal(target_init_strip(4), 5)
+        t |> equal(target_init_strip(-4), -2)
+        t |> equal(target_init_live(4), 7)
+        t |> equal(target_init_live(-4), -356)
+    }
+    t |> run("argument store lands in the caller") @(t : T?) {
+        var s : DseBody
+        target_arg_store(s, 1)
+        t |> equal(s.pos.x, 80)
     }
 }

--- a/tests/language/optimization_inline.das
+++ b/tests/language/optimization_inline.das
@@ -218,7 +218,7 @@ def test_inline_behavior(t : T?) {
         t |> equal(target_lazy(41), 42);
     }
     t |> run("body with a block literal splices") @(t : T?) {
-        var arr <- [3, 9, 1, 7];
+        let arr <- [3, 9, 1, 7];
         t |> equal(gathered_sum(arr, 2), 19);
         t |> equal(gathered_sum(arr, 6), 16);
     }

--- a/tests/language/optimization_inline.das
+++ b/tests/language/optimization_inline.das
@@ -103,6 +103,24 @@ def twice(x : auto) {
     return x + x;
 }
 
+def for_each_hlp(src : array<int>; blk : block<(v : int) : void>) {
+    for (v in src) {
+        invoke(blk, v);
+    }
+}
+
+[inline]
+def gathered_sum(src : array<int>; k : int) : int {
+    // a block literal in the body: stays in-frame, clones with the splice
+    var total = 0;
+    src |> for_each_hlp() $(v) {
+        if (v > k) {
+            total += v;
+        }
+    }
+    return total;
+}
+
 [export]
 def target_basic(x, y : int) : int {
     return add(x, y + 1); // inlines to x + (y + 1), zero temps
@@ -198,6 +216,11 @@ def test_inline_behavior(t : T?) {
         t |> equal(target_generic(21, 1.5), 45.0);
         t |> equal(target_while(5), 5);
         t |> equal(target_lazy(41), 42);
+    }
+    t |> run("body with a block literal splices") @(t : T?) {
+        var arr <- [3, 9, 1, 7];
+        t |> equal(gathered_sum(arr, 2), 19);
+        t |> equal(gathered_sum(arr, 6), 16);
     }
     t |> run("impure args evaluate once, in call order") @(t : T?) {
         g_log = "";

--- a/tests/linq/test_linq_fold_ast.das
+++ b/tests/linq/test_linq_fold_ast.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options rtti
+options disable_auto_inline    // this file pins linq-fold codegen shapes; splicing would dissolve them
 
 require daslib/ast
 require daslib/rtti

--- a/tests/linq/test_linq_from_decs.das
+++ b/tests/linq/test_linq_from_decs.das
@@ -1,5 +1,6 @@
 options gen2
 options rtti
+options disable_auto_inline    // this file pins linq splice shapes; auto-splicing would dissolve them
 options _no_linq_perf_warn = true  // file contains intentional cascade tests (regression guards for tier-2 fallthrough)
 require daslib/linq
 require dastest/testing_boost public

--- a/tests/lint/failed_lint013_unused_block_argument.das
+++ b/tests/lint/failed_lint013_unused_block_argument.das
@@ -9,6 +9,7 @@
 //
 // Total expected 50503 hits: 1.
 options gen2
+options disable_auto_inline    // this fixture pins LINT013 diagnostics; splicing the call away would eat them
 
 require daslib/lint
 


### PR DESCRIPTION
# The block-inlining arc

Sequel to #3389. A block literal at a call site is the user's signal: this PR makes the interpreter tier inline through it automatically, and builds the optimizer substrate those splices need. One PR for the whole arc, per plan.

## 1. CSE/DSE v2 — field and index chains over a shared alias model (`src/ast/ast_alias.h`)

Both passes extend their leaf model to Field/At/Swizzle chains rooted at plain local/argument bases (struct, tuple, bitfield fields; array, fixed-array, vector indexing — no pointer, handle, or table links). Soundness rides the access flags `buildAccessFlags` stamps before every optimization round: write flags land on whole chains including the call-site arguments of modifying callees, `r2cr` marks read-throughs.

* **CSE** gains memory pairs: repeated `s.pos.x` / `arr[i]` reads reuse a named holder. Kills: visible stores through the base; stores through untracked targets or loop variables (loop-var writes forward to the loop source's base); impure calls (anything beyond `modifyArgument`); argument/global stores kill argument-rooted pairs (arguments may alias each other and globals — locals cannot, and a store through one local correctly keeps pairs on another). Value leaves widen too: read-through (`r2cr`) occurrences no longer disqualify.
* **DSE** unifies whole-variable and exact field-chain stores in one liveness framework: disjoint fields never keep each other alive, a store to a strict prefix kills, a partial write keeps the prefix store live, and a dead pure declaration init strips to the plain zero-init declaration.

## 2. Automatic block inlining + invoke-of-literal devirtualization (`src/ast/ast_inline.cpp`)

Two contracts, never mixed: `[inline]` stays fail-closed MUST; the auto trigger is best-effort MAY — every gate declines **silently** (counted, logged under `log_optimization`), and unoptimized builds never run it. `options disable_auto_inline` / `CodeOfPolicies::disable_auto_inline` turn it off.

* **Half A** — a direct call to a das-bodied function passing a block **literal** splices the callee body via the existing patch-slot machinery. Literals read once outside loops substitute textually; otherwise they bind a move-init holder.
* **Half B** — an invoke whose block resolves to a same-function literal (directly, or through a move-initialized never-rebound local — exactly what a Half-A splice leaves behind) splices the block body in place. Same-frame semantics make capture free: the body already reads the caller's locals directly.
* The halves converge over patch rounds; block-forwarding chains inline through wave by wave. Recursion through the combined splice graph is declined up front, so rounds terminate.

Auto decline gates, each earned by a real breakage during validation: callee shape (the `[inline]` contract: single exit, by-value result); unsafe bodies (`Function::hasUnsafe` — survives `foldUnsafe`, unlike the wrappers); annotated callees (an annotation's `verifyCall` would be bypassed — `temp_string`'s tag macro must keep rejecting bad calls); generic `type<TT>` witnesses in the body (symbolic in instances, cannot re-resolve after a splice); smart-pointer parameters/results; cross-module private or not-directly-visible references judged by the generic **origin's** module (instances live in the caller's module). The instance-privateness conservatism is deliberate and documented at the gate — loosening it re-fires hundreds of cross-module linq_fold_common splices and destabilizes the fold macro's shape assumptions.

## 3. Splice-machinery hardening (v1 latent bugs the wider diet exposed)

`[inline]` now accepts plain block literals in bodies (in-frame, clone-safe; lambdas lower to generated functions during infer and stay rejected). Renamed locals move to the `_l_` sub-namespace (a callee local named `res` collided with the result temp). By-ref/non-copyable prefix expressions bind references or move instead of copying; mutable temps carry `-const` (autoinfer inherits init constness); rvalue-into-var-ref parameters bind mutable holders (consumed iterators); blocks bind `var` holders (a `let` holder const-propagates into the invoke, rejecting the block's own `var` parameters); `type<...>` witnesses substitute as the compile-time tags they are.

## 4. CodeOfPolicies counterparts for every knob

`disable_auto_inline` is born with a policy; the audit adds policy fields for `disable_run`, `fusion`, `log_optimization`, `log_optimization_passes` (annotation-registered; removed from `g_allOptions` to avoid the duplicate-option error; positional handmade doc lines; C-API enums appended at the end for ABI). AST serializer bumps to 98.

## Validation

| Lane | Result |
|---|---|
| Full interpreted sweep, isolated mode | **11084 / 11084** |
| Full AOT sweep, stubs regenerated | **11085 / 11085**, zero 50101 |
| JIT suites + verifier smoke | 328 / 328, no verifier errors |
| ctest | green |
| das2rst + Sphinx (latex + html) | clean, zero warnings |
| Lint on changed `.das` | zero warnings |

**Honesty numbers** (`log_optimization` on a linq-stack compile): 134 auto + 1 devirt splices fire inside linq_fold_common's own compile; decline census — 756 private-instance, 369 unsafe, **316 result-not-by-value** (the data for the future multi-return lowering arc). Interpreted block-taker hot loops: **48.8 ms → 13.2 ms (~3.7×)**, results bit-identical; lambda-based linq fold chains unchanged (±2%, out of scope by design).

Shape-pinning tests (linq-fold AST shapes, CSE/DSE structural targets, expect-count lint fixtures) opt out via `options disable_auto_inline` — they pin macro/optimizer *output shapes* that splicing legitimately transforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)