### PR TITLE
array resize() sizes exactly past 256 bytes (+ dastest optimizer A/B flags)

### DIFF
--- a/dastest/dastest_clargs.das
+++ b/dastest/dastest_clargs.das
@@ -89,6 +89,18 @@ struct DastestArgs {
     @clarg_doc = "Set cop.keep_alive so _KeepAlive SimNode variants get dispatched"
     keep_alive : bool = false
 
+    @clarg_doc = "Compile every test with the CSE (common-subexpression-elimination) pass disabled (cop.disable_cse)"
+    disable_cse : bool = false
+
+    @clarg_doc = "Compile every test with the DSE (dead-store-elimination) pass disabled (cop.disable_dse)"
+    disable_dse : bool = false
+
+    @clarg_doc = "Compile every test with the [inline] function inliner disabled (cop.disable_inline)"
+    disable_inline : bool = false
+
+    @clarg_doc = "Compile every test with automatic block-inlining + invoke-of-literal devirt disabled (cop.disable_auto_inline)"
+    disable_auto_inline : bool = false
+
     @clarg_doc = "On a test panic, walk the call stack at throw time (real frames + line info, args via context settings) instead of the post-unwind walk that reports sp=0 with no frames. Sets the test context's alwaysStackWalkOnException. Off by default: a test that swallows a panic via try/recover would also emit a walk — enable for debugging a failing/crashing test"
     stack_on_exception : bool = false
 

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -580,7 +580,7 @@ def private run_queued_benchmarks(var suite_ctx : SuiteCtx; var file_ctx : FileC
 }
 
 [export]
-def private bench_on_start_impl(var suite_ctx : SuiteCtx; var benchmarking : B?; var file_ctx : FileCtx; func_type, name, sub_name : string) {
+def private bench_on_start_impl(suite_ctx : SuiteCtx; var benchmarking : B?; file_ctx : FileCtx; func_type, name, sub_name : string) {
     let is_first_bench = !benchmarking.started
     benchmarking.started = true
     benchmarking.current_sub_name = sub_name
@@ -606,7 +606,7 @@ def private bench_on_start_impl(var suite_ctx : SuiteCtx; var benchmarking : B?;
 }
 
 [export]
-def private bench_on_finished_impl(var suite_ctx : SuiteCtx; var benchmarking : B?; stats : BenchmarkRunStats) {
+def private bench_on_finished_impl(suite_ctx : SuiteCtx; var benchmarking : B?; stats : BenchmarkRunStats) {
     let n = stats.n
     let time_ns = stats.time_ns
     let allocs = stats.allocs

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -38,6 +38,10 @@ struct SuiteCtx {
     debugger : bool = false
     keep_alive : bool = false
     stackOnException : bool = false
+    disable_cse : bool = false
+    disable_dse : bool = false
+    disable_inline : bool = false
+    disable_auto_inline : bool = false
 
     // Testing-related options.
     testNames : array<string>
@@ -95,6 +99,10 @@ def SuiteCtx(args : DastestArgs) : SuiteCtx {
     ctx.keep_alive = args.keep_alive
     ctx.debugger = args.debugger
     ctx.stackOnException = args.stack_on_exception
+    ctx.disable_cse = args.disable_cse
+    ctx.disable_dse = args.disable_dse
+    ctx.disable_inline = args.disable_inline
+    ctx.disable_auto_inline = args.disable_auto_inline
     let bench_format = args.bench_format
     if (bench_format == "go") {
         ctx.bench_format = BenchmarkOutputFormat.go_export
@@ -170,6 +178,10 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
             cop.jit_enabled = jit_enabled()
             cop.debugger = ctx.debugger
             cop.keep_alive = ctx.keep_alive
+            cop.disable_cse = ctx.disable_cse
+            cop.disable_dse = ctx.disable_dse
+            cop.disable_inline = ctx.disable_inline
+            cop.disable_auto_inline = ctx.disable_auto_inline
             if (jit_enabled()) {
                 access |> add_extra_module("just_in_time", "{get_das_root()}/daslib/just_in_time.das")
             }

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -96,10 +96,19 @@ namespace das
             context.throw_error_at(at, "array_resize: newSize exceeds INT64_MAX [newSize=%llu]", (unsigned long long)newSize);
         }
         if ( newSize > arr.capacity ) {
-            uint64_t newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
-            newCapacity = das::max(newCapacity, uint64_t(16));
-            // The pow2 round-up overflows past INT64_MAX when newSize > 2^62; clamp so the
-            // resulting capacity stays representable in the int64 long_capacity() surface.
+            uint64_t newCapacity;
+            // Small arrays round the capacity up to the next power of two, leaving slack for
+            // cheap incremental growth. Past 256 bytes that pow2 slack wastes up to ~2x memory,
+            // so a large resize() sizes to the request exactly (this is resize-only; push keeps
+            // geometric growth via array_grow). The newSize<=256 guard keeps newSize*stride from
+            // overflowing uint64 in the byte-size test.
+            if ( newSize <= uint64_t(256) && newSize * uint64_t(stride) <= uint64_t(256) ) {
+                newCapacity = uint64_t(1) << (64 - das_clz64(das::max(newSize, uint64_t(2)) - 1));
+                newCapacity = das::max(newCapacity, uint64_t(16));
+            } else {
+                newCapacity = newSize;
+            }
+            // Keep the resulting capacity representable in the int64 long_capacity() surface.
             if ( newCapacity > uint64_t(INT64_MAX) ) newCapacity = uint64_t(INT64_MAX);
             array_reserve(context, arr, newCapacity, stride, at);
         }

--- a/tests/language/dynamic_array.das
+++ b/tests/language/dynamic_array.das
@@ -41,6 +41,21 @@ def test_dynamic_array(t : T?) {
         t |> equal(capacity(arr), 33)
         t |> equal(length(arr), 4)
     }
+    t |> run("resize rounds to pow2 only under 256 bytes") @(t : T?) {
+        // int stride is 4 bytes, so the 256-byte pow2 threshold is 64 elements.
+        var tiny : array<int>
+        resize(tiny, 63)                // 252 bytes -> rounds UP to next pow2 (exact sizing would give 63)
+        t |> equal(capacity(tiny), 64)
+        var small : array<int>
+        resize(small, 64)               // exactly 256 bytes -> still next pow2
+        t |> equal(capacity(small), 64)
+        var big : array<int>
+        resize(big, 65)                 // 260 bytes -> sized exactly, not 128
+        t |> equal(capacity(big), 65)
+        var huge : array<int>
+        resize(huge, 1000)              // sized exactly, not 1024
+        t |> equal(capacity(huge), 1000)
+    }
     t |> run("move semantics") @(t : T?) {
         var arr : array<int>
         push(arr, 1)


### PR DESCRIPTION
Two bundled changes.

## runtime: `array resize()` sizes exactly past 256 bytes

`array_resize` rounded the capacity up to the next power of two at **every** size, wasting up to ~2x memory on large arrays (e.g. `resize(arr, 1025)` for `int` → capacity 2048).

Now the pow2 round-up is kept only while the array is **≤ 256 bytes** (cheap slack for incremental growth); beyond that the capacity is sized to the request exactly.

- **Threshold is 256 *bytes*** (`newSize * stride`), not element count — a 65-element `int` array (260 B) sizes exactly (cap 65); a 64-element one (256 B) still rounds to pow2 (cap 64). A `newSize <= 256` guard keeps the byte-size multiply from overflowing `uint64`.
- **resize-only.** `push`/`insert` grow geometrically via `array_grow` (`aot_builtin.h`), which is **unchanged**, so building an array by repeated `push` stays amortized O(1).
- Single source of truth: interpreter, JIT (`get_jit_array_resize` → `builtin_array_resize`), and AOT all route through this one C++ function.
- New `tests/language/dynamic_array.das` sub-test asserts the boundary: `resize→64` = cap 64 (pow2), `resize→65` = cap 65 (exact, not 128), `resize→1000` = cap 1000 (not 1024).

## dastest: `--disable-{cse,dse,inline,auto-inline}` optimizer A/B flags

Four `CodeOfPolicies` toggles wired to the cop used for every test compile, so `dastest --compile-only --test tests` can A/B one optimizer pass's compile-time cost by disabling it globally.

## dastest: LINT014 cleanup

`suite_ctx`/`file_ctx` in the benchmark `on_start`/`on_finished` hooks are read-only — drop the redundant `var`. The hooks are invoked by name via `invoke_in_context`, so const-adding the params doesn't affect the lookup.

## Validation

Lint clean (all changed `.das`), format clean, full interpreter suite **12167 pass / 0 fail**, JIT green, AOT `tests/language` **1286 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)