### PR TITLE
jobque: self-describing traces — named categories, colors, unit markers

### DIFF
--- a/daslib/jobque_profile.das
+++ b/daslib/jobque_profile.das
@@ -34,7 +34,7 @@ var private g_nextCategoryId = 1
 
 def private resolve_color(name : string; color : uint) : uint {
     if (color != 0u) return color
-    return DEFAULT_PALETTE[int(hash(name) % uint64(12))]
+    return DEFAULT_PALETTE[int(hash(name) % uint64(length(DEFAULT_PALETTE)))]
 }
 
 def public profile_start(events_per_lane : int = 65536) {

--- a/daslib/jobque_profile.das
+++ b/daslib/jobque_profile.das
@@ -1,0 +1,102 @@
+options gen2
+options indenting = 4
+
+module jobque_profile shared public
+
+//! Self-describing jobque profiling on top of the per-lane event tracer.
+//!
+//! Wraps the ``jobque_trace_*`` builtins with named **categories** (colored
+//! legend entries for the op tags stamped via ``profile_tag``) and **markers**
+//! (instant "unit" events such as ``frame`` or ``token``), so saved traces
+//! carry their own meaning. Files stay perfetto-compatible; the category and
+//! marker tables ride in a ``jobqueProfile`` sibling key viewers read.
+
+require jobque public
+
+// dark-theme viewer hues first (lane-timeline palette), then 4 extra distinct hues
+let private DEFAULT_PALETTE = fixed_array<uint>(
+    0x5E96DEu, 0x43B08Au, 0xAC82E4u, 0xC39536u, 0xE08563u, 0x4FC3D0u,
+    0xD678B4u, 0x8385E8u, 0xD8626Au, 0x9BB556u, 0x7A9AAEu, 0xB08968u)
+
+let public PROFILE_COLOR_BLUE = 0x5E96DEu
+let public PROFILE_COLOR_GREEN = 0x43B08Au
+let public PROFILE_COLOR_PURPLE = 0xAC82E4u
+let public PROFILE_COLOR_AMBER = 0xC39536u
+let public PROFILE_COLOR_CORAL = 0xE08563u
+let public PROFILE_COLOR_TEAL = 0x4FC3D0u
+let public PROFILE_COLOR_MAGENTA = 0xD678B4u
+let public PROFILE_COLOR_INDIGO = 0x8385E8u
+
+var private g_categoryIds : table<string; int>
+var private g_usedCategoryIds : table<int>
+var private g_markerIds : table<string; int>
+var private g_nextCategoryId = 1
+
+def private resolve_color(name : string; color : uint) : uint {
+    if (color != 0u) return color
+    return DEFAULT_PALETTE[int(hash(name) % uint64(12))]
+}
+
+def public profile_start(events_per_lane : int = 65536) {
+    //! Arm the per-lane trace rings (`events_per_lane` events each; full lanes stop recording).
+    jobque_trace_start(events_per_lane)
+}
+
+def public profile_stop() {
+    //! Disarm tracing. Must be called before `profile_save`.
+    jobque_trace_stop()
+}
+
+def public profile_save(path : string) : bool {
+    //! Write the recorded trace as perfetto-compatible JSON, including the category and
+    //! marker registries. Returns false when tracing is still on or nothing was recorded.
+    return jobque_trace_save(path)
+}
+
+def public profile_tag(tag : int) {
+    //! Stamp the current op tag; subsequent chain publishes carry it (viewer color channel).
+    jobque_trace_tag(tag)
+}
+
+def public profile_category(id : int; name : string; color : uint = 0u) {
+    //! Register a named category for an existing tag id (`color` is 0xRRGGBB;
+    //! 0 picks from the default palette by name hash).
+    g_usedCategoryIds |> insert(id)
+    g_categoryIds[name] = id
+    jobque_trace_category(id, name, resolve_color(name, color))
+}
+
+def public profile_category(name : string; color : uint = 0u) : int {
+    //! Register a named category with an auto-assigned tag id (idempotent per name).
+    //! Returns the tag to stamp via `profile_tag`.
+    var id = g_categoryIds?[name] ?? -1
+    if (id < 0) {
+        while (g_usedCategoryIds |> key_exists(g_nextCategoryId)) {
+            g_nextCategoryId++
+        }
+        id = g_nextCategoryId++
+        g_usedCategoryIds |> insert(id)
+        g_categoryIds[name] = id
+    }
+    jobque_trace_category(id, name, resolve_color(name, color))
+    return id
+}
+
+def public profile_marker_id(name : string) : int {
+    //! Register/look up a marker kind (e.g. "token", "frame"); idempotent per name.
+    let existing = g_markerIds?[name] ?? -1
+    if (existing >= 0) return existing
+    let id = jobque_trace_marker_name(name)
+    g_markerIds[name] = id
+    return id
+}
+
+def public profile_marker(id : int; arg : int = 0) {
+    //! Stamp an instant unit boundary on the caller lane (no-op when tracing is off).
+    jobque_trace_marker(id, arg)
+}
+
+def public profile_marker(name : string; arg : int = 0) {
+    //! Convenience form of `profile_marker`; prefer the id form in hot loops.
+    jobque_trace_marker(profile_marker_id(name), arg)
+}

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -27,6 +27,7 @@ require daslib/apply
 require daslib/algorithm
 require daslib/ansi_colors
 require daslib/jobque_boost
+require daslib/jobque_profile
 require daslib/apply_in_context
 require daslib/contracts
 require daslib/defer
@@ -584,7 +585,7 @@ def document_module_jobque(_root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Channel, JobStatus, Lockbox, Stream", mod, %regex~(append|notify|join|channel_create|channel_remove|stream_create|stream_remove|add_ref|release|notify_and_release|lock_box_create|lock_box_remove|job_status_create|job_status_remove)$%%),
         group_by_regex("Queries", mod, %regex~(get_total_hw_jobs|get_total_hw_threads|get_total_hw_cores|is_job_que_shutting_down|is_job_que_available|count_jobque_leaks)$%%),
-        group_by_regex("Event tracing", mod, %regex~(jobque_trace_start|jobque_trace_stop|jobque_trace_save|jobque_trace_tag)$%%),
+        group_by_regex("Event tracing", mod, %regex~(jobque_trace_start|jobque_trace_stop|jobque_trace_save|jobque_trace_tag|jobque_trace_category|jobque_trace_marker_name|jobque_trace_marker)$%%),
         group_by_regex("Internal invocations", mod, %regex~(new_job_invoke|new_thread_invoke|new_debugger_thread|set_jobque_fork_pool|set_jobque_fork_skip_heap_reset|set_jobque_worker_spin|set_jobque_batch_dispatch|set_jobque_join_spin|set_jobque_team_mode|get_jobque_team_mode|set_jobque_threads_cap|set_jobque_affinity|get_jobque_affinity|set_jobque_worker_limit|get_jobque_worker_limit|set_jobque_team_rank_gate|get_jobque_team_rank_gate|set_jobque_team_prof|reset_jobque_team_prof|get_jobque_team_prof|get_jobque_team_prof_counts|get_jobque_team_prof_react|team_parallel_for_invoke|team_parallel_for_indexed_invoke|team_parallel_stages_invoke|flush_jobque_batch|jobque_try_run_one)$%%),
         group_by_regex("Construction", mod, %regex~(with_channel|with_stream|with_job_status|with_job_que|with_lock_box|create_job_que|destroy_job_que)$%%),
         group_by_regex("Atomic", mod, %regex~(atomic32_create|atomic32_remove|with_atomic32|atomic64_create|atomic64_remove|with_atomic64|get|set|inc|dec)$%%)
@@ -605,6 +606,16 @@ def document_module_jobque_boost(_root : string) {
         group_by_regex("Internal capture details", mod, %regex~(capture_jobque_channel|capture_jobque_job_status|release_capture_jobque_channel|release_capture_jobque_job_status|capture_jobque_lock_box|release_capture_jobque_lock_box|capture_jobque_stream|release_capture_jobque_stream)$%%)
     )
     document("Boost package for jobs and threads", mod, "jobque_boost.rst", groups)
+}
+
+def document_module_jobque_profile(_root : string) {
+    var mod = find_module("jobque_profile")
+    var groups <- array<DocGroup>(
+        group_by_regex("Trace sessions", mod, %regex~(profile_start|profile_stop|profile_save)$%%),
+        group_by_regex("Categories", mod, %regex~(profile_category|profile_tag)$%%),
+        group_by_regex("Markers", mod, %regex~(profile_marker|profile_marker_id)$%%)
+    )
+    document("Self-describing jobque profiling", mod, "jobque_profile.rst", groups)
 }
 
 def document_module_apply_in_context(_root : string) {
@@ -1860,6 +1871,7 @@ def main {
     document_module_interfaces(root)
     document_module_is_local(root)
     document_module_jobque_boost(root)
+    document_module_jobque_profile(root)
     document_module_json_boost(root)
     document_module_json(root)
     document_module_jsonrpc(root)

--- a/doc/source/stdlib/handmade/function-jobque-jobque_trace_category-0x9e6a5d0ed05ba6da.rst
+++ b/doc/source/stdlib/handmade/function-jobque-jobque_trace_category-0x9e6a5d0ed05ba6da.rst
@@ -1,0 +1,1 @@
+Registers a named category for a trace op tag (the id stamped via ``jobque_trace_tag``), with a display color packed as 0xRRGGBB. Re-registering an id updates its name and color. The registry persists across trace sessions; ``jobque_trace_save`` writes it into the file's ``jobqueProfile`` header so viewers can label and color events without hardcoded knowledge.

--- a/doc/source/stdlib/handmade/function-jobque-jobque_trace_marker-0x23d3c8a055ea0170.rst
+++ b/doc/source/stdlib/handmade/function-jobque-jobque_trace_marker-0x23d3c8a055ea0170.rst
@@ -1,0 +1,1 @@
+Stamps an instant unit-boundary event (kind id from ``jobque_trace_marker_name``, plus a free-form ``arg`` such as the token index) on the caller lane. No-op when tracing is off — cheap enough for per-token/per-frame loops. Saved as a perfetto instant event, so unit boundaries render natively in Perfetto and unit-aware viewers can navigate trace windows by unit.

--- a/doc/source/stdlib/handmade/function-jobque-jobque_trace_marker_name-0x11d82ed54aded050.rst
+++ b/doc/source/stdlib/handmade/function-jobque-jobque_trace_marker_name-0x11d82ed54aded050.rst
@@ -1,0 +1,1 @@
+Registers a marker kind (a "unit" name such as "token", "frame", "layer") and returns its id for ``jobque_trace_marker``. Idempotent — re-registering the same name returns the existing id. Saved traces list all marker kinds in the ``jobqueProfile`` header.

--- a/doc/source/stdlib/handmade/module-jobque_profile.rst
+++ b/doc/source/stdlib/handmade/module-jobque_profile.rst
@@ -1,0 +1,37 @@
+The JOBQUE_PROFILE module wraps the low-level ``jobque_trace_*`` builtins into a
+self-describing profiling API: named **categories** with colors for the op tags
+stamped via ``profile_tag``, and **markers** — instant "unit" events such as
+``token`` or ``frame`` — so saved traces carry their own legend and are navigable
+unit-to-unit. Files remain perfetto-compatible; the category and marker tables
+ride in a ``jobqueProfile`` sibling key that Perfetto ignores.
+
+See also :doc:`jobque` for the underlying event tracer.
+
+All functions and symbols are in "jobque_profile" module, use require to get access to it.
+
+.. code-block:: das
+
+    require daslib/jobque_profile
+
+Example:
+
+.. code-block:: das
+
+    require daslib/jobque_boost
+    require daslib/jobque_profile
+
+    [export]
+    def main() {
+        with_job_que() {
+            let heavy = profile_category("heavy op")     // auto id + palette color
+            let tok = profile_marker_id("token")
+            profile_start(65536)
+            for (i in range(4)) {
+                profile_marker(tok, i)                   // unit boundary
+                profile_tag(heavy)
+                // ... dispatch work ...
+            }
+            profile_stop()
+            profile_save("trace.json")                   // open in Perfetto or the timeline viewer
+        }
+    }

--- a/doc/source/stdlib/sec_concurrency.rst
+++ b/doc/source/stdlib/sec_concurrency.rst
@@ -10,6 +10,7 @@ Job queues, coroutines, asynchronous operations, and cross-context invocation.
 
    generated/jobque.rst
    generated/jobque_boost.rst
+   generated/jobque_profile.rst
    generated/apply_in_context.rst
    generated/coroutines.rst
    generated/async_boost.rst

--- a/include/daScript/misc/job_que.h
+++ b/include/daScript/misc/job_que.h
@@ -197,6 +197,13 @@ namespace das {
         // small app-defined id before a dispatch; ChainPublish records numStages | (tag << 8) in
         // its stage field, and workers' chunk events join to it via the chain id.
         void traceSetTag ( int tag ) { mTraceTag.store(tag, std::memory_order_relaxed); }
+        // Self-describing traces: categories name the traceSetTag ids (viewer color/legend
+        // channel), markers stamp instant "unit" events (frame, token) on the caller lane so
+        // viewers navigate unit-to-unit. Registries persist across trace sessions; traceSave
+        // emits them in a "jobqueProfile" sibling key Perfetto ignores.
+        void traceCategory ( int id, const char * name, uint32_t rgb );    // rgb = 0xRRGGBB
+        int  traceMarkerName ( const char * name );                        // idempotent per name
+        void traceMarker ( int nameId, int arg );                          // no-op unless tracing
     protected:
         struct JobEntry {
             JobEntry( Job&& _function, JobCategory _category, JobPriority _priority) {
@@ -289,7 +296,7 @@ namespace das {
         uint64_t mTPreact = 0, mTPreactN = 0, mTPlastRel = 0, mTPlastN = 0;
         // per-lane trace rings (see traceStart). lane == worker threadIndex; the dispatching
         // caller records as lane getNumWorkers().
-        enum class TraceTag : uint32_t { ChainPublish, Chunk, StageWait, Wake, FifoJob };
+        enum class TraceTag : uint32_t { ChainPublish, Chunk, StageWait, Wake, FifoJob, Marker };
         struct TraceEvent {
             uint64_t t0, t1;        // ref_time_ticks (ns, one clock for every lane)
             uint32_t tag, stage;    // TraceTag; stage index (Chunk/StageWait) or stage count (ChainPublish)
@@ -304,6 +311,10 @@ namespace das {
         atomic<int32_t> mTraceTag{0};   // current op tag (traceSetTag) — folded into ChainPublish.stage's high bits
         uint64_t mTraceT0 = 0;          // session start tick — wake spans clamp their park-t0 to it
         vector<LaneTrace> mTrace;
+        struct TraceCategory { int id; string name; uint32_t rgb; };
+        mutex mTraceRegMutex;                    // guards both registries (cold path only)
+        vector<TraceCategory> mTraceCategories;
+        vector<string> mTraceMarkerNames;        // marker nameId = index
         __forceinline void traceEvent ( int lane, TraceTag tag, uint64_t t0, uint64_t t1,
                 uint32_t stage, uint32_t arg, uint32_t chain ) {
             if ( uint32_t(lane) >= uint32_t(mTrace.size()) ) return;

--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -199,6 +199,9 @@ namespace das {
     DAS_API void jobque_trace_stop ( Context * context, LineInfoArg * at );
     DAS_API bool jobque_trace_save ( const char * path, Context * context, LineInfoArg * at );
     DAS_API void jobque_trace_tag ( int32_t tag, Context * context, LineInfoArg * at );
+    DAS_API void jobque_trace_category ( int32_t id, const char * name, uint32_t color, Context * context, LineInfoArg * at );
+    DAS_API int32_t jobque_trace_marker_name ( const char * name, Context * context, LineInfoArg * at );
+    DAS_API void jobque_trace_marker ( int32_t id, int32_t arg, Context * context, LineInfoArg * at );
     DAS_API void jobque_set_thread_priority ( int32_t level, Context * context, LineInfoArg * at );
     DAS_API void team_parallel_for_invoke ( int32_t rangeBegin, int32_t rangeEnd, int32_t numChunks, Lambda lambda, Func fn, int32_t lambdaSize, Context * context, LineInfoArg * lineinfo );
     DAS_API void team_parallel_for_indexed_invoke ( int32_t rangeBegin, int32_t rangeEnd, int32_t numChunks, Lambda lambda, Func fn, int32_t lambdaSize, Context * context, LineInfoArg * lineinfo );

--- a/modules/dasLLAMA/benchmarks/batch_decode_perf.das
+++ b/modules/dasLLAMA/benchmarks/batch_decode_perf.das
@@ -103,7 +103,8 @@ def private run_batched(t : Model; kvdt : KVDtype; nb, p, n : int64) : double {
         cur |> push(greedy_top(ss[i].logits, vocab))
     }
     let t0 = ref_time_ticks()
-    for (_st in range64(n)) {
+    for (st in range64(n)) {
+        trace_marker("step", int(st))   // unit boundary for the timeline viewer (no-op untraced)
         eval_batch_(t, ws, sess, cur)
         for (i in range64(nb)) {
             cur[i] = greedy_top(ss[i].logits, vocab)

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -209,6 +209,7 @@ def private profile_window(t : Model; var s : Session; p, n : int64; tok0 : int6
     forward_profile_reset()
     let t0 = ref_time_ticks()
     for (i in range64(n)) {
+        trace_marker("token", int(i))   // unit boundary for the timeline viewer (no-op untraced)
         forward(t, s, tok, p + i)
         tok = greedy_top(s, t.config.vocab_size)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -8659,6 +8659,7 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     }
     if (!stack_done) {
         for (l in range64(c.n_layers)) {
+            trace_marker("layer", int(l))   // unit boundary for the timeline viewer (no-op untraced)
             trace_tag(TRACE_TAG_ATTN_STD)   // per-lane trace: color the prefill attention section
             t.blocks.attn_prefill(t, s, l, npos, start_pos)
             trace_tag(TRACE_TAG_FFN_STD)

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -526,7 +526,7 @@ def public get_team_rank_gate() : int { return g_team_rank_gate }
 var g_trace_tags = false
 def public set_trace_tags(on : bool) {
     g_trace_tags = on
-    if (on) {
+    if (on && is_job_que_available()) {   // registries live on the que; stay que-independent like trace_tag
         register_trace_categories()
     }
 }
@@ -547,7 +547,7 @@ def public trace_tag(t : int) {
 }
 def public trace_marker(name : string; arg : int) {
     // instant unit boundary ("token", "layer", "step") on the caller lane; same gate as trace_tag
-    if (g_trace_tags) {
+    if (g_trace_tags && is_job_que_available()) {
         profile_marker(name, arg)
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -6,6 +6,7 @@ require math
 require strings  // to_int: DASLLAMA_CALLER_PRIO env override in setup_dasllama_jobque_
 require daslib/fio  // has_env_variable: DAS_JOBQUE_TEAM_RANK_GATE suppresses the profile's team_rank_gate knob
 require daslib/jobque_boost public  // matmul's threaded path expands parallel_for; consumers need its symbols
+require daslib/jobque_profile  // named trace categories + unit markers (set_trace_tags registers them)
 require dasllama/dasllama_par  // maybe_parallel_for: thread-or-inline a kernel body on a runtime size flag
 require dasllama/dasllama_tune  // [tuned]: reconstitute dot from dot_template with per-box loop hints
 require llvm/daslib/f16_cvt  // f16<->f32 converts: JIT half intrinsics on aarch64 / x64+F16C, exact bit-twiddle elsewhere
@@ -523,7 +524,12 @@ def public get_team_rank_gate() : int { return g_team_rank_gate }
 // by OP rather than stage-count. Gated — set_trace_tags(true) rides with jobque_trace_start in
 // the profiling harness; production dispatches never pay the extern call.
 var g_trace_tags = false
-def public set_trace_tags(on : bool) { g_trace_tags = on }
+def public set_trace_tags(on : bool) {
+    g_trace_tags = on
+    if (on) {
+        register_trace_categories()
+    }
+}
 let public TRACE_TAG_ATTN_CHAIN = 1
 let public TRACE_TAG_ATTN_STD = 2
 let public TRACE_TAG_FFN_CHAIN = 3
@@ -538,6 +544,26 @@ def public trace_tag(t : int) {
     if (g_trace_tags) {
         jobque_trace_tag(t)
     }
+}
+def public trace_marker(name : string; arg : int) {
+    // instant unit boundary ("token", "layer", "step") on the caller lane; same gate as trace_tag
+    if (g_trace_tags) {
+        profile_marker(name, arg)
+    }
+}
+// names/colors match the lane-timeline viewer's dark-theme palette, so saved traces carry
+// the exact legend the artifact hardcoded
+def private register_trace_categories() {
+    profile_category(TRACE_TAG_ATTN_CHAIN, "attn chain", 0x5E96DEu)
+    profile_category(TRACE_TAG_ATTN_STD, "attn std", 0x5E96DEu)
+    profile_category(TRACE_TAG_FFN_CHAIN, "ffn chain", 0x43B08Au)
+    profile_category(TRACE_TAG_FFN_STD, "ffn per-op", 0x43B08Au)
+    profile_category(TRACE_TAG_CLS, "classifier", 0xAC82E4u)
+    profile_category(TRACE_TAG_MOE, "moe experts", 0xE08563u)
+    profile_category(TRACE_TAG_SHEXP, "shexp", 0xC39536u)
+    profile_category(TRACE_TAG_PLE, "ple", 0xC39536u)
+    profile_category(TRACE_TAG_ROUTE, "router", 0x4FC3D0u)
+    profile_category(TRACE_TAG_PARK, "park/reduce", 0xD678B4u)
 }
 
 //! Configure the job queue for dasLLAMA's pure fork/join matmul dispatch: pooled fork contexts,

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -828,6 +828,21 @@ namespace das {
         if ( g_jobQue ) g_jobQue->traceSetTag(tag);
     }
 
+    void jobque_trace_category ( int32_t id, const char * name, uint32_t color, Context * context, LineInfoArg * at ) {
+        if ( !g_jobQue ) context->throw_error_at(at, "need to be in a 'with_job_que' block, or call create_job_que() first");
+        g_jobQue->traceCategory(id, name ? name : "", color);
+    }
+
+    int32_t jobque_trace_marker_name ( const char * name, Context * context, LineInfoArg * at ) {
+        if ( !g_jobQue ) context->throw_error_at(at, "need to be in a 'with_job_que' block, or call create_job_que() first");
+        return g_jobQue->traceMarkerName(name ? name : "");
+    }
+
+    void jobque_trace_marker ( int32_t id, int32_t arg, Context *, LineInfoArg * ) {
+        // instant "unit" event (frame/token boundary); no-op without a que or with tracing off
+        if ( g_jobQue ) g_jobQue->traceMarker(id, arg);
+    }
+
     void jobque_set_thread_priority ( int32_t level, Context *, LineInfoArg * ) {
         // OS priority of the CALLING thread, JobPriority scale -2 (Minimum) .. 2 (Maximum).
         // The dispatch caller is load-bearing in team mode — only it publishes chains, so a
@@ -1508,6 +1523,15 @@ namespace das {
             addExtern<DAS_BIND_FUN(jobque_trace_tag)>(*this, lib,  "jobque_trace_tag",
                 SideEffects::modifyExternal, "jobque_trace_tag")
                     ->args({"tag","context","line"});
+            addExtern<DAS_BIND_FUN(jobque_trace_category)>(*this, lib,  "jobque_trace_category",
+                SideEffects::modifyExternal, "jobque_trace_category")
+                    ->args({"id","name","color","context","line"});
+            addExtern<DAS_BIND_FUN(jobque_trace_marker_name)>(*this, lib,  "jobque_trace_marker_name",
+                SideEffects::modifyExternal, "jobque_trace_marker_name")
+                    ->args({"name","context","line"});
+            addExtern<DAS_BIND_FUN(jobque_trace_marker)>(*this, lib,  "jobque_trace_marker",
+                SideEffects::modifyExternal, "jobque_trace_marker")
+                    ->args({"id","arg","context","line"});
             addExtern<DAS_BIND_FUN(jobque_set_thread_priority)>(*this, lib,  "set_current_thread_priority",
                 SideEffects::modifyExternal, "jobque_set_thread_priority")
                     ->args({"level","context","line"});

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -318,11 +318,12 @@ namespace das {
             for ( uint32_t i = 0; i != L.n; ++i ) {
                 const auto & e = L.ev[i];
                 if ( e.tag == uint32_t(TraceTag::Marker) ) {
-                    // perfetto instant event; name = the registered marker kind
+                    // perfetto instant event; name = the registered marker kind. arg is
+                    // signed in the API (jobque_trace_marker) — emit %d so it round-trips
                     fprintf(f, ",\n{\"ph\":\"i\",\"s\":\"g\",\"pid\":0,\"tid\":%d,\"ts\":%.3f,\"name\":",
                         int(lane), double(e.t0 - tmin) / 1000.0);
                     fputsJsonString(f, e.stage < uint32_t(markerNames.size()) ? markerNames[e.stage].c_str() : "marker");
-                    fprintf(f, ",\"args\":{\"arg\":%u}}", e.arg);
+                    fprintf(f, ",\"args\":{\"arg\":%d}}", int32_t(e.arg));
                     continue;
                 }
                 fprintf(f, ",\n{\"ph\":\"X\",\"pid\":0,\"tid\":%d,\"ts\":%.3f,\"dur\":%.3f,\"name\":\"%s\","

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -254,6 +254,42 @@ namespace das {
         mTraceOn.store(1, std::memory_order_seq_cst);
     }
 
+    void JobQue::traceCategory ( int id, const char * name, uint32_t rgb ) {
+        lock_guard<mutex> guard(mTraceRegMutex);
+        for ( auto & c : mTraceCategories ) {
+            if ( c.id == id ) { c.name = name ? name : ""; c.rgb = rgb; return; }
+        }
+        mTraceCategories.push_back({id, name ? name : "", rgb});
+    }
+
+    int JobQue::traceMarkerName ( const char * name ) {
+        lock_guard<mutex> guard(mTraceRegMutex);
+        string n = name ? name : "";
+        for ( size_t i = 0; i != mTraceMarkerNames.size(); ++i ) {
+            if ( mTraceMarkerNames[i] == n ) return int(i);
+        }
+        mTraceMarkerNames.push_back(n);
+        return int(mTraceMarkerNames.size()) - 1;
+    }
+
+    void JobQue::traceMarker ( int nameId, int arg ) {
+        if ( !mTraceOn.load(std::memory_order_relaxed) ) return;
+        // caller lane — markers come from the orchestrating thread (per-token/per-frame loops)
+        uint64_t t = uint64_t(ref_time_ticks());
+        traceEvent(int(mTrace.size()) - 1, TraceTag::Marker, t, t, uint32_t(nameId), uint32_t(arg), 0);
+    }
+
+    static void fputsJsonString ( FILE * f, const char * s ) {
+        fputc('"', f);
+        for ( ; s && *s; ++s ) {
+            char c = *s;
+            if ( c == '"' || c == '\\' ) { fputc('\\', f); fputc(c, f); }
+            else if ( uint8_t(c) >= 0x20 ) fputc(c, f);
+            else fprintf(f, "\\u%04x", c);
+        }
+        fputc('"', f);
+    }
+
     bool JobQue::traceSave ( const char * path ) {
         if ( mTraceOn.load(std::memory_order_relaxed) ) return false;   // stop before saving
         uint64_t tmin = ~0ull;
@@ -263,6 +299,13 @@ namespace das {
         if ( tmin == ~0ull ) return false;
         FILE * f = fopen(path, "wb");
         if ( !f ) return false;
+        vector<TraceCategory> cats;
+        vector<string> markerNames;
+        {
+            lock_guard<mutex> guard(mTraceRegMutex);
+            cats = mTraceCategories;
+            markerNames = mTraceMarkerNames;
+        }
         static const char * tagName[] = { "publish", "chunk", "stage_wait", "wake", "fifo_job" };
         fprintf(f, "{\"traceEvents\":[");
         bool first = true;
@@ -274,13 +317,34 @@ namespace das {
             first = false;
             for ( uint32_t i = 0; i != L.n; ++i ) {
                 const auto & e = L.ev[i];
+                if ( e.tag == uint32_t(TraceTag::Marker) ) {
+                    // perfetto instant event; name = the registered marker kind
+                    fprintf(f, ",\n{\"ph\":\"i\",\"s\":\"g\",\"pid\":0,\"tid\":%d,\"ts\":%.3f,\"name\":",
+                        int(lane), double(e.t0 - tmin) / 1000.0);
+                    fputsJsonString(f, e.stage < uint32_t(markerNames.size()) ? markerNames[e.stage].c_str() : "marker");
+                    fprintf(f, ",\"args\":{\"arg\":%u}}", e.arg);
+                    continue;
+                }
                 fprintf(f, ",\n{\"ph\":\"X\",\"pid\":0,\"tid\":%d,\"ts\":%.3f,\"dur\":%.3f,\"name\":\"%s\","
                     "\"args\":{\"stage\":%u,\"arg\":%u,\"chain\":%u}}",
                     int(lane), double(e.t0 - tmin) / 1000.0, double(e.t1 - e.t0) / 1000.0,
                     tagName[e.tag < 5 ? e.tag : 4], e.stage, e.arg, e.chain);
             }
         }
-        fprintf(f, "\n]}\n");
+        // sibling key after traceEvents (JSON Object Format) — Perfetto/chrome ignore unknown keys
+        fprintf(f, "\n],\"jobqueProfile\":{\"version\":1,\"lanes\":%d,\"categories\":[", int(mTrace.size()));
+        for ( size_t i = 0; i != cats.size(); ++i ) {
+            fprintf(f, "%s{\"id\":%d,\"name\":", i ? "," : "", cats[i].id);
+            fputsJsonString(f, cats[i].name.c_str());
+            fprintf(f, ",\"color\":\"#%06X\"}", cats[i].rgb & 0xFFFFFFu);
+        }
+        fprintf(f, "],\"markers\":[");
+        for ( size_t i = 0; i != markerNames.size(); ++i ) {
+            fprintf(f, "%s{\"id\":%d,\"name\":", i ? "," : "", int(i));
+            fputsJsonString(f, markerNames[i].c_str());
+            fputc('}', f);
+        }
+        fprintf(f, "]}}\n");
         fclose(f);
         return true;
     }

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -319,7 +319,10 @@ namespace das {
                 const auto & e = L.ev[i];
                 if ( e.tag == uint32_t(TraceTag::Marker) ) {
                     // perfetto instant event; name = the registered marker kind. arg is
-                    // signed in the API (jobque_trace_marker) — emit %d so it round-trips
+                    // signed in the API (jobque_trace_marker) — emit %d so it round-trips.
+                    // scope "g" is deliberate: unit boundaries (frame/token) draw across ALL
+                    // lanes in Perfetto; tid still records the emitting (caller) lane for
+                    // viewers that read it directly
                     fprintf(f, ",\n{\"ph\":\"i\",\"s\":\"g\",\"pid\":0,\"tid\":%d,\"ts\":%.3f,\"name\":",
                         int(lane), double(e.t0 - tmin) / 1000.0);
                     fputsJsonString(f, e.stage < uint32_t(markerNames.size()) ? markerNames[e.stage].c_str() : "marker");

--- a/tests/jobque/test_jobque_trace.das
+++ b/tests/jobque/test_jobque_trace.das
@@ -55,6 +55,7 @@ def test_trace_round_trip(t : T?) {
             set_jobque_team_mode(false)
             profile_marker(tokId, 41)
             profile_marker("token", 42)
+            profile_marker(tokId, -7)   // args are signed — must survive the JSON round-trip
             profile_stop()
 
             var terr = ""
@@ -131,9 +132,10 @@ def test_trace_round_trip(t : T?) {
             t |> equal(0, nUntaggedPublish)
             feint("tagged publishes: {nTaggedPublish}\n")
             sort(markerArgs)
-            t |> equal(2, length(markerArgs))
-            t |> equal(41, markerArgs[0])
-            t |> equal(42, markerArgs[1])
+            t |> equal(3, length(markerArgs))
+            t |> equal(-7, markerArgs[0])
+            t |> equal(41, markerArgs[1])
+            t |> equal(42, markerArgs[2])
         }
     }
 }

--- a/tests/jobque/test_jobque_trace.das
+++ b/tests/jobque/test_jobque_trace.das
@@ -1,0 +1,139 @@
+options gen2
+require dastest/testing_boost public
+require daslib/jobque_boost
+require daslib/jobque_profile
+require daslib/fio
+require daslib/json_boost
+require strings
+
+// Round-trip of the per-lane event tracer with the jobque_profile registries: arm, register
+// categories + markers, run a team dispatch storm with a tagged op and unit markers, save,
+// re-read the JSON, and assert the self-describing header + events survived.
+
+def read_text_file(path : string) : string {
+    var text = ""
+    fopen(path, "rb") $(f) {
+        if (f != null) {
+            text = fread(f)
+        }
+    }
+    return text
+}
+
+def team_storm(nj, total : int) {
+    var results : array<int>
+    results |> resize(total)
+    var pr = unsafe(addr(results[0]))
+    team_parallel_for(0, total, nj) <| @(job_begin : int; job_end : int) {
+        for (i in range(job_begin, job_end)) {
+            unsafe(pr[i]) = i * 3 + 1
+        }
+    }
+    delete results
+}
+
+[test]
+def test_trace_round_trip(t : T?) {
+    t |> run("categories, markers, and events round-trip through save") @(t : T?) {
+        with_job_que() {
+            // registries: explicit id, auto id (idempotent), auto skips used ids
+            profile_category(7, "seven", 0x112233u)
+            let catAlpha = profile_category("alpha")
+            t |> equal(1, catAlpha)
+            t |> equal(catAlpha, profile_category("alpha"))
+            profile_category(2, "two")
+            t |> equal(3, profile_category("beta"))
+            let tokId = profile_marker_id("token")
+            t |> equal(0, tokId)
+            t |> equal(tokId, profile_marker_id("token"))
+            t |> equal(1, profile_marker_id("frame"))
+
+            profile_start(8192)
+            set_jobque_team_mode(true)
+            profile_tag(7)
+            team_storm(8, 4096)
+            set_jobque_team_mode(false)
+            profile_marker(tokId, 41)
+            profile_marker("token", 42)
+            profile_stop()
+
+            var terr = ""
+            let dir = temp_directory(terr)
+            t |> success(terr == "", "temp_directory resolves")
+            let path = "{dir}/test_jobque_trace_out.json"
+            t |> success(profile_save(path), "profile_save succeeds")
+
+            let text = read_text_file(path)
+            t |> success(!empty(text), "trace file is not empty")
+            var jerr = ""
+            let root = read_json(text, jerr)
+            t |> success(root != null, "trace file parses as JSON: {jerr}")
+
+            // jobqueProfile header
+            let prof = root?["jobqueProfile"]
+            t |> success(prof != null, "jobqueProfile header present")
+            t |> equal(1, prof?["version"] ?? 0)
+            t |> success((prof?["lanes"] ?? 0) >= 1, "at least the caller lane")
+            var sawSeven = false
+            var sawAlpha = false
+            if (prof?["categories"] != null) {
+                for (cat in prof?["categories"] as _array) {
+                    let cname = cat?["name"] ?? ""
+                    if (cname == "seven") {
+                        sawSeven = true
+                        t |> equal(7, cat?["id"] ?? 0)
+                        t |> equal("#112233", cat?["color"] ?? "")
+                    } elif (cname == "alpha") {
+                        sawAlpha = true
+                        t |> equal(1, cat?["id"] ?? 0)
+                        t |> success(length(string(cat?["color"] ?? "")) == 7, "auto color is #RRGGBB")
+                    }
+                }
+            }
+            t |> success(sawSeven, "explicit category saved")
+            t |> success(sawAlpha, "auto category saved")
+            var sawTokenMarker = false
+            if (prof?["markers"] != null) {
+                for (mk in prof?["markers"] as _array) {
+                    if ((mk?["name"] ?? "") == "token") {
+                        sawTokenMarker = true
+                        t |> equal(tokId, mk?["id"] ?? -1)
+                    }
+                }
+            }
+            t |> success(sawTokenMarker, "marker kind saved")
+
+            // events: spans exist; both unit markers landed as perfetto instants; any publish
+            // recorded during the tagged storm carries tag 7 in stage>>8 (workers may be absent
+            // on a 1-core box — then the dispatch inlines and no publish is recorded)
+            t |> success(root?["traceEvents"] != null, "traceEvents present")
+            var nSpans = 0
+            var markerArgs : array<int>
+            var nTaggedPublish = 0
+            var nUntaggedPublish = 0
+            for (ev in root?["traceEvents"] as _array) {
+                let ph = ev?["ph"] ?? ""
+                if (ph == "X") {
+                    nSpans++
+                    if ((ev?["name"] ?? "") == "publish") {
+                        let packed = ev?["args"]?["stage"] ?? 0
+                        if ((packed >> 8) == 7) {
+                            nTaggedPublish++
+                        } else {
+                            nUntaggedPublish++
+                        }
+                    }
+                } elif (ph == "i" && (ev?["name"] ?? "") == "token") {
+                    markerArgs |> push(ev?["args"]?["arg"] ?? -1)
+                }
+            }
+            t |> success(nSpans > 0, "recorded work spans")
+            t |> equal(0, nUntaggedPublish)
+            feint("tagged publishes: {nTaggedPublish}\n")
+            sort(markerArgs)
+            t |> equal(2, length(markerArgs))
+            t |> equal(41, markerArgs[0])
+            t |> equal(42, markerArgs[1])
+        }
+    }
+}


### PR DESCRIPTION
Promotes the per-lane jobque event tracer to a self-describing common API — groundwork for the jobque timeline viewer tool (PR2 to follow).

## What

- **C++ ring** (`job_que.h/cpp`): new `TraceTag::Marker` kind + `JobQue::traceMarker` (instant "unit" event on the caller lane — token/frame/layer boundaries), and cold-path registries `traceCategory(id, name, rgb)` / `traceMarkerName(name)`. `traceSave` now emits markers as perfetto **instant events** (`"ph":"i"`) and appends a `jobqueProfile` sibling key (categories with `#RRGGBB` colors, marker kinds) after `traceEvents` — Perfetto ignores unknown keys, so **files stay perfetto-compatible** and the existing analyzers (`trace_window.py`, `trace_gaps.py`, …) work unchanged (verified).
- **New builtins**: `jobque_trace_category`, `jobque_trace_marker_name`, `jobque_trace_marker` (hot path = one relaxed load no-op when tracing is off), + AOT header decls.
- **`daslib/jobque_profile.das`** (new): `profile_start/stop/save`, `profile_category` (auto-id or explicit-id, palette fallback by name hash), `profile_tag`, `profile_marker`/`profile_marker_id`, `PROFILE_COLOR_*` constants.
- **dasLLAMA**: `set_trace_tags(true)` now registers the 10 lane-timeline categories with the viewer's exact names/colors, so saved traces carry the legend the browser artifact used to hardcode; unit markers stamped in the traced windows — `token` (decode_prof), `layer` (prefill stack), `step` (batch_decode_perf). Kills the `pick_cls.py`-style representative-window hunt: viewers navigate unit-to-unit.
- **Test**: `tests/jobque/test_jobque_trace.das` — arm → register → team-dispatch storm with tag + markers → save → re-read JSON → assert header/categories/markers/publish-tag packing round-trip. First test coverage of the trace API.
- **Docs**: das2rst group entries + handmade pages for the new builtins and module; `sec_concurrency` toctree.

## Verified

- `tests/jobque`: 210/210 pass; new round-trip test passes.
- Real trace: `decode_prof --trace` on Qwen2.5-0.5B → 106k events, all 10 categories in the header, 8 `token` markers (args 0..7) on the caller lane, publishes tagged attn-chain/ffn-chain/classifier.
- `trace_window.py` cuts the new-format file unchanged.
- Sphinx `-W` html build clean; no `Uncategorized`, no doc stubs; lint/format clean on all changed `.das`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)