### PR TITLE
Revert "fix ThinLTO SROA miscompile in das_index<Matrix>::at in aot.h"

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -856,19 +856,10 @@ namespace das {
         using MatT = Matrix<VecT,size>;
         static __forceinline VecT & at ( MatT & value, int32_t index, Context * __context__ ) {
             if ( index<0 || uint32_t(index)>=uint32_t(size) ) __context__->throw_error_ex("matrix index out of range, %d of %d", index, size);
-#if defined(__clang__) && defined(DAS_STRICT_ALIASING)
-            // Compiler barrier: prevents ThinLTO SROA from substituting a stale virtual-register
-            // value for value.m[idx] after a write through an aliased pointer of a different type
-            // (e.g. TMatrix & aliasing float3x4). No machine instruction is emitted.
-            std::atomic_signal_fence(std::memory_order_seq_cst);
-#endif
             return value.m[index];
         }
         static __forceinline VecT & at ( MatT & value, uint32_t idx, Context * __context__ ) {
             if ( idx>=uint32_t(size) ) __context__->throw_error_ex("matrix index out of range, %u of %d", idx, size);
-#if defined(__clang__) && defined(DAS_STRICT_ALIASING)
-            std::atomic_signal_fence(std::memory_order_seq_cst);
-#endif
             return value.m[idx];
         }
     };


### PR DESCRIPTION
The miscompile it worked around (stale matrix element reads under
clang ThinLTO) was traced to UB in host-project bindings: a 16-byte
vector load from a 12-byte struct and type-punned writes through an
unrelated type. Both are fixed at the source, so the barrier is no longer
needed.

This reverts commit 3f7989d471ea139c47ecdde3324a0575d1088370.