### PR TITLE
fp16/lattice JIT-native lowering (type-lattice W7): marshal, intrinsics, promote-narrow ops, arm64 fullfp16

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -2013,6 +2013,11 @@ class public CppAot : AstVisitor {
         if (is_alpha(first_character(that.op))) return true;
         return that.subexpr._type.isPolicyType;
     }
+    // fp16 unary policies (Unp/Unm) are vec4f-ABI like the whole SimPolicy_HalfVec family —
+    // unlike the typed generic scalar policies (int64 ++ etc.), so only they get the casts
+    def isF16Op1(that : ExprOp1?) {
+        return that._type.baseType == Type.tFloat16 || (that._type.isVectorType && that._type.vectorBaseType == Type.tFloat16);
+    }
     def override preVisitExprOp1(var that : ExprOp1?) {
         if (!that.func.flags.builtIn || that.func.flags.callBased) {
             that.arguments |> clear();
@@ -2021,8 +2026,15 @@ class public CppAot : AstVisitor {
             CallFunc_preVisit(that);
             CallFunc_preVisitCallArg(that, that.subexpr, true);
         } elif (isOpPolicy1(that)) {
+            if (isF16Op1(that)) {
+                let cfg = DescribeConfig(skip_ref = true, skip_const = true, cross_platform = cross_platform)
+                write(*ss, "cast<{describeCppType(that._type, cfg)}>::to(");
+            }
             outPolicy(that.subexpr._type);
             write(*ss, "::{opPolicyName(that)}(");
+            if (that.subexpr._type.baseType == Type.tFloat16) {
+                write(*ss, "cast<float16_t>::from(");
+            }
         } else {
             if (that.op != "+++" && that.op != "---") {
                 write(*ss, that.op);
@@ -2037,8 +2049,14 @@ class public CppAot : AstVisitor {
             CallFunc_visitCallArg(that, that.subexpr, true);
             CallFunc_visit(that);
             that.arguments.clear();
-        } elif (isOpPolicy1(that)){
+        } elif (isOpPolicy1(that)) {
+            if (that.subexpr._type.baseType == Type.tFloat16) {
+                write(*ss, ")");
+            }
             write(*ss, ",*__context__,nullptr)");
+            if (isF16Op1(that)) {
+                write(*ss, ")");
+            }
         } else {
             if (that.op == "+++" || that.op == "---") {
                 peek(that.op) $(op) {
@@ -2109,7 +2127,8 @@ class public CppAot : AstVisitor {
             }
             outPolicy(pt);
             write(*ss, "::{opPolicyName(that)}(");
-            if (isRefPolicyOp(that) && (pt.isVectorType || pt.isString)) {
+            // scalar float16 set-ops share the vector policies' (char *, vec4f) signature
+            if (isRefPolicyOp(that) && (pt.isVectorType || pt.isString || pt.baseType == Type.tFloat16)) {
                 write(*ss, "(char *)&(");
             } elif (policyArgNeedCast(pt, that.left._type)) {
                 let cfg = DescribeConfig(skip_ref = true, skip_const = true, cross_platform = cross_platform)
@@ -2136,7 +2155,7 @@ class public CppAot : AstVisitor {
             CallFunc_preVisitCallArg(that, that.right, true);
         } elif (isOpPolicy2(that)) {
             assume pt = opPolicyBase(that);
-            if (isRefPolicyOp(that) && (pt.isVectorType || pt.isString)) {
+            if (isRefPolicyOp(that) && (pt.isVectorType || pt.isString || pt.baseType == Type.tFloat16)) {
                 write(*ss, ")");
             } elif (policyArgNeedCast(pt, that.left._type)) {
                 if (that.left._type.isRefType) {
@@ -3740,7 +3759,9 @@ class public CppAot : AstVisitor {
     def policyArgNeedCast(polType : TypeDeclPtr; argType : TypeDeclPtr) {
         if (argType.isVectorType) return false;
         if (!polType.isHandle) {
-            if (polType.isVecPolicyType && argType.isVecPolicyType) return false;
+            // scalar float16 rides the vec4f policy ABI (SimPolicy_HalfVec<1>) but the C++
+            // float16_t has no implicit vec4f conversion — it always casts across
+            if (polType.isVecPolicyType && argType.isVecPolicyType && argType.baseType != Type.tFloat16) return false;
         }
         return polType.isPolicyType;
     }

--- a/modules/dasLLVM/daslib/llvm_boost.das
+++ b/modules/dasLLVM/daslib/llvm_boost.das
@@ -481,6 +481,12 @@ def public is_lattice_small_type(t : Type) {
     return int(t) >= int(Type.tFloat16) && int(t) <= int(Type.tUByte16)
 }
 
+// the fp16 sub-family (scalar float16 + half2/3/4/8) — fpext/fptrunc through half needs
+// hardware convert support (any aarch64, or x86-64 with F16C); the int lattice does not
+def public is_f16_small_type(t : Type) {
+    return int(t) >= int(Type.tFloat16) && int(t) <= int(Type.tHalf8)
+}
+
 def isExprOp2_Func(expr : ExprOp2?) {
     if (is_lattice_small_type(expr.left._type.baseType)
             || is_lattice_small_type(expr.right._type.baseType)

--- a/modules/dasLLVM/daslib/llvm_boost.das
+++ b/modules/dasLLVM/daslib/llvm_boost.das
@@ -510,25 +510,25 @@ def is_lattice_op2_native(expr : ExprOp2?) {
 }
 
 def isExprOp2_Func(expr : ExprOp2?) {
+    if (!expr.func.flags.builtIn) {
+        return true     // user-defined operator (incl. on lattice types) — always the function path
+    }
     if (is_lattice_small_type(expr.left._type.baseType)
             || is_lattice_small_type(expr.right._type.baseType)) {
         return !is_lattice_op2_native(expr)
-    }
-    if (!expr.func.flags.builtIn) {
-        return true
     }
     return expr.left._type.isHandle || expr.right._type.isHandle
 }
 
 def isExprOp1_Func(expr : ExprOp1?) {
+    if (!expr.func.flags.builtIn) {
+        return true     // user-defined operator (incl. on lattice types) — always the function path
+    }
     assume sbt = expr.subexpr._type.baseType
     if (is_lattice_small_type(sbt)) {
         if (is_f16_small_type(sbt) && (expr.op == "+" || expr.op == "-")) {
             return !g_lattice_fp16_ops_native
         }
-        return true
-    }
-    if (!expr.func.flags.builtIn) {
         return true
     }
     return expr.subexpr._type.isHandle

--- a/modules/dasLLVM/daslib/llvm_boost.das
+++ b/modules/dasLLVM/daslib/llvm_boost.das
@@ -472,11 +472,7 @@ def describe(blk : LLVMOpaqueBasicBlock?) {
     return st
 }
 
-// 16/8-bit lattice types (contiguous appended block in the Type enum). Ops on these route
-// through the function path — visitExprOp2_NonMonade only lowers float/int/uint vector
-// bases natively, and an unrouted lattice op would hard-fail JIT emission via g_errors.
-// Until the fp16 operators carry builtin addresses, the function path cleanly drops the
-// enclosing function to the interpreter (DisableJitVisitor).
+// 16/8-bit lattice types (contiguous appended block in the Type enum)
 def public is_lattice_small_type(t : Type) {
     return int(t) >= int(Type.tFloat16) && int(t) <= int(Type.tUByte16)
 }
@@ -487,17 +483,52 @@ def public is_f16_small_type(t : Type) {
     return int(t) >= int(Type.tFloat16) && int(t) <= int(Type.tHalf8)
 }
 
+// set by init_jit_target_flags (llvm_jit_common): true when the target lowers half
+// converts in hardware (aarch64 || x64-F16C), so fp16 operators may emit
+// promote-compute-narrow IR in visitExprOp2/Op1_NonMonade instead of falling back
+var public g_lattice_fp16_ops_native = false
+
+// Lattice op routing: ops NonMonade lowers natively return true here; everything else
+// lattice-typed routes to the function path, where the DisableJitVisitor builtin-address
+// gates cleanly drop the enclosing function to the interpreter.
+def is_lattice_op2_native(expr : ExprOp2?) {
+    assume lbt = expr.left._type.baseType
+    if (expr.op == "==" || expr.op == "!=") {
+        // int-lattice equality is icmp+reduce (unconditional); fp16 compares promote
+        // through float, so they ride the hardware-convert gate
+        return is_f16_small_type(lbt) ? g_lattice_fp16_ops_native : true
+    }
+    if (is_f16_small_type(lbt) || is_f16_small_type(expr.right._type.baseType)) {
+        // the closed fp16 arithmetic + scalar ordered compares
+        if (expr.op == "+" || expr.op == "-" || expr.op == "*" || expr.op == "/" ||
+                expr.op == "+=" || expr.op == "-=" || expr.op == "*=" || expr.op == "/=" ||
+                expr.op == "<" || expr.op == "<=" || expr.op == ">" || expr.op == ">=") {
+            return g_lattice_fp16_ops_native
+        }
+    }
+    return false
+}
+
 def isExprOp2_Func(expr : ExprOp2?) {
     if (is_lattice_small_type(expr.left._type.baseType)
-            || is_lattice_small_type(expr.right._type.baseType)
-            || !expr.func.flags.builtIn) {
+            || is_lattice_small_type(expr.right._type.baseType)) {
+        return !is_lattice_op2_native(expr)
+    }
+    if (!expr.func.flags.builtIn) {
         return true
     }
     return expr.left._type.isHandle || expr.right._type.isHandle
 }
 
 def isExprOp1_Func(expr : ExprOp1?) {
-    if (is_lattice_small_type(expr.subexpr._type.baseType) || !expr.func.flags.builtIn) {
+    assume sbt = expr.subexpr._type.baseType
+    if (is_lattice_small_type(sbt)) {
+        if (is_f16_small_type(sbt) && (expr.op == "+" || expr.op == "-")) {
+            return !g_lattice_fp16_ops_native
+        }
+        return true
+    }
+    if (!expr.func.flags.builtIn) {
         return true
     }
     return expr.subexpr._type.isHandle

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -7951,9 +7951,11 @@ class public DisableJitVisitor : AstVisitor {
                 disable = true
             }
         }
-        if (!disable && expr.func.flags.builtIn) {
-            // lattice values cross the extern ABI as LLVM half / packed vectors, but the
-            // C++ side expects the das slot conventions — fall back until the marshal wave
+        if (!disable && expr.func.flags.builtIn && !has_intrinsic(expr)) {
+            // lattice values crossing a builtin call lower as intrinsics (ctors/converts/
+            // sat-narrows emit IR directly); anything NOT in the intrinsic tables would hit
+            // the direct-extern ABI, where LLVM half / packed vectors mismatch the C++ das
+            // slot conventions — those still fall back
             var lattice = is_lattice_small_type(expr._type.baseType)
             if (!lattice) {
                 for (arg in expr.arguments) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -7870,22 +7870,15 @@ class public DisableJitVisitor : AstVisitor {
     def TypeInfoVisitor {
         disable = false
     }
-    // 16/8-bit lattice floor: plain loads/stores/moves of lattice values lower natively
-    // (the types are mapped), and lattice calls/ops fall back via the builtin-address gates
-    // below. What has no lowering yet is indexing and locals-with-init — gate those two
-    // RARE node kinds only (a generic preVisitExpression gate costs an adapter call per
-    // expression and blows the per-file JIT budget on daslib-sized programs).
+    // 16/8-bit lattice floor: data movement (loads/stores/moves/locals/indexing/swizzles)
+    // and the vec4f wrapper ABI lower natively; what still falls back is lattice values
+    // crossing a BUILTIN CALL boundary (ctors/converts/operators) — the builtin-address
+    // gates below catch those until the per-op emission wave completes.
     def lattice_fallback(t : TypeDeclPtr; at : LineInfo) {
         if (!disable && t != null && is_lattice_small_type(t.baseType)) {
             to_log(LOG_WARNING, "LLVM JIT: 16/8-bit lattice type `{describe(t)}` at {at}, falling back to interpreter.\n")
             disable = true
         }
-    }
-    def override preVisitExprLetVariable(expr : ExprLet?; arg : VariablePtr; lastArg : bool) : void {
-        lattice_fallback(arg._type, arg.at)
-    }
-    def override preVisitExprSwizzle(expr : ExprSwizzle?) : void {
-        lattice_fallback(expr.value._type, expr.at)
     }
     def override preVisitExprTypeInfo(expr : ExprTypeInfo?) : void {
         if (expr.trait == "ast_typedecl" || expr.trait == "rtti_classinfo" || expr.trait == "rtti_typeinfo") {
@@ -7939,7 +7932,6 @@ class public DisableJitVisitor : AstVisitor {
                 "type {type_str} to be used in JIT, keeping interpreter mode.\n")
             disable = true
         }
-        lattice_fallback(expr.subexpr._type, expr.at)
     }
 
     def override preVisitExprForSource(var expr : ExprFor?, var source : ExpressionPtr, last : bool) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -2511,7 +2511,9 @@ class public LlvmJitVisitor : AstVisitor {
             var data_bytes = LLVMBuildPointerCast(g_builder, data, LLVMPointerType(types.t_int8, 0u), "")
             // Stride const must match tidx width — Array.size-derived `tail` is i64,
             // dim-derived tail is i32; an i32 ConstI32 against i64 tidx is a verifier error.
-            var stride = LLVMConstInt(LLVMTypeOf(tidx), 12ul, 0)
+            // das packs 3-lane elements (12B float3/int3, 6B half3/short3, 3B byte3) while
+            // LLVM GEP on <3 x T> would advance by the padded alloc size — use the das stride.
+            var stride = LLVMConstInt(LLVMTypeOf(tidx), uint64(elemType.sizeOf), 0)
             var data_idx = LLVMBuildMul(g_builder, tidx, stride, "")
             ptr_idx = LLVMBuildGEP2(g_builder, types.t_int8, data_bytes, data_idx, "")
             ptr_idx = LLVMBuildPointerCast(g_builder, ptr_idx, LLVMPointerType(type_to_llvm_type(elemType), 0u), name)
@@ -6723,6 +6725,41 @@ class public LlvmJitVisitor : AstVisitor {
         return tres
     }
 
+    // 16/8-bit lattice vectors <-> the das vec4f slot. One shuffle widens/narrows between
+    // the value's lane count and its full-128-bit form; one bitcast crosses to <4 x float>.
+    // Little-endian lane order makes this byte-identical to cast<T>::from/to (memcpy of the
+    // packed value into the slot's low bytes). Tail lanes are zero-filled, not undef — see
+    // the poison note at cast_to_vec4f.
+    def lattice_full_lane_count(etype : TypeDeclPtr) : int {
+        assume vbt = etype.vectorBaseType
+        return (vbt == Type.tInt8 || vbt == Type.tUInt8) ? 16 : 8
+    }
+
+    def lattice_vec_to_vec4f(etype : TypeDeclPtr; tsrc : LLVMOpaqueValue?) {
+        let lanes = etype.vectorDim
+        let fullLanes = lattice_full_lane_count(etype)
+        var wide = tsrc
+        if (lanes != fullLanes) {
+            // tail indices land on lane 0 of the zero operand (source lanes are 0..lanes-1)
+            let mask <- [for (i in range(fullLanes)); min(i, lanes)]
+            let zero = LLVMConstNull(LLVMTypeOf(tsrc))
+            wide = LLVMBuildShuffleVector(g_builder, types, tsrc, zero, mask, "lattice_widen")
+        }
+        return LLVMBuildBitCast(g_builder, wide, types.LLVMFloat4Type(), "return_result")
+    }
+
+    def vec4f_to_lattice_vec(etype : TypeDeclPtr; v4f : LLVMOpaqueValue?) {
+        let lanes = etype.vectorDim
+        let fullLanes = lattice_full_lane_count(etype)
+        let elemT = base_type_to_llvm_type(etype.vectorBaseType)
+        var wide = LLVMBuildBitCast(g_builder, v4f, LLVMVectorType(elemT, uint(fullLanes)), "vec4f_to_lattice")
+        if (lanes == fullLanes) {
+            return wide
+        }
+        let mask <- [for (i in range(lanes)); i]
+        return LLVMBuildShuffleVector(g_builder, types, wide, wide, mask, "lattice_narrow")
+    }
+
     def cast_from_vec4f_workhorse(etype : TypeDeclPtr; expr : ExpressionPtr; v4f : LLVMOpaqueValue?) {
         let bt = etype.baseType
         if (bt == Type.tInt || bt == Type.tUInt || bt == Type.tBitfield || bt == Type.tEnumeration) {
@@ -6790,6 +6827,14 @@ class public LlvmJitVisitor : AstVisitor {
             return cast_from_vec4f_ptr(v4f, ptr_type)
         } elif (bt == Type.tRange64 || bt == Type.tURange64) {
             return LLVMBuildBitCast(g_builder, v4f, types.LLVMRange64Type(), "vec4f_to_range64")
+        } elif (bt == Type.tFloat16) {
+            // scalar convention: bits ride widened in lane 0, like int16 (cast<float16_t>)
+            var tbit = LLVMBuildExtractElement(g_builder, v4f, types.ConstI32(0ul), "")
+            var tres = LLVMBuildBitCast(g_builder, tbit, types.t_int32, "vec4f_to_int")
+            var hbits = LLVMBuildTruncOrBitCast(g_builder, tres, types.t_int16, "int_to_half_bits")
+            return LLVMBuildBitCast(g_builder, hbits, types.t_half, "vec4f_to_half")
+        } elif (is_lattice_small_type(bt)) {
+            return vec4f_to_lattice_vec(etype, v4f)
         } else {
             failed_E(expr, "unsupported cast_from_vec4f cast {describe(etype)} workhorse")
         }
@@ -6898,6 +6943,14 @@ class public LlvmJitVisitor : AstVisitor {
                 tres = LLVMBuildShuffleVector(g_builder, types, tsrc, tsrc, [ 0, 1, 2, -1], "return_result")
             } elif (bt == Type.tFloat4) {
                 tres = tsrc
+            } elif (bt == Type.tFloat16) {
+                // scalar convention: bits ride widened in lane 0, like int16 (cast<float16_t>)
+                var hbits = LLVMBuildBitCast(g_builder, tsrc, types.t_int16, "half_bits")
+                var tibit = LLVMBuildZExt(g_builder, hbits, types.t_int32, "int_bit")
+                var tbit = LLVMBuildBitCast(g_builder, tibit, types.t_float, "tbit")
+                tres = LLVMBuildInsertElement(g_builder, vres, tbit, types.ConstI32(0ul), "return_result")
+            } elif (is_lattice_small_type(bt)) {
+                tres = lattice_vec_to_vec4f(etype, tsrc)
             } elif (bt == Type.tString || bt == Type.tPointer) {
                 tres = cast_ptr_to_vec4f(tsrc)
             } else {
@@ -7833,15 +7886,6 @@ class public DisableJitVisitor : AstVisitor {
     }
     def override preVisitExprSwizzle(expr : ExprSwizzle?) : void {
         lattice_fallback(expr.value._type, expr.at)
-    }
-    def override preVisitFunction(fun : FunctionPtr) : void {
-        // signature-level gate: the interp<->jit wrappers marshal args/results through
-        // vec4f slots, and that marshaling is not lattice-aware yet (a vec4f <-> <4 x half>
-        // bitcast is invalid IR — one bad function fails the whole module)
-        lattice_fallback(fun.result, fun.at)
-        for (arg in fun.arguments) {
-            lattice_fallback(arg._type, arg.at)
-        }
     }
     def override preVisitExprTypeInfo(expr : ExprTypeInfo?) : void {
         if (expr.trait == "ast_typedecl" || expr.trait == "rtti_classinfo" || expr.trait == "rtti_typeinfo") {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -2892,8 +2892,11 @@ class public LlvmJitVisitor : AstVisitor {
         if (is_f16_small_type(opType.baseType)) {
             // fp16 family (float16 scalar + halfN): the reference semantics ARE promote-to-
             // f32 -> compute -> round-back (RNE), which is exactly fpext -> fop -> fptrunc.
-            // Compares run on the promoted floats (conversion is exact, so predicates agree).
-            // Only routed here when g_lattice_fp16_ops_native (aarch64 || x64-F16C).
+            // With native fullfp16 (arm64) the ops run directly on half — bit-identical for
+            // single ops, since f32 carries 2p+2 precision bits of f16 (the double-rounding
+            // safety bound for + - * /). Compares are exact either way. Only routed here
+            // when g_lattice_fp16_ops_native (aarch64 || x64-F16C).
+            let native = g_target_arm64_fullfp16
             let halfT = (opType.isVectorType
                 ? LLVMVectorType(types.t_half, uint(opType.vectorDim))
                 : types.t_half)
@@ -2901,8 +2904,12 @@ class public LlvmJitVisitor : AstVisitor {
                 ? LLVMVectorType(types.t_float, uint(opType.vectorDim))
                 : types.t_float)
             let rmw = isReadModifyWriteOp2(expr.op)
-            var lf = LLVMBuildFPExt(g_builder, rmw ? r2v_left : left, promoteT, "")
-            var rf = LLVMBuildFPExt(g_builder, right, promoteT, "")
+            var lf = rmw ? r2v_left : left
+            var rf = right
+            if (!native) {
+                lf = LLVMBuildFPExt(g_builder, lf, promoteT, "")
+                rf = LLVMBuildFPExt(g_builder, rf, promoteT, "")
+            }
             if (expr.op == "==" || expr.op == "!=" || expr.op == "<" || expr.op == "<=" || expr.op == ">" || expr.op == ">=") {
                 var opR = LLVMBuildFCmp(g_builder, get_float_compare_op(expr, string(expr.op)), lf, rf, "")
                 if (opType.isVectorType) {
@@ -2924,7 +2931,9 @@ class public LlvmJitVisitor : AstVisitor {
                 failed_E(expr, "unsupported fp16 operator {expr.op}")
                 return
             }
-            res = LLVMBuildFPTrunc(g_builder, res, halfT, "")
+            if (!native) {
+                res = LLVMBuildFPTrunc(g_builder, res, halfT, "")
+            }
             if (rmw) {
                 setE(expr, LLVMBuildStoreAligned(g_builder, res, left, uint(expr.left._type.alignOf)))
             } else {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -2889,6 +2889,49 @@ class public LlvmJitVisitor : AstVisitor {
             right = LLVMBuildAnd(g_builder, right, LLVMConstInt(type_to_llvm_type(opType), uint64((opType.sizeOf * 8) - 1), 0), "")
             right = build_broadcast_vector(g_builder, shiftType, right)
         }
+        if (is_f16_small_type(opType.baseType)) {
+            // fp16 family (float16 scalar + halfN): the reference semantics ARE promote-to-
+            // f32 -> compute -> round-back (RNE), which is exactly fpext -> fop -> fptrunc.
+            // Compares run on the promoted floats (conversion is exact, so predicates agree).
+            // Only routed here when g_lattice_fp16_ops_native (aarch64 || x64-F16C).
+            let halfT = (opType.isVectorType
+                ? LLVMVectorType(types.t_half, uint(opType.vectorDim))
+                : types.t_half)
+            let promoteT = (opType.isVectorType
+                ? LLVMVectorType(types.t_float, uint(opType.vectorDim))
+                : types.t_float)
+            let rmw = isReadModifyWriteOp2(expr.op)
+            var lf = LLVMBuildFPExt(g_builder, rmw ? r2v_left : left, promoteT, "")
+            var rf = LLVMBuildFPExt(g_builder, right, promoteT, "")
+            if (expr.op == "==" || expr.op == "!=" || expr.op == "<" || expr.op == "<=" || expr.op == ">" || expr.op == ">=") {
+                var opR = LLVMBuildFCmp(g_builder, get_float_compare_op(expr, string(expr.op)), lf, rf, "")
+                if (opType.isVectorType) {
+                    opR = reduce_bit_vector(opR, opType.vectorDim, string(expr.op))
+                }
+                setE(expr, opR)
+                return
+            }
+            var res : LLVMOpaqueValue?
+            if (expr.op == "+" || expr.op == "+=") {
+                res = LLVMBuildFAdd(g_builder, lf, rf, "")
+            } elif (expr.op == "-" || expr.op == "-=") {
+                res = LLVMBuildFSub(g_builder, lf, rf, "")
+            } elif (expr.op == "*" || expr.op == "*=") {
+                res = LLVMBuildFMul(g_builder, lf, rf, "")
+            } elif (expr.op == "/" || expr.op == "/=") {
+                res = LLVMBuildFDiv(g_builder, lf, rf, "")
+            } else {
+                failed_E(expr, "unsupported fp16 operator {expr.op}")
+                return
+            }
+            res = LLVMBuildFPTrunc(g_builder, res, halfT, "")
+            if (rmw) {
+                setE(expr, LLVMBuildStoreAligned(g_builder, res, left, uint(expr.left._type.alignOf)))
+            } else {
+                setE(expr, res)
+            }
+            return
+        }
         if (expr.op == "+") {
             if (isNumeric(opType)) {
                 setE(expr, LLVMBuildAdd(g_builder, left, right, ""))
@@ -3009,12 +3052,12 @@ class public LlvmJitVisitor : AstVisitor {
             }
         } elif (expr.op == "<" || expr.op == ">" || expr.op == "<=" || expr.op == ">=" || expr.op == "==" || expr.op == "!=") {
             var opR : LLVMOpaqueValue?
-            if (expr.left._type.isSignedInteger || (expr.left._type.isVectorType && (expr.left._type.vectorBaseType == Type.tInt || expr.left._type.vectorBaseType == Type.tInt64)) || expr.left._type.isEnum) {
+            if (expr.left._type.isSignedInteger || (expr.left._type.isVectorType && (expr.left._type.vectorBaseType == Type.tInt || expr.left._type.vectorBaseType == Type.tInt64 || expr.left._type.vectorBaseType == Type.tInt16 || expr.left._type.vectorBaseType == Type.tInt8)) || expr.left._type.isEnum) {
                 opR = LLVMBuildICmp(g_builder, get_int_compare_op(expr, string(expr.op)), left, right, "")
                 if (expr.left._type.isVectorType) {
                     opR = reduce_bit_vector(opR, expr.left._type.vectorDim, string(expr.op))
                 }
-            } elif (expr.left._type.isUnsignedInteger || (expr.left._type.isVectorType && (expr.left._type.vectorBaseType == Type.tUInt || expr.left._type.vectorBaseType == Type.tUInt64))) {
+            } elif (expr.left._type.isUnsignedInteger || (expr.left._type.isVectorType && (expr.left._type.vectorBaseType == Type.tUInt || expr.left._type.vectorBaseType == Type.tUInt64 || expr.left._type.vectorBaseType == Type.tUInt16 || expr.left._type.vectorBaseType == Type.tUInt8))) {
                 opR = LLVMBuildICmp(g_builder, get_uint_compare_op(expr, string(expr.op)), left, right, "")
                 if (expr.left._type.isVectorType) {
                     opR = reduce_bit_vector(opR, expr.left._type.vectorDim, string(expr.op))
@@ -6082,7 +6125,10 @@ class public LlvmJitVisitor : AstVisitor {
         } elif (expr.op == "-") {
             if (isNumeric(opType)) {
                 setE(expr, LLVMBuildNeg(g_builder, sexpr, ""))
-            } elif (opType.isFloatOrDouble || (opType.isVectorType && opType.vectorBaseType == Type.tFloat)) {
+            } elif (opType.isFloatOrDouble || (opType.isVectorType && opType.vectorBaseType == Type.tFloat)
+                    || is_f16_small_type(opType.baseType)) {
+                // fp16 negate = IEEE sign flip; identical to the reference promote-negate-
+                // narrow (both preserve payload bits), no rounding involved
                 setE(expr, LLVMBuildFNeg(g_builder, sexpr, ""))
             } else {
                 failed_E(expr, "unsupported - type {opType}")
@@ -6090,7 +6136,8 @@ class public LlvmJitVisitor : AstVisitor {
         } elif (expr.op == "+") {
             if (isNumeric(opType)) {
                 setE(expr, sexpr)
-            } elif (opType.isFloatOrDouble || (opType.isVectorType && opType.vectorBaseType == Type.tFloat)) {
+            } elif (opType.isFloatOrDouble || (opType.isVectorType && opType.vectorBaseType == Type.tFloat)
+                    || is_f16_small_type(opType.baseType)) {
                 setE(expr, sexpr)
             } else {
                 failed_E(expr, "unsupported + type {opType}")

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -571,29 +571,10 @@ def public init_jit_clopts() {
     }
 }
 
-[macro_function]
-def public init_jit(cg_opt_level : uint; target_triple : string = "") {
-    // also prevent double init (g_mod != null)
-    return if (is_in_completion() || is_compiling_macros() || g_mod != null)
-    LLVMLinkInMCJIT()
-    LLVMInitializeAllTargetInfos()
-    LLVMInitializeAllTargets()
-    LLVMInitializeAllTargetMCs()
-    LLVMInitializeAllAsmPrinters()
-    init_jit_clopts()
-    g_ctx = LLVMContextCreate()
-    g_prim_t = new PrimitiveTypes(g_ctx)
-    g_failed = false
-    g_fn_types |> clear()
-    g_handled_field_offset_globals |> clear()
-    g_mod = LLVMModuleCreateWithNameInContext("llvm_jit_module", g_ctx)
-    LLVMCreateJITCompilerForModule(g_engine, g_mod, cg_opt_level)
-    // For cross-compile targets (wasm32, etc.) pin the module's data layout
-    // to the TARGET's, not the host's, BEFORE any IR is built. LLVM constant-
-    // folds GEPs eagerly using the module's current layout — if the host has
-    // 8-byte pointers and the target has 4-byte, every for-loop end-pointer
-    // GEP bakes in the wrong stride and the loop never terminates. The native
-    // path (empty triple) keeps the host default.
+// Pure target-truth computation — no LLVM state touched, so it is safe (and required) to
+// call BEFORE init_jit: the DisableJitVisitor pass consults the g_target_* gates through
+// has_intrinsic, and it runs before the LLVM module exists. init_jit re-runs it (idempotent).
+def public init_jit_target_flags(target_triple : string = "") {
     g_target_is_wasm = target_triple |> starts_with("wasm")
     // Host path (empty triple): the module targets the host, so the daslang binary's own arch is the
     // JIT target arch. Explicit cross-compile triple: read the arch off the triple prefix.
@@ -626,6 +607,32 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
     // LLVM's host-features string OR the arm force env; cross aarch64 triples the env only.
     g_target_arm64_i8mm = g_target_is_aarch64 && (arm64_forced_feature("i8mm")
         || (empty(target_triple) && host_llvm_feature("i8mm")))
+}
+
+[macro_function]
+def public init_jit(cg_opt_level : uint; target_triple : string = "") {
+    // also prevent double init (g_mod != null)
+    return if (is_in_completion() || is_compiling_macros() || g_mod != null)
+    LLVMLinkInMCJIT()
+    LLVMInitializeAllTargetInfos()
+    LLVMInitializeAllTargets()
+    LLVMInitializeAllTargetMCs()
+    LLVMInitializeAllAsmPrinters()
+    init_jit_clopts()
+    g_ctx = LLVMContextCreate()
+    g_prim_t = new PrimitiveTypes(g_ctx)
+    g_failed = false
+    g_fn_types |> clear()
+    g_handled_field_offset_globals |> clear()
+    g_mod = LLVMModuleCreateWithNameInContext("llvm_jit_module", g_ctx)
+    LLVMCreateJITCompilerForModule(g_engine, g_mod, cg_opt_level)
+    // For cross-compile targets (wasm32, etc.) pin the module's data layout
+    // to the TARGET's, not the host's, BEFORE any IR is built. LLVM constant-
+    // folds GEPs eagerly using the module's current layout — if the host has
+    // 8-byte pointers and the target has 4-byte, every for-loop end-pointer
+    // GEP bakes in the wrong stride and the loop never terminates. The native
+    // path (empty triple) keeps the host default.
+    init_jit_target_flags(target_triple)
     if (!(target_triple |> empty())) {
         // wasm32 target isn't always part of LLVMInitializeAllTargets in
         // prebuilt LLVM.dll — call the explicit wasm initializer when needed.
@@ -641,7 +648,7 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
         // is the tier truth (see the g_target_x64_* gates above) and must
         // reach any codegen off this machine too.
         let features = (g_target_is_wasm ? wasm_target_features()
-            : (x64_cross ? x64_forced_plus_features() : ""))
+            : (g_target_is_x64 ? x64_forced_plus_features() : ""))   // inside the non-empty-triple branch, is_x64 == x64-cross
         with_target_machine(target_triple, "", features, cg_opt_level) $(targetMachine : LLVMTargetMachineRef) {
             let dl = LLVMCreateTargetDataLayout(targetMachine)
             LLVMSetModuleDataLayout(g_mod, dl)

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -580,8 +580,15 @@ def public init_jit_clopts() {
 
 // Pure target-truth computation — no LLVM state touched, so it is safe (and required) to
 // call BEFORE init_jit: the DisableJitVisitor pass consults the g_target_* gates through
-// has_intrinsic, and it runs before the LLVM module exists. init_jit re-runs it (idempotent).
-def public init_jit_target_flags(target_triple : string = "") {
+// has_intrinsic, and it runs before the LLVM module exists. init_jit re-runs it (idempotent —
+// callers must pass the SAME host_features both times or the pass and emission diverge).
+//
+// host_features=false (standalone-exe builds): the artifact targets a GENERIC CPU of the host
+// arch (write_exe use_host_cpu=false is the redistributable default), so every cpuid/host-
+// feature-derived gate must be conservative — host-F16C leaking into a generic x64 exe emits
+// fpext-through-half that lowers to compiler-rt libcalls (__extendhfsf2) msvcrt never links.
+// Env-FORCED features stay honored (explicit emission-only rail, same contract as cross triples).
+def public init_jit_target_flags(target_triple : string = ""; host_features : bool = true) {
     g_target_is_wasm = target_triple |> starts_with("wasm")
     // Host path (empty triple): the module targets the host, so the daslang binary's own arch is the
     // JIT target arch. Explicit cross-compile triple: read the arch off the triple prefix.
@@ -592,20 +599,19 @@ def public init_jit_target_flags(target_triple : string = "") {
         ? get_architecture_name() == "x86_64"
         : (starts_with(target_triple, "x86_64") || starts_with(target_triple, "amd64")))
     // AVX2 gate for the x64 intrinsic table (see the declaration comment): host targets take the
-    // running box's cpuid truth. Explicit x64 cross triples take DAS_JIT_X64_FORCE_FEATURES as
-    // the ONLY tier truth (emission-only artifacts, never executed) — no env, no AVX emission,
-    // which keeps the pre-force cross behavior.
-    let x64_cross = g_target_is_x64 && !empty(target_triple)
-    g_target_x64_avx2 = g_target_is_x64 && (x64_cross ? x64_forced_feature("avx2") : cpu_supports("avx2"))
-    g_target_x64_f16c = g_target_is_x64 && (x64_cross ? x64_forced_feature("f16c") : cpu_supports("f16c"))
+    // running box's cpuid truth. Explicit x64 cross triples — and generic-CPU exe builds — take
+    // DAS_JIT_X64_FORCE_FEATURES as the ONLY tier truth (emission-only artifacts).
+    let forced_only = (g_target_is_x64 && !empty(target_triple)) || !host_features
+    g_target_x64_avx2 = g_target_is_x64 && (forced_only ? x64_forced_feature("avx2") : cpu_supports("avx2"))
+    g_target_x64_f16c = g_target_is_x64 && (forced_only ? x64_forced_feature("f16c") : cpu_supports("f16c"))
     // Matrix-tier gates (see the declaration comment): cpuid truth OR'd with the
     // DAS_JIT_X64_FORCE_FEATURES emission-only override; forced-only on cross triples.
-    g_target_x64_vnni256 = g_target_x64_avx2 && (x64_tier_feature("avxvnni", x64_cross)
-        || (x64_tier_feature("avx512vnni", x64_cross) && x64_tier_feature("avx512vl", x64_cross)))
-    g_target_x64_avx512bw = g_target_x64_avx2 && x64_tier_feature("avx512f", x64_cross) && x64_tier_feature("avx512bw", x64_cross)
-    g_target_x64_avx512vnni = g_target_x64_avx512bw && x64_tier_feature("avx512vnni", x64_cross)
-    g_target_x64_vnniint8 = g_target_x64_avx2 && x64_tier_feature("avxvnniint8", x64_cross)
-    g_target_x64_amx = g_target_is_x64 && x64_tier_feature("amx-tile", x64_cross) && x64_tier_feature("amx-int8", x64_cross)
+    g_target_x64_vnni256 = g_target_x64_avx2 && (x64_tier_feature("avxvnni", forced_only)
+        || (x64_tier_feature("avx512vnni", forced_only) && x64_tier_feature("avx512vl", forced_only)))
+    g_target_x64_avx512bw = g_target_x64_avx2 && x64_tier_feature("avx512f", forced_only) && x64_tier_feature("avx512bw", forced_only)
+    g_target_x64_avx512vnni = g_target_x64_avx512bw && x64_tier_feature("avx512vnni", forced_only)
+    g_target_x64_vnniint8 = g_target_x64_avx2 && x64_tier_feature("avxvnniint8", forced_only)
+    g_target_x64_amx = g_target_is_x64 && x64_tier_feature("amx-tile", forced_only) && x64_tier_feature("amx-int8", forced_only)
     // target OS truth (native = host platform; cross = the triple's OS field)
     g_target_os_linux = (empty(target_triple)
         ? get_platform_name() == "linux"
@@ -613,17 +619,19 @@ def public init_jit_target_flags(target_triple : string = "") {
     // aarch64 i8mm tier (see the g_target_arm64_i8mm declaration comment): host targets read
     // LLVM's host-features string OR the arm force env; cross aarch64 triples the env only.
     g_target_arm64_i8mm = g_target_is_aarch64 && (arm64_forced_feature("i8mm")
-        || (empty(target_triple) && host_llvm_feature("i8mm")))
-    // aarch64 fullfp16 (see declaration comment): darwin-arm64 == Apple Silicon == always
+        || (empty(target_triple) && host_features && host_llvm_feature("i8mm")))
+    // aarch64 fullfp16 (see declaration comment): darwin-arm64 == Apple Silicon == always.
+    // Generic-exe builds stay off — the promote/narrow path is ARMv8.0-legal, fullfp16 is not.
     g_target_arm64_fullfp16 = g_target_is_aarch64 && (arm64_forced_feature("fullfp16")
-        || (empty(target_triple) && (host_llvm_feature("fullfp16") || get_platform_name() == "darwin")))
-    // fp16 operators lower as promote-compute-narrow IR wherever half converts are
-    // hardware (routing truth for isExprOp2/Op1_Func — lives in llvm_boost)
+        || (empty(target_triple) && host_features && (host_llvm_feature("fullfp16") || get_platform_name() == "darwin")))
+    // fp16 operators lower as promote-compute-narrow IR wherever half converts are hardware
+    // (routing truth for isExprOp2/Op1_Func — lives in llvm_boost). aarch64 needs no feature
+    // gate: f16<->f32 converts are ARMv8.0 baseline, so even generic-exe aarch64 stays native.
     g_lattice_fp16_ops_native = g_target_is_aarch64 || g_target_x64_f16c
 }
 
 [macro_function]
-def public init_jit(cg_opt_level : uint; target_triple : string = "") {
+def public init_jit(cg_opt_level : uint; target_triple : string = ""; host_features : bool = true) {
     // also prevent double init (g_mod != null)
     return if (is_in_completion() || is_compiling_macros() || g_mod != null)
     LLVMLinkInMCJIT()
@@ -645,7 +653,7 @@ def public init_jit(cg_opt_level : uint; target_triple : string = "") {
     // 8-byte pointers and the target has 4-byte, every for-loop end-pointer
     // GEP bakes in the wrong stride and the loop never terminates. The native
     // path (empty triple) keeps the host default.
-    init_jit_target_flags(target_triple)
+    init_jit_target_flags(target_triple, host_features)
     if (!(target_triple |> empty())) {
         // wasm32 target isn't always part of LLVMInitializeAllTargets in
         // prebuilt LLVM.dll — call the explicit wasm initializer when needed.

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -447,6 +447,13 @@ var public g_target_os_linux = false
 // Cross aarch64 triples read the force string only, same contract as the x64 tiers above.
 var public g_target_arm64_i8mm = false
 
+// ARMv8.2 fullfp16 (native half arithmetic — fadd.4h/8h etc.). Same detection contract as
+// i8mm, except darwin-arm64 is unconditionally true: LLVMGetHostCPUFeatures is empty on
+// macOS and every darwin-arm64 host is Apple Silicon (M1+), which always has fullfp16.
+// The target machine needs no feature append: Linux host feature strings carry +fullfp16
+// explicitly, and on macOS the host CPU name (apple-m1, ...) implies it in the backend.
+var public g_target_arm64_fullfp16 = false
+
 def private arm64_forced_feature(name : string) : bool {
     for (part in split(get_env_variable("DAS_JIT_ARM64_FORCE_FEATURES"), ",")) {
         if (part == name) {
@@ -607,6 +614,9 @@ def public init_jit_target_flags(target_triple : string = "") {
     // LLVM's host-features string OR the arm force env; cross aarch64 triples the env only.
     g_target_arm64_i8mm = g_target_is_aarch64 && (arm64_forced_feature("i8mm")
         || (empty(target_triple) && host_llvm_feature("i8mm")))
+    // aarch64 fullfp16 (see declaration comment): darwin-arm64 == Apple Silicon == always
+    g_target_arm64_fullfp16 = g_target_is_aarch64 && (arm64_forced_feature("fullfp16")
+        || (empty(target_triple) && (host_llvm_feature("fullfp16") || get_platform_name() == "darwin")))
     // fp16 operators lower as promote-compute-narrow IR wherever half converts are
     // hardware (routing truth for isExprOp2/Op1_Func — lives in llvm_boost)
     g_lattice_fp16_ops_native = g_target_is_aarch64 || g_target_x64_f16c

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -607,6 +607,9 @@ def public init_jit_target_flags(target_triple : string = "") {
     // LLVM's host-features string OR the arm force env; cross aarch64 triples the env only.
     g_target_arm64_i8mm = g_target_is_aarch64 && (arm64_forced_feature("i8mm")
         || (empty(target_triple) && host_llvm_feature("i8mm")))
+    // fp16 operators lower as promote-compute-narrow IR wherever half converts are
+    // hardware (routing truth for isExprOp2/Op1_Func — lives in llvm_boost)
+    g_lattice_fp16_ops_native = g_target_is_aarch64 || g_target_x64_f16c
 }
 
 [macro_function]

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -56,6 +56,40 @@ let g_intrin_lookup <- {
         "$::uint2" => @@intrinsic_builtin_int_vec,
         "$::uint3" => @@intrinsic_builtin_int_vec,
         "$::uint4" => @@intrinsic_builtin_int_vec,
+    // 16/8-bit int-lattice c-tors + converts (fp16 family lives in the gated table below)
+        "$::short2" => @@intrinsic_builtin_lattice_vec,
+        "$::short3" => @@intrinsic_builtin_lattice_vec,
+        "$::short4" => @@intrinsic_builtin_lattice_vec,
+        "$::short8" => @@intrinsic_builtin_lattice_vec,
+        "$::ushort2" => @@intrinsic_builtin_lattice_vec,
+        "$::ushort3" => @@intrinsic_builtin_lattice_vec,
+        "$::ushort4" => @@intrinsic_builtin_lattice_vec,
+        "$::ushort8" => @@intrinsic_builtin_lattice_vec,
+        "$::byte2" => @@intrinsic_builtin_lattice_vec,
+        "$::byte3" => @@intrinsic_builtin_lattice_vec,
+        "$::byte4" => @@intrinsic_builtin_lattice_vec,
+        "$::byte8" => @@intrinsic_builtin_lattice_vec,
+        "$::byte16" => @@intrinsic_builtin_lattice_vec,
+        "$::ubyte2" => @@intrinsic_builtin_lattice_vec,
+        "$::ubyte3" => @@intrinsic_builtin_lattice_vec,
+        "$::ubyte4" => @@intrinsic_builtin_lattice_vec,
+        "$::ubyte8" => @@intrinsic_builtin_lattice_vec,
+        "$::ubyte16" => @@intrinsic_builtin_lattice_vec,
+    // saturating narrows (clamp+trunc — backends select sqxtn/packs natively)
+        "$::short2_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::short3_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::short4_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ushort2_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ushort3_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ushort4_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::byte2_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::byte3_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::byte4_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::byte8_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ubyte2_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ubyte3_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ubyte4_sat" => @@intrinsic_builtin_lattice_sat,
+        "$::ubyte8_sat" => @@intrinsic_builtin_lattice_sat,
     // basic type c-tor
             "$::float" => @@intrinsic_builtin_float,
             "$::double" => @@intrinsic_builtin_float,
@@ -195,6 +229,19 @@ let g_f16_cvt_intrin_lookup <- {
     "f16_cvt::f32_to_f16" => @@intrinsic_f32_to_f16
 }
 
+// fp16-family lattice ctors/converts — same hardware-convert gate as g_f16_cvt above.
+// (float2/3/4-from-half and float-from-float16 ride the unconditional ctor entries; the
+// fp16-crossing guard in has_intrinsic keeps those off targets without hardware converts.)
+let g_f16_lattice_intrin_lookup <- {
+    "$::float16" => @@intrinsic_builtin_float16,
+    "$::half2" => @@intrinsic_builtin_lattice_vec,
+    "$::half3" => @@intrinsic_builtin_lattice_vec,
+    "$::half4" => @@intrinsic_builtin_lattice_vec,
+    "$::half8" => @@intrinsic_builtin_lattice_vec,
+    "$::half8_lo" => @@intrinsic_half8_lo_hi,
+    "$::half8_hi" => @@intrinsic_half8_lo_hi
+}
+
 def public has_intrinsic(expr : ExprCallFunc?) {
     var result = false
     assume argType = expr.arguments[0]._type
@@ -213,6 +260,14 @@ def public has_intrinsic(expr : ExprCallFunc?) {
         || (call_name == "$::empty" && !(argType.isGoodArrayType || argType.isGoodTableType))
         || (call_name == "$::hash" && argType.baseType != Type.tString)
         || (!expr.arguments |> empty() && argType.isHandle)) return false
+    // fp16-family values crossing ANY intrinsic need hardware half converts — without
+    // them fpext/fptrunc through half lower to compiler-rt libcalls the JIT doesn't link
+    if (!(g_target_is_aarch64 || g_target_x64_f16c)) {
+        return false if (is_f16_small_type(expr._type.baseType))
+        for (arg in expr.arguments) {
+            return false if (is_f16_small_type(arg._type.baseType))
+        }
+    }
     g_intrin_lookup |> get(call_name) $(_pfun) {
         result = true
     }
@@ -244,6 +299,11 @@ def public has_intrinsic(expr : ExprCallFunc?) {
     if (!result && (g_target_is_aarch64 || g_target_x64_f16c)) {
         g_f16_cvt_intrin_lookup |> get(call_name) $(_pfun) {
             result = true
+        }
+        if (!result) {
+            g_f16_lattice_intrin_lookup |> get(call_name) $(_pfun) {
+                result = true
+            }
         }
     }
     return result
@@ -283,6 +343,11 @@ def public lookup_intinsic(g_ctx : LLVMContextRef; g_builder : LLVMOpaqueBuilder
     if (result == null && (g_target_is_aarch64 || g_target_x64_f16c)) {
         g_f16_cvt_intrin_lookup |> get(call_name) $(pfun) {
             result = pfun |> invoke(JitCtx(ctx = g_ctx, builder = g_builder, types = types), expr, arguments)
+        }
+        if (result == null) {
+            g_f16_lattice_intrin_lookup |> get(call_name) $(pfun) {
+                result = pfun |> invoke(JitCtx(ctx = g_ctx, builder = g_builder, types = types), expr, arguments)
+            }
         }
     }
     // Check initrinsic consistency
@@ -531,7 +596,16 @@ def intrinsic_builtin_int_vec(var ctx : JitCtx; expr : ExprCallFunc?; arguments 
     let isFloatToUintVec = argType.isVectorType && (argType.vectorBaseType == Type.tFloat) && !outSigned
     if (length(arguments) == 1 && !isFloatToUintVec) {
         if (argType.isVectorType) {
-            return any2int(ctx, arguments[0], argType.vectorBaseType, type_to_llvm_type(expr._type), 4, 4, outSigned)
+            // source element size drives widen-vs-trunc: 2 for short/ushort lanes,
+            // 1 for byte/ubyte lanes (the lattice widen converts), 4 for int/uint/float
+            assume srcBt = argType.vectorBaseType
+            var srcElemBytes = 4
+            if (srcBt == Type.tInt16 || srcBt == Type.tUInt16) {
+                srcElemBytes = 2
+            } elif (srcBt == Type.tInt8 || srcBt == Type.tUInt8) {
+                srcElemBytes = 1
+            }
+            return any2int(ctx, arguments[0], argType.vectorBaseType, type_to_llvm_type(expr._type), srcElemBytes, 4, outSigned)
         } else {
             var val = any2int(ctx, arguments[0], argType.baseType, null, argType.sizeOf, 4, outSigned)
             return build_broadcast_vector(ctx.builder, resType, val)
@@ -560,6 +634,7 @@ def intrinsic_builtin_int_vec(var ctx : JitCtx; expr : ExprCallFunc?; arguments 
 def any2float(var ctx : JitCtx; val : LLVMOpaqueValue?; argType : Type; _outType : LLVMOpaqueType? = null) {   // nolint:LINT014 — private helper called from intrinsics that share the table signature
     let outType = _outType != null ? _outType : ctx.types.t_float
     return val                                              if (argType == Type.tFloat)
+    return LLVMBuildFPExt(ctx.builder, val, outType, "") if (argType == Type.tFloat16)
     return LLVMBuildFPTrunc(ctx.builder, val, outType, "") if (argType == Type.tDouble)
     return LLVMBuildSIToFP(ctx.builder, val, outType, "") if (argType == Type.tInt8 || argType == Type.tInt16 || argType == Type.tInt || argType == Type.tInt64)
     return LLVMBuildUIToFP(ctx.builder, val, outType, "") if (argType == Type.tUInt8 || argType == Type.tUInt16 || argType == Type.tUInt || argType == Type.tUInt64)
@@ -615,9 +690,144 @@ def intrinsic_builtin_float(var ctx : JitCtx; expr : ExprCallFunc?; arguments : 
         } else {
             return LLVMBuildFPExt(ctx.builder, arguments[0], floatType, string(expr.name))
         }
+    } elif (argType.baseType == Type.tFloat16) {
+        return LLVMBuildFPExt(ctx.builder, arguments[0], floatType, string(expr.name))
     } else {
         return null
     }
+}
+
+// ===== 16/8-bit lattice ctors / converts =====
+
+def lattice_scalar_to_elem(var ctx : JitCtx; val : LLVMOpaqueValue?; srcBt : Type; dstBt : Type) : LLVMOpaqueValue? {   // nolint:LINT014 — private helper shared by the lattice ctor intrinsics
+    // one ctor/splat scalar argument -> one lattice lane, matching SVecConv semantics
+    if (dstBt == Type.tFloat16) {
+        // SVecConv<float16_t> is float16_t(float(v)) — always promote through float32
+        if (srcBt == Type.tFloat16) {
+            return val
+        }
+        var f = val
+        if (srcBt == Type.tDouble) {
+            f = LLVMBuildFPTrunc(ctx.builder, val, ctx.types.t_float, "")
+        } elif (srcBt == Type.tInt) {
+            f = LLVMBuildSIToFP(ctx.builder, val, ctx.types.t_float, "")
+        } elif (srcBt == Type.tUInt) {
+            f = LLVMBuildUIToFP(ctx.builder, val, ctx.types.t_float, "")
+        }
+        return LLVMBuildFPTrunc(ctx.builder, f, ctx.types.t_half, "")
+    }
+    let dstT = base_type_to_llvm_type(dstBt)
+    if (srcBt == Type.tFloat || srcBt == Type.tDouble) {
+        let dstSigned = dstBt == Type.tInt16 || dstBt == Type.tInt8
+        if (dstSigned) {
+            return LLVMBuildFPToSI(ctx.builder, val, dstT, "")
+        }
+        return LLVMBuildFPToUI(ctx.builder, val, dstT, "")
+    }
+    return LLVMBuildTruncOrBitCast(ctx.builder, val, dstT, "")      // int/uint -> C truncation
+}
+
+def intrinsic_builtin_lattice_vec(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
+    assume resType = expr._type
+    let dstVecT = type_to_llvm_type(resType)
+    if (empty(arguments)) {
+        return LLVMConstNull(dstVecT)       // zero ctor (also the default<T> lowering)
+    }
+    assume argType = expr.arguments[0]._type
+    let dstBt = resType.vectorBaseType
+    if (length(arguments) == 1) {
+        if (argType.baseType == resType.baseType) {
+            return arguments[0]             // pass-through ctor
+        }
+        if (argType.isVectorType) {
+            // lane-matched converts (the das_sv_cvt externs share the ctor name)
+            assume srcBt = argType.vectorBaseType
+            if (dstBt == Type.tFloat16 && srcBt == Type.tFloat) {
+                return LLVMBuildFPTrunc(ctx.builder, arguments[0], dstVecT, string(expr.name))
+            }
+            if ((srcBt == Type.tInt || srcBt == Type.tUInt) ||
+                    (srcBt == Type.tInt16 && dstBt == Type.tInt8) ||
+                    (srcBt == Type.tUInt16 && dstBt == Type.tUInt8)) {
+                return LLVMBuildTrunc(ctx.builder, arguments[0], dstVecT, string(expr.name))    // C-truncating narrow
+            }
+            if (srcBt == Type.tInt8 && dstBt == Type.tInt16) {
+                return LLVMBuildSExt(ctx.builder, arguments[0], dstVecT, string(expr.name))     // byte -> short widen
+            }
+            if (srcBt == Type.tUInt8 && dstBt == Type.tUInt16) {
+                return LLVMBuildZExt(ctx.builder, arguments[0], dstVecT, string(expr.name))     // ubyte -> ushort widen
+            }
+            failed_E(expr, "unsupported lattice convert {expr.name}({describe(argType)})")
+            return null
+        }
+        let lane = lattice_scalar_to_elem(ctx, arguments[0], argType.baseType, dstBt)
+        return build_broadcast_vector(ctx.builder, resType, lane)   // scalar splat
+    }
+    if (resType.baseType == Type.tHalf8 && length(arguments) == 2 && argType.baseType == Type.tFloat4) {
+        // half8(float4 lo, float4 hi) pack
+        let half4T = LLVMVectorType(ctx.types.t_half, 4u)
+        var lo = LLVMBuildFPTrunc(ctx.builder, arguments[0], half4T, "half8_pack_lo")
+        var hi = LLVMBuildFPTrunc(ctx.builder, arguments[1], half4T, "half8_pack_hi")
+        return LLVMBuildShuffleVector(ctx.builder, ctx.types, lo, hi, [0, 1, 2, 3, 4, 5, 6, 7], "half8_pack")
+    }
+    // per-lane ctor (registrations are scalar-args-only for the lattice families)
+    var vres = LLVMGetUndef(dstVecT)
+    var elemIndex = 0
+    for (earg, arg in expr.arguments, arguments) {
+        let lane = lattice_scalar_to_elem(ctx, arg, earg._type.baseType, dstBt)
+        vres = LLVMBuildInsertElement(ctx.builder, vres, lane, ctx.types.ConstI32(uint64(elemIndex++)), "")
+    }
+    if (elemIndex != resType.vectorDim) {
+        failed_E(expr, "vector ctor {expr.name}({describe(expr._type)}) has {elemIndex} elements, but {resType.vectorDim} are expected")
+    }
+    return vres
+}
+
+def build_const_int_splat(elemT : LLVMOpaqueType?; lanes : int; value : int) : LLVMOpaqueValue? {
+    var elems <- [for (_i in range(lanes)); LLVMConstInt(elemT, uint64(int64(value)), value < 0 ? 1 : 0)]
+    return LLVMConstVector(array_data_ptr(elems), uint(lanes))
+}
+
+def build_int_minmax_call(var ctx : JitCtx; iname : string; a, b : LLVMOpaqueValue?; vecT : LLVMOpaqueType?) : LLVMOpaqueValue? {
+    var argTypes <- [vecT]
+    let id = LLVMLookupIntrinsicID(iname)
+    var decl = LLVMGetIntrinsicDeclaration(g_mod, id, argTypes)
+    var typ = LLVMFunctionType(vecT, [vecT, vecT])
+    var args <- [a, b]
+    return LLVMBuildCall2(ctx.builder, typ, decl, args, "")
+}
+
+def intrinsic_builtin_lattice_sat(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
+    // saturating narrow: clamp to the target range, then trunc. The clamp+trunc shape is
+    // what both backends pattern-match to native saturating narrows (aarch64 sqxtn/uqxtn,
+    // x64 packs/packus) — no target-specific gate needed, semantics match das_sv_cvt_sat.
+    assume resType = expr._type
+    assume argType = expr.arguments[0]._type
+    let dstBt = resType.vectorBaseType
+    let srcVecT = type_to_llvm_type(argType)
+    let srcElemT = base_type_to_llvm_type(argType.vectorBaseType)
+    let lanes = resType.vectorDim
+    var clamped = arguments[0]
+    if (dstBt == Type.tInt16 || dstBt == Type.tInt8) {
+        let lim = dstBt == Type.tInt16 ? 32767 : 127
+        clamped = build_int_minmax_call(ctx, "llvm.smin", clamped, build_const_int_splat(srcElemT, lanes, lim), srcVecT)
+        clamped = build_int_minmax_call(ctx, "llvm.smax", clamped, build_const_int_splat(srcElemT, lanes, -lim - 1), srcVecT)
+    } else {
+        let lim = dstBt == Type.tUInt16 ? 65535 : 255
+        clamped = build_int_minmax_call(ctx, "llvm.umin", clamped, build_const_int_splat(srcElemT, lanes, lim), srcVecT)
+    }
+    return LLVMBuildTrunc(ctx.builder, clamped, type_to_llvm_type(resType), string(expr.name))
+}
+
+def intrinsic_builtin_float16(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
+    // scalar float16(float) — the only registered scalar fp16 ctor
+    return LLVMBuildFPTrunc(ctx.builder, arguments[0], ctx.types.t_half, string(expr.name))
+}
+
+def intrinsic_half8_lo_hi(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {   // nolint:LINT014 — table-uniform signature required by g_intrin_lookup
+    let base = expr.name == "half8_lo" ? 0 : 4
+    let mask <- [for (i in range(4)); base + i]
+    var quad = LLVMBuildShuffleVector(ctx.builder, ctx.types, arguments[0], arguments[0], mask, string(expr.name))
+    return LLVMBuildFPExt(ctx.builder, quad, LLVMVectorType(ctx.types.t_float, 4u), "")
 }
 
 def intrinsic_builtin_range(var ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>) : LLVMOpaqueValue? {

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -380,9 +380,8 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
                 if (fun.flags.used && (jit_all_functions || rqj)) {
                     if (!fun.moreFlags.requestNoJit) {
                         disableJitVisitor.disable = false
-                        // the signature gate must run explicitly — `visit(fun)` does not
-                        // dispatch preVisitFunction through the adapter
-                        disableJitVisitor->preVisitFunction(fun)
+                        // if DisableJitVisitor ever grows a preVisitFunction check again, it must
+                        // be dispatched explicitly here — `visit(fun)` never calls preVisitFunction
                         fun |> visit(disableJitVisitorAdapter)
                         if (!disableJitVisitor.disable) {
                             fun.moreFlags.requestJit = true

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x3eul   // 16/8-bit type lattice tags (0x3d: distinct types)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x3ful   // lattice native lowering: marshal/ctors/converts/fp16 ops (0x3e: lattice tags)
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -372,6 +372,9 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
     // `options fast_math` (or policies.fast_math) is the one knob; `_jit_fast_math` kept as a legacy alias
     g_jit_fast_math = (prog._options |> find_arg("fast_math") ?as tBool ?? prog.policies.fast_math) || (prog._options |> find_arg("_jit_fast_math") ?as tBool ?? false)
 
+    // the disable pass consults target-gated intrinsic tables (has_intrinsic) — the
+    // g_target_* truth must be set BEFORE it runs, not first at init_jit time below
+    init_jit_target_flags(target_triple)
     make_visitor(*disableJitVisitor) $(disableJitVisitorAdapter) {
         prog |> for_each_module() $(mod) {
             mod |> for_each_function("") $(fun) {

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -373,8 +373,10 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
     g_jit_fast_math = (prog._options |> find_arg("fast_math") ?as tBool ?? prog.policies.fast_math) || (prog._options |> find_arg("_jit_fast_math") ?as tBool ?? false)
 
     // the disable pass consults target-gated intrinsic tables (has_intrinsic) — the
-    // g_target_* truth must be set BEFORE it runs, not first at init_jit time below
-    init_jit_target_flags(target_triple)
+    // g_target_* truth must be set BEFORE it runs, not first at init_jit time below.
+    // Standalone exes target a GENERIC CPU (write_exe use_host_cpu=false default), so
+    // host cpuid features must not leak into their emission (host_features=false).
+    init_jit_target_flags(target_triple, !gen_exe)
     make_visitor(*disableJitVisitor) $(disableJitVisitorAdapter) {
         prog |> for_each_module() $(mod) {
             mod |> for_each_function("") $(fun) {
@@ -416,7 +418,7 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {
         // Pass target_triple so init_jit can pin the module data layout
             // BEFORE IR construction (wasm32 cross-compile needs 4-byte pointer
             // sizes baked into GEP folding from the very first IR instruction).
-            init_jit(opt_level |> uint, target_triple)
+            init_jit(opt_level |> uint, target_triple, !gen_exe)
 
         var jit_flags : LlvmJitFlags
         jit_flags.emit_prologue = emit_prologue

--- a/tests/type_lattice/test_byte2.das
+++ b/tests/type_lattice/test_byte2.das
@@ -95,4 +95,12 @@ def test_byte2_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = byte2(1, 2)
+        let w = int2(a)
+        t |> success(w == int2(1, 2), "widen")
+        t |> success(byte2(w) == a, "narrow round trip")
+        let s = byte2_sat(int2(100000, -100000))
+        t |> success(s == byte2(127, -128), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_byte3.das
+++ b/tests/type_lattice/test_byte3.das
@@ -97,4 +97,12 @@ def test_byte3_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = byte3(1, 2, 3)
+        let w = int3(a)
+        t |> success(w == int3(1, 2, 3), "widen")
+        t |> success(byte3(w) == a, "narrow round trip")
+        let s = byte3_sat(int3(100000, -100000, 2))
+        t |> success(s == byte3(127, -128, 2), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_byte4.das
+++ b/tests/type_lattice/test_byte4.das
@@ -98,4 +98,12 @@ def test_byte4_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = byte4(1, 2, 3, 4)
+        let w = int4(a)
+        t |> success(w == int4(1, 2, 3, 4), "widen")
+        t |> success(byte4(w) == a, "narrow round trip")
+        let s = byte4_sat(int4(100000, -100000, 2, 3))
+        t |> success(s == byte4(127, -128, 2, 3), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_byte8.das
+++ b/tests/type_lattice/test_byte8.das
@@ -92,4 +92,12 @@ def test_byte8_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = byte8(1, 2, 3, 4, 5, 6, 7, 8)
+        let w = short8(a)
+        t |> success(w == short8(1, 2, 3, 4, 5, 6, 7, 8), "widen")
+        t |> success(byte8(w) == a, "narrow round trip")
+        let s = byte8_sat(short8(30000, -30000, 2, 3, 4, 5, 6, 7))
+        t |> success(s == byte8(127, -128, 2, 3, 4, 5, 6, 7), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_float16.das
+++ b/tests/type_lattice/test_float16.das
@@ -76,5 +76,16 @@ def test_float16_conformance(t : T?) {
         t |> success(b - a == float16(1.), "sub")
         t |> success(a * b == float16(2.), "mul")
         t |> success(b / a == float16(2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == float16(-1.), "unary minus")
+    }
+    t |> run("converts") @(t : T?) {
+        let a = 1.5h
+        t |> equal(float(a), 1.5)
+        t |> success(float16(1.5) == a, "narrow round trip")
     }
 }

--- a/tests/type_lattice/test_float2.das
+++ b/tests/type_lattice/test_float2.das
@@ -102,5 +102,17 @@ def test_float2_conformance(t : T?) {
         t |> success(b - a == float2(1., 2.), "sub")
         t |> success(a * b == float2(2., 8.), "mul")
         t |> success(b / a == float2(2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == float2(-1., -2.), "unary minus")
+        t |> success(a * 2. == a + a, "vec mul scalar")
+        t |> success(2. * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2. == a, "vec div scalar")
+        c = a
+        c *= 2.
+        t |> success(c == a + a, "mul assign scalar")
     }
 }

--- a/tests/type_lattice/test_float3.das
+++ b/tests/type_lattice/test_float3.das
@@ -104,5 +104,17 @@ def test_float3_conformance(t : T?) {
         t |> success(b - a == float3(1., 2., 3.), "sub")
         t |> success(a * b == float3(2., 8., 18.), "mul")
         t |> success(b / a == float3(2., 2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == float3(-1., -2., -3.), "unary minus")
+        t |> success(a * 2. == a + a, "vec mul scalar")
+        t |> success(2. * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2. == a, "vec div scalar")
+        c = a
+        c *= 2.
+        t |> success(c == a + a, "mul assign scalar")
     }
 }

--- a/tests/type_lattice/test_float4.das
+++ b/tests/type_lattice/test_float4.das
@@ -105,5 +105,17 @@ def test_float4_conformance(t : T?) {
         t |> success(b - a == float4(1., 2., 3., 4.), "sub")
         t |> success(a * b == float4(2., 8., 18., 32.), "mul")
         t |> success(b / a == float4(2., 2., 2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == float4(-1., -2., -3., -4.), "unary minus")
+        t |> success(a * 2. == a + a, "vec mul scalar")
+        t |> success(2. * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2. == a, "vec div scalar")
+        c = a
+        c *= 2.
+        t |> success(c == a + a, "mul assign scalar")
     }
 }

--- a/tests/type_lattice/test_half2.das
+++ b/tests/type_lattice/test_half2.das
@@ -102,5 +102,23 @@ def test_half2_conformance(t : T?) {
         t |> success(b - a == half2(1., 2.), "sub")
         t |> success(a * b == half2(2., 8.), "mul")
         t |> success(b / a == half2(2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == half2(-1., -2.), "unary minus")
+        t |> success(a * 2h == a + a, "vec mul scalar")
+        t |> success(2h * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2h == a, "vec div scalar")
+        c = a
+        c *= 2h
+        t |> success(c == a + a, "mul assign scalar")
+    }
+    t |> run("converts") @(t : T?) {
+        let a = half2(1., 2.)
+        let f = float2(a)
+        t |> success(f == float2(1., 2.), "widen to float")
+        t |> success(half2(f) == a, "narrow round trip")
     }
 }

--- a/tests/type_lattice/test_half3.das
+++ b/tests/type_lattice/test_half3.das
@@ -104,5 +104,23 @@ def test_half3_conformance(t : T?) {
         t |> success(b - a == half3(1., 2., 3.), "sub")
         t |> success(a * b == half3(2., 8., 18.), "mul")
         t |> success(b / a == half3(2., 2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == half3(-1., -2., -3.), "unary minus")
+        t |> success(a * 2h == a + a, "vec mul scalar")
+        t |> success(2h * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2h == a, "vec div scalar")
+        c = a
+        c *= 2h
+        t |> success(c == a + a, "mul assign scalar")
+    }
+    t |> run("converts") @(t : T?) {
+        let a = half3(1., 2., 3.)
+        let f = float3(a)
+        t |> success(f == float3(1., 2., 3.), "widen to float")
+        t |> success(half3(f) == a, "narrow round trip")
     }
 }

--- a/tests/type_lattice/test_half4.das
+++ b/tests/type_lattice/test_half4.das
@@ -105,5 +105,23 @@ def test_half4_conformance(t : T?) {
         t |> success(b - a == half4(1., 2., 3., 4.), "sub")
         t |> success(a * b == half4(2., 8., 18., 32.), "mul")
         t |> success(b / a == half4(2., 2., 2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == half4(-1., -2., -3., -4.), "unary minus")
+        t |> success(a * 2h == a + a, "vec mul scalar")
+        t |> success(2h * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2h == a, "vec div scalar")
+        c = a
+        c *= 2h
+        t |> success(c == a + a, "mul assign scalar")
+    }
+    t |> run("converts") @(t : T?) {
+        let a = half4(1., 2., 3., 4.)
+        let f = float4(a)
+        t |> success(f == float4(1., 2., 3., 4.), "widen to float")
+        t |> success(half4(f) == a, "narrow round trip")
     }
 }

--- a/tests/type_lattice/test_half8.das
+++ b/tests/type_lattice/test_half8.das
@@ -99,5 +99,25 @@ def test_half8_conformance(t : T?) {
         t |> success(b - a == half8(1., 2., 3., 4., 5., 6., 7., 8.), "sub")
         t |> success(a * b == half8(2., 8., 18., 32., 50., 72., 98., 128.), "mul")
         t |> success(b / a == half8(2., 2., 2., 2., 2., 2., 2., 2.), "div")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == half8(-1., -2., -3., -4., -5., -6., -7., -8.), "unary minus")
+        t |> success(a * 2h == a + a, "vec mul scalar")
+        t |> success(2h * a == a + a, "scalar mul vec")
+        t |> success((a + a) / 2h == a, "vec div scalar")
+        c = a
+        c *= 2h
+        t |> success(c == a + a, "mul assign scalar")
+    }
+    t |> run("converts") @(t : T?) {
+        let lo = float4(1., 2., 3., 4.)
+        let hi = float4(5., 6., 7., 8.)
+        let p = half8(lo, hi)
+        t |> success(p == half8(1., 2., 3., 4., 5., 6., 7., 8.), "pack")
+        t |> success(half8_lo(p) == lo, "unpack lo")
+        t |> success(half8_hi(p) == hi, "unpack hi")
     }
 }

--- a/tests/type_lattice/test_int2.das
+++ b/tests/type_lattice/test_int2.das
@@ -101,5 +101,16 @@ def test_int2_conformance(t : T?) {
         t |> success(a + b == int2(3, 6), "add")
         t |> success(b - a == int2(1, 2), "sub")
         t |> success(a * b == int2(2, 8), "mul")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(-a == int2(-1, -2), "unary minus")
+        t |> success(a * 2 == a + a, "vec mul scalar")
+        t |> success(2 * a == a + a, "scalar mul vec")
+        c = a
+        c *= 2
+        t |> success(c == a + a, "mul assign scalar")
     }
 }

--- a/tests/type_lattice/test_lattice_user_operators.das
+++ b/tests/type_lattice/test_lattice_user_operators.das
@@ -1,0 +1,33 @@
+// hand-written (NOT generated): user-defined operators involving lattice types must
+// resolve to the user function on every tier — under JIT they route to the function
+// path, never the native lattice op lowering (which only knows the builtin signatures)
+options gen2
+require dastest/testing_boost public
+
+def operator ==(a : short4; b : int4) : bool {
+    return int4(a) == b
+}
+
+def operator +(a : half4; b : float) : half4 {
+    return a + half4(float16(b))
+}
+
+def use_eq(a : short4; b : int4) : bool {
+    return a == b
+}
+
+def use_add(a : half4; b : float) : half4 {
+    return a + b
+}
+
+[test]
+def test_lattice_user_operators(t : T?) {
+    t |> run("mixed equality routes to the user operator") @(t : T?) {
+        t |> success(use_eq(short4(1, 2, 3, 4), int4(1, 2, 3, 4)), "equal")
+        t |> success(!use_eq(short4(1, 2, 3, 4), int4(1, 2, 3, 5)), "not equal")
+    }
+    t |> run("mixed add routes to the user operator") @(t : T?) {
+        let r = use_add(half4(1h, 2h, 3h, 4h), 0.5)
+        t |> success(r == half4(1.5h, 2.5h, 3.5h, 4.5h), "sum")
+    }
+}

--- a/tests/type_lattice/test_short2.das
+++ b/tests/type_lattice/test_short2.das
@@ -95,4 +95,12 @@ def test_short2_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = short2(1, 2)
+        let w = int2(a)
+        t |> success(w == int2(1, 2), "widen")
+        t |> success(short2(w) == a, "narrow round trip")
+        let s = short2_sat(int2(100000, -100000))
+        t |> success(s == short2(32767, -32768), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_short3.das
+++ b/tests/type_lattice/test_short3.das
@@ -97,4 +97,12 @@ def test_short3_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = short3(1, 2, 3)
+        let w = int3(a)
+        t |> success(w == int3(1, 2, 3), "widen")
+        t |> success(short3(w) == a, "narrow round trip")
+        let s = short3_sat(int3(100000, -100000, 2))
+        t |> success(s == short3(32767, -32768, 2), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_short4.das
+++ b/tests/type_lattice/test_short4.das
@@ -98,4 +98,12 @@ def test_short4_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = short4(1, 2, 3, 4)
+        let w = int4(a)
+        t |> success(w == int4(1, 2, 3, 4), "widen")
+        t |> success(short4(w) == a, "narrow round trip")
+        let s = short4_sat(int4(100000, -100000, 2, 3))
+        t |> success(s == short4(32767, -32768, 2, 3), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_short8.das
+++ b/tests/type_lattice/test_short8.das
@@ -92,4 +92,7 @@ def test_short8_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        t |> success(short8(byte8(1, 2, 3, 4, 5, 6, 7, 8)) == short8(1, 2, 3, 4, 5, 6, 7, 8), "widen from 8-bit")
+    }
 }

--- a/tests/type_lattice/test_ubyte2.das
+++ b/tests/type_lattice/test_ubyte2.das
@@ -95,4 +95,12 @@ def test_ubyte2_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ubyte2(1u, 2u)
+        let w = uint2(a)
+        t |> success(w == uint2(1u, 2u), "widen")
+        t |> success(ubyte2(w) == a, "narrow round trip")
+        let s = ubyte2_sat(uint2(100000u, 1u))
+        t |> success(s == ubyte2(255u, 1u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_ubyte3.das
+++ b/tests/type_lattice/test_ubyte3.das
@@ -97,4 +97,12 @@ def test_ubyte3_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ubyte3(1u, 2u, 3u)
+        let w = uint3(a)
+        t |> success(w == uint3(1u, 2u, 3u), "widen")
+        t |> success(ubyte3(w) == a, "narrow round trip")
+        let s = ubyte3_sat(uint3(100000u, 1u, 2u))
+        t |> success(s == ubyte3(255u, 1u, 2u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_ubyte4.das
+++ b/tests/type_lattice/test_ubyte4.das
@@ -98,4 +98,12 @@ def test_ubyte4_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ubyte4(1u, 2u, 3u, 4u)
+        let w = uint4(a)
+        t |> success(w == uint4(1u, 2u, 3u, 4u), "widen")
+        t |> success(ubyte4(w) == a, "narrow round trip")
+        let s = ubyte4_sat(uint4(100000u, 1u, 2u, 3u))
+        t |> success(s == ubyte4(255u, 1u, 2u, 3u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_ubyte8.das
+++ b/tests/type_lattice/test_ubyte8.das
@@ -92,4 +92,12 @@ def test_ubyte8_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ubyte8(1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u)
+        let w = ushort8(a)
+        t |> success(w == ushort8(1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u), "widen")
+        t |> success(ubyte8(w) == a, "narrow round trip")
+        let s = ubyte8_sat(ushort8(30000u, 1u, 2u, 3u, 4u, 5u, 6u, 7u))
+        t |> success(s == ubyte8(255u, 1u, 2u, 3u, 4u, 5u, 6u, 7u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_uint4.das
+++ b/tests/type_lattice/test_uint4.das
@@ -104,5 +104,15 @@ def test_uint4_conformance(t : T?) {
         t |> success(a + b == uint4(3u, 6u, 9u, 12u), "add")
         t |> success(b - a == uint4(1u, 2u, 3u, 4u), "sub")
         t |> success(a * b == uint4(2u, 8u, 18u, 32u), "mul")
+        var c = a
+        c += b
+        t |> success(c == a + b, "add assign")
+        c -= b
+        t |> success(c == a, "sub assign")
+        t |> success(a * 2u == a + a, "vec mul scalar")
+        t |> success(2u * a == a + a, "scalar mul vec")
+        c = a
+        c *= 2u
+        t |> success(c == a + a, "mul assign scalar")
     }
 }

--- a/tests/type_lattice/test_ushort2.das
+++ b/tests/type_lattice/test_ushort2.das
@@ -95,4 +95,12 @@ def test_ushort2_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ushort2(1u, 2u)
+        let w = uint2(a)
+        t |> success(w == uint2(1u, 2u), "widen")
+        t |> success(ushort2(w) == a, "narrow round trip")
+        let s = ushort2_sat(uint2(100000u, 1u))
+        t |> success(s == ushort2(65535u, 1u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_ushort3.das
+++ b/tests/type_lattice/test_ushort3.das
@@ -97,4 +97,12 @@ def test_ushort3_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ushort3(1u, 2u, 3u)
+        let w = uint3(a)
+        t |> success(w == uint3(1u, 2u, 3u), "widen")
+        t |> success(ushort3(w) == a, "narrow round trip")
+        let s = ushort3_sat(uint3(100000u, 1u, 2u))
+        t |> success(s == ushort3(65535u, 1u, 2u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_ushort4.das
+++ b/tests/type_lattice/test_ushort4.das
@@ -98,4 +98,12 @@ def test_ushort4_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        let a = ushort4(1u, 2u, 3u, 4u)
+        let w = uint4(a)
+        t |> success(w == uint4(1u, 2u, 3u, 4u), "widen")
+        t |> success(ushort4(w) == a, "narrow round trip")
+        let s = ushort4_sat(uint4(100000u, 1u, 2u, 3u))
+        t |> success(s == ushort4(65535u, 1u, 2u, 3u), "sat clamp")
+    }
 }

--- a/tests/type_lattice/test_ushort8.das
+++ b/tests/type_lattice/test_ushort8.das
@@ -92,4 +92,7 @@ def test_ushort8_conformance(t : T?) {
         let s = "{a}"
         t |> success(!empty(s), "interpolates")
     }
+    t |> run("converts") @(t : T?) {
+        t |> success(ushort8(ubyte8(1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u)) == ushort8(1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u), "widen from 8-bit")
+    }
 }

--- a/utils/dasgen/gen_type_conformance.das
+++ b/utils/dasgen/gen_type_conformance.das
@@ -134,6 +134,8 @@ def emit_s_swizzle_section(var writer; spec : TypeSpec) {
 }
 
 def emit_arith_section(var writer; spec : TypeSpec) {
+    // lane values stay small integers so every op below is EXACT in fp16 — the checks
+    // pin semantics across interp/jit/aot without rounding sensitivity
     writer |> write("    t |> run(\"arithmetic\") @(t : T?) \{\n")
     writer |> write("        let a = {ctor(spec, 1)}\n")
     writer |> write("        let b = {ctor_gen(spec) $(i) => (1 + i) * 2}\n")
@@ -142,6 +144,103 @@ def emit_arith_section(var writer; spec : TypeSpec) {
     writer |> write("        t |> success(a * b == {ctor_gen(spec) $(i) => (1 + i) * (1 + i) * 2}, \"mul\")\n")
     if (spec.kind == "float") {
         writer |> write("        t |> success(b / a == {ctor_gen(spec) $(_i) => 2}, \"div\")\n")
+    }
+    writer |> write("        var c = a\n")
+    writer |> write("        c += b\n")
+    writer |> write("        t |> success(c == a + b, \"add assign\")\n")
+    writer |> write("        c -= b\n")
+    writer |> write("        t |> success(c == a, \"sub assign\")\n")
+    if (spec.kind != "uint") {
+        writer |> write("        t |> success(-a == {ctor_gen(spec) $(i) => -(1 + i)}, \"unary minus\")\n")
+    }
+    if (spec.arity > 1) {
+        let s = lit(spec.ekind, 2)
+        writer |> write("        t |> success(a * {s} == a + a, \"vec mul scalar\")\n")
+        writer |> write("        t |> success({s} * a == a + a, \"scalar mul vec\")\n")
+        if (spec.kind == "float") {
+            writer |> write("        t |> success((a + a) / {s} == a, \"vec div scalar\")\n")
+        }
+        writer |> write("        c = a\n")
+        writer |> write("        c *= {s}\n")
+        writer |> write("        t |> success(c == a + a, \"mul assign scalar\")\n")
+    }
+    writer |> write("    \}\n")
+}
+
+// lane-matched converts + saturating narrows — mirrors the das_sv_cvt/das_sv_cvt_sat
+// registration matrix (module_builtin_vector_ctor.cpp)
+def emit_convert_section(var writer; spec : TypeSpec) {
+    let n = spec.arity
+    assume fam = spec.family
+    let isIntNarrow = (fam == "short" || fam == "byte" || fam == "ushort" || fam == "ubyte") && n <= 4
+    let isByte8 = (fam == "byte" || fam == "ubyte") && n == 8
+    let isShort8 = (fam == "short" || fam == "ushort") && n == 8
+    let isHalfVec = fam == "half" && n <= 4
+    if (!(isIntNarrow || isByte8 || isShort8 || isHalfVec || fam == "half" && n == 8 || spec.name == "float16")) {
+        return
+    }
+    writer |> write("    t |> run(\"converts\") @(t : T?) \{\n")
+    if (spec.name == "float16") {
+        writer |> write("        let a = 1.5h\n")
+        writer |> write("        t |> equal(float(a), 1.5)\n")
+        writer |> write("        t |> success(float16(1.5) == a, \"narrow round trip\")\n")
+    } elif (isHalfVec) {
+        writer |> write("        let a = {ctor(spec, 1)}\n")
+        var fspec = spec
+        fspec.name = "float{n}"
+        fspec.kind = "float"
+        writer |> write("        let f = float{n}(a)\n")
+        writer |> write("        t |> success(f == {ctor(fspec, 1)}, \"widen to float\")\n")
+        writer |> write("        t |> success({spec.name}(f) == a, \"narrow round trip\")\n")
+    } elif (fam == "half") {   // half8 <-> 2x float4 pack/unpack
+        writer |> write("        let lo = float4(1., 2., 3., 4.)\n")
+        writer |> write("        let hi = float4(5., 6., 7., 8.)\n")
+        writer |> write("        let p = half8(lo, hi)\n")
+        writer |> write("        t |> success(p == {ctor(spec, 1)}, \"pack\")\n")
+        writer |> write("        t |> success(half8_lo(p) == lo, \"unpack lo\")\n")
+        writer |> write("        t |> success(half8_hi(p) == hi, \"unpack hi\")\n")
+    } else {
+        let signed_ = fam == "short" || fam == "byte"
+        var src = spec
+        src.kind = signed_ ? "int" : "uint"
+        var big = 100000
+        if (isByte8) {
+            src.name = signed_ ? "short8" : "ushort8"   // byte8/ubyte8 narrow from the 16-bit 8-lane form
+            big = 30000
+        } elif (isShort8) {
+            src.name = signed_ ? "byte8" : "ubyte8"     // short8/ushort8 only WIDEN (from the 8-bit form)
+        } else {
+            src.name = (signed_ ? "int" : "uint") + "{n}"
+        }
+        if (isShort8) {
+            writer |> write("        t |> success({spec.name}({ctor(src, 1)}) == {ctor(spec, 1)}, \"widen from 8-bit\")\n")
+        } else {
+            // widen round trip: lattice -> 32/16-bit -> back (values in range, C-truncation exact)
+            writer |> write("        let a = {ctor(spec, 1)}\n")
+            writer |> write("        let w = {src.name}(a)\n")
+            writer |> write("        t |> success(w == {ctor(src, 1)}, \"widen\")\n")
+            writer |> write("        t |> success({spec.name}(w) == a, \"narrow round trip\")\n")
+            // saturating narrow: lane 0 clamps high, lane 1 clamps low (signed), tail lanes pass through
+            var lim = 0
+            if (fam == "short") {
+                lim = 32767
+            } elif (fam == "byte") {
+                lim = 127
+            } elif (fam == "ushort") {
+                lim = 65535
+            } else {
+                lim = 255
+            }
+            let limv = lim
+            let bigv = big
+            if (signed_) {
+                writer |> write("        let s = {spec.name}_sat({ctor_gen(src) $(i) => i == 0 ? bigv : (i == 1 ? -bigv : i)})\n")
+                writer |> write("        t |> success(s == {ctor_gen(spec) $(i) => i == 0 ? limv : (i == 1 ? -limv - 1 : i)}, \"sat clamp\")\n")
+            } else {
+                writer |> write("        let s = {spec.name}_sat({ctor_gen(src) $(i) => i == 0 ? bigv : i})\n")
+                writer |> write("        t |> success(s == {ctor_gen(spec) $(i) => i == 0 ? limv : i}, \"sat clamp\")\n")
+            }
+        }
     }
     writer |> write("    \}\n")
 }
@@ -243,6 +342,7 @@ def emit_test_file(spec : TypeSpec) {
             if (spec.has_arith) {
                 emit_arith_section(writer, spec)
             }
+            emit_convert_section(writer, spec)
             writer |> write("\}\n")
         }
         f |> fwrite(body)


### PR DESCRIPTION
# fp16/lattice JIT-native lowering — the type-lattice bonus wave (W7)

Follow-up to #3430. The 16/8-bit lattice types compiled everywhere but fell back **whole-function to the interpreter** the moment any lattice value appeared under `-jit`. This wave gives them native JIT lowering end to end: the full conformance suite now runs under the JIT with **zero interpreter fallbacks**, and on arm64 the emitted code is native fp16 (disasm-verified `fmul.4h`/`fadd.8h`, `sqxtn.4h`/`sqxtn.8b` for the saturating narrows, `fcvtn`/`fcvtn2`/`fcvtl` for converts).

## Design note — pure IR instead of address-bearing builtins

The original plan sketched per-op calls into the C++ reference impls (MatrixCTorFn-style address-bearing builtins). Implemented instead as **pure IR emission, entirely das-side**, because:

- the reference fp16 semantics *is* promote-to-f32 → compute → round-back (RNE), which is exactly fpext → fop → fptrunc — bit-identical by construction (f32 carries the 2p+2 double-rounding safety bound for + - * /);
- the call route has a real C-ABI trap: half4 is an 8-byte GPR-class struct in C while the JIT value is a SIMD-register vector — the ImplWrapCall pointer-reinterpret is only sound for vec4f-shaped types;
- 3 instructions beat a function call per op, and no C++ registration surface was needed.

With `+fullfp16` (any darwin-arm64, Linux aarch64 with the host feature, or forced via `DAS_JIT_ARM64_FORCE_FEATURES`) the ops emit **directly on half vectors** — provably identical to the promote path for single ops, and verified byte-for-byte against interp. Pre-F16C x64 keeps the interp fallback (half converts would lower to compiler-rt libcalls the JIT does not link); the int lattice lowers unconditionally on every target.

## Stages (one commit each)

1. **vec4f slot marshal + signature-gate lift** — `cast_to_vec4f`/`cast_from_vec4f` learn all 23 lattice types (one shuffle to/from the full-128-bit lane form + one bitcast, byte-identical to the C++ cast slot conventions; scalar float16 rides bits-widened in lane 0). Functions taking/returning lattice values now JIT and interop with interp callers.
   Also fixes the hard-coded 12-byte stride in `build_array_index` for 3-lane vectors — das packs half3/short3 at 6B and byte3 at 3B; arrays of those corrupted under JIT (element 1 written at the padded-alloc offset). float3/int3 emit identical IR as before (their das stride is the old constant).
2. **Data-path gates lifted** — indexing, swizzles, locals-with-init were already stride-correct in the emitter (element-typed GEPs); the conservative gates come off.
3. **Ctors/converts/sat-narrows/pack-unpack as intrinsic IR** — zero/splat/per-lane/pass-through ctors, the `das_sv_cvt` lane-matched converts, saturating narrows as clamp (`llvm.smin/smax/umin`) + trunc — the shape both backends pattern-match to native `sqxtn`/`packs`, semantics matching `das_sv_cvt_sat` exactly — plus `half8` pack/unpack and the scalar `float16`/`float` converts. fp16-family entries live behind the same hardware-convert gate as `f16_cvt`, with an fp16-crossing guard in `has_intrinsic`.
   Also fixes a latent ordering bug: the `DisableJitVisitor` pass consults target-gated intrinsic tables, but the target flags were only set in `init_jit` — which runs **after** the pass. Extracted `init_jit_target_flags` and run it before the pass.
4. **Operators** — fp16 `+ - * /` (plus assign forms, unary minus, scalar↔vector mixed forms, ordered/equality compares) lower in `visitExprOp2/Op1_NonMonade` as promote/compute/narrow IR; int-lattice `==`/`!=` join the existing icmp+reduce compare arms. Routing via `is_lattice_op2_native`; unsupported lattice ops still fall back cleanly.
5. **Native arm64 fullfp16** — `g_target_arm64_fullfp16` detection (i8mm-style; darwin-arm64 is unconditionally true since the macOS host feature string is empty and every Apple Silicon core has it) switches the same block to direct half-vector ops. `LLVM_JIT_CODEGEN_VERSION` 0x3e → 0x3f.
6. **Harness + AOT fixes** — `gen_type_conformance` now pins the surfaces this wave lowered (RMW ops, scalar↔vector forms, unary minus, convert round trips, saturating clamps, pack/unpack; lane values chosen exact-in-fp16 so checks are rounding-insensitive), 384 → **405 tests**. The new AOT-tier coverage immediately caught three pre-existing fp16 emission gaps in `daslib/aot_cpp.das` (untested shapes since the operator wave): unary policy results missing the typed result-cast wrap, scalar float16 set-ops missing the char-pointer first-arg convention the vector policies use, and `policyArgNeedCast` pair-exempting scalar float16 (grouped with the vec4f-convertible types, but `float16_t` has no implicit vec4f conversion).

## Verification

- `tests/type_lattice`: **405/405 on all five tiers** — interp, interp-isolated, jit (zero lattice fallback log lines across the whole suite), jit-isolated, `test_aot`.
- Probe outputs byte-identical interp vs JIT — including RNE rounding edges (`0.1h * 0.1h`), overflow-to-inf, and the native-fullfp16 vs promote-path comparison (both equal interp, hence each other).
- Full `tests/` tree under `-jit` (cold cache): green except `tests/dasLLAMA/test_chat.das` + `test_batch_decode.das`, which fail identically on **pure master** (verified twice, clean JIT cache — the pre-existing #3425 paged-KV reds).
- `preflight --full`: 15 passed, 1 skipped; the single failing gate is the JIT suite red above (pre-existing on master).
- Rebased onto current master; interp/jit/AOT re-verified with rebuilt binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
