### PR TITLE
CI: test_aot_subset as the per-PR AOT gate; full test_aot moves to nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,20 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Nightly: runs the heavy Windows toolchain builds (mingw, clang-cl) that are
-    # gated OFF per-PR/push CI below — see their `if:`. The matrix / bundle_smoke /
-    # gcc jobs are gated off `schedule`, so the nightly cron runs just the two
-    # toolchains (plus the lightweight `pre_job` setup they depend on). A manual
-    # `workflow_dispatch` is NOT gated off — it runs the FULL workflow: every
-    # per-PR job AND both toolchains.
-    - cron: '0 8 * * *'
+    # Nightly: runs everything the per-PR lanes deliberately skip —
+    #  * the heavy Windows toolchain builds (mingw, clang-cl), gated OFF per-PR
+    #    below (see their `if:`), including their FULL AOT sweeps;
+    #  * the main matrix (Release cells carry the FULL test_aot build + AOT
+    #    suite — "Slow Release Tests"; Debug cells ride along, matrix can't be
+    #    filtered in a job-level `if`). Per-PR CI only builds test_aot_subset
+    #    (tests/language, part of ALL) as a compile+link gate and runs no AOT
+    #    tests at all.
+    # bundle_smoke / gcc stay per-PR-only. A manual `workflow_dispatch` runs
+    # the FULL workflow: every per-PR job, both toolchains, and the full AOT
+    # suite.
+    # 02:00 UTC: dead time for EU working hours — the nightly is ~11 jobs and
+    # must not compete with daytime PR lanes for runners.
+    - cron: '0 2 * * *'
 defaults:
   run:
     shell: bash
@@ -51,9 +58,17 @@ jobs:
   build:
   ###########################################################
     needs: pre_job
-    # Per-PR/push lane (also runs on manual `workflow_dispatch`); skipped only on
-    # the nightly `schedule` cron, when just the toolchain jobs run.
-    if: needs.pre_job.outputs.should_skip != 'true' && github.event_name != 'schedule'
+    # Per-PR/push lane (also on manual `workflow_dispatch`). On the nightly
+    # `schedule` cron the matrix runs too — the Release cells carry the full
+    # AOT suite (see "Slow Release Tests") — unconditionally on the canonical
+    # repo (no pre_job skip: master unchanged overnight must still produce the
+    # nightly AOT signal). Debug cells ride along at night without an AOT step;
+    # `matrix` context is not available in a job-level `if`, so they can't be
+    # excluded here (actions runs with a matrix clause fail as a workflow-file
+    # error before any job spawns).
+    if: >-
+      (github.event_name == 'schedule' && github.repository == 'GaijinEntertainment/daScript')
+      || (github.event_name != 'schedule' && needs.pre_job.outputs.should_skip != 'true')
     runs-on: ${{ matrix.runner }}
     # actions: write needed for `gh cache delete` in the sccache refresh step.
     permissions:
@@ -519,7 +534,11 @@ jobs:
             ;;
         esac
     - name: "Slow Release Tests"
-      if: matrix.cmake_preset == 'Release'
+      # Full AOT suite: builds the full test_aot (EXCLUDE_FROM_ALL, ~1080 AOT
+      # TUs — the single biggest CI cost) via the run_tests_aot dependency and
+      # sweeps all of tests/. Nightly + manual dispatch only; per-PR lanes get
+      # the test_aot_subset compile+link gate from the Build step instead.
+      if: matrix.cmake_preset == 'Release' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       run: |
         set -eux
         case "${{ matrix.target }}${{ matrix.architecture }}" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ For path/filename ops use `fio` helpers (`base_name`/`dir_name`/`path_join`/etc.
 Most layout is obvious from `ls`. Non-obvious ones worth knowing:
 
 - `daslib/aot_cpp.das` — AOT C++ emitter lives here, NOT in C++ (`src/ast/ast_aot_cpp.cpp` was deleted; only the header remains)
-- `tests/aot/CMakeLists.txt` — register new test directories here for AOT compilation
+- `tests/aot/CMakeLists.txt` — register new test directories here for AOT compilation. Two AOT binaries: `test_aot_subset` (tests/language only, in ALL — the per-PR CI compile gate) and full `test_aot` (`EXCLUDE_FROM_ALL`, ~1080 AOT TUs — nightly CI + `preflight --full` only, via `--target test_aot`/`run_tests_aot`)
 - `dastest/` — test framework (used by both `tests/` and external repos)
 - `utils/detect-dupe/` (in-repo dupe finder) and `utils/find-dupe/` (Claude-based judge that needs `daspkg install --root utils/find-dupe` + `ANTHROPIC_API_KEY`) — both also exposed as MCP tools
 - `utils/mcp/`, `utils/daslang-live/`, `utils/daspkg/` — in-tree tools (most also have skills under `skills/`)

--- a/skills/aot_testing.md
+++ b/skills/aot_testing.md
@@ -30,6 +30,15 @@ Key helpers used by the emitter:
 
 `tests/aot/CMakeLists.txt` defines the `test_aot` executable — a standalone binary with AOT stubs compiled in. It uses the same `main.cpp` as `daslang` but links additional AOT-generated object files.
 
+**Two binaries since 2026-07:**
+
+| Binary | Contents | In default build (ALL)? | Who builds/runs it |
+|---|---|---|---|
+| `test_aot_subset` | `tests/language` + its `_*` fixtures + `dastest/testing.das` + the minimal daslib runtime closure (`AOT_SUBSET_DASLIB_MODULE_FILES` — random/regex/faker/fuzzer/coroutines/archive/strings_boost etc., ~15 small files; a language test requiring another runtime daslib module fails 50101 → extend that list) — ~230 AOT TUs total | YES — every CI lane, Debug included | Per-PR CI, as a **compile+link gate only** (no AOT test run on PRs); locally via `run_tests_aot_subset` |
+| `test_aot` | everything (~1080 AOT TUs) | NO — `EXCLUDE_FROM_ALL` | Nightly CI cron (all Release matrix lanes incl. sanitizers, plus mingw/clang-cl) and `preflight --full`, both via `--target test_aot` / `run_tests_aot` |
+
+Neither binary uses LTO (the full binary's LTCG link alone was ~21 min on MSVC CI). Consequence: **an AOT regression outside `tests/language` does NOT fail PR CI** — it's caught by local `preflight --full` before push, or by the nightly.
+
 ### Structure
 
 ```
@@ -77,7 +86,7 @@ The `-use-aot` flag enables AOT for sub-compiled test files even when the host b
 
 ## Adding Tests to AOT — CRITICAL
 
-**Every test directory under `tests/` must be registered in `tests/aot/CMakeLists.txt`**. The `test_aot` binary (built on Linux/macOS CI) runs ALL tests under `tests/` with AOT enabled. If a test directory's AOT stubs aren't generated and linked, `test_aot` will fail with `error[50101]: AOT link failed`.
+**Every test directory under `tests/` must be registered in `tests/aot/CMakeLists.txt`**. The full `test_aot` binary (nightly CI + `preflight --full`) runs ALL tests under `tests/` with AOT enabled. If a test directory's AOT stubs aren't generated and linked, `test_aot` will fail with `error[50101]: AOT link failed`. PR CI won't catch the missing registration (it only builds the `tests/language` subset) — the nightly and preflight will, so register up front.
 
 This applies to ALL test directories (e.g., `tests/fio/`, `tests/fs/`, `tests/json/`), not just `tests/aot/`. See the "Registering a New Test Directory" section below.
 

--- a/skills/build_and_debug.md
+++ b/skills/build_and_debug.md
@@ -18,8 +18,8 @@ The repo builds on **Windows, Linux, macOS, iOS, Android, and WASM** (CI runs th
 - **Run a script:** `<daslang-binary> path/to/script.das`
 - **Compile-only check:** `<daslang-binary> -compile-only path/to/script.das` — compiles without simulation or execution, useful for syntax/type checking without needing a window or GL context. Use `-dry-run` to also simulate (but not execute).
 - **Run tests:** `<daslang-binary> dastest/dastest.das -- --test path/to/test.das`
-- **AOT tests:** `cmake --build build --config Release --target test_aot` then `<test_aot-binary> -use-aot dastest/dastest.das -- --use-aot --test tests`
-- **IMPORTANT:** When adding a new test directory under `tests/`, register it in `tests/aot/CMakeLists.txt` for AOT compilation. See `skills/aot_testing.md` for the step-by-step pattern. CI runs ALL tests with AOT enabled — unregistered test directories cause `error[50101]: AOT link failed`
+- **AOT tests (full):** `cmake --build build --config Release --target test_aot` then `<test_aot-binary> -use-aot dastest/dastest.das -- --use-aot --test tests`. The full binary is `EXCLUDE_FROM_ALL` (~1080 AOT TUs); the default build only makes `test_aot_subset` (tests/language — the per-PR CI gate; `--target run_tests_aot_subset` sweeps it)
+- **IMPORTANT:** When adding a new test directory under `tests/`, register it in `tests/aot/CMakeLists.txt` for AOT compilation. See `skills/aot_testing.md` for the step-by-step pattern. The nightly CI + `preflight --full` run ALL tests with AOT enabled — unregistered test directories cause `error[50101]: AOT link failed` there (per-PR CI won't catch it)
 
 This skill uses `bin/Release/daslang.exe` in examples below (the dominant local-dev case); substitute the right path on other platforms.
 

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -199,7 +199,7 @@ taskkill /F /IM mcp.exe 2>/dev/null
 cmake --build build --config Release --target test_aot -j 64 -- /nodeReuse:false
 
 # Run AOT tests (must match CI: -use-aot before --, --use-aot after --)
-bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 900 --test tests
+bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 1800 --test tests
 ```
 
 Use `timeout: 0` (no timeout) for the cmake build — it can take 2-25 minutes.
@@ -342,7 +342,7 @@ Stage, commit, push, and create the PR using GitHub MCP tools or `gh` CLI. Follo
 | JIT smoke | `daslang.exe -jit <test>.das 2>&1 \| grep -iE "verifier\|Both operands"` | Empty output = pass. Windows `clang-cl` link fail is local-only, ignore |
 | Type-system/generics | sequence smoke (`skills/preflight.md`) + externals sweep (`skills/abi_break_sweep.md`) | Only for type-system / AST-layout / daslib-generics changes |
 | AOT build | `cmake --build build --config Release --target test_aot -j 64` | Kill daslang first. Register new test dirs |
-| AOT tests | `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` | Same as regular tests |
+| AOT tests | `test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests` | Same as regular tests. PR CI only builds the tests/language subset (`test_aot_subset`) — this local full gate + the nightly cron are the only full-AOT checks |
 | Docs | `das2rst.das` (loop until clean) + stubs + Uncategorized + untracked + Sphinx latex AND html | Any daslib/src-builtin/RST change triggers all seven gates — `skills/preflight.md` |
 | Format | MCP `format_file` with comma-separated list or glob of changed `.das` files (single call) | Only changed files |
 | `.md` stop | `git diff --name-only origin/master..HEAD \| grep '\.md$'` | If any match: STOP, list changes, ask user to review BEFORE push |

--- a/skills/preflight.md
+++ b/skills/preflight.md
@@ -28,26 +28,32 @@ the CI ref, never a working-tree copy.
 | Workflow | Trigger | Jobs |
 |---|---|---|
 | `build.yml` (per-PR) | every PR commit (via `pull_request`) + pushes to `master` | `build` matrix (5 targets × Debug/Release/RelWithDebInfo × sanitizers), `bundle_smoke`, `build_linux_gcc` |
-| `build.yml` (nightly) | the `schedule` cron (daily 08:00 UTC) runs these two *in isolation* | `build_windows_mingw`, `build_windows_clangcl` — the two ~26-min toolchain long-poles, gated OFF per-PR CI (alt-toolchain, lowest per-PR signal). A break here surfaces within ~24 h, not at PR time. |
+| `build.yml` (nightly) | the `schedule` cron (daily 02:00 UTC) | `build_windows_mingw` + `build_windows_clangcl` (the two toolchain long-poles, gated OFF per-PR CI — alt-toolchain, lowest per-PR signal) **plus the full build matrix — its Release cells (sanitizers included) run the full AOT sweep** ("Slow Release Tests"). A break in any of these surfaces within ~24 h, not at PR time. |
 | `extended_checks.yml` | every PR | linux + darwin15-arm64 + windows, ALL release modules ON |
 | `wasm_build.yml` | every PR | emscripten build of `web/` on 3 OSes + `wasm_cross` |
 | `build_eastl.yml` | every PR | EASTL shadow-config build + no-fileio build (linux clang) |
 | `doc.yml` | only if `doc/**`, `daslib/**`, or `src/builtin/**` changed | seven doc gates |
 | `playground-e2e.yml` | only if `site/**` / `web/examples/ui/**` changed | Playwright on the web playground |
 
-> A manual **`workflow_dispatch`** of `build.yml` runs the **whole** workflow — every per-PR job *and* both nightly toolchains. Only the cron `schedule` runs the two toolchains alone (the per-PR jobs are gated off `schedule`).
+> A manual **`workflow_dispatch`** of `build.yml` runs the **whole** workflow — every per-PR job, both nightly toolchains, *and* the full AOT sweep. The cron `schedule` runs the two toolchains + the full build matrix (Release cells add the full AOT sweep; Debug cells ride along — `matrix` isn't available in a job-level `if`, so they can't be excluded); `bundle_smoke` and `build_linux_gcc` are gated off `schedule`.
 
 ## build.yml — the build matrix
 
 Per-lane steps: build → JIT prewarm → JIT test sweep → interpreter sweep →
-`ctest -L small` → AOT sweep (Release lanes only).
+`ctest -L small`. The full AOT sweep runs on the NIGHTLY cron and on manual
+`workflow_dispatch` runs only (Release
+lanes incl. sanitizers + mingw/clang-cl); per-PR lanes just build
+`test_aot_subset` (tests/language, part of ALL) as a compile+link gate and run
+no AOT tests. **`preflight --full`'s full AOT gate is therefore the only
+pre-push check for AOT regressions outside tests/language — don't skip it.**
 
 | CI step | Local mirror | Notes |
 |---|---|---|
-| Interpreter sweep | `<daslang> dastest/dastest.das -- --color --failures-only --timeout 900 --test tests` | |
-| JIT sweep | `<daslang> dastest/dastest.das -jit -- --jit-opt-level=3 --color --failures-only --timeout 900 --test tests` | Windows-local `clang-cl` link failures are env noise — the catchable class is LLVM verifier errors; full end-to-end JIT needs WSL/mac. See `skills/make_pr.md` §2.5 for the 2-test smoke version |
+| Interpreter sweep | `<daslang> dastest/dastest.das -- --color --failures-only --timeout 1800 --test tests` | |
+| JIT sweep | `<daslang> dastest/dastest.das -jit -- --jit-opt-level=3 --color --failures-only --timeout 1800 --test tests` | Windows-local `clang-cl` link failures are env noise — the catchable class is LLVM verifier errors; full end-to-end JIT needs WSL/mac. See `skills/make_pr.md` §2.5 for the 2-test smoke version |
 | Small C++ tests | `ctest --test-dir build --build-config Release -L small --output-on-failure` | drop `--build-config` on single-config generators. **Run this after touching `tests-cpp/`** — and remember MSVC tolerates C++ that clang/gcc reject (the doctest bit-field incident); see `skills/writing_cpp_tests.md` |
-| AOT sweep | `cmake --build build --config Release --target test_aot`, then `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 900 --test tests` | Release lanes only in CI |
+| AOT sweep (full) | `cmake --build build --config Release --target test_aot`, then `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 1800 --test tests` | nightly CI + manual `workflow_dispatch` only — this local mirror is the only pre-push gate for it |
+| AOT subset gate | `cmake --build build --config Release --target test_aot_subset` (optionally `--target run_tests_aot_subset` to also sweep tests/language) | what per-PR CI lanes actually build (part of ALL) |
 | Debug lanes | `cmake --build build --config Debug --target daslang`, then the sweep against `bin/Debug/daslang.exe` — safe in-checkout: Debug coexists with Release by design (`bin/Debug/`, `_debug.shared_module` suffix) | Debug bypasses the fused interpreter permutations — a fix that lands only in the fused path passes Release everywhere and trips Debug; conversely fused-path bugs need Release. If you touched `src/simulate/simulate_fusion_*`, run both configs |
 | Sanitizer lanes (linux Release asan/tsan/ubsan) | WSL: `CC=clang CXX=clang++ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DDAS_USE_SANITIZER=<asan\|tsan\|ubsan>`, then the JIT sweep on `tests/language` | not mirrorable on Windows/mac. CI applies LSan suppressions (`format_error`, `uriParseSingleUriA`, `uriMakeOwner`) — see the workflow's Test step |
 | linux_arm / darwin lanes | mac: same commands as linux. From Windows: not mirrorable | ARM-specific reds (LLVM SelectionDAG, alignment) are CI-only signals |

--- a/skills/writing_tests.md
+++ b/skills/writing_tests.md
@@ -4,10 +4,12 @@ Tests use the `dastest` framework. Test files live in `tests/` with per-module s
 
 ## AOT registration (REQUIRED for new test directories)
 
-CI's `test_aot` binary runs EVERY test under `tests/` with AOT enabled (`fail_on_no_aot`).
-Creating a new test directory ⇒ register it in `tests/aot/CMakeLists.txt` (5-step pattern in
-`skills/aot_testing.md` § "Registering a New Test Directory"), or CI fails with
-`error[50101]: AOT link failed`.
+The full `test_aot` binary runs EVERY test under `tests/` with AOT enabled (`fail_on_no_aot`).
+It builds+runs on the NIGHTLY CI cron and in `preflight --full` — per-PR CI only builds the
+`tests/language` subset (`test_aot_subset`) as a compile gate, so a missing registration
+passes PR CI and fails the nightly. Creating a new test directory ⇒ register it in
+`tests/aot/CMakeLists.txt` (5-step pattern in `skills/aot_testing.md` § "Registering a New
+Test Directory"), or the nightly/preflight fails with `error[50101]: AOT link failed`.
 
 If a specific file genuinely can't AOT (emitter bug, interpreted-only by design): put
 `options no_aot` IN THE FILE **and** exclude it from the directory's AOT glob, with a

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,11 +54,25 @@ if(NOT DAS_TOOLS_DISABLED)
 endif()
 
 # test_aot only exists when tests + AOT examples are enabled (tests/aot/CMakeLists.txt).
+# The full binary is EXCLUDE_FROM_ALL; this target builds it on demand (nightly CI,
+# preflight --full).
 if(TARGET test_aot)
     add_custom_target(run_tests_aot
         COMMAND $<TARGET_FILE:test_aot> -use-aot ${PROJECT_SOURCE_DIR}/dastest/dastest.das -- --use-aot --color --failures-only --timeout 1800 --test ${PROJECT_SOURCE_DIR}/tests
         DEPENDS test_aot
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Running tests (AOT)"
+    )
+endif()
+
+# Fast AOT run over tests/language only, against the subset binary that per-PR
+# CI already builds as part of ALL. For local/debug use — PR CI treats the
+# subset build itself as the gate and runs no AOT tests.
+if(TARGET test_aot_subset)
+    add_custom_target(run_tests_aot_subset
+        COMMAND $<TARGET_FILE:test_aot_subset> -use-aot ${PROJECT_SOURCE_DIR}/dastest/dastest.das -- --use-aot --color --failures-only --timeout 1800 --test ${PROJECT_SOURCE_DIR}/tests/language
+        DEPENDS test_aot_subset
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMENT "Running tests (AOT, tests/language subset)"
     )
 endif()

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -551,6 +551,29 @@ list(FILTER AOT_LANGUAGE_TEST_FILES EXCLUDE REGEX "failed_|cant_|invalid_")
 # Exclude module files (they are compiled via DAS_AOT_LIB below)
 list(FILTER AOT_LANGUAGE_TEST_FILES EXCLUDE REGEX "/_")
 
+# Minimal daslib closure for test_aot_subset: ONLY the daslib modules whose
+# runtime functions tests/language actually calls (50101 otherwise). This is
+# NOT the all-daslib coverage lib above — keep it minimal; a new tests/language
+# test requiring another runtime daslib module extends this list. Leaf-first.
+SET(AOT_SUBSET_DASLIB_MODULE_FILES
+    daslib/math_bits.das
+    daslib/random.das
+    daslib/defer.das
+    daslib/strings_boost.das
+    daslib/enum_trait.das
+    daslib/regex.das
+    daslib/regex_boost.das
+    daslib/static_let.das
+    daslib/faker.das
+    daslib/fuzzer.das
+    daslib/coroutines.das
+    daslib/contracts.das
+    daslib/apply.das
+    daslib/templates.das
+    daslib/rtti.das
+    daslib/archive.das
+)
+
 # Language test module files (libraries required by tests)
 SET(AOT_LANGUAGE_MODULE_FILES
     tests/language/_distinct_fixture.das
@@ -924,6 +947,10 @@ add_custom_target(test_aot_language_modules)
 SET(LANGUAGE_MODULES_AOT_GENERATED_SRC)
 DAS_AOT_LIB("${AOT_LANGUAGE_MODULE_FILES}" LANGUAGE_MODULES_AOT_GENERATED_SRC test_aot_language_modules daslang)
 
+add_custom_target(test_aot_subset_daslib_modules)
+SET(SUBSET_DASLIB_MODULES_AOT_GENERATED_SRC)
+DAS_AOT_LIB("${AOT_SUBSET_DASLIB_MODULE_FILES}" SUBSET_DASLIB_MODULES_AOT_GENERATED_SRC test_aot_subset_daslib_modules daslang)
+
 add_custom_target(test_aot_daslib)
 SET(DASLIB_AOT_GENERATED_SRC)
 DAS_AOT("${AOT_DASLIB_TEST_FILES}" DASLIB_AOT_GENERATED_SRC test_aot_daslib daslang)
@@ -1023,6 +1050,7 @@ SOURCE_GROUP_FILES("aot generated" SPIRV_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" SPIRV_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" LANGUAGE_MODULES_AOT_GENERATED_SRC)
+SOURCE_GROUP_FILES("aot generated" SUBSET_DASLIB_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASLIB_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DECS_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASLIB_AOT_GENERATED_SRC)
@@ -1041,8 +1069,12 @@ SOURCE_GROUP_FILES("aot generated" PUGIXML_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASHV_MODULES_AOT_GENERATED_SRC)
 SOURCE_GROUP_FILES("aot generated" DASHV_AOT_GENERATED_SRC)
 
-# Build the test_aot executable using the same main.cpp as daslang
-add_executable(test_aot ${DAS_DASCRIPT_MAIN_SRC}
+# Build the test_aot executable using the same main.cpp as daslang.
+# EXCLUDE_FROM_ALL: the full binary (~1080 AOT TUs + heavy link) is built only
+# where it's explicitly requested — the nightly CI cron and `preflight --full`
+# (both via `--target test_aot` / `--target run_tests_aot`). Per-PR CI builds
+# test_aot_subset below instead.
+add_executable(test_aot EXCLUDE_FROM_ALL ${DAS_DASCRIPT_MAIN_SRC}
     ${TEST_AOT_GENERATED_SRC}
     ${TESTING_AOT_GENERATED_SRC}
     ${ALGORITHM_AOT_GENERATED_SRC}
@@ -1180,7 +1212,34 @@ ADD_DEPENDENCIES(test_aot libDaScriptAot
     test_aot_mcp
     test_aot_lsp
 )
-target_include_directories(test_aot PRIVATE ${NEED_MODULES_PATH} ${PROJECT_SOURCE_DIR}/modules/dasUnitTest ${PROJECT_SOURCE_DIR}/modules/dasLiveHost/src ${AUDIO_INCLUDE_DIR} ${CIPIC_HRTF_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/modules/dasMinfft/minfft ${PROJECT_SOURCE_DIR}/modules/dasPUGIXML/pugixml ${PROJECT_SOURCE_DIR}/modules/dasHV/hv/$<CONFIG>/include ${SQLITE_INCLUDE_DIR})
-target_compile_definitions(test_aot PRIVATE DAS_TEST_AOT MINFFT_SINGLE HRTF_SAMPLE_RATE=${DAS_AUDIO_SAMPLE_RATE})
+# Shared between test_aot and test_aot_subset — the two binaries MUST compile
+# main.cpp identically (a define present on one but not the other silently
+# changes module registration between the per-PR gate and the nightly binary).
+SET(TEST_AOT_INCLUDE_DIRS ${NEED_MODULES_PATH} ${PROJECT_SOURCE_DIR}/modules/dasUnitTest ${PROJECT_SOURCE_DIR}/modules/dasLiveHost/src ${AUDIO_INCLUDE_DIR} ${CIPIC_HRTF_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/modules/dasMinfft/minfft ${PROJECT_SOURCE_DIR}/modules/dasPUGIXML/pugixml ${PROJECT_SOURCE_DIR}/modules/dasHV/hv/$<CONFIG>/include ${SQLITE_INCLUDE_DIR})
+SET(TEST_AOT_COMPILE_DEFS DAS_TEST_AOT MINFFT_SINGLE HRTF_SAMPLE_RATE=${DAS_AUDIO_SAMPLE_RATE})
+
+target_include_directories(test_aot PRIVATE ${TEST_AOT_INCLUDE_DIRS})
+target_compile_definitions(test_aot PRIVATE ${TEST_AOT_COMPILE_DEFS})
 SETUP_CPP11(test_aot)
-SETUP_LTO(test_aot)
+# No SETUP_LTO: LTCG over ~1080 AOT TUs was a 21-minute link on MSVC CI for a
+# test binary that measures correctness, not performance.
+
+### AOT subset target — the per-PR CI gate
+# tests/language only (+ dastest/testing.das and the language fixture modules).
+# Part of the default build on every lane, Debug included: a fast compile+link
+# gate (~230 TUs, no LTO). The full suite builds and runs on the nightly cron.
+add_executable(test_aot_subset ${DAS_DASCRIPT_MAIN_SRC}
+    ${TESTING_AOT_GENERATED_SRC}
+    ${LANGUAGE_AOT_GENERATED_SRC}
+    ${LANGUAGE_MODULES_AOT_GENERATED_SRC}
+    ${SUBSET_DASLIB_MODULES_AOT_GENERATED_SRC}
+)
+TARGET_LINK_LIBRARIES(test_aot_subset libDaScriptAot ${SRC_LIBRARIES} ${DAS_MODULES_LIBS})
+ADD_DEPENDENCIES(test_aot_subset libDaScriptAot
+    test_aot_testing
+    test_aot_language test_aot_language_modules
+    test_aot_subset_daslib_modules
+)
+target_include_directories(test_aot_subset PRIVATE ${TEST_AOT_INCLUDE_DIRS})
+target_compile_definitions(test_aot_subset PRIVATE ${TEST_AOT_COMPILE_DEFS})
+SETUP_CPP11(test_aot_subset)


### PR DESCRIPTION
## Problem

Per-PR CI wall clock (~2h02 on the gating lane) is dominated by **building** the full `test_aot`: ~1080 AOT-generated TUs plus an LTO link, on every lane, every PR. Measured on run 29135508387 (full matrix):

| Lane | Build step | of which test_aot |
|---|---|---|
| windows-64-Release | 66.5 min | ~46 min (25 min AOT compile + **21 min LTCG link**) |
| linux-64-Release | 39 min | ~31 min (79%) |

Actually *running* the AOT suite costs 1–7 min. The cost was entirely build-side. (`daslang` itself has no LTO and links in ~1 s — the 21-min link was exclusively `test_aot`'s `SETUP_LTO`.)

## Change

**Per-PR CI runs zero AOT steps.** The AOT gate on PRs is now purely compile+link:

- **`test_aot_subset`** — new executable: `tests/language` + its fixtures + `dastest/testing.das` + a minimal daslib runtime closure (~230 AOT TUs, no LTO). Stays in ALL, so every lane — Debug, gcc, msvc, mingw, clang-cl, bundle_smoke — builds it as a compile+link gate.
- **`test_aot`** (full) — now `EXCLUDE_FROM_ALL`, `SETUP_LTO` dropped. Built and run only via `--target run_tests_aot`: by the nightly cron and by `preflight --full` (which already uses the explicit target).
- **build.yml** — the matrix "Slow Release Tests" (full AOT sweep) is now schedule/workflow_dispatch-only; the matrix Release cells (sanitizers included) join mingw/clang-cl on the nightly cron, unconditionally on the canonical repo so the nightly AOT signal is deterministic. Cron moved 08:00 → 02:00 UTC — the nightly grows from 2 jobs to ~11 and should not compete with EU-daytime PR lanes.
- **`run_tests_aot_subset`** — convenience target sweeping `tests/language` against the subset binary.

The minimal daslib closure (`AOT_SUBSET_DASLIB_MODULE_FILES`: random/regex/faker/fuzzer/coroutines/archive/strings_boost + support modules) is required — without it 15 language tests fail `error[50101]` on module-canonical AOT registrations. A future language test requiring another runtime daslib module extends that list; the CMake comment and `skills/aot_testing.md` document this.

**Coverage tradeoff (deliberate):** an AOT regression outside `tests/language` no longer fails PR CI — it is caught by local `preflight --full` before push, or by the nightly. Skills docs updated accordingly (`aot_testing`, `writing_tests`, `preflight`, `build_and_debug`, `make_pr`, `CLAUDE.md`).

## Expected effect

windows-64-Release build step 66 → ~28 min, lane ~2h → ~1h20; every Release lane sheds 25–45 min; Debug/msvc/bundle_smoke lanes drop their silently-built full test_aot too. Remaining gating cost is the JIT prewarm + sweep (~42 min) — separate follow-up.

## Verification (macOS arm64 Release, LLVM enabled)

- `run_tests_aot_subset`: **1341/1341 passed**
- Default ALL build: no `bin/test_aot` produced; everything else compiles
- Full nightly path (`--target run_tests_aot`): **11013 tests, 11007 passed, 0 failed, 6 skipped** (device skips)
- `ctest -L small`: 69/69; full preflight: all gates green except a pre-existing, model-gated master JIT issue in two dasLLAMA tests (fails on pristine master, JIT-only, invisible to CI runners — tracked separately, unrelated to this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)