### PR TITLE
compiler: block inlining PR2 — CondFolding soundness, return canonicalization, refType/unsafe splicing, DSE op-assign

### DIFF
--- a/daslib/ast_match.das
+++ b/daslib/ast_match.das
@@ -490,7 +490,9 @@ def private qm_guard(at : LineInfo; var cond : Expression?&; var fail_call : Exp
     var fail_ret = new ExprReturn(at = at, subexpr = fail_call)
     var fail_blk = new ExprBlock(at = at)
     fail_blk.list |> emplace(fail_ret)
-    return new ExprIfThenElse(at = at, cond = cond, if_true = fail_blk)
+    var g = new ExprIfThenElse(at = at, cond = cond, if_true = fail_blk)
+    g.genFlags.generated = true     // guard ladders are macro output; style lint skips them
+    return g
 }
 
 [macro_function]
@@ -1217,7 +1219,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
         body |> push <| qmacro_expr(${ var $i(cast_var) = $e(as_cast_ac); })
         // Match generatorSyntax (both true and false enforced)
         if (pat_gen) {
-            var cg = qmacro($i(cast_var).generatorSyntax == false)
+            var cg = qmacro(!$i(cast_var).generatorSyntax)
             var fg = qmacro(qm_fail_field($i(actual_var)))
             body |> push <| qm_guard(at, cg, fg)
         } else {
@@ -1227,7 +1229,7 @@ def private generate_match(pattern : Expression?; actual_var : string; var body 
         }
         // Match tableSyntax (both true and false enforced)
         if (pat_tbl) {
-            var ct = qmacro($i(cast_var).tableSyntax == false)
+            var ct = qmacro(!$i(cast_var).tableSyntax)
             var ft = qmacro(qm_fail_field($i(actual_var)))
             body |> push <| qm_guard(at, ct, ft)
         } else {

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -360,7 +360,10 @@ class LintVisitor : AstVisitor {
             op == "&"  || op == "|"  || op == "^" ||
             op == "-=" || op == "/=" || op == "%="
         )
-        if (op_same_suspicious && expr_equal(expr.left, expr.right, false)) {
+        // identical constants are macro-splice residue (`$v(n) > 1` with n == 1),
+        // const-fold food rather than a copy-paste typo
+        if (op_same_suspicious && expr_equal(expr.left, expr.right, false)
+                && !(expr.left.__rtti |> starts_with("ExprConst"))) {
             lint_error("LINT007: left and right operands of '{op}' are the same", expr.at)
         }
     }

--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -740,7 +740,7 @@ class StyleLintVisitor : AstVisitor {
     }
 
     def override preVisitExprIfThenElse(ifte : ExprIfThenElse?) : void {
-        if (ifte.if_flags.isStatic) return
+        if (ifte.if_flags.isStatic || ifte.genFlags.generated) return  // macro-made ifs are not user style
         // STYLE010: if (true) { ... }
         var cond = ifte.cond
         if (cond is ExprConstBool) {
@@ -826,7 +826,7 @@ class StyleLintVisitor : AstVisitor {
         for (i in range(n - 1)) {
             let cur = blk.list[i]
             let nxt = blk.list[i + 1]
-            if (!(cur is ExprIfThenElse)) continue
+            if (!(cur is ExprIfThenElse) || cur.genFlags.generated || nxt.genFlags.generated) continue  // macro-made guards skip
             let outer_if = cur as ExprIfThenElse
             if (outer_if.if_false != null) continue
             let outer_term = single_terminator_body(outer_if.if_true)

--- a/src/ast/ast_block_folding.cpp
+++ b/src/ast/ast_block_folding.cpp
@@ -305,48 +305,50 @@ namespace das {
         virtual bool canVisitArgumentInit ( Function * /*fun*/, const VariablePtr & /*var*/, Expression * /*init*/ ) override { return false; }
 
     protected:
+        // extract `return ...` from an if arm: either a naked return (folding a nested
+        // if/else in an elif chain leaves one), or a block holding exactly one return.
+        // a block with a finally section never qualifies - the fold would drop it.
+        static ExprReturn * armReturn ( Expression * arm ) {
+            ExprReturn * ret = nullptr;
+            if (arm->rtti_isReturn()) {
+                ret = static_cast<ExprReturn*>(arm);
+            } else if (arm->rtti_isBlock()) {
+                auto blk = static_cast<ExprBlock*>(arm);
+                if (blk->list.size() == 1 && blk->finalList.empty() && blk->list.back()->rtti_isReturn()) {
+                    ret = static_cast<ExprReturn*>(blk->list.back());
+                }
+            }
+            if ( ret && ret->subexpr && ret->subexpr->rtti_isMakeLocal() ) {
+                ret = nullptr;   // we don't touch CMRES stuff
+            }
+            return ret;
+        }
         virtual ExpressionPtr visit ( ExprIfThenElse * expr ) override {
             // if ( func && func->generator ) return Visitor::visit(expr);
             // if (cond) return x; else return y; => (cond ? x : y)
             if (expr->if_false) {
-                ExprReturn * lr = nullptr; ExprReturn * rr = nullptr;
-                if (expr->if_true->rtti_isBlock()) {
-                    auto tb = static_cast<ExprBlock*>(expr->if_true);
-                    if (tb->list.size() == 1 && tb->list.back()->rtti_isReturn()) {
-                        lr = static_cast<ExprReturn*>(tb->list.back());
-                        if ( lr->subexpr && lr->subexpr->rtti_isMakeLocal() ) {
-                            lr = nullptr;   // we don't touch CMRES stuff
-                        }
-                    }
-                }
-                if (expr->if_false->rtti_isBlock()) {
-                    auto fb = static_cast<ExprBlock*>(expr->if_false);
-                    if (fb->list.size() == 1 && fb->list.back()->rtti_isReturn()) {
-                        rr = static_cast<ExprReturn*>(fb->list.back());
-                        if ( rr->subexpr && rr->subexpr->rtti_isMakeLocal() ) {
-                            rr = nullptr;   // we don't touch CMRES stuff
-                        }
-                    }
-                }
+                ExprReturn * lr = armReturn(expr->if_true);
+                ExprReturn * rr = armReturn(expr->if_false);
                 if (lr && rr) {
                     if ( lr->moveSemantics != rr->moveSemantics ) {
                         lr = nullptr; // move semantics must match
                         rr = nullptr;
                     } else if ( lr->subexpr && rr->subexpr && (lr->subexpr->type->isRef() || rr->subexpr->type->isRef()) ) {
-                        lr = nullptr; // ref types must match
+                        lr = nullptr; // don't fold when either side is a ref
                         rr = nullptr;
                     }
                 }
                 if (lr && rr) {
-                    if ( lr->subexpr ) {
+                    if ( lr->subexpr && rr->subexpr ) {
                         auto newCond = new ExprOp3(expr->at, "?", expr->cond, lr->subexpr, rr->subexpr);
                         newCond->type = new TypeDecl(*lr->subexpr->type);
                         auto newRet = new ExprReturn(expr->at, newCond);
                         newRet->moveSemantics = lr->moveSemantics;
                         reportFolding();
                         return newRet;
-                    } else {
+                    } else if ( !lr->subexpr && !rr->subexpr && expr->cond->noSideEffects ) {
                         // this is actually if ( a ) return; else return;
+                        // evaluating `a` does nothing, so the whole thing is a bare return
                         reportFolding();
                         return lr;
                     }

--- a/src/ast/ast_dse.cpp
+++ b/src/ast/ast_dse.cpp
@@ -13,17 +13,20 @@ namespace das {
     // Removes a statement-level `x = <rhs>` / `x.field.path = <rhs>` when the target is
     // a chain (ast_alias.h) over a plain ExprLet local, the rhs is pure, and no path
     // from the store reaches a read overlapping the chain before the next full
-    // overwrite. Also strips a dead pure declaration init (`var x = <rhs>` where every
-    // path overwrites x before reading it) down to the plain zero-init declaration.
-    // Liveness runs backward over the statement-level CFG (ast_cfg.h), one bit per
-    // stored chain.
+    // overwrite. A dead store with an IMPURE rhs keeps the rhs as a bare statement
+    // (the store dies, the call stays). Also strips a dead pure declaration init
+    // (`var x = <rhs>` where every path overwrites x before reading it) down to the
+    // plain zero-init declaration. Liveness runs backward over the statement-level
+    // CFG (ast_cfg.h), one bit per stored chain.
     //
     // Soundness model (deliberately narrow):
     //  * bases are ExprLet locals (never arguments - argument writes are the caller's
     //    to observe). Every occurrence of a base must be a value read (r2v), a
-    //    read-through (r2cr without write - const-ref passes, read chains), or on the
-    //    spine of a statement-level ExprCopy store; anything else (addr(), mutable-ref
-    //    pass, op-assign, move/clone, delete) disqualifies the variable. A local whose
+    //    read-through (r2cr without write - const-ref passes, read chains), on the
+    //    spine of a statement-level ExprCopy store, or on the left spine of a
+    //    statement-level op-assign / increment (read-modify-write: uses its chains,
+    //    kills nothing, never a removal candidate); anything else (addr(), mutable-ref
+    //    pass, move/clone, delete) disqualifies the variable. A local whose
     //    every use is classified cannot escape, so no call can read it behind the
     //    pass's back;
     //  * removal candidates are stores through EXACT chains (fields only, no index or
@@ -46,15 +49,21 @@ namespace das {
 
     namespace {
 
+        bool isOpAssign ( const string & op ) {
+            return op=="+=" || op=="-=" || op=="*=" || op=="/=" || op=="%="
+                || op=="&=" || op=="|=" || op=="^=" || op=="||=" || op=="&&=" || op=="^^="
+                || op=="<<=" || op==">>=" || op=="<<<=" || op==">>>=";
+        }
+
         // one walk: (a) bail on constructs the CFG does not model, (b) collect locals,
         // (c) disqualify any variable with an occurrence that is neither a read nor on
-        // the spine of a statement-level store
+        // the spine of a statement-level store / op-assign
         class DsePrescan : public Visitor {
         public:
             bool eligible = true;
             vector<Variable *> locals;                  // every non-ref ExprLet local, in order
             das_hash_set<Variable *> disq;              // variables with an unclassified occurrence
-            das_hash_set<Expression *> storeSpines;     // nodes on statement-level ExprCopy store-left chains
+            das_hash_set<Expression *> storeSpines;     // nodes on statement-level store-left / op-assign-left chains
         protected:
             Expression * curStmt = nullptr;
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
@@ -87,6 +96,21 @@ namespace das {
                 if ( expr==curStmt ) {
                     AliasChain ch;
                     aliasChainOf(expr->left, ch, &storeSpines);
+                }
+            }
+            virtual void preVisit ( ExprOp2 * expr ) override {
+                Visitor::preVisit(expr);
+                if ( expr==curStmt && isOpAssign(expr->op) ) {
+                    AliasChain ch;
+                    aliasChainOf(expr->left, ch, &storeSpines);
+                }
+            }
+            virtual void preVisit ( ExprOp1 * expr ) override {
+                Visitor::preVisit(expr);
+                if ( expr==curStmt && (expr->op=="++" || expr->op=="--"
+                    || expr->op=="+++" || expr->op=="---") ) {
+                    AliasChain ch;
+                    aliasChainOf(expr->subexpr, ch, &storeSpines);
                 }
             }
             virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
@@ -158,6 +182,7 @@ namespace das {
         };
 
         void analyzeDeadStores ( Function * fn, das_hash_set<Expression *> & dead,
+                                 das_hash_set<Expression *> & deadKeepRhs,
                                  das_hash_set<Variable *> & deadInits ) {
             DsePrescan scan;
             fn->body->visit(scan);
@@ -307,9 +332,16 @@ namespace das {
                 live = BI.liveOut;
                 for ( size_t si=BI.stmts.size(); si-->0; ) {
                     auto & SI = BI.stmts[si];
-                    if ( SI.removeIdx>=0 && SI.rhsPure && isDead(live, SI.removeIdx) ) {
-                        dead.insert(b->stmts[si]);
-                        continue;   // the statement vanishes whole: no kills, no uses
+                    if ( SI.removeIdx>=0 && isDead(live, SI.removeIdx) ) {
+                        if ( SI.rhsPure ) {
+                            dead.insert(b->stmts[si]);
+                            continue;   // the statement vanishes whole: no kills, no uses
+                        }
+                        // impure rhs: the store dies, the rhs stays as a bare statement -
+                        // no kills (the write is gone), uses stay (the rhs still evaluates)
+                        deadKeepRhs.insert(b->stmts[si]);
+                        for ( int u : SI.uses ) live[u>>6] |= 1ull<<(u&63);
+                        continue;
                     }
                     if ( !SI.letInits.empty() ) {
                         // a later init in the same `let` may read an earlier variable -
@@ -331,14 +363,16 @@ namespace das {
             using PassVisitor::visit;
         protected:
             das_hash_set<Expression *> dead;
+            das_hash_set<Expression *> deadKeepRhs;
             das_hash_set<Variable *> deadInits;
             virtual bool canVisitFunction ( Function * fun ) override {
                 if ( fun->stub || fun->isTemplate || !funcIsDirty(fun) ) return false;
                 if ( !fun->body || !fun->body->rtti_isBlock() ) return false;
                 dead.clear();
+                deadKeepRhs.clear();
                 deadInits.clear();
-                analyzeDeadStores(fun, dead, deadInits);
-                return !dead.empty() || !deadInits.empty();
+                analyzeDeadStores(fun, dead, deadKeepRhs, deadInits);
+                return !dead.empty() || !deadKeepRhs.empty() || !deadInits.empty();
             }
             virtual bool canVisitStructure ( Structure * ) override { return false; }
             virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
@@ -350,6 +384,10 @@ namespace das {
                 if ( dead.find(expr)!=dead.end() ) {
                     reportFolding();
                     return nullptr;
+                }
+                if ( deadKeepRhs.find(expr)!=deadKeepRhs.end() ) {
+                    reportFolding();
+                    return static_cast<ExprCopy *>(expr)->right;
                 }
                 return Visitor::visitBlockExpression(block, expr);
             }

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -950,6 +950,10 @@ namespace das {
     }
     ExpressionPtr InferTypes::visit(ExprUnsafe *expr) {
         unsafeDepth--;
+        // an expression-position wrapper (macro-made) carries its body's type; the
+        // parser's statement-position `unsafe { }` wraps a statement block and stays untyped
+        if (expr->body->type)
+            expr->type = new TypeDecl(*expr->body->type);
         return Visitor::visit(expr);
     }
     Expression *InferTypes::findLabel(int32_t label) const {

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -192,7 +192,31 @@ namespace das {
                 // hundreds of linq_fold_common splices and destabilizes the fold macro's
                 // shape assumptions - measure before widening
                 if ( fn->privateFunction || origin->privateFunction ) {
-                    if ( fn->module==mod || origin->module==mod ) {
+                    // a private reference resolves after the splice only when it lives in
+                    // the DESTINATION module itself - a private instance in the callee's
+                    // module or any third module (a builtin generic instantiated there)
+                    // is unreachable from the caller's re-infer
+                    if ( fn->module!=dest && origin->module!=dest ) {
+                        privateSymbol = origin->name;
+                        return;
+                    }
+                }
+                // a generic INSTANCE call is name-mangled for the argument flavor it was
+                // instantiated with. tolerant instances (push, length) re-match after a
+                // splice, but an `explicit`-flavored parameter (==const generics: the
+                // clone family) locks the exact constness - substituting a non-const
+                // caller argument into a const-instantiated call stops the mangled name
+                // from matching. foreign-module instances decline outright (reachability),
+                // destination-module instances decline only on the explicit flavor
+                if ( fn->fromGeneric ) {
+                    bool explicitFlavor = false;
+                    for ( auto & arg : fn->arguments ) {
+                        if ( arg->type && (arg->type->explicitConst || arg->type->explicitRef) ) {
+                            explicitFlavor = true;
+                            break;
+                        }
+                    }
+                    if ( explicitFlavor || fn->module!=dest ) {
                         privateSymbol = origin->name;
                         return;
                     }
@@ -323,6 +347,12 @@ namespace das {
                     auto ait = rename->find(var->aka);
                     if ( ait != rename->end() ) var->aka = ait->second;
                 }
+                // a compiled (cross-module) callee has been through allocateStack, which
+                // aliases the returned local's storage to the function's CMRES slot. the
+                // spliced copy lives in the CALLER's frame, where that aliasing is stale -
+                // simulate would write the local through the caller's (possibly null)
+                // cmres. present virgin state; the caller's own allocation re-derives
+                var->aliasCMRES = false;
             }
             virtual void preVisit ( ExprFor * expr ) override {
                 Visitor::preVisit(expr);
@@ -573,7 +603,16 @@ namespace das {
                                                         // hoisting one would copy a non-copyable)
             if ( e->rtti_isTypeDecl() ) return true;    // type<...> witness: a compile-time tag
             if ( e->rtti_isUnsafe() ) return inlinePure(static_cast<ExprUnsafe *>(e)->body);
-            if ( e->rtti_isVar() ) return !static_cast<ExprVar *>(e)->isGlobalVariable();
+            if ( e->rtti_isVar() ) {
+                auto ev = static_cast<ExprVar *>(e);
+                // a manufactured, not-yet-resolved temp read (this pass's own __inl*
+                // vars, e.g. an earlier site's result temp): no flags, no type - reads
+                // as "global" and untyped, which would hoist it as an impure COPY.
+                // it is a plain local read - pure. everything else at patch time is
+                // resolved, so the flags can be trusted
+                if ( !ev->variable && !ev->type ) return true;
+                return !ev->isGlobalVariable();
+            }
             if ( e->rtti_isR2V() ) return inlinePure(static_cast<ExprRef2Value *>(e)->subexpr);
             if ( e->rtti_isField() ) return inlinePure(static_cast<ExprField *>(e)->value);
             if ( e->rtti_isSafeField() ) return inlinePure(static_cast<ExprSafeField *>(e)->value);
@@ -806,8 +845,15 @@ namespace das {
         const string & plainName = fn->fromGeneric ? fn->fromGeneric->name : fn->name;
         if ( !isPlainIdentifier(plainName) ) { err = "[inline] does not support operator overloads ('" + plainName + "')"; return false; }
         if ( fn->result && !fn->result->isVoid() ) {
-            if ( fn->result->ref || fn->result->isRefType() ) {
+            if ( fn->result->ref ) {
                 err = "[inline] result must be by-value (or void)";
+                return false;
+            }
+            // a refType result splices through a manufactured uninitialized (zeroed)
+            // temp that the trailing return fully writes before any read; a type whose
+            // C++ constructor must run cannot take that path
+            if ( fn->result->isRefType() && fn->result->hasNonTrivialCtor() ) {
+                err = "[inline] result type requires nontrivial construction";
                 return false;
             }
         }
@@ -869,15 +915,19 @@ namespace das {
     namespace {
 
         // a block literal the devirtualizer can splice in place: a plain in-frame block
-        // with a single-exit body and a by-value (or void) result. splicing dissolves the
-        // block boundary, so a break/continue not bound to a loop inside the body is out
+        // with a single-exit body and a non-reference (or void) result. splicing dissolves
+        // the block boundary, so a break/continue not bound to a loop inside the body is out
         bool checkDevirtShape ( ExprMakeBlock * mkb, string & why ) {
             if ( mkb->isLambda || mkb->isLocalFunction || !mkb->capture.empty() ) { why = "lambda literal"; return false; }
             if ( !mkb->block || !mkb->block->rtti_isBlock() ) { why = "no block body"; return false; }
             auto blk = static_cast<ExprBlock *>(mkb->block);
             bool isVoid = !blk->returnType || blk->returnType->isVoid();
-            if ( !isVoid && (blk->returnType->ref || blk->returnType->isRefType()) ) {
+            if ( !isVoid && blk->returnType->ref ) {
                 why = "result is not by-value";
+                return false;
+            }
+            if ( !isVoid && blk->returnType->isRefType() && blk->returnType->hasNonTrivialCtor() ) {
+                why = "result requires nontrivial construction";
                 return false;
             }
             for ( auto & arg : blk->arguments ) {
@@ -1185,7 +1235,12 @@ namespace das {
                 // ----- classify arguments -----
                 auto & stats = paramStats(body, *sa.params);
                 bool isVoid = subjResult==nullptr;
-                bool exprBody = body->list.size()==1 && body->list.back()->rtti_isReturn();
+                // a move return (`return <- x`) never substitutes as an expression: the
+                // substituted read would COPY where the callee moved (an error for
+                // non-copyables, a semantic change otherwise) - it takes the result-temp
+                // path, which preserves the move
+                bool exprBody = body->list.size()==1 && body->list.back()->rtti_isReturn()
+                    && !static_cast<ExprReturn *>(body->list.back())->moveSemantics;
                 bool writeFree = calleeFn ? calleeWriteFree(calleeFn) : false;  // a block body is judged unknown
                 das_hash_map<Variable *, ArgSub> paramSub;
                 vector<ExpressionPtr> temps;
@@ -1401,8 +1456,10 @@ namespace das {
                         string tname = "__inl" + to_string(inlineId) + "_low";
                         inlineId ++;
                         // a non-const temp: a `var p = <temp>` consumer of pointer type
-                        // rejects initialization from a const reference
-                        auto hoist = makeTemp(callLike->at, tname, lazy, false, false, false);
+                        // rejects initialization from a const reference. a non-copyable
+                        // lazy result (ternary of arrays) must move into the hoist
+                        bool viaMove = lazy->type && !lazy->type->canCopy();
+                        auto hoist = makeTemp(callLike->at, tname, lazy, false, false, viaMove);
                         ReplaceNode rn;
                         rn.what = lazy;
                         rn.with = new ExprVar(callLike->at, tname);
@@ -1423,14 +1480,20 @@ namespace das {
                     vector<ExpressionPtr> replacement;
                     replacement.push_back(makeUninitDecl(site.stmt->at, rootVar->name, lazy->type));
                     auto readT = [&]() { return new ExprVar(site.stmt->at, rootVar->name); };
+                    // the arm stores mirror the hoist's own init semantics: a temp that was
+                    // move-initialized (non-copyable lazy result) moves from the selected arm
+                    auto armStore = [&]( const LineInfo & at, Expression * src ) -> Expression * {
+                        if ( rootVar->init_via_move ) return new ExprMove(at, readT(), src);
+                        return new ExprCopy(at, readT(), src);
+                    };
                     if ( lazy->rtti_isOp3() ) {
                         auto op3 = static_cast<ExprOp3 *>(lazy);
                         auto thenBlk = new ExprBlock();
                         thenBlk->at = op3->at;
-                        thenBlk->list.push_back(new ExprCopy(op3->at, readT(), op3->left));
+                        thenBlk->list.push_back(armStore(op3->at, op3->left));
                         auto elseBlk = new ExprBlock();
                         elseBlk->at = op3->at;
-                        elseBlk->list.push_back(new ExprCopy(op3->at, readT(), op3->right));
+                        elseBlk->list.push_back(armStore(op3->at, op3->right));
                         replacement.push_back(new ExprIfThenElse(op3->at, op3->subexpr, thenBlk, elseBlk));
                     } else if ( lazy->rtti_isOp2() ) {
                         auto op2 = static_cast<ExprOp2 *>(lazy);
@@ -1533,8 +1596,13 @@ namespace das {
                         string resName = "__inl" + to_string(inlineId) + "_res";
                         splice.push_back(makeUninitDecl(callLike->at, resName, subjResult));
                         auto ret = static_cast<ExprReturn *>(trailing);
-                        bodyClone->list.push_back(new ExprCopy(ret->at,
-                            new ExprVar(ret->at, resName), ret->subexpr));
+                        // `return <- x` becomes a move into the result temp, `return x` a copy
+                        Expression * store = ret->moveSemantics
+                            ? static_cast<Expression *>(new ExprMove(ret->at,
+                                new ExprVar(ret->at, resName), ret->subexpr))
+                            : static_cast<Expression *>(new ExprCopy(ret->at,
+                                new ExprVar(ret->at, resName), ret->subexpr));
+                        bodyClone->list.push_back(store);
                         callReplacement = new ExprVar(callLike->at, resName);
                     }
                     splice.push_back(bodyClone->visit(rewriter));
@@ -1699,6 +1767,14 @@ namespace das {
             // [inline] bodies stay untouched: their shape contract is fail-closed, and a
             // multi-exit [inline] callee must be the same compile error at every -O level
             if ( fn->mustInline ) return false;
+            // only a function with a block parameter can ever be an auto splice callee
+            // (candidacy requires a block LITERAL argument), so canonicalizing anything
+            // else buys no splice and costs a re-infer round on every module that has one
+            bool hasBlockParam = false;
+            for ( auto & arg : fn->arguments ) {
+                if ( arg->type && arg->type->baseType==Type::tBlock ) { hasBlockParam = true; break; }
+            }
+            if ( !hasBlockParam ) return false;
             // goto can target a label in a tail this pass would move into an else arm; the
             // feature is rare enough that any use opts the whole function out
             bool hasGotoOrLabel = false;

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -1375,8 +1375,23 @@ namespace das {
                         break;
                     }
                     if ( byRefParam ) {
-                        if ( leafVar ) {
+                        // a substitution must not change the argument's CONST VIEW: body
+                        // subtrees may carry calls already resolved to ==const-flavored
+                        // instances (the `:=` clone family), and the splice re-infer
+                        // re-matches those against the instance's locked constness - a
+                        // non-const var replacing a const param read re-types them and
+                        // hard-fails (registry collapses the flavors). when the param is
+                        // more const than the leaf, bind a const reference instead
+                        bool sameConstView = !P->type->constant || (leafA->type && leafA->type->constant);
+                        if ( leafVar && sameConstView ) {
                             sub.substitute = leafA;             // same aliasing as the call itself
+                        } else if ( leafVar ) {
+                            // const-widened var: bind the const reference explicitly - a bare
+                            // var arg often carries no ref flag, and falling through would
+                            // materialize (and MOVE a non-copyable) instead of aliasing
+                            auto init = A->clone();
+                            init->alwaysSafe = true;            // generated binding to real storage
+                            makeArgTemp(init, true, true, false);
                         } else if ( leafA->rtti_isMakeBlock() ) {
                             // a block literal read once outside loops substitutes textually,
                             // keeping shapes a holder can't reproduce (temporary-typed block
@@ -1392,7 +1407,8 @@ namespace das {
                                 makeArgTemp(A->clone(), false, false, true);
                             }
                         } else if ( A->type && A->type->ref ) {
-                            // lvalue chain (field/index): bind a reference once, like the call did
+                            // lvalue chain (field/index), or a var whose const view the
+                            // param widens: bind a reference once, like the call did
                             auto init = A->clone();
                             init->alwaysSafe = true;            // generated binding to real storage
                             makeArgTemp(init, !varParam, true, false);

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -1585,6 +1585,137 @@ namespace das {
             order.push_back(fn);
         }
 
+        // ----- return canonicalization (pre-pass) -----
+
+        // optimized builds canonicalize early-exit shapes before candidates are evaluated:
+        //  (1) tail-else synthesis: `if (c) { ...; return }` followed by a tail moves the
+        //      tail into a synthesized else arm (what CondFolding does for nested blocks
+        //      at optimize time; here it also covers the function's top block);
+        //  (2) `if (c) return a; else return b;` folds to `return c ? a : b`.
+        // together they turn early-exit bodies into the single-trailing-return shape the
+        // inliner requires. new nodes are untyped: the pass reports astChanged and the
+        // restarted infer legalizes them, the same protocol as a splice. the optimize-time
+        // CondFolding copy stays - it serves compiles this pre-pass never sees (auto
+        // inlining off) and macro-generated post-infer shapes.
+        class ReturnCanonicalization : public Visitor {
+        public:
+            bool changed = false;
+        protected:
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            // extract `return ...` from an if arm: a naked return (an inner fold leaves one
+            // behind in an elif chain), or a block holding exactly one return. blocks with
+            // a finally section never qualify - the fold would drop it. CMRES makes stay
+            // behind: the make-local protocol doesn't survive under an Op3 arm
+            static ExprReturn * armReturn ( Expression * arm ) {
+                ExprReturn * ret = nullptr;
+                if ( arm->rtti_isReturn() ) {
+                    ret = static_cast<ExprReturn *>(arm);
+                } else if ( arm->rtti_isBlock() ) {
+                    auto blk = static_cast<ExprBlock *>(arm);
+                    if ( blk->list.size()==1 && blk->finalList.empty() && blk->list.back()->rtti_isReturn() ) {
+                        ret = static_cast<ExprReturn *>(blk->list.back());
+                    }
+                }
+                if ( ret && ret->subexpr && ret->subexpr->rtti_isMakeLocal() ) ret = nullptr;
+                return ret;
+            }
+            // the restarted infer expects parser shapes, where an if arm is a block. an
+            // inner fold leaves a naked return as the arm of an elif chain; when the outer
+            // if does not itself fold away, re-block the arm
+            static void reblockArm ( ExpressionPtr & arm ) {
+                if ( arm && arm->rtti_isReturn() ) {
+                    auto blk = new ExprBlock();
+                    blk->at = arm->at;
+                    blk->list.push_back(arm);
+                    arm = blk;
+                }
+            }
+            virtual ExpressionPtr visit ( ExprIfThenElse * expr ) override {
+                if ( expr->if_false && !expr->isStatic && !expr->doNotFold ) {
+                    ExprReturn * lr = armReturn(expr->if_true);
+                    ExprReturn * rr = armReturn(expr->if_false);
+                    if ( lr && rr && lr->moveSemantics==rr->moveSemantics ) {
+                        // a same-walk inner fold leaves untyped subexprs; decline those -
+                        // the arm folds on the next patch round, once infer has typed it.
+                        // return coercion is per-arm but ternary arms must match EACH OTHER,
+                        // and the merged arm loses per-arm coercions: `return derived?` vs
+                        // `return base?` stays an if, and so does `return null` (the null
+                        // literal to typed pointer coercion doesn't survive under an Op3 arm)
+                        if ( lr->subexpr && rr->subexpr
+                            && lr->subexpr->type && rr->subexpr->type
+                            && !lr->subexpr->type->isRef() && !rr->subexpr->type->isRef()
+                            && !lr->subexpr->type->isVoid()
+                            && !lr->subexpr->type->isVoidPointer() && !rr->subexpr->type->isVoidPointer()
+                            && lr->subexpr->type->isSameType(*rr->subexpr->type, RefMatters::no, ConstMatters::no, TemporaryMatters::yes) ) {
+                            auto ternary = new ExprOp3(expr->at, "?", expr->cond, lr->subexpr, rr->subexpr);
+                            auto ret = new ExprReturn(expr->at, ternary);
+                            ret->moveSemantics = lr->moveSemantics;
+                            changed = true;
+                            return ret;
+                        } else if ( !lr->subexpr && !rr->subexpr && inlinePure(expr->cond) ) {
+                            // both arms are bare returns and evaluating the cond does nothing
+                            changed = true;
+                            return lr;
+                        }
+                    }
+                }
+                reblockArm(expr->if_true);
+                reblockArm(expr->if_false);
+                return Visitor::visit(expr);
+            }
+            virtual ExpressionPtr visit ( ExprBlock * block ) override {
+                // a finally section references block locals BY NAME; nesting tail
+                // declarations under a synthesized else would hide them from it when
+                // infer re-resolves (the optimize-time copy of this transform survives
+                // only because post-infer references are by pointer)
+                if ( !block->finalList.empty() ) return Visitor::visit(block);
+                // tail-else synthesis, reversed order so one walk handles a whole batch
+                bool any = false;
+                for ( int i = int(block->list.size()) - 2; i>=0; i-- ) {
+                    auto expr = block->list[i];
+                    if ( !expr->rtti_isIfThenElse() ) continue;
+                    auto ite = static_cast<ExprIfThenElse *>(expr);
+                    if ( ite->if_false || ite->isStatic || ite->doNotFold || !ite->if_true->rtti_isBlock() ) continue;
+                    auto tb = static_cast<ExprBlock *>(ite->if_true);
+                    if ( tb->list.empty() ) continue;
+                    auto lastE = tb->list.back();
+                    if ( lastE->rtti_isReturn() || lastE->rtti_isBreak() || lastE->rtti_isContinue() ) {
+                        auto fb = new ExprBlock();
+                        fb->at = block->list[i+1]->at;
+                        fb->list.assign(block->list.begin()+i+1, block->list.end());
+                        ite->if_false = fb;
+                        block->list.resize(i+1);
+                        any = true;
+                    }
+                }
+                if ( any ) changed = true;
+                return Visitor::visit(block);
+            }
+        };
+
+        bool canonicalizeReturns ( Function * fn ) {
+            if ( !fn->body || !fn->body->rtti_isBlock() ) return false;
+            if ( fn->generator || fn->isTemplate ) return false;
+            // [inline] bodies stay untouched: their shape contract is fail-closed, and a
+            // multi-exit [inline] callee must be the same compile error at every -O level
+            if ( fn->mustInline ) return false;
+            // goto can target a label in a tail this pass would move into an else arm; the
+            // feature is rare enough that any use opts the whole function out
+            bool hasGotoOrLabel = false;
+            lookupExpressions(fn->body, [&](Expression * e) {
+                if ( e->rtti_isGoto() || e->rtti_isLabel() ) hasGotoOrLabel = true;
+            });
+            if ( hasGotoOrLabel ) return false;
+            bool any = false;
+            for ( int round = 0; round!=16; ++round ) {   // converges in 2-3; the cap is paranoia
+                ReturnCanonicalization pass;
+                fn->body = fn->body->visit(pass);
+                if ( !pass.changed ) break;
+                any = true;
+            }
+            return any;
+        }
+
     } // anonymous namespace
 
     bool Program::patchInline() {
@@ -1592,6 +1723,18 @@ namespace das {
         // best-effort inlining is an optimization: it stays out of unoptimized builds
         bool autoEnabled = getOptimize()
             && !options.getBoolOption("disable_auto_inline", policies.disable_auto_inline);
+        // canonicalize early-exit shapes ahead of candidacy: single exit is an inline shape
+        // requirement, and the rewrite must settle (re-infer) before anything splices on
+        // top of it. gated with auto inlining rather than bare optimization:
+        // `disable_auto_inline` is the one knob that promises "no patch-slot reshaping"
+        // to shape-pinning tests and macros
+        if ( autoEnabled && !failed() ) {
+            bool canon = false;
+            thisModule->functions.foreach([&](auto fn) {
+                canon |= canonicalizeReturns(fn);
+            });
+            if ( canon ) return true;
+        }
         // cheap gate: any [inline] function visible at all?
         bool anyInline = false;
         if ( mustEnabled ) {

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -1125,9 +1125,9 @@ namespace das {
                 return privateUseCache[fn] = scan.privateSymbol;
             }
 
-            // next free __inl counter in this function; names are function-scoped and
+            // next free __inl counter across a subtree; names are function-scoped and
             // later rounds keep splicing into the same function, so continue the sequence
-            int nextInlineId ( Function * fn ) {
+            int nextInlineIdIn ( Expression * body ) {
                 int mx = 0;
                 auto consider = [&]( const string & name ) {
                     if ( name.compare(0, 5, "__inl")==0 ) {
@@ -1135,7 +1135,7 @@ namespace das {
                         if ( id >= mx ) mx = id + 1;
                     }
                 };
-                lookupExpressions(fn->body, [&](Expression * expr) {
+                lookupExpressions(body, [&](Expression * expr) {
                     if ( expr->rtti_isLet() ) {
                         auto let = static_cast<ExprLet *>(expr);
                         for ( auto & v : let->variables ) consider(v->name);
@@ -1146,6 +1146,7 @@ namespace das {
                 });
                 return mx;
             }
+            int nextInlineId ( Function * fn ) { return nextInlineIdIn(fn->body); }
 
             void error ( const string & what, const LineInfo & at ) {
                 program->error(what, "", "", at, CompilationError::invalid_annotation);
@@ -1295,6 +1296,16 @@ namespace das {
                     if ( calleeFn->result && !calleeFn->result->isVoid() ) subjResult = calleeFn->result;
                     sa.args = &call->arguments; sa.ofs = 0; sa.params = &calleeFn->arguments;
                 }
+                // a callee body may itself contain manufactured __inl locals (interiors
+                // splice before their callers within a round, and the counter is
+                // function-scoped) - the site id must clear those too, or the rename map
+                // captures this site's synthesized names (the result store would retarget
+                // the callee's interior temp: a wrong-type error, or worse, a silent
+                // uninitialized read when the types happen to agree)
+                {
+                    int calleeNext = nextInlineIdIn(body);
+                    if ( calleeNext > inlineId ) inlineId = calleeNext;
+                }
                 // ----- classify arguments -----
                 auto & stats = paramStats(body, *sa.params);
                 bool isVoid = subjResult==nullptr;
@@ -1341,11 +1352,13 @@ namespace das {
                     // instances (which today collide in the instance registry). best-effort
                     // sites decline; MUST keeps its pre-existing contract
                     if ( site.kind!=SiteKind::MustCall && A->type && P->type ) {
+                        // gc_local: comparison-only temporaries, freed at scope exit
+                        // instead of lingering on the gc root until the next sweep
                         auto stripTop = [](const TypeDecl * t) {
                             auto c = new TypeDecl(*t);
                             c->ref = false;
                             c->constant = false;
-                            return c;
+                            return gc_local<TypeDecl>(c);
                         };
                         if ( !stripTop(A->type)->isSameType(*stripTop(P->type), RefMatters::yes,
                                 ConstMatters::yes, TemporaryMatters::yes, AllowSubstitute::no, false) ) {

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -21,9 +21,16 @@ namespace das {
     //    so a skip is never silent overall.
     //  * calls passing a block LITERAL argument (AUTO, optimized builds only): best-effort.
     //    The literal is the user's signal; nobody promised anything, so every gate -
-    //    callee shape, unsafe in the body, recursion through the splice graph, private
-    //    symbols, call position - declines SILENTLY (counted, logged under
+    //    callee shape, [unsafe_operation]/[unsafe_deref], recursion through the splice
+    //    graph, private symbols, call position - declines SILENTLY (counted, logged under
     //    log_optimization). `options disable_auto_inline` (or the policy) turns it off.
+    //    A plain unsafe body (hasUnsafe) splices: compiled callees lost their `unsafe { }`
+    //    wrappers to foldUnsafe and would re-error on the caller's re-infer, so the spliced
+    //    body rides the result-temp path under a generated statement-position ExprUnsafe -
+    //    later-round splices anchor INSIDE that block, keeping every hoisted temp within
+    //    its authorization region. The wrapper is generated: the no_unsafe policy and the
+    //    caller module's unsafe accounting don't see it (the rewriter also drops
+    //    userSaidItsSafe on callee-origin nodes - the callee's module already accounted).
     //  * invoke of a block literal (DEVIRT, same best-effort contract): an invoke whose
     //    block resolves to a same-function literal - directly or through a move-initialized,
     //    never-rewritten local (which is what an auto-spliced callee leaves behind) -
@@ -304,8 +311,18 @@ namespace das {
             das_hash_map<Variable *, ArgSub> * paramSub = nullptr;  // keyed by ORIGINAL callee param
             das_hash_map<string, string> * rename = nullptr;
             LineInfo tempAt;    // call site location for manufactured temp reads
+            bool clearUserUnsafe = false;   // splicing a function callee (not a devirt literal)
         protected:
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisitExpression ( Expression * expr ) override {
+                Visitor::preVisitExpression(expr);
+                // callee-origin `unsafe(...)` stays authorized via alwaysSafe; dropping the
+                // user-said bit keeps the CALLER module's unsafe accounting (lint anyUnsafe,
+                // no_unsafe policy) unchanged by the splice - the callee's module already
+                // accounted for its own unsafe. substituted caller expressions are grafted
+                // after this visit and keep theirs
+                if ( clearUserUnsafe ) expr->userSaidItsSafe = false;
+            }
             virtual ExpressionPtr visit ( ExprVar * expr ) override {
                 // cloned ExprVar nodes still point at the ORIGINAL callee variables
                 // (ExprVar::clone copies the raw pointer) - param matching is exact
@@ -914,6 +931,47 @@ namespace das {
 
     namespace {
 
+        // a call (or invoke) passing a `#` argument where the resolved target's parameter
+        // is neither `#` nor implicit: it resolved through GENERIC leniency (an OR-type
+        // accepting `string const#` reuses the plain-string instance - the registry
+        // collapses the flavors), and the splice protocol's rename + re-infer re-matches
+        // it directly against the instance's strict signature and fails. a subtree
+        // carrying one cannot ride a splice
+        bool reinferFragile ( Expression * root ) {
+            bool fragile = false;
+            lookupExpressions(root, [&](Expression * e) {
+                if ( fragile ) return;
+                if ( e->rtti_isCall() ) {
+                    auto c = static_cast<ExprCall *>(e);
+                    if ( !c->func ) return;
+                    size_t n = das::min(c->arguments.size(), c->func->arguments.size());
+                    for ( size_t i=0; i!=n; ++i ) {
+                        auto & at = c->arguments[i]->type;
+                        auto & pt = c->func->arguments[i]->type;
+                        if ( at && pt && at->temporary && !pt->temporary && !pt->implicit ) {
+                            fragile = true;
+                            return;
+                        }
+                    }
+                } else if ( e->rtti_isInvoke() ) {
+                    auto inv = static_cast<ExprInvoke *>(e);
+                    if ( inv->arguments.empty() ) return;
+                    auto & bt = inv->arguments[0]->type;
+                    if ( !bt || bt->argTypes.empty() ) return;
+                    size_t n = das::min(inv->arguments.size()-1, bt->argTypes.size());
+                    for ( size_t i=0; i!=n; ++i ) {
+                        auto & at = inv->arguments[i+1]->type;
+                        auto & pt = bt->argTypes[i];
+                        if ( at && pt && at->temporary && !pt->temporary && !pt->implicit ) {
+                            fragile = true;
+                            return;
+                        }
+                    }
+                }
+            });
+            return fragile;
+        }
+
         // a block literal the devirtualizer can splice in place: a plain in-frame block
         // with a single-exit body and a non-reference (or void) result. splicing dissolves
         // the block boundary, so a break/continue not bound to a loop inside the body is out
@@ -937,6 +995,7 @@ namespace das {
                 if ( arg->type->smartPtr ) { why = "smart-pointer parameter"; return false; }
             }
             if ( blk->returnType && blk->returnType->smartPtr ) { why = "smart-pointer result"; return false; }
+            if ( reinferFragile(mkb) ) { why = "body carries a temporary-flavored call"; return false; }
             InlineShapeScan scan(true);
             scan.lastTopLevelStmt = blk->list.empty() ? nullptr : blk->list.back();
             blk->visit(scan);
@@ -996,20 +1055,24 @@ namespace das {
                 return ok;
             }
 
-            // best-effort callee gate: [inline]'s shape contract, plus no unsafe in the
-            // body (a spliced unsafe re-checks against the CALLER module's permissions),
-            // plus no recursion through the combined splice graph
+            // best-effort callee gate: [inline]'s shape contract, plus no recursion
+            // through the combined splice graph. a plain unsafe body (hasUnsafe) is fine:
+            // it splices under a generated `unsafe { }` wrapper
             bool autoCalleeOk ( Function * fn, string & why ) {
                 auto it = autoOkCache.find(fn);
                 if ( it != autoOkCache.end() ) { why = it->second.second; return it->second.first; }
                 bool ok = true;
                 if ( !checkInlineShape(fn, why) ) {
                     ok = false;
-                } else if ( fn->unsafeOperation || fn->unsafeDeref || fn->hasUnsafe ) {
-                    // hasUnsafe is stamped by infer and survives foldUnsafe: a spliced
-                    // unsafe body would re-check against the caller's module, wrapper-less
+                } else if ( fn->unsafeOperation || fn->unsafeDeref ) {
+                    // [unsafe_operation]/[unsafe_deref] carry call-site and runtime
+                    // semantics (re-infer re-stamps deref null-check elision from the
+                    // CALLER's unsafeDeref flag) that a splice would change
                     ok = false;
                     why = "unsafe operation";
+                } else if ( reinferFragile(fn->body) ) {
+                    ok = false;
+                    why = "body carries a temporary-flavored call";
                 } else if ( annotatedCallee(fn, why) ) {
                     ok = false;     // an annotation may carry call-site semantics
                                     // (verifyCall & co) that a splice would bypass
@@ -1238,12 +1301,17 @@ namespace das {
                 // a move return (`return <- x`) never substitutes as an expression: the
                 // substituted read would COPY where the callee moved (an error for
                 // non-copyables, a semantic change otherwise) - it takes the result-temp
-                // path, which preserves the move
+                // path, which preserves the move. an unsafe body also takes the result-temp
+                // path: its generated `unsafe { }` wrapper must be a statement, so that
+                // every later-round splice inside it anchors INSIDE the wrapper's block
+                // (nothing unsafe can hoist out of its authorization region)
                 bool exprBody = body->list.size()==1 && body->list.back()->rtti_isReturn()
-                    && !static_cast<ExprReturn *>(body->list.back())->moveSemantics;
+                    && !static_cast<ExprReturn *>(body->list.back())->moveSemantics
+                    && !(calleeFn && calleeFn->hasUnsafe);
                 bool writeFree = calleeFn ? calleeWriteFree(calleeFn) : false;  // a block body is judged unknown
                 das_hash_map<Variable *, ArgSub> paramSub;
                 vector<ExpressionPtr> temps;
+                bool argFlavorFail = false;
                 for ( size_t ai=0, ais=sa.count(); ai!=ais; ++ai ) {
                     Expression * A = sa.arg(ai);
                     auto & P = sa.param(ai);
@@ -1264,6 +1332,34 @@ namespace das {
                         sub.substitute = leafA;
                         paramSub[P] = sub;
                         continue;
+                    }
+                    // a substitution (or an inferred temp) carries the ARGUMENT's exact type
+                    // into the body, where the call boundary coerced it to the PARAM's type.
+                    // beyond top-level ref/const (which the machinery navigates), a flavor
+                    // change re-types the body: a `#` element re-types field reads past what
+                    // resolved instances accept, and an element-const change forks generic
+                    // instances (which today collide in the instance registry). best-effort
+                    // sites decline; MUST keeps its pre-existing contract
+                    if ( site.kind!=SiteKind::MustCall && A->type && P->type ) {
+                        auto stripTop = [](const TypeDecl * t) {
+                            auto c = new TypeDecl(*t);
+                            c->ref = false;
+                            c->constant = false;
+                            return c;
+                        };
+                        if ( !stripTop(A->type)->isSameType(*stripTop(P->type), RefMatters::yes,
+                                ConstMatters::yes, TemporaryMatters::yes, AllowSubstitute::no, false) ) {
+                            decline(site, subjName + ": argument '" + P->name + "' flavor '"
+                                + A->type->describe() + "' vs parameter '" + P->type->describe() + "'", callLike->at);
+                            argFlavorFail = true;
+                            break;
+                        }
+                    }
+                    // a spliced literal's locals rename and re-infer with the site
+                    if ( site.kind!=SiteKind::MustCall && leafA->rtti_isMakeBlock() && reinferFragile(leafA) ) {
+                        decline(site, subjName + ": block argument carries a temporary-flavored call", callLike->at);
+                        argFlavorFail = true;
+                        break;
                     }
                     if ( byRefParam ) {
                         if ( leafVar ) {
@@ -1346,6 +1442,7 @@ namespace das {
                     }
                     paramSub[P] = sub;
                 }
+                if ( argFlavorFail ) continue;
                 bool needStatements = !temps.empty() || !exprBody;
                 if ( !needStatements ) {
                     // ----- pure graft: no statements, no anchors, legal in any position -----
@@ -1354,6 +1451,7 @@ namespace das {
                     rewriter.paramSub = &paramSub;
                     rewriter.rename = &rename;
                     rewriter.tempAt = callLike->at;
+                    rewriter.clearUserUnsafe = calleeFn != nullptr;
                     auto ret = static_cast<ExprReturn *>(body->list.back());
                     ExpressionPtr callReplacement = nullptr;
                     if ( ret->subexpr ) {
@@ -1567,6 +1665,7 @@ namespace das {
                 rewriter.paramSub = &paramSub;
                 rewriter.rename = &rename;
                 rewriter.tempAt = callLike->at;
+                rewriter.clearUserUnsafe = calleeFn != nullptr;
                 ExpressionPtr callReplacement = nullptr;
                 if ( exprBody ) {
                     auto ret = static_cast<ExprReturn *>(body->list.back());
@@ -1605,7 +1704,18 @@ namespace das {
                         bodyClone->list.push_back(store);
                         callReplacement = new ExprVar(callLike->at, resName);
                     }
-                    splice.push_back(bodyClone->visit(rewriter));
+                    ExpressionPtr spliced = bodyClone->visit(rewriter);
+                    if ( calleeFn && calleeFn->hasUnsafe ) {
+                        // a compiled callee lost its `unsafe { }` wrappers to foldUnsafe, and
+                        // the spliced body re-infers in the caller: re-authorize it under a
+                        // generated wrapper. generated = invisible to the no_unsafe policy
+                        // and to the caller module's unsafe accounting (ast_lint.cpp)
+                        auto wrap = new ExprUnsafe(callLike->at);
+                        wrap->body = spliced;
+                        wrap->generated = true;
+                        spliced = wrap;
+                    }
+                    splice.push_back(spliced);
                 }
                 auto & list = site.anchor.block->list;
                 list.insert(list.begin()+anchorIndex, splice.begin(), splice.end());

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -1395,7 +1395,7 @@ namespace das {
                         }
                     } else if ( varParam ) {
                         // a mutable by-value param IS a local copy
-                        makeArgTemp(A->clone(), false, false, false);
+                        makeArgTemp(A->clone(), false, false, A->type && !A->type->canCopy());
                     } else if ( leafConst ) {
                         sub.substitute = leafA;
                     } else if ( leafVar ) {
@@ -1437,7 +1437,7 @@ namespace das {
                         if ( reads<=1 && !underLoop && inlinePure(A) && orderSafe ) {
                             sub.substitute = A;
                         } else {
-                            makeArgTemp(A->clone(), true, false, false);
+                            makeArgTemp(A->clone(), true, false, A->type && !A->type->canCopy());
                         }
                     }
                     paramSub[P] = sub;

--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -208,6 +208,8 @@ namespace das {
             } else if ( expr->rtti_isR2V() ) {
                 auto rr = (ExprRef2Value *)expr;
                 propagateRead(rr->subexpr);
+            } else if ( expr->rtti_isUnsafe() ) {
+                propagateRead(((ExprUnsafe *) expr)->body);
             }
         }
         void propagateWrite ( Expression * expr ) {
@@ -266,6 +268,8 @@ namespace das {
                                     || call->func->firstArgReturnType) ) {
                     propagateWrite(call->arguments[0]);
                 }
+            } else if ( expr->rtti_isUnsafe() ) {
+                propagateWrite(((ExprUnsafe *) expr)->body);
             }
         }
         void propagateWriteViaCopyOrMove ( Expression * expr ) {
@@ -321,6 +325,8 @@ namespace das {
                                     || call->func->firstArgReturnType) ) {
                     propagateWriteViaCopyOrMove(call->arguments[0]);
                 }
+            } else if ( expr->rtti_isUnsafe() ) {
+                propagateWriteViaCopyOrMove(((ExprUnsafe *) expr)->body);
             }
         }
         // informational: argument appeared in a mutable-ref slot. peels the same shapes as
@@ -361,6 +367,8 @@ namespace das {
                                     || call->func->firstArgReturnType) ) {
                     propagatePassMutable(call->arguments[0]);
                 }
+            } else if ( expr->rtti_isUnsafe() ) {
+                propagatePassMutable(((ExprUnsafe *) expr)->body);
             }
         }
         void markPassMutableArguments ( const Function * fn, const vector<ExpressionPtr> & arguments ) {

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -549,6 +549,7 @@ list(FILTER AOT_LANGUAGE_TEST_FILES EXCLUDE REGEX "/_")
 SET(AOT_LANGUAGE_MODULE_FILES
     tests/language/_glob.das
     tests/language/_helper_foo.das
+    tests/language/_inline_unsafe_helper.das
     tests/language/_operators_derived.das
     tests/language/_operators_parent.das
 )

--- a/tests/ast_match/test_comprehensions.das
+++ b/tests/ast_match/test_comprehensions.das
@@ -2,6 +2,9 @@ options gen2
 options indenting = 4
 options rtti
 options no_coverage
+// the post-inference tests pin the compiled comprehension shell (invoke of the
+// comprehension generator) - auto block inlining legitimately dissolves it
+options disable_auto_inline
 
 require daslib/ast
 require daslib/rtti

--- a/tests/ast_match/test_comprehensions.das
+++ b/tests/ast_match/test_comprehensions.das
@@ -79,7 +79,7 @@ def test_array_comprehension_capture_subexpr(t : T?) {
         let r = qmatch(expr, [for (x in range(10)); $e(sub)])
         t |> success(r.matched, "should match with $e capture on subexpr")
         if (r.matched) {
-            t |> equal(string(sub.__rtti), "ExprOp2")
+            t |> equal(sub.__rtti, "ExprOp2")
         }
     }
 }
@@ -258,13 +258,13 @@ def test_local_function_not_lambda(t : T?) {
 
 [export]
 def target_with_local_fn() {
-    var f = @@(x : int) { return x + 1; }
+    let f = @@(x : int) { return x + 1; }
     feint("{f}")
 }
 
 [export]
 def target_with_local_fn_wrong() {
-    var f = @@(x : int) { return x - 1; }
+    let f = @@(x : int) { return x - 1; }
     feint("{f}")
 }
 
@@ -277,7 +277,7 @@ def test_local_fn_post_inference(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var f = @@(x : int) { return x + 1; }
+            let f = @@(x : int) { return x + 1; }
             feint("{f}")
         }
         t |> success(r.matched, "should match post-inference local function via ExprAddr")
@@ -292,7 +292,7 @@ def test_local_fn_post_inference_wrong_body(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var f = @@(x : int) { return x - 1; }
+            let f = @@(x : int) { return x - 1; }
             feint("{f}")
         }
         t |> success(!r.matched, "wrong body in local function should fail")
@@ -308,19 +308,19 @@ def test_local_fn_capture_body(t : T?) {
         }
         var body_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
-            var f = @@(x : int) { $e(body_expr); }
+            let f = @@(x : int) { $e(body_expr); }
             feint("{f}")
         }
         t |> success(r.matched, "should match with $e capture on local fn body")
         if (r.matched) {
-            t |> equal(string(body_expr.__rtti), "ExprReturn")
+            t |> equal(body_expr.__rtti, "ExprReturn")
         }
     }
 }
 
 [export]
 def target_with_local_fn_two_args() {
-    var f = @@(a : int; b : float) { return float(a) + b; }
+    let f = @@(a : int; b : float) { return float(a) + b; }
     feint("{f}")
 }
 
@@ -332,7 +332,7 @@ def test_local_fn_match_two_args(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var f = @@(a : int; b : float) { return float(a) + b; }
+            let f = @@(a : int; b : float) { return float(a) + b; }
             feint("{f}")
         }
         t |> success(r.matched, "should match local fn with two args")
@@ -348,7 +348,7 @@ def test_local_fn_capture_var_name(t : T?) {
         }
         var vname : string
         let r = qmatch_function(func) $() {
-            var $i(vname) = @@(x : int) { return x + 1; }
+            let $i(vname) = @@(x : int) { return x + 1; }
             feint("{f}")
         }
         t |> success(r.matched, "should match with $i capture on let variable name")
@@ -362,19 +362,19 @@ def test_local_fn_capture_var_name(t : T?) {
 
 [export]
 def target_comp_array() {
-    var a <- [for (x in range(10)); x * x]
+    let a <- [for (x in range(10)); x * x]
     feint("{a}")
 }
 
 [export]
 def target_comp_table() {
-    var t <- {for (x in range(10)); x => x * x}
+    let t <- {for (x in range(10)); x => x * x}
     feint("{t}")
 }
 
 [export]
 def target_comp_where() {
-    var a <- [for (x in range(10)); x * x; where x > 3]
+    let a <- [for (x in range(10)); x * x; where x > 3]
     feint("{a}")
 }
 
@@ -387,7 +387,7 @@ def test_comp_array_post_inference(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var a <- [for (x in range(10)); x * x]
+            let a <- [for (x in range(10)); x * x]
             feint("{a}")
         }
         t |> success(r.matched, "should match post-inference array comprehension")
@@ -403,7 +403,7 @@ def test_comp_table_post_inference(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var t <- {for (x in range(10)); x => x * x}
+            let t <- {for (x in range(10)); x => x * x}
             feint("{t}")
         }
         t |> success(r.matched, "should match post-inference table comprehension")
@@ -419,7 +419,7 @@ def test_comp_where_post_inference(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var a <- [for (x in range(10)); x * x; where x > 3]
+            let a <- [for (x in range(10)); x * x; where x > 3]
             feint("{a}")
         }
         t |> success(r.matched, "should match post-inference comprehension with where")
@@ -434,7 +434,7 @@ def test_comp_wrong_body_post_inference(t : T?) {
             return
         }
         let r = qmatch_function(func) $() {
-            var a <- [for (x in range(10)); x + x]
+            let a <- [for (x in range(10)); x + x]
             feint("{a}")
         }
         t |> success(!r.matched, "wrong subexpr should fail post-inference")
@@ -450,7 +450,7 @@ def test_comp_capture_post_inference(t : T?) {
         }
         var sub_expr : ExpressionPtr
         let r = qmatch_function(func) $() {
-            var a <- [for (x in range(10)); $e(sub_expr)]
+            let a <- [for (x in range(10)); $e(sub_expr)]
             feint("{a}")
         }
         t |> success(r.matched, "should match with $e capture on comprehension subexpr")
@@ -469,7 +469,7 @@ def test_comp_capture_iterator_post_inference(t : T?) {
         }
         var iter_name : string
         let r = qmatch_function(func) $() {
-            var a <- [for ($i(iter_name) in range(10)); $i(iter_name) * $i(iter_name)]
+            let a <- [for ($i(iter_name) in range(10)); $i(iter_name) * $i(iter_name)]
             feint("{a}")
         }
         t |> success(r.matched, "should match with $i capture on iterator name")

--- a/tests/language/_inline_unsafe_helper.das
+++ b/tests/language/_inline_unsafe_helper.das
@@ -1,0 +1,58 @@
+// Cross-module callees with unsafe bodies for optimization_inline_unsafe.das: a compiled
+// module loses its `unsafe { }` wrappers to foldUnsafe, so splicing these bodies exercises
+// the inliner's generated re-authorization wrapper. `_`-prefix keeps dastest from running it.
+options gen2
+
+module _inline_unsafe_helper public
+
+def sum_via_ptr(src : array<int>; blk : block<(v : int) : int>) : int {
+    // multi-statement block-form unsafe body
+    var total = 0
+    unsafe {
+        var p = addr(total)
+        for (v in src) {
+            *p += invoke(blk, v)
+        }
+    }
+    return total
+}
+
+def first_via_ptr(src : array<int>; blk : block<(v : int) : int>) : int {
+    // the invoke inside the unsafe region devirtualizes on a later round: its arg
+    // temp (deref/addr) must anchor INSIDE the spliced wrapper block
+    var r : int
+    unsafe {
+        r = invoke(blk, *addr(src[0]))
+    }
+    return r
+}
+
+def expr_unsafe_sum(src : array<int>; blk : block<(v : int) : int>) : int {
+    // expression-form unsafe only: alwaysSafe is sticky on the cloned nodes; the splice
+    // drops the user-said bit so the caller module's unsafe accounting stays unchanged
+    var total = 0
+    for (v in src) {
+        total += invoke(blk, unsafe(reinterpret<int>(uint(v))))
+    }
+    return total
+}
+
+[unsafe_deref]
+def deref_first(src : array<int>; blk : block<(v : int) : int>) : int {
+    var r : int
+    unsafe {
+        r = invoke(blk, *addr(src[0]))
+    }
+    return r
+}
+
+[inline]
+def scaled_bits(x : int; k : int) : int {
+    // [inline] MUST callee with a block-form unsafe body: spliced wrapper-less, this
+    // re-errored `cast requires unsafe` at the call site before the generated wrapper
+    var r : int
+    unsafe {
+        r = int(reinterpret<uint>(x)) * k
+    }
+    return r
+}

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -72,6 +72,29 @@ def recursive_taker(n : int; blk : block<(v : int) : int>) : int {
     return recursive_taker(n - 1, blk) + 1  // nolint:LINT010
 }
 
+struct LoHi {
+    lo : int
+    hi : int
+}
+
+def make_lohi(k : int; blk : block<(v : int) : int>) : LoHi {
+    // struct (refType) result, copy return: splices through the manufactured
+    // uninitialized result temp
+    let v = invoke(blk, k)
+    return LoHi(lo = v, hi = v * 10)
+}
+
+def doubled_of(src : array<int>; blk : block<(v : int) : int>) : array<int> {
+    // array result, move return: the trailing `return <-` becomes a move into the temp.
+    // deliberately a push loop, not a comprehension - the invoke must sit in a loop body
+    var r : array<int>
+    r |> reserve(length(src))
+    for (v in src) {
+        r |> push(invoke(blk, v))
+    }
+    return <- r
+}
+
 [export]
 def target_auto(src : array<int>) : int {
     return src |> transform_sum() $(v) => v * v
@@ -99,6 +122,23 @@ def target_multi_exit(src : array<int>) : int {
 [export]
 def target_canonicalized(src : array<int>) : int {
     return src |> guarded_first() $(v) => v * 3
+}
+
+[export]
+def target_struct_result(k : int) : int {
+    let p = make_lohi(k) $(v) => v + 1
+    return p.lo + p.hi
+}
+
+[export]
+def target_array_result(src : array<int>) : int {
+    var doubled <- src |> doubled_of() $(v) => v * 2
+    var sum = 0
+    for (v in doubled) {
+        sum += v
+    }
+    delete doubled
+    return sum
 }
 
 [export]
@@ -155,6 +195,15 @@ def test_auto_inline_fired(t : T?) {
             let b = body_of(t, "target_canonicalized")
             t |> success(!has(b, "guarded_first("), "call is gone: {b}")
         }
+        t |> run("struct-result callee splices through the result temp") @(t : T?) {
+            let b = body_of(t, "target_struct_result")
+            t |> success(!has(b, "make_lohi("), "call is gone: {b}")
+        }
+        t |> run("array-result callee splices, move return preserved") @(t : T?) {
+            let b = body_of(t, "target_array_result")
+            t |> success(!has(b, "doubled_of("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
         t |> run("recursive callee declines") @(t : T?) {
             let b = body_of(t, "target_recursive")
             t |> success(has(b, "recursive_taker("), "call stays regular: {b}")
@@ -171,9 +220,12 @@ def test_auto_inline_behavior(t : T?) {
         t |> equal(target_chain(src), 114)
         t |> equal(target_multi_exit(src), 30)
         t |> equal(target_canonicalized(src), 3)
+        t |> equal(target_struct_result(4), 55)
+        t |> equal(target_array_result(src), 20)
         let none : array<int>
         t |> equal(target_multi_exit(none), -1)
         t |> equal(target_canonicalized(none), -1)
+        t |> equal(target_array_result(none), 0)
         t |> equal(target_recursive(src), 11)
     }
     t |> run("impure arguments evaluate once in call order") @(t : T?) {

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -117,6 +117,47 @@ def doubled_of(src : array<int>; blk : block<(v : int) : int>) : array<int> {
     return <- r
 }
 
+typedef OptInt = tuple<_has : bool; _v : int>
+typedef ResOptInt = tuple<_ok : bool; _v2 : OptInt; _err : string>
+
+def inner_probe(k : int; blk : block<(v : int) : int>) : ResOptInt {
+    var res : ResOptInt
+    res._ok = invoke(blk, k) > 0
+    res._v2._has = res._ok
+    res._v2._v = k * 3
+    res._err = "e"
+    return <- res
+}
+
+def outer_probe(k : int; blk : block<(v : int) : int>) : OptInt {
+    // the LITERAL interior call splices first, planting manufactured __inl0_* locals
+    // in this body; splicing IT next must not let the rename map capture the new
+    // site's synthesized result store (the interior temp has a DIFFERENT type here -
+    // a captured store was error 30941 "can only move compatible type")
+    var r <- inner_probe(k, $(x) => invoke(blk, x) + 1)
+    if (!r._ok) {
+        panic("unexpected")
+    }
+    return <- r._v2
+}
+
+def inner_same(k : int; blk : block<(v : int) : int>) : OptInt {
+    var res : OptInt
+    res._has = true
+    res._v = invoke(blk, k) * 3
+    return <- res
+}
+
+def outer_same(k : int; blk : block<(v : int) : int>) : OptInt {
+    // same shape with MATCHING result types: a captured store compiled silently and
+    // read the outer temp uninitialized - the behavioral check pins the values
+    var r <- inner_same(k, $(x) => invoke(blk, x) + 1)
+    if (!r._has) {
+        panic("unexpected")
+    }
+    return <- r
+}
+
 [export]
 def target_auto(src : array<int>) : int {
     return src |> transform_sum() $(v) => v * v
@@ -190,6 +231,18 @@ def target_flavor_mismatch(src : array<int>) : int {
     return iter_sum_cref(unsafe(each(src))) $(v) => v + 1
 }
 
+[export]
+def target_nested_res(k : int) : int {
+    let o <- outer_probe(k) $(v) => v + 1
+    return o._has ? o._v : -1
+}
+
+[export]
+def target_nested_same(k : int) : int {
+    let o <- outer_same(k) $(v) => v + 1
+    return o._has ? o._v : -1
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -254,6 +307,14 @@ def test_auto_inline_fired(t : T?) {
             let b = body_of(t, "target_flavor_mismatch")
             t |> success(has(b, "iter_sum_cref("), "call stays regular: {b}")
         }
+        t |> run("callee with interior splice splices again without capture") @(t : T?) {
+            let b = body_of(t, "target_nested_res")
+            t |> success(!has(b, "outer_probe("), "outer call is gone: {b}")
+            t |> success(!has(b, "inner_probe("), "interior call is gone: {b}")
+            let b2 = body_of(t, "target_nested_same")
+            t |> success(!has(b2, "outer_same("), "outer call is gone: {b2}")
+            t |> success(!has(b2, "inner_same("), "interior call is gone: {b2}")
+        }
     }
 }
 
@@ -275,6 +336,8 @@ def test_auto_inline_behavior(t : T?) {
         t |> equal(target_recursive(src), 11)
         t |> equal(target_flavor_match(4), 10)
         t |> equal(target_flavor_mismatch(src), 14)
+        t |> equal(target_nested_res(5), 15)
+        t |> equal(target_nested_same(4), 18)
     }
     t |> run("impure arguments evaluate once in call order") @(t : T?) {
         g_log = ""

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -43,7 +43,22 @@ def chain_sum(src : array<int>; k : int; blk : block<(v : int) : int>) : int {
 }
 
 def multi_exit(src : array<int>; blk : block<(v : int) : int>) : int {
-    // two returns: single-exit gate declines this callee
+    // early guard + loop tail: return canonicalization synthesizes the else arm but
+    // cannot ternary-fold it (the arm is not a single return), so this stays
+    // multi-exit and the single-exit gate declines it
+    if (empty(src)) {
+        return -1
+    }
+    var total = 0
+    for (v in src) {
+        total += invoke(blk, v)
+    }
+    return total
+}
+
+def guarded_first(src : array<int>; blk : block<(v : int) : int>) : int {
+    // if/else-return pair: return canonicalization folds this to a single ternary
+    // return at patch time, which makes it a valid splice callee
     if (empty(src)) {
         return -1
     }
@@ -79,6 +94,11 @@ def target_chain(src : array<int>) : int {
 [export]
 def target_multi_exit(src : array<int>) : int {
     return src |> multi_exit() $(v) => v * 3
+}
+
+[export]
+def target_canonicalized(src : array<int>) : int {
+    return src |> guarded_first() $(v) => v * 3
 }
 
 [export]
@@ -131,6 +151,10 @@ def test_auto_inline_fired(t : T?) {
             let b = body_of(t, "target_multi_exit")
             t |> success(has(b, "multi_exit("), "call stays regular: {b}")
         }
+        t |> run("if/else-return callee canonicalizes and splices") @(t : T?) {
+            let b = body_of(t, "target_canonicalized")
+            t |> success(!has(b, "guarded_first("), "call is gone: {b}")
+        }
         t |> run("recursive callee declines") @(t : T?) {
             let b = body_of(t, "target_recursive")
             t |> success(has(b, "recursive_taker("), "call stays regular: {b}")
@@ -145,9 +169,11 @@ def test_auto_inline_behavior(t : T?) {
         t |> equal(target_auto(src), 30)
         t |> equal(target_void_auto(src), 10)
         t |> equal(target_chain(src), 114)
-        t |> equal(target_multi_exit(src), 3)
+        t |> equal(target_multi_exit(src), 30)
+        t |> equal(target_canonicalized(src), 3)
         let none : array<int>
         t |> equal(target_multi_exit(none), -1)
+        t |> equal(target_canonicalized(none), -1)
         t |> equal(target_recursive(src), 11)
     }
     t |> run("impure arguments evaluate once in call order") @(t : T?) {

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -72,6 +72,28 @@ def recursive_taker(n : int; blk : block<(v : int) : int>) : int {
     return recursive_taker(n - 1, blk) + 1  // nolint:LINT010
 }
 
+def iter_sum(var src : iterator<int>; blk : block<(v : int) : int>) : int {
+    // by-value-element iterator param: a generator argument is the same flavor
+    var total = 0
+    var v : int
+    while (next(src, v)) {
+        total += invoke(blk, v)
+    }
+    return total
+}
+
+def iter_sum_cref(var src : iterator<int const&>; blk : block<(v : int) : int>) : int {
+    // element-const iterator param: an each() argument is element-mutable - a legal
+    // call (variance), but the substitution would fork the body's instantiations,
+    // so the site declines
+    var total = 0
+    var v : int
+    while (next(src, v)) {
+        total += invoke(blk, v)
+    }
+    return total
+}
+
 struct LoHi {
     lo : int
     hi : int
@@ -152,6 +174,22 @@ def target_impure_args(a, b : int) : int {
     return transform_sum([side("a", a), side("b", b)]) $(v) => v * 2
 }
 
+[export]
+def target_flavor_match(n : int) : int {
+    var gen <- generator<int> {
+        for (i in range(n)) {
+            yield i
+        }
+        return false
+    }
+    return iter_sum(gen) $(v) => v + 1
+}
+
+[export]
+def target_flavor_mismatch(src : array<int>) : int {
+    return iter_sum_cref(unsafe(each(src))) $(v) => v + 1
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -208,6 +246,14 @@ def test_auto_inline_fired(t : T?) {
             let b = body_of(t, "target_recursive")
             t |> success(has(b, "recursive_taker("), "call stays regular: {b}")
         }
+        t |> run("matching element flavor splices") @(t : T?) {
+            let b = body_of(t, "target_flavor_match")
+            t |> success(!has(b, "iter_sum("), "call is gone: {b}")
+        }
+        t |> run("element flavor change declines") @(t : T?) {
+            let b = body_of(t, "target_flavor_mismatch")
+            t |> success(has(b, "iter_sum_cref("), "call stays regular: {b}")
+        }
     }
 }
 
@@ -227,6 +273,8 @@ def test_auto_inline_behavior(t : T?) {
         t |> equal(target_canonicalized(none), -1)
         t |> equal(target_array_result(none), 0)
         t |> equal(target_recursive(src), 11)
+        t |> equal(target_flavor_match(4), 10)
+        t |> equal(target_flavor_mismatch(src), 14)
     }
     t |> run("impure arguments evaluate once in call order") @(t : T?) {
         g_log = ""

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -117,6 +117,16 @@ def doubled_of(src : array<int>; blk : block<(v : int) : int>) : array<int> {
     return <- r
 }
 
+def clone_taker(n : int; blk : block<(data : array<uint8>) : void>) {
+    // const block param + non-const local arg: the devirt substitution must keep the
+    // param's const view (bind a const ref), or the literal's `pixels := m` - already
+    // resolved to a ==const-flavored clone instance - re-types and hard-fails 30341
+    var arr : array<uint8>
+    arr |> resize(n)
+    invoke(blk, arr)
+    delete arr
+}
+
 typedef OptInt = tuple<_has : bool; _v : int>
 typedef ResOptInt = tuple<_ok : bool; _v2 : OptInt; _err : string>
 
@@ -232,6 +242,17 @@ def target_flavor_mismatch(src : array<int>) : int {
 }
 
 [export]
+def target_clone_from_param(n : int) : int {
+    var pixels : array<uint8>
+    clone_taker(n) $(m) {
+        pixels := m
+    }
+    let l = length(pixels)
+    delete pixels
+    return l
+}
+
+[export]
 def target_nested_res(k : int) : int {
     let o <- outer_probe(k) $(v) => v + 1
     return o._has ? o._v : -1
@@ -307,6 +328,10 @@ def test_auto_inline_fired(t : T?) {
             let b = body_of(t, "target_flavor_mismatch")
             t |> success(has(b, "iter_sum_cref("), "call stays regular: {b}")
         }
+        t |> run("const-view-preserving substitution keeps := splice-safe") @(t : T?) {
+            let b = body_of(t, "target_clone_from_param")
+            t |> success(!has(b, "clone_taker("), "call is gone: {b}")
+        }
         t |> run("callee with interior splice splices again without capture") @(t : T?) {
             let b = body_of(t, "target_nested_res")
             t |> success(!has(b, "outer_probe("), "outer call is gone: {b}")
@@ -338,6 +363,7 @@ def test_auto_inline_behavior(t : T?) {
         t |> equal(target_flavor_mismatch(src), 14)
         t |> equal(target_nested_res(5), 15)
         t |> equal(target_nested_same(4), 18)
+        t |> equal(target_clone_from_param(4), 4)
     }
     t |> run("impure arguments evaluate once in call order") @(t : T?) {
         g_log = ""

--- a/tests/language/optimization_dead_stores.das
+++ b/tests/language/optimization_dead_stores.das
@@ -11,9 +11,9 @@ require daslib/strings_boost
 
 // structural FIRED proof + behavioral safety net for the dead-store-elimination pass
 // (src/ast/ast_dse.cpp): a store to a plain local is removed when nothing reads it
-// before the next full overwrite AND the rhs is pure. The behavioral tests pin the
-// safety gates: impure rhs kept, aliased/by-ref/op-assign locals untouched, functions
-// with finally skipped whole.
+// before the next full overwrite; an impure rhs survives as a bare statement. The
+// behavioral tests pin the safety gates: aliased/by-ref locals untouched, op-assign
+// is a read (gen) but never a candidate, functions with finally skipped whole.
 
 var g_count = 0
 var g_obs = 0
@@ -88,7 +88,16 @@ def target_chain(x : int) : int {
 [export]
 def target_impure(x : int) : int {
     var t = 0
-    t = bump() // target is dead but the rhs has side effects — statement must stay
+    t = bump() // target is dead, rhs has side effects — the store drops, the call stays
+    return x
+}
+
+[export]
+def target_impure_reads(x : int) : int {
+    var u = 0 // nolint:LINT010 -- deliberate dead init
+    u = x * 109 // LIVE: the kept bare rhs below still reads u
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    t = bump() + u // dead store, impure rhs: the call survives as a bare statement
     return x
 }
 
@@ -143,8 +152,34 @@ def target_finally(x : int) : int {
 [export]
 def target_opassign(x : int) : int {
     var t = x
-    t += 1 // nolint:PERF013 -- op-assign disqualifies t; the `+=` shape is the point
+    t += 1 // nolint:PERF013 -- op-assign is never a removal candidate; the `+=` shape is the point
     return x
+}
+
+[export]
+def target_opassign_gen(x : int) : int {
+    var t = x
+    t += 3 // gen: reads t, so the init above stays live
+    let r = t * 2
+    t = x * 93 // nolint:LINT010 -- dead: t never read again (op-assign no longer disqualifies)
+    return r
+}
+
+[export]
+def target_opassign_reads(x : int) : int {
+    var t = 0 // nolint:LINT010 -- deliberate dead init
+    t = x * 97 // LIVE: the op-assign below reads it
+    t += 5
+    return t
+}
+
+[export]
+def target_increment_gen(x : int) : int {
+    var t = x
+    t ++ // gen: reads t, so the init above stays live
+    let r = t * 4
+    t = x * 107 // nolint:LINT010 -- dead: t never read again
+    return r
 }
 
 // ----- v2: field-chain stores and declaration inits (ast_alias.h) -----
@@ -160,6 +195,15 @@ struct DseBody {
 }
 
 def observe_field(s : DseBody) : int => s.pos.x
+
+[export]
+def target_opassign_field(x : int) : int {
+    var s : DseBody
+    s.pos.x = x + 101 // LIVE: the op-assign below reads it
+    s.pos.x += 7
+    s.id = x * 103 // dead: id never read
+    return s.pos.x
+}
 
 [export]
 def target_field_overwrite(x : int) : int {
@@ -266,9 +310,15 @@ def test_dead_stores_fired(t : T?) {
             let b = body_of(t, "target_chain")
             t |> success(!has(b, "+ 13") && !has(b, "* 2"), "whole chain gone: {b}")
         }
-        t |> run("impure rhs keeps the statement") @(t : T?) {
+        t |> run("impure rhs survives as a bare call") @(t : T?) {
             let b = body_of(t, "target_impure")
-            t |> success(has(b, "bump"), "side-effecting store kept: {b}")
+            t |> success(has(b, "bump"), "side-effecting rhs kept: {b}")
+            t |> success(!has(b, "= bump"), "dead store stripped to a bare call: {b}")
+        }
+        t |> run("kept bare rhs still counts as a read") @(t : T?) {
+            let b = body_of(t, "target_impure_reads")
+            t |> success(has(b, "* 109"), "store read by the kept rhs stays: {b}")
+            t |> success(!has(b, "= bump"), "dead store stripped to a bare statement: {b}")
         }
         t |> run("addr() disqualifies the variable") @(t : T?) {
             let b = body_of(t, "target_alias")
@@ -292,9 +342,27 @@ def test_dead_stores_fired(t : T?) {
             let b = body_of(t, "target_finally")
             t |> success(has(b, "+ 21"), "store read by finally kept: {b}")
         }
-        t |> run("op-assign disqualifies the variable") @(t : T?) {
+        t |> run("op-assign alone is never a removal candidate") @(t : T?) {
             let b = body_of(t, "target_opassign")
             t |> success(has(b, "+="), "op-assign statement kept: {b}")
+        }
+        t |> run("op-assign no longer disqualifies: later dead store falls") @(t : T?) {
+            let b = body_of(t, "target_opassign_gen")
+            t |> success(!has(b, "* 93"), "dead store after op-assign gone: {b}")
+            t |> success(has(b, "+= 3"), "op-assign kept: {b}")
+        }
+        t |> run("op-assign reads keep the store they observe") @(t : T?) {
+            let b = body_of(t, "target_opassign_reads")
+            t |> success(has(b, "* 97"), "store read by op-assign stays: {b}")
+        }
+        t |> run("increment no longer disqualifies: later dead store falls") @(t : T?) {
+            let b = body_of(t, "target_increment_gen")
+            t |> success(!has(b, "* 107"), "dead store after increment gone: {b}")
+        }
+        t |> run("field op-assign: gen on its chain, disjoint dead store falls") @(t : T?) {
+            let b = body_of(t, "target_opassign_field")
+            t |> success(has(b, "+ 101"), "store read by field op-assign stays: {b}")
+            t |> success(!has(b, "* 103"), "disjoint dead field store gone: {b}")
         }
         t |> run("overwritten field store is removed") @(t : T?) {
             let b = body_of(t, "target_field_overwrite")
@@ -351,6 +419,14 @@ def test_dead_stores_behavior(t : T?) {
         t |> equal(g_count, 1)
         t |> equal(target_impure(2), 2)
         t |> equal(g_count, 2)
+        t |> equal(target_impure_reads(3), 3)
+        t |> equal(g_count, 3)
+    }
+    t |> run("op-assign values preserved") @(t : T?) {
+        t |> equal(target_opassign_gen(5), 16)
+        t |> equal(target_opassign_reads(3), 296)
+        t |> equal(target_increment_gen(2), 12)
+        t |> equal(target_opassign_field(1), 109)
     }
     t |> run("aliased store still lands") @(t : T?) {
         t |> equal(target_alias(7), 42)

--- a/tests/language/optimization_fold_shape.das
+++ b/tests/language/optimization_fold_shape.das
@@ -1,5 +1,6 @@
 options gen2
 options rtti
+options no_coverage // shape pins: injected coverage calls legitimately block the folds
 
 require daslib/ast
 require daslib/rtti

--- a/tests/language/optimization_fold_shape.das
+++ b/tests/language/optimization_fold_shape.das
@@ -4,6 +4,7 @@ options rtti
 require daslib/ast
 require daslib/rtti
 require daslib/ast_boost
+require daslib/defer
 require dastest/testing_boost public
 require strings
 require daslib/strings_boost
@@ -140,6 +141,51 @@ def target_sub_self_float(f : float) : float {
     return f - f // nolint:LINT007 -- deliberate: stays without fast_math (inf/NaN)
 }
 
+// ===== CondFolding: if/else-return => ternary =====
+
+[export]
+def target_elif_chain(x : int) : int {
+    if (x > 10) {
+        return 3
+    } elif (x > 5) {
+        return 2
+    } elif (x > 0) {
+        return 1
+    } else {
+        return 0
+    }
+}
+
+[export]
+def target_void_return_pure(b : bool) {
+    if (b) { // nolint:LINT009 -- deliberate: equivalent void arms are the fold under test
+        return
+    } else {
+        return
+    }
+}
+
+[export]
+def target_void_return_impure() {
+    if (bump_side() > 0) { // nolint:LINT009 -- deliberate: equivalent void arms are the fold under test
+        return
+    } else {
+        return
+    }
+}
+
+[export]
+def target_defer_in_arm(c : bool) : int {
+    if (c) {
+        defer() {
+            g_side++
+        }
+        return 1
+    } else {
+        return 2
+    }
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -261,6 +307,34 @@ def test_same_as_folds_fired(t : T?) {
         t |> run("f - f stays OFF without fast_math") @(t : T?) {
             let b = body_of(t, "target_sub_self_float")
             t |> success(has(b, "f - f"), "float self-sub not folded: {b}")
+        }
+    }
+}
+
+[test]
+def test_cond_folds_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("elif chain of returns collapses fully") @(t : T?) {
+            // regression: the inner fold leaves a naked ExprReturn as if_false, which
+            // the outer level used to reject (rtti_isBlock) — jamming after one level
+            let b = body_of(t, "target_elif_chain")
+            t |> success(!has(b, "if"), "no `if` survives: {b}")
+            t |> success(has(b, "?"), "ternary chain present: {b}")
+        }
+        t |> run("void arms with pure cond fold away") @(t : T?) {
+            let b = body_of(t, "target_void_return_pure")
+            t |> success(!has(b, "if"), "no `if` survives: {b}")
+        }
+        t |> run("void arms with impure cond keep the call") @(t : T?) {
+            // regression: this used to fold to a bare return, dropping the call
+            let b = body_of(t, "target_void_return_impure")
+            t |> success(has(b, "bump_side"), "condition side effect kept: {b}")
+        }
+        t |> run("arm with a finally section does not fold") @(t : T?) {
+            // regression: `if (c) { return 1 } finally { ... } else { return 2 }` — the
+            // shape defer() leaves — used to fold to a ternary, dropping the finally
+            let b = body_of(t, "target_defer_in_arm")
+            t |> success(has(b, "finally"), "finally section kept: {b}")
         }
     }
 }

--- a/tests/language/optimization_folding.das
+++ b/tests/language/optimization_folding.das
@@ -32,6 +32,37 @@ def only_finally {
     }
 }
 
+def void_return_impure {
+    if (side_b()) { // nolint:LINT009 -- deliberate: equivalent void arms are the fold under test
+        return
+    } else {
+        return
+    }
+}
+
+def elif_grade(x : int) : int {
+    if (x > 10) {
+        return 3
+    } elif (x > 5) {
+        return 2
+    } elif (x > 0) {
+        return 1
+    } else {
+        return 0
+    }
+}
+
+def defer_in_arm(c : bool) : int {
+    if (c) {
+        defer() {
+            g_calls++
+        }
+        return 1
+    } else {
+        return 2
+    }
+}
+
 [test]
 def test_mul_identities(t : T?) {
     t |> run("x*1 and 1*x") @(t : T?) {
@@ -189,6 +220,36 @@ def test_finalizer_only_function_still_runs(t : T?) {
     // call, silently dropping the defer's side effect under optimization
     g_calls = 0
     only_finally()
+    t |> equal(g_calls, 1)
+}
+
+[test]
+def test_cond_fold_keeps_impure_cond(t : T?) {
+    // regression: `if (impure()) return; else return;` folded to a bare return,
+    // silently dropping the condition's side effect
+    g_calls = 0
+    void_return_impure()
+    t |> equal(g_calls, 1)
+}
+
+[test]
+def test_elif_chain_values(t : T?) {
+    // the elif chain folds to nested ternaries (shape proof in optimization_fold_shape.das);
+    // every branch must keep its value
+    t |> equal(elif_grade(11), 3)
+    t |> equal(elif_grade(7), 2)
+    t |> equal(elif_grade(1), 1)
+    t |> equal(elif_grade(-5), 0)
+}
+
+[test]
+def test_cond_fold_keeps_arm_finally(t : T?) {
+    // regression: an arm holding one return plus a finally section (defer) used to
+    // fold to a ternary return, silently dropping the finally
+    g_calls = 0
+    t |> equal(defer_in_arm(true), 1)
+    t |> equal(g_calls, 1)
+    t |> equal(defer_in_arm(false), 2)
     t |> equal(g_calls, 1)
 }
 

--- a/tests/language/optimization_inline_unsafe.das
+++ b/tests/language/optimization_inline_unsafe.das
@@ -1,0 +1,139 @@
+options gen2
+options rtti
+options no_coverage
+
+require daslib/ast
+require daslib/rtti
+require daslib/ast_boost
+require dastest/testing_boost public
+require strings
+require daslib/strings_boost
+require _inline_unsafe_helper
+
+// unsafe callee bodies splice under a generated `unsafe { }` wrapper
+// (src/ast/ast_inline.cpp): a compiled callee lost its wrappers to foldUnsafe, so a
+// wrapper-less spliced body re-errors against the caller on re-infer. FIRED proof: the
+// cross-module calls (and the [inline] MUST call) are gone, invokes inside the unsafe
+// region devirtualize; behavioral: values identical. The negative pins the kept gate:
+// [unsafe_deref]/[unsafe_operation] change runtime semantics when spliced (re-infer
+// re-stamps deref null-check elision from the CALLER's flag), so they stay calls.
+
+def local_unsafe_sum(src : array<int>; blk : block<(v : int) : int>) : int {
+    // same-module callee: its own `unsafe { }` wrapper is still present at patch time
+    var total = 0
+    unsafe {
+        var p = addr(total)
+        for (v in src) {
+            *p += invoke(blk, v)
+        }
+    }
+    return total
+}
+
+[export]
+def target_block_unsafe(src : array<int>) : int {
+    return src |> sum_via_ptr() $(v) => v * v
+}
+
+[export]
+def target_single_return_unsafe(src : array<int>) : int {
+    return src |> first_via_ptr() $(v) => v + 10
+}
+
+[export]
+def target_expr_unsafe(src : array<int>) : int {
+    return src |> expr_unsafe_sum() $(v) => v * 3
+}
+
+[export]
+def target_local_unsafe(src : array<int>) : int {
+    return src |> local_unsafe_sum() $(v) => v - 1
+}
+
+[export]
+def target_unsafe_deref(src : array<int>) : int {
+    return src |> deref_first() $(v) => v + 1
+}
+
+[export]
+def target_must_unsafe(x : int) : int {
+    return scaled_bits(x, 7)
+}
+
+[export]
+def target_devirt_unsafe_literal(x : int) : int {
+    // caller-origin literal with expression-form unsafe: the devirt splice keeps the
+    // caller's own unsafe accounting (userSaidItsSafe survives non-callee splices)
+    let blk <- $(v : int) : int {
+        return unsafe(reinterpret<int>(uint(v))) + 1
+    }
+    return invoke(blk, x)
+}
+
+def has(s, sub : string) : bool {
+    return find(s, sub, 0) >= 0
+}
+
+def body_of(t : T?; nm : string) : string {
+    var body = ""
+    compiling_module() |> for_each_function("{nm}") $(func) {
+        if (empty(body)) {
+            body = "{describe(func.body)}"
+        }
+    }
+    t |> success(!empty(body), "target function found")
+    let clean <- [for (ln in split(body, "\n")); ln; where !(ln |> has("coverage("))]
+    return join(clean, "\n")
+}
+
+[test]
+def test_inline_unsafe_fired(t : T?) {
+    ast_gc_guard() {
+        t |> run("cross-module block-form unsafe body splices") @(t : T?) {
+            let b = body_of(t, "target_block_unsafe")
+            t |> success(!has(b, "sum_via_ptr("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("invoke inside the unsafe region devirtualizes") @(t : T?) {
+            let b = body_of(t, "target_single_return_unsafe")
+            t |> success(!has(b, "first_via_ptr("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("expression-form unsafe body splices") @(t : T?) {
+            let b = body_of(t, "target_expr_unsafe")
+            t |> success(!has(b, "expr_unsafe_sum("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("same-module unsafe body splices") @(t : T?) {
+            let b = body_of(t, "target_local_unsafe")
+            t |> success(!has(b, "local_unsafe_sum("), "call is gone: {b}")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+        t |> run("[unsafe_deref] callee stays a call") @(t : T?) {
+            let b = body_of(t, "target_unsafe_deref")
+            t |> success(has(b, "deref_first("), "call stays regular: {b}")
+        }
+        t |> run("[inline] MUST callee with unsafe body splices") @(t : T?) {
+            let b = body_of(t, "target_must_unsafe")
+            t |> success(!has(b, "scaled_bits("), "call is gone: {b}")
+        }
+        t |> run("caller-origin unsafe literal devirtualizes") @(t : T?) {
+            let b = body_of(t, "target_devirt_unsafe_literal")
+            t |> success(!has(b, "invoke("), "invoke devirtualized: {b}")
+        }
+    }
+}
+
+[test]
+def test_inline_unsafe_behavior(t : T?) {
+    t |> run("values preserved") @(t : T?) {
+        let src <- [1, 2, 3, 4]
+        t |> equal(target_block_unsafe(src), 30)
+        t |> equal(target_single_return_unsafe(src), 11)
+        t |> equal(target_expr_unsafe(src), 30)
+        t |> equal(target_local_unsafe(src), 6)
+        t |> equal(target_unsafe_deref(src), 2)
+        t |> equal(target_must_unsafe(6), 42)
+        t |> equal(target_devirt_unsafe_literal(41), 42)
+    }
+}

--- a/utils/lint/tests/lint007_same_operands.das
+++ b/utils/lint/tests/lint007_same_operands.das
@@ -21,6 +21,9 @@ options gen2
 //   `let x = 1; x == x` is folded to `true` before lint runs and will NOT
 //   fire. LINT007 catches cases where operands are runtime values (function
 //   parameters, field reads, etc.). The fixture uses parameters on purpose.
+//   Identical CONSTANT operands are also skipped explicitly: macro splices
+//   legitimately produce shapes like `1 > 1` (`$v(n) > 1` with n == 1), and
+//   those are const-fold food rather than copy-paste typos.
 
 expect 50503:17
 


### PR DESCRIPTION
Follow-up bundle to #3393, as discussed:

1. **CondFolding fixes** (`ast_block_folding.cpp`) — the void-arms fold dropped an impure condition (live miscompile on master: `if (bump()) return; else return;` folded to a bare `return`, side effect gone); finalList now gates on both arms; naked-`ExprReturn` arms accepted so elif chains stop jamming after one fold level.
2. **Patch-slot return canonicalization** — pre-pass at the top of patchInline (optimize-guarded, per-function fixpoint): if/else-return becomes ternary, tail-else synthesized — early-exit bodies become splice-eligible. Gates earned: same-type non-void arms only, finalList blocks skipped, only functions with a block param canonicalize (else +20% suite compile time).
3. **refType-result splicing** — results flow through an `__inl<N>_res` temp. Gates earned: cloned locals reset `aliasCMRES` (cross-module spliced callee wrote to CMRES 0x0 — pugixml crash), unresolved manufactured var reads count pure in `inlinePure`, foreign-module + `==const`-flavored instances decline (instance mangling is constness-flavor-locked).
4. **Unsafe-body splicing** — unsafe callees force the result-temp path and the body rides a generated statement-position `ExprUnsafe`, so later-round splices anchor inside the authorization region. Wrapper is `generated` (invisible to `no_unsafe` and module unsafe accounting); rewriter drops `userSaidItsSafe` on callee-origin nodes. Infer now types expression-position `ExprUnsafe` from its body. Also fixes a live `[inline]`+unsafe cross-module compile error on master (31004). Two re-infer-fragility gates added (arg-flavor strict match, `#`-flavored-call scan) pending the instance-registry mangler fix.
5. **Smalls** — DSE: statement-level op-assign/increment classifies as a read (gen) instead of disqualifying the variable; a dead store with an impure rhs keeps the rhs as a bare statement (`t = impure()` → `impure()`). Inliner: viaMove consistency on varParam/tier-C temps (Copilot nits from #3393). Lint: LINT007 skips identical-constant operands, STYLE016/005/010/017 skip macro-generated ifs, qmatch guard ladders are stamped `generated` — clears the pre-existing warning debt CI's changed-file gate would trip on.

Census (linq stack): 694 auto + 240 devirt fired, 0 unsafe declines, 130 flavor declines (all element-const iterator variance); result-shape decline bucket fully converted.

Validation: interp sweep 11161/11161 · AOT sweep 10430/10430, zero 50101 · JIT jit_tests 309/309 + language 1271/1271 · ctest 76/76 · block-taker bench 233ms → 62ms (3.7×), values bit-identical · changed-file lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)