### PR TITLE
dasMetal Phase 7: llama-3B GPU prefill — das-authored kernels match llama.cpp's best mode

### DIFF
--- a/modules/dasLLAMA/benchmarks/matmul/bench_metal_gemm_kernels.das
+++ b/modules/dasLLAMA/benchmarks/matmul/bench_metal_gemm_kernels.das
@@ -5,6 +5,7 @@ require dastest/testing_boost
 require metal/msl_shader
 require ?das_metal metal/das_metal_boost  // nolint:STYLE030 — GPU driver half, Apple builds only
 require ?das_metal dasllama/dasllama_math_metal  // nolint:STYLE030 — the production kernel MSL (v0 baseline)
+require dasllama/dasllama_metal_prefill  // nolint:STYLE030 — the production mul_mm companions (v25 = zero copy drift)
 require daslib/fio
 require math  // nolint:STYLE030 — used only inside the Apple static_if half; off-Apple lint sees the branch compiled out
 require strings
@@ -1363,6 +1364,383 @@ class MetalGemmLab6464Vec4 {
     }
 }
 
+// v18: v13 with 32-ELEMENT runs — each thread stages one whole Q8 block (row, kb): ONE scale
+// load (v13 pays it twice, once per 16-half) + 8 byte4 loads + 32 cvt/stores. 64 threads cover
+// A, the other 64 cover B — same tiles, same mac loop, half the scale traffic and address setup.
+class MetalGemmLab6464Run32 {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // 64 tokens x 32 k
+    @workgroup tb : float16[2048]           // 32 k x 64 outputs, transposed
+
+    [metal_kernel(name="lab_6464run32_msl")]
+    def lab_6464run32 {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let ntileN = ndim / 64u
+        let mBase = (gl_WorkGroupID.x / ntileN) * 64u
+        let nBase = (gl_WorkGroupID.x % ntileN) * 64u
+        let qm = (sg / 2u) * 32u
+        let qn = (sg % 2u) * 32u
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        var c20 : simdgroup_float8x8
+        var c21 : simdgroup_float8x8
+        var c22 : simdgroup_float8x8
+        var c23 : simdgroup_float8x8
+        var c30 : simdgroup_float8x8
+        var c31 : simdgroup_float8x8
+        var c32 : simdgroup_float8x8
+        var c33 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let ra = lid % 64u                  // staged row (token row for A half, output row for B)
+        let isB = lid >= 64u
+        var kb = 0u
+        while (kb * 32u < kdim) {
+            if (isB) {
+                let sw = ws[(nBase + ra) * (kdim / 32u) + kb]
+                let srcw = (nBase + ra) * kdim4 + kb * 8u
+                var j4 = 0u
+                while (j4 < 8u) {
+                    let v = float4(int4(wq[srcw + j4])) * sw
+                    let o = j4 * 4u
+                    tb[o * 64u + ra] = float16(v.x)
+                    tb[(o + 1u) * 64u + ra] = float16(v.y)
+                    tb[(o + 2u) * 64u + ra] = float16(v.z)
+                    tb[(o + 3u) * 64u + ra] = float16(v.w)
+                    j4++
+                }
+            } else {
+                let s = xs[(mBase + ra) * (kdim / 32u) + kb]
+                let src = (mBase + ra) * kdim4 + kb * 8u
+                let dst = ra * 32u
+                var i4 = 0u
+                while (i4 < 8u) {
+                    let v = float4(int4(xq[src + i4])) * s
+                    let o = dst + i4 * 4u
+                    ta[o] = float16(v.x)
+                    ta[o + 1u] = float16(v.y)
+                    ta[o + 2u] = float16(v.z)
+                    ta[o + 3u] = float16(v.w)
+                    i4++
+                }
+            }
+            barrier()
+            var k8 = 0u
+            while (k8 < 32u) {
+                var a0 : simdgroup_half8x8
+                var a1 : simdgroup_half8x8
+                var a2 : simdgroup_half8x8
+                var a3 : simdgroup_half8x8
+                var b0 : simdgroup_half8x8
+                var b1 : simdgroup_half8x8
+                var b2 : simdgroup_half8x8
+                var b3 : simdgroup_half8x8
+                simdgroup_load(a0, ta, qm * 32u + k8, 32u)
+                simdgroup_load(a1, ta, (qm + 8u) * 32u + k8, 32u)
+                simdgroup_load(a2, ta, (qm + 16u) * 32u + k8, 32u)
+                simdgroup_load(a3, ta, (qm + 24u) * 32u + k8, 32u)
+                simdgroup_load(b0, tb, k8 * 64u + qn, 64u)
+                simdgroup_load(b1, tb, k8 * 64u + (qn + 8u), 64u)
+                simdgroup_load(b2, tb, k8 * 64u + (qn + 16u), 64u)
+                simdgroup_load(b3, tb, k8 * 64u + (qn + 24u), 64u)
+                simdgroup_multiply_accumulate(c00, a0, b0, c00)
+                simdgroup_multiply_accumulate(c01, a0, b1, c01)
+                simdgroup_multiply_accumulate(c02, a0, b2, c02)
+                simdgroup_multiply_accumulate(c03, a0, b3, c03)
+                simdgroup_multiply_accumulate(c10, a1, b0, c10)
+                simdgroup_multiply_accumulate(c11, a1, b1, c11)
+                simdgroup_multiply_accumulate(c12, a1, b2, c12)
+                simdgroup_multiply_accumulate(c13, a1, b3, c13)
+                simdgroup_multiply_accumulate(c20, a2, b0, c20)
+                simdgroup_multiply_accumulate(c21, a2, b1, c21)
+                simdgroup_multiply_accumulate(c22, a2, b2, c22)
+                simdgroup_multiply_accumulate(c23, a2, b3, c23)
+                simdgroup_multiply_accumulate(c30, a3, b0, c30)
+                simdgroup_multiply_accumulate(c31, a3, b1, c31)
+                simdgroup_multiply_accumulate(c32, a3, b2, c32)
+                simdgroup_multiply_accumulate(c33, a3, b3, c33)
+                k8 += 8u
+            }
+            barrier()
+            kb++
+        }
+        let row0 = mBase + qm
+        let col0 = nBase + qn
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c20, y, (row0 + 16u) * ndim + col0, ndim)
+        simdgroup_store(c21, y, (row0 + 16u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c22, y, (row0 + 16u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c23, y, (row0 + 16u) * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c30, y, (row0 + 24u) * ndim + col0, ndim)
+        simdgroup_store(c31, y, (row0 + 24u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c32, y, (row0 + 24u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c33, y, (row0 + 24u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+// v19: v13 with the staging rebuilt on the two emitter extensions — B stages ROW-major
+// ([64 outputs x 32 k], contiguous like A) and the mac loop transposes at simdgroup_load
+// (the MSL transpose_matrix flag), killing the 64-strided threadgroup writes; ALL staging
+// stores collapse 4:1 through tg_store_half4 (one aligned half4 per byte4 dequant).
+class MetalGemmLab6464Trans {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // 64 tokens x 32 k
+    @workgroup tb : float16[2048]           // 64 outputs x 32 k — ROW-major (transposed at load)
+
+    [metal_kernel(name="lab_6464trans_msl")]
+    def lab_6464trans {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let ntileN = ndim / 64u
+        let mBase = (gl_WorkGroupID.x / ntileN) * 64u
+        let nBase = (gl_WorkGroupID.x % ntileN) * 64u
+        let qm = (sg / 2u) * 32u
+        let qn = (sg % 2u) * 32u
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        var c20 : simdgroup_float8x8
+        var c21 : simdgroup_float8x8
+        var c22 : simdgroup_float8x8
+        var c23 : simdgroup_float8x8
+        var c30 : simdgroup_float8x8
+        var c31 : simdgroup_float8x8
+        var c32 : simdgroup_float8x8
+        var c33 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let ra = lid / 2u
+        let c0a = (lid % 2u) * 16u
+        var kb = 0u
+        while (kb * 32u < kdim) {
+            {
+                let s = xs[(mBase + ra) * (kdim / 32u) + kb]
+                let src = (mBase + ra) * kdim4 + (kb * 32u + c0a) / 4u
+                let dst = ra * 32u + c0a
+                var i4 = 0u
+                while (i4 < 4u) {
+                    let v = float4(int4(xq[src + i4])) * s
+                    tg_store_half4(ta, dst + i4 * 4u, v)
+                    i4++
+                }
+            }
+            {
+                let sw = ws[(nBase + ra) * (kdim / 32u) + kb]
+                let srcw = (nBase + ra) * kdim4 + (kb * 32u + c0a) / 4u
+                let dstw = ra * 32u + c0a
+                var j4 = 0u
+                while (j4 < 4u) {
+                    let v = float4(int4(wq[srcw + j4])) * sw
+                    tg_store_half4(tb, dstw + j4 * 4u, v)
+                    j4++
+                }
+            }
+            barrier()
+            var k8 = 0u
+            while (k8 < 32u) {
+                var a0 : simdgroup_half8x8
+                var a1 : simdgroup_half8x8
+                var a2 : simdgroup_half8x8
+                var a3 : simdgroup_half8x8
+                var b0 : simdgroup_half8x8
+                var b1 : simdgroup_half8x8
+                var b2 : simdgroup_half8x8
+                var b3 : simdgroup_half8x8
+                simdgroup_load(a0, ta, qm * 32u + k8, 32u)
+                simdgroup_load(a1, ta, (qm + 8u) * 32u + k8, 32u)
+                simdgroup_load(a2, ta, (qm + 16u) * 32u + k8, 32u)
+                simdgroup_load(a3, ta, (qm + 24u) * 32u + k8, 32u)
+                simdgroup_load(b0, tb, qn * 32u + k8, 32u, true)
+                simdgroup_load(b1, tb, (qn + 8u) * 32u + k8, 32u, true)
+                simdgroup_load(b2, tb, (qn + 16u) * 32u + k8, 32u, true)
+                simdgroup_load(b3, tb, (qn + 24u) * 32u + k8, 32u, true)
+                simdgroup_multiply_accumulate(c00, a0, b0, c00)
+                simdgroup_multiply_accumulate(c01, a0, b1, c01)
+                simdgroup_multiply_accumulate(c02, a0, b2, c02)
+                simdgroup_multiply_accumulate(c03, a0, b3, c03)
+                simdgroup_multiply_accumulate(c10, a1, b0, c10)
+                simdgroup_multiply_accumulate(c11, a1, b1, c11)
+                simdgroup_multiply_accumulate(c12, a1, b2, c12)
+                simdgroup_multiply_accumulate(c13, a1, b3, c13)
+                simdgroup_multiply_accumulate(c20, a2, b0, c20)
+                simdgroup_multiply_accumulate(c21, a2, b1, c21)
+                simdgroup_multiply_accumulate(c22, a2, b2, c22)
+                simdgroup_multiply_accumulate(c23, a2, b3, c23)
+                simdgroup_multiply_accumulate(c30, a3, b0, c30)
+                simdgroup_multiply_accumulate(c31, a3, b1, c31)
+                simdgroup_multiply_accumulate(c32, a3, b2, c32)
+                simdgroup_multiply_accumulate(c33, a3, b3, c33)
+                k8 += 8u
+            }
+            barrier()
+            kb++
+        }
+        let row0 = mBase + qm
+        let col0 = nBase + qn
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c20, y, (row0 + 16u) * ndim + col0, ndim)
+        simdgroup_store(c21, y, (row0 + 16u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c22, y, (row0 + 16u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c23, y, (row0 + 16u) * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c30, y, (row0 + 24u) * ndim + col0, ndim)
+        simdgroup_store(c31, y, (row0 + 24u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c32, y, (row0 + 24u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c33, y, (row0 + 24u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+// v20: DEVICE-DIRECT B — the W tile never stages at all: B tiles simdgroup_load straight from
+// a resident PRE-DEQUANTIZED f16 W panel (row-major, transposed at load), killing the whole
+// B-side staging chain (device byte4 loads + dequant ALU + tg stores + half the barrier
+// pressure); only the A (activation) half stages. Trades W device traffic 1.03 -> 2 B/weight.
+class MetalGemmLab6464DevB {
+    @ssbo @binding = 0 wh : array<float16>  // [d x kdim] f16 weights (dequantized at upload)
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // 64 tokens x 32 k — the only staged tile
+
+    [metal_kernel(name="lab_6464devb_msl")]
+    def lab_6464devb {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let ntileN = ndim / 64u
+        let mBase = (gl_WorkGroupID.x / ntileN) * 64u
+        let nBase = (gl_WorkGroupID.x % ntileN) * 64u
+        let qm = (sg / 2u) * 32u
+        let qn = (sg % 2u) * 32u
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        var c20 : simdgroup_float8x8
+        var c21 : simdgroup_float8x8
+        var c22 : simdgroup_float8x8
+        var c23 : simdgroup_float8x8
+        var c30 : simdgroup_float8x8
+        var c31 : simdgroup_float8x8
+        var c32 : simdgroup_float8x8
+        var c33 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let ra = lid / 2u
+        let c0a = (lid % 2u) * 16u
+        var kb = 0u
+        while (kb * 32u < kdim) {
+            {
+                let s = xs[(mBase + ra) * (kdim / 32u) + kb]
+                let src = (mBase + ra) * kdim4 + (kb * 32u + c0a) / 4u
+                let dst = ra * 32u + c0a
+                var i4 = 0u
+                while (i4 < 4u) {
+                    let v = float4(int4(xq[src + i4])) * s
+                    tg_store_half4(ta, dst + i4 * 4u, v)
+                    i4++
+                }
+            }
+            barrier()
+            let kw = kb * 32u
+            var k8 = 0u
+            while (k8 < 32u) {
+                var a0 : simdgroup_half8x8
+                var a1 : simdgroup_half8x8
+                var a2 : simdgroup_half8x8
+                var a3 : simdgroup_half8x8
+                var b0 : simdgroup_half8x8
+                var b1 : simdgroup_half8x8
+                var b2 : simdgroup_half8x8
+                var b3 : simdgroup_half8x8
+                simdgroup_load(a0, ta, qm * 32u + k8, 32u)
+                simdgroup_load(a1, ta, (qm + 8u) * 32u + k8, 32u)
+                simdgroup_load(a2, ta, (qm + 16u) * 32u + k8, 32u)
+                simdgroup_load(a3, ta, (qm + 24u) * 32u + k8, 32u)
+                simdgroup_load(b0, wh, (nBase + qn) * kdim + kw + k8, kdim, true)
+                simdgroup_load(b1, wh, (nBase + qn + 8u) * kdim + kw + k8, kdim, true)
+                simdgroup_load(b2, wh, (nBase + qn + 16u) * kdim + kw + k8, kdim, true)
+                simdgroup_load(b3, wh, (nBase + qn + 24u) * kdim + kw + k8, kdim, true)
+                simdgroup_multiply_accumulate(c00, a0, b0, c00)
+                simdgroup_multiply_accumulate(c01, a0, b1, c01)
+                simdgroup_multiply_accumulate(c02, a0, b2, c02)
+                simdgroup_multiply_accumulate(c03, a0, b3, c03)
+                simdgroup_multiply_accumulate(c10, a1, b0, c10)
+                simdgroup_multiply_accumulate(c11, a1, b1, c11)
+                simdgroup_multiply_accumulate(c12, a1, b2, c12)
+                simdgroup_multiply_accumulate(c13, a1, b3, c13)
+                simdgroup_multiply_accumulate(c20, a2, b0, c20)
+                simdgroup_multiply_accumulate(c21, a2, b1, c21)
+                simdgroup_multiply_accumulate(c22, a2, b2, c22)
+                simdgroup_multiply_accumulate(c23, a2, b3, c23)
+                simdgroup_multiply_accumulate(c30, a3, b0, c30)
+                simdgroup_multiply_accumulate(c31, a3, b1, c31)
+                simdgroup_multiply_accumulate(c32, a3, b2, c32)
+                simdgroup_multiply_accumulate(c33, a3, b3, c33)
+                k8 += 8u
+            }
+            barrier()
+            kb++
+        }
+        let row0 = mBase + qm
+        let col0 = nBase + qn
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c20, y, (row0 + 16u) * ndim + col0, ndim)
+        simdgroup_store(c21, y, (row0 + 16u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c22, y, (row0 + 16u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c23, y, (row0 + 16u) * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c30, y, (row0 + 24u) * ndim + col0, ndim)
+        simdgroup_store(c31, y, (row0 + 24u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c32, y, (row0 + 24u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c33, y, (row0 + 24u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
 // knockout: v13 with staging removed — the 64x64 math + barrier + store ceiling
 class MetalGemmLab6464NoStage {
     @ssbo @binding = 0 wq : array<byte4>
@@ -1773,6 +2151,1353 @@ class MetalGemmLab6464Prefetch {
     }
 }
 
+// v21: the ggml kernel_mul_mm GEOMETRY on our planar Q8 contract — measured head-to-head vs
+// the (since-removed) verbatim llama.cpp reference. 64 outputs x 32 tokens per threadgroup (their NR0xNR1 — transposed
+// vs our 64x64), TILE-MAJOR 8x8 shared blocks so every simdgroup_load is one contiguous
+// 64-half run at stride 8, weights transposed WITHIN their tiles at staging (the math loop
+// needs no transposed loads), and all device reads issued into registers BEFORE the
+// pre-staging barrier (their latency-hiding order). Each simdgroup owns a 16-token x
+// 32-output quadrant: 8 accumulators, 6 tile loads per 8-k slab. Deviations from ggml, both
+// deliberate: our planar int8 + f32-scale buffers via byte4 loads (theirs: interleaved blobs
+// read a byte at a time), and no simdgroup_barrier(mem_none) scheduling hints (no emitter
+// spelling; production would inherit them via a fastmath-safe pragma if this lands).
+class MetalGemmLabGgmlGeo {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_ggmlgeo_msl")]
+    def lab_ggmlgeo {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let sA = ws[(nBase + lr0) * nkb + kb]
+            let srcA = (nBase + lr0) * kdim4 + (kb * 32u + il0 * 16u) / 4u
+            let a0 = wq[srcA]
+            let a1 = wq[srcA + 1u]
+            let a2 = wq[srcA + 2u]
+            let a3 = wq[srcA + 3u]
+            let sB = xs[(mBase + lr1) * nkb + kb]
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xq[srcB]
+            let b1 = xq[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            let va0 = float4(int4(a0)) * sA
+            let va1 = float4(int4(a1)) * sA
+            let va2 = float4(int4(a2)) * sA
+            let va3 = float4(int4(a3)) * sA
+            ta[tA0] = float16(va0.x)        // ly = k%8 -> +8 per lane; +32 = second 4-k half
+            ta[tA0 + 8u] = float16(va0.y)
+            ta[tA0 + 16u] = float16(va0.z)
+            ta[tA0 + 24u] = float16(va0.w)
+            ta[tA0 + 32u] = float16(va1.x)
+            ta[tA0 + 40u] = float16(va1.y)
+            ta[tA0 + 48u] = float16(va1.z)
+            ta[tA0 + 56u] = float16(va1.w)
+            ta[tA1] = float16(va2.x)
+            ta[tA1 + 8u] = float16(va2.y)
+            ta[tA1 + 16u] = float16(va2.z)
+            ta[tA1 + 24u] = float16(va2.w)
+            ta[tA1 + 32u] = float16(va3.x)
+            ta[tA1 + 40u] = float16(va3.y)
+            ta[tA1 + 48u] = float16(va3.z)
+            ta[tA1 + 56u] = float16(va3.w)
+            let vb0 = float4(int4(b0)) * sB
+            let vb1 = float4(int4(b1)) * sB
+            tg_store_half4(tb, ibB, vb0)    // k runs contiguous within the tile row — 2 vector stores
+            tg_store_half4(tb, ibB + 4u, vb1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+class MetalGemmLabGgmlGeoF32X {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xf : array<float4>   // PRE-DEQUANTIZED f32 activations — the raw-f32 B contract
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_ggmlgeof32x_msl")]
+    def lab_ggmlgeof32x {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let sA = ws[(nBase + lr0) * nkb + kb]
+            let srcA = (nBase + lr0) * kdim4 + (kb * 32u + il0 * 16u) / 4u
+            let a0 = wq[srcA]
+            let a1 = wq[srcA + 1u]
+            let a2 = wq[srcA + 2u]
+            let a3 = wq[srcA + 3u]
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xf[srcB]
+            let b1 = xf[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            let va0 = float4(int4(a0)) * sA
+            let va1 = float4(int4(a1)) * sA
+            let va2 = float4(int4(a2)) * sA
+            let va3 = float4(int4(a3)) * sA
+            ta[tA0] = float16(va0.x)        // ly = k%8 -> +8 per lane; +32 = second 4-k half
+            ta[tA0 + 8u] = float16(va0.y)
+            ta[tA0 + 16u] = float16(va0.z)
+            ta[tA0 + 24u] = float16(va0.w)
+            ta[tA0 + 32u] = float16(va1.x)
+            ta[tA0 + 40u] = float16(va1.y)
+            ta[tA0 + 48u] = float16(va1.z)
+            ta[tA0 + 56u] = float16(va1.w)
+            ta[tA1] = float16(va2.x)
+            ta[tA1 + 8u] = float16(va2.y)
+            ta[tA1 + 16u] = float16(va2.z)
+            ta[tA1 + 24u] = float16(va2.w)
+            ta[tA1 + 32u] = float16(va3.x)
+            ta[tA1 + 40u] = float16(va3.y)
+            ta[tA1 + 48u] = float16(va3.z)
+            ta[tA1 + 56u] = float16(va3.w)
+            tg_store_half4(tb, ibB, b0)     // no dequant on B — pure convert-and-store
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+class MetalGemmLabGgmlGeoNoScale {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_ggmlgeonosc_msl")]
+    def lab_ggmlgeonosc {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let sA = 1.0
+            let srcA = (nBase + lr0) * kdim4 + (kb * 32u + il0 * 16u) / 4u
+            let a0 = wq[srcA]
+            let a1 = wq[srcA + 1u]
+            let a2 = wq[srcA + 2u]
+            let a3 = wq[srcA + 3u]
+            let sB = 1.0
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xq[srcB]
+            let b1 = xq[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            let va0 = float4(int4(a0)) * sA
+            let va1 = float4(int4(a1)) * sA
+            let va2 = float4(int4(a2)) * sA
+            let va3 = float4(int4(a3)) * sA
+            ta[tA0] = float16(va0.x)        // ly = k%8 -> +8 per lane; +32 = second 4-k half
+            ta[tA0 + 8u] = float16(va0.y)
+            ta[tA0 + 16u] = float16(va0.z)
+            ta[tA0 + 24u] = float16(va0.w)
+            ta[tA0 + 32u] = float16(va1.x)
+            ta[tA0 + 40u] = float16(va1.y)
+            ta[tA0 + 48u] = float16(va1.z)
+            ta[tA0 + 56u] = float16(va1.w)
+            ta[tA1] = float16(va2.x)
+            ta[tA1 + 8u] = float16(va2.y)
+            ta[tA1 + 16u] = float16(va2.z)
+            ta[tA1 + 24u] = float16(va2.w)
+            ta[tA1 + 32u] = float16(va3.x)
+            ta[tA1 + 40u] = float16(va3.y)
+            ta[tA1 + 48u] = float16(va3.z)
+            ta[tA1 + 56u] = float16(va3.w)
+            let vb0 = float4(int4(b0)) * sB
+            let vb1 = float4(int4(b1)) * sB
+            tg_store_half4(tb, ibB, vb0)    // k runs contiguous within the tile row — 2 vector stores
+            tg_store_half4(tb, ibB + 4u, vb1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+class MetalGemmLabGgmlGeoScT {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>     // TRANSPOSED: [block][row] — 64 A-scales/tg = 4 cachelines, not 64
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_ggmlgeosct_msl")]
+    def lab_ggmlgeosct {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let sA = ws[kb * ndim + nBase + lr0]
+            let srcA = (nBase + lr0) * kdim4 + (kb * 32u + il0 * 16u) / 4u
+            let a0 = wq[srcA]
+            let a1 = wq[srcA + 1u]
+            let a2 = wq[srcA + 2u]
+            let a3 = wq[srcA + 3u]
+            let sB = xs[(mBase + lr1) * nkb + kb]
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xq[srcB]
+            let b1 = xq[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            let va0 = float4(int4(a0)) * sA
+            let va1 = float4(int4(a1)) * sA
+            let va2 = float4(int4(a2)) * sA
+            let va3 = float4(int4(a3)) * sA
+            ta[tA0] = float16(va0.x)        // ly = k%8 -> +8 per lane; +32 = second 4-k half
+            ta[tA0 + 8u] = float16(va0.y)
+            ta[tA0 + 16u] = float16(va0.z)
+            ta[tA0 + 24u] = float16(va0.w)
+            ta[tA0 + 32u] = float16(va1.x)
+            ta[tA0 + 40u] = float16(va1.y)
+            ta[tA0 + 48u] = float16(va1.z)
+            ta[tA0 + 56u] = float16(va1.w)
+            ta[tA1] = float16(va2.x)
+            ta[tA1 + 8u] = float16(va2.y)
+            ta[tA1 + 16u] = float16(va2.z)
+            ta[tA1 + 24u] = float16(va2.w)
+            ta[tA1 + 32u] = float16(va3.x)
+            ta[tA1 + 40u] = float16(va3.y)
+            ta[tA1 + 48u] = float16(va3.z)
+            ta[tA1 + 56u] = float16(va3.w)
+            let vb0 = float4(int4(b0)) * sB
+            let vb1 = float4(int4(b1)) * sB
+            tg_store_half4(tb, ibB, vb0)    // k runs contiguous within the tile row — 2 vector stores
+            tg_store_half4(tb, ibB + 4u, vb1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+class MetalGemmLabBlob36 {
+    @ssbo @binding = 0 wsc : array<float>   // 36B-block W blob (f32 scale + 32 int8), SCALE view: scale of block b at 9*b
+    @ssbo @binding = 1 wqv : array<byte4>   // the SAME blob buffer, QUANT view: block b quants at 9*b + 1 .. 9*b + 8
+    @ssbo @binding = 2 xf : array<float4>   // PRE-DEQUANTIZED f32 activations — the raw-f32 B contract
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_blob36_msl")]
+    def lab_blob36 {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let b9 = ((nBase + lr0) * nkb + kb) * 9u
+            let sA = wsc[b9]                // scale rides the quants' cacheline — the blob's point
+            let srcA = b9 + 1u + il0 * 4u
+            let a0 = wqv[srcA]
+            let a1 = wqv[srcA + 1u]
+            let a2 = wqv[srcA + 2u]
+            let a3 = wqv[srcA + 3u]
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xf[srcB]
+            let b1 = xf[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            let va0 = float4(int4(a0)) * sA
+            let va1 = float4(int4(a1)) * sA
+            let va2 = float4(int4(a2)) * sA
+            let va3 = float4(int4(a3)) * sA
+            ta[tA0] = float16(va0.x)        // ly = k%8 -> +8 per lane; +32 = second 4-k half
+            ta[tA0 + 8u] = float16(va0.y)
+            ta[tA0 + 16u] = float16(va0.z)
+            ta[tA0 + 24u] = float16(va0.w)
+            ta[tA0 + 32u] = float16(va1.x)
+            ta[tA0 + 40u] = float16(va1.y)
+            ta[tA0 + 48u] = float16(va1.z)
+            ta[tA0 + 56u] = float16(va1.w)
+            ta[tA1] = float16(va2.x)
+            ta[tA1 + 8u] = float16(va2.y)
+            ta[tA1 + 16u] = float16(va2.z)
+            ta[tA1 + 24u] = float16(va2.w)
+            ta[tA1 + 32u] = float16(va3.x)
+            ta[tA1 + 40u] = float16(va3.y)
+            ta[tA1 + 48u] = float16(va3.z)
+            ta[tA1 + 56u] = float16(va3.w)
+            tg_store_half4(tb, ibB, b0)     // no dequant on B — pure convert-and-store
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+// v23: v22's geometry on llama.cpp's OWN 34B blob (half scale + 32 int8, quants 2-byte-offset)
+// — their exact W contract and byte-wise load/dequant pattern, das-authored. Isolates the
+// residual data-contract share of the verbatim gap: half scale = 5.6% less W traffic, and the
+// +2 quant offset forces scalar byte loads (the reason ggml reads bytes, not vectors).
+class MetalGemmLabBlob34 {
+    @ssbo @binding = 0 wsh : array<float16> // 34B-block W blob, HALF-SCALE view: scale of block b at 17*b
+    @ssbo @binding = 1 wqb : array<int8>    // the SAME blob buffer, BYTE view: quants of block b at 34*b + 2
+    @ssbo @binding = 2 xf : array<float4>   // PRE-DEQUANTIZED f32 activations — the raw-f32 B contract
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_blob34_msl")]
+    def lab_blob34 {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let blk = (nBase + lr0) * nkb + kb
+            let sA = float(wsh[blk * 17u])   // half scale rides the quants' cacheline
+            let qb = blk * 34u + 2u + il0 * 16u
+            let q0 = wqb[qb]
+            let q1 = wqb[qb + 1u]
+            let q2 = wqb[qb + 2u]
+            let q3 = wqb[qb + 3u]
+            let q4 = wqb[qb + 4u]
+            let q5 = wqb[qb + 5u]
+            let q6 = wqb[qb + 6u]
+            let q7 = wqb[qb + 7u]
+            let q8 = wqb[qb + 8u]
+            let q9 = wqb[qb + 9u]
+            let q10 = wqb[qb + 10u]
+            let q11 = wqb[qb + 11u]
+            let q12 = wqb[qb + 12u]
+            let q13 = wqb[qb + 13u]
+            let q14 = wqb[qb + 14u]
+            let q15 = wqb[qb + 15u]
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xf[srcB]
+            let b1 = xf[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            ta[tA0] = float16(float(q0) * sA)   // ly = k%8 -> +8 per lane; tA1 = second 8-k tile
+            ta[tA0 + 8u] = float16(float(q1) * sA)
+            ta[tA0 + 16u] = float16(float(q2) * sA)
+            ta[tA0 + 24u] = float16(float(q3) * sA)
+            ta[tA0 + 32u] = float16(float(q4) * sA)
+            ta[tA0 + 40u] = float16(float(q5) * sA)
+            ta[tA0 + 48u] = float16(float(q6) * sA)
+            ta[tA0 + 56u] = float16(float(q7) * sA)
+            ta[tA1] = float16(float(q8) * sA)
+            ta[tA1 + 8u] = float16(float(q9) * sA)
+            ta[tA1 + 16u] = float16(float(q10) * sA)
+            ta[tA1 + 24u] = float16(float(q11) * sA)
+            ta[tA1 + 32u] = float16(float(q12) * sA)
+            ta[tA1 + 40u] = float16(float(q13) * sA)
+            ta[tA1 + 48u] = float16(float(q14) * sA)
+            ta[tA1 + 56u] = float16(float(q15) * sA)
+            tg_store_half4(tb, ibB, b0)     // no dequant on B — pure convert-and-store
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+// knockouts: v21 staging bisect — A half only / B half only (timing-only)
+class MetalGemmLabGgmlGeoAOnly {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_ggmlgeoa_msl")]
+    def lab_ggmlgeoa {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tiles il0*2 (lanes at stride 8)
+        let tA1 = ((il0 * 2u + 1u) * 8u + syA) * 64u + lxA  // k-tile il0*2+1
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let sA = ws[(nBase + lr0) * nkb + kb]
+            let srcA = (nBase + lr0) * kdim4 + (kb * 32u + il0 * 16u) / 4u
+            let a0 = wq[srcA]
+            let a1 = wq[srcA + 1u]
+            let a2 = wq[srcA + 2u]
+            let a3 = wq[srcA + 3u]
+            barrier()                       // previous math done reading the tiles
+            let va0 = float4(int4(a0)) * sA
+            let va1 = float4(int4(a1)) * sA
+            let va2 = float4(int4(a2)) * sA
+            let va3 = float4(int4(a3)) * sA
+            ta[tA0] = float16(va0.x)        // ly = k%8 -> +8 per lane; +32 = second 4-k half
+            ta[tA0 + 8u] = float16(va0.y)
+            ta[tA0 + 16u] = float16(va0.z)
+            ta[tA0 + 24u] = float16(va0.w)
+            ta[tA0 + 32u] = float16(va1.x)
+            ta[tA0 + 40u] = float16(va1.y)
+            ta[tA0 + 48u] = float16(va1.z)
+            ta[tA0 + 56u] = float16(va1.w)
+            ta[tA1] = float16(va2.x)
+            ta[tA1 + 8u] = float16(va2.y)
+            ta[tA1 + 16u] = float16(va2.z)
+            ta[tA1 + 24u] = float16(va2.w)
+            ta[tA1 + 32u] = float16(va3.x)
+            ta[tA1 + 40u] = float16(va3.y)
+            ta[tA1 + 48u] = float16(va3.z)
+            ta[tA1 + 56u] = float16(va3.w)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+class MetalGemmLabGgmlGeoBOnly {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="lab_ggmlgeob_msl")]
+    def lab_ggmlgeob {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads first — they fly while the previous math loop drains
+            let sB = xs[(mBase + lr1) * nkb + kb]
+            let srcB = (mBase + lr1) * kdim4 + (kb * 32u + iy) / 4u
+            let b0 = xq[srcB]
+            let b1 = xq[srcB + 1u]
+            barrier()                       // previous math done reading the tiles
+            let vb0 = float4(int4(b0)) * sB
+            let vb1 = float4(int4(b1)) * sB
+            tg_store_half4(tb, ibB, vb0)    // k runs contiguous within the tile row — 2 vector stores
+            tg_store_half4(tb, ibB + 4u, vb1)
+            barrier()
+            // math fully unrolled (their FOR_UNROLL): 4 k-slabs x (6 tile loads + 8 macs),
+            // constant tile offsets off hoisted quadrant bases
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
+// knockout: v21 with the staging removed (math + barriers + stores only, tiles read
+// uninitialized) — the ggml-geometry math ceiling; attributes v21's staging share
+class MetalGemmLabGgmlGeoNoStage {
+    @ssbo @binding = 0 wq : array<byte4>
+    @ssbo @binding = 1 ws : array<float>
+    @ssbo @binding = 2 xq : array<byte4>
+    @ssbo @binding = 3 xs : array<float>
+    @ssbo @binding = 4 y : array<float>
+    @uniform @binding = 5 kdim : uint
+    @uniform @binding = 6 ndim : uint
+    @workgroup ta : float16[2048]
+    @workgroup tb : float16[1024]
+
+    [metal_kernel(name="lab_ggmlgeons_msl")]
+    def lab_ggmlgeons {
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u
+        let nBase = gl_WorkGroupID.y * 64u
+        var c00 : simdgroup_float8x8
+        var c01 : simdgroup_float8x8
+        var c02 : simdgroup_float8x8
+        var c03 : simdgroup_float8x8
+        var c10 : simdgroup_float8x8
+        var c11 : simdgroup_float8x8
+        var c12 : simdgroup_float8x8
+        var c13 : simdgroup_float8x8
+        let nkb = kdim / 32u
+        let aB = (sg % 2u) * 256u
+        let bB = (sg / 2u) * 128u
+        var ma0 : simdgroup_half8x8
+        var ma1 : simdgroup_half8x8
+        var ma2 : simdgroup_half8x8
+        var ma3 : simdgroup_half8x8
+        var mb0 : simdgroup_half8x8
+        var mb1 : simdgroup_half8x8
+        var kb = 0u
+        while (kb < nkb) {
+            barrier()
+            barrier()
+            simdgroup_load(ma0, ta, aB, 8u)
+            simdgroup_load(ma1, ta, aB + 64u, 8u)
+            simdgroup_load(ma2, ta, aB + 128u, 8u)
+            simdgroup_load(ma3, ta, aB + 192u, 8u)
+            simdgroup_load(mb0, tb, bB, 8u)
+            simdgroup_load(mb1, tb, bB + 64u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 512u, 8u)
+            simdgroup_load(ma1, ta, aB + 576u, 8u)
+            simdgroup_load(ma2, ta, aB + 640u, 8u)
+            simdgroup_load(ma3, ta, aB + 704u, 8u)
+            simdgroup_load(mb0, tb, bB + 256u, 8u)
+            simdgroup_load(mb1, tb, bB + 320u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1024u, 8u)
+            simdgroup_load(ma1, ta, aB + 1088u, 8u)
+            simdgroup_load(ma2, ta, aB + 1152u, 8u)
+            simdgroup_load(ma3, ta, aB + 1216u, 8u)
+            simdgroup_load(mb0, tb, bB + 512u, 8u)
+            simdgroup_load(mb1, tb, bB + 576u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            simdgroup_load(ma0, ta, aB + 1536u, 8u)
+            simdgroup_load(ma1, ta, aB + 1600u, 8u)
+            simdgroup_load(ma2, ta, aB + 1664u, 8u)
+            simdgroup_load(ma3, ta, aB + 1728u, 8u)
+            simdgroup_load(mb0, tb, bB + 768u, 8u)
+            simdgroup_load(mb1, tb, bB + 832u, 8u)
+            simdgroup_multiply_accumulate(c00, mb0, ma0, c00)
+            simdgroup_multiply_accumulate(c01, mb0, ma1, c01)
+            simdgroup_multiply_accumulate(c02, mb0, ma2, c02)
+            simdgroup_multiply_accumulate(c03, mb0, ma3, c03)
+            simdgroup_multiply_accumulate(c10, mb1, ma0, c10)
+            simdgroup_multiply_accumulate(c11, mb1, ma1, c11)
+            simdgroup_multiply_accumulate(c12, mb1, ma2, c12)
+            simdgroup_multiply_accumulate(c13, mb1, ma3, c13)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u
+        let col0 = nBase + (sg % 2u) * 32u
+        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
+        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
+        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
+        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
+        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
+        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
+    }
+}
+
 // ===== driver (Apple-only; every Metal-typed helper is a generic so non-Apple never compiles it) =====
 
 struct private LabVariant {
@@ -1784,6 +3509,14 @@ struct private LabVariant {
     bn : int                                // C-tile output columns — requires d % bn == 0
     check : bool = true                     // false = knockout: time it, never compare output
     threads : int = 128                     // threads per threadgroup
+    f16w : bool = false                     // binding 0 gets the PRE-DEQUANTIZED f16 W panel
+    grid2d : bool = false                   // dispatch (M'/bm, d/bn, 1) — tokens on the fast axis (ggml rasterization)
+    f32x : bool = false                     // binding 2 gets the PRE-DEQUANTIZED f32 activation panel
+    wscT : bool = false                     // binding 1 gets the [block][row]-TRANSPOSED W scales
+    blob36 : bool = false                   // bindings 0+1 get the SAME 36B-block W blob (scale/quant views) + f32 X
+    blob34 : bool = false                   // bindings 0+1 get llama.cpp's OWN 34B blob (half-scale/byte views) + f32 X
+    blob34p : bool = false                  // the PRODUCTION mul_mm binding set: blob x2, f32 X, y, kdim, ndim
+    tgmem : uint64 = 0ul                    // dynamic [[threadgroup(0)]] bytes (0 = kernel uses static tg arrays)
 }
 
 def private align_up(v, a : int64) : int64 => ((v + a - 1l) / a) * a
@@ -1846,6 +3579,470 @@ def private download_floats(buf; var dst : array<float>; count : int64) {
     }
 }
 
+// ===== v24 probe: hand-restructured MSL — v22's emitted text, math section rolled =====
+// The emitted v22 is fully unrolled SSA: LLVM hoists ~42 loop-invariant threadgroup addresses
+// (16 A-store + 2 B-store + 24 sgmat-load pointers) out of the k-loop, holding them in registers
+// for the kernel's whole life — max_threads drops 1024 -> 832 (register-limited) and occupancy
+// eats ~13%. This probe keeps v22's staging verbatim but rewrites the math as llama.cpp shapes
+// it: matrix ARRAYS + rolled unroll(full) loops + two bumped tile pointers, so the AGX backend
+// unrolls with register-budget awareness. das-side equivalent needs emitter work — probe first.
+let LAB_V22ROLL_MSL = "#include <metal_stdlib>
+using namespace metal;
+kernel void lab_v22roll(device const float* wsc [[buffer(0)]],
+        device const char4* wqv [[buffer(1)]],
+        device const float4* xf [[buffer(2)]],
+        device const float* xs [[buffer(3)]],
+        device float* y [[buffer(4)]],
+        constant uint& kdim [[buffer(5)]],
+        constant uint& ndim [[buffer(6)]],
+        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]],
+        uint gl_SubgroupID [[simdgroup_index_in_threadgroup]],
+        uint3 gl_WorkGroupID [[threadgroup_position_in_grid]]) \{
+    threadgroup half ta[2048];
+    threadgroup half tb[1024];
+    uint lid = gl_LocalInvocationID.x;
+    uint sg = gl_SubgroupID;
+    uint mBase = (gl_WorkGroupID.x * 32u);
+    uint nBase = (gl_WorkGroupID.y * 64u);
+    simdgroup_half8x8 ma[4];
+    simdgroup_half8x8 mb[2];
+    simdgroup_float8x8 mc[8];
+    #pragma clang loop unroll(full)
+    for (short i = 0; i < 8; i++) \{
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    \}
+    uint kdim4 = (kdim / 4u);
+    uint nkb = (kdim / 32u);
+    uint lr0 = (lid / 2u);
+    uint il0 = (lid % 2u);
+    uint syA = (lr0 / 8u);
+    uint lxA = (lr0 % 8u);
+    uint tA0 = (((((il0 * 2u) * 8u) + syA) * 64u) + lxA);
+    uint tA1 = ((((((il0 * 2u) + 1u) * 8u) + syA) * 64u) + lxA);
+    uint lr1 = (lid / 4u);
+    uint iy = ((lid % 4u) * 8u);
+    uint ibB = (((((lid % 4u) * 4u) + (lr1 / 8u)) * 64u) + ((lr1 % 8u) * 8u));
+    uint aB = ((sg % 2u) * 256u);
+    uint bB = ((sg / 2u) * 128u);
+    uint kb = 0u;
+    while ((kb < nkb)) \{
+        uint b9 = ((((nBase + lr0) * nkb) + kb) * 9u);
+        float sA = wsc[b9];
+        uint srcA = ((b9 + 1u) + (il0 * 4u));
+        char4 a0 = wqv[srcA];
+        char4 a1 = wqv[(srcA + 1u)];
+        char4 a2 = wqv[(srcA + 2u)];
+        char4 a3 = wqv[(srcA + 3u)];
+        uint srcB = (((mBase + lr1) * kdim4) + (((kb * 32u) + iy) / 4u));
+        float4 b0 = xf[srcB];
+        float4 b1 = xf[(srcB + 1u)];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        float4 va0 = (float4(int4(a0)) * sA);
+        float4 va1 = (float4(int4(a1)) * sA);
+        float4 va2 = (float4(int4(a2)) * sA);
+        float4 va3 = (float4(int4(a3)) * sA);
+        ta[tA0] = half(va0.x);
+        ta[(tA0 + 8u)] = half(va0.y);
+        ta[(tA0 + 16u)] = half(va0.z);
+        ta[(tA0 + 24u)] = half(va0.w);
+        ta[(tA0 + 32u)] = half(va1.x);
+        ta[(tA0 + 40u)] = half(va1.y);
+        ta[(tA0 + 48u)] = half(va1.z);
+        ta[(tA0 + 56u)] = half(va1.w);
+        ta[tA1] = half(va2.x);
+        ta[(tA1 + 8u)] = half(va2.y);
+        ta[(tA1 + 16u)] = half(va2.z);
+        ta[(tA1 + 24u)] = half(va2.w);
+        ta[(tA1 + 32u)] = half(va3.x);
+        ta[(tA1 + 40u)] = half(va3.y);
+        ta[(tA1 + 48u)] = half(va3.z);
+        ta[(tA1 + 56u)] = half(va3.w);
+        *(threadgroup half4*)(tb + (ibB)) = half4(b0);
+        *(threadgroup half4*)(tb + ((ibB + 4u))) = half4(b1);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup const half * lsma = ta + aB;
+        threadgroup const half * lsmb = tb + bB;
+        #pragma clang loop unroll(full)
+        for (short ik = 0; ik < 4; ik++) \{
+            #pragma clang loop unroll(full)
+            for (short i = 0; i < 4; i++) \{
+                simdgroup_load(ma[i], lsma + 64*i, 8, 0, false);
+            \}
+            #pragma clang loop unroll(full)
+            for (short i = 0; i < 2; i++) \{
+                simdgroup_load(mb[i], lsmb + 64*i, 8, 0, false);
+            \}
+            #pragma clang loop unroll(full)
+            for (short i = 0; i < 8; i++) \{
+                simdgroup_multiply_accumulate(mc[i], mb[i/4], ma[i%4], mc[i]);
+            \}
+            lsma += 8*64;
+            lsmb += 4*64;
+        \}
+        ++kb;
+    \}
+    uint row0 = (mBase + ((sg / 2u) * 16u));
+    uint col0 = (nBase + ((sg % 2u) * 32u));
+    device float * C = y + ((row0 * ndim) + col0);
+    #pragma clang loop unroll(full)
+    for (short i = 0; i < 8; i++) \{
+        simdgroup_store(mc[i], C + 8*(i%4) + 8*ndim*(i/4), ndim, 0, false);
+    \}
+\}
+"
+
+let LAB_V24G_MSL = "#include <metal_stdlib>
+using namespace metal;
+kernel void lab_v24g(device const half* wsh [[buffer(0)]],
+        device const char* wqb [[buffer(1)]],
+        device const float4* xf [[buffer(2)]],
+        device const float* xs [[buffer(3)]],
+        device float* y [[buffer(4)]],
+        constant uint& kdim [[buffer(5)]],
+        constant uint& ndim [[buffer(6)]],
+        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]],
+        uint gl_SubgroupID [[simdgroup_index_in_threadgroup]],
+        uint3 gl_WorkGroupID [[threadgroup_position_in_grid]]) \{
+    threadgroup half ta[2048];
+    threadgroup half tb[1024];
+    uint lid = gl_LocalInvocationID.x;
+    uint sg = gl_SubgroupID;
+    uint mBase = (gl_WorkGroupID.x * 32u);
+    uint nBase = (gl_WorkGroupID.y * 64u);
+    simdgroup_half8x8 ma[4];
+    simdgroup_half8x8 mb[2];
+    simdgroup_float8x8 mc[8];
+    #pragma clang loop unroll(full)
+    for (short i = 0; i < 8; i++) \{
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    \}
+    uint kdim4 = (kdim / 4u);
+    uint nkb = (kdim / 32u);
+    uint lr0 = (lid / 2u);
+    uint il0 = (lid % 2u);
+    uint syA = (lr0 / 8u);
+    uint lxA = (lr0 % 8u);
+    uint tA0 = (((((il0 * 2u) * 8u) + syA) * 64u) + lxA);
+    uint lr1 = (lid / 4u);
+    uint iy = ((lid % 4u) * 8u);
+    uint ibB = (((((lid % 4u) * 4u) + (lr1 / 8u)) * 64u) + ((lr1 % 8u) * 8u));
+    uint aB = ((sg % 2u) * 256u);
+    uint bB = ((sg / 2u) * 128u);
+    uint kb = 0u;
+    while ((kb < nkb)) \{
+        uint blk = (((nBase + lr0) * nkb) + kb);
+        float sA = (float)wsh[blk * 17u];
+        device const char * qp = wqb + blk * 34u + 2u + il0 * 16u;
+        uint srcB = (((mBase + lr1) * kdim4) + (((kb * 32u) + iy) / 4u));
+        float4 b0 = xf[srcB];
+        float4 b1 = xf[(srcB + 1u)];
+        half va[16];
+        #pragma clang loop unroll(full)
+        for (short i = 0; i < 16; i++) \{
+            va[i] = (half)((float)qp[i] * sA);
+        \}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        #pragma clang loop unroll(full)
+        for (short i = 0; i < 16; i++) \{
+            ta[tA0 + (i/8)*512 + (i%8)*8] = va[i];
+        \}
+        *(threadgroup half4*)(tb + (ibB)) = half4(b0);
+        *(threadgroup half4*)(tb + ((ibB + 4u))) = half4(b1);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup const half * lsma = ta + aB;
+        threadgroup const half * lsmb = tb + bB;
+        #pragma clang loop unroll(full)
+        for (short ik = 0; ik < 4; ik++) \{
+            #pragma clang loop unroll(full)
+            for (short i = 0; i < 4; i++) \{
+                simdgroup_load(ma[i], lsma + 64*i, 8, 0, false);
+            \}
+            #pragma clang loop unroll(full)
+            for (short i = 0; i < 2; i++) \{
+                simdgroup_load(mb[i], lsmb + 64*i, 8, 0, false);
+            \}
+            #pragma clang loop unroll(full)
+            for (short i = 0; i < 8; i++) \{
+                simdgroup_multiply_accumulate(mc[i], mb[i/4], ma[i%4], mc[i]);
+            \}
+            lsma += 8*64;
+            lsmb += 4*64;
+        \}
+        ++kb;
+    \}
+    uint row0 = (mBase + ((sg / 2u) * 16u));
+    uint col0 = (nBase + ((sg % 2u) * 32u));
+    device float * C = y + ((row0 * ndim) + col0);
+    #pragma clang loop unroll(full)
+    for (short i = 0; i < 8; i++) \{
+        simdgroup_store(mc[i], C + 8*(i%4) + 8*ndim*(i/4), ndim, 0, false);
+    \}
+\}
+"
+
+let LAB_V24H1_MSL = "#include <metal_stdlib>
+using namespace metal;
+kernel void lab_v24h1(device const half* wsh [[buffer(0)]],
+        device const char* wqb [[buffer(1)]],
+        device const float4* xf [[buffer(2)]],
+        device const float* xs [[buffer(3)]],
+        device float* y [[buffer(4)]],
+        constant uint& kdim [[buffer(5)]],
+        constant uint& ndim [[buffer(6)]],
+        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]],
+        uint gl_SubgroupID [[simdgroup_index_in_threadgroup]],
+        uint3 gl_WorkGroupID [[threadgroup_position_in_grid]]) \{
+    threadgroup half ta[2048];
+    threadgroup half tb[1024];
+    uint lid = gl_LocalInvocationID.x;
+    uint sg = gl_SubgroupID;
+    uint mBase = (gl_WorkGroupID.x * 32u);
+    uint nBase = (gl_WorkGroupID.y * 64u);
+    simdgroup_half8x8 ma[4];
+    simdgroup_half8x8 mb[2];
+    simdgroup_float8x8 mc[8];
+    #pragma clang loop unroll(full)
+    for (short i = 0; i < 8; i++) \{
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    \}
+    uint kdim4 = (kdim / 4u);
+    uint nkb = (kdim / 32u);
+    uint lr0 = (lid / 2u);
+    uint il0 = (lid % 2u);
+    uint syA = (lr0 / 8u);
+    uint lxA = (lr0 % 8u);
+    uint tA0 = (((((il0 * 2u) * 8u) + syA) * 64u) + lxA);
+    uint lr1 = (lid / 4u);
+    uint iy = ((lid % 4u) * 8u);
+    uint ibB = (((((lid % 4u) * 4u) + (lr1 / 8u)) * 64u) + ((lr1 % 8u) * 8u));
+    uint aB = ((sg % 2u) * 256u);
+    uint bB = ((sg / 2u) * 128u);
+    uint kb = 0u;
+    while ((kb < nkb)) \{
+        uint blk = (((nBase + lr0) * nkb) + kb);
+        float sA = (float)wsh[blk * 17u];
+        device const char * qp = wqb + blk * 34u + 2u + il0 * 16u;
+        uint srcB = (((mBase + lr1) * kdim4) + (((kb * 32u) + iy) / 4u));
+        float4 b0 = xf[srcB];
+        float4 b1 = xf[(srcB + 1u)];
+        half va[16];
+        #pragma clang loop unroll(full)
+        for (short i = 0; i < 16; i++) \{
+            va[i] = (half)((float)qp[i] * sA);
+        \}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        #pragma clang loop unroll(full)
+        for (short i = 0; i < 16; i++) \{
+            ta[tA0 + (i/8)*512 + (i%8)*8] = va[i];
+        \}
+        *(threadgroup half4*)(tb + (ibB)) = half4(b0);
+        *(threadgroup half4*)(tb + ((ibB + 4u))) = half4(b1);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        #pragma clang loop unroll(full)
+        for (int ik = 0; ik < 4; ++ik) \{
+            #pragma clang loop unroll(full)
+            for (int i = 0; i < 4; ++i) \{
+                simdgroup_load(ma[i], ta + ((aB + (uint(ik) * 512u)) + (uint(i) * 64u)), 8u);
+            \}
+            #pragma clang loop unroll(full)
+            for (int i = 0; i < 2; ++i) \{
+                simdgroup_load(mb[i], tb + ((bB + (uint(ik) * 256u)) + (uint(i) * 64u)), 8u);
+            \}
+            #pragma clang loop unroll(full)
+            for (int i = 0; i < 8; ++i) \{
+                simdgroup_multiply_accumulate(mc[i], mb[(i / 4)], ma[(i % 4)], mc[i]);
+            \}
+        \}
+        ++kb;
+    \}
+    uint row0 = (mBase + ((sg / 2u) * 16u));
+    uint col0 = (nBase + ((sg % 2u) * 32u));
+    device float * C = y + ((row0 * ndim) + col0);
+    #pragma clang loop unroll(full)
+    for (short i = 0; i < 8; i++) \{
+        simdgroup_store(mc[i], C + 8*(i%4) + 8*ndim*(i/4), ndim, 0, false);
+    \}
+\}
+"
+
+
+// v26 probe: v25's emitted text with the STATIC threadgroup arrays swapped for one dynamic
+// [[threadgroup(0)]] buffer (llama.cpp's shmem shape). ISA rail: the backend constant-folds
+// carried tile pointers into absolute addresses of STATIC tg arrays and must materialize the
+// large offsets (23 iadds in the math phase); the opaque dynamic base keeps small carried
+// offsets — loop 185 -> 156 instructions, iadd 40 -> 15 (the llama.cpp reference: 165 / 24).
+let LAB_V26_SHMEM_MSL = "#include <metal_stdlib>
+using namespace metal;
+kernel void lab_shmem(device const half* wsh [[buffer(0)]],
+        device const char* wqb [[buffer(1)]],
+        device const float4* xf [[buffer(2)]],
+        device const float* xs [[buffer(3)]],
+        device float* y [[buffer(4)]],
+        constant uint& kdim [[buffer(5)]],
+        constant uint& ndim [[buffer(6)]],
+        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]],
+        uint gl_SubgroupID [[simdgroup_index_in_threadgroup]],
+        uint3 gl_WorkGroupID [[threadgroup_position_in_grid]],
+        threadgroup char * shmem [[threadgroup(0)]]) \{
+    threadgroup half * ta = (threadgroup half *)(shmem);
+    threadgroup half * tb = (threadgroup half *)(shmem + 4096);
+    uint lid = gl_LocalInvocationID.x;
+    uint sg = gl_SubgroupID;
+    uint mBase = (gl_WorkGroupID.x * 32u);
+    uint nBase = (gl_WorkGroupID.y * 64u);
+    simdgroup_float8x8 mc[8];
+    #pragma clang loop unroll(full)
+    for (int mc_zi = 0; mc_zi < 8; ++mc_zi) \{
+        mc[mc_zi] = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    \}
+    simdgroup_half8x8 ma[4];
+    #pragma clang loop unroll(full)
+    for (int ma_zi = 0; ma_zi < 4; ++ma_zi) \{
+        ma[ma_zi] = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    \}
+    simdgroup_half8x8 mb[2];
+    #pragma clang loop unroll(full)
+    for (int mb_zi = 0; mb_zi < 2; ++mb_zi) \{
+        mb[mb_zi] = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    \}
+    half va[16] = \{\};
+    uint kdim4 = (kdim / 4u);
+    uint nkb = (kdim / 32u);
+    uint lr0 = (lid / 2u);
+    uint il0 = (lid % 2u);
+    uint syA = (lr0 / 8u);
+    uint lxA = (lr0 % 8u);
+    uint tA0 = (((((il0 * 2u) * 8u) + syA) * 64u) + lxA);
+    uint lr1 = (lid / 4u);
+    uint iy = ((lid % 4u) * 8u);
+    uint ibB = (((((lid % 4u) * 4u) + (lr1 / 8u)) * 64u) + ((lr1 % 8u) * 8u));
+    uint aB = ((sg % 2u) * 256u);
+    uint bB = ((sg / 2u) * 128u);
+    uint blk0 = ((nBase + lr0) * nkb);
+    device const half * scur = wsh + ((blk0 * 17u));
+    device const char * qp = wqb + ((((blk0 * 34u) + 2u) + (il0 * 16u)));
+    device const float4 * xcur = xf + ((((mBase + lr1) * kdim4) + (iy / 4u)));
+    uint kb = 0u;
+    while ((kb < nkb)) \{
+        float sA = float(scur[0]);
+        float4 b0 = xcur[0];
+        float4 b1 = xcur[(1u)];
+        #pragma clang loop unroll(full)
+        for (int i = 0; i < 16; ++i) \{
+            va[i] = half((float(qp[(uint(i))]) * sA));
+        \}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        #pragma clang loop unroll(full)
+        for (int i = 0; i < 16; ++i) \{
+            ta[((tA0 + (uint((i / 8)) * 512u)) + (uint((i % 8)) * 8u))] = va[i];
+        \}
+        *(threadgroup half4*)(tb + (ibB)) = half4(b0);
+        *(threadgroup half4*)(tb + ((ibB + 4u))) = half4(b1);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup const half * acur = ta + (aB);
+        threadgroup const half * bcur = tb + (bB);
+        #pragma clang loop unroll(full)
+        for (int _ik = 0; _ik < 4; ++_ik) \{
+            #pragma clang loop unroll(full)
+            for (int i = 0; i < 4; ++i) \{
+                simdgroup_load(ma[i], acur + ((uint(i) * 64u)), 8u);
+            \}
+            #pragma clang loop unroll(full)
+            for (int i = 0; i < 2; ++i) \{
+                simdgroup_load(mb[i], bcur + ((uint(i) * 64u)), 8u);
+            \}
+            #pragma clang loop unroll(full)
+            for (int i = 0; i < 8; ++i) \{
+                simdgroup_multiply_accumulate(mc[i], mb[(i / 4)], ma[(i % 4)], mc[i]);
+            \}
+            acur += 512u;
+            bcur += 256u;
+        \}
+        scur += 17u;
+        qp += 34u;
+        xcur += 8u;
+        ++kb;
+    \}
+    uint row0 = (mBase + ((sg / 2u) * 16u));
+    uint col0 = (nBase + ((sg % 2u) * 32u));
+    #pragma clang loop unroll(full)
+    for (int i = 0; i < 8; ++i) \{
+        simdgroup_store(mc[i], y + ((((row0 + (uint((i / 4)) * 8u)) * ndim) + col0) + (uint((i % 4)) * 8u)), ndim);
+    \}
+\}
+"
+
+// ===== 34B q8-block data builders (GGUF q8_0's on-disk block layout: f16 scale + 32 int8) =====
+
+def private upload_q8_blob34(dev; q : array<int8>; s : array<float>; rows, k : int64; enabled : bool) {
+    if (!enabled) {
+        return metal_new_buffer(dev, 64ul)
+    }
+    let nb = int(k / 32l)
+    let kk = int(k)
+    var buf = metal_new_buffer(dev, uint64(rows * (k / 32l) * 34l))
+    var base = unsafe(reinterpret<int8?>(metal_buffer_contents(buf)))
+    for (r in range(int(rows))) {
+        for (bi in range(nb)) {
+            let off = (r * nb + bi) * 34
+            unsafe {
+                var ph = reinterpret<float16?>(base + off)
+                ph[0] = float16(s[r * nb + bi])
+                let src = r * kk + bi * 32
+                for (c in range(32)) {
+                    base[off + 2 + c] = q[src + c]
+                }
+            }
+        }
+    }
+    return buf
+}
+
+def private upload_f32_x(dev; xq : array<int8>; xs : array<float>; rows, k : int64; enabled : bool) {
+    if (!enabled) {
+        return metal_new_buffer(dev, 64ul)
+    }
+    let nb = int(k / 32l)
+    let kk = int(k)
+    var buf = metal_new_buffer(dev, uint64(rows * k * 4l))
+    var pf = unsafe(reinterpret<float?>(metal_buffer_contents(buf)))
+    for (r in range(int(rows))) {
+        let s0 = r * nb
+        for (i in range(kk)) {
+            unsafe(pf[r * kk + i]) = float(xq[r * kk + i]) * xs[s0 + i / 32]
+        }
+    }
+    return buf
+}
+
+// interleaved 36B-block W blob (f32 scale + 32 int8 quants, 4-aligned) — the Option-A
+// production layout: same bytes as planar quants+scales, but the scale rides the quants'
+// cacheline and byte4 quant loads stay aligned (ggml's 34B half-scale blocks force scalar reads)
+def private upload_blob36(dev; q : array<int8>; s : array<float>; rows, k : int64; enabled : bool) {
+    if (!enabled) {
+        return metal_new_buffer(dev, 64ul)
+    }
+    let nb = int(k / 32l)
+    let kk = int(k)
+    var buf = metal_new_buffer(dev, uint64(rows * (k / 32l) * 36l))
+    var pf = unsafe(reinterpret<float?>(metal_buffer_contents(buf)))
+    var p8 = unsafe(reinterpret<int8?>(metal_buffer_contents(buf)))
+    for (r in range(int(rows))) {
+        for (bi in range(nb)) {
+            let b = r * nb + bi
+            unsafe {
+                pf[b * 9] = s[b]
+                let dst = b * 36 + 4
+                let src = r * kk + bi * 32
+                for (c in range(32)) {
+                    p8[dst + c] = q[src + c]
+                }
+            }
+        }
+    }
+    return buf
+}
+
 // count bit-mismatches vs the reference (exact-arithmetic data — any deviation is a real bug)
 def private count_mismatch(got, ref_v : array<float>; cnt : int64; var firstBad : int64&) : int64 {
     var bad = 0l
@@ -1872,7 +4069,7 @@ def private compile_lab_pso(dev; v : LabVariant) {
 
 // one timed encoder: set state once, dispatch `reps` back-to-back (hazard tracking on the shared
 // y buffer serializes them); returns per-dispatch GPU milliseconds, or -1 on failure
-def private time_reps(queue; pso; bufs; groups, threads : uint; reps : int) : double {
+def private time_reps(queue; pso; bufs; groups : uint3; threads : uint; reps : int; tgmem : uint64) : double {
     var err : string
     var gpu_ms = 0.0lf
     let ok = with_compute_encoder_timed(queue, err, gpu_ms) $(enc) {
@@ -1880,8 +4077,11 @@ def private time_reps(queue; pso; bufs; groups, threads : uint; reps : int) : do
         for (bi in range(length(bufs))) {
             metal_set_buffer(enc, bufs[bi], 0ul, bi)
         }
+        if (tgmem > 0ul) {
+            metal_set_threadgroup_memory_length(enc, tgmem, 0)
+        }
         for (_i in range(reps)) {
-            metal_dispatch_threadgroups(enc, uint3(groups, 1u, 1u), uint3(threads, 1u, 1u))
+            metal_dispatch_threadgroups(enc, groups, uint3(threads, 1u, 1u))
         }
     }
     if (!ok) {
@@ -1913,10 +4113,17 @@ def private run_lab(b : B?; variants) {
     var psos <- [for (v in variants); compile_lab_pso(dev, v)]
     for (v, pso in variants, psos) {
         b |> success(pso != null, "pipeline compiles: {v.name}")
+        if (pso != null && want("DASMETAL_LAB_VARIANTS", v.name)) {
+            // register-pressure signal: a reg-limited kernel reports max_threads < 1024
+            to_log(LOG_INFO, "{v.name}: max_threads={metal_pipeline_max_total_threads(pso)} simd_width={metal_pipeline_thread_execution_width(pso)}\n")
+        }
     }
     // llama1b GEMM geometries (n = reduction dim, d = output rows)
     var shapes <- [("kv", 2048l, 512l), ("q", 2048l, 2048l), ("w13", 2048l, 8192l),
-                   ("w2", 8192l, 2048l), ("cls", 2048l, 128256l)]
+                   ("w2", 8192l, 2048l), ("cls", 2048l, 128256l),
+                   // the llama-3B set (dim 3072, hidden 8192, kv_dim 1024)
+                   ("kv3b", 3072l, 1024l), ("q3b", 3072l, 3072l), ("w13_3b", 3072l, 8192l),
+                   ("w2_3b", 8192l, 3072l)]
     let mp_max = align_up(ntok, 64l)
     for (sh in shapes) {
         if (!want("DASMETAL_LAB_SHAPES", sh._0)) {
@@ -1935,12 +4142,56 @@ def private run_lab(b : B?; variants) {
         var yref <- cpu_ref_rows(wq, ws, xq, xs, n, d, ref_rows)
         var wbuf = upload_array(dev, wq, d * n)
         var sbuf = upload_array(dev, ws, d * nb * 4l)
+        // the f16 W panel (v.f16w variants): W dequantized once host-side — exact in f16 under
+        // the lab's exact-arithmetic fill (|w| <= 16, int x pow2)
+        var wh : array<float16>
+        wh |> resize(int(d * n))
+        for (i in range64(d * n)) {
+            wh[i] = float16(float(wq[i]) * ws[(i / n) * nb + (i % n) / 32l])
+        }
+        var whbuf = upload_array(dev, wh, d * n * 2l)
         var xqbuf = upload_array(dev, xq, mp_max * n)
         var xsbuf = upload_array(dev, xs, mp_max * nb * 4l)
         var ybuf = metal_new_buffer(dev, uint64(mp_max * d * 4l))
         var kdimbuf = upload_u32(dev, uint(n))
         var ndimbuf = upload_u32(dev, uint(d))
         var bufs <- [wbuf, sbuf, xqbuf, xsbuf, ybuf, kdimbuf, ndimbuf]
+        var bufs16 <- [whbuf, sbuf, xqbuf, xsbuf, ybuf, kdimbuf, ndimbuf]
+        // the f32-X / blob legs' buffers — built only when a variant that needs them will run
+        var xf32On = false
+        for (v in variants) {
+            if ((v.f32x || v.blob36 || v.blob34 || v.blob34p) && want("DASMETAL_LAB_VARIANTS", v.name) && (d % int64(v.bn)) == 0l) {
+                xf32On = true
+            }
+        }
+        var blob36On = false
+        var blob34On = false
+        for (v in variants) {
+            if (v.blob36 && want("DASMETAL_LAB_VARIANTS", v.name) && (d % int64(v.bn)) == 0l) {
+                blob36On = true
+            }
+            if ((v.blob34 || v.blob34p) && want("DASMETAL_LAB_VARIANTS", v.name) && (d % int64(v.bn)) == 0l) {
+                blob34On = true
+            }
+        }
+        var wblob34 = upload_q8_blob34(dev, wq, ws, d, n, blob34On)
+        var xf32buf = upload_f32_x(dev, xq, xs, mp_max, n, xf32On)
+        var bufsf32x <- [wbuf, sbuf, xf32buf, xsbuf, ybuf, kdimbuf, ndimbuf]
+        // [block][row]-transposed W scales (wscT variants)
+        var wsT : array<float>
+        wsT |> resize(int(d * nb))
+        for (r in range64(d)) {
+            for (bi in range64(nb)) {
+                wsT[int(bi * d + r)] = ws[r * nb + bi]
+            }
+        }
+        var wsTbuf = upload_array(dev, wsT, d * nb * 4l)
+        delete wsT
+        var bufswsct <- [wbuf, wsTbuf, xqbuf, xsbuf, ybuf, kdimbuf, ndimbuf]
+        var wblob36 = upload_blob36(dev, wq, ws, d, n, blob36On)
+        var bufs36 <- [wblob36, wblob36, xf32buf, xsbuf, ybuf, kdimbuf, ndimbuf]
+        var bufs34 <- [wblob34, wblob34, xf32buf, xsbuf, ybuf, kdimbuf, ndimbuf]
+        var bufs34p <- [wblob34, wblob34, xf32buf, ybuf, kdimbuf, ndimbuf]
         let setup_ms = double(ref_time_ticks() - t_shape0) / 1000000.0lf
         to_log(LOG_INFO, "=== {sh._0} n={n} d={d} === (setup {setup_ms} ms)\n")
         var y0 : array<float>                // v0's full output — the cross-variant reference
@@ -1956,8 +4207,10 @@ def private run_lab(b : B?; variants) {
                 continue
             }
             let mp = align_up(ntok, int64(v.bm))
-            let groups = uint((mp / int64(v.bm)) * (d / int64(v.bn)))
-            let ms = time_reps(queue, pso, bufs, groups, uint(v.threads), 1)   // warmup + correctness dispatch
+            let groups = (v.grid2d
+                ? uint3(uint(mp / int64(v.bm)), uint(d / int64(v.bn)), 1u)
+                : uint3(uint((mp / int64(v.bm)) * (d / int64(v.bn))), 1u, 1u))
+            let ms = time_reps(queue, pso, v.blob36 ? bufs36 : (v.blob34p ? bufs34p : (v.blob34 ? bufs34 : (v.wscT ? bufswsct : (v.f32x ? bufsf32x : (v.f16w ? bufs16 : bufs))))), groups, uint(v.threads), 1, v.tgmem)   // warmup + correctness dispatch
             if (ms < 0.0lf) {
                 b |> success(false, "{v.name} {sh._0}: dispatch")
                 continue
@@ -1999,9 +4252,11 @@ def private run_lab(b : B?; variants) {
                     continue
                 }
                 let mp = align_up(ntok, int64(v.bm))
-                let groups = uint((mp / int64(v.bm)) * (d / int64(v.bn)))
+                let groups = (v.grid2d
+                    ? uint3(uint(mp / int64(v.bm)), uint(d / int64(v.bn)), 1u)
+                    : uint3(uint((mp / int64(v.bm)) * (d / int64(v.bn))), 1u, 1u))
                 let reps = clamp(int(25.0lf / max(est_ms[idx], 0.01lf)) + 1, 1, 128)
-                let ms = time_reps(queue, pso, bufs, groups, uint(v.threads), reps)
+                let ms = time_reps(queue, pso, v.blob36 ? bufs36 : (v.blob34p ? bufs34p : (v.blob34 ? bufs34 : (v.wscT ? bufswsct : (v.f32x ? bufsf32x : (v.f16w ? bufs16 : bufs))))), groups, uint(v.threads), reps, v.tgmem)
                 if (ms > 0.0lf && ms < best[idx]) {
                     best[idx] = ms
                 }
@@ -2020,6 +4275,36 @@ def private run_lab(b : B?; variants) {
             let rel = base_gmacs > 0.0lf ? gmacs / base_gmacs : 0.0lf
             to_log(LOG_INFO, "{v.name}  {sh._0} {best[idx]} ms  {gmacs} GMAC/s  {rel}x vs v0\n")
         }
+        metal_release(wblob34)
+        metal_release(xf32buf)
+        bufsf32x |> clear()                  // pointees released via bufs loop + blob releases
+        unsafe {
+            delete bufsf32x
+        }
+        metal_release(wsTbuf)
+        bufswsct |> clear()
+        unsafe {
+            delete bufswsct
+        }
+        metal_release(wblob36)               // bound twice in bufs36 — release exactly once here
+        bufs36 |> clear()
+        unsafe {
+            delete bufs36
+        }
+        bufs34 |> clear()                    // pointees released via blob releases + bufs loop
+        unsafe {
+            delete bufs34
+        }
+        bufs34p |> clear()
+        unsafe {
+            delete bufs34p
+        }
+        metal_release(whbuf)
+        bufs16 |> clear()
+        unsafe {
+            delete bufs16
+        }
+        delete wh
         for (buf in bufs) {
             metal_release(buf)
         }
@@ -2062,45 +4347,92 @@ def bench_metal_gemm_kernels(b : B?) {
     static_if (typeinfo builtin_module_exists(das_metal)) {
         var variants <- [
             LabVariant(name = "v0_prod32", src = metal_q8_gemm_msl, entry = metal_q8_gemm_msl_entry,
-                       fastmath = metal_q8_gemm_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = metal_q8_gemm_msl_fastmath, bm = 32, bn = 32, tgmem = metal_q8_gemm_msl_tgmem),
             LabVariant(name = "v0b_prod64", src = metal_q8_gemm64_msl, entry = metal_q8_gemm64_msl_entry,
-                       fastmath = metal_q8_gemm64_msl_fastmath, bm = 64, bn = 64),
+                       fastmath = metal_q8_gemm64_msl_fastmath, bm = 64, bn = 64, tgmem = metal_q8_gemm64_msl_tgmem),
+            LabVariant(name = "v21_ggmlgeo", src = lab_ggmlgeo_msl, entry = lab_ggmlgeo_msl_entry,
+                       fastmath = lab_ggmlgeo_msl_fastmath, bm = 32, bn = 64, grid2d = true, tgmem = lab_ggmlgeo_msl_tgmem),
+            // v21 with B staged from the pre-dequantized f32 panel — the raw-f32 B contract on our
+            // W path; tests whether in-kernel X dequant is the residual staging tax
+            LabVariant(name = "v21f32x", src = lab_ggmlgeof32x_msl, entry = lab_ggmlgeof32x_msl_entry,
+                       fastmath = lab_ggmlgeof32x_msl_fastmath, bm = 32, bn = 64, grid2d = true, f32x = true, tgmem = lab_ggmlgeof32x_msl_tgmem),
+            // v22: the Option-A production kernel — v21 geometry, W from the interleaved 36B
+            // blob (scale + quants one cacheline, byte4-aligned), X from the f32 panel
+            LabVariant(name = "v22_blob36", src = lab_blob36_msl, entry = lab_blob36_msl_entry,
+                       fastmath = lab_blob36_msl_fastmath, bm = 32, bn = 64, grid2d = true, blob36 = true, tgmem = lab_blob36_msl_tgmem),
+            // v23: v22's geometry on the 34B q8_0-layout blob (half scale, byte-wise quant
+            // loads) — isolates the data-contract residue from emitter codegen
+            LabVariant(name = "v23_blob34", src = lab_blob34_msl, entry = lab_blob34_msl_entry,
+                       fastmath = lab_blob34_msl_fastmath, bm = 32, bn = 64, grid2d = true, blob34 = true, tgmem = lab_blob34_msl_tgmem),
+            // v24: hand-MSL probe — v22's emitted text with the math section restructured
+            // rolled (matrix arrays + unroll(full) loops + bumped tile pointers);
+            // tests the register-pressure/occupancy hypothesis (v22 max_threads 832 vs 1024)
+            LabVariant(name = "v24_roll", src = LAB_V22ROLL_MSL, entry = "lab_v22roll",
+                       fastmath = true, bm = 32, bn = 64, grid2d = true, blob36 = true),
+            LabVariant(name = "v24g_roll34", src = LAB_V24G_MSL, entry = "lab_v24g",
+                       fastmath = true, bm = 32, bn = 64, grid2d = true, blob34 = true),
+            LabVariant(name = "v24h1_idx", src = LAB_V24H1_MSL, entry = "lab_v24h1",
+                       fastmath = true, bm = 32, bn = 64, grid2d = true, blob34 = true),
+            // v25: the PRODUCTION mul_mm (metal_q8_mulmm in dasllama_metal_prefill) — zero
+            // copy drift, exactly what the resident prefill dispatches
+            LabVariant(name = "v25_das_rolled", src = metal_q8_mulmm_msl, entry = metal_q8_mulmm_msl_entry,
+                       fastmath = metal_q8_mulmm_msl_fastmath, bm = 32, bn = 64, grid2d = true, blob34p = true, tgmem = metal_q8_mulmm_msl_tgmem),
+            LabVariant(name = "v26_shmem", src = LAB_V26_SHMEM_MSL, entry = "lab_shmem",
+                       fastmath = true, bm = 32, bn = 64, grid2d = true, blob34 = true, tgmem = 6144ul),
+            // v21 + [block][row]-transposed W scales — format-compatible (planar q8 unchanged,
+            // scale array re-laid at upload); collapses the A-scale reads to 4 cachelines/tg
+            LabVariant(name = "v21sct", src = lab_ggmlgeosct_msl, entry = lab_ggmlgeosct_msl_entry,
+                       fastmath = lab_ggmlgeosct_msl_fastmath, bm = 32, bn = 64, grid2d = true, wscT = true, tgmem = lab_ggmlgeosct_msl_tgmem),
             LabVariant(name = "v1_n64", src = lab_n64_msl, entry = lab_n64_msl_entry,
-                       fastmath = lab_n64_msl_fastmath, bm = 32, bn = 64),
+                       fastmath = lab_n64_msl_fastmath, bm = 32, bn = 64, tgmem = lab_n64_msl_tgmem),
             LabVariant(name = "v2_m64", src = lab_m64_msl, entry = lab_m64_msl_entry,
-                       fastmath = lab_m64_msl_fastmath, bm = 64, bn = 32),
+                       fastmath = lab_m64_msl_fastmath, bm = 64, bn = 32, tgmem = lab_m64_msl_tgmem),
             LabVariant(name = "v3_db32", src = lab_db32_msl, entry = lab_db32_msl_entry,
-                       fastmath = lab_db32_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_db32_msl_fastmath, bm = 32, bn = 32, tgmem = lab_db32_msl_tgmem),
             LabVariant(name = "v4_k64", src = lab_k64_msl, entry = lab_k64_msl_entry,
-                       fastmath = lab_k64_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_k64_msl_fastmath, bm = 32, bn = 32, tgmem = lab_k64_msl_tgmem),
             LabVariant(name = "v5_tile", src = lab_tile32_msl, entry = lab_tile32_msl_entry,
-                       fastmath = lab_tile32_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_tile32_msl_fastmath, bm = 32, bn = 32, tgmem = lab_tile32_msl_tgmem),
             LabVariant(name = "v6_pad36", src = lab_pad36_msl, entry = lab_pad36_msl_entry,
-                       fastmath = lab_pad36_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_pad36_msl_fastmath, bm = 32, bn = 32, tgmem = lab_pad36_msl_tgmem),
             LabVariant(name = "v7_run16", src = lab_run16_msl, entry = lab_run16_msl_entry,
-                       fastmath = lab_run16_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_run16_msl_fastmath, bm = 32, bn = 32, tgmem = lab_run16_msl_tgmem),
             LabVariant(name = "v8_vec4", src = lab_vec4_msl, entry = lab_vec4_msl_entry,
-                       fastmath = lab_vec4_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_vec4_msl_fastmath, bm = 32, bn = 32, tgmem = lab_vec4_msl_tgmem),
             LabVariant(name = "v9_vec16", src = lab_vec16_msl, entry = lab_vec16_msl_entry,
-                       fastmath = lab_vec16_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_vec16_msl_fastmath, bm = 32, bn = 32, tgmem = lab_vec16_msl_tgmem),
             LabVariant(name = "v10_dbvec4", src = lab_dbvec4_msl, entry = lab_dbvec4_msl_entry,
-                       fastmath = lab_dbvec4_msl_fastmath, bm = 32, bn = 32),
+                       fastmath = lab_dbvec4_msl_fastmath, bm = 32, bn = 32, tgmem = lab_dbvec4_msl_tgmem),
             LabVariant(name = "v11_n64vec4", src = lab_n64vec4_msl, entry = lab_n64vec4_msl_entry,
-                       fastmath = lab_n64vec4_msl_fastmath, bm = 32, bn = 64),
+                       fastmath = lab_n64vec4_msl_fastmath, bm = 32, bn = 64, tgmem = lab_n64vec4_msl_tgmem),
             LabVariant(name = "v12_m64vec4", src = lab_m64vec4_msl, entry = lab_m64vec4_msl_entry,
-                       fastmath = lab_m64vec4_msl_fastmath, bm = 64, bn = 32),
+                       fastmath = lab_m64vec4_msl_fastmath, bm = 64, bn = 32, tgmem = lab_m64vec4_msl_tgmem),
             LabVariant(name = "v13_6464vec4", src = lab_6464vec4_msl, entry = lab_6464vec4_msl_entry,
-                       fastmath = lab_6464vec4_msl_fastmath, bm = 64, bn = 64),
+                       fastmath = lab_6464vec4_msl_fastmath, bm = 64, bn = 64, tgmem = lab_6464vec4_msl_tgmem),
+            LabVariant(name = "v18_6464run32", src = lab_6464run32_msl, entry = lab_6464run32_msl_entry,
+                       fastmath = lab_6464run32_msl_fastmath, bm = 64, bn = 64, tgmem = lab_6464run32_msl_tgmem),
+            LabVariant(name = "v19_6464trans", src = lab_6464trans_msl, entry = lab_6464trans_msl_entry,
+                       fastmath = lab_6464trans_msl_fastmath, bm = 64, bn = 64, tgmem = lab_6464trans_msl_tgmem),
+            LabVariant(name = "v20_6464devb", src = lab_6464devb_msl, entry = lab_6464devb_msl_entry,
+                       fastmath = lab_6464devb_msl_fastmath, bm = 64, bn = 64, f16w = true, tgmem = lab_6464devb_msl_tgmem),
             LabVariant(name = "v15_6464x256", src = lab_6464x256_msl, entry = lab_6464x256_msl_entry,
-                       fastmath = lab_6464x256_msl_fastmath, bm = 64, bn = 64, threads = 256),
+                       fastmath = lab_6464x256_msl_fastmath, bm = 64, bn = 64, threads = 256, tgmem = lab_6464x256_msl_tgmem),
             LabVariant(name = "v16_6464pf", src = lab_6464pf_msl, entry = lab_6464pf_msl_entry,
-                       fastmath = lab_6464pf_msl_fastmath, bm = 64, bn = 64),
+                       fastmath = lab_6464pf_msl_fastmath, bm = 64, bn = 64, tgmem = lab_6464pf_msl_tgmem),
             LabVariant(name = "vk_nostage", src = lab_nostage_msl, entry = lab_nostage_msl_entry,
-                       fastmath = lab_nostage_msl_fastmath, bm = 32, bn = 32, check = false),
+                       fastmath = lab_nostage_msl_fastmath, bm = 32, bn = 32, check = false, tgmem = lab_nostage_msl_tgmem),
+            LabVariant(name = "vk21_nostage", src = lab_ggmlgeons_msl, entry = lab_ggmlgeons_msl_entry,
+                       fastmath = lab_ggmlgeons_msl_fastmath, bm = 32, bn = 64, grid2d = true, check = false, tgmem = lab_ggmlgeons_msl_tgmem),
+            LabVariant(name = "vk21_aonly", src = lab_ggmlgeoa_msl, entry = lab_ggmlgeoa_msl_entry,
+                       fastmath = lab_ggmlgeoa_msl_fastmath, bm = 32, bn = 64, grid2d = true, check = false, tgmem = lab_ggmlgeoa_msl_tgmem),
+            LabVariant(name = "vk21_noscale", src = lab_ggmlgeonosc_msl, entry = lab_ggmlgeonosc_msl_entry,
+                       fastmath = lab_ggmlgeonosc_msl_fastmath, bm = 32, bn = 64, grid2d = true, check = false, tgmem = lab_ggmlgeonosc_msl_tgmem),
+            LabVariant(name = "vk21_bonly", src = lab_ggmlgeob_msl, entry = lab_ggmlgeob_msl_entry,
+                       fastmath = lab_ggmlgeob_msl_fastmath, bm = 32, bn = 64, grid2d = true, check = false, tgmem = lab_ggmlgeob_msl_tgmem),
             LabVariant(name = "vk_6464nostage", src = lab_6464nostage_msl, entry = lab_6464nostage_msl_entry,
-                       fastmath = lab_6464nostage_msl_fastmath, bm = 64, bn = 64, check = false),
+                       fastmath = lab_6464nostage_msl_fastmath, bm = 64, bn = 64, check = false, tgmem = lab_6464nostage_msl_tgmem),
             LabVariant(name = "vk_nomath", src = lab_nomath_msl, entry = lab_nomath_msl_entry,
-                       fastmath = lab_nomath_msl_fastmath, bm = 32, bn = 32, check = false)
+                       fastmath = lab_nomath_msl_fastmath, bm = 32, bn = 32, check = false, tgmem = lab_nomath_msl_tgmem)
         ]
         run_lab(b, variants)
         delete variants

--- a/modules/dasLLAMA/benchmarks/matmul/occupancy_report.das
+++ b/modules/dasLLAMA/benchmarks/matmul/occupancy_report.das
@@ -1,0 +1,51 @@
+options gen2
+options persistent_heap
+
+// Per-kernel occupancy report over every production Metal kernel: maxTotalThreadsPerThreadgroup
+// is the register-pressure oracle — a reg-limited PSO reports < 1024 and runs fewer resident
+// simdgroups (the Phase-7 GEMM chase root cause). Run after ANY kernel change:
+//   bin/daslang modules/dasLLAMA/benchmarks/matmul/occupancy_report.das
+// Known tiers: q8_gemm64 = 704 (16 accumulators = 32 regs/lane of C — the 64x64 geometry's
+// floor); attn_qk/av_mm = 896 (f32 source values live across the staging barrier).
+require metal/das_metal_boost
+require dasllama/dasllama_metal_prefill
+require dasllama/dasllama_math_metal
+require strings
+
+def check(dev; name, src, entry : string; fastmath : bool) {
+    var err : string
+    var pso = pipeline_from_source(dev, src, entry, fastmath, err)
+    if (pso == null) {
+        print("{name}: COMPILE FAIL {err}\n")
+        return
+    }
+    let mt = int(metal_pipeline_max_total_threads(pso))
+    print("{name}: max_threads={mt}{mt < 1024 ? "  <-- REG-LIMITED" : ""}\n")
+    metal_release(pso)
+}
+
+[export]
+def main {
+    with_metal_device() $(dev : MetalDevice?) {
+        if (dev == null) {
+            return
+        }
+        check(dev, "q8_mulmm (prod GEMM)", metal_q8_mulmm_msl, metal_q8_mulmm_msl_entry, metal_q8_mulmm_msl_fastmath)
+        check(dev, "q8_gemm 32x32", metal_q8_gemm_msl, metal_q8_gemm_msl_entry, metal_q8_gemm_msl_fastmath)
+        check(dev, "q8_gemm64 64x64", metal_q8_gemm64_msl, metal_q8_gemm64_msl_entry, metal_q8_gemm64_msl_fastmath)
+        check(dev, "attn_qk_mm", metal_attn_qk_mm_msl, metal_attn_qk_mm_msl_entry, metal_attn_qk_mm_msl_fastmath)
+        check(dev, "attn_av_mm", metal_attn_av_mm_msl, metal_attn_av_mm_msl_entry, metal_attn_av_mm_msl_fastmath)
+        check(dev, "attn_qk (classic)", metal_attn_qk_msl, metal_attn_qk_msl_entry, metal_attn_qk_msl_fastmath)
+        check(dev, "attn_av (classic)", metal_attn_av_msl, metal_attn_av_msl_entry, metal_attn_av_msl_fastmath)
+        check(dev, "attn_softmax", metal_attn_softmax_msl, metal_attn_softmax_msl_entry, metal_attn_softmax_msl_fastmath)
+        check(dev, "rmsnorm", metal_rmsnorm_msl, metal_rmsnorm_msl_entry, metal_rmsnorm_msl_fastmath)
+        check(dev, "add_rms_quant", metal_add_rms_quant_msl, metal_add_rms_quant_msl_entry, metal_add_rms_quant_msl_fastmath)
+        check(dev, "swiglu_quant", metal_swiglu_quant_msl, metal_swiglu_quant_msl_entry, metal_swiglu_quant_msl_fastmath)
+        check(dev, "rope_qk", metal_rope_qk_msl, metal_rope_qk_msl_entry, metal_rope_qk_msl_fastmath)
+        check(dev, "quant", metal_q8_quant_msl, metal_q8_quant_msl_entry, metal_q8_quant_msl_fastmath)
+        check(dev, "gemv (logits)", metal_q8_gemv_msl, metal_q8_gemv_msl_entry, metal_q8_gemv_msl_fastmath)
+        check(dev, "swiglu", metal_swiglu_msl, metal_swiglu_msl_entry, metal_swiglu_msl_fastmath)
+        check(dev, "add", metal_add_msl, metal_add_msl_entry, metal_add_msl_fastmath)
+        check(dev, "rope", metal_rope_msl, metal_rope_msl_entry, metal_rope_msl_fastmath)
+    }
+}

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -204,7 +204,8 @@ typedef FfnPrefillFn  = function<(t : Model; var s : Session; l : int64; npos : 
 //! A whole-prefill override (e.g. the dasMetal GPU-resident path): claims the ENTIRE per-layer
 //! stack of one prefill — rope tables are already built, x_b holds the embedded rows; on true the
 //! KV cache is filled for every position and x_b holds the final residual stream (the final norm +
-//! classifier stay with the caller). false = declined (unsupported shape/config) — the caller runs
+//! classifier stay with the caller UNLESS the override calls prefill_override_logits_done after
+//! filling s.logits itself). false = declined (unsupported shape/config) — the caller runs
 //! the ordinary per-layer CPU loop. Same pin discipline as the batch-slot donors: registered by
 //! name at [init], activated only via select_prefill_override (env rail: DASLLAMA_PIN_PREFILL).
 typedef PrefillOverrideFn = function<(t : Model; var s : Session; npos : int64; start_pos : int64) : bool>
@@ -236,6 +237,16 @@ def select_prefill_override(name : string) : bool {
 
 def active_prefill_override : string {
     return g_prefill_override_name
+}
+
+// set by an override that ALSO produced the last position's logits; reset before every invocation
+var private g_prefill_logits_done = false
+
+//! A whole-prefill override that computed s.logits for the LAST position itself (final norm +
+//! classifier on its device, softcap/suppression semantics preserved or declined) calls this
+//! from inside its forward — forward_prefill_body then skips the CPU final-norm/classifier step.
+def prefill_override_logits_done {
+    g_prefill_logits_done = true
 }
 
 //! The copyable hot-path block pointers, resolved onto the Model at load and called per layer.
@@ -8644,8 +8655,10 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
         }
         return
     }
+    let ts_alloc = ref_time_ticks()
     kv_ensure(s, start_pos + npos)   // paged sessions: grow the block table BEFORE any cache-pointer hoist
     forward_prefill_alloc(t, s, npos, start_pos)
+    prof_add("alloc", ts_alloc)
 
     // token embeddings -> residual stream x_b [npos x dim]
     let dim = c.dim
@@ -8780,6 +8793,16 @@ def embed_(m : Model; text : string) : array<float> {
 }
 
 // batched-prefill scratch sizing, shared by the token and embedding entries
+// grow-only, contents-DISCARDING, no-init scratch sizing: the batched scratch is stage output —
+// old bytes are garbage, new bytes are fully written before any read. `delete` on grow skips
+// both the realloc's old-block copy and the zero-fill (together ~5ms on a first 512-row prefill).
+def private scratch_resize(var a : array<auto(numT)>; need : int64) {
+    if (int64(length(a)) < need) {
+        delete a
+    }
+    a |> resize_no_init(need)
+}
+
 def private forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : int64) {
     let c = t.config
     let dim = c.dim
@@ -8790,17 +8813,20 @@ def private forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : 
     let qd = n_heads * head_size       // query / attention-output width (== dim except Gemma2/gemma4)
     let xdim = max(dim, qd)            // xb_b holds the norm output (dim) then the attn output (qd)
     let maxn = max(xdim, hidden)
-    // size the batched scratch to this prompt
-    s.x_b |> resize(npos * dim)
-    s.xb_b |> resize(npos * xdim)
-    s.xb2_b |> resize(npos * dim)
-    s.q_b |> resize(npos * qd)
-    s.k_b |> resize(npos * kv_dim)
-    s.v_b |> resize(npos * kv_dim)
-    s.hb_b |> resize(npos * hidden)
-    s.hb2_b |> resize(npos * hidden)
-    s.xqb |> resize(npos * maxn)
-    s.xsb |> resize(npos * maxn / 32l)
+    // size the batched scratch to this prompt — no-init: every array here is stage output,
+    // fully written before the next stage reads it (embed fills x_b; each block writes its
+    // whole [npos x width] result), so the grow-time zero-fill was ~5ms of pure waste on a
+    // first 512-row prefill (~70 MB of scratch)
+    s.x_b |> scratch_resize(npos * dim)
+    s.xb_b |> scratch_resize(npos * xdim)
+    s.xb2_b |> scratch_resize(npos * dim)
+    s.q_b |> scratch_resize(npos * qd)
+    s.k_b |> scratch_resize(npos * kv_dim)
+    s.v_b |> scratch_resize(npos * kv_dim)
+    s.hb_b |> scratch_resize(npos * hidden)
+    s.hb2_b |> scratch_resize(npos * hidden)
+    s.xqb |> scratch_resize(npos * maxn)
+    s.xsb |> scratch_resize(npos * maxn / 32l)
     if (t.kquant_native) {   // kq batch tile: per-16 sums beside the batch quants
         s.xbsb |> resize(npos * maxn / 16l)
     }
@@ -8874,6 +8900,7 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     // block. An active whole-prefill override (select_prefill_override) may claim the entire stack;
     // it returns false to decline (unsupported shape/config), which falls back to the CPU loop.
     var stack_done = false
+    g_prefill_logits_done = false
     if (!empty(g_prefill_override_name)) {
         stack_done = invoke(g_prefill_override, t, s, npos, start_pos)
     }
@@ -8888,6 +8915,7 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     }
 
     // final rmsnorm + classifier on the LAST position only (that's what we sample next)
+    return if (stack_done && g_prefill_logits_done)   // the override already produced s.logits
     let ts_final = ref_time_ticks()
     let last = npos - 1l
     rms_at(s.xb, t, t.rms_final_off, s.x_b, last * dim, dim)

--- a/modules/dasLLAMA/dasllama/dasllama_math_metal.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_metal.das
@@ -144,22 +144,7 @@ class MetalQ8Gemm64 {
         let nBase = (gl_WorkGroupID.x % ntileN) * 64u
         let qm = (sg / 2u) * 32u            // this simdgroup's 32x32 quadrant of the C block
         let qn = (sg % 2u) * 32u
-        var c00 : simdgroup_float8x8
-        var c01 : simdgroup_float8x8
-        var c02 : simdgroup_float8x8
-        var c03 : simdgroup_float8x8
-        var c10 : simdgroup_float8x8
-        var c11 : simdgroup_float8x8
-        var c12 : simdgroup_float8x8
-        var c13 : simdgroup_float8x8
-        var c20 : simdgroup_float8x8
-        var c21 : simdgroup_float8x8
-        var c22 : simdgroup_float8x8
-        var c23 : simdgroup_float8x8
-        var c30 : simdgroup_float8x8
-        var c31 : simdgroup_float8x8
-        var c32 : simdgroup_float8x8
-        var c33 : simdgroup_float8x8
+        var mc : simdgroup_float8x8[16]     // 4x4 tile quadrant
         let kdim4 = kdim / 4u
         let ra = lid / 2u                   // one A run and one B run per thread
         let c0a = (lid % 2u) * 16u
@@ -195,63 +180,33 @@ class MetalQ8Gemm64 {
                 }
             }
             barrier()
-            var k8 = 0u
-            while (k8 < 32u) {
-                var a0 : simdgroup_half8x8
-                var a1 : simdgroup_half8x8
-                var a2 : simdgroup_half8x8
-                var a3 : simdgroup_half8x8
-                var b0 : simdgroup_half8x8
-                var b1 : simdgroup_half8x8
-                var b2 : simdgroup_half8x8
-                var b3 : simdgroup_half8x8
-                simdgroup_load(a0, ta, qm * 32u + k8, 32u)
-                simdgroup_load(a1, ta, (qm + 8u) * 32u + k8, 32u)
-                simdgroup_load(a2, ta, (qm + 16u) * 32u + k8, 32u)
-                simdgroup_load(a3, ta, (qm + 24u) * 32u + k8, 32u)
-                simdgroup_load(b0, tb, k8 * 64u + qn, 64u)
-                simdgroup_load(b1, tb, k8 * 64u + (qn + 8u), 64u)
-                simdgroup_load(b2, tb, k8 * 64u + (qn + 16u), 64u)
-                simdgroup_load(b3, tb, k8 * 64u + (qn + 24u), 64u)
-                simdgroup_multiply_accumulate(c00, a0, b0, c00)
-                simdgroup_multiply_accumulate(c01, a0, b1, c01)
-                simdgroup_multiply_accumulate(c02, a0, b2, c02)
-                simdgroup_multiply_accumulate(c03, a0, b3, c03)
-                simdgroup_multiply_accumulate(c10, a1, b0, c10)
-                simdgroup_multiply_accumulate(c11, a1, b1, c11)
-                simdgroup_multiply_accumulate(c12, a1, b2, c12)
-                simdgroup_multiply_accumulate(c13, a1, b3, c13)
-                simdgroup_multiply_accumulate(c20, a2, b0, c20)
-                simdgroup_multiply_accumulate(c21, a2, b1, c21)
-                simdgroup_multiply_accumulate(c22, a2, b2, c22)
-                simdgroup_multiply_accumulate(c23, a2, b3, c23)
-                simdgroup_multiply_accumulate(c30, a3, b0, c30)
-                simdgroup_multiply_accumulate(c31, a3, b1, c31)
-                simdgroup_multiply_accumulate(c32, a3, b2, c32)
-                simdgroup_multiply_accumulate(c33, a3, b3, c33)
-                k8 += 8u
+            // math ROLLED over matrix arrays + das-pointer tile bumps (hand-unrolled
+            // spelling measured max_threads 704 — an occupancy tier down)
+            var ma : simdgroup_half8x8[4]
+            var mb : simdgroup_half8x8[4]
+            var acur = unsafe(addr(ta[qm * 32u]))
+            var bcur = unsafe(addr(tb[qn]))
+            for [unroll_full] (_k8 in range(4)) {
+                for [unroll_full] (i in range(4)) {
+                    simdgroup_load(ma[i], acur, uint(i) * 256u, 32u)
+                }
+                for [unroll_full] (i in range(4)) {
+                    simdgroup_load(mb[i], bcur, uint(i) * 8u, 64u)
+                }
+                for [unroll_full] (i in range(16)) {
+                    simdgroup_multiply_accumulate(mc[i], ma[i / 4], mb[i % 4], mc[i])
+                }
+                acur = unsafe(acur + 8)
+                bcur = unsafe(bcur + 512)
             }
             barrier()
             kb++
         }
         let row0 = mBase + qm
         let col0 = nBase + qn
-        simdgroup_store(c00, y, row0 * ndim + col0, ndim)
-        simdgroup_store(c01, y, row0 * ndim + (col0 + 8u), ndim)
-        simdgroup_store(c02, y, row0 * ndim + (col0 + 16u), ndim)
-        simdgroup_store(c03, y, row0 * ndim + (col0 + 24u), ndim)
-        simdgroup_store(c10, y, (row0 + 8u) * ndim + col0, ndim)
-        simdgroup_store(c11, y, (row0 + 8u) * ndim + (col0 + 8u), ndim)
-        simdgroup_store(c12, y, (row0 + 8u) * ndim + (col0 + 16u), ndim)
-        simdgroup_store(c13, y, (row0 + 8u) * ndim + (col0 + 24u), ndim)
-        simdgroup_store(c20, y, (row0 + 16u) * ndim + col0, ndim)
-        simdgroup_store(c21, y, (row0 + 16u) * ndim + (col0 + 8u), ndim)
-        simdgroup_store(c22, y, (row0 + 16u) * ndim + (col0 + 16u), ndim)
-        simdgroup_store(c23, y, (row0 + 16u) * ndim + (col0 + 24u), ndim)
-        simdgroup_store(c30, y, (row0 + 24u) * ndim + col0, ndim)
-        simdgroup_store(c31, y, (row0 + 24u) * ndim + (col0 + 8u), ndim)
-        simdgroup_store(c32, y, (row0 + 24u) * ndim + (col0 + 16u), ndim)
-        simdgroup_store(c33, y, (row0 + 24u) * ndim + (col0 + 24u), ndim)
+        for [unroll_full] (i in range(16)) {
+            simdgroup_store(mc[i], y, (row0 + uint(i / 4) * 8u) * ndim + col0 + uint(i % 4) * 8u, ndim)
+        }
     }
 }
 
@@ -419,6 +374,8 @@ def metal_q8q8_batch(var yp : float?; wp : int8 const?; sp : float const?; xqp :
     let groups = uint(use64 ? (mp / 64l) * (d / 64l) : (mp / 32l) * (d / 32l))
     let ran = with_compute_encoder(g_queue, err) $(enc : MetalComputeEncoder?) {
         metal_set_pipeline(enc, use64 ? g_pso64 : g_pso)
+        metal_set_threadgroup_memory_length(enc, use64 ? metal_q8_gemm64_msl_tgmem : metal_q8_gemm_msl_tgmem, 0)
+        metal_set_threadgroup_memory_length(enc, use64 ? metal_q8_gemm64_msl_tgmem : metal_q8_gemm_msl_tgmem, 0)
         metal_set_buffer(enc, wbuf, 0ul, 0)
         metal_set_buffer(enc, sbuf, 0ul, 1)
         metal_set_buffer(enc, xqbuf, 0ul, 2)

--- a/modules/dasLLAMA/dasllama/dasllama_math_metal.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_metal.das
@@ -375,7 +375,6 @@ def metal_q8q8_batch(var yp : float?; wp : int8 const?; sp : float const?; xqp :
     let ran = with_compute_encoder(g_queue, err) $(enc : MetalComputeEncoder?) {
         metal_set_pipeline(enc, use64 ? g_pso64 : g_pso)
         metal_set_threadgroup_memory_length(enc, use64 ? metal_q8_gemm64_msl_tgmem : metal_q8_gemm_msl_tgmem, 0)
-        metal_set_threadgroup_memory_length(enc, use64 ? metal_q8_gemm64_msl_tgmem : metal_q8_gemm_msl_tgmem, 0)
         metal_set_buffer(enc, wbuf, 0ul, 0)
         metal_set_buffer(enc, sbuf, 0ul, 1)
         metal_set_buffer(enc, xqbuf, 0ul, 2)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -1262,6 +1262,7 @@ def private prefill_supported(t : Model; s : Session; npos, start_pos : int64) :
 def private enc_gemm(enc : MetalComputeEncoder?; bwq, bws, bxq, bxs, by, bkdim, bndim : MetalBuffer?; mp, d : int64) {
     let use64 = gemm_use64(mp, d)
     metal_set_pipeline(enc, use64 ? g_pso_gemm64 : g_pso_gemm)
+    metal_set_threadgroup_memory_length(enc, use64 ? metal_q8_gemm64_msl_tgmem : metal_q8_gemm_msl_tgmem, 0)
     metal_set_buffer(enc, bwq, 0ul, 0)
     metal_set_buffer(enc, bws, 0ul, 1)
     metal_set_buffer(enc, bxq, 0ul, 2)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -3,6 +3,7 @@ options gen2
 module dasllama_metal_prefill shared public
 
 require math
+require strings
 require daslib/fio
 require metal/msl_shader
 require metal/das_metal_boost
@@ -111,6 +112,155 @@ class MetalRmsNorm {
     }
 }
 
+// The production GEMM: 64-output x 32-token C tiles (4 simdgroups, one 16x32 quadrant each,
+// 8 accumulators), W as interleaved 34B q8 blocks (GGUF q8_0's own layout: f16 scale + 32
+// int8 — the scale rides the quants' cacheline), raw f32 activations. Rolled [unroll_full]
+// math over simdgroup-matrix arrays + das-pointer streams: the shapes the ISA rail proved out
+// (static-array/unrolled spellings cost an occupancy tier). Requires out-dim % 64, M padded
+// to 64. Beats the hand-written llama.cpp equivalent 2-3% on M1 Max (see benchmarks/matmul).
+class MetalQ8MulMm {
+    @ssbo @binding = 0 wsh : array<float16> // 34B-block W blob, HALF-SCALE view: scale of block b at 17*b
+    @ssbo @binding = 1 wqb : array<int8>    // the SAME blob buffer, BYTE view: quants of block b at 34*b + 2
+    @ssbo @binding = 2 xf : array<float4>   // raw f32 activations, float4 view
+    @ssbo @binding = 3 y : array<float>
+    @uniform @binding = 4 kdim : uint
+    @uniform @binding = 5 ndim : uint
+    @workgroup ta : float16[2048]           // W: 4 k-tiles x 8 row-tiles of 8x8, each tile (k row, wrow col)
+    @workgroup tb : float16[1024]           // X: 4 k-tiles x 4 token-tiles of 8x8, each tile (token row, k col)
+
+    [metal_kernel(name="metal_q8_mulmm_msl")]
+    def metal_q8_mulmm {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows — FAST axis: concurrent tgs share the W panel (ggml rasterization)
+        let nBase = gl_WorkGroupID.y * 64u  // output (weight) rows
+        var mc : simdgroup_float8x8[8]      // per-simdgroup C quadrant: 2 token-tiles x 4 output-tiles
+        var ma : simdgroup_half8x8[4]
+        var mb : simdgroup_half8x8[2]
+        var va : float16[16]                // dequantized A staging regs (this thread's block half)
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        // A split: each thread stages 16 weight elems — row lr0, k half il0
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA         // k-tile il0*2 (lanes at stride 8; +512 = next k-tile)
+        // B split: each thread stages 8 activation elems — token lr1, k offset iy
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u           // this simdgroup's A quadrant: 4 row-tiles of 64
+        let bB = (sg / 2u) * 128u           // this simdgroup's B quadrant: 2 token-tiles of 64
+        // device streams walk as REAL das pointers (unsafe(addr()) + bump at the loop tail):
+        // pointer-vs-index register-allocates differently on AGX and the winner is
+        // shape-dependent — both spellings stay writable in plain das; this kernel measured
+        // pointer (llama.cpp's loop reads its scale straight off a carried pointer)
+        let blk0 = (nBase + lr0) * nkb
+        var scur = unsafe(addr(wsh[blk0 * 17u]))                    // half scale rides the quants' cacheline
+        var qp = unsafe(addr(wqb[blk0 * 34u + 2u + il0 * 16u]))
+        var xcur = unsafe(addr(xf[(mBase + lr1) * kdim4 + iy / 4u]))
+        var kb = 0u
+        while (kb < nkb) {
+            // device reads + dequant first — they fly while the previous math loop drains
+            let sA = float(unsafe(scur[0]))
+            let b0 = unsafe(xcur[0])
+            let b1 = unsafe(xcur[1])
+            for [unroll_full] (i in range(16)) {
+                va[i] = float16(float(unsafe(qp[i])) * sA)
+            }
+            barrier()                       // previous math done reading the tiles
+            for [unroll_full] (i in range(16)) {
+                ta[tA0 + uint(i / 8) * 512u + uint(i % 8) * 8u] = va[i]
+            }
+            tg_store_half4(tb, ibB, b0)     // no dequant on B — pure convert-and-store
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            // math ROLLED: the pragma'd loops reach the backend intact — 4 k-slabs x
+            // (6 tile loads + 8 macs); tile POINTERS bump at the slab tail (index form
+            // measured max_threads 896 and -10% — the backend precomputes every address)
+            var acur = unsafe(addr(ta[aB]))
+            var bcur = unsafe(addr(tb[bB]))
+            for [unroll_full] (_ik in range(4)) {
+                for [unroll_full] (i in range(4)) {
+                    simdgroup_load(ma[i], acur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(2)) {
+                    simdgroup_load(mb[i], bcur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(8)) {
+                    simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i])
+                }
+                acur = unsafe(acur + 512)
+                bcur = unsafe(bcur + 256)
+            }
+            scur = unsafe(scur + 17)
+            qp = unsafe(qp + 34)
+            xcur = unsafe(xcur + 8)
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = outputs
+        for [unroll_full] (i in range(8)) {
+            simdgroup_store(mc[i], y, (row0 + uint(i / 4) * 8u) * ndim + col0 + uint(i % 4) * 8u, ndim)
+        }
+    }
+}
+
+// One simdgroup per output row: the classifier GEMV — a dim-long Q8 row dot one f32 vector
+// (the final-normed last position). Bandwidth-bound on the [vocab x dim] weight stream; x stays
+// cache-resident across rows. Lanes stride byte4s within the row; each byte4's int dot rides its
+// block's scale (exact under the unit tests' pow2-scale fills). 128 threads = 4 rows per group.
+class MetalQ8Gemv {
+    @ssbo @binding = 0 wq : array<byte4>    // [d x n] Q8 rows, byte4 view
+    @ssbo @binding = 1 ws : array<float>    // [d x n/32] scales
+    @ssbo @binding = 2 x : array<float4>    // [n] f32 vector, float4 view
+    @ssbo @binding = 3 y : array<float>     // [d] logits
+    @uniform @binding = 4 ndim : uint       // n (reduction dim, % 32)
+    @uniform @binding = 5 ddim : uint       // d (output rows)
+
+    [metal_kernel(name="metal_q8_gemv_msl")]
+    def metal_q8_gemv {
+        let row = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
+        if (row >= ddim) {
+            return
+        }
+        let lane = gl_SubgroupInvocationID
+        let nb4 = ndim / 4u
+        let wbase = row * nb4
+        let sbase = row * (ndim / 32u)
+        var acc = 0.0
+        var k = lane
+        // 4 blocks-in-flight per iteration (128 byte4s per simdgroup step) — amortizes the
+        // loop overhead on the bandwidth-bound weight stream; the plain loop drains the tail
+        while (k + 96u < nb4) {
+            let wa = float4(int4(wq[wbase + k]))
+            let xa = x[k]
+            let wb = float4(int4(wq[wbase + (k + 32u)]))
+            let xb = x[k + 32u]
+            let wc = float4(int4(wq[wbase + (k + 64u)]))
+            let xc = x[k + 64u]
+            let wd = float4(int4(wq[wbase + (k + 96u)]))
+            let xd = x[k + 96u]
+            acc += (wa.x * xa.x + wa.y * xa.y + wa.z * xa.z + wa.w * xa.w) * ws[sbase + k / 8u]
+            acc += (wb.x * xb.x + wb.y * xb.y + wb.z * xb.z + wb.w * xb.w) * ws[sbase + (k + 32u) / 8u]
+            acc += (wc.x * xc.x + wc.y * xc.y + wc.z * xc.z + wc.w * xc.w) * ws[sbase + (k + 64u) / 8u]
+            acc += (wd.x * xd.x + wd.y * xd.y + wd.z * xd.z + wd.w * xd.w) * ws[sbase + (k + 96u) / 8u]
+            k += 128u
+        }
+        while (k < nb4) {
+            let w4 = float4(int4(wq[wbase + k]))
+            let x4 = x[k]
+            acc += (w4.x * x4.x + w4.y * x4.y + w4.z * x4.z + w4.w * x4.w) * ws[sbase + k / 8u]
+            k += gl_SubgroupSize
+        }
+        acc = simd_sum(acc)
+        if (lane == 0u) {
+            y[row] = acc
+        }
+    }
+}
+
 // One thread per rotation pair, NORM layout (adjacent elements 2j, 2j+1 within each head):
 // v0*c - v1*s / v0*s + v1*c with this position's precomputed table row — rope_scaled_tab exactly.
 // One kernel serves q (n = qd) and k (n = kv_dim) as two dispatches.
@@ -144,6 +294,167 @@ class MetalRope {
     }
 }
 
+// The dispatch-fusion set (the 21 -> 15 dispatches/layer collapse — ew cost on M1 is launch
+// gaps, not bandwidth):
+//   metal_add_rms_quant  ~ add_inplace? + rmsnorm + quantize_q8_0 in ONE pass — the summed row
+//                          is staged in threadgroup memory (device writeback for the residual
+//                          stream happens alongside), so the normalized values never round-trip
+//                          device memory and the standalone add dispatch disappears. One
+//                          threadgroup per row; dim <= 3072 (the tg stage) gates the fused path.
+//   metal_swiglu_quant   ~ swiglu + quantize_q8_0 per 32-block, silu recomputed on the quant
+//                          pass instead of buffered — the gated activation is dead after the
+//                          quant, so it is never written back at all.
+//   metal_rope_qk        ~ both rope dispatches in one grid (q pairs first, then k).
+class MetalAddRmsQuant {
+    @ssbo @binding = 0 x : array<float>     // [nrows x dim] residual stream, updated in place
+    @ssbo @binding = 1 r : array<float>     // [nrows x dim] delta to fold in (addv != 0)
+    @ssbo @binding = 2 w : array<float>     // [dim] rms weight
+    @ssbo @binding = 3 xq : array<int8>     // [mp x dim] quants out
+    @ssbo @binding = 4 xs : array<float>    // [mp x dim/32] scales out
+    @uniform @binding = 5 dim : uint
+    @uniform @binding = 6 eps : float
+    @uniform @binding = 7 addv : uint       // 0 = plain rms+quant (layer 0 / no pending add)
+    @workgroup xrow : float[3072]           // the summed row (pre-norm) — llama-1B/3B dims fit
+    @workgroup partial : float[8]
+    @workgroup inv_sh : float
+
+    [metal_kernel(name="metal_add_rms_quant_msl")]
+    def metal_add_rms_quant {
+        let row = gl_WorkGroupID.x
+        let lid = gl_LocalInvocationID.x
+        var ss = 0.0
+        var k = lid
+        while (k < dim) {
+            var xv = x[row * dim + k]
+            if (addv != 0u) {
+                xv += r[row * dim + k]
+                x[row * dim + k] = xv          // the residual stream keeps the sum
+            }
+            xrow[k] = xv
+            ss += xv * xv
+            k += gl_WorkGroupSize.x
+        }
+        ss = simd_sum(ss)
+        if (gl_SubgroupInvocationID == 0u) {
+            partial[gl_SubgroupID] = ss
+        }
+        barrier()
+        if (lid == 0u) {
+            var tot = 0.0
+            var sgi = 0u
+            while (sgi < gl_NumSubgroups) {
+                tot += partial[sgi]
+                sgi++
+            }
+            inv_sh = rsqrt(tot / float(dim) + eps)
+        }
+        barrier()
+        let inv = inv_sh
+        let nb = dim / 32u
+        var cb = lid
+        while (cb < nb) {
+            let base = cb * 32u
+            var amax = 0.0
+            var e = 0u
+            while (e < 32u) {
+                amax = max(amax, abs(w[base + e] * (xrow[base + e] * inv)))
+                e++
+            }
+            let d = amax / 127.0
+            let id = d != 0.0 ? 1.0 / d : 0.0
+            xs[row * nb + cb] = d
+            e = 0u
+            while (e < 32u) {
+                xq[row * dim + base + e] = int8(round(w[base + e] * (xrow[base + e] * inv) * id))
+                e++
+            }
+            cb += gl_WorkGroupSize.x
+        }
+    }
+}
+
+class MetalSwigluQuant {
+    @ssbo @binding = 0 g : array<float>     // [ntok x hidden] W1 gate (read-only — dead after)
+    @ssbo @binding = 1 u : array<float>     // [ntok x hidden] W3 up
+    @ssbo @binding = 2 xq : array<int8>     // [mp x hidden] quants out
+    @ssbo @binding = 3 xs : array<float>    // [mp x hidden/32] scales out
+    @uniform @binding = 4 n : uint          // hidden, % 32
+    @uniform @binding = 5 nblk : uint       // ntok * hidden/32 — grid guard
+
+    [metal_kernel(name="metal_swiglu_quant_msl")]
+    def metal_swiglu_quant {
+        let gid = gl_GlobalInvocationID.x
+        if (gid >= nblk) {
+            return
+        }
+        let nb = n / 32u
+        let row = gid / nb
+        let cb = gid % nb
+        let base = row * n + cb * 32u
+        var amax = 0.0
+        var k = 0u
+        while (k < 32u) {
+            let gv = g[base + k]
+            let sv = (gv / (1.0 + exp(-gv))) * u[base + k]
+            amax = max(amax, abs(sv))
+            k++
+        }
+        let d = amax / 127.0
+        let id = d != 0.0 ? 1.0 / d : 0.0
+        xs[row * nb + cb] = d
+        k = 0u
+        while (k < 32u) {
+            let gv = g[base + k]
+            let sv = (gv / (1.0 + exp(-gv))) * u[base + k]
+            xq[base + k] = int8(round(sv * id))
+            k++
+        }
+    }
+}
+
+class MetalRopeQK {
+    @ssbo @binding = 0 q : array<float>     // [ntok x qd], roped in place
+    @ssbo @binding = 1 k : array<float>     // [ntok x kv_dim], roped in place
+    @ssbo @binding = 2 tcos : array<float>  // [ntok x head_size/2]
+    @ssbo @binding = 3 tsin : array<float>
+    @uniform @binding = 4 qd : uint
+    @uniform @binding = 5 kvd : uint
+    @uniform @binding = 6 head_size : uint
+    @uniform @binding = 7 npairs_q : uint   // ntok * qd/2 — the q half of the grid
+    @uniform @binding = 8 npairs : uint     // + ntok * kv_dim/2 — grid guard
+
+    [metal_kernel(name="metal_rope_qk_msl")]
+    def metal_rope_qk {
+        let gid = gl_GlobalInvocationID.x
+        if (gid >= npairs) {
+            return
+        }
+        let isK = gid >= npairs_q
+        let n = isK ? kvd : qd
+        let lgid = isK ? gid - npairs_q : gid
+        let pairs_per_row = n / 2u
+        let p = lgid / pairs_per_row
+        let rem = lgid % pairs_per_row
+        let half = head_size / 2u
+        let h = rem / half
+        let j = rem % half
+        let i = p * n + h * head_size + 2u * j
+        let fcr = tcos[p * half + j]
+        let fci = tsin[p * half + j]
+        if (isK) {
+            let v0 = k[i]
+            let v1 = k[i + 1u]
+            k[i] = v0 * fcr - v1 * fci
+            k[i + 1u] = v0 * fci + v1 * fcr
+        } else {
+            let v0 = q[i]
+            let v1 = q[i + 1u]
+            q[i] = v0 * fcr - v1 * fci
+            q[i + 1u] = v0 * fci + v1 * fcr
+        }
+    }
+}
+
 // Attention runs as a tiled-GEMM trio over a per-head score slab PADDED to 32-row blocks
 // (np32 = ceil32(npos) — sgmat stores are whole 8x8 tiles, so the slab must absorb edge tiles):
 //   metal_attn_qk       S = scale * Q_h . K_hT   (32x32 C blocks, mixed... all-f32 sgmat macs)
@@ -155,7 +466,9 @@ class MetalRope {
 // One threadgroup (128 threads = 4 simdgroups) per 32x32 score block (grid: qi-blocks x j-blocks
 // x heads; blocks fully above the causal diagonal exit early — softmax zeroes them). Q staging
 // folds `scale` in; K stages transposed with rows >= npos zeroed (V-GEMM pads can carry NaN and
-// 0*NaN would poison the tile). hs <= 64, % 8 (the 32x64 staging tiles are statically sized).
+// 0*NaN would poison the tile). head_size walks in 64-wide K-SLABS through the statically-sized
+// 32x64 staging tiles (accumulators persist across slabs), so any hs % 8 fits in the same
+// threadgroup footprint — hs 64 (llama-1B) is one slab, 128 (llama-3B) two.
 class MetalAttnQK {
     @ssbo @binding = 0 q : array<float>     // [mp x qd], roped
     @ssbo @binding = 1 k : array<float>     // [mp x kv_dim], roped
@@ -181,38 +494,44 @@ class MetalAttnQK {
         let lid = gl_LocalInvocationID.x
         let sg = gl_SubgroupID
         let kvhoff = (h / kv_mul) * head_size
-        var e = lid
-        while (e < 2048u) {
-            let r = e / 64u
-            let c = e % 64u
-            ta[e] = c < head_size ? q[(qi0 + r) * qd + h * head_size + c] * scale : 0.0
-            let jr = e % 32u
-            let kc = e / 32u
-            tb[e] = (kc < head_size && j0 + jr < npos) ? k[(j0 + jr) * kv_dim + kvhoff + kc] : 0.0
-            e += 128u
-        }
-        barrier()
         let qm = (sg / 2u) * 16u
         let qn = (sg % 2u) * 16u
         var c00 : simdgroup_float8x8
         var c01 : simdgroup_float8x8
         var c10 : simdgroup_float8x8
         var c11 : simdgroup_float8x8
-        var k8 = 0u
-        while (k8 < head_size) {
-            var a0 : simdgroup_float8x8
-            var a1 : simdgroup_float8x8
-            var b0 : simdgroup_float8x8
-            var b1 : simdgroup_float8x8
-            simdgroup_load(a0, ta, qm * 64u + k8, 64u)
-            simdgroup_load(a1, ta, (qm + 8u) * 64u + k8, 64u)
-            simdgroup_load(b0, tb, k8 * 32u + qn, 32u)
-            simdgroup_load(b1, tb, k8 * 32u + (qn + 8u), 32u)
-            simdgroup_multiply_accumulate(c00, a0, b0, c00)
-            simdgroup_multiply_accumulate(c01, a0, b1, c01)
-            simdgroup_multiply_accumulate(c10, a1, b0, c10)
-            simdgroup_multiply_accumulate(c11, a1, b1, c11)
-            k8 += 8u
+        var ks = 0u
+        while (ks < head_size) {
+            let kslab = min(head_size - ks, 64u)
+            var e = lid
+            while (e < 2048u) {
+                let r = e / 64u
+                let c = e % 64u
+                ta[e] = c < kslab ? q[(qi0 + r) * qd + h * head_size + ks + c] * scale : 0.0
+                let jr = e % 32u
+                let kc = e / 32u
+                tb[e] = (kc < kslab && j0 + jr < npos) ? k[(j0 + jr) * kv_dim + kvhoff + ks + kc] : 0.0
+                e += 128u
+            }
+            barrier()
+            var k8 = 0u
+            while (k8 < kslab) {
+                var a0 : simdgroup_float8x8
+                var a1 : simdgroup_float8x8
+                var b0 : simdgroup_float8x8
+                var b1 : simdgroup_float8x8
+                simdgroup_load(a0, ta, qm * 64u + k8, 64u)
+                simdgroup_load(a1, ta, (qm + 8u) * 64u + k8, 64u)
+                simdgroup_load(b0, tb, k8 * 32u + qn, 32u)
+                simdgroup_load(b1, tb, k8 * 32u + (qn + 8u), 32u)
+                simdgroup_multiply_accumulate(c00, a0, b0, c00)
+                simdgroup_multiply_accumulate(c01, a0, b1, c01)
+                simdgroup_multiply_accumulate(c10, a1, b0, c10)
+                simdgroup_multiply_accumulate(c11, a1, b1, c11)
+                k8 += 8u
+            }
+            barrier()
+            ks += 64u
         }
         let row0 = (h * np32 + qi0 + qm) * np32 + (j0 + qn)
         simdgroup_store(c00, att, row0, np32)
@@ -373,6 +692,213 @@ class MetalAttnAV {
     }
 }
 
+// The ggml-geometry attention pair (v21 lessons applied to the trio's QK/AV GEMMs — the old
+// 32x32 scalar-f32-staged kernels ran ~60x below mul_mm rate and owned 24ms of the 3B window):
+// 32x64 C tiles, tile-major 8x8 shared blocks staged as HALF via vectorized float4 loads (the
+// f32_f32 mul_mm instantiation llama.cpp ships stages half from f32 sources too), 2x4 simdgroup
+// quadrants, rolled [unroll_full] math over matrix arrays. Same buffer contract and oracle as the trio; the trio stays
+// as the DASLLAMA_METAL_ATTN=0 rail (and serves hs % 64 != 0 shapes).
+//
+// QK: S[h] = scale * Q_h . K_h^T — C tile 32 queries x 64 keys, k walks head_size in 32-blocks.
+// K stages TRANSPOSED within 8x8 tiles (v21's A pattern; loads stay contiguous along hs);
+// Q stages rows with scale folded (v21's B pattern). Blocks strictly above the causal diagonal
+// exit early (softmax zeroes them); K pad rows need no guard — their scores land in columns
+// j >= npos, which the causal softmax zeroes for every live row.
+class MetalAttnQKMm {
+    @ssbo @binding = 0 q : array<float4>    // [mp x qd/4], roped
+    @ssbo @binding = 1 k : array<float4>    // [mp x kv_dim/4], roped
+    @ssbo @binding = 2 att : array<float>   // [n_heads x np32 x np32] raw scores out
+    @uniform @binding = 3 qd : uint
+    @uniform @binding = 4 kv_dim : uint
+    @uniform @binding = 5 head_size : uint
+    @uniform @binding = 6 kv_mul : uint
+    @uniform @binding = 7 npos : uint
+    @uniform @binding = 8 np32 : uint
+    @uniform @binding = 9 scale : float
+    @workgroup ta : float16[2048]           // K: k-tiles x 8 key-tiles of 8x8, tile (k row, key col)
+    @workgroup tb : float16[1024]           // Q: k-tiles x 4 query-tiles of 8x8 (query row, k col)
+
+    [metal_kernel(name="metal_attn_qk_mm_msl")]
+    def metal_attn_qk_mm {
+        let mBase = gl_WorkGroupID.x * 32u  // query rows
+        let nBase = gl_WorkGroupID.y * 64u  // key rows
+        if (nBase > mBase + 31u) {
+            return                          // fully above the causal diagonal
+        }
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let h = gl_WorkGroupID.z
+        let kvhoff4 = ((h / kv_mul) * head_size) / 4u
+        let qoff4 = (h * head_size) / 4u
+        let qd4 = qd / 4u
+        let kvd4 = kv_dim / 4u
+        var mc : simdgroup_float8x8[8]      // C quadrant: 2 row-tiles x 4 col-tiles
+        let lr0 = lid / 2u                  // A split: key row + 16-k half
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA
+        let lr1 = lid / 4u                  // B split: query row + 8-k run
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u
+        let bB = (sg / 2u) * 128u
+        var ma : simdgroup_half8x8[4]
+        var mb : simdgroup_half8x8[2]
+        var kb = 0u
+        while (kb * 32u < head_size) {
+            let srcA = (nBase + lr0) * kvd4 + kvhoff4 + (kb * 32u + il0 * 16u) / 4u
+            let a0 = k[srcA]
+            let a1 = k[srcA + 1u]
+            let a2 = k[srcA + 2u]
+            let a3 = k[srcA + 3u]
+            let srcB = (mBase + lr1) * qd4 + qoff4 + (kb * 32u + iy) / 4u
+            let b0 = q[srcB] * scale
+            let b1 = q[srcB + 1u] * scale
+            var va : float16[16]
+            va[0] = float16(a0.x)
+            va[1] = float16(a0.y)
+            va[2] = float16(a0.z)
+            va[3] = float16(a0.w)
+            va[4] = float16(a1.x)
+            va[5] = float16(a1.y)
+            va[6] = float16(a1.z)
+            va[7] = float16(a1.w)
+            va[8] = float16(a2.x)
+            va[9] = float16(a2.y)
+            va[10] = float16(a2.z)
+            va[11] = float16(a2.w)
+            va[12] = float16(a3.x)
+            va[13] = float16(a3.y)
+            va[14] = float16(a3.z)
+            va[15] = float16(a3.w)
+            barrier()
+            // K stage as a rolled loop off tA0 (tA1 = tA0 + 512) — 16 hand-written strided
+            // stores hoist 16 tile addresses into loop-lifetime registers
+            for [unroll_full] (i in range(16)) {
+                ta[tA0 + uint(i / 8) * 512u + uint(i % 8) * 8u] = va[i]
+            }
+            tg_store_half4(tb, ibB, b0)
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            // math ROLLED over matrix arrays + das-pointer tile bumps — the hand-unrolled
+            // spelling costs an occupancy tier (this kernel measured max_threads 704)
+            var acur = unsafe(addr(ta[aB]))
+            var bcur = unsafe(addr(tb[bB]))
+            for [unroll_full] (_ik in range(4)) {
+                for [unroll_full] (i in range(4)) {
+                    simdgroup_load(ma[i], acur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(2)) {
+                    simdgroup_load(mb[i], bcur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(8)) {
+                    simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i])
+                }
+                acur = unsafe(acur + 512)
+                bcur = unsafe(bcur + 256)
+            }
+            kb++
+        }
+        let base = h * np32 * np32
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = queries
+        let col0 = nBase + (sg % 2u) * 32u  // accumulator cols = keys
+        for [unroll_full] (i in range(8)) {
+            simdgroup_store(mc[i], att, base + (row0 + uint(i / 4) * 8u) * np32 + col0 + uint(i % 4) * 8u, np32)
+        }
+    }
+}
+
+// AV: O_h = P_h . V_h — C tile 32 tokens x 64 V-columns, k walks the (causally limited)
+// position axis in 32-blocks. V stages in its natural (position row, column) orientation into
+// the tile-major A grid — contiguous float4 loads, position rows >= npos ZEROED (the causal
+// softmax zeroes P columns >= npos EXACTLY, and 0 * NaN from a pad V row would poison the
+// tile); P stages rows via float4 loads of the score slab (v21's B pattern).
+class MetalAttnAVMm {
+    @ssbo @binding = 0 att : array<float4>  // [n_heads x np32 x np32/4] normalized P
+    @ssbo @binding = 1 v : array<float4>    // [mp x kv_dim/4] raw V
+    @ssbo @binding = 2 xb : array<float>    // [mp x qd] attention output
+    @uniform @binding = 3 qd : uint
+    @uniform @binding = 4 kv_dim : uint
+    @uniform @binding = 5 head_size : uint
+    @uniform @binding = 6 kv_mul : uint
+    @uniform @binding = 7 npos : uint
+    @uniform @binding = 8 np32 : uint
+    @workgroup ta : float16[2048]           // V: pos-tiles x 8 col-tiles of 8x8, tile (pos row, col col)
+    @workgroup tb : float16[1024]           // P: pos-tiles x 4 token-tiles of 8x8 (token row, pos col)
+
+    [metal_kernel(name="metal_attn_av_mm_msl")]
+    def metal_attn_av_mm {
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let mBase = gl_WorkGroupID.x * 32u  // token rows
+        let vBase = gl_WorkGroupID.y * 64u  // V columns within the head
+        let h = gl_WorkGroupID.z
+        let kvhoff4 = ((h / kv_mul) * head_size) / 4u
+        let kvd4 = kv_dim / 4u
+        let np324 = np32 / 4u
+        var mc : simdgroup_float8x8[8]      // C quadrant: 2 row-tiles x 4 col-tiles
+        // A split: thread stages one position row x 16 contiguous V columns (4 x tg_store_half4)
+        let pr = lid / 4u
+        let vc16 = (lid % 4u) * 16u
+        let sxyA = (pr / 8u) * 8u * 64u + (pr % 8u) * 8u   // 64*(8*(pos/8)) + 8*(pos%8)
+        // B split: thread stages one token row x 8 contiguous positions of P
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u
+        let bB = (sg / 2u) * 128u
+        var ma : simdgroup_half8x8[4]
+        var mb : simdgroup_half8x8[2]
+        let klimit = min(mBase + 32u, np32) // causal: P rows here are zero past mBase+31
+        var kb = 0u
+        while (kb * 32u < klimit) {
+            let posg = kb * 32u + pr
+            let srcA = posg * kvd4 + kvhoff4 + (vBase + vc16) / 4u
+            let zero = float4(0.0)
+            let a0 = posg < npos ? v[srcA] : zero
+            let a1 = posg < npos ? v[srcA + 1u] : zero
+            let a2 = posg < npos ? v[srcA + 2u] : zero
+            let a3 = posg < npos ? v[srcA + 3u] : zero
+            let srcB = (h * np32 + mBase + lr1) * np324 + (kb * 32u + iy) / 4u
+            let b0 = att[srcB]
+            let b1 = att[srcB + 1u]
+            barrier()
+            let tbase = sxyA + (vc16 / 8u) * 64u            // first col-tile this thread touches
+            tg_store_half4(ta, tbase, a0)
+            tg_store_half4(ta, tbase + 4u, a1)
+            tg_store_half4(ta, tbase + 64u, a2)             // next 8-column tile
+            tg_store_half4(ta, tbase + 68u, a3)
+            tg_store_half4(tb, ibB, b0)
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            // math ROLLED over matrix arrays + das-pointer tile bumps — the hand-unrolled
+            // spelling costs an occupancy tier (this kernel measured max_threads 704)
+            var acur = unsafe(addr(ta[aB]))
+            var bcur = unsafe(addr(tb[bB]))
+            for [unroll_full] (_ik in range(4)) {
+                for [unroll_full] (i in range(4)) {
+                    simdgroup_load(ma[i], acur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(2)) {
+                    simdgroup_load(mb[i], bcur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(8)) {
+                    simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i])
+                }
+                acur = unsafe(acur + 512)
+                bcur = unsafe(bcur + 256)
+            }
+            kb++
+        }
+        let row0 = mBase + (sg / 2u) * 16u  // accumulator rows = tokens
+        let col0 = h * head_size + vBase + (sg % 2u) * 32u
+        for [unroll_full] (i in range(8)) {
+            simdgroup_store(mc[i], xb, (row0 + uint(i / 4) * 8u) * qd + col0 + uint(i % 4) * 8u, qd)
+        }
+    }
+}
+
 // Fused SwiGLU gate, one thread per element: g = silu(g) * u — swiglu exactly (the CPU side's
 // exp4 polynomial vs the GPU exp differ inside the shared tolerance envelope).
 class MetalSwiglu {
@@ -420,7 +946,10 @@ var private g_dev : MetalDevice?
 var private g_queue : MetalCommandQueue?
 var private g_failed = false
 var private g_regions : table<uint64; MetalBuffer?>    // base address -> resident weight/scale/norm region
+var private g_blob_regions : table<uint64; MetalBuffer?>    // quant base address -> resident block_q8_0 blob (lcpp mul_mm path)
+var private g_repack_us = 0l
 var private g_pool : MetalBufferPool
+var private g_upool : MetalBufferPool     // UNTRACKED pool: uniforms + rope tables (GPU-read-only)
 var private g_min_npos = 64l
 var private g_max_npos = 2048l          // naive-attention P footprint cap: heads x npos^2 floats
 var private g_prefills = 0l
@@ -435,6 +964,15 @@ var private g_pso_softmax : MetalComputePipeline?
 var private g_pso_av : MetalComputePipeline?
 var private g_pso_swiglu : MetalComputePipeline?
 var private g_pso_add : MetalComputePipeline?
+var private g_pso_addrmsq : MetalComputePipeline?
+var private g_pso_swigluq : MetalComputePipeline?
+var private g_pso_ropeqk : MetalComputePipeline?
+var private g_pso_mm : MetalComputePipeline?    // the production das mul_mm (34B q8 blocks + f32 X)
+var private g_pso_qkmm : MetalComputePipeline?
+var private g_pso_avmm : MetalComputePipeline?
+var private g_pso_gemv : MetalComputePipeline?      // classifier GEMV (logits-on-GPU)
+var private g_mm_legacy = false             // set_metal_prefill_mulmm_legacy — tests' exact-parity rail
+var private g_logits_cpu = false            // set_metal_prefill_logits_cpu — the logits A/B rail
 // timing-attribution knockout (DASLLAMA_METAL_PREFILL_SKIP=attn|gemm|ew|nongemm): skips encoding
 // that stage family (nongemm = attn AND ew, leaving the pure GEMM chain) — output is GARBAGE,
 // gpu-time deltas attribute the budget. Debug rail only.
@@ -444,6 +982,19 @@ var private g_skip = ""
 //! Set 1 to force every prefill onto the GPU (tests).
 def public set_metal_prefill_min_npos(v : int64) {
     g_min_npos = v
+}
+
+//! Pin the CPU final-norm/classifier step (logits-on-GPU off) — the A/B and fallback rail.
+//! `DASLLAMA_METAL_LOGITS=0` pins it process-wide.
+def public set_metal_prefill_logits_cpu(v : bool) {
+    g_logits_cpu = v
+}
+
+//! Pin the legacy quantized-activation GEMM path (q8 X + planar weights) instead of the default
+//! llama.cpp mul_mm path (f32 X + block_q8_0 blobs). The legacy path is bit-identical to the CPU
+//! forward — the tests' exact-parity rail. `DASLLAMA_METAL_MULMM=0` pins it process-wide.
+def public set_metal_prefill_mulmm_legacy(v : bool) {
+    g_mm_legacy = v
 }
 
 //! (gpu prefills served, declines to the CPU path) since load — diagnostics / tests.
@@ -464,7 +1015,18 @@ def public metal_prefill_shutdown {
     unsafe {
         delete g_regions
     }
+    for (buf in values(g_blob_regions)) {
+        if (buf != null) {
+            metal_release(buf)
+        }
+        buf = null
+    }
+    unsafe {
+        delete g_blob_regions
+    }
+    g_repack_us = 0l
     pool_drain(g_pool)
+    pool_drain(g_upool)
     if (g_pso_gemm != null) {
         metal_release(g_pso_gemm)
         g_pso_gemm = null
@@ -480,6 +1042,10 @@ def public metal_prefill_shutdown {
     if (g_pso_rms != null) {
         metal_release(g_pso_rms)
         g_pso_rms = null
+    }
+    if (g_pso_gemv != null) {
+        metal_release(g_pso_gemv)
+        g_pso_gemv = null
     }
     if (g_pso_rope != null) {
         metal_release(g_pso_rope)
@@ -505,6 +1071,30 @@ def public metal_prefill_shutdown {
         metal_release(g_pso_add)
         g_pso_add = null
     }
+    if (g_pso_addrmsq != null) {
+        metal_release(g_pso_addrmsq)
+        g_pso_addrmsq = null
+    }
+    if (g_pso_swigluq != null) {
+        metal_release(g_pso_swigluq)
+        g_pso_swigluq = null
+    }
+    if (g_pso_ropeqk != null) {
+        metal_release(g_pso_ropeqk)
+        g_pso_ropeqk = null
+    }
+    if (g_pso_mm != null) {
+        metal_release(g_pso_mm)
+        g_pso_mm = null
+    }
+    if (g_pso_qkmm != null) {
+        metal_release(g_pso_qkmm)
+        g_pso_qkmm = null
+    }
+    if (g_pso_avmm != null) {
+        metal_release(g_pso_avmm)
+        g_pso_avmm = null
+    }
     if (g_queue != null) {
         metal_release(g_queue)
         g_queue = null
@@ -514,6 +1104,10 @@ def public metal_prefill_shutdown {
         g_dev = null
     }
     g_failed = false
+}
+
+def private env_int(name : string; dflt : int) : int {
+    return has_env_variable(name) ? to_int(get_env_variable(name)) : dflt
 }
 
 def private compile_pso(source, entry : string; fastmath : bool; var ok : bool&) : MetalComputePipeline? {
@@ -551,6 +1145,13 @@ def private metal_prefill_init : bool {
     g_pso_av = compile_pso(metal_attn_av_msl, metal_attn_av_msl_entry, metal_attn_av_msl_fastmath, ok)
     g_pso_swiglu = compile_pso(metal_swiglu_msl, metal_swiglu_msl_entry, metal_swiglu_msl_fastmath, ok)
     g_pso_add = compile_pso(metal_add_msl, metal_add_msl_entry, metal_add_msl_fastmath, ok)
+    g_pso_addrmsq = compile_pso(metal_add_rms_quant_msl, metal_add_rms_quant_msl_entry, metal_add_rms_quant_msl_fastmath, ok)
+    g_pso_swigluq = compile_pso(metal_swiglu_quant_msl, metal_swiglu_quant_msl_entry, metal_swiglu_quant_msl_fastmath, ok)
+    g_pso_ropeqk = compile_pso(metal_rope_qk_msl, metal_rope_qk_msl_entry, metal_rope_qk_msl_fastmath, ok)
+    g_pso_mm = compile_pso(metal_q8_mulmm_msl, metal_q8_mulmm_msl_entry, metal_q8_mulmm_msl_fastmath, ok)
+    g_pso_qkmm = compile_pso(metal_attn_qk_mm_msl, metal_attn_qk_mm_msl_entry, metal_attn_qk_mm_msl_fastmath, ok)
+    g_pso_avmm = compile_pso(metal_attn_av_mm_msl, metal_attn_av_mm_msl_entry, metal_attn_av_mm_msl_fastmath, ok)
+    g_pso_gemv = compile_pso(metal_q8_gemv_msl, metal_q8_gemv_msl_entry, metal_q8_gemv_msl_fastmath, ok)
     if (!ok) {
         metal_prefill_shutdown()
         g_failed = true
@@ -566,7 +1167,10 @@ def private upload_region(src : void?; bytes : uint64) : MetalBuffer? {
     if (key_exists(g_regions, key)) {
         return g_regions[key]
     }
-    var buf = metal_new_buffer(g_dev, bytes)
+    // UNTRACKED: weights are GPU-read-only (written once here, before any commit), so they
+    // carry no hazards — keeping ~450 of them tracked made the command-buffer scheduler's
+    // dependency analysis the dominant non-GPU cost (~70ms/prefill on the 3B)
+    var buf = metal_new_buffer_untracked(g_dev, bytes)
     unsafe {
         memcpy(metal_buffer_contents(buf), src, int(bytes))
     }
@@ -574,22 +1178,53 @@ def private upload_region(src : void?; bytes : uint64) : MetalBuffer? {
     return buf
 }
 
+// lazily repack one weight region (planar quants + f32 scale plane) into a resident block_q8_0
+// blob — llama.cpp's mul_mm layout: 34-byte blocks of half scale + 32 int8 quants. One-time CPU
+// pass per region, keyed by the quant base address; f32 -> f16 scale narrowing is exact for
+// GGUF-q8_0-sourced weights (the loader widened the file's native f16 scales)
+def private upload_blob_region(qsrc : void?; ssrc : void?; rows, k : int64) : MetalBuffer? {
+    let key = intptr(qsrc)
+    if (key_exists(g_blob_regions, key)) {
+        return g_blob_regions[key]
+    }
+    let ts = ref_time_ticks()
+    let nblocks = int(rows * (k / 32l))
+    var buf = metal_new_buffer_untracked(g_dev, uint64(nblocks) * 34ul)
+    var base = unsafe(reinterpret<int8?>(metal_buffer_contents(buf)))
+    var qp = unsafe(reinterpret<int8?>(qsrc))
+    var sp = unsafe(reinterpret<float?>(ssrc))
+    for (b in range(nblocks)) {
+        let off = b * 34
+        unsafe {
+            var ph = reinterpret<float16?>(base + off)
+            ph[0] = float16(sp[b])
+            let src = b * 32
+            for (c in range(32)) {
+                base[off + 2 + c] = qp[src + c]
+            }
+        }
+    }
+    g_blob_regions[key] = buf
+    g_repack_us += int64(get_time_usec(ts))
+    return buf
+}
+
 def private uniform_u32(v : uint) : MetalBuffer? {
-    var buf = pool_acquire(g_pool, g_dev, 4ul)
+    var buf = pool_acquire_untracked(g_upool, g_dev, 4ul)
     var p = unsafe(reinterpret<uint?>(metal_buffer_contents(buf)))
     unsafe(p[0]) = v
     return buf
 }
 
 def private uniform_f32(v : float) : MetalBuffer? {
-    var buf = pool_acquire(g_pool, g_dev, 4ul)
+    var buf = pool_acquire_untracked(g_upool, g_dev, 4ul)
     var p = unsafe(reinterpret<float?>(metal_buffer_contents(buf)))
     unsafe(p[0]) = v
     return buf
 }
 
-// only the llama-family std shape is wired (Phase-6 mandate: ONE model, Llama-3.2-1B) — anything
-// else declines to the CPU loop
+// only the llama-family std shape is wired (Llama-3.2 class — 1B hs=64 and 3B hs=128 both
+// serve) — anything else declines to the CPU loop
 def private prefill_supported(t : Model; s : Session; npos, start_pos : int64) : bool {
     // the GEMM kernel reads ROW-MAJOR Q8 weights — a repack backend's interleaved layout is
     // unreadable here (the same donor contract as the Phase-5c batch offload: load under
@@ -609,7 +1244,8 @@ def private prefill_supported(t : Model; s : Session; npos, start_pos : int64) :
     let qd = c.n_heads * head_size
     let kv_dim = layer_kv_dim(c, 0l)
     let hidden = layer_hidden(t, 0l)
-    if ((qd != c.dim || (head_size % 32l) != 0l || head_size > 64l) ||
+    // head_size % 32: the AV kernel grids d in 32-blocks; the QK kernel k-slabs any size
+    if ((qd != c.dim || (head_size % 32l) != 0l) ||
             ((c.dim % 32l) != 0l || (kv_dim % 32l) != 0l || (hidden % 32l) != 0l)) {
         return false
     }
@@ -637,6 +1273,20 @@ def private enc_gemm(enc : MetalComputeEncoder?; bwq, bws, bxq, bxs, by, bkdim, 
     metal_dispatch_threadgroups(enc, uint3(groups, 1u, 1u), uint3(128u, 1u, 1u))
 }
 
+// the production mul_mm dispatch: W blob bound twice (half-scale + byte views), raw f32 X,
+// grid (mp/32 token tiles, d/64 output tiles). Requires d % 64 == 0 and mp % 64 == 0
+def private enc_gemm_mm(enc : MetalComputeEncoder?; bwblob, bx, by, bk, bn : MetalBuffer?; mp, d : int64) {
+    metal_set_pipeline(enc, g_pso_mm)
+    metal_set_threadgroup_memory_length(enc, metal_q8_mulmm_msl_tgmem, 0)
+    metal_set_buffer(enc, bwblob, 0ul, 0)
+    metal_set_buffer(enc, bwblob, 0ul, 1)
+    metal_set_buffer(enc, bx, 0ul, 2)
+    metal_set_buffer(enc, by, 0ul, 3)
+    metal_set_buffer(enc, bk, 0ul, 4)
+    metal_set_buffer(enc, bn, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint(mp / 32l), uint(d / 64l), 1u), uint3(128u, 1u, 1u))
+}
+
 def private enc_quant(enc : MetalComputeEncoder?; bx, bxq, bxs, bn, bnblk : MetalBuffer?; nblk : int64) {
     metal_set_pipeline(enc, g_pso_quant)
     metal_set_buffer(enc, bx, 0ul, 0)
@@ -649,12 +1299,37 @@ def private enc_quant(enc : MetalComputeEncoder?; bx, bxq, bxs, bn, bnblk : Meta
 
 def private enc_rms(enc : MetalComputeEncoder?; bx, bw, by, bdim, beps : MetalBuffer?; nrows : int64) {
     metal_set_pipeline(enc, g_pso_rms)
+    metal_set_threadgroup_memory_length(enc, metal_rmsnorm_msl_tgmem, 0)
     metal_set_buffer(enc, bx, 0ul, 0)
     metal_set_buffer(enc, bw, 0ul, 1)
     metal_set_buffer(enc, by, 0ul, 2)
     metal_set_buffer(enc, bdim, 0ul, 3)
     metal_set_buffer(enc, beps, 0ul, 4)
     metal_dispatch_threadgroups(enc, uint3(uint(nrows), 1u, 1u), uint3(256u, 1u, 1u))
+}
+
+// the final rmsnorm on ONE row: bx bound at the last position's byte offset (one threadgroup)
+def private enc_rms_last(enc : MetalComputeEncoder?; bx : MetalBuffer?; xoff : uint64; bw, by, bdim, beps : MetalBuffer?) {
+    metal_set_pipeline(enc, g_pso_rms)
+    metal_set_threadgroup_memory_length(enc, metal_rmsnorm_msl_tgmem, 0)
+    metal_set_buffer(enc, bx, xoff, 0)
+    metal_set_buffer(enc, bw, 0ul, 1)
+    metal_set_buffer(enc, by, 0ul, 2)
+    metal_set_buffer(enc, bdim, 0ul, 3)
+    metal_set_buffer(enc, beps, 0ul, 4)
+    metal_dispatch_threadgroups(enc, uint3(1u, 1u, 1u), uint3(256u, 1u, 1u))
+}
+
+// the classifier GEMV: d rows of logits, 4 rows (one simdgroup each) per threadgroup
+def private enc_gemv(enc : MetalComputeEncoder?; bwq, bws, bx, by, bn, bd : MetalBuffer?; d : int64) {
+    metal_set_pipeline(enc, g_pso_gemv)
+    metal_set_buffer(enc, bwq, 0ul, 0)
+    metal_set_buffer(enc, bws, 0ul, 1)
+    metal_set_buffer(enc, bx, 0ul, 2)
+    metal_set_buffer(enc, by, 0ul, 3)
+    metal_set_buffer(enc, bn, 0ul, 4)
+    metal_set_buffer(enc, bd, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((d + 3l) / 4l), 1u, 1u), uint3(128u, 1u, 1u))
 }
 
 def private enc_rope(enc : MetalComputeEncoder?; bv, bcos, bsin, bn, bhs, bnpairs : MetalBuffer?; npairs : int64) {
@@ -668,8 +1343,81 @@ def private enc_rope(enc : MetalComputeEncoder?; bv, bcos, bsin, bn, bhs, bnpair
     metal_dispatch_threadgroups(enc, uint3(uint((npairs + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
 }
 
+// the fused add?+rms+quant: one threadgroup per row, r folded in when baddv reads 1
+def private enc_add_rms_quant(enc : MetalComputeEncoder?; bx, br, bw, bxq, bxs, bdim, beps, baddv : MetalBuffer?; nrows : int64) {
+    metal_set_pipeline(enc, g_pso_addrmsq)
+    metal_set_threadgroup_memory_length(enc, metal_add_rms_quant_msl_tgmem, 0)
+    metal_set_buffer(enc, bx, 0ul, 0)
+    metal_set_buffer(enc, br, 0ul, 1)
+    metal_set_buffer(enc, bw, 0ul, 2)
+    metal_set_buffer(enc, bxq, 0ul, 3)
+    metal_set_buffer(enc, bxs, 0ul, 4)
+    metal_set_buffer(enc, bdim, 0ul, 5)
+    metal_set_buffer(enc, beps, 0ul, 6)
+    metal_set_buffer(enc, baddv, 0ul, 7)
+    metal_dispatch_threadgroups(enc, uint3(uint(nrows), 1u, 1u), uint3(256u, 1u, 1u))
+}
+
+def private enc_swiglu_quant(enc : MetalComputeEncoder?; bg, bu, bxq, bxs, bn, bnblk : MetalBuffer?; nblk : int64) {
+    metal_set_pipeline(enc, g_pso_swigluq)
+    metal_set_buffer(enc, bg, 0ul, 0)
+    metal_set_buffer(enc, bu, 0ul, 1)
+    metal_set_buffer(enc, bxq, 0ul, 2)
+    metal_set_buffer(enc, bxs, 0ul, 3)
+    metal_set_buffer(enc, bn, 0ul, 4)
+    metal_set_buffer(enc, bnblk, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((nblk + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
+}
+
+def private enc_rope_qk(enc : MetalComputeEncoder?; bq, bk, bcos, bsin, bqd, bkvd, bhs, bnpq, bnpall : MetalBuffer?; npairs : int64) {
+    metal_set_pipeline(enc, g_pso_ropeqk)
+    metal_set_buffer(enc, bq, 0ul, 0)
+    metal_set_buffer(enc, bk, 0ul, 1)
+    metal_set_buffer(enc, bcos, 0ul, 2)
+    metal_set_buffer(enc, bsin, 0ul, 3)
+    metal_set_buffer(enc, bqd, 0ul, 4)
+    metal_set_buffer(enc, bkvd, 0ul, 5)
+    metal_set_buffer(enc, bhs, 0ul, 6)
+    metal_set_buffer(enc, bnpq, 0ul, 7)
+    metal_set_buffer(enc, bnpall, 0ul, 8)
+    metal_dispatch_threadgroups(enc, uint3(uint((npairs + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
+}
+
+// the ggml-geometry attention pair: same buffer lists as the trio, 32x64 C tiles, z = heads
+def private enc_qk_mm(enc : MetalComputeEncoder?; bq, bk, batt, bqd, bkvd, bhs, bkvm, bnp, bnp32, bscale : MetalBuffer?; mp, heads : int64) {
+    metal_set_pipeline(enc, g_pso_qkmm)
+    metal_set_threadgroup_memory_length(enc, metal_attn_qk_mm_msl_tgmem, 0)
+    metal_set_buffer(enc, bq, 0ul, 0)
+    metal_set_buffer(enc, bk, 0ul, 1)
+    metal_set_buffer(enc, batt, 0ul, 2)
+    metal_set_buffer(enc, bqd, 0ul, 3)
+    metal_set_buffer(enc, bkvd, 0ul, 4)
+    metal_set_buffer(enc, bhs, 0ul, 5)
+    metal_set_buffer(enc, bkvm, 0ul, 6)
+    metal_set_buffer(enc, bnp, 0ul, 7)
+    metal_set_buffer(enc, bnp32, 0ul, 8)
+    metal_set_buffer(enc, bscale, 0ul, 9)
+    metal_dispatch_threadgroups(enc, uint3(uint(mp / 32l), uint(mp / 64l), uint(heads)), uint3(128u, 1u, 1u))
+}
+
+def private enc_av_mm(enc : MetalComputeEncoder?; batt, bv, bxb, bqd, bkvd, bhs, bkvm, bnp, bnp32 : MetalBuffer?; mp, heads, head_size : int64) {
+    metal_set_pipeline(enc, g_pso_avmm)
+    metal_set_threadgroup_memory_length(enc, metal_attn_av_mm_msl_tgmem, 0)
+    metal_set_buffer(enc, batt, 0ul, 0)
+    metal_set_buffer(enc, bv, 0ul, 1)
+    metal_set_buffer(enc, bxb, 0ul, 2)
+    metal_set_buffer(enc, bqd, 0ul, 3)
+    metal_set_buffer(enc, bkvd, 0ul, 4)
+    metal_set_buffer(enc, bhs, 0ul, 5)
+    metal_set_buffer(enc, bkvm, 0ul, 6)
+    metal_set_buffer(enc, bnp, 0ul, 7)
+    metal_set_buffer(enc, bnp32, 0ul, 8)
+    metal_dispatch_threadgroups(enc, uint3(uint(mp / 32l), uint(head_size / 64l), uint(heads)), uint3(128u, 1u, 1u))
+}
+
 def private enc_qk(enc : MetalComputeEncoder?; bq, bk, batt, bqd, bkvd, bhs, bkvm, bnp, bnp32, bscale : MetalBuffer?; mp, heads : int64) {
     metal_set_pipeline(enc, g_pso_qk)
+    metal_set_threadgroup_memory_length(enc, metal_attn_qk_msl_tgmem, 0)
     metal_set_buffer(enc, bq, 0ul, 0)
     metal_set_buffer(enc, bk, 0ul, 1)
     metal_set_buffer(enc, batt, 0ul, 2)
@@ -685,6 +1433,7 @@ def private enc_qk(enc : MetalComputeEncoder?; bq, bk, batt, bqd, bkvd, bhs, bkv
 
 def private enc_softmax(enc : MetalComputeEncoder?; batt, bnp32 : MetalBuffer?; npos, heads : int64) {
     metal_set_pipeline(enc, g_pso_softmax)
+    metal_set_threadgroup_memory_length(enc, metal_attn_softmax_msl_tgmem, 0)
     metal_set_buffer(enc, batt, 0ul, 0)
     metal_set_buffer(enc, bnp32, 0ul, 1)
     metal_dispatch_threadgroups(enc, uint3(uint(npos), uint(heads), 1u), uint3(128u, 1u, 1u))
@@ -692,6 +1441,7 @@ def private enc_softmax(enc : MetalComputeEncoder?; batt, bnp32 : MetalBuffer?; 
 
 def private enc_av(enc : MetalComputeEncoder?; batt, bv, bxb, bqd, bkvd, bhs, bkvm, bnp, bnp32 : MetalBuffer?; mp, heads, head_size : int64) {
     metal_set_pipeline(enc, g_pso_av)
+    metal_set_threadgroup_memory_length(enc, metal_attn_av_msl_tgmem, 0)
     metal_set_buffer(enc, batt, 0ul, 0)
     metal_set_buffer(enc, bv, 0ul, 1)
     metal_set_buffer(enc, bxb, 0ul, 2)
@@ -754,8 +1504,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var bxq = pool_acquire(g_pool, g_dev, bytes_xq)
     var bxs = pool_acquire(g_pool, g_dev, bytes_xs)
     var batt = pool_acquire(g_pool, g_dev, bytes_att)
-    var bcos = pool_acquire(g_pool, g_dev, bytes_tab)
-    var bsin = pool_acquire(g_pool, g_dev, bytes_tab)
+    var bcos = pool_acquire_untracked(g_upool, g_dev, bytes_tab)
+    var bsin = pool_acquire_untracked(g_upool, g_dev, bytes_tab)
     var bks : array<MetalBuffer?>
     var bvs : array<MetalBuffer?>
     bks |> reserve(int(c.n_layers))
@@ -788,96 +1538,273 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var u_total_h = uniform_u32(uint(npos * hidden))
     var u_scale = uniform_f32(scale)
     var u_eps = uniform_f32(c.norm_eps)
+    var u_addv0 = uniform_u32(0u)
+    var u_addv1 = uniform_u32(1u)
+    var u_npairs_all = uniform_u32(uint(npos * (qd + kv_dim) / 2l))
+    // the mul_mm GEMM path (the default): W as resident 34B q8-block blobs (GGUF q8_0's own
+    // layout), raw f32 activations — the X-quant dispatches disappear and the GEMMs run at
+    // mul_mm rate. Needs every GEMM output dim % 64; DASLLAMA_METAL_MULMM=0 (or the setter)
+    // pins the legacy quantized path, which is bit-identical to the CPU forward.
+    let mm = (!g_mm_legacy && get_env_variable("DASLLAMA_METAL_MULMM") != "0" &&
+        (dim % 64l) == 0l && (qd % 64l) == 0l && (kv_dim % 64l) == 0l && (hidden % 64l) == 0l)
+    // logits-on-GPU (default ON, DASLLAMA_METAL_LOGITS=0 pins the CPU classifier): the final
+    // rmsnorm on the last position + the classifier GEMV ride the last command buffer, and the
+    // caller's CPU final step is skipped (prefill_override_logits_done). Mirrors the CPU q8
+    // `mm` path only — softcap / suppression / non-q8 classifiers decline to the CPU step.
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
+    let gpu_logits = (!g_logits_cpu && get_env_variable("DASLLAMA_METAL_LOGITS") != "0" && empty(g_skip) &&
+        cls_fmt == KqFmt.q8 && !tied_f32 && c.final_logit_softcap <= 0.0 &&
+        empty(t.suppress) && t.wcls_off >= 0l)
+    var bxf = gpu_logits ? pool_acquire(g_pool, g_dev, uint64(dim * 4l)) : null
+    var blog = gpu_logits ? pool_acquire(g_pool, g_dev, uint64(c.vocab_size * 4l)) : null
+    var u_vocab = gpu_logits ? uniform_u32(uint(c.vocab_size)) : null
+    // the fused add+rms+quant stages one row in threadgroup memory — dim must fit its 3072 cap.
+    // DASLLAMA_METAL_FUSE=0 pins the unfused dispatch set (the A/B rail). The lcpp path runs the
+    // unfused elementwise set (no quant tails to fuse).
+    let fused = !mm && dim <= 3072l && get_env_variable("DASLLAMA_METAL_FUSE") != "0"
+    // ggml-geometry QK/AV (default): ~10x the old trio GEMMs' rate; needs hs % 64 (the AV grid)
+    // and mp % 64 (the QK key grid — true by construction). DASLLAMA_METAL_ATTN=0 pins the trio.
+    let mmattn = (head_size % 64l) == 0l && get_env_variable("DASLLAMA_METAL_ATTN") != "0"
     let ts_enc = ref_time_ticks()
     let setup_us = get_time_usec(ts_all)
     var err : string
-    var gpu_ms = 0.0lf
-    let ran = with_compute_encoder_timed(g_queue, err, gpu_ms) $(enc : MetalComputeEncoder?) {
+    var gpu_ms : double
+    var encode_ms : double
+    // command-buffer split (DASLLAMA_METAL_NCB chunks): each chunk commits as soon as it is
+    // encoded, so the scheduler analyzes chunk k while chunk k-1 executes — same-queue commit
+    // order plus hazard tracking on the activation buffers keeps cross-chunk ordering. With
+    // DASLLAMA_METAL_UNRETAINED=1 the chunks also skip the per-dispatch resource retain/release
+    // (safe here: pooled buffers release back only after the wait, weight regions are resident).
+    // default = ~4 layers per chunk (3B measured: slack 57ms -> 9ms, +10% pp512; finer splits
+    // are neutral). DASLLAMA_METAL_NCB=1 restores the single-buffer path.
+    let ncb = clamp(int64(env_int("DASLLAMA_METAL_NCB", int((c.n_layers + 3l) / 4l))), 1l, c.n_layers)
+    let unret = get_env_variable("DASLLAMA_METAL_UNRETAINED") == "1"
+    let layers_per_cb = (c.n_layers + ncb - 1l) / ncb
+    var cbs : array<MetalCommandBuffer?>
+    cbs |> reserve(int(ncb))
+    var cb : MetalCommandBuffer?
+    var enc : MetalComputeEncoder?
+    {
         for (l in range64(c.n_layers)) {
+            if (l % layers_per_cb == 0l) {
+                if (enc != null) {
+                    metal_end_encoding(enc)
+                    metal_release(enc)
+                    metal_commit(cb)
+                    cbs |> push(cb)
+                }
+                cb = unret ? metal_new_command_buffer_unretained(g_queue) : metal_new_command_buffer(g_queue)
+                enc = metal_new_compute_encoder(cb)
+            }
             unsafe {
                 var bw_att = upload_region(reinterpret<void?>(addr(t.fblob[t.rms_att_off + l * dim])), uint64(dim * 4l))
                 var bw_ffn = upload_region(reinterpret<void?>(addr(t.fblob[t.rms_ffn_off + l * dim])), uint64(dim * 4l))
-                var bwq = upload_region(reinterpret<void?>(addr(t.qblob[t.wq_offs[l]])), uint64(qd * dim))
-                var bwq_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wq_offs[l] / 32l])), uint64(qd * (dim / 32l) * 4l))
-                var bwk = upload_region(reinterpret<void?>(addr(t.qblob[t.wk_offs[l]])), uint64(kv_dim * dim))
-                var bwk_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wk_offs[l] / 32l])), uint64(kv_dim * (dim / 32l) * 4l))
-                var bwv = upload_region(reinterpret<void?>(addr(t.qblob[t.wv_offs[l]])), uint64(kv_dim * dim))
-                var bwv_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wv_offs[l] / 32l])), uint64(kv_dim * (dim / 32l) * 4l))
-                var bwo = upload_region(reinterpret<void?>(addr(t.qblob[t.wo_offs[l]])), uint64(dim * qd))
-                var bwo_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wo_offs[l] / 32l])), uint64(dim * (qd / 32l) * 4l))
-                var bw1 = upload_region(reinterpret<void?>(addr(t.qblob[t.w1_offs[l]])), uint64(hidden * dim))
-                var bw1_s = upload_region(reinterpret<void?>(addr(t.qscales[t.w1_offs[l] / 32l])), uint64(hidden * (dim / 32l) * 4l))
-                var bw3 = upload_region(reinterpret<void?>(addr(t.qblob[t.w3_offs[l]])), uint64(hidden * dim))
-                var bw3_s = upload_region(reinterpret<void?>(addr(t.qscales[t.w3_offs[l] / 32l])), uint64(hidden * (dim / 32l) * 4l))
-                var bw2 = upload_region(reinterpret<void?>(addr(t.qblob[t.w2_offs[l]])), uint64(dim * hidden))
-                var bw2_s = upload_region(reinterpret<void?>(addr(t.qscales[t.w2_offs[l] / 32l])), uint64(dim * (hidden / 32l) * 4l))
-                // attention: norm -> requant -> Q/K/V -> rope -> scores+softmax -> P.V -> out-proj -> residual
+                // attention: [pending W2 residual +] norm -> [requant ->] Q/K/V -> rope ->
+                // scores+softmax -> P.V -> out-proj (fused path folds each residual add into
+                // the FOLLOWING add+rms+quant; the last layer's pending add lands after the loop;
+                // the lcpp path feeds the normed f32 rows straight to mul_mm — no requant)
                 if (g_skip != "ew" && g_skip != "nongemm") {
-                    enc_rms(enc, bx, bw_att, bxb, u_dim, u_eps, npos)
-                    enc_quant(enc, bxb, bxq, bxs, u_dim, u_nblk_dim, npos * (dim / 32l))
+                    if (fused) {
+                        enc_add_rms_quant(enc, bx, bxb, bw_att, bxq, bxs, u_dim, u_eps, l > 0l ? u_addv1 : u_addv0, npos)
+                    } else {
+                        enc_rms(enc, bx, bw_att, bxb, u_dim, u_eps, npos)
+                        if (!mm) {
+                            enc_quant(enc, bxb, bxq, bxs, u_dim, u_nblk_dim, npos * (dim / 32l))
+                        }
+                    }
                 }
                 if (g_skip != "gemm") {
-                    enc_gemm(enc, bwq, bwq_s, bxq, bxs, bq, u_dim, u_qd, mp, qd)
-                    enc_gemm(enc, bwk, bwk_s, bxq, bxs, bks[l], u_dim, u_kvd, mp, kv_dim)
-                    enc_gemm(enc, bwv, bwv_s, bxq, bxs, bvs[l], u_dim, u_kvd, mp, kv_dim)
+                    if (mm) {
+                        var bwqb = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.wq_offs[l]])), reinterpret<void?>(addr(t.qscales[t.wq_offs[l] / 32l])), qd, dim)
+                        var bwkb = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.wk_offs[l]])), reinterpret<void?>(addr(t.qscales[t.wk_offs[l] / 32l])), kv_dim, dim)
+                        var bwvb = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.wv_offs[l]])), reinterpret<void?>(addr(t.qscales[t.wv_offs[l] / 32l])), kv_dim, dim)
+                        enc_gemm_mm(enc, bwqb, bxb, bq, u_dim, u_qd, mp, qd)
+                        enc_gemm_mm(enc, bwkb, bxb, bks[l], u_dim, u_kvd, mp, kv_dim)
+                        enc_gemm_mm(enc, bwvb, bxb, bvs[l], u_dim, u_kvd, mp, kv_dim)
+                    } else {
+                        var bwq = upload_region(reinterpret<void?>(addr(t.qblob[t.wq_offs[l]])), uint64(qd * dim))
+                        var bwq_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wq_offs[l] / 32l])), uint64(qd * (dim / 32l) * 4l))
+                        var bwk = upload_region(reinterpret<void?>(addr(t.qblob[t.wk_offs[l]])), uint64(kv_dim * dim))
+                        var bwk_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wk_offs[l] / 32l])), uint64(kv_dim * (dim / 32l) * 4l))
+                        var bwv = upload_region(reinterpret<void?>(addr(t.qblob[t.wv_offs[l]])), uint64(kv_dim * dim))
+                        var bwv_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wv_offs[l] / 32l])), uint64(kv_dim * (dim / 32l) * 4l))
+                        enc_gemm(enc, bwq, bwq_s, bxq, bxs, bq, u_dim, u_qd, mp, qd)
+                        enc_gemm(enc, bwk, bwk_s, bxq, bxs, bks[l], u_dim, u_kvd, mp, kv_dim)
+                        enc_gemm(enc, bwv, bwv_s, bxq, bxs, bvs[l], u_dim, u_kvd, mp, kv_dim)
+                    }
                 }
                 if (g_skip != "ew" && g_skip != "nongemm") {
-                    enc_rope(enc, bq, bcos, bsin, u_qd, u_hs, u_npairs_q, npos * qd / 2l)
-                    enc_rope(enc, bks[l], bcos, bsin, u_kvd, u_hs, u_npairs_k, npos * kv_dim / 2l)
+                    if (fused) {
+                        enc_rope_qk(enc, bq, bks[l], bcos, bsin, u_qd, u_kvd, u_hs, u_npairs_q, u_npairs_all, npos * (qd + kv_dim) / 2l)
+                    } else {
+                        enc_rope(enc, bq, bcos, bsin, u_qd, u_hs, u_npairs_q, npos * qd / 2l)
+                        enc_rope(enc, bks[l], bcos, bsin, u_kvd, u_hs, u_npairs_k, npos * kv_dim / 2l)
+                    }
                 }
                 if (g_skip != "attn" && g_skip != "nongemm") {
-                    enc_qk(enc, bq, bks[l], batt, u_qd, u_kvd, u_hs, u_kvm, u_np, u_np32, u_scale, mp, n_heads)
-                    enc_softmax(enc, batt, u_np32, npos, n_heads)
-                    enc_av(enc, batt, bvs[l], bxb, u_qd, u_kvd, u_hs, u_kvm, u_np, u_np32, mp, n_heads, head_size)
+                    if (g_skip != "attn_qk") {
+                        if (mmattn) {
+                            enc_qk_mm(enc, bq, bks[l], batt, u_qd, u_kvd, u_hs, u_kvm, u_np, u_np32, u_scale, mp, n_heads)
+                        } else {
+                            enc_qk(enc, bq, bks[l], batt, u_qd, u_kvd, u_hs, u_kvm, u_np, u_np32, u_scale, mp, n_heads)
+                        }
+                    }
+                    if (g_skip != "attn_sm") {
+                        enc_softmax(enc, batt, u_np32, npos, n_heads)
+                    }
+                    if (g_skip != "attn_av") {
+                        if (mmattn) {
+                            enc_av_mm(enc, batt, bvs[l], bxb, u_qd, u_kvd, u_hs, u_kvm, u_np, u_np32, mp, n_heads, head_size)
+                        } else {
+                            enc_av(enc, batt, bvs[l], bxb, u_qd, u_kvd, u_hs, u_kvm, u_np, u_np32, mp, n_heads, head_size)
+                        }
+                    }
                 }
-                if (g_skip != "ew" && g_skip != "nongemm") {
+                if (!mm && g_skip != "ew" && g_skip != "nongemm") {
                     enc_quant(enc, bxb, bxq, bxs, u_qd, u_nblk_qd, npos * (qd / 32l))
                 }
                 if (g_skip != "gemm") {
-                    enc_gemm(enc, bwo, bwo_s, bxq, bxs, bxb2, u_qd, u_dim, mp, dim)
+                    if (mm) {
+                        var bwob = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.wo_offs[l]])), reinterpret<void?>(addr(t.qscales[t.wo_offs[l] / 32l])), dim, qd)
+                        enc_gemm_mm(enc, bwob, bxb, bxb2, u_qd, u_dim, mp, dim)
+                    } else {
+                        var bwo = upload_region(reinterpret<void?>(addr(t.qblob[t.wo_offs[l]])), uint64(dim * qd))
+                        var bwo_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wo_offs[l] / 32l])), uint64(dim * (qd / 32l) * 4l))
+                        enc_gemm(enc, bwo, bwo_s, bxq, bxs, bxb2, u_qd, u_dim, mp, dim)
+                    }
                 }
-                // ffn: norm -> requant -> W1/W3 -> swiglu -> requant -> W2 -> residual
+                // ffn: [WO residual +] norm -> [requant ->] W1/W3 -> swiglu[+requant] -> W2
                 if (g_skip != "ew" && g_skip != "nongemm") {
-                    enc_ew2(enc, g_pso_add, bx, bxb2, u_total_dim, npos * dim)
-                    enc_rms(enc, bx, bw_ffn, bxb, u_dim, u_eps, npos)
-                    enc_quant(enc, bxb, bxq, bxs, u_dim, u_nblk_dim, npos * (dim / 32l))
+                    if (fused) {
+                        enc_add_rms_quant(enc, bx, bxb2, bw_ffn, bxq, bxs, u_dim, u_eps, u_addv1, npos)
+                    } else {
+                        enc_ew2(enc, g_pso_add, bx, bxb2, u_total_dim, npos * dim)
+                        enc_rms(enc, bx, bw_ffn, bxb, u_dim, u_eps, npos)
+                        if (!mm) {
+                            enc_quant(enc, bxb, bxq, bxs, u_dim, u_nblk_dim, npos * (dim / 32l))
+                        }
+                    }
                 }
                 if (g_skip != "gemm") {
-                    enc_gemm(enc, bw1, bw1_s, bxq, bxs, bhb, u_dim, u_hidden, mp, hidden)
-                    enc_gemm(enc, bw3, bw3_s, bxq, bxs, bhb2, u_dim, u_hidden, mp, hidden)
+                    if (mm) {
+                        var bw1b = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.w1_offs[l]])), reinterpret<void?>(addr(t.qscales[t.w1_offs[l] / 32l])), hidden, dim)
+                        var bw3b = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.w3_offs[l]])), reinterpret<void?>(addr(t.qscales[t.w3_offs[l] / 32l])), hidden, dim)
+                        enc_gemm_mm(enc, bw1b, bxb, bhb, u_dim, u_hidden, mp, hidden)
+                        enc_gemm_mm(enc, bw3b, bxb, bhb2, u_dim, u_hidden, mp, hidden)
+                    } else {
+                        var bw1 = upload_region(reinterpret<void?>(addr(t.qblob[t.w1_offs[l]])), uint64(hidden * dim))
+                        var bw1_s = upload_region(reinterpret<void?>(addr(t.qscales[t.w1_offs[l] / 32l])), uint64(hidden * (dim / 32l) * 4l))
+                        var bw3 = upload_region(reinterpret<void?>(addr(t.qblob[t.w3_offs[l]])), uint64(hidden * dim))
+                        var bw3_s = upload_region(reinterpret<void?>(addr(t.qscales[t.w3_offs[l] / 32l])), uint64(hidden * (dim / 32l) * 4l))
+                        enc_gemm(enc, bw1, bw1_s, bxq, bxs, bhb, u_dim, u_hidden, mp, hidden)
+                        enc_gemm(enc, bw3, bw3_s, bxq, bxs, bhb2, u_dim, u_hidden, mp, hidden)
+                    }
                 }
                 if (g_skip != "ew" && g_skip != "nongemm") {
-                    enc_ew2(enc, g_pso_swiglu, bhb, bhb2, u_total_h, npos * hidden)
-                    enc_quant(enc, bhb, bxq, bxs, u_hidden, u_nblk_h, npos * (hidden / 32l))
+                    if (fused) {
+                        enc_swiglu_quant(enc, bhb, bhb2, bxq, bxs, u_hidden, u_nblk_h, npos * (hidden / 32l))
+                    } else {
+                        enc_ew2(enc, g_pso_swiglu, bhb, bhb2, u_total_h, npos * hidden)
+                        if (!mm) {
+                            enc_quant(enc, bhb, bxq, bxs, u_hidden, u_nblk_h, npos * (hidden / 32l))
+                        }
+                    }
                 }
                 if (g_skip != "gemm") {
-                    enc_gemm(enc, bw2, bw2_s, bxq, bxs, bxb, u_hidden, u_dim, mp, dim)
+                    if (mm) {
+                        var bw2b = upload_blob_region(reinterpret<void?>(addr(t.qblob[t.w2_offs[l]])), reinterpret<void?>(addr(t.qscales[t.w2_offs[l] / 32l])), dim, hidden)
+                        enc_gemm_mm(enc, bw2b, bhb, bxb, u_hidden, u_dim, mp, dim)
+                    } else {
+                        var bw2 = upload_region(reinterpret<void?>(addr(t.qblob[t.w2_offs[l]])), uint64(dim * hidden))
+                        var bw2_s = upload_region(reinterpret<void?>(addr(t.qscales[t.w2_offs[l] / 32l])), uint64(dim * (hidden / 32l) * 4l))
+                        enc_gemm(enc, bw2, bw2_s, bxq, bxs, bxb, u_hidden, u_dim, mp, dim)
+                    }
                 }
-                if (g_skip != "ew" && g_skip != "nongemm") {
+                if (!fused && g_skip != "ew" && g_skip != "nongemm") {
                     enc_ew2(enc, g_pso_add, bx, bxb, u_total_dim, npos * dim)
                 }
             }
         }
+        if (fused && g_skip != "ew" && g_skip != "nongemm") {
+            enc_ew2(enc, g_pso_add, bx, bxb, u_total_dim, npos * dim)   // the last layer's pending W2 add
+        }
+        if (gpu_logits) {
+            // final rmsnorm on the LAST position + classifier GEMV — the caller samples from
+            // s.logits, so this closes the whole forward inside the GPU window
+            unsafe {
+                var bwfin = upload_region(reinterpret<void?>(addr(t.fblob[t.rms_final_off])), uint64(dim * 4l))
+                var bwc = upload_region(reinterpret<void?>(addr(t.qblob[t.wcls_off])), uint64(c.vocab_size * dim))
+                var bwc_s = upload_region(reinterpret<void?>(addr(t.qscales[t.wcls_off / 32l])), uint64(c.vocab_size * (dim / 32l) * 4l))
+                enc_rms_last(enc, bx, uint64((npos - 1l) * dim * 4l), bwfin, bxf, u_dim, u_eps)
+                enc_gemv(enc, bwc, bwc_s, bxf, blog, u_dim, u_vocab, c.vocab_size)
+            }
+        }
+        metal_end_encoding(enc)
+        metal_release(enc)
+        encode_ms = double(get_time_usec(ts_enc)) / 1000.0lf
+        metal_commit(cb)
+        cbs |> push(cb)
     }
+    // completion + readback INTERLEAVE: chunks complete in commit order, and each completed
+    // chunk's roped-K/raw-V rows stream into the CPU KV codec while later chunks keep the GPU
+    // busy (unified memory — the memcpy is safe the moment the chunk reports complete). The
+    // residual-stream copy needs the LAST chunk and lands after the loop.
+    var ran = true
+    var gpu_t0 = 0.0lf
+    var gpu_t1 = 0.0lf
+    var readback_us = 0l
+    unsafe {
+        let store_nrun = kv_runs(s, start_pos, start_pos + npos, s.kv_runs)
+        let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
+        for (cbi, i in cbs, count()) {
+            metal_wait_until_completed(cbi)
+            let e = metal_command_buffer_error(cbi)
+            if (!empty(e)) {
+                ran = false
+                err = e
+            }
+            let t0 = metal_command_buffer_gpu_start_time(cbi)
+            let t1 = metal_command_buffer_gpu_end_time(cbi)
+            if (i == 0 || t0 < gpu_t0) {
+                gpu_t0 = t0
+            }
+            if (i == 0 || t1 > gpu_t1) {
+                gpu_t1 = t1
+            }
+            metal_release(cbi)
+            if (ran) {
+                let ts_rb = ref_time_ticks()
+                let l1 = min(int64(i + 1) * layers_per_cb, c.n_layers)
+                for (l in range64(int64(i) * layers_per_cb, l1)) {
+                    memcpy(reinterpret<void?>(addr(s.k_b[0])), metal_buffer_contents(bks[l]), int(npos * kv_dim * 4l))
+                    memcpy(reinterpret<void?>(addr(s.v_b[0])), metal_buffer_contents(bvs[l]), int(npos * kv_dim * 4l))
+                    kv_store_batch(kv_layer_kbase(s, l, c.seq_len), kv_layer_vbase(s, l, c.seq_len),
+                        s.kv_dtype_k, s.kv_dtype_v, s.k_b, s.v_b, runsp, store_nrun, start_pos, npos, kv_dim)
+                }
+                readback_us += int64(get_time_usec(ts_rb))
+            }
+        }
+    }
+    cbs |> clear()
+    unsafe {
+        delete cbs
+    }
+    gpu_ms = (gpu_t1 - gpu_t0) * 1000.0lf   // whole-GPU window: first chunk start -> last chunk end
     let encwait_us = get_time_usec(ts_enc)
     let ok = ran
-    var readback_us = 0
     if (ran) {
-        // unified-memory readback: final residual stream + per-layer roped-K/raw-V into the
-        // session KV cache (codec stays CPU-side — any KV dtype works)
         let ts_rb = ref_time_ticks()
         unsafe {
             memcpy(reinterpret<void?>(addr(s.x_b[0])), metal_buffer_contents(bx), int(npos * dim * 4l))
-            let store_nrun = kv_runs(s, start_pos, start_pos + npos, s.kv_runs)
-            let runsp = reinterpret<KVRun const?>(addr(s.kv_runs[0]))
-            for (l in range64(c.n_layers)) {
-                memcpy(reinterpret<void?>(addr(s.k_b[0])), metal_buffer_contents(bks[l]), int(npos * kv_dim * 4l))
-                memcpy(reinterpret<void?>(addr(s.v_b[0])), metal_buffer_contents(bvs[l]), int(npos * kv_dim * 4l))
-                kv_store_batch(kv_layer_kbase(s, l, c.seq_len), kv_layer_vbase(s, l, c.seq_len),
-                    s.kv_dtype_k, s.kv_dtype_v, s.k_b, s.v_b, runsp, store_nrun, start_pos, npos, kv_dim)
+            if (gpu_logits) {
+                memcpy(reinterpret<void?>(addr(s.logits[0])), metal_buffer_contents(blog), int(c.vocab_size * 4l))
             }
         }
-        readback_us = get_time_usec(ts_rb)
+        if (gpu_logits) {
+            prefill_override_logits_done()
+        }
+        readback_us += int64(get_time_usec(ts_rb))
         g_prefills++
     } else {
         to_log(LOG_ERROR, "dasLLAMA metal prefill: dispatch failed ({err}) — falling back to the CPU layer loop\n")
@@ -893,8 +1820,13 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     pool_release(g_pool, bxq, bytes_xq)
     pool_release(g_pool, bxs, bytes_xs)
     pool_release(g_pool, batt, bytes_att)
-    pool_release(g_pool, bcos, bytes_tab)
-    pool_release(g_pool, bsin, bytes_tab)
+    if (gpu_logits) {
+        pool_release(g_pool, bxf, uint64(dim * 4l))
+        pool_release(g_pool, blog, uint64(c.vocab_size * 4l))
+        pool_release(g_upool, u_vocab, 4ul)
+    }
+    pool_release(g_upool, bcos, bytes_tab)
+    pool_release(g_upool, bsin, bytes_tab)
     for (l in range64(c.n_layers)) {
         pool_release(g_pool, bks[l], bytes_kv)
         pool_release(g_pool, bvs[l], bytes_kv)
@@ -905,26 +1837,31 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         delete bks
         delete bvs
     }
-    pool_release(g_pool, u_dim, 4ul)
-    pool_release(g_pool, u_qd, 4ul)
-    pool_release(g_pool, u_kvd, 4ul)
-    pool_release(g_pool, u_hidden, 4ul)
-    pool_release(g_pool, u_hs, 4ul)
-    pool_release(g_pool, u_kvm, 4ul)
-    pool_release(g_pool, u_np, 4ul)
-    pool_release(g_pool, u_np32, 4ul)
-    pool_release(g_pool, u_nblk_dim, 4ul)
-    pool_release(g_pool, u_nblk_qd, 4ul)
-    pool_release(g_pool, u_nblk_h, 4ul)
-    pool_release(g_pool, u_npairs_q, 4ul)
-    pool_release(g_pool, u_npairs_k, 4ul)
-    pool_release(g_pool, u_total_dim, 4ul)
-    pool_release(g_pool, u_total_h, 4ul)
-    pool_release(g_pool, u_scale, 4ul)
-    pool_release(g_pool, u_eps, 4ul)
+    pool_release(g_upool, u_dim, 4ul)
+    pool_release(g_upool, u_qd, 4ul)
+    pool_release(g_upool, u_kvd, 4ul)
+    pool_release(g_upool, u_hidden, 4ul)
+    pool_release(g_upool, u_hs, 4ul)
+    pool_release(g_upool, u_kvm, 4ul)
+    pool_release(g_upool, u_np, 4ul)
+    pool_release(g_upool, u_np32, 4ul)
+    pool_release(g_upool, u_nblk_dim, 4ul)
+    pool_release(g_upool, u_nblk_qd, 4ul)
+    pool_release(g_upool, u_nblk_h, 4ul)
+    pool_release(g_upool, u_npairs_q, 4ul)
+    pool_release(g_upool, u_npairs_k, 4ul)
+    pool_release(g_upool, u_total_dim, 4ul)
+    pool_release(g_upool, u_total_h, 4ul)
+    pool_release(g_upool, u_scale, 4ul)
+    pool_release(g_upool, u_eps, 4ul)
+    pool_release(g_upool, u_addv0, 4ul)
+    pool_release(g_upool, u_addv1, 4ul)
+    pool_release(g_upool, u_npairs_all, 4ul)
     if (ok) {
         let total_us = get_time_usec(ts_all)
-        to_log(LOG_INFO, "dasLLAMA metal prefill: npos={npos} total={float(total_us) / 1000.0}ms setup={float(setup_us) / 1000.0}ms encode+wait={float(encwait_us) / 1000.0}ms (gpu {gpu_ms}ms) kv+readback={float(readback_us) / 1000.0}ms dispatches={21l * c.n_layers}\n")
+        let repack_note = g_repack_us > 0l ? " weight-repack={float(g_repack_us) / 1000.0}ms(one-time)" : ""
+        g_repack_us = 0l
+        to_log(LOG_INFO, "dasLLAMA metal prefill: npos={npos} gemm={mm ? "mulmm" : "q8"} total={float(total_us) / 1000.0}ms setup={float(setup_us) / 1000.0}ms encode+wait={float(encwait_us) / 1000.0}ms (encode {encode_ms}ms, gpu {gpu_ms}ms) kv+readback={float(readback_us) / 1000.0}ms dispatches={(fused ? 15l : mm ? 17l : 21l) * c.n_layers + (fused ? 1l : 0l) + (gpu_logits ? 2l : 0l)} logits={gpu_logits ? "gpu" : "cpu"}{repack_note}\n")
     }
     return ok
 }

--- a/modules/dasMetal/MASTERPLAN.md
+++ b/modules/dasMetal/MASTERPLAN.md
@@ -650,3 +650,337 @@ it once). Anchors (stored from the 2026-07-11 clean window, per the no-baseline-
 rule): llama.cpp CPU pp512 813 (das CPU 823 ✓ sane window); **llama.cpp full-Metal pp512 3960 —
 das GPU-resident is now 1.65x away** (hybrid clean was 3.75x, resident-with-old-kernel dirty
 2.5x). Clean best == the dirty single-shot (2395 vs 2398) — the box was quiet.
+
+**2026-07-13 — Phase 7 (session 1): llama-3B unlock + the overhead hunt — pp512 111 (CPU
+fallback) -> ~880-960 tok/s DIRTY; lcpp full-Metal 3B = 1402 (1.5-1.6x away).** The 3B
+(dim 3072, hs 128, 28L) now serves: MetalAttnQK walks head_size in 64-wide k-slabs through the
+same 32x64 staging tiles (hs=64 one slab bit-identical, 128 two; gate's hs<=64 dropped;
+hs=128 unit arm + 1B parity green). Overhead work, measured by the new encode-vs-gpu split
+(with_compute_encoder_timed 4-out overload; encode is ~0.15ms = FREE): (1) weight region
+buffers HAZARD-UNTRACKED (new metal_new_buffer_untracked extern) — the scheduler's
+per-resource analysis over ~450 tracked weights was the dominant slack, 72 -> 32ms on its
+first read (876 -> 962 t/s), though later reps put the slack band at ~50-70ms (box wobble;
+re-read on a clean window); (2) uniforms + rope tables moved to an UNTRACKED pool
+(pool_acquire_untracked) — measured NO-OP on top of (1); the residual commit-to-done slack is
+NOT per-resource analysis; (3) fused dispatch set 21 -> 15/layer (metal_add_rms_quant folds
+the pending residual add into the next norm with a threadgroup row stage — dim <= 3072 gates
+it; metal_swiglu_quant recomputes silu on the quant pass, gate never written back;
+metal_rope_qk one grid) — interleaved ABBA says NEUTRAL (the "ew = launch gaps" hypothesis was
+WRONG — Metal pipelines back-to-back dispatches; the ew bucket is real kernel time and the
+fused rms+quant's 12KB tg stage gives the saving back in occupancy); kept for the smaller
+graph; DASLLAMA_METAL_FUSE=0 is the A/B rail. GEMM kernel round 2 (lab, 3B shapes kv3b/q3b/
+w13_3b/w2_3b added): **three structural variants ALL LOST to v13** — v18 32-elem runs (-1%),
+v19 row-major-B + transposed sgload + tg_store_half4 (-1.3%; the two NEW emitter constructs —
+simdgroup_load transpose-flag overload and tg_store_half4 — are GPU-validated bit-exact and
+stay as surface), v20 device-direct f16 B panels (-6-9%; strided transposed device loads beat
+by staging). v13 (run-staging + 64x64) holds a ~3480-3590 GMAC/s plateau vs the staging-
+removed ceiling 4600-4950 at 3B shapes; lcpp's implied kernel rate ~4400-4500 (from their own
+1B/3B walls). 3B GPU budget: gemm ~415ms, attn ~25, ew ~28; slack ~50-70; readback ~14.
+**Parity ledger (needs BOTH):** kernel 3590 -> ~4400 (next ideas: faithful ggml
+kernel_mul_mm geometry port — 64x32, 2x4 sg layout, their exact staging shape — as a lab
+variant; simdgroup async device->tg copies; f16-accumulate risk analysis) AND the ~90ms
+non-GEMM tail -> ~35 (next: commit-to-done slack attribution beyond resource tracking —
+retainedReferences=NO, split command buffers, concurrent encoder + coarse barriers; attention
+f16; readback overlap). (Labeled DIRTY when logged; Boris 2026-07-13: Parsec was OFF for
+these windows — treat the numbers as clean. The ~50-70ms slack band variance is real
+box-side variance, not Parsec.)
+
+**2026-07-13 — Phase 7 (session 2): llama.cpp's kernel VERBATIM in the lab — their geometry is
+worth +16-21% over our best, measured head-to-head.** `kernel_mul_mm_q8_0_f32` (classic
+simdgroup path, ggml @ ebd048f) now runs as lab variant `lcpp_mulmm` — byte-verbatim MSL
+(`benchmarks/matmul/_lcpp_mul_mm_q8.das`, function constants baked to their same-shape
+specialization), on their own production contract: interleaved block_q8_0 blobs, RAW F32
+activations (4x our activation bytes — they still win), kargs struct, 6144 B dynamic tg
+scratch via new `metal_set_threadgroup_memory_length` extern. Bit-exact vs v0 on all 9 shapes.
+M1 Max, ntok=512, CLEAN window (Parsec off — Boris), interleaved best-of-3 (GMAC/s):
+
+| shape | v0_prod32 | v0b_prod64 | lcpp_mulmm | lcpp vs our best |
+|---|---|---|---|---|
+| kv 2048x512 | 2742 | 2516 | 3330 | 1.21x |
+| q 2048x2048 | 2932 | 3345 | 4001 | 1.20x |
+| w13 2048x8192 | 3004 | 3595 | 4180 | 1.16x |
+| w2 8192x2048 | 2958 | 3393 | 4074 | 1.20x |
+| cls 2048x128256 | 3024 | 3648 | 4245 | 1.16x |
+| kv3b 3072x1024 | 2854 | 3220 | 3884 | 1.21x |
+| q3b 3072x3072 | 2969 | 3463 | 4105 | 1.19x |
+| w13_3b 3072x8192 | 3008 | 3573 | 4199 | 1.18x |
+| w2_3b 8192x3072 | 2984 | 3485 | 4134 | 1.19x |
+
+These are clean numbers: lcpp's real kernel rate on M1 Max is ~3900-4250 GMAC/s — slightly
+BELOW the ~4400-4500 implied-from-their-walls estimate, so the kernel gap to close is
+1.16-1.21x, not 1.25x+. Settles the Phase-7 kernel question: the gap is their 64x32 tile +
+2x4 sg layout + tile-major 8x8
+shared blocks + dequant-to-registers-then-scatter staging, not their data format (they pay
+MORE device traffic). Next lever: port that geometry faithfully as a das lab variant (the
+masterplan's step-2 idea, now de-risked — the win is proven in OUR harness, not inferred from
+their walls). Repro: `DASMETAL_LAB_VARIANTS=v0_prod32,v0b_prod64,lcpp_mulmm bin/daslang -jit
+dastest/dastest.das -- --bench --test modules/dasLLAMA/benchmarks/matmul/bench_metal_gemm_kernels.das`.
+
+**2026-07-13 — Phase 7 (session 2b): the ggml geometry port (v21) + the attribution ledger —
++19% over v0_prod32, beats BOTH production kernels, still 13-19% behind verbatim.**
+`v21_ggmlgeo` (+`v21sct` scale-transpose flavor): ggml's exact geometry on our planar contract
+— 64-output x 32-token tile, tile-major 8x8 shared blocks (every sgload = one contiguous
+64-half run), W transposed within tiles at staging, byte4 device loads to registers before the
+pre-staging barrier, fully-unrolled math (4 slabs x 6 loads + 8 macs), 2D grid tokens-fast,
+tg_store_half4 B stores. Bit-exact. CLEAN M1 Max (GMAC/s): kv 2948 / q 3474 / w13 3633 / w2
+3512 / cls 3684 / kv3b 3268 / q3b 3555 / w13_3b 3639 / w2_3b 3577 — beats v0b_prod64 on every
+shape (+1-4% big, and it WINS the kv shapes where v0b loses to v0_prod32, so one kernel could
+replace both + the gemm_use64 heuristic). Verbatim lcpp still +13-19% ahead. **Attribution
+(q3b, knockouts + string-surgery on the verbatim source):** total gap 0.186 ms/dispatch =
+math-loop codegen ~0.045 (their staging-stripped ceiling 4936 vs v21's 4719 GMAC/s) + staging
+~0.144 (theirs 0.197 vs ours 0.341). Within staging: dequant multiplies + dependency chain
+~0.076 (scales-baked-to-1.0 probe), B int-dequant ~0.024 (f32-activation-panel probe v21f32x:
+their B contract reads raw f32 — no dequant at all), residual staging codegen ~0.044. RULED
+OUT by measurement: simdgroup_barrier(mem_none) hints (lcpp_nosgbar identical), rasterization
+order (2D grid no change), scale-stream cacheline scatter (v21sct [block][row] transpose
++0.4%). **Upshot: the remaining lcpp edge is their DATA CONTRACT (f32 activations, inline
+scales) plus better-scheduled staging/math MSL — no single structural lever left on the planar
+format.** Production fork to decide: (A) adopt their contract for GPU prefill — one-time W
+repack to interleaved blobs at region-cache upload + feed f32 activations directly (also
+deletes the X-quant dispatches from the graph) → the lab-proven 4000-4250 rate; (B) ship v21
+as the planar harvest (+2-4% big shapes, kv fix, kernel unification) and put the effort into
+the ~90ms non-GEMM tail; (C) f32-X feed only (cheap, +2%, kills quant dispatches). All probe
+variants live in the lab (lcpp_nosgbar/lcpp_nostage/vk21_*/v21f32x/v21sct).
+
+**2026-07-13 — Phase 7 (session 2c): Option A SHIPPED — verbatim mul_mm + blob repack + f32-X
+in the resident prefill. 3B pp512 850 -> 1053 t/s (+24%); gap to lcpp 1402 now 1.33x.** Boris
+picked (A). First tried the das-native blob kernel (lab v22_blob36: das-friendly 36B blocks,
+f32 scale + byte4-aligned quants, two typed views of one buffer) — 3623 GMAC/s, only +2.3%
+over v21: the residual ~13% vs verbatim is emitter/MSL codegen, not format. So production runs
+the VERBATIM kernel: `dasllama/dasllama_lcpp_mulmm.das` (moved from the bench fixture, in
+.das_module), compiled alongside the kernel set. Driver (dasllama_metal_prefill.das):
+`upload_blob_region` lazily repacks each (quants, scales) weight region into resident
+block_q8_0 blobs — one-time CPU pass, 235ms 1B / 686ms 3B, f32->f16 scale exact for
+GGUF-q8_0-sourced weights; `uniform_mm_args` pooled 88-byte kargs images; `enc_gemm_lcpp`
+(kargs/blob/f32-X/dst, 6144B dynamic tg scratch, grid (mp/32, d/64) x (32,4,1)); mode gate
+`lcppmm` = default when every GEMM output dim % 64 == 0 (bc_out=false specialization), rails:
+`DASLLAMA_METAL_MULMM=0` env + `set_metal_prefill_mulmm_legacy()` setter. The lcpp path runs
+the UNFUSED elementwise set minus ALL X-quant dispatches (17/layer; rms/swiglu feed f32
+straight to mul_mm). Legacy quantized path fully preserved (donor/batch path untouched).
+Gates: mulmm_gate unit (verbatim PSO on exact-arithmetic blob W x f32 X vs CPU ref, BIT-exact,
+2 shapes — also the kargs layout oracle), parity test now runs BOTH modes — 40-token greedy
+matches the CPU control EXACTLY on the f32-X path too (counting-prompt family robust as
+designed), leak gates green. E2E A/B (clean, same binary, 3B): N=256 748.9 -> 899.4 t/s,
+N=512 849.8 -> 1053.0 t/s (GPU 508 -> 396 ms, -22%); 1B parity-run GPU 150.9 -> 116.9 ms
+(-22.5%). NEXT: the ~80ms non-GEMM tail (slack attribution / split command buffers /
+retainedReferences; f16 attention; readback overlap) — at gpu=396ms the tail is now ~17% of
+total; then the das-emitter codegen chase to retire the verbatim kernel (ledger: math-loop
+scheduling ~4.5%, staging codegen ~0.04ms/dispatch).
+
+**2026-07-13 — Phase 7 (session 2d): the tail is DEAD — chunked command buffers + interleaved
+KV readback. 3B pp512 1053 -> 1219.6 t/s (+16%); gap to lcpp 1402 now 1.15x.**
+metal_prefill_forward now splits the layer loop across N command buffers (default ~4
+layers/chunk = 7 on the 3B; DASLLAMA_METAL_NCB overrides, =1 restores single-buffer), each
+committed the moment it finishes encoding — the scheduler analyzes chunk k while chunk k-1
+executes (same-queue commit order + hazard tracking on the activation buffers carries
+cross-chunk ordering; untracked weights/uniforms are CPU-written before their chunk commits).
+Measured (3B pp512): slack 57ms -> 9ms, 1069 -> 1176 t/s. Then completion+readback
+interleave: wait per chunk in commit order, stream that chunk's K/V rows into the CPU KV
+codec while later chunks run — the 13ms store cost disappears inside the GPU window; residual
+stream copies after the last chunk. 1176 -> 1219.6 t/s; total-minus-GPU-window is now ~11ms
+(was ~80). Bonus: the one-time blob repack ALSO overlaps (encode of later chunks proceeds
+while earlier chunks execute — 1B first-prefill total 277ms w/ 242ms repack inside), and the
+legacy q8 path gains equally (1B GPU-run total 243 -> 173ms). RULED OUT by measurement:
+commandBufferWithUnretainedReferences (new extern metal_new_command_buffer_unretained, rail
+DASLLAMA_METAL_UNRETAINED=1) — neutral at every chunk count, kept as surface. Gates: parity
+BOTH modes green on the chunked driver, mulmm unit, donor gemm, leak gates. **Remaining vs
+lcpp 1402: the 398ms GPU window itself** — gemm ~343 (verbatim-rate; emitter chase is the
+lever), attn ~25 (f16 candidate), ew ~28.
+
+**2026-07-13 — Phase 7 (session 3): ggml-geometry attention pair — 3B pp512 1220 -> 1251 t/s;
+we now beat llama.cpp's fa=0 wall.** Window re-attribution first (new attn_qk/attn_sm/attn_av
+sub-skip rails): gemm ~350 / attn 28 (QK 14.2 + AV 10.2 + softmax 3.2) / ew only ~9 (the
+quant deletions already took the old 28ms bucket). llama-bench 3B: fa=0 1350.5, fa=1 1391.4
+— their OWN flash attention nets +3%, and their fa=0 attention is mul_mm + masked softmax =
+exactly our structure, so the trio's kernels were the outlier (32x32 C tiles, scalar f32
+staging, the pre-run-staging style — ~60x below mul_mm rate). Rewrote QK/AV with the v21
+lessons (MetalAttnQKMm/MetalAttnAVMm): 32x64 C tiles, tile-major 8x8 shared blocks staged
+HALF via float4 loads (lcpp's f32_f32 mul_mm stages half from f32 too), 2x4 sg quadrants,
+unrolled math, per-head z grid, QK causal block early-exit, AV causal k-limit, V pad rows
+zeroed at staging (0*NaN guard); K pads need NO guard (their scores land in columns the
+causal softmax zeroes). Softmax unchanged. Default at head_size % 64 == 0; rail
+DASLLAMA_METAL_ATTN=0 pins the trio (also serves other hs). Attention 28 -> 14.2ms
+(QK 5.2 + AV 6.3 + softmax 3.5); GPU window ~374ms; our wall 376ms vs their fa=0 379ms.
+Gates: causal-GQA oracle hs64-GQA2 + hs128-GQA3 within the half-staging envelope (2e-2 —
+the honest envelope of half-staged scores through softmax, same as lcpp's), parity 40/40
+exact both modes. Framing re-measured same-run: ~10ms (logits 3.7 + embed 0.7 + alloc ~5),
+NOT the 33ms cross-run wobble suggested. GEMM chain check: 1.44 TMAC / 343ms = 4190 GMAC/s =
+AT the verbatim kernel's lab rate — that bucket is done. **NEXT (the one big lever left):
+verbatim lcpp kernel_flash_attn_ext port — collapses QK+softmax+AV (~14 -> ~6ms, +2.5-3%)
+AND kills the heads x np32^2 score slab (the g_max_npos=2048 cap). Needs their KV-dtype
+contract read first (f16 K/V vs our f32 buffers). Micro ledger: softmax restructure ~2ms,
+logits-on-GPU ~3ms, prefill alloc caching ~5ms.**
+
+**2026-07-13 — Phase 7 (session 4): verbatim flash-attn ported — CORRECT but LOSES to the trio,
+kept as an opt-in rail.** New module `dasllama/dasllama_lcpp_flash_attn.das` = `kernel_flash_attn_ext`
++ `_blk` brought VERBATIM (byte round-trip-diffed; 33 KB MSL das-escaped) with three mechanical
+deviations (baked `constant` function-constants for our fixed specialization: causal mask, no
+bias/sinks/softcap, has_kvpad=false, nsg=4; NS10/NS20 from args so one entry pair serves every
+kv_dim; f32 AND f16 KV entries for dk64/dk128), plus one non-lcpp `metal_fa_causal_mask` kernel
+(ggml builds KQ_mask host-side). KEY layout fact: lcpp's KV-pad kernel assumes ggml's per-head-
+contiguous KV (nb11=head_size); OURS is interleaved [token][kv_head][d] (nb11=kv_dim), so the pad
+kernel is unusable — instead ne11=mp (64-padded => has_kvpad=false) + the causal mask covers the pad
+columns [npos,mp). V pad rows are safe (the mul_mm GEMM writes ALL mp rows finite => 0*finite=0). The
+flash impl is otherwise stride-generic so our strides drop straight into nb11/nb12/ns10; GQA via
+ne_12_2=n_kv_heads; ne1=n_heads lands dst in our [token][head][d] bxb. CORRECTNESS (both KV dtypes):
+1B parity exact vs CPU control; 3B (hs128) token-for-token vs the trio. **PERF (2 clean Parsec-off
+same-session A/B, flash-MINUS-trio delta rock-consistent): flash attention costs ~3ms MORE than the
+ggml-geometry trio — f32 KV +3.3ms (13.9 vs 10.6), f16 KV +3.1ms (17.4 vs 14.3).** f16 KV (lcpp's
+contract, via a per-layer f32->f16 pack) did NOT help — the pack overhead (56 dispatches + KV
+bandwidth) cancels the f16 kernel's bandwidth saving. WHY flash loses: the trio already runs QK/AV as
+mul_mm-rate GEMMs (session 3, 4190 GMAC/s) + causal skips, so the score-slab device round-trip flash
+eliminates is NOT the bottleneck (M1 Max bandwidth ample); meanwhile flash RE-READS K/V once per
+query block (~32x after the causal skip vs the trio's 1x), costing more than the fusion saves. lcpp's
+fa=1 +3% over fa=0 comes from their WHOLE f16 pipeline, not graftable via a KV-only pack. DECISION
+(Boris): keep the trio as default; flash is an OPT-IN rail (`DASLLAMA_METAL_FLASH=1`, KV dtype via
+`DASLLAMA_METAL_FLASH_KV=f16|f32`) with lazy pipeline compile (default never pays the 33 KB compile).
+Residual flash value = drops the heads x mp^2 score slab (memory) => a future lever to lift
+g_max_npos for long-context prefill. **NEXT: das-emitter codegen chase (retire the verbatim mul_mm),
+logits-on-GPU ~3ms, prefill-alloc caching ~5ms. Then PR the arc (preflight --full).**
+
+**2026-07-13 — Phase 7 (session 5): the emitter codegen chase — das kernel from 87% to ~98% of
+verbatim; the gap was REGISTER PRESSURE from frontend-unrolled statements.** Method: AIR-level
+IR diff (new Metal offline toolchain, `xcrun metal -S -emit-llvm`) + the new occupancy
+introspection externs (`metal_pipeline_max_total_threads` / `_thread_execution_width`, printed
+per variant by the lab) + hand-MSL morph probes bisected one spelling at a time. ROOT CAUSE:
+the das emitter's hand-unrolled statement blocks reach LLVM as one giant SSA body; LLVM hoists
+every loop-invariant tile address (~42 pointers: 16 A-store + 2 B-store + 24 sgmat-load) into
+long-lived registers -> max_threads 1024 -> 832 (an occupancy tier) -> flat -13% vs the verbatim
+lcpp kernel on every shape. llama.cpp's kernel keeps its loops ROLLED with
+`_Pragma("clang loop unroll(full)")` + two bumped tile POINTERS; the AGX backend unrolls late,
+register-budget-aware. Bisect verdicts (all on the 34B-blob contract, bit-exact, interleaved):
+34B-blob/byte loads on the OLD unrolled shape = neutral (v23); rolled math = +10-11% and 1024
+back (v24_roll); rolled A-staging = neutral; device-pointer k-loop bumps = -1%; vectorized
+half2x4 B move = -1%; ushort prologue = -1%; int-vs-short loop vars = FREE; index-form tile
+addressing (`aB + ik*512`) REGRESSES to 896/-12% even inside pragma'd loops (v24h1, kept in lab
+as the negative control) — the load operand must be a loop-carried POINTER; A-staging via a
+hoisted device pointer = the last +1.5%. SHIPPED (emitter + builtins, pure das, no C++ rebuild
+for the das half): `unroll_range(n)` (rolled-with-pragma for; const bound), fixed-array locals
+(scalar `half va[16] = {};` + sgmat arrays w/ pragma'd zero-fill loops), indexed sgmat args
+(`mc[i]`), `tg_cursor(member, base)` / `dev_cursor(member, base)` (CPU = plain uint offset;
+MSL = threadgroup/device const pointer local; sgmat-load offsets and element reads led by a
+cursor lower through the pointer; advance = `cur += N`). New dasMetal externs (dasMetal.mm):
+pipeline occupancy introspection (the register-pressure oracle — a reg-limited PSO reports
+max_threads < 1024). Tests: tests/msl census +8 tags + SgMatRolled fixture + golden (73/73);
+tests/metal test_metal_sgmat_rolled GPU-vs-CPU bit-exact (36/36). Lab: `v25_das_rolled` = the
+das-AUTHORED kernel on the production 34B contract — q3b 4028 / w13_3b 4112 / w2_3b 4034 GMAC/s
+= 97.6-98.6% of verbatim (4101/4201/4132), == the hand-MSL v24g reference, +11-12% over v22.
+One-shot morph probes pruned post-verdict; v22/v23/v24_roll/v24g/v24h1/v25 kept as the
+reproducible A/B family. PRODUCTION CALL (for PR review): verbatim stays the default GEMM —
+the last ~2% is AGX-backend scheduling even hand-MSL in the same shape can't reach, and ~2%
+GEMM ~= ~1% pp512 = the margin by which das beats lcpp fa=0. The das v25 kernel + constructs
+are the retirement PATH once the last 2% closes (ISA-level chase, priced separately).
+**NEXT: logits-on-GPU ~3ms, prefill-alloc caching ~5ms. Then PR the arc (preflight --full).**
+
+**2026-07-13 — Phase 7 (session 5b): logits-on-GPU — 3B pp512 -5.5ms (interleaved, rock-steady
+across 5 rounds: 377.3 vs 382.9 ms/prefill, ~+1.5%).** The final rmsnorm (one row, bx bound at
+the last position's byte offset into the existing rms PSO) + a new classifier GEMV kernel
+(`metal_q8_gemv`: one simdgroup per output row, lanes stride byte4s, 4-blocks-in-flight unroll —
+the rolled x1 form measured only ~140 GB/s; per-byte4 scale product, simd_sum reduce, row < ddim
+tail guard) ride the END of the last command buffer; s.logits reads back with the residual copy.
+The saving EXCEEDS the ~3.7ms CPU logits it replaces because the GEMV overlaps the interleaved
+KV-readback tail instead of serializing after the wait. Contract: the override calls the new
+`prefill_override_logits_done()` (dasllama_common) after filling s.logits; forward_prefill_body
+then skips its CPU final-norm/classifier step. Gates mirror the CPU q8 `mm` branch only — softcap,
+suppressed-token pins, non-q8 / tied-f32 classifiers decline to the CPU step (semantics preserved
+by construction). Cls weights ride the existing upload_region cache (tied-q8 = the embedding
+region, one-time). Rails: `DASLLAMA_METAL_LOGITS=0` env + `set_metal_prefill_logits_cpu()` (the
+in-process A/B setter). Tests: gemv_gate x2 shapes in test_metal_prefill_kernels (exact-arithmetic
+BIT-exact, incl. the guarded-tail grid), 1B parity token-for-token with GPU logits active, leak
+gates green. Attribution rail: g_skip modes keep logits OFF so knockout deltas stay comparable.
+**NEXT: prefill-alloc caching ~5ms. Then PR the arc (preflight --full).**
+
+**2026-07-13 — Phase 7 (session 5c): prefill scratch alloc — framing 5.7ms -> 1.1ms.** The
+"alloc 5ms" was forward_prefill_alloc's batched-scratch GROWTH cost on the first prefill at a
+new npos (~70 MB across 10 arrays at 512 rows): das `resize` zero-fills the grown span AND the
+realloc copies the old block. Both are pure waste here — the scratch is stage output, fully
+written before any read. Fix = `scratch_resize` (dasllama_common): grow-only, contents-
+DISCARDING (`delete` on grow skips the realloc's old-block copy), `resize_no_init` (skips the
+zero-fill). Measured (3B pp512, per-bucket profile): alloc 4969us -> 55us; embed +0.2ms
+(absorbs the first-touch page faults); framing TOTAL 5728 -> 1075us. A new `alloc` prof bucket
+makes the cost visible in every profile run. Exotic scratch (ple/deltanet/att_b/fa_*) stays on
+zeroing resize — only the 10 always-fully-written arrays switch. Gate: full tests/dasLLAMA
+suite (model oracles token-for-token).
+**NEXT: PR the arc — preflight --full + clean Parsec-off measurement round (announce, wait for go).**
+
+**2026-07-13 — Phase 7 CLEAN MEASUREMENT ROUND (Parsec off, Boris-confirmed window, best-of-3
+process-fresh prefill_perf runs + one interleaved lab sweep).** llama-3.2-3B pp512: **1300.5 t/s
+best** (median 1256; GPU window 375.4-378.9 ms, tight; e2e spread is commit-wait slack 15-35 ms);
+pp256 best 1256. Anchors: lcpp -ngl 99 fa=1 = 1402 (0.93x), fa=0 = ~1351 (0.96x) — GPU-window-vs-
+GPU-window we hold the session-3 fa=0 win (375-379 vs their 379). llama-3.2-1B pp512: **3467 t/s
+best** (median 3440; GPU 137.1-138.4 ms); pp256 best 3173; lcpp full-Metal anchor 3960 (0.88x) —
+vs Phase-6's 1054 clean hybrid = 3.3x across Phase 7. Lab GEMM (GMAC/s, das v25 vs verbatim lcpp):
+kv 3197/3326, q 3959/3999, w13 4099/4184, w2 4010/4069, cls 4161/4245, kv3b 3898/3890 (das WINS),
+q3b 4028/4102, w13_3b 4115/4200, w2_3b 4047/4132 — the das-authored kernel at 96-100% of verbatim
+everywhere, >= the hand-MSL v24g reference on most shapes. NOTE: 1B GPU window vs session 2c's
+dirty 116.9 ms is not comparable — the chunked driver's window now spans first-chunk-start to
+last-chunk-end (includes inter-chunk gaps) and sessions 3-5 added the attention pair + logits
+dispatches; the t/s headline is the honest cross-session metric.
+
+**2026-07-13 — Phase 7 REWORK step 1 (PR #3456 closed for redesign): `unroll_range` deleted,
+loop hints ride das's existing `for [hint] (...)` annotation surface.** Boris's call: the
+iterator-function spelling was a construct where the language already had the right one —
+`ExprFor/ExprWhile.annotations` (the per-loop hint list the JIT lowers to !llvm.loop.*
+metadata). The emitter now lowers the SAME vocabulary to clang loop pragmas: `[unroll]` ->
+unroll(enable), `[unroll_full]` -> unroll(full), `[unroll_disable]` -> unroll(disable),
+`[unroll_count=N]` -> unroll_count(N); unknown hints fail closed. Works on `for` and `while`.
+Kernels/fixtures rewritten to `for [unroll_full] (i in range(N))`; emitted MSL is byte-identical
+(msl goldens unchanged, 73/73). One spelling, per-backend lowering — CPU JIT gets LLVM metadata,
+Metal gets pragmas, interp ignores. REMAINING REWORK (design session): tg_cursor/dev_cursor —
+likely emitter-automatic LSR so natural source gets the pointer form; then das GEMM as default.
+
+**2026-07-13 — Phase 7 REWORK step 2: @workgroup -> dynamic shmem lowering — the das GEMM now
+BEATS verbatim llama.cpp on every shape.** The ISA rail (applegpu + MTLBinaryArchive harvest;
+`compiler_explorer.py` flow, MCT_MAX_THREADS env patch) settled the residual ~2%: registers a
+wash (r49/r50), heavy work identical, the whole gap = integer address materialization (40 vs 24
+iadd/iter, 23 of ours inside the fmadd-bound math phase vs their 5). Nulls along the way:
+pipeline-descriptor knobs (maxTotalThreads=128 + multiple-of-width — byte-identical ISA),
+unsigned-vs-signed offsets (identical), loop-carried device cursors (44->40 only). ROOT CAUSE:
+STATIC `threadgroup T name[N]` arrays — the AGX backend constant-folds carried tile pointers
+into their absolute addresses and the large offsets exceed the load immediate field; an opaque
+dynamic [[threadgroup(0)]] base keeps small carried offsets (loop 185 -> 156 instructions,
+SHORTER than verbatim's 165). Emitter change: @workgroup members lower to ONE dynamic
+threadgroup(0) param + derived pointers (scalars deref a derived pointer), name-sorted
+16B-aligned layout, total published as the `_tgmem` companion; `run_compute_1d` takes it,
+drivers pass it per dispatch. Every wg-bearing kernel inherits the codegen with zero source
+changes. Lab (interleaved, bit-exact): das v25 4128-4292 GMAC/s vs verbatim 4002-4201 —
+**+2.2-3.2% on all six big shapes**; emitted == hand morph exactly. Parity token-for-token.
+**NEXT: swap the production GEMM default to the das kernel (retiring the 33KB verbatim MSL to a
+rail), re-run the clean round, reopen the PR.**
+
+**2026-07-13 — Phase 7 REWORK step 3 (Boris's call: "get rid of abstraction — das is das is
+das"): tg_cursor/dev_cursor DELETED; the pointer form is spelled as a real das pointer.** The
+post-shmem re-measure proved BOTH spellings still matter (index-form math = max_threads 896,
+-10%, even on dynamic shmem), so the choice must stay visible in source. New spelling — plain
+das: `var p = unsafe(addr(member[expr]))` declares a pointer into a kernel member (emitter
+recognizes ExprRef2Ptr(ExprAt(member, idx)) by SHAPE, no magic names; address space from the
+member: @workgroup -> `threadgroup T *`, read-only @ssbo -> `device const T *`, written ->
+`device T *`); reads are das pointer indexing `unsafe(p[i])` (generic ExprAt emission);
+advance is das pointer arithmetic `p = unsafe(p + n)` (the i_das_ptr_add intrinsic lowers to
+element-scaled MSL pointer addition); a pointer is accepted as a simdgroup_load source (loads
+only — pointer stores fail closed). CPU semantics are das's REAL pointer semantics — the
+reference bodies walk actual memory (the simdgroup_load builtin bodies gained `unsafe()` on
+their indexing for pointer instantiations). Index form stays the safe spelling; pointer form
+is explicitly unsafe — exactly das's own contract. v25 + fixtures rewritten; emitted MSL and
+rates identical to the cursor world (v25 4133/4277 GMAC/s == v26, > verbatim's 3996/4184).
+Census: decl.ptr.tg/dev, op.ptr_add, call.sgmat_load_ptr.f16 (cursor tags gone).
+
+**2026-07-13 — Phase 7 REWORK step 4: the das mul_mm IS the production GEMM; verbatim + flash
+plumbing out of the driver; lessons swept across the kernel set (clean Parsec-off round).**
+Production: new `MetalQ8MulMm` (`metal_q8_mulmm_msl`) — the v25 shape on the driver's existing
+34B q8-block repack (GGUF q8_0's own layout), bindings blob x2 (half-scale/byte views) + f32 X
++ y + kdim/ndim; `enc_gemm_mm` replaces the verbatim dispatch at all five GEMM sites; the flash
+opt-in rail (verbatim lcpp MSL) is DELETED from the driver along with the kargs plumbing (rail
+findings preserved here as prose). The lab's v25 variant now references the production
+companions (zero copy drift, like v0). Lessons sweep via the new
+`benchmarks/matmul/occupancy_report.das` (permanent tool — run after any kernel change):
+found attn_qk_mm/attn_av_mm at 704 (the hot pair!) and q8_gemm64 at 704, everything else 1024.
+Rolled rework (matrix arrays + [unroll_full] + das-pointer tile bumps + QK staging via a
+register array): attention pair 704 -> 896 (residual = f32 source values live across the
+staging barrier; diminishing returns), gemm64 rolled but stays 704 — 16 accumulators = 32
+regs/lane of C is that geometry's floor (off the resident default path; the batch donor's
+call). CLEAN ROUND (best-of-3, process-fresh): 3B pp512 GPU window **367.5-372.0 ms** (was
+375.4-378.9 pre-swap) — **matches llama.cpp's fa=1 best mode (368 ms) head-on**; e2e best
+1299.3 t/s, median 1287.5 (spread = commit-wait slack). Parity token-for-token; all gates
+green. NEXT: pre-PR scrub (delete both verbatim modules + lab lcpp variants, squash to one
+fresh commit off origin/master, delete the old remote branch) -> final clean round -> reopen PR.

--- a/modules/dasMetal/metal/das_metal_boost.das
+++ b/modules/dasMetal/metal/das_metal_boost.das
@@ -44,12 +44,15 @@ def public pipeline_from_source(dev : MetalDevice?; source, entry : string; fast
 //! One 1D dispatch: encode pipeline + buffers (bound to [[buffer(0..N-1)]] in array order),
 //! dispatch ceil(threads/threads_per_group) threadgroups, commit, wait. Returns false with
 //! `error` filled when the command buffer reports a GPU-side failure.
-def public run_compute_1d(queue : MetalCommandQueue?; pso : MetalComputePipeline?; buffers : array<MetalBuffer?>; threads, threads_per_group : uint; var error : string&) : bool {
+def public run_compute_1d(queue : MetalCommandQueue?; pso : MetalComputePipeline?; buffers : array<MetalBuffer?>; threads, threads_per_group : uint; var error : string&; tgmem : uint64 = 0ul) : bool {
     let cb = metal_new_command_buffer(queue)
     let enc = metal_new_compute_encoder(cb)
     metal_set_pipeline(enc, pso)
     for (buf, index in buffers, range(length(buffers))) {
         metal_set_buffer(enc, buf, 0ul, index)
+    }
+    if (tgmem > 0ul) {
+        metal_set_threadgroup_memory_length(enc, tgmem, 0)
     }
     let groups = (threads + threads_per_group - 1u) / threads_per_group
     metal_dispatch_threadgroups(enc, uint3(groups, 1u, 1u), uint3(threads_per_group, 1u, 1u))
@@ -132,6 +135,20 @@ def public pool_acquire(var pool : MetalBufferPool; dev : MetalDevice?; bytes : 
     return metal_new_buffer(dev, bucket)
 }
 
+//! The UNTRACKED-pool twin, for GPU-read-only pool data the CPU fills before commit (uniforms,
+//! lookup tables): skips the command-buffer scheduler's per-resource hazard analysis. Keep a
+//! SEPARATE MetalBufferPool for these — tracked and untracked buffers must not mix in one pool.
+def public pool_acquire_untracked(var pool : MetalBufferPool; dev : MetalDevice?; bytes : uint64) : MetalBuffer? {
+    let bucket = pool_bucket(bytes)
+    var lst & = unsafe(pool.free_bufs[bucket])
+    if (!empty(lst)) {
+        var buf = lst[length(lst) - 1]
+        lst |> pop()
+        return buf
+    }
+    return metal_new_buffer_untracked(dev, bucket)
+}
+
 def public pool_release(var pool : MetalBufferPool; var buf : MetalBuffer?; bytes : uint64) {
     pool.free_bufs[pool_bucket(bytes)] |> push(buf)
 }
@@ -161,10 +178,19 @@ def public with_compute_encoder(queue : MetalCommandQueue?; var error : string&;
 //! GPUStartTime, milliseconds) — the honest GPU-busy number, as opposed to the host wall time
 //! around commit+wait which folds in scheduling and readback.
 def public with_compute_encoder_timed(queue : MetalCommandQueue?; var error : string&; var gpu_ms : double&; blk : block<(enc : MetalComputeEncoder?) : void>) : bool {
+    var encode_ms = 0.0lf
+    return with_compute_encoder_timed(queue, error, gpu_ms, encode_ms, blk)
+}
+
+//! The 4-out twin: also reports the host-side ENCODE time (block entry to commit) — the
+//! encode-CPU vs GPU-window split that attributes command-buffer overhead.
+def public with_compute_encoder_timed(queue : MetalCommandQueue?; var error : string&; var gpu_ms : double&; var encode_ms : double&; blk : block<(enc : MetalComputeEncoder?) : void>) : bool {
     let cb = metal_new_command_buffer(queue)
     let enc = metal_new_compute_encoder(cb)
+    let ts_enc = ref_time_ticks()
     invoke(blk, enc)
     metal_end_encoding(enc)
+    encode_ms = double(get_time_usec(ts_enc)) / 1000.0lf
     metal_commit(cb)
     metal_wait_until_completed(cb)
     error = metal_command_buffer_error(cb)

--- a/modules/dasMetal/metal/das_metal_boost.das
+++ b/modules/dasMetal/metal/das_metal_boost.das
@@ -182,8 +182,9 @@ def public with_compute_encoder_timed(queue : MetalCommandQueue?; var error : st
     return with_compute_encoder_timed(queue, error, gpu_ms, encode_ms, blk)
 }
 
-//! The 4-out twin: also reports the host-side ENCODE time (block entry to commit) — the
-//! encode-CPU vs GPU-window split that attributes command-buffer overhead.
+//! The 4-out twin: also reports the host-side ENCODE time — the CPU cost of building the command
+//! buffer, measured from block entry through end_encoding (captured just before commit) — for the
+//! encode-CPU vs GPU-window split. The metal_commit hand-off itself falls in neither number.
 def public with_compute_encoder_timed(queue : MetalCommandQueue?; var error : string&; var gpu_ms : double&; var encode_ms : double&; blk : block<(enc : MetalComputeEncoder?) : void>) : bool {
     let cb = metal_new_command_buffer(queue)
     let enc = metal_new_compute_encoder(cb)

--- a/modules/dasMetal/metal/metal_builtins.das
+++ b/modules/dasMetal/metal/metal_builtins.das
@@ -24,6 +24,7 @@ var gl_SubgroupSize : uint              // simdgroup execution width   -> [[thre
 var gl_NumSubgroups : uint              // simdgroups per threadgroup  -> [[simdgroups_per_threadgroup]]
 var gl_SubgroupID : uint                // simdgroup within the group  -> [[simdgroup_index_in_threadgroup]]
 
+// ===== loop shaping =====
 // ===== simdgroup reductions + shuffles (Metal spellings — the Metal value-add) =====
 // simd_sum(v): sum of v across the simdgroup's active lanes.
 [unused_argument(v), sideeffects] def public simd_sum(v : float) : float { return v }
@@ -88,7 +89,7 @@ def public make_filled_simdgroup_half8x8(v : float16) : simdgroup_half8x8 {
 def public simdgroup_load(var m : simdgroup_float8x8; src; offset : uint; stride : uint) {
     for (r in range(8)) {
         for (c in range(8)) {
-            m.data[r * 8 + c] = src[int(offset) + r * int(stride) + c]
+            m.data[r * 8 + c] = unsafe(src[int(offset) + r * int(stride) + c])   // pointer-source instantiations index through a das pointer
         }
     }
 }
@@ -96,9 +97,40 @@ def public simdgroup_load(var m : simdgroup_float8x8; src; offset : uint; stride
 def public simdgroup_load(var m : simdgroup_half8x8; src; offset : uint; stride : uint) {
     for (r in range(8)) {
         for (c in range(8)) {
-            m.data[r * 8 + c] = src[int(offset) + r * int(stride) + c]
+            m.data[r * 8 + c] = unsafe(src[int(offset) + r * int(stride) + c])   // pointer-source instantiations index through a das pointer
         }
     }
+}
+
+// The transpose-flag overloads: with transpose == true the (r, c) element is
+// src[offset + c*stride + r] — MSL's transpose_matrix argument. Lets a GEMM stage its B tile
+// ROW-major (contiguous threadgroup writes) and transpose at the simdgroup load instead of
+// paying strided staging stores.
+def public simdgroup_load(var m : simdgroup_float8x8; src; offset : uint; stride : uint; transpose : bool) {
+    for (r in range(8)) {
+        for (c in range(8)) {
+            m.data[r * 8 + c] = unsafe(src[int(offset) + (transpose ? c * int(stride) + r : r * int(stride) + c)])
+        }
+    }
+}
+
+def public simdgroup_load(var m : simdgroup_half8x8; src; offset : uint; stride : uint; transpose : bool) {
+    for (r in range(8)) {
+        for (c in range(8)) {
+            m.data[r * 8 + c] = unsafe(src[int(offset) + (transpose ? c * int(stride) + r : r * int(stride) + c)])
+        }
+    }
+}
+
+// tg_store_half4(dst, idx, v): dst[idx..idx+3] = half4(v) as ONE aligned vector store into a
+// float16 @workgroup array (idx % 4 == 0 — 8-byte alignment). The staging-loop sugar: four
+// scalar threadgroup stores collapse to one instruction on the GPU; the reference body is the
+// exact elementwise equivalent.
+def public tg_store_half4(var dst; idx : uint; v : float4) {
+    dst[int(idx)] = float16(v.x)
+    dst[int(idx) + 1] = float16(v.y)
+    dst[int(idx) + 2] = float16(v.z)
+    dst[int(idx) + 3] = float16(v.w)
 }
 
 // simdgroup_store(m, dst, offset, stride): the tile back out — @ssbo destinations only.

--- a/modules/dasMetal/metal/msl_emit.das
+++ b/modules/dasMetal/metal/msl_emit.das
@@ -37,6 +37,8 @@ struct private MslMember {
     workgroup : bool
     packed : bool           // elem != value_elem: 3-lane element behind a packed_T3 param
     wg_dim : int            // @workgroup fixed-array count; -1 = scalar/vector
+    wg_bytes : uint64       // @workgroup member's MSL byte size (whole member)
+    wg_off : uint64         // @workgroup member's offset inside the dynamic shmem buffer
 }
 
 struct private MslCtx {
@@ -45,6 +47,7 @@ struct private MslCtx {
     members : table<string; MslMember>          // das field name -> lowering
     builtins_used : table<string>               // referenced builtin globals (gl_*)
     renames : table<string; string>             // das identifier -> MSL-safe identifier
+    ptrs : table<string; string>                // pointer local (addr(member[..])) -> its member (das names)
     self_name : string
 }
 
@@ -159,18 +162,21 @@ def private scan_members(var ctx : MslCtx; fn : FunctionPtr) {
             }
             var wgElem = ""
             var wgDim = -1
+            var wgElemBytes = 0ul
             if (fld._type != null && fld._type.baseType == Type.tFixedArray && fld._type.firstType != null &&
                     fld._type.firstType.baseType != Type.tFixedArray) {
                 if (reject_cpu_only_width(ctx, fld.at, fld._type.firstType)) {
                     continue
                 }
                 wgElem = msl_type_name(fld._type.firstType)
+                wgElemBytes = msl_tg_elem_bytes(fld._type.firstType)
                 wgDim = fld._type.fixedDim
             } else {
                 if (reject_cpu_only_width(ctx, fld.at, fld._type)) {
                     continue
                 }
                 wgElem = msl_type_name(fld._type)
+                wgElemBytes = msl_tg_elem_bytes(fld._type)
             }
             if (empty(wgElem) || (wgDim == 0)) {
                 err(ctx, fld.at, "@workgroup member `{fld.name}` must be a scalar, vector, or single-dimension fixed array of those (e.g. uint[64]); got {fld._type == null ? "?" : describe(fld._type)}")
@@ -179,7 +185,8 @@ def private scan_members(var ctx : MslCtx; fn : FunctionPtr) {
             let wgName = string(fld.name)
             ctx.renames[wgName] = msl_safe_name(wgName)
             ctx.members[wgName] = MslMember(msl_name = msl_safe_name(wgName), elem = wgElem, value_elem = wgElem,
-                binding = -1, written = false, uniform = false, workgroup = true, packed = false, wg_dim = wgDim)
+                binding = -1, written = false, uniform = false, workgroup = true, packed = false, wg_dim = wgDim,
+                wg_bytes = wgElemBytes * uint64(wgDim > 0 ? wgDim : 1))
             continue
         }
         if (binding < 0) {
@@ -550,11 +557,17 @@ def private emit_value(var ctx : MslCtx; e : Expression?) : string {
         }
         err(ctx, ef.at, "field access `.{fieldName}` is not a kernel-class member access — only self.<@ssbo/@uniform member> lowers to MSL")
         return "/*.{fieldName}*/"
+    } elif (e is ExprCall && call_base_name("{(e as ExprCall).name}") == "i_das_ptr_add") {
+        // das pointer arithmetic (`p = unsafe(p + n)`): args = (ptr, elems, elem_size); MSL
+        // pointer addition element-scales the same way
+        let pc = e as ExprCall
+        note(ctx, "op.ptr_add")
+        return "({emit_value(ctx, pc.arguments[0])} + ({emit_value(ctx, pc.arguments[1])}))"
     } elif (e is ExprAt) {
         let ea = e as ExprAt
+        let pm = member_lookup(ctx, ea.subexpr)
         let sub = emit_value(ctx, ea.subexpr)
         let idx = emit_value(ctx, ea.index)
-        let pm = member_lookup(ctx, ea.subexpr)
         if (!empty(pm) && ctx.members[pm].packed) {
             // a packed 3-lane element loads back into its plain-type value form (packed types
             // have no arithmetic operators of their own)
@@ -934,12 +947,14 @@ def private emit_store_target(var ctx : MslCtx; e : Expression?) : string {
 // argument must be a kernel-class member — @ssbo (device) for both, @workgroup (threadgroup)
 // additionally as a load source — and lowers as `name + offset`. Element-type agreement is
 // enforced upstream by the das overloads (the reference body indexes src/dst with the matrix's
-// element type).
+// element type). A das pointer local (`var p = unsafe(addr(member[..]))`) is also accepted as
+// the source/destination and lowers through the pointer.
 def private emit_sgmat_load_store(var ctx : MslCtx; ec : ExprCall?; indent : string; var lines : array<string>) {
     let cname = call_base_name("{ec.name}")
     let isLoad = cname == "simdgroup_load"
-    if (length(ec.arguments) != 4) {
-        err(ctx, ec.at, "{cname} takes (matrix, buffer, offset, stride)")
+    let nargs = length(ec.arguments)
+    if (!(nargs == 4 || (isLoad && nargs == 5))) {
+        err(ctx, ec.at, "{cname} takes (matrix, buffer, offset, stride{isLoad ? "[, transpose]" : ""})")
         return
     }
     let sgname = sgmat_type_name(ec.arguments[0]._type)
@@ -947,9 +962,36 @@ def private emit_sgmat_load_store(var ctx : MslCtx; ec : ExprCall?; indent : str
         err(ctx, ec.at, "{cname} first argument must be a simdgroup matrix")
         return
     }
+    // pointer-local source: simdgroup_load(m, p, off, stride) where p = unsafe(addr(member[..]))
+    var parg = ec.arguments[1]
+    if (parg != null && parg is ExprRef2Value) {
+        parg = (parg as ExprRef2Value).subexpr
+    }
+    if (parg != null && parg is ExprVar && key_exists(ctx.ptrs, "{(parg as ExprVar).name}")) {
+        let pn0 = "{(parg as ExprVar).name}"
+        let pmem0 = ctx.ptrs[pn0]
+        let pmm = ctx.members[pmem0]
+        if (!isLoad) {
+            err(ctx, ec.at, "simdgroup_store through a das pointer is not supported — store to the @ssbo member directly")
+            return
+        }
+        let pmv = emit_value(ctx, ec.arguments[0])
+        let poff = emit_value(ctx, ec.arguments[2])
+        let pstride = emit_value(ctx, ec.arguments[3])
+        let pcls = sgmat_census_class(sgmat_type_name(ec.arguments[0]._type))
+        if (nargs == 5) {
+            let ptv = emit_value(ctx, ec.arguments[4])
+            note(ctx, "call.sgmat_load_ptr_t.{pcls}")
+            lines |> push("{indent}{cname}({pmv}, {ctx.renames[pn0]} + ({poff}), {pstride}, ulong2(0), {ptv});")
+            return
+        }
+        note(ctx, "call.sgmat_load_ptr.{pcls}")
+        lines |> push("{indent}{cname}({pmv}, {ctx.renames[pn0]} + ({poff}), {pstride});")
+        return
+    }
     let mem = member_lookup(ctx, ec.arguments[1])
     if (empty(mem)) {
-        err(ctx, ec.at, "{cname} {isLoad ? "source" : "destination"} must be an @ssbo{isLoad ? " or @workgroup" : ""} member")
+        err(ctx, ec.at, "{cname} {isLoad ? "source" : "destination"} must be an @ssbo{isLoad ? " or @workgroup" : ""} member, or a das pointer local over one")
         return
     }
     let m = ctx.members[mem]
@@ -962,15 +1004,48 @@ def private emit_sgmat_load_store(var ctx : MslCtx; ec : ExprCall?; indent : str
         return
     }
     let mv = emit_value(ctx, ec.arguments[0])
+    let cls = sgmat_census_class(sgname)
     let off = emit_value(ctx, ec.arguments[2])
     let stride = emit_value(ctx, ec.arguments[3])
-    let cls = sgmat_census_class(sgname)
+    if (nargs == 5) {   // the transpose-flag load: MSL's 5-arg form (origin 0, transpose_matrix)
+        note(ctx, m.workgroup ? "call.sgmat_load_tg_t.{cls}" : "call.sgmat_load_t.{cls}")
+        let tv = emit_value(ctx, ec.arguments[4])
+        lines |> push("{indent}{cname}({mv}, {m.msl_name} + {off}, {stride}, ulong2(0), {tv});")
+        return
+    }
     if (isLoad) {
         note(ctx, m.workgroup ? "call.sgmat_load_tg.{cls}" : "call.sgmat_load.{cls}")
     } else {
         note(ctx, "call.sgmat_store.{cls}")
     }
     lines |> push("{indent}{cname}({mv}, {m.msl_name} + {off}, {stride});")
+}
+
+// tg_store_half4(dst, idx, v): one aligned half4 vector store into a float16 @workgroup array —
+// `*(threadgroup half4*)(dst + idx) = half4(v);` (idx % 4 == 0 by contract; 8-byte alignment)
+def private emit_tg_store_half4(var ctx : MslCtx; ec : ExprCall?; indent : string; var lines : array<string>) {
+    if (length(ec.arguments) != 3) {
+        err(ctx, ec.at, "tg_store_half4 takes (workgroup array, index, float4)")
+        return
+    }
+    let mem = member_lookup(ctx, ec.arguments[0])
+    if (empty(mem)) {
+        err(ctx, ec.at, "tg_store_half4 destination must be a @workgroup member")
+        return
+    }
+    let m = ctx.members[mem]
+    if (!m.workgroup) {
+        err(ctx, ec.at, "tg_store_half4 destination must be a @workgroup member")
+        return
+    }
+    if (m.elem != "half") {
+        err(ctx, ec.at, "tg_store_half4 destination must be a float16 workgroup array (got {m.elem})")
+        return
+    }
+    let idx = emit_value(ctx, ec.arguments[1])
+    let v = emit_value(ctx, ec.arguments[2])
+    note(ctx, "call.tg_store_half4")
+    lines |> push("{indent}*(threadgroup half4*)({m.msl_name} + ({idx})) = half4({v});")
 }
 
 // simdgroup_multiply_accumulate(d, a, b, c) / simdgroup_multiply(d, a, b) — argument-type combos
@@ -1028,6 +1103,67 @@ def private emit_stmt(var ctx : MslCtx; e : Expression?; indent : string; var li
                     note(ctx, "stmt.var.sgmat")
                     lines |> push("{indent}{sgname} {ctx.renames[sgVarName]} = {init};")
                 }
+                continue
+            }
+            if (v.init != null && v.init is ExprRef2Ptr && (v.init as ExprRef2Ptr).subexpr is ExprAt) {
+                // `var p = unsafe(addr(member[expr]))` — a das pointer INTO a kernel member.
+                // Lowers to a real MSL pointer in the member's address space; the spelling
+                // exists because pointer-vs-index register-allocates differently on AGX and
+                // the winner is shape-dependent — both stay writable, plain das either way
+                let pat = (v.init as ExprRef2Ptr).subexpr as ExprAt
+                let pmem = member_lookup(ctx, pat.subexpr)
+                if (empty(pmem)) {
+                    err(ctx, v.at, "addr() in a kernel must take a kernel-class member element (addr(member[expr]))")
+                    continue
+                }
+                let pm = ctx.members[pmem]
+                if (pm.uniform || pm.packed) {
+                    err(ctx, v.at, "addr() over a @uniform or packed 3-lane member has no MSL pointer form")
+                    continue
+                }
+                let pname0 = string(v.name)
+                ctx.renames[pname0] = msl_safe_name(pname0)
+                ctx.ptrs[pname0] = pmem
+                let base = emit_value(ctx, pat.index)
+                let space = pm.workgroup ? "threadgroup" : (pm.written ? "device" : "device const")
+                note(ctx, pm.workgroup ? "decl.ptr.tg" : "decl.ptr.dev")
+                lines |> push("{indent}{space} {pm.elem} * {ctx.renames[pname0]} = {pm.msl_name} + ({base});")
+                continue
+            }
+            if (v._type != null && v._type.baseType == Type.tFixedArray && v._type.firstType != null &&
+                    v._type.firstType.baseType != Type.tFixedArray) {
+                // single-dim fixed-array local; das zero-init semantics, no initializer form
+                if (v.init != null) {
+                    err(ctx, v.at, "fixed-array local `{v.name}` takes no initializer — das zero-init is the MSL form")
+                    continue
+                }
+                let et = v._type.firstType
+                let n = v._type.fixedDim
+                let aname = string(v.name)
+                ctx.renames[aname] = msl_safe_name(aname)
+                let an = ctx.renames[aname]
+                let asg = sgmat_type_name(et)
+                if (!empty(asg)) {
+                    // the opaque tile type: `= {}` does not construct it — zero-fill in a
+                    // rolled pragma'd loop (the array form exists exactly for rolled math)
+                    note(ctx, "stmt.var.sgmat_array.{sgmat_census_class(asg)}")
+                    lines |> push("{indent}{asg} {an}[{n}];")
+                    lines |> push("{indent}#pragma clang loop unroll(full)")
+                    lines |> push("{indent}for (int {an}_zi = 0; {an}_zi < {n}; ++{an}_zi) \{")
+                    lines |> push("{indent}    {an}[{an}_zi] = {sgmat_zero_fill(asg)};")
+                    lines |> push("{indent}\}")
+                    continue
+                }
+                if (reject_cpu_only_width(ctx, v.at, et)) {
+                    continue
+                }
+                let ename = msl_type_name(et)
+                if (empty(ename)) {
+                    err(ctx, v.at, "local array `{v.name}` element type {describe(et)} has no MSL form")
+                    continue
+                }
+                note(ctx, "stmt.var.array")
+                lines |> push("{indent}{ename} {an}[{n}] = \{\};")
                 continue
             }
             if (reject_cpu_only_width(ctx, v.at, v._type)) {
@@ -1101,6 +1237,7 @@ def private emit_stmt(var ctx : MslCtx; e : Expression?; indent : string; var li
     } elif (e is ExprWhile) {
         let wh = e as ExprWhile
         let c = emit_value(ctx, wh.cond)
+        emit_loop_hints(ctx, wh.annotations, wh.at, indent, lines)
         note(ctx, "stmt.while")
         lines |> push("{indent}while ({c}) \{")
         emit_stmt(ctx, wh.body, indent + "    ", lines)
@@ -1122,6 +1259,8 @@ def private emit_stmt(var ctx : MslCtx; e : Expression?; indent : string; var li
             lines |> push("{indent}threadgroup_barrier(mem_flags::mem_threadgroup);")
         } elif (cname == "simdgroup_load" || cname == "simdgroup_store") {
             emit_sgmat_load_store(ctx, ec, indent, lines)
+        } elif (cname == "tg_store_half4") {
+            emit_tg_store_half4(ctx, ec, indent, lines)
         } elif (cname == "simdgroup_multiply_accumulate" || cname == "simdgroup_multiply") {
             emit_sgmat_multiply(ctx, ec, indent, lines)
         } else {
@@ -1169,6 +1308,31 @@ def private emit_if(var ctx : MslCtx; ite : ExprIfThenElse?; indent : string; va
 // endpoints ONCE at loop entry, so a non-constant end is hoisted into a loop-scoped local (the
 // comma-declaration keeps sequential same-name loops from colliding); a body that mutates memory
 // the end expression reads stays das-exact. Constant ranges inline the bounds.
+// Per-loop hint annotations (`for [unroll_full] (...)`) — the SAME AnnotationArgumentList
+// surface the JIT lowers to !llvm.loop.* metadata (llvm_jit.das append_loop_hint_operand);
+// here each recognized hint lowers to its clang loop pragma. The pragma'd loop reaches the
+// Metal frontend ROLLED and the GPU backend unrolls late, register-budget-aware — the
+// hand-unrolled spelling costs an occupancy tier (mul_mm: max_threads 1024 -> 832, -13%).
+def private emit_loop_hints(var ctx : MslCtx; anns : AnnotationArgumentList; at : LineInfo; indent : string; var lines : array<string>) {
+    for (a in anns) {
+        if (a.name == "unroll") {
+            note(ctx, "stmt.for.unroll")
+            lines |> push("{indent}#pragma clang loop unroll(enable)")
+        } elif (a.name == "unroll_full") {
+            note(ctx, "stmt.for.unroll")
+            lines |> push("{indent}#pragma clang loop unroll(full)")
+        } elif (a.name == "unroll_disable") {
+            note(ctx, "stmt.for.unroll")
+            lines |> push("{indent}#pragma clang loop unroll(disable)")
+        } elif (a.name == "unroll_count" && a.basicType == Type.tInt) {
+            note(ctx, "stmt.for.unroll")
+            lines |> push("{indent}#pragma clang loop unroll_count({a.iValue})")
+        } else {
+            err(ctx, at, "loop hint `{a.name}` has no MSL lowering — supported: unroll, unroll_full, unroll_disable, unroll_count=N")
+        }
+    }
+}
+
 def private emit_for(var ctx : MslCtx; fr : ExprFor?; indent : string; var lines : array<string>) {
     if (length(fr.iteratorVariables) != 1 || length(fr.sources) != 1) {
         err(ctx, fr.at, "only a single `for (i in range(...))` loop lowers to MSL")
@@ -1213,6 +1377,7 @@ def private emit_for(var ctx : MslCtx; fr : ExprFor?; indent : string; var lines
     let ivName = string(iv.name)
     ctx.renames[ivName] = msl_safe_name(ivName)
     let mn = ctx.renames[ivName]
+    emit_loop_hints(ctx, fr.annotations, fr.at, indent, lines)
     note(ctx, "stmt.for")
     if (hiIsConst) {
         lines |> push("{indent}for ({tname} {mn} = {lo}; {mn} < {hi}; ++{mn}) \{")
@@ -1239,7 +1404,7 @@ def public kernel_entry_name(fn : FunctionPtr; cfg : MslEmitConfig) : string {
 //! Lower a [metal_kernel] class method to MSL text. On any error the return is "" and `errors`
 //! explains; `census` collects the construct kinds emitted (gate B).
 [macro_function]
-def public generate_msl(fn : FunctionPtr; var errors : array<string>; cfg : MslEmitConfig; var census : table<string>) : string {
+def public generate_msl(fn : FunctionPtr; var errors : array<string>; cfg : MslEmitConfig; var census : table<string>; var tgmem : uint64&) : string {
     var ctx : MslCtx
     if (fn == null) {
         errors |> push("generate_msl: null function")
@@ -1256,24 +1421,38 @@ def public generate_msl(fn : FunctionPtr; var errors : array<string>; cfg : MslE
     ctx.self_name = string(fn.arguments[0].name)
     scan_members(ctx, fn)
     scan_body(ctx, fn.body)
-    var body_lines : array<string>
-    emit_stmt(ctx, fn.body, "    ", body_lines)
 
-    // @workgroup members are not parameters — MSL has no module-scope threadgroup variables, so
-    // each lowers to a threadgroup declaration at the top of the kernel body (name-sorted)
+    // @workgroup members lower to ONE dynamic [[threadgroup(0)]] buffer + derived pointers, NOT
+    // static threadgroup arrays: the AGX backend constant-folds tile pointers into a static
+    // array's absolute addresses, and the large offsets re-materialize as integer adds inside
+    // the math-bound loop phase (ISA-measured on mul_mm: 40 vs 24 iadds/iteration, the das
+    // kernel's whole residual vs llama.cpp). The opaque dynamic base keeps small carried
+    // offsets. Layout: name-sorted, each member 16B-aligned; the total ships as the `_tgmem`
+    // companion and the dispatch sets setThreadgroupMemoryLength(index 0) with it.
     var tg_lines : array<string>
     var wg_names <- [for (name, m in keys(ctx.members), values(ctx.members)); name; where m.workgroup]
     wg_names |> sort()
+    tgmem = 0ul
     for (name in wg_names) {
+        let moff = tgmem
+        ctx.members[name].wg_off = moff
         let m = ctx.members[name]
+        tgmem = (moff + m.wg_bytes + 15ul) & ~15ul
+        let base = moff == 0ul ? "(shmem)" : "(shmem + {int64(moff)})"
         if (m.wg_dim > 0) {
-            note(ctx, "decl.threadgroup_array")
-            tg_lines |> push("    threadgroup {m.elem} {m.msl_name}[{m.wg_dim}];")
+            note(ctx, "decl.shmem_ptr_array")
+            tg_lines |> push("    threadgroup {m.elem} * {m.msl_name} = (threadgroup {m.elem} *){base};")
         } else {
-            note(ctx, "decl.threadgroup")
-            tg_lines |> push("    threadgroup {m.elem} {m.msl_name};")
+            // scalar member: the pointer takes a derived name and every access dereferences it
+            note(ctx, "decl.shmem_ptr")
+            let pname = "{m.msl_name}_wg"
+            tg_lines |> push("    threadgroup {m.elem} * {pname} = (threadgroup {m.elem} *){base};")
+            ctx.members[name].msl_name = "(*{pname})"
         }
     }
+
+    var body_lines : array<string>
+    emit_stmt(ctx, fn.body, "    ", body_lines)
 
     var params : array<string>
     params |> reserve((ctx.members |> length) + (ctx.builtins_used |> length))
@@ -1306,6 +1485,10 @@ def public generate_msl(fn : FunctionPtr; var errors : array<string>; cfg : MslE
         let bi = builtin_msl_info(name)
         note(ctx, "param.builtin.{bi.attr}")
         params |> push("{bi.mslType} {name} [[{bi.attr}]]")
+    }
+    if (!empty(wg_names)) {
+        note(ctx, "param.shmem")
+        params |> push("threadgroup char * shmem [[threadgroup(0)]]")
     }
 
     if (!empty(ctx.errors)) {

--- a/modules/dasMetal/metal/msl_shader.das
+++ b/modules/dasMetal/metal/msl_shader.das
@@ -14,6 +14,9 @@ options indenting = 4
 //   N_entry    : string  — the kernel entry-point name (feed to metal_new_function)
 //   N_fastmath : bool    — the [metal_kernel(fastmath=...)] property, default true; feed to
 //                          metal_new_library_from_source
+//   N_tgmem    : uint64  — total dynamic [[threadgroup(0)]] bytes the kernel's @workgroup
+//                          members occupy (0 = none); the dispatch MUST pass it to
+//                          setThreadgroupMemoryLength (run_compute_1d takes it directly)
 //   N_census   : string  — newline-joined census kinds (gate B; text has no disassembler, so the
 //                          census is recorded at emit time and published for the meta-test)
 
@@ -54,7 +57,8 @@ class MetalKernel : AstFunctionAnnotation {
         return (add_typed_global(argName, Type.tString, func.at, errors) &&
             add_typed_global("{argName}_entry", Type.tString, func.at, errors) &&
             add_typed_global("{argName}_fastmath", Type.tBool, func.at, errors) &&
-            add_typed_global("{argName}_census", Type.tString, func.at, errors))
+            add_typed_global("{argName}_census", Type.tString, func.at, errors) &&
+            add_typed_global("{argName}_tgmem", Type.tUInt64, func.at, errors))
     }
     def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool {
         // Metal's runtime compiler does its own inlining — the CPU auto-inliner (patchInline,
@@ -84,7 +88,8 @@ class MetalKernel : AstFunctionAnnotation {
         var err : array<string>
         var census : table<string>
         let cfg = MslEmitConfig()
-        let text = generate_msl(func, err, cfg, census)
+        var tgmem = 0ul
+        let text = generate_msl(func, err, cfg, census, tgmem)
         if (!empty(err)) {
             errors := join(err, "\n")
             return false
@@ -99,6 +104,12 @@ class MetalKernel : AstFunctionAnnotation {
             fmGlob.init = new ExprConstBool(at = func.at, value = fastmath,
                 _type = new TypeDecl(at = func.at, baseType = Type.tBool))
             fmGlob._type.flags.constant = true
+        }
+        var tgGlob = find_variable(compiling_module(), "{argName}_tgmem")
+        if (tgGlob != null && tgGlob.init == null) {
+            tgGlob.init = new ExprConstUInt64(at = func.at, value = tgmem,
+                _type = new TypeDecl(at = func.at, baseType = Type.tUInt64))
+            tgGlob._type.flags.constant = true
         }
         return true
     }

--- a/modules/dasMetal/metal/msl_types.das
+++ b/modules/dasMetal/metal/msl_types.das
@@ -38,6 +38,23 @@ def public msl_type_name(t : TypeDecl?) : string {
     return cc > 1 ? "{base}{cc}" : base
 }
 
+//! MSL byte size of a THREADGROUP-resident element — the dynamic-shmem layout unit. Unlike the
+//! packed buffer path, threadgroup memory uses MSL's plain (non-packed) spellings, so 3-lane
+//! vectors stride four lanes.
+def public msl_tg_elem_bytes(t : TypeDecl?) : uint64 {
+    if (t == null) {
+        return 0ul
+    }
+    if (t.baseType == Type.tBool) {
+        return 1ul
+    }
+    if (scalar_class(t.baseType) < 0) {
+        return 0ul
+    }
+    let cc = component_count(t.baseType)
+    return uint64(scalar_width(t.baseType) / 8) * uint64(cc == 3 ? 4 : cc)
+}
+
 //! MSL spelling for a buffer/uniform ELEMENT — the layout-bearing position. das packs vectors
 //! tightly (float3 = 12B, half3 = 6B, byte3 = 3B) while non-packed MSL 3-vectors stride padded
 //! (float3 = 16B, half3 = 8B); with unified memory the das array IS the buffer, so 3-lane

--- a/modules/dasMetal/src/dasMetal.h
+++ b/modules/dasMetal/src/dasMetal.h
@@ -29,14 +29,20 @@ namespace das {
     DAS_MOD_API MetalFunction * metal_new_function ( MetalLibrary * lib, const char * name, Context * ctx, LineInfoArg * at );
     DAS_MOD_API MetalComputePipeline * metal_new_compute_pipeline ( MetalDevice * dev, MetalFunction * fn,
         char * & error, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API uint32_t metal_pipeline_max_total_threads ( MetalComputePipeline * pso, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API uint32_t metal_pipeline_thread_execution_width ( MetalComputePipeline * pso, Context * ctx, LineInfoArg * at );
 
     DAS_MOD_API MetalBuffer * metal_new_buffer ( MetalDevice * dev, uint64_t bytes, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API MetalBuffer * metal_new_buffer_untracked ( MetalDevice * dev, uint64_t bytes, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void * metal_buffer_contents ( MetalBuffer * buf, Context * ctx, LineInfoArg * at );
 
     DAS_MOD_API MetalCommandBuffer * metal_new_command_buffer ( MetalCommandQueue * queue, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API MetalCommandBuffer * metal_new_command_buffer_unretained ( MetalCommandQueue * queue, Context * ctx, LineInfoArg * at );
     DAS_MOD_API MetalComputeEncoder * metal_new_compute_encoder ( MetalCommandBuffer * cb, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void metal_set_pipeline ( MetalComputeEncoder * enc, MetalComputePipeline * pso, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void metal_set_buffer ( MetalComputeEncoder * enc, MetalBuffer * buf, uint64_t offset, int32_t index,
+        Context * ctx, LineInfoArg * at );
+    DAS_MOD_API void metal_set_threadgroup_memory_length ( MetalComputeEncoder * enc, uint64_t length, int32_t index,
         Context * ctx, LineInfoArg * at );
     DAS_MOD_API void metal_dispatch_threadgroups ( MetalComputeEncoder * enc, uint3 groups, uint3 threads_per_group,
         Context * ctx, LineInfoArg * at );

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -144,6 +144,19 @@ namespace das {
         }
     }
 
+    // occupancy introspection: register-pressure-limited kernels report < 1024 here
+    uint32_t metal_pipeline_max_total_threads ( MetalComputePipeline * pso, Context * ctx, LineInfoArg * at ) {
+        if ( !pso ) ctx->throw_error_at(at, "metal_pipeline_max_total_threads: null pipeline");
+        id<MTLComputePipelineState> p = (__bridge id<MTLComputePipelineState>)(void *) pso;
+        return (uint32_t) p.maxTotalThreadsPerThreadgroup;
+    }
+
+    uint32_t metal_pipeline_thread_execution_width ( MetalComputePipeline * pso, Context * ctx, LineInfoArg * at ) {
+        if ( !pso ) ctx->throw_error_at(at, "metal_pipeline_thread_execution_width: null pipeline");
+        id<MTLComputePipelineState> p = (__bridge id<MTLComputePipelineState>)(void *) pso;
+        return (uint32_t) p.threadExecutionWidth;
+    }
+
     // ===== buffers =====
 
     MetalBuffer * metal_new_buffer ( MetalDevice * dev, uint64_t bytes, Context * ctx, LineInfoArg * at ) {
@@ -152,6 +165,19 @@ namespace das {
         @autoreleasepool {
             id<MTLDevice> d = (__bridge id<MTLDevice>)(void *) dev;
             return retain_handle<MetalBuffer>([d newBufferWithLength:bytes options:MTLResourceStorageModeShared]);
+        }
+    }
+
+    // UNTRACKED buffer: opts out of the driver's per-command-buffer hazard/dependency analysis.
+    // For GPU-read-only data written by the CPU before commit (weights) — commit-boundary
+    // CPU->GPU coherency still holds for shared storage; the caller owns any GPU-GPU ordering.
+    MetalBuffer * metal_new_buffer_untracked ( MetalDevice * dev, uint64_t bytes, Context * ctx, LineInfoArg * at ) {
+        if ( !dev ) ctx->throw_error_at(at, "metal_new_buffer_untracked: null device");
+        if ( bytes == 0 ) ctx->throw_error_at(at, "metal_new_buffer_untracked: zero size");
+        @autoreleasepool {
+            id<MTLDevice> d = (__bridge id<MTLDevice>)(void *) dev;
+            return retain_handle<MetalBuffer>([d newBufferWithLength:bytes
+                options:MTLResourceStorageModeShared | MTLResourceHazardTrackingModeUntracked]);
         }
     }
 
@@ -168,6 +194,16 @@ namespace das {
         @autoreleasepool {
             id<MTLCommandQueue> q = (__bridge id<MTLCommandQueue>)(void *) queue;
             return retain_handle<MetalCommandBuffer>([q commandBuffer]);
+        }
+    }
+
+    // UNRETAINED command buffer: skips the per-dispatch retain/release of every referenced
+    // resource at commit — the CALLER guarantees all buffers/pipelines outlive completion
+    MetalCommandBuffer * metal_new_command_buffer_unretained ( MetalCommandQueue * queue, Context * ctx, LineInfoArg * at ) {
+        if ( !queue ) ctx->throw_error_at(at, "metal_new_command_buffer_unretained: null command queue");
+        @autoreleasepool {
+            id<MTLCommandQueue> q = (__bridge id<MTLCommandQueue>)(void *) queue;
+            return retain_handle<MetalCommandBuffer>([q commandBufferWithUnretainedReferences]);
         }
     }
 
@@ -193,6 +229,18 @@ namespace das {
         if ( index < 0 ) ctx->throw_error_at(at, "metal_set_buffer: negative buffer index %i", index);
         id<MTLComputeCommandEncoder> e = (__bridge id<MTLComputeCommandEncoder>)(void *) enc;
         [e setBuffer:(__bridge id<MTLBuffer>)(void *) buf offset:offset atIndex:NSUInteger(index)];
+    }
+
+    void metal_set_threadgroup_memory_length ( MetalComputeEncoder * enc, uint64_t length, int32_t index,
+            Context * ctx, LineInfoArg * at ) {
+        if ( !enc ) ctx->throw_error_at(at, "metal_set_threadgroup_memory_length: null encoder");
+        if ( index < 0 ) ctx->throw_error_at(at, "metal_set_threadgroup_memory_length: negative index %i", index);
+        if ( length == 0 || (length % 16) != 0 ) {   // Metal requires a non-zero multiple of 16
+            ctx->throw_error_at(at, "metal_set_threadgroup_memory_length: length %llu is not a non-zero multiple of 16",
+                (unsigned long long) length);
+        }
+        id<MTLComputeCommandEncoder> e = (__bridge id<MTLComputeCommandEncoder>)(void *) enc;
+        [e setThreadgroupMemoryLength:NSUInteger(length) atIndex:NSUInteger(index)];
     }
 
     static bool valid_grid ( uint3 g ) {
@@ -312,9 +360,18 @@ namespace das {
             addExtern<DAS_BIND_FUN(metal_new_compute_pipeline)>(*this, lib, "metal_new_compute_pipeline",
                 SideEffects::modifyArgumentAndExternal, "metal_new_compute_pipeline")
                     ->args({"device", "function", "error", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_pipeline_max_total_threads)>(*this, lib, "metal_pipeline_max_total_threads",
+                SideEffects::none, "metal_pipeline_max_total_threads")
+                    ->args({"pipeline", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_pipeline_thread_execution_width)>(*this, lib, "metal_pipeline_thread_execution_width",
+                SideEffects::none, "metal_pipeline_thread_execution_width")
+                    ->args({"pipeline", "context", "at"});
 
             addExtern<DAS_BIND_FUN(metal_new_buffer)>(*this, lib, "metal_new_buffer",
                 SideEffects::modifyExternal, "metal_new_buffer")
+                    ->args({"device", "bytes", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_new_buffer_untracked)>(*this, lib, "metal_new_buffer_untracked",
+                SideEffects::modifyExternal, "metal_new_buffer_untracked")
                     ->args({"device", "bytes", "context", "at"});
             addExtern<DAS_BIND_FUN(metal_buffer_contents)>(*this, lib, "metal_buffer_contents",
                 SideEffects::modifyExternal, "metal_buffer_contents")
@@ -322,6 +379,9 @@ namespace das {
 
             addExtern<DAS_BIND_FUN(metal_new_command_buffer)>(*this, lib, "metal_new_command_buffer",
                 SideEffects::modifyExternal, "metal_new_command_buffer")
+                    ->args({"queue", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_new_command_buffer_unretained)>(*this, lib, "metal_new_command_buffer_unretained",
+                SideEffects::modifyExternal, "metal_new_command_buffer_unretained")
                     ->args({"queue", "context", "at"});
             addExtern<DAS_BIND_FUN(metal_new_compute_encoder)>(*this, lib, "metal_new_compute_encoder",
                 SideEffects::modifyExternal, "metal_new_compute_encoder")
@@ -332,6 +392,9 @@ namespace das {
             addExtern<DAS_BIND_FUN(metal_set_buffer)>(*this, lib, "metal_set_buffer",
                 SideEffects::modifyExternal, "metal_set_buffer")
                     ->args({"encoder", "buffer", "offset", "index", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_set_threadgroup_memory_length)>(*this, lib, "metal_set_threadgroup_memory_length",
+                SideEffects::modifyExternal, "metal_set_threadgroup_memory_length")
+                    ->args({"encoder", "length", "index", "context", "at"});
             addExtern<DAS_BIND_FUN(metal_dispatch_threadgroups)>(*this, lib, "metal_dispatch_threadgroups",
                 SideEffects::modifyExternal, "metal_dispatch_threadgroups")
                     ->args({"encoder", "groups", "threads_per_group", "context", "at"});

--- a/skills/aot_hash_desync_debugging.md
+++ b/skills/aot_hash_desync_debugging.md
@@ -22,6 +22,8 @@ Background on the hash machinery is in [`skills/aot_testing.md`](aot_testing.md)
 
 4. **A stub regenerated with a different path spelling.** The compile-invocation file path reaches *hashed constants* in quote-lowered functions, so the AOT-gen input must be spelled exactly as the runtime suite spells it — source-root-relative (`tests/...`). The `DAS_AOT_EXT` rule passes relative inputs with `WORKING_DIRECTORY` = source root for exactly this reason; regenerating a stub by hand with an absolute path desyncs every ``quote`lowered`N`` in it.
 
+5. **The failing function has a `[tune]` family in its static call graph.** Generation and runtime must agree on the tune gate (`llvm_tune::tune_aot_gate` — `tune_frozen` at generation, `policies.aot && !jit` at runtime); a driver missing `tune_frozen` compiles in the STAMPED world (manifest/fallback stamps + full variants registries — the registries take function addresses, which flips `fastCall` on call sites) while the runtime compiles gated to the reference tier. There are TWO generation drivers that both need the policy: `utils/daScript/main.cpp` (`-aot`) **and** `utils/aot/main.das` (what the cmake AOT rules actually invoke) — the .das one was missed when #3423 introduced the policy (fixed in #3450). Diagnostic tell: a hand-run `bin/daslang -aot <file>` records hashes matching the runtime while the cmake-generated `.cpp` doesn't.
+
 If none apply, you have a real desync. Continue.
 
 ## Step 1 — Read the diagnostic

--- a/tests/dasLLAMA/test_deltanet.das
+++ b/tests/dasLLAMA/test_deltanet.das
@@ -37,6 +37,13 @@ def test_deltanet_chunked_prefill(t : T?) {
             t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
+        // the multi-chunk case diverges from the recurrent oracle on M1 (deterministic argmax
+        // mismatch at the chunk boundary; pre-existing — reproduces at master with a fresh JIT
+        // cache and rebuilt binary). Tracked as #3454; the env rail runs it anyway for the fix.
+        if (get_env_variable("DASLLAMA_DELTANET_MULTICHUNK") != "1") {
+            t |> skip("chunked-vs-recurrent multi-chunk diverges on M1 — tracked as #3454 (DASLLAMA_DELTANET_MULTICHUNK=1 to run)")
+            return
+        }
         let path = path_join(models_dir(), "Qwen3.5-0.8B-Q8_0.gguf")
         if (!model_available(t, path)) return
         var tr <- load_gguf(path, QuantMode.q8)

--- a/tests/dasLLAMA/test_deltanet.das
+++ b/tests/dasLLAMA/test_deltanet.das
@@ -37,13 +37,6 @@ def test_deltanet_chunked_prefill(t : T?) {
             t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
             return
         }
-        // the multi-chunk case diverges from the recurrent oracle on M1 (deterministic argmax
-        // mismatch at the chunk boundary; pre-existing — reproduces at master with a fresh JIT
-        // cache and rebuilt binary). Tracked as #3454; the env rail runs it anyway for the fix.
-        if (get_env_variable("DASLLAMA_DELTANET_MULTICHUNK") != "1") {
-            t |> skip("chunked-vs-recurrent multi-chunk diverges on M1 — tracked as #3454 (DASLLAMA_DELTANET_MULTICHUNK=1 to run)")
-            return
-        }
         let path = path_join(models_dir(), "Qwen3.5-0.8B-Q8_0.gguf")
         if (!model_available(t, path)) return
         var tr <- load_gguf(path, QuantMode.q8)

--- a/tests/dasLLAMA/test_metal_prefill_kernels.das
+++ b/tests/dasLLAMA/test_metal_prefill_kernels.das
@@ -40,6 +40,141 @@ def private approx(x, y : float) : bool {
     return abs(x - y) <= 1e-4 * max(1.0, max(abs(x), abs(y)))
 }
 
+// The tiled sgmat attention trio (QK^T -> softmax -> P.V) vs a direct causal-GQA oracle at one
+// (head_size, heads, kv_heads, npos) shape. Buffers carry np32 rows like the driver's (whole-tile
+// sgmat stores + staging reads walk the padded rows); rows >= npos are pad. GENERIC (untyped
+// dev/queue) so it instantiates only inside the Apple static_if.
+def private attn_trio_gate(t : T?; dev, queue; head_size, n_heads, n_kv_heads, npos : int; mm : bool) {
+    let kv_mul = n_heads / n_kv_heads
+    let qd = n_heads * head_size
+    let kv_dim = n_kv_heads * head_size
+    let np32 = (npos + 31) / 32 * 32
+    var err : string
+    var pso_sc = (mm
+        ? pipeline_from_source(dev, metal_attn_qk_mm_msl, metal_attn_qk_mm_msl_entry, metal_attn_qk_mm_msl_fastmath, err)
+        : pipeline_from_source(dev, metal_attn_qk_msl, metal_attn_qk_msl_entry, metal_attn_qk_msl_fastmath, err))
+    t |> success(pso_sc != null, "qk pipeline (mm={mm}): {err}")
+    var pso_sm = pipeline_from_source(dev, metal_attn_softmax_msl, metal_attn_softmax_msl_entry, metal_attn_softmax_msl_fastmath, err)
+    t |> success(pso_sm != null, "softmax pipeline: {err}")
+    var pso_av = (mm
+        ? pipeline_from_source(dev, metal_attn_av_mm_msl, metal_attn_av_mm_msl_entry, metal_attn_av_mm_msl_fastmath, err)
+        : pipeline_from_source(dev, metal_attn_av_msl, metal_attn_av_msl_entry, metal_attn_av_msl_fastmath, err))
+    t |> success(pso_av != null, "av pipeline (mm={mm}): {err}")
+    let scale = 1.0 / sqrt(float(head_size))
+    var aq : array<float>
+    var ak : array<float>
+    var av : array<float>
+    var axb_want : array<float>
+    aq |> resize(np32 * qd)
+    ak |> resize(np32 * kv_dim)
+    av |> resize(np32 * kv_dim)
+    axb_want |> resize(npos * qd)
+    for (k in range(npos * qd)) {
+        aq[k] = 0.13 * float(k % 31) - 1.9
+    }
+    for (k in range(npos * kv_dim)) {
+        ak[k] = 0.17 * float(k % 23) - 1.8
+        av[k] = 0.09 * float(k % 37) - 1.6
+    }
+    var prow : array<float>
+    prow |> resize(npos)
+    for (h in range(n_heads)) {
+        let kvhoff = (h / kv_mul) * head_size
+        for (qi in range(npos)) {
+            let cnt = qi + 1
+            var m = -1.0e30
+            for (j in range(cnt)) {
+                var dot = 0.0
+                for (d in range(head_size)) {
+                    dot += aq[qi * qd + h * head_size + d] * ak[j * kv_dim + kvhoff + d]
+                }
+                prow[j] = dot * scale
+                m = max(m, prow[j])
+            }
+            var sum = 0.0
+            for (j in range(cnt)) {
+                prow[j] = exp(prow[j] - m)
+                sum += prow[j]
+            }
+            for (d in range(head_size)) {
+                var acc = 0.0
+                for (j in range(cnt)) {
+                    acc += (prow[j] / sum) * av[j * kv_dim + kvhoff + d]
+                }
+                axb_want[qi * qd + h * head_size + d] = acc
+            }
+        }
+    }
+    var baq = buf_upload(dev, aq)
+    var bak = buf_upload(dev, ak)
+    var bav = buf_upload(dev, av)
+    var batt = buf_fill(dev, n_heads * np32 * np32, 0.0)
+    var bxb = buf_fill(dev, np32 * qd, 0.0)
+    var bqd = buf_u32(dev, uint(qd))
+    var bkvd = buf_u32(dev, uint(kv_dim))
+    var bhs = buf_u32(dev, uint(head_size))
+    var bkvm = buf_u32(dev, uint(kv_mul))
+    var bnp = buf_u32(dev, uint(npos))
+    var bnp32 = buf_u32(dev, uint(np32))
+    var bscale = buf_f32(dev, scale)
+    let aran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_sc)
+        metal_set_threadgroup_memory_length(enc, mm ? metal_attn_qk_mm_msl_tgmem : metal_attn_qk_msl_tgmem, 0)
+        metal_set_buffer(enc, baq, 0ul, 0)
+        metal_set_buffer(enc, bak, 0ul, 1)
+        metal_set_buffer(enc, batt, 0ul, 2)
+        metal_set_buffer(enc, bqd, 0ul, 3)
+        metal_set_buffer(enc, bkvd, 0ul, 4)
+        metal_set_buffer(enc, bhs, 0ul, 5)
+        metal_set_buffer(enc, bkvm, 0ul, 6)
+        metal_set_buffer(enc, bnp, 0ul, 7)
+        metal_set_buffer(enc, bnp32, 0ul, 8)
+        metal_set_buffer(enc, bscale, 0ul, 9)
+        metal_dispatch_threadgroups(enc, uint3(uint(np32 / 32), uint(np32 / (mm ? 64 : 32)), uint(n_heads)), uint3(128u, 1u, 1u))
+        metal_set_pipeline(enc, pso_sm)
+        metal_set_threadgroup_memory_length(enc, metal_attn_softmax_msl_tgmem, 0)
+        metal_set_buffer(enc, batt, 0ul, 0)
+        metal_set_buffer(enc, bnp32, 0ul, 1)
+        metal_dispatch_threadgroups(enc, uint3(uint(npos), uint(n_heads), 1u), uint3(128u, 1u, 1u))
+        metal_set_pipeline(enc, pso_av)
+        metal_set_threadgroup_memory_length(enc, mm ? metal_attn_av_mm_msl_tgmem : metal_attn_av_msl_tgmem, 0)
+        metal_set_buffer(enc, batt, 0ul, 0)
+        metal_set_buffer(enc, bav, 0ul, 1)
+        metal_set_buffer(enc, bxb, 0ul, 2)
+        metal_set_buffer(enc, bqd, 0ul, 3)
+        metal_set_buffer(enc, bkvd, 0ul, 4)
+        metal_set_buffer(enc, bhs, 0ul, 5)
+        metal_set_buffer(enc, bkvm, 0ul, 6)
+        metal_set_buffer(enc, bnp, 0ul, 7)
+        metal_set_buffer(enc, bnp32, 0ul, 8)
+        metal_dispatch_threadgroups(enc, uint3(uint(np32 / 32), uint(head_size / (mm ? 64 : 32)), uint(n_heads)), uint3(128u, 1u, 1u))
+    }
+    t |> success(aran, "attention dispatches (hs={head_size}, mm={mm}): {err}")
+    // the mm pair stages HALF (llama.cpp's f32_f32 mul_mm does the same) — the envelope is the
+    // half-precision score shift through softmax, ~1% of the convex-combination output
+    t |> equal(buf_mismatch_tol(bxb, axb_want, mm ? 2e-2 : 1e-4), 0)
+    metal_release(baq)
+    metal_release(bak)
+    metal_release(bav)
+    metal_release(batt)
+    metal_release(bxb)
+    metal_release(bqd)
+    metal_release(bkvd)
+    metal_release(bhs)
+    metal_release(bkvm)
+    metal_release(bnp)
+    metal_release(bnp32)
+    metal_release(bscale)
+    metal_release(pso_sc)
+    metal_release(pso_sm)
+    metal_release(pso_av)
+    delete aq
+    delete ak
+    delete av
+    delete axb_want
+    delete prow
+}
+
 [test]
 def test_metal_prefill_kernels(t : T?) {
     t |> run("phase-6 prefill kernels == dasLLAMA CPU twins") <| @(t : T?) {
@@ -139,6 +274,7 @@ def test_metal_prefill_kernels(t : T?) {
                 var breps = buf_f32(dev, EPS)
                 let rran = with_compute_encoder(queue, err) <| $(enc : MetalComputeEncoder?) {
                     metal_set_pipeline(enc, pso_rms)
+                    metal_set_threadgroup_memory_length(enc, metal_rmsnorm_msl_tgmem, 0)
                     metal_set_buffer(enc, brx, 0ul, 0)
                     metal_set_buffer(enc, brw, 0ul, 1)
                     metal_set_buffer(enc, bry, 0ul, 2)
@@ -203,118 +339,14 @@ def test_metal_prefill_kernels(t : T?) {
                 metal_release(brnp)
                 metal_release(pso_rope)
 
-                // ===== attention: the tiled sgmat trio (QK^T -> softmax -> P.V) vs a direct
-                // causal-GQA oracle. Buffers carry NP32 rows like the driver's (whole-tile sgmat
-                // stores + staging reads walk the padded rows); rows >= NPOS are pad.
-                var pso_sc = pipeline_from_source(dev, metal_attn_qk_msl, metal_attn_qk_msl_entry, metal_attn_qk_msl_fastmath, err)
-                t |> success(pso_sc != null, "qk pipeline: {err}")
-                var pso_sm = pipeline_from_source(dev, metal_attn_softmax_msl, metal_attn_softmax_msl_entry, metal_attn_softmax_msl_fastmath, err)
-                t |> success(pso_sm != null, "softmax pipeline: {err}")
-                var pso_av = pipeline_from_source(dev, metal_attn_av_msl, metal_attn_av_msl_entry, metal_attn_av_msl_fastmath, err)
-                t |> success(pso_av != null, "av pipeline: {err}")
-                let scale = 1.0 / sqrt(float(HEAD_SIZE))
-                var aq : array<float>
-                var ak : array<float>
-                var av : array<float>
-                var axb_want : array<float>
-                aq |> resize(NP32 * QD)
-                ak |> resize(NP32 * KV_DIM)
-                av |> resize(NP32 * KV_DIM)
-                axb_want |> resize(NPOS * QD)
-                for (k in range(NPOS * QD)) {
-                    aq[k] = 0.13 * float(k % 31) - 1.9
-                }
-                for (k in range(NPOS * KV_DIM)) {
-                    ak[k] = 0.17 * float(k % 23) - 1.8
-                    av[k] = 0.09 * float(k % 37) - 1.6
-                }
-                var prow : array<float>
-                prow |> resize(NPOS)
-                for (h in range(N_HEADS)) {
-                    let kvhoff = (h / KV_MUL) * HEAD_SIZE
-                    for (qi in range(NPOS)) {
-                        let cnt = qi + 1
-                        var m = -1.0e30
-                        for (j in range(cnt)) {
-                            var dot = 0.0
-                            for (d in range(HEAD_SIZE)) {
-                                dot += aq[qi * QD + h * HEAD_SIZE + d] * ak[j * KV_DIM + kvhoff + d]
-                            }
-                            prow[j] = dot * scale
-                            m = max(m, prow[j])
-                        }
-                        var sum = 0.0
-                        for (j in range(cnt)) {
-                            prow[j] = exp(prow[j] - m)
-                            sum += prow[j]
-                        }
-                        for (d in range(HEAD_SIZE)) {
-                            var acc = 0.0
-                            for (j in range(cnt)) {
-                                acc += (prow[j] / sum) * av[j * KV_DIM + kvhoff + d]
-                            }
-                            axb_want[qi * QD + h * HEAD_SIZE + d] = acc
-                        }
-                    }
-                }
-                var baq = buf_upload(dev, aq)
-                var bak = buf_upload(dev, ak)
-                var bav = buf_upload(dev, av)
-                var batt = buf_fill(dev, N_HEADS * NP32 * NP32, 0.0)
-                var bxb = buf_fill(dev, NP32 * QD, 0.0)
-                var bqd = buf_u32(dev, uint(QD))
-                var bkvd = buf_u32(dev, uint(KV_DIM))
-                var bhs = buf_u32(dev, uint(HEAD_SIZE))
-                var bkvm = buf_u32(dev, uint(KV_MUL))
-                var bnp = buf_u32(dev, uint(NPOS))
-                var bnp32 = buf_u32(dev, uint(NP32))
-                var bscale = buf_f32(dev, scale)
-                let aran = with_compute_encoder(queue, err) <| $(enc : MetalComputeEncoder?) {
-                    metal_set_pipeline(enc, pso_sc)
-                    metal_set_buffer(enc, baq, 0ul, 0)
-                    metal_set_buffer(enc, bak, 0ul, 1)
-                    metal_set_buffer(enc, batt, 0ul, 2)
-                    metal_set_buffer(enc, bqd, 0ul, 3)
-                    metal_set_buffer(enc, bkvd, 0ul, 4)
-                    metal_set_buffer(enc, bhs, 0ul, 5)
-                    metal_set_buffer(enc, bkvm, 0ul, 6)
-                    metal_set_buffer(enc, bnp, 0ul, 7)
-                    metal_set_buffer(enc, bnp32, 0ul, 8)
-                    metal_set_buffer(enc, bscale, 0ul, 9)
-                    metal_dispatch_threadgroups(enc, uint3(uint(NP32 / 32), uint(NP32 / 32), uint(N_HEADS)), uint3(128u, 1u, 1u))
-                    metal_set_pipeline(enc, pso_sm)
-                    metal_set_buffer(enc, batt, 0ul, 0)
-                    metal_set_buffer(enc, bnp32, 0ul, 1)
-                    metal_dispatch_threadgroups(enc, uint3(uint(NPOS), uint(N_HEADS), 1u), uint3(128u, 1u, 1u))
-                    metal_set_pipeline(enc, pso_av)
-                    metal_set_buffer(enc, batt, 0ul, 0)
-                    metal_set_buffer(enc, bav, 0ul, 1)
-                    metal_set_buffer(enc, bxb, 0ul, 2)
-                    metal_set_buffer(enc, bqd, 0ul, 3)
-                    metal_set_buffer(enc, bkvd, 0ul, 4)
-                    metal_set_buffer(enc, bhs, 0ul, 5)
-                    metal_set_buffer(enc, bkvm, 0ul, 6)
-                    metal_set_buffer(enc, bnp, 0ul, 7)
-                    metal_set_buffer(enc, bnp32, 0ul, 8)
-                    metal_dispatch_threadgroups(enc, uint3(uint(NP32 / 32), uint(HEAD_SIZE / 32), uint(N_HEADS)), uint3(128u, 1u, 1u))
-                }
-                t |> success(aran, "attention dispatches: {err}")
-                t |> equal(buf_mismatch_approx(bxb, axb_want), 0)
-                metal_release(baq)
-                metal_release(bak)
-                metal_release(bav)
-                metal_release(batt)
-                metal_release(bxb)
-                metal_release(bqd)
-                metal_release(bkvd)
-                metal_release(bhs)
-                metal_release(bkvm)
-                metal_release(bnp)
-                metal_release(bnp32)
-                metal_release(bscale)
-                metal_release(pso_sc)
-                metal_release(pso_sm)
-                metal_release(pso_av)
+                // ===== attention: the tiled sgmat trio vs the direct causal-GQA oracle, at the
+                // classic small shape (hs 32 — one QK k-slab) AND the llama-3B head shape
+                // (hs 128 — the QK kernel's two-k-slab path; 2 heads keep the oracle cheap)
+                attn_trio_gate(t, dev, queue, HEAD_SIZE, N_HEADS, N_KV_HEADS, NPOS, false)
+                attn_trio_gate(t, dev, queue, 128, 2, 1, NPOS, false)
+                // the ggml-geometry pair (hs % 64 shapes: llama-1B/3B classes + GQA)
+                attn_trio_gate(t, dev, queue, 64, 4, 2, NPOS, true)
+                attn_trio_gate(t, dev, queue, 128, 6, 2, 40, true)
 
                 // ===== swiglu + residual add =====
                 var pso_sw = pipeline_from_source(dev, metal_swiglu_msl, metal_swiglu_msl_entry, metal_swiglu_msl_fastmath, err)
@@ -370,6 +402,17 @@ def test_metal_prefill_kernels(t : T?) {
                 metal_release(pso_sw)
                 metal_release(pso_add)
 
+                // ===== the production mul_mm — the resident path's default GEMM =====
+                mulmm_gate(t, dev, queue, 96, 128, 64)      // 3 k-blocks, 2 output tiles, 2 token tiles
+                mulmm_gate(t, dev, queue, 64, 192, 32)      // 2 k-blocks, 3 output tiles, 1 token tile
+
+                // ===== the classifier GEMV (logits-on-GPU) =====
+                // exact-arithmetic data (quants in [-8, 7], pow2 scales, int x): every per-byte4
+                // dot, scale product, and simd_sum partial is exactly representable — BIT-exact
+                // vs the CPU reference. d = 21 exercises the row < ddim tail guard (grid pads to 24).
+                gemv_gate(t, dev, queue, 96, 21)            // 3 blocks per row, guarded tail
+                gemv_gate(t, dev, queue, 160, 64)           // 5 blocks per row, exact grid
+
                 metal_release(queue)
             }
             t |> equal(metal_live_object_count(), 0l)
@@ -377,6 +420,154 @@ def test_metal_prefill_kernels(t : T?) {
             feint("das_metal is not built on this platform; nothing to compare\n")
         }
     }
+}
+
+// The classifier GEMV kernel on exact-arithmetic data: [d x n] Q8 rows dot one f32 vector vs
+// a direct CPU dot, BIT-exact (see the call site for why exactness holds).
+def private gemv_gate(t : T?; dev, queue; n, d : int) {
+    var err : string
+    var pso = pipeline_from_source(dev, metal_q8_gemv_msl, metal_q8_gemv_msl_entry, metal_q8_gemv_msl_fastmath, err)
+    t |> success(pso != null, "gemv pipeline: {err}")
+    if (pso == null) {
+        return
+    }
+    let nblk = n / 32
+    var wq : array<int8>
+    var ws : array<float>
+    var xv : array<float>
+    var want : array<float>
+    wq |> resize(d * n)
+    ws |> resize(d * nblk)
+    xv |> resize(n)
+    want |> resize(d)
+    let lut = fixed_array(0.25, 0.5, 1.0, 2.0)
+    for (i in range(d * n)) {
+        wq[i] = int8((i * 7 + i / 31) % 16 - 8)
+    }
+    for (i in range(d * nblk)) {
+        ws[i] = lut[(i / 5) % 4]
+    }
+    for (i in range(n)) {
+        xv[i] = float((i * 3) % 9 - 4)
+    }
+    for (r in range(d)) {
+        var acc = 0.0
+        for (k in range(n)) {
+            acc += float(wq[r * n + k]) * ws[r * nblk + k / 32] * xv[k]
+        }
+        want[r] = acc
+    }
+    var bwq = buf_upload(dev, wq)
+    var bws = buf_upload(dev, ws)
+    var bx = buf_upload(dev, xv)
+    var by = buf_fill(dev, d, -1000.0)
+    var bn = buf_u32(dev, uint(n))
+    var bd = buf_u32(dev, uint(d))
+    let ran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso)
+        metal_set_buffer(enc, bwq, 0ul, 0)
+        metal_set_buffer(enc, bws, 0ul, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bn, 0ul, 4)
+        metal_set_buffer(enc, bd, 0ul, 5)
+        metal_dispatch_threadgroups(enc, uint3(uint((d + 3) / 4), 1u, 1u), uint3(128u, 1u, 1u))
+    }
+    t |> success(ran, "gemv dispatch n={n} d={d}: {err}")
+    t |> equal(buf_mismatch_exact(by, want), 0)
+    metal_release(bwq)
+    metal_release(bws)
+    metal_release(bx)
+    metal_release(by)
+    metal_release(bn)
+    metal_release(bd)
+    metal_release(pso)
+    delete wq
+    delete ws
+    delete xv
+    delete want
+}
+
+// The production mul_mm kernel on exact-arithmetic data: 34B q8-block W blobs (GGUF q8_0's
+// own layout: f16 scale + 32 int8) x raw f32 X rows vs a CPU reference, BIT-exact (quants in
+// [-8, 7], pow2 scales: every staged half, every product, and every f32 partial sum is exactly
+// representable, so any deviation is a real bug). The blob is built here independently of the
+// driver — it doubles as the layout oracle for upload_blob_region.
+def private mulmm_gate(t : T?; dev, queue; k, d, m : int) {
+    var err : string
+    var pso = pipeline_from_source(dev, metal_q8_mulmm_msl, metal_q8_mulmm_msl_entry, metal_q8_mulmm_msl_fastmath, err)
+    t |> success(pso != null, "mul_mm pipeline: {err}")
+    let nb = k / 32
+    let lut = fixed_array(0.25, 0.5, 1.0, 2.0)
+    var wq : array<int8>
+    var ws : array<float>
+    wq |> resize(d * k)
+    ws |> resize(d * nb)
+    for (i in range(d * k)) {
+        wq[i] = int8((i * 7 + i / 31) % 16 - 8)
+    }
+    for (i in range(d * nb)) {
+        ws[i] = lut[(i / 5) % 4]
+    }
+    // W blob: 34-byte blocks (half scale + 32 quants), built straight in the buffer
+    var bw = metal_new_buffer(dev, uint64(d * nb * 34))
+    var base = unsafe(reinterpret<int8?>(metal_buffer_contents(bw)))
+    for (b in range(d * nb)) {
+        let off = b * 34
+        unsafe {
+            var ph = reinterpret<float16?>(base + off)
+            ph[0] = float16(ws[b])
+            for (c in range(32)) {
+                base[off + 2 + c] = wq[b * 32 + c]
+            }
+        }
+    }
+    // X: raw f32 rows, integer-times-pow2 values (exact in half)
+    var xf : array<float>
+    xf |> resize(m * k)
+    for (i in range(m * k)) {
+        xf[i] = float((i * 5 + i / 17) % 16 - 8) * lut[(i / 3) % 4]
+    }
+    var bx = buf_upload(dev, xf)
+    var by = buf_fill(dev, m * d, 0.0)
+    var bk = buf_u32(dev, uint(k))
+    var bd = buf_u32(dev, uint(d))
+    var want : array<float>
+    want |> resize(m * d)
+    for (r in range(m)) {
+        for (j in range(d)) {
+            var acc = 0.0lf
+            for (c in range(k)) {
+                acc += double(float(wq[j * k + c]) * ws[j * nb + c / 32]) * double(xf[r * k + c])
+            }
+            want[r * d + j] = float(acc)
+        }
+    }
+    let ran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso)
+        metal_set_threadgroup_memory_length(enc, metal_q8_mulmm_msl_tgmem, 0)
+        metal_set_buffer(enc, bw, 0ul, 0)
+        metal_set_buffer(enc, bw, 0ul, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bk, 0ul, 4)
+        metal_set_buffer(enc, bd, 0ul, 5)
+        metal_dispatch_threadgroups(enc, uint3(uint(m / 32), uint(d / 64), 1u), uint3(128u, 1u, 1u))
+    }
+    t |> success(ran, "mul_mm dispatch {k}x{d}x{m}: {err}")
+    t |> equal(buf_mismatch_exact(by, want), 0)
+    metal_release(bk)
+    metal_release(bd)
+    metal_release(bw)
+    metal_release(bx)
+    metal_release(by)
+    if (pso != null) {
+        metal_release(pso)
+    }
+    delete wq
+    delete ws
+    delete xf
+    delete want
 }
 
 // ===== local GPU plumbing (generic bodies instantiate only inside the static_if above) =====
@@ -435,6 +626,18 @@ def private buf_mismatch_exact(buf; want : array<auto(TT)>) : int {
     var bad = 0
     for (k in range(length(want))) {
         if (unsafe(p[k]) != want[k]) {
+            bad++
+        }
+    }
+    return bad
+}
+
+def private buf_mismatch_tol(buf; want : array<float>; tol : float) : int {
+    let p = unsafe(reinterpret<float const?>(metal_buffer_contents(buf)))
+    var bad = 0
+    for (k in range(length(want))) {
+        let g = unsafe(p[k])
+        if (abs(g - want[k]) > tol * max(1.0, max(abs(g), abs(want[k])))) {
             bad++
         }
     }

--- a/tests/dasLLAMA/test_metal_prefill_parity.das
+++ b/tests/dasLLAMA/test_metal_prefill_parity.das
@@ -80,20 +80,26 @@ def test_metal_prefill_parity(t : T?) {
             t |> success(select_prefill_override("metal"), "override registered")
             set_metal_prefill_min_npos(1l)
             let before = metal_prefill_stats().prefills
-            let gpu <- continuation(tr, prompt, 40)
+            let gpu <- continuation(tr, prompt, 40)         // default = lcpp mul_mm (f32 activations)
             let served = metal_prefill_stats().prefills - before
+            set_metal_prefill_mulmm_legacy(true)            // the quantized path — bit-identical to CPU
+            let before2 = metal_prefill_stats().prefills
+            let gpu_legacy <- continuation(tr, prompt, 40)
+            let served2 = metal_prefill_stats().prefills - before2
+            set_metal_prefill_mulmm_legacy(false)
             select_prefill_override("")
             set_metal_prefill_min_npos(64l)
             clear_kernel_backend_pin()
             select_kernel_backend(prior_backend)
             set_wscale_f16(prior_wscale)
-            if (served == 0l) {
+            if (served == 0l || served2 == 0l) {
                 metal_prefill_shutdown()
                 delete tr
                 feint("metal prefill declined (no Metal device?); GPU parity skipped\n")
                 return
             }
-            t |> success(same(cpu, gpu), "40-token continuation matches the CPU control")
+            t |> success(same(cpu, gpu_legacy), "40-token continuation matches the CPU control (legacy quantized GEMM)")
+            t |> success(same(cpu, gpu), "40-token continuation matches the CPU control (lcpp mul_mm, f32 activations)")
             metal_prefill_shutdown()
             t |> equal(metal_live_object_count(), 0l)
             delete tr

--- a/tests/metal/test_metal_reduce.das
+++ b/tests/metal/test_metal_reduce.das
@@ -116,9 +116,9 @@ def test_reduce_gpu_vs_cpu(t : T?) {
                 var bfdst = buf_fill(dev, GROUPS, -1.0)
                 var bufs <- [busrc, budst, bfsrc, bfdst]
                 var rerr : string
-                let ranU = run_compute_1d(queue, psoU, bufs, uint(N), TPG, rerr)
+                let ranU = run_compute_1d(queue, psoU, bufs, uint(N), TPG, rerr, reduce_u_gpu_msl_tgmem)
                 t |> success(ranU, "run_compute_1d(u): {rerr}")
-                let ranF = run_compute_1d(queue, psoF, bufs, uint(N), TPG, rerr)
+                let ranF = run_compute_1d(queue, psoF, bufs, uint(N), TPG, rerr, reduce_f_gpu_msl_tgmem)
                 t |> success(ranF, "run_compute_1d(f): {rerr}")
                 if (ranU && ranF) {
                     gpu_bad = buf_mismatch_exact(budst, wantU) + buf_mismatch_approx(bfdst, wantF)

--- a/tests/metal/test_metal_sgmat_rolled.das
+++ b/tests/metal/test_metal_sgmat_rolled.das
@@ -1,75 +1,81 @@
 options gen2
 options indenting = 4
 
-// Real-GPU behavioral gate for Phase-5 simdgroup_matrix, tiled-GEMM layer — the offload kernel's
-// shape: each threadgroup (32 threads = one simdgroup) owns one 8x8 C tile, walks K in 8-steps
-// staging f16 A/B tiles into threadgroup memory, barriers, and runs the MIXED-precision mac (f32
-// accumulators, f16 operands). A barrier kernel cannot be sequentially replayed (Phase-3 rule),
-// so the oracle is the directly computed matmul over the widened halves; all values are small
-// integers (every product exact in half, every K=32 sum exact in float), so the compare is
-// BIT-EXACT.
+// Real-GPU behavioral gate for the Phase-7 rolled-GEMM constructs: simdgroup-matrix ARRAYS,
+// [unroll_full] loops (rolled-with-pragma MSL), and fixed-array staging locals. One threadgroup
+// (32 threads = one simdgroup) computes C(16x8) = A(16xK) x B(Kx8) with two f32 accumulator
+// tiles over f16 operands. Barrier kernel — the oracle is the directly computed matmul over
+// the widened halves; all values small integers, so the compare is BIT-EXACT.
 
 require dastest/testing_boost public
 require metal/msl_shader
 require _metal_common  // nolint:STYLE030 — used only inside the Apple static_if half; off-Apple lint sees the branch compiled out
 
 let M = 16
-let N = 16
+let N = 8
 let K = 32
-let TPG = 32u           // one simdgroup per threadgroup, one C tile each
+let TPG = 32u           // one simdgroup, two C tiles
 
-class SgMatTiledGpu {
+class SgMatRolledGpu {
     @ssbo @binding = 0 xa : array<float16>  // A [M x K] row-major
     @ssbo @binding = 1 wb : array<float16>  // B [K x N] row-major
     @ssbo @binding = 2 yo : array<float>    // C [M x N]
     @uniform @binding = 3 kdim : uint
-    @uniform @binding = 4 ndim : uint
-    @workgroup ta : float16[64]
-    @workgroup tb : float16[64]
+    @workgroup ta : float16[128]            // A slab: 2 row-tiles of 8x8
+    @workgroup tb : float16[64]             // B slab: one 8x8 tile
 
-    [metal_kernel(name="sgmat_tiled_gpu_msl"), marker(no_coverage)]
-    def sgmat_tiled_gpu {
+    [metal_kernel(name="sgmat_rolled_gpu_msl"), marker(no_coverage)]
+    def sgmat_rolled_gpu {
         let lid = gl_LocalInvocationID.x
-        let ntiles = ndim / 8u
-        let tr = gl_WorkGroupID.x / ntiles
-        let tc = gl_WorkGroupID.x % ntiles
-        var acc : simdgroup_float8x8
+        var mc : simdgroup_float8x8[2]
+        var ma : simdgroup_half8x8[2]
+        var va : float16[4]
         var kk = 0u
         while (kk < kdim) {
-            let i0 = lid
-            let i1 = lid + 32u
-            ta[i0] = xa[(tr * 8u + (i0 / 8u)) * kdim + (kk + (i0 % 8u))]
-            ta[i1] = xa[(tr * 8u + (i1 / 8u)) * kdim + (kk + (i1 % 8u))]
-            tb[i0] = wb[(kk + (i0 / 8u)) * ndim + (tc * 8u + (i0 % 8u))]
-            tb[i1] = wb[(kk + (i1 / 8u)) * ndim + (tc * 8u + (i1 % 8u))]
+            // this thread's 4 A elements are contiguous in xa — read through a das device pointer
+            let flat0 = lid * 4u
+            let xcur = unsafe(addr(xa[((flat0 / 64u) * 8u + (flat0 % 64u) / 8u) * kdim + kk + (flat0 % 8u)]))
+            for [unroll_full] (i in range(4)) {
+                va[i] = unsafe(xcur[i])
+            }
+            for [unroll_full] (i in range(4)) {
+                ta[lid * 4u + uint(i)] = va[i]
+            }
+            tb[lid] = wb[(kk + lid / 8u) * 8u + (lid % 8u)]
+            tb[lid + 32u] = wb[(kk + (lid + 32u) / 8u) * 8u + ((lid + 32u) % 8u)]
             barrier()
-            var ma : simdgroup_half8x8
-            var mb : simdgroup_half8x8
-            simdgroup_load(ma, ta, 0u, 8u)
-            simdgroup_load(mb, tb, 0u, 8u)
-            simdgroup_multiply_accumulate(acc, ma, mb, acc)
+            var mbb : simdgroup_half8x8
+            simdgroup_load(mbb, tb, 0u, 8u)
+            var acur = unsafe(addr(ta[0]))
+            for [unroll_full] (i in range(2)) {
+                simdgroup_load(ma[i], acur, 0u, 8u)
+                simdgroup_multiply_accumulate(mc[i], ma[i], mbb, mc[i])
+                acur = unsafe(acur + 64)
+            }
             barrier()
             kk += 8u
         }
-        simdgroup_store(acc, yo, (tr * 8u) * ndim + (tc * 8u), ndim)
+        for [unroll_full] (i in range(2)) {
+            simdgroup_store(mc[i], yo, uint(i) * 64u, 8u)
+        }
     }
 }
 
 [test]
-def test_sgmat_tiled_gpu_vs_cpu(t : T?) {
-    t |> run("simdgroup_matrix tiled GEMM: GPU == direct CPU matmul, bit-exact") <| @(t : T?) {
+def test_sgmat_rolled_gpu_vs_cpu(t : T?) {
+    t |> run("rolled GEMM (matrix arrays + [unroll_full]): GPU == direct CPU matmul, bit-exact") <| @(t : T?) {
         var a : array<float16>
         var b : array<float16>
         a |> resize(M * K)
         b |> resize(K * N)
         for (r in range(M)) {
             for (k in range(K)) {
-                a[r * K + k] = float16(float((r + k * 3) % 7 - 3))
+                a[r * K + k] = float16(float((r * 2 + k) % 7 - 3))
             }
         }
         for (k in range(K)) {
             for (c in range(N)) {
-                b[k * N + c] = float16(float((k * 5 + c) % 9 - 4))
+                b[k * N + c] = float16(float((k + c * 5) % 9 - 4))
             }
         }
         var want : array<float>
@@ -91,7 +97,7 @@ def test_sgmat_tiled_gpu_vs_cpu(t : T?) {
                     return
                 }
                 var perr : string
-                var pso = pipeline_from_source(dev, sgmat_tiled_gpu_msl, sgmat_tiled_gpu_msl_entry, sgmat_tiled_gpu_msl_fastmath, perr)
+                var pso = pipeline_from_source(dev, sgmat_rolled_gpu_msl, sgmat_rolled_gpu_msl_entry, sgmat_rolled_gpu_msl_fastmath, perr)
                 t |> success(pso != null, "pipeline_from_source: {perr}")
                 if (pso == null) {
                     return
@@ -101,11 +107,9 @@ def test_sgmat_tiled_gpu_vs_cpu(t : T?) {
                 var bwb = buf_upload(dev, b)
                 var byo = buf_fill(dev, M * N, -1000.0)
                 var bk = buf_fill(dev, 1, uint(K))
-                var bn = buf_fill(dev, 1, uint(N))
-                var bufs <- [bxa, bwb, byo, bk, bn]
+                var bufs <- [bxa, bwb, byo, bk]
                 var rerr : string
-                // (M/8)*(N/8) = 4 threadgroups of one simdgroup each — 128 threads
-                let ran = run_compute_1d(queue, pso, bufs, uint((M / 8) * (N / 8)) * TPG, TPG, rerr, sgmat_tiled_gpu_msl_tgmem)
+                let ran = run_compute_1d(queue, pso, bufs, TPG, TPG, rerr, sgmat_rolled_gpu_msl_tgmem)
                 t |> success(ran, "run_compute_1d: {rerr}")
                 if (ran) {
                     gpu_bad = buf_mismatch_exact(byo, want)
@@ -118,7 +122,6 @@ def test_sgmat_tiled_gpu_vs_cpu(t : T?) {
                 metal_release(bwb)
                 metal_release(byo)
                 metal_release(bk)
-                metal_release(bn)
                 metal_release(pso)
                 metal_release(queue)
             }

--- a/tests/msl/_msl_common.das
+++ b/tests/msl/_msl_common.das
@@ -450,6 +450,55 @@ class SgMatTiled {
     }
 }
 
+// Phase-7 rolled-GEMM shape: simdgroup-matrix ARRAYS + [unroll_full] loops + a fixed-array
+// staging local — the register-pressure-safe form (loops stay rolled through the Metal
+// frontend; the GPU backend unrolls with budget awareness). C(16x8) = A(16xK) x B(Kx8),
+// f32 accumulators over f16 operands, one simdgroup (32 threads).
+class SgMatRolled {
+    @ssbo @binding = 0 xa : array<float16>
+    @ssbo @binding = 1 wb : array<float16>
+    @ssbo @binding = 2 yo : array<float>
+    @uniform @binding = 3 kdim : uint
+    @workgroup ta : float16[128]        // A slab: 2 row-tiles of 8x8
+    @workgroup tb : float16[64]         // B slab: one 8x8 tile
+
+    [metal_kernel(name="sgmat_rolled_msl"), marker(no_coverage)]
+    def sgmat_rolled {
+        let lid = gl_LocalInvocationID.x
+        var mc : simdgroup_float8x8[2]
+        var ma : simdgroup_half8x8[2]
+        var va : float16[4]
+        var kk = 0u
+        while (kk < kdim) {
+            // this thread's 4 A elements are contiguous in xa — read through a das device pointer
+            let flat0 = lid * 4u
+            let xcur = unsafe(addr(xa[((flat0 / 64u) * 8u + (flat0 % 64u) / 8u) * kdim + kk + (flat0 % 8u)]))
+            for [unroll_full] (i in range(4)) {
+                va[i] = unsafe(xcur[i])
+            }
+            for [unroll_full] (i in range(4)) {
+                ta[lid * 4u + uint(i)] = va[i]
+            }
+            tb[lid] = wb[(kk + lid / 8u) * 8u + (lid % 8u)]
+            tb[lid + 32u] = wb[(kk + (lid + 32u) / 8u) * 8u + ((lid + 32u) % 8u)]
+            barrier()
+            var mbb : simdgroup_half8x8
+            simdgroup_load(mbb, tb, 0u, 8u)
+            var acur = unsafe(addr(ta[0]))
+            for [unroll_full] (i in range(2)) {
+                simdgroup_load(ma[i], acur, 0u, 8u)
+                simdgroup_multiply_accumulate(mc[i], ma[i], mbb, mc[i])
+                acur = unsafe(acur + 64)
+            }
+            barrier()
+            kk += 8u
+        }
+        for [unroll_full] (i in range(2)) {
+            simdgroup_store(mc[i], yo, uint(i) * 64u, 8u)
+        }
+    }
+}
+
 // Phase-6 math builtins: the value-call whitelist with 1:1 MSL spellings — float scalar +
 // vector classes throughout (abs also signed int; min/max any numeric class)
 class MathCalls {
@@ -511,8 +560,9 @@ def public declared_msl_census : table<string> {
         "param.builtin.simdgroups_per_threadgroup",
         "param.builtin.simdgroup_index_in_threadgroup",
         // threadgroup memory + synchronization
-        "decl.threadgroup",
-        "decl.threadgroup_array",
+        "decl.shmem_ptr",
+        "decl.shmem_ptr_array",
+        "param.shmem",
         "call.barrier",
         "call.memory_barrier_shared",
         // simdgroup intrinsics
@@ -626,6 +676,7 @@ def public declared_msl_census : table<string> {
         "cvt.i32.i16",
         "cvt.i16.i32",
         "cvt.i8.i32",
+        "cvt.i32.u32",
         "cvt_sat.i32v.i8v",
         "cvt_sat.u32v.u16v",
         // comparisons
@@ -674,6 +725,14 @@ def public declared_msl_census : table<string> {
         // multiply, multiply-accumulate (all-f32, all-f16, and the mixed f32-acc/f16-operand combo)
         "stmt.var.sgmat",
         "stmt.var.sgmat.zero",
+        "stmt.var.sgmat_array.f32",
+        "stmt.var.sgmat_array.f16",
+        "stmt.var.array",
+        "stmt.for.unroll",
+        "decl.ptr.tg",
+        "decl.ptr.dev",
+        "op.ptr_add",
+        "call.sgmat_load_ptr.f16",
         "call.sgmat_fill.f32",
         "call.sgmat_fill.f16",
         "call.sgmat_load.f32",
@@ -738,5 +797,5 @@ def public all_msl_censuses : array<string> {
     return <- [mul_ab_msl_census, uarith_msl_census, iarith_msl_census, farith_msl_census,
         vecarith_msl_census, control_msl_census, loops_msl_census, reduce_msl_census, simd_msl_census,
         halfarith_msl_census, latconv_msl_census, packed3_msl_census, sgmat_msl_census,
-        sgmat_tiled_msl_census, mathcalls_msl_census]
+        sgmat_tiled_msl_census, sgmat_rolled_msl_census, mathcalls_msl_census]
 }

--- a/tests/msl/test_msl_sgmat.das
+++ b/tests/msl/test_msl_sgmat.das
@@ -48,9 +48,10 @@ kernel void sgmat_tiled(device const half* xa [[buffer(0)]],
         device const half* wb [[buffer(1)]],
         device float* yo [[buffer(2)]],
         constant uint& kdim [[buffer(3)]],
-        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]]) \{
-    threadgroup half ta[64];
-    threadgroup half tb[64];
+        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]],
+        threadgroup char * shmem [[threadgroup(0)]]) \{
+    threadgroup half * ta = (threadgroup half *)(shmem);
+    threadgroup half * tb = (threadgroup half *)(shmem + 128);
     uint lid = gl_LocalInvocationID.x;
     simdgroup_float8x8 acc = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
     uint kk = 0u;
@@ -95,12 +96,90 @@ def test_sgmat_shape(t : T?) {
         t |> success(contains(sgmat_msl, "simdgroup_multiply_accumulate(hacc, hx, hy, hm);"), "f16 mac")
     }
     t |> run("sgmat tiled: threadgroup staging + mixed mac") <| @(t : T?) {
-        t |> success(contains(sgmat_tiled_msl, "threadgroup half ta[64];"), "staging tile declared")
+        t |> success(contains(sgmat_tiled_msl, "threadgroup half * ta = (threadgroup half *)(shmem);"), "staging tile derives from dynamic shmem")
         t |> success(contains(sgmat_tiled_msl, "simdgroup_load(ma, ta + 0u, 8u);"), "load from threadgroup tile")
         t |> success(contains(sgmat_tiled_msl, "simdgroup_multiply_accumulate(acc, ma, mb, acc);"), "mixed mac: f32 acc, f16 operands")
         t |> success(contains(sgmat_tiled_msl, "simdgroup_float8x8 acc"), "accumulator is f32")
         t |> success(contains(sgmat_tiled_msl, "simdgroup_half8x8 ma"), "operands are f16")
         t |> success(contains(sgmat_tiled_msl, "threadgroup_barrier(mem_flags::mem_threadgroup);"), "staging barrier")
+    }
+}
+
+// Phase-7 rolled-GEMM shape: matrix arrays declare + zero-fill in a pragma'd loop; all
+// [unroll_full] loops stay ROLLED with `#pragma clang loop unroll(full)` (the GPU backend
+// unrolls late, register-budget-aware — pre-unrolled statements cost an occupancy tier);
+// fixed-array locals get the aggregate zero form.
+let GOLDEN_SGMAT_ROLLED = "#include <metal_stdlib>
+using namespace metal;
+kernel void sgmat_rolled(device const half* xa [[buffer(0)]],
+        device const half* wb [[buffer(1)]],
+        device float* yo [[buffer(2)]],
+        constant uint& kdim [[buffer(3)]],
+        uint3 gl_LocalInvocationID [[thread_position_in_threadgroup]],
+        threadgroup char * shmem [[threadgroup(0)]]) \{
+    threadgroup half * ta = (threadgroup half *)(shmem);
+    threadgroup half * tb = (threadgroup half *)(shmem + 256);
+    uint lid = gl_LocalInvocationID.x;
+    simdgroup_float8x8 mc[2];
+    #pragma clang loop unroll(full)
+    for (int mc_zi = 0; mc_zi < 2; ++mc_zi) \{
+        mc[mc_zi] = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    \}
+    simdgroup_half8x8 ma[2];
+    #pragma clang loop unroll(full)
+    for (int ma_zi = 0; ma_zi < 2; ++ma_zi) \{
+        ma[ma_zi] = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    \}
+    half va[4] = \{\};
+    uint kk = 0u;
+    while ((kk < kdim)) \{
+        uint flat0 = (lid * 4u);
+        device const half * xcur = xa + (((((((flat0 / 64u) * 8u) + ((flat0 % 64u) / 8u)) * kdim) + kk) + (flat0 % 8u)));
+        #pragma clang loop unroll(full)
+        for (int i = 0; i < 4; ++i) \{
+            va[i] = xcur[i];
+        \}
+        #pragma clang loop unroll(full)
+        for (int i = 0; i < 4; ++i) \{
+            ta[((lid * 4u) + uint(i))] = va[i];
+        \}
+        tb[lid] = wb[(((kk + (lid / 8u)) * 8u) + (lid % 8u))];
+        tb[(lid + 32u)] = wb[(((kk + ((lid + 32u) / 8u)) * 8u) + ((lid + 32u) % 8u))];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_half8x8 mbb = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+        simdgroup_load(mbb, tb + 0u, 8u);
+        threadgroup half * acur = ta + (0);
+        #pragma clang loop unroll(full)
+        for (int i = 0; i < 2; ++i) \{
+            simdgroup_load(ma[i], acur + (0u), 8u);
+            simdgroup_multiply_accumulate(mc[i], ma[i], mbb, mc[i]);
+            acur = (acur + (64));
+        \}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        kk += 8u;
+    \}
+    #pragma clang loop unroll(full)
+    for (int i = 0; i < 2; ++i) \{
+        simdgroup_store(mc[i], yo + (uint(i) * 64u), 8u);
+    \}
+\}
+"
+
+[test]
+def test_sgmat_rolled_shape(t : T?) {
+    t |> run("sgmat rolled: arrays + [unroll_full] keep loops rolled") <| @(t : T?) {
+        t |> success(contains(sgmat_rolled_msl, "simdgroup_float8x8 mc[2];"), "f32 matrix array local")
+        t |> success(contains(sgmat_rolled_msl, "simdgroup_half8x8 ma[2];"), "f16 matrix array local")
+        t |> success(contains(sgmat_rolled_msl, "half va[4] = \{\};"), "fixed-array local zero form")
+        t |> success(contains(sgmat_rolled_msl, "#pragma clang loop unroll(full)"), "unroll pragma present")
+        t |> success(contains(sgmat_rolled_msl, "for (int i = 0; i < 2; ++i) \{"), "rolled loop form")
+        t |> success(contains(sgmat_rolled_msl, "threadgroup half * acur = ta + (0);"), "das threadgroup pointer decl")
+        t |> success(contains(sgmat_rolled_msl, "device const half * xcur = xa + ("), "das device pointer decl")
+        t |> success(contains(sgmat_rolled_msl, "simdgroup_load(ma[i], acur + (0u), 8u);"), "matrix load through the pointer")
+        t |> success(contains(sgmat_rolled_msl, "va[i] = xcur[i];"), "element read through the pointer")
+        t |> success(contains(sgmat_rolled_msl, "acur = (acur + (64));"), "pointer advance")
+        t |> success(contains(sgmat_rolled_msl, "simdgroup_multiply_accumulate(mc[i], ma[i], mbb, mc[i]);"), "indexed mac")
+        t |> success(contains(sgmat_rolled_msl, "mc[mc_zi] = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);"), "array zero-fill loop")
     }
 }
 
@@ -111,5 +190,8 @@ def test_sgmat_golden(t : T?) {
     }
     t |> run("sgmat tiled: golden snapshot") <| @(t : T?) {
         t |> equal(sgmat_tiled_msl, GOLDEN_SGMAT_TILED)
+    }
+    t |> run("sgmat rolled: golden snapshot") <| @(t : T?) {
+        t |> equal(sgmat_rolled_msl, GOLDEN_SGMAT_ROLLED)
     }
 }

--- a/tests/msl/test_msl_threadgroup.das
+++ b/tests/msl/test_msl_threadgroup.das
@@ -20,9 +20,10 @@ kernel void reduce(device const uint* src [[buffer(0)]],
         uint gl_LocalInvocationIndex [[thread_index_in_threadgroup]],
         uint3 gl_NumWorkGroups [[threadgroups_per_grid]],
         uint3 gl_WorkGroupID [[threadgroup_position_in_grid]],
-        uint3 gl_WorkGroupSize [[threads_per_threadgroup]]) \{
-    threadgroup uint tile[64];
-    threadgroup uint total;
+        uint3 gl_WorkGroupSize [[threads_per_threadgroup]],
+        threadgroup char * shmem [[threadgroup(0)]]) \{
+    threadgroup uint * tile = (threadgroup uint *)(shmem);
+    threadgroup uint * total_wg = (threadgroup uint *)(shmem + 256);
     uint gid = gl_GlobalInvocationID.x;
     uint lid = gl_LocalInvocationID.x;
     tile[lid] = src[gid];
@@ -36,11 +37,11 @@ kernel void reduce(device const uint* src [[buffer(0)]],
         s /= 2u;
     \}
     if ((gl_LocalInvocationIndex == 0u)) \{
-        total = (tile[0] + (gl_NumWorkGroups.x * 0u));
+        (*total_wg) = (tile[0] + (gl_NumWorkGroups.x * 0u));
     \}
     threadgroup_barrier(mem_flags::mem_threadgroup);
     if ((gl_LocalInvocationIndex == 0u)) \{
-        dst[gl_WorkGroupID.x] = total;
+        dst[gl_WorkGroupID.x] = (*total_wg);
     \}
 \}
 "
@@ -48,8 +49,8 @@ kernel void reduce(device const uint* src [[buffer(0)]],
 [test]
 def test_threadgroup_shape(t : T?) {
     t |> run("reduce: @workgroup members -> body-top threadgroup declarations") <| @(t : T?) {
-        t |> success(contains(reduce_msl, "    threadgroup uint tile[64];"), "fixed array -> threadgroup array declaration")
-        t |> success(contains(reduce_msl, "    threadgroup uint total;"), "scalar -> threadgroup scalar declaration")
+        t |> success(contains(reduce_msl, "    threadgroup uint * tile = (threadgroup uint *)(shmem);"), "fixed array -> shmem-derived pointer")
+        t |> success(contains(reduce_msl, "    threadgroup uint * total_wg = (threadgroup uint *)(shmem + 256);"), "scalar -> shmem-derived pointer, accesses dereference")
         t |> success(!contains(reduce_msl, "tile [[buffer"), "threadgroup memory is never a buffer parameter")
     }
     t |> run("reduce: barrier lowering") <| @(t : T?) {


### PR DESCRIPTION
The goal: parity with llama.cpp Metal on Llama-3.2-3B. Landed (clean Parsec-off rounds, M1 Max): 3B pp512 GPU window 367.5-372.0 ms — level with llama.cpp's fa=1 best mode (368 ms) — e2e best 1299 t/s; 1B pp512 3467 t/s (3.3x over Phase 6). Every shader in the resident prefill is das-authored and das-emitted, including the GEMM.

## The steps

- **3B unlock + overhead hunt**: QK k-slab loop (any head_size % 32), hazard-untracked weight regions (new `metal_new_buffer_untracked` extern), fused dispatch set (add+rms+quant, swiglu+quant, ropeQK). 111 (CPU fallback) → ~950 t/s.
- **mul_mm-rate GEMM path**: weights repacked once into resident 34-byte q8 blocks (GGUF q8_0's own layout — the scale rides the quants' cacheline), raw f32 activations end-to-end, all X-quant dispatches deleted. 850 → 1053 t/s. Rail: `DASLLAMA_METAL_MULMM=0` = the legacy quantized path (bit-identical to the CPU forward, the tests' exact-parity rail).
- **Chunked command buffers + interleaved KV readback**: commit-as-encoded chunks (`DASLLAMA_METAL_NCB`), per-chunk waits stream roped-K/V into the CPU KV codec while later chunks run. 1053 → 1220 t/s.
- **ggml-geometry attention pair** (QK/AV as mul_mm-rate GEMMs with causal skips): attention 28 → 14 ms. 1220 → 1251 t/s. Rail: `DASLLAMA_METAL_ATTN=0` = the elementwise trio (serves head_size % 64 != 0).
- **The emitter codegen chase** (below-MSL, via an AGX ISA rail: applegpu + MTLBinaryArchive harvest). Root cause of a flat 13% deficit: hand-unrolled das statements reach the Metal frontend as one giant SSA block, LLVM hoists every loop-invariant tile address into long-lived registers, occupancy drops a tier (maxTotalThreadsPerThreadgroup 1024 → 832). Fixes, each ISA-verified:
    * `for [unroll_full] (...)` loop hints — the SAME per-loop annotation list the JIT lowers to `!llvm.loop.*` metadata now lowers to clang loop pragmas in MSL; loops reach the backend ROLLED and it unrolls late, register-budget-aware.
    * `@workgroup` members lower to ONE dynamic `[[threadgroup(0)]]` buffer + derived pointers instead of static threadgroup arrays (the backend constant-folds static-array tile pointers into absolute addresses and re-materializes the offsets inside the fmadd-bound loop phase); the total ships as the `_tgmem` companion and dispatches set it.
    * das pointer streams: `var p = unsafe(addr(member[expr]))` declares a real threadgroup/device pointer (address space from the member), `unsafe(p[i])` reads, `p = unsafe(p + n)` advances — pointer-vs-index register-allocates differently per shape, so both spellings stay writable, plain das either way.

  The das-authored GEMM (`MetalQ8MulMm`) ended 2-3% FASTER than the hand-written llama.cpp equivalent on all 9 lab shapes and is the production default. New occupancy introspection externs (`metal_pipeline_max_total_threads` / `_thread_execution_width`) + `benchmarks/matmul/occupancy_report.das` make register pressure a one-command check; the same rolled rework lifted the attention pair 704 → 896.
- **Logits-on-GPU**: final rmsnorm (last position, byte-offset bind) + a classifier GEMV kernel ride the last command buffer; the override reports `prefill_override_logits_done()` and the caller skips its CPU classifier. −5.5 ms per 3B prefill (the GEMV hides behind the KV-readback tail). Rails: `DASLLAMA_METAL_LOGITS=0`, `set_metal_prefill_logits_cpu()`.
- **Prefill scratch alloc**: contents-discarding no-init sizing (`scratch_resize`) for the 10 always-fully-written batched-scratch arrays. Framing 5.7 → 1.1 ms; new `alloc` prof bucket.

## Tests

msl census + goldens for every new construct (73/73); tests/metal GPU bit-exact gates incl. the rolled-GEMM shape (36/36); dasLLAMA mulmm unit gate (exact-arithmetic, bit-exact), gemv gate, 1B prefill parity token-for-token in BOTH GEMM modes with GPU logits active; leak gates; `preflight --full`.

## Rebased on #3458

Rebased onto master after #3458 (hybrid deltanet serving) landed. Its `set_act_vec(false)` fix pins the scalar activation forms for the chunk-algebra gate — the chunked-vs-recurrent divergence was only exp4's ~2ulp reassociation flipping a near-tie greedy argmax at the chunk boundary — so `tests/dasLLAMA/test_deltanet` multi-chunk now matches the recurrent oracle. The env-gated #3454 skip carried while it was pre-existing red is removed; the test runs 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)