### PR TITLE
module_path: standalone -exe config/log resolution fix + dictation-bot startup hardening

### DIFF
--- a/daslib/module_path.das
+++ b/daslib/module_path.das
@@ -30,9 +30,16 @@ module module_path shared public
 //! ``<rel>`` is the substring of the call-site directory starting at
 //! the last ``/modules/`` segment (e.g. ``modules/dasCards/cards``).
 //! Tiers 1+2 are skipped when the call site has no ``/modules/`` segment
-//! (project-local code outside the package layout); tier 3 then returns
-//! the baked dir if it still exists on disk (dev) or ``<exe_dir>`` if it
-//! doesn't (relocated bundle). The result is never empty.
+//! (project-local code outside the package layout).
+//!
+//! A **standalone exe** (``is_standalone_exe()``, folded true only in a
+//! ``daspkg release`` ``-exe``) never resolves to tier 3's baked dev
+//! path: the compile-machine source dir is meaningless on a target box,
+//! and on the *author's own* machine it still exists — so the baked dir
+//! would shadow the assets shipped next to the exe. When standalone,
+//! tier 3 falls back to ``<exe_dir>``. Project-local code also falls
+//! back to ``<exe_dir>`` when the baked dir has gone missing (relocated
+//! bundle), even interpreted. The result is never empty.
 //!
 //! Usage::
 //!
@@ -64,6 +71,8 @@ class private GetThisModuleDirMacro : AstCallMacro {
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
         macro_verify(empty(call.arguments), prog, call.at, "expecting get_this_module_dir()")
         let baked = string(call.at.fileInfo.name)
-        return qmacro(__builtin_resolve_this_module_dir($v(baked)))
+        // is_standalone_exe() folds to a compile-time constant in a -exe build,
+        // so the resolver can refuse the baked dev path in a released bundle.
+        return qmacro(__builtin_resolve_this_module_dir($v(baked), is_standalone_exe()))
     }
 }

--- a/examples/telegram/dictation/main.das
+++ b/examples/telegram/dictation/main.das
@@ -156,6 +156,16 @@ def private parse_log_level(s : string) : int {
     return LOG_INFO
 }
 
+// Report a fatal startup error to BOTH the console and the log file, then the caller returns
+// false so main() exits non-zero. A bare panic() in a standalone -exe aborts the process
+// silently (panic in a jitted frame), turning a bad model path into a mysterious exit with no
+// message — so startup failures are reported explicitly here. Call after logger_set_path().
+def private fatal(msg : string) {
+    to_log(LOG_ERROR, "dictation: {msg}\n")   // console (stdout, level-tagged)
+    logger_error("dictation", msg)            // log file
+    logger_flush()
+}
+
 // ===== audio helpers =====
 
 def private tmpdir() : string {
@@ -396,34 +406,63 @@ def init(var out_rc : int&) : bool {
 
     var cerr = ""
     g_cfg = load_config(resolve_config_path(args.config), cerr)
-    if (!empty(cerr)) {
-        to_log(LOG_ERROR, "dictation: {cerr}\n")
-        out_rc = 1
-        return false
-    }
-    if (empty(g_cfg.bot_token)) {
-        to_log(LOG_ERROR, "dictation: no bot token — set TELEGRAM_BOT_TOKEN or bot_token in the config\n")
-        out_rc = 1
-        return false
-    }
-    if (empty(g_cfg.whisper_model) || empty(g_cfg.llm_model)) {
-        to_log(LOG_ERROR, "dictation: whisper_model and llm_model must be set in the config\n")
-        out_rc = 1
-        return false
-    }
 
-    // proper logging: operational events go to a leveled, categorized log file (dictation / dictation.msg);
-    // fatal startup errors above stay on the console. Engine (dasLLAMA/JIT) noise stays on stdout.
+    // Set up logging FIRST so every fatal startup error below is written to the log file as
+    // well as the console — not silently dropped. On a config failure g_cfg is defaulted, so
+    // this still resolves to <exe_dir>/dictation.log. Engine (dasLLAMA/JIT) noise stays on stdout.
     let logpath = empty(g_cfg.log_file) ? path_join(get_this_module_dir(), "dictation.log") : g_cfg.log_file
     logger_set_path(logpath)
     logger_set_min_level(parse_log_level(g_cfg.log_level))
     print("dictation: logging to {logpath}\n")
 
+    if (!empty(cerr)) {
+        fatal(cerr)
+        out_rc = 1
+        return false
+    }
+    if (empty(g_cfg.bot_token)) {
+        fatal("no bot token — set TELEGRAM_BOT_TOKEN or bot_token in the config")
+        out_rc = 1
+        return false
+    }
+    if (empty(g_cfg.whisper_model) || empty(g_cfg.llm_model)) {
+        fatal("whisper_model and llm_model must be set in the config")
+        out_rc = 1
+        return false
+    }
+    // The model files must exist before we load them: in a standalone -exe the loader's
+    // panic() on a missing file aborts the process SILENTLY (panic in a jitted frame), so
+    // check here and report a clear, logged error instead of a mysterious exit code 127.
+    if (!fexist(g_cfg.whisper_model)) {
+        fatal("whisper model file not found: {g_cfg.whisper_model}")
+        out_rc = 1
+        return false
+    }
+    if (!fexist(g_cfg.llm_model)) {
+        fatal("LLM model file not found: {g_cfg.llm_model}")
+        out_rc = 1
+        return false
+    }
+
     log_tune_status("dictation")
     set_jobque_threads_cap(g_cfg.threads)   // cap dasLLAMA to cfg.threads workers (DAS_JOBQUE_THREADS still overrides)
 
-    g_asr <- load_asr_model(g_cfg.whisper_model)
-    g_llm <- load_model(g_cfg.llm_model, QuantMode.q8)
+    // The files exist, but a corrupt or unsupported model still panics deep in the loader.
+    // Recover it so startup fails with a logged message rather than a silent abort. NOTE: a
+    // bare `return` from inside a recover block does not propagate in a jitted -exe (execution
+    // falls through) — so set a flag here and return AFTER the try/recover, in normal flow.
+    var load_failed = false
+    try {
+        g_asr <- load_asr_model(g_cfg.whisper_model)
+        g_llm <- load_model(g_cfg.llm_model, QuantMode.q8)
+    } recover {
+        fatal("failed to load models — check whisper_model / llm_model are valid model files: whisper='{g_cfg.whisper_model}' llm='{g_cfg.llm_model}'")
+        load_failed = true
+    }
+    if (load_failed) {
+        out_rc = 1
+        return false
+    }
     telegram_set_configuration(configuration(token = g_cfg.bot_token))
     logger_info("dictation", "bot started (whisper={g_cfg.whisper_model}, llm={g_cfg.llm_model}, threads={g_cfg.threads})")
     logger_flush()

--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -102,7 +102,7 @@ namespace das {
     DAS_API int builtin_popen_argv ( const Array & args_arr, float timeout_sec, const TBlock<void,const FILE *> & blk, Context * context, LineInfoArg * at );
     DAS_API int builtin_popen_argv_pipe ( const Array & args_arr, const TBlock<void,const FILE *,const FILE *> & blk, Context * context, LineInfoArg * at );
     DAS_API char * get_full_file_name ( const char * path, Context * context, LineInfoArg * );
-    DAS_API char * builtin_resolve_this_module_dir ( const char * baked_path, Context * context );
+    DAS_API char * builtin_resolve_this_module_dir ( const char * baked_path, bool standalone, Context * context );
     DAS_API bool builtin_remove_file ( const char * path );
     DAS_API bool builtin_rename_file ( const char * old_path, const char * new_path );
     DAS_API bool builtin_rmdir ( const char * path );

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -241,7 +241,7 @@ namespace das {
     bool builtin_chdir ( const char * ) GENERATE_IO_STUB_RET
     bool builtin_mkdir ( const char * ) GENERATE_IO_STUB_RET
     void builtin_exit ( int32_t ) GENERATE_IO_STUB
-    char * builtin_resolve_this_module_dir ( const char *, Context * ) GENERATE_IO_STUB_RET
+    char * builtin_resolve_this_module_dir ( const char *, bool, Context * ) GENERATE_IO_STUB_RET
     bool builtin_remove_file ( const char * ) GENERATE_IO_STUB_RET
     bool builtin_rename_file ( const char *, const char * ) GENERATE_IO_STUB_RET
     bool builtin_rmdir ( const char * ) GENERATE_IO_STUB_RET
@@ -1757,10 +1757,17 @@ namespace das {
     //   3. dir_name(baked_path)       — dev (interpreted from source tree)
     // <rel> is the substring of dir_name(baked) starting at the last
     // "/modules/" segment.  Tiers 1+2 are skipped when baked has no /modules/
-    // segment (e.g. project-local code outside the package layout); when the
-    // baked dir has also gone missing on the target machine (relocated bundle),
-    // tier 3's fallback is <exe_dir> rather than the dead dev path.
-    char * builtin_resolve_this_module_dir ( const char * baked_path, Context * context ) {
+    // segment (e.g. project-local code outside the package layout).
+    //
+    // `standalone` is is_standalone_exe() folded at the call site (true only in
+    // a daspkg-release -exe). A standalone exe must NEVER resolve to the baked
+    // dev source tree: the compile-machine path is meaningless on a target box,
+    // and on the AUTHOR's own machine it still exists — so tier 3 would wrongly
+    // prefer it over the assets shipped next to the exe (the dictation-bot
+    // release-config bug). When standalone, the tier-3 fallback is <exe_dir>.
+    // For project-local code that fallback also fires when the baked dir has
+    // gone missing on the target machine (relocated bundle), even interpreted.
+    char * builtin_resolve_this_module_dir ( const char * baked_path, bool standalone, Context * context ) {
         namespace fs = std::filesystem;
         if ( !baked_path || !*baked_path ) return context->allocateString("", nullptr);
         // generic_string() (here and at every other path-to-string conversion
@@ -1785,38 +1792,40 @@ namespace das {
         if ( pos != std::string::npos ) {
             rel = canon.substr(pos + 1);  // drop leading '/' to keep it relative
         }
-        // Tier 1 — exe_dir
-        if ( !rel.empty() ) {
+        // <exe_dir> — computed once, reused by the tier-1 probe and the fallback.
+        fs::path exeDir;
+        {
             das::string exeFile = das::getExecutableFileName();
             if ( !exeFile.empty() ) {
-                fs::path exeDir = fs::path(exeFile.c_str()).parent_path();
+                exeDir = fs::path(exeFile.c_str()).parent_path();
                 if ( exeDir.empty() ) exeDir = ".";
+            }
+        }
+        if ( !rel.empty() ) {
+            // Tier 1 — <exe_dir>/<rel>
+            if ( !exeDir.empty() ) {
                 fs::path candidate = exeDir / rel;
                 std::error_code ec;
                 if ( fs::is_directory(candidate, ec) ) {
                     return context->allocateString(candidate.generic_string().c_str(), nullptr);
                 }
             }
-            // Tier 2 — das_root
+            // Tier 2 — <das_root>/<rel>
             fs::path candidate = fs::path(das::getDasRoot().c_str()) / rel;
             std::error_code ec;
             if ( fs::is_directory(candidate, ec) ) {
                 return context->allocateString(candidate.generic_string().c_str(), nullptr);
             }
         }
-        // Tier 3 — baked dir as fallback. Special case: project-local code
-        // (rel empty so tiers 1+2 were skipped) running from a relocated
-        // bundle where the dev-time baked dir no longer exists — fall back
-        // to <exe_dir> so assets shipped next to the exe are findable.
-        if ( rel.empty() ) {
+        // Tier 3 — fallback. Prefer <exe_dir> over the baked dev dir when this
+        // is a standalone exe (never trust the compile-machine source path), or
+        // when project-local code's baked dir has gone missing (relocated
+        // bundle). Otherwise (dev, running from source) the baked dir is right.
+        if ( !exeDir.empty() ) {
             std::error_code ec;
-            if ( !fs::is_directory(baked_dir, ec) ) {
-                das::string exeFile = das::getExecutableFileName();
-                if ( !exeFile.empty() ) {
-                    fs::path exeDir = fs::path(exeFile.c_str()).parent_path();
-                    if ( exeDir.empty() ) exeDir = ".";
-                    return context->allocateString(exeDir.generic_string().c_str(), nullptr);
-                }
+            bool baked_dir_exists = fs::is_directory(baked_dir, ec);
+            if ( standalone || ( rel.empty() && !baked_dir_exists ) ) {
+                return context->allocateString(exeDir.generic_string().c_str(), nullptr);
             }
         }
         return context->allocateString(baked_dir_str.c_str(), nullptr);
@@ -2011,7 +2020,7 @@ namespace das {
                     ->args({"path","context","at"});
             addExtern<DAS_BIND_FUN(builtin_resolve_this_module_dir)>(*this, lib, "__builtin_resolve_this_module_dir",
                 SideEffects::accessExternal, "builtin_resolve_this_module_dir")
-                    ->args({"baked_path","context"});
+                    ->args({"baked_path","standalone","context"});
             addExtern<DAS_BIND_FUN(get_env_variable)>(*this, lib, "get_env_variable",
                 SideEffects::accessExternal, "get_env_variable")
                     ->args({"var","context","at"});

--- a/tests/fio/get_this_module_dir_resolver.das
+++ b/tests/fio/get_this_module_dir_resolver.das
@@ -4,24 +4,42 @@ require dastest/testing_boost public
 require daslib/fio
 require daslib/module_path
 
+// The resolver's second argument is is_standalone_exe(), folded at the call
+// site in a real build. These tests call the builtin directly with an explicit
+// flag so they are deterministic under any execution tier.
+
 [test]
 def test_real_project_local_path_returns_baked_dir(t : T?) {
-    t |> run("real project-local path returns its dir_name") @(t : T?) {
+    t |> run("dev (not standalone): real project-local path returns its dir_name") @(t : T?) {
         // This test file is project-local (sits in tests/fio/, no /modules/ segment).
         let real_baked = "{get_das_root()}/tests/fio/get_this_module_dir_resolver.das"
-        let dir = __builtin_resolve_this_module_dir(real_baked)
+        let dir = __builtin_resolve_this_module_dir(real_baked, false)
         t |> equal(dir, "{get_das_root()}/tests/fio")
     }
 }
 
 [test]
+def test_standalone_project_local_prefers_exe_dir(t : T?) {
+    t |> run("standalone: project-local path prefers exe dir over the (existing) baked dir") @(t : T?) {
+        // The dictation-bot release-config bug: on the author's own machine the
+        // dev source dir still exists, so a standalone exe must NOT read from it —
+        // it must resolve next to the exe, where the release ships its config.
+        let real_baked = "{get_das_root()}/tests/fio/get_this_module_dir_resolver.das"
+        let dir = __builtin_resolve_this_module_dir(real_baked, true)
+        t |> success(dir != "{get_das_root()}/tests/fio",
+            "standalone must not return the baked source dir, got '{dir}'")
+        t |> success(fexist(dir), "exe dir '{dir}' must exist on disk")
+    }
+}
+
+[test]
 def test_nonexistent_project_local_falls_back_to_exe_dir(t : T?) {
-    t |> run("nonexistent project-local baked path falls back to an existing dir") @(t : T?) {
+    t |> run("dev (not standalone): nonexistent project-local baked path falls back to an existing dir") @(t : T?) {
         // No /modules/ segment AND dir doesn't exist on disk → should fall
         // back to <exe_dir> rather than returning the dead path. Models the
         // relocated-bundle scenario where main.das's dev-time dir is gone.
         let dead = "/__no_such_dir_42__/__no_such_subdir__/main.das"
-        let dir = __builtin_resolve_this_module_dir(dead)
+        let dir = __builtin_resolve_this_module_dir(dead, false)
         t |> success(dir != "/__no_such_dir_42__/__no_such_subdir__",
             "must not return the dead baked dir, got '{dir}'")
         t |> success(fexist(dir), "fallback dir '{dir}' must exist on disk")
@@ -30,19 +48,33 @@ def test_nonexistent_project_local_falls_back_to_exe_dir(t : T?) {
 
 [test]
 def test_nonexistent_modules_path_keeps_baked(t : T?) {
-    t |> run("nonexistent /modules/ baked path returns baked dir unchanged") @(t : T?) {
-        // When rel is non-empty the new fallback does NOT fire — preserves
-        // existing tier-3 behavior for module paths so we don't accidentally
-        // mask a missing module with the exe dir.
+    t |> run("dev (not standalone): nonexistent /modules/ baked path returns baked dir unchanged") @(t : T?) {
+        // When rel is non-empty and not standalone the fallback does NOT fire —
+        // preserves existing tier-3 behavior for module paths so we don't
+        // accidentally mask a missing module with the exe dir.
         let dead = "/__no_such_root__/modules/__no_such_module__/foo.das"
-        let dir = __builtin_resolve_this_module_dir(dead)
+        let dir = __builtin_resolve_this_module_dir(dead, false)
         t |> equal(dir, "/__no_such_root__/modules/__no_such_module__")
+    }
+}
+
+[test]
+def test_standalone_modules_path_prefers_exe_dir(t : T?) {
+    t |> run("standalone: nonexistent /modules/ baked path still refuses the dev dir") @(t : T?) {
+        // rel non-empty, but neither <exe_dir>/<rel> nor <das_root>/<rel> exists;
+        // a standalone exe must fall back to <exe_dir>, never the baked dev path.
+        let dead = "/__no_such_root__/modules/__no_such_module__/foo.das"
+        let dir = __builtin_resolve_this_module_dir(dead, true)
+        t |> success(dir != "/__no_such_root__/modules/__no_such_module__",
+            "standalone must not return the dead baked dir, got '{dir}'")
+        t |> success(fexist(dir), "fallback dir '{dir}' must exist on disk")
     }
 }
 
 [test]
 def test_empty_baked_returns_empty(t : T?) {
     t |> run("empty input returns empty") @(t : T?) {
-        t |> equal(__builtin_resolve_this_module_dir(""), "")
+        t |> equal(__builtin_resolve_this_module_dir("", false), "")
+        t |> equal(__builtin_resolve_this_module_dir("", true), "")
     }
 }


### PR DESCRIPTION
Two fixes, prompted by the released `dictation-bot` standalone `-exe` failing to start (it read config from the wrong place, then silently quit on a stale model path).

## 1. `get_this_module_dir()` — a standalone `-exe` must never resolve to the dev source tree

**Root cause of "reads config from the wrong place":** the resolver's tier-3 fallback returned the **baked compile-time source directory** whenever it still exists on disk. For project-local code (a call site with no `/modules/` segment, e.g. `examples/telegram/dictation`), a `daspkg release` `-exe` therefore read its config/assets — and wrote its log — from the **original source tree** on the author's own machine, instead of from next to the exe. The same `get_this_module_dir()` drives both the config path and the log path, so both were affected. (It "worked when first shipped" only because the source `dictation.toml` still had real paths during testing; once the committed template was emptied, the standalone read that empty file.)

**Fix:** thread `is_standalone_exe()` (folded to a compile-time constant in a `-exe`) into `__builtin_resolve_this_module_dir`. A standalone exe now falls back to `<exe_dir>` — via the robust `getExecutableFileName()` the resolver already computes — never the baked dev path. Dev/interpreted and SDK/cmake-install behavior is unchanged (`is_standalone_exe() == false` there). This fixes **every** project-local (`examples/`, non-`modules/`) redistributable, not just this bot.

- `src/builtin/module_builtin_fio.cpp` — new `standalone` param + refactored tiers
- `include/daScript/simulate/aot_builtin_fio.h` — AOT stub signature
- `daslib/module_path.das` — macro emits the 2-arg resolver call + updated docs
- `tests/fio/get_this_module_dir_resolver.das` — `standalone=true` cases (incl. "prefers exe dir over an *existing* baked dir")

## 2. dictation-bot: fail startup loudly, never silently quit

A `panic()` in a jitted `-exe` frame aborts the process with **no message**, so a bad model path (the loader panics on a missing file) produced a mysterious exit-with-no-output (Windows exit code 127). Hardened `init()`:

- `fatal(msg)` helper writes to **both** the console (`to_log(LOG_ERROR)`) and the log file (`logger_error` + flush), then the caller returns non-zero
- logging is set up **first**, so every fatal startup error lands in the log file too
- `fexist()` pre-checks on the whisper/LLM model files before loading — the common missing/stale-path case gets a precise message and never reaches the panic
- `try/recover` around the loads for corrupt/unsupported files. **Gotcha found:** a bare `return` from inside a `recover` block does **not** propagate in a jitted `-exe` (execution falls through), so a flag is set and the return happens after the block; a plain `return` (not `exit()`) unwinds cleanly with no `atexit` env-imbalance noise.

## Testing

- Resolver unit test: **12/12** (interpreter), including the standalone-prefers-exe-dir cases
- A minimal standalone probe `-exe` (project-local source that still exists on disk): resolves next to the exe, reads the exe-dir file, not the source's
- Rebuilt `dictation-bot` release `-exe`: reads config **and** writes its log next to the exe; **missing-file / corrupt-file / happy-path** all verified — a clean logged `exit(1)` on failure, normal start otherwise
- Lint + format clean on the three changed `.das` files

Validated on Windows MSVC (LLVM-disabled) locally; the C++ change reuses the existing resolver's portable `std::filesystem` patterns. The `exe-paths` integration test covers dynamic-module resolution (a different mechanism) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)