### PR TITLE
debugger: DapiDataWalker 16/8-bit lattice leaves

### DIFF
--- a/daslib/debugger.das
+++ b/daslib/debugger.das
@@ -189,6 +189,29 @@ class DapiDataWalker {
     def abstract URange(var value : urange&) : void
     def abstract Range64(var value : range64&) : void
     def abstract URange64(var value : urange64&) : void
+    def abstract Float16(var value : float16&) : void
+    def abstract Half2(var value : half2&) : void
+    def abstract Half3(var value : half3&) : void
+    def abstract Half4(var value : half4&) : void
+    def abstract Half8(var value : half8&) : void
+    def abstract Short2(var value : short2&) : void
+    def abstract Short3(var value : short3&) : void
+    def abstract Short4(var value : short4&) : void
+    def abstract Short8(var value : short8&) : void
+    def abstract UShort2(var value : ushort2&) : void
+    def abstract UShort3(var value : ushort3&) : void
+    def abstract UShort4(var value : ushort4&) : void
+    def abstract UShort8(var value : ushort8&) : void
+    def abstract Byte2(var value : byte2&) : void
+    def abstract Byte3(var value : byte3&) : void
+    def abstract Byte4(var value : byte4&) : void
+    def abstract Byte8(var value : byte8&) : void
+    def abstract Byte16(var value : byte16&) : void
+    def abstract UByte2(var value : ubyte2&) : void
+    def abstract UByte3(var value : ubyte3&) : void
+    def abstract UByte4(var value : ubyte4&) : void
+    def abstract UByte8(var value : ubyte8&) : void
+    def abstract UByte16(var value : ubyte16&) : void
     def abstract WalkBlock(var value : DapiBlock) : void
     def abstract WalkFunction(var value : DapiFunc) : void
     def abstract WalkEnumeration(var value : int&; ei : EnumInfo) : void

--- a/include/daScript/builtin/debugapi_gen.inc
+++ b/include/daScript/builtin/debugapi_gen.inc
@@ -80,17 +80,40 @@ protected:
     __fn_URange = 76,
     __fn_Range64 = 77,
     __fn_URange64 = 78,
-    __fn_WalkBlock = 79,
-    __fn_WalkFunction = 80,
-    __fn_WalkEnumeration = 81,
-    __fn_WalkEnumeration8 = 82,
-    __fn_WalkEnumeration16 = 83,
-    __fn_WalkEnumeration64 = 84,
-    __fn_FakeContext = 85,
-    __fn_InvalidData = 86,
+    __fn_Float16 = 79,
+    __fn_Half2 = 80,
+    __fn_Half3 = 81,
+    __fn_Half4 = 82,
+    __fn_Half8 = 83,
+    __fn_Short2 = 84,
+    __fn_Short3 = 85,
+    __fn_Short4 = 86,
+    __fn_Short8 = 87,
+    __fn_UShort2 = 88,
+    __fn_UShort3 = 89,
+    __fn_UShort4 = 90,
+    __fn_UShort8 = 91,
+    __fn_Byte2 = 92,
+    __fn_Byte3 = 93,
+    __fn_Byte4 = 94,
+    __fn_Byte8 = 95,
+    __fn_Byte16 = 96,
+    __fn_UByte2 = 97,
+    __fn_UByte3 = 98,
+    __fn_UByte4 = 99,
+    __fn_UByte8 = 100,
+    __fn_UByte16 = 101,
+    __fn_WalkBlock = 102,
+    __fn_WalkFunction = 103,
+    __fn_WalkEnumeration = 104,
+    __fn_WalkEnumeration8 = 105,
+    __fn_WalkEnumeration16 = 106,
+    __fn_WalkEnumeration64 = 107,
+    __fn_FakeContext = 108,
+    __fn_InvalidData = 109,
   };
 protected:
-  int _das_class_method_offset[87];
+  int _das_class_method_offset[110];
 public:
   DapiDataWalker_Adapter ( const StructInfo * info ) {
       _das_class_method_offset[__fn_canVisitHandle] = info->fields[2]->offset;
@@ -172,14 +195,37 @@ public:
       _das_class_method_offset[__fn_URange] = info->fields[78]->offset;
       _das_class_method_offset[__fn_Range64] = info->fields[79]->offset;
       _das_class_method_offset[__fn_URange64] = info->fields[80]->offset;
-      _das_class_method_offset[__fn_WalkBlock] = info->fields[81]->offset;
-      _das_class_method_offset[__fn_WalkFunction] = info->fields[82]->offset;
-      _das_class_method_offset[__fn_WalkEnumeration] = info->fields[83]->offset;
-      _das_class_method_offset[__fn_WalkEnumeration8] = info->fields[84]->offset;
-      _das_class_method_offset[__fn_WalkEnumeration16] = info->fields[85]->offset;
-      _das_class_method_offset[__fn_WalkEnumeration64] = info->fields[86]->offset;
-      _das_class_method_offset[__fn_FakeContext] = info->fields[87]->offset;
-      _das_class_method_offset[__fn_InvalidData] = info->fields[88]->offset;
+      _das_class_method_offset[__fn_Float16] = info->fields[81]->offset;
+      _das_class_method_offset[__fn_Half2] = info->fields[82]->offset;
+      _das_class_method_offset[__fn_Half3] = info->fields[83]->offset;
+      _das_class_method_offset[__fn_Half4] = info->fields[84]->offset;
+      _das_class_method_offset[__fn_Half8] = info->fields[85]->offset;
+      _das_class_method_offset[__fn_Short2] = info->fields[86]->offset;
+      _das_class_method_offset[__fn_Short3] = info->fields[87]->offset;
+      _das_class_method_offset[__fn_Short4] = info->fields[88]->offset;
+      _das_class_method_offset[__fn_Short8] = info->fields[89]->offset;
+      _das_class_method_offset[__fn_UShort2] = info->fields[90]->offset;
+      _das_class_method_offset[__fn_UShort3] = info->fields[91]->offset;
+      _das_class_method_offset[__fn_UShort4] = info->fields[92]->offset;
+      _das_class_method_offset[__fn_UShort8] = info->fields[93]->offset;
+      _das_class_method_offset[__fn_Byte2] = info->fields[94]->offset;
+      _das_class_method_offset[__fn_Byte3] = info->fields[95]->offset;
+      _das_class_method_offset[__fn_Byte4] = info->fields[96]->offset;
+      _das_class_method_offset[__fn_Byte8] = info->fields[97]->offset;
+      _das_class_method_offset[__fn_Byte16] = info->fields[98]->offset;
+      _das_class_method_offset[__fn_UByte2] = info->fields[99]->offset;
+      _das_class_method_offset[__fn_UByte3] = info->fields[100]->offset;
+      _das_class_method_offset[__fn_UByte4] = info->fields[101]->offset;
+      _das_class_method_offset[__fn_UByte8] = info->fields[102]->offset;
+      _das_class_method_offset[__fn_UByte16] = info->fields[103]->offset;
+      _das_class_method_offset[__fn_WalkBlock] = info->fields[104]->offset;
+      _das_class_method_offset[__fn_WalkFunction] = info->fields[105]->offset;
+      _das_class_method_offset[__fn_WalkEnumeration] = info->fields[106]->offset;
+      _das_class_method_offset[__fn_WalkEnumeration8] = info->fields[107]->offset;
+      _das_class_method_offset[__fn_WalkEnumeration16] = info->fields[108]->offset;
+      _das_class_method_offset[__fn_WalkEnumeration64] = info->fields[109]->offset;
+      _das_class_method_offset[__fn_FakeContext] = info->fields[110]->offset;
+      _das_class_method_offset[__fn_InvalidData] = info->fields[111]->offset;
   }
   __forceinline Func get_canVisitHandle ( void * self ) const {
     return getDasClassMethod(self,_das_class_method_offset[__fn_canVisitHandle]);
@@ -889,6 +935,213 @@ public:
   __forceinline void invoke_URange64 ( Context * __context__, Func __funcCall__, void * self, urange64 & value ) const {
     das_invoke_function<void>::invoke
       <void *,urange64 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Float16 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Float16]);
+  }
+  __forceinline void invoke_Float16 ( Context * __context__, Func __funcCall__, void * self, float16_t & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,float16_t &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Half2 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Half2]);
+  }
+  __forceinline void invoke_Half2 ( Context * __context__, Func __funcCall__, void * self, half2 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,half2 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Half3 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Half3]);
+  }
+  __forceinline void invoke_Half3 ( Context * __context__, Func __funcCall__, void * self, half3 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,half3 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Half4 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Half4]);
+  }
+  __forceinline void invoke_Half4 ( Context * __context__, Func __funcCall__, void * self, half4 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,half4 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Half8 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Half8]);
+  }
+  __forceinline void invoke_Half8 ( Context * __context__, Func __funcCall__, void * self, half8 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,half8 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Short2 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Short2]);
+  }
+  __forceinline void invoke_Short2 ( Context * __context__, Func __funcCall__, void * self, short2 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,short2 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Short3 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Short3]);
+  }
+  __forceinline void invoke_Short3 ( Context * __context__, Func __funcCall__, void * self, short3 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,short3 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Short4 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Short4]);
+  }
+  __forceinline void invoke_Short4 ( Context * __context__, Func __funcCall__, void * self, short4 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,short4 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Short8 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Short8]);
+  }
+  __forceinline void invoke_Short8 ( Context * __context__, Func __funcCall__, void * self, short8 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,short8 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UShort2 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UShort2]);
+  }
+  __forceinline void invoke_UShort2 ( Context * __context__, Func __funcCall__, void * self, ushort2 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ushort2 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UShort3 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UShort3]);
+  }
+  __forceinline void invoke_UShort3 ( Context * __context__, Func __funcCall__, void * self, ushort3 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ushort3 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UShort4 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UShort4]);
+  }
+  __forceinline void invoke_UShort4 ( Context * __context__, Func __funcCall__, void * self, ushort4 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ushort4 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UShort8 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UShort8]);
+  }
+  __forceinline void invoke_UShort8 ( Context * __context__, Func __funcCall__, void * self, ushort8 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ushort8 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Byte2 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Byte2]);
+  }
+  __forceinline void invoke_Byte2 ( Context * __context__, Func __funcCall__, void * self, byte2 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,byte2 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Byte3 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Byte3]);
+  }
+  __forceinline void invoke_Byte3 ( Context * __context__, Func __funcCall__, void * self, byte3 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,byte3 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Byte4 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Byte4]);
+  }
+  __forceinline void invoke_Byte4 ( Context * __context__, Func __funcCall__, void * self, byte4 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,byte4 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Byte8 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Byte8]);
+  }
+  __forceinline void invoke_Byte8 ( Context * __context__, Func __funcCall__, void * self, byte8 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,byte8 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_Byte16 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_Byte16]);
+  }
+  __forceinline void invoke_Byte16 ( Context * __context__, Func __funcCall__, void * self, byte16 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,byte16 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UByte2 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UByte2]);
+  }
+  __forceinline void invoke_UByte2 ( Context * __context__, Func __funcCall__, void * self, ubyte2 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ubyte2 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UByte3 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UByte3]);
+  }
+  __forceinline void invoke_UByte3 ( Context * __context__, Func __funcCall__, void * self, ubyte3 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ubyte3 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UByte4 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UByte4]);
+  }
+  __forceinline void invoke_UByte4 ( Context * __context__, Func __funcCall__, void * self, ubyte4 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ubyte4 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UByte8 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UByte8]);
+  }
+  __forceinline void invoke_UByte8 ( Context * __context__, Func __funcCall__, void * self, ubyte8 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ubyte8 &>
+        (__context__,nullptr,__funcCall__,
+          self,value);
+  }
+  __forceinline Func get_UByte16 ( void * self ) const {
+    return getDasClassMethod(self,_das_class_method_offset[__fn_UByte16]);
+  }
+  __forceinline void invoke_UByte16 ( Context * __context__, Func __funcCall__, void * self, ubyte16 & value ) const {
+    das_invoke_function<void>::invoke
+      <void *,ubyte16 &>
         (__context__,nullptr,__funcCall__,
           self,value);
   }

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -641,6 +641,121 @@ namespace debugger {
                 invoke_URange64(context,fn_URange,classPtr,value);
             }
         }
+        virtual void Float16 ( float16_t & value ) override {
+           if ( auto fn_Float16 = get_Float16(classPtr) ) {
+                invoke_Float16(context,fn_Float16,classPtr,value);
+            }
+        }
+        virtual void Half2 ( half2 & value ) override {
+           if ( auto fn_Half2 = get_Half2(classPtr) ) {
+                invoke_Half2(context,fn_Half2,classPtr,value);
+            }
+        }
+        virtual void Half3 ( half3 & value ) override {
+           if ( auto fn_Half3 = get_Half3(classPtr) ) {
+                invoke_Half3(context,fn_Half3,classPtr,value);
+            }
+        }
+        virtual void Half4 ( half4 & value ) override {
+           if ( auto fn_Half4 = get_Half4(classPtr) ) {
+                invoke_Half4(context,fn_Half4,classPtr,value);
+            }
+        }
+        virtual void Half8 ( half8 & value ) override {
+           if ( auto fn_Half8 = get_Half8(classPtr) ) {
+                invoke_Half8(context,fn_Half8,classPtr,value);
+            }
+        }
+        virtual void Short2 ( short2 & value ) override {
+           if ( auto fn_Short2 = get_Short2(classPtr) ) {
+                invoke_Short2(context,fn_Short2,classPtr,value);
+            }
+        }
+        virtual void Short3 ( short3 & value ) override {
+           if ( auto fn_Short3 = get_Short3(classPtr) ) {
+                invoke_Short3(context,fn_Short3,classPtr,value);
+            }
+        }
+        virtual void Short4 ( short4 & value ) override {
+           if ( auto fn_Short4 = get_Short4(classPtr) ) {
+                invoke_Short4(context,fn_Short4,classPtr,value);
+            }
+        }
+        virtual void Short8 ( short8 & value ) override {
+           if ( auto fn_Short8 = get_Short8(classPtr) ) {
+                invoke_Short8(context,fn_Short8,classPtr,value);
+            }
+        }
+        virtual void UShort2 ( ushort2 & value ) override {
+           if ( auto fn_UShort2 = get_UShort2(classPtr) ) {
+                invoke_UShort2(context,fn_UShort2,classPtr,value);
+            }
+        }
+        virtual void UShort3 ( ushort3 & value ) override {
+           if ( auto fn_UShort3 = get_UShort3(classPtr) ) {
+                invoke_UShort3(context,fn_UShort3,classPtr,value);
+            }
+        }
+        virtual void UShort4 ( ushort4 & value ) override {
+           if ( auto fn_UShort4 = get_UShort4(classPtr) ) {
+                invoke_UShort4(context,fn_UShort4,classPtr,value);
+            }
+        }
+        virtual void UShort8 ( ushort8 & value ) override {
+           if ( auto fn_UShort8 = get_UShort8(classPtr) ) {
+                invoke_UShort8(context,fn_UShort8,classPtr,value);
+            }
+        }
+        virtual void Byte2 ( byte2 & value ) override {
+           if ( auto fn_Byte2 = get_Byte2(classPtr) ) {
+                invoke_Byte2(context,fn_Byte2,classPtr,value);
+            }
+        }
+        virtual void Byte3 ( byte3 & value ) override {
+           if ( auto fn_Byte3 = get_Byte3(classPtr) ) {
+                invoke_Byte3(context,fn_Byte3,classPtr,value);
+            }
+        }
+        virtual void Byte4 ( byte4 & value ) override {
+           if ( auto fn_Byte4 = get_Byte4(classPtr) ) {
+                invoke_Byte4(context,fn_Byte4,classPtr,value);
+            }
+        }
+        virtual void Byte8 ( byte8 & value ) override {
+           if ( auto fn_Byte8 = get_Byte8(classPtr) ) {
+                invoke_Byte8(context,fn_Byte8,classPtr,value);
+            }
+        }
+        virtual void Byte16 ( byte16 & value ) override {
+           if ( auto fn_Byte16 = get_Byte16(classPtr) ) {
+                invoke_Byte16(context,fn_Byte16,classPtr,value);
+            }
+        }
+        virtual void UByte2 ( ubyte2 & value ) override {
+           if ( auto fn_UByte2 = get_UByte2(classPtr) ) {
+                invoke_UByte2(context,fn_UByte2,classPtr,value);
+            }
+        }
+        virtual void UByte3 ( ubyte3 & value ) override {
+           if ( auto fn_UByte3 = get_UByte3(classPtr) ) {
+                invoke_UByte3(context,fn_UByte3,classPtr,value);
+            }
+        }
+        virtual void UByte4 ( ubyte4 & value ) override {
+           if ( auto fn_UByte4 = get_UByte4(classPtr) ) {
+                invoke_UByte4(context,fn_UByte4,classPtr,value);
+            }
+        }
+        virtual void UByte8 ( ubyte8 & value ) override {
+           if ( auto fn_UByte8 = get_UByte8(classPtr) ) {
+                invoke_UByte8(context,fn_UByte8,classPtr,value);
+            }
+        }
+        virtual void UByte16 ( ubyte16 & value ) override {
+           if ( auto fn_UByte16 = get_UByte16(classPtr) ) {
+                invoke_UByte16(context,fn_UByte16,classPtr,value);
+            }
+        }
         virtual void WalkBlock ( Block * value ) override {
            if ( auto fn_WalkBlock = get_WalkBlock(classPtr) ) {
                 invoke_WalkBlock(context,fn_WalkBlock,classPtr,*value);

--- a/tests/data_walker/dw_common.das
+++ b/tests/data_walker/dw_common.das
@@ -104,6 +104,77 @@ class LogWalker : DapiDataWalker {
         log += "URange64:{value}\n"
     }
 
+    // --- 16/8-bit lattice ---
+    def override Float16(var value : float16&) : void {
+        log += "Float16:{value}\n"
+    }
+    def override Half2(var value : half2&) : void {
+        log += "Half2:{value}\n"
+    }
+    def override Half3(var value : half3&) : void {
+        log += "Half3:{value}\n"
+    }
+    def override Half4(var value : half4&) : void {
+        log += "Half4:{value}\n"
+    }
+    def override Half8(var value : half8&) : void {
+        log += "Half8:{value}\n"
+    }
+    def override Short2(var value : short2&) : void {
+        log += "Short2:{value}\n"
+    }
+    def override Short3(var value : short3&) : void {
+        log += "Short3:{value}\n"
+    }
+    def override Short4(var value : short4&) : void {
+        log += "Short4:{value}\n"
+    }
+    def override Short8(var value : short8&) : void {
+        log += "Short8:{value}\n"
+    }
+    def override UShort2(var value : ushort2&) : void {
+        log += "UShort2:{value}\n"
+    }
+    def override UShort3(var value : ushort3&) : void {
+        log += "UShort3:{value}\n"
+    }
+    def override UShort4(var value : ushort4&) : void {
+        log += "UShort4:{value}\n"
+    }
+    def override UShort8(var value : ushort8&) : void {
+        log += "UShort8:{value}\n"
+    }
+    def override Byte2(var value : byte2&) : void {
+        log += "Byte2:{value}\n"
+    }
+    def override Byte3(var value : byte3&) : void {
+        log += "Byte3:{value}\n"
+    }
+    def override Byte4(var value : byte4&) : void {
+        log += "Byte4:{value}\n"
+    }
+    def override Byte8(var value : byte8&) : void {
+        log += "Byte8:{value}\n"
+    }
+    def override Byte16(var value : byte16&) : void {
+        log += "Byte16:{value}\n"
+    }
+    def override UByte2(var value : ubyte2&) : void {
+        log += "UByte2:{value}\n"
+    }
+    def override UByte3(var value : ubyte3&) : void {
+        log += "UByte3:{value}\n"
+    }
+    def override UByte4(var value : ubyte4&) : void {
+        log += "UByte4:{value}\n"
+    }
+    def override UByte8(var value : ubyte8&) : void {
+        log += "UByte8:{value}\n"
+    }
+    def override UByte16(var value : ubyte16&) : void {
+        log += "UByte16:{value}\n"
+    }
+
     // --- enum/bitfield ---
     def override WalkEnumeration(var value : int&; ei : EnumInfo) : void {
         log += "Enum:{ei.name}:{value}\n"

--- a/tests/data_walker/test_walk_lattice.das
+++ b/tests/data_walker/test_walk_lattice.das
@@ -1,0 +1,242 @@
+// Tests for DapiDataWalker — 16/8-bit type lattice leaves
+//
+// Covers: Float16, Half2/3/4/8, Short2/3/4/8, UShort2/3/4/8,
+//         Byte2/3/4/8/16, UByte2/3/4/8/16 dispatch to das-side walkers,
+//         lattice fields inside structs, fixed/dynamic arrays of lattice
+//         elements, and mutation through the by-ref leaf callbacks
+
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dw_common
+
+
+// ============================================================
+// Local data types
+// ============================================================
+
+struct LatticeStruct {
+    h : float16
+    hv : half4
+    sv : short2
+    bv : byte4
+    ubv : ubyte16
+}
+
+
+// ============================================================
+// Local walker classes
+// ============================================================
+
+// Overwrites lattice leaves through the by-ref callback
+class LatticeMutator : DapiDataWalker {
+    def override Half2(var value : half2&) : void {
+        value = half2(9., 9.)
+    }
+    def override Byte4(var value : byte4&) : void {
+        value = byte4(1, 2, 3, 4)
+    }
+}
+
+
+// ============================================================
+// Standalone leaf dispatch
+// ============================================================
+
+[test]
+def test_walk_lattice_leaves(t : T?) {
+    t |> run("half family") @(t : T?) {
+        var walker = new LogWalker()
+        var f16 = float16(1.5)
+        var h2 = half2(1., 2.)
+        var h3 = half3(1., 2., 3.)
+        var h4 = half4(1., 2., 3., 4.)
+        var h8 = half8(1., 2., 3., 4., 5., 6., 7., 8.)
+        var expected = ""
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(f16), typeinfo rtti_typeinfo(f16))
+                adapter |> walk_data(addr(h2), typeinfo rtti_typeinfo(h2))
+                adapter |> walk_data(addr(h3), typeinfo rtti_typeinfo(h3))
+                adapter |> walk_data(addr(h4), typeinfo rtti_typeinfo(h4))
+                adapter |> walk_data(addr(h8), typeinfo rtti_typeinfo(h8))
+            }
+        }
+        expected += "Float16:{f16}\n"
+        expected += "Half2:{h2}\n"
+        expected += "Half3:{h3}\n"
+        expected += "Half4:{h4}\n"
+        expected += "Half8:{h8}\n"
+        t |> equal(walker.log, expected)
+        unsafe { delete walker; }
+    }
+    t |> run("short family") @(t : T?) {
+        var walker = new LogWalker()
+        var s2 = short2(-1, 2)
+        var s3 = short3(-1, 2, -3)
+        var s4 = short4(-1, 2, -3, 4)
+        var s8 = short8(-1, 2, -3, 4, -5, 6, -7, 8)
+        var u2 = ushort2(1, 2)
+        var u3 = ushort3(1, 2, 3)
+        var u4 = ushort4(1, 2, 3, 4)
+        var u8 = ushort8(1, 2, 3, 4, 5, 6, 7, 8)
+        var expected = ""
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s2), typeinfo rtti_typeinfo(s2))
+                adapter |> walk_data(addr(s3), typeinfo rtti_typeinfo(s3))
+                adapter |> walk_data(addr(s4), typeinfo rtti_typeinfo(s4))
+                adapter |> walk_data(addr(s8), typeinfo rtti_typeinfo(s8))
+                adapter |> walk_data(addr(u2), typeinfo rtti_typeinfo(u2))
+                adapter |> walk_data(addr(u3), typeinfo rtti_typeinfo(u3))
+                adapter |> walk_data(addr(u4), typeinfo rtti_typeinfo(u4))
+                adapter |> walk_data(addr(u8), typeinfo rtti_typeinfo(u8))
+            }
+        }
+        expected += "Short2:{s2}\n"
+        expected += "Short3:{s3}\n"
+        expected += "Short4:{s4}\n"
+        expected += "Short8:{s8}\n"
+        expected += "UShort2:{u2}\n"
+        expected += "UShort3:{u3}\n"
+        expected += "UShort4:{u4}\n"
+        expected += "UShort8:{u8}\n"
+        t |> equal(walker.log, expected)
+        unsafe { delete walker; }
+    }
+    t |> run("byte family") @(t : T?) {
+        var walker = new LogWalker()
+        var b2 = byte2(-1, 2)
+        var b3 = byte3(-1, 2, -3)
+        var b4 = byte4(-1, 2, -3, 4)
+        var b8 = byte8(-1, 2, -3, 4, -5, 6, -7, 8)
+        var b16 = byte16(-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16)
+        var ub2 = ubyte2(1, 2)
+        var ub3 = ubyte3(1, 2, 3)
+        var ub4 = ubyte4(1, 2, 3, 4)
+        var ub8 = ubyte8(1, 2, 3, 4, 5, 6, 7, 8)
+        var ub16 = ubyte16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+        var expected = ""
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(b2), typeinfo rtti_typeinfo(b2))
+                adapter |> walk_data(addr(b3), typeinfo rtti_typeinfo(b3))
+                adapter |> walk_data(addr(b4), typeinfo rtti_typeinfo(b4))
+                adapter |> walk_data(addr(b8), typeinfo rtti_typeinfo(b8))
+                adapter |> walk_data(addr(b16), typeinfo rtti_typeinfo(b16))
+                adapter |> walk_data(addr(ub2), typeinfo rtti_typeinfo(ub2))
+                adapter |> walk_data(addr(ub3), typeinfo rtti_typeinfo(ub3))
+                adapter |> walk_data(addr(ub4), typeinfo rtti_typeinfo(ub4))
+                adapter |> walk_data(addr(ub8), typeinfo rtti_typeinfo(ub8))
+                adapter |> walk_data(addr(ub16), typeinfo rtti_typeinfo(ub16))
+            }
+        }
+        expected += "Byte2:{b2}\n"
+        expected += "Byte3:{b3}\n"
+        expected += "Byte4:{b4}\n"
+        expected += "Byte8:{b8}\n"
+        expected += "Byte16:{b16}\n"
+        expected += "UByte2:{ub2}\n"
+        expected += "UByte3:{ub3}\n"
+        expected += "UByte4:{ub4}\n"
+        expected += "UByte8:{ub8}\n"
+        expected += "UByte16:{ub16}\n"
+        t |> equal(walker.log, expected)
+        unsafe { delete walker; }
+    }
+}
+
+
+// ============================================================
+// Lattice fields inside a struct
+// ============================================================
+
+[test]
+def test_walk_lattice_struct(t : T?) {
+    t |> run("struct with lattice fields") @(t : T?) {
+        var walker = new LogWalker()
+        var s = LatticeStruct(
+            h = float16(1.5),
+            hv = half4(1., 2., 3., 4.),
+            sv = short2(-1, 2),
+            bv = byte4(-1, 2, -3, 4),
+            ubv = ubyte16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(s), typeinfo rtti_typeinfo(s))
+            }
+        }
+        t |> equal(find(walker.log, "beforeStruct:LatticeStruct") != -1, true)
+        t |> equal(find(walker.log, "Float16:{s.h}") != -1, true)
+        t |> equal(find(walker.log, "Half4:{s.hv}") != -1, true)
+        t |> equal(find(walker.log, "Short2:{s.sv}") != -1, true)
+        t |> equal(find(walker.log, "Byte4:{s.bv}") != -1, true)
+        t |> equal(find(walker.log, "UByte16:{s.ubv}") != -1, true)
+        t |> equal(find(walker.log, "afterStruct:LatticeStruct") != -1, true)
+        unsafe { delete walker; }
+    }
+}
+
+
+// ============================================================
+// Arrays of lattice elements
+// ============================================================
+
+[test]
+def test_walk_lattice_arrays(t : T?) {
+    t |> run("fixed array of half4") @(t : T?) {
+        var walker = new LogWalker()
+        var a : half4[2]
+        a[0] = half4(1., 2., 3., 4.)
+        a[1] = half4(5., 6., 7., 8.)
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(a), typeinfo rtti_typeinfo(a))
+            }
+        }
+        t |> equal(find(walker.log, "beforeDim") != -1, true)
+        t |> equal(find(walker.log, "Half4:{a[0]}") != -1, true)
+        t |> equal(find(walker.log, "Half4:{a[1]}") != -1, true)
+        t |> equal(find(walker.log, "afterDim") != -1, true)
+        unsafe { delete walker; }
+    }
+    t |> run("dynamic array of byte4") @(t : T?) {
+        var walker = new LogWalker()
+        var arr = [byte4(1, 2, 3, 4), byte4(5, 6, 7, 8)]
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(arr), typeinfo rtti_typeinfo(arr))
+            }
+        }
+        t |> equal(find(walker.log, "beforeArray") != -1, true)
+        t |> equal(find(walker.log, "Byte4:{arr[0]}") != -1, true)
+        t |> equal(find(walker.log, "Byte4:{arr[1]}") != -1, true)
+        t |> equal(find(walker.log, "afterArray") != -1, true)
+        delete arr
+        unsafe { delete walker; }
+    }
+}
+
+
+// ============================================================
+// Mutation through by-ref leaves
+// ============================================================
+
+[test]
+def test_walk_lattice_mutation(t : T?) {
+    t |> run("mutate half2 and byte4") @(t : T?) {
+        var walker = new LatticeMutator()
+        var h = half2(1., 2.)
+        var b = byte4(9, 9, 9, 9)
+        make_data_walker(walker) $(adapter) {
+            unsafe {
+                adapter |> walk_data(addr(h), typeinfo rtti_typeinfo(h))
+                adapter |> walk_data(addr(b), typeinfo rtti_typeinfo(b))
+            }
+        }
+        t |> equal(h == half2(9., 9.), true)
+        t |> equal(b == byte4(1, 2, 3, 4), true)
+        unsafe { delete walker; }
+    }
+}

--- a/tutorials/language/47_data_walker.das
+++ b/tutorials/language/47_data_walker.das
@@ -15,6 +15,8 @@
 // Key concepts:
 //   - DapiDataWalker is a visitor pattern for daScript data at runtime
 //   - Override scalar callbacks (Int, Float, String, ...) to handle values
+//   - Leaf callbacks exist for every leaf type: scalars, vectors, ranges,
+//     and the 16/8-bit lattice (Float16, Half*, Short*/UShort*, Byte*/UByte*)
 //   - Override before/after callbacks for containers (structures, arrays, etc.)
 //   - All canVisit methods default to true — override to prune traversal
 //   - Scalar callbacks receive mutable references — values can be modified


### PR DESCRIPTION
`DapiDataWalker` in `daslib/debugger.das` was never updated for the 16/8-bit type lattice: the C++ `DataWalker` dispatches `Float16`, `Half2/3/4/8`, `Short2/3/4/8`, `UShort2/3/4/8`, `Byte2/3/4/8/16`, `UByte2/3/4/8/16` to virtuals whose base defaults are no-ops, so das-side walkers silently skipped those leaves — no crash, no `invalidData`, just missing values.

## Changes

- **`daslib/debugger.das`** — 23 abstract leaf methods added to `DapiDataWalker`, inserted after `URange64` to mirror the C++ `DataWalker` declaration order.
- **`include/daScript/builtin/debugapi_gen.inc`** — regenerated via `utils/dasgen/gen_bind.das` (`ast_gen.inc` unchanged).
- **`src/builtin/module_builtin_debugger.cpp`** — matching hand-written `DataWalkerAdapter` overrides following the existing `get_*`/`invoke_*` pattern.
- **`tests/data_walker/`** — `LogWalker` extended with the 23 leaves; new `test_walk_lattice.das` covering standalone leaf dispatch for all 23 types, lattice fields inside a struct, `half4[2]` fixed array, `array<byte4>`, and mutation through the by-ref callbacks (proves two-way marshaling). Picked up by the existing AOT glob.
- **`tutorials/language/47_data_walker.das`** — key-concepts note naming the full leaf set. `JsonWalker` left as-is: tutorial walkers deliberately teach subsets (classic vectors were never covered either) and its demo data has no vector fields.

Out of scope per discussion: `FakeLineInfo` (call argument, never appears in walked data) and the `revisitStructure`/`revisitHandle` pair.

`DAWalker` (DAP debugger) needs no changes — it renders leaves via `sprint_data_fast`, which already handles the lattice. All `DapiDataWalker` methods are `def abstract` and the adapter null-checks each function pointer, so existing subclasses are unaffected.

## Validation

- `tests/data_walker`: 119/119 pass (11 new)
- lint + format clean on all changed `.das`; das2rst clean, no doc diffs
- tutorial 47 runs end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)