### PR TITLE
compiler: instance-registry re-resolution — flavor tie-break + origin-generic fallback

### DIFF
--- a/daslib/linq.das
+++ b/daslib/linq.das
@@ -2951,12 +2951,8 @@ def private all_impl_const(src : auto(ARGT); tt : auto(TT); predicate : block<(a
     return all_impl(unsafe(reinterpret<ARGT -const>(src)), type<TT -const -&>, predicate)
 }
 
-def all(var src : iterator<auto(TT) const>; predicate : block<(arg : TT -&) : bool>) : bool {
+def all(var src : iterator<auto(TT)>; predicate : block<(arg : TT -&) : bool>) : bool {
     //! Returns true if all elements in the iterator satisfy the predicate
-    //! `const` on the inner element collapses mut-ref and const-ref iterator sources
-    //! (`each(arr)` vs iterator comprehensions) into a single generic instance, sidestepping
-    //! the generic-mangler hash collision (error[50609]) that fires when both flavors
-    //! arise in one module. Full fix lives in the mangler itself (follow-up PR).
     return all_impl(src, type<TT -const -&>, predicate)
 }
 
@@ -3246,9 +3242,8 @@ def private contains_impl_const(src : auto(ARGT); tt : auto(TT); element : TT -&
     return contains_impl(unsafe(reinterpret<ARGT -const>(src)), type<TT -const -&>, element)
 }
 
-def contains(var src : iterator<auto(TT) const>; element : TT -&) : bool {
+def contains(var src : iterator<auto(TT)>; element : TT -&) : bool {
     //! Returns true if the element is present in the iterator
-    //! `const` on the inner element — see comment on `all()` above for the rationale.
     return contains_impl(src, type<TT -const -&>, element)
 }
 

--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -218,6 +218,8 @@ namespace das {
 
         void findMatchingFunctionsAndGenerics(MatchingFunctions &resultFunctions, MatchingFunctions &resultGenerics, const string &name, const vector<TypeDeclPtr> &types, bool inferBlock = false, bool visCheck = true) const;
 
+        Function * lockedNameGenericOrigin(const string &name, const MatchingFunctions &functions) const;
+
         bool trySeedTupleShorthand(ExprLooksLikeCall *expr, bool visCheck);
 
         void reportDualFunctionNotFound(const string &name, const string &extra,

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -712,6 +712,39 @@ namespace das {
                 return true; }, moduleName);
         return result;
     }
+    Function * InferTypes::lockedNameGenericOrigin(const string & name, const MatchingFunctions & functions) const {
+        if (name.compare(0, 4, "__::") != 0) return nullptr;
+        auto funcName = name.substr(4);
+        if (funcName.find('`') == string::npos) return nullptr;
+        Function * origin = nullptr;
+        auto consider = [&](Function * pFn) -> bool {       // false = not one shared family
+            if (!pFn || !pFn->fromGeneric) return false;
+            if (origin && origin != pFn->fromGeneric) return false;
+            origin = pFn->fromGeneric;
+            return true;
+        };
+        if (!functions.empty()) {                           // ambiguous candidates in hand
+            for (auto & pFn : functions) {
+                if (!consider(pFn)) return nullptr;
+            }
+            return origin;
+        }
+        auto hFuncName = hash64z(funcName.c_str());         // no visibility filter - only fromGeneric is read
+        bool conflict = false;
+        program->library.foreach([&](Module * mod) -> bool {
+            auto itFnList = mod->functionsByName.find(hFuncName);
+            if (itFnList) {
+                for (auto & pFn : itFnList->second) {
+                    if (!consider(pFn)) {
+                        conflict = true;
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }, "*");
+        return conflict ? nullptr : origin;
+    }
     void InferTypes::findMatchingFunctionsAndGenerics(MatchingFunctions &resultFunctions, MatchingFunctions &resultGenerics, const string &name, const vector<TypeDeclPtr> &types, const vector<MakeFieldDeclPtr> &arguments, bool inferBlock) const {
         string moduleName, funcName;
         splitTypeName(name, moduleName, funcName);
@@ -1417,6 +1450,22 @@ namespace das {
             if (functions.empty() && generics.empty() && expr->pipedCallArgument && !expr->arguments.empty()) {
                 tryPipedCallPadding(expr, types, functions, generics, visCheck);
             }
+            // a name locked to a generic-instance family ("__::module`name`hash") can
+            // stop matching after its subtree was cloned or re-typed: the genericFunction
+            // short-circuit does not survive ExprCall::clone, and lookup by the locked
+            // name sees only the flavor-frozen instances - the generic itself is
+            // unreachable under that name. fall back to the origin generic so the next
+            // pass re-resolves with first-resolution semantics, reusing a sibling or
+            // minting the right flavor
+            if (generics.empty() && functions.size() != 1) {
+                if (auto origin = lockedNameGenericOrigin(expr->name, functions)) {
+                    expr->name = origin->module->name.empty() ? origin->name
+                               : (origin->module->name + "::" + origin->name);
+                    reportAstChanged();
+                    if (func) func->notInferred();
+                    return nullptr;
+                }
+            }
         } else {
             functions.push_back(lookupFunction);
         }
@@ -1523,6 +1572,10 @@ namespace das {
                 auto oneGeneric = generics.back();
                 auto genName = getGenericInstanceName(oneGeneric);
                 auto instancedFunctions = findMatchingFunctions(program->thisModule->name, thisModule, genName, types, true); // "__::genName"
+                // pointer/iterator element variance lets one call match several flavor
+                // siblings (a const-element instance accepts a mut-element call).
+                // substitute distance separates them - the exact-flavor sibling wins
+                applyLSP(types, instancedFunctions);
                 if (instancedFunctions.size() > 1) {
                     TextWriter ss;
                     for (auto &instFn : instancedFunctions) {

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -210,11 +210,13 @@ namespace das {
                 }
                 // a generic INSTANCE call is name-mangled for the argument flavor it was
                 // instantiated with. tolerant instances (push, length) re-match after a
-                // splice, but an `explicit`-flavored parameter (==const generics: the
-                // clone family) locks the exact constness - substituting a non-const
-                // caller argument into a const-instantiated call stops the mangled name
-                // from matching. foreign-module instances decline outright (reachability),
-                // destination-module instances decline only on the explicit flavor
+                // splice - and a re-typed locked call now falls back to its origin
+                // generic - but an `explicit`-flavored parameter (==const generics: the
+                // clone family) marks a body TYPED against a locked constness view;
+                // splicing one under the caller's optimizer scope is a soundness
+                // boundary (see the flavor gates in processFunction). foreign-module
+                // instances decline outright (reachability), destination-module
+                // instances decline only on the explicit flavor
                 if ( fn->fromGeneric ) {
                     bool explicitFlavor = false;
                     for ( auto & arg : fn->arguments ) {
@@ -932,10 +934,11 @@ namespace das {
     namespace {
 
         // a call (or invoke) passing a `#` argument where the resolved target's parameter
-        // is neither `#` nor implicit: it resolved through GENERIC leniency (an OR-type
-        // accepting `string const#` reuses the plain-string instance - the registry
-        // collapses the flavors), and the splice protocol's rename + re-infer re-matches
-        // it directly against the instance's strict signature and fails. a subtree
+        // is neither `#` nor implicit. the binding is tolerated on the original node (the
+        // genericFunction short-circuit) and the locked-name fallback re-resolves it after
+        // a splice - but a spliced `#` view of container storage runs under the CALLER's
+        // optimizer scope, where the temp's real lifetime is no longer fenced by the call
+        // boundary (proven value corruption: linq's lazy group_by pipeline). a subtree
         // carrying one cannot ride a splice
         bool reinferFragile ( Expression * root ) {
             bool fragile = false;
@@ -1347,10 +1350,14 @@ namespace das {
                     // a substitution (or an inferred temp) carries the ARGUMENT's exact type
                     // into the body, where the call boundary coerced it to the PARAM's type.
                     // beyond top-level ref/const (which the machinery navigates), a flavor
-                    // change re-types the body: a `#` element re-types field reads past what
-                    // resolved instances accept, and an element-const change forks generic
-                    // instances (which today collide in the instance registry). best-effort
-                    // sites decline; MUST keeps its pre-existing contract
+                    // change is a SOUNDNESS boundary, not just a registry artifact: an
+                    // element-const view of mutable storage spliced inline hands the
+                    // optimizer const types it is licensed to trust (proven value
+                    // miscompile: linq's lazy group_by pipeline lost bucket elements),
+                    // and an already-typed block literal cannot re-match a re-typed
+                    // parameter (block argTypes compare strictly on re-infer). the
+                    // locked-name fallback heals RESOLUTION, not these; best-effort
+                    // sites decline, MUST keeps its pre-existing contract
                     if ( site.kind!=SiteKind::MustCall && A->type && P->type ) {
                         // gc_local: comparison-only temporaries, freed at scope exit
                         // instead of lingering on the gc root until the next sweep
@@ -1375,13 +1382,12 @@ namespace das {
                         break;
                     }
                     if ( byRefParam ) {
-                        // a substitution must not change the argument's CONST VIEW: body
-                        // subtrees may carry calls already resolved to ==const-flavored
-                        // instances (the `:=` clone family), and the splice re-infer
-                        // re-matches those against the instance's locked constness - a
-                        // non-const var replacing a const param read re-types them and
-                        // hard-fails (registry collapses the flavors). when the param is
-                        // more const than the leaf, bind a const reference instead
+                        // a substitution must not change the argument's CONST VIEW: the
+                        // body was typed against the param's constness, and a non-const
+                        // var replacing a const param read re-types body subtrees the
+                        // optimizer already trusts (the `:=` clone family being the
+                        // proven case). when the param is more const than the leaf,
+                        // bind a const reference instead
                         bool sameConstView = !P->type->constant || (leafA->type && leafA->type->constant);
                         if ( leafVar && sameConstView ) {
                             sub.substitute = leafA;             // same aliasing as the call itself

--- a/tests/dasPUGIXML/test_fold_must_inline_heal.das
+++ b/tests/dasPUGIXML/test_fold_must_inline_heal.das
@@ -1,0 +1,42 @@
+options gen2
+
+require pugixml/PUGIXML_boost
+require daslib/linq_fold
+require daslib/linq_boost public
+require daslib/strings_boost
+require dastest/testing_boost public
+
+// Regression for the locked-instance-name fallback: the fold macro locks the
+// predicate's contains() against the plain-string instance, then re-roots
+// `_.brand` onto peek_xml_field's `string const#` result. A MUST [inline]
+// splice clones the body (dropping the genericFunction short-circuit), the
+// locked name re-matches strictly, and pre-fix this was a hard error[30341]:
+//   __::strings_boost`contains`...(string const#, string const)
+// The fallback now re-resolves through the origin generic and binds the
+// `#`-flavored sibling.
+
+struct Car {
+    id    : int
+    brand : string
+}
+
+let XML = ("<cars>" +
+    "<car id=\"1\" brand=\"Ford\"/>" +
+    "<car id=\"2\" brand=\"Honda\"/>" +
+    "<car id=\"3\" brand=\"Fiat\"/>" +
+    "</cars>")
+
+[inline]
+def fold_contains_o(doc : pugixml::xml_document? const) : array<Car> {
+    return <- _fold(unsafe(from_xml_node(doc.document_element, type<Car>))._where(_.brand |> contains("o")).to_array())
+}
+
+[test]
+def test_must_inline_folded_temp_string_call_heals(t : T?) {
+    parse_xml(XML) $(doc; ok) {
+        t |> success(ok, "xml parses")
+        var cars <- fold_contains_o(doc)
+        t |> equal(2, length(cars))     // Ford and Honda contain 'o'; Fiat does not
+        delete cars
+    }
+}

--- a/tests/language/optimization_auto_inline.das
+++ b/tests/language/optimization_auto_inline.das
@@ -84,8 +84,8 @@ def iter_sum(var src : iterator<int>; blk : block<(v : int) : int>) : int {
 
 def iter_sum_cref(var src : iterator<int const&>; blk : block<(v : int) : int>) : int {
     // element-const iterator param: an each() argument is element-mutable - a legal
-    // call (variance), but the substitution would fork the body's instantiations,
-    // so the site declines
+    // call (variance), but the substitution would hand the optimizer a const view
+    // of mutable storage (a soundness boundary, not registry debt), so the site declines
     var total = 0
     var v : int
     while (next(src, v)) {

--- a/tests/type_traits/test_iterator_variance.das
+++ b/tests/type_traits/test_iterator_variance.das
@@ -18,7 +18,15 @@ def private sum_const_iter(var src : iterator<int const&>) : int {
 def private sum_const_generic(var src : iterator<auto(TT) const&>) : int {
     var total = 0
     for (it in src) {
-        total += int(it)
+        total += it
+    }
+    return total
+}
+
+def private sum_plain_generic(var src : iterator<auto(TT)>) : int {
+    var total = 0
+    for (it in src) {
+        total += it
     }
     return total
 }
@@ -55,5 +63,19 @@ def test_generic_const_param_accepts_both_flavors(t : T?) {
         let from_const = sum_const_generic([iterator for(x in 100..103); x])
         t |> equal(60, from_mut)
         t |> equal(303, from_const)
+    }
+}
+
+[test]
+def test_plain_generic_flavor_siblings_no_ice(t : T?) {
+    // A PLAIN-element generic mints one instance per element flavor (mut, then
+    // const). Pre-fix a THIRD mut-source call ICE'd with `error[50609]: multiple
+    // instances of ...` — the instance re-lookup matched both siblings through
+    // element variance with no exact-flavor tie-break. Order matters: mut first.
+    let arr <- [1, 2, 3]
+    unsafe {
+        t |> equal(6, sum_plain_generic(each(arr)))
+        t |> equal(33, sum_plain_generic([iterator for(x in 10..13); x]))
+        t |> equal(6, sum_plain_generic(each(arr)))
     }
 }

--- a/tests/typer_errors/failed_default_argument_mismatch.das
+++ b/tests/typer_errors/failed_default_argument_mismatch.das
@@ -4,9 +4,11 @@
 // DAS_ASSERTF assumed it never could ("how? it matched during findMatchingFunctions
 // the same way"). In release that fell through to a null makeType and crashed in
 // ExprMakeStruct::visit. The guard now returns cleanly, so the bad default surfaces
-// as ordinary compile errors instead of a crash.
+// as ordinary compile errors instead of a crash. (The former trailing 30341 was the
+// locked-instance-name dead end; the origin-generic fallback now re-resolves and the
+// broken default errors as 30511 instead.)
 options gen2
-expect 30161, 30254, 30341
+expect 30161, 30254, 30511, 30511
 
 tuple var0 {}
 


### PR DESCRIPTION
The instance-registry arc in one PR (root cause behind the #3396 flavor gates; supersedes #3397). Two resolver defects fixed, one daslib workaround retired — and one planned unwind deliberately **not** shipped, with the finding documented.

## Fix 1 — 50609 is a lookup ambiguity, not a mangling collapse

Instance re-lookup (`findMatchingFunctions` on the family name, ast_infer_type_function.cpp) matches through pointer/iterator element variance: a const-element instance accepts a mut-element call. Once both flavor-siblings of one generic exist in a module, a third call matches both → `error[50609] "multiple instances"` ICE. Both siblings register under distinct mangled names all along — the lookup just had no tie-break.

`applyLSP`'s substitute distance already separates them (strict inner compare + top-const tiebreaker), so the fix is one call: run `applyLSP` over the instance candidates. Repro pinned as `test_plain_generic_flavor_siblings_no_ice` (mut → const → mut on a plain `iterator<auto(TT)>` generic — ICE'd at the third call pre-fix).

## Fix 2 — locked instance names fall back to their origin generic

A resolved generic call gets its name locked to the instance family (``__::module`name`hash``). `ExprCall::clone` drops the `genericFunction` short-circuit, and the generic itself is unreachable under a locked name — so any cloned call whose args no longer strictly match (post-resolution drift from the linq fold macro re-rooting a predicate onto pugixml's `string const#` accessors; `==const` re-typing from substitution) was a hard 30341. Live on master: a MUST `[inline]` around a folded chain died with ``__::strings_boost`contains`…(string const#, string const)``.

On resolution failure, a locked name now falls back to its origin generic (`lockedNameGenericOrigin`) and re-resolves with first-resolution semantics — reusing a sibling or minting the right flavor. Pinned as `tests/dasPUGIXML/test_fold_must_inline_heal.das` (fails 30341 on master). One diagnostic shape shifted: `failed_default_argument_mismatch`'s trailing 30341 was the locked-name dead end; the broken default now errors as 2× 30511.

## What deliberately did NOT ship — the inliner gate unwind

The arc plan expected the #3396 flavor gates (arg-flavor strict, `reinferFragile`, `sameConstView`, `PrivateUseScan` explicit-flavor) to unwind once the registry healed. Probing the unwind produced a **value miscompile**: linq's lazy `group_by` pipeline lost bucket elements (`_count(_.N >= 3)` → 0, `to_array` → empty) — a const view of mutable storage spliced inline hands the optimizer types it is licensed to trust. The gates are an optimizer-soundness lattice, not registry debt; each one re-earned its keep against the probe. ast_inline.cpp changes are **comment-only**: the gate rationale now states the soundness boundary instead of the fixed registry story.

## Fix 3 — linq constify workaround retired

`all`/`contains` iterator overloads pinned `iterator<auto(TT) const>` purely to dodge the 50609 (their docstrings said so). With the tie-break in, they return to plain `iterator<auto(TT)>`.

## Validation

- interp full sweep 12153/12153; AOT full sweep zero 50101 (stubs purged + regenerated; new test needed a cmake reconfigure for the configure-time glob); JIT on linq (2007) / type_traits / dasPUGIXML (503); `--cov-path` coverage lane on tests/language 1273/1273; changed-set lint 0, all formatted
- landmark repros: 50609 case compiles + correct values; MUST/drift 30341 case compiles + correct values; the miscompile probe is correct with the gates intact
- inliner behavior intentionally unchanged (comment-only diff) — census/bench baselines from #3396 stand

🤖 Generated with [Claude Code](https://claude.com/claude-code)