### PR TITLE
ast: share one lock for handle type-info, drop per-annotation mutex

### DIFF
--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -14,6 +14,10 @@ namespace das
     #define DAS_BIND_MANAGED_FIELD(FIELDNAME)   DAS_BIND_FIELD(ManagedType,FIELDNAME)
     #define DAS_BIND_MANAGED_PROP(FIELDNAME)    DAS_BIND_PROP(ManagedType,FIELDNAME)
 
+    // shared lock for lazy handle type-info build; recursive since makeTypeInfo re-enters
+    // for nested types. sti/ati are published atomically only after the build completes.
+    inline recursive_mutex g_handleTypeInfoMutex;
+
     struct DummyTypeAnnotation : TypeAnnotation {
         DummyTypeAnnotation(const string & name, const string & cppName, size_t sz, size_t al)
             : TypeAnnotation(name,cppName), dummySize(sz), dummyAlignment(al) {
@@ -127,12 +131,11 @@ namespace das
         das_map<string,StructureField> fields;
         vector<string>                 fieldsInOrder;
         mutable DebugInfoHelper    helpA;
-        mutable StructInfo *       sti = nullptr;
+        mutable atomic<StructInfo*> sti { nullptr };
         mutable StructInfo *       sti_gc = nullptr;
         ModuleLibrary *            mlib = nullptr;
         vector<TypeAnnotation*> parents;
         bool validationNeverFails = false;
-        mutable recursive_mutex walkMutex;
     };
 
     template <typename TT, bool canCopy = isCloneable<TT>::value>
@@ -499,9 +502,9 @@ namespace das
             return context.code->makeNode<SimNode_AnyIterator<VectorType,StdVectorIterator<VectorType>>>(at, rv);
         }
         virtual void walk ( DataWalker & walker, void * vec ) override {
-            {
-                lock_guard<recursive_mutex> guard(walkMutex);
-                if ( !ati ) {
+            if ( !ati.load() ) {
+                lock_guard<recursive_mutex> guard(g_handleTypeInfoMutex);
+                if ( !ati.load() ) {
                     // gc_local: scratch TypeDecls just to drive makeTypeInfo —
                     // read once, never stored on the result. RAII unlinks from
                     // the thread gc_root immediately and deletes at scope exit.
@@ -510,14 +513,16 @@ namespace das
                     gc_local<TypeDecl> elemGuard(elemType);
                     elemType->ref = 0;
                     gc_local<TypeDecl> dimType(makeFixedArrayTypeDecl(1, elemType));
-                    ati = helpA.makeTypeInfo(nullptr, dimType);
-                    ati->flags |= TypeInfo::flag_isHandled;
+                    TypeInfo * tinfo = helpA.makeTypeInfo(nullptr, dimType);
+                    tinfo->flags |= TypeInfo::flag_isHandled;
+                    this->ati.store(tinfo);
                 }
             }
             auto pVec = (VectorType *)vec;
-            auto atit = *ati;
+            auto tinfo = this->ati.load();
+            auto atit = *tinfo;
             atit.dim[atit.dimSize - 1] = uint32_t(pVec->size());
-            atit.size = int(ati->size * pVec->size());
+            atit.size = int(tinfo->size * pVec->size());
             walker.walk_dim((char *)pVec->data(), &atit);
         }
         virtual bool isYetAnotherVectorTemplate() const override { return true; }
@@ -535,8 +540,7 @@ namespace das
         }
         TypeDeclPtr                vecType = nullptr;
         DebugInfoHelper            helpA;
-        TypeInfo *                 ati = nullptr;
-        recursive_mutex            walkMutex;
+        atomic<TypeInfo*>          ati { nullptr };
     };
 
     template <typename TT>

--- a/src/ast/ast_handle.cpp
+++ b/src/ast/ast_handle.cpp
@@ -75,8 +75,9 @@ namespace das {
 
     TypeInfo * BasicStructureAnnotation::getFieldType ( const string & na ) const {
         updateTypeInfo();
-        for ( uint32_t n=0; n!=sti->count; ++n ) {
-            auto & fi = sti->fields[n];
+        auto sinfo = this->sti.load();
+        for ( uint32_t n=0; n!=sinfo->count; ++n ) {
+            auto & fi = sinfo->fields[n];
             if ( fi->name == na ) {
                 return fi;
             }
@@ -166,29 +167,30 @@ namespace das {
     }
 
     void BasicStructureAnnotation::updateTypeInfo() const {
-        lock_guard<recursive_mutex> guard(walkMutex);
-        if ( !sti ) {
+        if ( sti.load() ) return;
+        lock_guard<recursive_mutex> guard(g_handleTypeInfoMutex);
+        if ( !sti.load() ) {
             auto debugInfo = helpA.debugInfo;
-            sti = debugInfo->template makeNode<StructInfo>();
-            sti->name = debugInfo->allocateName(name);
+            StructInfo * sinfo = debugInfo->template makeNode<StructInfo>();
+            sinfo->name = debugInfo->allocateName(name);
             sti_gc = debugInfo->template makeNode<StructInfo>();
-            sti_gc->name = sti->name;
+            sti_gc->name = sinfo->name;
             // flags
-            sti->flags = 0;
+            sinfo->flags = 0;
             sti_gc->flags = 0;
             // count fields
-            sti->count = 0;
+            sinfo->count = 0;
             for ( auto & fi : fields ) {
                 auto & var = fi.second;
                 if ( var.offset != -1U ) {
-                    sti->count ++;
+                    sinfo->count ++;
                 }
             }
             // and allocate
             sti_gc->count = 0;
-            sti->size = (uint32_t) getSizeOf();
-            sti_gc->size = sti->size;
-            sti->fields = (VarInfo **) debugInfo->allocate( sizeof(VarInfo *) * sti->count );
+            sinfo->size = (uint32_t) getSizeOf();
+            sti_gc->size = sinfo->size;
+            sinfo->fields = (VarInfo **) debugInfo->allocate( sizeof(VarInfo *) * sinfo->count );
             int i = 0;
             for ( const auto & fn : fieldsInOrder ) {
                 auto itvar = fields.find(fn);
@@ -199,7 +201,7 @@ namespace das {
                         helpA.makeTypeInfo(vi, var.decl);
                         vi->name = debugInfo->allocateName(fn);
                         vi->offset = var.offset;
-                        sti->fields[i++] = vi;
+                        sinfo->fields[i++] = vi;
                         if ( vi->flags & (TypeInfo::flag_heapGC | TypeInfo::flag_stringHeapGC)   ) {
                             sti_gc->count++;
                         }
@@ -209,8 +211,8 @@ namespace das {
             if ( sti_gc->count ) {
                 sti_gc->fields = (VarInfo **) debugInfo->allocate( sizeof(VarInfo *) * sti_gc->count );
                 int j = 0;
-                for ( uint32_t n=0; n!=sti->count; ++n ) {
-                    auto & fi = sti->fields[n];
+                for ( uint32_t n=0; n!=sinfo->count; ++n ) {
+                    auto & fi = sinfo->fields[n];
                     if ( fi->flags & (TypeInfo::flag_heapGC | TypeInfo::flag_stringHeapGC) ) {
                         sti_gc->fields[j++] = fi;
                     }
@@ -218,7 +220,8 @@ namespace das {
             } else {
                 sti_gc->fields = nullptr;
             }
-            sti->module_name = debugInfo->allocateCachedName(this->module->name);
+            sinfo->module_name = debugInfo->allocateCachedName(this->module->name);
+            this->sti.store(sinfo);
         }
     }
 
@@ -229,7 +232,7 @@ namespace das {
                 walker.walk_struct((char *)data, sti_gc);
             }
         } else {
-            walker.walk_struct((char *)data, sti);
+            walker.walk_struct((char *)data, sti.load());
         }
     }
 


### PR DESCRIPTION
Every BasicStructureAnnotation and ManagedVectorAnnotation<T> held its own recursive_mutex to guard the lazy type-info build, i.e. one OS mutex per annotation. On a large program that is thousands of live mutex handles allocated at registration, most never contended.

Replace them with a single shared recursive lock plus an atomic sti/ati pointer: steady-state walks take no lock (one atomic load), the lock is entered only for the one-time build, and the pointer is published only after the node is fully built so readers never observe a half-built node. Collapses the per-annotation handles to one and removes per-walk lock traffic on the gc/serialize path.