### PR TITLE
dasLLAMA: hybrid (deltanet) models serve — prefix-cache graceful degrade + gated-attention tq4

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -5326,7 +5326,34 @@ def private attention_qwen35_gated_decode(t : Model; var s : Session; l : int64;
         }
     }
     prof_add("rope", ts_rope)
-    if (s.kv_dtype_k == KVDtype.q8_0) {
+    let ktq4 = s.kv_dtype_k == KVDtype.tq4
+    let vtq4 = s.kv_dtype_v == KVDtype.tq4
+    if (ktq4 || vtq4) {
+        // tq4 basis change at the RoPE seam (attention_std_decode's twin): attention runs in the
+        // rotated basis; xb un-rotates per head after — the sigmoid out-gate lives in the original
+        let ts_rot = ref_time_ticks()
+        unsafe {
+            let sgp = reinterpret<float const?>(addr(s.kv_signs[0]))
+            if (ktq4) {
+                var qrp = addr(s.q[0])
+                for (hh in range64(qd / head_size)) {
+                    fwht_signs_row(qrp + hh * head_size, sgp, head_size)
+                }
+                var krp = addr(s.k[0])
+                for (hh in range64(kv_dim / head_size)) {
+                    fwht_signs_row(krp + hh * head_size, sgp, head_size)
+                }
+            }
+            if (vtq4) {
+                var vrp = addr(s.v[0])
+                for (hh in range64(kv_dim / head_size)) {
+                    fwht_signs_row(vrp + hh * head_size, sgp, head_size)
+                }
+            }
+        }
+        prof_add("tq4_rot", ts_rot)
+    }
+    if (s.kv_dtype_k == KVDtype.q8_0 || ktq4) {
         quantize_q8_0_into(s.q, qd, s.attq, s.atts, 0l, 0l)
     }
     let ts_kv = ref_time_ticks()
@@ -5345,9 +5372,10 @@ def private attention_qwen35_gated_decode(t : Model; var s : Session; l : int64;
     let vdt = s.kv_dtype_v
     let nrun = kv_runs(s, kstart, pos + 1l, s.kv_runs)
     unsafe {
+        let kplanes = kdt == KVDtype.q8_0 || kdt == KVDtype.tq4
         let qp = reinterpret<float const?>(addr(s.q[0]))
-        let qqp = kdt == KVDtype.q8_0 ? reinterpret<int8 const?>(addr(s.attq[0])) : null
-        let qsp = kdt == KVDtype.q8_0 ? reinterpret<float const?>(addr(s.atts[0])) : null
+        let qqp = kplanes ? reinterpret<int8 const?>(addr(s.attq[0])) : null
+        let qsp = kplanes ? reinterpret<float const?>(addr(s.atts[0])) : null
         let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
         var xbp = addr(s.xb[0])
         var attp = addr(s.att[0])
@@ -5364,6 +5392,15 @@ def private attention_qwen35_gated_decode(t : Model; var s : Session; l : int64;
         }
     }
     prof_add("attn", ts_attn)
+    if (vtq4) {   // tq4 V: xb accumulated in the rotated basis — un-rotate before the out-gate
+        unsafe {
+            let sgp = reinterpret<float const?>(addr(s.kv_signs[0]))
+            var xrp = addr(s.xb[0])
+            for (hh in range64(n_heads)) {
+                fwht_unsign_row(xrp + hh * head_size, sgp, head_size)
+            }
+        }
+    }
     // per-head sigmoid output gate on the attention output, before the out projection (exp4)
     let ts_wo = ref_time_ticks()
     unsafe {
@@ -7691,6 +7728,22 @@ def private attention_qwen35_gated_prefill(t : Model; var s : Session; l : int64
         }
     }
     prof_add("rope", ts_rope)
+    let ktq4 = s.kv_dtype_k == KVDtype.tq4
+    let vtq4 = s.kv_dtype_v == KVDtype.tq4
+    if (ktq4 || vtq4) {   // tq4 basis change (attention_std_prefill's twin); xb_b un-rotates below
+        let ts_rot = ref_time_ticks()
+        unsafe {
+            let sgp = reinterpret<float const?>(addr(s.kv_signs[0]))
+            if (ktq4) {
+                tq4_rotate_batch(s.q_b, npos, qd, head_size, sgp)
+                tq4_rotate_batch(s.k_b, npos, kv_dim, head_size, sgp)
+            }
+            if (vtq4) {
+                tq4_rotate_batch(s.v_b, npos, kv_dim, head_size, sgp)
+            }
+        }
+        prof_add("tq4_rot", ts_rot)
+    }
     let ts_kv = ref_time_ticks()
     let store_nrun = kv_runs(s, start_pos, start_pos + npos, s.kv_runs)
     unsafe {
@@ -7702,6 +7755,11 @@ def private attention_qwen35_gated_prefill(t : Model; var s : Session; l : int64
     prefill_attention(s, kcl, vcl, npos, start_pos, head_size, qd, kv_dim, n_heads, kv_mul, scale,
                       false, 0l, c.attn_logit_softcap, null)
     prof_add("attn", ts_attn)
+    if (vtq4) {   // un-rotate every position's xb before the out-gate (gate is in the original basis)
+        unsafe {
+            tq4_unrotate_batch(s.xb_b, npos, qd, head_size, reinterpret<float const?>(addr(s.kv_signs[0])))
+        }
+    }
     // per-head sigmoid output gate on every position's attention output, before the out projection.
     // Threaded + exp4: the serial scalar loop was npos·qd (2.1M @pp512) libm exps on the caller —
     // a ~10ms all-lane hole per attention layer in the lane trace. qd % 4 == 0 keeps the float4

--- a/modules/dasLLAMA/dasllama/dasllama_prefix.das
+++ b/modules/dasLLAMA/dasllama/dasllama_prefix.das
@@ -79,7 +79,9 @@ def prefix_held_groups_(cache : PrefixCache) : int64 => int64(length(cache.entri
 //! at one token short of the prompt so the tail eval always produces the sampling logits.
 def prefix_attach_(var cache : PrefixCache; var pool : KVPool; var s : Session; prompt : array<int64>) : int64 {
     if (!empty(s.dn_state_prefix)) {
-        panic("prefix_attach: hybrid (deltanet) models are not supported — KV pages alone cannot reconstruct recurrent state")
+        // hybrid (deltanet): KV pages alone cannot reconstruct recurrent state, so no cached
+        // prefix is ever attachable — 0 matched is the correct result, the caller prefills all
+        return 0l
     }
     if (s.kv_pool == null || s.kv_pool != unsafe(addr(pool))) {
         panic("prefix_attach: the session is not paged out of this pool")
@@ -136,6 +138,9 @@ def private prefix_evict_lru(var cache : PrefixCache; var pool : KVPool) {
 //! already cached, bumping the pool refcnt so the pages survive the session's release. Pages past
 //! the budget LRU-drop. Call right before ``release_kv_pages``.
 def prefix_insert_(var cache : PrefixCache; var pool : KVPool; s : Session; tokens : array<int64>) {
+    if (!empty(s.dn_state_prefix)) {
+        return   // hybrid (deltanet): pages without recurrent state can never be attached — don't cache
+    }
     if (s.kv_pool == null || s.kv_pool != unsafe(addr(pool))) {
         panic("prefix_insert: the session is not paged out of this pool")
     }


### PR DESCRIPTION
Every hybrid (qwen35 / qwen3next) chat through dasllama-server crashed on the first request. Two independent bugs:

## 1. Prefix cache × hybrids: panic on every paged admission

`prefix_attach` deliberately panics on hybrids (KV pages alone cannot reconstruct deltanet recurrent state) — but the scheduler calls it unconditionally when admitting a stream in paged mode (the default), so any hybrid model died instantly. **Fix: graceful degradation at the engine level** — `prefix_attach` returns 0 matched (correct: nothing is ever attachable, the caller prefills everything), `prefix_insert` no-ops (hybrid pages could never be re-attached). The scheduler stays arch-blind, preserving the facade acceptance rule.

## 2. Gated attention × tq4 KV: null query plane + missing basis rotation

The qwen35 gated-attention drivers predate the tq4 codec:
- no FWHT basis rotation of q/k/v at the RoPE seam (tq4 attention runs in the rotated basis),
- no rotated-query quantize — `dot_q8tq4kv` dereferenced a **null** query plane (`EXCEPTION: dereferencing null pointer, q is null` → access violation),
- the `kplanes` gate covered q8_0 only.

Both drivers (decode + prefill) now carry the std drivers' tq4 stanza: rotate q/k/v after RoPE, quantize the rotated query for the block-codec dot, un-rotate `xb` **before** the sigmoid out-gate (the gate lives in the original basis).

## Validation (Zen2, 16 threads)

| Check | Before | After |
|---|---|---|
| 0.8B hybrid server: paged+tq4 / paged+f16 / flat+tq4 | 💥 all three | ✅ all three |
| Qwen3.6-35B counting parity vs llama.cpp, `--kv tq4` | 💥 | **40/40 token-for-token** |
| Qwen3.6-35B counting parity, `--kv f32` (regression) | 40/40 | 40/40 |
| `test_deltanet` (JIT) | — | 2/2 |
| Lint / format (2 changed `.das`) | — | 0 issues / clean |

The tq4 40/40 is the strong bar: prefill and decode both run the new rotation path, and token-for-token parity against the oracle proves the basis math, not just crash-freedom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)