### PR TITLE
aot: fix batch-composition AOT hash sensitivity (g_isInAot leak) + make aot_cpp AOT-linkable (#3329)

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1186,17 +1186,17 @@ class public BlockVariableCollector : AstVisitor {
         }
         return blk;
     }
-    def getFinalBlock() {
+    def getFinalBlock() : ExprBlock? {
         for (i in range(length(stack))) {
-            let blk = stack[length(stack) - i - 1];
+            var blk = stack[length(stack) - i - 1];
             if (!empty(blk.finalList)) return blk;
             if (blk.blockFlags.isClosure) return null;
         }
         return null;
     }
-    def getTopBlock() {
+    def getTopBlock() : ExprBlock? {
         for (i in range(length(stack))) {
-            let blk = stack[length(stack) - i - 1];
+            var blk = stack[length(stack) - i - 1];
             if (blk.blockFlags.isClosure) return blk;
         }
         return stack[0];

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -4302,6 +4302,7 @@ def public getRequiredModulesFor(program : ProgramPtr) {
 
 def public compile_and_simulate(input : string, var access; var mg : ModuleGroup?, cop, blk) {
     //! Compiles a daslang file, simulates it, and invokes a callback with the program and context.
+    let wasInAot = is_in_aot()
     set_aot();
     compile_file(input, access, mg, cop) $(ok; var program : smart_ptr<Program>; issues) {
         if (!ok) {
@@ -4316,6 +4317,7 @@ def public compile_and_simulate(input : string, var access; var mg : ModuleGroup
             blk(program, pctx)
         }
     }
+    if (!wasInAot) reset_aot()
 }
 
 

--- a/include/daScript/simulate/aot_builtin_ast.h
+++ b/include/daScript/simulate/aot_builtin_ast.h
@@ -447,6 +447,7 @@ namespace das {
     DAS_CC_API Module * thisModule ( Context * context, LineInfoArg * lineinfo );
     DAS_CC_API smart_ptr_raw<Program> thisProgram ( Context * context );
     DAS_CC_API void astVisit ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
+    DAS_CC_API void astVisitWithSort ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, bool sortStructures, Context * context, LineInfoArg * line_info );
     DAS_CC_API void astVisitGenerics ( smart_ptr_raw<Program> program, VisitorAdapter * adapter, Context * context, LineInfoArg * line_info );
     DAS_CC_API void astVisitModule ( smart_ptr_raw<Program> program, VisitorAdapter * adapter,
                       Module* module, Context * context, LineInfoArg * line_info );
@@ -523,6 +524,7 @@ namespace das {
     DAS_CC_API void getAstContext ( smart_ptr_raw<Program> prog, Expression * expr, const TBlock<void,bool,AstContext> & block, Context * context, LineInfoArg * at );
     DAS_CC_API char * get_mangled_name ( Function * func, Context * context, LineInfoArg * at );
     DAS_CC_API char * get_mangled_name_t ( TypeDecl * typ, Context * context, LineInfoArg * at );
+    DAS_CC_API char * get_aot_hash_comment_fn ( const Function * func, Context * context, LineInfoArg * at );
     DAS_CC_API char * get_mangled_name_v ( Variable * var, Context * context, LineInfoArg * at );
     DAS_CC_API char * get_mangled_name_b ( ExprBlock * expr, Context * context, LineInfoArg * at );
     DAS_CC_API TypeDeclPtr parseMangledNameFn ( const char * txt, ModuleGroup & lib, Module * thisModule, Context * context, LineInfoArg * at );

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -13,22 +13,13 @@ DAS_AOT_LIB("${AOT_TESTING_FILES}" TESTING_AOT_GENERATED_SRC test_aot_testing da
 # AOT all daslib .das files — catches codegen regressions for any module,
 # not just those used in tests/. Files marked `options no_aot` are silently skipped.
 FILE(GLOB AOT_DASLIB_MODULE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "daslib/*.das")
-# Exclude modules that misbehave under batched AOT:
-#   aot_macro                  — [simulate_macro] fires, expects policies.aot_result
-#   debugger                   — required by others; error surfaces here
-#   profiler, ast_debug        — [_macro] installs thread-local debug agent at compile,
-#                                second module install panics on the first
-#   profiler_boost             — transitively requires profiler; installing the debug
-#                                agent in a batch perturbs SIM trees of subsequent
-#                                files, changing own-hashes so stubs don't match
-#                                runtime → error[50101] AOT link failed
-#   decs_state                 — [init, export] forks debug agent context during init
-#   aot_cpp, aot_standalone    — AST-codegen modules: rely on C++ bindings
-#                                (get_aot_hash_comment, visit_with_sort, aotFieldName,
-#                                 annotation_arguments, ExprBlock) lacking AOT header decls
-#   network                    — daslang class `Server` shadows C++ `das::Server`,
-#                                codegen resolves NetworkServer? to the daslang class
-list(FILTER AOT_DASLIB_MODULE_FILES EXCLUDE REGEX "daslib/(aot_macro|debugger|profiler|profiler_boost|ast_debug|decs_state|aot_standalone|network)\\.das$")
+# Exclude modules that genuinely break batched AOT:
+#   aot_macro      — [simulate_macro] fails to simulate during AOT generation
+#   profiler       — emits AOT C++ hitting an ambiguous __bit_set overload (aot.h)
+#   profiler_boost — its [_macro] forks profiler's thread-local instrumenting agent, which
+#                    perturbs later batch files' hashes → error[50101]
+#   network        — daslang class `Server` shadows C++ `das::Server` (server_init undeclared)
+list(FILTER AOT_DASLIB_MODULE_FILES EXCLUDE REGEX "daslib/(aot_macro|profiler|profiler_boost|network)\\.das$")
 # just_in_time bootstraps the LLVM-backed JIT module via [extern](library=LLVM.dll).
 # Without DAS_LLVM_DISABLED=OFF, the [extern] macro fails at compile time.
 IF(DAS_LLVM_DISABLED)

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -28,7 +28,7 @@ FILE(GLOB AOT_DASLIB_MODULE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPEN
 #                                 annotation_arguments, ExprBlock) lacking AOT header decls
 #   network                    — daslang class `Server` shadows C++ `das::Server`,
 #                                codegen resolves NetworkServer? to the daslang class
-list(FILTER AOT_DASLIB_MODULE_FILES EXCLUDE REGEX "daslib/(aot_macro|debugger|profiler|profiler_boost|ast_debug|decs_state|aot_cpp|aot_standalone|network)\\.das$")
+list(FILTER AOT_DASLIB_MODULE_FILES EXCLUDE REGEX "daslib/(aot_macro|debugger|profiler|profiler_boost|ast_debug|decs_state|aot_standalone|network)\\.das$")
 # just_in_time bootstraps the LLVM-backed JIT module via [extern](library=LLVM.dll).
 # Without DAS_LLVM_DISABLED=OFF, the [extern] macro fails at compile time.
 IF(DAS_LLVM_DISABLED)

--- a/tests/aot/_template_member_fixture.das
+++ b/tests/aot/_template_member_fixture.das
@@ -1,0 +1,11 @@
+options gen2
+
+struct template Box {
+    def method() {
+    }
+    def withDefault(other : Box = Box(); n : int) {
+    }
+}
+
+def main {
+}

--- a/tests/aot/test_template_member_emit.das
+++ b/tests/aot/test_template_member_emit.das
@@ -1,0 +1,20 @@
+options gen2
+options no_aot
+
+require daslib/aot_cpp
+require daslib/ast
+require strings
+require dastest/testing_boost public
+
+[test]
+def test_template_member_emit(t : T?) {
+    var cpp = ""
+    using() $(var cop : CodeOfPolicies) {
+        cop.aot_macros = true
+        cop.aot_module = true
+        cpp = aot("{get_das_root()}/tests/aot/_template_member_fixture.das", false, false, cop)
+    }
+    t |> success(!empty(cpp), "emitter produced output")
+    t |> success(find(cpp, "DAS_COMMENT(auto)") < 0, "no unresolved auto type in output")
+    t |> success(find(cpp, "DAS_COMMENT(alias)") < 0, "no unresolved alias type in output")
+}


### PR DESCRIPTION
Fixes #3329.

The issue reports that AOT stub hashes are sensitive to `-aotlib` batch composition: a test requiring `daslib/aot_cpp` needs `aot_cpp` AOT-linkable, but adding `aot_cpp` to the batch made an unrelated module (`test_bitfields`) fail to AOT-link (`error[50101]`). The two blockers turned out to be independent; both are fixed here.

## Commit 1 — make `aot_cpp` AOT-linkable

`aot_cpp`'s generated C++ didn't compile:
- `get_aot_hash_comment` / `visit_with_sort` had no AOT header declaration → added to `aot_builtin_ast.h`.
- `BlockVariableCollector`'s `getFinalBlock()` / `getTopBlock()` inferred a `void?` return (mixed `return blk` / `return null`); the interpreter accepts a `void?` table key but AOT emits a `void*` key that won't match `table<ExprBlock?;…>::operator()`. Given an explicit `: ExprBlock?` return (`var blk` keeps the pointer non-const).

Then `aot_cpp` is un-excluded from the daslib AOT batch.

## Commit 2 — reset `g_isInAot`, with the test that reveals the bug

Root cause of the batch/process-composition hash sensitivity: `compile_and_simulate` set the process-global `g_isInAot = true` but **never restored it**. A runtime `aot()` call left the whole process stuck in AOT mode, so every later compile used AOT export-all usage marking and kept otherwise-dead functions (`bitfield_trait`'s macro finalizers) `used` — which then need AOT stubs a standalone-generated stub never emitted → `error[50101]` on an unrelated module. It only surfaces once `aot_cpp` is actually linkable (bitfield passes standalone; fails only after a prior `aot()` pollutes the flag).

This commit adds the `#3269` regression test (`tests/aot/test_template_member_emit.das` + fixture), which drives the emitter via a runtime `aot()` and thus reveals the leak, and fixes it: save `is_in_aot()` on entry, `reset_aot()` on exit — scoping the flag to the compile that set it. This is exactly the "process-global state leaking between sequential compiles" the issue hypothesized.

## Commit 3 — Uncomment passing aot files
Few aot files/folders were marked in CMake as no aot without reason (or this reason was fixed).
## Verification

- Exact issue repro (`test_template_member_emit` + `test_bitfields`): passes under `-use-aot`.
- Full `tests/` AOT suite under `-use-aot`: **10475 tests, 10469 passed, 0 failed, 0 errors, 6 skipped** (was 1 error without the fix).
- `daslib/aot_cpp.das` lints clean.

No new C++ code — `reset_aot` was already bound; only two AOT forward-decls were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
