### PR TITLE
dasLLAMA: native K-quant tier (Q4_K/Q5_K/Q6_K) + scheduler audit

### DIFF
--- a/include/daScript/misc/job_que.h
+++ b/include/daScript/misc/job_que.h
@@ -316,4 +316,5 @@ namespace das {
 
     void SetCurrentThreadName ( const string & str );
     void SetCurrentThreadPriority ( JobPriority priority );             // change priority of current thread, 0 - normal, >0 above normal, <0 below normal
+    void SetCurrentThreadAffinityCpu ( int cpu, bool hard );            // bind current thread to a logical CPU: hard mask, or scheduler hint (Windows ideal processor); no-op where unsupported
 }

--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -199,6 +199,7 @@ namespace das {
     DAS_API void jobque_trace_stop ( Context * context, LineInfoArg * at );
     DAS_API bool jobque_trace_save ( const char * path, Context * context, LineInfoArg * at );
     DAS_API void jobque_trace_tag ( int32_t tag, Context * context, LineInfoArg * at );
+    DAS_API void jobque_set_thread_priority ( int32_t level, Context * context, LineInfoArg * at );
     DAS_API void team_parallel_for_invoke ( int32_t rangeBegin, int32_t rangeEnd, int32_t numChunks, Lambda lambda, Func fn, int32_t lambdaSize, Context * context, LineInfoArg * lineinfo );
     DAS_API void team_parallel_for_indexed_invoke ( int32_t rangeBegin, int32_t rangeEnd, int32_t numChunks, Lambda lambda, Func fn, int32_t lambdaSize, Context * context, LineInfoArg * lineinfo );
     DAS_API void team_parallel_stages_invoke ( const TArray<int3> & stages, Lambda lambda, Func fn, int32_t lambdaSize, Context * context, LineInfoArg * lineinfo );

--- a/modules/dasLLAMA/benchmarks/batch_decode_perf.das
+++ b/modules/dasLLAMA/benchmarks/batch_decode_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options _jit_fast_math = true   // ggml-parity FP laxity — same rail as decode_prof / perf
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration

--- a/modules/dasLLAMA/benchmarks/batch_decode_perf.das
+++ b/modules/dasLLAMA/benchmarks/batch_decode_perf.das
@@ -162,10 +162,27 @@ def main() {
         // warm both code paths (JIT + kernel dispatch) before any timed window
         let _w1 = run_sequential(t, cfg.kv, 1l, 8l, 2l)
         let _w2 = run_batched(t, cfg.kv, 2l, 8l, 2l)
+        // DASLLAMA_BATCH_TRACE=<path> saves a per-lane jobque trace of the LARGEST-B batched run
+        // (the lane-timeline viewer's input; same rig as decode_prof --trace)
+        let trace = has_env_variable("DASLLAMA_BATCH_TRACE") ? get_env_variable("DASLLAMA_BATCH_TRACE") : ""
         var nb = 1l
         while (nb <= bmax) {
             let seq_tps = run_sequential(t, cfg.kv, nb, p, n)
+            let doTrace = nb == bmax && !empty(trace)
+            if (doTrace) {
+                jobque_trace_start(1 << 21)
+                set_trace_tags(true)
+            }
             let bat_tps = run_batched(t, cfg.kv, nb, p, n)
+            if (doTrace) {
+                set_trace_tags(false)
+                jobque_trace_stop()
+                if (jobque_trace_save(trace)) {
+                    print("jobque trace saved: {trace}\n")
+                } else {
+                    print("jobque trace: nothing recorded\n")
+                }
+            }
             let speedup = bat_tps / seq_tps
             let stream_tps = bat_tps / double(nb)
             print("B={nb}: sequential {seq_tps} tok/s | batched {bat_tps} tok/s ({speedup}x) | per-stream {stream_tps} tok/s\n")

--- a/modules/dasLLAMA/benchmarks/batch_decode_perf.das
+++ b/modules/dasLLAMA/benchmarks/batch_decode_perf.das
@@ -50,16 +50,10 @@ def private build_prompt(n, salt : int64) : array<int64> {
     return <- [for (i in range64(n)); 1000l + ((i * 7l + salt * 131l) % 5000l)]
 }
 
+// team-scanned argmax (bit-identical to a serial first-wins scan) — the serial loop was a
+// ~0.75ms all-lane hole PER STREAM between eval_batch steps (B=8: 6.1ms holes, 18% of the run)
 def private greedy_top(lg : array<float>; vocab : int64) : int64 {
-    var best = 0l
-    var bestv = lg[0]
-    for (i in range64(vocab)) {
-        if (lg[i] > bestv) {
-            bestv = lg[i]
-            best = i
-        }
-    }
-    return best
+    return parallel_argmax(lg, vocab)
 }
 
 // nb fresh sessions, each prefilled to depth p with its own (salted) prompt

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -103,6 +103,23 @@ def private wbytes(q : QuantMode; wscale16 : bool = false) : double {
     return 4.0lf
 }
 
+// Bytes read per weight for one tensor: its native K-quant plane pair (quant + scale planes per
+// 256-weight superblock) when kq-tagged, else the model-wide q8 figure.
+def private kq_wbytes(f : KqFmt; q8wb : double) : double {
+    if (f == KqFmt.k4) {
+        return (128.0lf + 32.0lf) / 256.0lf   // nibbles + f16 (d*sc, dmin*m) pairs per 32
+    }
+    if (f == KqFmt.k5) {
+        return (160.0lf + 32.0lf) / 256.0lf   // nibbles + high-bit plane + scale pairs
+    }
+    if (f == KqFmt.k6) {
+        return (192.0lf + 18.0lf) / 256.0lf   // ql + qh + native int8 sub-scales + f16 d
+    }
+    return q8wb
+}
+
+def private fmt_or_q8(a : array<KqFmt>; l : int64) : KqFmt => empty(a) ? KqFmt.q8 : a[l]
+
 def private mb(v : double) : double => v / (1024.0lf * 1024.0lf)
 
 // Config-derived weight + KV bytes READ per decoded token, split by section, evaluated at context
@@ -116,8 +133,12 @@ def private print_traffic_table(t : Model; pos : int64; kvdt : KVDtype) {
     for (l in range64(c.n_layers)) {
         let qd = layer_qd(c, l)
         let kvd = layer_kv_dim(c, l)
-        let wv = t.wv_offs[l] >= 0l ? double(dim * kvd) : 0.0lf
-        attn += (double(dim * qd) + double(dim * kvd) + wv + double(qd * dim)) * wb
+        attn += double(dim * qd) * kq_wbytes(fmt_or_q8(t.wq_fmt, l), wb)
+        attn += double(dim * kvd) * kq_wbytes(fmt_or_q8(t.wk_fmt, l), wb)
+        if (t.wv_offs[l] >= 0l) {
+            attn += double(dim * kvd) * kq_wbytes(fmt_or_q8(t.wv_fmt, l), wb)
+        }
+        attn += double(qd * dim) * kq_wbytes(fmt_or_q8(t.wo_fmt, l), wb)
         let cnt = layer_is_sliding(c, l) ? min(pos, c.sliding_window) : pos
         kv_read += double(cnt * kv_row_bytes(kvdt, kvd)) * 2.0lf   // row bytes: codec-exact (q8_0 incl. block scales)
     }
@@ -127,18 +148,43 @@ def private print_traffic_table(t : Model; pos : int64; kvdt : KVDtype) {
     var shexp = 0.0lf
     if (c.moe) {
         router = double(c.n_layers * dim * c.n_expert) * 4.0lf   // router weights stay fp32
-        // native-MXFP4 experts read 17 bytes per 32 weights (nibbles + E8M0); else the active quant
-        let ewb = t.experts_mx4 ? 17.0lf / 32.0lf : wb
-        moe = double(c.n_layers * c.n_expert_used * 3l * dim * c.n_ff_exp) * ewb
+        for (l in range64(c.n_layers)) {
+            let epk = double(c.n_expert_used * dim * c.n_ff_exp)   // elements per (kind, token)
+            if (t.experts_mx4) {
+                moe += epk * 3.0lf * (17.0lf / 32.0lf)   // native MXFP4: nibbles + E8M0 per 32
+            } else {
+                moe += epk * (kq_wbytes(fmt_or_q8(t.we1_fmt, l), wb)
+                    + kq_wbytes(fmt_or_q8(t.we2_fmt, l), wb)
+                    + kq_wbytes(fmt_or_q8(t.we3_fmt, l), wb))
+            }
+        }
         if (c.n_ff_shexp > 0l) {
-            shexp = double(c.n_layers * 3l * dim * c.n_ff_shexp) * wb
+            shexp = double(c.n_layers * 3l * dim * c.n_ff_shexp) * wb   // wsh* stay on the q8 rail
+        }
+        if (c.moe_dense_shexp) {   // gemma4 dense parallel shared expert rides w1/w2/w3
+            for (l in range64(c.n_layers)) {
+                shexp += double(dim * layer_hidden(t, l)) * (kq_wbytes(fmt_or_q8(t.w1_fmt, l), wb)
+                    + kq_wbytes(fmt_or_q8(t.w2_fmt, l), wb)
+                    + kq_wbytes(fmt_or_q8(t.w3_fmt, l), wb))
+            }
         }
     } else {
-        ffn = double(c.n_layers * 3l * dim * c.hidden_dim) * wb
+        for (l in range64(c.n_layers)) {
+            ffn += double(dim * layer_hidden(t, l)) * (kq_wbytes(fmt_or_q8(t.w1_fmt, l), wb)
+                + kq_wbytes(fmt_or_q8(t.w2_fmt, l), wb)
+                + kq_wbytes(fmt_or_q8(t.w3_fmt, l), wb))
+        }
     }
-    let cls_fp32 = c.shared_weights && !t.cls_q8
-    let cls = double(dim * c.vocab_size) * (cls_fp32 ? 4.0lf : wb)
-    let embed = double(dim) * (t.cls_q8 ? wbytes(QuantMode.q8, t.wscale_f16) : 4.0lf)
+    var clsb = wb   // untied q8 default
+    if (cls_kq(t)) {
+        clsb = kq_wbytes(t.emb_fmt, wb)
+    } elif (c.shared_weights) {
+        clsb = t.cls_q8 ? wb : 4.0lf
+    } elif (t.wcls_fmt != KqFmt.q8) {
+        clsb = kq_wbytes(t.wcls_fmt, wb)
+    }
+    let cls = double(dim * c.vocab_size) * clsb
+    let embed = double(dim) * (t.cls_q8 ? wbytes(QuantMode.q8, t.wscale_f16) : (cls_kq(t) ? kq_wbytes(t.emb_fmt, wb) : 4.0lf))
     let total = attn + kv_read + ffn + moe + router + shexp + cls + embed
     print("--- per-token traffic at ctx depth {pos} (config-derived, MB read/token) ---\n")
     print("  attn weights: {mb(attn)} ({100.0lf * attn / total}%)\n")
@@ -202,7 +248,7 @@ def private run_profile(var t : Model; p, n, p2 : int64; team : bool; kvdt : KVD
         forward_prefill(t, s, prompt, p, 0l)
         var tok = greedy_top(s, c.vocab_size)
         if (!empty(trace)) {
-            jobque_trace_start(1 << 17)
+            jobque_trace_start(1 << 21)   // decode makes ~30k chunk events/token — size for a ~32-token window
             set_trace_tags(true)
         }
         tok = profile_window(t, s, p, n, tok)

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -71,6 +71,9 @@ struct Args {
     @clarg_doc = "Weight-scale plane A/B: 1 = convert to f16 at load (llama.cpp byte parity), 0 = keep f32, -1 = keep default"
     wscale_f16 : int = -1
 
+    @clarg_doc = "Native K-quant planes A/B: 1 = keep Q4_K/Q5_K/Q6_K packed at load, 0 = q8-requant fallback, -1 = keep default"
+    kquant_native : int = -1
+
     @clarg_doc = "A/B: size chunk counts to workers only (the pre-fix split), not workers + caller lane"
     legacy_lanes : bool
 
@@ -251,6 +254,11 @@ def main() {
     if (cfg.wscale_f16 >= 0) {
         set_wscale_f16(cfg.wscale_f16 != 0)
         print("wscale_f16 override: {cfg.wscale_f16 != 0}\n")
+    }
+    // native K-quant planes are a LOAD-TIME layout decision — same rule
+    if (cfg.kquant_native >= 0) {
+        set_kquant_native(cfg.kquant_native != 0)
+        print("kquant_native override: {cfg.kquant_native != 0}\n")
     }
     print("loading {cfg.model}\n")
     var t <- load_gguf(cfg.model, cfg.quant)

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them

--- a/modules/dasLLAMA/benchmarks/gguf_perf.das
+++ b/modules/dasLLAMA/benchmarks/gguf_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them

--- a/modules/dasLLAMA/benchmarks/llama3_perf.das
+++ b/modules/dasLLAMA/benchmarks/llama3_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them

--- a/modules/dasLLAMA/benchmarks/perf.das
+++ b/modules/dasLLAMA/benchmarks/perf.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -57,6 +57,11 @@ def main {
             print("join spin override: level {join_spin}\n")
         }
         // A/B the matmul min-grains (rows per chunk floor); 0 = clamp off (pre-grain behavior)
+        if (has_env_variable("DASLLAMA_BATCH_CHUNKS")) {   // batch-GEMM oversplit (chunks per hw job)
+            let bc = to_int(get_env_variable("DASLLAMA_BATCH_CHUNKS"))
+            set_q8_batch_chunks_per_job(bc)
+            print("q8_batch_chunks_per_job override: {bc}\n")
+        }
         if (has_env_variable("DASLLAMA_MIN_CHUNK_ROWS")) {
             let mg = to_int(get_env_variable("DASLLAMA_MIN_CHUNK_ROWS"))
             set_matmul_min_chunk_rows(mg)
@@ -96,9 +101,26 @@ def main {
                 set_jobque_team_prof(true)
                 reset_jobque_team_prof()
             }
+            // DASLLAMA_PREFILL_TRACE=<path> saves a per-lane jobque trace of the N=512 batched
+            // prefill (the lane-timeline viewer's input; same rig as decode_prof --trace)
+            let doTrace = n == 512l && has_env_variable("DASLLAMA_PREFILL_TRACE")
+            if (doTrace) {
+                jobque_trace_start(1 << 20)   // prefill windows are ~50x a decode token — bigger ring
+                set_trace_tags(true)
+            }
             let t1 = ref_time_ticks()
             forward_prefill(t, s, prompt, n, 0l)
             let us_new = get_time_usec(t1)
+            if (doTrace) {
+                set_trace_tags(false)
+                jobque_trace_stop()
+                let tpath = get_env_variable("DASLLAMA_PREFILL_TRACE")
+                if (jobque_trace_save(tpath)) {
+                    print("jobque trace saved: {tpath}\n")
+                } else {
+                    print("jobque trace: nothing recorded\n")
+                }
+            }
             if (teamProf) {
                 let prof = get_jobque_team_prof()
                 let counts = get_jobque_team_prof_counts()

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -73,6 +73,12 @@ def main {
             set_matmul_min_chunk_rows_gemv(mgv)
             print("gemv min chunk rows override: {mgv}\n")
         }
+        // A/B fused (region-list, default) vs per-expert expert GEMMs in the grouped MoE prefill
+        if (has_env_variable("DASLLAMA_MOE_FUSED")) {
+            let mf = to_int(get_env_variable("DASLLAMA_MOE_FUSED"))
+            set_moe_fused_expert_gemms(mf != 0)
+            print("moe_fused_expert_gemms override: {mf}\n")
+        }
         // A/B the 2-D batch chunk grid (0 = 1-D, 1 = fine grid, 2 = wave-aligned)
         if (has_env_variable("DASLLAMA_BATCH_GRID_2D")) {
             let bg2 = to_int(get_env_variable("DASLLAMA_BATCH_GRID_2D"))

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); tests stay bit-exact
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -873,11 +873,12 @@ def public get_wscale_f16() : bool {
 }
 
 // Native K-quant weight planes: Q4_K/Q5_K/Q6_K tensors stay packed in per-format planes (see
-// Model.k4q..k6s) instead of requantizing to Q8. Default OFF until the kernel tier lands — OFF
-// loads them through the q8-requant fallback exactly as before. Load-time switch (like wscale_f16).
-var private g_kquant_native = false
+// Model.k4q..k6s) instead of requantizing to Q8. Default ON since the kernel tier landed
+// (kq stage 5, gated on all-6-file parity); OFF loads them through the q8-requant fallback
+// exactly as before — the A/B opt-out. Load-time switch (like wscale_f16).
+var private g_kquant_native = true
 
-//! Enable/disable native K-quant weight planes for subsequent loads (A/B rail; default off).
+//! Enable/disable native K-quant weight planes for subsequent loads (A/B rail; default ON).
 def public set_kquant_native(on : bool) {
     g_kquant_native = on
 }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -3042,7 +3042,7 @@ def has_dual_rope(c : Config) : bool => (c.sliding_window > 0l
 // ctx 512. Slice length tuning = ledger.
 let FLASH_DECODE_SLICE = 256l       // single-pass threshold: cnt <= this never slices
 let FLASH_DECODE_SLICE_LEN = 32l    // slice granularity once slicing engages
-let FLASH_DECODE_MAX_SLICES = 16l
+let FLASH_DECODE_MAX_SLICES = 32l   // 4 chunks/lane at 16L: Qwen2.5-1.5B d4k attn wall 393->333us/layer vs cap 16
 
 // attn-norm → QKV(+bias) → RoPE → KV-store → GQA multi-head attention → out-proj(+post-norm) → residual.
 // Can layer l's attention run as the fused 3-stage chain? Std shape only: Q8 weights, group3

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1939,6 +1939,15 @@ struct Session {
     moe_gxs : array<float>      // one bucket's gathered activation scales (npos x dim/32)
     moe_gxbs : array<int>       // ... and their per-16 sums (npos x dim/16; kq-expert layers only)
     moe_hbs : array<int>        // bucket hidden requant per-16 sums (npos x nfx/16; kq-expert layers only)
+    moe_ord : array<int2>       // fused-prefill LPT region order (x = expert, y = bucket cnt; capacity ne)
+    // fused-prefill region triples (woff, row0, cnt) + per-expert bias offsets, one set per
+    // projection — cleared and refilled per layer, capacity persists (no per-layer alloc)
+    moe_offs1 : array<int64>    // gate regions (3 per touched expert)
+    moe_offs3 : array<int64>    // up regions
+    moe_offs2 : array<int64>    // down regions
+    moe_boffs1 : array<int64>   // gate bias offsets (moe_exps_bias arches)
+    moe_boffs3 : array<int64>   // up bias offsets
+    moe_boffs2 : array<int64>   // down bias offsets
     moe_ghb : array<float>      // bucket gate outputs (npos x max(n_ff_exp, n_ff_shexp))
     moe_ghb2 : array<float>     // bucket up outputs (same shape)
     moe_hq : array<int8>        // bucket hidden requant quants (npos x max(n_ff_exp, n_ff_shexp))
@@ -6396,55 +6405,61 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         moe_gather_rows(s, 0l, nk, dim, k, kq_layer)
         prof_add("moe_gather", ts_gather)
         // region triples (woff, row0, cnt) per touched expert; the three planes share row0/cnt
-        var offs1 : array<int64>
-        var offs3 : array<int64>
-        var offs2 : array<int64>
-        var boffs1 : array<int64>
-        var boffs3 : array<int64>
-        var boffs2 : array<int64>
-        offs1 |> reserve(ne * 3l)
-        offs3 |> reserve(ne * 3l)
-        offs2 |> reserve(ne * 3l)
+        s.moe_offs1 |> clear(); s.moe_offs1 |> reserve(ne * 3l)
+        s.moe_offs3 |> clear(); s.moe_offs3 |> reserve(ne * 3l)
+        s.moe_offs2 |> clear(); s.moe_offs2 |> reserve(ne * 3l)
         if (c.moe_exps_bias) {
-            boffs1 |> reserve(ne)
-            boffs3 |> reserve(ne)
-            boffs2 |> reserve(ne)
+            s.moe_boffs1 |> clear(); s.moe_boffs1 |> reserve(ne)
+            s.moe_boffs3 |> clear(); s.moe_boffs3 |> reserve(ne)
+            s.moe_boffs2 |> clear(); s.moe_boffs2 |> reserve(ne)
         }
-        var nreg = 0l
+        // LPT region order: biggest buckets FIRST, so the self-serve chunk queue front-loads the
+        // expensive spans and the dispatch tail drains on cheap ones (expert-order regions left
+        // 32% of the GEMM windows idle in last-wave raggedness — idle-by-tag census, dataset X).
+        // Region order can't change results: each region's y rows are keyed by its own row0.
+        s.moe_ord |> clear()
+        s.moe_ord |> reserve(int(ne))   // capacity persists across layers — no per-layer alloc
         for (e in range64(ne)) {
             let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
             let cnt = s.moe_cnt[e] - b0
-            if (cnt == 0l) {
-                continue
+            if (cnt > 0l) {
+                s.moe_ord |> push(int2(int(e), int(cnt)))
             }
+        }
+        s.moe_ord |> sort() $(a, b) => a.y != b.y ? a.y > b.y : a.x < b.x
+        var nreg = 0l
+        for (oe in s.moe_ord) {
+            let e = int64(oe.x)
+            let cnt = int64(oe.y)
+            let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
             let eg = l * ne + e
             let base = e * dim * nfe
-            offs1 |> push(t.we1_offs[l] + base)
-            offs1 |> push(b0)
-            offs1 |> push(cnt)
-            offs3 |> push(t.we3_offs[l] + base)
-            offs3 |> push(b0)
-            offs3 |> push(cnt)
-            offs2 |> push(t.we2_offs[l] + base)
-            offs2 |> push(b0)
-            offs2 |> push(cnt)
+            s.moe_offs1 |> push(t.we1_offs[l] + base)   // nolint:STYLE012 — loop-append into reused scratch
+            s.moe_offs1 |> push(b0)
+            s.moe_offs1 |> push(cnt)
+            s.moe_offs3 |> push(t.we3_offs[l] + base)   // nolint:STYLE012 — loop-append into reused scratch
+            s.moe_offs3 |> push(b0)
+            s.moe_offs3 |> push(cnt)
+            s.moe_offs2 |> push(t.we2_offs[l] + base)   // nolint:STYLE012 — loop-append into reused scratch
+            s.moe_offs2 |> push(b0)
+            s.moe_offs2 |> push(cnt)
             if (c.moe_exps_bias) {
-                boffs1 |> push(t.web1_off + eg * nfe)
-                boffs3 |> push(t.web3_off + eg * nfe)
-                boffs2 |> push(t.web2_off + eg * dim)
+                s.moe_boffs1 |> push(t.web1_off + eg * nfe)
+                s.moe_boffs3 |> push(t.web3_off + eg * nfe)
+                s.moe_boffs2 |> push(t.web2_off + eg * dim)
             }
             nreg++
         }
         let ts_g1 = ref_time_ticks()
         if (fused_kq) {   // native kq: one batched region-list GEMM per projection (never biased)
-            mm_b_kq_groupn(s.moe_ghb, t, f1, offs1, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
-            mm_b_kq_groupn(s.moe_ghb2, t, f3, offs3, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+            mm_b_kq_groupn(s.moe_ghb, t, f1, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+            mm_b_kq_groupn(s.moe_ghb2, t, f3, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
         } elif (c.moe_exps_bias) {   // gpt-oss: gate/up biases fold into the stores, before the act
-            matmul_mx4q8_batch_groupn(s.moe_ghb, t.mxq, t.mxs, offs1, nreg, s.moe_gxq, s.moe_gxs, t.fblob, boffs1, dim, nfe)
-            matmul_mx4q8_batch_groupn(s.moe_ghb2, t.mxq, t.mxs, offs3, nreg, s.moe_gxq, s.moe_gxs, t.fblob, boffs3, dim, nfe)
+            matmul_mx4q8_batch_groupn(s.moe_ghb, t.mxq, t.mxs, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, t.fblob, s.moe_boffs1, dim, nfe)
+            matmul_mx4q8_batch_groupn(s.moe_ghb2, t.mxq, t.mxs, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, t.fblob, s.moe_boffs3, dim, nfe)
         } else {
-            matmul_mx4q8_batch_groupn(s.moe_ghb, t.mxq, t.mxs, offs1, nreg, s.moe_gxq, s.moe_gxs, dim, nfe)
-            matmul_mx4q8_batch_groupn(s.moe_ghb2, t.mxq, t.mxs, offs3, nreg, s.moe_gxq, s.moe_gxs, dim, nfe)
+            matmul_mx4q8_batch_groupn(s.moe_ghb, t.mxq, t.mxs, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, dim, nfe)
+            matmul_mx4q8_batch_groupn(s.moe_ghb2, t.mxq, t.mxs, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, dim, nfe)
         }
         prof_add("mm_gemm", ts_g1)
         let ts_act = ref_time_ticks()
@@ -6457,11 +6472,11 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         }
         let ts_g3 = ref_time_ticks()
         if (fused_kq) {
-            mm_b_kq_groupn(s.moe_gout, t, f2, offs2, nreg, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim)
+            mm_b_kq_groupn(s.moe_gout, t, f2, s.moe_offs2, nreg, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim)
         } elif (c.moe_exps_bias) {   // ... and the down biases, inside the routed weight (ggml_add_id order)
-            matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, offs2, nreg, s.moe_hq, s.moe_hs, t.fblob, boffs2, nfe, dim)
+            matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, s.moe_offs2, nreg, s.moe_hq, s.moe_hs, t.fblob, s.moe_boffs2, nfe, dim)
         } else {
-            matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, offs2, nreg, s.moe_hq, s.moe_hs, nfe, dim)
+            matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, s.moe_offs2, nreg, s.moe_hq, s.moe_hs, nfe, dim)
         }
         prof_add("mm_gemm", ts_g3)
         // bucket row j -> the (position, slot) grid row for the reduce. Threaded: this is a
@@ -6483,12 +6498,6 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
             }
         }
         prof_add("moe_park", ts_park)
-        delete offs1
-        delete offs3
-        delete offs2
-        delete boffs1
-        delete boffs3
-        delete boffs2
     }
 
     // 3. one batched GEMM chain per touched expert over its gathered rows; raw down-projection

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -283,6 +283,11 @@ struct Model {
     w1_fmt : array<KqFmt>
     w2_fmt : array<KqFmt>
     w3_fmt : array<KqFmt>
+    // MoE routed expert stacks — one tag per (layer, kind); the whole 3D stack is one tensor,
+    // so every expert slice of a layer shares its tag (empty = all q8, like the arrays above)
+    we1_fmt : array<KqFmt>
+    we2_fmt : array<KqFmt>
+    we3_fmt : array<KqFmt>
     wcls_fmt : KqFmt = KqFmt.q8
     emb_fmt : KqFmt = KqFmt.q8
     // Attention projections use PER-LAYER offsets — tensor shapes differ per layer class on gemma4
@@ -320,9 +325,12 @@ struct Model {
     web3_off : int64        // ffn_up_exps.bias:   layers x n_expert x n_ff_exp
     // gpt-oss per-head attention-sink logits (fblob, valid when config.attn_sinks)
     sinks_off : int64       // fblob: layers x n_heads
-    we1_off : int64         // ffn_gate_exps: layers x n_expert x (dim x n_ff_exp)
-    we2_off : int64         // ffn_down_exps: layers x n_expert x (n_ff_exp x dim)
-    we3_off : int64         // ffn_up_exps:   layers x n_expert x (dim x n_ff_exp)
+    // PER-LAYER offsets (expert e of layer l at offs[l] + e*ege): a Q4_K_M file mixes expert-stack
+    // formats across layers (ffn_down_exps Q6_K on some), so each layer's stack takes its own
+    // format's plane cursor. Kind-major regions preserved (all we1 layers, then we2, then we3).
+    we1_offs : array<int64>   // ffn_gate_exps: per layer, n_expert x (dim x n_ff_exp)
+    we2_offs : array<int64>   // ffn_down_exps: per layer, n_expert x (n_ff_exp x dim)
+    we3_offs : array<int64>   // ffn_up_exps:   per layer, n_expert x (dim x n_ff_exp)
     wsh1_off : int64        // ffn_gate_shexp: layers x (dim x n_ff_shexp)
     wsh2_off : int64        // ffn_down_shexp: layers x (n_ff_shexp x dim)
     wsh3_off : int64        // ffn_up_shexp:   layers x (dim x n_ff_shexp)
@@ -620,20 +628,17 @@ def private layout_offsets(var t : Model) : LayoutSizes {
         // Native-MXFP4 loads keep the stacks in the mxq/mxs planes instead of qblob; we*_off then
         // count elements within those planes (same expert-major order).
         let ege = dim * c.n_ff_exp   // per-expert element count (same for gate/up and down)
+        t.we1_offs |> clear(); t.we1_offs |> reserve(layers)
+        t.we2_offs |> clear(); t.we2_offs |> reserve(layers)
+        t.we3_offs |> clear(); t.we3_offs |> reserve(layers)
         if (t.experts_mx4) {
-            t.we1_off = mx
-            mx += layers * c.n_expert * ege
-            t.we2_off = mx
-            mx += layers * c.n_expert * ege
-            t.we3_off = mx
-            mx += layers * c.n_expert * ege
+            for (_l in range64(layers)) { t.we1_offs |> push(mx); mx += c.n_expert * ege }
+            for (_l in range64(layers)) { t.we2_offs |> push(mx); mx += c.n_expert * ege }
+            for (_l in range64(layers)) { t.we3_offs |> push(mx); mx += c.n_expert * ege }
         } else {
-            t.we1_off = cur.wo
-            cur.wo += layers * c.n_expert * ege
-            t.we2_off = cur.wo
-            cur.wo += layers * c.n_expert * ege
-            t.we3_off = cur.wo
-            cur.wo += layers * c.n_expert * ege
+            for (l in range64(layers)) { t.we1_offs |> push(kq_take(cur, fmt_at(t.we1_fmt, l), c.n_expert * ege)) }
+            for (l in range64(layers)) { t.we2_offs |> push(kq_take(cur, fmt_at(t.we2_fmt, l), c.n_expert * ege)) }
+            for (l in range64(layers)) { t.we3_offs |> push(kq_take(cur, fmt_at(t.we3_fmt, l), c.n_expert * ege)) }
         }
         if (c.n_ff_shexp > 0l) {
             let she = dim * c.n_ff_shexp
@@ -929,6 +934,29 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
         any ||= t.wo_fmt[l] != KqFmt.q8 || t.w1_fmt[l] != KqFmt.q8 || t.w2_fmt[l] != KqFmt.q8
         any ||= t.w3_fmt[l] != KqFmt.q8
     }
+    // MoE routed expert stacks: one tag per (layer, kind). Guards: biased-experts arches
+    // (gpt-oss) stay q8 — the kq groupn carries no bias form (they're mx4 in practice anyway) —
+    // and per-expert slice addressing needs ege superblock-aligned (dim/n_ff_exp are ggml-row
+    // aligned per format, but the slice math is ours). MXFP4 stacks tag q8 via kq_fmt_of.
+    if (t.config.n_expert > 0l && !t.config.moe_exps_bias
+            && (t.config.dim * t.config.n_ff_exp) % 256l == 0l) {
+        t.we1_fmt |> resize(layers)
+        t.we2_fmt |> resize(layers)
+        t.we3_fmt |> resize(layers)
+        let fused_gu = t.config.moe_dense_shexp   // gemma4: experts ship fused as ffn_gate_up_exps
+        for (l in range64(layers)) {
+            if (fused_gu) {
+                let f = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_up_exps.weight"))
+                t.we1_fmt[l] = f
+                t.we3_fmt[l] = f
+            } else {
+                t.we1_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_exps.weight"))
+                t.we3_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up_exps.weight"))
+            }
+            t.we2_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down_exps.weight"))
+            any ||= t.we1_fmt[l] != KqFmt.q8 || t.we2_fmt[l] != KqFmt.q8 || t.we3_fmt[l] != KqFmt.q8
+        }
+    }
     if (t.config.shared_weights) {
         t.emb_fmt = kq_fmt_of(gguf_tensor_type(m, "token_embd.weight"))
         any ||= t.emb_fmt != KqFmt.q8
@@ -944,8 +972,16 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
         delete t.w1_fmt
         delete t.w2_fmt
         delete t.w3_fmt
+        delete t.we1_fmt
+        delete t.we2_fmt
+        delete t.we3_fmt
     }
     t.kquant_native = any
+}
+
+// Any K-quant-tagged expert stack in layer `l`? (The MoE dispatch and prefill gates branch on this.)
+def private moe_layer_kq(t : Model; l : int64) : bool {
+    return fmt_at(t.we1_fmt, l) != KqFmt.q8 || fmt_at(t.we2_fmt, l) != KqFmt.q8 || fmt_at(t.we3_fmt, l) != KqFmt.q8
 }
 
 // Convert the (already repacked/permuted) f32 scale plane to raw binary16 halfwords and free the
@@ -1007,10 +1043,15 @@ def private repack_q8_weights(var t : Model) {
             let ege = dim * c.n_ff_exp
             if (!t.experts_mx4) {   // native-MXFP4 stacks live in mxq/mxs, row-major (no Q8 repack)
                 for (e in range64(c.n_expert)) {
-                    let base = (l * c.n_expert + e) * ege
-                    repack_q8q8_weight(t.qblob, t.qscales, t.we1_off + base, dim, c.n_ff_exp)
-                    repack_q8q8_weight(t.qblob, t.qscales, t.we2_off + base, c.n_ff_exp, dim)
-                    repack_q8q8_weight(t.qblob, t.qscales, t.we3_off + base, dim, c.n_ff_exp)
+                    if (fmt_at(t.we1_fmt, l) == KqFmt.q8) {
+                        repack_q8q8_weight(t.qblob, t.qscales, t.we1_offs[l] + e * ege, dim, c.n_ff_exp)
+                    }
+                    if (fmt_at(t.we2_fmt, l) == KqFmt.q8) {
+                        repack_q8q8_weight(t.qblob, t.qscales, t.we2_offs[l] + e * ege, c.n_ff_exp, dim)
+                    }
+                    if (fmt_at(t.we3_fmt, l) == KqFmt.q8) {
+                        repack_q8q8_weight(t.qblob, t.qscales, t.we3_offs[l] + e * ege, dim, c.n_ff_exp)
+                    }
                 }
             }
             if (c.n_ff_shexp > 0l) {
@@ -1080,6 +1121,14 @@ def private repack_kq_weights(var t : Model) {
         }
         repack_kq_tensor(t, fmt_at(t.wo_fmt, l), t.wo_offs[l], qd, dim)
         if (c.n_expert > 0l) {
+            if (!t.experts_mx4) {   // each expert slice grp-repacks independently, like the Q8 loop
+                let ege = dim * c.n_ff_exp
+                for (e in range64(c.n_expert)) {
+                    repack_kq_tensor(t, fmt_at(t.we1_fmt, l), t.we1_offs[l] + e * ege, dim, c.n_ff_exp)
+                    repack_kq_tensor(t, fmt_at(t.we2_fmt, l), t.we2_offs[l] + e * ege, c.n_ff_exp, dim)
+                    repack_kq_tensor(t, fmt_at(t.we3_fmt, l), t.we3_offs[l] + e * ege, dim, c.n_ff_exp)
+                }
+            }
             if (c.moe_dense_shexp) {
                 repack_kq_tensor(t, fmt_at(t.w1_fmt, l), t.w1_offs[l], dim, c.hidden_dim)
                 repack_kq_tensor(t, fmt_at(t.w2_fmt, l), t.w2_offs[l], c.hidden_dim, dim)
@@ -1106,10 +1155,10 @@ def private repack_mx4_stacks(var t : Model) {
     let ege = dim * c.n_ff_exp
     for (l in range64(c.n_layers)) {
         for (e in range64(c.n_expert)) {
-            let base = (l * c.n_expert + e) * ege
-            repack_mx4_weight(t.mxq, t.mxs, t.we1_off + base, dim, c.n_ff_exp)
-            repack_mx4_weight(t.mxq, t.mxs, t.we2_off + base, c.n_ff_exp, dim)
-            repack_mx4_weight(t.mxq, t.mxs, t.we3_off + base, dim, c.n_ff_exp)
+            let base = e * ege
+            repack_mx4_weight(t.mxq, t.mxs, t.we1_offs[l] + base, dim, c.n_ff_exp)
+            repack_mx4_weight(t.mxq, t.mxs, t.we2_offs[l] + base, c.n_ff_exp, dim)
+            repack_mx4_weight(t.mxq, t.mxs, t.we3_offs[l] + base, dim, c.n_ff_exp)
         }
     }
 }
@@ -1563,28 +1612,29 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
                 }
                 if (t.experts_mx4) {
                     // native MXFP4: raw nibble + scale bits straight into the planes (no dequant)
-                    let mo1 = t.we1_off + l * ne * ege
-                    let mo2 = t.we2_off + l * ne * ege
-                    let mo3 = t.we3_off + l * ne * ege
+                    let mo1 = t.we1_offs[l]
+                    let mo2 = t.we2_offs[l]
+                    let mo3 = t.we3_offs[l]
                     gguf_transcode_mx4(m, bytes, "blk.{l}.ffn_gate_exps.weight", t.mxq, t.mxs, mo1 / 2l, mo1 / 32l, ne * ege)
                     gguf_transcode_mx4(m, bytes, "blk.{l}.ffn_down_exps.weight", t.mxq, t.mxs, mo2 / 2l, mo2 / 32l, ne * ege)
                     gguf_transcode_mx4(m, bytes, "blk.{l}.ffn_up_exps.weight", t.mxq, t.mxs, mo3 / 2l, mo3 / 32l, ne * ege)
                 } elif (t.config.moe_dense_shexp) {
                     // gemma4: experts ship FUSED as ffn_gate_up_exps {dim, 2*nfe, ne} — expert-major,
                     // each [2*nfe x dim] with rows [0..nfe) = gate, [nfe..2*nfe) = up. Split per expert
-                    // (block-aligned Q8 slices, ege is a multiple of 32) into the separate we1(gate)/
+                    // (block-aligned Q8 slices, ege is a multiple of 32; kq tags guarantee ege % 256,
+                    // so K-quant slices stay superblock-aligned too) into the separate we1(gate)/
                     // we3(up) stacks the routed GEMM seam expects; ffn_down_exps loads whole.
                     for (e in range64(ne)) {
-                        let dst = (l * ne + e) * ege
+                        let dst = e * ege
                         let src = e * 2l * ege
-                        load_big(m, bytes, "blk.{l}.ffn_gate_up_exps.weight", t, t.we1_off + dst, ege, scratch, src)
-                        load_big(m, bytes, "blk.{l}.ffn_gate_up_exps.weight", t, t.we3_off + dst, ege, scratch, src + ege)
+                        load_big(m, bytes, "blk.{l}.ffn_gate_up_exps.weight", t, t.we1_offs[l] + dst, ege, scratch, src, fmt_at(t.we1_fmt, l))
+                        load_big(m, bytes, "blk.{l}.ffn_gate_up_exps.weight", t, t.we3_offs[l] + dst, ege, scratch, src + ege, fmt_at(t.we3_fmt, l))
                     }
-                    load_big(m, bytes, "blk.{l}.ffn_down_exps.weight", t, t.we2_off + l * ne * ege, ne * ege, scratch)
+                    load_big(m, bytes, "blk.{l}.ffn_down_exps.weight", t, t.we2_offs[l], ne * ege, scratch, 0l, fmt_at(t.we2_fmt, l))
                 } else {
-                    load_big(m, bytes, "blk.{l}.ffn_gate_exps.weight", t, t.we1_off + l * ne * ege, ne * ege, scratch)
-                    load_big(m, bytes, "blk.{l}.ffn_down_exps.weight", t, t.we2_off + l * ne * ege, ne * ege, scratch)
-                    load_big(m, bytes, "blk.{l}.ffn_up_exps.weight", t, t.we3_off + l * ne * ege, ne * ege, scratch)
+                    load_big(m, bytes, "blk.{l}.ffn_gate_exps.weight", t, t.we1_offs[l], ne * ege, scratch, 0l, fmt_at(t.we1_fmt, l))
+                    load_big(m, bytes, "blk.{l}.ffn_down_exps.weight", t, t.we2_offs[l], ne * ege, scratch, 0l, fmt_at(t.we2_fmt, l))
+                    load_big(m, bytes, "blk.{l}.ffn_up_exps.weight", t, t.we3_offs[l], ne * ege, scratch, 0l, fmt_at(t.we3_fmt, l))
                 }
                 if (t.config.moe_exps_bias) {  // per-expert bias stacks, expert-major on disk like the weights
                     let nfe = t.config.n_ff_exp
@@ -1873,6 +1923,10 @@ struct Session {
     // matmul — dedicated buffers because the down-projections quantize s.hb into the shared xq/xs
     moe_xq : array<int8>        // xb's Q8 quants (dim)
     moe_xs : array<float>       // xb's per-block scales (dim / 32)
+    // K-quant activation block sums for the expert dispatch (the moe twins of xbs/xbs2, filled
+    // by the bs quantizers only on layers with kq-tagged expert stacks; sized always — ~KB)
+    moe_xbs : array<int>        // per-16 sums of moe_xq (dim / 16)
+    moe_dbs : array<int>        // per-16 sums of moe_dq (k x n_ff_exp / 16)
     // grouped MoE prefill scratch — sized per prefill by ffn_moe_prefill_grouped; empty for dense
     // arches, decode, and the per-position reference path
     moe_rlog : array<float>     // batched router logits (npos x n_expert)
@@ -1951,6 +2005,8 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
         }
         s.moe_xq |> resize(c.dim)
         s.moe_xs |> resize(c.dim / 32l)
+        s.moe_xbs |> resize(c.dim / 16l)
+        s.moe_dbs |> resize(c.n_expert_used * c.n_ff_exp / 16l)
         s.moe_offs |> resize(2l * c.n_expert_used)
         s.moe_boffs |> resize(c.n_expert_used)
         s.moe_gu |> resize(c.n_expert_used * c.n_ff_exp)
@@ -3212,6 +3268,29 @@ def private mm_b_kq(var s : Session; var y : array<float>; t : Model; fmt : KqFm
 
 // Chain hoists (kq stage 4): a kq-tagged weight's plane byte bases at element offset woff and
 // the stamped rows core for its format. q8 tags get nulls — their branch never reads these.
+// Region-list kq GEMV over the model's planes (the MoE expert dispatch's kq twin of
+// mm_at_q8_groupn; offs = (weight, activation) element-offset pairs within fmt's plane).
+// Repacked loads run the backend's kq_groupn (registered with the other kq slots — a kq
+// backend without one panics via the stub); disk-order loads run the portable region walk.
+def private mm_at_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64) {
+    let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
+    if (t.kq_repacked) {
+        if (fmt == KqFmt.k4) {
+            matmul_kq_groupn_active(fi, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
+        } elif (fmt == KqFmt.k5) {
+            matmul_kq_groupn_active(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+        } else {
+            matmul_kq_groupn_active(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+        }
+    } elif (fmt == KqFmt.k4) {
+        matmul_kq_groupn(fi, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
+    } elif (fmt == KqFmt.k5) {
+        matmul_kq_groupn(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+    } else {
+        matmul_kq_groupn(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+    }
+}
+
 def private kq_plane_q(t : Model; fmt : KqFmt; woff : int64) : uint8 const? {
     let sb = woff / 256l
     if (fmt == KqFmt.k4) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k4q[sb * K4_QSB]))))
@@ -4483,9 +4562,14 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
     // layer. Dedicated moe_xq/moe_xs buffers: the down-projections quantize s.hb into the shared
     // xq/xs scratch, which would clobber a hoisted xb image there. Bit-identical (same quants).
     let pre_q8 = t.quant == QuantMode.q8
+    let layer_kq = pre_q8 && moe_layer_kq(t, l)
     if (pre_q8) {
         let ts_rq = ref_time_ticks()
-        quantize_q8_0_into(s.xb, dim, s.moe_xq, s.moe_xs, 0l, 0l)
+        if (layer_kq) {   // bit-identical quants/scales; the bs form adds the per-16 sums the kq dots consume
+            quantize_q8_0_bs_into(s.xb, dim, s.moe_xq, s.moe_xs, s.moe_xbs, 0l, 0l, 0l)
+        } else {
+            quantize_q8_0_into(s.xb, dim, s.moe_xq, s.moe_xs, 0l, 0l)
+        }
         prof_add("mm_requant", ts_rq)
     }
     let nfe = c.n_ff_exp
@@ -4498,13 +4582,18 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
         // dense mms' 104 GB/s was mostly this dispatch overhead).
         let ts_gu = ref_time_ticks()
         let biased = c.moe_exps_bias   // gpt-oss: each expert's biases fold into the workers' stores
+        let f1 = fmt_at(t.we1_fmt, l)
+        let f2 = fmt_at(t.we2_fmt, l)
+        let f3 = fmt_at(t.we3_fmt, l)
         for (j in range64(k)) {
             let e = l * ne + s.moe_idx[j]
-            s.moe_offs[j * 2l] = t.we1_off + e * ege
+            s.moe_offs[j * 2l] = t.we1_offs[l] + s.moe_idx[j] * ege
             s.moe_offs[j * 2l + 1l] = 0l   // gates share the single hoisted xb image
             s.moe_boffs[j] = t.web1_off + e * nfe
         }
-        if (t.experts_mx4) {   // native 4-bit expert weights — half the Q8 traffic
+        if (f1 != KqFmt.q8) {   // native K-quant expert stack (never biased — detect guards that)
+            mm_at_kq_groupn(s.moe_gu, t, f1, s.moe_offs, k, s.moe_xq, s.moe_xs, s.moe_xbs, dim, nfe)
+        } elif (t.experts_mx4) {   // native 4-bit expert weights — half the Q8 traffic
             if (biased) {
                 mm_at_mx4_groupn(s.moe_gu, t, s.moe_offs, s.moe_boffs, k, s.moe_xq, s.moe_xs, dim, nfe)
             } else {
@@ -4517,11 +4606,13 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
         }
         for (j in range64(k)) {
             let e = l * ne + s.moe_idx[j]
-            s.moe_offs[j * 2l] = t.we3_off + e * ege
+            s.moe_offs[j * 2l] = t.we3_offs[l] + s.moe_idx[j] * ege
             s.moe_offs[j * 2l + 1l] = 0l   // ups read the same hoisted xb image (explicit, not inherited from the gate pass)
             s.moe_boffs[j] = t.web3_off + e * nfe
         }
-        if (t.experts_mx4) {
+        if (f3 != KqFmt.q8) {
+            mm_at_kq_groupn(s.moe_gu2, t, f3, s.moe_offs, k, s.moe_xq, s.moe_xs, s.moe_xbs, dim, nfe)
+        } elif (t.experts_mx4) {
             if (biased) {
                 mm_at_mx4_groupn(s.moe_gu2, t, s.moe_offs, s.moe_boffs, k, s.moe_xq, s.moe_xs, dim, nfe)
             } else {
@@ -4536,15 +4627,21 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_gu, s.moe_gu2, c.ffn_act, nfe, k)
         prof_add("act", ts_act)
-        requant_rows_q8(s.moe_gu, nfe, k, s.moe_dq, s.moe_ds)   // books mm_requant
+        if (f2 != KqFmt.q8) {   // bit-identical rows + the per-16 sums the down dots consume
+            requant_rows_q8_bs(s.moe_gu, nfe, k, s.moe_dq, s.moe_ds, s.moe_dbs)
+        } else {
+            requant_rows_q8(s.moe_gu, nfe, k, s.moe_dq, s.moe_ds)   // books mm_requant
+        }
         let ts_down = ref_time_ticks()
         for (j in range64(k)) {
             let e = l * ne + s.moe_idx[j]
-            s.moe_offs[j * 2l] = t.we2_off + e * ege
+            s.moe_offs[j * 2l] = t.we2_offs[l] + s.moe_idx[j] * ege
             s.moe_offs[j * 2l + 1l] = j * nfe   // each down reads its own requantized row
             s.moe_boffs[j] = t.web2_off + e * dim   // down bias inside the routed weight (ggml_add_id order)
         }
-        if (t.experts_mx4) {
+        if (f2 != KqFmt.q8) {
+            mm_at_kq_groupn(s.moe_dn, t, f2, s.moe_offs, k, s.moe_dq, s.moe_ds, s.moe_dbs, nfe, dim)
+        } elif (t.experts_mx4) {
             if (biased) {
                 mm_at_mx4_groupn(s.moe_dn, t, s.moe_offs, s.moe_boffs, k, s.moe_dq, s.moe_ds, nfe, dim)
             } else {
@@ -4565,10 +4662,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
         // fp32 reference path: the per-expert loop (q4 never routes here — MoE loads are q8/fp32)
         for (j in range64(k)) {
             let e = l * ne + s.moe_idx[j]
-            let base = e * ege
+            let base = s.moe_idx[j] * ege
             let ts_gu = ref_time_ticks()
-            mm(s.hb, t, t.we1_off + base, s.xb, s.xq, s.xs, dim, nfe)
-            mm(s.hb2, t, t.we3_off + base, s.xb, s.xq, s.xs, dim, nfe)
+            mm(s.hb, t, t.we1_offs[l] + base, s.xb, s.xq, s.xs, dim, nfe)
+            mm(s.hb2, t, t.we3_offs[l] + base, s.xb, s.xq, s.xs, dim, nfe)
             if (c.moe_exps_bias) {  // gpt-oss: this expert's gate/up biases before the activation
                 add_bias(s.hb, 0l, t.fblob, t.web1_off + e * nfe, nfe)
                 add_bias(s.hb2, 0l, t.fblob, t.web3_off + e * nfe, nfe)
@@ -4578,7 +4675,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
             gate_batch(s.hb, s.hb2, c.ffn_act, nfe, 1l)
             prof_add("act", ts_act)
             let ts_down = ref_time_ticks()
-            mm(s.xb2, t, t.we2_off + base, s.hb, s.xq, s.xs, nfe, dim)
+            mm(s.xb2, t, t.we2_offs[l] + base, s.hb, s.xq, s.xs, nfe, dim)
             if (c.moe_exps_bias) {  // ... and its down bias, inside the routed weight (ggml_add_id order)
                 add_bias(s.xb2, 0l, t.fblob, t.web2_off + e * dim, dim)
             }
@@ -4826,7 +4923,9 @@ def private ffn_gemma4_prefill(t : Model; var s : Session; l : int64; npos : int
         return
     }
     let dim = c.dim
-    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill) {
+    // K-quant expert layers take the per-position reference path for now — the grouped buckets'
+    // batch GEMMs are q8-only until the kq batch tile is wired in (the decode groupn serves them)
+    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && !moe_layer_kq(t, l)) {
         gemma4_moe_prefill_grouped(t, s, l, npos)
     } else {
         for (p in range64(npos)) {
@@ -6260,14 +6359,14 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
                 continue
             }
             let eg = l * ne + e
-            let base = eg * dim * nfe
-            offs1 |> push(t.we1_off + base)
+            let base = e * dim * nfe
+            offs1 |> push(t.we1_offs[l] + base)
             offs1 |> push(b0)
             offs1 |> push(cnt)
-            offs3 |> push(t.we3_off + base)
+            offs3 |> push(t.we3_offs[l] + base)
             offs3 |> push(b0)
             offs3 |> push(cnt)
-            offs2 |> push(t.we2_off + base)
+            offs2 |> push(t.we2_offs[l] + base)
             offs2 |> push(b0)
             offs2 |> push(cnt)
             if (c.moe_exps_bias) {
@@ -6322,27 +6421,27 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         moe_gather_rows(s, b0, cnt, dim, k)
         prof_add("moe_gather", ts_gather)
         let eg = l * ne + e
-        let base = eg * dim * nfe
+        let base = e * dim * nfe
         if (t.experts_mx4 && g_active_mx4_native_batch) {
             // native mx4 batch GEMMs straight off the nibble/E8M0 planes — no expansion
-            mm_b_mx4_pre(s.moe_ghb, t, t.we1_off + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
-            mm_b_mx4_pre(s.moe_ghb2, t, t.we3_off + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+            mm_b_mx4_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+            mm_b_mx4_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         } elif (t.experts_mx4) {   // exact Q8 expansion of this expert, then the proven batch GEMMs
             let ts_ex = ref_time_ticks()
-            expand_mx4_region_q8(t, t.we1_off + base, dim, nfe, s.mx4_wq, s.mx4_ws)
+            expand_mx4_region_q8(t, t.we1_offs[l] + base, dim, nfe, s.mx4_wq, s.mx4_ws)
             prof_add("moe_expand", ts_ex)
             let ts_g1 = ref_time_ticks()
             matmul_q8q8_batch(s.moe_ghb, s.mx4_wq, s.mx4_ws, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             prof_add("mm_gemm", ts_g1)
             let ts_ex2 = ref_time_ticks()
-            expand_mx4_region_q8(t, t.we3_off + base, dim, nfe, s.mx4_wq, s.mx4_ws)
+            expand_mx4_region_q8(t, t.we3_offs[l] + base, dim, nfe, s.mx4_wq, s.mx4_ws)
             prof_add("moe_expand", ts_ex2)
             let ts_g2 = ref_time_ticks()
             matmul_q8q8_batch(s.moe_ghb2, s.mx4_wq, s.mx4_ws, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             prof_add("mm_gemm", ts_g2)
         } else {
-            mm_b_q8_pre(s.moe_ghb, t, t.we1_off + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
-            mm_b_q8_pre(s.moe_ghb2, t, t.we3_off + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+            mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+            mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         }
         if (c.moe_exps_bias) {  // gpt-oss: this expert's gate/up biases before the activation
             for (r in range64(cnt)) {
@@ -6355,16 +6454,16 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         prof_add("act", ts_act)
         requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
         if (t.experts_mx4 && g_active_mx4_native_batch) {
-            mm_b_mx4_pre(s.moe_gout, t, t.we2_off + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
+            mm_b_mx4_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         } elif (t.experts_mx4) {
             let ts_ex3 = ref_time_ticks()
-            expand_mx4_region_q8(t, t.we2_off + base, nfe, dim, s.mx4_wq, s.mx4_ws)
+            expand_mx4_region_q8(t, t.we2_offs[l] + base, nfe, dim, s.mx4_wq, s.mx4_ws)
             prof_add("moe_expand", ts_ex3)
             let ts_g3 = ref_time_ticks()
             matmul_q8q8_batch(s.moe_gout, s.mx4_wq, s.mx4_ws, s.moe_hq, s.moe_hs, nfe, dim, cnt)
             prof_add("mm_gemm", ts_g3)
         } else {
-            mm_b_q8_pre(s.moe_gout, t, t.we2_off + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
+            mm_b_q8_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         }
         if (c.moe_exps_bias) {  // ... and its down bias, inside the routed weight (ggml_add_id order)
             for (r in range64(cnt)) {
@@ -6546,15 +6645,14 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
         let ts_gather = ref_time_ticks()
         moe_gather_rows(s, b0, cnt, dim, k)
         prof_add("moe_gather", ts_gather)
-        let eg = l * ne + e
-        let base = eg * dim * nfe
-        mm_b_q8_pre(s.moe_ghb, t, t.we1_off + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
-        mm_b_q8_pre(s.moe_ghb2, t, t.we3_off + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+        let base = e * dim * nfe
+        mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+        mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, cnt)
         prof_add("act", ts_act)
         requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
-        mm_b_q8_pre(s.moe_gout, t, t.we2_off + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
+        mm_b_q8_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         let ts_park = ref_time_ticks()
         for (r in range64(cnt)) {
             copy_floats(s.moe_gout, r * dim, s.moe_eout, s.moe_bkt[b0 + r] * dim, dim)
@@ -6626,7 +6724,9 @@ def private ffn_moe_prefill(t : Model; var s : Session; l : int64; npos : int64)
     // A native mx4-batch backend (x64) has no expansion tax, so its crossover sits lower (per-fork
     // overhead only) — the 8-rows/expert gate is kept until re-measured there.
     let mx4_grouped_pays = !t.experts_mx4 || npos * c.n_expert_used >= 8l * c.n_expert
-    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && mx4_grouped_pays) {
+    // K-quant expert layers take the per-position reference path for now — the grouped buckets'
+    // batch GEMMs are q8-only until the kq batch tile is wired in (the decode groupn serves them)
+    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && mx4_grouped_pays && !moe_layer_kq(t, l)) {
         ffn_moe_prefill_grouped(t, s, l, npos)
     } else {
         // per-position reference path — moe_ffn_core carries its own section buckets

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1937,6 +1937,8 @@ struct Session {
     moe_bkt : array<int64>      // (position*k + slot) entries grouped by expert (npos x k)
     moe_gxq : array<int8>       // one bucket's gathered activation quants (npos x dim)
     moe_gxs : array<float>      // one bucket's gathered activation scales (npos x dim/32)
+    moe_gxbs : array<int>       // ... and their per-16 sums (npos x dim/16; kq-expert layers only)
+    moe_hbs : array<int>        // bucket hidden requant per-16 sums (npos x nfx/16; kq-expert layers only)
     moe_ghb : array<float>      // bucket gate outputs (npos x max(n_ff_exp, n_ff_shexp))
     moe_ghb2 : array<float>     // bucket up outputs (same shape)
     moe_hq : array<int8>        // bucket hidden requant quants (npos x max(n_ff_exp, n_ff_shexp))
@@ -3288,6 +3290,20 @@ def private mm_at_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs :
         matmul_kq_groupn(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
     } else {
         matmul_kq_groupn(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+    }
+}
+
+// Batched kq GEMM off PRE-quantized activation rows (the grouped MoE prefill's kq twin of
+// mm_b_q8_pre). Callers guard with kq_repacked && kernel_backend_has_kq_batch() — the prefill
+// gate routes kq-expert layers to the per-position reference path otherwise.
+def private mm_b_kq_pre(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d, ntok : int64) {
+    let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
+    if (fmt == KqFmt.k4) {
+        matmul_kq_batch(fi, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, ntok)
+    } elif (fmt == KqFmt.k5) {
+        matmul_kq_batch(fi, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, ntok)
+    } else {
+        matmul_kq_batch(fi, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, ntok)
     }
 }
 
@@ -4923,9 +4939,10 @@ def private ffn_gemma4_prefill(t : Model; var s : Session; l : int64; npos : int
         return
     }
     let dim = c.dim
-    // K-quant expert layers take the per-position reference path for now — the grouped buckets'
-    // batch GEMMs are q8-only until the kq batch tile is wired in (the decode groupn serves them)
-    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && !moe_layer_kq(t, l)) {
+    // kq-expert layers ride the grouped buckets through the kq batch tile; without it (portable /
+    // no-kq backend) they take the per-position reference path (the decode groupn serves them)
+    let kq_grouped_ok = !moe_layer_kq(t, l) || (t.kq_repacked && kernel_backend_has_kq_batch())
+    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && kq_grouped_ok) {
         gemma4_moe_prefill_grouped(t, s, l, npos)
     } else {
         for (p in range64(npos)) {
@@ -6111,7 +6128,7 @@ def private copy_int64s(var d : int64?; s : int64 const?; n8 : int64) {
 // Gather one expert bucket's Q8-quantized activation rows (quants + scales) out of the whole-batch
 // image: gather row r comes from position moe_bkt[b0+r]/k. The int8 quant rows move as int64 lanes
 // (dim % 32 == 0 so dim % 8 == 0); the scales are genuine floats and ride the tuned copy_floats.
-def private moe_gather_rows(var s : Session; b0, cnt, dim, k : int64) {
+def private moe_gather_rows(var s : Session; b0, cnt, dim, k : int64; with_bs : bool = false) {
     let nb = dim / 32l
     let d8 = dim / 8l
     unsafe {
@@ -6123,6 +6140,15 @@ def private moe_gather_rows(var s : Session; b0, cnt, dim, k : int64) {
             let p = s.moe_bkt[b0 + r] / k
             copy_int64s(gqp + r * d8, xqp + p * d8, d8)
             copy_floats(gsp + r * nb, xsp + p * nb, nb)
+        }
+        if (with_bs) {   // kq-expert layers: the per-16 sum rows ride along (dim/16 ints = dim/32 int64s)
+            let nb8 = dim / 32l
+            let bp = reinterpret<int64 const?>(addr(s.xbsb[0]))
+            var gbp = reinterpret<int64?>(addr(s.moe_gxbs[0]))
+            for (r in range64(cnt)) {
+                let p = s.moe_bkt[b0 + r] / k
+                copy_int64s(gbp + r * nb8, bp + p * nb8, nb8)
+            }
         }
     }
 }
@@ -6271,6 +6297,11 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     // every routed row at once (nk rows, bucket-ordered) instead of one expert's bucket at a time
     let fused = t.experts_mx4 && g_active_mx4_native_batch && g_moe_fused_expert_gemms
     let grows = fused ? nk : npos
+    // per-layer expert stack formats (kq layers: the gate routed us here only with the batch tile up)
+    let kq_layer = moe_layer_kq(t, l)
+    let f1 = fmt_at(t.we1_fmt, l)
+    let f2 = fmt_at(t.we2_fmt, l)
+    let f3 = fmt_at(t.we3_fmt, l)
     s.moe_rlog |> resize(npos * ne)
     s.moe_idx_b |> resize(nk)
     s.moe_w_b |> resize(nk)
@@ -6286,6 +6317,10 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     s.moe_eout |> resize(nk * dim)
     if (nsh > 0l) {
         s.moe_gl_b |> resize(npos)
+    }
+    if (kq_layer) {
+        s.moe_gxbs |> resize(grows * dim / 16l)
+        s.moe_hbs |> resize(grows * nfx / 16l)
     }
 
     // 1. route every position: one batched router GEMM (bit-identical per row to decode's
@@ -6323,8 +6358,13 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     }
     prof_add("moe_route", ts_route)
 
-    // 2. quantize every normed activation row ONCE (same per-row quants as the decode hoist)
-    requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
+    // 2. quantize every normed activation row ONCE (same per-row quants as the decode hoist;
+    //    kq layers add the per-16 sums — bit-identical quants/scales either way)
+    if (kq_layer) {
+        requant_rows_q8_bs(s.xb_b, dim, npos, s.xqb, s.xsb, s.xbsb)
+    } else {
+        requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
+    }
 
     // 3F. fused expert GEMMs (native mx4-batch backends): gather every routed row once (bucket
     //     order), then ALL touched experts' gates, ups, and downs each run as ONE region-list
@@ -6418,11 +6458,22 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
             continue
         }
         let ts_gather = ref_time_ticks()
-        moe_gather_rows(s, b0, cnt, dim, k)
+        moe_gather_rows(s, b0, cnt, dim, k, kq_layer)
         prof_add("moe_gather", ts_gather)
         let eg = l * ne + e
         let base = e * dim * nfe
-        if (t.experts_mx4 && g_active_mx4_native_batch) {
+        if (kq_layer) {   // native kq batch tiles off the repacked planes, per-kind fmt (down may differ)
+            if (f1 != KqFmt.q8) {
+                mm_b_kq_pre(s.moe_ghb, t, f1, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+            } else {
+                mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+            }
+            if (f3 != KqFmt.q8) {
+                mm_b_kq_pre(s.moe_ghb2, t, f3, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+            } else {
+                mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+            }
+        } elif (t.experts_mx4 && g_active_mx4_native_batch) {
             // native mx4 batch GEMMs straight off the nibble/E8M0 planes — no expansion
             mm_b_mx4_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             mm_b_mx4_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
@@ -6452,8 +6503,14 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, cnt)
         prof_add("act", ts_act)
-        requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
-        if (t.experts_mx4 && g_active_mx4_native_batch) {
+        if (f2 != KqFmt.q8) {   // bit-identical rows + the per-16 sums the kq down tile consumes
+            requant_rows_q8_bs(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs, s.moe_hbs)
+        } else {
+            requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
+        }
+        if (f2 != KqFmt.q8) {
+            mm_b_kq_pre(s.moe_gout, t, f2, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim, cnt)
+        } elif (t.experts_mx4 && g_active_mx4_native_batch) {
             mm_b_mx4_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         } elif (t.experts_mx4) {
             let ts_ex3 = ref_time_ticks()
@@ -6584,6 +6641,11 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
     let k = c.n_expert_used
     let nfe = c.n_ff_exp
     let nk = npos * k
+    // per-layer expert stack formats (kq layers: the gate routed us here only with the batch tile up)
+    let kq_layer = moe_layer_kq(t, l)
+    let f1 = fmt_at(t.we1_fmt, l)
+    let f2 = fmt_at(t.we2_fmt, l)
+    let f3 = fmt_at(t.we3_fmt, l)
     s.moe_rlog |> resize(npos * ne)
     s.moe_idx_b |> resize(nk)
     s.moe_w_b |> resize(nk)
@@ -6597,6 +6659,10 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
     s.moe_hs |> resize(npos * nfe / 32l)
     s.moe_gout |> resize(npos * dim)
     s.moe_eout |> resize(nk * dim)
+    if (kq_layer) {
+        s.moe_gxbs |> resize(npos * dim / 16l)
+        s.moe_hbs |> resize(npos * nfe / 16l)
+    }
 
     // 1. route every position: custom double-RMS router input in xb2_b, one batched router GEMM,
     //    per-row select, then fold each selected expert's ffn_down_exps_s down scale into its weight
@@ -6631,10 +6697,15 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
     prof_add("moe_route", ts_route)
 
     // 2. expert input = pre_ffw_norm_2(residual) per position, quantized ONCE for every expert GEMM
+    //    (kq layers add the per-16 sums — bit-identical quants/scales either way)
     rms_batch(s.xb_b, s.x_b, t, t.rms_pre_ffn2_off + l * dim, dim, npos)
-    requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
+    if (kq_layer) {
+        requant_rows_q8_bs(s.xb_b, dim, npos, s.xqb, s.xsb, s.xbsb)
+    } else {
+        requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
+    }
 
-    // 3. one Q8 batch GEMM chain per touched expert over its gathered rows; the raw down-projection
+    // 3. one batched GEMM chain per touched expert over its gathered rows; the raw down-projection
     //    rows park in the (position, slot) grid for the ordered reduce
     for (e in range64(ne)) {
         let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
@@ -6643,16 +6714,29 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
             continue
         }
         let ts_gather = ref_time_ticks()
-        moe_gather_rows(s, b0, cnt, dim, k)
+        moe_gather_rows(s, b0, cnt, dim, k, kq_layer)
         prof_add("moe_gather", ts_gather)
         let base = e * dim * nfe
-        mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
-        mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+        if (f1 != KqFmt.q8) {
+            mm_b_kq_pre(s.moe_ghb, t, f1, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+        } else {
+            mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+        }
+        if (f3 != KqFmt.q8) {
+            mm_b_kq_pre(s.moe_ghb2, t, f3, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+        } else {
+            mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
+        }
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, cnt)
         prof_add("act", ts_act)
-        requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
-        mm_b_q8_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
+        if (f2 != KqFmt.q8) {
+            requant_rows_q8_bs(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs, s.moe_hbs)
+            mm_b_kq_pre(s.moe_gout, t, f2, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim, cnt)
+        } else {
+            requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
+            mm_b_q8_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
+        }
         let ts_park = ref_time_ticks()
         for (r in range64(cnt)) {
             copy_floats(s.moe_gout, r * dim, s.moe_eout, s.moe_bkt[b0 + r] * dim, dim)
@@ -6724,9 +6808,10 @@ def private ffn_moe_prefill(t : Model; var s : Session; l : int64; npos : int64)
     // A native mx4-batch backend (x64) has no expansion tax, so its crossover sits lower (per-fork
     // overhead only) — the 8-rows/expert gate is kept until re-measured there.
     let mx4_grouped_pays = !t.experts_mx4 || npos * c.n_expert_used >= 8l * c.n_expert
-    // K-quant expert layers take the per-position reference path for now — the grouped buckets'
-    // batch GEMMs are q8-only until the kq batch tile is wired in (the decode groupn serves them)
-    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && mx4_grouped_pays && !moe_layer_kq(t, l)) {
+    // kq-expert layers ride the grouped buckets through the kq batch tile; without it (portable /
+    // no-kq backend) they take the per-position reference path (the decode groupn serves them)
+    let kq_grouped_ok = !moe_layer_kq(t, l) || (t.kq_repacked && kernel_backend_has_kq_batch())
+    if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && mx4_grouped_pays && kq_grouped_ok) {
         ffn_moe_prefill_grouped(t, s, l, npos)
     } else {
         // per-position reference path — moe_ffn_core carries its own section buckets

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1836,6 +1836,7 @@ struct Session {
     hb2_b : array<float>      // FFN gate (npos x hidden_dim)
     xqb : array<int8>         // batched activation Q8 quants (npos x max(dim, hidden_dim))
     xsb : array<float>        // batched activation Q8 scales (npos x max(dim, hidden_dim) / 32)
+    xbsb : array<int>         // batched per-16 activation sums (npos x maxn / 16) — the kq batch tile's offset term
     // flash-attention per-head packing scratch (empty unless AttnPrefillMode.flash; sized in
     // forward_prefill to n_heads × tile, so each head's tile work is contention-free when threaded)
     fa_q : array<float>       // packed Q tile [n_heads × QT × head_size]
@@ -3181,14 +3182,30 @@ def private mm_kq(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x 
     mm_at_kq_pre(y, t, fmt, woff, xq, xs, xbs, n, d)
 }
 
-// Batched K-quant matmul: positions run serially, each bs-quantized into the shared decode
-// scratch then a full row GEMV (which parallelizes over d). Exact — the mx4 expand-to-q8 trick
-// is lossy for asymmetric K-quants, so prefill pays a slower path until a native tile lands.
-def private mm_b_kq(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; var xq : array<int8>; var xs : array<float>; var xbs : array<int>; n, d, npos : int64) {
+// Batched K-quant matmul. Repacked loads with a kq batch kernel run the native tile: one
+// threaded bs-requant of the whole activation image, then ONE weight-stationary GEMM (weights
+// stream once per 4-token tile — bit-for-bit npos x the per-position GEMV). Otherwise (disk-
+// order planes / no tile) positions run serially, each bs-quantized into the decode scratch
+// then a full row GEMV — exact; the mx4 expand-to-q8 trick is lossy for asymmetric K-quants.
+def private mm_b_kq(var s : Session; var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; n, d, npos : int64) {
+    if (t.kq_repacked && kernel_backend_has_kq_batch()) {
+        requant_rows_q8_bs(x, n, npos, s.xqb, s.xsb, s.xbsb)
+        let ts_gemm = ref_time_ticks()
+        let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
+        if (fmt == KqFmt.k4) {
+            matmul_kq_batch(fi, y, t.k4q, t.k4s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+        } elif (fmt == KqFmt.k5) {
+            matmul_kq_batch(fi, y, t.k5q, t.k5s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+        } else {
+            matmul_kq_batch(fi, y, t.k6q, t.k6s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+        }
+        prof_add("mm_gemm", ts_gemm)
+        return
+    }
     unsafe {
         for (p in range64(npos)) {
-            quantize_q8_0_bs_into_ptr(addr(x[p * n]), n, addr(xq[0]), addr(xs[0]), addr(xbs[0]), 0l, 0l, 0l)
-            mm_at_kq_pre(y, t, fmt, woff, xq, xs, xbs, n, d, p * d)
+            quantize_q8_0_bs_into_ptr(addr(x[p * n]), n, addr(s.xq[0]), addr(s.xs[0]), addr(s.xbs[0]), 0l, 0l, 0l)
+            mm_at_kq_pre(y, t, fmt, woff, s.xq, s.xs, s.xbs, n, d, p * d)
         }
     }
 }
@@ -3238,13 +3255,13 @@ def private mm_pre_f(var y : array<float>; t : Model; fmt : KqFmt; woff : int64;
     }
 }
 
-// Batched format router: q8 weights ride the batch tile; kq weights take the serial-per-position
-// plane GEMVs through the DECODE scratch (xq/xs/xbs — sized max(dim, hidden), not the batch planes).
+// Batched format router: q8 weights ride the batch tile; kq weights take the native kq tile
+// (repacked loads) or the serial-per-position fallback (see mm_b_kq).
 def private mm_b_f(var s : Session; var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; n, d, npos : int64) {
     if (fmt == KqFmt.q8) {
         mm_b(y, t, woff, x, s.xqb, s.xsb, n, d, npos)
     } else {
-        mm_b_kq(y, t, fmt, woff, x, s.xq, s.xs, s.xbs, n, d, npos)
+        mm_b_kq(s, y, t, fmt, woff, x, n, d, npos)
     }
 }
 
@@ -3278,6 +3295,30 @@ def private requant_rows_q8(x : array<float>; n, npos : int64; var xqb : array<i
                 for (p in range(rb, re)) {
                     let pp = int64(p)
                     quantize_q8_0_into_ptr(xp + pp * n, n, qp, sp, pp * n, pp * nb)
+                }
+            }
+        }
+    }
+    prof_add("mm_requant", ts_rq)
+}
+
+// The bs twin of requant_rows_q8: quants + scales byte-identical, plus the per-16 sums the kq
+// batch tile's offset term consumes (row p's sums at xbsb[p * n/16 ..)).
+def private requant_rows_q8_bs(x : array<float>; n, npos : int64; var xqb : array<int8>; var xsb : array<float>; var xbsb : array<int>) {
+    let nb = n / 32l
+    let nh = n / 16l
+    let ts_rq = ref_time_ticks()
+    unsafe {
+        let xp = reinterpret<float const?>(addr(x[0]))
+        var qp = addr(xqb[0])
+        var sp = addr(xsb[0])
+        var bp = addr(xbsb[0])
+        let rq_par = n * npos >= g_requant_par_threshold
+        maybe_parallel_for(rq_par, 0, int(npos), get_dispatch_lanes()) $(rb, re) {
+            unsafe {
+                for (p in range(rb, re)) {
+                    let pp = int64(p)
+                    quantize_q8_0_bs_into_ptr(xp + pp * n, n, qp, sp, bp, pp * n, pp * nb, pp * nh)
                 }
             }
         }
@@ -6770,6 +6811,9 @@ def private forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : 
     s.hb2_b |> resize(npos * hidden)
     s.xqb |> resize(npos * maxn)
     s.xsb |> resize(npos * maxn / 32l)
+    if (t.kquant_native) {   // kq batch tile: per-16 sums beside the batch quants
+        s.xbsb |> resize(npos * maxn / 16l)
+    }
     if (has_ple(c)) {   // gemma-4 E-series PLE prefill scratch (npos positions)
         let all = c.n_layers * c.n_embd_per_layer
         s.ple_inp |> resize(npos * all)
@@ -6912,6 +6956,9 @@ def private batch_decode_alloc(t : Model; var s : Session; nrows : int64) {
     s.hb2_b |> resize(nrows * hidden)
     s.xqb |> resize(nrows * maxn)
     s.xsb |> resize(nrows * maxn / 32l)
+    if (t.kquant_native) {   // kq batch tile: per-16 sums beside the batch quants
+        s.xbsb |> resize(nrows * maxn / 16l)
+    }
     if (s.kv_dtype_k == KVDtype.q8_0) {   // batch query-quant planes (dtypes snapshotted before this)
         s.attq |> resize(nrows * qd)
         s.atts |> resize(nrows * qd / 32l)
@@ -7147,7 +7194,7 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
         // tied weights (fp32/q4 loads): the classifier IS the fp32 embedding table
         mm_fblob_b(ws.logits_b, t, t.tok_emb_off, ws.scr.xb_b, dim, vocab, nrows)
     } elif (cls_fmt != KqFmt.q8) {
-        mm_b_kq(ws.logits_b, t, cls_fmt, t.wcls_off, ws.scr.xb_b, ws.scr.xq, ws.scr.xs, ws.scr.xbs, dim, vocab, nrows)
+        mm_b_kq(ws.scr, ws.logits_b, t, cls_fmt, t.wcls_off, ws.scr.xb_b, dim, vocab, nrows)
     } else {
         mm_b(ws.logits_b, t, t.wcls_off, ws.scr.xb_b, ws.scr.xqb, ws.scr.xsb, dim, vocab, nrows)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1527,6 +1527,11 @@ struct Session {
     // requant needs its own buffers; chain_stages is the reused stage-def array (no per-layer alloc)
     xq2 : array<int8>         // activated-hidden requant quants (ffn width)
     xs2 : array<float>        // ... and their scales (ffn width / 32)
+    // K-quant activation block sums: sum of each 16 quants of xq / xq2 (the K-quant dot's offset
+    // term is o * Σq_a per weight sub-block). Filled by quantize_q8_0_bs_into alongside xq/xs
+    // on the kq-native paths; sized always (~KB)
+    xbs : array<int>          // per-16 sums of xq (sized max(dim, hidden_dim) / 16)
+    xbs2 : array<int>         // per-16 sums of xq2 (ffn width / 16)
     chain_stages : array<int3>  // stage defs, int3(range_begin, range_end, num_chunks)
     // flash-decode attention partials (fused chain, ctx > FLASH_DECODE_SLICE): per (head, slice)
     // running max / exp-sum / unnormalized AV accumulator, combined per head in the chain's
@@ -1696,6 +1701,8 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
     s.xs |> resize(maxn / 32l)
     s.xq2 |> resize(ffw)        // fused-FFN chain requant (see the Session field comment)
     s.xs2 |> resize(ffw / 32l)
+    s.xbs |> resize(maxn / 16l)   // K-quant per-16 activation sums (~KB — sized regardless of format)
+    s.xbs2 |> resize(ffw / 16l)
     if (kdt == KVDtype.q8_0) {  // q8_0 K: the roped query quantizes ONCE per token (ggml lesson)
         s.attq |> resize(qd)
         s.atts |> resize(qd / 32l)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -3011,18 +3011,28 @@ def private mm_qkv(var s : Session; t : Model; l : int64) {
     let qoff = t.wq_offs[l]
     let koff = t.wk_offs[l]
     let voff = t.wv_offs[l]
+    let fq = fmt_at(t.wq_fmt, l)
+    let fk = fmt_at(t.wk_fmt, l)
+    let fv = fmt_at(t.wv_fmt, l)
     if (voff < 0l) {
         // no attn_v tensor (gemma4 global layers): V = the pre-norm K projection. With v_norm the
         // copy fuses into the norm — rmsnorm reads all of k before writing v, and k stays intact for
         // its own qk_norm + rope — one pass instead of copy-then-norm; the block's v_norm step skips
         // these layers. Bit-identical arithmetic to copy + in-place norm.
-        mm(s.q, t, qoff, s.xb, s.xq, s.xs, dim, qd)
-        mm(s.k, t, koff, s.xb, s.xq, s.xs, dim, kv)
+        mm_f(s.q, t, fq, qoff, s.xb, s.xq, s.xs, s.xbs, dim, qd)
+        mm_f(s.k, t, fk, koff, s.xb, s.xq, s.xs, s.xbs, dim, kv)
         if (c.v_norm) {
             rms_batch(s.v, s.k, t, t.rms_ones_off, layer_head_size(c, l), layer_n_kv_heads(c, l))
         } else {
             copy_floats(s.k, 0l, s.v, 0l, kv)
         }
+    } elif (fq != KqFmt.q8 || fk != KqFmt.q8 || fv != KqFmt.q8) {
+        // K-quant projections (formats can MIX per layer — Q4_K_M keeps attn_v at Q6_K):
+        // one bs-quantize, then a per-format plane GEMV each
+        quantize_q8_0_bs_into(s.xb, dim, s.xq, s.xs, s.xbs, 0l, 0l, 0l)
+        mm_pre_f(s.q, t, fq, qoff, s.xq, s.xs, s.xbs, dim, qd)
+        mm_pre_f(s.k, t, fk, koff, s.xq, s.xs, s.xbs, dim, kv)
+        mm_pre_f(s.v, t, fv, voff, s.xq, s.xs, s.xbs, dim, kv)
     } elif (t.quant == QuantMode.q8 && lanes_for_work(dim * (qd + 2l * kv), g_gemv_lane_cap) > 1) {
         quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
         if (t.wscale_f16) {
@@ -3080,6 +3090,67 @@ def private mm_at_mx4_groupn(var y : array<float>; t : Model; offs : array<int64
 
 def private mm_at_mx4_groupn(var y : array<float>; t : Model; offs, boffs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; n, d : int64) {
     matmul_mx4q8_groupn(y, t.mxq, t.mxs, offs, nregions, xq, xs, t.fblob, boffs, n, d)
+}
+
+// ===== native K-quant dispatch (kquant_native; fmt != q8 tags) =====
+
+// K-quant GEMV against a PRE-quantized activation (xq/xs/xbs already filled by the bs quantizer).
+def private mm_at_kq_pre(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64; yoff : int64 = 0l) {
+    if (fmt == KqFmt.k4) {
+        matmul_kq(4, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, yoff)
+    } elif (fmt == KqFmt.k5) {
+        matmul_kq(5, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, yoff)
+    } else {
+        matmul_kq(6, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, yoff)
+    }
+}
+
+// K-quant matmul: bs-quantize the activation (quants + scales + the per-16 sums the offset term
+// needs), then the format's plane GEMV. The kq sibling of mm/mm_at_q8.
+def private mm_kq(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; var xq : array<int8>; var xs : array<float>; var xbs : array<int>; n, d : int64) {
+    quantize_q8_0_bs_into(x, n, xq, xs, xbs, 0l, 0l, 0l)
+    mm_at_kq_pre(y, t, fmt, woff, xq, xs, xbs, n, d)
+}
+
+// Batched K-quant matmul: positions run serially, each bs-quantized into the shared decode
+// scratch then a full row GEMV (which parallelizes over d). Exact — the mx4 expand-to-q8 trick
+// is lossy for asymmetric K-quants, so prefill pays a slower path until a native tile lands.
+def private mm_b_kq(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; var xq : array<int8>; var xs : array<float>; var xbs : array<int>; n, d, npos : int64) {
+    unsafe {
+        for (p in range64(npos)) {
+            quantize_q8_0_bs_into_ptr(addr(x[p * n]), n, addr(xq[0]), addr(xs[0]), addr(xbs[0]), 0l, 0l, 0l)
+            mm_at_kq_pre(y, t, fmt, woff, xq, xs, xbs, n, d, p * d)
+        }
+    }
+}
+
+// Format router: q8-tagged weights take the classic mm; kq tags take the plane GEMV.
+def private mm_f(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; var xq : array<int8>; var xs : array<float>; var xbs : array<int>; n, d : int64) {
+    if (fmt == KqFmt.q8) {
+        mm(y, t, woff, x, xq, xs, n, d)
+    } else {
+        mm_kq(y, t, fmt, woff, x, xq, xs, xbs, n, d)
+    }
+}
+
+// Pre-quantized format router (the activation was bs-quantized once — its quants/scales are
+// byte-identical to the plain quantizer's, so q8-tagged weights consume them unchanged).
+def private mm_pre_f(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64) {
+    if (fmt == KqFmt.q8) {
+        mm_at_q8_pre(y, t, woff, xq, xs, n, d)
+    } else {
+        mm_at_kq_pre(y, t, fmt, woff, xq, xs, xbs, n, d)
+    }
+}
+
+// Batched format router: q8 weights ride the batch tile; kq weights take the serial-per-position
+// plane GEMVs through the DECODE scratch (xq/xs/xbs — sized max(dim, hidden), not the batch planes).
+def private mm_b_f(var s : Session; var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; n, d, npos : int64) {
+    if (fmt == KqFmt.q8) {
+        mm_b(y, t, woff, x, s.xqb, s.xsb, n, d, npos)
+    } else {
+        mm_b_kq(y, t, fmt, woff, x, s.xq, s.xs, s.xbs, n, d, npos)
+    }
 }
 
 // Route a big-weight matmul through the Q8, Q4, or fp32 kernel depending on the model's quant mode.
@@ -3273,6 +3344,8 @@ def private fused_attn_ok(t : Model; l : int64) : bool {
     // needs whole 32-quant groups per head (real targets are 64/128/256; stories15M's 48 falls back)
     return (g_fused_decode && t.quant == QuantMode.q8 && g_use_rope_table
         && t.wv_offs[l] >= 0l && layer_head_size(c, l) % 32l == 0l
+        && fmt_at(t.wq_fmt, l) == KqFmt.q8 && fmt_at(t.wk_fmt, l) == KqFmt.q8
+        && fmt_at(t.wv_fmt, l) == KqFmt.q8 && fmt_at(t.wo_fmt, l) == KqFmt.q8   // kq layers: per-op path (chain rows cores are Q8-only for now)
         && get_jobque_team_mode() && kernel_backend_has_rows()
         && (!t.wscale_f16 || kernel_backend_has_rows16())
         && lanes_for_work(c.dim * (layer_qd(c, l) + 2l * layer_kv_dim(c, l)), g_gemv_lane_cap) > 1)
@@ -3696,6 +3769,8 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
 def private fused_ffn_ok(t : Model; l : int64) : bool {
     let c = t.config
     return (g_fused_decode && t.quant == QuantMode.q8
+        && fmt_at(t.w1_fmt, l) == KqFmt.q8 && fmt_at(t.w2_fmt, l) == KqFmt.q8
+        && fmt_at(t.w3_fmt, l) == KqFmt.q8   // kq layers: per-op path (chain rows cores are Q8-only for now)
         && get_jobque_team_mode() && kernel_backend_has_rows()
         && (!t.wscale_f16 || kernel_backend_has_rows16())
         && lanes_for_work(c.dim * layer_hidden(t, l), g_gemv_lane_cap) > 1)
@@ -3863,7 +3938,7 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     // q, k, v projections (independent — share s.xb; fused into one parallel dispatch when Q8)
     let ts_qkv = ref_time_ticks()
     if (kv_shared) {
-        mm(s.q, t, t.wq_offs[l], s.xb, s.xq, s.xs, dim, qd)   // Q only
+        mm_f(s.q, t, fmt_at(t.wq_fmt, l), t.wq_offs[l], s.xb, s.xq, s.xs, s.xbs, dim, qd)   // Q only
     } else {
         mm_qkv(s, t, l)
     }
@@ -3972,7 +4047,7 @@ def private attention_std_decode(t : Model; var s : Session; l : int64; pos : in
     prof_add("attn", ts_attn)
     // output projection (qd -> dim), optional bias + post-attention norm, residual
     let ts_wo = ref_time_ticks()
-    mm(s.xb2, t, t.wo_offs[l], s.xb, s.xq, s.xs, qd, dim)
+    mm_f(s.xb2, t, fmt_at(t.wo_fmt, l), t.wo_offs[l], s.xb, s.xq, s.xs, s.xbs, qd, dim)
     if (c.attn_out_bias) {  // gpt-oss: + bias on the projected attention output
         add_bias(s.xb2, 0l, t.bo, l * dim, dim)
     }
@@ -3994,7 +4069,25 @@ def private dense_ffn_inplace(t : Model; var s : Session; l : int64) {
     let dim = c.dim
     let hidden = layer_hidden(t, l)   // gemma-4 E2B varies FFN width per layer
     let ts_ffn = ref_time_ticks()
-    if (t.quant == QuantMode.q8) {
+    let f1 = fmt_at(t.w1_fmt, l)
+    let f2 = fmt_at(t.w2_fmt, l)
+    let f3 = fmt_at(t.w3_fmt, l)
+    if (f1 != KqFmt.q8 || f2 != KqFmt.q8 || f3 != KqFmt.q8) {
+        // K-quant FFN (Q4_K_M keeps ffn_down at Q6_K on some layers — formats mix): one
+        // bs-quantize serves every format, gate/up as separate plane GEMVs, then the gated
+        // half requants (with sums) for the down projection
+        quantize_q8_0_bs_into(s.xb, dim, s.xq, s.xs, s.xbs, 0l, 0l, 0l)
+        mm_pre_f(s.hb, t, f1, t.w1_offs[l], s.xq, s.xs, s.xbs, dim, hidden)
+        mm_pre_f(s.hb2, t, f3, t.w3_offs[l], s.xq, s.xs, s.xbs, dim, hidden)
+        prof_add("mm_ffn", ts_ffn)
+        let ts_act = ref_time_ticks()
+        gate_batch(s.hb, s.hb2, c.ffn_act, hidden, 1l)
+        prof_add("act", ts_act)
+        let ts_down = ref_time_ticks()
+        quantize_q8_0_bs_into(s.hb, hidden, s.xq, s.xs, s.xbs, 0l, 0l, 0l)
+        mm_pre_f(s.xb, t, f2, t.w2_offs[l], s.xq, s.xs, s.xbs, hidden, dim)
+        prof_add("mm_ffn", ts_down)
+    } elif (t.quant == QuantMode.q8) {
         // gate+up share the activation: ONE quantize + ONE region-list dispatch into ffn_gu's
         // halves (bit-identical — same quants, same per-row dots, only the scheduling changes)
         quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
@@ -4580,11 +4673,27 @@ def private dequant_q8_row(t : Model; off, n : int64; var dst : float?) {
 }
 
 // Copy token `token`'s embedding row into dst — from the fp32 fblob table, or (cls_q8 loads, which
-// carry no fp32 table) dequanted on demand from the linear Q8 copy at emb_q8_off.
+// carry no fp32 table) dequanted on demand from the linear Q8 copy at emb_q8_off, or (cls_kq loads)
+// from the K-quant plane at wcls_off — rows are whole superblocks (dim % 256 == 0, a ggml K-quant
+// invariant the layout relies on).
 def private embed_row(t : Model; token : int64; var dst : float?) {
     let dim = t.config.dim
     if (t.cls_q8) {
         dequant_q8_row(t, t.emb_q8_off + token * dim, dim, dst)
+    } elif (cls_kq(t)) {
+        unsafe {
+            var row = temp_array(dst, dim, type<float>)
+            let sb0 = (t.wcls_off + token * dim) / 256l
+            for (s in range64(dim / 256l)) {
+                if (t.emb_fmt == KqFmt.k4) {
+                    dequant_k4_plane_superblock(t.k4q, (sb0 + s) * K4_QSB, t.k4s, (sb0 + s) * K4_SSB, row, s * 256l)
+                } elif (t.emb_fmt == KqFmt.k5) {
+                    dequant_k5_plane_superblock(t.k5q, (sb0 + s) * K5_QSB, t.k5s, (sb0 + s) * K5_SSB, row, s * 256l)
+                } else {
+                    dequant_k6_plane_superblock(t.k6q, (sb0 + s) * K6_QSB, t.k6s, (sb0 + s) * K6_SSB, row, s * 256l)
+                }
+            }
+        }
     } else {
         copy_floats(dst, unsafe(addr(t.fblob[t.tok_emb_off + token * dim])), dim)
     }
@@ -4687,14 +4796,18 @@ def forward(t : Model; var s : Session; token, pos : int64) {
     let ts_final = ref_time_ticks()
     trace_tag(TRACE_TAG_CLS)
     rms_at(s.xb, t, t.rms_final_off, s.x, dim)
-    let tied_f32 = c.shared_weights && !t.cls_q8
-    if (c.final_logit_softcap > 0.0 && !tied_f32 && fused_cls_ok(t)) {
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
+    if (c.final_logit_softcap > 0.0 && !tied_f32 && cls_fmt == KqFmt.q8 && fused_cls_ok(t)) {
         // Gemma2/E-series: soft-cap fused into the classifier chunks
         cls_softcap_chain(t, s, c.final_logit_softcap)
     } else {
         if (tied_f32) {
             // tied weights (fp32/q4 loads): the classifier IS the fp32 embedding table
             mm_fblob(s.logits, t, t.tok_emb_off, s.xb, dim, c.vocab_size)
+        } elif (cls_fmt != KqFmt.q8) {
+            // K-quant classifier (tied plane copy or untied kq output.weight)
+            mm_kq(s.logits, t, cls_fmt, t.wcls_off, s.xb, s.xq, s.xs, s.xbs, dim, c.vocab_size)
         } else {
             // untied — or the tied classifier's Q8 transcode (the exact quants llama.cpp matmuls)
             mm(s.logits, t, t.wcls_off, s.xb, s.xq, s.xs, dim, c.vocab_size)
@@ -5470,13 +5583,13 @@ def private attn_qkv_rope_prefix(t : Model; var s : Session; l : int64; npos : i
     prof_add("norm", ts_norm0)
     // batched q/k/v projections (each re-quantizes xb_b — cheap vs the matmul)
     let ts_qkv = ref_time_ticks()
-    mm_b(s.q_b, t, t.wq_offs[l], s.xb_b, s.xqb, s.xsb, dim, qd, npos)
+    mm_b_f(s, s.q_b, t, fmt_at(t.wq_fmt, l), t.wq_offs[l], s.xb_b, dim, qd, npos)
     if (kv_shared) {
         // E-series shared-KV layer: no K/V of its own — the source layer already filled the cache
     } else {
-        mm_b(s.k_b, t, t.wk_offs[l], s.xb_b, s.xqb, s.xsb, dim, kv_dim, npos)
+        mm_b_f(s, s.k_b, t, fmt_at(t.wk_fmt, l), t.wk_offs[l], s.xb_b, dim, kv_dim, npos)
         if (t.wv_offs[l] >= 0l) {
-            mm_b(s.v_b, t, t.wv_offs[l], s.xb_b, s.xqb, s.xsb, dim, kv_dim, npos)
+            mm_b_f(s, s.v_b, t, fmt_at(t.wv_fmt, l), t.wv_offs[l], s.xb_b, dim, kv_dim, npos)
         } elif (c.v_norm) {
             // no attn_v tensor (gemma4 global layers): V = the pre-norm K projection, with the copy
             // fused into the weightless V-norm (k_b read fully before v_b is written; k_b stays intact
@@ -5541,7 +5654,7 @@ def private attn_out_suffix(t : Model; var s : Session; l : int64; npos : int64)
     let qd = c.n_heads * layer_head_size(c, l)
     // output projection (batched, qd -> dim) + optional bias + post-attn norm + residual
     let ts_wo = ref_time_ticks()
-    mm_b(s.xb2_b, t, t.wo_offs[l], s.xb_b, s.xqb, s.xsb, qd, dim, npos)
+    mm_b_f(s, s.xb2_b, t, fmt_at(t.wo_fmt, l), t.wo_offs[l], s.xb_b, qd, dim, npos)
     if (c.attn_out_bias) {  // gpt-oss: + bias per position on the projected attention output
         for (p in range64(npos)) {
             add_bias(s.xb2_b, p * dim, t.bo, l * dim, dim)
@@ -5607,15 +5720,15 @@ def private ffn_dense_prefill(t : Model; var s : Session; l : int64; npos : int6
     prof_add("norm", ts_norm1)
     // gated FFN (batched): hb = act(W1·xb) * (W3·xb) — act/mul elementwise, so batch-flat
     let ts_ffn = ref_time_ticks()
-    mm_b(s.hb_b, t, t.w1_offs[l], s.xb_b, s.xqb, s.xsb, dim, hidden, npos)
-    mm_b(s.hb2_b, t, t.w3_offs[l], s.xb_b, s.xqb, s.xsb, dim, hidden, npos)
+    mm_b_f(s, s.hb_b, t, fmt_at(t.w1_fmt, l), t.w1_offs[l], s.xb_b, dim, hidden, npos)
+    mm_b_f(s, s.hb2_b, t, fmt_at(t.w3_fmt, l), t.w3_offs[l], s.xb_b, dim, hidden, npos)
     prof_add("mm_ffn", ts_ffn)
     let ts_act = ref_time_ticks()
     gate_batch(s.hb_b, s.hb2_b, c.ffn_act, hidden, npos)   // fused act*gate (exp4 unless act_vec off)
     prof_add("act", ts_act)
     // down projection (batched) + optional post-FFN norm + residual
     let ts_ffn2 = ref_time_ticks()
-    mm_b(s.xb_b, t, t.w2_offs[l], s.hb_b, s.xqb, s.xsb, hidden, dim, npos)
+    mm_b_f(s, s.xb_b, t, fmt_at(t.w2_fmt, l), t.w2_offs[l], s.hb_b, hidden, dim, npos)
     prof_add("mm_ffn", ts_ffn2)
     let ts_resid1 = ref_time_ticks()
     if (c.pre_post_norm) {  // Gemma2: post-FFN RMSNorm per position before residual
@@ -6228,10 +6341,10 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
     // 5. dense parallel shared expert over ALL positions: rms_ffn -> GeGLU -> post_ffw_norm_1 into gout
     let ts_sh = ref_time_ticks()
     rms_batch(s.xb_b, s.x_b, t, t.rms_ffn_off + l * dim, dim, npos)
-    mm_b(s.hb_b, t, t.w1_offs[l], s.xb_b, s.xqb, s.xsb, dim, hidden, npos)
-    mm_b(s.hb2_b, t, t.w3_offs[l], s.xb_b, s.xqb, s.xsb, dim, hidden, npos)
+    mm_b_f(s, s.hb_b, t, fmt_at(t.w1_fmt, l), t.w1_offs[l], s.xb_b, dim, hidden, npos)
+    mm_b_f(s, s.hb2_b, t, fmt_at(t.w3_fmt, l), t.w3_offs[l], s.xb_b, dim, hidden, npos)
     gate_batch(s.hb_b, s.hb2_b, c.ffn_act, hidden, npos)
-    mm_b(s.moe_gout, t, t.w2_offs[l], s.hb_b, s.xqb, s.xsb, hidden, dim, npos)
+    mm_b_f(s, s.moe_gout, t, fmt_at(t.w2_fmt, l), t.w2_offs[l], s.hb_b, hidden, dim, npos)
     rms_batch(s.moe_gout, s.moe_gout, t, t.rms_post_ffn1_off + l * dim, dim, npos)
     prof_add("mm_shexp", ts_sh)
 
@@ -6501,12 +6614,15 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     let ts_final = ref_time_ticks()
     let last = npos - 1l
     rms_at(s.xb, t, t.rms_final_off, s.x_b, last * dim, dim)
-    let tied_f32 = c.shared_weights && !t.cls_q8
-    if (c.final_logit_softcap > 0.0 && !tied_f32 && fused_cls_ok(t)) {
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
+    if (c.final_logit_softcap > 0.0 && !tied_f32 && cls_fmt == KqFmt.q8 && fused_cls_ok(t)) {
         cls_softcap_chain(t, s, c.final_logit_softcap)
     } else {
         if (tied_f32) {
             mm_fblob(s.logits, t, t.tok_emb_off, s.xb, dim, c.vocab_size)
+        } elif (cls_fmt != KqFmt.q8) {
+            mm_kq(s.logits, t, cls_fmt, t.wcls_off, s.xb, s.xq, s.xs, s.xbs, dim, c.vocab_size)
         } else {
             mm(s.logits, t, t.wcls_off, s.xb, s.xq, s.xs, dim, c.vocab_size)
         }
@@ -6813,9 +6929,12 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
     let vocab = c.vocab_size
     rms_batch(ws.scr.xb_b, ws.scr.x_b, t, t.rms_final_off, dim, nrows)
     ws.logits_b |> resize(nrows * vocab)
-    if (c.shared_weights && !t.cls_q8) {
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    if (c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) {
         // tied weights (fp32/q4 loads): the classifier IS the fp32 embedding table
         mm_fblob_b(ws.logits_b, t, t.tok_emb_off, ws.scr.xb_b, dim, vocab, nrows)
+    } elif (cls_fmt != KqFmt.q8) {
+        mm_b_kq(ws.logits_b, t, cls_fmt, t.wcls_off, ws.scr.xb_b, ws.scr.xq, ws.scr.xs, ws.scr.xbs, dim, vocab, nrows)
     } else {
         mm_b(ws.logits_b, t, t.wcls_off, ws.scr.xb_b, ws.scr.xqb, ws.scr.xsb, dim, vocab, nrows)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -3293,6 +3293,19 @@ def private mm_at_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs :
     }
 }
 
+// Fused batched region-list kq GEMM (the fused MoE prefill's kq twin of the mx4 batch groupn;
+// triple offs). Callers guard with kq_repacked && kernel_backend_has_kq_batch_groupn().
+def private mm_b_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64) {
+    let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
+    if (fmt == KqFmt.k4) {
+        matmul_kq_batch_groupn(fi, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
+    } elif (fmt == KqFmt.k5) {
+        matmul_kq_batch_groupn(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+    } else {
+        matmul_kq_batch_groupn(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+    }
+}
+
 // Batched kq GEMM off PRE-quantized activation rows (the grouped MoE prefill's kq twin of
 // mm_b_q8_pre). Callers guard with kq_repacked && kernel_backend_has_kq_batch() — the prefill
 // gate routes kq-expert layers to the per-position reference path otherwise.
@@ -6295,13 +6308,17 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     let nk = npos * k
     // fused expert GEMMs (native mx4-batch backends): the gather / hidden / output images span
     // every routed row at once (nk rows, bucket-ordered) instead of one expert's bucket at a time
-    let fused = t.experts_mx4 && g_active_mx4_native_batch && g_moe_fused_expert_gemms
-    let grows = fused ? nk : npos
     // per-layer expert stack formats (kq layers: the gate routed us here only with the batch tile up)
     let kq_layer = moe_layer_kq(t, l)
     let f1 = fmt_at(t.we1_fmt, l)
     let f2 = fmt_at(t.we2_fmt, l)
     let f3 = fmt_at(t.we3_fmt, l)
+    // fused single-dispatch expert GEMMs (the mul_mat_id shape): native mx4-batch backends, and
+    // kq layers whose three stacks are ALL K-quant (a mixed q8 kind keeps the per-expert loop)
+    let fused_kq = (kq_layer && f1 != KqFmt.q8 && f2 != KqFmt.q8 && f3 != KqFmt.q8
+        && t.kq_repacked && kernel_backend_has_kq_batch_groupn() && g_moe_fused_expert_gemms)
+    let fused = (t.experts_mx4 && g_active_mx4_native_batch && g_moe_fused_expert_gemms) || fused_kq
+    let grows = fused ? nk : npos
     s.moe_rlog |> resize(npos * ne)
     s.moe_idx_b |> resize(nk)
     s.moe_w_b |> resize(nk)
@@ -6374,7 +6391,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     //     the scheduling changes.
     if (fused) {
         let ts_gather = ref_time_ticks()
-        moe_gather_rows(s, 0l, nk, dim, k)
+        moe_gather_rows(s, 0l, nk, dim, k, kq_layer)
         prof_add("moe_gather", ts_gather)
         // region triples (woff, row0, cnt) per touched expert; the three planes share row0/cnt
         var offs1 : array<int64>
@@ -6417,7 +6434,10 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
             nreg++
         }
         let ts_g1 = ref_time_ticks()
-        if (c.moe_exps_bias) {   // gpt-oss: gate/up biases fold into the stores, before the act
+        if (fused_kq) {   // native kq: one batched region-list GEMM per projection (never biased)
+            mm_b_kq_groupn(s.moe_ghb, t, f1, offs1, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+            mm_b_kq_groupn(s.moe_ghb2, t, f3, offs3, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+        } elif (c.moe_exps_bias) {   // gpt-oss: gate/up biases fold into the stores, before the act
             matmul_mx4q8_batch_groupn(s.moe_ghb, t.mxq, t.mxs, offs1, nreg, s.moe_gxq, s.moe_gxs, t.fblob, boffs1, dim, nfe)
             matmul_mx4q8_batch_groupn(s.moe_ghb2, t.mxq, t.mxs, offs3, nreg, s.moe_gxq, s.moe_gxs, t.fblob, boffs3, dim, nfe)
         } else {
@@ -6428,9 +6448,15 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, nk)
         prof_add("act", ts_act)
-        requant_rows_q8(s.moe_ghb, nfe, nk, s.moe_hq, s.moe_hs)
+        if (fused_kq) {   // bit-identical rows + the per-16 sums the kq down GEMM consumes
+            requant_rows_q8_bs(s.moe_ghb, nfe, nk, s.moe_hq, s.moe_hs, s.moe_hbs)
+        } else {
+            requant_rows_q8(s.moe_ghb, nfe, nk, s.moe_hq, s.moe_hs)
+        }
         let ts_g3 = ref_time_ticks()
-        if (c.moe_exps_bias) {   // ... and the down biases, inside the routed weight (ggml_add_id order)
+        if (fused_kq) {
+            mm_b_kq_groupn(s.moe_gout, t, f2, offs2, nreg, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim)
+        } elif (c.moe_exps_bias) {   // ... and the down biases, inside the routed weight (ggml_add_id order)
             matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, offs2, nreg, s.moe_hq, s.moe_hs, t.fblob, boffs2, nfe, dim)
         } else {
             matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, offs2, nreg, s.moe_hq, s.moe_hs, nfe, dim)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -4732,6 +4732,7 @@ def private moe_ffn_core(t : Model; var s : Session; l : int64) {
     let c = t.config
     let dim = c.dim
     let ne = c.n_expert
+    trace_tag(TRACE_TAG_ROUTE)   // decode router GEMV — without this it rides the stale attn tag in traces
     let ts_route = ref_time_ticks()
     mm_fblob(s.moe_logits, t, t.router_off + l * ne * dim, s.xb, dim, ne)
     if (c.moe_router_bias) {
@@ -4895,6 +4896,7 @@ def private gemma4_moe_ffn(t : Model; var s : Session; l : int64) {
     let k = c.n_expert_used
     // routed branch — input, custom router, select, per-expert down scale, experts, post-norm
     rms_at(s.xb, t, t.rms_pre_ffn2_off + l * dim, s.moe_ao, dim)
+    trace_tag(TRACE_TAG_ROUTE)   // decode router GEMV — without this it rides the stale attn tag in traces
     let ts_route = ref_time_ticks()
     gemma4_router_tmp(t, s, l)
     mm_fblob(s.moe_logits, t, t.router_off + l * ne * dim, s.xb2, dim, ne)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -6472,7 +6472,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
                 s.moe_ord |> push(int2(int(e), int(cnt)))
             }
         }
-        s.moe_ord |> sort() $(a, b) => a.y != b.y ? a.y > b.y : a.x < b.x
+        lpt_order(s.moe_ord)
         var nreg = 0l
         for (oe in s.moe_ord) {
             let e = int64(oe.x)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -290,6 +290,9 @@ struct Model {
     we3_fmt : array<KqFmt>
     wcls_fmt : KqFmt = KqFmt.q8
     emb_fmt : KqFmt = KqFmt.q8
+    // gemma4 E-series PLE token table (per_layer_token_embd) — gather-only (whole superblock-
+    // aligned rows dequant per token), never repacked, never matmul'd; kq tag = native planes
+    ple_emb_fmt : KqFmt = KqFmt.q8
     // Attention projections use PER-LAYER offsets — tensor shapes differ per layer class on gemma4
     // (SWA 16Q/8KV heads of 256 vs global 16Q/1KV of 512); uniform arches fill the flat strides.
     // wv_offs[l] = -1 marks a layer with no attn_v tensor (V reuses the pre-norm K projection).
@@ -655,10 +658,10 @@ def private layout_offsets(var t : Model) : LayoutSizes {
     } else {
         fill_dense_ffn_offsets(t, cur, layers, dim, hidden)
     }
-    if (has_ple(c)) {  // gemma-4 E-series PLE big weights: the Q8 token table + per-layer Q8 gate/proj
+    if (has_ple(c)) {  // gemma-4 E-series PLE big weights: the token table + per-layer Q8 gate/proj
         let ple = c.n_embd_per_layer
-        t.ple_emb_off = cur.wo   // linear, NOT repacked — gathered per token
-        cur.wo += c.vocab_size * ple * layers
+        // gather-only rows, NOT repacked — kq tag keeps native planes (disk order), else q8 linear
+        t.ple_emb_off = kq_take(cur, t.ple_emb_fmt, c.vocab_size * ple * layers)
         t.ple_gate_off = cur.wo
         cur.wo += layers * dim * ple
         t.ple_proj_off = cur.wo
@@ -674,7 +677,7 @@ def private layout_offsets(var t : Model) : LayoutSizes {
             cur.wo += c.vocab_size * dim
         } elif (cls_kq(t)) {
             // tied K-quant: ONE plane copy serves both the classifier matmul and the embedding
-            // row reads — the kq planes stay in disk order (no repack), so no second linear copy
+            // row reads (a repacking backend interleaves it in place; embed_row grp-gathers then)
             t.wcls_off = kq_take(cur, t.emb_fmt, c.vocab_size * dim)
         } else {
             t.wcls_off = 0l   // unused — the classifier reads the fp32 embedding from fblob
@@ -906,11 +909,14 @@ def private kq_fmt_of(gt : int) : KqFmt {
 }
 
 // Fill the per-kind weight format tags from the file's tensor types (q8-mode loads with the
-// kquant_native knob on). Fused-projection arches (Phi3) stay all-q8 — their sub-tensor slices
-// split fused tensors, and a K-quant split is only superblock-aligned by luck. MoE expert stacks
-// and PLE tables also stay q8 (requant fallback) — no kq kernels target them.
+// kquant_native knob on). Fused-projection arches (Phi3) split attn_qkv / ffn_up ([gate; up])
+// at load with row-aligned slice offsets (multiples of dim) — a K-quant tensor's row length is
+// % 256 by ggml, so every slice is superblock-aligned (same argument as the gemma4
+// ffn_gate_up_exps split); one disk tensor = one tag for its slices. MoE expert stacks ride
+// per-layer tags; PLE tables stay q8 (requant fallback) — no kq kernels target them.
 def private detect_kq_formats(var t : Model; m : GGUFMeta) {
-    if (t.quant != QuantMode.q8 || !g_kquant_native || t.config.fused_qkv) {
+    if (t.quant != QuantMode.q8 || !g_kquant_native
+            || (t.config.fused_qkv && t.config.dim % 256l != 0l)) {   // fused slice offsets are dim-multiples
         return
     }
     let layers = t.config.n_layers
@@ -923,13 +929,23 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
     t.w3_fmt |> resize(layers)
     var any = false
     for (l in range64(layers)) {
-        t.wq_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_q.weight"))
-        t.wk_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_k.weight"))
-        t.wv_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_v.weight"))
+        if (t.config.fused_qkv) {
+            let fqkv = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_qkv.weight"))
+            t.wq_fmt[l] = fqkv
+            t.wk_fmt[l] = fqkv
+            t.wv_fmt[l] = fqkv
+            let fgu = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight"))
+            t.w1_fmt[l] = fgu
+            t.w3_fmt[l] = fgu
+        } else {
+            t.wq_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_q.weight"))
+            t.wk_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_k.weight"))
+            t.wv_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_v.weight"))
+            t.w1_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate.weight"))
+            t.w3_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight"))
+        }
         t.wo_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_output.weight"))
-        t.w1_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate.weight"))
         t.w2_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down.weight"))
-        t.w3_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight"))
         any ||= t.wq_fmt[l] != KqFmt.q8 || t.wk_fmt[l] != KqFmt.q8 || t.wv_fmt[l] != KqFmt.q8
         any ||= t.wo_fmt[l] != KqFmt.q8 || t.w1_fmt[l] != KqFmt.q8 || t.w2_fmt[l] != KqFmt.q8
         any ||= t.w3_fmt[l] != KqFmt.q8
@@ -963,6 +979,12 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
     } else {
         t.wcls_fmt = kq_fmt_of(gguf_tensor_type(m, "output.weight"))
         any ||= t.wcls_fmt != KqFmt.q8
+    }
+    // E-series PLE token table: gather-only whole rows of layers*ple — row length must be
+    // superblock-aligned for the plane walk (256 % holds on E2B/E4B: ple 256)
+    if (has_ple(t.config) && (t.config.n_layers * t.config.n_embd_per_layer) % 256l == 0l) {
+        t.ple_emb_fmt = kq_fmt_of(gguf_tensor_type(m, "per_layer_token_embd.weight"))
+        any ||= t.ple_emb_fmt != KqFmt.q8
     }
     if (!any) {   // nothing K-quant in the file: drop the tags so fmt_at short-circuits on empty
         delete t.wq_fmt
@@ -1586,10 +1608,11 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
             let qd_l = layer_qd(t.config, l)
             if (t.config.fused_qkv) {
                 // Phi3: attn_qkv rows are [q (qd) ; k (kv) ; v (kv)], ffn_up rows are [gate ; up] (hidden each).
-                // src_off slices the fused tensor, preserving its Q8 blocks (no fp32 requantize).
-                load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wq_offs[l], dim * qd_l, scratch, 0l)
-                load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wk_offs[l], dim * kv_l, scratch, dim * qd_l)
-                load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wv_offs[l], dim * kv_l, scratch, dim * qd_l + dim * kv_l)
+                // src_off slices the fused tensor, preserving its Q8 blocks (no fp32 requantize); K-quant
+                // slices stay superblock-aligned (offsets are dim-multiples, dim % 256 gated in detect).
+                load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wq_offs[l], dim * qd_l, scratch, 0l, fmt_at(t.wq_fmt, l))
+                load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wk_offs[l], dim * kv_l, scratch, dim * qd_l, fmt_at(t.wk_fmt, l))
+                load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wv_offs[l], dim * kv_l, scratch, dim * qd_l + dim * kv_l, fmt_at(t.wv_fmt, l))
             } else {
                 load_big(m, bytes, "blk.{l}.attn_q.weight", t, t.wq_offs[l], dim * qd_l, scratch, 0l, fmt_at(t.wq_fmt, l))
                 if (t.wk_offs[l] >= 0l) {   // absent on E-series shared-KV layers (reuse the source layer's K)
@@ -1655,9 +1678,9 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
                     load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], hidden * dim, scratch, 0l, fmt_at(t.w2_fmt, l))
                 }
             } elif (t.config.fused_qkv) {
-                load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w1_offs[l], dim * hidden, scratch, 0l)
-                load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w3_offs[l], dim * hidden, scratch, dim * hidden)
-                load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], hidden * dim, scratch)
+                load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w1_offs[l], dim * hidden, scratch, 0l, fmt_at(t.w1_fmt, l))
+                load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w3_offs[l], dim * hidden, scratch, dim * hidden, fmt_at(t.w3_fmt, l))
+                load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], hidden * dim, scratch, 0l, fmt_at(t.w2_fmt, l))
             } else {
                 let h = layer_hidden(t, l)   // gemma-4 E2B varies this per layer
                 load_big(m, bytes, "blk.{l}.ffn_gate.weight", t, t.w1_offs[l], dim * h, scratch, 0l, fmt_at(t.w1_fmt, l))
@@ -1670,8 +1693,8 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
                 load_big(m, bytes, "blk.{l}.proj.weight", t, t.ple_proj_off + l * ple * dim, ple * dim, scratch)
             }
         }
-        if (has_ple(t.config)) {  // the Q8 per-layer token-embedding table [vocab x (ple*layers)], linear (gathered per token, never repacked)
-            load_big(m, bytes, "per_layer_token_embd.weight", t, t.ple_emb_off, vocab * t.config.n_embd_per_layer * layers, scratch)
+        if (has_ple(t.config)) {  // the per-layer token-embedding table [vocab x (ple*layers)], gathered per token, never repacked
+            load_big(m, bytes, "per_layer_token_embd.weight", t, t.ple_emb_off, vocab * t.config.n_embd_per_layer * layers, scratch, 0l, t.ple_emb_fmt)
         }
         if (!t.config.shared_weights) {
             load_big(m, bytes, "output.weight", t, t.wcls_off, vocab * dim, scratch, 0l, t.wcls_fmt)
@@ -4800,10 +4823,31 @@ def private ple_pre_finish(t : Model; var s : Session; embd_scaled : array<float
     scale_inplace(unsafe(addr(s.ple_inp[0])), 1.0 / sqrt(2.0), npos * all)
 }
 
+// One PLE token row (all = layers*ple elements, superblock-aligned by the detect gate) off the
+// gather's storage: native disk-order K-quant planes (the table is excluded from the grp repack)
+// or the q8 linear region on fallback loads.
+def private ple_gather_row(t : Model; row : int64; var dst : array<float>; doff : int64) {
+    let all = t.config.n_layers * t.config.n_embd_per_layer
+    let eloff = t.ple_emb_off + row * all
+    if (t.ple_emb_fmt == KqFmt.q8) {
+        dequant_q8_row(t, eloff, all, unsafe(addr(dst[doff])))
+        return
+    }
+    for (blk in range64(all / 256l)) {
+        let sb = (eloff + blk * 256l) / 256l
+        if (t.ple_emb_fmt == KqFmt.k4) {
+            dequant_k4_plane_superblock(t.k4q, sb * K4_QSB, t.k4s, sb * K4_SSB, dst, doff + blk * 256l)
+        } elif (t.ple_emb_fmt == KqFmt.k5) {
+            dequant_k5_plane_superblock(t.k5q, sb * K5_QSB, t.k5s, sb * K5_SSB, dst, doff + blk * 256l)
+        } else {
+            dequant_k6_plane_superblock(t.k6q, sb * K6_QSB, t.k6s, sb * K6_SSB, dst, doff + blk * 256l)
+        }
+    }
+}
+
 // Decode pre-step: gather the single token's per-layer embedding row, then finish.
 def private ple_pre_decode(t : Model; var s : Session; token : int64) {
-    let all = t.config.n_layers * t.config.n_embd_per_layer
-    dequant_q8_row(t, t.ple_emb_off + token * all, all, unsafe(addr(s.ple_inp[0])))
+    ple_gather_row(t, token, s.ple_inp, 0l)
     ple_pre_finish(t, s, s.x, 1l)
 }
 
@@ -4811,7 +4855,7 @@ def private ple_pre_decode(t : Model; var s : Session; token : int64) {
 def private ple_pre_prefill(t : Model; var s : Session; tokens : array<int64>; npos : int64) {
     let all = t.config.n_layers * t.config.n_embd_per_layer
     for (p in range64(npos)) {
-        dequant_q8_row(t, t.ple_emb_off + tokens[p] * all, all, unsafe(addr(s.ple_inp[p * all])))
+        ple_gather_row(t, tokens[p], s.ple_inp, p * all)
     }
     ple_pre_finish(t, s, s.x_b, npos)
 }
@@ -4821,7 +4865,7 @@ def private ple_pre_prefill(t : Model; var s : Session; tokens : array<int64>; n
 def private ple_pre_prefill_pad(t : Model; var s : Session; npos : int64) {
     let all = t.config.n_layers * t.config.n_embd_per_layer
     for (p in range64(npos)) {
-        dequant_q8_row(t, t.ple_emb_off, all, unsafe(addr(s.ple_inp[p * all])))
+        ple_gather_row(t, 0l, s.ple_inp, p * all)
     }
     ple_pre_finish(t, s, s.x_b, npos)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -6342,6 +6342,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
 
     // 1. route every position: one batched router GEMM (bit-identical per row to decode's
     //    mm_fblob), then the shared select per row; the shexp gate dots ride along
+    trace_tag(TRACE_TAG_ROUTE)
     let ts_route = ref_time_ticks()
     mm_fblob_b(s.moe_rlog, t, t.router_off + l * ne * dim, s.xb_b, dim, ne, npos)
     for (p in range64(npos)) {
@@ -6390,6 +6391,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     //     vs the per-expert loop below: the same per-row dots / bias / act / requant per row, only
     //     the scheduling changes.
     if (fused) {
+        trace_tag(TRACE_TAG_MOE)
         let ts_gather = ref_time_ticks()
         moe_gather_rows(s, 0l, nk, dim, k, kq_layer)
         prof_add("moe_gather", ts_gather)
@@ -6462,9 +6464,23 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
             matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, offs2, nreg, s.moe_hq, s.moe_hs, nfe, dim)
         }
         prof_add("mm_gemm", ts_g3)
+        // bucket row j -> the (position, slot) grid row for the reduce. Threaded: this is a
+        // 2·nk·dim·4B scatter copy (~67MB of traffic at pp512 on the 30B) — serial it was an
+        // ~8ms ALL-LANE hole between the down GEMM and the reduce (per-lane trace, dataset W)
+        trace_tag(TRACE_TAG_PARK)
         let ts_park = ref_time_ticks()
-        for (j in range64(nk)) {   // bucket row j -> the (position, slot) grid row for the reduce
-            copy_floats(s.moe_gout, j * dim, s.moe_eout, s.moe_bkt[j] * dim, dim)
+        unsafe {
+            let gp = reinterpret<float const?>(addr(s.moe_gout[0]))
+            var ep = addr(s.moe_eout[0])
+            let bp = reinterpret<int64 const?>(addr(s.moe_bkt[0]))
+            maybe_parallel_for(nk * dim >= g_act_par_threshold, 0, int(nk), get_dispatch_lanes()) $(rb, re) {
+                unsafe {
+                    for (j in range(rb, re)) {
+                        let jj = int64(j)
+                        copy_floats(ep + bp[jj] * dim, gp + jj * dim, dim)
+                    }
+                }
+            }
         }
         prof_add("moe_park", ts_park)
         delete offs1
@@ -6477,6 +6493,9 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
 
     // 3. one batched GEMM chain per touched expert over its gathered rows; raw down-projection
     //    rows park in the (position, slot) grid for the ordered reduce (skipped when fused ran)
+    if (!fused) {
+        trace_tag(TRACE_TAG_MOE)
+    }
     for (e in range64(fused ? 0l : ne)) {
         let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
         let cnt = s.moe_cnt[e] - b0
@@ -6562,6 +6581,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
 
     // 4. shared expert for ALL positions — a plain dense batched FFN off the whole-batch image
     if (nsh > 0l) {
+        trace_tag(TRACE_TAG_SHEXP)
         let she = dim * nsh
         mm_b_q8_pre(s.moe_ghb, t, t.wsh1_off + l * she, s.xqb, s.xsb, dim, nsh, npos)
         mm_b_q8_pre(s.moe_ghb2, t, t.wsh3_off + l * she, s.xqb, s.xsb, dim, nsh, npos)
@@ -6576,6 +6596,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     //    the shared expert — exactly the decode accumulation order, so the sum is bit-identical.
     //    Plain mul+add loops (NOT axpy — its fused-FMA kernel would perturb the low bits); rows are
     //    disjoint so threading never changes the result.
+    trace_tag(TRACE_TAG_PARK)
     let ts_red = ref_time_ticks()
     unsafe {
         var ap = addr(s.xb2_b[0])
@@ -6692,6 +6713,7 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
 
     // 1. route every position: custom double-RMS router input in xb2_b, one batched router GEMM,
     //    per-row select, then fold each selected expert's ffn_down_exps_s down scale into its weight
+    trace_tag(TRACE_TAG_ROUTE)
     let ts_route = ref_time_ticks()
     gemma4_router_batch(t, s.xb2_b, s.x_b, l, dim, npos)
     mm_fblob_b(s.moe_rlog, t, t.router_off + l * ne * dim, s.xb2_b, dim, ne, npos)
@@ -6733,6 +6755,7 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
 
     // 3. one batched GEMM chain per touched expert over its gathered rows; the raw down-projection
     //    rows park in the (position, slot) grid for the ordered reduce
+    trace_tag(TRACE_TAG_MOE)
     for (e in range64(ne)) {
         let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
         let cnt = s.moe_cnt[e] - b0
@@ -7074,7 +7097,9 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
 
     // per-layer transformer stack — batched attention then FFN, each through the arch's registered block
     for (l in range64(c.n_layers)) {
+        trace_tag(TRACE_TAG_ATTN_STD)   // per-lane trace: color the prefill attention section
         t.blocks.attn_prefill(t, s, l, npos, start_pos)
+        trace_tag(TRACE_TAG_FFN_STD)
         t.blocks.ffn_prefill(t, s, l, npos)
     }
 

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -33,6 +33,17 @@ enum QuantMode {
     q4
 }
 
+//! Per-weight storage format under a q8-mode load with native K-quant planes (kquant_native):
+//! q8 = qblob/qscales as always; k4/k5/k6 = the tensor's element offset indexes that format's
+//! plane pair (Model.k4q/k4s etc). A Q4_K_M file mixes formats PER TENSOR (attn_v/ffn_down and
+//! the tied embedding go Q6_K), so the tag rides per layer next to each offset array.
+enum KqFmt : uint8 {
+    q8
+    k4
+    k5
+    k6
+}
+
 //! FFN gate activation: silu = SwiGLU (Llama family), gelu = GeGLU (Gemma), swiglu_oai = the
 //! clamped SwiGLU with +1 on the up branch (gpt-oss).
 enum FfnAct {
@@ -242,6 +253,32 @@ struct Model {
     // expand bit-for-bit. ple_model_off indexes bf16blob when set, fblob otherwise.
     bf16blob : array<uint16>
     ple_model_bf16 : bool = false
+    // Native K-quant planes (valid when kquant_native): big weights whose disk type is
+    // Q4_K/Q5_K/Q6_K live in per-format plane pairs instead of qblob — quant payloads packed per
+    // 256-weight superblock (k4q 128B nibbles; k5q [128B nibbles][32B high-bits]; k6q
+    // [128B ql][64B qh]) plus scale planes (k4s/k5s: f16 (d*sc, dmin*m) pairs per 32-sub-block,
+    // 4B — the load-time unpack of the 6-bit packed sub-scales that keeps llama.cpp ALU-bound;
+    // k6s: the native 16 int8 sub-scales + f16 d, 18B, trivial to widen in-loop). The matching
+    // *_fmt tag says which plane a weight's element offset indexes: quant byte =
+    // (off/256)*{128,160,192}, scale byte = (off/32)*4 for k4/k5, (off/256)*18 for k6.
+    k4q : array<uint8>
+    k4s : array<uint8>
+    k5q : array<uint8>
+    k5s : array<uint8>
+    k6q : array<uint8>
+    k6s : array<uint8>
+    kquant_native : bool = false
+    // per-layer weight format tags (KqFmt; empty = all q8). Filled by detect_kq_formats before
+    // layout_offsets so the layout walks each tensor into its format's cursor.
+    wq_fmt : array<KqFmt>
+    wk_fmt : array<KqFmt>
+    wv_fmt : array<KqFmt>
+    wo_fmt : array<KqFmt>
+    w1_fmt : array<KqFmt>
+    w2_fmt : array<KqFmt>
+    w3_fmt : array<KqFmt>
+    wcls_fmt : KqFmt = KqFmt.q8
+    emb_fmt : KqFmt = KqFmt.q8
     // Attention projections use PER-LAYER offsets — tensor shapes differ per layer class on gemma4
     // (SWA 16Q/8KV heads of 256 vs global 16Q/1KV of 512); uniform arches fill the flat strides.
     // wv_offs[l] = -1 marks a layer with no attn_v tensor (V reuses the pre-norm K projection).
@@ -366,20 +403,58 @@ struct private LayoutSizes {
     wblob_n : int64   // element count of the big-weight region
     mx_n : int64      // element count of the native-MXFP4 expert planes (0 unless experts_mx4)
     bf16_n : int64    // halfword count of the native-BF16 region (0 unless ple_model_bf16)
+    k4_n : int64      // element counts of the native K-quant planes (0 unless kquant_native)
+    k5_n : int64
+    k6_n : int64
 }
 
-// Fill the dense FFN offset tables (w1/w2/w3), each a contiguous per-layer region, from `wo` — the
-// running big-weight cursor. Per-layer FFN width (gemma-4 E2B) reads t.ffn_w; empty = uniform `hidden`.
-// Keeping w1/w2/w3 as separate contiguous regions preserves the llama2.c checkpoint's block copy.
-def private fill_dense_ffn_offsets(var t : Model; wo, layers, dim, hidden : int64) : int64 {
-    var off = wo
+// The big-weight layout cursors: one element cursor per storage plane. kq_take advances the
+// cursor a weight's format tag selects, so layout_offsets stays a single linear walk.
+struct private KqCursors {
+    wo : int64   // qblob / wblob / q4blob (the classic parallel-offset region)
+    k4 : int64
+    k5 : int64
+    k6 : int64
+}
+
+def private kq_take(var cur : KqCursors; f : KqFmt; n : int64) : int64 {
+    if (f == KqFmt.k4) {
+        let o = cur.k4
+        cur.k4 += n
+        return o
+    }
+    if (f == KqFmt.k5) {
+        let o = cur.k5
+        cur.k5 += n
+        return o
+    }
+    if (f == KqFmt.k6) {
+        let o = cur.k6
+        cur.k6 += n
+        return o
+    }
+    let o = cur.wo
+    cur.wo += n
+    return o
+}
+
+// Format tag for layer l of a per-kind tag array; empty array (non-kq load) = q8.
+def private fmt_at(a : array<KqFmt>; l : int64) : KqFmt => empty(a) ? KqFmt.q8 : a[l]
+
+//! Tied K-quant classifier: the embedding table lives in a native K-quant plane at wcls_off —
+//! no fp32 table, no qblob copy (the cls_q8 analog for kquant_native loads).
+def cls_kq(t : Model) : bool => t.kquant_native && t.config.shared_weights && t.emb_fmt != KqFmt.q8
+
+// Fill the dense FFN offset tables (w1/w2/w3), each a contiguous per-layer region, advancing the
+// cursor each weight's format selects. Per-layer FFN width (gemma-4 E2B) reads t.ffn_w; empty =
+// uniform `hidden`. Keeping w1/w2/w3 as separate contiguous regions preserves the llama2.c block copy.
+def private fill_dense_ffn_offsets(var t : Model; var cur : KqCursors; layers, dim, hidden : int64) {
     t.w1_offs |> clear(); t.w1_offs |> reserve(layers)
-    for (l in range64(layers)) { t.w1_offs |> push(off); off += dim * (empty(t.ffn_w) ? hidden : t.ffn_w[l]) }
+    for (l in range64(layers)) { t.w1_offs |> push(kq_take(cur, fmt_at(t.w1_fmt, l), dim * (empty(t.ffn_w) ? hidden : t.ffn_w[l]))) }
     t.w2_offs |> clear(); t.w2_offs |> reserve(layers)
-    for (l in range64(layers)) { t.w2_offs |> push(off); off += (empty(t.ffn_w) ? hidden : t.ffn_w[l]) * dim }
+    for (l in range64(layers)) { t.w2_offs |> push(kq_take(cur, fmt_at(t.w2_fmt, l), (empty(t.ffn_w) ? hidden : t.ffn_w[l]) * dim)) }
     t.w3_offs |> clear(); t.w3_offs |> reserve(layers)
-    for (l in range64(layers)) { t.w3_offs |> push(off); off += dim * (empty(t.ffn_w) ? hidden : t.ffn_w[l]) }
-    return off
+    for (l in range64(layers)) { t.w3_offs |> push(kq_take(cur, fmt_at(t.w3_fmt, l), dim * (empty(t.ffn_w) ? hidden : t.ffn_w[l]))) }
 }
 
 // Fill both offset tables from the config; return the element counts of each region. The big-weight
@@ -393,8 +468,8 @@ def private layout_offsets(var t : Model) : LayoutSizes {
     let layers = c.n_layers
     var fo = 0l
     var bf16 = 0l
-    if (t.cls_q8) {
-        t.tok_emb_off = -1l   // no fp32 embedding table — rows dequant from emb_q8_off
+    if (t.cls_q8 || cls_kq(t)) {
+        t.tok_emb_off = -1l   // no fp32 embedding table — rows dequant from emb_q8_off / the kq plane
     } else {
         t.tok_emb_off = fo
         fo += c.vocab_size * dim
@@ -502,12 +577,11 @@ def private layout_offsets(var t : Model) : LayoutSizes {
             kvrow += layer_kv_dim(c, l)
         }
     }
-    var wo = 0l
+    var cur = KqCursors()
     t.wq_offs |> clear()
     t.wq_offs |> reserve(layers)
     for (l in range64(layers)) {
-        t.wq_offs |> push(wo)
-        wo += dim * layer_qd(c, l)
+        t.wq_offs |> push(kq_take(cur, fmt_at(t.wq_fmt, l), dim * layer_qd(c, l)))
     }
     t.wk_offs |> clear()
     t.wk_offs |> reserve(layers)
@@ -515,8 +589,7 @@ def private layout_offsets(var t : Model) : LayoutSizes {
         if (t.kv_src[l] != l) {
             t.wk_offs |> push(-1l)   // shared-KV layer (E-series): no attn_k of its own
         } else {
-            t.wk_offs |> push(wo)
-            wo += dim * layer_kv_dim(c, l)
+            t.wk_offs |> push(kq_take(cur, fmt_at(t.wk_fmt, l), dim * layer_kv_dim(c, l)))
         }
     }
     t.wv_offs |> clear()
@@ -526,15 +599,13 @@ def private layout_offsets(var t : Model) : LayoutSizes {
         if (t.kv_src[l] != l || ((c.v_from_k_mask >> uint64(l)) & 1ul) != 0ul) {
             t.wv_offs |> push(-1l)
         } else {
-            t.wv_offs |> push(wo)
-            wo += dim * layer_kv_dim(c, l)
+            t.wv_offs |> push(kq_take(cur, fmt_at(t.wv_fmt, l), dim * layer_kv_dim(c, l)))
         }
     }
     t.wo_offs |> clear()
     t.wo_offs |> reserve(layers)
     for (l in range64(layers)) {
-        t.wo_offs |> push(wo)
-        wo += layer_qd(c, l) * dim
+        t.wo_offs |> push(kq_take(cur, fmt_at(t.wo_fmt, l), layer_qd(c, l) * dim))
     }
     var mx = 0l
     if (c.n_expert > 0l) {
@@ -551,53 +622,57 @@ def private layout_offsets(var t : Model) : LayoutSizes {
             t.we3_off = mx
             mx += layers * c.n_expert * ege
         } else {
-            t.we1_off = wo
-            wo += layers * c.n_expert * ege
-            t.we2_off = wo
-            wo += layers * c.n_expert * ege
-            t.we3_off = wo
-            wo += layers * c.n_expert * ege
+            t.we1_off = cur.wo
+            cur.wo += layers * c.n_expert * ege
+            t.we2_off = cur.wo
+            cur.wo += layers * c.n_expert * ege
+            t.we3_off = cur.wo
+            cur.wo += layers * c.n_expert * ege
         }
         if (c.n_ff_shexp > 0l) {
             let she = dim * c.n_ff_shexp
-            t.wsh1_off = wo
-            wo += layers * she
-            t.wsh2_off = wo
-            wo += layers * she
-            t.wsh3_off = wo
-            wo += layers * she
+            t.wsh1_off = cur.wo
+            cur.wo += layers * she
+            t.wsh2_off = cur.wo
+            cur.wo += layers * she
+            t.wsh3_off = cur.wo
+            cur.wo += layers * she
         }
         if (c.moe_dense_shexp) {  // gemma4: the DENSE parallel shared expert (plain ffn gate/up/down)
-            wo = fill_dense_ffn_offsets(t, wo, layers, dim, hidden)
+            fill_dense_ffn_offsets(t, cur, layers, dim, hidden)
         }
     } else {
-        wo = fill_dense_ffn_offsets(t, wo, layers, dim, hidden)
+        fill_dense_ffn_offsets(t, cur, layers, dim, hidden)
     }
     if (has_ple(c)) {  // gemma-4 E-series PLE big weights: the Q8 token table + per-layer Q8 gate/proj
         let ple = c.n_embd_per_layer
-        t.ple_emb_off = wo   // linear, NOT repacked — gathered per token
-        wo += c.vocab_size * ple * layers
-        t.ple_gate_off = wo
-        wo += layers * dim * ple
-        t.ple_proj_off = wo
-        wo += layers * ple * dim
+        t.ple_emb_off = cur.wo   // linear, NOT repacked — gathered per token
+        cur.wo += c.vocab_size * ple * layers
+        t.ple_gate_off = cur.wo
+        cur.wo += layers * dim * ple
+        t.ple_proj_off = cur.wo
+        cur.wo += layers * ple * dim
     }
     if (c.shared_weights) {
         if (t.cls_q8) {
             // tied Q8: the classifier transcode (repacked like every 2D weight) + the linear
             // embedding copy the row reads dequant from
-            t.wcls_off = wo
-            wo += c.vocab_size * dim
-            t.emb_q8_off = wo
-            wo += c.vocab_size * dim
+            t.wcls_off = cur.wo
+            cur.wo += c.vocab_size * dim
+            t.emb_q8_off = cur.wo
+            cur.wo += c.vocab_size * dim
+        } elif (cls_kq(t)) {
+            // tied K-quant: ONE plane copy serves both the classifier matmul and the embedding
+            // row reads — the kq planes stay in disk order (no repack), so no second linear copy
+            t.wcls_off = kq_take(cur, t.emb_fmt, c.vocab_size * dim)
         } else {
             t.wcls_off = 0l   // unused — the classifier reads the fp32 embedding from fblob
         }
     } else {
-        t.wcls_off = wo
-        wo += c.vocab_size * dim
+        t.wcls_off = kq_take(cur, t.wcls_fmt, c.vocab_size * dim)
     }
-    return LayoutSizes(fblob_n = fo, wblob_n = wo, mx_n = mx, bf16_n = bf16)
+    return LayoutSizes(fblob_n = fo, wblob_n = cur.wo, mx_n = mx, bf16_n = bf16,
+                       k4_n = cur.k4, k5_n = cur.k5, k6_n = cur.k6)
 }
 
 // Reserve exact capacity then size — avoids the array allocator's power-of-2 rounding on big arrays.
@@ -697,8 +772,16 @@ def load_checkpoint(path : string) : Model {
 // Read one big 2D weight tensor into the active representation: transcode straight from disk when
 // the on-disk type already matches the target precision, otherwise dequant to a reused fp32 scratch
 // and quantize into the shared blob. `woff` is the weight-element offset; `scratch` is reused.
-def private load_big(m : GGUFMeta; bytes : array<uint8> | #; name : string; var t : Model; woff, n : int64; var scratch : array<float>; src_off : int64 = 0l) {
-    if (t.quant == QuantMode.q8) {
+// `fmt` != q8 routes into that native K-quant plane pair (woff is then the plane-local offset the
+// layout's kq cursor assigned — the caller passes the tag it laid the tensor out with).
+def private load_big(m : GGUFMeta; bytes : array<uint8> | #; name : string; var t : Model; woff, n : int64; var scratch : array<float>; src_off : int64 = 0l; fmt : KqFmt = KqFmt.q8) {
+    if (fmt == KqFmt.k4) {
+        gguf_transcode_q4k(m, bytes, name, t.k4q, t.k4s, woff, n, src_off)
+    } elif (fmt == KqFmt.k5) {
+        gguf_transcode_q5k(m, bytes, name, t.k5q, t.k5s, woff, n, src_off)
+    } elif (fmt == KqFmt.k6) {
+        gguf_transcode_q6k(m, bytes, name, t.k6q, t.k6s, woff, n, src_off)
+    } elif (t.quant == QuantMode.q8) {
         if (gguf_tensor_type(m, name) == GGML_TYPE_Q8_0) {
             gguf_transcode_q8_0(m, bytes, name, t.qblob, t.qscales, woff, woff / 32l, n, src_off)
         } else {
@@ -783,6 +866,81 @@ def public get_wscale_f16() : bool {
     return g_wscale_f16
 }
 
+// Native K-quant weight planes: Q4_K/Q5_K/Q6_K tensors stay packed in per-format planes (see
+// Model.k4q..k6s) instead of requantizing to Q8. Default OFF until the kernel tier lands — OFF
+// loads them through the q8-requant fallback exactly as before. Load-time switch (like wscale_f16).
+var private g_kquant_native = false
+
+//! Enable/disable native K-quant weight planes for subsequent loads (A/B rail; default off).
+def public set_kquant_native(on : bool) {
+    g_kquant_native = on
+}
+def public get_kquant_native() : bool {
+    return g_kquant_native
+}
+
+// GGML disk type -> plane format tag (non-K-quant types ride the classic q8 path)
+def private kq_fmt_of(gt : int) : KqFmt {
+    if (gt == GGML_TYPE_Q4_K) {
+        return KqFmt.k4
+    }
+    if (gt == GGML_TYPE_Q5_K) {
+        return KqFmt.k5
+    }
+    if (gt == GGML_TYPE_Q6_K) {
+        return KqFmt.k6
+    }
+    return KqFmt.q8
+}
+
+// Fill the per-kind weight format tags from the file's tensor types (q8-mode loads with the
+// kquant_native knob on). Fused-projection arches (Phi3) stay all-q8 — their sub-tensor slices
+// split fused tensors, and a K-quant split is only superblock-aligned by luck. MoE expert stacks
+// and PLE tables also stay q8 (requant fallback) — no kq kernels target them.
+def private detect_kq_formats(var t : Model; m : GGUFMeta) {
+    if (t.quant != QuantMode.q8 || !g_kquant_native || t.config.fused_qkv) {
+        return
+    }
+    let layers = t.config.n_layers
+    t.wq_fmt |> resize(layers)
+    t.wk_fmt |> resize(layers)
+    t.wv_fmt |> resize(layers)
+    t.wo_fmt |> resize(layers)
+    t.w1_fmt |> resize(layers)
+    t.w2_fmt |> resize(layers)
+    t.w3_fmt |> resize(layers)
+    var any = false
+    for (l in range64(layers)) {
+        t.wq_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_q.weight"))
+        t.wk_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_k.weight"))
+        t.wv_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_v.weight"))
+        t.wo_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_output.weight"))
+        t.w1_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate.weight"))
+        t.w2_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down.weight"))
+        t.w3_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight"))
+        any ||= t.wq_fmt[l] != KqFmt.q8 || t.wk_fmt[l] != KqFmt.q8 || t.wv_fmt[l] != KqFmt.q8
+        any ||= t.wo_fmt[l] != KqFmt.q8 || t.w1_fmt[l] != KqFmt.q8 || t.w2_fmt[l] != KqFmt.q8
+        any ||= t.w3_fmt[l] != KqFmt.q8
+    }
+    if (t.config.shared_weights) {
+        t.emb_fmt = kq_fmt_of(gguf_tensor_type(m, "token_embd.weight"))
+        any ||= t.emb_fmt != KqFmt.q8
+    } else {
+        t.wcls_fmt = kq_fmt_of(gguf_tensor_type(m, "output.weight"))
+        any ||= t.wcls_fmt != KqFmt.q8
+    }
+    if (!any) {   // nothing K-quant in the file: drop the tags so fmt_at short-circuits on empty
+        delete t.wq_fmt
+        delete t.wk_fmt
+        delete t.wv_fmt
+        delete t.wo_fmt
+        delete t.w1_fmt
+        delete t.w2_fmt
+        delete t.w3_fmt
+    }
+    t.kquant_native = any
+}
+
 // Convert the (already repacked/permuted) f32 scale plane to raw binary16 halfwords and free the
 // f32 plane. f16->f32->f16 round-trips exactly, so for gguf-Q8 tensors the halfword plane equals
 // the disk scales bit-for-bit and every dot is bit-identical to the f32 plane; runtime-quantized
@@ -794,6 +952,9 @@ def private wscale_convert_f16(var t : Model) {
         return
     }
     let n = long_length(t.qscales)
+    if (n == 0l) {   // every big weight lives in a native plane (kq/mx4) — nothing to convert
+        return
+    }
     t.qscales16 |> resize(int(n))
     unsafe {
         cvt_f32_to_f16(addr(t.qscales16[0]), addr(t.qscales[0]), n)
@@ -816,14 +977,20 @@ def private repack_q8_weights(var t : Model) {
     for (l in range64(c.n_layers)) {
         let kv = layer_kv_dim(c, l)
         let qd = layer_qd(c, l)
-        repack_q8q8_weight(t.qblob, t.qscales, t.wq_offs[l], dim, qd)
-        if (t.wk_offs[l] >= 0l) {   // absent on E-series shared-KV layers
+        // K-quant-tagged weights live in the kq planes (disk order, never repacked) — their
+        // offsets are NOT qblob offsets, so repacking them here would permute foreign memory
+        if (fmt_at(t.wq_fmt, l) == KqFmt.q8) {
+            repack_q8q8_weight(t.qblob, t.qscales, t.wq_offs[l], dim, qd)
+        }
+        if (t.wk_offs[l] >= 0l && fmt_at(t.wk_fmt, l) == KqFmt.q8) {   // absent on E-series shared-KV layers
             repack_q8q8_weight(t.qblob, t.qscales, t.wk_offs[l], dim, kv)
         }
-        if (t.wv_offs[l] >= 0l) {
+        if (t.wv_offs[l] >= 0l && fmt_at(t.wv_fmt, l) == KqFmt.q8) {
             repack_q8q8_weight(t.qblob, t.qscales, t.wv_offs[l], dim, kv)
         }
-        repack_q8q8_weight(t.qblob, t.qscales, t.wo_offs[l], qd, dim)
+        if (fmt_at(t.wo_fmt, l) == KqFmt.q8) {
+            repack_q8q8_weight(t.qblob, t.qscales, t.wo_offs[l], qd, dim)
+        }
         if (has_ple(c)) {  // gemma-4 E-series per-layer PLE gate/proj (the emb table stays linear, unpacked)
             let ple = c.n_embd_per_layer
             repack_q8q8_weight(t.qblob, t.qscales, t.ple_gate_off + l * dim * ple, dim, ple)
@@ -846,20 +1013,32 @@ def private repack_q8_weights(var t : Model) {
                 repack_q8q8_weight(t.qblob, t.qscales, t.wsh3_off + l * she, dim, c.n_ff_shexp)
             }
             if (c.moe_dense_shexp) {  // gemma4: the dense parallel shared expert repacks like a plain FFN
-                repack_q8q8_weight(t.qblob, t.qscales, t.w1_offs[l], dim, hidden)
-                repack_q8q8_weight(t.qblob, t.qscales, t.w2_offs[l], hidden, dim)
-                repack_q8q8_weight(t.qblob, t.qscales, t.w3_offs[l], dim, hidden)
+                if (fmt_at(t.w1_fmt, l) == KqFmt.q8) {
+                    repack_q8q8_weight(t.qblob, t.qscales, t.w1_offs[l], dim, hidden)
+                }
+                if (fmt_at(t.w2_fmt, l) == KqFmt.q8) {
+                    repack_q8q8_weight(t.qblob, t.qscales, t.w2_offs[l], hidden, dim)
+                }
+                if (fmt_at(t.w3_fmt, l) == KqFmt.q8) {
+                    repack_q8q8_weight(t.qblob, t.qscales, t.w3_offs[l], dim, hidden)
+                }
             }
         } else {
             let h = layer_hidden(t, l)
-            repack_q8q8_weight(t.qblob, t.qscales, t.w1_offs[l], dim, h)
-            repack_q8q8_weight(t.qblob, t.qscales, t.w2_offs[l], h, dim)
-            repack_q8q8_weight(t.qblob, t.qscales, t.w3_offs[l], dim, h)
+            if (fmt_at(t.w1_fmt, l) == KqFmt.q8) {
+                repack_q8q8_weight(t.qblob, t.qscales, t.w1_offs[l], dim, h)
+            }
+            if (fmt_at(t.w2_fmt, l) == KqFmt.q8) {
+                repack_q8q8_weight(t.qblob, t.qscales, t.w2_offs[l], h, dim)
+            }
+            if (fmt_at(t.w3_fmt, l) == KqFmt.q8) {
+                repack_q8q8_weight(t.qblob, t.qscales, t.w3_offs[l], dim, h)
+            }
         }
     }
-    if (!c.shared_weights || t.cls_q8) {
+    if ((!c.shared_weights && t.wcls_fmt == KqFmt.q8) || t.cls_q8) {
         // the linear copy at emb_q8_off is deliberately NOT repacked — embedding-row dequant
-        // indexes it directly
+        // indexes it directly. K-quant classifiers (either tying) stay in their plane, unpacked.
         repack_q8q8_weight(t.qblob, t.qscales, t.wcls_off, dim, c.vocab_size)
     }
 }
@@ -1155,6 +1334,9 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
         // fp32 path (a requantized classifier would drift from the oracle for no parity gain).
         t.cls_q8 = (t.config.shared_weights && mode == QuantMode.q8
             && gguf_tensor_type(m, "token_embd.weight") == GGML_TYPE_Q8_0)
+        // per-tensor K-quant format tags (kquant_native rail; no-op when the knob is off or the
+        // file has no K-quant tensors) — must precede layout_offsets, which walks the tags
+        detect_kq_formats(t, m)
         // logit soft-caps from metadata when present (gemma2: 50/30, gemma4: final 30 only);
         // configure()'s values stay as the fallback for files without the keys
         if (gguf_has(m, "{arch}.attn_logit_softcapping")) {
@@ -1208,6 +1390,24 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
             t.mxs |> reserve(sz.mx_n / 32l)
             t.mxs |> resize(sz.mx_n / 32l)
         }
+        if (sz.k4_n > 0l) {
+            t.k4q |> reserve((sz.k4_n / 256l) * K4_QSB)
+            t.k4q |> resize((sz.k4_n / 256l) * K4_QSB)
+            t.k4s |> reserve((sz.k4_n / 256l) * K4_SSB)
+            t.k4s |> resize((sz.k4_n / 256l) * K4_SSB)
+        }
+        if (sz.k5_n > 0l) {
+            t.k5q |> reserve((sz.k5_n / 256l) * K5_QSB)
+            t.k5q |> resize((sz.k5_n / 256l) * K5_QSB)
+            t.k5s |> reserve((sz.k5_n / 256l) * K5_SSB)
+            t.k5s |> resize((sz.k5_n / 256l) * K5_SSB)
+        }
+        if (sz.k6_n > 0l) {
+            t.k6q |> reserve((sz.k6_n / 256l) * K6_QSB)
+            t.k6q |> resize((sz.k6_n / 256l) * K6_QSB)
+            t.k6s |> reserve((sz.k6_n / 256l) * K6_SSB)
+            t.k6s |> resize((sz.k6_n / 256l) * K6_SSB)
+        }
         if (mode == QuantMode.q8) {
             t.qblob |> reserve(sz.wblob_n)
             t.qblob |> resize(sz.wblob_n)
@@ -1221,9 +1421,10 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
         } else {
             reserve_resize(t.wblob, sz.wblob_n)
         }
-        // embedding + norms -> fblob (decoded to fp32 from whatever the disk type is); cls_q8 keeps
-        // the embedding out of fblob — both Q8 copies transcode with the big weights below
-        if (!t.cls_q8) {
+        // embedding + norms -> fblob (decoded to fp32 from whatever the disk type is); cls_q8 /
+        // cls_kq keep the embedding out of fblob — the quantized copies transcode with the big
+        // weights below
+        if (!t.cls_q8 && !cls_kq(t)) {
             gguf_read_tensor_f32(m, bytes, "token_embd.weight", t.fblob, t.tok_emb_off, vocab * dim)
         }
         // gpt-oss names its pre-FFN norm post_attention_norm (same graph role as ffn_norm)
@@ -1287,15 +1488,15 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
                 load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wk_offs[l], dim * kv_l, scratch, dim * qd_l)
                 load_big(m, bytes, "blk.{l}.attn_qkv.weight", t, t.wv_offs[l], dim * kv_l, scratch, dim * qd_l + dim * kv_l)
             } else {
-                load_big(m, bytes, "blk.{l}.attn_q.weight", t, t.wq_offs[l], dim * qd_l, scratch)
+                load_big(m, bytes, "blk.{l}.attn_q.weight", t, t.wq_offs[l], dim * qd_l, scratch, 0l, fmt_at(t.wq_fmt, l))
                 if (t.wk_offs[l] >= 0l) {   // absent on E-series shared-KV layers (reuse the source layer's K)
-                    load_big(m, bytes, "blk.{l}.attn_k.weight", t, t.wk_offs[l], dim * kv_l, scratch)
+                    load_big(m, bytes, "blk.{l}.attn_k.weight", t, t.wk_offs[l], dim * kv_l, scratch, 0l, fmt_at(t.wk_fmt, l))
                 }
                 if (t.wv_offs[l] >= 0l) {   // absent on gemma4 global (V-from-K) + E-series shared-KV layers
-                    load_big(m, bytes, "blk.{l}.attn_v.weight", t, t.wv_offs[l], dim * kv_l, scratch)
+                    load_big(m, bytes, "blk.{l}.attn_v.weight", t, t.wv_offs[l], dim * kv_l, scratch, 0l, fmt_at(t.wv_fmt, l))
                 }
             }
-            load_big(m, bytes, "blk.{l}.attn_output.weight", t, t.wo_offs[l], qd_l * dim, scratch)
+            load_big(m, bytes, "blk.{l}.attn_output.weight", t, t.wo_offs[l], qd_l * dim, scratch, 0l, fmt_at(t.wo_fmt, l))
             if (t.config.n_expert > 0l) {
                 // MoE: fp32 router (+ shared-expert gate vector) -> fblob; the 3D expert stacks are
                 // expert-major on disk, so ONE contiguous load lands every expert's 2D matrix at its
@@ -1345,9 +1546,9 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
                     load_big(m, bytes, "blk.{l}.ffn_up_shexp.weight", t, t.wsh3_off + l * she, she, scratch)
                 }
                 if (t.config.moe_dense_shexp) {  // gemma4: the DENSE parallel shared expert (plain ffn gate/up/down)
-                    load_big(m, bytes, "blk.{l}.ffn_gate.weight", t, t.w1_offs[l], dim * hidden, scratch)
-                    load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w3_offs[l], dim * hidden, scratch)
-                    load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], hidden * dim, scratch)
+                    load_big(m, bytes, "blk.{l}.ffn_gate.weight", t, t.w1_offs[l], dim * hidden, scratch, 0l, fmt_at(t.w1_fmt, l))
+                    load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w3_offs[l], dim * hidden, scratch, 0l, fmt_at(t.w3_fmt, l))
+                    load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], hidden * dim, scratch, 0l, fmt_at(t.w2_fmt, l))
                 }
             } elif (t.config.fused_qkv) {
                 load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w1_offs[l], dim * hidden, scratch, 0l)
@@ -1355,9 +1556,9 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
                 load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], hidden * dim, scratch)
             } else {
                 let h = layer_hidden(t, l)   // gemma-4 E2B varies this per layer
-                load_big(m, bytes, "blk.{l}.ffn_gate.weight", t, t.w1_offs[l], dim * h, scratch)
-                load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w3_offs[l], dim * h, scratch)
-                load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], h * dim, scratch)
+                load_big(m, bytes, "blk.{l}.ffn_gate.weight", t, t.w1_offs[l], dim * h, scratch, 0l, fmt_at(t.w1_fmt, l))
+                load_big(m, bytes, "blk.{l}.ffn_up.weight", t, t.w3_offs[l], dim * h, scratch, 0l, fmt_at(t.w3_fmt, l))
+                load_big(m, bytes, "blk.{l}.ffn_down.weight", t, t.w2_offs[l], h * dim, scratch, 0l, fmt_at(t.w2_fmt, l))
             }
             if (has_ple(t.config)) {  // gemma-4 E-series: per-layer PLE gate (dim->ple) + proj (ple->dim), Q8
                 let ple = t.config.n_embd_per_layer
@@ -1369,11 +1570,15 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
             load_big(m, bytes, "per_layer_token_embd.weight", t, t.ple_emb_off, vocab * t.config.n_embd_per_layer * layers, scratch)
         }
         if (!t.config.shared_weights) {
-            load_big(m, bytes, "output.weight", t, t.wcls_off, vocab * dim, scratch)
+            load_big(m, bytes, "output.weight", t, t.wcls_off, vocab * dim, scratch, 0l, t.wcls_fmt)
         } elif (t.cls_q8) {
             // tied Q8: classifier copy (repacked below) + the linear copy embedding rows read
             gguf_transcode_q8_0(m, bytes, "token_embd.weight", t.qblob, t.qscales, t.wcls_off, t.wcls_off / 32l, vocab * dim)
             gguf_transcode_q8_0(m, bytes, "token_embd.weight", t.qblob, t.qscales, t.emb_q8_off, t.emb_q8_off / 32l, vocab * dim)
+        } elif (cls_kq(t)) {
+            // tied K-quant: ONE plane copy serves the classifier matmul and embedding row reads
+            // (the kq planes stay in disk order — no repack, so no second linear copy)
+            load_big(m, bytes, "token_embd.weight", t, t.wcls_off, vocab * dim, scratch, 0l, t.emb_fmt)
         }
         // Qwen2 Q/K/V projection biases — small fp32 tensors, kept dense
         if (t.config.attn_qkv_bias) {
@@ -1450,6 +1655,8 @@ struct MemFootprint {
     q4_scale_bytes : int64
     mx4_bytes : int64
     mx4_scale_bytes : int64
+    kq_bytes : int64         // native K-quant planes: quant payloads (k4q+k5q+k6q)
+    kq_scale_bytes : int64   // ... and their scale planes (k4s+k5s+k6s)
     total : int64
 }
 
@@ -1464,9 +1671,12 @@ def footprint(t : Model) : MemFootprint {
     let q4s = long_length(t.q4scales) * 4l
     let mx4 = long_length(t.mxq)                  // uint8 (two nibbles) -> 1 byte each
     let mx4s = long_length(t.mxs)                 // raw E8M0 -> 1 byte per 32-block
+    let kq = long_length(t.k4q) + long_length(t.k5q) + long_length(t.k6q)
+    let kqs = long_length(t.k4s) + long_length(t.k5s) + long_length(t.k6s)
     return MemFootprint(aux_fp32_bytes = aux, weight_fp32_bytes = wf, q8_bytes = q8, q8_scale_bytes = q8s,
                         q4_bytes = q4, q4_scale_bytes = q4s, mx4_bytes = mx4, mx4_scale_bytes = mx4s,
-                        total = aux + wf + q8 + q8s + q4 + q4s + mx4 + mx4s)
+                        kq_bytes = kq, kq_scale_bytes = kqs,
+                        total = aux + wf + q8 + q8s + q4 + q4s + mx4 + mx4s + kq + kqs)
 }
 
 //! A caller-owned paged KV-cache pool (``create_kv_pool_``). Pages chunk POSITIONS (codec blocks
@@ -1828,6 +2038,7 @@ def apply_box_profile_runtime(path : string = "") {
     apply_i64_knob(rt, "matmul_min_chunk_rows_gemv") $(v) { set_matmul_min_chunk_rows_gemv(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "gemv_chunks_per_lane") $(v) { set_gemv_chunks_per_lane(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "wscale_f16") $(v) { set_wscale_f16(v != 0l) }
+    apply_i64_knob(rt, "kquant_native") $(v) { set_kquant_native(v != 0l) }
     apply_i64_knob(rt, "gemv_lane_cap") $(v) { set_gemv_lane_cap(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "batch_lane_cap") $(v) { set_batch_lane_cap(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "batch_grid_2d") $(v) { set_batch_grid_2d(int(min(v, 2l))) }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -7213,6 +7213,7 @@ struct BatchWorkspace {
     // delete of a plain array<T?> CASCADES to the pointees, which would free the sessions' cache blobs
     @do_not_delete kbase : array<uint8?>
     @do_not_delete vbase : array<uint8?>
+    @do_not_delete lrow : array<float?>   // row i's sessions[i].logits base (the threaded scatter)
     runs_b : array<KVRun>     // per-row physical runs, flattened rows × max-runs (flat rows: 1 each)
     nrun_b : array<int64>     // per-row run count
 }
@@ -7489,17 +7490,31 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
     } else {
         mm_b(ws.logits_b, t, t.wcls_off, ws.scr.xb_b, ws.scr.xqb, ws.scr.xsb, dim, vocab, nrows)
     }
-    if (c.final_logit_softcap > 0.0) {  // Gemma2: soft-cap the output logits per row
-        unsafe {
-            var lbp = addr(ws.logits_b[0])
-            for (i in range64(nrows)) {
-                softcap4(lbp + i * vocab, vocab, c.final_logit_softcap)
+    // per-row softcap + scatter into each session's logits + suppress pins, ONE row-parallel
+    // dispatch — the serial tail here was most of a ~6ms all-lane hole every step at B=8
+    // (B x vocab ≈ 5MB of copy). Rows are disjoint (row i writes only sessions[i].logits).
+    ws.lrow |> resize(int(nrows))
+    unsafe {
+        for (i in range64(nrows)) {
+            ws.lrow[i] = addr(sessions[i].logits[0])
+        }
+        var lbp = addr(ws.logits_b[0])
+        var lrp = addr(ws.lrow[0])
+        let softcap = c.final_logit_softcap
+        maybe_parallel_for(0, int(nrows), min(int(nrows), get_dispatch_lanes())) $(rb, re) {
+            unsafe {
+                for (i in range(rb, re)) {
+                    var src = lbp + int64(i) * vocab
+                    if (softcap > 0.0) {  // Gemma2: soft-cap the output logits per row
+                        softcap4(src, vocab, softcap)
+                    }
+                    copy_floats(lrp[i], src, vocab)
+                }
             }
         }
     }
     for (i in range64(nrows)) {
         var sp = sessions[i]
-        copy_floats(ws.logits_b, i * vocab, sp.logits, 0l, vocab)
         for (id in t.suppress) {  // gemma4: pin the checkpoint's suppressed token ids to -inf
             sp.logits[id] = -1.0e30
         }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -268,6 +268,12 @@ struct Model {
     k6q : array<uint8>
     k6s : array<uint8>
     kquant_native : bool = false
+    // kq stage 4: the kq planes were repacked at load into the active backend's grp<mr> layout
+    // (kernel_backend_has_kq at load time). From then on every kq matmul MUST run the backend
+    // slots — the disk-order portable kernels would read garbage — and embed_row gathers rows
+    // through the grp layout at kq_repack_mr (tail rows d % mr stay disk-order).
+    kq_repacked : bool = false
+    kq_repack_mr : int64 = 4l
     // per-layer weight format tags (KqFmt; empty = all q8). Filled by detect_kq_formats before
     // layout_offsets so the layout walks each tensor into its format's cursor.
     wq_fmt : array<KqFmt>
@@ -1043,6 +1049,53 @@ def private repack_q8_weights(var t : Model) {
     }
 }
 
+// route one kq-tagged tensor to its format's plane pair (q8 tags no-op — those live in qblob)
+def private repack_kq_tensor(var t : Model; fmt : KqFmt; woff, n, d : int64) {
+    if (fmt == KqFmt.k4) {
+        repack_kq_weight(4, t.k4q, t.k4s, woff, n, d)
+    } elif (fmt == KqFmt.k5) {
+        repack_kq_weight(5, t.k5q, t.k5s, woff, n, d)
+    } elif (fmt == KqFmt.k6) {
+        repack_kq_weight(6, t.k6q, t.k6s, woff, n, d)
+    }
+}
+
+// Repack every K-quant-tagged weight tensor into the active backend's grp<mr> kq layout, IN
+// PLACE (kq stage 4) — the kq sibling of repack_q8_weights, called only when the selected
+// backend carries the kq slots (kernel_backend_has_kq). The tied/untied classifier repacks
+// too: embed_row gathers its rows through the grp layout afterwards.
+def private repack_kq_weights(var t : Model) {
+    let c = t.config
+    let dim = c.dim
+    for (l in range64(c.n_layers)) {
+        let kv = layer_kv_dim(c, l)
+        let qd = layer_qd(c, l)
+        repack_kq_tensor(t, fmt_at(t.wq_fmt, l), t.wq_offs[l], dim, qd)
+        if (t.wk_offs[l] >= 0l) {
+            repack_kq_tensor(t, fmt_at(t.wk_fmt, l), t.wk_offs[l], dim, kv)
+        }
+        if (t.wv_offs[l] >= 0l) {
+            repack_kq_tensor(t, fmt_at(t.wv_fmt, l), t.wv_offs[l], dim, kv)
+        }
+        repack_kq_tensor(t, fmt_at(t.wo_fmt, l), t.wo_offs[l], qd, dim)
+        if (c.n_expert > 0l) {
+            if (c.moe_dense_shexp) {
+                repack_kq_tensor(t, fmt_at(t.w1_fmt, l), t.w1_offs[l], dim, c.hidden_dim)
+                repack_kq_tensor(t, fmt_at(t.w2_fmt, l), t.w2_offs[l], c.hidden_dim, dim)
+                repack_kq_tensor(t, fmt_at(t.w3_fmt, l), t.w3_offs[l], dim, c.hidden_dim)
+            }
+        } else {
+            let h = layer_hidden(t, l)
+            repack_kq_tensor(t, fmt_at(t.w1_fmt, l), t.w1_offs[l], dim, h)
+            repack_kq_tensor(t, fmt_at(t.w2_fmt, l), t.w2_offs[l], h, dim)
+            repack_kq_tensor(t, fmt_at(t.w3_fmt, l), t.w3_offs[l], dim, h)
+        }
+    }
+    if ((!c.shared_weights && t.wcls_fmt != KqFmt.q8) || cls_kq(t)) {
+        repack_kq_tensor(t, c.shared_weights ? t.emb_fmt : t.wcls_fmt, t.wcls_off, dim, c.vocab_size)
+    }
+}
+
 // Repack the native-MXFP4 expert stacks into the active backend's interleaved mx layout, IN PLACE
 // (each expert slice is its own 2D tensor). Mirrors repack_q8_weights' contract: called only after
 // select_matmul_backend_for_load picks a repack backend; the pointer is otherwise identity.
@@ -1605,6 +1658,12 @@ def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
             repack_q8_weights(t)
             if (t.experts_mx4) {
                 repack_mx4_stacks(t)
+            }
+            if (t.kquant_native && kernel_backend_has_kq()) {
+                repack_kq_weights(t)
+                t.kq_repacked = true
+                t.kq_repack_mr = active_q8_layout_mr()
+                to_log(LOG_INFO, "dasLLAMA: K-quant planes repacked to the '{active_kernel_backend()}' grp{t.kq_repack_mr} layout\n")
             }
         }
         if (mode == QuantMode.q8 && g_wscale_f16) {
@@ -3095,8 +3154,17 @@ def private mm_at_mx4_groupn(var y : array<float>; t : Model; offs, boffs : arra
 // ===== native K-quant dispatch (kquant_native; fmt != q8 tags) =====
 
 // K-quant GEMV against a PRE-quantized activation (xq/xs/xbs already filled by the bs quantizer).
+// kq_repacked loads run the backend's stamped cores; disk-order loads run the portable kernels.
 def private mm_at_kq_pre(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64; yoff : int64 = 0l) {
-    if (fmt == KqFmt.k4) {
+    if (t.kq_repacked) {
+        if (fmt == KqFmt.k4) {
+            matmul_kq_active(4, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, yoff)
+        } elif (fmt == KqFmt.k5) {
+            matmul_kq_active(5, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, yoff)
+        } else {
+            matmul_kq_active(6, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, yoff)
+        }
+    } elif (fmt == KqFmt.k4) {
         matmul_kq(4, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, yoff)
     } elif (fmt == KqFmt.k5) {
         matmul_kq(5, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, yoff)
@@ -3123,6 +3191,32 @@ def private mm_b_kq(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; 
         }
     }
 }
+
+// Chain hoists (kq stage 4): a kq-tagged weight's plane byte bases at element offset woff and
+// the stamped rows core for its format. q8 tags get nulls — their branch never reads these.
+def private kq_plane_q(t : Model; fmt : KqFmt; woff : int64) : uint8 const? {
+    let sb = woff / 256l
+    if (fmt == KqFmt.k4) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k4q[sb * K4_QSB]))))
+    if (fmt == KqFmt.k5) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k5q[sb * K5_QSB]))))
+    if (fmt == KqFmt.k6) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k6q[sb * K6_QSB]))))
+    return null
+}
+
+def private kq_plane_s(t : Model; fmt : KqFmt; woff : int64) : uint8 const? {
+    let sb = woff / 256l
+    if (fmt == KqFmt.k4) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k4s[sb * K4_SSB]))))
+    if (fmt == KqFmt.k5) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k5s[sb * K5_SSB]))))
+    if (fmt == KqFmt.k6) return unsafe(reinterpret<uint8 const?>(unsafe(addr(t.k6s[sb * K6_SSB]))))
+    return null
+}
+
+def private kq_rows_for(fmt : KqFmt) : MatmulKqRowsFn {
+    return kq_rows_fn(fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6))
+}
+
+// Can the fused chains serve a weight of this format? q8 always; kq only off a repacked load
+// (the backend rows cores read the grp layout the loader wrote).
+def private kq_servable(t : Model; fmt : KqFmt) : bool => fmt == KqFmt.q8 || t.kq_repacked
 
 // Format router: q8-tagged weights take the classic mm; kq tags take the plane GEMV.
 def private mm_f(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; x : array<float>; var xq : array<int8>; var xs : array<float>; var xbs : array<int>; n, d : int64) {
@@ -3344,8 +3438,8 @@ def private fused_attn_ok(t : Model; l : int64) : bool {
     // needs whole 32-quant groups per head (real targets are 64/128/256; stories15M's 48 falls back)
     return (g_fused_decode && t.quant == QuantMode.q8 && g_use_rope_table
         && t.wv_offs[l] >= 0l && layer_head_size(c, l) % 32l == 0l
-        && fmt_at(t.wq_fmt, l) == KqFmt.q8 && fmt_at(t.wk_fmt, l) == KqFmt.q8
-        && fmt_at(t.wv_fmt, l) == KqFmt.q8 && fmt_at(t.wo_fmt, l) == KqFmt.q8   // kq layers: per-op path (chain rows cores are Q8-only for now)
+        && kq_servable(t, fmt_at(t.wq_fmt, l)) && kq_servable(t, fmt_at(t.wk_fmt, l))
+        && kq_servable(t, fmt_at(t.wv_fmt, l)) && kq_servable(t, fmt_at(t.wo_fmt, l))
         && get_jobque_team_mode() && kernel_backend_has_rows()
         && (!t.wscale_f16 || kernel_backend_has_rows16())
         && lanes_for_work(c.dim * (layer_qd(c, l) + 2l * layer_kv_dim(c, l)), g_gemv_lane_cap) > 1)
@@ -3380,10 +3474,21 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
     let cnt = pos + 1l - kstart
     let nrun = kv_runs(s, kstart, pos + 1l, s.kv_runs)   // physical runs of this layer's window (flat: 1)
     let prow = kv_phys_row(s, pos)                       // where THIS position's row lives
-    // attention rmsnorm + input quantize (serial — dim-sized, microseconds)
+    // per-weight formats (kq layers reach here only off a repacked load — fused_attn_ok)
+    let fq = fmt_at(t.wq_fmt, l)
+    let fk = fmt_at(t.wk_fmt, l)
+    let fv = fmt_at(t.wv_fmt, l)
+    let fo = fmt_at(t.wo_fmt, l)
+    let any_kq = fq != KqFmt.q8 || fk != KqFmt.q8 || fv != KqFmt.q8 || fo != KqFmt.q8
+    // attention rmsnorm + input quantize (serial — dim-sized, microseconds); kq layers use the
+    // bs quantizer (same quants/scales byte-for-byte, plus the per-16 sums the offset term needs)
     let ts_norm0 = ref_time_ticks()
     rms_at(s.xb, t, t.rms_att_off + l * dim, s.x, dim)
-    quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
+    if (any_kq) {
+        quantize_q8_0_bs_into(s.xb, dim, s.xq, s.xs, s.xbs, 0l, 0l, 0l)
+    } else {
+        quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
+    }
     prof_add("norm", ts_norm0)
     let ts_chain = ref_time_ticks()
     trace_tag(TRACE_TAG_ATTN_CHAIN)
@@ -3457,10 +3562,13 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))   // this layer's physical runs (fork-safe hoist)
         // weight region bases (element offsets into the Q8 blob, scales at /32); wscale_f16
         // models carry the binary16 plane instead (qscales is freed) — each plane's pointers
-        // are formed only in its own branch, so no offset is ever taken off a null base
+        // are formed only in its own branch, so no offset is ever taken off a null base.
+        // All-kq layers (every big weight in the kq planes) skip the q8 bases entirely —
+        // qblob/qscales can be EMPTY on an all-K-quant file
         let f16w = t.wscale_f16
         let mmrows16 = mm_q8q8_rows16_fn()
-        let wqb = reinterpret<int8 const?>(addr(t.qblob[0]))
+        let has_q8w = fq == KqFmt.q8 || fk == KqFmt.q8 || fv == KqFmt.q8 || fo == KqFmt.q8
+        let wqb = has_q8w ? reinterpret<int8 const?>(addr(t.qblob[0])) : null
         var wsq : float const? = null
         var wsk : float const? = null
         var wsv : float const? = null
@@ -3469,13 +3577,13 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
         var wsk16 : uint16 const? = null
         var wsv16 : uint16 const? = null
         var wso16 : uint16 const? = null
-        if (f16w) {
+        if (f16w && has_q8w) {
             let wsb16 = reinterpret<uint16 const?>(addr(t.qscales16[0]))
             wsq16 = wsb16 + t.wq_offs[l] / 32l
             wsk16 = wsb16 + t.wk_offs[l] / 32l
             wsv16 = wsb16 + t.wv_offs[l] / 32l
             wso16 = wsb16 + t.wo_offs[l] / 32l
-        } else {
+        } elif (has_q8w) {
             let wsb = reinterpret<float const?>(addr(t.qscales[0]))
             wsq = wsb + t.wq_offs[l] / 32l
             wsk = wsb + t.wk_offs[l] / 32l
@@ -3486,6 +3594,21 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
         let wpk = wqb + t.wk_offs[l]
         let wpv = wqb + t.wv_offs[l]
         let wpo = wqb + t.wo_offs[l]
+        // kq-tagged weights: plane bases + the stamped rows core per format (nulls/unused on q8
+        // tags); xbsw = the shared per-16 activation-sum plane (the bs quantizer filled it)
+        var xbsw : int? = any_kq ? addr(s.xbs[0]) : null
+        let kqpq = kq_plane_q(t, fq, t.wq_offs[l])
+        let kspq = kq_plane_s(t, fq, t.wq_offs[l])
+        let rowsq = kq_rows_for(fq)
+        let kqpk = kq_plane_q(t, fk, t.wk_offs[l])
+        let kspk = kq_plane_s(t, fk, t.wk_offs[l])
+        let rowsk = kq_rows_for(fk)
+        let kqpv = kq_plane_q(t, fv, t.wv_offs[l])
+        let kspv = kq_plane_s(t, fv, t.wv_offs[l])
+        let rowsv = kq_rows_for(fv)
+        let kqpo = kq_plane_q(t, fo, t.wo_offs[l])
+        let kspo = kq_plane_s(t, fo, t.wo_offs[l])
+        let rowso = kq_rows_for(fo)
         // this position's rope table row (dual-rope arches: the sliding class's row)
         let swa_row = is_sliding && has_dual_rope(c)
         let crow = swa_row ? reinterpret<float const?>(addr(s.rope_cos_swa[0])) : reinterpret<float const?>(addr(s.rope_cos[0]))
@@ -3519,7 +3642,9 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                     while (r < rend) {
                         if (r < qd) {
                             let r1 = min(rend, qd)
-                            if (f16w) {
+                            if (fq != KqFmt.q8) {
+                                invoke(rowsq, qp, kqpq, kspq, xqp, xsp, xbsw, dim, r, r1)
+                            } elif (f16w) {
                                 invoke(mmrows16, qp, wpq, wsq16, xqp, xsp, dim, r, r1)
                             } else {
                                 invoke(mmrows, qp, wpq, wsq, xqp, xsp, dim, r, r1)
@@ -3531,7 +3656,9 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         } elif (r < qd + kv_dim) {
                             let r0 = r - qd
                             let r1 = min(rend, qd + kv_dim) - qd
-                            if (f16w) {
+                            if (fk != KqFmt.q8) {
+                                invoke(rowsk, kp, kqpk, kspk, xqp, xsp, xbsw, dim, r0, r1)
+                            } elif (f16w) {
                                 invoke(mmrows16, kp, wpk, wsk16, xqp, xsp, dim, r0, r1)
                             } else {
                                 invoke(mmrows, kp, wpk, wsk, xqp, xsp, dim, r0, r1)
@@ -3543,7 +3670,9 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         } else {
                             let r0 = r - qd - kv_dim
                             let r1 = min(rend, qd + 2l * kv_dim) - qd - kv_dim
-                            if (f16w) {
+                            if (fv != KqFmt.q8) {
+                                invoke(rowsv, vp, kqpv, kspv, xqp, xsp, xbsw, dim, r0, r1)
+                            } elif (f16w) {
                                 invoke(mmrows16, vp, wpv, wsv16, xqp, xsp, dim, r0, r1)
                             } else {
                                 invoke(mmrows, vp, wpv, wsv, xqp, xsp, dim, r0, r1)
@@ -3606,7 +3735,11 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         let kvhoff = (hh / kv_mul) * head_size  // GQA: which kv head this query head reads
                         attn_head_decode_d(attp + hh * seq_len, xbp, qp, attqp, attsp, kcl, vcl, kdt, vdt, runsp,
                             nrun, qoff, kvhoff, kstart, cnt, kv_dim, head_size, hh, scale, attn_softcap, sinksp)
-                        quantize_q8_0_into_ptr(xbp + qoff, head_size, xqp, xsp, qoff, qoff / 32l)
+                        if (fo != KqFmt.q8) {   // kq wo: the offset term needs this head's per-16 sums too
+                            quantize_q8_0_bs_into_ptr(xbp + qoff, head_size, xqp, xsp, xbsw, qoff, qoff / 32l, qoff / 16l)
+                        } else {
+                            quantize_q8_0_into_ptr(xbp + qoff, head_size, xqp, xsp, qoff, qoff / 32l)
+                        }
                     }
                 }
             } elif (stage == 2) {
@@ -3717,7 +3850,11 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                         for (i in range64(head_size)) {
                             xbp[qoff + i] *= inv
                         }
-                        quantize_q8_0_into_ptr(xbp + qoff, head_size, xqp, xsp, qoff, qoff / 32l)
+                        if (fo != KqFmt.q8) {   // kq wo: per-16 sums alongside (see the single-pass twin)
+                            quantize_q8_0_bs_into_ptr(xbp + qoff, head_size, xqp, xsp, xbsw, qoff, qoff / 32l, qoff / 16l)
+                        } else {
+                            quantize_q8_0_into_ptr(xbp + qoff, head_size, xqp, xsp, qoff, qoff / 32l)
+                        }
                     }
                 }
             } else {
@@ -3726,7 +3863,9 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
                 unsafe {
                     let r0 = int64(jb) * 32l
                     let r1 = int64(je) * 32l
-                    if (f16w) {
+                    if (fo != KqFmt.q8) {
+                        invoke(rowso, xb2p, kqpo, kspo, xqp, xsp, xbsw, qd, r0, r1)
+                    } elif (f16w) {
                         invoke(mmrows16, xb2p, wpo, wso16, xqp, xsp, qd, r0, r1)
                     } else {
                         invoke(mmrows, xb2p, wpo, wso, xqp, xsp, qd, r0, r1)
@@ -3769,8 +3908,8 @@ def private attention_chain_decode(t : Model; var s : Session; l : int64; pos : 
 def private fused_ffn_ok(t : Model; l : int64) : bool {
     let c = t.config
     return (g_fused_decode && t.quant == QuantMode.q8
-        && fmt_at(t.w1_fmt, l) == KqFmt.q8 && fmt_at(t.w2_fmt, l) == KqFmt.q8
-        && fmt_at(t.w3_fmt, l) == KqFmt.q8   // kq layers: per-op path (chain rows cores are Q8-only for now)
+        && kq_servable(t, fmt_at(t.w1_fmt, l)) && kq_servable(t, fmt_at(t.w2_fmt, l))
+        && kq_servable(t, fmt_at(t.w3_fmt, l))
         && get_jobque_team_mode() && kernel_backend_has_rows()
         && (!t.wscale_f16 || kernel_backend_has_rows16())
         && lanes_for_work(c.dim * layer_hidden(t, l), g_gemv_lane_cap) > 1)
@@ -3786,9 +3925,18 @@ def private ffn_chain_decode(t : Model; var s : Session; l : int64) {
     let c = t.config
     let dim = c.dim
     let hidden = layer_hidden(t, l)   // gemma-4 E2B varies FFN width per layer
+    // per-weight formats (kq layers reach here only off a repacked load — fused_ffn_ok)
+    let f1 = fmt_at(t.w1_fmt, l)
+    let f2 = fmt_at(t.w2_fmt, l)
+    let f3 = fmt_at(t.w3_fmt, l)
+    let any_kq = f1 != KqFmt.q8 || f2 != KqFmt.q8 || f3 != KqFmt.q8
     let ts_norm1 = ref_time_ticks()
     rms_at(s.xb, t, t.rms_ffn_off + l * dim, s.x, dim)
-    quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
+    if (f1 != KqFmt.q8 || f3 != KqFmt.q8) {   // kq gate/up read the per-16 sums of the input quants
+        quantize_q8_0_bs_into(s.xb, dim, s.xq, s.xs, s.xbs, 0l, 0l, 0l)
+    } else {
+        quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
+    }
     prof_add("norm", ts_norm1)
     let ts_chain = ref_time_ticks()
     trace_tag(TRACE_TAG_FFN_CHAIN)
@@ -3821,7 +3969,9 @@ def private ffn_chain_decode(t : Model; var s : Session; l : int64) {
         var xs2p = addr(s.xs2[0])
         let f16w = t.wscale_f16
         let mmrows16 = mm_q8q8_rows16_fn()
-        let wqb = reinterpret<int8 const?>(addr(t.qblob[0]))
+        // all-kq layers skip the q8 bases — qblob/qscales can be EMPTY on an all-K-quant file
+        let has_q8w = f1 == KqFmt.q8 || f2 == KqFmt.q8 || f3 == KqFmt.q8
+        let wqb = has_q8w ? reinterpret<int8 const?>(addr(t.qblob[0])) : null
         let w1o = t.w1_offs[l]
         let w3o = t.w3_offs[l]
         let w2o = t.w2_offs[l]
@@ -3831,12 +3981,12 @@ def private ffn_chain_decode(t : Model; var s : Session; l : int64) {
         var ws116 : uint16 const? = null
         var ws316 : uint16 const? = null
         var ws216 : uint16 const? = null
-        if (f16w) {
+        if (f16w && has_q8w) {
             let wsb16 = reinterpret<uint16 const?>(addr(t.qscales16[0]))
             ws116 = wsb16 + w1o / 32l
             ws316 = wsb16 + w3o / 32l
             ws216 = wsb16 + w2o / 32l
-        } else {
+        } elif (has_q8w) {
             let wsb = reinterpret<float const?>(addr(t.qscales[0]))
             ws1 = wsb + w1o / 32l
             ws3 = wsb + w3o / 32l
@@ -3845,17 +3995,36 @@ def private ffn_chain_decode(t : Model; var s : Session; l : int64) {
         let wp1 = wqb + w1o
         let wp3 = wqb + w3o
         let wp2 = wqb + w2o
+        // kq-tagged weights: plane bases + rows cores + the per-16 sum planes (input / requant)
+        var xbsw : int? = any_kq ? addr(s.xbs[0]) : null
+        var xbs2w : int? = f2 != KqFmt.q8 ? addr(s.xbs2[0]) : null
+        let kqp1 = kq_plane_q(t, f1, w1o)
+        let ksp1 = kq_plane_s(t, f1, w1o)
+        let rows1 = kq_rows_for(f1)
+        let kqp3 = kq_plane_q(t, f3, w3o)
+        let ksp3 = kq_plane_s(t, f3, w3o)
+        let rows3 = kq_rows_for(f3)
+        let kqp2 = kq_plane_q(t, f2, w2o)
+        let ksp2 = kq_plane_s(t, f2, w2o)
+        let rows2 = kq_rows_for(f2)
         team_parallel_stages(s.chain_stages) <| @(stage : int; jb : int; je : int) {
             unsafe {
                 let r0 = int64(jb) * 32l
                 let r1 = int64(je) * 32l
                 if (stage == 0) {
                     // paired gate/up rows, then act + requant on exactly these rows
-                    if (f16w) {
+                    if (f1 != KqFmt.q8) {
+                        invoke(rows1, gup, kqp1, ksp1, xqp, xsp, xbsw, dim, r0, r1)
+                    } elif (f16w) {
                         invoke(mmrows16, gup, wp1, ws116, xqp, xsp, dim, r0, r1)
-                        invoke(mmrows16, gup + hidden, wp3, ws316, xqp, xsp, dim, r0, r1)
                     } else {
                         invoke(mmrows, gup, wp1, ws1, xqp, xsp, dim, r0, r1)
+                    }
+                    if (f3 != KqFmt.q8) {
+                        invoke(rows3, gup + hidden, kqp3, ksp3, xqp, xsp, xbsw, dim, r0, r1)
+                    } elif (f16w) {
+                        invoke(mmrows16, gup + hidden, wp3, ws316, xqp, xsp, dim, r0, r1)
+                    } else {
                         invoke(mmrows, gup + hidden, wp3, ws3, xqp, xsp, dim, r0, r1)
                     }
                     if (vec) {
@@ -3875,11 +4044,17 @@ def private ffn_chain_decode(t : Model; var s : Session; l : int64) {
                             swiglu(gup + r0, gup + hidden + r0, r1 - r0)
                         }
                     }
-                    quantize_q8_0_into_ptr(gup + r0, r1 - r0, xq2p, xs2p, r0, r0 / 32l)
+                    if (f2 != KqFmt.q8) {   // kq down-proj: per-16 sums of the hidden requant too
+                        quantize_q8_0_bs_into_ptr(gup + r0, r1 - r0, xq2p, xs2p, xbs2w, r0, r0 / 32l, r0 / 16l)
+                    } else {
+                        quantize_q8_0_into_ptr(gup + r0, r1 - r0, xq2p, xs2p, r0, r0 / 32l)
+                    }
                 } else {
                     // down-projection rows + residual add (post-norm / layer_out_scale arches
                     // defer the add — the caller's serial tail owns it)
-                    if (f16w) {
+                    if (f2 != KqFmt.q8) {
+                        invoke(rows2, xbp, kqp2, ksp2, xq2p, xs2p, xbs2w, hidden, r0, r1)
+                    } elif (f16w) {
                         invoke(mmrows16, xbp, wp2, ws216, xq2p, xs2p, hidden, r0, r1)
                     } else {
                         invoke(mmrows, xbp, wp2, ws2, xq2p, xs2p, hidden, r0, r1)
@@ -4681,16 +4856,35 @@ def private embed_row(t : Model; token : int64; var dst : float?) {
     if (t.cls_q8) {
         dequant_q8_row(t, t.emb_q8_off + token * dim, dim, dst)
     } elif (cls_kq(t)) {
-        unsafe {
-            var row = temp_array(dst, dim, type<float>)
-            let sb0 = (t.wcls_off + token * dim) / 256l
-            for (s in range64(dim / 256l)) {
+        let mr = t.kq_repack_mr
+        if (t.kq_repacked && token < (t.config.vocab_size / mr) * mr) {
+            // repacked plane: gather the row through the grp<mr> layout (tail rows below stay
+            // disk-order — the repack leaves them verbatim)
+            unsafe {
+                let nsb = dim / 256l
+                let g = token / mr
+                let fmt = t.emb_fmt == KqFmt.k4 ? 4l : (t.emb_fmt == KqFmt.k5 ? 5l : 6l)
+                let sb0t = t.wcls_off / 256l
                 if (t.emb_fmt == KqFmt.k4) {
-                    dequant_k4_plane_superblock(t.k4q, (sb0 + s) * K4_QSB, t.k4s, (sb0 + s) * K4_SSB, row, s * 256l)
+                    dequant_kq_row_grp(fmt, addr(t.k4q[(sb0t + g * mr * nsb) * K4_QSB]), addr(t.k4s[(sb0t + g * mr * nsb) * K4_SSB]), token % mr, mr, dim, dst)
                 } elif (t.emb_fmt == KqFmt.k5) {
-                    dequant_k5_plane_superblock(t.k5q, (sb0 + s) * K5_QSB, t.k5s, (sb0 + s) * K5_SSB, row, s * 256l)
+                    dequant_kq_row_grp(fmt, addr(t.k5q[(sb0t + g * mr * nsb) * K5_QSB]), addr(t.k5s[(sb0t + g * mr * nsb) * K5_SSB]), token % mr, mr, dim, dst)
                 } else {
-                    dequant_k6_plane_superblock(t.k6q, (sb0 + s) * K6_QSB, t.k6s, (sb0 + s) * K6_SSB, row, s * 256l)
+                    dequant_kq_row_grp(fmt, addr(t.k6q[(sb0t + g * mr * nsb) * K6_QSB]), addr(t.k6s[(sb0t + g * mr * nsb) * K6_SSB]), token % mr, mr, dim, dst)
+                }
+            }
+        } else {
+            unsafe {
+                var row = temp_array(dst, dim, type<float>)
+                let sb0 = (t.wcls_off + token * dim) / 256l
+                for (s in range64(dim / 256l)) {
+                    if (t.emb_fmt == KqFmt.k4) {
+                        dequant_k4_plane_superblock(t.k4q, (sb0 + s) * K4_QSB, t.k4s, (sb0 + s) * K4_SSB, row, s * 256l)
+                    } elif (t.emb_fmt == KqFmt.k5) {
+                        dequant_k5_plane_superblock(t.k5q, (sb0 + s) * K5_QSB, t.k5s, (sb0 + s) * K5_SSB, row, s * 256l)
+                    } else {
+                        dequant_k6_plane_superblock(t.k6q, (sb0 + s) * K6_QSB, t.k6s, (sb0 + s) * K6_SSB, row, s * 256l)
+                    }
                 }
             }
         }
@@ -4699,11 +4893,14 @@ def private embed_row(t : Model; token : int64; var dst : float?) {
     }
 }
 
-// Can the classifier run as the fused matmul+softcap team chain? Q8 wcls (the tied-f32 load takes
-// mm_fblob and can't), team mode + a backend row core, 32-aligned vocab, and worth threading.
+// Can the classifier run as the fused matmul+softcap team chain? Q8 or repacked-kq wcls (the
+// tied-f32 load takes mm_fblob and can't), team mode + a backend row core, 32-aligned vocab,
+// and worth threading.
 def private fused_cls_ok(t : Model) : bool {
     let c = t.config
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     return (g_fused_decode && t.quant == QuantMode.q8
+        && kq_servable(t, cls_fmt)
         && get_jobque_team_mode() && kernel_backend_has_rows()
         && (!t.wscale_f16 || kernel_backend_has_rows16())
         && c.vocab_size % 32l == 0l
@@ -4713,12 +4910,18 @@ def private fused_cls_ok(t : Model) : bool {
 // Fused classifier + final-logit softcap: one team chain over 32-row vocab groups, each chunk
 // soft-capping the rows it just produced (cache-hot) — a serial softcap over a 256k vocab was
 // 2-4ms of every-lane-idle per token. Same row dots and same softcap4 element order as the
-// unfused mm + softcap4 pair, so bit-identical to it.
+// unfused mm + softcap4 pair, so bit-identical to it. A kq classifier (tied plane copy or
+// untied kq output.weight) runs the format's stamped rows core over the repacked planes.
 def private cls_softcap_chain(t : Model; var s : Session; cap : float) {
     let c = t.config
     let dim = c.dim
     let vocab = c.vocab_size
-    quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    if (cls_fmt != KqFmt.q8) {
+        quantize_q8_0_bs_into(s.xb, dim, s.xq, s.xs, s.xbs, 0l, 0l, 0l)
+    } else {
+        quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
+    }
     let mmrows = mm_q8q8_rows_fn()
     let ngrp = int(vocab / 32l)
     let n0 = chain_stage_chunks(ngrp, int(vocab), dim * vocab)
@@ -4731,19 +4934,28 @@ def private cls_softcap_chain(t : Model; var s : Session; cap : float) {
         var xsp = addr(s.xs[0])
         let f16w = t.wscale_f16
         let mmrows16 = mm_q8q8_rows16_fn()
-        let wp = reinterpret<int8 const?>(addr(t.qblob[0])) + t.wcls_off
+        let wp = cls_fmt == KqFmt.q8 ? reinterpret<int8 const?>(addr(t.qblob[0])) + t.wcls_off : null
         var ws : float const? = null
         var ws16 : uint16 const? = null
-        if (f16w) {
-            ws16 = reinterpret<uint16 const?>(addr(t.qscales16[0])) + t.wcls_off / 32l
-        } else {
-            ws = reinterpret<float const?>(addr(t.qscales[0])) + t.wcls_off / 32l
+        if (cls_fmt == KqFmt.q8) {
+            if (f16w) {
+                ws16 = reinterpret<uint16 const?>(addr(t.qscales16[0])) + t.wcls_off / 32l
+            } else {
+                ws = reinterpret<float const?>(addr(t.qscales[0])) + t.wcls_off / 32l
+            }
         }
+        var xbsw : int? = cls_fmt != KqFmt.q8 ? addr(s.xbs[0]) : null
+        let kqpc = kq_plane_q(t, cls_fmt, t.wcls_off)
+        let kspc = kq_plane_s(t, cls_fmt, t.wcls_off)
+        let rowsc = kq_rows_for(cls_fmt)
+        let is_kq = cls_fmt != KqFmt.q8
         team_parallel_stages(s.chain_stages) <| @(stage : int; jb : int; je : int) {
             unsafe {
                 let r0 = int64(jb) * 32l
                 let r1 = int64(je) * 32l
-                if (f16w) {
+                if (is_kq) {
+                    invoke(rowsc, lp, kqpc, kspc, xqp, xsp, xbsw, dim, r0, r1)
+                } elif (f16w) {
                     invoke(mmrows16, lp, wp, ws16, xqp, xsp, dim, r0, r1)
                 } else {
                     invoke(mmrows, lp, wp, ws, xqp, xsp, dim, r0, r1)
@@ -4798,8 +5010,8 @@ def forward(t : Model; var s : Session; token, pos : int64) {
     rms_at(s.xb, t, t.rms_final_off, s.x, dim)
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
-    if (c.final_logit_softcap > 0.0 && !tied_f32 && cls_fmt == KqFmt.q8 && fused_cls_ok(t)) {
-        // Gemma2/E-series: soft-cap fused into the classifier chunks
+    if (c.final_logit_softcap > 0.0 && !tied_f32 && fused_cls_ok(t)) {
+        // Gemma2/E-series: soft-cap fused into the classifier chunks (Q8 or repacked-kq wcls)
         cls_softcap_chain(t, s, c.final_logit_softcap)
     } else {
         if (tied_f32) {
@@ -6616,7 +6828,7 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     rms_at(s.xb, t, t.rms_final_off, s.x_b, last * dim, dim)
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
-    if (c.final_logit_softcap > 0.0 && !tied_f32 && cls_fmt == KqFmt.q8 && fused_cls_ok(t)) {
+    if (c.final_logit_softcap > 0.0 && !tied_f32 && fused_cls_ok(t)) {
         cls_softcap_chain(t, s, c.final_logit_softcap)
     } else {
         if (tied_f32) {

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
@@ -44,8 +44,10 @@ require dasllama/dasllama_gemm_schema
 // Runs in the llvm-jit context; wired via llvm_user_modules.das. The stubs it generates for
 // are dasllama/dasllama_math_gen.das::q8q8_tile_gen, ::q8q8_layout_gen, ::q8q8_wbias_gen,
 // ::q8q8_kgroup_gen, ::q8q8_tokstep_gen, ::q8q8_gemv_gen, ::mx4q8_gemv_gen,
-// ::q8q8_family_live (the witness), and the wscale_f16 twins ::q8q8_tile_s16_gen /
-// ::q8q8_gemv_s16_gen (same perm, same fold order — only the scale-fold load widens f16).
+// ::q8q8_family_live (the witness), the wscale_f16 twins ::q8q8_tile_s16_gen /
+// ::q8q8_gemv_s16_gen (same perm, same fold order — only the scale-fold load widens f16), and
+// the K-quant rows cores ::k4q8_gemv_gen / ::k5q8_gemv_gen / ::k6q8_gemv_gen (unsigned-quant
+// superblock GEMVs over the grp<mr> kq planes — kq stage 4).
 
 // dot-primitive kinds (TilePerm.dotPrim, parsed once into TileEmit.dotKind)
 let DOT_SDOT = 0
@@ -284,6 +286,9 @@ struct private TileEmit {
     xbs : LLVMOpaqueValue? [4]           // per-token bsum bases (−128·Σx i32 per block) — the tile's
                                          // bias128 correction plane; null = compute inline (gemv)
     mx4 : bool                           // block emitter: mx4 LUT-dequant instead of Q8 loads
+    kq : int                             // 4/5/6 = K-quant superblock emitter (0 = not kq): the
+                                         // block unit is a 256-weight superblock over the grp<mr>
+                                         // kq planes; dots run unsigned-q (kq_dot_lane)
     t_amx : LLVMOpaqueType?              // x86_amx — virtual tile values (the TMUL tile, slice I)
     tload_decl : LLVMOpaqueValue?        // llvm.x86.tileloadd64.internal (latch: raw tileloadd64)
     tload_ty : LLVMOpaqueType?
@@ -750,11 +755,181 @@ def private emit_block_mx4(var te : TileEmit; var bi : LLVMOpaqueValue?; var f :
     }
 }
 
+// one K-quant lane-dot: acc += q · (dword-group `lane` of x, splatted). The quants are UNSIGNED
+// (0..15/31/63) straight off the expand — they ARE the u8 side of vpdpbusd/maddubs (signed x on
+// the other side), and they fit s8 non-negatively for bssd/sdot — so no |w|, no sign apply, no
+// bias plane on any leg. maddubs pair-sums stay exact: 2·63·127 < 32767.
+def private kq_dot_lane(var te : TileEmit; var acc, qv, xv : LLVMOpaqueValue?; lane : int) : LLVMOpaqueValue? {
+    if (te.dotKind == DOT_SDOT || te.dotKind == DOT_SMMLA) {
+        return sdot_lane(te, acc, qv, xv, lane)
+    }
+    let b = te.builder
+    var xi32 = LLVMBuildBitCast(b, xv, te.v4i32, "")
+    let mask <- [for (_i in range(te.rv)); lane]
+    var xspl = LLVMBuildShuffleVector(b, te.types, xi32, xi32, mask, "xlane")
+    var xb = LLVMBuildBitCast(b, xspl, te.vwi8, "")
+    if (te.dotKind == DOT_MADDUBS) {
+        var margs <- [qv, xb]
+        var pairs = LLVMBuildCall2(b, te.madd_ty, te.madd_decl, margs, "pairs")
+        var wargs <- [pairs, ones_i16(te)]
+        var quads = LLVMBuildCall2(b, te.maddwd_ty, te.maddwd_decl, wargs, "quads")
+        return LLVMBuildAdd(b, acc, quads, "dot")
+    }
+    var dargs <- [acc, qv, xb]
+    return LLVMBuildCall2(b, te.dp_ty, te.dp_decl, dargs, "dot")
+}
+
+// one <rv x i8> row-byte load at BYTE offset, each byte splatted across its row's 4 lanes to
+// vwi8 (constant shufflevector — the backend picks tbl/pshufb itself; no intrinsic needed)
+def private load_row_bytes_x4(var te : TileEmit; var base, off : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
+    var vri8 = LLVMVectorType(te.types.t_int8, uint(te.rv))
+    var p = LLVMBuildGEP2(te.builder, te.types.t_int8, base, off, name)
+    var v = LLVMBuildLoad2Aligned(te.builder, vri8, p, 1u, name)
+    let mask <- [for (i in range(te.width / 8)); i / 4]
+    return LLVMBuildShuffleVector(te.builder, te.types, v, v, mask, name)
+}
+
+// one <rv x i16> binary16 load at BYTE offset off, widened to vnf32 (the kq scale planes are
+// byte-addressed; fcvtl / vcvtph2ps lowering, same as load_scale_vec's sgF16 arm)
+def private load_f16_vec_at(var te : TileEmit; var base, off : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
+    let b = te.builder
+    var p = LLVMBuildGEP2(b, te.types.t_int8, base, off, name)
+    var hv = LLVMBuildLoad2Aligned(b, te.vni16, p, 2u, name)
+    return LLVMBuildFPExt(b, LLVMBuildBitCast(b, hv, te.vnf16, ""), te.vnf32, name)
+}
+
+// or-in of a masked bit test as the nibble's 0x10: w |= (bytes & mask) != 0 ? 0x10 : 0
+// (pcmpeqb+pand shape after lowering — the k5 high-bit deposit)
+def private or_bit_x10(te : TileEmit; var w, bytes, maskv : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
+    let b = te.builder
+    var hit = LLVMBuildICmp(b, LLVMIntPredicate.LLVMIntNE, LLVMBuildAnd(b, bytes, maskv, ""), LLVMConstNull(te.vwi8), "")
+    var sel = LLVMBuildSelect(b, hit, splat_i8w(te, 16), LLVMConstNull(te.vwi8), name)
+    return LLVMBuildOr(b, w, sel, name)
+}
+
+// One 256-weight SUPERBLOCK, K-quant grp<mr> form (te.kq = 4/5/6; single token — the kq family
+// is GEMV-only). Plane layouts per superblock per mr-row group (see repack_k4/k5/k6_grp):
+//   k4  quants [blk 0..7][j 0..3][row][4B] — byte t of (blk,j) = nibble pair for k blk*32+j*4+t
+//       (low) / +16 (high), the mx4 pairing; scales [blk][mr f16 s][mr f16 o]
+//   k5  = k4 + high bits [blk][j][row] 1B — bits 0..3 = the 4 low-k weights, 4..7 = high
+//   k6  = k4-shaped low nibbles + high 2-bit groups [half 0..1][jj 0..7][row][4B] (jj covers the
+//       half's 32 byte columns; block g of the half reads jj=j (lo) / j+4 (hi) at uniform shift
+//       2g); scales [16 x mr int8 sc][mr f16 d] — NATIVE sub-scales, s = d·sc widened in-loop,
+//       so the fold math is bit-identical to the portable dot's
+// Fold per 32-sub-block: f += xs[b]·(s⊙float(Σq·a) − o⊙Σa) with Σa off the per-16 xbs plane
+// (k6: o = 32·s folds as s⊙(float(Σq·a) − 32·Σa16) per 16-half). Identical loads re-emitted
+// per sub-block (k6 qh groups, d vector) GVN to one — the file-wide splat discipline.
+def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]) {
+    let b = te.builder
+    let rq = te.rq
+    let mr = te.interleave
+    let w8 = te.width / 8
+    let qsb = te.kq == 4 ? 128 : (te.kq == 5 ? 160 : 192)
+    var wb = LLVMBuildMul(b, sbi, te.types->ConstI64(uint64(mr * qsb)), "wb")
+    var sb = LLVMBuildMul(b, sbi, te.types->ConstI64(uint64(mr * (te.kq == 6 ? 18 : 32))), "sb")
+    var xb = LLVMBuildMul(b, sbi, te.types->ConstI64(0x100ul), "xb")
+    var gb = LLVMBuildShl(b, sbi, te.types->ConstI64(3ul), "gb")
+    var maskLoElems <- [for (i in range(w8)); LLVMConstInt(te.types.t_int8, uint64(1 << (i % 4)), 0)]
+    var maskHiElems <- [for (i in range(w8)); LLVMConstInt(te.types.t_int8, uint64(16 << (i % 4)), 0)]
+    var maskLo = LLVMConstVector(array_data_ptr(maskLoElems), uint(w8))
+    var maskHi = LLVMConstVector(array_data_ptr(maskHiElems), uint(w8))
+    for (blk in range(8)) {
+        var xoff0 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32)), "")
+        var xoff1 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32 + 16)), "")
+        var xv0 = load_v16i8(te, te.x[0], xoff0, "x{blk}lo")
+        var xv1 = load_v16i8(te, te.x[0], xoff1, "x{blk}hi")
+        var a0 : LLVMOpaqueValue? [2]
+        var a1 : LLVMOpaqueValue? [2]
+        for (qd in range(rq)) {
+            a0[qd] = LLVMConstNull(te.vni32)
+            a1[qd] = LLVMConstNull(te.vni32)
+        }
+        for (j in range(4)) {
+            for (qd in range(rq)) {
+                var noff = LLVMBuildAdd(b, wb, te.types->ConstI64(uint64((blk * 16 + j * 4) * mr + qd * w8)), "")
+                var nv = load_vec(te, te.vwi8, te.wg, noff, "nv{blk}_{j * rq + qd}")
+                var wlo = LLVMBuildAnd(b, nv, splat_i8w(te, 15), "wlo{blk}_{j * rq + qd}")
+                var whi = LLVMBuildLShr(b, nv, splat_i8w(te, 4), "whi{blk}_{j * rq + qd}")
+                if (te.kq == 5) {
+                    var hoff = LLVMBuildAdd(b, wb, te.types->ConstI64(uint64(128 * mr + (blk * 4 + j) * mr + qd * te.rv)), "")
+                    var hb = load_row_bytes_x4(te, te.wg, hoff, "qh{blk}_{j * rq + qd}")
+                    wlo = or_bit_x10(te, wlo, hb, maskLo, "wlo5{blk}_{j * rq + qd}")
+                    whi = or_bit_x10(te, whi, hb, maskHi, "whi5{blk}_{j * rq + qd}")
+                } elif (te.kq == 6) {
+                    let g2 = (blk % 4) * 2
+                    let hbase = 128 * mr + ((blk / 4) * 8) * 4 * mr
+                    var hloOff = LLVMBuildAdd(b, wb, te.types->ConstI64(uint64(hbase + j * 4 * mr + qd * w8)), "")
+                    var hhiOff = LLVMBuildAdd(b, wb, te.types->ConstI64(uint64(hbase + (j + 4) * 4 * mr + qd * w8)), "")
+                    var qhlo = load_vec(te, te.vwi8, te.wg, hloOff, "qhl{blk / 4}_{j * rq + qd}")
+                    var qhhi = load_vec(te, te.vwi8, te.wg, hhiOff, "qhh{blk / 4}_{j * rq + qd}")
+                    var dlo = LLVMBuildAnd(b, LLVMBuildLShr(b, qhlo, splat_i8w(te, g2), ""), splat_i8w(te, 3), "")
+                    var dhi = LLVMBuildAnd(b, LLVMBuildLShr(b, qhhi, splat_i8w(te, g2), ""), splat_i8w(te, 3), "")
+                    wlo = LLVMBuildOr(b, wlo, LLVMBuildShl(b, dlo, splat_i8w(te, 4), ""), "wlo6{blk}_{j * rq + qd}")
+                    whi = LLVMBuildOr(b, whi, LLVMBuildShl(b, dhi, splat_i8w(te, 4), ""), "whi6{blk}_{j * rq + qd}")
+                }
+                a0[qd] = kq_dot_lane(te, a0[qd], wlo, xv0, j)
+                a1[qd] = kq_dot_lane(te, a1[qd], whi, xv1, j)
+            }
+        }
+        // per-sub-block fold; bIdx = the global 32-block index (activation scale/bsum space)
+        var bIdx = LLVMBuildAdd(b, gb, te.types->ConstI64(uint64(blk)), "b{blk}")
+        var qp = LLVMBuildGEP2(b, te.types.t_float, te.xs[0], bIdx, "qp{blk}")
+        var qs = LLVMBuildLoad2Aligned(b, te.types.t_float, qp, 4u, "qs{blk}")
+        var bi2 = LLVMBuildShl(b, bIdx, te.types->ConstI64(1ul), "")
+        var bp0 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[0], bi2, "bp{blk}a")
+        var bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{blk}a")
+        var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[0], LLVMBuildAdd(b, bi2, te.types->ConstI64(1ul), ""), "bp{blk}b")
+        var bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{blk}b")
+        if (te.kq == 6) {
+            // s16 chains: f += (float(acc) − 32·Σa16) · (d·sc16 · qs) per 16-half — the exact
+            // portable term (all three factors of the integer part are exact in f32)
+            var a16lo = LLVMBuildFMul(b, LLVMBuildSIToFP(b, bs0, te.types.t_float, ""), te.types->ConstReal(32.0lf), "a32{blk}a")
+            var a16hi = LLVMBuildFMul(b, LLVMBuildSIToFP(b, bs1, te.types.t_float, ""), te.types->ConstReal(32.0lf), "a32{blk}b")
+            var vri8 = LLVMVectorType(te.types.t_int8, uint(te.rv))
+            for (qd in range(rq)) {
+                var dv = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(16 * mr + 2 * (qd * te.rv))), ""), "d{qd}")
+                var sc0p = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * blk * mr + qd * te.rv)), ""), "sc{blk}a")
+                var sc1p = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64((2 * blk + 1) * mr + qd * te.rv)), ""), "sc{blk}b")
+                var sc0 = LLVMBuildSIToFP(b, LLVMBuildSExt(b, LLVMBuildLoad2Aligned(b, vri8, sc0p, 1u, ""), te.vni32, ""), te.vnf32, "")
+                var sc1 = LLVMBuildSIToFP(b, LLVMBuildSExt(b, LLVMBuildLoad2Aligned(b, vri8, sc1p, 1u, ""), te.vni32, ""), te.vnf32, "")
+                var qspl = splat_f32(te, qs, "qs{blk}v")
+                var s0 = LLVMBuildFMul(b, LLVMBuildFMul(b, dv, sc0, ""), qspl, "s0{blk}_{qd}")
+                var s1 = LLVMBuildFMul(b, LLVMBuildFMul(b, dv, sc1, ""), qspl, "s1{blk}_{qd}")
+                var t0 = LLVMBuildFSub(b, LLVMBuildSIToFP(b, a0[qd], te.vnf32, ""), splat_f32(te, a16lo, ""), "t0{blk}_{qd}")
+                var t1 = LLVMBuildFSub(b, LLVMBuildSIToFP(b, a1[qd], te.vnf32, ""), splat_f32(te, a16hi, ""), "t1{blk}_{qd}")
+                f[qd] = fold_fma(te, t0, s0, f[qd], "f{blk}_{qd}a")
+                f[qd] = fold_fma(te, t1, s1, f[qd], "f{blk}_{qd}b")
+            }
+        } else {
+            // k4/k5: one 32-wide chain per qd (both 16-halves share the block's f16 (s,o) pair);
+            // Σa32 = the two per-16 sums, offset term o·(qs·Σa) folds as a second fma
+            var acc : LLVMOpaqueValue? [2]
+            for (qd in range(rq)) {
+                acc[qd] = LLVMBuildAdd(b, a0[qd], a1[qd], "acc{blk}_{qd}")
+            }
+            var a32 = LLVMBuildAdd(b, bs0, bs1, "a32{blk}")
+            var qa = LLVMBuildFMul(b, qs, LLVMBuildSIToFP(b, a32, te.types.t_float, ""), "qa{blk}")
+            var nqa = LLVMBuildFNeg(b, qa, "nqa{blk}")
+            for (qd in range(rq)) {
+                var sv = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 4 * mr + 2 * (qd * te.rv))), ""), "s{blk}_{qd}")
+                var ov = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 4 * mr + 2 * mr + 2 * (qd * te.rv))), ""), "o{blk}_{qd}")
+                var af = LLVMBuildSIToFP(b, acc[qd], te.vnf32, "af{blk}_{qd}")
+                var sq = LLVMBuildFMul(b, sv, splat_f32(te, qs, "qs{blk}v"), "")
+                f[qd] = fold_fma(te, af, sq, f[qd], "f{blk}_{qd}")
+                f[qd] = fold_fma(te, ov, splat_f32(te, nqa, "nqa{blk}v"), f[qd], "f{blk}_{qd}o")
+            }
+        }
+    }
+}
+
 // block-emitter dispatch: the slice/loop machinery is quant-agnostic. The MMA form needs a
 // token PAIR — the gemv companion's single-token slices ride the sdot lattice (emit_block's
-// kg8 weight fixup reads the same plane).
+// kg8 weight fixup reads the same plane). kq blocks are SUPERBLOCKS (the kq gemv drives
+// emit_slice with nb = n/256) and single-token by construction.
 def private emit_one_block(var te : TileEmit; var bi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]; tokBase, tokCount : int) {
-    if (te.mx4) {
+    if (te.kq != 0) {
+        emit_block_kq(te, bi, f)
+    } elif (te.mx4) {
         emit_block_mx4(te, bi, f, tokBase, tokCount)
     } elif (te.dotKind == DOT_SMMLA && tokCount >= 2) {
         emit_block_smmla(te, bi, f, tokBase, tokCount)
@@ -920,15 +1095,15 @@ def private setup_tile_emit(var te : TileEmit; var gc : LlvmCodeCtx; p : TilePer
     te.types = gc.jit.types
     te.interleave = rt.interleave
     te.dotKind = dot_kind(p.dotPrim)
-    // the mx4 nibble plane is kgroup-independent (its own repack) — under an smmla perm the
-    // mx4 companion rides the plain sdot lattice (i8mm implies dotprod)
-    if (te.mx4 && te.dotKind == DOT_SMMLA) {
+    // the mx4/kq planes are kgroup-independent (their own repacks) — under an smmla perm those
+    // companions ride the plain sdot lattice (i8mm implies dotprod)
+    if ((te.mx4 || te.kq != 0) && te.dotKind == DOT_SMMLA) {
         te.dotKind = DOT_SDOT
     }
-    te.kgroup = te.mx4 ? 4 : rt.kgroup
-    // the perm's bias applies to the Q8 weight plane only — the mx4 nibble/LUT path always
-    // runs unbiased (its dequanted weights never see the repack)
-    te.bias = te.mx4 ? 0 : p.bias
+    te.kgroup = (te.mx4 || te.kq != 0) ? 4 : rt.kgroup
+    // the perm's bias applies to the Q8 weight plane only — the mx4 LUT path and the kq
+    // unsigned-quant planes never see the biased repack
+    te.bias = (te.mx4 || te.kq != 0) ? 0 : p.bias
     te.width = (te.dotKind == DOT_SDOT || te.dotKind == DOT_SMMLA) ? 128 : p.width
     te.rv = te.width / 32
     te.rq = rt.interleave / te.rv
@@ -1836,6 +2011,89 @@ def private mx4_gemv_gen(var gc : LlvmCodeCtx) : bool {
     return true
 }
 
+def private is_kq_gemv_signature(fn : Function const?) : bool {
+    if (length(fn.arguments) != 9 || fn.result.baseType != Type.tVoid) return false
+    for (i in range(6)) {
+        if (fn.arguments[i]._type.baseType != Type.tPointer) return false
+    }
+    for (i in range(6, 9)) {
+        if (fn.arguments[i]._type.baseType != Type.tInt64) return false
+    }
+    return true
+}
+
+// The K-quant sixth of the stamp (kq stage 4): rows-range GEMVs over the grp<mr> kq planes —
+// (yp, kq, ks, xq, xs, xbs, n, rb, re), rb/re multiples of mr. Same group walk as gemv_gen but
+// the block unit is a 256-weight SUPERBLOCK (nb = n/256, kstep pinned 1 — 8 sub-block dot
+// chains per unit already feed the ports; gkstep's extra unroll only bloats the body). The
+// unpacks are generic IR and the dots ride the existing lattice via kq_dot_lane, so the family
+// declines via the SAME perm_declines with NO new rails — witness lockstep holds for free.
+def private kq_gemv_gen_impl(var gc : LlvmCodeCtx; fmt : int) : bool {
+    if (!is_kq_gemv_signature(gc.fn)) return false
+    let p0 = parse_perm(gc)
+    if (perm_declines(gc, p0)) return false
+    let p = companion_perm(p0)
+
+    var te = TileEmit(kq = fmt)
+    if (!setup_tile_emit(te, gc, p, false)) return false
+
+    let b = gc.jit.builder
+    var entry = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "entry")
+    var ghead = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "ghead")
+    var gexit = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "gexit")
+
+    // entry: group range off the row range; per-row-per-superblock strides are the disk
+    // footprints (the repack only reorders): quants 128/160/192 B, scales 32/32/18 B
+    LLVMPositionBuilderAtEnd(b, entry)
+    var sa = SliceArgs(gc_impl = gc.impl, ctx = gc.jit.ctx, kstep = 1)
+    sa.yp = LLVMGetParam(gc.impl, 0u)
+    let kqp = LLVMGetParam(gc.impl, 1u)
+    let ksp = LLVMGetParam(gc.impl, 2u)
+    te.x[0] = LLVMGetParam(gc.impl, 3u)
+    te.xs[0] = LLVMGetParam(gc.impl, 4u)
+    te.xbs[0] = LLVMGetParam(gc.impl, 5u)
+    let n = LLVMGetParam(gc.impl, 6u)
+    let rbv = LLVMGetParam(gc.impl, 7u)
+    let rev = LLVMGetParam(gc.impl, 8u)
+    sa.nb = LLVMBuildSDiv(b, n, te.types->ConstI64(0x100ul), "nsb")
+    var qrow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(uint64(fmt == 4 ? 128 : (fmt == 5 ? 160 : 192))), "qrow")
+    var srow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(uint64(fmt == 6 ? 18 : 32)), "srow")
+    sa.d = te.types->ConstI64(0ul)
+    sa.t0 = te.types->ConstI64(0ul)
+    let mrC = te.types->ConstI64(uint64(te.interleave))
+    var g0 = LLVMBuildSDiv(b, rbv, mrC, "g0")
+    var g1 = LLVMBuildSDiv(b, rev, mrC, "g1")
+    var nonempty = LLVMBuildICmp(b, LLVMIntPredicate.LLVMIntSLT, g0, g1, "any")
+    LLVMBuildCondBr(b, nonempty, ghead, gexit)
+
+    LLVMPositionBuilderAtEnd(b, ghead)
+    var gPhi = LLVMBuildPhi(b, te.types.t_int64, "g")
+    var gEntryVals <- [g0]
+    var gEntryBlocks <- [entry]
+    LLVMAddIncoming(gPhi, gEntryVals, gEntryBlocks)
+    sa.g = gPhi
+    var gRow = LLVMBuildMul(b, gPhi, mrC, "grow")
+    te.wg = LLVMBuildGEP2(b, te.types.t_int8, kqp, LLVMBuildMul(b, gRow, qrow, ""), "wg")
+    te.sg = LLVMBuildGEP2(b, te.types.t_int8, ksp, LLVMBuildMul(b, gRow, srow, ""), "sg")
+
+    var after = emit_slice(te, sa, ghead, 0, 1, "")
+    LLVMPositionBuilderAtEnd(b, after)
+    var gNext = LLVMBuildAdd(b, gPhi, te.types->ConstI64(1ul), "gnext")
+    var more = LLVMBuildICmp(b, LLVMIntPredicate.LLVMIntSLT, gNext, g1, "more")
+    LLVMBuildCondBr(b, more, ghead, gexit)
+    var gLoopVals <- [gNext]
+    var gLoopBlocks <- [after]
+    LLVMAddIncoming(gPhi, gLoopVals, gLoopBlocks)
+
+    LLVMPositionBuilderAtEnd(b, gexit)
+    LLVMBuildRetVoid(b)
+    return true
+}
+
+def private k4_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 4)
+def private k5_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 5)
+def private k6_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 6)
+
 // Called from llvm_user_modules::register_user_llvm_code_generators — the JIT invokes that in the
 // context that reads the registry, so the direct call lands in the right table copy.
 [macro_function]
@@ -1850,5 +2108,8 @@ def public register_dasllama_gemm_generators {
     register_llvm_code_generator("dasllama_gemm_gen::q8q8_tile_s16", @@tile_s16_gen)
     register_llvm_code_generator("dasllama_gemm_gen::q8q8_gemv_s16", @@gemv_s16_gen)
     register_llvm_code_generator("dasllama_gemm_gen::mx4_gemv", @@mx4_gemv_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::k4_gemv", @@k4_gemv_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::k5_gemv", @@k5_gemv_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::k6_gemv", @@k6_gemv_gen)
     register_llvm_code_generator("dasllama_gemm_gen::q8q8_witness", @@witness_gen)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
@@ -807,8 +807,13 @@ def private or_bit_x10(te : TileEmit; var w, bytes, maskv : LLVMOpaqueValue?; na
     return LLVMBuildOr(b, w, sel, name)
 }
 
-// One 256-weight SUPERBLOCK, K-quant grp<mr> form (te.kq = 4/5/6; single token — the kq family
-// is GEMV-only). Plane layouts per superblock per mr-row group (see repack_k4/k5/k6_grp):
+// One 256-weight SUPERBLOCK, K-quant grp<mr> form (te.kq = 4/5/6) for tokens [tokBase,
+// tokBase+tokCount): weight vectors are unpacked ONCE per (sub-block, dword-group) and dotted
+// against every token's lane splat — the weight-stationary form that makes the kq tile stream
+// the planes once per 4-token tile instead of once per position. tokCount = 1 is the GEMV.
+// Per-token fold order is IDENTICAL to the single-token form, so the tile is bit-exact vs
+// per-token GEMVs over the same planes. Plane layouts per superblock per mr-row group (see
+// repack_k4/k5/k6_grp):
 //   k4  quants [blk 0..7][j 0..3][row][4B] — byte t of (blk,j) = nibble pair for k blk*32+j*4+t
 //       (low) / +16 (high), the mx4 pairing; scales [blk][mr f16 s][mr f16 o]
 //   k5  = k4 + high bits [blk][j][row] 1B — bits 0..3 = the 4 low-k weights, 4..7 = high
@@ -819,7 +824,7 @@ def private or_bit_x10(te : TileEmit; var w, bytes, maskv : LLVMOpaqueValue?; na
 // Fold per 32-sub-block: f += xs[b]·(s⊙float(Σq·a) − o⊙Σa) with Σa off the per-16 xbs plane
 // (k6: o = 32·s folds as s⊙(float(Σq·a) − 32·Σa16) per 16-half). Identical loads re-emitted
 // per sub-block (k6 qh groups, d vector) GVN to one — the file-wide splat discipline.
-def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]) {
+def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]; tokBase, tokCount : int) {
     let b = te.builder
     let rq = te.rq
     let mr = te.interleave
@@ -836,16 +841,21 @@ def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f :
     for (blk in range(8)) {
         var xoff0 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32)), "")
         var xoff1 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32 + 16)), "")
-        var xv0 = load_v16i8(te, te.x[0], xoff0, "x{blk}lo")
-        var xv1 = load_v16i8(te, te.x[0], xoff1, "x{blk}hi")
-        var a0 : LLVMOpaqueValue? [2]
-        var a1 : LLVMOpaqueValue? [2]
-        for (qd in range(rq)) {
-            a0[qd] = LLVMConstNull(te.vni32)
-            a1[qd] = LLVMConstNull(te.vni32)
+        var xv0 : LLVMOpaqueValue? [4]
+        var xv1 : LLVMOpaqueValue? [4]
+        for (i in range(tokCount)) {
+            xv0[i] = load_v16i8(te, te.x[tokBase + i], xoff0, "x{tokBase + i}_{blk}lo")
+            xv1[i] = load_v16i8(te, te.x[tokBase + i], xoff1, "x{tokBase + i}_{blk}hi")
+        }
+        var a0 : LLVMOpaqueValue? [8]     // [token * rq + qd]; tokCount*rq <= 8 (nrsplit*vq rail)
+        var a1 : LLVMOpaqueValue? [8]
+        for (i in range(tokCount * rq)) {
+            a0[i] = LLVMConstNull(te.vni32)
+            a1[i] = LLVMConstNull(te.vni32)
         }
         for (j in range(4)) {
             for (qd in range(rq)) {
+                // weight vectors unpacked ONCE, dotted against every token below
                 var noff = LLVMBuildAdd(b, wb, te.types->ConstI64(uint64((blk * 16 + j * 4) * mr + qd * w8)), "")
                 var nv = load_vec(te, te.vwi8, te.wg, noff, "nv{blk}_{j * rq + qd}")
                 var wlo = LLVMBuildAnd(b, nv, splat_i8w(te, 15), "wlo{blk}_{j * rq + qd}")
@@ -867,56 +877,80 @@ def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f :
                     wlo = LLVMBuildOr(b, wlo, LLVMBuildShl(b, dlo, splat_i8w(te, 4), ""), "wlo6{blk}_{j * rq + qd}")
                     whi = LLVMBuildOr(b, whi, LLVMBuildShl(b, dhi, splat_i8w(te, 4), ""), "whi6{blk}_{j * rq + qd}")
                 }
-                a0[qd] = kq_dot_lane(te, a0[qd], wlo, xv0, j)
-                a1[qd] = kq_dot_lane(te, a1[qd], whi, xv1, j)
+                for (i in range(tokCount)) {
+                    a0[i * rq + qd] = kq_dot_lane(te, a0[i * rq + qd], wlo, xv0[i], j)
+                    a1[i * rq + qd] = kq_dot_lane(te, a1[i * rq + qd], whi, xv1[i], j)
+                }
             }
         }
-        // per-sub-block fold; bIdx = the global 32-block index (activation scale/bsum space)
+        // per-sub-block fold; bIdx = the global 32-block index (activation scale/bsum space).
+        // Weight-side scale vectors load once per qd; each token folds with ITS qs/bsums in the
+        // exact single-token op order (tile == per-token GEMVs, bit-for-bit)
         var bIdx = LLVMBuildAdd(b, gb, te.types->ConstI64(uint64(blk)), "b{blk}")
-        var qp = LLVMBuildGEP2(b, te.types.t_float, te.xs[0], bIdx, "qp{blk}")
-        var qs = LLVMBuildLoad2Aligned(b, te.types.t_float, qp, 4u, "qs{blk}")
         var bi2 = LLVMBuildShl(b, bIdx, te.types->ConstI64(1ul), "")
-        var bp0 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[0], bi2, "bp{blk}a")
-        var bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{blk}a")
-        var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[0], LLVMBuildAdd(b, bi2, te.types->ConstI64(1ul), ""), "bp{blk}b")
-        var bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{blk}b")
+        var bi2b = LLVMBuildAdd(b, bi2, te.types->ConstI64(1ul), "")
         if (te.kq == 6) {
             // s16 chains: f += (float(acc) − 32·Σa16) · (d·sc16 · qs) per 16-half — the exact
             // portable term (all three factors of the integer part are exact in f32)
-            var a16lo = LLVMBuildFMul(b, LLVMBuildSIToFP(b, bs0, te.types.t_float, ""), te.types->ConstReal(32.0lf), "a32{blk}a")
-            var a16hi = LLVMBuildFMul(b, LLVMBuildSIToFP(b, bs1, te.types.t_float, ""), te.types->ConstReal(32.0lf), "a32{blk}b")
             var vri8 = LLVMVectorType(te.types.t_int8, uint(te.rv))
+            var dsc0 : LLVMOpaqueValue? [2]
+            var dsc1 : LLVMOpaqueValue? [2]
             for (qd in range(rq)) {
                 var dv = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(16 * mr + 2 * (qd * te.rv))), ""), "d{qd}")
                 var sc0p = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * blk * mr + qd * te.rv)), ""), "sc{blk}a")
                 var sc1p = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64((2 * blk + 1) * mr + qd * te.rv)), ""), "sc{blk}b")
                 var sc0 = LLVMBuildSIToFP(b, LLVMBuildSExt(b, LLVMBuildLoad2Aligned(b, vri8, sc0p, 1u, ""), te.vni32, ""), te.vnf32, "")
                 var sc1 = LLVMBuildSIToFP(b, LLVMBuildSExt(b, LLVMBuildLoad2Aligned(b, vri8, sc1p, 1u, ""), te.vni32, ""), te.vnf32, "")
-                var qspl = splat_f32(te, qs, "qs{blk}v")
-                var s0 = LLVMBuildFMul(b, LLVMBuildFMul(b, dv, sc0, ""), qspl, "s0{blk}_{qd}")
-                var s1 = LLVMBuildFMul(b, LLVMBuildFMul(b, dv, sc1, ""), qspl, "s1{blk}_{qd}")
-                var t0 = LLVMBuildFSub(b, LLVMBuildSIToFP(b, a0[qd], te.vnf32, ""), splat_f32(te, a16lo, ""), "t0{blk}_{qd}")
-                var t1 = LLVMBuildFSub(b, LLVMBuildSIToFP(b, a1[qd], te.vnf32, ""), splat_f32(te, a16hi, ""), "t1{blk}_{qd}")
-                f[qd] = fold_fma(te, t0, s0, f[qd], "f{blk}_{qd}a")
-                f[qd] = fold_fma(te, t1, s1, f[qd], "f{blk}_{qd}b")
+                dsc0[qd] = LLVMBuildFMul(b, dv, sc0, "dsc0{blk}_{qd}")
+                dsc1[qd] = LLVMBuildFMul(b, dv, sc1, "dsc1{blk}_{qd}")
+            }
+            for (i in range(tokCount)) {
+                let tk = tokBase + i
+                var qp = LLVMBuildGEP2(b, te.types.t_float, te.xs[tk], bIdx, "qp{tk}_{blk}")
+                var qs = LLVMBuildLoad2Aligned(b, te.types.t_float, qp, 4u, "qs{tk}_{blk}")
+                var bp0 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2, "bp{tk}_{blk}a")
+                var bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{tk}_{blk}a")
+                var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2b, "bp{tk}_{blk}b")
+                var bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{tk}_{blk}b")
+                var a16lo = LLVMBuildFMul(b, LLVMBuildSIToFP(b, bs0, te.types.t_float, ""), te.types->ConstReal(32.0lf), "a32{tk}_{blk}a")
+                var a16hi = LLVMBuildFMul(b, LLVMBuildSIToFP(b, bs1, te.types.t_float, ""), te.types->ConstReal(32.0lf), "a32{tk}_{blk}b")
+                for (qd in range(rq)) {
+                    var qspl = splat_f32(te, qs, "qs{tk}_{blk}v")
+                    var s0 = LLVMBuildFMul(b, dsc0[qd], qspl, "s0{tk}_{blk}_{qd}")
+                    var s1 = LLVMBuildFMul(b, dsc1[qd], qspl, "s1{tk}_{blk}_{qd}")
+                    var t0 = LLVMBuildFSub(b, LLVMBuildSIToFP(b, a0[i * rq + qd], te.vnf32, ""), splat_f32(te, a16lo, ""), "t0{tk}_{blk}_{qd}")
+                    var t1 = LLVMBuildFSub(b, LLVMBuildSIToFP(b, a1[i * rq + qd], te.vnf32, ""), splat_f32(te, a16hi, ""), "t1{tk}_{blk}_{qd}")
+                    f[i * rq + qd] = fold_fma(te, t0, s0, f[i * rq + qd], "f{tk}_{blk}_{qd}a")
+                    f[i * rq + qd] = fold_fma(te, t1, s1, f[i * rq + qd], "f{tk}_{blk}_{qd}b")
+                }
             }
         } else {
-            // k4/k5: one 32-wide chain per qd (both 16-halves share the block's f16 (s,o) pair);
-            // Σa32 = the two per-16 sums, offset term o·(qs·Σa) folds as a second fma
-            var acc : LLVMOpaqueValue? [2]
+            // k4/k5: one 32-wide chain per (token, qd) (both 16-halves share the block's f16
+            // (s, o) pair); Σa32 = the two per-16 sums, offset term o·(qs·Σa) folds as a second fma
+            var sv : LLVMOpaqueValue? [2]
+            var ov : LLVMOpaqueValue? [2]
             for (qd in range(rq)) {
-                acc[qd] = LLVMBuildAdd(b, a0[qd], a1[qd], "acc{blk}_{qd}")
+                sv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 4 * mr + 2 * (qd * te.rv))), ""), "s{blk}_{qd}")
+                ov[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 4 * mr + 2 * mr + 2 * (qd * te.rv))), ""), "o{blk}_{qd}")
             }
-            var a32 = LLVMBuildAdd(b, bs0, bs1, "a32{blk}")
-            var qa = LLVMBuildFMul(b, qs, LLVMBuildSIToFP(b, a32, te.types.t_float, ""), "qa{blk}")
-            var nqa = LLVMBuildFNeg(b, qa, "nqa{blk}")
-            for (qd in range(rq)) {
-                var sv = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 4 * mr + 2 * (qd * te.rv))), ""), "s{blk}_{qd}")
-                var ov = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 4 * mr + 2 * mr + 2 * (qd * te.rv))), ""), "o{blk}_{qd}")
-                var af = LLVMBuildSIToFP(b, acc[qd], te.vnf32, "af{blk}_{qd}")
-                var sq = LLVMBuildFMul(b, sv, splat_f32(te, qs, "qs{blk}v"), "")
-                f[qd] = fold_fma(te, af, sq, f[qd], "f{blk}_{qd}")
-                f[qd] = fold_fma(te, ov, splat_f32(te, nqa, "nqa{blk}v"), f[qd], "f{blk}_{qd}o")
+            for (i in range(tokCount)) {
+                let tk = tokBase + i
+                var qp = LLVMBuildGEP2(b, te.types.t_float, te.xs[tk], bIdx, "qp{tk}_{blk}")
+                var qs = LLVMBuildLoad2Aligned(b, te.types.t_float, qp, 4u, "qs{tk}_{blk}")
+                var bp0 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2, "bp{tk}_{blk}a")
+                var bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{tk}_{blk}a")
+                var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2b, "bp{tk}_{blk}b")
+                var bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{tk}_{blk}b")
+                var a32 = LLVMBuildAdd(b, bs0, bs1, "a32{tk}_{blk}")
+                var qa = LLVMBuildFMul(b, qs, LLVMBuildSIToFP(b, a32, te.types.t_float, ""), "qa{tk}_{blk}")
+                var nqa = LLVMBuildFNeg(b, qa, "nqa{tk}_{blk}")
+                for (qd in range(rq)) {
+                    var acc = LLVMBuildAdd(b, a0[i * rq + qd], a1[i * rq + qd], "acc{tk}_{blk}_{qd}")
+                    var af = LLVMBuildSIToFP(b, acc, te.vnf32, "af{tk}_{blk}_{qd}")
+                    var sq = LLVMBuildFMul(b, sv[qd], splat_f32(te, qs, "qs{tk}_{blk}v"), "")
+                    f[i * rq + qd] = fold_fma(te, af, sq, f[i * rq + qd], "f{tk}_{blk}_{qd}")
+                    f[i * rq + qd] = fold_fma(te, ov[qd], splat_f32(te, nqa, "nqa{tk}_{blk}v"), f[i * rq + qd], "f{tk}_{blk}_{qd}o")
+                }
             }
         }
     }
@@ -924,11 +958,11 @@ def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f :
 
 // block-emitter dispatch: the slice/loop machinery is quant-agnostic. The MMA form needs a
 // token PAIR — the gemv companion's single-token slices ride the sdot lattice (emit_block's
-// kg8 weight fixup reads the same plane). kq blocks are SUPERBLOCKS (the kq gemv drives
-// emit_slice with nb = n/256) and single-token by construction.
+// kg8 weight fixup reads the same plane). kq blocks are SUPERBLOCKS (the kq gemv/tile drive
+// emit_slice with nb = n/256).
 def private emit_one_block(var te : TileEmit; var bi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]; tokBase, tokCount : int) {
     if (te.kq != 0) {
-        emit_block_kq(te, bi, f)
+        emit_block_kq(te, bi, f, tokBase, tokCount)
     } elif (te.mx4) {
         emit_block_mx4(te, bi, f, tokBase, tokCount)
     } elif (te.dotKind == DOT_SMMLA && tokCount >= 2) {
@@ -2094,6 +2128,66 @@ def private k4_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 4)
 def private k5_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 5)
 def private k6_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 6)
 
+// The K-quant 4-token TILE (the kq batch family — weight-stationary prefill): same 10-arg
+// contract as the q8 tile (yp, kqg, ksg, xq image, xs, xbs, n, d, g, t0 — kqg/ksg are the
+// GROUP plane bases, the batch wrapper offsets per group), driven over SUPERBLOCK units with
+// per-token activation/scale/bsum bases. nrsplit slices bound the accumulator bank exactly
+// like the q8 tile; kstep pinned 1 (8 sub-block chains per unit already feed the ports).
+// emit_block_kq unpacks each weight vector ONCE and dots it against every token — the fold
+// order per token is the GEMV's, so one tile call is bit-exact vs 4 per-token GEMVs. Declines
+// via the SAME perm_declines (generic-IR unpacks — no new rails; amx perms ride the busd
+// lattice via companion_perm, the kq planes have no TMUL form).
+def private kq_tile_gen_impl(var gc : LlvmCodeCtx; fmt : int) : bool {
+    if (!is_tile_signature(gc.fn)) return false
+    let p0 = parse_perm(gc)
+    if (perm_declines(gc, p0)) return false
+    let p = companion_perm(p0)
+
+    var te = TileEmit(kq = fmt)
+    if (!setup_tile_emit(te, gc, p, false)) return false
+
+    let b = gc.jit.builder
+    var entry = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "entry")
+
+    // entry: per-token activation/scale/bsum bases; the block unit is a superblock (nb = n/256)
+    LLVMPositionBuilderAtEnd(b, entry)
+    var sa = SliceArgs(gc_impl = gc.impl, ctx = gc.jit.ctx, kstep = 1)
+    sa.yp = LLVMGetParam(gc.impl, 0u)
+    te.wg = LLVMGetParam(gc.impl, 1u)
+    te.sg = LLVMGetParam(gc.impl, 2u)
+    let xqp = LLVMGetParam(gc.impl, 3u)
+    let xsp = LLVMGetParam(gc.impl, 4u)
+    let xbsp = LLVMGetParam(gc.impl, 5u)
+    let n = LLVMGetParam(gc.impl, 6u)
+    sa.d = LLVMGetParam(gc.impl, 7u)
+    sa.g = LLVMGetParam(gc.impl, 8u)
+    sa.t0 = LLVMGetParam(gc.impl, 9u)
+    sa.nb = LLVMBuildSDiv(b, n, te.types->ConstI64(0x100ul), "nsb")
+    var nb32 = LLVMBuildSDiv(b, n, te.types->ConstI64(32ul), "nb32")
+    var nb16 = LLVMBuildSDiv(b, n, te.types->ConstI64(16ul), "nb16")
+    for (tk in range(4)) {
+        var tRow = LLVMBuildAdd(b, sa.t0, te.types->ConstI64(uint64(tk)), "")
+        te.x[tk] = LLVMBuildGEP2(b, te.types.t_int8, xqp, LLVMBuildMul(b, tRow, n, ""), "x{tk}")
+        te.xs[tk] = LLVMBuildGEP2(b, te.types.t_float, xsp, LLVMBuildMul(b, tRow, nb32, ""), "xs{tk}")
+        te.xbs[tk] = LLVMBuildGEP2(b, te.types.t_int32, xbsp, LLVMBuildMul(b, tRow, nb16, ""), "xbs{tk}")
+    }
+
+    // one k-loop slice per nrsplit tokens (the q8 tile's slice shape)
+    var pred = entry
+    var tokBase = 0
+    while (tokBase < 4) {
+        pred = emit_slice(te, sa, pred, tokBase, p.nrsplit, tokBase == 0 ? "" : "_{tokBase}")
+        tokBase += p.nrsplit
+    }
+    LLVMPositionBuilderAtEnd(b, pred)
+    LLVMBuildRetVoid(b)
+    return true
+}
+
+def private k4_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 4)
+def private k5_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 5)
+def private k6_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 6)
+
 // Called from llvm_user_modules::register_user_llvm_code_generators — the JIT invokes that in the
 // context that reads the registry, so the direct call lands in the right table copy.
 [macro_function]
@@ -2111,5 +2205,8 @@ def public register_dasllama_gemm_generators {
     register_llvm_code_generator("dasllama_gemm_gen::k4_gemv", @@k4_gemv_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k5_gemv", @@k5_gemv_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k6_gemv", @@k6_gemv_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::k4_tile", @@k4_tile_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::k5_tile", @@k5_tile_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::k6_tile", @@k6_tile_gen)
     register_llvm_code_generator("dasllama_gemm_gen::q8q8_witness", @@witness_gen)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
@@ -779,6 +779,56 @@ def private kq_dot_lane(var te : TileEmit; var acc, qv, xv : LLVMOpaqueValue?; l
     return LLVMBuildCall2(b, te.dp_ty, te.dp_decl, dargs, "dot")
 }
 
+// activation dword BROADCAST FROM MEMORY at BYTE offset (x64 legs): the register-splat form
+// costs a shuffle uop per dot that competes with pmaddubsw on FP1 (Zen2); vpbroadcastd m32
+// folds the splat into the load port instead — llama.cpp's repacked-GEMM transport. Same
+// dword, same value: bit-identical results, only the port mix changes.
+def private bcast_dword(var te : TileEmit; var xp, off : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
+    let b = te.builder
+    var p = LLVMBuildGEP2(b, te.types.t_int8, xp, off, name)
+    var s = LLVMBuildLoad2Aligned(b, te.types.t_int32, p, 1u, name)
+    var one = LLVMBuildInsertElement(b, LLVMGetUndef(te.vni32), s, te.types->ConstI32(0ul), "")
+    let mask <- [for (_i in range(te.rv)); 0]
+    var xspl = LLVMBuildShuffleVector(b, te.types, one, one, mask, name)
+    return LLVMBuildBitCast(b, xspl, te.vwi8, "")
+}
+
+// one K-quant lane-dot over a memory-broadcast activation dword (the non-maddubs x64 legs —
+// vpdpbusd/bssd are already one dot uop per 32B; maddubs rides the i16 lattice below instead)
+def private kq_dot_mem(var te : TileEmit; var acc, qv, xb : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    let b = te.builder
+    if (te.dotKind == DOT_MADDUBS) {
+        var margs <- [qv, xb]
+        var pairs = LLVMBuildCall2(b, te.madd_ty, te.madd_decl, margs, "pairs")
+        var wargs <- [pairs, ones_i16(te)]
+        var quads = LLVMBuildCall2(b, te.maddwd_ty, te.maddwd_decl, wargs, "quads")
+        return LLVMBuildAdd(b, acc, quads, "dot")
+    }
+    var dargs <- [acc, qv, xb]
+    return LLVMBuildCall2(b, te.dp_ty, te.dp_decl, dargs, "dot")
+}
+
+// one pmaddubsw into an i16 pair-sum chain (null chain head = the first madd). The K-quant i16
+// lattice: with UNSIGNED quants the pair-sums are bounded (k4 ±3810, k5 ±7874, k6 ±16002), so
+// several 32B dots accumulate EXACTLY in i16 — k4 all 8 of a sub-block (±30480), k5 four
+// (±31496), k6 two (±32004) — before ONE pmaddwd widens the chain. Cuts the maddubs lattice
+// from 3 uops/32B to ~2.1 (k4). Integer totals are identical, so results stay bit-exact.
+def private madd16_acc(var te : TileEmit; var chain, qv, xb : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    let b = te.builder
+    var margs <- [qv, xb]
+    var pairs = LLVMBuildCall2(b, te.madd_ty, te.madd_decl, margs, "pairs")
+    if (chain == null) return pairs
+    return LLVMBuildAdd(b, chain, pairs, "p16")
+}
+
+// widen an i16 chain into the i32 accumulator (pmaddwd against ones) — the chain flush
+def private madd16_flush(var te : TileEmit; var acc, chain : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    let b = te.builder
+    var wargs <- [chain, ones_i16(te)]
+    var quads = LLVMBuildCall2(b, te.maddwd_ty, te.maddwd_decl, wargs, "quads")
+    return LLVMBuildAdd(b, acc, quads, "a32")
+}
+
 // one <rv x i8> row-byte load at BYTE offset, each byte splatted across its row's 4 lanes to
 // vwi8 (constant shufflevector — the backend picks tbl/pshufb itself; no intrinsic needed)
 def private load_row_bytes_x4(var te : TileEmit; var base, off : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
@@ -838,20 +888,35 @@ def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f :
     var maskHiElems <- [for (i in range(w8)); LLVMConstInt(te.types.t_int8, uint64(16 << (i % 4)), 0)]
     var maskLo = LLVMConstVector(array_data_ptr(maskLoElems), uint(w8))
     var maskHi = LLVMConstVector(array_data_ptr(maskHiElems), uint(w8))
+    // x64 dot kinds take the activation dword straight from memory (vpbroadcastd — see
+    // kq_dot_lane_mem); the NEON sdot lattice keeps its chunk loads + indexed-lane splats
+    let memBcast = te.dotKind != DOT_SDOT && te.dotKind != DOT_SMMLA
     for (blk in range(8)) {
         var xoff0 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32)), "")
         var xoff1 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32 + 16)), "")
         var xv0 : LLVMOpaqueValue? [4]
         var xv1 : LLVMOpaqueValue? [4]
-        for (i in range(tokCount)) {
-            xv0[i] = load_v16i8(te, te.x[tokBase + i], xoff0, "x{tokBase + i}_{blk}lo")
-            xv1[i] = load_v16i8(te, te.x[tokBase + i], xoff1, "x{tokBase + i}_{blk}hi")
+        if (!memBcast) {
+            for (i in range(tokCount)) {
+                xv0[i] = load_v16i8(te, te.x[tokBase + i], xoff0, "x{tokBase + i}_{blk}lo")
+                xv1[i] = load_v16i8(te, te.x[tokBase + i], xoff1, "x{tokBase + i}_{blk}hi")
+            }
         }
         var a0 : LLVMOpaqueValue? [8]     // [token * rq + qd]; tokCount*rq <= 8 (nrsplit*vq rail)
         var a1 : LLVMOpaqueValue? [8]
         for (i in range(tokCount * rq)) {
             a0[i] = LLVMConstNull(te.vni32)
             a1[i] = LLVMConstNull(te.vni32)
+        }
+        // the maddubs i16 lattice (see madd16_acc): k4/k5 run ONE combined lo+hi chain per
+        // (token, qd) flushed per the format's overflow bound; k6 keeps lo/hi chains apart
+        // (its per-16 scales fold them separately)
+        let madd16 = memBcast && te.dotKind == DOT_MADDUBS
+        var p16lo : LLVMOpaqueValue? [8]
+        var p16hi : LLVMOpaqueValue? [8]
+        for (i in range(tokCount * rq)) {
+            p16lo[i] = null
+            p16hi[i] = null
         }
         for (j in range(4)) {
             for (qd in range(rq)) {
@@ -877,10 +942,49 @@ def private emit_block_kq(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f :
                     wlo = LLVMBuildOr(b, wlo, LLVMBuildShl(b, dlo, splat_i8w(te, 4), ""), "wlo6{blk}_{j * rq + qd}")
                     whi = LLVMBuildOr(b, whi, LLVMBuildShl(b, dhi, splat_i8w(te, 4), ""), "whi6{blk}_{j * rq + qd}")
                 }
-                for (i in range(tokCount)) {
-                    a0[i * rq + qd] = kq_dot_lane(te, a0[i * rq + qd], wlo, xv0[i], j)
-                    a1[i * rq + qd] = kq_dot_lane(te, a1[i * rq + qd], whi, xv1[i], j)
+                if (memBcast) {
+                    var doff0 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32 + j * 4)), "")
+                    var doff1 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32 + 16 + j * 4)), "")
+                    for (i in range(tokCount)) {
+                        var xlo = bcast_dword(te, te.x[tokBase + i], doff0, "xd{tokBase + i}_{blk}_{j}a")
+                        var xhi = bcast_dword(te, te.x[tokBase + i], doff1, "xd{tokBase + i}_{blk}_{j}b")
+                        if (madd16) {
+                            let k = i * rq + qd
+                            if (te.kq == 6) {
+                                p16lo[k] = madd16_acc(te, p16lo[k], wlo, xlo)
+                                p16hi[k] = madd16_acc(te, p16hi[k], whi, xhi)
+                            } else {
+                                p16lo[k] = madd16_acc(te, madd16_acc(te, p16lo[k], wlo, xlo), whi, xhi)
+                            }
+                        } else {
+                            a0[i * rq + qd] = kq_dot_mem(te, a0[i * rq + qd], wlo, xlo)
+                            a1[i * rq + qd] = kq_dot_mem(te, a1[i * rq + qd], whi, xhi)
+                        }
+                    }
+                } else {
+                    for (i in range(tokCount)) {
+                        a0[i * rq + qd] = kq_dot_lane(te, a0[i * rq + qd], wlo, xv0[i], j)
+                        a1[i * rq + qd] = kq_dot_lane(te, a1[i * rq + qd], whi, xv1[i], j)
+                    }
                 }
+            }
+            // i16 chain flushes at the format's overflow bound: k5 after 4 madds (j 1/3),
+            // k6 after 2 madds per chain (j 1/3); k4 runs the full 8 to the post-loop flush
+            if (madd16 && (j == 1 || j == 3) && te.kq != 4) {
+                for (k in range(tokCount * rq)) {
+                    a0[k] = madd16_flush(te, a0[k], p16lo[k])
+                    p16lo[k] = null
+                    if (te.kq == 6) {
+                        a1[k] = madd16_flush(te, a1[k], p16hi[k])
+                        p16hi[k] = null
+                    }
+                }
+            }
+        }
+        if (madd16 && te.kq == 4) {   // k4: one widen per (token, qd) for the whole sub-block
+            for (k in range(tokCount * rq)) {
+                a0[k] = madd16_flush(te, a0[k], p16lo[k])
+                p16lo[k] = null
             }
         }
         // per-sub-block fold; bIdx = the global 32-block index (activation scale/bsum space).

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -511,6 +511,200 @@ def dequant_q6k_superblock(bytes : array<uint8> | #; bo : int64; var dst : array
     }
 }
 
+// ===== K-quant native-plane transcode (superblock payloads -> split quant/scale planes) =====
+// Plane layouts (per 256-weight superblock; element offsets are plane-local and superblock-aligned):
+//   k4 quant: 128B nibbles verbatim            k4 scale: 8 x (f16 d*sc, f16 dmin*m) = 32B
+//   k5 quant: [128B nibbles][32B high-bits]    k5 scale: same 32B pair form
+//   k6 quant: [128B ql][64B qh]                k6 scale: [16 x int8 sub-scales][f16 d] = 18B
+// The f16 (s, o) pairs are the load-time unpack of the 6-bit packed sub-scales — the hot loop
+// reads them directly instead of re-deriving per dot (llama.cpp's ALU bill). f16 rounding of
+// d*sc / dmin*m is <= 2^-12 relative — far below the 4/5-bit quant noise; the plane-dequant
+// reference below applies the SAME rounding, so kernels gate bit-exactly against it.
+
+def private wr_f16(var p : array<uint8>; o : int64; v : float) {
+    let h = f32_to_f16(v)
+    p[o] = uint8(h & 0xFF)
+    p[o + 1l] = uint8(h >> 8u)
+}
+
+//! Transcode one Q4_K superblock (144 bytes at `bo`) into the k4 planes: nibbles verbatim to
+//! kq[kqo..+128), f16 (d*sc, dmin*m) pairs to ks[kso..+32).
+def transcode_q4k_superblock(bytes : array<uint8> | #; bo : int64; var kq : array<uint8>; kqo : int64; var ks : array<uint8>; kso : int64) {
+    let d = f16_to_f32(rd_u16(bytes, bo))
+    let dmin = f16_to_f32(rd_u16(bytes, bo + 2l))
+    for (j in range64(8l)) {
+        let sm = q4k_scale_min(bytes, bo + 4l, j)
+        wr_f16(ks, kso + j * 4l, d * float(sm.x))
+        wr_f16(ks, kso + j * 4l + 2l, dmin * float(sm.y))
+    }
+    for (i in range64(128l)) {
+        kq[kqo + i] = bytes[bo + 16l + i]
+    }
+}
+
+//! Transcode one Q5_K superblock (176 bytes at `bo`) into the k5 planes: [nibbles][high-bits]
+//! to kq[kqo..+160), f16 (d*sc, dmin*m) pairs to ks[kso..+32).
+def transcode_q5k_superblock(bytes : array<uint8> | #; bo : int64; var kq : array<uint8>; kqo : int64; var ks : array<uint8>; kso : int64) {
+    let d = f16_to_f32(rd_u16(bytes, bo))
+    let dmin = f16_to_f32(rd_u16(bytes, bo + 2l))
+    for (j in range64(8l)) {
+        let sm = q4k_scale_min(bytes, bo + 4l, j)
+        wr_f16(ks, kso + j * 4l, d * float(sm.x))
+        wr_f16(ks, kso + j * 4l + 2l, dmin * float(sm.y))
+    }
+    for (i in range64(128l)) {
+        kq[kqo + i] = bytes[bo + 48l + i]   // qs
+    }
+    for (i in range64(32l)) {
+        kq[kqo + 128l + i] = bytes[bo + 16l + i]   // qh
+    }
+}
+
+//! Transcode one Q6_K superblock (210 bytes at `bo`) into the k6 planes: [ql][qh] to
+//! kq[kqo..+192), the native int8 sub-scales + f16 d to ks[kso..+18) — all verbatim (exact).
+def transcode_q6k_superblock(bytes : array<uint8> | #; bo : int64; var kq : array<uint8>; kqo : int64; var ks : array<uint8>; kso : int64) {
+    for (i in range64(192l)) {
+        kq[kqo + i] = bytes[bo + i]   // ql (128) then qh (64) — disk order
+    }
+    for (i in range64(18l)) {
+        ks[kso + i] = bytes[bo + 192l + i]   // 16 int8 sub-scales + f16 d halfword
+    }
+}
+
+// f16 (s, o) pair read for the k4/k5 plane-dequant references
+def private rd_pair(ks : array<uint8> | #; o : int64) : float2 {
+    return float2(f16_to_f32(rd_u16(ks, o)), f16_to_f32(rd_u16(ks, o + 2l)))
+}
+
+//! Reference dequant of one k4-plane superblock (the exact math the k4 kernels must reproduce):
+//! w = s*q - o with the plane's f16-rounded (s, o) pairs.
+def dequant_k4_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float>; doff : int64) {
+    var dsto = doff
+    for (js in range64(4l)) {
+        let p0 = rd_pair(ks, kso + 2l * js * 4l)
+        let p1 = rd_pair(ks, kso + (2l * js + 1l) * 4l)
+        for (l in range64(32l)) {
+            let b = int(kq[kqo + 32l * js + l])
+            dst[dsto + l] = p0.x * float(b & 15) - p0.y
+            dst[dsto + 32l + l] = p1.x * float(b >> 4) - p1.y
+        }
+        dsto += 64l
+    }
+}
+
+//! Reference dequant of one k5-plane superblock: w = s*q - o, q = nibble | (high bit << 4).
+def dequant_k5_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float>; doff : int64) {
+    var dsto = doff
+    for (js in range64(4l)) {
+        let p0 = rd_pair(ks, kso + 2l * js * 4l)
+        let p1 = rd_pair(ks, kso + (2l * js + 1l) * 4l)
+        let u1 = 1 << (int(js) * 2)
+        let u2 = 2 << (int(js) * 2)
+        for (l in range64(32l)) {
+            let b = int(kq[kqo + 32l * js + l])
+            let h = int(kq[kqo + 128l + l])
+            dst[dsto + l] = p0.x * float((b & 15) + ((h & u1) != 0 ? 16 : 0)) - p0.y
+            dst[dsto + 32l + l] = p1.x * float((b >> 4) + ((h & u2) != 0 ? 16 : 0)) - p1.y
+        }
+        dsto += 64l
+    }
+}
+
+//! Reference dequant of one k6-plane superblock: w = (d*sc16)*(q - 32) — bit-identical to the
+//! disk dequant (the k6 planes are verbatim).
+def dequant_k6_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float>; doff : int64) {
+    let d = f16_to_f32(rd_u16(ks, kso + 16l))
+    var qlo = kqo
+    var qho = kqo + 128l
+    var sco = kso
+    var dsto = doff
+    for (_half in range(2)) {
+        for (l in range64(32l)) {
+            let si = l / 16l
+            let hl = int(kq[qho + l])
+            let q1 = ((int(kq[qlo + l]) & 15) | (((hl >> 0) & 3) << 4)) - 32
+            let q2 = ((int(kq[qlo + 32l + l]) & 15) | (((hl >> 2) & 3) << 4)) - 32
+            let q3 = ((int(kq[qlo + l]) >> 4) | (((hl >> 4) & 3) << 4)) - 32
+            let q4 = ((int(kq[qlo + 32l + l]) >> 4) | (((hl >> 6) & 3) << 4)) - 32
+            dst[dsto + l] = d * float(rd_i8(ks, sco + si)) * float(q1)
+            dst[dsto + 32l + l] = d * float(rd_i8(ks, sco + si + 2l)) * float(q2)
+            dst[dsto + 64l + l] = d * float(rd_i8(ks, sco + si + 4l)) * float(q3)
+            dst[dsto + 96l + l] = d * float(rd_i8(ks, sco + si + 6l)) * float(q4)
+        }
+        qlo += 64l
+        qho += 32l
+        sco += 8l
+        dsto += 128l
+    }
+}
+
+// K-quant plane strides (bytes per 256-weight superblock)
+let K4_QSB = 128l
+let K4_SSB = 32l
+let K5_QSB = 160l
+let K5_SSB = 32l
+let K6_QSB = 192l
+let K6_SSB = 18l
+
+// Shared header for the three file-level transcodes: locate + type-check + bounds-check, return
+// the superblock-aligned disk cursor.
+def private kq_transcode_base(m : GGUFMeta; name : string; want_type : int; type_name : string; src_off, expect_n, disk_sb : int64) : int64 {
+    let ti = gguf_find_tensor(m, name)
+    if (ti < 0) {
+        panic("gguf: tensor '{name}' not found")
+    }
+    if (m.tensors[ti].ggml_type != want_type) {
+        panic("gguf: tensor '{name}' is not {type_name} (type {m.tensors[ti].ggml_type})")
+    }
+    if (src_off % 256l != 0l || expect_n % 256l != 0l) {
+        panic("gguf: tensor '{name}' {type_name} slice [{src_off}, +{expect_n}) is not superblock-aligned")
+    }
+    if (src_off + expect_n > m.tensors[ti].n_elem) {
+        panic("gguf: tensor '{name}' slice [{src_off}, {src_off + expect_n}) exceeds {m.tensors[ti].n_elem} elems")
+    }
+    return m.data_offset + m.tensors[ti].offset + (src_off / 256l) * disk_sb
+}
+
+//! Transcode a Q4_K tensor into the k4 planes at plane-local element offset `eloff` (from the
+//! layout's k4 cursor): quant bytes at (eloff/256)*128, scale pairs at (eloff/256)*32.
+def gguf_transcode_q4k(m : GGUFMeta; bytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    var bo = kq_transcode_base(m, name, GGML_TYPE_Q4_K, "Q4_K", src_off, expect_n, 144l)
+    var kqo = (eloff / 256l) * K4_QSB
+    var kso = (eloff / 256l) * K4_SSB
+    for (_blk in range64(expect_n / 256l)) {
+        transcode_q4k_superblock(bytes, bo, kq, kqo, ks, kso)
+        bo += 144l
+        kqo += K4_QSB
+        kso += K4_SSB
+    }
+}
+
+//! Transcode a Q5_K tensor into the k5 planes (see gguf_transcode_q4k; strides 160/32).
+def gguf_transcode_q5k(m : GGUFMeta; bytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    var bo = kq_transcode_base(m, name, GGML_TYPE_Q5_K, "Q5_K", src_off, expect_n, 176l)
+    var kqo = (eloff / 256l) * K5_QSB
+    var kso = (eloff / 256l) * K5_SSB
+    for (_blk in range64(expect_n / 256l)) {
+        transcode_q5k_superblock(bytes, bo, kq, kqo, ks, kso)
+        bo += 176l
+        kqo += K5_QSB
+        kso += K5_SSB
+    }
+}
+
+//! Transcode a Q6_K tensor into the k6 planes (see gguf_transcode_q4k; strides 192/18, exact).
+def gguf_transcode_q6k(m : GGUFMeta; bytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    var bo = kq_transcode_base(m, name, GGML_TYPE_Q6_K, "Q6_K", src_off, expect_n, 210l)
+    var kqo = (eloff / 256l) * K6_QSB
+    var kso = (eloff / 256l) * K6_SSB
+    for (_blk in range64(expect_n / 256l)) {
+        transcode_q6k_superblock(bytes, bo, kq, kqo, ks, kso)
+        bo += 210l
+        kqo += K6_QSB
+        kso += K6_SSB
+    }
+}
+
 //! Decode tensor `name` (F32 or F16 on disk) into dst[dst_off ..] as fp32. Panics if the
 //! tensor is missing, has a different element count than expected, or uses a type we don't
 //! yet read (quantized types are wired in a later step).

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -37,6 +37,7 @@ let GGML_TYPE_F16 = 1
 let GGML_TYPE_Q4_0 = 2
 let GGML_TYPE_Q8_0 = 8
 let GGML_TYPE_Q4_K = 12
+let GGML_TYPE_Q5_K = 13
 let GGML_TYPE_Q6_K = 14
 let GGML_TYPE_BF16 = 30
 let GGML_TYPE_MXFP4 = 39
@@ -449,6 +450,38 @@ def dequant_q4k_superblock(bytes : array<uint8> | #; bo : int64; var dst : array
     }
 }
 
+//! Dequantize one Q5_K superblock (176 bytes at `bo`: fp16 d, fp16 dmin, 12 bytes of 6-bit
+//! sub-scales/mins, 32 high-bit bytes qh, 128 nibble bytes qs) into dst[doff .. doff+256).
+//! w = (d*sc)*q - (dmin*m) with q = nibble | (high bit << 4) in 0..31; the high bit for chunk
+//! js lives in bit 2js (low nibbles) / 2js+1 (high nibbles) of qh[l], qh base fixed per
+//! superblock. Matches llama.cpp dequantize_row_q5_K op-for-op.
+def dequant_q5k_superblock(bytes : array<uint8> | #; bo : int64; var dst : array<float>; doff : int64) {
+    let d = f16_to_f32(rd_u16(bytes, bo))
+    let dmin = f16_to_f32(rd_u16(bytes, bo + 2l))
+    let so = bo + 4l     // 12 scale/min bytes
+    let qho = bo + 16l   // 32 high-bit bytes (fixed base for the whole superblock)
+    var qo = bo + 48l    // 128 nibble bytes
+    var dsto = doff
+    for (js in range64(4l)) {
+        let s0 = q4k_scale_min(bytes, so, 2l * js)
+        let s1 = q4k_scale_min(bytes, so, 2l * js + 1l)
+        let d1 = d * float(s0.x)
+        let m1 = dmin * float(s0.y)
+        let d2 = d * float(s1.x)
+        let m2 = dmin * float(s1.y)
+        let u1 = 1 << (int(js) * 2)
+        let u2 = 2 << (int(js) * 2)
+        for (l in range64(32l)) {
+            let b = int(bytes[qo + l])
+            let h = int(bytes[qho + l])
+            dst[dsto + l] = d1 * float((b & 15) + ((h & u1) != 0 ? 16 : 0)) - m1
+            dst[dsto + 32l + l] = d2 * float((b >> 4) + ((h & u2) != 0 ? 16 : 0)) - m2
+        }
+        qo += 32l
+        dsto += 64l
+    }
+}
+
 //! Dequantize one Q6_K superblock (210 bytes at `bo`: 128 low-nibble bytes ql, 64 high-2-bit
 //! bytes qh, 16 int8 sub-scales for 16 sub-blocks of 16, fp16 d) into dst[doff .. doff+256).
 //! w = (d*sc)*q with q = (ql | qh<<4) - 32. Matches llama.cpp dequantize_row_q6_K op-for-op.
@@ -555,6 +588,16 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
             dequant_q4k_superblock(bytes, bo, dst, dst_off + blk * 256l)
             bo += 144l
         }
+    } elif (gtype == GGML_TYPE_Q5_K) {
+        if (src_off % 256l != 0l || expect_n % 256l != 0l) {
+            panic("gguf: tensor '{name}' Q5_K slice [{src_off}, +{expect_n}) is not superblock-aligned")
+        }
+        let nb = expect_n / 256l
+        var bo = base + (src_off / 256l) * 176l
+        for (blk in range64(nb)) {
+            dequant_q5k_superblock(bytes, bo, dst, dst_off + blk * 256l)
+            bo += 176l
+        }
     } elif (gtype == GGML_TYPE_Q6_K) {
         if (src_off % 256l != 0l || expect_n % 256l != 0l) {
             panic("gguf: tensor '{name}' Q6_K slice [{src_off}, +{expect_n}) is not superblock-aligned")
@@ -581,7 +624,7 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
             bo += 16l
         }
     } else {
-        panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/BF16/Q8_0/Q4_0/Q4_K/Q6_K/MXFP4)")
+        panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/BF16/Q8_0/Q4_0/Q4_K/Q5_K/Q6_K/MXFP4)")
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -578,7 +578,7 @@ def private rd_pair(ks : array<uint8> | #; o : int64) : float2 {
 
 //! Reference dequant of one k4-plane superblock (the exact math the k4 kernels must reproduce):
 //! w = s*q - o with the plane's f16-rounded (s, o) pairs.
-def dequant_k4_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float>; doff : int64) {
+def dequant_k4_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float> | #; doff : int64) {
     var dsto = doff
     for (js in range64(4l)) {
         let p0 = rd_pair(ks, kso + 2l * js * 4l)
@@ -593,7 +593,7 @@ def dequant_k4_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<u
 }
 
 //! Reference dequant of one k5-plane superblock: w = s*q - o, q = nibble | (high bit << 4).
-def dequant_k5_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float>; doff : int64) {
+def dequant_k5_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float> | #; doff : int64) {
     var dsto = doff
     for (js in range64(4l)) {
         let p0 = rd_pair(ks, kso + 2l * js * 4l)
@@ -612,7 +612,7 @@ def dequant_k5_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<u
 
 //! Reference dequant of one k6-plane superblock: w = (d*sc16)*(q - 32) — bit-identical to the
 //! disk dequant (the k6 planes are verbatim).
-def dequant_k6_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float>; doff : int64) {
+def dequant_k6_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float> | #; doff : int64) {
     let d = f16_to_f32(rd_u16(ks, kso + 16l))
     var qlo = kqo
     var qho = kqo + 128l

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -36,6 +36,8 @@ let GGML_TYPE_F32 = 0
 let GGML_TYPE_F16 = 1
 let GGML_TYPE_Q4_0 = 2
 let GGML_TYPE_Q8_0 = 8
+let GGML_TYPE_Q4_K = 12
+let GGML_TYPE_Q6_K = 14
 let GGML_TYPE_BF16 = 30
 let GGML_TYPE_MXFP4 = 39
 
@@ -399,6 +401,83 @@ def gguf_find_tensor(m : GGUFMeta; name : string) : int {
     return -1
 }
 
+// ===== K-quant superblock dequant (256-weight superblocks, ggml Q4_K / Q6_K) =====
+
+// int8 read (K-quant sub-scales are signed bytes)
+def private rd_i8(b : array<uint8> | #; o : int64) : int {
+    let u = int(b[o])
+    return u < 128 ? u : u - 256
+}
+
+// 6-bit sub-scale/min unpack for Q4_K/Q5_K superblocks (ggml get_scale_min_k4). The 12 scale
+// bytes hold 8 scales + 8 mins: j<4 live in the low 6 bits of bytes j / j+4; j>=4 split as
+// low-4 in byte j+4 (scale = low nibble, min = high) + top-2 of bytes j-4 / j.
+def private q4k_scale_min(b : array<uint8> | #; so, j : int64) : int2 {
+    if (j < 4l) {
+        return int2(int(b[so + j]) & 63, int(b[so + j + 4l]) & 63)
+    }
+    let sc = (int(b[so + j + 4l]) & 15) | ((int(b[so + j - 4l]) >> 6) << 4)
+    let mn = (int(b[so + j + 4l]) >> 4) | ((int(b[so + j]) >> 6) << 4)
+    return int2(sc, mn)
+}
+
+//! Dequantize one Q4_K superblock (144 bytes at `bo`: fp16 d, fp16 dmin, 12 bytes of 6-bit
+//! sub-scales/mins for 8 sub-blocks of 32, 128 nibble bytes) into dst[doff .. doff+256).
+//! w = (d*sc)*q - (dmin*m) with q the RAW nibble — the min term absorbs the offset. Per 64-weight
+//! chunk the 32 quant bytes carry weights 0..31 in low nibbles, 32..63 in high (ggml order).
+//! Matches llama.cpp dequantize_row_q4_K op-for-op, so the expansion is bit-exact.
+def dequant_q4k_superblock(bytes : array<uint8> | #; bo : int64; var dst : array<float>; doff : int64) {
+    let d = f16_to_f32(rd_u16(bytes, bo))
+    let dmin = f16_to_f32(rd_u16(bytes, bo + 2l))
+    let so = bo + 4l    // 12 scale/min bytes
+    var qo = bo + 16l   // 128 quant bytes
+    var dsto = doff
+    for (js in range64(4l)) {   // 4 chunks of 64 weights = sub-blocks 2js, 2js+1
+        let s0 = q4k_scale_min(bytes, so, 2l * js)
+        let s1 = q4k_scale_min(bytes, so, 2l * js + 1l)
+        let d1 = d * float(s0.x)
+        let m1 = dmin * float(s0.y)
+        let d2 = d * float(s1.x)
+        let m2 = dmin * float(s1.y)
+        for (l in range64(32l)) {
+            let b = int(bytes[qo + l])
+            dst[dsto + l] = d1 * float(b & 15) - m1
+            dst[dsto + 32l + l] = d2 * float(b >> 4) - m2
+        }
+        qo += 32l
+        dsto += 64l
+    }
+}
+
+//! Dequantize one Q6_K superblock (210 bytes at `bo`: 128 low-nibble bytes ql, 64 high-2-bit
+//! bytes qh, 16 int8 sub-scales for 16 sub-blocks of 16, fp16 d) into dst[doff .. doff+256).
+//! w = (d*sc)*q with q = (ql | qh<<4) - 32. Matches llama.cpp dequantize_row_q6_K op-for-op.
+def dequant_q6k_superblock(bytes : array<uint8> | #; bo : int64; var dst : array<float>; doff : int64) {
+    let d = f16_to_f32(rd_u16(bytes, bo + 208l))
+    var qlo = bo          // ql cursor (64 bytes per 128-weight half)
+    var qho = bo + 128l   // qh cursor (32 bytes per half)
+    var sco = bo + 192l   // sub-scale cursor (8 per half)
+    var dsto = doff
+    for (_half in range(2)) {
+        for (l in range64(32l)) {
+            let si = l / 16l
+            let hl = int(bytes[qho + l])
+            let q1 = ((int(bytes[qlo + l]) & 15) | (((hl >> 0) & 3) << 4)) - 32
+            let q2 = ((int(bytes[qlo + 32l + l]) & 15) | (((hl >> 2) & 3) << 4)) - 32
+            let q3 = ((int(bytes[qlo + l]) >> 4) | (((hl >> 4) & 3) << 4)) - 32
+            let q4 = ((int(bytes[qlo + 32l + l]) >> 4) | (((hl >> 6) & 3) << 4)) - 32
+            dst[dsto + l] = d * float(rd_i8(bytes, sco + si)) * float(q1)
+            dst[dsto + 32l + l] = d * float(rd_i8(bytes, sco + si + 2l)) * float(q2)
+            dst[dsto + 64l + l] = d * float(rd_i8(bytes, sco + si + 4l)) * float(q3)
+            dst[dsto + 96l + l] = d * float(rd_i8(bytes, sco + si + 6l)) * float(q4)
+        }
+        qlo += 64l
+        qho += 32l
+        sco += 8l
+        dsto += 128l
+    }
+}
+
 //! Decode tensor `name` (F32 or F16 on disk) into dst[dst_off ..] as fp32. Panics if the
 //! tensor is missing, has a different element count than expected, or uses a type we don't
 //! yet read (quantized types are wired in a later step).
@@ -409,7 +488,8 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
     }
     let nelem = m.tensors[ti].n_elem
     // src_off (element offset into the tensor) reads a sub-range — used to split fused qkv / gate_up
-    // tensors (Phi3). For quantized types it must be 32-aligned so it lands on a block boundary.
+    // tensors (Phi3). For quantized types it must be 32-aligned so it lands on a block boundary
+    // (256-aligned for the K-quant superblock types — those arms check).
     if (src_off + expect_n > nelem) {
         panic("gguf: tensor '{name}' slice [{src_off}, {src_off + expect_n}) exceeds {nelem} elems")
     }
@@ -465,6 +545,26 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
             }
             bo += 16l
         }
+    } elif (gtype == GGML_TYPE_Q4_K) {
+        if (src_off % 256l != 0l || expect_n % 256l != 0l) {
+            panic("gguf: tensor '{name}' Q4_K slice [{src_off}, +{expect_n}) is not superblock-aligned")
+        }
+        let nb = expect_n / 256l
+        var bo = base + (src_off / 256l) * 144l
+        for (blk in range64(nb)) {
+            dequant_q4k_superblock(bytes, bo, dst, dst_off + blk * 256l)
+            bo += 144l
+        }
+    } elif (gtype == GGML_TYPE_Q6_K) {
+        if (src_off % 256l != 0l || expect_n % 256l != 0l) {
+            panic("gguf: tensor '{name}' Q6_K slice [{src_off}, +{expect_n}) is not superblock-aligned")
+        }
+        let nb = expect_n / 256l
+        var bo = base + (src_off / 256l) * 210l
+        for (blk in range64(nb)) {
+            dequant_q6k_superblock(bytes, bo, dst, dst_off + blk * 256l)
+            bo += 210l
+        }
     } elif (gtype == GGML_TYPE_MXFP4) {
         // block of 32: 1 E8M0 scale byte + 16 nibble bytes (low nibbles = elems 0..15, high = 16..31);
         // x = e2m1[nibble] * scale — both sides carry the ×2/÷2 ggml convention (see MXFP4_KVALUES)
@@ -481,7 +581,7 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
             bo += 16l
         }
     } else {
-        panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/Q8_0/Q4_0/MXFP4)")
+        panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/BF16/Q8_0/Q4_0/Q4_K/Q6_K/MXFP4)")
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -369,6 +369,8 @@ let public TRACE_TAG_CLS = 5
 let public TRACE_TAG_MOE = 6
 let public TRACE_TAG_SHEXP = 7
 let public TRACE_TAG_PLE = 8
+let public TRACE_TAG_ROUTE = 9   // MoE router GEMM + select/bucket (prefill section split)
+let public TRACE_TAG_PARK = 10   // MoE park/reduce bookkeeping around the expert GEMMs
 def public trace_tag(t : int) {
     if (g_trace_tags) {
         jobque_trace_tag(t)
@@ -695,15 +697,45 @@ def matmul(var y : array<float>; w : array<float>; woff : int64; x : array<float
 //! all ntok tokens, vs ntok× matmul re-reading W every call. Bit-for-bit ntok× matmul.
 def matmul_batch(var y : array<float>; w : array<float> | #; x : array<float>; n, d, ntok : int64) {
     unsafe {
-        var yp = addr(y[0])
-        let wp = reinterpret<float const?>(addr(w[0]))
-        let xp = reinterpret<float const?>(addr(x[0]))
-        maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+        matmul_batch_core(addr(y[0]), reinterpret<float const?>(addr(w[0])), reinterpret<float const?>(addr(x[0])), n, d, ntok)
+    }
+}
+
+// The fp32 batch GEMM core: 1-D row split, except ROW-STARVED shapes (row chunks can't fill the
+// admitted lanes — the MoE router: d = n_expert = 128, grain 16 ⇒ 8 chunks idling half a 16-lane
+// box, worse with more lanes) split tokens too: a flat (row-chunk × token-block) domain. Disjoint
+// stores, the same dot per (row, token) — bit-identical either way.
+def private matmul_batch_core(var yp : float?; wp : float const?; xp : float const?; n, d, ntok : int64) {
+    var myp = yp
+    let rch = matmul_chunks(int(d), 1, n * d * ntok)
+    let L = lanes_for_work(n * d * ntok, g_batch_lane_cap)
+    let tb = (rch < L && ntok >= 128l) ? min(int64((2 * L + rch - 1) / rch), ntok / 64l) : 1l
+    if (tb <= 1l) {
+        maybe_parallel_for(0, int(d), rch) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let wrow = wp + int64(i) * n
                     for (tk in range64(ntok)) {
-                        yp[tk * d + int64(i)] = dot(wrow, xp + tk * n, n)
+                        myp[tk * d + int64(i)] = dot(wrow, xp + tk * n, n)
+                    }
+                }
+            }
+        }
+        return
+    }
+    let rows_per = (d + int64(rch) - 1l) / int64(rch)
+    let tok_per = (ntok + tb - 1l) / tb
+    maybe_parallel_for(0, int(int64(rch) * tb), int(int64(rch) * tb)) $(cb, ce) {
+        unsafe {
+            for (c in range(cb, ce)) {
+                let rc = int64(c) / tb
+                let tc = int64(c) % tb
+                let r1 = min(rc * rows_per + rows_per, d)
+                let t1 = min(tc * tok_per + tok_per, ntok)
+                for (i in range64(rc * rows_per, r1)) {
+                    let wrow = wp + i * n
+                    for (tk in range64(tc * tok_per, t1)) {
+                        myp[tk * d + i] = dot(wrow, xp + tk * n, n)
                     }
                 }
             }
@@ -714,19 +746,7 @@ def matmul_batch(var y : array<float>; w : array<float> | #; x : array<float>; n
 //! Blob+offset form of matmul_batch (see the matmul woff overload).
 def matmul_batch(var y : array<float>; w : array<float>; woff : int64; x : array<float>; n, d, ntok : int64) {
     unsafe {
-        var yp = addr(y[0])
-        let wp = reinterpret<float const?>(addr(w[woff]))
-        let xp = reinterpret<float const?>(addr(x[0]))
-        maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
-            unsafe {
-                for (i in range(rb, re)) {
-                    let wrow = wp + int64(i) * n
-                    for (tk in range64(ntok)) {
-                        yp[tk * d + int64(i)] = dot(wrow, xp + tk * n, n)
-                    }
-                }
-            }
-        }
+        matmul_batch_core(addr(y[0]), reinterpret<float const?>(addr(w[woff])), reinterpret<float const?>(addr(x[0])), n, d, ntok)
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -519,8 +519,15 @@ def public matmul_chunks(rows : int; oversplit : int; work : int64) : int {
         return want
     }
     let cap = clamp(rows / g_matmul_min_chunk_rows, 1, want)   // grain-limited ceiling (<= want = L × oversplit)
-    let waves = max(cap / L, 1)                                // whole L-waves within the cap
-    let chunks = min(waves * L, cap)                           // full waves; never exceed the grain cap
+    // the grain may only limit OVERSPLIT — never cut chunks below the admitted lanes (underfilling
+    // L idles lanes for the whole dispatch, always worse than sub-grain chunks; rows < L is the
+    // only natural floor)
+    if (cap < L) {
+        let chunks = clamp(rows, 1, L)
+        assert_wave_aligned(chunks, L)
+        return chunks
+    }
+    let chunks = (cap / L) * L                                 // whole L-waves within the grain cap
     assert_wave_aligned(chunks, L)
     return chunks
 }
@@ -559,16 +566,21 @@ def private gcd_int(a, b : int) : int {
 //! `tokq` is the tile token quantum — token cells stay whole-tile so no cell pays a systematic
 //! sub-tile tail (the range tail still rides the walk's per-token tail path).
 def public matmul_grid(units : int; unit_rows : int64; oversplit : int; work : int64; ntok : int64; tokq : int) : int2 {
-    let c1 = matmul_chunks(units * int(unit_rows), oversplit, work)
+    let rows = units * int(unit_rows)
+    let c1 = matmul_chunks(rows, oversplit, work)
     if (g_batch_grid_2d == 0 || c1 <= 1) {
         return int2(c1, 1)
     }
     let L = lanes_for_work(work, g_batch_lane_cap)
     let ntile = int(ntok / int64(tokq))
-    if (c1 >= L || ntile < 2) {   // not starved, or no token axis to split
+    // grain-starved = the 1-D count only reaches L by going sub-grain (matmul_chunks fills to L);
+    // the token axis supplies the missing parallelism at FULL row grain instead — weight rows
+    // stream in grain-sized spans, re-read once per token cell
+    let gcap = g_matmul_min_chunk_rows > 0 ? clamp(rows / g_matmul_min_chunk_rows, 1, c1) : c1
+    if (gcap >= L || ntile < 2) {   // not grain-starved, or no token axis to split
         return int2(c1, 1)
     }
-    let rc = clamp(c1, 1, max(units, 1))   // row cells finer than one unit are empty claims
+    let rc = clamp(gcap, 1, max(units, 1))   // row cells finer than one unit are empty claims
     var ntc = 1
     if (g_batch_grid_2d == 1) {
         ntc = min((int(ntok) + 15) / 16, ntile)
@@ -602,9 +614,11 @@ var g_gemv_chunks_per_lane = 8
 def public set_gemv_chunks_per_lane(v : int) { g_gemv_chunks_per_lane = max(v, 1) }
 def public get_gemv_chunks_per_lane() : int { return g_gemv_chunks_per_lane }
 
-// Wave fill: when the grain-derived count lands in [lanes/2, lanes), round UP to one full wave —
-// chunks shrink but stay >= grain/2 (the grain is chosen halvable), and no lane idles. Counts
-// below lanes/2 stay grain-limited (filling would shred chunks below the halvable bound).
+// Wave fill: when the grain-derived count lands below the admitted lanes, round UP to one full
+// wave — chunks go sub-grain, but underfilling admitted lanes idles them for the whole dispatch,
+// which always loses more (30B decode router: 128 rows / grain 64 = 2 chunks on 16 lanes, 14 idle,
+// ~3.3% of the token). rows < lanes is the only natural floor. false = the historical grain-limited
+// count (A/B rail).
 var g_gemv_wave_fill = true
 def public set_gemv_wave_fill(v : bool) { g_gemv_wave_fill = v }
 def public get_gemv_wave_fill() : bool { return g_gemv_wave_fill }
@@ -633,9 +647,18 @@ def public matmul_chunks_gemv(rows : int; oversplit : int; work : int64) : int {
         // fewer than one grain-sized chunk per lane — the grain-limited split below applies
     }
     let n = clamp(rows / g_matmul_min_chunk_rows_gemv, 1, L)
-    let chunks = (g_gemv_wave_fill && n < L && 2 * n >= L) ? L : n
+    let chunks = (g_gemv_wave_fill && n < L) ? clamp(rows, 1, L) : n
     assert_wave_aligned(chunks, L)
     return chunks
+}
+
+//! LPT (longest-processing-time-first) claim order for a region-list dispatch whose regions have
+//! known unequal costs: sort (id, cost) pairs biggest-cost first (ties: lowest id — deterministic),
+//! so the self-serve chunk queue front-loads the expensive regions and the dispatch tail drains on
+//! cheap ones. Region order never changes results when each region writes rows keyed by its own
+//! range. Use in every region-list BUILDER where per-region cost is known at build time.
+def public lpt_order(var ord : array<int2>) {
+    ord |> sort() $(a, b) => a.y != b.y ? a.y > b.y : a.x < b.x
 }
 
 //! Chunk count for a fused-chain stage over `groups` 32-row quant groups: the GEMV shaper's

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1073,6 +1073,10 @@ typedef MatmulKqRowsFn = function<(var yp : float?; kqp : uint8 const?; ksp : ui
 // The fmt-branched full K-quant GEMV (fmt 4/5/6; internal fork over d rows) and plane repack.
 typedef MatmulKqFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64) : void>
 typedef RepackKqFn = function<(fmt : int; var kq : uint8?; var ks : uint8?; n : int64; d : int64) : void>
+// Batched K-quant GEMM (the kq prefill tile): activations an [ntok x n] image with per-token
+// scale (n/32) and bsum (n/16) rows; Y token-major [ntok x d]. Bit-for-bit ntok x the fmt's
+// per-position GEMV over the same repacked planes.
+typedef MatmulKqBatchFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64; ntok : int64) : void>
 
 //! One kernel backend: the three Q8·Q8 matmul kernels + the weight repack, plus selection metadata.
 //! needs_repack = the kernels read an interleaved weight layout, so the loader must repack first
@@ -1114,6 +1118,7 @@ struct KernelBackend {
     kq_rows_k4 : MatmulKqRowsFn = @@kq_unset_rows
     kq_rows_k5 : MatmulKqRowsFn = @@kq_unset_rows
     kq_rows_k6 : MatmulKqRowsFn = @@kq_unset_rows
+    kq_batch : MatmulKqBatchFn = @@kq_unset_batch
     repack_kq : RepackKqFn = @@repack_kq_identity
     needs_repack : bool
     // The backend's repack_mx4 plane layout and repack Q8 layout satisfy the interleaved
@@ -1169,7 +1174,9 @@ var g_mm_kq = @@kq_unset_kernel
 var g_kq_rows_k4 = @@kq_unset_rows
 var g_kq_rows_k5 = @@kq_unset_rows
 var g_kq_rows_k6 = @@kq_unset_rows
+var g_mm_kq_batch = @@kq_unset_batch
 var g_active_has_kq = false         // does the active backend carry the native K-quant slots?
+var g_active_has_kq_batch = false   // ... including the batched kq GEMM (the prefill tile)?
 var g_repack_q8q8 = @@repack_q8q8_identity   // no-op until a repack backend is selected
 var g_repack_mx4 = @@repack_mx4_identity     // no-op until a repack backend is selected
 var g_repack_kq = @@repack_kq_identity       // no-op until a kq-capable backend is selected
@@ -1279,6 +1286,10 @@ def private kq_unset_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp 
 def private kq_unset_rows(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
     panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant row-range GEMV cores (kq_rows_*)")
 }
+[unused_argument(fmt, yp, kqp, ksp, xqp, xsp, xbsp, n, d, ntok)]
+def private kq_unset_batch(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, ntok : int64) {
+    panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant batch kernel (kq_batch)")
+}
 
 def private activate(be : KernelBackend) {
     g_mm_q8q8 = be.mm
@@ -1302,7 +1313,9 @@ def private activate(be : KernelBackend) {
     g_kq_rows_k4 = be.kq_rows_k4
     g_kq_rows_k5 = be.kq_rows_k5
     g_kq_rows_k6 = be.kq_rows_k6
+    g_mm_kq_batch = be.kq_batch
     g_active_has_kq = !(be.mm_kq == @@kq_unset_kernel)
+    g_active_has_kq_batch = !(be.kq_batch == @@kq_unset_batch)
     g_repack_q8q8 = be.repack
     g_repack_mx4 = be.repack_mx4
     g_repack_kq = be.repack_kq
@@ -1476,6 +1489,27 @@ def kq_rows_fn(fmt : int) : MatmulKqRowsFn {
     if (fmt == 4) return g_kq_rows_k4
     if (fmt == 5) return g_kq_rows_k5
     return g_kq_rows_k6
+}
+
+//! Does the active backend carry the batched kq GEMM (kq_batch — the prefill tile)? The
+//! batched dispatch gates on it and falls back to serial per-position GEMVs when down.
+def kernel_backend_has_kq_batch() : bool {
+    return g_active_has_kq_batch
+}
+
+//! Batched K-quant GEMM over a REPACKED plane pair at plane-local element offset `woff`
+//! (blob+offset form): ntok activation rows -> token-major Y [ntok x d]. Bit-for-bit ntok x
+//! matmul_kq_active. Callers guard with kq_repacked && kernel_backend_has_kq_batch().
+def matmul_kq_batch(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; woff : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d, ntok : int64) {
+    let sb = woff / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    unsafe {
+        invoke(g_mm_kq_batch, fmt, addr(y[0]),
+            reinterpret<uint8 const?>(addr(kq[sb * qsb])), reinterpret<uint8 const?>(addr(ks[sb * ssb])),
+            reinterpret<int8 const?>(addr(xq[0])), reinterpret<float const?>(addr(xs[0])),
+            reinterpret<int const?>(addr(xbs[0])), n, d, ntok)
+    }
 }
 
 //! Native K-quant GEMV over a REPACKED plane pair at plane-local element offset `woff`

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -740,7 +740,7 @@ def matmul_batch(var y : array<float>; w : array<float> | #; x : array<float>; n
 // stores, the same dot per (row, token) — bit-identical either way.
 def private matmul_batch_core(var yp : float?; wp : float const?; xp : float const?; n, d, ntok : int64) {
     var myp = yp
-    let rch = matmul_chunks(int(d), 1, n * d * ntok)
+    let rch = matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)
     let L = lanes_for_work(n * d * ntok, g_batch_lane_cap)
     let tb = (rch < L && ntok >= 128l) ? min(int64((2 * L + rch - 1) / rch), ntok / 64l) : 1l
     if (tb <= 1l) {
@@ -792,7 +792,7 @@ def matmul_bf16_batch(var y : array<float>; w : array<uint16>; woff : int64; x :
         var yp = addr(y[0])
         let wp = reinterpret<uint16 const?>(addr(w[woff]))
         let xp = reinterpret<float const?>(addr(x[0]))
-        let nch = ntok == 1l ? matmul_chunks_gemv(int(d), 1, n * d) : matmul_chunks(int(d), 1, n * d * ntok)
+        let nch = ntok == 1l ? matmul_chunks_gemv(int(d), 1, n * d) : matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)
         maybe_parallel_for(0, int(d), nch) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1077,6 +1077,12 @@ typedef RepackKqFn = function<(fmt : int; var kq : uint8?; var ks : uint8?; n : 
 // scale (n/32) and bsum (n/16) rows; Y token-major [ntok x d]. Bit-for-bit ntok x the fmt's
 // per-position GEMV over the same repacked planes.
 typedef MatmulKqBatchFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64; ntok : int64) : void>
+// Batched region-list K-quant GEMM (the kq batch groupn — the fused MoE prefill, llama.cpp's
+// mul_mat_id shape): `offs` packs TRIPLES like MatmulMx4Q8BatchGroupNFn — [3r] = region r's
+// weight element offset, [3r+1] = row0, [3r+2] = cnt; region r consumes activation rows
+// row0..row0+cnt and produces y rows row0..row0+cnt (token-major, y[(row0+tk)*d + row]).
+// Plane bases pass whole; one fmt per list; no bias form (biased-experts arches are mx4).
+typedef MatmulKqBatchGroupNFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64) : void>
 // Region-list K-quant GEMV (the kq groupn — MoE routed-expert decode dispatch): `offs` packs
 // (weight, activation) element-offset PAIRS like MatmulQ8Q8GroupNFn, region r's rows land at
 // y[r*d .. r*d+d). kqp/ksp are the fmt's PLANE BASES — each region computes its own superblock
@@ -1127,6 +1133,7 @@ struct KernelBackend {
     kq_rows_k6 : MatmulKqRowsFn = @@kq_unset_rows
     kq_batch : MatmulKqBatchFn = @@kq_unset_batch
     kq_groupn : MatmulKqGroupNFn = @@kq_unset_groupn
+    kq_batch_groupn : MatmulKqBatchGroupNFn = @@kq_unset_batch_groupn
     repack_kq : RepackKqFn = @@repack_kq_identity
     needs_repack : bool
     // The backend's repack_mx4 plane layout and repack Q8 layout satisfy the interleaved
@@ -1184,9 +1191,11 @@ var g_kq_rows_k5 = @@kq_unset_rows
 var g_kq_rows_k6 = @@kq_unset_rows
 var g_mm_kq_batch = @@kq_unset_batch
 var g_mm_kq_groupn = @@kq_unset_groupn
+var g_mm_kq_batch_groupn = @@kq_unset_batch_groupn
 var g_active_has_kq = false         // does the active backend carry the native K-quant slots?
 var g_active_has_kq_batch = false   // ... including the batched kq GEMM (the prefill tile)?
 var g_active_has_kq_groupn = false  // ... and the region-list kq GEMV (MoE expert dispatch)?
+var g_active_has_kq_batch_groupn = false   // ... and the fused batched region-list GEMM (MoE prefill)?
 var g_repack_q8q8 = @@repack_q8q8_identity   // no-op until a repack backend is selected
 var g_repack_mx4 = @@repack_mx4_identity     // no-op until a repack backend is selected
 var g_repack_kq = @@repack_kq_identity       // no-op until a kq-capable backend is selected
@@ -1300,6 +1309,10 @@ def private kq_unset_rows(var yp : float?; kqp : uint8 const?; ksp : uint8 const
 def private kq_unset_groupn(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
     panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant region-list kernel (kq_groupn)")
 }
+[unused_argument(fmt, yp, kqp, ksp, offs, nregions, xqp, xsp, xbsp, n, d)]
+def private kq_unset_batch_groupn(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant batched region-list kernel (kq_batch_groupn)")
+}
 [unused_argument(fmt, yp, kqp, ksp, xqp, xsp, xbsp, n, d, ntok)]
 def private kq_unset_batch(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, ntok : int64) {
     panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant batch kernel (kq_batch)")
@@ -1329,9 +1342,11 @@ def private activate(be : KernelBackend) {
     g_kq_rows_k6 = be.kq_rows_k6
     g_mm_kq_batch = be.kq_batch
     g_mm_kq_groupn = be.kq_groupn
+    g_mm_kq_batch_groupn = be.kq_batch_groupn
     g_active_has_kq = !(be.mm_kq == @@kq_unset_kernel)
     g_active_has_kq_batch = !(be.kq_batch == @@kq_unset_batch)
     g_active_has_kq_groupn = !(be.kq_groupn == @@kq_unset_groupn)
+    g_active_has_kq_batch_groupn = !(be.kq_batch_groupn == @@kq_unset_batch_groupn)
     g_repack_q8q8 = be.repack
     g_repack_mx4 = be.repack_mx4
     g_repack_kq = be.repack_kq
@@ -1517,6 +1532,24 @@ def kernel_backend_has_kq_batch() : bool {
 //! The MoE dispatch gates on it and falls back to per-region GEMVs when down.
 def kernel_backend_has_kq_groupn() : bool {
     return g_active_has_kq_groupn
+}
+
+//! Does the active backend carry the fused batched region-list kq GEMM (kq_batch_groupn — the
+//! fused MoE prefill)? The grouped prefill gates on it and keeps per-expert tiles when down.
+def kernel_backend_has_kq_batch_groupn() : bool {
+    return g_active_has_kq_batch_groupn
+}
+
+//! Batched region-list K-quant GEMM over REPACKED planes (triple offs — see the typedef).
+//! Callers guard with kq_repacked && kernel_backend_has_kq_batch_groupn().
+def matmul_kq_batch_groupn(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; offs : array<int64> | #; nregions : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64) {
+    unsafe {
+        invoke(g_mm_kq_batch_groupn, fmt, addr(y[0]),
+            reinterpret<uint8 const?>(addr(kq[0])), reinterpret<uint8 const?>(addr(ks[0])),
+            reinterpret<int64 const?>(addr(offs[0])), nregions,
+            reinterpret<int8 const?>(addr(xq[0])), reinterpret<float const?>(addr(xs[0])),
+            reinterpret<int const?>(addr(xbs[0])), n, d)
+    }
 }
 
 //! Region-list K-quant GEMV over REPACKED planes (blob form — the kq twin of mm_at_q8_groupn's

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -3,6 +3,7 @@ options gen2
 module dasllama_math shared public
 
 require math
+require strings  // to_int: DASLLAMA_CALLER_PRIO env override in setup_dasllama_jobque_
 require daslib/fio  // has_env_variable: DAS_JOBQUE_TEAM_RANK_GATE suppresses the profile's team_rank_gate knob
 require daslib/jobque_boost public  // matmul's threaded path expands parallel_for; consumers need its symbols
 require dasllama/dasllama_par  // maybe_parallel_for: thread-or-inline a kernel body on a runtime size flag
@@ -397,6 +398,15 @@ def setup_dasllama_jobque_() {
     if (g_team_rank_gate >= 0 && !has_env_variable("DAS_JOBQUE_TEAM_RANK_GATE")) {
         set_jobque_team_rank_gate(g_team_rank_gate != 0)
     }
+    // the dispatch caller is load-bearing in team mode — only it publishes chains, so a
+    // descheduled caller idles every lane (4B Q4 32L trace: 13 all-lane holes/token, worst
+    // 329us = 1.7%). Que creation ran this thread at High (+1); claim the top notch.
+    // DASLLAMA_CALLER_PRIO=<-2..2> is the A/B rail (1 = the old High).
+    var prio = 2
+    if (has_env_variable("DASLLAMA_CALLER_PRIO")) {
+        prio = to_int(get_env_variable("DASLLAMA_CALLER_PRIO"))
+    }
+    set_current_thread_priority(clamp(prio, -2, 2))
 }
 
 // dasLLAMA matmuls are lockstep linear algebra: SMT siblings share the FMA/load ports, so the

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1077,6 +1077,13 @@ typedef RepackKqFn = function<(fmt : int; var kq : uint8?; var ks : uint8?; n : 
 // scale (n/32) and bsum (n/16) rows; Y token-major [ntok x d]. Bit-for-bit ntok x the fmt's
 // per-position GEMV over the same repacked planes.
 typedef MatmulKqBatchFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64; ntok : int64) : void>
+// Region-list K-quant GEMV (the kq groupn — MoE routed-expert decode dispatch): `offs` packs
+// (weight, activation) element-offset PAIRS like MatmulQ8Q8GroupNFn, region r's rows land at
+// y[r*d .. r*d+d). kqp/ksp are the fmt's PLANE BASES — each region computes its own superblock
+// offset from offs[2r] (unlike mm_kq, whose caller pre-offsets the pointers). One fmt per list
+// (a MoE layer's expert stack is one tensor). No bias form: the only biased-experts arch
+// (gpt-oss) carries mx4 stacks, never K-quant.
+typedef MatmulKqGroupNFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64) : void>
 
 //! One kernel backend: the three Q8·Q8 matmul kernels + the weight repack, plus selection metadata.
 //! needs_repack = the kernels read an interleaved weight layout, so the loader must repack first
@@ -1119,6 +1126,7 @@ struct KernelBackend {
     kq_rows_k5 : MatmulKqRowsFn = @@kq_unset_rows
     kq_rows_k6 : MatmulKqRowsFn = @@kq_unset_rows
     kq_batch : MatmulKqBatchFn = @@kq_unset_batch
+    kq_groupn : MatmulKqGroupNFn = @@kq_unset_groupn
     repack_kq : RepackKqFn = @@repack_kq_identity
     needs_repack : bool
     // The backend's repack_mx4 plane layout and repack Q8 layout satisfy the interleaved
@@ -1175,8 +1183,10 @@ var g_kq_rows_k4 = @@kq_unset_rows
 var g_kq_rows_k5 = @@kq_unset_rows
 var g_kq_rows_k6 = @@kq_unset_rows
 var g_mm_kq_batch = @@kq_unset_batch
+var g_mm_kq_groupn = @@kq_unset_groupn
 var g_active_has_kq = false         // does the active backend carry the native K-quant slots?
 var g_active_has_kq_batch = false   // ... including the batched kq GEMM (the prefill tile)?
+var g_active_has_kq_groupn = false  // ... and the region-list kq GEMV (MoE expert dispatch)?
 var g_repack_q8q8 = @@repack_q8q8_identity   // no-op until a repack backend is selected
 var g_repack_mx4 = @@repack_mx4_identity     // no-op until a repack backend is selected
 var g_repack_kq = @@repack_kq_identity       // no-op until a kq-capable backend is selected
@@ -1286,6 +1296,10 @@ def private kq_unset_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp 
 def private kq_unset_rows(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
     panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant row-range GEMV cores (kq_rows_*)")
 }
+[unused_argument(fmt, yp, kqp, ksp, offs, nregions, xqp, xsp, xbsp, n, d)]
+def private kq_unset_groupn(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant region-list kernel (kq_groupn)")
+}
 [unused_argument(fmt, yp, kqp, ksp, xqp, xsp, xbsp, n, d, ntok)]
 def private kq_unset_batch(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, ntok : int64) {
     panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant batch kernel (kq_batch)")
@@ -1314,8 +1328,10 @@ def private activate(be : KernelBackend) {
     g_kq_rows_k5 = be.kq_rows_k5
     g_kq_rows_k6 = be.kq_rows_k6
     g_mm_kq_batch = be.kq_batch
+    g_mm_kq_groupn = be.kq_groupn
     g_active_has_kq = !(be.mm_kq == @@kq_unset_kernel)
     g_active_has_kq_batch = !(be.kq_batch == @@kq_unset_batch)
+    g_active_has_kq_groupn = !(be.kq_groupn == @@kq_unset_groupn)
     g_repack_q8q8 = be.repack
     g_repack_mx4 = be.repack_mx4
     g_repack_kq = be.repack_kq
@@ -1495,6 +1511,26 @@ def kq_rows_fn(fmt : int) : MatmulKqRowsFn {
 //! batched dispatch gates on it and falls back to serial per-position GEMVs when down.
 def kernel_backend_has_kq_batch() : bool {
     return g_active_has_kq_batch
+}
+
+//! Does the active backend carry the region-list kq GEMV (kq_groupn — MoE expert dispatch)?
+//! The MoE dispatch gates on it and falls back to per-region GEMVs when down.
+def kernel_backend_has_kq_groupn() : bool {
+    return g_active_has_kq_groupn
+}
+
+//! Region-list K-quant GEMV over REPACKED planes (blob form — the kq twin of mm_at_q8_groupn's
+//! kernels): `offs` packs (weight, activation) element-offset pairs, region r's rows land at
+//! y[r*d .. r*d+d). Plane bases pass whole — each region computes its own superblock offset.
+//! Callers guard with kq_repacked && kernel_backend_has_kq_groupn().
+def matmul_kq_groupn_active(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; offs : array<int64> | #; nregions : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64) {
+    unsafe {
+        invoke(g_mm_kq_groupn, fmt, addr(y[0]),
+            reinterpret<uint8 const?>(addr(kq[0])), reinterpret<uint8 const?>(addr(ks[0])),
+            reinterpret<int64 const?>(addr(offs[0])), nregions,
+            reinterpret<int8 const?>(addr(xq[0])), reinterpret<float const?>(addr(xs[0])),
+            reinterpret<int const?>(addr(xbs[0])), n, d)
+    }
 }
 
 //! Batched K-quant GEMM over a REPACKED plane pair at plane-local element offset `woff`

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1064,6 +1064,15 @@ typedef BackendAvailableFn = function<() : bool>
 // into every store of region r (per-expert bias vectors). Bit-exact vs a per-region loop of the
 // same backend's mx4 batch kernel — the same per-row dots, one fork instead of nregions.
 typedef MatmulMx4Q8BatchGroupNFn = function<(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n : int64; d : int64) : void>
+// Native K-quant rows-range GEMV core (kq stage 4): rows [rb, re) of one plane-region pair
+// (kqp/ksp = the format's quant/scale plane bases at the tensor's superblock), activation as
+// (xq, xs, xbs — the per-16 sums the offset term consumes). One typedef per the three formats;
+// a backend's cores read ITS repacked kq layout (repack_kq), so mixing backends across a load
+// is as illegal as for the Q8 plane. rb/re multiples of the backend's mr.
+typedef MatmulKqRowsFn = function<(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; rb : int64; re : int64) : void>
+// The fmt-branched full K-quant GEMV (fmt 4/5/6; internal fork over d rows) and plane repack.
+typedef MatmulKqFn = function<(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64) : void>
+typedef RepackKqFn = function<(fmt : int; var kq : uint8?; var ks : uint8?; n : int64; d : int64) : void>
 
 //! One kernel backend: the three Q8·Q8 matmul kernels + the weight repack, plus selection metadata.
 //! needs_repack = the kernels read an interleaved weight layout, so the loader must repack first
@@ -1097,6 +1106,15 @@ struct KernelBackend {
     group3_s16 : MatmulQ8Q8Group3FnS16 = @@q8q8_unset_group3_s16
     groupn_s16 : MatmulQ8Q8GroupNFnS16 = @@q8q8_unset_groupn_s16
     mm_rows_s16 : MatmulQ8Q8RowsFnS16 = @@q8q8_unset_rows_s16
+    // Optional native K-quant slots (kq stage 4). All-or-nothing per backend, keyed off mm_kq
+    // (kernel_backend_has_kq): the loader repacks the kq planes through repack_kq iff the
+    // gate is up, and from then on EVERY kq matmul must run these cores — the portable
+    // disk-order kernels would read garbage off the interleaved planes.
+    mm_kq : MatmulKqFn = @@kq_unset_kernel
+    kq_rows_k4 : MatmulKqRowsFn = @@kq_unset_rows
+    kq_rows_k5 : MatmulKqRowsFn = @@kq_unset_rows
+    kq_rows_k6 : MatmulKqRowsFn = @@kq_unset_rows
+    repack_kq : RepackKqFn = @@repack_kq_identity
     needs_repack : bool
     // The backend's repack_mx4 plane layout and repack Q8 layout satisfy the interleaved
     // byte-for-byte expand map (expand_mx4_region_q8's direct-interleave branch): nibble byte
@@ -1147,8 +1165,14 @@ var g_mm_q8q8_groupn_s16 = @@q8q8_unset_groupn_s16
 var g_mm_q8q8_rows_s16 = @@q8q8_unset_rows_s16
 var g_active_has_wscale16 = false   // does the active backend carry the f16-scale twins?
 var g_active_has_rows16 = false     // ... including the f16-scale row-range GEMV core?
+var g_mm_kq = @@kq_unset_kernel
+var g_kq_rows_k4 = @@kq_unset_rows
+var g_kq_rows_k5 = @@kq_unset_rows
+var g_kq_rows_k6 = @@kq_unset_rows
+var g_active_has_kq = false         // does the active backend carry the native K-quant slots?
 var g_repack_q8q8 = @@repack_q8q8_identity   // no-op until a repack backend is selected
 var g_repack_mx4 = @@repack_mx4_identity     // no-op until a repack backend is selected
+var g_repack_kq = @@repack_kq_identity       // no-op until a kq-capable backend is selected
 
 var g_kernel_backends : table<string; KernelBackend>
 var g_active_backend = ""           // name of the active backend ("" = the unset stub)
@@ -1170,6 +1194,10 @@ def repack_q8q8_identity(var wp : int8?; var sp : float?; n, d : int64) {}
 //! Default MXFP4 repack: no-op — the planes stay row-major for the portable / row-major kernels.
 [unused_argument(np, ep, n, d)]
 def repack_mx4_identity(var np : uint8?; var ep : uint8?; n, d : int64) {}
+
+//! Default K-quant repack: no-op — the kq planes stay disk-order for the portable kernels.
+[unused_argument(fmt, kq, ks, n, d)]
+def repack_kq_identity(fmt : int; var kq : uint8?; var ks : uint8?; n, d : int64) {}
 
 def private no_backend() {
     panic("dasLLAMA: no Q8·Q8 kernel backend registered — require dasllama/dasllama_math_default")
@@ -1241,6 +1269,16 @@ def private q8q8_unset_groupn_s16(var yp : float?; wp : int8 const?; sp : uint16
 def private q8q8_unset_rows_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, rb, re : int64) {
     panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no f16-scale row-range GEMV core (mm_rows_s16)")
 }
+// The kq stubs are reachable with a registered backend (the slots are optional) — dispatch
+// gates on kernel_backend_has_kq(); when it is down the disk-order portable kernels serve.
+[unused_argument(fmt, yp, kqp, ksp, xqp, xsp, xbsp, n, d)]
+def private kq_unset_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no native K-quant kernels (mm_kq)")
+}
+[unused_argument(yp, kqp, ksp, xqp, xsp, xbsp, n, rb, re)]
+def private kq_unset_rows(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
+    panic("dasLLAMA: the active kernel backend '{g_active_backend}' has no K-quant row-range GEMV cores (kq_rows_*)")
+}
 
 def private activate(be : KernelBackend) {
     g_mm_q8q8 = be.mm
@@ -1260,8 +1298,14 @@ def private activate(be : KernelBackend) {
     g_mm_q8q8_rows_s16 = be.mm_rows_s16
     g_active_has_wscale16 = !(be.mm_s16 == @@q8q8_unset_kernel_s16)
     g_active_has_rows16 = !(be.mm_rows_s16 == @@q8q8_unset_rows_s16)
+    g_mm_kq = be.mm_kq
+    g_kq_rows_k4 = be.kq_rows_k4
+    g_kq_rows_k5 = be.kq_rows_k5
+    g_kq_rows_k6 = be.kq_rows_k6
+    g_active_has_kq = !(be.mm_kq == @@kq_unset_kernel)
     g_repack_q8q8 = be.repack
     g_repack_mx4 = be.repack_mx4
+    g_repack_kq = be.repack_kq
     g_active_backend = be.name
     g_active_needs_repack = be.needs_repack
     g_active_mx4_expand_interleaved = be.mx4_expand_interleaved
@@ -1417,6 +1461,48 @@ def mm_q8q8_rows16_fn() : MatmulQ8Q8RowsFnS16 {
 //! kernel_backend_has_rows — a wscale_f16 model's fused chains gate on it.
 def kernel_backend_has_rows16() : bool {
     return g_active_has_rows16
+}
+
+//! Does the active backend carry the native K-quant slots (mm_kq + kq_rows_* + repack_kq)?
+//! Decides at LOAD whether the kq planes get repacked; a Model records the answer
+//! (kq_repacked) and every later dispatch routes off that record, not this live query.
+def kernel_backend_has_kq() : bool {
+    return g_active_has_kq
+}
+
+//! The active backend's K-quant rows core for `fmt` (4/5/6) — the chains' kq twin of
+//! mm_q8q8_rows_fn. Same read-into-a-local-then-capture rule.
+def kq_rows_fn(fmt : int) : MatmulKqRowsFn {
+    if (fmt == 4) return g_kq_rows_k4
+    if (fmt == 5) return g_kq_rows_k5
+    return g_kq_rows_k6
+}
+
+//! Native K-quant GEMV over a REPACKED plane pair at plane-local element offset `woff`
+//! (blob+offset form — the repacked twin of dasllama_math_default's matmul_kq). Dispatches
+//! to the active backend's mm_kq; callers guard with the model's kq_repacked record.
+def matmul_kq_active(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; woff : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64; yoff : int64 = 0l) {
+    let sb = woff / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    unsafe {
+        invoke(g_mm_kq, fmt, addr(y[yoff]),
+            reinterpret<uint8 const?>(addr(kq[sb * qsb])), reinterpret<uint8 const?>(addr(ks[sb * ssb])),
+            reinterpret<int8 const?>(addr(xq[0])), reinterpret<float const?>(addr(xs[0])),
+            reinterpret<int const?>(addr(xbs[0])), n, d)
+    }
+}
+
+//! Repack one K-quant weight tensor (region at element offset woff in the fmt's planes, shape
+//! [d rows x n cols]) into the active backend's kq layout, IN PLACE. No-op unless a kq-capable
+//! backend is active. n % 256 == 0 (the ggml K-quant row invariant).
+def repack_kq_weight(fmt : int; var kq : array<uint8>; var ks : array<uint8>; woff, n, d : int64) {
+    let sb = woff / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    unsafe {
+        invoke(g_repack_kq, fmt, addr(kq[sb * qsb]), addr(ks[sb * ssb]), n, d)
+    }
 }
 
 //! Registered backend names (diagnostics / tests).

--- a/modules/dasLLAMA/dasllama/dasllama_math_aarch64_neon.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_aarch64_neon.das
@@ -83,7 +83,7 @@ def private q8q8_kernel_neon_sdot4x4(var yp : float?; wp : int8 const?; sp : flo
 def private q8q8_batch_kernel_neon_sdot4x4(var yp : float?; wp : int8 const?; sp : float const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+    maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -476,7 +476,7 @@ def private q8q8_kernel_neon_sdot4x4_s16(var yp : float?; wp : int8 const?; sp :
 def private q8q8_batch_kernel_neon_sdot4x4_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+    maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n

--- a/modules/dasLLAMA/dasllama/dasllama_math_default.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_default.das
@@ -522,6 +522,43 @@ def matmul_kq(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : a
     }
 }
 
+//! Region-list K-quant GEMV over the DISK-ORDER planes (the groupn twin of matmul_kq, one
+//! flat fork like q8q8_groupn_kernel): `offs` packs (weight, activation) element-offset pairs,
+//! region r's rows land at y[r*d .. r*d+d). One fmt for the whole list — a MoE layer's expert
+//! stack is one tensor. No bias form (the only biased-experts arch, gpt-oss, is mx4).
+def matmul_kq_groupn(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; offs : array<int64> | #; nregions : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64) {
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    unsafe {
+        let kqp = reinterpret<uint8 const?>(addr(kq[0]))
+        let ksp = reinterpret<uint8 const?>(addr(ks[0]))
+        let offp = reinterpret<int64 const?>(addr(offs[0]))
+        let xqp = reinterpret<int8 const?>(addr(xq[0]))
+        let xsp = reinterpret<float const?>(addr(xs[0]))
+        let xbsp = reinterpret<int const?>(addr(xbs[0]))
+        var myp = addr(y[0])
+        maybe_parallel_for(0, int(nregions * d), matmul_chunks_gemv(int(nregions * d), 1, n * d * nregions)) $(rb, re) {
+            unsafe {
+                for (i in range(rb, re)) {
+                    let ii = int64(i)
+                    let r = ii / d
+                    let row = ii % d
+                    let sb = offp[r * 2l] / 256l + row * nsb
+                    let xoff = offp[r * 2l + 1l]
+                    if (fmt == 4) {
+                        myp[ii] = dot_k4q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n)
+                    } elif (fmt == 5) {
+                        myp[ii] = dot_k5q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n)
+                    } else {
+                        myp[ii] = dot_k6q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n)
+                    }
+                }
+            }
+        }
+    }
+}
+
 //! MXFP4·Q8 dot, scalar reference form (mirrors ggml_vec_dot_mxfp4_q8_0's tail loop): per 32-block,
 //! each of the 16 nibble bytes pairs its low nibble with xq[j] and its high nibble with xq[j+16]
 //! through the doubled-e2m1 `lut`, the exact int32 block sum flushing through e8m0_half(we) × xs.

--- a/modules/dasLLAMA/dasllama/dasllama_math_default.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_default.das
@@ -289,6 +289,181 @@ def q8q8_groupn_kernel_s16(var yp : float?; wp : int8 const?; sp : uint16 const?
     }
 }
 
+// ===== Native K-quant (Q4_K/Q5_K/Q6_K) dots + rows kernels =====
+// Plane layouts per 256-weight superblock (see dasllama_gguf transcode): k4 quant 128B nibbles +
+// 32B f16 (s, o) pairs per 32-sub-block; k5 [128B nibbles][32B qh] + the same pairs; k6
+// [128B ql][64B qh] + [16 int8 sub-scales][f16 d]. Dot per sub-block: s*(Σ q·a) − o*(Σ a) with
+// UNSIGNED quants — the offset term consumes the per-16 activation sums (xbs) the bs quantizer
+// emits. These read the planes in disk order (no repack), so they are backend-independent:
+// every backend runs them until a generated tier lands. Row strides: quant (n/256)*{128,160,192}
+// bytes, scale (n/256)*{32,32,18} bytes.
+
+def private kq_pair(ksrow : uint8 const?; o : int64) : float2 {
+    unsafe {
+        let s = uint(ksrow[o]) | (uint(ksrow[o + 1l]) << 8u)
+        let m = uint(ksrow[o + 2l]) | (uint(ksrow[o + 3l]) << 8u)
+        return float2(f16_to_f32(s), f16_to_f32(m))
+    }
+}
+
+[hint(unsafe_range_check, noalias = kqrow, noalias = ksrow, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def dot_k4q8(kqrow : uint8 const?; ksrow : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    var acc = 0.0
+    unsafe {
+        for (sb in range64(n / 256l)) {
+            let kqo = sb * 128l
+            let kso = sb * 32l
+            for (js in range64(4l)) {   // 32 quant bytes: low nibbles = sub-block 2js, high = 2js+1
+                let qb = kqo + 32l * js
+                let b0 = sb * 8l + 2l * js   // activation 32-block of the low-nibble sub-block
+                let ab = b0 * 32l
+                var ilo = 0
+                var ihi = 0
+                for (l in range64(32l)) {
+                    let q = int(kqrow[qb + l])
+                    ilo += (q & 15) * int(xqp[ab + l])
+                    ihi += (q >> 4) * int(xqp[ab + 32l + l])
+                }
+                let p0 = kq_pair(ksrow, kso + 2l * js * 4l)
+                let p1 = kq_pair(ksrow, kso + (2l * js + 1l) * 4l)
+                let a0 = float(xbsp[b0 * 2l] + xbsp[b0 * 2l + 1l])
+                let a1 = float(xbsp[b0 * 2l + 2l] + xbsp[b0 * 2l + 3l])
+                acc += xsp[b0] * (p0.x * float(ilo) - p0.y * a0)
+                acc += xsp[b0 + 1l] * (p1.x * float(ihi) - p1.y * a1)
+            }
+        }
+    }
+    return acc
+}
+
+[hint(unsafe_range_check, noalias = kqrow, noalias = ksrow, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def dot_k5q8(kqrow : uint8 const?; ksrow : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    var acc = 0.0
+    unsafe {
+        for (sb in range64(n / 256l)) {
+            let kqo = sb * 160l
+            let kso = sb * 32l
+            let qhb = kqo + 128l   // 32 high-bit bytes; chunk js owns bits 2js (low nibbles) / 2js+1
+            for (js in range64(4l)) {
+                let qb = kqo + 32l * js
+                let b0 = sb * 8l + 2l * js
+                let ab = b0 * 32l
+                let sh = int(js) * 2
+                var ilo = 0
+                var ihi = 0
+                for (l in range64(32l)) {
+                    let q = int(kqrow[qb + l])
+                    let h = int(kqrow[qhb + l]) >> sh
+                    ilo += ((q & 15) | ((h & 1) << 4)) * int(xqp[ab + l])
+                    ihi += ((q >> 4) | ((h & 2) << 3)) * int(xqp[ab + 32l + l])
+                }
+                let p0 = kq_pair(ksrow, kso + 2l * js * 4l)
+                let p1 = kq_pair(ksrow, kso + (2l * js + 1l) * 4l)
+                let a0 = float(xbsp[b0 * 2l] + xbsp[b0 * 2l + 1l])
+                let a1 = float(xbsp[b0 * 2l + 2l] + xbsp[b0 * 2l + 3l])
+                acc += xsp[b0] * (p0.x * float(ilo) - p0.y * a0)
+                acc += xsp[b0 + 1l] * (p1.x * float(ihi) - p1.y * a1)
+            }
+        }
+    }
+    return acc
+}
+
+[hint(unsafe_range_check, noalias = kqrow, noalias = ksrow, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def dot_k6q8(kqrow : uint8 const?; ksrow : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    var acc = 0.0
+    unsafe {
+        for (sb in range64(n / 256l)) {
+            let kqo = sb * 192l
+            let kso = sb * 18l
+            let d = f16_to_f32(uint(ksrow[kso + 16l]) | (uint(ksrow[kso + 17l]) << 8u))
+            for (half in range64(2l)) {
+                let qlb = kqo + 64l * half
+                let qhb = kqo + 128l + 32l * half
+                for (g in range64(4l)) {   // group g: ql byte (g&1)*32+l, shift 4*(g/2), qh bits 2g
+                    let bb = (g & 1l) * 32l
+                    let sh = g < 2l ? 0 : 4
+                    let hb = int(g) * 2
+                    let b = sb * 8l + half * 4l + g   // activation 32-block
+                    let ab = b * 32l
+                    var i0 = 0
+                    var i1 = 0
+                    for (l in range64(16l)) {
+                        let q0 = ((int(kqrow[qlb + bb + l]) >> sh) & 15) | (((int(kqrow[qhb + l]) >> hb) & 3) << 4)
+                        let q1 = ((int(kqrow[qlb + bb + 16l + l]) >> sh) & 15) | (((int(kqrow[qhb + 16l + l]) >> hb) & 3) << 4)
+                        i0 += q0 * int(xqp[ab + l])
+                        i1 += q1 * int(xqp[ab + 16l + l])
+                    }
+                    let si = kso + half * 8l + g * 2l
+                    let u0 = int(ksrow[si])
+                    let u1 = int(ksrow[si + 1l])
+                    let s0 = d * float(u0 < 128 ? u0 : u0 - 256)
+                    let s1 = d * float(u1 < 128 ? u1 : u1 - 256)
+                    let a0 = float(xbsp[b * 2l])
+                    let a1 = float(xbsp[b * 2l + 1l])
+                    acc += xsp[b] * (s0 * (float(i0) - 32.0 * a0) + s1 * (float(i1) - 32.0 * a1))
+                }
+            }
+        }
+    }
+    return acc
+}
+
+// Row-range cores + full GEMVs per format. Not `private`: invoked through hoisted function
+// pointers from lifted worker lambdas (the fused chains) and the dispatch wrappers in common.
+def k4_rows_kernel(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            yp[i] = dot_k4q8(kqp + i * nsb * 128l, ksp + i * nsb * 32l, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+def k5_rows_kernel(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            yp[i] = dot_k5q8(kqp + i * nsb * 160l, ksp + i * nsb * 32l, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+def k6_rows_kernel(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            yp[i] = dot_k6q8(kqp + i * nsb * 192l, ksp + i * nsb * 18l, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+def private kq_gemv_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    var myp = yp
+    maybe_parallel_for(0, int(d), matmul_chunks_gemv(int(d), 1, n * d)) $(rb, re) {
+        if (fmt == 4) {
+            k4_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
+        } elif (fmt == 5) {
+            k5_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
+        } else {
+            k6_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
+        }
+    }
+}
+
+//! K-quant GEMV over a plane pair at plane-local element offset `woff` (blob+offset form, the
+//! dispatch shape every call site uses). fmt: 4/5/6 selects the sub-format; rows land at
+//! y[yoff .. yoff+d) (batched callers pass the token row base).
+def matmul_kq(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; woff : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64; yoff : int64 = 0l) {
+    let sb = woff / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    unsafe {
+        kq_gemv_kernel(fmt, addr(y[yoff]), addr(kq[sb * qsb]), addr(ks[sb * ssb]),
+                       addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d)
+    }
+}
+
 //! MXFP4·Q8 dot, scalar reference form (mirrors ggml_vec_dot_mxfp4_q8_0's tail loop): per 32-block,
 //! each of the 16 nibble bytes pairs its low nibble with xq[j] and its high nibble with xq[j+16]
 //! through the doubled-e2m1 `lut`, the exact int32 block sum flushing through e8m0_half(we) × xs.

--- a/modules/dasLLAMA/dasllama/dasllama_math_default.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_default.das
@@ -451,6 +451,64 @@ def private kq_gemv_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp :
     }
 }
 
+//! Dequant one row off the grp<mr>-REPACKED K-quant planes (kq stage 4 — the layout
+//! repack_k4/k5/k6_grp writes; see dasllama_math_gen). kqg/ksg = the row's GROUP plane bases
+//! (group g = row/mr at g*mr*(n/256)*{qsb,ssb}); r = row % mr. embed_row's kq_repacked path —
+//! per-token, so scalar is fine.
+def dequant_kq_row_grp(fmt : int64; kqg : uint8 const?; ksg : uint8 const?; r, mr, n : int64; var dst : float?) {
+    let nsb = n / 256l
+    let qsb = fmt == 4l ? 128l : (fmt == 5l ? 160l : 192l)
+    let ssb = fmt == 6l ? 18l : 32l
+    unsafe {
+        for (sbi in range64(nsb)) {
+            let qb = sbi * qsb * mr
+            let sb = sbi * ssb * mr
+            let dk6 = fmt == 6l ? f16_to_f32(uint(ksg[sb + 16l * mr + 2l * r]) | (uint(ksg[sb + 16l * mr + 2l * r + 1l]) << 8u)) : 0.0
+            for (blk in range64(8l)) {
+                let kb = sbi * 256l + blk * 32l
+                var s0 = 0.0
+                var s1 = 0.0
+                var o = 0.0
+                if (fmt == 6l) {
+                    s0 = dk6 * float(int(int8(ksg[sb + 2l * blk * mr + r])))
+                    s1 = dk6 * float(int(int8(ksg[sb + (2l * blk + 1l) * mr + r])))
+                } else {
+                    let s4 = sb + blk * 4l * mr
+                    s0 = f16_to_f32(uint(ksg[s4 + 2l * r]) | (uint(ksg[s4 + 2l * r + 1l]) << 8u))
+                    s1 = s0
+                    o = f16_to_f32(uint(ksg[s4 + 2l * mr + 2l * r]) | (uint(ksg[s4 + 2l * mr + 2l * r + 1l]) << 8u))
+                }
+                for (j in range64(4l)) {
+                    let hb = fmt == 5l ? int(kqg[qb + 128l * mr + (blk * 4l + j) * mr + r]) : 0
+                    let g2 = uint((blk % 4l) * 2l)
+                    for (t in range64(4l)) {
+                        let nib = uint(kqg[qb + ((blk * 4l + j) * mr + r) * 4l + t])
+                        var qlo = int(nib & 15u)
+                        var qhi = int(nib >> 4u)
+                        if (fmt == 5l) {
+                            qlo |= ((hb >> int(t)) & 1) << 4
+                            qhi |= ((hb >> int(4l + t)) & 1) << 4
+                        } elif (fmt == 6l) {
+                            let hbase = qb + 128l * mr + (blk / 4l) * 32l * mr
+                            let h0 = uint(kqg[hbase + (j * mr + r) * 4l + t])
+                            let h1 = uint(kqg[hbase + ((j + 4l) * mr + r) * 4l + t])
+                            qlo |= int(((h0 >> g2) & 3u) << 4u)
+                            qhi |= int(((h1 >> g2) & 3u) << 4u)
+                        }
+                        if (fmt == 6l) {
+                            dst[kb + j * 4l + t] = s0 * (float(qlo) - 32.0)
+                            dst[kb + 16l + j * 4l + t] = s1 * (float(qhi) - 32.0)
+                        } else {
+                            dst[kb + j * 4l + t] = s0 * float(qlo) - o
+                            dst[kb + 16l + j * 4l + t] = s1 * float(qhi) - o
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 //! K-quant GEMV over a plane pair at plane-local element offset `woff` (blob+offset form, the
 //! dispatch shape every call site uses). fmt: 4/5/6 selects the sub-format; rows land at
 //! y[yoff .. yoff+d) (batched callers pass the token row base).

--- a/modules/dasLLAMA/dasllama/dasllama_math_default.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_default.das
@@ -121,7 +121,7 @@ def private q8q8_batch_kernel(var yp : float?; wp : int8 const?; sp : float cons
         let pf0 = ref_time_ticks()
         unsafe {
             let wsbase = addr(g_pf_ws[0])
-            parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re, wg) {
+            parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re, wg) {
                 unsafe {
                     var wsw = reinterpret<int64?>(wsbase)
                     wsw[rb] = ref_time_ticks() - pf0
@@ -152,7 +152,7 @@ def private q8q8_batch_kernel(var yp : float?; wp : int8 const?; sp : float cons
         g_pf_n ++
         return
     }
-    maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+    maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -220,7 +220,7 @@ def private q8q8_kernel_s16(var yp : float?; wp : int8 const?; sp : uint16 const
 def private q8q8_batch_kernel_s16(var yp : float?; wp : int8 const?; sp : uint16 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
     var myp = yp
-    maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+    maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
         unsafe {
             for (i in range(rb, re)) {
                 let wrow = wp + int64(i) * n
@@ -615,7 +615,7 @@ def mx4q8_batch_kernel(var yp : float?; wn : uint8 const?; we : uint8 const?; xq
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(0, int(d), matmul_chunks(int(d), 1, n * d * ntok)) $(rb, re) {
+        maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let wrow = wn + int64(i) * (n / 2l)
@@ -638,7 +638,7 @@ def mx4q8_batch_groupn_kernel(var yp : float?; wn : uint8 const?; we : uint8 con
     mxfp4_fill_lut(lut)
     unsafe {
         let lutp = addr(lut[0])   // frame outlives the join, so workers read a live pointer
-        maybe_parallel_for(0, int(nregions * d), matmul_chunks(int(nregions * d), 1, n * d * nregions)) $(rb, re) {
+        maybe_parallel_for(0, int(nregions * d), matmul_chunks(int(nregions * d), get_q8_batch_chunks_per_job(), n * d * nregions)) $(rb, re) {
             unsafe {
                 for (i in range(rb, re)) {
                     let ii = int64(i)

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -1234,6 +1234,56 @@ def private kq_batch_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
     }
 }
 
+// kq_batch_groupn slot: the fused MoE prefill form — ONE dispatch runs every touched expert's
+// batched GEMM (triple offs (woff, row0, cnt); y token-major over the gathered whole image).
+// Region-contiguous group spans through the SAME batch cell walk the per-expert tile uses
+// (kq_batch_cell_gen with the region's token range), so it is bit-exact vs a per-region loop
+// of kq_batch_kernel_gen; row tails (d % mr) disk-order per (region, token).
+def private kq_batch_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    let mr = int64(q8q8_layout_gen())
+    let ng = d / mr
+    let nb32 = n / 32l
+    let nb16 = n / 16l
+    var myp = yp
+    let TB = effective_token_block(g_q8_token_block, n)
+    maybe_parallel_for(0, int(nregions * ng), matmul_chunks_gemv(int(nregions * ng * mr), get_q8_batch_chunks_per_job(), n * d * nregions)) $(gb, ge) {
+        unsafe {
+            var gg = int64(gb)
+            while (gg < int64(ge)) {
+                let r = gg / ng
+                let gLocal = gg % ng
+                let gEnd = min(int64(ge) - r * ng, ng)
+                let sb = offs[r * 3l] / 256l
+                let row0 = offs[r * 3l + 1l]
+                let cnt = offs[r * 3l + 2l]
+                kq_batch_cell_gen(fmt, myp, kqp + sb * qsb, ksp + sb * ssb, xqp, xsp, xbsp, n, d, mr, TB, int(gLocal), int(gEnd), row0, row0 + cnt)
+                gg = r * ng + gEnd
+            }
+        }
+    }
+    unsafe {
+        for (r in range64(nregions)) {   // row tails (d % mr): disk-order per (region, token)
+            let sb = offs[r * 3l] / 256l
+            let row0 = offs[r * 3l + 1l]
+            let cnt = offs[r * 3l + 2l]
+            for (tk in range64(row0, row0 + cnt)) {
+                for (i in range64(ng * mr, d)) {
+                    if (fmt == 4) {
+                        myp[tk * d + i] = dot_k4q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * nb32, xbsp + tk * nb16, n)
+                    } elif (fmt == 5) {
+                        myp[tk * d + i] = dot_k5q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * nb32, xbsp + tk * nb16, n)
+                    } else {
+                        myp[tk * d + i] = dot_k6q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * nb32, xbsp + tk * nb16, n)
+                    }
+                }
+            }
+        }
+    }
+}
+
 // kq_groupn slot: region-list kq GEMV — the kq twin of q8q8_groupn_gen. Region-contiguous
 // group spans through the fmt's rows core (each region offsets the plane bases by its own
 // superblock), row tails (d % mr) disk-order per region like kq_kernel_gen's. Not `private`:
@@ -1578,7 +1628,7 @@ def dasllama_math_gen_register() {
             mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
             kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
             kq_rows_k6 = @@k6q8_gemv_gen, kq_batch = @@kq_batch_kernel_gen,
-            kq_groupn = @@kq_groupn_gen,
+            kq_groupn = @@kq_groupn_gen, kq_batch_groupn = @@kq_batch_groupn_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, q8_wbias = @@q8q8_wbias_gen,
             q8_kgroup = @@q8q8_kgroup_gen,

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -1216,7 +1216,10 @@ def private kq_batch_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
     let ng = d / mr
     var myp = yp
     let TB = effective_token_block(g_q8_token_block, n)
-    maybe_parallel_for(0, int(ng), matmul_chunks_gemv(int(ng * mr), get_q8_batch_chunks_per_job(), n * d * ntok)) $(ub, ue) {
+    // GEMM shaper, not the GEMV one: a batch row-unit is ntok dots of work, and the GEMV wave
+    // formula (rows/(64·L) waves × L) cancels L out — the 4B w2 GEMM issued a fixed 32 chunks
+    // at BOTH 16 and 32 lanes (1/lane at 32L, zero self-serve slack)
+    maybe_parallel_for(0, int(ng), matmul_chunks(int(ng * mr), get_q8_batch_chunks_per_job(), n * d * ntok)) $(ub, ue) {
         kq_batch_cell_gen(fmt, myp, kqp, ksp, xqp, xsp, xbsp, n, d, mr, TB, ub, ue, 0l, ntok)
     }
     unsafe {

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -5,6 +5,7 @@ module dasllama_math_gen shared public
 require dasllama/dasllama_math
 require dasllama/dasllama_math_aarch64_neon
 require dasllama/dasllama_math_default  // dot_q8q8_f16s — the row-major tails of the s16 twins
+require llvm/daslib/f16_cvt  // the kq reference bodies widen the f16 (s, o) scale pairs
 require llvm/daslib/llvm_tune  // [tune]/[tune_perm]/[tune_companion] + the [llvm_code] annotation it re-exports
 require dasllama/dasllama_gemm_schema
 require daslib/jobque_boost public
@@ -139,6 +140,106 @@ def mx4q8_gemv_gen(var yp : float?; wn : uint8 const?; we : uint8 const?; xqp : 
     }
 }
 
+//! One row's dot off the grp<mr> K-quant planes, scalar — the kq stubs' reference body (runs
+//! only when the stamp declined; production loads never see it) and the tests' repack oracle.
+//! kqg/ksg = the row's GROUP plane bases; r = the row within the group. Block contributions
+//! are computed and summed in the SAME order as the portable disk dots, so it is bit-exact
+//! against them (the integer sub-sums are exact; only the plane layout differs).
+def kq_grp_row_dot(fmt : int64; kqg : uint8 const?; ksg : uint8 const?; r, mr : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    var acc = 0.0
+    let nsb = n / 256l
+    let qsb = fmt == 4l ? 128l : (fmt == 5l ? 160l : 192l)
+    let ssb = fmt == 6l ? 18l : 32l
+    unsafe {
+        for (sbi in range64(nsb)) {
+            let qb = sbi * qsb * mr
+            let sb = sbi * ssb * mr
+            let dk6 = fmt == 6l ? f16_to_f32(uint(ksg[sb + 16l * mr + 2l * r]) | (uint(ksg[sb + 16l * mr + 2l * r + 1l]) << 8u)) : 0.0
+            for (blk in range64(8l)) {
+                let b = sbi * 8l + blk
+                var ilo = 0
+                var ihi = 0
+                for (j in range64(4l)) {
+                    let hb = fmt == 5l ? int(kqg[qb + 128l * mr + (blk * 4l + j) * mr + r]) : 0
+                    let g2 = uint((blk % 4l) * 2l)
+                    for (t in range64(4l)) {
+                        let nib = uint(kqg[qb + ((blk * 4l + j) * mr + r) * 4l + t])
+                        var qlo = int(nib & 15u)
+                        var qhi = int(nib >> 4u)
+                        if (fmt == 5l) {
+                            qlo |= ((hb >> int(t)) & 1) << 4
+                            qhi |= ((hb >> int(4l + t)) & 1) << 4
+                        } elif (fmt == 6l) {
+                            let hbase = qb + 128l * mr + (blk / 4l) * 32l * mr
+                            let h0 = uint(kqg[hbase + (j * mr + r) * 4l + t])
+                            let h1 = uint(kqg[hbase + ((j + 4l) * mr + r) * 4l + t])
+                            qlo |= int(((h0 >> g2) & 3u) << 4u)
+                            qhi |= int(((h1 >> g2) & 3u) << 4u)
+                        }
+                        ilo += qlo * int(xqp[b * 32l + j * 4l + t])
+                        ihi += qhi * int(xqp[b * 32l + 16l + j * 4l + t])
+                    }
+                }
+                if (fmt == 6l) {
+                    let s0 = dk6 * float(int(int8(ksg[sb + 2l * blk * mr + r])))
+                    let s1 = dk6 * float(int(int8(ksg[sb + (2l * blk + 1l) * mr + r])))
+                    let a0 = float(xbsp[b * 2l])
+                    let a1 = float(xbsp[b * 2l + 1l])
+                    acc += xsp[b] * (s0 * (float(ilo) - 32.0 * a0) + s1 * (float(ihi) - 32.0 * a1))
+                } else {
+                    let s4 = sb + blk * 4l * mr
+                    let s = f16_to_f32(uint(ksg[s4 + 2l * r]) | (uint(ksg[s4 + 2l * r + 1l]) << 8u))
+                    let o = f16_to_f32(uint(ksg[s4 + 2l * mr + 2l * r]) | (uint(ksg[s4 + 2l * mr + 2l * r + 1l]) << 8u))
+                    let a32 = float(xbsp[b * 2l] + xbsp[b * 2l + 1l])
+                    acc += xsp[b] * (s * float(ilo + ihi) - o * a32)
+                }
+            }
+        }
+    }
+    return acc
+}
+
+//! The K-quant GEMV companions (kq stage 4, the sixth family slice): rows [rb, re) of one
+//! plane-region pair off the grp<mr> kq planes (repack_k4/k5/k6_grp — the SAME mr as the Q8
+//! layout). The generators emit the unsigned-quant superblock loop (dasllama_gemm_gen::k*_gemv);
+//! reference bodies = the scalar grp walk above, declining in lockstep via the shared predicate.
+//! Not `private`: they ARE the kq_rows_* slots and are called from inside lifted worker lambdas.
+[hint(unsafe_range_check, noalias = kqp, noalias = ksp, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def k4q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) : void {
+    let mr = int64(q8q8_layout_gen())
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            let g = i / mr
+            yp[i] = kq_grp_row_dot(4l, kqp + g * mr * nsb * 128l, ksp + g * mr * nsb * 32l, i % mr, mr, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+[hint(unsafe_range_check, noalias = kqp, noalias = ksp, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def k5q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) : void {
+    let mr = int64(q8q8_layout_gen())
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            let g = i / mr
+            yp[i] = kq_grp_row_dot(5l, kqp + g * mr * nsb * 160l, ksp + g * mr * nsb * 32l, i % mr, mr, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+[hint(unsafe_range_check, noalias = kqp, noalias = ksp, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def k6q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) : void {
+    let mr = int64(q8q8_layout_gen())
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            let g = i / mr
+            yp[i] = kq_grp_row_dot(6l, kqp + g * mr * nsb * 192l, ksp + g * mr * nsb * 18l, i % mr, mr, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
 //! The f16-scale GEMV companion (the wscale_f16 rail): q8q8_gemv_gen's twin over the raw
 //! binary16 group-scale plane (Model.qscales16 — the repacked f32 plane, converted in place,
 //! element order preserved). Same rows-range contract; the generated body differs only in the
@@ -231,6 +332,9 @@ def q8q8_tile_s16_gen(var yp : float?; wg : int8 const?; sg : uint16 const?; xqp
  tune_companion(fn = "q8q8_tile_s16_gen", gen = "dasllama_gemm_gen::q8q8_tile_s16"),
  tune_companion(fn = "q8q8_gemv_s16_gen", gen = "dasllama_gemm_gen::q8q8_gemv_s16"),
  tune_companion(fn = "mx4q8_gemv_gen", gen = "dasllama_gemm_gen::mx4_gemv"),
+ tune_companion(fn = "k4q8_gemv_gen", gen = "dasllama_gemm_gen::k4_gemv"),
+ tune_companion(fn = "k5q8_gemv_gen", gen = "dasllama_gemm_gen::k5_gemv"),
+ tune_companion(fn = "k6q8_gemv_gen", gen = "dasllama_gemm_gen::k6_gemv"),
  tune_companion(fn = "q8q8_family_live", gen = "dasllama_gemm_gen::q8q8_witness"),
  tune(gen = "dasllama_gemm_gen::q8q8_tile",
       fallback = "dot_vpdpbusd_width512_mr16_kstep2_gkstep2_bias128;dot_vpdpbusd_width256_mr8_kstep2_gkstep2_bias128;dot_maddubs_width256_mr8_kstep2;kstep2"), unused_argument(xbsp),
@@ -366,6 +470,208 @@ def repack_mx4_grp(var np : uint8?; var ep : uint8?; n, d, mr : int64) {
 // interleave at the ONE stamped mr
 def private repack_mx4_gen(var np : uint8?; var ep : uint8?; n, d : int64) {
     repack_mx4_grp(np, ep, n, d, int64(q8q8_layout_gen()))
+}
+
+// ===== K-quant grp<mr> repacks (kq stage 4) =====
+// The layouts the stamped k4/k5/k6 rows cores read, per superblock per mr-row group (tail rows
+// d % mr stay disk-order at their original offsets — the portable dots serve them):
+//   quants  [blk 0..7][j 0..3][row][4B] — byte t of (blk,j) pairs k = blk*32+j*4+t (LOW nibble)
+//           with k+16 (HIGH), the mx4 pairing (disk pairs sub-blocks 2js/2js+1 instead)
+//   k5 high [blk][j][row] 1B — bit t = weight j*4+t's 5th bit, bit 4+t = the k+16 weight's
+//   k6 high [half][jj 0..7][row][4B] — the disk qh bytes verbatim (bits for all 4 blocks of the
+//           half at uniform shift 2g), only row-interleaved by 4-byte columns
+//   scales  k4/k5 [blk][mr f16 s][mr f16 o]; k6 [idx 0..15][mr int8 sc][mr f16 d]
+
+// low 4 bits of weight k off a disk-order k4/k5 nibble row (128 bytes per superblock)
+def private k45_nib(rowq : uint8 const?; k : int64) : uint {
+    let js = k / 64l
+    let rem = k % 64l
+    let b = uint(unsafe(rowq[js * 32l + rem % 32l]))
+    return rem < 32l ? b & 15u : b >> 4u
+}
+
+// the 5th bit of weight k off a disk-order k5 qh row (32 bytes per superblock)
+def private k5_hbit(rowh : uint8 const?; k : int64) : uint {
+    let js = k / 64l
+    let rem = k % 64l
+    return (uint(unsafe(rowh[rem % 32l])) >> uint(2l * js + (rem < 32l ? 0l : 1l))) & 1u
+}
+
+// low 4 bits of weight k off a disk-order k6 ql row (128 bytes per superblock)
+def private k6_nib(rowq : uint8 const?; k : int64) : uint {
+    let h = k / 128l
+    let g = (k % 128l) / 32l
+    let b = uint(unsafe(rowq[h * 64l + (g % 2l) * 32l + k % 32l]))
+    return g < 2l ? b & 15u : b >> 4u
+}
+
+//! mr-generalized K-quant plane repack, one function per format (grp layouts above). Runs once
+//! per kq weight tensor at load, on the main context. Public: probes/tests repack per-variant
+//! copies with an explicit mr.
+def repack_k4_grp(var kq : uint8?; var ks : uint8?; n, d, mr : int64) {
+    let nsb = n / 256l
+    let qrow = nsb * 128l
+    let srow = nsb * 32l
+    let ng = d / mr
+    var tq : array<uint8>
+    var ts : array<uint8>
+    tq |> resize(int(d * qrow))
+    ts |> resize(int(d * srow))
+    unsafe {
+        var tqp = addr(tq[0])
+        var tsp = addr(ts[0])
+        for (i in range64(d * qrow)) {
+            tqp[i] = kq[i]
+        }
+        for (i in range64(d * srow)) {
+            tsp[i] = ks[i]
+        }
+        for (g in range64(ng)) {
+            for (sbi in range64(nsb)) {
+                let dq = g * mr * qrow + sbi * 128l * mr
+                let ds = g * mr * srow + sbi * 32l * mr
+                for (r in range64(mr)) {
+                    let sq = (g * mr + r) * qrow + sbi * 128l
+                    let ss = (g * mr + r) * srow + sbi * 32l
+                    for (blk in range64(8l)) {
+                        for (j in range64(4l)) {
+                            for (t in range64(4l)) {
+                                let k = blk * 32l + j * 4l + t
+                                let lo = k45_nib(tqp + sq, k)
+                                let hi = k45_nib(tqp + sq, k + 16l)
+                                kq[dq + ((blk * 4l + j) * mr + r) * 4l + t] = uint8(lo | (hi << 4u))
+                            }
+                        }
+                        let sb4 = ds + blk * 4l * mr
+                        ks[sb4 + 2l * r] = tsp[ss + blk * 4l]
+                        ks[sb4 + 2l * r + 1l] = tsp[ss + blk * 4l + 1l]
+                        ks[sb4 + 2l * mr + 2l * r] = tsp[ss + blk * 4l + 2l]
+                        ks[sb4 + 2l * mr + 2l * r + 1l] = tsp[ss + blk * 4l + 3l]
+                    }
+                }
+            }
+        }
+    }
+    delete tq
+    delete ts
+}
+
+def repack_k5_grp(var kq : uint8?; var ks : uint8?; n, d, mr : int64) {
+    let nsb = n / 256l
+    let qrow = nsb * 160l
+    let srow = nsb * 32l
+    let ng = d / mr
+    var tq : array<uint8>
+    var ts : array<uint8>
+    tq |> resize(int(d * qrow))
+    ts |> resize(int(d * srow))
+    unsafe {
+        var tqp = addr(tq[0])
+        var tsp = addr(ts[0])
+        for (i in range64(d * qrow)) {
+            tqp[i] = kq[i]
+        }
+        for (i in range64(d * srow)) {
+            tsp[i] = ks[i]
+        }
+        for (g in range64(ng)) {
+            for (sbi in range64(nsb)) {
+                let dq = g * mr * qrow + sbi * 160l * mr
+                let ds = g * mr * srow + sbi * 32l * mr
+                for (r in range64(mr)) {
+                    let sq = (g * mr + r) * qrow + sbi * 160l
+                    let ss = (g * mr + r) * srow + sbi * 32l
+                    for (blk in range64(8l)) {
+                        for (j in range64(4l)) {
+                            var hb = 0u
+                            for (t in range64(4l)) {
+                                let k = blk * 32l + j * 4l + t
+                                let lo = k45_nib(tqp + sq, k)
+                                let hi = k45_nib(tqp + sq, k + 16l)
+                                kq[dq + ((blk * 4l + j) * mr + r) * 4l + t] = uint8(lo | (hi << 4u))
+                                hb |= k5_hbit(tqp + sq + 128l, k) << uint(t)
+                                hb |= k5_hbit(tqp + sq + 128l, k + 16l) << uint(4l + t)
+                            }
+                            kq[dq + 128l * mr + (blk * 4l + j) * mr + r] = uint8(hb)
+                        }
+                        let sb4 = ds + blk * 4l * mr
+                        ks[sb4 + 2l * r] = tsp[ss + blk * 4l]
+                        ks[sb4 + 2l * r + 1l] = tsp[ss + blk * 4l + 1l]
+                        ks[sb4 + 2l * mr + 2l * r] = tsp[ss + blk * 4l + 2l]
+                        ks[sb4 + 2l * mr + 2l * r + 1l] = tsp[ss + blk * 4l + 3l]
+                    }
+                }
+            }
+        }
+    }
+    delete tq
+    delete ts
+}
+
+def repack_k6_grp(var kq : uint8?; var ks : uint8?; n, d, mr : int64) {
+    let nsb = n / 256l
+    let qrow = nsb * 192l
+    let srow = nsb * 18l
+    let ng = d / mr
+    var tq : array<uint8>
+    var ts : array<uint8>
+    tq |> resize(int(d * qrow))
+    ts |> resize(int(d * srow))
+    unsafe {
+        var tqp = addr(tq[0])
+        var tsp = addr(ts[0])
+        for (i in range64(d * qrow)) {
+            tqp[i] = kq[i]
+        }
+        for (i in range64(d * srow)) {
+            tsp[i] = ks[i]
+        }
+        for (g in range64(ng)) {
+            for (sbi in range64(nsb)) {
+                let dq = g * mr * qrow + sbi * 192l * mr
+                let ds = g * mr * srow + sbi * 18l * mr
+                for (r in range64(mr)) {
+                    let sq = (g * mr + r) * qrow + sbi * 192l
+                    let ss = (g * mr + r) * srow + sbi * 18l
+                    for (blk in range64(8l)) {
+                        for (j in range64(4l)) {
+                            for (t in range64(4l)) {
+                                let k = blk * 32l + j * 4l + t
+                                let lo = k6_nib(tqp + sq, k)
+                                let hi = k6_nib(tqp + sq, k + 16l)
+                                kq[dq + ((blk * 4l + j) * mr + r) * 4l + t] = uint8(lo | (hi << 4u))
+                            }
+                        }
+                    }
+                    for (h in range64(2l)) {   // qh bytes verbatim, row-interleaved by 4-byte columns
+                        for (jj in range64(8l)) {
+                            for (t in range64(4l)) {
+                                kq[dq + 128l * mr + ((h * 8l + jj) * mr + r) * 4l + t] = tqp[sq + 128l + h * 32l + jj * 4l + t]
+                            }
+                        }
+                    }
+                    for (idx in range64(16l)) {
+                        ks[ds + idx * mr + r] = tsp[ss + idx]
+                    }
+                    ks[ds + 16l * mr + 2l * r] = tsp[ss + 16l]
+                    ks[ds + 16l * mr + 2l * r + 1l] = tsp[ss + 17l]
+                }
+            }
+        }
+    }
+    delete tq
+    delete ts
+}
+
+// the backend kq repack slot: same layout companion as the Q8/mx4 repacks — one stamped mr
+def private repack_kq_gen(fmt : int; var kq : uint8?; var ks : uint8?; n, d : int64) {
+    if (fmt == 4) {
+        repack_k4_grp(kq, ks, n, d, int64(q8q8_layout_gen()))
+    } elif (fmt == 5) {
+        repack_k5_grp(kq, ks, n, d, int64(q8q8_layout_gen()))
+    } else {
+        repack_k6_grp(kq, ks, n, d, int64(q8q8_layout_gen()))
+    }
 }
 
 //! Generic grp<mr> single-token dot for the mr != 4 slots and tails: scalar, correct
@@ -780,6 +1086,36 @@ def private mx4q8_groupn_gen(var yp : float?; wn : uint8 const?; we : uint8 cons
     }
 }
 
+// mm_kq slot: the K-quant twin of q8q8_kernel_gen/mx4q8_kernel_gen — group chunks handed to
+// the stamped kq rows core for the format, row tail (d % mr) row-major via the portable dots
+// (tail rows stay disk-order in the repack)
+def private kq_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    let nsb = n / 256l
+    let mr = int64(q8q8_layout_gen())
+    let ng = d / mr
+    var myp = yp
+    maybe_parallel_for(0, int(ng), matmul_chunks_gemv(int(ng * mr), get_q8_batch_chunks_per_job(), n * d)) $(rb, re) {
+        if (fmt == 4) {
+            k4q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
+        } elif (fmt == 5) {
+            k5q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
+        } else {
+            k6q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
+        }
+    }
+    unsafe {
+        for (i in range64(ng * mr, d)) {
+            if (fmt == 4) {
+                myp[i] = dot_k4q8(kqp + i * nsb * 128l, ksp + i * nsb * 32l, xqp, xsp, xbsp, n)
+            } elif (fmt == 5) {
+                myp[i] = dot_k5q8(kqp + i * nsb * 160l, ksp + i * nsb * 32l, xqp, xsp, xbsp, n)
+            } else {
+                myp[i] = dot_k6q8(kqp + i * nsb * 192l, ksp + i * nsb * 18l, xqp, xsp, xbsp, n)
+            }
+        }
+    }
+}
+
 // ===== f16-scale twins (the wscale_f16 rail): the same slot traversals over the binary16
 // group-scale plane — generated cores via the s16 companions, row-major tails via
 // dot_q8q8_f16s, token tails via the s16 rows core (no laneq fork needed: the generated
@@ -1073,6 +1409,9 @@ def dasllama_math_gen_register() {
             mm_s16 = @@q8q8_kernel_s16_gen, batch_s16 = @@q8q8_batch_kernel_s16_gen,
             group3_s16 = @@q8q8_group3_s16_gen, groupn_s16 = @@q8q8_groupn_s16_gen,
             mm_rows_s16 = @@q8q8_gemv_s16_gen,
+            mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
+            kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
+            kq_rows_k6 = @@k6q8_gemv_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, q8_wbias = @@q8q8_wbias_gen,
             q8_kgroup = @@q8q8_kgroup_gen,

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -240,6 +240,49 @@ def k6q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp :
     }
 }
 
+//! The K-quant TILE companions (the kq batch family): 4 tokens x mr rows per call over the
+//! grp<mr> kq planes — kqg/ksg are the GROUP plane bases (the batch wrapper offsets per
+//! group), activations an [ntok x n] image with per-token scale/bsum rows. The generated body
+//! unpacks each weight vector once per superblock and dots it against all 4 tokens
+//! (weight-stationary — the prefill fix for the serial per-position GEMVs); one call is
+//! bit-exact vs 4 per-token GEMVs. Reference bodies = per-token scalar grp walks, declining
+//! in lockstep via the shared predicate. Not `private`: called from lifted worker lambdas.
+[hint(unsafe_range_check, noalias = kqg, noalias = ksg, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def k4q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, g, t0 : int64) : void {
+    let mr = int64(q8q8_layout_gen())
+    unsafe {
+        for (t in range64(4l)) {
+            for (r in range64(mr)) {
+                yp[(t0 + t) * d + g * mr + r] = kq_grp_row_dot(4l, kqg, ksg, r, mr, xqp + (t0 + t) * n, xsp + (t0 + t) * (n / 32l), xbsp + (t0 + t) * (n / 16l), n)
+            }
+        }
+    }
+}
+
+[hint(unsafe_range_check, noalias = kqg, noalias = ksg, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def k5q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, g, t0 : int64) : void {
+    let mr = int64(q8q8_layout_gen())
+    unsafe {
+        for (t in range64(4l)) {
+            for (r in range64(mr)) {
+                yp[(t0 + t) * d + g * mr + r] = kq_grp_row_dot(5l, kqg, ksg, r, mr, xqp + (t0 + t) * n, xsp + (t0 + t) * (n / 32l), xbsp + (t0 + t) * (n / 16l), n)
+            }
+        }
+    }
+}
+
+[hint(unsafe_range_check, noalias = kqg, noalias = ksg, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def k6q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, g, t0 : int64) : void {
+    let mr = int64(q8q8_layout_gen())
+    unsafe {
+        for (t in range64(4l)) {
+            for (r in range64(mr)) {
+                yp[(t0 + t) * d + g * mr + r] = kq_grp_row_dot(6l, kqg, ksg, r, mr, xqp + (t0 + t) * n, xsp + (t0 + t) * (n / 32l), xbsp + (t0 + t) * (n / 16l), n)
+            }
+        }
+    }
+}
+
 //! The f16-scale GEMV companion (the wscale_f16 rail): q8q8_gemv_gen's twin over the raw
 //! binary16 group-scale plane (Model.qscales16 — the repacked f32 plane, converted in place,
 //! element order preserved). Same rows-range contract; the generated body differs only in the
@@ -335,6 +378,9 @@ def q8q8_tile_s16_gen(var yp : float?; wg : int8 const?; sg : uint16 const?; xqp
  tune_companion(fn = "k4q8_gemv_gen", gen = "dasllama_gemm_gen::k4_gemv"),
  tune_companion(fn = "k5q8_gemv_gen", gen = "dasllama_gemm_gen::k5_gemv"),
  tune_companion(fn = "k6q8_gemv_gen", gen = "dasllama_gemm_gen::k6_gemv"),
+ tune_companion(fn = "k4q8_tile_gen", gen = "dasllama_gemm_gen::k4_tile"),
+ tune_companion(fn = "k5q8_tile_gen", gen = "dasllama_gemm_gen::k5_tile"),
+ tune_companion(fn = "k6q8_tile_gen", gen = "dasllama_gemm_gen::k6_tile"),
  tune_companion(fn = "q8q8_family_live", gen = "dasllama_gemm_gen::q8q8_witness"),
  tune(gen = "dasllama_gemm_gen::q8q8_tile",
       fallback = "dot_vpdpbusd_width512_mr16_kstep2_gkstep2_bias128;dot_vpdpbusd_width256_mr8_kstep2_gkstep2_bias128;dot_maddubs_width256_mr8_kstep2;kstep2"), unused_argument(xbsp),
@@ -1116,6 +1162,78 @@ def private kq_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : 
     }
 }
 
+// one (group range x token range) cell of the kq batch walk: TB token blocks outer, groups
+// inner, 4-token tile calls + per-token gemv tails — the q8 batch cell's shape with ts pinned
+// 4 (the kq tile is the 4-token vector form on every stamp; no TMUL kq tile exists, so the
+// amx tokstep never applies)
+def private kq_batch_cell_gen(fmt : int; var myp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, mr, TB : int64; ub, ue : int; tb0, tend : int64) {
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    let nb32 = n / 32l
+    let nb16 = n / 16l
+    unsafe {
+        var tb = tb0
+        while (tb < tend) {
+            let tbe = min(tb + TB, tend)
+            let tb4 = tb + ((tbe - tb) / 4l) * 4l
+            for (gi in range(ub, ue)) {
+                let g = int64(gi)
+                let kqg = kqp + g * mr * nsb * qsb
+                let ksg = ksp + g * mr * nsb * ssb
+                var tk = tb
+                while (tk < tb4) {
+                    if (fmt == 4) {
+                        k4q8_tile_gen(myp, kqg, ksg, xqp, xsp, xbsp, n, d, g, tk)
+                    } elif (fmt == 5) {
+                        k5q8_tile_gen(myp, kqg, ksg, xqp, xsp, xbsp, n, d, g, tk)
+                    } else {
+                        k6q8_tile_gen(myp, kqg, ksg, xqp, xsp, xbsp, n, d, g, tk)
+                    }
+                    tk += 4l
+                }
+                while (tk < tbe) {   // token tail (< 4): the rows core, one position
+                    if (fmt == 4) {
+                        k4q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * nb32, xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
+                    } elif (fmt == 5) {
+                        k5q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * nb32, xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
+                    } else {
+                        k6q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * nb32, xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
+                    }
+                    tk++
+                }
+            }
+            tb += TB
+        }
+    }
+}
+
+// kq_batch slot: batched K-quant GEMM over the repacked planes — group chunks parallel, the
+// cell walk above per chunk, row tails (d % mr) disk-order per token via the portable dots
+def private kq_batch_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, ntok : int64) {
+    let nsb = n / 256l
+    let mr = int64(q8q8_layout_gen())
+    let ng = d / mr
+    var myp = yp
+    let TB = effective_token_block(g_q8_token_block, n)
+    maybe_parallel_for(0, int(ng), matmul_chunks_gemv(int(ng * mr), get_q8_batch_chunks_per_job(), n * d * ntok)) $(ub, ue) {
+        kq_batch_cell_gen(fmt, myp, kqp, ksp, xqp, xsp, xbsp, n, d, mr, TB, ub, ue, 0l, ntok)
+    }
+    unsafe {
+        for (tk in range64(ntok)) {
+            for (i in range64(ng * mr, d)) {
+                if (fmt == 4) {
+                    myp[tk * d + i] = dot_k4q8(kqp + i * nsb * 128l, ksp + i * nsb * 32l, xqp + tk * n, xsp + tk * (n / 32l), xbsp + tk * (n / 16l), n)
+                } elif (fmt == 5) {
+                    myp[tk * d + i] = dot_k5q8(kqp + i * nsb * 160l, ksp + i * nsb * 32l, xqp + tk * n, xsp + tk * (n / 32l), xbsp + tk * (n / 16l), n)
+                } else {
+                    myp[tk * d + i] = dot_k6q8(kqp + i * nsb * 192l, ksp + i * nsb * 18l, xqp + tk * n, xsp + tk * (n / 32l), xbsp + tk * (n / 16l), n)
+                }
+            }
+        }
+    }
+}
+
 // ===== f16-scale twins (the wscale_f16 rail): the same slot traversals over the binary16
 // group-scale plane — generated cores via the s16 companions, row-major tails via
 // dot_q8q8_f16s, token tails via the s16 rows core (no laneq fork needed: the generated
@@ -1411,7 +1529,7 @@ def dasllama_math_gen_register() {
             mm_rows_s16 = @@q8q8_gemv_s16_gen,
             mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
             kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
-            kq_rows_k6 = @@k6q8_gemv_gen,
+            kq_rows_k6 = @@k6q8_gemv_gen, kq_batch = @@kq_batch_kernel_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, q8_wbias = @@q8q8_wbias_gen,
             q8_kgroup = @@q8q8_kgroup_gen,

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -1234,6 +1234,54 @@ def private kq_batch_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
     }
 }
 
+// kq_groupn slot: region-list kq GEMV — the kq twin of q8q8_groupn_gen. Region-contiguous
+// group spans through the fmt's rows core (each region offsets the plane bases by its own
+// superblock), row tails (d % mr) disk-order per region like kq_kernel_gen's. Not `private`:
+// the groupn bit-exactness gate in test_kquant drives it directly over per-region grp slices.
+def kq_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    let mr = int64(q8q8_layout_gen())
+    let ng = d / mr
+    var myp = yp
+    maybe_parallel_for(0, int(nregions * ng), matmul_chunks_gemv(int(nregions * ng * mr), get_q8_batch_chunks_per_job(), n * d * nregions)) $(gb, ge) {
+        unsafe {
+            var gg = int64(gb)
+            while (gg < int64(ge)) {
+                let r = gg / ng
+                let gLocal = gg % ng
+                let gEnd = min(int64(ge) - r * ng, ng)
+                let sb = offs[r * 2l] / 256l
+                let xoff = offs[r * 2l + 1l]
+                if (fmt == 4) {
+                    k4q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
+                } elif (fmt == 5) {
+                    k5q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
+                } else {
+                    k6q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
+                }
+                gg = r * ng + gEnd
+            }
+        }
+    }
+    unsafe {
+        for (r in range64(nregions)) {   // row tails (d % mr): disk-order per region
+            let sb = offs[r * 2l] / 256l
+            let xoff = offs[r * 2l + 1l]
+            for (i in range64(ng * mr, d)) {
+                if (fmt == 4) {
+                    myp[r * d + i] = dot_k4q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n)
+                } elif (fmt == 5) {
+                    myp[r * d + i] = dot_k5q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n)
+                } else {
+                    myp[r * d + i] = dot_k6q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 32l, xbsp + xoff / 16l, n)
+                }
+            }
+        }
+    }
+}
+
 // ===== f16-scale twins (the wscale_f16 rail): the same slot traversals over the binary16
 // group-scale plane — generated cores via the s16 companions, row-major tails via
 // dot_q8q8_f16s, token tails via the s16 rows core (no laneq fork needed: the generated
@@ -1530,6 +1578,7 @@ def dasllama_math_gen_register() {
             mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
             kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
             kq_rows_k6 = @@k6q8_gemv_gen, kq_batch = @@kq_batch_kernel_gen,
+            kq_groupn = @@kq_groupn_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, q8_wbias = @@q8q8_wbias_gen,
             q8_kgroup = @@q8q8_kgroup_gen,

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -1605,6 +1605,13 @@ def dasllama_math_gen_register() {
             mm_s16 = @@q8q8_kernel_s16_gen, batch_s16 = @@q8q8_batch_kernel_s16_gen,
             group3_s16 = @@q8q8_group3_s16_gen, groupn_s16 = @@q8q8_groupn_s16_gen,
             mm_rows_s16 = @@q8q8_gemv_s16_gen,
+            // kq family: the emitters are generic-IR unpacks over kq_dot_lane, which rides the
+            // NEON sdot lattice here — decline lockstep with the q8 family (same perm rails), so
+            // the no-witness stance above covers kq too
+            mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
+            kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
+            kq_rows_k6 = @@k6q8_gemv_gen, kq_batch = @@kq_batch_kernel_gen,
+            kq_groupn = @@kq_groupn_gen, kq_batch_groupn = @@kq_batch_groupn_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, q8_wbias = @@q8q8_wbias_gen,
             q8_kgroup = @@q8q8_kgroup_gen))

--- a/modules/dasLLAMA/dasllama/dasllama_quant.das
+++ b/modules/dasLLAMA/dasllama/dasllama_quant.das
@@ -94,6 +94,56 @@ def template quantize_q8_0_into_ptr_template(src : float const ?; n : int64; var
 [hint(noalias = src, noalias = qdst, noalias = sdst), tuned(fallback = "plain")]
 def quantize_q8_0_into_ptr(src : float const?; n : int64; var qdst : int8?; var sdst : float?; qoff, soff : int64) {}
 
+//! quantize_q8_0_into + per-16 block sums: bdst[boff + i/16] = sum of the 16 int8 quants.
+//! The K-quant dot's offset term is o*(sum of activation quants) per weight sub-block (16 for
+//! Q6_K, pairs of 16 for Q4_K/Q5_K), so the activation quantizer emits the sums in one pass.
+//! Quants and scales are bit-identical to quantize_q8_0_into. n must be a multiple of 32.
+def quantize_q8_0_bs_into(src : array<float> | #; n : int64; var qdst : array<int8>; var sdst : array<float>; var bdst : array<int>; qoff, soff, boff : int64) {
+    assert(n % QK8 == 0l, "quantize_q8_0_bs_into requires n to be a multiple of 32")
+    quantize_q8_0_bs_into_ptr(unsafe(addr(src[0])), n, unsafe(addr(qdst[0])), unsafe(addr(sdst[0])), unsafe(addr(bdst[0])), qoff, soff, boff)
+}
+
+[hint(noalias = src, noalias = qdst, noalias = sdst, noalias = bdst)]
+def template quantize_q8_0_bs_into_ptr_template(src : float const ?; n : int64; var qdst : int8 ?; var sdst : float ?; var bdst : int ?; qoff, soff, boff : int64) : void {
+    let nblocks = n / QK8
+    unsafe {
+        let p4 = reinterpret<float4 const?>(src)
+        for (b in range64(nblocks)) {
+            let base = b * QK8
+            // amax reduction: same hand-vectorized two-lane shape as quantize_q8_0_into_ptr_template
+            let f4 = base / 4l
+            var m0 = abs(p4[f4])
+            var m1 = abs(p4[f4 + 1l])
+            for (k in range64(1l, 4l)) {
+                m0 = max(m0, abs(p4[f4 + 2l * k]))
+                m1 = max(m1, abs(p4[f4 + 2l * k + 1l]))
+            }
+            let m = max(m0, m1)
+            let amax = max(max(m.x, m.y), max(m.z, m.w))
+            let d = amax / 127.0
+            let id = d != 0.0 ? 1.0 / d : 0.0
+            sdst[soff + b] = d
+            for [tune = 1] (i in range64(QK8)) {
+                qdst[qoff + base + i] = int8(round(src[base + i] * id))
+            }
+            // per-16 sums of the just-stored quants (L1-hot); plain loop — 16 int8 adds is not
+            // the kernel's cost, the fp32 read above is
+            for (h in range64(2l)) {
+                var bs = 0
+                let hb = qoff + base + h * 16l
+                for (i in range64(16l)) {
+                    bs += int(qdst[hb + i])
+                }
+                bdst[boff + b * 2l + h] = bs
+            }
+        }
+    }
+}
+
+//! Pointer core of quantize_q8_0_bs_into (see there); fork-context callers thread raw addresses.
+[hint(noalias = src, noalias = qdst, noalias = sdst, noalias = bdst), tuned(fallback = "plain")]
+def quantize_q8_0_bs_into_ptr(src : float const?; n : int64; var qdst : int8?; var sdst : float?; var bdst : int?; qoff, soff, boff : int64) {}
+
 //! Dequantize Q8_0 back to fp32 in place: dst[i] = q[i] * scales[i / 32]. The exact
 //! reference the dequant-in-dot kernel must reproduce, and the input to the fp32 forward
 //! when measuring end-to-end quantization loss. dst must be pre-sized to qt.n.

--- a/modules/dasLLAMA/harness/flash_stage2_probe.das
+++ b/modules/dasLLAMA/harness/flash_stage2_probe.das
@@ -1,0 +1,223 @@
+options gen2
+options persistent_heap
+options _jit_fast_math = true   // match the engine config the trace numbers came from
+
+// Flash-decode stage-2 mechanism probe (30B emission investigation): the traced kv-partials
+// stage runs ~118us/chain at d544 vs ~40us byte-bound, format-independent (q8 KV barely moves
+// it) — so the cost is in the per-(pos, head) work structure, not the KV bytes. This isolates
+// the production nesting (8 small dot()/axpy() calls per position, one per GQA head) against a
+// fused 8-head walk (K/V row loaded once per j-step, 8 accumulators) and a stream-only floor,
+// on the exact 30B decode geometry. Single thread — per-lane kernel cost, no dispatch.
+//   bin/daslang -jit modules/dasLLAMA/harness/flash_stage2_probe.das
+
+require dasllama/dasllama_math
+require dasllama/dasllama_math_default
+require daslib/jobque_boost
+require math
+
+let HS = 128l          // head_size
+let KV_MUL = 8l        // q heads per kv head (GQA-8)
+let NKVH = 4l          // kv heads
+let KV_DIM = 512l      // NKVH * HS
+let NQH = 32l          // q heads
+let CNT = 544l         // window positions (d512 decode window mid-point)
+let SLICE = 32l        // FLASH_DECODE_SLICE_LEN
+let SEQ = 2048l        // att row stride (config.seq_len)
+let NL = 24l           // layer-slab rotation (2x26.7MB streams: defeats LLC between rounds)
+let ROUNDS = 5
+
+def private fill(var a : array<float>; n : int64; seed : float) {
+    a |> resize(int(n))
+    for (i in range64(n)) {
+        a[i] = sin(float(i) * 0.017 + seed) * 0.5
+    }
+}
+
+// Variant A — the production kv_slice_scores/kv_slice_av nesting: per position, kv_mul small
+// dot()/axpy() calls (one per q head of the group); K/V row re-read per head (L1-hot).
+def private stage2_calls(kp, vp, qp : float const?; var attp : float?; var flop : float?; nsl : int64) {
+    unsafe {
+        for (u in range64(NKVH * nsl)) {
+            let kvh = u / nsl
+            let sl = u % nsl
+            let kvhoff = kvh * HS
+            let qh0 = kvh * KV_MUL
+            let j0 = sl * SLICE
+            let j1 = min(j0 + SLICE, CNT)
+            for (j in range64(j0, j1)) {
+                let koff = j * KV_DIM + kvhoff
+                for (g in range64(KV_MUL)) {
+                    attp[(qh0 + g) * SEQ + j] = dot(qp + (qh0 + g) * HS, kp + koff, HS) * 0.088388
+                }
+            }
+            for (g in range64(KV_MUL)) {
+                let hh = qh0 + g
+                var op = flop + (hh * nsl + sl) * HS
+                for (i in range64(HS)) {
+                    op[i] = 0.0
+                }
+            }
+            for (j in range64(j0, j1)) {
+                let voff = j * KV_DIM + kvhoff
+                for (g in range64(KV_MUL)) {
+                    let hh = qh0 + g
+                    axpy(flop + (hh * nsl + sl) * HS, vp + voff, attp[hh * SEQ + j], HS)
+                }
+            }
+        }
+    }
+}
+
+// Variant B — fused 8-head walk: K row streamed ONCE per j-quad into 8 float4 accumulator
+// chains (no per-head call, no per-head hsum until the row ends); V pass accumulates all 8
+// partials off one V row read. Same flops, same reads at L1 level — isolates call/hsum/loop
+// structure. Fold order differs from dot() (tolerance-compared, fast-math anyway).
+def private stage2_fused(kp, vp, qp : float const?; var attp : float?; var flop : float?; nsl : int64) {
+    unsafe {
+        for (u in range64(NKVH * nsl)) {
+            let kvh = u / nsl
+            let sl = u % nsl
+            let kvhoff = kvh * HS
+            let qh0 = kvh * KV_MUL
+            let j0 = sl * SLICE
+            let j1 = min(j0 + SLICE, CNT)
+            let q4 = reinterpret<float4 const?>(qp + qh0 * HS)   // 8 contiguous head rows
+            for (j in range64(j0, j1)) {
+                let k4 = reinterpret<float4 const?>(kp + j * KV_DIM + kvhoff)
+                var a0 = float4(0.0)
+                var a1 = float4(0.0)
+                var a2 = float4(0.0)
+                var a3 = float4(0.0)
+                var a4 = float4(0.0)
+                var a5 = float4(0.0)
+                var a6 = float4(0.0)
+                var a7 = float4(0.0)
+                let hq = HS / 4l
+                for (c in range64(hq)) {
+                    let kv = k4[c]
+                    a0 += kv * q4[c]
+                    a1 += kv * q4[hq + c]
+                    a2 += kv * q4[2l * hq + c]
+                    a3 += kv * q4[3l * hq + c]
+                    a4 += kv * q4[4l * hq + c]
+                    a5 += kv * q4[5l * hq + c]
+                    a6 += kv * q4[6l * hq + c]
+                    a7 += kv * q4[7l * hq + c]
+                }
+                attp[(qh0 + 0l) * SEQ + j] = (a0.x + a0.y + a0.z + a0.w) * 0.088388
+                attp[(qh0 + 1l) * SEQ + j] = (a1.x + a1.y + a1.z + a1.w) * 0.088388
+                attp[(qh0 + 2l) * SEQ + j] = (a2.x + a2.y + a2.z + a2.w) * 0.088388
+                attp[(qh0 + 3l) * SEQ + j] = (a3.x + a3.y + a3.z + a3.w) * 0.088388
+                attp[(qh0 + 4l) * SEQ + j] = (a4.x + a4.y + a4.z + a4.w) * 0.088388
+                attp[(qh0 + 5l) * SEQ + j] = (a5.x + a5.y + a5.z + a5.w) * 0.088388
+                attp[(qh0 + 6l) * SEQ + j] = (a6.x + a6.y + a6.z + a6.w) * 0.088388
+                attp[(qh0 + 7l) * SEQ + j] = (a7.x + a7.y + a7.z + a7.w) * 0.088388
+            }
+            for (g in range64(KV_MUL)) {
+                var op = reinterpret<float4?>(flop + ((qh0 + g) * nsl + sl) * HS)
+                for (c in range64(HS / 4l)) {
+                    op[c] = float4(0.0)
+                }
+            }
+            for (j in range64(j0, j1)) {
+                let v4 = reinterpret<float4 const?>(vp + j * KV_DIM + kvhoff)
+                for (g in range64(KV_MUL)) {
+                    let hh = qh0 + g
+                    let w = attp[hh * SEQ + j]
+                    var op = reinterpret<float4?>(flop + (hh * nsl + sl) * HS)
+                    for (c in range64(HS / 4l)) {
+                        op[c] += v4[c] * w
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Variant C — stream floor: touch every K/V byte of the window once, minimal ALU.
+def private stage2_stream(kp, vp : float const?; var sink : float&) {
+    unsafe {
+        var s = float4(0.0)
+        let k4 = reinterpret<float4 const?>(kp)
+        let v4 = reinterpret<float4 const?>(vp)
+        for (c in range64(CNT * KV_DIM / 4l)) {
+            s += k4[c] + v4[c]
+        }
+        sink += s.x + s.y + s.z + s.w
+    }
+}
+
+[export]
+def main() {
+    if (!jit_enabled()) {
+        print("JIT-only probe — run with: daslang -jit <file>\n")
+        return
+    }
+    let nsl = (CNT + SLICE - 1l) / SLICE
+    var k : array<float>
+    var v : array<float>
+    var q : array<float>
+    var att : array<float>
+    var flop : array<float>
+    fill(k, NL * CNT * KV_DIM, 0.1)
+    fill(v, NL * CNT * KV_DIM, 0.7)
+    fill(q, NQH * HS, 1.3)
+    att |> resize(int(NQH * SEQ))
+    flop |> resize(int(NQH * nsl * HS))
+    var att2 : array<float>
+    var flop2 : array<float>
+    att2 |> resize(int(NQH * SEQ))
+    flop2 |> resize(int(NQH * nsl * HS))
+
+    let kvbytes = CNT * KV_DIM * 4l * 2l   // K+V per layer-window
+    print("geometry: cnt={CNT} kv_dim={KV_DIM} kv_mul={KV_MUL} nsl={nsl} | {NL} slabs x {kvbytes / 1024l}KB KV\n")
+
+    unsafe {
+        var qp = reinterpret<float const?>(addr(q[0]))
+        var attp = addr(att[0])
+        var flp = addr(flop[0])
+        var attp2 = addr(att2[0])
+        var flp2 = addr(flop2[0])
+        // correctness: A vs B on slab 0 (fold order differs — tolerance)
+        stage2_calls(addr(k[0]), addr(v[0]), qp, attp, flp, nsl)
+        stage2_fused(addr(k[0]), addr(v[0]), qp, attp2, flp2, nsl)
+        var worst = 0.0
+        for (h in range64(NQH)) {
+            for (j in range64(CNT)) {
+                worst = max(worst, abs(att[h * SEQ + j] - att2[h * SEQ + j]))
+            }
+        }
+        var worstf = 0.0
+        for (i in range64(NQH * nsl * HS)) {
+            worstf = max(worstf, abs(flop[i] - flop2[i]))
+        }
+        print("A-vs-B worst |att| diff {worst}, worst |partial| diff {worstf} (fast-math fold tolerance)\n")
+
+        var sink = 0.0
+        for (vr in range(3)) {
+            var best = 1.0e18lf
+            for (_r in range(ROUNDS)) {
+                let t0 = ref_time_ticks()
+                for (l in range64(NL)) {
+                    let kb = addr(k[0]) + l * CNT * KV_DIM
+                    let vb = addr(v[0]) + l * CNT * KV_DIM
+                    if (vr == 0) {
+                        stage2_calls(kb, vb, qp, attp, flp, nsl)
+                    } elif (vr == 1) {
+                        stage2_fused(kb, vb, qp, attp, flp, nsl)
+                    } else {
+                        stage2_stream(kb, vb, sink)
+                    }
+                }
+                let us = double(get_time_usec(t0))
+                best = min(best, us)
+            }
+            let per_layer = best / double(NL)
+            let ns_pos = per_layer * 1000.0lf / double(CNT)
+            let gbs = double(NL * kvbytes) / (best * 1.0e-6lf) / (1024.0lf * 1024.0lf * 1024.0lf)
+            let name = vr == 0 ? "A per-head dot/axpy calls" : (vr == 1 ? "B fused 8-head walk     " : "C stream floor          ")
+            print("{name}: {per_layer}us/window  {ns_pos}ns/pos  {gbs}GB/s effective\n")
+        }
+        print("sink {sink}\n")
+    }
+}

--- a/modules/dasLLAMA/harness/kv_range_probe.das
+++ b/modules/dasLLAMA/harness/kv_range_probe.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration
 require dasllama/dasllama_math   // setup_dasllama_jobque_

--- a/modules/dasLLAMA/harness/mem.das
+++ b/modules/dasLLAMA/harness/mem.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
 

--- a/modules/dasLLAMA/harness/parity.das
+++ b/modules/dasLLAMA/harness/parity.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
 require daslib/jobque_boost

--- a/modules/dasLLAMA/harness/parity.das
+++ b/modules/dasLLAMA/harness/parity.das
@@ -39,6 +39,9 @@ struct Args {
     @clarg_doc = "KV cache dtype (default: f32)"
     kv : KVDtype = KVDtype.f32
 
+    @clarg_doc = "Native K-quant planes A/B: 1 = keep Q4_K/Q5_K/Q6_K packed at load, 0 = q8-requant fallback, -1 = keep default"
+    kquant_native : int = -1
+
     @clarg_short = "?"
     @clarg_doc = "Show this help and exit"
     help : bool
@@ -69,6 +72,9 @@ def main {
         return
     }
 
+    if (cfg.kquant_native >= 0) {   // load-time layout decision, must precede load_gguf
+        set_kquant_native(cfg.kquant_native != 0)
+    }
     var t <- load_gguf(cfg.model, cfg.quant)
     // Cap the KV context: only ~(prompt + n_gen) positions are used, and native seq_len (Llama-3 /
     // Phi / gemma4: 131072) would waste multi-GB KV allocations. Same cap test_parity.das applies.

--- a/modules/dasLLAMA/harness/parity.sh
+++ b/modules/dasLLAMA/harness/parity.sh
@@ -38,8 +38,11 @@ PROMPT_IDS="$(printf '%s\n' "$REF" | sed -n 's/^PROMPT_IDS: //p')"
 REF_GEN="$(printf '%s\n' "$REF" | sed -n 's/^GEN_IDS: //p')"
 IDS_CSV="$(printf '%s' "$PROMPT_IDS" | tr ' ' ',')"
 
-# 2. dasLLAMA: same prompt ids -> greedy generated ids
-DAS="$("$DASLANG" -jit "$PARITY" -- -m "$MODEL" -n "$N" --quant "$QUANT" --kv "$KV" --ids "$IDS_CSV" 2>/dev/null)"
+# 2. dasLLAMA: same prompt ids -> greedy generated ids. KQ_NATIVE=1/0 (env) A/Bs the native
+# K-quant planes; unset keeps the engine default.
+KQ_FLAG=""
+[ -n "${KQ_NATIVE:-}" ] && KQ_FLAG="--kquant-native $KQ_NATIVE"
+DAS="$("$DASLANG" -jit "$PARITY" -- -m "$MODEL" -n "$N" --quant "$QUANT" --kv "$KV" $KQ_FLAG --ids "$IDS_CSV" 2>/dev/null)"
 DAS_GEN="$(printf '%s\n' "$DAS" | sed -n 's/^GEN_IDS: //p')"
 
 # 3. token-for-token diff

--- a/modules/dasLLAMA/harness/q4k_dequant_compare.py
+++ b/modules/dasLLAMA/harness/q4k_dequant_compare.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Bit-exact oracle for the K-quant dequant (Q4_K / Q6_K) in dasllama_gguf.das.
+# Pairs with q4k_dequant_probe.das:
+#   bin/daslang modules/dasLLAMA/harness/q4k_dequant_probe.das -- <model.gguf> > dump.txt
+#   python modules/dasLLAMA/harness/q4k_dequant_compare.py <model.gguf> dump.txt
+# Compares the das dump against gguf-py's dequantize (an independent implementation of the
+# ggml superblock spec) as raw uint32 bit patterns — exit 0 only on bit-exact agreement.
+# gguf-py location defaults to D:/Work/llama.cpp/gguf-py; override with LLAMA_CPP_DIR.
+
+import os
+import sys
+
+import numpy as np
+
+llama_cpp = os.environ.get("LLAMA_CPP_DIR", r"D:\Work\llama.cpp")
+sys.path.insert(0, os.path.join(llama_cpp, "gguf-py"))
+from gguf import GGUFReader
+from gguf.quants import dequantize
+
+gguf_path = sys.argv[1]
+dump_path = sys.argv[2]
+
+# parse the das dump: "TENSOR <name> <n> type <t>" followed by n hex bit patterns, one per line
+sections = {}
+with open(dump_path) as f:
+    vals = None
+    for line in f:
+        line = line.strip()
+        if line.startswith("TENSOR"):
+            vals = []
+            sections[line.split()[1]] = vals
+        elif line:
+            vals.append(int(line, 16))
+ours = {k: np.array(v, dtype=np.uint32).view(np.float32) for k, v in sections.items()}
+
+r = GGUFReader(gguf_path)
+by_name = {t.name: t for t in r.tensors}
+fail = 0
+for name, mine in ours.items():
+    t = by_name[name]
+    ref = dequantize(t.data, t.tensor_type).reshape(-1)[: len(mine)].astype(np.float32)
+    if np.array_equal(mine.view(np.uint32), ref.view(np.uint32)):
+        print(f"{name}: BIT-EXACT over {len(mine)} values ({t.tensor_type.name})")
+    else:
+        bad = mine.view(np.uint32) != ref.view(np.uint32)
+        idx = int(np.argmax(bad))
+        print(f"{name}: MISMATCH {int(bad.sum())}/{len(mine)} values, "
+              f"first at {idx}: ours {mine[idx]} ref {ref[idx]}")
+        fail = 1
+sys.exit(fail)

--- a/modules/dasLLAMA/harness/q4k_dequant_probe.das
+++ b/modules/dasLLAMA/harness/q4k_dequant_probe.das
@@ -1,0 +1,43 @@
+options gen2
+
+require daslib/fio
+require dasllama/dasllama_gguf
+require strings
+
+// K-quant dequant oracle probe: dump the fp32 expansion of Q4_K / Q6_K tensor prefixes as raw
+// bit patterns (one uint per line), for bit-exact comparison against gguf-py's dequantize.
+//
+// Usage: bin/daslang modules/dasLLAMA/harness/q4k_dequant_probe.das -- <path-to.gguf> > dump.txt
+// Compare: python modules/dasLLAMA/harness/q4k_dequant_compare.py <path-to.gguf> dump.txt
+
+def dump_tensor(m : GGUFMeta; bytes : array<uint8>#; name : string; n : int64) {
+    var dst : array<float>
+    dst |> resize(n)
+    gguf_read_tensor_f32(m, bytes, name, dst, 0l, n)
+    print("TENSOR {name} {n} type {gguf_tensor_type(m, name)}\n")
+    for (v in dst) {
+        print("{unsafe(reinterpret<uint>(v))}\n")
+    }
+    delete dst
+}
+
+[export]
+def main {
+    var path = "D:/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.requant.gguf"
+    let args = get_command_line_arguments()
+    if (!empty(args)) {
+        path = args[length(args) - 1]
+    }
+    let f = fopen(path, "rb")
+    if (f == null) {
+        panic("cannot open {path}")
+    }
+    fmap(f) $(var bytes : array<uint8>#) {
+        var m <- parse_gguf_meta(bytes)
+        dump_tensor(m, bytes, "blk.0.attn_q.weight", 256l * 256l)   // Q4_K
+        dump_tensor(m, bytes, "blk.0.attn_v.weight", 256l * 256l)   // Q6_K
+        dump_tensor(m, bytes, "token_embd.weight", 256l * 256l)     // Q6_K (tied cls)
+        delete m
+    }
+    fclose(f)
+}

--- a/modules/dasLLAMA/harness/quant_eval.das
+++ b/modules/dasLLAMA/harness/quant_eval.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
 require dasllama/dasllama_tokenizer

--- a/modules/dasLLAMA/harness/quant_eval_q4.das
+++ b/modules/dasLLAMA/harness/quant_eval_q4.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
 require dasllama/dasllama_tokenizer

--- a/modules/dasLLAMA/harness/tune_confirm_prefill.das
+++ b/modules/dasLLAMA/harness/tune_confirm_prefill.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options persistent_heap
 options _jit_fast_math = true   // production prefill config (prefill_perf parity)
 

--- a/modules/dasLLAMA/harness/tune_kernels.das
+++ b/modules/dasLLAMA/harness/tune_kernels.das
@@ -51,6 +51,8 @@ struct GridDotQ8Q8 {}
 struct GridDotMx4Q8 {}
 [dasllama_grid(src = "quantize_q8_0_into_ptr_template")]
 struct GridQuant {}
+[dasllama_grid(src = "quantize_q8_0_bs_into_ptr_template")]
+struct GridQuantBs {}
 [dasllama_grid(src = "rope_scaled_neox_tab_template")]
 struct GridRopeTab {}
 [dasllama_grid(src = "gemm_f32_uk_4x16_template")]
@@ -1371,6 +1373,89 @@ def bench_quantize() : string {
     return report("quantize_q8_0_into_ptr", names, best, ok, "plain")
 }
 
+// quantize + per-16 block sums (the K-quant activation pass): quants/scales must be byte-identical
+// to quantize_q8_0, sums exactly the integer sums of those quants.
+def bench_quantize_bs() : string {
+    let vs <- quantize_q8_0_bs_into_ptr_template_variants()
+    let nv = length(vs)
+    var src : array<float>
+    src |> resize(int(N))
+    for (i in range(int(N))) {
+        src[i] = 2.0f * sin(float(i) * 0.13f)
+    }
+    let want <- quantize_q8_0(src, N)
+    var wantbs : array<int>
+    wantbs |> resize(int(N / 16l))
+    for (h in range(int(N / 16l))) {
+        var bs = 0
+        for (i in range(16)) {
+            bs += int(want.q[h * 16 + i])
+        }
+        wantbs[h] = bs
+    }
+    var qdst : array<int8>
+    var sdst : array<float>
+    var bdst : array<int>
+    qdst |> resize(int(N))
+    sdst |> resize(int(N / 32l))
+    bdst |> resize(int(N / 16l))
+    let srcp = unsafe(addr(src[0]))
+    var qp = unsafe(addr(qdst[0]))
+    var sp = unsafe(addr(sdst[0]))
+    var bp = unsafe(addr(bdst[0]))
+
+    var names : array<string>
+    var ok : array<bool>
+    var best : array<double>
+    names |> resize(nv)
+    ok |> resize(nv)
+    best |> resize(nv)
+    for (i in range(nv)) {
+        names[i] = vs[i]._0
+        best[i] = 1.0e30lf
+        let f = vs[i]._1
+        invoke(f, srcp, N, qp, sp, bp, 0l, 0l, 0l)
+        var exact = true
+        for (j in range(int(N))) {
+            if (qdst[j] != want.q[j]) {
+                exact = false
+            }
+        }
+        for (b in range(int(N / 32l))) {
+            if (sdst[b] != want.scales[b]) {
+                exact = false
+            }
+        }
+        for (h in range(int(N / 16l))) {
+            if (bdst[h] != wantbs[h]) {
+                exact = false
+            }
+        }
+        ok[i] = exact
+    }
+
+    var sink = 0.0f
+    for (_round in range(ROUNDS)) {
+        for (i in range(nv)) {
+            if (!ok[i]) {
+                continue
+            }
+            let f = vs[i]._1
+            let t0 = ref_time_ticks()
+            for (_rep in range(REPS)) {
+                invoke(f, srcp, N, qp, sp, bp, 0l, 0l, 0l)
+            }
+            let us = double(get_time_usec(t0))
+            if (us < best[i]) {
+                best[i] = us
+            }
+        }
+        sink += sdst[0]
+    }
+    print("  checksum {sink}\n")
+    return report("quantize_q8_0_bs_into_ptr", names, best, ok, "plain")
+}
+
 // ===== rope_scaled_neox_tab: in-place rotation, norm-preserving — timing runs without reset.
 
 def bench_rope_tab() : string {
@@ -1693,6 +1778,7 @@ def main {
     let quantq8kvw = bench_quantize_q8kv_row()
     let dmx4w = bench_dot_mx4q8()
     let quantw = bench_quantize()
+    let quantbsw = bench_quantize_bs()
     let ropew = bench_rope_tab()
     let gemmw = bench_gemm_tile()
     let laneqw = bench_laneq4x4()   // last: it pins the repack backend (sticks until process exit)
@@ -1704,17 +1790,17 @@ def main {
         "add_inplace", "mul_inplace", "scale_inplace", "copy_floats",
         "softmax", "rmsnorm", "dot_q4", "dot_q8q8",
         "dot_q8kv", "dot_q8q8kv", "axpy_q8kv", "cvt_q8kv_to_f32", "quantize_q8kv_row",
-        "dot_mx4q8", "quantize_q8_0_into_ptr",
+        "dot_mx4q8", "quantize_q8_0_into_ptr", "quantize_q8_0_bs_into_ptr",
         "rope_scaled_neox_tab", "gemm_f32_uk_4x16", "dot_q8q8_laneq4x4")
     let kwin = fixed_array(dotw, axpyw, dotf16w, axpyf16w, cvt16w, cvt32w, addw, mulw, scalew, copyw,
         softmaxw, rmsw, dq4w, dq8w,
         dq8kvw, dq8q8kvw, axq8kvw, cvtq8kvw, quantq8kvw,
-        dmx4w, quantw, ropew, gemmw, laneqw)
+        dmx4w, quantw, quantbsw, ropew, gemmw, laneqw)
     let kfall = fixed_array(BASELINE, BASELINE, BASELINE, BASELINE, BASELINE, BASELINE,
         BASELINE, BASELINE, BASELINE, BASELINE,
         BASELINE, "plain", "vec4_u4", "vec16",
         BASELINE, "vec16", BASELINE, BASELINE, "plain",
-        "u2", "plain",
+        "u2", "plain", "plain",
         BASELINE, "u2", "u2")
     var changed = 0
     for (k, w, f in knames, kwin, kfall) {
@@ -1755,7 +1841,7 @@ def main {
         dot_q4 = dq4w, dot_q8q8 = dq8w,
         dot_q8kv = dq8kvw, dot_q8q8kv = dq8q8kvw, axpy_q8kv = axq8kvw,
         cvt_q8kv_to_f32 = cvtq8kvw, quantize_q8kv_row = quantq8kvw,
-        dot_mx4q8 = dmx4w, quantize_q8_0_into_ptr = quantw,
+        dot_mx4q8 = dmx4w, quantize_q8_0_into_ptr = quantw, quantize_q8_0_bs_into_ptr = quantbsw,
         rope_scaled_neox_tab = ropew, gemm_f32_uk_4x16 = gemmw, dot_q8q8_laneq4x4 = laneqw,
         runtime = runtime))
     let js = write_json(profile)

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x3ful   // lattice native lowering: marshal/ctors/converts/fp16 ops (0x3e: lattice tags)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x41ul   // kq maddubs i16 lattice: bounded pair-sum chains, one widen per chain (0x40: kq mem-broadcast)
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -828,6 +828,15 @@ namespace das {
         if ( g_jobQue ) g_jobQue->traceSetTag(tag);
     }
 
+    void jobque_set_thread_priority ( int32_t level, Context *, LineInfoArg * ) {
+        // OS priority of the CALLING thread, JobPriority scale -2 (Minimum) .. 2 (Maximum).
+        // The dispatch caller is load-bearing in team mode — only it publishes chains, so a
+        // descheduled caller idles every lane; JobQue creation runs its thread at High (+1),
+        // this exposes the remaining notch (and the rest of the scale) to scripts.
+        int32_t l = level < -2 ? -2 : (level > 2 ? 2 : level);
+        SetCurrentThreadPriority((JobPriority)l);
+    }
+
     void team_parallel_for_invoke ( int32_t rangeBegin, int32_t rangeEnd, int32_t numChunks, Lambda lambda, Func fn, int32_t lambdaSize, Context * context, LineInfoArg * lineinfo ) {
         if ( !g_jobQue ) context->throw_error_at(lineinfo, "need to be in a 'with_job_que' block, or call create_job_que() first");
         int total = rangeEnd - rangeBegin;
@@ -1488,6 +1497,9 @@ namespace das {
             addExtern<DAS_BIND_FUN(jobque_trace_tag)>(*this, lib,  "jobque_trace_tag",
                 SideEffects::modifyExternal, "jobque_trace_tag")
                     ->args({"tag","context","line"});
+            addExtern<DAS_BIND_FUN(jobque_set_thread_priority)>(*this, lib,  "set_current_thread_priority",
+                SideEffects::modifyExternal, "jobque_set_thread_priority")
+                    ->args({"level","context","line"});
             addExtern<DAS_BIND_FUN(team_parallel_for_invoke)>(*this, lib,  "team_parallel_for_invoke",
                 SideEffects::modifyExternal, "team_parallel_for_invoke")
                     ->args({"range_begin","range_end","num_chunks","lambda","function","lambdaSize","context","line"});

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -156,6 +156,25 @@ namespace das {
 
 #endif
 
+    // Slot -> logical-CPU affinity: fill DISTINCT physical cores first (even logical ids — SMT
+    // siblings are adjacent logical CPUs on Windows/Linux x86), then the odd siblings. Slot 0 is
+    // the que-creating (dispatch caller) thread, workers take slots 1..N. Without this the OS
+    // placement is a lottery: 32 busy lanes on a 32c/64t box sometimes land on 16 cores' SMT
+    // pairs — measured pp512 bimodal 306 vs 199 tok/s on the 3990X. Modes (DAS_JOBQUE_AFFINITY):
+    // 0 = off, 1 = ideal-processor hint (default; scheduler can still migrate under contention),
+    // 2 = hard mask (opt-in — pins survive ambient load but also can't dodge it).
+    static void jobque_apply_affinity_slot ( int slot, int mode ) {
+        if ( mode <= 0 ) return;
+        int hw = static_cast<int>(thread::hardware_concurrency());
+        if ( hw <= 1 ) return;
+        int half = hw / 2;
+        int cpu;
+        if ( half > 0 && slot < half ) cpu = slot * 2;               // distinct cores first
+        else if ( half > 0 && slot < hw ) cpu = (slot - half) * 2 + 1;   // then SMT siblings
+        else cpu = slot % hw;
+        SetCurrentThreadAffinityCpu(cpu, mode >= 2);
+    }
+
     JobQue::JobQue()
         : mSleepMs(1)
         , mShutdown(false)
@@ -170,11 +189,15 @@ namespace das {
         mTeamRankGate = (rankGateEnv != nullptr && atoi(rankGateEnv) != 0) ? 1 : 0;
         const char * eagerExitEnv = getenv("DAS_JOBQUE_TEAM_EAGER_EXIT");   // =0 re-enables the final-barrier spin (see setTeamEagerExit)
         mTeamEagerExit = (eagerExitEnv != nullptr) ? ((atoi(eagerExitEnv) != 0) ? 1 : 0) : 1;
+        const char * affinityEnv = getenv("DAS_JOBQUE_AFFINITY");   // 0 off / 1 ideal-CPU hint (default) / 2 hard mask
+        int affinityMode = affinityEnv ? atoi(affinityEnv) : 1;
         SetCurrentThreadPriority(JobPriority::High);
+        jobque_apply_affinity_slot(0, affinityMode);   // the que creator = the dispatch caller
         for (int j = 0, js = mThreadCount; j < js; j++) {
-            mThreads.emplace_back(make_unique<thread>([this, j]() {
+            mThreads.emplace_back(make_unique<thread>([this, j, affinityMode]() {
                 string thread_name = "JobQue_Job_" + to_string(j);
                 SetCurrentThreadName(thread_name);
+                jobque_apply_affinity_slot(j + 1, affinityMode);
                 job(j);
             }));
         }
@@ -1134,6 +1157,8 @@ namespace das {
         sched_param.sched_priority = platformPriority;
         pthread_setschedparam(pthread_self(), SCHED_OTHER, &sched_param);
     }
+
+    void SetCurrentThreadAffinityCpu ( int, bool ) {}   // no public thread-affinity API on macOS
 }
 
 #elif defined(_MSC_VER)
@@ -1179,6 +1204,12 @@ namespace das {
         }
         SetThreadPriority(GetCurrentThread(), winPriority);
     }
+
+    void SetCurrentThreadAffinityCpu ( int cpu, bool hard ) {
+        if ( cpu < 0 || cpu >= 64 ) return;   // single-group boxes only; >64-CPU groups need PROCESSOR_NUMBER plumbing
+        if ( hard ) SetThreadAffinityMask(GetCurrentThread(), 1ull << cpu);
+        else SetThreadIdealProcessor(GetCurrentThread(), DWORD(cpu));
+    }
 }
 
 #elif defined(__linux__) || defined __HAIKU__
@@ -1201,6 +1232,18 @@ namespace das
         sched_param.sched_priority = platformPriority;
         pthread_setschedparam(pthread_self(), SCHED_OTHER, &sched_param);
     }
+
+#if defined(__HAIKU__)
+    void SetCurrentThreadAffinityCpu ( int, bool ) {}
+#else
+    void SetCurrentThreadAffinityCpu ( int cpu, bool hard ) {
+        if ( !hard ) return;   // linux has no soft "ideal CPU" hint — only the hard-mask mode pins
+        cpu_set_t cs;
+        CPU_ZERO(&cs);
+        CPU_SET(cpu, &cs);
+        pthread_setaffinity_np(pthread_self(), sizeof(cs), &cs);
+    }
+#endif
 }
 
 #else
@@ -1209,6 +1252,7 @@ namespace das
 {
     void SetCurrentThreadName ( const string & ) {}
     void SetCurrentThreadPriority ( JobPriority ) {}
+    void SetCurrentThreadAffinityCpu ( int, bool ) {}
 }
 
 #endif

--- a/tests/dasLLAMA/_model_tier.das
+++ b/tests/dasLLAMA/_model_tier.das
@@ -41,7 +41,7 @@ def model_available(t : T?; path : string) : bool {
         return false
     }
     if (!parity_full_mode() && st.size > LARGE_TIER_BYTES) {
-        t |> skip("{base_name(path)} is large-tier ({st.size / (1024ul * 1024ul * 1024ul)} GB) — set DASLLAMA_PARITY_FULL=1 to run")
+        t |> skip("{base_name(path)} is large-tier ({int64(st.size / (1024ul * 1024ul * 1024ul))} GB) — set DASLLAMA_PARITY_FULL=1 to run")
         return false
     }
     return true

--- a/tests/dasLLAMA/test_arch_registry.das
+++ b/tests/dasLLAMA/test_arch_registry.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 
 require dastest/testing_boost public
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them

--- a/tests/dasLLAMA/test_dispatch_shaping.das
+++ b/tests/dasLLAMA/test_dispatch_shaping.das
@@ -80,8 +80,9 @@ def test_matmul_chunks_batch(t : T?) {
             // roomy rows: the full oversplit want survives
             t |> equal(matmul_chunks(16 * lanes * 8, 4, huge), 4 * lanes, "want = L x oversplit when grain allows")
         }
-        t |> run("tiny rows floor at one chunk (a partial wave beats sub-grain shredding)") @(t : T?) {
-            t |> equal(matmul_chunks(8, 4, huge), 1)
+        t |> run("sub-grain rows still fill the admitted lanes (never underfill L)") @(t : T?) {
+            t |> equal(matmul_chunks(8, 4, huge), min(8, lanes), "1-row chunks; rows < L is the only natural floor")
+            t |> equal(matmul_chunks(16 * (lanes - 1), 4, huge), lanes, "grain-capped below L rounds up to one full wave")
         }
         t |> run("grain off = raw L x oversplit; batch cap bounds L") @(t : T?) {
             set_matmul_min_chunk_rows(0)
@@ -106,7 +107,7 @@ def test_matmul_grid(t : T?) {
         t |> run("knob off (default): 1-D always, x = matmul_chunks") @(t : T?) {
             if (lanes >= 3) {
                 let g = matmul_grid(sunits, 4l, 4, huge, 2048l, 4)
-                t |> equal(g.x, lanes - 1, "starved shape keeps the grain-capped 1-D count")
+                t |> equal(g.x, lanes, "grain-starved shape wave-fills the 1-D count")
                 t |> equal(g.y, 1)
             }
             t |> equal(matmul_grid(4 * lanes * 8, 4l, 4, huge, 2048l, 4).y, 1, "roomy shape 1-D")
@@ -165,12 +166,13 @@ def test_matmul_chunks_gemv(t : T?) {
             t |> equal(matmul_chunks_gemv(64 * lanes, 1, huge), lanes)
             t |> equal(matmul_chunks_gemv(64 * lanes * 4, 8, huge), lanes, "oversplit never exceeds one chunk per lane")
         }
-        t |> run("GEMV grain floors small row counts; wave fill rounds near-full up") @(t : T?) {
+        t |> run("wave fill: grain-capped counts below L round up to one full wave (never underfill)") @(t : T?) {
             if (lanes > 2) {
-                t |> equal(matmul_chunks_gemv(64, 1, huge), 1, "one grain of rows = one chunk")
+                t |> equal(matmul_chunks_gemv(64, 1, huge), min(64, lanes), "sub-grain chunks fill the admitted lanes")
             }
             if (lanes >= 2) {
-                t |> equal(matmul_chunks_gemv(64 * (lanes - 1), 1, huge), lanes, "within half a wave rounds up to a full wave")
+                t |> equal(matmul_chunks_gemv(64 * (lanes - 1), 1, huge), lanes, "one grain short of a wave rounds up to a full wave")
+                t |> equal(matmul_chunks_gemv(128, 1, huge), min(128, lanes), "the 30B decode router shape (128 rows) fills every lane")
             }
             set_gemv_wave_fill(false)
             if (lanes >= 2) {
@@ -193,7 +195,7 @@ def test_matmul_chunks_gemv(t : T?) {
                 t |> equal(matmul_chunks_gemv(64 * lanes * 100, 1, huge), lanes * 8, "wave count caps at gemv_chunks_per_lane")
             }
             if (lanes > 2) {
-                t |> equal(matmul_chunks_gemv(32, 1, huge), 1, "sub-wave rows fall through to the grain-limited split")
+                t |> equal(matmul_chunks_gemv(32, 1, huge), min(32, lanes), "sub-wave rows fall through to the wave-filled split")
             }
             pin_shaping_baseline()
         }

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -490,9 +490,10 @@ def test_kq_load_layout(t : T?) {
         // this arm is the stage-2 CURSOR-PLACEMENT oracle over disk-order planes — pin the
         // portable backend so a kq-capable gen backend can't repack them at load (stage 4)
         pin_kernel_backend("portable")
+        let prev_kq = get_kquant_native()
         set_kquant_native(true)
         var tr <- load_gguf(path, QuantMode.q8)
-        set_kquant_native(false)
+        set_kquant_native(prev_kq)
         clear_kernel_backend_pin()
         t |> success(!tr.kq_repacked, "portable-pinned load keeps the kq planes disk-order")
         t |> success(tr.kquant_native, "load detected native K-quant tensors")

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -537,6 +537,178 @@ def test_kq_tile(t : T?) {
     }
 }
 
+// Groupn gate: the region-list kq GEMV (the MoE expert dispatch) must be BIT-exact vs per-row
+// disk dots — disk-order (the portable matmul_kq_groupn) AND repacked (kq_groupn_gen over
+// per-region grp slices, the per-expert-slice repack shape). Regions carry distinct LCG
+// payloads; both offs forms run — the shared activation image (gate/up, xoff 0) and
+// per-region activation rows (down, xoff = r*n).
+def private kq_groupn_gate(t : T?; fmt : int) {
+    let n = 512l
+    let d = 32l
+    let nreg = 3l
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    var kq : array<uint8>
+    var ks : array<uint8>
+    kq |> resize(int(nreg * d * nsb * qsb))
+    ks |> resize(int(nreg * d * nsb * ssb))
+    for (r in range64(nreg * d)) {
+        for (s in range64(nsb)) {
+            if (fmt == 4) {
+                transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 5) {
+                transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } else {
+                transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            }
+        }
+        var st = 0x51ED270Bu + uint(r) * 0x85EBCA6Bu
+        for (i in range64(nsb * qsb)) {
+            st = st * 1664525u + 1013904223u
+            kq[r * nsb * qsb + i] = uint8(uint(kq[r * nsb * qsb + i]) ^ (st >> 16u))
+        }
+    }
+    // nreg activation rows, bs-quantized per row
+    var src : array<float>
+    src |> resize(int(nreg * n))
+    for (i in range64(nreg * n)) {
+        src[i] = 1.1 * sin(float(i) * 0.23) - 0.6 * cos(float(i) * 0.071)
+    }
+    var xq : array<int8>
+    var xs : array<float>
+    var xbs : array<int>
+    xq |> resize(int(nreg * n))
+    xs |> resize(int(nreg * n / 32l))
+    xbs |> resize(int(nreg * n / 16l))
+    unsafe {
+        for (p in range64(nreg)) {
+            quantize_q8_0_bs_into_ptr(addr(src[p * n]), n, addr(xq[0]), addr(xs[0]), addr(xbs[0]), p * n, p * (n / 32l), p * (n / 16l))
+        }
+    }
+    var offs_sh : array<int64>
+    var offs_pr : array<int64>
+    offs_sh |> reserve(int(nreg * 2l))
+    offs_pr |> reserve(int(nreg * 2l))
+    for (r in range64(nreg)) {
+        offs_sh |> push(r * d * n)
+        offs_sh |> push(0l)
+        offs_pr |> push(r * d * n)
+        offs_pr |> push(r * n)
+    }
+    // references: per-row disk dots for both activation bindings
+    var want_sh : array<float>
+    var want_pr : array<float>
+    want_sh |> resize(int(nreg * d))
+    want_pr |> resize(int(nreg * d))
+    unsafe {
+        for (r in range64(nreg)) {
+            for (row in range64(d)) {
+                let sb = (r * d + row) * nsb
+                let kqr = addr(kq[sb * qsb])
+                let ksr = addr(ks[sb * ssb])
+                if (fmt == 4) {
+                    want_sh[r * d + row] = dot_k4q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+                    want_pr[r * d + row] = dot_k4q8(kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 32l)]), addr(xbs[r * (n / 16l)]), n)
+                } elif (fmt == 5) {
+                    want_sh[r * d + row] = dot_k5q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+                    want_pr[r * d + row] = dot_k5q8(kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 32l)]), addr(xbs[r * (n / 16l)]), n)
+                } else {
+                    want_sh[r * d + row] = dot_k6q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+                    want_pr[r * d + row] = dot_k6q8(kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 32l)]), addr(xbs[r * (n / 16l)]), n)
+                }
+            }
+        }
+    }
+    var y : array<float>
+    y |> resize(int(nreg * d))
+    var bad_dsh = 0
+    var bad_dpr = 0
+    matmul_kq_groupn(fmt, y, kq, ks, offs_sh, nreg, xq, xs, xbs, n, d)
+    for (i in range64(nreg * d)) {
+        if (y[i] != want_sh[i]) {
+            bad_dsh++
+        }
+    }
+    matmul_kq_groupn(fmt, y, kq, ks, offs_pr, nreg, xq, xs, xbs, n, d)
+    for (i in range64(nreg * d)) {
+        if (y[i] != want_pr[i]) {
+            bad_dpr++
+        }
+    }
+    t |> success(bad_dsh == 0, "disk groupn bit-matches per-row dots (shared image)")
+    t |> success(bad_dpr == 0, "disk groupn bit-matches per-row dots (per-region rows)")
+    // per-region grp repack (the per-expert-slice shape), then the gen driver over the slices.
+    // The grp reference is the ROWS CORE itself (one full-region call per region): under -jit
+    // that's the stamped kernel, whose float fold order differs from the portable dots at the
+    // last bit — the groupn driver's job is the region walk, so THAT must be bit-exact vs the
+    // per-region core calls (interp and stamped alike). Rows-core-vs-disk exactness for the
+    // das reference body is kq_repack_gate's gate.
+    let mr = int64(q8q8_layout_gen())
+    var bad_gsh = 0
+    var bad_gpr = 0
+    unsafe {
+        for (r in range64(nreg)) {
+            if (fmt == 4) {
+                repack_k4_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            } elif (fmt == 5) {
+                repack_k5_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            } else {
+                repack_k6_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            }
+        }
+        for (r in range64(nreg)) {   // grp references: one direct rows-core call per region, both bindings
+            let kqr = addr(kq[r * d * nsb * qsb])
+            let ksr = addr(ks[r * d * nsb * ssb])
+            if (fmt == 4) {
+                k4q8_gemv_gen(addr(want_sh[r * d]), kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, 0l, d)
+                k4q8_gemv_gen(addr(want_pr[r * d]), kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 32l)]), addr(xbs[r * (n / 16l)]), n, 0l, d)
+            } elif (fmt == 5) {
+                k5q8_gemv_gen(addr(want_sh[r * d]), kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, 0l, d)
+                k5q8_gemv_gen(addr(want_pr[r * d]), kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 32l)]), addr(xbs[r * (n / 16l)]), n, 0l, d)
+            } else {
+                k6q8_gemv_gen(addr(want_sh[r * d]), kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, 0l, d)
+                k6q8_gemv_gen(addr(want_pr[r * d]), kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 32l)]), addr(xbs[r * (n / 16l)]), n, 0l, d)
+            }
+        }
+        kq_groupn_gen(fmt, addr(y[0]), addr(kq[0]), addr(ks[0]), addr(offs_sh[0]), nreg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d)
+        for (i in range64(nreg * d)) {
+            if (y[i] != want_sh[i]) {
+                bad_gsh++
+            }
+        }
+        kq_groupn_gen(fmt, addr(y[0]), addr(kq[0]), addr(ks[0]), addr(offs_pr[0]), nreg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d)
+        for (i in range64(nreg * d)) {
+            if (y[i] != want_pr[i]) {
+                bad_gpr++
+            }
+        }
+    }
+    t |> success(bad_gsh == 0, "grp groupn bit-matches per-region rows-core calls (shared image)")
+    t |> success(bad_gpr == 0, "grp groupn bit-matches per-region rows-core calls (per-region rows)")
+    delete kq
+    delete ks
+    delete src
+    delete xq
+    delete xs
+    delete xbs
+    delete offs_sh
+    delete offs_pr
+    delete want_sh
+    delete want_pr
+    delete y
+}
+
+[test]
+def test_kq_groupn(t : T?) {
+    for (fmt in [4, 5, 6]) {
+        t |> run("k{fmt} region-list GEMV bit-matches per-row dots (disk + grp slices)") @(t : T?) {
+            kq_groupn_gate(t, fmt)
+        }
+    }
+}
+
 [test]
 def test_quantize_bs(t : T?) {
     t |> run("bs quantizer matches quantize_q8_0 byte-for-byte plus exact per-16 sums") @(t : T?) {

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -6,6 +6,7 @@ require dastest/testing_boost public
 require _model_tier
 require dasllama/dasllama_gguf
 require dasllama/dasllama_quant
+require dasllama/dasllama_math_default   // dot_k4q8/k5/k6 — the kernel arms gate them vs the plane dequant
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration for load_gguf
 require math
 
@@ -185,6 +186,104 @@ def test_kq_transcode_planes(t : T?) {
         for (k in range(256)) {
             t |> success(dst[k] == want[k], "k6 plane element must equal the file dequant bit-exactly")
         }
+    }
+}
+
+// XOR the quant payload of a synthetic superblock with an LCG byte stream — every quant bit
+// pattern is valid, so the second superblock of a kernel test carries different data (an
+// inter-superblock offset bug can't cancel).
+def private perturb_quants(var blkb : array<uint8>; qoff, qlen : int) {
+    var st = 0x12345u
+    for (i in range(qlen)) {
+        st = st * 1664525u + 1013904223u
+        blkb[qoff + i] = uint8(uint(blkb[qoff + i]) ^ (st >> 16u))
+    }
+}
+
+// Kernel-vs-reference gate core: transcode two distinct superblocks of `fmt`, quantize a smooth
+// activation with the bs quantizer, and compare the integer-domain kernel dot against the fp64
+// elementwise dot over the plane dequant (the kernels' declared oracle).
+def private kq_dot_gate(t : T?; fmt : int) {
+    let n = 512l
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    var blk2 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    if (fmt == 4) {
+        perturb_quants(blk2, 16, 128)
+    } elif (fmt == 5) {
+        perturb_quants(blk2, 16, 160)   // qh + qs
+    } else {
+        perturb_quants(blk2, 0, 192)    // ql + qh
+    }
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    var kq : array<uint8>
+    var ks : array<uint8>
+    kq |> resize(2l * qsb)
+    ks |> resize(2l * ssb)
+    if (fmt == 4) {
+        transcode_q4k_superblock(blk1, 0l, kq, 0l, ks, 0l)
+        transcode_q4k_superblock(blk2, 0l, kq, qsb, ks, ssb)
+    } elif (fmt == 5) {
+        transcode_q5k_superblock(blk1, 0l, kq, 0l, ks, 0l)
+        transcode_q5k_superblock(blk2, 0l, kq, qsb, ks, ssb)
+    } else {
+        transcode_q6k_superblock(blk1, 0l, kq, 0l, ks, 0l)
+        transcode_q6k_superblock(blk2, 0l, kq, qsb, ks, ssb)
+    }
+    // plane dequant = the reference weights
+    var w : array<float>
+    w |> resize(n)
+    for (s in range64(2l)) {
+        if (fmt == 4) {
+            dequant_k4_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
+        } elif (fmt == 5) {
+            dequant_k5_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
+        } else {
+            dequant_k6_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
+        }
+    }
+    // activation: smooth signal -> bs quantizer (quants + scales + per-16 sums)
+    var src : array<float>
+    src |> resize(n)
+    for (i in range64(n)) {
+        src[i] = 1.7 * sin(float(i) * 0.23) + 0.3 * cos(float(i) * 0.071)
+    }
+    var xq : array<int8>
+    var xs : array<float>
+    var xbs : array<int>
+    xq |> resize(n)
+    xs |> resize(n / 32l)
+    xbs |> resize(n / 16l)
+    quantize_q8_0_bs_into(src, n, xq, xs, xbs, 0l, 0l, 0l)
+    // fp64 elementwise reference over the SAME quantized activation
+    var ref = 0.0lf
+    for (i in range64(n)) {
+        ref += double(w[i]) * double(xq[i]) * double(xs[i / 32l])
+    }
+    var got = 0.0
+    unsafe {
+        if (fmt == 4) {
+            got = dot_k4q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+        } elif (fmt == 5) {
+            got = dot_k5q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+        } else {
+            got = dot_k6q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+        }
+    }
+    let denom = max(abs(float(ref)), 1.0e-6)
+    t |> success(abs(got - float(ref)) / denom < 1.0e-4, "kernel dot must match the fp64 plane-dequant reference")
+}
+
+[test]
+def test_kq_dots(t : T?) {
+    t |> run("dot_k4q8 matches the fp64 plane-dequant reference") @(t : T?) {
+        kq_dot_gate(t, 4)
+    }
+    t |> run("dot_k5q8 matches the fp64 plane-dequant reference") @(t : T?) {
+        kq_dot_gate(t, 5)
+    }
+    t |> run("dot_k6q8 matches the fp64 plane-dequant reference") @(t : T?) {
+        kq_dot_gate(t, 6)
     }
 }
 

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -4,6 +4,7 @@ options stack = 65536   // dasLLAMA program-root convention (options stack does 
 require dastest/testing_boost public
 require _model_tier
 require dasllama/dasllama_gguf
+require dasllama/dasllama_quant
 require math
 
 // K-quant (Q4_K / Q6_K) superblock dequant gates. The synthetic arms hand-pack one superblock
@@ -12,8 +13,9 @@ require math
 // proven bit-exact against gguf-py's dequantize (harness/q4k_dequant_probe.das); the real-file
 // arm cross-checks against the Q8_0 twin of the same weights at known quantization-error levels.
 
-// synthetic quant patterns: every nibble/6-bit value, position-dependent so swaps can't cancel
+// synthetic quant patterns: every nibble/5-bit/6-bit value, position-dependent so swaps can't cancel
 def private q4_pat(k : int) : int => (k * 7 + 3) % 16
+def private q5_pat(k : int) : int => (k * 3 + 7) % 32
 def private q6_pat(k : int) : int => (k * 5 + 11) % 64
 
 [test]
@@ -52,6 +54,44 @@ def test_q4k_synthetic(t : T?) {
             t |> success(dst[k] == expected, "Q4_K element must match hand-packed value exactly")
         }
     }
+    t |> run("Q5_K superblock unpacks the split high-bit plane") @(t : T?) {
+        // reuse the Q4_K scale/min values (same 12-byte packing) — the new surface is qh
+        let sc <- [63, 21, 37, 5, 48, 17, 60, 33]
+        let mn <- [1, 62, 19, 44, 7, 58, 25, 36]
+        let d = 0.5
+        let dmin = 0.25
+        var blkb : array<uint8>
+        blkb |> resize(176)
+        let dbits = f32_to_f16(d)
+        let mbits = f32_to_f16(dmin)
+        blkb[0] = uint8(dbits & 0xFF)
+        blkb[1] = uint8(dbits >> 8u)
+        blkb[2] = uint8(mbits & 0xFF)
+        blkb[3] = uint8(mbits >> 8u)
+        for (j in range(4)) {
+            blkb[4 + j] = uint8((sc[j] & 63) | (((sc[j + 4] >> 4) & 3) << 6))
+            blkb[8 + j] = uint8((mn[j] & 63) | (((mn[j + 4] >> 4) & 3) << 6))
+            blkb[12 + j] = uint8((sc[j + 4] & 15) | ((mn[j + 4] & 15) << 4))
+        }
+        // qh[l] bit 2js = high bit of weight 64js+l, bit 2js+1 = high bit of weight 64js+32+l
+        for (js in range(4)) {
+            for (l in range(32)) {
+                blkb[48 + 32 * js + l] = uint8((q5_pat(64 * js + l) & 15) | ((q5_pat(64 * js + 32 + l) & 15) << 4))
+                var h = int(blkb[16 + l])
+                h |= (q5_pat(64 * js + l) >> 4) << (2 * js)
+                h |= (q5_pat(64 * js + 32 + l) >> 4) << (2 * js + 1)
+                blkb[16 + l] = uint8(h)
+            }
+        }
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_q5k_superblock(blkb, 0l, dst, 0l)
+        for (k in range(256)) {
+            let sub = k / 32
+            let expected = d * float(sc[sub]) * float(q5_pat(k)) - dmin * float(mn[sub])
+            t |> success(dst[k] == expected, "Q5_K element must match hand-packed value exactly")
+        }
+    }
     t |> run("Q6_K superblock unpacks the ql/qh split and signed sub-scales") @(t : T?) {
         let scq <- [3, -5, 60, -60, 17, 127, -128, 1, 0, 33, -77, 90, -2, 45, -101, 7]
         let d = 0.25
@@ -79,6 +119,51 @@ def test_q4k_synthetic(t : T?) {
             let expected = d * float(scq[k / 16]) * float(q6_pat(k) - 32)
             t |> success(dst[k] == expected, "Q6_K element must match hand-packed value exactly")
         }
+    }
+}
+
+[test]
+def test_quantize_bs(t : T?) {
+    t |> run("bs quantizer matches quantize_q8_0 byte-for-byte plus exact per-16 sums") @(t : T?) {
+        let n = 4096l
+        var src : array<float>
+        src |> resize(n)
+        for (i in range64(n)) {
+            src[i] = 2.0 * sin(float(i) * 0.37) - 0.11 * float(i % 13l)
+        }
+        let want <- quantize_q8_0(src, n)
+        var qdst : array<int8>
+        var sdst : array<float>
+        var bdst : array<int>
+        qdst |> resize(n)
+        sdst |> resize(n / 32l)
+        bdst |> resize(n / 16l)
+        quantize_q8_0_bs_into(src, n, qdst, sdst, bdst, 0l, 0l, 0l)
+        var qbad = 0
+        var sbad = 0
+        var bbad = 0
+        for (j in range64(n)) {
+            if (qdst[j] != want.q[j]) {
+                qbad++
+            }
+        }
+        for (b in range64(n / 32l)) {
+            if (sdst[b] != want.scales[b]) {
+                sbad++
+            }
+        }
+        for (h in range64(n / 16l)) {
+            var bs = 0
+            for (i in range64(16l)) {
+                bs += int(want.q[h * 16l + i])
+            }
+            if (bdst[h] != bs) {
+                bbad++
+            }
+        }
+        t |> success(qbad == 0, "quants byte-identical to quantize_q8_0")
+        t |> success(sbad == 0, "scales bit-identical to quantize_q8_0")
+        t |> success(bbad == 0, "per-16 sums exact")
     }
 }
 

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -1,0 +1,152 @@
+options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
+
+require dastest/testing_boost public
+require _model_tier
+require dasllama/dasllama_gguf
+require math
+
+// K-quant (Q4_K / Q6_K) superblock dequant gates. The synthetic arms hand-pack one superblock
+// with the ggml bit layout written in the PACK direction (independent of the reader's unpack),
+// so a layout misread fails loudly with no model files needed. The dequant arithmetic itself is
+// proven bit-exact against gguf-py's dequantize (harness/q4k_dequant_probe.das); the real-file
+// arm cross-checks against the Q8_0 twin of the same weights at known quantization-error levels.
+
+// synthetic quant patterns: every nibble/6-bit value, position-dependent so swaps can't cancel
+def private q4_pat(k : int) : int => (k * 7 + 3) % 16
+def private q6_pat(k : int) : int => (k * 5 + 11) % 64
+
+[test]
+def test_q4k_synthetic(t : T?) {
+    t |> run("Q4_K superblock unpacks the 6-bit scale/min packing") @(t : T?) {
+        // 6-bit values > 15 exercise the split high-bit arms of get_scale_min_k4 (j >= 4)
+        let sc <- [63, 21, 37, 5, 48, 17, 60, 33]
+        let mn <- [1, 62, 19, 44, 7, 58, 25, 36]
+        let d = 0.5      // f16-exact, so expected-value math can use the f32 value directly
+        let dmin = 0.25
+        var blkb : array<uint8>
+        blkb |> resize(144)
+        let dbits = f32_to_f16(d)
+        let mbits = f32_to_f16(dmin)
+        blkb[0] = uint8(dbits & 0xFF)
+        blkb[1] = uint8(dbits >> 8u)
+        blkb[2] = uint8(mbits & 0xFF)
+        blkb[3] = uint8(mbits >> 8u)
+        for (j in range(4)) {
+            blkb[4 + j] = uint8((sc[j] & 63) | (((sc[j + 4] >> 4) & 3) << 6))
+            blkb[8 + j] = uint8((mn[j] & 63) | (((mn[j + 4] >> 4) & 3) << 6))
+            blkb[12 + j] = uint8((sc[j + 4] & 15) | ((mn[j + 4] & 15) << 4))
+        }
+        // chunk js: 32 bytes carry weights 64js..+31 in low nibbles, 64js+32..+31 in high
+        for (js in range(4)) {
+            for (l in range(32)) {
+                blkb[16 + 32 * js + l] = uint8(q4_pat(64 * js + l) | (q4_pat(64 * js + 32 + l) << 4))
+            }
+        }
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_q4k_superblock(blkb, 0l, dst, 0l)
+        for (k in range(256)) {
+            let sub = k / 32
+            let expected = d * float(sc[sub]) * float(q4_pat(k)) - dmin * float(mn[sub])
+            t |> success(dst[k] == expected, "Q4_K element must match hand-packed value exactly")
+        }
+    }
+    t |> run("Q6_K superblock unpacks the ql/qh split and signed sub-scales") @(t : T?) {
+        let scq <- [3, -5, 60, -60, 17, 127, -128, 1, 0, 33, -77, 90, -2, 45, -101, 7]
+        let d = 0.25
+        var blkb : array<uint8>
+        blkb |> resize(210)
+        for (half in range(2)) {
+            let base = 128 * half
+            for (l in range(32)) {
+                blkb[64 * half + l] = uint8((q6_pat(base + l) & 15) | ((q6_pat(base + 64 + l) & 15) << 4))
+                blkb[64 * half + 32 + l] = uint8((q6_pat(base + 32 + l) & 15) | ((q6_pat(base + 96 + l) & 15) << 4))
+                blkb[128 + 32 * half + l] = uint8((q6_pat(base + l) >> 4) | ((q6_pat(base + 32 + l) >> 4) << 2)
+                    | ((q6_pat(base + 64 + l) >> 4) << 4) | ((q6_pat(base + 96 + l) >> 4) << 6))
+            }
+        }
+        for (i in range(16)) {
+            blkb[192 + i] = uint8(scq[i] & 255)
+        }
+        let dbits = f32_to_f16(d)
+        blkb[208] = uint8(dbits & 0xFF)
+        blkb[209] = uint8(dbits >> 8u)
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_q6k_superblock(blkb, 0l, dst, 0l)
+        for (k in range(256)) {
+            let expected = d * float(scq[k / 16]) * float(q6_pat(k) - 32)
+            t |> success(dst[k] == expected, "Q6_K element must match hand-packed value exactly")
+        }
+    }
+}
+
+// Dequant the first `n` elements of `name` into fp32; reports the on-disk type via `gt`.
+def private read_prefix(path, name : string; n : int64; var gt : int&) : array<float> {
+    var dst : array<float>
+    dst |> resize(n)
+    let f = fopen(path, "rb")
+    if (f == null) {
+        panic("cannot open {path}")
+    }
+    fmap(f) $(var bytes : array<uint8>#) {
+        var m <- parse_gguf_meta(bytes)
+        gt = gguf_tensor_type(m, name)
+        gguf_read_tensor_f32(m, bytes, name, dst, 0l, n)
+        delete m
+    }
+    fclose(f)
+    return <- dst
+}
+
+// Relative RMS of (a - b) against RMS(b), double accumulation.
+def private rel_rms(a, b : array<float>) : float {
+    var num = 0.0lf
+    var den = 0.0lf
+    for (x, y in a, b) {
+        let dxy = double(x) - double(y)
+        num += dxy * dxy
+        den += double(y) * double(y)
+    }
+    return float(sqrt(num / den))
+}
+
+[test]
+def test_q4k_real_file(t : T?) {
+    t |> run("gemma-4-12B Q4_K_M dequant tracks the Q8_0 twin at quant-error level") @(t : T?) {
+        let q4path = path_join(models_dir(), "gemma-4-12B-it-Q4_K_M.requant.gguf")
+        let q8path = path_join(models_dir(), "gemma-4-12B-it-Q8_0.gguf")
+        if (!model_available(t, q4path)) {
+            return
+        }
+        if (!model_available(t, q8path)) {
+            return
+        }
+        // census: the Q4_K_M mix this arc targets — tied cls (token_embd) is Q6_K, bulk is Q4_K
+        var gt = 0
+        let n = 262144l   // 1024 superblocks — plenty of RMS statistics
+        var q4a <- read_prefix(q4path, "blk.0.attn_q.weight", n, gt)
+        t |> equal(gt, GGML_TYPE_Q4_K)
+        var q8a <- read_prefix(q8path, "blk.0.attn_q.weight", n, gt)
+        t |> equal(gt, GGML_TYPE_Q8_0)
+        let rq4 = rel_rms(q4a, q8a)
+        // measured 0.081 (requantized-from-q8 4.5-bit error); 2x margin, floor guards a same-file mixup
+        t |> success(rq4 > 0.005 && rq4 < 0.15, "Q4_K rel RMS vs Q8_0 twin within quant-error band")
+        delete q4a
+        delete q8a
+        var q6a <- read_prefix(q4path, "blk.0.attn_v.weight", n, gt)
+        t |> equal(gt, GGML_TYPE_Q6_K)
+        var q8b <- read_prefix(q8path, "blk.0.attn_v.weight", n, gt)
+        t |> equal(gt, GGML_TYPE_Q8_0)
+        let rq6 = rel_rms(q6a, q8b)
+        // measured 0.022
+        t |> success(rq6 > 0.002 && rq6 < 0.05, "Q6_K rel RMS vs Q8_0 twin within quant-error band")
+        delete q6a
+        delete q8b
+        var gte = 0
+        var emb <- read_prefix(q4path, "token_embd.weight", 256l, gte)
+        t |> equal(gte, GGML_TYPE_Q6_K)
+        delete emb
+    }
+}

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -1,10 +1,12 @@
 options gen2
 options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
+options persistent_heap   // the layout arm loads a multi-GB model; explicit delete below
 
 require dastest/testing_boost public
 require _model_tier
 require dasllama/dasllama_gguf
 require dasllama/dasllama_quant
+require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration for load_gguf
 require math
 
 // K-quant (Q4_K / Q6_K) superblock dequant gates. The synthetic arms hand-pack one superblock
@@ -18,106 +20,170 @@ def private q4_pat(k : int) : int => (k * 7 + 3) % 16
 def private q5_pat(k : int) : int => (k * 3 + 7) % 32
 def private q6_pat(k : int) : int => (k * 5 + 11) % 64
 
+// The shared synthetic scale/min sets: 6-bit values > 15 exercise the split high-bit arms of
+// get_scale_min_k4 (j >= 4); d/dmin are f16-exact so expected-value math uses the f32 value.
+let SYNTH_SC <- [63, 21, 37, 5, 48, 17, 60, 33]
+let SYNTH_MN <- [1, 62, 19, 44, 7, 58, 25, 36]
+let SYNTH_D = 0.5
+let SYNTH_DMIN = 0.25
+let SYNTH_SCQ <- [3, -5, 60, -60, 17, 127, -128, 1, 0, 33, -77, 90, -2, 45, -101, 7]
+
+// Pack the 4-byte header + 12 scale/min bytes shared by the Q4_K/Q5_K synthetic superblocks.
+def private pack_kq_header(var blkb : array<uint8>) {
+    let dbits = f32_to_f16(SYNTH_D)
+    let mbits = f32_to_f16(SYNTH_DMIN)
+    blkb[0] = uint8(dbits & 0xFF)
+    blkb[1] = uint8(dbits >> 8u)
+    blkb[2] = uint8(mbits & 0xFF)
+    blkb[3] = uint8(mbits >> 8u)
+    for (j in range(4)) {
+        blkb[4 + j] = uint8((SYNTH_SC[j] & 63) | (((SYNTH_SC[j + 4] >> 4) & 3) << 6))
+        blkb[8 + j] = uint8((SYNTH_MN[j] & 63) | (((SYNTH_MN[j + 4] >> 4) & 3) << 6))
+        blkb[12 + j] = uint8((SYNTH_SC[j + 4] & 15) | ((SYNTH_MN[j + 4] & 15) << 4))
+    }
+}
+
+def private build_q4k_block() : array<uint8> {
+    var blkb : array<uint8>
+    blkb |> resize(144)
+    pack_kq_header(blkb)
+    // chunk js: 32 bytes carry weights 64js..+31 in low nibbles, 64js+32..+31 in high
+    for (js in range(4)) {
+        for (l in range(32)) {
+            blkb[16 + 32 * js + l] = uint8(q4_pat(64 * js + l) | (q4_pat(64 * js + 32 + l) << 4))
+        }
+    }
+    return <- blkb
+}
+
+def private build_q5k_block() : array<uint8> {
+    var blkb : array<uint8>
+    blkb |> resize(176)
+    pack_kq_header(blkb)
+    // qh[l] bit 2js = high bit of weight 64js+l, bit 2js+1 = high bit of weight 64js+32+l
+    for (js in range(4)) {
+        for (l in range(32)) {
+            blkb[48 + 32 * js + l] = uint8((q5_pat(64 * js + l) & 15) | ((q5_pat(64 * js + 32 + l) & 15) << 4))
+            var h = int(blkb[16 + l])
+            h |= (q5_pat(64 * js + l) >> 4) << (2 * js)
+            h |= (q5_pat(64 * js + 32 + l) >> 4) << (2 * js + 1)
+            blkb[16 + l] = uint8(h)
+        }
+    }
+    return <- blkb
+}
+
+def private build_q6k_block() : array<uint8> {
+    var blkb : array<uint8>
+    blkb |> resize(210)
+    for (half in range(2)) {
+        let base = 128 * half
+        for (l in range(32)) {
+            blkb[64 * half + l] = uint8((q6_pat(base + l) & 15) | ((q6_pat(base + 64 + l) & 15) << 4))
+            blkb[64 * half + 32 + l] = uint8((q6_pat(base + 32 + l) & 15) | ((q6_pat(base + 96 + l) & 15) << 4))
+            blkb[128 + 32 * half + l] = uint8((q6_pat(base + l) >> 4) | ((q6_pat(base + 32 + l) >> 4) << 2)
+                | ((q6_pat(base + 64 + l) >> 4) << 4) | ((q6_pat(base + 96 + l) >> 4) << 6))
+        }
+    }
+    for (i in range(16)) {
+        blkb[192 + i] = uint8(SYNTH_SCQ[i] & 255)
+    }
+    let dbits = f32_to_f16(0.25)
+    blkb[208] = uint8(dbits & 0xFF)
+    blkb[209] = uint8(dbits >> 8u)
+    return <- blkb
+}
+
+// f16 round-trip: the rounding the transcoded (s, o) pairs carry
+def private f16r(x : float) : float => f16_to_f32(f32_to_f16(x))
+
 [test]
 def test_q4k_synthetic(t : T?) {
     t |> run("Q4_K superblock unpacks the 6-bit scale/min packing") @(t : T?) {
-        // 6-bit values > 15 exercise the split high-bit arms of get_scale_min_k4 (j >= 4)
-        let sc <- [63, 21, 37, 5, 48, 17, 60, 33]
-        let mn <- [1, 62, 19, 44, 7, 58, 25, 36]
-        let d = 0.5      // f16-exact, so expected-value math can use the f32 value directly
-        let dmin = 0.25
-        var blkb : array<uint8>
-        blkb |> resize(144)
-        let dbits = f32_to_f16(d)
-        let mbits = f32_to_f16(dmin)
-        blkb[0] = uint8(dbits & 0xFF)
-        blkb[1] = uint8(dbits >> 8u)
-        blkb[2] = uint8(mbits & 0xFF)
-        blkb[3] = uint8(mbits >> 8u)
-        for (j in range(4)) {
-            blkb[4 + j] = uint8((sc[j] & 63) | (((sc[j + 4] >> 4) & 3) << 6))
-            blkb[8 + j] = uint8((mn[j] & 63) | (((mn[j + 4] >> 4) & 3) << 6))
-            blkb[12 + j] = uint8((sc[j + 4] & 15) | ((mn[j + 4] & 15) << 4))
-        }
-        // chunk js: 32 bytes carry weights 64js..+31 in low nibbles, 64js+32..+31 in high
-        for (js in range(4)) {
-            for (l in range(32)) {
-                blkb[16 + 32 * js + l] = uint8(q4_pat(64 * js + l) | (q4_pat(64 * js + 32 + l) << 4))
-            }
-        }
+        let blkb <- build_q4k_block()
         var dst : array<float>
         dst |> resize(256)
         dequant_q4k_superblock(blkb, 0l, dst, 0l)
         for (k in range(256)) {
             let sub = k / 32
-            let expected = d * float(sc[sub]) * float(q4_pat(k)) - dmin * float(mn[sub])
+            let expected = SYNTH_D * float(SYNTH_SC[sub]) * float(q4_pat(k)) - SYNTH_DMIN * float(SYNTH_MN[sub])
             t |> success(dst[k] == expected, "Q4_K element must match hand-packed value exactly")
         }
     }
     t |> run("Q5_K superblock unpacks the split high-bit plane") @(t : T?) {
-        // reuse the Q4_K scale/min values (same 12-byte packing) — the new surface is qh
-        let sc <- [63, 21, 37, 5, 48, 17, 60, 33]
-        let mn <- [1, 62, 19, 44, 7, 58, 25, 36]
-        let d = 0.5
-        let dmin = 0.25
-        var blkb : array<uint8>
-        blkb |> resize(176)
-        let dbits = f32_to_f16(d)
-        let mbits = f32_to_f16(dmin)
-        blkb[0] = uint8(dbits & 0xFF)
-        blkb[1] = uint8(dbits >> 8u)
-        blkb[2] = uint8(mbits & 0xFF)
-        blkb[3] = uint8(mbits >> 8u)
-        for (j in range(4)) {
-            blkb[4 + j] = uint8((sc[j] & 63) | (((sc[j + 4] >> 4) & 3) << 6))
-            blkb[8 + j] = uint8((mn[j] & 63) | (((mn[j + 4] >> 4) & 3) << 6))
-            blkb[12 + j] = uint8((sc[j + 4] & 15) | ((mn[j + 4] & 15) << 4))
-        }
-        // qh[l] bit 2js = high bit of weight 64js+l, bit 2js+1 = high bit of weight 64js+32+l
-        for (js in range(4)) {
-            for (l in range(32)) {
-                blkb[48 + 32 * js + l] = uint8((q5_pat(64 * js + l) & 15) | ((q5_pat(64 * js + 32 + l) & 15) << 4))
-                var h = int(blkb[16 + l])
-                h |= (q5_pat(64 * js + l) >> 4) << (2 * js)
-                h |= (q5_pat(64 * js + 32 + l) >> 4) << (2 * js + 1)
-                blkb[16 + l] = uint8(h)
-            }
-        }
+        let blkb <- build_q5k_block()
         var dst : array<float>
         dst |> resize(256)
         dequant_q5k_superblock(blkb, 0l, dst, 0l)
         for (k in range(256)) {
             let sub = k / 32
-            let expected = d * float(sc[sub]) * float(q5_pat(k)) - dmin * float(mn[sub])
+            let expected = SYNTH_D * float(SYNTH_SC[sub]) * float(q5_pat(k)) - SYNTH_DMIN * float(SYNTH_MN[sub])
             t |> success(dst[k] == expected, "Q5_K element must match hand-packed value exactly")
         }
     }
     t |> run("Q6_K superblock unpacks the ql/qh split and signed sub-scales") @(t : T?) {
-        let scq <- [3, -5, 60, -60, 17, 127, -128, 1, 0, 33, -77, 90, -2, 45, -101, 7]
-        let d = 0.25
-        var blkb : array<uint8>
-        blkb |> resize(210)
-        for (half in range(2)) {
-            let base = 128 * half
-            for (l in range(32)) {
-                blkb[64 * half + l] = uint8((q6_pat(base + l) & 15) | ((q6_pat(base + 64 + l) & 15) << 4))
-                blkb[64 * half + 32 + l] = uint8((q6_pat(base + 32 + l) & 15) | ((q6_pat(base + 96 + l) & 15) << 4))
-                blkb[128 + 32 * half + l] = uint8((q6_pat(base + l) >> 4) | ((q6_pat(base + 32 + l) >> 4) << 2)
-                    | ((q6_pat(base + 64 + l) >> 4) << 4) | ((q6_pat(base + 96 + l) >> 4) << 6))
-            }
-        }
-        for (i in range(16)) {
-            blkb[192 + i] = uint8(scq[i] & 255)
-        }
-        let dbits = f32_to_f16(d)
-        blkb[208] = uint8(dbits & 0xFF)
-        blkb[209] = uint8(dbits >> 8u)
+        let blkb <- build_q6k_block()
         var dst : array<float>
         dst |> resize(256)
         dequant_q6k_superblock(blkb, 0l, dst, 0l)
         for (k in range(256)) {
-            let expected = d * float(scq[k / 16]) * float(q6_pat(k) - 32)
+            let expected = 0.25 * float(SYNTH_SCQ[k / 16]) * float(q6_pat(k) - 32)
             t |> success(dst[k] == expected, "Q6_K element must match hand-packed value exactly")
+        }
+    }
+}
+
+[test]
+def test_kq_transcode_planes(t : T?) {
+    // The transcoded planes ARE the kernel-facing format: k4/k5 dequant must equal the file
+    // dequant with the (s, o) pairs' f16 rounding applied; k6 planes are verbatim, so exact.
+    t |> run("k4 planes reproduce the f16-rounded Q4_K dequant") @(t : T?) {
+        let blkb <- build_q4k_block()
+        var kq : array<uint8>
+        var ks : array<uint8>
+        kq |> resize(128)
+        ks |> resize(32)
+        transcode_q4k_superblock(blkb, 0l, kq, 0l, ks, 0l)
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_k4_plane_superblock(kq, 0l, ks, 0l, dst, 0l)
+        for (k in range(256)) {
+            let sub = k / 32
+            let expected = f16r(SYNTH_D * float(SYNTH_SC[sub])) * float(q4_pat(k)) - f16r(SYNTH_DMIN * float(SYNTH_MN[sub]))
+            t |> success(dst[k] == expected, "k4 plane element must match the f16-rounded value exactly")
+        }
+    }
+    t |> run("k5 planes reproduce the f16-rounded Q5_K dequant") @(t : T?) {
+        let blkb <- build_q5k_block()
+        var kq : array<uint8>
+        var ks : array<uint8>
+        kq |> resize(160)
+        ks |> resize(32)
+        transcode_q5k_superblock(blkb, 0l, kq, 0l, ks, 0l)
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_k5_plane_superblock(kq, 0l, ks, 0l, dst, 0l)
+        for (k in range(256)) {
+            let sub = k / 32
+            let expected = f16r(SYNTH_D * float(SYNTH_SC[sub])) * float(q5_pat(k)) - f16r(SYNTH_DMIN * float(SYNTH_MN[sub]))
+            t |> success(dst[k] == expected, "k5 plane element must match the f16-rounded value exactly")
+        }
+    }
+    t |> run("k6 planes reproduce the Q6_K dequant bit-exactly") @(t : T?) {
+        let blkb <- build_q6k_block()
+        var kq : array<uint8>
+        var ks : array<uint8>
+        kq |> resize(192)
+        ks |> resize(18)
+        transcode_q6k_superblock(blkb, 0l, kq, 0l, ks, 0l)
+        var want : array<float>
+        want |> resize(256)
+        dequant_q6k_superblock(blkb, 0l, want, 0l)
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_k6_plane_superblock(kq, 0l, ks, 0l, dst, 0l)
+        for (k in range(256)) {
+            t |> success(dst[k] == want[k], "k6 plane element must equal the file dequant bit-exactly")
         }
     }
 }
@@ -164,6 +230,71 @@ def test_quantize_bs(t : T?) {
         t |> success(qbad == 0, "quants byte-identical to quantize_q8_0")
         t |> success(sbad == 0, "scales bit-identical to quantize_q8_0")
         t |> success(bbad == 0, "per-16 sums exact")
+    }
+}
+
+// Dequant `n` elements from a Model kq plane starting at plane-local element offset `eloff`.
+def private dequant_plane_prefix(tr : Model; fmt : KqFmt; eloff, n : int64; var dst : array<float>) {
+    for (blk in range64(n / 256l)) {
+        let sb = (eloff + blk * 256l) / 256l
+        if (fmt == KqFmt.k4) {
+            dequant_k4_plane_superblock(tr.k4q, sb * K4_QSB, tr.k4s, sb * K4_SSB, dst, blk * 256l)
+        } elif (fmt == KqFmt.k5) {
+            dequant_k5_plane_superblock(tr.k5q, sb * K5_QSB, tr.k5s, sb * K5_SSB, dst, blk * 256l)
+        } elif (fmt == KqFmt.k6) {
+            dequant_k6_plane_superblock(tr.k6q, sb * K6_QSB, tr.k6s, sb * K6_SSB, dst, blk * 256l)
+        } else {
+            panic("dequant_plane_prefix: not a kq format")
+        }
+    }
+}
+
+[test]
+def test_kq_load_layout(t : T?) {
+    // End-to-end stage-2 oracle: a kquant_native load must place every tagged tensor at its
+    // cursor-assigned plane offset. Plane-dequant of tensor prefixes vs the file dequant —
+    // exact for k6 (verbatim planes), quant-noise-free but f16-pair-rounded for k4 (rel RMS
+    // bound catches any misplaced superblock loudly; the synthetic arms above pin the bit level).
+    t |> run("kquant_native load places tensors at their cursor offsets (Qwen3-4B Q4_K_M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3-4B-Instruct-2507-Q4_K_M.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        set_kquant_native(true)
+        var tr <- load_gguf(path, QuantMode.q8)
+        set_kquant_native(false)
+        t |> success(tr.kquant_native, "load detected native K-quant tensors")
+        t |> success(cls_kq(tr), "tied Q6_K classifier takes the kq plane path")
+        t |> success(tr.wq_fmt[0] == KqFmt.k4, "blk.0.attn_q tagged k4")
+        t |> success(tr.wv_fmt[0] == KqFmt.k6, "blk.0.attn_v tagged k6")
+        let n = 262144l
+        var have : array<float>
+        have |> resize(n)
+        // deep-layer k4 tensor: catches cursor drift accumulated across every earlier tensor
+        let l = tr.config.n_layers - 1l
+        dequant_plane_prefix(tr, tr.wq_fmt[l], tr.wq_offs[l], n, have)
+        var gt = 0
+        var fdq <- read_prefix(path, "blk.{l}.attn_q.weight", n, gt)
+        let r4 = rel_rms(have, fdq)
+        t |> success(r4 < 1.0e-3, "deep-layer k4 plane matches the file dequant (f16-pair rounding only)")
+        delete fdq
+        // k6 (verbatim planes): the tied classifier row block — must be bit-exact
+        var fdq6 <- read_prefix(path, "token_embd.weight", n, gt)
+        dequant_plane_prefix(tr, tr.emb_fmt, tr.wcls_off, n, have)
+        var bad = 0
+        for (i in range64(n)) {
+            if (have[i] != fdq6[i]) {
+                bad++
+            }
+        }
+        t |> success(bad == 0, "k6 classifier plane bit-matches the file dequant")
+        delete fdq6
+        delete have
+        delete tr
     }
 }
 

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -6,7 +6,9 @@ require dastest/testing_boost public
 require _model_tier
 require dasllama/dasllama_gguf
 require dasllama/dasllama_quant
+require dasllama/dasllama_math   // pin_kernel_backend — the layout arm needs disk-order planes
 require dasllama/dasllama_math_default   // dot_k4q8/k5/k6 — the kernel arms gate them vs the plane dequant
+require dasllama/dasllama_math_gen   // repack_k4/k5/k6_grp + kq_grp_row_dot — the stage-4 repack oracle
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration for load_gguf
 require math
 
@@ -287,6 +289,128 @@ def test_kq_dots(t : T?) {
     }
 }
 
+// Stage-4 repack oracle core: build a d-row disk plane of `fmt` (transcoded synthetic
+// superblocks, per-row LCG-perturbed quant payloads — every quant bit pattern is valid),
+// capture the portable disk dots + row dequants, repack in place at `mr`, and require the
+// grp<mr> scalar reference (kq_grp_row_dot — the stamped cores' decline body) and the grp row
+// dequant to reproduce them BIT-EXACTLY (same block order, exact integer sub-sums — only the
+// plane layout moved).
+def private kq_repack_gate(t : T?; fmt : int; mr : int64) {
+    let n = 512l
+    let d = 32l
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    var kq : array<uint8>
+    var ks : array<uint8>
+    kq |> resize(int(d * nsb * qsb))
+    ks |> resize(int(d * nsb * ssb))
+    for (r in range64(d)) {
+        for (s in range64(nsb)) {
+            if (fmt == 4) {
+                transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 5) {
+                transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } else {
+                transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            }
+        }
+        // per-row LCG over the quant payload only (scale planes stay valid f16/int8)
+        var st = 0x9E3779Bu + uint(r) * 0x85EBCA6Bu
+        for (i in range64(nsb * qsb)) {
+            st = st * 1664525u + 1013904223u
+            kq[r * nsb * qsb + i] = uint8(uint(kq[r * nsb * qsb + i]) ^ (st >> 16u))
+        }
+    }
+    var src : array<float>
+    src |> resize(n)
+    for (i in range64(n)) {
+        src[i] = 1.3 * sin(float(i) * 0.19) - 0.4 * cos(float(i) * 0.057)
+    }
+    var xq : array<int8>
+    var xs : array<float>
+    var xbs : array<int>
+    xq |> resize(n)
+    xs |> resize(n / 32l)
+    xbs |> resize(n / 16l)
+    quantize_q8_0_bs_into(src, n, xq, xs, xbs, 0l, 0l, 0l)
+    var want : array<float>
+    var wrow : array<float>
+    want |> resize(int(d))
+    wrow |> resize(int(d * n))
+    unsafe {
+        for (r in range64(d)) {
+            let kqr = addr(kq[r * nsb * qsb])
+            let ksr = addr(ks[r * nsb * ssb])
+            if (fmt == 4) {
+                want[r] = dot_k4q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            } elif (fmt == 5) {
+                want[r] = dot_k5q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            } else {
+                want[r] = dot_k6q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            }
+            for (s in range64(nsb)) {
+                if (fmt == 4) {
+                    dequant_k4_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
+                } elif (fmt == 5) {
+                    dequant_k5_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
+                } else {
+                    dequant_k6_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
+                }
+            }
+        }
+        if (fmt == 4) {
+            repack_k4_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        } elif (fmt == 5) {
+            repack_k5_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        } else {
+            repack_k6_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        }
+        var dotbad = 0
+        var deqbad = 0
+        var row : array<float>
+        row |> resize(n)
+        for (r in range64(d)) {
+            let g = r / mr
+            let kqg = addr(kq[g * mr * nsb * qsb])
+            let ksg = addr(ks[g * mr * nsb * ssb])
+            let got = kq_grp_row_dot(int64(fmt), kqg, ksg, r % mr, mr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            if (got != want[r]) {
+                dotbad++
+            }
+            dequant_kq_row_grp(int64(fmt), kqg, ksg, r % mr, mr, n, addr(row[0]))
+            for (i in range64(n)) {
+                if (row[i] != wrow[r * n + i]) {
+                    deqbad++
+                }
+            }
+        }
+        t |> success(dotbad == 0, "grp<mr> row dots bit-match the disk dots after repack")
+        t |> success(deqbad == 0, "grp<mr> row dequant bit-matches the disk row dequant after repack")
+        delete row
+    }
+    delete kq
+    delete ks
+    delete want
+    delete wrow
+    delete src
+    delete xq
+    delete xs
+    delete xbs
+}
+
+[test]
+def test_kq_repack_grp(t : T?) {
+    for (fmt in [4, 5, 6]) {
+        for (mr in [4l, 8l, 16l]) {
+            t |> run("repack_k{fmt}_grp mr={mr} preserves dots and row dequants") @(t : T?) {
+                kq_repack_gate(t, fmt, mr)
+            }
+        }
+    }
+}
+
 [test]
 def test_quantize_bs(t : T?) {
     t |> run("bs quantizer matches quantize_q8_0 byte-for-byte plus exact per-16 sums") @(t : T?) {
@@ -363,9 +487,14 @@ def test_kq_load_layout(t : T?) {
         if (!model_available(t, path)) {
             return
         }
+        // this arm is the stage-2 CURSOR-PLACEMENT oracle over disk-order planes — pin the
+        // portable backend so a kq-capable gen backend can't repack them at load (stage 4)
+        pin_kernel_backend("portable")
         set_kquant_native(true)
         var tr <- load_gguf(path, QuantMode.q8)
         set_kquant_native(false)
+        clear_kernel_backend_pin()
+        t |> success(!tr.kq_repacked, "portable-pinned load keeps the kq planes disk-order")
         t |> success(tr.kquant_native, "load detected native K-quant tensors")
         t |> success(cls_kq(tr), "tied Q6_K classifier takes the kq plane path")
         t |> success(tr.wq_fmt[0] == KqFmt.k4, "blk.0.attn_q tagged k4")

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -411,6 +411,132 @@ def test_kq_repack_grp(t : T?) {
     }
 }
 
+// Tile-vs-GEMV gate: the kq 4-token tile must be BIT-exact vs 4 per-token GEMVs over the same
+// repacked planes (the tile's per-token fold order IS the GEMV's). Repack at the layout
+// companion's mr — the same value the stubs/kernels read, so this holds on the reference
+// bodies (interp) AND the stamped kernels (-jit) alike.
+def private kq_tile_gate(t : T?; fmt : int) {
+    let n = 512l
+    let d = 32l
+    let ntok = 7l   // 4-token tile + a 3-token gemv tail
+    let nsb = n / 256l
+    let mr = int64(q8q8_layout_gen())
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 32l
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    var kq : array<uint8>
+    var ks : array<uint8>
+    kq |> resize(int(d * nsb * qsb))
+    ks |> resize(int(d * nsb * ssb))
+    for (r in range64(d)) {
+        for (s in range64(nsb)) {
+            if (fmt == 4) {
+                transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 5) {
+                transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } else {
+                transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            }
+        }
+        var st = 0xDEADBEFu + uint(r) * 0x9E3779Bu
+        for (i in range64(nsb * qsb)) {
+            st = st * 1664525u + 1013904223u
+            kq[r * nsb * qsb + i] = uint8(uint(kq[r * nsb * qsb + i]) ^ (st >> 16u))
+        }
+    }
+    unsafe {
+        if (fmt == 4) {
+            repack_k4_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        } elif (fmt == 5) {
+            repack_k5_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        } else {
+            repack_k6_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        }
+    }
+    // ntok-row activation image, bs-quantized per row
+    var src : array<float>
+    src |> resize(int(ntok * n))
+    for (i in range64(ntok * n)) {
+        src[i] = 0.9 * sin(float(i) * 0.31) + 0.5 * cos(float(i) * 0.043)
+    }
+    var xq : array<int8>
+    var xs : array<float>
+    var xbs : array<int>
+    xq |> resize(int(ntok * n))
+    xs |> resize(int(ntok * n / 32l))
+    xbs |> resize(int(ntok * n / 16l))
+    unsafe {
+        for (p in range64(ntok)) {
+            quantize_q8_0_bs_into_ptr(addr(src[p * n]), n, addr(xq[0]), addr(xs[0]), addr(xbs[0]), p * n, p * (n / 32l), p * (n / 16l))
+        }
+    }
+    var ytile : array<float>
+    var ygemv : array<float>
+    ytile |> resize(int(ntok * d))
+    ygemv |> resize(int(ntok * d))
+    unsafe {
+        let ng = d / mr
+        for (g in range64(ng)) {
+            let kqg = addr(kq[g * mr * nsb * qsb])
+            let ksg = addr(ks[g * mr * nsb * ssb])
+            var tk = 0l
+            while (tk + 4l <= ntok) {   // whole tiles
+                if (fmt == 4) {
+                    k4q8_tile_gen(addr(ytile[0]), kqg, ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
+                } elif (fmt == 5) {
+                    k5q8_tile_gen(addr(ytile[0]), kqg, ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
+                } else {
+                    k6q8_tile_gen(addr(ytile[0]), kqg, ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
+                }
+                tk += 4l
+            }
+            while (tk < ntok) {   // token tail via the rows core (the batch cell's shape)
+                if (fmt == 4) {
+                    k4q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 32l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
+                } elif (fmt == 5) {
+                    k5q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 32l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
+                } else {
+                    k6q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 32l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
+                }
+                tk++
+            }
+        }
+        for (p in range64(ntok)) {   // reference: one full GEMV per token
+            if (fmt == 4) {
+                k4q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 32l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
+            } elif (fmt == 5) {
+                k5q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 32l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
+            } else {
+                k6q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 32l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
+            }
+        }
+    }
+    var bad = 0
+    for (i in range64(ntok * d)) {
+        if (ytile[i] != ygemv[i]) {
+            bad++
+        }
+    }
+    t |> success(bad == 0, "kq tile bit-matches per-token GEMVs")
+    delete kq
+    delete ks
+    delete src
+    delete xq
+    delete xs
+    delete xbs
+    delete ytile
+    delete ygemv
+}
+
+[test]
+def test_kq_tile(t : T?) {
+    for (fmt in [4, 5, 6]) {
+        t |> run("k{fmt} 4-token tile bit-matches per-token GEMVs") @(t : T?) {
+            kq_tile_gate(t, fmt)
+        }
+    }
+}
+
 [test]
 def test_quantize_bs(t : T?) {
     t |> run("bs quantizer matches quantize_q8_0 byte-for-byte plus exact per-16 sums") @(t : T?) {

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -825,6 +825,97 @@ def test_kq_load_layout(t : T?) {
     }
 }
 
+[test]
+def test_kq_fused_qkv_slices(t : T?) {
+    // Fused-projection (Phi3) gate-lift oracle: attn_qkv / ffn_up split at load with dim-multiple
+    // src_offs into the kq planes — a slice landing off by one superblock shows up as noise vs
+    // the file dequant. The K slice (src_off = dim*qd) is the non-trivial placement.
+    t |> run("phi3 fused attn_qkv K-quant slices land at their plane offsets (Phi-3.5 Q4_K_M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Phi-3.5-mini-instruct-Q4_K_M.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        pin_kernel_backend("portable")   // disk-order planes (the placement oracle, like test_kq_load_layout)
+        let prev_kq = get_kquant_native()
+        set_kquant_native(true)
+        var tr <- load_gguf(path, QuantMode.q8)
+        set_kquant_native(prev_kq)
+        clear_kernel_backend_pin()
+        t |> success(tr.kquant_native, "load detected native K-quant tensors")
+        t |> success(tr.wq_fmt[0] == KqFmt.k5 && tr.wk_fmt[0] == KqFmt.k5 && tr.wv_fmt[0] == KqFmt.k5,
+            "fused attn_qkv slices share the Q5_K tag")
+        t |> success(tr.w1_fmt[0] == KqFmt.k4 && tr.w3_fmt[0] == KqFmt.k4, "fused ffn_up gate/up slices tagged k4")
+        t |> success(tr.wcls_fmt == KqFmt.k6 && !cls_kq(tr), "untied Q6_K classifier tagged (no tied-cls path)")
+        let dim = tr.config.dim
+        let qd = layer_qd(tr.config, 0l)
+        let n = 262144l
+        var have : array<float>
+        have |> resize(n)
+        var gt = 0
+        // q slice (src_off 0): the trivial placement
+        dequant_plane_prefix(tr, tr.wq_fmt[0], tr.wq_offs[0], n, have)
+        var fq <- read_prefix(path, "blk.0.attn_qkv.weight", dim * qd + n, gt)
+        var want : array<float>
+        want |> resize(n)
+        for (i in range64(n)) {
+            want[i] = fq[i]
+        }
+        t |> success(rel_rms(have, want) < 1.0e-3, "q slice matches the file dequant (f16-pair rounding only)")
+        // k slice (src_off = dim*qd): the fused-split placement this arm exists for
+        dequant_plane_prefix(tr, tr.wk_fmt[0], tr.wk_offs[0], n, have)
+        for (i in range64(n)) {
+            want[i] = fq[dim * qd + i]
+        }
+        t |> success(rel_rms(have, want) < 1.0e-3, "k slice at src_off dim*qd matches the file dequant")
+        delete fq
+        delete want
+        delete have
+        delete tr
+    }
+}
+
+[test]
+def test_kq_ple_table(t : T?) {
+    // E-series PLE token table (family c): gather-only tensor rides native kq planes — the tag
+    // must take (a silent q8 fallback also passes parity, so pin it here) and whole-row plane
+    // dequant must match the file dequant at its offset.
+    t |> run("E-series PLE token table takes the kq plane path (gemma-4-E2B Q4_K_M)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "gemma-4-E2B-it-Q4_K_M.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        pin_kernel_backend("portable")   // disk-order planes (the placement oracle)
+        let prev_kq = get_kquant_native()
+        set_kquant_native(true)
+        var tr <- load_gguf(path, QuantMode.q8)
+        set_kquant_native(prev_kq)
+        clear_kernel_backend_pin()
+        t |> success(tr.kquant_native, "load detected native K-quant tensors")
+        t |> success(tr.ple_emb_fmt == KqFmt.k5, "per_layer_token_embd tagged k5")
+        t |> success(tr.emb_fmt == KqFmt.k4 && cls_kq(tr), "tied k4 classifier takes the kq plane path")
+        // whole-row placement: rows 0..R of the table vs the file dequant (f16-pair rounding only)
+        let all = tr.config.n_layers * tr.config.n_embd_per_layer
+        let n = all * 16l
+        var have : array<float>
+        have |> resize(n)
+        dequant_plane_prefix(tr, tr.ple_emb_fmt, tr.ple_emb_off, n, have)
+        var gt = 0
+        var fdq <- read_prefix(path, "per_layer_token_embd.weight", n, gt)
+        t |> success(rel_rms(have, fdq) < 1.0e-3, "PLE table plane rows match the file dequant")
+        delete fdq
+        delete have
+        delete tr
+    }
+}
+
 // Dequant the first `n` elements of `name` into fp32; reports the on-disk type via `gt`.
 def private read_prefix(path, name : string; n : int64; var gt : int&) : array<float> {
     var dst : array<float>

--- a/tests/dasLLAMA/test_prefill.das
+++ b/tests/dasLLAMA/test_prefill.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
 options persistent_heap   // + explicit deletes below: each test frees its model/session before the next loads, so multi-GB weights never accumulate in the process
 
 require dastest/testing_boost public


### PR DESCRIPTION
# Native K-quant tier + scheduler audit

Two arcs in one branch (they share the vehicle models and the branch history).

## 1. Native K-quant support (Q4_K_M / Q5_K_M / Q6_K)

GGUF K-quant tensors now run **native** end-to-end — load-time transcode to plane layout, per-32 f16 (d·sc, dmin·m) scale pairs, w4a8-style dots against per-16 activation block sums — instead of the dequant→q8 fallback.

- **Formats**: Q4_K / Q5_K / Q6_K, incl. scalar dequant oracles (bit-exact vs gguf-py), mixed-format models (Q6_K token_embd / attn_v / ffn_down splits), tied classifiers, `--kquant-native` opt-out rail (default ON).
- **Families**: dense; MoE expert stacks (per-expert-slice tags + grp repack + `kq_groupn` region kernels + fused grouped prefill w/ LPT region order); phi3 fused-qkv row slices (dim%256 superblock alignment); gemma-4 E-series PLE table (native planes, gather-only, ~0.7GB resident saved); arm64 (kq slots on arm64-gen, M1-verified).
- **Kernels**: x64-gen kq GEMV/GEMM emitters (sixth family slice; k5 hi-bit const-shuffle splat, k6 native int8 sub-scales), grp&lt;mr&gt; repack, batch tile (bit-exact vs per-token GEMVs), **maddubs i16 lattice** (accumulate all k4 sub-block dots in i16 before one pmaddwd → prefill +10-21% on Zen2).
- **Gates**: parity 40/40 token-for-token vs llama.cpp native K-quant across Qwen3-4B ×3 formats, gemma-4-12B ×3 (1490-token SWA prompt), Phi-3.5-mini, gemma-4-E2B, qwen3moe-30B-A3B; test_kquant synthetic + real-file arms; fused suite; **M1: Q4/Q5/Q6 parity 40/40 ×3 on arm64-gen**.

**Numbers (16t 3990X, ours | llama.cpp)**: Qwen3-4B decode d512 — Q4 18.6|17.9, Q5 16.2|15.7, Q6 14.9|13.9, Q8 12.3|11.4; pp512 Q4 201|180. gemma-4-12B pp512 Q4 69.9|63.8. qwen3moe-30B-A3B: pp512 ~198|150 (+32%), decode d512 20.95|20.49 (+2.2% post-audit).

## 2. Scheduler audit (jobque + dispatch shapers)

- **`lpt_order`**: shared biggest-cost-first region order for region-list dispatches with known unequal costs (fused-MoE buckets = first caller). The C++ team chunk mapping already claims big remainder chunks first.
- **Never-underfill-L**: grain caps in `matmul_chunks` / `matmul_chunks_gemv` may limit oversplit but no longer cut chunk count below the admitted lanes (30B decode router: 2→16 chunks/dispatch, route idle −65%, d512 tie → +2.2% win). `matmul_grid` gates its 2-D remedy on the grain-derived count.
- **Batch GEMMs off the GEMV shaper**: the GEMV wave formula (`rows/(64·L)·L`) cancels L — the 4B w2 GEMM issued a fixed 32 chunks at both 16 and 32 lanes; kq batch now uses the GEMM shaper, and 8 portable/neon/fp32/bf16 batch sites take the batch oversplit knob instead of a hardcoded 1.
- **Worker/caller CPU affinity** (`DAS_JOBQUE_AFFINITY`: 0/1=ideal-CPU hint (default)/2=hard mask): fills distinct physical cores before SMT siblings. Kills a placement lottery — 32 lanes on the 3990X measured pp512 **bimodal 306 vs 199 tok/s** (SMT-packed mode: walls flat, lane-time ×1.95); llama.cpp sat stable at 278. Fast mode = +11% over llama.cpp.
- **`set_current_thread_priority` builtin** (+AOT header decl): the team-dispatch caller is load-bearing (every all-lane hole in traced decode ends at a publish — hole-blame census); dasLLAMA claims Maximum by default, `DASLLAMA_CALLER_PRIO` rail.
- **eval_batch tail threading**: per-row logits softcap + scatter (5MB at B=8) becomes one row-parallel dispatch (ffn-side caller seams max 2318→808µs; batch≡seq 16/16 bit-exact).
- Tooling: per-lane jobque trace rails for prefill_perf (`DASLLAMA_PREFILL_TRACE`) and batch_decode_perf (`DASLLAMA_BATCH_TRACE`); decode router trace tags; per-tensor kq byte model in decode_prof; flash-decode slice cap 16→32 (deep-ctx +12-14%, Qwen2.5-1.5B crossover fixed).

## Gates

Full preflight 13/0 (token on HEAD); fused decode suite 10/10 armed (JIT); test_kquant; test_batch_decode 16/16 (batch≡sequential bit-exact incl. q8_kv); test_dispatch_shaping re-pinned to the never-underfill invariant; test_aot target builds clean post-rebase.

## Follow-ups (tracked)

- M1 kq tune pass: Q4 4B decode −9%/−5% vs llama.cpp on M1 (kernel-level, ~90 vs ~99GB/s effective; arm64 kq stamp shipped untuned).
- Batch decode step-boundary hole (~6-7ms before each step's first attention dispatch) — survives the argmax + scatter fixes, unexplained.
- (head × q-tile) prefill attention split + triangular LPT (geometry-capped per-head chunks; needs slot-indexed flash scratch).
- Stamped flash-decode s2 slice core (attn s2 = 100% of decode depth cost, 2.8-3.6× byte-bound busy-work at every depth).
- FLASH_DECODE_MAX_SLICES flat 32→64 A/B at 32 lanes (numeric carve-out — stays ctx-derived).

🤖 Generated with [Claude Code](https://claude.com/claude-code)