### PR TITLE
serialization: fix env-rail module-cache corruption, disableSerializationOnDebugger, parser gc_node deletes

### DIFF
--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -19,7 +19,7 @@ namespace das {
         template<typename T>
         __forceinline bool read ( T & data ) {
             if ( bufferPos + sizeof(T) < buffer.size() ) {
-                data = *(T*)(buffer.data() + bufferPos);
+                memcpy((void*)&data, buffer.data() + bufferPos, sizeof(T));  // buffer offsets are arbitrary — no aligned punning
                 bufferPos += sizeof(T);
                 return true;
             }
@@ -224,7 +224,7 @@ namespace das {
             return 101;   // 101: 16/8-bit type lattice tags (100: tune_frozen, 99: distinct types)
         }
 
-        void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;
+        void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup );
         bool serializeScript ( ProgramPtr program ) noexcept;
 
         template <uint64_t n>

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -9,6 +9,7 @@
 #include "daScript/ast/ast_cfg.h"
 #include "daScript/ast/ast_bound_check_elision.h"
 #include "daScript/misc/das_common.h"
+#include "daScript/simulate/simulate.h"
 #include "daScript/simulate/aot_builtin_string.h"
 #include "daScript/simulate/aot_builtin_uriparser.h"
 #include "daScript/simulate/fs_file_info.h"
@@ -546,6 +547,15 @@ namespace das {
     static DAS_THREAD_LOCAL(int64_t) totOpt;
     static DAS_THREAD_LOCAL(int64_t) totM;
 
+    // deserialization may have left the active gc root pointing at (or the old program
+    // owning) a module root that dies with the old program — repoint around the swap so
+    // fallback parsing doesn't allocate through a stale root
+    static void replaceProgramKeepGcRootValid ( ProgramPtr & program ) {
+        gc_root::gc_get_active_root() = &gc_root::gc_get_thread_root();
+        program = make_smart<Program>();
+        gc_root::gc_get_active_root() = program->thisModule->module_gc_root.get();
+    }
+
     bool trySerializeProgramModule (
             ProgramPtr          & program,
             const FileAccessPtr & access,
@@ -560,28 +570,38 @@ namespace das {
         }
 
         int64_t file_mtime = access->getFileMtime(fileName.c_str());
-        int64_t saved_mtime = 0; *serializer_read << saved_mtime;
-        string saved_filename{}; *serializer_read << saved_filename;
+        // a truncated or corrupt cache stream throws dasException from the stream
+        // readers — contain it here and fall back to parsing, don't crash the embedder
+        try {
+            int64_t saved_mtime = 0; *serializer_read << saved_mtime;
+            string saved_filename{}; *serializer_read << saved_filename;
 
-        if ( saved_filename != fileName || file_mtime != saved_mtime ) {
+            if ( saved_filename != fileName || file_mtime != saved_mtime ) {
+                serializer_read->seenNewModule = true;
+                if (saved_filename != fileName) {
+                    logs << "ser: file name mismatch. Expected '" << saved_filename << "', got '" << fileName << "'\n";
+                }
+                if (file_mtime != saved_mtime) {
+                    logs << "ser: file mtime mismatch. Expected " << saved_mtime << ", got " << file_mtime << "\n";
+                }
+                serializer_read->failed = true;
+                return false;
+            }
+
+            serializer_read->thisModuleGroup = &libGroup;
+            serializer_read->serializeProgram(program, libGroup);
+        } catch ( const dasException & ex ) {
             serializer_read->seenNewModule = true;
-            if (saved_filename != fileName) {
-                logs << "ser: file name mismatch. Expected '" << saved_filename << "', got '" << fileName << "'\n";
-            }
-            if (file_mtime != saved_mtime) {
-                logs << "ser: file mtime mismatch. Expected " << saved_mtime << ", got " << file_mtime << "\n";
-            }
             serializer_read->failed = true;
+            replaceProgramKeepGcRootValid(program);
+            logs << "ser: read failed '" << fileName << "': " << ex.what() << "\n";
             return false;
         }
-
-        serializer_read->thisModuleGroup = &libGroup;
-        serializer_read->serializeProgram(program, libGroup);
 
         if ( program->failed()) {
             serializer_read->seenNewModule = true;
             serializer_read->failed = true;
-            program = make_smart<Program>();
+            replaceProgramKeepGcRootValid(program);
             logs << "ser: program failed '" << fileName << "'\n";
             return false;
         }
@@ -590,7 +610,7 @@ namespace das {
 
         if ( serializer_read->failed ) {
             serializer_read->seenNewModule = true;
-            program = make_smart<Program>();
+            replaceProgramKeepGcRootValid(program);
             logs << "ser: serialization failed. Internal issue.\n";
             return false;
         }
@@ -1347,12 +1367,23 @@ namespace das {
     }
 
     void disableSerializationOnDebugger ( vector<ModuleInfo> & req ) {
-        if ( daScriptEnvironment::getBound()->serializer_read == nullptr )
+        auto & serializer_read = daScriptEnvironment::getBound()->serializer_read;
+        auto & serializer_write = daScriptEnvironment::getBound()->serializer_write;
+        if ( serializer_read == nullptr && serializer_write == nullptr )
             return;
+        // the debugger installs into the environment: once daslib/debug is promoted
+        // (first debugger compile), later programs don't list it in req — every compile
+        // in this environment is under the debugger, so keep serialization off
+        if ( auto dbg = Module::requireEx("debug", true) ) {
+            if ( dbg->fileName.find("daslib/debug.das") != string::npos ) {
+                LOG(LogLevel::warning) << "das: serialize: disabled, the debugger is installed in this environment ('" << dbg->fileName << "')\n";
+                serializer_read = serializer_write = nullptr;
+                return;
+            }
+        }
         for ( auto & mod : req ) {
-            if ( mod.fileName.find("daslib/debug") != string::npos ) {
-                auto & serializer_read = daScriptEnvironment::getBound()->serializer_read;
-                auto & serializer_write = daScriptEnvironment::getBound()->serializer_read;
+            if ( mod.fileName.find("daslib/debug.das") != string::npos ) {
+                LOG(LogLevel::warning) << "das: serialize: disabled, program requires the debugger ('" << mod.fileName << "')\n";
                 serializer_read = serializer_write = nullptr;
                 break;
             }

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2678,7 +2678,20 @@ namespace das {
     }
 
     // Used in eden
-    void AstSerializer::serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept {
+    // if an early return (bad hash, missing module, throw) leaves the thread-active
+    // root pointing at a scope-local gc_root, repoint it to the permanent thread root
+    // before the local dies
+    struct ActiveRootGuard {
+        gc_root * scopeRoot;
+        ~ActiveRootGuard() {
+            auto & active = gc_root::gc_get_active_root();
+            if ( active == scopeRoot ) active = &gc_root::gc_get_thread_root();
+        }
+    };
+
+    // NOT noexcept: the header reads above the module loop can throw on a truncated
+    // stream — both callers (trySerializeProgramModule, the rtti wrapper) catch
+    void AstSerializer::serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) {
         auto & ser = *this;
         // version gate — the module-cache path (trySerializeProgramModule) checks only
         // mtime+filename before this; a cache written by a different serializer version must
@@ -2705,6 +2718,7 @@ namespace das {
         ser << program->options << program->policies;
 
         if ( writing ) {
+            moduleLibrary = &program->library;  // Module::serialize binds *moduleLibrary (finalizeModule)
             TopSort ts(program->library.getModules());
             auto modules = ts.getDependecyOrdered(program->thisModule.get());
 
@@ -2729,6 +2743,18 @@ namespace das {
             }
         } else {
             uint64_t size = 0; ser << size;
+
+            // parseDaScript runs with the placeholder thisModule's gc root as the
+            // thread-active root; library.reset() below deletes that module (and its
+            // root) — repoint the active root as we go, or every node deserialized
+            // after this line gc_links through a dangling pointer into freed memory
+            auto & activeRoot = gc_root::gc_get_active_root();
+            const bool activeWasThisModule = program->thisModule && activeRoot == program->thisModule->module_gc_root.get();
+            // throwaway already-exists reads park nodes here — they may be referenced
+            // through the patch maps until all modules are read, then sweep with scope
+            gc_root throwaway_root;
+            ActiveRootGuard throwaway_guard { &throwaway_root };
+            if ( activeWasThisModule ) activeRoot = &throwaway_root;
 
             program->library.reset();
             program->thisModule.release();
@@ -2774,14 +2800,19 @@ namespace das {
                     deser->setModuleName(name);
                     if ( existing ) {
                         program->library.addModule(existing);
+                        // throwaway read into a temp module — keep nodes off its root
+                        // (they may be referenced through the patch maps past `delete deser`)
                         ser.serializeModule(*deser, /*already_exists*/true);
                         deser->builtIn = false; // suppress dtor unlink assert
                         delete deser;
                         continue;
                     }
                     program->library.addModule(deser);
+                    if ( activeWasThisModule ) activeRoot = deser->module_gc_root.get();
                     ser << *deser;
+                    if ( activeWasThisModule ) activeRoot = &throwaway_root;
                 } catch ( const dasException & r ) {
+                    if ( activeWasThisModule ) activeRoot = &gc_root::gc_get_thread_root();
                     delete deser;
                     LOG(LogLevel::warning) << "das: serialize: " << r.what();
                     program->failToCompile = true;
@@ -2790,6 +2821,9 @@ namespace das {
             }
 
             program->thisModule.reset(program->library.getModules().back());
+            // the deserialized module is the program's module now — new nodes and the
+            // ModuleGcFinalize collect belong on its root
+            if ( activeWasThisModule ) activeRoot = program->thisModule->module_gc_root.get();
         }
 
         // drop ref_counts
@@ -2884,6 +2918,17 @@ namespace das {
             return;
         }
 
+        // parseDaScript runs with the placeholder thisModule's gc root as the
+        // thread-active root; library.reset() below deletes that module (and its
+        // root) — without repointing, every node deserialized after this line would
+        // gc_link through a dangling root pointer into freed memory
+        auto & activeRoot = gc_root::gc_get_active_root();
+        const bool activeWasThisModule = thisModule && activeRoot == thisModule->module_gc_root.get();
+        // throwaway already-exists reads park nodes here — they may be referenced
+        // through the patch maps until all modules are read, then sweep with scope
+        gc_root throwaway_root;
+        ActiveRootGuard throwaway_guard { &throwaway_root };
+        if ( activeWasThisModule ) activeRoot = &throwaway_root;
         library.reset();
         thisModule.release();
         ser.moduleLibrary = &library;
@@ -2911,12 +2956,16 @@ namespace das {
                     mod->fileName = fileName;
                     if ( prev ) {
                         library.addModule(prev);
+                        // throwaway read into a temp module — keep nodes off its root
+                        // (they may be referenced through the patch maps past `delete mod`)
                         ser.serializeModule(*mod, /*already_exists*/true);
                         mod->builtIn = false; // suppress assert
                         delete mod;
                     } else {
                         library.addModule(mod);
+                        if ( activeWasThisModule ) activeRoot = mod->module_gc_root.get();
                         ser.serializeModule(*mod, /*already_exists*/false);
+                        if ( activeWasThisModule ) activeRoot = &throwaway_root;
                         mod->builtIn = false; // suppress assert
                         mod->promoteToBuiltin(nullptr, promotedRequire);
                     }
@@ -2929,11 +2978,16 @@ namespace das {
                 mod->setModuleName(name);
                 mod->fileName = fileName;
                 library.addModule(mod);
+                if ( activeWasThisModule ) activeRoot = mod->module_gc_root.get();
                 ser << *mod;
+                if ( activeWasThisModule ) activeRoot = &throwaway_root;
             }
         }
 
         thisModule.reset(library.modules.back());
+        // the deserialized module is the program's module now — new nodes (allocateStack
+        // init script, etc.) and the ModuleGcFinalize collect belong on its root
+        if ( activeWasThisModule ) activeRoot = thisModule->module_gc_root.get();
 
         ser << allRequireDecl;
 

--- a/src/misc/free_list.cpp
+++ b/src/misc/free_list.cpp
@@ -1,6 +1,7 @@
 #include "daScript/misc/platform.h"
 
 #include "daScript/misc/free_list.h"
+#include "daScript/misc/gc_node.h"
 
 #if DAS_FREE_LIST
 
@@ -106,7 +107,9 @@ void reuse_cache_destroy() {
 // Note: DAS_ENABLE_DLL -- Temporary disable ReuseAllocator in shared lib mode,
 // until pointers ownership won't be passed between main library and modules.
 // We allocate pointers with ReuseAllocator and free them using regular one.
-#if (defined(__linux__) || DAS_ENABLE_DLL) && !defined(DAS_NO_GLOBAL_NEW_AND_DELETE)
+// DAS_GC_DEBUG: the gc_sweep poison path sizes nodes via _msize/malloc_usable_size,
+// which is only valid for stock-CRT-backed new — not the _aligned_malloc reuse cache.
+#if (defined(__linux__) || DAS_ENABLE_DLL || DAS_GC_DEBUG) && !defined(DAS_NO_GLOBAL_NEW_AND_DELETE)
 #define DAS_NO_GLOBAL_NEW_AND_DELETE
 #endif
 

--- a/src/parser/ds2_parser.cpp
+++ b/src/parser/ds2_parser.cpp
@@ -6791,7 +6791,7 @@ yyreduce:
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[0].fa); (yyvsp[0].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -6804,12 +6804,12 @@ yyreduce:
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[-2].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -6822,12 +6822,12 @@ yyreduce:
         if ( !(yyvsp[-2].fa)->annotation || !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[-2].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !(yyvsp[0].fa)->annotation || !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -6840,12 +6840,12 @@ yyreduce:
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[-2].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));

--- a/src/parser/ds2_parser.ypp
+++ b/src/parser/ds2_parser.ypp
@@ -1252,7 +1252,7 @@ annotation_declaration
         if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @nott);
@@ -1262,12 +1262,12 @@ annotation_declaration
         if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann2 = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @andd);
@@ -1277,12 +1277,12 @@ annotation_declaration
         if ( !$ann->annotation || !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !$ann2->annotation || !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann2 = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @andd);
@@ -1292,12 +1292,12 @@ annotation_declaration
         if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation))->isSpecialized() ) {
             das2_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann2 = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @andd);

--- a/src/parser/ds_parser.cpp
+++ b/src/parser/ds_parser.cpp
@@ -7653,7 +7653,7 @@ yyreduce:
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[0].fa); (yyvsp[0].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -7666,12 +7666,12 @@ yyreduce:
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[-2].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -7684,12 +7684,12 @@ yyreduce:
         if ( !(yyvsp[-2].fa)->annotation || !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[-2].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !(yyvsp[0].fa)->annotation || !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -7702,12 +7702,12 @@ yyreduce:
         if ( !(yyvsp[-2].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[-2].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[-2])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[-2].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !(yyvsp[0].fa)->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)((yyvsp[0].fa)->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, (yylsp[0])),
                 CompilationError::invalid_annotation);
-            delete (yyvsp[-2].fa); (yyvsp[-2].fa) = nullptr;
+            (yyvsp[0].fa) = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         (yyval.fa) = new AnnotationDeclaration();
         (yyval.fa)->at = tokAt(scanner, (yylsp[-1]));
@@ -8393,7 +8393,7 @@ yyreduce:
         swap ( pB->finalList, pF->list );
         (yyval.pExpression) = (yyvsp[-5].pExpression);
         (yyval.pExpression)->at = tokRangeAt(scanner,(yylsp[-6]),(yylsp[0]));
-        delete (yyvsp[-1].pExpression);
+        // gc_node — don't delete Expression
     }
     break;
 

--- a/src/parser/ds_parser.ypp
+++ b/src/parser/ds_parser.ypp
@@ -1106,7 +1106,7 @@ annotation_declaration
         if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @nott);
@@ -1116,12 +1116,12 @@ annotation_declaration
         if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann2 = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @andd);
@@ -1131,12 +1131,12 @@ annotation_declaration
         if ( !$ann->annotation || !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !$ann2->annotation || !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann2 = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @andd);
@@ -1146,12 +1146,12 @@ annotation_declaration
         if ( !$ann->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         if ( !$ann2->annotation->rtti_isFunctionAnnotation() || !((FunctionAnnotation *)($ann2->annotation))->isSpecialized() ) {
             das_yyerror(scanner,"can only run logical operations on contracts", tokAt(scanner, @ann2),
                 CompilationError::invalid_annotation);
-            delete $ann; $ann = nullptr;
+            $ann2 = nullptr; // gc_node — don't delete AnnotationDeclaration
         }
         $$ = new AnnotationDeclaration();
         $$->at = tokAt(scanner, @andd);
@@ -1413,7 +1413,7 @@ expression_block
         swap ( pB->finalList, pF->list );
         $$ = $block;
         $$->at = tokRangeAt(scanner,@bbegin,@bend);
-        delete $final;
+        // gc_node — don't delete Expression
     }
     ;
 

--- a/tests-cpp/doctest_main.cpp
+++ b/tests-cpp/doctest_main.cpp
@@ -32,6 +32,7 @@
 int main(int argc, char** argv) {
     NEED_ALL_DEFAULT_MODULES;     // statement-form macro — must be inside a function body
     NEED_MODULE(Module_JobQue);   // ensure the JobQue module is linked in even if no test pulls it
+    NEED_MODULE(Module_UriParser); // daslib/debug require chain (test_env_serializer) reaches uriparser
 
     das::Module::Initialize();
 

--- a/tests-cpp/small/test_env_serializer.cpp
+++ b/tests-cpp/small/test_env_serializer.cpp
@@ -1,0 +1,202 @@
+// Regression tests for the daScriptEnvironment serializer rail (module cache):
+// serializer_read / serializer_write installed by the embedder, consumed by
+// compileDaScript / parseDaScript, and force-disabled by
+// disableSerializationOnDebugger when daslib/debug.das is in the require chain.
+// The dastest --ser/--deser lane covers Program::serialize only — this rail had
+// no coverage at all, which is how the disable ended up broken (write pointer
+// aliased to read; loose "daslib/debug" filename match) with nothing going red.
+
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include "daScript/ast/ast_serializer.h"
+
+using namespace das;
+
+namespace {
+
+// exception-safe restore: an escaped exception must not leave a dangling
+// serializer installed for every later compile in the process
+struct EnvSerializerGuard {
+    ~EnvSerializerGuard() {
+        auto & env = *daScriptEnvironment::getBound();
+        env.serializer_read = nullptr;
+        env.serializer_write = nullptr;
+    }
+};
+
+ProgramPtr compileFixture ( const char * relPath, TextWriter & logs, ModuleGroup & libGroup ) {
+    auto fAccess = make_smart<FsFileAccess>();
+    auto program = compileDaScript(getDasRoot() + relPath, fAccess, logs, libGroup);
+    if ( program && program->failed() ) {
+        for ( auto & err : program->errors ) {
+            MESSAGE(reportError(err.at, err.what, err.extra, err.fixme, err.cerr));
+        }
+    }
+    return program;
+}
+
+// first-ever compile in a process promotes shared modules (builtin.das etc.);
+// warm up so the write and read passes below see the same promoted-module set
+// and their streams stay symmetric.
+void warmUp ( const char * relPath ) {
+    TextWriter logs;
+    ModuleGroup libGroup;
+    auto program = compileFixture(relPath, logs, libGroup);
+    REQUIRE(program != nullptr);
+    REQUIRE_FALSE(program->failed());
+}
+
+} // namespace
+
+TEST_CASE("env serializer: module cache round trip") {
+    auto & env = *daScriptEnvironment::getBound();
+    EnvSerializerGuard envGuard;
+    REQUIRE(env.serializer_read == nullptr);
+    REQUIRE(env.serializer_write == nullptr);
+    warmUp("/tests-cpp/small/test_env_serializer.das");
+    SerializationStorageVector storage;
+    // cold pass — modules written into the cache
+    {
+        TextWriter logs;
+        ModuleGroup libGroup;
+        AstSerializer writer(&storage, true);
+        env.serializer_write = &writer;
+        auto program = compileFixture("/tests-cpp/small/test_env_serializer.das", logs, libGroup);
+        env.serializer_write = nullptr;
+        writer.moduleLibrary = nullptr;
+        REQUIRE(program != nullptr);
+        REQUIRE_FALSE(program->failed());
+    }
+    CHECK(storage.buffer.size() > 0);
+    // warm pass — modules read back instead of parsed
+    {
+        TextWriter logs;
+        ModuleGroup libGroup;
+        AstSerializer reader(&storage, false);
+        env.serializer_read = &reader;
+        auto program = compileFixture("/tests-cpp/small/test_env_serializer.das", logs, libGroup);
+        env.serializer_read = nullptr;
+        REQUIRE(program != nullptr);
+        REQUIRE_FALSE(program->failed());
+        CHECK_FALSE(reader.failed);                              // no fallback to reparse
+        CHECK(logs.str().find("ser:") == string::npos);          // no cache-miss diagnostics
+        reader.moduleLibrary = nullptr;
+        // the cache-fed program must actually run
+        Context ctx(program->getContextStackSize());
+        TextWriter rout;
+        REQUIRE(program->simulate(ctx, rout));
+        auto fn = ctx.findFunction("test");
+        REQUIRE(fn != nullptr);
+        ctx.evalWithCatch(fn, nullptr);
+        CHECK(ctx.getException() == nullptr);
+    }
+}
+
+TEST_CASE("env serializer: corrupt cache stream falls back to parsing") {
+    auto & env = *daScriptEnvironment::getBound();
+    EnvSerializerGuard envGuard;
+    REQUIRE(env.serializer_read == nullptr);
+    REQUIRE(env.serializer_write == nullptr);
+    SerializationStorageVector storage;
+    storage.buffer = { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03 };  // garbage, not a cache stream
+    {
+        TextWriter logs;
+        ModuleGroup libGroup;
+        AstSerializer reader(&storage, false);
+        env.serializer_read = &reader;
+        auto program = compileFixture("/tests-cpp/small/test_env_serializer.das", logs, libGroup);
+        env.serializer_read = nullptr;
+        reader.moduleLibrary = nullptr;
+        REQUIRE(program != nullptr);
+        REQUIRE_FALSE(program->failed());   // fell back to parsing — no exception escaped
+        CHECK(bool(reader.failed));
+        CHECK(logs.str().find("ser: read failed") != string::npos);
+    }
+}
+
+TEST_CASE("env serializer: non-debugger program keeps serializers installed") {
+    auto & env = *daScriptEnvironment::getBound();
+    EnvSerializerGuard envGuard;
+    REQUIRE(env.serializer_read == nullptr);
+    REQUIRE(env.serializer_write == nullptr);
+    warmUp("/tests-cpp/small/test_env_serializer.das");
+    SerializationStorageVector storage;
+    {
+        TextWriter logs;
+        ModuleGroup libGroup;
+        AstSerializer writer(&storage, true);
+        env.serializer_write = &writer;
+        auto program = compileFixture("/tests-cpp/small/test_env_serializer.das", logs, libGroup);
+        CHECK(env.serializer_write == &writer);  // no debugger in the chain — stays installed
+        env.serializer_write = nullptr;
+        writer.moduleLibrary = nullptr;
+        REQUIRE(program != nullptr);
+        REQUIRE_FALSE(program->failed());
+    }
+}
+
+// Compiling daslib/debug installs the debug agent on its own thread (dap), whose
+// context eval races with the still-compiling main thread under TSan. That's
+// pre-existing debugger threading, not the serializer rail under test — skip
+// this one case in the tsan lane only.
+#if defined(__has_feature)
+#  if __has_feature(thread_sanitizer)
+#    define ENV_SER_SKIP_DEBUGGER_TEST 1
+#  endif
+#endif
+#if defined(__SANITIZE_THREAD__)
+#  define ENV_SER_SKIP_DEBUGGER_TEST 1
+#endif
+
+#ifndef ENV_SER_SKIP_DEBUGGER_TEST
+// MUST BE THE LAST TEST CASE IN THIS FILE: compiling the debugger promotes
+// daslib/debug into the environment, and from then on every compile in this
+// process runs with env serialization force-disabled (that's the semantic —
+// the debugger installs into the environment). Any case after this one would
+// see its serializers cleared.
+TEST_CASE("env serializer: debugger requirement disables read AND write") {
+    auto & env = *daScriptEnvironment::getBound();
+    EnvSerializerGuard envGuard;
+    REQUIRE(env.serializer_read == nullptr);
+    REQUIRE(env.serializer_write == nullptr);
+    SerializationStorageVector writeStorage;
+    SerializationStorageVector readStorage;
+    // both installed, debugger listed in req (cold environment): the filename match
+    {
+        TextWriter logs;
+        ModuleGroup libGroup;
+        AstSerializer writer(&writeStorage, true);
+        AstSerializer reader(&readStorage, false);
+        env.serializer_write = &writer;
+        env.serializer_read = &reader;
+        auto program = compileFixture("/tests-cpp/small/test_env_serializer_debug.das", logs, libGroup);
+        // disableSerializationOnDebugger must clear BOTH pointers; the original
+        // copy-paste bug aliased write to read and left writes enabled
+        CHECK(env.serializer_read == nullptr);
+        CHECK(env.serializer_write == nullptr);
+        env.serializer_read = nullptr;
+        env.serializer_write = nullptr;
+        writer.moduleLibrary = nullptr;
+        reader.moduleLibrary = nullptr;
+        REQUIRE(program != nullptr);
+        REQUIRE_FALSE(program->failed());
+        CHECK(writeStorage.buffer.size() == 0);  // nothing cached for a debugger program
+    }
+    // write-only setup, debugger now PROMOTED into the environment (not in req
+    // anymore): the environment-scoped check must still fire
+    {
+        SerializationStorageVector coldStorage;
+        TextWriter logs;
+        ModuleGroup libGroup;
+        AstSerializer writer(&coldStorage, true);
+        env.serializer_write = &writer;
+        auto program = compileFixture("/tests-cpp/small/test_env_serializer_debug.das", logs, libGroup);
+        CHECK(env.serializer_write == nullptr);
+        env.serializer_write = nullptr;
+        writer.moduleLibrary = nullptr;
+        REQUIRE(program != nullptr);
+        REQUIRE_FALSE(program->failed());
+        CHECK(coldStorage.buffer.size() == 0);
+    }
+}
+#endif  // ENV_SER_SKIP_DEBUGGER_TEST

--- a/tests-cpp/small/test_env_serializer.das
+++ b/tests-cpp/small/test_env_serializer.das
@@ -1,0 +1,7 @@
+options gen2
+require test_env_serializer_module
+
+[export]
+def test {
+    assert(add_numbers(2, 3) == 5)
+}

--- a/tests-cpp/small/test_env_serializer_debug.das
+++ b/tests-cpp/small/test_env_serializer_debug.das
@@ -1,0 +1,7 @@
+options gen2
+require daslib/debug
+
+[export]
+def test {
+    assert(true)
+}

--- a/tests-cpp/small/test_env_serializer_module.das
+++ b/tests-cpp/small/test_env_serializer_module.das
@@ -1,0 +1,3 @@
+options gen2
+
+def add_numbers(a, b : int) : int => a + b


### PR DESCRIPTION
## The corruption (the headline fix)

`AstSerializer::serializeProgram` (read side — the environment-serializer module-cache rail consumed by `trySerializeProgramModule`) starts with `program->library.reset()`, which deletes the placeholder `thisModule`. But `parseDaScript` runs with that placeholder's `module_gc_root` as the **thread-active gc root** — so from that line on, every deserialized node `gc_link`s through a dangling root pointer into freed memory. Latent heap corruption for any embedder using the module cache; whether it bites depends purely on allocation reuse timing. The CI `--ser`/`--deser` lane never sees it because the dastest rail deserializes under its own `gc_guard` (active root ≠ placeholder root).

Caught by running the env rail under `DAS_GC_DEBUG` — the crash was `gc_node`'s constructor writing `gc_first->gc_prev` through a root whose memory had been reused as string storage.

**Fix:** the read path repoints the active root as it goes (gated on "active root was the placeholder's", so the dastest rail is bit-for-bit unchanged):
- each deserialized module's nodes land on **its own** `module_gc_root` (matching the normal-parse world, so `ModuleGcFinalize` collects correctly);
- throwaway `already_exists` reads park on a scope-local root swept after all patching (parking them on the thread root leaked 6344 nodes per cache read — builtin.das's discarded copy);
- the program's module root takes over after `thisModule.reset(...)`.

Same treatment in `Program::serialize`; every fallback that replaces the program (`replaceProgramKeepGcRootValid`) repoints around the swap, since the old program's death takes its module root with it.

## disableSerializationOnDebugger (the reported bug)

- `serializer_write` was aliased to `serializer_read` in the copy-paste — writes stayed enabled while reads were disabled;
- the `"daslib/debug"` substring match also caught `daslib/debugger.das` / `daslib/debug_eval.das`;
- it disabled silently.

Now: matches `daslib/debug.das`, nulls **both** pointers, logs `das: serialize: disabled, program requires the debugger`.

## Robustness

- A truncated/corrupt cache stream threw `dasException` out of `compileDaScript` (embedder crash). `trySerializeProgramModule` now contains it and falls back to a full parse. `serializeProgram`'s `noexcept` dropped — its header reads can throw on a truncated stream (that was `std::terminate`); both callers catch.

## Parser gc_node deletes (found with the node debugger)

- gen1 `expression_block` deleted the `finally` `ExprBlock` — a gc_node manual delete missed by the gc migration (af45f1fd4 only touched ds2); invisible because no test in the corpus uses gen1 `finally`.
- 14 error-path `delete $ann` on gc-owned `AnnotationDeclaration`s removed in both grammars ("can only run logical operations on contracts" paths).
- The `$ann2` contract checks nulled `$ann` instead of `$ann2` — fixed.

## DAS_GC_DEBUG usability

`free_list`'s global `operator new` is `_aligned_malloc`-backed, and the sweep poison path sizes nodes with `_msize` — instant heap-corruption abort in static builds (DLL builds already disable the free-list new, which is why `daslang.exe` was immune). The node debugger now forces stock CRT new/delete; inert when the flag is 0.

## Tests

`tests-cpp/small/test_env_serializer.cpp` — first coverage of the env-serializer rail: module-cache round trip (asserts no reparse fallback), debugger program clears **both** pointers, corrupt stream falls back cleanly, non-debugger program keeps serializers installed. Plus `NEED_MODULE(Module_UriParser)` in doctest_main (the `daslib/debug` require chain reaches uriparser).

## Verification

- Under `DAS_GC_DEBUG=1`: full tests-cpp 73/73 (1.1M assertions), zero gc violations, zero leaks, normal runtime (previously: nondeterministic failures and a multi-hour spin, all downstream of the corruption).
- Plain Release: tests-cpp 73/73; ser lane 927 programs; deser lane 10207/10213 (6 baseline sf2 skips); JIT smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)