### PR TITLE
gltf: add load_gltf_from_memory (parse glTF from in-memory bytes)

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -1726,7 +1726,7 @@ def document_module_gltf(_root : string) {
     var mod = [find_module("gltf_types"), find_module("gltf_accessor"),
         find_module("gltf_parse"), find_module("gltf_scene")]
     var groups <- array<DocGroup>(
-        group_by_regex("Loading", mod, %regex~.*(load_gltf)$%%),
+        group_by_regex("Loading", mod, %regex~.*(load_gltf|load_gltf_from_memory)$%%),
         group_by_regex("Scene, skinning and animation", mod, %regex~.*(update_world_transforms|gltf_scene_bounds|evaluate_animation|gltf_joint_matrix)$%%),
         group_by_regex("Accessor byte readers", mod, %regex~.*(gltf_rd_.*|gltf_read_comp_.*|gltf_comp_size|gltf_type_ncomp)$%%),
         hide_group(group_by_regex("Internal finalize infrastructure", mod, %regex~finalize%%))

--- a/modules/dasGLTF/README.md
+++ b/modules/dasGLTF/README.md
@@ -35,6 +35,9 @@ require gltf/gltf_boost
 var scene <- load_gltf("model.glb")         // .glb / .gltf / base64 / external .bin
 update_world_transforms(scene)              // fill GltfNode.world from the hierarchy
 let (mn, mx) = gltf_scene_bounds(scene)     // world-space AABB (auto-framing)
+
+// already have the bytes? parse in-memory (baseDir resolves external .bin/images; "" for self-contained .glb)
+var scene2 <- load_gltf_from_memory(bytes, baseDir)
 ```
 
 `GltfScene` holds `meshes / materials / textures / images / samplers / nodes / roots / skins /

--- a/modules/dasGLTF/gltf/gltf_parse.das
+++ b/modules/dasGLTF/gltf/gltf_parse.das
@@ -707,6 +707,24 @@ def private parse_gltf_json(jsonText : string; var glbBin : array<uint8>; baseDi
     return <- scene
 }
 
+def load_gltf_from_memory(bytes : array<uint8>; baseDir : string = "") : GltfScene {
+    //! Load a glTF 2.0 document (.gltf JSON, .glb binary, or base64-embedded
+    //! .gltf) from an in-memory byte buffer. `baseDir` resolves external
+    //! buffer/image URIs (pass "" for a self-contained .glb). Returns an empty
+    //! scene on failure.
+    var scene : GltfScene
+    var jsonText : string
+    var glbBin : array<uint8>
+    if (length(bytes) >= 12 && gltf_rd_u32(bytes, 0l) == 0x46546C67u) {
+        parse_glb(bytes, jsonText, glbBin)
+    } else {
+        jsonText = string(bytes)
+    }
+    scene <- parse_gltf_json(jsonText, glbBin, baseDir)
+    delete glbBin
+    return <- scene
+}
+
 def load_gltf(path : string) : GltfScene {
     //! Load a glTF 2.0 file (.gltf, .glb, or base64-embedded .gltf) into a
     //! backend-agnostic `GltfScene`. Returns an empty scene on failure.
@@ -725,16 +743,7 @@ def load_gltf(path : string) : GltfScene {
         to_log(LOG_ERROR, "gltf: cannot open {path}\n")
         return <- scene
     }
-    let baseDir = dir_name(path)
-    var jsonText : string
-    var glbBin : array<uint8>
-    if (length(fileBytes) >= 12 && gltf_rd_u32(fileBytes, 0l) == 0x46546C67u) {
-        parse_glb(fileBytes, jsonText, glbBin)
-    } else {
-        jsonText = string(fileBytes)
-    }
-    scene <- parse_gltf_json(jsonText, glbBin, baseDir)
+    scene <- load_gltf_from_memory(fileBytes, dir_name(path))
     delete fileBytes
-    delete glbBin
     return <- scene
 }


### PR DESCRIPTION
Splits `load_gltf` so a glTF document can be parsed directly from an in-memory byte buffer, without going through the filesystem.

## What

- **New public `load_gltf_from_memory(bytes : array<uint8>; baseDir : string = "")`** — detects GLB vs JSON (base64-embedded `.gltf` included) and runs the same shared parse path. `baseDir` resolves external `.bin`/image URIs; pass `""` for a self-contained `.glb`.
- **`load_gltf(path)`** now just maps the file into a byte buffer and delegates to `load_gltf_from_memory(fileBytes, dir_name(path))` — behavior unchanged.

Callers that already hold the bytes (downloaded asset, embedded resource, archive entry) can skip the file read that the loader was doing internally anyway. The `bytes` parameter is const — `parse_glb` and `gltf_rd_u32` already take const `array<uint8>`, so no copy.

## Docs

- `doc/reflections/das2rst.das` — extended the "Loading" group regex so the new function is categorized (not "Uncategorized").
- `modules/dasGLTF/README.md` — added the in-memory usage line to the Neutral core snippet.
- The function carries a `//!` docstring; regenerated stdlib RST renders it cleanly under **Loading** (no stub, no "Uncategorized").

## Checks

- `compile_check` + `lint` clean on both changed `.das` files (`format_file`: already formatted).
- `das2rst.das` regenerates with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)