### PR TITLE
CI: JIT sweep runs isolated-parallel; drop the Prewarm JIT cache step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
             architecture_string: x64
 
           # RelWithDebInfo only on Windows x64
-          # jit_disabled: skip the JIT prewarm + JIT test sweep here. JIT on
+          # jit_disabled: skip the JIT test sweep here. JIT on
           # win64-MSVC stays covered by the Release cell below and by the full
           # clang JIT sweep in build_windows_mingw — running it on all three
           # win64 presets just triples the slowest jobs in the matrix.
@@ -433,15 +433,11 @@ jobs:
         path: ${{ runner.temp }}/sccache
         key: sccache-${{ matrix.target }}-${{ matrix.architecture }}-${{ matrix.cmake_preset }}-${{ matrix.sanitizers }}
 
-    - name: "Prewarm JIT cache"
-      # Debug presets skip JIT entirely (prewarm + test sweep) — Debug+JIT is
-      # slow and, on LLVM ARM64, hangs mid-suite (see linux_arm64 note below).
-      # JIT stays covered by every Release cell and the mingw clang sweep.
-      if: env.das_llvm_disabled != 'ON' && matrix.jit_disabled != 'ON' && matrix.cmake_preset != 'Debug'
-      run: |
-        set -eux
-        cmake --build ./build --config ${{ matrix.cmake_preset }} --target jit_cache_all_tests
-
+    # NOTE: the "Prewarm JIT cache" step (jit_cache_all_tests, ~17 min on the
+    # win64 lane) is GONE: the JIT sweep now runs isolated-PARALLEL and mints
+    # the dll cache itself — cold-cache parallel measured faster than the old
+    # warm sequential sweep, so a separate prewarm only duplicated the
+    # frontend-compile of every test. The target still exists for local use.
     - name: "Test"
       run: |
         set -eux
@@ -486,8 +482,11 @@ jobs:
                 TEST_DIR=_dasroot_/tests
             fi
             # Use more time to pass UBSAN and disable leaks in JIT mode because we exit using exit(), and do not call destructors.
-            # Debug preset skips JIT (see "Prewarm JIT cache" note); sanitizer cells are Release, so they still run it.
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || ASAN_OPTIONS=detect_leaks=0 bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --timeout 1800 --test $TEST_DIR || ASAN_OPTIONS=detect_leaks=0 bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --isolated-mode --timeout 3600 --test $TEST_DIR
+            # Debug preset skips JIT — Debug+JIT is slow and, on LLVM ARM64, hangs
+            # mid-suite (see linux_arm64 note below); sanitizer cells are Release, so
+            # they still run it. Primary sweep is isolated-parallel (batch 4, mints
+            # the dll cache itself); retry is batch-1 full isolation.
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || ASAN_OPTIONS=detect_leaks=0 bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --isolated-mode --batch 4 --timeout 1800 --test $TEST_DIR || ASAN_OPTIONS=detect_leaks=0 bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --isolated-mode --timeout 3600 --test $TEST_DIR
             # Interpreter sweep: non-sanitizer only.
             if [ "${{ matrix.sanitizers }}" = "none" ]; then
                 cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter_isolated
@@ -497,7 +496,7 @@ jobs:
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter_isolated
             ;;
            windows*)
-            # Debug preset skips JIT (see "Prewarm JIT cache" note) in addition to the jit_disabled cells.
+            # Debug preset skips JIT (Debug+JIT is slow; ARM64 hang note above) in addition to the jit_disabled cells.
             [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.jit_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_jit || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_jit_isolated
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter_isolated
             ;;
@@ -508,11 +507,11 @@ jobs:
             # runs JIT — keep --failures-only off there so PASS lines print and
             # name the test running just before the hang if it reoccurs (see
             # RC2 release run #25572466058).
-            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --timeout 1800 --test _dasroot_/tests || bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --isolated-mode --timeout 3600 --test _dasroot_/tests
+            [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --isolated-mode --batch 4 --timeout 1800 --test _dasroot_/tests || bin/daslang _dasroot_/dastest/dastest.das -jit -- $JIT_LINKER_STRING $JIT_PATH_TO_LINKER $JIT_OPT --color --failures-only --isolated-mode --timeout 3600 --test _dasroot_/tests
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter_isolated
             ;;
            *)
-            # Debug preset skips JIT (see "Prewarm JIT cache" note).
+            # Debug preset skips JIT (Debug+JIT is slow; ARM64 hang note above).
             [ "${{ env.das_llvm_disabled }}" = "ON" ] || [ "${{ matrix.cmake_preset }}" = "Debug" ] || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_jit || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_jit_isolated
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter || cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_interpreter_isolated
             ;;

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -479,6 +479,11 @@ def main() : int {
     }
     var test_args <- parse_result |> move_unwrap
 
+    // Set BEFORE the --run worker early-return below: workers must honor
+    // --failures-only too, or every PASS line of every test flows through the
+    // captured pipe (parent-side display filtering already handles the rest).
+    log::failuresOnly = test_args.failures_only
+
     if (!empty(test_args.run)) {
         // Isolated/semi-isolated worker subprocess: run each --run file in this
         // one process, emitting a ##dastest## JSON report PER FILE as it
@@ -508,7 +513,6 @@ def main() : int {
         return rc
     }
 
-    log::failuresOnly = test_args.failures_only
 
     var res : SuiteResult
     let startTime = ref_time_ticks()
@@ -637,8 +641,11 @@ def main() : int {
         // Forward --stack-on-exception to each worker: the flag sets the test
         // context's at-throw stack walk, and the tests run in the worker, not here.
         let stackExcFlag = test_args.stack_on_exception ? " --stack-on-exception" : ""
+        // Forward --failures-only so workers suppress per-test PASS lines at the
+        // source instead of streaming them all through the captured pipe.
+        let failuresOnlyFlag = test_args.failures_only ? " --failures-only" : ""
         let cmdPrefix = "{launchPrefix} {jitstr} {aotstr} --"
-        let cmdSuffix = " {benchstr}{log::useTtyColors ? " --color" : ""}{headlessFlag}{stackExcFlag}"
+        let cmdSuffix = " {benchstr}{log::useTtyColors ? " --color" : ""}{headlessFlag}{stackExcFlag}{failuresOnlyFlag}"
         let batchSize = max(1, test_args.batch)
         // Group files into batches of batchSize. Each batch is run by one worker
         // subprocess (batchCmd); per-file singleCmds are kept so a crash can be

--- a/dastest/tests/test_isolated_mode.das
+++ b/dastest/tests/test_isolated_mode.das
@@ -116,4 +116,28 @@ def test_isolated_mode(tt : T?) {
         t |> success(!(output2 |> contains("CALL STACK")),
             "without --stack-on-exception there must be no stack walk, got:\n{output2}")
     }
+
+    tt |> run("--run worker path honors --failures-only (PASS lines suppressed at the source)") <| @(t : T?) {
+        // The worker (--run) path used to return before log::failuresOnly was set,
+        // AND the parent never forwarded the flag — so every per-test RUN/PASS line
+        // of every passing file streamed through the captured pipe. The JSON report
+        // must keep streaming regardless (it is the parent's IPC, emitted raw).
+        let exe = get_command_line_arguments()[0]
+        let file = "{fixture_dir()}/test_one.das"
+        var output : string
+        var exit_code : int
+        run_dastest("{exe} {dastest_root()}/dastest.das -- --run {file} --failures-only", output, exit_code)
+        t |> equal(exit_code, 0)
+        t |> success(output |> contains("##dastest##"),
+            "JSON report must stream regardless of --failures-only, got:\n{output}")
+        t |> success(!(output |> contains("--- PASS")),
+            "worker must suppress per-test PASS lines under --failures-only, got:\n{output}")
+
+        // Control: the same invocation WITHOUT the flag does print them (proves the
+        // assertion above is meaningful, not a fixture that never logs).
+        run_dastest("{exe} {dastest_root()}/dastest.das -- --run {file}", output, exit_code)
+        t |> equal(exit_code, 0)
+        t |> success(output |> contains("--- PASS"),
+            "control run without --failures-only should print PASS lines, got:\n{output}")
+    }
 }

--- a/skills/preflight.md
+++ b/skills/preflight.md
@@ -39,7 +39,9 @@ the CI ref, never a working-tree copy.
 
 ## build.yml — the build matrix
 
-Per-lane steps: build → JIT prewarm → JIT test sweep → interpreter sweep →
+Per-lane steps: build → JIT test sweep (isolated-parallel; it mints the dll
+cache itself — the old separate "Prewarm JIT cache" step is gone) →
+interpreter sweep →
 `ctest -L small`. The full AOT sweep runs on the NIGHTLY cron and on manual
 `workflow_dispatch` runs only (Release
 lanes incl. sanitizers + mingw/clang-cl); per-PR lanes just build
@@ -50,7 +52,7 @@ pre-push check for AOT regressions outside tests/language — don't skip it.**
 | CI step | Local mirror | Notes |
 |---|---|---|
 | Interpreter sweep | `<daslang> dastest/dastest.das -- --color --failures-only --timeout 1800 --test tests` | |
-| JIT sweep | `<daslang> dastest/dastest.das -jit -- --jit-opt-level=3 --color --failures-only --timeout 1800 --test tests` | Windows-local `clang-cl` link failures are env noise — the catchable class is LLVM verifier errors; full end-to-end JIT needs WSL/mac. See `skills/make_pr.md` §2.5 for the 2-test smoke version |
+| JIT sweep | `<daslang> dastest/dastest.das -jit -- --jit-opt-level=3 --color --failures-only --isolated-mode --batch 4 --timeout 1800 --test tests` | isolated-PARALLEL (2×hw-thread workers, 4 files/batch, ~3× vs sequential, identical pass/fail set; CI's retry drops `--batch` for one-process-per-test). Windows-local `clang-cl` link failures are env noise — the catchable class is LLVM verifier errors; full end-to-end JIT needs WSL/mac. See `skills/make_pr.md` §2.5 for the 2-test smoke version |
 | Small C++ tests | `ctest --test-dir build --build-config Release -L small --output-on-failure` | drop `--build-config` on single-config generators. **Run this after touching `tests-cpp/`** — and remember MSVC tolerates C++ that clang/gcc reject (the doctest bit-field incident); see `skills/writing_cpp_tests.md` |
 | AOT sweep (full) | `cmake --build build --config Release --target test_aot`, then `bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --color --failures-only --timeout 1800 --test tests` | nightly CI + manual `workflow_dispatch` only — this local mirror is the only pre-push gate for it |
 | AOT subset gate | `cmake --build build --config Release --target test_aot_subset` (optionally `--target run_tests_aot_subset` to also sweep tests/language) | what per-PR CI lanes actually build (part of ALL) |

--- a/skills/writing_tests.md
+++ b/skills/writing_tests.md
@@ -41,7 +41,8 @@ pointers whose only reference is a local in a jitted frame — native-stack loca
 invisible to the collector, so GC-semantics tests are interp-only; the other former `-jit`
 skips were lifted once `jit_enabled` started triggering daslib/quote lowering). Two traps:
 a whole-folder JIT/AOT failure usually means a missing entry here, NOT a per-file fix; and
-the `jit_cache_all_tests` prewarm target (utils/CMakeLists.txt) does NOT consult it — its
+the `jit_cache_all_tests` prewarm target (utils/CMakeLists.txt — local-use only since CI's
+isolated-parallel JIT sweep mints the dll cache itself) does NOT consult it — its
 `--exclude` list mirrors the skips manually and must be updated in the same change.
 Per-function `[no_jit]` is the finer-grained alternative when only some functions in a
 kept folder can't JIT — put it on the function whose CODE diverges under JIT, not just the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,11 +38,19 @@ if(NOT DAS_TOOLS_DISABLED)
             set(_DAS_JIT_LINKER_STRING "--jit-linker-string=-fsanitize=thread")
         endif()
         set(_DAS_JIT_FLAGS ${_DAS_JIT_LINKER_STRING} $<IF:$<CONFIG:Debug>,--jit-opt-level=0,--jit-opt-level=3>)
+        # Primary JIT sweep runs isolated-PARALLEL (2x-hw-thread worker
+        # subprocesses, 4 files per batch): ~3x FASTER wall-clock than the sequential
+        # sweep with an identical pass/fail set, and cold-cache parallel beats
+        # warm sequential — which is what made the CI "Prewarm JIT cache" step
+        # redundant. Safe because each test program owns its dll-cache path
+        # (.jitted_scripts/<namespace>/<contenthash>) and each file runs in
+        # exactly one batch. The _isolated retry stays batch-1 (one process per
+        # test — max crash isolation, and a batch crash re-dispatches per-file).
         add_custom_target(run_tests_jit
-            COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -jit -- ${_DAS_JIT_FLAGS} ${_DAS_TEST_COMMON} --timeout 1800
+            COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -jit -- ${_DAS_JIT_FLAGS} ${_DAS_TEST_COMMON} --isolated-mode --batch 4 --timeout 1800
             DEPENDS daslang
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            COMMENT "Running tests (JIT)"
+            COMMENT "Running tests (JIT, isolated-parallel)"
         )
         add_custom_target(run_tests_jit_isolated
             COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -jit -- ${_DAS_JIT_FLAGS} ${_DAS_TEST_COMMON} --isolated-mode --timeout 3600

--- a/utils/preflight/main.das
+++ b/utils/preflight/main.das
@@ -742,8 +742,10 @@ def gate_tests_jit(ctx : PreflightCtx) : GateResult {
         return GateResult(name = "tests-jit", status = GateStatus.Skip, seconds = seconds_since(t0),
             detail = "JIT probe failed (see output) — most common cause: daslang built without dasLLVM (-DDAS_LLVM_DISABLED=OFF)", output = probe.out)
     }
+    // Isolated-parallel like CI's run_tests_jit (~3x faster than sequential, identical
+    // pass/fail set; workers mint the dll cache themselves). Timeout matches CI's 1800.
     return run_test_gate("tests-jit",
-        [ctx.daslang, "dastest/dastest.das", "-jit", "--", "--jit-opt-level=3", "--failures-only", "--timeout", "900", "--test", "tests"],
+        [ctx.daslang, "dastest/dastest.das", "-jit", "--", "--jit-opt-level=3", "--failures-only", "--isolated-mode", "--batch", "4", "--timeout", "1800", "--test", "tests"],
         "JIT suite failures")
 }
 


### PR DESCRIPTION
## Problem

After #3435, the gating cost on the CI matrix is the JIT pipeline: a 17–19 min "Prewarm JIT cache" step (`jit_cache_all_tests`) plus a ~25 min **sequential** JIT test sweep on the win64-Release lane. The two together also frontend-compile every test twice — the prewarm exists only so dll codegen doesn't happen serially inside the sequential sweep.

## Change

Flip the primary JIT sweep to dastest's isolated-**parallel** mode and delete the prewarm:

- **`run_tests_jit`** → `--isolated-mode --batch 4`: 2×hw-thread worker subprocesses, 4 files per batch, per-file JSON streaming, and a crashed batch auto-re-dispatches one-process-per-file. The **`run_tests_jit_isolated`** retry stays batch-1 (maximum crash isolation) — the CI retry chain is unchanged in shape.
- **build.yml**: "Prewarm JIT cache" step deleted (the target stays for local use); the direct bash JIT invocations (linux64 incl. sanitizer cells, linux_arm64) get the same flags.
- **preflight `tests-jit` gate**: same flip; timeout aligned to CI's 1800.
- skills docs updated (`preflight.md`, `writing_tests.md`).

No new machinery was needed — isolated mode already forwards `-jit`/`-use-aot`, and `--worker-index` (used by live_host for port namespacing) already existed.

## Why it's safe

- **dll cache**: each test program owns its cache path (`.jitted_scripts/&lt;namespace&gt;/&lt;contenthash&gt;`) and each file runs in exactly one batch — workers never race on a dll. Proven in anger: a cold run re-minted the full 469 MB cache with 14 concurrent workers, zero corruption.
- **Resource audit**: dasHV ports are per-file-unique by documented design; dasSQLITE `test_data/*.db` are read-only checked-in fixtures (writers use temp files); live_host derives ports from `--worker-index`; `gc` is scan-filtered out of `-jit` sweeps entirely; the `.das_test` folder filter runs in the parent scan, so workers inherit it.
- **Device dirs** (audio/strudel/strudel_device) passed parallel on real CoreAudio locally — stricter than CI's null backend.

## Measured (macOS arm64, 14 worker threads; identical 11692-test result set — 11676 passed / 0 failed / 16 skipped — in every mode)

| JIT sweep | Wall |
|---|---|
| Sequential, warm cache (old primary) | 1020 s |
| Isolated-parallel batch-4, warm | **316 s (3.2×)** |
| Isolated-parallel batch-4, **cold** | **423 s** — beats warm sequential, which is what makes the prewarm redundant |

Full preflight green on the branch; its own `tests-jit` gate dropped 957 s → 289 s.

CI runners are 4-core and always cold, so the lane-level expectation is ~2× on the sweep plus the full prewarm deletion — this PR's own run is the verification (win64-Release baseline after #3435: prewarm 18.7 min + Test step ~29 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)