### PR TITLE
dasLLAMA: wscale_f16 default ON + neon f16s twins; dastest loud skips

### DIFF
--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -497,11 +497,11 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
             dt = get_time_usec(t0)
         }
     } recover {
-        if (!deliberateRecover && context.context.exception |> starts_with("test skipped")) {
-            // a nested arm's skip (T.skipNow) unwound through this level (the panic tears down
-            // every test-context frame, outer [test] body included, and the exception text
-            // carries a trailing newline — hence prefix match). The arm's own test_any already
-            // counted the skip; this level propagates as a skip, not an error.
+        if (!deliberateRecover && context.context != null && context.context.exception |> starts_with("test skipped")) {
+            // a DIRECT T.skipNow unwound through this level (its panic tears down every
+            // test-context frame, outer [test] body included; the exception text carries a
+            // trailing newline — hence prefix match). The pipe-form `t |> skip(...)` does not
+            // unwind and never lands here. Propagate as a skip, not an error.
             deliberateRecover = true
             skipped = true
         }

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -504,6 +504,7 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
             // unwind and never lands here. Propagate as a skip, not an error.
             deliberateRecover = true
             skipped = true
+            dt = get_time_usec(t0)
         }
         if (!deliberateRecover) {
             dt = get_time_usec(t0)

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -497,6 +497,14 @@ def private test_any(name : string; func; args_num : int; var context : FileCtx;
             dt = get_time_usec(t0)
         }
     } recover {
+        if (!deliberateRecover && context.context.exception |> starts_with("test skipped")) {
+            // a nested arm's skip (T.skipNow) unwound through this level (the panic tears down
+            // every test-context frame, outer [test] body included, and the exception text
+            // carries a trailing newline — hence prefix match). The arm's own test_any already
+            // counted the skip; this level propagates as a skip, not an error.
+            deliberateRecover = true
+            skipped = true
+        }
         if (!deliberateRecover) {
             dt = get_time_usec(t0)
             failed = true

--- a/dastest/testing.das
+++ b/dastest/testing.das
@@ -324,6 +324,12 @@ def failure(tb : Asserter?; msg = "") : bool {
     return false
 }
 
+//! Skip the current test arm: logs `msg`, lands the arm in the suite's skipped count (not a
+//! pass), and unwinds — statements after `t |> skip(...)` do not run.
+def skip(t : T?; msg : string) {
+    t->skipAt(msg, get_line_info(1))
+}
+
 typedef RunT = variant<lmd1 : lambda<(t : T?) : void>; func1 : function<(t : T?) : void>>
 
 

--- a/dastest/testing.das
+++ b/dastest/testing.das
@@ -324,12 +324,14 @@ def failure(tb : Asserter?; msg = "") : bool {
     return false
 }
 
-//! Skip the current test arm: logs `msg` and lands the arm in the suite's skipped count (not a
-//! pass). Does NOT unwind — use the arm-fatal shape `if (gate) { t |> skip("..."); return }`.
-//! (The panicking T.skipNow unwind proved fragile at volume from AOT-compiled tests; a plain
-//! flag + caller return needs none of it.)
+//! Skip the current test arm: prints `msg` and lands the arm in the suite's skipped count (not
+//! a pass). Does NOT unwind — use the arm-fatal shape `if (gate) { t |> skip("..."); return }`.
+//! Deliberately avoids both T.skipNow (its panic from AOT-compiled test frames corrupted state
+//! at volume) and onLog (the log handler grows dastest-owned arrays under the TEST context —
+//! a cross-context allocation that corrupted the heap at skip volume; skips don't need the
+//! failure-report message capture, so the reason prints directly).
 def skip(t : T?; msg : string) {
-    t->logAt(msg, get_line_info(1))
+    to_log(LOG_INFO, "\tskipped: {msg}\n")
     t.onSkipNow |> invoke()
 }
 

--- a/dastest/testing.das
+++ b/dastest/testing.das
@@ -324,10 +324,13 @@ def failure(tb : Asserter?; msg = "") : bool {
     return false
 }
 
-//! Skip the current test arm: logs `msg`, lands the arm in the suite's skipped count (not a
-//! pass), and unwinds — statements after `t |> skip(...)` do not run.
+//! Skip the current test arm: logs `msg` and lands the arm in the suite's skipped count (not a
+//! pass). Does NOT unwind — use the arm-fatal shape `if (gate) { t |> skip("..."); return }`.
+//! (The panicking T.skipNow unwind proved fragile at volume from AOT-compiled tests; a plain
+//! flag + caller return needs none of it.)
 def skip(t : T?; msg : string) {
-    t->skipAt(msg, get_line_info(1))
+    t->logAt(msg, get_line_info(1))
+    t.onSkipNow |> invoke()
 }
 
 typedef RunT = variant<lmd1 : lambda<(t : T?) : void>; func1 : function<(t : T?) : void>>

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -771,9 +771,11 @@ def private resolve_arch(var t : Model; arch : string) {
     t.blocks = g_arch_registry[arch].blocks
 }
 
-// The wscale_f16 rail's load-time switch (see Model.qscales16): default off; box-profile
-// runtime knob `wscale_f16` / benches flip it before load_gguf.
-var g_wscale_f16 = false
+// The wscale_f16 rail's load-time switch (see Model.qscales16): default ON — llama.cpp byte
+// parity, free at 16 lanes on the 3990X, +5.4% on the byte-bound M1; every backend carries the
+// s16 twins (the loader falls back to f32 with a warning otherwise). Box-profile runtime knob
+// `wscale_f16` / benches flip it before load_gguf; decode_prof --wscale-f16 0 is the A/B rail.
+var g_wscale_f16 = true
 def public set_wscale_f16(on : bool) {
     g_wscale_f16 = on
 }

--- a/modules/dasLLAMA/dasllama/dasllama_math_aarch64_neon.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_aarch64_neon.das
@@ -5,6 +5,7 @@ module dasllama_math_aarch64_neon shared public
 require dasllama/dasllama_math
 require dasllama/dasllama_tune  // [tuned]: reconstitute the laneq4x4 tile from its template with per-box loop hints
 require llvm/daslib/aarch64_neon  // sdot4: JIT-emitted ARM SDOT, scalar fallback elsewhere
+require llvm/daslib/f16_cvt  // f16_to_f32 — the wscale_f16 twins widen the binary16 scale in-loop
 require daslib/jobque_boost public  // kernels expand parallel_for; consumers need its symbols
 require dasllama/dasllama_par  // maybe_parallel_for
 
@@ -296,6 +297,36 @@ def dot_q8q8_laneq4(wg : int8 const?; sg : float const?; xq : int8 const?; xs : 
     return f
 }
 
+//! The wscale_f16 twin of dot_q8q8_laneq4: the group's 4 interleaved block scales are raw
+//! binary16 halfwords, widened in-loop — same fold order, so bit-identical over the widened
+//! plane. The gen backend's s16 reference bodies read this (grp4 = the reference layout).
+//! Not `private`: called from inside the lifted parallel_for worker lambdas.
+[hint(unsafe_range_check, noalias = wg, noalias = sg, noalias = xq, noalias = xs)]
+def dot_q8q8_laneq4_f16s(wg : int8 const?; sg : uint16 const?; xq : int8 const?; xs : float const?; n : int64) : float4 {
+    let nb = n / 32l
+    var f = float4(0.0, 0.0, 0.0, 0.0)
+    unsafe {
+        for (bi in range64(nb)) {
+            let wb = bi * 128l
+            let xb = bi * 32l
+            var acc = int4(0, 0, 0, 0)
+            acc = sdot4_laneq(acc, wg + wb, xq + xb, 0)
+            acc = sdot4_laneq(acc, wg + wb + 16l, xq + xb, 1)
+            acc = sdot4_laneq(acc, wg + wb + 32l, xq + xb, 2)
+            acc = sdot4_laneq(acc, wg + wb + 48l, xq + xb, 3)
+            acc = sdot4_laneq(acc, wg + wb + 64l, xq + xb + 16l, 0)
+            acc = sdot4_laneq(acc, wg + wb + 80l, xq + xb + 16l, 1)
+            acc = sdot4_laneq(acc, wg + wb + 96l, xq + xb + 16l, 2)
+            acc = sdot4_laneq(acc, wg + wb + 112l, xq + xb + 16l, 3)
+            let s = float4(f16_to_f32(uint(sg[bi * 4l])), f16_to_f32(uint(sg[bi * 4l + 1l])),
+                f16_to_f32(uint(sg[bi * 4l + 2l])), f16_to_f32(uint(sg[bi * 4l + 3l])))
+            let xsb = xs[bi]
+            f += float4(acc) * s * float4(xsb, xsb, xsb, xsb)
+        }
+    }
+    return f
+}
+
 [hint(unsafe_range_check, noalias = wg, noalias = sg, noalias = xqp, noalias = xsp)]
 def template dot_q8q8_laneq4x4_template(var yp : float ?; wg : int8 const ?; sg : float const ?; xqp : int8 const ?; xsp : float const ?; n, d, g, t0 : int64) : void {
     let nb = n / 32l
@@ -383,6 +414,137 @@ def q8q8_rows_kernel_neon_sdot4x4(var yp : float?; wp : int8 const?; sp : float 
     }
 }
 
+// ===== f16-scale twins (the wscale_f16 rail): the same SDOT loops over the binary16
+// weight-scale plane, widened in-loop (the f16-KV codec pattern) — bit-identical to the f32
+// forms over the plane the halfwords widen to =====
+
+//! The wscale_f16 twin of dot_q8q8_sdot4x4: the per-block WEIGHT scale is a raw binary16
+//! halfword. Not `private`: called from inside the lifted parallel_for worker lambdas.
+[hint(unsafe_range_check, noalias = wq, noalias = xq, noalias = ws, noalias = xs)]
+def dot_q8q8_sdot4x4_f16s(wq : int8 const?; ws : uint16 const?; xq : int8 const?; xs : float const?; n : int64) : float {
+    let nb = n / 32l
+    var f0 = 0.0
+    var f1 = 0.0
+    var f2 = 0.0
+    var f3 = 0.0
+    var bi = 0l
+    unsafe {
+        while (bi + 4l <= nb) {
+            let bb = bi * 32l
+            var a0 = int4(0, 0, 0, 0)
+            var a1 = int4(0, 0, 0, 0)
+            var a2 = int4(0, 0, 0, 0)
+            var a3 = int4(0, 0, 0, 0)
+            a0 = sdot4(a0, wq + bb, xq + bb)
+            a0 = sdot4(a0, wq + bb + 16l, xq + bb + 16l)
+            a1 = sdot4(a1, wq + bb + 32l, xq + bb + 32l)
+            a1 = sdot4(a1, wq + bb + 48l, xq + bb + 48l)
+            a2 = sdot4(a2, wq + bb + 64l, xq + bb + 64l)
+            a2 = sdot4(a2, wq + bb + 80l, xq + bb + 80l)
+            a3 = sdot4(a3, wq + bb + 96l, xq + bb + 96l)
+            a3 = sdot4(a3, wq + bb + 112l, xq + bb + 112l)
+            f0 += float(a0.x + a0.y + a0.z + a0.w) * f16_to_f32(uint(ws[bi + 0l])) * xs[bi + 0l]
+            f1 += float(a1.x + a1.y + a1.z + a1.w) * f16_to_f32(uint(ws[bi + 1l])) * xs[bi + 1l]
+            f2 += float(a2.x + a2.y + a2.z + a2.w) * f16_to_f32(uint(ws[bi + 2l])) * xs[bi + 2l]
+            f3 += float(a3.x + a3.y + a3.z + a3.w) * f16_to_f32(uint(ws[bi + 3l])) * xs[bi + 3l]
+            bi += 4l
+        }
+        while (bi < nb) {
+            let base = bi * 32l
+            var acc = int4(0, 0, 0, 0)
+            acc = sdot4(acc, wq + base, xq + base)
+            acc = sdot4(acc, wq + base + 16l, xq + base + 16l)
+            f0 += float(acc.x + acc.y + acc.z + acc.w) * f16_to_f32(uint(ws[bi])) * xs[bi]
+            bi++
+        }
+    }
+    return f0 + f1 + f2 + f3
+}
+
+def private q8q8_kernel_neon_sdot4x4_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, d : int64) {
+    let nb = n / 32l
+    var myp = yp
+    maybe_parallel_for(0, int(d), matmul_chunks_gemv(int(d), get_q8_batch_chunks_per_job(), n * d)) $(rb, re) {
+        unsafe {
+            for (i in range(rb, re)) {
+                myp[i] = dot_q8q8_sdot4x4_f16s(wp + int64(i) * n, sp + int64(i) * nb, xqp, xsp, n)
+            }
+        }
+    }
+}
+
+def private q8q8_batch_kernel_neon_sdot4x4_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
+    let nb = n / 32l
+    var myp = yp
+    maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+        unsafe {
+            for (i in range(rb, re)) {
+                let wrow = wp + int64(i) * n
+                let srow = sp + int64(i) * nb
+                for (tk in range64(ntok)) {
+                    myp[tk * d + int64(i)] = dot_q8q8_sdot4x4_f16s(wrow, srow, xqp + tk * n, xsp + tk * nb, n)
+                }
+            }
+        }
+    }
+}
+
+def private q8q8_group3_kernel_neon_sdot4x4_s16(var y0p : float?; var y1p : float?; var y2p : float?; wp : int8 const?; sp : uint16 const?;
+                                                woff0, woff1, woff2 : int64; xqp : int8 const?; xsp : float const?; n, d0, d1, d2 : int64) {
+    let nb = n / 32l
+    let dtot = d0 + d1 + d2
+    var w0 = y0p
+    var w1 = y1p
+    var w2 = y2p
+    maybe_parallel_for(0, int(dtot), matmul_chunks_gemv(int(dtot), get_jobque_team_mode() ? get_q8_batch_chunks_per_job() : 1, n * dtot)) $(rb, re) {
+        unsafe {
+            for (gi in range(rb, re)) {
+                let g = int64(gi)
+                if (g < d0) {
+                    w0[g] = dot_q8q8_sdot4x4_f16s(wp + woff0 + g * n, sp + woff0 / 32l + g * nb, xqp, xsp, n)
+                } elif (g < d0 + d1) {
+                    let r = g - d0
+                    w1[r] = dot_q8q8_sdot4x4_f16s(wp + woff1 + r * n, sp + woff1 / 32l + r * nb, xqp, xsp, n)
+                } else {
+                    let r = g - d0 - d1
+                    w2[r] = dot_q8q8_sdot4x4_f16s(wp + woff2 + r * n, sp + woff2 / 32l + r * nb, xqp, xsp, n)
+                }
+            }
+        }
+    }
+}
+
+def private q8q8_groupn_kernel_neon_sdot4x4_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n, d : int64) {
+    let nb = n / 32l
+    var myp = yp
+    maybe_parallel_for(0, int(nregions * d), matmul_chunks_gemv(int(nregions * d), get_q8_batch_chunks_per_job(), n * d * nregions)) $(rb, re) {
+        unsafe {
+            for (i in range(rb, re)) {
+                let ii = int64(i)
+                let r = ii / d
+                let row = ii % d
+                let woff = offs[r * 2l]
+                let xoff = offs[r * 2l + 1l]
+                var v = dot_q8q8_sdot4x4_f16s(wp + woff + row * n, sp + woff / 32l + row * nb, xqp + xoff, xsp + xoff / 32l, n)
+                if (bp != null) {
+                    v += bp[boffs[r] + row]
+                }
+                myp[ii] = v
+            }
+        }
+    }
+}
+
+// Not `private`: invoked through the kernel pointer from lifted worker lambdas.
+def q8q8_rows_kernel_neon_sdot4x4_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, rb, re : int64) {
+    let nb = n / 32l
+    unsafe {
+        for (i in range64(rb, re)) {
+            yp[i] = dot_q8q8_sdot4x4_f16s(wp + i * n, sp + i * nb, xqp, xsp, n)
+        }
+    }
+}
+
 [init]
 def dasllama_math_aarch64_neon_register() {
     // Only register the SDOT backends under JIT on arm64. Off-JIT (interpreter or AOT) sdot4/sdot4_laneq
@@ -396,6 +558,9 @@ def dasllama_math_aarch64_neon_register() {
             repack = @@repack_q8q8_identity, mm_mx4 = @@mx4q8_kernel_neon,
             groupn = @@q8q8_groupn_kernel_neon_sdot4x4, groupn_mx4 = @@mx4q8_groupn_kernel_neon,
             mm_rows = @@q8q8_rows_kernel_neon_sdot4x4,
+            mm_s16 = @@q8q8_kernel_neon_sdot4x4_s16, batch_s16 = @@q8q8_batch_kernel_neon_sdot4x4_s16,
+            group3_s16 = @@q8q8_group3_kernel_neon_sdot4x4_s16, groupn_s16 = @@q8q8_groupn_kernel_neon_sdot4x4_s16,
+            mm_rows_s16 = @@q8q8_rows_kernel_neon_sdot4x4_s16,
             needs_repack = false, priority = 10))
         // The repack tier (interleaved groups, load-select only) is "arm64-gen" in
         // dasllama_math_gen — it superseded the hand arm64-laneq backend that lived here.

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -5,7 +5,6 @@ module dasllama_math_gen shared public
 require dasllama/dasllama_math
 require dasllama/dasllama_math_aarch64_neon
 require dasllama/dasllama_math_default  // dot_q8q8_f16s — the row-major tails of the s16 twins
-require llvm/daslib/f16_cvt             // f16_to_f32 — the s16 reference bodies' in-loop widen
 require llvm/daslib/llvm_tune  // [tune]/[tune_perm]/[tune_companion] + the [llvm_code] annotation it re-exports
 require dasllama/dasllama_gemm_schema
 require daslib/jobque_boost public
@@ -143,29 +142,39 @@ def mx4q8_gemv_gen(var yp : float?; wn : uint8 const?; we : uint8 const?; xqp : 
 //! The f16-scale GEMV companion (the wscale_f16 rail): q8q8_gemv_gen's twin over the raw
 //! binary16 group-scale plane (Model.qscales16 — the repacked f32 plane, converted in place,
 //! element order preserved). Same rows-range contract; the generated body differs only in the
-//! scale fold's widen (fcvtl/vcvtph2ps). Reference body = the scalar grp4 walk — correct on
-//! every tier; the hand laneq f16s twin is the neon backend's stage. Not `private`: it IS the
-//! mm_rows_s16 slot and is called from inside lifted parallel_for worker lambdas.
+//! scale fold's widen (fcvtl/vcvtph2ps). Reference body = the hand laneq f16s rows walk over
+//! the grp4 reference layout, declining in lockstep via the shared predicate. Not `private`:
+//! it IS the mm_rows_s16 slot and is called from inside lifted parallel_for worker lambdas.
 [hint(unsafe_range_check, noalias = wp, noalias = sp, noalias = xqp, noalias = xsp)]
 def q8q8_gemv_s16_gen(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, rb, re : int64) : void {
     let nb = n / 32l
     unsafe {
         for (g in range64(rb / 4l, re / 4l)) {
-            q8q8_token_grp_generic(yp, wp + g * 4l * n, sp + g * 4l * nb, xqp, xsp, n, 0l, g * 4l, 0l, 4l)
+            let f = dot_q8q8_laneq4_f16s(wp + g * 4l * n, sp + g * 4l * nb, xqp, xsp, n)
+            yp[g * 4l + 0l] = f.x
+            yp[g * 4l + 1l] = f.y
+            yp[g * 4l + 2l] = f.z
+            yp[g * 4l + 3l] = f.w
         }
     }
 }
 
 //! The f16-scale tile companion: q8q8_tile_gen's twin over the binary16 group-scale plane —
 //! same 4-token contract, stamped with the SAME perm (bias128/amx/smmla included; only the
-//! scale-fold load differs). Reference body = 4 scalar grp4 token walks, same per-block fold
-//! order. Not `private`: called from inside the lifted parallel_for worker lambdas.
+//! scale-fold load differs). Reference body = 4 single-token laneq f16s dots with the tile's
+//! per-block fold order. Not `private`: called from inside the lifted parallel_for worker
+//! lambdas.
 [unused_argument(xbsp), hint(unsafe_range_check, noalias = wg, noalias = sg, noalias = xqp, noalias = xsp, noalias = xbsp)]
 def q8q8_tile_s16_gen(var yp : float?; wg : int8 const?; sg : uint16 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, g, t0 : int64) : void {
     let nb = n / 32l
     unsafe {
         for (t in range64(4l)) {
-            q8q8_token_grp_generic(yp, wg, sg, xqp + (t0 + t) * n, xsp + (t0 + t) * nb, n, d, g * 4l, t0 + t, 4l)
+            let f = dot_q8q8_laneq4_f16s(wg, sg, xqp + (t0 + t) * n, xsp + (t0 + t) * nb, n)
+            let r = g * 4l
+            yp[(t0 + t) * d + r + 0l] = f.x
+            yp[(t0 + t) * d + r + 1l] = f.y
+            yp[(t0 + t) * d + r + 2l] = f.z
+            yp[(t0 + t) * d + r + 3l] = f.w
         }
     }
 }
@@ -391,41 +400,6 @@ def q8q8_token_grp_generic(var yp : float?; wg : int8 const?; sg : float const?;
                     acc += int(int8(int(wg[wo + 3l]) + wb0)) * int(xq[xo + 3l])
                 }
                 f[int(r)] += float(acc) * sg[bi * mr + r] * xsb
-            }
-        }
-        for (r in range64(mr)) {
-            yp[trow * d + col + r] = f[int(r)]
-        }
-    }
-}
-
-//! The wscale_f16 overload of q8q8_token_grp_generic: the same walk with the per-block weight
-//! scale widened in-loop from the raw binary16 plane. The s16 stubs' reference bodies.
-def q8q8_token_grp_generic(var yp : float?; wg : int8 const?; sg : uint16 const?; xq : int8 const?; xs : float const?; n, d, col, trow, mr : int64; wbias : int64 = 0l; kgroup : int64 = 4l) {
-    let nb = n / 32l
-    let wb0 = int(wbias)
-    var f : float[32]   // scratch cap = the grid's max stampable mr (busd512 mr32 row)
-    for (r in range(int(mr))) {
-        f[r] = 0.0
-    }
-    unsafe {
-        for (bi in range64(nb)) {
-            let wb = bi * mr * 32l
-            let xb = bi * 32l
-            let xsb = xs[bi]
-            for (r in range64(mr)) {
-                var acc = 0
-                for (kg in range64(8l)) {
-                    let wo = (kgroup == 8l
-                        ? wb + (kg / 2l) * 8l * mr + r * 8l + (kg % 2l) * 4l
-                        : wb + kg * 4l * mr + r * 4l)
-                    let xo = xb + kg * 4l
-                    acc += int(int8(int(wg[wo + 0l]) + wb0)) * int(xq[xo + 0l])
-                    acc += int(int8(int(wg[wo + 1l]) + wb0)) * int(xq[xo + 1l])
-                    acc += int(int8(int(wg[wo + 2l]) + wb0)) * int(xq[xo + 2l])
-                    acc += int(int8(int(wg[wo + 3l]) + wb0)) * int(xq[xo + 3l])
-                }
-                f[int(r)] += float(acc) * f16_to_f32(uint(sg[bi * mr + r])) * xsb
             }
         }
         for (r in range64(mr)) {

--- a/tests/dasLLAMA/_model_tier.das
+++ b/tests/dasLLAMA/_model_tier.das
@@ -31,10 +31,9 @@ def parity_full_mode() : bool {
 
 // Presence + tier gate for a model-loading test. Returns true if the caller should proceed to
 // load `path`; otherwise registers a LOUD skip on `t` (model absent, or large-tier without
-// DASLLAMA_PARITY_FULL) — the arm lands in the suite's skipped count instead of masquerading
-// as a pass (two real x64 failures hid behind the passing form for months). `skip` unwinds,
-// so the `return false` is for the signature; every call site is the arm-fatal
-// `if (!model_available(t, path)) return` shape.
+// DASLLAMA_PARITY_FULL) and returns false — the arm lands in the suite's skipped count instead
+// of masquerading as a pass (two real x64 failures hid behind the passing form for months).
+// `skip` does NOT unwind: the caller's `if (!model_available(t, path)) return` exits the arm.
 def model_available(t : T?; path : string) : bool {
     let st = stat(path)
     if (!st.is_valid) {

--- a/tests/dasLLAMA/_model_tier.das
+++ b/tests/dasLLAMA/_model_tier.das
@@ -30,16 +30,19 @@ def parity_full_mode() : bool {
 }
 
 // Presence + tier gate for a model-loading test. Returns true if the caller should proceed to
-// load `path`; otherwise registers a passing skip on `t` (model absent, or large-tier without
-// DASLLAMA_PARITY_FULL) and returns false. Collapses the per-test presence-check boilerplate.
+// load `path`; otherwise registers a LOUD skip on `t` (model absent, or large-tier without
+// DASLLAMA_PARITY_FULL) — the arm lands in the suite's skipped count instead of masquerading
+// as a pass (two real x64 failures hid behind the passing form for months). `skip` unwinds,
+// so the `return false` is for the signature; every call site is the arm-fatal
+// `if (!model_available(t, path)) return` shape.
 def model_available(t : T?; path : string) : bool {
     let st = stat(path)
     if (!st.is_valid) {
-        t |> success(true, "skipped: {base_name(path)} not present")
+        t |> skip("{base_name(path)} not present")
         return false
     }
     if (!parity_full_mode() && st.size > LARGE_TIER_BYTES) {
-        t |> success(true, "skipped: {base_name(path)} is large-tier ({st.size / (1024ul * 1024ul * 1024ul)} GB) — set DASLLAMA_PARITY_FULL=1 to run")
+        t |> skip("{base_name(path)} is large-tier ({st.size / (1024ul * 1024ul * 1024ul)} GB) — set DASLLAMA_PARITY_FULL=1 to run")
         return false
     }
     return true

--- a/tests/dasLLAMA/test_audio.das
+++ b/tests/dasLLAMA/test_audio.das
@@ -226,7 +226,7 @@ def test_omni_tower(t : T?) {
 def test_encoder_oracle(t : T?) {
     t |> run("all-ones mel through the tower matches mtmd (needs qwen2audio mmproj)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "qwen2audio-mmproj-f32.gguf")

--- a/tests/dasLLAMA/test_batch_decode.das
+++ b/tests/dasLLAMA/test_batch_decode.das
@@ -176,11 +176,11 @@ def private batch_vs_ref(t : T?; tr : Model; kdt : KVDtype; nsteps : int64; tol 
 
 def private model_missing(t : T?) : bool {
     if (!jit_enabled()) {
-        t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+        t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
         return true
     }
     if (!stat(MODEL_PATH).is_valid) {
-        t |> success(true, "skipped: stories15M.bin not present")
+        t |> skip("stories15M.bin not present")
         return true
     }
     return false
@@ -250,7 +250,7 @@ def test_batch_decode_f16_kv(t : T?) {
 def test_batch_decode_q8_kv(t : T?) {
     t |> run("batched decode == sequential under the q8_0 KV codec (needs SmolLM2-135M)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         // stories15M's head_size 48 is rejected by the q8_0 32-block check (by design) — this arm
@@ -259,7 +259,7 @@ def test_batch_decode_q8_kv(t : T?) {
         let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
         let path = path_join(mdir, "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var tr <- load_gguf(path, QuantMode.q8)

--- a/tests/dasLLAMA/test_chat.das
+++ b/tests/dasLLAMA/test_chat.das
@@ -70,7 +70,7 @@ def test_chat_tinyllama_zephyr(t : T?) {
     t |> run("TinyLlama (arch=llama + SPM) renders the Zephyr prefill") @(t : T?) {
         let path = path_join(models_dir(), "tinyllama-1.1b-chat-v1.0.Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_capped(path)
@@ -94,7 +94,7 @@ def test_chat_gemma(t : T?) {
     t |> run("Gemma-2 (SPM, no system role) folds system into the first user turn") @(t : T?) {
         let path = path_join(models_dir(), "gemma-2-2b-it-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_capped(path)
@@ -119,7 +119,7 @@ def test_chat_phi(t : T?) {
     t |> run("Phi-3.5 (SPM) renders the Phi-3 prefill") @(t : T?) {
         let path = path_join(models_dir(), "Phi-3.5-mini-instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_capped(path)
@@ -147,7 +147,7 @@ def test_chat_qwen(t : T?) {
     t |> run("Qwen2.5 (BPE) renders the ChatML prefill") @(t : T?) {
         let path = path_join(models_dir(), "Qwen2.5-1.5B-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_capped(path)
@@ -177,7 +177,7 @@ def test_chat_llama3(t : T?) {
     t |> run("Llama-3 (arch=llama + BPE) renders the Llama-3 header prefill") @(t : T?) {
         let path = path_join(models_dir(), "Llama-3.2-1B-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_capped(path)
@@ -206,12 +206,12 @@ def test_chat_llama3(t : T?) {
 def test_chat_end_to_end(t : T?) {
     t |> run("respond() streams a reply, stops on a stop token, records stats + transcript") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-2-2b-it-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_model(path, QuantMode.q8)
@@ -327,7 +327,7 @@ def test_chat_pending_cleared_on_consume(t : T?) {
     t |> run("respond()/add_assistant() clear the consumed user text (needs SmolLM2-135M)") @(t : T?) {
         let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         with_job_que() {
@@ -355,12 +355,12 @@ def test_chat_pending_cleared_on_consume(t : T?) {
 def test_chat_render_seam(t : T?) {
     t |> run("render_assistant ≡ add_assistant evals; renderer chat holds no KV (needs SmolLM2-135M)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         with_job_que() {

--- a/tests/dasLLAMA/test_facade.das
+++ b/tests/dasLLAMA/test_facade.das
@@ -50,7 +50,7 @@ def test_facade_spm(t : T?) {
     t |> run("SPM facade auto-dispatch matches raw SentencePiece") @(t : T?) {
         let path = path_join(models_dir(), "tinyllama-1.1b-chat-v1.0.Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var v <- load_tokenizer_auto(path)
@@ -70,7 +70,7 @@ def test_facade_bpe(t : T?) {
     t |> run("BPE facade auto-dispatch matches raw byte-level BPE") @(t : T?) {
         let path = path_join(models_dir(), "Qwen2.5-0.5B-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var v <- load_tokenizer_auto(path)
@@ -99,7 +99,7 @@ def test_facade_model(t : T?) {
     t |> run("load_model owns the tokenizer; model facade delegates") @(t : T?) {
         let path = path_join(models_dir(), "Qwen2.5-0.5B-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_model(path, QuantMode.q8)

--- a/tests/dasLLAMA/test_flash.das
+++ b/tests/dasLLAMA/test_flash.das
@@ -97,11 +97,11 @@ def run_all(t : T?; tr : Model; tk : SpmTokenizer) {
 def test_flash_fp32(t : T?) {
     t |> run("flash ~= classic, fp32 (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -116,11 +116,11 @@ def test_flash_fp32(t : T?) {
 def test_flash_q8(t : T?) {
     t |> run("flash ~= classic, Q8 + forced sliding window (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)

--- a/tests/dasLLAMA/test_forward.das
+++ b/tests/dasLLAMA/test_forward.das
@@ -38,11 +38,11 @@ def same(a, b : array<int64>) : bool {
 def test_forward_end_to_end(t : T?) {
     t |> run("forward + tokenizer match llama2.c (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin / tokenizer.bin not present")
+            t |> skip("stories15M.bin / tokenizer.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -71,11 +71,11 @@ def test_forward_end_to_end(t : T?) {
 def test_forward_q8(t : T?) {
     t |> run("all-weights Q8 forward matches fp32 oracle (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin / tokenizer.bin not present")
+            t |> skip("stories15M.bin / tokenizer.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -102,11 +102,11 @@ def test_forward_q8(t : T?) {
 def test_forward_q8_pooled(t : T?) {
     t |> run("Q8 forward with pooled fork contexts still matches the oracle (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin / tokenizer.bin not present")
+            t |> skip("stories15M.bin / tokenizer.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -135,11 +135,11 @@ def test_forward_q8_pooled(t : T?) {
 def test_forward_q4(t : T?) {
     t |> run("all-weights Q4 forward matches the fp32 oracle prefix (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin / tokenizer.bin not present")
+            t |> skip("stories15M.bin / tokenizer.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -167,11 +167,11 @@ def test_forward_q4(t : T?) {
 def test_forward_threaded_decode_attention(t : T?) {
     t |> run("threaded decode attention is bit-exact vs inline (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)

--- a/tests/dasLLAMA/test_fused_decode.das
+++ b/tests/dasLLAMA/test_fused_decode.das
@@ -55,11 +55,11 @@ def private greedy_ids(tr : Model; var s : Session; var ids : array<int64>; var 
 def test_fused_decode_bit_exact(t : T?) {
     t |> run("fused stage chains == per-op dispatches, ids + logits bit-exact (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -157,12 +157,12 @@ def private fused_vs_std_bit_exact(t : T?; tr : Model) {
 def test_fused_flash_deep_ctx(t : T?) {
     t |> run("flash-sliced fused chain: per-layer witness + structural logit bound (needs SmolLM2-135M)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         let prev_backend = active_kernel_backend()
@@ -224,12 +224,12 @@ def test_fused_flash_deep_ctx(t : T?) {
 def test_fused_flash_deep_ctx_q8(t : T?) {
     t |> run("flash-sliced fused chain under q8_0 KV: per-layer witness + structural logit bound (needs SmolLM2-135M)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         let prev_backend = active_kernel_backend()
@@ -291,7 +291,7 @@ def test_fused_flash_deep_ctx_q8(t : T?) {
 def test_fused_decode_pre_post_norm(t : T?) {
     t |> run("fused chains bit-exact on pre/post-norm arches (needs the gemma ggufs)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let prev_backend = active_kernel_backend()
@@ -303,6 +303,8 @@ def test_fused_decode_pre_post_norm(t : T?) {
             for (name in ["gemma-3-1b-it-Q8_0.gguf", "gemma-2-2b-it-Q8_0.gguf", "gemma-4-E2B-it-Q8_0.gguf"]) {
                 let path = path_join(models_dir(), name)
                 if (!stat(path).is_valid) {
+                    // deliberately NOT `t |> skip` — skip unwinds the whole arm, and this loop
+                    // must keep testing the models that ARE present
                     t |> success(true, "skipped: {path} not present")
                     continue
                 }
@@ -321,12 +323,12 @@ def test_fused_decode_pre_post_norm(t : T?) {
 def test_fused_decode_attn_chain(t : T?) {
     t |> run("fused attention chain bit-exact on SmolLM2-135M (needs the gguf)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         let prev_backend = active_kernel_backend()

--- a/tests/dasLLAMA/test_fused_decode.das
+++ b/tests/dasLLAMA/test_fused_decode.das
@@ -303,8 +303,8 @@ def test_fused_decode_pre_post_norm(t : T?) {
             for (name in ["gemma-3-1b-it-Q8_0.gguf", "gemma-2-2b-it-Q8_0.gguf", "gemma-4-E2B-it-Q8_0.gguf"]) {
                 let path = path_join(models_dir(), name)
                 if (!stat(path).is_valid) {
-                    // deliberately NOT `t |> skip` — skip unwinds the whole arm, and this loop
-                    // must keep testing the models that ARE present
+                    // deliberately NOT `t |> skip` — it would mark the WHOLE arm skipped even
+                    // when the loop goes on to exercise the models that ARE present
                     t |> success(true, "skipped: {path} not present")
                     continue
                 }

--- a/tests/dasLLAMA/test_kv_codec.das
+++ b/tests/dasLLAMA/test_kv_codec.das
@@ -302,11 +302,11 @@ def private greedy_ids(tr : Model; var s : Session; var ids : array<int64>; var 
 def test_kv_f16_decode(t : T?) {
     t |> run("f16 KV: greedy trajectory matches f32, fused==std bit-exact under f16 (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -379,11 +379,11 @@ def test_kv_f16_decode(t : T?) {
 def test_kv_f16_prefill_vs_decode(t : T?) {
     t |> run("f16 KV: prefill == per-token decode, logits bit-exact (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -448,11 +448,11 @@ let GGUF_PATH = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
 
 def private gguf_missing(t : T?) : bool {
     if (!jit_enabled()) {
-        t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+        t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
         return true
     }
     if (!stat(GGUF_PATH).is_valid) {
-        t |> success(true, "skipped: {GGUF_PATH} not present")
+        t |> skip("{GGUF_PATH} not present")
         return true
     }
     return false

--- a/tests/dasLLAMA/test_kv_paged.das
+++ b/tests/dasLLAMA/test_kv_paged.das
@@ -293,11 +293,11 @@ def private cache_rows_equal(var sf : Session; var sp : Session; c : Config; npo
 def test_kv_paged_decode(t : T?) {
     t |> run("interleaved paged sessions == flat, bit-exact under fragmentation (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -351,7 +351,7 @@ def test_kv_paged_decode(t : T?) {
 def test_kv_paged_q8(t : T?) {
     t |> run("paged q8_0 sessions == flat q8_0, bit-exact under fragmentation (needs SmolLM2-135M)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         // q8_0 needs a head_size-64 carrier (stories15M's 48 is rejected by the 32-block check)
@@ -359,7 +359,7 @@ def test_kv_paged_q8(t : T?) {
         let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
         let path = path_join(mdir, "SmolLM2-135M-Instruct-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var tr <- load_gguf(path, QuantMode.q8)
@@ -412,11 +412,11 @@ def test_kv_paged_q8(t : T?) {
 def test_kv_paged_prefill(t : T?) {
     t |> run("paged prefill == flat prefill: logits and cache rows bit-exact (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -465,11 +465,11 @@ def test_kv_paged_prefill(t : T?) {
 def test_kv_paged_eval_batch(t : T?) {
     t |> run("paged eval_batch == flat eval_batch, ragged depths on one pool (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)

--- a/tests/dasLLAMA/test_kv_prefix.das
+++ b/tests/dasLLAMA/test_kv_prefix.das
@@ -164,11 +164,11 @@ def private logits_match(s : Session; all : array<float>; snap, vocab : int64) :
 def test_prefix_warm_equals_cold(t : T?) {
     t |> run("attached pages + tail eval == cold prefill, bit-exact (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)

--- a/tests/dasLLAMA/test_parity.das
+++ b/tests/dasLLAMA/test_parity.das
@@ -3,6 +3,7 @@ options persistent_heap   // + explicit deletes below: each test frees its model
 
 require dastest/testing_boost public
 require dasllama/dasllama   // the public facade — public-path tests exercise the API through it (engine + arch registrations + chat)
+require llvm/daslib/f16_cvt   // f16_to_f32 — the tied-cls arm reads the live scale plane
 require daslib/jobque_boost
 require daslib/fio
 require strings
@@ -82,7 +83,7 @@ def private parity_ok(path : string; quant : QuantMode; prompt, want : array<int
 def test_parity_tied_cls_q8_rows(t : T?) {
     t |> run("tied Q8 load: cls_q8 embedding rows bit-match the fp32 table") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
@@ -97,7 +98,10 @@ def test_parity_tied_cls_q8_rows(t : T?) {
             for (i in range64(dim)) {
                 let el = t8.emb_q8_off + token * dim + i
                 let want = t32.fblob[t32.tok_emb_off + token * dim + i]
-                if (float(t8.qblob[el]) * t8.qscales[el / 32l] != want) {
+                // read whichever scale plane is live (wscale_f16 frees the f32 one; the widen
+                // is the exact disk value, so the bit-match claim is unchanged)
+                let sc = t8.wscale_f16 ? f16_to_f32(uint(t8.qscales16[el / 32l])) : t8.qscales[el / 32l]
+                if (float(t8.qblob[el]) * sc != want) {
                     bad++
                 }
             }
@@ -125,7 +129,7 @@ let GEMMA2_GEN <- [235248l, 235321l, 235269l, 235248l, 235315l, 235269l, 235248l
 def test_parity_gemma2(t : T?) {
     t |> run("gemma2 forward (gemma-2-2b-it Q8)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-2-2b-it-Q8_0.gguf")
@@ -146,7 +150,7 @@ let TINYLLAMA_V03_GEN <- [29892l, 727l, 471l, 263l, 4123l, 7826l, 4257l, 365l, 2
 def test_parity_tinyllama_v03(t : T?) {
     t |> run("llama forward (TinyLlama-1.1B-v0.3 F16 -> fp32)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "tinyllama-1.1b-v0.3-f16.gguf")
@@ -167,7 +171,7 @@ let LLAMA32_1B_GEN <- [11l, 304l, 264l, 2678l, 14458l, 89777l, 304l, 279l, 20700
 def test_parity_llama3_2_1b(t : T?) {
     t |> run("llama forward (Llama-3.2-1B-Instruct Q8, θ=500000)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Llama-3.2-1B-Instruct-Q8_0.gguf")
@@ -190,7 +194,7 @@ let QWEN25_15B_GEN <- [220l, 23l, 11l, 220l, 24l, 11l, 220l, 16l, 15l, 11l,
 def test_parity_qwen25_15b(t : T?) {
     t |> run("qwen2 forward (Qwen2.5-1.5B-Instruct Q8)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Qwen2.5-1.5B-Instruct-Q8_0.gguf")
@@ -212,7 +216,7 @@ let PHI35_GEN <- [29871l, 29947l, 29892l, 29871l, 29929l, 29892l, 29871l, 29896l
 def test_parity_phi35(t : T?) {
     t |> run("phi3 forward (Phi-3.5-mini-instruct Q8, fused QKV + LongRoPE)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Phi-3.5-mini-instruct-Q8_0.gguf")
@@ -232,7 +236,7 @@ let SMOLLM2_GEN <- [28l, 281l, 253l, 1165l, 6560l, 32047l, 826l, 827l, 1109l, 87
 def test_parity_smollm2(t : T?) {
     t |> run("llama forward (SmolLM2-1.7B-Instruct Q8)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "SmolLM2-1.7B-Instruct-Q8_0.gguf")
@@ -252,7 +256,7 @@ let MISTRAL7B_GEN <- [29493l, 1504l, 1171l, 1032l, 3286l, 1444l, 5928l, 5067l, 2
 def test_parity_mistral7b(t : T?) {
     t |> run("llama forward (Mistral-7B-Instruct-v0.3 Q8)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Mistral-7B-Instruct-v0.3-Q8_0.gguf")
@@ -275,7 +279,7 @@ let QWEN3_GEN <- [220l, 23l, 11l, 220l, 24l, 11l, 220l, 16l, 15l, 11l,
 def test_parity_qwen3_06b(t : T?) {
     t |> run("qwen3 forward (Qwen3-0.6B Q8, QK-norm)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Qwen3-0.6B-Q8_0.gguf")
@@ -288,7 +292,7 @@ def test_parity_qwen3_06b(t : T?) {
 def test_parity_qwen3_4b(t : T?) {
     t |> run("qwen3 forward (Qwen3-4B-Instruct-2507 Q8, QK-norm)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Qwen3-4B-Instruct-2507-Q8_0.gguf")
@@ -307,7 +311,7 @@ def test_parity_qwen3_4b(t : T?) {
 def test_parity_qwen2moe(t : T?) {
     t |> run("qwen2moe forward (Qwen1.5-MoE-A2.7B-Chat Q8, routed experts + shared expert)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Qwen1.5-MoE-A2.7B-Chat.Q8_0.gguf")
@@ -341,7 +345,7 @@ def test_parity_qwen2moe(t : T?) {
 def test_parity_qwen3moe_30b(t : T?) {
     t |> run("qwen3moe forward (Qwen3-30B-A3B Q8: QK-norm attn, softmax top-8-of-128 renormalized, no shared expert)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "Qwen3-30B-A3B-Q8_0.gguf")
@@ -391,7 +395,7 @@ let GEMMA3_4B_GEN <- [236743l, 236828l, 236764l, 236743l, 236819l, 236764l, 2367
 def test_parity_gemma3_1b(t : T?) {
     t |> run("gemma3 forward (gemma-3-1b-it Q8, SWA pattern + dual rope)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-3-1b-it-Q8_0.gguf")
@@ -404,7 +408,7 @@ def test_parity_gemma3_1b(t : T?) {
 def test_parity_gemma3_4b(t : T?) {
     t |> run("gemma3 forward (gemma-3-4b-it Q8, SWA pattern + dual rope + linear scale)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-3-4b-it-Q8_0.gguf")
@@ -454,7 +458,7 @@ def private parity_text_ok(path : string; quant : QuantMode; text : string; want
 def test_parity_gemma4_12b(t : T?) {
     t |> run("gemma4 forward (gemma-4-12B-it Q8, heterogeneous SWA/global geometry, window engaged)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-4-12B-it-Q8_0.gguf")
@@ -473,7 +477,7 @@ def test_parity_gemma4_12b(t : T?) {
 def test_parity_gemma4_31b(t : T?) {
     t |> run("gemma4 forward (gemma-4-31B-it Q8, same arch as 12B scaled: 60L/5376d)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-4-31B-it-Q8_0.gguf")
@@ -505,7 +509,7 @@ let GEMMA4_26B_GEN <- [236743l, 236800l, 236778l, 236770l, 236764l, 236743l, 236
 def test_parity_gemma4_26b(t : T?) {
     t |> run("gemma4 MoE forward (gemma-4-26B-A4B-it Q8: dense shared expert + routed top-8-of-128)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-4-26B-A4B-it-Q8_0.gguf")
@@ -531,7 +535,7 @@ def test_parity_gemma4_26b(t : T?) {
 def test_parity_gemma4_e4b(t : T?) {
     t |> run("gemma4 forward (gemma-4-E4B-it Q8: per-layer embeddings + cross-layer KV sharing)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-4-E4B-it-Q8_0.gguf")
@@ -550,7 +554,7 @@ def test_parity_gemma4_e4b(t : T?) {
 def test_parity_gemma4_e2b(t : T?) {
     t |> run("gemma4 forward (gemma-4-E2B-it Q8: PLE + KV sharing + per-layer FFN width)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-4-E2B-it-Q8_0.gguf")
@@ -595,7 +599,7 @@ def private gptoss_counting_prompt() : string {
 def test_parity_gptoss_20b(t : T?) {
     t |> run("gpt-oss forward (gpt-oss-20b native-MXFP4 experts, sinks + YaRN + MoE biases; short + window-engaged)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gpt-oss-20b-mxfp4.gguf")

--- a/tests/dasLLAMA/test_prefill.das
+++ b/tests/dasLLAMA/test_prefill.das
@@ -98,11 +98,11 @@ def check_continuation(t : T?; tr : Model; prompt : array<int64>; split : int64;
 def test_prefill_fp32(t : T?) {
     t |> run("prefill == N× forward, fp32 (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
@@ -123,11 +123,11 @@ def test_prefill_fp32(t : T?) {
 def test_prefill_q8(t : T?) {
     t |> run("prefill == N× forward, Q8 (needs stories15M.bin)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!stat(MODEL_PATH).is_valid || !stat(TOKENIZER_PATH).is_valid) {
-            t |> success(true, "skipped: stories15M.bin not present")
+            t |> skip("stories15M.bin not present")
             return
         }
         // bit-exactness across forward_batch (batch tile) and forward (GEMV) needs same-dot

--- a/tests/dasLLAMA/test_sampling.das
+++ b/tests/dasLLAMA/test_sampling.das
@@ -43,12 +43,12 @@ def private same(a, b : array<int64>) : bool {
 def test_sampling_greedy_matches_oracle(t : T?) {
     t |> run("greedy sampling generate reproduces the gemma2 oracle") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-2-2b-it-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_model(path, QuantMode.q8)
@@ -79,12 +79,12 @@ def test_sampling_greedy_matches_oracle(t : T?) {
 def test_sampling_deterministic(t : T?) {
     t |> run("same seed => identical sampled output") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(models_dir(), "gemma-2-2b-it-Q8_0.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         var m <- load_model(path, QuantMode.q8)

--- a/tests/dasLLAMA/test_tokenizer.das
+++ b/tests/dasLLAMA/test_tokenizer.das
@@ -70,7 +70,7 @@ def test_tokenizer_gemma4(t : T?) {
     t |> run("gemma4 SPM-style BPE vs the llama.cpp corpus") @(t : T?) {
         let path = path_join(models_dir(), "ggml-vocab-gemma-4.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         corpus_gate(t, path)
@@ -82,7 +82,7 @@ def test_tokenizer_llama_bpe(t : T?) {
     t |> run("llama3 byte-level BPE vs the llama.cpp corpus") @(t : T?) {
         let path = path_join(models_dir(), "ggml-vocab-llama-bpe.gguf")
         if (!stat(path).is_valid) {
-            t |> success(true, "skipped: {path} not present")
+            t |> skip("{path} not present")
             return
         }
         corpus_gate(t, path)

--- a/tests/dasLLAMA/test_vad.das
+++ b/tests/dasLLAMA/test_vad.das
@@ -94,7 +94,7 @@ def test_vad_segments_jfk(t : T?) {
         let wav = "{samples_dir()}/jfk.wav"
         let samples <- read_wav_pcm16_mono(wav)
         if (empty(samples)) {
-            t |> success(true, "skipped: jfk.wav not present in DASLLAMA_MODELS_DIR")
+            t |> skip("jfk.wav not present in DASLLAMA_MODELS_DIR")
             return
         }
         // silero get_speech_timestamps defaults, sample indices (harness/silero_segment_oracle.py)

--- a/tests/dasLLAMA/test_whisper.das
+++ b/tests/dasLLAMA/test_whisper.das
@@ -288,14 +288,14 @@ def test_asr_surface(t : T?) {
 def test_qwen3a_tower(t : T?) {
     t |> run("qwen3a tower: conv2d frontend + windowed encode matches mtmd on jfk") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(samples_dir(), "mmproj-Qwen3-ASR-0.6B-bf16.gguf")
         if (!model_available(t, path)) return
         let samples <- read_wav_pcm16_mono(path_join(samples_dir(), "jfk.wav"))
         if (length(samples) == 0) {
-            t |> success(true, "skipped: jfk.wav not present")
+            t |> skip("jfk.wav not present")
             return
         }
         var tw <- load_qwen3a_tower(path)
@@ -330,14 +330,14 @@ def test_qwen3a_tower(t : T?) {
 def test_parakeet_oracle(t : T?) {
     t |> run("parakeet-TDT greedy on jfk.wav is token-for-token with parakeet-cli") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(whisper_models_dir(), "ggml-parakeet-tdt-0.6b-v2-f32.bin")
         if (!model_available(t, path)) return
         let samples <- read_wav_pcm16_mono(path_join(samples_dir(), "jfk.wav"))
         if (length(samples) == 0) {
-            t |> success(true, "skipped: jfk.wav not present")
+            t |> skip("jfk.wav not present")
             return
         }
         // through the uniform ASR surface: the sniff routes a small-vocab ggml bin to parakeet
@@ -393,14 +393,14 @@ def test_parakeet_oracle(t : T?) {
 def test_parakeet_v3_oracle(t : T?) {
     t |> run("parakeet-TDT v3 (25-lang) greedy on jfk.wav is token-for-token with parakeet-cli") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let path = path_join(whisper_models_dir(), "ggml-parakeet-tdt-0.6b-v3-f32.bin")
         if (!model_available(t, path)) return
         let samples <- read_wav_pcm16_mono(path_join(samples_dir(), "jfk.wav"))
         if (length(samples) == 0) {
-            t |> success(true, "skipped: jfk.wav not present")
+            t |> skip("jfk.wav not present")
             return
         }
         // the 8192-piece SPM vocab routes to parakeet AND flips the multilingual caps
@@ -436,14 +436,14 @@ def test_parakeet_v3_oracle(t : T?) {
 def test_whisper_transcribe_oracle(t : T?) {
     t |> run("tiny greedy on jfk.wav is token-for-token with whisper-cli") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let model_path = path_join(whisper_models_dir(), "ggml-tiny.bin")
         if (!model_available(t, model_path)) return
         let samples <- read_wav_pcm16_mono(path_join(samples_dir(), "jfk.wav"))
         if (length(samples) == 0) {
-            t |> success(true, "skipped: jfk.wav not present")
+            t |> skip("jfk.wav not present")
             return
         }
         var w <- load_whisper_model(model_path)
@@ -512,14 +512,14 @@ def test_whisper_transcribe_oracle(t : T?) {
 def test_whisper_q8_gate(t : T?) {
     t |> run("tiny q8 tower (the load_asr_model default) stays token-identical to fp32 on jfk") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let model_path = path_join(whisper_models_dir(), "ggml-tiny.bin")
         if (!model_available(t, model_path)) return
         let samples <- read_wav_pcm16_mono(path_join(samples_dir(), "jfk.wav"))
         if (length(samples) == 0) {
-            t |> success(true, "skipped: jfk.wav not present")
+            t |> skip("jfk.wav not present")
             return
         }
         var m <- load_asr_model(model_path)     // the asr-surface default: q8 tower
@@ -567,7 +567,7 @@ def test_whisper_q8_gate(t : T?) {
 def private check_canary_clip(t : T?; m : AsrModel; wav : string; expected : array<int>) {
     let samples <- read_wav_pcm16_mono(wav)
     if (empty(samples)) {
-        t |> success(true, "skipped: {base_name(wav)} not present")
+        t |> skip("{base_name(wav)} not present")
         return
     }
     var s <- create_session(m, "en")
@@ -587,11 +587,11 @@ def private check_canary_clip(t : T?; m : AsrModel; wav : string; expected : arr
 def test_canary_qwen_oracle(t : T?) {
     t |> run("Canary-Qwen 2.5B greedy is token-for-token with the NeMo SALM oracle") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!parity_full_mode()) {   // ~6.7 GB two-file (decoder GGUF + f32 encoder bin) — large-tier
-            t |> success(true, "skipped: canary-qwen is large-tier — set DASLLAMA_PARITY_FULL=1 to run")
+            t |> skip("canary-qwen is large-tier — set DASLLAMA_PARITY_FULL=1 to run")
             return
         }
         let dec = path_join(samples_dir(), "canary-qwen-2.5b-decoder-f16.gguf")
@@ -633,7 +633,7 @@ def test_canary_qwen_oracle(t : T?) {
 def test_gemma4a_audio_oracle(t : T?) {
     t |> run("Gemma-4 E2B audio greedy is token-for-token with llama-mtmd-cli (confident prefix)") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         let dec = path_join(samples_dir(), "gemma-4-E2B-it-Q8_0.gguf")
@@ -649,9 +649,9 @@ def test_gemma4a_audio_oracle(t : T?) {
         let wav = path_join(corpus_dir(), "gemma4a_test2.wav")
         let samples <- read_wav_pcm16_mono(wav)
         if (empty(samples)) {
-            t |> success(true, "skipped: gemma4a_test2.wav not present")
-            delete m.dec.wblob
+            delete m.dec.wblob   // free the weights BEFORE the skip — skip unwinds the arm
             delete m.g4a.blob
+            t |> skip("gemma4a_test2.wav not present")
             return
         }
         with_job_que() {
@@ -690,7 +690,7 @@ def test_gemma4a_audio_oracle(t : T?) {
 def private check_q3omni_clip(t : T?; m : AsrModel; wav : string; expected : array<int>) {
     let samples <- read_wav_pcm16_mono(wav)
     if (empty(samples)) {
-        t |> success(true, "skipped: {base_name(wav)} not present")
+        t |> skip("{base_name(wav)} not present")
         return
     }
     var s <- create_session(m, "auto")
@@ -715,11 +715,11 @@ def private check_q3omni_clip(t : T?; m : AsrModel; wav : string; expected : arr
 def test_qwen3omni_audio_oracle(t : T?) {
     t |> run("Qwen3-Omni-30B greedy audio transcription is token-for-token with llama-mtmd-cli") @(t : T?) {
         if (!jit_enabled()) {
-            t |> success(true, "skipped: interpreted (dasLLAMA model tests are JIT-only)")
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
         if (!parity_full_mode()) {   // ~34 GB (Q8 thinker + bf16 mmproj) — large-tier
-            t |> success(true, "skipped: Qwen3-Omni-30B is large-tier — set DASLLAMA_PARITY_FULL=1 to run")
+            t |> skip("Qwen3-Omni-30B is large-tier — set DASLLAMA_PARITY_FULL=1 to run")
             return
         }
         let dec = path_join(samples_dir(), "Qwen3-Omni-30B-A3B-Instruct-Q8_0.gguf")

--- a/tests/dasLLAMA/test_whisper.das
+++ b/tests/dasLLAMA/test_whisper.das
@@ -649,7 +649,7 @@ def test_gemma4a_audio_oracle(t : T?) {
         let wav = path_join(corpus_dir(), "gemma4a_test2.wav")
         let samples <- read_wav_pcm16_mono(wav)
         if (empty(samples)) {
-            delete m.dec.wblob   // free the weights BEFORE the skip — skip unwinds the arm
+            delete m.dec.wblob
             delete m.g4a.blob
             t |> skip("gemma4a_test2.wav not present")
             return


### PR DESCRIPTION
Finishes the f16 weight-scale rail (stages 3+4 of the #3432 plan) and makes model-gated test skips honest — which is how two dastest landmines got found and defused.

## wscale_f16: stage 3 + default flip

- **Neon hand-backend twins**: `dot_q8q8_sdot4x4_f16s` + the five `arm64-sdot` slot twins (row-major plane), and `dot_q8q8_laneq4_f16s` (grp4 interleaved) — the gen backend's s16 stub reference bodies upgrade from the scalar walk to the laneq dots, so the arm64 decline rail keeps the fast grp4 reference pair on both planes. Every registered backend (portable / arm64-sdot / arm64-gen / x64-gen) now carries the s16 slots.
- **Default ON**: gguf-q8 scales stay bit-identical (f16→f32→f16 round-trips exactly), weight traffic drops 2 bytes per 32 weights (−5.6% of dense-q8 decode reads). The loader still falls back to f32 with a warning on a twin-less backend; `decode_prof --wscale-f16 0` is the A/B rail.

Gates: 4-arm probes — (per-op | fused) × (f32 | f16) — greedy ids + logits **bit-identical** on x64-gen and portable (3990X) and on arm64-gen, arm64-sdot and portable (M1); M1 gemma-3-4b no-flag anchor +5.4/+5.0% vs `--wscale-f16 0` (the llama.cpp-parity result from #3432, now the default); fused suite 10/10 under the flip. One flip regression caught by the suite and fixed: `test_parity`'s tied-cls arm read the freed f32 plane.

## dastest: loud skips (and the two landmines they exposed)

Two real x64 failures hid for months behind model-gated tests that "passed" in microseconds when the model was absent. (The pair itself — `test_batch_decode_q8_kv` + a `test_chat` arm — no longer reproduces on this tree: 3 clean armed runs; #3432's decode/batch score alignment is the prime suspect.)

- `t |> skip(msg)` becomes a real free function: prints the reason, lands the arm in the suite's **skipped** count. All 105 arm-fatal `success(true, "skipped: ...")` sites in `tests/dasLLAMA` convert (2 deliberate exceptions: the fused multi-model `continue` loop, and whisper's cleanup-before-skip).
- **Landmine 1 — `T.skipNow`'s panic from AOT-compiled test frames corrupts state at volume** (same-address AV after dozens of skips, position drifting with timing). The pipe-form skip therefore does NOT unwind — every call site is the `skip; return` shape. The suite recover still propagates a direct `skipNow` unwind as a skip instead of an error.
- **Landmine 2 — the `onLog` handoff corrupts from AOT frames**: the handler executes under the TEST context and grows dastest-stack-owned arrays (`testMessages` push → buffer realloc on the wrong heap) — the classic cross-context allocation. Bisect-proven with fresh full-regen stubs per step: master green → stage3+flip green → old-tests+new-dastest green → flag-only skip green → skip-with-logAt crash. The skip prints via `to_log` directly; the onLog seam remains latent for high-volume *failure* logging from AOT tests — flagging it here for a follow-up discussion.

Suite states: no-models 285 passed / 81 skipped (was 366 fake-passed); armed JIT 324/42/0; armed AOT 299/67/0; whole `tests/` under AOT 11013 tests, 10926 passed, 0 failed, 87 skipped; jobque 208/208, flatten 277/277 under the modified dastest; full preflight 13 passed / 0 failed (token minted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)