### PR TITLE
dasLLAMA: paged KV + q8_0 KV codec + continuous-batching server with prefix caching

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -297,6 +297,7 @@ def document_module_dasllama(_root : string) {
     var mod = find_module("dasllama")
     var groups <- array<DocGroup>(
         group_by_regex("Model loading and sessions", mod, %regex~(load_model|create_session|create_kv_pool|release_kv_pages|create_batch_workspace|setup_dasllama_jobque|caps)$%%),
+        group_by_regex("Prefix cache", mod, %regex~(create_prefix_cache|prefix_attach|prefix_insert|prefix_release|prefix_held_groups)$%%),
         group_by_regex("Tokenizer", mod, %regex~(encode|decode|piece)$%%),
         group_by_regex("Evaluation and sampling", mod, %regex~(eval|eval_embd|eval_batch|sample|set_seed|stats)$%%),
         group_by_regex("Generation", mod, %regex~(generate|generate_embd)$%%),
@@ -316,6 +317,8 @@ def document_module_dasllama(_root : string) {
             "Caller-owned scratch for ``eval_batch``: the batched activation buffers a step of B sessions shares. One per concurrent batch, reused across calls; holds no session state — positions, caches and logits stay in the sessions.")
         dasllama_type_stanza(f, "struct-dasllama_common-KVPool", "KVPool",
             "A caller-owned paged KV-cache pool (``create_kv_pool``): sessions created over it allocate fixed-size page groups on demand, so cache memory tracks the actual context instead of the full ``seq_len`` slab. One pool serves many sessions; an ``eval_batch`` batch must share one pool. Keep it alive and in place while its sessions live.")
+        dasllama_type_stanza(f, "struct-dasllama_prefix-PrefixCache", "PrefixCache",
+            "A page-granular prefix cache over one pool's sessions (``create_prefix_cache``): finished streams donate their KV pages keyed by a chained page hash of the token history, and later requests attach the longest cached prefix instead of re-prefilling it. Pages are refcounted with the pool; an LRU budget bounds retention.")
         dasllama_type_stanza(f, "enum-dasllama_common-KVDtype", "KVDtype",
             "Per-session KV-cache codec picked at ``create_session``/``create_chat``: ``f16`` — the default, half the KV bytes and faster deep-context decode (stores clamp to ±65504); ``f32`` — the bit-exact reference.")
         dasllama_type_stanza(f, "enum-dasllama_common-QuantMode", "QuantMode",

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -251,7 +251,7 @@ def document_module_dashv(_root : string) {
         group_by_regex("Request configuration", mod, %regex~(set_basic_auth|set_bearer_token_auth|set_timeout|set_connect_timeout|allow_redirect|set_param|get_param|each_param)$%%),
         group_by_regex("Cookies", mod, %regex~(add_cookie|get_cookie|each_cookie)$%%),
         group_by_regex("Form data", mod, %regex~(set_form_data|set_form_file|get_form_data|each_form_field|save_form_file|set_url_encoded|get_url_encoded)$%%),
-        group_by_regex("SSE response writer", mod, %regex~(respond|sse_event|end_headers|write_chunked|close_writer|release_writer)$%%)
+        group_by_regex("SSE response writer", mod, %regex~(respond|sse_event|end_headers|write_chunked|close_writer|release_writer|is_writer_connected)$%%)
     )
     document("HTTP and WebSocket library (libhv)", mod, "dashv.rst", groups)
 }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -301,7 +301,7 @@ def document_module_dasllama(_root : string) {
         group_by_regex("Evaluation and sampling", mod, %regex~(eval|eval_embd|eval_batch|sample|set_seed|stats)$%%),
         group_by_regex("Generation", mod, %regex~(generate|generate_embd)$%%),
         group_by_regex("Embeddings", mod, %regex~(embed)$%%),
-        group_by_regex("Chat", mod, %regex~(create_chat|add_user|add_user_audio|add_assistant|render_turn|respond)$%%)
+        group_by_regex("Chat", mod, %regex~(create_chat|create_chat_renderer|add_user|add_user_audio|add_assistant|render_turn|render_assistant|render_close|respond)$%%)
     )
     var hook = DocsHook()
     hook.afterEnums <- @(var f : FILE const?; _was_enums : bool) {

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -296,7 +296,7 @@ def private dasllama_type_stanza(f : FILE const?; lab : string; tname : string; 
 def document_module_dasllama(_root : string) {
     var mod = find_module("dasllama")
     var groups <- array<DocGroup>(
-        group_by_regex("Model loading and sessions", mod, %regex~(load_model|create_session|create_batch_workspace|setup_dasllama_jobque|caps)$%%),
+        group_by_regex("Model loading and sessions", mod, %regex~(load_model|create_session|create_kv_pool|release_kv_pages|create_batch_workspace|setup_dasllama_jobque|caps)$%%),
         group_by_regex("Tokenizer", mod, %regex~(encode|decode|piece)$%%),
         group_by_regex("Evaluation and sampling", mod, %regex~(eval|eval_embd|eval_batch|sample|set_seed|stats)$%%),
         group_by_regex("Generation", mod, %regex~(generate|generate_embd)$%%),
@@ -314,6 +314,8 @@ def document_module_dasllama(_root : string) {
             "One generation stream over a model: the KV cache, scratch buffers, sampling RNG, and the current position ``n_past``. ``logits`` holds the distribution produced by the last ``eval``. A model serves many independent sessions.")
         dasllama_type_stanza(f, "struct-dasllama_common-BatchWorkspace", "BatchWorkspace",
             "Caller-owned scratch for ``eval_batch``: the batched activation buffers a step of B sessions shares. One per concurrent batch, reused across calls; holds no session state — positions, caches and logits stay in the sessions.")
+        dasllama_type_stanza(f, "struct-dasllama_common-KVPool", "KVPool",
+            "A caller-owned paged KV-cache pool (``create_kv_pool``): sessions created over it allocate fixed-size page groups on demand, so cache memory tracks the actual context instead of the full ``seq_len`` slab. One pool serves many sessions; an ``eval_batch`` batch must share one pool. Keep it alive and in place while its sessions live.")
         dasllama_type_stanza(f, "enum-dasllama_common-KVDtype", "KVDtype",
             "Per-session KV-cache codec picked at ``create_session``/``create_chat``: ``f16`` — the default, half the KV bytes and faster deep-context decode (stores clamp to ±65504); ``f32`` — the bit-exact reference.")
         dasllama_type_stanza(f, "enum-dasllama_common-QuantMode", "QuantMode",

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -320,7 +320,7 @@ def document_module_dasllama(_root : string) {
         dasllama_type_stanza(f, "struct-dasllama_prefix-PrefixCache", "PrefixCache",
             "A page-granular prefix cache over one pool's sessions (``create_prefix_cache``): finished streams donate their KV pages keyed by a chained page hash of the token history, and later requests attach the longest cached prefix instead of re-prefilling it. Pages are refcounted with the pool; an LRU budget bounds retention.")
         dasllama_type_stanza(f, "enum-dasllama_common-KVDtype", "KVDtype",
-            "Per-session KV-cache codec picked at ``create_session``/``create_chat``: ``f16`` — the default, half the KV bytes and faster deep-context decode (stores clamp to ±65504); ``f32`` — the bit-exact reference.")
+            "Per-session KV-cache codec picked at ``create_session``/``create_chat``: ``f16`` — the default, half the KV bytes and faster deep-context decode (stores clamp to ±65504); ``f32`` — the bit-exact reference; ``q8_0`` — block-quantized (llama.cpp ``-ctk``/``-ctv q8_0``), half the f16 bytes again and near-lossless in practice; needs head_size and kv_dim to be multiples of 32 (checked at create).")
         dasllama_type_stanza(f, "enum-dasllama_common-QuantMode", "QuantMode",
             "Weight representation picked at load: ``fp32`` — the token-exact reference; ``q8`` — int8 quantization, the fast CPU path; ``q4`` — 4-bit, smallest footprint.")
         dasllama_type_stanza(f, "struct-dasllama_common-SamplingParams", "SamplingParams",

--- a/doc/source/stdlib/handmade/function-dashv-is_writer_connected-0xc4a42f90e7c72e4e.rst
+++ b/doc/source/stdlib/handmade/function-dashv-is_writer_connected-0xc4a42f90e7c72e4e.rst
@@ -1,0 +1,1 @@
+Returns true while the writer's client connection is still open (false for null, unknown, or released writers). The asynchronous writer operations never report a dead peer, so a long-lived stream polls this to evict clients that disconnected.

--- a/modules/dasHV/src/aot_hv.h
+++ b/modules/dasHV/src/aot_hv.h
@@ -60,6 +60,7 @@ namespace das {
     int das_writer_write_chunked ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w, const char * data );
     void das_writer_close ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w );
     void das_writer_release ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w );
+    bool das_writer_is_connected ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w );
 
     // response helpers
     http_status das_resp_string ( HttpResponse * resp, const char * msg, http_status status );

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -692,13 +692,22 @@ int das_writer_respond ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter *
     return 0;
 }
 
-// One SSE event: SSEvent(data, NULL) auto-sends the text/event-stream headers on first call and emits
-// exactly `data: <data>\n\n` (no event: line) — the OpenAI streaming wire format.
+// One SSE event, chunk-framed: `data: <data>\n\n` (an `event:` line only when named) — the OpenAI
+// streaming wire format. The first event sends text/event-stream + Transfer-Encoding: chunked
+// headers; chunked framing is what makes close_writer's End() a VISIBLE terminator (the 0-chunk).
+// libhv's raw SSEvent() writes unframed bytes whose only end-of-stream is a connection close that
+// keep-alive never sends — buffered clients would wait out their whole timeout on every stream.
 int das_writer_sse_event ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w, const char * data, const char * event ) {
     std::string d = data ? data : "";
     std::string e = event ? event : "";
     post_writer_op(h, w, [d,e](hv::HttpResponseWriter* wr){
-        wr->SSEvent(d, e.empty() ? nullptr : e.c_str());
+        if ( wr->state == hv::HttpResponseWriter::SEND_BEGIN ) {
+            wr->WriteHeader("Content-Type", "text/event-stream");
+        }
+        std::string msg;
+        if ( !e.empty() ) { msg = "event: "; msg += e; msg += "\n"; }
+        msg += "data: "; msg += d; msg += "\n\n";
+        wr->WriteChunked(msg);   // first call emits the headers via EndHeaders("Transfer-Encoding", "chunked")
     });
     return 0;
 }

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -741,6 +741,17 @@ void das_writer_release ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter 
     if ( auto adapter = lookup_server(h) ) adapter->release_writer(w);
 }
 
+// True while the writer's connection is still open (isOpened: io alive + not disconnected). The
+// async write ops never report a dead peer, so a server polls this to evict abandoned streams.
+// False for null / unknown / already-released writers.
+bool das_writer_is_connected ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w ) {
+    auto adapter = lookup_server(h);
+    if ( !adapter || !w ) return false;
+    auto sp = adapter->find_writer(w);
+    if ( !sp ) return false;
+    return sp->isOpened();
+}
+
 void das_wss_set_document_root ( Handle<hv::WebSocketServer> h, const char * dir ) {
     if ( auto adapter = lookup_server(h) ) adapter->SET_DOCUMENT_ROOT(dir);
 }
@@ -1530,6 +1541,9 @@ public:
                 ->args({"server","writer"});
         addExtern<DAS_BIND_FUN(das_writer_release)> (*this, lib, "release_writer",
             SideEffects::worstDefault, "das_writer_release")
+                ->args({"server","writer"});
+        addExtern<DAS_BIND_FUN(das_writer_is_connected)> (*this, lib, "is_writer_connected",
+            SideEffects::worstDefault, "das_writer_is_connected")
                 ->args({"server","writer"});
 
     }

--- a/modules/dasHV/src/dasHV.h
+++ b/modules/dasHV/src/dasHV.h
@@ -61,6 +61,7 @@ int das_writer_sse_event ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter
 int das_writer_write_chunked ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w, const char * data );
 void das_writer_close ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w );
 void das_writer_release ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w );
+bool das_writer_is_connected ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w );
 
 http_status das_resp_string ( HttpResponse * resp, const char * msg, http_status status = HTTP_STATUS_OK );
 http_status das_resp_json ( HttpResponse * resp, const char * json_str, http_status status = HTTP_STATUS_OK );

--- a/modules/dasLLAMA/.das_module
+++ b/modules/dasLLAMA/.das_module
@@ -5,7 +5,7 @@ require daslib/fio
 def initialize(project_path : string) {
     let dasllama_paths = [
         "dasllama_par", "dasllama_tune", "dasllama_math", "dasllama_math_default", "dasllama_math_aarch64_neon", "dasllama_math_gen", "dasllama_gemm_gen", "dasllama_gemm_register", "dasllama_gemm_schema", "dasllama_quant", "dasllama_gguf",
-        "dasllama_unicode", "dasllama_tokenizer", "dasllama_bpe", "dasllama_common", "dasllama_audio", "dasllama_audio_io", "dasllama_whisper", "dasllama_qwen3a", "dasllama_parakeet", "dasllama_canary", "dasllama_gemma4a", "dasllama_vad", "dasllama_asr",
+        "dasllama_unicode", "dasllama_tokenizer", "dasllama_bpe", "dasllama_common", "dasllama_prefix", "dasllama_audio", "dasllama_audio_io", "dasllama_whisper", "dasllama_qwen3a", "dasllama_parakeet", "dasllama_canary", "dasllama_gemma4a", "dasllama_vad", "dasllama_asr",
         "dasllama_arch_llama", "dasllama_arch_qwen2", "dasllama_arch_qwen3", "dasllama_arch_phi3", "dasllama_arch_gemma2", "dasllama_arch_gemma3", "dasllama_arch_gemma4", "dasllama_arch_qwen2moe", "dasllama_arch_qwen3moe", "dasllama_arch_gptoss",
         "dasllama_transformer", "dasllama_chat", "dasllama"
     ]

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -104,7 +104,6 @@ def private mb(v : double) : double => v / (1024.0lf * 1024.0lf)
 def private print_traffic_table(t : Model; pos : int64; kvdt : KVDtype) {
     let c = t.config
     let wb = wbytes(t.quant)
-    let kv_esize = double(kv_elem_bytes(kvdt))
     let dim = c.dim
     var attn = 0.0lf
     var kv_read = 0.0lf
@@ -114,7 +113,7 @@ def private print_traffic_table(t : Model; pos : int64; kvdt : KVDtype) {
         let wv = t.wv_offs[l] >= 0l ? double(dim * kvd) : 0.0lf
         attn += (double(dim * qd) + double(dim * kvd) + wv + double(qd * dim)) * wb
         let cnt = layer_is_sliding(c, l) ? min(pos, c.sliding_window) : pos
-        kv_read += double(cnt * kvd) * 2.0lf * kv_esize
+        kv_read += double(cnt * kv_row_bytes(kvdt, kvd)) * 2.0lf   // row bytes: codec-exact (q8_0 incl. block scales)
     }
     var ffn = 0.0lf
     var moe = 0.0lf

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -41,6 +41,12 @@ struct Args {
     @clarg_doc = "KV cache dtype (default: f32)"
     kv : KVDtype = KVDtype.f32
 
+    @clarg_doc = "Page the KV cache through a KVPool instead of the flat slabs"
+    paged : bool
+
+    @clarg_doc = "Positions per page when --paged (default: 64)"
+    page_rows : int = 64
+
     @clarg_doc = "Override target_chunk_work (MACs per dispatch chunk; 1 = thread everything, -1 = keep default)"
     target_work : int = -1
 
@@ -164,9 +170,16 @@ def private profile_window(t : Model; var s : Session; p, n : int64; tok0 : int6
     return tok
 }
 
-def private run_profile(var t : Model; p, n, p2 : int64; team : bool; kvdt : KVDtype) {
+def private run_profile(var t : Model; p, n, p2 : int64; team : bool; kvdt : KVDtype; paged : bool; page_rows : int64) {
     let c = t.config
-    var s <- make_run_state(c, kvdt, kvdt)
+    var pool <- create_kv_pool_(c, page_rows, kvdt, kvdt)   // empty (no groups) unless --paged
+    var s : Session
+    if (paged) {
+        s <- make_run_state_paged(c, pool)
+        print("paged KV: page_rows={page_rows}\n")
+    } else {
+        s <- make_run_state(c, kvdt, kvdt)
+    }
     with_job_que() {
         setup_dasllama_jobque_()   // pooled forks + batched dispatch + spin window + join poll (the engine standard)
         if (team) {   // needs the live job que — must sit inside with_job_que
@@ -256,5 +269,5 @@ def main() {
     if (cfg.kv != KVDtype.f32) {
         print("kv cache dtype: {cfg.kv}\n")
     }
-    run_profile(t, p, n, p2, cfg.team, cfg.kv)
+    run_profile(t, p, n, p2, cfg.team, cfg.kv, cfg.paged, int64(cfg.page_rows))
 }

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -54,6 +54,31 @@ def create_session(model : Model; kv_dtype : KVDtype = KVDtype.f16) : Session {
     return <- create_session_(model, kv_dtype, kv_dtype)
 }
 
+def create_kv_pool(model : Model; page_rows : int64 = 64l; kv_dtype : KVDtype = KVDtype.f16) : KVPool {
+    //! Create a caller-owned PAGED KV pool over ``model``'s cache geometry. Sessions created over it
+    //! (``create_session(model, pool)``) allocate cache pages of ``page_rows`` positions on demand
+    //! instead of the full ``seq_len`` slab up front — KV memory tracks the ACTUAL context, and many
+    //! sessions share one elastic pool. ``kv_dtype`` fixes the codec for every session in the pool.
+    //! Keep the pool alive (and in place) as long as its sessions live; it is plain data — ``delete``
+    //! frees everything at the end.
+    return <- create_kv_pool_(model.config, page_rows, kv_dtype, kv_dtype)
+}
+
+def create_session(model : Model; var pool : KVPool) : Session {
+    //! Create a session whose KV cache is PAGED out of ``pool`` (see ``create_kv_pool``) — pages
+    //! allocate on demand as the context grows. Call ``release_kv_pages`` when the session is done
+    //! (before ``delete``), or its pages stay checked out of the pool. Everything else — ``eval``,
+    //! ``sample``, ``generate``, ``eval_batch`` — behaves exactly like a flat session.
+    return <- create_session_(model, pool)
+}
+
+def release_kv_pages(var session : Session) {
+    //! Return ``session``'s KV pages to its pool (no-op on flat sessions). The normal shape is
+    //! release + ``delete``; a released session stays alive but loses its cached context — to reuse
+    //! it, also reset ``session.n_past`` to 0.
+    release_kv_pages_(session)
+}
+
 def encode(model : Model; text : string; add_special = true; parse_special = false) : array<int64> {
     //! Encode ``text`` to token ids with the model's tokenizer. ``add_special`` prepends BOS where the
     //! model expects one. ``parse_special`` is reserved and not yet honored — special tokens reach the
@@ -100,9 +125,10 @@ def eval_batch(model : Model; var ws : BatchWorkspace; var sessions : array<Sess
     //! position, logits land in ``sessions[i].logits``, and each session advances by one — B
     //! independent conversations through ONE pass of the weights (the weight GEMVs batch into GEMMs;
     //! attention stays per-session). Sessions must be distinct, same-geometry (one model, equal
-    //! cache sizes, uniform KV dtype) and each have room for one more position. Ragged batches:
-    //! pass only the still-active sessions — B may shrink between calls. B == 1 and q4 weights
-    //! delegate to the exact per-session ``forward`` path.
+    //! cache sizes, uniform KV dtype; paged sessions must share ONE pool, never mixed with flat
+    //! rows) and each have room for one more position. Ragged batches: pass only the still-active
+    //! sessions — B may shrink between calls. B == 1 and q4 weights delegate to the exact
+    //! per-session ``forward`` path.
     eval_batch_(model, ws, sessions, tokens)
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -16,6 +16,7 @@ options gen2
 module dasllama shared public
 
 require dasllama/dasllama_transformer public   // the engine + arch registry; every arch [init] fires
+require dasllama/dasllama_prefix public        // page-granular prefix cache over the paged pool
 require dasllama/dasllama_chat public          // layer 2: chat sessions over the same engine
 require dasllama/dasllama_audio public         // audio tower (mel frontend + whisper encoder + projectors)
 require dasllama/dasllama_asr public           // uniform ASR surface (whisper today; parakeet/qwen3-asr land behind the same sniff)
@@ -79,6 +80,44 @@ def release_kv_pages(var session : Session) {
     //! release + ``delete``; a released session stays alive but loses its cached context — to reuse
     //! it, also reset ``session.n_past`` to 0.
     release_kv_pages_(session)
+}
+
+def create_prefix_cache(max_groups : int64 = 0l) : PrefixCache {
+    //! Create a prefix cache for the paged sessions of one ``create_kv_pool`` pool: finished
+    //! streams donate their KV pages (``prefix_insert``) and later requests with the same prompt
+    //! prefix attach them (``prefix_attach``) instead of re-prefilling — the serving win for
+    //! shared system prompts and multi-turn chats. ``max_groups`` caps how many page groups the
+    //! cache retains (LRU-dropped past it); 0 = unbounded. Page hashes route, stored token ids
+    //! verify — a hit attaches only after its tokens compare equal.
+    return <- create_prefix_cache_(max_groups)
+}
+
+def prefix_attach(var cache : PrefixCache; var pool : KVPool; var session : Session; prompt : array<int64>) : int64 {
+    //! Attach the longest cached prefix of ``prompt`` to a FRESH paged ``session`` of ``pool``:
+    //! matched whole pages join the session's block table (shared, refcounted) and ``n_past``
+    //! advances past them, so the caller prefills only the tail. Returns the matched token count
+    //! — a multiple of the pool's ``page_rows``, capped one token short of the prompt so the tail
+    //! eval always produces the sampling logits.
+    return prefix_attach_(cache, pool, session, prompt)
+}
+
+def prefix_insert(var cache : PrefixCache; var pool : KVPool; session : Session; tokens : array<int64>) {
+    //! Donate a finished session's KV pages to the cache. ``tokens`` is the session's full EVALED
+    //! history (prompt + reply + any closing tokens; only the first ``n_past`` count — those rows
+    //! exist); every full page of it not already cached is registered and survives the session's
+    //! ``release_kv_pages``. Call right before releasing.
+    prefix_insert_(cache, pool, session, tokens)
+}
+
+def prefix_release(var cache : PrefixCache; var pool : KVPool) {
+    //! Release every cached page back to ``pool`` and clear the cache (pages still used by live
+    //! sessions stay alive until those sessions release them). Call before deleting the pool.
+    prefix_release_(cache, pool)
+}
+
+def prefix_held_groups(cache : PrefixCache) : int64 {
+    //! Pages the cache currently holds (== pool groups retained for reuse).
+    return prefix_held_groups_(cache)
 }
 
 def encode(model : Model; text : string; add_special = true; parse_special = false) : array<int64> {

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -49,7 +49,9 @@ def create_session(model : Model; kv_dtype : KVDtype = KVDtype.f16) : Session {
     //! On large-context models cap ``model.config.seq_len`` BEFORE creating sessions to bound KV memory.
     //! ``kv_dtype`` picks this session's KV-cache codec — the ``KVDtype.f16`` default halves the KV
     //! bytes and speeds up deep-context decode (near-lossless: stores clamp to ±65504; llama.cpp's
-    //! default is F16 too); pass ``KVDtype.f32`` for the bit-exact reference. Per-session state, so
+    //! default is F16 too); pass ``KVDtype.f32`` for the bit-exact reference, or ``KVDtype.q8_0``
+    //! (llama.cpp ``-ctk/-ctv q8_0``) to halve the bytes again — block-quantized, near-lossless in
+    //! practice, needs head_size/kv_dim multiples of 32 (checked at create). Per-session state, so
     //! sessions with different codecs and parallel models never interact.
     return <- create_session_(model, kv_dtype, kv_dtype)
 }

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -202,6 +202,14 @@ def create_chat(model : Model; var tower : AudioTower; system : string = ""; max
     return <- create_chat_(model, tower, system, max_new, kv_dtype)
 }
 
+def create_chat_renderer(model : Model; system : string = ""; max_new : int64 = 256l) : ChatSession {
+    //! ``create_chat``'s RENDER-ONLY twin: resolves the chat template, stop ids, and turn close
+    //! exactly like ``create_chat``, but creates NO KV session — a queued request can render its
+    //! whole prompt (``add_user`` / ``render_assistant`` / ``render_turn`` / ``render_close``)
+    //! holding tokens only, no cache memory. It cannot ``respond``/``eval``.
+    return <- create_chat_renderer_(model, system, max_new)
+}
+
 def add_user(var chat : ChatSession; text : string) {
     //! Queue a user message for the next ``respond``.
     add_user_(chat, text)
@@ -235,6 +243,21 @@ def render_turn(model : Model; chat : ChatSession) : array<int64> {
     //! Render the next turn's prefill token ids — BOS + system on the first turn, then the user turn
     //! and the generation prompt — WITHOUT running the model. For inspection, token budgeting, tests.
     return <- render_turn_(model, chat)
+}
+
+def render_assistant(model : Model; var chat : ChatSession; text : string; var out : array<int64>) {
+    //! ``add_assistant``'s render half: append the exact token stream a known assistant reply
+    //! prefills — the pending user turn, the assistant-open prompt, ``text``, and the turn close —
+    //! to ``out`` WITHOUT running the model, advancing the transcript exactly like ``add_assistant``.
+    //! Replay a stateless request's history on a ``create_chat_renderer`` chat to render its full
+    //! prompt with no KV memory. Precondition: a user message is pending; a no-op otherwise.
+    render_assistant_(model, chat, text, out)
+}
+
+def render_close(model : Model; chat : ChatSession) : array<int64> {
+    //! The tokens that TERMINATE an assistant turn (what ``respond`` evals after the reply) — for
+    //! schedulers that close a finished stream's turn themselves.
+    return <- render_close_(model, chat)
 }
 
 def respond(model : Model; var chat : ChatSession; params : SamplingParams;

--- a/modules/dasLLAMA/dasllama/dasllama_chat.das
+++ b/modules/dasLLAMA/dasllama/dasllama_chat.das
@@ -220,12 +220,21 @@ def private render_prompt_audio(m : Model; c : ChatSession; var head : array<int
 
 // ===== Public API =====
 
-//! Start a conversation over `model`. `system` is the system prompt (empty = none); `max_new` caps
-//! each reply; `kv_dtype` is the session's KV-cache codec (f16 default, f32 = bit-exact reference).
-//! A model can drive many independent ChatSessions.
-def create_chat_(model : Model; system : string = ""; max_new : int64 = 256l; kv_dtype : KVDtype = KVDtype.f16) : ChatSession {
-    var c = ChatSession(session <- create_session_(model, kv_dtype, kv_dtype), tmpl <- chat_template(model),
-                        system = system, max_new = max_new)
+// Consume the pending user turn once its render is done — render_prompt_audio reads c.pending
+// gated only on n_audio_rows, so a leftover would silently re-inject the text into a later
+// audio-only turn.
+def private consume_pending_(var c : ChatSession) {
+    c.first = false
+    c.has_pending = false
+    c.pending = ""
+}
+
+//! `create_chat_`'s RENDER-ONLY twin: resolves the chat template, stop ids, and turn close exactly
+//! like `create_chat_`, but creates NO KV session — a queued request can render its whole prompt
+//! (`add_user_` / `render_assistant_` / `render_turn_` / `render_close_`) holding tokens only, no
+//! cache memory. Do not eval/respond on it.
+def create_chat_renderer_(model : Model; system : string = ""; max_new : int64 = 256l) : ChatSession {
+    var c = ChatSession(tmpl <- chat_template(model), system = system, max_new = max_new)
     for (sp in c.tmpl.stop) {
         let id = special_id(model, sp)
         if (id >= 0l) {
@@ -246,6 +255,15 @@ def create_chat_(model : Model; system : string = ""; max_new : int64 = 256l; kv
             }
         }
     }
+    return <- c
+}
+
+//! Start a conversation over `model`. `system` is the system prompt (empty = none); `max_new` caps
+//! each reply; `kv_dtype` is the session's KV-cache codec (f16 default, f32 = bit-exact reference).
+//! A model can drive many independent ChatSessions.
+def create_chat_(model : Model; system : string = ""; max_new : int64 = 256l; kv_dtype : KVDtype = KVDtype.f16) : ChatSession {
+    var c <- create_chat_renderer_(model, system, max_new)
+    c.session <- create_session_(model, kv_dtype, kv_dtype)
     return <- c
 }
 
@@ -292,6 +310,31 @@ def render_turn_(m : Model; c : ChatSession) : array<int64> {
     return <- out
 }
 
+//! Render the tokens that TERMINATE an assistant turn — the template's explicit assistant_close,
+//! else the user template's post-content parts — exactly what respond_/add_assistant_ eval after
+//! the reply. For schedulers that close a finished stream's turn themselves.
+def render_close_(m : Model; c : ChatSession) : array<int64> {
+    var out : array<int64>
+    render_parts(m, c.close_parts, "", out)
+    return <- out
+}
+
+//! `add_assistant_`'s render half: append the exact token stream a KNOWN assistant reply prefills —
+//! the pending user turn, the assistant-open prompt, `text`, and the turn close — to `out`, WITHOUT
+//! running the model, advancing the transcript exactly like `add_assistant_`. Replaying a stateless
+//! request's history on a `create_chat_renderer_` chat renders its full prompt while holding NO KV
+//! memory. Precondition: a user message is pending (`add_user_` first); a no-op otherwise.
+def render_assistant_(m : Model; var c : ChatSession; text : string; var out : array<int64>) {
+    if (!c.has_pending) {
+        return
+    }
+    render_prompt(m, c, out)
+    out |> push_from(encode_(m, text, false, false))
+    consume_pending_(c)
+    render_parts(m, c.close_parts, "", out)
+    c.history |> push(Message(role = Role.assistant, content = text))
+}
+
 //! Queue a user message for the next respond().
 def add_user_(var c : ChatSession; text : string) {
     c.pending = text
@@ -309,15 +352,14 @@ def add_assistant_(m : Model; var c : ChatSession; text : string) {
     if (!c.has_pending) {
         return
     }
+    // in lockstep with render_assistant_ (rendered ≡ evaled; test_chat's render-seam case proves
+    // it) — but evaled as the SAME three spans as always, so flash-prefill numerics never shift
     var pre : array<int64>
     render_prompt(m, c, pre)   // user turn + the assistant-open generation prompt
     eval_(m, c.session, pre)
     let body <- encode_(m, text, false, false)
     eval_(m, c.session, body)
-    c.first = false
-    c.has_pending = false
-    c.pending = ""   // consumed — render_prompt_audio reads it gated only on n_audio_rows, so a
-                     // leftover would silently re-inject this text into a later audio-only turn
+    consume_pending_(c)
     var close : array<int64>
     render_parts(m, c.close_parts, "", close)
     eval_(m, c.session, close)
@@ -386,10 +428,7 @@ def respond_(m : Model; var c : ChatSession; params : SamplingParams;
             return invoke(blk, piece)
         }
     }
-    c.first = false
-    c.has_pending = false
-    c.pending = ""   // consumed — render_prompt_audio reads it gated only on n_audio_rows, so a
-                     // leftover would silently re-inject this text into a later audio-only turn
+    consume_pending_(c)
     // close the assistant turn so the next turn continues cleanly
     var close : array<int64>
     render_parts(m, c.close_parts, "", close)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -66,10 +66,13 @@ enum AttnPrefillMode {
 
 //! KV-cache storage codec, chosen per session at create time via ``create_session``/``create_chat``
 //! (llama.cpp -ctk/-ctv analog; K and V carry independent dtypes). f16 is the facade default
-//! (half the KV bytes, near-lossless); f32 is the bit-exact reference.
+//! (half the KV bytes, near-lossless); f32 is the bit-exact reference. q8_0 is the block codec
+//! (32 int8 quants + one f16 scale per block, ggml block_q8_0 layout — 34 bytes per 32 elements,
+//! ~half the f16 bytes again); it needs kv_dim and head_size multiples of 32 (checked at create).
 enum KVDtype {
     f32
     f16
+    q8_0
 }
 
 //! Model hyperparameters (the 7-int checkpoint header plus derived sizes).
@@ -1447,6 +1450,11 @@ struct Session {
     logits : array<float>     // output logits (vocab_size)
     xq : array<int8>          // activation quantized to Q8 (sized max(dim, hidden_dim)) for the Q8·Q8 kernel
     xs : array<float>         // per-block activation scales (sized max(dim, hidden_dim) / 32)
+    // q8_0-K decode query, quantized ONCE per token after RoPE (empty unless kv_dtype_k == q8_0;
+    // batched decode resizes to nrows × qd). Dedicated planes: xq/xs hold the LIVE input quants
+    // while the fused chain's stage-0 q epilogues fill these
+    attq : array<int8>        // quantized query rows (qd)
+    atts : array<float>       // ... and their per-32-block scales (qd / 32)
     // fused decode-chain scratch (team_parallel_stages): the FFN chain's stage-0 workers requant
     // their activated-hidden rows while OTHER chunks still read the input quants in xq/xs, so the
     // requant needs its own buffers; chain_stages is the reused stage-def array (no per-layer alloc)
@@ -1550,10 +1558,27 @@ struct Session {
     ple_gate : array<float>     // per-(position) gate vector for the layer block (npos x ple)
 }
 
+// q8_0 KV needs whole 32-blocks everywhere the cache is sliced: rows (kv_dim) and head slots
+// (head_size — reads offset per head, the fused chain stores per head slot). Real GGUF targets
+// pass (head sizes 64/128/256); llama2.c stories15M (head_size 48) is rejected by design.
+def private kv_validate_q8(c : Config; kdt, vdt : KVDtype) {
+    if (kdt != KVDtype.q8_0 && vdt != KVDtype.q8_0) {
+        return
+    }
+    for (l in range64(c.n_layers)) {
+        let kvd = layer_kv_dim(c, l)
+        let hs = layer_head_size(c, l)
+        if (kvd % 32l != 0l || hs % 32l != 0l) {
+            panic("q8_0 KV cache needs layer kv_dim and head_size to be multiples of 32 — layer {l} has kv_dim={kvd}, head_size={hs}")
+        }
+    }
+}
+
 //! Allocate the run state sized to a model. `kdt`/`vdt` pick the KV-cache codec for THIS session
 //! (no process-global state — sessions with different codecs coexist, models run in parallel).
 //! `alloc_cache = false` skips the flat cache slabs (paged sessions and cache-less scratch).
 def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDtype.f32; alloc_cache : bool = true) : Session {
+    kv_validate_q8(c, kdt, vdt)
     var s : Session
     // qd = n_heads * head_size, the query / attention-output width. == dim for the llama family,
     // but Gemma2 has qd (2048) != dim (2304), so q and the attention scratch xb size to max(dim, qd).
@@ -1604,6 +1629,10 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
     s.xs |> resize(maxn / 32l)
     s.xq2 |> resize(ffw)        // fused-FFN chain requant (see the Session field comment)
     s.xs2 |> resize(ffw / 32l)
+    if (kdt == KVDtype.q8_0) {  // q8_0 K: the roped query quantizes ONCE per token (ggml lesson)
+        s.attq |> resize(qd)
+        s.atts |> resize(qd / 32l)
+    }
     s.chain_stages |> resize(3)
     s.kv_runs |> resize(1)      // flat cache: every window is one physical run (paged sessions re-size)
     // KV cache: walk the per-layer row-byte prefixes (the byte analog of layout_offsets'
@@ -1981,7 +2010,17 @@ def private rope_batch_tab(var q_b : array<float>; var k_b : array<float>; cos_t
 def kv_elem_bytes(dt : KVDtype) : int64 => dt == KVDtype.f16 ? 2l : 4l
 
 //! Byte stride of one position row of width kv_dim under codec dt — THE layout seam.
-def kv_row_bytes(dt : KVDtype; kv_dim : int64) : int64 => kv_dim * kv_elem_bytes(dt)
+//! q8_0: kv_dim/32 blocks of {f16 d; int8 qs[32]} = 34 bytes each (kv_dim % 32 == 0 by create).
+def kv_row_bytes(dt : KVDtype; kv_dim : int64) : int64 {
+    return dt == KVDtype.q8_0 ? kv_dim / 32l * 34l : kv_dim * kv_elem_bytes(dt)
+}
+
+//! Head-slot offset in the side's own addressing units: elements for scalar codecs, bytes for
+//! q8_0 (whole blocks — head_size % 32 == 0 by create). The _d dispatch wrappers prescale with
+//! this so the codec-generic workers' `(rowbase + j) * kdim + khoff` walks stay unit-correct.
+def kv_side_off(dt : KVDtype; elems : int64) : int64 {
+    return dt == KVDtype.q8_0 ? elems / 32l * 34l : elems
+}
 
 //! Layer l's slab base (BYTES) in the key cache; the byte analog of kv_cache_off, reading the
 //! LIVE seq_len so post-load seq_len caps keep working.
@@ -2074,6 +2113,7 @@ def create_kv_pool_(c : Config; page_rows : int64; kdt, vdt : KVDtype) : KVPool 
     if (page_rows <= 0l) {
         panic("create_kv_pool: page_rows must be positive (got {page_rows})")
     }
+    kv_validate_q8(c, kdt, vdt)
     var p = KVPool(page_rows = page_rows, kdt = kdt, vdt = vdt)
     p.blob_of |> reserve(int(c.n_layers))
     for (l in range64(c.n_layers)) {
@@ -2174,6 +2214,12 @@ def kv_store_row(var dst0 : uint8?; dt : KVDtype; kv_dim, row, sub, n : int64; s
             var d = reinterpret<uint16?>(dst0)
             cvt_f32_to_f16(d + row * kv_dim + sub, src, n)   // clamps to ±65504: inf never enters the cache
         }
+    } elif (dt == KVDtype.q8_0) {
+        unsafe {
+            // sub is 0 or a head boundary and head_size/kv_dim are 32-multiples (create-time
+            // contract), so the destination is always a whole-block offset
+            quantize_q8kv_row(dst0 + (row * kv_dim + sub) / 32l * 34l, src, n)
+        }
     } else {
         panic("KV cache codec not yet implemented")
     }
@@ -2190,6 +2236,28 @@ def private kv_axpy(var d : float?; s : uint16 const?; scale : float; n : int64)
     axpy_f16(d, s, scale, n)
 }
 def private kv_load(p : uint16 const?; base, i : int64) : float => f16_to_f32(uint(unsafe(p[base + i])))
+// q8_0: the cache pointer stays uint8 (byte units — the _d wrappers prescale stride/offset via
+// kv_side_off), so `base` here is a whole-block BYTE offset and `i` an element index within it
+def private kv_dot(a : float const?; b : uint8 const?; n : int64) : float => dot_q8kv(a, b, n)
+def private kv_axpy(var d : float?; s : uint8 const?; scale : float; n : int64) {
+    axpy_q8kv(d, s, scale, n)
+}
+def private kv_load(p : uint8 const?; base, i : int64) : float {
+    unsafe {
+        let blk = p + base + i / 32l * 34l
+        let b16 = reinterpret<uint16 const?>(blk)   // bind first: reinterpret would swallow the index
+        let bq = reinterpret<int8 const?>(blk)
+        return float(bq[2l + i % 32l]) * f16_to_f32(uint(b16[0]))
+    }
+}
+// kv_side_off's pointer-typed twin for code that is generic over the cache element type (the
+// flash-decode witness): element offset -> the side's own addressing units
+[unused_argument(p)]
+def private kv_head_off(p : float const?; elems : int64) : int64 => elems
+[unused_argument(p)]
+def private kv_head_off(p : uint16 const?; elems : int64) : int64 => elems
+[unused_argument(p)]
+def private kv_head_off(p : uint8 const?; elems : int64) : int64 => elems / 32l * 34l
 
 // Bulk one-row dequant into f32 scratch — the flash pack's per-row primitive (and any future
 // codec's bulk-dequant seam: q8_0 adds a cvt overload here, never a new pack shape).
@@ -2203,6 +2271,30 @@ def private kv_row_to_f32(var d : float?; p : uint16 const?; base, n : int64) {
         cvt_f16_to_f32(d, p + base, n)
     }
 }
+def private kv_row_to_f32(var d : float?; p : uint8 const?; base, n : int64) {
+    unsafe {
+        cvt_q8kv_to_f32(d, p + base, n)
+    }
+}
+
+// Decode-read score dot, resolved on the K-cache pointer type: scalar codecs dot the f32 query;
+// q8_0 dots the PRE-QUANTIZED query planes (qq/qs — filled once per token after RoPE) through the
+// int8×int8 kernel. Lets the flash-decode witness recompute scores exactly as the sliced path did.
+[unused_argument(qq, qs)]
+def private kv_score(qp : float const?; qq : int8 const?; qs : float const?; kcp : float const?;
+                     koff, qoff, head_size : int64) : float {
+    return kv_dot(unsafe(qp + qoff), unsafe(kcp + koff), head_size)
+}
+[unused_argument(qq, qs)]
+def private kv_score(qp : float const?; qq : int8 const?; qs : float const?; kcp : uint16 const?;
+                     koff, qoff, head_size : int64) : float {
+    return kv_dot(unsafe(qp + qoff), unsafe(kcp + koff), head_size)
+}
+[unused_argument(qp)]
+def private kv_score(qp : float const?; qq : int8 const?; qs : float const?; kcp : uint8 const?;
+                     koff, qoff, head_size : int64) : float {
+    return dot_q8q8kv(unsafe(qq + qoff), unsafe(qs + qoff / 32l), unsafe(kcp + koff), head_size)
+}
 
 // One decode attention head over one layer's cache slab — the attention_std_decode /
 // chain-decode stage-1 worker body, generic over the cache element type (float = f32; further
@@ -2210,8 +2302,11 @@ def private kv_row_to_f32(var d : float?; p : uint16 const?; base, n : int64) {
 // pointers; arow is this head's score row (window-relative: arow[j - kstart]). Cache rows are
 // found through `runs` (physical position runs, kv_runs contract): the flat single-run case is
 // instruction-identical to a direct kstart..kstart+cnt walk. kdim/khoff and vdim/vhoff are the
-// PER-SIDE row stride / head offset in the side's own units (elements for scalar codecs).
+// PER-SIDE row stride / head offset in the side's own units (elements for scalar codecs, BYTES
+// for q8_0). Scores go through kv_score, which resolves on the K pointer type: scalar codecs dot
+// the f32 query, q8_0 runs the int8×int8 dot against the pre-quantized planes qq/qs.
 def private attn_head_decode(var arow : float?; var xbp : float?; qp : float const?;
+                             qq : int8 const?; qsp : float const?;
                              kcp, vcp : auto const?; runs : KVRun const?;
                              nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh : int64;
                              scale, attn_softcap : float; sinksp : float const?) {
@@ -2221,7 +2316,7 @@ def private attn_head_decode(var arow : float?; var xbp : float?; qp : float con
             let rj1 = min(runs[r].j1, kstart + cnt)
             let rowbase = runs[r].row0 - runs[r].j0
             for (j in range64(rj0, rj1)) {
-                arow[j - kstart] = kv_dot(qp + qoff, kcp + (rowbase + j) * kdim + khoff, head_size) * scale
+                arow[j - kstart] = kv_score(qp, qq, qsp, kcp, (rowbase + j) * kdim + khoff, qoff, head_size) * scale
             }
         }
         if (attn_softcap > 0.0) {  // Gemma2: soft-cap scores before softmax
@@ -2248,9 +2343,11 @@ def private attn_head_decode(var arow : float?; var xbp : float?; qp : float con
 }
 
 // Flash-decode sliced K pass (chain stage 1, nsl > 1): the slice's K rows stream once, dotted
-// against every q-head of the GQA group. Codec-generic + run-walking like attn_head_decode;
-// the slice sub-window [kstart+j0, kstart+j1) intersects each run.
-def private kv_slice_scores(var attp : float?; qp : float const?; kcp : auto const?; runs : KVRun const?;
+// against every q-head of the GQA group. Codec-generic + run-walking like attn_head_decode
+// (scores through kv_score — q8_0 K reads the pre-quantized query planes qq/qs); the slice
+// sub-window [kstart+j0, kstart+j1) intersects each run.
+def private kv_slice_scores(var attp : float?; qp : float const?; qq : int8 const?; qsp : float const?;
+                            kcp : auto const?; runs : KVRun const?;
                             nrun, kstart, j0, j1, kdim, khoff, head_size, qh0, kv_mul, seq_len : int64;
                             scale : float) {
     unsafe {
@@ -2262,7 +2359,7 @@ def private kv_slice_scores(var attp : float?; qp : float const?; kcp : auto con
                 let j = aj - kstart
                 let koff = (rowbase + aj) * kdim + khoff
                 for (g in range64(kv_mul)) {
-                    attp[(qh0 + g) * seq_len + j] = kv_dot(qp + (qh0 + g) * head_size, kcp + koff, head_size) * scale
+                    attp[(qh0 + g) * seq_len + j] = kv_score(qp, qq, qsp, kcp, koff, (qh0 + g) * head_size, head_size) * scale
                 }
             }
         }
@@ -2296,40 +2393,69 @@ def private kv_slice_av(var flop : float?; attp : float const?; vcp : auto const
 // per element.
 
 def private attn_head_decode_d(var arow : float?; var xbp : float?; qp : float const?;
+                               qq : int8 const?; qsp : float const?;
                                kcl, vcl : uint8 const?; kdt, vdt : KVDtype; runs : KVRun const?;
                                nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh : int64;
                                scale, attn_softcap : float; sinksp : float const?) {
-    // per-side stride/offset in the side's own units — identical for scalar codecs; a block codec
-    // (q8_0) rescales its side to bytes here, once per head
+    // per-side stride/offset in the side's own units — elements for scalar codecs, BYTES for the
+    // q8_0 block codec, rescaled here once per head. qq/qsp = the pre-quantized query planes
+    // (q8_0-K callers only; null otherwise)
+    let kdim = kv_side_off(kdt, kv_dim)
+    let khoff = kv_side_off(kdt, kvhoff)
+    let vdim = kv_side_off(vdt, kv_dim)
+    let vhoff = kv_side_off(vdt, kvhoff)
     unsafe {
-        if (kdt == KVDtype.f16) {
-            if (vdt == KVDtype.f16) {
-                attn_head_decode(arow, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
-                    runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+        if (kdt == KVDtype.q8_0) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_decode(arow, xbp, qp, qq, qsp, kcl, vcl,
+                    runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_decode(arow, xbp, qp, qq, qsp, kcl, reinterpret<uint16 const?>(vcl),
+                    runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
             } else {
-                attn_head_decode(arow, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
-                    runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+                attn_head_decode(arow, xbp, qp, qq, qsp, kcl, reinterpret<float const?>(vcl),
+                    runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
             }
+        } elif (kdt == KVDtype.f16) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_decode(arow, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), vcl,
+                    runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_decode(arow, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
+                    runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+            } else {
+                attn_head_decode(arow, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
+                    runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+            }
+        } elif (vdt == KVDtype.q8_0) {
+            attn_head_decode(arow, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), vcl,
+                runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
         } elif (vdt == KVDtype.f16) {
-            attn_head_decode(arow, xbp, qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
-                runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+            attn_head_decode(arow, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
+                runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
         } else {
-            attn_head_decode(arow, xbp, qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
-                runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
+            attn_head_decode(arow, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
+                runs, nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
         }
     }
 }
 
-def private kv_slice_scores_d(var attp : float?; qp : float const?; kcl : uint8 const?; kdt : KVDtype;
+def private kv_slice_scores_d(var attp : float?; qp : float const?; qq : int8 const?; qsp : float const?;
+                              kcl : uint8 const?; kdt : KVDtype;
                               runs : KVRun const?;
                               nrun, kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len : int64;
                               scale : float) {
+    let kdim = kv_side_off(kdt, kv_dim)
+    let khoff = kv_side_off(kdt, kvhoff)
     unsafe {
-        if (kdt == KVDtype.f16) {
-            kv_slice_scores(attp, qp, reinterpret<uint16 const?>(kcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
+        if (kdt == KVDtype.q8_0) {
+            kv_slice_scores(attp, qp, qq, qsp, kcl, runs, nrun, kstart, j0, j1, kdim, khoff,
+                head_size, qh0, kv_mul, seq_len, scale)
+        } elif (kdt == KVDtype.f16) {
+            kv_slice_scores(attp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), runs, nrun, kstart, j0, j1, kdim, khoff,
                 head_size, qh0, kv_mul, seq_len, scale)
         } else {
-            kv_slice_scores(attp, qp, reinterpret<float const?>(kcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
+            kv_slice_scores(attp, qp, qq, qsp, reinterpret<float const?>(kcl), runs, nrun, kstart, j0, j1, kdim, khoff,
                 head_size, qh0, kv_mul, seq_len, scale)
         }
     }
@@ -2338,12 +2464,17 @@ def private kv_slice_scores_d(var attp : float?; qp : float const?; kcl : uint8 
 def private kv_slice_av_d(var flop : float?; attp : float const?; vcl : uint8 const?; vdt : KVDtype;
                           runs : KVRun const?;
                           nrun, kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len, nsl, sl : int64) {
+    let vdim = kv_side_off(vdt, kv_dim)
+    let vhoff = kv_side_off(vdt, kvhoff)
     unsafe {
-        if (vdt == KVDtype.f16) {
-            kv_slice_av(flop, attp, reinterpret<uint16 const?>(vcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
+        if (vdt == KVDtype.q8_0) {
+            kv_slice_av(flop, attp, vcl, runs, nrun, kstart, j0, j1, vdim, vhoff,
+                head_size, qh0, kv_mul, seq_len, nsl, sl)
+        } elif (vdt == KVDtype.f16) {
+            kv_slice_av(flop, attp, reinterpret<uint16 const?>(vcl), runs, nrun, kstart, j0, j1, vdim, vhoff,
                 head_size, qh0, kv_mul, seq_len, nsl, sl)
         } else {
-            kv_slice_av(flop, attp, reinterpret<float const?>(vcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
+            kv_slice_av(flop, attp, reinterpret<float const?>(vcl), runs, nrun, kstart, j0, j1, vdim, vhoff,
                 head_size, qh0, kv_mul, seq_len, nsl, sl)
         }
     }
@@ -2351,24 +2482,27 @@ def private kv_slice_av_d(var flop : float?; attp : float const?; vcl : uint8 co
 
 // The flash-decode witness body (see the call in attention_chain_decode): exact single-pass
 // recompute of every head's attention output vs the sliced result in xb. Codec-generic like the
-// workers; test-only and serial, so the extraction costs nothing.
-def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv : float const?;
+// workers (per-side kdim/vdim strides in the side's own units; kv_score reruns the q8_0 K path
+// through the SAME quantized-query dot); test-only and serial, so the extraction costs nothing.
+def private flash_decode_check_g(qp : float const?; qq : int8 const?; qsp : float const?;
+                                 kcp, vcp : auto const?; xbv : float const?;
                                  runs : KVRun const?;
-                                 nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, nsl : int64;
+                                 nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl : int64;
                                  scale, attn_softcap : float; sinksp : float const?) {
     var sref : array<float>
     sref |> resize(int(cnt))
     unsafe {
         for (hh in range64(n_heads)) {
             let qoff = hh * head_size
-            let kvhoff = (hh / kv_mul) * head_size
+            let khoff = kv_head_off(kcp, (hh / kv_mul) * head_size)
+            let vhoff = kv_head_off(vcp, (hh / kv_mul) * head_size)
             for (r in range64(nrun)) {
                 let rj0 = max(runs[r].j0, kstart)
                 let rj1 = min(runs[r].j1, kstart + cnt)
                 let rowbase = runs[r].row0 - runs[r].j0
                 for (aj in range64(rj0, rj1)) {
-                    let koff = (rowbase + aj) * kv_dim + kvhoff   // kcp is layer-base (codec seam)
-                    let sc = kv_dot(qp + qoff, kcp + koff, head_size) * scale
+                    let koff = (rowbase + aj) * kdim + khoff   // kcp is layer-base (codec seam)
+                    let sc = kv_score(qp, qq, qsp, kcp, koff, qoff, head_size) * scale
                     sref[aj - kstart] = attn_softcap > 0.0 ? attn_softcap * tanh(sc / attn_softcap) : sc
                 }
             }
@@ -2394,7 +2528,7 @@ def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv 
                     let rj1 = min(runs[r].j1, kstart + cnt)
                     let rowbase = runs[r].row0 - runs[r].j0
                     for (aj in range64(rj0, rj1)) {
-                        let voff = (rowbase + aj) * kv_dim + kvhoff   // vcp is layer-base (codec seam)
+                        let voff = (rowbase + aj) * vdim + vhoff   // vcp is layer-base (codec seam)
                         acc += exp(sref[aj - kstart] - m2) / l2 * kv_load(vcp, voff, i)
                     }
                 }
@@ -2406,6 +2540,50 @@ def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv 
         }
     }
     delete sref
+}
+
+// The witness' codec dispatch — the K×V matrix spelled once, like the worker wrappers.
+def private flash_decode_check_d(qp : float const?; qq : int8 const?; qsp : float const?;
+                                 kcl, vcl : uint8 const?; kdt, vdt : KVDtype; xbv : float const?;
+                                 runs : KVRun const?;
+                                 nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, nsl : int64;
+                                 scale, attn_softcap : float; sinksp : float const?) {
+    let kdim = kv_side_off(kdt, kv_dim)
+    let vdim = kv_side_off(vdt, kv_dim)
+    unsafe {
+        if (kdt == KVDtype.q8_0) {
+            if (vdt == KVDtype.q8_0) {
+                flash_decode_check_g(qp, qq, qsp, kcl, vcl, xbv, runs,
+                    nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                flash_decode_check_g(qp, qq, qsp, kcl, reinterpret<uint16 const?>(vcl), xbv, runs,
+                    nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+            } else {
+                flash_decode_check_g(qp, qq, qsp, kcl, reinterpret<float const?>(vcl), xbv, runs,
+                    nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+            }
+        } elif (kdt == KVDtype.f16) {
+            if (vdt == KVDtype.q8_0) {
+                flash_decode_check_g(qp, qq, qsp, reinterpret<uint16 const?>(kcl), vcl, xbv, runs,
+                    nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                flash_decode_check_g(qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl), xbv, runs,
+                    nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+            } else {
+                flash_decode_check_g(qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl), xbv, runs,
+                    nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+            }
+        } elif (vdt == KVDtype.q8_0) {
+            flash_decode_check_g(qp, qq, qsp, reinterpret<float const?>(kcl), vcl, xbv, runs,
+                nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+        } elif (vdt == KVDtype.f16) {
+            flash_decode_check_g(qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl), xbv, runs,
+                nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+        } else {
+            flash_decode_check_g(qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl), xbv, runs,
+                nrun, n_heads, kv_mul, head_size, kdim, vdim, kstart, cnt, l, nsl, scale, attn_softcap, sinksp)
+        }
+    }
 }
 
 // Store the roped k / raw v for all npos positions into the layer's KV cache. Each worker chunk
@@ -2880,6 +3058,12 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
         var attp = addr(s.att[0])
         var xqp = addr(s.xq[0])
         var xsp = addr(s.xs[0])
+        // q8_0 K: the quantized-query planes each stage-0 q slot fills after its rope (chunk-local
+        // whole blocks — head_size % 32 == 0 by create; per-32-block quants are grouping-free, so
+        // the per-slot fill is byte-identical to one serial whole-row quantize)
+        let kq8 = kdt == KVDtype.q8_0
+        var attqp = kq8 ? addr(s.attq[0]) : null
+        var attsp = kq8 ? addr(s.atts[0]) : null
         var kcl = kv_layer_kbase(s, l, c.seq_len)  // layer-base byte pointers (stores + the _d read dispatch)
         var vcl = kv_layer_vbase(s, l, c.seq_len)
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))   // this layer's physical runs (fork-safe hoist)
@@ -2937,6 +3121,9 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                             } else {
                                 rope_scaled_tab(qp + r0, head_size, head_size, crow, srow)
                             }
+                            if (kq8) {   // quantize this head's roped query for the int8×int8 score dot
+                                quantize_q8_0_into_ptr(qp + r0, head_size, attqp, attsp, r0, r0 / 32l)
+                            }
                         } elif (sl < n_heads + n_kv_heads) {
                             let r0 = (sl - n_heads) * head_size
                             invoke(mmrows, kp, wpk, wsk, xqp, xsp, dim, r0, r0 + head_size)
@@ -2979,7 +3166,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         let hh = int64(h)
                         let qoff = hh * head_size
                         let kvhoff = (hh / kv_mul) * head_size  // GQA: which kv head this query head reads
-                        attn_head_decode_d(attp + hh * seq_len, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                        attn_head_decode_d(attp + hh * seq_len, xbp, qp, attqp, attsp, kcl, vcl, kdt, vdt, runsp,
                             nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
                         quantize_q8_0_into_ptr(xbp + qoff, head_size, xqp, xsp, qoff, qoff / 32l)
                     }
@@ -3000,7 +3187,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         let j0 = sl * slice_len
                         let j1 = min(j0 + slice_len, cnt)
                         // K pass: each K row read once, dotted against every group q-head
-                        kv_slice_scores_d(attp, qp, kcl, kdt, runsp, nrun, kstart, j0, j1, kv_dim, kvhoff, head_size,
+                        kv_slice_scores_d(attp, qp, attqp, attsp, kcl, kdt, runsp, nrun, kstart, j0, j1, kv_dim, kvhoff, head_size,
                             qh0, kv_mul, seq_len, scale)
                         for (g in range64(kv_mul)) {
                             let hh = qh0 + g
@@ -3108,21 +3295,8 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
             // reassociation tolerance. Logit-level A/Bs can't gate this — a 1-ulp xb difference can
             // cross an int8 requant boundary and amplify through the remaining Q8 layers — so the
             // contract is checked HERE, per layer, at the attention output itself.
-            if (kdt == KVDtype.f16) {
-                if (vdt == KVDtype.f16) {
-                    flash_decode_check_g(qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl), xbp, runsp,
-                        nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
-                } else {
-                    flash_decode_check_g(qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl), xbp, runsp,
-                        nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
-                }
-            } elif (vdt == KVDtype.f16) {
-                flash_decode_check_g(qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl), xbp, runsp,
-                    nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
-            } else {
-                flash_decode_check_g(qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl), xbp, runsp,
-                    nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
-            }
+            flash_decode_check_d(qp, attqp, attsp, kcl, vcl, kdt, vdt, xbp, runsp,
+                nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
             g_flash_decode_checked++
         }
     }
@@ -3326,6 +3500,11 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
         }
     }
     prof_add("rope", ts_rope)
+    if (s.kv_dtype_k == KVDtype.q8_0) {
+        // quantize the roped query ONCE for the int8×int8 score dot (ggml's convert-the-query
+        // lesson) — O(qd) serial, dwarfed by the attention reads it feeds
+        quantize_q8_0_into(s.q, qd, s.attq, s.atts, 0l, 0l)
+    }
     // store k, v for this position into the KV cache (shared-KV layers: nothing to store — the
     // source layer already cached its K/V, which kbase/vbase point at)
     if (!kv_shared) {
@@ -3357,6 +3536,8 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     let nrun = kv_runs(s, kstart, pos + 1l, s.kv_runs)   // physical runs of this layer's window (flat: 1)
     unsafe {
         let qp = reinterpret<float const?>(addr(s.q[0]))
+        let qqp = kdt == KVDtype.q8_0 ? reinterpret<int8 const?>(addr(s.attq[0])) : null
+        let qsp = kdt == KVDtype.q8_0 ? reinterpret<float const?>(addr(s.atts[0])) : null
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb[0])
         var attp = addr(s.att[0])
@@ -3366,7 +3547,7 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
                     let hh = int64(h)
                     let qoff = hh * head_size
                     let kvhoff = (hh / kv_mul) * head_size  // GQA: which kv head this query head reads
-                    attn_head_decode_d(attp + hh * seq_len, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                    attn_head_decode_d(attp + hh * seq_len, xbp, qp, qqp, qsp, kcl, vcl, kdt, vdt, runsp,
                         nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
                 }
             }
@@ -4359,7 +4540,10 @@ def private attn_head_flash(qp : float const?; kcp, vcp : auto const?; var xbp :
 // One head of BLOCKED prefill attention (see prefill_attention) — codec-generic + run-walking.
 // kcp/vcp are layer-base typed pointers; attp_h = this head's ATTN_BLOCK_Q score rows
 // (maxctx-strided, window-relative). The block's key range intersects the layer's physical runs.
+// Scores go through kv_score (q8_0 K: the pre-quantized qq/qs planes — the same dot decode runs,
+// keeping prefill == decode bit-exact under the block codec too).
 def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float const?;
+                              qq : int8 const?; qsp : float const?;
                               kcp, vcp : auto const?; runs : KVRun const?;
                               nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh : int64;
                               scale : float; is_sliding : bool; sliding_window : int64;
@@ -4388,7 +4572,7 @@ def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float 
                         let ap = start_pos + p
                         let kstart_p = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
                         let qbase = p * qd + qoff
-                        attp_h[bi * maxctx + (kk - kstart_p)] = kv_dot(qp + qbase, kcp + koff, head_size) * scale
+                        attp_h[bi * maxctx + (kk - kstart_p)] = kv_score(qp, qq, qsp, kcp, koff, qbase, head_size) * scale
                     }
                 }
             }
@@ -4440,8 +4624,9 @@ def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float 
 
 // One head of CLASSIC prefill attention (see prefill_attention) — codec-generic + run-walking.
 // attp_h = this head's private score row (maxctx wide, window-relative); each query's window
-// [kstart, ap] intersects the layer's physical runs.
+// [kstart, ap] intersects the layer's physical runs. Scores through kv_score (see attn_head_blocked).
 def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float const?;
+                              qq : int8 const?; qsp : float const?;
                               kcp, vcp : auto const?; runs : KVRun const?;
                               nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh : int64;
                               scale : float; is_sliding : bool; sliding_window : int64;
@@ -4457,7 +4642,7 @@ def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float 
                 let rj1 = min(runs[r].j1, ap + 1l)
                 let rowbase = runs[r].row0 - runs[r].j0
                 for (aj in range64(rj0, rj1)) {
-                    attp_h[aj - kstart] = kv_dot(qp + qbase, kcp + (rowbase + aj) * kdim + khoff, head_size) * scale
+                    attp_h[aj - kstart] = kv_score(qp, qq, qsp, kcp, (rowbase + aj) * kdim + khoff, qbase, head_size) * scale
                 }
             }
             if (attn_softcap > 0.0) {  // Gemma2: soft-cap scores before softmax
@@ -4484,86 +4669,168 @@ def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float 
 }
 
 // Prefill codec dispatch (same contract as attn_head_decode_d): one wrapper per prefill worker,
-// the 2x2 scalar K×V matrix spelled once.
+// the 3x3 K×V matrix spelled once (per-side strides in the side's own units — bytes for q8_0,
+// whose reads here go through the f32-query kv_dot/kv_row_to_f32 overloads: prefill is
+// compute-bound, so the dequant-in-dot form is fine and no query quantize is needed).
 def private attn_head_flash_d(qp : float const?; kcl, vcl : uint8 const?; kdt, vdt : KVDtype; var xbp : float?;
                               var qpk, kpk, vpk, kqp, vkqp, tmpp : float?; runs : KVRun const?;
                               nrun, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff : int64;
                               scale : float; is_sliding : bool; sliding_window : int64; attn_softcap : float;
                               has_sink : bool; sink : float) {
+    let kdim = kv_side_off(kdt, kv_dim)
+    let khoff = kv_side_off(kdt, kvhoff)
+    let vdim = kv_side_off(vdt, kv_dim)
+    let vhoff = kv_side_off(vdt, kvhoff)
     unsafe {
-        if (kdt == KVDtype.f16) {
-            if (vdt == KVDtype.f16) {
+        if (kdt == KVDtype.q8_0) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_flash(qp, kcl, vcl, xbp,
+                    qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                    kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_flash(qp, kcl, reinterpret<uint16 const?>(vcl), xbp,
+                    qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                    kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+            } else {
+                attn_head_flash(qp, kcl, reinterpret<float const?>(vcl), xbp,
+                    qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                    kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+            }
+        } elif (kdt == KVDtype.f16) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_flash(qp, reinterpret<uint16 const?>(kcl), vcl, xbp,
+                    qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                    kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+            } elif (vdt == KVDtype.f16) {
                 attn_head_flash(qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl), xbp,
                     qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
-                    kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                    kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
             } else {
                 attn_head_flash(qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl), xbp,
                     qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
-                    kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                    kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
             }
+        } elif (vdt == KVDtype.q8_0) {
+            attn_head_flash(qp, reinterpret<float const?>(kcl), vcl, xbp,
+                qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
         } elif (vdt == KVDtype.f16) {
             attn_head_flash(qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl), xbp,
                 qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
-                kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
         } else {
             attn_head_flash(qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl), xbp,
                 qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
-                kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                kdim, khoff, vdim, vhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
         }
     }
 }
 
 def private attn_head_blocked_d(var attp_h : float?; var xbp : float?; qp : float const?;
+                                qq : int8 const?; qsp : float const?;
                                 kcl, vcl : uint8 const?; kdt, vdt : KVDtype; runs : KVRun const?;
                                 nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
                                 scale : float; is_sliding : bool; sliding_window : int64;
                                 attn_softcap : float; sinksp : float const?) {
+    let kdim = kv_side_off(kdt, kv_dim)
+    let khoff = kv_side_off(kdt, kvhoff)
+    let vdim = kv_side_off(vdt, kv_dim)
+    let vhoff = kv_side_off(vdt, kvhoff)
     unsafe {
-        if (kdt == KVDtype.f16) {
-            if (vdt == KVDtype.f16) {
-                attn_head_blocked(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
-                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+        if (kdt == KVDtype.q8_0) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_blocked(attp_h, xbp, qp, qq, qsp, kcl, vcl,
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_blocked(attp_h, xbp, qp, qq, qsp, kcl, reinterpret<uint16 const?>(vcl),
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             } else {
-                attn_head_blocked(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
-                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+                attn_head_blocked(attp_h, xbp, qp, qq, qsp, kcl, reinterpret<float const?>(vcl),
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             }
+        } elif (kdt == KVDtype.f16) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_blocked(attp_h, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), vcl,
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_blocked(attp_h, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            } else {
+                attn_head_blocked(attp_h, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            }
+        } elif (vdt == KVDtype.q8_0) {
+            attn_head_blocked(attp_h, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), vcl,
+                runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                scale, is_sliding, sliding_window, attn_softcap, sinksp)
         } elif (vdt == KVDtype.f16) {
-            attn_head_blocked(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
-                runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+            attn_head_blocked(attp_h, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
+                runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         } else {
-            attn_head_blocked(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
-                runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+            attn_head_blocked(attp_h, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
+                runs, nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         }
     }
 }
 
 def private attn_head_classic_d(var attp_h : float?; var xbp : float?; qp : float const?;
+                                qq : int8 const?; qsp : float const?;
                                 kcl, vcl : uint8 const?; kdt, vdt : KVDtype; runs : KVRun const?;
                                 nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
                                 scale : float; is_sliding : bool; sliding_window : int64;
                                 attn_softcap : float; sinksp : float const?) {
+    let kdim = kv_side_off(kdt, kv_dim)
+    let khoff = kv_side_off(kdt, kvhoff)
+    let vdim = kv_side_off(vdt, kv_dim)
+    let vhoff = kv_side_off(vdt, kvhoff)
     unsafe {
-        if (kdt == KVDtype.f16) {
-            if (vdt == KVDtype.f16) {
-                attn_head_classic(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
-                    runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+        if (kdt == KVDtype.q8_0) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_classic(attp_h, xbp, qp, qq, qsp, kcl, vcl,
+                    runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_classic(attp_h, xbp, qp, qq, qsp, kcl, reinterpret<uint16 const?>(vcl),
+                    runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             } else {
-                attn_head_classic(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
-                    runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+                attn_head_classic(attp_h, xbp, qp, qq, qsp, kcl, reinterpret<float const?>(vcl),
+                    runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             }
+        } elif (kdt == KVDtype.f16) {
+            if (vdt == KVDtype.q8_0) {
+                attn_head_classic(attp_h, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), vcl,
+                    runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            } elif (vdt == KVDtype.f16) {
+                attn_head_classic(attp_h, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
+                    runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            } else {
+                attn_head_classic(attp_h, xbp, qp, qq, qsp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
+                    runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                    scale, is_sliding, sliding_window, attn_softcap, sinksp)
+            }
+        } elif (vdt == KVDtype.q8_0) {
+            attn_head_classic(attp_h, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), vcl,
+                runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
+                scale, is_sliding, sliding_window, attn_softcap, sinksp)
         } elif (vdt == KVDtype.f16) {
-            attn_head_classic(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
-                runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+            attn_head_classic(attp_h, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
+                runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         } else {
-            attn_head_classic(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
-                runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
+            attn_head_classic(attp_h, xbp, qp, qq, qsp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
+                runs, nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         }
     }
@@ -4581,8 +4848,21 @@ def private prefill_attention(var s : Session; kcl, vcl : uint8 const?; npos, st
     // sub-windows with each run (two max/min per run)
     let kstart_min = (is_sliding && start_pos + 1l > sliding_window) ? (start_pos + 1l - sliding_window) : 0l
     let nrun = kv_runs(s, kstart_min, start_pos + npos, s.kv_runs)
+    // q8_0 K, blocked/classic: quantize every query row once so scores run the SAME int8×int8 dot
+    // as decode — the bit-exact prefill==decode contract survives the block codec. Flash never
+    // reads these (it packs the cache to f32 tiles and GEMMs the f32 queries; tolerance-validated).
+    if (kdt == KVDtype.q8_0 && g_attn_prefill_mode != AttnPrefillMode.flash) {
+        if (int64(length(s.attq)) < npos * qd) {
+            s.attq |> resize(int(npos * qd))
+            s.atts |> resize(int(npos * qd / 32l))
+        }
+        quantize_q8_0_into(s.q_b, npos * qd, s.attq, s.atts, 0l, 0l)
+    }
     unsafe {
         let qp = reinterpret<float const?>(addr(s.q_b[0]))
+        let kq8bc = kdt == KVDtype.q8_0 && g_attn_prefill_mode != AttnPrefillMode.flash
+        let qqp = kq8bc ? reinterpret<int8 const?>(addr(s.attq[0])) : null
+        let qsp = kq8bc ? reinterpret<float const?>(addr(s.atts[0])) : null
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb_b[0])
         // att_b is sized only for the blocked/classic modes (flash packs into fa_* instead), so the
@@ -4618,7 +4898,7 @@ def private prefill_attention(var s : Session; kcl, vcl : uint8 const?; npos, st
                         let hh = int64(h)
                         let qoff = hh * head_size
                         let kvhoff = (hh / kv_mul) * head_size
-                        attn_head_blocked_d(attp + hh * ATTN_BLOCK_Q * maxctx, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                        attn_head_blocked_d(attp + hh * ATTN_BLOCK_Q * maxctx, xbp, qp, qqp, qsp, kcl, vcl, kdt, vdt, runsp,
                             nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
                             scale, is_sliding, sliding_window, attn_softcap, sinksp)
                     }
@@ -4631,7 +4911,7 @@ def private prefill_attention(var s : Session; kcl, vcl : uint8 const?; npos, st
                         let hh = int64(h)
                         let qoff = hh * head_size
                         let kvhoff = (hh / kv_mul) * head_size
-                        attn_head_classic_d(attp + hh * maxctx, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                        attn_head_classic_d(attp + hh * maxctx, xbp, qp, qqp, qsp, kcl, vcl, kdt, vdt, runsp,
                             nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
                             scale, is_sliding, sliding_window, attn_softcap, sinksp)
                     }
@@ -5796,6 +6076,10 @@ def private batch_decode_alloc(t : Model; var s : Session; nrows : int64) {
     s.hb2_b |> resize(nrows * hidden)
     s.xqb |> resize(nrows * maxn)
     s.xsb |> resize(nrows * maxn / 32l)
+    if (s.kv_dtype_k == KVDtype.q8_0) {   // batch query-quant planes (dtypes snapshotted before this)
+        s.attq |> resize(nrows * qd)
+        s.atts |> resize(nrows * qd / 32l)
+    }
     if (has_ple(c)) {   // gemma-4 E-series PLE scratch (one row per batch slot)
         let all = c.n_layers * c.n_embd_per_layer
         s.ple_inp |> resize(nrows * all)
@@ -5831,6 +6115,11 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; sessions 
     // start_pos is only read by the classic (non-table) rope path, which eval_batch_ never routes
     // here — the rows table already bakes each row's own position in
     attn_qkv_rope_prefix(t, ws.scr, l, nrows, 0l)
+    if (kdt == KVDtype.q8_0) {
+        // quantize every row's roped query in one pass (q_b rows are contiguous and qd % 32 == 0,
+        // so per-32-block quants equal the per-row form byte-for-byte)
+        quantize_q8_0_into(ws.scr.q_b, nrows * qd, ws.scr.attq, ws.scr.atts, 0l, 0l)
+    }
     if (!kv_shared) {
         let ts_kv = ref_time_ticks()
         unsafe {
@@ -5869,6 +6158,9 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; sessions 
         : null)
     unsafe {
         let qp = reinterpret<float const?>(addr(ws.scr.q_b[0]))
+        let kq8 = kdt == KVDtype.q8_0
+        let qqp0 = kq8 ? reinterpret<int8 const?>(addr(ws.scr.attq[0])) : null
+        let qsp0 = kq8 ? reinterpret<float const?>(addr(ws.scr.atts[0])) : null
         var xbp = addr(ws.scr.xb_b[0])
         var attp = addr(ws.scr.att_b[0])
         let posp = reinterpret<int64 const?>(addr(ws.positions[0]))
@@ -5888,6 +6180,7 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; sessions 
                     let qoff = hh * head_size
                     let kvhoff = (hh / kv_mul) * head_size
                     attn_head_decode_d(attp + ix * maxctx, xbp + ii * qd, qp + ii * qd,
+                        kq8 ? qqp0 + ii * qd : null, kq8 ? qsp0 + ii * qd / 32l : null,
                         paged ? pkcl : kbpp[ii] + kbb, paged ? pvcl : vbpp[ii] + vbb, kdt, vdt,
                         runsbp + ii * maxruns, nrunbp[ii], qoff, kvhoff, kstart, cnt, kv_dim, head_size,
                         hh, scale, attn_softcap, sinksp)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1399,6 +1399,27 @@ def footprint(t : Model) : MemFootprint {
                         total = aux + wf + q8 + q8s + q4 + q4s + mx4 + mx4s)
 }
 
+//! A caller-owned paged KV-cache pool (``create_kv_pool_``). Pages chunk POSITIONS (codec blocks
+//! chunk features — they compose: a page holds whole rows). ONE allocation unit = a page GROUP:
+//! the {K,V}-pages of every owning layer for the same ``page_rows``-position span, so a session's
+//! block table is one int per span, uniform across layers and both sides. Shared-KV layers alias
+//! their source's blob (``blob_of``), mirroring the flat prefix walk. Keep the pool alive (and in
+//! place) as long as its sessions; it is plain data — ``delete`` frees everything at the end.
+struct KVPool {
+    page_rows : int64            // P: positions per page (fixed at create)
+    kdt : KVDtype                // KV codec of every session in this pool
+    vdt : KVDtype
+    nblobs : int64               // owning layers (shared-KV layers alias — see blob_of)
+    capacity_groups : int64      // groups each blob currently holds (grows geometrically)
+    blob_of : array<int64>       // layer -> owning blob index (shared layers -> their source's)
+    krow_bytes : array<int64>    // per blob: one position row's K bytes
+    vrow_bytes : array<int64>
+    kblobs : array<array<uint8>> // per blob: capacity_groups pages of page_rows rows each
+    vblobs : array<array<uint8>>
+    free_groups : array<int>     // LIFO free list
+    refcnt : array<int>          // per group; 0/1 today (the prefix cache bumps it later)
+}
+
 //! Per-step scratch buffers and the KV cache (allocated once, reused every token).
 struct Session {
     n_past : int64            // absolute position of the next token to eval (0 at session start); advanced by eval()
@@ -1449,6 +1470,11 @@ struct Session {
     kv_bprefix_k : array<int64>  // per-layer row-BYTE prefix (seq_len-independent)
     kv_bprefix_v : array<int64>
     kv_runs : array<KVRun>       // per-layer physical-run scratch (kv_runs fills it; flat = 1 entry)
+    // paged sessions (make_run_state_paged): the cache lives in a caller-owned pool and the flat
+    // slabs above stay EMPTY; block_table[i] = the page group holding positions [i*P, (i+1)*P),
+    // grown on demand by kv_ensure. Flat sessions: kv_pool == null, block_table empty.
+    @do_not_delete kv_pool : KVPool?   // borrowed — the pool outlives its sessions
+    block_table : array<int>
     // batched prefill scratch — empty until forward_prefill sizes them to npos × ... (see forward_prefill)
     x_b : array<float>        // residual stream (npos x dim)
     xb_b : array<float>       // rmsnorm / attention out (npos x dim)
@@ -1526,7 +1552,8 @@ struct Session {
 
 //! Allocate the run state sized to a model. `kdt`/`vdt` pick the KV-cache codec for THIS session
 //! (no process-global state — sessions with different codecs coexist, models run in parallel).
-def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDtype.f32) : Session {
+//! `alloc_cache = false` skips the flat cache slabs (paged sessions and cache-less scratch).
+def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDtype.f32; alloc_cache : bool = true) : Session {
     var s : Session
     // qd = n_heads * head_size, the query / attention-output width. == dim for the llama family,
     // but Gemma2 has qd (2048) != dim (2304), so q and the attention scratch xb size to max(dim, qd).
@@ -1602,8 +1629,10 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
             vrow += kv_row_bytes(s.kv_dtype_v, layer_kv_dim(c, l))
         }
     }
-    s.key_cache |> resize(c.seq_len * krow)
-    s.value_cache |> resize(c.seq_len * vrow)
+    if (alloc_cache) {
+        s.key_cache |> resize(c.seq_len * krow)
+        s.value_cache |> resize(c.seq_len * vrow)
+    }
     s.sample_scratch |> resize(c.vocab_size)
     s.rng = random_seed(1234)
     return <- s
@@ -1614,6 +1643,32 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
 //! `kdt`/`vdt` pick this session's KV-cache codec (per-session state, no globals).
 def create_session_(model : Model; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDtype.f32) : Session {
     return <- make_run_state(model.config, kdt, vdt)
+}
+
+//! Allocate a PAGED run state over a caller-owned pool: the flat slabs stay empty and cache pages
+//! come from `pool` on demand (kv_ensure), so KV memory tracks actual context. The pool must
+//! outlive the session and stay in place; release the pages (release_kv_pages_) when done.
+def make_run_state_paged(c : Config; var pool : KVPool) : Session {
+    if (int64(length(pool.blob_of)) != c.n_layers) {
+        panic("make_run_state_paged: pool was built for a different model ({length(pool.blob_of)} layers vs {c.n_layers})")
+    }
+    for (l in range64(c.n_layers)) {
+        if (pool.krow_bytes[pool.blob_of[l]] != kv_row_bytes(pool.kdt, layer_kv_dim(c, l))) {
+            panic("make_run_state_paged: pool row bytes mismatch at layer {l} — pool built for a different geometry")
+        }
+    }
+    var s <- make_run_state(c, pool.kdt, pool.vdt, false)
+    unsafe {
+        s.kv_pool = addr(pool)
+    }
+    // paged run scratch: a window can span every page of the (post-cap) context
+    s.kv_runs |> resize(int((c.seq_len + pool.page_rows - 1l) / pool.page_rows + 1l))
+    return <- s
+}
+
+//! `create_session_`'s paged twin — see make_run_state_paged / create_kv_pool_.
+def create_session_(model : Model; var pool : KVPool) : Session {
+    return <- make_run_state_paged(model.config, pool)
 }
 
 //! THE eval primitive: run `tokens` at the session's current position and advance it. Prefill =
@@ -1947,22 +2002,159 @@ struct KVRun {
 }
 
 //! Fill `runs` with the physical runs covering absolute positions [lo, hi); returns the run count.
-//! THE flat/paged branch lives here: a flat session is always exactly one run. `runs` is caller
-//! scratch (Session.kv_runs / BatchWorkspace.runs_b), sized ahead to the worst case.
-[unused_argument(s)]   // the paged branch (block tables) reads the session; flat needs only the range
+//! THE flat/paged branch lives here: a flat session is always exactly one run; a paged one gets a
+//! run per block-table page span (physically-consecutive spans merge). `runs` is caller scratch
+//! (Session.kv_runs / BatchWorkspace.runs_b), sized ahead to the worst case.
 def kv_runs(s : Session; lo, hi : int64; var runs : array<KVRun>; at : int64 = 0l) : int64 {
     if (hi <= lo) {
         return 0l
     }
-    // flat cache: one contiguous slab — one run, physical row == absolute position
-    runs[at] = KVRun(j0 = lo, j1 = hi, row0 = lo)
-    return 1l
+    if (s.kv_pool == null) {
+        // flat cache: one contiguous slab — one run, physical row == absolute position
+        runs[at] = KVRun(j0 = lo, j1 = hi, row0 = lo)
+        return 1l
+    }
+    let pr = s.kv_pool.page_rows
+    var n = 0l
+    var j = lo
+    while (j < hi) {
+        let pj1 = min(hi, (j / pr + 1l) * pr)
+        let row0 = int64(s.block_table[j / pr]) * pr + j % pr
+        if (n > 0l && runs[at + n - 1l].row0 + (j - runs[at + n - 1l].j0) == row0) {
+            runs[at + n - 1l].j1 = pj1   // physically consecutive with the previous run: extend
+        } else {
+            runs[at + n] = KVRun(j0 = j, j1 = pj1, row0 = row0)
+            n ++
+        }
+        j = pj1
+    }
+    return n
 }
 
 //! Physical row index of absolute position `pos` — the single-row-store analog of kv_runs.
-//! Flat cache: identity. (Paged sessions translate through the block table.)
-[unused_argument(s)]   // same seam as kv_runs: the paged branch reads the session
-def kv_phys_row(s : Session; pos : int64) : int64 => pos
+//! Flat cache: identity; paged: through the block table (page group * P + in-page offset).
+def kv_phys_row(s : Session; pos : int64) : int64 {
+    if (s.kv_pool == null) {
+        return pos
+    }
+    let pr = s.kv_pool.page_rows
+    return int64(s.block_table[pos / pr]) * pr + pos % pr
+}
+
+//! Layer l's base byte pointer in the key cache — THE flat/paged storage branch, hoisted once per
+//! driver preamble. Flat: the session slab at its byte prefix; paged: the pool's owning blob for l
+//! (physical rows index it uniformly — group * page_rows + in-page offset, exactly what kv_runs /
+//! kv_phys_row produce; shared-KV layers alias their source's blob through blob_of). Hoist AFTER
+//! kv_ensure: pool growth resizes blobs, which would dangle this pointer.
+def kv_layer_kbase(var s : Session; l, seq_len : int64) : uint8? {
+    unsafe {
+        if (s.kv_pool != null) {
+            return addr(s.kv_pool.kblobs[s.kv_pool.blob_of[l]][0])
+        }
+        return addr(s.key_cache[0]) + kv_base_k(s, l, seq_len)
+    }
+}
+
+//! Layer l's base byte pointer in the value cache — see kv_layer_kbase.
+def kv_layer_vbase(var s : Session; l, seq_len : int64) : uint8? {
+    unsafe {
+        if (s.kv_pool != null) {
+            return addr(s.kv_pool.vblobs[s.kv_pool.blob_of[l]][0])
+        }
+        return addr(s.value_cache[0]) + kv_base_v(s, l, seq_len)
+    }
+}
+
+// ===== paged KV pool (E2) =====
+
+//! Create a paged KV pool for `c`'s cache geometry: sessions created over it (make_run_state_paged)
+//! allocate `page_rows`-position page groups on demand instead of the full seq_len slab, so cache
+//! memory tracks actual context and many sessions share one elastic pool.
+def create_kv_pool_(c : Config; page_rows : int64; kdt, vdt : KVDtype) : KVPool {
+    if (page_rows <= 0l) {
+        panic("create_kv_pool: page_rows must be positive (got {page_rows})")
+    }
+    var p = KVPool(page_rows = page_rows, kdt = kdt, vdt = vdt)
+    p.blob_of |> reserve(int(c.n_layers))
+    for (l in range64(c.n_layers)) {
+        let src = layer_kv_source(c, l)
+        if (src != l) {
+            p.blob_of |> push(p.blob_of[src])   // shared-KV layer: alias the source's blob
+        } else {
+            p.blob_of |> push(p.nblobs)
+            p.krow_bytes |> push(kv_row_bytes(kdt, layer_kv_dim(c, l)))
+            p.vrow_bytes |> push(kv_row_bytes(vdt, layer_kv_dim(c, l)))
+            p.nblobs ++
+        }
+    }
+    p.kblobs |> resize(int(p.nblobs))
+    p.vblobs |> resize(int(p.nblobs))
+    return <- p
+}
+
+// Double the pool's group capacity. Every blob resizes IN PLACE — a hoisted cache pointer would
+// dangle, which is why kv_ensure runs at the top of the forward entries, before any hoist.
+def private kv_pool_grow(var p : KVPool) {
+    let oldcap = p.capacity_groups
+    let newcap = oldcap <= 0l ? 4l : oldcap * 2l
+    for (b in range64(p.nblobs)) {
+        p.kblobs[b] |> resize(int(newcap * p.page_rows * p.krow_bytes[b]))
+        p.vblobs[b] |> resize(int(newcap * p.page_rows * p.vrow_bytes[b]))
+    }
+    p.refcnt |> resize(int(newcap))
+    var g = int(newcap)
+    while (g > int(oldcap)) {   // push high->low so the LOWEST new group pops first
+        g --
+        p.free_groups |> push(g)
+    }
+    p.capacity_groups = newcap
+}
+
+//! Allocate one page group (refcount 1): pop the free list, growing the pool when it runs dry.
+def kv_pool_alloc_group(var p : KVPool) : int {
+    if (empty(p.free_groups)) {
+        kv_pool_grow(p)
+    }
+    let g = p.free_groups[length(p.free_groups) - 1]
+    p.free_groups |> pop()
+    p.refcnt[g] = 1
+    return g
+}
+
+//! Drop one reference to group `g`; at zero the group returns to the free list.
+def kv_pool_release_group(var p : KVPool; g : int) {
+    verify(p.refcnt[g] > 0)
+    p.refcnt[g] --
+    if (p.refcnt[g] == 0) {
+        p.free_groups |> push(g)
+    }
+}
+
+//! Return every page this session holds to its pool (flat sessions: no-op). Call when the session
+//! is done — pages are pool-owned, so deleting the session alone leaks them from the pool. The
+//! session itself stays alive but loses its cached context; to reuse it, also reset n_past to 0.
+def release_kv_pages_(var s : Session) {
+    if (s.kv_pool == null) {
+        return
+    }
+    for (g in s.block_table) {
+        kv_pool_release_group(*s.kv_pool, g)
+    }
+    s.block_table |> clear()
+}
+
+//! Grow this session's block table to cover positions [0, upto) — the ONLY place a paged session
+//! allocates cache. Runs at the top of forward/forward_prefill/eval_batch, BEFORE any cache-pointer
+//! hoist: group allocation may resize the pool's blobs. Flat sessions: no-op.
+def kv_ensure(var s : Session; upto : int64) {
+    if (s.kv_pool == null) {
+        return
+    }
+    let np = (upto + s.kv_pool.page_rows - 1l) / s.kv_pool.page_rows
+    while (int64(length(s.block_table)) < np) {
+        s.block_table |> push(kv_pool_alloc_group(*s.kv_pool))
+    }
+}
 
 //! Store n f32 values into a KV-cache layer slab at (row, sub-row element offset). dst0 = the
 //! layer's base byte pointer (see kv_base_k/kv_base_v). Codec dispatch happens HERE, once per
@@ -2221,13 +2413,11 @@ def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv 
 // (the vectorized codec store; bounds-checked array copy doesn't vectorize) — a flat cache is one
 // run, making the chunk ONE multi-row call exactly as before. Threaded over positions (workers own
 // disjoint cache slices; runs partition positions). Self-gates on g_kv_store_par_threshold.
-// kbase/vbase = the layer's slab base BYTES; runs cover [start_pos, start_pos + npos).
-def private kv_store_batch(var key_cache : array<uint8>; var value_cache : array<uint8>;
+// kcp/vcp = the layer's base byte pointers (kv_layer_kbase); runs cover [start_pos, start_pos + npos).
+def private kv_store_batch(var kcp : uint8?; var vcp : uint8?;
                            kdt, vdt : KVDtype; k_b : array<float>; v_b : array<float>;
-                           runs : KVRun const?; nrun, kbase, vbase, start_pos, npos, kv_dim : int64) {
+                           runs : KVRun const?; nrun, start_pos, npos, kv_dim : int64) {
     unsafe {
-        var kcp = addr(key_cache[0]) + kbase
-        var vcp = addr(value_cache[0]) + vbase
         let kbp = reinterpret<float const?>(addr(k_b[0]))
         let vbp = reinterpret<float const?>(addr(v_b[0]))
         maybe_parallel_for(kv_dim * npos >= g_kv_store_par_threshold, 0, int(npos), get_dispatch_lanes()) $(rb, re) {
@@ -2623,8 +2813,6 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
     let qd = n_heads * head_size
     let kv_mul = n_heads / n_kv_heads
     let scale = c.attn_scale > 0.0 ? c.attn_scale : 1.0 / sqrt(float(head_size))
-    let kbase = kv_base_k(s, l, c.seq_len)   // this layer's slab base BYTES (aliases the source layer when shared)
-    let vbase = kv_base_v(s, l, c.seq_len)
     let is_sliding = layer_is_sliding(c, l)
     let kstart = (is_sliding && pos + 1l > c.sliding_window) ? (pos + 1l - c.sliding_window) : 0l
     let cnt = pos + 1l - kstart
@@ -2692,8 +2880,8 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
         var attp = addr(s.att[0])
         var xqp = addr(s.xq[0])
         var xsp = addr(s.xs[0])
-        var kcl = addr(s.key_cache[0]) + kbase     // layer-base byte pointers (stores + the _d read dispatch)
-        var vcl = addr(s.value_cache[0]) + vbase
+        var kcl = kv_layer_kbase(s, l, c.seq_len)  // layer-base byte pointers (stores + the _d read dispatch)
+        var vcl = kv_layer_vbase(s, l, c.seq_len)
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))   // this layer's physical runs (fork-safe hoist)
         // weight region bases (element offsets into the Q8 blob, scales at /32)
         let wqb = reinterpret<int8 const?>(addr(t.qblob[0]))
@@ -3068,13 +3256,13 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     let qd = n_heads * head_size       // query / attention-output width (== dim except Gemma2/gemma4)
     let kv_mul = n_heads / n_kv_heads
     let scale = c.attn_scale > 0.0 ? c.attn_scale : 1.0 / sqrt(float(head_size))
-    let kbase = kv_base_k(s, l, c.seq_len)   // this layer's slab base BYTES (aliases the source layer when shared)
-    let vbase = kv_base_v(s, l, c.seq_len)
+    var kcl = kv_layer_kbase(s, l, c.seq_len)   // layer-base byte pointers (aliases the source layer when shared)
+    var vcl = kv_layer_vbase(s, l, c.seq_len)
     // Sliding-window (local) vs global attention per the arch's layer pattern (Gemma2 alternates,
     // Gemma3 5:1). The window covers all positions when pos < window, so it's a no-op for short contexts.
     let is_sliding = layer_is_sliding(c, l)
     // gemma-4 E-series shared-KV layer: no attn_k/attn_v of its own — project Q only and attend
-    // against the SOURCE layer's cached K/V (kbase/vbase already alias the source's slab).
+    // against the SOURCE layer's cached K/V (kcl/vcl already alias the source's slab).
     let kv_shared = t.kv_src[l] != l
     let kstart = (is_sliding && pos + 1l > c.sliding_window) ? (pos + 1l - c.sliding_window) : 0l
     let cnt = pos + 1l - kstart
@@ -3143,9 +3331,9 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     if (!kv_shared) {
         let ts_kv = ref_time_ticks()
         unsafe {
-            kv_store_row(addr(s.key_cache[0]) + kbase, s.kv_dtype_k, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
+            kv_store_row(kcl, s.kv_dtype_k, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
                 reinterpret<float const?>(addr(s.k[0])))
-            kv_store_row(addr(s.value_cache[0]) + vbase, s.kv_dtype_v, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
+            kv_store_row(vcl, s.kv_dtype_v, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
                 reinterpret<float const?>(addr(s.v[0])))
         }
         prof_add("kv_store", ts_kv)
@@ -3169,8 +3357,6 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     let nrun = kv_runs(s, kstart, pos + 1l, s.kv_runs)   // physical runs of this layer's window (flat: 1)
     unsafe {
         let qp = reinterpret<float const?>(addr(s.q[0]))
-        let kcl = addr(s.key_cache[0]) + kbase   // layer-base byte pointers (the _d read dispatch)
-        let vcl = addr(s.value_cache[0]) + vbase
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb[0])
         var attp = addr(s.att[0])
@@ -3770,6 +3956,7 @@ def private embed_row(t : Model; token : int64; var dst : float?) {
 def forward(t : Model; var s : Session; token, pos : int64) {
     let c = t.config
     let dim = c.dim
+    kv_ensure(s, pos + 1l)   // paged sessions: grow the block table BEFORE any cache-pointer hoist
 
     // token embedding: row `token` into the residual stream
     let ts_embed = ref_time_ticks()
@@ -4382,7 +4569,7 @@ def private attn_head_classic_d(var attp_h : float?; var xbp : float?; qp : floa
     }
 }
 
-def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, head_size, qd, kv_dim,
+def private prefill_attention(var s : Session; kcl, vcl : uint8 const?; npos, start_pos, head_size, qd, kv_dim,
                               n_heads, kv_mul : int64; scale : float;
                               is_sliding : bool; sliding_window : int64; attn_softcap : float;
                               sinksp : float const?) {   // this layer's per-head sink logits; null = no sinks
@@ -4396,8 +4583,6 @@ def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, he
     let nrun = kv_runs(s, kstart_min, start_pos + npos, s.kv_runs)
     unsafe {
         let qp = reinterpret<float const?>(addr(s.q_b[0]))
-        let kcl = addr(s.key_cache[0]) + kbase   // layer-base byte pointers (the _d read dispatch)
-        let vcl = addr(s.value_cache[0]) + vbase
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb_b[0])
         // att_b is sized only for the blocked/classic modes (flash packs into fa_* instead), so the
@@ -4583,8 +4768,8 @@ def private attention_std_prefill(t : Model; var s : Session; l : int64; npos : 
     let qd = n_heads * head_size
     let kv_mul = n_heads / n_kv_heads
     let scale = c.attn_scale > 0.0 ? c.attn_scale : 1.0 / sqrt(float(head_size))
-    let kbase = kv_base_k(s, l, c.seq_len)   // this layer's slab base BYTES (aliases the source layer when shared)
-    let vbase = kv_base_v(s, l, c.seq_len)
+    var kcl = kv_layer_kbase(s, l, c.seq_len)   // layer-base byte pointers (aliases the source layer when shared)
+    var vcl = kv_layer_vbase(s, l, c.seq_len)
     let is_sliding = layer_is_sliding(c, l)
     let kv_shared = t.kv_src[l] != l
     attn_qkv_rope_prefix(t, s, l, npos, start_pos)
@@ -4595,8 +4780,8 @@ def private attention_std_prefill(t : Model; var s : Session; l : int64; npos : 
         let ts_kv = ref_time_ticks()
         let store_nrun = kv_runs(s, start_pos, start_pos + npos, s.kv_runs)   // where the new rows land
         unsafe {
-            kv_store_batch(s.key_cache, s.value_cache, s.kv_dtype_k, s.kv_dtype_v, s.k_b, s.v_b,
-                reinterpret<KVRun const?>(addr(s.kv_runs[0])), store_nrun, kbase, vbase, start_pos, npos, kv_dim)
+            kv_store_batch(kcl, vcl, s.kv_dtype_k, s.kv_dtype_v, s.k_b, s.v_b,
+                reinterpret<KVRun const?>(addr(s.kv_runs[0])), store_nrun, start_pos, npos, kv_dim)
         }
         prof_add("kv_store", ts_kv)
     }
@@ -4607,7 +4792,7 @@ def private attention_std_prefill(t : Model; var s : Session; l : int64; npos : 
     let sinksp = (c.attn_sinks
         ? unsafe(reinterpret<float const?>(unsafe(addr(t.fblob[t.sinks_off + l * n_heads]))))
         : null)
-    prefill_attention(s, kbase, vbase, npos, start_pos, head_size, qd, kv_dim, n_heads, kv_mul, scale,
+    prefill_attention(s, kcl, vcl, npos, start_pos, head_size, qd, kv_dim, n_heads, kv_mul, scale,
                       is_sliding, c.sliding_window, c.attn_logit_softcap, sinksp)
     prof_add("attn", ts_attn)
     attn_out_suffix(t, s, l, npos)
@@ -5312,6 +5497,7 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
         }
         return
     }
+    kv_ensure(s, start_pos + npos)   // paged sessions: grow the block table BEFORE any cache-pointer hoist
     forward_prefill_alloc(t, s, npos, start_pos)
 
     // token embeddings -> residual stream x_b [npos x dim]
@@ -5349,6 +5535,7 @@ def forward_prefill_embd(t : Model; var s : Session; embd : array<float>; npos, 
     if (int64(length(embd)) < npos * t.config.dim) {
         panic("forward_prefill_embd: embd has {length(embd)} floats — npos={npos} rows of dim={t.config.dim} need {npos * t.config.dim}")
     }
+    kv_ensure(s, start_pos + npos)   // paged sessions: grow the block table BEFORE any cache-pointer hoist
     forward_prefill_alloc(t, s, npos, start_pos)
     let dim = t.config.dim
     let ts_embed = ref_time_ticks()
@@ -5575,17 +5762,15 @@ struct BatchWorkspace {
     // delete of a plain array<T?> CASCADES to the pointees, which would free the sessions' cache blobs
     @do_not_delete kbase : array<uint8?>
     @do_not_delete vbase : array<uint8?>
-    runs_b : array<KVRun>     // per-row physical runs, flattened rows × max-runs (flat: 1 per row)
+    runs_b : array<KVRun>     // per-row physical runs, flattened rows × max-runs (flat rows: 1 each)
     nrun_b : array<int64>     // per-row run count
 }
 
 def create_batch_workspace_(model : Model) : BatchWorkspace {
     var ws : BatchWorkspace
-    ws.scr <- make_run_state(model.config)
     // the scratch Session never owns cache or sampler state — eval_batch reads/writes the real
-    // sessions' caches through kbase/vbase; drop the big allocations before they're ever touched
-    delete ws.scr.key_cache
-    delete ws.scr.value_cache
+    // sessions' caches through kbase/vbase (flat) or the batch's pool (paged)
+    ws.scr <- make_run_state(model.config, KVDtype.f32, KVDtype.f32, false)
     delete ws.scr.sample_scratch
     return <- ws
 }
@@ -5622,7 +5807,7 @@ def private batch_decode_alloc(t : Model; var s : Session; nrows : int64) {
 // One layer's batched-decode attention: shared prefix (norm → QKV GEMM → qk/v-norm → per-row RoPE
 // via the positions table) → scatter-store each row's k/v into ITS session's cache → per-(row, head)
 // decode attention through the codec seam worker → shared suffix (wo GEMM → post-norm → residual).
-def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows : int64) {
+def private attention_batch_decode(t : Model; var ws : BatchWorkspace; sessions : array<Session?>; l, nrows : int64) {
     let c = t.config
     let kv_dim = layer_kv_dim(c, l)
     let head_size = layer_head_size(c, l)
@@ -5634,8 +5819,13 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
     let is_sliding = layer_is_sliding(c, l)
     let swin = c.sliding_window
     let kv_shared = t.kv_src[l] != l
-    let kbb = kv_base_k(ws.scr, l, c.seq_len)   // layer slab base BYTES — uniform across the batch
-    let vbb = kv_base_v(ws.scr, l, c.seq_len)   // (ws.scr carries the batch's dtypes + prefixes)
+    // flat rows address each session's slab (per-row base + the uniform layer byte offset); paged
+    // rows all address the batch's ONE pool, whose owning blob for l is the uniform layer base
+    let paged = ws.scr.kv_pool != null
+    let kbb = paged ? 0l : kv_base_k(ws.scr, l, c.seq_len)   // layer slab base BYTES — uniform across the batch
+    let vbb = paged ? 0l : kv_base_v(ws.scr, l, c.seq_len)   // (ws.scr carries the batch's dtypes + prefixes)
+    var pkcl = paged ? kv_layer_kbase(ws.scr, l, c.seq_len) : null
+    var pvcl = paged ? kv_layer_vbase(ws.scr, l, c.seq_len) : null
     let kdt = ws.scr.kv_dtype_k
     let vdt = ws.scr.kv_dtype_v
     // start_pos is only read by the classic (non-table) rope path, which eval_batch_ never routes
@@ -5647,8 +5837,9 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
             let kbp = reinterpret<float const?>(addr(ws.scr.k_b[0]))
             let vbp = reinterpret<float const?>(addr(ws.scr.v_b[0]))
             for (i in range64(nrows)) {
-                kv_store_row(ws.kbase[i] + kbb, kdt, kv_dim, ws.positions[i], 0l, kv_dim, kbp + i * kv_dim)
-                kv_store_row(ws.vbase[i] + vbb, vdt, kv_dim, ws.positions[i], 0l, kv_dim, vbp + i * kv_dim)
+                let prow = kv_phys_row(*sessions[i], ws.positions[i])   // flat: identity
+                kv_store_row(paged ? pkcl : ws.kbase[i] + kbb, kdt, kv_dim, prow, 0l, kv_dim, kbp + i * kv_dim)
+                kv_store_row(paged ? pvcl : ws.vbase[i] + vbb, vdt, kv_dim, prow, 0l, kv_dim, vbp + i * kv_dim)
             }
         }
         prof_add("kv_store", ts_kv)
@@ -5659,18 +5850,17 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
     let ts_attn = ref_time_ticks()
     var maxctx = 0l
     var work = 0l   // Σ 2·cnt_i·head_size MACs per head
-    ws.runs_b |> resize(nrows)   // one run per row while rows are flat (paged rows re-size per table)
+    // runs_b row stride: a flat row is always one run; a paged row can span every page of the context
+    let maxruns = paged ? (c.seq_len + ws.scr.kv_pool.page_rows - 1l) / ws.scr.kv_pool.page_rows + 1l : 1l
+    ws.runs_b |> resize(nrows * maxruns)
     ws.nrun_b |> resize(nrows)
     for (i in range64(nrows)) {
         let pos = ws.positions[i]
         let kstart = (is_sliding && pos + 1l > swin) ? (pos + 1l - swin) : 0l
         maxctx = max(maxctx, pos + 1l - kstart)
         work += 2l * (pos + 1l - kstart) * head_size
-        // flat rows: one physical run per row (E2 routes this through the row's block table)
-        ws.runs_b[i] = KVRun(j0 = kstart, j1 = pos + 1l, row0 = kstart)
-        ws.nrun_b[i] = 1l
+        ws.nrun_b[i] = kv_runs(*sessions[i], kstart, pos + 1l, ws.runs_b, i * maxruns)   // flat: 1 identity run
     }
-    let maxruns = 1l   // runs_b row stride
     ws.scr.att_b |> resize(nrows * n_heads * maxctx)
     let attn_softcap = c.attn_logit_softcap
     let attn_lanes = min(int(nrows * n_heads), lanes_for_work(work * n_heads, g_gemv_lane_cap))
@@ -5698,8 +5888,9 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
                     let qoff = hh * head_size
                     let kvhoff = (hh / kv_mul) * head_size
                     attn_head_decode_d(attp + ix * maxctx, xbp + ii * qd, qp + ii * qd,
-                        kbpp[ii] + kbb, vbpp[ii] + vbb, kdt, vdt, runsbp + ii * maxruns,
-                        nrunbp[ii], qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                        paged ? pkcl : kbpp[ii] + kbb, paged ? pvcl : vbpp[ii] + vbb, kdt, vdt,
+                        runsbp + ii * maxruns, nrunbp[ii], qoff, kvhoff, kstart, cnt, kv_dim, head_size,
+                        hh, scale, attn_softcap, sinksp)
                 }
             }
         }
@@ -5710,10 +5901,10 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
 
 //! One synchronous batched decode step: row i evals tokens[i] at sessions[i]'s position, logits
 //! scatter into sessions[i].logits, and each session advances by one. Sessions must be distinct,
-//! same-geometry (one model, equal cache sizes, uniform KV dtype) and have room for one position.
-//! Ragged batches: pass only the still-active sessions (B may shrink between calls). B == 1, q4
-//! weights, a non-std attention arch, or the classic (non-table) rope path fall back to the exact
-//! per-row forward() loop.
+//! same-geometry (one model, equal cache sizes, uniform KV dtype; paged sessions share ONE pool —
+//! never mix paged and flat rows) and have room for one position. Ragged batches: pass only the
+//! still-active sessions (B may shrink between calls). B == 1, q4 weights, a non-std attention
+//! arch, or the classic (non-table) rope path fall back to the exact per-row forward() loop.
 def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session?>; tokens : array<int64>) {   // nolint:LINT014 — rows mutate THROUGH the pointers; a const array constifies the pointees
     let c = t.config
     let nrows = int64(length(sessions))
@@ -5736,13 +5927,16 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
             }
         }
     }
-    let s0 = sessions[0]
+    var s0 = sessions[0]
     for (i in range64(1l, nrows)) {
         let sp = sessions[i]
         if (sp.kv_dtype_k != s0.kv_dtype_k || sp.kv_dtype_v != s0.kv_dtype_v) {
             panic("eval_batch: sessions[{i}] KV dtype differs from sessions[0] — the batch must be uniform")
         }
-        if (length(sp.key_cache) != length(s0.key_cache) || length(sp.value_cache) != length(s0.value_cache)) {
+        if (sp.kv_pool != s0.kv_pool) {
+            panic("eval_batch: sessions[{i}] KV pool differs from sessions[0] — one pool (or all-flat) per batch")
+        }
+        if (s0.kv_pool == null && (length(sp.key_cache) != length(s0.key_cache) || length(sp.value_cache) != length(s0.value_cache))) {
             panic("eval_batch: sessions[{i}] cache size differs from sessions[0] — same model + same seq_len required")
         }
     }
@@ -5757,21 +5951,30 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
         }
         return
     }
-    // snapshot the batch's cache geometry onto the scratch Session (kv_base_* and the store/read
-    // dispatch read it there) and capture each row's position + cache base
+    // snapshot the batch's cache geometry onto the scratch Session (kv_base_* / kv_layer_* and the
+    // store/read dispatch read it there) and capture each row's position + cache base. kv_ensure
+    // runs for every row FIRST: paged growth resizes pool blobs, so no pool pointer may be hoisted
+    // until all rows have their pages.
     ws.scr.kv_dtype_k = s0.kv_dtype_k
     ws.scr.kv_dtype_v = s0.kv_dtype_v
     ws.scr.kv_bprefix_k := s0.kv_bprefix_k
     ws.scr.kv_bprefix_v := s0.kv_bprefix_v
+    ws.scr.kv_pool = s0.kv_pool
     ws.positions |> resize(nrows)
     ws.kbase |> resize(nrows)
     ws.vbase |> resize(nrows)
     for (i in range64(nrows)) {
         var sp = sessions[i]
+        kv_ensure(*sp, sp.n_past + 1l)
         ws.positions[i] = sp.n_past
-        unsafe {
-            ws.kbase[i] = addr(sp.key_cache[0])
-            ws.vbase[i] = addr(sp.value_cache[0])
+        if (s0.kv_pool == null) {
+            unsafe {
+                ws.kbase[i] = addr(sp.key_cache[0])
+                ws.vbase[i] = addr(sp.value_cache[0])
+            }
+        } else {
+            ws.kbase[i] = null   // paged rows address the pool blobs, hoisted per layer
+            ws.vbase[i] = null
         }
     }
     batch_decode_alloc(t, ws.scr, nrows)
@@ -5802,7 +6005,7 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
     prof_add("rope_build", ts_rope_build)
     // layer stack: batched attention (per-row cache scatter) + the arch's batched FFN (position-free)
     for (l in range64(c.n_layers)) {
-        attention_batch_decode(t, ws, l, nrows)
+        attention_batch_decode(t, ws, sessions, l, nrows)
         t.blocks.ffn_prefill(t, ws.scr, l, nrows)
     }
     // final rmsnorm + classifier over ALL rows, then per-row softcap/pins scattered per session

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -64,8 +64,9 @@ enum AttnPrefillMode {
     flash
 }
 
-//! KV-cache storage codec, chosen per session at create time (llama.cpp -ctk/-ctv analog; K and V
-//! carry independent dtypes). f32 is today's exact baseline. Select via set_kv_cache_dtype.
+//! KV-cache storage codec, chosen per session at create time via ``create_session``/``create_chat``
+//! (llama.cpp -ctk/-ctv analog; K and V carry independent dtypes). f16 is the facade default
+//! (half the KV bytes, near-lossless); f32 is the bit-exact reference.
 enum KVDtype {
     f32
     f16
@@ -1447,6 +1448,7 @@ struct Session {
     value_cache : array<uint8>
     kv_bprefix_k : array<int64>  // per-layer row-BYTE prefix (seq_len-independent)
     kv_bprefix_v : array<int64>
+    kv_runs : array<KVRun>       // per-layer physical-run scratch (kv_runs fills it; flat = 1 entry)
     // batched prefill scratch — empty until forward_prefill sizes them to npos × ... (see forward_prefill)
     x_b : array<float>        // residual stream (npos x dim)
     xb_b : array<float>       // rmsnorm / attention out (npos x dim)
@@ -1465,6 +1467,7 @@ struct Session {
     fa_v : array<float>       // packed V tile  [n_heads × KV × head_size]
     fa_kq : array<float>      // score / prob tile [n_heads × QT × KV]
     fa_vkq : array<float>     // output accumulator [n_heads × QT × head_size]
+    fa_tmp : array<float>     // per-head one-row dequant staging for the Kᵀ pack [n_heads × head_size]
     // RoPE cos/sin table (empty until forward_prefill builds it once per prefill, sized npos × head_size/2).
     // angle = pos*freq is identical across all heads AND layers, so cos/sin is precomputed once here
     // instead of recomputed per head/layer. Kept LOCAL (run-state, not a module global) so jobque
@@ -1575,6 +1578,7 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
     s.xq2 |> resize(ffw)        // fused-FFN chain requant (see the Session field comment)
     s.xs2 |> resize(ffw / 32l)
     s.chain_stages |> resize(3)
+    s.kv_runs |> resize(1)      // flat cache: every window is one physical run (paged sessions re-size)
     // KV cache: walk the per-layer row-byte prefixes (the byte analog of layout_offsets'
     // kv_row_prefix walk — shared-KV layers alias their source's slab and contribute no width).
     // Sizing is exact per dtype; for uniform models this equals seq_len * kv_row_total *
@@ -1931,6 +1935,35 @@ def kv_base_k(s : Session; l, seq_len : int64) : int64 => s.kv_bprefix_k[l] * se
 //! Layer l's slab base (BYTES) in the value cache.
 def kv_base_v(s : Session; l, seq_len : int64) : int64 => s.kv_bprefix_v[l] * seq_len
 
+//! One run of positions whose rows are PHYSICALLY consecutive in the cache: absolute positions
+//! [j0, j1), with the row of j0 living at physical row index row0 (flat cache: row0 == j0 always).
+//! Attention workers iterate runs and address rows as (row0 - j0 + j) — the flat case degenerates
+//! to a single run with rowbase 0, keeping the inner loop instruction-identical to the pre-run
+//! code. Paged caches (block tables) produce one run per page span.
+struct KVRun {
+    j0 : int64
+    j1 : int64
+    row0 : int64
+}
+
+//! Fill `runs` with the physical runs covering absolute positions [lo, hi); returns the run count.
+//! THE flat/paged branch lives here: a flat session is always exactly one run. `runs` is caller
+//! scratch (Session.kv_runs / BatchWorkspace.runs_b), sized ahead to the worst case.
+[unused_argument(s)]   // the paged branch (block tables) reads the session; flat needs only the range
+def kv_runs(s : Session; lo, hi : int64; var runs : array<KVRun>; at : int64 = 0l) : int64 {
+    if (hi <= lo) {
+        return 0l
+    }
+    // flat cache: one contiguous slab — one run, physical row == absolute position
+    runs[at] = KVRun(j0 = lo, j1 = hi, row0 = lo)
+    return 1l
+}
+
+//! Physical row index of absolute position `pos` — the single-row-store analog of kv_runs.
+//! Flat cache: identity. (Paged sessions translate through the block table.)
+[unused_argument(s)]   // same seam as kv_runs: the paged branch reads the session
+def kv_phys_row(s : Session; pos : int64) : int64 => pos
+
 //! Store n f32 values into a KV-cache layer slab at (row, sub-row element offset). dst0 = the
 //! layer's base byte pointer (see kv_base_k/kv_base_v). Codec dispatch happens HERE, once per
 //! row-store — never per element. Contract: either one partial row (sub + n <= kv_dim), or whole
@@ -1959,24 +1992,45 @@ def private kv_dot(a : float const?; b : float const?; n : int64) : float => dot
 def private kv_axpy(var d : float?; s : float const?; scale : float; n : int64) {
     axpy(d, s, scale, n)
 }
-def private kv_load(p : float const?; i : int64) : float => unsafe(p[i])
+def private kv_load(p : float const?; base, i : int64) : float => unsafe(p[base + i])
 def private kv_dot(a : float const?; b : uint16 const?; n : int64) : float => dot_f16(a, b, n)
 def private kv_axpy(var d : float?; s : uint16 const?; scale : float; n : int64) {
     axpy_f16(d, s, scale, n)
 }
-def private kv_load(p : uint16 const?; i : int64) : float => f16_to_f32(uint(unsafe(p[i])))
+def private kv_load(p : uint16 const?; base, i : int64) : float => f16_to_f32(uint(unsafe(p[base + i])))
+
+// Bulk one-row dequant into f32 scratch — the flash pack's per-row primitive (and any future
+// codec's bulk-dequant seam: q8_0 adds a cvt overload here, never a new pack shape).
+def private kv_row_to_f32(var d : float?; p : float const?; base, n : int64) {
+    unsafe {
+        copy_floats(d, p + base, n)
+    }
+}
+def private kv_row_to_f32(var d : float?; p : uint16 const?; base, n : int64) {
+    unsafe {
+        cvt_f16_to_f32(d, p + base, n)
+    }
+}
 
 // One decode attention head over one layer's cache slab — the attention_std_decode /
 // chain-decode stage-1 worker body, generic over the cache element type (float = f32; further
 // codecs add kv_dot/kv_axpy overloads and monomorphize here). kcp/vcp are LAYER-BASE typed
-// pointers; arow is this head's score row.
+// pointers; arow is this head's score row (window-relative: arow[j - kstart]). Cache rows are
+// found through `runs` (physical position runs, kv_runs contract): the flat single-run case is
+// instruction-identical to a direct kstart..kstart+cnt walk. kdim/khoff and vdim/vhoff are the
+// PER-SIDE row stride / head offset in the side's own units (elements for scalar codecs).
 def private attn_head_decode(var arow : float?; var xbp : float?; qp : float const?;
-                             kcp, vcp : auto const?;
-                             qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh : int64;
+                             kcp, vcp : auto const?; runs : KVRun const?;
+                             nrun, qoff, kdim, khoff, vdim, vhoff, kstart, cnt, head_size, hh : int64;
                              scale, attn_softcap : float; sinksp : float const?) {
     unsafe {
-        for (j in range64(cnt)) {
-            arow[j] = kv_dot(qp + qoff, kcp + (kstart + j) * kv_dim + kvhoff, head_size) * scale
+        for (r in range64(nrun)) {
+            let rj0 = max(runs[r].j0, kstart)
+            let rj1 = min(runs[r].j1, kstart + cnt)
+            let rowbase = runs[r].row0 - runs[r].j0
+            for (j in range64(rj0, rj1)) {
+                arow[j - kstart] = kv_dot(qp + qoff, kcp + (rowbase + j) * kdim + khoff, head_size) * scale
+            }
         }
         if (attn_softcap > 0.0) {  // Gemma2: soft-cap scores before softmax
             softcap(arow, cnt, attn_softcap)
@@ -1990,36 +2044,54 @@ def private attn_head_decode(var arow : float?; var xbp : float?; qp : float con
         for (i in range64(head_size)) {
             xbp[qoff + i] = 0.0
         }
-        for (j in range64(cnt)) {
-            kv_axpy(xbp + qoff, vcp + (kstart + j) * kv_dim + kvhoff, arow[j], head_size)
+        for (r in range64(nrun)) {
+            let rj0 = max(runs[r].j0, kstart)
+            let rj1 = min(runs[r].j1, kstart + cnt)
+            let rowbase = runs[r].row0 - runs[r].j0
+            for (j in range64(rj0, rj1)) {
+                kv_axpy(xbp + qoff, vcp + (rowbase + j) * vdim + vhoff, arow[j - kstart], head_size)
+            }
         }
     }
 }
 
 // Flash-decode sliced K pass (chain stage 1, nsl > 1): the slice's K rows stream once, dotted
-// against every q-head of the GQA group. Codec-generic like attn_head_decode.
-def private kv_slice_scores(var attp : float?; qp : float const?; kcp : auto const?;
-                            kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len : int64;
+// against every q-head of the GQA group. Codec-generic + run-walking like attn_head_decode;
+// the slice sub-window [kstart+j0, kstart+j1) intersects each run.
+def private kv_slice_scores(var attp : float?; qp : float const?; kcp : auto const?; runs : KVRun const?;
+                            nrun, kstart, j0, j1, kdim, khoff, head_size, qh0, kv_mul, seq_len : int64;
                             scale : float) {
     unsafe {
-        for (j in range64(j0, j1)) {
-            let koff = (kstart + j) * kv_dim + kvhoff
-            for (g in range64(kv_mul)) {
-                attp[(qh0 + g) * seq_len + j] = kv_dot(qp + (qh0 + g) * head_size, kcp + koff, head_size) * scale
+        for (r in range64(nrun)) {
+            let rj0 = max(runs[r].j0, kstart + j0)
+            let rj1 = min(runs[r].j1, kstart + j1)
+            let rowbase = runs[r].row0 - runs[r].j0
+            for (aj in range64(rj0, rj1)) {
+                let j = aj - kstart
+                let koff = (rowbase + aj) * kdim + khoff
+                for (g in range64(kv_mul)) {
+                    attp[(qh0 + g) * seq_len + j] = kv_dot(qp + (qh0 + g) * head_size, kcp + koff, head_size) * scale
+                }
             }
         }
     }
 }
 
 // Flash-decode sliced V pass: each V row read once, weighted into every group head's partial.
-def private kv_slice_av(var flop : float?; attp : float const?; vcp : auto const?;
-                        kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len, nsl, sl : int64) {
+def private kv_slice_av(var flop : float?; attp : float const?; vcp : auto const?; runs : KVRun const?;
+                        nrun, kstart, j0, j1, vdim, vhoff, head_size, qh0, kv_mul, seq_len, nsl, sl : int64) {
     unsafe {
-        for (j in range64(j0, j1)) {
-            let voff = (kstart + j) * kv_dim + kvhoff
-            for (g in range64(kv_mul)) {
-                let hh = qh0 + g
-                kv_axpy(flop + (hh * nsl + sl) * head_size, vcp + voff, attp[hh * seq_len + j], head_size)
+        for (r in range64(nrun)) {
+            let rj0 = max(runs[r].j0, kstart + j0)
+            let rj1 = min(runs[r].j1, kstart + j1)
+            let rowbase = runs[r].row0 - runs[r].j0
+            for (aj in range64(rj0, rj1)) {
+                let j = aj - kstart
+                let voff = (rowbase + aj) * vdim + vhoff
+                for (g in range64(kv_mul)) {
+                    let hh = qh0 + g
+                    kv_axpy(flop + (hh * nsl + sl) * head_size, vcp + voff, attp[hh * seq_len + j], head_size)
+                }
             }
         }
     }
@@ -2032,50 +2104,54 @@ def private kv_slice_av(var flop : float?; attp : float const?; vcp : auto const
 // per element.
 
 def private attn_head_decode_d(var arow : float?; var xbp : float?; qp : float const?;
-                               kcl, vcl : uint8 const?; kdt, vdt : KVDtype;
-                               qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh : int64;
+                               kcl, vcl : uint8 const?; kdt, vdt : KVDtype; runs : KVRun const?;
+                               nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh : int64;
                                scale, attn_softcap : float; sinksp : float const?) {
+    // per-side stride/offset in the side's own units — identical for scalar codecs; a block codec
+    // (q8_0) rescales its side to bytes here, once per head
     unsafe {
         if (kdt == KVDtype.f16) {
             if (vdt == KVDtype.f16) {
                 attn_head_decode(arow, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
-                    qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                    runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
             } else {
                 attn_head_decode(arow, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
-                    qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                    runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
             }
         } elif (vdt == KVDtype.f16) {
             attn_head_decode(arow, xbp, qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
-                qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
         } else {
             attn_head_decode(arow, xbp, qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
-                qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                runs, nrun, qoff, kv_dim, kvhoff, kv_dim, kvhoff, kstart, cnt, head_size, hh, scale, attn_softcap, sinksp)
         }
     }
 }
 
 def private kv_slice_scores_d(var attp : float?; qp : float const?; kcl : uint8 const?; kdt : KVDtype;
-                              kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len : int64;
+                              runs : KVRun const?;
+                              nrun, kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len : int64;
                               scale : float) {
     unsafe {
         if (kdt == KVDtype.f16) {
-            kv_slice_scores(attp, qp, reinterpret<uint16 const?>(kcl), kstart, j0, j1, kv_dim, kvhoff,
+            kv_slice_scores(attp, qp, reinterpret<uint16 const?>(kcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
                 head_size, qh0, kv_mul, seq_len, scale)
         } else {
-            kv_slice_scores(attp, qp, reinterpret<float const?>(kcl), kstart, j0, j1, kv_dim, kvhoff,
+            kv_slice_scores(attp, qp, reinterpret<float const?>(kcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
                 head_size, qh0, kv_mul, seq_len, scale)
         }
     }
 }
 
 def private kv_slice_av_d(var flop : float?; attp : float const?; vcl : uint8 const?; vdt : KVDtype;
-                          kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len, nsl, sl : int64) {
+                          runs : KVRun const?;
+                          nrun, kstart, j0, j1, kv_dim, kvhoff, head_size, qh0, kv_mul, seq_len, nsl, sl : int64) {
     unsafe {
         if (vdt == KVDtype.f16) {
-            kv_slice_av(flop, attp, reinterpret<uint16 const?>(vcl), kstart, j0, j1, kv_dim, kvhoff,
+            kv_slice_av(flop, attp, reinterpret<uint16 const?>(vcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
                 head_size, qh0, kv_mul, seq_len, nsl, sl)
         } else {
-            kv_slice_av(flop, attp, reinterpret<float const?>(vcl), kstart, j0, j1, kv_dim, kvhoff,
+            kv_slice_av(flop, attp, reinterpret<float const?>(vcl), runs, nrun, kstart, j0, j1, kv_dim, kvhoff,
                 head_size, qh0, kv_mul, seq_len, nsl, sl)
         }
     }
@@ -2085,7 +2161,8 @@ def private kv_slice_av_d(var flop : float?; attp : float const?; vcl : uint8 co
 // recompute of every head's attention output vs the sliced result in xb. Codec-generic like the
 // workers; test-only and serial, so the extraction costs nothing.
 def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv : float const?;
-                                 n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, nsl : int64;
+                                 runs : KVRun const?;
+                                 nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, nsl : int64;
                                  scale, attn_softcap : float; sinksp : float const?) {
     var sref : array<float>
     sref |> resize(int(cnt))
@@ -2093,10 +2170,15 @@ def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv 
         for (hh in range64(n_heads)) {
             let qoff = hh * head_size
             let kvhoff = (hh / kv_mul) * head_size
-            for (j in range64(cnt)) {
-                let koff = (kstart + j) * kv_dim + kvhoff   // kcp is layer-base (codec seam)
-                let sc = kv_dot(qp + qoff, kcp + koff, head_size) * scale
-                sref[j] = attn_softcap > 0.0 ? attn_softcap * tanh(sc / attn_softcap) : sc
+            for (r in range64(nrun)) {
+                let rj0 = max(runs[r].j0, kstart)
+                let rj1 = min(runs[r].j1, kstart + cnt)
+                let rowbase = runs[r].row0 - runs[r].j0
+                for (aj in range64(rj0, rj1)) {
+                    let koff = (rowbase + aj) * kv_dim + kvhoff   // kcp is layer-base (codec seam)
+                    let sc = kv_dot(qp + qoff, kcp + koff, head_size) * scale
+                    sref[aj - kstart] = attn_softcap > 0.0 ? attn_softcap * tanh(sc / attn_softcap) : sc
+                }
             }
             var m2 = sref[0]
             for (j in range64(1l, cnt)) {
@@ -2115,9 +2197,14 @@ def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv 
             var worstd = 0.0
             for (i in range64(head_size)) {
                 var acc = 0.0
-                for (j in range64(cnt)) {
-                    let voff = (kstart + j) * kv_dim + kvhoff   // vcp is layer-base (codec seam)
-                    acc += exp(sref[j] - m2) / l2 * kv_load(vcp, voff + i)
+                for (r in range64(nrun)) {
+                    let rj0 = max(runs[r].j0, kstart)
+                    let rj1 = min(runs[r].j1, kstart + cnt)
+                    let rowbase = runs[r].row0 - runs[r].j0
+                    for (aj in range64(rj0, rj1)) {
+                        let voff = (rowbase + aj) * kv_dim + kvhoff   // vcp is layer-base (codec seam)
+                        acc += exp(sref[aj - kstart] - m2) / l2 * kv_load(vcp, voff, i)
+                    }
                 }
                 worstd = max(worstd, abs(acc - xbv[qoff + i]))
             }
@@ -2129,26 +2216,31 @@ def private flash_decode_check_g(qp : float const?; kcp, vcp : auto const?; xbv 
     delete sref
 }
 
-// Store the roped k / raw v for all npos positions into the layer's KV cache. The destination row
-// start_pos+p and the source offset p*kv_dim both advance by one row per position, so the whole
-// k_b -> key_cache store is ONE contiguous run of npos rows (v likewise) — handed to kv_store_row
-// in whole-row chunks (the vectorized codec store; bounds-checked array copy doesn't vectorize),
-// threaded over the positions (each worker owns a disjoint cache slice). Self-gates on
-// g_kv_store_par_threshold. kbase/vbase = the layer's slab base BYTES.
+// Store the roped k / raw v for all npos positions into the layer's KV cache. Each worker chunk
+// [rb, re) walks the physical runs covering its positions and hands kv_store_row whole-row spans
+// (the vectorized codec store; bounds-checked array copy doesn't vectorize) — a flat cache is one
+// run, making the chunk ONE multi-row call exactly as before. Threaded over positions (workers own
+// disjoint cache slices; runs partition positions). Self-gates on g_kv_store_par_threshold.
+// kbase/vbase = the layer's slab base BYTES; runs cover [start_pos, start_pos + npos).
 def private kv_store_batch(var key_cache : array<uint8>; var value_cache : array<uint8>;
                            kdt, vdt : KVDtype; k_b : array<float>; v_b : array<float>;
-                           kbase, vbase, start_pos, npos, kv_dim : int64) {
+                           runs : KVRun const?; nrun, kbase, vbase, start_pos, npos, kv_dim : int64) {
     unsafe {
         var kcp = addr(key_cache[0]) + kbase
         var vcp = addr(value_cache[0]) + vbase
         let kbp = reinterpret<float const?>(addr(k_b[0]))
         let vbp = reinterpret<float const?>(addr(v_b[0]))
         maybe_parallel_for(kv_dim * npos >= g_kv_store_par_threshold, 0, int(npos), get_dispatch_lanes()) $(rb, re) {
-            let m0 = int64(rb) * kv_dim
-            let cnt = (int64(re) - int64(rb)) * kv_dim
             unsafe {
-                kv_store_row(kcp, kdt, kv_dim, start_pos + int64(rb), 0l, cnt, kbp + m0)
-                kv_store_row(vcp, vdt, kv_dim, start_pos + int64(rb), 0l, cnt, vbp + m0)
+                for (r in range64(nrun)) {
+                    let o0 = max(runs[r].j0, start_pos + int64(rb))
+                    let o1 = min(runs[r].j1, start_pos + int64(re))
+                    if (o1 > o0) {
+                        let rowbase = runs[r].row0 - runs[r].j0
+                        kv_store_row(kcp, kdt, kv_dim, rowbase + o0, 0l, (o1 - o0) * kv_dim, kbp + (o0 - start_pos) * kv_dim)
+                        kv_store_row(vcp, vdt, kv_dim, rowbase + o0, 0l, (o1 - o0) * kv_dim, vbp + (o0 - start_pos) * kv_dim)
+                    }
+                }
             }
         }
     }
@@ -2536,6 +2628,8 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
     let is_sliding = layer_is_sliding(c, l)
     let kstart = (is_sliding && pos + 1l > c.sliding_window) ? (pos + 1l - c.sliding_window) : 0l
     let cnt = pos + 1l - kstart
+    let nrun = kv_runs(s, kstart, pos + 1l, s.kv_runs)   // physical runs of this layer's window (flat: 1)
+    let prow = kv_phys_row(s, pos)                       // where THIS position's row lives
     // attention rmsnorm + input quantize (serial — dim-sized, microseconds)
     let ts_norm0 = ref_time_ticks()
     rms_at(s.xb, t, t.rms_att_off + l * dim, s.x, dim)
@@ -2600,6 +2694,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
         var xsp = addr(s.xs[0])
         var kcl = addr(s.key_cache[0]) + kbase     // layer-base byte pointers (stores + the _d read dispatch)
         var vcl = addr(s.value_cache[0]) + vbase
+        let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))   // this layer's physical runs (fork-safe hoist)
         // weight region bases (element offsets into the Q8 blob, scales at /32)
         let wqb = reinterpret<int8 const?>(addr(t.qblob[0]))
         let wsb = reinterpret<float const?>(addr(t.qscales[0]))
@@ -2670,7 +2765,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                             } else {
                                 rope_scaled_tab(kp + r0, head_size, head_size, crow, srow)
                             }
-                            kv_store_row(kcl, kdt, kv_dim, pos, r0, head_size, kp + r0)
+                            kv_store_row(kcl, kdt, kv_dim, prow, r0, head_size, kp + r0)
                         } else {
                             let r0 = (sl - n_heads - n_kv_heads) * head_size
                             invoke(mmrows, vp, wpv, wsv, xqp, xsp, dim, r0, r0 + head_size)
@@ -2682,7 +2777,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                             if (rvp != null) {
                                 rmsnorm(vp + r0, vp + r0, rvp, head_size, eps)
                             }
-                            kv_store_row(vcl, vdt, kv_dim, pos, r0, head_size, vp + r0)
+                            kv_store_row(vcl, vdt, kv_dim, prow, r0, head_size, vp + r0)
                         }
                     }
                 }
@@ -2696,8 +2791,8 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         let hh = int64(h)
                         let qoff = hh * head_size
                         let kvhoff = (hh / kv_mul) * head_size  // GQA: which kv head this query head reads
-                        attn_head_decode_d(attp + hh * seq_len, xbp, qp, kcl, vcl, kdt, vdt,
-                            qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                        attn_head_decode_d(attp + hh * seq_len, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                            nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
                         quantize_q8_0_into_ptr(xbp + qoff, head_size, xqp, xsp, qoff, qoff / 32l)
                     }
                 }
@@ -2717,7 +2812,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         let j0 = sl * slice_len
                         let j1 = min(j0 + slice_len, cnt)
                         // K pass: each K row read once, dotted against every group q-head
-                        kv_slice_scores_d(attp, qp, kcl, kdt, kstart, j0, j1, kv_dim, kvhoff, head_size,
+                        kv_slice_scores_d(attp, qp, kcl, kdt, runsp, nrun, kstart, j0, j1, kv_dim, kvhoff, head_size,
                             qh0, kv_mul, seq_len, scale)
                         for (g in range64(kv_mul)) {
                             let hh = qh0 + g
@@ -2762,7 +2857,7 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                             fllp[hh * int64(nsl) + sl] = lsum
                         }
                         // V pass: each V row read once, weighted into every group head's partial
-                        kv_slice_av_d(flop, attp, vcl, vdt, kstart, j0, j1, kv_dim, kvhoff, head_size,
+                        kv_slice_av_d(flop, attp, vcl, vdt, runsp, nrun, kstart, j0, j1, kv_dim, kvhoff, head_size,
                             qh0, kv_mul, seq_len, int64(nsl), sl)
                     }
                 }
@@ -2827,18 +2922,18 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
             // contract is checked HERE, per layer, at the attention output itself.
             if (kdt == KVDtype.f16) {
                 if (vdt == KVDtype.f16) {
-                    flash_decode_check_g(qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl), xbp,
-                        n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
+                    flash_decode_check_g(qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl), xbp, runsp,
+                        nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
                 } else {
-                    flash_decode_check_g(qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl), xbp,
-                        n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
+                    flash_decode_check_g(qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl), xbp, runsp,
+                        nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
                 }
             } elif (vdt == KVDtype.f16) {
-                flash_decode_check_g(qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl), xbp,
-                    n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
+                flash_decode_check_g(qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl), xbp, runsp,
+                    nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
             } else {
-                flash_decode_check_g(qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl), xbp,
-                    n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
+                flash_decode_check_g(qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl), xbp, runsp,
+                    nrun, n_heads, kv_mul, head_size, kv_dim, kstart, cnt, l, int64(nsl), scale, attn_softcap, sinksp)
             }
             g_flash_decode_checked++
         }
@@ -3048,9 +3143,9 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     if (!kv_shared) {
         let ts_kv = ref_time_ticks()
         unsafe {
-            kv_store_row(addr(s.key_cache[0]) + kbase, s.kv_dtype_k, kv_dim, pos, 0l, kv_dim,
+            kv_store_row(addr(s.key_cache[0]) + kbase, s.kv_dtype_k, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
                 reinterpret<float const?>(addr(s.k[0])))
-            kv_store_row(addr(s.value_cache[0]) + vbase, s.kv_dtype_v, kv_dim, pos, 0l, kv_dim,
+            kv_store_row(addr(s.value_cache[0]) + vbase, s.kv_dtype_v, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
                 reinterpret<float const?>(addr(s.v[0])))
         }
         prof_add("kv_store", ts_kv)
@@ -3071,10 +3166,12 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
         : null)
     let kdt = s.kv_dtype_k
     let vdt = s.kv_dtype_v
+    let nrun = kv_runs(s, kstart, pos + 1l, s.kv_runs)   // physical runs of this layer's window (flat: 1)
     unsafe {
         let qp = reinterpret<float const?>(addr(s.q[0]))
         let kcl = addr(s.key_cache[0]) + kbase   // layer-base byte pointers (the _d read dispatch)
         let vcl = addr(s.value_cache[0]) + vbase
+        let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb[0])
         var attp = addr(s.att[0])
         maybe_parallel_for(0, int(n_heads), attn_lanes) $(rb, re) {
@@ -3083,8 +3180,8 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
                     let hh = int64(h)
                     let qoff = hh * head_size
                     let kvhoff = (hh / kv_mul) * head_size  // GQA: which kv head this query head reads
-                    attn_head_decode_d(attp + hh * seq_len, xbp, qp, kcl, vcl, kdt, vdt,
-                        qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                    attn_head_decode_d(attp + hh * seq_len, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                        nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
                 }
             }
         }
@@ -3949,8 +4046,8 @@ def forward_profile_report() {
 // per-query running max/sum (mrun/srun) folds each KV tile in. All pointers are pre-offset to this
 // head; qpk/kpk/vpk/kqp/vkqp are this head's scratch bases. NOT bit-exact vs classic (online reorder).
 def private attn_head_flash(qp : float const?; kcp, vcp : auto const?; var xbp : float?;
-                            var qpk, kpk, vpk, kqp, vkqp : float?;
-                            npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff : int64;
+                            var qpk, kpk, vpk, kqp, vkqp, tmpp : float?; runs : KVRun const?;
+                            nrun, npos, start_pos, head_size, qd, kdim, khoff, vdim, vhoff, qoff : int64;
                             scale : float; is_sliding : bool; sliding_window : int64; attn_softcap : float;
                             has_sink : bool; sink : float) {
     let QT = ATTN_FLASH_QT
@@ -3984,19 +4081,26 @@ def private attn_head_flash(qp : float const?; kcp, vcp : auto const?; var xbp :
             var kt0 = kstart_min
             while (kt0 <= apL) {
                 let kvalid = min(KV, apL + 1l - kt0)
-                // pack Kᵀ tile [head_size × KV] and V tile [KV × head_size], zero-padding the tail
-                for (kt in range64(KV)) {
-                    if (kt < kvalid) {
-                        let ksrc = (kt0 + kt) * kv_dim + kvhoff   // kcp/vcp are layer-base (codec seam);
-                        for (d in range64(head_size)) {           // the dequant seam is THIS pack step —
-                            kpk[d * KV + kt] = kv_load(kcp, ksrc + d)      // the GEMMs read f32 scratch
-                            vpk[kt * head_size + d] = kv_load(vcp, ksrc + d)
-                        }
-                    } else {
+                // pack Kᵀ tile [head_size × KV] and V tile [KV × head_size] by physical run: each
+                // cached row dequants ONCE via kv_row_to_f32 (the dequant seam — the GEMMs read f32
+                // scratch), V straight into its tile row, K through tmpp then transpose-scattered
+                for (r in range64(nrun)) {
+                    let rj0 = max(runs[r].j0, kt0)
+                    let rj1 = min(runs[r].j1, kt0 + kvalid)
+                    let rowbase = runs[r].row0 - runs[r].j0
+                    for (aj in range64(rj0, rj1)) {
+                        let kt = aj - kt0
+                        kv_row_to_f32(vpk + kt * head_size, vcp, (rowbase + aj) * vdim + vhoff, head_size)
+                        kv_row_to_f32(tmpp, kcp, (rowbase + aj) * kdim + khoff, head_size)
                         for (d in range64(head_size)) {
-                            kpk[d * KV + kt] = 0.0
-                            vpk[kt * head_size + d] = 0.0
+                            kpk[d * KV + kt] = tmpp[d]
                         }
+                    }
+                }
+                for (kt in range64(kvalid, KV)) {   // zero-pad the tail columns
+                    for (d in range64(head_size)) {
+                        kpk[d * KV + kt] = 0.0
+                        vpk[kt * head_size + d] = 0.0
                     }
                 }
                 // scores: kq[tile_rows × KV] = Q · Kᵀ  (gemm_f32 accumulates, so zero first)
@@ -4065,12 +4169,12 @@ def private attn_head_flash(qp : float const?; kcp, vcp : auto const?; var xbp :
     }
 }
 
-// One head of BLOCKED prefill attention (see prefill_attention) — codec-generic over the cache
-// element type like attn_head_decode. kcp/vcp are layer-base typed pointers; attp_h = this head's
-// ATTN_BLOCK_Q score rows (maxctx-strided).
+// One head of BLOCKED prefill attention (see prefill_attention) — codec-generic + run-walking.
+// kcp/vcp are layer-base typed pointers; attp_h = this head's ATTN_BLOCK_Q score rows
+// (maxctx-strided, window-relative). The block's key range intersects the layer's physical runs.
 def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float const?;
-                              kcp, vcp : auto const?;
-                              npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
+                              kcp, vcp : auto const?; runs : KVRun const?;
+                              nrun, npos, start_pos, maxctx, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh : int64;
                               scale : float; is_sliding : bool; sliding_window : int64;
                               attn_softcap : float; sinksp : float const?) {
     unsafe {
@@ -4081,19 +4185,24 @@ def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float 
             let ap_last = ap_first + bq - 1l
             let kstart_block = (is_sliding && ap_first + 1l > sliding_window) ? (ap_first + 1l - sliding_window) : 0l
             // PASS 1: scores — each K[kk] loaded once, reused across the block's queries
-            for (kk in range64(kstart_block, ap_last + 1l)) {
-                let koff = kk * kv_dim + kvhoff
-                let bi_lo = max(0l, kk - ap_first)            // causal: keep queries with ap >= kk
-                var bi_hi = bq
-                if (is_sliding) {                            // window: keep queries with kstart_p <= kk
-                    bi_hi = min(bq, kk + sliding_window - ap_first)
-                }
-                for (bi in range64(bi_lo, bi_hi)) {
-                    let p = p0 + bi
-                    let ap = start_pos + p
-                    let kstart_p = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
-                    let qbase = p * qd + qoff
-                    attp_h[bi * maxctx + (kk - kstart_p)] = kv_dot(qp + qbase, kcp + koff, head_size) * scale
+            for (r in range64(nrun)) {
+                let rj0 = max(runs[r].j0, kstart_block)
+                let rj1 = min(runs[r].j1, ap_last + 1l)
+                let rowbase = runs[r].row0 - runs[r].j0
+                for (kk in range64(rj0, rj1)) {
+                    let koff = (rowbase + kk) * kdim + khoff
+                    let bi_lo = max(0l, kk - ap_first)            // causal: keep queries with ap >= kk
+                    var bi_hi = bq
+                    if (is_sliding) {                            // window: keep queries with kstart_p <= kk
+                        bi_hi = min(bq, kk + sliding_window - ap_first)
+                    }
+                    for (bi in range64(bi_lo, bi_hi)) {
+                        let p = p0 + bi
+                        let ap = start_pos + p
+                        let kstart_p = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
+                        let qbase = p * qd + qoff
+                        attp_h[bi * maxctx + (kk - kstart_p)] = kv_dot(qp + qbase, kcp + koff, head_size) * scale
+                    }
                 }
             }
             // softcap + softmax per query, then zero its output slice
@@ -4117,19 +4226,24 @@ def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float 
                 }
             }
             // PASS 2: output += Σ att[j]·V[j] — each V[kk] loaded once, reused across the block
-            for (kk in range64(kstart_block, ap_last + 1l)) {
-                let voff = kk * kv_dim + kvhoff
-                let bi_lo = max(0l, kk - ap_first)
-                var bi_hi = bq
-                if (is_sliding) {
-                    bi_hi = min(bq, kk + sliding_window - ap_first)
-                }
-                for (bi in range64(bi_lo, bi_hi)) {
-                    let p = p0 + bi
-                    let ap = start_pos + p
-                    let kstart_p = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
-                    let qbase = p * qd + qoff
-                    kv_axpy(xbp + qbase, vcp + voff, attp_h[bi * maxctx + (kk - kstart_p)], head_size)
+            for (r in range64(nrun)) {
+                let rj0 = max(runs[r].j0, kstart_block)
+                let rj1 = min(runs[r].j1, ap_last + 1l)
+                let rowbase = runs[r].row0 - runs[r].j0
+                for (kk in range64(rj0, rj1)) {
+                    let voff = (rowbase + kk) * vdim + vhoff
+                    let bi_lo = max(0l, kk - ap_first)
+                    var bi_hi = bq
+                    if (is_sliding) {
+                        bi_hi = min(bq, kk + sliding_window - ap_first)
+                    }
+                    for (bi in range64(bi_lo, bi_hi)) {
+                        let p = p0 + bi
+                        let ap = start_pos + p
+                        let kstart_p = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
+                        let qbase = p * qd + qoff
+                        kv_axpy(xbp + qbase, vcp + voff, attp_h[bi * maxctx + (kk - kstart_p)], head_size)
+                    }
                 }
             }
             p0 += ATTN_BLOCK_Q
@@ -4137,11 +4251,12 @@ def private attn_head_blocked(var attp_h : float?; var xbp : float?; qp : float 
     }
 }
 
-// One head of CLASSIC prefill attention (see prefill_attention) — codec-generic. attp_h = this
-// head's private score row (maxctx wide).
+// One head of CLASSIC prefill attention (see prefill_attention) — codec-generic + run-walking.
+// attp_h = this head's private score row (maxctx wide, window-relative); each query's window
+// [kstart, ap] intersects the layer's physical runs.
 def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float const?;
-                              kcp, vcp : auto const?;
-                              npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
+                              kcp, vcp : auto const?; runs : KVRun const?;
+                              nrun, npos, start_pos, qd, head_size, kdim, khoff, vdim, vhoff, qoff, hh : int64;
                               scale : float; is_sliding : bool; sliding_window : int64;
                               attn_softcap : float; sinksp : float const?) {
     unsafe {
@@ -4150,9 +4265,13 @@ def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float 
             let kstart = (is_sliding && ap + 1l > sliding_window) ? (ap + 1l - sliding_window) : 0l
             let cnt = ap + 1l - kstart
             let qbase = p * qd + qoff           // q row == output row (both qd-strided)
-            for (j in range64(cnt)) {
-                let koff = (kstart + j) * kv_dim + kvhoff
-                attp_h[j] = kv_dot(qp + qbase, kcp + koff, head_size) * scale
+            for (r in range64(nrun)) {
+                let rj0 = max(runs[r].j0, kstart)
+                let rj1 = min(runs[r].j1, ap + 1l)
+                let rowbase = runs[r].row0 - runs[r].j0
+                for (aj in range64(rj0, rj1)) {
+                    attp_h[aj - kstart] = kv_dot(qp + qbase, kcp + (rowbase + aj) * kdim + khoff, head_size) * scale
+                }
             }
             if (attn_softcap > 0.0) {  // Gemma2: soft-cap scores before softmax
                 softcap(attp_h, cnt, attn_softcap)
@@ -4165,9 +4284,13 @@ def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float 
             for (i in range64(head_size)) {
                 xbp[qbase + i] = 0.0
             }
-            for (j in range64(cnt)) {   // output += Σ att[j]·V[j]
-                let voff = (kstart + j) * kv_dim + kvhoff
-                kv_axpy(xbp + qbase, vcp + voff, attp_h[j], head_size)
+            for (r in range64(nrun)) {   // output += Σ att[j]·V[j]
+                let rj0 = max(runs[r].j0, kstart)
+                let rj1 = min(runs[r].j1, ap + 1l)
+                let rowbase = runs[r].row0 - runs[r].j0
+                for (aj in range64(rj0, rj1)) {
+                    kv_axpy(xbp + qbase, vcp + (rowbase + aj) * vdim + vhoff, attp_h[aj - kstart], head_size)
+                }
             }
         }
     }
@@ -4176,84 +4299,84 @@ def private attn_head_classic(var attp_h : float?; var xbp : float?; qp : float 
 // Prefill codec dispatch (same contract as attn_head_decode_d): one wrapper per prefill worker,
 // the 2x2 scalar K×V matrix spelled once.
 def private attn_head_flash_d(qp : float const?; kcl, vcl : uint8 const?; kdt, vdt : KVDtype; var xbp : float?;
-                              var qpk, kpk, vpk, kqp, vkqp : float?;
-                              npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff : int64;
+                              var qpk, kpk, vpk, kqp, vkqp, tmpp : float?; runs : KVRun const?;
+                              nrun, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff : int64;
                               scale : float; is_sliding : bool; sliding_window : int64; attn_softcap : float;
                               has_sink : bool; sink : float) {
     unsafe {
         if (kdt == KVDtype.f16) {
             if (vdt == KVDtype.f16) {
                 attn_head_flash(qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl), xbp,
-                    qpk, kpk, vpk, kqp, vkqp, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff,
-                    scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                    qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                    kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
             } else {
                 attn_head_flash(qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl), xbp,
-                    qpk, kpk, vpk, kqp, vkqp, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff,
-                    scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                    qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                    kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
             }
         } elif (vdt == KVDtype.f16) {
             attn_head_flash(qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl), xbp,
-                qpk, kpk, vpk, kqp, vkqp, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff,
-                scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
         } else {
             attn_head_flash(qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl), xbp,
-                qpk, kpk, vpk, kqp, vkqp, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff,
-                scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
+                qpk, kpk, vpk, kqp, vkqp, tmpp, runs, nrun, npos, start_pos, head_size, qd,
+                kv_dim, kvhoff, kv_dim, kvhoff, qoff, scale, is_sliding, sliding_window, attn_softcap, has_sink, sink)
         }
     }
 }
 
 def private attn_head_blocked_d(var attp_h : float?; var xbp : float?; qp : float const?;
-                                kcl, vcl : uint8 const?; kdt, vdt : KVDtype;
-                                npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
+                                kcl, vcl : uint8 const?; kdt, vdt : KVDtype; runs : KVRun const?;
+                                nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
                                 scale : float; is_sliding : bool; sliding_window : int64;
                                 attn_softcap : float; sinksp : float const?) {
     unsafe {
         if (kdt == KVDtype.f16) {
             if (vdt == KVDtype.f16) {
                 attn_head_blocked(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
-                    npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             } else {
                 attn_head_blocked(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
-                    npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                    runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             }
         } elif (vdt == KVDtype.f16) {
             attn_head_blocked(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
-                npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         } else {
             attn_head_blocked(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
-                npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                runs, nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         }
     }
 }
 
 def private attn_head_classic_d(var attp_h : float?; var xbp : float?; qp : float const?;
-                                kcl, vcl : uint8 const?; kdt, vdt : KVDtype;
-                                npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
+                                kcl, vcl : uint8 const?; kdt, vdt : KVDtype; runs : KVRun const?;
+                                nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh : int64;
                                 scale : float; is_sliding : bool; sliding_window : int64;
                                 attn_softcap : float; sinksp : float const?) {
     unsafe {
         if (kdt == KVDtype.f16) {
             if (vdt == KVDtype.f16) {
                 attn_head_classic(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<uint16 const?>(vcl),
-                    npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                    runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             } else {
                 attn_head_classic(attp_h, xbp, qp, reinterpret<uint16 const?>(kcl), reinterpret<float const?>(vcl),
-                    npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                    runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                     scale, is_sliding, sliding_window, attn_softcap, sinksp)
             }
         } elif (vdt == KVDtype.f16) {
             attn_head_classic(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<uint16 const?>(vcl),
-                npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         } else {
             attn_head_classic(attp_h, xbp, qp, reinterpret<float const?>(kcl), reinterpret<float const?>(vcl),
-                npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                runs, nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, kv_dim, kvhoff, qoff, hh,
                 scale, is_sliding, sliding_window, attn_softcap, sinksp)
         }
     }
@@ -4267,10 +4390,15 @@ def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, he
     let attn_par = npos * maxctx * n_heads >= g_attn_par_threshold
     let kdt = s.kv_dtype_k
     let vdt = s.kv_dtype_v
+    // ONE run list over the layer's widest window; workers intersect their per-query/tile
+    // sub-windows with each run (two max/min per run)
+    let kstart_min = (is_sliding && start_pos + 1l > sliding_window) ? (start_pos + 1l - sliding_window) : 0l
+    let nrun = kv_runs(s, kstart_min, start_pos + npos, s.kv_runs)
     unsafe {
         let qp = reinterpret<float const?>(addr(s.q_b[0]))
         let kcl = addr(s.key_cache[0]) + kbase   // layer-base byte pointers (the _d read dispatch)
         let vcl = addr(s.value_cache[0]) + vbase
+        let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb_b[0])
         // att_b is sized only for the blocked/classic modes (flash packs into fa_* instead), so the
         // base pointer must not index an empty array under flash — null there, never dereferenced.
@@ -4278,7 +4406,7 @@ def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, he
         if (g_attn_prefill_mode == AttnPrefillMode.flash) {
             // per-head packing scratch bases (sized in forward_prefill for this mode)
             var qpk0 = addr(s.fa_q[0]);  var kpk0 = addr(s.fa_k[0]);  var vpk0 = addr(s.fa_v[0])
-            var kqp0 = addr(s.fa_kq[0]); var vkqp0 = addr(s.fa_vkq[0])
+            var kqp0 = addr(s.fa_kq[0]); var vkqp0 = addr(s.fa_vkq[0]); var tmp0 = addr(s.fa_tmp[0])
             maybe_parallel_for(attn_par, 0, int(n_heads), get_dispatch_lanes()) $(rb, re) {
                 unsafe {
                     for (h in range(rb, re)) {
@@ -4291,7 +4419,8 @@ def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, he
                             vpk0 + hh * ATTN_FLASH_KV * head_size,
                             kqp0 + hh * ATTN_FLASH_QT * ATTN_FLASH_KV,
                             vkqp0 + hh * ATTN_FLASH_QT * head_size,
-                            npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff,
+                            tmp0 + hh * head_size, runsp,
+                            nrun, npos, start_pos, head_size, qd, kv_dim, kvhoff, qoff,
                             scale, is_sliding, sliding_window, attn_softcap,
                             sinksp != null, sinksp != null ? sinksp[hh] : 0.0)
                     }
@@ -4304,8 +4433,8 @@ def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, he
                         let hh = int64(h)
                         let qoff = hh * head_size
                         let kvhoff = (hh / kv_mul) * head_size
-                        attn_head_blocked_d(attp + hh * ATTN_BLOCK_Q * maxctx, xbp, qp, kcl, vcl, kdt, vdt,
-                            npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                        attn_head_blocked_d(attp + hh * ATTN_BLOCK_Q * maxctx, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                            nrun, npos, start_pos, maxctx, qd, head_size, kv_dim, kvhoff, qoff, hh,
                             scale, is_sliding, sliding_window, attn_softcap, sinksp)
                     }
                 }
@@ -4317,8 +4446,8 @@ def private prefill_attention(var s : Session; kbase, vbase, npos, start_pos, he
                         let hh = int64(h)
                         let qoff = hh * head_size
                         let kvhoff = (hh / kv_mul) * head_size
-                        attn_head_classic_d(attp + hh * maxctx, xbp, qp, kcl, vcl, kdt, vdt,
-                            npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
+                        attn_head_classic_d(attp + hh * maxctx, xbp, qp, kcl, vcl, kdt, vdt, runsp,
+                            nrun, npos, start_pos, qd, head_size, kv_dim, kvhoff, qoff, hh,
                             scale, is_sliding, sliding_window, attn_softcap, sinksp)
                     }
                 }
@@ -4464,8 +4593,11 @@ def private attention_std_prefill(t : Model; var s : Session; l : int64; npos : 
     // Shared-KV layers store nothing — the source layer (processed earlier) already cached its K/V.
     if (!kv_shared) {
         let ts_kv = ref_time_ticks()
-        kv_store_batch(s.key_cache, s.value_cache, s.kv_dtype_k, s.kv_dtype_v, s.k_b, s.v_b,
-            kbase, vbase, start_pos, npos, kv_dim)
+        let store_nrun = kv_runs(s, start_pos, start_pos + npos, s.kv_runs)   // where the new rows land
+        unsafe {
+            kv_store_batch(s.key_cache, s.value_cache, s.kv_dtype_k, s.kv_dtype_v, s.k_b, s.v_b,
+                reinterpret<KVRun const?>(addr(s.kv_runs[0])), store_nrun, kbase, vbase, start_pos, npos, kv_dim)
+        }
         prof_add("kv_store", ts_kv)
     }
     // causal attention into xb_b (position ap attends to cached keys kstart..ap; kstart = 0 unless a
@@ -5358,6 +5490,7 @@ def private forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : 
         s.fa_v |> resize(n_heads * ATTN_FLASH_KV * head_size)
         s.fa_kq |> resize(n_heads * ATTN_FLASH_QT * ATTN_FLASH_KV)
         s.fa_vkq |> resize(n_heads * ATTN_FLASH_QT * head_size)
+        s.fa_tmp |> resize(n_heads * head_size)
     } else {
         s.att_b |> resize(n_heads * ATTN_BLOCK_Q * (start_pos + npos))
     }
@@ -5442,6 +5575,8 @@ struct BatchWorkspace {
     // delete of a plain array<T?> CASCADES to the pointees, which would free the sessions' cache blobs
     @do_not_delete kbase : array<uint8?>
     @do_not_delete vbase : array<uint8?>
+    runs_b : array<KVRun>     // per-row physical runs, flattened rows × max-runs (flat: 1 per row)
+    nrun_b : array<int64>     // per-row run count
 }
 
 def create_batch_workspace_(model : Model) : BatchWorkspace {
@@ -5524,12 +5659,18 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
     let ts_attn = ref_time_ticks()
     var maxctx = 0l
     var work = 0l   // Σ 2·cnt_i·head_size MACs per head
+    ws.runs_b |> resize(nrows)   // one run per row while rows are flat (paged rows re-size per table)
+    ws.nrun_b |> resize(nrows)
     for (i in range64(nrows)) {
         let pos = ws.positions[i]
         let kstart = (is_sliding && pos + 1l > swin) ? (pos + 1l - swin) : 0l
         maxctx = max(maxctx, pos + 1l - kstart)
         work += 2l * (pos + 1l - kstart) * head_size
+        // flat rows: one physical run per row (E2 routes this through the row's block table)
+        ws.runs_b[i] = KVRun(j0 = kstart, j1 = pos + 1l, row0 = kstart)
+        ws.nrun_b[i] = 1l
     }
+    let maxruns = 1l   // runs_b row stride
     ws.scr.att_b |> resize(nrows * n_heads * maxctx)
     let attn_softcap = c.attn_logit_softcap
     let attn_lanes = min(int(nrows * n_heads), lanes_for_work(work * n_heads, g_gemv_lane_cap))
@@ -5541,6 +5682,8 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
         var xbp = addr(ws.scr.xb_b[0])
         var attp = addr(ws.scr.att_b[0])
         let posp = reinterpret<int64 const?>(addr(ws.positions[0]))
+        let runsbp = reinterpret<KVRun const?>(addr(ws.runs_b[0]))
+        let nrunbp = reinterpret<int64 const?>(addr(ws.nrun_b[0]))
         var kbpp = addr(ws.kbase[0])
         var vbpp = addr(ws.vbase[0])
         maybe_parallel_for(0, int(nrows * n_heads), attn_lanes) $(rb, re) {
@@ -5555,8 +5698,8 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; l, nrows 
                     let qoff = hh * head_size
                     let kvhoff = (hh / kv_mul) * head_size
                     attn_head_decode_d(attp + ix * maxctx, xbp + ii * qd, qp + ii * qd,
-                        kbpp[ii] + kbb, vbpp[ii] + vbb, kdt, vdt,
-                        qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
+                        kbpp[ii] + kbb, vbpp[ii] + vbb, kdt, vdt, runsbp + ii * maxruns,
+                        nrunbp[ii], qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
                 }
             }
         }

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -107,6 +107,135 @@ def template cvt_f16_to_f32_template(var d : float ?; s : uint16 const ?; n : in
 [hint(unsafe_range_check, noalias = d, noalias = s), tuned]
 def cvt_f16_to_f32(var d : float?; s : uint16 const?; n : int64) {}
 
+// The q8_0 KV-codec kernels: the cache side is ggml block_q8_0 — 32 int8 quants sharing one f16
+// scale, INTERLEAVED {f16 d; int8 qs[32]} = 34 bytes per block (llama.cpp -ctk/-ctv q8_0 layout,
+// so the oracle cross-checks stay honest). Rows are whole blocks (kv_dim % 32 == 0, validated at
+// session create), so a row is n/32 blocks and the scale sits 2-byte aligned at each 34-byte step
+// (17 uint16s). n is always a multiple of 32.
+
+//! Dot of an f32 query row against a q8_0 cache row: the block scale factors out —
+//! d * Σ a[j]·q[j] per 32-block (the prefill read; decode uses the int8×int8 twin below).
+[hint(unsafe_range_check, noalias = a, noalias = b)]
+def template dot_q8kv_template(a : float const ?; b : uint8 const ?; n : int64) : float {
+    var acc = 0.0
+    unsafe {
+        let b16 = reinterpret<uint16 const?>(b)
+        let bq = reinterpret<int8 const?>(b)
+        for (bi in range64(n / 32l)) {
+            let base = bi * 32l
+            let qb = bi * 34l + 2l
+            var facc = 0.0
+            for [tune = 1] (k in range64(32l)) {
+                facc = mad(a[base + k], float(bq[qb + k]), facc)
+            }
+            acc = mad(facc, f16_to_f32(uint(b16[bi * 17l])), acc)
+        }
+    }
+    return acc
+}
+[hint(unsafe_range_check, noalias = a, noalias = b), tuned]
+def dot_q8kv(a : float const?; b : uint8 const?; n : int64) : float {}
+
+//! THE q8_0 decode hot path: a Q8-quantized query (int8 quants + f32 scales per 32, the
+//! quantize_q8_0_into planes) against a q8_0 cache row. The inner loop is pure int8·int8
+//! multiply-accumulate — the same SDOT/VNNI shape as dot_q8q8 — with both block scales
+//! multiplying in once per 32-block.
+[hint(unsafe_range_check, noalias = q, noalias = qs, noalias = b)]
+def template dot_q8q8kv_template(q : int8 const ?; qs : float const ?; b : uint8 const ?; n : int64) : float {
+    var acc = 0.0
+    unsafe {
+        let b16 = reinterpret<uint16 const?>(b)
+        let bq = reinterpret<int8 const?>(b)
+        for (bi in range64(n / 32l)) {
+            let base = bi * 32l
+            let qb = bi * 34l + 2l
+            var iacc = 0
+            for [tune = 1] (k in range64(32l)) {
+                iacc += int(q[base + k]) * int(bq[qb + k])
+            }
+            acc += float(iacc) * qs[bi] * f16_to_f32(uint(b16[bi * 17l]))
+        }
+    }
+    return acc
+}
+[hint(unsafe_range_check, noalias = q, noalias = qs, noalias = b), tuned(fallback = "vec16")]
+def dot_q8q8kv(q : int8 const?; qs : float const?; b : uint8 const?; n : int64) : float {}
+
+//! AXPY from a q8_0 cache row: d[j] += scale * (q[j] * d_block) — the V-accumulate under the
+//! q8_0 codec; scale * d_block hoists per 32-block.
+[hint(unsafe_range_check, noalias = d, noalias = s)]
+def template axpy_q8kv_template(var d : float ?; s : uint8 const ?; scale : float; n : int64) : void {
+    unsafe {
+        let s16 = reinterpret<uint16 const?>(s)
+        let sq = reinterpret<int8 const?>(s)
+        for (bi in range64(n / 32l)) {
+            let base = bi * 32l
+            let qb = bi * 34l + 2l
+            let c = scale * f16_to_f32(uint(s16[bi * 17l]))
+            for [tune = 1] (k in range64(32l)) {
+                d[base + k] = mad(c, float(sq[qb + k]), d[base + k])
+            }
+        }
+    }
+}
+[hint(unsafe_range_check, noalias = d, noalias = s), tuned]
+def axpy_q8kv(var d : float?; s : uint8 const?; scale : float; n : int64) {}
+
+//! q8_0 -> f32 row convert (the flash pack's bulk dequant): d[j] = q[j] * d_block.
+[hint(unsafe_range_check, noalias = d, noalias = s)]
+def template cvt_q8kv_to_f32_template(var d : float ?; s : uint8 const ?; n : int64) : void {
+    unsafe {
+        let s16 = reinterpret<uint16 const?>(s)
+        let sq = reinterpret<int8 const?>(s)
+        for (bi in range64(n / 32l)) {
+            let base = bi * 32l
+            let qb = bi * 34l + 2l
+            let db = f16_to_f32(uint(s16[bi * 17l]))
+            for [tune = 1] (k in range64(32l)) {
+                d[base + k] = float(sq[qb + k]) * db
+            }
+        }
+    }
+}
+[hint(unsafe_range_check, noalias = d, noalias = s), tuned]
+def cvt_q8kv_to_f32(var d : float?; s : uint8 const?; n : int64) {}
+
+//! Quantize n f32s (a whole number of 32-blocks) into q8_0 blocks at dst — the codec store.
+//! ggml's exact quantize_row_q8_0 semantics: per block d = amax/127 stored as f16, quants
+//! round with the UN-rounded f32 1/d — which makes the codec idempotent (re-quantizing a
+//! dequantized row is byte-identical: the max element quantizes to ±127, so the recovered
+//! d equals the stored f16 exactly). amax uses quantize_q8_0_into_ptr's two-lane float4 max
+//! (exact — max is order-free on finite input).
+[hint(unsafe_range_check, noalias = dst, noalias = src)]
+def template quantize_q8kv_row_template(var dst : uint8 ?; src : float const ?; n : int64) : void {
+    unsafe {
+        let p4 = reinterpret<float4 const?>(src)
+        var d16 = reinterpret<uint16?>(dst)
+        var dq = reinterpret<int8?>(dst)
+        for (bi in range64(n / 32l)) {
+            let base = bi * 32l
+            let f4 = base / 4l
+            var m0 = abs(p4[f4])
+            var m1 = abs(p4[f4 + 1l])
+            for (k in range64(1l, 4l)) {
+                m0 = max(m0, abs(p4[f4 + 2l * k]))
+                m1 = max(m1, abs(p4[f4 + 2l * k + 1l]))
+            }
+            let m = max(m0, m1)
+            let amax = max(max(m.x, m.y), max(m.z, m.w))
+            let d = amax / 127.0
+            let id = d != 0.0 ? 1.0 / d : 0.0
+            d16[bi * 17l] = uint16(f32_to_f16(d))
+            let qb = bi * 34l + 2l
+            for [tune = 1] (i in range64(32l)) {
+                dq[qb + i] = int8(round(src[base + i] * id))
+            }
+        }
+    }
+}
+[hint(unsafe_range_check, noalias = dst, noalias = src), tuned(fallback = "plain")]
+def quantize_q8kv_row(var dst : uint8?; src : float const?; n : int64) {}
+
 //! d[j] += s[j], width-8 vectorized (the residual-stream update). The plain `for k; a[k]+=b[k]`
 //! over bounds-checked arrays does NOT vectorize under the JIT — this pointer form is ~5x faster.
 [hint(unsafe_range_check, noalias = d, noalias = s)]

--- a/modules/dasLLAMA/dasllama/dasllama_prefix.das
+++ b/modules/dasLLAMA/dasllama/dasllama_prefix.das
@@ -1,0 +1,172 @@
+options gen2
+
+module dasllama_prefix shared public
+
+require dasllama/dasllama_common   // KVPool, Session, kv_pool_release_group
+require math   // min
+
+// The prefix cache (vLLM-style, page-granular): completed streams donate their full KV pages,
+// keyed by a CHAINED page hash over token ids, so a later request with the same prompt prefix
+// attaches those pages (pool refcnt++) and prefills only the tail. Whole-page matching keeps a
+// live stream's write cursor in its own private pages — no copy-on-write on the serving path.
+// Hashes route, tokens verify: every hit compares the stored token ids before attaching.
+
+//! One cached page: the pool group holding P consecutive positions of some evaled token history,
+//! keyed by the chained hash of every token up to and including this page.
+struct PrefixEntry {
+    group : int                 // page-group id in the pool (held: its refcnt includes this entry)
+    tokens : array<int64>       // the page's P token ids — verified on every hit
+    last_use : int64            // LRU clock value of the last attach/insert touch
+}
+
+//! Page-granular prefix cache over the sessions of ONE ``KVPool`` (``create_prefix_cache_``).
+//! Pure data — every verb takes the pool explicitly, so the cache can live inside any owner
+//! struct without interior pointers. Not thread-safe; drive it from the pool's owning thread.
+struct PrefixCache {
+    entries : table<uint64; PrefixEntry>   // chained page hash -> cached page
+    max_groups : int64          // held-page budget (LRU-evicts past it); 0 = unbounded
+    tick : int64                // LRU clock
+    n_hit_pages : int64         // pages attached across all lookups
+    n_insert_pages : int64      // pages donated
+    n_evicted_pages : int64     // pages LRU-dropped
+}
+
+// FNV-1a 64 over the 8 bytes of v, continuing h.
+def private fnv1a64(h : uint64; v : uint64) : uint64 {
+    var x = h
+    var b = v
+    for (_i in range(8)) {
+        x = (x ^ (b & 0xfful)) * 0x100000001b3ul
+        b >>= 8ul
+    }
+    return x
+}
+
+// Chained hash of tokens[lo, hi) continuing `prev` — the chain is what makes a page's key encode
+// its FULL history, so equal keys mean equal token prefixes (module hash collisions, which the
+// stored tokens verify away).
+def private chain_page_hash(prev : uint64; tokens : array<int64>; lo, hi : int64) : uint64 {
+    var h = fnv1a64(0xcbf29ce484222325ul, prev)
+    for (i in range64(lo, hi)) {
+        h = fnv1a64(h, uint64(tokens[i]))
+    }
+    return h
+}
+
+def private page_tokens_match(entry : PrefixEntry; tokens : array<int64>; lo : int64) : bool {
+    for (i in range64(int64(length(entry.tokens)))) {
+        if (entry.tokens[i] != tokens[lo + i]) {
+            return false
+        }
+    }
+    return true
+}
+
+//! Create a prefix cache for the sessions of one pool. ``max_groups`` caps how many page groups
+//! the cache retains (LRU-dropped past it; a dropped page a session still uses stays alive — only
+//! the cache's hold is released); 0 = unbounded.
+def create_prefix_cache_(max_groups : int64 = 0l) : PrefixCache {
+    return <- PrefixCache(max_groups = max_groups)
+}
+
+//! Pages the cache currently holds (== held pool groups).
+def prefix_held_groups_(cache : PrefixCache) : int64 => int64(length(cache.entries))
+
+//! Attach the longest cached prefix of ``prompt`` to a FRESH paged session of ``pool``: walks the
+//! prompt page by page (chained hash, then token verification), copies matched groups into the
+//! session's block table (refcnt++), and sets ``n_past`` to the matched length — the caller
+//! prefills only the tail. Returns the matched token count (a multiple of ``page_rows``), capped
+//! at one token short of the prompt so the tail eval always produces the sampling logits.
+def prefix_attach_(var cache : PrefixCache; var pool : KVPool; var s : Session; prompt : array<int64>) : int64 {
+    if (s.kv_pool == null || s.kv_pool != unsafe(addr(pool))) {
+        panic("prefix_attach: the session is not paged out of this pool")
+    }
+    if (s.n_past != 0l || !empty(s.block_table)) {
+        panic("prefix_attach: the session already holds context (n_past {s.n_past}, {length(s.block_table)} pages) — attach only to a fresh session")
+    }
+    let np = int64(length(prompt))
+    let pr = pool.page_rows
+    let pages_max = np > 0l ? (np - 1l) / pr : 0l
+    var h = 0ul
+    var matched = 0l
+    for (i in range64(pages_max)) {
+        h = chain_page_hash(h, prompt, i * pr, (i + 1l) * pr)
+        if (!key_exists(cache.entries, h)) {
+            break
+        }
+        // interior pointer into the table — nothing inserts before the loop exits
+        var e = unsafe(cache.entries?[h])
+        if (e == null || !page_tokens_match(*e, prompt, i * pr)) {
+            break   // hash collision or corrupted entry: tokens are the truth
+        }
+        cache.tick ++
+        e.last_use = cache.tick
+        s.block_table |> push(e.group)
+        pool.refcnt[e.group] ++
+        matched += pr
+        cache.n_hit_pages ++
+    }
+    s.n_past = matched
+    return matched
+}
+
+// Drop the least-recently-used entry (release its group hold).
+def private prefix_evict_lru(var cache : PrefixCache; var pool : KVPool) {
+    var lru_key = 0ul
+    var lru_use = 0l
+    var first = true
+    for (k, e in keys(cache.entries), values(cache.entries)) {
+        if (first || e.last_use < lru_use) {
+            lru_use = e.last_use
+            lru_key = k
+            first = false
+        }
+    }
+    kv_pool_release_group(pool, cache.entries[lru_key].group)
+    delete cache.entries[lru_key]   // erase is a raw remove — finalize the owned tokens first
+    cache.entries |> erase(lru_key)
+    cache.n_evicted_pages ++
+}
+
+//! Donate a finished session's pages: registers every full page of ``tokens`` (the session's full
+//! EVALED history — cache rows must exist, so only the first ``n_past`` tokens count) that is not
+//! already cached, bumping the pool refcnt so the pages survive the session's release. Pages past
+//! the budget LRU-drop. Call right before ``release_kv_pages``.
+def prefix_insert_(var cache : PrefixCache; var pool : KVPool; s : Session; tokens : array<int64>) {
+    if (s.kv_pool == null || s.kv_pool != unsafe(addr(pool))) {
+        panic("prefix_insert: the session is not paged out of this pool")
+    }
+    let pr = pool.page_rows
+    let covered = min(int64(length(tokens)), s.n_past)
+    let pages = covered / pr
+    var h = 0ul
+    for (i in range64(pages)) {
+        h = chain_page_hash(h, tokens, i * pr, (i + 1l) * pr)
+        cache.tick ++
+        if (key_exists(cache.entries, h)) {
+            // interior pointer into the table — released before anything inserts
+            var e = unsafe(cache.entries?[h])
+            e.last_use = cache.tick
+            continue
+        }
+        var e <- PrefixEntry(group = s.block_table[i], last_use = cache.tick)
+        e.tokens <- [for (j in range64(i * pr, (i + 1l) * pr)); tokens[j]]
+        cache.entries[h] <- e
+        pool.refcnt[s.block_table[i]] ++
+        cache.n_insert_pages ++
+    }
+    if (cache.max_groups > 0l) {
+        while (int64(length(cache.entries)) > cache.max_groups) {
+            prefix_evict_lru(cache, pool)
+        }
+    }
+}
+
+//! Release every cached page hold back to ``pool`` and clear the cache (pages still used by live
+//! sessions stay alive until those sessions release them). Call before deleting the pool.
+def prefix_release_(var cache : PrefixCache; var pool : KVPool) {
+    for (e in values(cache.entries)) {
+        kv_pool_release_group(pool, e.group)
+    }
+    delete cache.entries
+}

--- a/modules/dasLLAMA/harness/oracle/simple_ids.cpp
+++ b/modules/dasLLAMA/harness/oracle/simple_ids.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 static void print_usage(const char * argv0) {
-    fprintf(stderr, "\nusage: %s -m model.gguf [-n n_predict] [-ngl n_gpu_layers] [-p prompt]\n\n", argv0);
+    fprintf(stderr, "\nusage: %s -m model.gguf [-n n_predict] [-ngl n_gpu_layers] [-p prompt] [-ctk f16|q8_0]\n\n", argv0);
 }
 
 int main(int argc, char ** argv) {
@@ -31,6 +31,7 @@ int main(int argc, char ** argv) {
 
     std::string model_path;
     std::string prompt = "Once upon a time";
+    std::string ctk;      // KV-cache type override (K AND V) — "" keeps llama.cpp's default (f16)
     int ngl = 0;          // CPU only — match dasLLAMA's CPU forward so argmax ties agree
     int n_predict = 40;
 
@@ -43,10 +44,16 @@ int main(int argc, char ** argv) {
             ngl = std::stoi(argv[++i]);
         } else if (strcmp(argv[i], "-p") == 0 && i + 1 < argc) {
             prompt = argv[++i];
+        } else if (strcmp(argv[i], "-ctk") == 0 && i + 1 < argc) {
+            ctk = argv[++i];
         } else {
             print_usage(argv[0]);
             return 1;
         }
+    }
+    if (!ctk.empty() && ctk != "f16" && ctk != "q8_0") {
+        fprintf(stderr, "simple_ids: unsupported -ctk %s (f16|q8_0)\n", ctk.c_str());
+        return 1;
     }
     if (model_path.empty()) {
         print_usage(argv[0]);
@@ -83,6 +90,15 @@ int main(int argc, char ** argv) {
     ctx_params.n_ctx   = n_prompt + n_predict;
     ctx_params.n_batch = n_prompt;
     ctx_params.no_perf = true;
+    if (ctk == "q8_0") {
+        // the dasLLAMA q8_0 KV parity arm: quantized V needs flash attention in llama.cpp
+        ctx_params.type_k = GGML_TYPE_Q8_0;
+        ctx_params.type_v = GGML_TYPE_Q8_0;
+        ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+    } else if (ctk == "f16") {
+        ctx_params.type_k = GGML_TYPE_F16;
+        ctx_params.type_v = GGML_TYPE_F16;
+    }
     llama_context * ctx = llama_init_from_model(model, ctx_params);
     if (ctx == NULL) {
         fprintf(stderr, "simple_ids: failed to create context\n");

--- a/modules/dasLLAMA/harness/parity.sh
+++ b/modules/dasLLAMA/harness/parity.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # dasLLAMA token-for-token parity check: reference oracle (simple_ids) vs dasLLAMA (parity.das).
 #
-# Usage:   parity.sh <model.gguf> [N] [quant] [prompt] [kv]
+# Usage:   parity.sh <model.gguf> [N] [quant] [prompt] [kv] [ctk]
 #   N       generated tokens to compare (default 40)
 #   quant   dasLLAMA storage: fp32|q8|q4 — pick the file's native type (default q8; use fp32 for F16/F32)
 #   prompt  raw continuation prompt (default "Once upon a time")
-#   kv      dasLLAMA KV-cache dtype: f32|f16 (default f32; the oracle always runs its own default)
+#   kv      dasLLAMA KV-cache dtype: f32|f16|q8_0 (default f32)
+#   ctk     ORACLE KV-cache type: f16|q8_0 (default: llama.cpp's own default; pass q8_0 with kv=q8_0
+#           for the both-sides-quantized run — the oracle then also turns flash attention on)
 #
 # Env overrides: LLAMA_CPP (default ~/Work/llama.cpp), DASLANG (default <repo>/bin/daslang)
 # The oracle binary must be built once — see harness/oracle/simple_ids.cpp for the one-line recipe.
@@ -16,6 +18,7 @@ N="${2:-40}"
 QUANT="${3:-q8}"
 PROMPT="${4:-Once upon a time}"
 KV="${5:-f32}"
+CTK="${6:-}"
 
 LLAMA_CPP="${LLAMA_CPP:-$HOME/Work/llama.cpp}"
 ORACLE="$LLAMA_CPP/build/bin/simple_ids"
@@ -26,7 +29,11 @@ PARITY="$DAS_ROOT/modules/dasLLAMA/harness/parity.das"
 [ -x "$ORACLE" ] || { echo "missing oracle: $ORACLE — build it (see harness/oracle/simple_ids.cpp)"; exit 2; }
 
 # 1. reference: prompt ids (as llama.cpp tokenizes) + greedy generated ids
-REF="$("$ORACLE" -m "$MODEL" -n "$N" -p "$PROMPT" 2>/dev/null)"
+if [ -n "$CTK" ]; then
+    REF="$("$ORACLE" -m "$MODEL" -n "$N" -p "$PROMPT" -ctk "$CTK" 2>/dev/null)"
+else
+    REF="$("$ORACLE" -m "$MODEL" -n "$N" -p "$PROMPT" 2>/dev/null)"
+fi
 PROMPT_IDS="$(printf '%s\n' "$REF" | sed -n 's/^PROMPT_IDS: //p')"
 REF_GEN="$(printf '%s\n' "$REF" | sed -n 's/^GEN_IDS: //p')"
 IDS_CSV="$(printf '%s' "$PROMPT_IDS" | tr ' ' ',')"

--- a/modules/dasLLAMA/harness/tune_kernels.das
+++ b/modules/dasLLAMA/harness/tune_kernels.das
@@ -65,6 +65,16 @@ struct GridAxpyF16 {}
 struct GridCvtToF16 {}
 [dasllama_grid(src = "cvt_f16_to_f32_template")]
 struct GridCvtToF32 {}
+[dasllama_grid(src = "dot_q8kv_template")]
+struct GridDotQ8Kv {}
+[dasllama_grid(src = "dot_q8q8kv_template")]
+struct GridDotQ8Q8Kv {}
+[dasllama_grid(src = "axpy_q8kv_template")]
+struct GridAxpyQ8Kv {}
+[dasllama_grid(src = "cvt_q8kv_to_f32_template")]
+struct GridCvtQ8Kv {}
+[dasllama_grid(src = "quantize_q8kv_row_template")]
+struct GridQuantQ8Kv {}
 
 // Registry fn-ptr signatures (== function_to_type of each template).
 typedef DotFn = function<(a : float const?; b : float const?; n : int64) : float>
@@ -875,6 +885,345 @@ def bench_dot_q8q8() : string {
     return report("dot_q8q8", names, best, ok, "vec16")
 }
 
+// ===== q8_0 KV-codec kernels: dot_q8kv / dot_q8q8kv / axpy_q8kv / cvt_q8kv_to_f32 /
+// quantize_q8kv_row. The cache side is interleaved ggml block_q8_0 ({f16 d; int8 qs[32]} = 34
+// bytes per 32 elements); the reference row below IS the quantize_q8kv_row contract, so the
+// quantize bench gates byte-EXACT against it, the cvt gates element-exact, and the dots gate
+// f64-relative on the exact int block sums / dequantized values.
+
+// reference q8_0 row builder — scalar amax (order-free == the kernel's float4 form), f16 scale,
+// f32-id rounding: quantize_q8kv_row's exact semantics
+def private build_q8kv_row(src : array<float>; n : int64; var row : array<uint8>) {
+    row |> resize(int(n / 32l * 34l))
+    for (bi in range64(n / 32l)) {
+        let base = bi * 32l
+        var amax = 0.0
+        for (k in range64(32l)) {
+            amax = max(amax, abs(src[base + k]))
+        }
+        let d = amax / 127.0
+        let id = d != 0.0 ? 1.0 / d : 0.0
+        let dh = f32_to_f16(d)
+        let bb = bi * 34l
+        row[bb] = uint8(dh & 0xFF)
+        row[bb + 1l] = uint8((dh >> 8u) & 0xFF)
+        for (k in range64(32l)) {
+            row[bb + 2l + k] = uint8(int(round(src[base + k] * id)) & int(0xFF))
+        }
+    }
+}
+
+// dequantized element (bi*32 + k) of a reference row, in f64 — for the dot/axpy references
+def private q8kv_elem(row : array<uint8>; i : int64) : double {
+    let bb = i / 32l * 34l
+    let dh = uint(row[bb]) | (uint(row[bb + 1l]) << 8u)
+    let q = int(int8(row[bb + 2l + i % 32l]))
+    return double(q) * double(f16_to_f32(dh))
+}
+
+def bench_dot_q8kv() : string {
+    var a : array<float>
+    var wf : array<float>
+    var row : array<uint8>
+    a |> resize(int(N))
+    wf |> resize(int(N))
+    for (i in range(int(N))) {
+        a[i] = sin(float(i) * 0.1f)
+        wf[i] = cos(float(i) * 0.07f)
+    }
+    build_q8kv_row(wf, N, row)
+    var want = 0.0lf
+    for (j in range64(N)) {
+        want += double(a[j]) * q8kv_elem(row, j)
+    }
+    let pa = unsafe(addr(a[0]))
+    let pb = unsafe(addr(row[0]))
+
+    let vs <- dot_q8kv_template_variants()
+    let nv = length(vs)
+    var names : array<string>
+    var ok : array<bool>
+    var best : array<double>
+    names |> resize(nv)
+    ok |> resize(nv)
+    best |> resize(nv)
+    for (i in range(nv)) {
+        names[i] = vs[i]._0
+        best[i] = 1.0e30lf
+        let f = vs[i]._1
+        let got = double(f(pa, pb, N))
+        ok[i] = abs(got - want) / (abs(want) + 1.0lf) <= TOL
+    }
+
+    var sink = 0.0f
+    for (_round in range(ROUNDS)) {
+        for (i in range(nv)) {
+            if (!ok[i]) {
+                continue
+            }
+            let f = vs[i]._1
+            let t0 = ref_time_ticks()
+            for (_rep in range(REPS)) {
+                sink += f(pa, pb, N)
+            }
+            let us = double(get_time_usec(t0))
+            if (us < best[i]) {
+                best[i] = us
+            }
+        }
+    }
+    if (sink == 12345.678f) {
+        print("")   // keep sink live
+    }
+    return report("dot_q8kv", names, best, ok)
+}
+
+def bench_dot_q8q8kv() : string {
+    var xf : array<float>
+    var wf : array<float>
+    var row : array<uint8>
+    xf |> resize(int(N))
+    wf |> resize(int(N))
+    for (i in range(int(N))) {
+        xf[i] = sin(float(i) * 0.1f)
+        wf[i] = cos(float(i) * 0.07f)
+    }
+    build_q8kv_row(wf, N, row)
+    let xq <- quantize_q8_0(xf, N)   // the query planes (int8 quants + f32 scales)
+    var want = 0.0lf
+    for (bi in range64(N / 32l)) {
+        let bb = bi * 34l
+        let dh = uint(row[bb]) | (uint(row[bb + 1l]) << 8u)
+        var iacc = 0
+        for (k in range64(32l)) {
+            iacc += int(xq.q[bi * 32l + k]) * int(int8(row[bb + 2l + k]))
+        }
+        want += double(iacc) * double(xq.scales[bi]) * double(f16_to_f32(dh))
+    }
+    let qp = unsafe(addr(xq.q[0]))
+    let sp = unsafe(addr(xq.scales[0]))
+    let pb = unsafe(addr(row[0]))
+
+    let vs <- dot_q8q8kv_template_variants()
+    let nv = length(vs)
+    var names : array<string>
+    var ok : array<bool>
+    var best : array<double>
+    names |> resize(nv)
+    ok |> resize(nv)
+    best |> resize(nv)
+    for (i in range(nv)) {
+        names[i] = vs[i]._0
+        best[i] = 1.0e30lf
+        let f = vs[i]._1
+        let got = double(f(qp, sp, pb, N))
+        ok[i] = abs(got - want) / (abs(want) + 1.0lf) <= TOL
+    }
+
+    var sink = 0.0f
+    for (_round in range(ROUNDS)) {
+        for (i in range(nv)) {
+            if (!ok[i]) {
+                continue
+            }
+            let f = vs[i]._1
+            let t0 = ref_time_ticks()
+            for (_rep in range(REPS)) {
+                sink += f(qp, sp, pb, N)
+            }
+            let us = double(get_time_usec(t0))
+            if (us < best[i]) {
+                best[i] = us
+            }
+        }
+    }
+    if (sink == 12345.678f) {
+        print("")   // keep sink live
+    }
+    return report("dot_q8q8kv", names, best, ok, "vec16")
+}
+
+def bench_axpy_q8kv() : string {
+    let vs <- axpy_q8kv_template_variants()
+    let nv = length(vs)
+    let scale = 0.5f
+    var d0 : array<float>
+    var wf : array<float>
+    var row : array<uint8>
+    var d : array<float>
+    d0 |> resize(int(N))
+    wf |> resize(int(N))
+    d |> resize(int(N))
+    for (i in range(int(N))) {
+        d0[i] = 0.5f + 0.3f * sin(float(i) * 0.05f)
+        wf[i] = cos(float(i) * 0.03f)
+    }
+    build_q8kv_row(wf, N, row)
+    var dp = unsafe(addr(d[0]))
+    let sp = unsafe(addr(row[0]))
+
+    var names : array<string>
+    var ok : array<bool>
+    var best : array<double>
+    names |> resize(nv)
+    ok |> resize(nv)
+    best |> resize(nv)
+    for (i in range(nv)) {
+        names[i] = vs[i]._0
+        best[i] = 1.0e30lf
+        reset(d, d0)
+        let f = vs[i]._1
+        invoke(f, dp, sp, scale, N)
+        var maxrel = 0.0lf
+        for (j in range64(N)) {
+            let want = double(d0[j]) + double(scale) * q8kv_elem(row, j)
+            let rel = abs(double(d[j]) - want) / (abs(want) + 1.0lf)
+            if (rel > maxrel) {
+                maxrel = rel
+            }
+        }
+        ok[i] = maxrel <= TOL
+    }
+
+    var sink = 0.0f
+    for (_round in range(ROUNDS)) {
+        for (i in range(nv)) {
+            if (!ok[i]) {
+                continue
+            }
+            reset(d, d0)
+            let f = vs[i]._1
+            let t0 = ref_time_ticks()
+            for (_rep in range(REPS)) {
+                invoke(f, dp, sp, scale, N)
+            }
+            let us = double(get_time_usec(t0))
+            if (us < best[i]) {
+                best[i] = us
+            }
+        }
+        sink += d[0]
+    }
+    print("  checksum {sink}\n")
+    return report("axpy_q8kv", names, best, ok)
+}
+
+def bench_cvt_q8kv_to_f32() : string {
+    let vs <- cvt_q8kv_to_f32_template_variants()
+    let nv = length(vs)
+    var wf : array<float>
+    var row : array<uint8>
+    var d : array<float>
+    wf |> resize(int(N))
+    d |> resize(int(N))
+    for (i in range(int(N))) {
+        wf[i] = 300.0f * cos(float(i) * 0.09f)
+    }
+    build_q8kv_row(wf, N, row)
+    var dp = unsafe(addr(d[0]))
+    let sp = unsafe(addr(row[0]))
+
+    var names : array<string>
+    var ok : array<bool>
+    var best : array<double>
+    names |> resize(nv)
+    ok |> resize(nv)
+    best |> resize(nv)
+    for (i in range(nv)) {
+        names[i] = vs[i]._0
+        best[i] = 1.0e30lf
+        for (j in range(int(N))) {
+            d[j] = -1.0e30f
+        }
+        let f = vs[i]._1
+        invoke(f, dp, sp, N)
+        var exact = true
+        for (j in range64(N)) {
+            exact &&= double(d[j]) == q8kv_elem(row, j)   // float(q)*f16(d) is exact in f32
+        }
+        ok[i] = exact
+    }
+
+    var sink = 0.0f
+    for (_round in range(ROUNDS)) {
+        for (i in range(nv)) {
+            if (!ok[i]) {
+                continue
+            }
+            let f = vs[i]._1
+            let t0 = ref_time_ticks()
+            for (_rep in range(REPS)) {
+                invoke(f, dp, sp, N)
+            }
+            let us = double(get_time_usec(t0))
+            if (us < best[i]) {
+                best[i] = us
+            }
+        }
+        sink += d[0]
+    }
+    print("  checksum {sink}\n")
+    return report("cvt_q8kv_to_f32", names, best, ok)
+}
+
+def bench_quantize_q8kv_row() : string {
+    let vs <- quantize_q8kv_row_template_variants()
+    let nv = length(vs)
+    var src : array<float>
+    var ref_row : array<uint8>
+    var d : array<uint8>
+    src |> resize(int(N))
+    for (i in range(int(N))) {
+        src[i] = 300.0f * sin(float(i) * 0.11f)
+    }
+    build_q8kv_row(src, N, ref_row)   // the contract: byte-exact ggml quantize_row_q8_0
+    d |> resize(length(ref_row))
+    var dp = unsafe(addr(d[0]))
+    let sp = unsafe(addr(src[0]))
+
+    var names : array<string>
+    var ok : array<bool>
+    var best : array<double>
+    names |> resize(nv)
+    ok |> resize(nv)
+    best |> resize(nv)
+    for (i in range(nv)) {
+        names[i] = vs[i]._0
+        best[i] = 1.0e30lf
+        for (b in d) {
+            b = uint8(0xA5)
+        }
+        let f = vs[i]._1
+        invoke(f, dp, sp, N)
+        var exact = true
+        for (j in range(length(d))) {
+            exact &&= d[j] == ref_row[j]
+        }
+        ok[i] = exact
+    }
+
+    var sink = 0
+    for (_round in range(ROUNDS)) {
+        for (i in range(nv)) {
+            if (!ok[i]) {
+                continue
+            }
+            let f = vs[i]._1
+            let t0 = ref_time_ticks()
+            for (_rep in range(REPS)) {
+                invoke(f, dp, sp, N)
+            }
+            let us = double(get_time_usec(t0))
+            if (us < best[i]) {
+                best[i] = us
+            }
+        }
+        sink += int(d[0])
+    }
+    print("  checksum {sink}\n")
+    return report("quantize_q8kv_row", names, best, ok, "plain")
+}
+
 // ===== dot_mx4q8: native-MXFP4 weight planes (deterministic nibbles + E8M0 bytes) vs Q8 activation.
 // The vec* perms are inert (straight-line tbl16/sdot4_w intrinsic body — the hint is ignored), so
 // only the unroll rows genuinely compete, exactly like laneq4x4.
@@ -1337,6 +1686,11 @@ def main {
     let rmsw = bench_rmsnorm()
     let dq4w = bench_dot_q4()
     let dq8w = bench_dot_q8q8()
+    let dq8kvw = bench_dot_q8kv()
+    let dq8q8kvw = bench_dot_q8q8kv()
+    let axq8kvw = bench_axpy_q8kv()
+    let cvtq8kvw = bench_cvt_q8kv_to_f32()
+    let quantq8kvw = bench_quantize_q8kv_row()
     let dmx4w = bench_dot_mx4q8()
     let quantw = bench_quantize()
     let ropew = bench_rope_tab()
@@ -1348,13 +1702,19 @@ def main {
     print("\n===== summary (winner per kernel) =====\n")
     let knames = fixed_array("dot", "axpy", "dot_f16", "axpy_f16", "cvt_f32_to_f16", "cvt_f16_to_f32",
         "add_inplace", "mul_inplace", "scale_inplace", "copy_floats",
-        "softmax", "rmsnorm", "dot_q4", "dot_q8q8", "dot_mx4q8", "quantize_q8_0_into_ptr",
+        "softmax", "rmsnorm", "dot_q4", "dot_q8q8",
+        "dot_q8kv", "dot_q8q8kv", "axpy_q8kv", "cvt_q8kv_to_f32", "quantize_q8kv_row",
+        "dot_mx4q8", "quantize_q8_0_into_ptr",
         "rope_scaled_neox_tab", "gemm_f32_uk_4x16", "dot_q8q8_laneq4x4")
     let kwin = fixed_array(dotw, axpyw, dotf16w, axpyf16w, cvt16w, cvt32w, addw, mulw, scalew, copyw,
-        softmaxw, rmsw, dq4w, dq8w, dmx4w, quantw, ropew, gemmw, laneqw)
+        softmaxw, rmsw, dq4w, dq8w,
+        dq8kvw, dq8q8kvw, axq8kvw, cvtq8kvw, quantq8kvw,
+        dmx4w, quantw, ropew, gemmw, laneqw)
     let kfall = fixed_array(BASELINE, BASELINE, BASELINE, BASELINE, BASELINE, BASELINE,
         BASELINE, BASELINE, BASELINE, BASELINE,
-        BASELINE, "plain", "vec4_u4", "vec16", "u2", "plain",
+        BASELINE, "plain", "vec4_u4", "vec16",
+        BASELINE, "vec16", BASELINE, BASELINE, "plain",
+        "u2", "plain",
         BASELINE, "u2", "u2")
     var changed = 0
     for (k, w, f in knames, kwin, kfall) {
@@ -1392,7 +1752,10 @@ def main {
         cvt_f32_to_f16 = cvt16w, cvt_f16_to_f32 = cvt32w, add_inplace = addw,
         mul_inplace = mulw, scale_inplace = scalew, copy_floats = copyw,
         softmax = softmaxw, softmax_sink = softmaxw, rmsnorm = rmsw,
-        dot_q4 = dq4w, dot_q8q8 = dq8w, dot_mx4q8 = dmx4w, quantize_q8_0_into_ptr = quantw,
+        dot_q4 = dq4w, dot_q8q8 = dq8w,
+        dot_q8kv = dq8kvw, dot_q8q8kv = dq8q8kvw, axpy_q8kv = axq8kvw,
+        cvt_q8kv_to_f32 = cvtq8kvw, quantize_q8kv_row = quantq8kvw,
+        dot_mx4q8 = dmx4w, quantize_q8_0_into_ptr = quantw,
         rope_scaled_neox_tab = ropew, gemm_f32_uk_4x16 = gemmw, dot_q8q8_laneq4x4 = laneqw,
         runtime = runtime))
     let js = write_json(profile)

--- a/skills/dashv.md
+++ b/skills/dashv.md
@@ -59,9 +59,14 @@ STREAM("/events") <| @(var req : HttpRequest?; var writer : HttpResponseWriter?)
 ```
 
 - **Writer ops are handle-first** — `respond` / `sse_event` / `write_chunked` / `end_headers` /
-  `close_writer` / `release_writer` all take the **server handle first**, then the `writer`. That
-  is deliberate: generation runs on the tick thread, and the op posts the socket write to the
-  connection's event loop (`adapter->loop()->runInLoop`) so writes marshal to the right loop.
+  `close_writer` / `release_writer` / `is_writer_connected` all take the **server handle first**,
+  then the `writer`. That is deliberate: generation runs on the tick thread, and the op posts the
+  socket write to the connection's event loop (`adapter->loop()->runInLoop`) so writes marshal to
+  the right loop.
+- `is_writer_connected(server, writer)` — true while the writer's client connection is still open
+  (false for null / unknown / released writers). The async write ops never report a dead peer, so
+  a long-lived stream **polls this to evict abandoned clients** (see `openai_server.das`'s
+  `reap_disconnected`).
 - `sse_event(server, writer, data, "")` emits exact `data: <json>\n\n` framing. Terminate an SSE
   stream with a final `sse_event(server, writer, "[DONE]", "")` then `close_writer`.
 - One `STREAM` route serves both streaming and non-streaming responses: stream with `sse_event`,

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -110,6 +110,7 @@ SET(AOT_DASLLAMA_MODULE_FILES
     modules/dasLLAMA/dasllama/dasllama_tokenizer.das
     modules/dasLLAMA/dasllama/dasllama_bpe.das
     modules/dasLLAMA/dasllama/dasllama_common.das
+    modules/dasLLAMA/dasllama/dasllama_prefix.das
     modules/dasLLAMA/dasllama/dasllama_audio.das
     modules/dasLLAMA/dasllama/dasllama_whisper.das
     modules/dasLLAMA/dasllama/dasllama_qwen3a.das

--- a/tests/dasHV/_dashv_test_common.das
+++ b/tests/dasHV/_dashv_test_common.das
@@ -27,6 +27,7 @@ let PORT_COOKIES        = 19005
 let PORT_FORMS          = 19006
 let PORT_WEBSOCKETS     = 19007
 let PORT_SSE            = 19008
+let PORT_WRITER_CONNECTED = 19009
 
 // ──────────────────────────────────────────────────────────────────────────
 // Generic server lifecycle
@@ -70,7 +71,7 @@ def with_test_server(server_type : auto(ServerType); port : int; blk : block<(ba
 // ──────────────────────────────────────────────────────────────────────────
 
 def write_test_file(path, content : string) {
-    fopen(path, "w") <| $(f) {
+    fopen(path, "w") $(f) {
         if (f != null) {
             fwrite(f, content)
         }
@@ -79,7 +80,7 @@ def write_test_file(path, content : string) {
 
 def read_test_file(path : string) : string {
     var result = ""
-    fopen(path, "r") <| $(f) {
+    fopen(path, "r") $(f) {
         if (f != null) {
             result = fread(f)
         }

--- a/tests/dasHV/test_writer_connected.das
+++ b/tests/dasHV/test_writer_connected.das
@@ -1,0 +1,75 @@
+// Tests for is_writer_connected — writer liveness while held in active_writers
+//
+// The async writer ops never report a dead peer; is_writer_connected is the primitive a server
+// polls to evict streams whose client disconnected (dasllama-server's S4 eviction).
+
+options gen2
+options persistent_heap
+options gc
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require _dashv_test_common
+require strings
+
+// Server-context globals: handlers run serially on the tick thread, in the server thread's context.
+var g_held : HttpResponseWriter?
+var g_at_open = false
+
+class HoldServer : HvWebServer {
+    def override onInit {
+        // Hold a stream open forever: record liveness at open, stash the writer, flush headers
+        // with one event, and never close — the client's read timeout is what ends the connection.
+        STREAM("/hold") <| @(var req : HttpRequest?; var writer : HttpResponseWriter?) {
+            g_at_open = is_writer_connected(server, writer)
+            g_held = writer
+            sse_event(server, writer, "held", "")
+        }
+        GET("/status") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            let now = g_held != null ? is_writer_connected(server, g_held) : false
+            let nul = is_writer_connected(server, null)
+            return resp |> TEXT_PLAIN("open={g_at_open} now={now} null={nul}")
+        }
+    }
+}
+
+def private fetch_status(base_url : string) : string {
+    var body = ""
+    GET("{base_url}/status") $(var resp) {
+        if (resp != null) {
+            body = clone_string(string(resp.body))
+        }
+    }
+    return body
+}
+
+[test]
+def test_writer_connected(t : T?) {
+    with_test_server(type<HoldServer>, PORT_WRITER_CONNECTED) $(base_url) {
+        t |> run("null / no held writer reads not-connected") @(t : T?) {
+            let st = fetch_status(base_url)
+            t |> success(find(st, "now=false") >= 0, "no writer held yet (got '{st}')")
+            t |> success(find(st, "null=false") >= 0, "null writer is not connected (got '{st}')")
+        }
+        t |> run("held writer: connected at open, disconnected after the client goes away") @(t : T?) {
+            // The stream never ends, so the 1s read timeout fires and the client closes the socket.
+            with_http_request() <| $(var req) {
+                req.method = http_method.GET
+                req.url := "{base_url}/hold"
+                set_timeout(req, 1)
+                request(req) <| $(var resp) {}   // timeout: resp is null or partial — irrelevant
+            }
+            var st = ""
+            for (_attempt in range(100)) {   // up to ~10s for the server loop to see the EOF
+                st = fetch_status(base_url)
+                if (find(st, "now=false") >= 0) {
+                    break
+                }
+                sleep(100u)
+            }
+            t |> success(find(st, "open=true") >= 0, "writer was connected at handler time (got '{st}')")
+            t |> success(find(st, "now=false") >= 0, "held writer reads disconnected after client abort (got '{st}')")
+        }
+    }
+}

--- a/tests/dasLLAMA/test_batch_decode.das
+++ b/tests/dasLLAMA/test_batch_decode.das
@@ -89,6 +89,17 @@ def private kv_blob_max_diff(blob : array<uint8>; refb : array<uint8>; pref : ar
                     for (e in range64(kvd)) {
                         maxd = max(maxd, abs(f16_to_f32(uint(hb[e])) - f16_to_f32(uint(hr[e]))))
                     }
+                } elif (dt == KVDtype.q8_0) {
+                    let qb = bp + base + row * rowb
+                    let qr = rp + base + row * rowb
+                    for (bi in range64(kvd / 32l)) {
+                        let bb = bi * 34l
+                        let db = f16_to_f32(uint(qb[bb]) | (uint(qb[bb + 1l]) << 8u))
+                        let dr = f16_to_f32(uint(qr[bb]) | (uint(qr[bb + 1l]) << 8u))
+                        for (k in range64(32l)) {
+                            maxd = max(maxd, abs(float(int8(qb[bb + 2l + k])) * db - float(int8(qr[bb + 2l + k])) * dr))
+                        }
+                    }
                 } else {
                     let fb = reinterpret<float const?>(bp + base + row * rowb)
                     let fr = reinterpret<float const?>(rp + base + row * rowb)
@@ -222,6 +233,34 @@ def test_batch_decode_f16_kv(t : T?) {
         set_fused_decode(false)
         with_job_que() {
             batch_vs_ref(t, tr, KVDtype.f16, 8l, 1.0e-6, "f16kv")
+        }
+        set_fused_decode(prev_fused)
+        delete tr
+    }
+}
+
+[test]
+def test_batch_decode_q8_kv(t : T?) {
+    t |> run("batched decode == sequential under the q8_0 KV codec (needs SmolLM2-135M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        // stories15M's head_size 48 is rejected by the q8_0 32-block check (by design) — this arm
+        // runs the SmolLM2 GGUF carrier instead, same rail as test_fused_decode
+        let env = get_env_variable("DASLLAMA_MODELS_DIR")
+        let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+        let path = path_join(mdir, "SmolLM2-135M-Instruct-Q8_0.gguf")
+        if (!stat(path).is_valid) {
+            t |> success(true, "skipped: {path} not present")
+            return
+        }
+        var tr <- load_gguf(path, QuantMode.q8)
+        tr.config.seq_len = min(tr.config.seq_len, 64l)
+        let prev_fused = get_fused_decode()
+        set_fused_decode(false)
+        with_job_que() {
+            batch_vs_ref(t, tr, KVDtype.q8_0, 8l, 1.0e-6, "q8_0kv")
         }
         set_fused_decode(prev_fused)
         delete tr

--- a/tests/dasLLAMA/test_chat.das
+++ b/tests/dasLLAMA/test_chat.das
@@ -35,6 +35,19 @@ def private same(a, b : array<int64>) : bool {
     return true
 }
 
+// KV caches are codec-encoded byte blobs — byte equality IS bit-exactness for a same-dtype pair
+def private same(a, b : array<uint8>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
 // Load capped to a tiny context: these cases only render prompts, and the session's KV cache is sized
 // to config.seq_len — Phi/Llama-3's native 131072 would allocate ~64GB.
 def private load_capped(path : string) : Model {
@@ -331,6 +344,58 @@ def test_chat_pending_cleared_on_consume(t : T?) {
             add_assistant(m, c, "One, two, three, four.")
             t |> equal(c.pending, "", "add_assistant() cleared the consumed text")
             delete c
+            delete m
+        }
+    }
+}
+
+// ===== render seam: render_assistant produces EXACTLY the tokens add_assistant evals =====
+
+[test]
+def test_chat_render_seam(t : T?) {
+    t |> run("render_assistant ≡ add_assistant evals; renderer chat holds no KV (needs SmolLM2-135M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+        if (!stat(path).is_valid) {
+            t |> success(true, "skipped: {path} not present")
+            return
+        }
+        with_job_que() {
+            setup_dasllama_jobque()
+            var m <- load_capped(path)
+            // classic prefill is bit-exact under ANY chunking (test_prefill's contract), so a
+            // byte-equal cache proves the render and eval paths agree token for token
+            let saved_mode = get_prefill_attn_mode()
+            set_prefill_attn_mode(AttnPrefillMode.classic)
+            var a = create_chat(m, SYS, 4l)   // the eval path: two replayed turns
+            add_user(a, "Count to three.")
+            add_assistant(m, a, "One, two, three.")
+            add_user(a, "And four?")
+            add_assistant(m, a, "Four.")
+            var b = create_chat_renderer(m, SYS, 4l)   // the render path: same turns, tokens only
+            var toks : array<int64>
+            add_user(b, "Count to three.")
+            render_assistant(m, b, "One, two, three.", toks)
+            add_user(b, "And four?")
+            render_assistant(m, b, "Four.", toks)
+            t |> equal(length(b.session.key_cache), 0, "renderer chat allocates no KV")
+            t |> equal(b.session.n_past, 0l, "renderer chat never evals")
+            t |> equal(a.session.n_past, int64(length(toks)), "rendered token count == evaled positions")
+            t |> equal(length(b.history), length(a.history), "transcripts advance in lockstep")
+            t |> equal(b.pending, "", "render_assistant consumed the pending text")
+            t |> success(same(b.stop_ids, a.stop_ids), "renderer resolves the same stop ids")
+            // eval the rendered stream on a fresh session: byte-equal caches ⟺ identical tokens
+            var s <- create_session(m)
+            eval(m, s, toks)
+            t |> success(same(a.session.key_cache, s.key_cache), "key cache byte-equal: rendered ≡ evaled")
+            t |> success(same(a.session.value_cache, s.value_cache), "value cache byte-equal: rendered ≡ evaled")
+            set_prefill_attn_mode(saved_mode)
+            delete s
+            delete b
+            delete a
             delete m
         }
     }

--- a/tests/dasLLAMA/test_facade_docs.das
+++ b/tests/dasLLAMA/test_facade_docs.das
@@ -16,6 +16,7 @@ require daslib/strings_boost
 let FACADE = "modules/dasLLAMA/dasllama/dasllama.das"
 let ENGINE_FILES = [
     "modules/dasLLAMA/dasllama/dasllama_common.das",
+    "modules/dasLLAMA/dasllama/dasllama_prefix.das",
     "modules/dasLLAMA/dasllama/dasllama_chat.das",
     "modules/dasLLAMA/dasllama/dasllama_math.das"   // setup_dasllama_jobque_ (jobque setup lives with the runtime knobs)
 ]

--- a/tests/dasLLAMA/test_fused_decode.das
+++ b/tests/dasLLAMA/test_fused_decode.das
@@ -217,6 +217,73 @@ def test_fused_flash_deep_ctx(t : T?) {
     }
 }
 
+// The q8_0-KV twin of the deep-ctx witness: the sliced K pass runs the int8×int8 quantized-query
+// dot and the witness recomputes through the SAME dot (kv_score), so the 1e-4 in-chain contract
+// holds under the block codec too.
+[test]
+def test_fused_flash_deep_ctx_q8(t : T?) {
+    t |> run("flash-sliced fused chain under q8_0 KV: per-layer witness + structural logit bound (needs SmolLM2-135M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+        if (!stat(path).is_valid) {
+            t |> success(true, "skipped: {path} not present")
+            return
+        }
+        let prev_backend = active_kernel_backend()
+        let prev_thresh = get_target_chunk_work()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            pin_kernel_backend("portable")
+            var tr <- load_gguf(path, QuantMode.q8)
+            tr.config.seq_len = min(tr.config.seq_len, 384l)
+            let c = tr.config
+            let PREFILL = 300  // past the 256 boundary -> the fused side slices (nsl == 2)
+            let STEPS = 4
+            var lg_std : array<float>
+            lg_std |> resize(int(int64(STEPS) * c.vocab_size))
+            var worst = 0.0
+            for (mode in range(2)) {
+                set_fused_decode(mode == 1)
+                set_flash_decode_check(mode == 1)   // panics inside the chain past 1e-4
+                var s <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+                var pos = 0l
+                for (i in range(PREFILL)) {
+                    forward(tr, s, int64(i % 100 + 2), pos)
+                    pos++
+                }
+                for (st in range(STEPS)) {
+                    forward(tr, s, int64(st * 37 + 11), pos)
+                    pos++
+                    let base = int64(st) * c.vocab_size
+                    if (mode == 0) {
+                        for (i in range64(c.vocab_size)) {
+                            lg_std[base + i] = s.logits[i]
+                        }
+                    } else {
+                        for (i in range64(c.vocab_size)) {
+                            worst = max(worst, abs(lg_std[base + i] - s.logits[i]))
+                        }
+                    }
+                }
+                delete s
+            }
+            t |> success(get_flash_decode_check_count() > 0, "the sliced q8 path ran and every layer passed the witness ({get_flash_decode_check_count()} layers checked)")
+            set_flash_decode_check(false)
+            set_fused_decode(true)
+            t |> success(worst < 4.0, "teacher-forced logits within the structural bound (worst |diff| = {worst})")
+            delete lg_std
+            delete tr
+            clear_kernel_backend_pin()
+        }
+        set_target_chunk_work(prev_thresh)
+        select_kernel_backend(prev_backend)
+    }
+}
+
 // pre_post_norm arches (Gemma2/3): the chains defer the residual add and run the post-norm as a
 // serial tail after the rendezvous. gemma-3-1b covers qk-norm + dual-rope sliding (5:1) + the
 // attn deferral; gemma-2-2b covers softcap + GeGLU + qd != dim + alternating sliding.

--- a/tests/dasLLAMA/test_kv_codec.das
+++ b/tests/dasLLAMA/test_kv_codec.das
@@ -119,6 +119,35 @@ def test_kv_layout_f16(t : T?) {
 }
 
 [test]
+def test_kv_runs_flat(t : T?) {
+    t |> run("flat sessions: every window is exactly one identity run; kv_phys_row is identity") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 64l, 16l)
+        var s <- make_run_state(c)
+        t |> equal(1, length(s.kv_runs))   // make_run_state sizes the flat scratch to one entry
+        // whole-window, offset-window, single-row — all one run with row0 == j0
+        var nrun = kv_runs(s, 0l, 16l, s.kv_runs)
+        t |> equal(1l, nrun)
+        t |> equal(0l, s.kv_runs[0].j0)
+        t |> equal(16l, s.kv_runs[0].j1)
+        t |> equal(0l, s.kv_runs[0].row0)
+        nrun = kv_runs(s, 5l, 12l, s.kv_runs)   // sliding-window shape
+        t |> equal(1l, nrun)
+        t |> equal(5l, s.kv_runs[0].j0)
+        t |> equal(12l, s.kv_runs[0].j1)
+        t |> equal(5l, s.kv_runs[0].row0)       // flat: physical row == absolute position
+        nrun = kv_runs(s, 7l, 8l, s.kv_runs)    // one row
+        t |> equal(1l, nrun)
+        t |> equal(7l, s.kv_runs[0].row0)
+        t |> equal(0l, kv_runs(s, 9l, 9l, s.kv_runs))   // empty window: no runs
+        t |> equal(0l, kv_runs(s, 9l, 3l, s.kv_runs))   // inverted window: no runs
+        for (pos in range64(16l)) {
+            t |> equal(pos, kv_phys_row(s, pos))
+        }
+        delete s
+    }
+}
+
+[test]
 def test_kv_store_row_f16(t : T?) {
     t |> run("f16 kv_store_row: RNE convert on store, clamp to ±65504, exact read-back") @(t : T?) {
         let c = mk_config(3l, 4l, 2l, 16l, 4l)

--- a/tests/dasLLAMA/test_kv_codec.das
+++ b/tests/dasLLAMA/test_kv_codec.das
@@ -119,6 +119,94 @@ def test_kv_layout_f16(t : T?) {
 }
 
 [test]
+def test_kv_layout_q8(t : T?) {
+    t |> run("q8_0 sessions: 34-bytes-per-32 prefixes, mixed dtypes walk independently") @(t : T?) {
+        let c = mk_config(4l, 4l, 2l, 64l, 8l)
+        let ref <- ref_prefix_elems(c)
+        var sq <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+        for (l in range64(c.n_layers)) {
+            t |> equal(sq.kv_bprefix_k[l], ref[l] / 32l * 34l)   // block codec: 34 bytes per 32 elements
+            t |> equal(sq.kv_bprefix_v[l], sq.kv_bprefix_k[l])
+        }
+        let wantq = c.seq_len * own_row_elems(c) / 32l * 34l
+        t |> success(int64(length(sq.key_cache)) == wantq, "q8_0 key cache sized exactly (34/32 of the element count)")
+        t |> success(int64(length(sq.value_cache)) == wantq, "q8_0 value cache sized exactly")
+        delete sq
+        var smix <- make_run_state(c, KVDtype.q8_0, KVDtype.f16)   // K/V dtypes stay independent
+        for (l in range64(c.n_layers)) {
+            t |> equal(smix.kv_bprefix_k[l], ref[l] / 32l * 34l)
+            t |> equal(smix.kv_bprefix_v[l], ref[l] * 2l)
+        }
+        delete smix
+    }
+}
+
+// block bi's dequantized element k, read back from stored q8_0 row bytes
+def private q8_row_elem(p : uint8 const?; bi, k : int64) : float {
+    unsafe {
+        let bb = bi * 34l
+        let dh = uint(p[bb]) | (uint(p[bb + 1l]) << 8u)
+        return float(int8(p[bb + 2l + k])) * f16_to_f32(dh)
+    }
+}
+
+[test]
+def test_kv_store_row_q8(t : T?) {
+    t |> run("q8_0 kv_store_row: round-trip within d/2, idempotent re-quantize, head-slot placement") @(t : T?) {
+        let c = mk_config(3l, 4l, 2l, 32l, 6l)
+        let kv_dim = layer_kv_dim(c, 1l)   // 64 = 2 blocks per row
+        var s <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+        var src : array<float>
+        src |> resize(int(kv_dim))
+        for (i in range(length(src))) {
+            src[i] = 3.0 * sin(float(i) * 0.37 + 0.11)   // no exact-zero block, spans +/-
+        }
+        let rowb = kv_row_bytes(KVDtype.q8_0, kv_dim)
+        t |> equal(rowb, kv_dim / 32l * 34l)
+        unsafe {
+            let kbase = kv_base_k(s, 1l, c.seq_len)
+            var kcl = addr(s.key_cache[0]) + kbase
+            kv_store_row(kcl, s.kv_dtype_k, kv_dim, 3l, 0l, kv_dim, reinterpret<float const?>(addr(src[0])))
+            // round-trip: |src - dequant| <= d/2 per element (d = that block's stored scale)
+            let row3 = reinterpret<uint8 const?>(kcl + 3l * rowb)
+            var ok_rt = true
+            var dq : array<float>
+            dq |> resize(int(kv_dim))
+            for (bi in range64(kv_dim / 32l)) {
+                let dh = uint(row3[bi * 34l]) | (uint(row3[bi * 34l + 1l]) << 8u)
+                let d = f16_to_f32(dh)
+                for (k in range64(32l)) {
+                    let v = q8_row_elem(row3, bi, k)
+                    dq[bi * 32l + k] = v
+                    // d/2 from the round, + up to 127·(f16 rounding of d) — quants round with the
+                    // UN-rounded f32 scale but dequant reads the stored f16 one (ggml semantics)
+                    ok_rt &&= abs(src[bi * 32l + k] - v) <= d * 0.57 + 1.0e-7
+                }
+            }
+            t |> success(ok_rt, "every element within half a quantization step (+ f16-scale rounding)")
+            // idempotence: re-quantizing the dequantized row reproduces the bytes exactly
+            kv_store_row(kcl, s.kv_dtype_k, kv_dim, 4l, 0l, kv_dim, reinterpret<float const?>(addr(dq[0])))
+            var idem = true
+            for (b in range64(rowb)) {
+                idem &&= kcl[3l * rowb + b] == kcl[4l * rowb + b]
+            }
+            t |> success(idem, "quantize(dequantize(row)) is byte-identical")
+            // head-slot partial store (sub = head_size = 32): lands at whole-block offset in row 1
+            kv_store_row(kcl, s.kv_dtype_k, kv_dim, 1l, 32l, 32l, reinterpret<float const?>(addr(src[0])))
+            let row1 = reinterpret<uint8 const?>(kcl + 1l * rowb)
+            var ok_sub = true
+            for (k in range64(32l)) {
+                ok_sub &&= abs(src[k] - q8_row_elem(row1, 1l, k)) <= f16_to_f32(uint(row1[34l]) | (uint(row1[35l]) << 8u)) * 0.57 + 1.0e-7
+            }
+            t |> success(ok_sub, "head-slot store lands at the right block")
+            delete dq
+        }
+        delete src
+        delete s
+    }
+}
+
+[test]
 def test_kv_runs_flat(t : T?) {
     t |> run("flat sessions: every window is exactly one identity run; kv_phys_row is identity") @(t : T?) {
         let c = mk_config(2l, 4l, 2l, 64l, 16l)
@@ -346,6 +434,164 @@ def test_kv_f16_prefill_vs_decode(t : T?) {
         set_prefill_attn_mode(prev_mode)
         set_target_chunk_work(prev_thresh)
         delete tr
+    }
+}
+
+// q8_0 model tests run a GGUF carrier (stories15M's head_size 48 is rejected by the create-time
+// 32-block check — by design); SmolLM2-135M is the small head_size-64 carrier, same rail as
+// test_fused_decode. Override the model root with DASLLAMA_MODELS_DIR.
+def private models_dir() : string {
+    let env = get_env_variable("DASLLAMA_MODELS_DIR")
+    return empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+}
+let GGUF_PATH = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+
+def private gguf_missing(t : T?) : bool {
+    if (!jit_enabled()) {
+        t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+        return true
+    }
+    if (!stat(GGUF_PATH).is_valid) {
+        t |> success(true, "skipped: {GGUF_PATH} not present")
+        return true
+    }
+    return false
+}
+
+// teacher-forced per-step logits under one KV config: the SAME deterministic token stream into a
+// fresh session, all N_STEPS logit rows out — trajectory-compounding-free comparisons
+def private forced_logits(tr : Model; kdt, vdt : KVDtype; var out : array<float>) {
+    let c = tr.config
+    out |> resize(int(int64(N_STEPS) * c.vocab_size))
+    var s <- make_run_state(c, kdt, vdt)
+    var pos = 0l
+    for (st in range(N_STEPS)) {
+        forward(tr, s, int64(st * 37 % 100 + 2), pos)
+        pos++
+        let base = int64(st) * c.vocab_size
+        for (i in range64(c.vocab_size)) {
+            out[base + i] = s.logits[i]
+        }
+    }
+    delete s
+}
+
+def private worst_diff(a : array<float>; b : array<float>) : float {
+    var w = 0.0
+    for (i in range(length(a))) {
+        w = max(w, abs(a[i] - b[i]))
+    }
+    return w
+}
+
+[test]
+def test_kv_q8_decode(t : T?) {
+    t |> run("q8_0 KV: teacher-forced logits track f16, fused==std bit-exact under q8 (needs SmolLM2-135M)") @(t : T?) {
+        if (gguf_missing(t)) {
+            return
+        }
+        let prev_backend = active_kernel_backend()
+        let prev_thresh = get_target_chunk_work()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            pin_kernel_backend("portable")   // the rows core every host shares — the fused gate needs one
+            var tr <- load_gguf(GGUF_PATH, QuantMode.q8)
+            tr.config.seq_len = min(tr.config.seq_len, 128l)
+            var lg16 : array<float>
+            var lg8 : array<float>
+            var lg8m : array<float>
+            var lg8f : array<float>
+            set_fused_decode(false)
+            forced_logits(tr, KVDtype.f16, KVDtype.f16, lg16)
+            forced_logits(tr, KVDtype.q8_0, KVDtype.q8_0, lg8)
+            forced_logits(tr, KVDtype.q8_0, KVDtype.f16, lg8m)   // K quantized, V half
+            set_fused_decode(true)
+            forced_logits(tr, KVDtype.q8_0, KVDtype.q8_0, lg8f)
+            // q8 vs f16, teacher-forced: per-step logits stay within the structural bound (greedy
+            // trajectories are NOT compared — on a 135M model a near-tie argmax flips under f16
+            // noise too, and one flip compounds the whole stream). Measured here: q8-vs-f32 noise
+            // is the same order as f16-vs-f32 (~0.4-1.8 worst per step).
+            let w8 = worst_diff(lg16, lg8)
+            t |> success(w8 < 4.0, "q8/q8-vs-f16 teacher-forced logits within the structural bound (worst |diff| = {w8})")
+            let w8m = worst_diff(lg16, lg8m)
+            t |> success(w8m < 4.0, "q8-K/f16-V-vs-f16 within the structural bound (worst |diff| = {w8m})")
+            // fused vs std, BOTH under q8: identical kernels + identical query quants -> bit-exact
+            var lg_bad = 0
+            for (i in range(length(lg8))) {
+                if (lg8[i] != lg8f[i]) {
+                    lg_bad++
+                }
+            }
+            t |> equal(0, lg_bad)
+            delete lg16
+            delete lg8
+            delete lg8m
+            delete lg8f
+            delete tr
+            clear_kernel_backend_pin()
+        }
+        set_target_chunk_work(prev_thresh)
+        select_kernel_backend(prev_backend)
+    }
+}
+
+[test]
+def test_kv_q8_prefill_vs_decode(t : T?) {
+    t |> run("q8_0 KV: blocked prefill == per-token decode, logits + cache bit-exact (needs SmolLM2-135M)") @(t : T?) {
+        if (gguf_missing(t)) {
+            return
+        }
+        let prev_thresh = get_target_chunk_work()
+        let prev_mode = get_prefill_attn_mode()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            set_prefill_attn_mode(AttnPrefillMode.blocked)   // the bit-exact prefill mode (flash reorders)
+            var tr <- load_gguf(GGUF_PATH, QuantMode.q8)
+            tr.config.seq_len = min(tr.config.seq_len, 64l)
+            let c = tr.config
+            var prompt : array<int64>
+            for (i in range(16)) {
+                prompt |> push(int64(i % 50 + 2))
+            }
+            let n = int64(length(prompt))
+            var sp <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+            forward_batch(tr, sp, prompt, n, 0l)
+            var sd <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+            var pos = 0l
+            for (tok in prompt) {
+                forward(tr, sd, tok, pos)
+                pos++
+            }
+            // blocked prefill quantizes its queries and runs the SAME int8×int8 score dot as
+            // decode — the prefill==decode contract stays bit-exact under the block codec
+            var lg_bad = 0
+            for (i in range64(c.vocab_size)) {
+                if (sp.logits[i] != sd.logits[i]) {
+                    lg_bad++
+                }
+            }
+            t |> equal(0, lg_bad)
+            var kv_bad = 0
+            for (i in range(length(sd.key_cache))) {
+                if (sp.key_cache[i] != sd.key_cache[i]) {
+                    kv_bad++
+                }
+            }
+            for (i in range(length(sd.value_cache))) {
+                if (sp.value_cache[i] != sd.value_cache[i]) {
+                    kv_bad++
+                }
+            }
+            t |> equal(0, kv_bad)
+            delete sp
+            delete sd
+            delete prompt
+            delete tr
+        }
+        set_prefill_attn_mode(prev_mode)
+        set_target_chunk_work(prev_thresh)
     }
 }
 

--- a/tests/dasLLAMA/test_kv_paged.das
+++ b/tests/dasLLAMA/test_kv_paged.das
@@ -1,0 +1,486 @@
+options gen2
+options persistent_heap   // the paged/flat A/Bs hold several Sessions (see test_forward.das)
+options stack = 65536
+
+require dastest/testing_boost public
+require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration
+require dasllama/dasllama_math   // setup_dasllama_jobque_ + target_chunk_work
+require daslib/jobque_boost
+require daslib/fio
+
+// Paged KV pool (E2) — pool accounting, block-table run math, and the paged/flat storage seam on
+// synthetic Configs (no model files, never skips); then paged == flat BIT-EXACTNESS on stories15M
+// (decode incl. forced fragmentation, prefill incl. cache bytes, eval_batch — env-gated skips,
+// same contract as test_forward).
+
+def private mk_config(layers, heads, kv_heads, hs, ctx : int64) : Config {
+    return Config(dim = heads * hs, hidden_dim = 32l, n_layers = layers, n_heads = heads,
+        n_kv_heads = kv_heads, vocab_size = 8l, seq_len = ctx, head_size = hs,
+        kv_dim = kv_heads * hs, shared_weights = true, rope_freq_base = 10000.0)
+}
+
+// the E-series shape from test_kv_codec: layers 4 (sliding -> src 2) and 5 (global -> src 3) share
+def private mk_shared_config() : Config {
+    var c = mk_config(6l, 4l, 2l, 64l, 8l)
+    c.sliding_window = 4l
+    c.swa_pattern = 2l
+    c.n_layer_kv_from_start = 4l
+    return c
+}
+
+[test]
+def test_kv_pool_layout(t : T?) {
+    t |> run("blob_of aliases shared-KV layers; row bytes track the dtype; blobs start empty") @(t : T?) {
+        let c = mk_shared_config()
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f16, KVDtype.f32)
+        t |> equal(int64(length(pool.blob_of)), c.n_layers)
+        t |> equal(pool.nblobs, 4l)   // layers 0..3 own, 4/5 alias
+        t |> equal(pool.blob_of[4], pool.blob_of[2])
+        t |> equal(pool.blob_of[5], pool.blob_of[3])
+        for (l in range64(4l)) {
+            t |> equal(pool.krow_bytes[pool.blob_of[l]], layer_kv_dim(c, l) * 2l)   // f16 K
+            t |> equal(pool.vrow_bytes[pool.blob_of[l]], layer_kv_dim(c, l) * 4l)   // f32 V
+        }
+        t |> equal(pool.capacity_groups, 0l)
+        t |> equal(0, length(pool.kblobs[0]))   // nothing allocated until a session needs a page
+        delete pool
+    }
+}
+
+[test]
+def test_kv_pool_alloc_release(t : T?) {
+    t |> run("alloc pops LIFO from a geometrically grown free list; release returns at refcnt 0") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 16l, 32l)
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        let g0 = kv_pool_alloc_group(pool)
+        let g1 = kv_pool_alloc_group(pool)
+        t |> equal(0, g0)   // first grow pushes high->low, so the lowest id pops first
+        t |> equal(1, g1)
+        t |> equal(pool.capacity_groups, 4l)
+        t |> equal(int64(length(pool.kblobs[0])), 4l * 4l * pool.krow_bytes[0])
+        t |> equal(1, pool.refcnt[g0])
+        kv_pool_release_group(pool, g0)
+        t |> equal(0, pool.refcnt[g0])
+        t |> equal(3, length(pool.free_groups))
+        let g0b = kv_pool_alloc_group(pool)
+        t |> equal(g0, g0b)   // LIFO: the just-freed group comes back first
+        // exhaust the first grow, then force the geometric second one
+        for (_i in range(2)) {
+            kv_pool_alloc_group(pool)
+        }
+        t |> equal(pool.capacity_groups, 4l)
+        let g4 = kv_pool_alloc_group(pool)
+        t |> equal(4, g4)
+        t |> equal(pool.capacity_groups, 8l)
+        delete pool
+    }
+}
+
+[test]
+def test_kv_ensure_growth(t : T?) {
+    t |> run("kv_ensure grows the block table to cover [0, upto); release returns every page") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 16l, 32l)
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        var s <- make_run_state_paged(c, pool)
+        t |> success(s.kv_pool != null, "paged session carries the pool")
+        t |> equal(0, length(s.key_cache))    // flat slabs stay empty
+        t |> equal(0, length(s.value_cache))
+        kv_ensure(s, 1l)
+        t |> equal(1, length(s.block_table))
+        kv_ensure(s, 9l)                      // ceil(9/4) = 3 pages
+        t |> equal(3, length(s.block_table))
+        kv_ensure(s, 9l)                      // idempotent
+        t |> equal(3, length(s.block_table))
+        kv_ensure(s, 2l)                      // never shrinks
+        t |> equal(3, length(s.block_table))
+        release_kv_pages_(s)
+        t |> equal(0, length(s.block_table))
+        var live = 0
+        for (g in range64(pool.capacity_groups)) {
+            live += pool.refcnt[g]
+        }
+        t |> equal(0, live)
+        t |> equal(int64(length(pool.free_groups)), pool.capacity_groups)   // accounting back to baseline
+        release_kv_pages_(s)                  // no-op on an empty table
+        delete s
+        delete pool
+    }
+}
+
+[test]
+def test_kv_runs_paged(t : T?) {
+    t |> run("paged kv_runs: page-span runs through the block table, physically-consecutive spans merge") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 16l, 16l)
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        var s <- make_run_state_paged(c, pool)
+        t |> equal(5, length(s.kv_runs))   // ceil(16/4) + 1 worst-case scratch
+        // identity table: pages are physically consecutive -> every window merges to ONE run
+        for (g in range(4)) {
+            s.block_table |> push(g)
+        }
+        var nrun = kv_runs(s, 0l, 16l, s.kv_runs)
+        t |> equal(1l, nrun)
+        t |> equal(0l, s.kv_runs[0].j0)
+        t |> equal(16l, s.kv_runs[0].j1)
+        t |> equal(0l, s.kv_runs[0].row0)
+        nrun = kv_runs(s, 5l, 12l, s.kv_runs)   // straddles pages 1..2, still consecutive
+        t |> equal(1l, nrun)
+        t |> equal(5l, s.kv_runs[0].row0)
+        // shuffled table: every straddled boundary splits, row0 goes through the table
+        s.block_table[0] = 2
+        s.block_table[1] = 0
+        s.block_table[2] = 3
+        s.block_table[3] = 1
+        nrun = kv_runs(s, 5l, 12l, s.kv_runs)   // [5,8) in page 1, [8,12) in page 2
+        t |> equal(2l, nrun)
+        t |> equal(5l, s.kv_runs[0].j0)
+        t |> equal(8l, s.kv_runs[0].j1)
+        t |> equal(1l, s.kv_runs[0].row0)       // group 0, in-page offset 1
+        t |> equal(8l, s.kv_runs[1].j0)
+        t |> equal(12l, s.kv_runs[1].j1)
+        t |> equal(12l, s.kv_runs[1].row0)      // group 3 * 4
+        nrun = kv_runs(s, 6l, 8l, s.kv_runs)    // inside one page
+        t |> equal(1l, nrun)
+        t |> equal(2l, s.kv_runs[0].row0)
+        t |> equal(0l, kv_runs(s, 9l, 9l, s.kv_runs))   // empty window
+        t |> equal(0l, kv_runs(s, 9l, 3l, s.kv_runs))   // inverted window
+        // partial merge: pages 2 and 3 hold groups 3 and 1 -> [8,16) splits; pages 0 and 1 hold
+        // groups 2 and 0 -> no merge either; but a table like [0,1,3,...] merges only the 0/1 seam
+        s.block_table[0] = 0
+        s.block_table[1] = 1
+        s.block_table[2] = 3
+        nrun = kv_runs(s, 0l, 12l, s.kv_runs)
+        t |> equal(2l, nrun)
+        t |> equal(8l, s.kv_runs[0].j1)   // pages 0+1 merged
+        t |> equal(12l, s.kv_runs[1].row0)
+        // kv_phys_row goes through the same table
+        t |> equal(1l, kv_phys_row(s, 1l))
+        t |> equal(5l, kv_phys_row(s, 5l))
+        t |> equal(13l, kv_phys_row(s, 9l))   // page 2 = group 3: 3*4 + 1
+        s.block_table |> clear()   // hand-built table, never pool-allocated: don't release
+        delete s
+        delete pool
+    }
+}
+
+[test]
+def test_kv_paged_memory_proportional(t : T?) {
+    t |> run("paged cache bytes track actual context, not seq_len") @(t : T?) {
+        let c = mk_config(4l, 4l, 2l, 64l, 1024l)
+        var flat <- make_run_state(c)
+        let flat_bytes = int64(length(flat.key_cache)) + int64(length(flat.value_cache))
+        delete flat
+        var pool <- create_kv_pool_(c, 64l, KVDtype.f32, KVDtype.f32)
+        var s <- make_run_state_paged(c, pool)
+        kv_ensure(s, 10l)   // 10 positions -> 1 page -> first grow (4 groups)
+        var paged_bytes = 0l
+        for (b in range64(pool.nblobs)) {
+            paged_bytes += int64(length(pool.kblobs[b])) + int64(length(pool.vblobs[b]))
+        }
+        t |> success(paged_bytes * 2l < flat_bytes,
+            "10-position paged pool ({paged_bytes}B) is far under the flat slabs ({flat_bytes}B)")
+        kv_ensure(s, 600l)   // 10 pages -> grows toward the context, still bounded
+        var grown = 0l
+        for (b in range64(pool.nblobs)) {
+            grown += int64(length(pool.kblobs[b])) + int64(length(pool.vblobs[b]))
+        }
+        t |> success(grown > paged_bytes, "deeper context grows the pool")
+        release_kv_pages_(s)
+        delete s
+        delete pool
+    }
+}
+
+[test]
+def test_kv_paged_store_roundtrip(t : T?) {
+    t |> run("kv_store_row through kv_layer_kbase + kv_phys_row round-trips; shared layers alias") @(t : T?) {
+        let c = mk_shared_config()
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        var s <- make_run_state_paged(c, pool)
+        kv_ensure(s, 7l)   // 2 pages
+        let kv_dim = layer_kv_dim(c, 1l)
+        var src : array<float>
+        src |> resize(int(kv_dim))
+        for (i in range(length(src))) {
+            src[i] = float(i) * 0.25 - 3.0
+        }
+        unsafe {
+            var kcl = kv_layer_kbase(s, 1l, c.seq_len)
+            let pos = 6l   // second page
+            kv_store_row(kcl, s.kv_dtype_k, kv_dim, kv_phys_row(s, pos), 0l, kv_dim,
+                reinterpret<float const?>(addr(src[0])))
+            var d = reinterpret<float const?>(kcl)
+            var ok = true
+            for (i in range64(kv_dim)) {
+                ok &&= d[kv_phys_row(s, pos) * kv_dim + i] == src[i]
+            }
+            t |> success(ok, "paged store reads back exactly at the block-table row")
+            // shared-KV layers alias their source's blob — same base pointer
+            t |> success(kv_layer_kbase(s, 4l, c.seq_len) == kv_layer_kbase(s, 2l, c.seq_len),
+                "layer 4 K base aliases its source layer 2")
+            t |> success(kv_layer_vbase(s, 5l, c.seq_len) == kv_layer_vbase(s, 3l, c.seq_len),
+                "layer 5 V base aliases its source layer 3")
+        }
+        delete src
+        release_kv_pages_(s)
+        delete s
+        delete pool
+    }
+}
+
+// ===== paged == flat bit-exactness on a real model (env-gated, JIT-only) =====
+
+def private llama2c_dir() : string {
+    let env = get_env_variable("DASLLAMA_LLAMA2C_DIR")
+    return empty(env) ? "/Users/borisbatkin/Work/llama2.c" : env
+}
+let MODEL_PATH = path_join(llama2c_dir(), "stories15M.bin")
+
+def private mk_prompt(n : int64) : array<int64> {
+    return <- [for (i in range64(n)); 2l + i % 40l]
+}
+
+def private argmax_of(s : Session; vocab : int64) : int64 {
+    var best = 0l
+    for (i in range64(1l, vocab)) {
+        if (s.logits[i] > s.logits[best]) {
+            best = i
+        }
+    }
+    return best
+}
+
+def private logits_equal(a : Session; b : Session; vocab : int64) : bool {
+    for (i in range64(vocab)) {
+        if (a.logits[i] != b.logits[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+// per-(layer, position) cache-row byte compare through the storage seam — flat rows at identity,
+// paged rows through the block table
+def private cache_rows_equal(var sf : Session; var sp : Session; c : Config; npos : int64) : bool {
+    unsafe {
+        for (l in range64(c.n_layers)) {
+            let kvd = layer_kv_dim(c, l)
+            let krb = kv_row_bytes(sf.kv_dtype_k, kvd)
+            let vrb = kv_row_bytes(sf.kv_dtype_v, kvd)
+            var fk = kv_layer_kbase(sf, l, c.seq_len)
+            var pk = kv_layer_kbase(sp, l, c.seq_len)
+            var fv = kv_layer_vbase(sf, l, c.seq_len)
+            var pv = kv_layer_vbase(sp, l, c.seq_len)
+            for (pos in range64(npos)) {
+                let pr = kv_phys_row(sp, pos)
+                for (b in range64(krb)) {
+                    if (fk[pos * krb + b] != pk[pr * krb + b]) {
+                        return false
+                    }
+                }
+                for (b in range64(vrb)) {
+                    if (fv[pos * vrb + b] != pv[pr * vrb + b]) {
+                        return false
+                    }
+                }
+            }
+        }
+    }
+    return true
+}
+
+[test]
+def test_kv_paged_decode(t : T?) {
+    t |> run("interleaved paged sessions == flat, bit-exact under fragmentation (needs stories15M.bin)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        if (!stat(MODEL_PATH).is_valid) {
+            t |> success(true, "skipped: stories15M.bin not present")
+            return
+        }
+        var tr <- load_checkpoint(MODEL_PATH)
+        let c = tr.config
+        quantize_weights(tr)
+        let prev_thresh = get_target_chunk_work()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            // two paged sessions interleave allocations on ONE pool (P=16), so their pages
+            // FRAGMENT: [0,2,4] vs [1,3,5]. Each decodes a deterministic token stream and must
+            // stay bit-exact against its own flat reference, every step.
+            var pool <- create_kv_pool_(c, 16l, KVDtype.f32, KVDtype.f32)
+            var pa <- make_run_state_paged(c, pool)
+            var pb <- make_run_state_paged(c, pool)
+            var fa <- make_run_state(c)
+            var fb <- make_run_state(c)
+            let nsteps = 40l
+            var bad = 0
+            for (i in range64(nsteps)) {
+                let ta = 2l + (i * 7l) % (c.vocab_size - 2l)
+                let tb = 2l + (i * 11l) % (c.vocab_size - 2l)
+                forward(tr, pa, ta, i)
+                forward(tr, pb, tb, i)
+                forward(tr, fa, ta, i)
+                forward(tr, fb, tb, i)
+                if (!logits_equal(pa, fa, c.vocab_size) || !logits_equal(pb, fb, c.vocab_size)) {
+                    bad ++
+                }
+            }
+            t |> equal(0, bad)
+            t |> equal(3, length(pa.block_table))
+            t |> success(pa.block_table[1] != pa.block_table[0] + 1,
+                "interleaved sessions actually fragment the pool")
+            t |> success(cache_rows_equal(fa, pa, c, nsteps), "session A cache rows byte-equal flat")
+            t |> success(cache_rows_equal(fb, pb, c, nsteps), "session B cache rows byte-equal flat")
+            release_kv_pages_(pa)
+            release_kv_pages_(pb)
+            delete pa
+            delete pb
+            delete fa
+            delete fb
+            delete pool
+        }
+        set_target_chunk_work(prev_thresh)
+        delete tr
+    }
+}
+
+[test]
+def test_kv_paged_prefill(t : T?) {
+    t |> run("paged prefill == flat prefill: logits and cache rows bit-exact (needs stories15M.bin)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        if (!stat(MODEL_PATH).is_valid) {
+            t |> success(true, "skipped: stories15M.bin not present")
+            return
+        }
+        var tr <- load_checkpoint(MODEL_PATH)
+        let c = tr.config
+        quantize_weights(tr)
+        let prev_thresh = get_target_chunk_work()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            var prompt : array<int64>
+            for (i in range(21)) {   // straddles pages at P=8 (2 full + 1 partial)
+                prompt |> push(int64(i % 50 + 2))
+            }
+            let n = int64(length(prompt))
+            var pool <- create_kv_pool_(c, 8l, KVDtype.f32, KVDtype.f32)
+            var sp <- make_run_state_paged(c, pool)
+            forward_batch(tr, sp, prompt, n, 0l)
+            var sf <- make_run_state(c)
+            forward_batch(tr, sf, prompt, n, 0l)
+            t |> success(logits_equal(sp, sf, c.vocab_size), "prefill logits bit-exact")
+            t |> success(cache_rows_equal(sf, sp, c, n), "prefill cache rows byte-equal flat")
+            // decode a few more on top of the paged prefill, against the flat reference
+            var tok = argmax_of(sf, c.vocab_size)
+            var bad = 0
+            for (i in range64(8l)) {
+                forward(tr, sp, tok, n + i)
+                forward(tr, sf, tok, n + i)
+                if (!logits_equal(sp, sf, c.vocab_size)) {
+                    bad ++
+                }
+                tok = argmax_of(sf, c.vocab_size)
+            }
+            t |> equal(0, bad)
+            release_kv_pages_(sp)
+            delete sp
+            delete sf
+            delete pool
+            delete prompt
+        }
+        set_target_chunk_work(prev_thresh)
+        delete tr
+    }
+}
+
+[test]
+def test_kv_paged_eval_batch(t : T?) {
+    t |> run("paged eval_batch == flat eval_batch, ragged depths on one pool (needs stories15M.bin)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        if (!stat(MODEL_PATH).is_valid) {
+            t |> success(true, "skipped: stories15M.bin not present")
+            return
+        }
+        var tr <- load_checkpoint(MODEL_PATH)
+        let c = tr.config
+        quantize_weights(tr)
+        let prev_thresh = get_target_chunk_work()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            // ragged depths: 1, 2 and 3 pages at P=8; q0 crosses a page boundary MID-batch-decode
+            // (kv_ensure growth inside eval_batch), and the sequential prefills interleave the
+            // sessions' groups in the pool
+            var p0 <- mk_prompt(5l)
+            var p1 <- mk_prompt(9l)
+            var p2 <- mk_prompt(17l)
+            var pool <- create_kv_pool_(c, 8l, KVDtype.f32, KVDtype.f32)
+            var q0 <- make_run_state_paged(c, pool)
+            var q1 <- make_run_state_paged(c, pool)
+            var q2 <- make_run_state_paged(c, pool)
+            var f0 <- make_run_state(c)
+            var f1 <- make_run_state(c)
+            var f2 <- make_run_state(c)
+            eval_(tr, q0, p0)
+            eval_(tr, q1, p1)
+            eval_(tr, q2, p2)
+            eval_(tr, f0, p0)
+            eval_(tr, f1, p1)
+            eval_(tr, f2, p2)
+            var ws <- create_batch_workspace_(tr)
+            var qsess <- [unsafe(addr(q0)), unsafe(addr(q1)), unsafe(addr(q2))]
+            var fsess <- [unsafe(addr(f0)), unsafe(addr(f1)), unsafe(addr(f2))]
+            var toks : array<int64>
+            toks |> resize(3)
+            var bad = 0
+            for (step in range64(6l)) {
+                for (i in range64(3l)) {
+                    toks[i] = 100l + step * 3l + i
+                }
+                eval_batch_(tr, ws, qsess, toks)
+                eval_batch_(tr, ws, fsess, toks)
+                for (i in range64(3l)) {
+                    if (!logits_equal(*qsess[i], *fsess[i], c.vocab_size)) {
+                        bad ++
+                    }
+                }
+            }
+            t |> equal(0, bad)
+            t |> equal(q0.n_past, f0.n_past)
+            t |> success(cache_rows_equal(f2, q2, c, q2.n_past), "deepest row cache rows byte-equal flat")
+            release_kv_pages_(q0)
+            release_kv_pages_(q1)
+            release_kv_pages_(q2)
+            qsess |> clear()   // drop the borrowed handles: delete of array<T?> cascades to the pointees
+            fsess |> clear()
+            unsafe {
+                delete ws
+                delete qsess
+                delete fsess
+            }
+            delete toks
+            delete q0
+            delete q1
+            delete q2
+            delete f0
+            delete f1
+            delete f2
+            delete pool
+            delete p0
+            delete p1
+            delete p2
+        }
+        set_target_chunk_work(prev_thresh)
+        delete tr
+    }
+}

--- a/tests/dasLLAMA/test_kv_paged.das
+++ b/tests/dasLLAMA/test_kv_paged.das
@@ -348,6 +348,67 @@ def test_kv_paged_decode(t : T?) {
 }
 
 [test]
+def test_kv_paged_q8(t : T?) {
+    t |> run("paged q8_0 sessions == flat q8_0, bit-exact under fragmentation (needs SmolLM2-135M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        // q8_0 needs a head_size-64 carrier (stories15M's 48 is rejected by the 32-block check)
+        let env = get_env_variable("DASLLAMA_MODELS_DIR")
+        let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+        let path = path_join(mdir, "SmolLM2-135M-Instruct-Q8_0.gguf")
+        if (!stat(path).is_valid) {
+            t |> success(true, "skipped: {path} not present")
+            return
+        }
+        var tr <- load_gguf(path, QuantMode.q8)
+        if (tr.config.seq_len > 64l) {   // cap the KV allocation (no math require here)
+            tr.config.seq_len = 64l
+        }
+        let c = tr.config
+        let prev_thresh = get_target_chunk_work()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            // two q8 paged sessions interleave on ONE pool (P=16): fragmented BYTE-strided runs
+            var pool <- create_kv_pool_(c, 16l, KVDtype.q8_0, KVDtype.q8_0)
+            var pa <- make_run_state_paged(c, pool)
+            var pb <- make_run_state_paged(c, pool)
+            var fa <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+            var fb <- make_run_state(c, KVDtype.q8_0, KVDtype.q8_0)
+            let nsteps = 40l
+            var bad = 0
+            for (i in range64(nsteps)) {
+                let ta = 2l + (i * 7l) % (c.vocab_size - 2l)
+                let tb = 2l + (i * 11l) % (c.vocab_size - 2l)
+                forward(tr, pa, ta, i)
+                forward(tr, pb, tb, i)
+                forward(tr, fa, ta, i)
+                forward(tr, fb, tb, i)
+                if (!logits_equal(pa, fa, c.vocab_size) || !logits_equal(pb, fb, c.vocab_size)) {
+                    bad ++
+                }
+            }
+            t |> equal(0, bad)
+            t |> success(pa.block_table[1] != pa.block_table[0] + 1,
+                "interleaved sessions actually fragment the pool")
+            t |> success(cache_rows_equal(fa, pa, c, nsteps), "session A q8 cache rows byte-equal flat")
+            t |> success(cache_rows_equal(fb, pb, c, nsteps), "session B q8 cache rows byte-equal flat")
+            release_kv_pages_(pa)
+            release_kv_pages_(pb)
+            delete pa
+            delete pb
+            delete fa
+            delete fb
+            delete pool
+        }
+        set_target_chunk_work(prev_thresh)
+        delete tr
+    }
+}
+
+[test]
 def test_kv_paged_prefill(t : T?) {
     t |> run("paged prefill == flat prefill: logits and cache rows bit-exact (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {

--- a/tests/dasLLAMA/test_kv_prefix.das
+++ b/tests/dasLLAMA/test_kv_prefix.das
@@ -1,0 +1,281 @@
+options gen2
+options persistent_heap   // several Sessions live at once (see test_forward.das)
+options stack = 65536
+
+require dastest/testing_boost public
+require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration
+require dasllama/dasllama_prefix
+require dasllama/dasllama_math   // setup_dasllama_jobque_ + target_chunk_work
+require daslib/jobque_boost
+require daslib/fio
+
+// Prefix cache (S5) — accounting, the attach cap, LRU budget, and token verification on a tiny
+// synthetic Config (no model files, never skips); then warm == cold BIT-EXACT reuse on stories15M
+// (classic prefill is chunk-invariant, so attached pages + a tail eval reproduce the cold logits
+// byte for byte).
+
+def private mk_config(layers, heads, kv_heads, hs, ctx : int64) : Config {
+    return Config(dim = heads * hs, hidden_dim = 32l, n_layers = layers, n_heads = heads,
+        n_kv_heads = kv_heads, vocab_size = 8l, seq_len = ctx, head_size = hs,
+        kv_dim = kv_heads * hs, shared_weights = true, rope_freq_base = 10000.0)
+}
+
+[test]
+def test_prefix_accounting(t : T?) {
+    t |> run("insert holds pages past session release; attach shares them; release returns all") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 16l, 32l)
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        var cache <- create_prefix_cache_()
+        var s <- make_run_state_paged(c, pool)
+        kv_ensure(s, 8l)          // 2 pages at P=4
+        s.n_past = 8l             // structural test: pretend both pages are evaled
+        var toks <- [for (i in range64(8l)); 100l + i]
+        prefix_insert_(cache, pool, s, toks)
+        t |> equal(2l, prefix_held_groups_(cache))
+        let g0 = s.block_table[0]
+        let g1 = s.block_table[1]
+        t |> equal(2, pool.refcnt[g0])   // session + cache
+        release_kv_pages_(s)
+        t |> equal(1, pool.refcnt[g0])   // the cache keeps donated pages alive
+        t |> equal(1, pool.refcnt[g1])
+        // np == 8 -> pages_max = (8-1)/4 = 1: the cap leaves a tail to eval for logits
+        var w <- make_run_state_paged(c, pool)
+        t |> equal(4l, prefix_attach_(cache, pool, w, toks))
+        t |> equal(4l, w.n_past)
+        t |> equal(1, length(w.block_table))
+        t |> equal(g0, w.block_table[0])
+        t |> equal(2, pool.refcnt[g0])
+        // a longer prompt with the same 8-token prefix attaches BOTH pages
+        var toks12 <- [for (i in range64(12l)); i < 8l ? 100l + i : 900l + i]
+        var w2 <- make_run_state_paged(c, pool)
+        t |> equal(8l, prefix_attach_(cache, pool, w2, toks12))
+        t |> equal(3, pool.refcnt[g0])
+        // divergence in page 0 -> no match, nothing attached
+        var other <- [for (i in range64(8l)); 500l + i]
+        var w3 <- make_run_state_paged(c, pool)
+        t |> equal(0l, prefix_attach_(cache, pool, w3, other))
+        t |> equal(0, length(w3.block_table))
+        t |> equal(0l, w3.n_past)
+        release_kv_pages_(w)
+        release_kv_pages_(w2)
+        prefix_release_(cache, pool)
+        t |> equal(int64(length(pool.free_groups)), pool.capacity_groups)   // accounting to baseline
+        var live = 0
+        for (g in range64(pool.capacity_groups)) {
+            live += pool.refcnt[g]
+        }
+        t |> equal(0, live)
+        delete other
+        delete toks12
+        delete toks
+        delete w
+        delete w2
+        delete w3
+        delete s
+        delete cache
+        delete pool
+    }
+}
+
+[test]
+def test_prefix_lru_budget(t : T?) {
+    t |> run("max_groups LRU-drops the oldest page; a dropped page a session still uses stays alive") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 16l, 32l)
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        var cache <- create_prefix_cache_(2l)   // hold at most 2 pages
+        var s <- make_run_state_paged(c, pool)
+        kv_ensure(s, 12l)   // 3 pages
+        s.n_past = 12l
+        var toks <- [for (i in range64(12l)); 100l + i]
+        prefix_insert_(cache, pool, s, toks)   // 3 donated -> the oldest (page 0) LRU-drops
+        t |> equal(2l, prefix_held_groups_(cache))
+        t |> equal(1l, cache.n_evicted_pages)
+        t |> equal(1, pool.refcnt[s.block_table[0]])   // dropped: only the session holds it
+        t |> equal(2, pool.refcnt[s.block_table[1]])
+        // page 0 is gone and the chain starts there -> attach misses at once
+        var w <- make_run_state_paged(c, pool)
+        t |> equal(0l, prefix_attach_(cache, pool, w, toks))
+        release_kv_pages_(s)
+        prefix_release_(cache, pool)
+        t |> equal(int64(length(pool.free_groups)), pool.capacity_groups)
+        delete toks
+        delete w
+        delete s
+        delete cache
+        delete pool
+    }
+}
+
+[test]
+def test_prefix_verify_tokens(t : T?) {
+    t |> run("hashes route, tokens verify: a corrupted entry refuses to attach") @(t : T?) {
+        let c = mk_config(2l, 4l, 2l, 16l, 32l)
+        var pool <- create_kv_pool_(c, 4l, KVDtype.f32, KVDtype.f32)
+        var cache <- create_prefix_cache_()
+        var s <- make_run_state_paged(c, pool)
+        kv_ensure(s, 8l)
+        s.n_past = 8l
+        var toks <- [for (i in range64(8l)); 100l + i]
+        prefix_insert_(cache, pool, s, toks)
+        for (e in values(cache.entries)) {   // simulate a hash collision: key routes, tokens differ
+            e.tokens[0] = 424242l
+        }
+        var w <- make_run_state_paged(c, pool)
+        t |> equal(0l, prefix_attach_(cache, pool, w, toks))
+        t |> equal(0, length(w.block_table))
+        release_kv_pages_(s)
+        prefix_release_(cache, pool)
+        delete toks
+        delete w
+        delete s
+        delete cache
+        delete pool
+    }
+}
+
+// ===== warm == cold bit-exactness on a real model (env-gated, JIT-only) =====
+
+def private llama2c_dir() : string {
+    let env = get_env_variable("DASLLAMA_LLAMA2C_DIR")
+    return empty(env) ? "/Users/borisbatkin/Work/llama2.c" : env
+}
+let MODEL_PATH = path_join(llama2c_dir(), "stories15M.bin")
+
+def private argmax_of(s : Session; vocab : int64) : int64 {
+    var best = 0l
+    for (i in range64(1l, vocab)) {
+        if (s.logits[i] > s.logits[best]) {
+            best = i
+        }
+    }
+    return best
+}
+
+def private logits_match(s : Session; all : array<float>; snap, vocab : int64) : bool {
+    for (i in range64(vocab)) {
+        if (s.logits[i] != all[snap * vocab + i]) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def test_prefix_warm_equals_cold(t : T?) {
+    t |> run("attached pages + tail eval == cold prefill, bit-exact (needs stories15M.bin)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        if (!stat(MODEL_PATH).is_valid) {
+            t |> success(true, "skipped: stories15M.bin not present")
+            return
+        }
+        var tr <- load_checkpoint(MODEL_PATH)
+        let c = tr.config
+        quantize_weights(tr)
+        let prev_thresh = get_target_chunk_work()
+        let saved_mode = get_prefill_attn_mode()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            set_target_chunk_work(1l)
+            // classic prefill is bit-exact under ANY chunking (test_prefill's contract), so the
+            // warm tail eval must reproduce the cold single-shot prefill byte for byte
+            set_prefill_attn_mode(AttnPrefillMode.classic)
+            var prompt <- [for (i in range64(21l)); 2l + i % 40l]
+            let np = int64(length(prompt))
+            let nsteps = 8l
+            var pool <- create_kv_pool_(c, 8l, KVDtype.f32, KVDtype.f32)
+            var cache <- create_prefix_cache_()
+            // COLD: single-shot prefill + greedy decode, snapshotting every logits vector
+            var cold <- make_run_state_paged(c, pool)
+            eval_(tr, cold, prompt)
+            var cold_all : array<float>
+            cold_all |> push_from(cold.logits)
+            var cold_toks : array<int64>
+            var one : array<int64>
+            one |> resize(1)
+            var tok = argmax_of(cold, c.vocab_size)
+            for (_i in range64(nsteps)) {
+                cold_toks |> push(tok)
+                one[0] = tok
+                eval_(tr, cold, one)
+                cold_all |> push_from(cold.logits)
+                tok = argmax_of(cold, c.vocab_size)
+            }
+            // donate: full evaled history = prompt + sampled tokens, floor(29/8) = 3 pages
+            var full : array<int64>
+            full |> push_from(prompt)
+            full |> push_from(cold_toks)
+            prefix_insert_(cache, pool, cold, full)
+            t |> equal(3l, prefix_held_groups_(cache))
+            let g0 = cold.block_table[0]
+            let g1 = cold.block_table[1]
+            release_kv_pages_(cold)
+            // WARM: attach 2 pages ((21-1)/8), classic-eval only the 5-token tail
+            var warm <- make_run_state_paged(c, pool)
+            t |> equal(16l, prefix_attach_(cache, pool, warm, prompt))
+            t |> equal(g0, warm.block_table[0])   // the pages are SHARED, not copied
+            t |> equal(g1, warm.block_table[1])
+            t |> equal(2, pool.refcnt[g0])        // cache + warm
+            var tail <- [for (j in range64(16l, np)); prompt[j]]
+            eval_(tr, warm, tail)
+            t |> success(logits_match(warm, cold_all, 0l, c.vocab_size), "post-prefill logits bit-exact")
+            var wtok = argmax_of(warm, c.vocab_size)
+            var bad = 0
+            for (i in range64(nsteps)) {
+                if (wtok != cold_toks[i]) {
+                    bad ++
+                }
+                one[0] = wtok
+                eval_(tr, warm, one)
+                if (!logits_match(warm, cold_all, 1l + i, c.vocab_size)) {
+                    bad ++
+                }
+                wtok = argmax_of(warm, c.vocab_size)
+            }
+            t |> equal(0, bad)
+            // DIVERGENT suffix: same 16-token prefix, different tail — warm attach == its own cold
+            var prompt2 : array<int64>
+            for (i in range64(24l)) {
+                prompt2 |> push(i < 16l ? prompt[i] : 3l + i % 30l)
+            }
+            var cold2 <- make_run_state_paged(c, pool)
+            eval_(tr, cold2, prompt2)
+            var warm2 <- make_run_state_paged(c, pool)
+            t |> equal(16l, prefix_attach_(cache, pool, warm2, prompt2))
+            var tail2 <- [for (j in range64(16l, 24l)); prompt2[j]]
+            eval_(tr, warm2, tail2)
+            var bad2 = 0
+            for (i in range64(c.vocab_size)) {
+                if (warm2.logits[i] != cold2.logits[i]) {
+                    bad2 ++
+                }
+            }
+            t |> equal(0, bad2)
+            // teardown: everything returns to the pool
+            release_kv_pages_(warm)
+            release_kv_pages_(warm2)
+            release_kv_pages_(cold2)
+            prefix_release_(cache, pool)
+            t |> equal(int64(length(pool.free_groups)), pool.capacity_groups)
+            delete tail2
+            delete warm2
+            delete cold2
+            delete prompt2
+            delete tail
+            delete warm
+            delete full
+            delete one
+            delete cold_toks
+            delete cold_all
+            delete cold
+            delete cache
+            delete pool
+            delete prompt
+        }
+        set_prefill_attn_mode(saved_mode)
+        set_target_chunk_work(prev_thresh)
+        delete tr
+    }
+}

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -4,15 +4,17 @@ A drop-in OpenAI-compatible server for [dasLLAMA](../../modules/dasLLAMA) CPU in
 entirely in daslang over the public dasLLAMA facade + the `dasHV` HTTP layer. Point any OpenAI
 client (opencode, Open WebUI, the `llm` CLI, the `openai` Python SDK, …) at `http://127.0.0.1:<port>/v1`.
 
-It reaches **only** public facade verbs (`load_model` / `create_chat` / `add_user` / `add_assistant` /
-`respond` / `transcribe` / `embed`) — that is the point: the server is the acceptance test for the
-API rework. If it builds with no reach into engine internals, the facade is complete.
+It reaches **only** public facade verbs (`load_model` / `create_chat_renderer` / `add_user` /
+`render_assistant` / `render_turn` / `eval_batch` via `llm_scheduler` / `transcribe` / `embed`) —
+that is the point: the server is the acceptance test for the API rework. If it builds with no
+reach into engine internals, the facade is complete.
 
 ## Run
 
 ```sh
 bin/daslang -jit utils/dasllama-server/main.das -- --model <model.gguf> [--port 8080] [--quant q8] \
-                                                    [--asr <asr.bin>] [--mmproj <mmproj.gguf>] [--ctx 4096]
+                                                    [--asr <asr.bin>] [--mmproj <mmproj.gguf>] [--ctx 4096] \
+                                                    [--streams 4] [--chunk 64]
 ```
 
 Run under `-jit` — interpreted inference is far too slow. Flags:
@@ -25,11 +27,17 @@ Run under `-jit` — interpreted inference is far too slow. Flags:
 | `--asr` | `-a` | — | ASR model (whisper/parakeet/qwen3-asr) — enables the `/v1/audio/*` routes |
 | `--mmproj` | — | — | mmproj GGUF for the Qwen3-ASR route (paired with `--asr`) |
 | `--ctx` | — | `4096` | Context-length cap in tokens |
+| `--streams` | `-s` | `4` | Max concurrent generation streams (each holds a full KV cache) |
+| `--chunk` | — | `64` | Prefill quantum in tokens — decode stalls at most this per tick |
 | `--help` | `-?` | — | Show help and exit |
 
-The server is single-context and serializes requests on the tick thread (one in-flight request),
-matching dasLLAMA's one-generation-loop. OpenAI is stateless — the client resends the full
-transcript each turn.
+Chat and completion requests **batch continuously** (`llm_scheduler.das`): up to `--streams`
+generations run concurrently through one `eval_batch` decode step per tick, with long prompts
+prefilled in `--chunk`-token slices so a new arrival never stalls running streams for more than
+one chunk. Requests beyond `--streams` queue (up to 32; then 503). The buffered endpoints
+(`/v1/models`, `/v1/embeddings`, `/v1/audio/*`) still run to completion in-handler and pause
+generation for their duration. OpenAI is stateless — the client resends the full transcript each
+turn.
 
 ## Endpoints
 
@@ -41,6 +49,7 @@ transcript each turn.
 | `POST` | `/v1/embeddings` | Mean-pooled, L2-normalized sentence embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech→text (multipart upload; needs `--asr`) |
 | `POST` | `/v1/audio/translations` | Speech→English text (needs `--asr`) |
+| `GET`  | `/v1/stats` | Scheduler counters: active/queued/peak_active, decode_steps, avg_batch, … |
 | `POST` | `/shutdown` | Graceful stop |
 
 ### Chat
@@ -77,10 +86,17 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 
 ## Testing
 
-`test_openai_server.das` (in this directory) is a model-gated, JIT-only conformance test: it starts
-the server on its own thread, then drives `/v1/models`, `/v1/embeddings`, and `/v1/chat/completions`
-over the real dashv HTTP client. It skips cleanly when the model GGUF is absent; set
-`DASLLAMA_MODELS_DIR` to point at a directory containing `tinyllama-1.1b-chat-v1.0.Q8_0.gguf`, then:
+All tests in this directory are model-gated and JIT-only (they skip cleanly when the GGUF is
+absent; set `DASLLAMA_MODELS_DIR`):
+
+- `test_openai_server.das` — endpoint conformance (`/v1/models`, `/v1/embeddings`, buffered chat)
+  over the real dashv HTTP client; needs `tinyllama-1.1b-chat-v1.0.Q8_0.gguf`.
+- `test_llm_scheduler.das` — the continuous-batching scheduler against `generate()` references
+  (bit-exact single stream, chunk invariance, staggered admits, eviction); needs
+  `SmolLM2-135M-Instruct-Q8_0.gguf`.
+- `test_openai_server_stream.das` — SSE chunk framing, the over-long-prompt 400, and two
+  concurrent clients batching on one server (`peak_active >= 2` via `/v1/stats`); needs
+  `SmolLM2-135M-Instruct-Q8_0.gguf`.
 
 ```sh
 bin/daslang -jit dastest/dastest.das -- --test utils/dasllama-server/test_openai_server.das

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -14,7 +14,7 @@ reach into engine internals, the facade is complete.
 ```sh
 bin/daslang -jit utils/dasllama-server/main.das -- --model <model.gguf> [--port 8080] [--quant q8] \
                                                     [--asr <asr.bin>] [--mmproj <mmproj.gguf>] [--ctx 4096] \
-                                                    [--streams 4] [--chunk 64]
+                                                    [--streams 4] [--chunk 64] [--page-rows 64] [--prefix N]
 ```
 
 Run under `-jit` — interpreted inference is far too slow. Flags:
@@ -27,14 +27,21 @@ Run under `-jit` — interpreted inference is far too slow. Flags:
 | `--asr` | `-a` | — | ASR model (whisper/parakeet/qwen3-asr) — enables the `/v1/audio/*` routes |
 | `--mmproj` | — | — | mmproj GGUF for the Qwen3-ASR route (paired with `--asr`) |
 | `--ctx` | — | `4096` | Context-length cap in tokens |
-| `--streams` | `-s` | `4` | Max concurrent generation streams (each holds a full KV cache) |
+| `--streams` | `-s` | `4` | Max concurrent generation streams |
 | `--chunk` | — | `64` | Prefill quantum in tokens — decode stalls at most this per tick |
+| `--page-rows` | — | `64` | KV page size in positions for paged serving |
+| `--prefix` | — | *auto* | Prefix-cache retention cap in pages (auto: one full context per stream; `-1` = unbounded) |
+| `--flat` | — | — | Flat preallocated KV sessions — disables paged serving and the prefix cache |
 | `--help` | `-?` | — | Show help and exit |
 
 Chat and completion requests **batch continuously** (`llm_scheduler.das`): up to `--streams`
 generations run concurrently through one `eval_batch` decode step per tick, with long prompts
 prefilled in `--chunk`-token slices so a new arrival never stalls running streams for more than
-one chunk. Requests beyond `--streams` queue (up to 32; then 503). The buffered endpoints
+one chunk. Requests beyond `--streams` queue (up to 32; then 503). KV is **paged** by default —
+cache memory tracks each stream's actual context, and finished streams donate their pages to a
+**prefix cache**, so a repeated prompt prefix (a shared system prompt, the next turn of the same
+conversation) attaches instead of re-prefilling — time-to-first-token collapses on warm prompts.
+Clients whose connection drops mid-generation are evicted within a tick. The buffered endpoints
 (`/v1/models`, `/v1/embeddings`, `/v1/audio/*`) still run to completion in-handler and pause
 generation for their duration. OpenAI is stateless — the client resends the full transcript each
 turn.
@@ -49,7 +56,7 @@ turn.
 | `POST` | `/v1/embeddings` | Mean-pooled, L2-normalized sentence embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech→text (multipart upload; needs `--asr`) |
 | `POST` | `/v1/audio/translations` | Speech→English text (needs `--asr`) |
-| `GET`  | `/v1/stats` | Scheduler counters: active/queued/peak_active, decode_steps, avg_batch, … |
+| `GET`  | `/v1/stats` | Scheduler counters: active/queued/peak_active, decode_steps, avg_batch, evicted, cached_tokens, prefix_pages, … |
 | `POST` | `/shutdown` | Graceful stop |
 
 ### Chat
@@ -94,13 +101,18 @@ absent; set `DASLLAMA_MODELS_DIR`):
 - `test_llm_scheduler.das` — the continuous-batching scheduler against `generate()` references
   (bit-exact single stream, chunk invariance, staggered admits, eviction); needs
   `SmolLM2-135M-Instruct-Q8_0.gguf`.
-- `test_openai_server_stream.das` — SSE chunk framing, the over-long-prompt 400, and two
-  concurrent clients batching on one server (`peak_active >= 2` via `/v1/stats`); needs
+- `test_openai_server_stream.das` — SSE chunk framing, the over-long-prompt 400, two concurrent
+  clients batching on one server (`peak_active >= 2` via `/v1/stats`), mid-generation disconnect
+  eviction, and the prefix cache returning an identical completion for a repeated request; needs
   `SmolLM2-135M-Instruct-Q8_0.gguf`.
 
 ```sh
 bin/daslang -jit dastest/dastest.das -- --test utils/dasllama-server/test_openai_server.das
 ```
+
+`server_bench.das` (same directory) measures the serving latencies directly through the scheduler
+seam: tok/s + TTFT + inter-token percentiles vs batch size, decode stall per prefill chunk size,
+and warm-vs-cold TTFT for the prefix cache.
 
 ## Not yet implemented
 

--- a/utils/dasllama-server/llm_scheduler.das
+++ b/utils/dasllama-server/llm_scheduler.das
@@ -1,0 +1,277 @@
+options gen2
+
+module llm_scheduler
+
+require dasllama/dasllama   // the public facade — the scheduler reaches no engine internals
+require math
+
+// Continuous-batching scheduler over the dasLLAMA facade. One thread, synchronous: each
+// scheduler_step admits queued requests, runs ONE eval_batch decode step over every decoding
+// stream (decode priority), then at most ONE bounded prefill chunk FCFS — a long prompt stalls
+// decode by T_chunk, not T_prefill. Results flow out as SchedEvents; no HTTP here — the wiring
+// (openai_server) owns the writers, so the whole scheduler unit-tests with zero network.
+
+//! Stream lifecycle: prefilling (prompt chunks pending) -> decoding (one token per step) -> done.
+enum StreamState {
+    prefilling
+    decoding
+    done
+}
+
+//! What a SchedEvent reports: a generated piece, or the stream's completion.
+enum SchedEventKind {
+    piece
+    finished
+}
+
+//! One scheduler output: a text piece for a stream, or its completion (with usage + timing).
+//! The wiring dispatches these to HTTP writers; tests assert on them directly.
+struct SchedEvent {
+    stream : int64                          // Stream/PendingReq id
+    kind : SchedEventKind = SchedEventKind.piece
+    token : int64 = -1l                     // piece: the sampled token id
+    text : string = ""                      // piece: its decoded text
+    finish : string = ""                    // finished: "stop" | "length" | "evicted"
+    n_prompt : int64 = 0l                   // finished: prompt tokens prefilled
+    n_gen : int64 = 0l                      // finished: tokens generated
+    n_cached : int64 = 0l                   // finished: prefix-cache hit length (0 until the prefix cache lands)
+    ttft_us : int64 = 0l                    // finished: admit -> first sampled token (microseconds)
+    gen_us : int64 = 0l                     // finished: first sampled token -> finish (microseconds)
+}
+
+//! A parsed + rendered request awaiting admission: tokens only, NO session — queued requests hold
+//! no KV memory. The caller renders (create_chat_renderer / render_assistant / render_turn, or a
+//! raw encode) and assigns unique ids.
+struct PendingReq {
+    id : int64
+    prompt : array<int64>                   // the full rendered prompt
+    close_toks : array<int64>               // the turn-terminating tokens (render_close; evaled once the prefix cache lands)
+    stop_ids : array<int64>                 // sampling one of these finishes "stop" (the token is not emitted)
+    params : SamplingParams = SamplingParams()
+    max_new : int64 = 256l                  // reply token budget (>= 1)
+    seed : int = 0                          // != 0 => set_seed at admit (reproducible sampling)
+}
+
+//! One active generation stream: the owned KV session plus its request state. Managed wholly by
+//! the scheduler; readable for stats and tests.
+struct Stream {
+    id : int64
+    session : Session
+    params : SamplingParams = SamplingParams()
+    prompt : array<int64>
+    close_toks : array<int64>
+    stop_ids : array<int64>
+    n_prefilled : int64                     // prompt tokens evaled so far
+    max_new : int64
+    n_gen : int64                           // tokens emitted so far
+    cur_tok : int64 = -1l                   // sampled but not yet evaled — the next decode step's input
+    state : StreamState = StreamState.prefilling
+    finish : string = ""
+    n_cached : int64                        // prefix-cache hit length (0 this rung)
+    t_admit : int64                         // ref_time_ticks at admit
+    t_first : int64                         // ref_time_ticks at the first sampled token (0 until then)
+    ttft_us : int64
+}
+
+//! The continuous-batching scheduler: active streams, the admission queue, the shared eval_batch
+//! workspace, knobs, and counters. One per served model; drive it with scheduler_step.
+struct Scheduler {
+    ws : BatchWorkspace
+    streams : array<Stream>                 // admission order (the FCFS prefill scan is first-to-last)
+    queue : array<PendingReq>
+    max_streams : int64 = 4l
+    max_queue : int64 = 32l
+    chunk_tokens : int64 = 64l              // prefill quantum K: decode stalls at most this many tokens
+    // per-step gather scratch. @do_not_delete is load-bearing: delete of a plain array<T?>
+    // CASCADES to the pointees — these are borrowed rows into streams[i].session
+    @do_not_delete batch_rows : array<Session?>
+    batch_toks : array<int64>
+    batch_idx : array<int64>                // batch row -> streams index
+    chunk : array<int64>                    // the current prefill chunk
+    // counters (/v1/stats and server_bench read these)
+    n_admitted : int64
+    n_finished : int64                      // reaped streams (any finish, evictions included)
+    n_evicted : int64                       // evictions, active or still queued
+    decode_steps : int64
+    gen_tokens : int64
+    sum_batch : int64                       // Σ decode batch size (avg batch = sum_batch / decode_steps)
+    peak_active : int64
+    cached_tokens : int64                   // prefix-cache hits (0 this rung)
+}
+
+//! Create a scheduler over `model`: `max_streams` concurrent sessions (each a full KV cache — cap
+//! model.config.seq_len BEFORE this to bound memory), `max_queue` waiting requests, `chunk_tokens`
+//! the prefill quantum. Free with `unsafe(delete sch)` — live sessions and the workspace go with it.
+def create_scheduler(model : Model; max_streams : int64 = 4l; max_queue : int64 = 32l;
+                     chunk_tokens : int64 = 64l) : Scheduler {
+    return <- Scheduler(ws <- create_batch_workspace(model), max_streams = max(1l, max_streams),
+                        max_queue = max(1l, max_queue), chunk_tokens = max(1l, chunk_tokens))
+}
+
+//! Active stream count (prefilling + decoding).
+def n_active(sch : Scheduler) : int64 => int64(length(sch.streams))
+
+//! Queued (not yet admitted) request count.
+def n_queued(sch : Scheduler) : int64 => int64(length(sch.queue))
+
+//! Queue a request; false = queue full (the wiring answers 503). Preconditions PANIC — the wiring
+//! must reject them first (its 400s): a non-empty prompt that fits the model context with room to
+//! generate, and max_new >= 1.
+def submit(model : Model; var sch : Scheduler; var req : PendingReq) : bool {
+    let np = int64(length(req.prompt))
+    if (np <= 0l) {
+        panic("llm_scheduler: empty prompt (stream {req.id}) — the wiring must reject it first")
+    }
+    if (np + 1l > model.config.seq_len) {
+        panic("llm_scheduler: {np}-token prompt does not fit seq_len {model.config.seq_len} (stream {req.id}) — the wiring must reject it first")
+    }
+    if (req.max_new < 1l) {
+        panic("llm_scheduler: max_new {req.max_new} < 1 (stream {req.id}) — the wiring must clamp it first")
+    }
+    if (int64(length(sch.queue)) >= sch.max_queue) {
+        return false
+    }
+    sch.queue |> emplace(req)
+    return true
+}
+
+// Terminate a stream: mark done (reaped at step end) and append its finished event.
+def private finish_stream(var st : Stream; finish : string; var events : array<SchedEvent>) {
+    st.state = StreamState.done
+    st.finish = finish
+    events |> push(SchedEvent(stream = st.id, kind = SchedEventKind.finished, finish = finish,
+                              n_prompt = int64(length(st.prompt)), n_gen = st.n_gen,
+                              n_cached = st.n_cached, ttft_us = st.ttft_us,
+                              gen_us = st.t_first != 0l ? int64(get_time_usec(st.t_first)) : 0l))
+}
+
+// Sample the next token from st.session's fresh logits and run the emit protocol — stop-id check,
+// piece event, recent push, budget check — identical for the inline first token and every decode
+// step (generate_'s ordering). Returns true when a piece was emitted (the caller counts it).
+def private sample_advance(m : Model; var st : Stream; var events : array<SchedEvent>) : bool {
+    let tok = sample(st.session, st.params)
+    if (st.t_first == 0l) {
+        st.t_first = ref_time_ticks()
+        st.ttft_us = int64(get_time_usec(st.t_admit))
+    }
+    for (sid in st.stop_ids) {
+        if (tok == sid) {
+            finish_stream(st, "stop", events)
+            return false
+        }
+    }
+    events |> push(SchedEvent(stream = st.id, token = tok, text = piece(m, tok)))
+    st.session.recent |> push(tok)
+    st.n_gen ++
+    st.cur_tok = tok
+    if (st.n_gen >= st.max_new) {
+        finish_stream(st, "length", events)
+    }
+    return true
+}
+
+//! Evict a stream (the client disconnected): an active stream finishes "evicted" (its finished
+//! event appends NOW; the session is reaped next step), a queued request is dropped with the same
+//! event. False = unknown id.
+def evict(var sch : Scheduler; id : int64; var events : array<SchedEvent>) : bool {
+    for (i in range64(int64(length(sch.streams)))) {
+        if (sch.streams[i].id == id && sch.streams[i].state != StreamState.done) {
+            finish_stream(sch.streams[i], "evicted", events)
+            sch.n_evicted ++
+            return true
+        }
+    }
+    for (i in range64(int64(length(sch.queue)))) {
+        if (sch.queue[i].id == id) {
+            events |> push(SchedEvent(stream = id, kind = SchedEventKind.finished, finish = "evicted",
+                                      n_prompt = int64(length(sch.queue[i].prompt))))
+            delete sch.queue[i]   // erase is a raw memmove — finalize the owned arrays first
+            sch.queue |> erase(i)
+            sch.n_evicted ++
+            return true
+        }
+    }
+    return false
+}
+
+//! One scheduler tick: admit from the queue while under max_streams, ONE eval_batch decode step
+//! over every decoding stream, at most ONE chunk_tokens prefill chunk (FCFS; the final chunk's
+//! logits sample the first token inline), then reap finished streams. Events append to `events`
+//! (the caller drains it). Returns true while any stream or queued request remains.
+def scheduler_step(m : Model; var sch : Scheduler; var events : array<SchedEvent>) : bool {
+    // (1) admit FIFO while under the cap — sessions (KV memory) exist only from this point on
+    while (!empty(sch.queue) && int64(length(sch.streams)) < sch.max_streams) {
+        var st <- Stream(id = sch.queue[0].id, session <- create_session(m),
+                         params = sch.queue[0].params, prompt <- sch.queue[0].prompt,
+                         close_toks <- sch.queue[0].close_toks, stop_ids <- sch.queue[0].stop_ids,
+                         max_new = sch.queue[0].max_new, t_admit = ref_time_ticks())
+        if (sch.queue[0].seed != 0) {
+            set_seed(st.session, sch.queue[0].seed)
+        }
+        sch.streams |> emplace(st)
+        delete sch.queue[0]   // erase is a raw memmove — finalize what the move-out left behind
+        sch.queue |> erase(0)
+        sch.n_admitted ++
+    }
+    sch.peak_active = max(sch.peak_active, int64(length(sch.streams)))
+    // (2) ONE batched decode step over every decoding stream (decode priority). Rows are gathered
+    // fresh each step: admission above may have reallocated `streams`, and nothing below grows it.
+    sch.batch_rows |> clear()
+    sch.batch_toks |> clear()
+    sch.batch_idx |> clear()
+    for (i in range64(int64(length(sch.streams)))) {
+        if (sch.streams[i].state != StreamState.decoding) {
+            continue
+        }
+        if (sch.streams[i].session.n_past + 1l > m.config.seq_len) {   // pre-check: never reach the eval_batch panic
+            finish_stream(sch.streams[i], "length", events)
+            continue
+        }
+        sch.batch_rows |> push(unsafe(addr(sch.streams[i].session)))
+        sch.batch_toks |> push(sch.streams[i].cur_tok)
+        sch.batch_idx |> push(i)
+    }
+    if (!empty(sch.batch_rows)) {
+        eval_batch(m, sch.ws, sch.batch_rows, sch.batch_toks)
+        sch.decode_steps ++
+        sch.sum_batch += int64(length(sch.batch_rows))
+        for (bi in range64(int64(length(sch.batch_idx)))) {
+            if (sample_advance(m, sch.streams[sch.batch_idx[bi]], events)) {
+                sch.gen_tokens ++
+            }
+        }
+    }
+    // (3) at most ONE prefill chunk, FCFS — decode-priority with a bounded prefill quantum
+    for (i in range64(int64(length(sch.streams)))) {
+        if (sch.streams[i].state != StreamState.prefilling) {
+            continue
+        }
+        let np = int64(length(sch.streams[i].prompt))
+        let take = min(sch.chunk_tokens, np - sch.streams[i].n_prefilled)
+        sch.chunk |> resize(int(take))
+        for (k in range64(take)) {
+            sch.chunk[k] = sch.streams[i].prompt[sch.streams[i].n_prefilled + k]
+        }
+        eval(m, sch.streams[i].session, sch.chunk)
+        sch.streams[i].n_prefilled += take
+        if (sch.streams[i].n_prefilled >= np) {
+            sch.streams[i].state = StreamState.decoding   // before sampling: sample_advance may finish it
+            if (sample_advance(m, sch.streams[i], events)) {   // the final chunk's logits sample the first token inline
+                sch.gen_tokens ++
+            }
+        }
+        break
+    }
+    // (4) reap done streams (their finished events were emitted at the state flip)
+    var i = 0
+    while (i < length(sch.streams)) {
+        if (sch.streams[i].state == StreamState.done) {
+            delete sch.streams[i]   // erase is a raw memmove — finalize the owned session first
+            sch.streams |> erase(i)
+            sch.n_finished ++
+        } else {
+            i ++
+        }
+    }
+    return !empty(sch.streams) || !empty(sch.queue)
+}

--- a/utils/dasllama-server/llm_scheduler.das
+++ b/utils/dasllama-server/llm_scheduler.das
@@ -82,12 +82,18 @@ struct Scheduler {
     max_streams : int64 = 4l
     max_queue : int64 = 32l
     chunk_tokens : int64 = 64l              // prefill quantum K: decode stalls at most this many tokens
+    // paged serving (page_rows > 0 at create): sessions page KV out of the pool, and finished
+    // streams donate their pages to the prefix cache so repeat prefixes skip their prefill
+    paged : bool
+    pool : KVPool
+    prefix : PrefixCache
     // per-step gather scratch. @do_not_delete is load-bearing: delete of a plain array<T?>
     // CASCADES to the pointees — these are borrowed rows into streams[i].session
     @do_not_delete batch_rows : array<Session?>
     batch_toks : array<int64>
     batch_idx : array<int64>                // batch row -> streams index
     chunk : array<int64>                    // the current prefill chunk
+    donate_toks : array<int64>              // reap-time scratch: tail eval + the insert token list
     // counters (/v1/stats and server_bench read these)
     n_admitted : int64
     n_finished : int64                      // reaped streams (any finish, evictions included)
@@ -96,16 +102,26 @@ struct Scheduler {
     gen_tokens : int64
     sum_batch : int64                       // Σ decode batch size (avg batch = sum_batch / decode_steps)
     peak_active : int64
-    cached_tokens : int64                   // prefix-cache hits (0 this rung)
+    cached_tokens : int64                   // prefix-cache hits (tokens attached instead of prefilled)
 }
 
-//! Create a scheduler over `model`: `max_streams` concurrent sessions (each a full KV cache — cap
-//! model.config.seq_len BEFORE this to bound memory), `max_queue` waiting requests, `chunk_tokens`
-//! the prefill quantum. Free with `unsafe(delete sch)` — live sessions and the workspace go with it.
+//! Create a scheduler over `model`: `max_streams` concurrent sessions, `max_queue` waiting
+//! requests, `chunk_tokens` the prefill quantum. `page_rows` > 0 switches to PAGED serving — KV
+//! pages allocate on demand (memory tracks actual context, not seq_len × streams) and a prefix
+//! cache reuses completed streams' pages across requests (`prefix_groups` caps its retention;
+//! 0 = unbounded); 0 keeps today's flat preallocated sessions. Free with `unsafe(delete sch)` —
+//! live sessions, the pool, and the workspace go with it.
 def create_scheduler(model : Model; max_streams : int64 = 4l; max_queue : int64 = 32l;
-                     chunk_tokens : int64 = 64l) : Scheduler {
-    return <- Scheduler(ws <- create_batch_workspace(model), max_streams = max(1l, max_streams),
-                        max_queue = max(1l, max_queue), chunk_tokens = max(1l, chunk_tokens))
+                     chunk_tokens : int64 = 64l; page_rows : int64 = 0l;
+                     prefix_groups : int64 = 0l) : Scheduler {
+    var sch <- Scheduler(ws <- create_batch_workspace(model), max_streams = max(1l, max_streams),
+                         max_queue = max(1l, max_queue), chunk_tokens = max(1l, chunk_tokens))
+    if (page_rows > 0l) {
+        sch.paged = true
+        sch.pool <- create_kv_pool(model, page_rows)
+        sch.prefix <- create_prefix_cache(prefix_groups)
+    }
+    return <- sch
 }
 
 //! Active stream count (prefilling + decoding).
@@ -199,12 +215,22 @@ def evict(var sch : Scheduler; id : int64; var events : array<SchedEvent>) : boo
 //! logits sample the first token inline), then reap finished streams. Events append to `events`
 //! (the caller drains it). Returns true while any stream or queued request remains.
 def scheduler_step(m : Model; var sch : Scheduler; var events : array<SchedEvent>) : bool {
-    // (1) admit FIFO while under the cap — sessions (KV memory) exist only from this point on
+    // (1) admit FIFO while under the cap — sessions (KV memory) exist only from this point on.
+    // Paged mode also attaches the longest prefix-cache hit: those positions never prefill.
     while (!empty(sch.queue) && int64(length(sch.streams)) < sch.max_streams) {
-        var st <- Stream(id = sch.queue[0].id, session <- create_session(m),
+        var st <- Stream(id = sch.queue[0].id,
                          params = sch.queue[0].params, prompt <- sch.queue[0].prompt,
                          close_toks <- sch.queue[0].close_toks, stop_ids <- sch.queue[0].stop_ids,
                          max_new = sch.queue[0].max_new, t_admit = ref_time_ticks())
+        if (sch.paged) {
+            st.session <- create_session(m, sch.pool)
+            let matched = prefix_attach(sch.prefix, sch.pool, st.session, st.prompt)
+            st.n_prefilled = matched
+            st.n_cached = matched
+            sch.cached_tokens += matched
+        } else {
+            st.session <- create_session(m)
+        }
         if (sch.queue[0].seed != 0) {
             set_seed(st.session, sch.queue[0].seed)
         }
@@ -262,10 +288,15 @@ def scheduler_step(m : Model; var sch : Scheduler; var events : array<SchedEvent
         }
         break
     }
-    // (4) reap done streams (their finished events were emitted at the state flip)
+    // (4) reap done streams (their finished events were emitted at the state flip); paged streams
+    // donate their pages to the prefix cache on the way out
     var i = 0
     while (i < length(sch.streams)) {
         if (sch.streams[i].state == StreamState.done) {
+            if (sch.paged) {
+                donate_stream(m, sch, sch.streams[i])
+                release_kv_pages(sch.streams[i].session)
+            }
             delete sch.streams[i]   // erase is a raw memmove — finalize the owned session first
             sch.streams |> erase(i)
             sch.n_finished ++
@@ -274,4 +305,26 @@ def scheduler_step(m : Model; var sch : Scheduler; var events : array<SchedEvent
         }
     }
     return !empty(sch.streams) || !empty(sch.queue)
+}
+
+// Donate a finished stream's KV pages. A completed stream first evals its pending token (the last
+// emitted one — sampled but never fed back) plus the close tokens, so the NEXT turn of the same
+// conversation (prompt + reply + close + new user turn) extends the cached prefix; an evicted or
+// context-full stream donates only what it evaled. prefix_insert trims to n_past.
+def private donate_stream(m : Model; var sch : Scheduler; var st : Stream) {
+    let close_n = int64(length(st.close_toks))
+    if (st.finish != "evicted" && st.cur_tok >= 0l
+            && st.session.n_past + 1l + close_n <= m.config.seq_len) {
+        sch.donate_toks |> clear()
+        sch.donate_toks |> push(st.cur_tok)
+        sch.donate_toks |> push_from(st.close_toks)
+        eval(m, st.session, sch.donate_toks)
+    }
+    sch.donate_toks |> clear()
+    sch.donate_toks |> reserve(int(st.n_prefilled) + length(st.session.recent) + length(st.close_toks))
+    for (k in range64(st.n_prefilled)) {
+        sch.donate_toks |> push(st.prompt[k])
+    }
+    sch.donate_toks |> push_from(st.session.recent, st.close_toks)
+    prefix_insert(sch.prefix, sch.pool, st.session, sch.donate_toks)
 }

--- a/utils/dasllama-server/llm_scheduler.das
+++ b/utils/dasllama-server/llm_scheduler.das
@@ -34,7 +34,7 @@ struct SchedEvent {
     finish : string = ""                    // finished: "stop" | "length" | "evicted"
     n_prompt : int64 = 0l                   // finished: prompt tokens prefilled
     n_gen : int64 = 0l                      // finished: tokens generated
-    n_cached : int64 = 0l                   // finished: prefix-cache hit length (0 until the prefix cache lands)
+    n_cached : int64 = 0l                   // finished: prefix-cache hit length (tokens attached at admit)
     ttft_us : int64 = 0l                    // finished: admit -> first sampled token (microseconds)
     gen_us : int64 = 0l                     // finished: first sampled token -> finish (microseconds)
 }
@@ -45,7 +45,7 @@ struct SchedEvent {
 struct PendingReq {
     id : int64
     prompt : array<int64>                   // the full rendered prompt
-    close_toks : array<int64>               // the turn-terminating tokens (render_close; evaled once the prefix cache lands)
+    close_toks : array<int64>               // the turn-terminating tokens (render_close; evaled at donation so the next turn extends the cached prefix)
     stop_ids : array<int64>                 // sampling one of these finishes "stop" (the token is not emitted)
     params : SamplingParams = SamplingParams()
     max_new : int64 = 256l                  // reply token budget (>= 1)
@@ -67,7 +67,7 @@ struct Stream {
     cur_tok : int64 = -1l                   // sampled but not yet evaled — the next decode step's input
     state : StreamState = StreamState.prefilling
     finish : string = ""
-    n_cached : int64                        // prefix-cache hit length (0 this rung)
+    n_cached : int64                        // prefix-cache hit length (set at admit; 0 in flat mode)
     t_admit : int64                         // ref_time_ticks at admit
     t_first : int64                         // ref_time_ticks at the first sampled token (0 until then)
     ttft_us : int64

--- a/utils/dasllama-server/llm_scheduler.das
+++ b/utils/dasllama-server/llm_scheduler.das
@@ -307,18 +307,24 @@ def scheduler_step(m : Model; var sch : Scheduler; var events : array<SchedEvent
     return !empty(sch.streams) || !empty(sch.queue)
 }
 
-// Donate a finished stream's KV pages. A completed stream first evals its pending token (the last
-// emitted one — sampled but never fed back) plus the close tokens, so the NEXT turn of the same
-// conversation (prompt + reply + close + new user turn) extends the cached prefix; an evicted or
-// context-full stream donates only what it evaled. prefix_insert trims to n_past.
+// Donate a finished stream's KV pages, first evaling what the cache still lacks. A "length"
+// finish leaves the last emitted token pending (sampled, never fed back); a "stop" finish already
+// evaled every emitted token — the stop was sampled from the last one's eval — so only the close
+// tokens are pending (re-evaling the last token would shift every row past the reply boundary
+// against the page's token list). Either way the close tokens follow, so the NEXT turn of this
+// conversation (prompt + reply + close + new user turn) extends the cached prefix. The tail is
+// skipped when it cannot fit; evicted streams donate only what ran. prefix_insert trims to n_past.
 def private donate_stream(m : Model; var sch : Scheduler; var st : Stream) {
-    let close_n = int64(length(st.close_toks))
-    if (st.finish != "evicted" && st.cur_tok >= 0l
-            && st.session.n_past + 1l + close_n <= m.config.seq_len) {
+    if (st.finish != "evicted") {
         sch.donate_toks |> clear()
-        sch.donate_toks |> push(st.cur_tok)
+        if (st.finish == "length" && st.cur_tok >= 0l) {
+            sch.donate_toks |> push(st.cur_tok)
+        }
         sch.donate_toks |> push_from(st.close_toks)
-        eval(m, st.session, sch.donate_toks)
+        if (!empty(sch.donate_toks)
+                && st.session.n_past + int64(length(sch.donate_toks)) <= m.config.seq_len) {
+            eval(m, st.session, sch.donate_toks)
+        }
     }
     sch.donate_toks |> clear()
     sch.donate_toks |> reserve(int(st.n_prefilled) + length(st.session.recent) + length(st.close_toks))

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -45,6 +45,13 @@ struct ServerArgs {
     @clarg_doc = "Context-length cap in tokens (default 4096)"
     ctx : int
 
+    @clarg_short = "s"
+    @clarg_doc = "Max concurrent generation streams — each holds a full KV cache (default 4)"
+    streams : int
+
+    @clarg_doc = "Prefill chunk in tokens: decode stalls at most this many per tick (default 64)"
+    chunk : int
+
     @clarg_doc = "Re-tune this box's dasLLAMA kernels, then relaunch (handled before arg parsing)"
     tune : bool
 
@@ -89,6 +96,8 @@ def main : int {
 
     let port = cfg.port > 0 ? cfg.port : 8080     // non-positive (incl. a stray negative) -> default
     let ctx = cfg.ctx > 0 ? int64(cfg.ctx) : 4096l   // guard: a negative ctx would make seq_len < 0
+    let streams = cfg.streams > 0 ? int64(cfg.streams) : 4l
+    let chunk = cfg.chunk > 0 ? int64(cfg.chunk) : 64l
 
     log_tune_status("dasllama-server")
     print("loading {cfg.model} ...\n")
@@ -102,6 +111,6 @@ def main : int {
         set_asr(a)
     }
 
-    run_server(port)
+    run_server(port, streams, chunk_tokens = chunk)
     return 0
 }

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -46,11 +46,20 @@ struct ServerArgs {
     ctx : int
 
     @clarg_short = "s"
-    @clarg_doc = "Max concurrent generation streams — each holds a full KV cache (default 4)"
+    @clarg_doc = "Max concurrent generation streams (default 4)"
     streams : int
 
     @clarg_doc = "Prefill chunk in tokens: decode stalls at most this many per tick (default 64)"
     chunk : int
+
+    @clarg_doc = "KV page size in positions for paged serving (default 64)"
+    page_rows : int
+
+    @clarg_doc = "Prefix-cache retention cap in pages (default: one full context per stream; -1 = unbounded)"
+    prefix : int
+
+    @clarg_doc = "Flat preallocated KV sessions — disables paged serving and the prefix cache"
+    flat : bool
 
     @clarg_doc = "Re-tune this box's dasLLAMA kernels, then relaunch (handled before arg parsing)"
     tune : bool
@@ -98,6 +107,8 @@ def main : int {
     let ctx = cfg.ctx > 0 ? int64(cfg.ctx) : 4096l   // guard: a negative ctx would make seq_len < 0
     let streams = cfg.streams > 0 ? int64(cfg.streams) : 4l
     let chunk = cfg.chunk > 0 ? int64(cfg.chunk) : 64l
+    let page_rows = cfg.flat ? 0l : (cfg.page_rows > 0 ? int64(cfg.page_rows) : 64l)
+    let prefix = int64(cfg.prefix)   // 0 = auto (run_server sizes it), < 0 = unbounded
 
     log_tune_status("dasllama-server")
     print("loading {cfg.model} ...\n")
@@ -111,6 +122,6 @@ def main : int {
         set_asr(a)
     }
 
-    run_server(port, streams, chunk_tokens = chunk)
+    run_server(port, streams, chunk_tokens = chunk, page_rows = page_rows, prefix_groups = prefix)
     return 0
 }

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -440,9 +440,20 @@ def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var
     register_request(srv, writer, toks, none_stop, none_close, params, max_new, streaming, false, "cmpl")
 }
 
+// Evict streams whose client vanished: is_writer_connected reads false once the connection is
+// gone (the async writer ops themselves never report a dead peer). The scheduler appends the
+// "evicted" finished event; flush_events below releases the writer and drops the wire.
+def private reap_disconnected(srv : WebSocketServer) {
+    for (id, w in keys(g_wires), values(g_wires)) {
+        if (!is_writer_connected(srv, w.writer)) {
+            evict(g_sched, id, g_events)
+        }
+    }
+}
+
 // Route drained SchedEvents to their writers: streaming wires emit SSE chunks, buffered wires
 // accumulate pieces and respond once at finish. "evicted" releases the writer with no bytes —
-// the client is gone (S4's disconnect poll produces it). Finished wires unregister.
+// the client is gone (reap_disconnected produced it). Finished wires unregister.
 def private flush_events(srv : WebSocketServer) {
     for (e in g_events) {
         // interior pointer into g_wires — nothing inserts into the table between here and the erase
@@ -605,8 +616,9 @@ class OpenAiServer : HvWebServer {
 }
 
 //! Run the server on the calling thread until ``request_stop`` (or ``POST /shutdown``). Sets up the
-//! job queue, then drives the serve loop: pump HTTP (handlers parse + render + submit), one
-//! scheduler step (continuous batching over every live stream), flush events to the writers.
+//! job queue, then drives the serve loop: pump HTTP (handlers parse + render + submit), evict
+//! streams whose client disconnected, one scheduler step (continuous batching over every live
+//! stream), flush events to the writers.
 //! ``max_streams`` concurrent generation streams (each holds a full KV cache — cap the context with
 //! ``--ctx`` to bound memory), ``max_queue`` waiting requests (503 beyond), ``chunk_tokens`` the
 //! prefill quantum (decode stalls at most this many tokens per tick). Call after ``set_model``.
@@ -624,6 +636,7 @@ def run_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; ch
             to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (model: {g_model_name}, streams: {max_streams}, prefill chunk: {chunk_tokens})\n")
             while (!g_should_stop) {
                 server->tick()   // drains queued handlers: requests parse + render + submit here
+                reap_disconnected(server.server)
                 let busy = scheduler_step(g_model, g_sched, g_events)
                 flush_events(server.server)
                 if (!busy) {

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -516,6 +516,7 @@ struct private OaiStatsResponse {
     gen_tokens : int64
     avg_batch : float
     cached_tokens : int64
+    prefix_pages : int64
     max_streams : int64
     chunk_tokens : int64
 }
@@ -526,7 +527,7 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
         admitted = g_sched.n_admitted, finished = g_sched.n_finished, evicted = g_sched.n_evicted,
         decode_steps = g_sched.decode_steps, gen_tokens = g_sched.gen_tokens,
         avg_batch = float(g_sched.sum_batch) / float(max(g_sched.decode_steps, 1l)),
-        cached_tokens = g_sched.cached_tokens,
+        cached_tokens = g_sched.cached_tokens, prefix_pages = prefix_held_groups(g_sched.prefix),
         max_streams = g_sched.max_streams, chunk_tokens = g_sched.chunk_tokens)
     return resp |> JSON(sprint_json(out, false), http_status.OK)
 }
@@ -619,21 +620,35 @@ class OpenAiServer : HvWebServer {
 //! job queue, then drives the serve loop: pump HTTP (handlers parse + render + submit), evict
 //! streams whose client disconnected, one scheduler step (continuous batching over every live
 //! stream), flush events to the writers.
-//! ``max_streams`` concurrent generation streams (each holds a full KV cache — cap the context with
-//! ``--ctx`` to bound memory), ``max_queue`` waiting requests (503 beyond), ``chunk_tokens`` the
-//! prefill quantum (decode stalls at most this many tokens per tick). Call after ``set_model``.
-def run_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; chunk_tokens : int64 = 64l) {
+//! ``max_streams`` concurrent generation streams, ``max_queue`` waiting requests (503 beyond),
+//! ``chunk_tokens`` the prefill quantum (decode stalls at most this many tokens per tick).
+//! ``page_rows`` > 0 (the default) serves PAGED: KV memory tracks actual context and a prefix
+//! cache reuses completed streams' pages, so repeated prompts (system prompts, multi-turn chats)
+//! skip their prefill; ``prefix_groups`` caps the cache (0 = auto: one full context per stream
+//! slot, < 0 = unbounded). ``page_rows`` = 0 restores flat preallocated sessions (each the full
+//! ``--ctx`` slab). Call after ``set_model``.
+def run_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; chunk_tokens : int64 = 64l;
+               page_rows : int64 = 64l; prefix_groups : int64 = 0l) {
     g_should_stop = false   // reset so a restart in the same context after /shutdown doesn't exit at once
     with_job_que() {
         setup_dasllama_jobque()
-        g_sched <- create_scheduler(g_model, max_streams, max_queue, chunk_tokens)
+        var pfx = prefix_groups
+        if (page_rows > 0l && pfx == 0l) {   // auto: retain up to one full context per stream slot
+            pfx = max_streams * ((g_model.config.seq_len + page_rows - 1l) / page_rows)
+        }
+        if (pfx < 0l) {
+            pfx = 0l   // explicit unbounded
+        }
+        g_sched <- create_scheduler(g_model, max_streams, max_queue, chunk_tokens, page_rows, pfx)
         var server = new OpenAiServer()
         server->init(port)
         let rc = server->start()   // 0 on success; non-zero = bind/listen failed (e.g. port in use)
         if (rc != 0) {
             to_log(LOG_ERROR, "dasllama-server: could not start on port {port} (start rc {rc}; is the port already in use?)\n")
         } else {
-            to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (model: {g_model_name}, streams: {max_streams}, prefill chunk: {chunk_tokens})\n")
+            let pfx_desc = pfx > 0l ? "{pfx}" : "unbounded"
+            let kv_mode = page_rows > 0l ? "paged P={page_rows}, prefix cache {pfx_desc} pages" : "flat"
+            to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (model: {g_model_name}, streams: {max_streams}, prefill chunk: {chunk_tokens}, kv: {kv_mode})\n")
             while (!g_should_stop) {
                 server->tick()   // drains queued handlers: requests parse + render + submit here
                 reap_disconnected(server.server)

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1,10 +1,11 @@
 options gen2
 options stack = 65536   // the forward/prefill chain + generated kernels need more than the 16K default on arm64
-options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact); inference tool, not the test suite
+options fast_math = true   // ggml-parity FP laxity (non-bit-exact); inference tool, not the test suite
 
 module openai_server
 
 require dasllama/dasllama       // the public facade — the main dasLLAMA surface this tool touches
+require llm_scheduler           // continuous-batching scheduler (sibling — bare require, hyphenated dir)
 require dashv/dashv_boost public
 require daslib/json_boost
 require daslib/defer            // defer() { delete js } — free the parsed request JSON on every exit path
@@ -18,7 +19,12 @@ require dasllama/dasllama_audio_io   // load_audio_16k_mono: any uploaded audio 
 // An OpenAI-compatible HTTP server over the dasLLAMA facade. It reaches only public facade verbs —
 // no engine internals — which is the acceptance test for the API: if a full OpenAI surface builds
 // without reaching into the engine, the facade is complete.
-// One process, one context, one in-flight request (serialized on the tick thread).
+// Chat and completion requests batch continuously: handlers parse + render + register and return;
+// run_server's loop drives llm_scheduler (one eval_batch decode step over every live stream + one
+// bounded prefill chunk per tick) and routes SchedEvents back to each request's writer. Streaming
+// and buffered responses both ride the deferred writer ops, so N streams generate concurrently.
+// The buffered holdouts (/v1/models, /v1/embeddings, /v1/audio/*, /shutdown, /v1/stats) still run
+// to completion in-handler and stall generation for their duration.
 
 // ===== Served state (set once at startup; handlers run serially on the tick thread) =====
 
@@ -28,6 +34,21 @@ var g_asr = AsrModel()
 var g_has_asr = false
 var g_should_stop = false
 var g_req_counter = 0l
+var g_sched = Scheduler()       // live from run_server on; handlers submit into it
+var g_events : array<SchedEvent>
+
+// One registered request's HTTP side: where this stream id's SchedEvents go. The writer is owned by
+// dasHV's active_writers (respond/close_writer/release_writer drop it) — never deleted from here.
+struct private StreamWire {
+    @do_not_delete writer : HttpResponseWriter?
+    streaming : bool
+    is_chat : bool                  // chat.completion.chunk vs text_completion framing
+    id : string                     // "chatcmpl-N" / "cmpl-N"
+    created : int64
+    reply_parts : array<string>     // non-streaming: pieces accumulate until the finished event
+}
+
+var g_wires : table<int64; StreamWire>
 
 //! Move a loaded model into the server (call once, before run_server). ``name`` is the id reported
 //! by ``/v1/models`` and echoed back in responses.
@@ -194,9 +215,10 @@ struct private OaiEmbeddingList {
 
 // ===== Helpers =====
 
-def private next_id(prefix : string) : string {
+// Stream ids are the request counter: the scheduler keys on the int64, the wire keys the JSON id.
+def private next_id() : int64 {
     g_req_counter ++
-    return "{prefix}-{g_req_counter}"
+    return g_req_counter
 }
 
 // `created` is a unix-seconds field no OpenAI client validates; a monotone stand-in is honest and
@@ -302,6 +324,42 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
     return resp |> JSON(sprint_json(out, false), http_status.OK)
 }
 
+// Validate the rendered prompt, submit it to the scheduler, and register the wire that routes its
+// SchedEvents back to `writer`. Owns the mandatory 400 (prompt does not fit the context — submit
+// would panic) and the 503 (queue full). Moves prompt/stop_ids/close_toks into the request.
+def private register_request(srv : WebSocketServer; var writer : HttpResponseWriter?;
+                             var prompt, stop_ids, close_toks : array<int64>;
+                             params : SamplingParams; max_new : int64;
+                             streaming, is_chat : bool; prefix : string) {
+    let np = int64(length(prompt))
+    if (np + 1l > g_model.config.seq_len) {
+        bad_request(srv, writer, "the rendered prompt is {np} tokens; the model context is {g_model.config.seq_len} — shorten the conversation or raise --ctx")
+        return
+    }
+    let rid = next_id()
+    let cid = "{prefix}-{rid}"
+    let created = created_ts()
+    var preq <- PendingReq(id = rid, params = params, max_new = max_new)
+    preq.prompt <- prompt
+    preq.stop_ids <- stop_ids
+    preq.close_toks <- close_toks
+    if (!submit(g_model, g_sched, preq)) {
+        delete preq
+        respond(srv, writer, int(http_status.SERVICE_UNAVAILABLE), "application/json",
+                error_body("the server is at capacity ({g_sched.max_queue} requests queued) — retry shortly", "server_error"))
+        return
+    }
+    var wire <- StreamWire(writer = writer, streaming = streaming, is_chat = is_chat,
+                           id = cid, created = created)
+    g_wires[rid] <- wire
+    if (streaming && is_chat) {
+        send_chat_chunk(srv, writer, cid, created, "assistant", "", "")   // opening role delta
+    }
+}
+
+// Parse + validate + render + register, then return — no generation in the handler. The prompt is
+// rendered through the S1 render seam (tokens only, no KV), so a queued request holds no cache
+// memory; the session exists only once the scheduler admits the stream.
 def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var writer : HttpResponseWriter?) {
     var perr = ""
     var js = read_json(string(req.body), perr)
@@ -323,22 +381,24 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     let max_new = clamp_max(js?["max_tokens"] ?? 256l)
 
     // OpenAI is stateless — the client resends the whole transcript. Fold system turns, replay prior
-    // user/assistant pairs into the KV cache (add_assistant = inject, no generation), then respond to
-    // the trailing user turn.
+    // user/assistant pairs through the renderer, then render the trailing user turn + generation prompt.
     var system = ""
     for (msg in messages) {
         if (msg.role == "system") {
             system = empty(system) ? msg.content : "{system}\n{msg.content}"
         }
     }
-    var chat = create_chat(g_model, system, max_new)
+    var chat <- create_chat_renderer(g_model, system, max_new)
+    defer() { delete chat }
+    var prompt : array<int64>
+    defer() { delete prompt }
     var pending_user = false
     for (msg in messages) {
         if (msg.role == "user") {
             add_user(chat, msg.content)
             pending_user = true
         } elif (msg.role == "assistant" && pending_user) {
-            add_assistant(g_model, chat, msg.content)
+            render_assistant(g_model, chat, msg.content, prompt)
             pending_user = false
         }
     }
@@ -346,33 +406,12 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
         bad_request(srv, writer, "the last message must be from the user")
         return
     }
-
-    let cid = next_id("chatcmpl")
-    let created = created_ts()
-    if (streaming) {
-        send_chat_chunk(srv, writer, cid, created, "assistant", "", "")   // opening role delta
-        respond(g_model, chat, params) $(piece) {
-            send_chat_chunk(srv, writer, cid, created, "", piece, "")
-            return true
-        }
-        let st = stats(chat.session)
-        send_chat_chunk(srv, writer, cid, created, "", "", st.n_gen >= max_new ? "length" : "stop")
-        sse_event(srv, writer, "[DONE]", "")
-        close_writer(srv, writer)
-        return
-    }
-
-    let reply = respond(g_model, chat, params) $(_piece) {
-        return true
-    }
-    let st = stats(chat.session)
-    let finish = st.n_gen >= max_new ? "length" : "stop"
-    var out = OaiChatResponse(id = cid, _object = "chat.completion", created = created, model = g_model_name)
-    out.choices |> push(OaiChoice(index = 0, message = OaiMessage(role = "assistant", content = reply),
-                                  finish_reason = finish))
-    out.usage = OaiUsage(prompt_tokens = st.n_prompt, completion_tokens = st.n_gen,
-                         total_tokens = st.n_prompt + st.n_gen)
-    respond(srv, writer, int(http_status.OK), "application/json", sprint_json(out, false))
+    var turn <- render_turn(g_model, chat)
+    prompt |> push_from(turn)
+    delete turn
+    var close <- render_close(g_model, chat)
+    defer() { delete close }   // register_request moves it on success; the 400/503 paths leave it here
+    register_request(srv, writer, prompt, chat.stop_ids, close, params, max_new, streaming, true, "chatcmpl")
 }
 
 def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var writer : HttpResponseWriter?) {
@@ -393,35 +432,92 @@ def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var
     params.temp = js?["temperature"] ?? 0.0
     params.top_k = js?["top_k"] ?? 0l
     let max_new = clamp_max(js?["max_tokens"] ?? 256l)
+    var toks <- encode(g_model, prompt, true, false)
+    defer() { delete toks }
+    // no stop ids and no close: raw completions run to the budget, matching bare generate()
+    var none_stop : array<int64>
+    var none_close : array<int64>
+    register_request(srv, writer, toks, none_stop, none_close, params, max_new, streaming, false, "cmpl")
+}
 
-    let cid = next_id("cmpl")
-    let created = created_ts()
-    var session = create_session(g_model)
-    let toks <- encode(g_model, prompt, true, false)
-    if (streaming) {
-        generate(g_model, session, toks, params, max_new) $(_id, piece) {
-            send_compl_chunk(srv, writer, cid, created, piece, "")
-            return true
+// Route drained SchedEvents to their writers: streaming wires emit SSE chunks, buffered wires
+// accumulate pieces and respond once at finish. "evicted" releases the writer with no bytes —
+// the client is gone (S4's disconnect poll produces it). Finished wires unregister.
+def private flush_events(srv : WebSocketServer) {
+    for (e in g_events) {
+        // interior pointer into g_wires — nothing inserts into the table between here and the erase
+        var w = unsafe(g_wires?[e.stream])
+        if (w == null) {
+            continue
         }
-        let st = stats(session)
-        send_compl_chunk(srv, writer, cid, created, "", st.n_gen >= max_new ? "length" : "stop")
-        sse_event(srv, writer, "[DONE]", "")
-        close_writer(srv, writer)
-        return
+        if (e.kind == SchedEventKind.piece) {
+            if (!w.streaming) {
+                w.reply_parts |> push(e.text)
+            } elif (w.is_chat) {
+                send_chat_chunk(srv, w.writer, w.id, w.created, "", e.text, "")
+            } else {
+                send_compl_chunk(srv, w.writer, w.id, w.created, e.text, "")
+            }
+            continue
+        }
+        if (e.finish == "evicted") {
+            release_writer(srv, w.writer)
+        } elif (w.streaming) {
+            if (w.is_chat) {
+                send_chat_chunk(srv, w.writer, w.id, w.created, "", "", e.finish)
+            } else {
+                send_compl_chunk(srv, w.writer, w.id, w.created, "", e.finish)
+            }
+            sse_event(srv, w.writer, "[DONE]", "")
+            close_writer(srv, w.writer)
+        } elif (w.is_chat) {
+            var out = OaiChatResponse(id = w.id, _object = "chat.completion", created = w.created, model = g_model_name)
+            out.choices |> push(OaiChoice(index = 0,
+                                          message = OaiMessage(role = "assistant", content = join(w.reply_parts, "")),
+                                          finish_reason = e.finish))
+            out.usage = OaiUsage(prompt_tokens = e.n_prompt, completion_tokens = e.n_gen,
+                                 total_tokens = e.n_prompt + e.n_gen)
+            respond(srv, w.writer, int(http_status.OK), "application/json", sprint_json(out, false))
+            delete out
+        } else {
+            var out = OaiComplResponse(id = w.id, _object = "text_completion", created = w.created, model = g_model_name)
+            out.choices |> push(OaiComplChoice(index = 0, text = join(w.reply_parts, ""), finish_reason = e.finish))
+            out.usage = OaiUsage(prompt_tokens = e.n_prompt, completion_tokens = e.n_gen,
+                                 total_tokens = e.n_prompt + e.n_gen)
+            respond(srv, w.writer, int(http_status.OK), "application/json", sprint_json(out, false))
+            delete out
+        }
+        delete g_wires[e.stream]   // finalize the wire in place (erase is a raw remove)
+        g_wires |> erase(e.stream)
     }
+    g_events |> clear()
+}
 
-    var reply_parts : array<string>
-    generate(g_model, session, toks, params, max_new) $(_id, piece) {
-        reply_parts |> push(piece)
-        return true
-    }
-    let st = stats(session)
-    let finish = st.n_gen >= max_new ? "length" : "stop"
-    var out = OaiComplResponse(id = cid, _object = "text_completion", created = created, model = g_model_name)
-    out.choices |> push(OaiComplChoice(index = 0, text = join(reply_parts, ""), finish_reason = finish))
-    out.usage = OaiUsage(prompt_tokens = st.n_prompt, completion_tokens = st.n_gen,
-                         total_tokens = st.n_prompt + st.n_gen)
-    respond(srv, writer, int(http_status.OK), "application/json", sprint_json(out, false))
+// /v1/stats: the scheduler's counters as JSON (buffered — cheap enough to run in-handler).
+struct private OaiStatsResponse {
+    active : int64
+    queued : int64
+    peak_active : int64
+    admitted : int64
+    finished : int64
+    evicted : int64
+    decode_steps : int64
+    gen_tokens : int64
+    avg_batch : float
+    cached_tokens : int64
+    max_streams : int64
+    chunk_tokens : int64
+}
+
+def private handle_stats(var resp : HttpResponse?) : http_status {
+    let out = OaiStatsResponse(
+        active = n_active(g_sched), queued = n_queued(g_sched), peak_active = g_sched.peak_active,
+        admitted = g_sched.n_admitted, finished = g_sched.n_finished, evicted = g_sched.n_evicted,
+        decode_steps = g_sched.decode_steps, gen_tokens = g_sched.gen_tokens,
+        avg_batch = float(g_sched.sum_batch) / float(max(g_sched.decode_steps, 1l)),
+        cached_tokens = g_sched.cached_tokens,
+        max_streams = g_sched.max_streams, chunk_tokens = g_sched.chunk_tokens)
+    return resp |> JSON(sprint_json(out, false), http_status.OK)
 }
 
 // /v1/audio/transcriptions (translate=false) and /v1/audio/translations (translate=true, to English).
@@ -498,6 +594,9 @@ class OpenAiServer : HvWebServer {
         POST("/v1/embeddings") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_embeddings(req, resp)
         }
+        GET("/v1/stats") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_stats(resp)
+        }
         POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             g_should_stop = true
             return resp |> JSON("\{\"ok\":true}", http_status.OK)
@@ -506,22 +605,30 @@ class OpenAiServer : HvWebServer {
 }
 
 //! Run the server on the calling thread until ``request_stop`` (or ``POST /shutdown``). Sets up the
-//! job queue so the facade's kernels thread, then ticks. Call after ``set_model`` (and optionally
-//! ``set_asr``).
-def run_server(port : int) {
+//! job queue, then drives the serve loop: pump HTTP (handlers parse + render + submit), one
+//! scheduler step (continuous batching over every live stream), flush events to the writers.
+//! ``max_streams`` concurrent generation streams (each holds a full KV cache — cap the context with
+//! ``--ctx`` to bound memory), ``max_queue`` waiting requests (503 beyond), ``chunk_tokens`` the
+//! prefill quantum (decode stalls at most this many tokens per tick). Call after ``set_model``.
+def run_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; chunk_tokens : int64 = 64l) {
     g_should_stop = false   // reset so a restart in the same context after /shutdown doesn't exit at once
     with_job_que() {
         setup_dasllama_jobque()
+        g_sched <- create_scheduler(g_model, max_streams, max_queue, chunk_tokens)
         var server = new OpenAiServer()
         server->init(port)
         let rc = server->start()   // 0 on success; non-zero = bind/listen failed (e.g. port in use)
         if (rc != 0) {
             to_log(LOG_ERROR, "dasllama-server: could not start on port {port} (start rc {rc}; is the port already in use?)\n")
         } else {
-            to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (model: {g_model_name})\n")
+            to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (model: {g_model_name}, streams: {max_streams}, prefill chunk: {chunk_tokens})\n")
             while (!g_should_stop) {
-                server->tick()
-                sleep(2u)
+                server->tick()   // drains queued handlers: requests parse + render + submit here
+                let busy = scheduler_step(g_model, g_sched, g_events)
+                flush_events(server.server)
+                if (!busy) {
+                    sleep(2u)
+                }
             }
             server->stop()
         }
@@ -529,5 +636,10 @@ def run_server(port : int) {
         unsafe {
             delete server
         }
+        unsafe {
+            delete g_sched   // live sessions + workspace go with it (writers already died with the server)
+        }
+        delete g_events
+        delete g_wires
     }
 }

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -498,6 +498,8 @@ def private flush_events(srv : WebSocketServer) {
             respond(srv, w.writer, int(http_status.OK), "application/json", sprint_json(out, false))
             delete out
         }
+        let tps = e.gen_us > 0l ? int64(double(e.n_gen) * 1.0e6lf / double(e.gen_us)) : 0l
+        to_log(LOG_INFO, "stream {w.id}: finish={e.finish} prompt={e.n_prompt} cached={e.n_cached} gen={e.n_gen} ttft={e.ttft_us / 1000l}ms tps={tps}\n")
         delete g_wires[e.stream]   // finalize the wire in place (erase is a raw remove)
         g_wires |> erase(e.stream)
     }

--- a/utils/dasllama-server/server_bench.das
+++ b/utils/dasllama-server/server_bench.das
@@ -1,0 +1,285 @@
+options gen2
+options stack = 65536     // the forward/prefill chain outgrows the 16K default on arm64
+options fast_math = true  // ggml-parity FP laxity — a serving benchmark, not the bit-exact suite
+
+// Serving-latency benchmark for llm_scheduler — drives the scheduler directly through the
+// SchedEvent seam (no HTTP), so every number is server-side truth:
+//   1. aggregate tok/s + TTFT p50/p95 + inter-token p50/p95 vs batch size B
+//   2. chunk interference: a decoding stream's inter-token p95 while a long prompt prefills,
+//      per chunk size K — the data that tunes --chunk
+//   3. warm vs cold TTFT for an identical prompt — the prefix-cache collapse
+//   bin/daslang -jit utils/dasllama-server/server_bench.das -- -m <model.gguf> [-b 8] [-n 64] [--long 512]
+
+require llm_scheduler           // the scheduler under bench (sibling — bare require, hyphenated dir)
+require dasllama/dasllama       // facade: load_model / setup_dasllama_jobque
+require daslib/jobque_boost
+require daslib/clargs
+require daslib/strings_boost    // split (the --chunks list)
+require strings                 // to_int64 / strip
+require math
+
+[CommandLineArgs]
+struct Args {
+    @clarg_required
+    @clarg_short = "m"
+    @clarg_doc = "Model GGUF path"
+    model : string
+
+    @clarg_short = "q"
+    @clarg_doc = "Weight quant mode (default: q8)"
+    quant : QuantMode = QuantMode.q8
+
+    @clarg_short = "p"
+    @clarg_doc = "Prompt tokens per stream in the B sweep (default: 64)"
+    prompt : int = 64
+
+    @clarg_short = "n"
+    @clarg_doc = "Tokens generated per stream (default: 64)"
+    ngen : int = 64
+
+    @clarg_short = "b"
+    @clarg_doc = "Largest batch size — sweeps 1,2,4,... up to this (default: 8)"
+    bmax : int = 8
+
+    @clarg_doc = "Long-prompt tokens for the interference and warm-TTFT arms (default: 512)"
+    long_prompt : int = 512
+
+    @clarg_doc = "Comma-separated chunk sizes for the interference arm (default 16,64,256)"
+    chunks : string
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+def private build_prompt(n, salt : int64) : array<int64> {
+    return <- [for (i in range64(n)); 1000l + ((i * 7l + salt * 131l) % 5000l)]
+}
+
+def private pct(var xs : array<int64>; p : float) : int64 {
+    if (empty(xs)) {
+        return 0l
+    }
+    xs |> sort()
+    let idx = clamp(int(float(length(xs) - 1) * p + 0.5), 0, length(xs) - 1)
+    return xs[idx]
+}
+
+def private ms(us : int64) : float => float(us) / 1000.0
+
+struct private RoundStats {
+    agg_tps : double            // Σ generated tokens / (last piece - first piece)
+    ttft_us : array<int64>      // per stream, admit -> first sampled token
+    itl_us : array<int64>       // inter-token deltas, all streams pooled
+    cached : int64              // Σ n_cached across finished streams
+}
+
+// Submit nreq salted prompts, then step to idle, timestamping every piece as it leaves the
+// scheduler — the same loop shape as the server, minus HTTP.
+def private drive(m : Model; var sch : Scheduler; nreq, p_tokens, max_new, salt0 : int64) : RoundStats {
+    var st = RoundStats()
+    var events : array<SchedEvent>
+    var last_piece : table<int64; int64>
+    for (i in range64(nreq)) {
+        var req <- PendingReq(id = salt0 * 1000l + i, max_new = max_new)
+        req.prompt <- build_prompt(p_tokens, salt0 * 97l + i)
+        if (!submit(m, sch, req)) {
+            panic("server_bench: submit rejected (queue too small for the sweep)")
+        }
+    }
+    let t0 = ref_time_ticks()
+    var first_us = -1l
+    var final_us = 0l
+    var gen_total = 0l
+    var guard = 0
+    var running = true
+    while (running) {   // the LAST step's events (the final finished) must still process
+        running = scheduler_step(m, sch, events)
+        let now = int64(get_time_usec(t0))
+        for (e in events) {
+            if (e.kind == SchedEventKind.piece) {
+                if (first_us < 0l) {
+                    first_us = now
+                }
+                final_us = now
+                if (key_exists(last_piece, e.stream)) {
+                    st.itl_us |> push(now - last_piece[e.stream])
+                }
+                last_piece[e.stream] = now
+            } else {
+                st.ttft_us |> push(e.ttft_us)
+                st.cached += e.n_cached
+                gen_total += e.n_gen
+            }
+        }
+        events |> clear()
+        guard ++
+        if (guard > 1000000) {
+            panic("server_bench: scheduler did not go idle")
+        }
+    }
+    if (final_us > first_us && first_us >= 0l) {
+        st.agg_tps = double(gen_total) * 1.0e6lf / double(final_us - first_us)
+    }
+    delete events
+    delete last_piece
+    return <- st
+}
+
+// Stream A decodes; a long prompt lands mid-run and prefills in K-token chunks. A's inter-token
+// gaps during that window are the interference the chunk size buys or costs.
+def private interference_run(m : Model; var sch : Scheduler; long_p, salt : int64) : array<int64> {
+    var itl : array<int64>
+    var events : array<SchedEvent>
+    var req_a <- PendingReq(id = 1l, max_new = long_p)   // enough budget to outlast B's prefill
+    req_a.prompt <- build_prompt(64l, salt * 7l + 1l)
+    if (!submit(m, sch, req_a)) {
+        panic("server_bench: submit A rejected")
+    }
+    let t0 = ref_time_ticks()
+    var a_last = -1l
+    var b_running = false
+    var b_first_piece = false
+    var guard = 0
+    var running = true
+    while (running && !b_first_piece) {
+        running = scheduler_step(m, sch, events)
+        let now = int64(get_time_usec(t0))
+        for (e in events) {
+            if (e.kind != SchedEventKind.piece) {
+                continue
+            }
+            if (e.stream == 1l) {
+                if (b_running && a_last >= 0l) {
+                    itl |> push(now - a_last)   // only the window that overlaps B's prefill
+                }
+                a_last = now
+                if (!b_running) {   // A is decoding — drop the long prompt on the scheduler
+                    var req_b <- PendingReq(id = 2l, max_new = 2l)
+                    req_b.prompt <- build_prompt(long_p, salt * 7l + 2l)
+                    if (!submit(m, sch, req_b)) {
+                        panic("server_bench: submit B rejected")
+                    }
+                    b_running = true
+                }
+            } elif (e.stream == 2l) {
+                b_first_piece = true   // B's prefill is done — the window closes
+            }
+        }
+        events |> clear()
+        guard ++
+        if (guard > 1000000) {
+            panic("server_bench: interference run did not converge")
+        }
+    }
+    evict(sch, 1l, events)
+    evict(sch, 2l, events)
+    var draining = true
+    while (draining) {
+        draining = scheduler_step(m, sch, events)
+        events |> clear()
+    }
+    delete events
+    return <- itl
+}
+
+[export]
+def main() {
+    if (!jit_enabled()) {
+        print("This benchmark is JIT-only — run with: daslang -jit <file>\n")
+        return
+    }
+    var r <- parse_args(type<Args>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Args>), "server_bench")
+        return
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Args>), "server_bench")
+        return
+    }
+    let p = max(int64(cfg.prompt), 8l)
+    let n = max(int64(cfg.ngen), 4l)
+    let bmax = clamp(int64(cfg.bmax), 1l, 32l)
+    let long_p = max(int64(cfg.long_prompt), 128l)
+    var chunks : array<int64>
+    if (!empty(cfg.chunks)) {
+        var parts <- split(cfg.chunks, ",")
+        for (s in parts) {
+            let k = to_int64(strip(s))
+            if (k > 0l) {
+                chunks |> push(k)
+            }
+        }
+        delete parts
+    }
+    if (empty(chunks)) {
+        chunks <- [16l, 64l, 256l]
+    }
+    print("loading {cfg.model}\n")
+    var m <- load_model(cfg.model, cfg.quant)
+    // every arm must fit: the B sweep (p+n), the interference arm (64 + long_p of A-budget), warm TTFT
+    let need = max(p + n + 8l, max(long_p + 16l, 64l + long_p + 8l))
+    m.config.seq_len = min(m.config.seq_len, need)
+    print("config: dim={m.config.dim} layers={m.config.n_layers} ctx={m.config.seq_len}\n\n")
+    with_job_que() {
+        setup_dasllama_jobque()
+        // ===== 1. throughput + latency vs batch size (distinct prompts — no prefix effects) =====
+        print("== tok/s + latency vs B  (prompt {p}, gen {n} per stream, paged P=64) ==\n")
+        var salt = 1l
+        {
+            var warm_sch <- create_scheduler(m, 2l, 64l, 64l, 64l)   // warm the JIT + kernel dispatch
+            var wst <- drive(m, warm_sch, 2l, 16l, 4l, salt)
+            delete wst
+            unsafe {
+                delete warm_sch
+            }
+        }
+        var nb = 1l
+        while (nb <= bmax) {
+            salt ++
+            var sch <- create_scheduler(m, nb, 64l, 64l, 64l)
+            var st <- drive(m, sch, nb, p, n, salt)
+            print("B={nb}: {st.agg_tps} tok/s | ttft p50 {ms(pct(st.ttft_us, 0.5))}ms p95 {ms(pct(st.ttft_us, 0.95))}ms" +
+                  " | inter-token p50 {ms(pct(st.itl_us, 0.5))}ms p95 {ms(pct(st.itl_us, 0.95))}ms\n")
+            delete st
+            unsafe {
+                delete sch
+            }
+            nb *= 2l
+        }
+        // ===== 2. chunk interference: decode stall while a long prompt prefills =====
+        print("\n== inter-token gap of a live stream while a {long_p}-token prompt prefills, per chunk K ==\n")
+        for (k in chunks) {
+            salt ++
+            var sch <- create_scheduler(m, 2l, 4l, k, 64l)
+            var itl <- interference_run(m, sch, long_p, salt)
+            print("K={k}: {length(itl)} gaps | p50 {ms(pct(itl, 0.5))}ms | p95 {ms(pct(itl, 0.95))}ms | max {ms(pct(itl, 1.0))}ms\n")
+            delete itl
+            unsafe {
+                delete sch
+            }
+        }
+        // ===== 3. warm vs cold TTFT: the prefix-cache prefill collapse =====
+        print("\n== warm vs cold TTFT for an identical {long_p}-token prompt (prefix cache) ==\n")
+        {
+            salt ++
+            var sch <- create_scheduler(m, 1l, 4l, 64l, 64l)
+            var cold <- drive(m, sch, 1l, long_p, 8l, salt)
+            var warm <- drive(m, sch, 1l, long_p, 8l, salt)   // same salt -> same prompt
+            let c_us = pct(cold.ttft_us, 0.5)
+            let w_us = pct(warm.ttft_us, 0.5)
+            let ratio = w_us > 0l ? double(c_us) / double(w_us) : 0.0lf
+            print("cold ttft {ms(c_us)}ms | warm ttft {ms(w_us)}ms ({ratio}x) | warm cached {warm.cached} tokens\n")
+            delete cold
+            delete warm
+            unsafe {
+                delete sch
+            }
+        }
+    }
+    delete chunks
+    delete m
+}

--- a/utils/dasllama-server/server_bench.das
+++ b/utils/dasllama-server/server_bench.das
@@ -8,7 +8,7 @@ options fast_math = true  // ggml-parity FP laxity — a serving benchmark, not 
 //   2. chunk interference: a decoding stream's inter-token p95 while a long prompt prefills,
 //      per chunk size K — the data that tunes --chunk
 //   3. warm vs cold TTFT for an identical prompt — the prefix-cache collapse
-//   bin/daslang -jit utils/dasllama-server/server_bench.das -- -m <model.gguf> [-b 8] [-n 64] [--long 512]
+//   bin/daslang -jit utils/dasllama-server/server_bench.das -- -m <model.gguf> [-b 8] [-n 64] [--long-prompt 512]
 
 require llm_scheduler           // the scheduler under bench (sibling — bare require, hyphenated dir)
 require dasllama/dasllama       // facade: load_model / setup_dasllama_jobque

--- a/utils/dasllama-server/test_llm_scheduler.das
+++ b/utils/dasllama-server/test_llm_scheduler.das
@@ -324,6 +324,58 @@ def test_scheduler_batching(t : T?) {
     }
 }
 
+// ===== paged serving + prefix cache: a repeat request attaches pages and skips their prefill =====
+
+[test]
+def test_scheduler_prefix_cache(t : T?) {
+    t |> run("paged scheduler: repeat request attaches cached pages, identical stream (needs SmolLM2-135M)") @(t : T?) {
+        if (model_missing(t)) {
+            return
+        }
+        with_job_que() {
+            setup_dasllama_jobque()
+            var m <- load_capped(128l)
+            // classic prefill: the warm run re-chunks the prompt (tail-only), and only classic is
+            // bit-exact under re-chunking — the same pin as the chunk-size arm above
+            let saved_mode = get_prefill_attn_mode()
+            set_prefill_attn_mode(AttnPrefillMode.classic)
+            var prompt <- encode(m, "Once upon a time in a small village near the mountains there lived a very curious little robot who loved counting stars", true, false)
+            let np = int64(length(prompt))
+            t |> success(np > 17l, "prompt spans multiple pages at P=16 ({np} tokens)")
+            var none : array<int64>
+            let greedy = SamplingParams()
+            var sch <- create_scheduler(m, 1l, 4l, 64l, 16l)   // paged, P=16, unbounded prefix cache
+            var events : array<SchedEvent>
+            t |> success(submit(m, sch, make_req(1l, prompt, greedy, 8l, none)), "cold stream queued")
+            drain(m, sch, events)
+            var cold <- toks_of(events, 1l)
+            t |> equal(finished_of(events, 1l).n_cached, 0l)
+            t |> success(prefix_held_groups(sch.prefix) > 0l, "the finished stream donated its pages")
+            t |> equal(sch.cached_tokens, 0l)
+            events |> clear()
+            t |> success(submit(m, sch, make_req(2l, prompt, greedy, 8l, none)), "warm stream queued")
+            drain(m, sch, events)
+            var warm <- toks_of(events, 2l)
+            let fin2 = finished_of(events, 2l)
+            t |> equal(fin2.n_cached, (np - 1l) / 16l * 16l)   // whole pages, capped below np
+            t |> success(same(warm, cold), "warm stream identical to cold")
+            t |> equal(sch.cached_tokens, fin2.n_cached)
+            // idle scheduler: the only live page holds are the cache's
+            t |> equal(int64(length(sch.pool.free_groups)),
+                       sch.pool.capacity_groups - prefix_held_groups(sch.prefix))
+            set_prefill_attn_mode(saved_mode)
+            delete cold
+            delete warm
+            delete events
+            unsafe {
+                delete sch
+            }
+            delete prompt
+            delete m
+        }
+    }
+}
+
 // ===== active eviction mid-run + the context-exhaustion length pre-check =====
 
 [test]

--- a/utils/dasllama-server/test_llm_scheduler.das
+++ b/utils/dasllama-server/test_llm_scheduler.das
@@ -1,0 +1,381 @@
+options gen2
+options stack = 131072    // model frames: a Scheduler (workspace Session inline) + reference Sessions
+options persistent_heap   // each test frees its model/scheduler before the next loads
+
+require dastest/testing_boost public
+require llm_scheduler                                   // the scheduler under test (sibling — bare require, hyphenated dir)
+require dasllama/dasllama                               // facade: load/encode/generate references + engine knobs
+require daslib/jobque_boost
+require daslib/fio
+require math
+
+// Unit gates for the continuous-batching scheduler — all through the SchedEvent seam, zero HTTP:
+// scheduler ≡ generate bit-exact (1 stream), chunk-size invariance under classic prefill, staggered
+// admit + queue overflow, stop/budget/context-length finishes, evict mid-run. Model-gated + JIT-only
+// (SmolLM2-135M GGUF via DASLLAMA_MODELS_DIR), same skip contract as test_openai_server.
+
+def private models_dir() : string {
+    let env = get_env_variable("DASLLAMA_MODELS_DIR")
+    return empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+}
+let MODEL_PATH = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+
+def private model_missing(t : T?) : bool {
+    if (!jit_enabled()) {
+        t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+        return true
+    }
+    if (!stat(MODEL_PATH).is_valid) {
+        t |> success(true, "skipped: {MODEL_PATH} not present")
+        return true
+    }
+    return false
+}
+
+def private load_capped(cap : int64) : Model {
+    var m <- load_model(MODEL_PATH, QuantMode.q8)
+    m.config.seq_len = min(m.config.seq_len, cap)
+    return <- m
+}
+
+def private same(a, b : array<int64>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+// One stream's reference: generate() with the wiring's stop protocol (stop token ends the stream
+// unemitted; otherwise the budget runs out) — what the scheduler must reproduce.
+struct private RefStream {
+    toks : array<int64>
+    pieces : array<string>
+    finish : string
+}
+
+def private ref_generate(m : Model; prompt : array<int64>; params : SamplingParams;
+                         max_new : int64; stop_ids : array<int64>; seed : int = 0) : RefStream {
+    var s <- create_session(m)
+    if (seed != 0) {
+        set_seed(s, seed)
+    }
+    var r : RefStream
+    var stops := stop_ids
+    var hit_stop = false
+    generate(m, s, prompt, params, max_new) $(id, pc) {
+        for (sid in stops) {
+            if (id == sid) {
+                hit_stop = true
+                return false
+            }
+        }
+        r.toks |> push(id)
+        r.pieces |> push(pc)
+        return true
+    }
+    r.finish = hit_stop ? "stop" : "length"
+    delete s
+    return <- r
+}
+
+def private make_req(id : int64; prompt : array<int64>; params : SamplingParams; max_new : int64;
+                     stop_ids : array<int64>; seed : int = 0) : PendingReq {
+    var r <- PendingReq(id = id, params = params, max_new = max_new, seed = seed)
+    r.prompt := prompt
+    r.stop_ids := stop_ids
+    return <- r
+}
+
+// step until idle (bounded — a runaway scheduler must not hang the suite)
+def private drain(m : Model; var sch : Scheduler; var events : array<SchedEvent>) {
+    var steps = 0
+    while (scheduler_step(m, sch, events)) {
+        steps ++
+        if (steps > 4096) {
+            panic("test_llm_scheduler: scheduler did not go idle in 4096 steps")
+        }
+    }
+}
+
+def private toks_of(events : array<SchedEvent>; id : int64) : array<int64> {
+    return <- [for (e in events); e.token; where e.stream == id && e.kind == SchedEventKind.piece]
+}
+
+def private pieces_of(events : array<SchedEvent>; id : int64) : array<string> {
+    return <- [for (e in events); e.text; where e.stream == id && e.kind == SchedEventKind.piece]
+}
+
+def private finished_of(events : array<SchedEvent>; id : int64) : SchedEvent {
+    for (e in events) {
+        if (e.stream == id && e.kind == SchedEventKind.finished) {
+            return e
+        }
+    }
+    return SchedEvent(stream = -1l)
+}
+
+// ===== scheduler ≡ generate (1 stream): greedy bit-exact, seeded sampling, stop finish =====
+
+[test]
+def test_scheduler_matches_generate(t : T?) {
+    t |> run("scheduler ≡ generate: bit-exact stream, seeded sampling, stop/budget (needs SmolLM2-135M)") @(t : T?) {
+        if (model_missing(t)) {
+            return
+        }
+        with_job_que() {
+            setup_dasllama_jobque()
+            var m <- load_capped(128l)
+            var prompt <- encode(m, "Once upon a time", true, false)
+            var none : array<int64>
+            // greedy, single-chunk prefill: the eval sequence is identical to generate()'s, so the
+            // emitted stream must be BIT-exact (B==1 eval_batch delegates to the same forward())
+            let greedy = SamplingParams()
+            var ref <- ref_generate(m, prompt, greedy, 10l, none)
+            var sch <- create_scheduler(m, 1l, 4l, 512l)
+            var events : array<SchedEvent>
+            t |> success(submit(m, sch, make_req(1l, prompt, greedy, 10l, none)), "greedy stream queued")
+            drain(m, sch, events)
+            var got <- toks_of(events, 1l)
+            var gotp <- pieces_of(events, 1l)
+            t |> success(same(got, ref.toks), "greedy tokens ≡ generate() bit-exact")
+            t |> equal(length(gotp), length(ref.pieces))
+            for (i in range(length(gotp))) {
+                t |> equal(gotp[i], ref.pieces[i])
+            }
+            let fin = finished_of(events, 1l)
+            t |> equal(fin.finish, "length")
+            t |> equal(fin.n_gen, 10l)
+            t |> equal(fin.n_prompt, int64(length(prompt)))
+            t |> success(fin.ttft_us > 0l, "TTFT recorded")
+            t |> equal(sch.gen_tokens, 10l)
+            t |> success(sch.decode_steps > 0l, "decode steps counted")
+            // seeded sampling (temp + top-k): the scheduler makes the same sample() calls in the
+            // same order, so a seeded run reproduces generate() exactly
+            let sp = SamplingParams(temp = 0.8, top_k = 40l)
+            var ref2 <- ref_generate(m, prompt, sp, 10l, none, 4242)
+            events |> clear()
+            t |> success(submit(m, sch, make_req(2l, prompt, sp, 10l, none, 4242)), "seeded stream queued")
+            drain(m, sch, events)
+            var got2 <- toks_of(events, 2l)
+            t |> success(same(got2, ref2.toks), "seeded sampled tokens ≡ generate()")
+            // stop finish: pick the first greedy token that did not occur earlier in the stream,
+            // declare it a stop id — the scheduler must end there, stop token unemitted
+            var kstop = -1
+            for (k in range(1, length(ref.toks))) {
+                var seen = false
+                for (j in range(k)) {
+                    seen ||= ref.toks[j] == ref.toks[k]
+                }
+                if (!seen) {
+                    kstop = k
+                    break
+                }
+            }
+            if (kstop > 0) {
+                var stops <- [ref.toks[kstop]]
+                var ref3 <- ref_generate(m, prompt, greedy, 10l, stops)
+                events |> clear()
+                t |> success(submit(m, sch, make_req(3l, prompt, greedy, 10l, stops)), "stop stream queued")
+                drain(m, sch, events)
+                var got3 <- toks_of(events, 3l)
+                t |> equal(length(got3), kstop)
+                t |> success(same(got3, ref3.toks), "stop-bounded tokens ≡ generate()")
+                let fin3 = finished_of(events, 3l)
+                t |> equal(fin3.finish, "stop")
+                t |> equal(fin3.n_gen, int64(kstop))
+                delete got3
+                delete ref3
+                delete stops
+            } else {
+                t |> success(true, "no unique stop candidate in 10 greedy tokens — stop arm skipped")
+            }
+            delete got
+            delete gotp
+            delete got2
+            delete ref
+            delete ref2
+            delete events
+            unsafe {
+                delete sch
+            }
+            delete prompt
+            delete m
+        }
+    }
+}
+
+// ===== chunked prefill: {1,3,17,64} produce the identical stream under classic prefill =====
+
+[test]
+def test_scheduler_chunk_sizes(t : T?) {
+    t |> run("prefill chunk sizes 1/3/17/64 give the same stream — classic mode (needs SmolLM2-135M)") @(t : T?) {
+        if (model_missing(t)) {
+            return
+        }
+        with_job_que() {
+            setup_dasllama_jobque()
+            var m <- load_capped(128l)
+            // classic prefill is bit-exact under ANY chunking (test_prefill's contract) — the same
+            // pin as test_chat's render-seam case, so every chunk size must yield ONE stream
+            let saved_mode = get_prefill_attn_mode()
+            set_prefill_attn_mode(AttnPrefillMode.classic)
+            var prompt <- encode(m, "The quick brown fox jumps over the lazy dog while the little robot watches from a small hill near the old village bakery and counts every bird that crosses the evening sky", true, false)
+            t |> success(int64(length(prompt)) > 17l, "prompt spans multiple chunks ({length(prompt)} tokens)")
+            var none : array<int64>
+            let greedy = SamplingParams()
+            var first <- [-1l, -1l, -1l, -1l]
+            var streams : array<array<int64>>
+            for (ci, K in range(4), [1l, 3l, 17l, 64l]) {
+                var sch <- create_scheduler(m, 1l, 4l, K)
+                var events : array<SchedEvent>
+                t |> success(submit(m, sch, make_req(int64(ci), prompt, greedy, 6l, none)), "stream queued (K={K})")
+                drain(m, sch, events)
+                var got <- toks_of(events, int64(ci))
+                first[ci] = length(got) > 0 ? got[0] : -1l
+                streams |> emplace(got)
+                delete events
+                unsafe {
+                    delete sch
+                }
+            }
+            t |> success(first[0] >= 0l, "chunked runs produced tokens")
+            for (ci in range(1, 4)) {
+                t |> equal(first[ci], first[0])
+                t |> success(same(streams[ci], streams[0]), "K arm {ci}: full stream identical to K=1")
+            }
+            set_prefill_attn_mode(saved_mode)
+            delete first
+            delete streams
+            delete prompt
+            delete m
+        }
+    }
+}
+
+// ===== staggered admit, queue overflow, queued eviction, multi-stream token match =====
+
+[test]
+def test_scheduler_batching(t : T?) {
+    t |> run("staggered admit + queue overflow: every stream matches its solo reference (needs SmolLM2-135M)") @(t : T?) {
+        if (model_missing(t)) {
+            return
+        }
+        with_job_que() {
+            setup_dasllama_jobque()
+            var m <- load_capped(128l)
+            // the batch worker mirrors the std decode path — pin the fused chain off so the solo
+            // generate() references share its numerics (test_batch_decode's contract)
+            let prev_fused = get_fused_decode()
+            set_fused_decode(false)
+            let greedy = SamplingParams()
+            var none : array<int64>
+            var pa <- encode(m, "Once upon a time", true, false)
+            var pb <- encode(m, "The little robot", true, false)
+            var pc <- encode(m, "In a small village", true, false)
+            var refs <- [ <- ref_generate(m, pa, greedy, 6l, none), <- ref_generate(m, pb, greedy, 6l, none),
+                         <- ref_generate(m, pc, greedy, 6l, none)]
+            var sch <- create_scheduler(m, 2l, 2l, 64l)
+            var events : array<SchedEvent>
+            t |> success(submit(m, sch, make_req(10l, pa, greedy, 6l, none)), "stream A queued")
+            t |> success(submit(m, sch, make_req(11l, pb, greedy, 6l, none)), "stream B queued")
+            // 3 ticks: A and B admit (cap 2) and start decoding; C arrives mid-run — staggered
+            for (_i in range(3)) {
+                scheduler_step(m, sch, events)
+            }
+            t |> equal(n_active(sch), 2l)
+            t |> success(submit(m, sch, make_req(12l, pc, greedy, 6l, none)), "stream C queued mid-run")
+            t |> success(submit(m, sch, make_req(13l, pa, greedy, 6l, none)), "stream D queued (fills the queue)")
+            t |> success(!submit(m, sch, make_req(14l, pb, greedy, 6l, none)), "queue full: submit rejected")
+            t |> success(evict(sch, 13l, events), "queued stream D evicted")
+            t |> equal(finished_of(events, 13l).finish, "evicted")
+            t |> equal(n_queued(sch), 1l)
+            drain(m, sch, events)
+            var ga <- toks_of(events, 10l)
+            var gb <- toks_of(events, 11l)
+            var gc <- toks_of(events, 12l)
+            t |> success(same(ga, refs[0].toks), "stream A (batched) matches its solo reference")
+            t |> success(same(gb, refs[1].toks), "stream B (batched) matches its solo reference")
+            t |> success(same(gc, refs[2].toks), "stream C (admitted after a slot freed) matches its solo reference")
+            t |> equal(finished_of(events, 12l).finish, "length")
+            t |> equal(length(toks_of(events, 13l)), 0)
+            t |> equal(sch.peak_active, 2l)
+            t |> equal(sch.n_evicted, 1l)
+            t |> equal(sch.n_finished, 3l)
+            t |> success(sch.sum_batch >= 2l * 2l, "decode steps actually batched (Σ batch {sch.sum_batch})")
+            set_fused_decode(prev_fused)
+            delete ga
+            delete gb
+            delete gc
+            delete events
+            unsafe {
+                delete sch
+            }
+            delete refs
+            delete pa
+            delete pb
+            delete pc
+            delete m
+        }
+    }
+}
+
+// ===== active eviction mid-run + the context-exhaustion length pre-check =====
+
+[test]
+def test_scheduler_evict_and_context_length(t : T?) {
+    t |> run("evict mid-run leaves the survivor exact; context exhaustion finishes 'length' (needs SmolLM2-135M)") @(t : T?) {
+        if (model_missing(t)) {
+            return
+        }
+        with_job_que() {
+            setup_dasllama_jobque()
+            var m <- load_capped(64l)
+            let prev_fused = get_fused_decode()
+            set_fused_decode(false)
+            let greedy = SamplingParams()
+            var none : array<int64>
+            var pa <- encode(m, "Once upon a time", true, false)
+            var pb <- encode(m, "The little robot", true, false)
+            var ref_a <- ref_generate(m, pa, greedy, 8l, none)
+            var sch <- create_scheduler(m, 2l, 4l, 64l)
+            var events : array<SchedEvent>
+            t |> success(submit(m, sch, make_req(20l, pa, greedy, 8l, none)), "survivor queued")
+            t |> success(submit(m, sch, make_req(21l, pb, greedy, 8l, none)), "victim queued")
+            for (_i in range(4)) {   // both prefilled + a few decode steps at B=2
+                scheduler_step(m, sch, events)
+            }
+            let b_before = length(toks_of(events, 21l))
+            t |> success(b_before > 0, "victim generated before eviction")
+            t |> success(evict(sch, 21l, events), "victim evicted mid-run")
+            t |> equal(finished_of(events, 21l).finish, "evicted")
+            drain(m, sch, events)
+            t |> equal(length(toks_of(events, 21l)), b_before)
+            var ga <- toks_of(events, 20l)
+            t |> success(same(ga, ref_a.toks), "survivor stream unaffected by the eviction")
+            t |> equal(finished_of(events, 20l).finish, "length")
+            // context exhaustion: budget far beyond the capped seq_len — the decode pre-check must
+            // finish "length" (n_gen = seq_len - n_prompt + 1) instead of reaching the engine panic
+            events |> clear()
+            t |> success(submit(m, sch, make_req(22l, pa, greedy, 512l, none)), "exhaustion stream queued")
+            drain(m, sch, events)
+            let fin = finished_of(events, 22l)
+            t |> equal(fin.finish, "length")
+            t |> equal(fin.n_gen, m.config.seq_len - int64(length(pa)) + 1l)
+            set_fused_decode(prev_fused)
+            delete ga
+            delete events
+            unsafe {
+                delete sch
+            }
+            delete ref_a
+            delete pa
+            delete pb
+            delete m
+        }
+    }
+}

--- a/utils/dasllama-server/test_llm_scheduler.das
+++ b/utils/dasllama-server/test_llm_scheduler.das
@@ -363,6 +363,74 @@ def test_scheduler_prefix_cache(t : T?) {
             // idle scheduler: the only live page holds are the cache's
             t |> equal(int64(length(sch.pool.free_groups)),
                        sch.pool.capacity_groups - prefix_held_groups(sch.prefix))
+
+            // ===== stop-finished streams donate an ALIGNED history: continuation attach == cold.
+            // A "stop" finish must donate rows matching prompt + emitted + close exactly — the stop
+            // was sampled from the last emitted token's eval, so only the CLOSE tokens are pending.
+            // Re-evaling the last token would shift every row past the reply boundary against the
+            // page's token list, poisoning multi-turn continuation attaches.
+            var prompt3 <- encode(m, "The little robot climbed the old bakery roof to count the evening birds", true, false)
+            var ref3 <- ref_generate(m, prompt3, greedy, 8l, none)
+            var kstop = -1
+            for (k in range(1, length(ref3.toks))) {   // first token unique so far — a safe stop id
+                var seen = false
+                for (j in range(k)) {
+                    seen ||= ref3.toks[j] == ref3.toks[k]
+                }
+                if (!seen) {
+                    kstop = k
+                    break
+                }
+            }
+            if (kstop >= 1) {
+                var stops <- [ref3.toks[kstop]]
+                var close <- [100l, 200l]   // any valid ids: the donated history must include them
+                var sch2 <- create_scheduler(m, 1l, 4l, 64l, 16l)
+                events |> clear()
+                var req <- make_req(50l, prompt3, greedy, 8l, stops)
+                req.close_toks := close
+                t |> success(submit(m, sch2, req), "stop stream queued")
+                drain(m, sch2, events)
+                t |> equal(finished_of(events, 50l).finish, "stop")
+                var emitted <- toks_of(events, 50l)
+                t |> equal(length(emitted), kstop)
+                // continuation: the next turn's prompt replays prompt + reply + close, then diverges
+                var prompt4 : array<int64>
+                prompt4 |> push_from(prompt3, emitted, close)
+                for (i in range64(16l)) {
+                    prompt4 |> push(500l + i)
+                }
+                events |> clear()
+                t |> success(submit(m, sch2, make_req(51l, prompt4, greedy, 6l, none)), "warm continuation queued")
+                drain(m, sch2, events)
+                var warm4 <- toks_of(events, 51l)
+                let fin4 = finished_of(events, 51l)
+                t |> success(fin4.n_cached > int64(length(prompt3)),
+                    "continuation attached past the reply boundary (cached {fin4.n_cached})")
+                // cold reference: the same continuation with no cache
+                var sch3 <- create_scheduler(m, 1l, 4l, 64l, 16l)
+                events |> clear()
+                t |> success(submit(m, sch3, make_req(52l, prompt4, greedy, 6l, none)), "cold continuation queued")
+                drain(m, sch3, events)
+                var cold4 <- toks_of(events, 52l)
+                t |> success(same(warm4, cold4), "continuation attach bit-exact vs cold — donated rows aligned")
+                delete cold4
+                unsafe {
+                    delete sch3
+                }
+                delete warm4
+                delete prompt4
+                delete emitted
+                unsafe {
+                    delete sch2
+                }
+                delete close
+                delete stops
+            } else {
+                t |> success(true, "no unique stop candidate in 8 greedy tokens — continuation arm skipped")
+            }
+            delete ref3
+            delete prompt3
             set_prefill_attn_mode(saved_mode)
             delete cold
             delete warm

--- a/utils/dasllama-server/test_openai_server_stream.das
+++ b/utils/dasllama-server/test_openai_server_stream.das
@@ -13,14 +13,15 @@ require daslib/fio                                      // get_env_variable / st
 require strings                                         // starts_with / build_string
 require math                                            // min
 
-// S3 conformance for the continuous-batching server wiring: SSE chunk framing on a streaming chat,
-// the mandatory 400 on a prompt that cannot fit the context (the scheduler would panic), and two
-// client THREADS batching on one server (proven by /v1/stats peak_active >= 2). Same skip contract
+// S3/S4 conformance for the continuous-batching server wiring: SSE chunk framing on a streaming
+// chat, the mandatory 400 on a prompt that cannot fit the context (the scheduler would panic), two
+// client THREADS batching on one server (proven by /v1/stats peak_active >= 2), and disconnect
+// eviction (an abandoned client's stream finishes "evicted", proven via stats). Same skip contract
 // as test_openai_server; SmolLM2-135M — small, chatml template (real stop ids). In-dir like its
 // siblings: a require path can't contain the '-' of "dasllama-server".
 
 let TEST_PORT = 18101
-let TEST_CTX = 192l   // small context so the 400 over-long-prompt arm stays cheap to drive
+let TEST_CTX = 1024l   // big enough that the eviction arm's 900-token budget outlasts a 1s client timeout
 
 def private models_dir() : string {
     let env = get_env_variable("DASLLAMA_MODELS_DIR")
@@ -170,7 +171,7 @@ def test_openai_server_stream(t : T?) {
         }
         t |> run("over-long prompt answers 400 before the scheduler (mandatory pre-check)") @(t : T?) {
             let big = build_string() $(w) {
-                for (_i in range(400)) {   // ~400 tokens — far beyond the TEST_CTX-token context
+                for (_i in range(1400)) {   // ~1400 tokens — far beyond the TEST_CTX-token context
                     w |> write("word ")
                 }
             }
@@ -242,6 +243,45 @@ def test_openai_server_stream(t : T?) {
                         delete js
                     }
                 }
+            }
+        }
+        t |> run("disconnected client is evicted mid-generation (observed via /v1/stats)") @(t : T?) {
+            // Non-streaming: the client receives ZERO bytes until finish, so its 1s idle-read
+            // timeout fires deterministically while the server is still generating the 900-token
+            // budget (a 135M model is nowhere near 900 tok/s); the serve loop's
+            // is_writer_connected poll then evicts the stream and reaps its session.
+            with_http_request() <| $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/v1/chat/completions"
+                req.body := "\{\"messages\":[\{\"role\":\"user\",\"content\":\"Tell me a very long story.\"}],\"max_tokens\":900}"
+                set_content_type(req, "application/json")
+                set_timeout(req, 1)
+                request(req) $(_resp) {}   // times out — the abort IS the test stimulus
+            }
+            var evicted = 0l
+            for (_attempt in range(300)) {   // up to ~30s; generation stops at eviction, so usually instant
+                GET("{base_url}/v1/stats") $(resp) {
+                    if (resp != null && resp.status_code == http_status.OK) {
+                        var perr = ""
+                        var js = read_json(string(resp.body), perr)
+                        if (js != null) {
+                            evicted = int64(js?["evicted"] ?? 0l)
+                            unsafe {
+                                delete js
+                            }
+                        }
+                    }
+                }
+                if (evicted >= 1l) {
+                    break
+                }
+                sleep(100u)
+            }
+            t |> success(evicted >= 1l, "the abandoned stream was evicted (evicted = {evicted})")
+            // the server survives the eviction and still serves
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":\"Hi\"}],\"max_tokens\":4}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
             }
         }
     }

--- a/utils/dasllama-server/test_openai_server_stream.das
+++ b/utils/dasllama-server/test_openai_server_stream.das
@@ -1,0 +1,248 @@
+options gen2
+options persistent_heap   // the server thread loads/frees a model once; explicit deletes below
+options stack = 262144    // the forward chain runs under the HTTP tick + C++->das bridge (matches main.das)
+options fast_math = true  // ggml-parity FP laxity — this is an inference tool test, not the bit-exact suite
+
+require dastest/testing_boost public
+require openai_server                                   // the scheduler-wired server (sibling — bare require, hyphenated dir)
+require dasllama/dasllama                               // load_model / QuantMode
+require daslib/jobque_boost                             // with_job_status / with_channel (threads + results)
+require daslib/json_boost                               // read_json / from_JV
+require daslib/strings_boost                            // split / trim_prefix
+require daslib/fio                                      // get_env_variable / stat / path_join / sleep
+require strings                                         // starts_with / build_string
+require math                                            // min
+
+// S3 conformance for the continuous-batching server wiring: SSE chunk framing on a streaming chat,
+// the mandatory 400 on a prompt that cannot fit the context (the scheduler would panic), and two
+// client THREADS batching on one server (proven by /v1/stats peak_active >= 2). Same skip contract
+// as test_openai_server; SmolLM2-135M — small, chatml template (real stop ids). In-dir like its
+// siblings: a require path can't contain the '-' of "dasllama-server".
+
+let TEST_PORT = 18101
+let TEST_CTX = 192l   // small context so the 400 over-long-prompt arm stays cheap to drive
+
+def private models_dir() : string {
+    let env = get_env_variable("DASLLAMA_MODELS_DIR")
+    return empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+}
+let MODEL_PATH = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+
+def private model_missing(t : T?) : bool {
+    if (!jit_enabled()) {
+        t |> success(true, "skipped: interpreted (dasLLAMA server test is JIT-only)")
+        return true
+    }
+    if (!stat(MODEL_PATH).is_valid) {
+        t |> success(true, "skipped: {MODEL_PATH} not present")
+        return true
+    }
+    return false
+}
+
+// Start the server on a dedicated thread (model loaded in-thread — g_model is per-context), wait
+// until it answers /v1/models, run the block, POST /shutdown, join. Caps the context to TEST_CTX.
+def private with_stream_server(t : T?; model_path : string; port : int; blk : block<(base_url : string) : void>) {
+    with_job_status(1) $(finished) {
+        new_thread() @() {
+            var m <- load_model(model_path, QuantMode.q8)
+            m.config.seq_len = min(m.config.seq_len, TEST_CTX)
+            set_model(m, "test-llm-stream")
+            run_server(port)   // scheduler defaults: 4 streams, queue 32, chunk 64
+            finished |> notify_and_release
+        }
+        let base_url = "http://127.0.0.1:{port}"
+        var ready = false
+        for (_attempt in range(300)) {   // up to ~30s for load + JIT
+            GET("{base_url}/v1/models") $(resp) {
+                if (resp != null && resp.status_code == http_status.OK) {
+                    ready = true
+                }
+            }
+            if (ready) {
+                break
+            }
+            sleep(100u)
+        }
+        if (ready) {
+            invoke(blk, base_url)
+        }
+        POST("{base_url}/shutdown", "") $(_resp) {}
+        finished |> join
+        t |> success(ready, "dasllama server became ready")
+    }
+}
+
+// Every `data: <payload>` line of an SSE body, in order ("[DONE]" included).
+def private sse_datas(body : string) : array<string> {
+    var lines <- split(body, "\n")
+    var out <- [for (ln in lines); trim_prefix(ln, "data: "); where starts_with(ln, "data: ")]
+    delete lines
+    return <- out
+}
+
+// chat.completion.chunk mirror shapes (from_JV defaults the fields a chunk omits)
+struct private ChunkDelta {
+    @optional role : string
+    @optional content : string
+}
+struct private ChunkChoice {
+    delta : ChunkDelta
+    @optional finish_reason : string
+}
+struct private Chunk {
+    @rename = "object" _object : string
+    choices : array<ChunkChoice>
+}
+
+// non-streaming chat.completion mirror shapes
+struct private RespMsg {
+    content : string
+}
+struct private RespChoice {
+    message : RespMsg
+    finish_reason : string
+}
+struct private ChatResp {
+    @rename = "object" _object : string
+    choices : array<RespChoice>
+}
+
+// one concurrent client's verdict, shipped back over the channel (asserts live on the main thread)
+struct ClientResult {
+    status : int
+    ok : int   // 1 = valid chat.completion with non-empty content
+}
+
+[test]
+def test_openai_server_stream(t : T?) {
+    if (model_missing(t)) {
+        return
+    }
+    with_stream_server(t, MODEL_PATH, TEST_PORT) $(base_url) {
+        t |> run("streaming chat: SSE framing (role delta, content chunks, finish, [DONE])") @(t : T?) {
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":\"Say hi.\"}],\"max_tokens\":6,\"stream\":true}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var datas <- sse_datas(string(resp.body))
+                t |> success(length(datas) >= 3, "role + terminating chunk + [DONE] at minimum (got {length(datas)} events)")
+                if (length(datas) < 3) {
+                    return
+                }
+                t |> equal(datas[length(datas) - 1], "[DONE]")
+                var perr = ""
+                var js0 = read_json(datas[0], perr)
+                t |> success(js0 != null, "first chunk parses")
+                if (js0 != null) {
+                    let c = from_JV(js0, type<Chunk>)
+                    t |> equal(c._object, "chat.completion.chunk")
+                    t |> success(length(c.choices) == 1, "one choice per chunk")
+                    if (length(c.choices) == 1) {
+                        t |> equal(c.choices[0].delta.role, "assistant")
+                    }
+                    unsafe {
+                        delete js0
+                    }
+                }
+                var content_events = 0
+                var finish = ""
+                for (i in range(1, length(datas) - 1)) {
+                    var jsi = read_json(datas[i], perr)
+                    if (jsi != null) {
+                        let c = from_JV(jsi, type<Chunk>)
+                        if (length(c.choices) == 1) {
+                            if (!empty(c.choices[0].delta.content)) {
+                                content_events ++
+                            }
+                            if (!empty(c.choices[0].finish_reason)) {
+                                finish = c.choices[0].finish_reason
+                            }
+                        }
+                        unsafe {
+                            delete jsi
+                        }
+                    }
+                }
+                t |> success(content_events >= 1, "at least one content delta ({content_events})")
+                t |> success(finish == "stop" || finish == "length", "terminating chunk carries finish_reason (got '{finish}')")
+                delete datas
+            }
+        }
+        t |> run("over-long prompt answers 400 before the scheduler (mandatory pre-check)") @(t : T?) {
+            let big = build_string() $(w) {
+                for (_i in range(400)) {   // ~400 tokens — far beyond the TEST_CTX-token context
+                    w |> write("word ")
+                }
+            }
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":\"{big}\"}],\"max_tokens\":4}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+                var perr = ""
+                var js = read_json(string(resp.body), perr)
+                t |> success(js != null, "error body parses")
+                if (js != null) {
+                    t |> equal(string(js?["error"]?["type"] ?? ""), "invalid_request_error")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+        }
+        t |> run("two concurrent clients batch on one server (peak_active >= 2 via /v1/stats)") @(t : T?) {
+            with_channel(2) $(ch) {
+                for (ti in range(2)) {
+                    let prompt_txt = ti == 0 ? "Once upon a time" : "The little robot"
+                    new_thread() @() {
+                        var r = ClientResult()
+                        POST("{base_url}/v1/chat/completions",
+                             "\{\"messages\":[\{\"role\":\"user\",\"content\":\"{prompt_txt}\"}],\"max_tokens\":48}") $(resp) {
+                            if (resp != null) {
+                                r.status = int(resp.status_code)
+                                var perr = ""
+                                var js = read_json(string(resp.body), perr)
+                                if (js != null) {
+                                    let cr = from_JV(js, type<ChatResp>)
+                                    if (cr._object == "chat.completion" && length(cr.choices) == 1) {
+                                        r.ok = !empty(cr.choices[0].message.content) ? 1 : 0
+                                    }
+                                    unsafe {
+                                        delete js
+                                    }
+                                }
+                            }
+                        }
+                        ch |> push_clone(r)
+                        ch |> notify_and_release
+                    }
+                }
+                var got = 0
+                var all_ok = true
+                ch |> for_each_clone() $(r : ClientResult#) {
+                    got ++
+                    all_ok &&= r.status == 200 && r.ok == 1
+                }
+                t |> equal(got, 2)
+                t |> success(all_ok, "both concurrent chat requests returned a valid completion")
+            }
+            GET("{base_url}/v1/stats") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var perr = ""
+                var js = read_json(string(resp.body), perr)
+                t |> success(js != null, "stats parses")
+                if (js != null) {
+                    let peak = int64(js?["peak_active"] ?? 0l)
+                    let steps = int64(js?["decode_steps"] ?? 0l)
+                    let gen = int64(js?["gen_tokens"] ?? 0l)
+                    let fin = int64(js?["finished"] ?? 0l)
+                    t |> success(peak >= 2l, "peak_active >= 2 — the streams were concurrent (got {peak})")
+                    t |> success(steps > 0l, "decode steps counted ({steps})")
+                    t |> success(gen > 0l, "generated tokens counted ({gen})")
+                    t |> success(fin >= 3l, "finished streams counted across the run ({fin})")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+        }
+    }
+}

--- a/utils/dasllama-server/test_openai_server_stream.das
+++ b/utils/dasllama-server/test_openai_server_stream.das
@@ -284,5 +284,55 @@ def test_openai_server_stream(t : T?) {
                 t |> equal(int(resp.status_code), int(http_status.OK))
             }
         }
+        t |> run("prefix cache: the same request twice returns the identical completion, warm run cached") @(t : T?) {
+            // The rendered prompt must span at least one full page (server default P = 64 = the
+            // prefill chunk, so warm chunk boundaries align with cold's and flash prefill repeats
+            // the exact same evals — greedy output is bit-identical, not just similar).
+            let user = ("Tell me about a little robot who lives in a small village near the mountains" +
+                " and spends every evening counting the birds that cross the sky above the old bakery" +
+                " while dreaming about the day it will finally learn to fly like them." +
+                " The robot keeps a careful notebook of every sparrow, swallow and crow it has ever" +
+                " counted, and the baker sometimes leaves a warm roll on the windowsill for it." +
+                " In winter the birds are fewer, so the robot recounts the old pages and wonders" +
+                " whether the mountains are lonely too. Please tell the story slowly and gently.")
+            let body = "\{\"messages\":[\{\"role\":\"user\",\"content\":\"{user}\"}],\"max_tokens\":24}"
+            var replies : array<string>
+            for (_round in range(2)) {
+                POST("{base_url}/v1/chat/completions", body) $(resp) {
+                    t |> equal(int(resp.status_code), int(http_status.OK))
+                    var perr = ""
+                    var js = read_json(string(resp.body), perr)
+                    if (js != null) {
+                        let cr = from_JV(js, type<ChatResp>)
+                        if (length(cr.choices) == 1) {
+                            replies |> push("{cr.choices[0].message.content}\t{cr.choices[0].finish_reason}")
+                        }
+                        unsafe {
+                            delete js
+                        }
+                    }
+                }
+            }
+            t |> equal(2, length(replies))
+            if (length(replies) == 2) {
+                t |> success(!empty(replies[0]), "cold reply non-empty")
+                t |> equal(replies[0], replies[1])
+            }
+            GET("{base_url}/v1/stats") $(resp) {
+                var perr = ""
+                var js = read_json(string(resp.body), perr)
+                t |> success(js != null, "stats parses")
+                if (js != null) {
+                    let cached = int64(js?["cached_tokens"] ?? 0l)
+                    let pages = int64(js?["prefix_pages"] ?? 0l)
+                    t |> success(cached >= 64l, "the warm run attached at least one full page ({cached} tokens)")
+                    t |> success(pages > 0l, "the prefix cache retains pages ({pages})")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            delete replies
+        }
     }
 }

--- a/utils/mcp/setup.das
+++ b/utils/mcp/setup.das
@@ -271,8 +271,10 @@ def main() : int {
         return 1
     }
 
-    ensure_sgconfig(root)
+    // grammar first: its build target's POST_BUILD step stamps sgconfig.yml from the platform
+    // template, so ensure_sgconfig must report AFTER any such stamp to describe the final state
     ensure_grammar(root)
+    ensure_sgconfig(root)
     stage_jit_backend(root)
     if (!emit_mcp_config(root)) {
         return 1

--- a/utils/mcp/setup.das
+++ b/utils/mcp/setup.das
@@ -64,8 +64,9 @@ def shell_unsafe(s : string) : bool {
         find(s, "%") >= 0 || find(s, "\n") >= 0 || find(s, "\r") >= 0)
 }
 
-// Build the daslang target (required) plus tree_sitter_daslang (best-effort —
-// it powers the ast-grep tools). Configures build/ first if needed. A non-empty
+// Build the daslang target (required; the tree-sitter grammar is ensure_grammar's
+// job — it must happen even when this build is skipped). Configures build/ first if
+// needed. A non-empty
 // `openssl_dir` is passed as -DOPENSSL_ROOT_DIR so dasHV reuses one OpenSSL build
 // across worktrees instead of rebuilding it per build dir (~15 min each). The
 // flag only takes effect on the INITIAL configure — a build/ that already has a
@@ -91,14 +92,42 @@ def build_worktree(root, openssl_dir : string) : bool {
         print("ERROR: building daslang failed (exit {rc})\n")
         return false
     }
-    // Grammar shared lib for ast-grep (grep_usage/outline/cpp_*). Optional —
-    // the compiler-backed tools work without it.
-    print("Building tree-sitter grammar ...\n")
-    let grc = run_visible("cmake --build \"{build_dir}\" --target tree_sitter_daslang --config Release")
-    if (grc != 0) {
-        print("WARNING: tree_sitter_daslang build failed (exit {grc}); ast-grep tools may be unavailable\n")
-    }
     return true
+}
+
+// The tree-sitter grammar shared lib powers the ast-grep tools (grep_usage/outline);
+// without it they silently match NOTHING. Runs unconditionally — the build step above is
+// skipped whenever a daslang binary already exists (or --no-build), which used to leave
+// worktrees grammar-less. Build the target when a configured build dir is present (two C
+// files, seconds); else stage the lib from the tree running this setup, best-effort.
+def ensure_grammar(root : string) {
+    let plat = get_platform_name()
+    let lib_name = plat == "windows" ? "daslang.dll" : (plat == "darwin" ? "daslang.dylib" : "daslang.so")
+    let rel = path_join("tree-sitter-daslang", lib_name)
+    let dst = path_join(root, rel)
+    if (fexist(dst)) {
+        return
+    }
+    let build_dir = path_join(root, "build")
+    if (fexist(path_join(build_dir, "CMakeCache.txt"))) {
+        print("Building tree-sitter grammar ...\n")
+        let rc = run_visible("cmake --build \"{build_dir}\" --target tree_sitter_daslang --config Release")
+        if (rc == 0 && fexist(dst)) {
+            return
+        }
+        print("WARNING: grammar build did not produce {rel} (exit {rc}); staging from the source tree instead\n")
+    }
+    let src = path_join(get_das_root(), rel)
+    if (!fexist(src) || get_full_file_name(src) == get_full_file_name(dst)) {
+        print("WARNING: no grammar lib to stage ({rel}); ast-grep tools (grep_usage/outline) will return nothing\n")
+        return
+    }
+    let cr = copy_file_result(src, dst, false)
+    if (cr is error) {
+        print("WARNING: failed to stage grammar lib: {cr as error}\n")
+    } else {
+        print("Staged tree-sitter grammar from {get_das_root()} — a grammar-changing branch should rebuild its own (cmake --build build --target tree_sitter_daslang)\n")
+    }
 }
 
 // Copy the platform sgconfig.yml template if no sgconfig.yml exists yet.
@@ -243,6 +272,7 @@ def main() : int {
     }
 
     ensure_sgconfig(root)
+    ensure_grammar(root)
     stage_jit_backend(root)
     if (!emit_mcp_config(root)) {
         return 1


### PR DESCRIPTION
The vLLM-direction serving arc, on CPU. PR #3419 gave dasLLAMA a KV codec seam (f16 default) and synchronous batched decode; this PR is the structural continuation: **PagedAttention-style paged KV**, a **q8_0 KV codec**, **continuous batching in the real OpenAI server**, and a **page-granular prefix cache** — with a perf-transparency contract held at every rung: flat sessions stay bit-exact, and flat decode stays within measurement noise on both x64 and M1.

## Engine half

- **E1 — position-run restructure** (bit-exact, NFC for flat). All KV read loops go run-outer: `KVRun {j0, j1, row0}` + `kv_runs`/`kv_phys_row` — flat sessions degenerate to a single identity run whose inner body is instruction-identical to before. Per-side unit strides land here so the codec kernels only ever meet the final loop shape.
- **E2 — paged KV pool + block tables** (opt-in; flat stays the default). `KVPool`: one allocation unit is a page *group* — the {K,V} pages of every owning layer for the same `page_rows`-position span — so a session's block table is one int per span; shared-KV layers alias their source's blob. `kv_ensure` grows on demand (LIFO free list, geometric blob growth, refcounts). KV memory tracks the *actual* context instead of `seq_len × row_bytes` per session (~7 MB per 64-position group on Qwen3-0.6B f16 vs a multi-GB preallocated slab at full context).
- **E3 — q8_0 KV codec.** ggml `block_q8_0`-compatible interleaved rows ({f16 d; int8 qs[32]} = 34 B/32), K/V independent, flat + paged. Five new `[tuned]` System-A kernels; the decode hot path quantizes the *query* once per token (the ggml lesson) and every score dot routes through a `kv_score` overload set resolved on the K-pointer type — blocked/classic prefill also use the quantized query, which is what preserves the bit-exact prefill==decode contract under q8. KV read at deep context: **31.6 MB/tok vs f16's 59.5** (exact 34/64) on Qwen3-0.6B @544.

## Server half

- **S1 — chat render seam** (NFC): render a turn's tokens without evaluating them — queued requests hold no KV.
- **S2 — `llm_scheduler`** (engine-agnostic, zero HTTP): continuous batching on one thread — admit FIFO → ONE `eval_batch` decode step over every live stream (decode priority) → at most ONE `chunk_tokens` prefill chunk FCFS → reap. Results flow out as `SchedEvent`s, so the whole scheduler unit-tests without a socket. Interleave policy: a long prompt stalls decode by T_chunk, not T_prefill.
- **S3 — server wiring.** `openai_server` handlers parse + validate + render + register and return; the serve loop drives the scheduler and routes events back to each request's writer. Non-streaming requests JOIN the scheduler (deferred buffered respond). `/v1/stats` reports the batching counters. Also fixes a real dasHV wire bug found here: libhv's raw `SSEvent()` writes unframed bytes whose end-of-stream is invisible under keep-alive — `sse_event` now uses chunked framing so `close_writer`'s `End()` emits the terminating 0-chunk (the standard SSE-over-HTTP/1.1 shape).
- **S4 — disconnect eviction.** New dasHV `is_writer_connected(server, writer)` (the async writer ops never report a dead peer); the serve loop polls it and evicts abandoned streams through the scheduler — sessions reap, writers release with no bytes.
- **S5 — prefix cache** (page-granular, vLLM-style — not a radix trie). Finished streams donate their full KV pages keyed by a *chained* page hash of the token history; a later request attaches the longest cached run (refcounted, block-table share) and prefills only the tail. Hashes route, stored tokens verify. Whole-page matching keeps the write cursor in private pages — no copy-on-write anywhere. The scheduler evals a finished stream's pending token + close tokens before donating, so the *next turn of the same conversation* extends the cached prefix. LRU budget bounds retention. The server defaults to paged P=64 with an auto budget; `--page-rows` / `--prefix` / `--flat` knobs.
- **S6 — `server_bench`**: drives the scheduler through the event seam (server-side truth): tok/s + TTFT p50/p95 + inter-token p50/p95 vs B, chunk-interference per K, warm-vs-cold TTFT.

## Numbers (Qwen3-0.6B Q8, prompt 64 / gen 64)

| | x64 (3990X) | M1 Max |
|---|---|---|
| tok/s @ B=1/2/4/8 | 48.6 / 57.2 / 99.7 / 129.3 | 132 / 182 / 236 / 327 |
| interference p95 @ K=16/64/256 (512-tok prompt) | 154 / 178 / 341 ms | 52 / 68 / 187 ms |
| warm vs cold TTFT (512-tok prompt) | 810 → 175 ms (**4.6×**) | 426 → 56 ms (**7.6×**) |

K=64 default confirmed: near-K=16 latency at 4× fewer preemptions; K=256 doubles the stall. Flat decode A/B'd within noise at every rung (stash-swap method, both boxes); q8 deep-ctx KV bytes ≈ ½ f16 as designed.

## Gates

- Full `tests/dasLLAMA` sweep **363/363, JIT and interp, x64 and M1**, every rung.
- Paged ≡ flat bit-exact under forced fragmentation (decode / prefill / ragged `eval_batch` crossing page boundaries mid-run, f32 and q8), cache rows byte-equal.
- q8: round-trip + byte idempotence, fused==std bit-exact, prefill==decode byte-equal, teacher-forced logit gates vs f16, llama.cpp oracle parity with `-ctk/-ctv q8_0`.
- Prefix cache: warm ≡ cold **bit-exact** (classic prefill), divergent-suffix bit-exact, pool accounting returns to baseline, LRU budget respected, corrupted-entry verification refuses to attach; HTTP same-request-twice identical bodies under the default flash prefill.
- Scheduler ≡ `generate()` bit-exact (1 stream), chunk-size invariance {1,3,17,64}, staggered admit, queue overflow, stop/budget/context-length finishes, evict mid-run.
- dasHV suite 139/139 incl. the new writer-liveness test; server conformance incl. SSE framing, two concurrent client threads (peak_active ≥ 2), mid-generation disconnect eviction observed via stats.
- Post-rebase (onto master incl. #3420): preflight `--full` green, AOT sweep 10582/10588 (0 failed), full-tree JIT sweeps green on x64 (10093) and M1 (11241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)