### PR TITLE
fix dasHV tsan races: marshal writer ops via loop(0); tsan-instrument libhv

### DIFF
--- a/.github/tsan_suppressions.txt
+++ b/.github/tsan_suppressions.txt
@@ -1,0 +1,27 @@
+# ThreadSanitizer suppressions for the sanitizer CI lanes (DAS_USE_SANITIZER=tsan).
+# libhv is now tsan-instrumented (modules/dasHV/CMakeLists.txt forwards -fsanitize=thread,
+# same as the asan branch), which lets tsan see libhv's synchronization — the price is that
+# libhv's own plain-flag idioms and the known dasHV<->libhv cross-thread seams report.
+# Every entry below is a narrow access-site symbol, never a dispatcher frame like
+# hloop_process_events (tsan matches a suppression against EVERY frame of both stacks,
+# so naming a dispatcher would blanket-hide real races).
+
+# libhv cross-thread stop: hloop_stop writes plain status/wakeup flags that hloop_run /
+# hloop_process_events read — upstream idiom, worst case is one extra loop iteration.
+race:hloop_stop
+
+# Deliberate unsynchronized liveness peek: das_writer_is_connected polls hio_is_opened
+# from the tick thread; a momentarily stale answer is the API's documented contract.
+race:hio_is_opened
+
+# Cross-thread WebSocket send: das_wss_send / das_wsc_send call hio_write from das threads;
+# libhv mutex-guards the write queue but hio_write4 reads io state outside it (#3428).
+race:hio_write4
+
+# WebSocket client open/close callback bookkeeping inside hv::WebSocketClient (#3428).
+race:hv::WebSocketClient::close
+
+# Keep-alive handler reuse vs dasHV deferred (HTTP_STATUS_UNFINISHED) responses: the loop
+# thread may parse the next pipelined message while the tick thread still fills the
+# previous response object (#3428).
+race:HttpHandler::onMessageComplete

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -461,6 +461,7 @@ jobs:
             # tracked separately, real fix is in the binding).
             printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
+            export TSAN_OPTIONS="suppressions=$(pwd)/.github/tsan_suppressions.txt"
             # Sanitizer matrix: only run language tests under JIT (full test
             # suite under asan/tsan/ubsan adds ~10m wall-clock without proportionate
             # coverage value). Non-sanitizer keeps the full sweep.
@@ -533,6 +534,7 @@ jobs:
             # need them here too.
             printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
+            export TSAN_OPTIONS="suppressions=$(pwd)/.github/tsan_suppressions.txt"
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_aot
             ;;
         esac

--- a/modules/dasHV/CMakeLists.txt
+++ b/modules/dasHV/CMakeLists.txt
@@ -135,14 +135,21 @@ IF ((NOT DAS_HV_INCLUDED) AND ((NOT ${DAS_HV_DISABLED}) OR (NOT DEFINED DAS_HV_D
 	IF(MSVC)
 		SET(_HV_CXX_FLAGS "${_HV_CXX_FLAGS} /EHsc")
 	ENDIF()
+	SET(_HV_SAN_FLAG "")
 	IF(DAS_USE_SANITIZER STREQUAL "address" OR DAS_USE_SANITIZER STREQUAL "asan")
 		IF(MSVC)
-			SET(_HV_ASAN_FLAG "/fsanitize=address")
+			SET(_HV_SAN_FLAG "/fsanitize=address")
 		ELSE()
-			SET(_HV_ASAN_FLAG "-fsanitize=address")
+			SET(_HV_SAN_FLAG "-fsanitize=address")
 		ENDIF()
-		SET(_HV_C_FLAGS "${_HV_C_FLAGS} ${_HV_ASAN_FLAG}")
-		SET(_HV_CXX_FLAGS "${_HV_CXX_FLAGS} ${_HV_ASAN_FLAG}")
+	ELSEIF((DAS_USE_SANITIZER STREQUAL "thread" OR DAS_USE_SANITIZER STREQUAL "tsan") AND NOT MSVC)
+		# An uninstrumented libhv hides its atomics from tsan — proper shared_ptr teardown
+		# then reads as a false "data race in operator delete" (partially-instrumented code).
+		SET(_HV_SAN_FLAG "-fsanitize=thread")
+	ENDIF()
+	IF(_HV_SAN_FLAG)
+		SET(_HV_C_FLAGS "${_HV_C_FLAGS} ${_HV_SAN_FLAG}")
+		SET(_HV_CXX_FLAGS "${_HV_CXX_FLAGS} ${_HV_SAN_FLAG}")
 	ENDIF()
 	LIST(APPEND HV_CMAKE_FLAGS
 		"-DCMAKE_C_FLAGS:STRING=${_HV_C_FLAGS}"

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -667,7 +667,9 @@ static void post_writer_op ( Handle<hv::WebSocketServer> h, hv::HttpResponseWrit
     if ( !adapter || !w ) return;
     auto sp = adapter->find_writer(w);
     if ( !sp ) return;
-    auto loop = adapter->loop();
+    // loop(0), not loop(): the default idx=-1 resolves via currentThreadEventLoop — always null on
+    // the tick thread, so the fallback ran every write there, racing the loop thread (glibc gmtime).
+    auto loop = adapter->loop(0);
     if ( loop ) {
         loop->runInLoop([ssp,sp,fn](){ fn(sp.get()); });
     } else {


### PR DESCRIPTION
Fixes the linux_tsan lane flake first seen on [run 29091745893](https://github.com/GaijinEntertainment/daScript/actions/runs/29091745893) (PR #3425's `tests/dasHV/test_writer_connected`): a `gmtime` data race and an `HttpRequest` `operator delete` race, exit 66 with all tests passing.

## Fix (a): `loop(0)` in `post_writer_op` — the real bug

`hv::HttpServer::loop(idx = -1)` resolves the loop via `currentThreadEventLoop`, i.e. it returns non-null **only when called from a loop thread**. `post_writer_op`'s `adapter->loop()` was therefore always null on the das tick thread, and every SSE/stream write took the synchronous fallback — socket writes ran on the tick thread, contradicting the function's own comment. That put the tick thread inside glibc `gmtime` (static `struct tm`, via libhv's `gmtime_fmt` when dumping headers in the first second of a server's life, before the Date-refresh timer primes `s_date`) concurrently with the loop thread's 1s timer — the flake fired whenever a stream's first event beat the timer. `loop(0)` returns the single worker loop (libhv forces `worker_threads` to 1), restoring the intended marshaling.

## Fix (b): forward `-fsanitize=thread` to the libhv sub-build

The `operator delete` report was a TSAN artifact of partially-instrumented code: the libhv ExternalProject forwarded sanitizer flags **only for asan**, so `on_close`'s atomic refcount release was invisible to TSAN and the final delete looked unsynchronized. libhv now builds instrumented on the tsan lane, mirroring the asan branch.

Instrumenting libhv makes TSAN see its internals for the first time; the newly visible reports (libhv's plain-flag stop/wakeup idioms plus three pre-existing dasHV↔libhv cross-thread seams, tracked in #3428) are silenced by narrow access-site suppressions in `.github/tsan_suppressions.txt`, wired into the sanitizer lanes via `TSAN_OPTIONS`. No suppression names a dispatcher frame (TSAN matches every frame of both stacks, so naming e.g. `hloop_process_events` would blanket-hide real races).

## Validation (WSL CI-mirror rig, fresh clone @ 7fc814838, CI-verbatim tsan build)

| world | result |
|---|---|
| pre-fix | both CI races reproduce on run 1 of `tests/dasHV` |
| fix (a) only | `gmtime` gone; delete artifact still fires (run 1) |
| fix (a)+(b), no suppressions | original races gone; 59 libhv-internal/seam reports |
| **full package** | **5× targeted runs clean: 0 warnings, 139/139 pass** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)