### PR TITLE
pages: publish site/dasllama.html (fix daslang.io/dasllama.html 404)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -343,6 +343,7 @@ jobs:
         cp site/downloads.html _site/
         cp site/daspkg.html _site/
         cp site/examples.html _site/
+        cp site/dasllama.html _site/
         cp site/robots.txt _site/
         cp -r site/files _site/files
 


### PR DESCRIPTION
## Problem

`https://daslang.io/dasllama.html` returns **404**, even though the dasLLAMA landing page and every nav link to it have been on `master` since the page landed.

## Root cause

The "Stage site for deployment" step in `.github/workflows/pages.yml` copies a **hardcoded allow-list** of top-level pages into `_site/`:

```bash
cp site/index.html _site/
cp site/downloads.html _site/
cp site/daspkg.html _site/
cp site/examples.html _site/
cp site/robots.txt _site/
```

There is no `cp site/dasllama.html _site/`. GitHub Pages publishes `_site` as a **complete fresh snapshot** (`actions/deploy-pages`), so any file not staged simply doesn't exist on the live site.

Everything else was correctly in place on `master`:
- `site/dasllama.html` exists and is committed
- Nav links to it from `index.html`, `daspkg.html`, `downloads.html`, `examples.html`, `blog/template.html`, `playground/*`
- The news post `2026-07-09-daslang-gets-an-inference-engine-check-out-dasllama.md` links `/dasllama.html`

The page's author wired every *link* but missed the one staging line that copies the file into the published snapshot — the failure mode this explicit allow-list invites (unlike `site/files`, which is copied wholesale via `cp -r`).

## Fix

Add the missing `cp site/dasllama.html _site/`. The next Pages deploy (push to `master`) will serve the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)